### PR TITLE
fix(docs): ignore localhost dead links (VitePress build)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,6 +6,10 @@ export default defineConfig({
     "Template repository for building protoLabs A2A agents on LangGraph.",
   base: "/protoAgent/",
 
+  // Tutorials legitimately reference the local dev server (http://localhost:7870);
+  // VitePress treats dead links as fatal, so skip just the localhost ones.
+  ignoreDeadLinks: "localhostLinks",
+
   head: [["link", { rel: "icon", href: "/protoAgent/favicon.svg" }]],
 
   themeConfig: {


### PR DESCRIPTION
Second half of the docs-deploy repair (after #197 fixed the workflow parse error). The VitePress build failed on a dead-link check — `tutorials/first-agent.md` links `http://localhost:7870` (the local dev server) and VitePress treats dead links as fatal. Set its built-in `ignoreDeadLinks: 'localhostLinks'`. Verified `npm run docs:build` completes locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)