### PR TITLE
Bundle the protoAgent server as a Tauri sidecar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,3 +54,8 @@ docs/.vitepress/cache/
 .automaker/knowledge.db
 .automaker/knowledge.db-*
 .beads/last-touched
+
+# Built Tauri sidecar binaries (produced by apps/desktop/sidecar/build_sidecar.py)
+apps/desktop/src-tauri/binaries/
+# PyInstaller sidecar build workdir
+/build/sidecar/

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -5,17 +5,31 @@ Tauri v2 wrapper for the React operator console.
 ## Commands
 
 ```bash
-npm run desktop:dev
+# 1. Freeze the headless server into the bundled sidecar (per platform).
+#    Needs a venv with the runtime deps + PyInstaller:
+#      pip install -r requirements.txt pyinstaller
+npm run desktop:sidecar
+
+# 2. Build the React app + native bundle (expects the sidecar from step 1).
 npm run desktop:build
+
+# Dev (also needs the sidecar binary present from step 1):
+npm run desktop:dev
 ```
 
 `desktop:build` builds the React app with relative asset paths, then produces the native bundle under `apps/desktop/src-tauri/target/release/bundle/`.
 
 ## Runtime Model
 
-This wrapper is in connect-to-local-server mode. The packaged UI expects a protoAgent server at `http://127.0.0.1:7870` and calls its `/api`, `/a2a`, and `/v1` routes from the desktop webview. Sidecar bundling can replace that requirement later.
+The app **bundles and launches the protoAgent server itself** as a Tauri sidecar — no separately-running server required.
 
-To point the desktop UI at a different server, set `protoagent.apiBase` in localStorage to the desired base URL.
+- `apps/desktop/sidecar/build_sidecar.py` freezes the server (`server.py --headless`) into a single binary via PyInstaller, named `binaries/protoagent-server-<target-triple>` (the `externalBin` Tauri bundles). Gradio is excluded — the React console is the UI — so the binary is ~55 MB rather than carrying the full UI stack.
+- On launch the Rust shell (`src-tauri/src/lib.rs`) spawns the sidecar with `--headless --port 7870`, sets `PROTOAGENT_CONFIG_DIR` to the per-user app-config dir (so the read-only binary still persists setup/secrets), drains its output to the log, and kills it on app exit.
+- The webview loads the bundled React build and calls the sidecar's `/api`, `/a2a`, and `/v1` on `127.0.0.1:7870`. The console probes with backoff on startup so the few-second cold start doesn't surface as an error.
+
+The sidecar binary is gitignored — it's a build artifact produced per platform by step 1 (locally or in CI before `tauri build`).
+
+To point the desktop UI at a *different* server instead of the bundled one, set `protoagent.apiBase` in localStorage to the desired base URL.
 
 ## Desktop Behavior
 

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -1,0 +1,109 @@
+#!/usr/bin/env python3
+"""Freeze the headless protoAgent server into a single-file Tauri sidecar.
+
+Produces ``apps/desktop/src-tauri/binaries/protoagent-server-<target-triple>``
+— the ``externalBin`` Tauri bundles and launches. Gradio is excluded (the
+desktop app renders the React console itself), so the binary stays as small
+as this dependency stack allows.
+
+Run from a venv with the runtime deps + PyInstaller installed:
+
+    pip install -r requirements.txt pyinstaller
+    python apps/desktop/sidecar/build_sidecar.py
+
+The target triple matches Tauri's expectation (``rustc`` host), so the binary
+lands at the exact name Tauri looks for during ``tauri build``.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+
+REPO = Path(__file__).resolve().parents[3]
+BINARIES_DIR = REPO / "apps" / "desktop" / "src-tauri" / "binaries"
+NAME = "protoagent-server"
+
+# Read-only defaults the frozen server reads via REPO_ROOT/config (which
+# resolves to _MEIPASS/config inside the bundle). Live state (langgraph-config
+# .yaml, secrets.yaml, .setup-complete) is NOT bundled — it's written at
+# runtime to PROTOAGENT_CONFIG_DIR. Never bundle secrets.yaml or the live YAML.
+BUNDLED_DATA: list[tuple[str, str]] = [
+    ("config/langgraph-config.example.yaml", "config"),
+    ("config/SOUL.md", "config"),
+    ("config/soul-presets", "config/soul-presets"),
+    ("static", "static"),
+]
+
+# Packages PyInstaller's static analysis under-collects (dynamic imports +
+# importlib.metadata entry points). --collect-all pulls modules + data + metadata.
+COLLECT_ALL = [
+    "langchain",
+    "langchain_core",
+    "langchain_openai",
+    "langgraph",
+    "ddgs",
+    "langfuse",
+    "croniter",
+]
+
+# Gradio (and the chat_ui module that imports it) is dead weight in headless
+# mode and the worst thing to freeze — exclude it outright.
+EXCLUDE = ["gradio", "chat_ui", "tkinter"]
+
+
+def target_triple() -> str:
+    """Tauri names sidecars ``<bin>-<rustc-host-triple>``; match it."""
+    out = subprocess.run(["rustc", "-Vv"], capture_output=True, text=True, check=True).stdout
+    for line in out.splitlines():
+        if line.startswith("host:"):
+            return line.split(":", 1)[1].strip()
+    raise SystemExit("could not determine rustc host triple (is rustc installed?)")
+
+
+def main() -> None:
+    triple = target_triple()
+    work = REPO / "build" / "sidecar"
+    sep = ";" if os.name == "nt" else ":"
+
+    add_data: list[str] = []
+    for src, dest in BUNDLED_DATA:
+        if (REPO / src).exists():
+            add_data += ["--add-data", f"{REPO / src}{sep}{dest}"]
+        else:
+            print(f"warning: bundled data missing, skipping: {src}", file=sys.stderr)
+
+    collect: list[str] = []
+    for pkg in COLLECT_ALL:
+        collect += ["--collect-all", pkg]
+    exclude: list[str] = []
+    for mod in EXCLUDE:
+        exclude += ["--exclude-module", mod]
+
+    cmd = [
+        sys.executable, "-m", "PyInstaller",
+        "--onefile", "--noconfirm", "--clean",
+        "--name", NAME,
+        "--distpath", str(work / "dist"),
+        "--workpath", str(work / "build"),
+        "--specpath", str(work),
+        *exclude, *add_data, *collect,
+        str(REPO / "server.py"),
+    ]
+    print("running:", " ".join(cmd))
+    subprocess.run(cmd, check=True, cwd=str(REPO))
+
+    BINARIES_DIR.mkdir(parents=True, exist_ok=True)
+    suffix = ".exe" if os.name == "nt" else ""
+    built = work / "dist" / f"{NAME}{suffix}"
+    dest = BINARIES_DIR / f"{NAME}-{triple}{suffix}"
+    shutil.copy2(built, dest)
+    os.chmod(dest, 0o755)
+    print(f"\nsidecar -> {dest}")
+
+
+if __name__ == "__main__":
+    main()

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -813,6 +813,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
+dependencies = [
+ "cfg-if",
+]
+
+[[package]]
 name = "env_filter"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,6 +1682,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d98f6fed1fde3f8c21bc40a1abb88dd75e67924f9cffc3ef95607bad8017f8e2"
 
 [[package]]
+name = "is-docker"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "928bae27f42bc99b60d9ac7334e3a21d10ad8f1835a4e12ec3ec0464765ed1b3"
+dependencies = [
+ "once_cell",
+]
+
+[[package]]
+name = "is-wsl"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "173609498df190136aa7dea1a91db051746d339e18476eed5ca40521f02d7aa5"
+dependencies = [
+ "is-docker",
+ "once_cell",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2236,10 +2264,32 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
+name = "open"
+version = "5.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fbaa89d2ddc8473c78a3adf69eea8cffa28c483b8e02a971ef31527cd0fc92c"
+dependencies = [
+ "dunce",
+ "is-wsl",
+ "libc",
+ "pathdiff",
+]
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "os_pipe"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
+dependencies = [
+ "libc",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "pango"
@@ -2288,6 +2338,12 @@ dependencies = [
  "smallvec",
  "windows-link 0.2.1",
 ]
+
+[[package]]
+name = "pathdiff"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df94ce210e5bc13cb6651479fa48d14f601d9858cfe0467f43ae157023b938d3"
 
 [[package]]
 name = "percent-encoding"
@@ -2512,6 +2568,7 @@ dependencies = [
  "tauri-build",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
+ "tauri-plugin-shell",
 ]
 
 [[package]]
@@ -3069,10 +3126,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "shared_child"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e362d9935bc50f019969e2f9ecd66786612daae13e8f277be7bfb66e8bed3f7"
+dependencies = [
+ "libc",
+ "sigchld",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "sigchld"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47106eded3c154e70176fc83df9737335c94ce22f821c32d17ed1db1f83badb1"
+dependencies = [
+ "libc",
+ "os_pipe",
+ "signal-hook",
+]
+
+[[package]]
+name = "signal-hook"
+version = "0.3.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d881a16cf4426aa584979d30bd82cb33429027e42122b169753d6ef1085ed6e2"
+dependencies = [
+ "libc",
+ "signal-hook-registry",
+]
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+dependencies = [
+ "errno",
+ "libc",
+]
 
 [[package]]
 name = "simd-adler32"
@@ -3491,6 +3590,27 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "time",
+]
+
+[[package]]
+name = "tauri-plugin-shell"
+version = "2.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8457dbf9e2bab1edd8df22bb2c20857a59a9868e79cb3eac5ed639eec4d0c73b"
+dependencies = [
+ "encoding_rs",
+ "log",
+ "open",
+ "os_pipe",
+ "regex",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "shared_child",
+ "tauri",
+ "tauri-plugin",
+ "thiserror 2.0.18",
+ "tokio",
 ]
 
 [[package]]
@@ -4556,6 +4676,15 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
+dependencies = [
+ "windows-targets 0.53.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
@@ -4587,11 +4716,28 @@ dependencies = [
  "windows_aarch64_gnullvm 0.52.6",
  "windows_aarch64_msvc 0.52.6",
  "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm",
+ "windows_i686_gnullvm 0.52.6",
  "windows_i686_msvc 0.52.6",
  "windows_x86_64_gnu 0.52.6",
  "windows_x86_64_gnullvm 0.52.6",
  "windows_x86_64_msvc 0.52.6",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.53.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
+dependencies = [
+ "windows-link 0.2.1",
+ "windows_aarch64_gnullvm 0.53.1",
+ "windows_aarch64_msvc 0.53.1",
+ "windows_i686_gnu 0.53.1",
+ "windows_i686_gnullvm 0.53.1",
+ "windows_i686_msvc 0.53.1",
+ "windows_x86_64_gnu 0.53.1",
+ "windows_x86_64_gnullvm 0.53.1",
+ "windows_x86_64_msvc 0.53.1",
 ]
 
 [[package]]
@@ -4625,6 +4771,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+
+[[package]]
 name = "windows_aarch64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4635,6 +4787,12 @@ name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_aarch64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -4649,10 +4807,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
+name = "windows_i686_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+
+[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
+
+[[package]]
+name = "windows_i686_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -4667,6 +4837,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
+name = "windows_i686_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
 name = "windows_x86_64_gnu"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4677,6 +4853,12 @@ name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -4691,6 +4873,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
+name = "windows_x86_64_gnullvm"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
 name = "windows_x86_64_msvc"
 version = "0.42.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4701,6 +4889,12 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.53.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "winnow"

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -24,3 +24,4 @@ log = "0.4"
 tauri = { version = "2.11.2", features = ["tray-icon"] }
 tauri-plugin-global-shortcut = "2.3.2"
 tauri-plugin-log = "2"
+tauri-plugin-shell = "2"

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -6,6 +6,16 @@
     "main"
   ],
   "permissions": [
-    "core:default"
+    "core:default",
+    {
+      "identifier": "shell:allow-execute",
+      "allow": [
+        {
+          "name": "binaries/protoagent-server",
+          "sidecar": true,
+          "args": ["--headless", "--port", { "validator": "\\d+" }]
+        }
+      ]
+    }
   ]
 }

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,92 @@
+use std::sync::Mutex;
+
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    AppHandle, Manager, Runtime, WindowEvent,
+    AppHandle, Manager, RunEvent, Runtime, WindowEvent,
 };
 use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
+use tauri_plugin_shell::{
+    process::{CommandChild, CommandEvent},
+    ShellExt,
+};
+
+/// Port the bundled server binds and the React console talks to. Matches the
+/// connect-to-local-server default in `apps/web/src/lib/api.ts`.
+const SIDECAR_PORT: &str = "7870";
+
+/// Holds the running sidecar so it can be killed when the app exits.
+#[derive(Default)]
+struct SidecarProcess(Mutex<Option<CommandChild>>);
+
+/// Launch the bundled headless protoAgent server as a sidecar.
+///
+/// The frozen binary is read-only, so its writable state (live config,
+/// secrets, setup marker) is pointed at the per-user app-config dir via
+/// `PROTOAGENT_CONFIG_DIR`. Failures are logged, not fatal — the window still
+/// opens (and shows the API error) rather than the whole app refusing to boot.
+fn spawn_sidecar<R: Runtime>(app: &AppHandle<R>) {
+    let config_dir = match app.path().app_config_dir() {
+        Ok(dir) => dir,
+        Err(e) => {
+            log::error!("sidecar: cannot resolve app config dir: {e}");
+            return;
+        }
+    };
+    if let Err(e) = std::fs::create_dir_all(&config_dir) {
+        log::error!("sidecar: cannot create config dir {config_dir:?}: {e}");
+        return;
+    }
+
+    let command = match app.shell().sidecar("protoagent-server") {
+        Ok(cmd) => cmd,
+        Err(e) => {
+            log::error!("sidecar: binary not found (run apps/desktop/sidecar/build_sidecar.py): {e}");
+            return;
+        }
+    };
+    let command = command
+        .args(["--headless", "--port", SIDECAR_PORT])
+        .env("PROTOAGENT_HEADLESS", "1")
+        .env("PROTOAGENT_CONFIG_DIR", config_dir.to_string_lossy().to_string());
+
+    let (mut rx, child) = match command.spawn() {
+        Ok(pair) => pair,
+        Err(e) => {
+            log::error!("sidecar: spawn failed: {e}");
+            return;
+        }
+    };
+
+    if let Some(state) = app.try_state::<SidecarProcess>() {
+        *state.0.lock().unwrap() = Some(child);
+    }
+
+    // Drain stdout/stderr so the OS pipe buffer never fills and stalls the child.
+    tauri::async_runtime::spawn(async move {
+        while let Some(event) = rx.recv().await {
+            match event {
+                CommandEvent::Stdout(bytes) | CommandEvent::Stderr(bytes) => {
+                    log::info!("[sidecar] {}", String::from_utf8_lossy(&bytes).trim_end());
+                }
+                CommandEvent::Terminated(payload) => {
+                    log::warn!("[sidecar] terminated: {payload:?}");
+                    break;
+                }
+                _ => {}
+            }
+        }
+    });
+}
+
+/// Kill the sidecar if it's still running (called on app exit).
+fn kill_sidecar<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(state) = app.try_state::<SidecarProcess>() {
+        if let Some(child) = state.0.lock().unwrap().take() {
+            let _ = child.kill();
+        }
+    }
+}
 
 fn show_main_window<R: Runtime>(app: &AppHandle<R>) {
     if let Some(window) = app.get_webview_window("main") {
@@ -72,6 +155,7 @@ fn build_tray(app: &tauri::App) -> tauri::Result<()> {
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .plugin(tauri_plugin_shell::init())
         .plugin(
             tauri_plugin_global_shortcut::Builder::new()
                 .with_shortcut(Shortcut::new(
@@ -94,6 +178,8 @@ pub fn run() {
                         .build(),
                 )?;
             }
+            app.manage(SidecarProcess::default());
+            spawn_sidecar(app.handle());
             build_tray(app)?;
             Ok(())
         })
@@ -103,6 +189,12 @@ pub fn run() {
                 let _ = window.hide();
             }
         })
-        .run(tauri::generate_context!())
-        .expect("error while running tauri application");
+        .build(tauri::generate_context!())
+        .expect("error while building tauri application")
+        .run(|app_handle, event| {
+            // Tear the bundled server down with the app rather than orphaning it.
+            if let RunEvent::Exit = event {
+                kill_sidecar(app_handle);
+            }
+        });
 }

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -30,6 +30,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
+    "externalBin": ["binaries/protoagent-server"],
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -280,7 +280,26 @@ export function App() {
   }
 
   useEffect(() => {
-    void refreshAll();
+    let cancelled = false;
+    (async () => {
+      // The desktop app launches the server as a bundled sidecar, which can
+      // take a few seconds to boot. Probe with backoff before the first load
+      // so the startup gap doesn't surface as an error. In browser mode the
+      // server is already up, so the first probe succeeds immediately.
+      for (let attempt = 0; attempt < 30 && !cancelled; attempt += 1) {
+        try {
+          await api.runtimeStatus();
+          break;
+        } catch {
+          if (attempt === 0) setStatus("starting server…");
+          await new Promise((resolve) => window.setTimeout(resolve, 1000));
+        }
+      }
+      if (!cancelled) void refreshAll();
+    })();
+    return () => {
+      cancelled = true;
+    };
   }, []);
 
   useEffect(() => {

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -36,13 +36,44 @@ from graph.config import LangGraphConfig
 log = logging.getLogger("protoagent.config_io")
 
 REPO_ROOT = Path(__file__).parent.parent
-# Live runtime config — untracked, per-deployment. Generated from the tracked
+
+# Two config roots, normally the same directory:
+#
+# * BUNDLE  — read-only shipped defaults: the ``.example`` template, SOUL
+#   presets, the default SOUL.md. Lives next to the code (``REPO_ROOT/config``,
+#   or _MEIPASS/config inside a PyInstaller-frozen sidecar).
+# * LIVE    — writable per-deployment state: the live YAML, secrets, and the
+#   setup marker. Overridable via ``PROTOAGENT_CONFIG_DIR``.
+#
+# The desktop sidecar is a read-only frozen binary, so it points
+# ``PROTOAGENT_CONFIG_DIR`` at the per-user app-data dir — defaults are read
+# from the bundle, live state is written to app-data. Unset (local dev, the
+# Docker config volume) collapses both to ``REPO_ROOT/config`` — unchanged.
+_BUNDLE_CONFIG_DIR = REPO_ROOT / "config"
+
+
+def _live_config_dir() -> Path:
+    override = os.environ.get("PROTOAGENT_CONFIG_DIR", "").strip()
+    return Path(override).expanduser() if override else _BUNDLE_CONFIG_DIR
+
+
+_LIVE_CONFIG_DIR = _live_config_dir()
+
+# Bundled, read-only defaults.
+CONFIG_EXAMPLE_PATH = _BUNDLE_CONFIG_DIR / "langgraph-config.example.yaml"
+SOUL_SOURCE_PATH = _BUNDLE_CONFIG_DIR / "SOUL.md"
+# SOUL.md starter templates. The wizard offers these as presets the
+# user can pick then edit before saving. Adding a new file here
+# automatically makes it a choice — no registry to update.
+PRESETS_DIR = _BUNDLE_CONFIG_DIR / "soul-presets"
+
+# Writable, per-deployment state.
+#
+# Live runtime config — untracked, per-deployment. Generated from the
 # ``.example`` template on first run (see ``ensure_live_config``) and rewritten
 # by the wizard/drawer. Keeping it out of git means setup edits never dirty a
 # tracked file; the template carries the shipped defaults + comments.
-CONFIG_YAML_PATH = REPO_ROOT / "config" / "langgraph-config.yaml"
-CONFIG_EXAMPLE_PATH = REPO_ROOT / "config" / "langgraph-config.example.yaml"
-SOUL_SOURCE_PATH = REPO_ROOT / "config" / "SOUL.md"
+CONFIG_YAML_PATH = _LIVE_CONFIG_DIR / "langgraph-config.yaml"
 SOUL_RUNTIME_PATH = Path("/sandbox/SOUL.md")
 
 # Secrets overlay. The setup wizard / drawer collect a model API key and an
@@ -50,7 +81,7 @@ SOUL_RUNTIME_PATH = Path("/sandbox/SOUL.md")
 # configured checkout carries credentials in git. Instead they live in this
 # untracked sibling file (gitignored + dockerignored), read back by
 # ``LangGraphConfig.from_yaml`` and stripped from the main YAML on every save.
-SECRETS_YAML_PATH = CONFIG_YAML_PATH.parent / "secrets.yaml"
+SECRETS_YAML_PATH = _LIVE_CONFIG_DIR / "secrets.yaml"
 
 # (section, key) pairs that must never be written to the tracked YAML.
 SECRET_PATHS: tuple[tuple[str, str], ...] = (
@@ -61,14 +92,9 @@ SECRET_PATHS: tuple[tuple[str, str], ...] = (
 # Setup wizard state.
 # Presence of this (empty) marker file = wizard has been run and the
 # server should boot straight into the chat UI. Absence = show the
-# wizard on first page load. Lives in ``config/`` so a Docker volume
-# mount at /opt/<agent>/config persists setup across container runs.
-SETUP_MARKER_PATH = REPO_ROOT / "config" / ".setup-complete"
-
-# SOUL.md starter templates. The wizard offers these as presets the
-# user can pick then edit before saving. Adding a new file here
-# automatically makes it a choice — no registry to update.
-PRESETS_DIR = REPO_ROOT / "config" / "soul-presets"
+# wizard on first page load. Lives in the live config dir so a Docker volume
+# mount (or the desktop app-data dir) persists setup across runs.
+SETUP_MARKER_PATH = _LIVE_CONFIG_DIR / ".setup-complete"
 
 
 # ---------------------------------------------------------------------------

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "web:dev": "npm --workspace @protoagent/web run dev",
     "web:build": "npm --workspace @protoagent/web run build",
     "web:preview": "npm --workspace @protoagent/web run preview",
+    "desktop:sidecar": "python apps/desktop/sidecar/build_sidecar.py",
     "desktop:dev": "npm --workspace @protoagent/desktop run dev",
     "desktop:build": "npm --workspace @protoagent/desktop run build"
   },

--- a/server.py
+++ b/server.py
@@ -1120,8 +1120,17 @@ def _main():
     parser = argparse.ArgumentParser(description=f"{AGENT_NAME_ENV} — protoAgent server")
     parser.add_argument("--port", type=int, default=7870)
     parser.add_argument("--config", type=str, default=None)
+    parser.add_argument(
+        "--headless",
+        action="store_true",
+        default=os.environ.get("PROTOAGENT_HEADLESS", "").lower() in ("1", "true", "yes"),
+        help="Serve only the API / A2A / React console — skip the Gradio UI. "
+             "Used by the desktop sidecar (the React console is the UI there, "
+             "and Gradio is the heaviest dependency to freeze).",
+    )
     args = parser.parse_args()
     _active_port = args.port
+    headless = args.headless
 
     # Initialize observability
     import tracing
@@ -1131,18 +1140,21 @@ def _main():
 
     _init_langgraph_agent()
 
-    # Optional Gradio chat UI — comment out if your agent is headless.
-    from chat_ui import create_chat_app
-    blocks = create_chat_app(
-        chat_fn=chat,
-        title=agent_name(),
-        subtitle="protoAgent",
-        placeholder="Send a message...",
-        pwa=True,
-        settings=_build_settings_callbacks(),
-    )
+    # Optional Gradio chat UI — skipped entirely in headless mode so the
+    # frozen sidecar never imports Gradio (its biggest, PyInstaller-hostile
+    # dependency). The React console is the UI in that mode.
+    blocks = None
+    if not headless:
+        from chat_ui import create_chat_app
+        blocks = create_chat_app(
+            chat_fn=chat,
+            title=agent_name(),
+            subtitle="protoAgent",
+            placeholder="Send a message...",
+            pwa=True,
+            settings=_build_settings_callbacks(),
+        )
 
-    import gradio as gr
     import uvicorn
     from fastapi import FastAPI, Request
     from fastapi.middleware.cors import CORSMiddleware
@@ -1495,14 +1507,20 @@ def _main():
 
         fastapi_app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
-    # --- Mount Gradio at root -----------------------------------------------
-    app = gr.mount_gradio_app(
-        fastapi_app, blocks, path="/",
-        footer_links=[],
-        favicon_path=str(static_dir / "favicon.svg") if (static_dir / "favicon.svg").exists() else None,
-    )
+    # --- Mount Gradio at root (skipped when headless) -----------------------
+    if headless:
+        app = fastapi_app
+        log.info("Starting %s (headless — no Gradio) on http://0.0.0.0:%d", agent_name(), args.port)
+    else:
+        import gradio as gr
 
-    log.info("Starting %s on http://0.0.0.0:%d", agent_name(), args.port)
+        app = gr.mount_gradio_app(
+            fastapi_app, blocks, path="/",
+            footer_links=[],
+            favicon_path=str(static_dir / "favicon.svg") if (static_dir / "favicon.svg").exists() else None,
+        )
+        log.info("Starting %s on http://0.0.0.0:%d", agent_name(), args.port)
+
     uvicorn.run(app, host="0.0.0.0", port=args.port)
 
 

--- a/server.py
+++ b/server.py
@@ -91,13 +91,14 @@ def _init_langgraph_agent():
     global _graph, _graph_config, _checkpointer, _knowledge_store
 
     from graph.config import LangGraphConfig
-    from graph.config_io import ensure_live_config, is_setup_complete
+    from graph.config_io import CONFIG_YAML_PATH, ensure_live_config, is_setup_complete
     from langgraph.checkpoint.memory import MemorySaver
 
     # Seed the untracked live config from the .example template on first run.
+    # CONFIG_YAML_PATH honors PROTOAGENT_CONFIG_DIR (the desktop sidecar points
+    # it at per-user app-data), so load through it rather than a fixed path.
     ensure_live_config()
-    config_path = Path(__file__).parent / "config" / "langgraph-config.yaml"
-    _graph_config = LangGraphConfig.from_yaml(config_path)
+    _graph_config = LangGraphConfig.from_yaml(CONFIG_YAML_PATH)
     _checkpointer = MemorySaver()
 
     if not is_setup_complete():
@@ -305,12 +306,11 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
 
     from graph.agent import create_agent_graph
     from graph.config import LangGraphConfig
-    from graph.config_io import ensure_live_config, is_setup_complete
+    from graph.config_io import CONFIG_YAML_PATH, ensure_live_config, is_setup_complete
 
     ensure_live_config()
-    config_path = Path(__file__).parent / "config" / "langgraph-config.yaml"
     try:
-        new_config = LangGraphConfig.from_yaml(config_path)
+        new_config = LangGraphConfig.from_yaml(CONFIG_YAML_PATH)
     except Exception as e:
         log.exception("[reload] config load failed")
         return False, f"config load failed: {e}"

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -93,6 +93,18 @@ def test_from_yaml_overlays_secrets_file(tmp_path: Path) -> None:
     assert cfg.auth_token == "bearer-overlay"
 
 
+def test_live_config_dir_honors_env_override(monkeypatch, tmp_path: Path) -> None:
+    # The desktop sidecar points PROTOAGENT_CONFIG_DIR at a writable app-data
+    # dir so a read-only frozen binary can still persist setup.
+    from graph import config_io
+
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path / "appdata"))
+    assert config_io._live_config_dir() == tmp_path / "appdata"
+
+    monkeypatch.delenv("PROTOAGENT_CONFIG_DIR", raising=False)
+    assert config_io._live_config_dir() == config_io._BUNDLE_CONFIG_DIR
+
+
 def test_from_yaml_without_secrets_leaves_blank_for_env_fallback(tmp_path: Path) -> None:
     # No secrets.yaml and a blank YAML key → config stays "" so create_llm /
     # set_a2a_token fall back to OPENAI_API_KEY / A2A_AUTH_TOKEN.


### PR DESCRIPTION
## Summary

Closes the deferred desktop item from #237: the packaged app launched no server and expected one already running on `127.0.0.1:7870`. It now **bundles and launches the server itself** as a Tauri sidecar.

Built in three layers (one commit each), each validated independently:

### 1. Headless server mode (`server.py --headless`)
Gates the Gradio chat UI behind `--headless` (also `PROTOAGENT_HEADLESS`). In headless mode the server never imports `chat_ui`/`gradio` and runs uvicorn on the bare FastAPI app — just `/api`, `/a2a`, `/v1`, the React console, and static. Gradio is the heaviest, most PyInstaller-hostile dependency and is dead weight in desktop mode (the React console is the UI), so excluding it shrinks and de-risks the freeze.

### 2. Relocatable config (`PROTOAGENT_CONFIG_DIR`)
A frozen one-file binary reads bundled files from a read-only temp dir, but the server writes live config/secrets/marker. Split the roots: **bundle** (read-only defaults — `.example`, SOUL presets) vs **live** (writable state, overridable via `PROTOAGENT_CONFIG_DIR`). Unset = today's behavior (collapses to `REPO_ROOT/config`); the sidecar points it at the per-user app-config dir.

### 3. Tauri sidecar
- `apps/desktop/sidecar/build_sidecar.py` freezes the headless server via PyInstaller → `binaries/protoagent-server-<rustc-triple>` (the `externalBin`). **~55 MB** (vs. 334 MB of site-packages) thanks to the Gradio exclusion. Bundles read-only defaults; never bundles `secrets.yaml`/live YAML.
- `tauri.conf.json` declares the `externalBin`; the shell-plugin capability scopes its args (`--headless --port <n>`).
- `lib.rs` spawns the sidecar on setup with `PROTOAGENT_HEADLESS=1` + `PROTOAGENT_CONFIG_DIR=<app-config-dir>`, drains its output to the log, and kills it on `RunEvent::Exit`.
- The React console probes runtime status with backoff on startup so the sidecar's few-second cold start isn't shown as an error.
- `npm run desktop:sidecar` builds the binary; the binary is **gitignored** (per-platform build artifact, produced before `tauri build` locally or in CI).

## Validation

- **Frozen binary**: boots against a temp `PROTOAGENT_CONFIG_DIR` and serves `/api/runtime/status`, `/api/subagents`, and `setup-status` (bundled presets) — all 200, no startup errors. Seeds the live config into the override dir; repo `config/` untouched.
- **`cargo check`** passes with the sidecar spawn/kill + shell plugin.
- **Web build** (tsc + vite) clean; **suite 607 green** (3 new config tests across the layers).
- **Not run here:** the full `tauri build` (packaged `.app`/`.dmg` with the sidecar embedded + GUI launch) — it compiles all of Tauri in release mode and touches codesigning, so it's left to `npm run desktop:build` / CI. The mechanism (externalBin resolution, spawn, lifecycle) is validated at each layer below the final bundle.

## Follow-ups (not in this PR)
- CI matrix to build per-platform sidecars (`desktop:sidecar`) + bundles, and ship `pyinstaller` in a build extra.
- Onefile cold start is ~16 s (extraction); a `--onedir` sidecar or a splash/health-gate would improve first-launch UX.
- Optional free-port selection instead of a fixed 7870.

🤖 Generated with [Claude Code](https://claude.com/claude-code)