### PR TITLE
Send chat on Cmd/Ctrl+Enter

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -274,7 +274,14 @@ function ChatSessionSlot({
         <textarea
           value={draft}
           onChange={(event) => setDraft(event.target.value)}
-          placeholder="Message protoAgent"
+          onKeyDown={(event) => {
+            // Cmd/Ctrl+Enter sends; plain Enter keeps inserting newlines.
+            if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+              event.preventDefault();
+              void send();
+            }
+          }}
+          placeholder="Message protoAgent  (⌘/Ctrl+Enter to send)"
           rows={3}
         />
         {status === "streaming" ? (


### PR DESCRIPTION
## Summary

The chat composer only sent via the **Send** button — a plain Enter in the `<textarea>` just inserts a newline, so there was no keyboard send at all.

Adds a `keydown` handler that fires `send()` on **⌘+Enter (mac) / Ctrl+Enter**, preventing the newline. Plain Enter still inserts newlines for multi-line prompts. `send()` already guards on `canSend` (non-empty draft, not mid-stream), so the shortcut is a no-op when there's nothing to send. The placeholder now hints the shortcut.

## Validation

- `npm run web:build` (tsc typecheck + vite) — clean.
- Verified on the running server: ⌘/Ctrl+Enter sends; plain Enter adds a newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)