### PR TITLE
Docs: surface extensibility features in overview pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ rename / release-pipeline wiring.
 | Subagents | `graph/subagents/config.py` | DeerFlow-pattern delegation via a `task()` tool; one worked example ships — a `researcher` (web + memory, plan→search→synthesize→cite) |
 | Starter tools | `tools/lg_tools.py`, `tools/github_tools.py` | Sixteen tools default-on: 4 keyless general (`current_time`, `calculator` safe AST eval, `web_search` via DuckDuckGo, `fetch_url`) + 4 GitHub read tools over the `gh` CLI (`github_get_pr`, `github_get_issue`, `github_list_issues`, `github_get_commit_diff`) + 5 memory (`memory_ingest`, `memory_recall`, `memory_list`, `memory_stats`, `daily_log`) bound to the KB store + 3 scheduler (`schedule_task`, `list_schedules`, `cancel_schedule`) bound to the scheduler backend |
 | Knowledge store | `knowledge/store.py` | sqlite + FTS5 (LIKE fallback). One `chunks` table for operator notes, daily-log entries, and conversation findings. Default-on; turn off with `middleware.knowledge: false` |
+| Extensibility | `graph/skills/`, `tools/mcp_tools.py`, `graph/plugins/` | Three opt-in ways to extend a running agent without forking: **`SKILL.md` skills** (AgentSkills format, auto-retrieved), **MCP servers** (external tools over stdio/HTTP), and **plugins** (drop-in packages adding tools + bundled skills). See [Skills](./docs/guides/skills.md), [MCP](./docs/guides/mcp.md), [Plugins](./docs/guides/plugins.md) and [ADR 0001](./docs/adr/0001-extensibility-and-plugin-architecture.md) |
 | Scheduler | `scheduler/` | `schedule_task` / `list_schedules` / `cancel_schedule` tools backed by either a bundled sqlite scheduler or a Workstacean adapter (env-selected). Multi-agent-safe — every job is namespaced by `AGENT_NAME`. See [Schedule future work](./docs/guides/scheduler.md) |
 | Eval harness | `evals/` | Side-effect-verified A2A test harness — audit log + reply text + KB state. `python -m evals.runner` against a running agent. See [Eval your fork](./docs/guides/evals.md) |
 | Tracing | `tracing.py` | Langfuse trace_session with distributed `a2a.trace` propagation and the OTel cross-context-detach filter |
@@ -170,16 +171,20 @@ on forks. Update the repo check in all three when forking.
 
 ## Skill loop — agents that learn from experience
 
-protoAgent includes an end-to-end **skill loop** where successful subagent
-workflows are captured as reusable skills, retrieved automatically on future
-tasks, and periodically optimised by the skill curator.
+protoAgent includes an end-to-end **skill loop** where the agent **learns from
+its own runs** — successful subagent workflows are captured as reusable skills,
+retrieved automatically on future tasks, and periodically optimised by the skill
+curator. The same index also serves **human-authored skills** dropped in as
+[`SKILL.md`](./docs/guides/skills.md) folders, so authored and agent-emitted
+skills are retrieved together.
 
 | Component | Where it lives | What it does |
 |---|---|---|
-| Skill emission | `graph/extensions/skills.py` | Captures `task()` results as `SkillV1Artifact` when `emit_skill=True` |
-| Skill index | `/sandbox/skills.db` | SQLite (FTS5) store of accumulated skill recipes, read by `KnowledgeMiddleware` |
-| Knowledge injection | `graph/middleware/knowledge.py` | Queries index before each LLM call, injects top-k matching skills as context |
-| Skill curator | `graph/skills/curator.py` | Periodic agent that deduplicates, decays, and prunes the skill index |
+| `SKILL.md` skills | `config/skills/`, `<config>/skills/`, plugins | Human-authored skills (AgentSkills format) loaded into the index on boot (`source=disk`). See [Skills](./docs/guides/skills.md) |
+| Skill emission | `graph/extensions/skills.py` | Captures `task()` results as `SkillV1Artifact` when `emit_skill=True`, **persisted** to the index (`source=emitted`) |
+| Skill index | `/sandbox/skills.db` (→ `~/.protoagent`) | SQLite (FTS5) store of authored + emitted skills, queried by `KnowledgeMiddleware` |
+| Knowledge injection | `graph/middleware/knowledge.py` | Queries index before each LLM call, injects top-k matching skills as a `<learned_skills>` block |
+| Skill curator | `graph/skills/curator.py` | Periodic agent that deduplicates, decays, and prunes *emitted* skills (disk skills are pinned) |
 
 ### Running the curator
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -96,18 +96,28 @@ The `task()` subagent tool captures successful workflows as **skill-v1 artifacts
 
 Four pieces:
 
-1. **Emission** — when a subagent completes successfully and `task(..., emit_skill=True)` was called (and the subagent's config has `allow_skill_emission: true`), `graph/extensions/skills.py` serializes a `SkillV1Artifact` (name, description, prompt_template, tools_used, source_session_id) into a ContextVar.
-2. **Collection** — the A2A handler reads the ContextVar at task completion and appends a DataPart with `mimeType: application/vnd.protolabs.skill-v1+json` to the terminal artifact. See the [skill-v1 extension reference](/reference/extensions#skill-v1).
-3. **Indexing** — `graph/skills/index.py` stores emitted skills in a SQLite database at `/sandbox/skills.db` with an FTS5 virtual table over `name + description + prompt_template`. The DB auto-initializes on first write; an empty DB is a no-op for queries.
-4. **Retrieval** — `KnowledgeMiddleware.load_skills(query)` returns the top-k matches (default 5, BM25-ranked) for the current user message + recent context, injected as a `<learned_skills>` block in the system prompt. Same 2 K-token budget discipline as `<prior_sessions>`.
+1. **Emission** — when a subagent completes successfully and `task(..., emit_skill=True)` was called (and the subagent's config has `allow_skill_emission: true`), `graph/extensions/skills.py` serializes a `SkillV1Artifact` (name, description, prompt_template, tools_used, source_session_id), and `_run_subagent` **persists it to the index** (`source=emitted`, de-duped by name).
+2. **Collection** — the same artifact is also surfaced to A2A consumers as a DataPart with `mimeType: application/vnd.protolabs.skill-v1+json` on the terminal artifact. See the [skill-v1 extension reference](/reference/extensions#skill-v1).
+3. **Indexing** — `graph/skills/index.py` is a SQLite/FTS5 store at `/sandbox/skills.db` (→ `~/.protoagent/skills.db` when `/sandbox` isn't writable). It holds two sources: `emitted` (agent-authored, above) and `disk` — human-authored [`SKILL.md`](/guides/skills) folders re-seeded on every boot. Both are retrieved together.
+4. **Retrieval** — `KnowledgeMiddleware.load_skills(query)` returns the top-k matches (default 5, BM25-ranked) for the current user message + recent context, injected as a `<learned_skills>` block in the system prompt. Same 2 K-token budget discipline as `<prior_sessions>`. (The index is wired into `KnowledgeMiddleware` via `create_agent_graph`'s `skills_index`.)
 
-**Curation** — `python -m graph.skills.curator` runs a periodic sweep that deduplicates near-identical skills and decays confidence 50 % every 90 days of idleness. Skills below 0.2 confidence are pruned. Run it on a cron or let operators trigger it manually — no automatic scheduling in the template.
+**Curation** — `python -m graph.skills.curator` runs a periodic sweep that deduplicates near-identical skills and decays confidence 50 % every 90 days of idleness. Skills below 0.2 confidence are pruned. It operates only on `emitted` skills; `disk` skills are **pinned** (they're re-seeded from `SKILL.md` files, not curated). Run it on a cron or let operators trigger it manually — no automatic scheduling in the template.
 
 **Opting out per subagent** — set `allow_skill_emission: false` in `graph/subagents/config.py` for subagents whose runs shouldn't be captured (e.g. sensitive ones). The `disallowed_tools` mechanism is unaffected — skill emission is orthogonal to tool access control.
 
 **Why SQLite + FTS5** — the index lives inside the container, survives restarts if `/sandbox` is volume-mounted, handles tens of thousands of skills without a separate service, and the fts5 virtual table gives BM25 ranking without embedding model overhead. You can swap in a vector store later if recall beats keyword BM25 for your domain; the `KnowledgeMiddleware.load_skills()` seam is the single swap point.
 
 See the [skill loop tutorial](/tutorials/skill-loop) for the end-to-end walkthrough.
+
+## Extending the agent (tools, skills, plugins)
+
+Beyond the shipped tools, three opt-in seams add capability to a *running* agent without forking — the architecture recorded in [ADR 0001](/adr/):
+
+- **Tools enter via one list.** `create_agent_graph` assembles `get_all_tools()` (built-in) plus an `extra_tools` argument, then hands the combined set to the LangGraph loop. Both external sources below feed `extra_tools`, so they're indistinguishable to the model and inherit the same Audit/Langfuse middleware.
+- **MCP** (`tools/mcp_tools.py`) — configured [Model Context Protocol](/guides/mcp) servers (stdio / streamable-HTTP) are connected via `langchain-mcp-adapters`; their tools are discovered at graph-build time, namespaced `<server>__<tool>`, and appended to `extra_tools`. The client is stateless (a fresh session per call), so discovery happens once and tools are event-loop-agnostic.
+- **Plugins** (`graph/plugins/`) — drop-in packages (`protoagent.plugin.yaml` + `register(registry)`) that contribute tools (→ `extra_tools`) and bundled `SKILL.md` dirs (→ the skill index). They run **in-process** with the agent's privileges, so they're disabled by default and load only when enabled. See [Plugins](/guides/plugins).
+
+All three are surfaced in `GET /api/runtime/status` (`skills`, `mcp`, `plugins`) and load best-effort — a bad skill/server/plugin is logged and skipped, never fatal. Untrusted third-party tools belong on MCP (out-of-process) rather than in-process plugins.
 
 ## Why LiteLLM sits between the agent and models
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -6,8 +6,11 @@ Task-oriented procedures. Assumes you already have a running agent (see [Tutoria
 |---|---|
 | [Customize & deploy](/guides/customize-and-deploy) | You've evaluated via the wizard and now want to fork, rename, and ship your own image |
 | [Fork checklist (fast path)](/guides/fork-the-template) | Terser version of the above for experienced forkers |
-| [Add a custom skill](/guides/add-a-skill) | Your agent does new things and callers need to dispatch to them |
+| [Add a custom skill (A2A card)](/guides/add-a-skill) | You want A2A callers to dispatch a named capability — a *card* skill, distinct from the `SKILL.md` skills below |
 | [Configure subagents](/guides/subagents) | You want specialized delegates beyond the shipped `researcher` |
+| [Skills (`SKILL.md`)](/guides/skills) | You want to drop in reusable, auto-retrieved skill instructions in the AgentSkills `SKILL.md` format |
+| [Connect MCP servers](/guides/mcp) | You want to plug external tools into the agent via the Model Context Protocol (stdio / HTTP) |
+| [Plugins](/guides/plugins) | You want drop-in packages that add tools + bundled skills without forking |
 | [React + Tauri UI migration](/guides/react-tauri-ui) | You want to replace Gradio with the multi-chat React console and package it for desktop |
 | [Wire Langfuse + Prometheus](/guides/observability) | You need traces and metrics in production |
 | [Eval your fork](/guides/evals) | You want a baseline pass-rate for the tools / memory / A2A surface in your fork |

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -1,6 +1,8 @@
 # Extensions
 
-A2A extensions the template implements. Each is either emitted, parsed, or both.
+A2A **protocol** extensions the template implements — typed `DataPart`s on the wire. Each is either emitted, parsed, or both.
+
+> Not what you're after? For *extending the agent's capabilities* — `SKILL.md` skills, MCP servers, and plugins — see the [Skills](/guides/skills), [MCP](/guides/mcp), and [Plugins](/guides/plugins) guides and [ADR 0001](/adr/). This page is about the A2A wire protocol.
 
 ## `cost-v1`
 


### PR DESCRIPTION
The new extensibility features had their own guides + config reference + ADR, but the **overview / front-door docs predated them**. This upserts the gaps (docs-only; no styling changes):

- **README** — new *Extensibility* row in the feature table (SKILL.md / MCP / plugins); the *Skill loop* section now reflects that human-authored `SKILL.md` skills feed the same index, that emitted skills are **persisted**, and the disk-vs-emitted curation split.
- **guides/index.md** — lists the **Skills (`SKILL.md`)**, **MCP**, and **Plugins** guides; relabels "Add a custom skill" as the A2A *card* skill to clear the term collision.
- **explanation/architecture.md** — skill-loop reflects persistence + disk/emitted sources; new **"Extending the agent"** section explaining how MCP + plugins enter the tool loop via `create_agent_graph`'s `extra_tools` seam.
- **reference/extensions.md** — disambiguation note (this page = A2A *protocol* extensions, not agent extensibility → points to the guides + ADR).

Docs build clean; new cross-links resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)