### PR TITLE
Shrink the Runtime metric grid

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -658,15 +658,15 @@ textarea {
 }
 
 .metric {
-  min-height: 56px;
+  min-height: 40px;
   display: grid;
   grid-template-columns: auto minmax(0, 1fr);
   grid-template-rows: auto auto;
   align-content: center;
   column-gap: 8px;
-  row-gap: 2px;
+  row-gap: 0;
   background: var(--bg-panel);
-  padding: 10px 12px;
+  padding: 6px 12px;
 }
 
 .metric svg {
@@ -1257,7 +1257,7 @@ textarea {
   }
 
   .metric-grid {
-    grid-template-columns: 1fr;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
   }
 
   .message {


### PR DESCRIPTION
Reported: the Runtime metric grid takes up half the page. Two causes — under the 720px breakpoint the grid collapsed to one column (4 tiles → 4 tall stacked rows, and the main stage is narrower than 720px with the nav + right panel), and the tiles themselves were tall (56px). Fix: keep 2 columns when narrow (4 tiles → 2 rows) and tighten tile height/padding. CSS-only; web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)