### PR TITLE
feat(mcp): per-server tool allowlist + lazy connect (ADR 0005 #1)

### DIFF
--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -49,6 +49,47 @@ other servers.
 - `GET /api/runtime/status` reports `mcp.enabled`, the connected `servers`
   (`name`, `transport`, `tool_count`), and total `tool_count`.
 
+## Keeping tools out of context (allowlist + lazy connect)
+
+A single MCP server can export dozens or hundreds of tools, and **every bound
+tool's name, description, and full input schema is sent to the model on every
+turn**. Past ~10–15 tools this burns context and measurably degrades tool
+selection ("tool pollution" — see [ADR 0005](/adr/0005-tool-pollution-and-progressive-disclosure)).
+Two per-server knobs keep the surface small:
+
+```yaml
+mcp:
+  enabled: true
+  denylist: [dangerous__tool]    # cross-server hard block (always wins)
+  servers:
+    - name: github
+      transport: stdio
+      command: npx
+      args: ["-y", "@modelcontextprotocol/server-github"]
+      tools:
+        include: [get_pull_request, list_issues]   # allowlist — ONLY these bind
+        exclude: [delete_repository]                # drop from whatever remains
+    - name: staging-only
+      enabled: false             # configured but not connected (no tools, no cost)
+      transport: streamable_http
+      url: "https://staging.example.com/mcp"
+```
+
+- **`tools.include`** — an allowlist. When set, *only* the listed tools are
+  bound; everything else from that server is dropped. This is the surgical fix
+  for a chatty server — pick the 2–10 tools you actually use.
+- **`tools.exclude`** — drops the listed tools from whatever remains. `include`
+  wins over a same-server `exclude` if a name appears in both.
+- **`enabled: false`** — the server is **not connected at all** (lazy). Use it
+  to park a server's config without paying its connection or context cost.
+- Both `include`/`exclude` match the **bare** tool name (`get_pull_request`) or
+  the namespaced form (`github__get_pull_request`).
+- The global `denylist` is the hard safety net — it removes a tool even if an
+  `include` lists it.
+
+When no filter is set, all of a server's tools bind (the original behavior), so
+existing configs are unchanged.
+
 ## Transports
 
 | Transport | Use when | Required fields |

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -284,7 +284,9 @@ Connect external [Model Context Protocol](../guides/mcp.md) servers; their tools
 | `enabled` | `false` | Connect the configured servers and expose their tools. |
 | `timeout_seconds` | `20` | Per-server discovery timeout. A slow/unreachable server is skipped, never fatal. |
 | `denylist` | `[]` | Namespaced tool names to drop (e.g. `filesystem__write_file`). |
-| `servers` | `[]` | List of `{name, transport, …}`. `stdio` → `command`/`args`/`env`/`cwd`; `streamable_http`/`sse` → `url`/`headers`. |
+| `servers` | `[]` | List of `{name, transport, …}`. `stdio` → `command`/`args`/`env`/`cwd`; `streamable_http`/`sse` → `url`/`headers`. Per-server: `enabled: false` skips connecting it (lazy); `tools: {include: [...], exclude: [...]}` filters which of its tools bind. |
+
+Per-server `tools.include` is an **allowlist** (only those tools bind) — the fix for a server with a large catalog flooding context; `exclude` drops from the remainder (`include` wins on conflict). The global `denylist` is the cross-server hard block. Both match the bare or namespaced tool name. See [ADR 0005](../adr/0005-tool-pollution-and-progressive-disclosure.md) on tool pollution.
 
 Servers are discovered at startup/reload. `GET /api/runtime/status` reports `mcp.servers` and `mcp.tool_count`. See the [MCP guide](../guides/mcp.md) and `examples/mcp/echo_server.py`.
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -225,7 +225,12 @@ class LangGraphConfig:
     # (stdio or streamable-HTTP); their tools become agent tools, namespaced
     # ``<server>__<tool>`` so they can't shadow core tools. OFF by default —
     # configuring a server is the opt-in. ``servers`` entries are
-    # ``{name, transport, command/args/env | url/headers}``. See tools/mcp_tools.py.
+    # ``{name, transport, command/args/env | url/headers}`` plus two optional
+    # context-control keys: ``enabled: false`` skips connecting that server
+    # entirely (lazy), and ``tools: {include: [...], exclude: [...]}`` filters
+    # which of its tools are bound — ``include`` is an allowlist (only those
+    # survive), the surgical defense against a large catalog flooding context.
+    # ``denylist`` is a cross-server hard block. See tools/mcp_tools.py.
     mcp_enabled: bool = False
     mcp_servers: list[dict] = field(default_factory=list)
     mcp_timeout_seconds: float = 20.0

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -114,6 +114,78 @@ def test_denylist_and_core_collision_filtered(monkeypatch) -> None:
     assert meta[0]["tool_count"] == 1
 
 
+def test_disabled_server_not_connected(monkeypatch) -> None:
+    # enabled: false → the server is skipped before any connection attempt.
+    calls = {"connected": False}
+
+    class TripwireClient:
+        def __init__(self, connections, tool_name_prefix=False):
+            calls["connected"] = True
+
+        async def get_tools(self):
+            return [SimpleNamespace(name="x__t")]
+
+    monkeypatch.setattr("langchain_mcp_adapters.client.MultiServerMCPClient", TripwireClient)
+    _clients, tools, meta = build_mcp_tools(
+        _cfg([{"name": "x", "transport": "stdio", "command": "python", "args": ["s.py"], "enabled": False}])
+    )
+    assert tools == [] and meta == []
+    assert calls["connected"] is False
+
+
+def test_include_allowlist_keeps_only_listed(monkeypatch) -> None:
+    _fake_client_factory(monkeypatch, by_server={
+        "s": [SimpleNamespace(name="s__a"), SimpleNamespace(name="s__b"), SimpleNamespace(name="s__c")],
+    })
+    # include matches the bare tool name (what you'd configure).
+    cfg = _cfg([{
+        "name": "s", "transport": "stdio", "command": "python", "args": ["s.py"],
+        "tools": {"include": ["a", "c"]},
+    }])
+    _clients, tools, meta = build_mcp_tools(cfg)
+    assert [t.name for t in tools] == ["s__a", "s__c"]
+    assert meta[0]["tool_count"] == 2
+
+
+def test_exclude_drops_listed(monkeypatch) -> None:
+    _fake_client_factory(monkeypatch, by_server={
+        "s": [SimpleNamespace(name="s__keep"), SimpleNamespace(name="s__drop")],
+    })
+    cfg = _cfg([{
+        "name": "s", "transport": "stdio", "command": "python", "args": ["s.py"],
+        "tools": {"exclude": ["drop"]},
+    }])
+    _clients, tools, _meta = build_mcp_tools(cfg)
+    assert [t.name for t in tools] == ["s__keep"]
+
+
+def test_include_wins_over_same_server_exclude(monkeypatch) -> None:
+    # A name in both include and exclude is kept — explicit inclusion wins.
+    _fake_client_factory(monkeypatch, by_server={
+        "s": [SimpleNamespace(name="s__a"), SimpleNamespace(name="s__b")],
+    })
+    cfg = _cfg([{
+        "name": "s", "transport": "stdio", "command": "python", "args": ["s.py"],
+        "tools": {"include": ["a"], "exclude": ["a"]},
+    }])
+    _clients, tools, _meta = build_mcp_tools(cfg)
+    assert [t.name for t in tools] == ["s__a"]
+
+
+def test_global_denylist_overrides_include(monkeypatch) -> None:
+    # The cross-server denylist is the hard safety net — include cannot revive it.
+    _fake_client_factory(monkeypatch, by_server={
+        "s": [SimpleNamespace(name="s__a"), SimpleNamespace(name="s__danger")],
+    })
+    cfg = _cfg([{
+        "name": "s", "transport": "stdio", "command": "python", "args": ["s.py"],
+        "tools": {"include": ["a", "danger"]},
+    }])
+    cfg.mcp_denylist = ["s__danger"]
+    _clients, tools, _meta = build_mcp_tools(cfg)
+    assert [t.name for t in tools] == ["s__a"]
+
+
 def test_one_bad_server_does_not_break_others(monkeypatch) -> None:
     _fake_client_factory(monkeypatch, by_server={
         "good": [SimpleNamespace(name="good__t")],

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -146,6 +146,21 @@ def build_mcp_tools(config) -> tuple[list, list, list[dict]]:
             log.warning("[mcp] skipping invalid server entry (need name + command/url): %r", server)
             continue
 
+        # Lazy connect: a server explicitly disabled is never contacted, so a
+        # configured-but-paused server costs neither a connection nor context.
+        if server.get("enabled", True) is False:
+            log.info("[mcp] server %r disabled — not connecting", name)
+            continue
+
+        # Per-server tool filter — the primary defense against a large catalog
+        # dumping dozens of tool schemas into context. ``include`` is an
+        # allowlist (when set, only those tools survive); ``exclude`` drops
+        # tools from whatever remains. Both match the bare tool name (what you
+        # configure) or the namespaced ``<server>__<tool>`` form.
+        tool_filter = server.get("tools") or {}
+        include = {str(n) for n in (tool_filter.get("include") or [])}
+        exclude = {str(n) for n in (tool_filter.get("exclude") or [])}
+
         try:
             # tool_name_prefix=True → tools are named "<server>__<tool>".
             client = MultiServerMCPClient({name: conn}, tool_name_prefix=True)
@@ -154,9 +169,21 @@ def build_mcp_tools(config) -> tuple[list, list, list[dict]]:
             log.warning("[mcp] server %r discovery failed: %s — skipping", name, exc)
             continue
 
+        prefix = f"{name}__"
         kept = []
         for tool in discovered:
-            if tool.name in denylist:
+            bare = tool.name[len(prefix):] if tool.name.startswith(prefix) else tool.name
+            names = {tool.name, bare}
+            included = bool(names & include)
+            if include and not included:
+                log.info("[mcp] %s: %s not in include allowlist — skipped", name, tool.name)
+                continue
+            # include wins over a same-server exclude; the global denylist is the
+            # hard safety net and is never overridden.
+            if (names & exclude) and not included:
+                log.info("[mcp] %s: %s in exclude — skipped", name, tool.name)
+                continue
+            if names & denylist:
                 log.info("[mcp] %s: %s in denylist — skipped", name, tool.name)
                 continue
             if tool.name in core_names:


### PR DESCRIPTION
First of the ADR 0005 tool-pollution improvements — the highest-impact, lowest-effort one.

## Problem

A single MCP server can export dozens-to-hundreds of tools. protoAgent bound **every** discovered tool eagerly, and every bound tool's name + description + JSON schema is sent to the model on **every** turn. Past ~10–15 tools that burns context and degrades selection accuracy ([ADR 0005](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0005-tool-pollution-and-progressive-disclosure.md)).

## Change

Two per-server knobs in `build_mcp_tools` (`tools/mcp_tools.py`), keyed off the existing `servers[]` dict shape (no dataclass change):

| Key | Effect |
|---|---|
| `tools.include: [...]` | **Allowlist** — when set, only these tools bind. The surgical fix for a chatty server. |
| `tools.exclude: [...]` | Drops from the remainder. `include` wins if a name is in both. |
| `enabled: false` | Server is **never connected** (lazy) — no connection, no context cost. |

- Filters match the **bare** (`get_pull_request`) or **namespaced** (`github__get_pull_request`) name.
- The global `denylist` stays the cross-server hard block and is never overridden by `include`.
- **No filter set → all tools bind** (original behavior). Existing configs unchanged.

```yaml
mcp:
  enabled: true
  servers:
    - name: github
      transport: stdio
      command: npx
      args: ["-y", "@modelcontextprotocol/server-github"]
      tools:
        include: [get_pull_request, list_issues]   # ONLY these bind
```

## Verification

- `tests/test_mcp_tools.py`: +5 tests — allowlist keeps only listed, exclude drops, include-wins-over-same-server-exclude, global-denylist-overrides-include, and lazy disable (asserts the client is **never constructed**). Full mcp+config slice: 92 passed.
- `npm run docs:build` clean.
- Docs: MCP guide gains a "Keeping tools out of context" section; configuration reference + ADR 0005 cross-linked.

Part of the ADR 0005 series (next: skills `tools:` wiring, then opt-in deferred `search_tools`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)