### PR TITLE
feat(middleware): EnforcementMiddleware + RateLimiter (pre-execution tool gate)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -76,6 +76,25 @@ Adding a new subagent name to the YAML requires matching entries in `graph/subag
 | `audit` | `true` | Append every tool call to `/sandbox/audit/audit.jsonl`. |
 | `memory` | `true` | Persist a session summary on terminal turn and asynchronously index conversation findings under `domain='finding'`. |
 | `scheduler` | `true` | Wire the bundled scheduler backend (local sqlite, or `WorkstaceanScheduler` when env vars are set). Drops the `schedule_task` / `list_schedules` / `cancel_schedule` tools from the agent loop when `false`. Has the same effect as `SCHEDULER_DISABLED=1` — but `middleware.scheduler: false` is the canonical opt-out (drawer/wizard editable, survives restarts), while the env var is a runtime escape hatch for fleet operators who can't edit YAML in the moment. |
+| `enforcement` | `false` | Opt-in safety gate that blocks tool calls **before** they execute (see `enforcement` block below). No-op unless a deny list or rate limit is configured. |
+
+## `enforcement`
+
+Optional pre-execution gate (`graph/middleware/enforcement.py`). Only read when `middleware.enforcement: true`. Blocked calls return a `ToolMessage` explaining the denial (the model reads it and adapts) instead of running the tool. Forks needing richer policy (scope/cost/etc.) can attach a `predicate(tool_name, args) -> reason|None` in code.
+
+```yaml
+middleware:
+  enforcement: true
+enforcement:
+  disallowed_tools: [fetch_url]          # exact names never allowed
+  rate_limits:
+    web_search: { max: 20, window_seconds: 60 }
+```
+
+| Key | Default | What |
+|---|---|---|
+| `disallowed_tools` | `[]` | Tool names that are always blocked. |
+| `rate_limits` | `{}` | Per-tool sliding-window limit: `{max, window_seconds}`. |
 
 ## `knowledge`
 

--- a/enforcement/__init__.py
+++ b/enforcement/__init__.py
@@ -1,0 +1,1 @@
+"""Tool-call enforcement primitives (rate limiting, allow/deny gating)."""

--- a/enforcement/rate_limiter.py
+++ b/enforcement/rate_limiter.py
@@ -1,0 +1,54 @@
+"""Sliding-window rate limiter for tool-call frequency.
+
+In-memory only — resets on process restart (rate limits are per-process, not
+persistent). Backported from the protoLabs fleet (pwnDeck), generalised to
+neutral tool names.
+"""
+
+from __future__ import annotations
+
+import time
+from collections import defaultdict
+
+
+class RateLimiter:
+    """Sliding-window rate limiter keyed by action (tool) name.
+
+    Args:
+        limits: maps an action name to ``{"max": int, "window_seconds": int}``.
+            Actions not present are unlimited.
+            e.g. ``{"web_search": {"max": 20, "window_seconds": 60}}``
+    """
+
+    def __init__(self, limits: dict | None = None):
+        self._limits = dict(limits or {})
+        self._windows: dict[str, list[float]] = defaultdict(list)
+
+    def check(self, action: str) -> tuple[bool, str | None]:
+        """Return ``(allowed, reason)``. Records the call when allowed."""
+        cfg = self._limits.get(action)
+        if cfg is None:
+            return True, None
+
+        max_calls = int(cfg["max"])
+        window = float(cfg["window_seconds"])
+        now = time.monotonic()
+        cutoff = now - window
+
+        recent = [t for t in self._windows[action] if t > cutoff]
+        self._windows[action] = recent
+
+        if len(recent) >= max_calls:
+            return False, (
+                f"Rate limit exceeded for '{action}': "
+                f"{max_calls} calls per {window:g}s window."
+            )
+        recent.append(now)
+        return True, None
+
+    def reset(self, action: str | None = None) -> None:
+        """Reset counters — one action, or all when ``action`` is None."""
+        if action:
+            self._windows.pop(action, None)
+        else:
+            self._windows.clear()

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -21,6 +21,17 @@ from tools.lg_tools import get_all_tools
 def _build_middleware(config: LangGraphConfig, knowledge_store=None):
     middleware = []
 
+    # Enforcement gate first (outermost) so disallowed/rate-limited tool
+    # calls are blocked before any execution. Opt-in via config.
+    if config.enforcement_enabled and (
+        config.enforcement_disallowed_tools or config.enforcement_rate_limits
+    ):
+        from graph.middleware.enforcement import EnforcementMiddleware
+        middleware.append(EnforcementMiddleware(
+            disallowed_tools=config.enforcement_disallowed_tools,
+            rate_limits=config.enforcement_rate_limits,
+        ))
+
     if config.knowledge_middleware and knowledge_store:
         middleware.append(KnowledgeMiddleware(
             knowledge_store, top_k=config.knowledge_top_k,

--- a/graph/config.py
+++ b/graph/config.py
@@ -68,6 +68,14 @@ class LangGraphConfig:
     memory_middleware: bool = True
     scheduler_enabled: bool = True
 
+    # Enforcement gate — opt-in safety middleware that blocks tool calls
+    # before they execute (deny list + per-tool rate limits). Off by default;
+    # forks enable it and supply a deny list / rate limits (and can attach a
+    # custom predicate in code). See graph/middleware/enforcement.py.
+    enforcement_enabled: bool = False
+    enforcement_disallowed_tools: list[str] = field(default_factory=list)
+    enforcement_rate_limits: dict = field(default_factory=dict)
+
     # Knowledge store — sqlite + FTS5, see ``knowledge/store.py``.
     # The default path lives under ``/sandbox/`` to play well with the
     # bundled Docker volume; the store falls back to
@@ -132,6 +140,13 @@ class LangGraphConfig:
             audit_middleware=middleware.get("audit", cls.audit_middleware),
             memory_middleware=middleware.get("memory", cls.memory_middleware),
             scheduler_enabled=middleware.get("scheduler", cls.scheduler_enabled),
+            enforcement_enabled=middleware.get("enforcement", cls.enforcement_enabled),
+            enforcement_disallowed_tools=(
+                data.get("enforcement", {}).get("disallowed_tools", [])
+            ),
+            enforcement_rate_limits=(
+                data.get("enforcement", {}).get("rate_limits", {})
+            ),
             knowledge_db_path=knowledge.get("db_path", cls.knowledge_db_path),
             embed_model=knowledge.get("embed_model", cls.embed_model),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),

--- a/graph/middleware/enforcement.py
+++ b/graph/middleware/enforcement.py
@@ -1,0 +1,88 @@
+"""EnforcementMiddleware — a pre-execution gate for tool calls.
+
+A generic safety gate (the protoAgent template otherwise has audit /
+knowledge / memory / message-capture middleware but no way to *block* a
+tool call). Before a tool runs, the gate checks, in order:
+
+  1. deny list — exact tool names that are never allowed,
+  2. a pluggable ``predicate(tool_name, args) -> reason | None`` for
+     fork-specific policy (scope/mode/cost/etc.),
+  3. a sliding-window rate limit per tool.
+
+If any check returns a reason, the tool is **not executed** — instead a
+``ToolMessage`` carrying the reason is returned, preserving the
+tool_use/tool_result pairing the model expects (so the agent can read the
+denial and adapt). Place it first in the chain so it gates before execution.
+
+Mechanism backported from the protoLabs fleet (pwnDeck
+``graph/middleware/enforcement.py``); the domain policy (pentest scope /
+kill-chain phases) is intentionally dropped — core ships the gate + a
+pluggable predicate, off by default.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import ToolMessage
+
+from enforcement.rate_limiter import RateLimiter
+
+logger = logging.getLogger(__name__)
+
+# predicate(tool_name, args) -> deny-reason string, or None to allow.
+EnforcementPredicate = Callable[[str, dict], str | None]
+
+
+class EnforcementMiddleware(AgentMiddleware):
+    """Block disallowed / rate-limited tool calls before they execute."""
+
+    def __init__(
+        self,
+        disallowed_tools: set[str] | list[str] | None = None,
+        rate_limits: dict | None = None,
+        predicate: EnforcementPredicate | None = None,
+    ):
+        super().__init__()
+        self._denied = set(disallowed_tools or ())
+        self._predicate = predicate
+        self._limiter = RateLimiter(rate_limits) if rate_limits else None
+
+    def _enforce(self, request) -> str | None:
+        """Return a deny-reason for this tool call, or None to allow."""
+        name = request.tool_call.get("name", "")
+        args = request.tool_call.get("args", {}) or {}
+
+        if name in self._denied:
+            return f"Tool '{name}' is disabled by policy."
+        if self._predicate is not None:
+            reason = self._predicate(name, args)
+            if reason:
+                return reason
+        if self._limiter is not None:
+            allowed, reason = self._limiter.check(name)
+            if not allowed:
+                return reason
+        return None
+
+    def _blocked(self, request, reason: str) -> ToolMessage:
+        logger.info("[enforcement] blocked %s: %s",
+                    request.tool_call.get("name", "?"), reason)
+        return ToolMessage(
+            content=f"Blocked by policy: {reason}",
+            tool_call_id=request.tool_call.get("id", ""),
+        )
+
+    def wrap_tool_call(self, request, handler):
+        reason = self._enforce(request)
+        if reason:
+            return self._blocked(request, reason)
+        return handler(request)
+
+    async def awrap_tool_call(self, request, handler):
+        reason = self._enforce(request)
+        if reason:
+            return self._blocked(request, reason)
+        return await handler(request)

--- a/tests/test_enforcement.py
+++ b/tests/test_enforcement.py
@@ -1,0 +1,115 @@
+"""Tests for the enforcement gate (RateLimiter + EnforcementMiddleware)."""
+
+from types import SimpleNamespace
+
+import pytest
+from langchain_core.messages import ToolMessage
+
+from enforcement.rate_limiter import RateLimiter
+from graph.middleware.enforcement import EnforcementMiddleware
+
+
+def _req(name, args=None, call_id="c1"):
+    return SimpleNamespace(tool_call={"name": name, "args": args or {}, "id": call_id})
+
+
+# ── RateLimiter ───────────────────────────────────────────────────────────────
+
+def test_rate_limiter_unlimited_when_unconfigured():
+    rl = RateLimiter()
+    for _ in range(100):
+        assert rl.check("anything") == (True, None)
+
+
+def test_rate_limiter_blocks_over_limit():
+    rl = RateLimiter({"x": {"max": 2, "window_seconds": 60}})
+    assert rl.check("x")[0] is True
+    assert rl.check("x")[0] is True
+    allowed, reason = rl.check("x")
+    assert allowed is False and "Rate limit exceeded" in reason
+    # A different action is independent.
+    assert rl.check("y")[0] is True
+
+
+def test_rate_limiter_reset():
+    rl = RateLimiter({"x": {"max": 1, "window_seconds": 60}})
+    assert rl.check("x")[0] is True
+    assert rl.check("x")[0] is False
+    rl.reset("x")
+    assert rl.check("x")[0] is True
+
+
+# ── EnforcementMiddleware ─────────────────────────────────────────────────────
+
+def test_allows_when_unconfigured():
+    mw = EnforcementMiddleware()
+    called = {}
+    def handler(r):
+        called["yes"] = True
+        return "ok"
+    assert mw.wrap_tool_call(_req("foo"), handler) == "ok"
+    assert called.get("yes")
+
+
+def test_denies_listed_tool_without_executing():
+    mw = EnforcementMiddleware(disallowed_tools=["danger"])
+    called = {}
+    def handler(r):
+        called["ran"] = True
+        return "ok"
+    out = mw.wrap_tool_call(_req("danger", call_id="abc"), handler)
+    assert isinstance(out, ToolMessage)
+    assert out.tool_call_id == "abc"
+    assert "policy" in out.content.lower()
+    assert "ran" not in called  # handler never invoked
+
+
+def test_predicate_blocks_with_reason():
+    def deny_big(name, args):
+        if args.get("n", 0) > 10:
+            return "n too large"
+        return None
+    mw = EnforcementMiddleware(predicate=deny_big)
+    assert mw.wrap_tool_call(_req("t", {"n": 5}), lambda r: "ok") == "ok"
+    out = mw.wrap_tool_call(_req("t", {"n": 99}), lambda r: "ok")
+    assert isinstance(out, ToolMessage) and "n too large" in out.content
+
+
+def test_rate_limit_blocks_third_call():
+    mw = EnforcementMiddleware(rate_limits={"t": {"max": 2, "window_seconds": 60}})
+    h = lambda r: "ok"
+    assert mw.wrap_tool_call(_req("t"), h) == "ok"
+    assert mw.wrap_tool_call(_req("t"), h) == "ok"
+    out = mw.wrap_tool_call(_req("t"), h)
+    assert isinstance(out, ToolMessage) and "Rate limit" in out.content
+
+
+@pytest.mark.asyncio
+async def test_async_path_blocks_and_allows():
+    mw = EnforcementMiddleware(disallowed_tools=["bad"])
+    async def handler(r):
+        return "ran"
+    assert await mw.awrap_tool_call(_req("good"), handler) == "ran"
+    out = await mw.awrap_tool_call(_req("bad", call_id="z"), handler)
+    assert isinstance(out, ToolMessage) and out.tool_call_id == "z"
+
+
+def test_config_wires_enforcement(monkeypatch, tmp_path):
+    """When enabled with a deny list, _build_middleware prepends the gate."""
+    import yaml
+    from graph.config import LangGraphConfig
+    from graph.agent import _build_middleware
+
+    p = tmp_path / "c.yaml"
+    p.write_text(yaml.safe_dump({
+        "middleware": {"enforcement": True, "knowledge": False, "audit": False,
+                       "memory": False},
+        "enforcement": {"disallowed_tools": ["rm_rf"]},
+    }))
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.enforcement_enabled is True
+    assert cfg.enforcement_disallowed_tools == ["rm_rf"]
+    mw = _build_middleware(cfg, knowledge_store=None)
+    assert any(m.__class__.__name__ == "EnforcementMiddleware" for m in mw)
+    # Gate is outermost.
+    assert mw[0].__class__.__name__ == "EnforcementMiddleware"


### PR DESCRIPTION
Backport from #174 (Tier-2), source: pwnDeck. The template had audit/knowledge/memory/message-capture middleware but **no way to block a tool call** — this adds a generic safety gate.

Before a tool runs, the gate checks: (1) deny list, (2) optional `predicate(tool_name, args) -> reason|None` for fork policy, (3) per-tool sliding-window rate limit. On a hit the tool is **not executed** — a `ToolMessage` carrying the reason is returned (preserving tool_use/result pairing) so the model can adapt. Placed first (outermost) in the chain.

pwnDeck's pentest policy (scope/kill-chain phases) is dropped — core ships the mechanism + pluggable predicate, **off by default**.

- `enforcement/rate_limiter.py` — clean sliding-window limiter
- `graph/middleware/enforcement.py` — `EnforcementMiddleware`
- config: `middleware.enforcement` + `enforcement.{disallowed_tools,rate_limits}`; wired in `agent.py`
- 9 tests; 423 pass (non-root 3.12); configuration.md documented

🤖 Generated with [Claude Code](https://claude.com/claude-code)