### PR TITLE
Add schema-driven settings backend (all config sections)

### DIFF
--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -1,0 +1,200 @@
+"""Settings schema — the single source of truth for the operator console's
+generic Settings UI.
+
+Each :class:`Field` maps a YAML path (``key``, e.g. ``compaction.enabled``) to
+the ``LangGraphConfig`` attribute that holds its live value (``attr``), plus the
+metadata the UI needs to render an input and tell the user whether a change
+applies on save (hot-reload) or needs a process ``restart``.
+
+The write path reuses ``_apply_settings_changes`` (validate → persist → reload),
+so this module only has to: describe fields, read current values, and turn the
+flat ``{key: value}`` payload the UI sends back into the nested dict the YAML
+writer expects.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+
+@dataclass
+class Field:
+    key: str                      # dotted YAML path, e.g. "model.temperature"
+    attr: str                     # LangGraphConfig attribute holding the value
+    label: str
+    type: str                     # string|number|bool|select|string_list|secret
+    section: str
+    description: str = ""
+    restart: bool = False         # True = needs a full process restart (not hot-reload)
+    options: list[str] = field(default_factory=list)
+    options_source: str = ""      # "models" → filled dynamically by the endpoint
+    minimum: float | None = None
+    maximum: float | None = None
+
+
+# Ordered registry. Section order here is the order the UI renders groups in.
+FIELDS: list[Field] = [
+    # ── Model ────────────────────────────────────────────────────────────────
+    Field("model.name", "model_name", "Primary model", "select", "Model",
+          "The main reasoning model (gateway alias).", options_source="models"),
+    Field("model.provider", "model_provider", "Provider", "string", "Model"),
+    Field("model.api_base", "api_base", "API base URL", "string", "Model"),
+    Field("model.api_key", "api_key", "API key", "secret", "Model",
+          "Stored in secrets.yaml, never echoed back."),
+    Field("model.temperature", "temperature", "Temperature", "number", "Model",
+          minimum=0, maximum=2),
+    Field("model.max_tokens", "max_tokens", "Max output tokens", "number", "Model", minimum=1),
+    Field("model.max_iterations", "max_iterations", "Max tool iterations", "number", "Model",
+          "Hard cap on the agent loop per turn.", minimum=1),
+
+    # ── Routing ──────────────────────────────────────────────────────────────
+    Field("routing.aux_model", "aux_model", "Auxiliary (fast) model", "string", "Routing",
+          "Cheap/fast alias for summarization, goal-verification, and subagents. "
+          "Blank = use the main model."),
+    Field("routing.fallback_models", "routing_fallback_models", "Fallback models", "string_list",
+          "Routing", "Retried in order when the primary model errors."),
+
+    # ── Context compaction ───────────────────────────────────────────────────
+    Field("compaction.enabled", "compaction_enabled", "Enable compaction", "bool", "Compaction",
+          "Summarize old history near the context limit."),
+    Field("compaction.trigger", "compaction_trigger", "Trigger", "string", "Compaction",
+          'fraction:0.8 | tokens:120000 | messages:80 (fraction/tokens need a model profile).'),
+    Field("compaction.keep_messages", "compaction_keep_messages", "Keep last N messages", "number",
+          "Compaction", minimum=1),
+    Field("compaction.model", "compaction_model", "Summarizer model", "string", "Compaction",
+          "Blank = routing.aux_model, then the main model."),
+
+    # ── Goal mode ────────────────────────────────────────────────────────────
+    Field("goal.enabled", "goal_enabled", "Enable goal mode", "bool", "Goal mode"),
+    Field("goal.max_iterations", "goal_max_iterations", "Max continuations", "number", "Goal mode",
+          minimum=1),
+    Field("goal.eval_model", "goal_eval_model", "Verifier model", "string", "Goal mode",
+          "Blank = routing.aux_model, then the main model."),
+
+    # ── Programmatic tool calling ────────────────────────────────────────────
+    Field("execute_code.enabled", "execute_code_enabled", "Enable execute_code", "bool", "Tools",
+          "Lets the model run one Python script composing many tools. SECURITY: runs "
+          "model-authored code in a sandboxed subprocess — only enable for trusted "
+          "models or in a hardened container."),
+    Field("execute_code.timeout", "execute_code_timeout", "Script timeout (s)", "number", "Tools",
+          minimum=1),
+
+    # ── Prompt caching ───────────────────────────────────────────────────────
+    Field("prompt_cache.enabled", "prompt_cache_enabled", "Enable prefix caching", "bool", "Caching",
+          "Anthropic prefix caching on the stable prompt; no-op on non-Anthropic models."),
+    Field("prompt_cache.ttl", "prompt_cache_ttl", "Cache TTL", "select", "Caching",
+          options=["5m", "1h"]),
+    Field("prompt_cache.warm.enabled", "cache_warming_enabled", "Cache warming", "bool", "Caching",
+          "Reproduce the cached prefix on an interval (only for sporadic, latency-sensitive traffic)."),
+    Field("prompt_cache.warm.interval_seconds", "cache_warming_interval_seconds",
+          "Warm interval (s)", "number", "Caching", minimum=1),
+
+    # ── Knowledge / memory ───────────────────────────────────────────────────
+    Field("knowledge.top_k", "knowledge_top_k", "Knowledge recall top-k", "number", "Knowledge",
+          minimum=1),
+    Field("knowledge.embed_model", "embed_model", "Embedding model", "string", "Knowledge"),
+    Field("skills.top_k", "skills_top_k", "Skill recall top-k", "number", "Knowledge", minimum=1),
+
+    # ── Middleware toggles ───────────────────────────────────────────────────
+    Field("middleware.knowledge", "knowledge_middleware", "Knowledge middleware", "bool", "Middleware"),
+    Field("middleware.memory", "memory_middleware", "Memory middleware", "bool", "Middleware"),
+    Field("middleware.audit", "audit_middleware", "Audit middleware", "bool", "Middleware"),
+    Field("middleware.scheduler", "scheduler_enabled", "Scheduler", "bool", "Middleware"),
+    Field("middleware.enforcement", "enforcement_enabled", "Tool enforcement", "bool", "Middleware"),
+
+    # ── Identity / operator ──────────────────────────────────────────────────
+    Field("identity.name", "identity_name", "Agent name", "string", "Identity"),
+    Field("identity.operator", "identity_operator", "Operator", "string", "Identity"),
+    Field("operator.allowed_dirs", "operator_allowed_dirs", "Allowed project dirs", "string_list",
+          "Identity", "Directories the beads/notes APIs may touch."),
+    Field("auth.token", "auth_token", "A2A auth token", "secret", "Identity",
+          "Bearer token for the A2A endpoint. Stored in secrets.yaml; applies live."),
+
+    # ── Runtime (restart) ────────────────────────────────────────────────────
+    Field("runtime.autostart_on_boot", "autostart_on_boot", "Autostart on boot", "bool", "Runtime",
+          "Install/remove the boot LaunchAgent.", restart=True),
+]
+
+_BY_KEY = {f.key: f for f in FIELDS}
+_SECRET_KEYS = {f.key for f in FIELDS if f.type == "secret"}
+
+
+def build_schema(config, *, model_options: list[str] | None = None) -> list[dict[str, Any]]:
+    """Return the settings schema grouped by section, with current values.
+
+    Secrets report ``value: ""`` plus ``is_set`` rather than echoing the secret.
+    """
+    defaults = type(config)()
+    groups: dict[str, dict[str, Any]] = {}
+    for f in FIELDS:
+        current = getattr(config, f.attr, None)
+        entry: dict[str, Any] = {
+            "key": f.key,
+            "label": f.label,
+            "type": f.type,
+            "section": f.section,
+            "description": f.description,
+            "restart": f.restart,
+            "options": (model_options or []) if f.options_source == "models" else list(f.options),
+            "default": _jsonable(getattr(defaults, f.attr, None)),
+        }
+        if f.type == "secret":
+            entry["value"] = ""
+            entry["is_set"] = bool(current)
+        else:
+            entry["value"] = _jsonable(current)
+        if f.minimum is not None:
+            entry["minimum"] = f.minimum
+        if f.maximum is not None:
+            entry["maximum"] = f.maximum
+        groups.setdefault(f.section, {"section": f.section, "fields": []})["fields"].append(entry)
+    return list(groups.values())
+
+
+def validate_flat(updates: dict[str, Any]) -> tuple[bool, str | None]:
+    """Light per-field validation against the registry before persisting."""
+    for key, val in updates.items():
+        f = _BY_KEY.get(key)
+        if f is None:
+            return False, f"unknown setting: {key}"
+        if f.type == "bool" and not isinstance(val, bool):
+            return False, f"{key} must be a boolean"
+        if f.type == "number":
+            if not isinstance(val, (int, float)) or isinstance(val, bool):
+                return False, f"{key} must be a number"
+            if f.minimum is not None and val < f.minimum:
+                return False, f"{key} must be ≥ {f.minimum}"
+            if f.maximum is not None and val > f.maximum:
+                return False, f"{key} must be ≤ {f.maximum}"
+        if f.type == "string_list" and not (isinstance(val, list) and all(isinstance(x, str) for x in val)):
+            return False, f"{key} must be a list of strings"
+        if f.type == "select" and f.options and val not in f.options:
+            return False, f"{key} must be one of {f.options}"
+    return True, None
+
+
+def nest_updates(updates: dict[str, Any]) -> dict[str, Any]:
+    """Turn a flat ``{"model.temperature": 0.5}`` payload into the nested dict
+    the YAML writer expects, dropping unset secrets (empty string)."""
+    nested: dict[str, Any] = {}
+    for key, val in updates.items():
+        if key in _SECRET_KEYS and (val is None or val == ""):
+            continue  # leave an existing secret untouched
+        cursor = nested
+        parts = key.split(".")
+        for part in parts[:-1]:
+            cursor = cursor.setdefault(part, {})
+        cursor[parts[-1]] = val
+    return nested
+
+
+def restart_keys(updates: dict[str, Any]) -> list[str]:
+    """Keys in the payload that need a process restart to take effect."""
+    return [k for k in updates if (_BY_KEY.get(k) and _BY_KEY[k].restart)]
+
+
+def _jsonable(val: Any) -> Any:
+    if isinstance(val, (list, tuple)):
+        return list(val)
+    return val

--- a/server.py
+++ b/server.py
@@ -1662,6 +1662,36 @@ def _main():
         from graph.config_io import read_soul_preset
         return {"name": name, "content": read_soul_preset(name)}
 
+    # --- Generic settings (schema-driven UI) --------------------------------
+    @fastapi_app.get("/api/settings/schema")
+    async def _api_settings_schema():
+        """All editable settings, grouped, with current values + metadata
+        (type, default, restart-vs-hot-reload, description). Drives the
+        operator console's Settings surface."""
+        from graph.config_io import list_gateway_models
+        from graph.settings_schema import build_schema
+
+        models: list[str] = []
+        if _graph_config is not None:
+            models, _ = list_gateway_models(_graph_config.api_base, _graph_config.api_key)
+        return {"groups": build_schema(_graph_config, model_options=models)}
+
+    class SettingsUpdateRequest(PydanticBaseModel):
+        updates: dict[str, Any] = {}
+
+    @fastapi_app.post("/api/settings")
+    async def _api_save_settings(req: SettingsUpdateRequest):
+        """Validate a flat {key: value} payload, persist it to YAML (secrets
+        split out), and hot-reload the graph. Returns any keys that need a
+        full process restart to take effect."""
+        from graph.settings_schema import nest_updates, restart_keys, validate_flat
+
+        ok, err = validate_flat(req.updates)
+        if not ok:
+            return {"ok": False, "messages": [f"validation: {err}"], "restart_required": []}
+        ok, messages = _apply_settings_changes(config=nest_updates(req.updates))
+        return {"ok": ok, "messages": messages, "restart_required": restart_keys(req.updates)}
+
     # --- OpenAI-compatible chat completions --------------------------------
     # Lets this agent be registered as a model in the LiteLLM gateway /
     # OpenWebUI without any protocol adapter.

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -1,0 +1,72 @@
+"""Tests for the settings schema layer (graph/settings_schema.py)."""
+
+from __future__ import annotations
+
+from graph.config import LangGraphConfig
+from graph.settings_schema import (
+    FIELDS,
+    build_schema,
+    nest_updates,
+    restart_keys,
+    validate_flat,
+)
+
+
+def test_schema_groups_and_values():
+    cfg = LangGraphConfig()
+    groups = build_schema(cfg, model_options=["a", "b"])
+    # Grouped, ordered, every field carries the metadata the UI needs.
+    assert [g["section"] for g in groups][:3] == ["Model", "Routing", "Compaction"]
+    fields = [f for g in groups for f in g["fields"]]
+    assert len(fields) == len(FIELDS)
+    for f in fields:
+        assert {"key", "label", "type", "value", "default", "restart", "description"} <= set(f)
+    # The model select is populated from the probed options.
+    model = next(f for f in fields if f["key"] == "model.name")
+    assert model["type"] == "select" and model["options"] == ["a", "b"]
+
+
+def test_secrets_are_redacted_with_is_set():
+    cfg = LangGraphConfig()
+    cfg.auth_token = "super-secret"
+    fields = {f["key"]: f for g in build_schema(cfg) for f in g["fields"]}
+    tok = fields["auth.token"]
+    assert tok["type"] == "secret" and tok["value"] == "" and tok["is_set"] is True
+    assert fields["model.api_key"]["is_set"] is False  # default blank
+
+
+def test_current_values_reflect_config():
+    cfg = LangGraphConfig()
+    cfg.compaction_enabled = True
+    cfg.aux_model = "protolabs/fast"
+    fields = {f["key"]: f for g in build_schema(cfg) for f in g["fields"]}
+    assert fields["compaction.enabled"]["value"] is True
+    assert fields["routing.aux_model"]["value"] == "protolabs/fast"
+
+
+def test_validate_rejects_bad_types_and_bounds():
+    assert validate_flat({"compaction.enabled": "yes"})[0] is False     # not bool
+    assert validate_flat({"model.temperature": 5})[0] is False          # > max 2
+    assert validate_flat({"model.max_iterations": 0})[0] is False        # < min 1
+    assert validate_flat({"routing.fallback_models": "x"})[0] is False   # not list
+    assert validate_flat({"prompt_cache.ttl": "9m"})[0] is False         # not in options
+    assert validate_flat({"nope.nope": 1})[0] is False                   # unknown key
+    assert validate_flat({"model.temperature": 0.5, "compaction.enabled": True})[0] is True
+
+
+def test_nest_updates_builds_yaml_shape_and_drops_blank_secrets():
+    nested = nest_updates({
+        "model.temperature": 0.5,
+        "prompt_cache.warm.enabled": True,   # 3-level
+        "auth.token": "",                    # blank secret → dropped (leave existing)
+        "model.api_key": "sk-new",           # set secret → kept
+    })
+    assert nested == {
+        "model": {"temperature": 0.5, "api_key": "sk-new"},
+        "prompt_cache": {"warm": {"enabled": True}},
+    }
+
+
+def test_restart_keys_flags_only_restart_fields():
+    keys = restart_keys({"runtime.autostart_on_boot": True, "model.temperature": 0.5})
+    assert keys == ["runtime.autostart_on_boot"]


### PR DESCRIPTION
Backend foundation for the "manage all settings from the UI" feature.

## What
- **`graph/settings_schema.py`** — one ordered field registry (35 fields / 10 sections) mapping each YAML path → its `LangGraphConfig` attr + the UI metadata: `type` (string/number/bool/select/string_list/secret), `default`, `description`, **`restart`** (hot-reload vs process-restart), select `options`, and bounds. Helpers: `build_schema()` (groups + current values, secrets redacted to `is_set`), `validate_flat`, `nest_updates`, `restart_keys`.
- **`GET /api/settings/schema`** — all settings grouped, model select filled from the gateway model list.
- **`POST /api/settings`** — validates a flat `{key: value}` payload, nests it to YAML shape, and reuses the existing `_apply_settings_changes` (secrets split → persist → **hot-reload** the graph). Returns `restart_required` for the rare restart-only keys.

The write path is generic (`apply_updates_to_yaml` deep-merges any section; ruamel preserves comments), so this covers the sections the old `config_to_dict` didn't — compaction, routing, goal, execute_code, prompt_cache, cache_warming.

## Verified live
Schema lists all 10 sections (aux_model shows `protolabs/fast`); `POST` changing `compaction.keep_messages` persisted to YAML with comments intact and hot-reloaded, `restart_required: []`.

## Tests
Schema shape/values, secret redaction, type+bounds validation, nested YAML assembly (incl. 3-level `prompt_cache.warm.*` and blank-secret drop), restart flagging. Full suite **702 passed**.

Next PR wires the generic Settings UI over this schema.

🤖 Generated with [Claude Code](https://claude.com/claude-code)