### PR TITLE
Implement multi-instance data scoping + scheduler interlock (ADR 0004)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -51,6 +51,7 @@ export default defineConfig({
             { text: "Scheduler", link: "/guides/scheduler" },
             { text: "Operator console (React/Tauri)", link: "/guides/react-tauri-ui" },
             { text: "Wire Langfuse + Prometheus", link: "/guides/observability" },
+            { text: "Run multiple instances", link: "/guides/multi-instance" },
             { text: "Deploy via GHCR", link: "/guides/deploy" },
           ],
         },

--- a/docs/adr/0004-multi-instance-data-scoping.md
+++ b/docs/adr/0004-multi-instance-data-scoping.md
@@ -1,6 +1,6 @@
 # ADR 0004 — Multi-Instance Data Scoping
 
-- **Status:** Accepted (2026-05-30) — design agreed; implementation to follow
+- **Status:** Accepted (2026-05-30) — implemented (instance scoping + scheduler owner-lock)
 - **Date:** 2026-05-30
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** architecture, deployment, state, scheduler, knowledge, multi-instance
@@ -66,11 +66,16 @@ A single **instance id** resolved once at startup, in priority order:
 
 1. `PROTOAGENT_INSTANCE` env, else
 2. `instance_id` config field, else
-3. the agent identity name when it's non-default, else
-4. empty → **legacy mode** (today's exact paths).
+3. empty → **legacy mode** (today's exact paths).
 
 When empty, nothing changes — existing single-instance deployments keep their
 current paths and data. When set, every store nests under it.
+
+> **As implemented**, scoping is strictly opt-in via the env/config id above. We
+> deliberately do **not** auto-derive it from a non-default agent identity name —
+> that would silently move data for anyone who'd named their agent, breaking the
+> zero-migration guarantee. Distinct instances on shared storage set a distinct
+> `PROTOAGENT_INSTANCE`.
 
 ### 2.2 One scoped data root + a single path helper
 

--- a/docs/guides/multi-instance.md
+++ b/docs/guides/multi-instance.md
@@ -1,0 +1,70 @@
+# Run multiple instances
+
+Running several protoAgent instances on one machine needs each one's on-disk
+state (conversation checkpoints, knowledge, skills, workflows, memory, scheduled
+jobs, inbox) kept separate. How much you need to do depends on how you run them.
+See [ADR 0004](/adr/0004-multi-instance-data-scoping) for the full rationale.
+
+## The easy path: one container per instance
+
+Each container has its own filesystem, so the default `/sandbox/...` paths are
+**already isolated** — nothing to configure. This is the recommended way to run
+a fleet. Give each container a distinct port if you expose them on the host.
+
+## Shared filesystem: set an instance id
+
+When several instances share one filesystem — multiple bare processes on a host,
+or containers that mount the **same** volume — the default paths (and the
+`~/.protoagent/...` fallback used when `/sandbox` isn't writable) would collide.
+Scope each instance with a distinct id:
+
+```bash
+PROTOAGENT_INSTANCE=alice  python server.py --port 7871
+PROTOAGENT_INSTANCE=bob    python server.py --port 7872
+```
+
+or in `config.yaml`:
+
+```yaml
+instance_id: alice
+```
+
+With an id set, **every** store nests under it — e.g.
+`~/.protoagent/alice/checkpoints.db`, `~/.protoagent/scheduler/alice/…/jobs.db`,
+`~/.protoagent/alice/memory/`, and so on — so two ids never share a file. The
+env var wins over the config field.
+
+### Opt-in — no migration
+
+Leaving the id **unset** keeps the exact single-instance paths used today, so
+existing deployments are untouched. Scoping is purely additive: set an id only
+when you actually run more than one instance on shared storage. (Note: a
+*non-default agent name* does **not** auto-scope — only an explicit instance id
+does — so naming your agent never silently moves its data.)
+
+One instance = one id + one port. Renaming an instance's id points it at a fresh
+data root; the old data stays under the old id (no auto-migration).
+
+## Safety interlock
+
+Even with the guidance above, a misconfiguration (two instances sharing a
+`jobs.db`) is easy to make and fails *silently* — both schedulers poll the same
+table and a due job is fired by whichever ticks first, so the other never sees
+it. To catch this, the scheduler takes an **exclusive owner-lock** on its
+`jobs.db` at startup. If another live instance already holds it, the scheduler
+logs a loud error and **does not start** (the rest of the agent serves normally):
+
+```
+[scheduler] jobs.db at <path> is already owned by another live instance —
+not starting the scheduler. Run each instance with a distinct
+PROTOAGENT_INSTANCE (or agent name) so they don't share a jobs.db.
+```
+
+The fix is always the same: give the instances distinct `PROTOAGENT_INSTANCE`
+ids (or run them in separate containers).
+
+## Related
+
+- [ADR 0004 — Multi-Instance Data Scoping](/adr/0004-multi-instance-data-scoping)
+- [Scheduler](/guides/scheduler)
+- [Configuration](/reference/configuration)

--- a/graph/config.py
+++ b/graph/config.py
@@ -248,6 +248,13 @@ class LangGraphConfig:
     identity_name: str = "protoagent"
     identity_operator: str = ""
 
+    # Instance id for multi-instance data scoping (ADR 0004). When set, every
+    # store nests under <base>/<id>/ so several instances can share one
+    # filesystem without clobbering each other. Empty = single-instance (legacy)
+    # paths, unchanged. Seeded into the PROTOAGENT_INSTANCE env at startup so the
+    # env-reading stores (knowledge/scheduler/memory) honor it too.
+    instance_id: str = ""
+
     # A2A bearer token — blank = open mode (local dev). Writing a token
     # here makes the A2A handler require ``Authorization: Bearer <token>``
     # on every request and advertises the bearer scheme on the agent card.
@@ -368,6 +375,7 @@ class LangGraphConfig:
             plugins_dir=plugins.get("dir", cls.plugins_dir),
             identity_name=identity.get("name", cls.identity_name),
             identity_operator=identity.get("operator", cls.identity_operator),
+            instance_id=data.get("instance", {}).get("id", "") or data.get("instance_id", cls.instance_id),
             auth_token=secret_auth_token or auth.get("token", cls.auth_token),
             autostart_on_boot=runtime.get("autostart_on_boot", cls.autostart_on_boot),
             operator_allowed_dirs=list(operator.get("allowed_dirs", []) or []),

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -27,7 +27,11 @@ log = logging.getLogger(__name__)
 # Configuration — read once at module init
 # ---------------------------------------------------------------------------
 
-MEMORY_PATH = os.environ.get("MEMORY_PATH", "/sandbox/memory/")
+from paths import scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
+
+# ``PROTOAGENT_INSTANCE`` is seeded by server init before the graph (and this
+# middleware) is built, so the instance segment applies here too.
+MEMORY_PATH = str(scope_leaf(os.environ.get("MEMORY_PATH", "/sandbox/memory/")))
 _DISABLE_ENV = os.environ.get("PROTOAGENT_DISABLE_MEMORY", "")
 _PERSISTENCE_DISABLED = _DISABLE_ENV.lower() in ("1", "true", "yes")
 

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -73,8 +73,10 @@ class Chunk:
 
 def _resolve_path(db_path: str | Path | None) -> Path:
     """Pick a writable DB path. Env > arg > default; fall back to ~/.protoagent."""
+    from paths import scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
+
     raw = os.environ.get("KNOWLEDGE_DB_PATH") or db_path or DEFAULT_DB_PATH
-    p = Path(str(raw)).expanduser()
+    p = scope_leaf(raw)
     try:
         p.parent.mkdir(parents=True, exist_ok=True)
         # Probe writability
@@ -83,7 +85,7 @@ def _resolve_path(db_path: str | Path | None) -> Path:
         probe.unlink()
         return p
     except OSError:
-        fallback = Path.home() / ".protoagent" / "knowledge" / "agent.db"
+        fallback = scope_leaf(Path.home() / ".protoagent" / "knowledge" / "agent.db")
         fallback.parent.mkdir(parents=True, exist_ok=True)
         log.info(
             "[knowledge] %s not writable; using %s instead",

--- a/paths.py
+++ b/paths.py
@@ -1,0 +1,44 @@
+"""Per-instance data-path scoping (ADR 0004).
+
+Multiple protoAgent instances on one shared filesystem must not clobber each
+other's on-disk state. When an **instance id** is set (``PROTOAGENT_INSTANCE``
+env, seeded from ``instance_id`` config at startup), every store nests its files
+under that id; when unset, paths are byte-identical to the single-instance
+default — so existing deployments need no migration, and containers (each with
+its own ``/sandbox``) are unaffected.
+
+``scope_leaf`` is the one knob: applied to a store's final resolved path, it
+inserts the instance segment as the leaf's parent dir (a no-op when no id is
+set). Apply it at the end of each resolver, *after* the writable-fallback choice,
+so the segment survives a ``/sandbox`` → ``~/.protoagent`` fallback.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+from pathlib import Path
+
+
+def instance_id() -> str:
+    """The active instance id, or "" for single-instance (legacy) mode."""
+    return os.environ.get("PROTOAGENT_INSTANCE", "").strip()
+
+
+def _safe_segment(seg: str) -> str:
+    """Sanitize an id to a single safe path segment (defence against traversal)."""
+    return re.sub(r"[^A-Za-z0-9._-]", "_", seg) or "instance"
+
+
+def scope_leaf(path: str | Path) -> Path:
+    """Insert the instance id as the parent dir of ``path``'s leaf when set.
+
+    ``/sandbox/checkpoints.db`` → ``/sandbox/<id>/checkpoints.db``;
+    ``~/.protoagent/knowledge/agent.db`` → ``~/.protoagent/knowledge/<id>/agent.db``.
+    A no-op (returns ``path`` unchanged) when no instance id is configured.
+    """
+    p = Path(str(path)).expanduser()
+    iid = instance_id()
+    if not iid:
+        return p
+    return p.parent / _safe_segment(iid) / p.name

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -48,6 +48,56 @@ _POLL_INTERVAL_S = 1.0
 _MISSED_FIRE_WINDOW_S = 24 * 60 * 60  # 24h — matches Workstacean
 
 
+# Owner-lock interlock (ADR 0004): one live instance owns a given jobs.db. Two
+# instances sharing it would both poll and race to claim due jobs (a fired job
+# vanishes from the other's view). The in-process set catches same-process /
+# test collisions; fcntl.flock catches separate processes on a shared filesystem.
+_LOCKED_PATHS: set[str] = set()
+
+
+def _acquire_jobs_lock(path: Path):
+    """Try to take the exclusive owner-lock for ``path``'s jobs.db.
+
+    Returns the held lock file object on success, or ``None`` if another live
+    instance already owns it (caller should log + skip starting the scheduler).
+    """
+    key = str(path)
+    if key in _LOCKED_PATHS:
+        return None
+    try:
+        import fcntl
+
+        fd = open(key + ".lock", "w")
+        try:
+            fcntl.flock(fd, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError:
+            fd.close()
+            return None
+    except ImportError:  # pragma: no cover - non-POSIX; fall back to in-proc guard
+        fd = None
+    _LOCKED_PATHS.add(key)
+    return fd if fd is not None else _InProcLock(key)
+
+
+class _InProcLock:
+    """Marker returned when fcntl is unavailable — release just drops the path."""
+
+    def __init__(self, key: str):
+        self._key = key
+
+    def close(self):
+        pass
+
+
+def _release_jobs_lock(path: Path, fd) -> None:
+    _LOCKED_PATHS.discard(str(path))
+    try:
+        if fd is not None:
+            fd.close()
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _resolve_db_path(db_dir: str | Path | None, agent_name: str) -> Path:
     """Pick a writable jobs.db path namespaced by agent name.
 
@@ -57,9 +107,11 @@ def _resolve_db_path(db_dir: str | Path | None, agent_name: str) -> Path:
     cheap and prevents an exotic typo from putting a sqlite file
     outside the configured scheduler dir.
     """
+    from paths import scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
+
     safe_name = _safe_segment(agent_name)
     raw = os.environ.get("SCHEDULER_DB_DIR") or db_dir or DEFAULT_DB_DIR
-    base = Path(str(raw)).expanduser() / safe_name
+    base = scope_leaf(Path(str(raw)).expanduser() / safe_name)
     try:
         base.mkdir(parents=True, exist_ok=True)
         probe = base / ".write-probe"
@@ -67,7 +119,7 @@ def _resolve_db_path(db_dir: str | Path | None, agent_name: str) -> Path:
         probe.unlink()
         return base / "jobs.db"
     except OSError:
-        fallback = Path.home() / ".protoagent" / "scheduler" / safe_name
+        fallback = scope_leaf(Path.home() / ".protoagent" / "scheduler" / safe_name)
         fallback.mkdir(parents=True, exist_ok=True)
         log.info("[scheduler] %s not writable; using %s instead", base, fallback)
         return fallback / "jobs.db"
@@ -149,6 +201,7 @@ class LocalScheduler:
         self.path = _resolve_db_path(db_dir, agent_name)
         self._task: asyncio.Task | None = None
         self._stopping = False
+        self._lock_fd = None  # owner-lock fd (ADR 0004) held while polling
         self._init_db()
 
     # ── DB plumbing ─────────────────────────────────────────────────────────
@@ -232,6 +285,18 @@ class LocalScheduler:
     async def start(self) -> None:
         if self._task is not None:
             return
+        # Owner-lock interlock (ADR 0004): refuse to poll a jobs.db another live
+        # instance owns, rather than silently racing it. Loud error + skip the
+        # scheduler (the rest of the agent still serves normally).
+        self._lock_fd = _acquire_jobs_lock(self.path)
+        if self._lock_fd is None:
+            log.error(
+                "[scheduler] jobs.db at %s is already owned by another live instance — "
+                "not starting the scheduler. Run each instance with a distinct "
+                "PROTOAGENT_INSTANCE (or agent name) so they don't share a jobs.db.",
+                self.path,
+            )
+            return
         self._stopping = False
         self._recover_missed_fires()
         self._task = asyncio.create_task(self._poll_loop(), name="scheduler.local.poll")
@@ -242,22 +307,25 @@ class LocalScheduler:
 
     async def stop(self) -> None:
         self._stopping = True
-        if self._task is None:
-            return
-        self._task.cancel()
-        try:
-            await self._task
-        except asyncio.CancelledError:
-            # Expected — we just cancelled it.
-            pass
-        except Exception:  # noqa: BLE001
-            # Anything else means the polling loop crashed during
-            # shutdown. Log with traceback so we can debug; don't
-            # re-raise (caller is in shutdown path, raising would
-            # mask the original shutdown trigger).
-            log.exception("[scheduler] polling task raised during stop")
-        self._task = None
-        log.info("[scheduler] local backend stopped")
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                # Expected — we just cancelled it.
+                pass
+            except Exception:  # noqa: BLE001
+                # Anything else means the polling loop crashed during
+                # shutdown. Log with traceback so we can debug; don't
+                # re-raise (caller is in shutdown path, raising would
+                # mask the original shutdown trigger).
+                log.exception("[scheduler] polling task raised during stop")
+            self._task = None
+            log.info("[scheduler] local backend stopped")
+        # Release the owner-lock (ADR 0004) so another instance can take over.
+        if self._lock_fd is not None:
+            _release_jobs_lock(self.path, self._lock_fd)
+            self._lock_fd = None
 
     # ── polling + firing ────────────────────────────────────────────────────
 

--- a/server.py
+++ b/server.py
@@ -34,6 +34,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from events import ACTIVITY_CONTEXT, EventBus
+from paths import scope_leaf
 from graph.output_format import (
     DROPPED_SCRATCH_KICKER,
     extract_confidence,
@@ -119,6 +120,11 @@ def _init_langgraph_agent():
     # it at per-user app-data), so load through it rather than a fixed path.
     ensure_live_config()
     _graph_config = LangGraphConfig.from_yaml(CONFIG_YAML_PATH)
+    # Multi-instance scoping (ADR 0004): seed PROTOAGENT_INSTANCE from config so
+    # every store (incl. the env-reading knowledge/scheduler/memory modules) nests
+    # under the same id. Opt-in — empty config.instance_id leaves paths unchanged.
+    # Set before any store is built or the memory middleware is imported.
+    _seed_instance_env(_graph_config)
     # Conversation checkpointer: durable SQLite when a path is configured (chat
     # history survives restarts), else in-memory. Bound into the graph at
     # compile time below — a checkpointer in the invoke config is ignored.
@@ -308,6 +314,17 @@ def _build_plugins(config, existing_tools=None):
         return PluginLoadResult()
 
 
+def _seed_instance_env(config) -> None:
+    """Seed PROTOAGENT_INSTANCE from config.instance_id (ADR 0004), unless the
+    env is already set (env wins). Opt-in: no id → no scoping → legacy paths."""
+    if os.environ.get("PROTOAGENT_INSTANCE", "").strip():
+        return
+    iid = (getattr(config, "instance_id", "") or "").strip()
+    if iid:
+        os.environ["PROTOAGENT_INSTANCE"] = iid
+        log.info("[instance] data scoped to instance id %r (ADR 0004)", iid)
+
+
 def _resolve_checkpoint_db(configured: str) -> str:
     """Pick a writable checkpoint DB path; fall back to ~/.protoagent when the
     configured dir (default /sandbox) isn't creatable (e.g. local dev)."""
@@ -318,10 +335,12 @@ def _resolve_checkpoint_db(configured: str) -> str:
     try:
         candidate.parent.mkdir(parents=True, exist_ok=True)
         if os.access(candidate.parent, os.W_OK):
-            return str(candidate)
+            scoped = scope_leaf(candidate)
+            scoped.parent.mkdir(parents=True, exist_ok=True)
+            return str(scoped)
     except OSError:
         pass
-    fallback = Path.home() / ".protoagent" / "checkpoints.db"
+    fallback = scope_leaf(Path.home() / ".protoagent" / "checkpoints.db")
     fallback.parent.mkdir(parents=True, exist_ok=True)
     return str(fallback)
 
@@ -429,14 +448,14 @@ def _build_inbox_store(config):
     from inbox import InboxStore
 
     name = re.sub(r"[^a-zA-Z0-9._-]", "_", agent_name()) or "agent"
-    configured = Path(getattr(config, "inbox_db_path", "") or "/sandbox/inbox") / f"{name}.db"
+    configured = scope_leaf(Path(getattr(config, "inbox_db_path", "") or "/sandbox/inbox") / f"{name}.db")
     try:
         configured.parent.mkdir(parents=True, exist_ok=True)
         if not os.access(configured.parent, os.W_OK):
             raise OSError
         path = str(configured)
     except OSError:
-        fallback = Path.home() / ".protoagent" / "inbox" / f"{name}.db"
+        fallback = scope_leaf(Path.home() / ".protoagent" / "inbox" / f"{name}.db")
         fallback.parent.mkdir(parents=True, exist_ok=True)
         path = str(fallback)
     try:
@@ -462,13 +481,13 @@ def _build_workflow_registry(config):
         if bundled.is_dir():
             dirs.append(str(bundled))
         # Writable dir for user / agent-emitted recipes (same fallback shape).
-        writable = Path(config.workflow_dir).expanduser()
+        writable = scope_leaf(Path(config.workflow_dir).expanduser())
         try:
             writable.mkdir(parents=True, exist_ok=True)
             if not os.access(writable, os.W_OK):
                 raise OSError
         except OSError:
-            writable = Path.home() / ".protoagent" / "workflows"
+            writable = scope_leaf(Path.home() / ".protoagent" / "workflows")
             writable.mkdir(parents=True, exist_ok=True)
         dirs.append(str(writable))
         return WorkflowRegistry(dirs, writable_dir=str(writable))
@@ -488,10 +507,12 @@ def _resolve_skills_db(configured: str) -> str:
     try:
         candidate.parent.mkdir(parents=True, exist_ok=True)
         if os.access(candidate.parent, os.W_OK):
-            return str(candidate)
+            scoped = scope_leaf(candidate)
+            scoped.parent.mkdir(parents=True, exist_ok=True)
+            return str(scoped)
     except OSError:
         pass
-    fallback = Path.home() / ".protoagent" / "skills.db"
+    fallback = scope_leaf(Path.home() / ".protoagent" / "skills.db")
     fallback.parent.mkdir(parents=True, exist_ok=True)
     return str(fallback)
 

--- a/tests/test_instance_scoping.py
+++ b/tests/test_instance_scoping.py
@@ -1,0 +1,96 @@
+"""Tests for multi-instance data scoping + scheduler interlock (ADR 0004)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import paths
+from scheduler.local import (
+    LocalScheduler,
+    _acquire_jobs_lock,
+    _release_jobs_lock,
+)
+
+
+# ── scope_leaf ───────────────────────────────────────────────────────────────
+
+
+def test_scope_leaf_is_noop_without_instance(monkeypatch):
+    monkeypatch.delenv("PROTOAGENT_INSTANCE", raising=False)
+    assert str(paths.scope_leaf("/sandbox/checkpoints.db")) == "/sandbox/checkpoints.db"
+    assert str(paths.scope_leaf("/sandbox/knowledge/agent.db")) == "/sandbox/knowledge/agent.db"
+
+
+def test_scope_leaf_nests_under_instance(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
+    assert str(paths.scope_leaf("/sandbox/checkpoints.db")) == "/sandbox/alice/checkpoints.db"
+    assert str(paths.scope_leaf("/sandbox/knowledge/agent.db")) == "/sandbox/knowledge/alice/agent.db"
+    assert str(paths.scope_leaf("/sandbox/workflows")) == "/sandbox/alice/workflows"
+
+
+def test_scope_leaf_sanitizes_dangerous_ids(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "../../etc")
+    out = paths.scope_leaf("/sandbox/x.db")
+    # Path separators are flattened to a single segment, so the id can't escape
+    # the intended directory (no "/" in the inserted segment).
+    assert out == __import__("pathlib").Path("/sandbox/.._.._etc/x.db")
+    assert "/" not in out.parent.name  # single sanitized segment
+    assert out.parts[:2] == ("/", "sandbox")  # stays under the base
+
+
+def test_two_instances_get_disjoint_paths(monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
+    a = str(paths.scope_leaf("/sandbox/checkpoints.db"))
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "bob")
+    b = str(paths.scope_leaf("/sandbox/checkpoints.db"))
+    assert a != b
+
+
+# ── scheduler resolver honors the instance id ────────────────────────────────
+
+
+def test_scheduler_db_path_nests_under_instance(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
+    monkeypatch.setenv("SCHEDULER_DB_DIR", str(tmp_path))
+    from scheduler.local import _resolve_db_path
+
+    p = _resolve_db_path(None, "myagent")
+    # .../alice/myagent/jobs.db — instance segment present, agent segment present
+    assert "alice" in p.parts and "myagent" in p.parts and p.name == "jobs.db"
+
+
+# ── owner-lock interlock ─────────────────────────────────────────────────────
+
+
+def test_jobs_lock_excludes_a_second_holder(tmp_path):
+    db = tmp_path / "jobs.db"
+    first = _acquire_jobs_lock(db)
+    assert first is not None
+    assert _acquire_jobs_lock(db) is None  # second holder refused
+    _release_jobs_lock(db, first)
+    again = _acquire_jobs_lock(db)
+    assert again is not None  # available after release
+    _release_jobs_lock(db, again)
+
+
+def test_second_scheduler_on_same_db_does_not_start_polling(tmp_path):
+    async def run():
+        a = LocalScheduler("agentA", invoke_url="http://127.0.0.1:7870", db_dir=str(tmp_path))
+        b = LocalScheduler("agentA", invoke_url="http://127.0.0.1:7871", db_dir=str(tmp_path))
+        assert a.path == b.path  # same jobs.db (same agent + dir)
+        await a.start()
+        await b.start()  # interlock: b must NOT start a poll task
+        started = (a._task is not None, b._task is not None)
+        await a.stop()
+        await b.stop()
+        # After A releases, a fresh scheduler can claim it.
+        c = LocalScheduler("agentA", invoke_url="http://127.0.0.1:7872", db_dir=str(tmp_path))
+        await c.start()
+        c_started = c._task is not None
+        await c.stop()
+        return started, c_started
+
+    (a_started, b_started), c_started = asyncio.run(run())
+    assert a_started is True
+    assert b_started is False
+    assert c_started is True


### PR DESCRIPTION
## What

Implements [ADR 0004](../blob/main/docs/adr/0004-multi-instance-data-scoping.md) — lets several protoAgent instances share one filesystem without clobbering each other's on-disk state. **Opt-in and zero-migration**: an unset id keeps today's exact paths, and one-container-per-instance (each with its own `/sandbox`) is unaffected.

## How

- **`paths.py`** — `scope_leaf(path)` inserts the instance id as the leaf's parent dir (a **no-op when unset**), applied *after* each resolver's writable-fallback choice so the segment survives the `/sandbox`→`~/.protoagent` fallback. Instance id comes from `PROTOAGENT_INSTANCE` env or the new `instance_id` config field, seeded into the env at init so the env-reading stores honor it too.
- **Scoped every store resolver**: checkpoints, skills, workflows, inbox (`server.py`), knowledge (`knowledge/store.py`), scheduler (`scheduler/local.py`), memory (`graph/middleware/memory.py`).
- **Scheduler owner-lock interlock** — `start()` takes an exclusive `flock` on `jobs.db` (+ an in-process guard); if another live instance owns it, it logs a loud error and **skips the scheduler** rather than silently racing. The bug this prevents: two instances sharing a `jobs.db` both poll, and a due job is fired by whichever ticks first while the other never sees it (exactly what we hit earlier).

Scoping is opt-in via the env/config id **only** — deliberately *not* auto-derived from a non-default agent name, which would silently move existing data and break zero-migration.

## Tests / docs

- `tests/test_instance_scoping.py` — `scope_leaf` no-op / nest / sanitize / disjoint, scheduler path nesting, owner-lock excludes a second holder, and a second scheduler on a shared db doesn't poll (but a fresh one can after release).
- **776 pytest green**; docs build clean.
- **Live-verified** across three processes: the default instance keeps its legacy paths; a second same-id instance hits the interlock (scheduler skipped, server still 200); a `PROTOAGENT_INSTANCE=alice` instance gets its own scoped `jobs.db` and `~/.protoagent/alice/` root.
- Docs: new **"Run multiple instances"** guide (leads with containers as the isolation boundary) + ADR 0004 marked implemented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)