### PR TITLE
skill-v1 artifact emission from task() completion

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000500-memwrite1",
-  "startedAt": "2026-04-19T16:27:32.308Z"
+  "featureId": "feature-1776800000800-sklemit01",
+  "startedAt": "2026-04-19T17:16:55.674Z"
 }

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -55,6 +55,7 @@ def _build_task_tool(config: LangGraphConfig, all_tools: list[BaseTool]):
         description: str,
         prompt: str,
         subagent_type: str = "worker",
+        emit_skill: bool = False,
     ) -> str:
         """Delegate a task to a specialized subagent.
 
@@ -62,7 +63,16 @@ def _build_task_tool(config: LangGraphConfig, all_tools: list[BaseTool]):
             description: Short description of what this task will accomplish
             prompt: Detailed instructions for the subagent
             subagent_type: Which subagent to use (see SUBAGENT_REGISTRY)
+            emit_skill: When True and the subagent config permits it, capture
+                the workflow as a skill-v1 artifact on successful completion.
+                Defaults to False (opt-in). No artifact is emitted on failure
+                or when the subagent config has allow_skill_emission=False.
         """
+        from datetime import datetime, timezone
+
+        import tracing
+        from graph.extensions.skills import SkillV1Artifact, emit_skill_artifact
+
         sub_config = SUBAGENT_REGISTRY.get(subagent_type)
         if not sub_config:
             return f"Error: Unknown subagent '{subagent_type}'. Available: {available_subagents}"
@@ -89,13 +99,56 @@ def _build_task_tool(config: LangGraphConfig, all_tools: list[BaseTool]):
             )
 
             messages = result.get("messages", [])
+
+            # Extract tools actually invoked during the subagent run.
+            tools_used: list[str] = []
+            for msg in messages:
+                # AIMessage tool_calls: [{"name": ..., "args": ..., "id": ...}]
+                for tc in getattr(msg, "tool_calls", []) or []:
+                    name = tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", None)
+                    if name and name not in tools_used:
+                        tools_used.append(name)
+
+            output_text = None
             for msg in reversed(messages):
                 if hasattr(msg, "content") and msg.content:
                     content = msg.content if isinstance(msg.content, str) else str(msg.content)
                     if content and not content.startswith("Error"):
-                        return f"[{subagent_type} completed: {description}]\n\n{content}"
+                        output_text = f"[{subagent_type} completed: {description}]\n\n{content}"
+                        break
 
-            return f"[{subagent_type} completed: {description}] -- no output produced."
+            if output_text is None:
+                output_text = f"[{subagent_type} completed: {description}] -- no output produced."
+
+            # Emit skill-v1 artifact when opted in and config permits.
+            if emit_skill and sub_config.allow_skill_emission:
+                if not tools_used:
+                    import logging
+                    logging.getLogger(__name__).warning(
+                        "[skill] emit_skill=True but no tool usage metadata "
+                        "captured for subagent '%s'; skipping skill emission.",
+                        subagent_type,
+                    )
+                else:
+                    try:
+                        artifact = SkillV1Artifact(
+                            name=description,
+                            description=f"Captured workflow: {description}",
+                            prompt_template=prompt,
+                            tools_used=tools_used,
+                            created_at=datetime.now(timezone.utc),
+                            source_session_id=tracing.current_session_id(),
+                        )
+                        emit_skill_artifact(artifact)
+                    except Exception as exc:
+                        import logging
+                        logging.getLogger(__name__).error(
+                            "[skill] skill-v1 artifact construction failed: %s; "
+                            "skipping emission.",
+                            exc,
+                        )
+
+            return output_text
         except Exception as e:
             return f"Error: Subagent '{subagent_type}' failed: {e}"
 

--- a/graph/extensions/skills.py
+++ b/graph/extensions/skills.py
@@ -1,0 +1,109 @@
+"""Skill-v1 artifact schema and emission infrastructure for protoAgent.
+
+A skill-v1 artifact captures the "recipe" of a successful subagent workflow —
+which tools were used, the prompt template, and provenance metadata. These
+artifacts are emitted by task() when emit_skill=True and the subagent config
+permits it.
+
+The emitted DataPart shape follows the A2A extension pattern used by cost-v1
+and worldstate-delta-v1: a ``kind: "data"`` part with a ``mimeType`` metadata
+field that A2A consumers (e.g. Workstacean) use to route the payload to the
+matching interceptor.
+
+Emission is stored in a ContextVar so the collector (the A2A handler or any
+other runtime wrapper) can retrieve all skills emitted during a task run
+without coupling the graph package to the server package.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+SKILL_V1_MIME = "application/vnd.protolabs.skill-v1+json"
+
+# ContextVar holding skills emitted during the current async context (task run).
+# Initialised to None; callers must use get_pending_skills() and
+# emit_skill_artifact() rather than accessing this directly.
+_pending_skills: contextvars.ContextVar[list[SkillV1Artifact] | None] = (
+    contextvars.ContextVar("_pending_skills", default=None)
+)
+
+
+@dataclass
+class SkillV1Artifact:
+    """Serializable record of a subagent workflow captured as a reusable skill.
+
+    Fields
+    ------
+    name              Short human-readable label for the skill.
+    description       What the skill does, suitable for a skill registry.
+    prompt_template   The prompt that drove the subagent run.
+    tools_used        Tool names actually invoked during the run.
+    created_at        UTC timestamp of capture.
+    source_session_id Session that produced this artifact (for provenance).
+    """
+
+    name: str
+    description: str
+    prompt_template: str
+    tools_used: list[str] = field(default_factory=list)
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    source_session_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("SkillV1Artifact.name must be a non-empty string")
+        if not isinstance(self.tools_used, list):
+            raise TypeError("SkillV1Artifact.tools_used must be a list")
+        if not isinstance(self.created_at, datetime):
+            raise TypeError("SkillV1Artifact.created_at must be a datetime")
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "prompt_template": self.prompt_template,
+            "tools_used": list(self.tools_used),
+            "created_at": self.created_at.isoformat(),
+            "source_session_id": self.source_session_id,
+        }
+
+    def to_datapart(self) -> dict:
+        """Serialize as an A2A DataPart for inclusion in artifact ``parts``."""
+        return {
+            "kind": "data",
+            "data": self.to_dict(),
+            "metadata": {"mimeType": SKILL_V1_MIME},
+        }
+
+
+# ── ContextVar helpers ────────────────────────────────────────────────────────
+
+
+def get_pending_skills() -> list[SkillV1Artifact]:
+    """Return a snapshot of skills emitted in the current async context."""
+    skills = _pending_skills.get()
+    return list(skills) if skills is not None else []
+
+
+def emit_skill_artifact(artifact: SkillV1Artifact) -> None:
+    """Append *artifact* to the pending-skills list for this async context.
+
+    Creates the list on first call within a fresh context. Subsequent calls
+    append to the same list so multiple task() invocations in one session
+    accumulate correctly.
+    """
+    skills = _pending_skills.get()
+    if skills is None:
+        skills = []
+        _pending_skills.set(skills)
+    skills.append(artifact)
+    log.debug("[skill] emitted skill artifact: %s", artifact.name)

--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -34,6 +34,11 @@ class SubagentConfig:
     tools: list[str] = field(default_factory=list)
     disallowed_tools: list[str] = field(default_factory=lambda: ["task"])
     max_turns: int = 30
+    # When False, skill-v1 artifact emission is suppressed even if the caller
+    # passes emit_skill=True to task(). Set to False for subagents whose
+    # workflows should not be captured as reusable skills (e.g. agents that
+    # handle sensitive data or that produce non-deterministic outputs).
+    allow_skill_emission: bool = True
 
 
 WORKER_CONFIG = SubagentConfig(

--- a/tests/test_skill_emission.py
+++ b/tests/test_skill_emission.py
@@ -1,0 +1,358 @@
+"""Unit tests for skill-v1 artifact emission from task() subagent completions.
+
+Covers:
+- SkillV1Artifact schema validation (required fields, types)
+- skill artifact emitted with correct schema when emit_skill=True
+- no emission when emit_skill=False
+- no emission when subagent config has allow_skill_emission=False
+- no emission when subagent raises an exception
+- DataPart serialization format
+- tool tracking metadata captured correctly
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from graph.extensions.skills import (
+    SKILL_V1_MIME,
+    SkillV1Artifact,
+    _pending_skills,
+    emit_skill_artifact,
+    get_pending_skills,
+)
+from graph.subagents.config import SubagentConfig
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_pending_skills():
+    """Reset the _pending_skills ContextVar to None before each test."""
+    _pending_skills.set(None)
+    yield
+    _pending_skills.set(None)
+
+
+# ── SkillV1Artifact schema tests ──────────────────────────────────────────────
+
+
+def test_skill_artifact_schema() -> None:
+    """SkillV1Artifact must accept all required fields and serialize correctly."""
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+    artifact = SkillV1Artifact(
+        name="web-research",
+        description="Research a topic using web search",
+        prompt_template="Search for information about {topic}",
+        tools_used=["web_search", "fetch_url"],
+        created_at=now,
+        source_session_id="sess-abc123",
+    )
+    assert artifact.name == "web-research"
+    assert artifact.description == "Research a topic using web search"
+    assert artifact.prompt_template == "Search for information about {topic}"
+    assert artifact.tools_used == ["web_search", "fetch_url"]
+    assert artifact.created_at == now
+    assert artifact.source_session_id == "sess-abc123"
+
+
+def test_skill_artifact_to_dict() -> None:
+    """to_dict() must return a JSON-compatible mapping with all fields."""
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+    artifact = SkillV1Artifact(
+        name="calc-task",
+        description="Run calculations",
+        prompt_template="Compute the result of {expr}",
+        tools_used=["calculator"],
+        created_at=now,
+        source_session_id="sess-1",
+    )
+    d = artifact.to_dict()
+    assert d["name"] == "calc-task"
+    assert d["description"] == "Run calculations"
+    assert d["prompt_template"] == "Compute the result of {expr}"
+    assert d["tools_used"] == ["calculator"]
+    assert d["created_at"] == now.isoformat()
+    assert d["source_session_id"] == "sess-1"
+
+
+def test_skill_datapart_serialization() -> None:
+    """to_datapart() must return a valid A2A DataPart with the skill-v1 MIME type."""
+    artifact = SkillV1Artifact(
+        name="dp-test",
+        description="DataPart test",
+        prompt_template="prompt",
+        tools_used=["echo"],
+        source_session_id="s1",
+    )
+    part = artifact.to_datapart()
+    assert part["kind"] == "data"
+    assert part["metadata"]["mimeType"] == SKILL_V1_MIME
+    assert part["data"]["name"] == "dp-test"
+    assert part["data"]["tools_used"] == ["echo"]
+    # created_at must be present and parseable
+    datetime.fromisoformat(part["data"]["created_at"])
+
+
+def test_skill_artifact_defaults() -> None:
+    """created_at and source_session_id have sensible defaults."""
+    before = datetime.now(timezone.utc)
+    artifact = SkillV1Artifact(
+        name="minimal",
+        description="d",
+        prompt_template="p",
+    )
+    after = datetime.now(timezone.utc)
+    assert before <= artifact.created_at <= after
+    assert artifact.source_session_id == ""
+    assert artifact.tools_used == []
+
+
+def test_skill_artifact_validation_empty_name() -> None:
+    """SkillV1Artifact must reject an empty name."""
+    with pytest.raises(ValueError, match="name"):
+        SkillV1Artifact(name="", description="d", prompt_template="p")
+
+
+def test_skill_artifact_validation_tools_not_list() -> None:
+    """SkillV1Artifact must reject a non-list tools_used."""
+    with pytest.raises(TypeError, match="tools_used"):
+        SkillV1Artifact(
+            name="x", description="d", prompt_template="p",
+            tools_used="echo",  # type: ignore[arg-type]
+        )
+
+
+# ── ContextVar emission helpers ───────────────────────────────────────────────
+
+
+def test_get_pending_skills_empty_returns_empty_list() -> None:
+    """get_pending_skills returns [] when no skills have been emitted."""
+    assert get_pending_skills() == []
+
+
+def test_emit_and_get_pending_skills() -> None:
+    """emit_skill_artifact followed by get_pending_skills returns the artifact."""
+    artifact = SkillV1Artifact(name="ctx-test", description="d", prompt_template="p")
+    emit_skill_artifact(artifact)
+    skills = get_pending_skills()
+    assert len(skills) == 1
+    assert skills[0].name == "ctx-test"
+
+
+def test_emit_multiple_skills() -> None:
+    """Multiple emit calls accumulate in order."""
+    for i in range(3):
+        emit_skill_artifact(SkillV1Artifact(
+            name=f"skill-{i}", description="d", prompt_template="p",
+        ))
+    skills = get_pending_skills()
+    assert [s.name for s in skills] == ["skill-0", "skill-1", "skill-2"]
+
+
+# ── SubagentConfig allow_skill_emission field ─────────────────────────────────
+
+
+def test_subagent_config_default_allows_skill_emission() -> None:
+    """SubagentConfig.allow_skill_emission defaults to True."""
+    cfg = SubagentConfig(
+        name="worker",
+        description="d",
+        system_prompt="s",
+    )
+    assert cfg.allow_skill_emission is True
+
+
+def test_subagent_config_can_disable_skill_emission() -> None:
+    """SubagentConfig.allow_skill_emission can be set to False."""
+    cfg = SubagentConfig(
+        name="worker",
+        description="d",
+        system_prompt="s",
+        allow_skill_emission=False,
+    )
+    assert cfg.allow_skill_emission is False
+
+
+def test_subagent_config_disallowed_tools_unaffected() -> None:
+    """Adding allow_skill_emission does not affect disallowed_tools."""
+    cfg = SubagentConfig(
+        name="worker",
+        description="d",
+        system_prompt="s",
+        disallowed_tools=["task", "rm_rf"],
+    )
+    assert cfg.disallowed_tools == ["task", "rm_rf"]
+    assert cfg.allow_skill_emission is True
+
+
+# ── task() emit_skill logic (inline simulation) ───────────────────────────────
+#
+# These tests verify the emission logic by calling the same conditional block
+# that graph/agent.py uses, without spinning up a real LangGraph agent.
+
+
+def _make_ai_message_with_tool_calls(tool_names: list[str]) -> MagicMock:
+    msg = MagicMock(spec=AIMessage)
+    msg.content = ""
+    msg.tool_calls = [{"name": n, "args": {}, "id": f"call-{n}"} for n in tool_names]
+    return msg
+
+
+def _make_ai_message_with_content(content: str) -> MagicMock:
+    msg = MagicMock(spec=AIMessage)
+    msg.content = content
+    msg.tool_calls = []
+    return msg
+
+
+def _run_emit_logic(
+    *,
+    messages: list,
+    description: str,
+    prompt: str,
+    emit_skill: bool,
+    allow_skill_emission: bool,
+    session_id: str = "sess-test",
+) -> None:
+    """Replicate the skill emission block from task() for isolated unit testing."""
+    tools_used: list[str] = []
+    for msg in messages:
+        for tc in getattr(msg, "tool_calls", []) or []:
+            name = tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", None)
+            if name and name not in tools_used:
+                tools_used.append(name)
+
+    if emit_skill and allow_skill_emission:
+        if not tools_used:
+            logging.getLogger(__name__).warning(
+                "[skill] emit_skill=True but no tool usage metadata captured; "
+                "skipping skill emission.",
+            )
+        else:
+            artifact = SkillV1Artifact(
+                name=description,
+                description=f"Captured workflow: {description}",
+                prompt_template=prompt,
+                tools_used=tools_used,
+                created_at=datetime.now(timezone.utc),
+                source_session_id=session_id,
+            )
+            emit_skill_artifact(artifact)
+
+
+def test_skill_emitted_when_emit_skill_true() -> None:
+    """Skill artifact is emitted when emit_skill=True and subagent succeeds."""
+    msgs = [
+        _make_ai_message_with_tool_calls(["echo"]),
+        _make_ai_message_with_content("done"),
+    ]
+    _run_emit_logic(
+        messages=msgs,
+        description="my-task",
+        prompt="do the thing",
+        emit_skill=True,
+        allow_skill_emission=True,
+    )
+    skills = get_pending_skills()
+    assert len(skills) == 1
+    skill = skills[0]
+    assert skill.name == "my-task"
+    assert skill.tools_used == ["echo"]
+    assert skill.prompt_template == "do the thing"
+    assert "Captured workflow" in skill.description
+
+
+def test_no_emission_on_opt_out() -> None:
+    """No skill artifact is emitted when emit_skill=False."""
+    msgs = [
+        _make_ai_message_with_tool_calls(["echo"]),
+        _make_ai_message_with_content("done"),
+    ]
+    _run_emit_logic(
+        messages=msgs,
+        description="my-task",
+        prompt="do the thing",
+        emit_skill=False,
+        allow_skill_emission=True,
+    )
+    assert get_pending_skills() == []
+
+
+def test_no_emission_on_failure() -> None:
+    """No skill artifact is emitted when the exception path is taken (no emission call)."""
+    # The failure path in task() does not reach the emission block at all —
+    # verify by calling _run_emit_logic with emit_skill=True but no messages
+    # (simulating the state after an exception: messages list is empty and
+    # the outer except would have returned before reaching emission).
+    #
+    # This test focuses on: even if someone mistakenly called the emit block
+    # with empty messages + no tools, no artifact is written.
+    _run_emit_logic(
+        messages=[],
+        description="failed-task",
+        prompt="do the thing",
+        emit_skill=True,
+        allow_skill_emission=True,
+    )
+    assert get_pending_skills() == []
+
+
+def test_no_emission_when_config_disallows() -> None:
+    """No skill artifact is emitted when allow_skill_emission=False."""
+    msgs = [
+        _make_ai_message_with_tool_calls(["echo"]),
+        _make_ai_message_with_content("done"),
+    ]
+    _run_emit_logic(
+        messages=msgs,
+        description="my-task",
+        prompt="do the thing",
+        emit_skill=True,
+        allow_skill_emission=False,
+    )
+    assert get_pending_skills() == []
+
+
+def test_tool_tracking_metadata_captured() -> None:
+    """tools_used in the artifact lists all tools invoked, deduplicated."""
+    msgs = [
+        _make_ai_message_with_tool_calls(["echo", "calculator"]),
+        _make_ai_message_with_tool_calls(["echo"]),  # duplicate — should appear once
+        _make_ai_message_with_content("result"),
+    ]
+    _run_emit_logic(
+        messages=msgs,
+        description="dedup-test",
+        prompt="compute",
+        emit_skill=True,
+        allow_skill_emission=True,
+    )
+    skills = get_pending_skills()
+    assert len(skills) == 1
+    assert skills[0].tools_used.count("echo") == 1
+    assert "calculator" in skills[0].tools_used
+
+
+def test_no_emission_when_no_tool_usage(caplog) -> None:
+    """When emit_skill=True but no tools were used, a warning is logged."""
+    content_msg = _make_ai_message_with_content("plain response")
+    content_msg.tool_calls = []
+
+    with caplog.at_level(logging.WARNING):
+        _run_emit_logic(
+            messages=[content_msg],
+            description="no-tools-task",
+            prompt="just answer",
+            emit_skill=True,
+            allow_skill_emission=True,
+        )
+
+    assert get_pending_skills() == []
+    assert any("no tool usage metadata" in r.message for r in caplog.records)


### PR DESCRIPTION
## Summary

Emit a `skill-v1` artifact from `task()` subagent completions when the subagent opts in.

## Problem
protoAgent's `task()` tool delegates to subagents and returns their output — but the 'recipe' of what worked (which tools, in which order, with which prompts) is discarded. Hermes captures these as skills.

## Approach
- Define `skill-v1` artifact in `graph/extensions/skills.py`: name, description, prompt_template, tools_used, created_at, source_session_id
- `task()` tool in `graph/agent.py` gain...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tasks now support optional skill artifact emission for capturing reusable skills
  * Enable skill generation on successful task completion via new parameter
  * Subagent-level configuration option to control skill emission behavior

<!-- end of auto-generated comment: release notes by coderabbit.ai -->