### PR TITLE
Render live tool-call cards in the operator console chat

### DIFF
--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -80,6 +80,10 @@ COST_MIME = "application/vnd.protolabs.cost-v1+json"
 # result.data.confidenceExplanation to record calibration samples.
 # Schema: {"confidence": float, "confidenceExplanation": str?, "success": bool}
 CONFIDENCE_MIME = "application/vnd.protolabs.confidence-v1+json"
+# Per-tool event ({id, name, phase, input|output}) surfaced on status frames so
+# the operator console can render live tool-call cards. Progress signal, not a
+# terminal extension — emitted on status-update, not the terminal artifact.
+TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json"
 
 # ── Data types ────────────────────────────────────────────────────────────────
 
@@ -115,6 +119,11 @@ class TaskRecord:
     # progress without being coupled to the producer's in-process event
     # stream. Cleared to None on terminal transitions.
     last_status_message: str | None = None
+    # Most recent structured tool event ({id, name, phase, input|output}),
+    # emitted as a tool-call-v1 DataPart on status frames so the console can
+    # render per-tool cards (vs. the flattened text in last_status_message).
+    # Reset to None after each frame build so a tool event is emitted once.
+    last_tool_event: dict | None = None
     # Observed world-state mutations to emit on the terminal artifact under
     # the worldstate-delta-v1 MIME type. Populated during the run whenever a
     # tool with known effects succeeds (see _chat_langgraph_stream). Shape:
@@ -179,6 +188,7 @@ class A2ATaskStore:
         accumulated_text: str | None = None,
         error: str | None = None,
         status_message: str | None = None,
+        tool_event: dict | None = None,
     ) -> TaskRecord | None:
         async with self._lock:
             record = self._tasks.get(task_id)
@@ -192,10 +202,13 @@ class A2ATaskStore:
                 record.error_message = error
             if status_message is not None:
                 record.last_status_message = status_message
-            # Terminal transitions clear the status message so post-run
+            if tool_event is not None:
+                record.last_tool_event = tool_event
+            # Terminal transitions clear the status/tool ping so post-run
             # subscribers see the final state cleanly, not a stale tool ping.
             if state in _TERMINAL:
                 record.last_status_message = None
+                record.last_tool_event = None
             old_event = record._update_event
             record._update_event = asyncio.Event()
         # Wake subscribers outside the lock so they can re-acquire it
@@ -498,10 +511,19 @@ def _build_status_event(record: TaskRecord, *, final: bool = False) -> dict:
     elif record.last_status_message and record.state not in _TERMINAL:
         # Surface tool_start / tool_end messages to SSE subscribers. Cleared
         # on terminal transitions so consumers see the final state cleanly.
-        evt["status"]["message"] = {
-            "role": "agent",
-            "parts": [{"kind": "text", "text": record.last_status_message}],
-        }
+        parts: list[dict[str, Any]] = [
+            {"kind": "text", "text": record.last_status_message},
+        ]
+        # Structured tool event → tool-call-v1 DataPart, so the console can
+        # render live tool cards. The text part above stays for text-only
+        # consumers. Clients dedupe by (id, phase).
+        if record.last_tool_event:
+            parts.append({
+                "kind": "data",
+                "data": record.last_tool_event,
+                "metadata": {"mimeType": TOOL_CALL_MIME},
+            })
+        evt["status"]["message"] = {"role": "agent", "parts": parts}
     return evt
 
 
@@ -821,13 +843,26 @@ async def _run_task_background(
                 await _store.update_state(task_id, WORKING, accumulated_text=accumulated)
 
             elif event_type in ("tool_start", "tool_end"):
-                # Status update only — preserve the tool message on the record
-                # so SSE subscribers see it (both the initial message/sendStream
-                # consumer and any :subscribe reconnect).
+                # Structured payload is {id, name, input|output}: derive a text
+                # status (back-compat for text-only consumers) AND a structured
+                # tool event for the tool-call-v1 DataPart (console cards).
+                # A plain-string payload (legacy producers) is used as the text
+                # status verbatim with no structured event.
+                if isinstance(payload, dict):
+                    if event_type == "tool_start":
+                        text = f"🔧 {payload.get('name', '')}: {str(payload.get('input', ''))[:200]}"
+                        tool_event = {**payload, "phase": "start"}
+                    else:
+                        text = f"✅ {payload.get('name', '')} → {str(payload.get('output', ''))[:300]}"
+                        tool_event = {**payload, "phase": "end"}
+                else:
+                    text = str(payload)
+                    tool_event = None
                 await _store.update_state(
                     task_id, WORKING,
                     accumulated_text=accumulated,
-                    status_message=payload,
+                    status_message=text,
+                    tool_event=tool_event,
                 )
 
             elif event_type == "delta":

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -531,6 +531,111 @@ select:disabled {
   word-break: break-word;
 }
 
+/* Tool-call cards — the agent's tool activity streamed into an assistant
+   message (name, running→done/error state, expandable input/result). */
+.tool-calls {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 0 0 0.6em;
+  white-space: normal;
+}
+.tool-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+  overflow: hidden;
+}
+.tool-card-running {
+  border-color: var(--warning);
+}
+.tool-card-head {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  width: 100%;
+  padding: 6px 9px;
+  background: none;
+  border: none;
+  color: var(--fg-secondary);
+  font: inherit;
+  font-size: 0.82rem;
+  text-align: left;
+  cursor: pointer;
+}
+.tool-card-head:disabled {
+  cursor: default;
+}
+.tool-card-caret {
+  flex: none;
+  color: var(--fg-muted);
+  transition: transform 0.12s ease;
+}
+.tool-card-caret.open {
+  transform: rotate(90deg);
+}
+.tool-card-caret-spacer {
+  width: 13px;
+  flex: none;
+}
+.tool-card-icon {
+  flex: none;
+  color: var(--brand-violet-light);
+}
+.tool-card-name {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-family: var(--font-mono);
+  color: var(--fg);
+}
+.tool-card-status {
+  flex: none;
+}
+.tool-card-status.done {
+  color: var(--success);
+}
+.tool-card-status.error {
+  color: var(--error);
+}
+.tool-card-status.running {
+  color: var(--warning);
+}
+.tool-card-body {
+  border-top: 1px solid var(--border);
+  padding: 8px 9px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.tool-card-section {
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+.tool-card-label {
+  font-size: 0.68rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.tool-card-body pre {
+  margin: 0;
+  padding: 6px 8px;
+  background: var(--bg);
+  border-radius: 6px;
+  font-family: var(--font-mono);
+  font-size: 0.78rem;
+  line-height: 1.45;
+  color: var(--fg-secondary);
+  white-space: pre-wrap;
+  word-break: break-word;
+  max-height: 220px;
+  overflow: auto;
+}
+
 /* Rendered markdown (assistant messages). The parent keeps pre-wrap for the
    literal user text; markdown content reflows normally. */
 .markdown {

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -10,9 +10,10 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "../lib/api";
-import type { ChatMessage, SlashCommand } from "../lib/types";
+import type { ChatMessage, SlashCommand, ToolCall } from "../lib/types";
 import { chatStore, MAX_ACTIVE_SESSIONS, useChatState } from "./chat-store";
 import { Markdown } from "./Markdown";
+import { ToolCalls } from "./ToolCalls";
 
 function messageId() {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -199,6 +200,37 @@ function ChatSessionSlot({
             ),
           );
         },
+        onToolCall: (evt) => {
+          const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
+          if (!latest) return;
+          chatStore.updateMessages(
+            session.id,
+            latest.messages.map((message) => {
+              if (message.id !== assistantId) return message;
+              const calls = [...(message.toolCalls || [])];
+              const idx = calls.findIndex((c) => c.id === evt.id);
+              if (evt.phase === "start") {
+                const card: ToolCall = {
+                  id: evt.id,
+                  name: evt.name,
+                  input: evt.input,
+                  status: "running",
+                };
+                if (idx >= 0) calls[idx] = { ...calls[idx], ...card };
+                else calls.push(card);
+              } else {
+                // end — flip the matching card to done (or create one if the
+                // start frame was missed).
+                if (idx >= 0) {
+                  calls[idx] = { ...calls[idx], output: evt.output, status: "done" };
+                } else {
+                  calls.push({ id: evt.id, name: evt.name, output: evt.output, status: "done" });
+                }
+              }
+              return { ...message, toolCalls: calls };
+            }),
+          );
+        },
         onDone: () => {
           const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
           if (!latest) return;
@@ -293,11 +325,14 @@ function ChatSessionSlot({
             <article className={`message message-${message.role}`} key={message.id || `${message.role}-${message.createdAt}`}>
               <div className="message-role">{message.role}</div>
               <div className="message-body">
+                {message.toolCalls && message.toolCalls.length > 0 ? (
+                  <ToolCalls calls={message.toolCalls} />
+                ) : null}
                 {message.content
                   ? message.role === "assistant"
                     ? <Markdown>{message.content}</Markdown>
                     : message.content
-                  : message.status === "streaming"
+                  : message.status === "streaming" && !(message.toolCalls && message.toolCalls.length)
                     ? <Loader2 className="spin" size={15} />
                     : null}
               </div>

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -1,0 +1,70 @@
+import { Check, ChevronRight, Loader2, Wrench, X } from "lucide-react";
+import { useState } from "react";
+
+import type { ToolCall } from "../lib/types";
+
+/**
+ * Renders the agent's tool activity as collapsible cards inside an assistant
+ * message. Each card shows the tool name, a running→done/error state pill, and
+ * (when expanded) the input preview + result preview the server streamed over
+ * the tool-call DataPart. Mirrors ProtoMaker's chat tool-call cards.
+ */
+export function ToolCalls({ calls }: { calls: ToolCall[] }) {
+  return (
+    <div className="tool-calls">
+      {calls.map((call) => (
+        <ToolCard key={call.id} call={call} />
+      ))}
+    </div>
+  );
+}
+
+function ToolCard({ call }: { call: ToolCall }) {
+  // Done cards collapse by default; running cards stay open so the operator
+  // can watch the input as it fires.
+  const [open, setOpen] = useState(call.status === "running");
+  const hasDetail = Boolean(call.input || call.output);
+
+  return (
+    <div className={`tool-card tool-card-${call.status}`}>
+      <button
+        type="button"
+        className="tool-card-head"
+        aria-expanded={open}
+        disabled={!hasDetail}
+        onClick={() => setOpen((v) => !v)}
+      >
+        {hasDetail ? (
+          <ChevronRight size={13} className={`tool-card-caret${open ? " open" : ""}`} />
+        ) : (
+          <span className="tool-card-caret-spacer" />
+        )}
+        <Wrench size={13} className="tool-card-icon" />
+        <span className="tool-card-name">{call.name}</span>
+        <StatusGlyph status={call.status} />
+      </button>
+      {open && hasDetail ? (
+        <div className="tool-card-body">
+          {call.input ? (
+            <div className="tool-card-section">
+              <span className="tool-card-label">input</span>
+              <pre>{call.input}</pre>
+            </div>
+          ) : null}
+          {call.output ? (
+            <div className="tool-card-section">
+              <span className="tool-card-label">result</span>
+              <pre>{call.output}</pre>
+            </div>
+          ) : null}
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
+function StatusGlyph({ status }: { status: ToolCall["status"] }) {
+  if (status === "running") return <Loader2 size={13} className="spin tool-card-status running" />;
+  if (status === "error") return <X size={13} className="tool-card-status error" />;
+  return <Check size={13} className="tool-card-status done" />;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -10,6 +10,7 @@ import type {
   SetupStatus,
   SlashCommand,
   Subagent,
+  ToolEvent,
 } from "./types";
 
 type RequestOptions = Omit<RequestInit, "body"> & {
@@ -27,7 +28,12 @@ type A2AFrame = {
     status?: {
       state?: string;
       message?: {
-        parts?: Array<{ kind?: string; text?: string }>;
+        parts?: Array<{
+          kind?: string;
+          text?: string;
+          data?: unknown;
+          metadata?: { mimeType?: string };
+        }>;
       };
     };
     artifact?: {
@@ -101,6 +107,18 @@ function textFromParts(parts?: Array<{ kind?: string; text?: string }>) {
     .filter((part) => (part.kind === undefined || part.kind === "text") && part.text)
     .map((part) => part.text)
     .join("");
+}
+
+const TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json";
+
+/** Pull a structured tool event ({id, name, phase, input|output}) off a frame's parts. */
+function toolEventFromParts(
+  parts?: Array<{ kind?: string; data?: unknown; metadata?: { mimeType?: string } }>,
+): ToolEvent | null {
+  const part = (parts || []).find(
+    (p) => p.kind === "data" && p.metadata?.mimeType === TOOL_CALL_MIME,
+  );
+  return part ? (part.data as ToolEvent) : null;
 }
 
 function textFromTerminalTask(result: NonNullable<A2AFrame["result"]>) {
@@ -253,6 +271,7 @@ export const api = {
       onTaskId?: (taskId: string) => void;
       onStatus?: (status: string) => void;
       onText?: (text: string, append: boolean) => void;
+      onToolCall?: (evt: ToolEvent) => void;
       onDone?: () => void;
     } = {},
   ) {
@@ -294,6 +313,8 @@ export const api = {
         const state = result.status?.state || "";
         const messageText = textFromParts(result.status?.message?.parts);
         handlers.onStatus?.(messageText || state);
+        const toolEvent = toolEventFromParts(result.status?.message?.parts);
+        if (toolEvent) handlers.onToolCall?.(toolEvent);
         if (result.final) handlers.onDone?.();
       }
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -101,10 +101,28 @@ export type Subagent = {
   allow_skill_emission: boolean;
 };
 
+export type ToolCall = {
+  id: string;
+  name: string;
+  input?: string;
+  output?: string;
+  status: "running" | "done" | "error";
+};
+
+/** Wire shape of a single tool event streamed over the A2A tool-call DataPart. */
+export type ToolEvent = {
+  id: string;
+  name: string;
+  phase: "start" | "end";
+  input?: string;
+  output?: string;
+};
+
 export type ChatMessage = {
   id?: string;
   role: "user" | "assistant" | "system";
   content: string;
+  toolCalls?: ToolCall[];
   createdAt?: number;
   status?: "streaming" | "done" | "error";
 };

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -47,6 +47,8 @@ export default defineConfig({
             { text: "MCP servers", link: "/guides/mcp" },
             { text: "Plugins", link: "/guides/plugins" },
             { text: "Goal mode", link: "/guides/goal-mode" },
+            { text: "Scheduler", link: "/guides/scheduler" },
+            { text: "Operator console (React/Tauri)", link: "/guides/react-tauri-ui" },
             { text: "Wire Langfuse + Prometheus", link: "/guides/observability" },
             { text: "Deploy via GHCR", link: "/guides/deploy" },
           ],

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -199,6 +199,14 @@ For streaming, prefer A2A `message/stream` first because it already emits task
 state and tool progress. A later pass can add an AI-SDK-compatible `/api/chat`
 stream if we want to use `@ai-sdk/react` directly.
 
+The shipped chat surface already renders assistant markdown
+(`apps/web/src/chat/Markdown.tsx`), slash-command autocomplete from
+`GET /api/chat/commands`, and **live tool-call cards**: each tool the agent
+invokes streams in as a collapsible card (name, running→done/error state,
+input/result preview) via the `tool-call-v1` DataPart on `status-update`
+frames — see [Extensions § tool-call-v1](/reference/extensions#tool-call-v1)
+for the wire contract and `apps/web/src/chat/ToolCalls.tsx` for the renderer.
+
 ### 4. Manual Subagents
 
 Add a panel next to chat:

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -149,6 +149,43 @@ Emitted as a DataPart on the terminal artifact:
 
 The template doesn't emit this by default because the shipped tools don't mutate anything. See `a2a_handler.py::TaskRecord.add_delta` for where to hook in.
 
+## `tool-call-v1`
+
+**mimeType**: `application/vnd.protolabs.tool-call-v1+json`
+**Direction**: emitted by this agent
+**Declared on card**: no (progressive status DataPart, not a card capability)
+
+Unlike the other DataParts here — which ride the **terminal artifact** — this one rides **`status-update` frames** while the task is still `WORKING`. It's how a live consumer (the React operator console) watches the agent work: each tool the agent invokes streams a `start` frame as it begins and an `end` frame as it finishes, so the UI can render running→done tool-call cards in real time.
+
+```json
+{
+  "kind": "data",
+  "metadata": {"mimeType": "application/vnd.protolabs.tool-call-v1+json"},
+  "data": {
+    "id": "run-abc123",
+    "name": "web_search",
+    "phase": "start",
+    "input": "latest protoLabs news"
+  }
+}
+```
+
+Fields:
+
+| Field | What |
+|---|---|
+| `id` | The tool run id (langchain `run_id`) — pairs the `start` and `end` frames. Consumers dedupe/merge by it. |
+| `name` | Tool name |
+| `phase` | `"start"` or `"end"` |
+| `input` | Truncated string preview of the tool input (on `start`) |
+| `output` | Truncated string preview of the tool result (on `end`) |
+
+**Producer** — `server.py::_run_turn_stream` yields structured `("tool_start"|"tool_end", {...})` tuples from langchain's `astream_events`. The runner stores the latest on `TaskRecord.last_tool_event` and `_build_status_event` attaches it alongside the existing text status part (`🔧 name: input` / `✅ name → output`), so text-only consumers still see progress — the DataPart is purely additive and backward-compatible.
+
+**Coalescing caveat** — the SSE watcher (`_watch_task`) coalesces bursts of updates, so a tool that starts and ends within a single event-loop tick may only surface one frame. Real tools are slow enough (network, I/O) that `start` and `end` land on separate frames. Consumers must tolerate a missing `start` (render the `end` as a completed card) and dedupe by `(id, phase)`.
+
+**Consumer** — the console's `streamChat` (`apps/web/src/lib/api.ts`) extracts the DataPart in the `status-update` branch and merges it into the streaming assistant message's `toolCalls` by `id`; `ChatSurface` renders the `<ToolCalls>` cards. The `last_tool_event` is cleared on terminal transitions so a completed task shows a clean final state.
+
 ## `skill-v1`
 
 **URI / mimeType**: `application/vnd.protolabs.skill-v1+json`

--- a/server.py
+++ b/server.py
@@ -861,10 +861,20 @@ async def _run_turn_stream(message: str, session_id: str, config: dict):
         name = event.get("name", "")
         if kind == "on_tool_start":
             tool_input = event.get("data", {}).get("input", "")
-            yield ("tool_start", f"🔧 {name}: {str(tool_input)[:200] if tool_input else ''}")
+            # Structured frame (id pairs start↔end) so consumers can render a
+            # per-tool card; the A2A handler also derives a text status from it.
+            yield ("tool_start", {
+                "id": event.get("run_id") or name,
+                "name": name,
+                "input": str(tool_input)[:500] if tool_input else "",
+            })
         elif kind == "on_tool_end":
             output = event.get("data", {}).get("output", "")
-            yield ("tool_end", f"✅ {name} → {str(output)[:300] if output else ''}")
+            yield ("tool_end", {
+                "id": event.get("run_id") or name,
+                "name": name,
+                "output": str(output)[:500] if output else "",
+            })
         elif kind == "on_chat_model_stream":
             chunk = event.get("data", {}).get("chunk")
             if chunk and hasattr(chunk, "content") and chunk.content:

--- a/tests/test_a2a_tool_events.py
+++ b/tests/test_a2a_tool_events.py
@@ -1,0 +1,285 @@
+"""Tests for the tool-call-v1 DataPart — structured tool events streamed to the
+console so it can render live tool-call cards.
+
+The producer (`server.py::_run_turn_stream`) yields structured
+``("tool_start"|"tool_end", {id, name, input|output})`` tuples; the runner
+stores the latest on ``record.last_tool_event`` and ``_build_status_event``
+attaches it as a ``tool-call-v1`` DataPart alongside the existing text part.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from unittest.mock import patch
+
+import httpx
+import pytest
+
+from a2a_handler import (
+    COMPLETED,
+    SUBMITTED,
+    TOOL_CALL_MIME,
+    WORKING,
+    A2ATaskStore,
+    TaskRecord,
+    _build_status_event,
+    _now_iso,
+    _run_task_background,
+    _store,
+    register_a2a_routes,
+)
+
+
+@pytest.fixture(autouse=True)
+def _reset_module_state():
+    """Keep the module-level _store hermetic between integration tests."""
+    from a2a_handler import _pending_webhook_tasks
+    _store._tasks.clear()
+    _pending_webhook_tasks.clear()
+    yield
+    _store._tasks.clear()
+    _pending_webhook_tasks.clear()
+
+
+def _make_record(**kwargs) -> TaskRecord:
+    now = _now_iso()
+    defaults = dict(
+        id="tool-task",
+        context_id="ctx",
+        state=SUBMITTED,
+        created_at=now,
+        updated_at=now,
+        message_text="hi",
+    )
+    defaults.update(kwargs)
+    return TaskRecord(**defaults)
+
+
+async def _mock_stream(*events):
+    for event in events:
+        yield event
+        await asyncio.sleep(0)
+
+
+# ── _build_status_event: tool-call DataPart ──────────────────────────────────
+
+
+def test_status_event_includes_tool_call_datapart_alongside_text():
+    """When a tool event is present, the status message carries BOTH the text
+    part (back-compat for text-only consumers) AND a tool-call-v1 DataPart."""
+    record = _make_record(state=WORKING)
+    record.last_status_message = "🔧 web_search: latest news"
+    record.last_tool_event = {
+        "id": "run-1",
+        "name": "web_search",
+        "input": "latest news",
+        "phase": "start",
+    }
+    evt = _build_status_event(record)
+    parts = evt["status"]["message"]["parts"]
+
+    text_parts = [p for p in parts if p.get("kind") == "text"]
+    data_parts = [p for p in parts if p.get("kind") == "data"]
+    assert text_parts and text_parts[0]["text"] == "🔧 web_search: latest news"
+    assert len(data_parts) == 1
+    assert data_parts[0]["metadata"]["mimeType"] == TOOL_CALL_MIME
+    assert data_parts[0]["data"] == record.last_tool_event
+
+
+def test_status_event_text_only_when_no_tool_event():
+    """No tool event → just the text part, no empty DataPart that consumers
+    looking for tool cards would have to special-case."""
+    record = _make_record(state=WORKING)
+    record.last_status_message = "thinking..."
+    record.last_tool_event = None
+    parts = _build_status_event(record)["status"]["message"]["parts"]
+    assert all(p.get("kind") == "text" for p in parts)
+    assert len(parts) == 1
+
+
+def test_status_event_terminal_state_drops_tool_event():
+    """On a terminal transition the status message branch is skipped entirely,
+    so no stale tool ping rides the final frame."""
+    record = _make_record(state=COMPLETED)
+    record.last_status_message = "🔧 web_search: ..."
+    record.last_tool_event = {"id": "run-1", "name": "web_search", "phase": "start"}
+    evt = _build_status_event(record, final=True)
+    assert "message" not in evt["status"]
+
+
+# ── update_state: tool_event persistence ─────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_update_state_persists_tool_event():
+    store = A2ATaskStore()
+    record = _make_record()
+    await store.create(record)
+    evt = {"id": "r1", "name": "calc", "input": "2+2", "phase": "start"}
+    await store.update_state("tool-task", WORKING, tool_event=evt)
+    assert (await store.get("tool-task")).last_tool_event == evt
+
+
+@pytest.mark.asyncio
+async def test_update_state_clears_tool_event_on_terminal():
+    """Terminal transitions wipe the rolling tool event (same contract as
+    last_status_message) so a completed task shows a clean final state."""
+    store = A2ATaskStore()
+    record = _make_record(state=WORKING)
+    record.last_tool_event = {"id": "r1", "name": "calc", "phase": "start"}
+    await store.create(record)
+    await store.update_state("tool-task", COMPLETED)
+    assert (await store.get("tool-task")).last_tool_event is None
+
+
+# ── Background runner: structured tool events ────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_runner_records_structured_tool_events():
+    """Structured tool_start/tool_end dicts flow through the runner: each is
+    passed to update_state as a structured tool_event (phase-tagged) AND a text
+    status is derived for back-compat."""
+    store = A2ATaskStore()
+    record = _make_record(id="bg-tools")
+    await store.create(record)
+
+    # Spy on the tool_event kwarg the runner hands to update_state — _push only
+    # fires on the initial WORKING + terminal transitions, so it can't observe
+    # the mid-run tool pings.
+    captured: list[dict] = []
+    orig_update = store.update_state
+
+    async def _spy(task_id, state, *, tool_event=None, **kwargs):
+        if tool_event is not None:
+            captured.append(tool_event)
+        return await orig_update(task_id, state, tool_event=tool_event, **kwargs)
+
+    stream_fn = lambda: _mock_stream(
+        ("text", "working"),
+        ("tool_start", {"id": "r1", "name": "web_search", "input": "news"}),
+        ("tool_end", {"id": "r1", "name": "web_search", "output": "3 results"}),
+        ("done", "working"),
+    )
+
+    async def _noop(_r):
+        pass
+
+    with patch("a2a_handler._store", store), patch("a2a_handler._push", _noop):
+        store.update_state = _spy
+        try:
+            await _run_task_background("bg-tools", stream_fn)
+        finally:
+            store.update_state = orig_update
+
+    final = await store.get("bg-tools")
+    assert final.state == COMPLETED
+    # Terminal clears the rolling tool event.
+    assert final.last_tool_event is None
+    # The runner emitted a phase-tagged start (with input) and end (with output).
+    starts = [e for e in captured if e.get("phase") == "start"]
+    ends = [e for e in captured if e.get("phase") == "end"]
+    assert starts and starts[0]["input"] == "news"
+    assert ends and ends[0]["output"] == "3 results"
+
+
+@pytest.mark.asyncio
+async def test_runner_accepts_legacy_string_tool_payloads():
+    """Back-compat: a producer that yields plain-string tool payloads still
+    works — used as the text status verbatim, no structured event, no crash."""
+    store = A2ATaskStore()
+    record = _make_record(id="bg-legacy")
+    await store.create(record)
+
+    stream_fn = lambda: _mock_stream(
+        ("tool_start", "🔧 file_bug: draft"),
+        ("tool_end", "✅ file_bug → done"),
+        ("done", "ok"),
+    )
+
+    async def _noop(_r):
+        pass
+
+    with patch("a2a_handler._store", store), patch("a2a_handler._push", _noop):
+        await _run_task_background("bg-legacy", stream_fn)
+
+    assert (await store.get("bg-legacy")).state == COMPLETED
+
+
+# ── End-to-end: tool-call DataPart over the live SSE stream ──────────────────
+
+
+def _make_tool_app():
+    """A FastAPI app whose chat stream emits a structured tool_start/tool_end
+    pair, so the SSE path can be exercised without langgraph or a real model."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+    card = {"name": "test", "capabilities": {}}
+
+    async def _fake_stream(text, context_id, **kwargs):
+        # Sleeps model real tool latency: in production tool_start and tool_end
+        # are separated by the tool actually running, so the SSE watcher (which
+        # coalesces bursts) wakes between them and emits each tool frame.
+        yield ("text", "looking that up")
+        await asyncio.sleep(0.03)
+        yield ("tool_start", {"id": "r1", "name": "current_time", "input": ""})
+        await asyncio.sleep(0.03)
+        yield ("tool_end", {"id": "r1", "name": "current_time", "output": "2026-05-29T12:00:00Z"})
+        await asyncio.sleep(0.03)
+        yield ("done", "It is noon UTC.")
+
+    async def _fake_chat(text, session_id):
+        return [{"role": "assistant", "content": "It is noon UTC."}]
+
+    register_a2a_routes(
+        app=app,
+        chat_stream_fn_factory=_fake_stream,
+        chat_fn=_fake_chat,
+        api_key="",
+        agent_card=card,
+    )
+    return app
+
+
+@pytest.mark.asyncio
+async def test_message_stream_carries_tool_call_datapart():
+    """The whole backend path: a tool-emitting producer → runner → store →
+    _build_status_event → SSE. A status-update frame must carry a tool-call-v1
+    DataPart with {name, input/output} so the console can render a tool card.
+    The text status part rides alongside it (back-compat)."""
+    app = _make_tool_app()
+
+    tool_parts: list[dict] = []
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        async with client.stream(
+            "POST", "/a2a",
+            json={
+                "jsonrpc": "2.0",
+                "id": "s1",
+                "method": "message/stream",
+                "params": {"message": {"parts": [{"kind": "text", "text": "what time is it"}]}},
+            },
+        ) as resp:
+            assert resp.status_code == 200
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                result = json.loads(line[6:]).get("result", {})
+                if result.get("kind") != "status-update":
+                    continue
+                for part in result.get("status", {}).get("message", {}).get("parts", []):
+                    if part.get("metadata", {}).get("mimeType") == TOOL_CALL_MIME:
+                        tool_parts.append(part)
+                if result.get("final"):
+                    break
+
+    # At least the tool_start (and ideally tool_end) DataParts were streamed.
+    assert tool_parts, "no tool-call-v1 DataPart appeared on any status-update frame"
+    names = {p["data"]["name"] for p in tool_parts}
+    phases = {p["data"]["phase"] for p in tool_parts}
+    assert names == {"current_time"}
+    assert "start" in phases or "end" in phases


### PR DESCRIPTION
## What

Stream the agent's tool activity into the React operator console chat as **collapsible tool-call cards** — name, running→done/error state, and an expandable input/result preview — so an operator can watch the agent work in real time. Mirrors ProtoMaker's chat tool-call cards.

![flow] tool_start → running card → tool_end → done card

## How

**Backend**
- `server.py::_run_turn_stream` yields structured `("tool_start"|"tool_end", {id, name, input|output})` frames (keyed by langchain `run_id` so start/end pair up) instead of flattening to a preview string.
- `a2a_handler.py`: `TaskRecord.last_tool_event` + `update_state(tool_event=...)`; the runner derives a text status (back-compat) *and* the structured event; `_build_status_event` attaches a `tool-call-v1` DataPart (`application/vnd.protolabs.tool-call-v1+json`) on `status-update` frames, alongside the existing text part. Cleared on terminal transitions. Legacy plain-string tool payloads (goal/retry pings) still work unchanged.

**Frontend**
- `apps/web/src/lib/api.ts`: `streamChat` extracts the DataPart in the `status-update` branch → `onToolCall`.
- `apps/web/src/chat/ChatSurface.tsx`: merges events into the streaming assistant message's `toolCalls` by `id` (start→running with input, end→done with output; dedupe by id+phase).
- New `apps/web/src/chat/ToolCalls.tsx` renders the cards; styles in `theme.css`.

## Why this approach

Enriches the existing A2A stream with a typed DataPart (the proven `cost-v1`/`worldstate-delta-v1` pattern) rather than a second SSE endpoint — A2A-spec-compliant, backward-compatible (text status part stays), no double-consumption/ordering races.

## Tests

- `tests/test_a2a_tool_events.py`: DataPart builder, `update_state` persistence + terminal clearing, the runner's structured **and** legacy string paths, plus an **end-to-end SSE test** that drives `message/stream` and asserts the `tool-call-v1` DataPart rides a `status-update` frame.
- Full `tests/test_a2a_handler.py` suite stays green; `npm run web:build` + `npm run docs:build` clean.

## Docs

- New **`tool-call-v1`** section in the [Extensions reference](docs/reference/extensions.md) (wire contract + coalescing caveat).
- Note in the operator-console guide.
- Wired the orphaned **Scheduler** + **Operator console** guides into the VitePress sidebar.

## Out of scope (follow-ups)

Per-tool custom renderers / tool-result registry; HITL approval + inline forms; step grouping; token-by-token assistant text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)