### PR TITLE
feat(skills): surface a skill's declared tools to the agent (ADR 0005 #2)

### DIFF
--- a/docs/adr/0005-tool-pollution-and-progressive-disclosure.md
+++ b/docs/adr/0005-tool-pollution-and-progressive-disclosure.md
@@ -1,6 +1,6 @@
 # ADR 0005 — Tool Pollution & Progressive Tool Disclosure
 
-- **Status:** Proposed (2026-05-31) — findings + ranked plan; no code yet
+- **Status:** Accepted (2026-05-31) — implementing the ranked plan (#1, #2 shipped)
 - **Date:** 2026-05-31
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** architecture, agent, tools, mcp, skills, context, prompt
@@ -144,25 +144,28 @@ directional:
    already-parsed-but-unused `tools:` frontmatter) rather than inventing a
    parallel mechanism.
 
-## 5. Ranked Plan (impact → effort) — *for a follow-up, not committed here*
+## 5. Ranked Plan (impact → effort)
 
-1. **MCP per-server allowlist + lazy connect** *(low effort, biggest win).*
-   Add `mcp.servers[].tools.include` (+ keep `exclude`/global `denylist`); filter
-   discovered tools in `build_mcp_tools` so a large server can't dump its whole
-   catalog; skip connecting a server that's disabled or contributes zero tools.
-   Pure Hermes pattern; fits the existing config shape (`graph/config.py`
-   `mcp_servers`, `mcp_denylist`).
-2. **Wire skills' `tools:` frontmatter** *(medium).* When a skill is retrieved
-   for the turn, surface/prioritize its declared tool subset (and let heavy
-   groups stay quiet otherwise). Turns the existing skill layer into the
-   per-task tool selector — the OpenClaw model.
-3. **Deferred `search_tools` meta-tool** *(medium-high; only past ~15 routinely
-   relevant tools).* Bind a names-only roster + one retrieval tool that expands
-   matching schemas and re-binds them for subsequent turns (Anthropic
-   Tool-Search / this harness's ToolSearch). Real change to how `create_agent`
-   binds tools (dynamic per-turn tool set).
-4. **Code-execution facade over MCP** *(high; only if hundreds of endpoints and
-   1–3 are insufficient).* Highest ceiling, most infrastructure.
+1. ✅ **MCP per-server allowlist + lazy connect** *(low effort, biggest win —
+   shipped).* `mcp.servers[].tools.include`/`exclude` + per-server
+   `enabled: false` filter discovered tools in `build_mcp_tools` so a large
+   server can't dump its whole catalog; the global `denylist` stays the hard
+   block. Pure Hermes pattern; no config-dataclass change (per-server dict keys).
+2. ✅ **Wire skills' `tools:` frontmatter** *(medium — shipped).* When a skill is
+   retrieved for the turn, its declared tools are surfaced to the model as a
+   `<relevant_tools>` hint inside the `<learned_skills>` block (a relevance
+   nudge, not a gate — every tool stays bound). `SkillRecord.tools_used` now
+   flows from `load_skills` through `KnowledgeMiddleware._format_learned_skills`.
+   The OpenClaw "skill points at its tools" model, adapted to a bound tool set.
+3. **Deferred `search_tools` meta-tool** *(medium-high; opt-in — only worth
+   enabling past ~15 routinely relevant tools).* Bind a names-only roster + one
+   retrieval tool that expands matching schemas and re-binds them for subsequent
+   turns (Anthropic Tool-Search / this harness's ToolSearch). Real change to how
+   `create_agent` binds tools (dynamic per-turn tool set); ship behind a config
+   flag, default off, so default behavior is unchanged.
+4. **Code-execution facade over MCP** *(high; deferred — only if hundreds of
+   endpoints and 1–3 are insufficient).* Highest ceiling, most infrastructure.
+   With #1 bounding MCP catalogs, this trigger is unlikely near-term.
 
 Subagent isolation (result pollution) already exists and needs no work.
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -13,4 +13,4 @@ decision, numbered, never deleted (supersede instead).
 | [0002](./0002-reusable-subagent-workflows.md) | Reusable Subagent Workflows | Accepted |
 | [0003](./0003-reactive-agent-activity-thread.md) | Reactive Agent: Activity Thread, Event Bus & Inbound Inbox | Accepted |
 | [0004](./0004-multi-instance-data-scoping.md) | Multi-Instance Data Scoping | Accepted |
-| [0005](./0005-tool-pollution-and-progressive-disclosure.md) | Tool Pollution & Progressive Tool Disclosure | Proposed |
+| [0005](./0005-tool-pollution-and-progressive-disclosure.md) | Tool Pollution & Progressive Tool Disclosure | Accepted |

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -36,7 +36,7 @@ tools: [web_search, fetch_url]   # optional, advisory
 |---|---|---|
 | `name` | ✅ | Unique, lowercase-with-hyphens. |
 | `description` | ✅ | ≤ 1024 chars. This is the **trigger signal** — write it "pushy": say plainly *when* the agent should reach for this skill, or it under-triggers. |
-| `tools` (or `metadata.tools`) | — | Advisory list of tool names the skill uses. |
+| `tools` (or `metadata.tools`) | — | Advisory list of tool names the skill uses. When the skill is retrieved for a turn, these are surfaced to the agent as `<relevant_tools>` so it knows which of its (already-bound) tools this skill relies on — a relevance hint, not a gate. See [ADR 0005](/adr/0005-tool-pollution-and-progressive-disclosure). |
 
 The markdown **body** is the skill's instructions — freeform; write whatever
 helps the agent perform the task.

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -270,9 +270,17 @@ class KnowledgeMiddleware(AgentMiddleware):
         def _format_skill(s: "SkillRecord") -> str:
             # Truncate prompt_template to 500 chars to keep block concise
             pt = s.prompt_template[:500] if s.prompt_template else ""
+            # Surface the skill's declared tools so the model knows which of its
+            # (already-bound) tools this skill relies on — a relevance hint, not
+            # a gate. See ADR 0005 (tool pollution / progressive disclosure).
+            tools = getattr(s, "tools_used", ()) or ()
+            tools_line = (
+                f"    <relevant_tools>{', '.join(tools)}</relevant_tools>\n" if tools else ""
+            )
             return (
                 f'  <skill name="{s.name}">\n'
                 f"    <description>{s.description}</description>\n"
+                f"{tools_line}"
                 f"    <prompt_template>{pt}</prompt_template>\n"
                 f"  </skill>"
             )

--- a/graph/skills/index.py
+++ b/graph/skills/index.py
@@ -55,6 +55,7 @@ class SkillRecord(NamedTuple):
     description: str
     prompt_template: str
     score: float
+    tools_used: tuple[str, ...] = ()
 
 
 class SkillsIndex:
@@ -286,7 +287,8 @@ class SkillsIndex:
         try:
             cur = conn.execute(
                 """
-                SELECT name, description, prompt_template, bm25(skills_fts) AS score
+                SELECT name, description, prompt_template, tools_used,
+                       bm25(skills_fts) AS score
                 FROM skills_fts
                 WHERE skills_fts MATCH ?
                 ORDER BY score
@@ -301,6 +303,7 @@ class SkillsIndex:
                     description=row["description"],
                     prompt_template=row["prompt_template"],
                     score=float(row["score"]),
+                    tools_used=tuple((row["tools_used"] or "").split()),
                 )
                 for row in rows
             ]

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -194,6 +194,14 @@ def test_load_skills_returns_skill_records(populated_index) -> None:
     assert isinstance(r.score, float)
 
 
+def test_load_skills_returns_tools_used(populated_index) -> None:
+    """load_skills() surfaces the skill's declared tools (ADR 0005) so the
+    middleware can hint which tools a retrieved skill relies on."""
+    results = populated_index.load_skills("web search research")
+    top = next(r for r in results if r.name == "web-research")
+    assert top.tools_used == ("web_search", "fetch_url")
+
+
 def test_retrieval_ranking(populated_index) -> None:
     """FTS5 must rank the most relevant skill first for a specific query."""
     results = populated_index.load_skills("mathematical calculation expression")
@@ -323,6 +331,31 @@ def test_format_learned_skills_basic_formatting() -> None:
     assert 'name="web-research"' in block
     assert "Research the web" in block
     assert "Search for {topic}" in block
+
+
+def test_format_learned_skills_surfaces_relevant_tools() -> None:
+    """A skill's declared tools are emitted as <relevant_tools> (ADR 0005)."""
+    km = _make_knowledge_middleware_no_store()
+    block = km._format_learned_skills([SkillRecord(
+        name="web-research",
+        description="Research the web",
+        prompt_template="Search for {topic}",
+        score=-1.5,
+        tools_used=("web_search", "fetch_url"),
+    )])
+    assert "<relevant_tools>web_search, fetch_url</relevant_tools>" in block
+
+
+def test_format_learned_skills_omits_tools_when_none() -> None:
+    """No declared tools → no <relevant_tools> line (back-compat)."""
+    km = _make_knowledge_middleware_no_store()
+    block = km._format_learned_skills([SkillRecord(
+        name="bare",
+        description="No tools declared",
+        prompt_template="do {thing}",
+        score=-1.0,
+    )])
+    assert "<relevant_tools>" not in block
 
 
 def test_token_budget_enforcement() -> None:


### PR DESCRIPTION
Second ADR 0005 improvement — make the skill system the per-task tool-selection layer.

## Problem

Skills already parse a `tools:` frontmatter array (`SkillV1Artifact.tools_used`) and store it in the FTS index — but **nothing consumed it**. The retrieval path injected a skill's name/description/prompt_template and dropped the tool hint on the floor.

## Change

Wire `tools_used` through retrieval so a matched skill tells the model which tools it relies on:

- `SkillRecord` gains `tools_used`; `load_skills` now `SELECT`s the column and returns it (space-joined string → tuple).
- `KnowledgeMiddleware._format_learned_skills` emits a `<relevant_tools>` line in each `<skill>` block when tools are declared:

```xml
<learned_skills>
  <skill name="web-research">
    <description>Research a topic…</description>
    <relevant_tools>web_search, fetch_url</relevant_tools>
    <prompt_template>…</prompt_template>
  </skill>
</learned_skills>
```

**This is a relevance hint, not a gate** — every tool stays bound, so a mis-retrieved skill can never *hide* a needed tool. It's the OpenClaw "skill points at its tools" model adapted to a bound tool set: when a skill triggers, the agent is nudged toward its tools without removing anything.

## Verification

- `tests/test_skill_index.py`: `load_skills` returns `tools_used`; `_format_learned_skills` emits `<relevant_tools>` when present and **omits** it when absent (back-compat). 35 passed; full skill suite (106) green.
- `npm run docs:build` clean.
- Docs: skills-guide frontmatter table updated; **ADR 0005 → Accepted**, #1 + #2 marked shipped.

Next: opt-in deferred `search_tools` (#3, behind a default-off flag). #4 (code-exec facade) stays deferred per the ADR's trigger condition.

🤖 Generated with [Claude Code](https://claude.com/claude-code)