### PR TITLE
feat(tools): with_fallback decorator + wire starter tools

### DIFF
--- a/tests/test_fallbacks.py
+++ b/tests/test_fallbacks.py
@@ -1,0 +1,84 @@
+"""Tests for the with_fallback tool decorator."""
+
+import pytest
+
+from tools.fallbacks import with_fallback
+
+
+@pytest.mark.asyncio
+async def test_async_success_passthrough():
+    @with_fallback()
+    async def ok(x: str) -> str:
+        return f"got {x}"
+
+    assert await ok("hi") == "got hi"
+
+
+@pytest.mark.asyncio
+async def test_async_exception_becomes_partial_result():
+    @with_fallback()
+    async def boom(x: str) -> str:
+        raise ValueError("kaboom")
+
+    result = await boom("hi")
+    assert result.startswith("Error (partial result):")
+    assert "ValueError: kaboom" in result
+    # Default detail names the wrapped function.
+    assert "boom" in result
+
+
+@pytest.mark.asyncio
+async def test_custom_fallback_message():
+    @with_fallback("the weather service is down")
+    async def boom() -> str:
+        raise RuntimeError("503")
+
+    result = await boom()
+    assert "the weather service is down" in result
+    assert "RuntimeError: 503" in result
+
+
+def test_sync_tool_supported():
+    @with_fallback()
+    def boom() -> str:
+        raise KeyError("missing")
+
+    result = boom()
+    assert result.startswith("Error (partial result):")
+    assert "KeyError" in result
+
+
+def test_sync_success_passthrough():
+    @with_fallback()
+    def ok() -> str:
+        return "fine"
+
+    assert ok() == "fine"
+
+
+@pytest.mark.asyncio
+async def test_long_error_is_truncated():
+    @with_fallback()
+    async def boom() -> str:
+        raise ValueError("x" * 1000)
+
+    result = await boom()
+    # Error message clamped to 200 chars.
+    assert "x" * 200 in result
+    assert "x" * 300 not in result
+
+
+@pytest.mark.asyncio
+async def test_preserves_name_and_signature():
+    @with_fallback()
+    async def my_named_tool(query: str, limit: int = 5) -> str:
+        """Docstring stays."""
+        return query
+
+    import inspect
+
+    assert my_named_tool.__name__ == "my_named_tool"
+    assert my_named_tool.__doc__ == "Docstring stays."
+    # Signature is recoverable through functools.wraps __wrapped__.
+    params = list(inspect.signature(my_named_tool).parameters)
+    assert params == ["query", "limit"]

--- a/tools/fallbacks.py
+++ b/tools/fallbacks.py
@@ -1,0 +1,79 @@
+"""Graceful fallback wrapper for agent tools.
+
+Wraps a tool so an *unhandled* exception becomes a structured "partial
+result" string the model can read and recover from, instead of propagating
+out of the tool loop and surfacing as a 500 in the A2A handler.
+
+Tools should still return their own ``"Error: ..."`` strings for *expected*
+failures (the established protoLabs convention — the LLM reads the string and
+retries). ``with_fallback`` is the safety net for the *unexpected*: a network
+library raising a novel exception type, a parsing edge case, etc.
+
+Adapted from the pattern shipped across the protoLabs agent fleet
+(quinn / protoResearcher / pwnDeck ``tools/fallbacks.py``), generalised to
+neutral wording and both sync and async tools.
+
+Usage — apply between ``@tool`` and the function so LangGraph still sees the
+real signature::
+
+    @tool
+    @with_fallback()
+    async def my_tool(query: str) -> str:
+        ...
+"""
+
+from __future__ import annotations
+
+import asyncio
+import functools
+import logging
+from typing import Callable
+
+log = logging.getLogger(__name__)
+
+
+def _format_fallback(func_name: str, fallback_msg: str, exc: Exception) -> str:
+    error_type = type(exc).__name__
+    error_msg = str(exc)[:200]
+    log.warning("[tool:%s] fell back after %s: %s", func_name, error_type, error_msg)
+    detail = fallback_msg or f"{func_name} could not complete."
+    # Lead with "Error" so AuditMiddleware records success=False, matching the
+    # convention tools use for their own returned error strings.
+    return (
+        f"Error (partial result): {detail}\n"
+        f"{error_type}: {error_msg}\n"
+        f"Tip: adjust the arguments and try again, or use a different tool."
+    )
+
+
+def with_fallback(fallback_msg: str = "") -> Callable:
+    """Decorator: turn an unhandled tool exception into a partial-result string.
+
+    Works on both ``async def`` and ``def`` tools. ``fallback_msg`` overrides
+    the generic "<tool> could not complete." line.
+    """
+
+    def decorator(func: Callable) -> Callable:
+        func_name = getattr(func, "__name__", "tool")
+
+        if asyncio.iscoroutinefunction(func):
+
+            @functools.wraps(func)
+            async def awrapper(*args, **kwargs):
+                try:
+                    return await func(*args, **kwargs)
+                except Exception as exc:  # noqa: BLE001 - safety net by design
+                    return _format_fallback(func_name, fallback_msg, exc)
+
+            return awrapper
+
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            try:
+                return func(*args, **kwargs)
+            except Exception as exc:  # noqa: BLE001 - safety net by design
+                return _format_fallback(func_name, fallback_msg, exc)
+
+        return wrapper
+
+    return decorator

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -47,11 +47,14 @@ from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from langchain_core.tools import tool
 
+from tools.fallbacks import with_fallback
+
 
 # ── current_time ─────────────────────────────────────────────────────────────
 
 
 @tool
+@with_fallback()
 async def current_time(timezone: str = "UTC") -> str:
     """Return the current wall-clock time in the given IANA timezone.
 
@@ -117,6 +120,7 @@ def _safe_eval(node: ast.AST) -> float | int:
 
 
 @tool
+@with_fallback()
 async def calculator(expression: str) -> str:
     """Evaluate a numeric expression and return the result.
 
@@ -145,6 +149,7 @@ async def calculator(expression: str) -> str:
 
 
 @tool
+@with_fallback()
 async def web_search(query: str, max_results: int = 5) -> str:
     """Search the web via DuckDuckGo and return a list of result summaries.
 
@@ -194,6 +199,7 @@ _MAX_OUTPUT_CHARS = 8000      # LLM context budget; callers can ask for a shorte
 
 
 @tool
+@with_fallback()
 async def fetch_url(url: str, max_chars: int = _MAX_OUTPUT_CHARS) -> str:
     """Fetch a URL and return its main text content.
 


### PR DESCRIPTION
Backport from #174 (Tier-1). Corroborated by 3 forks (quinn/protoResearcher/pwnDeck).

Adds `tools/fallbacks.py::with_fallback` — wraps a tool so an *unhandled* exception becomes a structured `Error (partial result): ...` string the model can read and recover from, instead of propagating to the A2A handler as a 500. Generalised from the fork pattern: neutral wording, logging, and both sync + async tools.

Applied to `current_time`/`calculator`/`web_search`/`fetch_url` as the canonical example (placed between `@tool` and the function so LangGraph keeps the real signature). Forks apply it to their own tools.

Tests: `tests/test_fallbacks.py` (success passthrough, exception→partial result, custom message, sync support, truncation, signature/name preservation). Full suite 389 passed (non-root 3.12).

> Base is `chore/workspace-config-conformance` (#171) for green CI; retarget to `main` once that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)