### PR TITLE
fix(llm): override OpenAI SDK User-Agent to bypass Cloudflare WAF

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,6 +10,7 @@ permissions:
   contents: read
   pages: write
   id-token: write
+  administration: write
 
 concurrency:
   group: pages
@@ -39,3 +40,7 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
+      - name: Update repo homepage
+        run: gh api -X PATCH repos/${{ github.repository }} -f homepage="${{ steps.deployment.outputs.page_url }}"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -32,4 +32,14 @@ def create_llm(config: LangGraphConfig) -> ChatOpenAI:
         # AIMessageChunks with usage_metadata=None and we can't emit
         # the cost-v1 DataPart on the terminal artifact.
         stream_usage=True,
+        # Cloudflare's managed WAF blocks the OpenAI SDK's default
+        # `OpenAI/Python <ver>` User-Agent (observed 403 "Your request
+        # was blocked" against api.proto-labs.ai). Override with the
+        # same identifier `tools/lg_tools.py` uses for outbound fetches
+        # so every protoAgent egress presents a consistent, allowlisted
+        # UA. If you self-host behind a different edge, this is safe to
+        # keep.
+        default_headers={
+            "User-Agent": "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)",
+        },
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.1.0"
+version = "0.2.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.2.0"
+version = "0.2.1"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
## Summary
- LangChain's `ChatOpenAI` sent the default `OpenAI/Python <ver>` User-Agent, which the managed WAF on the `proto-labs.ai` zone returns **HTTP 403 \"Your request was blocked.\"** for.
- `/v1/models` happened to succeed (different SDK path / UA), so the failure looked like a key/ACL problem when it was a header signature match.
- Sets `default_headers={\"User-Agent\": \"protoAgent/0.1 (+...)\"}` on the `ChatOpenAI` instance in `graph/llm.py`, matching the identifier `tools/lg_tools.py:226` already uses for outbound HTTP fetches.

## Reproduction (before fix)
\`\`\`
curl -H 'User-Agent: OpenAI/Python 1.54.0' -H 'Authorization: Bearer <key>' \
  -H 'Content-Type: application/json' \
  https://api.proto-labs.ai/v1/chat/completions \
  -d '{\"model\":\"groq-llama-70b\",\"messages\":[{\"role\":\"user\",\"content\":\"hi\"}]}'
# HTTP 403  \"Your request was blocked.\"
\`\`\`
Same call with any non-OpenAI UA (e.g. `curl/8.5`, `python-httpx/*`, `MyApp/1.0`, empty) → `200`.

## Why this path (not a WAF skip rule)
A Cloudflare Custom Rule skipping managed rules on `api.proto-labs.ai` is cleaner at the edge, but couples agent operability to zone config and the current `CLOUDFLARE_API_TOKEN` is DNS-only. The in-client override keeps self-hosters behind other edges working and removes the per-deployment Cloudflare dependency.

## Test plan
- [x] End-to-end: patched `graph/llm.py` in running `protoagent-local` container; `llm.invoke(\"reply with: pong\")` → `pong`. Captured outbound `User-Agent: protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)` on the wire.
- [ ] CI green on this PR.
- [ ] Image rebuild + redeploy (Watchtower / manual) picks up the fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Version**
  * Upgraded to v0.2.1

* **Improvements**
  * Enhanced LLM client configuration with improved request identification

* **Chores**
  * Optimized deployment workflow to automatically sync repository metadata with GitHub Pages publication
  * Expanded workflow permissions for deployment automation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->