### PR TITLE
Enable context compaction by default + resilient trigger; add tuning guide

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -72,6 +72,41 @@ skills:
   top_k: 5
   max_tokens: 2000
 
+# Context compaction — summarize old history near the context limit so long
+# sessions don't overflow the window. ON by default.
+#   trigger: "fraction:0.8" | "tokens:120000" | "messages:80"
+# NOTE: "fraction:"/"tokens:" need the model's context-window profile. A custom
+# gateway alias usually lacks one, so the wiring auto-falls back to a
+# message-count trigger (logged). Set "messages:N" explicitly to be deterministic.
+#   model: a cheaper/faster alias to summarize with (blank = main model).
+compaction:
+  enabled: true
+  trigger: "fraction:0.8"
+  keep_messages: 20
+  # model: protolabs/fast
+
+# Model routing / failover — on a primary error, retry on each fallback model
+# (same gateway) in order. Empty = no failover.
+routing:
+  fallback_models: []
+  #  - claude-haiku-4-5
+
+# Goal mode — route the goal verifier (classification, not the main reasoning
+# task) to a cheaper model with `eval_model`. Blank = main model.
+goal:
+  # eval_model: protolabs/fast
+  max_iterations: 8
+
+# Programmatic tool calling — let the model write ONE Python script that
+# composes several tools in a single turn (collapses long tool-call chains).
+# SECURITY: runs model-authored code in a subprocess (scrubbed env + hard
+# timeout). OFF by default — only enable for trusted models or inside a
+# hardened container. `tools: []` exposes all tools except execute_code itself.
+execute_code:
+  enabled: false
+  timeout: 30
+  tools: []
+
 # React operator console — the beads/notes APIs accept a project path from
 # the (free-text) UI, so the server, not the client, decides which
 # directories they may touch. The protoAgent repo root is always allowed;

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -78,6 +78,7 @@ export default defineConfig({
             { text: "Architecture", link: "/explanation/architecture" },
             { text: "A2A protocol", link: "/explanation/a2a-protocol" },
             { text: "Cost & trace propagation", link: "/explanation/cost-and-trace" },
+            { text: "Tuning & cost", link: "/explanation/tuning-and-cost" },
             { text: "Output protocol", link: "/explanation/output-protocol" },
             { text: "LiteLLM gateway", link: "/explanation/litellm-gateway" },
             { text: "Architecture decisions (ADRs)", link: "/adr/" },

--- a/docs/explanation/tuning-and-cost.md
+++ b/docs/explanation/tuning-and-cost.md
@@ -1,0 +1,101 @@
+# Tuning & cost
+
+protoAgent ships the optimizations that long-running agent runtimes (Nous's
+Hermes Agent, OpenClaw) treat as table stakes — context compaction, aux-model
+routing, programmatic tool calling, prefix caching, and provider failover. Most
+are config flags in `config/langgraph-config.yaml`. This page is the map.
+
+## The levers
+
+| Lever | Config | Default | What it buys |
+|---|---|---|---|
+| Context compaction | `compaction.*` | **on** | Summarize old turns near the window limit so long sessions don't overflow |
+| Aux-model routing | `compaction.model`, `goal.eval_model` | main model | Run summarization + goal-verification on a cheaper/faster model |
+| Programmatic tool calling | `execute_code.*` | off | One script composes many tools in a single turn |
+| Prompt / prefix caching | `prompt_cache.*` | on (Anthropic-gated) | Cache the stable system+tools prefix across turns |
+| Cache warming | `cache_warming.*` | off | Keep the cached prefix warm for sporadic, latency-sensitive traffic |
+| Provider failover | `routing.fallback_models` | none | Retry on fallback models when the primary errors |
+| Iteration budget | `model.max_iterations`, subagent `max_turns` | 50 / per-subagent | Stop runaway loops |
+
+## Context compaction
+
+`SummarizationMiddleware` summarizes the *middle* of the history when a trigger
+fires, keeping the last `keep_messages` turns intact. On by default — a long
+session would otherwise hit the context window and error.
+
+```yaml
+compaction:
+  enabled: true
+  trigger: "fraction:0.8"   # | "tokens:120000" | "messages:80"
+  keep_messages: 20
+  # model: protolabs/fast   # summarize with a cheap model (blank = main model)
+```
+
+**Trigger caveat:** `fraction:` and `tokens:` need the model's context-window
+**profile**. A custom gateway alias (e.g. `protolabs/reasoning`) usually doesn't
+expose one, so langchain raises at construction. The wiring catches this and
+**falls back to a message-count trigger** (logged) rather than crashing the
+graph — but for deterministic behavior on a profile-less model, set
+`trigger: "messages:N"` explicitly.
+
+## Aux-model routing
+
+Not every model call is the hard reasoning task. Summarization and goal
+verification are classification-grade work — route them to a cheaper, faster
+alias and reserve the reasoning model for the actual turn:
+
+```yaml
+compaction:
+  model: protolabs/fast
+goal:
+  eval_model: protolabs/fast
+```
+
+## Programmatic tool calling (`execute_code`)
+
+Instead of a long `search → fetch → search → fetch` tool-call chain (one model
+round-trip each), the model writes **one** Python script that calls several
+tools, loops/filters/composes their results, and returns only stdout —
+collapsing the chain into a single turn.
+
+```yaml
+execute_code:
+  enabled: true
+  timeout: 30
+  tools: []   # empty = all tools except execute_code itself
+```
+
+::: warning Security
+`execute_code` runs **model-authored code** in a subprocess with a scrubbed env
+(no secrets) and a hard timeout, with tool calls bridged back over an fd-based
+RPC. It's still arbitrary code execution — enable it only for a trusted model or
+inside a hardened container, not on a workstation handling untrusted input.
+:::
+
+## Prefix caching & warming
+
+`prompt_cache` applies Anthropic cache breakpoints to the stable system+tools
+prefix; it's a safe no-op on non-Anthropic models (vLLM gateways do prefix
+caching server-side). `cache_warming` reproduces the cached prefix on an
+interval so the first request after an idle gap hits a warm cache — only worth
+it for sporadic, latency-sensitive workloads on the `1h` tier; for steady
+traffic it's pure cost.
+
+## What's already optimal
+
+- **Parallel tool calls** — langchain's `create_agent` runs a turn's tool calls
+  concurrently; results are stitched back in order.
+- **Interruptible turns** — A2A `tasks/cancel` + SSE disconnect stop a run
+  cleanly without corrupting history.
+- **Search-don't-load memory** — `KnowledgeMiddleware` retrieves top-k relevant
+  memory rather than replaying full history into every prompt.
+- **Self-authored skills** — successful subagent runs emit reusable `skill-v1`
+  recipes, indexed in FTS5 and recalled into later prompts (the "closed learning
+  loop").
+
+## Related
+
+- [Architecture](/explanation/architecture)
+- [A2A protocol](/explanation/a2a-protocol) — streaming + cost-v1
+- [Cost & trace propagation](/explanation/cost-and-trace)
+- [Configuration reference](/reference/configuration)

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -70,11 +70,27 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
     if config.compaction_enabled:
         from langchain.agents.middleware import SummarizationMiddleware
         summ_model = create_llm(config, model_name=config.compaction_model or None)
-        middleware.append(SummarizationMiddleware(
-            model=summ_model,
-            trigger=_parse_compaction_trigger(config.compaction_trigger),
-            keep=("messages", config.compaction_keep_messages),
-        ))
+        keep = ("messages", config.compaction_keep_messages)
+        try:
+            mw = SummarizationMiddleware(
+                model=summ_model,
+                trigger=_parse_compaction_trigger(config.compaction_trigger),
+                keep=keep,
+            )
+        except ValueError:
+            # `fraction:`/`tokens:` triggers need the model's context-window
+            # profile, which custom gateway aliases don't expose — langchain
+            # raises here. Fall back to a message-count trigger so compaction
+            # still runs instead of taking down the whole graph at load.
+            import logging
+            fallback = max(config.compaction_keep_messages * 3, 60)
+            logging.getLogger(__name__).warning(
+                "[compaction] trigger %r needs a model profile that %r lacks; "
+                "falling back to messages:%d",
+                config.compaction_trigger, config.model_name, fallback,
+            )
+            mw = SummarizationMiddleware(model=summ_model, trigger=("messages", fallback), keep=keep)
+        middleware.append(mw)
 
     # Model routing / failover — retry on fallback models (same gateway).
     if config.routing_fallback_models:

--- a/graph/config.py
+++ b/graph/config.py
@@ -129,9 +129,13 @@ class LangGraphConfig:
     cache_warming_interval_seconds: int = 3300  # 55m — just under the 1h tier
 
     # Context compaction — wires langchain's SummarizationMiddleware to
-    # summarize old history near the context limit. Opt-in. trigger is
+    # summarize old history near the context limit. ON by default (a long
+    # session would otherwise overflow the window). trigger is
     # "fraction:0.8" | "tokens:120000" | "messages:80"; keep = last N messages.
-    compaction_enabled: bool = False
+    # NOTE: "fraction:"/"tokens:" triggers need the model's context-window
+    # profile; for a custom gateway alias that lacks one, the wiring falls back
+    # to a message-count trigger (see graph/agent.py) instead of crashing.
+    compaction_enabled: bool = True
     compaction_trigger: str = "fraction:0.8"
     compaction_keep_messages: int = 20
     compaction_model: str = ""            # blank = summarize with the main model

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ that pytest inserts during collection.
 """
 from __future__ import annotations
 
+import os
 import site
 import sys
 
@@ -17,3 +18,10 @@ def pytest_configure(config):  # noqa: ARG001
         if sp in sys.path:
             sys.path.remove(sp)
         sys.path.insert(0, sp)
+
+    # Default-on context compaction builds a summarizer LLM whenever the
+    # middleware stack is assembled, and ChatOpenAI requires a key at
+    # construction. Production always has one at graph-build time; provide a
+    # dummy so middleware-wiring tests don't each need to set it.
+    # `setdefault` never overrides a real key, and no test asserts key-absence.
+    os.environ.setdefault("OPENAI_API_KEY", "test-key")

--- a/tests/test_compaction_routing.py
+++ b/tests/test_compaction_routing.py
@@ -13,9 +13,25 @@ def test_parse_trigger():
     assert _parse_compaction_trigger("garbage") == ("fraction", 0.8)  # safe fallback
 
 
-def test_compaction_off_by_default():
-    mw = _build_middleware(LangGraphConfig(), knowledge_store=None)
-    assert not any(m.__class__.__name__ == "SummarizationMiddleware" for m in mw)
+def test_compaction_on_by_default(monkeypatch):
+    """Compaction is a default-on safety net against context overflow."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    cfg = LangGraphConfig()
+    assert cfg.compaction_enabled
+    mw = _build_middleware(cfg, knowledge_store=None)
+    assert any(m.__class__.__name__ == "SummarizationMiddleware" for m in mw)
+
+
+def test_compaction_fraction_trigger_falls_back_without_model_profile(monkeypatch):
+    """A `fraction:` trigger needs the model's context-window profile, which a
+    custom gateway alias lacks — langchain raises at construction. The wiring
+    must degrade to a message-count trigger, not crash the whole graph at load.
+    Regression: defaulting compaction on would otherwise brick custom-model forks."""
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
+    cfg = LangGraphConfig()  # default trigger "fraction:0.8"; model alias has no profile
+    assert cfg.compaction_trigger.startswith("fraction:")
+    mw = _build_middleware(cfg, knowledge_store=None)  # must not raise
+    assert any(m.__class__.__name__ == "SummarizationMiddleware" for m in mw)
 
 
 def test_compaction_wired_when_enabled(tmp_path, monkeypatch):
@@ -28,7 +44,9 @@ def test_compaction_wired_when_enabled(tmp_path, monkeypatch):
     assert any(m.__class__.__name__ == "SummarizationMiddleware" for m in mw)
 
 
-def test_routing_off_by_default():
+def test_routing_off_by_default(monkeypatch):
+    # Default-on compaction builds a summarizer LLM, which needs a key.
+    monkeypatch.setenv("OPENAI_API_KEY", "test-key")
     mw = _build_middleware(LangGraphConfig(), knowledge_store=None)
     assert not any(m.__class__.__name__ == "ModelFallbackMiddleware" for m in mw)
 


### PR DESCRIPTION
From the Hermes Agent (Nous) / OpenClaw review: protoAgent already had the core optimizations wired (compaction, aux-model routing, programmatic tool calling, prefix caching, failover) but most were **opt-in**. This turns on the safe, high-value default and documents the rest.

## Changes
- **Compaction on by default** (`compaction_enabled = True`) — a long session would otherwise overflow the context window. The `SummarizationMiddleware` summarizes the middle of the history, keeping the last N turns. Fires only near the limit.
- **Resilient trigger (the enabler)** — `fraction:`/`tokens:` triggers need the model's context-window *profile*; a custom gateway alias (`protolabs/reasoning`) doesn't expose one, so langchain **raises at construction**. The wiring now catches that and falls back to a message-count trigger (logged) instead of crashing the graph at load. Without this, defaulting compaction on would brick any fork on a custom-model gateway. *(Verified: this exact crash happened when I first enabled it.)*
- **`example.yaml`** — documented `compaction` / `routing` / `goal.eval_model` / `execute_code` blocks, with the profile caveat, the aux-model routing pattern, and the `execute_code` security note.
- **Docs** — new **Tuning & cost** explanation page mapping every lever to config, wired into the sidebar.
- **Tests** — compaction-on-by-default + a fraction-trigger-fallback regression; `conftest` sets a dummy `OPENAI_API_KEY` (default-on compaction builds a summarizer LLM at middleware assembly; production always has a key there).

## Deliberately unchanged
- `execute_code` stays **off** by default (runs model-authored code — opt-in per deployment, ideally in a container).
- `compaction_model` / `goal_eval_model` stay blank (the cheap-alias name is fork-specific). Deployment tuning (routing aux calls to `protolabs/fast`, enabling `execute_code`) lives in the untracked live config.

Full suite **693 passed**; docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)