### PR TITLE
feat: Tier-3 grab-bag — response cache + eval A/B compare

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,100 @@
+"""Tiny SHA256-keyed, TTL'd response cache (SQLite-backed).
+
+A generic helper for memoising expensive deterministic calls — an LLM
+classification, a relevance grade, a web fetch — keyed by the inputs. Reused
+across the protoLabs fleet (protoResearcher/quinn ``guardrails.py``),
+generalised here into an injectable class.
+
+Best-effort by design: every operation swallows errors (a cache that can't
+read/write must never break the caller). Falls back to a per-user path when
+the configured location isn't writable (same pattern as ``audit.py``).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import sqlite3
+import time
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_TTL_S = 86_400  # 24h
+
+
+class ResponseCache:
+    """Key→value cache with per-entry TTL. Keys are the SHA256 of the inputs."""
+
+    def __init__(self, path: str | Path = "/sandbox/cache/responses.db", ttl_seconds: float = _DEFAULT_TTL_S):
+        self.ttl = float(ttl_seconds)
+        self.path = Path(path)
+        self._conn: sqlite3.Connection | None = None
+        try:
+            self.path.parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            self.path = Path.home() / ".protoagent" / "cache" / self.path.name
+            try:
+                self.path.parent.mkdir(parents=True, exist_ok=True)
+            except OSError:
+                pass
+        self._init_db()
+
+    def _init_db(self) -> None:
+        try:
+            self._conn = sqlite3.connect(str(self.path), check_same_thread=False)
+            self._conn.execute(
+                "CREATE TABLE IF NOT EXISTS response_cache "
+                "(key TEXT PRIMARY KEY, value TEXT NOT NULL, created_at REAL NOT NULL)"
+            )
+            self._conn.commit()
+        except sqlite3.DatabaseError as exc:
+            log.warning("[cache] init failed (%s) — caching disabled", exc)
+            self._conn = None
+
+    @staticmethod
+    def _key(*parts: object) -> str:
+        raw = "\x1f".join(str(p).strip().lower() for p in parts)
+        return hashlib.sha256(raw.encode()).hexdigest()
+
+    def get(self, *parts: object) -> str | None:
+        """Return the cached value for *parts*, or None on miss/expiry/error."""
+        if self._conn is None:
+            return None
+        key = self._key(*parts)
+        try:
+            row = self._conn.execute(
+                "SELECT value, created_at FROM response_cache WHERE key = ?", (key,)
+            ).fetchone()
+            if row is None:
+                return None
+            value, created_at = row
+            if time.time() - created_at < self.ttl:
+                return value
+            self._conn.execute("DELETE FROM response_cache WHERE key = ?", (key,))
+            self._conn.commit()
+        except sqlite3.DatabaseError:
+            return None
+        return None
+
+    def set(self, value: str, *parts: object) -> None:
+        """Cache *value* under *parts*. No-op on error."""
+        if self._conn is None:
+            return
+        try:
+            self._conn.execute(
+                "INSERT OR REPLACE INTO response_cache (key, value, created_at) VALUES (?, ?, ?)",
+                (self._key(*parts), str(value), time.time()),
+            )
+            self._conn.commit()
+        except sqlite3.DatabaseError:
+            pass
+
+    def clear(self) -> None:
+        if self._conn is None:
+            return
+        try:
+            self._conn.execute("DELETE FROM response_cache")
+            self._conn.commit()
+        except sqlite3.DatabaseError:
+            pass

--- a/evals/compare.py
+++ b/evals/compare.py
@@ -1,0 +1,94 @@
+"""Compare two eval runs into a markdown diff report.
+
+Reads two reports written by ``evals.runner`` (``evals/results/run-*.json``,
+shape ``{"total", "passed", "results": [{"id","category","name","passed",
+"detail"}]}``) and reports the pass-rate delta, per-category deltas, and which
+cases flipped — the regression check for a model/backend/prompt change.
+
+Backported from the protoLabs fleet (protoResearcher ``evals/compare.py``).
+
+    python -m evals.compare evals/results/run-OLD.json evals/results/run-NEW.json
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+
+def _by_id(report: dict) -> dict[str, bool]:
+    return {r["id"]: bool(r["passed"]) for r in report.get("results", [])}
+
+
+def _category_passed(report: dict) -> dict[str, tuple[int, int]]:
+    """category -> (passed, total)."""
+    agg: dict[str, list[int]] = defaultdict(lambda: [0, 0])
+    for r in report.get("results", []):
+        cell = agg[r.get("category", "?")]
+        cell[1] += 1
+        if r.get("passed"):
+            cell[0] += 1
+    return {c: (p, t) for c, (p, t) in agg.items()}
+
+
+def _pct(passed: int, total: int) -> str:
+    return f"{(100 * passed / total):.0f}%" if total else "—"
+
+
+def compare_reports(old: dict, new: dict) -> str:
+    """Return a markdown comparison of two eval reports."""
+    o_total, o_pass = old.get("total", 0), old.get("passed", 0)
+    n_total, n_pass = new.get("total", 0), new.get("passed", 0)
+    delta = n_pass - o_pass
+
+    lines = ["# Eval comparison", ""]
+    arrow = "▲" if delta > 0 else ("▼" if delta < 0 else "■")
+    lines.append(
+        f"**Overall:** {o_pass}/{o_total} ({_pct(o_pass, o_total)}) → "
+        f"{n_pass}/{n_total} ({_pct(n_pass, n_total)})  {arrow} {delta:+d}"
+    )
+    lines.append("")
+
+    # Per-category
+    oc, nc = _category_passed(old), _category_passed(new)
+    cats = sorted(set(oc) | set(nc))
+    lines.append("| Category | Old | New | Δ |")
+    lines.append("|---|---|---|---|")
+    for c in cats:
+        op, ot = oc.get(c, (0, 0))
+        nps, nt = nc.get(c, (0, 0))
+        lines.append(f"| {c} | {op}/{ot} | {nps}/{nt} | {nps - op:+d} |")
+    lines.append("")
+
+    # Flips
+    o_ids, n_ids = _by_id(old), _by_id(new)
+    regressed = sorted(i for i in n_ids if o_ids.get(i) and not n_ids[i])
+    fixed = sorted(i for i in n_ids if n_ids[i] and o_ids.get(i) is False)
+    if regressed:
+        lines.append("### ❌ Newly failing")
+        lines += [f"- `{i}`" for i in regressed]
+        lines.append("")
+    if fixed:
+        lines.append("### ✅ Newly passing")
+        lines += [f"- `{i}`" for i in fixed]
+        lines.append("")
+    if not regressed and not fixed:
+        lines.append("_No cases flipped._")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    argv = argv if argv is not None else sys.argv[1:]
+    if len(argv) != 2:
+        sys.stderr.write("usage: python -m evals.compare <old.json> <new.json>\n")
+        return 2
+    old = json.loads(Path(argv[0]).read_text())
+    new = json.loads(Path(argv[1]).read_text())
+    print(compare_reports(old, new))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -1,0 +1,47 @@
+"""Tests for the SHA256/TTL ResponseCache."""
+
+from cache import ResponseCache
+
+
+def test_set_get_roundtrip(tmp_path):
+    c = ResponseCache(tmp_path / "c.db")
+    assert c.get("q") is None
+    c.set("answer", "q")
+    assert c.get("q") == "answer"
+
+
+def test_key_normalizes_case_and_whitespace(tmp_path):
+    c = ResponseCache(tmp_path / "c.db")
+    c.set("v", "  Hello World ")
+    assert c.get("hello world") == "v"
+
+
+def test_multipart_key_is_distinct(tmp_path):
+    c = ResponseCache(tmp_path / "c.db")
+    c.set("a", "q", "ctx1")
+    c.set("b", "q", "ctx2")
+    assert c.get("q", "ctx1") == "a"
+    assert c.get("q", "ctx2") == "b"
+    assert c.get("q") is None  # different arity → different key
+
+
+def test_ttl_expiry(tmp_path):
+    c = ResponseCache(tmp_path / "c.db", ttl_seconds=0)
+    c.set("v", "q")
+    assert c.get("q") is None  # ttl=0 → immediately expired
+
+
+def test_clear(tmp_path):
+    c = ResponseCache(tmp_path / "c.db")
+    c.set("v", "q")
+    c.clear()
+    assert c.get("q") is None
+
+
+def test_unwritable_path_degrades_gracefully(tmp_path, monkeypatch):
+    # Force the configured path AND the home fallback to be unwritable;
+    # the cache must construct + no-op without raising.
+    monkeypatch.setattr("pathlib.Path.mkdir", lambda *a, **k: (_ for _ in ()).throw(OSError()))
+    c = ResponseCache("/definitely/not/writable/c.db")
+    c.set("v", "q")          # no raise
+    assert c.get("q") is None

--- a/tests/test_eval_compare.py
+++ b/tests/test_eval_compare.py
@@ -1,0 +1,40 @@
+"""Tests for evals.compare — A/B diff of two eval reports."""
+
+from evals.compare import compare_reports
+
+
+def _report(results):
+    return {"total": len(results), "passed": sum(1 for r in results if r["passed"]),
+            "results": results}
+
+
+def test_overall_and_flips():
+    old = _report([
+        {"id": "a", "category": "tool", "name": "A", "passed": True, "detail": ""},
+        {"id": "b", "category": "tool", "name": "B", "passed": False, "detail": ""},
+        {"id": "c", "category": "a2a", "name": "C", "passed": True, "detail": ""},
+    ])
+    new = _report([
+        {"id": "a", "category": "tool", "name": "A", "passed": True, "detail": ""},
+        {"id": "b", "category": "tool", "name": "B", "passed": True, "detail": ""},   # fixed
+        {"id": "c", "category": "a2a", "name": "C", "passed": False, "detail": ""},   # regressed
+    ])
+    md = compare_reports(old, new)
+    assert "2/3" in md and "1/3" not in md.split("\n")[2]  # overall line: 2/3 → 2/3
+    assert "Newly passing" in md and "`b`" in md
+    assert "Newly failing" in md and "`c`" in md
+    # per-category table present
+    assert "| tool |" in md and "| a2a |" in md
+
+
+def test_no_flips_message():
+    rep = _report([{"id": "a", "category": "x", "name": "A", "passed": True, "detail": ""}])
+    md = compare_reports(rep, rep)
+    assert "No cases flipped" in md
+
+
+def test_handles_new_and_removed_categories():
+    old = _report([{"id": "a", "category": "old_cat", "name": "A", "passed": True, "detail": ""}])
+    new = _report([{"id": "b", "category": "new_cat", "name": "B", "passed": True, "detail": ""}])
+    md = compare_reports(old, new)
+    assert "old_cat" in md and "new_cat" in md


### PR DESCRIPTION
Backport from #174 (Tier-3). The grab-bag is a basket of optional extras; this lands the two cleanest, **service-free, broadly-useful** ones and explicitly scopes the rest.

- **`cache.py::ResponseCache`** — SHA256-keyed, TTL'd, SQLite-backed memo cache for expensive deterministic calls (an LLM relevance grade, a fetch). Best-effort (never raises), per-user path fallback like `audit.py`. From protoResearcher/quinn `guardrails.py`, generalised to an injectable class.
- **`evals/compare.py`** — diffs two `evals.runner` reports into markdown: overall pass-rate delta, per-category deltas, and which cases flipped (newly passing/failing). The regression check for a model/backend/prompt change. From protoResearcher.

9 tests; 445 pass (non-root 3.12).

### Deferred (with rationale)
Not worth forcing into core — they need external infra or are domain-shaped:
- **browser tool** — needs the `agent-browser` CLI
- **A2A peer federation** — needs a multi-agent deployment to be meaningful
- **GitHub-App token auth** — niche; the GitHub tools (#185) already work with a PAT
- **pwnDeck `BaseShellTool` / parser-registry** — offensive-security-shaped; the `with_fallback` + GitHub `gh_cli` patterns already cover core's generic needs

🤖 Generated with [Claude Code](https://claude.com/claude-code)