### PR TITLE
Live-refresh the Notes panel when the agent writes

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -387,6 +387,28 @@ export function App() {
     return () => window.clearTimeout(handle);
   }, [notesBusy, notesDirty, projectPath, workspace]);
 
+  // Live notes refresh — the agent (via notes_write) or another tab can change
+  // the workspace on disk. Poll while the Notes panel is open and adopt newer
+  // server state, but never clobber the user's unsaved edits (notesDirty) and
+  // keep their active tab selection.
+  useEffect(() => {
+    if (rightPanel !== "notes" || !projectPath.trim()) return;
+    const handle = window.setInterval(async () => {
+      if (notesDirty || notesBusy) return;
+      try {
+        const { workspace: latest } = await api.getNotes(projectPath);
+        setWorkspace((current) => {
+          if (!current || latest.workspaceVersion <= current.workspaceVersion) return current;
+          const keepActive = latest.tabs[current.activeTabId] ? current.activeTabId : latest.activeTabId;
+          return { ...latest, activeTabId: keepActive };
+        });
+      } catch {
+        /* transient — retry next tick */
+      }
+    }, 4000);
+    return () => window.clearInterval(handle);
+  }, [rightPanel, projectPath, notesDirty, notesBusy]);
+
   useEffect(() => {
     if (surface === "schedule") void refreshSchedules();
     if (surface === "goals") void refreshGoals();


### PR DESCRIPTION
The Notes panel only loaded on mount, so an agent `notes_write` (or another tab's edit) didn't show until a manual refresh.

Polls the workspace every 4s while the Notes panel is open and adopts newer server state — **edit-safe**: skips while the user has unsaved edits (`notesDirty`/`notesBusy`), preserves the active-tab selection, and only adopts when `workspaceVersion` advanced (agent writes bump it) so there are no needless re-renders/cursor jumps.

**Verified live:** the agent appended a unique marker to the Todo tab via `notes_write` and the panel updated on its own within the poll interval — no manual refresh. 22 e2e specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)