### PR TITLE
feat(llm): optional sampling params (top_p/top_k/penalties/chat_template_kwargs)

### DIFF
--- a/config/langgraph-config.yaml
+++ b/config/langgraph-config.yaml
@@ -18,6 +18,15 @@ model:
   temperature: 0.2
   max_tokens: 4096
   max_iterations: 50
+  # Advanced sampling — all optional; omit to use the gateway / model-card
+  # defaults. top_p + presence_penalty are standard OpenAI params; top_k +
+  # repetition_penalty + chat_template_kwargs ride extra_body for vLLM-style
+  # gateways. Typical self-hosted Qwen card:
+  #   top_p: 0.95
+  #   top_k: 20
+  #   presence_penalty: 0.0
+  #   repetition_penalty: 1.05
+  #   chat_template_kwargs: { preserve_thinking: true }
 
 subagents:
   worker:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -52,6 +52,13 @@ knowledge:
 | `temperature` | `0.2` | Sampling temperature. |
 | `max_tokens` | `4096` | Per-call output cap. |
 | `max_iterations` | `50` | Upper bound on tool-call loops per task. |
+| `top_p` | _(unset)_ | Nucleus sampling. Standard OpenAI param; sent only when set. |
+| `presence_penalty` | _(unset)_ | Standard OpenAI param; sent only when set. |
+| `top_k` | `-1` | Top-k sampling. Rides `extra_body` (vLLM-style gateways). `-1`/negative = gateway default. |
+| `repetition_penalty` | _(unset)_ | Rides `extra_body`; sent only when set. |
+| `chat_template_kwargs` | _(unset)_ | Dict passed via `extra_body` to the vLLM renderer, e.g. `{preserve_thinking: true}` to keep historical `<think>`/`<scratch_pad>` blocks across turns. |
+
+All sampling params are optional — omit to use the gateway / model-card defaults. `temperature`, `max_tokens`, `top_p`, and `presence_penalty` are standard OpenAI fields; `top_k`, `repetition_penalty`, and `chat_template_kwargs` are sent via `extra_body` for vLLM-compatible gateways.
 
 ## `subagents`
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -34,6 +34,18 @@ class LangGraphConfig:
     max_tokens: int = 4096
     max_iterations: int = 75
 
+    # Advanced sampling — all opt-in. ``None`` (or a negative top_k) means
+    # "let the gateway / model card decide". top_p and presence_penalty are
+    # standard OpenAI params; top_k and repetition_penalty aren't, so they
+    # ride ``extra_body`` for vLLM-compatible gateways. ``chat_template_kwargs``
+    # also rides extra_body — e.g. vLLM's ``preserve_thinking=True`` to keep
+    # historical <think>/<scratch_pad> blocks across turns.
+    top_p: float | None = None
+    top_k: int = -1
+    presence_penalty: float | None = None
+    repetition_penalty: float | None = None
+    chat_template_kwargs: dict | None = None
+
     # Subagents — template ships with one example (see graph/subagents/config.py).
     # Add fields here as you add entries to SUBAGENT_REGISTRY.
     worker: SubagentDef = field(default_factory=lambda: SubagentDef(
@@ -110,6 +122,11 @@ class LangGraphConfig:
             temperature=model.get("temperature", cls.temperature),
             max_tokens=model.get("max_tokens", cls.max_tokens),
             max_iterations=model.get("max_iterations", cls.max_iterations),
+            top_p=model.get("top_p", cls.top_p),
+            top_k=model.get("top_k", cls.top_k),
+            presence_penalty=model.get("presence_penalty", cls.presence_penalty),
+            repetition_penalty=model.get("repetition_penalty", cls.repetition_penalty),
+            chat_template_kwargs=model.get("chat_template_kwargs", cls.chat_template_kwargs),
             knowledge_middleware=middleware.get("knowledge", cls.knowledge_middleware),
             audit_middleware=middleware.get("audit", cls.audit_middleware),
             memory_middleware=middleware.get("memory", cls.memory_middleware),

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -11,27 +11,22 @@ from langchain_openai import ChatOpenAI
 from graph.config import LangGraphConfig
 
 
-def create_llm(config: LangGraphConfig) -> ChatOpenAI:
-    """Create a LangChain ChatModel from config.
-
-    Routes through the LiteLLM gateway which handles provider
-    routing (Anthropic, OpenAI, vLLM, etc.) behind a single
-    OpenAI-compatible endpoint.
-    """
+def _build_llm_kwargs(config: LangGraphConfig) -> dict:
+    """Assemble the ChatOpenAI kwargs from config (extracted for testing)."""
     api_key = config.api_key or os.environ.get("OPENAI_API_KEY", "")
 
-    return ChatOpenAI(
-        base_url=config.api_base,
-        api_key=api_key,
-        model=config.model_name,
-        temperature=config.temperature,
-        max_tokens=config.max_tokens,
+    kwargs: dict = {
+        "base_url": config.api_base,
+        "api_key": api_key,
+        "model": config.model_name,
+        "temperature": config.temperature,
+        "max_tokens": config.max_tokens,
         # Forces token-usage info onto the final streaming chunk so
         # `astream_events(v2)` populates `output.usage_metadata` on
         # `on_chat_model_end`. Without this, streaming chunks arrive as
         # AIMessageChunks with usage_metadata=None and we can't emit
         # the cost-v1 DataPart on the terminal artifact.
-        stream_usage=True,
+        "stream_usage": True,
         # Cloudflare's managed WAF blocks the OpenAI SDK's default
         # `OpenAI/Python <ver>` User-Agent (observed 403 "Your request
         # was blocked" against api.proto-labs.ai). Override with the
@@ -39,7 +34,38 @@ def create_llm(config: LangGraphConfig) -> ChatOpenAI:
         # so every protoAgent egress presents a consistent, allowlisted
         # UA. If you self-host behind a different edge, this is safe to
         # keep.
-        default_headers={
+        "default_headers": {
             "User-Agent": "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)",
         },
-    )
+    }
+
+    # Optional sampling params — only sent when set, so the gateway / model
+    # card defaults win otherwise. top_p + presence_penalty are standard
+    # OpenAI fields; top_k, repetition_penalty, and chat_template_kwargs ride
+    # `extra_body` for vLLM-compatible gateways (not in OpenAI's schema).
+    if config.top_p is not None:
+        kwargs["top_p"] = config.top_p
+    if config.presence_penalty is not None:
+        kwargs["presence_penalty"] = config.presence_penalty
+
+    extra_body: dict = {}
+    if config.top_k is not None and config.top_k >= 0:
+        extra_body["top_k"] = config.top_k
+    if config.repetition_penalty is not None:
+        extra_body["repetition_penalty"] = config.repetition_penalty
+    if config.chat_template_kwargs:
+        extra_body["chat_template_kwargs"] = dict(config.chat_template_kwargs)
+    if extra_body:
+        kwargs["extra_body"] = extra_body
+
+    return kwargs
+
+
+def create_llm(config: LangGraphConfig) -> ChatOpenAI:
+    """Create a LangChain ChatModel from config.
+
+    Routes through the LiteLLM gateway which handles provider
+    routing (Anthropic, OpenAI, vLLM, etc.) behind a single
+    OpenAI-compatible endpoint.
+    """
+    return ChatOpenAI(**_build_llm_kwargs(config))

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -1,0 +1,69 @@
+"""Tests for LLM kwargs assembly — sampling params + extra_body wiring."""
+
+from graph.config import LangGraphConfig
+from graph.llm import _build_llm_kwargs
+
+
+def test_defaults_omit_optional_sampling_params():
+    kwargs = _build_llm_kwargs(LangGraphConfig())
+    # Always present.
+    assert kwargs["model"]
+    assert kwargs["stream_usage"] is True
+    assert kwargs["max_tokens"] == LangGraphConfig().max_tokens
+    # Opt-in params are absent by default → gateway/model-card defaults win.
+    assert "top_p" not in kwargs
+    assert "presence_penalty" not in kwargs
+    assert "extra_body" not in kwargs
+
+
+def test_standard_openai_params_passed_directly():
+    cfg = LangGraphConfig(top_p=0.95, presence_penalty=0.5)
+    kwargs = _build_llm_kwargs(cfg)
+    assert kwargs["top_p"] == 0.95
+    assert kwargs["presence_penalty"] == 0.5
+    # These aren't extra_body fields.
+    assert "extra_body" not in kwargs
+
+
+def test_non_openai_params_ride_extra_body():
+    cfg = LangGraphConfig(
+        top_k=20,
+        repetition_penalty=1.1,
+        chat_template_kwargs={"preserve_thinking": True},
+    )
+    kwargs = _build_llm_kwargs(cfg)
+    eb = kwargs["extra_body"]
+    assert eb["top_k"] == 20
+    assert eb["repetition_penalty"] == 1.1
+    assert eb["chat_template_kwargs"] == {"preserve_thinking": True}
+
+
+def test_negative_top_k_means_default_and_is_omitted():
+    # -1 is the "let the gateway decide" sentinel.
+    kwargs = _build_llm_kwargs(LangGraphConfig(top_k=-1))
+    assert "extra_body" not in kwargs
+
+
+def test_from_yaml_reads_sampling_block(tmp_path):
+    import yaml
+
+    p = tmp_path / "c.yaml"
+    p.write_text(
+        yaml.safe_dump(
+            {
+                "model": {
+                    "top_p": 0.9,
+                    "top_k": 40,
+                    "presence_penalty": 0.3,
+                    "repetition_penalty": 1.05,
+                    "chat_template_kwargs": {"preserve_thinking": True},
+                }
+            }
+        )
+    )
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.top_p == 0.9
+    assert cfg.top_k == 40
+    assert cfg.presence_penalty == 0.3
+    assert cfg.repetition_penalty == 1.05
+    assert cfg.chat_template_kwargs == {"preserve_thinking": True}


### PR DESCRIPTION
Backport from #174 (Tier-1), source: gina.

Adds opt-in sampling params to the LLM factory:
- `top_p`, `presence_penalty` — standard OpenAI fields, passed directly
- `top_k`, `repetition_penalty`, `chat_template_kwargs` — ride `extra_body` for vLLM-compatible gateways (e.g. `{preserve_thinking: true}`)

All optional — omitted unless set, so the gateway / model-card defaults win otherwise. `top_k=-1` is the "use default" sentinel.

`_build_llm_kwargs()` extracted from `create_llm()` for testing. Adds `LangGraphConfig` fields + `from_yaml` parsing, commented YAML examples, a `configuration.md` table, and `tests/test_llm.py`. 387 tests pass (non-root 3.12).

> Base `chore/workspace-config-conformance`; retarget to `main` after that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)