### PR TITLE
feat(knowledge): HybridKnowledgeStore (embeddings-on-FTS5, RRF + circuit breaker)

### DIFF
--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -1,0 +1,225 @@
+"""Reference embeddings-on-FTS5 knowledge store.
+
+The base ``KnowledgeStore`` (knowledge/store.py) is FTS5 + LIKE only, and its
+docstring invites forks that want semantic search to *subclass and override
+``search()``*. This is that reference implementation, backported from the
+protoLabs fleet (protoResearcher / gina), generalised:
+
+- **Pluggable embeddings.** Pass ``embed_fn(text) -> list[float]`` (wire it to
+  Ollama, the LiteLLM gateway, sentence-transformers, …). With ``embed_fn=None``
+  the store behaves exactly like the FTS5 base — so it's a safe drop-in.
+- **Hybrid retrieval via RRF.** Fuses the base FTS5 ranking with a vector
+  ranking using Reciprocal Rank Fusion, so lexical and semantic hits reinforce
+  each other without tuning a weight.
+- **Embedding circuit breaker.** If ``embed_fn`` errors repeatedly, the breaker
+  opens for a cooldown and search silently falls back to FTS5 — an embedding
+  outage degrades quality, never availability.
+
+Storage: vectors live in a side ``chunk_vectors`` table in the same DB; query
+time does brute-force cosine in Python. That's fine for a template's
+operator-notes-scale store — forks at scale should swap in ``sqlite-vec`` or a
+real vector DB (override ``_vector_search``).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import math
+import sqlite3
+import time
+from collections.abc import Callable
+
+from knowledge.store import KnowledgeStore
+
+log = logging.getLogger(__name__)
+
+EmbedFn = Callable[[str], "list[float]"]
+
+
+class HybridKnowledgeStore(KnowledgeStore):
+    """KnowledgeStore + optional semantic search (RRF over FTS5 ∪ vectors)."""
+
+    def __init__(
+        self,
+        db_path=None,
+        *,
+        embed_fn: EmbedFn | None = None,
+        vector_k: int = 20,
+        rrf_k: int = 60,
+        breaker_threshold: int = 2,
+        breaker_cooldown_s: float = 300.0,
+    ):
+        super().__init__(db_path)
+        self._embed_fn = embed_fn
+        self._vector_k = vector_k
+        self._rrf_k = rrf_k
+        self._breaker_threshold = breaker_threshold
+        self._breaker_cooldown_s = breaker_cooldown_s
+        self._embed_failures = 0
+        self._breaker_open_until = 0.0
+        if embed_fn is not None:
+            self._ensure_vectors_table()
+
+    # ── circuit breaker ────────────────────────────────────────────────────────
+
+    def _breaker_open(self) -> bool:
+        return time.monotonic() < self._breaker_open_until
+
+    def _record_embed_failure(self) -> None:
+        self._embed_failures += 1
+        if self._embed_failures >= self._breaker_threshold:
+            self._breaker_open_until = time.monotonic() + self._breaker_cooldown_s
+            log.warning(
+                "[knowledge] embedding circuit opened for %.0fs after %d failures",
+                self._breaker_cooldown_s, self._embed_failures,
+            )
+
+    def _record_embed_success(self) -> None:
+        self._embed_failures = 0
+        self._breaker_open_until = 0.0
+
+    def _embed(self, text: str) -> list[float] | None:
+        if self._embed_fn is None or self._breaker_open():
+            return None
+        try:
+            vec = self._embed_fn(text)
+            self._record_embed_success()
+            return [float(x) for x in vec]
+        except Exception as exc:  # noqa: BLE001 - breaker by design
+            log.warning("[knowledge] embed_fn failed: %s", exc)
+            self._record_embed_failure()
+            return None
+
+    # ── vector storage ──────────────────────────────────────────────────────────
+
+    def _ensure_vectors_table(self) -> None:
+        db = self._get_db()
+        if db is None:
+            return
+        try:
+            db.execute(
+                "CREATE TABLE IF NOT EXISTS chunk_vectors "
+                "(chunk_id INTEGER PRIMARY KEY, vec TEXT NOT NULL)"
+            )
+            db.commit()
+        except sqlite3.DatabaseError as exc:
+            log.warning("[knowledge] could not create chunk_vectors: %s", exc)
+        finally:
+            db.close()
+
+    def add_chunk(self, content: str, domain: str = "general", heading=None, **kw) -> int | None:
+        chunk_id = super().add_chunk(content, domain, heading, **kw)
+        if chunk_id is None or self._embed_fn is None:
+            return chunk_id
+        # Embed the heading+content so semantic search sees the same text FTS5 does.
+        text = (heading + "\n" if heading else "") + content
+        vec = self._embed(text)
+        if vec is not None:
+            db = self._get_db()
+            if db is not None:
+                try:
+                    db.execute(
+                        "INSERT OR REPLACE INTO chunk_vectors (chunk_id, vec) VALUES (?, ?)",
+                        (chunk_id, json.dumps(vec)),
+                    )
+                    db.commit()
+                except sqlite3.DatabaseError as exc:
+                    log.warning("[knowledge] store vector failed for %d: %s", chunk_id, exc)
+                finally:
+                    db.close()
+        return chunk_id
+
+    def _vector_search(self, query_vec: list[float], k: int, domain: str | None) -> list[int]:
+        """Return chunk ids ranked by cosine similarity (brute force)."""
+        db = self._get_db()
+        if db is None:
+            return []
+        try:
+            if domain:
+                rows = db.execute(
+                    "SELECT v.chunk_id, v.vec FROM chunk_vectors v "
+                    "JOIN chunks c ON c.id = v.chunk_id WHERE c.domain = ?",
+                    (domain,),
+                ).fetchall()
+            else:
+                rows = db.execute("SELECT chunk_id, vec FROM chunk_vectors").fetchall()
+        except sqlite3.DatabaseError:
+            return []
+        finally:
+            db.close()
+
+        qn = math.sqrt(sum(x * x for x in query_vec)) or 1.0
+        scored: list[tuple[float, int]] = []
+        for r in rows:
+            try:
+                vec = json.loads(r["vec"])
+            except (json.JSONDecodeError, TypeError):
+                continue
+            if len(vec) != len(query_vec):
+                continue
+            dot = sum(a * b for a, b in zip(query_vec, vec))
+            vn = math.sqrt(sum(x * x for x in vec)) or 1.0
+            scored.append((dot / (qn * vn), int(r["chunk_id"])))
+        scored.sort(reverse=True)
+        return [cid for _, cid in scored[:k]]
+
+    # ── hybrid search ────────────────────────────────────────────────────────────
+
+    def search(self, query, k: int = 5, *, domain: str | None = None) -> list[dict]:
+        """RRF-fuse the FTS5 ranking with a vector ranking.
+
+        Falls back to pure FTS5 when embeddings are unavailable (no embed_fn,
+        circuit open, or the query fails to embed) — same shape, never raises.
+        """
+        if not query or not query.strip():
+            return []
+
+        base = super().search(query, k=self._vector_k, domain=domain)
+        query_vec = self._embed(query)
+        if query_vec is None:
+            return base[:k]
+
+        vec_ids = self._vector_search(query_vec, self._vector_k, domain)
+        if not vec_ids:
+            return base[:k]
+
+        # Reciprocal Rank Fusion over the two rankings, keyed by chunk id.
+        scores: dict[int, float] = {}
+        by_id: dict[int, dict] = {}
+        for rank, item in enumerate(base):
+            cid = item.get("id")
+            if cid is None:
+                continue
+            scores[cid] = scores.get(cid, 0.0) + 1.0 / (self._rrf_k + rank)
+            by_id[cid] = item
+        for rank, cid in enumerate(vec_ids):
+            scores[cid] = scores.get(cid, 0.0) + 1.0 / (self._rrf_k + rank)
+
+        ordered = sorted(scores, key=lambda c: scores[c], reverse=True)[:k]
+        results: list[dict] = []
+        for cid in ordered:
+            if cid in by_id:
+                results.append(by_id[cid])
+            else:
+                hydrated = self._hydrate_chunk(cid)
+                if hydrated is not None:
+                    results.append(hydrated)
+        return results
+
+    def _hydrate_chunk(self, chunk_id: int) -> dict | None:
+        """Build a result dict for a vector-only hit not in the FTS5 results."""
+        db = self._get_db()
+        if db is None:
+            return None
+        try:
+            row = db.execute("SELECT * FROM chunks WHERE id = ?", (chunk_id,)).fetchone()
+        except sqlite3.DatabaseError:
+            return None
+        finally:
+            db.close()
+        if row is None:
+            return None
+        d = dict(row)
+        preview = (d.get("heading") + ": " if d.get("heading") else "") + d.get("content", "")
+        return {"table": "chunks", "preview": preview[:240], **d}

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -22,7 +22,10 @@ The store is path-aware and degradation-aware:
   the store never crashes the agent loop on a corrupt or read-only DB.
 
 Forks that want embeddings on top of FTS5 can subclass and override
-``search()`` — the middleware reads through that one method.
+``search()`` — the middleware reads through that one method. A worked
+reference lives in ``knowledge/hybrid_store.py`` (``HybridKnowledgeStore``):
+pluggable ``embed_fn``, RRF fusion of FTS5 + vector rankings, and an
+embedding circuit breaker that falls back to FTS5 on outage.
 """
 
 from __future__ import annotations

--- a/tests/test_hybrid_store.py
+++ b/tests/test_hybrid_store.py
@@ -1,0 +1,84 @@
+"""Tests for HybridKnowledgeStore — embeddings-on-FTS5 reference subclass."""
+
+import sqlite3
+
+import pytest
+
+from knowledge.hybrid_store import HybridKnowledgeStore
+
+_VOCAB = ["calculator", "math", "weather", "forecast", "python", "async"]
+
+
+def _bow_embed(text: str) -> list[float]:
+    """Deterministic bag-of-words embedding over a tiny vocab."""
+    t = text.lower()
+    return [1.0 if w in t else 0.0 for w in _VOCAB]
+
+
+def _db(tmp_path):
+    return str(tmp_path / "kb.db")
+
+
+def test_no_embed_fn_behaves_like_base(tmp_path):
+    store = HybridKnowledgeStore(_db(tmp_path), embed_fn=None)
+    store.add_chunk("use the calculator for math", domain="general")
+    results = store.search("calculator")
+    assert results and any("calculator" in r["content"] for r in results)
+    # No vector table side effects when embeddings are off.
+    db = sqlite3.connect(_db(tmp_path))
+    tbls = {r[0] for r in db.execute("SELECT name FROM sqlite_master WHERE type='table'")}
+    db.close()
+    assert "chunk_vectors" not in tbls
+
+
+def test_vector_persisted_on_add(tmp_path):
+    store = HybridKnowledgeStore(_db(tmp_path), embed_fn=_bow_embed)
+    cid = store.add_chunk("tomorrow's weather forecast", domain="general")
+    db = sqlite3.connect(_db(tmp_path))
+    row = db.execute("SELECT chunk_id FROM chunk_vectors WHERE chunk_id = ?", (cid,)).fetchone()
+    db.close()
+    assert row is not None
+
+
+def test_hybrid_returns_relevant_chunk(tmp_path):
+    store = HybridKnowledgeStore(_db(tmp_path), embed_fn=_bow_embed)
+    store.add_chunk("use the calculator for math", domain="general")
+    store.add_chunk("tomorrow's weather forecast", domain="general")
+    results = store.search("math calculator", k=2)
+    assert results
+    assert any("calculator" in r["content"] for r in results)
+
+
+def test_vector_only_hit_is_hydrated(tmp_path):
+    """A chunk FTS5 can't match (no shared tokens) still surfaces via the
+    vector ranking, and is hydrated into a full result dict."""
+    const_vec = lambda text: [1.0, 0.0]  # everything maps to the same vector
+    store = HybridKnowledgeStore(_db(tmp_path), embed_fn=const_vec)
+    cid = store.add_chunk("alpha beta gamma", domain="general")
+    # Query shares no lexical tokens with the chunk → FTS5 base is empty …
+    results = store.search("zzzzz", k=5)
+    # … but the vector ranking (cosine 1.0) surfaces it, hydrated.
+    assert any(r["id"] == cid and r["table"] == "chunks" for r in results)
+    assert all("preview" in r for r in results)
+
+
+def test_circuit_breaker_falls_back_to_fts(tmp_path):
+    calls = {"n": 0}
+
+    def flaky_embed(text):
+        calls["n"] += 1
+        raise RuntimeError("embedding service down")
+
+    store = HybridKnowledgeStore(
+        _db(tmp_path), embed_fn=flaky_embed, breaker_threshold=2, breaker_cooldown_s=999,
+    )
+    # add_chunk still succeeds (FTS5 path); embedding just fails silently.
+    store.add_chunk("use the calculator for math", domain="general")
+    # Search never raises and returns FTS5 results despite the failing embedder.
+    results = store.search("calculator")
+    assert any("calculator" in r["content"] for r in results)
+    # After the threshold, the breaker is open → embed_fn is no longer called.
+    before = calls["n"]
+    store.search("calculator")
+    store.search("calculator")
+    assert calls["n"] == before  # breaker short-circuits embed_fn


### PR DESCRIPTION
Backport from #174 (Tier-2), source: protoResearcher/gina. The reference implementation of the embeddings subclass the base `KnowledgeStore` docstring invites.

`HybridKnowledgeStore(KnowledgeStore)`:
- **Pluggable `embed_fn(text) -> list[float]`** — wire Ollama / the gateway / sentence-transformers. `embed_fn=None` → behaves exactly like the FTS5 base (safe drop-in).
- **RRF fusion** of the FTS5 ranking with a vector ranking (brute-force cosine over a side `chunk_vectors` table) — lexical + semantic reinforce without a tuned weight.
- **Embedding circuit breaker** — after repeated `embed_fn` failures the breaker opens for a cooldown and `search()` falls back to FTS5. An embedding outage degrades quality, never availability.

Brute-force cosine is fine at operator-notes scale; forks at scale override `_vector_search` with `sqlite-vec`/a vector DB. 5 tests with a deterministic fake embedder (no service needed); 436 pass (non-root 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)