### PR TITLE
Show a per-tool icon in tool-call card headers

### DIFF
--- a/apps/web/e2e/tool-renderers.spec.ts
+++ b/apps/web/e2e/tool-renderers.spec.ts
@@ -25,6 +25,19 @@ test("calculator renders expression = result", async ({ page }) => {
   await expect(calc.locator("code")).toHaveText("19 * 23");
   await expect(calc.locator("strong")).toHaveText("437");
   await expect(body.locator("pre")).toHaveCount(0);
+  // Header shows the tool-specific icon (not the generic wrench).
+  await expect(page.locator(".tool-card-head .tool-card-icon.lucide-calculator")).toBeVisible();
+});
+
+test("each tool gets its own header icon", async ({ page }) => {
+  for (const [prompt, icon] of [
+    ["TIME now", "lucide-clock"],
+    ["FETCH it", "lucide-globe"],
+    ["search for things", "lucide-search"],
+  ] as const) {
+    await run(page, prompt);
+    await expect(page.locator(`.tool-card-head .tool-card-icon.${icon}`).first()).toBeVisible();
+  }
 });
 
 test("current_time renders the timestamp and human line", async ({ page }) => {

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -1,8 +1,32 @@
-import { Check, ChevronRight, Loader2, Wrench, X } from "lucide-react";
+import {
+  Calculator,
+  Check,
+  ChevronRight,
+  Clock,
+  Database,
+  Globe,
+  Loader2,
+  Network,
+  Search,
+  Wrench,
+  X,
+} from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useState } from "react";
 
 import type { ToolCall } from "../lib/types";
 import { ToolValue } from "./tool-renderers";
+
+/** Map a tool name to a recognizable icon; falls back to a generic wrench. */
+function iconFor(name: string): LucideIcon {
+  if (name === "calculator") return Calculator;
+  if (name === "web_search") return Search;
+  if (name === "fetch_url") return Globe;
+  if (name === "current_time") return Clock;
+  if (name === "task") return Network; // subagent delegation
+  if (name.startsWith("memory")) return Database;
+  return Wrench;
+}
 
 /**
  * Renders the agent's tool activity as collapsible cards inside an assistant
@@ -27,6 +51,7 @@ function ToolCard({ call }: { call: ToolCall }) {
   // cards they care about.
   const [open, setOpen] = useState(false);
   const hasDetail = Boolean(call.input || call.output);
+  const Icon = iconFor(call.name);
 
   return (
     <div className={`tool-card tool-card-${call.status}`}>
@@ -42,7 +67,7 @@ function ToolCard({ call }: { call: ToolCall }) {
         ) : (
           <span className="tool-card-caret-spacer" />
         )}
-        <Wrench size={13} className="tool-card-icon" />
+        <Icon size={13} className="tool-card-icon" />
         <span className="tool-card-name">{call.name}</span>
         <StatusGlyph status={call.status} />
       </button>


### PR DESCRIPTION
First of the planned card-polish items.

Replaces the generic wrench in each tool-call card header with a recognizable icon per tool — calculator, `web_search` (search), `fetch_url` (globe), `current_time` (clock), `task` (network/subagent), `memory_*` (database), wrench fallback — so a multi-tool turn is scannable at a glance.

**Tests:** e2e asserts the calculator card shows the calculator icon and that time / fetch / search each render their own header icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)