### PR TITLE
Code-split the markdown/highlight pipeline out of the initial bundle

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -12,7 +12,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../lib/api";
 import type { ChatMessage, SlashCommand, ToolCall } from "../lib/types";
 import { chatStore, MAX_ACTIVE_SESSIONS, useChatState } from "./chat-store";
-import { Markdown } from "./Markdown";
+import { Markdown } from "./LazyMarkdown";
 import { ToolCalls } from "./ToolCalls";
 
 function messageId() {

--- a/apps/web/src/chat/LazyMarkdown.tsx
+++ b/apps/web/src/chat/LazyMarkdown.tsx
@@ -1,0 +1,16 @@
+import { lazy, Suspense } from "react";
+
+// The markdown pipeline (react-markdown + remark-gfm + rehype-highlight, which
+// bundles highlight.js) is the heaviest dependency in the app. Load it lazily
+// so it isn't in the initial chunk — it only matters once an assistant message
+// renders. Until the chunk arrives, fall back to the raw text (a blink at most;
+// then the same `.markdown` container takes over).
+const MarkdownImpl = lazy(() => import("./Markdown").then((m) => ({ default: m.Markdown })));
+
+export function Markdown({ children }: { children: string }) {
+  return (
+    <Suspense fallback={<div className="markdown">{children}</div>}>
+      <MarkdownImpl>{children}</MarkdownImpl>
+    </Suspense>
+  );
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -8,6 +8,20 @@ export default defineConfig(({ mode }) => {
   return {
     base: "/app/",
     plugins: [react()],
+    build: {
+      rollupOptions: {
+        output: {
+          // Split the React runtime into its own long-lived vendor chunk. The
+          // package-boundary regex avoids matching react-markdown / sibling
+          // packages so the lazily-loaded markdown chunk stays separate.
+          manualChunks(id) {
+            if (/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)) {
+              return "react-vendor";
+            }
+          },
+        },
+      },
+    },
     server: {
       port: 5173,
       proxy: {


### PR DESCRIPTION
The chat bundle was a single **~552 KB** chunk, dominated by react-markdown + remark-gfm + rehype-highlight (which bundles highlight.js).

## Change
- **Lazy-load** the `Markdown` component (`React.lazy` + `Suspense`, raw-text fallback while the chunk loads) so the highlighter is fetched only when an assistant message first renders.
- **Split the React runtime** into its own long-lived `react-vendor` chunk (package-boundary regex so it doesn't swallow `react-markdown`).

## Result
| chunk | before | after |
|---|---|---|
| initial app | 552 KB | **77 KB** (gzip ~20 KB) |
| react-vendor | — | 142 KB (cacheable) |
| markdown (lazy) | — | 334 KB on demand |

No more >500 KB chunk warning. Initial load is now ~219 KB (≈66 KB gzip) vs 552 KB.

**Tests:** 18 e2e specs green — markdown still renders through the lazy boundary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)