### PR TITLE
Agent card does not advertise bearer scheme when A2A_AUTH_TOKEN is set

### DIFF
--- a/server.py
+++ b/server.py
@@ -251,6 +251,14 @@ async def _chat_langgraph(message: str, session_id: str) -> list[dict[str, Any]]
 AGENT_NAME = os.environ.get("AGENT_NAME", "protoagent")
 
 
+def _build_security_schemes() -> dict:
+    """Return securitySchemes dict, adding bearer only when A2A_AUTH_TOKEN is set."""
+    schemes: dict = {"apiKey": {"type": "apiKey", "in": "header", "name": "X-API-Key"}}
+    if os.environ.get("A2A_AUTH_TOKEN", ""):
+        schemes["bearer"] = {"type": "http", "scheme": "bearer"}
+    return schemes
+
+
 def _build_agent_card(host: str) -> dict:
     """Build the A2A agent card served at /.well-known/agent-card.json.
 
@@ -308,9 +316,7 @@ def _build_agent_card(host: str) -> dict:
                 "examples": ["hello", "what can you do?"],
             },
         ],
-        "securitySchemes": {
-            "apiKey": {"type": "apiKey", "in": "header", "name": "X-API-Key"}
-        },
+        "securitySchemes": _build_security_schemes(),
         "security": [{"apiKey": []}],
     }
 

--- a/tests/test_a2a_integration.py
+++ b/tests/test_a2a_integration.py
@@ -54,6 +54,29 @@ def test_agent_card_has_at_least_one_skill() -> None:
         assert "description" in skill
 
 
+def test_agent_card_no_bearer_when_token_unset(monkeypatch) -> None:
+    """With A2A_AUTH_TOKEN unset, card must NOT advertise bearer scheme."""
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    from server import _build_agent_card
+
+    card = _build_agent_card("protoagent:7870")
+    schemes = card.get("securitySchemes", {})
+    assert "apiKey" in schemes, "apiKey scheme must always be present"
+    assert "bearer" not in schemes, "bearer must not appear when A2A_AUTH_TOKEN is unset"
+
+
+def test_agent_card_bearer_when_token_set(monkeypatch) -> None:
+    """With A2A_AUTH_TOKEN set, card must advertise bearer scheme."""
+    monkeypatch.setenv("A2A_AUTH_TOKEN", "secret-test-token")
+    from server import _build_agent_card
+
+    card = _build_agent_card("protoagent:7870")
+    schemes = card.get("securitySchemes", {})
+    assert "apiKey" in schemes, "apiKey scheme must always be present"
+    assert "bearer" in schemes, "bearer must appear when A2A_AUTH_TOKEN is set"
+    assert schemes["bearer"] == {"type": "http", "scheme": "bearer"}
+
+
 def test_agent_card_declares_cost_v1_extension() -> None:
     """The runtime captures token usage on `on_chat_model_end` and the
     A2A handler emits a cost-v1 DataPart on every terminal task. The


### PR DESCRIPTION
## Summary

## Problem

With `A2A_AUTH_TOKEN=<token>` set, the agent card served at `/.well-known/agent-card.json` and `/.well-known/agent.json` does **not** include `securitySchemes.bearer`, despite the fact that the bearer check IS enforced on `/a2a` routes.

## Reproduction (v0.2.0 live smoke)

```bash
docker run -d --name pa-test --network ai_default -p 7881:7870 \
  -e A2A_AUTH_TOKEN=secret-test-token-xyz \
  -e OPENAI_API_KEY=$GATEWAY_KEY -e OPENAI_BASE_URL=http://gateway:4000/v1 \
  protoagent:test

...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Bearer token authentication support now available alongside the existing API key authentication method, automatically enabled when the corresponding environment variable is configured.
  * Security scheme configuration is now fully dynamic and environment-driven instead of hard-coded.

* **Tests**
  * Integration tests added to validate security scheme configuration behavior across different environment scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->