### PR TITLE
fix(skills): reconcile curator with the live SQLite index — closes #173

### DIFF
--- a/graph/skills/curator.py
+++ b/graph/skills/curator.py
@@ -15,7 +15,7 @@ Usage
 
     # Custom paths:
     python -m graph.skills.curator \\
-        --index /sandbox/skills/index.jsonl \\
+        --db /sandbox/skills.db \\
         --audit /sandbox/audit/curator.jsonl
 
 Skill index format (JSONL, one JSON object per line)
@@ -83,7 +83,9 @@ log = logging.getLogger(__name__)
 HALF_LIFE_DAYS: float = 90.0
 PRUNE_THRESHOLD: float = 0.2
 SIMILARITY_THRESHOLD: float = 0.6
-DEFAULT_INDEX_PATH: str = "/sandbox/skills/index.jsonl"
+# The live skill index is the SQLite store written by the runtime
+# (graph/skills/index.py); the curator operates on it directly.
+DEFAULT_DB_PATH: str = "/sandbox/skills.db"
 DEFAULT_AUDIT_PATH: str = "audit.jsonl"
 AUDIT_MAX_BYTES: int = 100 * 1024 * 1024  # 100 MB
 
@@ -155,19 +157,29 @@ class SkillCurator:
 
     def __init__(
         self,
-        index_path: str = DEFAULT_INDEX_PATH,
+        db_path: str = DEFAULT_DB_PATH,
         audit_path: str = DEFAULT_AUDIT_PATH,
         dry_run: bool = False,
         half_life_days: float = HALF_LIFE_DAYS,
         prune_threshold: float = PRUNE_THRESHOLD,
         similarity_threshold: float = SIMILARITY_THRESHOLD,
+        index=None,
     ) -> None:
-        self.index_path = index_path
+        self.db_path = db_path
         self.audit_path = audit_path
         self.dry_run = dry_run
         self.half_life_days = half_life_days
         self.prune_threshold = prune_threshold
         self.similarity_threshold = similarity_threshold
+        # The live SkillsIndex (SQLite). Injectable for tests; built lazily
+        # from db_path otherwise.
+        self._index = index
+
+    def _get_index(self):
+        if self._index is None:
+            from graph.skills.index import SkillsIndex
+            self._index = SkillsIndex(self.db_path)
+        return self._index
 
     # ── Public API ─────────────────────────────────────────────────────────────
 
@@ -218,44 +230,30 @@ class SkillCurator:
     # ── Loading / saving ───────────────────────────────────────────────────────
 
     def _load_index(self) -> list[dict]:
-        """Load skills from the JSONL index.  Returns [] if file is absent."""
-        if not os.path.exists(self.index_path):
-            log.info("[curator] index not found at %s — starting with empty set", self.index_path)
-            return []
-
-        skills: list[dict] = []
-        with open(self.index_path, encoding="utf-8") as fh:
-            for lineno, line in enumerate(fh, 1):
-                line = line.strip()
-                if not line:
-                    continue
-                try:
-                    skill = json.loads(line)
-                    if not isinstance(skill, dict):
-                        raise ValueError("expected a JSON object")
-                    # Ensure required fields exist
-                    if "id" not in skill:
-                        skill["id"] = str(uuid.uuid4())
-                    if "confidence" not in skill:
-                        skill["confidence"] = 1.0
-                    skills.append(skill)
-                except (json.JSONDecodeError, ValueError) as exc:
-                    log.error(
-                        "[curator] skipping malformed entry at line %d in %s: %s",
-                        lineno,
-                        self.index_path,
-                        exc,
-                    )
-        log.info("[curator] loaded %d skills from %s", len(skills), self.index_path)
+        """Load every skill from the live SQLite index as curator dicts."""
+        skills = self._get_index().all_skills()
+        log.info("[curator] loaded %d skills from %s", len(skills), self.db_path)
         return skills
 
-    def _save_index(self, skills: list[dict]) -> None:
-        """Persist *skills* back to the JSONL index."""
-        os.makedirs(os.path.dirname(self.index_path) or ".", exist_ok=True)
-        with open(self.index_path, "w", encoding="utf-8") as fh:
-            for skill in skills:
-                fh.write(json.dumps(skill, default=str) + "\n")
-        log.info("[curator] saved %d skills to %s", len(skills), self.index_path)
+    def _save_index(self, kept: list[dict]) -> None:
+        """Reconcile the SQLite index against the post-curation *kept* set.
+
+        Skills removed by dedup/prune (present in the store but not in *kept*)
+        are deleted; survivors get their (decayed) confidence written back.
+        """
+        index = self._get_index()
+        kept_by_id = {s["id"]: s for s in kept if s.get("id") is not None}
+        deleted = 0
+        for current in index.all_skills():
+            if current["id"] not in kept_by_id:
+                index.delete_skill(current["id"])
+                deleted += 1
+        for sid, s in kept_by_id.items():
+            index.update_confidence(sid, s.get("confidence", 1.0))
+        log.info(
+            "[curator] persisted %d skills to %s (deleted %d)",
+            len(kept_by_id), self.db_path, deleted,
+        )
 
     # ── Confidence decay ───────────────────────────────────────────────────────
 
@@ -468,10 +466,10 @@ def _build_parser() -> argparse.ArgumentParser:
         ),
     )
     p.add_argument(
-        "--index",
-        default=DEFAULT_INDEX_PATH,
+        "--db",
+        default=DEFAULT_DB_PATH,
         metavar="PATH",
-        help=f"Path to the JSONL skill index (default: {DEFAULT_INDEX_PATH})",
+        help=f"Path to the SQLite skill index (default: {DEFAULT_DB_PATH})",
     )
     p.add_argument(
         "--audit",
@@ -524,7 +522,7 @@ def main(argv: list[str] | None = None) -> None:
     )
 
     curator = SkillCurator(
-        index_path=args.index,
+        db_path=args.db,
         audit_path=args.audit,
         dry_run=args.dry_run,
         half_life_days=args.half_life,

--- a/graph/skills/index.py
+++ b/graph/skills/index.py
@@ -33,7 +33,8 @@ def _build_match_query(query: str) -> str:
     return " OR ".join(f"{t}*" for t in terms)
 
 # Bump when FTS table columns change — triggers auto-migration
-_SCHEMA_VERSION = 1
+# v2: added confidence + last_used (consumed by the skill curator).
+_SCHEMA_VERSION = 2
 
 # Columns indexed by FTS5 (order matters for sqlite_master check)
 _FTS_CONTENT_COLUMNS = (
@@ -143,7 +144,9 @@ class SkillsIndex:
                 prompt_template,
                 tools_used,
                 source_session_id,
-                created_at UNINDEXED
+                created_at UNINDEXED,
+                confidence UNINDEXED,
+                last_used UNINDEXED
             );
 
             CREATE TABLE _skills_meta (
@@ -152,7 +155,7 @@ class SkillsIndex:
             );
 
             INSERT INTO _skills_meta (key, version)
-            VALUES ('schema_version', 1);
+            VALUES ('schema_version', 2);
         """)
         conn.commit()
         log.info("[skills] schema created at %s", self._db_path)
@@ -193,16 +196,21 @@ class SkillsIndex:
         created_at = str(getattr(artifact, "created_at", ""))
 
         tools_str = " ".join(tools_used) if isinstance(tools_used, (list, tuple)) else str(tools_used)
+        # New skills start fully confident; last_used seeds from created_at so
+        # the curator's decay clock starts at emission (bumped on retrieval).
+        last_used = created_at
 
         conn = self._open_conn()
         try:
             conn.execute(
                 """
                 INSERT INTO skills_fts
-                    (name, description, prompt_template, tools_used, source_session_id, created_at)
-                VALUES (?, ?, ?, ?, ?, ?)
+                    (name, description, prompt_template, tools_used,
+                     source_session_id, created_at, confidence, last_used)
+                VALUES (?, ?, ?, ?, ?, ?, 1.0, ?)
                 """,
-                (name, description, prompt_template, tools_str, source_session_id, created_at),
+                (name, description, prompt_template, tools_str,
+                 source_session_id, created_at, last_used),
             )
             conn.commit()
             log.debug("[skills] indexed skill: %s", name)
@@ -260,6 +268,58 @@ class SkillsIndex:
             # Table may be empty or query syntax invalid
             log.debug("[skills] FTS5 search error (returning empty): %s", exc)
             return []
+
+    # ── Curation surface (consumed by graph/skills/curator.py) ─────────────────
+
+    def all_skills(self) -> list[dict]:
+        """Return every skill as a dict, including the curator's bookkeeping
+        fields (``id`` = rowid, ``confidence``, ``last_used``). Empty on error."""
+        conn = self._open_conn()
+        try:
+            cur = conn.execute(
+                """
+                SELECT rowid AS id, name, description, prompt_template, tools_used,
+                       created_at, confidence, last_used
+                FROM skills_fts
+                """
+            )
+            return [
+                {
+                    "id": row["id"],
+                    "name": row["name"],
+                    "description": row["description"],
+                    "prompt_template": row["prompt_template"],
+                    "tools_used": (row["tools_used"] or "").split(),
+                    "created_at": row["created_at"],
+                    "confidence": float(row["confidence"]) if row["confidence"] is not None else 1.0,
+                    "last_used": row["last_used"],
+                }
+                for row in cur.fetchall()
+            ]
+        except sqlite3.OperationalError as exc:
+            log.debug("[skills] all_skills error (returning empty): %s", exc)
+            return []
+
+    def update_confidence(self, skill_id: int, confidence: float) -> None:
+        """Set a skill's confidence (used by the curator's decay pass)."""
+        conn = self._open_conn()
+        try:
+            conn.execute(
+                "UPDATE skills_fts SET confidence = ? WHERE rowid = ?",
+                (float(confidence), int(skill_id)),
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            log.error("[skills] update_confidence failed for %s: %s", skill_id, exc)
+
+    def delete_skill(self, skill_id: int) -> None:
+        """Remove a skill by rowid (used by the curator's dedup/prune passes)."""
+        conn = self._open_conn()
+        try:
+            conn.execute("DELETE FROM skills_fts WHERE rowid = ?", (int(skill_id),))
+            conn.commit()
+        except sqlite3.Error as exc:
+            log.error("[skills] delete_skill failed for %s: %s", skill_id, exc)
 
     def rebuild_index(self, artifacts: list[object]) -> None:
         """Drop all rows and re-index from *artifacts*.

--- a/tests/test_skill_curator.py
+++ b/tests/test_skill_curator.py
@@ -61,10 +61,32 @@ def _make_skill(
     return skill
 
 
-def _write_index(path: str, skills: list[dict]) -> None:
-    with open(path, "w", encoding="utf-8") as fh:
-        for s in skills:
-            fh.write(json.dumps(s) + "\n")
+def _seed_index(db_path: str, skills: list[dict]):
+    """Create a SkillsIndex at *db_path* and insert *skills* directly.
+
+    Inserts confidence/last_used/created_at verbatim (bypassing add_skill's
+    defaults) so curation tests can stage exact decay/prune scenarios. The
+    rowid becomes the curator's skill ``id``. Returns the SkillsIndex.
+    """
+    from graph.skills.index import SkillsIndex
+
+    idx = SkillsIndex(db_path)
+    conn = idx._open_conn()
+    for s in skills:
+        conn.execute(
+            """INSERT INTO skills_fts
+               (name, description, prompt_template, tools_used,
+                source_session_id, created_at, confidence, last_used)
+               VALUES (?, ?, ?, ?, ?, ?, ?, ?)""",
+            (
+                s["name"], s["description"], s.get("prompt_template", ""),
+                " ".join(s.get("tools_used", [])), "",
+                s.get("created_at", ""), s.get("confidence", 1.0),
+                s.get("last_used", s.get("created_at", "")),
+            ),
+        )
+    conn.commit()
+    return idx
 
 
 # ── _clamp ─────────────────────────────────────────────────────────────────────
@@ -121,7 +143,7 @@ class TestJaccard:
 class TestConfidenceDecay:
     def _curator(self, **kwargs) -> SkillCurator:
         return SkillCurator(
-            index_path="/dev/null",
+            db_path="/dev/null",
             audit_path="/dev/null",
             dry_run=True,
             **kwargs,
@@ -199,7 +221,7 @@ class TestConfidenceDecay:
 class TestDeduplication:
     def _curator(self, threshold: float = SIMILARITY_THRESHOLD) -> SkillCurator:
         return SkillCurator(
-            index_path="/dev/null",
+            db_path="/dev/null",
             audit_path="/dev/null",
             dry_run=True,
             similarity_threshold=threshold,
@@ -264,7 +286,7 @@ class TestDeduplication:
 class TestPruning:
     def _curator(self, threshold: float = PRUNE_THRESHOLD) -> SkillCurator:
         return SkillCurator(
-            index_path="/dev/null",
+            db_path="/dev/null",
             audit_path="/dev/null",
             dry_run=True,
             prune_threshold=threshold,
@@ -314,29 +336,31 @@ class TestPruning:
 
 
 class TestCuratorRun:
-    def test_dry_run_does_not_write_files(self, tmp_path):
-        index = str(tmp_path / "index.jsonl")
-        audit = str(tmp_path / "audit.jsonl")
-        skills = [_make_skill(confidence=1.0, days_ago=0)]
-        _write_index(index, skills)
+    """End-to-end runs against the live SQLite SkillsIndex (the store the
+    runtime actually writes — see #173)."""
 
-        curator = SkillCurator(
-            index_path=index,
-            audit_path=audit,
-            dry_run=True,
-        )
-        curator.run()
-        # Audit file should NOT be created in dry_run mode
+    def _audit(self, tmp_path):
+        return str(tmp_path / "audit.jsonl")
+
+    def test_dry_run_does_not_write_files(self, tmp_path):
+        idx = _seed_index(str(tmp_path / "skills.db"), [_make_skill(confidence=1.0)])
+        audit = self._audit(tmp_path)
+        SkillCurator(index=idx, audit_path=audit, dry_run=True).run()
         assert not os.path.exists(audit)
 
-    def test_full_run_writes_audit(self, tmp_path):
-        index = str(tmp_path / "index.jsonl")
-        audit = str(tmp_path / "audit.jsonl")
-        skills = [_make_skill(confidence=1.0)]
-        _write_index(index, skills)
+    def test_dry_run_leaves_store_unchanged(self, tmp_path):
+        # A low-confidence, long-idle skill would be pruned on a real run.
+        idx = _seed_index(str(tmp_path / "skills.db"), [
+            _make_skill(name="stale", description="old thing",
+                        confidence=1.0, last_used_days_ago=400),
+        ])
+        SkillCurator(index=idx, audit_path=self._audit(tmp_path), dry_run=True).run()
+        assert len(idx.all_skills()) == 1  # nothing deleted in dry-run
 
-        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
-        curator.run()
+    def test_full_run_writes_audit(self, tmp_path):
+        idx = _seed_index(str(tmp_path / "skills.db"), [_make_skill(confidence=1.0)])
+        audit = self._audit(tmp_path)
+        SkillCurator(index=idx, audit_path=audit, dry_run=False).run()
 
         assert os.path.exists(audit)
         with open(audit) as fh:
@@ -344,25 +368,16 @@ class TestCuratorRun:
         assert "run_id" in entry
         assert entry["dry_run"] is False
 
-    def test_missing_index_produces_empty_run(self, tmp_path):
-        audit = str(tmp_path / "audit.jsonl")
-        curator = SkillCurator(
-            index_path=str(tmp_path / "nonexistent.jsonl"),
-            audit_path=audit,
-            dry_run=False,
-        )
-        entry = curator.run()
+    def test_empty_store_produces_empty_run(self, tmp_path):
+        idx = _seed_index(str(tmp_path / "skills.db"), [])
+        entry = SkillCurator(index=idx, audit_path=self._audit(tmp_path), dry_run=False).run()
         assert entry["skills_before"] == 0
         assert entry["skills_after"] == 0
 
     def test_decay_then_prune_pipeline(self, tmp_path):
-        """A skill idle for >300 days should be pruned in a full run."""
-        index = str(tmp_path / "index.jsonl")
-        audit = str(tmp_path / "audit.jsonl")
-
-        # After 300 days: 0.5^(300/90) ≈ 0.099 < 0.2 → should be pruned.
-        # Distinct name/description so dedup doesn't collapse the pair before
-        # prune runs — this test exercises the decay→prune path specifically.
+        """A skill idle >300 days decays below threshold and is pruned from
+        the SQLite store; the fresh one survives. Distinct names so dedup
+        doesn't collapse the pair before prune runs."""
         old_skill = _make_skill(
             name="stale crawler", description="scrapes an old feed",
             confidence=1.0, last_used_days_ago=300,
@@ -371,57 +386,41 @@ class TestCuratorRun:
             name="active summarizer", description="summarizes recent docs",
             confidence=0.9, last_used_days_ago=5,
         )
-        _write_index(index, [old_skill, fresh_skill])
+        idx = _seed_index(str(tmp_path / "skills.db"), [old_skill, fresh_skill])
 
-        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
-        entry = curator.run()
+        entry = SkillCurator(index=idx, audit_path=self._audit(tmp_path), dry_run=False).run()
 
         assert entry["skills_before"] == 2
         assert entry["skills_after"] == 1
         assert len(entry["pruned"]) == 1
-        assert entry["pruned"][0]["id"] == old_skill["id"]
+        remaining = idx.all_skills()
+        assert len(remaining) == 1
+        assert remaining[0]["name"] == "active summarizer"
 
     def test_audit_entry_structure(self, tmp_path):
-        index = str(tmp_path / "index.jsonl")
-        audit = str(tmp_path / "audit.jsonl")
-        _write_index(index, [_make_skill()])
-
-        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
-        entry = curator.run()
-
+        idx = _seed_index(str(tmp_path / "skills.db"), [_make_skill()])
+        entry = SkillCurator(index=idx, audit_path=self._audit(tmp_path), dry_run=False).run()
         required_keys = {
             "run_id", "timestamp", "dry_run", "skills_before",
             "skills_after", "decay_applied", "deduplicated", "pruned",
         }
         assert required_keys.issubset(entry.keys())
 
-    def test_malformed_index_lines_are_skipped(self, tmp_path):
-        index = str(tmp_path / "index.jsonl")
-        audit = str(tmp_path / "audit.jsonl")
+    def test_store_persisted_after_run(self, tmp_path):
+        old_skill = _make_skill(
+            name="stale crawler", description="scrapes an old feed",
+            confidence=1.0, last_used_days_ago=300,
+        )
+        fresh_skill = _make_skill(
+            name="active summarizer", description="summarizes recent docs",
+            confidence=0.9, last_used_days_ago=2,
+        )
+        idx = _seed_index(str(tmp_path / "skills.db"), [old_skill, fresh_skill])
 
-        with open(index, "w") as fh:
-            fh.write("not json\n")
-            fh.write(json.dumps(_make_skill()) + "\n")
-            fh.write("{incomplete\n")
+        SkillCurator(index=idx, audit_path=self._audit(tmp_path), dry_run=False).run()
 
-        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=True)
-        entry = curator.run()
-        # Only the valid skill should be loaded
-        assert entry["skills_before"] == 1
-
-    def test_index_persisted_after_run(self, tmp_path):
-        index = str(tmp_path / "index.jsonl")
-        audit = str(tmp_path / "audit.jsonl")
-
-        # Create two skills; one will be pruned (low confidence, old)
-        old_skill = _make_skill(confidence=1.0, last_used_days_ago=300)
-        fresh_skill = _make_skill(confidence=0.9, last_used_days_ago=2)
-        _write_index(index, [old_skill, fresh_skill])
-
-        curator = SkillCurator(index_path=index, audit_path=audit, dry_run=False)
-        curator.run()
-
-        with open(index) as fh:
-            remaining = [json.loads(l) for l in fh if l.strip()]
+        remaining = idx.all_skills()
         assert len(remaining) == 1
-        assert remaining[0]["id"] == fresh_skill["id"]
+        assert remaining[0]["name"] == "active summarizer"
+        # Survivor's decayed confidence was written back (< its seeded 0.9).
+        assert remaining[0]["confidence"] < 0.9

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -132,7 +132,8 @@ def test_schema_meta_table_exists(tmp_db) -> None:
     cur = conn.execute("SELECT version FROM _skills_meta WHERE key = 'schema_version'")
     row = cur.fetchone()
     assert row is not None
-    assert row[0] == 1
+    from graph.skills.index import _SCHEMA_VERSION
+    assert row[0] == _SCHEMA_VERSION
     conn.close()
 
 
@@ -476,3 +477,40 @@ def test_build_skills_query_caps_at_context_chars() -> None:
     messages = [HumanMessage(content=long_content)]
     query = km._build_skills_query(messages)
     assert len(query) <= 2000
+
+
+# ── Curation surface (v2 schema: confidence + last_used) ──────────────────────
+
+
+def test_all_skills_returns_curation_fields(populated_index) -> None:
+    """all_skills() exposes id/confidence/last_used for the curator."""
+    rows = populated_index.all_skills()
+    assert len(rows) == 3
+    r = rows[0]
+    assert set(r) >= {"id", "name", "description", "prompt_template",
+                      "tools_used", "created_at", "confidence", "last_used"}
+    assert r["confidence"] == 1.0          # new skills start fully confident
+    assert isinstance(r["id"], int)        # rowid
+    assert isinstance(r["tools_used"], list)
+
+
+def test_update_confidence_and_delete(populated_index) -> None:
+    rows = populated_index.all_skills()
+    target = rows[0]["id"]
+    populated_index.update_confidence(target, 0.42)
+    updated = {r["id"]: r for r in populated_index.all_skills()}
+    assert abs(updated[target]["confidence"] - 0.42) < 1e-9
+
+    populated_index.delete_skill(target)
+    remaining = {r["id"] for r in populated_index.all_skills()}
+    assert target not in remaining
+    assert len(remaining) == 2
+
+
+def test_curator_runs_against_live_index(populated_index) -> None:
+    """The curator operates on the live SkillsIndex (no JSONL) — #173."""
+    from graph.skills.curator import SkillCurator
+
+    before = len(populated_index.all_skills())
+    entry = SkillCurator(index=populated_index, audit_path="/dev/null", dry_run=True).run()
+    assert entry["skills_before"] == before


### PR DESCRIPTION
**Closes #173.** The skill curator operated on a JSONL file (`/sandbox/skills/index.jsonl`) that the runtime never wrote, while the live index `KnowledgeMiddleware` reads is SQLite (`/sandbox/skills.db`) — so curation always ran against an empty set (dead feature).

**Fix — point the curator at the live store:**
- `SkillsIndex` schema **v2**: add `confidence` + `last_used` columns (the curator's decay clock). `add_skill` seeds `confidence=1.0`, `last_used=created_at`. New curation surface: `all_skills()`, `update_confidence()`, `delete_skill()`. Schema bump auto-migrates (backup-and-rebuild) existing v1 DBs.
- Curator loads from `SkillsIndex.all_skills()` and writes back through the index (decayed confidence for survivors; delete dedup/prune casualties). `__init__` takes `db_path` (or an injected `index`); CLI `--index` → `--db`. The pure decay/dedup/prune/clamp/jaccard logic is unchanged.

Tests reworked onto a seeded SQLite index, plus new index curation-method tests. 426 pass (non-root 3.12).

> Note: auto-scheduling the curator (via the bundled scheduler) is left as an ops choice — `python -m graph.skills.curator` now correctly curates the live store on demand / via cron.

🤖 Generated with [Claude Code](https://claude.com/claude-code)