### PR TITLE
Apply .stage-body wrap to the Subagents surface

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -708,6 +708,7 @@ export function App() {
                 </div>
                 <StatusPill label={subagentBusy ? "running" : "ready"} tone={subagentBusy ? "warning" : "muted"} />
               </div>
+              <div className="stage-body">
               <div className="subagent-mode segmented">
                 <button type="button" className={subagentMode === "single" ? "active" : ""} onClick={() => setSubagentMode("single")}>
                   Single
@@ -809,6 +810,7 @@ export function App() {
                 </button>
               </div>
               {subagentOutput ? <pre className="output-block">{subagentOutput}</pre> : null}
+              </div>
             </section>
           ) : null}
 


### PR DESCRIPTION
Follow-up to #272 — the Subagents surface had the same stretch (its Single/Batch toggle was the 2nd child landing in the 3-row grid's 1fr track). Wrap its body in the same `.stage-body` scroll container. All four stage surfaces now consistent. Frontend-only; web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)