### PR TITLE
feat(subagents): researcher reference subagent (worker→researcher)

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ rename / release-pipeline wiring.
 | A2A server | `a2a_handler.py` | JSON-RPC 2.0 over `/a2a`, SSE streaming, `tasks/*` lifecycle, push notifications, well-known agent card, dual token-shape parsing |
 | Agent runtime | `graph/agent.py`, `server.py` | LangGraph `create_agent()` wired to the A2A handler, with streaming token capture for cost-v1 |
 | LLM gateway | `graph/llm.py` | OpenAI-compatible client pointed at LiteLLM — swap models by editing the gateway config, not the fork |
-| Subagents | `graph/subagents/config.py` | DeerFlow-pattern delegation via a `task()` tool; one placeholder `worker` ships |
+| Subagents | `graph/subagents/config.py` | DeerFlow-pattern delegation via a `task()` tool; one worked example ships — a `researcher` (web + memory, plan→search→synthesize→cite) |
 | Starter tools | `tools/lg_tools.py` | Twelve tools default-on: 4 keyless general (`current_time`, `calculator` safe AST eval, `web_search` via DuckDuckGo, `fetch_url`) + 5 memory (`memory_ingest`, `memory_recall`, `memory_list`, `memory_stats`, `daily_log`) bound to the KB store + 3 scheduler (`schedule_task`, `list_schedules`, `cancel_schedule`) bound to the scheduler backend |
 | Knowledge store | `knowledge/store.py` | sqlite + FTS5 (LIKE fallback). One `chunks` table for operator notes, daily-log entries, and conversation findings. Default-on; turn off with `middleware.knowledge: false` |
 | Scheduler | `scheduler/` | `schedule_task` / `list_schedules` / `cancel_schedule` tools backed by either a bundled sqlite scheduler or a Workstacean adapter (env-selected). Multi-agent-safe — every job is namespaced by `AGENT_NAME`. See [Schedule future work](./docs/guides/scheduler.md) |

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -110,7 +110,7 @@ Guidelines that have paid off across the protoLabs fleet:
 
 ## 5. Configure subagents (optional)
 
-`graph/subagents/config.py` ships with one placeholder `worker`.
+`graph/subagents/config.py` ships with one example, a `researcher`.
 Add more by registering `SubagentConfig` instances in
 `SUBAGENT_REGISTRY`. Each subagent gets a subset of tools and
 its own recursion budget.

--- a/config/langgraph-config.yaml
+++ b/config/langgraph-config.yaml
@@ -1,6 +1,6 @@
 # protoAgent — LangGraph runtime configuration
 #
-# The template ships with a single ``worker`` subagent and no knowledge
+# The template ships with a single ``researcher`` subagent and no knowledge
 # store. Fork this file to match your agent's skills / subagents /
 # middleware needs. Anything referenced here must also have a matching
 # entry in ``graph/subagents/config.py`` (for subagents) or a tool
@@ -20,22 +20,15 @@ model:
   max_iterations: 50
 
 subagents:
-  worker:
+  researcher:
     enabled: true
     tools:
       - current_time
-      - calculator
       - web_search
       - fetch_url
-      - memory_ingest
       - memory_recall
       - memory_list
-      - memory_stats
-      - daily_log
-      - schedule_task
-      - list_schedules
-      - cancel_schedule
-    max_turns: 20
+    max_turns: 40
 
 middleware:
   # All four subsystems default ON. The template constructs the
@@ -43,7 +36,7 @@ middleware:
   # ``server.py::_build_knowledge_store`` and ``_build_scheduler``).
   # Flip any of these to ``false`` to opt out — the corresponding
   # tools (memory_*, schedule_*) are dropped from the agent loop
-  # without touching the worker subagent's tool allowlist.
+  # without touching the researcher subagent's tool allowlist.
   knowledge: true
   audit: true
   memory: true

--- a/docs/guides/customize-and-deploy.md
+++ b/docs/guides/customize-and-deploy.md
@@ -101,7 +101,7 @@ The memory tools are dropped automatically when `middleware.knowledge: false`; t
 
 ## 6. (Optional) Configure subagents
 
-`graph/subagents/config.py` ships with one `worker`. Register more `SubagentConfig` instances in `SUBAGENT_REGISTRY` and add matching fields in `graph/config.py::LangGraphConfig`. The lead agent delegates via the `task` tool; the subagent delegation rules are built from the registry.
+`graph/subagents/config.py` ships with one `researcher`. Register more `SubagentConfig` instances in `SUBAGENT_REGISTRY` and add matching fields in `graph/config.py::LangGraphConfig`. The lead agent delegates via the `task` tool; the subagent delegation rules are built from the registry.
 
 ## 7. Build and ship the image
 

--- a/docs/guides/fork-the-template.md
+++ b/docs/guides/fork-the-template.md
@@ -49,7 +49,7 @@ See the [starter tools reference](/reference/starter-tools) for the shapes of th
 
 ## 5. Configure subagents (optional)
 
-`graph/subagents/config.py` ships with one `worker`. Either:
+`graph/subagents/config.py` ships with one `researcher`. Either:
 
 - Add more by registering `SubagentConfig` instances in `SUBAGENT_REGISTRY` and matching fields in `graph/config.py::LangGraphConfig`, or
 - Call `create_agent_graph(config, include_subagents=False)` in `server.py::_init_langgraph_agent()` to skip subagents entirely.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -7,7 +7,7 @@ Task-oriented procedures. Assumes you already have a running agent (see [Tutoria
 | [Customize & deploy](/guides/customize-and-deploy) | You've evaluated via the wizard and now want to fork, rename, and ship your own image |
 | [Fork checklist (fast path)](/guides/fork-the-template) | Terser version of the above for experienced forkers |
 | [Add a custom skill](/guides/add-a-skill) | Your agent does new things and callers need to dispatch to them |
-| [Configure subagents](/guides/subagents) | You want specialized delegates beyond the placeholder `worker` |
+| [Configure subagents](/guides/subagents) | You want specialized delegates beyond the shipped `researcher` |
 | [Wire Langfuse + Prometheus](/guides/observability) | You need traces and metrics in production |
 | [Eval your fork](/guides/evals) | You want a baseline pass-rate for the tools / memory / A2A surface in your fork |
 | [Schedule future work](/guides/scheduler) | You want the agent to defer tasks to itself ("remind me tomorrow", recurring sweeps) — local sqlite or Workstacean-backed |

--- a/docs/guides/subagents.md
+++ b/docs/guides/subagents.md
@@ -1,6 +1,6 @@
 # Configure subagents
 
-Subagents are specialized LLM workers the lead agent delegates to via the `task()` tool. The template ships with one placeholder `worker`. This guide walks through either adding more, trimming down, or turning the pattern off entirely.
+Subagents are specialized LLM workers the lead agent delegates to via the `task()` tool. The template ships one worked example: a `researcher` (web + memory, plan→search→synthesize→cite). This guide walks through adding more, trimming down, or turning the pattern off entirely.
 
 ## When to use subagents
 
@@ -15,56 +15,55 @@ When *not* to use:
 
 ## 1. Define the config
 
-Edit `graph/subagents/config.py`:
+`graph/subagents/config.py` already defines `RESEARCHER_CONFIG`. To add a second role, define another `SubagentConfig` and register it:
 
 ```python
-RESEARCHER_CONFIG = SubagentConfig(
-    name="researcher",
+SUMMARIZER_CONFIG = SubagentConfig(
+    name="summarizer",
     description=(
-        "Gathers background on a topic via web_search + fetch_url. "
-        "Returns a 200-word brief; the lead decides what to do next."
+        "Condenses long source text into a tight brief. "
+        "Returns a ≤200-word summary; the lead decides what to do next."
     ),
-    system_prompt="""You are the researcher subagent.
+    system_prompt="""You are the summarizer subagent.
 
-Your job: given a topic, search the web, read the top few results,
-and return a concise brief (≤200 words) that covers:
-- What the topic is
-- Key facts worth knowing
-- Any obvious risks or controversies
+Your job: given source text or URLs, return a concise brief (≤200 words):
+- What the material says
+- Key facts worth keeping
+- Any obvious gaps or caveats
 
 Rules:
 - Keep responses focused — the lead agent is waiting on your return
   value, not a conversation.
 - Use the same <scratch_pad> / <output> format as the lead agent.
 """,
-    tools=["web_search", "fetch_url", "current_time"],
+    tools=["fetch_url", "current_time"],
     max_turns=15,
 )
 
 SUBAGENT_REGISTRY: dict[str, SubagentConfig] = {
-    "worker": WORKER_CONFIG,
     "researcher": RESEARCHER_CONFIG,
+    "summarizer": SUMMARIZER_CONFIG,
 }
 ```
 
 ## 2. Expose the config shape
 
-The template's `LangGraphConfig` (in `graph/config.py`) has a `worker` field. Add one for each new subagent:
+The template's `LangGraphConfig` (in `graph/config.py`) has a `researcher` field. Add one for each new subagent:
 
 ```python
 @dataclass
 class LangGraphConfig:
     # ... existing fields ...
-    worker: SubagentDef = field(default_factory=lambda: SubagentDef(
-        tools=[
-            "current_time", "calculator", "web_search", "fetch_url",
-            "memory_ingest", "memory_recall", "memory_list", "memory_stats",
-            "daily_log",
-        ],
-        max_turns=20,
-    ))
     researcher: SubagentDef = field(default_factory=lambda: SubagentDef(
-        tools=["web_search", "fetch_url", "current_time"],
+        tools=[
+            "current_time",
+            "web_search", "fetch_url",
+            "memory_recall", "memory_list",
+        ],
+        max_turns=40,
+    ))
+    summarizer: SubagentDef = field(default_factory=lambda: SubagentDef(
+        tools=["fetch_url", "current_time"],
         max_turns=15,
     ))
 ```
@@ -72,7 +71,7 @@ class LangGraphConfig:
 And update the `from_yaml()` subagent loop:
 
 ```python
-for name in ("worker", "researcher"):  # ← add new names
+for name in ("researcher", "summarizer"):  # ← add new names
     if name in subagents:
         sub = subagents[name]
         setattr(config, name, SubagentDef(
@@ -88,22 +87,18 @@ for name in ("worker", "researcher"):  # ← add new names
 
 ```yaml
 subagents:
-  worker:
+  researcher:
     enabled: true
     tools:
       - current_time
-      - calculator
       - web_search
       - fetch_url
-      - memory_ingest
       - memory_recall
       - memory_list
-      - memory_stats
-      - daily_log
-    max_turns: 20
-  researcher:
+    max_turns: 40
+  summarizer:
     enabled: true
-    tools: [web_search, fetch_url, current_time]
+    tools: [fetch_url, current_time]
     max_turns: 15
 ```
 
@@ -115,8 +110,8 @@ The lead's `task()` tool docstring is how the LLM learns what subagents exist. I
 SYSTEM_PROMPT = """You are my-agent.
 
 Available subagents (invoke via the `task` tool):
-- `researcher` — gathers background on a topic, returns a ≤200-word brief
-- `worker` — general-purpose tool runner
+- `researcher` — gathers + synthesizes background on a topic, returns a sourced brief
+- `summarizer` — condenses long source text into a ≤200-word brief
 
 Delegate to researcher when a user asks an open-ended "find out about X"
 question. Handle short factual queries yourself.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -15,19 +15,15 @@ model:
   max_iterations: 50
 
 subagents:
-  worker:
+  researcher:
     enabled: true
     tools:
       - current_time
-      - calculator
       - web_search
       - fetch_url
-      - memory_ingest
       - memory_recall
       - memory_list
-      - memory_stats
-      - daily_log
-    max_turns: 20
+    max_turns: 40
 
 middleware:
   knowledge: true

--- a/docs/tutorials/first-tool.md
+++ b/docs/tutorials/first-tool.md
@@ -47,7 +47,7 @@ def get_all_tools(knowledge_store=None):
 
 ## 2. Allow the subagent to use it (optional)
 
-If you want the worker subagent to be able to call `git_sha`, add it to the allowlist in `graph/subagents/config.py`. Append rather than replace — dropping the bundled defaults removes the worker's memory tools:
+If you want the researcher subagent to be able to call `git_sha`, add it to the allowlist in `graph/subagents/config.py`. Append rather than replace — dropping the bundled defaults removes the researcher's memory tools:
 
 ```python
 WORKER_CONFIG = SubagentConfig(

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -54,7 +54,7 @@ def _build_task_tool(config: LangGraphConfig, all_tools: list[BaseTool]):
     async def task(
         description: str,
         prompt: str,
-        subagent_type: str = "worker",
+        subagent_type: str = "researcher",
         emit_skill: bool = False,
     ) -> str:
         """Delegate a task to a specialized subagent.

--- a/graph/config.py
+++ b/graph/config.py
@@ -34,16 +34,17 @@ class LangGraphConfig:
     max_tokens: int = 4096
     max_iterations: int = 75
 
-    # Subagents — template ships with one example (see graph/subagents/config.py).
-    # Add fields here as you add entries to SUBAGENT_REGISTRY.
-    worker: SubagentDef = field(default_factory=lambda: SubagentDef(
+    # Subagents — template ships one example, `researcher` (see
+    # graph/subagents/config.py). Add fields here as you add entries to
+    # SUBAGENT_REGISTRY. Tool/max_turns here mirror the registry default and
+    # are the YAML-overridable layer.
+    researcher: SubagentDef = field(default_factory=lambda: SubagentDef(
         tools=[
-            "current_time", "calculator", "web_search", "fetch_url",
-            "memory_ingest", "memory_recall", "memory_list", "memory_stats",
-            "daily_log",
-            "schedule_task", "list_schedules", "cancel_schedule",
+            "current_time",
+            "web_search", "fetch_url",
+            "memory_recall", "memory_list",
         ],
-        max_turns=20,
+        max_turns=40,
     ))
 
     # Middleware / subsystem toggles. All default-on so a fresh fork has
@@ -123,7 +124,7 @@ class LangGraphConfig:
             autostart_on_boot=runtime.get("autostart_on_boot", cls.autostart_on_boot),
         )
 
-        for name in ("worker",):
+        for name in ("researcher",):
             if name in subagents:
                 sub = subagents[name]
                 setattr(config, name, SubagentDef(

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -123,10 +123,10 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
             "max_iterations": config.max_iterations,
         },
         "subagents": {
-            "worker": {
-                "enabled": config.worker.enabled,
-                "tools": list(config.worker.tools),
-                "max_turns": config.worker.max_turns,
+            "researcher": {
+                "enabled": config.researcher.enabled,
+                "tools": list(config.researcher.tools),
+                "max_turns": config.researcher.max_turns,
             },
         },
         "middleware": {
@@ -196,14 +196,14 @@ def validate_config_dict(updates: dict[str, Any]) -> tuple[bool, str]:
         if max_iter < 1:
             return False, f"max_iterations must be >= 1, got {max_iter}"
 
-        worker = updates.get("subagents", {}).get("worker", {})
-        if worker:
-            max_turns = int(worker.get("max_turns", 20))
+        researcher = updates.get("subagents", {}).get("researcher", {})
+        if researcher:
+            max_turns = int(researcher.get("max_turns", 40))
             if max_turns < 1:
-                return False, f"worker.max_turns must be >= 1, got {max_turns}"
-            tools = worker.get("tools", [])
+                return False, f"researcher.max_turns must be >= 1, got {max_turns}"
+            tools = researcher.get("tools", [])
             if not isinstance(tools, list):
-                return False, "worker.tools must be a list"
+                return False, "researcher.tools must be a list"
 
         knowledge = updates.get("knowledge", {})
         if knowledge:

--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -6,11 +6,12 @@ prompt, and runs through ``AuditMiddleware`` exactly like the lead
 agent — so every tool call they make lands in ``audit.jsonl`` and
 Langfuse with the same session_id.
 
-The template ships with a single ``worker`` subagent to show the
-pattern. Extend, rename, or delete to match your agent's actual
-delegation surface. Quinn's reference layout had three (``auditor``
-for scans, ``verifier`` for validation, ``reporter`` for publishing);
-keep whatever shape fits your work.
+The template ships one subagent, ``researcher``, as a worked example:
+a read-and-synthesize role with web + memory tools and a real
+plan→search→read→synthesize→cite prompt. Extend, rename, or delete to
+match your agent's delegation surface. Quinn's reference layout had
+three (``auditor`` for scans, ``verifier`` for validation, ``reporter``
+for publishing); keep whatever shape fits your work.
 
 Rules:
 - ``tools`` — allowlist of tool names from ``tools/lg_tools.py``. If
@@ -41,38 +42,69 @@ class SubagentConfig:
     allow_skill_emission: bool = True
 
 
-WORKER_CONFIG = SubagentConfig(
-    name="worker",
+RESEARCHER_CONFIG = SubagentConfig(
+    name="researcher",
     description=(
-        "Example subagent — handles a scoped piece of work and reports "
-        "back to the lead. Replace with your agent's actual specialist "
-        "roles."
+        "Reads and synthesizes information from the web and the operator's "
+        "knowledge base. Use for: 'what's the current state of X?', "
+        "'find the best approach to Y', 'compare these three options', "
+        "or any background reading the lead agent doesn't want to do "
+        "inline. Multiple researcher tasks can run in parallel — fan out "
+        "when a question splits into independent sub-questions."
     ),
-    system_prompt="""You are a worker subagent for protoAgent.
+    system_prompt="""You are protoAgent's researcher subagent.
 
-Your job: execute the delegated task using the tools available to you
-and return a concise result.
+Your job: take a research question from the lead agent, gather
+evidence (web + the operator's knowledge base), and return a tight
+synthesis with sources.
+
+Workflow:
+1. **Plan briefly.** What does the question actually need answered?
+   What angles are worth covering? Note in <scratch_pad>.
+2. **Search.** Use ``web_search`` to find candidate sources;
+   ``memory_recall`` to pull anything the operator has already noted
+   on the topic. Skip memory_recall when the question is plainly
+   external-only (e.g., "what's the latest version of X?").
+3. **Read.** Use ``fetch_url`` on the most promising 2-4 sources.
+   Don't fetch every result — pick well, read deeply.
+4. **Synthesize.** Compose a tight answer in <output>. Lead with
+   the bottom line; back it with 2-4 specific claims, each with
+   the source URL inline. Note disagreement between sources when
+   it matters. End with a one-line "Confidence: high/medium/low"
+   based on source quality and consensus.
 
 Rules:
-- Keep responses focused — the lead agent is waiting on your return
-  value, not a conversation.
-- If a tool fails, surface the error in plain text; the lead decides
-  whether to retry or route differently.
-- Use the same <scratch_pad> / <output> format as the lead agent:
-  put deliberation in scratch_pad, the final result in output.
+- Lead with the answer, not the process. The lead agent doesn't
+  need to see "I searched for X, found Y" — they need the conclusion.
+- Cite sources inline as ``(domain.com)`` or full URL when short.
+  No bare claims that the operator can't verify.
+- Time-sensitive questions → call ``current_time`` first so
+  "latest" / "as of" framing is honest.
+- If memory has highly relevant context, say so explicitly
+  ("operator's notes from <date> say…") so the lead agent knows the
+  answer leans on private context vs. public sources.
+- Don't ingest your findings into memory unless the lead agent
+  explicitly asked for it. The lead is the operator-facing surface
+  and decides what's worth saving.
+- Hard stop at the configured max_turns. If you haven't converged
+  by then, return what you have with "Confidence: low — partial".
 
-Replace this prompt with domain-specific guidance once your agent has
-real specialized roles.""",
+Output format (same as the lead agent): deliberation in
+<scratch_pad>, the final synthesis in <output>. Keep <output>
+under ~400 words unless the question demands more.""",
     tools=[
-        "current_time", "calculator", "web_search", "fetch_url",
-        "memory_ingest", "memory_recall", "memory_list", "memory_stats",
-        "daily_log",
-        "schedule_task", "list_schedules", "cancel_schedule",
+        "current_time",
+        "web_search", "fetch_url",
+        "memory_recall", "memory_list",
     ],
-    max_turns=20,
+    # 40 turns leaves room for a real broad-question research arc
+    # (multiple search/fetch cycles + synthesis). Single-question
+    # researches typically converge in 6-10 turns, so this is
+    # headroom, not a target.
+    max_turns=40,
 )
 
 
 SUBAGENT_REGISTRY: dict[str, SubagentConfig] = {
-    "worker": WORKER_CONFIG,
+    "researcher": RESEARCHER_CONFIG,
 }

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -94,22 +94,22 @@ def test_apply_updates_adds_missing_sections(tmp_path: Path) -> None:
     assert doc["model"]["name"] == "x"
 
 
-def test_apply_updates_nested_worker(tmp_path: Path) -> None:
-    """subagents.worker.tools is a list, subagents.worker.enabled
+def test_apply_updates_nested_researcher(tmp_path: Path) -> None:
+    """subagents.researcher.tools is a list, subagents.researcher.enabled
     is a bool — both must land in the right nested slot."""
     from graph import config_io
 
     yaml_path = tmp_path / "c.yaml"
-    yaml_path.write_text("subagents:\n  worker:\n    enabled: false\n")
+    yaml_path.write_text("subagents:\n  researcher:\n    enabled: false\n")
     doc = config_io.load_yaml_doc(yaml_path)
 
     config_io.apply_updates_to_yaml(
         doc,
-        {"subagents": {"worker": {"enabled": True, "tools": ["current_time", "calculator"]}}},
+        {"subagents": {"researcher": {"enabled": True, "tools": ["current_time", "calculator"]}}},
     )
 
-    assert doc["subagents"]["worker"]["enabled"] is True
-    assert list(doc["subagents"]["worker"]["tools"]) == ["current_time", "calculator"]
+    assert doc["subagents"]["researcher"]["enabled"] is True
+    assert list(doc["subagents"]["researcher"]["tools"]) == ["current_time", "calculator"]
 
 
 # ── config_to_dict ───────────────────────────────────────────────────────────
@@ -134,7 +134,7 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature
-    assert d["subagents"]["worker"]["tools"] == list(cfg.worker.tools)
+    assert d["subagents"]["researcher"]["tools"] == list(cfg.researcher.tools)
     assert d["middleware"]["audit"] == cfg.audit_middleware
     assert d["knowledge"]["top_k"] == cfg.knowledge_top_k
     assert d["identity"]["name"] == cfg.identity_name
@@ -150,8 +150,8 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     ({"model": {"temperature": -0.1}}, "temperature"),
     ({"model": {"max_tokens": 0}}, "max_tokens"),
     ({"model": {"max_iterations": 0}}, "max_iterations"),
-    ({"subagents": {"worker": {"max_turns": 0}}}, "max_turns"),
-    ({"subagents": {"worker": {"tools": "not-a-list"}}}, "list"),
+    ({"subagents": {"researcher": {"max_turns": 0}}}, "max_turns"),
+    ({"subagents": {"researcher": {"tools": "not-a-list"}}}, "list"),
     ({"knowledge": {"top_k": 0}}, "top_k"),
 ])
 def test_validate_rejects_bad_values(bad_value, expected_error_fragment):

--- a/tests/test_skill_emission.py
+++ b/tests/test_skill_emission.py
@@ -162,7 +162,7 @@ def test_emit_multiple_skills() -> None:
 def test_subagent_config_default_allows_skill_emission() -> None:
     """SubagentConfig.allow_skill_emission defaults to True."""
     cfg = SubagentConfig(
-        name="worker",
+        name="researcher",
         description="d",
         system_prompt="s",
     )
@@ -172,7 +172,7 @@ def test_subagent_config_default_allows_skill_emission() -> None:
 def test_subagent_config_can_disable_skill_emission() -> None:
     """SubagentConfig.allow_skill_emission can be set to False."""
     cfg = SubagentConfig(
-        name="worker",
+        name="researcher",
         description="d",
         system_prompt="s",
         allow_skill_emission=False,
@@ -183,7 +183,7 @@ def test_subagent_config_can_disable_skill_emission() -> None:
 def test_subagent_config_disallowed_tools_unaffected() -> None:
     """Adding allow_skill_emission does not affect disallowed_tools."""
     cfg = SubagentConfig(
-        name="worker",
+        name="researcher",
         description="d",
         system_prompt="s",
         disallowed_tools=["task", "rm_rf"],


### PR DESCRIPTION
Backport from #174 (Tier-1), source: gina.

Replaces the generic empty `worker` placeholder with a real worked example — a `researcher` subagent with a plan→search→read→synthesize→cite prompt, web + memory tools, and `max_turns=40`. (`memory_search` adapted to core's `memory_recall`.)

Full rename `worker`→`researcher`:
- `graph/subagents/config.py` registry + `RESEARCHER_CONFIG`
- `graph/config.py` `LangGraphConfig.researcher` field + `from_yaml` loop
- `graph/config_io.py` serialization + validation
- `graph/agent.py` `task()` default `subagent_type`
- `config/langgraph-config.yaml`
- `tests/test_config_io.py`, `tests/test_skill_emission.py`
- docs: subagents guide reframed (add a `summarizer` alongside the shipped `researcher`); README / TEMPLATE / configuration / fork / first-tool one-liners

382 tests pass (validated non-root on 3.12).

> Base is `chore/workspace-config-conformance` for green CI; retarget to `main` after that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)