### PR TITLE
feat(evals): push-notification webhook harness

### DIFF
--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -143,6 +143,21 @@ implementation runs 3 attempts and gates at 2 passes for those
 categories. Deterministic ones (`a2a-protocol`, `subsystem` with
 seeded state) gate at 100%.
 
+## Testing push notifications
+
+A2A push notifications POST to a consumer callback URL. To assert on delivery without a real server, use [`evals/webhook.py`](https://github.com/protoLabsAI/protoAgent/blob/main/evals/webhook.py):
+
+```python
+from evals.webhook import webhook_listener
+
+async with webhook_listener() as (url, capture):
+    # register `url` as the task's pushNotificationConfig, then run the task
+    ...
+    assert capture.received  # the agent delivered a notification (body + headers captured)
+```
+
+It runs a raw `asyncio` HTTP server on an ephemeral port (no FastAPI/aiohttp) and captures each POST body + headers.
+
 ## References
 
 - [`evals/README.md`](https://github.com/protoLabsAI/protoAgent/blob/main/evals/README.md) — quick reference for case authors

--- a/evals/webhook.py
+++ b/evals/webhook.py
@@ -1,0 +1,80 @@
+"""Lightweight webhook receiver for A2A push-notification eval cases.
+
+A2A push notifications are a single POST with a JSON body to a consumer
+callback URL. To assert on them in an eval (or test) without standing up a
+real web server, ``webhook_listener`` runs a raw ``asyncio`` HTTP server on an
+ephemeral port and captures every POST body + headers into a ``WebhookCapture``
+the caller asserts against — no FastAPI/aiohttp dependency.
+
+    async with webhook_listener() as (url, capture):
+        # register `url` as the task's pushNotificationConfig, run the task …
+        assert capture.received  # the agent delivered a notification
+
+Backported from the protoLabs fleet (gina ``evals/webhook.py``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import socket
+from contextlib import asynccontextmanager
+from dataclasses import dataclass, field
+
+
+@dataclass
+class WebhookCapture:
+    received: list[dict] = field(default_factory=list)
+    headers: list[dict] = field(default_factory=list)
+
+
+def _free_port() -> int:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.bind(("127.0.0.1", 0))
+        return s.getsockname()[1]
+
+
+@asynccontextmanager
+async def webhook_listener(host: str = "127.0.0.1"):
+    """Yield ``(url, capture)``; the server runs until the context exits."""
+    port = _free_port()
+    capture = WebhookCapture()
+
+    async def handle(reader: asyncio.StreamReader, writer: asyncio.StreamWriter):
+        try:
+            await reader.readline()  # request line (ignored)
+            headers: dict[str, str] = {}
+            while True:
+                line = await reader.readline()
+                if line in (b"", b"\r\n"):
+                    break
+                name, _, val = line.decode("latin-1").partition(":")
+                if name:
+                    headers[name.strip().lower()] = val.strip()
+
+            length = int(headers.get("content-length", "0") or 0)
+            body = await reader.readexactly(length) if length else b""
+            try:
+                payload = json.loads(body.decode("utf-8")) if body else {}
+            except json.JSONDecodeError:
+                payload = {"_raw": body.decode("utf-8", errors="replace")}
+
+            capture.received.append(payload)
+            capture.headers.append(headers)
+
+            writer.write(b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nOK")
+            await writer.drain()
+        finally:
+            writer.close()
+            try:
+                await writer.wait_closed()
+            except Exception:
+                pass
+
+    server = await asyncio.start_server(handle, host, port)
+    url = f"http://{host}:{port}/webhook"
+    try:
+        yield url, capture
+    finally:
+        server.close()
+        await server.wait_closed()

--- a/tests/test_eval_webhook.py
+++ b/tests/test_eval_webhook.py
@@ -1,0 +1,38 @@
+"""Tests for the eval webhook listener."""
+
+import json
+
+import httpx
+import pytest
+
+from evals.webhook import WebhookCapture, webhook_listener
+
+
+@pytest.mark.asyncio
+async def test_captures_posted_json():
+    async with webhook_listener() as (url, capture):
+        async with httpx.AsyncClient() as client:
+            r = await client.post(url, json={"taskId": "t1", "state": "completed"},
+                                  headers={"Authorization": "Bearer xyz"})
+        assert r.status_code == 200
+    assert len(capture.received) == 1
+    assert capture.received[0] == {"taskId": "t1", "state": "completed"}
+    assert capture.headers[0]["authorization"] == "Bearer xyz"
+
+
+@pytest.mark.asyncio
+async def test_multiple_posts_and_non_json_body():
+    async with webhook_listener() as (url, capture):
+        async with httpx.AsyncClient() as client:
+            await client.post(url, json={"n": 1})
+            await client.post(url, content=b"not json", headers={"content-type": "text/plain"})
+    assert len(capture.received) == 2
+    assert capture.received[0] == {"n": 1}
+    assert capture.received[1]["_raw"] == "not json"
+
+
+@pytest.mark.asyncio
+async def test_capture_empty_until_post():
+    async with webhook_listener() as (url, capture):
+        assert isinstance(capture, WebhookCapture)
+        assert capture.received == []


### PR DESCRIPTION
Backport from #174, source: gina. `evals/webhook.py` — `webhook_listener()` async context manager runs a raw `asyncio` HTTP server on an ephemeral port (no FastAPI/aiohttp) and captures every POST body + headers into a `WebhookCapture`, so evals/tests can assert A2A push-notification delivery without a real server. 3 tests; 468 pass (non-root 3.12). Documented in the eval guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)