### PR TITLE
Session memory persistence on terminal state

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000300-secorigin",
-  "startedAt": "2026-04-19T15:53:21.357Z"
+  "featureId": "feature-1776800000500-memwrite1",
+  "startedAt": "2026-04-19T16:27:32.308Z"
 }

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -2,23 +2,175 @@
 
 After the agent responds, extracts key topics/findings from the
 conversation and stores them in the knowledge base asynchronously.
+
+Also persists a session summary to disk when sessions end via the
+on_session_end lifecycle hook, enabling session memory across restarts.
 """
 
+import json
+import logging
+import os
+import tempfile
 import threading
+from datetime import datetime, timezone
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from langgraph.prebuilt.chat_agent_executor import AgentState
 
 
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration — read once at module init
+# ---------------------------------------------------------------------------
+
+MEMORY_PATH = os.environ.get("MEMORY_PATH", "/sandbox/memory/")
+_DISABLE_ENV = os.environ.get("PROTOAGENT_DISABLE_MEMORY", "")
+_PERSISTENCE_DISABLED = _DISABLE_ENV.lower() in ("1", "true", "yes")
+
+if _PERSISTENCE_DISABLED:
+    log.debug("[memory] persistence disabled via PROTOAGENT_DISABLE_MEMORY")
+else:
+    log.info("[memory] session persistence enabled — path: %s", MEMORY_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Session persistence
+# ---------------------------------------------------------------------------
+
+def _persist_session(state: dict, trace_id: str) -> None:
+    """Write a session summary JSON file atomically.
+
+    Summary schema:
+        session_id       — str
+        trace_id         — str
+        messages         — list[{"role": str, "content": str}]
+        tool_calls       — top-5 by duration list[{"name", "args", "result", "duration_ms"}]
+        tool_calls_total_count — int (present when > 5 tool calls)
+        final_output     — str | null
+        timestamp        — ISO-8601 UTC string
+
+    Writes atomically: temp file → os.rename to avoid partial reads.
+    """
+    if _PERSISTENCE_DISABLED:
+        return
+
+    session_id: str = state.get("session_id", "") or ""
+    messages_raw: list = state.get("messages", []) or []
+
+    # --- Extract user-visible messages ---
+    user_messages: list[dict] = []
+    for msg in messages_raw:
+        if isinstance(msg, HumanMessage):
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            user_messages.append({"role": "user", "content": content})
+        elif isinstance(msg, AIMessage) and msg.content:
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            user_messages.append({"role": "assistant", "content": content})
+
+    # --- Extract tool call records ---
+    # Reconstruct from AI messages (which carry tool_calls) and ToolMessages
+    tool_results: dict[str, str] = {}
+    all_tool_calls: list[dict] = []
+
+    for msg in messages_raw:
+        if isinstance(msg, ToolMessage):
+            tool_call_id = getattr(msg, "tool_call_id", "") or ""
+            tool_results[tool_call_id] = (
+                msg.content if isinstance(msg.content, str) else str(msg.content)
+            )
+
+    for msg in messages_raw:
+        if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+            for tc in msg.tool_calls:
+                tc_id = tc.get("id", "")
+                all_tool_calls.append({
+                    "name": tc.get("name", ""),
+                    "args": tc.get("args", {}),
+                    "result": tool_results.get(tc_id, ""),
+                    "duration_ms": 0,  # timing not available in state
+                })
+
+    total_count = len(all_tool_calls)
+
+    # Top-5 by duration (duration is 0 for all when not available — stable sort)
+    sorted_calls = sorted(all_tool_calls, key=lambda x: x["duration_ms"], reverse=True)
+    top_calls = sorted_calls[:5]
+
+    # --- Final output: last assistant message ---
+    final_output: str | None = None
+    for msg in reversed(messages_raw):
+        if isinstance(msg, AIMessage) and msg.content:
+            final_output = msg.content if isinstance(msg.content, str) else str(msg.content)
+            break
+
+    # --- Build summary ---
+    summary: dict[str, Any] = {
+        "session_id": session_id,
+        "trace_id": trace_id,
+        "messages": user_messages,
+        "tool_calls": top_calls,
+        "final_output": final_output,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    if total_count > 5:
+        summary["tool_calls_total_count"] = total_count
+
+    # --- Ensure directory exists ---
+    try:
+        os.makedirs(MEMORY_PATH, exist_ok=True)
+        log.debug("[memory] ensured directory: %s", MEMORY_PATH)
+    except OSError as exc:
+        log.warning("[memory] cannot create directory %s: %s — skipping persistence", MEMORY_PATH, exc)
+        return
+
+    # --- Atomic write ---
+    filename = f"{session_id or 'unknown'}.json"
+    dest = os.path.join(MEMORY_PATH, filename)
+    tmp_fd = None
+    tmp_path = None
+    try:
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=MEMORY_PATH, suffix=".tmp")
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            json.dump(summary, fh, indent=2, default=str)
+            tmp_fd = None  # fdopen took ownership
+        os.rename(tmp_path, dest)
+        log.info("[memory] persisted session %s -> %s", session_id, dest)
+        tmp_path = None  # rename succeeded — no cleanup needed
+    except OSError as exc:
+        log.error("[memory] write failed for session %s: %s", session_id, exc)
+    finally:
+        # Clean up temp file if rename didn't happen
+        if tmp_fd is not None:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Middleware class
+# ---------------------------------------------------------------------------
+
 class MemoryMiddleware(AgentMiddleware):
-    """Extract and store QA findings after agent responses."""
+    """Extract and store QA findings after agent responses.
+
+    Also persists a session summary on session end via on_session_end.
+    """
 
     def __init__(self, knowledge_store):
         super().__init__()
         self._store = knowledge_store
+
+    # --- Knowledge extraction (existing) ---
 
     def after_agent(self, state, runtime) -> dict | None:
         """Queue conversation for async knowledge extraction."""
@@ -61,3 +213,15 @@ class MemoryMiddleware(AgentMiddleware):
 
     async def aafter_agent(self, state, runtime) -> dict | None:
         return self.after_agent(state, runtime)
+
+    # --- Session persistence ---
+
+    def on_session_end(self, state, runtime) -> dict | None:
+        """Persist session summary to disk when session reaches terminal state."""
+        import tracing
+        trace_id = tracing.current_trace_id()
+        _persist_session(state, trace_id)
+        return None
+
+    async def aon_session_end(self, state, runtime) -> dict | None:
+        return self.on_session_end(state, runtime)

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -1,0 +1,394 @@
+"""Unit tests for graph.middleware.memory._persist_session.
+
+Covers:
+- successful file persistence with correct JSON structure
+- atomic write resilience (temp file cleanup, no partial writes visible)
+- opt-out when PROTOAGENT_DISABLE_MEMORY=1
+- custom MEMORY_PATH override
+- automatic directory creation
+- graceful handling of permission errors
+- tool_calls count and top-5 duration sorting
+- empty session handling
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reload_memory(env_overrides: dict | None = None):
+    """Reload graph.middleware.memory with given env overrides active.
+
+    Returns the freshly-imported module so tests can call _persist_session
+    with a known MEMORY_PATH / PROTOAGENT_DISABLE_MEMORY state.
+    """
+    env_overrides = env_overrides or {}
+    with patch.dict(os.environ, env_overrides, clear=False):
+        if "graph.middleware.memory" in sys.modules:
+            del sys.modules["graph.middleware.memory"]
+        import graph.middleware.memory as mod
+        return mod
+
+
+def _make_state(
+    session_id: str = "test-session-1",
+    messages=None,
+):
+    """Build a minimal state dict as the middleware would see it."""
+    if messages is None:
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi there! How can I help you today? " * 5),
+        ]
+    return {
+        "session_id": session_id,
+        "messages": messages,
+        "context": "",
+        "captured_messages": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Successful persistence with correct JSON structure
+# ---------------------------------------------------------------------------
+
+def test_persist_session_creates_json_file(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = _make_state("abc-123")
+    with patch("tracing.current_trace_id", return_value="trace-xyz"):
+        mod._persist_session(state, "trace-xyz")
+
+    expected = tmp_path / "abc-123.json"
+    assert expected.exists(), "session JSON file was not created"
+
+    data = json.loads(expected.read_text())
+    assert data["session_id"] == "abc-123"
+    assert data["trace_id"] == "trace-xyz"
+    assert isinstance(data["messages"], list)
+    assert isinstance(data["tool_calls"], list)
+    assert "timestamp" in data
+
+
+def test_persist_session_json_has_required_fields(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = _make_state("req-fields")
+    with patch("tracing.current_trace_id", return_value="t1"):
+        mod._persist_session(state, "t1")
+
+    data = json.loads((tmp_path / "req-fields.json").read_text())
+    for key in ("session_id", "trace_id", "messages", "tool_calls", "final_output", "timestamp"):
+        assert key in data, f"missing required field: {key}"
+
+
+def test_persist_session_captures_messages(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    messages = [
+        HumanMessage(content="What is 2+2?"),
+        AIMessage(content="The answer is 4."),
+    ]
+    state = _make_state("msg-test", messages=messages)
+    mod._persist_session(state, "t2")
+
+    data = json.loads((tmp_path / "msg-test.json").read_text())
+    roles = [m["role"] for m in data["messages"]]
+    assert "user" in roles
+    assert "assistant" in roles
+    contents = [m["content"] for m in data["messages"]]
+    assert any("2+2" in c for c in contents)
+    assert any("4" in c for c in contents)
+
+
+def test_persist_session_final_output_is_last_ai_message(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    messages = [
+        HumanMessage(content="Hi"),
+        AIMessage(content="First reply."),
+        HumanMessage(content="Tell me more"),
+        AIMessage(content="This is the final answer."),
+    ]
+    state = _make_state("final-out", messages=messages)
+    mod._persist_session(state, "t3")
+
+    data = json.loads((tmp_path / "final-out.json").read_text())
+    assert data["final_output"] == "This is the final answer."
+
+
+# ---------------------------------------------------------------------------
+# 2. Atomic write — no partial file visible
+# ---------------------------------------------------------------------------
+
+def test_atomic_write_no_partial_file_on_error(tmp_path):
+    """If json.dump fails mid-write, no corrupted file should exist at dest."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = _make_state("atomic-test")
+    dest = tmp_path / "atomic-test.json"
+
+    original_json_dump = json.dump
+
+    def bad_dump(*args, **kwargs):
+        raise OSError("simulated write error")
+
+    with patch("json.dump", side_effect=bad_dump):
+        mod._persist_session(state, "t4")
+
+    # Destination file must NOT exist — no partial write
+    assert not dest.exists(), "partial file should not be visible on write failure"
+
+    # No .tmp files left behind
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert len(tmp_files) == 0, f"temp files not cleaned up: {tmp_files}"
+
+
+def test_atomic_write_succeeds_with_valid_rename(tmp_path):
+    """After a successful write, only the final .json file exists."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = _make_state("rename-test")
+    mod._persist_session(state, "t5")
+
+    assert (tmp_path / "rename-test.json").exists()
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert len(tmp_files) == 0, "temp files should be cleaned up after successful write"
+
+
+# ---------------------------------------------------------------------------
+# 3. Opt-out via PROTOAGENT_DISABLE_MEMORY
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_env_var(tmp_path):
+    mod = _reload_memory({
+        "MEMORY_PATH": str(tmp_path),
+        "PROTOAGENT_DISABLE_MEMORY": "1",
+    })
+
+    state = _make_state("disabled-session")
+    mod._persist_session(state, "t6")
+
+    # No file should be created
+    assert not list(tmp_path.glob("*.json")), "no file should be written when disabled"
+
+
+@pytest.mark.parametrize("value", ["1", "true", "True"])
+def test_disabled_by_env_var_variants(tmp_path, value):
+    mod = _reload_memory({
+        "MEMORY_PATH": str(tmp_path),
+        "PROTOAGENT_DISABLE_MEMORY": value,
+    })
+
+    state = _make_state("disabled-variant")
+    mod._persist_session(state, "t7")
+
+    assert not list(tmp_path.glob("*.json")), f"no file should be written for PROTOAGENT_DISABLE_MEMORY={value!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Custom MEMORY_PATH override
+# ---------------------------------------------------------------------------
+
+def test_custom_memory_path(tmp_path):
+    custom = tmp_path / "custom" / "path"
+    mod = _reload_memory({
+        "MEMORY_PATH": str(custom),
+        "PROTOAGENT_DISABLE_MEMORY": "",
+    })
+
+    state = _make_state("custom-path-session")
+    mod._persist_session(state, "t8")
+
+    expected = custom / "custom-path-session.json"
+    assert expected.exists(), f"file not written to custom path: {expected}"
+    data = json.loads(expected.read_text())
+    assert data["session_id"] == "custom-path-session"
+
+
+# ---------------------------------------------------------------------------
+# 5. Automatic directory creation
+# ---------------------------------------------------------------------------
+
+def test_directory_auto_created(tmp_path):
+    nested = tmp_path / "a" / "b" / "c"
+    assert not nested.exists(), "pre-condition: directory should not exist yet"
+
+    mod = _reload_memory({
+        "MEMORY_PATH": str(nested),
+        "PROTOAGENT_DISABLE_MEMORY": "",
+    })
+
+    state = _make_state("mkdir-session")
+    mod._persist_session(state, "t9")
+
+    assert nested.exists(), "directory should have been created automatically"
+    assert (nested / "mkdir-session.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# 6. Graceful permission error handling
+# ---------------------------------------------------------------------------
+
+def test_permission_error_does_not_raise(tmp_path):
+    """If makedirs raises PermissionError, persist_session must not raise."""
+    mod = _reload_memory({
+        "MEMORY_PATH": str(tmp_path / "no-perms"),
+        "PROTOAGENT_DISABLE_MEMORY": "",
+    })
+
+    state = _make_state("perm-session")
+
+    with patch("os.makedirs", side_effect=OSError("Permission denied")):
+        # Must not raise
+        mod._persist_session(state, "t10")
+
+
+def test_write_error_does_not_raise(tmp_path):
+    """If the write itself fails (disk full etc.), persist_session must not raise."""
+    mod = _reload_memory({
+        "MEMORY_PATH": str(tmp_path),
+        "PROTOAGENT_DISABLE_MEMORY": "",
+    })
+
+    state = _make_state("write-err-session")
+
+    with patch("os.rename", side_effect=OSError("No space left on device")):
+        # Must not raise
+        mod._persist_session(state, "t11")
+
+
+# ---------------------------------------------------------------------------
+# 7. Tool call count and top-5 by duration sorting
+# ---------------------------------------------------------------------------
+
+def _ai_msg_with_tool_calls(tool_calls: list[dict]) -> AIMessage:
+    """Build an AIMessage that carries tool_calls metadata."""
+    msg = AIMessage(content="")
+    msg.tool_calls = tool_calls
+    return msg
+
+
+def _tool_msg(tool_call_id: str, content: str) -> ToolMessage:
+    return ToolMessage(content=content, tool_call_id=tool_call_id)
+
+
+def test_tool_calls_included_in_summary(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    tc1 = {"id": "tc1", "name": "search", "args": {"query": "python"}}
+    tc2 = {"id": "tc2", "name": "calculator", "args": {"expression": "1+1"}}
+    messages = [
+        HumanMessage(content="Do something"),
+        _ai_msg_with_tool_calls([tc1, tc2]),
+        _tool_msg("tc1", "search result"),
+        _tool_msg("tc2", "2"),
+        AIMessage(content="Done."),
+    ]
+    state = _make_state("tool-test", messages=messages)
+    mod._persist_session(state, "t12")
+
+    data = json.loads((tmp_path / "tool-test.json").read_text())
+    assert len(data["tool_calls"]) == 2
+    names = {tc["name"] for tc in data["tool_calls"]}
+    assert names == {"search", "calculator"}
+
+
+def test_tool_calls_total_count_when_more_than_5(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    # 7 tool calls
+    tcs = [{"id": f"tc{i}", "name": f"tool_{i}", "args": {}} for i in range(7)]
+    tool_msgs = [_tool_msg(f"tc{i}", f"result {i}") for i in range(7)]
+    messages = [
+        HumanMessage(content="Do things"),
+        _ai_msg_with_tool_calls(tcs),
+        *tool_msgs,
+        AIMessage(content="All done."),
+    ]
+    state = _make_state("many-tools", messages=messages)
+    mod._persist_session(state, "t13")
+
+    data = json.loads((tmp_path / "many-tools.json").read_text())
+    assert len(data["tool_calls"]) == 5
+    assert data["tool_calls_total_count"] == 7
+
+
+def test_tool_calls_no_total_count_when_5_or_fewer(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    tcs = [{"id": f"tc{i}", "name": f"tool_{i}", "args": {}} for i in range(3)]
+    tool_msgs = [_tool_msg(f"tc{i}", f"result {i}") for i in range(3)]
+    messages = [
+        HumanMessage(content="Do 3 things"),
+        _ai_msg_with_tool_calls(tcs),
+        *tool_msgs,
+        AIMessage(content="Done."),
+    ]
+    state = _make_state("few-tools", messages=messages)
+    mod._persist_session(state, "t14")
+
+    data = json.loads((tmp_path / "few-tools.json").read_text())
+    assert len(data["tool_calls"]) == 3
+    assert "tool_calls_total_count" not in data
+
+
+# ---------------------------------------------------------------------------
+# 8. Empty session
+# ---------------------------------------------------------------------------
+
+def test_empty_session_creates_file_with_empty_arrays(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = {
+        "session_id": "empty-session",
+        "messages": [],
+        "context": "",
+        "captured_messages": [],
+    }
+    mod._persist_session(state, "t15")
+
+    expected = tmp_path / "empty-session.json"
+    assert expected.exists(), "file should be created even for empty session"
+
+    data = json.loads(expected.read_text())
+    assert data["session_id"] == "empty-session"
+    assert data["messages"] == []
+    assert data["tool_calls"] == []
+    assert data["final_output"] is None
+    assert "timestamp" in data
+
+
+# ---------------------------------------------------------------------------
+# 9. on_session_end middleware hook
+# ---------------------------------------------------------------------------
+
+def test_on_session_end_calls_persist_session(tmp_path):
+    """MemoryMiddleware.on_session_end must call _persist_session."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    store = MagicMock()
+    mw = mod.MemoryMiddleware(knowledge_store=store)
+
+    state = _make_state("hook-session")
+    runtime = MagicMock()
+
+    with patch.object(mod, "_persist_session") as mock_persist, \
+         patch("tracing.current_trace_id", return_value="trace-hook"):
+        result = mw.on_session_end(state, runtime)
+
+    mock_persist.assert_called_once_with(state, "trace-hook")
+    assert result is None


### PR DESCRIPTION
## Summary

Persist a session summary to `/sandbox/memory/{session_id}.json` when a session reaches terminal state.

## Problem
`MemoryMiddleware` is in the stack but there's no visible persistence layer. Fork users mount `/sandbox/` as a volume but nothing's written there session-over-session.

## Approach
- Add `graph/middleware/memory.py::_persist_session(state, trace_id)` — called from `on_session_end` hook
- Summary includes: session_id, trace_id, user-visible messages, tool calls (count + top-5 by dur...

---
*Recovered automatically by Automaker post-agent hook*