### PR TITLE
Surface skills / MCP / plugins in the Runtime console panel

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -765,8 +765,11 @@ export function App() {
                 <Metric icon={<Bot size={16} />} label="Agent" value={runtime?.identity?.name || "protoagent"} />
                 <Metric icon={<Settings2 size={16} />} label="Provider" value={runtime?.model?.provider || "none"} />
                 <Metric icon={<Database size={16} />} label="Knowledge" value={runtime?.knowledge.resolved_path || runtime?.knowledge.configured_path || "disabled"} />
+                <Metric icon={<Gauge size={16} />} label="Skills" value={`${runtime?.skills?.count ?? 0} loaded`} />
+                <Metric icon={<Network size={16} />} label="MCP tools" value={runtime?.mcp?.enabled ? `${runtime?.mcp?.tool_count ?? 0} from ${runtime?.mcp?.servers.length ?? 0} server${(runtime?.mcp?.servers.length ?? 0) === 1 ? "" : "s"}` : "off"} />
                 <Metric icon={<Sparkles size={16} />} label="Goal mode" value={formatBool(Boolean(runtime?.goal.enabled))} />
               </div>
+              <p className="panel-kicker">Middleware</p>
               <div className="table-list">
                 {middleware.map(([name, enabled]) => (
                   <div className="table-row" key={name}>
@@ -775,6 +778,50 @@ export function App() {
                   </div>
                 ))}
               </div>
+
+              <p className="panel-kicker">MCP servers</p>
+              <div className="table-list">
+                {runtime?.mcp?.servers?.length ? (
+                  runtime.mcp.servers.map((server) => (
+                    <div className="table-row" key={server.name}>
+                      <span>{server.name} · {server.transport}</span>
+                      <StatusPill label={`${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`} tone="success" />
+                    </div>
+                  ))
+                ) : (
+                  <div className="table-row">
+                    <span>no MCP servers</span>
+                    <StatusPill label={runtime?.mcp?.enabled ? "enabled" : "off"} tone="muted" />
+                  </div>
+                )}
+              </div>
+
+              <p className="panel-kicker">Plugins</p>
+              <div className="table-list">
+                {runtime?.plugins?.length ? (
+                  runtime.plugins.map((plugin) => (
+                    <div className="table-row" key={plugin.id}>
+                      <span>
+                        {plugin.name}
+                        {plugin.loaded && plugin.tools.length ? ` · ${plugin.tools.length} tool${plugin.tools.length === 1 ? "" : "s"}` : ""}
+                        {plugin.loaded && plugin.skills ? ` · ${plugin.skills} skill${plugin.skills === 1 ? "" : "s"}` : ""}
+                        {plugin.error ? ` · ${plugin.error}` : ""}
+                      </span>
+                      <StatusPill
+                        label={plugin.loaded ? "loaded" : plugin.error ? "error" : plugin.enabled ? "enabled" : "disabled"}
+                        tone={plugin.loaded ? "success" : plugin.error ? "error" : "muted"}
+                      />
+                    </div>
+                  ))
+                ) : (
+                  <div className="table-row">
+                    <span>no plugins</span>
+                    <StatusPill label="none" tone="muted" />
+                  </div>
+                )}
+              </div>
+
+              <p className="panel-kicker">Subagents</p>
               <div className="subagent-list">
                 {subagents.map((subagent) => (
                   <div className="subagent-row" key={subagent.name}>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -39,6 +39,26 @@ export type RuntimeStatus = {
     loaded: boolean;
     interval_seconds?: number | null;
   };
+  skills?: {
+    enabled: boolean;
+    count: number;
+    top_k?: number | null;
+  };
+  mcp?: {
+    enabled: boolean;
+    servers: { name: string; transport: string; tool_count: number }[];
+    tool_count: number;
+  };
+  plugins?: {
+    id: string;
+    name: string;
+    version?: string;
+    enabled: boolean;
+    loaded: boolean;
+    tools: string[];
+    skills: number;
+    error?: string;
+  }[];
 };
 
 export type Subagent = {


### PR DESCRIPTION
## Summary

The extensibility features shipped in #251/#254/#256/#258 were exposed in `GET /api/runtime/status` but **invisible in the React console** — the Runtime panel predated them and only rendered model / middleware / subagents. So an operator enabling MCP or a plugin saw no change in the UI. This adds the missing views.

- `RuntimeStatus` type gains optional `skills` / `mcp` / `plugins` blocks (already returned by the API).
- Runtime panel: **Skills** and **MCP tools** metric tiles; a labeled **MCP servers** list (`name · transport · N tools`) and **Plugins** list (`name · tools · skills` with a loaded/enabled/error/disabled status pill). Middleware and Subagents sections are now labeled too.

## Validation
- `npm run web:build` (tsc typecheck + vite) clean.
- Verified against the running server: the panels render the live `echo` MCP server, the `hello` plugin, and the skill count.

Frontend-only. A deeper management UI (enable/disable from the console) is a later slice; this is read/visibility.

🤖 Generated with [Claude Code](https://claude.com/claude-code)