### PR TITLE
MemoryMiddleware.on_session_end is never invoked - memory persistence dead on arrival

### DIFF
--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -173,8 +173,23 @@ class MemoryMiddleware(AgentMiddleware):
     # --- Knowledge extraction (existing) ---
 
     def after_agent(self, state, runtime) -> dict | None:
-        """Queue conversation for async knowledge extraction."""
+        """Queue conversation for async knowledge extraction. Persists session on terminal turn."""
         messages = state.get("messages", [])
+
+        # --- Session persistence: detect terminal turn ---
+        # Terminal = last message is AIMessage with content and no pending tool calls
+        if messages:
+            last_msg = messages[-1]
+            if (
+                isinstance(last_msg, AIMessage)
+                and last_msg.content
+                and not getattr(last_msg, "tool_calls", None)
+            ):
+                import tracing
+                trace_id = tracing.current_trace_id()
+                _persist_session(state, trace_id)
+
+        # --- Knowledge extraction ---
         if len(messages) < 2:
             return None
 

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -392,3 +392,73 @@ def test_on_session_end_calls_persist_session(tmp_path):
 
     mock_persist.assert_called_once_with(state, "trace-hook")
     assert result is None
+
+
+# ---------------------------------------------------------------------------
+# 10. after_agent persistence on terminal turn
+# ---------------------------------------------------------------------------
+
+def test_after_agent_persists_on_terminal_turn(tmp_path):
+    """after_agent must call _persist_session when last message is a terminal AIMessage."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    store = MagicMock()
+    mw = mod.MemoryMiddleware(knowledge_store=store)
+
+    messages = [
+        HumanMessage(content="Hello"),
+        AIMessage(content="Final answer with no pending tool calls."),
+    ]
+    state = _make_state("after-agent-terminal", messages=messages)
+    runtime = MagicMock()
+
+    with patch.object(mod, "_persist_session") as mock_persist, \
+         patch("tracing.current_trace_id", return_value="trace-after"):
+        mw.after_agent(state, runtime)
+
+    mock_persist.assert_called_once_with(state, "trace-after")
+
+
+def test_after_agent_does_not_persist_when_tool_calls_pending(tmp_path):
+    """after_agent must NOT persist when the last AIMessage has pending tool_calls."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    store = MagicMock()
+    mw = mod.MemoryMiddleware(knowledge_store=store)
+
+    ai_msg = AIMessage(content="")
+    ai_msg.tool_calls = [{"id": "tc1", "name": "search", "args": {"query": "x"}}]
+    messages = [
+        HumanMessage(content="Search for x"),
+        ai_msg,
+    ]
+    state = _make_state("after-agent-pending", messages=messages)
+    runtime = MagicMock()
+
+    with patch.object(mod, "_persist_session") as mock_persist, \
+         patch("tracing.current_trace_id", return_value="trace-pending"):
+        mw.after_agent(state, runtime)
+
+    mock_persist.assert_not_called()
+
+
+def test_after_agent_does_not_persist_when_last_msg_not_ai(tmp_path):
+    """after_agent must NOT persist when the last message is not an AIMessage."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    store = MagicMock()
+    mw = mod.MemoryMiddleware(knowledge_store=store)
+
+    messages = [
+        HumanMessage(content="Hello"),
+        AIMessage(content="Some response."),
+        HumanMessage(content="Follow-up question"),
+    ]
+    state = _make_state("after-agent-human-last", messages=messages)
+    runtime = MagicMock()
+
+    with patch.object(mod, "_persist_session") as mock_persist, \
+         patch("tracing.current_trace_id", return_value="trace-human"):
+        mw.after_agent(state, runtime)
+
+    mock_persist.assert_not_called()


### PR DESCRIPTION
## Summary

## Problem

The MemoryMiddleware.on_session_end(state, runtime) hook that calls _persist_session() never fires. No files are written to /sandbox/memory/ even after successful A2A message/send round-trips.

## Reproduction (v0.2.0 live smoke, 2026-04-19)

Boot with memory enabled (default) and volume-mounted /sandbox. Run a successful message/send. Check MEMORY_PATH.

Observed: empty directory.
Expected: session-<uuid>.json with messages, tool stats, final output.

Container log shows '[memory] s...

---
*Recovered automatically by Automaker post-agent hook*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sessions are now automatically persisted when conversations reach a terminal state—when the last message is an AI response without pending tool actions.

* **Tests**
  * Added unit tests to verify session persistence triggers correctly at conversation terminal states and does not trigger when tool actions are pending or when the last message is not an AI response.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->