### PR TITLE
feat(tools): run_command async subprocess helper (BaseShellTool core)

### DIFF
--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -203,6 +203,8 @@ Cross-agent cancellation is blocked — `gina-personal` cannot cancel `gina-work
 
 ## Adding your own
 
+For tools that shell out, build on `tools/shell.py::run_command` (async; handles timeout/kill, missing-binary → structured error, env merge, stdin/cwd) or `tools/gh_cli.py` for `gh` specifically — don't hand-roll `subprocess`.
+
 Follow the same pattern:
 
 ```python

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1,0 +1,45 @@
+"""Tests for tools.shell.run_command."""
+
+import pytest
+
+from tools.shell import ShellResult, run_command
+
+
+@pytest.mark.asyncio
+async def test_success_and_stdout():
+    res = await run_command(["echo", "hello world"])
+    assert res.ok
+    assert res.stdout == "hello world"
+    assert res.returncode == 0
+
+
+@pytest.mark.asyncio
+async def test_nonzero_exit_not_ok():
+    res = await run_command(["sh", "-c", "echo oops >&2; exit 3"])
+    assert not res.ok
+    assert res.returncode == 3
+    assert "oops" in res.stderr
+    assert res.error is None  # it ran, just failed
+
+
+@pytest.mark.asyncio
+async def test_missing_binary_structured_error():
+    res = await run_command(["definitely-not-a-real-binary-xyz"])
+    assert not res.ok
+    assert res.error is not None and "not installed" in res.error  # no raise
+
+
+@pytest.mark.asyncio
+async def test_timeout_kills_process():
+    res = await run_command(["sleep", "5"], timeout=0.2)
+    assert res.timed_out is True
+    assert not res.ok
+    assert "timed out" in (res.error or "")
+
+
+@pytest.mark.asyncio
+async def test_stdin_and_env_merge(monkeypatch):
+    res = await run_command(["cat"], stdin="piped input")
+    assert res.stdout == "piped input"
+    res2 = await run_command(["sh", "-c", "echo $MY_VAR"], env={"MY_VAR": "merged"})
+    assert res2.stdout == "merged"

--- a/tools/shell.py
+++ b/tools/shell.py
@@ -1,0 +1,89 @@
+"""Async subprocess helper for shell/CLI-backed tools.
+
+A small, neutral foundation for any tool that shells out — the generic core of
+the protoLabs fleet's ``BaseShellTool`` (pwnDeck), stripped of its
+offensive-security specifics. Complements ``tools/gh_cli.py`` (which is
+``gh``-specific). Handles the things every shell tool gets wrong:
+
+- timeout + process kill,
+- missing binary → a structured ``error`` (never a raised ``FileNotFoundError``),
+- env merge over the current environment,
+- captured stdout/stderr (text), optional stdin and cwd.
+
+    res = await run_command(["git", "rev-parse", "HEAD"])
+    return res.stdout if res.ok else f"Error: {res.error or res.stderr}"
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class ShellResult:
+    returncode: int
+    stdout: str
+    stderr: str
+    timed_out: bool = False
+    error: str | None = None  # set when the command couldn't run at all
+
+    @property
+    def ok(self) -> bool:
+        return self.error is None and not self.timed_out and self.returncode == 0
+
+
+async def run_command(
+    argv: list[str],
+    *,
+    timeout: float = 30.0,
+    stdin: str | None = None,
+    env: dict[str, str] | None = None,
+    cwd: str | None = None,
+) -> ShellResult:
+    """Run ``argv`` as an async subprocess, returning a ``ShellResult``.
+
+    Never raises for the common failure modes: a missing binary or a timeout
+    come back as ``error`` / ``timed_out`` so callers can return a clean tool
+    string. ``env`` is merged over the current environment.
+    """
+    merged_env = None
+    if env is not None:
+        merged_env = os.environ.copy()
+        merged_env.update(env)
+
+    proc = None
+    try:
+        proc = await asyncio.create_subprocess_exec(
+            *argv,
+            stdin=asyncio.subprocess.PIPE if stdin is not None else None,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env=merged_env,
+            cwd=cwd,
+        )
+    except FileNotFoundError:
+        binary = argv[0] if argv else "?"
+        return ShellResult(1, "", "", error=f"{binary!r} is not installed or not on PATH.")
+    except OSError as exc:
+        return ShellResult(1, "", "", error=f"failed to launch {argv[0]!r}: {exc}")
+
+    try:
+        out, err = await asyncio.wait_for(
+            proc.communicate(stdin.encode() if stdin is not None else None),
+            timeout=timeout,
+        )
+    except asyncio.TimeoutError:
+        proc.kill()
+        try:
+            await proc.communicate()
+        except Exception:
+            pass
+        return ShellResult(1, "", "", timed_out=True, error=f"timed out after {timeout:g}s")
+
+    return ShellResult(
+        returncode=proc.returncode or 0,
+        stdout=out.decode(errors="replace").strip(),
+        stderr=err.decode(errors="replace").strip(),
+    )


### PR DESCRIPTION
Backport from #174, source: pwnDeck (generic core of `BaseShellTool`, security specifics dropped). `tools/shell.py::run_command(argv, …)` runs an async subprocess and returns a `ShellResult` — handling **timeout + kill**, **missing-binary → structured `error`** (never a raised `FileNotFoundError`), **env merge**, and optional **stdin/cwd**. A neutral foundation for any shell-backed tool, complementing `tools/gh_cli.py`. 5 tests; 479 pass (non-root 3.12).

🤖 Generated with [Claude Code](https://claude.com/claude-code)