### PR TITLE
A2A: per-transition progress webhooks + streaming/push conformance

### DIFF
--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -764,7 +764,11 @@ async def _deliver_webhook(record: TaskRecord, push_config: PushNotificationConf
 
     headers = {"Content-Type": "application/json"}
     if push_config.token:
+        # Authorization: Bearer (broad compat) + the spec-canonical
+        # X-A2A-Notification-Token header so a strict receiver can validate the
+        # notification belongs to a config it created (A2A push-notification spec).
         headers["Authorization"] = f"Bearer {push_config.token}"
+        headers["X-A2A-Notification-Token"] = push_config.token
 
     backoff = [1, 3, 9]
     async with httpx.AsyncClient(timeout=10) as client:
@@ -814,20 +818,72 @@ def _notify_terminal(record: TaskRecord) -> None:
         logger.exception("[a2a] terminal hook failed for task %s", record.id)
 
 
+# Coalescing for progress webhooks (A2A spec: fire on transitions the caller
+# cares about). SSE subscribers get every per-tool status update; webhook
+# consumers get the same progress but throttled to at most one POST per
+# _PUSH_MIN_INTERVAL_S (latest state), so a burst of tool events can't storm a
+# webhook. Terminal transitions always flush immediately.
+_PUSH_MIN_INTERVAL_S = 1.5
+_push_last: dict[str, float] = {}            # task_id → loop time of last delivery
+_push_trailing: dict[str, asyncio.Task] = {}  # task_id → scheduled trailing send
+
+
+def _spawn_webhook(record: TaskRecord, cfg: PushNotificationConfig) -> None:
+    task = asyncio.create_task(_deliver_webhook(record, cfg))
+    _pending_webhook_tasks.add(task)
+    task.add_done_callback(_pending_webhook_tasks.discard)
+
+
 async def _push(record: TaskRecord) -> None:
-    """Fire webhook delivery for *record* if a push config is currently
-    registered on it.
+    """Fire (or schedule) webhook delivery for *record*'s current state.
 
     Reads record.push_config at call time rather than closing over the
     submit-time value — otherwise a caller who registered a webhook via
     POST /tasks/{id}/pushNotificationConfigs *after* submitting would
     never receive any state transitions.
+
+    Non-terminal transitions (working / per-tool progress) are throttled to one
+    POST per ``_PUSH_MIN_INTERVAL_S`` carrying the latest state; terminal
+    transitions cancel any pending throttle and deliver immediately.
     """
     cfg = record.push_config
-    if cfg and record.state in _TERMINAL | {WORKING}:
-        task = asyncio.create_task(_deliver_webhook(record, cfg))
-        _pending_webhook_tasks.add(task)
-        task.add_done_callback(_pending_webhook_tasks.discard)
+    if cfg is None:
+        return
+
+    if record.state in _TERMINAL:
+        pending = _push_trailing.pop(record.id, None)
+        if pending is not None:
+            pending.cancel()
+        _push_last.pop(record.id, None)
+        _spawn_webhook(record, cfg)
+        return
+
+    loop = asyncio.get_running_loop()
+    now = loop.time()
+    last = _push_last.get(record.id, 0.0)
+    if now - last >= _PUSH_MIN_INTERVAL_S:
+        _push_last[record.id] = now
+        _spawn_webhook(record, cfg)
+        return
+
+    # Inside the throttle window — ensure a single trailing delivery is queued
+    # that will fire with whatever the latest state is when the window closes.
+    if record.id in _push_trailing and not _push_trailing[record.id].done():
+        return
+
+    async def _trailing() -> None:
+        try:
+            await asyncio.sleep(_PUSH_MIN_INTERVAL_S - (now - last))
+            cur = await _store.get(record.id)
+            if cur is not None and cur.push_config is not None and cur.state not in _TERMINAL:
+                _push_last[cur.id] = asyncio.get_running_loop().time()
+                _spawn_webhook(cur, cur.push_config)
+        except asyncio.CancelledError:
+            pass
+        finally:
+            _push_trailing.pop(record.id, None)
+
+    _push_trailing[record.id] = asyncio.create_task(_trailing())
 
 
 # ── Background task runner ────────────────────────────────────────────────────
@@ -875,12 +931,15 @@ async def _run_task_background(
                 else:
                     text = str(payload)
                     tool_event = None
-                await _store.update_state(
+                rec = await _store.update_state(
                     task_id, WORKING,
                     accumulated_text=accumulated,
                     status_message=text,
                     tool_event=tool_event,
                 )
+                # Mirror SSE per-tool progress to webhook consumers (throttled).
+                if rec is not None:
+                    await _push(rec)
 
             elif event_type == "delta":
                 # Worldstate-delta emitted by a tool that mutated shared state.
@@ -1073,6 +1132,7 @@ def register_a2a_routes(
     register_card_route: bool = True,
     auth_token: str = "",
     on_terminal: Callable[["TaskRecord"], None] | None = None,
+    card_provider: Callable[[str], dict] | None = None,
 ) -> None:
     """Register all A2A routes on *app* and update *agent_card* capabilities.
 
@@ -1523,6 +1583,16 @@ def register_a2a_routes(
             async with _store._lock:
                 record.push_config = None
             return _rpc_result(None)
+
+        # ── agent/getAuthenticatedExtendedCard ────────────────────────────────
+        # The request already passed _check_bearer_auth above, so the caller is
+        # authenticated; return the (extended) agent card. Falls back to the
+        # capability-mutated agent_card when no provider is wired.
+        if method == "agent/getAuthenticatedExtendedCard":
+            if card_provider is not None:
+                host = request.headers.get("host", "") or "localhost"
+                return _rpc_result(card_provider(host))
+            return _rpc_result(agent_card)
 
         return _rpc_error(-32601, f"Method not found: {method}")
 

--- a/docs/reference/a2a-endpoints.md
+++ b/docs/reference/a2a-endpoints.md
@@ -97,9 +97,25 @@ SSE stream of remaining frames for an in-flight task. Lets a consumer reconnect 
 
 Transitions the task to `canceled` if it's still running. No-op on terminal tasks.
 
+### `agent/getAuthenticatedExtendedCard`
+
+```json
+{"method": "agent/getAuthenticatedExtendedCard", "params": {}}
+```
+
+Returns the agent card to an authenticated caller (the request has already
+passed the bearer/api-key check). Same shape as the public
+`/.well-known/agent-card.json`.
+
 ### `tasks/pushNotificationConfig/{set,get,list,delete}`
 
-Register webhooks for terminal task delivery.
+Register webhooks so a non-streaming consumer is kept updated as work
+progresses. The agent POSTs to the webhook on **every meaningful transition the
+caller cares about** — the initial `working`, each per-tool progress step, and
+the terminal state — mirroring what SSE subscribers see. Non-terminal updates
+are **throttled** to at most one POST per ~1.5s (carrying the latest state) so a
+burst of tool events can't storm the webhook; terminal transitions flush
+immediately. The COMPLETED webhook also carries the terminal `artifact`.
 
 ```json
 {
@@ -121,7 +137,15 @@ The handler accepts both token shapes the A2A spec permits:
 | Top-level `token` (what `@a2a-js/sdk` serializes by default) | `{"url": "...", "token": "..."}` |
 | Structured `authentication.credentials` (RFC-8821) | `{"url": "...", "authentication": {"schemes": ["Bearer"], "credentials": "..."}}` |
 
-Both produce `Authorization: Bearer <token>` on outgoing webhook POSTs. When both are present, top-level wins.
+Both produce `Authorization: Bearer <token>` **and** the spec-canonical
+`X-A2A-Notification-Token: <token>` header on outgoing webhook POSTs, so a
+strict receiver can validate the notification belongs to a config it created.
+When both token shapes are present, top-level wins.
+
+Webhook payload: a `TaskStatusUpdateEvent` (the same envelope as the matching
+SSE `status-update` frame); the terminal/COMPLETED POST attaches the full
+`artifact`. Delivery retries 3× with exponential backoff (1s/3s/9s), skipping
+retry on 4xx.
 
 ## REST aliases
 

--- a/docs/reference/agent-card.md
+++ b/docs/reference/agent-card.md
@@ -105,6 +105,12 @@ MY_AGENT_API_KEY=sk-abc123...
 
 If the env var is unset, the API key check is skipped entirely — useful for local dev, not appropriate for production.
 
+When an A2A bearer token is configured (`auth.token` / `A2A_AUTH_TOKEN`), the
+card adds a `bearer` scheme **and** lists it in the `security` requirement
+alongside `apiKey` (`[{"apiKey": []}, {"bearer": []}]` — either is accepted), so
+a consumer reading the card actually learns bearer is an option rather than
+seeing only `apiKey`.
+
 ## Fork this file
 
 The card lives in `server.py::_build_agent_card`. The template ships a placeholder with one `chat` skill and the cost-v1 extension declared. At a minimum, every fork should replace:

--- a/server.py
+++ b/server.py
@@ -1548,12 +1548,26 @@ def agent_name() -> str:
     return AGENT_NAME_ENV
 
 
+def _bearer_configured() -> bool:
+    return bool(os.environ.get("A2A_AUTH_TOKEN", "") or (_graph_config and _graph_config.auth_token))
+
+
 def _build_security_schemes() -> dict:
     """Return securitySchemes dict, adding bearer only when A2A_AUTH_TOKEN is set."""
     schemes: dict = {"apiKey": {"type": "apiKey", "in": "header", "name": "X-API-Key"}}
-    if os.environ.get("A2A_AUTH_TOKEN", "") or (_graph_config and _graph_config.auth_token):
+    if _bearer_configured():
         schemes["bearer"] = {"type": "http", "scheme": "bearer"}
     return schemes
+
+
+def _build_security_requirements() -> list[dict]:
+    """The `security` array — which schemes a caller may use. Advertises bearer
+    (as an OR alternative) when a token is configured, so the served card
+    actually tells clients bearer is accepted, not just apiKey."""
+    reqs: list[dict] = [{"apiKey": []}]
+    if _bearer_configured():
+        reqs.append({"bearer": []})
+    return reqs
 
 
 def _package_version() -> str:
@@ -1665,7 +1679,7 @@ def _build_agent_card(host: str) -> dict:
             },
         ],
         "securitySchemes": _build_security_schemes(),
-        "security": [{"apiKey": []}],
+        "security": _build_security_requirements(),
     }
 
 
@@ -2300,6 +2314,7 @@ def _main():
         agent_card={},
         register_card_route=False,  # card is already served above
         on_terminal=_publish_activity_terminal,  # ADR 0003: surface Activity turns
+        card_provider=_build_agent_card,  # agent/getAuthenticatedExtendedCard
     )
 
     # --- Prometheus metrics -------------------------------------------------

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -427,6 +427,93 @@ async def test_push_retains_webhook_task_reference():
         assert task not in _pending_webhook_tasks
 
 
+@pytest.mark.asyncio
+async def test_deliver_webhook_includes_notification_token_header():
+    """Webhook carries both Authorization: Bearer and the spec-canonical
+    X-A2A-Notification-Token header so strict receivers can validate."""
+    from a2a_handler import _deliver_webhook
+
+    captured: dict = {}
+
+    class _Resp:
+        status_code = 200
+
+    class _Client:
+        def __init__(self, *a, **k):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *a):
+            return False
+
+        async def post(self, url, json=None, headers=None):
+            captured["headers"] = headers
+            return _Resp()
+
+    rec = _make_record(state=COMPLETED, accumulated_text="done")
+    cfg = PushNotificationConfig(url="https://example.com/hook", token="sek")
+    with patch("a2a_handler.httpx.AsyncClient", _Client):
+        await _deliver_webhook(rec, cfg)
+    assert captured["headers"]["Authorization"] == "Bearer sek"
+    assert captured["headers"]["X-A2A-Notification-Token"] == "sek"
+
+
+@pytest.mark.asyncio
+async def test_push_noop_without_config():
+    from a2a_handler import _push
+
+    calls = []
+
+    async def _deliver(r, cfg):
+        calls.append(r.state)
+
+    rec = _make_record(state=WORKING)  # no push_config
+    with patch("a2a_handler._deliver_webhook", _deliver):
+        await _push(rec)
+        await asyncio.sleep(0.02)
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_push_throttles_nonterminal_then_flushes_terminal(monkeypatch):
+    """Non-terminal transitions are throttled to one POST per window (latest
+    state, via a trailing send); a terminal transition flushes immediately."""
+    import a2a_handler as h
+
+    monkeypatch.setattr(h, "_PUSH_MIN_INTERVAL_S", 0.05)
+    h._push_last.clear()
+    h._push_trailing.clear()
+
+    calls: list[str] = []
+
+    async def _deliver(r, cfg):
+        calls.append(r.state)
+
+    rec = _make_record(state=WORKING)
+    rec.push_config = PushNotificationConfig(url="https://example.com/hook", token="t")
+    h._store._tasks[rec.id] = rec  # trailing send re-reads the record from the store
+
+    with patch("a2a_handler._deliver_webhook", _deliver):
+        await h._push(rec)            # leading edge → immediate
+        await asyncio.sleep(0.01)
+        await h._push(rec)            # within window → suppressed, trailing scheduled
+        await asyncio.sleep(0.01)
+        assert calls == [WORKING]     # only the immediate one so far
+
+        await asyncio.sleep(0.08)     # window closes → trailing fires with latest
+        assert calls == [WORKING, WORKING]
+
+        rec.state = COMPLETED         # terminal → immediate flush
+        await h._push(rec)
+        await asyncio.sleep(0.01)
+        assert calls == [WORKING, WORKING, COMPLETED]
+
+    h._push_last.clear()
+    h._push_trailing.clear()
+
+
 # ── Background task runner ────────────────────────────────────────────────────
 
 

--- a/tests/test_a2a_integration.py
+++ b/tests/test_a2a_integration.py
@@ -75,6 +75,18 @@ def test_agent_card_bearer_when_token_set(monkeypatch) -> None:
     assert "apiKey" in schemes, "apiKey scheme must always be present"
     assert "bearer" in schemes, "bearer must appear when A2A_AUTH_TOKEN is set"
     assert schemes["bearer"] == {"type": "http", "scheme": "bearer"}
+    # The `security` requirement must also list bearer (as an OR alternative),
+    # not just apiKey — otherwise the served card never tells clients bearer works.
+    reqs = card.get("security", [])
+    assert {"apiKey": []} in reqs and {"bearer": []} in reqs
+
+
+def test_agent_card_security_requirement_apikey_only_when_token_unset(monkeypatch) -> None:
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    from server import _build_agent_card
+
+    card = _build_agent_card("protoagent:7870")
+    assert card.get("security") == [{"apiKey": []}]
 
 
 def test_agent_card_declares_cost_v1_extension() -> None:

--- a/tests/test_a2a_tool_events.py
+++ b/tests/test_a2a_tool_events.py
@@ -283,3 +283,35 @@ async def test_message_stream_carries_tool_call_datapart():
     phases = {p["data"]["phase"] for p in tool_parts}
     assert names == {"current_time"}
     assert "start" in phases or "end" in phases
+
+
+@pytest.mark.asyncio
+async def test_get_authenticated_extended_card_returns_card():
+    """agent/getAuthenticatedExtendedCard returns the card from card_provider."""
+    from fastapi import FastAPI
+
+    app = FastAPI()
+
+    async def _fake_stream(text, session_id, **kw):
+        yield ("done", "ok")
+
+    register_a2a_routes(
+        app=app,
+        chat_stream_fn_factory=_fake_stream,
+        chat_fn=lambda *a, **k: [],
+        api_key="",
+        agent_card={},
+        card_provider=lambda host: {"name": "protoagent", "url": f"http://{host}/a2a", "capabilities": {"streaming": True}},
+    )
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        resp = await client.post("/a2a", json={
+            "jsonrpc": "2.0", "id": "c1",
+            "method": "agent/getAuthenticatedExtendedCard", "params": {},
+        })
+        assert resp.status_code == 200
+        result = resp.json()["result"]
+        assert result["name"] == "protoagent"
+        assert result["capabilities"]["streaming"] is True


### PR DESCRIPTION
## What

Audited the A2A server for streaming + push-notification spec conformance (with ORBIS and protoWorkstacean as reference comps), then closed the gaps that matter for **keeping A2A clients updated as work completes**.

**Verdict from the audit:** protoAgent's A2A was already strong — full `message/send`/`message/stream`/`tasks/get`/`cancel`/`resubscribe`, all four `pushNotificationConfig/*`, correct `kind`/`final`/`append`/`lastChunk`, SSRF guard, dual token shapes, and (unlike ORBIS) a card that honestly advertises `streaming`/`pushNotifications`. The real gaps were push granularity + a few conformance nits.

## Push progress (headline)

Webhook (push) consumers previously got only **first-working + terminal** — far coarser than SSE subscribers, who see per-tool progress. Now `_push` fires on **every meaningful transition** (initial `working`, each per-tool step, terminal), throttled to **one POST per ~1.5s** (latest state, via a trailing send) so a tool burst can't storm the webhook; terminal flushes immediately. This is what protoWorkstacean's own contract asks for ("fire on every transition the caller cares about").

## Conformance

- **`X-A2A-Notification-Token`** header on webhook POSTs (alongside `Authorization: Bearer`) — the spec-canonical validation header; Workstacean's callback already accepts both.
- **`agent/getAuthenticatedExtendedCard`** implemented (was `-32601`), via a `card_provider` from `server.py`.
- Served card **`security`** now lists `bearer` (as an OR alternative) when a token is configured — previously only `apiKey`, so consumers never learned bearer was accepted.

## Tests / docs

- `test_a2a_handler` (webhook token header; push throttle → immediate + coalesced trailing + terminal flush; push no-op without config), `test_a2a_integration` (card `security` lists bearer when token set), `test_a2a_tool_events` (extended-card route). **781 pytest green**; docs build clean.
- **Live-verified** (isolated instance + a local webhook receiver): a tool-running task delivered multiple throttled `working` webhooks **+** a terminal `completed` with the `artifact`, all carrying `X-A2A-Notification-Token`; `getAuthenticatedExtendedCard` returns the card.
- Docs: `a2a-endpoints` (push-on-every-transition, throttle, X-A2A-Notification-Token, extended-card method) + `agent-card` (bearer in the security requirement).

## Follow-up (separate PR, per your call)

Persist push configs to SQLite (24h TTL) so pending webhooks survive a restart — coming next. Deferred (your call): `input-required`/HITL (no consumer yet).

🤖 Generated with [Claude Code](https://claude.com/claude-code)