### PR TITLE
Agent-emitted workflows: save_workflow tool (ADR 0002, slice 2)

### DIFF
--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -57,6 +57,15 @@ Workflows only delegate to **configured subagents** (each with its own tool
 allowlist and turn cap), and subagents don't get `run_workflow` — so there's no
 recursion and the blast radius is exactly the subagent system's.
 
+## The agent can author them (closed loop)
+
+The lead agent also has **`save_workflow(name, description, steps, inputs?, output?)`**.
+Once it's worked out a multi-step process ad-hoc (via `task` / `task_batch`), it
+can capture it as a reusable recipe — *"save that as a workflow called
+competitor-scan"* — which is validated, written to `workflows.dir`, and
+immediately runnable via `run_workflow`. This generalizes `skill-v1` emission
+(a single-subagent recipe) to multi-step flows.
+
 ## Related
 
 - [ADR 0002 — Reusable Subagent Workflows](/adr/0002-reusable-subagent-workflows)

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -498,6 +498,50 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
 
         tools.append(run_workflow)
 
+        @tool
+        async def save_workflow(
+            name: str,
+            description: str,
+            steps: list[dict],
+            inputs: list[dict] | None = None,
+            output: str = "",
+        ) -> str:
+            """Save a reusable multi-step workflow so it can be re-run later with
+            run_workflow — capture a multi-step subagent process you just worked
+            out (the closed loop). Saving overwrites any existing workflow of the
+            same name.
+
+            Args:
+                name: Unique slug for the workflow.
+                description: One-line summary of what it does.
+                steps: Ordered list of step objects, each with ``id`` (str),
+                    ``subagent`` (a configured subagent type), ``prompt`` (str,
+                    may reference {{inputs.x}} and {{steps.<id>.output}}), and
+                    optional ``depends_on`` (list of earlier step ids that run
+                    first — independent steps run in parallel).
+                inputs: Optional list of {name, required?, default?} the workflow
+                    accepts (referenced as {{inputs.name}} in prompts).
+                output: Optional final-output template (default = last step's output).
+            """
+            recipe: dict = {"name": name, "description": description, "version": 1, "steps": steps}
+            if inputs:
+                recipe["inputs"] = inputs
+            if output:
+                recipe["output"] = output
+            errs = validate_recipe(recipe, known_subagents=set(SUBAGENT_REGISTRY))
+            if errs:
+                return "Cannot save — the workflow is invalid: " + "; ".join(errs)
+            try:
+                path = workflow_registry.save(recipe)
+            except Exception as exc:  # noqa: BLE001 — readable tool error
+                return f"Error saving workflow: {exc}"
+            return (
+                f"Saved workflow {name!r} ({len(steps)} step(s)) to {path}. "
+                f"Run it with run_workflow({name!r}, ...)."
+            )
+
+        tools.append(save_workflow)
+
     return tools
 
 

--- a/graph/workflows/registry.py
+++ b/graph/workflows/registry.py
@@ -9,6 +9,7 @@ win on a name clash so a user copy can override a bundled example.
 from __future__ import annotations
 
 import logging
+import re
 from pathlib import Path
 from typing import Any
 
@@ -17,9 +18,17 @@ import yaml
 log = logging.getLogger(__name__)
 
 
+def _slug(name: str) -> str:
+    return re.sub(r"[^a-z0-9_-]+", "-", (name or "").lower()).strip("-") or "workflow"
+
+
 class WorkflowRegistry:
-    def __init__(self, dirs: list[str] | None = None):
+    def __init__(self, dirs: list[str] | None = None, writable_dir: str | None = None):
         self._dirs = [Path(d) for d in (dirs or [])]
+        # The dir agent-emitted / user recipes are written to. Defaults to the
+        # last configured dir (which wins on a name clash, so a saved recipe can
+        # override a bundled one).
+        self._writable = Path(writable_dir) if writable_dir else (self._dirs[-1] if self._dirs else None)
         self._recipes: dict[str, dict[str, Any]] = {}
         self.reload()
 
@@ -64,3 +73,25 @@ class WorkflowRegistry:
 
     def names(self) -> list[str]:
         return sorted(self._recipes)
+
+    def save(self, recipe: dict[str, Any]) -> str:
+        """Persist a recipe to the writable dir (agent emission / UI authoring)
+        and reload so it's immediately runnable. Returns the file path."""
+        if self._writable is None:
+            raise RuntimeError("no writable workflow directory configured")
+        self._writable.mkdir(parents=True, exist_ok=True)
+        path = self._writable / f"{_slug(recipe['name'])}.yaml"
+        path.write_text(yaml.safe_dump(recipe, sort_keys=False, allow_unicode=True), encoding="utf-8")
+        self.reload()
+        return str(path)
+
+    def delete(self, name: str) -> bool:
+        """Remove a recipe's file from the writable dir. Returns True if removed."""
+        if self._writable is None:
+            return False
+        path = self._writable / f"{_slug(name)}.yaml"
+        if path.exists():
+            path.unlink()
+            self.reload()
+            return True
+        return False

--- a/server.py
+++ b/server.py
@@ -434,7 +434,7 @@ def _build_workflow_registry(config):
             writable = Path.home() / ".protoagent" / "workflows"
             writable.mkdir(parents=True, exist_ok=True)
         dirs.append(str(writable))
-        return WorkflowRegistry(dirs)
+        return WorkflowRegistry(dirs, writable_dir=str(writable))
     except Exception:
         log.exception("[workflows] registry init failed; running without workflows")
         return None

--- a/tests/test_workflows.py
+++ b/tests/test_workflows.py
@@ -119,6 +119,35 @@ def test_execute_records_failure_inline_and_continues():
     assert "Error: step 'gather'" in res["steps"]["brief"]
 
 
+def test_registry_save_roundtrip_and_override(tmp_path):
+    bundled = tmp_path / "bundled"
+    writable = tmp_path / "writable"
+    bundled.mkdir()
+    (bundled / "demo.yaml").write_text(
+        "name: demo\ndescription: bundled\nsteps:\n  - id: a\n    subagent: researcher\n    prompt: p\n",
+        encoding="utf-8",
+    )
+    reg = WorkflowRegistry([str(bundled), str(writable)], writable_dir=str(writable))
+    assert reg.get("demo")["description"] == "bundled"
+    # Save overrides (writable dir wins) + is immediately runnable.
+    reg.save({"name": "demo", "description": "saved", "steps": [{"id": "a", "subagent": "researcher", "prompt": "p"}]})
+    assert reg.get("demo")["description"] == "saved"
+    assert (writable / "demo.yaml").exists()
+    # New recipe persists + loads.
+    reg.save({"name": "Fresh One", "description": "x", "steps": [{"id": "a", "subagent": "researcher", "prompt": "p"}]})
+    assert "Fresh One" in reg.names()
+    assert (writable / "fresh-one.yaml").exists()  # slugified filename
+
+
+def test_registry_delete(tmp_path):
+    reg = WorkflowRegistry([str(tmp_path)], writable_dir=str(tmp_path))
+    reg.save({"name": "temp", "description": "x", "steps": [{"id": "a", "subagent": "researcher", "prompt": "p"}]})
+    assert "temp" in reg.names()
+    assert reg.delete("temp") is True
+    assert "temp" not in reg.names()
+    assert reg.delete("temp") is False
+
+
 def test_registry_loads_and_lists(tmp_path):
     (tmp_path / "w.yaml").write_text(
         "name: wf\ndescription: d\nsteps:\n  - id: a\n    subagent: researcher\n    prompt: p\n",


### PR DESCRIPTION
Closes the loop ([ADR 0002](../blob/main/docs/adr/0002-reusable-subagent-workflows.md) slice 2): the lead agent can capture a multi-step process it worked out as a **reusable workflow recipe**.

- **`WorkflowRegistry.save(recipe)`** — writes a slugified `*.yaml` to the writable dir and reloads, so it's immediately runnable; a writable recipe overrides a bundled one of the same name. Plus `delete(name)` and an explicit `writable_dir`.
- **`save_workflow(name, description, steps, inputs?, output?)`** tool on the lead agent — validates via `validate_recipe` (against the subagent registry), then persists. Generalizes `skill-v1` emission (single-subagent recipe) to multi-step flows.

## Verified live
The agent used `save_workflow` to author `echo-flow` (file written to `~/.protoagent/workflows/`), then `run_workflow("echo-flow", {phrase: …})` executed it end-to-end and returned the expected output.

## Tests
Registry save round-trip + bundled-override + slugified filename, delete, and the existing engine/validate suite. Full suite **742 passed**. Docs updated.

Next: the operator console Workflows surface (slice 3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)