### PR TITLE
Declutter topbar: one status dot + bottom utility bar

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -798,6 +798,15 @@ export function App() {
 
   const workspaceCols = `${railCollapsed ? "0px" : "72px"} minmax(0, 1fr) ${rightCollapsed ? "0px" : `${rightWidth}px`}`;
 
+  // One glanceable health light for the topbar (detail on hover; full status in
+  // System → Runtime). Worst-state wins.
+  const health: { tone: "ok" | "warning" | "error"; label: string } =
+    runtime && !runtime.setup_complete ? { tone: "warning", label: "setup pending" }
+    : runtime && !runtime.graph_loaded ? { tone: "error", label: "graph offline" }
+    : status === "error" ? { tone: "error", label: "error" }
+    : status === "streaming" || status === "refreshing" || status.includes("…") ? { tone: "warning", label: status }
+    : { tone: "ok", label: "ready" };
+
   return (
     <div className="app-shell">
       <header className="topbar">
@@ -809,46 +818,22 @@ export function App() {
           </div>
         </div>
         <div className="topbar-status">
-          <StatusPill
-            label={runtime?.setup_complete ? "setup complete" : "setup pending"}
-            tone={statusTone(runtime?.setup_complete)}
-          />
-          <StatusPill
-            label={runtime?.graph_loaded ? "graph loaded" : "graph offline"}
-            tone={statusTone(runtime?.graph_loaded)}
-          />
-          <StatusPill label={status} tone={status === "error" ? "error" : "muted"} />
-          <span
-            className={`live-dot ${live ? "is-live" : ""}`}
-            role="status"
-            aria-label={live ? "event stream connected" : "event stream offline"}
-            title={live ? "Live — event stream connected" : "Event stream offline"}
+          <button
+            type="button"
+            className={`status-dot tone-${health.tone}`}
+            onClick={() => void refreshAll()}
+            title={
+              `Setup: ${runtime?.setup_complete ? "complete" : "pending"}\n` +
+              `Graph: ${runtime?.graph_loaded ? "loaded" : "offline"}\n` +
+              `Event stream: ${live ? "connected" : "offline"}\n` +
+              `Status: ${status}` +
+              (error ? `\nError: ${error}` : "") +
+              `\n\nClick to refresh.`
+            }
+            aria-label={`Status: ${health.label}. Click to refresh.`}
             data-testid="live-indicator"
             data-live={live ? "true" : "false"}
           />
-          <button
-            className={`icon-button ${railCollapsed ? "is-off" : ""}`}
-            type="button"
-            onClick={() => setRailCollapsed(railCollapsed ? "" : "1")}
-            title={railCollapsed ? "Show rail" : "Hide rail"}
-            aria-label="Toggle rail"
-            data-testid="toggle-rail"
-          >
-            <PanelLeft size={16} />
-          </button>
-          <button
-            className={`icon-button ${rightCollapsed ? "is-off" : ""}`}
-            type="button"
-            onClick={() => setRightCollapsed(rightCollapsed ? "" : "1")}
-            title={rightCollapsed ? "Show side panel" : "Hide side panel"}
-            aria-label="Toggle side panel"
-            data-testid="toggle-right"
-          >
-            <PanelRight size={16} />
-          </button>
-          <button className="icon-button" type="button" onClick={() => void refreshAll()} title="Refresh">
-            <RefreshCw size={16} />
-          </button>
         </div>
       </header>
 
@@ -1595,6 +1580,33 @@ export function App() {
           ) : null}
         </aside>
       </div>
+
+      <footer className="utility-bar">
+        <button
+          type="button"
+          className={`util-btn ${railCollapsed ? "is-off" : ""}`}
+          onClick={() => setRailCollapsed(railCollapsed ? "" : "1")}
+          title={railCollapsed ? "Show rail" : "Hide rail"}
+          aria-label="Toggle rail"
+          data-testid="toggle-rail"
+        >
+          <PanelLeft size={14} />
+          <span>{railCollapsed ? "Show rail" : "Hide rail"}</span>
+        </button>
+        <div className="util-spacer" />
+        <button
+          type="button"
+          className={`util-btn ${rightCollapsed ? "is-off" : ""}`}
+          onClick={() => setRightCollapsed(rightCollapsed ? "" : "1")}
+          title={rightCollapsed ? "Show side panel" : "Hide side panel"}
+          aria-label="Toggle side panel"
+          data-testid="toggle-right"
+        >
+          <span>{rightCollapsed ? "Show panel" : "Hide panel"}</span>
+          <PanelRight size={14} />
+        </button>
+      </footer>
+
       <SetupWizard
         open={runtime?.setup_complete === false}
         projectPath={projectPath}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -86,9 +86,83 @@ h2 {
   height: 100%;
   min-height: 100vh;
   display: grid;
-  grid-template-rows: 48px minmax(0, 1fr);
+  grid-template-rows: 48px minmax(0, 1fr) 28px;
   overflow: hidden;
   background: var(--bg);
+}
+
+/* Topbar health light — one dot, detail on hover, click to refresh. */
+.status-dot {
+  width: 11px;
+  height: 11px;
+  padding: 0;
+  border: 0;
+  border-radius: 50%;
+  background: var(--fg-tertiary, #555);
+  cursor: pointer;
+  flex: none;
+  transition: background 0.2s ease, box-shadow 0.2s ease;
+}
+
+.status-dot.tone-ok {
+  background: var(--success, #3fb950);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--success, #3fb950) 22%, transparent);
+}
+
+.status-dot.tone-warning {
+  background: var(--warning, #d29922);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--warning, #d29922) 22%, transparent);
+}
+
+.status-dot.tone-error {
+  background: var(--danger, #ff6b6b);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--danger, #ff6b6b) 22%, transparent);
+}
+
+.status-dot:hover {
+  filter: brightness(1.15);
+}
+
+/* Bottom utility bar — panel collapse toggles, pinned to their sides. */
+.utility-bar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 10px;
+  border-top: 1px solid var(--border);
+  background: var(--bg);
+  font-size: 11px;
+}
+
+.utility-bar .util-spacer {
+  flex: 1;
+}
+
+.util-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  height: 20px;
+  padding: 0 8px;
+  border: 0;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--fg-secondary);
+  font-size: 11px;
+  cursor: pointer;
+}
+
+.util-btn:hover {
+  background: var(--bg-elevated, #1a1a1f);
+  color: var(--fg);
+}
+
+.util-btn svg {
+  flex: none;
+}
+
+.util-btn.is-off {
+  color: var(--accent, #7c8cff);
 }
 
 .topbar {


### PR DESCRIPTION
## What

The topbar had three text pills (`setup complete` / `graph loaded` / `ready`) + a live dot + three icon buttons — too much, especially after the collapse toggles landed.

- **Status → one dot.** A single health light (worst-state wins: ready / setup pending / graph offline / error / working). **Hover** = the full breakdown (setup · graph · event stream · status); **click** = refresh. Full detail still lives in **System → Runtime**.
- **Refresh button removed** — folded into the status dot (you refresh to update status; that's its natural target). It was redundant anyway: surfaces already have their own refresh, and it uniquely re-pulled only the runtime status the dot now shows.
- **Panel toggles → bottom utility bar.** The rail + right-panel collapse toggles move out of the topbar into a new thin footer, pinned to their sides ("Hide rail" left, "Hide panel" right).

## Result

Topbar is now just the brand + a single dot. A VS-Code-style bottom bar owns the panel controls.

## Tests

testids preserved (`live-indicator` on the dot; `toggle-rail`/`toggle-right` on the footer buttons), so events + layout e2e pass without changes. **33 e2e green**, web build clean. Verified live (screenshots): clean topbar with a green dot, footer toggles collapse/restore the panels.

🤖 Generated with [Claude Code](https://claude.com/claude-code)