### PR TITLE
Fix agent amnesia — bind the checkpointer at compile time

### DIFF
--- a/graph/agent.py
+++ b/graph/agent.py
@@ -450,6 +450,7 @@ def create_agent_graph(
     skills_index=None,
     extra_tools=None,
     include_subagents: bool = True,
+    checkpointer=None,
 ):
     """Create the protoAgent LangGraph agent.
 
@@ -457,8 +458,15 @@ def create_agent_graph(
     (e.g. MCP-server tools discovered at startup). Appended before subagent /
     middleware assembly so they're in the tool map and visible to the model.
 
+    ``checkpointer`` persists conversation state per ``thread_id``: pass one so
+    multi-turn chats keep their history (the agent sees prior turns instead of
+    starting fresh each message). Compaction middleware summarizes the old part
+    of that history near the context limit. A checkpointer set only in the
+    invoke ``config`` is ignored by LangGraph — it must be bound at compile time.
+
     Returns a compiled graph that can be invoked with:
-        graph.ainvoke({"messages": [HumanMessage(content="...")]})
+        graph.ainvoke({"messages": [HumanMessage(content="...")]},
+                      config={"configurable": {"thread_id": "..."}})
     """
     llm = create_llm(config)
 
@@ -487,6 +495,7 @@ def create_agent_graph(
         tools=all_tools,
         middleware=middleware,
         system_prompt=system_prompt,
+        checkpointer=checkpointer,
     )
 
     return agent

--- a/server.py
+++ b/server.py
@@ -158,6 +158,7 @@ def _init_langgraph_agent():
     _graph = create_agent_graph(
         _graph_config, knowledge_store=_knowledge_store, scheduler=_scheduler,
         skills_index=_skills_index, extra_tools=_mcp_tools + _plugin_tools,
+        checkpointer=_checkpointer,
     )
 
     # Cache-warming heartbeat — off by default; start() no-ops unless enabled
@@ -509,6 +510,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
             new_graph = create_agent_graph(
                 new_config, knowledge_store=new_store, scheduler=next_scheduler,
                 skills_index=new_skills, extra_tools=new_mcp_tools + new_plugin_tools,
+                checkpointer=_checkpointer,
             )
         except Exception as e:
             log.exception("[reload] graph rebuild failed")
@@ -983,14 +985,13 @@ async def _chat_langgraph_stream(
                     yield ("done", reply)
                     return
 
-            # thread_id prefix isolates A2A sessions from Gradio chat in the
-            # shared MemorySaver checkpointer.
+            # thread_id keys this session's history in the checkpointer (bound
+            # at compile time in create_agent_graph). The prefix isolates A2A
+            # sessions from Gradio chat in the shared MemorySaver.
             config = {
                 "configurable": {"thread_id": f"a2a:{session_id}"},
                 "recursion_limit": 200,
             }
-            if _checkpointer:
-                config["checkpointer"] = _checkpointer
 
             # When a goal is already active, the whole turn is goal-driven —
             # suppress cross-session prior_sessions on the initial turn (and the
@@ -1120,8 +1121,6 @@ async def _chat_langgraph(message: str, session_id: str) -> list[dict[str, Any]]
                     return [{"role": "assistant", "content": reply}]
 
             config = {"configurable": {"thread_id": f"gradio:{session_id}"}}
-            if _checkpointer:
-                config["checkpointer"] = _checkpointer
 
             def _last_ai(result) -> str:
                 for msg in reversed(result.get("messages", [])):

--- a/tests/test_agent_checkpointer.py
+++ b/tests/test_agent_checkpointer.py
@@ -1,0 +1,24 @@
+"""Regression: the agent graph must be compiled WITH the checkpointer so
+multi-turn chats keep their history instead of starting fresh each message.
+
+A checkpointer passed only in the invoke `config` is ignored by LangGraph — it
+must be bound at compile time. Missing this gave the agent amnesia: every turn
+ran with just the new message, so it couldn't resolve references to prior turns
+("update it") or recall earlier context.
+"""
+
+from __future__ import annotations
+
+from langgraph.checkpoint.memory import MemorySaver
+
+from graph.agent import create_agent_graph
+from graph.config import LangGraphConfig
+
+
+def test_graph_binds_checkpointer_at_compile_time():
+    g = create_agent_graph(LangGraphConfig(), checkpointer=MemorySaver())
+    assert g.checkpointer is not None
+
+
+def test_graph_has_no_checkpointer_when_none_passed():
+    assert create_agent_graph(LangGraphConfig()).checkpointer is None


### PR DESCRIPTION
## Symptom
The agent had **amnesia**: every chat turn started fresh. It couldn't recall earlier context, and — as you spotted — couldn't resolve references like "update **it**" (it reached for `SOUL.md` because the prior turn naming the Todo tab was gone).

## Root cause
The graph was compiled **without a checkpointer**. The A2A and Gradio paths set `thread_id` and stuffed `_checkpointer` into the *invoke config* — but LangGraph **ignores a checkpointer in the config**; it must be bound at **compile time**. So `thread_id` keyed nothing and no history ever persisted. Each turn ran with just `{"messages": [new message]}`.

## Fix
- Thread `checkpointer` through `create_agent_graph` → pass `_checkpointer` (the shared `MemorySaver`) to `create_agent` at **both** build sites (initial load + reload).
- Removed the no-op `config["checkpointer"]` assignments; kept `thread_id` (`a2a:<session>` / `gradio:<session>`), which now actually keys per-session history.

Combined with the already-on **compaction** middleware, each turn now gets the session's recent history verbatim **plus a summary of the older part** near the context limit — exactly the "feed history + summarize the rest" behavior, instead of amnesia.

## Verified live
A two-turn session: turn 1 "remember the magic word is bazinga-seven" → turn 2 "what was the magic word?" → **"bazinga-seven"**. 

Regression test asserts the compiled graph binds the checkpointer (passing it only in config is the trap that caused this). Full suite **711 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)