### PR TITLE
fix(ci): repair docs Pages deploy (invalid 'administration' permission)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,7 +10,6 @@ permissions:
   contents: read
   pages: write
   id-token: write
-  administration: write
 
 concurrency:
   group: pages
@@ -40,7 +39,3 @@ jobs:
     steps:
       - id: deployment
         uses: actions/deploy-pages@v4
-      - name: Update repo homepage
-        run: gh api -X PATCH repos/${{ github.repository }} -f homepage="${{ steps.deployment.outputs.page_url }}"
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
`docs.yml` had `permissions: administration: write` — **not a valid GitHub Actions permission scope**, so the workflow failed to *parse*: every run errored and `workflow_dispatch` returned `HTTP 422: Unexpected value 'administration'`. The last successful docs deploy was **2026-04-19** — the live site has been stale since (the "borked CSS" was a symptom of failing/partial deploys; the base path `/protoAgent/` itself is correct and live assets return 200).

The bad permission existed only to let an "Update repo homepage" step `gh api -X PATCH` the repo — which `GITHUB_TOKEN` can't be granted `administration` for regardless, and which is redundant (homepage is already set). Removed both.

After merge I'll `workflow_dispatch` docs.yml to confirm the build+deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)