### PR TITLE
WebSocket/SSE origin verification

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000200-secredact",
-  "startedAt": "2026-04-19T06:01:26.319Z"
+  "featureId": "feature-1776800000300-secorigin",
+  "startedAt": "2026-04-19T15:53:21.357Z"
 }

--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -960,6 +960,31 @@ def register_a2a_routes(
         if not hmac.compare_digest(provided, _a2a_token):
             raise HTTPException(status_code=401, detail="Unauthorized: invalid bearer token")
 
+    # ── Origin verification for SSE/streaming endpoints ───────────────────────
+    _raw_allowed_origins = os.environ.get("A2A_ALLOWED_ORIGINS", "")
+    _allowed_origins_str = _raw_allowed_origins.strip()
+    if not _allowed_origins_str:
+        logger.warning(
+            "[a2a] A2A_ALLOWED_ORIGINS not set — SSE/streaming origin verification disabled"
+        )
+        _allowed_origins: list[str] | None = None
+    elif _allowed_origins_str == "*":
+        _allowed_origins = None  # wildcard: verification disabled
+    else:
+        _allowed_origins = [o.strip().lower() for o in _allowed_origins_str.split(",") if o.strip()]
+
+    def _check_origin(request: Request) -> None:
+        """Validate Origin header against A2A_ALLOWED_ORIGINS.
+
+        No-ops when A2A_ALLOWED_ORIGINS is unset or '*'.
+        Raises HTTP 403 when Origin is not in the allowlist.
+        """
+        if _allowed_origins is None:
+            return
+        origin = request.headers.get("Origin", "").lower()
+        if origin not in _allowed_origins:
+            raise HTTPException(status_code=403, detail="Forbidden: origin not allowed")
+
     # Update agent card capabilities
     agent_card.setdefault("capabilities", {})
     agent_card["capabilities"]["streaming"] = True
@@ -1189,6 +1214,12 @@ def register_a2a_routes(
             msg_metadata = params.get("metadata") or {}
             caller_trace = msg_metadata.get("a2a.trace") or {}
 
+            if method in ("message/stream", "message/sendStream"):
+                try:
+                    _check_origin(request)
+                except HTTPException as exc:
+                    return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+
             if method == "message/send":
                 record = await _submit_task(text, context_id, push_config, caller_trace)
                 # Use _task_to_response so the `kind: "task"` discriminator
@@ -1243,6 +1274,10 @@ def register_a2a_routes(
                 return _rpc_error(-32602, "Invalid params: id is required")
             if await _store.get(task_id) is None:
                 return _rpc_error(-32001, f"Task not found: {task_id}")
+            try:
+                _check_origin(request)
+            except HTTPException as exc:
+                return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
             return StreamingResponse(
                 _resubscribe_jsonrpc_stream(task_id, rpc_id),
                 media_type="text/event-stream",
@@ -1355,6 +1390,7 @@ def register_a2a_routes(
     async def _rest_stream(request: Request, body: dict):
         _check_auth(request, api_key)
         _check_bearer_auth(request)
+        _check_origin(request)
         message = body.get("message", {})
         configuration = body.get("configuration", {})
         context_id = body.get("contextId", "")
@@ -1385,6 +1421,7 @@ def register_a2a_routes(
     async def _subscribe_task(task_id: str, request: Request):
         _check_auth(request, api_key)
         _check_bearer_auth(request)
+        _check_origin(request)
         record = await _store.get(task_id)
         if record is None:
             raise HTTPException(404, f"Task not found: {task_id}")

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -33,6 +33,14 @@ If both keys are unset, tracing is disabled and every helper in `tracing.py` bec
 
 The template explicitly calls `logging.basicConfig(level=INFO)` — without this, Python's default WARNING would hide `logger.info(...)` lines like "webhook delivered", making A2A issues invisible in container logs.
 
+## Streaming / origin verification
+
+| Variable | Default | What |
+|---|---|---|
+| `A2A_ALLOWED_ORIGINS` | (unset — allow all, with WARNING) | Comma-separated list of allowed `Origin` header values for SSE and WebSocket streaming endpoints (`/a2a` streaming methods, `/message:stream`, `/tasks/{id}:subscribe`). Example: `https://app.example.com,https://admin.example.com`. Set to `*` to explicitly disable origin verification without the WARNING log. Origin values are compared case-insensitively. |
+
+When unset, all origins are accepted but a WARNING is logged at startup. When set, requests whose `Origin` header does not match any entry receive a `403 Forbidden` response. A missing `Origin` header is treated as an empty string and will be rejected when verification is enabled.
+
 ## Push notifications / SSRF guard
 
 | Variable | Default | What |

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -1630,3 +1630,216 @@ async def test_whitespace_only_token_treated_as_unset():
         })
     assert resp.status_code == 200
     assert "securitySchemes" not in card
+
+
+# ── Origin verification ────────────────────────────────────────────────────────
+
+
+def _make_origin_test_app(allowed_origins: str | None):
+    """Build a test FastAPI app with A2A_ALLOWED_ORIGINS configured."""
+    import os
+    from fastapi import FastAPI
+    env = {}
+    if allowed_origins is not None:
+        env["A2A_ALLOWED_ORIGINS"] = allowed_origins
+    else:
+        os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+
+    with patch.dict("os.environ", env, clear=False):
+        if allowed_origins is None:
+            os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("text", "hello")
+            yield ("done", "hello")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        register_a2a_routes(
+            app=app,
+            chat_stream_fn_factory=_fake_stream,
+            chat_fn=_fake_chat,
+            api_key="",
+            agent_card=card,
+        )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_allowed_origin_passes_sse():
+    """SSE stream with matching Origin header is accepted."""
+    app = _make_origin_test_app("https://example.com,https://other.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        async with client.stream(
+            "POST", "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "https://example.com"},
+        ) as resp:
+            assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_rejected_origin_returns_403():
+    """SSE stream with non-matching Origin header receives 403."""
+    app = _make_origin_test_app("https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "https://evil.com"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unset_origins_warning(caplog):
+    """WARNING is logged at startup when A2A_ALLOWED_ORIGINS is not set."""
+    import logging
+    import os
+    from fastapi import FastAPI as _FastAPI
+    os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+    with patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+        app = _FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("done", "")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        with caplog.at_level(logging.WARNING, logger="a2a_handler"):
+            register_a2a_routes(
+                app=app,
+                chat_stream_fn_factory=_fake_stream,
+                chat_fn=_fake_chat,
+                api_key="",
+                agent_card=card,
+            )
+
+    assert any("A2A_ALLOWED_ORIGINS" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_wildcard_disables_verification():
+    """A2A_ALLOWED_ORIGINS='*' disables origin verification — any origin passes."""
+    app = _make_origin_test_app("*")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        async with client.stream(
+            "POST", "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "https://anything.example.com"},
+        ) as resp:
+            assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_missing_origin_header_rejected_when_allowlist_set():
+    """Missing Origin header is treated as empty string and rejected when allowlist is set."""
+    app = _make_origin_test_app("https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_origin_case_insensitive():
+    """Origin comparison is case-insensitive (HTTPS://Example.COM matches https://example.com)."""
+    app = _make_origin_test_app("https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        async with client.stream(
+            "POST", "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "HTTPS://Example.COM"},
+        ) as resp:
+            assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_origin_whitespace_trimmed_in_allowlist():
+    """Whitespace around comma-separated origins is trimmed."""
+    app = _make_origin_test_app("  https://example.com  ,  https://other.com  ")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        async with client.stream(
+            "POST", "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "https://other.com"},
+        ) as resp:
+            assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_rest_message_stream_origin_rejected():
+    """REST POST /message:stream rejects non-matching Origin with 403."""
+    app = _make_origin_test_app("https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/message:stream",
+            json={"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            headers={"Origin": "https://evil.com"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_subscribe_endpoint_origin_rejected():
+    """GET /tasks/{id}:subscribe rejects non-matching Origin with 403."""
+    # First create a task
+    app = _make_origin_test_app("https://example.com")
+
+    # Create a task via unprotected message/send (no origin check on non-streaming)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        })
+        assert resp.status_code == 200
+        task_id = resp.json()["result"]["id"]
+
+        # Now try to subscribe with a bad origin
+        sub_resp = await client.get(
+            f"/tasks/{task_id}:subscribe",
+            headers={"Origin": "https://evil.com"},
+        )
+    assert sub_resp.status_code == 403


### PR DESCRIPTION
## Summary

Verify origins on websocket and SSE connections to the A2A streaming endpoint.

## Problem
Anyone who can reach the A2A endpoint can open an SSE connection and drain another session's events if they know or guess the task ID. OpenClaw had the same class of bug — no origin verification. A2A spec leaves this to implementations.

## Approach
- Read `A2A_ALLOWED_ORIGINS` env (comma-separated) at startup; default empty (allow all, with WARNING log)
- When set: reject SSE/WebSocket requests whose `Ori...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added configurable origin allowlist enforcement for streaming and Server-Sent Events (SSE) endpoints to enhance security controls.

* **Documentation**
  * Added documentation for the new environment variable to configure allowed origins for streaming endpoints.

* **Tests**
  * Added comprehensive test suite validating origin verification behavior across all streaming endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->