### PR TITLE
Keep the Runtime metric grid compact

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -765,8 +765,6 @@ export function App() {
                 <Metric icon={<Bot size={16} />} label="Agent" value={runtime?.identity?.name || "protoagent"} />
                 <Metric icon={<Settings2 size={16} />} label="Provider" value={runtime?.model?.provider || "none"} />
                 <Metric icon={<Database size={16} />} label="Knowledge" value={runtime?.knowledge.resolved_path || runtime?.knowledge.configured_path || "disabled"} />
-                <Metric icon={<Gauge size={16} />} label="Skills" value={`${runtime?.skills?.count ?? 0} loaded`} />
-                <Metric icon={<Network size={16} />} label="MCP tools" value={runtime?.mcp?.enabled ? `${runtime?.mcp?.tool_count ?? 0} from ${runtime?.mcp?.servers.length ?? 0} server${(runtime?.mcp?.servers.length ?? 0) === 1 ? "" : "s"}` : "off"} />
                 <Metric icon={<Sparkles size={16} />} label="Goal mode" value={formatBool(Boolean(runtime?.goal.enabled))} />
               </div>
               <p className="panel-kicker">Middleware</p>
@@ -777,6 +775,17 @@ export function App() {
                     <StatusPill label={formatBool(enabled)} tone={enabled ? "success" : "muted"} />
                   </div>
                 ))}
+              </div>
+
+              <p className="panel-kicker">Skills</p>
+              <div className="table-list">
+                <div className="table-row">
+                  <span>SKILL.md skills loaded</span>
+                  <StatusPill
+                    label={`${runtime?.skills?.count ?? 0}`}
+                    tone={(runtime?.skills?.count ?? 0) > 0 ? "success" : "muted"}
+                  />
+                </div>
               </div>
 
               <p className="panel-kicker">MCP servers</p>


### PR DESCRIPTION
Follow-up to #262. The skills + MCP-tools metric tiles bumped the 2-column grid from 4 to 6 tiles, so the metric block took ~half the Runtime page and pushed the MCP/Plugins lists below the fold (reported). They duplicated the labeled lists anyway — this drops the two tiles (grid back to 4 rows) and shows the skill count as a row in the list area beside MCP servers / Plugins. Frontend-only; web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)