### PR TITLE
Stop Schedule/Runtime panels stretching when sparse

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -824,6 +824,7 @@ export function App() {
                 </button>
               </div>
 
+              <div className="stage-body">
               <div className="subagent-grid">
                 <label className="field">
                   <span>When (cron or ISO datetime)</span>
@@ -894,6 +895,7 @@ export function App() {
                   </div>
                 )}
               </div>
+              </div>
             </section>
           ) : null}
 
@@ -906,6 +908,7 @@ export function App() {
                 </div>
                 <StatusPill label={runtime?.scheduler.backend || "scheduler"} tone="muted" />
               </div>
+              <div className="stage-body">
               <div className="metric-grid">
                 <Metric icon={<Bot size={16} />} label="Agent" value={runtime?.identity?.name || "protoagent"} />
                 <Metric icon={<Settings2 size={16} />} label="Provider" value={runtime?.model?.provider || "none"} />
@@ -986,6 +989,7 @@ export function App() {
                     <StatusPill label={`${subagent.max_turns} turns`} tone={subagent.enabled ? "success" : "muted"} />
                   </div>
                 ))}
+              </div>
               </div>
             </section>
           ) : null}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -212,6 +212,15 @@ h2 {
   grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
+/* Scrollable body for panels whose content is a top-down stack (Schedule,
+   Runtime) rather than a single fill-the-space element. Occupies the panel's
+   1fr row and scrolls; block layout so children keep their natural height
+   instead of stretching to fill empty space. */
+.stage-body {
+  min-height: 0;
+  overflow-y: auto;
+}
+
 .side-panel {
   height: 100%;
   display: grid;


### PR DESCRIPTION
Reported: the Schedule form's inputs (and the Runtime panel) take over the space when there are no jobs/items listed. Cause — `.stage-panel` is a 3-row grid (`auto / 1fr / auto`) expecting header + one flexible middle; these surfaces have many stacked children, so the 2nd child fell into the `1fr` track and stretched. Fix: wrap each surface's body in a single `.stage-body` scroll container so content stacks at natural height (scrolling when long) with empty space below. Subagents surface untouched. Frontend-only; web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)