### PR TITLE
WebSocket/SSE origin verification

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000100-seca2atok",
-  "startedAt": "2026-04-19T05:54:55.811Z"
+  "featureId": "feature-1776800000300-secorigin",
+  "startedAt": "2026-04-19T06:00:11.908Z"
 }

--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -960,6 +960,66 @@ def register_a2a_routes(
         if not hmac.compare_digest(provided, _a2a_token):
             raise HTTPException(status_code=401, detail="Unauthorized: invalid bearer token")
 
+    # ── Origin verification for SSE/WebSocket connections ─────────────────────
+    # Read A2A_ALLOWED_ORIGINS at startup (comma-separated list of allowed
+    # origins).  Empty/unset means "log a WARNING, allow all".  The special
+    # value '*' explicitly disables origin checking with no warning.
+    #
+    # Deviation rules:
+    #  - Missing Origin header           → allow (same-origin / older clients)
+    #  - Origin header present but empty → reject 403
+    #  - Case-insensitive domain comparison per RFC 6454
+    #  - Malformed env value             → log ERROR, fail-safe (allow all)
+    _raw_allowed_origins = os.environ.get("A2A_ALLOWED_ORIGINS", "").strip()
+    _allowed_origins: list[str] | None  # None = disabled (wildcard or error)
+
+    if _raw_allowed_origins == "*":
+        # Wildcard: explicitly disable origin checking — no WARNING logged.
+        _allowed_origins = None
+    elif not _raw_allowed_origins:
+        # Unset or empty: open mode, but warn operators.
+        logger.warning(
+            "[a2a] A2A_ALLOWED_ORIGINS not configured — SSE/WebSocket origin "
+            "verification is disabled; set this to a comma-separated list of "
+            "allowed origins (e.g. https://example.com) or '*' to silence this warning"
+        )
+        _allowed_origins = None
+    else:
+        try:
+            _allowed_origins = [o.strip().lower() for o in _raw_allowed_origins.split(",") if o.strip()]
+            if not _allowed_origins:
+                raise ValueError("empty after parsing")
+        except Exception as exc:  # pragma: no cover – malformed env
+            logger.error(
+                "[a2a] A2A_ALLOWED_ORIGINS is malformed (%r): %s — "
+                "CRITICAL: origin verification is disabled (fail-safe open mode)",
+                _raw_allowed_origins, exc,
+            )
+            _allowed_origins = None
+
+    def _check_origin(request: Request) -> None:
+        """Validate the Origin header against A2A_ALLOWED_ORIGINS.
+
+        Only applied to SSE-producing endpoints (message/stream,
+        tasks/resubscribe, /message:stream, /tasks/{id}:subscribe).
+
+        - Missing Origin header → allowed (same-origin requests / older clients)
+        - Origin present but empty → rejected with 403
+        - Origin not in allowlist → rejected with 403
+        - _allowed_origins is None (wildcard or unset) → no-op
+        """
+        if _allowed_origins is None:
+            return
+        origin = request.headers.get("Origin")
+        if origin is None:
+            # No Origin header: allow (same-origin, curl, server-to-server).
+            return
+        if not origin or origin.lower() not in _allowed_origins:
+            raise HTTPException(
+                status_code=403,
+                detail=f"Forbidden: Origin '{origin}' is not allowed",
+            )
+
     # Update agent card capabilities
     agent_card.setdefault("capabilities", {})
     agent_card["capabilities"]["streaming"] = True
@@ -1200,6 +1260,10 @@ def register_a2a_routes(
                 return _rpc_result(_task_to_response(record))
 
             # streaming path — SSE frames wrapped in JSON-RPC envelopes
+            try:
+                _check_origin(request)
+            except HTTPException as exc:
+                return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
             return StreamingResponse(
                 _stream_new_task(text, context_id, push_config, rpc_id=rpc_id, caller_trace=caller_trace),
                 media_type="text/event-stream",
@@ -1243,6 +1307,10 @@ def register_a2a_routes(
                 return _rpc_error(-32602, "Invalid params: id is required")
             if await _store.get(task_id) is None:
                 return _rpc_error(-32001, f"Task not found: {task_id}")
+            try:
+                _check_origin(request)
+            except HTTPException as exc:
+                return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
             return StreamingResponse(
                 _resubscribe_jsonrpc_stream(task_id, rpc_id),
                 media_type="text/event-stream",
@@ -1355,6 +1423,7 @@ def register_a2a_routes(
     async def _rest_stream(request: Request, body: dict):
         _check_auth(request, api_key)
         _check_bearer_auth(request)
+        _check_origin(request)
         message = body.get("message", {})
         configuration = body.get("configuration", {})
         context_id = body.get("contextId", "")
@@ -1385,6 +1454,7 @@ def register_a2a_routes(
     async def _subscribe_task(task_id: str, request: Request):
         _check_auth(request, api_key)
         _check_bearer_auth(request)
+        _check_origin(request)
         record = await _store.get(task_id)
         if record is None:
             raise HTTPException(404, f"Task not found: {task_id}")

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -42,6 +42,13 @@ The template explicitly calls `logging.basicConfig(level=INFO)` — without this
 
 Without these set, the handler rejects webhook URLs that resolve to private / loopback / link-local IPs — defends against SSRF where a client registers `http://169.254.169.254/...` or `http://10.0.0.1/...` as a callback.
 
+## A2A security
+
+| Variable | Default | What |
+|---|---|---|
+| `A2A_AUTH_TOKEN` | (unset — open) | Bearer token required on all `/a2a` requests. When set, the `Authorization: Bearer <token>` header must match. Logs a WARNING at startup when unset. |
+| `A2A_ALLOWED_ORIGINS` | (unset — allow all) | Comma-separated list of allowed `Origin` header values for SSE and WebSocket streaming connections (e.g. `https://app.example.com,https://admin.example.com`). When unset, a WARNING is logged and all origins are accepted. Set to `*` to explicitly disable origin checking without a warning. Origin comparison is case-insensitive per RFC 6454. Requests without an `Origin` header (same-origin, curl, server-to-server) are always allowed. |
+
 ## UI
 
 | Variable | Default | What |

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -1630,3 +1630,221 @@ async def test_whitespace_only_token_treated_as_unset():
         })
     assert resp.status_code == 200
     assert "securitySchemes" not in card
+
+
+# ── Origin verification tests ──────────────────────────────────────────────────
+
+
+def _make_origin_test_app(allowed_origins: str | None = "https://example.com"):
+    """Create a test app with A2A_ALLOWED_ORIGINS configured."""
+    from fastapi import FastAPI
+    import os
+
+    app = FastAPI()
+    card = {"name": "test", "capabilities": {}}
+
+    async def _fake_stream(text, context_id, **kwargs):
+        yield ("text", "hello ")
+        yield ("done", "hello")
+
+    async def _fake_chat(text, session_id):
+        return [{"role": "assistant", "content": "response"}]
+
+    env_patch = {"A2A_ALLOWED_ORIGINS": allowed_origins} if allowed_origins is not None else {}
+    with patch.dict("os.environ", env_patch, clear=False):
+        if allowed_origins is None:
+            os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+        os.environ.pop("A2A_AUTH_TOKEN", None)
+        register_a2a_routes(
+            app=app,
+            chat_stream_fn_factory=_fake_stream,
+            chat_fn=_fake_chat,
+            api_key="",
+            agent_card=card,
+        )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_origin_allowed_passes_sse():
+    """SSE request with Origin in allowlist is allowed."""
+    app = _make_origin_test_app(allowed_origins="https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/message:stream",
+            json={"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            headers={"Origin": "https://example.com"},
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_origin_rejected_returns_403():
+    """SSE request with Origin not in allowlist returns 403."""
+    app = _make_origin_test_app(allowed_origins="https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/message:stream",
+            json={"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            headers={"Origin": "https://evil.com"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_origin_missing_header_is_allowed():
+    """SSE request without Origin header is allowed (same-origin / curl)."""
+    app = _make_origin_test_app(allowed_origins="https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/message:stream",
+            json={"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_origin_empty_string_rejected():
+    """SSE request with empty Origin header value is rejected with 403."""
+    app = _make_origin_test_app(allowed_origins="https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/message:stream",
+            json={"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            headers={"Origin": ""},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_origin_wildcard_disables_check():
+    """When A2A_ALLOWED_ORIGINS='*', any origin is accepted without warning."""
+    app = _make_origin_test_app(allowed_origins="*")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/message:stream",
+            json={"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            headers={"Origin": "https://any-domain.com"},
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_origin_unset_logs_warning(caplog):
+    """When A2A_ALLOWED_ORIGINS is unset, a WARNING is logged at startup."""
+    import logging
+    import os
+    with patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+        os.environ.pop("A2A_AUTH_TOKEN", None)
+        from fastapi import FastAPI
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("done", "")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        with caplog.at_level(logging.WARNING, logger="a2a_handler"):
+            register_a2a_routes(
+                app=app,
+                chat_stream_fn_factory=_fake_stream,
+                chat_fn=_fake_chat,
+                api_key="",
+                agent_card=card,
+            )
+
+    assert any("A2A_ALLOWED_ORIGINS" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_origin_wildcard_no_warning(caplog):
+    """When A2A_ALLOWED_ORIGINS='*', no origin warning is logged."""
+    import logging
+    import os
+    with patch.dict("os.environ", {"A2A_ALLOWED_ORIGINS": "*"}, clear=False):
+        os.environ.pop("A2A_AUTH_TOKEN", None)
+        from fastapi import FastAPI
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("done", "")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        with caplog.at_level(logging.WARNING, logger="a2a_handler"):
+            register_a2a_routes(
+                app=app,
+                chat_stream_fn_factory=_fake_stream,
+                chat_fn=_fake_chat,
+                api_key="",
+                agent_card=card,
+            )
+
+    assert not any("A2A_ALLOWED_ORIGINS" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_origin_case_insensitive():
+    """Origin matching is case-insensitive per RFC 6454."""
+    app = _make_origin_test_app(allowed_origins="https://Example.COM")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/message:stream",
+            json={"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            headers={"Origin": "https://example.com"},
+        )
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_origin_rpc_stream_rejected():
+    """JSON-RPC message/stream with disallowed Origin returns 403."""
+    app = _make_origin_test_app(allowed_origins="https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "https://evil.com"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_origin_subscribe_rejected():
+    """GET /tasks/{id}:subscribe with disallowed Origin returns 403."""
+    app = _make_origin_test_app(allowed_origins="https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        submit = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        })
+        task_id = submit.json()["result"]["id"]
+        resp = await client.get(
+            f"/tasks/{task_id}:subscribe",
+            headers={"Origin": "https://evil.com"},
+        )
+    assert resp.status_code == 403


### PR DESCRIPTION
## Summary

Verify origins on websocket and SSE connections to the A2A streaming endpoint.

## Problem
Anyone who can reach the A2A endpoint can open an SSE connection and drain another session's events if they know or guess the task ID. OpenClaw had the same class of bug — no origin verification. A2A spec leaves this to implementations.

## Approach
- Read `A2A_ALLOWED_ORIGINS` env (comma-separated) at startup; default empty (allow all, with WARNING log)
- When set: reject SSE/WebSocket requests whose `Ori...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added origin verification for A2A streaming endpoints to enhance security controls.

* **Documentation**
  * Added A2A security environment variables documentation for authentication token and origin allowlisting configuration.

* **Tests**
  * Added comprehensive test coverage for origin verification functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->