### PR TITLE
A2A bearer token authentication middleware

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,0 +1,5 @@
+{
+  "pid": 7,
+  "featureId": "feature-1776800000100-seca2atok",
+  "startedAt": "2026-04-19T05:54:55.811Z"
+}

--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -32,6 +32,7 @@ REST convenience aliases
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -933,10 +934,42 @@ def register_a2a_routes(
     so FastAPI does not raise on a duplicate route registration.
     """
 
+    # ── Bearer token authentication ───────────────────────────────────────────
+    _raw_a2a_token = os.environ.get("A2A_AUTH_TOKEN", "")
+    _a2a_token: str | None = _raw_a2a_token.strip() or None
+    if not _a2a_token:
+        logger.warning(
+            "[a2a] A2A auth token not configured — endpoint is open"
+        )
+
+    def _check_bearer_auth(request: Request) -> None:
+        """Validate Authorization: Bearer <token> against A2A_AUTH_TOKEN.
+
+        No-ops when A2A_AUTH_TOKEN is unset (open mode).
+        Raises HTTP 401 on missing or invalid token.
+        """
+        if not _a2a_token:
+            return
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            raise HTTPException(
+                status_code=401,
+                detail="Unauthorized: expected 'Authorization: Bearer <token>'",
+            )
+        provided = auth_header[len("Bearer "):]
+        if not hmac.compare_digest(provided, _a2a_token):
+            raise HTTPException(status_code=401, detail="Unauthorized: invalid bearer token")
+
     # Update agent card capabilities
     agent_card.setdefault("capabilities", {})
     agent_card["capabilities"]["streaming"] = True
     agent_card["capabilities"]["pushNotifications"] = True
+    if _a2a_token:
+        agent_card.setdefault("securitySchemes", {})
+        agent_card["securitySchemes"]["bearer"] = {
+            "type": "http",
+            "scheme": "bearer",
+        }
 
     # ── Agent card ────────────────────────────────────────────────────────────
 
@@ -1114,6 +1147,10 @@ def register_a2a_routes(
     async def _a2a_rpc(request: Request, req: dict):
         if api_key and request.headers.get("x-api-key") != api_key:
             return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+        try:
+            _check_bearer_auth(request)
+        except HTTPException as exc:
+            return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
 
         rpc_id = req.get("id")
         method = req.get("method", "")
@@ -1301,6 +1338,7 @@ def register_a2a_routes(
     @app.post("/message:send", include_in_schema=False)
     async def _rest_send(request: Request, body: dict):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         message = body.get("message", {})
         configuration = body.get("configuration", {})
         context_id = body.get("contextId", "")
@@ -1316,6 +1354,7 @@ def register_a2a_routes(
     @app.post("/message:stream", include_in_schema=False)
     async def _rest_stream(request: Request, body: dict):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         message = body.get("message", {})
         configuration = body.get("configuration", {})
         context_id = body.get("contextId", "")
@@ -1334,6 +1373,7 @@ def register_a2a_routes(
     @app.get("/tasks/{task_id}", include_in_schema=False)
     async def _get_task(task_id: str, request: Request):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         record = await _store.get(task_id)
         if record is None:
             raise HTTPException(404, f"Task not found: {task_id}")
@@ -1344,6 +1384,7 @@ def register_a2a_routes(
     @app.get("/tasks/{task_id}:subscribe", include_in_schema=False)
     async def _subscribe_task(task_id: str, request: Request):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         record = await _store.get(task_id)
         if record is None:
             raise HTTPException(404, f"Task not found: {task_id}")
@@ -1403,6 +1444,7 @@ def register_a2a_routes(
     @app.post("/tasks/{task_id}:cancel", include_in_schema=False)
     async def _cancel_task(task_id: str, request: Request):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         # Single atomic read+write under the store lock. The previous
         # get → sleep → cancel → update sequence could race with the
         # background runner and clobber a legitimate COMPLETED state.
@@ -1425,6 +1467,7 @@ def register_a2a_routes(
     @app.post("/tasks/{task_id}/pushNotificationConfigs", include_in_schema=False)
     async def _create_push_config(task_id: str, request: Request, body: dict):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         record = await _store.get(task_id)
         if record is None:
             raise HTTPException(404, f"Task not found: {task_id}")

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -1435,3 +1435,198 @@ async def test_rpc_unknown_method_returns_method_not_found():
     body = r.json()
     assert body["error"]["code"] == -32601
     assert "some/bogus/method" in body["error"]["message"]
+
+
+# ── Bearer token authentication tests ─────────────────────────────────────────
+
+
+def _make_auth_test_app(token: str | None = "secret-token"):
+    """Create a test app with A2A_AUTH_TOKEN configured (or unset)."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    card = {"name": "test", "capabilities": {}}
+
+    async def _fake_stream(text, context_id, **kwargs):
+        yield ("text", "hello ")
+        yield ("done", "hello")
+
+    async def _fake_chat(text, session_id):
+        return [{"role": "assistant", "content": "response"}]
+
+    env_patch = {"A2A_AUTH_TOKEN": token} if token is not None else {}
+    with patch.dict("os.environ", env_patch, clear=True if token is None else False):
+        register_a2a_routes(
+            app=app,
+            chat_stream_fn_factory=_fake_stream,
+            chat_fn=_fake_chat,
+            api_key="",
+            agent_card=card,
+        )
+    return app, card
+
+
+@pytest.mark.asyncio
+async def test_missing_bearer_token():
+    """POST /a2a without Authorization header returns 401 when auth is enabled."""
+    app, _ = _make_auth_test_app(token="secret-token")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        })
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_bearer_token():
+    """POST /a2a with wrong bearer token returns 401."""
+    app, _ = _make_auth_test_app(token="secret-token")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        }, headers={"Authorization": "Bearer wrong-token"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_valid_bearer_token():
+    """POST /a2a with correct bearer token returns 200 and processes request."""
+    app, _ = _make_auth_test_app(token="secret-token")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        }, headers={"Authorization": "Bearer secret-token"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "result" in body
+    assert body["result"]["status"]["state"] == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_auth_disabled_no_token():
+    """When A2A_AUTH_TOKEN is unset, requests pass without Authorization header."""
+    with patch.dict("os.environ", {}, clear=True):
+        from fastapi import FastAPI
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("text", "hello ")
+            yield ("done", "hello")
+
+        async def _fake_chat(text, session_id):
+            return [{"role": "assistant", "content": "response"}]
+
+        # Ensure A2A_AUTH_TOKEN is not set
+        import os
+        os.environ.pop("A2A_AUTH_TOKEN", None)
+
+        register_a2a_routes(
+            app=app,
+            chat_stream_fn_factory=_fake_stream,
+            chat_fn=_fake_chat,
+            api_key="",
+            agent_card=card,
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        })
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_auth_disabled_warning(caplog):
+    """WARNING is logged at startup when A2A_AUTH_TOKEN is not configured."""
+    import logging
+    import os
+    with patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("A2A_AUTH_TOKEN", None)
+        from fastapi import FastAPI
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("done", "")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        with caplog.at_level(logging.WARNING, logger="a2a_handler"):
+            register_a2a_routes(
+                app=app,
+                chat_stream_fn_factory=_fake_stream,
+                chat_fn=_fake_chat,
+                api_key="",
+                agent_card=card,
+            )
+
+    assert any("A2A auth token not configured" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_advertised_in_agent_card():
+    """securitySchemes.bearer is present in agent card when A2A_AUTH_TOKEN is set."""
+    _, card = _make_auth_test_app(token="secret-token")
+    assert "securitySchemes" in card
+    assert card["securitySchemes"]["bearer"]["type"] == "http"
+    assert card["securitySchemes"]["bearer"]["scheme"] == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_not_in_agent_card_when_unset():
+    """securitySchemes is absent from agent card when A2A_AUTH_TOKEN is not set."""
+    import os
+    os.environ.pop("A2A_AUTH_TOKEN", None)
+    with patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("A2A_AUTH_TOKEN", None)
+        _, card = _make_auth_test_app(token=None)
+    assert "securitySchemes" not in card
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_token_treated_as_unset():
+    """A2A_AUTH_TOKEN with only whitespace is treated as unset (open mode)."""
+    import os
+    with patch.dict("os.environ", {"A2A_AUTH_TOKEN": "   "}, clear=False):
+        from fastapi import FastAPI
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("done", "")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        register_a2a_routes(
+            app=app,
+            chat_stream_fn_factory=_fake_stream,
+            chat_fn=_fake_chat,
+            api_key="",
+            agent_card=card,
+        )
+
+    # With whitespace-only token, no auth required — request succeeds without header
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        })
+    assert resp.status_code == 200
+    assert "securitySchemes" not in card


### PR DESCRIPTION
## Summary

Add bearer token authentication middleware to the A2A JSON-RPC endpoint.

## Problem
`a2a_handler.py` registers POST `/a2a` with no authentication. A fork that exposes port 7870 to the internet ships an auth-off agent. OpenClaw had ~1,000 such instances found by Bitsight researchers in 2026.

## Approach
- Read `A2A_AUTH_TOKEN` env at startup in `a2a_handler.register_a2a_routes`
- If set: require `Authorization: Bearer <token>` header on all A2A routes; return 401 on missing/mismatch
- If unset:...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added optional bearer token authentication for the A2A API. When enabled via configuration, requests to A2A endpoints require valid bearer tokens for access.

* **Tests**
  * Added comprehensive test coverage for bearer token authentication validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->