### PR TITLE
Workflow engine + run_workflow tool (ADR 0002, slice 1)

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -72,6 +72,14 @@ skills:
   top_k: 5
   max_tokens: 2000
 
+# Workflows — reusable declarative multi-step subagent recipes (ADR 0002),
+# run via the run_workflow tool. Bundled examples ship in the repo workflows/
+# dir; `dir` is the writable root for user/agent-emitted recipes (same
+# /sandbox→~/.protoagent fallback as the stores).
+workflows:
+  enabled: true
+  dir: /sandbox/workflows
+
 # Context compaction — summarize old history near the context limit so long
 # sessions don't overflow the window. ON by default.
 #   trigger: "fraction:0.8" | "tokens:120000" | "messages:80"

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,6 +43,7 @@ export default defineConfig({
             { text: "Fork checklist (fast path)", link: "/guides/fork-the-template" },
             { text: "Add a custom skill", link: "/guides/add-a-skill" },
             { text: "Configure subagents", link: "/guides/subagents" },
+            { text: "Reusable workflows", link: "/guides/workflows" },
             { text: "Skills (SKILL.md)", link: "/guides/skills" },
             { text: "MCP servers", link: "/guides/mcp" },
             { text: "Plugins", link: "/guides/plugins" },

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -1,0 +1,64 @@
+# Reusable workflows
+
+A **workflow** is a reusable, multi-step recipe over your subagents: research →
+extract angles → write a brief, each step feeding the next, some running in
+parallel. Define it once as YAML, run it many times with different inputs. It's
+the multi-step generalization of a single-subagent skill — see
+[ADR 0002](/adr/0002-reusable-subagent-workflows) for the design.
+
+## Anatomy
+
+```yaml
+name: research-and-brief            # unique slug (the lookup key)
+description: Research a topic and write a cited brief.
+inputs:
+  - name: topic
+    required: true
+  - name: depth
+    default: deep
+steps:
+  - id: gather
+    subagent: researcher            # a key from SUBAGENT_REGISTRY
+    prompt: "Research {{ inputs.topic }} ({{ inputs.depth }}). Find 3–5 sources."
+  - id: angles
+    subagent: researcher
+    depends_on: [gather]
+    prompt: "From this research, list the 3 key angles:\n{{ steps.gather.output }}"
+  - id: brief
+    subagent: researcher
+    depends_on: [gather, angles]
+    prompt: "Write a cited brief on {{ inputs.topic }}.\n{{ steps.gather.output }}\n{{ steps.angles.output }}"
+output: "{{ steps.brief.output }}"  # optional; default = last step's output
+```
+
+- **Templating** substitutes `inputs.<name>` and `steps.<id>.output` (double
+  curly braces). References are validated against the declared inputs + step ids.
+- **`depends_on`** forms a DAG. Steps whose dependencies are ready run **in
+  parallel** (bounded by `subagents.max_concurrency`), so latency ≈ the critical
+  path. A step failure is recorded inline so independent branches still finish.
+
+## Where recipes live
+
+- **Bundled examples**: the repo's `workflows/` dir (ships with
+  `research-and-brief.yaml`).
+- **Your recipes**: `workflows.dir` in `config/langgraph-config.yaml` (default
+  `/sandbox/workflows`, falling back to `~/.protoagent/workflows` for local dev).
+  Drop a `*.yaml` recipe there; it's loaded on the next start/reload.
+
+## Running one
+
+The lead agent has a **`run_workflow(name, inputs)`** tool:
+
+- "run the research-and-brief workflow on quantum error correction" →
+  `run_workflow("research-and-brief", {"topic": "quantum error correction"})`.
+- An empty name lists the available workflows and their inputs.
+
+Workflows only delegate to **configured subagents** (each with its own tool
+allowlist and turn cap), and subagents don't get `run_workflow` — so there's no
+recursion and the blast radius is exactly the subagent system's.
+
+## Related
+
+- [ADR 0002 — Reusable Subagent Workflows](/adr/0002-reusable-subagent-workflows)
+- [Configure subagents](/guides/subagents)
+- [Starter tools](/reference/starter-tools) — `run_workflow` lives alongside `task` / `task_batch`

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -328,7 +328,7 @@ async def run_manual_subagent_batch(
     return "\n\n".join(parts)
 
 
-def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills_index=None):
+def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills_index=None, workflow_registry=None):
     """Build the subagent-delegation tools: single ``task`` and concurrent ``task_batch``.
 
     Subagents share AuditMiddleware so their tool calls land alongside the
@@ -440,7 +440,65 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
             parts.append(f"=== Task {i}/{len(results)} ===\n{res}")
         return "\n\n".join(parts)
 
-    return [task, task_batch]
+    tools = [task, task_batch]
+
+    # Reusable declarative workflows (ADR 0002) — run a saved multi-step recipe
+    # over subagents. Only the lead agent gets this; subagents don't, so
+    # workflows can't recurse.
+    if getattr(config, "workflows_enabled", False) and workflow_registry is not None:
+        from graph.workflows.engine import execute_workflow, resolve_inputs, validate_recipe
+
+        @tool
+        async def run_workflow(name: str = "", inputs: dict | None = None) -> str:
+            """Run a saved multi-step workflow recipe over subagents.
+
+            Workflows chain subagent steps (some in parallel), threading each
+            step's output into the next — for repeatable jobs like
+            research→synthesize→write. Pass an empty ``name`` to list the
+            available workflows and their inputs.
+
+            Args:
+                name: The workflow name (see the list with an empty name).
+                inputs: Mapping of the workflow's declared inputs to values.
+            """
+            if not name.strip():
+                summaries = workflow_registry.list()
+                if not summaries:
+                    return "No workflows are available."
+                lines = ["Available workflows:"]
+                for s in summaries:
+                    req = [i["name"] for i in s["inputs"] if i["required"]]
+                    lines.append(f"- {s['name']}: {s['description']} (inputs: {', '.join(req) or 'none required'})")
+                return "\n".join(lines)
+            recipe = workflow_registry.get(name)
+            if recipe is None:
+                return f"No workflow named {name!r}. Available: {', '.join(workflow_registry.names()) or '(none)'}."
+            errs = validate_recipe(recipe, known_subagents=set(SUBAGENT_REGISTRY))
+            if errs:
+                return f"Workflow {name!r} is invalid: " + "; ".join(errs)
+            resolved, missing = resolve_inputs(recipe, inputs or {})
+            if missing:
+                return f"Workflow {name!r} needs input(s): {', '.join(missing)}."
+
+            async def _run_step(subagent_type: str, prompt: str, step_id: str) -> str:
+                return await _run_subagent(
+                    config=config,
+                    tool_map=tool_map,
+                    available_subagents=available_subagents,
+                    description=f"workflow {name}:{step_id}",
+                    prompt=prompt,
+                    subagent_type=subagent_type,
+                    emit_skill=False,
+                    truncate=truncate,
+                    skills_index=skills_index,
+                )
+
+            result = await execute_workflow(recipe, resolved, run_step=_run_step, max_concurrency=max_concurrency)
+            return result["output"]
+
+        tools.append(run_workflow)
+
+    return tools
 
 
 def create_agent_graph(
@@ -451,6 +509,7 @@ def create_agent_graph(
     extra_tools=None,
     include_subagents: bool = True,
     checkpointer=None,
+    workflow_registry=None,
 ):
     """Create the protoAgent LangGraph agent.
 
@@ -476,7 +535,9 @@ def create_agent_graph(
         all_tools.extend(extra_tools)
 
     if include_subagents:
-        all_tools.extend(_build_task_tools(config, all_tools, skills_index=skills_index))
+        all_tools.extend(_build_task_tools(
+            config, all_tools, skills_index=skills_index, workflow_registry=workflow_registry,
+        ))
 
     # Programmatic tool calling — opt-in. Built last so it can wrap every
     # other tool (including task/task_batch) but never itself.

--- a/graph/config.py
+++ b/graph/config.py
@@ -214,6 +214,13 @@ class LangGraphConfig:
     skills_top_k: int = 5
     skills_dir: str = ""
 
+    # Workflows — declarative multi-step subagent recipes (see ADR 0002),
+    # exposed via the run_workflow tool. Bundled examples ship in the repo
+    # ``workflows/`` dir; ``dir`` is the writable root for user/agent-emitted
+    # recipes (same /sandbox→~/.protoagent fallback, resolved in server.py).
+    workflows_enabled: bool = True
+    workflow_dir: str = "/sandbox/workflows"
+
     # MCP — Model Context Protocol client. Connect to external MCP servers
     # (stdio or streamable-HTTP); their tools become agent tools, namespaced
     # ``<server>__<tool>`` so they can't shadow core tools. OFF by default —
@@ -345,6 +352,8 @@ class LangGraphConfig:
             checkpoint_max_age_days=data.get("checkpoint", {}).get("max_age_days", cls.checkpoint_max_age_days),
             checkpoint_prune_interval_hours=data.get("checkpoint", {}).get("prune_interval_hours", cls.checkpoint_prune_interval_hours),
             checkpoint_harvest_enabled=data.get("checkpoint", {}).get("harvest_enabled", cls.checkpoint_harvest_enabled),
+            workflows_enabled=data.get("workflows", {}).get("enabled", cls.workflows_enabled),
+            workflow_dir=data.get("workflows", {}).get("dir", cls.workflow_dir),
             embed_model=knowledge.get("embed_model", cls.embed_model),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
             skills_enabled=skills.get("enabled", cls.skills_enabled),

--- a/graph/workflows/__init__.py
+++ b/graph/workflows/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable declarative subagent workflows (see docs/adr/0002)."""

--- a/graph/workflows/engine.py
+++ b/graph/workflows/engine.py
@@ -1,0 +1,185 @@
+"""Workflow engine — validate + execute a declarative workflow recipe.
+
+A recipe is a dict (parsed from YAML):
+
+    name: str
+    description: str (optional)
+    inputs: [{name, required?, default?}]   (optional)
+    steps:  [{id, subagent, prompt, depends_on?}]
+    output: str (optional template; default = last step's output)
+
+Execution resolves the ``depends_on`` DAG, runs steps whose deps are satisfied
+**in parallel** (bounded by a semaphore), threads each step's output into
+later prompts via ``{{inputs.x}}`` / ``{{steps.id.output}}`` substitution, and
+returns the rendered ``output``. The engine is decoupled from the subagent
+runner via the injected ``run_step`` callback, so it's unit-testable.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import re
+from typing import Any, Awaitable, Callable
+
+# {{ inputs.name }} | {{ steps.id.output }}
+_REF_RE = re.compile(r"\{\{\s*([a-zA-Z0-9_.]+)\s*\}\}")
+
+
+def _refs(text: str) -> list[str]:
+    return _REF_RE.findall(text or "")
+
+
+def validate_recipe(recipe: dict, *, known_subagents: set[str] | None = None) -> list[str]:
+    """Return a list of human-readable validation errors ([] = valid)."""
+    errors: list[str] = []
+    if not isinstance(recipe, dict):
+        return ["recipe must be a mapping"]
+    if not isinstance(recipe.get("name"), str) or not recipe["name"].strip():
+        errors.append("missing 'name'")
+    steps = recipe.get("steps")
+    if not isinstance(steps, list) or not steps:
+        return errors + ["'steps' must be a non-empty list"]
+
+    input_names = {i.get("name") for i in (recipe.get("inputs") or []) if isinstance(i, dict)}
+    ids: list[str] = []
+    for n, step in enumerate(steps):
+        if not isinstance(step, dict):
+            errors.append(f"step #{n + 1} must be a mapping")
+            continue
+        sid = step.get("id")
+        if not isinstance(sid, str) or not sid.strip():
+            errors.append(f"step #{n + 1} missing 'id'")
+        elif sid in ids:
+            errors.append(f"duplicate step id {sid!r}")
+        else:
+            ids.append(sid)
+        if not isinstance(step.get("subagent"), str) or not step["subagent"].strip():
+            errors.append(f"step {sid!r}: missing 'subagent'")
+        elif known_subagents is not None and step["subagent"] not in known_subagents:
+            errors.append(f"step {sid!r}: unknown subagent {step['subagent']!r}")
+        if not isinstance(step.get("prompt"), str) or not step["prompt"].strip():
+            errors.append(f"step {sid!r}: missing 'prompt'")
+
+    id_set = set(ids)
+    # depends_on references + cycle check
+    for step in steps:
+        if not isinstance(step, dict):
+            continue
+        for dep in step.get("depends_on", []) or []:
+            if dep not in id_set:
+                errors.append(f"step {step.get('id')!r}: depends_on unknown step {dep!r}")
+    if not errors and _has_cycle(steps):
+        errors.append("steps form a dependency cycle")
+
+    # template references must resolve to a declared input or an existing step output
+    for text in [s.get("prompt", "") for s in steps if isinstance(s, dict)] + [recipe.get("output", "")]:
+        for ref in _refs(text):
+            if ref.startswith("inputs."):
+                if ref[len("inputs."):] not in input_names:
+                    errors.append(f"template references unknown input {ref!r}")
+            elif ref.startswith("steps.") and ref.endswith(".output"):
+                mid = ref[len("steps."):-len(".output")]
+                if mid not in id_set:
+                    errors.append(f"template references unknown step {mid!r}")
+            else:
+                errors.append(f"unrecognized template reference {ref!r}")
+    return errors
+
+
+def _has_cycle(steps: list[dict]) -> bool:
+    graph = {s["id"]: set(s.get("depends_on", []) or []) for s in steps if isinstance(s, dict) and s.get("id")}
+    state: dict[str, int] = {}  # 0=visiting, 1=done
+
+    def visit(node: str) -> bool:
+        if state.get(node) == 1:
+            return False
+        if node in state:  # currently visiting → back-edge → cycle
+            return True
+        state[node] = 0
+        for dep in graph.get(node, ()):  # dep must finish before node
+            if dep in graph and visit(dep):
+                return True
+        state[node] = 1
+        return False
+
+    return any(visit(n) for n in graph)
+
+
+def render_template(text: str, inputs: dict, step_outputs: dict) -> str:
+    def sub(m: re.Match) -> str:
+        ref = m.group(1)
+        if ref.startswith("inputs."):
+            return str(inputs.get(ref[len("inputs."):], ""))
+        if ref.startswith("steps.") and ref.endswith(".output"):
+            return str(step_outputs.get(ref[len("steps."):-len(".output")], ""))
+        return m.group(0)
+    return _REF_RE.sub(sub, text or "")
+
+
+def resolve_inputs(recipe: dict, provided: dict) -> tuple[dict, list[str]]:
+    """Merge provided inputs with declared defaults; return (inputs, missing)."""
+    resolved: dict[str, Any] = {}
+    missing: list[str] = []
+    provided = provided or {}
+    for spec in recipe.get("inputs", []) or []:
+        if not isinstance(spec, dict) or "name" not in spec:
+            continue
+        name = spec["name"]
+        if name in provided and provided[name] not in (None, ""):
+            resolved[name] = provided[name]
+        elif "default" in spec:
+            resolved[name] = spec["default"]
+        elif spec.get("required"):
+            missing.append(name)
+    # pass through any extra provided inputs too
+    for k, v in provided.items():
+        resolved.setdefault(k, v)
+    return resolved, missing
+
+
+async def execute_workflow(
+    recipe: dict,
+    inputs: dict,
+    *,
+    run_step: Callable[[str, str, str], Awaitable[str]],
+    max_concurrency: int = 4,
+) -> dict:
+    """Run the recipe's step DAG. ``run_step(subagent, prompt, step_id) -> output``.
+
+    Returns ``{"output": str, "steps": {id: output}, "failed": [ids]}``. Step
+    failures are recorded inline (the step's output becomes the error text) so
+    independent branches still complete — matching task_batch semantics.
+    """
+    steps = recipe["steps"]
+    by_id = {s["id"]: s for s in steps}
+    pending = {s["id"]: set(s.get("depends_on", []) or []) for s in steps}
+    done: dict[str, str] = {}
+    failed: list[str] = []
+    sem = asyncio.Semaphore(max(1, max_concurrency))
+
+    async def run_one(sid: str) -> tuple[str, str, bool]:
+        step = by_id[sid]
+        prompt = render_template(step["prompt"], inputs, done)
+        async with sem:
+            try:
+                out = await run_step(step["subagent"], prompt, sid)
+                return sid, str(out), False
+            except Exception as exc:  # noqa: BLE001 — record inline, keep the DAG going
+                return sid, f"Error: step {sid!r} raised {type(exc).__name__}: {exc}", True
+
+    while pending:
+        ready = [sid for sid, deps in pending.items() if deps <= set(done)]
+        if not ready:  # should be impossible post-validate (cycle) — guard anyway
+            for sid in pending:
+                done[sid] = f"Error: step {sid!r} skipped (unsatisfiable dependencies)"
+                failed.append(sid)
+            break
+        for sid, out, err in await asyncio.gather(*(run_one(s) for s in ready)):
+            done[sid] = out
+            if err:
+                failed.append(sid)
+        for sid in ready:
+            pending.pop(sid)
+
+    output_tpl = recipe.get("output") or f"{{{{steps.{steps[-1]['id']}.output}}}}"
+    return {"output": render_template(output_tpl, inputs, done), "steps": done, "failed": failed}

--- a/graph/workflows/registry.py
+++ b/graph/workflows/registry.py
@@ -1,0 +1,66 @@
+"""Workflow registry — load declarative recipes (`*.yaml`) from disk.
+
+Scans one or more directories for workflow recipes (bundled examples in the
+repo's ``workflows/`` dir + a writable dir for user/agent-emitted ones, same
+shape as the skills loader). A recipe's ``name`` is the lookup key; later dirs
+win on a name clash so a user copy can override a bundled example.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+log = logging.getLogger(__name__)
+
+
+class WorkflowRegistry:
+    def __init__(self, dirs: list[str] | None = None):
+        self._dirs = [Path(d) for d in (dirs or [])]
+        self._recipes: dict[str, dict[str, Any]] = {}
+        self.reload()
+
+    def reload(self) -> None:
+        recipes: dict[str, dict[str, Any]] = {}
+        for d in self._dirs:
+            if not d.is_dir():
+                continue
+            for path in sorted(d.glob("*.yaml")) + sorted(d.glob("*.yml")):
+                try:
+                    data = yaml.safe_load(path.read_text(encoding="utf-8"))
+                except (OSError, yaml.YAMLError) as exc:
+                    log.warning("[workflows] skipping %s: %s", path, exc)
+                    continue
+                if isinstance(data, dict) and isinstance(data.get("name"), str):
+                    recipes[data["name"]] = data
+                else:
+                    log.warning("[workflows] skipping %s: not a named recipe", path)
+        self._recipes = recipes
+        log.info("[workflows] loaded %d workflow(s): %s", len(recipes), ", ".join(sorted(recipes)) or "(none)")
+
+    def list(self) -> list[dict[str, Any]]:
+        """Lightweight summaries for the UI / tool discovery."""
+        out = []
+        for name, r in sorted(self._recipes.items()):
+            out.append({
+                "name": name,
+                "description": r.get("description", ""),
+                "inputs": [
+                    {"name": i.get("name"), "required": bool(i.get("required")), "default": i.get("default")}
+                    for i in (r.get("inputs") or []) if isinstance(i, dict)
+                ],
+                "steps": [
+                    {"id": s.get("id"), "subagent": s.get("subagent"), "depends_on": list(s.get("depends_on", []) or [])}
+                    for s in (r.get("steps") or []) if isinstance(s, dict)
+                ],
+            })
+        return out
+
+    def get(self, name: str) -> dict[str, Any] | None:
+        return self._recipes.get(name)
+
+    def names(self) -> list[str]:
+        return sorted(self._recipes)

--- a/server.py
+++ b/server.py
@@ -69,6 +69,7 @@ _checkpoint_path = None  # resolved sqlite path when persistent (for the pruner)
 _checkpoint_prune_task = None  # background prune loop handle
 _knowledge_store = None  # KnowledgeStore bound into the active graph, or None.
 _skills_index = None     # SkillsIndex (human-authored SKILL.md store), or None.
+_workflow_registry = None  # WorkflowRegistry (declarative workflow recipes), or None.
 _mcp_clients = []        # Live MultiServerMCPClient handles (kept alive for reconnect).
 _mcp_tools = []          # MCP-server tools appended to the active graph.
 _mcp_meta = []           # Per-server {name, transport, tool_count} for runtime status.
@@ -99,6 +100,7 @@ def _init_langgraph_agent():
     provide them, then triggers a reload.
     """
     global _graph, _graph_config, _checkpointer, _knowledge_store, _skills_index
+    global _workflow_registry
     global _mcp_clients, _mcp_tools, _mcp_meta
     global _plugin_tools, _plugin_skill_dirs, _plugin_meta
 
@@ -159,10 +161,12 @@ def _init_langgraph_agent():
     # seeded into the FTS index; KnowledgeMiddleware retrieves + injects them.
     _skills_index = _build_skills_index(_graph_config, extra_skill_dirs=_plugin_skill_dirs)
 
+    _workflow_registry = _build_workflow_registry(_graph_config)
+
     _graph = create_agent_graph(
         _graph_config, knowledge_store=_knowledge_store, scheduler=_scheduler,
         skills_index=_skills_index, extra_tools=_mcp_tools + _plugin_tools,
-        checkpointer=_checkpointer,
+        checkpointer=_checkpointer, workflow_registry=_workflow_registry,
     )
 
     # Cache-warming heartbeat — off by default; start() no-ops unless enabled
@@ -405,6 +409,37 @@ async def _retire_thread(thread_id: str) -> str | None:
     return chunk_id
 
 
+def _build_workflow_registry(config):
+    """Load workflow recipes (ADR 0002) from the bundled repo ``workflows/`` dir
+    plus a writable dir (user/agent-emitted). Best-effort; never blocks boot."""
+    if not getattr(config, "workflows_enabled", True):
+        return None
+    try:
+        import os
+        from pathlib import Path
+
+        from graph.workflows.registry import WorkflowRegistry
+
+        dirs: list[str] = []
+        bundled = Path(__file__).resolve().parent / "workflows"
+        if bundled.is_dir():
+            dirs.append(str(bundled))
+        # Writable dir for user / agent-emitted recipes (same fallback shape).
+        writable = Path(config.workflow_dir).expanduser()
+        try:
+            writable.mkdir(parents=True, exist_ok=True)
+            if not os.access(writable, os.W_OK):
+                raise OSError
+        except OSError:
+            writable = Path.home() / ".protoagent" / "workflows"
+            writable.mkdir(parents=True, exist_ok=True)
+        dirs.append(str(writable))
+        return WorkflowRegistry(dirs)
+    except Exception:
+        log.exception("[workflows] registry init failed; running without workflows")
+        return None
+
+
 def _resolve_skills_db(configured: str) -> str:
     """Pick a writable skills DB path; fall back to ~/.protoagent when the
     configured dir (default /sandbox) isn't creatable — same idea as the
@@ -561,7 +596,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     compiling — the wizard is still in front of the user, so there
     is nothing to hot-swap yet.
     """
-    global _graph, _graph_config, _knowledge_store, _skills_index
+    global _graph, _graph_config, _knowledge_store, _skills_index, _workflow_registry
     global _mcp_clients, _mcp_tools, _mcp_meta
     global _plugin_tools, _plugin_skill_dirs, _plugin_meta
 
@@ -626,10 +661,11 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
             new_plugin_skill_dirs = new_plugins.skill_dirs
             new_plugin_meta = new_plugins.meta
             new_skills = _build_skills_index(new_config, extra_skill_dirs=new_plugin_skill_dirs)
+            new_workflow_registry = _build_workflow_registry(new_config)
             new_graph = create_agent_graph(
                 new_config, knowledge_store=new_store, scheduler=next_scheduler,
                 skills_index=new_skills, extra_tools=new_mcp_tools + new_plugin_tools,
-                checkpointer=_checkpointer,
+                checkpointer=_checkpointer, workflow_registry=new_workflow_registry,
             )
         except Exception as e:
             log.exception("[reload] graph rebuild failed")
@@ -638,6 +674,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
             return False, f"graph rebuild failed: {e}"
     else:
         new_graph = None
+        new_workflow_registry = None
 
     # Commit: config → A2A bearer → graph. All three reference the
     # same ``new_config`` so they stay consistent.
@@ -657,6 +694,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
         # before _main wires routes) — harmless.
         pass
     _graph = new_graph
+    _workflow_registry = new_workflow_registry
     # Commit the scheduler swap. start/stop are async — fire-and-forget
     # onto the active loop so reload stays sync. We've already verified
     # the graph rebuild succeeded; if start/stop fails we log but

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -1,0 +1,131 @@
+"""Tests for the declarative workflow engine + registry (ADR 0002)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from graph.workflows.engine import (
+    execute_workflow,
+    render_template,
+    resolve_inputs,
+    validate_recipe,
+)
+from graph.workflows.registry import WorkflowRegistry
+
+VALID = {
+    "name": "demo",
+    "inputs": [{"name": "topic", "required": True}, {"name": "depth", "default": "deep"}],
+    "steps": [
+        {"id": "gather", "subagent": "researcher", "prompt": "research {{inputs.topic}} ({{inputs.depth}})"},
+        {"id": "brief", "subagent": "researcher", "depends_on": ["gather"],
+         "prompt": "write up:\n{{steps.gather.output}}"},
+    ],
+    "output": "{{steps.brief.output}}",
+}
+
+
+def test_validate_accepts_valid_recipe():
+    assert validate_recipe(VALID, known_subagents={"researcher"}) == []
+
+
+def test_validate_catches_structural_errors():
+    assert "missing 'name'" in validate_recipe({"steps": [{"id": "a", "subagent": "researcher", "prompt": "x"}]})
+    assert any("non-empty list" in e for e in validate_recipe({"name": "x"}))
+    dup = {"name": "x", "steps": [
+        {"id": "a", "subagent": "researcher", "prompt": "p"},
+        {"id": "a", "subagent": "researcher", "prompt": "p"},
+    ]}
+    assert any("duplicate step id" in e for e in validate_recipe(dup))
+
+
+def test_validate_catches_dep_and_cycle_and_subagent():
+    bad_dep = {"name": "x", "steps": [{"id": "a", "subagent": "researcher", "prompt": "p", "depends_on": ["z"]}]}
+    assert any("unknown step 'z'" in e for e in validate_recipe(bad_dep))
+    cycle = {"name": "x", "steps": [
+        {"id": "a", "subagent": "researcher", "prompt": "p", "depends_on": ["b"]},
+        {"id": "b", "subagent": "researcher", "prompt": "p", "depends_on": ["a"]},
+    ]}
+    assert any("cycle" in e for e in validate_recipe(cycle))
+    unknown_sub = {"name": "x", "steps": [{"id": "a", "subagent": "nope", "prompt": "p"}]}
+    assert any("unknown subagent" in e for e in validate_recipe(unknown_sub, known_subagents={"researcher"}))
+
+
+def test_validate_catches_bad_template_refs():
+    bad = {"name": "x", "inputs": [{"name": "topic"}], "steps": [
+        {"id": "a", "subagent": "researcher", "prompt": "{{inputs.missing}} {{steps.ghost.output}}"},
+    ]}
+    errs = validate_recipe(bad)
+    assert any("unknown input" in e for e in errs)
+    assert any("unknown step" in e for e in errs)
+
+
+def test_render_template_substitutes():
+    out = render_template("hi {{inputs.topic}} / {{steps.s.output}}", {"topic": "x"}, {"s": "RESULT"})
+    assert out == "hi x / RESULT"
+
+
+def test_resolve_inputs_defaults_and_missing():
+    resolved, missing = resolve_inputs(VALID, {"topic": "ai"})
+    assert resolved["topic"] == "ai" and resolved["depth"] == "deep" and missing == []
+    _, missing2 = resolve_inputs(VALID, {})
+    assert missing2 == ["topic"]
+
+
+def test_execute_threads_outputs_sequentially():
+    calls = []
+
+    async def run_step(subagent, prompt, sid):
+        calls.append((sid, prompt))
+        return f"<{sid}-out>"
+
+    res = asyncio.run(execute_workflow(VALID, {"topic": "ai", "depth": "deep"}, run_step=run_step))
+    # gather ran first; brief's prompt saw gather's output threaded in.
+    brief_prompt = dict((sid, p) for sid, p in calls)["brief"]
+    assert "<gather-out>" in brief_prompt
+    assert res["output"] == "<brief-out>"
+    assert res["failed"] == []
+
+
+def test_execute_runs_independent_steps_in_parallel():
+    running = 0
+    max_seen = 0
+
+    async def run_step(subagent, prompt, sid):
+        nonlocal running, max_seen
+        running += 1
+        max_seen = max(max_seen, running)
+        await asyncio.sleep(0.02)
+        running -= 1
+        return sid
+
+    fanout = {"name": "f", "steps": [
+        {"id": "a", "subagent": "researcher", "prompt": "p"},
+        {"id": "b", "subagent": "researcher", "prompt": "p"},
+        {"id": "c", "subagent": "researcher", "prompt": "p"},
+    ]}
+    asyncio.run(execute_workflow(fanout, {}, run_step=run_step, max_concurrency=4))
+    assert max_seen >= 2  # independent steps overlapped
+
+
+def test_execute_records_failure_inline_and_continues():
+    async def run_step(subagent, prompt, sid):
+        if sid == "gather":
+            raise RuntimeError("boom")
+        return f"saw:{prompt}"
+
+    res = asyncio.run(execute_workflow(VALID, {"topic": "ai"}, run_step=run_step))
+    assert "gather" in res["failed"]
+    # brief still ran and saw the error text from gather.
+    assert "Error: step 'gather'" in res["steps"]["brief"]
+
+
+def test_registry_loads_and_lists(tmp_path):
+    (tmp_path / "w.yaml").write_text(
+        "name: wf\ndescription: d\nsteps:\n  - id: a\n    subagent: researcher\n    prompt: p\n",
+        encoding="utf-8",
+    )
+    (tmp_path / "bad.yaml").write_text("just a string", encoding="utf-8")  # ignored
+    reg = WorkflowRegistry([str(tmp_path)])
+    assert reg.names() == ["wf"]
+    assert reg.get("wf")["description"] == "d"
+    assert reg.list()[0]["name"] == "wf"

--- a/workflows/research-and-brief.yaml
+++ b/workflows/research-and-brief.yaml
@@ -1,0 +1,38 @@
+# A bundled example workflow (see docs/adr/0002). Reusable, multi-step
+# orchestration over subagents: research a topic, pull out the key angles, then
+# write a cited brief — each step feeds the next. Run it with:
+#   run_workflow("research-and-brief", {"topic": "…", "depth": "deep"})
+name: research-and-brief
+description: Research a topic across the web + memory and write a short cited brief.
+version: 1
+inputs:
+  - name: topic
+    description: The subject to research.
+    required: true
+  - name: depth
+    description: How deep to go — "shallow" or "deep".
+    default: deep
+steps:
+  - id: gather
+    subagent: researcher
+    prompt: |
+      Research the topic: {{inputs.topic}} (depth: {{inputs.depth}}).
+      Find 3–5 strong, recent sources and capture the key facts with citations.
+  - id: angles
+    subagent: researcher
+    depends_on: [gather]
+    prompt: |
+      From this research, identify the 3 most important angles to cover in a brief.
+      Research:
+      {{steps.gather.output}}
+  - id: brief
+    subagent: researcher
+    depends_on: [gather, angles]
+    prompt: |
+      Write a concise, cited brief on {{inputs.topic}}.
+      Use this research:
+      {{steps.gather.output}}
+
+      Cover these angles:
+      {{steps.angles.output}}
+output: "{{steps.brief.output}}"


### PR DESCRIPTION
First slice of reusable subagent workflows ([ADR 0002](../blob/main/docs/adr/0002-reusable-subagent-workflows.md)).

## Engine (`graph/workflows/engine.py`)
- **`validate_recipe`** — unique step ids, `depends_on` resolves, no cycles, `subagent` is registered, templates reference only declared inputs / existing step outputs.
- **`execute_workflow`** — runs the `depends_on` DAG with **ready-set parallelism** (bounded by the subagent concurrency cap), threads each step's output into later prompts (`{{inputs.x}}` / `{{steps.id.output}}`), and records step failures inline so independent branches still finish (task_batch semantics).
- `render_template`, `resolve_inputs` (defaults + required-missing).

## Registry + tool
- **`graph/workflows/registry.py`** loads `*.yaml` recipes from the bundled repo `workflows/` dir + a writable dir (user/agent-emitted).
- **`run_workflow(name, inputs)`** tool on the **lead agent only** (subagents don't get it → no recursion); an empty name lists available workflows. Wired through `create_agent_graph → _build_task_tools`; the registry is built in `server` (init + reload) with the `/sandbox`→`~/.protoagent` writable fallback.
- `config.workflows_enabled` / `workflow_dir`; bundled example `workflows/research-and-brief.yaml`; docs guide (+ sidebar) and `example.yaml` block.

## Verified
Live: the agent called `run_workflow("smoke")` and the engine executed the recipe over `_run_subagent`, returning the result. Unit tests cover validate (structural/dep/cycle/subagent/template), DAG output threading, parallelism, inline failure, and registry load. Full suite **740 passed**; docs build clean.

Next slices: agent-emitted workflows, operator console surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)