### PR TITLE
Note version history + undo (revert tool + UI Undo button)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -19,6 +19,7 @@ import {
   Settings2,
   Sparkles,
   Target,
+  Undo2,
   Trash2,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
@@ -244,6 +245,9 @@ export function App() {
   const [goalsBusy, setGoalsBusy] = useState(false);
 
   const activeTab = workspace?.tabs[workspace.activeTabId] || null;
+  const canUndoNote = Boolean(
+    ((activeTab?.metadata as Record<string, unknown> | undefined)?.history as unknown[] | undefined)?.length,
+  );
 
   async function refreshRuntime() {
     const [runtimePayload, subagentPayload] = await Promise.all([
@@ -478,6 +482,34 @@ export function App() {
   function updateWorkspace(nextWorkspace: NotesWorkspace) {
     setWorkspace(nextWorkspace);
     setNotesDirty(true);
+  }
+
+  // Undo the last write to the active tab, restoring the previous version from
+  // the per-tab history that notes_write / the editor record.
+  function undoActiveNote() {
+    if (!workspace || !activeTab) return;
+    const meta = (activeTab.metadata || {}) as Record<string, unknown>;
+    const history = (meta.history as Array<{ content: string }> | undefined) || [];
+    if (!history.length) return;
+    const restored = history[history.length - 1].content;
+    updateWorkspace({
+      ...workspace,
+      workspaceVersion: workspace.workspaceVersion + 1,
+      tabs: {
+        ...workspace.tabs,
+        [activeTab.id]: {
+          ...activeTab,
+          content: restored,
+          metadata: {
+            ...meta,
+            history: history.slice(0, -1),
+            updatedAt: Date.now(),
+            characterCount: restored.length,
+            wordCount: restored.split(/\s+/).filter(Boolean).length,
+          },
+        },
+      },
+    });
   }
 
   function saveActiveNote(content: string) {
@@ -1165,6 +1197,9 @@ export function App() {
                   </button>
                   <button className="icon-button" type="button" onClick={deleteActiveNote} disabled={!workspace || workspace.tabOrder.length <= 1} title="Delete note">
                     <Trash2 size={16} />
+                  </button>
+                  <button className="icon-button" type="button" onClick={undoActiveNote} disabled={!canUndoNote} title="Undo last change">
+                    <Undo2 size={16} />
                   </button>
                   <button className="icon-button" type="button" onClick={() => void persistNotes()} disabled={!workspace || notesBusy} title="Save notes">
                     {notesBusy ? <Loader2 className="spin" size={16} /> : <Save size={16} />}

--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -6,7 +6,7 @@ Sixteen tools ship by default:
 - Four **GitHub read tools** — `github_get_pr`, `github_get_issue`, `github_list_issues`, `github_get_commit_diff` (`tools/github_tools.py`) — over the `gh` CLI. Each requires an explicit `repo` (`owner/name`, no default); they degrade to a readable error if `gh`/auth is missing. Auth via `GITHUB_TOKEN`/`GH_TOKEN` env, else gh's ambient login.
 - Five **memory tools** — `memory_ingest`, `memory_recall`, `memory_list`, `memory_stats`, `daily_log` — bound to the bundled `KnowledgeStore` (sqlite + FTS5, see [Configuration](/reference/configuration#knowledge)).
 - Three **scheduler tools** — `schedule_task`, `list_schedules`, `cancel_schedule` — bound to the bundled scheduler backend (local sqlite or the Workstacean adapter, see [Schedule future work](/guides/scheduler)).
-- Three **project-notes tools** — `notes_list`, `notes_read`, `notes_write` — bridge the operator console's Notes panel tabs to the agent, gated per-tab by the operator's Agent-read/write toggles.
+- Four **project-notes tools** — `notes_list`, `notes_read`, `notes_write`, `notes_revert` — bridge the operator console's Notes panel tabs to the agent, gated per-tab by the operator's Agent-read/write toggles; writes are versioned (undoable) and surface live in the panel.
 
 `get_all_tools(knowledge_store, scheduler)` is the registry. When `knowledge_store` is `None` the memory tools are omitted; when `scheduler` is `None` the scheduler tools are omitted. Both backends are constructed by default in `server.py`; opt out via `middleware.knowledge: false` / `middleware.scheduler: false` in `config/langgraph-config.yaml`.
 
@@ -214,12 +214,18 @@ toggles in the panel; these tools **honor them per tab**:
 async def notes_list(project_path: str = "") -> str          # tabs + read/write flags
 async def notes_read(tab: str = "", project_path: str = "") -> str   # agent-readable tabs only
 async def notes_write(tab: str, content: str, mode: str = "append", project_path: str = "") -> str
+async def notes_revert(tab: str, steps: int = 1, project_path: str = "") -> str  # undo recent writes
 ```
 
 - `notes_read` returns only tabs with **Agent read** on (a named tab with it off
   reports "not shared", never the content); blank `tab` returns every readable tab.
 - `notes_write` only writes tabs with **Agent write** on, to an existing tab
-  (`append` or `replace`), and updates the tab's word/char counts.
+  (`append` or `replace`), updates the tab's word/char counts, and **snapshots
+  the prior content** (last 10 versions) so a write can be undone.
+- `notes_revert` rolls a tab back `steps` versions from that history (the Notes
+  panel also has an **Undo** button that does the same client-side).
+- Writes land **live** in the Notes panel (it polls + adopts newer versions
+  without clobbering unsaved edits).
 - `project_path` defaults to the current project (the repo root the Notes panel
   shows); notes live at `<project>/.automaker/notes/workspace.json`.
 

--- a/tests/test_notes_tools.py
+++ b/tests/test_notes_tools.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 import pytest
 
 from operator_api.notes import NotesService
-from tools.notes_tools import notes_list, notes_read, notes_write
+from tools.notes_tools import _MAX_NOTE_HISTORY, notes_list, notes_read, notes_revert, notes_write
 
 
 def _seed(tmp_path):
@@ -80,3 +80,60 @@ async def test_write_unknown_tab_errors(tmp_path):
     proj = _seed(tmp_path)
     out = await notes_write.ainvoke({"tab": "Nope", "content": "x", "project_path": proj})
     assert "no notes tab named" in out.lower()
+
+
+# ── version history + revert ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_write_records_prior_version_for_undo(tmp_path):
+    proj = _seed(tmp_path)
+    await notes_write.ainvoke({"tab": "Todo", "content": "call mom", "project_path": proj})
+    ws = NotesService().load_workspace(proj)
+    history = ws["tabs"]["t1"]["metadata"]["history"]
+    assert history and history[-1]["content"] == "buy milk"  # pre-write snapshot
+
+
+@pytest.mark.asyncio
+async def test_history_is_capped(tmp_path):
+    proj = _seed(tmp_path)
+    for i in range(_MAX_NOTE_HISTORY + 5):
+        await notes_write.ainvoke({"tab": "Todo", "content": f"item {i}", "project_path": proj})
+    ws = NotesService().load_workspace(proj)
+    assert len(ws["tabs"]["t1"]["metadata"]["history"]) == _MAX_NOTE_HISTORY
+
+
+@pytest.mark.asyncio
+async def test_revert_restores_previous_version(tmp_path):
+    proj = _seed(tmp_path)
+    await notes_write.ainvoke({"tab": "Todo", "content": "call mom", "project_path": proj})
+    # content is now "buy milk\ncall mom"; revert → back to "buy milk"
+    out = await notes_revert.ainvoke({"tab": "Todo", "project_path": proj})
+    assert "Reverted" in out
+    ws = NotesService().load_workspace(proj)
+    assert ws["tabs"]["t1"]["content"] == "buy milk"
+    assert ws["tabs"]["t1"]["metadata"]["history"] == []  # rolled-past version dropped
+
+
+@pytest.mark.asyncio
+async def test_revert_multiple_steps(tmp_path):
+    proj = _seed(tmp_path)
+    await notes_write.ainvoke({"tab": "Todo", "content": "a", "project_path": proj})  # hist: ["buy milk"]
+    await notes_write.ainvoke({"tab": "Todo", "content": "b", "project_path": proj})  # hist: ["buy milk", "buy milk\na"]
+    out = await notes_revert.ainvoke({"tab": "Todo", "steps": 2, "project_path": proj})
+    assert "2 version" in out
+    assert NotesService().load_workspace(proj)["tabs"]["t1"]["content"] == "buy milk"
+
+
+@pytest.mark.asyncio
+async def test_revert_with_no_history(tmp_path):
+    proj = _seed(tmp_path)
+    out = await notes_revert.ainvoke({"tab": "Todo", "project_path": proj})
+    assert "No earlier version" in out
+
+
+@pytest.mark.asyncio
+async def test_revert_blocked_when_agentWrite_off(tmp_path):
+    proj = _seed(tmp_path)
+    out = await notes_revert.ainvoke({"tab": "Private", "project_path": proj})
+    assert "read-only" in out.lower()

--- a/tools/notes_tools.py
+++ b/tools/notes_tools.py
@@ -129,8 +129,9 @@ async def notes_write(tab: str, content: str, mode: str = "append", project_path
     else:
         new_content = f"{existing}\n{content}" if existing else content
 
-    found["content"] = new_content
     meta = found.setdefault("metadata", {})
+    _push_history(meta, existing)  # snapshot the pre-write content for undo
+    found["content"] = new_content
     meta["updatedAt"] = int(time.time() * 1000)
     meta["characterCount"] = len(new_content)
     meta["wordCount"] = len(new_content.split())
@@ -143,6 +144,58 @@ async def notes_write(tab: str, content: str, mode: str = "append", project_path
     return f"Updated the {found.get('name')!r} tab ({mode}). It now has {len(new_content)} chars."
 
 
+@tool
+async def notes_revert(tab: str, steps: int = 1, project_path: str = "") -> str:
+    """Undo recent writes to a Notes tab, restoring an earlier version.
+
+    Use when asked to undo/revert a change to a tab. Reverts ``steps`` versions
+    back (default 1) from the per-tab history that ``notes_write`` records.
+
+    Args:
+        tab: Tab name (case-insensitive).
+        steps: How many versions to roll back (default 1).
+        project_path: Project whose notes to revert. Defaults to the current project.
+    """
+    proj = _project(project_path)
+    ws = _notes.load_workspace(proj)
+    _tid, found = _find_tab(ws, tab)
+    if found is None:
+        return f"No notes tab named {tab!r}. Use notes_list to see available tabs."
+    if not (found.get("permissions") or {}).get("agentWrite"):
+        return f"The {found.get('name')!r} tab is read-only for the agent (Agent write is off)."
+
+    meta = found.setdefault("metadata", {})
+    history = meta.get("history") or []
+    if not history:
+        return f"No earlier version of the {found.get('name')!r} tab to revert to."
+
+    steps = max(1, min(steps, len(history)))
+    restored = history[-steps]["content"]
+    meta["history"] = history[:-steps]  # drop the versions we rolled past
+    found["content"] = restored
+    meta["updatedAt"] = int(time.time() * 1000)
+    meta["characterCount"] = len(restored)
+    meta["wordCount"] = len(restored.split())
+    ws["workspaceVersion"] = int(ws.get("workspaceVersion", 0)) + 1
+
+    try:
+        _notes.save_workspace(proj, ws)
+    except Exception as e:  # noqa: BLE001
+        return f"Error: could not save notes: {e}"
+    return f"Reverted the {found.get('name')!r} tab {steps} version(s) back ({len(restored)} chars)."
+
+
+# Keep a short undo history per tab (newest last), capped.
+_MAX_NOTE_HISTORY = 10
+
+
+def _push_history(meta: dict, prev_content: str) -> None:
+    history = meta.setdefault("history", [])
+    history.append({"content": prev_content, "at": int(time.time() * 1000)})
+    if len(history) > _MAX_NOTE_HISTORY:
+        del history[: len(history) - _MAX_NOTE_HISTORY]
+
+
 def get_notes_tools() -> list:
     """The project-notes tools, gated per-tab by the operator's read/write toggles."""
-    return [notes_list, notes_read, notes_write]
+    return [notes_list, notes_read, notes_write, notes_revert]


### PR DESCRIPTION
Keeps the last few versions of each notes tab so agent (or user) writes can be undone — the "save the last couple iterations so we can revert" ask.

- **`notes_write`** snapshots the pre-write content into the tab's `metadata.history` (capped at 10) before overwriting.
- **`notes_revert(tab, steps=1)`** — new tool that rolls a tab back N versions from that history (permission-gated like `notes_write`); the agent can "undo that" on request.
- **Notes panel Undo button** — reverts the active tab to its previous version client-side, then autosaves. Enabled only when history exists.

Composes with the live-refresh (#326): an agent write appears in the panel within the poll interval, and Undo rolls it back.

**Verified live end-to-end:** agent appended a marker via `notes_write` → panel live-updated → the Undo button was enabled → clicking it removed the marker (reverted to the prior version).

**Tests:** history recording + cap, single/multi-step revert, no-history message, write-blocked-when-read-only. 13 notes tests green; web build clean. Docs (starter-tools) updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)