### PR TITLE
feat(output): dropped-scratch kicker-retry loop

### DIFF
--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -174,3 +174,37 @@ def extract_output(text: str) -> str:
         preview,
     )
     return ""
+
+
+def is_dropped_scratch_turn(text: str) -> bool:
+    """Detect the 'scratch-only, never committed' dropped-turn pattern.
+
+    Failure mode: the model writes reasoning (``<scratch_pad>...`` or
+    ``<think>...``) and then stops without emitting a tool call or an
+    ``<output>`` block. ``extract_output`` strips the reasoning, returns
+    empty, and the turn silently drops. Detecting it lets the server issue a
+    kicker and retry once. Callers should also confirm no tool call fired this
+    turn (the LangChain tool channel is separate from text content) — an empty
+    extract_output with a tool call is a normal mid-loop step, not a drop.
+
+    True when the text has ``<scratch_pad>`` or ``<think>`` content and no
+    ``<output>`` tag.
+    """
+    if not text:
+        return False
+    lower = text.lower()
+    if "<scratch_pad>" not in lower and "<think>" not in lower:
+        return False
+    return "<output>" not in lower
+
+
+# Follow-up user message sent on the same thread when is_dropped_scratch_turn
+# fires — the dropped turn is still in the checkpointer history, so the model
+# has full context to pick up where it left off.
+DROPPED_SCRATCH_KICKER = (
+    "Your previous turn emitted only reasoning (`<scratch_pad>`/`<think>`) — "
+    "no tool call and no `<output>` block, so it was dropped. Pick up where "
+    "you left off: if you were about to call a tool, call it now; if you have "
+    "enough to answer, write the answer in `<output>` directly. Do not emit "
+    "another bare reasoning block without committing to one of those paths."
+)

--- a/server.py
+++ b/server.py
@@ -33,7 +33,12 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from graph.output_format import extract_confidence, extract_output
+from graph.output_format import (
+    DROPPED_SCRATCH_KICKER,
+    extract_confidence,
+    extract_output,
+    is_dropped_scratch_turn,
+)
 
 if TYPE_CHECKING:
     from scheduler.interface import SchedulerBackend
@@ -737,14 +742,64 @@ async def _chat_langgraph_stream(
                             "output_tokens": int(usage.get("output_tokens", 0) or 0),
                         })
 
-            # Self-reported confidence, if the model emitted <confidence>.
-            # Yielded before "done" so the A2A handler records it on the
+            final_text = extract_output(accumulated_raw)
+            final_raw = accumulated_raw
+
+            # Dropped-turn recovery: the model emitted only <scratch_pad>/<think>
+            # — no <output>, no tool call — so extract_output is empty and the
+            # turn would silently drop. Re-prompt once on the same thread with a
+            # kicker (history is preserved by the checkpointer). Capped at 1 retry.
+            if not final_text and is_dropped_scratch_turn(accumulated_raw):
+                log.warning(
+                    "[chat-stream] dropped scratch-only turn (session=%s) — kicker retry",
+                    session_id,
+                )
+                yield ("tool_start", "↻ retry: prior turn dropped scratch-only")
+                retry_raw = ""
+                async for event in _graph.astream_events(
+                    {"messages": [HumanMessage(content=DROPPED_SCRATCH_KICKER)],
+                     "session_id": session_id},
+                    config=config,
+                    version="v2",
+                ):
+                    kind = event.get("event", "")
+                    name = event.get("name", "")
+                    if kind == "on_tool_start":
+                        tool_input = event.get("data", {}).get("input", "")
+                        yield ("tool_start", f"🔧 {name}: {str(tool_input)[:200] if tool_input else ''}")
+                    elif kind == "on_tool_end":
+                        out = event.get("data", {}).get("output", "")
+                        yield ("tool_end", f"✅ {name} → {str(out)[:300] if out else ''}")
+                    elif kind == "on_chat_model_stream":
+                        chunk = event.get("data", {}).get("chunk")
+                        if chunk and hasattr(chunk, "content") and chunk.content:
+                            retry_raw += chunk.content if isinstance(chunk.content, str) else str(chunk.content)
+                    elif kind == "on_chat_model_end":
+                        output = event.get("data", {}).get("output")
+                        usage = getattr(output, "usage_metadata", None) if output else None
+                        if usage:
+                            yield ("usage", {
+                                "input_tokens": int(usage.get("input_tokens", 0) or 0),
+                                "output_tokens": int(usage.get("output_tokens", 0) or 0),
+                            })
+                recovered = extract_output(retry_raw)
+                if recovered:
+                    final_text, final_raw = recovered, retry_raw
+                    log.info("[chat-stream] kicker recovered the turn (session=%s)", session_id)
+                else:
+                    log.warning(
+                        "[chat-stream] kicker retry also empty (session=%s) — falling back",
+                        session_id,
+                    )
+
+            # Self-reported confidence (from whichever pass produced the answer),
+            # yielded before "done" so the A2A handler records it on the
             # terminal artifact's confidence-v1 DataPart.
-            confidence, explanation = extract_confidence(accumulated_raw)
+            confidence, explanation = extract_confidence(final_raw)
             if confidence is not None:
                 yield ("confidence", {"confidence": confidence, "explanation": explanation})
 
-            yield ("done", extract_output(accumulated_raw))
+            yield ("done", final_text)
 
         except GeneratorExit:
             # Expected: A2A consumers (e.g. Workstacean's A2AExecutor) break

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -116,3 +116,31 @@ def test_extract_output_empty_when_scratch_only(caplog):
 def test_extract_output_empty_input_returns_empty():
     assert extract_output("") == ""
     assert extract_output("   \n  ") == ""
+
+
+# ── dropped-turn detection ────────────────────────────────────────────────────
+
+from graph.output_format import DROPPED_SCRATCH_KICKER, is_dropped_scratch_turn
+
+
+def test_dropped_scratch_only_is_detected():
+    assert is_dropped_scratch_turn("<scratch_pad>thinking, never committed</scratch_pad>") is True
+
+
+def test_dropped_think_only_is_detected():
+    """Qwen-style <think> with no output is also a drop."""
+    assert is_dropped_scratch_turn("<think>reasoning</think>") is True
+
+
+def test_not_dropped_when_output_present():
+    assert is_dropped_scratch_turn("<scratch_pad>x</scratch_pad><output>answer</output>") is False
+
+
+def test_not_dropped_when_no_reasoning_markers():
+    assert is_dropped_scratch_turn("plain text answer") is False
+    assert is_dropped_scratch_turn("") is False
+
+
+def test_kicker_is_actionable():
+    k = DROPPED_SCRATCH_KICKER.lower()
+    assert "<output>" in k and ("tool" in k)


### PR DESCRIPTION
Backport from #174, source: gina. The companion to #181 (which added truncated-`<output>` recovery).

Adds `is_dropped_scratch_turn` (text has `<scratch_pad>`/`<think>` but no `<output>`) + `DROPPED_SCRATCH_KICKER`, and wires a **capped one-shot retry** into the streaming producer: when `extract_output` is empty and the turn was scratch-only (no output, no tool call), re-prompt once on the same thread — the checkpointer preserves history — with the kicker, re-stream tool/usage events, and adopt the recovered output (and its confidence) if any; otherwise fall back to the empty result as before.

Mirrors gina's validated wiring. 5 detection tests; 431 pass (non-root 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)