### PR TITLE
Remove the rail toggle; panel toggle icon-only

### DIFF
--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -1,25 +1,16 @@
 import { expect, test } from "@playwright/test";
 
-// The rail and right panel are collapsible (topbar toggles) and the right
-// panel is resizable (drag its left edge); state persists to localStorage.
+// The right panel is collapsible (bottom utility-bar toggle) and resizable
+// (drag its left edge); state persists to localStorage. (The rail is fixed.)
 
-test("rail and right panel collapse + restore via the topbar toggles", async ({ page }) => {
+test("right panel collapses + restores via the utility-bar toggle", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  const rail = page.locator(".rail");
   const right = page.locator(".right-panel");
   // A zero-width (collapsed) element reports a null boundingBox → treat as 0.
   const widthOf = async (loc) => (await loc.boundingBox())?.width ?? 0;
-  await expect(rail).toBeVisible();
+  await expect(right).toBeVisible();
 
-  // Collapse the rail → its grid column goes to 0 width.
-  await page.getByTestId("toggle-rail").click();
-  await expect.poll(() => widthOf(rail)).toBe(0);
-  // Restore.
-  await page.getByTestId("toggle-rail").click();
-  await expect.poll(() => widthOf(rail)).toBeGreaterThan(0);
-
-  // Collapse the right panel.
   await page.getByTestId("toggle-right").click();
   await expect.poll(() => widthOf(right)).toBe(0);
   await page.getByTestId("toggle-right").click();

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -13,7 +13,6 @@ import {
   Inbox,
   Loader2,
   MessageSquare,
-  PanelLeft,
   PanelRight,
   Network,
   Play,
@@ -227,9 +226,8 @@ export function App() {
   const [systemTab, setSystemTab] = useState<SystemTab>("runtime");
   const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
-  // Collapsible/resizable layout (persisted). Flags are "1"/"" strings; width
+  // Collapsible/resizable right panel (persisted). Flag is "1"/"" string; width
   // is a px string clamped on read.
-  const [railCollapsed, setRailCollapsed] = useLocalStorageState("protoagent.railCollapsed", "");
   const [rightCollapsed, setRightCollapsed] = useLocalStorageState("protoagent.rightCollapsed", "");
   const [rightWidthStr, setRightWidthStr] = useLocalStorageState("protoagent.rightWidth", "360");
   const rightWidth = Math.min(720, Math.max(280, parseInt(rightWidthStr, 10) || 360));
@@ -796,7 +794,7 @@ export function App() {
     window.addEventListener("mouseup", onUp);
   }
 
-  const workspaceCols = `${railCollapsed ? "0px" : "72px"} minmax(0, 1fr) ${rightCollapsed ? "0px" : `${rightWidth}px`}`;
+  const workspaceCols = `72px minmax(0, 1fr) ${rightCollapsed ? "0px" : `${rightWidth}px`}`;
 
   // One glanceable health light for the topbar (detail on hover; full status in
   // System → Runtime). Worst-state wins.
@@ -838,7 +836,7 @@ export function App() {
       </header>
 
       <div
-        className={`workspace ${railCollapsed ? "rail-collapsed" : ""} ${rightCollapsed ? "right-collapsed" : ""}`}
+        className={`workspace ${rightCollapsed ? "right-collapsed" : ""}`}
         style={{ gridTemplateColumns: workspaceCols }}
       >
         <aside className="rail" aria-label="Workspace surfaces">
@@ -1582,17 +1580,6 @@ export function App() {
       </div>
 
       <footer className="utility-bar">
-        <button
-          type="button"
-          className={`util-btn ${railCollapsed ? "is-off" : ""}`}
-          onClick={() => setRailCollapsed(railCollapsed ? "" : "1")}
-          title={railCollapsed ? "Show rail" : "Hide rail"}
-          aria-label="Toggle rail"
-          data-testid="toggle-rail"
-        >
-          <PanelLeft size={14} />
-          <span>{railCollapsed ? "Show rail" : "Hide rail"}</span>
-        </button>
         <div className="util-spacer" />
         <button
           type="button"
@@ -1602,7 +1589,6 @@ export function App() {
           aria-label="Toggle side panel"
           data-testid="toggle-right"
         >
-          <span>{rightCollapsed ? "Show panel" : "Hide panel"}</span>
           <PanelRight size={14} />
         </button>
       </footer>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -281,7 +281,6 @@ h2 {
   overflow: hidden;
 }
 
-.workspace.rail-collapsed .rail,
 .workspace.right-collapsed .right-panel {
   padding: 0;
   border: 0;


### PR DESCRIPTION
## What

Per feedback: hiding the rail is pointless (it's always useful), so the **Hide rail** button and its collapse logic are removed entirely (`railCollapsed` state, the `rail-collapsed` grid class + CSS, the persisted key, the now-unused `PanelLeft` import). The **right-panel** toggle stays in the utility bar but is now **icon-only** (the "Hide panel" text label is gone; tooltip/aria-label kept).

## Tests

`layout.spec` trimmed to the right-panel collapse + resize cases. **33 e2e green**, web build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)