### PR TITLE
Persist agent-emitted skills (complete the SKILL.md self-improvement loop)

### DIFF
--- a/graph/agent.py
+++ b/graph/agent.py
@@ -111,6 +111,7 @@ async def _run_subagent(
     subagent_type: str,
     emit_skill: bool,
     truncate: int | None = None,
+    skills_index=None,
 ) -> str:
     """Run a single subagent delegation and return its output text.
 
@@ -191,6 +192,17 @@ async def _run_subagent(
                         source_session_id=tracing.current_session_id(),
                     )
                     emit_skill_artifact(artifact)
+                    # Persist to the skill index here — same async context as
+                    # emission, so task_batch (which fans out into child tasks)
+                    # doesn't lose artifacts the way a ContextVar drain would.
+                    if skills_index is not None:
+                        try:
+                            skills_index.add_emitted_skill(artifact)
+                        except Exception as exc:
+                            import logging
+                            logging.getLogger(__name__).error(
+                                "[skill] persisting emitted skill failed: %s", exc
+                            )
                 except Exception as exc:
                     import logging
                     logging.getLogger(__name__).error(
@@ -288,7 +300,7 @@ async def run_manual_subagent_batch(
     return "\n\n".join(parts)
 
 
-def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool]):
+def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills_index=None):
     """Build the subagent-delegation tools: single ``task`` and concurrent ``task_batch``.
 
     Subagents share AuditMiddleware so their tool calls land alongside the
@@ -338,6 +350,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool]):
             subagent_type=subagent_type,
             emit_skill=emit_skill,
             truncate=None,
+            skills_index=skills_index,
         )
 
     @tool
@@ -386,6 +399,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool]):
                     subagent_type=spec.get("subagent_type", "researcher"),
                     emit_skill=bool(spec.get("emit_skill", False)),
                     truncate=truncate,
+                    skills_index=skills_index,
                 )
 
         results = await asyncio.gather(
@@ -427,7 +441,7 @@ def create_agent_graph(
         all_tools.extend(extra_tools)
 
     if include_subagents:
-        all_tools.extend(_build_task_tools(config, all_tools))
+        all_tools.extend(_build_task_tools(config, all_tools, skills_index=skills_index))
 
     # Programmatic tool calling — opt-in. Built last so it can wrap every
     # other tool (including task/task_batch) but never itself.

--- a/graph/skills/curator.py
+++ b/graph/skills/curator.py
@@ -230,9 +230,14 @@ class SkillCurator:
     # ── Loading / saving ───────────────────────────────────────────────────────
 
     def _load_index(self) -> list[dict]:
-        """Load every skill from the live SQLite index as curator dicts."""
-        skills = self._get_index().all_skills()
-        log.info("[curator] loaded %d skills from %s", len(skills), self.db_path)
+        """Load curatable skills from the live SQLite index.
+
+        Disk-sourced skills (human-authored SKILL.md) are pinned — they're
+        re-seeded from disk each boot, so the curator must not decay/dedupe/
+        prune them. Only agent-``emitted`` skills are curated.
+        """
+        skills = [s for s in self._get_index().all_skills() if s.get("source") != "disk"]
+        log.info("[curator] loaded %d curatable skill(s) from %s", len(skills), self.db_path)
         return skills
 
     def _save_index(self, kept: list[dict]) -> None:
@@ -245,6 +250,10 @@ class SkillCurator:
         kept_by_id = {s["id"]: s for s in kept if s.get("id") is not None}
         deleted = 0
         for current in index.all_skills():
+            # Never delete pinned disk skills — they aren't curated and aren't
+            # in *kept* (see _load_index), so they'd otherwise be reaped here.
+            if current.get("source") == "disk":
+                continue
             if current["id"] not in kept_by_id:
                 index.delete_skill(current["id"])
                 deleted += 1

--- a/graph/skills/index.py
+++ b/graph/skills/index.py
@@ -34,7 +34,9 @@ def _build_match_query(query: str) -> str:
 
 # Bump when FTS table columns change — triggers auto-migration
 # v2: added confidence + last_used (consumed by the skill curator).
-_SCHEMA_VERSION = 2
+# v3: added `source` ('disk' = human-authored SKILL.md, re-seeded each boot;
+#     'emitted' = agent-authored via task(), persisted + curator-managed).
+_SCHEMA_VERSION = 3
 
 # Columns indexed by FTS5 (order matters for sqlite_master check)
 _FTS_CONTENT_COLUMNS = (
@@ -146,7 +148,8 @@ class SkillsIndex:
                 source_session_id,
                 created_at UNINDEXED,
                 confidence UNINDEXED,
-                last_used UNINDEXED
+                last_used UNINDEXED,
+                source UNINDEXED
             );
 
             CREATE TABLE _skills_meta (
@@ -155,7 +158,7 @@ class SkillsIndex:
             );
 
             INSERT INTO _skills_meta (key, version)
-            VALUES ('schema_version', 2);
+            VALUES ('schema_version', 3);
         """)
         conn.commit()
         log.info("[skills] schema created at %s", self._db_path)
@@ -177,12 +180,14 @@ class SkillsIndex:
 
     # ── Write path ────────────────────────────────────────────────────────────
 
-    def add_skill(self, artifact: object) -> None:
+    def add_skill(self, artifact: object, source: str = "emitted") -> None:
         """Insert a SkillV1Artifact into the FTS5 index.
 
         Accepts any object with matching attributes so this module does not
         import graph.extensions.skills (avoiding circular dependency).
-        Silently skips artifacts with empty names.
+        Silently skips artifacts with empty names. ``source`` is ``'disk'`` for
+        human-authored SKILL.md skills (re-seeded each boot) or ``'emitted'``
+        for agent-authored ones (persisted + curator-managed).
         """
         name = getattr(artifact, "name", "") or ""
         if not name:
@@ -206,16 +211,51 @@ class SkillsIndex:
                 """
                 INSERT INTO skills_fts
                     (name, description, prompt_template, tools_used,
-                     source_session_id, created_at, confidence, last_used)
-                VALUES (?, ?, ?, ?, ?, ?, 1.0, ?)
+                     source_session_id, created_at, confidence, last_used, source)
+                VALUES (?, ?, ?, ?, ?, ?, 1.0, ?, ?)
                 """,
                 (name, description, prompt_template, tools_str,
-                 source_session_id, created_at, last_used),
+                 source_session_id, created_at, last_used, source),
             )
             conn.commit()
-            log.debug("[skills] indexed skill: %s", name)
+            log.debug("[skills] indexed skill: %s (source=%s)", name, source)
         except sqlite3.Error as exc:
             log.error("[skills] failed to index skill %s: %s", name, exc)
+
+    def add_emitted_skill(self, artifact: object) -> None:
+        """Persist an agent-emitted skill, de-duped by name.
+
+        Replaces any prior ``emitted`` skill with the same name so repeated runs
+        of the same workflow refresh rather than accumulate. Disk skills (same
+        name) are left untouched — they're a separate, pinned source.
+        """
+        name = getattr(artifact, "name", "") or ""
+        if not name:
+            return
+        conn = self._open_conn()
+        try:
+            conn.execute(
+                "DELETE FROM skills_fts WHERE name = ? AND source = 'emitted'", (name,)
+            )
+            conn.commit()
+        except sqlite3.Error as exc:
+            log.error("[skills] failed to de-dupe emitted skill %s: %s", name, exc)
+        self.add_skill(artifact, source="emitted")
+
+    def replace_disk_skills(self, artifacts: list[object]) -> None:
+        """Reset the ``disk`` source to exactly *artifacts*, leaving ``emitted``
+        skills intact. Used to (re)seed human-authored SKILL.md skills on boot
+        without clobbering the agent's persisted procedural memory."""
+        conn = self._open_conn()
+        try:
+            conn.execute("DELETE FROM skills_fts WHERE source = 'disk'")
+            conn.commit()
+        except sqlite3.Error as exc:
+            log.error("[skills] failed to clear disk skills for re-seed: %s", exc)
+            return
+        for artifact in artifacts:
+            self.add_skill(artifact, source="disk")
+        log.info("[skills] seeded %d disk skill(s)", len(artifacts))
 
     # ── Read path ─────────────────────────────────────────────────────────────
 
@@ -279,7 +319,7 @@ class SkillsIndex:
             cur = conn.execute(
                 """
                 SELECT rowid AS id, name, description, prompt_template, tools_used,
-                       created_at, confidence, last_used
+                       created_at, confidence, last_used, source
                 FROM skills_fts
                 """
             )
@@ -293,6 +333,7 @@ class SkillsIndex:
                     "created_at": row["created_at"],
                     "confidence": float(row["confidence"]) if row["confidence"] is not None else 1.0,
                     "last_used": row["last_used"],
+                    "source": (row["source"] if "source" in row.keys() else "emitted") or "emitted",
                 }
                 for row in cur.fetchall()
             ]

--- a/graph/skills/loader.py
+++ b/graph/skills/loader.py
@@ -125,15 +125,15 @@ def load_skills_from_disk(roots: list[Path]) -> list[SkillV1Artifact]:
 
 
 def seed_skills_index(index, roots: list[Path]) -> int:
-    """Rebuild the skill index from the ``SKILL.md`` files under *roots*.
+    """(Re)seed the ``disk`` source of the skill index from the ``SKILL.md``
+    files under *roots*. Returns the number of disk skills indexed.
 
-    Returns the number of skills indexed. ``rebuild_index`` is safe here because
-    in this slice the index holds only disk-authored skills; agent-emitted
-    skills (a later slice) will introduce a source column before they share it.
+    Uses ``replace_disk_skills`` so re-seeding on boot/reload refreshes the
+    human-authored skills without clobbering agent-``emitted`` ones.
     """
     artifacts = load_skills_from_disk(roots)
     try:
-        index.rebuild_index(artifacts)
+        index.replace_disk_skills(artifacts)
     except Exception as exc:  # noqa: BLE001 — seeding must never be fatal
         log.warning("[skills] index seed failed: %s", exc)
         return 0

--- a/tests/test_skill_persistence.py
+++ b/tests/test_skill_persistence.py
@@ -1,0 +1,165 @@
+"""Tests for persisting agent-emitted skills alongside disk SKILL.md skills.
+
+Covers the `source` column, disk/emitted separation on re-seed, emitted dedup,
+the curator pinning disk skills, and the _run_subagent → index persist path.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+
+from graph.skills.index import SkillsIndex
+
+
+def _artifact(name: str, desc: str = "d", prompt: str = "p", tools=("web_search",)):
+    return SimpleNamespace(
+        name=name,
+        description=desc,
+        prompt_template=prompt,
+        tools_used=list(tools),
+        source_session_id="s1",
+        created_at=datetime.now(timezone.utc).isoformat(),
+    )
+
+
+def test_v2_db_migrates_to_v3(tmp_path) -> None:
+    # An older v2 index (no `source` column) must auto-migrate (backup + rebuild)
+    # rather than crash when the bumped SkillsIndex opens it.
+    import sqlite3
+
+    p = tmp_path / "old.db"
+    conn = sqlite3.connect(str(p))
+    conn.executescript(
+        """
+        CREATE VIRTUAL TABLE skills_fts USING fts5(
+            name, description, prompt_template, tools_used, source_session_id,
+            created_at UNINDEXED, confidence UNINDEXED, last_used UNINDEXED
+        );
+        CREATE TABLE _skills_meta (key TEXT PRIMARY KEY, version INTEGER NOT NULL);
+        INSERT INTO _skills_meta (key, version) VALUES ('schema_version', 2);
+        """
+    )
+    conn.commit()
+    conn.close()
+
+    idx = SkillsIndex(str(p))  # detects v2 → backup + rebuild to v3
+    idx.add_skill(_artifact("post-migrate"), source="emitted")
+    assert any(s["name"] == "post-migrate" and s["source"] == "emitted" for s in idx.all_skills())
+
+
+def test_add_skill_records_source(tmp_path) -> None:
+    idx = SkillsIndex(str(tmp_path / "s.db"))
+    idx.add_skill(_artifact("a"), source="emitted")
+    idx.add_skill(_artifact("b"), source="disk")
+    by_name = {s["name"]: s["source"] for s in idx.all_skills()}
+    assert by_name == {"a": "emitted", "b": "disk"}
+
+
+def test_replace_disk_skills_preserves_emitted(tmp_path) -> None:
+    idx = SkillsIndex(str(tmp_path / "s.db"))
+    idx.add_emitted_skill(_artifact("learned"))
+    idx.replace_disk_skills([_artifact("disk-one"), _artifact("disk-two")])
+    names = {s["name"]: s["source"] for s in idx.all_skills()}
+    assert names == {"learned": "emitted", "disk-one": "disk", "disk-two": "disk"}
+
+    # Re-seeding disk again still leaves the emitted skill intact, and refreshes
+    # the disk set (disk-two dropped).
+    idx.replace_disk_skills([_artifact("disk-one")])
+    names = {s["name"]: s["source"] for s in idx.all_skills()}
+    assert names == {"learned": "emitted", "disk-one": "disk"}
+
+
+def test_add_emitted_skill_dedupes_by_name(tmp_path) -> None:
+    idx = SkillsIndex(str(tmp_path / "s.db"))
+    idx.add_emitted_skill(_artifact("dup", prompt="v1"))
+    idx.add_emitted_skill(_artifact("dup", prompt="v2"))
+    rows = [s for s in idx.all_skills() if s["name"] == "dup"]
+    assert len(rows) == 1 and rows[0]["prompt_template"] == "v2"
+
+
+def test_emitted_dedup_does_not_touch_same_name_disk(tmp_path) -> None:
+    idx = SkillsIndex(str(tmp_path / "s.db"))
+    idx.replace_disk_skills([_artifact("shared", prompt="disk")])
+    idx.add_emitted_skill(_artifact("shared", prompt="emitted"))
+    by_source = {s["source"]: s["prompt_template"] for s in idx.all_skills() if s["name"] == "shared"}
+    assert by_source == {"disk": "disk", "emitted": "emitted"}
+
+
+def test_curator_pins_disk_skills(tmp_path) -> None:
+    from graph.skills.curator import SkillCurator
+
+    idx = SkillsIndex(str(tmp_path / "s.db"))
+    idx.replace_disk_skills([_artifact("pinned")])
+    idx.add_emitted_skill(_artifact("ephemeral"))
+
+    curator = SkillCurator(db_path=str(tmp_path / "s.db"), index=idx)
+    loaded = {s["name"] for s in curator._load_index()}
+    assert loaded == {"ephemeral"}  # disk skill excluded from curation
+
+    # A full run must never delete the pinned disk skill.
+    curator.run()
+    remaining = {s["name"] for s in idx.all_skills()}
+    assert "pinned" in remaining
+
+
+async def test_run_subagent_persists_emitted_skill(tmp_path, monkeypatch) -> None:
+    from langchain_core.messages import AIMessage
+    from langchain_core.tools import tool
+
+    from graph import agent as agentmod
+
+    class _FakeAgent:
+        async def ainvoke(self, *_a, **_k):
+            return {"messages": [AIMessage(
+                content="found the answer",
+                tool_calls=[{"name": "web_search", "args": {}, "id": "tc1"}],
+            )]}
+
+    monkeypatch.setattr(agentmod, "create_agent", lambda **_k: _FakeAgent())
+
+    @tool
+    async def web_search(query: str) -> str:
+        """search"""
+        return ""
+
+    idx = SkillsIndex(str(tmp_path / "s.db"))
+    out = await agentmod._run_subagent(
+        llm=object(),
+        tool_map={"web_search": web_search},
+        available_subagents="researcher",
+        description="find the capital of France",
+        prompt="research the capital of France",
+        subagent_type="researcher",
+        emit_skill=True,
+        skills_index=idx,
+    )
+    assert "found the answer" in out
+    persisted = idx.all_skills()
+    assert any(s["name"] == "find the capital of France" and s["source"] == "emitted"
+               for s in persisted)
+
+
+async def test_run_subagent_no_persist_without_index(tmp_path, monkeypatch) -> None:
+    # emit_skill=True but no index → must not raise; nothing persisted anywhere.
+    from langchain_core.messages import AIMessage
+    from langchain_core.tools import tool
+
+    from graph import agent as agentmod
+
+    class _FakeAgent:
+        async def ainvoke(self, *_a, **_k):
+            return {"messages": [AIMessage(content="ok", tool_calls=[{"name": "web_search", "args": {}, "id": "t"}])]}
+
+    monkeypatch.setattr(agentmod, "create_agent", lambda **_k: _FakeAgent())
+
+    @tool
+    async def web_search(query: str) -> str:
+        """search"""
+        return ""
+
+    out = await agentmod._run_subagent(
+        llm=object(), tool_map={"web_search": web_search}, available_subagents="researcher",
+        description="x", prompt="y", subagent_type="researcher", emit_skill=True, skills_index=None,
+    )
+    assert "ok" in out


### PR DESCRIPTION
## Summary

The fast-follow to Slice 1. protoAgent already authors skill-v1 recipes when a subagent runs with `task(emit_skill=True)`, but those artifacts only went to a `ContextVar` (for the A2A consumer) and were **never persisted** — so the agent never actually learned across sessions. This wires persistence, completing the loop and turning on the self-improving-skills capability (the Hermes-style differentiator the codebase was already half-built for).

## What changed

- **Skill index schema v3** — adds a `source` column: `disk` (human-authored `SKILL.md`, re-seeded each boot) vs `emitted` (agent-authored, persisted). Auto-migrates from v2 (backup + rebuild). New methods: `add_emitted_skill` (de-dupe by name so repeated runs refresh, not pile up), `replace_disk_skills` (reset the disk source, leave emitted intact); `all_skills` returns `source`.
- **Persist at the emission point** in `_run_subagent` (threaded through `_build_task_tools` → `create_agent_graph` via `skills_index`). Persisting *there* — the same async context as emission — means `task_batch`'s child tasks persist correctly, which a `ContextVar` drain in the lead agent's `after_agent` would miss (the classic set-in-child-task-invisible-to-parent gotcha).
- **Boot re-seed no longer clobbers learned skills** — `loader.seed_skills_index` uses `replace_disk_skills`, so re-seeding `SKILL.md` files leaves `emitted` skills intact.
- **Curator pins disk skills** — `_load_index` excludes `source='disk'` and `_save_index` never reaps them (they're re-seeded from disk, not curated). Caught + fixed the reconcile-deletes-disk-skills bug this introduced.

## Validation
- **Suite 636 green** (8 new): source column, disk/emitted separation across re-seed, emitted dedup, same-name disk+emitted coexistence, curator pinning (load + full-run), `_run_subagent` persistence via a faked subagent (no LLM), and **v2→v3 migration**. The 95 existing skill tests still pass.
- **Live boot**: v3 schema seeds disk skills, `skills.count` correct.

## Out of scope
The operator-console *manual* subagent launch doesn't thread the index yet (only the lead agent's `task()` persists); a console view of learned-vs-authored skills.

🤖 Generated with [Claude Code](https://claude.com/claude-code)