### PR TITLE
Periodic pruning for the checkpoint DB (per-thread cap + age TTL)

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -91,6 +91,12 @@ compaction:
 # (history cleared on restart).
 checkpoint:
   db_path: /sandbox/checkpoints.db
+  # Pruning keeps the DB bounded: keep the latest N checkpoints per session,
+  # and drop whole sessions idle past max_age_days. Swept every
+  # prune_interval_hours (0 disables the sweep).
+  keep_per_thread: 5
+  max_age_days: 30
+  prune_interval_hours: 6
 
 # Model routing / failover.
 #   aux_model: ONE cheap/fast alias for the non-reasoning calls — context

--- a/docs/explanation/tuning-and-cost.md
+++ b/docs/explanation/tuning-and-cost.md
@@ -102,7 +102,16 @@ a clean one.
 ```yaml
 checkpoint:
   db_path: /sandbox/checkpoints.db   # blank = in-memory
+  keep_per_thread: 5                 # latest checkpoints kept per session
+  max_age_days: 30                   # drop sessions idle longer than this (0 = never)
+  prune_interval_hours: 6            # sweep cadence (0 disables)
 ```
+
+A background **pruner** keeps the DB bounded: LangGraph writes ~3 checkpoint
+rows per turn and retains them all, but only the latest is needed to resume — so
+the sweep keeps the latest `keep_per_thread` per session and drops whole sessions
+idle past `max_age_days` (age decoded from the checkpoint's UUIDv6). The DB runs
+in WAL mode so the sweep coexists with live writes.
 
 ## What's already optimal
 

--- a/graph/checkpoint_prune.py
+++ b/graph/checkpoint_prune.py
@@ -1,0 +1,106 @@
+"""Periodic pruning for the SQLite conversation checkpointer.
+
+LangGraph writes ~3 checkpoint rows per turn (one per super-step), all retained
+per ``thread_id`` — so the DB grows unbounded as chats accumulate. We don't use
+time-travel/replay, only resume-from-latest, so older checkpoints are dead
+weight. This trims the DB two ways:
+
+- **Per-thread cap** — keep only the latest ``keep_per_thread`` checkpoints per
+  ``(thread_id, checkpoint_ns)`` (resume needs only the most recent). Ordered by
+  ``checkpoint_id``, which LangGraph generates as a time-sortable UUIDv6.
+- **Age TTL** — delete whole threads whose newest checkpoint is older than
+  ``max_age_days`` (idle conversations). The age comes from the UUIDv6
+  timestamp, so no extra bookkeeping table is needed.
+
+All pure SQL on a short-lived connection (the saver runs WAL mode, so this
+coexists with live writes); failures are caught by the caller and never block.
+"""
+
+from __future__ import annotations
+
+import sqlite3
+import uuid
+
+# 100ns intervals between the UUID (Gregorian, 1582-10-15) and Unix epochs.
+_GREGORIAN_OFFSET = 0x01B21DD213814000
+
+
+def uuidv6_unix_seconds(checkpoint_id: str) -> float | None:
+    """Unix seconds encoded in a UUIDv6, or None if it isn't a parseable v6."""
+    try:
+        u = uuid.UUID(checkpoint_id)
+    except (ValueError, AttributeError):
+        return None
+    if u.version != 6:
+        return None
+    i = u.int
+    time_high = (i >> 96) & 0xFFFFFFFF
+    time_mid = (i >> 80) & 0xFFFF
+    time_low = (i >> 64) & 0x0FFF
+    ticks = (time_high << 28) | (time_mid << 12) | time_low  # 100ns since 1582
+    return (ticks - _GREGORIAN_OFFSET) / 1e7
+
+
+def prune_checkpoints(
+    db_path: str,
+    *,
+    keep_per_thread: int = 5,
+    max_age_seconds: float | None = None,
+    now: float | None = None,
+) -> dict[str, int]:
+    """Trim the checkpoint DB. Returns counts of what was removed.
+
+    ``max_age_seconds=None`` disables the age TTL (only the per-thread cap runs).
+    ``now`` is injectable for tests.
+    """
+    conn = sqlite3.connect(db_path, timeout=10)
+    conn.execute("PRAGMA busy_timeout=5000")
+    threads_deleted = 0
+    checkpoints_deleted = 0
+    try:
+        threads = [r[0] for r in conn.execute("SELECT DISTINCT thread_id FROM checkpoints")]
+
+        # 1. Age TTL — drop whole threads idle past the cutoff.
+        if max_age_seconds is not None:
+            import time as _time
+            cutoff = (now if now is not None else _time.time()) - max_age_seconds
+            for thread_id in list(threads):
+                rows = conn.execute(
+                    "SELECT checkpoint_id FROM checkpoints WHERE thread_id=?", (thread_id,)
+                ).fetchall()
+                stamps = [t for t in (uuidv6_unix_seconds(r[0]) for r in rows) if t is not None]
+                # Only TTL threads we can date *and* that are entirely old.
+                if stamps and max(stamps) < cutoff:
+                    conn.execute("DELETE FROM checkpoints WHERE thread_id=?", (thread_id,))
+                    conn.execute("DELETE FROM writes WHERE thread_id=?", (thread_id,))
+                    threads.remove(thread_id)
+                    threads_deleted += 1
+
+        # 2. Per-thread cap — keep the latest N checkpoints per namespace.
+        keep = max(1, keep_per_thread)
+        for thread_id in threads:
+            for (ns,) in conn.execute(
+                "SELECT DISTINCT checkpoint_ns FROM checkpoints WHERE thread_id=?", (thread_id,)
+            ).fetchall():
+                stale = [
+                    r[0] for r in conn.execute(
+                        "SELECT checkpoint_id FROM checkpoints WHERE thread_id=? AND checkpoint_ns=? "
+                        "ORDER BY checkpoint_id DESC LIMIT -1 OFFSET ?",
+                        (thread_id, ns, keep),
+                    ).fetchall()
+                ]
+                for cid in stale:
+                    conn.execute(
+                        "DELETE FROM checkpoints WHERE thread_id=? AND checkpoint_ns=? AND checkpoint_id=?",
+                        (thread_id, ns, cid),
+                    )
+                    conn.execute(
+                        "DELETE FROM writes WHERE thread_id=? AND checkpoint_ns=? AND checkpoint_id=?",
+                        (thread_id, ns, cid),
+                    )
+                    checkpoints_deleted += 1
+
+        conn.commit()
+    finally:
+        conn.close()
+    return {"threads_deleted": threads_deleted, "checkpoints_deleted": checkpoints_deleted}

--- a/graph/checkpointer.py
+++ b/graph/checkpointer.py
@@ -47,6 +47,10 @@ class ThreadedSqliteSaver(SqliteSaver):
 def build_sqlite_checkpointer(db_path: str) -> ThreadedSqliteSaver:
     """Open (or create) the checkpoint DB and return a ready saver."""
     conn = sqlite3.connect(db_path, check_same_thread=False)
+    # WAL lets the periodic pruner (separate connection) run while the agent
+    # writes; busy_timeout avoids spurious "database is locked" under contention.
+    conn.execute("PRAGMA journal_mode=WAL")
+    conn.execute("PRAGMA busy_timeout=5000")
     saver = ThreadedSqliteSaver(conn)
     saver.setup()  # create the checkpoint tables if absent (idempotent)
     return saver

--- a/graph/config.py
+++ b/graph/config.py
@@ -192,6 +192,12 @@ class LangGraphConfig:
     # blank → in-memory (history cleared on restart). Bound at graph-compile
     # time (see graph/checkpointer.py); changing the path needs a restart.
     checkpoint_db_path: str = "/sandbox/checkpoints.db"
+    # Checkpoint pruning — keeps the SQLite DB from growing unbounded. Keep the
+    # latest N checkpoints per session, and TTL whole sessions idle past
+    # max_age_days. Runs every prune_interval_hours (0 disables the sweep).
+    checkpoint_keep_per_thread: int = 5
+    checkpoint_max_age_days: int = 30
+    checkpoint_prune_interval_hours: int = 6
 
     # Skills — human-authored ``SKILL.md`` folders (AgentSkills open standard)
     # loaded from disk into the FTS5 skill index and retrieved at inference by
@@ -331,6 +337,9 @@ class LangGraphConfig:
             subagent_output_truncate=subagents.get("output_truncate", cls.subagent_output_truncate),
             knowledge_db_path=knowledge.get("db_path", cls.knowledge_db_path),
             checkpoint_db_path=data.get("checkpoint", {}).get("db_path", cls.checkpoint_db_path),
+            checkpoint_keep_per_thread=data.get("checkpoint", {}).get("keep_per_thread", cls.checkpoint_keep_per_thread),
+            checkpoint_max_age_days=data.get("checkpoint", {}).get("max_age_days", cls.checkpoint_max_age_days),
+            checkpoint_prune_interval_hours=data.get("checkpoint", {}).get("prune_interval_hours", cls.checkpoint_prune_interval_hours),
             embed_model=knowledge.get("embed_model", cls.embed_model),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
             skills_enabled=skills.get("enabled", cls.skills_enabled),

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -98,6 +98,13 @@ FIELDS: list[Field] = [
     Field("checkpoint.db_path", "checkpoint_db_path", "Conversation history DB", "string", "Knowledge",
           "SQLite path for per-session chat history (survives restarts). Blank = in-memory.",
           restart=True),
+    Field("checkpoint.keep_per_thread", "checkpoint_keep_per_thread", "History: keep N per session",
+          "number", "Knowledge", "Latest checkpoints retained per chat session.", minimum=1),
+    Field("checkpoint.max_age_days", "checkpoint_max_age_days", "History: max age (days)", "number",
+          "Knowledge", "Drop whole sessions idle longer than this (0 = never).", minimum=0),
+    Field("checkpoint.prune_interval_hours", "checkpoint_prune_interval_hours", "History: prune every (hours)",
+          "number", "Knowledge", "How often the prune sweep runs (0 disables it).", minimum=0,
+          restart=True),
 
     # ── Middleware toggles ───────────────────────────────────────────────────
     Field("middleware.knowledge", "knowledge_middleware", "Knowledge middleware", "bool", "Middleware"),

--- a/server.py
+++ b/server.py
@@ -64,7 +64,9 @@ log = logging.getLogger("protoagent.server")
 
 _graph = None          # LangGraph compiled graph
 _graph_config = None   # LangGraphConfig
-_checkpointer = None   # MemorySaver for session persistence
+_checkpointer = None   # checkpointer for session persistence (sqlite or memory)
+_checkpoint_path = None  # resolved sqlite path when persistent (for the pruner)
+_checkpoint_prune_task = None  # background prune loop handle
 _knowledge_store = None  # KnowledgeStore bound into the active graph, or None.
 _skills_index = None     # SkillsIndex (human-authored SKILL.md store), or None.
 _mcp_clients = []        # Live MultiServerMCPClient handles (kept alive for reconnect).
@@ -315,14 +317,52 @@ def _build_checkpointer(config):
         return MemorySaver()
     try:
         from graph.checkpointer import build_sqlite_checkpointer
+        global _checkpoint_path
         path = _resolve_checkpoint_db(config.checkpoint_db_path)
         saver = build_sqlite_checkpointer(path)
+        _checkpoint_path = path
         log.info("[checkpointer] persistent chat history at %s", path)
         return saver
     except Exception:
         log.exception("[checkpointer] SQLite init failed; using in-memory (history won't persist)")
         from langgraph.checkpoint.memory import MemorySaver
         return MemorySaver()
+
+
+async def _checkpoint_prune_loop() -> None:
+    """Periodically trim the SQLite checkpoint DB (per-thread cap + age TTL).
+
+    Reads the path + knobs from the live globals each pass so a config reload
+    takes effect without restarting the loop. Failures are logged, never fatal.
+    """
+    import asyncio
+
+    from graph.checkpoint_prune import prune_checkpoints
+
+    await asyncio.sleep(60)  # let boot settle before the first sweep
+    while True:
+        cfg = _graph_config
+        path = _checkpoint_path
+        interval_h = getattr(cfg, "checkpoint_prune_interval_hours", 0) if cfg else 0
+        if path and cfg and interval_h > 0:
+            try:
+                max_age = (
+                    cfg.checkpoint_max_age_days * 86400 if cfg.checkpoint_max_age_days else None
+                )
+                res = await asyncio.to_thread(
+                    prune_checkpoints,
+                    path,
+                    keep_per_thread=cfg.checkpoint_keep_per_thread,
+                    max_age_seconds=max_age,
+                )
+                if res["threads_deleted"] or res["checkpoints_deleted"]:
+                    log.info(
+                        "[checkpoint-prune] removed %d idle thread(s), %d old checkpoint(s)",
+                        res["threads_deleted"], res["checkpoints_deleted"],
+                    )
+            except Exception:
+                log.exception("[checkpoint-prune] sweep failed")
+        await asyncio.sleep(max(1, interval_h) * 3600)
 
 
 def _resolve_skills_db(configured: str) -> str:
@@ -1584,6 +1624,15 @@ def _main():
                 await _cache_warmer.start()
             except Exception:
                 log.exception("[cache-warmer] startup failed")
+        # Checkpoint pruner — periodic sweep to keep the SQLite history DB bounded.
+        global _checkpoint_prune_task
+        if (
+            _checkpoint_path
+            and _graph_config is not None
+            and _graph_config.checkpoint_prune_interval_hours > 0
+        ):
+            import asyncio
+            _checkpoint_prune_task = asyncio.create_task(_checkpoint_prune_loop())
 
     @fastapi_app.on_event("shutdown")
     async def _scheduler_shutdown() -> None:
@@ -1597,6 +1646,8 @@ def _main():
                 await _cache_warmer.stop()
             except Exception:
                 log.exception("[cache-warmer] shutdown failed")
+        if _checkpoint_prune_task is not None:
+            _checkpoint_prune_task.cancel()
 
     # --- Chat API -----------------------------------------------------------
     class ChatRequest(PydanticBaseModel):

--- a/tests/test_checkpoint_prune.py
+++ b/tests/test_checkpoint_prune.py
@@ -1,0 +1,103 @@
+"""Tests for the checkpoint pruner (per-thread cap + age TTL)."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+import time
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+from graph.checkpoint_prune import prune_checkpoints, uuidv6_unix_seconds
+from graph.checkpointer import build_sqlite_checkpointer
+
+
+def _graph(saver):
+    g = StateGraph(MessagesState)
+    g.add_node("n", lambda s: {"messages": [AIMessage(content="ok")]})
+    g.add_edge(START, "n")
+    g.add_edge("n", END)
+    return g.compile(checkpointer=saver)
+
+
+def _count(db, table, thread_id=None):
+    conn = sqlite3.connect(db)
+    try:
+        if thread_id:
+            return conn.execute(f"SELECT COUNT(*) FROM {table} WHERE thread_id=?", (thread_id,)).fetchone()[0]
+        return conn.execute(f"SELECT COUNT(*) FROM {table}").fetchone()[0]
+    finally:
+        conn.close()
+
+
+def _seed(db, threads=("A", "B"), turns=3):
+    async def main():
+        app = _graph(build_sqlite_checkpointer(db))
+        for t in threads:
+            for i in range(turns):
+                await app.ainvoke({"messages": [HumanMessage(content=f"{t}{i}")]},
+                                  {"configurable": {"thread_id": t}})
+    asyncio.run(main())
+
+
+def test_uuidv6_timestamp_decode_is_sane(tmp_path):
+    # A real checkpoint id (LangGraph generates v6) should decode to ~now.
+    db = str(tmp_path / "c.db")
+    _seed(db, threads=("A",), turns=1)
+    conn = sqlite3.connect(db)
+    cid = conn.execute("SELECT checkpoint_id FROM checkpoints LIMIT 1").fetchone()[0]
+    conn.close()
+    ts = uuidv6_unix_seconds(cid)
+    assert ts is not None and abs(ts - time.time()) < 30
+    assert uuidv6_unix_seconds("not-a-uuid") is None
+
+
+def test_per_thread_cap_keeps_latest(tmp_path):
+    db = str(tmp_path / "c.db")
+    _seed(db, threads=("A", "B"), turns=3)  # ~9 checkpoints/thread
+    before = _count(db, "checkpoints", "A")
+    assert before > 2
+    res = prune_checkpoints(db, keep_per_thread=2, max_age_seconds=None)
+    assert _count(db, "checkpoints", "A") == 2
+    assert _count(db, "checkpoints", "B") == 2
+    assert res["checkpoints_deleted"] == (before - 2) * 2  # both threads trimmed
+
+
+def test_pruned_thread_can_still_resume(tmp_path):
+    """Keeping the latest checkpoint must preserve resume — history continues."""
+    db = str(tmp_path / "c.db")
+    _seed(db, threads=("A",), turns=3)
+    prune_checkpoints(db, keep_per_thread=1, max_age_seconds=None)
+
+    async def resume_len():
+        app = _graph(build_sqlite_checkpointer(db))
+        cfg = {"configurable": {"thread_id": "A"}}
+        before = await app.aget_state(cfg)
+        await app.ainvoke({"messages": [HumanMessage(content="more")]}, cfg)
+        after = await app.aget_state(cfg)
+        return len(before.values["messages"]), len(after.values["messages"])
+
+    b, a = asyncio.run(resume_len())
+    assert b >= 1 and a > b  # state survived the prune and kept accumulating
+
+
+def test_age_ttl_drops_old_threads_only(tmp_path):
+    db = str(tmp_path / "c.db")
+    _seed(db, threads=("recent",), turns=2)
+    # Forge an "old" thread by inserting a checkpoint with a year-2000 v6 id.
+    conn = sqlite3.connect(db)
+    old_id = "1dc8b9f0-0000-6000-8000-000000000000"  # ~2000-era v6 timestamp
+    assert uuidv6_unix_seconds(old_id) is not None
+    conn.execute(
+        "INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, type, checkpoint, metadata) "
+        "VALUES (?,?,?,?,?,?,?)",
+        ("stale", "", old_id, None, "", b"{}", b"{}"),
+    )
+    conn.commit()
+    conn.close()
+
+    res = prune_checkpoints(db, keep_per_thread=50, max_age_seconds=86400)  # 1-day TTL
+    assert res["threads_deleted"] == 1
+    assert _count(db, "checkpoints", "stale") == 0       # old thread gone
+    assert _count(db, "checkpoints", "recent") > 0       # recent thread kept


### PR DESCRIPTION
Keeps the SQLite conversation-history DB (#320) from growing unbounded.

## The growth
LangGraph writes **~3 checkpoint rows per turn** and retains them all per session. We only resume from the latest, so the rest is dead weight — a busy chat balloons the DB.

## The sweep (`graph/checkpoint_prune.py`)
- **Per-thread cap** — keep only the latest `keep_per_thread` checkpoints per session (ordered by the time-sortable UUIDv6 `checkpoint_id`); the rest + their `writes` rows are deleted. This is the big win.
- **Age TTL** — drop whole sessions whose newest checkpoint is older than `max_age_days`, with the age **decoded from the UUIDv6 timestamp** (no extra bookkeeping table).
- Pure SQL on a short-lived connection; the DB now runs **WAL mode** so the sweep coexists with live writes. Failures are logged, never fatal.

## Wiring
- Background task on FastAPI startup, runs every `prune_interval_hours` (0 disables), off the event loop via `to_thread`. Reads live config each pass so reloads take effect; cancelled on shutdown.
- Config: `checkpoint.keep_per_thread` (5), `max_age_days` (30), `prune_interval_hours` (6) — in `example.yaml` and **Settings → Knowledge**.

## Verified
- On the **live** DB: 38 → 6 checkpoints at `keep_per_thread=3`, both sessions still resume.
- Tests: per-thread cap keeps latest, a pruned thread still resumes + keeps accumulating, age-TTL drops a forged old thread but keeps recent ones, UUIDv6 decode ≈ now. Full suite **719 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)