### PR TITLE
Surface goals as a console panel

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -18,6 +18,7 @@ import {
   Save,
   Settings2,
   Sparkles,
+  Target,
   Trash2,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -25,11 +26,11 @@ import type { ReactNode } from "react";
 
 import { ChatSurface } from "../chat/ChatSurface";
 import { api } from "../lib/api";
-import type { BeadsIssue, NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
+import type { BeadsIssue, GoalState, NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
 import { ScrollArea } from "./ScrollArea";
 import { SetupWizard } from "../setup/SetupWizard";
 
-type Surface = "chat" | "subagents" | "runtime" | "schedule";
+type Surface = "chat" | "subagents" | "runtime" | "schedule" | "goals";
 type RightPanel = "notes" | "beads";
 type SubagentMode = "single" | "batch";
 type StatusTone = "success" | "warning" | "error" | "muted";
@@ -238,6 +239,9 @@ export function App() {
   const [scheduleJobId, setScheduleJobId] = useState("");
   const [scheduleBusy, setScheduleBusy] = useState(false);
 
+  const [goalsList, setGoalsList] = useState<GoalState[]>([]);
+  const [goalsBusy, setGoalsBusy] = useState(false);
+
   const activeTab = workspace?.tabs[workspace.activeTabId] || null;
 
   async function refreshRuntime() {
@@ -292,6 +296,28 @@ export function App() {
       setError(exc instanceof Error ? exc.message : String(exc));
     } finally {
       setScheduleBusy(false);
+    }
+  }
+
+  async function refreshGoals() {
+    try {
+      const payload = await api.goals();
+      setGoalsList(payload.goals);
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : String(exc));
+    }
+  }
+
+  async function clearGoal(sessionId: string) {
+    if (goalsBusy) return;
+    setGoalsBusy(true);
+    try {
+      await api.clearGoal(sessionId);
+      await refreshGoals();
+    } catch (exc) {
+      setError(exc instanceof Error ? exc.message : String(exc));
+    } finally {
+      setGoalsBusy(false);
     }
   }
 
@@ -362,6 +388,7 @@ export function App() {
 
   useEffect(() => {
     if (surface === "schedule") void refreshSchedules();
+    if (surface === "goals") void refreshGoals();
   }, [surface]);
 
   async function runSubagent() {
@@ -680,6 +707,12 @@ export function App() {
             onClick={() => setSurface("schedule")}
           />
           <RailButton
+            active={surface === "goals"}
+            label="Goals"
+            icon={<Target size={18} />}
+            onClick={() => setSurface("goals")}
+          />
+          <RailButton
             active={surface === "runtime"}
             label="Runtime"
             icon={<Gauge size={18} />}
@@ -897,6 +930,67 @@ export function App() {
                   </div>
                 )}
               </div>
+              </div>
+            </section>
+          ) : null}
+
+          {surface === "goals" ? (
+            <section className="panel stage-panel">
+              <div className="panel-header">
+                <div>
+                  <h1>Goals</h1>
+                  <p className="panel-kicker">{goalsList.length} goal{goalsList.length === 1 ? "" : "s"}</p>
+                </div>
+                <button className="icon-button" type="button" onClick={() => void refreshGoals()} title="Refresh">
+                  {goalsBusy ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
+                </button>
+              </div>
+              <div className="stage-body">
+                <div className="subagent-list">
+                  {goalsList.length ? (
+                    goalsList.map((goal) => (
+                      <div className="subagent-row" key={goal.session_id}>
+                        <div>
+                          <strong>{goal.condition || goal.session_id}</strong>
+                          <span>
+                            {goal.session_id} · {goal.verifier?.type || "llm"} · iter {goal.iteration ?? 0}/{goal.max_iterations ?? 0}
+                            {goal.last_reason ? ` · ${goal.last_reason.length > 70 ? `${goal.last_reason.slice(0, 70)}…` : goal.last_reason}` : ""}
+                          </span>
+                        </div>
+                        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
+                          <StatusPill
+                            label={goal.status}
+                            tone={
+                              goal.status === "achieved"
+                                ? "success"
+                                : goal.status === "active"
+                                  ? "warning"
+                                  : goal.status === "unachievable"
+                                    ? "error"
+                                    : "muted"
+                            }
+                          />
+                          <button
+                            className="icon-button"
+                            type="button"
+                            onClick={() => void clearGoal(goal.session_id)}
+                            disabled={goalsBusy}
+                            title="Clear goal"
+                          >
+                            <Trash2 size={16} />
+                          </button>
+                        </div>
+                      </div>
+                    ))
+                  ) : (
+                    <div className="subagent-row">
+                      <div>
+                        <strong>No goals</strong>
+                        <span>set one in chat with <code>/goal …</code></span>
+                      </div>
+                    </div>
+                  )}
+                </div>
               </div>
             </section>
           ) : null}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -3,6 +3,7 @@ import type {
   BeadsIssue,
   ChatMessage,
   ConfigPayload,
+  GoalState,
   NotesWorkspace,
   RuntimeStatus,
   ScheduledJob,
@@ -218,6 +219,16 @@ export const api = {
 
   cancelSchedule(jobId: string) {
     return request<{ canceled: boolean }>(`/api/scheduler/jobs/${encodeURIComponent(jobId)}`, {
+      method: "DELETE",
+    });
+  },
+
+  goals() {
+    return request<{ goals: GoalState[]; enabled: boolean }>("/api/goals");
+  },
+
+  clearGoal(sessionId: string) {
+    return request<{ cleared: boolean }>(`/api/goals/${encodeURIComponent(sessionId)}`, {
       method: "DELETE",
     });
   },

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -61,6 +61,18 @@ export type RuntimeStatus = {
   }[];
 };
 
+export type GoalState = {
+  session_id: string;
+  condition: string;
+  status: string;
+  verifier?: { type?: string } & Record<string, unknown>;
+  iteration?: number;
+  max_iterations?: number;
+  last_reason?: string;
+  started_at?: number;
+  finished_at?: number | null;
+};
+
 export type ScheduledJob = {
   id: string;
   prompt: string;

--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -38,6 +38,15 @@ Send a control message through any channel (A2A, Gradio chat, OpenAI-compat):
 
 Programmatic status/clear is also available: `GET /api/goal/{session_id}` and `DELETE /api/goal/{session_id}`.
 
+## Manage from the console
+
+The React console's **Goals** surface lists every session's goal — its condition, status (`active` / `achieved` / `exhausted` / `unachievable`), iteration count, verifier type, and the latest verifier reason — and lets you **clear** any of them. Goals are still *set* in chat with `/goal` (setting can run shell/test verifiers, so it stays an explicit in-chat action); the panel is a read-and-clear view. Backed by:
+
+| Method | Path | Purpose |
+|---|---|---|
+| `GET` | `/api/goals` | List all goals across sessions (`{goals, enabled}`) |
+| `DELETE` | `/api/goals/{session_id}` | Clear one (`{cleared}`) |
+
 ## Verifier types
 
 Set via `verifier.type` in the JSON spec:

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -146,6 +146,7 @@ Add these before the React UI depends on them:
 | `GET/POST /api/beads/issues` | list/create/update/close/delete issues through `br --json` |
 | `GET/POST /api/notes/workspace` | load/save the notes workspace file |
 | `GET/POST /api/scheduler/jobs`, `DELETE /api/scheduler/jobs/{id}` | list/create/cancel scheduled jobs over the active `SchedulerBackend` |
+| `GET /api/goals`, `DELETE /api/goals/{session_id}` | list goals across sessions / clear one (goals are *set* in chat via `/goal`) |
 
 Manual subagents should reuse the existing `_run_subagent` implementation, but
 expose it through a service function instead of calling the lead agent's tool.

--- a/graph/goals/store.py
+++ b/graph/goals/store.py
@@ -98,3 +98,19 @@ class GoalStore:
         except OSError as exc:
             log.warning("[goal] clear failed for %s: %s", session_id, exc)
             return False
+
+    def all(self) -> list[GoalState]:
+        """Every persisted goal across sessions, newest-started first.
+
+        Best-effort: unreadable/corrupt files are skipped and logged. Used by
+        the console's Goals panel to list goals beyond the current session.
+        """
+        states: list[GoalState] = []
+        for path in self._base.glob("*.json"):
+            try:
+                with open(path, encoding="utf-8") as fh:
+                    states.append(GoalState.from_dict(json.load(fh)))
+            except (OSError, json.JSONDecodeError, ValueError, TypeError) as exc:
+                log.warning("[goal] skipping %s: %s", path, exc)
+        states.sort(key=lambda s: getattr(s, "started_at", 0) or 0, reverse=True)
+        return states

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -95,6 +95,8 @@ def register_operator_routes(
     scheduler_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
     scheduler_add: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
     scheduler_cancel: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
+    goal_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
+    goal_clear: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
 ) -> None:
     """Register React operator-console routes on a FastAPI app.
 
@@ -229,5 +231,26 @@ def register_operator_routes(
         async def _scheduler_cancel(job_id: str):
             try:
                 return await scheduler_cancel(job_id)
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    # --- Goals ---------------------------------------------------------------
+    # List goals across sessions + clear one. Goals are *set* in chat (`/goal`);
+    # the console surface is a read + clear view.
+    if goal_list is not None:
+
+        @app.get("/api/goals")
+        async def _goals():
+            try:
+                return await goal_list()
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    if goal_clear is not None:
+
+        @app.delete("/api/goals/{session_id}")
+        async def _goal_clear(session_id: str):
+            try:
+                return await goal_clear(session_id)
             except Exception as exc:
                 raise _http_error(exc) from exc

--- a/server.py
+++ b/server.py
@@ -1432,6 +1432,20 @@ def _main():
         canceled = await asyncio.to_thread(_scheduler.cancel_job, job_id)
         return {"canceled": bool(canceled)}
 
+    async def _operator_goals_list() -> dict:
+        import asyncio
+        if _goal_controller is None:
+            return {"goals": [], "enabled": False}
+        states = await asyncio.to_thread(_goal_controller.store.all)
+        return {"goals": [s.to_dict() for s in states], "enabled": True}
+
+    async def _operator_goals_clear(session_id: str) -> dict:
+        import asyncio
+        if _goal_controller is None:
+            return {"cleared": False, "enabled": False}
+        cleared = await asyncio.to_thread(_goal_controller.store.clear, session_id)
+        return {"cleared": bool(cleared)}
+
     register_operator_routes(
         fastapi_app,
         runtime_status=_operator_runtime_status,
@@ -1442,6 +1456,8 @@ def _main():
         scheduler_list=_operator_scheduler_list,
         scheduler_add=_operator_scheduler_add,
         scheduler_cancel=_operator_scheduler_cancel,
+        goal_list=_operator_goals_list,
+        goal_clear=_operator_goals_clear,
     )
 
     # --- Scheduler lifecycle ------------------------------------------------

--- a/tests/test_goal_store.py
+++ b/tests/test_goal_store.py
@@ -42,3 +42,23 @@ def test_forward_compatible_unknown_keys(tmp_path):
     p.write_text('{"session_id": "s3", "condition": "x", "future_key": 1}')
     loaded = store.get("s3")
     assert loaded is not None and loaded.condition == "x"
+
+
+def test_all_lists_every_session(tmp_path):
+    store = GoalStore(tmp_path)
+    store.set(GoalState(session_id="s1", condition="first"))
+    store.set(GoalState(session_id="s2", condition="second"))
+    store.set(GoalState(session_id="s3", condition="third"))
+
+    states = store.all()
+    assert {s.session_id for s in states} == {"s1", "s2", "s3"}
+    assert {s.condition for s in states} == {"first", "second", "third"}
+
+
+def test_all_empty_and_skips_corrupt(tmp_path):
+    store = GoalStore(tmp_path)
+    assert store.all() == []
+    store.set(GoalState(session_id="ok", condition="c"))
+    (tmp_path / "broken.json").write_text("{ not json")  # must be skipped, not raise
+    states = store.all()
+    assert [s.session_id for s in states] == ["ok"]

--- a/tests/test_operator_api_routes.py
+++ b/tests/test_operator_api_routes.py
@@ -126,3 +126,55 @@ def test_operator_routes_map_value_errors_to_400() -> None:
 
     assert response.status_code == 400
     assert response.json()["detail"] == "bad prompt"
+
+
+# ── goals routes (list + clear) ──────────────────────────────────────────────
+
+
+def _goals_client(*, goals=None, on_clear=None):
+    app = FastAPI()
+
+    async def glist():
+        return {"goals": goals if goals is not None else [], "enabled": True}
+
+    async def gclear(session_id):
+        if on_clear:
+            on_clear(session_id)
+        return {"cleared": True}
+
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=lambda r: None,
+        subagent_batch=lambda r: None,
+        goal_list=glist,
+        goal_clear=gclear,
+    )
+    return TestClient(app)
+
+
+def test_goals_list_and_clear() -> None:
+    seen = {}
+    client = _goals_client(
+        goals=[{"session_id": "s1", "condition": "ship it", "status": "active", "iteration": 2}],
+        on_clear=lambda sid: seen.update(id=sid),
+    )
+    body = client.get("/api/goals").json()
+    assert body["enabled"] is True
+    assert body["goals"][0]["session_id"] == "s1" and body["goals"][0]["status"] == "active"
+
+    assert client.delete("/api/goals/s1").json() == {"cleared": True}
+    assert seen["id"] == "s1"
+
+
+def test_goals_routes_absent_when_not_wired() -> None:
+    app = FastAPI()
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=lambda r: None,
+        subagent_batch=lambda r: None,
+    )
+    assert TestClient(app).get("/api/goals").status_code == 404


### PR DESCRIPTION
## Summary

Goals were only reachable per-session (chat `/goal` + `GET/DELETE /api/goal/{session_id}`) — no way to see everything that's scheduled to self-drive. This adds a **Goals** console surface, mirroring the Schedule panel.

- **`GoalStore.all()`** — every persisted goal across sessions (glob + load, skips corrupt files).
- **Operator API** — `GET /api/goals` (list) + `DELETE /api/goals/{session_id}` (clear), via `server.py` accessors over `_goal_controller.store`.
- **Console** — a **Goals** nav surface listing each goal's condition, status (`active`/`achieved`/`exhausted`/`unachievable` pill), iteration `N/max`, verifier type, and latest reason, with a clear button. Read + clear; goals are still **set in chat via `/goal`** (verifiers run shell/tests, so setting stays an explicit in-chat action). Wrapped in `.stage-body` like the other surfaces.
- **Docs** — goal-mode "Manage from the console" section + react-tauri-ui API contracts.

## Validation
- **Suite 658 green** (GoalStore.all: lists all / empty / skips corrupt; goals routes: list+clear, absent-when-unwired).
- **Live E2E**: set a goal via `/goal {...}` in chat → `GET /api/goals` lists it (`active`, command verifier) → `DELETE /api/goals/{id}` → `{cleared:true}` → empty.
- Web build + docs build clean; `ruff` clean.

## Follow-ups
Setting/editing a goal from the panel (kept in chat for now since verifiers execute); status auto-refresh while a goal runs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)