### PR TITLE
Swap chat composer keybinds: Enter sends, Ctrl/Cmd+Enter = newline

### DIFF
--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -9,13 +9,25 @@ async function send(page, prompt: string) {
   await composer.waitFor({ state: "visible" });
   await composer.fill(prompt);
   // The composer sends on Ctrl/Cmd+Enter (checks metaKey || ctrlKey).
-  await composer.press("Control+Enter");
+  await composer.press("Enter");
 }
 
 test.beforeEach(async ({ page }) => {
   await page.goto("/app/", { waitUntil: "networkidle" });
   // Setup wizard must not block — the mock reports setup_complete:true.
   await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+});
+
+test("Enter sends; Ctrl+Enter inserts a newline", async ({ page }) => {
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.fill("line one");
+  await composer.press("Control+Enter"); // newline, not send
+  await expect(composer).toHaveValue("line one\n");
+  await expect(page.locator(".message-user")).toHaveCount(0);
+
+  await composer.fill("hello there"); // plain Enter sends
+  await composer.press("Enter");
+  await expect(page.locator(".message-user")).toHaveText(/hello there/);
 });
 
 test("tool-call card is collapsed by default and renders structured components", async ({ page }) => {

--- a/apps/web/e2e/copy.spec.ts
+++ b/apps/web/e2e/copy.spec.ts
@@ -9,7 +9,7 @@ test("copy button writes the raw value to the clipboard", async ({ page }) => {
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.waitFor({ state: "visible" });
   await composer.fill("CALC compute it");
-  await composer.press("Control+Enter");
+  await composer.press("Enter");
 
   const card = page.locator(".tool-card").first();
   await expect(card.locator(".tool-card-status.done")).toBeVisible();

--- a/apps/web/e2e/nesting.spec.ts
+++ b/apps/web/e2e/nesting.spec.ts
@@ -9,7 +9,7 @@ test("subagent child tools nest under the task card", async ({ page }) => {
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.waitFor({ state: "visible" });
   await composer.fill("SUBAGENT delegate this");
-  await composer.press("Control+Enter");
+  await composer.press("Enter");
 
   // The parent task card is top-level inside a group.
   const group = page.locator(".tool-calls > .tool-card-group");

--- a/apps/web/e2e/streaming.spec.ts
+++ b/apps/web/e2e/streaming.spec.ts
@@ -10,7 +10,7 @@ test("assistant answer streams in and reconciles to the final text", async ({ pa
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.waitFor({ state: "visible" });
   await composer.fill("STREAM the answer");
-  await composer.press("Control+Enter");
+  await composer.press("Enter");
 
   const answer = page.locator(".message-assistant .markdown");
   // Partial text appears before the full answer (append:true delta).

--- a/apps/web/e2e/tool-renderers.spec.ts
+++ b/apps/web/e2e/tool-renderers.spec.ts
@@ -9,7 +9,7 @@ async function run(page, prompt: string) {
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.waitFor({ state: "visible" });
   await composer.fill(prompt);
-  await composer.press("Control+Enter");
+  await composer.press("Enter");
   const card = page.locator(".tool-card").first();
   await expect(card).toBeVisible();
   await expect(card.locator(".tool-card-status.done")).toBeVisible();

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -414,13 +414,32 @@ function ChatSessionSlot({
                 return;
               }
             }
-            // Cmd/Ctrl+Enter sends; plain Enter keeps inserting newlines.
-            if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
-              event.preventDefault();
-              void send();
+            // Enter sends; Cmd/Ctrl+Enter (and Shift+Enter) insert a newline.
+            if (event.key === "Enter") {
+              if (event.metaKey || event.ctrlKey) {
+                // Ctrl/Cmd+Enter → newline at the caret (the textarea wouldn't
+                // insert one for this combo on its own).
+                event.preventDefault();
+                const ta = textareaRef.current;
+                if (ta) {
+                  const start = ta.selectionStart;
+                  const end = ta.selectionEnd;
+                  const next = `${draft.slice(0, start)}\n${draft.slice(end)}`;
+                  setDraft(next);
+                  requestAnimationFrame(() => {
+                    ta.selectionStart = ta.selectionEnd = start + 1;
+                  });
+                }
+                return;
+              }
+              if (!event.shiftKey) {
+                // Plain Enter → send. (Shift+Enter falls through to a newline.)
+                event.preventDefault();
+                void send();
+              }
             }
           }}
-          placeholder="Message protoAgent  (/ for commands · ⌘/Ctrl+Enter to send)"
+          placeholder="Message protoAgent  (/ for commands · Enter to send · ⌘/Ctrl+Enter for newline)"
           rows={3}
         />
         {status === "streaming" ? (


### PR DESCRIPTION
Reverses the composer mapping per request: **Enter submits**, **Ctrl/Cmd+Enter inserts a newline** (at the caret — the textarea wouldn't for that combo, so it's done manually); Shift+Enter still makes a newline. Slash-menu Enter (complete command) is unchanged; placeholder updated.

E2E: every spec that sent via `Control+Enter` now presses `Enter`; added a regression asserting Ctrl+Enter inserts a newline without sending and Enter submits. 22 specs green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)