### PR TITLE
Durable SQLite checkpointer — chat history survives restarts

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -85,6 +85,13 @@ compaction:
   keep_messages: 20
   # model: protolabs/fast
 
+# Conversation checkpointer — persists each chat session's history per
+# thread_id so multi-turn chats survive a server restart. Same
+# /sandbox→~/.protoagent writable fallback as the stores. Blank = in-memory
+# (history cleared on restart).
+checkpoint:
+  db_path: /sandbox/checkpoints.db
+
 # Model routing / failover.
 #   aux_model: ONE cheap/fast alias for the non-reasoning calls — context
 #     summarization, goal verification, and subagent delegation all fall back

--- a/docs/explanation/tuning-and-cost.md
+++ b/docs/explanation/tuning-and-cost.md
@@ -85,6 +85,25 @@ interval so the first request after an idle gap hits a warm cache — only worth
 it for sporadic, latency-sensitive workloads on the `1h` tier; for steady
 traffic it's pure cost.
 
+## Conversation history
+
+Each chat session's history is checkpointed per `thread_id` (the chat tab's
+context id, prefixed `a2a:` / `gradio:`), so a turn sees the prior turns instead
+of starting fresh — and compaction summarizes the older part near the limit. The
+checkpointer is bound at **graph-compile time** (a checkpointer set only in the
+invoke config is ignored by LangGraph).
+
+By default it's a **durable SQLite** store (`checkpoint.db_path`, same
+`/sandbox`→`~/.protoagent` writable fallback as the other stores), so histories
+**survive a server restart**. Set `checkpoint.db_path` blank for an in-memory
+store (cleared on restart). Each tab is an independent thread; "New chat" starts
+a clean one.
+
+```yaml
+checkpoint:
+  db_path: /sandbox/checkpoints.db   # blank = in-memory
+```
+
 ## What's already optimal
 
 - **Parallel tool calls** — langchain's `create_agent` runs a turn's tool calls

--- a/graph/checkpointer.py
+++ b/graph/checkpointer.py
@@ -1,0 +1,52 @@
+"""Durable conversation checkpointer (SQLite) for the agent graph.
+
+LangGraph needs the checkpointer bound at **compile time** so multi-turn chats
+keep their history per ``thread_id``. Two constraints shape the choice here:
+
+- The graph is compiled **synchronously at boot**, before uvicorn starts the
+  event loop — so an aiosqlite-based ``AsyncSqliteSaver`` (which wants a running
+  loop at construction/setup) is an awkward fit.
+- The agent runs **async** (``astream_events``), and the stock sync
+  ``SqliteSaver`` raises ``NotImplementedError`` on the async methods.
+
+So we wrap the sync ``SqliteSaver`` and delegate its async methods to worker
+threads via ``asyncio.to_thread``: synchronous construction (no loop needed),
+loop-agnostic at call time, durable on disk. The saver serializes access with
+its own lock and ``check_same_thread=False``, which keeps the cross-thread
+``to_thread`` calls safe.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+
+from langgraph.checkpoint.sqlite import SqliteSaver
+
+
+class ThreadedSqliteSaver(SqliteSaver):
+    """A sync ``SqliteSaver`` whose async methods run on a worker thread, so the
+    async agent graph can use it while history persists to a SQLite file."""
+
+    async def aget_tuple(self, config):
+        return await asyncio.to_thread(self.get_tuple, config)
+
+    async def aput(self, *args, **kwargs):
+        return await asyncio.to_thread(self.put, *args, **kwargs)
+
+    async def aput_writes(self, *args, **kwargs):
+        return await asyncio.to_thread(self.put_writes, *args, **kwargs)
+
+    async def alist(self, *args, **kwargs):
+        # The base `list` is a sync generator; materialize it off-thread, then
+        # re-yield (alist must itself be an async generator).
+        for item in await asyncio.to_thread(lambda: list(self.list(*args, **kwargs))):
+            yield item
+
+
+def build_sqlite_checkpointer(db_path: str) -> ThreadedSqliteSaver:
+    """Open (or create) the checkpoint DB and return a ready saver."""
+    conn = sqlite3.connect(db_path, check_same_thread=False)
+    saver = ThreadedSqliteSaver(conn)
+    saver.setup()  # create the checkpoint tables if absent (idempotent)
+    return saver

--- a/graph/config.py
+++ b/graph/config.py
@@ -186,6 +186,13 @@ class LangGraphConfig:
     embed_model: str = "nomic-embed-text"
     knowledge_top_k: int = 5
 
+    # Conversation checkpointer — persists each chat session's history per
+    # thread_id so multi-turn chats survive a server restart. A path → durable
+    # SQLite (same /sandbox→~/.protoagent writable fallback as the stores);
+    # blank → in-memory (history cleared on restart). Bound at graph-compile
+    # time (see graph/checkpointer.py); changing the path needs a restart.
+    checkpoint_db_path: str = "/sandbox/checkpoints.db"
+
     # Skills — human-authored ``SKILL.md`` folders (AgentSkills open standard)
     # loaded from disk into the FTS5 skill index and retrieved at inference by
     # KnowledgeMiddleware. ``db_path`` follows the same /sandbox→~/.protoagent
@@ -323,6 +330,7 @@ class LangGraphConfig:
             subagent_max_concurrency=subagents.get("max_concurrency", cls.subagent_max_concurrency),
             subagent_output_truncate=subagents.get("output_truncate", cls.subagent_output_truncate),
             knowledge_db_path=knowledge.get("db_path", cls.knowledge_db_path),
+            checkpoint_db_path=data.get("checkpoint", {}).get("db_path", cls.checkpoint_db_path),
             embed_model=knowledge.get("embed_model", cls.embed_model),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
             skills_enabled=skills.get("enabled", cls.skills_enabled),

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -95,6 +95,9 @@ FIELDS: list[Field] = [
           minimum=1),
     Field("knowledge.embed_model", "embed_model", "Embedding model", "string", "Knowledge"),
     Field("skills.top_k", "skills_top_k", "Skill recall top-k", "number", "Knowledge", minimum=1),
+    Field("checkpoint.db_path", "checkpoint_db_path", "Conversation history DB", "string", "Knowledge",
+          "SQLite path for per-session chat history (survives restarts). Blank = in-memory.",
+          restart=True),
 
     # ── Middleware toggles ───────────────────────────────────────────────────
     Field("middleware.knowledge", "knowledge_middleware", "Knowledge middleware", "bool", "Middleware"),

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,6 +14,9 @@ langchain>=1.2.3
 langchain-core>=1.0
 langgraph>=1.1.0
 langchain-openai>=1.0
+# Durable conversation history — SQLite checkpointer so multi-turn chats
+# survive a server restart (graph/checkpointer.py).
+langgraph-checkpoint-sqlite>=2.0
 
 # MCP client — connect external Model Context Protocol servers (stdio /
 # streamable-HTTP); their tools become agent tools. See tools/mcp_tools.py.

--- a/server.py
+++ b/server.py
@@ -102,14 +102,16 @@ def _init_langgraph_agent():
 
     from graph.config import LangGraphConfig
     from graph.config_io import CONFIG_YAML_PATH, ensure_live_config, is_setup_complete
-    from langgraph.checkpoint.memory import MemorySaver
 
     # Seed the untracked live config from the .example template on first run.
     # CONFIG_YAML_PATH honors PROTOAGENT_CONFIG_DIR (the desktop sidecar points
     # it at per-user app-data), so load through it rather than a fixed path.
     ensure_live_config()
     _graph_config = LangGraphConfig.from_yaml(CONFIG_YAML_PATH)
-    _checkpointer = MemorySaver()
+    # Conversation checkpointer: durable SQLite when a path is configured (chat
+    # history survives restarts), else in-memory. Bound into the graph at
+    # compile time below — a checkpointer in the invoke config is ignored.
+    _checkpointer = _build_checkpointer(_graph_config)
 
     if not is_setup_complete():
         _graph = None
@@ -284,6 +286,43 @@ def _build_plugins(config, existing_tools=None):
         from graph.plugins.loader import PluginLoadResult
 
         return PluginLoadResult()
+
+
+def _resolve_checkpoint_db(configured: str) -> str:
+    """Pick a writable checkpoint DB path; fall back to ~/.protoagent when the
+    configured dir (default /sandbox) isn't creatable (e.g. local dev)."""
+    import os
+    from pathlib import Path
+
+    candidate = Path(configured).expanduser()
+    try:
+        candidate.parent.mkdir(parents=True, exist_ok=True)
+        if os.access(candidate.parent, os.W_OK):
+            return str(candidate)
+    except OSError:
+        pass
+    fallback = Path.home() / ".protoagent" / "checkpoints.db"
+    fallback.parent.mkdir(parents=True, exist_ok=True)
+    return str(fallback)
+
+
+def _build_checkpointer(config):
+    """Durable SQLite checkpointer when ``checkpoint_db_path`` is set, else an
+    in-memory saver (history cleared on restart). Falls back to in-memory if the
+    SQLite saver can't be built so a bad path never blocks boot."""
+    if not getattr(config, "checkpoint_db_path", ""):
+        from langgraph.checkpoint.memory import MemorySaver
+        return MemorySaver()
+    try:
+        from graph.checkpointer import build_sqlite_checkpointer
+        path = _resolve_checkpoint_db(config.checkpoint_db_path)
+        saver = build_sqlite_checkpointer(path)
+        log.info("[checkpointer] persistent chat history at %s", path)
+        return saver
+    except Exception:
+        log.exception("[checkpointer] SQLite init failed; using in-memory (history won't persist)")
+        from langgraph.checkpoint.memory import MemorySaver
+        return MemorySaver()
 
 
 def _resolve_skills_db(configured: str) -> str:

--- a/tests/test_checkpointer.py
+++ b/tests/test_checkpointer.py
@@ -1,0 +1,75 @@
+"""Tests for the durable SQLite conversation checkpointer."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+from graph.checkpointer import build_sqlite_checkpointer
+
+
+def _toy_graph(checkpointer):
+    g = StateGraph(MessagesState)
+    g.add_node("n", lambda s: {"messages": [AIMessage(content="ok")]})
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+    return g.compile(checkpointer=checkpointer)
+
+
+def test_threaded_sqlite_saver_persists_across_restart(tmp_path):
+    """A new saver opened on the same DB file sees the prior session's history —
+    this is the durability the in-memory saver lacked (history survives a
+    process restart)."""
+    db = str(tmp_path / "ckpt.db")
+    cfg = {"configurable": {"thread_id": "chat-1"}}
+
+    async def turn(text: str) -> int:
+        saver = build_sqlite_checkpointer(db)  # fresh saver each call = "restart"
+        app = _toy_graph(saver)
+        await app.ainvoke({"messages": [HumanMessage(content=text)]}, cfg)
+        state = await app.aget_state(cfg)
+        return len(state.values["messages"])
+
+    n1 = asyncio.run(turn("hello"))   # 1 human + 1 ai
+    n2 = asyncio.run(turn("again"))   # reopened DB → accumulates on top
+    assert n1 == 2
+    assert n2 == 4  # history persisted across the simulated restart
+
+
+def test_threaded_sqlite_saver_isolates_threads(tmp_path):
+    """Different thread_ids (chat tabs) keep independent histories."""
+    db = str(tmp_path / "ckpt.db")
+    saver = build_sqlite_checkpointer(db)
+    app = _toy_graph(saver)
+
+    async def main():
+        await app.ainvoke({"messages": [HumanMessage(content="tab A")]}, {"configurable": {"thread_id": "A"}})
+        b = await app.aget_state({"configurable": {"thread_id": "B"}})
+        return b
+
+    state_b = asyncio.run(main())
+    # Thread B was never written → empty (A's history doesn't bleed in).
+    assert not state_b.values  # no checkpoint for B
+
+
+def test_build_checkpointer_in_memory_when_path_blank():
+    """server._build_checkpointer falls back to an in-memory saver when no path
+    is configured (opt-out of durable history)."""
+    import server
+    from langgraph.checkpoint.memory import MemorySaver
+
+    class _Cfg:
+        checkpoint_db_path = ""
+
+    assert isinstance(server._build_checkpointer(_Cfg()), MemorySaver)
+
+
+@pytest.mark.asyncio
+async def test_threaded_saver_async_methods_work(tmp_path):
+    """The async methods (delegated to threads) are usable directly."""
+    saver = build_sqlite_checkpointer(str(tmp_path / "c.db"))
+    # No checkpoint yet for this thread → aget_tuple returns None, doesn't raise.
+    assert await saver.aget_tuple({"configurable": {"thread_id": "none"}}) is None


### PR DESCRIPTION
Follow-up to #318: the in-memory `MemorySaver` lost every chat's history on restart. Switch to a **durable SQLite** checkpointer (default), keyed per session `thread_id`, so multi-turn conversations persist across server restarts.

## Why a wrapped sync saver
The graph is compiled **synchronously at boot** (before uvicorn's event loop), so the aiosqlite `AsyncSqliteSaver` (loop-bound async setup) is an awkward fit — and the stock **sync** `SqliteSaver` raises `NotImplementedError` on the async methods the agent graph calls. `graph/checkpointer.py` wraps `SqliteSaver` and delegates its async methods to worker threads via `asyncio.to_thread`: synchronous construction (no loop), loop-agnostic at call time, durable on disk, serialized by the saver's own lock (`check_same_thread=False`).

## Wiring
- `config.checkpoint_db_path` — default `/sandbox/checkpoints.db` (same `/sandbox`→`~/.protoagent` writable fallback as the other stores); **blank = in-memory**.
- `server._build_checkpointer` binds it at both graph-build sites; falls back to in-memory if SQLite init fails so a bad path never blocks boot.
- Exposed in **Settings → Knowledge → "Conversation history DB"** (restart-required badge — changing where history lives needs a restart).
- `requirements.txt`: `langgraph-checkpoint-sqlite`.

## Verified live
Set a fact ("UI accent color is teal") → **killed and restarted the server** → next turn in the same session recalled **"teal"** from `~/.protoagent/checkpoints.db`.

## Tests
Cross-restart accumulation (reopen same DB → history grows), per-thread isolation (tabs independent), async methods usable, and the in-memory fallback. Full suite **715 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)