### PR TITLE
feat(middleware): KnowledgeIngestMiddleware (capture tool output into KB)

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -77,6 +77,7 @@ Adding a new subagent name to the YAML requires matching entries in `graph/subag
 | `memory` | `true` | Persist a session summary on terminal turn and asynchronously index conversation findings under `domain='finding'`. |
 | `scheduler` | `true` | Wire the bundled scheduler backend (local sqlite, or `WorkstaceanScheduler` when env vars are set). Drops the `schedule_task` / `list_schedules` / `cancel_schedule` tools from the agent loop when `false`. Has the same effect as `SCHEDULER_DISABLED=1` — but `middleware.scheduler: false` is the canonical opt-out (drawer/wizard editable, survives restarts), while the env var is a runtime escape hatch for fleet operators who can't edit YAML in the moment. |
 | `enforcement` | `false` | Opt-in safety gate that blocks tool calls **before** they execute (see `enforcement` block below). No-op unless a deny list or rate limit is configured. |
+| `ingest` | `false` | Opt-in: capture tool output into the KB **after** execution (see `ingest` block below). |
 
 ## `enforcement`
 
@@ -95,6 +96,21 @@ enforcement:
 |---|---|---|
 | `disallowed_tools` | `[]` | Tool names that are always blocked. |
 | `rate_limits` | `{}` | Per-tool sliding-window limit: `{max, window_seconds}`. |
+
+## `ingest`
+
+Optional post-execution capture (`graph/middleware/knowledge_ingest.py`). Only read when `middleware.ingest: true`. After a tool runs, its output is stored in the KB under `domain='finding'` (recall-able later). Fire-and-forget — never breaks the loop. With no extractor it stores the raw (truncated) output; forks attach `extractor(tool_name, output) -> list[str]` in code (e.g. a small LLM) for distilled findings.
+
+```yaml
+middleware:
+  ingest: true
+ingest:
+  tools: [web_search, fetch_url]   # empty/omitted = capture all tools
+```
+
+| Key | Default | What |
+|---|---|---|
+| `tools` | `[]` | Restrict capture to these tool names (empty = all). |
 
 ## `knowledge`
 

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -43,6 +43,12 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None):
     if config.memory_middleware:
         middleware.append(MemoryMiddleware(knowledge_store))
 
+    if config.ingest_enabled and knowledge_store is not None:
+        from graph.middleware.knowledge_ingest import KnowledgeIngestMiddleware
+        middleware.append(KnowledgeIngestMiddleware(
+            knowledge_store, ingest_tools=config.ingest_tools or None,
+        ))
+
     middleware.append(MessageCaptureMiddleware())
 
     return middleware

--- a/graph/config.py
+++ b/graph/config.py
@@ -76,6 +76,13 @@ class LangGraphConfig:
     enforcement_disallowed_tools: list[str] = field(default_factory=list)
     enforcement_rate_limits: dict = field(default_factory=dict)
 
+    # Knowledge-ingest gate — opt-in middleware that captures tool output into
+    # the KB after execution. Off by default; ``ingest_tools`` (empty = all)
+    # narrows which tools are captured. Forks attach a structured extractor in
+    # code. See graph/middleware/knowledge_ingest.py.
+    ingest_enabled: bool = False
+    ingest_tools: list[str] = field(default_factory=list)
+
     # Knowledge store — sqlite + FTS5, see ``knowledge/store.py``.
     # The default path lives under ``/sandbox/`` to play well with the
     # bundled Docker volume; the store falls back to
@@ -147,6 +154,8 @@ class LangGraphConfig:
             enforcement_rate_limits=(
                 data.get("enforcement", {}).get("rate_limits", {})
             ),
+            ingest_enabled=middleware.get("ingest", cls.ingest_enabled),
+            ingest_tools=data.get("ingest", {}).get("tools", []),
             knowledge_db_path=knowledge.get("db_path", cls.knowledge_db_path),
             embed_model=knowledge.get("embed_model", cls.embed_model),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),

--- a/graph/middleware/knowledge_ingest.py
+++ b/graph/middleware/knowledge_ingest.py
@@ -1,0 +1,93 @@
+"""KnowledgeIngestMiddleware — auto-capture tool output into the knowledge store.
+
+After a tool runs, optionally extract findings from its output and persist them
+to the KB (``domain='finding'``) so later turns can recall them. Generalised
+from the protoLabs fleet (pwnDeck), stripped of its security-domain extractor:
+
+- **Pluggable extractor** — ``extractor(tool_name, output) -> list[str]`` lets a
+  fork distil structured findings (e.g. a small/fast LLM). With no extractor,
+  the deterministic fallback stores the (truncated) raw output as one finding.
+- **Fire-and-forget** — ingestion never raises into the agent loop; a capture
+  failure is logged and skipped.
+- **Opt-in** — off by default; wired only when ``middleware.ingest: true``.
+
+Skips empty output and tool errors / policy blocks so junk doesn't pollute the
+store.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Callable
+
+from langchain.agents.middleware import AgentMiddleware
+
+log = logging.getLogger(__name__)
+
+# extractor(tool_name, output) -> list of finding strings (empty = nothing to keep)
+IngestExtractor = Callable[[str, str], "list[str]"]
+
+_SKIP_PREFIXES = ("Error", "Blocked by policy", "[BLOCKED]")
+
+
+class KnowledgeIngestMiddleware(AgentMiddleware):
+    """Capture tool output into the knowledge store after execution."""
+
+    def __init__(
+        self,
+        knowledge_store,
+        *,
+        extractor: IngestExtractor | None = None,
+        ingest_tools: set[str] | list[str] | None = None,
+        max_chars: int = 4000,
+    ):
+        super().__init__()
+        self._store = knowledge_store
+        self._extractor = extractor
+        self._ingest_tools = set(ingest_tools) if ingest_tools else None  # None = all
+        self._max_chars = max_chars
+
+    def wrap_tool_call(self, request, handler):
+        result = handler(request)
+        self._try_ingest(request, result)
+        return result
+
+    async def awrap_tool_call(self, request, handler):
+        result = await handler(request)
+        self._try_ingest(request, result)
+        return result
+
+    def _try_ingest(self, request, result) -> None:
+        try:
+            if self._store is None:
+                return
+            tool_name = request.tool_call.get("name", "")
+            if self._ingest_tools is not None and tool_name not in self._ingest_tools:
+                return
+            content = getattr(result, "content", None)
+            if content is None:
+                return
+            content = str(content)
+            if not content.strip() or content.startswith(_SKIP_PREFIXES):
+                return
+            if len(content) > self._max_chars:
+                content = content[: self._max_chars] + "\n… [truncated]"
+
+            findings: list[str] = []
+            if self._extractor is not None:
+                try:
+                    findings = self._extractor(tool_name, content) or []
+                except Exception as exc:  # noqa: BLE001 - extractor is fork code
+                    log.debug("[ingest] extractor failed for %s: %s", tool_name, exc)
+            if not findings:
+                findings = [content]  # deterministic fallback: keep the raw output
+
+            for f in findings:
+                self._store.add_finding(
+                    content=str(f),
+                    source=f"tool:{tool_name}",
+                    source_type="tool_output",
+                    finding_type="ingest",
+                )
+        except Exception as exc:  # noqa: BLE001 - never break the agent loop
+            log.debug("[ingest] skipped: %s", exc)

--- a/tests/test_knowledge_ingest.py
+++ b/tests/test_knowledge_ingest.py
@@ -1,0 +1,99 @@
+"""Tests for KnowledgeIngestMiddleware."""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from graph.middleware.knowledge_ingest import KnowledgeIngestMiddleware
+
+
+def _req(name):
+    return SimpleNamespace(tool_call={"name": name, "args": {}, "id": "c1"})
+
+
+def _result(content):
+    return SimpleNamespace(content=content)
+
+
+def test_default_fallback_stores_raw_output():
+    store = MagicMock()
+    mw = KnowledgeIngestMiddleware(store)
+    out = mw.wrap_tool_call(_req("web_search"), lambda r: _result("3 results found"))
+    assert out.content == "3 results found"  # passthrough
+    store.add_finding.assert_called_once()
+    assert store.add_finding.call_args.kwargs["content"] == "3 results found"
+    assert store.add_finding.call_args.kwargs["source"] == "tool:web_search"
+
+
+def test_extractor_used_when_provided():
+    store = MagicMock()
+    mw = KnowledgeIngestMiddleware(store, extractor=lambda name, out: ["fact A", "fact B"])
+    mw.wrap_tool_call(_req("t"), lambda r: _result("raw output"))
+    assert store.add_finding.call_count == 2
+    stored = [c.kwargs["content"] for c in store.add_finding.call_args_list]
+    assert stored == ["fact A", "fact B"]
+
+
+def test_skips_errors_and_empty():
+    store = MagicMock()
+    mw = KnowledgeIngestMiddleware(store)
+    mw.wrap_tool_call(_req("t"), lambda r: _result("Error: boom"))
+    mw.wrap_tool_call(_req("t"), lambda r: _result("Blocked by policy: x"))
+    mw.wrap_tool_call(_req("t"), lambda r: _result("   "))
+    store.add_finding.assert_not_called()
+
+
+def test_ingest_tools_filter():
+    store = MagicMock()
+    mw = KnowledgeIngestMiddleware(store, ingest_tools=["keep"])
+    mw.wrap_tool_call(_req("skip"), lambda r: _result("data"))
+    store.add_finding.assert_not_called()
+    mw.wrap_tool_call(_req("keep"), lambda r: _result("data"))
+    store.add_finding.assert_called_once()
+
+
+def test_extractor_failure_falls_back_and_never_raises():
+    store = MagicMock()
+    def boom(name, out):
+        raise RuntimeError("llm down")
+    mw = KnowledgeIngestMiddleware(store, extractor=boom)
+    # no raise; falls back to storing raw output
+    mw.wrap_tool_call(_req("t"), lambda r: _result("raw"))
+    store.add_finding.assert_called_once()
+
+
+def test_store_failure_never_raises():
+    store = MagicMock()
+    store.add_finding.side_effect = RuntimeError("db down")
+    mw = KnowledgeIngestMiddleware(store)
+    # must not propagate
+    out = mw.wrap_tool_call(_req("t"), lambda r: _result("data"))
+    assert out.content == "data"
+
+
+@pytest.mark.asyncio
+async def test_async_path():
+    store = MagicMock()
+    mw = KnowledgeIngestMiddleware(store)
+    async def handler(r):
+        return _result("async data")
+    out = await mw.awrap_tool_call(_req("t"), handler)
+    assert out.content == "async data"
+    store.add_finding.assert_called_once()
+
+
+def test_config_wires_ingest(tmp_path):
+    import yaml
+    from graph.config import LangGraphConfig
+    from graph.agent import _build_middleware
+
+    p = tmp_path / "c.yaml"
+    p.write_text(yaml.safe_dump({
+        "middleware": {"ingest": True, "knowledge": False, "audit": False, "memory": False},
+        "ingest": {"tools": ["web_search"]},
+    }))
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.ingest_enabled is True and cfg.ingest_tools == ["web_search"]
+    mw = _build_middleware(cfg, knowledge_store=MagicMock())
+    assert any(m.__class__.__name__ == "KnowledgeIngestMiddleware" for m in mw)


### PR DESCRIPTION
Backport from #174, source: pwnDeck (generalised — security-domain extractor dropped). After a tool runs, optionally distil findings from its output and persist to the KB (`domain='finding'`) for later recall. **Pluggable** `extractor(tool_name, output) -> list[str]` (fork wires a small LLM); with none, the deterministic fallback stores the truncated raw output. Skips errors/policy-blocks/empty; fire-and-forget (never raises). **Off by default** — `middleware.ingest` + `ingest.tools` (empty = all). 8 tests; 458 pass (non-root 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)