### PR TITLE
Flip lingering tool cards to done when a turn completes

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -233,6 +233,16 @@ function scenarioFor(prompt) {
         { id: "task-1", name: "task", phase: "end", output: "Subagent finished: found 1 result." },
       ],
     };
+  if (t.includes("NOEND"))
+    // A tool whose `end` frame never arrives (e.g. a workflow card whose end
+    // races with the terminal `done`). The turn still completes — the client
+    // must flip the lingering card running→done, not spin forever.
+    return {
+      answer: "Workflow finished.",
+      events: [
+        { id: "wf-1", name: "workflow:research-and-brief", phase: "start", input: JSON.stringify({ topic: "quantum computing" }) },
+      ],
+    };
   if (t.includes("TOOLERR"))
     return { name: "web_search", input: { query: "x" }, output: "Error: DuckDuckGo search failed: rate limited", answer: "Search failed." };
   if (t.includes("OVERFLOW"))

--- a/apps/web/e2e/tool-renderers.spec.ts
+++ b/apps/web/e2e/tool-renderers.spec.ts
@@ -71,3 +71,21 @@ test("scalar input values render inline, objects as key/value fields", async ({ 
   await expect(body.locator(".tool-kv-key", { hasText: "url" })).toBeVisible();
   await expect(body.locator(".tool-kv-val a.tool-link")).toHaveAttribute("href", "https://example.com");
 });
+
+test("a tool whose end frame never arrives still finishes when the turn completes", async ({ page }) => {
+  // Reproduces the workflow "spun on active" bug: a tool_start with no tool_end
+  // (end raced the terminal done). The card must flip running→done, not spin.
+  await page.goto("/app/", { waitUntil: "load" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+  await composer.fill("NOEND run the workflow");
+  await composer.press("Enter");
+
+  const card = page.locator(".tool-card").first();
+  await expect(card).toBeVisible();
+  // The assistant's final text arrives (turn completed).
+  await expect(page.getByText("Workflow finished.")).toBeVisible();
+  // The card resolved to done — no lingering spinner.
+  await expect(card).toHaveClass(/tool-card-done/);
+  await expect(card.locator(".tool-card-status.running")).toHaveCount(0);
+});

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -245,11 +245,26 @@ function ChatSessionSlot({
         onDone: () => {
           const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
           if (!latest) return;
+          const now = Date.now();
           chatStore.updateMessages(
             session.id,
-            latest.messages.map((message) =>
-              message.id === assistantId ? { ...message, status: "done" } : message,
-            ),
+            latest.messages.map((message) => {
+              if (message.id !== assistantId) return message;
+              // A completed turn can't have tools still running: a tool_end frame
+              // that races with the terminal `done` (e.g. a workflow card whose
+              // end arrives in the same tick) would otherwise leave the card
+              // spinning forever. Flip any lingering `running` cards to `done`.
+              const toolCalls = message.toolCalls?.map((c) =>
+                c.status === "running"
+                  ? {
+                      ...c,
+                      status: "done" as const,
+                      durationMs: c.durationMs ?? (c.startedAt !== undefined ? now - c.startedAt : undefined),
+                    }
+                  : c,
+              );
+              return { ...message, status: "done", toolCalls };
+            }),
           );
         },
       });


### PR DESCRIPTION
## What

Fixes the workflow slash command (and Workflows surface) appearing to **"hang on active"** — reported running `/research-and-brief quantum computing`.

## Root cause (not a backend hang)

The workflow itself runs fine: I reproduced `research-and-brief` server-side and it returns in **~8s** with all 3 steps and `failed: []`. The hang was purely visual — the **tool card stayed spinning forever**.

Tracing the A2A stream showed the turn reaches `completed`, but only the `('start', 'workflow:research-and-brief')` tool phase is delivered — the **`tool_end` frame races with the terminal `done`** (the handler emits the completed status without a trailing tool-end DataPart). `ChatSurface.onDone` marked the *message* done but left the card in `running`, so it spun indefinitely even though the answer had arrived.

## Fix

`onDone` now flips any still-`running` tool calls to `done` (stamping duration from `startedAt`). A completed turn can't have a tool still running — a **general guard**, so any tool whose end frame is dropped/raced resolves cleanly, not just workflows.

## Tests

- New e2e `NOEND` scenario: a `tool_start` with **no** `tool_end`. Asserts that once the turn completes, the card is `tool-card-done` with **no** running spinner. (Fails without the fix.)
- **31 e2e green**; web build clean.

## Follow-up (not in this PR)

The workflow emits one opaque card for the whole run. Per-step progress (gather → angles → brief) would be a nicer UX for longer workflows — worth doing separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)