### PR TITLE
Durable Activity thread + console surface (ADR 0003 slice 2)

### DIFF
--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -797,6 +797,23 @@ async def _deliver_webhook(record: TaskRecord, push_config: PushNotificationConf
 _pending_webhook_tasks: set[asyncio.Task] = set()
 
 
+# Optional terminal hook (ADR 0003). Set via register_a2a_routes; invoked with
+# the terminal TaskRecord when a turn completes, so a host can surface
+# agent-initiated output (e.g. publish to the event bus for the Activity thread).
+_ON_TERMINAL: list[Callable[["TaskRecord"], None] | None] = [None]
+
+
+def _notify_terminal(record: TaskRecord) -> None:
+    """Best-effort fire the host's terminal hook. Never raises into the runner."""
+    cb = _ON_TERMINAL[0]
+    if cb is None:
+        return
+    try:
+        cb(record)
+    except Exception:  # noqa: BLE001
+        logger.exception("[a2a] terminal hook failed for task %s", record.id)
+
+
 async def _push(record: TaskRecord) -> None:
     """Fire webhook delivery for *record* if a push config is currently
     registered on it.
@@ -900,6 +917,7 @@ async def _run_task_background(
                     accumulated_text=payload or accumulated,
                 )
                 await _push(record)
+                _notify_terminal(record)
                 return
 
             elif event_type == "error":
@@ -1054,6 +1072,7 @@ def register_a2a_routes(
     agent_card: dict,
     register_card_route: bool = True,
     auth_token: str = "",
+    on_terminal: Callable[["TaskRecord"], None] | None = None,
 ) -> None:
     """Register all A2A routes on *app* and update *agent_card* capabilities.
 
@@ -1070,6 +1089,8 @@ def register_a2a_routes(
     # ── Bearer token authentication ───────────────────────────────────────────
     # Seed order: explicit arg > env. Stored in the module-level holder
     # so mutations propagate to the closure below.
+    _ON_TERMINAL[0] = on_terminal
+
     seed = (auth_token or os.environ.get("A2A_AUTH_TOKEN", "") or "").strip()
     _A2A_TOKEN[0] = seed or None
     if _A2A_TOKEN[0] is None:

--- a/apps/web/e2e/activity.spec.ts
+++ b/apps/web/e2e/activity.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+
+// The Activity surface (ADR 0003): the durable thread where agent-initiated
+// turns land. Loads history from GET /api/activity, shows an unread badge while
+// off-surface, and appends pushed `activity.message` events live.
+
+test("unread badge counts pushed messages; surface shows history + live append", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // Pushed activity messages arrive while we're on Chat → the rail badge shows.
+  await expect(page.getByTestId("activity-badge")).toBeVisible();
+
+  await page.getByRole("button", { name: "Activity", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Activity" })).toBeVisible();
+
+  // History from GET /api/activity renders.
+  await expect(page.getByText("morning standup")).toBeVisible();
+  await expect(page.getByText("3 PRs merged overnight, CI green.")).toBeVisible();
+
+  // Opening the surface clears the badge.
+  await expect(page.getByTestId("activity-badge")).toHaveCount(0);
+
+  // A pushed event appends live while the surface is open.
+  await expect(page.getByText("live activity ping").first()).toBeVisible();
+});
+
+test("replying optimistically appends the operator's message", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Activity", exact: true }).click();
+
+  await page.locator(".activity-composer textarea").fill("ping from operator");
+  await page.getByRole("button", { name: "Send", exact: true }).click();
+  await expect(page.getByText("ping from operator")).toBeVisible();
+});

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -51,6 +51,14 @@ export const SUBAGENTS = [
   },
 ];
 
+export const ACTIVITY_HISTORY = {
+  context_id: "system:activity",
+  messages: [
+    { role: "user", content: "morning standup" },
+    { role: "assistant", content: "3 PRs merged overnight, CI green." },
+  ],
+};
+
 export const WORKFLOWS = [
   {
     name: "research-and-brief",

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -14,6 +14,7 @@ import { extname, join, normalize } from "node:path";
 import { fileURLToPath } from "node:url";
 
 import {
+  ACTIVITY_HISTORY,
   buildFrames,
   GOALS,
   NOTES_WORKSPACE,
@@ -84,6 +85,8 @@ function handleApiGet(pathname) {
       return { groups: SETTINGS_SCHEMA };
     case "/api/workflows":
       return { workflows: WORKFLOWS };
+    case "/api/activity":
+      return ACTIVITY_HISTORY;
     default:
       return null;
   }
@@ -159,10 +162,12 @@ const server = createServer(async (req, res) => {
       connection: "keep-alive",
     });
     res.write(": connected\n\n");
-    const t = setTimeout(() => {
-      res.write('event: activity.message\ndata: {"text":"hello from mock"}\n\n');
-    }, 50);
-    req.on("close", () => clearTimeout(t));
+    // Push an activity.message periodically so both the unread badge (while off
+    // the surface) and live append (while on it) are deterministically testable.
+    const t = setInterval(() => {
+      res.write('event: activity.message\ndata: {"text":"live activity ping"}\n\n');
+    }, 500);
+    req.on("close", () => clearInterval(t));
     return;
   }
   if (pathname.startsWith("/api/")) {

--- a/apps/web/src/activity/ActivitySurface.tsx
+++ b/apps/web/src/activity/ActivitySurface.tsx
@@ -1,0 +1,128 @@
+import { Loader2, RefreshCw, Send } from "lucide-react";
+import { useEffect, useRef, useState } from "react";
+
+import { Markdown } from "../chat/LazyMarkdown";
+import { api } from "../lib/api";
+import { onServerEvent } from "../lib/events";
+import type { ActivityMessage } from "../lib/types";
+
+// The durable Activity thread (ADR 0003): where agent-initiated turns
+// (scheduled fires, inbox items) land. Loads history from GET /api/activity,
+// appends live via the `activity.message` push event, and lets the operator
+// reply — a normal turn into the `system:activity` context. We don't render the
+// reply's stream; the assistant's response arrives uniformly via the bus event,
+// the same path a scheduled fire takes, so there's no double-render.
+
+export function ActivitySurface({ onError }: { onError: (message: string) => void }) {
+  const [messages, setMessages] = useState<ActivityMessage[]>([]);
+  const [contextId, setContextId] = useState("system:activity");
+  const [draft, setDraft] = useState("");
+  const [sending, setSending] = useState(false);
+  const [loading, setLoading] = useState(true);
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const r = await api.activity();
+      setContextId(r.context_id);
+      setMessages(r.messages);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+  useEffect(() => {
+    void load();
+  }, []);
+
+  // Live append: every completed Activity turn (scheduled fire, inbox item, or
+  // our own reply) pushes an `activity.message` event with the assistant text.
+  useEffect(
+    () =>
+      onServerEvent("activity.message", (data) => {
+        const text = typeof data.text === "string" ? data.text : "";
+        if (text) setMessages((prev) => [...prev, { role: "assistant", content: text }]);
+      }),
+    [],
+  );
+
+  // Keep the latest message in view.
+  useEffect(() => {
+    scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
+  }, [messages]);
+
+  async function send() {
+    const text = draft.trim();
+    if (!text || sending) return;
+    setSending(true);
+    setDraft("");
+    setMessages((prev) => [...prev, { role: "user", content: text }]);
+    try {
+      // Fire the turn into the Activity context; the reply arrives via the bus.
+      await api.streamChat(text, contextId, {});
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSending(false);
+    }
+  }
+
+  return (
+    <section className="panel stage-panel">
+      <div className="panel-header">
+        <div>
+          <h1>Activity</h1>
+          <p className="panel-kicker">scheduled fires &amp; agent-initiated messages</p>
+        </div>
+        <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
+          {loading ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
+        </button>
+      </div>
+
+      <div className="stage-body activity-body">
+        <div className="activity-log" ref={scrollRef}>
+          {messages.length === 0 && !loading ? (
+            <div className="activity-empty">
+              Nothing yet. Scheduled prompts and other agent-initiated messages land here.
+            </div>
+          ) : null}
+          {messages.map((m, i) => (
+            <div className={`activity-msg activity-${m.role}`} key={i}>
+              <span className="activity-role">{m.role === "user" ? "you" : "agent"}</span>
+              <div className="activity-content">
+                <Markdown>{m.content}</Markdown>
+              </div>
+            </div>
+          ))}
+        </div>
+
+        <form
+          className="activity-composer"
+          onSubmit={(e) => {
+            e.preventDefault();
+            void send();
+          }}
+        >
+          <textarea
+            value={draft}
+            onChange={(e) => setDraft(e.target.value)}
+            placeholder="Reply in the activity thread…"
+            rows={2}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey) {
+                e.preventDefault();
+                void send();
+              }
+            }}
+          />
+          <button className="primary-button" type="submit" disabled={sending || !draft.trim()}>
+            {sending ? <Loader2 className="spin" size={16} /> : <Send size={16} />}
+            Send
+          </button>
+        </form>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,4 +1,5 @@
 import {
+  Activity,
   Bot,
   Boxes,
   CalendarClock,
@@ -23,19 +24,20 @@ import {
   Trash2,
   Workflow,
 } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
+import { ActivitySurface } from "../activity/ActivitySurface";
 import { ChatSurface } from "../chat/ChatSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
-import { onConnectionChange } from "../lib/events";
+import { onConnectionChange, onServerEvent } from "../lib/events";
 import type { BeadsIssue, GoalState, NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
 import { ScrollArea } from "./ScrollArea";
 import { SetupWizard } from "../setup/SetupWizard";
 
-type Surface = "chat" | "subagents" | "workflows" | "runtime" | "schedule" | "goals" | "settings";
+type Surface = "chat" | "subagents" | "workflows" | "activity" | "runtime" | "schedule" | "goals" | "settings";
 type RightPanel = "notes" | "beads";
 type SubagentMode = "single" | "batch";
 type StatusTone = "success" | "warning" | "error" | "muted";
@@ -214,6 +216,7 @@ export function App() {
   const [surface, setSurface] = useState<Surface>("chat");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
   const [live, setLive] = useState(false);
+  const [activityUnread, setActivityUnread] = useState(0);
   const [projectPath, setProjectPath] = useLocalStorageState("protoagent.projectPath", "");
   const [runtime, setRuntime] = useState<RuntimeStatus | null>(null);
   const [subagents, setSubagents] = useState<Subagent[]>([]);
@@ -425,6 +428,21 @@ export function App() {
   // Open the server→client event stream (ADR 0003) and track its connection
   // state for the "live" indicator. Surfaces subscribe to named events.
   useEffect(() => onConnectionChange(setLive), []);
+
+  // Unread badge on the Activity rail: count agent-initiated messages that
+  // arrive while the operator isn't looking at the Activity surface.
+  const surfaceRef = useRef(surface);
+  surfaceRef.current = surface;
+  useEffect(
+    () =>
+      onServerEvent("activity.message", () => {
+        if (surfaceRef.current !== "activity") setActivityUnread((n) => n + 1);
+      }),
+    [],
+  );
+  useEffect(() => {
+    if (surface === "activity") setActivityUnread(0);
+  }, [surface]);
 
   async function runSubagent() {
     const prompt = subagentPrompt.trim();
@@ -778,6 +796,13 @@ export function App() {
             onClick={() => setSurface("workflows")}
           />
           <RailButton
+            active={surface === "activity"}
+            label="Activity"
+            icon={<Activity size={18} />}
+            onClick={() => setSurface("activity")}
+            badge={activityUnread}
+          />
+          <RailButton
             active={surface === "schedule"}
             label="Schedule"
             icon={<CalendarClock size={18} />}
@@ -931,6 +956,8 @@ export function App() {
           ) : null}
 
           {surface === "workflows" ? <WorkflowsSurface onError={setError} /> : null}
+
+          {surface === "activity" ? <ActivitySurface onError={setError} /> : null}
 
           {surface === "schedule" ? (
             <section className="panel stage-panel">
@@ -1481,16 +1508,23 @@ function RailButton({
   label,
   icon,
   onClick,
+  badge,
 }: {
   active: boolean;
   label: string;
   icon: ReactNode;
   onClick: () => void;
+  badge?: number;
 }) {
   return (
     <button className={active ? "active" : ""} type="button" onClick={onClick} title={label} aria-label={label}>
       {icon}
       <span>{label}</span>
+      {badge ? (
+        <span className="rail-badge" data-testid="activity-badge">
+          {badge > 9 ? "9+" : badge}
+        </span>
+      ) : null}
     </button>
   );
 }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1139,6 +1139,87 @@ textarea {
   white-space: pre-wrap;
 }
 
+/* Activity surface + rail badge (ADR 0003) ---------------------------------- */
+.rail-badge {
+  position: absolute;
+  top: 4px;
+  right: 6px;
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--accent, #7c8cff);
+  color: #fff;
+  font-size: 10px;
+  line-height: 16px;
+  text-align: center;
+  font-weight: 600;
+}
+
+.rail button {
+  position: relative;
+}
+
+.activity-body {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.activity-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.activity-empty {
+  color: var(--fg-secondary);
+  font-size: 13px;
+  margin: auto;
+  text-align: center;
+  max-width: 36ch;
+}
+
+.activity-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.activity-role {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-tertiary, var(--fg-secondary));
+}
+
+.activity-content {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  background: var(--bg-elevated, #111114);
+  font-size: 14px;
+}
+
+.activity-user .activity-content {
+  background: color-mix(in srgb, var(--accent, #7c8cff) 12%, transparent);
+}
+
+.activity-composer {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.activity-composer textarea {
+  flex: 1;
+  resize: none;
+}
+
 /* Live event-stream indicator (ADR 0003) ------------------------------------ */
 .live-dot {
   width: 8px;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  ActivityHistory,
   AgentConfig,
   BeadsIssue,
   ChatMessage,
@@ -261,6 +262,10 @@ export const api = {
 
   settingsSchema() {
     return request<{ groups: SettingsGroup[] }>("/api/settings/schema");
+  },
+
+  activity() {
+    return request<ActivityHistory>("/api/activity");
   },
 
   workflows() {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -97,6 +97,13 @@ export type WorkflowRunResult = {
   failed: string[];
 };
 
+export type ActivityMessage = { role: "user" | "assistant"; content: string };
+
+export type ActivityHistory = {
+  context_id: string;
+  messages: ActivityMessage[];
+};
+
 export type GoalState = {
   session_id: string;
   condition: string;

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -149,6 +149,7 @@ Add these before the React UI depends on them:
 | `GET /api/goals`, `DELETE /api/goals/{session_id}` | list goals across sessions / clear one (goals are *set* in chat via `/goal`) |
 | `GET /api/chat/commands` | registered slash commands (`{name, description, usage}`) for the composer's `/` autocomplete |
 | `GET /api/events` | **server→client SSE push channel** (ADR 0003). Holds open for the app's lifetime; the server pushes unsolicited events (`activity.message`, `inbox.item`) the request-scoped chat stream can't. Read-only. |
+| `GET /api/activity` | the durable **Activity thread**'s message history (ADR 0003) — `{context_id, messages:[{role, content}]}` read from the checkpointer (`a2a:system:activity`). Where agent-initiated turns (scheduled fires) land. |
 
 ### Event stream (push channel)
 
@@ -162,6 +163,17 @@ receives it. Frames are SSE `event:`/`data:` with periodic `: keepalive` comment
 
 > **Playwright note:** a long-lived SSE connection never lets `networkidle`
 > settle — navigate with `waitUntil: "load"` in e2e, not `"networkidle"`.
+
+### Activity surface
+
+The **Activity** rail surface (`activity/ActivitySurface.tsx`) is the console
+view of the durable Activity thread (ADR 0003). It loads history from
+`GET /api/activity`, appends live as `activity.message` events arrive, and lets
+the operator reply — a normal turn into the `system:activity` context. The
+operator's own message is appended optimistically; the assistant's reply arrives
+via the same `activity.message` event a scheduled fire produces, so there's one
+uniform render path and no double-render. A rail **unread badge** counts events
+that land while the operator is on another surface.
 
 Manual subagents should reuse the existing `_run_subagent` implementation, but
 expose it through a service function instead of calling the lead agent's tool.

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -112,14 +112,22 @@ The local scheduler runs an asyncio polling task on FastAPI's
 
 1. Read jobs where `next_fire <= now()` and `enabled = 1`.
 2. For each due job: POST to `http://127.0.0.1:<active_port>/a2a` as
-   a `message/send` with the job's prompt as the message text. Bearer
-   + X-API-Key are forwarded automatically.
+   a `message/send` with the job's prompt as the message text, routed
+   into the durable **Activity thread** (`contextId: system:activity`,
+   `metadata.origin: scheduler`). Bearer + X-API-Key are forwarded
+   automatically.
 3. One-shot ISO jobs are deleted after firing. Cron jobs reschedule
    forward via `croniter`.
 
 Going through HTTP rather than calling into the graph directly buys
 parity with real callers — the audit log, cost-v1 capture, and
 push-notification path all behave identically.
+
+**Where the response lands.** The fired turn runs in the Activity thread
+(ADR 0003), so its output persists and shows up live in the console's
+**Activity** surface (pushed over `/api/events` as an `activity.message`).
+Before ADR 0003 a fired prompt minted a throwaway context and its answer
+was evicted unseen.
 
 ### Missed-fire recovery
 

--- a/events/__init__.py
+++ b/events/__init__.py
@@ -2,4 +2,10 @@
 
 from events.bus import EventBus
 
-__all__ = ["EventBus"]
+# The single durable "Activity" thread (ADR 0003). Reactive producers (the
+# scheduler, the inbox) route their turns into this A2A context, which maps to
+# checkpointer thread ``a2a:system:activity`` — so the conversation persists and
+# can be opened/continued in the console's Activity surface.
+ACTIVITY_CONTEXT = "system:activity"
+
+__all__ = ["EventBus", "ACTIVITY_CONTEXT"]

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -134,6 +134,7 @@ def register_operator_routes(
     workflows_list: Callable[[], dict[str, Any]] | None = None,
     workflows_run: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
     events_subscribe: Callable[[], AsyncIterator[dict[str, Any]]] | None = None,
+    activity_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
 ) -> None:
     """Register React operator-console routes on a FastAPI app.
 
@@ -321,6 +322,19 @@ def register_operator_routes(
         async def _workflow_run(name: str, req: WorkflowRunRequest):
             try:
                 return await workflows_run(name, req.inputs)
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    # --- Activity thread -----------------------------------------------------
+    # The durable Activity thread's history (ADR 0003). Agent-initiated turns
+    # (scheduled fires, inbox items) land here; the console loads this when the
+    # Activity surface opens and appends live via the `activity.message` event.
+    if activity_list is not None:
+
+        @app.get("/api/activity")
+        async def _activity():
+            try:
+                return await activity_list()
             except Exception as exc:
                 raise _http_error(exc) from exc
 

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -38,6 +38,7 @@ from typing import Any
 
 from croniter import croniter
 
+from events import ACTIVITY_CONTEXT
 from scheduler.interface import Job, is_cron, parse_iso_to_utc
 
 log = logging.getLogger(__name__)
@@ -382,6 +383,11 @@ class LocalScheduler:
             "id": message_id,
             "method": "message/send",
             "params": {
+                # Route into the durable Activity thread (ADR 0003) so the
+                # fired turn lands somewhere visible/continuable instead of a
+                # throwaway context. Without this, a2a_handler mints a fresh
+                # context per fire and the response surfaces nowhere.
+                "contextId": ACTIVITY_CONTEXT,
                 "message": {
                     "role": "user",
                     "parts": [{"kind": "text", "text": job.prompt}],
@@ -394,6 +400,7 @@ class LocalScheduler:
                 "metadata": {
                     "scheduler_job_id": job.id,
                     "scheduler_kind": "local",
+                    "origin": "scheduler",
                 },
             },
         }

--- a/server.py
+++ b/server.py
@@ -33,7 +33,7 @@ import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
-from events import EventBus
+from events import ACTIVITY_CONTEXT, EventBus
 from graph.output_format import (
     DROPPED_SCRATCH_KICKER,
     extract_confidence,
@@ -1673,6 +1673,47 @@ def _main():
             name=name, inputs=inputs or {},
         )
 
+    def _publish_activity_terminal(record) -> None:
+        """Terminal hook (ADR 0003): when a turn in the Activity thread completes,
+        push the assistant's visible output to the event bus so connected
+        consoles append it live. No-op for every other context."""
+        if getattr(record, "context_id", "") != ACTIVITY_CONTEXT:
+            return
+        raw = getattr(record, "accumulated_text", "") or ""
+        text = extract_output(raw) or raw
+        if not text.strip():
+            return
+        _event_bus.publish(
+            "activity.message",
+            {"role": "assistant", "text": text, "context_id": ACTIVITY_CONTEXT},
+        )
+
+    async def _operator_activity_list() -> dict:
+        """Return the Activity thread's message history from the checkpointer
+        (ADR 0003). The console loads this when opening the Activity surface."""
+        messages: list[dict] = []
+        if _checkpointer is not None:
+            thread_id = f"a2a:{ACTIVITY_CONTEXT}"
+            try:
+                tup = await _checkpointer.aget_tuple({"configurable": {"thread_id": thread_id}})
+                raw = (tup.checkpoint or {}).get("channel_values", {}).get("messages", []) if tup else []
+            except Exception:
+                log.exception("[activity] failed to read thread %s", thread_id)
+                raw = []
+            for m in raw:
+                role = getattr(m, "type", "")
+                content = getattr(m, "content", "")
+                if not isinstance(content, str):
+                    content = str(content)
+                if role == "human":
+                    messages.append({"role": "user", "content": content})
+                elif role == "ai":
+                    visible = extract_output(content) or content
+                    if visible.strip():
+                        messages.append({"role": "assistant", "content": visible})
+                # tool/system messages are omitted from the surface view
+        return {"context_id": ACTIVITY_CONTEXT, "messages": messages}
+
     def _operator_chat_commands() -> dict:
         """Slash commands the chat understands — drives the composer autocomplete.
 
@@ -1704,6 +1745,7 @@ def _main():
         workflows_list=_operator_workflows_list,
         workflows_run=_operator_workflow_run,
         events_subscribe=_event_bus.subscribe,
+        activity_list=_operator_activity_list,
     )
 
     # --- Scheduler lifecycle ------------------------------------------------
@@ -1979,6 +2021,7 @@ def _main():
         auth_token=yaml_bearer,
         agent_card={},
         register_card_route=False,  # card is already served above
+        on_terminal=_publish_activity_terminal,  # ADR 0003: surface Activity turns
     )
 
     # --- Prometheus metrics -------------------------------------------------

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -1,0 +1,79 @@
+"""Tests for the Activity thread wiring (ADR 0003 slice 2)."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import a2a_handler
+from operator_api.routes import register_operator_routes
+
+
+def test_notify_terminal_invokes_hook_and_is_exception_safe():
+    record = SimpleNamespace(id="t1", context_id="system:activity", accumulated_text="hi")
+    seen = []
+    prior = a2a_handler._ON_TERMINAL[0]
+    try:
+        a2a_handler._ON_TERMINAL[0] = seen.append
+        a2a_handler._notify_terminal(record)
+        assert seen == [record]
+
+        # A throwing hook must not propagate into the background runner.
+        def boom(_):
+            raise RuntimeError("nope")
+
+        a2a_handler._ON_TERMINAL[0] = boom
+        a2a_handler._notify_terminal(record)  # no raise
+
+        # No hook registered → no-op.
+        a2a_handler._ON_TERMINAL[0] = None
+        a2a_handler._notify_terminal(record)
+    finally:
+        a2a_handler._ON_TERMINAL[0] = prior
+
+
+def test_activity_route_returns_history():
+    async def activity_list():
+        return {
+            "context_id": "system:activity",
+            "messages": [
+                {"role": "user", "content": "morning standup"},
+                {"role": "assistant", "content": "3 PRs merged overnight."},
+            ],
+        }
+
+    app = FastAPI()
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=_unused,
+        subagent_batch=_unused,
+        activity_list=activity_list,
+    )
+    client = TestClient(app)
+    resp = client.get("/api/activity")
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["context_id"] == "system:activity"
+    assert [m["role"] for m in body["messages"]] == ["user", "assistant"]
+
+
+def test_activity_route_absent_without_callback():
+    """No activity_list wired → route isn't registered (404)."""
+    app = FastAPI()
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=_unused,
+        subagent_batch=_unused,
+    )
+    client = TestClient(app)
+    assert client.get("/api/activity").status_code == 404
+
+
+async def _unused(*_a, **_k):  # pragma: no cover - placeholder callable
+    return ""

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -290,6 +290,13 @@ async def test_due_job_fires(tmp_path, monkeypatch):
     # One-shot was deleted after firing
     assert s.list_jobs() == []
 
+    # Fires route into the durable Activity thread (ADR 0003) so the response
+    # surfaces, with an origin tag for the activity surface.
+    call = next(c for c in fired if "FIRED-ME" in str(c["json"]))
+    params = call["json"]["params"]
+    assert params["contextId"] == "system:activity"
+    assert params["metadata"]["origin"] == "scheduler"
+
 
 @pytest.mark.asyncio
 async def test_fire_failure_leaves_job_in_place(tmp_path, monkeypatch):


### PR DESCRIPTION
## What

Scheduled prompts (and any agent-initiated turn) now land in a single **durable Activity thread** with a console surface to read and continue them — closing the gap where a fired job's response evaporated. Builds on the slice-1 event bus.

## Backend

- **`ACTIVITY_CONTEXT = "system:activity"`** (`events/__init__.py`) — maps to checkpointer thread `a2a:system:activity`, so the conversation persists for free.
- **`scheduler/local.py`** — fires route into the Activity context (`contextId`) tagged `metadata.origin=scheduler`, instead of letting the handler mint a throwaway context.
- **`a2a_handler.py`** — an optional `on_terminal` hook (set via `register_a2a_routes`), invoked when a turn completes; exception-safe so it never breaks the runner.
- **`server.py`** — `_publish_activity_terminal` pushes the assistant's visible output to the bus as `activity.message` for Activity-context turns; **`GET /api/activity`** reads the thread's history from the checkpointer.

## Frontend

- **`ActivitySurface`** — loads history, live-appends `activity.message` events, and a reply box. The operator's own reply is appended optimistically; the assistant reply returns via the same bus event a scheduled fire produces — **one uniform render path, no double-render**.
- Rail entry with an **unread badge** counting events that arrive while off-surface.

## Tests / docs

- `tests/test_activity.py` (terminal hook fires + is exception-safe; `/api/activity` returns history; 404 when unwired); `test_scheduler_local` asserts the fire body carries `contextId=system:activity` + `origin=scheduler`; `e2e/activity.spec.ts` (badge, history, live append, optimistic reply).
- **751 pytest + 29 e2e green**; web + docs build clean.
- **Live-verified end-to-end**: a turn routed into `system:activity` persisted in `GET /api/activity` and emitted `activity.message` on the bus.
- Docs: `react-tauri-ui` (Activity surface + `/api/activity`), `scheduler` (where fired output lands).

Slice 3 (inbound inbox + `check_inbox`) builds on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)