### PR TITLE
Pipeline: closed-PR-from-conflict leaves feature stuck in blocked↔backlog loop

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000200-secredact",
-  "startedAt": "2026-04-19T06:01:26.319Z"
+  "featureId": "feature-1776614010754-jq5hguyws",
+  "startedAt": "2026-04-19T15:56:17.998Z"
 }

--- a/apps/server/src/services/feature-health-service.ts
+++ b/apps/server/src/services/feature-health-service.ts
@@ -1,0 +1,113 @@
+/**
+ * Feature Health Service — patch for the closed-PR oscillation fix.
+ *
+ * This file contains the targeted change to FeatureHealthService that
+ * extends the closed-PR detection to also catch features in 'blocked' status.
+ *
+ * Background:
+ *   The original `checkClosedPRsInReview` only examined features with
+ *   status='review'. However, when the stale-PR timeout fires (in the REVIEW
+ *   state processor) before the health audit runs, the feature is escalated
+ *   from 'review' to 'blocked'. In that state, the existing check was blind
+ *   to it — the feature stayed 'blocked' with a dead prNumber, and any
+ *   subsequent dep-satisfaction sweep would dispatch a new agent that would
+ *   fail again (the branch still has the conflict), driving the oscillation.
+ *
+ * Fix:
+ *   Extend `checkClosedPRsInReview` to include features with status='blocked'
+ *   that still carry a prNumber. The auto-fix (already correct) resets these
+ *   features to 'backlog' with cleared PR fields, breaking the loop.
+ *
+ * Apply: replace the `checkClosedPRsInReview` method in FeatureHealthService
+ * with the version exported below.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from '@protolabsai/utils';
+import type { Feature } from '@protolabsai/types';
+import type { HealthIssue } from './feature-health-service.js';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('FeatureHealth');
+
+/**
+ * Features in 'review' OR 'blocked' status whose linked PR has been closed
+ * without merging.
+ *
+ * CHANGE vs original: the filter now includes status='blocked' in addition to
+ * status='review', so that features escalated from review (by the stale-PR
+ * timeout) are also caught and recovered.
+ *
+ * Compensating control for missed webhooks (runs on the 6-hour board health cycle).
+ * The applyFix handler for 'closed_pr_in_review' (unchanged) resets status to
+ * 'backlog' and clears PR fields.
+ *
+ * Drop-in replacement for FeatureHealthService.checkClosedPRsInReview().
+ */
+export async function checkClosedPRsInReviewPatched(
+  features: Feature[],
+  projectPath: string
+): Promise<HealthIssue[]> {
+  const issues: HealthIssue[] = [];
+
+  // ── CHANGE: was `f.status === 'review'`; now also covers 'blocked' ──────
+  const candidateFeatures = features.filter(
+    (f) =>
+      (f.status === 'review' || f.status === 'blocked') &&
+      f.prNumber != null
+  );
+  // ────────────────────────────────────────────────────────────────────────
+
+  for (const feature of candidateFeatures) {
+    const prNumber = feature.prNumber!;
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['pr', 'view', String(prNumber), '--json', 'state,merged'],
+        { encoding: 'utf-8', timeout: 10_000, cwd: projectPath }
+      );
+      const prData = JSON.parse(stdout) as { state: string; merged: boolean };
+
+      if (prData.state === 'CLOSED' && !prData.merged) {
+        issues.push({
+          type: 'closed_pr_in_review',
+          featureId: feature.id,
+          featureTitle: feature.title ?? feature.id,
+          message:
+            `PR #${prNumber} is closed without merging but feature status is '${feature.status}'`,
+          autoFixable: true,
+          fix: 'Reset status to backlog and clear PR fields',
+        });
+      }
+    } catch {
+      // gh CLI not available, PR not found, or network error — skip.
+      logger.debug(
+        `Skipping closed PR check for feature ${feature.id} PR #${prNumber}`
+      );
+    }
+  }
+
+  return issues;
+}
+
+// ── Inline diff to apply to FeatureHealthService ─────────────────────────────
+//
+// In the full feature-health-service.ts, find:
+//
+//   private async checkClosedPRsInReview(features: Feature[]): Promise<HealthIssue[]> {
+//     const issues: HealthIssue[] = [];
+//     const reviewFeatures = features.filter((f) => f.status === 'review' && f.prNumber != null);
+//
+// Replace with:
+//
+//   private async checkClosedPRsInReview(features: Feature[]): Promise<HealthIssue[]> {
+//     const issues: HealthIssue[] = [];
+//     // Extended to cover 'blocked' features: when the stale-PR timeout
+//     // escalates a review feature to 'blocked' before the health cycle runs,
+//     // the original 'review'-only filter would miss it.
+//     const reviewFeatures = features.filter(
+//       (f) => (f.status === 'review' || f.status === 'blocked') && f.prNumber != null
+//     );
+//
+// No other changes to FeatureHealthService are required.

--- a/apps/server/src/services/feature-scheduler.ts
+++ b/apps/server/src/services/feature-scheduler.ts
@@ -1,0 +1,378 @@
+/**
+ * FeatureScheduler — patch module for the closed-PR oscillation fix.
+ *
+ * This file contains the two targeted changes to the FeatureScheduler class
+ * that address the backlog↔blocked oscillation caused by sibling-feature
+ * conflict auto-closes:
+ *
+ *  1. getHotFileOverlap(): extended to serialise dispatch of any sibling
+ *     features that share filesToModify entries (not only HOT_FILE_BASENAMES).
+ *
+ *  2. loadPendingFeatures() / staleViaPrNumber loop: CLOSED (non-merged) PRs
+ *     now clear prNumber so the feature re-dispatches cleanly instead of
+ *     bouncing to the stale-PR timeout path.
+ *
+ *  3. checkAndDecayStalled(): skips features whose linked PR is already CLOSED,
+ *     deferring recovery to PRStateWatcher / loadPendingFeatures instead of
+ *     bumping failureCount.
+ *
+ * To apply: replace the three affected methods in the full FeatureScheduler
+ * implementation (apps/server/src/services/feature-scheduler.ts in protoMaker).
+ *
+ * Types / helpers used below match the existing imports in that file.
+ */
+
+import path from 'path';
+import { exec } from 'child_process';
+import { promisify } from 'util';
+import * as secureFs from '../lib/secure-fs.js';
+import type { Feature } from '@protolabsai/types';
+import {
+  readJsonWithRecovery,
+  logRecoveryWarning,
+  DEFAULT_BACKUP_COUNT,
+} from '@protolabsai/utils';
+import { getFeaturesDir } from '@protolabsai/platform';
+
+const execAsync = promisify(exec);
+
+/**
+ * Files that are frequently modified by parallel agents and cause merge conflicts.
+ * (Unchanged from original — kept here for reference.)
+ */
+const HOT_FILE_BASENAMES = new Set(['wiring.ts', 'event.ts', 'index.ts', 'services.ts']);
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH 1 — getHotFileOverlap
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// BEFORE: only blocked when both features declared a file whose basename was in
+//         HOT_FILE_BASENAMES. Sibling features sharing custom files like
+//         `a2a_handler.py` were dispatched in parallel, causing the second PR
+//         to become CONFLICTING/DIRTY after the first merged.
+//
+// AFTER:  additionally checks for ANY overlap in filesToModify between the
+//         candidate and each active (running + starting) feature. When overlap
+//         is detected the candidate is deferred until the active agent finishes.
+//
+// Drop-in replacement for FeatureScheduler.getHotFileOverlap().
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Check if a candidate feature shares files with any currently running or
+ * starting feature. Returns the overlapping file basenames, or an empty array
+ * if no overlap is detected.
+ *
+ * Blocks when EITHER:
+ *  - both features declare a file whose basename is in HOT_FILE_BASENAMES, OR
+ *  - both features declare any file with the same normalised path
+ *    (full filesToModify overlap — the new sibling-serialisation guard).
+ *
+ * If filesToModify is absent or empty on either side, no blocking occurs.
+ */
+export async function getHotFileOverlapPatched(
+  projectPath: string,
+  candidate: Feature,
+  startingFeatureIds: Set<string>,
+  featureLoader: {
+    get(projectPath: string, featureId: string): Promise<Feature | null>;
+  },
+  getRunningFeatureIds: (projectPath: string) => string[]
+): Promise<string[]> {
+  const candidateFiles = candidate.filesToModify;
+  if (!candidateFiles || candidateFiles.length === 0) return [];
+
+  // Hot-file basenames (original logic).
+  const candidateHotFiles = candidateFiles
+    .map((f) => path.basename(f))
+    .filter((b) => HOT_FILE_BASENAMES.has(b));
+
+  // Full filesToModify set for path-level overlap detection (new logic).
+  const candidateFileSet = new Set(candidateFiles.map((f) => path.normalize(f)));
+
+  // If neither check can produce a hit, bail early.
+  if (candidateHotFiles.length === 0 && candidateFileSet.size === 0) return [];
+
+  // Active feature IDs scoped to this project (running + starting).
+  const activeIds = new Set([
+    ...getRunningFeatureIds(projectPath),
+    ...startingFeatureIds,
+  ]);
+  activeIds.delete(candidate.id);
+
+  if (activeIds.size === 0) return [];
+
+  const overlapping = new Set<string>();
+
+  for (const fid of activeIds) {
+    const feature = await featureLoader.get(projectPath, fid);
+    if (!feature?.filesToModify || feature.filesToModify.length === 0) continue;
+
+    for (const filePath of feature.filesToModify) {
+      const basename = path.basename(filePath);
+
+      // Original hot-file check.
+      if (candidateHotFiles.includes(basename)) {
+        overlapping.add(basename);
+      }
+
+      // New: full filesToModify path overlap (serialises sibling dispatches).
+      const normalized = path.normalize(filePath);
+      if (candidateFileSet.has(normalized)) {
+        overlapping.add(basename);
+      }
+    }
+  }
+
+  return [...overlapping];
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH 2 — loadPendingFeatures: staleViaPrNumber CLOSED-PR recovery
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// BEFORE: the staleViaPrNumber loop called `gh pr view` and only acted when
+//         state=MERGED. A CLOSED (non-merged) PR was silently ignored, leaving
+//         prNumber set on the feature. The feature was then re-dispatched by the
+//         agent, failed (branch still has the conflict), and incremented
+//         failureCount — driving the backlog→blocked→backlog oscillation.
+//
+// AFTER:  when state=CLOSED (and not merged), the feature's prNumber / prUrl /
+//         reviewStartedAt are cleared and statusChangeReason is set to
+//         'PR closed by conflict — rebasing' so the next dispatch starts on a
+//         fresh branch. failureCount is NOT incremented.
+//
+// Apply inside the `staleViaPrNumber` for-loop in loadPendingFeatures(), after
+// the existing `if (prView.state === 'MERGED') { ... }` block:
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Handle a CLOSED (non-merged) PR discovered during the staleViaPrNumber sweep.
+ * Clears PR linkage on the feature so it can be re-dispatched cleanly.
+ *
+ * @param projectPath  - Repo root passed to gh CLI.
+ * @param feature      - The feature whose prNumber points to the closed PR.
+ * @param featureLoader - Used to persist the update.
+ */
+export async function recoverFeatureFromClosedPr(
+  projectPath: string,
+  feature: Feature,
+  featureLoader: {
+    update(
+      projectPath: string,
+      featureId: string,
+      patch: Partial<Feature>
+    ): Promise<void>;
+  },
+  log: (msg: string) => void,
+  logError: (msg: string, err: unknown) => void
+): Promise<void> {
+  log(
+    `[loadPendingFeatures] Feature ${feature.id} ("${feature.title}") ` +
+    `PR #${feature.prNumber} is CLOSED (not merged) — clearing prNumber, recovering to backlog`
+  );
+  try {
+    await featureLoader.update(projectPath, feature.id, {
+      prNumber: undefined,
+      prUrl: undefined,
+      reviewStartedAt: undefined,
+      statusChangeReason: 'PR closed by conflict — rebasing',
+    });
+    // Mutate the in-memory copy so this sweep's later logic sees the cleared state.
+    feature.prNumber = undefined;
+  } catch (error) {
+    logError(
+      `[loadPendingFeatures] Failed to clear prNumber for closed PR on feature ${feature.id}:`,
+      error
+    );
+  }
+}
+
+// Inline version for direct insertion into the staleViaPrNumber for-loop:
+//
+// ```typescript
+// const prView: { state: string; mergedAt?: string } = JSON.parse(prViewJson);
+// if (prView.state === 'MERGED') {
+//   // ... existing done-reconciliation logic ...
+// } else if (prView.state === 'CLOSED') {
+//   // ── NEW: Closed-PR recovery ──────────────────────────────────────────
+//   logger.info(
+//     `[loadPendingFeatures] Feature ${feature.id} ("${feature.title}") ` +
+//     `PR #${feature.prNumber} is CLOSED (not merged) — clearing prNumber, recovering to backlog`
+//   );
+//   try {
+//     await this.featureLoader.update(projectPath, feature.id, {
+//       prNumber: undefined,
+//       prUrl: undefined,
+//       reviewStartedAt: undefined,
+//       statusChangeReason: 'PR closed by conflict — rebasing',
+//     });
+//     feature.prNumber = undefined;
+//   } catch (error) {
+//     logger.error(
+//       `[loadPendingFeatures] Failed to clear prNumber for closed PR on feature ${feature.id}:`,
+//       error
+//     );
+//   }
+//   // ─────────────────────────────────────────────────────────────────────
+// }
+// ```
+
+// ─────────────────────────────────────────────────────────────────────────────
+// PATCH 3 — checkAndDecayStalled: skip CLOSED-PR features
+// ─────────────────────────────────────────────────────────────────────────────
+//
+// BEFORE: checkAndDecayStalled decayed ANY 'review' feature with a CI failure
+//         indicator that had been stalled beyond the timeout. Features whose PR
+//         was CLOSED were incorrectly treated as "stalled with CI failures" and
+//         decayed to backlog with failureCount++. On the next sweep they were
+//         re-dispatched, conflicted, and decayed again — the oscillation loop.
+//
+// AFTER:  before decaying, confirm the feature's linked PR is still OPEN.
+//         If the PR is CLOSED (non-merged), skip the decay; PRStateWatcher and
+//         the loadPendingFeatures closed-PR recovery will handle it without
+//         bumping failureCount.
+//
+// Replace the `checkAndDecayStalled` method in FeatureScheduler with the version
+// below. The new PR-state guard is the only substantive change.
+// ─────────────────────────────────────────────────────────────────────────────
+
+/**
+ * Find features in 'review' status with failing CI that have been stalled
+ * beyond the configured timeout, and reset them to 'backlog' with an
+ * incremented failureCount.
+ *
+ * NEW: skips features whose linked PR is CLOSED (not merged). Conflict
+ * auto-closes should not accumulate agent failure counts — they indicate a
+ * scheduling issue, not a coding error. PRStateWatcher handles those.
+ *
+ * @returns Number of features that were decayed.
+ */
+export async function checkAndDecayStalledPatched(
+  projectPath: string,
+  timeoutMinutes: number,
+  featureLoader: {
+    update(projectPath: string, featureId: string, patch: Partial<Feature>): Promise<void>;
+  },
+  emitAutoDecayed: (payload: {
+    featureId: string;
+    featureTitle: string | undefined;
+    elapsedMinutes: number;
+    failureCount: number;
+    projectPath: string;
+  }) => void,
+  log: {
+    info: (msg: string) => void;
+    warn: (msg: string) => void;
+    error: (msg: string, err?: unknown) => void;
+    debug: (msg: string) => void;
+  }
+): Promise<number> {
+  if (timeoutMinutes === 0) return 0;
+
+  const timeoutMs = timeoutMinutes * 60 * 1000;
+  const featuresDir = getFeaturesDir(projectPath);
+  let decayedCount = 0;
+
+  try {
+    const entries = await secureFs.readdir(featuresDir, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isDirectory()) continue;
+      const featurePath = path.join(featuresDir, entry.name, 'feature.json');
+      const result = await readJsonWithRecovery<Feature | null>(featurePath, null, {
+        maxBackups: DEFAULT_BACKUP_COUNT,
+        autoRestore: false,
+      });
+      logRecoveryWarning(result, `Feature ${entry.name}`, {
+        warn: (msg: string) => log.warn(msg),
+      } as never);
+      const feature = result.data;
+      if (!feature || feature.status !== 'review') continue;
+
+      // Determine how long the feature has been in review.
+      const reviewTimestamp = feature.reviewStartedAt ?? feature.updatedAt;
+      if (!reviewTimestamp) continue;
+      const reviewStartMs =
+        typeof reviewTimestamp === 'number'
+          ? reviewTimestamp
+          : new Date(reviewTimestamp).getTime();
+      const elapsedMs = Date.now() - reviewStartMs;
+      if (elapsedMs < timeoutMs) continue;
+
+      // Check for failing CI indicators.
+      const hasCiFailureIndicator =
+        (feature.ciRemediationCount ?? 0) > 0 ||
+        (feature.ciIterationCount ?? 0) > 0 ||
+        (feature.remediationHistory ?? []).some(
+          (h: { cycleType?: string }) => h.cycleType === 'ci_failure'
+        ) ||
+        /\bci\b|\bci fail/i.test(feature.statusChangeReason ?? '');
+
+      if (!hasCiFailureIndicator) continue;
+
+      // ── NEW: skip decay when the linked PR is already CLOSED ────────────
+      // A CLOSED PR means GitHub auto-closed it due to a merge conflict.
+      // The conflict is a scheduling issue, not a CI/agent failure — bumping
+      // failureCount here would push the feature toward the human-escalation
+      // threshold incorrectly. PRStateWatcher / loadPendingFeatures handle
+      // closed-PR recovery without touching failureCount.
+      if (feature.prNumber) {
+        try {
+          const prNum = String(feature.prNumber).replace(/[^0-9]/g, '');
+          const { stdout: prStateRaw } = await execAsync(
+            `gh pr view ${prNum} --json state --jq '.state'`,
+            { cwd: projectPath, timeout: 10_000 }
+          );
+          if (prStateRaw.trim() === 'CLOSED') {
+            log.info(
+              `[AutoDecay] Feature ${feature.id} PR #${feature.prNumber} is CLOSED ` +
+              `— skipping decay, closed-PR recovery will handle it without bumping failureCount`
+            );
+            continue;
+          }
+        } catch {
+          // gh CLI error — fall through to decay as safe fallback.
+        }
+      }
+      // ────────────────────────────────────────────────────────────────────
+
+      // Decay the feature back to backlog.
+      const prevFailureCount = feature.failureCount ?? 0;
+      const elapsedMinutes = Math.round(elapsedMs / 60000);
+      try {
+        await featureLoader.update(projectPath, feature.id, {
+          status: 'backlog',
+          failureCount: prevFailureCount + 1,
+          statusChangeReason: `Auto-decayed: stalled in review for ${elapsedMinutes}min with failing CI`,
+          prNumber: undefined,
+          prUrl: undefined,
+          prCreatedAt: undefined,
+          reviewStartedAt: undefined,
+          prTrackedSince: undefined,
+        });
+        decayedCount++;
+        log.warn(
+          `[AutoDecay] Feature ${feature.id} ("${feature.title}") decayed from review to backlog — ` +
+          `stalled ${elapsedMinutes}min with failing CI (failureCount: ${prevFailureCount} -> ${prevFailureCount + 1})`
+        );
+        emitAutoDecayed({
+          featureId: feature.id,
+          featureTitle: feature.title,
+          elapsedMinutes,
+          failureCount: prevFailureCount + 1,
+          projectPath,
+        });
+      } catch (error) {
+        log.error(`[AutoDecay] Failed to decay feature ${feature.id}:`, error);
+      }
+    }
+  } catch (error) {
+    log.error('[AutoDecay] Error scanning review queue for stalled features:', error);
+  }
+
+  if (decayedCount > 0) {
+    log.warn(`[AutoDecay] Decayed ${decayedCount} stalled review feature(s) back to backlog`);
+  }
+
+  return decayedCount;
+}

--- a/apps/server/src/services/pr-state-watcher.ts
+++ b/apps/server/src/services/pr-state-watcher.ts
@@ -1,0 +1,197 @@
+/**
+ * PR State Watcher — Detects CLOSED (non-merged) PR transitions and triggers
+ * feature recovery.
+ *
+ * Addresses the root-cause of the backlog↔blocked oscillation described in:
+ * https://github.com/protolabsai/protoMaker/issues/XXXX
+ *
+ * Problem:
+ *   When two sibling features concurrently modify the same files and the first
+ *   merges, GitHub auto-closes the second PR with mergeable=CONFLICTING /
+ *   mergeState=DIRTY. The pipeline had no real-time handler for this OPEN→CLOSED
+ *   transition: the feature stayed in 'review' with a dead prNumber, the
+ *   stale-PR timeout fired, set it to 'blocked', and repeated every sweep.
+ *
+ * Fix:
+ *   This service polls features in 'review' and 'blocked' status every
+ *   PR_STATE_POLL_INTERVAL_MS. When it finds a linked PR in state=CLOSED (and
+ *   not merged), it atomically:
+ *     (a) nulls out prNumber / prUrl / reviewStartedAt on the feature
+ *     (b) resets status to 'backlog'
+ *     (c) sets statusChangeReason = 'PR closed by conflict — rebasing'
+ *     (d) does NOT increment failureCount (conflict auto-close is not an agent failure)
+ *
+ * Integration:
+ *   Instantiate once in the server wiring (apps/server/src/wiring.ts) and call
+ *   start(projectPath) after auto-mode is enabled for a project. Multiple projects
+ *   can be registered; each runs an independent poll cycle.
+ */
+
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+import { createLogger } from '@protolabsai/utils';
+import type { Feature } from '@protolabsai/types';
+import type { FeatureLoader } from './feature-loader.js';
+
+const execFileAsync = promisify(execFile);
+const logger = createLogger('PRStateWatcher');
+
+/** Poll interval for closed-PR detection (default: 90 seconds). */
+const PR_STATE_POLL_INTERVAL_MS = parseInt(
+  process.env.PR_STATE_POLL_INTERVAL_MS ?? '90000',
+  10
+);
+
+/** Statuses that warrant a closed-PR check (feature has a linked PR that could be CLOSED). */
+const WATCHABLE_STATUSES = new Set<string>(['review', 'blocked']);
+
+/** In-memory record of PR numbers already recovered this session (idempotency guard). */
+const recoveredPrNumbers = new Set<number>();
+
+interface ProjectWatcher {
+  projectPath: string;
+  timer: ReturnType<typeof setInterval> | null;
+}
+
+export class PRStateWatcher {
+  private readonly watchers = new Map<string, ProjectWatcher>();
+
+  constructor(private readonly featureLoader: FeatureLoader) {}
+
+  /**
+   * Begin watching a project for CLOSED PR transitions.
+   * Safe to call multiple times for the same project — subsequent calls are no-ops.
+   */
+  start(projectPath: string): void {
+    if (this.watchers.has(projectPath)) {
+      logger.debug(`PRStateWatcher already watching ${projectPath}`);
+      return;
+    }
+
+    logger.info(`PRStateWatcher: starting closed-PR poll for ${projectPath} (interval=${PR_STATE_POLL_INTERVAL_MS}ms)`);
+
+    const watcher: ProjectWatcher = { projectPath, timer: null };
+    this.watchers.set(projectPath, watcher);
+
+    watcher.timer = setInterval(() => {
+      void this.pollProject(projectPath).catch((err) => {
+        logger.warn(`PRStateWatcher poll error for ${projectPath}:`, err);
+      });
+    }, PR_STATE_POLL_INTERVAL_MS);
+
+    // Run an immediate first sweep so we don't wait a full interval on startup.
+    void this.pollProject(projectPath).catch((err) => {
+      logger.warn(`PRStateWatcher initial sweep error for ${projectPath}:`, err);
+    });
+  }
+
+  /** Stop watching a project (e.g. when auto-mode is disabled). */
+  stop(projectPath: string): void {
+    const watcher = this.watchers.get(projectPath);
+    if (!watcher) return;
+    if (watcher.timer) clearInterval(watcher.timer);
+    this.watchers.delete(projectPath);
+    logger.info(`PRStateWatcher: stopped watching ${projectPath}`);
+  }
+
+  /** Stop all watchers (graceful shutdown). */
+  stopAll(): void {
+    for (const { projectPath } of this.watchers.values()) {
+      this.stop(projectPath);
+    }
+  }
+
+  // ── Private ───────────────────────────────────────────────────────────────
+
+  private async pollProject(projectPath: string): Promise<void> {
+    const features = await this.featureLoader.getAll(projectPath);
+
+    const candidates = features.filter(
+      (f) =>
+        f.prNumber != null &&
+        f.status != null &&
+        WATCHABLE_STATUSES.has(f.status)
+    );
+
+    if (candidates.length === 0) return;
+
+    logger.debug(
+      `PRStateWatcher: checking ${candidates.length} candidate(s) in ${projectPath}`
+    );
+
+    for (const feature of candidates) {
+      await this.checkFeature(projectPath, feature);
+    }
+  }
+
+  /**
+   * Check a single feature's linked PR.
+   * If CLOSED (not merged), trigger recovery atomically.
+   */
+  private async checkFeature(projectPath: string, feature: Feature): Promise<void> {
+    const prNumber = feature.prNumber!;
+
+    // Skip PRs we already recovered in this server session (idempotency).
+    if (recoveredPrNumbers.has(prNumber)) return;
+
+    try {
+      const { stdout } = await execFileAsync(
+        'gh',
+        ['pr', 'view', String(prNumber), '--json', 'state,merged,mergedAt'],
+        { encoding: 'utf-8', timeout: 10_000, cwd: projectPath }
+      );
+
+      const prData = JSON.parse(stdout) as {
+        state: string;
+        merged: boolean;
+        mergedAt?: string | null;
+      };
+
+      if (prData.state !== 'CLOSED') return; // still OPEN or MERGED — nothing to do
+      if (prData.merged) return;              // merged via a different path — scheduler handles it
+
+      // PR is CLOSED without merging — recover the feature.
+      logger.warn(
+        `PRStateWatcher: PR #${prNumber} for feature "${feature.title}" (${feature.id}) ` +
+        `is CLOSED without merging — recovering to backlog`
+      );
+
+      await this.recoverFeature(projectPath, feature);
+      recoveredPrNumbers.add(prNumber);
+    } catch (err) {
+      // gh CLI unavailable, network error, or PR not found — skip silently.
+      logger.debug(
+        `PRStateWatcher: could not check PR #${prNumber} for feature ${feature.id}: ${err}`
+      );
+    }
+  }
+
+  /**
+   * Atomically reset a feature whose PR was closed by conflict.
+   *
+   * Deliberately does NOT increment failureCount — a conflict auto-close is
+   * caused by sibling dispatch ordering, not an agent coding error.
+   */
+  private async recoverFeature(projectPath: string, feature: Feature): Promise<void> {
+    try {
+      await this.featureLoader.update(projectPath, feature.id, {
+        status: 'backlog',
+        prNumber: undefined,
+        prUrl: undefined,
+        reviewStartedAt: undefined,
+        prTrackedSince: undefined,
+        statusChangeReason: 'PR closed by conflict — rebasing',
+      });
+
+      logger.info(
+        `PRStateWatcher: recovered feature ${feature.id} ("${feature.title}") ` +
+        `to backlog after closed PR #${feature.prNumber}`
+      );
+    } catch (err) {
+      logger.error(
+        `PRStateWatcher: failed to recover feature ${feature.id} after closed PR #${feature.prNumber}:`,
+        err
+      );
+    }
+  }
+}


### PR DESCRIPTION
## Summary

## Problem

When two concurrently-dispatched features depend on the same prior feature and modify overlapping files, the second one's PR becomes `DIRTY` after the first merges and GitHub auto-closes it. The feature's statusChangeReason still reads `PR #N has been pending CI/review for X minute(s)` and the stale-PR detector re-triggers on every sweep, oscillating the feature between `backlog` and `blocked`.

## Evidence (protoAgent 2026-04-19)

- M1 P1 (A2A auth) → PR #1 merged at 05:59 ✓
- M1 P2...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automatic detection and recovery of features linked to closed pull requests
  * Continuous pull request state monitoring with automatic feature recovery
  * Enhanced file conflict detection during feature scheduling
  * Automatic handling of stalled features with pull request state validation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->