### PR TITLE
Stream per-step workflow progress + sharpen the brief recipe

### DIFF
--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -71,6 +71,10 @@ output instead of a normal model reply. Arguments map to the recipe's inputs:
 
 Missing a required input returns a `⚠️`-prefixed error naming it.
 
+Each step streams its own tool card (e.g. `research-and-brief · gather` →
+`· angles` → `· brief`) so a multi-step workflow shows live progress instead of
+one opaque card.
+
 ## From the operator console
 
 The React console has a **Workflows** surface (the rail icon next to Subagents).

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -286,11 +286,17 @@ async def run_manual_workflow(
     scheduler=None,
     name: str,
     inputs: dict | None = None,
+    on_step=None,
 ) -> dict:
     """Run a saved workflow recipe outside the lead agent's tool (operator UI).
 
     Returns the engine result ``{"output", "steps", "failed"}``. Raises
     ``ValueError`` for an unknown / invalid recipe or missing required inputs.
+
+    ``on_step`` (optional async callback) is invoked with
+    ``{"phase": "start"|"end", "step_id", "subagent", "output"?}`` around each
+    step so a caller can stream per-step progress (e.g. the chat slash command's
+    tool cards). Errors in the callback never interrupt the run.
     """
     from graph.workflows.engine import execute_workflow, resolve_inputs, validate_recipe
 
@@ -306,8 +312,17 @@ async def run_manual_workflow(
     if missing:
         raise ValueError(f"missing required input(s): {', '.join(missing)}")
 
+    async def _emit(event: dict) -> None:
+        if on_step is None:
+            return
+        try:
+            await on_step(event)
+        except Exception:  # noqa: BLE001 — progress is best-effort, never fatal
+            pass
+
     async def _run_step(subagent_type: str, prompt: str, step_id: str) -> str:
-        return await run_manual_subagent(
+        await _emit({"phase": "start", "step_id": step_id, "subagent": subagent_type})
+        out = await run_manual_subagent(
             config,
             knowledge_store=knowledge_store,
             scheduler=scheduler,
@@ -315,6 +330,8 @@ async def run_manual_workflow(
             prompt=prompt,
             subagent_type=subagent_type,
         )
+        await _emit({"phase": "end", "step_id": step_id, "subagent": subagent_type, "output": out})
+        return out
 
     return await execute_workflow(
         recipe, resolved, run_step=_run_step, max_concurrency=config.subagent_max_concurrency,

--- a/server.py
+++ b/server.py
@@ -25,6 +25,7 @@ This is the main entry point. It:
 """
 
 import argparse
+import asyncio
 import json
 import logging
 import os
@@ -1211,15 +1212,18 @@ def _parse_workflow_command(message: str):
     return name, _parse_workflow_inputs(recipe, rest)
 
 
-async def _run_parsed_workflow(name: str, inputs: dict) -> str:
-    """Run a workflow command and format its output as the assistant reply."""
+async def _run_parsed_workflow(name: str, inputs: dict, *, on_step=None) -> str:
+    """Run a workflow command and format its output as the assistant reply.
+
+    ``on_step`` is forwarded to ``run_manual_workflow`` so the caller can stream
+    per-step progress (the chat path renders a tool card per step)."""
     from graph.agent import run_manual_workflow
 
     try:
         result = await run_manual_workflow(
             _graph_config, _workflow_registry,
             knowledge_store=_knowledge_store, scheduler=_scheduler,
-            name=name, inputs=inputs,
+            name=name, inputs=inputs, on_step=on_step,
         )
     except ValueError as exc:
         return f"⚠️ {exc}"
@@ -1286,15 +1290,43 @@ async def _chat_langgraph_stream(
                     return
 
             # Workflow slash command (/<workflow-name> …) short-circuits the turn:
-            # run the recipe and return its output. A tool_start/end pair renders
-            # a card so the operator sees it running.
+            # run the recipe and return its output. Each step renders its own
+            # tool card (gather → angles → brief) so a multi-step workflow shows
+            # live progress instead of one opaque card that looks hung.
             parsed = _parse_workflow_command(message)
             if parsed is not None:
                 wf_name, wf_inputs = parsed
-                tool_id = f"workflow:{wf_name}"
-                yield ("tool_start", {"id": tool_id, "name": tool_id, "input": _coerce_tool_value(wf_inputs)})
-                wf_out = await _run_parsed_workflow(wf_name, wf_inputs)
-                yield ("tool_end", {"id": tool_id, "name": tool_id, "output": wf_out[:300]})
+                _WF_DONE = object()
+                step_q: asyncio.Queue = asyncio.Queue()
+
+                async def _on_step(event: dict) -> None:
+                    await step_q.put(event)
+
+                async def _runner() -> str:
+                    try:
+                        return await _run_parsed_workflow(wf_name, wf_inputs, on_step=_on_step)
+                    finally:
+                        await step_q.put(_WF_DONE)
+
+                runner = asyncio.create_task(_runner())
+                # An umbrella card for the whole workflow, then one per step.
+                yield ("tool_start", {"id": f"workflow:{wf_name}", "name": f"workflow:{wf_name}",
+                                      "input": _coerce_tool_value(wf_inputs)})
+                while True:
+                    event = await step_q.get()
+                    if event is _WF_DONE:
+                        break
+                    sid = event.get("step_id", "")
+                    step_tool_id = f"workflow:{wf_name}:{sid}"
+                    label = f"{wf_name} · {sid}"
+                    if event.get("phase") == "start":
+                        yield ("tool_start", {"id": step_tool_id, "name": label,
+                                              "input": event.get("subagent", "")})
+                    else:
+                        yield ("tool_end", {"id": step_tool_id, "name": label,
+                                            "output": extract_output(event.get("output", "")) or event.get("output", "")})
+                wf_out = await runner
+                yield ("tool_end", {"id": f"workflow:{wf_name}", "name": f"workflow:{wf_name}", "output": wf_out[:300]})
                 yield ("done", wf_out)
                 return
 

--- a/workflows/research-and-brief.yaml
+++ b/workflows/research-and-brief.yaml
@@ -29,10 +29,14 @@ steps:
     subagent: researcher
     depends_on: [gather, angles]
     prompt: |
-      Write a concise, cited brief on {{inputs.topic}}.
-      Use this research:
+      Write the final brief on {{inputs.topic}} now — this is the deliverable,
+      not a plan. Produce 3–4 short paragraphs of prose (NOT a list of angles),
+      opening with a one-sentence takeaway, with inline source citations.
+      Develop the angles below into the narrative; don't just restate them.
+
+      Research:
       {{steps.gather.output}}
 
-      Cover these angles:
+      Angles to weave in:
       {{steps.angles.output}}
 output: "{{steps.brief.output}}"


### PR DESCRIPTION
## What

Follow-ups to the workflow "looks hung" report: make a multi-step workflow **visibly advance** in chat, and fix the brief recipe that was echoing angles instead of writing a brief.

## Per-step progress

A workflow slash command used to emit **one opaque tool card** for the whole run — during the (seconds-to-minutes) execution it looked stuck. Now each step renders its **own card** (`research-and-brief · gather` → `· angles` → `· brief`) under an umbrella `workflow:<name>` card.

- `run_manual_workflow` gains an optional `on_step` async callback (`{phase, step_id, subagent, output?}`), best-effort.
- The chat slash path runs the workflow on a task and drains a step queue, yielding `tool_start`/`tool_end` per step (output cleaned via `extract_output`). #358's `onDone` guard flips any card whose `end` races the terminal `done`.
- **Bug fixed:** `server.py` now imports `asyncio` at module scope — the new stream block used `asyncio.Queue`/`create_task` and hit a runtime `NameError` (no test covers `_chat_langgraph_stream`'s workflow branch; caught by a live A2A smoke).

## Brief recipe

`research-and-brief.yaml`'s brief step now explicitly asks for **prose** (a one-sentence takeaway + 3–4 cited paragraphs, *not* a list of angles, developing the angles rather than restating them).

## Verified live (isolated `PROTOAGENT_INSTANCE=wftest` instance)

- SSE carries the umbrella + `gather`/`angles`/`brief` start/end cards in order; turn completes.
- Brief step now returns cited prose: *"Quantum computing represents a fundamental departure… qubits exploit superposition and entanglement… (ibm.com; scientificamerican.com)"* — no longer an angles list.
- 776 pytest green; docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)