### PR TITLE
Consolidate the operator console nav (8 surfaces → 4)

### DIFF
--- a/apps/web/e2e/activity.spec.ts
+++ b/apps/web/e2e/activity.spec.ts
@@ -11,14 +11,12 @@ test("unread badge counts pushed messages; surface shows history + live append",
   await expect(page.getByTestId("activity-badge")).toBeVisible();
 
   await page.getByRole("button", { name: "Activity", exact: true }).click();
+  // Activity opens on its Thread sub-tab by default.
   await expect(page.getByRole("heading", { name: "Activity" })).toBeVisible();
 
   // History from GET /api/activity renders.
   await expect(page.getByText("morning standup")).toBeVisible();
   await expect(page.getByText("3 PRs merged overnight, CI green.")).toBeVisible();
-
-  // Opening the surface clears the badge.
-  await expect(page.getByTestId("activity-badge")).toHaveCount(0);
 
   // A pushed event appends live while the surface is open.
   await expect(page.getByText("live activity ping").first()).toBeVisible();

--- a/apps/web/e2e/inbox.spec.ts
+++ b/apps/web/e2e/inbox.spec.ts
@@ -1,15 +1,16 @@
 import { expect, test } from "@playwright/test";
 
-// The Inbox sidebar panel (ADR 0003): lists pending inbound items, shows an
-// unread badge while off-panel, live-updates on `inbox.item`, and dismisses.
+// The Inbox lives under Activity (ADR 0003): inbound items, a sub-tab unread
+// badge, live updates on `inbox.item`, and dismiss.
 
 test("inbox badge appears, panel lists items, and dismiss removes one", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // inbox.item events arrive while the default (Notes) panel is showing → badge.
-  await expect(page.getByTestId("inbox-badge")).toBeVisible();
+  // Inbound events bump the Activity rail's combined unread badge.
+  await expect(page.getByTestId("activity-badge")).toBeVisible();
 
-  // Open the Inbox tab (its accessible name includes the badge count).
+  // Open Activity → its Inbox sub-tab.
+  await page.getByRole("button", { name: "Activity", exact: true }).click();
   await page.getByRole("button", { name: /Inbox/ }).click();
   await expect(page.getByRole("heading", { name: "Inbox" })).toBeVisible();
 
@@ -18,7 +19,7 @@ test("inbox badge appears, panel lists items, and dismiss removes one", async ({
   await expect(page.getByText("new signup: acme.co")).toBeVisible();
   await expect(page.locator(".inbox-pri-now")).toBeVisible();
 
-  // Opening the panel clears the badge.
+  // Viewing the Inbox sub-tab clears its unread badge.
   await expect(page.getByTestId("inbox-badge")).toHaveCount(0);
 
   // Dismiss the first item → it leaves the list.

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -9,31 +9,33 @@ test.beforeEach(async ({ page }) => {
   await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
 });
 
-async function openSurface(page, name: string) {
-  await page.getByRole("button", { name, exact: true }).click();
+// Grouped nav (heavy consolidation): click a rail group, then its in-surface sub-tab.
+async function openSub(page, group: string, tab: string) {
+  await page.getByRole("button", { name: group, exact: true }).click();
+  await page.getByRole("button", { name: tab, exact: true }).click();
 }
 
 test("subagents surface lists the registered subagent", async ({ page }) => {
-  await openSurface(page, "Subagents");
+  await openSub(page, "Studio", "Subagents");
   await expect(page.getByRole("heading", { name: "Manual Subagent" })).toBeVisible();
   // The registered-count kicker reflects the mocked subagent list.
   await expect(page.getByText("1 registered")).toBeVisible();
 });
 
 test("schedule surface lists scheduled jobs", async ({ page }) => {
-  await openSurface(page, "Schedule");
+  await openSub(page, "Studio", "Schedule");
   await expect(page.getByRole("heading", { name: "Schedule" })).toBeVisible();
   await expect(page.getByText("Summarize overnight activity")).toBeVisible();
 });
 
 test("goals surface lists active goals", async ({ page }) => {
-  await openSurface(page, "Goals");
+  await openSub(page, "Studio", "Goals");
   await expect(page.getByRole("heading", { name: "Goals" })).toBeVisible();
   await expect(page.getByText("All tests pass")).toBeVisible();
 });
 
 test("runtime surface surfaces skills, MCP servers, and plugins", async ({ page }) => {
-  await openSurface(page, "Runtime");
+  await openSub(page, "System", "Runtime");
   await expect(page.getByRole("heading", { name: "Runtime" })).toBeVisible();
 
   // Extensibility blocks — the features added across the initiative.

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -6,6 +6,7 @@ import { expect, test } from "@playwright/test";
 
 async function openSettings(page) {
   await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "System", exact: true }).click();
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
 }

--- a/apps/web/e2e/workflows.spec.ts
+++ b/apps/web/e2e/workflows.spec.ts
@@ -6,6 +6,7 @@ import { expect, test } from "@playwright/test";
 
 async function openWorkflows(page) {
   await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Studio", exact: true }).click();
   await page.getByRole("button", { name: "Workflows", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Workflows" })).toBeVisible();
 }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -39,8 +39,13 @@ import type { BeadsIssue, GoalState, NotesWorkspace, RuntimeStatus, ScheduledJob
 import { ScrollArea } from "./ScrollArea";
 import { SetupWizard } from "../setup/SetupWizard";
 
-type Surface = "chat" | "subagents" | "workflows" | "activity" | "runtime" | "schedule" | "goals" | "settings";
-type RightPanel = "notes" | "beads" | "inbox";
+// Consolidated nav (heavy grouping): four rail surfaces, each grouped one
+// fanning out to sub-views via an in-surface segmented control.
+type Surface = "chat" | "activity" | "studio" | "system";
+type StudioTab = "subagents" | "workflows" | "schedule" | "goals";
+type SystemTab = "runtime" | "settings";
+type ActivityTab = "thread" | "inbox";
+type RightPanel = "notes" | "beads";
 type SubagentMode = "single" | "batch";
 type StatusTone = "success" | "warning" | "error" | "muted";
 
@@ -216,6 +221,9 @@ function groupIssues(issues: BeadsIssue[]) {
 
 export function App() {
   const [surface, setSurface] = useState<Surface>("chat");
+  const [studioTab, setStudioTab] = useState<StudioTab>("subagents");
+  const [systemTab, setSystemTab] = useState<SystemTab>("runtime");
+  const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
   const [live, setLive] = useState(false);
   const [activityUnread, setActivityUnread] = useState(0);
@@ -424,43 +432,45 @@ export function App() {
   }, [rightPanel, projectPath, notesDirty, notesBusy]);
 
   useEffect(() => {
-    if (surface === "schedule") void refreshSchedules();
-    if (surface === "goals") void refreshGoals();
-  }, [surface]);
+    if (surface === "studio" && studioTab === "schedule") void refreshSchedules();
+    if (surface === "studio" && studioTab === "goals") void refreshGoals();
+  }, [surface, studioTab]);
 
   // Open the server→client event stream (ADR 0003) and track its connection
   // state for the "live" indicator. Surfaces subscribe to named events.
   useEffect(() => onConnectionChange(setLive), []);
 
-  // Unread badge on the Activity rail: count agent-initiated messages that
-  // arrive while the operator isn't looking at the Activity surface.
+  // Unread badges (Activity rail + its Inbox sub-tab): count agent-initiated
+  // messages / inbound items that arrive while the operator isn't looking at
+  // the matching view. Refs so the event handlers read the live view.
   const surfaceRef = useRef(surface);
   surfaceRef.current = surface;
+  const activityTabRef = useRef(activityTab);
+  activityTabRef.current = activityTab;
+  const viewingThread = () => surfaceRef.current === "activity" && activityTabRef.current === "thread";
+  const viewingInbox = () => surfaceRef.current === "activity" && activityTabRef.current === "inbox";
+
   useEffect(
     () =>
       onServerEvent("activity.message", () => {
-        if (surfaceRef.current !== "activity") setActivityUnread((n) => n + 1);
+        if (!viewingThread()) setActivityUnread((n) => n + 1);
       }),
     [],
   );
   useEffect(() => {
-    if (surface === "activity") setActivityUnread(0);
-  }, [surface]);
+    if (viewingThread()) setActivityUnread(0);
+  }, [surface, activityTab]);
 
-  // Unread count on the Inbox sidebar tab: inbound items that arrive while the
-  // operator isn't looking at the inbox panel.
-  const rightPanelRef = useRef(rightPanel);
-  rightPanelRef.current = rightPanel;
   useEffect(
     () =>
       onServerEvent("inbox.item", () => {
-        if (rightPanelRef.current !== "inbox") setInboxUnread((n) => n + 1);
+        if (!viewingInbox()) setInboxUnread((n) => n + 1);
       }),
     [],
   );
   useEffect(() => {
-    if (rightPanel === "inbox") setInboxUnread(0);
-  }, [rightPanel]);
+    if (viewingInbox()) setInboxUnread(0);
+  }, [surface, activityTab]);
 
   async function runSubagent() {
     const prompt = subagentPrompt.trim();
@@ -802,47 +812,23 @@ export function App() {
             onClick={() => setSurface("chat")}
           />
           <RailButton
-            active={surface === "subagents"}
-            label="Subagents"
-            icon={<Network size={18} />}
-            onClick={() => setSurface("subagents")}
-          />
-          <RailButton
-            active={surface === "workflows"}
-            label="Workflows"
-            icon={<Workflow size={18} />}
-            onClick={() => setSurface("workflows")}
-          />
-          <RailButton
             active={surface === "activity"}
             label="Activity"
             icon={<Activity size={18} />}
             onClick={() => setSurface("activity")}
-            badge={activityUnread}
+            badge={activityUnread + inboxUnread}
           />
           <RailButton
-            active={surface === "schedule"}
-            label="Schedule"
-            icon={<CalendarClock size={18} />}
-            onClick={() => setSurface("schedule")}
+            active={surface === "studio"}
+            label="Studio"
+            icon={<Boxes size={18} />}
+            onClick={() => setSurface("studio")}
           />
           <RailButton
-            active={surface === "goals"}
-            label="Goals"
-            icon={<Target size={18} />}
-            onClick={() => setSurface("goals")}
-          />
-          <RailButton
-            active={surface === "runtime"}
-            label="Runtime"
+            active={surface === "system"}
+            label="System"
             icon={<Gauge size={18} />}
-            onClick={() => setSurface("runtime")}
-          />
-          <RailButton
-            active={surface === "settings"}
-            label="Settings"
-            icon={<Settings2 size={18} />}
-            onClick={() => setSurface("settings")}
+            onClick={() => setSurface("system")}
           />
         </aside>
 
@@ -854,11 +840,50 @@ export function App() {
             </div>
           ) : null}
 
+          {/* In-surface sub-nav for the grouped rail surfaces. */}
+          {surface === "activity" ? (
+            <div className="stage-subnav">
+              <button className={activityTab === "thread" ? "active" : ""} onClick={() => setActivityTab("thread")}>
+                <Activity size={15} /> Thread
+              </button>
+              <button className={activityTab === "inbox" ? "active" : ""} onClick={() => setActivityTab("inbox")}>
+                <Inbox size={15} /> Inbox
+                {inboxUnread ? <span className="subnav-badge" data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span> : null}
+              </button>
+            </div>
+          ) : null}
+          {surface === "studio" ? (
+            <div className="stage-subnav">
+              <button className={studioTab === "subagents" ? "active" : ""} onClick={() => setStudioTab("subagents")}>
+                <Network size={15} /> Subagents
+              </button>
+              <button className={studioTab === "workflows" ? "active" : ""} onClick={() => setStudioTab("workflows")}>
+                <Workflow size={15} /> Workflows
+              </button>
+              <button className={studioTab === "schedule" ? "active" : ""} onClick={() => setStudioTab("schedule")}>
+                <CalendarClock size={15} /> Schedule
+              </button>
+              <button className={studioTab === "goals" ? "active" : ""} onClick={() => setStudioTab("goals")}>
+                <Target size={15} /> Goals
+              </button>
+            </div>
+          ) : null}
+          {surface === "system" ? (
+            <div className="stage-subnav">
+              <button className={systemTab === "runtime" ? "active" : ""} onClick={() => setSystemTab("runtime")}>
+                <Gauge size={15} /> Runtime
+              </button>
+              <button className={systemTab === "settings" ? "active" : ""} onClick={() => setSystemTab("settings")}>
+                <Settings2 size={15} /> Settings
+              </button>
+            </div>
+          ) : null}
+
           {surface === "chat" ? (
             <ChatSurface onError={setError} />
           ) : null}
 
-          {surface === "subagents" ? (
+          {surface === "studio" && studioTab === "subagents" ? (
             <section className="panel stage-panel">
               <div className="panel-header">
                 <div>
@@ -973,11 +998,12 @@ export function App() {
             </section>
           ) : null}
 
-          {surface === "workflows" ? <WorkflowsSurface onError={setError} /> : null}
+          {surface === "studio" && studioTab === "workflows" ? <WorkflowsSurface onError={setError} /> : null}
 
-          {surface === "activity" ? <ActivitySurface onError={setError} /> : null}
+          {surface === "activity" && activityTab === "thread" ? <ActivitySurface onError={setError} /> : null}
+          {surface === "activity" && activityTab === "inbox" ? <InboxPanel onError={setError} /> : null}
 
-          {surface === "schedule" ? (
+          {surface === "studio" && studioTab === "schedule" ? (
             <section className="panel stage-panel">
               <div className="panel-header">
                 <div>
@@ -1064,7 +1090,7 @@ export function App() {
             </section>
           ) : null}
 
-          {surface === "goals" ? (
+          {surface === "studio" && studioTab === "goals" ? (
             <section className="panel stage-panel">
               <div className="panel-header">
                 <div>
@@ -1125,7 +1151,7 @@ export function App() {
             </section>
           ) : null}
 
-          {surface === "runtime" ? (
+          {surface === "system" && systemTab === "runtime" ? (
             <section className="panel stage-panel">
               <div className="panel-header">
                 <div>
@@ -1220,7 +1246,7 @@ export function App() {
             </section>
           ) : null}
 
-          {surface === "settings" ? <SettingsSurface onError={setError} /> : null}
+          {surface === "system" && systemTab === "settings" ? <SettingsSurface onError={setError} /> : null}
         </main>
 
         <aside className="right-panel">
@@ -1248,19 +1274,6 @@ export function App() {
             <button type="button" className={rightPanel === "beads" ? "active" : ""} onClick={() => setRightPanel("beads")}>
               <Boxes size={15} />
               Beads
-            </button>
-            <button
-              type="button"
-              className={rightPanel === "inbox" ? "active" : ""}
-              onClick={() => setRightPanel("inbox")}
-            >
-              <Inbox size={15} />
-              Inbox
-              {inboxUnread ? (
-                <span className="rail-badge" data-testid="inbox-badge">
-                  {inboxUnread > 9 ? "9+" : inboxUnread}
-                </span>
-              ) : null}
             </button>
           </div>
 
@@ -1518,8 +1531,6 @@ export function App() {
               </ScrollArea>
             </section>
           ) : null}
-
-          {rightPanel === "inbox" ? <InboxPanel onError={setError} /> : null}
         </aside>
       </div>
       <SetupWizard

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1220,6 +1220,56 @@ textarea {
   resize: none;
 }
 
+/* In-surface sub-nav (grouped rail surfaces) ------------------------------- */
+.stage-subnav {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  padding: 12px 16px 0;
+}
+
+.stage-subnav button {
+  position: relative;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px;
+  font-size: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.stage-subnav button svg {
+  flex: 0 0 auto;
+}
+
+.stage-subnav button:hover {
+  color: var(--fg);
+}
+
+.stage-subnav button.active {
+  background: color-mix(in srgb, var(--accent, #7c8cff) 14%, transparent);
+  color: var(--accent, #7c8cff);
+  border-color: color-mix(in srgb, var(--accent, #7c8cff) 50%, var(--border));
+}
+
+.subnav-badge {
+  min-width: 16px;
+  height: 16px;
+  padding: 0 4px;
+  border-radius: 8px;
+  background: var(--accent, #7c8cff);
+  color: #fff;
+  font-size: 10px;
+  line-height: 16px;
+  text-align: center;
+  font-weight: 600;
+}
+
 /* Inbox panel (ADR 0003) ---------------------------------------------------- */
 .inbox-list {
   flex: 1;


### PR DESCRIPTION
## What

The console had grown to **11 views** (8 rail surfaces + 3 right-panel tabs). This regroups them into a tighter set with in-surface segmented sub-tabs (the "heavy" consolidation we picked).

## Rail: 8 → 4

| Surface | Sub-tabs |
|---|---|
| **Chat** | — |
| **Activity** | Thread · **Inbox** |
| **Studio** | Subagents · Workflows · Schedule · Goals |
| **System** | Runtime · Settings |

**Right panel: 3 → 2** — Notes · Beads.

**Inbox** moves out of the right panel into Activity — it's the inbound feed that drives the activity thread, so they belong together. The Activity rail badge now shows combined activity+inbox unread; the Inbox sub-tab carries its own badge.

## How

Each grouped surface renders a `.stage-subnav` segmented control above its content; the existing per-view blocks are simply re-guarded on `(surface, sub-tab)` — **no behavior change inside any view**, just where they live in the nav. Labels are easy to tweak.

## Tests

- e2e nav paths updated: navigation/settings/workflows now go group → sub-tab; inbox is Activity → Inbox; the activity badge assertion is relaxed for the now-combined badge.
- **31 e2e green**, web build clean. Verified live (screenshot): rail `[Chat · Activity · Studio · System]`, Studio sub-nav, right panel `[Notes · Beads]`.

Next PR: make the rail + right panel **resizable / collapsible** (requested).

🤖 Generated with [Claude Code](https://claude.com/claude-code)