### PR TITLE
Manage scheduled jobs from the console; Workstacean opt-in

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,6 +1,7 @@
 import {
   Bot,
   Boxes,
+  CalendarClock,
   CheckCircle2,
   ChevronDown,
   ChevronRight,
@@ -24,11 +25,11 @@ import type { ReactNode } from "react";
 
 import { ChatSurface } from "../chat/ChatSurface";
 import { api } from "../lib/api";
-import type { BeadsIssue, NotesWorkspace, RuntimeStatus, Subagent } from "../lib/types";
+import type { BeadsIssue, NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
 import { ScrollArea } from "./ScrollArea";
 import { SetupWizard } from "../setup/SetupWizard";
 
-type Surface = "chat" | "subagents" | "runtime";
+type Surface = "chat" | "subagents" | "runtime" | "schedule";
 type RightPanel = "notes" | "beads";
 type SubagentMode = "single" | "batch";
 type StatusTone = "success" | "warning" | "error" | "muted";
@@ -230,6 +231,13 @@ export function App() {
   const [beadsBusy, setBeadsBusy] = useState(false);
   const [collapsedIssueGroups, setCollapsedIssueGroups] = useState<Set<string>>(() => new Set(["closed"]));
 
+  const [scheduleJobs, setScheduleJobs] = useState<ScheduledJob[]>([]);
+  const [scheduleBackend, setScheduleBackend] = useState("local");
+  const [schedulePrompt, setSchedulePrompt] = useState("");
+  const [scheduleWhen, setScheduleWhen] = useState("");
+  const [scheduleJobId, setScheduleJobId] = useState("");
+  const [scheduleBusy, setScheduleBusy] = useState(false);
+
   const activeTab = workspace?.tabs[workspace.activeTabId] || null;
 
   async function refreshRuntime() {
@@ -243,6 +251,48 @@ export function App() {
       setSubagentType(subagentPayload.subagents[0]?.name || "researcher");
     }
     return runtimePayload;
+  }
+
+  async function refreshSchedules() {
+    try {
+      const payload = await api.schedules();
+      setScheduleJobs(payload.jobs);
+      setScheduleBackend(payload.backend);
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : String(exc));
+    }
+  }
+
+  async function createSchedule() {
+    const prompt = schedulePrompt.trim();
+    const schedule = scheduleWhen.trim();
+    if (!prompt || !schedule || scheduleBusy) return;
+    setScheduleBusy(true);
+    setError("");
+    try {
+      await api.addSchedule({ prompt, schedule, job_id: scheduleJobId.trim() || undefined });
+      setSchedulePrompt("");
+      setScheduleWhen("");
+      setScheduleJobId("");
+      await refreshSchedules();
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : String(exc));
+    } finally {
+      setScheduleBusy(false);
+    }
+  }
+
+  async function cancelScheduleJob(jobId: string) {
+    if (scheduleBusy) return;
+    setScheduleBusy(true);
+    try {
+      await api.cancelSchedule(jobId);
+      await refreshSchedules();
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : String(exc));
+    } finally {
+      setScheduleBusy(false);
+    }
   }
 
   async function refreshProjectState(path = projectPath) {
@@ -309,6 +359,10 @@ export function App() {
     }, 800);
     return () => window.clearTimeout(handle);
   }, [notesBusy, notesDirty, projectPath, workspace]);
+
+  useEffect(() => {
+    if (surface === "schedule") void refreshSchedules();
+  }, [surface]);
 
   async function runSubagent() {
     const prompt = subagentPrompt.trim();
@@ -620,6 +674,12 @@ export function App() {
             onClick={() => setSurface("subagents")}
           />
           <RailButton
+            active={surface === "schedule"}
+            label="Schedule"
+            icon={<CalendarClock size={18} />}
+            onClick={() => setSurface("schedule")}
+          />
+          <RailButton
             active={surface === "runtime"}
             label="Runtime"
             icon={<Gauge size={18} />}
@@ -749,6 +809,91 @@ export function App() {
                 </button>
               </div>
               {subagentOutput ? <pre className="output-block">{subagentOutput}</pre> : null}
+            </section>
+          ) : null}
+
+          {surface === "schedule" ? (
+            <section className="panel stage-panel">
+              <div className="panel-header">
+                <div>
+                  <h1>Schedule</h1>
+                  <p className="panel-kicker">{scheduleJobs.length} job{scheduleJobs.length === 1 ? "" : "s"} · {scheduleBackend}</p>
+                </div>
+                <button className="icon-button" type="button" onClick={() => void refreshSchedules()} title="Refresh">
+                  {scheduleBusy ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
+                </button>
+              </div>
+
+              <div className="subagent-grid">
+                <label className="field">
+                  <span>When (cron or ISO datetime)</span>
+                  <input
+                    value={scheduleWhen}
+                    onChange={(event) => setScheduleWhen(event.target.value)}
+                    placeholder='e.g. "0 9 * * 1-5"  or  "2026-06-01T15:00:00Z"'
+                  />
+                </label>
+                <label className="field">
+                  <span>Job id (optional)</span>
+                  <input
+                    value={scheduleJobId}
+                    onChange={(event) => setScheduleJobId(event.target.value)}
+                    placeholder="auto"
+                  />
+                </label>
+                <button
+                  className="primary-button"
+                  type="button"
+                  onClick={() => void createSchedule()}
+                  disabled={scheduleBusy || !schedulePrompt.trim() || !scheduleWhen.trim()}
+                >
+                  <Plus size={16} />
+                  Schedule
+                </button>
+              </div>
+              <label className="field grow">
+                <span>Prompt (delivered to the agent when it fires)</span>
+                <textarea
+                  value={schedulePrompt}
+                  onChange={(event) => setSchedulePrompt(event.target.value)}
+                  placeholder="What the agent should do when this fires"
+                  rows={5}
+                />
+              </label>
+
+              <div className="subagent-list">
+                {scheduleJobs.length ? (
+                  scheduleJobs.map((job) => (
+                    <div className="subagent-row" key={job.id}>
+                      <div>
+                        <strong>{job.id}</strong>
+                        <span>
+                          {job.schedule}
+                          {job.next_fire ? ` · next ${job.next_fire}` : ""}
+                          {" · "}
+                          {job.prompt.length > 80 ? `${job.prompt.slice(0, 80)}…` : job.prompt}
+                        </span>
+                      </div>
+                      <button
+                        className="icon-button"
+                        type="button"
+                        onClick={() => void cancelScheduleJob(job.id)}
+                        disabled={scheduleBusy}
+                        title="Cancel job"
+                      >
+                        <Trash2 size={16} />
+                      </button>
+                    </div>
+                  ))
+                ) : (
+                  <div className="subagent-row">
+                    <div>
+                      <strong>No scheduled jobs</strong>
+                      <span>{scheduleBackend !== "local" && scheduleBackend !== "disabled" ? `jobs may be managed remotely by ${scheduleBackend}` : "create one above"}</span>
+                    </div>
+                  </div>
+                )}
+              </div>
             </section>
           ) : null}
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   ConfigPayload,
   NotesWorkspace,
   RuntimeStatus,
+  ScheduledJob,
   SetupStatus,
   Subagent,
 } from "./types";
@@ -201,6 +202,23 @@ export const api = {
     return request<{ ok: boolean; session_id: string; output: string }>("/api/subagents/batch", {
       method: "POST",
       body,
+    });
+  },
+
+  schedules() {
+    return request<{ jobs: ScheduledJob[]; backend: string }>("/api/scheduler/jobs");
+  },
+
+  addSchedule(body: { prompt: string; schedule: string; job_id?: string }) {
+    return request<{ job: ScheduledJob }>("/api/scheduler/jobs", {
+      method: "POST",
+      body,
+    });
+  },
+
+  cancelSchedule(jobId: string) {
+    return request<{ canceled: boolean }>(`/api/scheduler/jobs/${encodeURIComponent(jobId)}`, {
+      method: "DELETE",
     });
   },
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -61,6 +61,17 @@ export type RuntimeStatus = {
   }[];
 };
 
+export type ScheduledJob = {
+  id: string;
+  prompt: string;
+  schedule: string;
+  agent_name?: string;
+  created_at?: string;
+  next_fire?: string | null;
+  last_fire?: string | null;
+  enabled?: boolean;
+};
+
 export type Subagent = {
   name: string;
   description: string;

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -145,6 +145,7 @@ Add these before the React UI depends on them:
 | `POST /api/beads/init` | run `br init` idempotently |
 | `GET/POST /api/beads/issues` | list/create/update/close/delete issues through `br --json` |
 | `GET/POST /api/notes/workspace` | load/save the notes workspace file |
+| `GET/POST /api/scheduler/jobs`, `DELETE /api/scheduler/jobs/{id}` | list/create/cancel scheduled jobs over the active `SchedulerBackend` |
 
 Manual subagents should reuse the existing `_run_subagent` implementation, but
 expose it through a service function instead of calling the lead agent's tool.

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -39,20 +39,24 @@ not "do that thing we discussed").
    `middleware.memory` — drawer/wizard editable.)
 2. `SCHEDULER_DISABLED=1` env → no scheduler. Runtime escape hatch
    for fleet operators who can't edit config.
-3. `WORKSTACEAN_API_BASE` + `WORKSTACEAN_API_KEY` set →
-   **`WorkstaceanScheduler`**.
-4. Otherwise → **`LocalScheduler`** (sqlite, asyncio polling).
+3. `SCHEDULER_BACKEND=workstacean` **and** `WORKSTACEAN_API_BASE` +
+   `WORKSTACEAN_API_KEY` set → **`WorkstaceanScheduler`** (opt-in).
+4. Otherwise → **`LocalScheduler`** (sqlite, asyncio polling) — the default.
 
-Both backends honor the same `SchedulerBackend` protocol; the agent
-loop never knows which one is wired up. The scheduler is **default
-on** — explicitly opt out via either config path above when a fork
-wants a stateless agent with no scheduling surface.
+The bundled **`LocalScheduler` is the default**; the remote
+`WorkstaceanScheduler` is **opt-in**. Setting the Workstacean env vars alone
+no longer switches the backend — you must explicitly set
+`SCHEDULER_BACKEND=workstacean` (if you opt in without the creds, it logs and
+falls back to local). Both backends honor the same `SchedulerBackend` protocol;
+the agent loop never knows which one is wired up. The scheduler is **default
+on** — opt out via either config path above for a stateless agent.
 
 ```bash
-# Solo / local dev — falls through to LocalScheduler automatically.
+# Solo / local dev — LocalScheduler (the default).
 python server.py
 
-# Workstacean install — set both env vars and restart.
+# Workstacean install — opt in explicitly AND set the creds.
+export SCHEDULER_BACKEND=workstacean
 export WORKSTACEAN_API_BASE=http://your-workstacean-host:3000
 export WORKSTACEAN_API_KEY=<key>
 python server.py
@@ -62,6 +66,24 @@ python server.py
 > `ava` node; `WORKSTACEAN_API_KEY` is in the org's secrets manager
 > under `secret-management → workstacean`. Coordinate with the team
 > for the exact URL.
+
+## Manage from the console
+
+The agent schedules jobs via its tools, but operators can also view and manage
+them directly from the React console's **Schedule** surface — list current
+jobs, create one (a prompt + a `when` that's a cron expression or ISO
+datetime), and cancel one. It's backed by these operator-API endpoints over the
+active backend:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/scheduler/jobs` | List jobs (`{jobs, backend}`) |
+| `POST` | `/api/scheduler/jobs` | Create — `{prompt, schedule, job_id?}` → `{job}` |
+| `DELETE` | `/api/scheduler/jobs/{id}` | Cancel → `{canceled}` |
+
+A malformed `schedule` returns `400`. With a remote backend (`WorkstaceanScheduler`),
+`list_jobs` may be empty even when jobs exist — they're managed on the bus, and
+the console notes this.
 
 ## Multi-agent isolation
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -58,8 +58,9 @@ The bundled scheduler is enabled by default. See [Schedule future work](/guides/
 
 | Variable | Default | What |
 |---|---|---|
-| `WORKSTACEAN_API_BASE` | (unset) | When set together with `WORKSTACEAN_API_KEY`, swaps the bundled `LocalScheduler` for the `WorkstaceanScheduler` HTTP adapter. |
-| `WORKSTACEAN_API_KEY` | (unset) | Auth token sent as `X-API-Key` to Workstacean's `/publish`. |
+| `SCHEDULER_BACKEND` | `local` | Set to `workstacean` to **opt in** to the remote `WorkstaceanScheduler` (also requires the `WORKSTACEAN_*` vars below). Any other value / unset → the bundled `LocalScheduler`. |
+| `WORKSTACEAN_API_BASE` | (unset) | Workstacean base URL. Used only when `SCHEDULER_BACKEND=workstacean`; on its own it no longer switches the backend. |
+| `WORKSTACEAN_API_KEY` | (unset) | Auth token sent as `X-API-Key` to Workstacean's `/publish`. Required (with the base) when opting in to Workstacean. |
 | `WORKSTACEAN_TOPIC_PREFIX` | `cron.<agent_name>` | Override the bus topic the adapter fires on, when your Workstacean install uses a different convention. |
 | `SCHEDULER_DB_DIR` | `/sandbox/scheduler` | Local backend: parent directory for `<agent_name>/jobs.db`. Falls back to `~/.protoagent/scheduler/<agent_name>/jobs.db` when unwritable. |
 | `SCHEDULER_INVOKE_URL` | `http://127.0.0.1:<active_port>` | Local backend: where to POST `message/send` when a job fires. Override only if the agent's A2A endpoint isn't on localhost. |

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -31,6 +31,12 @@ class NotesSaveRequest(BaseModel):
     workspace: dict[str, Any]
 
 
+class ScheduleAddRequest(BaseModel):
+    prompt: str
+    schedule: str  # 5-field cron expression OR an ISO-8601 datetime
+    job_id: str | None = None
+
+
 class BeadsInitRequest(BaseModel):
     project_path: str
     prefix: str | None = None
@@ -86,6 +92,9 @@ def register_operator_routes(
     beads_service: BeadsService | None = None,
     notes_service: NotesService | None = None,
     allowed_dirs: Callable[[], list[str]] | None = None,
+    scheduler_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+    scheduler_add: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+    scheduler_cancel: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
 ) -> None:
     """Register React operator-console routes on a FastAPI app.
 
@@ -191,3 +200,34 @@ def register_operator_routes(
             return await asyncio.to_thread(beads.delete, project_path, issue_id)
         except Exception as exc:
             raise _http_error(exc) from exc
+
+    # --- Scheduler -----------------------------------------------------------
+    # Registered only when the accessors are wired (server.py passes them over
+    # the live scheduler backend). Lets the console list/create/cancel the jobs
+    # the agent would otherwise only reach through its schedule_* tools.
+    if scheduler_list is not None:
+
+        @app.get("/api/scheduler/jobs")
+        async def _scheduler_jobs():
+            try:
+                return await scheduler_list()
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    if scheduler_add is not None:
+
+        @app.post("/api/scheduler/jobs")
+        async def _scheduler_add(req: ScheduleAddRequest):
+            try:
+                return {"job": await scheduler_add(_model_payload(req))}
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    if scheduler_cancel is not None:
+
+        @app.delete("/api/scheduler/jobs/{job_id}")
+        async def _scheduler_cancel(job_id: str):
+            try:
+                return await scheduler_cancel(job_id)
+            except Exception as exc:
+                raise _http_error(exc) from exc

--- a/server.py
+++ b/server.py
@@ -342,13 +342,12 @@ def _stop_scheduler_async(backend: "SchedulerBackend") -> None:
 def _build_scheduler(config) -> "SchedulerBackend | None":
     """Return the active scheduler backend, or ``None`` when disabled.
 
-    Selection order:
-
-    1. ``WORKSTACEAN_API_BASE`` + ``WORKSTACEAN_API_KEY`` set →
-       ``WorkstaceanScheduler``. Forks running on the protoLabs fleet
-       infrastructure get this for free.
-    2. Otherwise → ``LocalScheduler`` with sqlite at
-       ``/sandbox/scheduler/<agent_name>/jobs.db``.
+    **The bundled ``LocalScheduler`` (sqlite) is the default.** The remote
+    ``WorkstaceanScheduler`` is **opt-in**: it's used only when
+    ``SCHEDULER_BACKEND=workstacean`` is set *and* ``WORKSTACEAN_API_BASE`` +
+    ``WORKSTACEAN_API_KEY`` are present. Having the Workstacean env vars alone
+    no longer switches the backend — local stays the default unless explicitly
+    opted in.
 
     Returns ``None`` when explicitly disabled via ``SCHEDULER_DISABLED=1``
     so a fork can ship without a scheduler at all.
@@ -372,21 +371,30 @@ def _build_scheduler(config) -> "SchedulerBackend | None":
         return None
 
     name = agent_name()
+    # Workstacean is opt-in: require an explicit SCHEDULER_BACKEND=workstacean,
+    # not merely the presence of the API env vars (default stays local).
+    workstacean_opt_in = os.environ.get("SCHEDULER_BACKEND", "").strip().lower() == "workstacean"
     workstacean_base = os.environ.get("WORKSTACEAN_API_BASE", "").strip()
     workstacean_key = os.environ.get("WORKSTACEAN_API_KEY", "").strip()
-    if workstacean_base and workstacean_key:
-        try:
-            from scheduler import WorkstaceanScheduler
-            return WorkstaceanScheduler(
-                agent_name=name,
-                base_url=workstacean_base,
-                api_key=workstacean_key,
-                topic_prefix=os.environ.get("WORKSTACEAN_TOPIC_PREFIX") or None,
-            )
-        except Exception as exc:
+    if workstacean_opt_in:
+        if workstacean_base and workstacean_key:
+            try:
+                from scheduler import WorkstaceanScheduler
+                return WorkstaceanScheduler(
+                    agent_name=name,
+                    base_url=workstacean_base,
+                    api_key=workstacean_key,
+                    topic_prefix=os.environ.get("WORKSTACEAN_TOPIC_PREFIX") or None,
+                )
+            except Exception as exc:
+                log.warning(
+                    "[server] WorkstaceanScheduler init failed: %s; falling back to local",
+                    exc,
+                )
+        else:
             log.warning(
-                "[server] WorkstaceanScheduler init failed: %s; falling back to local",
-                exc,
+                "[server] SCHEDULER_BACKEND=workstacean but WORKSTACEAN_API_BASE/"
+                "API_KEY missing; falling back to local scheduler",
             )
 
     try:
@@ -1392,6 +1400,38 @@ def _main():
             tasks=req.get("tasks", []),
         )
 
+    async def _operator_scheduler_list() -> dict:
+        import asyncio
+        if _scheduler is None:
+            return {"jobs": [], "backend": "disabled"}
+        jobs = await asyncio.to_thread(_scheduler.list_jobs)
+        return {
+            "jobs": [j.as_dict() for j in jobs],
+            "backend": getattr(_scheduler, "name", "local"),
+        }
+
+    async def _operator_scheduler_add(req: dict) -> dict:
+        import asyncio
+        if _scheduler is None:
+            raise RuntimeError("scheduler is not loaded (disabled or setup incomplete)")
+        prompt = (req.get("prompt") or "").strip()
+        schedule = (req.get("schedule") or "").strip()
+        if not prompt:
+            raise ValueError("prompt is required")
+        if not schedule:
+            raise ValueError("schedule is required")
+        job = await asyncio.to_thread(
+            _scheduler.add_job, prompt, schedule, job_id=req.get("job_id") or None
+        )
+        return job.as_dict()
+
+    async def _operator_scheduler_cancel(job_id: str) -> dict:
+        import asyncio
+        if _scheduler is None:
+            raise RuntimeError("scheduler is not loaded (disabled or setup incomplete)")
+        canceled = await asyncio.to_thread(_scheduler.cancel_job, job_id)
+        return {"canceled": bool(canceled)}
+
     register_operator_routes(
         fastapi_app,
         runtime_status=_operator_runtime_status,
@@ -1399,6 +1439,9 @@ def _main():
         subagent_run=_operator_subagent_run,
         subagent_batch=_operator_subagent_batch,
         allowed_dirs=_operator_allowed_dirs,
+        scheduler_list=_operator_scheduler_list,
+        scheduler_add=_operator_scheduler_add,
+        scheduler_cancel=_operator_scheduler_cancel,
     )
 
     # --- Scheduler lifecycle ------------------------------------------------

--- a/tests/test_operator_api_scheduler.py
+++ b/tests/test_operator_api_scheduler.py
@@ -1,0 +1,145 @@
+"""Tests for the scheduler operator-API routes.
+
+Registers the routes against a FastAPI TestClient backed by a fake in-memory
+scheduler that mirrors the SchedulerBackend contract (add/list/cancel, ValueError
+on malformed schedule). Mirrors tests/test_operator_api_routes.py.
+"""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from operator_api.routes import register_operator_routes
+
+
+class _FakeJob:
+    def __init__(self, jid, prompt, schedule):
+        self.id = jid
+        self.prompt = prompt
+        self.schedule = schedule
+        self.next_fire = "2026-06-01T09:00:00+00:00"
+        self.enabled = True
+
+    def as_dict(self):
+        return {
+            "id": self.id,
+            "prompt": self.prompt,
+            "schedule": self.schedule,
+            "next_fire": self.next_fire,
+            "enabled": self.enabled,
+        }
+
+
+class _FakeScheduler:
+    name = "local"
+
+    def __init__(self):
+        self._jobs: dict[str, _FakeJob] = {}
+        self._n = 0
+
+    def list_jobs(self):
+        return list(self._jobs.values())
+
+    def add_job(self, prompt, schedule, *, job_id=None):
+        if schedule == "bad":
+            raise ValueError("malformed schedule")
+        self._n += 1
+        jid = job_id or f"job-{self._n}"
+        job = _FakeJob(jid, prompt, schedule)
+        self._jobs[jid] = job
+        return job
+
+    def cancel_job(self, job_id):
+        return self._jobs.pop(job_id, None) is not None
+
+
+def _client(scheduler=None):
+    import asyncio
+
+    app = FastAPI()
+    sched = scheduler  # None → no-backend behavior
+
+    async def _list():
+        if sched is None:
+            return {"jobs": [], "backend": "disabled"}
+        jobs = await asyncio.to_thread(sched.list_jobs)
+        return {"jobs": [j.as_dict() for j in jobs], "backend": sched.name}
+
+    async def _add(req):
+        if sched is None:
+            raise RuntimeError("scheduler is not loaded")
+        if not req.get("prompt"):
+            raise ValueError("prompt is required")
+        job = await asyncio.to_thread(sched.add_job, req["prompt"], req["schedule"], job_id=req.get("job_id") or None)
+        return job.as_dict()
+
+    async def _cancel(job_id):
+        if sched is None:
+            raise RuntimeError("scheduler is not loaded")
+        return {"canceled": bool(await asyncio.to_thread(sched.cancel_job, job_id))}
+
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {"graph_loaded": True},
+        subagent_list=lambda: [],
+        subagent_run=lambda req: None,
+        subagent_batch=lambda req: None,
+        scheduler_list=_list,
+        scheduler_add=_add,
+        scheduler_cancel=_cancel,
+    )
+    return TestClient(app)
+
+
+def test_list_empty_then_populated() -> None:
+    sched = _FakeScheduler()
+    client = _client(sched)
+
+    assert client.get("/api/scheduler/jobs").json() == {"jobs": [], "backend": "local"}
+
+    created = client.post("/api/scheduler/jobs", json={"prompt": "sweep", "schedule": "0 9 * * *"})
+    assert created.status_code == 200
+    job = created.json()["job"]
+    assert job["prompt"] == "sweep" and job["schedule"] == "0 9 * * *" and job["next_fire"]
+
+    listed = client.get("/api/scheduler/jobs").json()
+    assert len(listed["jobs"]) == 1 and listed["jobs"][0]["id"] == job["id"]
+
+
+def test_add_honors_job_id_and_cancel() -> None:
+    client = _client(_FakeScheduler())
+    client.post("/api/scheduler/jobs", json={"prompt": "p", "schedule": "* * * * *", "job_id": "nightly"})
+    assert any(j["id"] == "nightly" for j in client.get("/api/scheduler/jobs").json()["jobs"])
+
+    assert client.delete("/api/scheduler/jobs/nightly").json() == {"canceled": True}
+    assert client.delete("/api/scheduler/jobs/nightly").json() == {"canceled": False}
+    assert client.get("/api/scheduler/jobs").json()["jobs"] == []
+
+
+def test_malformed_schedule_is_400() -> None:
+    client = _client(_FakeScheduler())
+    resp = client.post("/api/scheduler/jobs", json={"prompt": "p", "schedule": "bad"})
+    assert resp.status_code == 400
+    assert "malformed" in resp.json()["detail"]
+
+
+def test_no_backend_paths() -> None:
+    client = _client(None)
+    # list is graceful
+    assert client.get("/api/scheduler/jobs").json() == {"jobs": [], "backend": "disabled"}
+    # add maps RuntimeError "not loaded" → 409
+    assert client.post("/api/scheduler/jobs", json={"prompt": "p", "schedule": "* * * * *"}).status_code == 409
+
+
+def test_routes_absent_when_accessors_not_wired() -> None:
+    # When scheduler accessors aren't passed, the routes shouldn't exist.
+    app = FastAPI()
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=lambda req: None,
+        subagent_batch=lambda req: None,
+    )
+    assert TestClient(app).get("/api/scheduler/jobs").status_code == 404

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -368,3 +368,41 @@ async def test_fire_returns_bool(tmp_path, monkeypatch):
 
     monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _FakeClient(_ErrResponse()))
     assert await s._fire(job) is False
+
+
+# ── backend selection: Workstacean is opt-in (local is the default) ──────────
+
+
+def test_workstacean_is_opt_in(monkeypatch):
+    """Workstacean env vars alone must NOT switch the backend; only an explicit
+    SCHEDULER_BACKEND=workstacean does. Otherwise the default stays local."""
+    import server
+    from graph.config import LangGraphConfig
+    from scheduler import LocalScheduler, WorkstaceanScheduler
+
+    cfg = LangGraphConfig()  # scheduler_enabled defaults True
+    monkeypatch.setenv("WORKSTACEAN_API_BASE", "https://example.com")
+    monkeypatch.setenv("WORKSTACEAN_API_KEY", "k")
+    monkeypatch.delenv("SCHEDULER_BACKEND", raising=False)
+    monkeypatch.delenv("SCHEDULER_DISABLED", raising=False)
+
+    backend = server._build_scheduler(cfg)
+    assert isinstance(backend, LocalScheduler)  # env present but not opted in → local
+
+    monkeypatch.setenv("SCHEDULER_BACKEND", "workstacean")
+    backend = server._build_scheduler(cfg)
+    assert isinstance(backend, WorkstaceanScheduler)  # explicit opt-in honored
+
+
+def test_workstacean_opt_in_without_creds_falls_back_local(monkeypatch):
+    import server
+    from graph.config import LangGraphConfig
+    from scheduler import LocalScheduler
+
+    cfg = LangGraphConfig()
+    monkeypatch.setenv("SCHEDULER_BACKEND", "workstacean")
+    monkeypatch.delenv("WORKSTACEAN_API_BASE", raising=False)
+    monkeypatch.delenv("WORKSTACEAN_API_KEY", raising=False)
+    monkeypatch.delenv("SCHEDULER_DISABLED", raising=False)
+
+    assert isinstance(server._build_scheduler(cfg), LocalScheduler)


### PR DESCRIPTION
## Summary

Scheduled jobs were only reachable through the agent's `schedule_*` tools — **no HTTP API, no UI**. An operator couldn't see or manage what the agent had scheduled. This adds operator-API endpoints + a **Schedule** surface in the React console, and (per request) makes the remote Workstacean backend **opt-in** so the bundled local scheduler is the default.

## What's included
- **Operator API** (`operator_api/routes.py` + `server.py`): `GET /api/scheduler/jobs`, `POST /api/scheduler/jobs` (`{prompt, schedule, job_id?}`), `DELETE /api/scheduler/jobs/{id}` — closures over the live `_scheduler`, run via `asyncio.to_thread`. Malformed `schedule` → `400`, no backend → `409`. Routes register only when the accessors are wired.
- **Console** (`App.tsx`, `api.ts`, `types.ts`): a new **Schedule** nav surface — list jobs (schedule · next_fire · prompt preview), a create row (prompt + `when` accepting cron *or* ISO datetime + optional id), and per-job cancel. Loads on open + after mutate; hints when a remote backend manages jobs out of band.
- **Backend selection**: `LocalScheduler` is now the **unconditional default**; `WorkstaceanScheduler` is opt-in via `SCHEDULER_BACKEND=workstacean` (the `WORKSTACEAN_*` env vars alone no longer switch it; opting in without creds logs + falls back to local).
- **Docs**: `scheduler.md` (console management section + opt-in selection), `environment-variables.md` (`SCHEDULER_BACKEND`), `react-tauri-ui.md` API contracts.

## Validation
- **Suite 654 green** (5 scheduler-API tests: list/add/cancel/malformed-400/no-backend/routes-absent; 2 backend-selection tests: opt-in honored, env-without-opt-in stays local, opt-in-without-creds falls back).
- **Web build** clean.
- **Live E2E** (default `LocalScheduler`): create cron job → computed `next_fire`; appears in list; malformed schedule → 400; cancel → `{canceled:true}`; runtime status reports `backend: local`.

## Out of scope (follow-ups)
A cron/datetime *picker* widget (single cron-or-ISO field matches the tool today); pause/resume + edit (backend has no update — cancel + recreate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)