### PR TITLE
Let the agent read/write the operator's Notes panel tabs

### DIFF
--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -6,6 +6,7 @@ Sixteen tools ship by default:
 - Four **GitHub read tools** — `github_get_pr`, `github_get_issue`, `github_list_issues`, `github_get_commit_diff` (`tools/github_tools.py`) — over the `gh` CLI. Each requires an explicit `repo` (`owner/name`, no default); they degrade to a readable error if `gh`/auth is missing. Auth via `GITHUB_TOKEN`/`GH_TOKEN` env, else gh's ambient login.
 - Five **memory tools** — `memory_ingest`, `memory_recall`, `memory_list`, `memory_stats`, `daily_log` — bound to the bundled `KnowledgeStore` (sqlite + FTS5, see [Configuration](/reference/configuration#knowledge)).
 - Three **scheduler tools** — `schedule_task`, `list_schedules`, `cancel_schedule` — bound to the bundled scheduler backend (local sqlite or the Workstacean adapter, see [Schedule future work](/guides/scheduler)).
+- Three **project-notes tools** — `notes_list`, `notes_read`, `notes_write` — bridge the operator console's Notes panel tabs to the agent, gated per-tab by the operator's Agent-read/write toggles.
 
 `get_all_tools(knowledge_store, scheduler)` is the registry. When `knowledge_store` is `None` the memory tools are omitted; when `scheduler` is `None` the scheduler tools are omitted. Both backends are constructed by default in `server.py`; opt out via `middleware.knowledge: false` / `middleware.scheduler: false` in `config/langgraph-config.yaml`.
 
@@ -200,6 +201,31 @@ async def cancel_schedule(job_id: str) -> str
 Cancel a scheduled job by id. Returns `"Canceled <id>."` or `"Error: no such job <id>."`.
 
 Cross-agent cancellation is blocked — `gina-personal` cannot cancel `gina-work`'s jobs even when sharing a sqlite path or a Workstacean install.
+
+## `notes_list` / `notes_read` / `notes_write`
+
+Read and write the **operator console's Notes panel** tabs — the human-curated
+notes the operator keeps in the UI, distinct from the agent's private
+`memory_*` store. Each tab carries `agentRead` / `agentWrite` permission
+toggles in the panel; these tools **honor them per tab**:
+
+```python
+@tool
+async def notes_list(project_path: str = "") -> str          # tabs + read/write flags
+async def notes_read(tab: str = "", project_path: str = "") -> str   # agent-readable tabs only
+async def notes_write(tab: str, content: str, mode: str = "append", project_path: str = "") -> str
+```
+
+- `notes_read` returns only tabs with **Agent read** on (a named tab with it off
+  reports "not shared", never the content); blank `tab` returns every readable tab.
+- `notes_write` only writes tabs with **Agent write** on, to an existing tab
+  (`append` or `replace`), and updates the tab's word/char counts.
+- `project_path` defaults to the current project (the repo root the Notes panel
+  shows); notes live at `<project>/.automaker/notes/workspace.json`.
+
+These bridge the Notes panel's permission toggles to the agent — without them,
+"what's on my Todo tab?" never reaches the notes (the agent would only see its
+`memory_*` store).
 
 ## Adding your own
 

--- a/tests/test_notes_tools.py
+++ b/tests/test_notes_tools.py
@@ -1,0 +1,82 @@
+"""Tests for the project-notes agent tools — per-tab read/write permission gating."""
+
+from __future__ import annotations
+
+import pytest
+
+from operator_api.notes import NotesService
+from tools.notes_tools import notes_list, notes_read, notes_write
+
+
+def _seed(tmp_path):
+    ws = {
+        "version": 1,
+        "workspaceVersion": 0,
+        "activeTabId": "t1",
+        "tabOrder": ["t1", "t2"],
+        "tabs": {
+            "t1": {"id": "t1", "name": "Todo", "content": "buy milk",
+                   "permissions": {"agentRead": True, "agentWrite": True}, "metadata": {}},
+            "t2": {"id": "t2", "name": "Private", "content": "the secret",
+                   "permissions": {"agentRead": False, "agentWrite": False}, "metadata": {}},
+        },
+    }
+    NotesService().save_workspace(str(tmp_path), ws)
+    return str(tmp_path)
+
+
+@pytest.mark.asyncio
+async def test_list_shows_tabs_and_permission_flags(tmp_path):
+    proj = _seed(tmp_path)
+    out = await notes_list.ainvoke({"project_path": proj})
+    assert "Todo [read, write]" in out
+    assert "Private [no-read, no-write]" in out
+
+
+@pytest.mark.asyncio
+async def test_read_named_readable_tab(tmp_path):
+    proj = _seed(tmp_path)
+    out = await notes_read.ainvoke({"tab": "todo", "project_path": proj})  # case-insensitive
+    assert "buy milk" in out
+
+
+@pytest.mark.asyncio
+async def test_read_blocked_when_agentRead_off(tmp_path):
+    proj = _seed(tmp_path)
+    out = await notes_read.ainvoke({"tab": "Private", "project_path": proj})
+    assert "the secret" not in out
+    assert "isn't shared" in out.lower() or "agent read is off" in out.lower()
+
+
+@pytest.mark.asyncio
+async def test_read_all_excludes_non_readable(tmp_path):
+    proj = _seed(tmp_path)
+    out = await notes_read.ainvoke({"project_path": proj})
+    assert "buy milk" in out
+    assert "the secret" not in out
+
+
+@pytest.mark.asyncio
+async def test_write_appends_to_writable_tab(tmp_path):
+    proj = _seed(tmp_path)
+    out = await notes_write.ainvoke({"tab": "Todo", "content": "call mom", "project_path": proj})
+    assert "Updated" in out
+    reloaded = NotesService().load_workspace(proj)
+    assert reloaded["tabs"]["t1"]["content"] == "buy milk\ncall mom"
+    assert reloaded["tabs"]["t1"]["metadata"]["characterCount"] == len("buy milk\ncall mom")
+
+
+@pytest.mark.asyncio
+async def test_write_blocked_when_agentWrite_off(tmp_path):
+    proj = _seed(tmp_path)
+    out = await notes_write.ainvoke({"tab": "Private", "content": "x", "project_path": proj})
+    assert "read-only" in out.lower()
+    # content untouched
+    assert NotesService().load_workspace(proj)["tabs"]["t2"]["content"] == "the secret"
+
+
+@pytest.mark.asyncio
+async def test_write_unknown_tab_errors(tmp_path):
+    proj = _seed(tmp_path)
+    out = await notes_write.ainvoke({"tab": "Nope", "content": "x", "project_path": proj})
+    assert "no notes tab named" in out.lower()

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -521,6 +521,11 @@ def get_all_tools(knowledge_store=None, scheduler=None):
     # included — they degrade to a readable error if gh/auth is missing.
     from tools.github_tools import get_github_tools
     tools.extend(get_github_tools())
+    # Project-notes tools — read/write the operator console's Notes panel tabs,
+    # gated per-tab by the operator's Agent-read/write toggles. Always included
+    # so "what's on my Todo tab?" reaches the notes, not the memory store.
+    from tools.notes_tools import get_notes_tools
+    tools.extend(get_notes_tools())
     # A2A peer-consult tools — only when at least one PEER_<HANDLE>_URL is set,
     # so agents with no federation peers aren't cluttered.
     from tools.peer_tools import get_peer_tools, list_env_peers

--- a/tools/notes_tools.py
+++ b/tools/notes_tools.py
@@ -1,0 +1,148 @@
+"""Project-notes tools — let the agent read/write the operator console's Notes
+panel tabs, respecting each tab's per-tab ``agentRead`` / ``agentWrite``
+permission toggles.
+
+The Notes panel persists a workspace at ``<project>/.automaker/notes/workspace.json``
+(see ``operator_api/notes.py``). Each tab carries
+``permissions: {agentRead, agentWrite}`` — the operator decides which tabs the
+agent may see or edit. These tools are the bridge that makes those toggles
+mean something; without them the agent can't see the operator's notes at all
+(it would otherwise confuse them with its private ``memory_*`` store).
+
+The project defaults to the server's working directory (the repo root the Notes
+panel shows by default); pass ``project_path`` to target another project.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+
+from langchain_core.tools import tool
+
+from operator_api.notes import NotesService
+
+_notes = NotesService()
+
+
+def _project(project_path: str) -> str:
+    return project_path.strip() or os.getcwd()
+
+
+def _find_tab(workspace: dict, name: str):
+    """Return (tab_id, tab) matching ``name`` (case-insensitive), or (None, None)."""
+    target = name.strip().lower()
+    for tab_id, tab in (workspace.get("tabs") or {}).items():
+        if str(tab.get("name", "")).strip().lower() == target:
+            return tab_id, tab
+    return None, None
+
+
+@tool
+async def notes_list(project_path: str = "") -> str:
+    """List the operator's Notes panel tabs and which ones the agent may
+    read/write. Use this to discover the operator's notes (e.g. a "Todo" tab)
+    before reading them. These are the human-curated notes in the console's
+    Notes panel — distinct from your private ``memory_*`` store.
+
+    Args:
+        project_path: Project whose notes to list. Defaults to the current
+            project (the repo root shown in the Notes panel).
+    """
+    ws = _notes.load_workspace(_project(project_path))
+    tabs = ws.get("tabs") or {}
+    if not tabs:
+        return "No notes tabs exist for this project."
+    order = ws.get("tabOrder") or list(tabs.keys())
+    lines = [f"{len(tabs)} notes tab(s):"]
+    for tid in order:
+        tab = tabs.get(tid)
+        if not tab:
+            continue
+        perms = tab.get("permissions") or {}
+        flags = []
+        flags.append("read" if perms.get("agentRead") else "no-read")
+        flags.append("write" if perms.get("agentWrite") else "no-write")
+        chars = len(str(tab.get("content") or ""))
+        lines.append(f"- {tab.get('name', '(unnamed)')} [{', '.join(flags)}] — {chars} chars")
+    return "\n".join(lines)
+
+
+@tool
+async def notes_read(tab: str = "", project_path: str = "") -> str:
+    """Read the operator's Notes panel tab content (only tabs the operator has
+    marked agent-readable). Use this when the operator asks what's in their
+    notes / a specific tab (e.g. "what's on my Todo tab?").
+
+    Args:
+        tab: Tab name to read (case-insensitive). Leave blank to read every
+            agent-readable tab.
+        project_path: Project whose notes to read. Defaults to the current project.
+    """
+    ws = _notes.load_workspace(_project(project_path))
+    tabs = ws.get("tabs") or {}
+
+    if tab.strip():
+        tid, found = _find_tab(ws, tab)
+        if found is None:
+            return f"No notes tab named {tab!r}. Use notes_list to see available tabs."
+        if not (found.get("permissions") or {}).get("agentRead"):
+            return f"The {found.get('name')!r} tab isn't shared with the agent (Agent read is off)."
+        content = str(found.get("content") or "")
+        return f"# {found.get('name')}\n\n{content or '(empty)'}"
+
+    # No tab specified → all readable tabs.
+    order = ws.get("tabOrder") or list(tabs.keys())
+    readable = [
+        tabs[tid] for tid in order
+        if tabs.get(tid) and (tabs[tid].get("permissions") or {}).get("agentRead")
+    ]
+    if not readable:
+        return "No notes tabs are shared with the agent (no tab has Agent read enabled)."
+    blocks = [f"# {t.get('name')}\n\n{str(t.get('content') or '') or '(empty)'}" for t in readable]
+    return "\n\n---\n\n".join(blocks)
+
+
+@tool
+async def notes_write(tab: str, content: str, mode: str = "append", project_path: str = "") -> str:
+    """Write to an operator Notes panel tab (only tabs the operator has marked
+    agent-writable). Use this to record something into the operator's notes
+    (e.g. add an item to their Todo tab).
+
+    Args:
+        tab: Tab name to write (case-insensitive). Must already exist.
+        content: Text to write.
+        mode: "append" (default — add to the end on a new line) or "replace".
+        project_path: Project whose notes to write. Defaults to the current project.
+    """
+    proj = _project(project_path)
+    ws = _notes.load_workspace(proj)
+    tid, found = _find_tab(ws, tab)
+    if found is None:
+        return f"No notes tab named {tab!r}. Use notes_list to see available tabs."
+    if not (found.get("permissions") or {}).get("agentWrite"):
+        return f"The {found.get('name')!r} tab is read-only for the agent (Agent write is off)."
+
+    existing = str(found.get("content") or "")
+    if mode == "replace":
+        new_content = content
+    else:
+        new_content = f"{existing}\n{content}" if existing else content
+
+    found["content"] = new_content
+    meta = found.setdefault("metadata", {})
+    meta["updatedAt"] = int(time.time() * 1000)
+    meta["characterCount"] = len(new_content)
+    meta["wordCount"] = len(new_content.split())
+    ws["workspaceVersion"] = int(ws.get("workspaceVersion", 0)) + 1
+
+    try:
+        _notes.save_workspace(proj, ws)
+    except Exception as e:  # noqa: BLE001 — surface a readable tool error
+        return f"Error: could not save notes: {e}"
+    return f"Updated the {found.get('name')!r} tab ({mode}). It now has {len(new_content)} chars."
+
+
+def get_notes_tools() -> list:
+    """The project-notes tools, gated per-tab by the operator's read/write toggles."""
+    return [notes_list, notes_read, notes_write]


### PR DESCRIPTION
## Bug
The Notes panel's per-tab **Agent read / Agent write** toggles were dead UI — no tool exposed the notes workspace to the agent. Asking *"what's on my Todo tab?"* fell through to the unrelated `memory_*` store, so the agent insisted it had no notes (even with read+write enabled).

## Fix
New `notes_list` / `notes_read` / `notes_write` (`tools/notes_tools.py`), always registered in `get_all_tools`. They operate on the Notes workspace (`<project>/.automaker/notes/workspace.json`) and **honor each tab's permissions**:
- `notes_read` — only agent-readable tabs; a named tab with read off reports "not shared" (never leaks content); blank tab returns all readable tabs.
- `notes_write` — only agent-writable existing tabs (`append`/`replace`); updates word/char counts.
- `project_path` defaults to the current project (the repo root the panel shows).

## Verified live
With the real "Todo" tab (read+write on), the agent now calls `notes_read` and returns its content (`test say bazinga if you see this`) instead of confusing it with memory.

## Tests
Permission gating — read allowed vs blocked (no content leak), all-readable excludes a private tab, write allowed vs read-only refusal, unknown-tab error. Full suite **709 passed**. Docs: starter-tools reference entry + summary.

## Note
These default to the **repo-root** project (matching the panel default) and run with the agent's in-process trust (no extra sandbox). If you operate multiple project notes, the agent reads the current project's unless a `project_path` is passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)