### PR TITLE
feat: RAG guardrails (pluggable doc-grade + query-rewrite)

### DIFF
--- a/graph/guardrails.py
+++ b/graph/guardrails.py
@@ -1,0 +1,97 @@
+"""RAG guardrails — relevance grading + query rewriting.
+
+Two retrieval-quality primitives backported from the protoLabs fleet
+(protoResearcher/quinn ``guardrails.py``), generalised so core doesn't hardcode
+a gateway/model/token: the LLM call is a **pluggable callable** the fork
+supplies. Both fail open — an LLM outage degrades quality, never availability.
+
+- ``grade_document`` — binary "is this chunk relevant to the query?" check
+  before the agent leans on a retrieved doc. Pluggable ``grade_fn(query,
+  excerpt) -> bool | str``.
+- ``rewrite_query`` — rewrite a sparse-result query for a better second pass.
+  Pluggable ``rewrite_fn(query) -> str``.
+
+Pairs with ``cache.ResponseCache`` (memoise the grade/rewrite calls).
+
+    from graph.guardrails import grade_document, filter_relevant, rewrite_query
+    kept = await filter_relevant(q, hits, grade_fn=my_grader, key=lambda h: h["preview"])
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import Awaitable, Callable, Union
+
+log = logging.getLogger(__name__)
+
+GRADE_PROMPT = (
+    "Is the following content relevant to answering the query? "
+    "Answer only 'yes' or 'no'.\n\nQuery: {query}\n\nContent:\n{excerpt}"
+)
+REWRITE_PROMPT = (
+    "Rewrite this search query to retrieve better results — expand acronyms, "
+    "add synonyms, keep it concise. Return only the rewritten query.\n\n{query}"
+)
+
+_MIN_CONTENT_CHARS = 50
+_EXCERPT_CHARS = 500
+
+GradeFn = Callable[[str, str], Union[bool, str, "Awaitable[bool | str]"]]
+RewriteFn = Callable[[str], Union[str, "Awaitable[str]"]]
+
+
+async def _maybe_await(value):
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+def _is_yes(answer) -> bool:
+    if isinstance(answer, bool):
+        return answer
+    return str(answer).strip().lower().startswith("y")
+
+
+async def grade_document(query: str, content: str, *, grade_fn: GradeFn) -> bool:
+    """Return whether *content* is relevant to *query*.
+
+    Very short content is rejected outright. Otherwise ``grade_fn`` is asked
+    (sync or async); any error **fails open** (returns True) so an LLM outage
+    never silently drops every document.
+    """
+    if not content or len(content.strip()) < _MIN_CONTENT_CHARS:
+        return False
+    try:
+        answer = await _maybe_await(grade_fn(query, content[:_EXCERPT_CHARS]))
+        return _is_yes(answer)
+    except Exception as exc:  # noqa: BLE001 - fail open
+        log.debug("[guardrails] grade_fn failed, keeping doc: %s", exc)
+        return True
+
+
+async def filter_relevant(query, docs, *, grade_fn: GradeFn, key=None) -> list:
+    """Keep only the docs ``grade_document`` rates relevant to *query*.
+
+    ``key`` extracts the text to grade from each doc (default: the doc itself).
+    """
+    extract = key or (lambda d: d)
+    kept = []
+    for d in docs:
+        if await grade_document(query, str(extract(d)), grade_fn=grade_fn):
+            kept.append(d)
+    return kept
+
+
+async def rewrite_query(query: str, *, rewrite_fn: RewriteFn) -> str:
+    """Return a rewritten *query* (sync or async ``rewrite_fn``).
+
+    Falls back to the original query on empty output or error.
+    """
+    try:
+        rewritten = await _maybe_await(rewrite_fn(query))
+        rewritten = (rewritten or "").strip()
+        return rewritten or query
+    except Exception as exc:  # noqa: BLE001 - fall back to original
+        log.debug("[guardrails] rewrite_fn failed, using original: %s", exc)
+        return query

--- a/tests/test_guardrails.py
+++ b/tests/test_guardrails.py
@@ -1,0 +1,57 @@
+"""Tests for RAG guardrails (grade_document / filter_relevant / rewrite_query)."""
+
+import pytest
+
+from graph.guardrails import filter_relevant, grade_document, rewrite_query
+
+
+@pytest.mark.asyncio
+async def test_short_content_rejected():
+    called = []
+    assert await grade_document("q", "tiny", grade_fn=lambda *a: called.append(1) or "yes") is False
+    assert not called  # grade_fn not even consulted for too-short content
+
+
+@pytest.mark.asyncio
+async def test_grade_yes_no():
+    yes = lambda q, c: "Yes, relevant"
+    no = lambda q, c: "no"
+    content = "x" * 100
+    assert await grade_document("q", content, grade_fn=yes) is True
+    assert await grade_document("q", content, grade_fn=no) is False
+
+
+@pytest.mark.asyncio
+async def test_grade_accepts_bool_and_async():
+    content = "x" * 100
+    assert await grade_document("q", content, grade_fn=lambda q, c: True) is True
+    async def agrade(q, c):
+        return "yes"
+    assert await grade_document("q", content, grade_fn=agrade) is True
+
+
+@pytest.mark.asyncio
+async def test_grade_fails_open():
+    def boom(q, c):
+        raise RuntimeError("llm down")
+    # error → keep the doc (fail open)
+    assert await grade_document("q", "x" * 100, grade_fn=boom) is True
+
+
+@pytest.mark.asyncio
+async def test_filter_relevant_with_key():
+    docs = [{"preview": "a" * 100}, {"preview": "b" * 100}]
+    grade_fn = lambda q, c: "yes" if c.startswith("a") else "no"
+    kept = await filter_relevant("q", docs, grade_fn=grade_fn, key=lambda d: d["preview"])
+    assert kept == [docs[0]]
+
+
+@pytest.mark.asyncio
+async def test_rewrite_query():
+    assert await rewrite_query("moe", rewrite_fn=lambda q: "mixture of experts") == "mixture of experts"
+    # empty result → original
+    assert await rewrite_query("moe", rewrite_fn=lambda q: "  ") == "moe"
+    # error → original
+    def boom(q):
+        raise RuntimeError("x")
+    assert await rewrite_query("moe", rewrite_fn=boom) == "moe"


### PR DESCRIPTION
Backport from #174, source: protoResearcher/quinn (generalised — no hardcoded gateway/model/token; the LLM call is a pluggable callable). `graph/guardrails.py`:
- `grade_document(query, content, grade_fn)` — binary relevance check; rejects too-short content; **fails open** on grader error (an outage never drops every doc).
- `filter_relevant(query, docs, grade_fn, key=…)` — filter a retrieved doc list.
- `rewrite_query(query, rewrite_fn)` — rewrite a sparse-result query; falls back to the original on empty/error.

`grade_fn`/`rewrite_fn` may be sync or async. Pairs with `cache.ResponseCache` to memoise the calls. 6 tests; 474 pass (non-root 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)