### PR TITLE
Fix right-panel tab overflow with 3+ tabs

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1458,22 +1458,34 @@ textarea {
 .segmented {
   height: 34px;
   display: grid;
-  grid-template-columns: 1fr 1fr;
+  /* Equal-width columns for any number of tabs (2, 3, …) — avoids overflow
+     when a tab is added. (Pattern shared with pwnDeck's right panel.) */
+  grid-auto-flow: column;
+  grid-auto-columns: 1fr;
   border: 1px solid var(--border);
   border-radius: var(--radius);
   overflow: hidden;
 }
 
 .segmented button {
+  position: relative; /* anchor for an absolutely-positioned tab badge */
   display: inline-flex;
   align-items: center;
   justify-content: center;
   gap: 6px;
+  min-width: 0;
+  padding: 0 4px;
+  font-size: 12px;
+  white-space: nowrap;
   border: 0;
   border-right: 1px solid var(--border);
   background: transparent;
   color: var(--fg-muted);
   cursor: pointer;
+}
+
+.segmented button svg {
+  flex: 0 0 auto;
 }
 
 .segmented button:last-child {


### PR DESCRIPTION
## What

The right-sidebar tab row overflowed once the **Inbox** tab joined Notes + Beads — the `.segmented` control hardcoded `grid-template-columns: 1fr 1fr` (exactly two columns), so the third tab spilled.

## Fix

Switch to `grid-auto-flow: column; grid-auto-columns: 1fr` so **any** number of tabs split the width equally, with `min-width: 0` / tight padding / `nowrap` on the buttons — the same pattern **pwnDeck** uses for its 3-tab right panel (notes/beads/engagement). Also marks `.segmented button` `position: relative` so the Inbox unread badge anchors to its own tab.

## Verified

- Live measurement on the running console: 3 tabs render equal-width (118px each), `scrollWidth (354) == clientWidth (354)` → no overflow.
- 30 e2e green (the suite clicks every tab).

(Reference: `protoLabsAI/pwnDeck` `apps/web/src/app/theme.css` `.segmented`.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)