### PR TITLE
Add a Playwright E2E smoke harness for the operator console (+ favicon fix)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -57,3 +57,24 @@ jobs:
         run: |
           . .venv/bin/activate
           python -m pytest tests/ -q
+
+  web-e2e:
+    name: Web E2E smoke
+    runs-on: namespace-profile-protolabs-linux
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: npm
+      - name: Install dependencies
+        run: npm ci
+      - name: Install Playwright chromium
+        run: npm --workspace @protoagent/web exec -- playwright install --with-deps chromium
+      - name: Run E2E smoke (built SPA vs mock backend)
+        # Builds the web app, then drives it with Playwright against the
+        # deterministic mock backend (apps/web/e2e/mock-server.mjs) — no Python,
+        # model, or network. Guards the operator-console rendering contract:
+        # tool-call cards, markdown, slash commands, runtime panel.
+        run: npm run test:e2e --workspace @protoagent/web

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,9 @@ docs/.vitepress/cache/
 apps/desktop/src-tauri/binaries/
 # PyInstaller sidecar build workdir
 /build/sidecar/
+
+# Playwright E2E artifacts (apps/web smoke harness)
+apps/web/test-results/
+apps/web/playwright-report/
+apps/web/blob-report/
+apps/web/.playwright/

--- a/apps/web/e2e/assets.spec.ts
+++ b/apps/web/e2e/assets.spec.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "@playwright/test";
+
+// Static-asset wiring. The favicon href is base-sensitive: a hardcoded "/app/"
+// prefix double-prepends under Vite's dev base (→ "/app/app/…", 404). This
+// guards that the icon link actually resolves so the tab favicon shows.
+
+test("favicon link resolves to the icon asset", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "domcontentloaded" });
+
+  const href = await page.locator('link[rel="icon"]').getAttribute("href");
+  expect(href, "an icon link must be declared").toBeTruthy();
+
+  // Resolve relative to the document URL the way the browser does, then fetch.
+  const resolved = new URL(href as string, page.url()).toString();
+  const resp = await page.request.get(resolved);
+  expect(resp.status(), `favicon ${resolved} should resolve`).toBe(200);
+  expect(resp.headers()["content-type"]).toContain("svg");
+});

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+
+// Drives the chat surface against the mock A2A stream and asserts the
+// tool-call card contract: stable collapsed-by-default rows, pretty-printed
+// JSON on expand, clean markdown answers, and no horizontal overflow.
+
+async function send(page, prompt: string) {
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+  await composer.fill(prompt);
+  // The composer sends on Ctrl/Cmd+Enter (checks metaKey || ctrlKey).
+  await composer.press("Control+Enter");
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "networkidle" });
+  // Setup wizard must not block — the mock reports setup_complete:true.
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+});
+
+test("tool-call card is collapsed by default, expands to pretty-printed JSON", async ({ page }) => {
+  await send(page, "search for AI coding agents");
+
+  const card = page.locator(".tool-card").first();
+  await expect(card).toBeVisible();
+  await expect(card.locator(".tool-card-name")).toHaveText("web_search");
+
+  // Stable default: collapsed — no body rendered until the user opens it.
+  await expect(page.locator(".tool-card-body")).toHaveCount(0);
+
+  // The tool finishes → done glyph (not the running spinner).
+  await expect(card.locator(".tool-card-status.done")).toBeVisible();
+
+  // Expand → input rendered as indented JSON (the bug was a Python repr).
+  await card.locator(".tool-card-head").click();
+  const body = card.locator(".tool-card-body");
+  await expect(body).toBeVisible();
+  // Two sections in order: input then result.
+  const pres = body.locator("pre");
+  const input = await pres.nth(0).innerText();
+  expect(input).toContain('"max_results": 8'); // double-quoted, pretty-printed
+  expect(input).toContain("\n"); // multi-line indent, not a one-line blob
+  expect(input).not.toContain("'"); // no single-quoted Python repr
+
+  // Result shows the actual tool output, not a ToolMessage repr.
+  const result = await pres.nth(1).innerText();
+  expect(result).toContain("8 result(s)");
+  expect(result).not.toContain("tool_call_id=");
+});
+
+test("expanded state is sticky and the assistant answer renders as markdown", async ({ page }) => {
+  await send(page, "MARKDOWN: summarize");
+
+  // Final answer renders through the markdown pipeline.
+  const md = page.locator(".message-assistant .markdown");
+  await expect(md.locator("h2")).toHaveText("Summary");
+  await expect(md.locator("strong")).toHaveText("key");
+  await expect(md.locator("li")).toHaveCount(2);
+  await expect(md.locator("pre code")).toContainText("const x = 1;");
+});
+
+test("long tool values do not overflow the chat horizontally", async ({ page }) => {
+  await send(page, "OVERFLOW: trigger a long token");
+
+  const card = page.locator(".tool-card").first();
+  await expect(card).toBeVisible();
+  await card.locator(".tool-card-head").click();
+  await expect(card.locator(".tool-card-body")).toBeVisible();
+
+  const metrics = await page.evaluate(() => {
+    const body = document.querySelector(".message-assistant .message-body");
+    return {
+      docScroll: document.documentElement.scrollWidth,
+      win: window.innerWidth,
+      bodyScroll: body ? body.scrollWidth : 0,
+      bodyClient: body ? body.clientWidth : 0,
+    };
+  });
+  // No page-level horizontal scrollbar, and the message body contains its
+  // content (long values wrap rather than blowing out the column).
+  expect(metrics.docScroll).toBeLessThanOrEqual(metrics.win + 1);
+  expect(metrics.bodyScroll).toBeLessThanOrEqual(metrics.bodyClient + 1);
+});

--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -1,0 +1,38 @@
+import { expect, test } from "@playwright/test";
+
+import { SLASH_COMMANDS } from "./fixtures.mjs";
+
+// The chat composer fetches the server's registered slash commands
+// (GET /api/chat/commands) and autocompletes them as you type "/name".
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "networkidle" });
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+});
+
+test("slash menu opens and lists the server commands", async ({ page }) => {
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.fill("/");
+
+  const menu = page.locator(".slash-menu");
+  await expect(menu).toBeVisible();
+  // Each command renders as a `.slash-name` row (the description can repeat the
+  // name, so scope to the name span to avoid matching twice).
+  const names = await menu.locator(".slash-name").allInnerTexts();
+  expect(names).toEqual(SLASH_COMMANDS.map((c) => `/${c.name}`));
+});
+
+test("filtering narrows the menu and selecting completes the command", async ({ page }) => {
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.fill("/go");
+
+  const menu = page.locator(".slash-menu");
+  await expect(menu.locator(".slash-item")).toHaveCount(1);
+  await expect(menu.getByText("/goal", { exact: true })).toBeVisible();
+
+  // Enter completes the highlighted command into the composer.
+  await composer.press("Enter");
+  await expect(composer).toHaveValue("/goal ");
+  // Completing closes the menu (a space follows the command).
+  await expect(menu).toBeHidden();
+});

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -1,0 +1,181 @@
+// Shared fixtures for the operator-console E2E smoke harness.
+//
+// The mock server (mock-server.mjs) serves these as the backend API + A2A
+// stream so Playwright can exercise the real built frontend deterministically
+// — no Python, no langgraph, no model, no network. Specs import the same
+// constants to assert against, so the contract can't drift between the two.
+
+export const TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json";
+
+export const RUNTIME_STATUS = {
+  setup_complete: true,
+  graph_loaded: true,
+  project: { path: "/tmp/e2e-project", allowed_dirs: ["/tmp/e2e-project"] },
+  model: {
+    provider: "openai",
+    name: "protolabs/reasoning",
+    api_base: "https://api.proto-labs.ai/v1",
+    api_key_configured: true,
+    temperature: 0.2,
+    max_tokens: 2048,
+    max_iterations: 8,
+  },
+  identity: { name: "protoAgent", operator: "e2e" },
+  middleware: { knowledge: true, audit: true, memory: false, scheduler: true },
+  knowledge: { enabled: true, configured_path: "/tmp/k.db", resolved_path: "/tmp/k.db", top_k: 5 },
+  scheduler: { enabled: true, backend: "local" },
+  goal: { enabled: true, controller_loaded: true, max_iterations: 6 },
+  cache_warmer: { enabled: false, loaded: false, interval_seconds: null },
+  // Surfaced in the Runtime panel — the extensibility features.
+  skills: { enabled: true, count: 3, top_k: 4 },
+  mcp: {
+    enabled: true,
+    servers: [{ name: "echo", transport: "stdio", tool_count: 2 }],
+    tool_count: 2,
+  },
+  plugins: [
+    { id: "demo", name: "Demo Plugin", version: "1.0.0", enabled: true, loaded: true, tools: ["demo_tool"], skills: 1 },
+  ],
+};
+
+export const SUBAGENTS = [
+  {
+    name: "researcher",
+    description: "Researches a topic and reports findings",
+    enabled: true,
+    tools: ["web_search", "fetch_url"],
+    default_tools: ["web_search", "fetch_url"],
+    max_turns: 6,
+    default_max_turns: 6,
+    allow_skill_emission: true,
+  },
+];
+
+export const SLASH_COMMANDS = [
+  { name: "goal", description: "Set a goal for this session", usage: "/goal <condition>" },
+  { name: "clear", description: "Clear the conversation", usage: "/clear" },
+];
+
+export const SCHEDULER_JOBS = {
+  backend: "local",
+  jobs: [
+    {
+      id: "job-1",
+      prompt: "Summarize overnight activity",
+      schedule: "0 9 * * *",
+      agent_name: "protoAgent",
+      enabled: true,
+      next_fire: "2026-05-30T09:00:00Z",
+    },
+  ],
+};
+
+export const GOALS = {
+  enabled: true,
+  goals: [
+    {
+      session_id: "operator-default",
+      condition: "All tests pass",
+      status: "in_progress",
+      iteration: 1,
+      max_iterations: 6,
+    },
+  ],
+};
+
+export const NOTES_WORKSPACE = {
+  version: 1,
+  workspaceVersion: 1,
+  activeTabId: "tab-1",
+  tabOrder: ["tab-1"],
+  tabs: {
+    "tab-1": {
+      id: "tab-1",
+      name: "Notes",
+      content: "e2e note",
+      permissions: { agentRead: true, agentWrite: true },
+      metadata: {},
+    },
+  },
+};
+
+const MARKDOWN_ANSWER = [
+  "## Summary",
+  "",
+  "Here are the **key** findings:",
+  "",
+  "- First point",
+  "- Second point",
+  "",
+  "```js",
+  "const x = 1;",
+  "```",
+].join("\n");
+
+/**
+ * Build the ordered A2A SSE frames for a streamed turn. The scenario is chosen
+ * from the user's prompt text so specs can drive different rendering paths:
+ *   - contains "OVERFLOW" → a tool whose input is one very long unbroken token
+ *   - contains "MARKDOWN" → a rich-markdown final answer
+ *   - otherwise           → a web_search tool with JSON input + a short answer
+ */
+export function buildFrames({ rpcId, contextId, taskId, prompt }) {
+  const text = (prompt || "").toUpperCase();
+  const wantOverflow = text.includes("OVERFLOW");
+  const wantMarkdown = text.includes("MARKDOWN");
+
+  const toolInput = wantOverflow
+    ? JSON.stringify({ token: "x".repeat(400) })
+    : JSON.stringify({ max_results: 8, query: "AI coding agents latest news" });
+  const toolOutput = wantOverflow
+    ? "y".repeat(400)
+    : "8 result(s) for 'AI coding agents latest news':\n1. Example — https://example.com/a";
+  const answer = wantMarkdown ? MARKDOWN_ANSWER : "Done — found 8 results.";
+
+  const wrap = (result) => ({ jsonrpc: "2.0", id: rpcId, result });
+  const toolEvent = (phase, extra) => ({
+    id: "run-e2e-1",
+    name: "web_search",
+    phase,
+    ...extra,
+  });
+  const statusWithTool = (stateText, phase, extra) =>
+    wrap({
+      kind: "status-update",
+      taskId,
+      contextId,
+      status: {
+        state: "working",
+        message: {
+          role: "agent",
+          parts: [
+            { kind: "text", text: stateText },
+            { kind: "data", data: toolEvent(phase, extra), metadata: { mimeType: TOOL_CALL_MIME } },
+          ],
+        },
+      },
+      final: false,
+    });
+
+  return [
+    wrap({ kind: "task", id: taskId, contextId, status: { state: "submitted" }, artifacts: [] }),
+    wrap({
+      kind: "status-update",
+      taskId,
+      contextId,
+      status: { state: "working", message: { role: "agent", parts: [{ kind: "text", text: "working…" }] } },
+      final: false,
+    }),
+    statusWithTool(`🔧 web_search: ${toolInput}`, "start", { input: toolInput }),
+    statusWithTool(`✅ web_search → ${toolOutput}`, "end", { output: toolOutput }),
+    wrap({
+      kind: "artifact-update",
+      taskId,
+      contextId,
+      artifact: { artifactId: taskId, parts: [{ kind: "text", text: answer }] },
+      append: false,
+      lastChunk: true,
+    }),
+    wrap({ kind: "status-update", taskId, contextId, status: { state: "completed" }, final: true }),
+  ];
+}

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -1,0 +1,163 @@
+// Deterministic mock backend for the operator-console E2E harness.
+//
+// Serves the built SPA (apps/web/dist, base "/app/") AND the subset of the
+// operator API + the A2A stream that the console calls — with canned data from
+// fixtures.mjs. This lets Playwright drive the *real* compiled frontend with
+// zero Python / langgraph / model / network, so the rendering contract (tool
+// cards, markdown, slash commands, runtime panel) is tested in isolation.
+//
+// Run: node e2e/mock-server.mjs [port]   (defaults to 4319)
+
+import { createServer } from "node:http";
+import { readFile, stat } from "node:fs/promises";
+import { extname, join, normalize } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  buildFrames,
+  GOALS,
+  NOTES_WORKSPACE,
+  RUNTIME_STATUS,
+  SCHEDULER_JOBS,
+  SLASH_COMMANDS,
+  SUBAGENTS,
+} from "./fixtures.mjs";
+
+const PORT = Number(process.argv[2] || process.env.E2E_PORT || 4319);
+const DIST = fileURLToPath(new URL("../dist", import.meta.url));
+
+const MIME = {
+  ".html": "text/html; charset=utf-8",
+  ".js": "text/javascript; charset=utf-8",
+  ".mjs": "text/javascript; charset=utf-8",
+  ".css": "text/css; charset=utf-8",
+  ".json": "application/json; charset=utf-8",
+  ".svg": "image/svg+xml",
+  ".png": "image/png",
+  ".ico": "image/x-icon",
+  ".woff": "font/woff",
+  ".woff2": "font/woff2",
+  ".map": "application/json; charset=utf-8",
+};
+
+function sendJson(res, body, status = 200) {
+  const data = JSON.stringify(body);
+  res.writeHead(status, { "content-type": "application/json; charset=utf-8" });
+  res.end(data);
+}
+
+async function readBody(req) {
+  const chunks = [];
+  for await (const c of req) chunks.push(c);
+  const raw = Buffer.concat(chunks).toString("utf8");
+  try {
+    return raw ? JSON.parse(raw) : {};
+  } catch {
+    return {};
+  }
+}
+
+// GET API routes → canned fixtures.
+function handleApiGet(pathname) {
+  switch (pathname) {
+    case "/api/runtime/status":
+      return RUNTIME_STATUS;
+    case "/api/subagents":
+      return { subagents: SUBAGENTS };
+    case "/api/chat/commands":
+      return { commands: SLASH_COMMANDS };
+    case "/api/scheduler/jobs":
+      return SCHEDULER_JOBS;
+    case "/api/goals":
+      return GOALS;
+    case "/api/notes/workspace":
+      return { workspace: NOTES_WORKSPACE };
+    case "/api/beads/status":
+      return { initialized: false };
+    case "/api/beads/issues":
+      return { issues: [] };
+    default:
+      return null;
+  }
+}
+
+// POST /a2a message/stream → SSE of the canned frames for this prompt.
+async function handleA2AStream(req, res, body) {
+  const params = body.params || {};
+  const prompt = (params.message?.parts || [])
+    .filter((p) => p.kind === "text" || p.kind === undefined)
+    .map((p) => p.text)
+    .join("");
+  const frames = buildFrames({
+    rpcId: body.id ?? "1",
+    contextId: params.contextId || "e2e-ctx",
+    taskId: "task-e2e-1",
+    prompt,
+  });
+
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+    connection: "keep-alive",
+  });
+  for (const frame of frames) {
+    res.write(`data: ${JSON.stringify(frame)}\n\n`);
+    // Small gap so the "working/tool" frames are observably distinct from the
+    // terminal artifact (mirrors real tool latency; lets running→done show).
+    await new Promise((r) => setTimeout(r, 40));
+  }
+  res.end();
+}
+
+async function serveStatic(pathname, res) {
+  // The SPA is built with base "/app/". Map "/app/x" → dist/x, root-level
+  // assets pass through, unknown app routes fall back to index.html (SPA).
+  let rel = pathname.startsWith("/app/") ? pathname.slice("/app/".length) : pathname.replace(/^\//, "");
+  if (rel === "" || rel === "app") rel = "index.html";
+  let filePath = normalize(join(DIST, rel));
+  if (!filePath.startsWith(DIST)) {
+    res.writeHead(403).end("forbidden");
+    return;
+  }
+  try {
+    const info = await stat(filePath);
+    if (info.isDirectory()) filePath = join(filePath, "index.html");
+  } catch {
+    filePath = join(DIST, "index.html"); // SPA fallback
+  }
+  try {
+    const data = await readFile(filePath);
+    res.writeHead(200, { "content-type": MIME[extname(filePath)] || "application/octet-stream" });
+    res.end(data);
+  } catch {
+    res.writeHead(404).end("not found");
+  }
+}
+
+const server = createServer(async (req, res) => {
+  const url = new URL(req.url, `http://localhost:${PORT}`);
+  const { pathname } = url;
+
+  if (pathname === "/a2a" && req.method === "POST") {
+    return handleA2AStream(req, res, await readBody(req));
+  }
+  if (pathname.startsWith("/api/")) {
+    if (req.method === "GET") {
+      const payload = handleApiGet(pathname);
+      if (payload !== null) return sendJson(res, payload);
+      return sendJson(res, { detail: "not mocked" }, 404);
+    }
+    // POST/PATCH/DELETE writes → generic ok so the UI doesn't error.
+    await readBody(req);
+    return sendJson(res, { ok: true });
+  }
+  if (req.method !== "GET") {
+    return sendJson(res, { detail: "method not allowed" }, 405);
+  }
+  return serveStatic(pathname, res);
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  // Playwright's webServer waits on this readiness line / the port.
+  console.log(`[e2e mock] serving on http://127.0.0.1:${PORT}/app/`);
+});

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from "@playwright/test";
+
+// Every workspace surface mounts and renders its mocked data. Guards against a
+// surface crashing on an unexpected payload shape — the Runtime panel in
+// particular reads the skills / MCP / plugins blocks.
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "networkidle" });
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+});
+
+async function openSurface(page, name: string) {
+  await page.getByRole("button", { name, exact: true }).click();
+}
+
+test("subagents surface lists the registered subagent", async ({ page }) => {
+  await openSurface(page, "Subagents");
+  await expect(page.getByRole("heading", { name: "Manual Subagent" })).toBeVisible();
+  // The registered-count kicker reflects the mocked subagent list.
+  await expect(page.getByText("1 registered")).toBeVisible();
+});
+
+test("schedule surface lists scheduled jobs", async ({ page }) => {
+  await openSurface(page, "Schedule");
+  await expect(page.getByRole("heading", { name: "Schedule" })).toBeVisible();
+  await expect(page.getByText("Summarize overnight activity")).toBeVisible();
+});
+
+test("goals surface lists active goals", async ({ page }) => {
+  await openSurface(page, "Goals");
+  await expect(page.getByRole("heading", { name: "Goals" })).toBeVisible();
+  await expect(page.getByText("All tests pass")).toBeVisible();
+});
+
+test("runtime surface surfaces skills, MCP servers, and plugins", async ({ page }) => {
+  await openSurface(page, "Runtime");
+  await expect(page.getByRole("heading", { name: "Runtime" })).toBeVisible();
+
+  // Extensibility blocks — the features added across the initiative.
+  await expect(page.getByText("SKILL.md skills loaded")).toBeVisible();
+  await expect(page.getByText("echo · stdio")).toBeVisible(); // MCP server
+  await expect(page.getByText("Demo Plugin", { exact: false })).toBeVisible(); // plugin
+});

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
-    <link rel="icon" href="/app/protolabs-icon-outline.svg" />
+    <link rel="icon" href="protolabs-icon-outline.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "dev": "vite --host 127.0.0.1",
     "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
-    "preview": "vite preview --host 127.0.0.1"
+    "preview": "vite preview --host 127.0.0.1",
+    "test:e2e": "npm run build && playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
     "lucide-react": "^0.468.0",
@@ -17,6 +19,7 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@playwright/test": "^1.60.0",
     "@types/react": "^18.3.12",
     "@types/react-dom": "^18.3.1",
     "@vitejs/plugin-react": "^4.3.4",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -1,0 +1,32 @@
+import { defineConfig, devices } from "@playwright/test";
+
+// E2E smoke harness for the operator console. Drives the *built* SPA against
+// the deterministic mock backend (e2e/mock-server.mjs) — no Python/model.
+// `npm run test:e2e` builds the app first (see package.json), then this config
+// boots the mock server and runs the specs against it.
+
+const PORT = Number(process.env.E2E_PORT || 4319);
+const BASE = `http://127.0.0.1:${PORT}`;
+
+export default defineConfig({
+  testDir: "./e2e",
+  testMatch: "**/*.spec.ts",
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? "github" : "list",
+  timeout: 30_000,
+  expect: { timeout: 10_000 },
+  use: {
+    baseURL: BASE,
+    trace: "on-first-retry",
+    viewport: { width: 1200, height: 900 },
+  },
+  projects: [{ name: "chromium", use: { ...devices["Desktop Chrome"] } }],
+  webServer: {
+    command: `node e2e/mock-server.mjs ${PORT}`,
+    url: `${BASE}/app/`,
+    reuseExistingServer: !process.env.CI,
+    timeout: 30_000,
+  },
+});

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -297,6 +297,28 @@ server — not the client — decides which directories they may read and write.
 - The runtime-status `project.allowed_dirs` field feeds the project-path
   picker's suggestions; it does not relax the server-side check.
 
+## E2E smoke harness
+
+The console has a Playwright smoke suite under `apps/web/e2e/` that drives the
+**built** SPA against a deterministic mock backend — no Python, langgraph,
+model, or network. It exists so the rendering contract (the part most likely to
+regress) is verifiable in CI.
+
+- `apps/web/e2e/mock-server.mjs` serves the built `dist/` *and* the subset of
+  the operator API + the `/a2a` SSE stream the console calls, with canned data
+  from `apps/web/e2e/fixtures.mjs`. The A2A scenario is chosen from the prompt
+  text (`MARKDOWN`, `OVERFLOW`, default) so specs can drive different paths.
+- Specs: `chat.spec.ts` (tool-call cards — collapsed-by-default, pretty-printed
+  JSON on expand, markdown answers, no horizontal overflow), `commands.spec.ts`
+  (slash-command autocomplete), `navigation.spec.ts` (every surface mounts; the
+  Runtime panel shows skills / MCP / plugins).
+- Run locally: `npm run test:e2e --workspace @protoagent/web` (builds first,
+  boots the mock server, runs headless). `test:e2e:ui` opens the Playwright UI.
+- CI: the **Web E2E smoke** job in `.github/workflows/checks.yml`.
+
+When you add a console feature, extend the mock fixtures + a spec rather than
+reaching for a live backend — keep the harness deterministic.
+
 ## Risks
 
 - A2A streaming events are not AI SDK data-stream events; the first chat UI

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,6 +34,7 @@
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
+        "@playwright/test": "^1.60.0",
         "@types/react": "^18.3.12",
         "@types/react-dom": "^18.3.1",
         "@vitejs/plugin-react": "^4.3.4",
@@ -1088,6 +1089,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@protoagent/desktop": {
@@ -3861,6 +3878,53 @@
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
     },
     "node_modules/postcss": {
       "version": "8.5.10",


### PR DESCRIPTION
A committed UI smoke harness, expanded beyond the tool cards — plus a favicon dev-404 fix it now guards.

## Approach

CI has no model/langgraph, so the harness drives the **built SPA against a deterministic mock backend** (`apps/web/e2e/mock-server.mjs`) that serves the built `dist/` *and* the subset of the operator API + the `/a2a` SSE stream the console calls — with canned data from `e2e/fixtures.mjs`. No Python, model, or network. This tests the **rendering contract** — the part most likely to regress — in isolation.

The A2A scenario is selected from the prompt text (`MARKDOWN`, `OVERFLOW`, default) so specs drive different rendering paths off one server.

## Coverage (10 specs)

- **`chat.spec.ts`** — the tool-call card contract: collapsed-by-default stable rows; running→done glyph; pretty-printed JSON input on expand (double-quoted, multi-line, no Python repr); result unwrapped from `ToolMessage` (no `tool_call_id=`); markdown answers (h2/strong/list/code); no horizontal overflow for long values.
- **`commands.spec.ts`** — slash-command autocomplete: open, filter, Enter completes, menu closes.
- **`navigation.spec.ts`** — every surface mounts; Runtime panel shows skills / MCP servers / plugins.
- **`assets.spec.ts`** — favicon link resolves to a 200 SVG.

## Favicon fix (bundled)

The favicon `<link>` hardcoded the `/app/` base, so Vite's **dev** server prepended the base again → `/app/app/protolabs-icon-outline.svg` (404); the tab favicon never loaded under `npm run dev`. (The built app resolved fine, so it was dev-only — which is why the new `assets.spec.ts`, running against the built app, guards the wiring but didn't itself reproduce the dev failure; I verified the dev fix separately.) Switched to a relative href that resolves correctly in both dev and build.

## Wiring

- `apps/web/playwright.config.ts` boots the mock server as its `webServer`.
- Scripts: `npm run test:e2e --workspace @protoagent/web` (builds then runs headless), `test:e2e:ui`.
- CI: new **Web E2E smoke** job in `checks.yml` (`npm ci` → install chromium → `test:e2e`).
- `@playwright/test` web devDep; `test-results/` / `playwright-report/` gitignored.
- Docs: "E2E smoke harness" section in the operator-console guide.

## Verified

`npm run test:e2e --workspace @protoagent/web` → **10 passed** locally (the exact command CI runs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)