### PR TITLE
Extensibility Slice 2: MCP client

### DIFF
--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -1,0 +1,87 @@
+# MCP (Model Context Protocol)
+
+protoAgent can connect to external [MCP](https://modelcontextprotocol.io)
+servers and expose **their tools as agent tools** — a standard way to plug in
+filesystems, browsers, databases, SaaS APIs, and more without writing any
+protoAgent-specific tool code. MCP is the same interop layer Claude Code,
+Hermes, and OpenClaw speak, so the existing server ecosystem works out of the
+box.
+
+Built on [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mcp-adapters).
+
+## Enabling it
+
+MCP is **off by default** — configuring a server is the opt-in. Add an `mcp`
+section to your config (`config/langgraph-config.yaml`, or via the wizard/drawer):
+
+```yaml
+mcp:
+  enabled: true
+  timeout_seconds: 20        # per-server discovery timeout
+  denylist: []               # optional: drop specific (namespaced) tool names
+  servers:
+    # Local subprocess over stdio
+    - name: filesystem
+      transport: stdio
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/data"]
+      env: {}                # optional
+    # Remote server over streamable HTTP
+    - name: weather
+      transport: streamable_http
+      url: "https://example.com/mcp"
+      headers: {}            # optional (e.g. auth)
+```
+
+Servers are discovered at startup (and on config reload). A server that's
+unreachable or errors is **logged and skipped** — it never blocks boot or the
+other servers.
+
+## How tools show up
+
+- Each server's tools are **namespaced by server name**: a `read_file` tool on
+  the `filesystem` server becomes **`filesystem__read_file`**. This prevents
+  collisions with protoAgent's built-in tools (any that would still collide are
+  skipped and logged).
+- Tools are available to the **lead agent**. Subagents only get them if you add
+  the namespaced name to that subagent's tool allowlist
+  (`graph/subagents/config.py`).
+- `GET /api/runtime/status` reports `mcp.enabled`, the connected `servers`
+  (`name`, `transport`, `tool_count`), and total `tool_count`.
+
+## Transports
+
+| Transport | Use when | Required fields |
+|---|---|---|
+| `stdio` | Local tools / simple setups (server runs as a subprocess) | `command`, `args` (`env`, `cwd` optional) |
+| `streamable_http` | Remote, production servers | `url` (`headers` optional) |
+| `sse` | Legacy SSE servers | `url` (`headers` optional) |
+
+Each tool invocation opens a fresh MCP session and cleans up (the client is
+stateless), so there's no long-lived connection to manage.
+
+## Try it locally
+
+A minimal stdio server ships at `examples/mcp/echo_server.py`:
+
+```yaml
+mcp:
+  enabled: true
+  servers:
+    - name: echo
+      transport: stdio
+      command: python
+      args: ["examples/mcp/echo_server.py"]
+```
+
+Start protoAgent and check `GET /api/runtime/status` — you'll see the `echo`
+server with one tool (`echo__echo`).
+
+## Notes & limits
+
+- **Tools only** for now — MCP *Resources* and *Prompts* aren't wired yet.
+- Changing the `mcp` config is picked up on restart/reload, not hot-swapped
+  per-request.
+- Remote-server auth (OAuth 2.1) beyond static `headers` isn't handled yet —
+  pass tokens via `headers` for now.
+- Only enable servers you trust: their tools run with the agent's privileges.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -275,6 +275,19 @@ Human-authored skills in the AgentSkills [`SKILL.md`](../guides/skills.md) forma
 
 Skills load from two roots — bundled (`config/skills/`, shipped) and writable (`<config-dir>/skills/`, your drop-ins); live skills override bundled ones by `name`. `GET /api/runtime/status` reports `skills.count`. See the [Skills guide](../guides/skills.md) for authoring.
 
+## `mcp`
+
+Connect external [Model Context Protocol](../guides/mcp.md) servers; their tools become agent tools (namespaced `<server>__<tool>`). Off by default — adding a server is the opt-in. Built on `langchain-mcp-adapters`.
+
+| Key | Default | What |
+|---|---|---|
+| `enabled` | `false` | Connect the configured servers and expose their tools. |
+| `timeout_seconds` | `20` | Per-server discovery timeout. A slow/unreachable server is skipped, never fatal. |
+| `denylist` | `[]` | Namespaced tool names to drop (e.g. `filesystem__write_file`). |
+| `servers` | `[]` | List of `{name, transport, …}`. `stdio` → `command`/`args`/`env`/`cwd`; `streamable_http`/`sse` → `url`/`headers`. |
+
+Servers are discovered at startup/reload. `GET /api/runtime/status` reports `mcp.servers` and `mcp.tool_count`. See the [MCP guide](../guides/mcp.md) and `examples/mcp/echo_server.py`.
+
 ## Scheduler
 
 Scheduler **enable/disable** is YAML-controlled (`middleware.scheduler` above) so the drawer can flip it without a restart. Backend **selection and runtime knobs** (which backend, where to write the sqlite, where to publish, etc.) are env-driven so the same container image can run under either backend without a rebuild. See [Schedule future work](/guides/scheduler) for the full guide.

--- a/examples/mcp/echo_server.py
+++ b/examples/mcp/echo_server.py
@@ -1,0 +1,32 @@
+"""Minimal MCP stdio server — for testing protoAgent's MCP client.
+
+Exposes a single ``echo`` tool over stdio using the FastMCP helper that ships
+with the ``mcp`` SDK (a transitive dependency of langchain-mcp-adapters). Point
+protoAgent at it to confirm MCP discovery end-to-end:
+
+    # config/langgraph-config.yaml (or via the wizard/drawer)
+    mcp:
+      enabled: true
+      servers:
+        - name: echo
+          transport: stdio
+          command: python
+          args: ["examples/mcp/echo_server.py"]
+
+The tool then appears to the agent as ``echo__echo`` (tools are namespaced by
+server name).
+"""
+
+from mcp.server.fastmcp import FastMCP
+
+mcp = FastMCP("echo")
+
+
+@mcp.tool()
+def echo(text: str) -> str:
+    """Echo back the given text — a trivial round-trip to prove the link works."""
+    return text
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -407,9 +407,14 @@ def create_agent_graph(
     knowledge_store=None,
     scheduler=None,
     skills_index=None,
+    extra_tools=None,
     include_subagents: bool = True,
 ):
     """Create the protoAgent LangGraph agent.
+
+    ``extra_tools`` are additional LangChain tools to expose to the lead agent
+    (e.g. MCP-server tools discovered at startup). Appended before subagent /
+    middleware assembly so they're in the tool map and visible to the model.
 
     Returns a compiled graph that can be invoked with:
         graph.ainvoke({"messages": [HumanMessage(content="...")]})
@@ -417,6 +422,9 @@ def create_agent_graph(
     llm = create_llm(config)
 
     all_tools = get_all_tools(knowledge_store, scheduler=scheduler)
+
+    if extra_tools:
+        all_tools.extend(extra_tools)
 
     if include_subagents:
         all_tools.extend(_build_task_tools(config, all_tools))

--- a/graph/config.py
+++ b/graph/config.py
@@ -187,6 +187,16 @@ class LangGraphConfig:
     skills_top_k: int = 5
     skills_dir: str = ""
 
+    # MCP — Model Context Protocol client. Connect to external MCP servers
+    # (stdio or streamable-HTTP); their tools become agent tools, namespaced
+    # ``<server>__<tool>`` so they can't shadow core tools. OFF by default —
+    # configuring a server is the opt-in. ``servers`` entries are
+    # ``{name, transport, command/args/env | url/headers}``. See tools/mcp_tools.py.
+    mcp_enabled: bool = False
+    mcp_servers: list[dict] = field(default_factory=list)
+    mcp_timeout_seconds: float = 20.0
+    mcp_denylist: list[str] = field(default_factory=list)
+
     # Identity — captured by the setup wizard, editable via the drawer.
     # ``identity_name`` falls back to the AGENT_NAME env var at runtime;
     # the YAML value wins when both are set so per-fork customization
@@ -232,6 +242,7 @@ class LangGraphConfig:
         middleware = data.get("middleware", {})
         knowledge = data.get("knowledge", {})
         skills = data.get("skills", {})
+        mcp = data.get("mcp", {})
         identity = data.get("identity", {})
         auth = data.get("auth", {})
         runtime = data.get("runtime", {})
@@ -297,6 +308,10 @@ class LangGraphConfig:
             skills_db_path=skills.get("db_path", cls.skills_db_path),
             skills_top_k=skills.get("top_k", cls.skills_top_k),
             skills_dir=skills.get("dir", cls.skills_dir),
+            mcp_enabled=mcp.get("enabled", cls.mcp_enabled),
+            mcp_servers=list(mcp.get("servers", []) or []),
+            mcp_timeout_seconds=mcp.get("timeout_seconds", cls.mcp_timeout_seconds),
+            mcp_denylist=list(mcp.get("denylist", []) or []),
             identity_name=identity.get("name", cls.identity_name),
             identity_operator=identity.get("operator", cls.identity_operator),
             auth_token=secret_auth_token or auth.get("token", cls.auth_token),

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -220,6 +220,12 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
             "top_k": config.skills_top_k,
             "dir": config.skills_dir,
         },
+        "mcp": {
+            "enabled": config.mcp_enabled,
+            "servers": list(config.mcp_servers),
+            "timeout_seconds": config.mcp_timeout_seconds,
+            "denylist": list(config.mcp_denylist),
+        },
         "identity": {
             "name": config.identity_name,
             "operator": config.identity_operator,

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -17,6 +17,7 @@ def build_runtime_status(
     cache_warmer: Any = None,
     goal_controller: Any = None,
     skills_index: Any = None,
+    mcp: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Return UI-safe runtime status.
 
@@ -35,6 +36,8 @@ def build_runtime_status(
         except Exception:  # noqa: BLE001 — status must never raise
             skill_count = 0
 
+    mcp_block = mcp or {"enabled": False, "servers": [], "tool_count": 0}
+
     if config is None:
         return {
             "setup_complete": bool(setup_complete),
@@ -45,6 +48,7 @@ def build_runtime_status(
             "middleware": {},
             "knowledge": {"enabled": False, "configured_path": None, "resolved_path": None},
             "skills": {"enabled": False, "count": skill_count, "configured_path": None},
+            "mcp": mcp_block,
             "scheduler": {"enabled": False, "backend": "disabled"},
             "goal": {"enabled": False, "controller_loaded": False},
             "cache_warmer": {"enabled": False, "loaded": False},
@@ -90,6 +94,7 @@ def build_runtime_status(
             "configured_path": getattr(config, "skills_db_path", None),
             "top_k": getattr(config, "skills_top_k", None),
         },
+        "mcp": mcp_block,
         "scheduler": {
             "enabled": bool(getattr(config, "scheduler_enabled", False)),
             "backend": getattr(scheduler, "name", "disabled") if scheduler else "disabled",

--- a/requirements.txt
+++ b/requirements.txt
@@ -15,6 +15,11 @@ langchain-core>=1.0
 langgraph>=1.1.0
 langchain-openai>=1.0
 
+# MCP client — connect external Model Context Protocol servers (stdio /
+# streamable-HTTP); their tools become agent tools. See tools/mcp_tools.py.
+# Pulls the `mcp` SDK transitively (also used by examples/mcp/echo_server.py).
+langchain-mcp-adapters>=0.2,<0.3
+
 # Starter tools (tools/lg_tools.py)
 ddgs>=9.0
 beautifulsoup4>=4.12

--- a/server.py
+++ b/server.py
@@ -66,6 +66,9 @@ _graph_config = None   # LangGraphConfig
 _checkpointer = None   # MemorySaver for session persistence
 _knowledge_store = None  # KnowledgeStore bound into the active graph, or None.
 _skills_index = None     # SkillsIndex (human-authored SKILL.md store), or None.
+_mcp_clients = []        # Live MultiServerMCPClient handles (kept alive for reconnect).
+_mcp_tools = []          # MCP-server tools appended to the active graph.
+_mcp_meta = []           # Per-server {name, transport, tool_count} for runtime status.
 _active_port = 7870    # populated by _main() — the port this process is actually bound to.
                        # Read by the autostart installer so the LaunchAgent reboots
                        # on the same port the operator launched with, not the default.
@@ -90,6 +93,7 @@ def _init_langgraph_agent():
     provide them, then triggers a reload.
     """
     global _graph, _graph_config, _checkpointer, _knowledge_store, _skills_index
+    global _mcp_clients, _mcp_tools, _mcp_meta
 
     from graph.config import LangGraphConfig
     from graph.config_io import CONFIG_YAML_PATH, ensure_live_config, is_setup_complete
@@ -124,6 +128,10 @@ def _init_langgraph_agent():
     # KnowledgeMiddleware retrieves + injects them at inference.
     _skills_index = _build_skills_index(_graph_config)
 
+    # MCP — external Model Context Protocol servers; their tools become agent
+    # tools (namespaced <server>__<tool>). Off unless mcp.enabled.
+    _mcp_clients, _mcp_tools, _mcp_meta = _build_mcp(_graph_config)
+
     # Scheduler — local sqlite by default, swaps to a WorkstaceanScheduler
     # automatically when WORKSTACEAN_API_BASE + WORKSTACEAN_API_KEY env
     # vars are set. Both backends share the same agent-tool surface
@@ -133,7 +141,7 @@ def _init_langgraph_agent():
 
     _graph = create_agent_graph(
         _graph_config, knowledge_store=_knowledge_store, scheduler=_scheduler,
-        skills_index=_skills_index,
+        skills_index=_skills_index, extra_tools=_mcp_tools,
     )
 
     # Cache-warming heartbeat — off by default; start() no-ops unless enabled
@@ -211,6 +219,25 @@ def _build_skills_index(config):
     except Exception as exc:  # noqa: BLE001 — skills are optional, never fatal
         log.warning("[skills] index init failed: %s; running without SKILL.md skills", exc)
         return None
+
+
+def _build_mcp(config):
+    """Discover tools from configured MCP servers. Returns (clients, tools, meta).
+
+    Best-effort and per-server isolated (see tools/mcp_tools.build_mcp_tools):
+    a bad/unreachable server is logged and skipped, never fatal. Returns empty
+    lists when MCP is disabled.
+    """
+    try:
+        from tools.mcp_tools import build_mcp_tools
+
+        clients, tools, meta = build_mcp_tools(config)
+        if tools:
+            log.info("[mcp] %d tool(s) from %d server(s)", len(tools), len(meta))
+        return clients, tools, meta
+    except Exception as exc:  # noqa: BLE001 — MCP is optional, never fatal
+        log.warning("[mcp] init failed: %s; running without MCP tools", exc)
+        return [], [], []
 
 
 def _resolve_skills_db(configured: str) -> str:
@@ -362,6 +389,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     is nothing to hot-swap yet.
     """
     global _graph, _graph_config, _knowledge_store, _skills_index
+    global _mcp_clients, _mcp_tools, _mcp_meta
 
     from graph.agent import create_agent_graph
     from graph.config import LangGraphConfig
@@ -409,13 +437,15 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
 
     new_store = None
     new_skills = None
+    new_mcp_clients, new_mcp_tools, new_mcp_meta = [], [], []
     if is_setup_complete():
         try:
             new_store = _build_knowledge_store(new_config)
             new_skills = _build_skills_index(new_config)
+            new_mcp_clients, new_mcp_tools, new_mcp_meta = _build_mcp(new_config)
             new_graph = create_agent_graph(
                 new_config, knowledge_store=new_store, scheduler=next_scheduler,
-                skills_index=new_skills,
+                skills_index=new_skills, extra_tools=new_mcp_tools,
             )
         except Exception as e:
             log.exception("[reload] graph rebuild failed")
@@ -430,6 +460,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     _graph_config = new_config
     _knowledge_store = new_store
     _skills_index = new_skills
+    _mcp_clients, _mcp_tools, _mcp_meta = new_mcp_clients, new_mcp_tools, new_mcp_meta
     try:
         from a2a_handler import set_a2a_token
 
@@ -1270,6 +1301,11 @@ def _main():
             cache_warmer=_cache_warmer,
             goal_controller=_goal_controller,
             skills_index=_skills_index,
+            mcp={
+                "enabled": bool(getattr(_graph_config, "mcp_enabled", False)) if _graph_config else False,
+                "servers": _mcp_meta,
+                "tool_count": len(_mcp_tools),
+            },
         )
 
     def _operator_subagent_list():

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -129,7 +129,7 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # Adding a new section here without updating config_to_dict would
     # strand fork-added fields outside the drawer's round-trip.
     assert set(d.keys()) == {
-        "model", "subagents", "middleware", "knowledge", "skills",
+        "model", "subagents", "middleware", "knowledge", "skills", "mcp",
         "identity", "auth", "runtime", "operator",
     }
     assert d["model"]["name"] == cfg.model_name

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -1,0 +1,166 @@
+"""Tests for the MCP client (tools/mcp_tools.py).
+
+No real MCP servers: MultiServerMCPClient is monkeypatched to return canned
+tools so we can exercise connection mapping, the loop-safe blocking runner,
+namespacing/denylist/collision filtering, and per-server failure isolation.
+The real stdio round-trip is covered by the end-to-end check in the PR.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+
+from graph.config import LangGraphConfig
+from tools.mcp_tools import _run_blocking, _server_connection, build_mcp_tools
+
+
+# ── connection mapping ───────────────────────────────────────────────────────
+
+
+def test_stdio_connection_mapping() -> None:
+    conn = _server_connection(
+        {"name": "fs", "transport": "stdio", "command": "npx", "args": ["-y", "x"], "env": {"A": "1"}}
+    )
+    assert conn == {"transport": "stdio", "command": "npx", "args": ["-y", "x"], "env": {"A": "1"}}
+
+
+def test_http_connection_mapping_and_alias() -> None:
+    for transport in ("streamable_http", "http", "streamable-http"):
+        conn = _server_connection({"transport": transport, "url": "https://x/mcp"})
+        assert conn == {"transport": "streamable_http", "url": "https://x/mcp"}
+
+
+def test_connection_missing_required_returns_none() -> None:
+    assert _server_connection({"transport": "stdio"}) is None  # no command
+    assert _server_connection({"transport": "streamable_http"}) is None  # no url
+
+
+# ── _run_blocking (both loop contexts) ───────────────────────────────────────
+
+
+def test_run_blocking_no_running_loop() -> None:
+    async def coro():
+        return 42
+
+    assert _run_blocking(coro(), timeout=5) == 42
+
+
+def test_run_blocking_inside_running_loop() -> None:
+    # Calling from within a running loop must offload to a thread, not deadlock.
+    async def outer():
+        async def inner():
+            return 7
+
+        return _run_blocking(inner(), timeout=5)
+
+    assert asyncio.run(outer()) == 7
+
+
+# ── build_mcp_tools ──────────────────────────────────────────────────────────
+
+
+def _fake_client_factory(monkeypatch, *, by_server: dict):
+    """Patch MultiServerMCPClient so each server returns canned tools or raises.
+
+    ``by_server`` maps server name → list[tool] | Exception.
+    """
+    class FakeClient:
+        def __init__(self, connections, tool_name_prefix=False):
+            self.name = next(iter(connections))
+
+        async def get_tools(self):
+            result = by_server.get(self.name)
+            if isinstance(result, Exception):
+                raise result
+            return result or []
+
+    monkeypatch.setattr(
+        "langchain_mcp_adapters.client.MultiServerMCPClient", FakeClient
+    )
+
+
+def _cfg(servers):
+    return LangGraphConfig(mcp_enabled=True, mcp_servers=servers)
+
+
+def test_disabled_returns_empty() -> None:
+    clients, tools, meta = build_mcp_tools(LangGraphConfig(mcp_enabled=False, mcp_servers=[{"name": "x"}]))
+    assert (clients, tools, meta) == ([], [], [])
+
+
+def test_build_collects_tools_and_meta(monkeypatch) -> None:
+    _fake_client_factory(monkeypatch, by_server={"echo": [SimpleNamespace(name="echo__echo")]})
+    clients, tools, meta = build_mcp_tools(
+        _cfg([{"name": "echo", "transport": "stdio", "command": "python", "args": ["s.py"]}])
+    )
+    assert [t.name for t in tools] == ["echo__echo"]
+    assert meta == [{"name": "echo", "transport": "stdio", "tool_count": 1}]
+    assert len(clients) == 1
+
+
+def test_denylist_and_core_collision_filtered(monkeypatch) -> None:
+    _fake_client_factory(monkeypatch, by_server={
+        "s": [
+            SimpleNamespace(name="s__keep"),
+            SimpleNamespace(name="s__drop"),       # denylisted
+            SimpleNamespace(name="current_time"),  # collides with a core tool
+        ],
+    })
+    cfg = _cfg([{"name": "s", "transport": "stdio", "command": "python", "args": ["s.py"]}])
+    cfg.mcp_denylist = ["s__drop"]
+    _clients, tools, meta = build_mcp_tools(cfg)
+    assert [t.name for t in tools] == ["s__keep"]
+    assert meta[0]["tool_count"] == 1
+
+
+def test_one_bad_server_does_not_break_others(monkeypatch) -> None:
+    _fake_client_factory(monkeypatch, by_server={
+        "good": [SimpleNamespace(name="good__t")],
+        "bad": RuntimeError("connection refused"),
+    })
+    cfg = _cfg([
+        {"name": "good", "transport": "stdio", "command": "python", "args": ["g.py"]},
+        {"name": "bad", "transport": "stdio", "command": "python", "args": ["b.py"]},
+    ])
+    _clients, tools, meta = build_mcp_tools(cfg)
+    assert [t.name for t in tools] == ["good__t"]
+    assert [m["name"] for m in meta] == ["good"]
+
+
+def test_invalid_server_entry_skipped(monkeypatch) -> None:
+    _fake_client_factory(monkeypatch, by_server={})
+    cfg = _cfg([{"name": "noconn", "transport": "stdio"}])  # no command → invalid
+    _clients, tools, meta = build_mcp_tools(cfg)
+    assert tools == [] and meta == []
+
+
+# ── config round-trip ────────────────────────────────────────────────────────
+
+
+def test_from_yaml_parses_mcp(tmp_path) -> None:
+    p = tmp_path / "langgraph-config.yaml"
+    p.write_text(
+        "mcp:\n"
+        "  enabled: true\n"
+        "  timeout_seconds: 12\n"
+        "  denylist: [x__y]\n"
+        "  servers:\n"
+        "    - name: echo\n"
+        "      transport: stdio\n"
+        "      command: python\n"
+        "      args: ['s.py']\n"
+    )
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.mcp_enabled is True
+    assert cfg.mcp_timeout_seconds == 12
+    assert cfg.mcp_denylist == ["x__y"]
+    assert cfg.mcp_servers[0]["name"] == "echo"
+
+
+def test_config_to_dict_includes_mcp() -> None:
+    from graph.config_io import config_to_dict
+
+    d = config_to_dict(LangGraphConfig(mcp_enabled=True))
+    assert d["mcp"]["enabled"] is True
+    assert "servers" in d["mcp"] and "denylist" in d["mcp"]

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -1,0 +1,175 @@
+"""Model Context Protocol (MCP) client — expose MCP-server tools to the agent.
+
+Configured MCP servers (stdio or streamable-HTTP) are connected via
+``langchain-mcp-adapters``; their tools are discovered at graph-build time and
+appended to the agent's tool list as ordinary LangChain ``BaseTool``s. Tools are
+namespaced by server (``<server>__<tool>``) so they can't shadow core tools, and
+``MultiServerMCPClient`` is stateless — each invocation opens a fresh MCP
+session — so the discovered tools are event-loop-agnostic and the client object
+just needs to stay alive for reconnection.
+
+Configuring a server is the opt-in act; MCP is off unless ``mcp.enabled`` is set.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+log = logging.getLogger("protoagent.mcp")
+
+
+def _server_connection(server: dict) -> dict | None:
+    """Map a config ``mcp.servers[]`` entry to a langchain-mcp-adapters
+    connection dict. Returns ``None`` for an entry missing its essential fields
+    (logged + skipped by the caller). Only provided keys are set; the adapter
+    fills the rest with defaults.
+    """
+    transport = str(server.get("transport") or "stdio").strip().lower()
+
+    if transport in ("http", "streamable_http", "streamable-http"):
+        url = server.get("url")
+        if not url:
+            return None
+        conn: dict[str, Any] = {"transport": "streamable_http", "url": str(url)}
+        if server.get("headers"):
+            conn["headers"] = dict(server["headers"])
+        return conn
+
+    if transport == "sse":
+        url = server.get("url")
+        if not url:
+            return None
+        conn = {"transport": "sse", "url": str(url)}
+        if server.get("headers"):
+            conn["headers"] = dict(server["headers"])
+        return conn
+
+    # Default: stdio (local subprocess).
+    command = server.get("command")
+    if not command:
+        return None
+    conn = {"transport": "stdio", "command": str(command), "args": list(server.get("args") or [])}
+    if server.get("env"):
+        conn["env"] = dict(server["env"])
+    if server.get("cwd"):
+        conn["cwd"] = str(server["cwd"])
+    return conn
+
+
+def _run_blocking(coro, timeout: float):
+    """Run an async coroutine to completion from sync code, in any context.
+
+    At boot there's no running loop → ``asyncio.run``. The reload path runs
+    inside the server's event loop → offload to a throwaway thread with its own
+    loop. Safe because MCP discovery sessions are stateless and short-lived.
+    """
+    import asyncio
+
+    async def _with_timeout():
+        return await asyncio.wait_for(coro, timeout)
+
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return asyncio.run(_with_timeout())
+
+    import threading
+
+    box: dict[str, Any] = {}
+
+    def _worker():
+        try:
+            box["value"] = asyncio.run(_with_timeout())
+        except BaseException as exc:  # noqa: BLE001 — re-raised on the calling thread
+            box["error"] = exc
+
+    thread = threading.Thread(target=_worker, daemon=True)
+    thread.start()
+    thread.join()
+    if "error" in box:
+        raise box["error"]
+    return box.get("value")
+
+
+def _core_tool_names() -> set[str]:
+    """Names the agent already uses — MCP tools that collide are skipped."""
+    try:
+        from tools.lg_tools import (
+            MEMORY_TOOL_NAMES,
+            SCHEDULER_TOOL_NAMES,
+            get_all_tools,
+        )
+
+        names = {t.name for t in get_all_tools()}
+        names |= set(MEMORY_TOOL_NAMES) | set(SCHEDULER_TOOL_NAMES)
+        names |= {"task", "task_batch", "execute_code"}
+        return names
+    except Exception:  # noqa: BLE001 — collision check is best-effort
+        return set()
+
+
+def build_mcp_tools(config) -> tuple[list, list, list[dict]]:
+    """Discover tools from configured MCP servers.
+
+    Returns ``(clients, tools, servers_meta)``:
+    - ``clients`` — live ``MultiServerMCPClient``s, one per server, kept alive so
+      the stateless tools can reconnect on invocation.
+    - ``tools`` — LangChain ``BaseTool``s to append to the agent.
+    - ``servers_meta`` — ``[{name, transport, tool_count}]`` for runtime status.
+
+    Each server is isolated: a bad/unreachable one is logged and skipped, never
+    fatal. MCP is off unless ``config.mcp_enabled``.
+    """
+    clients: list = []
+    tools: list = []
+    meta: list[dict] = []
+
+    if not getattr(config, "mcp_enabled", False):
+        return clients, tools, meta
+
+    servers = getattr(config, "mcp_servers", []) or []
+    timeout = float(getattr(config, "mcp_timeout_seconds", 20.0))
+    denylist = set(getattr(config, "mcp_denylist", []) or [])
+    core_names = _core_tool_names()
+
+    from langchain_mcp_adapters.client import MultiServerMCPClient
+
+    for server in servers:
+        if not isinstance(server, dict):
+            log.warning("[mcp] skipping non-mapping server entry: %r", server)
+            continue
+        name = str(server.get("name") or "").strip()
+        conn = _server_connection(server)
+        if not name or conn is None:
+            log.warning("[mcp] skipping invalid server entry (need name + command/url): %r", server)
+            continue
+
+        try:
+            # tool_name_prefix=True → tools are named "<server>__<tool>".
+            client = MultiServerMCPClient({name: conn}, tool_name_prefix=True)
+            discovered = _run_blocking(client.get_tools(), timeout)
+        except Exception as exc:  # noqa: BLE001 — one server must not break the rest
+            log.warning("[mcp] server %r discovery failed: %s — skipping", name, exc)
+            continue
+
+        kept = []
+        for tool in discovered:
+            if tool.name in denylist:
+                log.info("[mcp] %s: %s in denylist — skipped", name, tool.name)
+                continue
+            if tool.name in core_names:
+                log.warning("[mcp] %s: %s collides with a core tool — skipped", name, tool.name)
+                continue
+            kept.append(tool)
+
+        clients.append(client)
+        tools.extend(kept)
+        meta.append({
+            "name": name,
+            "transport": conn["transport"],
+            "tool_count": len(kept),
+        })
+        log.info("[mcp] server %s (%s): %d tool(s)", name, conn["transport"], len(kept))
+
+    return clients, tools, meta


### PR DESCRIPTION
## Summary

Second slice of the extensibility roadmap (**ADR 0001**, Accepted). Adds a **Model Context Protocol (MCP) client** so an operator can point protoAgent at any MCP server (stdio or streamable-HTTP) and its tools become first-class agent tools — importing an entire external ecosystem with no protoAgent-specific tool code. MCP is the interop seam every reference stack (Hermes, OpenClaw, Claude Code) already speaks; protoAgent was the only one without it.

**Off by default** — configuring a server is the opt-in:
```yaml
mcp:
  enabled: true
  servers:
    - { name: echo, transport: stdio, command: python, args: ["examples/mcp/echo_server.py"] }
```

## How it works

- **`tools/mcp_tools.py`** — `build_mcp_tools` discovers tools via `langchain-mcp-adapters` (**one `MultiServerMCPClient` per server** so a bad/unreachable one can't break the rest), namespaces them `<server>__<tool>` (`tool_name_prefix=True`) so they can't shadow core tools, applies a `denylist` + core-collision skip, and is non-fatal per server.
- **The async/sync bridge** — `_run_blocking` runs discovery from sync graph-build code in both contexts: `asyncio.run` at boot, a throwaway-loop thread when called under the server's reload loop. Safe because `MultiServerMCPClient` is **stateless** (fresh session per invocation), so the discovered tools are event-loop-agnostic and the lightweight client just stays alive for reconnection.
- **Wiring** — `create_agent_graph` gains `extra_tools` (appended before subagent/middleware assembly); `server.py` threads `_build_mcp` through `_init`/`_reload` exactly like the knowledge store and skills index. Config (`mcp_*` fields + `mcp:` YAML), `config_to_dict`, and runtime status (`mcp.servers`, `mcp.tool_count`) all surface it.
- **Dep**: `langchain-mcp-adapters>=0.2,<0.3` (verified compatible with the pinned langchain-core 1.3.0; pulls the `mcp` SDK).

## Validation

- **Suite 629 green** (12 new): connection mapping (stdio/http/alias/missing), the loop-safe `_run_blocking` (both contexts), namespacing + denylist + core-collision filtering, **per-server failure isolation**, and config round-trip.
- **Real stdio E2E**: ran the headless server with `examples/mcp/echo_server.py` (a FastMCP stdio server) configured — `GET /api/runtime/status` shows the `echo` server with `tool_count: 1` (`echo__echo`). Genuine discovery, not mocks.
- `ruff` clean for changed files; docs build clean. CI installs `requirements.txt`, so the new dep is exercised there.

## Out of scope (later slices)
MCP Resources/Prompts (tools only), per-tool capability-approval UI, remote OAuth (use `headers` for now), hot-reload without restart, and exposing MCP tools to subagents by default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)