### PR TITLE
Add copy-to-clipboard to tool input/result sections

### DIFF
--- a/apps/web/e2e/copy.spec.ts
+++ b/apps/web/e2e/copy.spec.ts
@@ -1,0 +1,29 @@
+import { expect, test } from "@playwright/test";
+
+// Each expanded tool section has a copy button that writes the raw value to the
+// clipboard. Grant clipboard permissions so we can read it back and verify.
+test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+
+test("copy button writes the raw value to the clipboard", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "networkidle" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+  await composer.fill("CALC compute it");
+  await composer.press("Control+Enter");
+
+  const card = page.locator(".tool-card").first();
+  await expect(card.locator(".tool-card-status.done")).toBeVisible();
+  await card.locator(".tool-card-head").click();
+
+  // Copy the input section's raw value.
+  const inputSection = card.locator(".tool-card-section").first();
+  await expect(inputSection.locator(".tool-copy")).toBeVisible();
+  await inputSection.locator(".tool-copy").click();
+
+  // Button flips to the copied (check) state.
+  await expect(inputSection.locator(".tool-copy")).toHaveAttribute("aria-label", "Copied");
+
+  // Clipboard holds the raw tool input (JSON for the calculator expression).
+  const clip = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clip).toContain("19 * 23");
+});

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -633,6 +633,30 @@ select:disabled {
   text-transform: uppercase;
   color: var(--fg-muted);
 }
+.tool-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.tool-copy {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 2px;
+  background: none;
+  border: none;
+  border-radius: 4px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  opacity: 0.6;
+  transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
+}
+.tool-copy:hover {
+  opacity: 1;
+  color: var(--fg);
+  background: var(--bg-hover);
+}
 .tool-card-body pre {
   margin: 0;
   padding: 6px 8px;

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -3,6 +3,7 @@ import {
   Check,
   ChevronRight,
   Clock,
+  Copy,
   Database,
   Globe,
   Loader2,
@@ -77,20 +78,60 @@ function ToolCard({ call }: { call: ToolCall }) {
       {open && hasDetail ? (
         <div className="tool-card-body">
           {call.input ? (
-            <div className="tool-card-section">
-              <span className="tool-card-label">input</span>
-              <ToolValue raw={call.input} role="input" tool={call.name} />
-            </div>
+            <ToolSection label="input" raw={call.input} role="input" tool={call.name} />
           ) : null}
           {call.output ? (
-            <div className="tool-card-section">
-              <span className="tool-card-label">result</span>
-              <ToolValue raw={call.output} role="output" tool={call.name} />
-            </div>
+            <ToolSection label="result" raw={call.output} role="output" tool={call.name} />
           ) : null}
         </div>
       ) : null}
     </div>
+  );
+}
+
+function ToolSection({
+  label,
+  raw,
+  role,
+  tool,
+}: {
+  label: string;
+  raw: string;
+  role: "input" | "output";
+  tool: string;
+}) {
+  return (
+    <div className="tool-card-section">
+      <div className="tool-section-head">
+        <span className="tool-card-label">{label}</span>
+        <CopyButton text={raw} />
+      </div>
+      <ToolValue raw={raw} role={role} tool={tool} />
+    </div>
+  );
+}
+
+/** Copies the raw value to the clipboard, flashing a check on success. */
+function CopyButton({ text }: { text: string }) {
+  const [copied, setCopied] = useState(false);
+  return (
+    <button
+      type="button"
+      className="tool-copy"
+      title="Copy to clipboard"
+      aria-label={copied ? "Copied" : "Copy"}
+      onClick={async () => {
+        try {
+          await navigator.clipboard.writeText(text);
+          setCopied(true);
+          setTimeout(() => setCopied(false), 1200);
+        } catch {
+          // Clipboard unavailable (insecure context / denied) — no-op.
+        }
+      }}
+    >
+      {copied ? <Check size={12} /> : <Copy size={12} />}
+    </button>
   );
 }
 


### PR DESCRIPTION
Third planned card-polish item.

Each expanded tool section gets a small copy button (top-right of the section header) that writes the raw value to the clipboard and flashes a check on success. Degrades quietly when the clipboard API is unavailable (insecure context / denied).

**Tests:** e2e grants clipboard permissions, copies the calculator input, and asserts both the "Copied" state and the actual clipboard contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)