### PR TITLE
fix(docker): install runtime deps from requirements.txt (croniter drift)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,14 +21,14 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
 ARG SANDBOX_UID=1001
 RUN useradd -m -s /bin/bash -u ${SANDBOX_UID} sandbox
 
-# Python deps for the base runtime. If your fork needs agent-browser,
-# sqlite-vec for a knowledge store, or pyjwt[crypto] for GitHub App
-# auth, add them here. The ddgs + beautifulsoup4 pair powers the
-# starter web_search / fetch_url tools; drop them if you strip those.
-RUN pip install --no-cache-dir \
-    gradio httpx uvicorn langfuse prometheus-client pyyaml 'ruamel.yaml>=0.18' \
-    langchain langchain-openai langgraph websockets \
-    ddgs beautifulsoup4
+# Python deps — installed from requirements.txt so the runtime image stays
+# in lockstep with local + CI installs. A hand-maintained list here drifts
+# (it had silently lost `croniter`, which the scheduler imports). Copy just
+# the requirements first so this layer stays cached across source-only
+# changes. Forks that need extras (agent-browser, sqlite-vec, pyjwt[crypto])
+# add them to requirements.txt.
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir -r /tmp/requirements.txt
 
 # Single COPY with a matching .dockerignore covers everything that
 # should ship and excludes .git/, tests/, docs, and dev state. Adding a


### PR DESCRIPTION
The `docker-publish` "Verify — pytest collection in runtime image" step on `main` fails with `ModuleNotFoundError: No module named 'croniter'`.

**Cause:** the Dockerfile maintained a hardcoded pip list that drifted from `requirements.txt` — it never gained `croniter` (which `scheduler/local.py` imports). It was masked until the collection-poisoning fix (#171) let pytest collection proceed far enough to import the scheduler tests.

**Fix:** install from `requirements.txt` (copying it first to keep the layer cached) so the image can't drift from local/CI again. Verified locally: image builds and `pytest --collect-only` reports **407 tests collected**, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)