### PR TITLE
Harvest retired conversations into the searchable knowledge base

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -318,7 +318,12 @@ function ChatSessionSlot({
             type="button"
             title="Delete session"
             disabled={status === "streaming"}
-            onClick={() => chatStore.deleteSession(session.id)}
+            onClick={() => {
+              // Retire server-side (harvest history → knowledge, purge
+              // checkpoints), best-effort, then drop the tab locally.
+              void api.deleteChatSession(session.id).catch(() => {});
+              chatStore.deleteSession(session.id);
+            }}
           >
             <Trash2 size={16} />
           </button>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -275,6 +275,15 @@ export const api = {
     });
   },
 
+  // Retire a chat session server-side: harvest its history into knowledge (if
+  // enabled) then purge its checkpoints. Fire-and-forget on tab delete.
+  deleteChatSession(sessionId: string) {
+    return request<{ deleted: boolean; harvested: boolean }>(
+      `/api/chat/sessions/${encodeURIComponent(sessionId)}`,
+      { method: "DELETE" },
+    );
+  },
+
   async streamChat(
     message: string,
     sessionId: string,

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -97,6 +97,10 @@ checkpoint:
   keep_per_thread: 5
   max_age_days: 30
   prune_interval_hours: 6
+  # When a session is retired (aged out or deleted), summarize it into the
+  # knowledge base (searchable via memory_recall) before dropping the raw
+  # checkpoints. Needs the knowledge middleware enabled.
+  harvest_enabled: true
 
 # Model routing / failover.
 #   aux_model: ONE cheap/fast alias for the non-reasoning calls — context

--- a/docs/explanation/tuning-and-cost.md
+++ b/docs/explanation/tuning-and-cost.md
@@ -113,6 +113,14 @@ the sweep keeps the latest `keep_per_thread` per session and drops whole session
 idle past `max_age_days` (age decoded from the checkpoint's UUIDv6). The DB runs
 in WAL mode so the sweep coexists with live writes.
 
+**Harvest to knowledge** (`harvest_enabled`, on): when a session is *retired* —
+aged out by the pruner, or explicitly deleted (the chat tab's trash button hits
+`DELETE /api/chat/sessions/{id}`) — it's first summarized into the knowledge
+base (`domain: conversation`, by the cheap aux model) and *then* its raw
+checkpoints are dropped. So past conversations stay searchable via
+`memory_recall` while the bulky raw history is reclaimed — signal kept, space
+freed. Needs the knowledge middleware enabled.
+
 ## What's already optimal
 
 - **Parallel tool calls** — langchain's `create_agent` runs a turn's tool calls

--- a/graph/checkpoint_prune.py
+++ b/graph/checkpoint_prune.py
@@ -41,6 +41,43 @@ def uuidv6_unix_seconds(checkpoint_id: str) -> float | None:
     return (ticks - _GREGORIAN_OFFSET) / 1e7
 
 
+def find_aged_threads(
+    db_path: str, max_age_seconds: float, *, now: float | None = None
+) -> list[str]:
+    """Thread ids whose newest checkpoint is older than the cutoff (datable via
+    UUIDv6). Used to harvest a thread to knowledge *before* deleting it."""
+    import time as _time
+
+    cutoff = (now if now is not None else _time.time()) - max_age_seconds
+    conn = sqlite3.connect(db_path, timeout=10)
+    try:
+        aged: list[str] = []
+        for (thread_id,) in conn.execute("SELECT DISTINCT thread_id FROM checkpoints"):
+            rows = conn.execute(
+                "SELECT checkpoint_id FROM checkpoints WHERE thread_id=?", (thread_id,)
+            ).fetchall()
+            stamps = [t for t in (uuidv6_unix_seconds(r[0]) for r in rows) if t is not None]
+            if stamps and max(stamps) < cutoff:
+                aged.append(thread_id)
+        return aged
+    finally:
+        conn.close()
+
+
+def delete_thread(db_path: str, thread_id: str) -> int:
+    """Delete all checkpoints + writes for a thread. Returns checkpoints removed."""
+    conn = sqlite3.connect(db_path, timeout=10)
+    conn.execute("PRAGMA busy_timeout=5000")
+    try:
+        n = conn.execute("SELECT COUNT(*) FROM checkpoints WHERE thread_id=?", (thread_id,)).fetchone()[0]
+        conn.execute("DELETE FROM checkpoints WHERE thread_id=?", (thread_id,))
+        conn.execute("DELETE FROM writes WHERE thread_id=?", (thread_id,))
+        conn.commit()
+        return n
+    finally:
+        conn.close()
+
+
 def prune_checkpoints(
     db_path: str,
     *,

--- a/graph/config.py
+++ b/graph/config.py
@@ -198,6 +198,10 @@ class LangGraphConfig:
     checkpoint_keep_per_thread: int = 5
     checkpoint_max_age_days: int = 30
     checkpoint_prune_interval_hours: int = 6
+    # When a session is retired (aged out or deleted), summarize it into the
+    # knowledge base before dropping the raw checkpoints — so past conversations
+    # stay searchable via memory_recall. Needs the knowledge store enabled.
+    checkpoint_harvest_enabled: bool = True
 
     # Skills — human-authored ``SKILL.md`` folders (AgentSkills open standard)
     # loaded from disk into the FTS5 skill index and retrieved at inference by
@@ -340,6 +344,7 @@ class LangGraphConfig:
             checkpoint_keep_per_thread=data.get("checkpoint", {}).get("keep_per_thread", cls.checkpoint_keep_per_thread),
             checkpoint_max_age_days=data.get("checkpoint", {}).get("max_age_days", cls.checkpoint_max_age_days),
             checkpoint_prune_interval_hours=data.get("checkpoint", {}).get("prune_interval_hours", cls.checkpoint_prune_interval_hours),
+            checkpoint_harvest_enabled=data.get("checkpoint", {}).get("harvest_enabled", cls.checkpoint_harvest_enabled),
             embed_model=knowledge.get("embed_model", cls.embed_model),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
             skills_enabled=skills.get("enabled", cls.skills_enabled),

--- a/graph/conversation_harvest.py
+++ b/graph/conversation_harvest.py
@@ -1,0 +1,106 @@
+"""Harvest a retired conversation into the searchable knowledge base.
+
+When a chat thread is retired — aged out by the checkpoint pruner, or explicitly
+deleted — we don't just drop it: we summarize it and ingest the summary into the
+``KnowledgeStore`` (FTS5 + embeddings), so the substance becomes searchable via
+``memory_recall`` while the bulky raw checkpoints are reclaimed. Save space,
+keep the signal.
+
+The summary is produced by the cheap aux model (``routing.aux_model``) — it's
+classification-grade work, not the main reasoning task.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langchain_core.messages import AIMessage, HumanMessage
+
+from graph.output_format import extract_output
+
+log = logging.getLogger(__name__)
+
+# Cap the transcript fed to the summarizer (keep the most recent tail).
+_MAX_TRANSCRIPT_CHARS = 16000
+
+
+def render_transcript(messages: list) -> str:
+    """Render a User/Assistant transcript from checkpoint messages.
+
+    Assistant turns are run through ``extract_output`` (drop scratch_pad/think);
+    tool and system messages are skipped. Returns the most-recent
+    ``_MAX_TRANSCRIPT_CHARS`` when long.
+    """
+    lines: list[str] = []
+    for m in messages:
+        content = getattr(m, "content", "")
+        if not isinstance(content, str) or not content.strip():
+            continue
+        if isinstance(m, HumanMessage):
+            lines.append(f"User: {content.strip()}")
+        elif isinstance(m, AIMessage):
+            clean = extract_output(content).strip()
+            if clean:
+                lines.append(f"Assistant: {clean}")
+    transcript = "\n".join(lines)
+    if len(transcript) > _MAX_TRANSCRIPT_CHARS:
+        transcript = "…\n" + transcript[-_MAX_TRANSCRIPT_CHARS:]
+    return transcript
+
+
+_SUMMARY_PROMPT = (
+    "Summarize this chat conversation for long-term, searchable memory. Capture "
+    "the user's goals, the concrete facts/preferences they shared, decisions "
+    "made, and outcomes — anything worth recalling in a future conversation. "
+    "Write a concise factual summary (a few sentences). Omit pleasantries and "
+    "meta-commentary.\n\nConversation:\n{transcript}\n\nSummary:"
+)
+
+
+async def _default_summarizer(transcript: str, config) -> str:
+    from graph.agent import _resolve_aux_model
+    from graph.llm import create_llm
+
+    llm = create_llm(config, model_name=_resolve_aux_model(config, ""))
+    resp = await llm.ainvoke([HumanMessage(content=_SUMMARY_PROMPT.format(transcript=transcript))])
+    # The aux model may or may not wrap output in tags; extract defensively.
+    return extract_output(str(resp.content)).strip() or str(resp.content).strip()
+
+
+async def harvest_thread(
+    thread_id: str,
+    *,
+    checkpointer,
+    knowledge_store,
+    config,
+    summarizer=_default_summarizer,
+) -> str | None:
+    """Summarize ``thread_id``'s conversation into the knowledge base.
+
+    Returns the new chunk id, or None when there's nothing to harvest (no
+    knowledge store, no checkpoint, empty transcript, or a summarizer failure).
+    Never raises — harvesting is best-effort and must not block retirement.
+    """
+    if knowledge_store is None:
+        return None
+    try:
+        tup = await checkpointer.aget_tuple({"configurable": {"thread_id": thread_id}})
+        if tup is None:
+            return None
+        messages = (tup.checkpoint or {}).get("channel_values", {}).get("messages", [])
+        transcript = render_transcript(messages)
+        if not transcript.strip():
+            return None
+        summary = await summarizer(transcript, config)
+        if not summary.strip():
+            return None
+        chunk_id = knowledge_store.add_chunk(
+            summary,
+            domain="conversation",
+            heading=f"Conversation summary ({thread_id})",
+        )
+        log.info("[harvest] summarized thread %s into knowledge (chunk %s)", thread_id, chunk_id)
+        return chunk_id
+    except Exception:
+        log.exception("[harvest] failed for thread %s", thread_id)
+        return None

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -105,6 +105,8 @@ FIELDS: list[Field] = [
     Field("checkpoint.prune_interval_hours", "checkpoint_prune_interval_hours", "History: prune every (hours)",
           "number", "Knowledge", "How often the prune sweep runs (0 disables it).", minimum=0,
           restart=True),
+    Field("checkpoint.harvest_enabled", "checkpoint_harvest_enabled", "History: harvest to knowledge", "bool",
+          "Knowledge", "Summarize a session into the searchable knowledge base before pruning/deleting it."),
 
     # ── Middleware toggles ───────────────────────────────────────────────────
     Field("middleware.knowledge", "knowledge_middleware", "Knowledge middleware", "bool", "Middleware"),

--- a/server.py
+++ b/server.py
@@ -337,7 +337,7 @@ async def _checkpoint_prune_loop() -> None:
     """
     import asyncio
 
-    from graph.checkpoint_prune import prune_checkpoints
+    from graph.checkpoint_prune import find_aged_threads, prune_checkpoints
 
     await asyncio.sleep(60)  # let boot settle before the first sweep
     while True:
@@ -349,11 +349,24 @@ async def _checkpoint_prune_loop() -> None:
                 max_age = (
                     cfg.checkpoint_max_age_days * 86400 if cfg.checkpoint_max_age_days else None
                 )
+                harvest = bool(
+                    max_age
+                    and cfg.checkpoint_harvest_enabled
+                    and _knowledge_store is not None
+                    and _checkpointer is not None
+                )
+                if harvest:
+                    # Summarize each aged thread into knowledge, then drop it —
+                    # past conversations stay searchable, raw checkpoints freed.
+                    for thread_id in await asyncio.to_thread(find_aged_threads, path, max_age):
+                        await _retire_thread(thread_id)
+                # Per-thread cap on the survivors (SQL age-TTL is the fallback
+                # delete path when harvesting is off).
                 res = await asyncio.to_thread(
                     prune_checkpoints,
                     path,
                     keep_per_thread=cfg.checkpoint_keep_per_thread,
-                    max_age_seconds=max_age,
+                    max_age_seconds=(None if harvest else max_age),
                 )
                 if res["threads_deleted"] or res["checkpoints_deleted"]:
                     log.info(
@@ -363,6 +376,33 @@ async def _checkpoint_prune_loop() -> None:
             except Exception:
                 log.exception("[checkpoint-prune] sweep failed")
         await asyncio.sleep(max(1, interval_h) * 3600)
+
+
+async def _retire_thread(thread_id: str) -> str | None:
+    """Harvest a thread to the knowledge base (best-effort) then delete its
+    checkpoints. Shared by the prune sweep and explicit tab deletion. Returns
+    the harvested knowledge chunk id, if any."""
+    import asyncio
+
+    from graph.checkpoint_prune import delete_thread
+
+    chunk_id = None
+    if _graph_config is not None and getattr(_graph_config, "checkpoint_harvest_enabled", False):
+        from graph.conversation_harvest import harvest_thread
+        chunk_id = await harvest_thread(
+            thread_id,
+            checkpointer=_checkpointer,
+            knowledge_store=_knowledge_store,
+            config=_graph_config,
+        )
+    if _checkpoint_path:
+        await asyncio.to_thread(delete_thread, _checkpoint_path, thread_id)
+    elif _checkpointer is not None and hasattr(_checkpointer, "delete_thread"):
+        try:
+            _checkpointer.delete_thread(thread_id)
+        except Exception:
+            log.exception("[retire] in-memory delete_thread failed for %s", thread_id)
+    return chunk_id
 
 
 def _resolve_skills_db(configured: str) -> str:
@@ -1659,6 +1699,15 @@ def _main():
         result = await chat(req.message, req.session_id)
         parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
         return {"response": "\n\n".join(parts), "messages": result}
+
+    @fastapi_app.delete("/api/chat/sessions/{session_id}")
+    async def _api_delete_session(session_id: str):
+        """Retire a chat session: harvest its conversation into the knowledge
+        base (if enabled), then purge its checkpoints. Called when the operator
+        deletes a chat tab, so deleted conversations don't linger to the TTL —
+        their substance lives on as searchable memory instead."""
+        chunk_id = await _retire_thread(f"a2a:{session_id}")
+        return {"deleted": True, "harvested": chunk_id is not None}
 
     # --- Goal mode API ------------------------------------------------------
     # Programmatic status/clear for a session's goal (setting is done via the

--- a/tests/test_conversation_harvest.py
+++ b/tests/test_conversation_harvest.py
@@ -1,0 +1,106 @@
+"""Tests for harvesting retired conversations into the knowledge base."""
+
+from __future__ import annotations
+
+import asyncio
+
+from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.graph import END, START, MessagesState, StateGraph
+
+from graph.checkpoint_prune import delete_thread, find_aged_threads
+from graph.checkpointer import build_sqlite_checkpointer
+from graph.conversation_harvest import harvest_thread, render_transcript
+
+
+def test_render_transcript_cleans_and_skips_noise():
+    msgs = [
+        HumanMessage(content="what is 2+2?"),
+        AIMessage(content="<scratch_pad>add them</scratch_pad><output>It's 4.</output>"),
+        AIMessage(content="   "),  # empty → skipped
+    ]
+    t = render_transcript(msgs)
+    assert "User: what is 2+2?" in t
+    assert "Assistant: It's 4." in t       # extracted from <output>, scratch dropped
+    assert "scratch_pad" not in t
+
+
+class _FakeKnowledge:
+    def __init__(self):
+        self.chunks = []
+
+    def add_chunk(self, content, domain=None, heading=None):
+        self.chunks.append({"content": content, "domain": domain, "heading": heading})
+        return f"chunk-{len(self.chunks)}"
+
+
+def _seed(db, thread="a2a:chat-1"):
+    g = StateGraph(MessagesState)
+    g.add_node("n", lambda s: {"messages": [AIMessage(content="<output>noted</output>")]})
+    g.add_edge(START, "n"); g.add_edge("n", END)
+
+    async def main():
+        app = g.compile(checkpointer=build_sqlite_checkpointer(db))
+        await app.ainvoke({"messages": [HumanMessage(content="my favorite color is teal")]},
+                          {"configurable": {"thread_id": thread}})
+    asyncio.run(main())
+
+
+def test_harvest_thread_summarizes_into_knowledge(tmp_path):
+    db = str(tmp_path / "c.db")
+    _seed(db)
+    saver = build_sqlite_checkpointer(db)
+    kb = _FakeKnowledge()
+
+    async def fake_summarizer(transcript, config):
+        assert "teal" in transcript  # got the real conversation
+        return "User prefers teal."
+
+    cid = asyncio.run(harvest_thread(
+        "a2a:chat-1", checkpointer=saver, knowledge_store=kb, config=object(),
+        summarizer=fake_summarizer,
+    ))
+    assert cid == "chunk-1"
+    assert kb.chunks[0]["domain"] == "conversation"
+    assert "teal" in kb.chunks[0]["content"]
+
+
+def test_harvest_noop_without_knowledge_store(tmp_path):
+    db = str(tmp_path / "c.db")
+    _seed(db)
+    saver = build_sqlite_checkpointer(db)
+    assert asyncio.run(
+        harvest_thread("a2a:chat-1", checkpointer=saver, knowledge_store=None, config=object())
+    ) is None
+
+
+def test_harvest_noop_on_unknown_thread(tmp_path):
+    db = str(tmp_path / "c.db")
+    _seed(db)
+    saver = build_sqlite_checkpointer(db)
+    kb = _FakeKnowledge()
+
+    async def _boom(transcript, config):
+        raise AssertionError("should not summarize an empty/unknown thread")
+
+    out = asyncio.run(
+        harvest_thread("a2a:nope", checkpointer=saver, knowledge_store=kb, config=object(), summarizer=_boom)
+    )
+    assert out is None and kb.chunks == []
+
+
+def test_find_aged_threads_and_delete(tmp_path):
+    import sqlite3
+    db = str(tmp_path / "c.db")
+    _seed(db, thread="recent")
+    conn = sqlite3.connect(db)
+    conn.execute(
+        "INSERT INTO checkpoints (thread_id, checkpoint_ns, checkpoint_id, parent_checkpoint_id, type, checkpoint, metadata) "
+        "VALUES (?,?,?,?,?,?,?)",
+        ("stale", "", "1dc8b9f0-0000-6000-8000-000000000000", None, "", b"{}", b"{}"),
+    )
+    conn.commit(); conn.close()
+
+    aged = find_aged_threads(db, max_age_seconds=86400)
+    assert aged == ["stale"]
+    assert delete_thread(db, "stale") == 1
+    assert find_aged_threads(db, max_age_seconds=86400) == []


### PR DESCRIPTION
Answers "what should we do when a conversation is retired?" → **keep the signal as searchable knowledge, drop the bulk.**

When a chat session is retired (aged out by the pruner, or you delete the tab), it's now **summarized into the knowledge base** (`domain: conversation`, via the cheap aux model) *before* its raw checkpoints are dropped. Past conversations stay searchable via `memory_recall`; the bulky raw history is reclaimed.

## Pieces
- **`graph/conversation_harvest.py`** — renders a clean User/Assistant transcript (assistant turns through `extract_output`, tool/scratch noise dropped), summarizes with the aux model, ingests via `knowledge_store.add_chunk`. Best-effort, never raises.
- **`graph/checkpoint_prune.py`** — `find_aged_threads` + `delete_thread` so the sweep can harvest each aged thread *before* removing it (falls back to the SQL age-TTL when harvesting is off / knowledge disabled).
- **`server._retire_thread`** — shared harvest→purge, used by the prune loop **and** the new `DELETE /api/chat/sessions/{id}` endpoint. Deleting a tab now purges the thread server-side instead of leaving it orphaned to the TTL.
- **Frontend** — the tab trash button fires the endpoint (best-effort) before dropping the tab locally.
- **Config** — `checkpoint.harvest_enabled` (on); exposed in **Settings → Knowledge**; documented in `example.yaml` + the tuning guide.

## Verified live
Shared a fact → deleted the tab → endpoint returned `harvested:true`, the thread's checkpoints went **12 → 0**, and a `conversation` summary chunk landed in knowledge: *"The user's production deployment region is `us-west-2`, and deployments are scheduled to occur on Fridays."*

## Tests
Transcript rendering (scratch/tool stripped), harvest (with store / no store / unknown thread / summarizer-not-called), `find_aged_threads` + `delete_thread`. Full suite **724 passed**; web build clean.

## Design note
"Delete" now means *harvest-then-purge*, not hard-delete — matching the "conversations become searchable knowledge" intent. If you ever want a true hard-delete (e.g. for sensitive chats), that'd be a small opt-out flag on the delete call.

🤖 Generated with [Claude Code](https://claude.com/claude-code)