### PR TITLE
Console layout polish: settings padding + Runtime heading alignment

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -221,6 +221,17 @@ h2 {
   overflow-y: auto;
 }
 
+/* Section headings stacked inside a scrolling stage body (Runtime, Schedule,
+   Subagents) — inset to align with the inset rows (.table-row padding) below
+   them, with vertical separation from the preceding block. */
+.stage-body > .panel-kicker {
+  padding: 0 12px;
+  margin: 22px 0 8px;
+}
+.stage-body > .panel-kicker:first-child {
+  margin-top: 12px;
+}
+
 .side-panel {
   height: 100%;
   display: grid;
@@ -1793,7 +1804,7 @@ textarea {
   font-family: var(--font-mono);
 }
 .settings-group {
-  margin-bottom: 28px;
+  margin-bottom: 40px;
 }
 .settings-group-title {
   margin: 0 0 4px;
@@ -1806,10 +1817,10 @@ textarea {
 }
 .setting-row {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(220px, 300px);
-  gap: 24px;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+  gap: 28px;
   align-items: center;
-  padding: 16px 4px;
+  padding: 26px 6px;
   border-bottom: 1px solid var(--border);
 }
 .setting-row.dirty {
@@ -1845,7 +1856,7 @@ textarea {
 .setting-input {
   width: 100%;
   box-sizing: border-box;
-  padding: 9px 10px;
+  padding: 11px 12px;
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 6px;

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1793,29 +1793,29 @@ textarea {
   font-family: var(--font-mono);
 }
 .settings-group {
-  margin-bottom: 18px;
+  margin-bottom: 28px;
 }
 .settings-group-title {
-  margin: 0 0 6px;
+  margin: 0 0 4px;
   font-size: 0.72rem;
   letter-spacing: 0.06em;
   text-transform: uppercase;
   color: var(--brand-violet-light);
   border-bottom: 1px solid var(--border);
-  padding-bottom: 4px;
+  padding-bottom: 8px;
 }
 .setting-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(220px, 300px);
-  gap: 14px;
-  align-items: start;
-  padding: 9px 0;
+  gap: 24px;
+  align-items: center;
+  padding: 16px 4px;
   border-bottom: 1px solid var(--border);
 }
 .setting-row.dirty {
   /* subtle marker that this field has unsaved edits */
   box-shadow: inset 2px 0 0 var(--brand-violet);
-  padding-left: 8px;
+  padding-left: 10px;
 }
 .setting-meta { min-width: 0; }
 .setting-label {
@@ -1845,7 +1845,7 @@ textarea {
 .setting-input {
   width: 100%;
   box-sizing: border-box;
-  padding: 6px 8px;
+  padding: 9px 10px;
   background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 6px;


### PR DESCRIPTION
Two layout fixes from feedback.

1. **Settings rows** were cramped — bumped row padding (9px → 26px), label↔control gap, input height, and group spacing for real breathing room.
2. **Runtime / Schedule / Subagents section headings** (Middleware, Skills, MCP servers, Plugins, Subagents) sat flush at the container's left edge while the rows beneath them were inset 12px. Inset the stage-body section headings to align with the rows and added vertical separation.

CSS-only; verified live against the running app (screenshots), e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)