### PR TITLE
Session memory loading + default-on config

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
   "featureId": "feature-1776800000600-memload22",
-  "startedAt": "2026-04-19T16:35:09.847Z"
+  "startedAt": "2026-04-19T16:59:59.859Z"
 }

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000800-sklemit01",
-  "startedAt": "2026-04-19T17:16:55.674Z"
+  "featureId": "feature-1776800000600-memload22",
+  "startedAt": "2026-04-19T16:35:09.847Z"
 }

--- a/config/langgraph-config.yaml
+++ b/config/langgraph-config.yaml
@@ -26,14 +26,22 @@ subagents:
     max_turns: 20
 
 middleware:
-  # The knowledge / memory middlewares require a knowledge store. The
-  # template ships with no store, so leave these false until you add
-  # one.
+  # The knowledge middleware requires a knowledge store. Leave false
+  # until you add one. Memory persistence is enabled by default and
+  # writes session summaries to /sandbox/memory/ without a store.
   knowledge: false
   audit: true
-  memory: false
+  memory: true
 
 knowledge:
   db_path: /sandbox/knowledge/agent.db
   embed_model: nomic-embed-text
   top_k: 5
+
+# Session memory loading — prior summaries injected into system prompt
+# by KnowledgeMiddleware when it is active. Persistence via MemoryMiddleware
+# uses the same path. Mount a volume at this path to survive container restarts.
+memory:
+  path: /sandbox/memory/
+  max_sessions: 10
+  max_tokens: 2000

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -61,12 +61,22 @@ LangGraph's `create_agent` gives you:
 
 The template's middleware chain (`_build_middleware` in `graph/agent.py`) is ordered:
 
-1. **KnowledgeMiddleware** (optional) — injects retrieved context before each LLM call
+1. **KnowledgeMiddleware** (optional) — injects retrieved context before each LLM call; also loads prior session summaries from `/sandbox/memory/` as a `<prior_sessions>` block
 2. **AuditMiddleware** — records every tool call to JSONL + Langfuse
-3. **MemoryMiddleware** (optional) — persists useful context
+3. **MemoryMiddleware** (optional) — persists session summaries to `/sandbox/memory/` on session end
 4. **MessageCaptureMiddleware** — captures `message()` tool calls for later retrieval
 
 Middleware order matters. Knowledge must run before audit (so the injected context is captured). Message capture runs last so every upstream transformation is already applied.
+
+## Session memory
+
+Memory is **enabled by default** (`middleware.memory: true` in `langgraph-config.yaml`). At session end `MemoryMiddleware` writes a JSON summary to `/sandbox/memory/`. On the next session, `KnowledgeMiddleware.load_memory()` reads the 10 most recent summaries and injects them as a `<prior_sessions>` XML block into the system prompt context, giving the agent continuity across restarts without any external store.
+
+**Token budget:** the prior-sessions block is capped at 2 000 tokens (character approximation: chars ÷ 4). Oldest sessions are dropped first when the budget is exceeded.
+
+**Disabling memory:** set `middleware.memory: false` in your fork's config, or set `PROTOAGENT_DISABLE_MEMORY=1` in the environment to suppress disk writes without changing the config.
+
+**Persistence across container restarts:** mount a volume at `/sandbox/memory/`. Without a volume the directory is ephemeral and summaries are lost on container stop.
 
 ## Why LiteLLM sits between the agent and models
 

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -2,7 +2,14 @@
 
 Queries the KnowledgeStore with the last user message and adds
 top-k results to the state's `context` field.
+
+Also loads prior session summaries from disk and injects them as a
+<prior_sessions> block at the start of each session's context.
 """
+
+import json
+import logging
+import os
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import HumanMessage
@@ -10,41 +17,177 @@ from langchain_core.messages import HumanMessage
 from langgraph.prebuilt.chat_agent_executor import AgentState
 
 
+log = logging.getLogger(__name__)
+
+
 class KnowledgeMiddleware(AgentMiddleware):
-    """Inject knowledge store context before each LLM call."""
+    """Inject knowledge store context before each LLM call.
+
+    Also loads prior session summaries from /sandbox/memory/ and injects
+    them as a <prior_sessions> block so the agent has continuity across
+    sessions without requiring an active knowledge store.
+    """
 
     def __init__(self, knowledge_store, top_k: int = 5):
         super().__init__()
         self._store = knowledge_store
         self._top_k = top_k
+        # Lazily loaded on first before_model call; None = not yet loaded
+        self._prior_sessions_cache: str | None = None
+
+    # ---------------------------------------------------------------------------
+    # Session memory loading
+    # ---------------------------------------------------------------------------
+
+    def load_memory(
+        self,
+        memory_path: str = "/sandbox/memory/",
+        max_sessions: int = 10,
+        max_tokens: int = 2000,
+    ) -> str:
+        """Load prior session summaries and format as a <prior_sessions> block.
+
+        Reads up to *max_sessions* most recent JSON files from *memory_path*,
+        enforces *max_tokens* budget by dropping oldest sessions first, and
+        returns a formatted XML block ready for injection into the system
+        prompt context.
+
+        Returns an empty string when the directory is missing (first run) or
+        when no readable sessions exist.  Never raises — all errors are logged
+        and treated as empty memory.
+
+        Token counting uses the character-based approximation (chars // 4)
+        because tiktoken is not guaranteed to be installed.
+        """
+        # --- Guard: directory must exist ---
+        if not os.path.isdir(memory_path):
+            log.info(
+                "[knowledge] memory directory not found: %s — starting with empty prior_sessions",
+                memory_path,
+            )
+            return ""
+
+        # --- List JSON session files, sorted newest-first by mtime ---
+        try:
+            entries: list[tuple[float, str]] = []
+            for fname in os.listdir(memory_path):
+                if not fname.endswith(".json"):
+                    continue
+                fpath = os.path.join(memory_path, fname)
+                try:
+                    entries.append((os.path.getmtime(fpath), fpath))
+                except OSError:
+                    continue
+            entries.sort(reverse=True)  # newest first
+        except OSError as exc:
+            log.warning(
+                "[knowledge] cannot list memory directory %s: %s — treating as empty",
+                memory_path,
+                exc,
+            )
+            return ""
+
+        if not entries:
+            return "<prior_sessions/>"
+
+        # --- Parse session files (skip malformed) ---
+        summaries: list[dict] = []
+        for _, fpath in entries[:max_sessions]:
+            try:
+                with open(fpath, encoding="utf-8") as fh:
+                    data = json.load(fh)
+                summaries.append(data)
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
+                log.debug(
+                    "[knowledge] skipping malformed session file %s: %s", fpath, exc
+                )
+                continue
+
+        if not summaries:
+            return "<prior_sessions/>"
+
+        # --- Format each summary as XML ---
+        def _format_summary(s: dict) -> str:
+            ts = s.get("timestamp", "unknown")
+            sid = s.get("session_id", "unknown")
+            lines = [f'<session id="{sid}" timestamp="{ts}">']
+
+            msgs: list[dict] = s.get("messages", [])
+            if msgs:
+                lines.append("  <messages>")
+                for m in msgs:
+                    role = m.get("role", "unknown")
+                    content = (m.get("content", "") or "")[:500]
+                    lines.append(f"    <{role}>{content}</{role}>")
+                lines.append("  </messages>")
+
+            final = (s.get("final_output") or "")[:300]
+            if final:
+                lines.append(f"  <final_output>{final}</final_output>")
+
+            lines.append("</session>")
+            return "\n".join(lines)
+
+        # Token approximation — chars // 4 (no tiktoken dependency)
+        def _count_tokens(text: str) -> int:
+            return max(1, len(text) // 4)
+
+        # --- Enforce token budget: drop oldest sessions (end of list) ---
+        formatted = [_format_summary(s) for s in summaries]
+        while formatted:
+            joined = "\n".join(formatted)
+            if _count_tokens(joined) <= max_tokens:
+                break
+            formatted.pop()  # remove oldest (newest-first ordering)
+
+        if not formatted:
+            return "<prior_sessions/>"
+
+        return "<prior_sessions>\n" + "\n".join(formatted) + "\n</prior_sessions>"
+
+    # ---------------------------------------------------------------------------
+    # Middleware hooks
+    # ---------------------------------------------------------------------------
 
     def before_model(self, state, runtime) -> dict | None:
-        """Query knowledge store with last user message, inject context."""
+        """Query knowledge store with last user message, inject context.
+
+        Also prepends prior session summaries on the first call so the
+        agent has cross-session continuity from the very first LLM turn.
+        """
+        parts: list[str] = []
+
+        # Load prior sessions once per middleware instance (lazy cache)
+        if self._prior_sessions_cache is None:
+            self._prior_sessions_cache = self.load_memory()
+        if self._prior_sessions_cache:
+            parts.append(self._prior_sessions_cache)
+
         messages = state.get("messages", [])
-        if not messages:
+        if messages:
+            # Find the last human message
+            last_human: str | None = None
+            for msg in reversed(messages):
+                if isinstance(msg, HumanMessage):
+                    last_human = (
+                        msg.content
+                        if isinstance(msg.content, str)
+                        else str(msg.content)
+                    )
+                    break
+
+            if last_human:
+                results = self._store.search(last_human, k=self._top_k)
+                if results:
+                    context_parts = ["[Relevant knowledge from previous sessions:]"]
+                    for r in results:
+                        context_parts.append(f"- [{r['table']}] {r['preview']}")
+                    parts.append("\n".join(context_parts))
+
+        if not parts:
             return None
 
-        # Find the last human message
-        last_human = None
-        for msg in reversed(messages):
-            if isinstance(msg, HumanMessage):
-                last_human = msg.content if isinstance(msg.content, str) else str(msg.content)
-                break
-
-        if not last_human:
-            return None
-
-        # Search knowledge store
-        results = self._store.search(last_human, k=self._top_k)
-        if not results:
-            return None
-
-        # Format context
-        context_parts = ["[Relevant knowledge from previous sessions:]"]
-        for r in results:
-            context_parts.append(f"- [{r['table']}] {r['preview']}")
-
-        return {"context": "\n".join(context_parts)}
+        return {"context": "\n\n".join(parts)}
 
     async def abefore_model(self, state, runtime) -> dict | None:
         """Async version — same logic."""

--- a/tests/test_memory_load.py
+++ b/tests/test_memory_load.py
@@ -1,0 +1,256 @@
+"""Unit tests for KnowledgeMiddleware.load_memory().
+
+Covers:
+- Successful loading of multiple session summaries
+- Token budget enforcement (oldest sessions truncated first)
+- Missing memory directory returns empty string (not an error)
+- Malformed/unreadable session file is skipped gracefully
+- Empty memory directory returns <prior_sessions/>
+- Disabled knowledge middleware: load_memory() still works as standalone
+- Result is cached after first call (no repeated disk reads)
+- before_model injects prior_sessions block into returned context
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_middleware(knowledge_store=None):
+    """Instantiate KnowledgeMiddleware with a mock store."""
+    from graph.middleware.knowledge import KnowledgeMiddleware
+
+    store = knowledge_store or MagicMock()
+    store.search.return_value = []  # no knowledge hits by default
+    return KnowledgeMiddleware(store, top_k=5)
+
+
+def _write_session(directory: str, session_id: str, content: dict) -> str:
+    """Write a session summary JSON file and return its path."""
+    fpath = os.path.join(directory, f"{session_id}.json")
+    with open(fpath, "w", encoding="utf-8") as fh:
+        json.dump(content, fh)
+    return fpath
+
+
+def _sample_session(session_id: str = "s1", timestamp: str = "2024-01-01T00:00:00+00:00") -> dict:
+    return {
+        "session_id": session_id,
+        "trace_id": f"trace-{session_id}",
+        "messages": [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ],
+        "tool_calls": [],
+        "final_output": "Hi there!",
+        "timestamp": timestamp,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Missing directory — returns empty string, does not raise
+# ---------------------------------------------------------------------------
+
+def test_load_memory_missing_directory():
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path="/tmp/nonexistent_protoagent_memory_xyz_999/")
+    assert result == "", f"Expected empty string for missing dir, got: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Empty directory — returns <prior_sessions/>
+# ---------------------------------------------------------------------------
+
+def test_load_memory_empty_directory(tmp_path):
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+    assert result == "<prior_sessions/>", f"Expected empty tag, got: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Single valid session — appears in output
+# ---------------------------------------------------------------------------
+
+def test_load_memory_single_session(tmp_path):
+    _write_session(str(tmp_path), "sess-1", _sample_session("sess-1"))
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+
+    assert "<prior_sessions>" in result
+    assert 'id="sess-1"' in result
+    assert "Hello" in result
+    assert "Hi there!" in result
+
+
+# ---------------------------------------------------------------------------
+# 4. Multiple sessions — all appear when within budget
+# ---------------------------------------------------------------------------
+
+def test_load_memory_multiple_sessions(tmp_path):
+    for i in range(3):
+        _write_session(str(tmp_path), f"sess-{i}", _sample_session(f"sess-{i}"))
+
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+
+    assert result.count("<session") == 3
+
+
+# ---------------------------------------------------------------------------
+# 5. Token budget enforcement — oldest sessions truncated first
+# ---------------------------------------------------------------------------
+
+def test_load_memory_token_budget_drops_oldest(tmp_path):
+    # Write 5 sessions with enough per-session content to trigger budget enforcement.
+    # The formatter truncates final_output to 300 and each message to 500 chars.
+    # Per-session formatted size: ~50 (XML tag) + 500 (user) + 500 (asst) + 300 (final) + overhead
+    # ≈ 1400 chars → ~350 tokens per session.  5 sessions → ~1750 tokens.
+    # We use max_tokens=700 (budget for ~2 sessions) so budget enforcement fires.
+
+    for i in range(5):
+        session = _sample_session(f"sess-{i}", f"2024-01-0{i + 1}T00:00:00+00:00")
+        session["messages"] = [
+            {"role": "user", "content": "Q" * 500},
+            {"role": "assistant", "content": "A" * 500},
+        ]
+        session["final_output"] = "F" * 300
+        fpath = _write_session(str(tmp_path), f"sess-{i}", session)
+        # Space out mtimes so ordering is deterministic: sess-4 is newest
+        os.utime(fpath, (1000 + i, 1000 + i))
+
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path), max_sessions=5, max_tokens=700)
+
+    # Budget must be respected
+    token_count = max(1, len(result) // 4)
+    assert token_count <= 700, f"Token budget exceeded: ~{token_count} tokens"
+
+    # At least one session should survive (newest)
+    session_count = result.count("<session")
+    assert session_count >= 1, "Expected at least one session within budget"
+
+    # Fewer than 5 sessions should be present (budget enforcement dropped some)
+    assert session_count < 5, f"Expected budget enforcement to drop some sessions, got {session_count}"
+
+
+def test_load_memory_respects_max_sessions(tmp_path):
+    for i in range(15):
+        _write_session(str(tmp_path), f"sess-{i}", _sample_session(f"sess-{i}"))
+
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path), max_sessions=5, max_tokens=100_000)
+
+    assert result.count("<session") <= 5
+
+
+# ---------------------------------------------------------------------------
+# 6. Malformed session file — skipped, other sessions still loaded
+# ---------------------------------------------------------------------------
+
+def test_load_memory_skips_malformed_file(tmp_path):
+    # Write one good session
+    _write_session(str(tmp_path), "good", _sample_session("good"))
+
+    # Write a malformed JSON file
+    bad_path = os.path.join(str(tmp_path), "bad.json")
+    with open(bad_path, "w") as fh:
+        fh.write("this is not json {{{")
+
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+
+    assert "<prior_sessions>" in result
+    assert 'id="good"' in result
+    # Bad session should not appear
+    assert 'id="bad"' not in result
+
+
+# ---------------------------------------------------------------------------
+# 7. Result is cached after first load_memory call
+# ---------------------------------------------------------------------------
+
+def test_load_memory_cache_via_before_model(tmp_path):
+    _write_session(str(tmp_path), "cached-sess", _sample_session("cached-sess"))
+
+    mw = _make_middleware()
+    # Monkey-patch load_memory to count calls
+    call_count = {"n": 0}
+    original = mw.load_memory
+
+    def counting_load(**kw):
+        call_count["n"] += 1
+        return original(**kw)
+
+    mw.load_memory = counting_load
+
+    state = {"messages": []}
+
+    # Trigger before_model twice
+    mw.before_model(state, runtime=None)
+    mw.before_model(state, runtime=None)
+
+    # load_memory should only have been called once (cache hit on second call)
+    assert call_count["n"] == 1, (
+        f"load_memory called {call_count['n']} times — expected 1 (cached)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. before_model injects prior_sessions into returned context
+# ---------------------------------------------------------------------------
+
+def test_before_model_injects_prior_sessions(tmp_path):
+    _write_session(str(tmp_path), "inject-sess", _sample_session("inject-sess"))
+
+    mw = _make_middleware()
+    # Override load_memory to use tmp_path
+    mw._prior_sessions_cache = mw.load_memory(memory_path=str(tmp_path))
+
+    from langchain_core.messages import HumanMessage
+    state = {"messages": [HumanMessage(content="What did we discuss?")]}
+
+    result = mw.before_model(state, runtime=None)
+    assert result is not None
+    assert "<prior_sessions>" in result.get("context", "")
+    assert 'id="inject-sess"' in result["context"]
+
+
+# ---------------------------------------------------------------------------
+# 9. Disabled memory (no sessions) yields empty block or empty string
+# ---------------------------------------------------------------------------
+
+def test_load_memory_no_sessions_yields_empty_tag(tmp_path):
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+    # Empty dir → empty self-closing tag (not a full block)
+    assert result == "<prior_sessions/>"
+
+
+# ---------------------------------------------------------------------------
+# 10. load_memory() works as a standalone call without a knowledge store
+# ---------------------------------------------------------------------------
+
+def test_load_memory_standalone_no_knowledge_store(tmp_path):
+    """load_memory() does not touch self._store — it should work independently."""
+    _write_session(str(tmp_path), "standalone", _sample_session("standalone"))
+
+    # Pass a store that raises on any call to ensure load_memory doesn't use it
+    broken_store = MagicMock()
+    broken_store.search.side_effect = RuntimeError("store should not be called")
+
+    from graph.middleware.knowledge import KnowledgeMiddleware
+    mw = KnowledgeMiddleware(broken_store, top_k=5)
+    result = mw.load_memory(memory_path=str(tmp_path))
+
+    assert "<prior_sessions>" in result
+    assert "standalone" in result


### PR DESCRIPTION
Load prior session summaries at session start. Enable memory by default.

- KnowledgeMiddleware loads 10 most recent sessions from /sandbox/memory/
- Injected as prior_sessions block, 2K token budget
- langgraph-config.yaml: memory enabled: true by default

Recovered by Ava via REST API after GraphQL secondary-rate-limit failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session memory enabled by default: prior session summaries are loaded and injected into prompts to improve conversational context, with persistence across sessions.
  * Memory respects limits (10 most recent sessions, ~2,000-token budget) and can be disabled via config or environment variable.

* **Documentation**
  * Architecture docs updated to describe session memory behavior, storage path, limits, and disable controls.

* **Tests**
  * Added tests validating memory loading, eviction, robustness, and injection behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->