### PR TITLE
Resizable + collapsible rail and right panel

### DIFF
--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -1,0 +1,49 @@
+import { expect, test } from "@playwright/test";
+
+// The rail and right panel are collapsible (topbar toggles) and the right
+// panel is resizable (drag its left edge); state persists to localStorage.
+
+test("rail and right panel collapse + restore via the topbar toggles", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  const rail = page.locator(".rail");
+  const right = page.locator(".right-panel");
+  // A zero-width (collapsed) element reports a null boundingBox → treat as 0.
+  const widthOf = async (loc) => (await loc.boundingBox())?.width ?? 0;
+  await expect(rail).toBeVisible();
+
+  // Collapse the rail → its grid column goes to 0 width.
+  await page.getByTestId("toggle-rail").click();
+  await expect.poll(() => widthOf(rail)).toBe(0);
+  // Restore.
+  await page.getByTestId("toggle-rail").click();
+  await expect.poll(() => widthOf(rail)).toBeGreaterThan(0);
+
+  // Collapse the right panel.
+  await page.getByTestId("toggle-right").click();
+  await expect.poll(() => widthOf(right)).toBe(0);
+  await page.getByTestId("toggle-right").click();
+  await expect.poll(() => widthOf(right)).toBeGreaterThan(0);
+});
+
+test("right panel resizes by dragging its handle and the width persists", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const right = page.locator(".right-panel");
+  const before = (await right.boundingBox())!.width;
+
+  const handle = page.getByTestId("right-resize");
+  const hb = (await handle.boundingBox())!;
+  // Drag the handle left ~120px → the panel grows.
+  await page.mouse.move(hb.x + hb.width / 2, hb.y + hb.height / 2);
+  await page.mouse.down();
+  await page.mouse.move(hb.x - 120, hb.y + hb.height / 2, { steps: 8 });
+  await page.mouse.up();
+
+  const after = (await right.boundingBox())!.width;
+  expect(after).toBeGreaterThan(before + 50);
+
+  // Persists across a reload.
+  await page.reload({ waitUntil: "load" });
+  const reloaded = (await page.locator(".right-panel").boundingBox())!.width;
+  expect(Math.abs(reloaded - after)).toBeLessThan(8);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -13,6 +13,8 @@ import {
   Inbox,
   Loader2,
   MessageSquare,
+  PanelLeft,
+  PanelRight,
   Network,
   Play,
   Plus,
@@ -225,6 +227,12 @@ export function App() {
   const [systemTab, setSystemTab] = useState<SystemTab>("runtime");
   const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
+  // Collapsible/resizable layout (persisted). Flags are "1"/"" strings; width
+  // is a px string clamped on read.
+  const [railCollapsed, setRailCollapsed] = useLocalStorageState("protoagent.railCollapsed", "");
+  const [rightCollapsed, setRightCollapsed] = useLocalStorageState("protoagent.rightCollapsed", "");
+  const [rightWidthStr, setRightWidthStr] = useLocalStorageState("protoagent.rightWidth", "360");
+  const rightWidth = Math.min(720, Math.max(280, parseInt(rightWidthStr, 10) || 360));
   const [live, setLive] = useState(false);
   const [activityUnread, setActivityUnread] = useState(0);
   const [inboxUnread, setInboxUnread] = useState(0);
@@ -769,6 +777,27 @@ export function App() {
 
   const groupedIssues = useMemo(() => groupIssues(beadsIssues), [beadsIssues]);
 
+  // Drag the right panel's left edge to resize (clamped 280–720px, persisted).
+  function startRightResize(e: React.MouseEvent) {
+    e.preventDefault();
+    const startX = e.clientX;
+    const startW = rightWidth;
+    const onMove = (ev: MouseEvent) => {
+      const next = Math.min(720, Math.max(280, startW + (startX - ev.clientX)));
+      setRightWidthStr(String(Math.round(next)));
+    };
+    const onUp = () => {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+      document.body.style.userSelect = "";
+    };
+    document.body.style.userSelect = "none";
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  const workspaceCols = `${railCollapsed ? "0px" : "72px"} minmax(0, 1fr) ${rightCollapsed ? "0px" : `${rightWidth}px`}`;
+
   return (
     <div className="app-shell">
       <header className="topbar">
@@ -797,13 +826,36 @@ export function App() {
             data-testid="live-indicator"
             data-live={live ? "true" : "false"}
           />
+          <button
+            className={`icon-button ${railCollapsed ? "is-off" : ""}`}
+            type="button"
+            onClick={() => setRailCollapsed(railCollapsed ? "" : "1")}
+            title={railCollapsed ? "Show rail" : "Hide rail"}
+            aria-label="Toggle rail"
+            data-testid="toggle-rail"
+          >
+            <PanelLeft size={16} />
+          </button>
+          <button
+            className={`icon-button ${rightCollapsed ? "is-off" : ""}`}
+            type="button"
+            onClick={() => setRightCollapsed(rightCollapsed ? "" : "1")}
+            title={rightCollapsed ? "Show side panel" : "Hide side panel"}
+            aria-label="Toggle side panel"
+            data-testid="toggle-right"
+          >
+            <PanelRight size={16} />
+          </button>
           <button className="icon-button" type="button" onClick={() => void refreshAll()} title="Refresh">
             <RefreshCw size={16} />
           </button>
         </div>
       </header>
 
-      <div className="workspace">
+      <div
+        className={`workspace ${railCollapsed ? "rail-collapsed" : ""} ${rightCollapsed ? "right-collapsed" : ""}`}
+        style={{ gridTemplateColumns: workspaceCols }}
+      >
         <aside className="rail" aria-label="Workspace surfaces">
           <RailButton
             active={surface === "chat"}
@@ -1250,6 +1302,16 @@ export function App() {
         </main>
 
         <aside className="right-panel">
+          {!rightCollapsed ? (
+            <div
+              className="resize-handle"
+              role="separator"
+              aria-orientation="vertical"
+              aria-label="Resize side panel"
+              onMouseDown={startRightResize}
+              data-testid="right-resize"
+            />
+          ) : null}
           <div className="project-bar">
             <input
               value={projectPath}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -188,6 +188,7 @@ h2 {
 }
 
 .right-panel {
+  position: relative; /* anchors the resize handle on its left edge */
   min-width: 0;
   min-height: 0;
   display: grid;
@@ -195,6 +196,43 @@ h2 {
   gap: 10px;
   overflow: hidden;
   padding: 12px;
+}
+
+/* Collapsed panels: the workspace grid sets their track to 0; zero the box so
+   no residual padding/border shows (the element stays a grid item — using
+   display:none would shift the other items into the wrong tracks). min-width:0
+   lets the tracks shrink to 0 / resize freely. */
+.rail {
+  min-width: 0;
+  overflow: hidden;
+}
+
+.workspace.rail-collapsed .rail,
+.workspace.right-collapsed .right-panel {
+  padding: 0;
+  border: 0;
+}
+
+/* Drag handle on the boundary between the stage and the right panel. */
+.resize-handle {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 7px;
+  margin-left: -4px;
+  cursor: col-resize;
+  z-index: 5;
+}
+
+.resize-handle:hover,
+.resize-handle:active {
+  background: color-mix(in srgb, var(--accent, #7c8cff) 45%, transparent);
+}
+
+/* Dim a collapse toggle when its panel is hidden. */
+.icon-button.is-off {
+  color: var(--fg-tertiary, #666);
 }
 
 .panel {


### PR DESCRIPTION
## What

Makes the console layout adjustable (requested follow-up to the nav consolidation):

- **Collapse** — two topbar toggles (`PanelLeft` / `PanelRight`) hide/restore the **rail** and the **right panel**. Persisted to localStorage.
- **Resize** — drag the right panel's left edge (`.resize-handle`) to set its width; clamped 280–720px, persisted.

## How

The `.workspace` grid columns are driven from state (`72px | 1fr | <width>px`, with a collapsed track → `0px`). Collapsed panels **stay grid items** with their box zeroed (`padding/border: 0`) — using `display:none` would drop a grid item and shift the others into the wrong tracks (the stage would inherit the 0px column). Width persists via the existing `useLocalStorageState`.

## Tests

- `e2e/layout.spec.ts` — rail + right-panel collapse/restore (boundingBox → 0 then > 0), and right-panel drag-resize + persistence across a reload.
- **33 e2e green**, web build clean. Verified live (screenshots): collapsing the rail reflows the stage and the right panel stays in place; dragging widens the panel and the width sticks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)