### PR TITLE
Inbox surface in the right sidebar (ADR 0003)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -59,6 +59,13 @@ export const ACTIVITY_HISTORY = {
   ],
 };
 
+export const INBOX_ITEMS = {
+  items: [
+    { id: 1, created_at: "2026-05-30T09:00:00+00:00", priority: "now", source: "ci", text: "build failed on main", dedup_key: null, delivered_at: null },
+    { id: 2, created_at: "2026-05-30T09:05:00+00:00", priority: "next", source: "webhook", text: "new signup: acme.co", dedup_key: null, delivered_at: null },
+  ],
+};
+
 export const WORKFLOWS = [
   {
     name: "research-and-brief",

--- a/apps/web/e2e/inbox.spec.ts
+++ b/apps/web/e2e/inbox.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+// The Inbox sidebar panel (ADR 0003): lists pending inbound items, shows an
+// unread badge while off-panel, live-updates on `inbox.item`, and dismisses.
+
+test("inbox badge appears, panel lists items, and dismiss removes one", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // inbox.item events arrive while the default (Notes) panel is showing → badge.
+  await expect(page.getByTestId("inbox-badge")).toBeVisible();
+
+  // Open the Inbox tab (its accessible name includes the badge count).
+  await page.getByRole("button", { name: /Inbox/ }).click();
+  await expect(page.getByRole("heading", { name: "Inbox" })).toBeVisible();
+
+  // Items from GET /api/inbox render with priority + source.
+  await expect(page.getByText("build failed on main")).toBeVisible();
+  await expect(page.getByText("new signup: acme.co")).toBeVisible();
+  await expect(page.locator(".inbox-pri-now")).toBeVisible();
+
+  // Opening the panel clears the badge.
+  await expect(page.getByTestId("inbox-badge")).toHaveCount(0);
+
+  // Dismiss the first item → it leaves the list.
+  const firstItem = page.locator(".inbox-item", { hasText: "build failed on main" });
+  await firstItem.locator(".inbox-dismiss").click();
+  await expect(page.getByText("build failed on main")).toHaveCount(0);
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -17,6 +17,7 @@ import {
   ACTIVITY_HISTORY,
   buildFrames,
   GOALS,
+  INBOX_ITEMS,
   NOTES_WORKSPACE,
   RUNTIME_STATUS,
   SCHEDULER_JOBS,
@@ -87,6 +88,8 @@ function handleApiGet(pathname) {
       return { workflows: WORKFLOWS };
     case "/api/activity":
       return ACTIVITY_HISTORY;
+    case "/api/inbox":
+      return INBOX_ITEMS;
     default:
       return null;
   }
@@ -166,6 +169,7 @@ const server = createServer(async (req, res) => {
     // the surface) and live append (while on it) are deterministically testable.
     const t = setInterval(() => {
       res.write('event: activity.message\ndata: {"text":"live activity ping"}\n\n');
+      res.write('event: inbox.item\ndata: {"id":99,"priority":"next","source":"mock","text":"live inbox ping"}\n\n');
     }, 500);
     req.on("close", () => clearInterval(t));
     return;

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -10,6 +10,7 @@ import {
   Database,
   FileText,
   Gauge,
+  Inbox,
   Loader2,
   MessageSquare,
   Network,
@@ -28,6 +29,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import { ActivitySurface } from "../activity/ActivitySurface";
+import { InboxPanel } from "../inbox/InboxPanel";
 import { ChatSurface } from "../chat/ChatSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
@@ -38,7 +40,7 @@ import { ScrollArea } from "./ScrollArea";
 import { SetupWizard } from "../setup/SetupWizard";
 
 type Surface = "chat" | "subagents" | "workflows" | "activity" | "runtime" | "schedule" | "goals" | "settings";
-type RightPanel = "notes" | "beads";
+type RightPanel = "notes" | "beads" | "inbox";
 type SubagentMode = "single" | "batch";
 type StatusTone = "success" | "warning" | "error" | "muted";
 
@@ -217,6 +219,7 @@ export function App() {
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
   const [live, setLive] = useState(false);
   const [activityUnread, setActivityUnread] = useState(0);
+  const [inboxUnread, setInboxUnread] = useState(0);
   const [projectPath, setProjectPath] = useLocalStorageState("protoagent.projectPath", "");
   const [runtime, setRuntime] = useState<RuntimeStatus | null>(null);
   const [subagents, setSubagents] = useState<Subagent[]>([]);
@@ -443,6 +446,21 @@ export function App() {
   useEffect(() => {
     if (surface === "activity") setActivityUnread(0);
   }, [surface]);
+
+  // Unread count on the Inbox sidebar tab: inbound items that arrive while the
+  // operator isn't looking at the inbox panel.
+  const rightPanelRef = useRef(rightPanel);
+  rightPanelRef.current = rightPanel;
+  useEffect(
+    () =>
+      onServerEvent("inbox.item", () => {
+        if (rightPanelRef.current !== "inbox") setInboxUnread((n) => n + 1);
+      }),
+    [],
+  );
+  useEffect(() => {
+    if (rightPanel === "inbox") setInboxUnread(0);
+  }, [rightPanel]);
 
   async function runSubagent() {
     const prompt = subagentPrompt.trim();
@@ -1231,6 +1249,19 @@ export function App() {
               <Boxes size={15} />
               Beads
             </button>
+            <button
+              type="button"
+              className={rightPanel === "inbox" ? "active" : ""}
+              onClick={() => setRightPanel("inbox")}
+            >
+              <Inbox size={15} />
+              Inbox
+              {inboxUnread ? (
+                <span className="rail-badge" data-testid="inbox-badge">
+                  {inboxUnread > 9 ? "9+" : inboxUnread}
+                </span>
+              ) : null}
+            </button>
           </div>
 
           {rightPanel === "notes" ? (
@@ -1487,6 +1518,8 @@ export function App() {
               </ScrollArea>
             </section>
           ) : null}
+
+          {rightPanel === "inbox" ? <InboxPanel onError={setError} /> : null}
         </aside>
       </div>
       <SetupWizard

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1220,6 +1220,82 @@ textarea {
   resize: none;
 }
 
+/* Inbox panel (ADR 0003) ---------------------------------------------------- */
+.inbox-list {
+  flex: 1;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 10px;
+}
+
+.inbox-empty {
+  color: var(--fg-secondary);
+  font-size: 12px;
+  padding: 8px;
+  line-height: 1.5;
+}
+
+.inbox-empty code {
+  font-size: 11px;
+  background: var(--bg-elevated, #111114);
+  padding: 1px 4px;
+  border-radius: 4px;
+}
+
+.inbox-item {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-elevated, #111114);
+  padding: 8px 10px;
+}
+
+.inbox-item-head {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin-bottom: 4px;
+}
+
+.inbox-pri {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  font-weight: 600;
+  padding: 1px 6px;
+  border-radius: 8px;
+  color: #fff;
+}
+
+.inbox-pri-now {
+  background: var(--danger, #ff6b6b);
+}
+
+.inbox-pri-next {
+  background: var(--accent, #7c8cff);
+}
+
+.inbox-pri-later {
+  background: var(--fg-tertiary, #555);
+}
+
+.inbox-source {
+  font-size: 11px;
+  color: var(--fg-secondary);
+  font-family: var(--font-mono);
+}
+
+.inbox-dismiss {
+  margin-left: auto;
+}
+
+.inbox-text {
+  font-size: 13px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* Live event-stream indicator (ADR 0003) ------------------------------------ */
 .live-dot {
   width: 8px;

--- a/apps/web/src/inbox/InboxPanel.tsx
+++ b/apps/web/src/inbox/InboxPanel.tsx
@@ -1,0 +1,90 @@
+import { Check, Loader2, RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { api } from "../lib/api";
+import { onServerEvent } from "../lib/events";
+import type { InboxItem } from "../lib/types";
+
+// Right-sidebar view of the inbound inbox (ADR 0003). Lists pending stimuli
+// (webhooks / external systems / sister agents), live-updates as items arrive
+// over the `inbox.item` push event, and lets the operator dismiss one
+// (mark it delivered). External intake is POST /api/inbox (token-gated); this
+// surface is read + dismiss only.
+
+const PRIORITY_TONE: Record<string, string> = { now: "now", next: "next", later: "later" };
+
+export function InboxPanel({ onError }: { onError: (message: string) => void }) {
+  const [items, setItems] = useState<InboxItem[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const r = await api.inbox("later", false); // all pending tiers
+      setItems(r.items);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+  useEffect(() => {
+    void load();
+  }, []);
+
+  // Live: a new item arrived. Reload to pick it up with its server-assigned id.
+  useEffect(() => onServerEvent("inbox.item", () => void load()), []);
+
+  async function dismiss(id: number) {
+    try {
+      await api.deliverInbox(id);
+      setItems((prev) => prev.filter((i) => i.id !== id));
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  return (
+    <section className="panel side-panel inbox-panel">
+      <div className="panel-header compact">
+        <div>
+          <h2>Inbox</h2>
+          <p className="panel-kicker">
+            {loading ? "loading…" : `${items.length} pending`}
+          </p>
+        </div>
+        <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
+          {loading ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
+        </button>
+      </div>
+
+      <div className="inbox-list">
+        {!loading && items.length === 0 ? (
+          <div className="inbox-empty">
+            Nothing pending. Inbound stimuli (webhooks, scripts, sister agents) posted to
+            <code>/api/inbox</code> show up here.
+          </div>
+        ) : null}
+        {items.map((item) => (
+          <div className="inbox-item" key={item.id}>
+            <div className="inbox-item-head">
+              <span className={`inbox-pri inbox-pri-${PRIORITY_TONE[item.priority] || "next"}`}>
+                {item.priority}
+              </span>
+              {item.source ? <span className="inbox-source">{item.source}</span> : null}
+              <button
+                className="icon-button inbox-dismiss"
+                type="button"
+                onClick={() => void dismiss(item.id)}
+                title="Mark delivered (dismiss)"
+              >
+                <Check size={15} />
+              </button>
+            </div>
+            <div className="inbox-text">{item.text}</div>
+          </div>
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   ChatMessage,
   ConfigPayload,
   GoalState,
+  InboxItem,
   NotesWorkspace,
   RuntimeStatus,
   ScheduledJob,
@@ -266,6 +267,18 @@ export const api = {
 
   activity() {
     return request<ActivityHistory>("/api/activity");
+  },
+
+  inbox(floor: "now" | "next" | "later" = "later", includeDelivered = false) {
+    const q = `?floor=${floor}&include_delivered=${includeDelivered}`;
+    return request<{ items: InboxItem[] }>(`/api/inbox${q}`);
+  },
+
+  deliverInbox(id: number) {
+    return request<{ ok: boolean; delivered: number }>(`/api/inbox/${id}/deliver`, {
+      method: "POST",
+      body: {},
+    });
   },
 
   workflows() {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -97,6 +97,16 @@ export type WorkflowRunResult = {
   failed: string[];
 };
 
+export type InboxItem = {
+  id: number;
+  created_at: string;
+  priority: "now" | "next" | "later";
+  source: string | null;
+  text: string;
+  dedup_key: string | null;
+  delivered_at: string | null;
+};
+
 export type ActivityMessage = { role: "user" | "assistant"; content: string };
 
 export type ActivityHistory = {

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -151,6 +151,8 @@ Add these before the React UI depends on them:
 | `GET /api/events` | **server→client SSE push channel** (ADR 0003). Holds open for the app's lifetime; the server pushes unsolicited events (`activity.message`, `inbox.item`) the request-scoped chat stream can't. Read-only. |
 | `GET /api/activity` | the durable **Activity thread**'s message history (ADR 0003) — `{context_id, messages:[{role, content}]}` read from the checkpointer (`a2a:system:activity`). Where agent-initiated turns (scheduled fires) land. |
 | `POST /api/inbox` | **authenticated inbound intake** (ADR 0003). `{text, priority?, source?, dedup_key?}` — `priority` is `now` \| `next` \| `later`. `now` items fire an Activity turn immediately; the rest queue for the agent's `check_inbox` tool. Bearer token required (same token as `/a2a`). |
+| `GET /api/inbox` | console-side list of pending inbox items (`?floor=&include_delivered=`) → `{items:[…]}`. Unauthenticated like other operator reads. |
+| `POST /api/inbox/{id}/deliver` | mark one item delivered (the console "dismiss" action). |
 
 ### Event stream (push channel)
 
@@ -186,6 +188,13 @@ dedup window + an anti-storm rate cap), while `next`/`later` queue for the
 agent's **`check_inbox`** tool to surface on its own terms. Items live in a
 durable SQLite `inbox` table; a `dedup_key` collapses a retrying producer's
 repeats. Arrivals publish an `inbox.item` event on the bus.
+
+The console exposes this as the **Inbox** tab in the right sidebar (alongside
+Notes and Beads, `inbox/InboxPanel.tsx`): it lists pending items from
+`GET /api/inbox` with their priority + source, live-updates on `inbox.item`,
+carries an unread badge while you're on another tab, and dismisses an item
+(marks it delivered) via `POST /api/inbox/{id}/deliver`. External intake stays
+token-gated on `POST /api/inbox`; the read/dismiss views are console-side.
 
 Manual subagents should reuse the existing `_run_subagent` implementation, but
 expose it through a service function instead of calling the lead agent's tool.

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -144,6 +144,8 @@ def register_operator_routes(
     activity_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
     inbox_add: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
     inbox_authorized: Callable[[str | None], bool] | None = None,
+    inbox_list: Callable[[str, bool], Awaitable[dict[str, Any]]] | None = None,
+    inbox_deliver: Callable[[int], Awaitable[dict[str, Any]]] | None = None,
 ) -> None:
     """Register React operator-console routes on a FastAPI app.
 
@@ -363,6 +365,26 @@ def register_operator_routes(
                     raise HTTPException(status_code=401, detail="invalid or missing bearer token")
             try:
                 return await inbox_add(_model_payload(req))
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    # Console-side inbox views (read + dismiss). Unauthenticated like the other
+    # operator routes — only POST /api/inbox (external intake) is token-gated.
+    if inbox_list is not None:
+
+        @app.get("/api/inbox")
+        async def _inbox_get(floor: str = "later", include_delivered: bool = False):
+            try:
+                return await inbox_list(floor, include_delivered)
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    if inbox_deliver is not None:
+
+        @app.post("/api/inbox/{item_id}/deliver")
+        async def _inbox_deliver(item_id: int):
+            try:
+                return await inbox_deliver(item_id)
             except Exception as exc:
                 raise _http_error(exc) from exc
 

--- a/server.py
+++ b/server.py
@@ -1813,6 +1813,19 @@ def _main():
         fired = await _fire_activity_from_inbox(item) if item["priority"] == "now" else False
         return {"ok": True, "item": item, "fired": fired}
 
+    async def _operator_inbox_list(floor: str, include_delivered: bool) -> dict:
+        if _inbox_store is None:
+            return {"items": []}
+        items = _inbox_store.list(
+            priority_floor=floor or "later", include_delivered=include_delivered, limit=200,
+        )
+        return {"items": items}
+
+    async def _operator_inbox_deliver(item_id: int) -> dict:
+        if _inbox_store is None:
+            raise RuntimeError("inbox not loaded; finish setup first")
+        return {"ok": True, "delivered": _inbox_store.mark_delivered([item_id])}
+
     def _operator_chat_commands() -> dict:
         """Slash commands the chat understands — drives the composer autocomplete.
 
@@ -1847,6 +1860,8 @@ def _main():
         activity_list=_operator_activity_list,
         inbox_add=_operator_inbox_add,
         inbox_authorized=_inbox_authorized,
+        inbox_list=_operator_inbox_list,
+        inbox_deliver=_operator_inbox_deliver,
     )
 
     # --- Scheduler lifecycle ------------------------------------------------

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -138,6 +138,41 @@ def test_inbox_route_rejects_bad_token():
     assert r2.status_code == 401
 
 
+def test_inbox_list_and_deliver_routes():
+    captured = {}
+
+    async def inbox_list(floor, include_delivered):
+        captured["floor"] = floor
+        captured["include_delivered"] = include_delivered
+        return {"items": [{"id": 1, "priority": "now", "text": "x"}]}
+
+    async def inbox_deliver(item_id):
+        captured["delivered_id"] = item_id
+        return {"ok": True, "delivered": 1}
+
+    app = FastAPI()
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=_unused,
+        subagent_batch=_unused,
+        inbox_list=inbox_list,
+        inbox_deliver=inbox_deliver,
+    )
+    client = TestClient(app)
+
+    r = client.get("/api/inbox?floor=next&include_delivered=true")
+    assert r.status_code == 200
+    assert r.json()["items"][0]["id"] == 1
+    assert captured["floor"] == "next" and captured["include_delivered"] is True
+
+    r2 = client.post("/api/inbox/7/deliver")
+    assert r2.status_code == 200
+    assert r2.json() == {"ok": True, "delivered": 1}
+    assert captured["delivered_id"] == 7
+
+
 def test_inbox_route_accepts_with_token():
     seen = []
 


### PR DESCRIPTION
## What

A dedicated **Inbox** view in the operator console's right sidebar — alongside Notes and Beads (per @joshmabry: "a dedicated inbox surface, perhaps in the notes/beads sidebar"). Makes the inbound inbox (ADR 0003 slice 3) visible/manageable rather than agent-only.

## Backend

- **`GET /api/inbox`** (`?floor=&include_delivered=`) → `{items:[…]}` — console-side list of pending items.
- **`POST /api/inbox/{id}/deliver`** — mark one item delivered (the "dismiss" action).
- Both wired over the existing `InboxStore`. External intake stays **token-gated** on `POST /api/inbox`; these console read/dismiss routes are unauthenticated like the other operator routes.

## Frontend

- **`inbox/InboxPanel.tsx`** — lists items with a priority pill (`now`/`next`/`later`) + source, **live-updates** on the `inbox.item` push event, and dismisses an item (✓ → `deliver`).
- Right-sidebar **Inbox** tab with an **unread badge** counting items that arrive while you're on another tab.

## Tests / docs

- `tests/test_inbox.py` — list + deliver route test; `e2e/inbox.spec.ts` — badge appears, panel lists items, dismiss removes one.
- **763 pytest + 30 e2e green**; web + docs build clean.
- **Live-verified**: `GET /api/inbox` lists priority-ordered pending items; `deliver` removes one.
- Docs: `react-tauri-ui` (the two endpoints + the Inbox panel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)