### PR TITLE
Slash-command autocomplete in the chat composer

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -622,6 +622,51 @@ select:disabled {
   border-top: 1px solid var(--border);
 }
 
+/* Slash-command autocomplete (floats above the composer). */
+.composer-wrap {
+  position: relative;
+}
+.slash-menu {
+  position: absolute;
+  left: 12px;
+  right: 12px;
+  bottom: calc(100% + 6px);
+  z-index: 20;
+  max-height: 240px;
+  overflow-y: auto;
+  background: var(--bg-raised);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+}
+.slash-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  width: 100%;
+  text-align: left;
+  padding: 8px 12px;
+  background: none;
+  border: 0;
+  border-bottom: 1px solid var(--border);
+  cursor: pointer;
+}
+.slash-item:last-child {
+  border-bottom: 0;
+}
+.slash-item.active {
+  background: var(--bg-hover);
+}
+.slash-name {
+  font-family: var(--font-mono);
+  font-size: 13px;
+  color: var(--brand-violet-light);
+}
+.slash-desc {
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+
 input,
 textarea,
 select {

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -10,7 +10,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "../lib/api";
-import type { ChatMessage } from "../lib/types";
+import type { ChatMessage, SlashCommand } from "../lib/types";
 import { chatStore, MAX_ACTIVE_SESSIONS, useChatState } from "./chat-store";
 import { Markdown } from "./Markdown";
 
@@ -99,7 +99,42 @@ function ChatSessionSlot({
   const [taskId, setTaskId] = useState("");
   const abortRef = useRef<AbortController | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const status = chat.sessionStatusMap[sessionId] || "idle";
+
+  // Slash-command autocomplete. Commands the server handles (e.g. /goal) are
+  // fetched once; the dropdown is active while typing "/name" (before a space).
+  const [commands, setCommands] = useState<SlashCommand[]>([]);
+  const [slashIndex, setSlashIndex] = useState(0);
+  const [slashDismissed, setSlashDismissed] = useState(false);
+
+  useEffect(() => {
+    api.chatCommands().then((r) => setCommands(r.commands)).catch(() => {});
+  }, []);
+
+  const slashQuery = useMemo(() => {
+    if (slashDismissed || !draft.startsWith("/")) return null;
+    const after = draft.slice(1);
+    return after.includes(" ") ? null : after; // closes once a space is typed
+  }, [draft, slashDismissed]);
+
+  const slashMatches = useMemo(() => {
+    if (slashQuery === null) return [];
+    const q = slashQuery.toLowerCase();
+    return commands.filter(
+      (c) => !q || c.name.toLowerCase().includes(q) || c.description.toLowerCase().includes(q),
+    );
+  }, [slashQuery, commands]);
+
+  const slashActive = slashMatches.length > 0;
+  const slashSel = slashActive ? Math.min(slashIndex, slashMatches.length - 1) : 0;
+
+  function completeCommand(cmd: SlashCommand) {
+    setDraft(`/${cmd.name} `);
+    setSlashIndex(0);
+    setSlashDismissed(true); // a space follows, so it would close anyway
+    textareaRef.current?.focus();
+  }
 
   useEffect(() => {
     if (!visible) return;
@@ -271,24 +306,70 @@ function ChatSessionSlot({
         )}
       </div>
 
-      <form
-        className="composer"
-        onSubmit={(event) => {
-          event.preventDefault();
-          void send();
-        }}
-      >
+      <div className="composer-wrap">
+        {slashActive ? (
+          <div className="slash-menu" role="listbox">
+            {slashMatches.map((cmd, index) => (
+              <button
+                type="button"
+                key={cmd.name}
+                role="option"
+                aria-selected={index === slashSel}
+                className={`slash-item${index === slashSel ? " active" : ""}`}
+                onMouseEnter={() => setSlashIndex(index)}
+                onClick={() => completeCommand(cmd)}
+              >
+                <span className="slash-name">/{cmd.name}</span>
+                <span className="slash-desc">{cmd.usage || cmd.description}</span>
+              </button>
+            ))}
+          </div>
+        ) : null}
+        <form
+          className="composer"
+          onSubmit={(event) => {
+            event.preventDefault();
+            void send();
+          }}
+        >
         <textarea
+          ref={textareaRef}
           value={draft}
-          onChange={(event) => setDraft(event.target.value)}
+          onChange={(event) => {
+            setDraft(event.target.value);
+            setSlashDismissed(false); // re-open the menu when the input changes
+          }}
           onKeyDown={(event) => {
+            // Slash-command navigation takes priority while the menu is open.
+            if (slashActive) {
+              if (event.key === "ArrowDown") {
+                event.preventDefault();
+                setSlashIndex((i) => (i + 1) % slashMatches.length);
+                return;
+              }
+              if (event.key === "ArrowUp") {
+                event.preventDefault();
+                setSlashIndex((i) => (i - 1 + slashMatches.length) % slashMatches.length);
+                return;
+              }
+              if (event.key === "Enter" || event.key === "Tab") {
+                event.preventDefault();
+                completeCommand(slashMatches[slashSel]);
+                return;
+              }
+              if (event.key === "Escape") {
+                event.preventDefault();
+                setSlashDismissed(true);
+                return;
+              }
+            }
             // Cmd/Ctrl+Enter sends; plain Enter keeps inserting newlines.
             if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
               event.preventDefault();
               void send();
             }
           }}
-          placeholder="Message protoAgent  (⌘/Ctrl+Enter to send)"
+          placeholder="Message protoAgent  (/ for commands · ⌘/Ctrl+Enter to send)"
           rows={3}
         />
         {status === "streaming" ? (
@@ -302,7 +383,8 @@ function ChatSessionSlot({
             Send
           </button>
         )}
-      </form>
+        </form>
+      </div>
     </div>
   );
 }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeStatus,
   ScheduledJob,
   SetupStatus,
+  SlashCommand,
   Subagent,
 } from "./types";
 
@@ -231,6 +232,10 @@ export const api = {
     return request<{ cleared: boolean }>(`/api/goals/${encodeURIComponent(sessionId)}`, {
       method: "DELETE",
     });
+  },
+
+  chatCommands() {
+    return request<{ commands: SlashCommand[] }>("/api/chat/commands");
   },
 
   chat(message: string, sessionId: string) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -61,6 +61,12 @@ export type RuntimeStatus = {
   }[];
 };
 
+export type SlashCommand = {
+  name: string;
+  description: string;
+  usage?: string;
+};
+
 export type GoalState = {
   session_id: string;
   condition: string;

--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -36,6 +36,10 @@ Send a control message through any channel (A2A, Gradio chat, OpenAI-compat):
 - **Status:** `/goal`
 - **Clear:** `/goal clear` (aliases: `stop`, `off`, `cancel`, `reset`, `none`)
 
+In the React console, typing `/` in the chat composer opens a command
+autocomplete (served from `GET /api/chat/commands`) so `/goal` is discoverable;
+↑/↓ to pick, Enter/Tab to insert.
+
 Programmatic status/clear is also available: `GET /api/goal/{session_id}` and `DELETE /api/goal/{session_id}`.
 
 ## Manage from the console

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -147,6 +147,7 @@ Add these before the React UI depends on them:
 | `GET/POST /api/notes/workspace` | load/save the notes workspace file |
 | `GET/POST /api/scheduler/jobs`, `DELETE /api/scheduler/jobs/{id}` | list/create/cancel scheduled jobs over the active `SchedulerBackend` |
 | `GET /api/goals`, `DELETE /api/goals/{session_id}` | list goals across sessions / clear one (goals are *set* in chat via `/goal`) |
+| `GET /api/chat/commands` | registered slash commands (`{name, description, usage}`) for the composer's `/` autocomplete |
 
 Manual subagents should reuse the existing `_run_subagent` implementation, but
 expose it through a service function instead of calling the lead agent's tool.

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -97,6 +97,7 @@ def register_operator_routes(
     scheduler_cancel: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
     goal_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
     goal_clear: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
+    chat_commands: Callable[[], dict[str, Any]] | None = None,
 ) -> None:
     """Register React operator-console routes on a FastAPI app.
 
@@ -252,5 +253,17 @@ def register_operator_routes(
         async def _goal_clear(session_id: str):
             try:
                 return await goal_clear(session_id)
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    # --- Slash commands ------------------------------------------------------
+    # The chat console fetches the registered `/`-commands the server handles
+    # (e.g. `/goal`) to drive its autocomplete. Static per server config.
+    if chat_commands is not None:
+
+        @app.get("/api/chat/commands")
+        async def _chat_commands():
+            try:
+                return chat_commands()
             except Exception as exc:
                 raise _http_error(exc) from exc

--- a/server.py
+++ b/server.py
@@ -1446,6 +1446,21 @@ def _main():
         cleared = await asyncio.to_thread(_goal_controller.store.clear, session_id)
         return {"cleared": bool(cleared)}
 
+    def _operator_chat_commands() -> dict:
+        """Slash commands the chat understands — drives the composer autocomplete.
+
+        Currently just `/goal` (when goal mode is loaded). Register a new
+        server-handled control command here and the console picks it up.
+        """
+        commands = []
+        if _goal_controller is not None:
+            commands.append({
+                "name": "goal",
+                "description": "Set, check, or clear a self-driving goal for this chat session.",
+                "usage": "/goal <condition>   ·   /goal  (status)   ·   /goal clear",
+            })
+        return {"commands": commands}
+
     register_operator_routes(
         fastapi_app,
         runtime_status=_operator_runtime_status,
@@ -1458,6 +1473,7 @@ def _main():
         scheduler_cancel=_operator_scheduler_cancel,
         goal_list=_operator_goals_list,
         goal_clear=_operator_goals_clear,
+        chat_commands=_operator_chat_commands,
     )
 
     # --- Scheduler lifecycle ------------------------------------------------

--- a/tests/test_operator_api_routes.py
+++ b/tests/test_operator_api_routes.py
@@ -178,3 +178,32 @@ def test_goals_routes_absent_when_not_wired() -> None:
         subagent_batch=lambda r: None,
     )
     assert TestClient(app).get("/api/goals").status_code == 404
+
+
+# ── slash commands ───────────────────────────────────────────────────────────
+
+
+def test_chat_commands_endpoint() -> None:
+    app = FastAPI()
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=lambda r: None,
+        subagent_batch=lambda r: None,
+        chat_commands=lambda: {"commands": [{"name": "goal", "description": "set a goal", "usage": "/goal ..."}]},
+    )
+    body = TestClient(app).get("/api/chat/commands").json()
+    assert body["commands"][0]["name"] == "goal"
+
+
+def test_chat_commands_absent_when_not_wired() -> None:
+    app = FastAPI()
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=lambda r: None,
+        subagent_batch=lambda r: None,
+    )
+    assert TestClient(app).get("/api/chat/commands").status_code == 404


### PR DESCRIPTION
## Summary

Server-handled `/`-commands (currently `/goal`) had **no discoverability** — you had to know the syntax. Following ProtoMaker's chat (`GET /api/chat/commands` + composer autocomplete), this registers commands server-side and surfaces them in the console.

- **Server** — `GET /api/chat/commands` → `[{name, description, usage}]`, built in `server.py::_operator_chat_commands` (includes `goal` when goal mode is loaded) and exposed via the operator-API routes. Register a new server control command there and the console picks it up automatically.
- **Console** — `ChatSurface` fetches the commands once; typing `/name` (before a space) opens a filtered dropdown above the composer: ↑/↓ navigate, Enter/Tab insert `/<name> `, Esc dismiss, click to pick. Plain Enter still newlines; ⌘/Ctrl+Enter still sends; the menu closes once a space is typed (argument entry). Added `SlashCommand` type, `api.chatCommands`, and `.slash-menu` styles.

## Validation
- **Suite 660 green** (chat/commands route present-when-wired / 404-when-not).
- Web + docs build clean.
- Live: `GET /api/chat/commands` returns `/goal`; the dropdown surfaces it on `/`.

## Out of scope (follow-ups)
Client-executed commands (`/clear`, `/new`) and per-command argument hinting. And the separately-requested **tool-call component rendering** in chat is next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)