### PR TITLE
Fix scratch_pad leak when reasoning names the <output> tag

### DIFF
--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -66,11 +66,13 @@ Optionally, after `</output>`, you may self-report confidence:
 """.strip()
 
 
-# The closing tag must NOT be preceded by a backtick: a self-describing answer
-# mentions the protocol in inline code (`` `</output>` ``), and a non-greedy
-# match would otherwise close on that literal mention and truncate the reply.
-# The real closer ends normal prose, never a backtick.
-_OUTPUT_RE = re.compile(r"<output>([\s\S]*?)(?<!`)</output>", re.IGNORECASE)
+# Neither the opening nor closing tag may be preceded by a backtick. A reply
+# (or its scratch_pad reasoning) often names the protocol in inline code —
+# ``answer in `<output>` format``, ``confidence after `</output>` ``. Without
+# the guards the matcher would open on a backticked `<output>` mention inside
+# the scratch_pad (leaking reasoning) or close on a backticked `</output>`
+# (truncating the answer). The real tags are never backtick-wrapped.
+_OUTPUT_RE = re.compile(r"(?<!`)<output>([\s\S]*?)(?<!`)</output>", re.IGNORECASE)
 _SCRATCH_RE = re.compile(r"<scratch_pad>[\s\S]*?</scratch_pad>", re.IGNORECASE)
 _ORPHAN_SCRATCH_OPEN_RE = re.compile(r"<scratch_pad>[\s\S]*$", re.IGNORECASE)
 _THINK_RE = re.compile(r"<think>[\s\S]*?</think>", re.IGNORECASE)
@@ -126,7 +128,7 @@ def _strip_reasoning_balanced(text: str) -> str:
     return text
 
 
-_ORPHAN_OUTPUT_OPEN_RE = re.compile(r"<output>([\s\S]*)$", re.IGNORECASE)
+_ORPHAN_OUTPUT_OPEN_RE = re.compile(r"(?<!`)<output>([\s\S]*)$", re.IGNORECASE)
 
 
 def stream_visible_output(raw: str) -> str:
@@ -145,11 +147,13 @@ def stream_visible_output(raw: str) -> str:
     as ``raw`` grows, the result only ever extends (until ``</output>`` closes
     it), so a caller can emit ``result[already_emitted:]`` each step.
     """
-    low = raw.lower()
-    start = low.find("<output>")
-    if start == -1:
+    # Open on the first real <output> — skip backticked mentions in the
+    # scratch_pad (e.g. ``answer in `<output>` format``) so reasoning that
+    # names the tag never starts the stream early.
+    open_m = re.search(r"(?<!`)<output>", raw, re.IGNORECASE)
+    if open_m is None:
         return ""  # still in scratch_pad — nothing user-facing yet
-    after = raw[start + len("<output>") :]
+    after = raw[open_m.end() :]
     # Close on the first real </output> — skip backtick-wrapped literal mentions
     # (`` `</output>` ``) so a self-describing answer isn't cut short.
     m = re.search(r"(?<!`)</output>", after, re.IGNORECASE)

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -165,6 +165,26 @@ def test_extract_output_keeps_literal_scratch_pad_mention():
     assert "<scratch_pad>" in out  # the literal mention survives
 
 
+def test_extract_output_ignores_backticked_open_tag_in_scratch():
+    """Regression: the model commonly explains the protocol *in its scratch_pad*
+    ("answer in `<output>` format"). The matcher must open on the real
+    <output>, not the backticked mention — otherwise scratch reasoning leaks
+    into the user-facing answer."""
+    raw = (
+        "<scratch_pad>\nI reason in `<scratch_pad>`, answer in `<output>` format "
+        "with optional confidence.\nThis is a template, so I'll give an overview.\n"
+        "</scratch_pad>\n\n<output>\n# What I Can Do\nSearch, calculate, remember.\n</output>"
+    )
+    assert extract_output(raw) == "# What I Can Do\nSearch, calculate, remember."
+
+
+def test_stream_visible_ignores_backticked_open_in_scratch():
+    """The same guard for streaming: while still in scratch_pad (which names the
+    tag in backticks), nothing user-facing is streamed."""
+    mid = "<scratch_pad>plan: answer in `<output>` format, then finish"
+    assert stream_visible_output(mid) == ""
+
+
 def test_extract_output_keeps_literal_close_tag_mention():
     """Regression: a backtick-wrapped `</output>` mention in the answer must not
     close the block early. The real closer ends prose, not a backtick."""


### PR DESCRIPTION
Follow-up to #302. That fix guarded the **closing** `</output>` against backticked mentions; the **opening** tag needed the same guard, which this PR adds.

## Symptom
Asking "what can you do?" rendered the agent's reasoning ahead of the answer — a scratch tail, a literal `</scratch_pad>`, and the real `<output>` tag — instead of clean markdown.

## Cause
The model describes the protocol **inside its scratch_pad** ("I reason in `` `<scratch_pad>` ``, answer in `` `<output>` `` format"). `_OUTPUT_RE` opened on that **backticked** `<output>` mention and captured from inside the scratch_pad, leaking reasoning into the user-facing answer.

## Fix
Add the `(?<!\`)` negative lookbehind to the **opening** tag too — on `_OUTPUT_RE`, `_ORPHAN_OUTPUT_OPEN_RE`, and `stream_visible_output`'s opener search — so a backtick-wrapped mention never starts the output region. Real protocol tags are never backtick-wrapped.

## Verified
Against the **real agent**: "what can you do?" now renders clean markdown with no tag/scratch leakage (ran twice, both clean). Regression tests cover the opener facet for both `extract_output` and `stream_visible_output`. Full suite **692 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)