### PR TITLE
Run workflows as chat slash commands (ADR 0002)

### DIFF
--- a/apps/web/e2e/commands.spec.ts
+++ b/apps/web/e2e/commands.spec.ts
@@ -20,6 +20,8 @@ test("slash menu opens and lists the server commands", async ({ page }) => {
   // name, so scope to the name span to avoid matching twice).
   const names = await menu.locator(".slash-name").allInnerTexts();
   expect(names).toEqual(SLASH_COMMANDS.map((c) => `/${c.name}`));
+  // Workflows are listed as slash commands too (ADR 0002).
+  expect(names).toContain("/research-and-brief");
 });
 
 test("filtering narrows the menu and selecting completes the command", async ({ page }) => {

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -93,6 +93,8 @@ export const WORKFLOW_RUN_RESULT = {
 export const SLASH_COMMANDS = [
   { name: "goal", description: "Set a goal for this session", usage: "/goal <condition>" },
   { name: "clear", description: "Clear the conversation", usage: "/clear" },
+  // Workflows surface as slash commands too (ADR 0002) — server lists them.
+  { name: "research-and-brief", description: "Research a topic, then write a brief.", usage: "/research-and-brief <topic> [depth]" },
 ];
 
 export const SCHEDULER_JOBS = {

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -57,6 +57,20 @@ Workflows only delegate to **configured subagents** (each with its own tool
 allowlist and turn cap), and subagents don't get `run_workflow` — so there's no
 recursion and the blast radius is exactly the subagent system's.
 
+### As a slash command
+
+Every registered workflow is also runnable straight from the chat composer as
+**`/<workflow-name>`** — it autocompletes (the server lists workflows in
+`GET /api/chat/commands`) and short-circuits the turn, returning the workflow's
+output instead of a normal model reply. Arguments map to the recipe's inputs:
+
+- `` /research-and-brief quantum error correction `` — free text fills the first
+  required input (`topic`).
+- `` /research-and-brief topic="quantum error correction" depth=shallow `` —
+  explicit `key=value` tokens (quotes respected) set named inputs.
+
+Missing a required input returns a `⚠️`-prefixed error naming it.
+
 ## From the operator console
 
 The React console has a **Workflows** surface (the rail icon next to Subagents).

--- a/server.py
+++ b/server.py
@@ -1132,6 +1132,86 @@ async def _run_turn_stream(message: str, session_id: str, config: dict):
     yield ("__raw__", accumulated_raw)
 
 
+# --- Workflow slash commands (ADR 0002) --------------------------------------
+# A chat message like ``/research-and-brief quantum computing`` runs the named
+# workflow instead of a normal model turn — the slash-command analogue of the
+# run_workflow tool. Free text maps to the first unset (required) input; explicit
+# ``key=value`` tokens set named inputs. Short-circuits the turn like /goal does.
+
+
+def _parse_slash_command(message: str) -> tuple[str, str]:
+    """Split ``/name rest`` → (name, rest). Returns ("", "") if not a slash msg."""
+    s = (message or "").strip()
+    if not s.startswith("/"):
+        return "", ""
+    parts = s[1:].split(None, 1)
+    return (parts[0] if parts else ""), (parts[1] if len(parts) > 1 else "")
+
+
+def _parse_workflow_inputs(recipe: dict, rest: str) -> dict:
+    """Map a slash-command argument string to a workflow's named inputs.
+
+    ``key=value`` tokens (quotes respected) set inputs explicitly; any leftover
+    free text is assigned to the first not-yet-set input, preferring required
+    ones — so ``/research-and-brief quantum computing`` fills ``topic``.
+    """
+    import shlex
+
+    try:
+        tokens = shlex.split(rest)
+    except ValueError:
+        tokens = rest.split()
+    inputs: dict = {}
+    leftover: list[str] = []
+    for tok in tokens:
+        if "=" in tok and tok.split("=", 1)[0].isidentifier():
+            key, val = tok.split("=", 1)
+            inputs[key] = val
+        else:
+            leftover.append(tok)
+    if leftover:
+        declared = recipe.get("inputs", []) or []
+        target = next((i["name"] for i in declared if i["name"] not in inputs and i.get("required")), None)
+        if target is None:
+            target = next((i["name"] for i in declared if i["name"] not in inputs), None)
+        if target:
+            inputs[target] = " ".join(leftover)
+    return inputs
+
+
+def _parse_workflow_command(message: str):
+    """Return (name, inputs) if ``message`` is ``/<known-workflow> …``, else None."""
+    name, rest = _parse_slash_command(message)
+    if not name or _workflow_registry is None:
+        return None
+    recipe = _workflow_registry.get(name)
+    if recipe is None:
+        return None
+    return name, _parse_workflow_inputs(recipe, rest)
+
+
+async def _run_parsed_workflow(name: str, inputs: dict) -> str:
+    """Run a workflow command and format its output as the assistant reply."""
+    from graph.agent import run_manual_workflow
+
+    try:
+        result = await run_manual_workflow(
+            _graph_config, _workflow_registry,
+            knowledge_store=_knowledge_store, scheduler=_scheduler,
+            name=name, inputs=inputs,
+        )
+    except ValueError as exc:
+        return f"⚠️ {exc}"
+    raw = result.get("output") or ""
+    # Strip subagent scratch_pad/output tags so the chat shows clean text,
+    # matching how a normal turn is rendered.
+    out = extract_output(raw) or raw or "(workflow produced no output)"
+    failed = result.get("failed") or []
+    if failed:
+        out += f"\n\n_(failed steps: {', '.join(failed)})_"
+    return out
+
+
 async def _chat_langgraph_stream(
     message: str,
     session_id: str,
@@ -1183,6 +1263,19 @@ async def _chat_langgraph_stream(
                 if reply is not None:
                     yield ("done", reply)
                     return
+
+            # Workflow slash command (/<workflow-name> …) short-circuits the turn:
+            # run the recipe and return its output. A tool_start/end pair renders
+            # a card so the operator sees it running.
+            parsed = _parse_workflow_command(message)
+            if parsed is not None:
+                wf_name, wf_inputs = parsed
+                tool_id = f"workflow:{wf_name}"
+                yield ("tool_start", {"id": tool_id, "name": tool_id, "input": _coerce_tool_value(wf_inputs)})
+                wf_out = await _run_parsed_workflow(wf_name, wf_inputs)
+                yield ("tool_end", {"id": tool_id, "name": tool_id, "output": wf_out[:300]})
+                yield ("done", wf_out)
+                return
 
             # thread_id keys this session's history in the checkpointer (bound
             # at compile time in create_agent_graph). The prefix isolates A2A
@@ -1318,6 +1411,11 @@ async def _chat_langgraph(message: str, session_id: str) -> list[dict[str, Any]]
                 reply = await _goal_controller.parse_control(message, session_id)
                 if reply is not None:
                     return [{"role": "assistant", "content": reply}]
+
+            # Workflow slash command (/<workflow-name> …) short-circuits the turn.
+            parsed = _parse_workflow_command(message)
+            if parsed is not None:
+                return [{"role": "assistant", "content": await _run_parsed_workflow(*parsed)}]
 
             config = {"configurable": {"thread_id": f"gradio:{session_id}"}}
 
@@ -1839,6 +1937,17 @@ def _main():
                 "description": "Set, check, or clear a self-driving goal for this chat session.",
                 "usage": "/goal <condition>   ·   /goal  (status)   ·   /goal clear",
             })
+        # Each registered workflow is runnable as /<name> (ADR 0002).
+        if _workflow_registry is not None:
+            for wf in _workflow_registry.list():
+                declared = wf.get("inputs", []) or []
+                req = "".join(f" <{i['name']}>" for i in declared if i.get("required"))
+                opt = "".join(f" [{i['name']}]" for i in declared if not i.get("required"))
+                commands.append({
+                    "name": wf["name"],
+                    "description": wf.get("description") or f"Run the {wf['name']} workflow.",
+                    "usage": f"/{wf['name']}{req}{opt}",
+                })
         return {"commands": commands}
 
     register_operator_routes(

--- a/tests/test_workflow_slash.py
+++ b/tests/test_workflow_slash.py
@@ -1,0 +1,47 @@
+"""Tests for workflow slash-command parsing (ADR 0002 — /<workflow> in chat)."""
+
+from __future__ import annotations
+
+import server
+
+RECIPE = {
+    "name": "research-and-brief",
+    "inputs": [{"name": "topic", "required": True}, {"name": "depth", "default": "deep"}],
+}
+
+
+def test_parse_slash_command_splits_name_and_rest():
+    assert server._parse_slash_command("/research-and-brief quantum computing") == (
+        "research-and-brief",
+        "quantum computing",
+    )
+    assert server._parse_slash_command("/bare") == ("bare", "")
+    assert server._parse_slash_command("not a command") == ("", "")
+    assert server._parse_slash_command("   ") == ("", "")
+
+
+def test_free_text_maps_to_first_required_input():
+    assert server._parse_workflow_inputs(RECIPE, "quantum computing") == {"topic": "quantum computing"}
+
+
+def test_key_value_tokens_set_named_inputs_with_quotes():
+    out = server._parse_workflow_inputs(RECIPE, 'topic="quantum error correction" depth=shallow')
+    assert out == {"topic": "quantum error correction", "depth": "shallow"}
+
+
+def test_mixed_free_text_and_key_value():
+    # key=value sets depth; the leftover free text fills the first unset required input
+    out = server._parse_workflow_inputs(RECIPE, "quantum computing depth=shallow")
+    assert out == {"depth": "shallow", "topic": "quantum computing"}
+
+
+def test_no_inputs_recipe_ignores_free_text():
+    out = server._parse_workflow_inputs({"inputs": []}, "whatever text")
+    assert out == {}
+
+
+def test_parse_workflow_command_returns_none_without_registry():
+    # _workflow_registry is None in a bare import (no graph built) → not a wf command
+    assert server._workflow_registry is None
+    assert server._parse_workflow_command("/research-and-brief topic=x") is None
+    assert server._parse_workflow_command("hello") is None


### PR DESCRIPTION
## What

Workflows are now runnable straight from the chat composer as **`/<workflow-name>`** — the slash-command analogue of the `run_workflow` tool (per @joshmabry: "we should be able to use the workflows as slash commands").

## How

- **`server.py`** — `_parse_workflow_command` / `_run_parsed_workflow` + a short-circuit in both `_chat_langgraph_stream` (console/A2A path) and `_chat_langgraph` (gradio/openai-compat), mirroring the existing `/goal` control short-circuit.
  - Free text maps to the first unset **required** input (`/research-and-brief quantum computing` → `topic`); explicit `key=value` tokens (quotes respected) set named inputs.
  - Output runs through `extract_output` so subagent `<scratch_pad>`/`<output>` tags don't leak into chat.
  - The stream path emits a `workflow:<name>` tool card so the run is visible while it executes.
- **`_operator_chat_commands`** lists each registered workflow (name + a usage string built from its inputs), so the existing composer autocomplete surfaces them automatically — no frontend change needed.

## Tests / docs

- `tests/test_workflow_slash.py` — slash parsing + input mapping (free text, quoted `key=value`, mixed, no-inputs, no-registry).
- `e2e/commands.spec.ts` — a workflow appears in the slash menu.
- **769 pytest + 30 e2e green**; web + docs build clean.
- **Live-verified end-to-end**: `/op-smoke token=…` ran through the A2A chat stream and returned the workflow output with a `workflow:` card; `GET /api/chat/commands` lists `goal` + `research-and-brief` with usage.
- Docs: `workflows` guide — "As a slash command" section.

Note: like `/goal`, a slash-command turn short-circuits the graph, so its result isn't written to the server-side checkpointer history (the console still shows it locally). Persisting these is a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)