### PR TITLE
A2A: persist task records (durable across restart)

### DIFF
--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -147,6 +147,52 @@ class TaskRecord:
     _bg_task: asyncio.Task | None = field(default=None, repr=False)
 
 
+# ── Task record persistence (durable across restart) ──────────────────────────
+
+
+def _record_to_row(r: TaskRecord) -> dict:
+    """Serialize the durable subset of a TaskRecord (asyncio primitives skipped)."""
+    pc = r.push_config
+    return {
+        "id": r.id,
+        "context_id": r.context_id,
+        "state": r.state,
+        "created_at": r.created_at,
+        "updated_at": r.updated_at,
+        "message_text": r.message_text,
+        "accumulated_text": r.accumulated_text,
+        "error_message": r.error_message,
+        "push_config": ({"url": pc.url, "token": pc.token, "id": pc.id} if pc else None),
+        "deltas": r.deltas,
+        "usage": r.usage,
+        "confidence": r.confidence,
+        "confidence_explanation": r.confidence_explanation,
+    }
+
+
+def _row_to_record(row: dict) -> TaskRecord:
+    """Reconstruct a TaskRecord from a persisted row (fresh asyncio primitives)."""
+    pc = row.get("push_config")
+    return TaskRecord(
+        id=row["id"],
+        context_id=row.get("context_id", ""),
+        state=row.get("state", FAILED),
+        created_at=row.get("created_at", _now_iso()),
+        updated_at=row.get("updated_at", _now_iso()),
+        message_text=row.get("message_text", ""),
+        accumulated_text=row.get("accumulated_text", "") or "",
+        error_message=row.get("error_message"),
+        push_config=(
+            PushNotificationConfig(url=pc["url"], token=pc.get("token"), id=pc.get("id") or str(uuid4()))
+            if pc else None
+        ),
+        deltas=row.get("deltas") or [],
+        usage=row.get("usage") or {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0},
+        confidence=row.get("confidence"),
+        confidence_explanation=row.get("confidence_explanation"),
+    )
+
+
 # ── Task store ────────────────────────────────────────────────────────────────
 
 
@@ -172,14 +218,37 @@ class A2ATaskStore:
         self._lock = asyncio.Lock()
         self._tasks: dict[str, TaskRecord] = {}
         self._cleanup_task: asyncio.Task | None = None
+        self._persist = None  # optional A2ATaskPersistence (durable across restart)
+
+    def attach_persistence(self, persistence) -> None:
+        self._persist = persistence
+
+    def _save(self, record: TaskRecord) -> None:
+        if self._persist is None:
+            return
+        try:
+            self._persist.save(_record_to_row(record))
+        except Exception:  # noqa: BLE001 — durability is best-effort, never fatal
+            logger.exception("[a2a] failed to persist task %s", record.id)
 
     async def create(self, record: TaskRecord) -> TaskRecord:
         async with self._lock:
             self._tasks[record.id] = record
+        self._save(record)
         return record
 
     async def get(self, task_id: str) -> TaskRecord | None:
-        return self._tasks.get(task_id)
+        record = self._tasks.get(task_id)
+        if record is not None:
+            return record
+        # Cache miss — lazy-load from the durable store (survives eviction +
+        # restart) so tasks/get and tasks/resubscribe still answer.
+        if self._persist is not None:
+            row = self._persist.get(task_id)
+            if row is not None:
+                record = _row_to_record(row)
+                self._tasks[task_id] = record
+        return record
 
     async def update_state(
         self,
@@ -213,6 +282,11 @@ class A2ATaskStore:
             record._update_event = asyncio.Event()
         # Wake subscribers outside the lock so they can re-acquire it
         old_event.set()
+        # Persist terminal state (final text + artifact inputs) so tasks/get
+        # answers after eviction/restart. Intermediate states aren't persisted —
+        # the in-memory runner is the source of truth while a task is live.
+        if state in _TERMINAL:
+            self._save(record)
         return record
 
     async def cancel(self, task_id: str) -> bool:
@@ -302,6 +376,7 @@ class A2ATaskStore:
             old_event = record._update_event
             record._update_event = asyncio.Event()
         old_event.set()
+        self._save(record)  # CANCELED is terminal — persist it
         record._cancel_event.set()
         if record._bg_task and not record._bg_task.done():
             record._bg_task.cancel()
@@ -1159,6 +1234,7 @@ def register_a2a_routes(
     on_terminal: Callable[["TaskRecord"], None] | None = None,
     card_provider: Callable[[str], dict] | None = None,
     push_store=None,
+    task_persistence=None,
 ) -> None:
     """Register all A2A routes on *app* and update *agent_card* capabilities.
 
@@ -1177,6 +1253,17 @@ def register_a2a_routes(
     # so mutations propagate to the closure below.
     _ON_TERMINAL[0] = on_terminal
     _PUSH_STORE[0] = push_store
+    if task_persistence is not None:
+        _store.attach_persistence(task_persistence)
+        try:
+            task_persistence.sweep_expired()
+            interrupted = task_persistence.fail_interrupted(
+                tuple(_TERMINAL), error="interrupted by server restart"
+            )
+            if interrupted:
+                logger.info("[a2a] marked %d interrupted task(s) failed on boot", interrupted)
+        except Exception:  # noqa: BLE001 — boot rehydrate is best-effort
+            logger.exception("[a2a] task persistence rehydrate failed")
 
     seed = (auth_token or os.environ.get("A2A_AUTH_TOKEN", "") or "").strip()
     _A2A_TOKEN[0] = seed or None

--- a/a2a_task_store.py
+++ b/a2a_task_store.py
@@ -1,0 +1,132 @@
+"""Durable persistence for A2A task records (A2A spec / ADR 0003).
+
+Pairs with the in-memory ``A2ATaskStore``: task records are written through to
+SQLite on create and on every terminal transition, so ``tasks/get`` /
+``tasks/resubscribe`` answer with the final state + artifacts even after the
+in-memory copy is evicted (1h) or the process restarts (within the 24h TTL).
+
+The actual *work* (the LangGraph background runner) does not survive a restart,
+so on boot any task still in a non-terminal state is marked ``failed`` — it
+would otherwise hang forever. The in-memory store lazy-loads a row from here on
+a cache miss.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_TTL_S = 24 * 60 * 60  # 24h, matching the push-config store
+
+
+class A2ATaskPersistence:
+    def __init__(self, db_path: str, *, ttl_s: int = _DEFAULT_TTL_S) -> None:
+        self.path = str(db_path)
+        self._ttl_s = ttl_s
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(self.path)
+        db.row_factory = sqlite3.Row
+        return db
+
+    def _init_db(self) -> None:
+        db = self._connect()
+        try:
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS tasks (
+                    task_id    TEXT PRIMARY KEY,
+                    state      TEXT NOT NULL,
+                    updated_at TEXT NOT NULL,
+                    data       TEXT NOT NULL
+                )
+                """
+            )
+            db.execute("CREATE INDEX IF NOT EXISTS ix_tasks_state ON tasks(state)")
+            db.commit()
+        finally:
+            db.close()
+
+    def save(self, row: dict) -> None:
+        """Upsert a serialized task record (``row`` must carry id/state/updated_at)."""
+        task_id = row.get("id")
+        if not task_id:
+            return
+        db = self._connect()
+        try:
+            db.execute(
+                "INSERT INTO tasks (task_id, state, updated_at, data) VALUES (?, ?, ?, ?) "
+                "ON CONFLICT(task_id) DO UPDATE SET state=excluded.state, "
+                "updated_at=excluded.updated_at, data=excluded.data",
+                (task_id, row.get("state", ""), row.get("updated_at", ""), json.dumps(row)),
+            )
+            db.commit()
+        finally:
+            db.close()
+
+    def get(self, task_id: str) -> dict | None:
+        db = self._connect()
+        try:
+            r = db.execute("SELECT data FROM tasks WHERE task_id = ?", (task_id,)).fetchone()
+        finally:
+            db.close()
+        if r is None:
+            return None
+        try:
+            return json.loads(r["data"])
+        except (ValueError, TypeError):
+            return None
+
+    def delete(self, task_id: str) -> None:
+        db = self._connect()
+        try:
+            db.execute("DELETE FROM tasks WHERE task_id = ?", (task_id,))
+            db.commit()
+        finally:
+            db.close()
+
+    def sweep_expired(self, *, now: datetime | None = None) -> int:
+        now = now or datetime.now(UTC)
+        cutoff = (now - timedelta(seconds=self._ttl_s)).isoformat()
+        db = self._connect()
+        try:
+            cur = db.execute("DELETE FROM tasks WHERE updated_at < ?", (cutoff,))
+            db.commit()
+            return cur.rowcount
+        finally:
+            db.close()
+
+    def fail_interrupted(self, terminal_states: tuple[str, ...], *, error: str, now: datetime | None = None) -> int:
+        """Mark any persisted non-terminal task as failed — its runner did not
+        survive the restart, so it would otherwise hang. Returns the count."""
+        now = now or datetime.now(UTC)
+        placeholders = ",".join("?" for _ in terminal_states)
+        db = self._connect()
+        try:
+            rows = db.execute(
+                f"SELECT task_id, data FROM tasks WHERE state NOT IN ({placeholders})",
+                terminal_states,
+            ).fetchall()
+            for row in rows:
+                try:
+                    data = json.loads(row["data"])
+                except (ValueError, TypeError):
+                    data = {"id": row["task_id"]}
+                data["state"] = "failed"
+                data["error_message"] = error
+                data["updated_at"] = now.isoformat()
+                db.execute(
+                    "UPDATE tasks SET state='failed', updated_at=?, data=? WHERE task_id=?",
+                    (data["updated_at"], json.dumps(data), row["task_id"]),
+                )
+            db.commit()
+            return len(rows)
+        finally:
+            db.close()

--- a/docs/reference/a2a-endpoints.md
+++ b/docs/reference/a2a-endpoints.md
@@ -81,6 +81,13 @@ Consumers must check `kind` before interpreting fields — without it, `@a2a-js/
 
 Returns the current state of a task. Use to poll when push notifications aren't wired.
 
+Task records are **persisted** (instance-scoped `a2a-tasks.db`, 24h TTL,
+write-through on create + every terminal transition), so `tasks/get` and
+`tasks/resubscribe` answer with the final state + artifacts even after the
+in-memory copy is evicted (1h) or the process restarts. The background *runner*
+doesn't survive a restart, so any task still non-terminal at boot is marked
+`failed` ("interrupted by server restart") rather than left hanging.
+
 ### `tasks/resubscribe`
 
 ```json
@@ -149,9 +156,7 @@ retry on 4xx.
 
 Registered configs are **persisted** (write-through to an instance-scoped
 `a2a-push.db`, 24h TTL) so they survive the task's terminal eviction and a
-process restart. Task *records* remain in-memory, so a restart still drops
-in-flight work — durable end-to-end resubscribe/redelivery would need task
-persistence too.
+process restart.
 
 ## REST aliases
 

--- a/server.py
+++ b/server.py
@@ -466,6 +466,28 @@ def _build_inbox_store(config):
         return None
 
 
+def _build_a2a_task_persistence():
+    """Durable A2A task-record store (survives restart/eviction, 24h TTL,
+    instance-scoped per ADR 0004). Best-effort; failure → tasks in-memory only."""
+    from a2a_task_store import A2ATaskPersistence
+
+    configured = scope_leaf(Path("/sandbox/a2a-tasks.db"))
+    try:
+        configured.parent.mkdir(parents=True, exist_ok=True)
+        if not os.access(configured.parent, os.W_OK):
+            raise OSError
+        path = str(configured)
+    except OSError:
+        fallback = scope_leaf(Path.home() / ".protoagent" / "a2a-tasks.db")
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        path = str(fallback)
+    try:
+        return A2ATaskPersistence(path)
+    except Exception:
+        log.exception("[a2a] failed to build task persistence at %s; tasks in-memory only", path)
+        return None
+
+
 def _build_a2a_push_store():
     """Durable A2A push-config store (A2A spec / ADR 0003). Path resolves like
     the other stores (/sandbox → ~/.protoagent fallback) and is instance-scoped
@@ -2342,6 +2364,7 @@ def _main():
         on_terminal=_publish_activity_terminal,  # ADR 0003: surface Activity turns
         card_provider=_build_agent_card,  # agent/getAuthenticatedExtendedCard
         push_store=_build_a2a_push_store(),  # durable push configs (24h TTL)
+        task_persistence=_build_a2a_task_persistence(),  # durable task records (24h TTL)
     )
 
     # --- Prometheus metrics -------------------------------------------------

--- a/tests/test_a2a_task_store.py
+++ b/tests/test_a2a_task_store.py
@@ -1,0 +1,109 @@
+"""Tests for durable A2A task-record persistence (A2A spec / ADR 0003)."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from a2a_handler import (
+    COMPLETED,
+    SUBMITTED,
+    WORKING,
+    A2ATaskStore,
+    PushNotificationConfig,
+    TaskRecord,
+    _now_iso,
+    _record_to_row,
+    _row_to_record,
+)
+from a2a_task_store import A2ATaskPersistence
+
+
+def _rec(**kw) -> TaskRecord:
+    now = _now_iso()
+    d = dict(id="t1", context_id="ctx", state=SUBMITTED, created_at=now,
+             updated_at=now, message_text="hi")
+    d.update(kw)
+    return TaskRecord(**d)
+
+
+# ── serialization ─────────────────────────────────────────────────────────────
+
+
+def test_record_roundtrip_preserves_durable_fields():
+    rec = _rec(
+        state=COMPLETED, accumulated_text="the answer",
+        usage={"input_tokens": 5, "output_tokens": 7, "total_tokens": 12},
+        confidence=0.9, deltas=[{"domain": "x", "op": "inc"}],
+        push_config=PushNotificationConfig(url="https://h/cb", token="sek", id="c1"),
+    )
+    back = _row_to_record(_record_to_row(rec))
+    assert back.id == "t1" and back.state == COMPLETED
+    assert back.accumulated_text == "the answer"
+    assert back.usage["total_tokens"] == 12
+    assert back.confidence == 0.9
+    assert back.deltas == [{"domain": "x", "op": "inc"}]
+    assert back.push_config.url == "https://h/cb" and back.push_config.token == "sek"
+
+
+# ── persistence layer ─────────────────────────────────────────────────────────
+
+
+def test_save_get_delete(tmp_path):
+    p = A2ATaskPersistence(str(tmp_path / "a2a-tasks.db"))
+    p.save(_record_to_row(_rec(id="t1", state=COMPLETED, accumulated_text="x")))
+    assert p.get("t1")["accumulated_text"] == "x"
+    p.delete("t1")
+    assert p.get("t1") is None
+
+
+def test_sweep_expired(tmp_path):
+    p = A2ATaskPersistence(str(tmp_path / "a2a-tasks.db"), ttl_s=60)
+    old = (datetime.now(UTC) - timedelta(seconds=120)).isoformat()
+    p.save({"id": "stale", "state": COMPLETED, "updated_at": old})
+    p.save(_record_to_row(_rec(id="fresh", state=COMPLETED)))
+    assert p.sweep_expired() == 1
+    assert p.get("stale") is None and p.get("fresh") is not None
+
+
+def test_fail_interrupted_marks_nonterminal(tmp_path):
+    p = A2ATaskPersistence(str(tmp_path / "a2a-tasks.db"))
+    p.save(_record_to_row(_rec(id="live", state=WORKING)))
+    p.save(_record_to_row(_rec(id="done", state=COMPLETED, accumulated_text="ok")))
+    n = p.fail_interrupted((COMPLETED, "failed", "canceled"), error="interrupted by server restart")
+    assert n == 1
+    assert p.get("live")["state"] == "failed"
+    assert p.get("live")["error_message"] == "interrupted by server restart"
+    assert p.get("done")["state"] == COMPLETED  # untouched
+
+
+# ── store integration ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_store_persists_on_create_and_terminal(tmp_path):
+    p = A2ATaskPersistence(str(tmp_path / "a2a-tasks.db"))
+    store = A2ATaskStore()
+    store.attach_persistence(p)
+    await store.create(_rec(id="t1", state=SUBMITTED))
+    assert p.get("t1")["state"] == SUBMITTED  # persisted on create
+    await store.update_state("t1", WORKING)
+    # WORKING is non-terminal → not re-persisted (still SUBMITTED on disk)
+    assert p.get("t1")["state"] == SUBMITTED
+    await store.update_state("t1", COMPLETED, accumulated_text="done")
+    assert p.get("t1")["state"] == COMPLETED  # terminal persisted
+    assert p.get("t1")["accumulated_text"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_store_lazy_loads_from_disk_after_eviction(tmp_path):
+    p = A2ATaskPersistence(str(tmp_path / "a2a-tasks.db"))
+    p.save(_record_to_row(_rec(id="t1", state=COMPLETED, accumulated_text="recovered")))
+    store = A2ATaskStore()
+    store.attach_persistence(p)
+    assert "t1" not in store._tasks  # not in memory (e.g. evicted / post-restart)
+    got = await store.get("t1")
+    assert got is not None and got.state == COMPLETED
+    assert got.accumulated_text == "recovered"
+    assert "t1" in store._tasks  # cached back in


### PR DESCRIPTION
## What

Task records now survive in-memory eviction (1h) **and a process restart** — so `tasks/get` / `tasks/resubscribe` answer with the final state + artifacts afterward. Completes the A2A durability work (configs persisted in #365; this adds the tasks themselves), the remaining lever for cross-restart reliability.

## How

- **`a2a_task_store.py`** — `A2ATaskPersistence` (SQLite, 24h TTL, instance-scoped): `save`/`get`/`delete`, `sweep_expired`, `fail_interrupted`.
- **`a2a_handler.py`** — `_record_to_row`/`_row_to_record` (the durable field subset — asyncio primitives recreated fresh). `A2ATaskStore` writes through on **create + every terminal transition** (not intermediate WORKING/tool states — the in-memory runner is the source of truth while a task is live); `get()` lazy-loads from disk on a cache miss. Wired via `register_a2a_routes(task_persistence=…)`, which on boot **sweeps expired** and marks any persisted **non-terminal task `failed`** ("interrupted by server restart") — the background runner doesn't survive, so it would otherwise hang.
- **`server.py`** — `_build_a2a_task_persistence` (scoped path, `/sandbox`→`~/.protoagent` fallback).

## Tests / docs

- `test_a2a_task_store` — record roundtrip, save/get/delete, TTL sweep, `fail_interrupted`, store write-through (create + terminal, **not** intermediate), lazy-load-after-eviction. **794 pytest green**; docs build clean.
- **Live-verified**: a completed task persisted to `a2a-tasks.db`; after a full restart `tasks/get` returned `state=completed` **with its artifact**.
- Docs: `a2a-endpoints` `tasks/get` section (persistence + the interrupted→failed boot behavior).

## A2A durability — now complete

streaming ✓ · per-transition push (throttled) ✓ · `X-A2A-Notification-Token` ✓ · `getAuthenticatedExtendedCard` ✓ · push configs persisted ✓ · **task records persisted ✓**. Remaining spec gap: `input-required`/HITL multi-turn — next up (coordinated with Workstacean re-enabling it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)