### PR TITLE
Skill index + retrieval injection

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000800-sklemit01",
-  "startedAt": "2026-04-19T17:16:55.674Z"
+  "featureId": "feature-1776800000900-sklindex2",
+  "startedAt": "2026-04-19T17:24:36.858Z"
 }

--- a/config/langgraph-config.yaml
+++ b/config/langgraph-config.yaml
@@ -37,3 +37,10 @@ knowledge:
   db_path: /sandbox/knowledge/agent.db
   embed_model: nomic-embed-text
   top_k: 5
+
+skills:
+  # Path to the SQLite database used for skill-v1 artifact indexing and
+  # retrieval.  Created automatically on first run; no-op until skills
+  # are actually emitted.
+  db_path: /sandbox/skills.db
+  top_k: 5

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -2,7 +2,12 @@
 
 Queries the KnowledgeStore with the last user message and adds
 top-k results to the state's `context` field.
+
+Also exposes ``load_skills(query, k)`` for retrieving top-k relevant
+skill-v1 artifacts from the SQLite skill index.
 """
+
+from __future__ import annotations
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import HumanMessage
@@ -13,10 +18,12 @@ from langgraph.prebuilt.chat_agent_executor import AgentState
 class KnowledgeMiddleware(AgentMiddleware):
     """Inject knowledge store context before each LLM call."""
 
-    def __init__(self, knowledge_store, top_k: int = 5):
+    def __init__(self, knowledge_store, top_k: int = 5, skill_index=None):
         super().__init__()
         self._store = knowledge_store
         self._top_k = top_k
+        # Optional SkillIndex for load_skills() retrieval.
+        self._skill_index = skill_index
 
     def before_model(self, state, runtime) -> dict | None:
         """Query knowledge store with last user message, inject context."""
@@ -49,3 +56,34 @@ class KnowledgeMiddleware(AgentMiddleware):
     async def abefore_model(self, state, runtime) -> dict | None:
         """Async version — same logic."""
         return self.before_model(state, runtime)
+
+    # ------------------------------------------------------------------
+    # Skill retrieval
+    # ------------------------------------------------------------------
+
+    def load_skills(self, query: str, k: int = 5) -> list[dict]:
+        """Return up to *k* skill-v1 artifacts ranked by relevance to *query*.
+
+        Searches the skill index (SQLite FTS5 or LIKE fallback) using the
+        provided query string — typically the current user message combined
+        with recent conversation context (last ~2 K chars).
+
+        Parameters
+        ----------
+        query:
+            Free-text search string.
+        k:
+            Maximum number of results to return (default 5).
+
+        Returns
+        -------
+        list[dict]
+            Each dict contains: ``id``, ``name``, ``description``,
+            ``prompt_template``, ``tools_used``, ``created_at``,
+            ``source_session_id``, ``score``.
+            Returns an empty list when no skill index is configured or
+            when the index contains no relevant results.
+        """
+        if self._skill_index is None:
+            return []
+        return self._skill_index.search(query, k=k)

--- a/graph/skills/__init__.py
+++ b/graph/skills/__init__.py
@@ -1,0 +1,5 @@
+"""graph.skills — SQLite-backed skill index for protoAgent."""
+
+from graph.skills.index import SkillIndex
+
+__all__ = ["SkillIndex"]

--- a/graph/skills/index.py
+++ b/graph/skills/index.py
@@ -1,0 +1,322 @@
+"""SkillIndex — SQLite-backed full-text search index for skill-v1 artifacts.
+
+Falls back to LIKE-based pattern matching with word tokenization and relevance
+scoring when SQLite FTS5 is not available (deviation rule: SQLite FTS5
+unavailable).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_CREATE_SKILLS_TABLE = """
+CREATE TABLE IF NOT EXISTS skills (
+    id                INTEGER PRIMARY KEY AUTOINCREMENT,
+    name              TEXT NOT NULL,
+    description       TEXT NOT NULL DEFAULT '',
+    prompt_template   TEXT NOT NULL DEFAULT '',
+    tools_used        TEXT NOT NULL DEFAULT '[]',
+    created_at        TEXT NOT NULL DEFAULT '',
+    source_session_id TEXT NOT NULL DEFAULT ''
+);
+"""
+
+_CREATE_SKILLS_FTS = """
+CREATE VIRTUAL TABLE IF NOT EXISTS skills_fts
+USING fts5(
+    name,
+    description,
+    prompt_template,
+    content=skills,
+    content_rowid=id
+);
+"""
+
+# Triggers to keep the FTS index in sync with the skills table.
+# Split into individual statements so they can be executed one at a time.
+_FTS_TRIGGERS = [
+    """CREATE TRIGGER IF NOT EXISTS skills_ai AFTER INSERT ON skills BEGIN
+        INSERT INTO skills_fts(rowid, name, description, prompt_template)
+        VALUES (new.id, new.name, new.description, new.prompt_template);
+    END""",
+    """CREATE TRIGGER IF NOT EXISTS skills_ad AFTER DELETE ON skills BEGIN
+        INSERT INTO skills_fts(skills_fts, rowid, name, description, prompt_template)
+        VALUES ('delete', old.id, old.name, old.description, old.prompt_template);
+    END""",
+    """CREATE TRIGGER IF NOT EXISTS skills_au AFTER UPDATE ON skills BEGIN
+        INSERT INTO skills_fts(skills_fts, rowid, name, description, prompt_template)
+        VALUES ('delete', old.id, old.name, old.description, old.prompt_template);
+        INSERT INTO skills_fts(rowid, name, description, prompt_template)
+        VALUES (new.id, new.name, new.description, new.prompt_template);
+    END""",
+]
+
+
+def _fts5_available() -> bool:
+    """Return True if the SQLite build includes the FTS5 extension.
+
+    Uses an in-memory database to avoid corrupting the real DB if FTS5
+    is absent and the CREATE VIRTUAL TABLE statement raises.
+    """
+    try:
+        conn = sqlite3.connect(":memory:")
+        conn.execute("CREATE VIRTUAL TABLE _probe USING fts5(x)")
+        conn.close()
+        return True
+    except sqlite3.OperationalError:
+        return False
+
+
+class SkillIndex:
+    """SQLite-backed index for skill-v1 artifacts.
+
+    Provides full-text search via FTS5 when available; falls back to
+    LIKE-based word matching with relevance scoring otherwise.
+
+    Parameters
+    ----------
+    db_path:
+        Path to the SQLite database file.  The parent directory is
+        created automatically if it does not exist.
+    """
+
+    def __init__(self, db_path: str = "/sandbox/skills.db") -> None:
+        self._db_path = db_path
+        self._use_fts5: bool = False
+        self._init_db()
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_conn(self) -> sqlite3.Connection:
+        conn = sqlite3.connect(self._db_path)
+        conn.row_factory = sqlite3.Row
+        return conn
+
+    def _init_db(self) -> None:
+        """Create the database directory and apply the schema."""
+        Path(self._db_path).parent.mkdir(parents=True, exist_ok=True)
+
+        conn = self._get_conn()
+        try:
+            # Create the base table first (outside of FTS5 check so it
+            # is always available even on FTS5-less builds).
+            conn.execute(_CREATE_SKILLS_TABLE)
+            conn.execute(
+                "CREATE INDEX IF NOT EXISTS idx_skills_name ON skills(name)"
+            )
+            conn.commit()
+
+            if _fts5_available():
+                # Track whether the FTS virtual table is new so we can
+                # back-fill existing rows on migration.
+                existing_fts = conn.execute(
+                    "SELECT count(*) FROM sqlite_master "
+                    "WHERE type='table' AND name='skills_fts'"
+                ).fetchone()[0]
+
+                conn.execute(_CREATE_SKILLS_FTS)
+                for trigger_sql in _FTS_TRIGGERS:
+                    conn.execute(trigger_sql)
+
+                if not existing_fts:
+                    # Back-fill any rows inserted before FTS was set up.
+                    conn.execute(
+                        "INSERT INTO skills_fts(rowid, name, description, prompt_template) "
+                        "SELECT id, name, description, prompt_template FROM skills"
+                    )
+
+                conn.commit()
+                self._use_fts5 = True
+                log.debug("[skill-index] FTS5 enabled at %s", self._db_path)
+            else:
+                log.warning(
+                    "[skill-index] FTS5 unavailable — falling back to LIKE search at %s",
+                    self._db_path,
+                )
+                self._use_fts5 = False
+        finally:
+            conn.close()
+
+    def _row_to_dict(self, row: sqlite3.Row) -> dict:
+        tools_used: list = []
+        try:
+            tools_used = json.loads(row["tools_used"])
+        except (json.JSONDecodeError, TypeError):
+            pass
+
+        keys = row.keys()
+        score = float(row["score"]) if "score" in keys else 0.0
+
+        return {
+            "id": row["id"],
+            "name": row["name"],
+            "description": row["description"],
+            "prompt_template": row["prompt_template"],
+            "tools_used": tools_used,
+            "created_at": row["created_at"],
+            "source_session_id": row["source_session_id"],
+            "score": score,
+        }
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    def index_skill(self, artifact) -> int:
+        """Insert a SkillV1Artifact into the index.
+
+        Parameters
+        ----------
+        artifact:
+            Any object with the same fields as SkillV1Artifact (duck-typed).
+
+        Returns
+        -------
+        int
+            The ``id`` of the newly inserted row.
+        """
+        conn = self._get_conn()
+        try:
+            cur = conn.execute(
+                """INSERT INTO skills
+                       (name, description, prompt_template, tools_used,
+                        created_at, source_session_id)
+                   VALUES (?, ?, ?, ?, ?, ?)""",
+                (
+                    artifact.name,
+                    artifact.description,
+                    artifact.prompt_template,
+                    json.dumps(list(artifact.tools_used)),
+                    (
+                        artifact.created_at.isoformat()
+                        if hasattr(artifact.created_at, "isoformat")
+                        else str(artifact.created_at)
+                    ),
+                    artifact.source_session_id,
+                ),
+            )
+            conn.commit()
+            log.debug("[skill-index] indexed skill '%s' (id=%d)", artifact.name, cur.lastrowid)
+            return cur.lastrowid
+        finally:
+            conn.close()
+
+    def search(self, query: str, k: int = 5) -> list[dict]:
+        """Search the index and return up to *k* results sorted by relevance.
+
+        An empty or whitespace-only *query* falls back to the *k* most
+        recently inserted skills.
+
+        Parameters
+        ----------
+        query:
+            Free-text search string (e.g. current user message).
+        k:
+            Maximum number of results to return.
+        """
+        if not query or not query.strip():
+            return self._get_recent(k)
+
+        if self._use_fts5:
+            return self._search_fts5(query, k)
+        return self._search_like(query, k)
+
+    def count(self) -> int:
+        """Return the total number of indexed skills."""
+        conn = self._get_conn()
+        try:
+            return conn.execute("SELECT COUNT(*) FROM skills").fetchone()[0]
+        finally:
+            conn.close()
+
+    # ------------------------------------------------------------------
+    # Search backends
+    # ------------------------------------------------------------------
+
+    def _search_fts5(self, query: str, k: int) -> list[dict]:
+        """FTS5 BM25-ranked full-text search."""
+        # Strip non-alphanumeric tokens that would break FTS5 query parsing.
+        tokens = [w for w in query.split() if any(c.isalnum() for c in w)]
+        safe_query = " ".join(tokens)
+        if not safe_query:
+            return self._get_recent(k)
+
+        conn = self._get_conn()
+        try:
+            rows = conn.execute(
+                """SELECT s.id, s.name, s.description, s.prompt_template,
+                          s.tools_used, s.created_at, s.source_session_id,
+                          bm25(skills_fts) AS score
+                   FROM skills_fts
+                   JOIN skills s ON s.id = skills_fts.rowid
+                   WHERE skills_fts MATCH ?
+                   ORDER BY score
+                   LIMIT ?""",
+                (safe_query, k),
+            ).fetchall()
+            return [self._row_to_dict(r) for r in rows]
+        except sqlite3.OperationalError as exc:
+            log.warning("[skill-index] FTS5 query failed, falling back to LIKE: %s", exc)
+            self._use_fts5 = False
+            return self._search_like(query, k)
+        finally:
+            conn.close()
+
+    def _search_like(self, query: str, k: int) -> list[dict]:
+        """LIKE-based fallback with word-overlap relevance scoring."""
+        words = [w.lower() for w in query.split() if len(w) >= 2]
+        if not words:
+            return self._get_recent(k)
+
+        conn = self._get_conn()
+        try:
+            rows = conn.execute(
+                "SELECT id, name, description, prompt_template, "
+                "tools_used, created_at, source_session_id FROM skills"
+            ).fetchall()
+
+            scored: list[dict] = []
+            for row in rows:
+                score = self._relevance_score(row, words)
+                if score > 0:
+                    d = self._row_to_dict(row)
+                    d["score"] = score
+                    scored.append(d)
+
+            scored.sort(key=lambda x: x["score"], reverse=True)
+            return scored[:k]
+        finally:
+            conn.close()
+
+    def _relevance_score(self, row: sqlite3.Row, words: list[str]) -> float:
+        """Word-overlap fraction in [0, 1] for LIKE-based ranking."""
+        text = " ".join(
+            [
+                str(row["name"] or ""),
+                str(row["description"] or ""),
+                str(row["prompt_template"] or ""),
+            ]
+        ).lower()
+        matches = sum(1 for w in words if w in text)
+        return matches / len(words) if words else 0.0
+
+    def _get_recent(self, k: int) -> list[dict]:
+        """Return the *k* most recently inserted skills."""
+        conn = self._get_conn()
+        try:
+            rows = conn.execute(
+                "SELECT id, name, description, prompt_template, "
+                "tools_used, created_at, source_session_id "
+                "FROM skills ORDER BY id DESC LIMIT ?",
+                (k,),
+            ).fetchall()
+            return [self._row_to_dict(r) for r in rows]
+        finally:
+            conn.close()

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -1,0 +1,377 @@
+"""Comprehensive unit tests for graph.skills.index.SkillIndex.
+
+Covers:
+- Schema creation and table existence
+- Skill indexing and count
+- Top-k retrieval with various query types
+- Empty database state (no errors, empty list returned)
+- Token budget awareness via description length
+- Edge cases: duplicate names, special characters, very long descriptions
+- KnowledgeMiddleware.load_skills integration
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sqlite3
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+
+import pytest
+
+from graph.skills.index import SkillIndex
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+@dataclass
+class _FakeSkill:
+    """Minimal duck-typed stand-in for SkillV1Artifact used in tests."""
+
+    name: str
+    description: str = ""
+    prompt_template: str = ""
+    tools_used: list = field(default_factory=list)
+    created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
+    source_session_id: str = ""
+
+
+@pytest.fixture()
+def tmp_db(tmp_path):
+    """Return a temporary database path that is cleaned up after each test."""
+    return str(tmp_path / "test_skills.db")
+
+
+@pytest.fixture()
+def index(tmp_db):
+    """Return a fresh SkillIndex backed by a temp DB."""
+    return SkillIndex(db_path=tmp_db)
+
+
+def _make_skill(name="test-skill", description="A useful skill", prompt_template="Do X then Y", tools_used=None, session="sess-1"):
+    return _FakeSkill(
+        name=name,
+        description=description,
+        prompt_template=prompt_template,
+        tools_used=tools_used or ["echo", "calculator"],
+        source_session_id=session,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Schema creation
+# ---------------------------------------------------------------------------
+
+class TestSchemaCreation:
+    def test_db_file_created(self, tmp_db):
+        SkillIndex(db_path=tmp_db)
+        assert Path(tmp_db).exists()
+
+    def test_skills_table_exists(self, tmp_db):
+        SkillIndex(db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        tables = {r[0] for r in conn.execute("SELECT name FROM sqlite_master WHERE type='table'").fetchall()}
+        conn.close()
+        assert "skills" in tables
+
+    def test_index_on_name_column(self, tmp_db):
+        SkillIndex(db_path=tmp_db)
+        conn = sqlite3.connect(tmp_db)
+        indexes = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='skills'"
+        ).fetchall()
+        conn.close()
+        index_names = {r[0] for r in indexes}
+        assert "idx_skills_name" in index_names
+
+    def test_parent_dirs_created(self, tmp_path):
+        deep_path = str(tmp_path / "a" / "b" / "skills.db")
+        SkillIndex(db_path=deep_path)
+        assert Path(deep_path).exists()
+
+    def test_repeated_init_is_idempotent(self, tmp_db):
+        """Re-creating the index on an existing DB should not raise."""
+        idx1 = SkillIndex(db_path=tmp_db)
+        idx1.index_skill(_make_skill())
+        idx2 = SkillIndex(db_path=tmp_db)
+        assert idx2.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Indexing
+# ---------------------------------------------------------------------------
+
+class TestIndexSkill:
+    def test_count_increases_after_insert(self, index):
+        assert index.count() == 0
+        index.index_skill(_make_skill(name="skill-a"))
+        assert index.count() == 1
+        index.index_skill(_make_skill(name="skill-b"))
+        assert index.count() == 2
+
+    def test_returns_row_id(self, index):
+        row_id = index.index_skill(_make_skill())
+        assert isinstance(row_id, int)
+        assert row_id >= 1
+
+    def test_tools_used_persisted(self, tmp_db):
+        idx = SkillIndex(db_path=tmp_db)
+        tools = ["web_search", "fetch_url", "calculator"]
+        idx.index_skill(_make_skill(tools_used=tools))
+        conn = sqlite3.connect(tmp_db)
+        row = conn.execute("SELECT tools_used FROM skills LIMIT 1").fetchone()
+        conn.close()
+        assert json.loads(row[0]) == tools
+
+    def test_datetime_stored_as_iso_string(self, tmp_db):
+        idx = SkillIndex(db_path=tmp_db)
+        dt = datetime(2025, 6, 15, 12, 0, 0, tzinfo=timezone.utc)
+        skill = _make_skill()
+        skill.created_at = dt
+        idx.index_skill(skill)
+        conn = sqlite3.connect(tmp_db)
+        row = conn.execute("SELECT created_at FROM skills LIMIT 1").fetchone()
+        conn.close()
+        assert "2025-06-15" in row[0]
+
+    def test_duplicate_names_allowed(self, index):
+        index.index_skill(_make_skill(name="duplicate"))
+        index.index_skill(_make_skill(name="duplicate"))
+        assert index.count() == 2
+
+    def test_empty_tools_list(self, index):
+        """Skills with no tools should be indexed without error."""
+        index.index_skill(_make_skill(tools_used=[]))
+        assert index.count() == 1
+
+    def test_very_long_description(self, index):
+        long_desc = "word " * 2000  # ~10 K chars
+        index.index_skill(_make_skill(description=long_desc))
+        assert index.count() == 1
+
+    def test_special_characters_in_name(self, index):
+        index.index_skill(_make_skill(name="skill: (v2) [beta] & more!"))
+        assert index.count() == 1
+
+    def test_unicode_content(self, index):
+        index.index_skill(_make_skill(name="スキル", description="説明テキスト"))
+        assert index.count() == 1
+
+
+# ---------------------------------------------------------------------------
+# Search — empty database
+# ---------------------------------------------------------------------------
+
+class TestSearchEmptyDB:
+    def test_search_empty_db_returns_empty_list(self, index):
+        results = index.search("anything")
+        assert results == []
+
+    def test_search_empty_query_returns_empty_list(self, index):
+        results = index.search("")
+        assert results == []
+
+    def test_search_whitespace_query_returns_empty_list(self, index):
+        results = index.search("   ")
+        assert results == []
+
+    def test_count_on_empty_db_is_zero(self, index):
+        assert index.count() == 0
+
+
+# ---------------------------------------------------------------------------
+# Search — retrieval correctness
+# ---------------------------------------------------------------------------
+
+class TestSearchRetrieval:
+    def test_search_returns_matching_skill(self, index):
+        index.index_skill(_make_skill(name="web-scraper", description="scrapes web pages"))
+        results = index.search("web scraper")
+        assert len(results) >= 1
+        assert any(r["name"] == "web-scraper" for r in results)
+
+    def test_search_by_description_keyword(self, index):
+        index.index_skill(_make_skill(name="calc", description="arithmetic calculator tool"))
+        results = index.search("arithmetic")
+        assert any(r["name"] == "calc" for r in results)
+
+    def test_search_by_prompt_template_keyword(self, index):
+        index.index_skill(_make_skill(name="pipeline", prompt_template="run build then deploy"))
+        results = index.search("deploy")
+        assert any(r["name"] == "pipeline" for r in results)
+
+    def test_top_k_limit_respected(self, index):
+        for i in range(10):
+            index.index_skill(_make_skill(name=f"skill-{i}", description="common keyword overlap"))
+        results = index.search("common keyword", k=3)
+        assert len(results) <= 3
+
+    def test_top_k_equals_one(self, index):
+        index.index_skill(_make_skill(name="a", description="alpha result"))
+        index.index_skill(_make_skill(name="b", description="alpha beta"))
+        results = index.search("alpha", k=1)
+        assert len(results) == 1
+
+    def test_no_results_for_unrelated_query(self, index):
+        index.index_skill(_make_skill(name="unrelated", description="zzzz xyzzy qwerty"))
+        results = index.search("completely different topic here", k=5)
+        # May or may not return results depending on overlap; just verify type
+        assert isinstance(results, list)
+
+    def test_result_dict_has_required_keys(self, index):
+        index.index_skill(_make_skill())
+        results = index.search("test skill")
+        assert len(results) >= 1
+        r = results[0]
+        for key in ("id", "name", "description", "prompt_template", "tools_used", "created_at", "source_session_id", "score"):
+            assert key in r, f"Missing key: {key}"
+
+    def test_tools_used_deserialized_as_list(self, index):
+        index.index_skill(_make_skill(tools_used=["echo", "calculator"]))
+        results = index.search("test skill")
+        if results:
+            assert isinstance(results[0]["tools_used"], list)
+
+    def test_score_is_numeric(self, index):
+        index.index_skill(_make_skill())
+        results = index.search("test skill")
+        if results:
+            assert isinstance(results[0]["score"], (int, float))
+
+    def test_empty_query_returns_recent_skills(self, index):
+        for i in range(5):
+            index.index_skill(_make_skill(name=f"skill-{i}"))
+        results = index.search("", k=3)
+        # Empty query → recent skills (up to k)
+        assert len(results) <= 3
+
+    def test_recent_skill_first_on_empty_query(self, index):
+        index.index_skill(_make_skill(name="first"))
+        index.index_skill(_make_skill(name="last"))
+        results = index.search("", k=1)
+        assert results[0]["name"] == "last"
+
+    def test_more_relevant_skill_ranked_higher(self, index):
+        """A skill whose name+description matches more query words ranks higher."""
+        index.index_skill(_make_skill(
+            name="web search workflow",
+            description="fetches pages, parses HTML, extracts links",
+        ))
+        index.index_skill(_make_skill(
+            name="calculator",
+            description="does arithmetic",
+        ))
+        results = index.search("web search html pages", k=5)
+        if len(results) >= 2:
+            names = [r["name"] for r in results]
+            assert names.index("web search workflow") < names.index("calculator")
+
+    def test_multiple_inserts_all_searchable(self, index):
+        skills = [
+            _make_skill(name="alpha-skill", description="alpha content"),
+            _make_skill(name="beta-skill", description="beta content"),
+            _make_skill(name="gamma-skill", description="gamma content"),
+        ]
+        for s in skills:
+            index.index_skill(s)
+        results = index.search("alpha content")
+        assert any(r["name"] == "alpha-skill" for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+class TestEdgeCases:
+    def test_query_with_only_special_chars(self, index):
+        index.index_skill(_make_skill())
+        # Should not raise; may return empty or recent
+        results = index.search("!!! ??? --- ~~~")
+        assert isinstance(results, list)
+
+    def test_very_long_query(self, index):
+        index.index_skill(_make_skill(description="needle in a haystack"))
+        long_query = "needle " + "filler " * 500
+        results = index.search(long_query, k=5)
+        assert isinstance(results, list)
+
+    def test_k_larger_than_row_count(self, index):
+        index.index_skill(_make_skill())
+        results = index.search("test", k=100)
+        assert len(results) <= 1
+
+    def test_k_zero_returns_empty(self, index):
+        index.index_skill(_make_skill())
+        results = index.search("test", k=0)
+        assert results == []
+
+    def test_source_session_id_persisted(self, index):
+        index.index_skill(_make_skill(session="session-xyz"))
+        results = index.search("test skill", k=5)
+        if results:
+            assert results[0]["source_session_id"] == "session-xyz"
+
+    def test_empty_prompt_template(self, index):
+        index.index_skill(_make_skill(prompt_template=""))
+        assert index.count() == 1
+
+    def test_newlines_in_prompt_template(self, index):
+        multiline = "Step 1: do this\nStep 2: do that\nStep 3: finish"
+        index.index_skill(_make_skill(prompt_template=multiline))
+        results = index.search("step finish")
+        assert isinstance(results, list)
+
+
+# ---------------------------------------------------------------------------
+# KnowledgeMiddleware.load_skills integration
+# ---------------------------------------------------------------------------
+
+class TestKnowledgeMiddlewareLoadSkills:
+    """Tests that KnowledgeMiddleware.load_skills delegates to SkillIndex."""
+
+    def _make_middleware(self, skill_index=None):
+        from unittest.mock import MagicMock
+        from graph.middleware.knowledge import KnowledgeMiddleware
+
+        knowledge_store = MagicMock()
+        knowledge_store.search.return_value = []
+        return KnowledgeMiddleware(knowledge_store, skill_index=skill_index)
+
+    def test_load_skills_no_index_returns_empty(self):
+        mw = self._make_middleware(skill_index=None)
+        assert mw.load_skills("any query") == []
+
+    def test_load_skills_with_index_returns_results(self, index):
+        index.index_skill(_make_skill(name="my-workflow", description="runs tests automatically"))
+        mw = self._make_middleware(skill_index=index)
+        results = mw.load_skills("run tests", k=5)
+        assert any(r["name"] == "my-workflow" for r in results)
+
+    def test_load_skills_respects_k_param(self, index):
+        for i in range(10):
+            index.index_skill(_make_skill(name=f"sk-{i}", description="generic skill"))
+        mw = self._make_middleware(skill_index=index)
+        results = mw.load_skills("generic skill", k=3)
+        assert len(results) <= 3
+
+    def test_load_skills_empty_query_returns_recent(self, index):
+        index.index_skill(_make_skill(name="recent-skill"))
+        mw = self._make_middleware(skill_index=index)
+        results = mw.load_skills("", k=5)
+        assert any(r["name"] == "recent-skill" for r in results)
+
+    def test_load_skills_empty_db_returns_empty(self, index):
+        mw = self._make_middleware(skill_index=index)
+        assert mw.load_skills("any query") == []
+
+    def test_load_skills_default_k_is_five(self, index):
+        for i in range(10):
+            index.index_skill(_make_skill(name=f"sk-{i}", description="common skill keyword"))
+        mw = self._make_middleware(skill_index=index)
+        results = mw.load_skills("common skill keyword")
+        assert len(results) <= 5


### PR DESCRIPTION
## Summary

Index emitted skills in SQLite and inject top-k relevant skills into the system prompt.

## Problem
Emitting skills to artifacts isn't useful until the agent can find and reuse them.

## Approach
- `graph/skills/index.py` — SQLite store at `/sandbox/skills.db` with fts5 over `name + description + prompt_template`
- `KnowledgeMiddleware.load_skills(query)` — top-k retrieval (default k=5, configurable)
- Query = current user message + recent context (last 2K chars)
- Injected as `<learned_skills>`...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a skill indexing and search system with full-text search capabilities.
  * Skills can be indexed and retrieved with ranking based on relevance.
  * Supports configurable limits and filtering for skill retrieval results.

* **Tests**
  * Added comprehensive test suite covering skill indexing and search functionality.

* **Chores**
  * Updated configuration with new skill storage settings and defaults.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->