### PR TITLE
feat(tools): opt-in deferred tools + search_tools meta-tool (ADR 0005 #3)

### DIFF
--- a/docs/adr/0005-tool-pollution-and-progressive-disclosure.md
+++ b/docs/adr/0005-tool-pollution-and-progressive-disclosure.md
@@ -1,6 +1,6 @@
 # ADR 0005 — Tool Pollution & Progressive Tool Disclosure
 
-- **Status:** Accepted (2026-05-31) — implementing the ranked plan (#1, #2 shipped)
+- **Status:** Accepted (2026-05-31) — #1, #2, #3 shipped; #4 deferred by design
 - **Date:** 2026-05-31
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** architecture, agent, tools, mcp, skills, context, prompt
@@ -157,12 +157,16 @@ directional:
    nudge, not a gate — every tool stays bound). `SkillRecord.tools_used` now
    flows from `load_skills` through `KnowledgeMiddleware._format_learned_skills`.
    The OpenClaw "skill points at its tools" model, adapted to a bound tool set.
-3. **Deferred `search_tools` meta-tool** *(medium-high; opt-in — only worth
-   enabling past ~15 routinely relevant tools).* Bind a names-only roster + one
-   retrieval tool that expands matching schemas and re-binds them for subsequent
-   turns (Anthropic Tool-Search / this harness's ToolSearch). Real change to how
-   `create_agent` binds tools (dynamic per-turn tool set); ship behind a config
-   flag, default off, so default behavior is unchanged.
+3. ✅ **Deferred `search_tools` meta-tool** *(medium-high; opt-in — shipped,
+   default off).* `tools.deferred.enabled` adds a `search_tools` meta-tool +
+   `ToolDeferralMiddleware`. `create_agent` still receives every tool (so all
+   executors are registered — deferral never breaks execution); the middleware's
+   `wrap_model_call` trims `request.tools` to a base set (keyless core +
+   delegation/workflow + `search_tools`) plus whatever the agent has *loaded* by
+   calling `search_tools`. "Loaded" is read straight from the message history
+   (the backticked names in `search_tools` results) — no extra state channel.
+   Anthropic Tool-Search / this harness's ToolSearch pattern, model-agnostic
+   (works through any gateway, not just the Anthropic beta param).
 4. **Code-execution facade over MCP** *(high; deferred — only if hundreds of
    endpoints and 1–3 are insufficient).* Highest ceiling, most infrastructure.
    With #1 bounding MCP catalogs, this trigger is unlikely near-term.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -206,6 +206,24 @@ execute_code:
 
 > **Security:** subprocess + env-scrub + timeout is *isolation, not a true sandbox* — the child can still touch the filesystem and network as the server user. Enable only for trusted-model output or inside a hardened container (seccomp / read-only FS / network policy). Narrow `tools` to the minimum the workload needs.
 
+## `tools`
+
+**Deferred tools** — progressive tool disclosure for high tool counts ([ADR 0005](../adr/0005-tool-pollution-and-progressive-disclosure.md)). When enabled, only a small base set + a `search_tools` meta-tool are shown to the model each turn; the rest stay bound (callable) but their schemas are withheld until the agent calls `search_tools` to load them. This cuts the per-turn tool-schema footprint and improves selection accuracy once you routinely exceed ~15 tools.
+
+```yaml
+tools:
+  deferred:
+    enabled: false          # OFF by default — the full tool set is shown
+    keep: []                # always-on tool names; empty = built-in base
+```
+
+| Key | Default | What |
+|---|---|---|
+| `deferred.enabled` | `false` | Withhold most tool schemas; expose them via `search_tools`. |
+| `deferred.keep` | `[]` | Tool names always shown. Empty → built-in base (keyless core + `task`/`task_batch`/`run_workflow`/`save_workflow` + `search_tools`). `search_tools` is always kept regardless. |
+
+Every tool remains **executable** even while deferred — `create_agent` registers all executors; deferral only trims what the model *sees* per turn. The agent loads tools by calling `search_tools("github pull request")`; matches stay available for the rest of the thread. Leave off unless you have a large catalog (e.g. a chatty MCP server) — for a handful of tools it adds a discovery hop for no benefit.
+
 ## `routing`
 
 Wires langchain's `ModelFallbackMiddleware`: on a primary-model error, retry on each fallback model (same gateway) in order. Opt-in (empty = no fallback).

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -54,6 +54,14 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
             skills_top_k=config.skills_top_k,
         ))
 
+    # Deferred-tool disclosure (ADR 0005 #3) — trims the per-call tool set to
+    # base + agent-loaded. Opt-in; the search_tools meta-tool is added to the
+    # tool list in create_agent_graph when this is on.
+    if config.tools_deferred_enabled:
+        from graph.middleware.tool_deferral import ToolDeferralMiddleware
+        from tools.lg_tools import resolve_deferred_keep
+        middleware.append(ToolDeferralMiddleware(resolve_deferred_keep(config.tools_deferred_keep)))
+
     if config.audit_middleware:
         middleware.append(AuditMiddleware())
 
@@ -649,6 +657,15 @@ def create_agent_graph(
     if config.execute_code_enabled:
         from tools.execute_code import build_execute_code_tool
         all_tools.append(build_execute_code_tool(all_tools, config=config))
+
+    # Deferred tools (ADR 0005 #3) — opt-in progressive disclosure. The
+    # search_tools meta-tool is built over the full set (so it can surface any
+    # of them) and ToolDeferralMiddleware trims the per-call schemas to base +
+    # loaded. Every tool stays callable; only the model's view is trimmed.
+    if config.tools_deferred_enabled:
+        from tools.lg_tools import build_search_tools_tool, resolve_deferred_keep
+        keep = resolve_deferred_keep(config.tools_deferred_keep)
+        all_tools.append(build_search_tools_tool(all_tools, keep))
 
     middleware = _build_middleware(config, knowledge_store, skills_index=skills_index)
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -153,6 +153,17 @@ class LangGraphConfig:
     execute_code_tools: list[str] = field(default_factory=list)
     execute_code_output_truncate: int = 6000
 
+    # Deferred tools (ADR 0005 #3) — progressive tool disclosure for high tool
+    # counts. When enabled, only a small base set + a ``search_tools`` meta-tool
+    # are exposed to the model each turn; the rest are bound (callable) but their
+    # schemas are withheld until the agent searches for and "loads" them. Cuts
+    # the per-turn tool-schema footprint and improves selection accuracy past
+    # ~15 tools. OFF by default — the full tool set is exposed (unchanged).
+    # ``tools_deferred_keep`` overrides the always-on base (empty → built-in
+    # base: keyless core + delegation/workflow tools + search_tools).
+    tools_deferred_enabled: bool = False
+    tools_deferred_keep: list[str] = field(default_factory=list)
+
     # Model routing / failover — wires langchain's ModelFallbackMiddleware.
     # On primary error, retry on each fallback model (same gateway) in order.
     routing_fallback_models: list[str] = field(default_factory=list)
@@ -349,6 +360,8 @@ class LangGraphConfig:
             execute_code_timeout=data.get("execute_code", {}).get("timeout", cls.execute_code_timeout),
             execute_code_tools=data.get("execute_code", {}).get("tools", []),
             execute_code_output_truncate=data.get("execute_code", {}).get("output_truncate", cls.execute_code_output_truncate),
+            tools_deferred_enabled=data.get("tools", {}).get("deferred", {}).get("enabled", cls.tools_deferred_enabled),
+            tools_deferred_keep=list(data.get("tools", {}).get("deferred", {}).get("keep", []) or []),
             routing_fallback_models=data.get("routing", {}).get("fallback_models", []),
             aux_model=data.get("routing", {}).get("aux_model", cls.aux_model),
             goal_enabled=data.get("goal", {}).get("enabled", cls.goal_enabled),

--- a/graph/middleware/tool_deferral.py
+++ b/graph/middleware/tool_deferral.py
@@ -1,0 +1,106 @@
+"""ToolDeferralMiddleware — progressive tool disclosure (ADR 0005 #3).
+
+When the agent is wired with many tools (notably a large MCP catalog), every
+bound tool's name + description + JSON schema is sent to the model on *every*
+turn. Past ~10–15 tools that burns context and degrades tool selection ("tool
+pollution"). This middleware withholds most tool *schemas* from the model while
+keeping every tool *callable*:
+
+- ``create_agent`` still receives the full tool list, so the ToolNode can
+  execute any tool — deferral never breaks execution.
+- At the ``wrap_model_call`` boundary (the only place that sees the final
+  ModelRequest), we trim ``request.tools`` to a small **base** set plus whatever
+  the agent has *loaded* by calling ``search_tools``.
+
+"Loaded" is read straight from the message history: ``search_tools`` returns its
+matches as a backticked bulleted list, so the names it surfaced are recoverable
+from its ToolMessages — no extra state channel, and it survives summarization as
+long as those messages do. Once surfaced, a tool stays available for the rest of
+the thread.
+
+OFF by default (the middleware is only added when ``tools.deferred.enabled``);
+when off, the full tool set reaches the model exactly as before.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from langchain.agents.middleware import AgentMiddleware
+
+from tools.lg_tools import SEARCH_TOOLS_NAME
+
+log = logging.getLogger(__name__)
+
+# Names inside backticks on the search_tools result lines.
+_BACKTICKED = re.compile(r"`([^`]+)`")
+
+
+def _message_text(msg) -> str:
+    """Flatten a message's content to text (str or content-block list)."""
+    content = getattr(msg, "content", "")
+    if isinstance(content, str):
+        return content
+    if isinstance(content, list):
+        return "".join(
+            b.get("text", "") for b in content if isinstance(b, dict) and b.get("type") == "text"
+        )
+    return str(content)
+
+
+def _tool_name(t) -> str | None:
+    """Name of a request tool entry — a BaseTool or a provider tool-spec dict."""
+    name = getattr(t, "name", None)
+    if name:
+        return name
+    if isinstance(t, dict):
+        return t.get("name") or (t.get("function") or {}).get("name")
+    return None
+
+
+def activated_tool_names(messages) -> set[str]:
+    """Tool names the agent has surfaced via ``search_tools`` so far.
+
+    Scans ToolMessages emitted by ``search_tools`` for the backticked names in
+    its rendered result. Tolerant: a non-search ToolMessage or odd content
+    contributes nothing.
+    """
+    names: set[str] = set()
+    for m in messages or []:
+        if getattr(m, "type", None) != "tool":
+            continue
+        if getattr(m, "name", None) != SEARCH_TOOLS_NAME:
+            continue
+        names.update(_BACKTICKED.findall(_message_text(m)))
+    return names
+
+
+class ToolDeferralMiddleware(AgentMiddleware):
+    """Trim the per-call tool set to base + agent-loaded tools."""
+
+    def __init__(self, keep_names):
+        super().__init__()
+        self._keep = set(keep_names)
+
+    def _transform(self, request):
+        tools = getattr(request, "tools", None)
+        if not tools:
+            return request
+        state = getattr(request, "state", None) or {}
+        messages = state.get("messages") if isinstance(state, dict) else getattr(state, "messages", None)
+        allowed = self._keep | activated_tool_names(messages)
+        # Keep base + loaded tools; an unidentifiable entry (no name) is kept.
+        kept = [t for t in tools if (_tool_name(t) or "") in allowed or _tool_name(t) is None]
+        if not kept or len(kept) == len(tools):
+            return request  # nothing deferred this turn — safe no-op
+        log.debug(
+            "[tool-deferral] exposing %d/%d tools this turn", len(kept), len(tools)
+        )
+        return request.override(tools=kept)
+
+    def wrap_model_call(self, request, handler):
+        return handler(self._transform(request))
+
+    async def awrap_model_call(self, request, handler):
+        return await handler(self._transform(request))

--- a/tests/test_tool_deferral.py
+++ b/tests/test_tool_deferral.py
@@ -1,0 +1,171 @@
+"""Tests for deferred-tool progressive disclosure (ADR 0005 #3).
+
+Covers the search_tools meta-tool (matching/listing) and the
+ToolDeferralMiddleware (trimming the per-call tool set to base + loaded),
+plus the config round-trip. No live model — the middleware is exercised with
+a fake ModelRequest, mirroring how langchain calls wrap_model_call.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+from langchain_core.messages import HumanMessage, ToolMessage
+
+from graph.config import LangGraphConfig
+from graph.middleware.tool_deferral import (
+    ToolDeferralMiddleware,
+    activated_tool_names,
+)
+from tools.lg_tools import (
+    DEFERRED_BASE_TOOL_NAMES,
+    SEARCH_TOOLS_NAME,
+    build_search_tools_tool,
+    resolve_deferred_keep,
+)
+
+
+def _tool(name, desc):
+    return SimpleNamespace(name=name, description=desc)
+
+
+def _catalog():
+    # A base tool (kept) + three deferred tools.
+    return [
+        _tool("web_search", "Search the web with DuckDuckGo."),
+        _tool("github_get_pr", "Fetch a GitHub pull request by number."),
+        _tool("notes_read", "Read a tab from the operator Notes panel."),
+        _tool("schedule_task", "Schedule a future reminder or job."),
+    ]
+
+
+# ── resolve_deferred_keep ─────────────────────────────────────────────────────
+
+
+def test_resolve_keep_defaults_to_builtin_base() -> None:
+    keep = resolve_deferred_keep([])
+    assert keep == set(DEFERRED_BASE_TOOL_NAMES)
+    assert SEARCH_TOOLS_NAME in keep
+
+
+def test_resolve_keep_override_always_includes_search() -> None:
+    # A custom keep list that forgets search_tools still gets it (bootstrap).
+    keep = resolve_deferred_keep(["web_search"])
+    assert keep == {"web_search", SEARCH_TOOLS_NAME}
+
+
+# ── search_tools meta-tool ────────────────────────────────────────────────────
+
+
+def test_search_tools_matches_by_keyword() -> None:
+    st = build_search_tools_tool(_catalog(), {"web_search", SEARCH_TOOLS_NAME})
+    out = st.invoke({"query": "github pull request"})
+    assert "`github_get_pr`" in out
+    assert "`notes_read`" not in out
+
+
+def test_search_tools_excludes_kept_tools() -> None:
+    # web_search is in keep → never offered by search_tools (it's already shown).
+    st = build_search_tools_tool(_catalog(), {"web_search", SEARCH_TOOLS_NAME})
+    out = st.invoke({"query": "search"})
+    assert "`web_search`" not in out
+
+
+def test_search_tools_empty_query_lists_all_deferred() -> None:
+    st = build_search_tools_tool(_catalog(), {"web_search", SEARCH_TOOLS_NAME})
+    out = st.invoke({"query": ""})
+    for name in ("github_get_pr", "notes_read", "schedule_task"):
+        assert f"`{name}`" in out
+
+
+def test_search_tools_no_match_falls_back_to_listing() -> None:
+    st = build_search_tools_tool(_catalog(), {"web_search", SEARCH_TOOLS_NAME})
+    out = st.invoke({"query": "xyzzy-nonexistent"})
+    assert "No tool matched" in out
+    assert "`github_get_pr`" in out  # still callable via the fallback listing
+
+
+# ── activated_tool_names ──────────────────────────────────────────────────────
+
+
+def test_activated_reads_backticked_names_from_search_results() -> None:
+    msgs = [
+        HumanMessage(content="do a thing"),
+        ToolMessage(
+            content="Found 1 tool(s) — now available to call:\n- `github_get_pr` — Fetch a PR.",
+            name=SEARCH_TOOLS_NAME,
+            tool_call_id="t1",
+        ),
+    ]
+    assert activated_tool_names(msgs) == {"github_get_pr"}
+
+
+def test_activated_ignores_non_search_tool_messages() -> None:
+    msgs = [ToolMessage(content="result with a `backtick`", name="github_get_pr", tool_call_id="t2")]
+    assert activated_tool_names(msgs) == set()
+
+
+# ── ToolDeferralMiddleware ────────────────────────────────────────────────────
+
+
+class _FakeRequest:
+    def __init__(self, tools, messages):
+        self.tools = tools
+        self.state = {"messages": messages}
+
+    def override(self, **kw):
+        self.tools = kw.get("tools", self.tools)
+        return self
+
+
+def _names(tools):
+    return [t.name for t in tools]
+
+
+def test_middleware_trims_to_base_when_nothing_loaded() -> None:
+    mw = ToolDeferralMiddleware({"web_search", SEARCH_TOOLS_NAME})
+    tools = _catalog() + [_tool(SEARCH_TOOLS_NAME, "Find tools.")]
+    req = _FakeRequest(tools, [HumanMessage(content="hi")])
+    out = mw.wrap_model_call(req, lambda r: r)
+    assert set(_names(out.tools)) == {"web_search", SEARCH_TOOLS_NAME}
+
+
+def test_middleware_exposes_loaded_tools() -> None:
+    mw = ToolDeferralMiddleware({"web_search", SEARCH_TOOLS_NAME})
+    tools = _catalog() + [_tool(SEARCH_TOOLS_NAME, "Find tools.")]
+    msgs = [
+        HumanMessage(content="get the PR"),
+        ToolMessage(content="- `github_get_pr` — Fetch a PR.", name=SEARCH_TOOLS_NAME, tool_call_id="t1"),
+    ]
+    req = _FakeRequest(tools, msgs)
+    out = mw.wrap_model_call(req, lambda r: r)
+    assert set(_names(out.tools)) == {"web_search", SEARCH_TOOLS_NAME, "github_get_pr"}
+
+
+def test_middleware_noop_when_all_tools_are_base() -> None:
+    # Nothing to defer → request is returned untouched (same object).
+    mw = ToolDeferralMiddleware({"web_search", SEARCH_TOOLS_NAME})
+    tools = [_tool("web_search", "x"), _tool(SEARCH_TOOLS_NAME, "y")]
+    req = _FakeRequest(tools, [])
+    out = mw.wrap_model_call(req, lambda r: r)
+    assert _names(out.tools) == ["web_search", SEARCH_TOOLS_NAME]
+
+
+# ── config round-trip ─────────────────────────────────────────────────────────
+
+
+def test_config_parses_deferred_tools(tmp_path) -> None:
+    p = tmp_path / "langgraph-config.yaml"
+    p.write_text(
+        "tools:\n"
+        "  deferred:\n"
+        "    enabled: true\n"
+        "    keep: [web_search, current_time]\n"
+    )
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.tools_deferred_enabled is True
+    assert cfg.tools_deferred_keep == ["web_search", "current_time"]
+
+
+def test_config_deferred_default_off() -> None:
+    assert LangGraphConfig().tools_deferred_enabled is False

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -599,3 +599,89 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None):
     if inbox_store is not None:
         tools.extend(_build_inbox_tools(inbox_store))
     return tools
+
+
+# ── deferred tools (ADR 0005 #3) ──────────────────────────────────────────────
+
+SEARCH_TOOLS_NAME = "search_tools"
+
+# Tools always exposed to the model when deferral is on. The keyless core +
+# delegation/workflow tools + the search meta-tool itself — enough to operate
+# and to *discover* the rest. Everything else is deferred until searched.
+DEFERRED_BASE_TOOL_NAMES = frozenset({
+    "current_time", "calculator", "web_search", "fetch_url", "ask_human",
+    "task", "task_batch", "run_workflow", "save_workflow",
+    SEARCH_TOOLS_NAME,
+})
+
+
+def resolve_deferred_keep(configured_keep) -> set[str]:
+    """Resolve the always-on tool set for deferral: the configured override (if
+    any) else the built-in base. ``search_tools`` is always kept — without it the
+    agent could never load anything back."""
+    keep = {str(n) for n in (configured_keep or [])} or set(DEFERRED_BASE_TOOL_NAMES)
+    keep.add(SEARCH_TOOLS_NAME)
+    return keep
+
+
+def _tool_summary(t) -> str:
+    """First non-empty line of a tool's description, truncated."""
+    desc = (getattr(t, "description", "") or "").strip()
+    first = next((ln.strip() for ln in desc.splitlines() if ln.strip()), "")
+    return (first[:119].rstrip() + "…") if len(first) > 120 else first
+
+
+def build_search_tools_tool(all_tools, keep_names):
+    """Build the ``search_tools`` meta-tool over the *deferred* tools.
+
+    It keyword-matches the deferred tools (everything not in ``keep_names``) by
+    name + description and returns matches as a backticked bulleted list. The
+    ``ToolDeferralMiddleware`` reads those backticked names from the result and
+    binds the matched tools on subsequent turns (progressive disclosure).
+    """
+    keep = set(keep_names)
+    catalog = [
+        (t.name, _tool_summary(t))
+        for t in all_tools
+        if getattr(t, "name", None) and t.name not in keep
+    ]
+
+    def _render(pairs, header) -> str:
+        lines = [header]
+        for name, summary in pairs:
+            lines.append(f"- `{name}` — {summary}" if summary else f"- `{name}`")
+        return "\n".join(lines)
+
+    @tool
+    def search_tools(query: str = "", limit: int = 10) -> str:
+        """Find and load additional tools by capability.
+
+        Most tools are not shown up-front, to keep your working context focused.
+        When your visible tools don't cover the task, call this with a few
+        keywords describing what you need (e.g. "github pull request", "schedule
+        reminder", "read notes panel"). Matching tools become available to call
+        on your next step. Leave ``query`` empty to list every available tool.
+        Returns a bulleted list of ``name — purpose``.
+        """
+        if not catalog:
+            return "No additional tools are available beyond the ones already shown."
+        terms = (query or "").lower().split()
+        lim = max(1, min(int(limit or 10), 50))
+        if not terms:
+            return _render(catalog[:lim], "All additional tools — now available to call:")
+        scored = []
+        for name, summary in catalog:
+            hay = f"{name} {summary}".lower()
+            score = sum(hay.count(term) for term in terms)
+            if score:
+                scored.append((score, name, summary))
+        if not scored:
+            return _render(
+                catalog[:lim],
+                f'No tool matched "{query}". Here are the available tools (now callable):',
+            )
+        scored.sort(key=lambda r: (-r[0], r[1]))
+        shown = [(n, s) for _, n, s in scored[:lim]]
+        return _render(shown, f'Found {len(shown)} tool(s) for "{query}" — now available to call:')
+
+    return search_tools


### PR DESCRIPTION
Third ADR 0005 improvement — progressive tool disclosure (Anthropic Tool-Search / this harness's ToolSearch pattern), **default off**.

## Problem

Every bound tool's name + description + JSON schema is sent to the model **every turn**. Past ~10–15 tools that burns context and degrades selection. PR #387 bounded the MCP catalog; this adds the general lever for when the *total* tool count is high.

## Change

`tools.deferred.enabled: true` →

- **`search_tools` meta-tool** (`tools/lg_tools.py`) — keyword-searches the deferred tools by name + description; empty query lists all; no match falls back to the full listing. Returns a backticked bulleted roster.
- **`ToolDeferralMiddleware`** (`graph/middleware/tool_deferral.py`) — at the `wrap_model_call` boundary, trims `request.tools` to a base set + whatever the agent has **loaded**. "Loaded" is read straight from the message history (the backticked names in prior `search_tools` results) — no extra state channel, survives summarization with the messages.
- **`graph/agent.py`** — when enabled, appends `search_tools` to the tool list and registers the middleware.

```yaml
tools:
  deferred:
    enabled: true
    keep: []          # always-on names; empty = built-in base
```

**Key safety property:** `create_agent` still receives *every* tool, so all executors are registered — deferral only trims what the model **sees**, never what it can **run**. If the model ever calls a not-yet-loaded tool, the ToolNode still executes it. Default off → full tool set shown, behavior unchanged. Model-agnostic (works through any gateway, not just the Anthropic `defer_loading` beta).

## Verification

- `tests/test_tool_deferral.py` (13): search matching / exclude-kept / empty-lists-all / no-match-fallback; `activated_tool_names` parsing (and ignoring non-search ToolMessages); middleware trim-to-base / expose-loaded / no-op-when-all-base; config round-trip + default-off.
- Wiring smoke: `ToolDeferralMiddleware` present iff enabled; `search_tools` builds over the full set and excludes kept names.
- Full config + mcp + deferral slice green; `npm run docs:build` clean.
- Docs: configuration reference gains a `tools` section; **ADR 0005 → #1/#2/#3 shipped, #4 deferred** by its own trigger condition.

## On #4 (code-execution facade)

Left deferred per the ADR: it's "only if hundreds of endpoints and 1–3 are insufficient." With #1 bounding MCP catalogs and #3 available for high counts, that trigger is unlikely near-term — building it now would be speculative infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)