### PR TITLE
Skill curator + docs tutorial

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000600-memload22",
-  "startedAt": "2026-04-19T16:59:59.859Z"
+  "featureId": "feature-1776800001000-sklcurat3",
+  "startedAt": "2026-04-19T18:32:20.627Z"
 }

--- a/README.md
+++ b/README.md
@@ -151,6 +151,37 @@ the repo check in all three files when forking.
   (see `config/langgraph-config.yaml`)
 - Optional: Langfuse, Prometheus, Discord webhook
 
+## Skill loop — agents that learn from experience
+
+protoAgent includes an end-to-end **skill loop** where successful subagent
+workflows are captured as reusable skills, retrieved automatically on future
+tasks, and periodically optimised by the skill curator.
+
+| Component | Where it lives | What it does |
+|---|---|---|
+| Skill emission | `graph/extensions/skills.py` | Captures `task()` results as `SkillV1Artifact` when `emit_skill=True` |
+| Skill index | `/sandbox/skills/index.jsonl` | JSONL store of accumulated skill recipes |
+| Knowledge injection | `graph/middleware/knowledge.py` | Queries index before each LLM call, injects top-k matching skills as context |
+| Skill curator | `graph/skills/curator.py` | Periodic agent that deduplicates, decays, and prunes the skill index |
+
+### Running the curator
+
+```bash
+# Dry-run — see what would change without touching the index
+python -m graph.skills.curator --dry-run
+
+# Full curation pass (reads index.jsonl, writes audit.jsonl)
+python -m graph.skills.curator
+```
+
+The curator applies a **90-day confidence half-life** (confidence halves for
+every 90 days a skill goes unused), clusters near-duplicate skills by
+similarity and keeps the highest-confidence copy, and prunes any skill whose
+confidence has fallen below 0.2.
+
+See [docs/tutorials/skill-loop.md](./docs/tutorials/skill-loop.md) for a
+complete end-to-end example and cron setup.
+
 ## Contributing
 
 This is a template repo — bugs and improvements to the shared

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -156,6 +156,23 @@ your fork. A useful pattern:
 - Extend `tests/test_a2a_integration.py` with assertions for
   your declared skills + extensions on the agent card
 
+## 9a. Understand the skill loop
+
+protoAgent's skill loop lets your agent learn from experience automatically.
+After forking, review the skill loop lifecycle:
+
+1. **Emission** — subagents configured with `allow_skill_emission=True` capture
+   successful `task()` runs as `SkillV1Artifact` objects stored in the skill
+   index (`/sandbox/skills/index.jsonl`).
+2. **Retrieval** — `KnowledgeMiddleware` injects the top-k most relevant skills
+   before each LLM call, so the agent reuses proven workflows.
+3. **Curation** — run `python -m graph.skills.curator` periodically (or via
+   cron) to deduplicate near-identical skills, apply the 90-day confidence
+   half-life decay, and prune stale entries below confidence 0.2.
+
+See [docs/tutorials/skill-loop.md](./docs/tutorials/skill-loop.md) for a
+complete end-to-end example with cron setup and audit log inspection.
+
 ## 10. Delete this file
 
 Once you've worked through the checklist, delete `TEMPLATE.md`.

--- a/docs/tutorials/skill-loop.md
+++ b/docs/tutorials/skill-loop.md
@@ -1,0 +1,212 @@
+# Your agent learns from experience
+
+protoAgent includes a **skill loop** — an end-to-end feedback cycle where your agent
+captures successful workflows as reusable skills, retrieves them on future tasks, and
+periodically curates them to keep the index high-quality.
+
+This tutorial walks through the full example: a skill is born, the agent reuses it, and
+the curator automatically optimises the index over time.
+
+---
+
+## What is a skill?
+
+A **skill-v1 artifact** is a structured record of a successful subagent run:
+
+```json
+{
+  "id": "a1b2c3d4-...",
+  "name": "web research summary",
+  "description": "Searches DuckDuckGo, fetches top results, and returns a structured summary.",
+  "prompt_template": "Research the following topic and return a structured summary: {topic}",
+  "tools_used": ["web_search", "fetch_url"],
+  "confidence": 0.95,
+  "created_at": "2025-03-01T10:00:00+00:00",
+  "last_used": "2025-04-10T14:30:00+00:00"
+}
+```
+
+Skills are emitted as A2A `DataPart` objects (MIME type
+`application/vnd.protolabs.skill-v1+json`) and accumulated in the
+skill index at `/sandbox/skills/index.jsonl`.
+
+---
+
+## Step 1 — Emit a skill from a subagent run
+
+Call `task()` with `emit_skill=True` in your subagent configuration to capture the
+workflow as a reusable recipe:
+
+```python
+# graph/subagents/config.py
+from graph.subagents.config import SubagentConfig
+
+RESEARCH_WORKER = SubagentConfig(
+    name="research_worker",
+    description="Searches and summarises information from the web.",
+    system_prompt="You are a research assistant. Use web_search and fetch_url to gather information.",
+    tools=["web_search", "fetch_url"],
+    max_turns=10,
+    allow_skill_emission=True,   # ← enables skill capture on success
+)
+```
+
+When the worker completes successfully the runtime calls `emit_skill_artifact()` which
+stores a `SkillV1Artifact` in the async context.  The A2A handler collects it and writes
+it to the skill index.
+
+---
+
+## Step 2 — Agent retrieves relevant skills at runtime
+
+`KnowledgeMiddleware` queries the skill index before each LLM call and injects the
+top-k matching skills as context:
+
+```
+[Relevant knowledge from previous sessions:]
+- [skills] web research summary — searches DuckDuckGo and fetches top results
+- [skills] calculator — evaluates arithmetic expressions safely
+```
+
+The agent uses these injected skills to choose the best subagent or to reuse an
+existing prompt template rather than generating one from scratch.  This means each
+successful run makes the next run faster and more accurate.
+
+---
+
+## Step 3 — Understand the end-to-end skill loop
+
+Here is the complete feedback cycle in one diagram:
+
+```
+┌──────────────┐   emit_skill=True   ┌──────────────────┐
+│  task()      │ ──────────────────▶ │  SkillV1Artifact │
+│  (subagent)  │                     │  (emitted as     │
+│              │                     │   A2A DataPart)  │
+└──────────────┘                     └────────┬─────────┘
+                                              │ written to
+                                              ▼
+                                     ┌──────────────────┐
+                                     │  skill index     │
+                                     │  (index.jsonl)   │
+                                     └────────┬─────────┘
+                                              │ queried by
+                                              ▼
+                                     ┌──────────────────┐
+                                     │ KnowledgeMiddle- │
+                                     │ ware injects     │
+                                     │ top-k skills     │
+                                     └────────┬─────────┘
+                                              │ context for
+                                              ▼
+                                     ┌──────────────────┐
+                                     │   LLM call       │
+                                     │   (smarter each  │
+                                     │    run)          │
+                                     └──────────────────┘
+                                              │ periodically
+                                              ▼
+                                     ┌──────────────────┐
+                                     │  Skill Curator   │
+                                     │  (dedup + decay  │
+                                     │   + prune)       │
+                                     └──────────────────┘
+```
+
+---
+
+## Step 4 — Run the skill curator
+
+The curator keeps the index lean and high-quality by running three passes:
+
+| Pass | What it does |
+|---|---|
+| **Confidence decay** | Halves confidence every 90 days of inactivity — stale skills sink to the bottom |
+| **Deduplication** | Clusters similar skills by Jaccard similarity; keeps the highest-confidence copy |
+| **Pruning** | Removes skills whose confidence has fallen below 0.2 |
+
+Run the curator manually:
+
+```bash
+# Dry-run — compute changes but write nothing
+python -m graph.skills.curator --dry-run
+
+# Full run with defaults (/sandbox/skills/index.jsonl → audit.jsonl)
+python -m graph.skills.curator
+
+# Custom paths and thresholds
+python -m graph.skills.curator \
+    --index /sandbox/skills/index.jsonl \
+    --audit /sandbox/audit/curator.jsonl \
+    --prune-threshold 0.15 \
+    --half-life 60
+```
+
+See all options:
+
+```bash
+python -m graph.skills.curator --help
+```
+
+### Schedule with cron
+
+Add the curator to cron so it runs automatically:
+
+```cron
+# Run skill curator every Sunday at 02:00
+0 2 * * 0  cd /opt/protoagent && python -m graph.skills.curator >> /var/log/curator.log 2>&1
+```
+
+---
+
+## Step 5 — Inspect the audit log
+
+After each run the curator appends a structured JSON entry to `audit.jsonl`:
+
+```bash
+# Pretty-print the latest audit entry
+tail -1 audit.jsonl | python -m json.tool
+```
+
+Example output:
+
+```json
+{
+  "run_id": "c7a3f1b2-...",
+  "timestamp": "2025-04-14T02:00:01.123456+00:00",
+  "dry_run": false,
+  "skills_before": 47,
+  "skills_after": 41,
+  "decay_applied": [
+    {"id": "a1b2...", "days_idle": 91.3, "old": 0.95, "new": 0.474}
+  ],
+  "deduplicated": [
+    {"kept": "b3c4...", "removed": ["d5e6...", "f7a8..."]}
+  ],
+  "pruned": [
+    {"id": "9abc...", "name": "outdated search recipe", "confidence": 0.18}
+  ]
+}
+```
+
+---
+
+## What happens to pruned skills?
+
+Pruned skills are removed from the active index but recorded in `audit.jsonl`.  If you
+need to recover a pruned skill, grep the audit log for its `id` or `name`:
+
+```bash
+grep 'outdated search recipe' audit.jsonl | python -m json.tool
+```
+
+Then restore it by adding the original JSONL entry back to `index.jsonl` with a
+refreshed `last_used` timestamp and confidence reset to 1.0.
+
+---
+
+## Next steps
+
+- [Add a skill →](/guides/add-a-skill) — how to manually author skills and add them to the index
+- [Subagents →](/guides/subagents) — how to configure workers that emit skills
+- [Observability →](/guides/observability) — how to monitor curator runs via audit logs and Prometheus metrics

--- a/graph/skills/__init__.py
+++ b/graph/skills/__init__.py
@@ -1,0 +1,1 @@
+"""graph.skills — skill curation and management utilities."""

--- a/graph/skills/curator.py
+++ b/graph/skills/curator.py
@@ -1,0 +1,535 @@
+"""Periodic skill curator agent for protoAgent.
+
+Reads the skill index, clusters skills by similarity to identify duplicates,
+applies exponential confidence decay for stale skills, and prunes those with
+confidence below the configured threshold.  Writes a structured audit entry to
+audit.jsonl after each run.
+
+Usage
+-----
+    # Dry-run (no writes to index or audit):
+    python -m graph.skills.curator --dry-run
+
+    # Full run with default paths:
+    python -m graph.skills.curator
+
+    # Custom paths:
+    python -m graph.skills.curator \\
+        --index /sandbox/skills/index.jsonl \\
+        --audit /sandbox/audit/curator.jsonl
+
+Skill index format (JSONL, one JSON object per line)
+-----------------------------------------------------
+    {
+        "id": "<uuid>",
+        "name": "<short label>",
+        "description": "<what the skill does>",
+        "prompt_template": "<the prompt that drove the subagent run>",
+        "tools_used": ["tool_a", "tool_b"],
+        "confidence": 0.9,
+        "created_at": "<ISO-8601 UTC>",
+        "last_used": "<ISO-8601 UTC>"   // optional; falls back to created_at
+    }
+
+Confidence decay model
+----------------------
+Confidence decays with a 90-day half-life of inactivity:
+
+    decay_factor = 0.5 ** (days_idle / 90)
+    new_confidence = original_confidence * decay_factor
+
+Skills whose post-decay confidence falls below PRUNE_THRESHOLD (0.2) are
+removed from the index.
+
+Duplicate detection
+-------------------
+Skills are clustered using token-based Jaccard similarity on the concatenation
+of ``name + " " + description``.  When sentence-transformers is available it is
+used instead for higher-quality clustering; a warning is logged when the
+fallback is active.  Within each cluster the skill with the highest confidence
+is kept; the rest are consolidated and removed.
+
+Audit log
+---------
+Each run appends one JSON object to audit.jsonl:
+
+    {
+        "run_id": "<uuid>",
+        "timestamp": "<ISO-8601 UTC>",
+        "dry_run": false,
+        "skills_before": 42,
+        "skills_after": 38,
+        "decay_applied": [{"id": "...", "old": 0.9, "new": 0.72}],
+        "deduplicated": [{"kept": "id-a", "removed": ["id-b", "id-c"]}],
+        "pruned": [{"id": "...", "name": "...", "confidence": 0.18}]
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+HALF_LIFE_DAYS: float = 90.0
+PRUNE_THRESHOLD: float = 0.2
+SIMILARITY_THRESHOLD: float = 0.6
+DEFAULT_INDEX_PATH: str = "/sandbox/skills/index.jsonl"
+DEFAULT_AUDIT_PATH: str = "audit.jsonl"
+AUDIT_MAX_BYTES: int = 100 * 1024 * 1024  # 100 MB
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(ts: str) -> datetime:
+    """Parse an ISO-8601 string, always returning a timezone-aware datetime."""
+    dt = datetime.fromisoformat(ts)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    """Clamp *value* to [lo, hi], handling NaN / infinity."""
+    if not math.isfinite(value):
+        log.warning("[curator] confidence clamped from non-finite value %s", value)
+        return lo
+    return max(lo, min(hi, value))
+
+
+def _jaccard(text_a: str, text_b: str) -> float:
+    """Token-level Jaccard similarity between two strings."""
+    tokens_a = set(text_a.lower().split())
+    tokens_b = set(text_b.lower().split())
+    if not tokens_a and not tokens_b:
+        return 1.0
+    intersection = len(tokens_a & tokens_b)
+    union = len(tokens_a | tokens_b)
+    return intersection / union if union else 0.0
+
+
+def _skill_text(skill: dict) -> str:
+    """Canonical text used for similarity comparison."""
+    return f"{skill.get('name', '')} {skill.get('description', '')}"
+
+
+# ── Core curator ──────────────────────────────────────────────────────────────
+
+
+class SkillCurator:
+    """Reads, curates, and optionally persists a skill index.
+
+    Parameters
+    ----------
+    index_path:
+        Path to the JSONL skill index file.
+    audit_path:
+        Path to the audit JSONL file.
+    dry_run:
+        When *True* the curator computes all changes but writes nothing to disk.
+    half_life_days:
+        Confidence half-life in days (default 90).
+    prune_threshold:
+        Skills with post-decay confidence below this value are pruned (default 0.2).
+    similarity_threshold:
+        Jaccard / embedding similarity above which two skills are considered
+        duplicates (default 0.6).
+    """
+
+    def __init__(
+        self,
+        index_path: str = DEFAULT_INDEX_PATH,
+        audit_path: str = DEFAULT_AUDIT_PATH,
+        dry_run: bool = False,
+        half_life_days: float = HALF_LIFE_DAYS,
+        prune_threshold: float = PRUNE_THRESHOLD,
+        similarity_threshold: float = SIMILARITY_THRESHOLD,
+    ) -> None:
+        self.index_path = index_path
+        self.audit_path = audit_path
+        self.dry_run = dry_run
+        self.half_life_days = half_life_days
+        self.prune_threshold = prune_threshold
+        self.similarity_threshold = similarity_threshold
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def run(self) -> dict:
+        """Execute a full curation cycle.
+
+        Returns the audit entry that was (or would be) written.
+        """
+        run_id = str(uuid.uuid4())
+        started_at = _now_utc()
+        log.info("[curator] starting run %s (dry_run=%s)", run_id, self.dry_run)
+
+        skills = self._load_index()
+        skills_before = len(skills)
+
+        decay_report = self._apply_decay(skills)
+        dedup_report = self._deduplicate(skills)
+        prune_report, skills = self._prune(skills)
+
+        skills_after = len(skills)
+
+        audit_entry = {
+            "run_id": run_id,
+            "timestamp": started_at.isoformat(),
+            "dry_run": self.dry_run,
+            "skills_before": skills_before,
+            "skills_after": skills_after,
+            "decay_applied": decay_report,
+            "deduplicated": dedup_report,
+            "pruned": prune_report,
+        }
+
+        if not self.dry_run:
+            self._save_index(skills)
+            self._append_audit(audit_entry)
+
+        log.info(
+            "[curator] run %s complete — before=%d after=%d decay=%d dedup_clusters=%d pruned=%d",
+            run_id,
+            skills_before,
+            skills_after,
+            len(decay_report),
+            len(dedup_report),
+            len(prune_report),
+        )
+        return audit_entry
+
+    # ── Loading / saving ───────────────────────────────────────────────────────
+
+    def _load_index(self) -> list[dict]:
+        """Load skills from the JSONL index.  Returns [] if file is absent."""
+        if not os.path.exists(self.index_path):
+            log.info("[curator] index not found at %s — starting with empty set", self.index_path)
+            return []
+
+        skills: list[dict] = []
+        with open(self.index_path, encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    skill = json.loads(line)
+                    if not isinstance(skill, dict):
+                        raise ValueError("expected a JSON object")
+                    # Ensure required fields exist
+                    if "id" not in skill:
+                        skill["id"] = str(uuid.uuid4())
+                    if "confidence" not in skill:
+                        skill["confidence"] = 1.0
+                    skills.append(skill)
+                except (json.JSONDecodeError, ValueError) as exc:
+                    log.error(
+                        "[curator] skipping malformed entry at line %d in %s: %s",
+                        lineno,
+                        self.index_path,
+                        exc,
+                    )
+        log.info("[curator] loaded %d skills from %s", len(skills), self.index_path)
+        return skills
+
+    def _save_index(self, skills: list[dict]) -> None:
+        """Persist *skills* back to the JSONL index."""
+        os.makedirs(os.path.dirname(self.index_path) or ".", exist_ok=True)
+        with open(self.index_path, "w", encoding="utf-8") as fh:
+            for skill in skills:
+                fh.write(json.dumps(skill, default=str) + "\n")
+        log.info("[curator] saved %d skills to %s", len(skills), self.index_path)
+
+    # ── Confidence decay ───────────────────────────────────────────────────────
+
+    def _days_idle(self, skill: dict) -> float:
+        """Return the number of days since the skill was last used."""
+        now = _now_utc()
+        # Prefer last_used; fall back to created_at as proxy
+        ts_str = skill.get("last_used") or skill.get("created_at")
+        if not ts_str:
+            log.debug(
+                "[curator] skill %s has no timestamp — using 0 days idle", skill.get("id")
+            )
+            return 0.0
+        try:
+            last = _parse_iso(ts_str)
+            delta = now - last
+            return max(0.0, delta.total_seconds() / 86400.0)
+        except (ValueError, TypeError) as exc:
+            log.warning(
+                "[curator] cannot parse timestamp for skill %s: %s — treating as 0 days idle",
+                skill.get("id"),
+                exc,
+            )
+            return 0.0
+
+    def _decay_factor(self, days_idle: float) -> float:
+        """Compute the multiplicative decay factor for *days_idle* days of inactivity."""
+        return 0.5 ** (days_idle / self.half_life_days)
+
+    def _apply_decay(self, skills: list[dict]) -> list[dict]:
+        """Apply confidence decay in-place.  Returns the decay report."""
+        report: list[dict] = []
+        for skill in skills:
+            old_confidence = _clamp(float(skill.get("confidence", 1.0)))
+            days = self._days_idle(skill)
+            if days <= 0:
+                continue
+            factor = self._decay_factor(days)
+            new_confidence = _clamp(old_confidence * factor)
+            if new_confidence != old_confidence:
+                report.append(
+                    {
+                        "id": skill.get("id"),
+                        "days_idle": round(days, 1),
+                        "old": round(old_confidence, 4),
+                        "new": round(new_confidence, 4),
+                    }
+                )
+                skill["confidence"] = new_confidence
+        log.info("[curator] decay applied to %d skills", len(report))
+        return report
+
+    # ── Deduplication ──────────────────────────────────────────────────────────
+
+    def _build_similarity_matrix(
+        self, skills: list[dict]
+    ) -> list[list[float]]:
+        """Return an n×n similarity matrix using Jaccard similarity."""
+        # Try sentence-transformers first; fall back to Jaccard with a warning.
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+
+            model = SentenceTransformer("all-MiniLM-L6-v2")
+            texts = [_skill_text(s) for s in skills]
+            embeddings = model.encode(texts, normalize_embeddings=True)
+            # Cosine similarity via dot product (embeddings are normalised)
+            import numpy as np  # type: ignore
+
+            matrix = (embeddings @ embeddings.T).tolist()
+            log.debug("[curator] similarity matrix built with sentence-transformers")
+            return matrix
+        except ImportError:
+            log.warning(
+                "[curator] sentence-transformers not available — "
+                "falling back to token Jaccard similarity"
+            )
+
+        n = len(skills)
+        texts = [_skill_text(s) for s in skills]
+        matrix = [[0.0] * n for _ in range(n)]
+        for i in range(n):
+            for j in range(i, n):
+                sim = _jaccard(texts[i], texts[j])
+                matrix[i][j] = sim
+                matrix[j][i] = sim
+        return matrix
+
+    def _cluster_skills(self, skills: list[dict]) -> list[list[int]]:
+        """Return clusters (lists of indices) using greedy single-linkage."""
+        if not skills:
+            return []
+
+        matrix = self._build_similarity_matrix(skills)
+        n = len(skills)
+        assigned = [False] * n
+        clusters: list[list[int]] = []
+
+        for i in range(n):
+            if assigned[i]:
+                continue
+            cluster = [i]
+            assigned[i] = True
+            for j in range(i + 1, n):
+                if not assigned[j] and matrix[i][j] >= self.similarity_threshold:
+                    cluster.append(j)
+                    assigned[j] = True
+            clusters.append(cluster)
+
+        return clusters
+
+    def _deduplicate(self, skills: list[dict]) -> list[dict]:
+        """Remove duplicates in-place.  Returns the deduplication report.
+
+        Within each cluster the skill with the highest confidence is kept;
+        the rest are removed.  Modifies *skills* in-place.
+        """
+        if not skills:
+            return []
+
+        clusters = self._cluster_skills(skills)
+        report: list[dict] = []
+        ids_to_remove: set[str] = set()
+
+        for cluster in clusters:
+            if len(cluster) <= 1:
+                continue
+            # Pick the skill with the highest confidence as the canonical one
+            best_idx = max(cluster, key=lambda i: float(skills[i].get("confidence", 0)))
+            removed_ids = [
+                skills[i]["id"] for i in cluster if i != best_idx
+            ]
+            report.append(
+                {"kept": skills[best_idx]["id"], "removed": removed_ids}
+            )
+            ids_to_remove.update(removed_ids)
+
+        if ids_to_remove:
+            skills[:] = [s for s in skills if s.get("id") not in ids_to_remove]
+            log.info("[curator] deduplicated: removed %d skills across %d clusters", len(ids_to_remove), len(report))
+        return report
+
+    # ── Pruning ────────────────────────────────────────────────────────────────
+
+    def _prune(self, skills: list[dict]) -> tuple[list[dict], list[dict]]:
+        """Remove skills with confidence below prune_threshold.
+
+        Returns ``(prune_report, surviving_skills)``.
+        """
+        surviving: list[dict] = []
+        report: list[dict] = []
+
+        for skill in skills:
+            confidence = _clamp(float(skill.get("confidence", 1.0)))
+            if confidence < self.prune_threshold:
+                report.append(
+                    {
+                        "id": skill.get("id"),
+                        "name": skill.get("name", ""),
+                        "confidence": round(confidence, 4),
+                    }
+                )
+            else:
+                surviving.append(skill)
+
+        if report:
+            log.info("[curator] pruned %d skills below threshold %.2f", len(report), self.prune_threshold)
+        return report, surviving
+
+    # ── Audit log ─────────────────────────────────────────────────────────────
+
+    def _append_audit(self, entry: dict) -> None:
+        """Append *entry* as a JSON line to the audit file.
+
+        Archives the audit file when it exceeds AUDIT_MAX_BYTES.
+        """
+        audit_dir = os.path.dirname(self.audit_path) or "."
+        os.makedirs(audit_dir, exist_ok=True)
+
+        # Archive if over size limit
+        if os.path.exists(self.audit_path):
+            size = os.path.getsize(self.audit_path)
+            if size > AUDIT_MAX_BYTES:
+                ts = _now_utc().strftime("%Y-%m-%d")
+                archive = os.path.join(
+                    audit_dir, f"audit-{ts}.jsonl"
+                )
+                os.rename(self.audit_path, archive)
+                log.warning(
+                    "[curator] audit.jsonl exceeded 100 MB — archived to %s", archive
+                )
+
+        with open(self.audit_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, default=str) + "\n")
+        log.info("[curator] audit entry written to %s", self.audit_path)
+
+
+# ── CLI entry point ────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m graph.skills.curator",
+        description=(
+            "Periodic skill curator — deduplicates, decays confidence, and "
+            "prunes the protoAgent skill index."
+        ),
+    )
+    p.add_argument(
+        "--index",
+        default=DEFAULT_INDEX_PATH,
+        metavar="PATH",
+        help=f"Path to the JSONL skill index (default: {DEFAULT_INDEX_PATH})",
+    )
+    p.add_argument(
+        "--audit",
+        default=DEFAULT_AUDIT_PATH,
+        metavar="PATH",
+        help=f"Path to the audit JSONL file (default: {DEFAULT_AUDIT_PATH})",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute changes but do not write to disk",
+    )
+    p.add_argument(
+        "--half-life",
+        type=float,
+        default=HALF_LIFE_DAYS,
+        metavar="DAYS",
+        help=f"Confidence half-life in days (default: {HALF_LIFE_DAYS})",
+    )
+    p.add_argument(
+        "--prune-threshold",
+        type=float,
+        default=PRUNE_THRESHOLD,
+        metavar="FLOAT",
+        help=f"Prune skills below this confidence (default: {PRUNE_THRESHOLD})",
+    )
+    p.add_argument(
+        "--similarity-threshold",
+        type=float,
+        default=SIMILARITY_THRESHOLD,
+        metavar="FLOAT",
+        help=f"Jaccard similarity above which skills are duplicates (default: {SIMILARITY_THRESHOLD})",
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging verbosity (default: INFO)",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    curator = SkillCurator(
+        index_path=args.index,
+        audit_path=args.audit,
+        dry_run=args.dry_run,
+        half_life_days=args.half_life,
+        prune_threshold=args.prune_threshold,
+        similarity_threshold=args.similarity_threshold,
+    )
+    audit_entry = curator.run()
+
+    if args.dry_run:
+        print("[dry-run] audit entry that would be written:")
+        print(json.dumps(audit_entry, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_skill_curator.py
+++ b/tests/test_skill_curator.py
@@ -1,0 +1,419 @@
+"""Unit tests for graph.skills.curator.
+
+Covers:
+- Confidence decay calculations (50% after 90 days idle)
+- Deduplication via Jaccard similarity clustering
+- Pruning of low-confidence skills
+- Audit log writing
+- Full curator run on a fixture skill set
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from graph.skills.curator import (
+    HALF_LIFE_DAYS,
+    PRUNE_THRESHOLD,
+    SIMILARITY_THRESHOLD,
+    SkillCurator,
+    _clamp,
+    _jaccard,
+    _parse_iso,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _utc_iso(days_ago: float = 0) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return dt.isoformat()
+
+
+def _make_skill(
+    name: str = "test skill",
+    description: str = "does something useful",
+    confidence: float = 1.0,
+    days_ago: float = 0,
+    last_used_days_ago: float | None = None,
+    skill_id: str | None = None,
+) -> dict:
+    """Return a minimal well-formed skill dict."""
+    skill: dict = {
+        "id": skill_id or str(uuid.uuid4()),
+        "name": name,
+        "description": description,
+        "prompt_template": f"Run the {name} workflow.",
+        "tools_used": ["echo"],
+        "confidence": confidence,
+        "created_at": _utc_iso(days_ago),
+    }
+    if last_used_days_ago is not None:
+        skill["last_used"] = _utc_iso(last_used_days_ago)
+    return skill
+
+
+def _write_index(path: str, skills: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for s in skills:
+            fh.write(json.dumps(s) + "\n")
+
+
+# ── _clamp ─────────────────────────────────────────────────────────────────────
+
+
+class TestClamp:
+    def test_value_in_range(self):
+        assert _clamp(0.5) == 0.5
+
+    def test_value_below_zero(self):
+        assert _clamp(-0.1) == 0.0
+
+    def test_value_above_one(self):
+        assert _clamp(1.5) == 1.0
+
+    def test_nan_clamps_to_lo(self):
+        result = _clamp(float("nan"))
+        assert result == 0.0
+
+    def test_infinity_clamps_to_one(self):
+        result = _clamp(float("inf"))
+        assert result == 1.0
+
+    def test_negative_infinity_clamps_to_zero(self):
+        result = _clamp(float("-inf"))
+        assert result == 0.0
+
+
+# ── _jaccard ──────────────────────────────────────────────────────────────────
+
+
+class TestJaccard:
+    def test_identical_strings(self):
+        assert _jaccard("hello world", "hello world") == 1.0
+
+    def test_disjoint_strings(self):
+        assert _jaccard("foo bar", "baz qux") == 0.0
+
+    def test_partial_overlap(self):
+        # {"search", "web"} ∩ {"search", "results"} = {"search"} → 1/3
+        sim = _jaccard("web search", "search results")
+        assert abs(sim - 1 / 3) < 1e-9
+
+    def test_empty_strings(self):
+        assert _jaccard("", "") == 1.0
+
+    def test_case_insensitive(self):
+        assert _jaccard("Hello World", "hello world") == 1.0
+
+
+# ── Confidence decay ──────────────────────────────────────────────────────────
+
+
+class TestConfidenceDecay:
+    def _curator(self, **kwargs) -> SkillCurator:
+        return SkillCurator(
+            index_path="/dev/null",
+            audit_path="/dev/null",
+            dry_run=True,
+            **kwargs,
+        )
+
+    def test_no_decay_when_fresh(self):
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, days_ago=0)
+        report = curator._apply_decay([skill])
+        assert report == []
+        assert skill["confidence"] == 1.0
+
+    def test_half_life_90_days(self):
+        """After 90 days idle the confidence should halve."""
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, last_used_days_ago=90)
+        curator._apply_decay([skill])
+        assert abs(skill["confidence"] - 0.5) < 1e-6
+
+    def test_half_life_180_days(self):
+        """After 180 days idle the confidence should be ~0.25."""
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, last_used_days_ago=180)
+        curator._apply_decay([skill])
+        assert abs(skill["confidence"] - 0.25) < 1e-6
+
+    def test_partial_decay(self):
+        """After 45 days the confidence is 0.5^(45/90) = sqrt(0.5) ≈ 0.7071."""
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, last_used_days_ago=45)
+        curator._apply_decay([skill])
+        expected = 0.5 ** (45 / 90)
+        assert abs(skill["confidence"] - expected) < 1e-6
+
+    def test_decay_uses_last_used_over_created_at(self):
+        """last_used timestamp takes priority over created_at."""
+        curator = self._curator()
+        # created 180 days ago but used 10 days ago
+        skill = _make_skill(
+            confidence=1.0, days_ago=180, last_used_days_ago=10
+        )
+        curator._apply_decay([skill])
+        expected = 0.5 ** (10 / 90)
+        assert abs(skill["confidence"] - expected) < 1e-6
+
+    def test_decay_falls_back_to_created_at(self):
+        """When last_used is absent, created_at is used as proxy."""
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, days_ago=90)
+        # no last_used key
+        assert "last_used" not in skill
+        curator._apply_decay([skill])
+        assert abs(skill["confidence"] - 0.5) < 1e-6
+
+    def test_custom_half_life(self):
+        curator = self._curator(half_life_days=30)
+        skill = _make_skill(confidence=1.0, last_used_days_ago=30)
+        curator._apply_decay([skill])
+        assert abs(skill["confidence"] - 0.5) < 1e-6
+
+    def test_report_entries(self):
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, last_used_days_ago=90)
+        report = curator._apply_decay([skill])
+        assert len(report) == 1
+        entry = report[0]
+        assert entry["id"] == skill["id"]
+        assert abs(entry["old"] - 1.0) < 1e-3
+        assert abs(entry["new"] - 0.5) < 1e-3
+
+
+# ── Deduplication ─────────────────────────────────────────────────────────────
+
+
+class TestDeduplication:
+    def _curator(self, threshold: float = SIMILARITY_THRESHOLD) -> SkillCurator:
+        return SkillCurator(
+            index_path="/dev/null",
+            audit_path="/dev/null",
+            dry_run=True,
+            similarity_threshold=threshold,
+        )
+
+    def test_no_duplicates(self):
+        curator = self._curator()
+        skills = [
+            _make_skill("web search tool", "searches the web for info"),
+            _make_skill("calculator tool", "performs arithmetic operations"),
+        ]
+        report = curator._deduplicate(skills)
+        assert report == []
+        assert len(skills) == 2
+
+    def test_exact_duplicates_kept_higher_confidence(self):
+        """Two identical skills: the one with higher confidence survives."""
+        curator = self._curator(threshold=0.9)
+        id_a, id_b = str(uuid.uuid4()), str(uuid.uuid4())
+        skills = [
+            _make_skill("web search", "searches the web", confidence=0.6, skill_id=id_a),
+            _make_skill("web search", "searches the web", confidence=0.9, skill_id=id_b),
+        ]
+        report = curator._deduplicate(skills)
+        assert len(report) == 1
+        assert report[0]["kept"] == id_b
+        assert id_a in report[0]["removed"]
+        assert len(skills) == 1
+        assert skills[0]["id"] == id_b
+
+    def test_dissimilar_skills_not_merged(self):
+        curator = self._curator(threshold=0.8)
+        skills = [
+            _make_skill("web scraper", "scrapes HTML from URLs"),
+            _make_skill("database query", "runs SQL against Postgres"),
+        ]
+        report = curator._deduplicate(skills)
+        assert report == []
+        assert len(skills) == 2
+
+    def test_three_similar_skills_one_survives(self):
+        """Three very similar skills → only the highest-confidence one survives."""
+        curator = self._curator(threshold=0.5)
+        ids = [str(uuid.uuid4()) for _ in range(3)]
+        skills = [
+            _make_skill("fetch url content", "fetches and returns URL content", confidence=0.5, skill_id=ids[0]),
+            _make_skill("fetch url page", "fetches and returns URL page", confidence=0.7, skill_id=ids[1]),
+            _make_skill("fetch url data", "fetches and returns URL data", confidence=0.6, skill_id=ids[2]),
+        ]
+        report = curator._deduplicate(skills)
+        # At least one cluster with a removal
+        removed_total = sum(len(r["removed"]) for r in report)
+        assert removed_total >= 1
+        # The surviving skill(s) should all have id from the original set
+        for s in skills:
+            assert s["id"] in ids
+
+
+# ── Pruning ────────────────────────────────────────────────────────────────────
+
+
+class TestPruning:
+    def _curator(self, threshold: float = PRUNE_THRESHOLD) -> SkillCurator:
+        return SkillCurator(
+            index_path="/dev/null",
+            audit_path="/dev/null",
+            dry_run=True,
+            prune_threshold=threshold,
+        )
+
+    def test_no_pruning_above_threshold(self):
+        curator = self._curator()
+        skills = [_make_skill(confidence=0.5), _make_skill(confidence=0.9)]
+        report, surviving = curator._prune(skills)
+        assert report == []
+        assert len(surviving) == 2
+
+    def test_prune_below_threshold(self):
+        curator = self._curator()
+        low = _make_skill(confidence=0.1)
+        high = _make_skill(confidence=0.8)
+        report, surviving = curator._prune([low, high])
+        assert len(report) == 1
+        assert report[0]["id"] == low["id"]
+        assert len(surviving) == 1
+        assert surviving[0]["id"] == high["id"]
+
+    def test_prune_at_threshold_boundary(self):
+        """Confidence exactly equal to threshold is kept (not pruned)."""
+        curator = self._curator(threshold=0.2)
+        at_threshold = _make_skill(confidence=0.2)
+        report, surviving = curator._prune([at_threshold])
+        assert report == []
+        assert len(surviving) == 1
+
+    def test_prune_all(self):
+        curator = self._curator(threshold=0.5)
+        skills = [_make_skill(confidence=0.1), _make_skill(confidence=0.3)]
+        report, surviving = curator._prune(skills)
+        assert len(report) == 2
+        assert surviving == []
+
+    def test_prune_report_contains_name_and_confidence(self):
+        curator = self._curator()
+        skill = _make_skill(name="stale skill", confidence=0.05)
+        report, _ = curator._prune([skill])
+        assert report[0]["name"] == "stale skill"
+        assert "confidence" in report[0]
+
+
+# ── Full run on fixture ───────────────────────────────────────────────────────
+
+
+class TestCuratorRun:
+    def test_dry_run_does_not_write_files(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+        skills = [_make_skill(confidence=1.0, days_ago=0)]
+        _write_index(index, skills)
+
+        curator = SkillCurator(
+            index_path=index,
+            audit_path=audit,
+            dry_run=True,
+        )
+        curator.run()
+        # Audit file should NOT be created in dry_run mode
+        assert not os.path.exists(audit)
+
+    def test_full_run_writes_audit(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+        skills = [_make_skill(confidence=1.0)]
+        _write_index(index, skills)
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
+        curator.run()
+
+        assert os.path.exists(audit)
+        with open(audit) as fh:
+            entry = json.loads(fh.readline())
+        assert "run_id" in entry
+        assert entry["dry_run"] is False
+
+    def test_missing_index_produces_empty_run(self, tmp_path):
+        audit = str(tmp_path / "audit.jsonl")
+        curator = SkillCurator(
+            index_path=str(tmp_path / "nonexistent.jsonl"),
+            audit_path=audit,
+            dry_run=False,
+        )
+        entry = curator.run()
+        assert entry["skills_before"] == 0
+        assert entry["skills_after"] == 0
+
+    def test_decay_then_prune_pipeline(self, tmp_path):
+        """A skill idle for >300 days should be pruned in a full run."""
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+
+        # After 300 days: 0.5^(300/90) ≈ 0.099 < 0.2 → should be pruned
+        old_skill = _make_skill(confidence=1.0, last_used_days_ago=300)
+        fresh_skill = _make_skill(confidence=0.9, last_used_days_ago=5)
+        _write_index(index, [old_skill, fresh_skill])
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
+        entry = curator.run()
+
+        assert entry["skills_before"] == 2
+        assert entry["skills_after"] == 1
+        assert len(entry["pruned"]) == 1
+        assert entry["pruned"][0]["id"] == old_skill["id"]
+
+    def test_audit_entry_structure(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+        _write_index(index, [_make_skill()])
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
+        entry = curator.run()
+
+        required_keys = {
+            "run_id", "timestamp", "dry_run", "skills_before",
+            "skills_after", "decay_applied", "deduplicated", "pruned",
+        }
+        assert required_keys.issubset(entry.keys())
+
+    def test_malformed_index_lines_are_skipped(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+
+        with open(index, "w") as fh:
+            fh.write("not json\n")
+            fh.write(json.dumps(_make_skill()) + "\n")
+            fh.write("{incomplete\n")
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=True)
+        entry = curator.run()
+        # Only the valid skill should be loaded
+        assert entry["skills_before"] == 1
+
+    def test_index_persisted_after_run(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+
+        # Create two skills; one will be pruned (low confidence, old)
+        old_skill = _make_skill(confidence=1.0, last_used_days_ago=300)
+        fresh_skill = _make_skill(confidence=0.9, last_used_days_ago=2)
+        _write_index(index, [old_skill, fresh_skill])
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
+        curator.run()
+
+        with open(index) as fh:
+            remaining = [json.loads(l) for l in fh if l.strip()]
+        assert len(remaining) == 1
+        assert remaining[0]["id"] == fresh_skill["id"]


### PR DESCRIPTION
## Summary

Periodic curator agent that deduplicates skills, promotes high-quality ones, prunes stale ones. Ship the docs tutorial.

## Problem
Skills accumulate forever without curation — duplicates, low-quality recipes, stale domain knowledge. Hermes has a 90-day confidence half-life model worth borrowing.

## Approach
- `graph/skills/curator.py` — agent runnable triggered via cron or manual invocation (`python -m graph.skills.curator`)
- Reads skill index, clusters by embedding similarity (sentence-trans...

---
*Recovered automatically by Automaker post-agent hook*