### PR TITLE
Add Workflows operator console surface (ADR 0002 slice 3)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -51,6 +51,30 @@ export const SUBAGENTS = [
   },
 ];
 
+export const WORKFLOWS = [
+  {
+    name: "research-and-brief",
+    description: "Research a topic, then write a brief.",
+    inputs: [
+      { name: "topic", required: true },
+      { name: "depth", required: false, default: "deep" },
+    ],
+    steps: [
+      { id: "gather", subagent: "researcher", depends_on: [] },
+      { id: "brief", subagent: "researcher", depends_on: ["gather"] },
+    ],
+  },
+];
+
+export const WORKFLOW_RUN_RESULT = {
+  output: "## Brief on AI\n\nKey findings…",
+  steps: {
+    gather: "raw research notes",
+    brief: "## Brief on AI\n\nKey findings…",
+  },
+  failed: [],
+};
+
 export const SLASH_COMMANDS = [
   { name: "goal", description: "Set a goal for this session", usage: "/goal <condition>" },
   { name: "clear", description: "Clear the conversation", usage: "/clear" },

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -23,6 +23,8 @@ import {
   settingsRestartRequired,
   SLASH_COMMANDS,
   SUBAGENTS,
+  WORKFLOW_RUN_RESULT,
+  WORKFLOWS,
 } from "./fixtures.mjs";
 
 const PORT = Number(process.argv[2] || process.env.E2E_PORT || 4319);
@@ -80,6 +82,8 @@ function handleApiGet(pathname) {
       return { issues: [] };
     case "/api/settings/schema":
       return { groups: SETTINGS_SCHEMA };
+    case "/api/workflows":
+      return { workflows: WORKFLOWS };
     default:
       return null;
   }
@@ -159,6 +163,9 @@ const server = createServer(async (req, res) => {
         messages: ["config saved", "reloaded • model=protolabs/reasoning"],
         restart_required: settingsRestartRequired(body.updates),
       });
+    }
+    if (/^\/api\/workflows\/[^/]+\/run$/.test(pathname)) {
+      return sendJson(res, WORKFLOW_RUN_RESULT);
     }
     return sendJson(res, { ok: true });
   }

--- a/apps/web/e2e/workflows.spec.ts
+++ b/apps/web/e2e/workflows.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+// The Workflows surface lists recipes from GET /api/workflows, shows the
+// selected recipe's step DAG + inputs, and runs it via
+// POST /api/workflows/{name}/run — rendering the output + per-step results.
+
+async function openWorkflows(page) {
+  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.getByRole("button", { name: "Workflows", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Workflows" })).toBeVisible();
+}
+
+test("lists a recipe with its steps and inputs", async ({ page }) => {
+  await openWorkflows(page);
+  await expect(page.getByText("1 recipe", { exact: true })).toBeVisible();
+  // The recipe's description + step DAG render.
+  await expect(page.getByText("Research a topic, then write a brief.")).toBeVisible();
+  const steps = page.locator(".workflow-step");
+  await expect(steps).toHaveCount(2);
+  await expect(steps.nth(1)).toContainText("after gather");
+  // Required + optional inputs are present; the optional one shows its default.
+  await expect(page.locator(".field span", { hasText: /^topic \*$/ })).toBeVisible();
+  await expect(page.locator('input[placeholder="default: deep"]')).toBeVisible();
+});
+
+test("requires the required input before running", async ({ page }) => {
+  await openWorkflows(page);
+  const run = page.getByRole("button", { name: "Run", exact: true });
+  await expect(run).toBeDisabled(); // topic is empty
+});
+
+test("runs the workflow and renders the result", async ({ page }) => {
+  await openWorkflows(page);
+  // Fill the required input → Run enables.
+  const topic = page.locator(".subagent-grid .field").first().locator("input");
+  await topic.fill("AI");
+  const run = page.getByRole("button", { name: "Run", exact: true });
+  await expect(run).toBeEnabled();
+  await run.click();
+  // The run result output renders.
+  await expect(page.locator(".workflow-result .output-block").first()).toContainText("Brief on AI");
+  // Per-step details are available.
+  await expect(page.getByText(/Per-step output \(2\)/)).toBeVisible();
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -21,18 +21,20 @@ import {
   Target,
   Undo2,
   Trash2,
+  Workflow,
 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
 import { ChatSurface } from "../chat/ChatSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
+import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import type { BeadsIssue, GoalState, NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
 import { ScrollArea } from "./ScrollArea";
 import { SetupWizard } from "../setup/SetupWizard";
 
-type Surface = "chat" | "subagents" | "runtime" | "schedule" | "goals" | "settings";
+type Surface = "chat" | "subagents" | "workflows" | "runtime" | "schedule" | "goals" | "settings";
 type RightPanel = "notes" | "beads";
 type SubagentMode = "single" | "batch";
 type StatusTone = "success" | "warning" | "error" | "muted";
@@ -756,6 +758,12 @@ export function App() {
             onClick={() => setSurface("subagents")}
           />
           <RailButton
+            active={surface === "workflows"}
+            label="Workflows"
+            icon={<Workflow size={18} />}
+            onClick={() => setSurface("workflows")}
+          />
+          <RailButton
             active={surface === "schedule"}
             label="Schedule"
             icon={<CalendarClock size={18} />}
@@ -907,6 +915,8 @@ export function App() {
               </div>
             </section>
           ) : null}
+
+          {surface === "workflows" ? <WorkflowsSurface onError={setError} /> : null}
 
           {surface === "schedule" ? (
             <section className="panel stage-panel">

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1139,6 +1139,84 @@ textarea {
   white-space: pre-wrap;
 }
 
+/* Workflows surface --------------------------------------------------------- */
+.workflow-desc {
+  margin: 0 12px;
+  color: var(--fg-secondary);
+  font-size: 13px;
+}
+
+.workflow-steps {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  margin: 4px 12px;
+}
+
+.workflow-step {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elevated, #111114);
+  font-size: 13px;
+}
+
+.workflow-step svg {
+  color: var(--accent, #7c8cff);
+  flex: none;
+}
+
+.workflow-step-sub {
+  color: var(--fg-secondary);
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.workflow-step-dep {
+  margin-left: auto;
+  color: var(--fg-tertiary, var(--fg-secondary));
+  font-size: 11px;
+}
+
+.workflow-result {
+  margin: 8px 0 0;
+}
+
+.workflow-result h2 {
+  margin: 8px 12px 4px;
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-secondary);
+}
+
+.workflow-result details {
+  margin: 0 12px 12px;
+}
+
+.workflow-result summary {
+  cursor: pointer;
+  color: var(--fg-secondary);
+  font-size: 12px;
+  padding: 4px 0;
+}
+
+.workflow-step-out strong {
+  display: block;
+  margin: 6px 12px 2px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+
+.workflow-failed {
+  margin: 0 12px;
+  color: var(--danger, #ff6b6b);
+  font-size: 13px;
+}
+
 .metric-grid {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -12,6 +12,8 @@ import type {
   SlashCommand,
   Subagent,
   ToolEvent,
+  WorkflowRunResult,
+  WorkflowSummary,
 } from "./types";
 
 type RequestOptions = Omit<RequestInit, "body"> & {
@@ -259,6 +261,17 @@ export const api = {
 
   settingsSchema() {
     return request<{ groups: SettingsGroup[] }>("/api/settings/schema");
+  },
+
+  workflows() {
+    return request<{ workflows: WorkflowSummary[] }>("/api/workflows");
+  },
+
+  runWorkflow(name: string, inputs: Record<string, unknown>) {
+    return request<WorkflowRunResult>(`/api/workflows/${encodeURIComponent(name)}/run`, {
+      method: "POST",
+      body: { inputs },
+    });
   },
 
   saveSettings(updates: Record<string, unknown>) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -84,6 +84,19 @@ export type SettingsField = {
 
 export type SettingsGroup = { section: string; fields: SettingsField[] };
 
+export type WorkflowSummary = {
+  name: string;
+  description: string;
+  inputs: { name: string; required: boolean; default?: unknown }[];
+  steps: { id: string; subagent: string; depends_on: string[] }[];
+};
+
+export type WorkflowRunResult = {
+  output: string;
+  steps: Record<string, string>;
+  failed: string[];
+};
+
 export type GoalState = {
   session_id: string;
   condition: string;

--- a/apps/web/src/workflows/WorkflowsSurface.tsx
+++ b/apps/web/src/workflows/WorkflowsSurface.tsx
@@ -1,0 +1,184 @@
+import { Loader2, Play, RefreshCw, Workflow } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { api } from "../lib/api";
+import type { WorkflowRunResult, WorkflowSummary } from "../lib/types";
+
+// Operator surface for declarative workflow recipes (ADR 0002). Lists the
+// registered recipes, shows the selected one's step DAG, collects its inputs,
+// and runs it — surfacing each step's output plus any inline failures.
+
+export function WorkflowsSurface({ onError }: { onError: (message: string) => void }) {
+  const [workflows, setWorkflows] = useState<WorkflowSummary[] | null>(null);
+  const [selected, setSelected] = useState<string>("");
+  const [inputs, setInputs] = useState<Record<string, string>>({});
+  const [running, setRunning] = useState(false);
+  const [result, setResult] = useState<WorkflowRunResult | null>(null);
+
+  async function load() {
+    try {
+      const r = await api.workflows();
+      setWorkflows(r.workflows);
+      if (r.workflows.length && !r.workflows.some((w) => w.name === selected)) {
+        setSelected(r.workflows[0].name);
+      }
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  }
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const current = useMemo(
+    () => workflows?.find((w) => w.name === selected) ?? null,
+    [workflows, selected],
+  );
+
+  // Reset the inputs form (seed defaults) when the selected recipe changes.
+  useEffect(() => {
+    if (!current) return;
+    const seed: Record<string, string> = {};
+    for (const inp of current.inputs) {
+      seed[inp.name] = inp.default != null ? String(inp.default) : "";
+    }
+    setInputs(seed);
+    setResult(null);
+  }, [selected]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const missingRequired = useMemo(() => {
+    if (!current) return [];
+    return current.inputs.filter((i) => i.required && !inputs[i.name]?.trim()).map((i) => i.name);
+  }, [current, inputs]);
+
+  async function run() {
+    if (!current) return;
+    setRunning(true);
+    setResult(null);
+    onError("");
+    try {
+      const payload: Record<string, unknown> = {};
+      for (const inp of current.inputs) {
+        const v = inputs[inp.name];
+        if (v != null && v !== "") payload[inp.name] = v;
+      }
+      const r = await api.runWorkflow(current.name, payload);
+      setResult(r);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setRunning(false);
+    }
+  }
+
+  return (
+    <section className="panel stage-panel">
+      <div className="panel-header">
+        <div>
+          <h1>Workflows</h1>
+          <p className="panel-kicker">
+            {workflows ? `${workflows.length} recipe${workflows.length === 1 ? "" : "s"}` : "loading…"}
+          </p>
+        </div>
+        <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
+          <RefreshCw size={16} />
+        </button>
+      </div>
+
+      <div className="stage-body">
+        {workflows && !workflows.length ? (
+          <div className="subagent-row">
+            <div>
+              <strong>No workflows registered</strong>
+              <span>Drop a recipe in the workflows directory, or have the agent save one.</span>
+            </div>
+          </div>
+        ) : null}
+
+        {workflows && workflows.length ? (
+          <label className="field">
+            <span>Recipe</span>
+            <select value={selected} onChange={(event) => setSelected(event.target.value)}>
+              {workflows.map((w) => (
+                <option key={w.name} value={w.name}>
+                  {w.name}
+                </option>
+              ))}
+            </select>
+          </label>
+        ) : null}
+
+        {current ? (
+          <>
+            {current.description ? <p className="workflow-desc">{current.description}</p> : null}
+
+            <div className="workflow-steps">
+              {current.steps.map((step) => (
+                <div className="workflow-step" key={step.id}>
+                  <Workflow size={14} />
+                  <strong>{step.id}</strong>
+                  <span className="workflow-step-sub">{step.subagent}</span>
+                  {step.depends_on.length ? (
+                    <span className="workflow-step-dep">after {step.depends_on.join(", ")}</span>
+                  ) : null}
+                </div>
+              ))}
+            </div>
+
+            {current.inputs.length ? (
+              <div className="subagent-grid">
+                {current.inputs.map((inp) => (
+                  <label className="field" key={inp.name}>
+                    <span>
+                      {inp.name}
+                      {inp.required ? " *" : ""}
+                    </span>
+                    <input
+                      value={inputs[inp.name] ?? ""}
+                      onChange={(event) => setInputs((prev) => ({ ...prev, [inp.name]: event.target.value }))}
+                      placeholder={inp.default != null ? `default: ${String(inp.default)}` : inp.required ? "required" : "optional"}
+                    />
+                  </label>
+                ))}
+              </div>
+            ) : null}
+
+            <div className="panel-actions">
+              <button
+                className="primary-button"
+                type="button"
+                onClick={() => void run()}
+                disabled={running || missingRequired.length > 0}
+                title={missingRequired.length ? `missing: ${missingRequired.join(", ")}` : "Run workflow"}
+              >
+                {running ? <Loader2 className="spin" size={16} /> : <Play size={16} />}
+                Run
+              </button>
+            </div>
+          </>
+        ) : null}
+
+        {result ? (
+          <div className="workflow-result">
+            {result.failed.length ? (
+              <p className="workflow-failed">Failed steps: {result.failed.join(", ")}</p>
+            ) : null}
+            <h2>Output</h2>
+            <pre className="output-block">{result.output}</pre>
+            {Object.keys(result.steps).length ? (
+              <details>
+                <summary>Per-step output ({Object.keys(result.steps).length})</summary>
+                {Object.entries(result.steps).map(([id, out]) => (
+                  <div className="workflow-step-out" key={id}>
+                    <strong>{id}</strong>
+                    <pre className="output-block">{out}</pre>
+                  </div>
+                ))}
+              </details>
+            ) : null}
+          </div>
+        ) : null}
+      </div>
+    </section>
+  );
+}

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -57,6 +57,16 @@ Workflows only delegate to **configured subagents** (each with its own tool
 allowlist and turn cap), and subagents don't get `run_workflow` — so there's no
 recursion and the blast radius is exactly the subagent system's.
 
+## From the operator console
+
+The React console has a **Workflows** surface (the rail icon next to Subagents).
+It lists every registered recipe, shows the selected recipe's step DAG and its
+inputs, and runs it with a one-click form — the same path the agent's
+`run_workflow` tool takes. The result panel shows the final output plus a
+collapsible per-step breakdown, and flags any steps that failed (failures are
+recorded inline so the rest of the DAG still runs). It's backed by
+`GET /api/workflows` and `POST /api/workflows/{name}/run`.
+
 ## The agent can author them (closed loop)
 
 The lead agent also has **`save_workflow(name, description, steps, inputs?, output?)`**.

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -278,6 +278,49 @@ async def run_manual_subagent(
     )
 
 
+async def run_manual_workflow(
+    config: LangGraphConfig,
+    registry,
+    *,
+    knowledge_store=None,
+    scheduler=None,
+    name: str,
+    inputs: dict | None = None,
+) -> dict:
+    """Run a saved workflow recipe outside the lead agent's tool (operator UI).
+
+    Returns the engine result ``{"output", "steps", "failed"}``. Raises
+    ``ValueError`` for an unknown / invalid recipe or missing required inputs.
+    """
+    from graph.workflows.engine import execute_workflow, resolve_inputs, validate_recipe
+
+    if registry is None:
+        raise ValueError("workflows are not enabled")
+    recipe = registry.get(name)
+    if recipe is None:
+        raise ValueError(f"no workflow named {name!r}")
+    errs = validate_recipe(recipe, known_subagents=set(SUBAGENT_REGISTRY))
+    if errs:
+        raise ValueError("invalid workflow: " + "; ".join(errs))
+    resolved, missing = resolve_inputs(recipe, inputs or {})
+    if missing:
+        raise ValueError(f"missing required input(s): {', '.join(missing)}")
+
+    async def _run_step(subagent_type: str, prompt: str, step_id: str) -> str:
+        return await run_manual_subagent(
+            config,
+            knowledge_store=knowledge_store,
+            scheduler=scheduler,
+            description=f"workflow {name}:{step_id}",
+            prompt=prompt,
+            subagent_type=subagent_type,
+        )
+
+    return await execute_workflow(
+        recipe, resolved, run_step=_run_step, max_concurrency=config.subagent_max_concurrency,
+    )
+
+
 async def run_manual_subagent_batch(
     config: LangGraphConfig,
     knowledge_store=None,

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -37,6 +37,10 @@ class ScheduleAddRequest(BaseModel):
     job_id: str | None = None
 
 
+class WorkflowRunRequest(BaseModel):
+    inputs: dict[str, Any] = {}
+
+
 class BeadsInitRequest(BaseModel):
     project_path: str
     prefix: str | None = None
@@ -98,6 +102,8 @@ def register_operator_routes(
     goal_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
     goal_clear: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
     chat_commands: Callable[[], dict[str, Any]] | None = None,
+    workflows_list: Callable[[], dict[str, Any]] | None = None,
+    workflows_run: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
 ) -> None:
     """Register React operator-console routes on a FastAPI app.
 
@@ -265,5 +271,25 @@ def register_operator_routes(
         async def _chat_commands():
             try:
                 return chat_commands()
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    # --- Workflows -----------------------------------------------------------
+    # List the registered workflow recipes and run one with inputs (ADR 0002).
+    if workflows_list is not None:
+
+        @app.get("/api/workflows")
+        async def _workflows():
+            try:
+                return workflows_list()
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    if workflows_run is not None:
+
+        @app.post("/api/workflows/{name}/run")
+        async def _workflow_run(name: str, req: WorkflowRunRequest):
+            try:
+                return await workflows_run(name, req.inputs)
             except Exception as exc:
                 raise _http_error(exc) from exc

--- a/server.py
+++ b/server.py
@@ -1653,6 +1653,21 @@ def _main():
         cleared = await asyncio.to_thread(_goal_controller.store.clear, session_id)
         return {"cleared": bool(cleared)}
 
+    def _operator_workflows_list() -> dict:
+        if _workflow_registry is None:
+            return {"workflows": []}
+        return {"workflows": _workflow_registry.list()}
+
+    async def _operator_workflow_run(name: str, inputs: dict) -> dict:
+        if _graph is None:
+            raise RuntimeError("agent graph is not loaded; finish setup first")
+        from graph.agent import run_manual_workflow
+        return await run_manual_workflow(
+            _graph_config, _workflow_registry,
+            knowledge_store=_knowledge_store, scheduler=_scheduler,
+            name=name, inputs=inputs or {},
+        )
+
     def _operator_chat_commands() -> dict:
         """Slash commands the chat understands — drives the composer autocomplete.
 
@@ -1681,6 +1696,8 @@ def _main():
         goal_list=_operator_goals_list,
         goal_clear=_operator_goals_clear,
         chat_commands=_operator_chat_commands,
+        workflows_list=_operator_workflows_list,
+        workflows_run=_operator_workflow_run,
     )
 
     # --- Scheduler lifecycle ------------------------------------------------


### PR DESCRIPTION
## What

Surfaces the declarative workflow recipes (ADR 0002) in the React operator console — the last slice of the workflows initiative. You can now list registered recipes, see the selected recipe's step DAG + inputs, and run one from a form, without going through the chat agent.

## Backend

- `run_manual_workflow()` (`graph/agent.py`) runs a saved recipe outside the lead agent's `run_workflow` tool: validates the recipe, resolves inputs, and delegates each step to `run_manual_subagent` via the existing `execute_workflow` engine (same DAG / parallelism / inline-failure semantics).
- `GET /api/workflows` and `POST /api/workflows/{name}/run` operator routes + `WorkflowRunRequest`; `server.py` closures wired to the live `WorkflowRegistry`.

## Frontend

- New **Workflows** rail surface (`WorkflowsSurface`): recipe picker, step DAG view, inputs form with required-field gating + defaults, and a result panel showing the final output, a collapsible per-step breakdown, and any failed steps.
- `WorkflowSummary` / `WorkflowRunResult` types, `api.workflows()` / `api.runWorkflow()`, theme styles.

## Tests / docs

- `e2e/workflows.spec.ts` (list + step DAG, required-input gating, run → result) with mock routes + fixtures.
- Full web e2e green (**26 passed**); Python suite green (**742 passed**); docs build clean.
- Verified live against the running backend: `GET /api/workflows` lists recipes; `POST /api/workflows/op-smoke/run` executed the subagent and threaded its output (`failed: []`).
- `docs/guides/workflows.md`: new operator-console section.

🤖 Generated with [Claude Code](https://claude.com/claude-code)