### PR TITLE
chore(release): manual cadence + committed CHANGELOG, harden for release

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -1,16 +1,16 @@
 name: 'Prepare Release'
 
-# Runs after any non-release PR merges to main, OR manually.
-# Bumps the version in pyproject.toml, opens a prepare-release/vX.Y.Z
-# branch, commits it as "chore: release vX.Y.Z", auto-merges back to
-# main once CI passes, and pushes the semver tag. The tag push is what
-# triggers release.yml — it builds the stable semver Docker image,
-# creates the GitHub release, and posts notes to Discord.
+# Manual, on-demand releases (workflow_dispatch only). Bumps the version in
+# pyproject.toml, rolls CHANGELOG.md [Unreleased] → the new version, opens a
+# prepare-release/vX.Y.Z branch, commits it as "chore: release vX.Y.Z",
+# auto-merges back to main once the required CI checks pass, then pushes the
+# semver tag. The tag push is what triggers release.yml — it builds the stable
+# semver Docker image, creates the GitHub release, and posts notes to Discord.
+#
+# Releases are deliberately NOT cut on every merge — pick the bump level and
+# run this when a batch is ready. See docs/guides/releasing.md.
 
 on:
-  pull_request:
-    types: [closed]
-    branches: [main]
   workflow_dispatch:
     inputs:
       bump:
@@ -32,21 +32,8 @@ jobs:
   prepare:
     name: Prepare Release
     runs-on: namespace-profile-protolabs-linux
-    # Guards:
-    # - repo-scope: don't run in forks
-    # - workflow_dispatch always runs
-    # - PR merge runs only if merged=true AND title doesn't start with
-    #   "chore: release" — this is the self-loop cutoff. The release PR
-    #   merging its own bump must NOT kick off another bump.
-    if: >-
-      github.repository == 'protoLabsAI/protoAgent' &&
-      (
-        github.event_name == 'workflow_dispatch' ||
-        (
-          github.event.pull_request.merged == true &&
-          !startsWith(github.event.pull_request.title, 'chore: release')
-        )
-      )
+    # Repo-scope guard: don't run in forks.
+    if: github.repository == 'protoLabsAI/protoAgent'
     permissions:
       contents: write
       pull-requests: write
@@ -78,11 +65,14 @@ jobs:
           ")
           echo "version=$V" >> "$GITHUB_OUTPUT"
 
+      - name: Roll changelog
+        run: python scripts/changelog.py roll "${{ steps.version.outputs.version }}"
+
       - name: Preview (dry run)
         if: inputs.dry_run == true
         run: |
           echo "New version: v${{ steps.version.outputs.version }}"
-          git diff pyproject.toml
+          git --no-pager diff pyproject.toml CHANGELOG.md
 
       - name: Create release branch + PR
         if: inputs.dry_run != true
@@ -96,7 +86,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
 
           git checkout -b "${BRANCH}"
-          git add pyproject.toml
+          git add pyproject.toml CHANGELOG.md
           git commit -m "chore: release v${VERSION}"
           git push origin "${BRANCH}"
 
@@ -108,18 +98,13 @@ jobs:
           echo "PR: ${PR_URL}"
 
           # Merge strategy:
-          # - Try `--auto` first: GitHub waits for required checks and
-          #   merges when they pass. Happy path when CodeRabbit / other
-          #   checks are still pending.
-          # - If `--auto` fails for any reason, fall back to a direct
-          #   squash merge. GitHub rejects `--auto` in several distinct
-          #   cases that are all fine for this workflow's purposes:
-          #     * "clean status" — PR is already mergeable, no checks
-          #       to wait on
-          #     * "Protected branch rules not configured" — no branch
-          #       protection, so auto-merge has nothing to gate on
-          #     * (future) any other reason — the direct merge below
-          #       either succeeds or fails loud with a real error.
+          # - Try `--auto` first: the `main` ruleset requires the 3 CI checks,
+          #   so auto-merge waits for them and merges when they pass (the
+          #   release PR — pyproject.toml + CHANGELOG.md — passes all three).
+          # - Fallback to a direct squash only if `--auto` can't be enabled.
+          #   With the ruleset in place a direct merge is itself gated by the
+          #   required checks, so it either merges cleanly or fails loud (the
+          #   poll below then times out) — never a silent bypass.
           # - `--admin` is avoided entirely; it breaks when checks are
           #   "expected" but haven't started (protoPen PR #18 history).
           if ! gh pr merge "${PR_URL}" --squash --auto 2>/tmp/merge-err; then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,37 @@
+# Changelog
+
+All notable changes to protoAgent are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+> **Add your entries under [Unreleased]** in your PR. When a release is cut,
+> `prepare-release.yml` rolls them into a dated, versioned section via
+> `scripts/changelog.py`. See [Releasing](docs/guides/releasing.md).
+
+## [Unreleased]
+
+### Added
+- MCP per-server tool allowlist (`tools.include` / `tools.exclude`) and lazy
+  `enabled: false` connect, bounding the per-turn tool-schema footprint
+  (ADR 0005 #1).
+- Skills surface their declared `tools:` to the agent as `<relevant_tools>`
+  when retrieved — a relevance hint, not a gate (ADR 0005 #2).
+- Opt-in deferred tools + a `search_tools` meta-tool for progressive tool
+  disclosure at high tool counts (`tools.deferred`, ADR 0005 #3).
+- `CHANGELOG.md` (this file), following Keep a Changelog.
+
+### Changed
+- Releases are now cut **manually** via `workflow_dispatch` (choose
+  patch/minor/major) instead of auto-bumping on every merge to `main`.
+- `main` is protected by a repository ruleset: a PR and the three CI checks
+  (Verify workspace config, Python tests, Web E2E smoke) are required to merge.
+
+### Docs
+- ADR 0005 — Tool Pollution & Progressive Tool Disclosure.
+- Releasing runbook (`docs/guides/releasing.md`).
+
+---
+
+Releases cut before this changelog was introduced are recorded on the
+[GitHub Releases](https://github.com/protoLabsAI/protoAgent/releases) page.

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -53,6 +53,7 @@ export default defineConfig({
             { text: "Wire Langfuse + Prometheus", link: "/guides/observability" },
             { text: "Run multiple instances", link: "/guides/multi-instance" },
             { text: "Deploy via GHCR", link: "/guides/deploy" },
+            { text: "Releasing", link: "/guides/releasing" },
           ],
         },
       ],

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -1,0 +1,71 @@
+# Releasing
+
+protoAgent releases are **manual and on-demand** — you pick the bump level and
+run one workflow when a batch of work is ready. Merges to `main` do **not** cut
+releases on their own.
+
+## The flow at a glance
+
+```
+feature PR (adds a CHANGELOG [Unreleased] entry)  ──▶  merge to main
+                                                          │
+run "Prepare Release" (workflow_dispatch, pick bump) ◀────┘
+   │  bumps pyproject.toml + rolls CHANGELOG.md
+   │  opens chore: release vX.Y.Z PR → auto-merges when the 3 checks pass
+   ▼
+pushes tag vX.Y.Z  ──▶  Release workflow:
+                          • builds + pushes the semver Docker tags
+                          • creates the GitHub Release (notes minus chore/docs)
+                          • posts notes to Discord (release-tools)
+```
+
+`latest` Docker tag is pushed on every `main` merge by `docker-publish.yml` —
+independent of releases.
+
+## Cutting a release
+
+1. **Actions → Prepare Release → Run workflow.**
+2. Choose the **bump**: `patch` (default) · `minor` · `major`. Use `dry_run`
+   to preview the version + changelog/​pyproject diff without opening a PR.
+3. The workflow bumps the version, rolls the changelog, opens
+   `chore: release vX.Y.Z`, and auto-merges once the required checks pass, then
+   tags `vX.Y.Z` — which triggers the **Release** workflow.
+
+That's it. Don't bump `pyproject.toml` or tag by hand — the workflow owns both.
+
+## The changelog protocol
+
+We keep a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)-style
+[`CHANGELOG.md`](https://github.com/protoLabsAI/protoAgent/blob/main/CHANGELOG.md).
+
+- **In your feature PR**, add a bullet under `## [Unreleased]` in the right
+  group (`### Added` / `### Changed` / `### Fixed` / `### Removed` / `### Docs`).
+- **At release time**, `scripts/changelog.py roll <version>` (run by
+  `prepare-release.yml`) moves everything under `[Unreleased]` into a dated
+  `## [X.Y.Z] - YYYY-MM-DD` section and leaves a fresh empty `[Unreleased]`.
+- The rolled changelog is committed **inside the release PR**, so it goes
+  through the same `main` ruleset (PR + checks) as any change — nothing is
+  pushed to `main` directly.
+
+## Branch protection
+
+`main` is protected by a repository **ruleset**: every change needs a PR, and
+the three CI checks must pass to merge —
+
+| Check | Workflow |
+|---|---|
+| Verify workspace config | `checks.yml` (runs `release-tools`' `verify-workspace-config`) |
+| Python tests | `checks.yml` (`pytest`) |
+| Web E2E smoke | `checks.yml` (Playwright vs. mock backend) |
+
+Direct pushes, force-pushes, and branch deletion are blocked. Approvals are set
+to **0** so the solo/automated flow (you + the release bot) is never blocked on
+a reviewer — the gate is CI, not human review.
+
+## Required secrets
+
+| Secret | Used by | Purpose |
+|---|---|---|
+| `GH_PAT` | `prepare-release.yml` | A PAT (not `GITHUB_TOKEN`) so the tag push can trigger the downstream Release workflow. |
+| `GATEWAY_API_KEY` | `release.yml` (release-tools) | Rewrites the commit range into themed release notes via the protoLabs gateway. |
+| `DISCORD_RELEASE_WEBHOOK` | `release.yml` (release-tools) | Posts the release embed to Discord. **Optional** — the step is `continue-on-error`, so releases still succeed without it; set it to enable the Discord post. |

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python3
+"""Maintain CHANGELOG.md (Keep a Changelog format).
+
+The release-prep workflow (.github/workflows/prepare-release.yml) calls:
+
+    python scripts/changelog.py roll 0.4.0            # date = today (UTC)
+    python scripts/changelog.py roll 0.4.0 --date 2026-06-01
+
+which moves everything under ``## [Unreleased]`` into a new dated
+``## [0.4.0] - YYYY-MM-DD`` section and leaves a fresh, empty Unreleased
+block at the top. The rolled file is committed as part of the
+``chore: release vX.Y.Z`` PR, so the changelog goes through the same
+branch ruleset (PR + checks) as any other change — nothing pushes to
+``main`` directly.
+
+Contributors add their entries under ``## [Unreleased]`` in their feature
+PRs (``### Added`` / ``### Changed`` / ``### Fixed`` / ``### Docs`` / …).
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import re
+from pathlib import Path
+
+CHANGELOG = Path(__file__).parent.parent / "CHANGELOG.md"
+
+_UNRELEASED_HEADING = "## [Unreleased]"
+
+
+def roll(text: str, version: str, date: str) -> str:
+    """Return *text* with the Unreleased section promoted to ``[version] - date``.
+
+    Raises ``ValueError`` if there's no Unreleased heading.
+    """
+    m = re.search(r"^## \[Unreleased\][ \t]*\n", text, re.MULTILINE)
+    if not m:
+        raise ValueError("no '## [Unreleased]' section in CHANGELOG.md")
+
+    start = m.end()
+    # The Unreleased body runs until the next version heading (or EOF / footer).
+    nxt = re.search(r"^## \[", text[start:], re.MULTILINE)
+    end = start + nxt.start() if nxt else len(text)
+    body = text[start:end].strip("\n")
+
+    section = f"## [{version}] - {date}\n"
+    if body:
+        section += f"\n{body}\n"
+
+    before = text[: m.start()]
+    after = text[end:]
+    rebuilt = f"{before}{_UNRELEASED_HEADING}\n\n{section}\n{after}"
+    # Normalize runs of blank lines introduced by the splice.
+    return re.sub(r"\n{3,}", "\n\n", rebuilt)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Maintain CHANGELOG.md")
+    sub = parser.add_subparsers(dest="cmd", required=True)
+    p_roll = sub.add_parser("roll", help="promote Unreleased to a dated version section")
+    p_roll.add_argument("version", help="version being released, e.g. 0.4.0")
+    p_roll.add_argument(
+        "--date",
+        default=datetime.datetime.now(datetime.timezone.utc).date().isoformat(),
+        help="release date (YYYY-MM-DD); defaults to today (UTC)",
+    )
+    args = parser.parse_args()
+
+    if args.cmd == "roll":
+        text = CHANGELOG.read_text(encoding="utf-8")
+        CHANGELOG.write_text(roll(text, args.version, args.date), encoding="utf-8")
+        print(f"changelog: rolled Unreleased → [{args.version}] - {args.date}")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -1,0 +1,66 @@
+"""Tests for scripts/changelog.py (the release-prep changelog roll)."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+_SPEC = importlib.util.spec_from_file_location(
+    "changelog", Path(__file__).parent.parent / "scripts" / "changelog.py"
+)
+changelog = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(changelog)
+
+
+_BASE = """# Changelog
+
+intro text
+
+## [Unreleased]
+
+### Added
+- a new thing
+
+## [0.3.0] - 2026-05-01
+### Added
+- older thing
+"""
+
+
+def test_roll_promotes_unreleased_to_dated_section() -> None:
+    out = changelog.roll(_BASE, "0.4.0", "2026-06-01")
+    # New dated section exists with the moved content.
+    assert "## [0.4.0] - 2026-06-01" in out
+    assert "- a new thing" in out
+    # Prior version section is untouched and stays below.
+    assert "## [0.3.0] - 2026-05-01" in out
+    assert out.index("## [0.4.0]") < out.index("## [0.3.0]")
+
+
+def test_roll_leaves_fresh_empty_unreleased_on_top() -> None:
+    out = changelog.roll(_BASE, "0.4.0", "2026-06-01")
+    # Unreleased heading still present, now empty, and above the new version.
+    assert "## [Unreleased]" in out
+    assert out.index("## [Unreleased]") < out.index("## [0.4.0]")
+    # The moved entry no longer sits under Unreleased.
+    unreleased = out.split("## [Unreleased]", 1)[1].split("## [0.4.0]", 1)[0]
+    assert "- a new thing" not in unreleased
+
+
+def test_roll_handles_empty_unreleased() -> None:
+    text = "# Changelog\n\n## [Unreleased]\n\n## [0.1.0] - 2026-01-01\n- seed\n"
+    out = changelog.roll(text, "0.2.0", "2026-06-01")
+    assert "## [0.2.0] - 2026-06-01" in out
+    assert out.index("## [Unreleased]") < out.index("## [0.2.0]")
+
+
+def test_roll_without_unreleased_raises() -> None:
+    with pytest.raises(ValueError, match="Unreleased"):
+        changelog.roll("# Changelog\n\n## [0.1.0] - 2026-01-01\n- x\n", "0.2.0", "2026-06-01")
+
+
+def test_roll_does_not_pile_blank_lines() -> None:
+    out = changelog.roll(_BASE, "0.4.0", "2026-06-01")
+    assert "\n\n\n" not in out


### PR DESCRIPTION
Tightens the release pipeline now that `main` is protected by a ruleset (PR + 3 required checks). **This PR is also the first run through that ruleset** — its own merge validates the gate.

## Changes

**Manual release cadence** — `prepare-release.yml` is now `workflow_dispatch`-only. Merges to `main` no longer auto-cut a patch (we cut 8 micro-releases in ~4h today). Pick the bump (patch/minor/major) and release a batch on demand. Removes the `pull_request: closed` trigger and the self-loop `if` guard it needed.

**Committed CHANGELOG** — `CHANGELOG.md` (Keep a Changelog). Contributors add entries under `## [Unreleased]`; `scripts/changelog.py roll <version>` promotes them into a dated `## [X.Y.Z]` section at release time. The roll runs in `prepare-release.yml` and is **committed inside the release PR**, so it flows through the ruleset like any change — `release.yml` never pushes to `main` directly (which the ruleset would block).

**Runbook** — `docs/guides/releasing.md`: the manual flow, the changelog protocol, the branch ruleset, and required secrets — including the **optional `DISCORD_RELEASE_WEBHOOK` (currently unset)** that gates the Discord post.

## Branch ruleset (already applied, out-of-band)

Created on `main` (id 17102099, active): require PR + the 3 checks (Verify workspace config / Python tests / Web E2E smoke), 0 approvals (solo/bot-friendly), non-strict, block direct push / force-push / deletion.

## Verification

- `tests/test_changelog.py` (5): roll promotes Unreleased, leaves a fresh empty Unreleased, handles an empty section, raises without a section, no blank-line pileup.
- YAML parse: trigger is `workflow_dispatch` only; steps include `Roll changelog`.
- `npm run docs:build` clean; releasing guide wired into the sidebar.

## Follow-up

Filing an issue on `protoLabsAI/release-tools` to suggest a shared **changelog protocol** (roll + verify) so the whole fleet gets this, not just protoAgent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)