### PR TITLE
feat(output): recover truncated <output>, diagnose silent turns

### DIFF
--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -25,7 +25,10 @@ both the lead agent and subagent system prompts.
 
 from __future__ import annotations
 
+import logging
 import re
+
+log = logging.getLogger("protoagent.output_format")
 
 OUTPUT_FORMAT_INSTRUCTIONS = """
 # Response format
@@ -76,18 +79,55 @@ def _strip_reasoning(text: str) -> str:
     return text
 
 
+_ORPHAN_OUTPUT_OPEN_RE = re.compile(r"<output>([\s\S]*)$", re.IGNORECASE)
+
+
 def extract_output(text: str) -> str:
     """Return the user-facing content from a complete model response.
 
     Order of preference:
-    1. Content inside the first ``<output>...</output>`` pair (still
-       with any nested reasoning markers stripped).
-    2. Full text with all reasoning markers stripped — covers the case
+    1. Content inside the first ``<output>...</output>`` pair (with any
+       nested reasoning markers stripped).
+    2. Orphan-open ``<output>`` with no closing tag — recovers responses
+       truncated mid-output when ``max_tokens`` is hit. Everything from the
+       opener to end of text, scratch stripped.
+    3. Full text with all reasoning markers stripped — covers the case
        where the model skipped ``<output>`` but still wrapped scratch.
-    3. Raw text if none of the above triggers — the model ignored every
-       convention. Rare in practice once the prompt is in place.
+
+    Returns "" when every strategy yields empty, logging a WARNING with a
+    sanitized preview so operators can tell *why* a turn went silent
+    (truncated mid-scratch vs. truly empty vs. odd shape). ``scratch_pad`` is
+    never surfaced — leaking internal reasoning breaks the protocol contract.
     """
+    if not text or not text.strip():
+        return ""
+
+    # 1. Closed <output>...</output>
     m = _OUTPUT_RE.search(text)
     if m:
-        return _strip_reasoning(m.group(1)).strip()
-    return _strip_reasoning(text).strip()
+        cleaned = _strip_reasoning(m.group(1)).strip()
+        if cleaned:
+            return cleaned
+
+    # 2. Orphan <output> opener (max_tokens truncation mid-output).
+    orphan = _ORPHAN_OUTPUT_OPEN_RE.search(text)
+    if orphan:
+        cleaned = _strip_reasoning(orphan.group(1)).strip()
+        if cleaned:
+            return cleaned
+
+    # 3. Last resort — strip reasoning, return what's left.
+    fallback = _strip_reasoning(text).strip()
+    if fallback:
+        return fallback
+
+    preview = text[:400].replace("\n", "\\n")
+    log.warning(
+        "[extract_output] empty after stripping — len=%d scratch=%s "
+        "output=%s preview=%r",
+        len(text),
+        "<scratch_pad>" in text.lower(),
+        "<output>" in text.lower(),
+        preview,
+    )
+    return ""

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -94,3 +94,25 @@ def test_instructions_mention_both_tags():
     """Sanity check — the prompt fragment must teach both tags."""
     assert "<scratch_pad>" in OUTPUT_FORMAT_INSTRUCTIONS
     assert "<output>" in OUTPUT_FORMAT_INSTRUCTIONS
+
+
+def test_extract_output_recovers_truncated_orphan_output():
+    """max_tokens hit mid-<output>: no closing tag. Tier 2 recovers the
+    partial answer from the opener to EOT, scratch stripped."""
+    text = "<scratch_pad>planning the reply</scratch_pad><output>The partial answer that got cut o"
+    assert extract_output(text) == "The partial answer that got cut o"
+
+
+def test_extract_output_empty_when_scratch_only(caplog):
+    """Scratch-only with no output → empty (never leak reasoning), and a
+    WARNING diagnostic so the operator can see the turn went silent."""
+    import logging
+
+    with caplog.at_level(logging.WARNING, logger="protoagent.output_format"):
+        assert extract_output("<scratch_pad>only reasoning, never committed</scratch_pad>") == ""
+    assert any("empty after stripping" in r.message for r in caplog.records)
+
+
+def test_extract_output_empty_input_returns_empty():
+    assert extract_output("") == ""
+    assert extract_output("   \n  ") == ""


### PR DESCRIPTION
Backport from #174 (Tier-1), source: gina.

Upgrades `extract_output` from 2-tier to 3-tier:
1. Closed `<output>…</output>` (unchanged)
2. **New:** orphan-open `<output>` with no closing tag — recovers a reply truncated mid-output when `max_tokens` is hit (take from the opener to EOT, scratch stripped)
3. Strip-all fallback (unchanged)

When every strategy yields empty, it logs a `WARNING` with a sanitized preview (`len` / has-scratch / has-output) so operators can distinguish a truncated-mid-scratch turn from a genuinely empty one — instead of a silent drop. `scratch_pad` is never surfaced.

3 new tests; 385 pass (non-root 3.12).

### Deferred (scoped follow-up)
gina's companion `is_dropped_scratch_turn` + `DROPPED_SCRATCH_KICKER` re-prompt loop (detect a scratch-only/no-output/no-tool-call turn and kick once) threads through the server streaming loop — held back so it gets a careful, focused integration rather than riding this self-contained parsing fix.

> Base `chore/workspace-config-conformance`; retarget to `main` after that merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)