### PR TITLE
Sandbox operator console to an allowed directory list

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -777,7 +777,13 @@ export function App() {
               value={projectPath}
               onChange={(event) => setProjectPath(event.target.value)}
               placeholder="Project path"
+              list="operator-allowed-dirs"
             />
+            <datalist id="operator-allowed-dirs">
+              {(runtime?.project.allowed_dirs || []).map((dir) => (
+                <option key={dir} value={dir} />
+              ))}
+            </datalist>
             <button className="icon-button" type="button" onClick={() => void loadProject()} title="Load project">
               {notesBusy || beadsBusy ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
             </button>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -564,6 +564,12 @@ textarea {
   padding: 0 12px;
 }
 
+.field-hint {
+  color: var(--fg-subtle, var(--fg-muted));
+  font-size: 11px;
+  opacity: 0.75;
+}
+
 .subagent-grid {
   display: grid;
   grid-template-columns: 180px minmax(0, 1fr) auto;

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -3,6 +3,7 @@ export type RuntimeStatus = {
   graph_loaded: boolean;
   project: {
     path: string;
+    allowed_dirs?: string[];
   };
   model: null | {
     provider: string;
@@ -130,6 +131,9 @@ export type AgentConfig = {
   };
   runtime: {
     autostart_on_boot: boolean;
+  };
+  operator?: {
+    allowed_dirs: string[];
   };
 };
 

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -36,6 +36,7 @@ type WizardState = {
   researcherTurns: number;
   knowledgePath: string;
   knowledgeTopK: number;
+  allowedDirs: string;
   initBeads: boolean;
 };
 
@@ -60,6 +61,7 @@ function defaultState(): WizardState {
     researcherTurns: 40,
     knowledgePath: "/sandbox/knowledge/agent.db",
     knowledgeTopK: 5,
+    allowedDirs: "",
     initBeads: false,
   };
 }
@@ -86,6 +88,7 @@ function hydrateState(payload: ConfigPayload, status: SetupStatus | null): Wizar
     researcherTurns: Number(config.subagents.researcher.max_turns ?? 40),
     knowledgePath: config.knowledge.db_path || "/sandbox/knowledge/agent.db",
     knowledgeTopK: Number(config.knowledge.top_k ?? 5),
+    allowedDirs: (config.operator?.allowed_dirs || []).join("\n"),
     initBeads: false,
   };
 }
@@ -221,6 +224,12 @@ export function SetupWizard({
             db_path: state.knowledgePath.trim(),
             embed_model: "nomic-embed-text",
             top_k: Number(state.knowledgeTopK),
+          },
+          operator: {
+            allowed_dirs: state.allowedDirs
+              .split("\n")
+              .map((dir) => dir.trim())
+              .filter(Boolean),
           },
         },
         state.soul,
@@ -394,6 +403,18 @@ export function SetupWizard({
                   <input value={projectPath} onChange={(event) => onProjectPathChange(event.target.value)} />
                 </label>
               </div>
+              <label className="field">
+                <span>Allowed project directories</span>
+                <textarea
+                  rows={3}
+                  value={state.allowedDirs}
+                  onChange={(event) => update({ allowedDirs: event.target.value })}
+                  placeholder={"One path per line.\nThe protoAgent directory is always allowed."}
+                />
+                <span className="field-hint">
+                  Beads and notes may only read/write inside these directories. One per line.
+                </span>
+              </label>
               <label className="checkbox-field setup-checkbox">
                 <input type="checkbox" checked={state.initBeads} onChange={(event) => update({ initBeads: event.target.checked })} />
                 <span>Initialize beads</span>

--- a/config/langgraph-config.yaml
+++ b/config/langgraph-config.yaml
@@ -71,3 +71,12 @@ skills:
   db_path: /sandbox/skills.db
   top_k: 5
   max_tokens: 2000
+
+# React operator console — the beads/notes APIs accept a project path from
+# the (free-text) UI, so the server, not the client, decides which
+# directories they may touch. The protoAgent repo root is always allowed;
+# add any other project roots you operate on here. Empty = repo root only.
+# Editable in-app from the setup wizard's Workspace step.
+operator:
+  allowed_dirs: []
+  # - /home/kj/projects/my-other-repo

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -271,6 +271,21 @@ block React UI validation.
 7. **Tauri shell**: wrap `/app`, add tray/hotkey/hide-on-close.
 8. **Gradio retirement**: remove only after React covers setup, config, chat, diagnostics.
 
+## Directory Allowlist
+
+The beads and notes APIs take a `project_path` from the (free-text) UI, so the
+server — not the client — decides which directories they may read and write.
+`operator.allowed_dirs` in `config/langgraph-config.yaml` is that boundary:
+
+- The protoAgent repo root is always allowed (the default project).
+- Add other project roots you operate on to `operator.allowed_dirs`, or edit
+  the list in-app from the setup wizard's **Workspace** step.
+- An out-of-allowlist path is rejected with a 400 before any subprocess or file
+  I/O. `resolve_project_path` resolves symlinks and `..` *before* the
+  containment check, so neither can escape an allowed root.
+- The runtime-status `project.allowed_dirs` field feeds the project-path
+  picker's suggestions; it does not relax the server-side check.
+
 ## Risks
 
 - A2A streaming events are not AI SDK data-stream events; the first chat UI

--- a/graph/config.py
+++ b/graph/config.py
@@ -177,6 +177,14 @@ class LangGraphConfig:
     # whether the plist should exist.
     autostart_on_boot: bool = False
 
+    # Operator-console directory allowlist — the extra directories the
+    # React console's beads/notes APIs may read and write. The protoAgent
+    # repo root is always allowed implicitly (it's the default project);
+    # add other project roots here to operate on them. Empty = repo root
+    # only. The client sends a free-text project path, so this server-side
+    # list — not the UI — is the security boundary. See operator_api/paths.
+    operator_allowed_dirs: list[str] = field(default_factory=list)
+
     @classmethod
     def from_yaml(cls, path: str | Path) -> "LangGraphConfig":
         """Load config from YAML file. Falls back to defaults if absent."""
@@ -194,6 +202,7 @@ class LangGraphConfig:
         identity = data.get("identity", {})
         auth = data.get("auth", {})
         runtime = data.get("runtime", {})
+        operator = data.get("operator", {})
 
         config = cls(
             model_provider=model.get("provider", cls.model_provider),
@@ -249,6 +258,7 @@ class LangGraphConfig:
             identity_operator=identity.get("operator", cls.identity_operator),
             auth_token=auth.get("token", cls.auth_token),
             autostart_on_boot=runtime.get("autostart_on_boot", cls.autostart_on_boot),
+            operator_allowed_dirs=list(operator.get("allowed_dirs", []) or []),
         )
 
         for name in ("researcher",):

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -150,6 +150,9 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
         "runtime": {
             "autostart_on_boot": config.autostart_on_boot,
         },
+        "operator": {
+            "allowed_dirs": list(config.operator_allowed_dirs),
+        },
     }
 
 
@@ -210,6 +213,12 @@ def validate_config_dict(updates: dict[str, Any]) -> tuple[bool, str]:
             top_k = int(knowledge.get("top_k", 5))
             if top_k < 1:
                 return False, f"knowledge.top_k must be >= 1, got {top_k}"
+
+        operator = updates.get("operator", {})
+        if operator:
+            allowed = operator.get("allowed_dirs", [])
+            if not isinstance(allowed, list) or not all(isinstance(d, str) for d in allowed):
+                return False, "operator.allowed_dirs must be a list of strings"
     except (TypeError, ValueError) as e:
         return False, f"config validation: {e}"
     return True, ""

--- a/operator_api/beads.py
+++ b/operator_api/beads.py
@@ -6,6 +6,7 @@ import json
 import os
 import subprocess
 import threading
+from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Any
 
@@ -31,8 +32,14 @@ class BeadsService:
     locking, JSONL flushes, and store-discovery semantics.
     """
 
-    def __init__(self, *, timeout_s: float = 15.0):
+    def __init__(
+        self,
+        *,
+        timeout_s: float = 15.0,
+        allowed_dirs: Callable[[], list[str]] | None = None,
+    ):
         self.timeout_s = timeout_s
+        self._allowed_dirs = allowed_dirs
         self._lock = threading.Lock()
 
     def status(self, project_path: str) -> dict[str, bool]:
@@ -116,7 +123,8 @@ class BeadsService:
         return result.stdout
 
     def _run_allow_fail(self, project_path: str, args: list[str]) -> subprocess.CompletedProcess:
-        cwd = resolve_project_path(project_path)
+        allowed = self._allowed_dirs() if self._allowed_dirs is not None else None
+        cwd = resolve_project_path(project_path, allowed)
         try:
             with self._lock:
                 return subprocess.run(

--- a/operator_api/notes.py
+++ b/operator_api/notes.py
@@ -6,6 +6,7 @@ import json
 import os
 import time
 import uuid
+from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
@@ -40,8 +41,12 @@ def create_default_workspace() -> dict[str, Any]:
 class NotesService:
     """Load/save a ProtoMaker-compatible notes workspace."""
 
+    def __init__(self, *, allowed_dirs: Callable[[], list[str]] | None = None):
+        self._allowed_dirs = allowed_dirs
+
     def workspace_path(self, project_path: str) -> Path:
-        return resolve_project_path(project_path) / ".automaker" / "notes" / "workspace.json"
+        allowed = self._allowed_dirs() if self._allowed_dirs is not None else None
+        return resolve_project_path(project_path, allowed) / ".automaker" / "notes" / "workspace.json"
 
     def load_workspace(self, project_path: str) -> dict[str, Any]:
         path = self.workspace_path(project_path)

--- a/operator_api/paths.py
+++ b/operator_api/paths.py
@@ -2,11 +2,36 @@
 
 from __future__ import annotations
 
+from collections.abc import Iterable
 from pathlib import Path
 
 
-def resolve_project_path(project_path: str) -> Path:
-    """Resolve and validate a project directory path from the UI."""
+def _resolved_roots(allowed_dirs: Iterable[str]) -> list[Path]:
+    roots: list[Path] = []
+    for raw in allowed_dirs:
+        if not raw or not str(raw).strip():
+            continue
+        roots.append(Path(raw).expanduser().resolve())
+    return roots
+
+
+def resolve_project_path(
+    project_path: str,
+    allowed_dirs: Iterable[str] | None = None,
+) -> Path:
+    """Resolve and validate a project directory path from the UI.
+
+    When ``allowed_dirs`` is provided, the resolved path must be equal to
+    or nested under one of those directories. This is the operator-console
+    sandbox: the React client sends a free-text ``project_path``, so the
+    server — not the client — decides which directories beads/notes may
+    touch. ``None`` means "no allowlist configured" and stays permissive
+    so non-operator callers and tests keep the old behavior.
+
+    Resolution happens before the containment check (``Path.resolve`` walks
+    symlinks and normalizes ``..``), so neither ``../../etc`` nor a symlink
+    pointing outside an allowed root can escape the sandbox.
+    """
     if not project_path or not project_path.strip():
         raise ValueError("project_path is required")
     path = Path(project_path).expanduser().resolve()
@@ -14,4 +39,12 @@ def resolve_project_path(project_path: str) -> Path:
         raise ValueError(f"project_path does not exist: {path}")
     if not path.is_dir():
         raise ValueError(f"project_path is not a directory: {path}")
+
+    if allowed_dirs is not None:
+        roots = _resolved_roots(allowed_dirs)
+        if not any(path == root or root in path.parents for root in roots):
+            raise ValueError(
+                f"project_path is outside the allowed directories: {path}"
+            )
+
     return path

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -85,10 +85,17 @@ def register_operator_routes(
     subagent_batch: Callable[[dict[str, Any]], Awaitable[str]],
     beads_service: BeadsService | None = None,
     notes_service: NotesService | None = None,
+    allowed_dirs: Callable[[], list[str]] | None = None,
 ) -> None:
-    """Register React operator-console routes on a FastAPI app."""
-    beads = beads_service or BeadsService()
-    notes = notes_service or NotesService()
+    """Register React operator-console routes on a FastAPI app.
+
+    ``allowed_dirs`` is an accessor returning the directories the operator
+    console may read/write (beads + notes). It's a callable, not a static
+    list, so it re-reads live config after a settings reload. Injected
+    services keep their own allowlist; it only wires the defaults.
+    """
+    beads = beads_service or BeadsService(allowed_dirs=allowed_dirs)
+    notes = notes_service or NotesService(allowed_dirs=allowed_dirs)
 
     @app.get("/api/runtime/status")
     async def _runtime_status():

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -11,6 +11,7 @@ def build_runtime_status(
     setup_complete: bool,
     graph_loaded: bool,
     project_path: str = "",
+    allowed_dirs: list[str] | None = None,
     knowledge_store: Any = None,
     scheduler: Any = None,
     cache_warmer: Any = None,
@@ -20,12 +21,16 @@ def build_runtime_status(
 
     Secrets are represented as booleans only. The React setup/runtime screens
     need to know whether auth/model credentials exist, not what they are.
+
+    ``allowed_dirs`` is the operator-console sandbox the client uses to
+    populate the project-path picker; the server still enforces it.
     """
+    project = {"path": project_path, "allowed_dirs": list(allowed_dirs or [])}
     if config is None:
         return {
             "setup_complete": bool(setup_complete),
             "graph_loaded": False,
-            "project": {"path": project_path},
+            "project": project,
             "model": None,
             "identity": None,
             "middleware": {},
@@ -38,7 +43,7 @@ def build_runtime_status(
     return {
         "setup_complete": bool(setup_complete),
         "graph_loaded": bool(graph_loaded),
-        "project": {"path": project_path},
+        "project": project,
         "model": {
             "provider": getattr(config, "model_provider", ""),
             "name": getattr(config, "model_name", ""),

--- a/server.py
+++ b/server.py
@@ -1157,12 +1157,24 @@ def _main():
         run_manual_subagent_batch as _operator_run_manual_subagent_batch,
     )
 
+    _operator_repo_root = str(Path(__file__).parent.resolve())
+
+    def _operator_allowed_dirs() -> list[str]:
+        # The repo root is always operable (it's the default project);
+        # config adds any extra project roots. Read live so a settings
+        # reload takes effect without restarting the server.
+        roots = [_operator_repo_root]
+        if _graph_config is not None:
+            roots.extend(getattr(_graph_config, "operator_allowed_dirs", []) or [])
+        return roots
+
     def _operator_runtime_status():
         return _build_operator_status(
             config=_graph_config,
             setup_complete=_operator_setup_complete(),
             graph_loaded=_graph is not None,
-            project_path=str(Path(__file__).parent.resolve()),
+            project_path=_operator_repo_root,
+            allowed_dirs=_operator_allowed_dirs(),
             knowledge_store=_knowledge_store,
             scheduler=_scheduler,
             cache_warmer=_cache_warmer,
@@ -1201,6 +1213,7 @@ def _main():
         subagent_list=_operator_subagent_list,
         subagent_run=_operator_subagent_run,
         subagent_batch=_operator_subagent_batch,
+        allowed_dirs=_operator_allowed_dirs,
     )
 
     # --- Scheduler lifecycle ------------------------------------------------

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -130,7 +130,7 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # strand fork-added fields outside the drawer's round-trip.
     assert set(d.keys()) == {
         "model", "subagents", "middleware", "knowledge",
-        "identity", "auth", "runtime",
+        "identity", "auth", "runtime", "operator",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature
@@ -140,6 +140,7 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     assert d["identity"]["name"] == cfg.identity_name
     assert d["auth"]["token"] == cfg.auth_token
     assert d["runtime"]["autostart_on_boot"] == cfg.autostart_on_boot
+    assert d["operator"]["allowed_dirs"] == list(cfg.operator_allowed_dirs)
 
 
 # ── validate_config_dict ─────────────────────────────────────────────────────
@@ -153,6 +154,8 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     ({"subagents": {"researcher": {"max_turns": 0}}}, "max_turns"),
     ({"subagents": {"researcher": {"tools": "not-a-list"}}}, "list"),
     ({"knowledge": {"top_k": 0}}, "top_k"),
+    ({"operator": {"allowed_dirs": "not-a-list"}}, "allowed_dirs"),
+    ({"operator": {"allowed_dirs": [1, 2]}}, "allowed_dirs"),
 ])
 def test_validate_rejects_bad_values(bad_value, expected_error_fragment):
     from graph.config_io import validate_config_dict
@@ -167,6 +170,34 @@ def test_validate_accepts_happy_path():
 
     ok, err = validate_config_dict(config_to_dict(LangGraphConfig()))
     assert ok, err
+
+
+def test_from_yaml_reads_operator_allowed_dirs(tmp_path: Path) -> None:
+    """The operator allowlist round-trips through the YAML schema so a
+    settings reload (not just first-run setup) can change it."""
+    from graph.config import LangGraphConfig
+
+    p = tmp_path / "langgraph-config.yaml"
+    p.write_text(
+        "operator:\n"
+        "  allowed_dirs:\n"
+        "    - /home/kj/projects/foo\n"
+        "    - /home/kj/projects/bar\n"
+    )
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.operator_allowed_dirs == [
+        "/home/kj/projects/foo",
+        "/home/kj/projects/bar",
+    ]
+
+
+def test_from_yaml_operator_allowed_dirs_defaults_empty(tmp_path: Path) -> None:
+    from graph.config import LangGraphConfig
+
+    p = tmp_path / "langgraph-config.yaml"
+    p.write_text("model:\n  name: test\n")
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.operator_allowed_dirs == []
 
 
 # ── SOUL.md dual-path ────────────────────────────────────────────────────────

--- a/tests/test_operator_api_paths.py
+++ b/tests/test_operator_api_paths.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import pytest
+
+from operator_api.notes import NotesService
+from operator_api.paths import resolve_project_path
+
+
+def test_resolve_requires_non_empty_path() -> None:
+    with pytest.raises(ValueError, match="required"):
+        resolve_project_path("   ")
+
+
+def test_resolve_rejects_missing_path(tmp_path) -> None:
+    with pytest.raises(ValueError, match="does not exist"):
+        resolve_project_path(str(tmp_path / "nope"))
+
+
+def test_resolve_rejects_file(tmp_path) -> None:
+    f = tmp_path / "file.txt"
+    f.write_text("x")
+    with pytest.raises(ValueError, match="not a directory"):
+        resolve_project_path(str(f))
+
+
+def test_no_allowlist_is_permissive(tmp_path) -> None:
+    # allowed_dirs=None keeps the pre-hardening behavior for non-operator callers.
+    assert resolve_project_path(str(tmp_path)) == tmp_path.resolve()
+
+
+def test_path_inside_allowed_root_is_accepted(tmp_path) -> None:
+    root = tmp_path / "root"
+    nested = root / "project"
+    nested.mkdir(parents=True)
+
+    assert resolve_project_path(str(nested), [str(root)]) == nested.resolve()
+    # the root itself is allowed, not just descendants
+    assert resolve_project_path(str(root), [str(root)]) == root.resolve()
+
+
+def test_path_outside_allowed_root_is_rejected(tmp_path) -> None:
+    allowed = tmp_path / "allowed"
+    other = tmp_path / "other"
+    allowed.mkdir()
+    other.mkdir()
+
+    with pytest.raises(ValueError, match="outside the allowed"):
+        resolve_project_path(str(other), [str(allowed)])
+
+
+def test_empty_allowlist_rejects_everything(tmp_path) -> None:
+    # An empty list is still an allowlist (deny all), unlike None.
+    with pytest.raises(ValueError, match="outside the allowed"):
+        resolve_project_path(str(tmp_path), [])
+
+
+def test_dotdot_traversal_cannot_escape_allowed_root(tmp_path) -> None:
+    allowed = tmp_path / "allowed"
+    secret = tmp_path / "secret"
+    allowed.mkdir()
+    secret.mkdir()
+
+    escape = str(allowed / ".." / "secret")
+    with pytest.raises(ValueError, match="outside the allowed"):
+        resolve_project_path(escape, [str(allowed)])
+
+
+def test_symlink_cannot_escape_allowed_root(tmp_path) -> None:
+    allowed = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed.mkdir()
+    outside.mkdir()
+    link = allowed / "link"
+    link.symlink_to(outside, target_is_directory=True)
+
+    # The symlink lives inside the allowed root but points outside it;
+    # resolve() follows it before the containment check, so it's rejected.
+    with pytest.raises(ValueError, match="outside the allowed"):
+        resolve_project_path(str(link), [str(allowed)])
+
+
+def test_notes_service_enforces_allowlist(tmp_path) -> None:
+    allowed = tmp_path / "allowed"
+    other = tmp_path / "other"
+    allowed.mkdir()
+    other.mkdir()
+    service = NotesService(allowed_dirs=lambda: [str(allowed)])
+
+    # in-allowlist project saves/loads fine
+    service.save_workspace(str(allowed), {"version": 1})
+    assert service.load_workspace(str(allowed)) == {"version": 1}
+
+    # out-of-allowlist project is blocked before touching disk
+    with pytest.raises(ValueError, match="outside the allowed"):
+        service.workspace_path(str(other))

--- a/tests/test_operator_api_runtime.py
+++ b/tests/test_operator_api_runtime.py
@@ -27,6 +27,7 @@ def test_runtime_status_redacts_secret_values() -> None:
         setup_complete=True,
         graph_loaded=True,
         project_path="/tmp/protoagent",
+        allowed_dirs=["/tmp/protoagent", "/home/kj/projects/foo"],
         knowledge_store=_Store(),
         scheduler=_Scheduler(),
         cache_warmer=object(),
@@ -37,6 +38,7 @@ def test_runtime_status_redacts_secret_values() -> None:
     assert status["model"]["api_key_configured"] is True
     assert status["model"]["api_base"] == "https://api.proto-labs.ai/v1"
     assert status["project"]["path"] == "/tmp/protoagent"
+    assert status["project"]["allowed_dirs"] == ["/tmp/protoagent", "/home/kj/projects/foo"]
     assert status["knowledge"]["resolved_path"] == "/tmp/protoagent/knowledge.db"
     assert status["scheduler"]["backend"] == "local"
     assert "sk-secret" not in repr(status)
@@ -53,6 +55,7 @@ def test_runtime_status_handles_missing_config() -> None:
     assert status["graph_loaded"] is False
     assert status["model"] is None
     assert status["knowledge"]["enabled"] is False
+    assert status["project"]["allowed_dirs"] == []
 
 
 def test_list_subagents_uses_registry_and_config_override() -> None:


### PR DESCRIPTION
## Summary

Follow-up hardening to the React/Tauri operator console (#237). The beads and notes APIs accept a `project_path` from the (free-text) UI and use it as a subprocess `cwd` / file path. This adds a **server-side allowlist** so the server — not the client — decides which directories are operable, closing the arbitrary-path observation from the #237 review.

## What changed

- **`operator_api/paths.resolve_project_path`** now enforces containment in an allowlist when one is provided. It resolves symlinks and `..` *before* the containment check, so neither can escape an allowed root. `None` stays permissive (non-operator callers/tests); an empty list denies all.
- **`BeadsService` / `NotesService`** take a live `allowed_dirs` accessor, threaded through `register_operator_routes` from `server.py`. The protoAgent repo root is **always** allowed (the default project); `config.operator_allowed_dirs` adds more, read live so a settings reload takes effect without a restart.
- **New config field `operator.allowed_dirs`** — wired through `LangGraphConfig.from_yaml`, `config_to_dict`, and `validate_config_dict`. Editable in-app from the setup wizard's **Workspace** step (textarea, one path per line).
- **Runtime status** exposes `project.allowed_dirs`, which feeds the project-path picker's `<datalist>` suggestions. This is UX only — the server still enforces.
- Documented in `config/langgraph-config.yaml` and `docs/guides/react-tauri-ui.md`.

## Validation

- `.venv-test/bin/python -m pytest -q` → **596 passed** (581 + 15 new)
- `npm run web:build` (tsc typecheck + vite build) → clean
- New tests: path containment (inside / outside / empty / `..` traversal / symlink escape), service-level enforcement, config YAML round-trip, validation, and runtime-status surfacing.

## Notes

- Default behavior is secure: out of the box only the protoAgent repo root is operable; operators opt other directories in.
- Sidecar bundling for packaged desktop mode remains deferred (as in #237).

🤖 Generated with [Claude Code](https://claude.com/claude-code)