### PR TITLE
Install br in the image; auto-allow the wizard's project path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,30 @@ RUN mkdir -p -m 755 /etc/apt/keyrings \
     && apt-get install -y --no-install-recommends gh \
     && rm -rf /var/lib/apt/lists/*
 
+# beads_rust (`br`) — the agent-first issue tracker the operator console's
+# beads panel and the setup wizard's "Initialize beads" shell out to. It must
+# be present in the image so beads init genuinely works rather than failing at
+# runtime. We pull a pinned, checksum-verified prebuilt binary instead of
+# installing the Rust toolchain, keeping the slim base small. dpkg's amd64 /
+# arm64 map straight onto the release asset arch names; bump BEADS_VERSION to
+# upgrade. Source: https://github.com/Dicklesworthstone/beads_rust
+ARG BEADS_VERSION=v0.1.23
+RUN set -eux; \
+    arch="$(dpkg --print-architecture)"; \
+    case "$arch" in \
+      amd64|arm64) ;; \
+      *) echo "unsupported arch for br: $arch" >&2; exit 1 ;; \
+    esac; \
+    asset="br-${BEADS_VERSION}-linux_${arch}.tar.gz"; \
+    base="https://github.com/Dicklesworthstone/beads_rust/releases/download/${BEADS_VERSION}"; \
+    curl -fsSL -o "/tmp/${asset}" "${base}/${asset}"; \
+    curl -fsSL -o "/tmp/${asset}.sha256" "${base}/${asset}.sha256"; \
+    (cd /tmp && sha256sum -c "${asset}.sha256"); \
+    tar -xzf "/tmp/${asset}" -C /usr/local/bin br; \
+    chmod +x /usr/local/bin/br; \
+    rm -f "/tmp/${asset}" "/tmp/${asset}.sha256"; \
+    br --version
+
 # Non-root sandbox user
 ARG SANDBOX_UID=1001
 RUN useradd -m -s /bin/bash -u ${SANDBOX_UID} sandbox

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -205,6 +205,18 @@ export function SetupWizard({
       if (state.apiKey.trim()) {
         model.api_key = state.apiKey.trim();
       }
+      // The project you're setting up should be operable, so fold its path
+      // into the allowlist automatically — otherwise picking a project path
+      // outside the (empty) allowlist silently makes beads/notes unusable
+      // for it. Extra dirs from the textarea are merged and de-duped.
+      const allowedDirs = Array.from(
+        new Set(
+          [
+            ...state.allowedDirs.split("\n").map((dir) => dir.trim()),
+            projectPath.trim(),
+          ].filter(Boolean),
+        ),
+      );
       const response = await api.finishSetup(
         {
           model,
@@ -226,10 +238,7 @@ export function SetupWizard({
             top_k: Number(state.knowledgeTopK),
           },
           operator: {
-            allowed_dirs: state.allowedDirs
-              .split("\n")
-              .map((dir) => dir.trim())
-              .filter(Boolean),
+            allowed_dirs: allowedDirs,
           },
         },
         state.soul,
@@ -238,6 +247,9 @@ export function SetupWizard({
         setError(response.message);
         return;
       }
+      // `br` ships in the container, so init is expected to succeed — surface
+      // a failure rather than swallowing it. The allowlist no longer blocks it
+      // (the project path is folded into allowed_dirs above).
       if (state.initBeads && projectPath.trim()) {
         await api.initBeads(projectPath);
       }
@@ -413,6 +425,7 @@ export function SetupWizard({
                 />
                 <span className="field-hint">
                   Beads and notes may only read/write inside these directories. One per line.
+                  The protoAgent directory and the project path above are always allowed.
                 </span>
               </label>
               <label className="checkbox-field setup-checkbox">


### PR DESCRIPTION
## Summary

Two fixes to the operator console's beads/notes sandbox, both surfaced while testing the directory allowlist (#238):

1. **`br` (beads_rust) now ships in the container.** The beads panel and the setup wizard's *Initialize beads* shell out to `br`; if it isn't on `PATH`, init fails at runtime. The Dockerfile now installs a **pinned, checksum-verified prebuilt binary** (`v0.1.23`, glibc, `amd64`/`arm64` via `dpkg --print-architecture`) — no Rust toolchain, so the slim base stays small. Beads init is therefore a real, reliable operation, not best-effort.

2. **The wizard auto-allows the project path you pick.** Previously you could set a *Project path* outside the (empty) allowlist and *Initialize beads* would be rejected with a confusing "outside the allowed directories" error — and that failure aborted the whole finish even though config had saved. Now the chosen project path is folded into `operator.allowed_dirs` on finish (merged + de-duped with the extra-dirs textarea), so the project you're setting up is always operable. Beads init stays a hard, surfaced failure rather than being swallowed.

## Why not make beads-init best-effort?

An earlier pass made init best-effort to tolerate a missing `br`. That hides a real deployment gap. The correct fix is to guarantee `br` is present (fix #1) and remove the allowlist footgun (fix #2), so init is *expected* to succeed and a failure is worth showing.

## Validation

- `npm run web:build` (tsc typecheck + vite) — clean.
- Both release assets `br-v0.1.23-linux_{amd64,arm64}.tar.gz` download, pass `sha256sum -c`, and contain the `br` binary (verified against the GitHub release).
- Local run: with the project path added to the allowlist, `GET /api/beads/status?project_path=…` returns `200`; out-of-allowlist paths still `400`.
- Full Docker image build not run here (no daemon available in this environment); the `br` layer's download + checksum + extract steps were validated standalone for both arches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)