### PR TITLE
Extensibility Slice 1: human-authored skills (AgentSkills SKILL.md)

### DIFF
--- a/config/skills/web-research/SKILL.md
+++ b/config/skills/web-research/SKILL.md
@@ -1,0 +1,28 @@
+---
+name: web-research
+description: >-
+  Use this whenever the user asks you to research a topic, find the current
+  state of something, compare options, or gather background from the web —
+  e.g. "what's the latest on X", "find the best approach to Y", "compare
+  these three tools". Drives a plan → search → read → synthesize → cite loop.
+tools: [web_search, fetch_url]
+---
+
+# Web Research
+
+A disciplined loop for turning an open question into a tight, sourced answer.
+
+1. **Plan briefly.** What does the question actually need? What angles are
+   worth covering? Note them before searching.
+2. **Search.** Use `web_search` to find candidate sources. Prefer primary
+   sources and recent material; treat listicles as leads, not authority.
+3. **Read selectively.** `fetch_url` the 2–4 most promising sources. Read
+   deeply rather than skimming ten shallow hits.
+4. **Synthesize.** Lead with the bottom line, then 2–4 specific claims, each
+   with its source URL inline. Surface disagreement between sources when it
+   matters.
+5. **Rate confidence.** End with `Confidence: high | medium | low` based on
+   source quality and consensus.
+
+Keep it tight: the answer first, the process never. Don't pad with "I searched
+for…"; deliver the conclusion and let the citations carry the evidence.

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -1,0 +1,80 @@
+# Skills (`SKILL.md`)
+
+protoAgent loads **human-authored skills** in the [AgentSkills](https://agentskills.io/specification)
+open `SKILL.md` format — the same portable format Claude Code, Hermes, and
+OpenClaw use. A skill teaches the agent *how and when* to use its tools for a
+recurring task. Relevant skills are retrieved and injected into the system
+prompt at inference time (the `<learned_skills>` block), so the agent picks the
+right approach without you re-explaining it each turn.
+
+## Anatomy of a skill
+
+A skill is a **folder containing a `SKILL.md`** file: YAML frontmatter followed
+by a markdown body.
+
+```markdown
+---
+name: web-research
+description: >-
+  Use this whenever the user asks you to research a topic, compare options, or
+  gather background from the web. Be specific about WHEN to trigger.
+tools: [web_search, fetch_url]   # optional, advisory
+---
+
+# Web Research
+
+1. Plan briefly.
+2. Search with web_search.
+3. Read the best 2–4 sources with fetch_url.
+4. Synthesize: bottom line first, claims with inline source URLs.
+5. End with Confidence: high | medium | low.
+```
+
+### Frontmatter
+
+| Field | Required | Notes |
+|---|---|---|
+| `name` | ✅ | Unique, lowercase-with-hyphens. |
+| `description` | ✅ | ≤ 1024 chars. This is the **trigger signal** — write it "pushy": say plainly *when* the agent should reach for this skill, or it under-triggers. |
+| `tools` (or `metadata.tools`) | — | Advisory list of tool names the skill uses. |
+
+The markdown **body** is the skill's instructions — freeform; write whatever
+helps the agent perform the task.
+
+## Where skills live
+
+Two roots, mirroring protoAgent's config bundle/live split:
+
+- **Bundled (shipped, read-only):** `config/skills/<slug>/SKILL.md` — example
+  skills that travel with the agent (and into the desktop sidecar).
+- **Your skills (writable, drop-in):** `<config-dir>/skills/<slug>/SKILL.md`,
+  where `<config-dir>` is `PROTOAGENT_CONFIG_DIR` (defaults to `config/`).
+  Override the root with `skills.dir` in the config.
+
+If a live skill and a bundled skill share a `name`, the live one wins.
+Sub-folders are organizational only — the skill is named by its frontmatter.
+
+Skills are (re)loaded into the FTS index on server start; drop a folder in and
+restart (or trigger a config reload) to pick it up.
+
+## Configuration
+
+```yaml
+skills:
+  enabled: true            # default
+  db_path: /sandbox/skills.db   # falls back to ~/.protoagent/skills.db
+  top_k: 5                 # max skills injected per turn
+  dir: ""                  # optional override for the writable skills root
+```
+
+`GET /api/runtime/status` reports `skills.count` so you can confirm how many
+loaded.
+
+## Notes
+
+- Skills are *retrieved by relevance* (BM25 over name/description/body), so a
+  precise, trigger-oriented `description` matters most.
+- This is the human-authored half. protoAgent also captures **agent-authored**
+  skills from successful `task()` runs (skill-v1 procedural memory); surfacing
+  those alongside `SKILL.md` skills is a planned follow-up.
+- OS/binary gating fields are parsed but not yet enforced.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -262,6 +262,19 @@ The bundled store is sqlite + FTS5 (with an automatic LIKE fallback when FTS5 is
 
 **Hot memory** — chunks stored under `domain='hot'` are *always-on*: `KnowledgeMiddleware` injects them into context every turn (vs. retrieved-on-relevance), re-read each turn so a freshly-added hot fact is seen immediately. Set one with `memory_ingest(content, domain="hot")` for facts the agent should never forget (operator preferences, standing constraints).
 
+## `skills`
+
+Human-authored skills in the AgentSkills [`SKILL.md`](../guides/skills.md) format — a folder with YAML frontmatter (`name` + `description`) and a markdown body. Loaded from disk into an FTS5 index on boot and retrieved + injected (`<learned_skills>`) at inference by `KnowledgeMiddleware`.
+
+| Key | Default | What |
+|---|---|---|
+| `enabled` | `true` | Load `SKILL.md` skills and activate skill retrieval. |
+| `db_path` | `/sandbox/skills.db` | FTS5 index path. Falls back to `~/.protoagent/skills.db` when the configured path isn't writable. |
+| `top_k` | `5` | Max skills injected per turn (ranked by BM25 relevance to the message). |
+| `dir` | `""` | Optional override for the *writable* skills root. Default: `<config-dir>/skills` (where `<config-dir>` honors `PROTOAGENT_CONFIG_DIR`). |
+
+Skills load from two roots — bundled (`config/skills/`, shipped) and writable (`<config-dir>/skills/`, your drop-ins); live skills override bundled ones by `name`. `GET /api/runtime/status` reports `skills.count`. See the [Skills guide](../guides/skills.md) for authoring.
+
 ## Scheduler
 
 Scheduler **enable/disable** is YAML-controlled (`middleware.scheduler` above) so the drawer can flip it without a restart. Backend **selection and runtime knobs** (which backend, where to write the sqlite, where to publish, etc.) are env-driven so the same container image can run under either backend without a rebuild. See [Schedule future work](/guides/scheduler) for the full guide.

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -18,7 +18,7 @@ from graph.subagents.config import SUBAGENT_REGISTRY
 from tools.lg_tools import get_all_tools
 
 
-def _build_middleware(config: LangGraphConfig, knowledge_store=None):
+def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_index=None):
     middleware = []
 
     # Prompt caching + knowledge-context delivery (wrap_model_call). Added
@@ -42,9 +42,16 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None):
             rate_limits=config.enforcement_rate_limits,
         ))
 
-    if config.knowledge_middleware and knowledge_store:
+    # KnowledgeMiddleware also carries human-authored skill retrieval (the
+    # <learned_skills> injection). Build it when knowledge OR skills is active,
+    # so skills work even on a KB-less agent (the store is None-tolerant).
+    _skills_index = skills_index if config.skills_enabled else None
+    if (config.knowledge_middleware and knowledge_store) or _skills_index is not None:
         middleware.append(KnowledgeMiddleware(
-            knowledge_store, top_k=config.knowledge_top_k,
+            knowledge_store if config.knowledge_middleware else None,
+            top_k=config.knowledge_top_k,
+            skills_index=_skills_index,
+            skills_top_k=config.skills_top_k,
         ))
 
     if config.audit_middleware:
@@ -399,6 +406,7 @@ def create_agent_graph(
     config: LangGraphConfig,
     knowledge_store=None,
     scheduler=None,
+    skills_index=None,
     include_subagents: bool = True,
 ):
     """Create the protoAgent LangGraph agent.
@@ -419,7 +427,7 @@ def create_agent_graph(
         from tools.execute_code import build_execute_code_tool
         all_tools.append(build_execute_code_tool(all_tools, config=config))
 
-    middleware = _build_middleware(config, knowledge_store)
+    middleware = _build_middleware(config, knowledge_store, skills_index=skills_index)
 
     system_prompt = build_system_prompt(
         include_subagents=include_subagents,

--- a/graph/config.py
+++ b/graph/config.py
@@ -176,6 +176,17 @@ class LangGraphConfig:
     embed_model: str = "nomic-embed-text"
     knowledge_top_k: int = 5
 
+    # Skills — human-authored ``SKILL.md`` folders (AgentSkills open standard)
+    # loaded from disk into the FTS5 skill index and retrieved at inference by
+    # KnowledgeMiddleware. ``db_path`` follows the same /sandbox→~/.protoagent
+    # writable fallback as the knowledge store (resolved in server.py).
+    # ``dir`` optionally overrides the writable skills root (default:
+    # ``<config_dir>/skills``); shipped example skills live in ``config/skills``.
+    skills_enabled: bool = True
+    skills_db_path: str = "/sandbox/skills.db"
+    skills_top_k: int = 5
+    skills_dir: str = ""
+
     # Identity — captured by the setup wizard, editable via the drawer.
     # ``identity_name`` falls back to the AGENT_NAME env var at runtime;
     # the YAML value wins when both are set so per-fork customization
@@ -220,6 +231,7 @@ class LangGraphConfig:
         subagents = data.get("subagents", {})
         middleware = data.get("middleware", {})
         knowledge = data.get("knowledge", {})
+        skills = data.get("skills", {})
         identity = data.get("identity", {})
         auth = data.get("auth", {})
         runtime = data.get("runtime", {})
@@ -281,6 +293,10 @@ class LangGraphConfig:
             knowledge_db_path=knowledge.get("db_path", cls.knowledge_db_path),
             embed_model=knowledge.get("embed_model", cls.embed_model),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
+            skills_enabled=skills.get("enabled", cls.skills_enabled),
+            skills_db_path=skills.get("db_path", cls.skills_db_path),
+            skills_top_k=skills.get("top_k", cls.skills_top_k),
+            skills_dir=skills.get("dir", cls.skills_dir),
             identity_name=identity.get("name", cls.identity_name),
             identity_operator=identity.get("operator", cls.identity_operator),
             auth_token=secret_auth_token or auth.get("token", cls.auth_token),

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -214,6 +214,12 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
             "embed_model": config.embed_model,
             "top_k": config.knowledge_top_k,
         },
+        "skills": {
+            "enabled": config.skills_enabled,
+            "db_path": config.skills_db_path,
+            "top_k": config.skills_top_k,
+            "dir": config.skills_dir,
+        },
         "identity": {
             "name": config.identity_name,
             "operator": config.identity_operator,

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -367,7 +367,7 @@ class KnowledgeMiddleware(AgentMiddleware):
                     )
                     break
 
-            if last_human:
+            if last_human and self._store is not None:
                 results = self._store.search(last_human, k=self._top_k)
                 if results:
                     context_parts = ["[Relevant knowledge from previous sessions:]"]

--- a/graph/skills/loader.py
+++ b/graph/skills/loader.py
@@ -1,0 +1,140 @@
+"""Load human-authored skills in the AgentSkills ``SKILL.md`` format.
+
+A skill is a folder containing a ``SKILL.md`` file: YAML frontmatter (``name`` +
+``description``, the open AgentSkills standard) followed by a markdown body of
+instructions. This is the same portable format Hermes, OpenClaw, and Claude
+Code use — adopting it (rather than a bespoke shape) keeps protoAgent skills
+shareable across the ecosystem.
+
+Loaded skills are turned into the existing ``SkillV1Artifact`` shape and seeded
+into the ``SkillsIndex`` (FTS5), so the dormant retrieval path in
+``KnowledgeMiddleware`` (``load_skills`` → ``<learned_skills>`` injection) lights
+up without any new retrieval code.
+
+Two roots, mirroring the config bundle/live split:
+- bundle (read-only, shipped): ``<repo>/config/skills/<slug>/SKILL.md``
+- live (writable, user drop-in): ``<PROTOAGENT_CONFIG_DIR>/skills/<slug>/SKILL.md``
+Live overrides bundle by skill ``name`` (later-wins).
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+import yaml
+
+from graph.extensions.skills import SkillV1Artifact
+
+log = logging.getLogger("protoagent.skills.loader")
+
+# AgentSkills caps the description (the trigger signal) at 1024 chars.
+_MAX_DESCRIPTION = 1024
+
+
+def parse_skill_md(path: Path) -> SkillV1Artifact | None:
+    """Parse one ``SKILL.md`` into a ``SkillV1Artifact`` (or ``None`` if invalid).
+
+    Never raises — a malformed skill file is logged and skipped so one bad drop
+    can't take down skill loading (or the boot).
+    """
+    try:
+        text = path.read_text(encoding="utf-8")
+    except OSError as exc:
+        log.warning("[skills] cannot read %s: %s", path, exc)
+        return None
+
+    frontmatter, body = _split_frontmatter(text)
+    if frontmatter is None:
+        log.warning("[skills] %s has no YAML frontmatter — skipping", path)
+        return None
+
+    try:
+        meta = yaml.safe_load(frontmatter) or {}
+    except yaml.YAMLError as exc:
+        log.warning("[skills] %s frontmatter is not valid YAML: %s", path, exc)
+        return None
+    if not isinstance(meta, dict):
+        log.warning("[skills] %s frontmatter is not a mapping — skipping", path)
+        return None
+
+    name = str(meta.get("name", "")).strip()
+    description = str(meta.get("description", "")).strip()
+    if not name or not description:
+        log.warning("[skills] %s missing required 'name'/'description' — skipping", path)
+        return None
+    if len(description) > _MAX_DESCRIPTION:
+        log.warning(
+            "[skills] %s description exceeds %d chars — truncating", path, _MAX_DESCRIPTION
+        )
+        description = description[:_MAX_DESCRIPTION]
+
+    # Optional advisory tool hints (frontmatter `tools:` or `metadata.tools:`).
+    tools = meta.get("tools")
+    if tools is None and isinstance(meta.get("metadata"), dict):
+        tools = meta["metadata"].get("tools")
+    tools_used = [str(t) for t in tools] if isinstance(tools, (list, tuple)) else []
+
+    return SkillV1Artifact(
+        name=name,
+        description=description,
+        prompt_template=body.strip(),
+        tools_used=tools_used,
+        source_session_id=f"skill-md:{path.parent.name}",
+    )
+
+
+def _split_frontmatter(text: str) -> tuple[str | None, str]:
+    """Split ``---``-fenced YAML frontmatter from the markdown body.
+
+    Returns ``(frontmatter_text, body)`` or ``(None, text)`` when there's no
+    leading frontmatter block.
+    """
+    stripped = text.lstrip("﻿")  # tolerate a BOM
+    if not stripped.startswith("---"):
+        return None, text
+    lines = stripped.splitlines()
+    # First line is the opening fence; find the closing fence.
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            return "\n".join(lines[1:i]), "\n".join(lines[i + 1:])
+    return None, text
+
+
+def discover_skill_files(roots: list[Path]) -> list[Path]:
+    """Return every ``SKILL.md`` under the given roots (nested folders allowed).
+
+    The skill is named by its frontmatter, not its folder, so grouping
+    directories are purely organizational (the OpenClaw/AgentSkills rule).
+    """
+    files: list[Path] = []
+    for root in roots:
+        if root and root.exists() and root.is_dir():
+            files.extend(sorted(root.glob("**/SKILL.md")))
+    return files
+
+
+def load_skills_from_disk(roots: list[Path]) -> list[SkillV1Artifact]:
+    """Parse all skills under *roots*, de-duped by name (later root wins)."""
+    by_name: dict[str, SkillV1Artifact] = {}
+    for path in discover_skill_files(roots):
+        artifact = parse_skill_md(path)
+        if artifact is not None:
+            by_name[artifact.name] = artifact  # later (live) root overrides earlier
+    return list(by_name.values())
+
+
+def seed_skills_index(index, roots: list[Path]) -> int:
+    """Rebuild the skill index from the ``SKILL.md`` files under *roots*.
+
+    Returns the number of skills indexed. ``rebuild_index`` is safe here because
+    in this slice the index holds only disk-authored skills; agent-emitted
+    skills (a later slice) will introduce a source column before they share it.
+    """
+    artifacts = load_skills_from_disk(roots)
+    try:
+        index.rebuild_index(artifacts)
+    except Exception as exc:  # noqa: BLE001 — seeding must never be fatal
+        log.warning("[skills] index seed failed: %s", exc)
+        return 0
+    return len(artifacts)

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -16,6 +16,7 @@ def build_runtime_status(
     scheduler: Any = None,
     cache_warmer: Any = None,
     goal_controller: Any = None,
+    skills_index: Any = None,
 ) -> dict[str, Any]:
     """Return UI-safe runtime status.
 
@@ -26,6 +27,14 @@ def build_runtime_status(
     populate the project-path picker; the server still enforces it.
     """
     project = {"path": project_path, "allowed_dirs": list(allowed_dirs or [])}
+
+    skill_count = 0
+    if skills_index is not None:
+        try:
+            skill_count = len(skills_index.all_skills())
+        except Exception:  # noqa: BLE001 — status must never raise
+            skill_count = 0
+
     if config is None:
         return {
             "setup_complete": bool(setup_complete),
@@ -35,6 +44,7 @@ def build_runtime_status(
             "identity": None,
             "middleware": {},
             "knowledge": {"enabled": False, "configured_path": None, "resolved_path": None},
+            "skills": {"enabled": False, "count": skill_count, "configured_path": None},
             "scheduler": {"enabled": False, "backend": "disabled"},
             "goal": {"enabled": False, "controller_loaded": False},
             "cache_warmer": {"enabled": False, "loaded": False},
@@ -73,6 +83,12 @@ def build_runtime_status(
             "configured_path": getattr(config, "knowledge_db_path", None),
             "resolved_path": str(getattr(knowledge_store, "path", "") or "") or None,
             "top_k": getattr(config, "knowledge_top_k", None),
+        },
+        "skills": {
+            "enabled": bool(getattr(config, "skills_enabled", False)),
+            "count": skill_count,
+            "configured_path": getattr(config, "skills_db_path", None),
+            "top_k": getattr(config, "skills_top_k", None),
         },
         "scheduler": {
             "enabled": bool(getattr(config, "scheduler_enabled", False)),

--- a/server.py
+++ b/server.py
@@ -65,6 +65,7 @@ _graph = None          # LangGraph compiled graph
 _graph_config = None   # LangGraphConfig
 _checkpointer = None   # MemorySaver for session persistence
 _knowledge_store = None  # KnowledgeStore bound into the active graph, or None.
+_skills_index = None     # SkillsIndex (human-authored SKILL.md store), or None.
 _active_port = 7870    # populated by _main() — the port this process is actually bound to.
                        # Read by the autostart installer so the LaunchAgent reboots
                        # on the same port the operator launched with, not the default.
@@ -88,7 +89,7 @@ def _init_langgraph_agent():
     clone with no model credentials — the wizard drives the user to
     provide them, then triggers a reload.
     """
-    global _graph, _graph_config, _checkpointer, _knowledge_store
+    global _graph, _graph_config, _checkpointer, _knowledge_store, _skills_index
 
     from graph.config import LangGraphConfig
     from graph.config_io import CONFIG_YAML_PATH, ensure_live_config, is_setup_complete
@@ -119,6 +120,10 @@ def _init_langgraph_agent():
     # the worker subagent — the store is still cheap to construct.
     _knowledge_store = _build_knowledge_store(_graph_config)
 
+    # Skills — human-authored SKILL.md folders seeded into the FTS index;
+    # KnowledgeMiddleware retrieves + injects them at inference.
+    _skills_index = _build_skills_index(_graph_config)
+
     # Scheduler — local sqlite by default, swaps to a WorkstaceanScheduler
     # automatically when WORKSTACEAN_API_BASE + WORKSTACEAN_API_KEY env
     # vars are set. Both backends share the same agent-tool surface
@@ -128,6 +133,7 @@ def _init_langgraph_agent():
 
     _graph = create_agent_graph(
         _graph_config, knowledge_store=_knowledge_store, scheduler=_scheduler,
+        skills_index=_skills_index,
     )
 
     # Cache-warming heartbeat — off by default; start() no-ops unless enabled
@@ -171,6 +177,59 @@ def _build_knowledge_store(config):
     except Exception as exc:
         log.warning("[server] knowledge store init failed: %s; running KB-less", exc)
         return None
+
+
+def _build_skills_index(config):
+    """Return a ``SkillsIndex`` seeded from on-disk ``SKILL.md`` folders, or None.
+
+    Resolves a writable DB path (the configured ``/sandbox/skills.db`` →
+    ``~/.protoagent/skills.db`` fallback, mirroring the knowledge store), then
+    rebuilds the index from the bundled example skills (``config/skills``) plus
+    the operator's drop-in skills (``<config_dir>/skills`` or ``skills.dir``).
+    Best-effort: any failure logs and returns None so a bad skill never blocks
+    boot.
+    """
+    if not getattr(config, "skills_enabled", True):
+        return None
+    try:
+        from pathlib import Path
+
+        from graph.config_io import _BUNDLE_CONFIG_DIR, _live_config_dir
+        from graph.skills.index import SkillsIndex
+        from graph.skills.loader import seed_skills_index
+
+        db_path = _resolve_skills_db(config.skills_db_path)
+        index = SkillsIndex(db_path=db_path)
+
+        live_root = Path(config.skills_dir).expanduser() if config.skills_dir else (
+            _live_config_dir() / "skills"
+        )
+        roots = [_BUNDLE_CONFIG_DIR / "skills", live_root]  # bundle first, live overrides
+        count = seed_skills_index(index, roots)
+        log.info("[skills] indexed %d SKILL.md skill(s) into %s", count, db_path)
+        return index
+    except Exception as exc:  # noqa: BLE001 — skills are optional, never fatal
+        log.warning("[skills] index init failed: %s; running without SKILL.md skills", exc)
+        return None
+
+
+def _resolve_skills_db(configured: str) -> str:
+    """Pick a writable skills DB path; fall back to ~/.protoagent when the
+    configured dir (default /sandbox) isn't creatable — same idea as the
+    knowledge store's ``_resolve_path``."""
+    import os
+    from pathlib import Path
+
+    candidate = Path(configured)
+    try:
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        if os.access(candidate.parent, os.W_OK):
+            return str(candidate)
+    except OSError:
+        pass
+    fallback = Path.home() / ".protoagent" / "skills.db"
+    fallback.parent.mkdir(parents=True, exist_ok=True)
+    return str(fallback)
 
 
 def _start_scheduler_async(backend: "SchedulerBackend") -> None:
@@ -302,7 +361,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     compiling — the wizard is still in front of the user, so there
     is nothing to hot-swap yet.
     """
-    global _graph, _graph_config, _knowledge_store
+    global _graph, _graph_config, _knowledge_store, _skills_index
 
     from graph.agent import create_agent_graph
     from graph.config import LangGraphConfig
@@ -349,11 +408,14 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
         next_scheduler = _scheduler
 
     new_store = None
+    new_skills = None
     if is_setup_complete():
         try:
             new_store = _build_knowledge_store(new_config)
+            new_skills = _build_skills_index(new_config)
             new_graph = create_agent_graph(
                 new_config, knowledge_store=new_store, scheduler=next_scheduler,
+                skills_index=new_skills,
             )
         except Exception as e:
             log.exception("[reload] graph rebuild failed")
@@ -367,6 +429,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     # same ``new_config`` so they stay consistent.
     _graph_config = new_config
     _knowledge_store = new_store
+    _skills_index = new_skills
     try:
         from a2a_handler import set_a2a_token
 
@@ -1206,6 +1269,7 @@ def _main():
             scheduler=_scheduler,
             cache_warmer=_cache_warmer,
             goal_controller=_goal_controller,
+            skills_index=_skills_index,
         )
 
     def _operator_subagent_list():

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -129,7 +129,7 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # Adding a new section here without updating config_to_dict would
     # strand fork-added fields outside the drawer's round-trip.
     assert set(d.keys()) == {
-        "model", "subagents", "middleware", "knowledge",
+        "model", "subagents", "middleware", "knowledge", "skills",
         "identity", "auth", "runtime", "operator",
     }
     assert d["model"]["name"] == cfg.model_name
@@ -140,6 +140,8 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     assert d["subagents"]["researcher"]["tools"] == list(cfg.researcher.tools)
     assert d["middleware"]["audit"] == cfg.audit_middleware
     assert d["knowledge"]["top_k"] == cfg.knowledge_top_k
+    assert d["skills"]["enabled"] == cfg.skills_enabled
+    assert d["skills"]["db_path"] == cfg.skills_db_path
     assert d["identity"]["name"] == cfg.identity_name
     assert d["runtime"]["autostart_on_boot"] == cfg.autostart_on_boot
     assert d["operator"]["allowed_dirs"] == list(cfg.operator_allowed_dirs)

--- a/tests/test_skills_loader.py
+++ b/tests/test_skills_loader.py
@@ -1,0 +1,140 @@
+"""Tests for the SKILL.md loader and the (now-activated) skill retrieval path.
+
+Covers:
+- parse_skill_md: valid, missing frontmatter, missing required fields,
+  oversized description, invalid YAML.
+- bundle/live name override (live wins).
+- seed_skills_index → SkillsIndex.load_skills round-trip.
+- KnowledgeMiddleware now carries a skills_index and injects <learned_skills>.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graph.skills.index import SkillsIndex
+from graph.skills.loader import (
+    load_skills_from_disk,
+    parse_skill_md,
+    seed_skills_index,
+)
+
+
+def _write_skill(root: Path, slug: str, frontmatter: str, body: str = "do the thing") -> Path:
+    d = root / slug
+    d.mkdir(parents=True, exist_ok=True)
+    p = d / "SKILL.md"
+    p.write_text(f"---\n{frontmatter}\n---\n{body}\n", encoding="utf-8")
+    return p
+
+
+def test_parse_valid_skill(tmp_path: Path) -> None:
+    p = _write_skill(
+        tmp_path, "web-research",
+        "name: web-research\ndescription: Use when researching on the web.\ntools: [web_search, fetch_url]",
+        "# Web Research\nPlan, search, read, cite.",
+    )
+    art = parse_skill_md(p)
+    assert art is not None
+    assert art.name == "web-research"
+    assert art.description == "Use when researching on the web."
+    assert art.tools_used == ["web_search", "fetch_url"]
+    assert "Plan, search" in art.prompt_template
+    assert art.source_session_id == "skill-md:web-research"
+
+
+def test_parse_no_frontmatter_returns_none(tmp_path: Path) -> None:
+    p = tmp_path / "x" / "SKILL.md"
+    p.parent.mkdir(parents=True)
+    p.write_text("# just markdown, no frontmatter\n", encoding="utf-8")
+    assert parse_skill_md(p) is None
+
+
+def test_parse_missing_required_fields_returns_none(tmp_path: Path) -> None:
+    p = _write_skill(tmp_path, "nodesc", "name: nodesc")  # no description
+    assert parse_skill_md(p) is None
+    p2 = _write_skill(tmp_path, "noname", "description: has desc but no name")
+    assert parse_skill_md(p2) is None
+
+
+def test_parse_invalid_yaml_returns_none(tmp_path: Path) -> None:
+    p = _write_skill(tmp_path, "bad", "name: [unclosed\ndescription: x")
+    assert parse_skill_md(p) is None
+
+
+def test_parse_truncates_oversized_description(tmp_path: Path) -> None:
+    long_desc = "x" * 2000
+    p = _write_skill(tmp_path, "long", f"name: long\ndescription: {long_desc}")
+    art = parse_skill_md(p)
+    assert art is not None
+    assert len(art.description) == 1024
+
+
+def test_metadata_tools_fallback(tmp_path: Path) -> None:
+    p = _write_skill(
+        tmp_path, "meta",
+        "name: meta\ndescription: d\nmetadata:\n  tools: [a, b]",
+    )
+    art = parse_skill_md(p)
+    assert art is not None and art.tools_used == ["a", "b"]
+
+
+def test_live_overrides_bundle_by_name(tmp_path: Path) -> None:
+    bundle = tmp_path / "bundle"
+    live = tmp_path / "live"
+    _write_skill(bundle, "dup", "name: dup\ndescription: from bundle")
+    _write_skill(live, "dup", "name: dup\ndescription: from live")
+    arts = load_skills_from_disk([bundle, live])  # bundle first, live second
+    assert len(arts) == 1
+    assert arts[0].description == "from live"
+
+
+def test_seed_and_retrieve_round_trip(tmp_path: Path) -> None:
+    root = tmp_path / "skills"
+    _write_skill(
+        root, "web-research",
+        "name: web-research\ndescription: Research a topic on the web and cite sources.",
+        "Plan, search, read, synthesize, cite.",
+    )
+    index = SkillsIndex(db_path=str(tmp_path / "skills.db"))
+    count = seed_skills_index(index, [root])
+    assert count == 1
+
+    hits = index.load_skills("research the web", k=5)
+    assert any(h.name == "web-research" for h in hits)
+
+
+def test_middleware_carries_skills_index_when_enabled(tmp_path: Path) -> None:
+    from graph.agent import _build_middleware
+    from graph.config import LangGraphConfig
+    from graph.middleware.knowledge import KnowledgeMiddleware
+
+    cfg = LangGraphConfig()  # skills_enabled defaults True, knowledge defaults True
+    index = SkillsIndex(db_path=str(tmp_path / "skills.db"))
+    mw = _build_middleware(cfg, knowledge_store=None, skills_index=index)
+    km = next((m for m in mw if isinstance(m, KnowledgeMiddleware)), None)
+    assert km is not None
+    assert km._skills_index is index
+
+
+def test_before_model_injects_learned_skills(tmp_path: Path) -> None:
+    from langchain_core.messages import HumanMessage
+
+    from graph.middleware.knowledge import KnowledgeMiddleware
+
+    root = tmp_path / "skills"
+    _write_skill(
+        root, "web-research",
+        "name: web-research\ndescription: Research a topic on the web and cite sources.",
+        "Plan, search, read, synthesize, cite.",
+    )
+    index = SkillsIndex(db_path=str(tmp_path / "skills.db"))
+    seed_skills_index(index, [root])
+
+    # No knowledge store — proves skills work KB-less (the None-store guard).
+    mw = KnowledgeMiddleware(None, skills_index=index)
+    state = {"messages": [HumanMessage(content="please research the web for me")]}
+    out = mw.before_model(state, runtime=None)
+    assert out is not None
+    assert "<learned_skills>" in out["context"]
+    assert "web-research" in out["context"]


### PR DESCRIPTION
## Summary

First executable slice of the extensibility roadmap from **ADR 0001** (#250). Adopts the [AgentSkills](https://agentskills.io/specification) open **`SKILL.md`** format for human-authored, drop-in skills — the portable format Claude Code, Hermes, and OpenClaw all use.

**Key finding that shaped this slice:** `KnowledgeMiddleware` already contained the *entire* skill-retrieval + `<learned_skills>` injection path — but `_build_middleware` never handed it a `SkillsIndex`, and there was no on-disk skill format or loader. So this slice both adopts the standard **and lights up infrastructure that was dead code.**

## What's included

- **`graph/skills/loader.py`** — parse `SKILL.md` (YAML frontmatter `name`+`description`, ≤1024-char description per the standard; markdown body → prompt template) into the existing `SkillV1Artifact`; discover + seed the FTS5 index. Two roots — bundle `config/skills/` and live `<config_dir>/skills/` (honors `PROTOAGENT_CONFIG_DIR`); live overrides bundle by `name`. Never raises — a malformed skill is logged and skipped.
- **Activation** — `skills_index` threaded `create_agent_graph → _build_middleware → KnowledgeMiddleware` (built when knowledge **or** skills is on). Added a `None`-store guard in `KnowledgeMiddleware` so skills work even on a KB-less agent.
- **Config** — parse the previously-unread `skills:` YAML section (`enabled`/`db_path`/`top_k`/`dir`); surfaced in `config_to_dict` and runtime status (`skills.count`).
- **Server** — `_build_skills_index` with a writable-path fallback (`/sandbox`→`~/.protoagent`, mirroring the knowledge store); seeded from disk at init and reload; non-fatal.
- **Example + docs** — `config/skills/web-research/SKILL.md`, `docs/guides/skills.md`, and a `skills` section in `docs/reference/configuration.md`.

## Out of scope (later slices)
Agent-*emitted* skill persistence (will add a `source`/pinned column first), personas-as-`SKILL.md`, OS/binary gating enforcement, and the MCP / plugin / marketplace tiers.

## Validation
- **Suite 617 green** (10 new): loader parsing (valid / no-frontmatter / missing-field / invalid-YAML / oversized-description), bundle↔live override, seed→`load_skills` round-trip, middleware-carries-index, and `before_model` injecting `<learned_skills>` **without an LLM**.
- **E2E** (headless server): boots with the bundled skill (`skills.count=1`); dropping a `SKILL.md` into the live skills dir + reload → `count=2`; loader/`rebuild_index` confirmed in logs.
- Docs build clean; `ruff` clean for changed files (3 remaining warnings are pre-existing in untouched lines).

🤖 Generated with [Claude Code](https://claude.com/claude-code)