### PR TITLE
Add the Settings surface — manage all config from the UI

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -99,6 +99,45 @@ export const NOTES_WORKSPACE = {
   },
 };
 
+// Settings schema the Settings surface renders. Exercises every input type
+// plus a restart-flagged field.
+export const SETTINGS_SCHEMA = [
+  {
+    section: "Model",
+    fields: [
+      { key: "model.name", label: "Primary model", type: "select", section: "Model", restart: false, description: "", options: ["protolabs/reasoning", "protolabs/fast"], value: "protolabs/reasoning", default: "protolabs/agent" },
+      { key: "model.temperature", label: "Temperature", type: "number", section: "Model", restart: false, description: "", options: [], value: 0.2, default: 0.2, minimum: 0, maximum: 2 },
+      { key: "model.api_key", label: "API key", type: "secret", section: "Model", restart: false, description: "Stored in secrets.yaml.", options: [], value: "", is_set: true },
+    ],
+  },
+  {
+    section: "Routing",
+    fields: [
+      { key: "routing.aux_model", label: "Auxiliary (fast) model", type: "string", section: "Routing", restart: false, description: "Cheap alias for aux calls.", options: [], value: "protolabs/fast", default: "" },
+      { key: "routing.fallback_models", label: "Fallback models", type: "string_list", section: "Routing", restart: false, description: "", options: [], value: [], default: [] },
+    ],
+  },
+  {
+    section: "Compaction",
+    fields: [
+      { key: "compaction.enabled", label: "Enable compaction", type: "bool", section: "Compaction", restart: false, description: "", options: [], value: true, default: true },
+    ],
+  },
+  {
+    section: "Runtime",
+    fields: [
+      { key: "runtime.autostart_on_boot", label: "Autostart on boot", type: "bool", section: "Runtime", restart: true, description: "Install/remove the boot LaunchAgent.", options: [], value: false, default: false },
+    ],
+  },
+];
+
+/** restart_required for a flat updates payload, per the schema. */
+export function settingsRestartRequired(updates) {
+  const flagged = new Set();
+  for (const g of SETTINGS_SCHEMA) for (const f of g.fields) if (f.restart) flagged.add(f.key);
+  return Object.keys(updates || {}).filter((k) => flagged.has(k));
+}
+
 const MARKDOWN_ANSWER = [
   "## Summary",
   "",

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -19,6 +19,8 @@ import {
   NOTES_WORKSPACE,
   RUNTIME_STATUS,
   SCHEDULER_JOBS,
+  SETTINGS_SCHEMA,
+  settingsRestartRequired,
   SLASH_COMMANDS,
   SUBAGENTS,
 } from "./fixtures.mjs";
@@ -76,6 +78,8 @@ function handleApiGet(pathname) {
       return { initialized: false };
     case "/api/beads/issues":
       return { issues: [] };
+    case "/api/settings/schema":
+      return { groups: SETTINGS_SCHEMA };
     default:
       return null;
   }
@@ -148,7 +152,14 @@ const server = createServer(async (req, res) => {
       return sendJson(res, { detail: "not mocked" }, 404);
     }
     // POST/PATCH/DELETE writes → generic ok so the UI doesn't error.
-    await readBody(req);
+    const body = await readBody(req);
+    if (pathname === "/api/settings") {
+      return sendJson(res, {
+        ok: true,
+        messages: ["config saved", "reloaded • model=protolabs/reasoning"],
+        restart_required: settingsRestartRequired(body.updates),
+      });
+    }
     return sendJson(res, { ok: true });
   }
   if (req.method !== "GET") {

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+// The Settings surface renders GET /api/settings/schema generically, saves
+// changed fields via POST /api/settings (auto-reload), and flags fields that
+// need a process restart.
+
+async function openSettings(page) {
+  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
+}
+
+test("renders schema groups and current values", async ({ page }) => {
+  await openSettings(page);
+  // Grouped sections from the schema (scope to the group titles — some names
+  // like "Runtime" also appear in the nav rail).
+  // allTextContents (raw DOM text) — innerText would be uppercased by CSS.
+  const titles = await page.locator(".settings-group-title").allTextContents();
+  expect(titles).toEqual(["Model", "Routing", "Compaction", "Runtime"]);
+  // A string field shows its current value.
+  const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
+  await expect(aux).toHaveValue("protolabs/fast");
+  // The restart-flagged field shows the badge.
+  const autostart = page.locator('.setting-row[data-key="runtime.autostart_on_boot"]');
+  await expect(autostart.locator(".setting-restart")).toBeVisible();
+  // Secret is never echoed — empty with a "set" placeholder.
+  const key = page.locator('.setting-row[data-key="model.api_key"] input');
+  await expect(key).toHaveValue("");
+  await expect(key).toHaveAttribute("placeholder", /set/);
+});
+
+test("editing enables save and round-trips", async ({ page }) => {
+  await openSettings(page);
+  const save = page.getByRole("button", { name: /Save & apply/ });
+  await expect(save).toBeDisabled(); // nothing dirty yet
+
+  const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
+  await aux.fill("protolabs/turbo");
+  await expect(save).toBeEnabled();
+  await save.click();
+  // Server (mock) reports saved + reloaded.
+  await expect(page.locator(".settings-status")).toContainText("config saved");
+});
+
+test("toggling a restart-flagged field shows the restart banner", async ({ page }) => {
+  await openSettings(page);
+  await expect(page.locator(".settings-banner")).toHaveCount(0);
+  await page.locator('.setting-row[data-key="runtime.autostart_on_boot"] input[type="checkbox"]').check();
+  await expect(page.locator(".settings-banner")).toContainText("restart");
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -25,12 +25,13 @@ import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
 import { ChatSurface } from "../chat/ChatSurface";
+import { SettingsSurface } from "../settings/SettingsSurface";
 import { api } from "../lib/api";
 import type { BeadsIssue, GoalState, NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
 import { ScrollArea } from "./ScrollArea";
 import { SetupWizard } from "../setup/SetupWizard";
 
-type Surface = "chat" | "subagents" | "runtime" | "schedule" | "goals";
+type Surface = "chat" | "subagents" | "runtime" | "schedule" | "goals" | "settings";
 type RightPanel = "notes" | "beads";
 type SubagentMode = "single" | "batch";
 type StatusTone = "success" | "warning" | "error" | "muted";
@@ -718,6 +719,12 @@ export function App() {
             icon={<Gauge size={18} />}
             onClick={() => setSurface("runtime")}
           />
+          <RailButton
+            active={surface === "settings"}
+            label="Settings"
+            icon={<Settings2 size={18} />}
+            onClick={() => setSurface("settings")}
+          />
         </aside>
 
         <main className="stage">
@@ -1089,6 +1096,8 @@ export function App() {
               </div>
             </section>
           ) : null}
+
+          {surface === "settings" ? <SettingsSurface onError={setError} /> : null}
         </main>
 
         <aside className="right-panel">

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1766,3 +1766,107 @@ textarea {
     transition-duration: 0.001ms !important;
   }
 }
+
+/* ── Settings surface ─────────────────────────────────────────────────────── */
+.settings-actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.settings-banner {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 8px 10px;
+  margin-bottom: 10px;
+  border-radius: var(--radius);
+  background: rgba(212, 189, 79, 0.14);
+  border: 1px solid rgba(212, 189, 79, 0.32);
+  color: #eadf9a;
+  font-size: 0.82rem;
+}
+.settings-banner svg { flex: none; }
+.settings-status {
+  margin: 0 0 10px;
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+}
+.settings-group {
+  margin-bottom: 18px;
+}
+.settings-group-title {
+  margin: 0 0 6px;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--brand-violet-light);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 4px;
+}
+.setting-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 300px);
+  gap: 14px;
+  align-items: start;
+  padding: 9px 0;
+  border-bottom: 1px solid var(--border);
+}
+.setting-row.dirty {
+  /* subtle marker that this field has unsaved edits */
+  box-shadow: inset 2px 0 0 var(--brand-violet);
+  padding-left: 8px;
+}
+.setting-meta { min-width: 0; }
+.setting-label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.86rem;
+  color: var(--fg);
+}
+.setting-restart {
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(212, 189, 79, 0.16);
+  border: 1px solid rgba(212, 189, 79, 0.3);
+  color: #eadf9a;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.setting-desc {
+  margin: 3px 0 0;
+  font-size: 0.76rem;
+  line-height: 1.45;
+  color: var(--fg-muted);
+}
+.setting-control { min-width: 0; }
+.setting-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 6px 8px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+.setting-input:focus {
+  outline: none;
+  border-color: var(--brand-violet);
+}
+.setting-textarea {
+  resize: vertical;
+  line-height: 1.45;
+}
+.setting-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--fg-secondary);
+  cursor: pointer;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   RuntimeStatus,
   ScheduledJob,
   SetupStatus,
+  SettingsGroup,
   SlashCommand,
   Subagent,
   ToolEvent,
@@ -254,6 +255,17 @@ export const api = {
 
   chatCommands() {
     return request<{ commands: SlashCommand[] }>("/api/chat/commands");
+  },
+
+  settingsSchema() {
+    return request<{ groups: SettingsGroup[] }>("/api/settings/schema");
+  },
+
+  saveSettings(updates: Record<string, unknown>) {
+    return request<{ ok: boolean; messages: string[]; restart_required: string[] }>("/api/settings", {
+      method: "POST",
+      body: { updates },
+    });
   },
 
   chat(message: string, sessionId: string) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -67,6 +67,23 @@ export type SlashCommand = {
   usage?: string;
 };
 
+export type SettingsField = {
+  key: string;
+  label: string;
+  type: "string" | "number" | "bool" | "select" | "string_list" | "secret";
+  section: string;
+  description?: string;
+  restart: boolean;
+  options: string[];
+  default?: unknown;
+  value?: unknown; // absent for secrets
+  is_set?: boolean; // secrets only
+  minimum?: number;
+  maximum?: number;
+};
+
+export type SettingsGroup = { section: string; fields: SettingsField[] };
+
 export type GoalState = {
   session_id: string;
   condition: string;

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,0 +1,251 @@
+import { AlertTriangle, RefreshCw, RotateCcw, Save } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { api } from "../lib/api";
+import type { SettingsField, SettingsGroup } from "../lib/types";
+
+// Generic settings surface — renders whatever GET /api/settings/schema returns,
+// so it stays in sync as config grows. Saving POSTs the changed fields and the
+// server hot-reloads the agent; fields flagged `restart` get a badge + banner.
+
+export function SettingsSurface({ onError }: { onError: (message: string) => void }) {
+  const [groups, setGroups] = useState<SettingsGroup[] | null>(null);
+  const [dirty, setDirty] = useState<Record<string, unknown>>({});
+  const [saving, setSaving] = useState(false);
+  const [status, setStatus] = useState("");
+
+  async function load() {
+    try {
+      const r = await api.settingsSchema();
+      setGroups(r.groups);
+      setDirty({});
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  }
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const dirtyKeys = Object.keys(dirty);
+
+  // Pending changes that won't take effect until a process restart.
+  const pendingRestart = useMemo(() => {
+    if (!groups) return [];
+    const labels: string[] = [];
+    for (const g of groups) {
+      for (const f of g.fields) {
+        if (f.restart && f.key in dirty) labels.push(f.label);
+      }
+    }
+    return labels;
+  }, [groups, dirty]);
+
+  async function save() {
+    if (!dirtyKeys.length) return;
+    setSaving(true);
+    setStatus("saving…");
+    onError("");
+    try {
+      const r = await api.saveSettings(dirty);
+      if (!r.ok) {
+        onError(r.messages.join(" · "));
+        setStatus("save failed");
+        return;
+      }
+      const restartNote = r.restart_required.length
+        ? ` — restart required for: ${r.restart_required.join(", ")}`
+        : "";
+      setStatus(`${r.messages.join(" · ")}${restartNote}`);
+      await load();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+      setStatus("save failed");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (!groups) {
+    return (
+      <section className="panel stage-panel">
+        <div className="panel-header">
+          <h1>Settings</h1>
+        </div>
+        <div className="stage-body">
+          <div className="empty-state">
+            <RefreshCw size={16} className="spin" />
+            <span>Loading settings…</span>
+          </div>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section className="panel stage-panel">
+      <div className="panel-header">
+        <div>
+          <h1>Settings</h1>
+          <p className="panel-kicker">
+            {dirtyKeys.length ? `${dirtyKeys.length} unsaved change${dirtyKeys.length === 1 ? "" : "s"}` : "applies on save"}
+          </p>
+        </div>
+        <div className="settings-actions">
+          <button className="secondary-button" type="button" onClick={() => void load()} disabled={saving || !dirtyKeys.length}>
+            <RotateCcw size={15} />
+            Discard
+          </button>
+          <button className="primary-button" type="button" onClick={() => void save()} disabled={saving || !dirtyKeys.length}>
+            <Save size={16} />
+            Save &amp; apply
+          </button>
+        </div>
+      </div>
+      <div className="stage-body">
+        {pendingRestart.length ? (
+          <div className="settings-banner" role="alert">
+            <AlertTriangle size={14} />
+            <span>Needs a restart to take effect: {pendingRestart.join(", ")}</span>
+          </div>
+        ) : null}
+        {status ? <p className="settings-status">{status}</p> : null}
+
+        {groups.map((group) => (
+          <section className="settings-group" key={group.section}>
+            <p className="settings-group-title">{group.section}</p>
+            {group.fields.map((field) => (
+              <SettingRow
+                key={field.key}
+                field={field}
+                dirty={field.key in dirty}
+                value={field.key in dirty ? dirty[field.key] : field.value}
+                onChange={(v) => setDirty((d) => ({ ...d, [field.key]: v }))}
+              />
+            ))}
+          </section>
+        ))}
+      </div>
+    </section>
+  );
+}
+
+function SettingRow({
+  field,
+  value,
+  dirty,
+  onChange,
+}: {
+  field: SettingsField;
+  value: unknown;
+  dirty: boolean;
+  onChange: (value: unknown) => void;
+}) {
+  return (
+    <div className={`setting-row${dirty ? " dirty" : ""}`} data-key={field.key}>
+      <div className="setting-meta">
+        <label className="setting-label" htmlFor={`set-${field.key}`}>
+          {field.label}
+          {field.restart ? <span className="setting-restart">restart</span> : null}
+        </label>
+        {field.description ? <p className="setting-desc">{field.description}</p> : null}
+      </div>
+      <div className="setting-control">
+        <SettingInput field={field} value={value} onChange={onChange} />
+      </div>
+    </div>
+  );
+}
+
+function SettingInput({
+  field,
+  value,
+  onChange,
+}: {
+  field: SettingsField;
+  value: unknown;
+  onChange: (value: unknown) => void;
+}) {
+  const id = `set-${field.key}`;
+
+  if (field.type === "bool") {
+    return (
+      <label className="setting-toggle">
+        <input
+          id={id}
+          type="checkbox"
+          checked={Boolean(value)}
+          onChange={(e) => onChange(e.target.checked)}
+        />
+        <span>{value ? "on" : "off"}</span>
+      </label>
+    );
+  }
+
+  if (field.type === "number") {
+    return (
+      <input
+        id={id}
+        className="setting-input"
+        type="number"
+        value={value === undefined || value === null ? "" : String(value)}
+        min={field.minimum}
+        max={field.maximum}
+        onChange={(e) => onChange(e.target.value === "" ? null : Number(e.target.value))}
+      />
+    );
+  }
+
+  if (field.type === "select" && field.options.length) {
+    return (
+      <select id={id} className="setting-input" value={String(value ?? "")} onChange={(e) => onChange(e.target.value)}>
+        {field.options.map((opt) => (
+          <option key={opt} value={opt}>
+            {opt}
+          </option>
+        ))}
+      </select>
+    );
+  }
+
+  if (field.type === "string_list") {
+    const text = Array.isArray(value) ? value.join("\n") : "";
+    return (
+      <textarea
+        id={id}
+        className="setting-input setting-textarea"
+        rows={3}
+        value={text}
+        placeholder="one per line"
+        onChange={(e) =>
+          onChange(e.target.value.split("\n").map((s) => s.trim()).filter(Boolean))
+        }
+      />
+    );
+  }
+
+  if (field.type === "secret") {
+    return (
+      <input
+        id={id}
+        className="setting-input"
+        type="password"
+        autoComplete="new-password"
+        value={typeof value === "string" ? value : ""}
+        placeholder={field.is_set ? "•••••••• (set — leave blank to keep)" : "unset"}
+        onChange={(e) => onChange(e.target.value)}
+      />
+    );
+  }
+
+  // string + select-without-options fallback
+  return (
+    <input
+      id={id}
+      className="setting-input"
+      type="text"
+      value={typeof value === "string" ? value : value === undefined || value === null ? "" : String(value)}
+      onChange={(e) => onChange(e.target.value)}
+    />
+  );
+}

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -297,6 +297,20 @@ server — not the client — decides which directories they may read and write.
 - The runtime-status `project.allowed_dirs` field feeds the project-path
   picker's suggestions; it does not relax the server-side check.
 
+## Settings surface
+
+The **Settings** rail surface lets an operator manage every config field from
+the UI. It's **schema-driven**: `GET /api/settings/schema` returns the fields
+grouped by section with their type, current value, default, description, and a
+`restart` flag; the React surface (`apps/web/src/settings/SettingsSurface.tsx`)
+renders the inputs generically, so new config fields appear automatically
+without a UI change. Saving POSTs only the changed fields to `POST
+/api/settings`, which validates, writes the YAML (secrets split into
+`secrets.yaml`), and **hot-reloads the agent** in-process — most changes apply
+without a restart. The rare fields that need a process restart carry a `restart`
+badge and raise a banner when edited. Secrets are never echoed back (shown as
+`(set)` / `unset`). The field registry lives in `graph/settings_schema.py`.
+
 ## E2E smoke harness
 
 The console has a Playwright smoke suite under `apps/web/e2e/` that drives the


### PR DESCRIPTION
Completes the "manage all settings from the UI" follow-up (over the schema backend in #310).

## What
A new **Settings** rail surface that renders `GET /api/settings/schema` **generically** — grouped sections with type-appropriate inputs (text / number / toggle / select / string-list / password), per-field descriptions, and a **`restart` badge** on the few fields that need a process restart. Because it's schema-driven, new config fields appear automatically with no UI change.

- **Save → auto-reload**: editing tracks dirty state; *Save & apply* POSTs only the changed fields to `POST /api/settings`, which validates → writes YAML (secrets split to `secrets.yaml`) → **hot-reloads the agent**. A status line reports the result; a banner lists any pending restart-required edits.
- **Secrets**: never echoed — shown as `(set)` / `unset`, only sent when changed.

## Verified
Live against the running backend: the surface renders **all 10 real sections / 35 fields** with current values (Primary model select, redacted API key, `routing.aux_model = protolabs/fast`, compaction toggle, etc.); Save stays disabled until something's dirty.

## Tests
Mock serves `/api/settings/schema` + `/api/settings`; `settings.spec.ts` covers render / current values / secret redaction / restart badge, the edit→save round-trip, and the restart banner. **22 e2e specs green**; `web:build` clean.

Docs: Settings-surface section in the operator-console guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)