### PR TITLE
Fix pytest collection errors

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -75,6 +75,16 @@ jobs:
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache
           cache-to: type=registry,ref=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:buildcache,mode=max
 
+      - name: Verify — pytest collection in runtime image
+        run: |
+          SHORT_SHA=$(echo "${{ github.sha }}" | cut -c1-7)
+          docker run --rm \
+            -v "${{ github.workspace }}:/repo" \
+            -w /repo \
+            --entrypoint sh \
+            "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${SHORT_SHA}" \
+            -c 'pip install -q pytest pytest-asyncio && python -m pytest tests/ --collect-only -q'
+
       - name: Summary
         run: |
           echo "## Published" >> "$GITHUB_STEP_SUMMARY"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,3 +7,4 @@ requires-python = ">=3.11"
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]
+pythonpath = ["."]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ websockets>=12.0
 
 # LangGraph agent backend
 langchain>=1.2.3
+langchain-core>=0.3.0
 langgraph>=1.1.0
 langchain-openai>=0.3.0
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Ensure deterministic import resolution for the protoagent test suite.
+
+Moves site-packages to the front of sys.path so installed packages
+(langchain_core, langchain, etc.) are never shadowed by local directories
+that pytest inserts during collection.
+"""
+from __future__ import annotations
+
+import site
+import sys
+
+
+def pytest_configure(config):  # noqa: ARG001
+    """Prepend site-packages to sys.path before any test imports occur."""
+    site_dirs = site.getsitepackages()
+    for sp in reversed(site_dirs):
+        if sp in sys.path:
+            sys.path.remove(sp)
+        sys.path.insert(0, sp)


### PR DESCRIPTION
Fix pytest collection errors on test_memory_persistence and test_skill_index.

Addresses the bug found during v0.2.0 smoke testing where running pytest tests/ in a fresh Docker env fails at collection with:
  ModuleNotFoundError: No module named langchain_core.language_models; langchain_core is not a package

Recovered by Ava via REST API after pipeline could not push the branch itself.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated dependency constraints to include `langchain-core` with minimum version requirement.
  * Enhanced test infrastructure configuration for improved test execution and verification.
  * Updated CI/CD pipeline to validate published runtime images.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->