### PR TITLE
A2A: human-in-the-loop — input-required pause + resume (ADR 0003)

### DIFF
--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -54,8 +54,13 @@ WORKING = "working"
 COMPLETED = "completed"
 FAILED = "failed"
 CANCELED = "canceled"
+INPUT_REQUIRED = "input-required"  # HITL: paused awaiting the caller's input (non-terminal)
 
 _TERMINAL = {COMPLETED, FAILED, CANCELED}
+# States that end the current SSE stream cycle: terminal states plus
+# input-required (the turn paused — the client must answer to resume). The
+# stream closes with final:true; the task is parked, not finished.
+_STREAM_CLOSING = _TERMINAL | {INPUT_REQUIRED}
 
 # MIME type for worldstate-delta-v1 artifacts. Workstacean's effect-domain
 # interceptor extracts any DataPart carrying this type on a terminal Task
@@ -283,9 +288,11 @@ class A2ATaskStore:
         # Wake subscribers outside the lock so they can re-acquire it
         old_event.set()
         # Persist terminal state (final text + artifact inputs) so tasks/get
-        # answers after eviction/restart. Intermediate states aren't persisted —
-        # the in-memory runner is the source of truth while a task is live.
-        if state in _TERMINAL:
+        # answers after eviction/restart, and input-required (a parked task must
+        # survive so the caller can resume it). Intermediate WORKING states
+        # aren't persisted — the in-memory runner is the source of truth while
+        # a task is actively running.
+        if state in _STREAM_CLOSING:
             self._save(record)
         return record
 
@@ -826,7 +833,7 @@ async def _deliver_webhook(record: TaskRecord, push_config: PushNotificationConf
     Retries 3× with exponential backoff (1s / 3s / 9s).
     Skips retry on 4xx (client error — retrying won't help).
     """
-    payload = _build_status_event(record, final=record.state in _TERMINAL)
+    payload = _build_status_event(record, final=record.state in _STREAM_CLOSING)
     if record.state == COMPLETED:
         parts = _terminal_artifact_parts(record)
         if parts:
@@ -950,7 +957,9 @@ async def _push(record: TaskRecord) -> None:
     if cfg is None:
         return
 
-    if record.state in _TERMINAL:
+    # Terminal AND input-required flush immediately (cancel any throttle): a
+    # parked task's question must reach the caller now so they can resume.
+    if record.state in _STREAM_CLOSING:
         pending = _push_trailing.pop(record.id, None)
         if pending is not None:
             pending.cancel()
@@ -1069,6 +1078,21 @@ async def _run_task_background(
                         explanation=payload.get("explanation"),
                     )
 
+            elif event_type == "input_required":
+                # HITL pause (ADR 0003): the agent called ask_human. Park the
+                # task as input-required carrying the question, close the stream
+                # cycle (final:true), and push immediately so a webhook caller
+                # can answer. The caller resumes via message/send on this taskId.
+                question = payload.get("question", "Input required.") if isinstance(payload, dict) else str(payload)
+                record = await _store.update_state(
+                    task_id, INPUT_REQUIRED,
+                    accumulated_text=accumulated,
+                    status_message=question,
+                )
+                if record is not None:
+                    await _push(record)
+                return
+
             elif event_type == "done":
                 record = await _store.update_state(
                     task_id,
@@ -1163,7 +1187,7 @@ async def _watch_task(
         last_sent_len = len(record.accumulated_text)
         yield ("text_delta", record, delta)
 
-    if record.state in _TERMINAL:
+    if record.state in _STREAM_CLOSING:
         return
 
     while True:
@@ -1188,7 +1212,7 @@ async def _watch_task(
             last_sent_len = len(r.accumulated_text)
             yield ("text_delta", r, delta)
 
-        if r.state in _TERMINAL:
+        if r.state in _STREAM_CLOSING:
             return
 
 
@@ -1372,6 +1396,29 @@ def register_a2a_routes(
         logger.info("[a2a] task %s submitted (context=%s)", task_id, context_id)
         return record
 
+    async def _resume_task(task_id: str, text: str, caller_trace: dict | None = None):
+        """Resume a task parked at input-required, feeding the caller's answer
+        into the LangGraph interrupt (Command(resume=…)) on the same thread.
+
+        Returns the WORKING record, or None if the task isn't resumable (missing
+        or not input-required). The background runner picks up exactly where the
+        agent called ask_human and drives to a terminal — or another pause."""
+        record = await _store.get(task_id)
+        if record is None or record.state != INPUT_REQUIRED:
+            return None
+        ct = caller_trace or {}
+        ctx = record.context_id
+        await _store.update_state(task_id, WORKING)
+        bg = asyncio.create_task(
+            _run_task_background(
+                task_id,
+                lambda: chat_stream_fn_factory(text, ctx, resume=True, caller_trace=ct),
+            )
+        )
+        record._bg_task = bg
+        logger.info("[a2a] task %s resumed from input-required (context=%s)", task_id, ctx)
+        return await _store.get(task_id)
+
     # ── Streaming SSE generator ───────────────────────────────────────────────
 
     async def _stream_new_task(
@@ -1421,7 +1468,7 @@ def register_a2a_routes(
                     else:
                         yield _sse_rpc(
                             rpc_id,
-                            _build_status_event(r, final=r.state in _TERMINAL),
+                            _build_status_event(r, final=r.state in _STREAM_CLOSING),
                         )
 
                 elif kind == "text_delta":
@@ -1478,7 +1525,7 @@ def register_a2a_routes(
                     else:
                         yield _sse_rpc(
                             rpc_id,
-                            _build_status_event(r, final=r.state in _TERMINAL),
+                            _build_status_event(r, final=r.state in _STREAM_CLOSING),
                         )
                 elif kind == "text_delta":
                     if r.state not in _TERMINAL and payload:
@@ -1553,6 +1600,25 @@ def register_a2a_routes(
                     _check_origin(request)
                 except HTTPException as exc:
                     return JSONResponse({"detail": exc.detail}, status_code=exc.status_code)
+
+            # HITL resume (ADR 0003): a message carrying an existing taskId that's
+            # parked at input-required continues THAT task with the caller's
+            # answer (Command(resume=…)), rather than minting a fresh task. Any
+            # other taskId falls through to a normal new-task submit.
+            resume_task_id = message.get("taskId")
+            if resume_task_id:
+                existing = await _store.get(resume_task_id)
+                if existing is not None and existing.state == INPUT_REQUIRED:
+                    resumed = await _resume_task(resume_task_id, text, caller_trace)
+                    if resumed is None:
+                        return _rpc_error(-32002, f"Task not resumable: {resume_task_id}")
+                    if method == "message/send":
+                        return _rpc_result(_task_to_response(resumed))
+                    return StreamingResponse(
+                        _resubscribe_jsonrpc_stream(resume_task_id, rpc_id),
+                        media_type="text/event-stream",
+                        headers=_SSE_HEADERS,
+                    )
 
             if method == "message/send":
                 record = await _submit_task(text, context_id, push_config, caller_trace)

--- a/docs/reference/a2a-endpoints.md
+++ b/docs/reference/a2a-endpoints.md
@@ -68,7 +68,7 @@ Same as `message/send` but streams frames as the run progresses. One SSE event p
 | `kind` | When emitted |
 |---|---|
 | `task` | First frame — initial task state |
-| `status-update` | State transitions, tool-start / tool-end progress |
+| `status-update` | State transitions, tool-start / tool-end progress, and the `input-required` pause (with `final: true`) |
 | `artifact-update` | Streaming partial outputs |
 
 Consumers must check `kind` before interpreting fields — without it, `@a2a-js/sdk`'s `for await` loop silently skips frames.
@@ -95,6 +95,32 @@ doesn't survive a restart, so any task still non-terminal at boot is marked
 ```
 
 SSE stream of remaining frames for an in-flight task. Lets a consumer reconnect after a network blip without losing events.
+
+### Human-in-the-loop (`input-required`)
+
+The agent can pause mid-task to ask the operator a question — the spec's
+`input-required` flow (ADR 0003). It's driven by the lead-agent **`ask_human`**
+tool, which issues a LangGraph `interrupt()`; the graph checkpoints at that exact
+point.
+
+1. The task transitions to **`input-required`** — a `status-update` whose
+   `status.message` carries the question, with `final: true`, closing the SSE
+   cycle. The task is **not** terminal; it's parked (and persisted, so it
+   survives a restart). Webhook consumers get an immediate (un-throttled) push.
+2. The caller answers by sending a **`message/send`** (or `message/stream`)
+   carrying the **same `taskId`** (and `contextId`) with the reply as a text
+   part. protoAgent resumes the graph via `Command(resume=…)` from the
+   checkpoint — continuing exactly where `ask_human` paused — and drives to a
+   terminal state (or another `input-required`).
+
+```json
+{"method": "message/stream", "params": {
+  "message": {"taskId": "<parked-task-id>", "contextId": "<ctx>",
+              "parts": [{"kind": "text", "text": "approved"}]}}}
+```
+
+A message with no `taskId` (or one that isn't `input-required`) starts a fresh
+task as usual. The card advertises support via the `hitl-mode-v1` extension.
 
 ### `tasks/cancel`
 

--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -7,6 +7,7 @@ Sixteen tools ship by default:
 - Five **memory tools** — `memory_ingest`, `memory_recall`, `memory_list`, `memory_stats`, `daily_log` — bound to the bundled `KnowledgeStore` (sqlite + FTS5, see [Configuration](/reference/configuration#knowledge)).
 - Three **scheduler tools** — `schedule_task`, `list_schedules`, `cancel_schedule` — bound to the bundled scheduler backend (local sqlite or the Workstacean adapter, see [Schedule future work](/guides/scheduler)).
 - One **inbox tool** — `check_inbox` — bound to the durable inbound inbox (ADR 0003) when configured; pulls stimuli pushed to `POST /api/inbox`.
+- One **HITL tool** — `ask_human` — pauses the turn (A2A `input-required`) to ask the operator and resumes with their answer (lead-agent only).
 - Four **project-notes tools** — `notes_list`, `notes_read`, `notes_write`, `notes_revert` — bridge the operator console's Notes panel tabs to the agent, gated per-tab by the operator's Agent-read/write toggles; writes are versioned (undoable) and surface live in the panel.
 
 `get_all_tools(knowledge_store, scheduler)` is the registry. When `knowledge_store` is `None` the memory tools are omitted; when `scheduler` is `None` the scheduler tools are omitted. Both backends are constructed by default in `server.py`; opt out via `middleware.knowledge: false` / `middleware.scheduler: false` in `config/langgraph-config.yaml`.
@@ -202,6 +203,22 @@ async def cancel_schedule(job_id: str) -> str
 Cancel a scheduled job by id. Returns `"Canceled <id>."` or `"Error: no such job <id>."`.
 
 Cross-agent cancellation is blocked — `gina-personal` cannot cancel `gina-work`'s jobs even when sharing a sqlite path or a Workstacean install.
+
+## `ask_human`
+
+```python
+@tool
+def ask_human(question: str) -> str
+```
+
+Pause the turn and ask the human operator a question, then continue with their
+answer (human-in-the-loop, ADR 0003). Issues a LangGraph `interrupt()`, which
+checkpoints the graph at the call site; A2A callers see the task transition to
+`input-required` carrying the question, and resume it by sending a follow-up
+message with the same `taskId`. **Lead-agent only** — it's excluded from
+subagent allowlists, since the interrupt is resumed by the lead turn's runner.
+Use it only for a decision/input you genuinely must wait on (an approval, a
+missing fact), never for narration.
 
 ## `check_inbox`
 

--- a/server.py
+++ b/server.py
@@ -1144,7 +1144,7 @@ def _coerce_tool_output(value) -> str:
     return _coerce_tool_value(getattr(value, "content", value))
 
 
-async def _run_turn_stream(message: str, session_id: str, config: dict):
+async def _run_turn_stream(message: str, session_id: str, config: dict, *, resume_value=None):
     """Run one graph turn over ``astream_events``.
 
     Yields the same ``(kind, payload)`` status/usage frames the A2A handler
@@ -1152,13 +1152,25 @@ async def _run_turn_stream(message: str, session_id: str, config: dict):
     intercepts to get the turn's raw model text. Factored out so the initial
     turn, the dropped-scratch kicker retry, and goal-mode continuations all
     share one event loop instead of copy-pasting it.
+
+    When ``resume_value`` is given, the turn resumes a graph paused at an
+    ``ask_human`` interrupt (LangGraph HITL) by feeding ``Command(resume=…)``
+    instead of a fresh user message. If the turn pauses (the agent called
+    ``ask_human``), yields a terminal ``("input_required", {"question": …})``
+    frame instead of ``__raw__`` so the A2A layer can park the task (ADR 0003).
     """
     from langchain_core.messages import HumanMessage
+    from langgraph.types import Command
 
+    graph_input = (
+        Command(resume=resume_value)
+        if resume_value is not None
+        else {"messages": [HumanMessage(content=message)], "session_id": session_id}
+    )
     accumulated_raw = ""
     streamed_len = 0  # chars of visible <output> already emitted as text frames
     async for event in _graph.astream_events(
-        {"messages": [HumanMessage(content=message)], "session_id": session_id},
+        graph_input,
         config=config,
         version="v2",
     ):
@@ -1199,6 +1211,24 @@ async def _run_turn_stream(message: str, session_id: str, config: dict):
                     "input_tokens": int(usage.get("input_tokens", 0) or 0),
                     "output_tokens": int(usage.get("output_tokens", 0) or 0),
                 })
+
+    # HITL pause (ADR 0003): the agent called ask_human → LangGraph interrupt().
+    # The graph is checkpointed at the interrupt; surface the question so the A2A
+    # layer parks the task as input-required. Resume later with resume_value.
+    try:
+        snapshot = await _graph.aget_state(config)
+        pending = list(getattr(snapshot, "interrupts", None) or [])
+        if not pending:
+            for t in getattr(snapshot, "tasks", ()) or ():
+                pending.extend(getattr(t, "interrupts", ()) or ())
+    except Exception:
+        pending = []
+    if pending:
+        val = getattr(pending[0], "value", pending[0])
+        question = val.get("question") if isinstance(val, dict) else str(val)
+        yield ("input_required", {"question": question or "Input required."})
+        return
+
     yield ("__raw__", accumulated_raw)
 
 
@@ -1290,6 +1320,7 @@ async def _chat_langgraph_stream(
     session_id: str,
     *,
     caller_trace: dict | None = None,
+    resume: bool = False,
 ):
     """Async generator — yields (event_type, payload) tuples from the
     LangGraph run. Consumed by ``a2a_handler.register_a2a_routes`` to
@@ -1398,12 +1429,27 @@ async def _chat_langgraph_stream(
             # get progress from tool_start/tool_end). Final text is extracted
             # once via extract_output().
             accumulated_raw = ""
+            paused = False
             with goal_turn(goal_active):
-                async for kind, payload in _run_turn_stream(message, session_id, config):
+                async for kind, payload in _run_turn_stream(
+                    message, session_id, config,
+                    resume_value=(message if resume else None),
+                ):
                     if kind == "__raw__":
                         accumulated_raw = payload
+                    elif kind == "input_required":
+                        # Agent paused for human input — surface it and park the
+                        # turn; the A2A runner sets the task input-required and the
+                        # caller resumes via message/send on the same taskId.
+                        yield (kind, payload)
+                        paused = True
                     else:
                         yield (kind, payload)
+
+            # A paused turn produced no final answer — don't run the
+            # dropped-scratch kicker or goal verification; the task is parked.
+            if paused:
+                return
 
             final_text = extract_output(accumulated_raw)
             final_raw = accumulated_raw
@@ -1706,12 +1752,15 @@ def _build_agent_card(host: str) -> dict:
                 #     "uri": "https://proto-labs.ai/a2a/ext/blast-v1",
                 #     "params": {"skills": {"my_skill": {"radius": "self"}}},
                 # },
-                # hitl-mode-v1 — human-in-the-loop approval per skill
-                # (autonomous | notification). Composes with blast-v1:
-                # {
-                #     "uri": "https://proto-labs.ai/a2a/ext/hitl-mode-v1",
-                #     "params": {"skills": {"my_skill": {"mode": "autonomous"}}},
-                # },
+                # hitl-mode-v1 — the agent supports human-in-the-loop: it can
+                # pause a task as `input-required` (via the `ask_human` tool /
+                # LangGraph interrupt) and resume on a follow-up message to the
+                # same taskId. Add per-skill `params` once you've replaced the
+                # placeholder skill below — a consumer (e.g. Workstacean) reads
+                # them to gate execution (autonomous | notification | veto |
+                # gated | compound):
+                #   "params": {"skills": {"my_skill": {"mode": "gated"}}}
+                {"uri": "https://proto-labs.ai/a2a/ext/hitl-mode-v1"},
             ],
         },
         "defaultInputModes": ["text/plain"],

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -548,6 +548,52 @@ async def test_background_runner_success():
 
 
 @pytest.mark.asyncio
+async def test_background_runner_input_required_parks_task():
+    """An input_required event parks the task (non-terminal) carrying the
+    question, and pushes immediately — the HITL pause (ADR 0003)."""
+    from a2a_handler import INPUT_REQUIRED, _STREAM_CLOSING, _TERMINAL
+
+    assert INPUT_REQUIRED not in _TERMINAL  # parked, not finished
+    assert INPUT_REQUIRED in _STREAM_CLOSING  # but closes the stream cycle
+
+    store = A2ATaskStore()
+    await store.create(_make_record(id="bg-hitl"))
+    push_calls = []
+
+    async def _fake_push(r):
+        push_calls.append(r.state)
+
+    stream_fn = lambda: _mock_stream(
+        ("text", "thinking… "),
+        ("input_required", {"question": "Approve the merge?"}),
+        ("done", "should not reach"),  # runner must stop at input_required
+    )
+    with patch("a2a_handler._store", store), patch("a2a_handler._push", _fake_push):
+        await _run_task_background("bg-hitl", stream_fn)
+
+    rec = await store.get("bg-hitl")
+    assert rec.state == INPUT_REQUIRED
+    assert rec.last_status_message == "Approve the merge?"  # question retained
+    assert INPUT_REQUIRED in push_calls
+    assert COMPLETED not in push_calls  # the trailing done was never processed
+
+
+def test_status_event_final_on_input_required():
+    from a2a_handler import INPUT_REQUIRED, _build_status_event
+
+    rec = _make_record(id="q1", state=INPUT_REQUIRED)
+    rec.last_status_message = "What is the threshold?"
+    evt = _build_status_event(rec, final=True)
+    assert evt["kind"] == "status-update"
+    assert evt["status"]["state"] == "input-required"
+    assert evt["final"] is True
+    # The question rides in status.message (input-required isn't terminal, so
+    # the status message is preserved rather than cleared).
+    text = " ".join(p.get("text", "") for p in evt["status"]["message"]["parts"])
+    assert "threshold" in text
+
+
+@pytest.mark.asyncio
 async def test_background_runner_error():
     store = A2ATaskStore()
     record = _make_record(id="bg-err")

--- a/tests/test_a2a_tool_events.py
+++ b/tests/test_a2a_tool_events.py
@@ -315,3 +315,68 @@ async def test_get_authenticated_extended_card_returns_card():
         result = resp.json()["result"]
         assert result["name"] == "protoagent"
         assert result["capabilities"]["streaming"] is True
+
+
+@pytest.mark.asyncio
+async def test_input_required_round_trip_over_stream():
+    """HITL: a turn that pauses surfaces input-required + final:true; a follow-up
+    message with the same taskId resumes it to completed (ADR 0003)."""
+    from fastapi import FastAPI
+
+    from a2a_handler import _store
+
+    _store._tasks.clear()
+
+    # Fake producer: first turn pauses (ask_human), the resume turn completes.
+    async def _fake_stream(text, session_id, *, resume=False, caller_trace=None):
+        if resume:
+            yield ("done", f"answer: {text}")
+        else:
+            yield ("input_required", {"question": "What is your favorite color?"})
+
+    app = FastAPI()
+    register_a2a_routes(
+        app=app, chat_stream_fn_factory=_fake_stream, chat_fn=lambda *a, **k: [], api_key="", agent_card={},
+    )
+
+    async def _drive(client, params):
+        state = question = artifact = None
+        task_id = None
+        async with client.stream("POST", "/a2a", json={
+            "jsonrpc": "2.0", "id": "1", "method": "message/stream", "params": params,
+        }) as resp:
+            async for line in resp.aiter_lines():
+                if not line.startswith("data: "):
+                    continue
+                r = json.loads(line[6:]).get("result", {})
+                if r.get("kind") == "task":
+                    task_id = r.get("id")
+                st = (r.get("status") or {}).get("state")
+                if st:
+                    state = st
+                for p in ((r.get("status") or {}).get("message", {}) or {}).get("parts", []):
+                    if p.get("kind") == "text":
+                        question = p.get("text")
+                for a in (r.get("artifacts") or ([r["artifact"]] if r.get("artifact") else [])):
+                    for p in a.get("parts", []):
+                        if p.get("kind") == "text":
+                            artifact = p.get("text")
+        return task_id, state, question, artifact
+
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5.0,
+    ) as client:
+        tid, state, question, _ = await _drive(client, {
+            "contextId": "c", "message": {"parts": [{"kind": "text", "text": "ask me"}]},
+        })
+        assert state == "input-required"
+        assert question == "What is your favorite color?"
+
+        _, state2, _, artifact = await _drive(client, {
+            "contextId": "c",
+            "message": {"taskId": tid, "contextId": "c", "parts": [{"kind": "text", "text": "teal"}]},
+        })
+        assert state2 == "completed"
+        assert artifact == "answer: teal"
+
+    _store._tasks.clear()

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -54,6 +54,27 @@ from tools.fallbacks import with_fallback
 
 
 @tool
+def ask_human(question: str) -> str:
+    """Pause and ask the human operator a question, then continue with their answer.
+
+    Use this only when you genuinely need a human decision or a fact you cannot
+    determine yourself — an approval ("merge this PR?"), a missing input, or a
+    choice between options. The task pauses (surfaced to A2A callers as the
+    ``input-required`` state) until the operator answers; their reply is returned
+    from this call so you can continue. Do NOT use it for narration or status —
+    only for an answer you must wait on. Phrase ``question`` as a clear,
+    self-contained ask.
+    """
+    # LangGraph HITL: interrupt() checkpoints the graph at this exact point. On
+    # resume (Command(resume=answer)) it returns the operator's reply. Requires a
+    # checkpointer (bound at compile) — which protoAgent always has.
+    from langgraph.types import interrupt
+
+    answer = interrupt({"question": question})
+    return answer if isinstance(answer, str) else str(answer)
+
+
+@tool
 @with_fallback()
 async def current_time(timezone: str = "UTC") -> str:
     """Return the current wall-clock time in the given IANA timezone.
@@ -552,7 +573,11 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None):
     Pass ``None`` to disable either subsystem — the lead agent runs
     fine with just the four keyless general tools.
     """
-    tools = [current_time, calculator, web_search, fetch_url]
+    # ask_human is a lead-agent HITL tool — it pauses the A2A turn via a
+    # LangGraph interrupt that only the lead turn's runner resumes. Subagents
+    # (run outside that runner) must not get it, so it's gated by allowlist:
+    # present in the full set for the lead agent, absent from subagent allowlists.
+    tools = [current_time, calculator, web_search, fetch_url, ask_human]
     # GitHub read tools (PRs/issues/commits) over the gh CLI. Always
     # included — they degrade to a readable error if gh/auth is missing.
     from tools.github_tools import get_github_tools


### PR DESCRIPTION
## What

The last A2A spec gap: the agent can now **pause a task to ask the operator and resume on the answer** — the `input-required` flow ORBIS/Workstacean expect (Workstacean is re-enabling its approval gate; today its TaskTracker *fails* `input-required` tasks with "no approval gate is wired").

## How (LangGraph interrupt → A2A input-required → resume)

- **`ask_human` tool** (lead-agent only — excluded from subagent allowlists, since the interrupt is resumed by the lead turn's runner) issues a LangGraph `interrupt()`; the graph checkpoints at that exact point.
- **Producer** (`_run_turn_stream`): after the turn, detects a pending interrupt via `aget_state` and yields `("input_required", {question})`; `_chat_langgraph_stream` surfaces it and parks the turn (skips the kicker/goal logic). A resume feeds `Command(resume=text)` on the same thread, continuing from the interrupt.
- **`a2a_handler`**: new non-terminal `INPUT_REQUIRED` state + `_STREAM_CLOSING` set. The runner parks the task (question in `status.message`), persists it (survives restart), and pushes immediately. SSE + webhook close the cycle with `final: true` but **no** terminal artifact. **Resume routing**: a `message/send`/`stream` carrying an existing `input-required` `taskId` resumes that task (`Command(resume)`) instead of minting a fresh one.
- Card advertises the **`hitl-mode-v1`** extension.

## Interop (matches Workstacean's `a2a-executor.resumeTask`)

protoAgent emits `status.state: input-required` + the question + `final: true`; the caller resumes with the same `taskId` + `contextId` carrying the answer. Exactly the contract `task-tracker.ts` / `a2a-executor.ts` drive.

## Tests / docs

- `test_a2a_handler`: runner parks on `input_required` (non-terminal, question retained, pushes, stops before the trailing `done`); `status-update` `final` on input-required. `test_a2a_tool_events`: full `input-required → resume → completed` round-trip over the stream route.
- **797 pytest + docs + 31 e2e green.**
- **Live-verified end-to-end**: `ask_human` paused at `input-required` ("What is your favorite color?"), resume with the same `taskId` + "teal" → `completed`, artifact `"teal"`.
- Docs: `a2a-endpoints` (HITL section + events table), `starter-tools` (`ask_human`).

## A2A is now fully conformant

streaming ✓ · per-transition push ✓ · X-A2A-Notification-Token ✓ · getAuthenticatedExtendedCard ✓ · push-configs persisted ✓ · task-records persisted ✓ · **input-required / HITL ✓**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)