### PR TITLE
Keep secrets out of the tracked config YAML

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -31,6 +31,7 @@ README.md
 venv/
 .env
 .env.*
+config/secrets.yaml
 
 # Tests — not needed at runtime; image stays lean
 tests/

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,10 @@ __pycache__/
 .venv-*/
 venv/
 
+# Secrets overlay — the wizard/drawer write the model API key + A2A bearer
+# here instead of the tracked config YAML. Never commit it.
+config/secrets.yaml
+
 # Local-run artifacts — autostart stdout/stderr logs + memory middleware
 # fallback directory when /sandbox is not available.
 logs/

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -44,7 +44,7 @@ knowledge:
 | `provider` | `openai` | LangChain LLM provider. The template's `graph/llm.py` only uses `openai` (via LiteLLM gateway). |
 | `name` | `protolabs/agent` | Gateway alias or direct model name. |
 | `api_base` | `http://gateway:4000/v1` | OpenAI-compatible endpoint. |
-| `api_key` | `""` | Falls back to the `OPENAI_API_KEY` env var. |
+| `api_key` | `""` | **Secret — not stored here.** Managed in the untracked `config/secrets.yaml` (see [Secrets](#secrets)); falls back to the `OPENAI_API_KEY` env var. |
 | `temperature` | `0.2` | Sampling temperature. |
 | `max_tokens` | `32768` | Per-call output cap. 32k headroom for the Qwen models we run. |
 | `max_iterations` | `50` | Upper bound on tool-call loops per task. |
@@ -55,6 +55,20 @@ knowledge:
 | `chat_template_kwargs` | _(unset)_ | Dict passed via `extra_body` to the vLLM renderer, e.g. `{preserve_thinking: true}` to keep historical `<think>`/`<scratch_pad>` blocks across turns. |
 
 All sampling params are optional — omit to use the gateway / model-card defaults. `temperature`, `max_tokens`, `top_p`, and `presence_penalty` are standard OpenAI fields; `top_k`, `repetition_penalty`, and `chat_template_kwargs` are sent via `extra_body` for vLLM-compatible gateways.
+
+## Secrets
+
+Two fields are secrets and are **never written to the tracked config YAML**: the model `api_key` and the A2A `auth.token`. The setup wizard and settings drawer persist them to an **untracked** sibling file, `config/secrets.yaml` (gitignored, dockerignored, written `0600`):
+
+```yaml
+# config/secrets.yaml — never committed
+model:
+  api_key: sk-...
+auth:
+  token: bearer-...
+```
+
+`LangGraphConfig.from_yaml` overlays this file on top of the main config at load time. Precedence for each secret: **`secrets.yaml` → main YAML value → env var** (`OPENAI_API_KEY` / `A2A_AUTH_TOKEN`). So env-injected deployments (e.g. `infisical run`) work unchanged — just leave `secrets.yaml` absent. Every config save also strips any secret keys the main YAML might still carry, so a checkout converges to secret-free. The `/api/config` endpoint redacts both fields to `""`; runtime status reports only whether a key is set (`model.api_key_configured`), never the value.
 
 ## `subagents`
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -15,6 +15,25 @@ from pathlib import Path
 
 import yaml
 
+# Secrets (model API key, A2A bearer) live in an untracked ``secrets.yaml``
+# sibling of the main config, never in the tracked YAML. See graph/config_io
+# for the write side. ``from_yaml`` overlays them below; both still fall back
+# to env (OPENAI_API_KEY / A2A_AUTH_TOKEN) when the file is absent, so
+# infisical/env-injected deployments are unaffected.
+SECRETS_FILENAME = "secrets.yaml"
+
+
+def _load_secrets_doc(config_dir: Path) -> dict:
+    """Load the untracked secrets overlay sitting next to the config YAML."""
+    secrets_path = config_dir / SECRETS_FILENAME
+    if not secrets_path.exists():
+        return {}
+    try:
+        with open(secrets_path) as f:
+            return yaml.safe_load(f) or {}
+    except (OSError, yaml.YAMLError):
+        return {}
+
 
 @dataclass
 class SubagentDef:
@@ -195,6 +214,8 @@ class LangGraphConfig:
         with open(p) as f:
             data = yaml.safe_load(f) or {}
 
+        secrets = _load_secrets_doc(p.parent)
+
         model = data.get("model", {})
         subagents = data.get("subagents", {})
         middleware = data.get("middleware", {})
@@ -204,11 +225,17 @@ class LangGraphConfig:
         runtime = data.get("runtime", {})
         operator = data.get("operator", {})
 
+        # Secret overlay wins when present; otherwise the (now secret-free)
+        # main YAML value, otherwise the dataclass default — and a blank
+        # value still lets create_llm / set_a2a_token fall back to env.
+        secret_api_key = secrets.get("model", {}).get("api_key")
+        secret_auth_token = secrets.get("auth", {}).get("token")
+
         config = cls(
             model_provider=model.get("provider", cls.model_provider),
             model_name=model.get("name", cls.model_name),
             api_base=model.get("api_base", cls.api_base),
-            api_key=model.get("api_key", cls.api_key),
+            api_key=secret_api_key or model.get("api_key", cls.api_key),
             temperature=model.get("temperature", cls.temperature),
             max_tokens=model.get("max_tokens", cls.max_tokens),
             max_iterations=model.get("max_iterations", cls.max_iterations),
@@ -256,7 +283,7 @@ class LangGraphConfig:
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
             identity_name=identity.get("name", cls.identity_name),
             identity_operator=identity.get("operator", cls.identity_operator),
-            auth_token=auth.get("token", cls.auth_token),
+            auth_token=secret_auth_token or auth.get("token", cls.auth_token),
             autostart_on_boot=runtime.get("autostart_on_boot", cls.autostart_on_boot),
             operator_allowed_dirs=list(operator.get("allowed_dirs", []) or []),
         )

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -40,6 +40,19 @@ CONFIG_YAML_PATH = REPO_ROOT / "config" / "langgraph-config.yaml"
 SOUL_SOURCE_PATH = REPO_ROOT / "config" / "SOUL.md"
 SOUL_RUNTIME_PATH = Path("/sandbox/SOUL.md")
 
+# Secrets overlay. The setup wizard / drawer collect a model API key and an
+# A2A bearer token; persisting those into the tracked config YAML means every
+# configured checkout carries credentials in git. Instead they live in this
+# untracked sibling file (gitignored + dockerignored), read back by
+# ``LangGraphConfig.from_yaml`` and stripped from the main YAML on every save.
+SECRETS_YAML_PATH = CONFIG_YAML_PATH.parent / "secrets.yaml"
+
+# (section, key) pairs that must never be written to the tracked YAML.
+SECRET_PATHS: tuple[tuple[str, str], ...] = (
+    ("model", "api_key"),
+    ("auth", "token"),
+)
+
 # Setup wizard state.
 # Presence of this (empty) marker file = wizard has been run and the
 # server should boot straight into the chat UI. Absence = show the
@@ -111,13 +124,19 @@ def save_yaml_doc(doc: Any, path: Path = CONFIG_YAML_PATH) -> None:
 def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
     """Serialize a LangGraphConfig into the nested dict shape the UI
     works with. Mirrors the YAML schema so round-tripping is trivial.
+
+    Secret fields (model API key, A2A bearer) are redacted to ``""`` — the
+    UI never needs the value back, only whether one is set (runtime status
+    carries that as a boolean). Combined with the blank-means-unchanged save
+    semantics in ``split_secret_updates``, a save that echoes the blank back
+    leaves the stored secret intact.
     """
     return {
         "model": {
             "provider": config.model_provider,
             "name": config.model_name,
             "api_base": config.api_base,
-            "api_key": config.api_key,
+            "api_key": "",
             "temperature": config.temperature,
             "max_tokens": config.max_tokens,
             "max_iterations": config.max_iterations,
@@ -145,7 +164,7 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
             "operator": config.identity_operator,
         },
         "auth": {
-            "token": config.auth_token,
+            "token": "",
         },
         "runtime": {
             "autostart_on_boot": config.autostart_on_boot,
@@ -179,6 +198,98 @@ def apply_updates_to_yaml(doc: Any, updates: dict[str, Any]) -> Any:
             else:
                 doc[section][key] = val
     return doc
+
+
+# ---------------------------------------------------------------------------
+# Secrets overlay
+# ---------------------------------------------------------------------------
+
+
+def split_secret_updates(config: dict[str, Any]) -> tuple[dict[str, Any], dict[str, Any]]:
+    """Split a UI config dict into (non-secret, secret) halves.
+
+    Secret fields (``SECRET_PATHS``) are pulled out of the returned
+    non-secret dict so they never reach the tracked YAML. Only *non-blank*
+    secret values are routed to the secret half — a blank value means "leave
+    the stored secret unchanged" (the UI sends blank when the user didn't
+    re-enter a key), so it's dropped entirely rather than clobbering.
+    """
+    import copy
+
+    main = copy.deepcopy(config)
+    secrets: dict[str, Any] = {}
+    for section, key in SECRET_PATHS:
+        sect = main.get(section)
+        if not isinstance(sect, dict) or key not in sect:
+            continue
+        value = sect.pop(key)
+        if isinstance(value, str) and value.strip():
+            secrets.setdefault(section, {})[key] = value.strip()
+        # Drop the section entirely if popping the secret emptied it, so we
+        # don't write an empty `auth: {}` block to the main YAML.
+        if not sect:
+            main.pop(section, None)
+    return main, secrets
+
+
+def strip_secrets_from_doc(doc: Any) -> Any:
+    """Remove any secret keys already present in the main YAML document.
+
+    Belt-and-suspenders alongside ``split_secret_updates``: even if an older
+    YAML still carries an ``api_key`` (or a hand-edit reintroduces one), every
+    save scrubs it so the tracked file converges to secret-free.
+    """
+    for section, key in SECRET_PATHS:
+        sect = doc.get(section) if hasattr(doc, "get") else None
+        if isinstance(sect, dict) and key in sect:
+            del sect[key]
+        if isinstance(sect, dict) and not sect:
+            try:
+                del doc[section]
+            except (KeyError, TypeError):
+                pass
+    return doc
+
+
+def load_secrets() -> dict[str, Any]:
+    """Load the untracked secrets overlay (empty dict if absent/unreadable)."""
+    if not SECRETS_YAML_PATH.exists():
+        return {}
+    import yaml as _yaml
+
+    try:
+        with open(SECRETS_YAML_PATH) as f:
+            data = _yaml.safe_load(f) or {}
+        return data if isinstance(data, dict) else {}
+    except (OSError, _yaml.YAMLError):
+        return {}
+
+
+def save_secrets(secret_updates: dict[str, Any]) -> None:
+    """Merge non-blank secret updates into the untracked secrets file.
+
+    Written with mode 0600 (owner-only). Merges rather than overwrites so a
+    save that only changes the API key doesn't drop a stored bearer token.
+    """
+    if not secret_updates:
+        return
+    import os
+    import yaml as _yaml
+
+    current = load_secrets()
+    for section, values in secret_updates.items():
+        if not isinstance(values, dict):
+            continue
+        dest = current.setdefault(section, {})
+        for key, val in values.items():
+            dest[key] = val
+
+    SECRETS_YAML_PATH.parent.mkdir(parents=True, exist_ok=True)
+    tmp = SECRETS_YAML_PATH.with_suffix(".yaml.tmp")
+    with open(tmp, "w") as f:
+        _yaml.safe_dump(current, f, sort_keys=False, default_flow_style=False)
+    os.chmod(tmp, 0o600)
+    os.replace(tmp, SECRETS_YAML_PATH)
 
 
 def validate_config_dict(updates: dict[str, Any]) -> tuple[bool, str]:

--- a/server.py
+++ b/server.py
@@ -438,7 +438,10 @@ def _apply_settings_changes(
     from graph.config_io import (
         apply_updates_to_yaml,
         load_yaml_doc,
+        save_secrets,
         save_yaml_doc,
+        split_secret_updates,
+        strip_secrets_from_doc,
         validate_config_dict,
         write_soul,
     )
@@ -450,8 +453,11 @@ def _apply_settings_changes(
         if not ok:
             return False, [f"validation: {err}"]
         try:
+            main_config, secret_updates = split_secret_updates(config)
+            save_secrets(secret_updates)
             doc = load_yaml_doc()
-            apply_updates_to_yaml(doc, config)
+            apply_updates_to_yaml(doc, main_config)
+            strip_secrets_from_doc(doc)
             save_yaml_doc(doc)
             messages.append("config saved")
         except Exception as e:
@@ -531,21 +537,27 @@ def _build_settings_callbacks() -> dict[str, Any]:
         from graph.config_io import (
             apply_updates_to_yaml,
             load_yaml_doc,
+            save_secrets,
             save_yaml_doc,
+            split_secret_updates,
+            strip_secrets_from_doc,
             validate_config_dict,
             write_soul,
         )
 
         messages: list[str] = []
 
-        # 1. Persist
+        # 1. Persist (secrets to the untracked overlay, never the tracked YAML)
         if config is not None:
             ok, err = validate_config_dict(config)
             if not ok:
                 return False, f"validation: {err}"
             try:
+                main_config, secret_updates = split_secret_updates(config)
+                save_secrets(secret_updates)
                 doc = load_yaml_doc()
-                apply_updates_to_yaml(doc, config)
+                apply_updates_to_yaml(doc, main_config)
+                strip_secrets_from_doc(doc)
                 save_yaml_doc(doc)
                 messages.append("config saved")
             except Exception as e:

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -134,11 +134,13 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature
+    # Secrets are redacted out of the UI-facing dict.
+    assert d["model"]["api_key"] == ""
+    assert d["auth"]["token"] == ""
     assert d["subagents"]["researcher"]["tools"] == list(cfg.researcher.tools)
     assert d["middleware"]["audit"] == cfg.audit_middleware
     assert d["knowledge"]["top_k"] == cfg.knowledge_top_k
     assert d["identity"]["name"] == cfg.identity_name
-    assert d["auth"]["token"] == cfg.auth_token
     assert d["runtime"]["autostart_on_boot"] == cfg.autostart_on_boot
     assert d["operator"]["allowed_dirs"] == list(cfg.operator_allowed_dirs)
 

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -1,0 +1,103 @@
+"""Secrets overlay — model API key + A2A bearer must never land in the
+tracked config YAML.
+
+Invariants:
+- ``split_secret_updates`` pulls secret fields out of the main config and
+  keeps only non-blank values on the secret side (blank = leave unchanged).
+- ``strip_secrets_from_doc`` scrubs secrets an older YAML still carries.
+- ``save_secrets`` merges (doesn't clobber siblings) and writes 0600.
+- ``LangGraphConfig.from_yaml`` overlays the secrets file, and a blank
+  overlay still leaves the env fallback intact.
+"""
+
+from __future__ import annotations
+
+import os
+import stat
+from pathlib import Path
+
+
+def test_split_extracts_secrets_and_drops_blanks() -> None:
+    from graph.config_io import split_secret_updates
+
+    main, secrets = split_secret_updates(
+        {
+            "model": {"name": "m", "api_base": "http://x", "api_key": "sk-live"},
+            "auth": {"token": ""},  # blank → leave unchanged
+            "identity": {"name": "a"},
+        }
+    )
+
+    # secret pulled out of main, non-secret model fields preserved
+    assert "api_key" not in main["model"]
+    assert main["model"] == {"name": "m", "api_base": "http://x"}
+    assert main["identity"] == {"name": "a"}
+    # blank auth.token dropped entirely (no empty section left behind)
+    assert "auth" not in main
+    assert secrets == {"model": {"api_key": "sk-live"}}
+
+
+def test_split_does_not_mutate_input() -> None:
+    from graph.config_io import split_secret_updates
+
+    original = {"model": {"api_key": "sk-x", "name": "m"}}
+    split_secret_updates(original)
+    assert original["model"]["api_key"] == "sk-x"  # deep-copied, untouched
+
+
+def test_strip_secrets_from_doc_scrubs_existing_key() -> None:
+    from graph.config_io import strip_secrets_from_doc
+
+    doc = {"model": {"name": "m", "api_key": "sk-leftover"}, "auth": {"token": "t"}}
+    strip_secrets_from_doc(doc)
+    assert doc["model"] == {"name": "m"}
+    assert "auth" not in doc  # emptied section removed
+
+
+def test_save_and_load_secrets_round_trip(monkeypatch, tmp_path: Path) -> None:
+    from graph import config_io
+
+    secrets_path = tmp_path / "secrets.yaml"
+    monkeypatch.setattr(config_io, "SECRETS_YAML_PATH", secrets_path)
+
+    config_io.save_secrets({"model": {"api_key": "sk-1"}})
+    config_io.save_secrets({"auth": {"token": "bearer-2"}})  # merge, don't clobber
+
+    loaded = config_io.load_secrets()
+    assert loaded == {"model": {"api_key": "sk-1"}, "auth": {"token": "bearer-2"}}
+    # owner-only perms
+    assert stat.S_IMODE(os.stat(secrets_path).st_mode) == 0o600
+
+
+def test_save_secrets_noop_on_empty(monkeypatch, tmp_path: Path) -> None:
+    from graph import config_io
+
+    secrets_path = tmp_path / "secrets.yaml"
+    monkeypatch.setattr(config_io, "SECRETS_YAML_PATH", secrets_path)
+    config_io.save_secrets({})
+    assert not secrets_path.exists()
+
+
+def test_from_yaml_overlays_secrets_file(tmp_path: Path) -> None:
+    from graph.config import LangGraphConfig
+
+    (tmp_path / "langgraph-config.yaml").write_text(
+        "model:\n  name: m\n  api_key: \"\"\nauth:\n  token: \"\"\n"
+    )
+    (tmp_path / "secrets.yaml").write_text(
+        "model:\n  api_key: sk-from-overlay\nauth:\n  token: bearer-overlay\n"
+    )
+
+    cfg = LangGraphConfig.from_yaml(tmp_path / "langgraph-config.yaml")
+    assert cfg.api_key == "sk-from-overlay"
+    assert cfg.auth_token == "bearer-overlay"
+
+
+def test_from_yaml_without_secrets_leaves_blank_for_env_fallback(tmp_path: Path) -> None:
+    # No secrets.yaml and a blank YAML key → config stays "" so create_llm /
+    # set_a2a_token fall back to OPENAI_API_KEY / A2A_AUTH_TOKEN.
+    from graph.config import LangGraphConfig
+
+    (tmp_path / "langgraph-config.yaml").write_text("model:\n  name: m\n  api_key: \"\"\n")
+    cfg = LangGraphConfig.from_yaml(tmp_path / "langgraph-config.yaml")
+    assert cfg.api_key == ""


### PR DESCRIPTION
## Summary

The setup wizard and settings drawer collected a model **API key** and an **A2A bearer token** and persisted them into `config/langgraph-config.yaml` — a **tracked** file. Every configured checkout therefore carried live credentials in git, one `git add` away from leaking (exactly what happened during testing).

Secrets now live in an **untracked** `config/secrets.yaml` sibling (gitignored + dockerignored, written `0600`).

## How it works

- **Load:** `LangGraphConfig.from_yaml` overlays `secrets.yaml` on top of the main config. Precedence per secret: **`secrets.yaml` → main YAML value → env var** (`OPENAI_API_KEY` / `A2A_AUTH_TOKEN`). Env-injected deployments (`infisical run`, etc.) are unaffected — just leave the file absent.
- **Save:** `split_secret_updates` routes secret fields out of the main config; `strip_secrets_from_doc` scrubs any secret an older YAML still carries, so a checkout converges to secret-free. `save_secrets` merges (won't clobber a sibling secret) and writes owner-only.
- **Blank = unchanged:** the UI sends a blank key when the user didn't re-enter one, so blanks are dropped rather than overwriting the stored secret.
- **Read:** `config_to_dict` redacts both fields to `""`; runtime status already exposes only `model.api_key_configured` (a boolean), never the value.

## Validation

- Full suite **603 passed** (596 + 7 new in `tests/test_config_secrets.py`, plus updated `config_to_dict` redaction assertions).
- Verified end-to-end on a live server:
  - key loads from `secrets.yaml` → `api_key_configured: true`, chat works;
  - `GET /api/config` returns `model.api_key: ""` and `auth.token: ""`;
  - a config save through `/api/config` writes the key to `secrets.yaml` and leaves the tracked YAML with **no** `api_key` line;
  - chat still works after save + reload.

## Notes

- This addresses the secret footgun specifically. Non-secret live edits still land in the tracked YAML (model name, allowed dirs, etc.) — annoying-if-committed but not dangerous; out of scope here.
- The shipped `config/langgraph-config.yaml` template keeps `api_key: ""` with an updated comment pointing at `secrets.yaml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)