### PR TITLE
chore(ci): update repo homepage after docs deploy

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  administration: write
 
 concurrency:
   group: pages
@@ -39,3 +40,7 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+      - name: Update repo homepage
+        run: gh api -X PATCH repos/${{ github.repository }} -f homepage="${{ steps.deployment.outputs.page_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
- Writes the deployed GitHub Pages URL back to the repo's `homepage` field so it renders in the About sidebar.
- Adds `administration: write` permission so `GITHUB_TOKEN` can PATCH the repo metadata.

## Test plan
- [ ] Merge, then confirm the next docs deploy updates the About sidebar automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated GitHub Actions workflow configuration to automatically sync the repository's homepage setting with deployed Pages URL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->