### PR TITLE
promote: staging -> main

### DIFF
--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
   "featureId": "feature-1776800000600-memload22",
-  "startedAt": "2026-04-19T16:35:09.847Z"
+  "startedAt": "2026-04-19T16:59:59.859Z"
 }

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000200-secredact",
-  "startedAt": "2026-04-19T06:01:26.319Z"
+  "featureId": "feature-1776800000300-secorigin",
+  "startedAt": "2026-04-19T15:53:21.357Z"
 }

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000500-memwrite1",
-  "startedAt": "2026-04-19T16:27:32.308Z"
+  "featureId": "feature-1776800000800-sklemit01",
+  "startedAt": "2026-04-19T17:16:55.674Z"
 }

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,0 +1,5 @@
+{
+  "pid": 7,
+  "featureId": "feature-1776800000100-seca2atok",
+  "startedAt": "2026-04-19T05:54:55.811Z"
+}

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,0 @@
-{
-  "pid": 7,
-  "featureId": "feature-1776800000900-sklindex2",
-  "startedAt": "2026-04-19T18:05:53.199Z"
-}

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000100-seca2atok",
-  "startedAt": "2026-04-19T05:54:55.811Z"
+  "featureId": "feature-1776800000200-secredact",
+  "startedAt": "2026-04-19T06:01:26.319Z"
 }

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000800-sklemit01",
-  "startedAt": "2026-04-19T17:16:55.674Z"
+  "featureId": "feature-1776800000600-memload22",
+  "startedAt": "2026-04-19T16:35:09.847Z"
 }

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800001000-sklcurat3",
-  "startedAt": "2026-04-19T18:32:20.627Z"
+  "featureId": "feature-1776800000900-sklindex2",
+  "startedAt": "2026-04-19T18:05:53.199Z"
 }

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000300-secorigin",
-  "startedAt": "2026-04-19T15:53:21.357Z"
+  "featureId": "feature-1776800000500-memwrite1",
+  "startedAt": "2026-04-19T16:27:32.308Z"
 }

--- a/.automaker-lock
+++ b/.automaker-lock
@@ -1,5 +1,5 @@
 {
   "pid": 7,
-  "featureId": "feature-1776800000600-memload22",
-  "startedAt": "2026-04-19T16:59:59.859Z"
+  "featureId": "feature-1776800001000-sklcurat3",
+  "startedAt": "2026-04-19T18:32:20.627Z"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -12,8 +12,11 @@ build/
 *.jsonl
 
 # protoLabs Studio agent workspace (never commit)
+.automaker-lock
 .automaker/
 .claude/
+.worktrees/
+worktrees/
 
 # VitePress build artifacts + node modules
 node_modules/

--- a/README.md
+++ b/README.md
@@ -151,6 +151,37 @@ the repo check in all three files when forking.
   (see `config/langgraph-config.yaml`)
 - Optional: Langfuse, Prometheus, Discord webhook
 
+## Skill loop — agents that learn from experience
+
+protoAgent includes an end-to-end **skill loop** where successful subagent
+workflows are captured as reusable skills, retrieved automatically on future
+tasks, and periodically optimised by the skill curator.
+
+| Component | Where it lives | What it does |
+|---|---|---|
+| Skill emission | `graph/extensions/skills.py` | Captures `task()` results as `SkillV1Artifact` when `emit_skill=True` |
+| Skill index | `/sandbox/skills/index.jsonl` | JSONL store of accumulated skill recipes |
+| Knowledge injection | `graph/middleware/knowledge.py` | Queries index before each LLM call, injects top-k matching skills as context |
+| Skill curator | `graph/skills/curator.py` | Periodic agent that deduplicates, decays, and prunes the skill index |
+
+### Running the curator
+
+```bash
+# Dry-run — see what would change without touching the index
+python -m graph.skills.curator --dry-run
+
+# Full curation pass (reads index.jsonl, writes audit.jsonl)
+python -m graph.skills.curator
+```
+
+The curator applies a **90-day confidence half-life** (confidence halves for
+every 90 days a skill goes unused), clusters near-duplicate skills by
+similarity and keeps the highest-confidence copy, and prunes any skill whose
+confidence has fallen below 0.2.
+
+See [docs/tutorials/skill-loop.md](./docs/tutorials/skill-loop.md) for a
+complete end-to-end example and cron setup.
+
 ## Contributing
 
 This is a template repo — bugs and improvements to the shared

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -156,6 +156,23 @@ your fork. A useful pattern:
 - Extend `tests/test_a2a_integration.py` with assertions for
   your declared skills + extensions on the agent card
 
+## 9a. Understand the skill loop
+
+protoAgent's skill loop lets your agent learn from experience automatically.
+After forking, review the skill loop lifecycle:
+
+1. **Emission** — subagents configured with `allow_skill_emission=True` capture
+   successful `task()` runs as `SkillV1Artifact` objects stored in the skill
+   index (`/sandbox/skills/index.jsonl`).
+2. **Retrieval** — `KnowledgeMiddleware` injects the top-k most relevant skills
+   before each LLM call, so the agent reuses proven workflows.
+3. **Curation** — run `python -m graph.skills.curator` periodically (or via
+   cron) to deduplicate near-identical skills, apply the 90-day confidence
+   half-life decay, and prune stale entries below confidence 0.2.
+
+See [docs/tutorials/skill-loop.md](./docs/tutorials/skill-loop.md) for a
+complete end-to-end example with cron setup and audit log inspection.
+
 ## 10. Delete this file
 
 Once you've worked through the checklist, delete `TEMPLATE.md`.

--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -960,6 +960,31 @@ def register_a2a_routes(
         if not hmac.compare_digest(provided, _a2a_token):
             raise HTTPException(status_code=401, detail="Unauthorized: invalid bearer token")
 
+    # ── Origin verification for SSE/streaming endpoints ───────────────────────
+    _raw_allowed_origins = os.environ.get("A2A_ALLOWED_ORIGINS", "")
+    _allowed_origins_str = _raw_allowed_origins.strip()
+    if not _allowed_origins_str:
+        logger.warning(
+            "[a2a] A2A_ALLOWED_ORIGINS not set — SSE/streaming origin verification disabled"
+        )
+        _allowed_origins: list[str] | None = None
+    elif _allowed_origins_str == "*":
+        _allowed_origins = None  # wildcard: verification disabled
+    else:
+        _allowed_origins = [o.strip().lower() for o in _allowed_origins_str.split(",") if o.strip()]
+
+    def _check_origin(request: Request) -> None:
+        """Validate Origin header against A2A_ALLOWED_ORIGINS.
+
+        No-ops when A2A_ALLOWED_ORIGINS is unset or '*'.
+        Raises HTTP 403 when Origin is not in the allowlist.
+        """
+        if _allowed_origins is None:
+            return
+        origin = request.headers.get("Origin", "").lower()
+        if origin not in _allowed_origins:
+            raise HTTPException(status_code=403, detail="Forbidden: origin not allowed")
+
     # Update agent card capabilities
     agent_card.setdefault("capabilities", {})
     agent_card["capabilities"]["streaming"] = True
@@ -1189,6 +1214,12 @@ def register_a2a_routes(
             msg_metadata = params.get("metadata") or {}
             caller_trace = msg_metadata.get("a2a.trace") or {}
 
+            if method in ("message/stream", "message/sendStream"):
+                try:
+                    _check_origin(request)
+                except HTTPException as exc:
+                    return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+
             if method == "message/send":
                 record = await _submit_task(text, context_id, push_config, caller_trace)
                 # Use _task_to_response so the `kind: "task"` discriminator
@@ -1243,6 +1274,10 @@ def register_a2a_routes(
                 return _rpc_error(-32602, "Invalid params: id is required")
             if await _store.get(task_id) is None:
                 return _rpc_error(-32001, f"Task not found: {task_id}")
+            try:
+                _check_origin(request)
+            except HTTPException as exc:
+                return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
             return StreamingResponse(
                 _resubscribe_jsonrpc_stream(task_id, rpc_id),
                 media_type="text/event-stream",
@@ -1355,6 +1390,7 @@ def register_a2a_routes(
     async def _rest_stream(request: Request, body: dict):
         _check_auth(request, api_key)
         _check_bearer_auth(request)
+        _check_origin(request)
         message = body.get("message", {})
         configuration = body.get("configuration", {})
         context_id = body.get("contextId", "")
@@ -1385,6 +1421,7 @@ def register_a2a_routes(
     async def _subscribe_task(task_id: str, request: Request):
         _check_auth(request, api_key)
         _check_bearer_auth(request)
+        _check_origin(request)
         record = await _store.get(task_id)
         if record is None:
             raise HTTPException(404, f"Task not found: {task_id}")

--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -32,6 +32,7 @@ REST convenience aliases
 from __future__ import annotations
 
 import asyncio
+import hmac
 import json
 import logging
 import os
@@ -933,10 +934,42 @@ def register_a2a_routes(
     so FastAPI does not raise on a duplicate route registration.
     """
 
+    # ── Bearer token authentication ───────────────────────────────────────────
+    _raw_a2a_token = os.environ.get("A2A_AUTH_TOKEN", "")
+    _a2a_token: str | None = _raw_a2a_token.strip() or None
+    if not _a2a_token:
+        logger.warning(
+            "[a2a] A2A auth token not configured — endpoint is open"
+        )
+
+    def _check_bearer_auth(request: Request) -> None:
+        """Validate Authorization: Bearer <token> against A2A_AUTH_TOKEN.
+
+        No-ops when A2A_AUTH_TOKEN is unset (open mode).
+        Raises HTTP 401 on missing or invalid token.
+        """
+        if not _a2a_token:
+            return
+        auth_header = request.headers.get("Authorization", "")
+        if not auth_header.startswith("Bearer "):
+            raise HTTPException(
+                status_code=401,
+                detail="Unauthorized: expected 'Authorization: Bearer <token>'",
+            )
+        provided = auth_header[len("Bearer "):]
+        if not hmac.compare_digest(provided, _a2a_token):
+            raise HTTPException(status_code=401, detail="Unauthorized: invalid bearer token")
+
     # Update agent card capabilities
     agent_card.setdefault("capabilities", {})
     agent_card["capabilities"]["streaming"] = True
     agent_card["capabilities"]["pushNotifications"] = True
+    if _a2a_token:
+        agent_card.setdefault("securitySchemes", {})
+        agent_card["securitySchemes"]["bearer"] = {
+            "type": "http",
+            "scheme": "bearer",
+        }
 
     # ── Agent card ────────────────────────────────────────────────────────────
 
@@ -1114,6 +1147,10 @@ def register_a2a_routes(
     async def _a2a_rpc(request: Request, req: dict):
         if api_key and request.headers.get("x-api-key") != api_key:
             return JSONResponse({"detail": "Unauthorized"}, status_code=401)
+        try:
+            _check_bearer_auth(request)
+        except HTTPException as exc:
+            return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
 
         rpc_id = req.get("id")
         method = req.get("method", "")
@@ -1301,6 +1338,7 @@ def register_a2a_routes(
     @app.post("/message:send", include_in_schema=False)
     async def _rest_send(request: Request, body: dict):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         message = body.get("message", {})
         configuration = body.get("configuration", {})
         context_id = body.get("contextId", "")
@@ -1316,6 +1354,7 @@ def register_a2a_routes(
     @app.post("/message:stream", include_in_schema=False)
     async def _rest_stream(request: Request, body: dict):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         message = body.get("message", {})
         configuration = body.get("configuration", {})
         context_id = body.get("contextId", "")
@@ -1334,6 +1373,7 @@ def register_a2a_routes(
     @app.get("/tasks/{task_id}", include_in_schema=False)
     async def _get_task(task_id: str, request: Request):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         record = await _store.get(task_id)
         if record is None:
             raise HTTPException(404, f"Task not found: {task_id}")
@@ -1344,6 +1384,7 @@ def register_a2a_routes(
     @app.get("/tasks/{task_id}:subscribe", include_in_schema=False)
     async def _subscribe_task(task_id: str, request: Request):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         record = await _store.get(task_id)
         if record is None:
             raise HTTPException(404, f"Task not found: {task_id}")
@@ -1403,6 +1444,7 @@ def register_a2a_routes(
     @app.post("/tasks/{task_id}:cancel", include_in_schema=False)
     async def _cancel_task(task_id: str, request: Request):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         # Single atomic read+write under the store lock. The previous
         # get → sleep → cancel → update sequence could race with the
         # background runner and clobber a legitimate COMPLETED state.
@@ -1425,6 +1467,7 @@ def register_a2a_routes(
     @app.post("/tasks/{task_id}/pushNotificationConfigs", include_in_schema=False)
     async def _create_push_config(task_id: str, request: Request, body: dict):
         _check_auth(request, api_key)
+        _check_bearer_auth(request)
         record = await _store.get(task_id)
         if record is None:
             raise HTTPException(404, f"Task not found: {task_id}")

--- a/config/langgraph-config.yaml
+++ b/config/langgraph-config.yaml
@@ -26,14 +26,22 @@ subagents:
     max_turns: 20
 
 middleware:
-  # The knowledge / memory middlewares require a knowledge store. The
-  # template ships with no store, so leave these false until you add
-  # one.
+  # The knowledge middleware requires a knowledge store. Leave false
+  # until you add one. Memory persistence is enabled by default and
+  # writes session summaries to /sandbox/memory/ without a store.
   knowledge: false
   audit: true
-  memory: false
+  memory: true
 
 knowledge:
   db_path: /sandbox/knowledge/agent.db
   embed_model: nomic-embed-text
   top_k: 5
+
+# Session memory loading — prior summaries injected into system prompt
+# by KnowledgeMiddleware when it is active. Persistence via MemoryMiddleware
+# uses the same path. Mount a volume at this path to survive container restarts.
+memory:
+  path: /sandbox/memory/
+  max_sessions: 10
+  max_tokens: 2000

--- a/config/langgraph-config.yaml
+++ b/config/langgraph-config.yaml
@@ -45,3 +45,11 @@ memory:
   path: /sandbox/memory/
   max_sessions: 10
   max_tokens: 2000
+
+# Skill index — SQLite FTS5 store for learned skill-v1 artifacts.
+# Skills emitted by task() are indexed here and injected into the system
+# prompt as a <learned_skills> block at inference time.
+skills:
+  db_path: /sandbox/skills.db
+  top_k: 5
+  max_tokens: 2000

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -61,12 +61,22 @@ LangGraph's `create_agent` gives you:
 
 The template's middleware chain (`_build_middleware` in `graph/agent.py`) is ordered:
 
-1. **KnowledgeMiddleware** (optional) — injects retrieved context before each LLM call
+1. **KnowledgeMiddleware** (optional) — injects retrieved context before each LLM call; also loads prior session summaries from `/sandbox/memory/` as a `<prior_sessions>` block
 2. **AuditMiddleware** — records every tool call to JSONL + Langfuse
-3. **MemoryMiddleware** (optional) — persists useful context
+3. **MemoryMiddleware** (optional) — persists session summaries to `/sandbox/memory/` on session end
 4. **MessageCaptureMiddleware** — captures `message()` tool calls for later retrieval
 
 Middleware order matters. Knowledge must run before audit (so the injected context is captured). Message capture runs last so every upstream transformation is already applied.
+
+## Session memory
+
+Memory is **enabled by default** (`middleware.memory: true` in `langgraph-config.yaml`). At session end `MemoryMiddleware` writes a JSON summary to `/sandbox/memory/`. On the next session, `KnowledgeMiddleware.load_memory()` reads the 10 most recent summaries and injects them as a `<prior_sessions>` XML block into the system prompt context, giving the agent continuity across restarts without any external store.
+
+**Token budget:** the prior-sessions block is capped at 2 000 tokens (character approximation: chars ÷ 4). Oldest sessions are dropped first when the budget is exceeded.
+
+**Disabling memory:** set `middleware.memory: false` in your fork's config, or set `PROTOAGENT_DISABLE_MEMORY=1` in the environment to suppress disk writes without changing the config.
+
+**Persistence across container restarts:** mount a volume at `/sandbox/memory/`. Without a volume the directory is ephemeral and summaries are lost on container stop.
 
 ## Why LiteLLM sits between the agent and models
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -78,6 +78,37 @@ Memory is **enabled by default** (`middleware.memory: true` in `langgraph-config
 
 **Persistence across container restarts:** mount a volume at `/sandbox/memory/`. Without a volume the directory is ephemeral and summaries are lost on container stop.
 
+## Security
+
+Three independent layers defend the A2A surface. Each can be enabled or left open for local dev, but production forks should enable all three.
+
+**Bearer authentication** — `a2a_handler.py` reads `A2A_AUTH_TOKEN` at startup. When set, every A2A route (`/a2a`, `message/send`, `tasks/*`, and SSE streaming endpoints) requires `Authorization: Bearer <token>`. Comparison uses `hmac.compare_digest` so timing analysis can't leak the token. When set, the agent card advertises `securitySchemes.bearer` so consumers know to present credentials.
+
+**Audit redaction** — `graph/middleware/redaction.py` scrubs credentials before anything is written to `audit.jsonl` or emitted as a Langfuse span attribute. Patterns covered: `Authorization: Bearer ...`, OpenAI-style `sk-...` keys, generic `api_key=...` forms, and nested dicts keyed by well-known env var names (`OPENAI_API_KEY`, `LANGFUSE_SECRET_KEY`, `A2A_AUTH_TOKEN`, etc.). This closes the class of bugs where a tool returns a secret in its payload and it leaks into the audit trail or trace.
+
+**Origin verification** — SSE and WebSocket connections to streaming endpoints check the `Origin` header against `A2A_ALLOWED_ORIGINS`. Without this, anyone who can reach the A2A endpoint can drain another session's events if they guess the task ID. Unset logs a WARNING at startup and accepts all origins (template default); setting `*` explicitly disables the check without the warning.
+
+The three layers compose: auth proves the caller is known, redaction ensures the audit trail won't leak secrets even if a tool misbehaves, origin verification prevents cross-origin SSE drain. Turn them all on — none substitute for the others.
+
+## Skill loop
+
+The `task()` subagent tool captures successful workflows as **skill-v1 artifacts** so the agent can reuse them on similar future problems. This is the "gets better the longer it runs" property you see in systems like Hermes Agent, adapted to protoAgent's A2A-native shape.
+
+Four pieces:
+
+1. **Emission** — when a subagent completes successfully and `task(..., emit_skill=True)` was called (and the subagent's config has `allow_skill_emission: true`), `graph/extensions/skills.py` serializes a `SkillV1Artifact` (name, description, prompt_template, tools_used, source_session_id) into a ContextVar.
+2. **Collection** — the A2A handler reads the ContextVar at task completion and appends a DataPart with `mimeType: application/vnd.protolabs.skill-v1+json` to the terminal artifact. See the [skill-v1 extension reference](/reference/extensions#skill-v1).
+3. **Indexing** — `graph/skills/index.py` stores emitted skills in a SQLite database at `/sandbox/skills.db` with an FTS5 virtual table over `name + description + prompt_template`. The DB auto-initializes on first write; an empty DB is a no-op for queries.
+4. **Retrieval** — `KnowledgeMiddleware.load_skills(query)` returns the top-k matches (default 5, BM25-ranked) for the current user message + recent context, injected as a `<learned_skills>` block in the system prompt. Same 2 K-token budget discipline as `<prior_sessions>`.
+
+**Curation** — `python -m graph.skills.curator` runs a periodic sweep that deduplicates near-identical skills and decays confidence 50 % every 90 days of idleness. Skills below 0.2 confidence are pruned. Run it on a cron or let operators trigger it manually — no automatic scheduling in the template.
+
+**Opting out per subagent** — set `allow_skill_emission: false` in `graph/subagents/config.py` for subagents whose runs shouldn't be captured (e.g. sensitive ones). The `disallowed_tools` mechanism is unaffected — skill emission is orthogonal to tool access control.
+
+**Why SQLite + FTS5** — the index lives inside the container, survives restarts if `/sandbox` is volume-mounted, handles tens of thousands of skills without a separate service, and the fts5 virtual table gives BM25 ranking without embedding model overhead. You can swap in a vector store later if recall beats keyword BM25 for your domain; the `KnowledgeMiddleware.load_skills()` seam is the single swap point.
+
+See the [skill loop tutorial](/tutorials/skill-loop) for the end-to-end walkthrough.
+
 ## Why LiteLLM sits between the agent and models
 
 See [LiteLLM gateway](/explanation/litellm-gateway) for the full rationale. The short version: swapping models should be a one-line gateway config change, not a code change in every agent.

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -33,6 +33,14 @@ If both keys are unset, tracing is disabled and every helper in `tracing.py` bec
 
 The template explicitly calls `logging.basicConfig(level=INFO)` — without this, Python's default WARNING would hide `logger.info(...)` lines like "webhook delivered", making A2A issues invisible in container logs.
 
+## Streaming / origin verification
+
+| Variable | Default | What |
+|---|---|---|
+| `A2A_ALLOWED_ORIGINS` | (unset — allow all, with WARNING) | Comma-separated list of allowed `Origin` header values for SSE and WebSocket streaming endpoints (`/a2a` streaming methods, `/message:stream`, `/tasks/{id}:subscribe`). Example: `https://app.example.com,https://admin.example.com`. Set to `*` to explicitly disable origin verification without the WARNING log. Origin values are compared case-insensitively. |
+
+When unset, all origins are accepted but a WARNING is logged at startup. When set, requests whose `Origin` header does not match any entry receive a `403 Forbidden` response. A missing `Origin` header is treated as an empty string and will be rejected when verification is enabled.
+
 ## Push notifications / SSRF guard
 
 | Variable | Default | What |

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -15,6 +15,27 @@ Every env var the template reads at runtime.
 | `AGENT_NAME` | `protoagent` | Short slug. Used as the Prometheus metric prefix, Langfuse trace tag, and in log labels. Should match what you used when forking. |
 | `<AGENT_NAME>_API_KEY` | (unset — no auth) | Expected value of the `X-API-Key` header if you want to require auth on `/a2a` and `/v1/*`. Uppercased, non-alphanumeric → underscore. e.g. `MY_AGENT_API_KEY`. |
 
+## Authentication — A2A bearer token
+
+| Variable | Default | What |
+|---|---|---|
+| `A2A_AUTH_TOKEN` | (unset — open mode) | Required bearer token for all A2A routes (POST `/a2a`, `message/send`, `tasks/*`, SSE streaming). When set, requests without `Authorization: Bearer <token>` get 401. Token comparison uses `hmac.compare_digest` (constant-time). |
+
+When unset, the handler logs a WARNING at startup (`"A2A auth token not configured — endpoint is open"`) and accepts all traffic — appropriate for local development, not production. When set, the agent card advertises `securitySchemes.bearer` so A2A consumers know to present credentials.
+
+This is independent of the legacy `<AGENT_NAME>_API_KEY` header-based scheme (X-API-Key) documented above. You can enable one, both, or neither; bearer is the preferred mechanism going forward.
+
+## Memory
+
+Session memory is enabled by default. See [architecture § Session memory](/explanation/architecture#session-memory) for the full rationale.
+
+| Variable | Default | What |
+|---|---|---|
+| `MEMORY_PATH` | `/sandbox/memory/` | Directory where `MemoryMiddleware` writes JSON session summaries and where `KnowledgeMiddleware.load_memory()` reads them. Writes are atomic (temp file + rename). |
+| `PROTOAGENT_DISABLE_MEMORY` | (unset) | Set to `1` (or any non-empty value) to suppress disk persistence without changing `langgraph-config.yaml`. Loading still occurs if summaries exist from prior runs. |
+
+To persist memory across container restarts, mount a volume at whatever `MEMORY_PATH` resolves to. Without a volume the directory is ephemeral.
+
 ## Tracing (optional)
 
 | Variable | What |

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -94,6 +94,48 @@ Emitted as a DataPart on the terminal artifact:
 
 The template doesn't emit this by default because the shipped tools don't mutate anything. See `a2a_handler.py::TaskRecord.add_delta` for where to hook in.
 
+## `skill-v1`
+
+**URI / mimeType**: `application/vnd.protolabs.skill-v1+json`
+**Direction**: emitted by this agent (when subagents opt in)
+**Declared on card**: no (runtime artifact, not a card capability)
+
+Captures the "recipe" of a successful subagent workflow so future runs can reuse it. Emitted as a DataPart on the terminal artifact of any task that called `task(..., emit_skill=True)` when the subagent's config has `allow_skill_emission: true`:
+
+```json
+{
+  "kind": "data",
+  "metadata": {"mimeType": "application/vnd.protolabs.skill-v1+json"},
+  "data": {
+    "name": "refactor-memory-load",
+    "description": "Rewrites KnowledgeMiddleware.load_memory() to enforce a token budget",
+    "prompt_template": "You are the memory subagent. Given {{target_file}} and {{budget}}, ...",
+    "tools_used": ["read_file", "write_file", "run_tests"],
+    "created_at": "2026-04-19T17:24:36.860Z",
+    "source_session_id": "session-abc123"
+  }
+}
+```
+
+Fields:
+
+| Field | What |
+|---|---|
+| `name` | Short human-readable label used as the FTS5 search key |
+| `description` | What the skill does; primary retrieval surface |
+| `prompt_template` | The prompt that drove the original successful run, reusable verbatim or with variable substitution |
+| `tools_used` | Tool names actually invoked — proxy for which subagent type would run this skill |
+| `created_at` | UTC ISO timestamp |
+| `source_session_id` | Provenance — which session produced the artifact |
+
+**Collection** — `a2a_handler.py` reads skills from the `_pending_skills` ContextVar at task completion and appends them as DataParts. Agents and middleware never access the ContextVar directly; they use `emit_skill_artifact()` to add and `get_pending_skills()` to read.
+
+**Indexing** — protoAgent's own `SkillsIndex` (`graph/skills/index.py`) at `/sandbox/skills.db` picks these up on the next sweep and makes them retrievable by `KnowledgeMiddleware.load_skills(query)`. Consumers running their own skill registries can index the DataParts from the A2A stream directly — the mimeType is the contract.
+
+**Why ContextVar and not a state field** — skill emission happens inside LangGraph's tool loop, potentially from async tool execution frames that don't see the top-level state object. ContextVars propagate across async boundaries without threading state through every call site.
+
+See [architecture § Skill loop](/explanation/architecture#skill-loop) for the rationale and [skill loop tutorial](/tutorials/skill-loop) for the walkthrough.
+
 ## `a2a.trace` — distributed Langfuse propagation
 
 **Not an extension**, a protocol convention. Lives in `params.metadata`, not `capabilities.extensions`.

--- a/docs/tutorials/skill-loop.md
+++ b/docs/tutorials/skill-loop.md
@@ -1,0 +1,212 @@
+# Your agent learns from experience
+
+protoAgent includes a **skill loop** — an end-to-end feedback cycle where your agent
+captures successful workflows as reusable skills, retrieves them on future tasks, and
+periodically curates them to keep the index high-quality.
+
+This tutorial walks through the full example: a skill is born, the agent reuses it, and
+the curator automatically optimises the index over time.
+
+---
+
+## What is a skill?
+
+A **skill-v1 artifact** is a structured record of a successful subagent run:
+
+```json
+{
+  "id": "a1b2c3d4-...",
+  "name": "web research summary",
+  "description": "Searches DuckDuckGo, fetches top results, and returns a structured summary.",
+  "prompt_template": "Research the following topic and return a structured summary: {topic}",
+  "tools_used": ["web_search", "fetch_url"],
+  "confidence": 0.95,
+  "created_at": "2025-03-01T10:00:00+00:00",
+  "last_used": "2025-04-10T14:30:00+00:00"
+}
+```
+
+Skills are emitted as A2A `DataPart` objects (MIME type
+`application/vnd.protolabs.skill-v1+json`) and accumulated in the
+skill index at `/sandbox/skills/index.jsonl`.
+
+---
+
+## Step 1 — Emit a skill from a subagent run
+
+Call `task()` with `emit_skill=True` in your subagent configuration to capture the
+workflow as a reusable recipe:
+
+```python
+# graph/subagents/config.py
+from graph.subagents.config import SubagentConfig
+
+RESEARCH_WORKER = SubagentConfig(
+    name="research_worker",
+    description="Searches and summarises information from the web.",
+    system_prompt="You are a research assistant. Use web_search and fetch_url to gather information.",
+    tools=["web_search", "fetch_url"],
+    max_turns=10,
+    allow_skill_emission=True,   # ← enables skill capture on success
+)
+```
+
+When the worker completes successfully the runtime calls `emit_skill_artifact()` which
+stores a `SkillV1Artifact` in the async context.  The A2A handler collects it and writes
+it to the skill index.
+
+---
+
+## Step 2 — Agent retrieves relevant skills at runtime
+
+`KnowledgeMiddleware` queries the skill index before each LLM call and injects the
+top-k matching skills as context:
+
+```
+[Relevant knowledge from previous sessions:]
+- [skills] web research summary — searches DuckDuckGo and fetches top results
+- [skills] calculator — evaluates arithmetic expressions safely
+```
+
+The agent uses these injected skills to choose the best subagent or to reuse an
+existing prompt template rather than generating one from scratch.  This means each
+successful run makes the next run faster and more accurate.
+
+---
+
+## Step 3 — Understand the end-to-end skill loop
+
+Here is the complete feedback cycle in one diagram:
+
+```
+┌──────────────┐   emit_skill=True   ┌──────────────────┐
+│  task()      │ ──────────────────▶ │  SkillV1Artifact │
+│  (subagent)  │                     │  (emitted as     │
+│              │                     │   A2A DataPart)  │
+└──────────────┘                     └────────┬─────────┘
+                                              │ written to
+                                              ▼
+                                     ┌──────────────────┐
+                                     │  skill index     │
+                                     │  (index.jsonl)   │
+                                     └────────┬─────────┘
+                                              │ queried by
+                                              ▼
+                                     ┌──────────────────┐
+                                     │ KnowledgeMiddle- │
+                                     │ ware injects     │
+                                     │ top-k skills     │
+                                     └────────┬─────────┘
+                                              │ context for
+                                              ▼
+                                     ┌──────────────────┐
+                                     │   LLM call       │
+                                     │   (smarter each  │
+                                     │    run)          │
+                                     └──────────────────┘
+                                              │ periodically
+                                              ▼
+                                     ┌──────────────────┐
+                                     │  Skill Curator   │
+                                     │  (dedup + decay  │
+                                     │   + prune)       │
+                                     └──────────────────┘
+```
+
+---
+
+## Step 4 — Run the skill curator
+
+The curator keeps the index lean and high-quality by running three passes:
+
+| Pass | What it does |
+|---|---|
+| **Confidence decay** | Halves confidence every 90 days of inactivity — stale skills sink to the bottom |
+| **Deduplication** | Clusters similar skills by Jaccard similarity; keeps the highest-confidence copy |
+| **Pruning** | Removes skills whose confidence has fallen below 0.2 |
+
+Run the curator manually:
+
+```bash
+# Dry-run — compute changes but write nothing
+python -m graph.skills.curator --dry-run
+
+# Full run with defaults (/sandbox/skills/index.jsonl → audit.jsonl)
+python -m graph.skills.curator
+
+# Custom paths and thresholds
+python -m graph.skills.curator \
+    --index /sandbox/skills/index.jsonl \
+    --audit /sandbox/audit/curator.jsonl \
+    --prune-threshold 0.15 \
+    --half-life 60
+```
+
+See all options:
+
+```bash
+python -m graph.skills.curator --help
+```
+
+### Schedule with cron
+
+Add the curator to cron so it runs automatically:
+
+```cron
+# Run skill curator every Sunday at 02:00
+0 2 * * 0  cd /opt/protoagent && python -m graph.skills.curator >> /var/log/curator.log 2>&1
+```
+
+---
+
+## Step 5 — Inspect the audit log
+
+After each run the curator appends a structured JSON entry to `audit.jsonl`:
+
+```bash
+# Pretty-print the latest audit entry
+tail -1 audit.jsonl | python -m json.tool
+```
+
+Example output:
+
+```json
+{
+  "run_id": "c7a3f1b2-...",
+  "timestamp": "2025-04-14T02:00:01.123456+00:00",
+  "dry_run": false,
+  "skills_before": 47,
+  "skills_after": 41,
+  "decay_applied": [
+    {"id": "a1b2...", "days_idle": 91.3, "old": 0.95, "new": 0.474}
+  ],
+  "deduplicated": [
+    {"kept": "b3c4...", "removed": ["d5e6...", "f7a8..."]}
+  ],
+  "pruned": [
+    {"id": "9abc...", "name": "outdated search recipe", "confidence": 0.18}
+  ]
+}
+```
+
+---
+
+## What happens to pruned skills?
+
+Pruned skills are removed from the active index but recorded in `audit.jsonl`.  If you
+need to recover a pruned skill, grep the audit log for its `id` or `name`:
+
+```bash
+grep 'outdated search recipe' audit.jsonl | python -m json.tool
+```
+
+Then restore it by adding the original JSONL entry back to `index.jsonl` with a
+refreshed `last_used` timestamp and confidence reset to 1.0.
+
+---
+
+## Next steps
+
+- [Add a skill →](/guides/add-a-skill) — how to manually author skills and add them to the index
+- [Subagents →](/guides/subagents) — how to configure workers that emit skills
+- [Observability →](/guides/observability) — how to monitor curator runs via audit logs and Prometheus metrics

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -55,6 +55,7 @@ def _build_task_tool(config: LangGraphConfig, all_tools: list[BaseTool]):
         description: str,
         prompt: str,
         subagent_type: str = "worker",
+        emit_skill: bool = False,
     ) -> str:
         """Delegate a task to a specialized subagent.
 
@@ -62,7 +63,16 @@ def _build_task_tool(config: LangGraphConfig, all_tools: list[BaseTool]):
             description: Short description of what this task will accomplish
             prompt: Detailed instructions for the subagent
             subagent_type: Which subagent to use (see SUBAGENT_REGISTRY)
+            emit_skill: When True and the subagent config permits it, capture
+                the workflow as a skill-v1 artifact on successful completion.
+                Defaults to False (opt-in). No artifact is emitted on failure
+                or when the subagent config has allow_skill_emission=False.
         """
+        from datetime import datetime, timezone
+
+        import tracing
+        from graph.extensions.skills import SkillV1Artifact, emit_skill_artifact
+
         sub_config = SUBAGENT_REGISTRY.get(subagent_type)
         if not sub_config:
             return f"Error: Unknown subagent '{subagent_type}'. Available: {available_subagents}"
@@ -89,13 +99,56 @@ def _build_task_tool(config: LangGraphConfig, all_tools: list[BaseTool]):
             )
 
             messages = result.get("messages", [])
+
+            # Extract tools actually invoked during the subagent run.
+            tools_used: list[str] = []
+            for msg in messages:
+                # AIMessage tool_calls: [{"name": ..., "args": ..., "id": ...}]
+                for tc in getattr(msg, "tool_calls", []) or []:
+                    name = tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", None)
+                    if name and name not in tools_used:
+                        tools_used.append(name)
+
+            output_text = None
             for msg in reversed(messages):
                 if hasattr(msg, "content") and msg.content:
                     content = msg.content if isinstance(msg.content, str) else str(msg.content)
                     if content and not content.startswith("Error"):
-                        return f"[{subagent_type} completed: {description}]\n\n{content}"
+                        output_text = f"[{subagent_type} completed: {description}]\n\n{content}"
+                        break
 
-            return f"[{subagent_type} completed: {description}] -- no output produced."
+            if output_text is None:
+                output_text = f"[{subagent_type} completed: {description}] -- no output produced."
+
+            # Emit skill-v1 artifact when opted in and config permits.
+            if emit_skill and sub_config.allow_skill_emission:
+                if not tools_used:
+                    import logging
+                    logging.getLogger(__name__).warning(
+                        "[skill] emit_skill=True but no tool usage metadata "
+                        "captured for subagent '%s'; skipping skill emission.",
+                        subagent_type,
+                    )
+                else:
+                    try:
+                        artifact = SkillV1Artifact(
+                            name=description,
+                            description=f"Captured workflow: {description}",
+                            prompt_template=prompt,
+                            tools_used=tools_used,
+                            created_at=datetime.now(timezone.utc),
+                            source_session_id=tracing.current_session_id(),
+                        )
+                        emit_skill_artifact(artifact)
+                    except Exception as exc:
+                        import logging
+                        logging.getLogger(__name__).error(
+                            "[skill] skill-v1 artifact construction failed: %s; "
+                            "skipping emission.",
+                            exc,
+                        )
+
+            return output_text
         except Exception as e:
             return f"Error: Subagent '{subagent_type}' failed: {e}"
 

--- a/graph/extensions/skills.py
+++ b/graph/extensions/skills.py
@@ -1,0 +1,109 @@
+"""Skill-v1 artifact schema and emission infrastructure for protoAgent.
+
+A skill-v1 artifact captures the "recipe" of a successful subagent workflow —
+which tools were used, the prompt template, and provenance metadata. These
+artifacts are emitted by task() when emit_skill=True and the subagent config
+permits it.
+
+The emitted DataPart shape follows the A2A extension pattern used by cost-v1
+and worldstate-delta-v1: a ``kind: "data"`` part with a ``mimeType`` metadata
+field that A2A consumers (e.g. Workstacean) use to route the payload to the
+matching interceptor.
+
+Emission is stored in a ContextVar so the collector (the A2A handler or any
+other runtime wrapper) can retrieve all skills emitted during a task run
+without coupling the graph package to the server package.
+"""
+
+from __future__ import annotations
+
+import contextvars
+import logging
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+
+log = logging.getLogger(__name__)
+
+SKILL_V1_MIME = "application/vnd.protolabs.skill-v1+json"
+
+# ContextVar holding skills emitted during the current async context (task run).
+# Initialised to None; callers must use get_pending_skills() and
+# emit_skill_artifact() rather than accessing this directly.
+_pending_skills: contextvars.ContextVar[list[SkillV1Artifact] | None] = (
+    contextvars.ContextVar("_pending_skills", default=None)
+)
+
+
+@dataclass
+class SkillV1Artifact:
+    """Serializable record of a subagent workflow captured as a reusable skill.
+
+    Fields
+    ------
+    name              Short human-readable label for the skill.
+    description       What the skill does, suitable for a skill registry.
+    prompt_template   The prompt that drove the subagent run.
+    tools_used        Tool names actually invoked during the run.
+    created_at        UTC timestamp of capture.
+    source_session_id Session that produced this artifact (for provenance).
+    """
+
+    name: str
+    description: str
+    prompt_template: str
+    tools_used: list[str] = field(default_factory=list)
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    source_session_id: str = ""
+
+    def __post_init__(self) -> None:
+        if not self.name:
+            raise ValueError("SkillV1Artifact.name must be a non-empty string")
+        if not isinstance(self.tools_used, list):
+            raise TypeError("SkillV1Artifact.tools_used must be a list")
+        if not isinstance(self.created_at, datetime):
+            raise TypeError("SkillV1Artifact.created_at must be a datetime")
+
+    def to_dict(self) -> dict:
+        """Serialize to a JSON-compatible dict."""
+        return {
+            "name": self.name,
+            "description": self.description,
+            "prompt_template": self.prompt_template,
+            "tools_used": list(self.tools_used),
+            "created_at": self.created_at.isoformat(),
+            "source_session_id": self.source_session_id,
+        }
+
+    def to_datapart(self) -> dict:
+        """Serialize as an A2A DataPart for inclusion in artifact ``parts``."""
+        return {
+            "kind": "data",
+            "data": self.to_dict(),
+            "metadata": {"mimeType": SKILL_V1_MIME},
+        }
+
+
+# ── ContextVar helpers ────────────────────────────────────────────────────────
+
+
+def get_pending_skills() -> list[SkillV1Artifact]:
+    """Return a snapshot of skills emitted in the current async context."""
+    skills = _pending_skills.get()
+    return list(skills) if skills is not None else []
+
+
+def emit_skill_artifact(artifact: SkillV1Artifact) -> None:
+    """Append *artifact* to the pending-skills list for this async context.
+
+    Creates the list on first call within a fresh context. Subsequent calls
+    append to the same list so multiple task() invocations in one session
+    accumulate correctly.
+    """
+    skills = _pending_skills.get()
+    if skills is None:
+        skills = []
+        _pending_skills.set(skills)
+    skills.append(artifact)
+    log.debug("[skill] emitted skill artifact: %s", artifact.name)

--- a/graph/middleware/audit.py
+++ b/graph/middleware/audit.py
@@ -12,6 +12,8 @@ from langchain_core.messages import ToolMessage
 
 from langgraph.prebuilt.chat_agent_executor import AgentState
 
+from graph.middleware.redaction import redact
+
 
 class AuditMiddleware(AgentMiddleware):
     """Log all tool calls to audit, Langfuse, and Prometheus."""
@@ -45,12 +47,15 @@ class AuditMiddleware(AgentMiddleware):
                 content = str(result.content)[:200]
             success = not content.startswith("Error")
 
+            safe_args = redact(args)
+            safe_content = redact(content)
+
             audit_logger.log(
-                session_id=session_id, tool=tool_name, args=args,
-                result_summary=content, duration_ms=duration_ms, success=success,
+                session_id=session_id, tool=tool_name, args=safe_args,
+                result_summary=safe_content, duration_ms=duration_ms, success=success,
             )
             tracing.trace_tool_call(
-                tool_name=tool_name, args=args, result=content,
+                tool_name=tool_name, args=safe_args, result=safe_content,
                 duration_ms=duration_ms, success=success, session_id=session_id,
             )
             metrics.record_tool_call(tool_name, success, duration_ms / 1000)
@@ -58,12 +63,14 @@ class AuditMiddleware(AgentMiddleware):
             return result
         except Exception as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
+            safe_args = redact(args)
+            safe_exc = redact(str(exc)[:200])
             audit_logger.log(
-                session_id=session_id, tool=tool_name, args=args,
-                result_summary=str(exc)[:200], duration_ms=duration_ms, success=False,
+                session_id=session_id, tool=tool_name, args=safe_args,
+                result_summary=safe_exc, duration_ms=duration_ms, success=False,
             )
             tracing.trace_tool_call(
-                tool_name=tool_name, args=args, result=str(exc)[:200],
+                tool_name=tool_name, args=safe_args, result=safe_exc,
                 duration_ms=duration_ms, success=False, session_id=session_id,
             )
             metrics.record_tool_call(tool_name, False, duration_ms / 1000)
@@ -89,12 +96,15 @@ class AuditMiddleware(AgentMiddleware):
                 content = str(result.content)[:200]
             success = not content.startswith("Error")
 
+            safe_args = redact(args)
+            safe_content = redact(content)
+
             audit_logger.log(
-                session_id=session_id, tool=tool_name, args=args,
-                result_summary=content, duration_ms=duration_ms, success=success,
+                session_id=session_id, tool=tool_name, args=safe_args,
+                result_summary=safe_content, duration_ms=duration_ms, success=success,
             )
             tracing.trace_tool_call(
-                tool_name=tool_name, args=args, result=content,
+                tool_name=tool_name, args=safe_args, result=safe_content,
                 duration_ms=duration_ms, success=success, session_id=session_id,
             )
             metrics.record_tool_call(tool_name, success, duration_ms / 1000)
@@ -102,12 +112,14 @@ class AuditMiddleware(AgentMiddleware):
             return result
         except Exception as exc:
             duration_ms = int((time.monotonic() - t0) * 1000)
+            safe_args = redact(args)
+            safe_exc = redact(str(exc)[:200])
             audit_logger.log(
-                session_id=session_id, tool=tool_name, args=args,
-                result_summary=str(exc)[:200], duration_ms=duration_ms, success=False,
+                session_id=session_id, tool=tool_name, args=safe_args,
+                result_summary=safe_exc, duration_ms=duration_ms, success=False,
             )
             tracing.trace_tool_call(
-                tool_name=tool_name, args=args, result=str(exc)[:200],
+                tool_name=tool_name, args=safe_args, result=safe_exc,
                 duration_ms=duration_ms, success=False, session_id=session_id,
             )
             metrics.record_tool_call(tool_name, False, duration_ms / 1000)

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -2,7 +2,14 @@
 
 Queries the KnowledgeStore with the last user message and adds
 top-k results to the state's `context` field.
+
+Also loads prior session summaries from disk and injects them as a
+<prior_sessions> block at the start of each session's context.
 """
+
+import json
+import logging
+import os
 
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import HumanMessage
@@ -10,41 +17,177 @@ from langchain_core.messages import HumanMessage
 from langgraph.prebuilt.chat_agent_executor import AgentState
 
 
+log = logging.getLogger(__name__)
+
+
 class KnowledgeMiddleware(AgentMiddleware):
-    """Inject knowledge store context before each LLM call."""
+    """Inject knowledge store context before each LLM call.
+
+    Also loads prior session summaries from /sandbox/memory/ and injects
+    them as a <prior_sessions> block so the agent has continuity across
+    sessions without requiring an active knowledge store.
+    """
 
     def __init__(self, knowledge_store, top_k: int = 5):
         super().__init__()
         self._store = knowledge_store
         self._top_k = top_k
+        # Lazily loaded on first before_model call; None = not yet loaded
+        self._prior_sessions_cache: str | None = None
+
+    # ---------------------------------------------------------------------------
+    # Session memory loading
+    # ---------------------------------------------------------------------------
+
+    def load_memory(
+        self,
+        memory_path: str = "/sandbox/memory/",
+        max_sessions: int = 10,
+        max_tokens: int = 2000,
+    ) -> str:
+        """Load prior session summaries and format as a <prior_sessions> block.
+
+        Reads up to *max_sessions* most recent JSON files from *memory_path*,
+        enforces *max_tokens* budget by dropping oldest sessions first, and
+        returns a formatted XML block ready for injection into the system
+        prompt context.
+
+        Returns an empty string when the directory is missing (first run) or
+        when no readable sessions exist.  Never raises — all errors are logged
+        and treated as empty memory.
+
+        Token counting uses the character-based approximation (chars // 4)
+        because tiktoken is not guaranteed to be installed.
+        """
+        # --- Guard: directory must exist ---
+        if not os.path.isdir(memory_path):
+            log.info(
+                "[knowledge] memory directory not found: %s — starting with empty prior_sessions",
+                memory_path,
+            )
+            return ""
+
+        # --- List JSON session files, sorted newest-first by mtime ---
+        try:
+            entries: list[tuple[float, str]] = []
+            for fname in os.listdir(memory_path):
+                if not fname.endswith(".json"):
+                    continue
+                fpath = os.path.join(memory_path, fname)
+                try:
+                    entries.append((os.path.getmtime(fpath), fpath))
+                except OSError:
+                    continue
+            entries.sort(reverse=True)  # newest first
+        except OSError as exc:
+            log.warning(
+                "[knowledge] cannot list memory directory %s: %s — treating as empty",
+                memory_path,
+                exc,
+            )
+            return ""
+
+        if not entries:
+            return "<prior_sessions/>"
+
+        # --- Parse session files (skip malformed) ---
+        summaries: list[dict] = []
+        for _, fpath in entries[:max_sessions]:
+            try:
+                with open(fpath, encoding="utf-8") as fh:
+                    data = json.load(fh)
+                summaries.append(data)
+            except (OSError, json.JSONDecodeError, ValueError) as exc:
+                log.debug(
+                    "[knowledge] skipping malformed session file %s: %s", fpath, exc
+                )
+                continue
+
+        if not summaries:
+            return "<prior_sessions/>"
+
+        # --- Format each summary as XML ---
+        def _format_summary(s: dict) -> str:
+            ts = s.get("timestamp", "unknown")
+            sid = s.get("session_id", "unknown")
+            lines = [f'<session id="{sid}" timestamp="{ts}">']
+
+            msgs: list[dict] = s.get("messages", [])
+            if msgs:
+                lines.append("  <messages>")
+                for m in msgs:
+                    role = m.get("role", "unknown")
+                    content = (m.get("content", "") or "")[:500]
+                    lines.append(f"    <{role}>{content}</{role}>")
+                lines.append("  </messages>")
+
+            final = (s.get("final_output") or "")[:300]
+            if final:
+                lines.append(f"  <final_output>{final}</final_output>")
+
+            lines.append("</session>")
+            return "\n".join(lines)
+
+        # Token approximation — chars // 4 (no tiktoken dependency)
+        def _count_tokens(text: str) -> int:
+            return max(1, len(text) // 4)
+
+        # --- Enforce token budget: drop oldest sessions (end of list) ---
+        formatted = [_format_summary(s) for s in summaries]
+        while formatted:
+            joined = "\n".join(formatted)
+            if _count_tokens(joined) <= max_tokens:
+                break
+            formatted.pop()  # remove oldest (newest-first ordering)
+
+        if not formatted:
+            return "<prior_sessions/>"
+
+        return "<prior_sessions>\n" + "\n".join(formatted) + "\n</prior_sessions>"
+
+    # ---------------------------------------------------------------------------
+    # Middleware hooks
+    # ---------------------------------------------------------------------------
 
     def before_model(self, state, runtime) -> dict | None:
-        """Query knowledge store with last user message, inject context."""
+        """Query knowledge store with last user message, inject context.
+
+        Also prepends prior session summaries on the first call so the
+        agent has cross-session continuity from the very first LLM turn.
+        """
+        parts: list[str] = []
+
+        # Load prior sessions once per middleware instance (lazy cache)
+        if self._prior_sessions_cache is None:
+            self._prior_sessions_cache = self.load_memory()
+        if self._prior_sessions_cache:
+            parts.append(self._prior_sessions_cache)
+
         messages = state.get("messages", [])
-        if not messages:
+        if messages:
+            # Find the last human message
+            last_human: str | None = None
+            for msg in reversed(messages):
+                if isinstance(msg, HumanMessage):
+                    last_human = (
+                        msg.content
+                        if isinstance(msg.content, str)
+                        else str(msg.content)
+                    )
+                    break
+
+            if last_human:
+                results = self._store.search(last_human, k=self._top_k)
+                if results:
+                    context_parts = ["[Relevant knowledge from previous sessions:]"]
+                    for r in results:
+                        context_parts.append(f"- [{r['table']}] {r['preview']}")
+                    parts.append("\n".join(context_parts))
+
+        if not parts:
             return None
 
-        # Find the last human message
-        last_human = None
-        for msg in reversed(messages):
-            if isinstance(msg, HumanMessage):
-                last_human = msg.content if isinstance(msg.content, str) else str(msg.content)
-                break
-
-        if not last_human:
-            return None
-
-        # Search knowledge store
-        results = self._store.search(last_human, k=self._top_k)
-        if not results:
-            return None
-
-        # Format context
-        context_parts = ["[Relevant knowledge from previous sessions:]"]
-        for r in results:
-            context_parts.append(f"- [{r['table']}] {r['preview']}")
-
-        return {"context": "\n".join(context_parts)}
+        return {"context": "\n\n".join(parts)}
 
     async def abefore_model(self, state, runtime) -> dict | None:
         """Async version — same logic."""

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -5,19 +5,30 @@ top-k results to the state's `context` field.
 
 Also loads prior session summaries from disk and injects them as a
 <prior_sessions> block at the start of each session's context.
+
+Retrieves relevant learned skills from the SkillsIndex and injects
+them as a <learned_skills> block alongside <prior_sessions>.
 """
 
 import json
 import logging
 import os
+from typing import TYPE_CHECKING
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage
 
 from langgraph.prebuilt.chat_agent_executor import AgentState
 
+if TYPE_CHECKING:
+    from graph.skills.index import SkillRecord, SkillsIndex
+
 
 log = logging.getLogger(__name__)
+
+# Token budget for the <learned_skills> block (chars // 4 approximation)
+_SKILLS_MAX_TOKENS = 2000
+_SKILLS_CONTEXT_CHARS = 2000  # chars of recent context to include in query
 
 
 class KnowledgeMiddleware(AgentMiddleware):
@@ -28,10 +39,18 @@ class KnowledgeMiddleware(AgentMiddleware):
     sessions without requiring an active knowledge store.
     """
 
-    def __init__(self, knowledge_store, top_k: int = 5):
+    def __init__(
+        self,
+        knowledge_store,
+        top_k: int = 5,
+        skills_index: "SkillsIndex | None" = None,
+        skills_top_k: int = 5,
+    ):
         super().__init__()
         self._store = knowledge_store
         self._top_k = top_k
+        self._skills_index = skills_index
+        self._skills_top_k = skills_top_k
         # Lazily loaded on first before_model call; None = not yet loaded
         self._prior_sessions_cache: str | None = None
 
@@ -146,6 +165,123 @@ class KnowledgeMiddleware(AgentMiddleware):
         return "<prior_sessions>\n" + "\n".join(formatted) + "\n</prior_sessions>"
 
     # ---------------------------------------------------------------------------
+    # Skill retrieval
+    # ---------------------------------------------------------------------------
+
+    def load_skills(self, query: str, k: int | None = None) -> list["SkillRecord"]:
+        """Retrieve top-k relevant skills from the SkillsIndex.
+
+        Searches the FTS5 index using *query* and returns ranked results.
+        Returns an empty list when no index is configured or there are no
+        matches — callers must handle the empty case gracefully.
+
+        Args:
+            query: Combined user message + recent context (up to 2K chars).
+            k:     Max results; defaults to self._skills_top_k.
+        """
+        if self._skills_index is None:
+            return []
+        if not query or not query.strip():
+            return []
+        k = k if k is not None else self._skills_top_k
+        try:
+            return self._skills_index.load_skills(query, k=k)
+        except Exception as exc:  # pragma: no cover
+            log.warning("[knowledge] skills retrieval error: %s", exc)
+            return []
+
+    def _build_skills_query(self, messages: list) -> str:
+        """Build a query string from the last human message + recent context.
+
+        Constructs query = last human message + last _SKILLS_CONTEXT_CHARS
+        chars of recent AI/human message content, capped at 2K chars total.
+        """
+        last_human = ""
+        context_parts: list[str] = []
+
+        for msg in reversed(messages):
+            if isinstance(msg, HumanMessage):
+                if not last_human:
+                    last_human = (
+                        msg.content
+                        if isinstance(msg.content, str)
+                        else str(msg.content)
+                    )
+                else:
+                    content = (
+                        msg.content
+                        if isinstance(msg.content, str)
+                        else str(msg.content)
+                    )
+                    context_parts.append(content)
+            elif isinstance(msg, AIMessage):
+                content = (
+                    msg.content
+                    if isinstance(msg.content, str)
+                    else str(msg.content)
+                )
+                context_parts.append(content)
+
+        recent_context = " ".join(reversed(context_parts))
+        if recent_context:
+            recent_context = recent_context[-_SKILLS_CONTEXT_CHARS:]
+
+        query = (last_human + " " + recent_context).strip()
+        return query[:_SKILLS_CONTEXT_CHARS]
+
+    def _format_learned_skills(self, skills: list["SkillRecord"]) -> str:
+        """Format retrieved skills as a <learned_skills> XML block.
+
+        Enforces a token budget of _SKILLS_MAX_TOKENS (chars // 4 approximation).
+        Iteratively removes lowest-relevance skills (highest score, least negative
+        BM25 value) then truncates descriptions if still over budget.
+
+        Returns an empty string when *skills* is empty.
+        """
+        if not skills:
+            return ""
+
+        def _count_tokens(text: str) -> int:
+            return max(1, len(text) // 4)
+
+        def _format_skill(s: "SkillRecord") -> str:
+            # Truncate prompt_template to 500 chars to keep block concise
+            pt = s.prompt_template[:500] if s.prompt_template else ""
+            return (
+                f'  <skill name="{s.name}">\n'
+                f"    <description>{s.description}</description>\n"
+                f"    <prompt_template>{pt}</prompt_template>\n"
+                f"  </skill>"
+            )
+
+        # Sort by score ascending (most relevant first, BM25 scores are negative)
+        sorted_skills = sorted(skills, key=lambda s: s.score)
+
+        formatted = [_format_skill(s) for s in sorted_skills]
+
+        # Enforce token budget: remove lowest-relevance skills first (end of list)
+        while formatted:
+            block = "<learned_skills>\n" + "\n".join(formatted) + "\n</learned_skills>"
+            if _count_tokens(block) <= _SKILLS_MAX_TOKENS:
+                break
+            formatted.pop()
+            if formatted:
+                log.debug("[knowledge] skills token budget exceeded — removed lowest-relevance skill")
+
+        if not formatted:
+            return ""
+
+        # If still over budget after removing all but one, truncate descriptions
+        block = "<learned_skills>\n" + "\n".join(formatted) + "\n</learned_skills>"
+        if _count_tokens(block) > _SKILLS_MAX_TOKENS:
+            # Hard truncate the block to fit
+            max_chars = _SKILLS_MAX_TOKENS * 4
+            block = block[:max_chars]
+            log.warning("[knowledge] skills block hard-truncated to fit token budget")
+
+        return block
+
+    # ---------------------------------------------------------------------------
     # Middleware hooks
     # ---------------------------------------------------------------------------
 
@@ -154,6 +290,9 @@ class KnowledgeMiddleware(AgentMiddleware):
 
         Also prepends prior session summaries on the first call so the
         agent has cross-session continuity from the very first LLM turn.
+
+        Retrieves relevant learned skills from the SkillsIndex (when
+        configured) and injects them as a <learned_skills> block.
         """
         parts: list[str] = []
 
@@ -164,6 +303,16 @@ class KnowledgeMiddleware(AgentMiddleware):
             parts.append(self._prior_sessions_cache)
 
         messages = state.get("messages", [])
+
+        # Inject learned skills from SkillsIndex when available
+        if self._skills_index is not None and messages:
+            skills_query = self._build_skills_query(messages)
+            if skills_query:
+                skills = self.load_skills(skills_query)
+                skills_block = self._format_learned_skills(skills)
+                if skills_block:
+                    parts.append(skills_block)
+
         if messages:
             # Find the last human message
             last_human: str | None = None

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -2,23 +2,175 @@
 
 After the agent responds, extracts key topics/findings from the
 conversation and stores them in the knowledge base asynchronously.
+
+Also persists a session summary to disk when sessions end via the
+on_session_end lifecycle hook, enabling session memory across restarts.
 """
 
+import json
+import logging
+import os
+import tempfile
 import threading
+from datetime import datetime, timezone
 from typing import Any
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from langgraph.prebuilt.chat_agent_executor import AgentState
 
 
+log = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration — read once at module init
+# ---------------------------------------------------------------------------
+
+MEMORY_PATH = os.environ.get("MEMORY_PATH", "/sandbox/memory/")
+_DISABLE_ENV = os.environ.get("PROTOAGENT_DISABLE_MEMORY", "")
+_PERSISTENCE_DISABLED = _DISABLE_ENV.lower() in ("1", "true", "yes")
+
+if _PERSISTENCE_DISABLED:
+    log.debug("[memory] persistence disabled via PROTOAGENT_DISABLE_MEMORY")
+else:
+    log.info("[memory] session persistence enabled — path: %s", MEMORY_PATH)
+
+
+# ---------------------------------------------------------------------------
+# Session persistence
+# ---------------------------------------------------------------------------
+
+def _persist_session(state: dict, trace_id: str) -> None:
+    """Write a session summary JSON file atomically.
+
+    Summary schema:
+        session_id       — str
+        trace_id         — str
+        messages         — list[{"role": str, "content": str}]
+        tool_calls       — top-5 by duration list[{"name", "args", "result", "duration_ms"}]
+        tool_calls_total_count — int (present when > 5 tool calls)
+        final_output     — str | null
+        timestamp        — ISO-8601 UTC string
+
+    Writes atomically: temp file → os.rename to avoid partial reads.
+    """
+    if _PERSISTENCE_DISABLED:
+        return
+
+    session_id: str = state.get("session_id", "") or ""
+    messages_raw: list = state.get("messages", []) or []
+
+    # --- Extract user-visible messages ---
+    user_messages: list[dict] = []
+    for msg in messages_raw:
+        if isinstance(msg, HumanMessage):
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            user_messages.append({"role": "user", "content": content})
+        elif isinstance(msg, AIMessage) and msg.content:
+            content = msg.content if isinstance(msg.content, str) else str(msg.content)
+            user_messages.append({"role": "assistant", "content": content})
+
+    # --- Extract tool call records ---
+    # Reconstruct from AI messages (which carry tool_calls) and ToolMessages
+    tool_results: dict[str, str] = {}
+    all_tool_calls: list[dict] = []
+
+    for msg in messages_raw:
+        if isinstance(msg, ToolMessage):
+            tool_call_id = getattr(msg, "tool_call_id", "") or ""
+            tool_results[tool_call_id] = (
+                msg.content if isinstance(msg.content, str) else str(msg.content)
+            )
+
+    for msg in messages_raw:
+        if isinstance(msg, AIMessage) and getattr(msg, "tool_calls", None):
+            for tc in msg.tool_calls:
+                tc_id = tc.get("id", "")
+                all_tool_calls.append({
+                    "name": tc.get("name", ""),
+                    "args": tc.get("args", {}),
+                    "result": tool_results.get(tc_id, ""),
+                    "duration_ms": 0,  # timing not available in state
+                })
+
+    total_count = len(all_tool_calls)
+
+    # Top-5 by duration (duration is 0 for all when not available — stable sort)
+    sorted_calls = sorted(all_tool_calls, key=lambda x: x["duration_ms"], reverse=True)
+    top_calls = sorted_calls[:5]
+
+    # --- Final output: last assistant message ---
+    final_output: str | None = None
+    for msg in reversed(messages_raw):
+        if isinstance(msg, AIMessage) and msg.content:
+            final_output = msg.content if isinstance(msg.content, str) else str(msg.content)
+            break
+
+    # --- Build summary ---
+    summary: dict[str, Any] = {
+        "session_id": session_id,
+        "trace_id": trace_id,
+        "messages": user_messages,
+        "tool_calls": top_calls,
+        "final_output": final_output,
+        "timestamp": datetime.now(timezone.utc).isoformat(),
+    }
+    if total_count > 5:
+        summary["tool_calls_total_count"] = total_count
+
+    # --- Ensure directory exists ---
+    try:
+        os.makedirs(MEMORY_PATH, exist_ok=True)
+        log.debug("[memory] ensured directory: %s", MEMORY_PATH)
+    except OSError as exc:
+        log.warning("[memory] cannot create directory %s: %s — skipping persistence", MEMORY_PATH, exc)
+        return
+
+    # --- Atomic write ---
+    filename = f"{session_id or 'unknown'}.json"
+    dest = os.path.join(MEMORY_PATH, filename)
+    tmp_fd = None
+    tmp_path = None
+    try:
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=MEMORY_PATH, suffix=".tmp")
+        with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+            json.dump(summary, fh, indent=2, default=str)
+            tmp_fd = None  # fdopen took ownership
+        os.rename(tmp_path, dest)
+        log.info("[memory] persisted session %s -> %s", session_id, dest)
+        tmp_path = None  # rename succeeded — no cleanup needed
+    except OSError as exc:
+        log.error("[memory] write failed for session %s: %s", session_id, exc)
+    finally:
+        # Clean up temp file if rename didn't happen
+        if tmp_fd is not None:
+            try:
+                os.close(tmp_fd)
+            except OSError:
+                pass
+        if tmp_path is not None:
+            try:
+                os.unlink(tmp_path)
+            except OSError:
+                pass
+
+
+# ---------------------------------------------------------------------------
+# Middleware class
+# ---------------------------------------------------------------------------
+
 class MemoryMiddleware(AgentMiddleware):
-    """Extract and store QA findings after agent responses."""
+    """Extract and store QA findings after agent responses.
+
+    Also persists a session summary on session end via on_session_end.
+    """
 
     def __init__(self, knowledge_store):
         super().__init__()
         self._store = knowledge_store
+
+    # --- Knowledge extraction (existing) ---
 
     def after_agent(self, state, runtime) -> dict | None:
         """Queue conversation for async knowledge extraction."""
@@ -61,3 +213,15 @@ class MemoryMiddleware(AgentMiddleware):
 
     async def aafter_agent(self, state, runtime) -> dict | None:
         return self.after_agent(state, runtime)
+
+    # --- Session persistence ---
+
+    def on_session_end(self, state, runtime) -> dict | None:
+        """Persist session summary to disk when session reaches terminal state."""
+        import tracing
+        trace_id = tracing.current_trace_id()
+        _persist_session(state, trace_id)
+        return None
+
+    async def aon_session_end(self, state, runtime) -> dict | None:
+        return self.on_session_end(state, runtime)

--- a/graph/middleware/redaction.py
+++ b/graph/middleware/redaction.py
@@ -1,0 +1,120 @@
+"""Credential redaction for audit logs and Langfuse spans.
+
+Provides a redact() function that scrubs sensitive credentials from
+strings and nested data structures before they are written to audit.jsonl
+or emitted as Langfuse observations.
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+# Patterns are compiled once at module load for performance.
+# Each entry is (pattern_name, compiled_regex, replacement).
+PATTERNS: dict[str, re.Pattern] = {
+    "bearer_token": re.compile(
+        r"(Authorization\s*:\s*Bearer\s+)\S+",
+        re.IGNORECASE,
+    ),
+    "openai_key": re.compile(
+        r"\bsk-[A-Za-z0-9_\-]{20,}\b",
+    ),
+    "generic_api_key": re.compile(
+        r"(?i)(?:api[_\-]?key|apikey)(?:[\"'\s:=]+)([A-Za-z0-9_\-]{16,})",
+    ),
+    "env_var_assignment": re.compile(
+        r"(?i)\b(OPENAI_API_KEY|LANGFUSE_SECRET_KEY|LANGFUSE_PUBLIC_KEY|"
+        r"A2A_AUTH_TOKEN|API_KEY|SECRET_KEY|AUTH_TOKEN|ACCESS_TOKEN|"
+        r"PRIVATE_KEY)\s*[=:]\s*\S+",
+    ),
+}
+
+# Known environment variable key names whose dict values should be redacted.
+_SENSITIVE_ENV_KEYS: frozenset[str] = frozenset({
+    "OPENAI_API_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_PUBLIC_KEY",
+    "A2A_AUTH_TOKEN",
+    "API_KEY",
+    "SECRET_KEY",
+    "AUTH_TOKEN",
+    "ACCESS_TOKEN",
+    "PRIVATE_KEY",
+    "authorization",
+    "Authorization",
+    "api_key",
+    "apikey",
+    "secret_key",
+    "auth_token",
+    "access_token",
+    "private_key",
+})
+
+_PLACEHOLDER = "[REDACTED]"
+_MAX_DEPTH = 10
+
+
+def _redact_string_simple(value: str) -> str:
+    """Simplified string redaction using direct substitution."""
+    # Bearer token
+    value = PATTERNS["bearer_token"].sub(r"\1[REDACTED]", value)
+    # OpenAI-style key
+    value = PATTERNS["openai_key"].sub(_PLACEHOLDER, value)
+    # Generic api_key — redact the captured credential value group
+    def _replace_api_key(m: re.Match) -> str:
+        full = m.group(0)
+        cred = m.group(1)
+        return full[: len(full) - len(cred)] + _PLACEHOLDER
+
+    value = PATTERNS["generic_api_key"].sub(_replace_api_key, value)
+    # env var assignment — keep the key name, redact value after =/:
+    def _replace_env_var(m: re.Match) -> str:
+        full = m.group(0)
+        key = m.group(1)
+        # find the separator and everything after
+        rest = full[len(key):]
+        sep_match = re.match(r"\s*[=:]\s*", rest)
+        if sep_match:
+            return key + sep_match.group(0) + _PLACEHOLDER
+        return key + _PLACEHOLDER
+
+    value = PATTERNS["env_var_assignment"].sub(_replace_env_var, value)
+    return value
+
+
+def redact(data: Any, _depth: int = 0) -> Any:
+    """Recursively redact credentials from strings, dicts, and lists.
+
+    Args:
+        data: The value to redact. May be a string, dict, list, or any other type.
+
+    Returns:
+        A copy of ``data`` with all credential patterns replaced by [REDACTED].
+        Non-string scalar values (int, bool, None, etc.) are returned unchanged.
+    """
+    if _depth > _MAX_DEPTH:
+        return data
+
+    if isinstance(data, str):
+        return _redact_string_simple(data)
+
+    if isinstance(data, dict):
+        result: dict[str, Any] = {}
+        for k, v in data.items():
+            # Redact values for known sensitive keys unconditionally
+            if k in _SENSITIVE_ENV_KEYS or (
+                isinstance(k, str) and k.upper() in _SENSITIVE_ENV_KEYS
+            ):
+                result[k] = _PLACEHOLDER
+            else:
+                result[k] = redact(v, _depth + 1)
+        return result
+
+    if isinstance(data, list):
+        return [redact(item, _depth + 1) for item in data]
+
+    if isinstance(data, tuple):
+        return tuple(redact(item, _depth + 1) for item in data)
+
+    return data

--- a/graph/skills/__init__.py
+++ b/graph/skills/__init__.py
@@ -1,0 +1,1 @@
+"""graph.skills — skill curation and management utilities."""

--- a/graph/skills/curator.py
+++ b/graph/skills/curator.py
@@ -1,0 +1,535 @@
+"""Periodic skill curator agent for protoAgent.
+
+Reads the skill index, clusters skills by similarity to identify duplicates,
+applies exponential confidence decay for stale skills, and prunes those with
+confidence below the configured threshold.  Writes a structured audit entry to
+audit.jsonl after each run.
+
+Usage
+-----
+    # Dry-run (no writes to index or audit):
+    python -m graph.skills.curator --dry-run
+
+    # Full run with default paths:
+    python -m graph.skills.curator
+
+    # Custom paths:
+    python -m graph.skills.curator \\
+        --index /sandbox/skills/index.jsonl \\
+        --audit /sandbox/audit/curator.jsonl
+
+Skill index format (JSONL, one JSON object per line)
+-----------------------------------------------------
+    {
+        "id": "<uuid>",
+        "name": "<short label>",
+        "description": "<what the skill does>",
+        "prompt_template": "<the prompt that drove the subagent run>",
+        "tools_used": ["tool_a", "tool_b"],
+        "confidence": 0.9,
+        "created_at": "<ISO-8601 UTC>",
+        "last_used": "<ISO-8601 UTC>"   // optional; falls back to created_at
+    }
+
+Confidence decay model
+----------------------
+Confidence decays with a 90-day half-life of inactivity:
+
+    decay_factor = 0.5 ** (days_idle / 90)
+    new_confidence = original_confidence * decay_factor
+
+Skills whose post-decay confidence falls below PRUNE_THRESHOLD (0.2) are
+removed from the index.
+
+Duplicate detection
+-------------------
+Skills are clustered using token-based Jaccard similarity on the concatenation
+of ``name + " " + description``.  When sentence-transformers is available it is
+used instead for higher-quality clustering; a warning is logged when the
+fallback is active.  Within each cluster the skill with the highest confidence
+is kept; the rest are consolidated and removed.
+
+Audit log
+---------
+Each run appends one JSON object to audit.jsonl:
+
+    {
+        "run_id": "<uuid>",
+        "timestamp": "<ISO-8601 UTC>",
+        "dry_run": false,
+        "skills_before": 42,
+        "skills_after": 38,
+        "decay_applied": [{"id": "...", "old": 0.9, "new": 0.72}],
+        "deduplicated": [{"kept": "id-a", "removed": ["id-b", "id-c"]}],
+        "pruned": [{"id": "...", "name": "...", "confidence": 0.18}]
+    }
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import math
+import os
+import uuid
+from datetime import datetime, timezone
+from typing import Any
+
+log = logging.getLogger(__name__)
+
+# ── Constants ──────────────────────────────────────────────────────────────────
+
+HALF_LIFE_DAYS: float = 90.0
+PRUNE_THRESHOLD: float = 0.2
+SIMILARITY_THRESHOLD: float = 0.6
+DEFAULT_INDEX_PATH: str = "/sandbox/skills/index.jsonl"
+DEFAULT_AUDIT_PATH: str = "audit.jsonl"
+AUDIT_MAX_BYTES: int = 100 * 1024 * 1024  # 100 MB
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _now_utc() -> datetime:
+    return datetime.now(timezone.utc)
+
+
+def _parse_iso(ts: str) -> datetime:
+    """Parse an ISO-8601 string, always returning a timezone-aware datetime."""
+    dt = datetime.fromisoformat(ts)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+    return dt
+
+
+def _clamp(value: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    """Clamp *value* to [lo, hi], handling NaN / infinity."""
+    if not math.isfinite(value):
+        log.warning("[curator] confidence clamped from non-finite value %s", value)
+        return lo
+    return max(lo, min(hi, value))
+
+
+def _jaccard(text_a: str, text_b: str) -> float:
+    """Token-level Jaccard similarity between two strings."""
+    tokens_a = set(text_a.lower().split())
+    tokens_b = set(text_b.lower().split())
+    if not tokens_a and not tokens_b:
+        return 1.0
+    intersection = len(tokens_a & tokens_b)
+    union = len(tokens_a | tokens_b)
+    return intersection / union if union else 0.0
+
+
+def _skill_text(skill: dict) -> str:
+    """Canonical text used for similarity comparison."""
+    return f"{skill.get('name', '')} {skill.get('description', '')}"
+
+
+# ── Core curator ──────────────────────────────────────────────────────────────
+
+
+class SkillCurator:
+    """Reads, curates, and optionally persists a skill index.
+
+    Parameters
+    ----------
+    index_path:
+        Path to the JSONL skill index file.
+    audit_path:
+        Path to the audit JSONL file.
+    dry_run:
+        When *True* the curator computes all changes but writes nothing to disk.
+    half_life_days:
+        Confidence half-life in days (default 90).
+    prune_threshold:
+        Skills with post-decay confidence below this value are pruned (default 0.2).
+    similarity_threshold:
+        Jaccard / embedding similarity above which two skills are considered
+        duplicates (default 0.6).
+    """
+
+    def __init__(
+        self,
+        index_path: str = DEFAULT_INDEX_PATH,
+        audit_path: str = DEFAULT_AUDIT_PATH,
+        dry_run: bool = False,
+        half_life_days: float = HALF_LIFE_DAYS,
+        prune_threshold: float = PRUNE_THRESHOLD,
+        similarity_threshold: float = SIMILARITY_THRESHOLD,
+    ) -> None:
+        self.index_path = index_path
+        self.audit_path = audit_path
+        self.dry_run = dry_run
+        self.half_life_days = half_life_days
+        self.prune_threshold = prune_threshold
+        self.similarity_threshold = similarity_threshold
+
+    # ── Public API ─────────────────────────────────────────────────────────────
+
+    def run(self) -> dict:
+        """Execute a full curation cycle.
+
+        Returns the audit entry that was (or would be) written.
+        """
+        run_id = str(uuid.uuid4())
+        started_at = _now_utc()
+        log.info("[curator] starting run %s (dry_run=%s)", run_id, self.dry_run)
+
+        skills = self._load_index()
+        skills_before = len(skills)
+
+        decay_report = self._apply_decay(skills)
+        dedup_report = self._deduplicate(skills)
+        prune_report, skills = self._prune(skills)
+
+        skills_after = len(skills)
+
+        audit_entry = {
+            "run_id": run_id,
+            "timestamp": started_at.isoformat(),
+            "dry_run": self.dry_run,
+            "skills_before": skills_before,
+            "skills_after": skills_after,
+            "decay_applied": decay_report,
+            "deduplicated": dedup_report,
+            "pruned": prune_report,
+        }
+
+        if not self.dry_run:
+            self._save_index(skills)
+            self._append_audit(audit_entry)
+
+        log.info(
+            "[curator] run %s complete — before=%d after=%d decay=%d dedup_clusters=%d pruned=%d",
+            run_id,
+            skills_before,
+            skills_after,
+            len(decay_report),
+            len(dedup_report),
+            len(prune_report),
+        )
+        return audit_entry
+
+    # ── Loading / saving ───────────────────────────────────────────────────────
+
+    def _load_index(self) -> list[dict]:
+        """Load skills from the JSONL index.  Returns [] if file is absent."""
+        if not os.path.exists(self.index_path):
+            log.info("[curator] index not found at %s — starting with empty set", self.index_path)
+            return []
+
+        skills: list[dict] = []
+        with open(self.index_path, encoding="utf-8") as fh:
+            for lineno, line in enumerate(fh, 1):
+                line = line.strip()
+                if not line:
+                    continue
+                try:
+                    skill = json.loads(line)
+                    if not isinstance(skill, dict):
+                        raise ValueError("expected a JSON object")
+                    # Ensure required fields exist
+                    if "id" not in skill:
+                        skill["id"] = str(uuid.uuid4())
+                    if "confidence" not in skill:
+                        skill["confidence"] = 1.0
+                    skills.append(skill)
+                except (json.JSONDecodeError, ValueError) as exc:
+                    log.error(
+                        "[curator] skipping malformed entry at line %d in %s: %s",
+                        lineno,
+                        self.index_path,
+                        exc,
+                    )
+        log.info("[curator] loaded %d skills from %s", len(skills), self.index_path)
+        return skills
+
+    def _save_index(self, skills: list[dict]) -> None:
+        """Persist *skills* back to the JSONL index."""
+        os.makedirs(os.path.dirname(self.index_path) or ".", exist_ok=True)
+        with open(self.index_path, "w", encoding="utf-8") as fh:
+            for skill in skills:
+                fh.write(json.dumps(skill, default=str) + "\n")
+        log.info("[curator] saved %d skills to %s", len(skills), self.index_path)
+
+    # ── Confidence decay ───────────────────────────────────────────────────────
+
+    def _days_idle(self, skill: dict) -> float:
+        """Return the number of days since the skill was last used."""
+        now = _now_utc()
+        # Prefer last_used; fall back to created_at as proxy
+        ts_str = skill.get("last_used") or skill.get("created_at")
+        if not ts_str:
+            log.debug(
+                "[curator] skill %s has no timestamp — using 0 days idle", skill.get("id")
+            )
+            return 0.0
+        try:
+            last = _parse_iso(ts_str)
+            delta = now - last
+            return max(0.0, delta.total_seconds() / 86400.0)
+        except (ValueError, TypeError) as exc:
+            log.warning(
+                "[curator] cannot parse timestamp for skill %s: %s — treating as 0 days idle",
+                skill.get("id"),
+                exc,
+            )
+            return 0.0
+
+    def _decay_factor(self, days_idle: float) -> float:
+        """Compute the multiplicative decay factor for *days_idle* days of inactivity."""
+        return 0.5 ** (days_idle / self.half_life_days)
+
+    def _apply_decay(self, skills: list[dict]) -> list[dict]:
+        """Apply confidence decay in-place.  Returns the decay report."""
+        report: list[dict] = []
+        for skill in skills:
+            old_confidence = _clamp(float(skill.get("confidence", 1.0)))
+            days = self._days_idle(skill)
+            if days <= 0:
+                continue
+            factor = self._decay_factor(days)
+            new_confidence = _clamp(old_confidence * factor)
+            if new_confidence != old_confidence:
+                report.append(
+                    {
+                        "id": skill.get("id"),
+                        "days_idle": round(days, 1),
+                        "old": round(old_confidence, 4),
+                        "new": round(new_confidence, 4),
+                    }
+                )
+                skill["confidence"] = new_confidence
+        log.info("[curator] decay applied to %d skills", len(report))
+        return report
+
+    # ── Deduplication ──────────────────────────────────────────────────────────
+
+    def _build_similarity_matrix(
+        self, skills: list[dict]
+    ) -> list[list[float]]:
+        """Return an n×n similarity matrix using Jaccard similarity."""
+        # Try sentence-transformers first; fall back to Jaccard with a warning.
+        try:
+            from sentence_transformers import SentenceTransformer  # type: ignore
+
+            model = SentenceTransformer("all-MiniLM-L6-v2")
+            texts = [_skill_text(s) for s in skills]
+            embeddings = model.encode(texts, normalize_embeddings=True)
+            # Cosine similarity via dot product (embeddings are normalised)
+            import numpy as np  # type: ignore
+
+            matrix = (embeddings @ embeddings.T).tolist()
+            log.debug("[curator] similarity matrix built with sentence-transformers")
+            return matrix
+        except ImportError:
+            log.warning(
+                "[curator] sentence-transformers not available — "
+                "falling back to token Jaccard similarity"
+            )
+
+        n = len(skills)
+        texts = [_skill_text(s) for s in skills]
+        matrix = [[0.0] * n for _ in range(n)]
+        for i in range(n):
+            for j in range(i, n):
+                sim = _jaccard(texts[i], texts[j])
+                matrix[i][j] = sim
+                matrix[j][i] = sim
+        return matrix
+
+    def _cluster_skills(self, skills: list[dict]) -> list[list[int]]:
+        """Return clusters (lists of indices) using greedy single-linkage."""
+        if not skills:
+            return []
+
+        matrix = self._build_similarity_matrix(skills)
+        n = len(skills)
+        assigned = [False] * n
+        clusters: list[list[int]] = []
+
+        for i in range(n):
+            if assigned[i]:
+                continue
+            cluster = [i]
+            assigned[i] = True
+            for j in range(i + 1, n):
+                if not assigned[j] and matrix[i][j] >= self.similarity_threshold:
+                    cluster.append(j)
+                    assigned[j] = True
+            clusters.append(cluster)
+
+        return clusters
+
+    def _deduplicate(self, skills: list[dict]) -> list[dict]:
+        """Remove duplicates in-place.  Returns the deduplication report.
+
+        Within each cluster the skill with the highest confidence is kept;
+        the rest are removed.  Modifies *skills* in-place.
+        """
+        if not skills:
+            return []
+
+        clusters = self._cluster_skills(skills)
+        report: list[dict] = []
+        ids_to_remove: set[str] = set()
+
+        for cluster in clusters:
+            if len(cluster) <= 1:
+                continue
+            # Pick the skill with the highest confidence as the canonical one
+            best_idx = max(cluster, key=lambda i: float(skills[i].get("confidence", 0)))
+            removed_ids = [
+                skills[i]["id"] for i in cluster if i != best_idx
+            ]
+            report.append(
+                {"kept": skills[best_idx]["id"], "removed": removed_ids}
+            )
+            ids_to_remove.update(removed_ids)
+
+        if ids_to_remove:
+            skills[:] = [s for s in skills if s.get("id") not in ids_to_remove]
+            log.info("[curator] deduplicated: removed %d skills across %d clusters", len(ids_to_remove), len(report))
+        return report
+
+    # ── Pruning ────────────────────────────────────────────────────────────────
+
+    def _prune(self, skills: list[dict]) -> tuple[list[dict], list[dict]]:
+        """Remove skills with confidence below prune_threshold.
+
+        Returns ``(prune_report, surviving_skills)``.
+        """
+        surviving: list[dict] = []
+        report: list[dict] = []
+
+        for skill in skills:
+            confidence = _clamp(float(skill.get("confidence", 1.0)))
+            if confidence < self.prune_threshold:
+                report.append(
+                    {
+                        "id": skill.get("id"),
+                        "name": skill.get("name", ""),
+                        "confidence": round(confidence, 4),
+                    }
+                )
+            else:
+                surviving.append(skill)
+
+        if report:
+            log.info("[curator] pruned %d skills below threshold %.2f", len(report), self.prune_threshold)
+        return report, surviving
+
+    # ── Audit log ─────────────────────────────────────────────────────────────
+
+    def _append_audit(self, entry: dict) -> None:
+        """Append *entry* as a JSON line to the audit file.
+
+        Archives the audit file when it exceeds AUDIT_MAX_BYTES.
+        """
+        audit_dir = os.path.dirname(self.audit_path) or "."
+        os.makedirs(audit_dir, exist_ok=True)
+
+        # Archive if over size limit
+        if os.path.exists(self.audit_path):
+            size = os.path.getsize(self.audit_path)
+            if size > AUDIT_MAX_BYTES:
+                ts = _now_utc().strftime("%Y-%m-%d")
+                archive = os.path.join(
+                    audit_dir, f"audit-{ts}.jsonl"
+                )
+                os.rename(self.audit_path, archive)
+                log.warning(
+                    "[curator] audit.jsonl exceeded 100 MB — archived to %s", archive
+                )
+
+        with open(self.audit_path, "a", encoding="utf-8") as fh:
+            fh.write(json.dumps(entry, default=str) + "\n")
+        log.info("[curator] audit entry written to %s", self.audit_path)
+
+
+# ── CLI entry point ────────────────────────────────────────────────────────────
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m graph.skills.curator",
+        description=(
+            "Periodic skill curator — deduplicates, decays confidence, and "
+            "prunes the protoAgent skill index."
+        ),
+    )
+    p.add_argument(
+        "--index",
+        default=DEFAULT_INDEX_PATH,
+        metavar="PATH",
+        help=f"Path to the JSONL skill index (default: {DEFAULT_INDEX_PATH})",
+    )
+    p.add_argument(
+        "--audit",
+        default=DEFAULT_AUDIT_PATH,
+        metavar="PATH",
+        help=f"Path to the audit JSONL file (default: {DEFAULT_AUDIT_PATH})",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Compute changes but do not write to disk",
+    )
+    p.add_argument(
+        "--half-life",
+        type=float,
+        default=HALF_LIFE_DAYS,
+        metavar="DAYS",
+        help=f"Confidence half-life in days (default: {HALF_LIFE_DAYS})",
+    )
+    p.add_argument(
+        "--prune-threshold",
+        type=float,
+        default=PRUNE_THRESHOLD,
+        metavar="FLOAT",
+        help=f"Prune skills below this confidence (default: {PRUNE_THRESHOLD})",
+    )
+    p.add_argument(
+        "--similarity-threshold",
+        type=float,
+        default=SIMILARITY_THRESHOLD,
+        metavar="FLOAT",
+        help=f"Jaccard similarity above which skills are duplicates (default: {SIMILARITY_THRESHOLD})",
+    )
+    p.add_argument(
+        "--log-level",
+        default="INFO",
+        choices=["DEBUG", "INFO", "WARNING", "ERROR"],
+        help="Logging verbosity (default: INFO)",
+    )
+    return p
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = _build_parser()
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(
+        level=getattr(logging, args.log_level),
+        format="%(asctime)s %(levelname)s %(name)s %(message)s",
+    )
+
+    curator = SkillCurator(
+        index_path=args.index,
+        audit_path=args.audit,
+        dry_run=args.dry_run,
+        half_life_days=args.half_life,
+        prune_threshold=args.prune_threshold,
+        similarity_threshold=args.similarity_threshold,
+    )
+    audit_entry = curator.run()
+
+    if args.dry_run:
+        print("[dry-run] audit entry that would be written:")
+        print(json.dumps(audit_entry, indent=2, default=str))
+
+
+if __name__ == "__main__":
+    main()

--- a/graph/skills/index.py
+++ b/graph/skills/index.py
@@ -1,0 +1,268 @@
+"""SQLite FTS5 skill index for protoAgent.
+
+Stores emitted skill-v1 artifacts in a full-text search index so the
+agent can retrieve relevant past skills at inference time.
+
+Database location: configurable, defaults to /sandbox/skills.db.
+Schema version is stamped in a metadata table; incompatible schemas
+trigger a backup-and-rebuild cycle per the deviation rules.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import shutil
+import sqlite3
+from typing import NamedTuple
+
+log = logging.getLogger(__name__)
+
+# Bump when FTS table columns change — triggers auto-migration
+_SCHEMA_VERSION = 1
+
+# Columns indexed by FTS5 (order matters for sqlite_master check)
+_FTS_CONTENT_COLUMNS = (
+    "name",
+    "description",
+    "prompt_template",
+    "tools_used",
+    "source_session_id",
+)
+
+
+class SkillRecord(NamedTuple):
+    """A single result from FTS5 skill retrieval."""
+
+    name: str
+    description: str
+    prompt_template: str
+    score: float
+
+
+class SkillsIndex:
+    """SQLite FTS5-backed skill index.
+
+    Usage::
+
+        index = SkillsIndex("/sandbox/skills.db")
+        index.add_skill(artifact)           # SkillV1Artifact from extensions.skills
+        results = index.load_skills("web research", k=5)
+    """
+
+    def __init__(self, db_path: str = "/sandbox/skills.db") -> None:
+        self._db_path = db_path
+        self._conn: sqlite3.Connection | None = None
+        self.initialize_db()
+
+    # ── Schema management ─────────────────────────────────────────────────────
+
+    def initialize_db(self) -> None:
+        """Create (or verify) the SQLite database and FTS5 virtual table.
+
+        On first run: creates the DB file and table.
+        On re-run with matching schema: no-op (idempotent).
+        On schema mismatch: backup existing DB to .bak, drop and recreate.
+        """
+        db_dir = os.path.dirname(self._db_path)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+
+        # Open connection — creates the file if absent
+        conn = self._open_conn()
+
+        if self._schema_compatible(conn):
+            log.debug("[skills] existing schema is compatible, no migration needed")
+            return
+
+        # Schema mismatch — backup and rebuild
+        conn.close()
+        self._conn = None
+        self._backup_and_reset()
+        conn = self._open_conn()
+        self._create_schema(conn)
+
+    def _open_conn(self) -> sqlite3.Connection:
+        """Open (or reuse) the SQLite connection."""
+        if self._conn is not None:
+            return self._conn
+        conn = sqlite3.connect(self._db_path, check_same_thread=False)
+        conn.row_factory = sqlite3.Row
+        self._conn = conn
+        return conn
+
+    def _schema_compatible(self, conn: sqlite3.Connection) -> bool:
+        """Return True if the DB has the expected schema at the current version."""
+        try:
+            cur = conn.execute(
+                "SELECT version FROM _skills_meta WHERE key = 'schema_version' LIMIT 1"
+            )
+            row = cur.fetchone()
+            if row is None:
+                # Meta table exists but no version row → treat as incompatible
+                return False
+            return int(row[0]) == _SCHEMA_VERSION
+        except sqlite3.OperationalError:
+            # Table doesn't exist yet — fresh DB
+            self._create_schema(conn)
+            return True
+
+    def _create_schema(self, conn: sqlite3.Connection) -> None:
+        """Create FTS5 table and metadata table from scratch."""
+        # Check FTS5 availability
+        try:
+            conn.execute("CREATE VIRTUAL TABLE IF NOT EXISTS _fts5_probe USING fts5(x)")
+            conn.execute("DROP TABLE IF EXISTS _fts5_probe")
+        except sqlite3.OperationalError as exc:
+            raise RuntimeError(
+                "SQLite FTS5 extension not available in this build. "
+                "Rebuild SQLite with FTS5 enabled."
+            ) from exc
+
+        conn.executescript("""
+            DROP TABLE IF EXISTS skills_fts;
+            DROP TABLE IF EXISTS _skills_meta;
+
+            CREATE VIRTUAL TABLE skills_fts USING fts5(
+                name,
+                description,
+                prompt_template,
+                tools_used,
+                source_session_id,
+                created_at UNINDEXED
+            );
+
+            CREATE TABLE _skills_meta (
+                key   TEXT PRIMARY KEY,
+                version INTEGER NOT NULL
+            );
+
+            INSERT INTO _skills_meta (key, version)
+            VALUES ('schema_version', 1);
+        """)
+        conn.commit()
+        log.info("[skills] schema created at %s", self._db_path)
+
+    def _backup_and_reset(self) -> None:
+        """Backup the existing DB file to .bak and remove the original."""
+        bak_path = self._db_path + ".bak"
+        if os.path.exists(self._db_path):
+            try:
+                shutil.copy2(self._db_path, bak_path)
+                os.remove(self._db_path)
+                log.warning(
+                    "[skills] incompatible schema — backed up %s → %s and will rebuild",
+                    self._db_path,
+                    bak_path,
+                )
+            except OSError as exc:
+                log.error("[skills] backup failed: %s — will attempt in-place schema reset", exc)
+
+    # ── Write path ────────────────────────────────────────────────────────────
+
+    def add_skill(self, artifact: object) -> None:
+        """Insert a SkillV1Artifact into the FTS5 index.
+
+        Accepts any object with matching attributes so this module does not
+        import graph.extensions.skills (avoiding circular dependency).
+        Silently skips artifacts with empty names.
+        """
+        name = getattr(artifact, "name", "") or ""
+        if not name:
+            log.debug("[skills] skipping artifact with empty name")
+            return
+
+        description = getattr(artifact, "description", "") or ""
+        prompt_template = getattr(artifact, "prompt_template", "") or ""
+        tools_used = getattr(artifact, "tools_used", []) or []
+        source_session_id = getattr(artifact, "source_session_id", "") or ""
+        created_at = str(getattr(artifact, "created_at", ""))
+
+        tools_str = " ".join(tools_used) if isinstance(tools_used, (list, tuple)) else str(tools_used)
+
+        conn = self._open_conn()
+        try:
+            conn.execute(
+                """
+                INSERT INTO skills_fts
+                    (name, description, prompt_template, tools_used, source_session_id, created_at)
+                VALUES (?, ?, ?, ?, ?, ?)
+                """,
+                (name, description, prompt_template, tools_str, source_session_id, created_at),
+            )
+            conn.commit()
+            log.debug("[skills] indexed skill: %s", name)
+        except sqlite3.Error as exc:
+            log.error("[skills] failed to index skill %s: %s", name, exc)
+
+    # ── Read path ─────────────────────────────────────────────────────────────
+
+    def load_skills(self, query: str, k: int = 5) -> list[SkillRecord]:
+        """Return top-k skills matching *query* ranked by FTS5 BM25 relevance.
+
+        Returns an empty list when the database is empty or the query has no
+        FTS5 matches — callers must handle the empty case gracefully.
+
+        BM25 scores in SQLite FTS5 are negative; lower (more negative) = more
+        relevant. Results are ordered ascending so index 0 is the best match.
+
+        Args:
+            query: Free-text query string (user message + recent context).
+            k:     Maximum number of results to return (default 5).
+
+        Returns:
+            List of SkillRecord named tuples ordered best-first.
+        """
+        if not query or not query.strip():
+            return []
+
+        conn = self._open_conn()
+        try:
+            cur = conn.execute(
+                """
+                SELECT name, description, prompt_template, bm25(skills_fts) AS score
+                FROM skills_fts
+                WHERE skills_fts MATCH ?
+                ORDER BY score
+                LIMIT ?
+                """,
+                (query.strip(), k),
+            )
+            rows = cur.fetchall()
+            return [
+                SkillRecord(
+                    name=row["name"],
+                    description=row["description"],
+                    prompt_template=row["prompt_template"],
+                    score=float(row["score"]),
+                )
+                for row in rows
+            ]
+        except sqlite3.OperationalError as exc:
+            # Table may be empty or query syntax invalid
+            log.debug("[skills] FTS5 search error (returning empty): %s", exc)
+            return []
+
+    def rebuild_index(self, artifacts: list[object]) -> None:
+        """Drop all rows and re-index from *artifacts*.
+
+        Useful after schema migration or if the index becomes inconsistent.
+        """
+        conn = self._open_conn()
+        try:
+            conn.execute("DELETE FROM skills_fts")
+            conn.commit()
+        except sqlite3.Error as exc:
+            log.error("[skills] failed to clear FTS table for rebuild: %s", exc)
+            return
+
+        for artifact in artifacts:
+            self.add_skill(artifact)
+
+        log.info("[skills] rebuilt index with %d artifacts", len(artifacts))
+
+    def close(self) -> None:
+        """Close the database connection."""
+        if self._conn is not None:
+            self._conn.close()
+            self._conn = None

--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -34,6 +34,11 @@ class SubagentConfig:
     tools: list[str] = field(default_factory=list)
     disallowed_tools: list[str] = field(default_factory=lambda: ["task"])
     max_turns: int = 30
+    # When False, skill-v1 artifact emission is suppressed even if the caller
+    # passes emit_skill=True to task(). Set to False for subagents whose
+    # workflows should not be captured as reusable skills (e.g. agents that
+    # handle sensitive data or that produce non-deterministic outputs).
+    allow_skill_emission: bool = True
 
 
 WORKER_CONFIG = SubagentConfig(

--- a/tests/middleware/test_audit_redaction_integration.py
+++ b/tests/middleware/test_audit_redaction_integration.py
@@ -1,0 +1,236 @@
+"""Integration tests: verify redaction is applied in AuditMiddleware flow."""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from graph.middleware.redaction import redact
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_tool_message(content: str):
+    msg = MagicMock()
+    msg.content = content
+    return msg
+
+
+def _make_request(name: str, args: dict):
+    req = MagicMock()
+    req.tool_call = {"name": name, "args": args}
+    return req
+
+
+# ---------------------------------------------------------------------------
+# AuditMiddleware sync integration
+# ---------------------------------------------------------------------------
+
+class TestAuditMiddlewareSyncRedaction:
+    """Test that _handle_tool_call applies redaction before audit/tracing."""
+
+    def _build_middleware(self):
+        from graph.middleware.audit import AuditMiddleware
+        return AuditMiddleware()
+
+    def test_bearer_token_in_args_redacted_in_audit(self, tmp_path):
+        """Credentials in tool args must not appear in audit.jsonl."""
+        audit_file = tmp_path / "audit.jsonl"
+
+        from audit import AuditLogger
+        fake_logger = AuditLogger(path=audit_file)
+
+        middleware = self._build_middleware()
+        request = _make_request(
+            "fetch_data",
+            {"Authorization": "Bearer supersecret12345678", "url": "https://example.com"},
+        )
+        result_msg = _make_tool_message("some plain result")
+
+        with (
+            patch("audit.audit_logger", fake_logger),
+            patch("tracing.current_session_id", return_value="sess-1"),
+            patch("tracing.current_trace_id", return_value="trace-1"),
+            patch("tracing.trace_tool_call"),
+            patch("metrics.record_tool_call"),
+        ):
+            middleware._handle_tool_call(request, lambda r: result_msg)
+
+        entries = list(audit_file.read_text().strip().splitlines())
+        assert len(entries) == 1
+        entry = json.loads(entries[0])
+        assert "supersecret12345678" not in json.dumps(entry)
+        assert entry["args"]["Authorization"] == "[REDACTED]"
+
+    def test_openai_key_in_result_redacted_in_audit(self, tmp_path):
+        """OpenAI keys in tool results must not appear in audit.jsonl."""
+        audit_file = tmp_path / "audit.jsonl"
+
+        from audit import AuditLogger
+        fake_logger = AuditLogger(path=audit_file)
+
+        middleware = self._build_middleware()
+        request = _make_request("get_config", {"section": "openai"})
+        secret_key = "sk-TestKeyABCDEFGHIJKLMNOPQR"
+        result_msg = _make_tool_message(f"api_key={secret_key}")
+
+        with (
+            patch("audit.audit_logger", fake_logger),
+            patch("tracing.current_session_id", return_value="sess-2"),
+            patch("tracing.current_trace_id", return_value="trace-2"),
+            patch("tracing.trace_tool_call"),
+            patch("metrics.record_tool_call"),
+        ):
+            middleware._handle_tool_call(request, lambda r: result_msg)
+
+        entries = list(audit_file.read_text().strip().splitlines())
+        entry = json.loads(entries[0])
+        assert secret_key not in json.dumps(entry)
+        assert "[REDACTED]" in entry["result_summary"]
+
+    def test_redaction_applied_to_langfuse_call(self):
+        """trace_tool_call must receive redacted args, not raw credentials."""
+        middleware = self._build_middleware()
+        request = _make_request(
+            "env_fetch",
+            {"OPENAI_API_KEY": "sk-real-key-abcdefghijk12345"},
+        )
+        result_msg = _make_tool_message("ok")
+
+        captured_trace_args = {}
+
+        def fake_trace(tool_name, args, result, duration_ms, success, session_id):
+            captured_trace_args.update(args)
+
+        with (
+            patch("audit.audit_logger") as fake_audit,
+            patch("tracing.current_session_id", return_value="sess-3"),
+            patch("tracing.trace_tool_call", side_effect=fake_trace),
+            patch("metrics.record_tool_call"),
+        ):
+            middleware._handle_tool_call(request, lambda r: result_msg)
+
+        assert captured_trace_args.get("OPENAI_API_KEY") == "[REDACTED]"
+
+    def test_non_sensitive_args_preserved(self, tmp_path):
+        """Non-credential args must pass through unchanged."""
+        audit_file = tmp_path / "audit.jsonl"
+
+        from audit import AuditLogger
+        fake_logger = AuditLogger(path=audit_file)
+
+        middleware = self._build_middleware()
+        request = _make_request("search", {"query": "Python decorators", "limit": 10})
+        result_msg = _make_tool_message("3 results found")
+
+        with (
+            patch("audit.audit_logger", fake_logger),
+            patch("tracing.current_session_id", return_value="sess-4"),
+            patch("tracing.current_trace_id", return_value=""),
+            patch("tracing.trace_tool_call"),
+            patch("metrics.record_tool_call"),
+        ):
+            middleware._handle_tool_call(request, lambda r: result_msg)
+
+        entries = list(audit_file.read_text().strip().splitlines())
+        entry = json.loads(entries[0])
+        assert entry["args"]["query"] == "Python decorators"
+        assert entry["result_summary"] == "3 results found"
+
+
+# ---------------------------------------------------------------------------
+# AuditMiddleware async integration
+# ---------------------------------------------------------------------------
+
+class TestAuditMiddlewareAsyncRedaction:
+    """Test that _ahandle_tool_call applies redaction before audit/tracing."""
+
+    def _build_middleware(self):
+        from graph.middleware.audit import AuditMiddleware
+        return AuditMiddleware()
+
+    async def test_bearer_token_in_args_redacted_async(self, tmp_path):
+        audit_file = tmp_path / "audit.jsonl"
+
+        from audit import AuditLogger
+        fake_logger = AuditLogger(path=audit_file)
+
+        middleware = self._build_middleware()
+        request = _make_request(
+            "async_fetch",
+            {"authorization": "Bearer asynctoken9876543210"},
+        )
+        result_msg = _make_tool_message("result data")
+
+        async def fake_handler(r):
+            return result_msg
+
+        with (
+            patch("audit.audit_logger", fake_logger),
+            patch("tracing.current_session_id", return_value="sess-async-1"),
+            patch("tracing.current_trace_id", return_value="trace-async-1"),
+            patch("tracing.trace_tool_call"),
+            patch("metrics.record_tool_call"),
+        ):
+            await middleware._ahandle_tool_call(request, fake_handler)
+
+        entries = list(audit_file.read_text().strip().splitlines())
+        entry = json.loads(entries[0])
+        assert "asynctoken9876543210" not in json.dumps(entry)
+        assert entry["args"]["authorization"] == "[REDACTED]"
+
+    async def test_exception_path_redacts_args(self):
+        """Even when the tool raises, logged args must be redacted."""
+        middleware = self._build_middleware()
+        request = _make_request(
+            "bad_tool",
+            {"LANGFUSE_SECRET_KEY": "lf_secret_key_abc123def456"},
+        )
+
+        captured_audit_args = {}
+
+        def fake_log(**kwargs):
+            captured_audit_args.update(kwargs.get("args", {}))
+
+        async def raising_handler(r):
+            raise ValueError("tool failure")
+
+        with (
+            patch("audit.audit_logger") as fake_audit,
+            patch("tracing.current_session_id", return_value="sess-exc"),
+            patch("tracing.trace_tool_call"),
+            patch("metrics.record_tool_call"),
+        ):
+            fake_audit.log.side_effect = fake_log
+            with pytest.raises(ValueError):
+                await middleware._ahandle_tool_call(request, raising_handler)
+
+        assert captured_audit_args.get("LANGFUSE_SECRET_KEY") == "[REDACTED]"
+
+
+# ---------------------------------------------------------------------------
+# Standalone redact() contract tests
+# ---------------------------------------------------------------------------
+
+def test_redact_returns_valid_json_serializable_values():
+    """Ensure [REDACTED] placeholder is JSON-safe."""
+    data = {
+        "OPENAI_API_KEY": "sk-secret12345678901234",
+        "normal": "value",
+    }
+    result = redact(data)
+    serialized = json.dumps(result)
+    parsed = json.loads(serialized)
+    assert parsed["OPENAI_API_KEY"] == "[REDACTED]"
+    assert parsed["normal"] == "value"
+
+
+def test_redact_does_not_mutate_original():
+    """redact() must not modify the input dict in place."""
+    original = {"OPENAI_API_KEY": "sk-real-key-1234567890abcdef"}
+    _ = redact(original)
+    assert original["OPENAI_API_KEY"] == "sk-real-key-1234567890abcdef"

--- a/tests/middleware/test_redaction.py
+++ b/tests/middleware/test_redaction.py
@@ -1,0 +1,299 @@
+"""Unit tests for graph.middleware.redaction module."""
+
+import pytest
+
+from graph.middleware.redaction import redact, PATTERNS
+
+
+# ---------------------------------------------------------------------------
+# Pattern presence
+# ---------------------------------------------------------------------------
+
+def test_patterns_dict_has_required_keys():
+    assert "bearer_token" in PATTERNS
+    assert "openai_key" in PATTERNS
+    assert "generic_api_key" in PATTERNS
+    assert "env_var_assignment" in PATTERNS
+    assert len(PATTERNS) >= 4
+
+
+# ---------------------------------------------------------------------------
+# Bearer token
+# ---------------------------------------------------------------------------
+
+def test_bearer_token_in_header_string():
+    s = "Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.payload.signature"
+    result = redact(s)
+    assert "eyJhbGciOiJIUzI1NiJ9" not in result
+    assert "[REDACTED]" in result
+    assert "Authorization" in result
+    assert "Bearer" in result
+
+
+def test_bearer_token_case_insensitive():
+    s = "authorization: bearer mysecrettoken12345"
+    result = redact(s)
+    assert "mysecrettoken12345" not in result
+    assert "[REDACTED]" in result
+
+
+def test_bearer_token_in_dict_value():
+    data = {"headers": "Authorization: Bearer abc123token999"}
+    result = redact(data)
+    assert "abc123token999" not in result["headers"]
+    assert "[REDACTED]" in result["headers"]
+
+
+# ---------------------------------------------------------------------------
+# OpenAI-style API keys (sk-...)
+# ---------------------------------------------------------------------------
+
+def test_openai_key_bare_string():
+    s = "sk-aBcDefGhIjKlMnOpQrStUvWxYz1234"
+    result = redact(s)
+    assert "sk-aBcDefGhIjKlMnOpQrStUvWxYz1234" not in result
+    assert "[REDACTED]" in result
+
+
+def test_openai_key_in_sentence():
+    s = "my key is sk-proj-1234567890abcdefghij and nothing else"
+    result = redact(s)
+    assert "sk-proj-1234567890abcdefghij" not in result
+    assert "[REDACTED]" in result
+
+
+def test_openai_key_in_dict_value():
+    data = {"openai_token": "sk-testKey0000000000000000000000"}
+    result = redact(data)
+    # The dict key is not a sensitive env key, so value redaction via pattern
+    assert "sk-testKey0000000000000000000000" not in str(result)
+    assert "[REDACTED]" in str(result)
+
+
+def test_openai_key_too_short_not_redacted():
+    # Keys shorter than 20 chars after sk- should not be redacted by openai pattern
+    s = "sk-short"
+    result = redact(s)
+    # Should remain unchanged (not matching the pattern)
+    assert result == s
+
+
+# ---------------------------------------------------------------------------
+# Generic api_key
+# ---------------------------------------------------------------------------
+
+def test_generic_api_key_equals():
+    s = 'api_key="abcdefghijklmnopq1234"'
+    result = redact(s)
+    assert "abcdefghijklmnopq1234" not in result
+    assert "[REDACTED]" in result
+
+
+def test_generic_api_key_colon():
+    s = "api_key: xyzXYZ123456789012"
+    result = redact(s)
+    assert "xyzXYZ123456789012" not in result
+    assert "[REDACTED]" in result
+
+
+def test_apikey_no_separator():
+    s = 'apikey="supersecretvalue1234"'
+    result = redact(s)
+    assert "supersecretvalue1234" not in result
+    assert "[REDACTED]" in result
+
+
+# ---------------------------------------------------------------------------
+# Environment variable dict key redaction
+# ---------------------------------------------------------------------------
+
+def test_env_var_redaction_openai():
+    data = {"OPENAI_API_KEY": "sk-real-secret-key-that-is-long"}
+    result = redact(data)
+    assert result["OPENAI_API_KEY"] == "[REDACTED]"
+
+
+def test_env_var_redaction_langfuse_secret():
+    data = {"LANGFUSE_SECRET_KEY": "lf_secret_1234567890abcdef"}
+    result = redact(data)
+    assert result["LANGFUSE_SECRET_KEY"] == "[REDACTED]"
+
+
+def test_env_var_redaction_a2a_auth_token():
+    data = {"A2A_AUTH_TOKEN": "bearer-token-value-here"}
+    result = redact(data)
+    assert result["A2A_AUTH_TOKEN"] == "[REDACTED]"
+
+
+def test_env_var_lowercase_api_key():
+    data = {"api_key": "my_secret_api_key_12345"}
+    result = redact(data)
+    assert result["api_key"] == "[REDACTED]"
+
+
+def test_env_var_authorization_header():
+    data = {"authorization": "Bearer some-jwt-token"}
+    result = redact(data)
+    assert result["authorization"] == "[REDACTED]"
+
+
+def test_non_sensitive_key_unchanged():
+    data = {"url": "https://api.example.com/v1/query", "count": 42}
+    result = redact(data)
+    assert result["url"] == "https://api.example.com/v1/query"
+    assert result["count"] == 42
+
+
+# ---------------------------------------------------------------------------
+# Nested dict traversal
+# ---------------------------------------------------------------------------
+
+def test_nested_dict():
+    data = {
+        "outer": {
+            "inner": {
+                "OPENAI_API_KEY": "secret-key-value-here"
+            }
+        }
+    }
+    result = redact(data)
+    assert result["outer"]["inner"]["OPENAI_API_KEY"] == "[REDACTED]"
+
+
+def test_nested_list():
+    data = {
+        "headers": [
+            "Authorization: Bearer token123456789012345",
+            "Content-Type: application/json",
+        ]
+    }
+    result = redact(data)
+    assert "token123456789012345" not in result["headers"][0]
+    assert "[REDACTED]" in result["headers"][0]
+    assert result["headers"][1] == "Content-Type: application/json"
+
+
+def test_deeply_nested():
+    data = {"a": {"b": {"c": {"d": {"OPENAI_API_KEY": "deep-secret-value"}}}}}
+    result = redact(data)
+    assert result["a"]["b"]["c"]["d"]["OPENAI_API_KEY"] == "[REDACTED]"
+
+
+def test_list_of_dicts():
+    data = [
+        {"OPENAI_API_KEY": "key1value1234567890"},
+        {"url": "https://example.com"},
+        {"Authorization": "Bearer tokenvalue12345"},
+    ]
+    result = redact(data)
+    assert result[0]["OPENAI_API_KEY"] == "[REDACTED]"
+    assert result[1]["url"] == "https://example.com"
+    assert result[2]["Authorization"] == "[REDACTED]"
+
+
+def test_mixed_types_in_list():
+    data = ["Authorization: Bearer tok12345678901234", 42, None, True]
+    result = redact(data)
+    assert "tok12345678901234" not in result[0]
+    assert "[REDACTED]" in result[0]
+    assert result[1] == 42
+    assert result[2] is None
+    assert result[3] is True
+
+
+# ---------------------------------------------------------------------------
+# False positives — legitimate data must not be mangled
+# ---------------------------------------------------------------------------
+
+def test_false_positives_url_with_key():
+    # URL containing 'key' should not be redacted (no credential pattern match)
+    url = "https://maps.example.com/api/v1/geocode?format=json"
+    result = redact(url)
+    assert result == url
+
+
+def test_false_positives_short_values():
+    s = "the key is important"
+    result = redact(s)
+    assert result == s
+
+
+def test_false_positives_numeric_values():
+    data = {"count": 100, "page": 2, "limit": 50}
+    result = redact(data)
+    assert result == data
+
+
+def test_false_positives_normal_text():
+    s = "The query returned 42 results for the search term."
+    result = redact(s)
+    assert result == s
+
+
+def test_false_positives_content_type_header():
+    s = "Content-Type: application/json"
+    result = redact(s)
+    assert result == s
+
+
+# ---------------------------------------------------------------------------
+# Edge cases
+# ---------------------------------------------------------------------------
+
+def test_empty_string():
+    assert redact("") == ""
+
+
+def test_empty_dict():
+    assert redact({}) == {}
+
+
+def test_empty_list():
+    assert redact([]) == []
+
+
+def test_none_value():
+    assert redact(None) is None
+
+
+def test_integer_value():
+    assert redact(42) == 42
+
+
+def test_bool_value():
+    assert redact(True) is True
+
+
+def test_nested_redaction():
+    data = {
+        "tool_args": {
+            "query": "weather in Paris",
+            "api_key": "supersecretvalue12345",
+        },
+        "headers": {
+            "Authorization": "Bearer jwt.token.value123",
+            "Accept": "application/json",
+        },
+    }
+    result = redact(data)
+    assert result["tool_args"]["query"] == "weather in Paris"
+    assert result["tool_args"]["api_key"] == "[REDACTED]"
+    assert result["headers"]["Authorization"] == "[REDACTED]"
+    assert result["headers"]["Accept"] == "application/json"
+
+
+def test_langfuse_redaction():
+    # Simulate a Langfuse span payload
+    payload = {
+        "name": "tool:fetch_secret",
+        "input": {
+            "LANGFUSE_SECRET_KEY": "lf_sk_abc123def456",
+            "query": "get config",
+        },
+        "output": "Authorization: Bearer mytoken1234567890",
+    }
+    result = redact(payload)
+    assert result["input"]["LANGFUSE_SECRET_KEY"] == "[REDACTED]"
+    assert result["input"]["query"] == "get config"
+    assert "mytoken1234567890" not in result["output"]
+    assert "[REDACTED]" in result["output"]

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -1435,3 +1435,198 @@ async def test_rpc_unknown_method_returns_method_not_found():
     body = r.json()
     assert body["error"]["code"] == -32601
     assert "some/bogus/method" in body["error"]["message"]
+
+
+# ── Bearer token authentication tests ─────────────────────────────────────────
+
+
+def _make_auth_test_app(token: str | None = "secret-token"):
+    """Create a test app with A2A_AUTH_TOKEN configured (or unset)."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    card = {"name": "test", "capabilities": {}}
+
+    async def _fake_stream(text, context_id, **kwargs):
+        yield ("text", "hello ")
+        yield ("done", "hello")
+
+    async def _fake_chat(text, session_id):
+        return [{"role": "assistant", "content": "response"}]
+
+    env_patch = {"A2A_AUTH_TOKEN": token} if token is not None else {}
+    with patch.dict("os.environ", env_patch, clear=True if token is None else False):
+        register_a2a_routes(
+            app=app,
+            chat_stream_fn_factory=_fake_stream,
+            chat_fn=_fake_chat,
+            api_key="",
+            agent_card=card,
+        )
+    return app, card
+
+
+@pytest.mark.asyncio
+async def test_missing_bearer_token():
+    """POST /a2a without Authorization header returns 401 when auth is enabled."""
+    app, _ = _make_auth_test_app(token="secret-token")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        })
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_invalid_bearer_token():
+    """POST /a2a with wrong bearer token returns 401."""
+    app, _ = _make_auth_test_app(token="secret-token")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        }, headers={"Authorization": "Bearer wrong-token"})
+    assert resp.status_code == 401
+
+
+@pytest.mark.asyncio
+async def test_valid_bearer_token():
+    """POST /a2a with correct bearer token returns 200 and processes request."""
+    app, _ = _make_auth_test_app(token="secret-token")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        }, headers={"Authorization": "Bearer secret-token"})
+    assert resp.status_code == 200
+    body = resp.json()
+    assert "result" in body
+    assert body["result"]["status"]["state"] == "submitted"
+
+
+@pytest.mark.asyncio
+async def test_auth_disabled_no_token():
+    """When A2A_AUTH_TOKEN is unset, requests pass without Authorization header."""
+    with patch.dict("os.environ", {}, clear=True):
+        from fastapi import FastAPI
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("text", "hello ")
+            yield ("done", "hello")
+
+        async def _fake_chat(text, session_id):
+            return [{"role": "assistant", "content": "response"}]
+
+        # Ensure A2A_AUTH_TOKEN is not set
+        import os
+        os.environ.pop("A2A_AUTH_TOKEN", None)
+
+        register_a2a_routes(
+            app=app,
+            chat_stream_fn_factory=_fake_stream,
+            chat_fn=_fake_chat,
+            api_key="",
+            agent_card=card,
+        )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        })
+    assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_auth_disabled_warning(caplog):
+    """WARNING is logged at startup when A2A_AUTH_TOKEN is not configured."""
+    import logging
+    import os
+    with patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("A2A_AUTH_TOKEN", None)
+        from fastapi import FastAPI
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("done", "")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        with caplog.at_level(logging.WARNING, logger="a2a_handler"):
+            register_a2a_routes(
+                app=app,
+                chat_stream_fn_factory=_fake_stream,
+                chat_fn=_fake_chat,
+                api_key="",
+                agent_card=card,
+            )
+
+    assert any("A2A auth token not configured" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_advertised_in_agent_card():
+    """securitySchemes.bearer is present in agent card when A2A_AUTH_TOKEN is set."""
+    _, card = _make_auth_test_app(token="secret-token")
+    assert "securitySchemes" in card
+    assert card["securitySchemes"]["bearer"]["type"] == "http"
+    assert card["securitySchemes"]["bearer"]["scheme"] == "bearer"
+
+
+@pytest.mark.asyncio
+async def test_bearer_token_not_in_agent_card_when_unset():
+    """securitySchemes is absent from agent card when A2A_AUTH_TOKEN is not set."""
+    import os
+    os.environ.pop("A2A_AUTH_TOKEN", None)
+    with patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("A2A_AUTH_TOKEN", None)
+        _, card = _make_auth_test_app(token=None)
+    assert "securitySchemes" not in card
+
+
+@pytest.mark.asyncio
+async def test_whitespace_only_token_treated_as_unset():
+    """A2A_AUTH_TOKEN with only whitespace is treated as unset (open mode)."""
+    import os
+    with patch.dict("os.environ", {"A2A_AUTH_TOKEN": "   "}, clear=False):
+        from fastapi import FastAPI
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("done", "")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        register_a2a_routes(
+            app=app,
+            chat_stream_fn_factory=_fake_stream,
+            chat_fn=_fake_chat,
+            api_key="",
+            agent_card=card,
+        )
+
+    # With whitespace-only token, no auth required — request succeeds without header
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        })
+    assert resp.status_code == 200
+    assert "securitySchemes" not in card

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -1630,3 +1630,216 @@ async def test_whitespace_only_token_treated_as_unset():
         })
     assert resp.status_code == 200
     assert "securitySchemes" not in card
+
+
+# ── Origin verification ────────────────────────────────────────────────────────
+
+
+def _make_origin_test_app(allowed_origins: str | None):
+    """Build a test FastAPI app with A2A_ALLOWED_ORIGINS configured."""
+    import os
+    from fastapi import FastAPI
+    env = {}
+    if allowed_origins is not None:
+        env["A2A_ALLOWED_ORIGINS"] = allowed_origins
+    else:
+        os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+
+    with patch.dict("os.environ", env, clear=False):
+        if allowed_origins is None:
+            os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+        app = FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("text", "hello")
+            yield ("done", "hello")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        register_a2a_routes(
+            app=app,
+            chat_stream_fn_factory=_fake_stream,
+            chat_fn=_fake_chat,
+            api_key="",
+            agent_card=card,
+        )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_allowed_origin_passes_sse():
+    """SSE stream with matching Origin header is accepted."""
+    app = _make_origin_test_app("https://example.com,https://other.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        async with client.stream(
+            "POST", "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "https://example.com"},
+        ) as resp:
+            assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_rejected_origin_returns_403():
+    """SSE stream with non-matching Origin header receives 403."""
+    app = _make_origin_test_app("https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "https://evil.com"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_unset_origins_warning(caplog):
+    """WARNING is logged at startup when A2A_ALLOWED_ORIGINS is not set."""
+    import logging
+    import os
+    from fastapi import FastAPI as _FastAPI
+    os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+    with patch.dict("os.environ", {}, clear=False):
+        os.environ.pop("A2A_ALLOWED_ORIGINS", None)
+        app = _FastAPI()
+        card = {"name": "test", "capabilities": {}}
+
+        async def _fake_stream(text, context_id, **kwargs):
+            yield ("done", "")
+
+        async def _fake_chat(text, session_id):
+            return []
+
+        with caplog.at_level(logging.WARNING, logger="a2a_handler"):
+            register_a2a_routes(
+                app=app,
+                chat_stream_fn_factory=_fake_stream,
+                chat_fn=_fake_chat,
+                api_key="",
+                agent_card=card,
+            )
+
+    assert any("A2A_ALLOWED_ORIGINS" in r.message for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_wildcard_disables_verification():
+    """A2A_ALLOWED_ORIGINS='*' disables origin verification — any origin passes."""
+    app = _make_origin_test_app("*")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        async with client.stream(
+            "POST", "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "https://anything.example.com"},
+        ) as resp:
+            assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_missing_origin_header_rejected_when_allowlist_set():
+    """Missing Origin header is treated as empty string and rejected when allowlist is set."""
+    app = _make_origin_test_app("https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_origin_case_insensitive():
+    """Origin comparison is case-insensitive (HTTPS://Example.COM matches https://example.com)."""
+    app = _make_origin_test_app("https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        async with client.stream(
+            "POST", "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "HTTPS://Example.COM"},
+        ) as resp:
+            assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_origin_whitespace_trimmed_in_allowlist():
+    """Whitespace around comma-separated origins is trimmed."""
+    app = _make_origin_test_app("  https://example.com  ,  https://other.com  ")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        async with client.stream(
+            "POST", "/a2a",
+            json={
+                "jsonrpc": "2.0", "id": 1, "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            },
+            headers={"Origin": "https://other.com"},
+        ) as resp:
+            assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_rest_message_stream_origin_rejected():
+    """REST POST /message:stream rejects non-matching Origin with 403."""
+    app = _make_origin_test_app("https://example.com")
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post(
+            "/message:stream",
+            json={"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+            headers={"Origin": "https://evil.com"},
+        )
+    assert resp.status_code == 403
+
+
+@pytest.mark.asyncio
+async def test_subscribe_endpoint_origin_rejected():
+    """GET /tasks/{id}:subscribe rejects non-matching Origin with 403."""
+    # First create a task
+    app = _make_origin_test_app("https://example.com")
+
+    # Create a task via unprotected message/send (no origin check on non-streaming)
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test",
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": 1, "method": "message/send",
+            "params": {"message": {"parts": [{"kind": "text", "text": "hi"}]}},
+        })
+        assert resp.status_code == 200
+        task_id = resp.json()["result"]["id"]
+
+        # Now try to subscribe with a bad origin
+        sub_resp = await client.get(
+            f"/tasks/{task_id}:subscribe",
+            headers={"Origin": "https://evil.com"},
+        )
+    assert sub_resp.status_code == 403

--- a/tests/test_memory_load.py
+++ b/tests/test_memory_load.py
@@ -1,0 +1,256 @@
+"""Unit tests for KnowledgeMiddleware.load_memory().
+
+Covers:
+- Successful loading of multiple session summaries
+- Token budget enforcement (oldest sessions truncated first)
+- Missing memory directory returns empty string (not an error)
+- Malformed/unreadable session file is skipped gracefully
+- Empty memory directory returns <prior_sessions/>
+- Disabled knowledge middleware: load_memory() still works as standalone
+- Result is cached after first call (no repeated disk reads)
+- before_model injects prior_sessions block into returned context
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_middleware(knowledge_store=None):
+    """Instantiate KnowledgeMiddleware with a mock store."""
+    from graph.middleware.knowledge import KnowledgeMiddleware
+
+    store = knowledge_store or MagicMock()
+    store.search.return_value = []  # no knowledge hits by default
+    return KnowledgeMiddleware(store, top_k=5)
+
+
+def _write_session(directory: str, session_id: str, content: dict) -> str:
+    """Write a session summary JSON file and return its path."""
+    fpath = os.path.join(directory, f"{session_id}.json")
+    with open(fpath, "w", encoding="utf-8") as fh:
+        json.dump(content, fh)
+    return fpath
+
+
+def _sample_session(session_id: str = "s1", timestamp: str = "2024-01-01T00:00:00+00:00") -> dict:
+    return {
+        "session_id": session_id,
+        "trace_id": f"trace-{session_id}",
+        "messages": [
+            {"role": "user", "content": "Hello"},
+            {"role": "assistant", "content": "Hi there!"},
+        ],
+        "tool_calls": [],
+        "final_output": "Hi there!",
+        "timestamp": timestamp,
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Missing directory — returns empty string, does not raise
+# ---------------------------------------------------------------------------
+
+def test_load_memory_missing_directory():
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path="/tmp/nonexistent_protoagent_memory_xyz_999/")
+    assert result == "", f"Expected empty string for missing dir, got: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Empty directory — returns <prior_sessions/>
+# ---------------------------------------------------------------------------
+
+def test_load_memory_empty_directory(tmp_path):
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+    assert result == "<prior_sessions/>", f"Expected empty tag, got: {result!r}"
+
+
+# ---------------------------------------------------------------------------
+# 3. Single valid session — appears in output
+# ---------------------------------------------------------------------------
+
+def test_load_memory_single_session(tmp_path):
+    _write_session(str(tmp_path), "sess-1", _sample_session("sess-1"))
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+
+    assert "<prior_sessions>" in result
+    assert 'id="sess-1"' in result
+    assert "Hello" in result
+    assert "Hi there!" in result
+
+
+# ---------------------------------------------------------------------------
+# 4. Multiple sessions — all appear when within budget
+# ---------------------------------------------------------------------------
+
+def test_load_memory_multiple_sessions(tmp_path):
+    for i in range(3):
+        _write_session(str(tmp_path), f"sess-{i}", _sample_session(f"sess-{i}"))
+
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+
+    assert result.count("<session") == 3
+
+
+# ---------------------------------------------------------------------------
+# 5. Token budget enforcement — oldest sessions truncated first
+# ---------------------------------------------------------------------------
+
+def test_load_memory_token_budget_drops_oldest(tmp_path):
+    # Write 5 sessions with enough per-session content to trigger budget enforcement.
+    # The formatter truncates final_output to 300 and each message to 500 chars.
+    # Per-session formatted size: ~50 (XML tag) + 500 (user) + 500 (asst) + 300 (final) + overhead
+    # ≈ 1400 chars → ~350 tokens per session.  5 sessions → ~1750 tokens.
+    # We use max_tokens=700 (budget for ~2 sessions) so budget enforcement fires.
+
+    for i in range(5):
+        session = _sample_session(f"sess-{i}", f"2024-01-0{i + 1}T00:00:00+00:00")
+        session["messages"] = [
+            {"role": "user", "content": "Q" * 500},
+            {"role": "assistant", "content": "A" * 500},
+        ]
+        session["final_output"] = "F" * 300
+        fpath = _write_session(str(tmp_path), f"sess-{i}", session)
+        # Space out mtimes so ordering is deterministic: sess-4 is newest
+        os.utime(fpath, (1000 + i, 1000 + i))
+
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path), max_sessions=5, max_tokens=700)
+
+    # Budget must be respected
+    token_count = max(1, len(result) // 4)
+    assert token_count <= 700, f"Token budget exceeded: ~{token_count} tokens"
+
+    # At least one session should survive (newest)
+    session_count = result.count("<session")
+    assert session_count >= 1, "Expected at least one session within budget"
+
+    # Fewer than 5 sessions should be present (budget enforcement dropped some)
+    assert session_count < 5, f"Expected budget enforcement to drop some sessions, got {session_count}"
+
+
+def test_load_memory_respects_max_sessions(tmp_path):
+    for i in range(15):
+        _write_session(str(tmp_path), f"sess-{i}", _sample_session(f"sess-{i}"))
+
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path), max_sessions=5, max_tokens=100_000)
+
+    assert result.count("<session") <= 5
+
+
+# ---------------------------------------------------------------------------
+# 6. Malformed session file — skipped, other sessions still loaded
+# ---------------------------------------------------------------------------
+
+def test_load_memory_skips_malformed_file(tmp_path):
+    # Write one good session
+    _write_session(str(tmp_path), "good", _sample_session("good"))
+
+    # Write a malformed JSON file
+    bad_path = os.path.join(str(tmp_path), "bad.json")
+    with open(bad_path, "w") as fh:
+        fh.write("this is not json {{{")
+
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+
+    assert "<prior_sessions>" in result
+    assert 'id="good"' in result
+    # Bad session should not appear
+    assert 'id="bad"' not in result
+
+
+# ---------------------------------------------------------------------------
+# 7. Result is cached after first load_memory call
+# ---------------------------------------------------------------------------
+
+def test_load_memory_cache_via_before_model(tmp_path):
+    _write_session(str(tmp_path), "cached-sess", _sample_session("cached-sess"))
+
+    mw = _make_middleware()
+    # Monkey-patch load_memory to count calls
+    call_count = {"n": 0}
+    original = mw.load_memory
+
+    def counting_load(**kw):
+        call_count["n"] += 1
+        return original(**kw)
+
+    mw.load_memory = counting_load
+
+    state = {"messages": []}
+
+    # Trigger before_model twice
+    mw.before_model(state, runtime=None)
+    mw.before_model(state, runtime=None)
+
+    # load_memory should only have been called once (cache hit on second call)
+    assert call_count["n"] == 1, (
+        f"load_memory called {call_count['n']} times — expected 1 (cached)"
+    )
+
+
+# ---------------------------------------------------------------------------
+# 8. before_model injects prior_sessions into returned context
+# ---------------------------------------------------------------------------
+
+def test_before_model_injects_prior_sessions(tmp_path):
+    _write_session(str(tmp_path), "inject-sess", _sample_session("inject-sess"))
+
+    mw = _make_middleware()
+    # Override load_memory to use tmp_path
+    mw._prior_sessions_cache = mw.load_memory(memory_path=str(tmp_path))
+
+    from langchain_core.messages import HumanMessage
+    state = {"messages": [HumanMessage(content="What did we discuss?")]}
+
+    result = mw.before_model(state, runtime=None)
+    assert result is not None
+    assert "<prior_sessions>" in result.get("context", "")
+    assert 'id="inject-sess"' in result["context"]
+
+
+# ---------------------------------------------------------------------------
+# 9. Disabled memory (no sessions) yields empty block or empty string
+# ---------------------------------------------------------------------------
+
+def test_load_memory_no_sessions_yields_empty_tag(tmp_path):
+    mw = _make_middleware()
+    result = mw.load_memory(memory_path=str(tmp_path))
+    # Empty dir → empty self-closing tag (not a full block)
+    assert result == "<prior_sessions/>"
+
+
+# ---------------------------------------------------------------------------
+# 10. load_memory() works as a standalone call without a knowledge store
+# ---------------------------------------------------------------------------
+
+def test_load_memory_standalone_no_knowledge_store(tmp_path):
+    """load_memory() does not touch self._store — it should work independently."""
+    _write_session(str(tmp_path), "standalone", _sample_session("standalone"))
+
+    # Pass a store that raises on any call to ensure load_memory doesn't use it
+    broken_store = MagicMock()
+    broken_store.search.side_effect = RuntimeError("store should not be called")
+
+    from graph.middleware.knowledge import KnowledgeMiddleware
+    mw = KnowledgeMiddleware(broken_store, top_k=5)
+    result = mw.load_memory(memory_path=str(tmp_path))
+
+    assert "<prior_sessions>" in result
+    assert "standalone" in result

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -1,0 +1,394 @@
+"""Unit tests for graph.middleware.memory._persist_session.
+
+Covers:
+- successful file persistence with correct JSON structure
+- atomic write resilience (temp file cleanup, no partial writes visible)
+- opt-out when PROTOAGENT_DISABLE_MEMORY=1
+- custom MEMORY_PATH override
+- automatic directory creation
+- graceful handling of permission errors
+- tool_calls count and top-5 duration sorting
+- empty session handling
+"""
+
+from __future__ import annotations
+
+import importlib
+import json
+import os
+import sys
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _reload_memory(env_overrides: dict | None = None):
+    """Reload graph.middleware.memory with given env overrides active.
+
+    Returns the freshly-imported module so tests can call _persist_session
+    with a known MEMORY_PATH / PROTOAGENT_DISABLE_MEMORY state.
+    """
+    env_overrides = env_overrides or {}
+    with patch.dict(os.environ, env_overrides, clear=False):
+        if "graph.middleware.memory" in sys.modules:
+            del sys.modules["graph.middleware.memory"]
+        import graph.middleware.memory as mod
+        return mod
+
+
+def _make_state(
+    session_id: str = "test-session-1",
+    messages=None,
+):
+    """Build a minimal state dict as the middleware would see it."""
+    if messages is None:
+        messages = [
+            HumanMessage(content="Hello"),
+            AIMessage(content="Hi there! How can I help you today? " * 5),
+        ]
+    return {
+        "session_id": session_id,
+        "messages": messages,
+        "context": "",
+        "captured_messages": [],
+    }
+
+
+# ---------------------------------------------------------------------------
+# 1. Successful persistence with correct JSON structure
+# ---------------------------------------------------------------------------
+
+def test_persist_session_creates_json_file(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = _make_state("abc-123")
+    with patch("tracing.current_trace_id", return_value="trace-xyz"):
+        mod._persist_session(state, "trace-xyz")
+
+    expected = tmp_path / "abc-123.json"
+    assert expected.exists(), "session JSON file was not created"
+
+    data = json.loads(expected.read_text())
+    assert data["session_id"] == "abc-123"
+    assert data["trace_id"] == "trace-xyz"
+    assert isinstance(data["messages"], list)
+    assert isinstance(data["tool_calls"], list)
+    assert "timestamp" in data
+
+
+def test_persist_session_json_has_required_fields(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = _make_state("req-fields")
+    with patch("tracing.current_trace_id", return_value="t1"):
+        mod._persist_session(state, "t1")
+
+    data = json.loads((tmp_path / "req-fields.json").read_text())
+    for key in ("session_id", "trace_id", "messages", "tool_calls", "final_output", "timestamp"):
+        assert key in data, f"missing required field: {key}"
+
+
+def test_persist_session_captures_messages(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    messages = [
+        HumanMessage(content="What is 2+2?"),
+        AIMessage(content="The answer is 4."),
+    ]
+    state = _make_state("msg-test", messages=messages)
+    mod._persist_session(state, "t2")
+
+    data = json.loads((tmp_path / "msg-test.json").read_text())
+    roles = [m["role"] for m in data["messages"]]
+    assert "user" in roles
+    assert "assistant" in roles
+    contents = [m["content"] for m in data["messages"]]
+    assert any("2+2" in c for c in contents)
+    assert any("4" in c for c in contents)
+
+
+def test_persist_session_final_output_is_last_ai_message(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    messages = [
+        HumanMessage(content="Hi"),
+        AIMessage(content="First reply."),
+        HumanMessage(content="Tell me more"),
+        AIMessage(content="This is the final answer."),
+    ]
+    state = _make_state("final-out", messages=messages)
+    mod._persist_session(state, "t3")
+
+    data = json.loads((tmp_path / "final-out.json").read_text())
+    assert data["final_output"] == "This is the final answer."
+
+
+# ---------------------------------------------------------------------------
+# 2. Atomic write — no partial file visible
+# ---------------------------------------------------------------------------
+
+def test_atomic_write_no_partial_file_on_error(tmp_path):
+    """If json.dump fails mid-write, no corrupted file should exist at dest."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = _make_state("atomic-test")
+    dest = tmp_path / "atomic-test.json"
+
+    original_json_dump = json.dump
+
+    def bad_dump(*args, **kwargs):
+        raise OSError("simulated write error")
+
+    with patch("json.dump", side_effect=bad_dump):
+        mod._persist_session(state, "t4")
+
+    # Destination file must NOT exist — no partial write
+    assert not dest.exists(), "partial file should not be visible on write failure"
+
+    # No .tmp files left behind
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert len(tmp_files) == 0, f"temp files not cleaned up: {tmp_files}"
+
+
+def test_atomic_write_succeeds_with_valid_rename(tmp_path):
+    """After a successful write, only the final .json file exists."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = _make_state("rename-test")
+    mod._persist_session(state, "t5")
+
+    assert (tmp_path / "rename-test.json").exists()
+    tmp_files = list(tmp_path.glob("*.tmp"))
+    assert len(tmp_files) == 0, "temp files should be cleaned up after successful write"
+
+
+# ---------------------------------------------------------------------------
+# 3. Opt-out via PROTOAGENT_DISABLE_MEMORY
+# ---------------------------------------------------------------------------
+
+def test_disabled_by_env_var(tmp_path):
+    mod = _reload_memory({
+        "MEMORY_PATH": str(tmp_path),
+        "PROTOAGENT_DISABLE_MEMORY": "1",
+    })
+
+    state = _make_state("disabled-session")
+    mod._persist_session(state, "t6")
+
+    # No file should be created
+    assert not list(tmp_path.glob("*.json")), "no file should be written when disabled"
+
+
+@pytest.mark.parametrize("value", ["1", "true", "True"])
+def test_disabled_by_env_var_variants(tmp_path, value):
+    mod = _reload_memory({
+        "MEMORY_PATH": str(tmp_path),
+        "PROTOAGENT_DISABLE_MEMORY": value,
+    })
+
+    state = _make_state("disabled-variant")
+    mod._persist_session(state, "t7")
+
+    assert not list(tmp_path.glob("*.json")), f"no file should be written for PROTOAGENT_DISABLE_MEMORY={value!r}"
+
+
+# ---------------------------------------------------------------------------
+# 4. Custom MEMORY_PATH override
+# ---------------------------------------------------------------------------
+
+def test_custom_memory_path(tmp_path):
+    custom = tmp_path / "custom" / "path"
+    mod = _reload_memory({
+        "MEMORY_PATH": str(custom),
+        "PROTOAGENT_DISABLE_MEMORY": "",
+    })
+
+    state = _make_state("custom-path-session")
+    mod._persist_session(state, "t8")
+
+    expected = custom / "custom-path-session.json"
+    assert expected.exists(), f"file not written to custom path: {expected}"
+    data = json.loads(expected.read_text())
+    assert data["session_id"] == "custom-path-session"
+
+
+# ---------------------------------------------------------------------------
+# 5. Automatic directory creation
+# ---------------------------------------------------------------------------
+
+def test_directory_auto_created(tmp_path):
+    nested = tmp_path / "a" / "b" / "c"
+    assert not nested.exists(), "pre-condition: directory should not exist yet"
+
+    mod = _reload_memory({
+        "MEMORY_PATH": str(nested),
+        "PROTOAGENT_DISABLE_MEMORY": "",
+    })
+
+    state = _make_state("mkdir-session")
+    mod._persist_session(state, "t9")
+
+    assert nested.exists(), "directory should have been created automatically"
+    assert (nested / "mkdir-session.json").exists()
+
+
+# ---------------------------------------------------------------------------
+# 6. Graceful permission error handling
+# ---------------------------------------------------------------------------
+
+def test_permission_error_does_not_raise(tmp_path):
+    """If makedirs raises PermissionError, persist_session must not raise."""
+    mod = _reload_memory({
+        "MEMORY_PATH": str(tmp_path / "no-perms"),
+        "PROTOAGENT_DISABLE_MEMORY": "",
+    })
+
+    state = _make_state("perm-session")
+
+    with patch("os.makedirs", side_effect=OSError("Permission denied")):
+        # Must not raise
+        mod._persist_session(state, "t10")
+
+
+def test_write_error_does_not_raise(tmp_path):
+    """If the write itself fails (disk full etc.), persist_session must not raise."""
+    mod = _reload_memory({
+        "MEMORY_PATH": str(tmp_path),
+        "PROTOAGENT_DISABLE_MEMORY": "",
+    })
+
+    state = _make_state("write-err-session")
+
+    with patch("os.rename", side_effect=OSError("No space left on device")):
+        # Must not raise
+        mod._persist_session(state, "t11")
+
+
+# ---------------------------------------------------------------------------
+# 7. Tool call count and top-5 by duration sorting
+# ---------------------------------------------------------------------------
+
+def _ai_msg_with_tool_calls(tool_calls: list[dict]) -> AIMessage:
+    """Build an AIMessage that carries tool_calls metadata."""
+    msg = AIMessage(content="")
+    msg.tool_calls = tool_calls
+    return msg
+
+
+def _tool_msg(tool_call_id: str, content: str) -> ToolMessage:
+    return ToolMessage(content=content, tool_call_id=tool_call_id)
+
+
+def test_tool_calls_included_in_summary(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    tc1 = {"id": "tc1", "name": "search", "args": {"query": "python"}}
+    tc2 = {"id": "tc2", "name": "calculator", "args": {"expression": "1+1"}}
+    messages = [
+        HumanMessage(content="Do something"),
+        _ai_msg_with_tool_calls([tc1, tc2]),
+        _tool_msg("tc1", "search result"),
+        _tool_msg("tc2", "2"),
+        AIMessage(content="Done."),
+    ]
+    state = _make_state("tool-test", messages=messages)
+    mod._persist_session(state, "t12")
+
+    data = json.loads((tmp_path / "tool-test.json").read_text())
+    assert len(data["tool_calls"]) == 2
+    names = {tc["name"] for tc in data["tool_calls"]}
+    assert names == {"search", "calculator"}
+
+
+def test_tool_calls_total_count_when_more_than_5(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    # 7 tool calls
+    tcs = [{"id": f"tc{i}", "name": f"tool_{i}", "args": {}} for i in range(7)]
+    tool_msgs = [_tool_msg(f"tc{i}", f"result {i}") for i in range(7)]
+    messages = [
+        HumanMessage(content="Do things"),
+        _ai_msg_with_tool_calls(tcs),
+        *tool_msgs,
+        AIMessage(content="All done."),
+    ]
+    state = _make_state("many-tools", messages=messages)
+    mod._persist_session(state, "t13")
+
+    data = json.loads((tmp_path / "many-tools.json").read_text())
+    assert len(data["tool_calls"]) == 5
+    assert data["tool_calls_total_count"] == 7
+
+
+def test_tool_calls_no_total_count_when_5_or_fewer(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    tcs = [{"id": f"tc{i}", "name": f"tool_{i}", "args": {}} for i in range(3)]
+    tool_msgs = [_tool_msg(f"tc{i}", f"result {i}") for i in range(3)]
+    messages = [
+        HumanMessage(content="Do 3 things"),
+        _ai_msg_with_tool_calls(tcs),
+        *tool_msgs,
+        AIMessage(content="Done."),
+    ]
+    state = _make_state("few-tools", messages=messages)
+    mod._persist_session(state, "t14")
+
+    data = json.loads((tmp_path / "few-tools.json").read_text())
+    assert len(data["tool_calls"]) == 3
+    assert "tool_calls_total_count" not in data
+
+
+# ---------------------------------------------------------------------------
+# 8. Empty session
+# ---------------------------------------------------------------------------
+
+def test_empty_session_creates_file_with_empty_arrays(tmp_path):
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    state = {
+        "session_id": "empty-session",
+        "messages": [],
+        "context": "",
+        "captured_messages": [],
+    }
+    mod._persist_session(state, "t15")
+
+    expected = tmp_path / "empty-session.json"
+    assert expected.exists(), "file should be created even for empty session"
+
+    data = json.loads(expected.read_text())
+    assert data["session_id"] == "empty-session"
+    assert data["messages"] == []
+    assert data["tool_calls"] == []
+    assert data["final_output"] is None
+    assert "timestamp" in data
+
+
+# ---------------------------------------------------------------------------
+# 9. on_session_end middleware hook
+# ---------------------------------------------------------------------------
+
+def test_on_session_end_calls_persist_session(tmp_path):
+    """MemoryMiddleware.on_session_end must call _persist_session."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    store = MagicMock()
+    mw = mod.MemoryMiddleware(knowledge_store=store)
+
+    state = _make_state("hook-session")
+    runtime = MagicMock()
+
+    with patch.object(mod, "_persist_session") as mock_persist, \
+         patch("tracing.current_trace_id", return_value="trace-hook"):
+        result = mw.on_session_end(state, runtime)
+
+    mock_persist.assert_called_once_with(state, "trace-hook")
+    assert result is None

--- a/tests/test_skill_curator.py
+++ b/tests/test_skill_curator.py
@@ -1,0 +1,419 @@
+"""Unit tests for graph.skills.curator.
+
+Covers:
+- Confidence decay calculations (50% after 90 days idle)
+- Deduplication via Jaccard similarity clustering
+- Pruning of low-confidence skills
+- Audit log writing
+- Full curator run on a fixture skill set
+"""
+
+from __future__ import annotations
+
+import json
+import math
+import os
+import tempfile
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from graph.skills.curator import (
+    HALF_LIFE_DAYS,
+    PRUNE_THRESHOLD,
+    SIMILARITY_THRESHOLD,
+    SkillCurator,
+    _clamp,
+    _jaccard,
+    _parse_iso,
+)
+
+
+# ── Helpers ────────────────────────────────────────────────────────────────────
+
+
+def _utc_iso(days_ago: float = 0) -> str:
+    dt = datetime.now(timezone.utc) - timedelta(days=days_ago)
+    return dt.isoformat()
+
+
+def _make_skill(
+    name: str = "test skill",
+    description: str = "does something useful",
+    confidence: float = 1.0,
+    days_ago: float = 0,
+    last_used_days_ago: float | None = None,
+    skill_id: str | None = None,
+) -> dict:
+    """Return a minimal well-formed skill dict."""
+    skill: dict = {
+        "id": skill_id or str(uuid.uuid4()),
+        "name": name,
+        "description": description,
+        "prompt_template": f"Run the {name} workflow.",
+        "tools_used": ["echo"],
+        "confidence": confidence,
+        "created_at": _utc_iso(days_ago),
+    }
+    if last_used_days_ago is not None:
+        skill["last_used"] = _utc_iso(last_used_days_ago)
+    return skill
+
+
+def _write_index(path: str, skills: list[dict]) -> None:
+    with open(path, "w", encoding="utf-8") as fh:
+        for s in skills:
+            fh.write(json.dumps(s) + "\n")
+
+
+# ── _clamp ─────────────────────────────────────────────────────────────────────
+
+
+class TestClamp:
+    def test_value_in_range(self):
+        assert _clamp(0.5) == 0.5
+
+    def test_value_below_zero(self):
+        assert _clamp(-0.1) == 0.0
+
+    def test_value_above_one(self):
+        assert _clamp(1.5) == 1.0
+
+    def test_nan_clamps_to_lo(self):
+        result = _clamp(float("nan"))
+        assert result == 0.0
+
+    def test_infinity_clamps_to_one(self):
+        result = _clamp(float("inf"))
+        assert result == 1.0
+
+    def test_negative_infinity_clamps_to_zero(self):
+        result = _clamp(float("-inf"))
+        assert result == 0.0
+
+
+# ── _jaccard ──────────────────────────────────────────────────────────────────
+
+
+class TestJaccard:
+    def test_identical_strings(self):
+        assert _jaccard("hello world", "hello world") == 1.0
+
+    def test_disjoint_strings(self):
+        assert _jaccard("foo bar", "baz qux") == 0.0
+
+    def test_partial_overlap(self):
+        # {"search", "web"} ∩ {"search", "results"} = {"search"} → 1/3
+        sim = _jaccard("web search", "search results")
+        assert abs(sim - 1 / 3) < 1e-9
+
+    def test_empty_strings(self):
+        assert _jaccard("", "") == 1.0
+
+    def test_case_insensitive(self):
+        assert _jaccard("Hello World", "hello world") == 1.0
+
+
+# ── Confidence decay ──────────────────────────────────────────────────────────
+
+
+class TestConfidenceDecay:
+    def _curator(self, **kwargs) -> SkillCurator:
+        return SkillCurator(
+            index_path="/dev/null",
+            audit_path="/dev/null",
+            dry_run=True,
+            **kwargs,
+        )
+
+    def test_no_decay_when_fresh(self):
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, days_ago=0)
+        report = curator._apply_decay([skill])
+        assert report == []
+        assert skill["confidence"] == 1.0
+
+    def test_half_life_90_days(self):
+        """After 90 days idle the confidence should halve."""
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, last_used_days_ago=90)
+        curator._apply_decay([skill])
+        assert abs(skill["confidence"] - 0.5) < 1e-6
+
+    def test_half_life_180_days(self):
+        """After 180 days idle the confidence should be ~0.25."""
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, last_used_days_ago=180)
+        curator._apply_decay([skill])
+        assert abs(skill["confidence"] - 0.25) < 1e-6
+
+    def test_partial_decay(self):
+        """After 45 days the confidence is 0.5^(45/90) = sqrt(0.5) ≈ 0.7071."""
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, last_used_days_ago=45)
+        curator._apply_decay([skill])
+        expected = 0.5 ** (45 / 90)
+        assert abs(skill["confidence"] - expected) < 1e-6
+
+    def test_decay_uses_last_used_over_created_at(self):
+        """last_used timestamp takes priority over created_at."""
+        curator = self._curator()
+        # created 180 days ago but used 10 days ago
+        skill = _make_skill(
+            confidence=1.0, days_ago=180, last_used_days_ago=10
+        )
+        curator._apply_decay([skill])
+        expected = 0.5 ** (10 / 90)
+        assert abs(skill["confidence"] - expected) < 1e-6
+
+    def test_decay_falls_back_to_created_at(self):
+        """When last_used is absent, created_at is used as proxy."""
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, days_ago=90)
+        # no last_used key
+        assert "last_used" not in skill
+        curator._apply_decay([skill])
+        assert abs(skill["confidence"] - 0.5) < 1e-6
+
+    def test_custom_half_life(self):
+        curator = self._curator(half_life_days=30)
+        skill = _make_skill(confidence=1.0, last_used_days_ago=30)
+        curator._apply_decay([skill])
+        assert abs(skill["confidence"] - 0.5) < 1e-6
+
+    def test_report_entries(self):
+        curator = self._curator()
+        skill = _make_skill(confidence=1.0, last_used_days_ago=90)
+        report = curator._apply_decay([skill])
+        assert len(report) == 1
+        entry = report[0]
+        assert entry["id"] == skill["id"]
+        assert abs(entry["old"] - 1.0) < 1e-3
+        assert abs(entry["new"] - 0.5) < 1e-3
+
+
+# ── Deduplication ─────────────────────────────────────────────────────────────
+
+
+class TestDeduplication:
+    def _curator(self, threshold: float = SIMILARITY_THRESHOLD) -> SkillCurator:
+        return SkillCurator(
+            index_path="/dev/null",
+            audit_path="/dev/null",
+            dry_run=True,
+            similarity_threshold=threshold,
+        )
+
+    def test_no_duplicates(self):
+        curator = self._curator()
+        skills = [
+            _make_skill("web search tool", "searches the web for info"),
+            _make_skill("calculator tool", "performs arithmetic operations"),
+        ]
+        report = curator._deduplicate(skills)
+        assert report == []
+        assert len(skills) == 2
+
+    def test_exact_duplicates_kept_higher_confidence(self):
+        """Two identical skills: the one with higher confidence survives."""
+        curator = self._curator(threshold=0.9)
+        id_a, id_b = str(uuid.uuid4()), str(uuid.uuid4())
+        skills = [
+            _make_skill("web search", "searches the web", confidence=0.6, skill_id=id_a),
+            _make_skill("web search", "searches the web", confidence=0.9, skill_id=id_b),
+        ]
+        report = curator._deduplicate(skills)
+        assert len(report) == 1
+        assert report[0]["kept"] == id_b
+        assert id_a in report[0]["removed"]
+        assert len(skills) == 1
+        assert skills[0]["id"] == id_b
+
+    def test_dissimilar_skills_not_merged(self):
+        curator = self._curator(threshold=0.8)
+        skills = [
+            _make_skill("web scraper", "scrapes HTML from URLs"),
+            _make_skill("database query", "runs SQL against Postgres"),
+        ]
+        report = curator._deduplicate(skills)
+        assert report == []
+        assert len(skills) == 2
+
+    def test_three_similar_skills_one_survives(self):
+        """Three very similar skills → only the highest-confidence one survives."""
+        curator = self._curator(threshold=0.5)
+        ids = [str(uuid.uuid4()) for _ in range(3)]
+        skills = [
+            _make_skill("fetch url content", "fetches and returns URL content", confidence=0.5, skill_id=ids[0]),
+            _make_skill("fetch url page", "fetches and returns URL page", confidence=0.7, skill_id=ids[1]),
+            _make_skill("fetch url data", "fetches and returns URL data", confidence=0.6, skill_id=ids[2]),
+        ]
+        report = curator._deduplicate(skills)
+        # At least one cluster with a removal
+        removed_total = sum(len(r["removed"]) for r in report)
+        assert removed_total >= 1
+        # The surviving skill(s) should all have id from the original set
+        for s in skills:
+            assert s["id"] in ids
+
+
+# ── Pruning ────────────────────────────────────────────────────────────────────
+
+
+class TestPruning:
+    def _curator(self, threshold: float = PRUNE_THRESHOLD) -> SkillCurator:
+        return SkillCurator(
+            index_path="/dev/null",
+            audit_path="/dev/null",
+            dry_run=True,
+            prune_threshold=threshold,
+        )
+
+    def test_no_pruning_above_threshold(self):
+        curator = self._curator()
+        skills = [_make_skill(confidence=0.5), _make_skill(confidence=0.9)]
+        report, surviving = curator._prune(skills)
+        assert report == []
+        assert len(surviving) == 2
+
+    def test_prune_below_threshold(self):
+        curator = self._curator()
+        low = _make_skill(confidence=0.1)
+        high = _make_skill(confidence=0.8)
+        report, surviving = curator._prune([low, high])
+        assert len(report) == 1
+        assert report[0]["id"] == low["id"]
+        assert len(surviving) == 1
+        assert surviving[0]["id"] == high["id"]
+
+    def test_prune_at_threshold_boundary(self):
+        """Confidence exactly equal to threshold is kept (not pruned)."""
+        curator = self._curator(threshold=0.2)
+        at_threshold = _make_skill(confidence=0.2)
+        report, surviving = curator._prune([at_threshold])
+        assert report == []
+        assert len(surviving) == 1
+
+    def test_prune_all(self):
+        curator = self._curator(threshold=0.5)
+        skills = [_make_skill(confidence=0.1), _make_skill(confidence=0.3)]
+        report, surviving = curator._prune(skills)
+        assert len(report) == 2
+        assert surviving == []
+
+    def test_prune_report_contains_name_and_confidence(self):
+        curator = self._curator()
+        skill = _make_skill(name="stale skill", confidence=0.05)
+        report, _ = curator._prune([skill])
+        assert report[0]["name"] == "stale skill"
+        assert "confidence" in report[0]
+
+
+# ── Full run on fixture ───────────────────────────────────────────────────────
+
+
+class TestCuratorRun:
+    def test_dry_run_does_not_write_files(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+        skills = [_make_skill(confidence=1.0, days_ago=0)]
+        _write_index(index, skills)
+
+        curator = SkillCurator(
+            index_path=index,
+            audit_path=audit,
+            dry_run=True,
+        )
+        curator.run()
+        # Audit file should NOT be created in dry_run mode
+        assert not os.path.exists(audit)
+
+    def test_full_run_writes_audit(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+        skills = [_make_skill(confidence=1.0)]
+        _write_index(index, skills)
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
+        curator.run()
+
+        assert os.path.exists(audit)
+        with open(audit) as fh:
+            entry = json.loads(fh.readline())
+        assert "run_id" in entry
+        assert entry["dry_run"] is False
+
+    def test_missing_index_produces_empty_run(self, tmp_path):
+        audit = str(tmp_path / "audit.jsonl")
+        curator = SkillCurator(
+            index_path=str(tmp_path / "nonexistent.jsonl"),
+            audit_path=audit,
+            dry_run=False,
+        )
+        entry = curator.run()
+        assert entry["skills_before"] == 0
+        assert entry["skills_after"] == 0
+
+    def test_decay_then_prune_pipeline(self, tmp_path):
+        """A skill idle for >300 days should be pruned in a full run."""
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+
+        # After 300 days: 0.5^(300/90) ≈ 0.099 < 0.2 → should be pruned
+        old_skill = _make_skill(confidence=1.0, last_used_days_ago=300)
+        fresh_skill = _make_skill(confidence=0.9, last_used_days_ago=5)
+        _write_index(index, [old_skill, fresh_skill])
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
+        entry = curator.run()
+
+        assert entry["skills_before"] == 2
+        assert entry["skills_after"] == 1
+        assert len(entry["pruned"]) == 1
+        assert entry["pruned"][0]["id"] == old_skill["id"]
+
+    def test_audit_entry_structure(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+        _write_index(index, [_make_skill()])
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
+        entry = curator.run()
+
+        required_keys = {
+            "run_id", "timestamp", "dry_run", "skills_before",
+            "skills_after", "decay_applied", "deduplicated", "pruned",
+        }
+        assert required_keys.issubset(entry.keys())
+
+    def test_malformed_index_lines_are_skipped(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+
+        with open(index, "w") as fh:
+            fh.write("not json\n")
+            fh.write(json.dumps(_make_skill()) + "\n")
+            fh.write("{incomplete\n")
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=True)
+        entry = curator.run()
+        # Only the valid skill should be loaded
+        assert entry["skills_before"] == 1
+
+    def test_index_persisted_after_run(self, tmp_path):
+        index = str(tmp_path / "index.jsonl")
+        audit = str(tmp_path / "audit.jsonl")
+
+        # Create two skills; one will be pruned (low confidence, old)
+        old_skill = _make_skill(confidence=1.0, last_used_days_ago=300)
+        fresh_skill = _make_skill(confidence=0.9, last_used_days_ago=2)
+        _write_index(index, [old_skill, fresh_skill])
+
+        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
+        curator.run()
+
+        with open(index) as fh:
+            remaining = [json.loads(l) for l in fh if l.strip()]
+        assert len(remaining) == 1
+        assert remaining[0]["id"] == fresh_skill["id"]

--- a/tests/test_skill_emission.py
+++ b/tests/test_skill_emission.py
@@ -1,0 +1,358 @@
+"""Unit tests for skill-v1 artifact emission from task() subagent completions.
+
+Covers:
+- SkillV1Artifact schema validation (required fields, types)
+- skill artifact emitted with correct schema when emit_skill=True
+- no emission when emit_skill=False
+- no emission when subagent config has allow_skill_emission=False
+- no emission when subagent raises an exception
+- DataPart serialization format
+- tool tracking metadata captured correctly
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.messages import AIMessage
+
+from graph.extensions.skills import (
+    SKILL_V1_MIME,
+    SkillV1Artifact,
+    _pending_skills,
+    emit_skill_artifact,
+    get_pending_skills,
+)
+from graph.subagents.config import SubagentConfig
+
+
+# ── Fixtures ──────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture(autouse=True)
+def _reset_pending_skills():
+    """Reset the _pending_skills ContextVar to None before each test."""
+    _pending_skills.set(None)
+    yield
+    _pending_skills.set(None)
+
+
+# ── SkillV1Artifact schema tests ──────────────────────────────────────────────
+
+
+def test_skill_artifact_schema() -> None:
+    """SkillV1Artifact must accept all required fields and serialize correctly."""
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+    artifact = SkillV1Artifact(
+        name="web-research",
+        description="Research a topic using web search",
+        prompt_template="Search for information about {topic}",
+        tools_used=["web_search", "fetch_url"],
+        created_at=now,
+        source_session_id="sess-abc123",
+    )
+    assert artifact.name == "web-research"
+    assert artifact.description == "Research a topic using web search"
+    assert artifact.prompt_template == "Search for information about {topic}"
+    assert artifact.tools_used == ["web_search", "fetch_url"]
+    assert artifact.created_at == now
+    assert artifact.source_session_id == "sess-abc123"
+
+
+def test_skill_artifact_to_dict() -> None:
+    """to_dict() must return a JSON-compatible mapping with all fields."""
+    now = datetime(2026, 4, 19, 12, 0, 0, tzinfo=timezone.utc)
+    artifact = SkillV1Artifact(
+        name="calc-task",
+        description="Run calculations",
+        prompt_template="Compute the result of {expr}",
+        tools_used=["calculator"],
+        created_at=now,
+        source_session_id="sess-1",
+    )
+    d = artifact.to_dict()
+    assert d["name"] == "calc-task"
+    assert d["description"] == "Run calculations"
+    assert d["prompt_template"] == "Compute the result of {expr}"
+    assert d["tools_used"] == ["calculator"]
+    assert d["created_at"] == now.isoformat()
+    assert d["source_session_id"] == "sess-1"
+
+
+def test_skill_datapart_serialization() -> None:
+    """to_datapart() must return a valid A2A DataPart with the skill-v1 MIME type."""
+    artifact = SkillV1Artifact(
+        name="dp-test",
+        description="DataPart test",
+        prompt_template="prompt",
+        tools_used=["echo"],
+        source_session_id="s1",
+    )
+    part = artifact.to_datapart()
+    assert part["kind"] == "data"
+    assert part["metadata"]["mimeType"] == SKILL_V1_MIME
+    assert part["data"]["name"] == "dp-test"
+    assert part["data"]["tools_used"] == ["echo"]
+    # created_at must be present and parseable
+    datetime.fromisoformat(part["data"]["created_at"])
+
+
+def test_skill_artifact_defaults() -> None:
+    """created_at and source_session_id have sensible defaults."""
+    before = datetime.now(timezone.utc)
+    artifact = SkillV1Artifact(
+        name="minimal",
+        description="d",
+        prompt_template="p",
+    )
+    after = datetime.now(timezone.utc)
+    assert before <= artifact.created_at <= after
+    assert artifact.source_session_id == ""
+    assert artifact.tools_used == []
+
+
+def test_skill_artifact_validation_empty_name() -> None:
+    """SkillV1Artifact must reject an empty name."""
+    with pytest.raises(ValueError, match="name"):
+        SkillV1Artifact(name="", description="d", prompt_template="p")
+
+
+def test_skill_artifact_validation_tools_not_list() -> None:
+    """SkillV1Artifact must reject a non-list tools_used."""
+    with pytest.raises(TypeError, match="tools_used"):
+        SkillV1Artifact(
+            name="x", description="d", prompt_template="p",
+            tools_used="echo",  # type: ignore[arg-type]
+        )
+
+
+# ── ContextVar emission helpers ───────────────────────────────────────────────
+
+
+def test_get_pending_skills_empty_returns_empty_list() -> None:
+    """get_pending_skills returns [] when no skills have been emitted."""
+    assert get_pending_skills() == []
+
+
+def test_emit_and_get_pending_skills() -> None:
+    """emit_skill_artifact followed by get_pending_skills returns the artifact."""
+    artifact = SkillV1Artifact(name="ctx-test", description="d", prompt_template="p")
+    emit_skill_artifact(artifact)
+    skills = get_pending_skills()
+    assert len(skills) == 1
+    assert skills[0].name == "ctx-test"
+
+
+def test_emit_multiple_skills() -> None:
+    """Multiple emit calls accumulate in order."""
+    for i in range(3):
+        emit_skill_artifact(SkillV1Artifact(
+            name=f"skill-{i}", description="d", prompt_template="p",
+        ))
+    skills = get_pending_skills()
+    assert [s.name for s in skills] == ["skill-0", "skill-1", "skill-2"]
+
+
+# ── SubagentConfig allow_skill_emission field ─────────────────────────────────
+
+
+def test_subagent_config_default_allows_skill_emission() -> None:
+    """SubagentConfig.allow_skill_emission defaults to True."""
+    cfg = SubagentConfig(
+        name="worker",
+        description="d",
+        system_prompt="s",
+    )
+    assert cfg.allow_skill_emission is True
+
+
+def test_subagent_config_can_disable_skill_emission() -> None:
+    """SubagentConfig.allow_skill_emission can be set to False."""
+    cfg = SubagentConfig(
+        name="worker",
+        description="d",
+        system_prompt="s",
+        allow_skill_emission=False,
+    )
+    assert cfg.allow_skill_emission is False
+
+
+def test_subagent_config_disallowed_tools_unaffected() -> None:
+    """Adding allow_skill_emission does not affect disallowed_tools."""
+    cfg = SubagentConfig(
+        name="worker",
+        description="d",
+        system_prompt="s",
+        disallowed_tools=["task", "rm_rf"],
+    )
+    assert cfg.disallowed_tools == ["task", "rm_rf"]
+    assert cfg.allow_skill_emission is True
+
+
+# ── task() emit_skill logic (inline simulation) ───────────────────────────────
+#
+# These tests verify the emission logic by calling the same conditional block
+# that graph/agent.py uses, without spinning up a real LangGraph agent.
+
+
+def _make_ai_message_with_tool_calls(tool_names: list[str]) -> MagicMock:
+    msg = MagicMock(spec=AIMessage)
+    msg.content = ""
+    msg.tool_calls = [{"name": n, "args": {}, "id": f"call-{n}"} for n in tool_names]
+    return msg
+
+
+def _make_ai_message_with_content(content: str) -> MagicMock:
+    msg = MagicMock(spec=AIMessage)
+    msg.content = content
+    msg.tool_calls = []
+    return msg
+
+
+def _run_emit_logic(
+    *,
+    messages: list,
+    description: str,
+    prompt: str,
+    emit_skill: bool,
+    allow_skill_emission: bool,
+    session_id: str = "sess-test",
+) -> None:
+    """Replicate the skill emission block from task() for isolated unit testing."""
+    tools_used: list[str] = []
+    for msg in messages:
+        for tc in getattr(msg, "tool_calls", []) or []:
+            name = tc.get("name") if isinstance(tc, dict) else getattr(tc, "name", None)
+            if name and name not in tools_used:
+                tools_used.append(name)
+
+    if emit_skill and allow_skill_emission:
+        if not tools_used:
+            logging.getLogger(__name__).warning(
+                "[skill] emit_skill=True but no tool usage metadata captured; "
+                "skipping skill emission.",
+            )
+        else:
+            artifact = SkillV1Artifact(
+                name=description,
+                description=f"Captured workflow: {description}",
+                prompt_template=prompt,
+                tools_used=tools_used,
+                created_at=datetime.now(timezone.utc),
+                source_session_id=session_id,
+            )
+            emit_skill_artifact(artifact)
+
+
+def test_skill_emitted_when_emit_skill_true() -> None:
+    """Skill artifact is emitted when emit_skill=True and subagent succeeds."""
+    msgs = [
+        _make_ai_message_with_tool_calls(["echo"]),
+        _make_ai_message_with_content("done"),
+    ]
+    _run_emit_logic(
+        messages=msgs,
+        description="my-task",
+        prompt="do the thing",
+        emit_skill=True,
+        allow_skill_emission=True,
+    )
+    skills = get_pending_skills()
+    assert len(skills) == 1
+    skill = skills[0]
+    assert skill.name == "my-task"
+    assert skill.tools_used == ["echo"]
+    assert skill.prompt_template == "do the thing"
+    assert "Captured workflow" in skill.description
+
+
+def test_no_emission_on_opt_out() -> None:
+    """No skill artifact is emitted when emit_skill=False."""
+    msgs = [
+        _make_ai_message_with_tool_calls(["echo"]),
+        _make_ai_message_with_content("done"),
+    ]
+    _run_emit_logic(
+        messages=msgs,
+        description="my-task",
+        prompt="do the thing",
+        emit_skill=False,
+        allow_skill_emission=True,
+    )
+    assert get_pending_skills() == []
+
+
+def test_no_emission_on_failure() -> None:
+    """No skill artifact is emitted when the exception path is taken (no emission call)."""
+    # The failure path in task() does not reach the emission block at all —
+    # verify by calling _run_emit_logic with emit_skill=True but no messages
+    # (simulating the state after an exception: messages list is empty and
+    # the outer except would have returned before reaching emission).
+    #
+    # This test focuses on: even if someone mistakenly called the emit block
+    # with empty messages + no tools, no artifact is written.
+    _run_emit_logic(
+        messages=[],
+        description="failed-task",
+        prompt="do the thing",
+        emit_skill=True,
+        allow_skill_emission=True,
+    )
+    assert get_pending_skills() == []
+
+
+def test_no_emission_when_config_disallows() -> None:
+    """No skill artifact is emitted when allow_skill_emission=False."""
+    msgs = [
+        _make_ai_message_with_tool_calls(["echo"]),
+        _make_ai_message_with_content("done"),
+    ]
+    _run_emit_logic(
+        messages=msgs,
+        description="my-task",
+        prompt="do the thing",
+        emit_skill=True,
+        allow_skill_emission=False,
+    )
+    assert get_pending_skills() == []
+
+
+def test_tool_tracking_metadata_captured() -> None:
+    """tools_used in the artifact lists all tools invoked, deduplicated."""
+    msgs = [
+        _make_ai_message_with_tool_calls(["echo", "calculator"]),
+        _make_ai_message_with_tool_calls(["echo"]),  # duplicate — should appear once
+        _make_ai_message_with_content("result"),
+    ]
+    _run_emit_logic(
+        messages=msgs,
+        description="dedup-test",
+        prompt="compute",
+        emit_skill=True,
+        allow_skill_emission=True,
+    )
+    skills = get_pending_skills()
+    assert len(skills) == 1
+    assert skills[0].tools_used.count("echo") == 1
+    assert "calculator" in skills[0].tools_used
+
+
+def test_no_emission_when_no_tool_usage(caplog) -> None:
+    """When emit_skill=True but no tools were used, a warning is logged."""
+    content_msg = _make_ai_message_with_content("plain response")
+    content_msg.tool_calls = []
+
+    with caplog.at_level(logging.WARNING):
+        _run_emit_logic(
+            messages=[content_msg],
+            description="no-tools-task",
+            prompt="just answer",
+            emit_skill=True,
+            allow_skill_emission=True,
+        )
+
+    assert get_pending_skills() == []
+    assert any("no tool usage metadata" in r.message for r in caplog.records)

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -1,0 +1,478 @@
+"""Unit and integration tests for graph/skills/index.py.
+
+Covers:
+- FTS5 database initialization (idempotent schema creation)
+- add_skill() indexing
+- load_skills() FTS5 retrieval and BM25 ranking
+- Empty DB / empty query graceful handling
+- Token budget enforcement in format_learned_skills
+- Schema migration: backup + recreate on version mismatch
+- KnowledgeMiddleware.load_skills() integration
+- KnowledgeMiddleware._format_learned_skills() formatting
+- <learned_skills> block in before_model output
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import tempfile
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+
+from graph.skills.index import SkillRecord, SkillsIndex
+from graph.middleware.knowledge import KnowledgeMiddleware
+
+
+# ── Helpers / fixtures ────────────────────────────────────────────────────────
+
+
+@dataclass
+class _FakeArtifact:
+    """Minimal SkillV1Artifact lookalike for testing without importing extensions."""
+
+    name: str
+    description: str
+    prompt_template: str
+    tools_used: list[str] = field(default_factory=list)
+    created_at: datetime = field(
+        default_factory=lambda: datetime.now(timezone.utc)
+    )
+    source_session_id: str = ""
+
+
+def _make_artifact(
+    name: str = "web-research",
+    description: str = "Research a topic using web search",
+    prompt_template: str = "Search the web for information about {topic}",
+    tools_used: list[str] | None = None,
+    source_session_id: str = "sess-test",
+) -> _FakeArtifact:
+    return _FakeArtifact(
+        name=name,
+        description=description,
+        prompt_template=prompt_template,
+        tools_used=tools_used or ["web_search"],
+        source_session_id=source_session_id,
+    )
+
+
+@pytest.fixture
+def tmp_db(tmp_path) -> str:
+    """Return a path to a temporary SQLite DB that doesn't exist yet."""
+    return str(tmp_path / "skills.db")
+
+
+@pytest.fixture
+def index(tmp_db) -> SkillsIndex:
+    """A fresh SkillsIndex backed by a temp DB."""
+    return SkillsIndex(db_path=tmp_db)
+
+
+@pytest.fixture
+def populated_index(index) -> SkillsIndex:
+    """SkillsIndex pre-populated with three skill artifacts."""
+    index.add_skill(_make_artifact(
+        name="web-research",
+        description="Research a topic using web search tools",
+        prompt_template="Search the web for: {query}",
+        tools_used=["web_search", "fetch_url"],
+    ))
+    index.add_skill(_make_artifact(
+        name="calculator-math",
+        description="Perform mathematical calculations",
+        prompt_template="Calculate the following: {expression}",
+        tools_used=["calculator"],
+    ))
+    index.add_skill(_make_artifact(
+        name="time-lookup",
+        description="Get the current time in any timezone",
+        prompt_template="What is the current time in {timezone}?",
+        tools_used=["current_time"],
+    ))
+    return index
+
+
+# ── SkillsIndex: initialization ───────────────────────────────────────────────
+
+
+def test_initialize_db_creates_file(tmp_db) -> None:
+    """initialize_db() must create the SQLite file and FTS5 table."""
+    assert not os.path.exists(tmp_db)
+    SkillsIndex(db_path=tmp_db)
+    assert os.path.exists(tmp_db)
+
+    conn = sqlite3.connect(tmp_db)
+    cur = conn.execute(
+        "SELECT name FROM sqlite_master WHERE type='table' AND name='skills_fts'"
+    )
+    assert cur.fetchone() is not None, "skills_fts table should exist"
+    conn.close()
+
+
+def test_initialize_db_idempotent(tmp_db) -> None:
+    """Calling SkillsIndex() twice on the same DB must not raise or corrupt data."""
+    idx1 = SkillsIndex(db_path=tmp_db)
+    idx1.add_skill(_make_artifact())
+
+    idx2 = SkillsIndex(db_path=tmp_db)
+    results = idx2.load_skills("web search research")
+    assert len(results) == 1, "Existing rows must survive re-initialization"
+
+
+def test_schema_meta_table_exists(tmp_db) -> None:
+    """_skills_meta table must record schema version."""
+    SkillsIndex(db_path=tmp_db)
+    conn = sqlite3.connect(tmp_db)
+    cur = conn.execute("SELECT version FROM _skills_meta WHERE key = 'schema_version'")
+    row = cur.fetchone()
+    assert row is not None
+    assert row[0] == 1
+    conn.close()
+
+
+# ── SkillsIndex: add_skill ────────────────────────────────────────────────────
+
+
+def test_add_skill_inserts_row(index) -> None:
+    """add_skill() must insert a row that can be retrieved."""
+    index.add_skill(_make_artifact(name="my-skill", description="does something useful"))
+    results = index.load_skills("useful something")
+    assert any(r.name == "my-skill" for r in results)
+
+
+def test_add_skill_empty_name_skipped(index) -> None:
+    """add_skill() must silently skip artifacts with empty names."""
+    index.add_skill(_make_artifact(name=""))
+    results = index.load_skills("research")
+    assert results == []
+
+
+def test_add_skill_tools_stored_as_space_separated(index, tmp_db) -> None:
+    """add_skill() must join tools_used list into a space-separated string."""
+    index.add_skill(_make_artifact(tools_used=["web_search", "fetch_url"]))
+    # Verify raw storage
+    conn = sqlite3.connect(tmp_db)
+    cur = conn.execute("SELECT tools_used FROM skills_fts")
+    row = cur.fetchone()
+    assert row is not None
+    assert "web_search" in row[0]
+    assert "fetch_url" in row[0]
+    conn.close()
+
+
+# ── SkillsIndex: load_skills ──────────────────────────────────────────────────
+
+
+def test_load_skills_empty_db(index) -> None:
+    """load_skills() must return an empty list on an empty database."""
+    results = index.load_skills("web research")
+    assert results == []
+
+
+def test_load_skills_empty_query(populated_index) -> None:
+    """load_skills() must return an empty list for empty/whitespace query."""
+    assert populated_index.load_skills("") == []
+    assert populated_index.load_skills("   ") == []
+
+
+def test_load_skills_returns_skill_records(populated_index) -> None:
+    """load_skills() must return SkillRecord named tuples."""
+    results = populated_index.load_skills("web search research")
+    assert len(results) > 0
+    r = results[0]
+    assert isinstance(r, SkillRecord)
+    assert isinstance(r.name, str)
+    assert isinstance(r.description, str)
+    assert isinstance(r.prompt_template, str)
+    assert isinstance(r.score, float)
+
+
+def test_retrieval_ranking(populated_index) -> None:
+    """FTS5 must rank the most relevant skill first for a specific query."""
+    results = populated_index.load_skills("mathematical calculation expression")
+    assert len(results) > 0
+    assert results[0].name == "calculator-math", (
+        f"Expected 'calculator-math' first, got: {[r.name for r in results]}"
+    )
+
+
+def test_load_skills_top_k_limit(populated_index) -> None:
+    """load_skills() must respect the k limit."""
+    results = populated_index.load_skills("search web calculator time", k=2)
+    assert len(results) <= 2
+
+
+def test_load_skills_scores_ordered(populated_index) -> None:
+    """Results must be ordered best-first (ascending BM25 score)."""
+    results = populated_index.load_skills("search web research")
+    scores = [r.score for r in results]
+    assert scores == sorted(scores), "BM25 scores must be sorted ascending (best-first)"
+
+
+def test_load_skills_no_match_returns_empty(populated_index) -> None:
+    """load_skills() must return an empty list when FTS finds no matches."""
+    # A query using FTS5 special syntax that matches nothing
+    results = populated_index.load_skills("zzz_no_match_xyz_abc_impossible_token")
+    # This may return empty or have no results
+    # Either way, must not raise
+    assert isinstance(results, list)
+
+
+# ── SkillsIndex: rebuild_index ────────────────────────────────────────────────
+
+
+def test_rebuild_index_clears_and_reindexes(index) -> None:
+    """rebuild_index() must clear existing rows and insert new ones."""
+    index.add_skill(_make_artifact(name="old-skill"))
+    new_artifacts = [
+        _make_artifact(name="new-skill-1", description="brand new skill one"),
+        _make_artifact(name="new-skill-2", description="brand new skill two"),
+    ]
+    index.rebuild_index(new_artifacts)
+
+    # Old skill should not appear
+    old_results = index.load_skills("old skill")
+    assert not any(r.name == "old-skill" for r in old_results)
+
+    # New skills should appear
+    new_results = index.load_skills("brand new skill")
+    names = {r.name for r in new_results}
+    assert "new-skill-1" in names or "new-skill-2" in names
+
+
+# ── Schema migration ──────────────────────────────────────────────────────────
+
+
+def test_migration_empty_fork(tmp_db) -> None:
+    """First run on empty path must create schema without error."""
+    idx = SkillsIndex(db_path=tmp_db)
+    assert os.path.exists(tmp_db)
+    # Must be usable immediately
+    idx.add_skill(_make_artifact())
+    results = idx.load_skills("web research")
+    assert len(results) == 1
+
+
+def test_migration_version_mismatch_creates_backup(tmp_db) -> None:
+    """If schema version mismatches, existing DB should be backed up."""
+    # Create a DB with wrong schema version
+    conn = sqlite3.connect(tmp_db)
+    conn.executescript("""
+        CREATE VIRTUAL TABLE skills_fts USING fts5(name, description);
+        CREATE TABLE _skills_meta (key TEXT PRIMARY KEY, version INTEGER NOT NULL);
+        INSERT INTO _skills_meta VALUES ('schema_version', 999);
+    """)
+    conn.close()
+
+    # SkillsIndex should detect mismatch and backup
+    idx = SkillsIndex(db_path=tmp_db)
+    bak_path = tmp_db + ".bak"
+    assert os.path.exists(bak_path), "Backup file should exist after migration"
+
+    # New DB should be functional
+    idx.add_skill(_make_artifact())
+    results = idx.load_skills("web research")
+    assert len(results) == 1
+
+
+def test_migration_compatible_schema_no_backup(tmp_db) -> None:
+    """Compatible schema must not trigger a backup."""
+    SkillsIndex(db_path=tmp_db)
+    bak_path = tmp_db + ".bak"
+    # Re-open — should not create a backup
+    SkillsIndex(db_path=tmp_db)
+    assert not os.path.exists(bak_path), "No backup should be created for compatible schema"
+
+
+# ── Token budget enforcement ──────────────────────────────────────────────────
+
+
+def _make_knowledge_middleware_no_store() -> KnowledgeMiddleware:
+    """Return a KnowledgeMiddleware with a stub store (no real DB)."""
+    store = MagicMock()
+    store.search.return_value = []
+    return KnowledgeMiddleware(knowledge_store=store)
+
+
+def test_format_learned_skills_empty_returns_empty() -> None:
+    """_format_learned_skills() must return empty string for empty input."""
+    km = _make_knowledge_middleware_no_store()
+    result = km._format_learned_skills([])
+    assert result == ""
+
+
+def test_format_learned_skills_basic_formatting() -> None:
+    """_format_learned_skills() must produce a valid <learned_skills> block."""
+    km = _make_knowledge_middleware_no_store()
+    skills = [SkillRecord(
+        name="web-research",
+        description="Research the web",
+        prompt_template="Search for {topic}",
+        score=-1.5,
+    )]
+    block = km._format_learned_skills(skills)
+    assert "<learned_skills>" in block
+    assert "</learned_skills>" in block
+    assert 'name="web-research"' in block
+    assert "Research the web" in block
+    assert "Search for {topic}" in block
+
+
+def test_token_budget_enforcement() -> None:
+    """_format_learned_skills() must remove low-relevance skills to fit budget."""
+    km = _make_knowledge_middleware_no_store()
+    # Create many skills with large descriptions to exceed budget
+    skills = [
+        SkillRecord(
+            name=f"skill-{i}",
+            description="x" * 500,  # large description
+            prompt_template="y" * 500,  # large template
+            score=float(-i),  # skill-0 is best (most negative)
+        )
+        for i in range(20)
+    ]
+    block = km._format_learned_skills(skills)
+    # Block must not exceed 2000 tokens (~8000 chars)
+    token_count = len(block) // 4
+    assert token_count <= 2000, f"Block exceeds 2000 token budget: {token_count} tokens"
+    # Must still contain at least the best skill
+    assert "skill-19" in block or len(block) > 0  # best skill retained
+
+
+def test_token_budget_best_skill_retained() -> None:
+    """After truncation, the most relevant skill (best score) should be retained."""
+    km = _make_knowledge_middleware_no_store()
+    skills = [
+        SkillRecord(name="best-skill", description="best " * 10, prompt_template="pt", score=-10.0),
+        SkillRecord(name="worst-skill", description="worst " * 400, prompt_template="pt " * 400, score=-0.1),
+    ]
+    block = km._format_learned_skills(skills)
+    assert "best-skill" in block
+
+
+# ── KnowledgeMiddleware: load_skills integration ──────────────────────────────
+
+
+def test_km_load_skills_no_index_returns_empty() -> None:
+    """load_skills() must return [] when no skills_index is configured."""
+    km = _make_knowledge_middleware_no_store()
+    assert km._skills_index is None
+    results = km.load_skills("any query")
+    assert results == []
+
+
+def test_km_load_skills_with_index(tmp_db) -> None:
+    """load_skills() must delegate to SkillsIndex when configured."""
+    idx = SkillsIndex(db_path=tmp_db)
+    idx.add_skill(_make_artifact(
+        name="test-skill",
+        description="A test skill for unit testing",
+    ))
+
+    store = MagicMock()
+    store.search.return_value = []
+    km = KnowledgeMiddleware(knowledge_store=store, skills_index=idx)
+
+    results = km.load_skills("test skill unit")
+    assert any(r.name == "test-skill" for r in results)
+
+
+def test_km_load_skills_empty_query_returns_empty(tmp_db) -> None:
+    """load_skills() with empty query must return [] without querying index."""
+    idx = SkillsIndex(db_path=tmp_db)
+    store = MagicMock()
+    store.search.return_value = []
+    km = KnowledgeMiddleware(knowledge_store=store, skills_index=idx)
+
+    assert km.load_skills("") == []
+    assert km.load_skills("   ") == []
+
+
+# ── KnowledgeMiddleware: before_model with skills injection ───────────────────
+
+
+def test_before_model_injects_learned_skills(tmp_db) -> None:
+    """before_model() must include <learned_skills> block when index has results."""
+    idx = SkillsIndex(db_path=tmp_db)
+    idx.add_skill(_make_artifact(
+        name="web-research",
+        description="Research topics using web search",
+    ))
+
+    store = MagicMock()
+    store.search.return_value = []
+    km = KnowledgeMiddleware(knowledge_store=store, skills_index=idx)
+    km._prior_sessions_cache = ""  # skip session loading
+
+    state = {
+        "messages": [HumanMessage(content="research web search topics")]
+    }
+    result = km.before_model(state, runtime=None)
+
+    assert result is not None
+    assert "context" in result
+    assert "<learned_skills>" in result["context"]
+    assert "web-research" in result["context"]
+
+
+def test_before_model_no_skills_no_learned_block(tmp_db) -> None:
+    """before_model() must omit <learned_skills> block when index is empty."""
+    idx = SkillsIndex(db_path=tmp_db)  # empty index
+
+    store = MagicMock()
+    store.search.return_value = []
+    km = KnowledgeMiddleware(knowledge_store=store, skills_index=idx)
+    km._prior_sessions_cache = ""
+
+    state = {
+        "messages": [HumanMessage(content="some query")]
+    }
+    result = km.before_model(state, runtime=None)
+
+    # With empty store and empty index, result should be None or no learned_skills
+    if result is not None:
+        assert "<learned_skills>" not in result.get("context", "")
+
+
+def test_before_model_no_skills_index_configured() -> None:
+    """before_model() must not crash when skills_index is None."""
+    store = MagicMock()
+    store.search.return_value = []
+    km = KnowledgeMiddleware(knowledge_store=store)  # no skills_index
+    km._prior_sessions_cache = ""
+
+    state = {"messages": [HumanMessage(content="test query")]}
+    # Must not raise
+    result = km.before_model(state, runtime=None)
+    if result is not None:
+        assert "<learned_skills>" not in result.get("context", "")
+
+
+# ── build_skills_query ────────────────────────────────────────────────────────
+
+
+def test_build_skills_query_uses_last_human_message() -> None:
+    """_build_skills_query() must include the last human message text."""
+    km = _make_knowledge_middleware_no_store()
+    messages = [
+        HumanMessage(content="hello"),
+        AIMessage(content="how can I help?"),
+        HumanMessage(content="research machine learning"),
+    ]
+    query = km._build_skills_query(messages)
+    assert "research machine learning" in query
+
+
+def test_build_skills_query_caps_at_context_chars() -> None:
+    """_build_skills_query() must cap the query at 2000 chars."""
+    km = _make_knowledge_middleware_no_store()
+    long_content = "x" * 5000
+    messages = [HumanMessage(content=long_content)]
+    query = km._build_skills_query(messages)
+    assert len(query) <= 2000

--- a/tests/utils/check_audit_clean.py
+++ b/tests/utils/check_audit_clean.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python3
+"""Scan audit.jsonl for unredacted credential patterns.
+
+Usage:
+    python tests/utils/check_audit_clean.py [audit.jsonl]
+
+Exits with code 0 if no credentials found, 1 if any are detected.
+Use in CI/CD to gate deployments on clean audit logs.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import sys
+from pathlib import Path
+from typing import NamedTuple
+
+
+class _Violation(NamedTuple):
+    line_number: int
+    pattern_name: str
+    excerpt: str
+
+
+# Patterns that should NOT appear in a clean audit log.
+_LEAK_PATTERNS: dict[str, re.Pattern] = {
+    "bearer_token": re.compile(
+        r"Authorization\s*:\s*Bearer\s+(?!\[REDACTED\])\S+",
+        re.IGNORECASE,
+    ),
+    "openai_key": re.compile(
+        r"\bsk-[A-Za-z0-9_\-]{20,}\b",
+    ),
+    "generic_api_key": re.compile(
+        r"(?i)(?:api[_\-]?key|apikey)(?:[\"'\s:=]+)(?!\[REDACTED\])([A-Za-z0-9_\-]{16,})",
+    ),
+    "env_var_assignment": re.compile(
+        r"(?i)\b(?:OPENAI_API_KEY|LANGFUSE_SECRET_KEY|LANGFUSE_PUBLIC_KEY|"
+        r"A2A_AUTH_TOKEN|SECRET_KEY|AUTH_TOKEN|ACCESS_TOKEN|PRIVATE_KEY)"
+        r"\s*[=:]\s*(?!\[REDACTED\])\S+",
+    ),
+}
+
+
+def scan_file(path: Path) -> list[_Violation]:
+    """Scan a JSONL file and return a list of credential violations found."""
+    violations: list[_Violation] = []
+
+    if not path.exists():
+        print(f"[check_audit_clean] File not found: {path}", file=sys.stderr)
+        return violations
+
+    for lineno, raw_line in enumerate(path.read_text().splitlines(), start=1):
+        raw_line = raw_line.strip()
+        if not raw_line:
+            continue
+
+        # Scan the raw serialized line (catches nested values too)
+        for pattern_name, pattern in _LEAK_PATTERNS.items():
+            m = pattern.search(raw_line)
+            if m:
+                # Truncate excerpt for readability
+                start = max(0, m.start() - 20)
+                end = min(len(raw_line), m.end() + 20)
+                excerpt = raw_line[start:end]
+                violations.append(_Violation(lineno, pattern_name, excerpt))
+
+    return violations
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv or sys.argv[1:]
+    if not argv:
+        print("Usage: check_audit_clean.py <audit.jsonl>", file=sys.stderr)
+        return 1
+
+    path = Path(argv[0])
+    violations = scan_file(path)
+
+    if not violations:
+        print(f"[check_audit_clean] {path}: CLEAN — no credentials detected.")
+        return 0
+
+    print(f"[check_audit_clean] {path}: VIOLATIONS FOUND ({len(violations)})")
+    for v in violations:
+        print(f"  line {v.line_number}: [{v.pattern_name}] ...{v.excerpt}...")
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Shipping the **protoagent-community-improvements** project to main. 13 commits, 3 milestones, 11 features:

**M1 — Security Hardening**
- A2A bearer token authentication middleware
- Audit log credential redaction
- WebSocket/SSE origin verification

**M2 — Memory On By Default**
- Session memory persistence on terminal state
- Session memory loading + default-on config

**M3 — Skill Loop**
- skill-v1 artifact emission from subagent task() completion
- SQLite FTS5 skill index + retrieval injection
- Skill curator + docs tutorial

**Infra / docs**
- `.automaker-lock` + `.worktrees/` now in .gitignore
- Security + skill-loop architecture sections added
- New env vars documented: A2A_AUTH_TOKEN, MEMORY_PATH, PROTOAGENT_DISABLE_MEMORY
- `skill-v1` reference entry in extensions.md

Post-merge `prepare-release.yml` will auto-bump version + cut the release tag.

## Merge strategy
Use **merge commit** (not squash) per branch-strategy.md.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added bearer-token authentication for API endpoints with configurable security tokens.
  * Added origin validation for streaming connections to control cross-origin access.
  * Session memory now persists conversation summaries across restarts for context continuity.
  * Skill learning loop: agents emit and index learned skills for future task optimization.
  * Skill curator tool manages learned skills with confidence decay and deduplication.

* **Documentation**
  * Architecture guide updated with security and skill-learning details.
  * New environment variable reference for authentication and memory configuration.
  * Skill-loop tutorial with curation workflow examples.

* **Tests**
  * Added comprehensive test coverage for authentication, memory, and skill features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->