### PR TITLE
feat(tools): A2A peer federation (peer_list / peer_consult)

### DIFF
--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -109,6 +109,15 @@ Without these set, the handler rejects webhook URLs that resolve to private / lo
 | `GRADIO_SERVER_NAME` | `0.0.0.0` | Bind address for the Gradio UI. |
 | `GRADIO_SERVER_PORT` | `7870` | Port for the Gradio UI. The A2A handler + metrics + agent card are all served on the same port. |
 
+## Peer federation (A2A peer-consult tools)
+
+Register peer agents so this agent can consult them via the `peer_list` / `peer_consult` tools (added to the toolset only when at least one peer is set). See [`tools/peer_tools.py`](https://github.com/protoLabsAI/protoAgent/blob/main/tools/peer_tools.py).
+
+| Variable | What |
+|---|---|
+| `PEER_<HANDLE>_URL` | Base URL of a peer agent (its `/a2a` endpoint is derived). `<HANDLE>` becomes the peer name (e.g. `PEER_ALICE_URL` → peer `alice`). |
+| `PEER_<HANDLE>_TOKEN` | Optional bearer token sent to that peer if it requires auth. |
+
 ## Release pipeline (shared `release-tools` Action)
 
 These are **CI secrets**, not env vars the template reads at runtime. The

--- a/tests/test_peer_federation.py
+++ b/tests/test_peer_federation.py
@@ -1,0 +1,101 @@
+"""Tests for A2A peer federation tools."""
+
+import pytest
+
+from tools.peer_tools import _resolve_peer, get_peer_tools, list_env_peers
+
+
+def _tools():
+    return {t.name: t for t in get_peer_tools()}
+
+
+def test_list_env_peers(monkeypatch):
+    monkeypatch.setenv("PEER_ALICE_URL", "https://alice.example")
+    monkeypatch.setenv("PEER_ALICE_TOKEN", "secret")
+    monkeypatch.setenv("PEER_BOB_URL", "https://bob.example")
+    peers = {p["handle"]: p for p in list_env_peers()}
+    assert peers["alice"]["url"] == "https://alice.example"
+    assert peers["alice"]["has_token"] is True
+    assert peers["bob"]["has_token"] is False
+
+
+def test_resolve_peer(monkeypatch):
+    monkeypatch.setenv("PEER_ALICE_URL", "https://alice.example")
+    monkeypatch.setenv("PEER_ALICE_TOKEN", "tok")
+    assert _resolve_peer("alice") == ("https://alice.example", "tok")
+    assert _resolve_peer("nope") == (None, None)
+    assert _resolve_peer("bad handle!") == (None, None)
+
+
+@pytest.mark.asyncio
+async def test_peer_consult_not_configured():
+    out = await _tools()["peer_consult"].ainvoke({"name": "ghost", "message": "hi"})
+    assert out.startswith("Error:") and "not configured" in out
+
+
+class _Resp:
+    def __init__(self, payload, status=200):
+        self._p, self.status_code, self.text = payload, status, "err"
+
+    def json(self):
+        return self._p
+
+
+class _FakeClient:
+    """Async-context client returning queued responses per .post call."""
+    def __init__(self, responses):
+        self._responses = list(responses)
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return False
+
+    async def post(self, url, json=None, headers=None):
+        return self._responses.pop(0)
+
+
+def _task(state, text=None):
+    art = {"artifacts": [{"parts": [{"kind": "text", "text": text}]}]} if text else {}
+    return {"jsonrpc": "2.0", "result": {"id": "t1", "status": {"state": state}, **art}}
+
+
+@pytest.mark.asyncio
+async def test_peer_consult_inline_reply(monkeypatch):
+    monkeypatch.setenv("PEER_ALICE_URL", "https://alice.example")
+    import httpx
+    monkeypatch.setattr(httpx, "AsyncClient",
+                        lambda *a, **k: _FakeClient([_Resp(_task("completed", "the answer"))]))
+    out = await _tools()["peer_consult"].ainvoke({"name": "alice", "message": "q"})
+    assert out == "[alice] the answer"
+
+
+@pytest.mark.asyncio
+async def test_peer_consult_polls_async_task(monkeypatch):
+    monkeypatch.setenv("PEER_ALICE_URL", "https://alice.example")
+    monkeypatch.setattr("tools.peer_tools._POLL_INTERVAL_S", 0)
+    import httpx
+    # send → submitted (no text); first tasks/get → working; second → completed.
+    responses = [_Resp(_task("submitted")), _Resp(_task("working")), _Resp(_task("completed", "done"))]
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: _FakeClient(responses))
+    out = await _tools()["peer_consult"].ainvoke({"name": "alice", "message": "q"})
+    assert out == "[alice] done"
+
+
+@pytest.mark.asyncio
+async def test_peer_consult_http_error(monkeypatch):
+    monkeypatch.setenv("PEER_ALICE_URL", "https://alice.example")
+    import httpx
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: _FakeClient([_Resp({}, status=500)]))
+    out = await _tools()["peer_consult"].ainvoke({"name": "alice", "message": "q"})
+    assert out.startswith("Error:") and "failed" in out
+
+
+def test_get_all_tools_includes_peers_only_when_configured(monkeypatch):
+    from tools.lg_tools import get_all_tools
+    names = {t.name for t in get_all_tools()}
+    assert "peer_consult" not in names  # no peers configured
+    monkeypatch.setenv("PEER_ALICE_URL", "https://alice.example")
+    names2 = {t.name for t in get_all_tools()}
+    assert "peer_consult" in names2 and "peer_list" in names2

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -521,6 +521,11 @@ def get_all_tools(knowledge_store=None, scheduler=None):
     # included — they degrade to a readable error if gh/auth is missing.
     from tools.github_tools import get_github_tools
     tools.extend(get_github_tools())
+    # A2A peer-consult tools — only when at least one PEER_<HANDLE>_URL is set,
+    # so agents with no federation peers aren't cluttered.
+    from tools.peer_tools import get_peer_tools, list_env_peers
+    if list_env_peers():
+        tools.extend(get_peer_tools())
     if knowledge_store is not None:
         tools.extend(_build_memory_tools(knowledge_store))
     if scheduler is not None:

--- a/tools/peer_tools.py
+++ b/tools/peer_tools.py
@@ -1,0 +1,147 @@
+"""A2A peer federation — consult another agent over the A2A protocol.
+
+When the answer depends on another agent's context, this agent sends it an
+A2A message and relays the reply. Backported from the protoLabs fleet (gina),
+simplified for core: peers come from **environment variables only** (no DB
+schema change). Register a peer with:
+
+    PEER_<HANDLE>_URL=https://other-agent.example   # base URL (its /a2a is derived)
+    PEER_<HANDLE>_TOKEN=<bearer>                     # optional, if the peer requires auth
+
+``peer_list`` / ``peer_consult`` are added to the toolset only when at least
+one peer is configured (see ``get_peer_tools``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import re
+import uuid
+
+from langchain_core.tools import tool
+
+from tools.fallbacks import with_fallback
+
+_HANDLE_RE = re.compile(r"^[A-Za-z0-9_-]{1,40}$")
+_POLL_INTERVAL_S = 1.0
+_MAX_POLLS = 30  # ~30s for an async peer to reach a terminal state
+
+
+def _resolve_peer(name: str) -> tuple[str | None, str | None]:
+    if not _HANDLE_RE.match(name or ""):
+        return None, None
+    key = name.upper().replace("-", "_")
+    return os.environ.get(f"PEER_{key}_URL"), os.environ.get(f"PEER_{key}_TOKEN")
+
+
+def list_env_peers() -> list[dict]:
+    """Peers registered via ``PEER_<HANDLE>_URL`` env vars."""
+    peers: list[dict] = []
+    for key, url in os.environ.items():
+        m = re.match(r"^PEER_([A-Z0-9_]+)_URL$", key)
+        if not m:
+            continue
+        peers.append({
+            "handle": m.group(1).lower().replace("_", "-"),
+            "url": url,
+            "has_token": bool(os.environ.get(f"PEER_{m.group(1)}_TOKEN")),
+        })
+    return sorted(peers, key=lambda p: p["handle"])
+
+
+def _extract_text(result) -> str | None:
+    """Pull text content out of an A2A Task/message result dict."""
+    if not isinstance(result, dict):
+        return None
+    for art in result.get("artifacts") or []:
+        chunks = [p.get("text", "") for p in art.get("parts", []) if p.get("kind") == "text"]
+        if any(chunks):
+            return "\n".join(c for c in chunks if c)
+    status = result.get("status") or {}
+    msg = status.get("message") or {}
+    parts = [p.get("text", "") for p in (msg.get("parts") or []) if p.get("kind") == "text"]
+    text = "\n".join(p for p in parts if p)
+    return text or None
+
+
+_TERMINAL = {"completed", "failed", "canceled"}
+
+
+def get_peer_tools() -> list:
+    """Return the peer tools — only call when peers are configured."""
+
+    @tool
+    @with_fallback()
+    async def peer_list() -> str:
+        """List the peer agents this agent can consult (from PEER_<HANDLE>_URL env)."""
+        peers = list_env_peers()
+        if not peers:
+            return "No peers configured (set PEER_<HANDLE>_URL)."
+        lines = [f"{len(peers)} peer(s):"]
+        for p in peers:
+            lines.append(f"  - {p['handle']}: {p['url']}" + (" (auth)" if p["has_token"] else ""))
+        return "\n".join(lines)
+
+    @tool
+    @with_fallback()
+    async def peer_consult(name: str, message: str) -> str:
+        """Ask another agent (by peer handle) a question and return its reply.
+
+        Args:
+            name: Peer handle (must match a configured ``PEER_<HANDLE>_URL``).
+            message: The question — be specific; the peer answers from its own context.
+        """
+        if not name.strip():
+            return "Error: peer name is required."
+        base, token = _resolve_peer(name)
+        if not base:
+            return f"Error: peer {name!r} is not configured (set PEER_{name.upper().replace('-', '_')}_URL)."
+
+        import httpx
+
+        url = f"{base.rstrip('/')}/a2a"
+        headers = {"Content-Type": "application/json"}
+        if token:
+            headers["Authorization"] = f"Bearer {token}"
+
+        async def _rpc(client, method, params):
+            body = {"jsonrpc": "2.0", "id": str(uuid.uuid4()), "method": method, "params": params}
+            r = await client.post(url, json=body, headers=headers)
+            if r.status_code >= 400:
+                raise RuntimeError(f"HTTP {r.status_code}: {r.text[:300]}")
+            data = r.json()
+            if "error" in data:
+                raise RuntimeError(str(data["error"]))
+            return data.get("result") or {}
+
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                result = await _rpc(client, "message/send", {
+                    "message": {
+                        "role": "user",
+                        "parts": [{"kind": "text", "text": message}],
+                        "messageId": str(uuid.uuid4()),
+                    }
+                })
+                # Inline reply? (some peers answer synchronously)
+                text = _extract_text(result)
+                if text:
+                    return f"[{name}] {text}"
+                # Otherwise poll the task to a terminal state.
+                task_id = result.get("id")
+                state = (result.get("status") or {}).get("state")
+                polls = 0
+                while task_id and state not in _TERMINAL and polls < _MAX_POLLS:
+                    await asyncio.sleep(_POLL_INTERVAL_S)
+                    polls += 1
+                    result = await _rpc(client, "tasks/get", {"id": task_id})
+                    state = (result.get("status") or {}).get("state")
+                text = _extract_text(result)
+                if text:
+                    return f"[{name}] {text}"
+                return f"Error: peer {name!r} returned no text (state={state})."
+        except Exception as exc:  # noqa: BLE001 - surface as a tool error string
+            return f"Error: consulting peer {name!r} failed: {exc}"
+
+    return [peer_list, peer_consult]


### PR DESCRIPTION
Backport from #174, source: gina (simplified — env-only registry, no DB schema change). Agent-to-agent consultation over A2A: `peer_consult(name, message)` sends `message/send` to `PEER_<HANDLE>_URL`'s `/a2a` (optional `PEER_<HANDLE>_TOKEN`), then polls `tasks/get` to terminal (core's handler is async) and relays the reply; `peer_list` shows configured peers. Both are added to `get_all_tools` **only when ≥1 peer is configured**. 7 tests (mocked httpx: inline reply, async-poll, error/not-configured); 465 pass (non-root 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)