### PR TITLE
Show per-tool elapsed duration on the card header

### DIFF
--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -31,6 +31,9 @@ test("tool-call card is collapsed by default and renders structured components",
   // The tool finishes → done glyph (not the running spinner).
   await expect(card.locator(".tool-card-status.done")).toBeVisible();
 
+  // A duration pill is stamped on completion (mock gaps frames ~40ms).
+  await expect(card.locator(".tool-card-dur")).toHaveText(/^\d+ms$|^\d+\.\d+s$/);
+
   await card.locator(".tool-card-head").click();
   const body = card.locator(".tool-card-body");
   await expect(body).toBeVisible();

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -596,6 +596,13 @@ select:disabled {
   font-family: var(--font-mono);
   color: var(--fg);
 }
+.tool-card-dur {
+  flex: none;
+  font-family: var(--font-mono);
+  font-size: 0.7rem;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
 .tool-card-status {
   flex: none;
 }

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -209,20 +209,24 @@ function ChatSessionSlot({
               if (message.id !== assistantId) return message;
               const calls = [...(message.toolCalls || [])];
               const idx = calls.findIndex((c) => c.id === evt.id);
+              const now = Date.now();
               if (evt.phase === "start") {
                 const card: ToolCall = {
                   id: evt.id,
                   name: evt.name,
                   input: evt.input,
                   status: "running",
+                  startedAt: now,
                 };
                 if (idx >= 0) calls[idx] = { ...calls[idx], ...card };
                 else calls.push(card);
               } else {
                 // end — flip the matching card to done (or create one if the
-                // start frame was missed).
+                // start frame was missed). Stamp elapsed when we saw the start.
+                const startedAt = idx >= 0 ? calls[idx].startedAt : undefined;
+                const durationMs = startedAt !== undefined ? now - startedAt : undefined;
                 if (idx >= 0) {
-                  calls[idx] = { ...calls[idx], output: evt.output, status: "done" };
+                  calls[idx] = { ...calls[idx], output: evt.output, status: "done", durationMs };
                 } else {
                   calls.push({ id: evt.id, name: evt.name, output: evt.output, status: "done" });
                 }

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -69,6 +69,9 @@ function ToolCard({ call }: { call: ToolCall }) {
         )}
         <Icon size={13} className="tool-card-icon" />
         <span className="tool-card-name">{call.name}</span>
+        {call.durationMs !== undefined ? (
+          <span className="tool-card-dur">{formatDuration(call.durationMs)}</span>
+        ) : null}
         <StatusGlyph status={call.status} />
       </button>
       {open && hasDetail ? (
@@ -89,6 +92,12 @@ function ToolCard({ call }: { call: ToolCall }) {
       ) : null}
     </div>
   );
+}
+
+/** Human-readable elapsed: "820ms" under a second, "1.2s" above. */
+function formatDuration(ms: number): string {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  return `${(ms / 1000).toFixed(1)}s`;
 }
 
 function StatusGlyph({ status }: { status: ToolCall["status"] }) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -107,6 +107,10 @@ export type ToolCall = {
   input?: string;
   output?: string;
   status: "running" | "done" | "error";
+  /** Client wall-clock when the start frame arrived (ms epoch). */
+  startedAt?: number;
+  /** Elapsed start→end, stamped client-side when the end frame arrives. */
+  durationMs?: number;
 };
 
 /** Wire shape of a single tool event streamed over the A2A tool-call DataPart. */


### PR DESCRIPTION
Second planned card-polish item.

The client stamps wall-clock when a tool's `start` frame arrives and computes elapsed when the `end` frame lands (`startedAt`/`durationMs` on `ToolCall`). The header shows a small muted pill — `820ms` under a second, `1.2s` above. No badge when the start frame was coalesced away, so it never shows a bogus 0.

**Tests:** e2e asserts the duration pill renders with a sane format on completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)