### PR TITLE
feat(a2a): confidence-v1 extension (self-reported confidence DataPart)

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ subagent `task()` delegation, and the structured-output protocol.
 | URI | Declared on card | Emitted at runtime |
 |---|---|---|
 | `cost-v1` (`https://protolabs.ai/a2a/ext/cost-v1`) | Yes | Yes — every terminal task carries a cost-v1 DataPart with token usage + `durationMs` |
+| `confidence-v1` (`https://proto-labs.ai/a2a/ext/confidence-v1`) | Yes | When the model self-reports a `<confidence>` tag — a confidence-v1 DataPart with the score (`[0,1]`), optional explanation, and `success` |
 | `a2a.trace` propagation | No (it's a protocol convention, not a card extension) | Yes — reads caller's Langfuse trace context from `params.metadata["a2a.trace"]` and nests this agent's trace under it |
 
 Declare additional extensions on the card in

--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -74,6 +74,13 @@ WORLDSTATE_DELTA_MIME = "application/vnd.protolabs.worldstate-delta+json"
 # Ref: protoWorkstacean/docs/extensions/cost-v1.md
 COST_MIME = "application/vnd.protolabs.cost-v1+json"
 
+# Confidence-v1: the agent's self-reported confidence + optional explanation on
+# the terminal artifact. A consumer (e.g. Workstacean's confidence interceptor)
+# reads result.data.confidence (clamped to [0, 1]) and optional
+# result.data.confidenceExplanation to record calibration samples.
+# Schema: {"confidence": float, "confidenceExplanation": str?, "success": bool}
+CONFIDENCE_MIME = "application/vnd.protolabs.confidence-v1+json"
+
 # ── Data types ────────────────────────────────────────────────────────────────
 
 
@@ -119,6 +126,12 @@ class TaskRecord:
     # cost interceptor (protoWorkstacean#372) can record per-skill samples.
     # Shape: {"input_tokens": int, "output_tokens": int, "total_tokens": int}
     usage: dict = field(default_factory=lambda: {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+    # Self-reported confidence for the confidence-v1 DataPart. Set by the
+    # producer when it parses a <confidence> tag out of the model's final
+    # output. Clamped to [0, 1] on write; None when the model didn't report
+    # one (the DataPart is then omitted).
+    confidence: float | None = None
+    confidence_explanation: str | None = None
     # ── asyncio primitives (not serialised) ──
     _cancel_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
     _update_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
@@ -236,6 +249,28 @@ class A2ATaskStore:
                 record.usage["input_tokens"] + record.usage["output_tokens"]
             )
 
+    async def set_confidence(
+        self,
+        task_id: str,
+        confidence: float,
+        explanation: str | None = None,
+    ) -> None:
+        """Record the agent's self-reported confidence for this task.
+
+        Called once from the producer when it parses a <confidence> tag out of
+        the model's final output. Emitted on the terminal artifact under the
+        confidence-v1 MIME. Clamped to [0, 1] defensively so the DataPart is
+        always in-spec.
+        """
+        clamped = max(0.0, min(1.0, float(confidence)))
+        async with self._lock:
+            record = self._tasks.get(task_id)
+            if record is None:
+                return
+            record.confidence = clamped
+            if explanation and isinstance(explanation, str):
+                record.confidence_explanation = explanation.strip() or None
+
     async def cancel_if_not_terminal(self, task_id: str) -> TaskRecord | None:
         """Atomically cancel a task iff it's not already terminal.
 
@@ -350,7 +385,33 @@ def _terminal_artifact_parts(record: TaskRecord) -> list[dict]:
             "data": cost_data,
             "metadata": {"mimeType": COST_MIME},
         })
+    confidence_data = _confidence_payload(record)
+    if confidence_data is not None:
+        parts.append({
+            "kind": "data",
+            "data": confidence_data,
+            "metadata": {"mimeType": CONFIDENCE_MIME},
+        })
     return parts
+
+
+def _confidence_payload(record: TaskRecord) -> dict | None:
+    """Build the confidence-v1 payload, or None if the agent didn't
+    self-report a confidence this run.
+
+    ``success`` is derived from the terminal state — COMPLETED is the only
+    truthy case. Reporting confidence on a FAILED run is exactly the
+    "high-confidence failure" calibration signal, so it's still emitted.
+    """
+    if record.confidence is None:
+        return None
+    payload: dict = {
+        "confidence": record.confidence,
+        "success": record.state == COMPLETED,
+    }
+    if record.confidence_explanation:
+        payload["confidenceExplanation"] = record.confidence_explanation
+    return payload
 
 
 def _cost_payload(record: TaskRecord) -> dict | None:
@@ -784,6 +845,17 @@ async def _run_task_background(
                         task_id,
                         input_tokens=payload.get("input_tokens", 0),
                         output_tokens=payload.get("output_tokens", 0),
+                    )
+
+            elif event_type == "confidence":
+                # Self-reported confidence parsed from the model's <confidence>
+                # tag. Yielded before "done" so it lands on the COMPLETED
+                # artifact's confidence-v1 DataPart.
+                if isinstance(payload, dict) and payload.get("confidence") is not None:
+                    await _store.set_confidence(
+                        task_id,
+                        confidence=payload["confidence"],
+                        explanation=payload.get("explanation"),
                     )
 
             elif event_type == "done":

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -29,6 +29,27 @@ Captured by the `on_chat_model_end` handler in `_chat_langgraph_stream`. Require
 
 `costUsd` is not captured today — deriving it from model rates is a follow-up. Consumers tolerate missing `costUsd` and can compute it from `usage` themselves.
 
+## `confidence-v1`
+
+**URI**: `https://proto-labs.ai/a2a/ext/confidence-v1`
+**mimeType**: `application/vnd.protolabs.confidence-v1+json`
+**Direction**: emitted by this agent
+**Declared on card**: yes (by default)
+
+When the model self-reports a `<confidence>` tag in its final output, the terminal task carries a DataPart with the score:
+
+```json
+{
+  "data": {
+    "confidence": 0.85,
+    "success": true,
+    "confidenceExplanation": "two consistent sources agreed"
+  }
+}
+```
+
+The model emits the tags after `</output>` (see the protocol in `graph/output_format.py::OUTPUT_FORMAT_INSTRUCTIONS`); the server parses them with `extract_confidence()` and the A2A handler records them via `set_confidence()`, clamping to `[0, 1]`. The DataPart is omitted entirely when the model didn't report a score. `success` reflects the terminal state (`COMPLETED` only) — a high `confidence` on a non-success run is the "high-confidence failure" calibration signal.
+
 ## `effect-domain-v1`
 
 **URI**: `https://protolabs.ai/a2a/ext/effect-domain-v1`

--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -50,6 +50,16 @@ Rules:
   finished, customer-ready answer in `<output>`.
 - If you must defer or ask for clarification, put the question inside
   `<output>` too — the user never sees `<scratch_pad>`.
+
+Optionally, after `</output>`, you may self-report confidence:
+
+    <confidence>0.85</confidence>
+    <confidence_explanation>one short sentence on what drove the score</confidence_explanation>
+
+- `<confidence>` is a number in [0, 1] — your honest self-assessment of
+  whether the answer is correct/complete. Omit it if you'd only be guessing.
+- `<confidence_explanation>` is optional. Neither tag is shown to the user;
+  they ride a confidence-v1 DataPart on the A2A artifact.
 """.strip()
 
 
@@ -59,6 +69,14 @@ _ORPHAN_SCRATCH_OPEN_RE = re.compile(r"<scratch_pad>[\s\S]*$", re.IGNORECASE)
 _THINK_RE = re.compile(r"<think>[\s\S]*?</think>", re.IGNORECASE)
 _ORPHAN_THINK_OPEN_RE = re.compile(r"<think>[\s\S]*$", re.IGNORECASE)
 _ORPHAN_THINK_CLOSE_RE = re.compile(r"</think>\s*", re.IGNORECASE)
+_CONFIDENCE_BLOCK_RE = re.compile(r"<confidence>[\s\S]*?</confidence>", re.IGNORECASE)
+_CONFIDENCE_EXPL_BLOCK_RE = re.compile(
+    r"<confidence_explanation>[\s\S]*?</confidence_explanation>", re.IGNORECASE,
+)
+_CONFIDENCE_RE = re.compile(r"<confidence>\s*(-?[\d.]+)\s*</confidence>", re.IGNORECASE)
+_CONFIDENCE_EXPLANATION_RE = re.compile(
+    r"<confidence_explanation>([\s\S]*?)</confidence_explanation>", re.IGNORECASE,
+)
 
 
 def _strip_reasoning(text: str) -> str:
@@ -73,7 +91,32 @@ def _strip_reasoning(text: str) -> str:
     text = _ORPHAN_THINK_CLOSE_RE.sub("", text)
     text = _SCRATCH_RE.sub("", text)
     text = _ORPHAN_SCRATCH_OPEN_RE.sub("", text)
+    # Confidence tags ride a DataPart, never the user-facing text. Strip them
+    # in case the model emits them inside (or right after) <output>.
+    text = _CONFIDENCE_EXPL_BLOCK_RE.sub("", text)
+    text = _CONFIDENCE_BLOCK_RE.sub("", text)
     return text
+
+
+def extract_confidence(text: str) -> tuple[float | None, str | None]:
+    """Parse an optional self-reported ``<confidence>`` (and explanation).
+
+    Returns ``(confidence, explanation)`` where confidence is a float or
+    None (malformed/absent) and explanation is a stripped string or None.
+    The A2A handler clamps confidence to [0, 1] on write.
+    """
+    confidence: float | None = None
+    m = _CONFIDENCE_RE.search(text)
+    if m:
+        try:
+            confidence = float(m.group(1))
+        except ValueError:
+            confidence = None
+    explanation: str | None = None
+    me = _CONFIDENCE_EXPLANATION_RE.search(text)
+    if me:
+        explanation = me.group(1).strip() or None
+    return confidence, explanation
 
 
 def extract_output(text: str) -> str:

--- a/server.py
+++ b/server.py
@@ -32,7 +32,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from graph.output_format import extract_output
+from graph.output_format import extract_confidence, extract_output
 
 if TYPE_CHECKING:
     from scheduler.interface import SchedulerBackend
@@ -736,6 +736,13 @@ async def _chat_langgraph_stream(
                             "output_tokens": int(usage.get("output_tokens", 0) or 0),
                         })
 
+            # Self-reported confidence, if the model emitted <confidence>.
+            # Yielded before "done" so the A2A handler records it on the
+            # terminal artifact's confidence-v1 DataPart.
+            confidence, explanation = extract_confidence(accumulated_raw)
+            if confidence is not None:
+                yield ("confidence", {"confidence": confidence, "explanation": explanation})
+
             yield ("done", extract_output(accumulated_raw))
 
         except GeneratorExit:
@@ -868,6 +875,10 @@ def _build_agent_card(host: str) -> dict:
                 # cost-v1 emission is wired by default via the `on_chat_model_end`
                 # capture in _chat_langgraph_stream above.
                 {"uri": "https://protolabs.ai/a2a/ext/cost-v1"},
+                # confidence-v1: emitted when the model self-reports a
+                # <confidence> tag (see graph/output_format.py::extract_confidence
+                # and the confidence handler in _run_task_background).
+                {"uri": "https://proto-labs.ai/a2a/ext/confidence-v1"},
             ],
         },
         "defaultInputModes": ["text/plain"],

--- a/tests/test_confidence.py
+++ b/tests/test_confidence.py
@@ -1,0 +1,116 @@
+"""Tests for the confidence-v1 A2A extension wiring."""
+
+import pytest
+
+from a2a_handler import (
+    CANCELED,
+    COMPLETED,
+    CONFIDENCE_MIME,
+    A2ATaskStore,
+    TaskRecord,
+    _confidence_payload,
+    _terminal_artifact_parts,
+)
+from graph.output_format import extract_confidence, extract_output
+
+
+def _now() -> str:
+    from datetime import datetime, timezone
+
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _record(**kw) -> TaskRecord:
+    d = dict(
+        id="t", context_id="c", state=COMPLETED,
+        created_at=_now(), updated_at=_now(), message_text="hi",
+    )
+    d.update(kw)
+    return TaskRecord(**d)
+
+
+# ── extract_confidence ────────────────────────────────────────────────────────
+
+def test_extract_confidence_parses_score_and_explanation():
+    text = (
+        "<output>The answer is 42.</output>\n"
+        "<confidence>0.85</confidence>\n"
+        "<confidence_explanation>two consistent sources</confidence_explanation>"
+    )
+    conf, expl = extract_confidence(text)
+    assert conf == 0.85
+    assert expl == "two consistent sources"
+
+
+def test_extract_confidence_absent_returns_none():
+    conf, expl = extract_confidence("<output>no confidence here</output>")
+    assert conf is None
+    assert expl is None
+
+
+def test_extract_confidence_malformed_score_is_none():
+    conf, _ = extract_confidence("<confidence>not-a-number</confidence>")
+    assert conf is None
+
+
+def test_confidence_tags_stripped_from_output():
+    text = (
+        "<output>Clean answer.</output>"
+        "<confidence>0.9</confidence>"
+        "<confidence_explanation>x</confidence_explanation>"
+    )
+    out = extract_output(text)
+    assert out == "Clean answer."
+    assert "confidence" not in out.lower()
+
+
+# ── _confidence_payload ───────────────────────────────────────────────────────
+
+def test_payload_none_when_no_confidence():
+    assert _confidence_payload(_record(confidence=None)) is None
+
+
+def test_payload_success_true_on_completed():
+    p = _confidence_payload(_record(state=COMPLETED, confidence=0.7))
+    assert p == {"confidence": 0.7, "success": True}
+
+
+def test_payload_success_false_on_non_completed_includes_explanation():
+    p = _confidence_payload(
+        _record(state=CANCELED, confidence=0.9, confidence_explanation="sure but wrong")
+    )
+    assert p["success"] is False
+    assert p["confidence"] == 0.9
+    assert p["confidenceExplanation"] == "sure but wrong"
+
+
+def test_terminal_artifact_includes_confidence_datapart():
+    parts = _terminal_artifact_parts(
+        _record(accumulated_text="done", confidence=0.6)
+    )
+    data_parts = [p for p in parts if p.get("metadata", {}).get("mimeType") == CONFIDENCE_MIME]
+    assert len(data_parts) == 1
+    assert data_parts[0]["data"]["confidence"] == 0.6
+
+
+def test_terminal_artifact_omits_confidence_when_unset():
+    parts = _terminal_artifact_parts(_record(accumulated_text="done"))
+    assert not any(
+        p.get("metadata", {}).get("mimeType") == CONFIDENCE_MIME for p in parts
+    )
+
+
+# ── set_confidence clamping ───────────────────────────────────────────────────
+
+@pytest.mark.asyncio
+async def test_set_confidence_clamps_and_stores():
+    store = A2ATaskStore()
+    rec = await store.create(_record(id="conf-task", state="working"))
+    await store.set_confidence(rec.id, confidence=1.7, explanation="  over  ")
+    got = await store.get(rec.id)
+    assert got.confidence == 1.0  # clamped
+    assert got.confidence_explanation == "over"
+
+    await store.set_confidence(rec.id, confidence=-0.5)
+    got = await store.get(rec.id)
+    assert got.confidence == 0.0


### PR DESCRIPTION
Backport from #174 (Tier-1), source: quinn. Mirrors the existing cost-v1 wiring end-to-end.

**Flow:** the model optionally emits `<confidence>0.85</confidence>` (+ optional `<confidence_explanation>`) after `</output>` → `graph/output_format.py::extract_confidence` parses it → the server yields a `("confidence", …)` event before `done` → the A2A handler's `set_confidence()` records it on the `TaskRecord` (clamped to `[0,1]`) → `_terminal_artifact_parts` emits a `confidence-v1` DataPart `{confidence, success, confidenceExplanation?}`.

- `success` reflects the terminal state (COMPLETED only) — high confidence on a non-success run is the "high-confidence failure" calibration signal.
- DataPart omitted entirely when the model doesn't self-report.
- Confidence tags are stripped from the user-facing output.
- Declared on the agent card (`https://proto-labs.ai/a2a/ext/confidence-v1`).

Files: `a2a_handler.py` (MIME, TaskRecord fields, `set_confidence`, `_confidence_payload`, consumer case), `graph/output_format.py` (parse + strip + prompt), `server.py` (emit + card), `tests/test_confidence.py` (10 tests), README + extensions reference.

392 tests pass (non-root 3.12).

> Base `chore/workspace-config-conformance`; retarget to `main` after that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)