### PR TITLE
test(evals): goal-mode harness coverage

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -38,6 +38,7 @@ Reports land in `evals/results/run-<ts>.json` per run.
 | `tool` | Single-tool invocations across the starter set |
 | `chained` | Multi-step reasoning that calls 2+ tools |
 | `subsystem` | KnowledgeMiddleware retrieval, hot-memory injection |
+| `goal` | Goal mode: set a goal, trigger the loop, assert the resulting goal state + footer |
 
 ## File layout
 
@@ -79,6 +80,30 @@ Append to `tasks.json`:
 Use **unique markers** (`EVAL-MARK-XYZ`, `eval-chain-flag-q9`) in
 prompts whenever you need a verifier to disambiguate from real
 operator data.
+
+### Goal-mode cases (`kind: "goal"`)
+
+Goal cases set a goal in a pinned session, send a trigger turn, then assert
+the resulting goal state and reply footer. The goal is cleared before and
+after the case.
+
+```json
+{
+  "id": "goal_achieved",
+  "category": "goal",
+  "kind": "goal",
+  "name": "...",
+  "set_goal": {"condition": "...", "verifier": {"type": "command", "command": "true"}},
+  "prompt": "Please make progress toward the goal.",
+  "expected_goal_status": "achieved",
+  "expected_patterns": ["goal achieved"]
+}
+```
+
+Prefer deterministic `command` verifiers (`"true"` → achieved, `"false"` with
+`"max_iterations": 1` → exhausted) so the outcome is independent of model
+competence and needs no host file I/O. `expected_goal_status` is checked
+against `GET /api/goal/{session}`; `expected_patterns` against the reply.
 
 ## Why side-effect verification
 

--- a/evals/client.py
+++ b/evals/client.py
@@ -106,20 +106,28 @@ class AgentClient:
 
     # ── message/send + poll ─────────────────────────────────────────────────
 
-    async def ask(self, prompt: str, *, timeout_s: int = 90) -> TaskResult:
-        """Send + poll until terminal. Returns TaskResult with extracted text."""
+    async def ask(self, prompt: str, *, timeout_s: int = 90, context_id: str | None = None) -> TaskResult:
+        """Send + poll until terminal. Returns TaskResult with extracted text.
+
+        ``context_id`` pins the A2A contextId (= the agent's session_id) so
+        multiple calls share one session — required for goal-mode cases that
+        set a goal on one turn and trigger the loop on the next.
+        """
         mid = str(uuid.uuid4())
+        params: dict = {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": prompt}],
+                "messageId": mid,
+            }
+        }
+        if context_id is not None:
+            params["contextId"] = context_id
         payload = {
             "jsonrpc": "2.0",
             "id": mid,
             "method": "message/send",
-            "params": {
-                "message": {
-                    "role": "user",
-                    "parts": [{"kind": "text", "text": prompt}],
-                    "messageId": mid,
-                }
-            },
+            "params": params,
         }
         start = time.time()
         async with httpx.AsyncClient(timeout=30) as client:
@@ -163,25 +171,31 @@ class AgentClient:
 
     # ── message/stream (SSE) ────────────────────────────────────────────────
 
-    async def stream(self, prompt: str, *, timeout_s: int = 90) -> tuple[list[dict], TaskResult | None]:
+    async def stream(self, prompt: str, *, timeout_s: int = 90, context_id: str | None = None) -> tuple[list[dict], TaskResult | None]:
         """Stream a turn over SSE. Returns (event_log, final TaskResult).
 
         Each event is a dict shaped ``{kind, result}``. Use this to assert
         on the streaming protocol itself (status-update sequence, final
         flag, artifact chunks). Most cases should use ``ask()`` instead.
+
+        ``context_id`` pins the A2A contextId (= session_id) so the turn
+        runs in a known session (e.g. one a goal was set on).
         """
         mid = str(uuid.uuid4())
+        params: dict = {
+            "message": {
+                "role": "user",
+                "parts": [{"kind": "text", "text": prompt}],
+                "messageId": mid,
+            }
+        }
+        if context_id is not None:
+            params["contextId"] = context_id
         payload = {
             "jsonrpc": "2.0",
             "id": mid,
             "method": "message/stream",
-            "params": {
-                "message": {
-                    "role": "user",
-                    "parts": [{"kind": "text", "text": prompt}],
-                    "messageId": mid,
-                }
-            },
+            "params": params,
         }
         events: list[dict] = []
         final: TaskResult | None = None
@@ -222,6 +236,25 @@ class AgentClient:
                             )
                             break
         return events, final
+
+    # ── goal mode ─────────────────────────────────────────────────────────────
+
+    async def get_goal(self, session_id: str) -> dict:
+        """GET ``/api/goal/{session_id}`` → ``{enabled, goal}`` (goal is the
+        full persisted state dict, or None when no goal is set)."""
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.get(f"{self.base_url}/api/goal/{session_id}", headers=self.headers)
+            r.raise_for_status()
+            return r.json()
+
+    async def clear_goal(self, session_id: str) -> dict:
+        """DELETE ``/api/goal/{session_id}`` → ``{enabled, cleared}``."""
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.request(
+                "DELETE", f"{self.base_url}/api/goal/{session_id}", headers=self.headers,
+            )
+            r.raise_for_status()
+            return r.json()
 
     # ── tasks/cancel ────────────────────────────────────────────────────────
 

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -322,11 +322,16 @@ async def _run_goal_case(client: AgentClient, case: dict) -> CaseResult:
 
         expected_status = case.get("expected_goal_status")
         if expected_status:
-            gstate = (await client.get_goal(ctx)).get("goal") or {}
-            actual = gstate.get("status")
-            if actual != expected_status:
+            goal_resp = await client.get_goal(ctx)
+            gstate = goal_resp.get("goal")
+            if not isinstance(gstate, dict):
+                # Fail loudly on a missing/empty goal record instead of letting
+                # a None status quietly mismatch — surfaces a backend/shape
+                # divergence rather than masking it.
+                problems.append(f"expected goal status {expected_status!r} but no goal state returned (resp={goal_resp})")
+            elif gstate.get("status") != expected_status:
                 problems.append(
-                    f"goal status={actual!r} expected {expected_status!r} "
+                    f"goal status={gstate.get('status')!r} expected {expected_status!r} "
                     f"(iter={gstate.get('iteration')}, reason={str(gstate.get('last_reason',''))[:80]!r})"
                 )
 

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -283,6 +283,72 @@ async def _run_prompt_case(
             verify.apply_teardown(case["teardown"])
 
 
+async def _run_goal_case(client: AgentClient, case: dict) -> CaseResult:
+    """Goal-mode case: set a goal in a pinned session, send a trigger turn,
+    then assert on the resulting goal state and the reply footer.
+
+    Case schema (in addition to id/category/name):
+      - ``set_goal``: the goal spec dict sent as ``/goal {json}`` (condition +
+        verifier + optional max_iterations). Use deterministic ``command``
+        verifiers (``"true"``/``"false"``) so the outcome is independent of
+        model competence.
+      - ``prompt``: the trigger message that runs the goal loop.
+      - ``expected_goal_status``: ``achieved`` / ``exhausted`` / ``unachievable``
+        — checked against ``GET /api/goal/{session}``.
+      - ``expected_patterns``: substrings that must appear in the reply (the
+        goal footer, e.g. ``goal achieved``).
+
+    The goal is cleared before (clean slate) and after (teardown) the case.
+    """
+    cid = case.get("id", "goal")
+    ctx = case.get("context_id") or f"eval-goal-{cid}"
+    cat, name = case.get("category", "goal"), case.get("name", cid)
+    try:
+        await client.clear_goal(ctx)
+
+        spec = case.get("set_goal")
+        if not isinstance(spec, dict):
+            return CaseResult(cid, cat, name, False, "case missing 'set_goal' spec")
+        set_reply = await client.ask("/goal " + json.dumps(spec), timeout_s=30, context_id=ctx)
+        if set_reply.state != "completed" or "goal set" not in set_reply.text.lower():
+            return CaseResult(cid, cat, name, False, f"goal not set (state={set_reply.state}): {set_reply.text[:120]!r}")
+
+        result = await client.ask(case["prompt"], timeout_s=case.get("timeout_s", 120), context_id=ctx)
+        if result is None or result.state != "completed":
+            state = result.state if result else "no-final-event"
+            return CaseResult(cid, cat, name, False, f"trigger state={state}; error={(result.error if result else None) or '(none)'}")
+
+        problems: list[str] = []
+
+        expected_status = case.get("expected_goal_status")
+        if expected_status:
+            gstate = (await client.get_goal(ctx)).get("goal") or {}
+            actual = gstate.get("status")
+            if actual != expected_status:
+                problems.append(
+                    f"goal status={actual!r} expected {expected_status!r} "
+                    f"(iter={gstate.get('iteration')}, reason={str(gstate.get('last_reason',''))[:80]!r})"
+                )
+
+        text_lower = result.text.lower()
+        for pattern in case.get("expected_patterns") or []:
+            if pattern.lower() not in text_lower:
+                problems.append(f"missing pattern {pattern!r}")
+
+        detail = "; ".join(problems) if problems else f"OK ({result.duration_ms}ms)"
+        return CaseResult(
+            cid, cat, name, passed=not problems, detail=detail,
+            duration_ms=result.duration_ms,
+            tokens=result.usage.get("total_tokens", 0) or 0,
+            raw={"reply": result.text[:300]},
+        )
+    finally:
+        try:
+            await client.clear_goal(ctx)
+        except Exception:
+            pass
+
+
 # ── dispatch ────────────────────────────────────────────────────────────────
 
 
@@ -291,6 +357,7 @@ _RUNNERS = {
     "auth_check": _run_auth_check,
     "ask": _run_ask,
     "stream": _run_stream,
+    "goal": _run_goal_case,
 }
 
 

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -6,7 +6,9 @@
     "name": "Agent card discovery",
     "expect": {
       "skills_min": 1,
-      "extensions_contain": ["cost-v1"]
+      "extensions_contain": [
+        "cost-v1"
+      ]
     }
   },
   {
@@ -15,7 +17,9 @@
     "kind": "auth_check",
     "name": "Reject bad bearer when bearer auth is configured",
     "bad_token": "definitely-not-the-real-token",
-    "expect": {"status": 401}
+    "expect": {
+      "status": 401
+    }
   },
   {
     "id": "streaming_status_updates",
@@ -25,9 +29,10 @@
     "prompt": "Hi.",
     "expected_tools": [],
     "expected_patterns": [],
-    "expected_event_kinds": ["status-update"]
+    "expected_event_kinds": [
+      "status-update"
+    ]
   },
-
   {
     "id": "abstain_no_tool",
     "category": "abstention",
@@ -35,7 +40,9 @@
     "name": "Don't reach for a tool when training data is fine",
     "prompt": "What's the capital of France? One word.",
     "expected_tools": [],
-    "expected_patterns": ["paris"]
+    "expected_patterns": [
+      "paris"
+    ]
   },
   {
     "id": "greeting",
@@ -46,151 +53,285 @@
     "expected_tools": [],
     "expected_patterns": []
   },
-
   {
     "id": "current_time_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks about live time → current_time",
+    "name": "Asks about live time \u2192 current_time",
     "prompt": "What time is it in UTC right now?",
-    "expected_tools": ["current_time"],
-    "expected_patterns": ["UTC"]
+    "expected_tools": [
+      "current_time"
+    ],
+    "expected_patterns": [
+      "UTC"
+    ]
   },
   {
     "id": "calculator_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks for arithmetic → calculator",
+    "name": "Asks for arithmetic \u2192 calculator",
     "prompt": "How much is 17 times 23, plus 1?",
-    "expected_tools": ["calculator"],
-    "expected_patterns": ["392"]
+    "expected_tools": [
+      "calculator"
+    ],
+    "expected_patterns": [
+      "392"
+    ]
   },
   {
     "id": "web_search_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks about recent news → web_search",
+    "name": "Asks about recent news \u2192 web_search",
     "prompt": "Anything notable in the news about Anthropic this week?",
-    "expected_tools": ["web_search"],
+    "expected_tools": [
+      "web_search"
+    ],
     "expected_patterns": []
   },
   {
     "id": "fetch_url_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks about a URL's content → fetch_url",
+    "name": "Asks about a URL's content \u2192 fetch_url",
     "prompt": "What's on https://example.com? Just the page title is fine.",
-    "expected_tools": ["fetch_url"],
-    "expected_patterns": ["example"]
+    "expected_tools": [
+      "fetch_url"
+    ],
+    "expected_patterns": [
+      "example"
+    ]
   },
-
   {
     "id": "memory_ingest_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Stores a stable preference → memory_ingest writes a chunk",
+    "name": "Stores a stable preference \u2192 memory_ingest writes a chunk",
     "prompt": "Remember that I prefer protoLabs Studio standups at 9am Eastern.",
-    "expected_tools": ["memory_ingest"],
+    "expected_tools": [
+      "memory_ingest"
+    ],
     "expected_patterns": [],
     "verify_kb": {
       "find_chunk_containing": "9am"
     },
     "teardown": [
-      {"kb_delete_by_content": {"contains": "9am"}}
+      {
+        "kb_delete_by_content": {
+          "contains": "9am"
+        }
+      }
     ]
   },
   {
     "id": "daily_log_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks to log an event → daily_log writes today's chunk",
+    "name": "Asks to log an event \u2192 daily_log writes today's chunk",
     "prompt": "Log this for today: my standup just ended, team is unblocked on the auth migration.",
-    "expected_tools": ["daily_log"],
+    "expected_tools": [
+      "daily_log"
+    ],
     "expected_patterns": [],
     "verify_kb": {
       "find_chunk_containing": "auth migration",
       "domain": "daily-log"
     },
     "teardown": [
-      {"kb_delete_by_content": {"contains": "auth migration"}}
+      {
+        "kb_delete_by_content": {
+          "contains": "auth migration"
+        }
+      }
     ]
   },
   {
     "id": "memory_recall_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks about a stored fact → recall surfaces it",
+    "name": "Asks about a stored fact \u2192 recall surfaces it",
     "setup": [
-      {"kb_ingest": {
-        "content": "Operator's primary lab is Snickerdoodle, located in Spokane.",
-        "domain": "context",
-        "heading": "lab"
-      }}
+      {
+        "kb_ingest": {
+          "content": "Operator's primary lab is Snickerdoodle, located in Spokane.",
+          "domain": "context",
+          "heading": "lab"
+        }
+      }
     ],
     "prompt": "Where's my primary lab and what's it called?",
-    "expected_tools": ["memory_recall"],
-    "expected_patterns": ["snickerdoodle", "spokane"],
+    "expected_tools": [
+      "memory_recall"
+    ],
+    "expected_patterns": [
+      "snickerdoodle",
+      "spokane"
+    ],
     "teardown": [
-      {"kb_delete_by_heading": {"domain": "context", "heading": "lab"}}
+      {
+        "kb_delete_by_heading": {
+          "domain": "context",
+          "heading": "lab"
+        }
+      }
     ]
   },
   {
     "id": "memory_list_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks for recent log entries → memory_list",
+    "name": "Asks for recent log entries \u2192 memory_list",
     "setup": [
-      {"kb_ingest": {"content": "called the dentist", "domain": "daily-log", "heading": "today"}},
-      {"kb_ingest": {"content": "merged the auth PR", "domain": "daily-log", "heading": "today"}}
+      {
+        "kb_ingest": {
+          "content": "called the dentist",
+          "domain": "daily-log",
+          "heading": "today"
+        }
+      },
+      {
+        "kb_ingest": {
+          "content": "merged the auth PR",
+          "domain": "daily-log",
+          "heading": "today"
+        }
+      }
     ],
     "prompt": "What did I do today? Summarize from the log.",
-    "expected_tools": ["memory_list"],
-    "expected_patterns": ["dentist"],
+    "expected_tools": [
+      "memory_list"
+    ],
+    "expected_patterns": [
+      "dentist"
+    ],
     "teardown": [
-      {"kb_delete_by_content": {"contains": "called the dentist"}},
-      {"kb_delete_by_content": {"contains": "merged the auth PR"}}
+      {
+        "kb_delete_by_content": {
+          "contains": "called the dentist"
+        }
+      },
+      {
+        "kb_delete_by_content": {
+          "contains": "merged the auth PR"
+        }
+      }
     ]
   },
   {
     "id": "memory_stats_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks how much is in memory → memory_stats",
+    "name": "Asks how much is in memory \u2192 memory_stats",
     "prompt": "How much have I got stored across each memory domain?",
-    "expected_tools": ["memory_stats"],
+    "expected_tools": [
+      "memory_stats"
+    ],
     "expected_patterns": []
   },
-
   {
     "id": "log_then_recall_chain",
     "category": "chained",
     "kind": "ask",
     "name": "Log an event, then recall it later in the same turn",
     "prompt": "Log this for today: 'eval-chain-flag-q9: chained log+recall test'. After logging, search memory for that flag and quote it back.",
-    "expected_tools": ["daily_log", "memory_recall"],
-    "expected_patterns": ["eval-chain-flag-q9"],
+    "expected_tools": [
+      "daily_log",
+      "memory_recall"
+    ],
+    "expected_patterns": [
+      "eval-chain-flag-q9"
+    ],
     "teardown": [
-      {"kb_delete_by_content": {"contains": "eval-chain-flag-q9"}}
+      {
+        "kb_delete_by_content": {
+          "contains": "eval-chain-flag-q9"
+        }
+      }
     ]
   },
-
   {
     "id": "knowledge_middleware_recall",
     "category": "subsystem",
     "kind": "ask",
     "name": "KnowledgeMiddleware surfaces a stored fact without an explicit search",
     "setup": [
-      {"kb_ingest": {
-        "content": "Operator's preferred coffee is a Gibraltar with oat milk from Atticus.",
-        "domain": "preferences",
-        "heading": "coffee"
-      }}
+      {
+        "kb_ingest": {
+          "content": "Operator's preferred coffee is a Gibraltar with oat milk from Atticus.",
+          "domain": "preferences",
+          "heading": "coffee"
+        }
+      }
     ],
     "prompt": "What's my usual coffee order?",
     "expected_tools": [],
-    "expected_patterns": ["gibraltar", "oat"],
+    "expected_patterns": [
+      "gibraltar",
+      "oat"
+    ],
     "teardown": [
-      {"kb_delete_by_heading": {"domain": "preferences", "heading": "coffee"}}
+      {
+        "kb_delete_by_heading": {
+          "domain": "preferences",
+          "heading": "coffee"
+        }
+      }
+    ]
+  },
+  {
+    "id": "goal_achieved",
+    "category": "goal",
+    "kind": "goal",
+    "name": "Goal with a passing verifier resolves to achieved",
+    "set_goal": {
+      "condition": "the readiness check passes",
+      "verifier": {
+        "type": "command",
+        "command": "true"
+      }
+    },
+    "prompt": "Please make progress toward the goal.",
+    "expected_goal_status": "achieved",
+    "expected_patterns": [
+      "goal achieved"
+    ]
+  },
+  {
+    "id": "goal_exhausted",
+    "category": "goal",
+    "kind": "goal",
+    "name": "Never-satisfiable goal runs out of its iteration budget",
+    "set_goal": {
+      "condition": "the readiness check passes",
+      "verifier": {
+        "type": "command",
+        "command": "false"
+      },
+      "max_iterations": 1
+    },
+    "prompt": "Please make progress toward the goal.",
+    "expected_goal_status": "exhausted",
+    "expected_patterns": [
+      "goal exhausted"
+    ]
+  },
+  {
+    "id": "goal_verifier_beats_giveup",
+    "category": "goal",
+    "kind": "goal",
+    "name": "Passing verifier overrides a model give-up in the same turn",
+    "set_goal": {
+      "condition": "the readiness check passes",
+      "verifier": {
+        "type": "command",
+        "command": "true"
+      }
+    },
+    "prompt": "You have no way to do this and no relevant tools. Give up: state that the goal is unachievable and stop.",
+    "expected_goal_status": "achieved",
+    "expected_patterns": [
+      "goal achieved"
     ]
   }
 ]

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -6,9 +6,7 @@
     "name": "Agent card discovery",
     "expect": {
       "skills_min": 1,
-      "extensions_contain": [
-        "cost-v1"
-      ]
+      "extensions_contain": ["cost-v1"]
     }
   },
   {
@@ -17,9 +15,7 @@
     "kind": "auth_check",
     "name": "Reject bad bearer when bearer auth is configured",
     "bad_token": "definitely-not-the-real-token",
-    "expect": {
-      "status": 401
-    }
+    "expect": {"status": 401}
   },
   {
     "id": "streaming_status_updates",
@@ -29,10 +25,9 @@
     "prompt": "Hi.",
     "expected_tools": [],
     "expected_patterns": [],
-    "expected_event_kinds": [
-      "status-update"
-    ]
+    "expected_event_kinds": ["status-update"]
   },
+
   {
     "id": "abstain_no_tool",
     "category": "abstention",
@@ -40,9 +35,7 @@
     "name": "Don't reach for a tool when training data is fine",
     "prompt": "What's the capital of France? One word.",
     "expected_tools": [],
-    "expected_patterns": [
-      "paris"
-    ]
+    "expected_patterns": ["paris"]
   },
   {
     "id": "greeting",
@@ -53,285 +46,182 @@
     "expected_tools": [],
     "expected_patterns": []
   },
+
   {
     "id": "current_time_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks about live time \u2192 current_time",
+    "name": "Asks about live time → current_time",
     "prompt": "What time is it in UTC right now?",
-    "expected_tools": [
-      "current_time"
-    ],
-    "expected_patterns": [
-      "UTC"
-    ]
+    "expected_tools": ["current_time"],
+    "expected_patterns": ["UTC"]
   },
   {
     "id": "calculator_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks for arithmetic \u2192 calculator",
+    "name": "Asks for arithmetic → calculator",
     "prompt": "How much is 17 times 23, plus 1?",
-    "expected_tools": [
-      "calculator"
-    ],
-    "expected_patterns": [
-      "392"
-    ]
+    "expected_tools": ["calculator"],
+    "expected_patterns": ["392"]
   },
   {
     "id": "web_search_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks about recent news \u2192 web_search",
+    "name": "Asks about recent news → web_search",
     "prompt": "Anything notable in the news about Anthropic this week?",
-    "expected_tools": [
-      "web_search"
-    ],
+    "expected_tools": ["web_search"],
     "expected_patterns": []
   },
   {
     "id": "fetch_url_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks about a URL's content \u2192 fetch_url",
+    "name": "Asks about a URL's content → fetch_url",
     "prompt": "What's on https://example.com? Just the page title is fine.",
-    "expected_tools": [
-      "fetch_url"
-    ],
-    "expected_patterns": [
-      "example"
-    ]
+    "expected_tools": ["fetch_url"],
+    "expected_patterns": ["example"]
   },
+
   {
     "id": "memory_ingest_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Stores a stable preference \u2192 memory_ingest writes a chunk",
+    "name": "Stores a stable preference → memory_ingest writes a chunk",
     "prompt": "Remember that I prefer protoLabs Studio standups at 9am Eastern.",
-    "expected_tools": [
-      "memory_ingest"
-    ],
+    "expected_tools": ["memory_ingest"],
     "expected_patterns": [],
     "verify_kb": {
       "find_chunk_containing": "9am"
     },
     "teardown": [
-      {
-        "kb_delete_by_content": {
-          "contains": "9am"
-        }
-      }
+      {"kb_delete_by_content": {"contains": "9am"}}
     ]
   },
   {
     "id": "daily_log_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks to log an event \u2192 daily_log writes today's chunk",
+    "name": "Asks to log an event → daily_log writes today's chunk",
     "prompt": "Log this for today: my standup just ended, team is unblocked on the auth migration.",
-    "expected_tools": [
-      "daily_log"
-    ],
+    "expected_tools": ["daily_log"],
     "expected_patterns": [],
     "verify_kb": {
       "find_chunk_containing": "auth migration",
       "domain": "daily-log"
     },
     "teardown": [
-      {
-        "kb_delete_by_content": {
-          "contains": "auth migration"
-        }
-      }
+      {"kb_delete_by_content": {"contains": "auth migration"}}
     ]
   },
   {
     "id": "memory_recall_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks about a stored fact \u2192 recall surfaces it",
+    "name": "Asks about a stored fact → recall surfaces it",
     "setup": [
-      {
-        "kb_ingest": {
-          "content": "Operator's primary lab is Snickerdoodle, located in Spokane.",
-          "domain": "context",
-          "heading": "lab"
-        }
-      }
+      {"kb_ingest": {
+        "content": "Operator's primary lab is Snickerdoodle, located in Spokane.",
+        "domain": "context",
+        "heading": "lab"
+      }}
     ],
     "prompt": "Where's my primary lab and what's it called?",
-    "expected_tools": [
-      "memory_recall"
-    ],
-    "expected_patterns": [
-      "snickerdoodle",
-      "spokane"
-    ],
+    "expected_tools": ["memory_recall"],
+    "expected_patterns": ["snickerdoodle", "spokane"],
     "teardown": [
-      {
-        "kb_delete_by_heading": {
-          "domain": "context",
-          "heading": "lab"
-        }
-      }
+      {"kb_delete_by_heading": {"domain": "context", "heading": "lab"}}
     ]
   },
   {
     "id": "memory_list_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks for recent log entries \u2192 memory_list",
+    "name": "Asks for recent log entries → memory_list",
     "setup": [
-      {
-        "kb_ingest": {
-          "content": "called the dentist",
-          "domain": "daily-log",
-          "heading": "today"
-        }
-      },
-      {
-        "kb_ingest": {
-          "content": "merged the auth PR",
-          "domain": "daily-log",
-          "heading": "today"
-        }
-      }
+      {"kb_ingest": {"content": "called the dentist", "domain": "daily-log", "heading": "today"}},
+      {"kb_ingest": {"content": "merged the auth PR", "domain": "daily-log", "heading": "today"}}
     ],
     "prompt": "What did I do today? Summarize from the log.",
-    "expected_tools": [
-      "memory_list"
-    ],
-    "expected_patterns": [
-      "dentist"
-    ],
+    "expected_tools": ["memory_list"],
+    "expected_patterns": ["dentist"],
     "teardown": [
-      {
-        "kb_delete_by_content": {
-          "contains": "called the dentist"
-        }
-      },
-      {
-        "kb_delete_by_content": {
-          "contains": "merged the auth PR"
-        }
-      }
+      {"kb_delete_by_content": {"contains": "called the dentist"}},
+      {"kb_delete_by_content": {"contains": "merged the auth PR"}}
     ]
   },
   {
     "id": "memory_stats_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks how much is in memory \u2192 memory_stats",
+    "name": "Asks how much is in memory → memory_stats",
     "prompt": "How much have I got stored across each memory domain?",
-    "expected_tools": [
-      "memory_stats"
-    ],
+    "expected_tools": ["memory_stats"],
     "expected_patterns": []
   },
+
   {
     "id": "log_then_recall_chain",
     "category": "chained",
     "kind": "ask",
     "name": "Log an event, then recall it later in the same turn",
     "prompt": "Log this for today: 'eval-chain-flag-q9: chained log+recall test'. After logging, search memory for that flag and quote it back.",
-    "expected_tools": [
-      "daily_log",
-      "memory_recall"
-    ],
-    "expected_patterns": [
-      "eval-chain-flag-q9"
-    ],
+    "expected_tools": ["daily_log", "memory_recall"],
+    "expected_patterns": ["eval-chain-flag-q9"],
     "teardown": [
-      {
-        "kb_delete_by_content": {
-          "contains": "eval-chain-flag-q9"
-        }
-      }
+      {"kb_delete_by_content": {"contains": "eval-chain-flag-q9"}}
     ]
   },
+
   {
     "id": "knowledge_middleware_recall",
     "category": "subsystem",
     "kind": "ask",
     "name": "KnowledgeMiddleware surfaces a stored fact without an explicit search",
     "setup": [
-      {
-        "kb_ingest": {
-          "content": "Operator's preferred coffee is a Gibraltar with oat milk from Atticus.",
-          "domain": "preferences",
-          "heading": "coffee"
-        }
-      }
+      {"kb_ingest": {
+        "content": "Operator's preferred coffee is a Gibraltar with oat milk from Atticus.",
+        "domain": "preferences",
+        "heading": "coffee"
+      }}
     ],
     "prompt": "What's my usual coffee order?",
     "expected_tools": [],
-    "expected_patterns": [
-      "gibraltar",
-      "oat"
-    ],
+    "expected_patterns": ["gibraltar", "oat"],
     "teardown": [
-      {
-        "kb_delete_by_heading": {
-          "domain": "preferences",
-          "heading": "coffee"
-        }
-      }
+      {"kb_delete_by_heading": {"domain": "preferences", "heading": "coffee"}}
     ]
   },
+
   {
     "id": "goal_achieved",
     "category": "goal",
     "kind": "goal",
     "name": "Goal with a passing verifier resolves to achieved",
-    "set_goal": {
-      "condition": "the readiness check passes",
-      "verifier": {
-        "type": "command",
-        "command": "true"
-      }
-    },
+    "set_goal": {"condition": "the readiness check passes", "verifier": {"type": "command", "command": "true"}},
     "prompt": "Please make progress toward the goal.",
     "expected_goal_status": "achieved",
-    "expected_patterns": [
-      "goal achieved"
-    ]
+    "expected_patterns": ["goal achieved"]
   },
   {
     "id": "goal_exhausted",
     "category": "goal",
     "kind": "goal",
     "name": "Never-satisfiable goal runs out of its iteration budget",
-    "set_goal": {
-      "condition": "the readiness check passes",
-      "verifier": {
-        "type": "command",
-        "command": "false"
-      },
-      "max_iterations": 1
-    },
+    "set_goal": {"condition": "the readiness check passes", "verifier": {"type": "command", "command": "false"}, "max_iterations": 1},
     "prompt": "Please make progress toward the goal.",
     "expected_goal_status": "exhausted",
-    "expected_patterns": [
-      "goal exhausted"
-    ]
+    "expected_patterns": ["goal exhausted"]
   },
   {
     "id": "goal_verifier_beats_giveup",
     "category": "goal",
     "kind": "goal",
     "name": "Passing verifier overrides a model give-up in the same turn",
-    "set_goal": {
-      "condition": "the readiness check passes",
-      "verifier": {
-        "type": "command",
-        "command": "true"
-      }
-    },
+    "set_goal": {"condition": "the readiness check passes", "verifier": {"type": "command", "command": "true"}},
     "prompt": "You have no way to do this and no relevant tools. Give up: state that the goal is unachievable and stop.",
     "expected_goal_status": "achieved",
-    "expected_patterns": [
-      "goal achieved"
-    ]
+    "expected_patterns": ["goal achieved"]
   }
 ]


### PR DESCRIPTION
## Summary

Goal mode (PR #229 + the QA fixes in #231) had unit tests and ad-hoc live verification but **no coverage in the project's eval harness** (`evals/`). This adds a `goal` case kind so goal mode is exercised over A2A end-to-end, the same way the starter tools are.

A `goal` case:
1. Sets a goal in a **pinned session** (new `context_id` support on the eval client) via the `/goal {json}` control message.
2. Sends a trigger turn that runs the goal loop.
3. Asserts the resulting **goal state** (`GET /api/goal/{session}`) *and* the reply footer (`expected_patterns`).
4. Clears the goal before and after (teardown).

### Cases (`evals/tasks.json`, category `goal`)

Deterministic `command` verifiers — model-independent outcomes, no host file I/O:
- `goal_achieved` — `command: "true"` → `achieved`.
- `goal_exhausted` — `command: "false"` + `max_iterations: 1` → `exhausted`.
- `goal_verifier_beats_giveup` — passing verifier + a trigger that pushes the model to give up → `achieved` (the verifier-precedence fix from #231, exercised end-to-end).

### Changes

- `evals/client.py` — `context_id` param on `ask()`/`stream()`; `get_goal()` / `clear_goal()` for the `/api/goal` endpoints.
- `evals/runner.py` — `goal` case kind (`_run_goal_case`): set → trigger → assert state + footer, clear in `finally`.
- `evals/tasks.json` — three goal cases (additions only).
- `evals/README.md` — documents the `goal` category + case schema.

## Test plan

- [x] `python -m evals.runner --category goal` against a live agent (proto-labs gateway, `protolabs/smart`): **3/3 passed**.
- [x] Negative control — flipping `goal_achieved`'s `expected_goal_status` to a wrong value makes it **fail** (`goal status='achieved' expected 'unachievable'`), proving the goal-state assertion is real, not a no-op.
- [x] Changes are additive — existing case kinds (`ask`/`stream`/`agent_card`/`auth_check`) and the optional `context_id` default (`None`) leave all 16 existing cases unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)