### PR TITLE
Server→client event bus + /api/events SSE (ADR 0003 slice 1)

### DIFF
--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -13,7 +13,7 @@ async function send(page, prompt: string) {
 }
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.goto("/app/", { waitUntil: "load" });
   // Setup wizard must not block — the mock reports setup_complete:true.
   await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
 });

--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -6,7 +6,7 @@ import { SLASH_COMMANDS } from "./fixtures.mjs";
 // (GET /api/chat/commands) and autocompletes them as you type "/name".
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.goto("/app/", { waitUntil: "load" });
   await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
 });
 

--- a/apps/web/e2e/copy.spec.ts
+++ b/apps/web/e2e/copy.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 test.use({ permissions: ["clipboard-read", "clipboard-write"] });
 
 test("copy button writes the raw value to the clipboard", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.goto("/app/", { waitUntil: "load" });
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.waitFor({ state: "visible" });
   await composer.fill("CALC compute it");

--- a/apps/web/e2e/events.spec.ts
+++ b/apps/web/e2e/events.spec.ts
@@ -1,0 +1,12 @@
+import { expect, test } from "@playwright/test";
+
+// The console opens a server→client SSE channel (GET /api/events, ADR 0003) for
+// the app's lifetime. The topbar "live" indicator reflects the connection.
+
+test("live indicator turns connected when the event stream opens", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const dot = page.getByTestId("live-indicator");
+  await expect(dot).toBeVisible();
+  // EventSource onopen flips it live shortly after the response headers arrive.
+  await expect(dot).toHaveAttribute("data-live", "true");
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -149,6 +149,22 @@ const server = createServer(async (req, res) => {
   if (pathname === "/a2a" && req.method === "POST") {
     return handleA2AStream(req, res, await readBody(req));
   }
+  if (pathname === "/api/events" && req.method === "GET") {
+    // Server→client SSE push channel (ADR 0003). Hold the connection open so
+    // the client's EventSource fires onopen (the "live" indicator), then push
+    // one named event to exercise event delivery.
+    res.writeHead(200, {
+      "content-type": "text/event-stream",
+      "cache-control": "no-cache",
+      connection: "keep-alive",
+    });
+    res.write(": connected\n\n");
+    const t = setTimeout(() => {
+      res.write('event: activity.message\ndata: {"text":"hello from mock"}\n\n');
+    }, 50);
+    req.on("close", () => clearTimeout(t));
+    return;
+  }
   if (pathname.startsWith("/api/")) {
     if (req.method === "GET") {
       const payload = handleApiGet(pathname);

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 // particular reads the skills / MCP / plugins blocks.
 
 test.beforeEach(async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.goto("/app/", { waitUntil: "load" });
   await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
 });
 

--- a/apps/web/e2e/nesting.spec.ts
+++ b/apps/web/e2e/nesting.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 // list. (A tool that starts while a `task` is still running is its child.)
 
 test("subagent child tools nest under the task card", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.goto("/app/", { waitUntil: "load" });
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.waitFor({ state: "visible" });
   await composer.fill("SUBAGENT delegate this");

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 // need a process restart.
 
 async function openSettings(page) {
-  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
 }

--- a/apps/web/e2e/streaming.spec.ts
+++ b/apps/web/e2e/streaming.spec.ts
@@ -6,7 +6,7 @@ import { expect, test } from "@playwright/test";
 // replace).
 
 test("assistant answer streams in and reconciles to the final text", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.goto("/app/", { waitUntil: "load" });
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.waitFor({ state: "visible" });
   await composer.fill("STREAM the answer");

--- a/apps/web/e2e/tool-renderers.spec.ts
+++ b/apps/web/e2e/tool-renderers.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 // from the prompt keyword (see e2e/fixtures.mjs).
 
 async function run(page, prompt: string) {
-  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.goto("/app/", { waitUntil: "load" });
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.waitFor({ state: "visible" });
   await composer.fill(prompt);

--- a/apps/web/e2e/workflows.spec.ts
+++ b/apps/web/e2e/workflows.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 // POST /api/workflows/{name}/run — rendering the output + per-step results.
 
 async function openWorkflows(page) {
-  await page.goto("/app/", { waitUntil: "networkidle" });
+  await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Workflows", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Workflows" })).toBeVisible();
 }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -30,6 +30,7 @@ import { ChatSurface } from "../chat/ChatSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
+import { onConnectionChange } from "../lib/events";
 import type { BeadsIssue, GoalState, NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
 import { ScrollArea } from "./ScrollArea";
 import { SetupWizard } from "../setup/SetupWizard";
@@ -212,6 +213,7 @@ function groupIssues(issues: BeadsIssue[]) {
 export function App() {
   const [surface, setSurface] = useState<Surface>("chat");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
+  const [live, setLive] = useState(false);
   const [projectPath, setProjectPath] = useLocalStorageState("protoagent.projectPath", "");
   const [runtime, setRuntime] = useState<RuntimeStatus | null>(null);
   const [subagents, setSubagents] = useState<Subagent[]>([]);
@@ -419,6 +421,10 @@ export function App() {
     if (surface === "schedule") void refreshSchedules();
     if (surface === "goals") void refreshGoals();
   }, [surface]);
+
+  // Open the server→client event stream (ADR 0003) and track its connection
+  // state for the "live" indicator. Surfaces subscribe to named events.
+  useEffect(() => onConnectionChange(setLive), []);
 
   async function runSubagent() {
     const prompt = subagentPrompt.trim();
@@ -737,6 +743,14 @@ export function App() {
             tone={statusTone(runtime?.graph_loaded)}
           />
           <StatusPill label={status} tone={status === "error" ? "error" : "muted"} />
+          <span
+            className={`live-dot ${live ? "is-live" : ""}`}
+            role="status"
+            aria-label={live ? "event stream connected" : "event stream offline"}
+            title={live ? "Live — event stream connected" : "Event stream offline"}
+            data-testid="live-indicator"
+            data-live={live ? "true" : "false"}
+          />
           <button className="icon-button" type="button" onClick={() => void refreshAll()} title="Refresh">
             <RefreshCw size={16} />
           </button>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1139,6 +1139,21 @@ textarea {
   white-space: pre-wrap;
 }
 
+/* Live event-stream indicator (ADR 0003) ------------------------------------ */
+.live-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fg-tertiary, #555);
+  flex: none;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.live-dot.is-live {
+  background: var(--success, #3fb950);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--success, #3fb950) 25%, transparent);
+}
+
 /* Workflows surface --------------------------------------------------------- */
 .workflow-desc {
   margin: 0 12px;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -71,7 +71,7 @@ function defaultApiBase() {
   return "";
 }
 
-function apiUrl(path: string) {
+export function apiUrl(path: string) {
   if (/^https?:\/\//.test(path)) return path;
   const base = defaultApiBase();
   return base ? `${base}${path.startsWith("/") ? path : `/${path}`}` : path;

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,0 +1,70 @@
+import { apiUrl } from "./api";
+
+// Client for the server→client SSE push channel (ADR 0003). One EventSource is
+// shared across the app for its lifetime; surfaces register handlers per event
+// name. EventSource reconnects automatically on transient drops; we just track
+// the connection state for the "live" indicator.
+
+type Listener = (data: Record<string, unknown>) => void;
+
+const listeners = new Map<string, Set<Listener>>();
+const connListeners = new Set<(connected: boolean) => void>();
+let source: EventSource | null = null;
+let connected = false;
+
+function setConnected(next: boolean) {
+  if (connected === next) return;
+  connected = next;
+  connListeners.forEach((fn) => fn(connected));
+}
+
+function attach(name: string) {
+  // Lazily bind an EventSource listener the first time a name is subscribed.
+  source?.addEventListener(name, (event) => {
+    let data: Record<string, unknown> = {};
+    try {
+      data = JSON.parse((event as MessageEvent).data || "{}");
+    } catch {
+      data = {};
+    }
+    listeners.get(name)?.forEach((fn) => fn(data));
+  });
+}
+
+function ensureOpen() {
+  if (source || typeof EventSource === "undefined") return;
+  source = new EventSource(apiUrl("/api/events"));
+  source.onopen = () => setConnected(true);
+  source.onerror = () => setConnected(false); // EventSource auto-reconnects
+  // Re-bind any names registered before the source existed.
+  for (const name of listeners.keys()) attach(name);
+}
+
+/** Subscribe to a named server event. Returns an unsubscribe function. */
+export function onServerEvent(name: string, fn: Listener): () => void {
+  ensureOpen();
+  let set = listeners.get(name);
+  if (!set) {
+    set = new Set();
+    listeners.set(name, set);
+    attach(name);
+  }
+  set.add(fn);
+  return () => {
+    set?.delete(fn);
+  };
+}
+
+/** Observe connection state. Returns an unsubscribe function. */
+export function onConnectionChange(fn: (connected: boolean) => void): () => void {
+  ensureOpen();
+  connListeners.add(fn);
+  fn(connected);
+  return () => {
+    connListeners.delete(fn);
+  };
+}
+
+export function isConnected(): boolean {
+  return connected;
+}

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -148,6 +148,20 @@ Add these before the React UI depends on them:
 | `GET/POST /api/scheduler/jobs`, `DELETE /api/scheduler/jobs/{id}` | list/create/cancel scheduled jobs over the active `SchedulerBackend` |
 | `GET /api/goals`, `DELETE /api/goals/{session_id}` | list goals across sessions / clear one (goals are *set* in chat via `/goal`) |
 | `GET /api/chat/commands` | registered slash commands (`{name, description, usage}`) for the composer's `/` autocomplete |
+| `GET /api/events` | **server→client SSE push channel** (ADR 0003). Holds open for the app's lifetime; the server pushes unsolicited events (`activity.message`, `inbox.item`) the request-scoped chat stream can't. Read-only. |
+
+### Event stream (push channel)
+
+The console opens one `EventSource` to `GET /api/events` for the app's lifetime
+(`lib/events.ts` — `onServerEvent(name, fn)` / `onConnectionChange(fn)`), backed
+server-side by an in-process `EventBus` (`events/bus.py`, bounded drop-oldest
+queues). The topbar **live dot** reflects the connection. This is the foundation
+for the reactive surfaces in ADR 0003 (the Activity thread, the inbox); producers
+call `bus.publish(event, data)` from the event loop and every connected console
+receives it. Frames are SSE `event:`/`data:` with periodic `: keepalive` comments.
+
+> **Playwright note:** a long-lived SSE connection never lets `networkidle`
+> settle — navigate with `waitUntil: "load"` in e2e, not `"networkidle"`.
 
 Manual subagents should reuse the existing `_run_subagent` implementation, but
 expose it through a service function instead of calling the lead agent's tool.

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -1,0 +1,5 @@
+"""In-process server→client event bus (ADR 0003)."""
+
+from events.bus import EventBus
+
+__all__ = ["EventBus"]

--- a/events/bus.py
+++ b/events/bus.py
@@ -1,0 +1,54 @@
+"""An in-process publish/subscribe event bus (ADR 0003).
+
+The bus is the foundational "server speaks unprompted" primitive: any component
+running on the event loop can ``publish`` an event, and every connected console
+(subscribed via the ``GET /api/events`` SSE route) receives it. It is read-only
+server→client — subscribers never push back through it.
+
+Each subscriber gets its own bounded queue. On overflow the bus drops the
+*oldest* event for that subscriber and enqueues the newest, so one slow console
+can never apply backpressure to a producer (or to the other subscribers).
+
+``publish`` is synchronous and must be called from the event-loop thread (every
+producer — the A2A terminal hook, the scheduler, the inbox — already runs there).
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any
+
+
+class EventBus:
+    def __init__(self, *, max_queue: int = 256) -> None:
+        self._subscribers: set[asyncio.Queue[dict[str, Any]]] = set()
+        self._max_queue = max_queue
+
+    def publish(self, event: str, data: dict[str, Any] | None = None) -> None:
+        """Fan an event out to every current subscriber (drop-oldest on overflow)."""
+        payload = {"event": event, "data": data or {}}
+        for q in list(self._subscribers):
+            if q.full():
+                # Drop the oldest queued event to make room for the newest.
+                try:
+                    q.get_nowait()
+                except asyncio.QueueEmpty:
+                    pass
+            try:
+                q.put_nowait(payload)
+            except asyncio.QueueFull:  # pragma: no cover - racing producers
+                pass
+
+    async def subscribe(self) -> AsyncIterator[dict[str, Any]]:
+        """Yield events until the consumer stops (e.g. the SSE connection closes)."""
+        q: asyncio.Queue[dict[str, Any]] = asyncio.Queue(maxsize=self._max_queue)
+        self._subscribers.add(q)
+        try:
+            while True:
+                yield await q.get()
+        finally:
+            self._subscribers.discard(q)
+
+    def subscriber_count(self) -> int:
+        return len(self._subscribers)

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import asyncio
-from collections.abc import Awaitable, Callable
+import json
+from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any
 
 from fastapi import HTTPException
+from fastapi.responses import StreamingResponse
 from pydantic import BaseModel
 
 from operator_api.beads import BeadsCommandError, BeadsService
@@ -70,6 +72,33 @@ class BeadsCloseRequest(BaseModel):
     reason: str | None = None
 
 
+async def _sse_event_stream(
+    subscribe: Callable[[], AsyncIterator[dict[str, Any]]],
+    *,
+    keepalive_s: float = 15.0,
+) -> AsyncIterator[str]:
+    """Frame bus events as SSE text for the ``/api/events`` response.
+
+    Emits a ``: connected`` comment up front (so the client's ``onopen`` fires),
+    then one ``event:``/``data:`` frame per published event, with periodic
+    ``: keepalive`` comments to hold the connection open through idle stretches.
+    """
+    yield ": connected\n\n"
+    agen = subscribe()
+    try:
+        while True:
+            try:
+                evt = await asyncio.wait_for(agen.__anext__(), timeout=keepalive_s)
+            except asyncio.TimeoutError:
+                yield ": keepalive\n\n"
+                continue
+            except StopAsyncIteration:
+                break
+            yield f"event: {evt['event']}\ndata: {json.dumps(evt['data'])}\n\n"
+    finally:
+        await agen.aclose()
+
+
 def _http_error(exc: Exception) -> HTTPException:
     if isinstance(exc, ValueError):
         return HTTPException(status_code=400, detail=str(exc))
@@ -104,6 +133,7 @@ def register_operator_routes(
     chat_commands: Callable[[], dict[str, Any]] | None = None,
     workflows_list: Callable[[], dict[str, Any]] | None = None,
     workflows_run: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+    events_subscribe: Callable[[], AsyncIterator[dict[str, Any]]] | None = None,
 ) -> None:
     """Register React operator-console routes on a FastAPI app.
 
@@ -293,3 +323,15 @@ def register_operator_routes(
                 return await workflows_run(name, req.inputs)
             except Exception as exc:
                 raise _http_error(exc) from exc
+
+    # --- Event stream --------------------------------------------------------
+    # Server→client SSE push channel (ADR 0003). The console keeps one of these
+    # open for the app's lifetime; the server pushes unsolicited events
+    # (activity messages, inbox items) the request-scoped chat stream can't.
+    if events_subscribe is not None:
+
+        @app.get("/api/events")
+        async def _events():
+            return StreamingResponse(
+                _sse_event_stream(events_subscribe), media_type="text/event-stream"
+            )

--- a/server.py
+++ b/server.py
@@ -33,6 +33,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
+from events import EventBus
 from graph.output_format import (
     DROPPED_SCRATCH_KICKER,
     extract_confidence,
@@ -87,6 +88,10 @@ _cache_warmer = None   # Optional CacheWarmer (off by default). Same start/stop
                        # lifecycle as _scheduler; keeps the prompt cache warm.
 _goal_controller = None  # Optional GoalController (goal mode). Parses /goal
                          # control messages and runs the goal-completion loop.
+
+_event_bus = EventBus()  # Server→client SSE push channel (ADR 0003). Process-
+                         # lifetime singleton; producers publish, /api/events
+                         # streams to connected consoles.
 
 
 def _init_langgraph_agent():
@@ -1698,6 +1703,7 @@ def _main():
         chat_commands=_operator_chat_commands,
         workflows_list=_operator_workflows_list,
         workflows_run=_operator_workflow_run,
+        events_subscribe=_event_bus.subscribe,
     )
 
     # --- Scheduler lifecycle ------------------------------------------------

--- a/tests/test_event_bus.py
+++ b/tests/test_event_bus.py
@@ -1,0 +1,118 @@
+"""Tests for the in-process event bus + /api/events SSE route (ADR 0003)."""
+
+from __future__ import annotations
+
+import asyncio
+
+from events.bus import EventBus
+
+
+def test_publish_fans_out_to_all_subscribers():
+    async def run():
+        bus = EventBus()
+        a = bus.subscribe()
+        b = bus.subscribe()
+        # Prime both subscriptions (registers their queues).
+        ta = asyncio.ensure_future(a.__anext__())
+        tb = asyncio.ensure_future(b.__anext__())
+        await asyncio.sleep(0)  # let the generators register
+        bus.publish("hello", {"n": 1})
+        ra, rb = await asyncio.wait_for(asyncio.gather(ta, tb), timeout=1)
+        await a.aclose()
+        await b.aclose()
+        return ra, rb
+
+    ra, rb = asyncio.run(run())
+    assert ra == {"event": "hello", "data": {"n": 1}}
+    assert rb == {"event": "hello", "data": {"n": 1}}
+
+
+def test_publish_defaults_empty_data():
+    async def run():
+        bus = EventBus()
+        sub = bus.subscribe()
+        t = asyncio.ensure_future(sub.__anext__())
+        await asyncio.sleep(0)
+        bus.publish("ping")
+        evt = await asyncio.wait_for(t, timeout=1)
+        await sub.aclose()
+        return evt
+
+    assert asyncio.run(run()) == {"event": "ping", "data": {}}
+
+
+def test_drop_oldest_on_overflow():
+    async def run():
+        bus = EventBus(max_queue=2)
+        sub = bus.subscribe()
+        # Register the queue without draining it.
+        t = asyncio.ensure_future(sub.__anext__())
+        await asyncio.sleep(0)
+        # First event satisfies the pending __anext__ immediately.
+        bus.publish("e", {"i": 0})
+        first = await asyncio.wait_for(t, timeout=1)
+        # Now fill the queue (cap 2) and overflow it.
+        for i in range(1, 5):
+            bus.publish("e", {"i": i})
+        drained = []
+        for _ in range(2):
+            drained.append(await asyncio.wait_for(sub.__anext__(), timeout=1))
+        await sub.aclose()
+        return first, drained
+
+    first, drained = asyncio.run(run())
+    assert first == {"event": "e", "data": {"i": 0}}
+    # Oldest (i=1, i=2) were dropped; newest two survive.
+    assert [d["data"]["i"] for d in drained] == [3, 4]
+
+
+def test_unsubscribe_on_close():
+    async def run():
+        bus = EventBus()
+        sub = bus.subscribe()
+        t = asyncio.ensure_future(sub.__anext__())
+        await asyncio.sleep(0)
+        assert bus.subscriber_count() == 1
+        bus.publish("x")
+        await asyncio.wait_for(t, timeout=1)
+        await sub.aclose()
+        return bus.subscriber_count()
+
+    assert asyncio.run(run()) == 0
+
+
+def test_sse_event_stream_preamble_and_frame():
+    """The SSE framing helper emits the preamble then one frame per event."""
+    from operator_api.routes import _sse_event_stream
+
+    async def run():
+        bus = EventBus()
+        gen = _sse_event_stream(bus.subscribe, keepalive_s=5)
+        preamble = await gen.__anext__()  # ": connected\n\n"
+        # The next pull subscribes to the bus and blocks on q.get(); drive it on
+        # a task so we can publish once it has registered.
+        pull = asyncio.ensure_future(gen.__anext__())
+        await asyncio.sleep(0.05)  # let the generator subscribe
+        bus.publish("activity.message", {"text": "hi"})
+        frame = await asyncio.wait_for(pull, timeout=2)
+        await gen.aclose()
+        return preamble, frame
+
+    preamble, frame = asyncio.run(run())
+    assert preamble == ": connected\n\n"
+    assert frame == 'event: activity.message\ndata: {"text": "hi"}\n\n'
+
+
+def test_sse_event_stream_emits_keepalive_when_idle():
+    """With no events, the stream emits keepalive comments (holds the conn)."""
+    from operator_api.routes import _sse_event_stream
+
+    async def run():
+        bus = EventBus()
+        gen = _sse_event_stream(bus.subscribe, keepalive_s=0.05)
+        await gen.__anext__()  # preamble
+        ka = await asyncio.wait_for(gen.__anext__(), timeout=2)  # idle → keepalive
+        await gen.aclose()
+        return ka
+
+    assert asyncio.run(run()) == ": keepalive\n\n"


### PR DESCRIPTION
## What

The foundational **push channel** for the reactive surfaces (ADR 0003 slice 1): the server can now speak unprompted. Today all streaming is request-scoped — the console opens an SSE stream *in response to a user turn* and closes it when the turn ends, so the server has no way to push an unsolicited message (a scheduled-job result, an inbox item). This adds that channel.

## Backend

- **`events/bus.py`** — an in-process `EventBus`: `publish(event, data)` fans out to every subscriber's **bounded, drop-oldest** queue, so one slow console can never backpressure a producer or the other subscribers. Process-lifetime singleton in `server.py`.
- **`GET /api/events`** — SSE route streaming published events: `: connected` preamble (fires the client's `onopen`), `event:`/`data:` frames, `: keepalive` comments when idle. Framing extracted to `_sse_event_stream()` for testability.

## Frontend

- **`lib/events.ts`** — one shared `EventSource` for the app's lifetime; `onServerEvent(name, fn)` / `onConnectionChange(fn)`.
- A topbar **live dot** reflecting the connection state.

## Tests / docs

- `tests/test_event_bus.py` — fan-out, default data, drop-oldest overflow, unsubscribe-on-close, SSE framing + keepalive.
- `e2e/events.spec.ts` — the live indicator turns connected when the stream opens (mock `/api/events`).
- **748 pytest + 27 e2e green**; web + docs build clean. Live-verified `/api/events` streams `: connected` and holds open.
- Docs: `react-tauri-ui` event-stream section.

### Heads-up: networkidle → load

A long-lived SSE connection never lets Playwright's `networkidle` settle (the held-open request counts as in-flight), which hung the suite. All e2e navigations switch to `waitUntil: "load"` (Playwright discourages `networkidle` anyway). Mechanical change across the existing specs.

Slice 2 (Activity thread) and slice 3 (inbox) build on this bus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)