### PR TITLE
docs(a2a): blast-v1 + hitl-mode-v1 per-skill policy card stanzas

### DIFF
--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -50,6 +50,38 @@ When the model self-reports a `<confidence>` tag in its final output, the termin
 
 The model emits the tags after `</output>` (see the protocol in `graph/output_format.py::OUTPUT_FORMAT_INSTRUCTIONS`); the server parses them with `extract_confidence()` and the A2A handler records them via `set_confidence()`, clamping to `[0, 1]`. The DataPart is omitted entirely when the model didn't report a score. `success` reflects the terminal state (`COMPLETED` only) — a high `confidence` on a non-success run is the "high-confidence failure" calibration signal.
 
+## `blast-v1`
+
+**URI**: `https://proto-labs.ai/a2a/ext/blast-v1`
+**Direction**: declared by this agent
+**Declared on card**: no (commented template stanza — fill per fork)
+
+Declares the **scope of effect** of each skill so a consumer can gate higher-impact work. `radius` is `self` (affects only this agent), `project`, or `repo`.
+
+```json
+{
+  "uri": "https://proto-labs.ai/a2a/ext/blast-v1",
+  "params": {"skills": {"my_skill": {"radius": "self"}}}
+}
+```
+
+Purely declarative — keep the declared radius honest with what each skill handler actually does. Uncomment the stanza in `server.py::_build_agent_card` and use your real skill IDs.
+
+## `hitl-mode-v1`
+
+**URI**: `https://proto-labs.ai/a2a/ext/hitl-mode-v1`
+**Direction**: declared by this agent
+**Declared on card**: no (commented template stanza — fill per fork)
+
+Declares a human-in-the-loop **approval policy** per skill: `autonomous` (run without approval) or `notification` (surface the action). Composes with `blast-v1` so higher-blast skills can be gated independently of goal-level config.
+
+```json
+{
+  "uri": "https://proto-labs.ai/a2a/ext/hitl-mode-v1",
+  "params": {"skills": {"my_skill": {"mode": "autonomous"}}}
+}
+```
+
 ## `effect-domain-v1`
 
 **URI**: `https://proto-labs.ai/a2a/ext/effect-domain-v1`

--- a/server.py
+++ b/server.py
@@ -965,6 +965,23 @@ def _build_agent_card(host: str) -> dict:
                 # <confidence> tag (see graph/output_format.py::extract_confidence
                 # and the confidence handler in _run_task_background).
                 {"uri": "https://proto-labs.ai/a2a/ext/confidence-v1"},
+                # ── Per-skill policy metadata (optional; declarative only) ──────
+                # Uncomment and fill with YOUR real skill IDs once you've replaced
+                # the placeholder card below. A consumer (e.g. Workstacean) reads
+                # these to gate execution; the template makes no claims for you.
+                #
+                # blast-v1 — scope of effect per skill (self | project | repo),
+                # so higher-blast work can be policy-gated:
+                # {
+                #     "uri": "https://proto-labs.ai/a2a/ext/blast-v1",
+                #     "params": {"skills": {"my_skill": {"radius": "self"}}},
+                # },
+                # hitl-mode-v1 — human-in-the-loop approval per skill
+                # (autonomous | notification). Composes with blast-v1:
+                # {
+                #     "uri": "https://proto-labs.ai/a2a/ext/hitl-mode-v1",
+                #     "params": {"skills": {"my_skill": {"mode": "autonomous"}}},
+                # },
             ],
         },
         "defaultInputModes": ["text/plain"],


### PR DESCRIPTION
Backport from #174, source: quinn. Adds the per-skill policy metadata extensions as **commented template stanzas** in `_build_agent_card` (forks uncomment + fill with their real skill IDs) plus extensions-reference docs:
- **blast-v1** — each skill's scope of effect (`self`|`project`|`repo`)
- **hitl-mode-v1** — approval policy per skill (`autonomous`|`notification`); composes with blast-v1

Both are declarative — a consumer (e.g. Workstacean) reads them to gate execution; the template makes no policy claims on a fork's behalf. No behavior change; card still parses; 474 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)