### PR TITLE
Polish tool-call cards: clean previews, stable layout, no overflow

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -365,13 +365,14 @@ h2 {
 
 .status-pill {
   min-height: 22px;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
+  max-width: 240px;
+  display: inline-block;
   white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
   border: 1px solid var(--border);
   border-radius: 999px;
-  padding: 2px 8px;
+  padding: 4px 8px;
   color: var(--fg-muted);
   font-family: var(--font-mono);
   font-size: 11px;
@@ -538,9 +539,13 @@ select:disabled {
   flex-direction: column;
   gap: 6px;
   margin: 0 0 0.6em;
+  min-width: 0;
+  max-width: 100%;
   white-space: normal;
 }
 .tool-card {
+  min-width: 0;
+  max-width: 100%;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-raised);

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -425,5 +425,12 @@ function ChatSessionSlot({
 }
 
 function StatusPill({ label, tone }: { label: string; tone: "warning" | "error" | "muted" }) {
-  return <span className={`status-pill ${tone}`}>{label}</span>;
+  // Tool status lines can be long (e.g. "🔧 web_search: {…}"); keep the pill
+  // compact and surface the full text on hover. CSS also clamps the width.
+  const short = label.length > 56 ? `${label.slice(0, 55)}…` : label;
+  return (
+    <span className={`status-pill ${tone}`} title={label}>
+      {short}
+    </span>
+  );
 }

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -19,10 +19,23 @@ export function ToolCalls({ calls }: { calls: ToolCall[] }) {
   );
 }
 
+/** Pretty-print a value the server sent as JSON; fall back to the raw text. */
+function prettyValue(raw: string): string {
+  const trimmed = raw.trim();
+  if (!(trimmed.startsWith("{") || trimmed.startsWith("["))) return raw;
+  try {
+    return JSON.stringify(JSON.parse(trimmed), null, 2);
+  } catch {
+    return raw;
+  }
+}
+
 function ToolCard({ call }: { call: ToolCall }) {
-  // Done cards collapse by default; running cards stay open so the operator
-  // can watch the input as it fires.
-  const [open, setOpen] = useState(call.status === "running");
+  // Collapsed by default and stays put — the header row (icon, name, status)
+  // is the stable at-a-glance view; expanding is an explicit, sticky choice so
+  // the message doesn't reflow as tools start and finish. The user opens the
+  // cards they care about.
+  const [open, setOpen] = useState(false);
   const hasDetail = Boolean(call.input || call.output);
 
   return (
@@ -48,13 +61,13 @@ function ToolCard({ call }: { call: ToolCall }) {
           {call.input ? (
             <div className="tool-card-section">
               <span className="tool-card-label">input</span>
-              <pre>{call.input}</pre>
+              <pre>{prettyValue(call.input)}</pre>
             </div>
           ) : null}
           {call.output ? (
             <div className="tool-card-section">
               <span className="tool-card-label">result</span>
-              <pre>{call.output}</pre>
+              <pre>{prettyValue(call.output)}</pre>
             </div>
           ) : null}
         </div>

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -177,14 +177,14 @@ Fields:
 | `id` | The tool run id (langchain `run_id`) — pairs the `start` and `end` frames. Consumers dedupe/merge by it. |
 | `name` | Tool name |
 | `phase` | `"start"` or `"end"` |
-| `input` | Truncated string preview of the tool input (on `start`) |
-| `output` | Truncated string preview of the tool result (on `end`) |
+| `input` | Truncated preview of the tool input (on `start`). Structured inputs (dict/list) are rendered as **compact JSON** so the console can pretty-print them; everything else is stringified. |
+| `output` | Truncated preview of the tool result (on `end`). Unwrapped from langchain's `ToolMessage` to its `.content` — the message repr would otherwise leak `name=`/`tool_call_id=` noise into the card. |
 
-**Producer** — `server.py::_run_turn_stream` yields structured `("tool_start"|"tool_end", {...})` tuples from langchain's `astream_events`. The runner stores the latest on `TaskRecord.last_tool_event` and `_build_status_event` attaches it alongside the existing text status part (`🔧 name: input` / `✅ name → output`), so text-only consumers still see progress — the DataPart is purely additive and backward-compatible.
+**Producer** — `server.py::_run_turn_stream` yields structured `("tool_start"|"tool_end", {...})` tuples from langchain's `astream_events`. Inputs/outputs are coerced via `_coerce_tool_value` / `_coerce_tool_output` (JSON for structured values, `.content` for `ToolMessage`s) and truncated to `_TOOL_PREVIEW_CHARS`. The runner stores the latest on `TaskRecord.last_tool_event` and `_build_status_event` attaches it alongside the existing text status part (`🔧 name: input` / `✅ name → output`), so text-only consumers still see progress — the DataPart is purely additive and backward-compatible.
 
 **Coalescing caveat** — the SSE watcher (`_watch_task`) coalesces bursts of updates, so a tool that starts and ends within a single event-loop tick may only surface one frame. Real tools are slow enough (network, I/O) that `start` and `end` land on separate frames. Consumers must tolerate a missing `start` (render the `end` as a completed card) and dedupe by `(id, phase)`.
 
-**Consumer** — the console's `streamChat` (`apps/web/src/lib/api.ts`) extracts the DataPart in the `status-update` branch and merges it into the streaming assistant message's `toolCalls` by `id`; `ChatSurface` renders the `<ToolCalls>` cards. The `last_tool_event` is cleared on terminal transitions so a completed task shows a clean final state.
+**Consumer** — the console's `streamChat` (`apps/web/src/lib/api.ts`) extracts the DataPart in the `status-update` branch and merges it into the streaming assistant message's `toolCalls` by `id`; `ChatSurface` renders the `<ToolCalls>` cards. Cards default **collapsed** (a stable one-line row: icon, name, running→done status) so the message doesn't reflow as tools start and finish — expanding is an explicit, sticky choice that pretty-prints the JSON input/result. The `last_tool_event` is cleared on terminal transitions so a completed task shows a clean final state.
 
 ## `skill-v1`
 

--- a/server.py
+++ b/server.py
@@ -840,6 +840,38 @@ async def chat(message: str, session_id: str) -> list[dict[str, Any]]:
     return await _chat_langgraph(message, session_id)
 
 
+# Cap tool input/output previews so a single frame stays small on the wire.
+_TOOL_PREVIEW_CHARS = 800
+
+
+def _coerce_tool_value(value) -> str:
+    """Render a tool input/output for a tool-call card.
+
+    Structured values (dict/list) become compact JSON with double quotes so
+    the console can pretty-print them — Python's ``str()`` would emit a repr
+    with single quotes that no JSON parser accepts. Everything else is
+    stringified. Always truncated to keep the SSE frame small.
+    """
+    if value is None or value == "":
+        return ""
+    if isinstance(value, (dict, list)):
+        try:
+            return json.dumps(value, ensure_ascii=False, default=str)[:_TOOL_PREVIEW_CHARS]
+        except (TypeError, ValueError):
+            pass
+    return str(value)[:_TOOL_PREVIEW_CHARS]
+
+
+def _coerce_tool_output(value) -> str:
+    """Unwrap a tool result to its payload.
+
+    ``on_tool_end`` hands back the LangChain ``ToolMessage``, whose ``str()``
+    leaks ``name=``/``tool_call_id=`` noise — the card wants the actual
+    ``.content``. Falls back to the raw value for plain returns.
+    """
+    return _coerce_tool_value(getattr(value, "content", value))
+
+
 async def _run_turn_stream(message: str, session_id: str, config: dict):
     """Run one graph turn over ``astream_events``.
 
@@ -866,14 +898,14 @@ async def _run_turn_stream(message: str, session_id: str, config: dict):
             yield ("tool_start", {
                 "id": event.get("run_id") or name,
                 "name": name,
-                "input": str(tool_input)[:500] if tool_input else "",
+                "input": _coerce_tool_value(tool_input),
             })
         elif kind == "on_tool_end":
             output = event.get("data", {}).get("output", "")
             yield ("tool_end", {
                 "id": event.get("run_id") or name,
                 "name": name,
-                "output": str(output)[:500] if output else "",
+                "output": _coerce_tool_output(output),
             })
         elif kind == "on_chat_model_stream":
             chunk = event.get("data", {}).get("chunk")

--- a/tests/test_tool_preview.py
+++ b/tests/test_tool_preview.py
@@ -1,0 +1,77 @@
+"""Tests for the tool-call preview coercion in ``server.py``.
+
+`_run_turn_stream` renders each tool's input/output for the console's
+tool-call cards. Structured values must become real JSON (double-quoted,
+parseable) — not a Python ``repr`` — and tool outputs must be unwrapped from
+the LangChain ``ToolMessage`` to their actual ``.content`` (the message repr
+leaks ``name=``/``tool_call_id=`` noise into the card).
+"""
+
+from __future__ import annotations
+
+import json
+
+from langchain_core.messages import ToolMessage
+
+from server import _TOOL_PREVIEW_CHARS, _coerce_tool_output, _coerce_tool_value
+
+
+def test_dict_input_becomes_parseable_json():
+    """A dict tool input renders as JSON the console can `JSON.parse` — the
+    bug was `str(dict)` emitting single-quoted Python repr no parser accepts."""
+    out = _coerce_tool_value({"max_results": 8, "query": "AI coding agents"})
+    assert json.loads(out) == {"max_results": 8, "query": "AI coding agents"}
+    assert "'" not in out  # double-quoted JSON, not a Python repr
+
+
+def test_list_input_becomes_json():
+    out = _coerce_tool_value(["a", "b"])
+    assert json.loads(out) == ["a", "b"]
+
+
+def test_plain_string_input_passes_through():
+    assert _coerce_tool_value("just text") == "just text"
+
+
+def test_empty_and_none_render_empty():
+    assert _coerce_tool_value("") == ""
+    assert _coerce_tool_value(None) == ""
+
+
+def test_non_serializable_falls_back_to_str():
+    """A value json.dumps can't handle (even with default=str shouldn't raise)
+    still yields a string, never an exception that would drop the frame."""
+
+    class Weird:
+        def __repr__(self):
+            return "<weird>"
+
+    out = _coerce_tool_value({"obj": Weird()})
+    # default=str keeps it serializable
+    assert json.loads(out) == {"obj": "<weird>"}
+
+
+def test_output_unwraps_toolmessage_to_content():
+    """The card wants the result, not `content='..' name='..' tool_call_id='..'`."""
+    msg = ToolMessage(content="1234 * 5678 = 7006652", name="calculator", tool_call_id="x")
+    assert _coerce_tool_output(msg) == "1234 * 5678 = 7006652"
+
+
+def test_output_dict_content_is_passed_through_as_langchain_stringified_it():
+    """LangChain coerces non-string ToolMessage content to a Python-repr
+    string at construction (upstream of us), so a dict result arrives as a
+    string. We pass it through verbatim — the client's pretty-printer falls
+    back to raw text when it isn't valid JSON. Documents the boundary so a
+    future reader doesn't expect us to reconstruct the dict."""
+    msg = ToolMessage(content={"ok": True}, name="t", tool_call_id="x")
+    assert _coerce_tool_output(msg) == "{'ok': True}"
+
+
+def test_output_plain_value_passes_through():
+    assert _coerce_tool_output("plain result") == "plain result"
+
+
+def test_previews_are_truncated():
+    big = {"query": "x" * 5000}
+    assert len(_coerce_tool_value(big)) <= _TOOL_PREVIEW_CHARS
+    assert len(_coerce_tool_output("y" * 5000)) <= _TOOL_PREVIEW_CHARS


### PR DESCRIPTION
Follow-up to #282 based on live use of the tool-call cards.

## Issues fixed

**1. Raw values → clean rendering**
- Inputs showed Python reprs (`{'max_results': 8, 'query': '...'}`); outputs showed the langchain `ToolMessage` repr (`content='...' name='...' tool_call_id='...'`).
- `_run_turn_stream` now coerces structured inputs to compact JSON (`_coerce_tool_value`) and unwraps outputs to `ToolMessage.content` (`_coerce_tool_output`). The card pretty-prints JSON values (indented) and falls back to raw text otherwise.

**2. Layout bounce → stable**
- Cards initialised expanded-while-running, so the message reflowed as each tool started/finished. Cards now default **collapsed** to a stable one-line row (icon, name, running→done status); expanding is an explicit, sticky choice. "Pick one and stick with it."

**3. Overflow → contained**
- A long tool status line (`🔧 web_search: {…}`) blew out the session header. `.status-pill` is now width-clamped with ellipsis (full text on hover); tool cards + `pre` blocks are `min-width:0 / max-width:100%` so long inputs wrap.

## Verified against the real agent

Ran the actual LangGraph agent (proto-labs gateway) through the console and drove it with Playwright:
- web_search input renders as indented JSON; result shows the actual search text (no `ToolMessage` noise).
- 4 cards (web_search + 3× fetch_url) stay as compact rows — no reflow, no horizontal overflow (`document` + `.tool-card` + `.message-body` all within bounds; the status pill clips to its clamp as intended).
- No console errors.

## Tests

`tests/test_tool_preview.py`: dict/list→JSON, plain-string passthrough, empty/None, non-serializable fallback, `ToolMessage`→`.content`, truncation, and the langchain dict-content stringification boundary. Full suite green (**677 passed**); `npm run web:build` clean.

## Docs

Updated the `tool-call-v1` extension reference: input/output shapes (JSON / unwrapped content) and the pretty-print + collapsed-by-default rendering contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)