### PR TITLE
chore: release v0.3.55

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.3.54"
+version = "0.3.55"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
Automated version bump to `v0.3.55`.