### PR TITLE
feat(knowledge): hot-memory injection (always-on domain='hot' facts)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -108,6 +108,8 @@ Only read when `middleware.knowledge` is `true`.
 
 The bundled store is sqlite + FTS5 (with an automatic LIKE fallback when FTS5 isn't available). One `chunks` table; the `domain` column distinguishes operator-set notes (`memory_ingest`), daily-log entries (`daily_log`), and conversation findings extracted by `MemoryMiddleware` (`domain='finding'`).
 
+**Hot memory** — chunks stored under `domain='hot'` are *always-on*: `KnowledgeMiddleware` injects them into context every turn (vs. retrieved-on-relevance), re-read each turn so a freshly-added hot fact is seen immediately. Set one with `memory_ingest(content, domain="hot")` for facts the agent should never forget (operator preferences, standing constraints).
+
 ## Scheduler
 
 Scheduler **enable/disable** is YAML-controlled (`middleware.scheduler` above) so the drawer can flip it without a restart. Backend **selection and runtime knobs** (which backend, where to write the sqlite, where to publish, etc.) are env-driven so the same container image can run under either backend without a rebuild. See [Schedule future work](/guides/scheduler) for the full guide.

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -302,6 +302,16 @@ class KnowledgeMiddleware(AgentMiddleware):
         if self._prior_sessions_cache:
             parts.append(self._prior_sessions_cache)
 
+        # Hot memory — always-on operator facts (domain="hot"). Loaded per turn
+        # (not cached) so a freshly-added hot fact is seen immediately.
+        if self._store is not None and hasattr(self._store, "get_hot_memory"):
+            try:
+                hot = self._store.get_hot_memory()
+                if hot:
+                    parts.append(f"[Always-on facts (hot memory):]\n{hot}")
+            except Exception as exc:  # noqa: BLE001 - never break the loop on memory
+                log.debug("[knowledge] hot memory load failed: %s", exc)
+
         messages = state.get("messages", [])
 
         # Inject learned skills from SkillsIndex when available

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -429,6 +429,25 @@ class KnowledgeStore:
             db.close()
         return [Chunk(**dict(r)) for r in rows]
 
+    def get_hot_memory(self, max_chars: int = 6000) -> str:
+        """Concatenate every ``domain="hot"`` chunk for always-on injection.
+
+        "Hot" chunks are operator facts that should be in front of the model
+        every turn (vs. retrieved-on-relevance). ``KnowledgeMiddleware`` reads
+        this each turn so a newly-added hot fact is seen immediately. Returns
+        "" when there are none; trims oldest-first if over ``max_chars``.
+        """
+        chunks = self.list_chunks(domain="hot", limit=100)  # newest-first
+        formatted: list[str] = []
+        total = 0
+        for c in chunks:  # newest-first → oldest trimmed when over budget
+            piece = (f"[{c.heading}] " if c.heading else "") + c.content
+            if total + len(piece) > max_chars:
+                break
+            formatted.append(piece)
+            total += len(piece)
+        return "\n".join(formatted)
+
     def stats(self) -> dict[str, int]:
         """Return per-domain chunk counts plus a ``total`` key."""
         db = self._get_db()

--- a/tests/test_hot_memory.py
+++ b/tests/test_hot_memory.py
@@ -1,0 +1,52 @@
+"""Tests for hot-memory (always-on domain='hot' facts)."""
+
+from unittest.mock import MagicMock
+
+from langchain_core.messages import HumanMessage
+
+from graph.middleware.knowledge import KnowledgeMiddleware
+from knowledge.store import KnowledgeStore
+
+
+def test_get_hot_memory_empty_when_none(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    assert store.get_hot_memory() == ""
+
+
+def test_get_hot_memory_returns_hot_chunks(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("operator prefers metric units", domain="hot", heading="prefs")
+    store.add_chunk("a normal note", domain="general")  # not hot
+    out = store.get_hot_memory()
+    assert "operator prefers metric units" in out
+    assert "[prefs]" in out
+    assert "a normal note" not in out  # only domain=hot
+
+
+def test_get_hot_memory_respects_budget(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("x" * 100, domain="hot")
+    store.add_chunk("y" * 100, domain="hot")
+    out = store.get_hot_memory(max_chars=120)
+    # Only one ~100-char chunk fits under the 120 budget.
+    assert len(out) <= 120
+
+
+def test_middleware_injects_hot_memory(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("deploys go out Fridays", domain="hot", heading="ops")
+    km = KnowledgeMiddleware(knowledge_store=store)
+    km._prior_sessions_cache = ""  # skip session loading
+    result = km.before_model({"messages": [HumanMessage(content="anything")]}, runtime=None)
+    assert result is not None
+    assert "Always-on facts (hot memory)" in result["context"]
+    assert "deploys go out Fridays" in result["context"]
+
+
+def test_middleware_no_hot_memory_no_block(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    km = KnowledgeMiddleware(knowledge_store=store)
+    km._prior_sessions_cache = ""
+    result = km.before_model({"messages": [HumanMessage(content="hi")]}, runtime=None)
+    if result is not None:
+        assert "hot memory" not in result.get("context", "").lower()


### PR DESCRIPTION
Backport from #174, source: gina. Adds `KnowledgeStore.get_hot_memory()` (concatenates `domain='hot'` chunks, newest-first, char-budgeted) and has `KnowledgeMiddleware` inject them into context **every turn** — re-read per turn so a freshly-added hot fact is seen immediately (vs. retrieved-on-relevance). Operators set one with `memory_ingest(content, domain='hot')` for standing facts (preferences, constraints). 5 tests; 450 pass (non-root 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)