### PR TITLE
Fix answer truncation when the reply mentions protocol tags

### DIFF
--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -66,7 +66,11 @@ Optionally, after `</output>`, you may self-report confidence:
 """.strip()
 
 
-_OUTPUT_RE = re.compile(r"<output>([\s\S]*?)</output>", re.IGNORECASE)
+# The closing tag must NOT be preceded by a backtick: a self-describing answer
+# mentions the protocol in inline code (`` `</output>` ``), and a non-greedy
+# match would otherwise close on that literal mention and truncate the reply.
+# The real closer ends normal prose, never a backtick.
+_OUTPUT_RE = re.compile(r"<output>([\s\S]*?)(?<!`)</output>", re.IGNORECASE)
 _SCRATCH_RE = re.compile(r"<scratch_pad>[\s\S]*?</scratch_pad>", re.IGNORECASE)
 _ORPHAN_SCRATCH_OPEN_RE = re.compile(r"<scratch_pad>[\s\S]*$", re.IGNORECASE)
 _THINK_RE = re.compile(r"<think>[\s\S]*?</think>", re.IGNORECASE)
@@ -101,6 +105,27 @@ def _strip_reasoning(text: str) -> str:
     return text
 
 
+def _strip_reasoning_balanced(text: str) -> str:
+    """Strip only *balanced* reasoning blocks — no orphan eat-to-end variants.
+
+    For content inside a properly-closed ``<output>...</output>`` block, where
+    the text is the finished answer. The orphan strippers
+    (``<scratch_pad>[\\s\\S]*$``) would treat a literal tag *mention* in the
+    answer — e.g. the agent describing its own protocol ("I think in
+    ``<scratch_pad>`` then write ``<output>``") — as real leaked reasoning and
+    delete everything from that point to the end, silently truncating the
+    reply. A closed ``<output>`` can't have been truncated mid-reasoning, so
+    only balanced blocks are stripped here; the orphan eaters stay reserved for
+    the truncation-recovery tiers below.
+    """
+    text = _THINK_RE.sub("", text)
+    text = _ORPHAN_THINK_CLOSE_RE.sub("", text)
+    text = _SCRATCH_RE.sub("", text)
+    text = _CONFIDENCE_EXPL_BLOCK_RE.sub("", text)
+    text = _CONFIDENCE_BLOCK_RE.sub("", text)
+    return text
+
+
 _ORPHAN_OUTPUT_OPEN_RE = re.compile(r"<output>([\s\S]*)$", re.IGNORECASE)
 
 
@@ -125,9 +150,11 @@ def stream_visible_output(raw: str) -> str:
     if start == -1:
         return ""  # still in scratch_pad — nothing user-facing yet
     after = raw[start + len("<output>") :]
-    close = after.lower().find("</output>")
-    if close != -1:
-        after = after[:close]
+    # Close on the first real </output> — skip backtick-wrapped literal mentions
+    # (`` `</output>` ``) so a self-describing answer isn't cut short.
+    m = re.search(r"(?<!`)</output>", after, re.IGNORECASE)
+    if m:
+        after = after[: m.start()]
     # Strip provider reasoning that can appear inside the output region.
     after = _THINK_RE.sub("", after)
     after = _ORPHAN_THINK_OPEN_RE.sub("", after)
@@ -180,10 +207,12 @@ def extract_output(text: str) -> str:
     if not text or not text.strip():
         return ""
 
-    # 1. Closed <output>...</output>
+    # 1. Closed <output>...</output> — balanced-only stripping so a literal
+    #    tag mention in the answer (self-describing replies) isn't treated as
+    #    leaked reasoning and truncated.
     m = _OUTPUT_RE.search(text)
     if m:
-        cleaned = _strip_reasoning(m.group(1)).strip()
+        cleaned = _strip_reasoning_balanced(m.group(1)).strip()
         if cleaned:
             return cleaned
 

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -147,6 +147,57 @@ def test_kicker_is_actionable():
     assert "<output>" in k and ("tool" in k)
 
 
+# ── self-referential answers (literal tag mentions) ──────────────────────────
+
+
+def test_extract_output_keeps_literal_scratch_pad_mention():
+    """Regression: when the answer *describes the protocol* (e.g. "what can you
+    do?"), it names the tags in prose. A closed <output> must NOT treat a
+    literal `<scratch_pad>` mention as leaked reasoning and truncate the reply
+    at it — that silently cut answers off mid-sentence."""
+    raw = (
+        "<output>Here's what I can do: search and calculate.\n\n"
+        "My Approach\nI think in `<scratch_pad>` tags, then write the answer "
+        "in `<output>`.</output>"
+    )
+    out = extract_output(raw)
+    assert out.endswith("write the answer in `<output>`.")
+    assert "<scratch_pad>" in out  # the literal mention survives
+
+
+def test_extract_output_keeps_literal_close_tag_mention():
+    """Regression: a backtick-wrapped `</output>` mention in the answer must not
+    close the block early. The real closer ends prose, not a backtick."""
+    raw = (
+        "<output>How I work:\n1. Reason in `<scratch_pad>`\n"
+        "2. Answer in `<output>`\n3. Confidence goes after `</output>`.\n\n"
+        "That is the whole protocol.</output>"
+    )
+    out = extract_output(raw)
+    assert out.endswith("That is the whole protocol.")
+    assert "`</output>`" in out
+
+
+def test_extract_output_still_takes_first_of_two_real_blocks():
+    """The backtick guard must not change multi-block behavior: two real
+    (non-backticked) <output> blocks still resolve to the first."""
+    assert extract_output("<output>first</output> junk <output>second</output>") == "first"
+
+
+def test_extract_output_still_strips_balanced_reasoning_inside_output():
+    """The fix is scoped: balanced <think>/<scratch_pad> blocks inside a closed
+    <output> are still stripped (real provider leakage)."""
+    raw = "<output>before <scratch_pad>leaked plan</scratch_pad> after</output>"
+    assert extract_output(raw) == "before  after"
+
+
+def test_extract_output_orphan_tier_still_strips_truncated_scratch():
+    """An *orphan-open* <output> (max_tokens truncation) still uses the
+    eat-to-end stripper — that case really is truncated mid-reasoning."""
+    raw = "<output>partial answer <scratch_pad>then it got cut off mid-think"
+    assert extract_output(raw) == "partial answer"
+
+
 # ── stream_visible_output (incremental token streaming) ──────────────────────
 
 


### PR DESCRIPTION
## Symptom
A "what can you do?" reply cut off mid-sentence at a backtick (`"…I think in `"`). **Not a token limit** — `max_tokens` is 32k and a fresh repro came back complete. The cause was content-dependent: the output-protocol parser truncates the answer when the answer *itself* names the protocol tags (which happens naturally when the agent describes how it works).

## Two facets, both fixed

**1. Orphan reasoning-strippers ate the answer.** `_strip_reasoning` applies eat-to-end rules (`<scratch_pad>[\s\S]*$`) intended to drop truncated mid-reasoning. Run over a *closed* `<output>` block, a literal `` `<scratch_pad>` `` mention in the answer deleted everything after it. → Closed `<output>` now uses `_strip_reasoning_balanced` (balanced `<think>…</think>` / `<scratch_pad>…</scratch_pad>` / confidence blocks only; no orphan eaters). The orphan eaters stay reserved for the orphan-output and fallback tiers where truncation is real.

**2. A backticked `` `</output>` `` mention closed the block early.** The non-greedy `_OUTPUT_RE` matched the literal mention instead of the real closer. → Added a negative lookbehind `(?<!\`)</output>` so backtick-wrapped mentions don't close the block; `stream_visible_output` got the same guard. Multi-block behavior (two real blocks → first) is preserved.

## Verified
Against the **real agent**: a reply explicitly naming `<scratch_pad>` / `<output>` / `</output>` now streams through whole (1708 chars, clean ending) instead of truncating at the first tag mention.

## Tests
Regression tests for both facets + guards that balanced-strip (real leakage) and orphan-recovery (true truncation) behavior are unchanged. Full suite **690 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)