### PR TITLE
Stream the assistant answer token-by-token

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -157,6 +157,16 @@ function scenarioFor(prompt) {
     return { name: "web_search", input: { query: "x" }, output: "Error: DuckDuckGo search failed: rate limited", answer: "Search failed." };
   if (t.includes("OVERFLOW"))
     return { name: "web_search", input: { token: "x".repeat(400) }, output: "y".repeat(400), answer: "done" };
+  if (t.includes("STREAM"))
+    return {
+      name: "web_search",
+      input: { query: "stream" },
+      output: DEFAULT_SEARCH_OUTPUT,
+      // Streamed token-by-token as append:true deltas, then reconciled by the
+      // terminal append:false frame (mirrors the real output-streaming path).
+      streamChunks: ["Testing ", "catches bugs ", "before users do."],
+      answer: "Testing catches bugs before users do.",
+    };
   if (t.includes("MARKDOWN"))
     return { name: "web_search", input: { query: "md" }, output: DEFAULT_SEARCH_OUTPUT, answer: MARKDOWN_ANSWER };
   return { name: "web_search", input: { max_results: 8, query: "AI coding agents latest news" }, output: DEFAULT_SEARCH_OUTPUT, answer: "Done — found 8 results." };
@@ -205,6 +215,20 @@ export function buildFrames({ rpcId, contextId, taskId, prompt }) {
   for (const ev of toolEvents) {
     const text = ev.phase === "start" ? `🔧 ${ev.name}: ${ev.input ?? ""}` : `✅ ${ev.name} → ${ev.output ?? ""}`;
     frames.push(statusFrame(text, ev));
+  }
+  // Stream the answer as append:true deltas when the scenario asks for it,
+  // then always send the authoritative append:false terminal artifact.
+  for (const chunk of scenario.streamChunks || []) {
+    frames.push(
+      wrap({
+        kind: "artifact-update",
+        taskId,
+        contextId,
+        artifact: { artifactId: taskId, parts: [{ kind: "text", text: chunk }] },
+        append: true,
+        lastChunk: false,
+      }),
+    );
   }
   frames.push(
     wrap({

--- a/apps/web/e2e/streaming.spec.ts
+++ b/apps/web/e2e/streaming.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+// The assistant answer streams in as append:true deltas, then the terminal
+// append:false frame reconciles the authoritative final text. Guards the
+// client's incremental-append path (the other specs only exercise the terminal
+// replace).
+
+test("assistant answer streams in and reconciles to the final text", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "networkidle" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+  await composer.fill("STREAM the answer");
+  await composer.press("Control+Enter");
+
+  const answer = page.locator(".message-assistant .markdown");
+  // Partial text appears before the full answer (append:true delta).
+  await expect(answer).toContainText("Testing");
+  // Final reconciled text — concatenated cleanly, not duplicated.
+  await expect(answer).toHaveText("Testing catches bugs before users do.");
+});

--- a/docs/explanation/a2a-protocol.md
+++ b/docs/explanation/a2a-protocol.md
@@ -32,6 +32,8 @@ Every SSE frame must carry one of:
 - `"kind": "status-update"` (state transitions, tool progress)
 - `"kind": "artifact-update"` (streaming artifacts)
 
+The assistant's answer streams incrementally: `artifact-update` frames with `append: true` carry each new suffix as the model generates it, and a final `append: false` frame replaces the artifact with the authoritative full text. Only the user-facing `<output>` region streams — the server's `stream_visible_output` holds back the `<scratch_pad>` and any partial trailing tag, and the terminal `extract_output` reconciles the result. Consumers that only want the final answer can ignore the deltas and read the last `append: false` frame.
+
 `@a2a-js/sdk`'s `for await` loop routes frames by `kind`. Without the field, the loop silently skips every frame and consumers never attach. The template's regression test `test_message_stream_events_have_kind_discriminator` locks this in — inline dict construction is the path of least resistance and also the easiest way to forget this field.
 
 ## Camel-case vs snake-case

--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -104,6 +104,41 @@ def _strip_reasoning(text: str) -> str:
 _ORPHAN_OUTPUT_OPEN_RE = re.compile(r"<output>([\s\S]*)$", re.IGNORECASE)
 
 
+def stream_visible_output(raw: str) -> str:
+    """The portion of the user-facing ``<output>`` that's safe to show mid-stream.
+
+    Given a *partial* (still-streaming) raw response, returns only the text
+    inside the first (possibly still-open) ``<output>`` block, with reasoning
+    stripped and any partial trailing tag held back — so a half-written
+    ``</output>`` or ``<confidence>`` never flashes on screen. Returns ``""``
+    while the model is still in ``<scratch_pad>`` (before ``<output>`` opens),
+    so internal reasoning is never streamed.
+
+    This is the incremental counterpart to ``extract_output``: callers stream
+    the growing prefix of this, and the terminal artifact (full
+    ``extract_output``) reconciles any held-back tail at the end. Monotonic —
+    as ``raw`` grows, the result only ever extends (until ``</output>`` closes
+    it), so a caller can emit ``result[already_emitted:]`` each step.
+    """
+    low = raw.lower()
+    start = low.find("<output>")
+    if start == -1:
+        return ""  # still in scratch_pad — nothing user-facing yet
+    after = raw[start + len("<output>") :]
+    close = after.lower().find("</output>")
+    if close != -1:
+        after = after[:close]
+    # Strip provider reasoning that can appear inside the output region.
+    after = _THINK_RE.sub("", after)
+    after = _ORPHAN_THINK_OPEN_RE.sub("", after)
+    # Hold back a partial trailing tag ("</outp", "<conf", a lone "<") so it
+    # never flashes; the terminal replace delivers the full, clean text.
+    lt = after.rfind("<")
+    if lt != -1 and ">" not in after[lt:]:
+        after = after[:lt]
+    return after
+
+
 def extract_confidence(text: str) -> tuple[float | None, str | None]:
     """Parse an optional self-reported ``<confidence>`` (and explanation).
 

--- a/server.py
+++ b/server.py
@@ -38,6 +38,7 @@ from graph.output_format import (
     extract_confidence,
     extract_output,
     is_dropped_scratch_turn,
+    stream_visible_output,
 )
 
 if TYPE_CHECKING:
@@ -884,6 +885,7 @@ async def _run_turn_stream(message: str, session_id: str, config: dict):
     from langchain_core.messages import HumanMessage
 
     accumulated_raw = ""
+    streamed_len = 0  # chars of visible <output> already emitted as text frames
     async for event in _graph.astream_events(
         {"messages": [HumanMessage(content=message)], "session_id": session_id},
         config=config,
@@ -911,6 +913,13 @@ async def _run_turn_stream(message: str, session_id: str, config: dict):
             chunk = event.get("data", {}).get("chunk")
             if chunk and hasattr(chunk, "content") and chunk.content:
                 accumulated_raw += chunk.content if isinstance(chunk.content, str) else str(chunk.content)
+                # Stream only the user-facing <output> region, token by token —
+                # never the scratch_pad. The terminal artifact (extract_output)
+                # reconciles any partial tail held back here.
+                visible = stream_visible_output(accumulated_raw)
+                if len(visible) > streamed_len:
+                    yield ("text", visible[streamed_len:])
+                    streamed_len = len(visible)
         elif kind == "on_chat_model_end":
             output = event.get("data", {}).get("output")
             usage = getattr(output, "usage_metadata", None) if output else None

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -7,10 +7,10 @@ Covers the three shapes of traffic we see live:
 3. Native thinking — provider (MiniMax, DeepSeek, Qwen3) leaks
    `<think>...</think>` regions that the filter must also strip.
 
-We no longer parse mid-stream — ``_chat_langgraph_stream`` accumulates
-the model's tokens silently and passes the complete text through
-``extract_output`` exactly once on the terminal frame. So only the
-one-shot path is tested.
+The one-shot terminal path runs the complete text through ``extract_output``.
+The incremental path (``stream_visible_output``) streams the user-facing
+``<output>`` region token-by-token without leaking ``<scratch_pad>``; the
+terminal ``extract_output`` reconciles any held-back tail. Both are covered.
 """
 
 from __future__ import annotations
@@ -19,6 +19,7 @@ from graph.output_format import (
     OUTPUT_FORMAT_INSTRUCTIONS,
     _strip_reasoning,
     extract_output,
+    stream_visible_output,
 )
 
 
@@ -144,3 +145,59 @@ def test_not_dropped_when_no_reasoning_markers():
 def test_kicker_is_actionable():
     k = DROPPED_SCRATCH_KICKER.lower()
     assert "<output>" in k and ("tool" in k)
+
+
+# ── stream_visible_output (incremental token streaming) ──────────────────────
+
+
+def test_stream_visible_empty_while_in_scratch():
+    """Before <output> opens, nothing user-facing is streamed — the scratch_pad
+    must never leak token-by-token."""
+    assert stream_visible_output("<scratch_pad>still thinking about") == ""
+    assert stream_visible_output("") == ""
+    assert stream_visible_output("no tags yet") == ""
+
+
+def test_stream_visible_orphan_open_streams_content():
+    """An open <output> with no close yet (mid-stream) surfaces its content."""
+    assert stream_visible_output("<scratch_pad>x</scratch_pad><output>Hello there") == "Hello there"
+
+
+def test_stream_visible_closed_output():
+    assert stream_visible_output("<output>the answer</output>") == "the answer"
+
+
+def test_stream_visible_holds_back_partial_closing_tag():
+    """A half-written </output> must not flash on screen."""
+    assert stream_visible_output("<output>done </out") == "done "
+    assert stream_visible_output("<output>done<") == "done"
+
+
+def test_stream_visible_holds_back_partial_confidence_tag():
+    assert stream_visible_output("<output>answer</output><conf") == "answer"
+
+
+def test_stream_visible_strips_think_regions():
+    assert stream_visible_output("<output>A<think>noise</think>B</output>") == "AB"
+    assert stream_visible_output("<output>A<think>partial reasoning") == "A"
+
+
+def test_stream_visible_keeps_legit_angle_brackets():
+    """A '<' followed later by '>' is real content, not a partial tag."""
+    assert stream_visible_output("<output>a < b > c") == "a < b > c"
+
+
+def test_stream_visible_is_monotonic_prefix():
+    """As raw grows, the visible result only extends — so a caller can safely
+    emit result[already_emitted:] each step."""
+    chunks = ["<output>", "Hel", "lo wor", "ld</output><confidence>0.9</confidence>"]
+    raw = ""
+    seen = ""
+    for c in chunks:
+        raw += c
+        vis = stream_visible_output(raw)
+        assert vis.startswith(seen) or seen.startswith(vis)  # never diverges
+        seen = vis
+    assert seen == "Hello world"
+    # The terminal extractor agrees with the final streamed text.
+    assert extract_output(raw) == "Hello world"


### PR DESCRIPTION
The assistant answer used to appear all at once on the terminal artifact. It now streams in as the model generates it.

## How

- `_run_turn_stream` emits the user-facing `<output>` region incrementally as `("text", delta)` frames. These flow through the **existing** watcher → `append:true` artifact-update path, so the console renders the answer progressively. The terminal `append:false` frame still delivers the authoritative full text (`extract_output`), reconciling any held-back tail — so the final render is always correct even if a mid-stream delta was imperfect.
- New `stream_visible_output(raw)` in `output_format.py` is the incremental counterpart to `extract_output`: returns only the text inside the (possibly still-open) first `<output>` block, strips `<think>` regions, and **holds back a partial trailing tag** so a half-written `</output>`/`<confidence>` never flashes. Returns `""` while still in `<scratch_pad>` — **internal reasoning is never streamed**.

## Verified against the real agent

Drove the live agent: the answer streams in progressively, **no scratchpad/tag leakage** (the incremental `append:true` frame carried clean output text; terminal `append:false` matched). Granularity is coarse for short, fast answers (the SSE watcher coalesces bursts by design) and finer for longer ones.

## Tests

- `stream_visible_output` unit cases: scratch-gated (no leak), orphan-open, closed, partial-tag hold-back, think-strip, legit angle brackets, monotonic-prefix. Full Python suite green (**685**).
- E2E: new `STREAM` mock scenario + `streaming.spec.ts` exercising the client's `append:true` incremental path (previously only the terminal replace was covered). **19 specs green.**

## Docs

A2A protocol explainer documents the incremental output streaming + the scratchpad/partial-tag guarantees.

## Known limitation

In goal-mode multi-turn runs, mid-stream text from successive continuations concatenates before the terminal `append:false` replaces it with the final answer — cosmetic, and the final render is correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)