### PR TITLE
Fast-model router: unified routing.aux_model + per-subagent override

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -85,14 +85,18 @@ compaction:
   keep_messages: 20
   # model: protolabs/fast
 
-# Model routing / failover — on a primary error, retry on each fallback model
-# (same gateway) in order. Empty = no failover.
+# Model routing / failover.
+#   aux_model: ONE cheap/fast alias for the non-reasoning calls — context
+#     summarization, goal verification, and subagent delegation all fall back
+#     to it unless they set a specific override. Blank = main model everywhere.
+#   fallback_models: on a primary error, retry on each in order. Empty = none.
 routing:
+  # aux_model: protolabs/fast
   fallback_models: []
   #  - claude-haiku-4-5
 
-# Goal mode — route the goal verifier (classification, not the main reasoning
-# task) to a cheaper model with `eval_model`. Blank = main model.
+# Goal mode — route the goal verifier to a cheaper model with `eval_model`
+# (else it uses routing.aux_model, else the main model).
 goal:
   # eval_model: protolabs/fast
   max_iterations: 8

--- a/docs/explanation/tuning-and-cost.md
+++ b/docs/explanation/tuning-and-cost.md
@@ -40,16 +40,20 @@ graph — but for deterministic behavior on a profile-less model, set
 
 ## Aux-model routing
 
-Not every model call is the hard reasoning task. Summarization and goal
-verification are classification-grade work — route them to a cheaper, faster
-alias and reserve the reasoning model for the actual turn:
+Not every model call is the hard reasoning task. Context summarization, goal
+verification, and **subagent delegation** are lighter work — route them to a
+cheaper, faster alias and reserve the reasoning model for the lead turn. One
+knob covers all three:
 
 ```yaml
-compaction:
-  model: protolabs/fast
-goal:
-  eval_model: protolabs/fast
+routing:
+  aux_model: protolabs/fast
 ```
+
+Each path resolves **specific override → `routing.aux_model` → main model**, so
+you can still pin an individual path: `compaction.model`, `goal.eval_model`, or
+a per-subagent `model` (in `graph/subagents/config.py`) — e.g. keep a
+heavy-reasoning subagent on the main model while the rest run on the fast alias.
 
 ## Programmatic tool calling (`execute_code`)
 

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -69,7 +69,7 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
     # Context compaction — summarize old history near the context limit.
     if config.compaction_enabled:
         from langchain.agents.middleware import SummarizationMiddleware
-        summ_model = create_llm(config, model_name=config.compaction_model or None)
+        summ_model = create_llm(config, model_name=_resolve_aux_model(config, config.compaction_model))
         keep = ("messages", config.compaction_keep_messages)
         try:
             mw = SummarizationMiddleware(
@@ -103,6 +103,16 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
     return middleware
 
 
+def _resolve_aux_model(config, specific: str = "") -> str | None:
+    """Pick the model for an auxiliary call: a specific override, else the
+    shared ``routing.aux_model`` fast alias, else None (→ the main model)."""
+    for candidate in (specific, getattr(config, "aux_model", "")):
+        cleaned = (candidate or "").strip()
+        if cleaned:
+            return cleaned
+    return None
+
+
 def _parse_compaction_trigger(spec: str):
     """Parse 'fraction:0.8' / 'tokens:120000' / 'messages:80' → langchain trigger tuple."""
     try:
@@ -119,7 +129,7 @@ def _parse_compaction_trigger(spec: str):
 
 async def _run_subagent(
     *,
-    llm,
+    config,
     tool_map: dict,
     available_subagents: str,
     description: str,
@@ -148,8 +158,11 @@ async def _run_subagent(
     if not sub_tools:
         return f"Error: No tools available for subagent '{subagent_type}'."
 
+    # Subagent model: per-subagent override → routing.aux_model → main model.
+    sub_llm = create_llm(config, model_name=_resolve_aux_model(config, getattr(sub_config, "model", "")))
+
     subagent = create_agent(
-        model=llm,
+        model=sub_llm,
         tools=sub_tools,
         middleware=[AuditMiddleware()],
         system_prompt=build_subagent_prompt(subagent_type),
@@ -249,13 +262,12 @@ async def run_manual_subagent(
     work. It intentionally uses the same private runner as ``task`` so audit,
     prompt, max-turn, and one-level delegation behavior stay aligned.
     """
-    llm = create_llm(config)
     all_tools = get_all_tools(knowledge_store, scheduler=scheduler)
     tool_map = {t.name: t for t in all_tools}
     available_subagents = ", ".join(SUBAGENT_REGISTRY.keys()) or "(none configured)"
 
     return await _run_subagent(
-        llm=llm,
+        config=config,
         tool_map=tool_map,
         available_subagents=available_subagents,
         description=description,
@@ -329,7 +341,6 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
 
     from langchain_core.tools import tool
 
-    llm = create_llm(config)
     tool_map = {t.name: t for t in all_tools}
     available_subagents = ", ".join(SUBAGENT_REGISTRY.keys()) or "(none configured)"
     max_concurrency = max(1, config.subagent_max_concurrency)
@@ -358,7 +369,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
                 or when the subagent config has allow_skill_emission=False.
         """
         return await _run_subagent(
-            llm=llm,
+            config=config,
             tool_map=tool_map,
             available_subagents=available_subagents,
             description=description,
@@ -407,7 +418,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
                 return f"Error: task '{desc}' is missing 'prompt'."
             async with sem:
                 return await _run_subagent(
-                    llm=llm,
+                    config=config,
                     tool_map=tool_map,
                     available_subagents=available_subagents,
                     description=desc,

--- a/graph/config.py
+++ b/graph/config.py
@@ -157,6 +157,12 @@ class LangGraphConfig:
     # On primary error, retry on each fallback model (same gateway) in order.
     routing_fallback_models: list[str] = field(default_factory=list)
 
+    # Auxiliary model — a single cheap/fast alias for the non-reasoning calls
+    # (context summarization, goal verification, subagent delegation). Each of
+    # those paths uses its own specific override if set, else falls back to
+    # this, else the main model. Blank = everything on the main model.
+    aux_model: str = ""
+
     # Goal mode — testable-outcome goals the agent self-drives toward. The
     # machinery is available when enabled, but no goal is active until one is
     # set via `/goal` (a control message) or the /goal HTTP endpoints. After
@@ -308,6 +314,7 @@ class LangGraphConfig:
             execute_code_tools=data.get("execute_code", {}).get("tools", []),
             execute_code_output_truncate=data.get("execute_code", {}).get("output_truncate", cls.execute_code_output_truncate),
             routing_fallback_models=data.get("routing", {}).get("fallback_models", []),
+            aux_model=data.get("routing", {}).get("aux_model", cls.aux_model),
             goal_enabled=data.get("goal", {}).get("enabled", cls.goal_enabled),
             goal_max_iterations=data.get("goal", {}).get("max_iterations", cls.goal_max_iterations),
             goal_no_progress_limit=data.get("goal", {}).get("no_progress_limit", cls.goal_no_progress_limit),

--- a/graph/goals/verifiers.py
+++ b/graph/goals/verifiers.py
@@ -176,7 +176,13 @@ async def _verify_llm(spec: dict, ctx: VerifyContext) -> VerifyResult:
 
         from graph.llm import create_llm
 
-        model_name = getattr(ctx.config, "goal_eval_model", "") or None
+        # Goal verification is classification, not the main reasoning task:
+        # eval_model override → routing.aux_model → main model.
+        model_name = (
+            getattr(ctx.config, "goal_eval_model", "")
+            or getattr(ctx.config, "aux_model", "")
+            or None
+        )
         llm = create_llm(ctx.config, model_name=model_name)
         prompt = (
             f"GOAL: {spec.get('condition') or ctx.condition}\n\n"

--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -35,6 +35,10 @@ class SubagentConfig:
     tools: list[str] = field(default_factory=list)
     disallowed_tools: list[str] = field(default_factory=lambda: ["task"])
     max_turns: int = 30
+    # Per-subagent model override. Blank = fall back to routing.aux_model, then
+    # the main model. Pin a subagent that needs heavy reasoning to the main
+    # model even when aux_model routes the others to a cheaper alias.
+    model: str = ""
     # When False, skill-v1 artifact emission is suppressed even if the caller
     # passes emit_skill=True to task(). Set to False for subagents whose
     # workflows should not be captured as reusable skills (e.g. agents that

--- a/tests/test_compaction_routing.py
+++ b/tests/test_compaction_routing.py
@@ -2,8 +2,30 @@
 
 import yaml
 
-from graph.agent import _build_middleware, _parse_compaction_trigger
+from graph.agent import _build_middleware, _parse_compaction_trigger, _resolve_aux_model
 from graph.config import LangGraphConfig
+
+
+def test_resolve_aux_model_precedence():
+    """specific override > routing.aux_model > main model (None)."""
+    cfg = LangGraphConfig()
+    assert _resolve_aux_model(cfg, "") is None            # no aux set → main model
+    cfg.aux_model = "protolabs/fast"
+    assert _resolve_aux_model(cfg, "") == "protolabs/fast"        # falls back to aux
+    assert _resolve_aux_model(cfg, "explicit") == "explicit"     # specific wins
+    assert _resolve_aux_model(cfg, "  ") == "protolabs/fast"     # blank/whitespace → aux
+
+
+def test_aux_model_parsed_from_routing_yaml(tmp_path):
+    p = tmp_path / "c.yaml"
+    p.write_text(yaml.safe_dump({"routing": {"aux_model": "protolabs/fast"}}))
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.aux_model == "protolabs/fast"
+
+
+def test_subagent_model_override_field_defaults_blank():
+    from graph.subagents.config import SUBAGENT_REGISTRY
+    assert getattr(SUBAGENT_REGISTRY["researcher"], "model", None) == ""
 
 
 def test_parse_trigger():

--- a/tests/test_skill_persistence.py
+++ b/tests/test_skill_persistence.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from datetime import datetime, timezone
 from types import SimpleNamespace
 
+from graph.config import LangGraphConfig
 from graph.skills.index import SkillsIndex
 
 
@@ -125,7 +126,7 @@ async def test_run_subagent_persists_emitted_skill(tmp_path, monkeypatch) -> Non
 
     idx = SkillsIndex(str(tmp_path / "s.db"))
     out = await agentmod._run_subagent(
-        llm=object(),
+        config=LangGraphConfig(),
         tool_map={"web_search": web_search},
         available_subagents="researcher",
         description="find the capital of France",
@@ -159,7 +160,7 @@ async def test_run_subagent_no_persist_without_index(tmp_path, monkeypatch) -> N
         return ""
 
     out = await agentmod._run_subagent(
-        llm=object(), tool_map={"web_search": web_search}, available_subagents="researcher",
+        config=LangGraphConfig(), tool_map={"web_search": web_search}, available_subagents="researcher",
         description="x", prompt="y", subagent_type="researcher", emit_skill=True, skills_index=None,
     )
     assert "ok" in out


### PR DESCRIPTION
Extends the fast-model routing beyond compaction + goal eval to **subagents**, behind one knob.

## Changes
- **`routing.aux_model`** — a single cheap/fast alias that context summarization, goal verification, and subagent delegation fall back to. Per-path resolution: **specific override → `aux_model` → main model** (`_resolve_aux_model`).
- **Subagents now route** — `_run_subagent` previously reused the lead model; it now builds its own LLM from the resolved subagent model (refactored `llm=` → `config=` across the three callers: `task`, `task_batch`, `run_manual_subagent`).
- **Per-subagent `model` override** on `SubagentConfig` — pin a heavy-reasoning subagent to the main model while the rest use the fast alias.
- Goal verifier + compaction consult `aux_model` when their specific override is blank.

## Verified
Against the real agent: with `routing.aux_model: protolabs/fast`, a `task` delegation runs the subagent on the fast model and completes cleanly. Live config simplified to the single knob (dropped the per-path `compaction.model` / `goal.eval_model`).

## Tests
aux-model precedence (specific > aux > main, whitespace-safe), `routing.aux_model` YAML parsing, per-subagent `model` default; updated the two `_run_subagent` callers in `test_skill_persistence` to the new `config=` signature. Full suite **696 passed**.

Docs + example.yaml updated. These `routing.aux_model` / per-subagent fields will surface in the upcoming Settings UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)