### PR TITLE
feat(observability): measurement foundation — cost, cache tokens, wired LLM metrics (ADR 0006 #1)

### DIFF
--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -78,6 +78,11 @@ WORLDSTATE_DELTA_MIME = "application/vnd.protolabs.worldstate-delta+json"
 #          "costUsd": float?}
 # Ref: protoWorkstacean/docs/extensions/cost-v1.md
 COST_MIME = "application/vnd.protolabs.cost-v1+json"
+# The A2A protocol-extension URI for cost-v1. Declared in the agent card's
+# capabilities.extensions so Workstacean's ExtensionRegistry recognises the
+# extension and runs its cost interceptor (which records per-skill samples
+# from the cost-v1 DataPart). Ref: protoWorkstacean/src/executor/extensions/cost.ts.
+COST_EXT_URI = "https://proto-labs.ai/a2a/ext/cost-v1"
 
 # Confidence-v1: the agent's self-reported confidence + optional explanation on
 # the terminal artifact. A consumer (e.g. Workstacean's confidence interceptor)
@@ -138,8 +143,13 @@ class TaskRecord:
     # Token usage accumulated across every LLM call in the run. Emitted on
     # the terminal artifact under the cost-v1 MIME so Workstacean's
     # cost interceptor (protoWorkstacean#372) can record per-skill samples.
-    # Shape: {"input_tokens": int, "output_tokens": int, "total_tokens": int}
-    usage: dict = field(default_factory=lambda: {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0})
+    # Cache fields are Anthropic-shaped to match Workstacean's CostArtifactUsage
+    # (ADR 0006 Slice 1); cost_usd is the running USD total (pricing.py).
+    usage: dict = field(default_factory=lambda: {
+        "input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+        "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0,
+        "cost_usd": 0.0,
+    })
     # Self-reported confidence for the confidence-v1 DataPart. Set by the
     # producer when it parses a <confidence> tag out of the model's final
     # output. Clamped to [0, 1] on write; None when the model didn't report
@@ -323,15 +333,20 @@ class A2ATaskStore:
                 return
             record.deltas.append(delta)
 
-    async def add_usage(self, task_id: str, input_tokens: int, output_tokens: int) -> None:
-        """Accumulate LLM token usage for the task.
+    async def add_usage(
+        self, task_id: str, input_tokens: int, output_tokens: int,
+        cache_read_input_tokens: int = 0, cache_creation_input_tokens: int = 0,
+        cost_usd: float = 0.0,
+    ) -> None:
+        """Accumulate LLM token usage + cost for the task.
 
         Called from the producer on every ``on_chat_model_end`` event. The
         running totals are emitted on the terminal artifact under the
         ``cost-v1`` MIME so Workstacean's cost interceptor can record
-        per-skill samples (protoWorkstacean#372).
+        per-skill samples (protoWorkstacean#372). Cache fields + cost are
+        ADR 0006 Slice 1.
         """
-        if input_tokens <= 0 and output_tokens <= 0:
+        if input_tokens <= 0 and output_tokens <= 0 and cost_usd <= 0:
             return
         async with self._lock:
             record = self._tasks.get(task_id)
@@ -342,6 +357,9 @@ class A2ATaskStore:
             record.usage["total_tokens"] = (
                 record.usage["input_tokens"] + record.usage["output_tokens"]
             )
+            record.usage["cache_read_input_tokens"] += int(cache_read_input_tokens)
+            record.usage["cache_creation_input_tokens"] += int(cache_creation_input_tokens)
+            record.usage["cost_usd"] = round(record.usage.get("cost_usd", 0.0) + float(cost_usd), 6)
 
     async def set_confidence(
         self,
@@ -514,16 +532,21 @@ def _cost_payload(record: TaskRecord) -> dict | None:
     cost-relevant data is available.
 
     Always includes ``durationMs`` (cheap to compute from created_at →
-    updated_at) when usage was tracked. ``costUsd`` is omitted for now —
-    LiteLLM exposes per-call cost in its callback hooks but the runtime
-    doesn't capture it yet; consumers of cost-v1 can derive cost from
-    usage + their own per-model rates, or wait for a follow-up that
-    plumbs ``response_cost`` through.
+    updated_at) when usage was tracked. ``costUsd`` is the in-process estimate
+    accumulated across the turn's LLM calls (pricing.py, ADR 0006 Slice 1) —
+    consumers prefer it over deriving from tokens. The ``usage`` block carries
+    Workstacean's Anthropic-shaped CostArtifactUsage fields (input/output +
+    cache read/creation); the internal ``cost_usd`` accumulator is lifted out to
+    the top-level ``costUsd``.
     """
     usage = record.usage
     if not usage or usage.get("total_tokens", 0) <= 0:
         return None
-    payload: dict = {"usage": dict(usage)}
+    cost = float(usage.get("cost_usd", 0.0) or 0.0)
+    usage_block = {k: v for k, v in usage.items() if k != "cost_usd"}
+    payload: dict = {"usage": usage_block}
+    if cost > 0:
+        payload["costUsd"] = round(cost, 6)
     duration_ms = _duration_ms(record)
     if duration_ms is not None:
         payload["durationMs"] = duration_ms
@@ -1065,6 +1088,9 @@ async def _run_task_background(
                         task_id,
                         input_tokens=payload.get("input_tokens", 0),
                         output_tokens=payload.get("output_tokens", 0),
+                        cache_read_input_tokens=payload.get("cache_read_input_tokens", 0),
+                        cache_creation_input_tokens=payload.get("cache_creation_input_tokens", 0),
+                        cost_usd=payload.get("cost_usd", 0.0),
                     )
 
             elif event_type == "confidence":
@@ -1345,6 +1371,16 @@ def register_a2a_routes(
     agent_card.setdefault("capabilities", {})
     agent_card["capabilities"]["streaming"] = True
     agent_card["capabilities"]["pushNotifications"] = True
+    # Declare the cost-v1 protocol extension (ADR 0006) so consumers like
+    # Workstacean's ExtensionRegistry recognise it and run the cost interceptor
+    # on our terminal cost-v1 DataPart. Idempotent: don't duplicate on reload.
+    _exts = agent_card["capabilities"].setdefault("extensions", [])
+    if not any(isinstance(e, dict) and e.get("uri") == COST_EXT_URI for e in _exts):
+        _exts.append({
+            "uri": COST_EXT_URI,
+            "description": "Emits token usage, prompt-cache tokens, duration, and costUsd "
+                           "on the terminal task artifact (application/vnd.protolabs.cost-v1+json).",
+        })
     if _A2A_TOKEN[0]:
         agent_card.setdefault("securitySchemes", {})
         agent_card["securitySchemes"]["bearer"] = {

--- a/docs/adr/0006-observability-and-the-self-improving-flywheel.md
+++ b/docs/adr/0006-observability-and-the-self-improving-flywheel.md
@@ -100,10 +100,14 @@ outbound telemetry with the fleet so the data is useful beyond protoAgent.
 ## 4. Ranked Plan (slices)
 
 1. ✅ **Measure (foundation) — ships with this ADR.** Capture cache tokens +
-   per-call latency + model in `_run_turn_stream`; add `pricing.py` →
-   cache-aware `costUsd`; wire `record_llm_call` (extended with cache + cost
-   series) and per-call Langfuse generation spans; emit cache fields + `costUsd`
-   on `cost-v1` and declare the extension URI in the card. *(fixes 1–4)*
+   per-call latency + model in `_run_turn_stream`; add `pricing.py` → `costUsd`
+   (base input/output rates, fleet-consistent; cache-discounted cost deferred
+   until gateway token semantics are validated); wire `record_llm_call`
+   (extended with cache + cost series). Per-call **Langfuse** generation spans
+   already come from the LiteLLM gateway callback — we deliberately *don't* add
+   a manual shim that would bypass `trace_session`'s nesting (guarded by
+   `test_no_legacy_shims_exist`). Emit cache fields + `costUsd` on `cost-v1` and
+   declare the extension URI in the card. *(fixes 1–4)*
 2. **Persist & aggregate.** A local telemetry SQLite (per-turn + per-call
    rollups: tokens, cache, cost, latency, model, tool counts) queryable inside
    protoAgent, scoped per instance like the other stores (ADR 0004). Survives

--- a/docs/explanation/cost-and-trace.md
+++ b/docs/explanation/cost-and-trace.md
@@ -11,30 +11,36 @@ A multi-agent fleet needs to answer: *how much is each (agent, skill) costing, a
 cost-v1 is the measurement. Every terminal task carries a DataPart with:
 
 - `usage.input_tokens`, `usage.output_tokens`, `usage.total_tokens`
+- `usage.cache_read_input_tokens`, `usage.cache_creation_input_tokens` — Anthropic-shaped prompt-cache tokens (ADR 0006), matching Workstacean's `CostArtifactUsage`
 - `durationMs`
-- (eventually) `costUsd`
+- `costUsd` — the in-process estimate accumulated across the turn's LLM calls (`pricing.py`); consumers prefer it over recomputing from tokens
 
-The consuming system (Workstacean's `defaultCostStore`) keeps a rolling window of samples per `(agent, skill)` key and uses them to rank candidates for dispatch — replacing self-advertisement with observation after 5+ samples.
+The agent also **declares the extension** in its card (`capabilities.extensions`, URI `https://proto-labs.ai/a2a/ext/cost-v1`), which is what gates Workstacean's cost interceptor.
+
+The consuming system (Workstacean's `defaultCostStore`) keeps a rolling window of samples per `(agent, skill)` key and uses them to rank candidates for dispatch — replacing self-advertisement with observation after 5+ samples. See [ADR 0006](/adr/0006-observability-and-the-self-improving-flywheel).
 
 ### Why token capture lives where it does
 
 The temptation is to hook cost capture into the A2A handler. Don't — the handler has no visibility into individual LLM calls. A task may hit the model N times (tool-call loops, subagent delegation, retries). By the time the handler sees "task done", the per-call detail is gone.
 
-The template captures in `_chat_langgraph_stream` via the `on_chat_model_end` event from `astream_events(v2)`:
+The template captures in `_run_turn_stream` via the `on_chat_model_end` event from `astream_events(v2)`. The same seam reads the prompt-cache token details, measures per-call latency (paired with `on_chat_model_start`), resolves the model, computes `costUsd` (`pricing.py`), and — this is the part that was missing — feeds Prometheus via `metrics.record_llm_call` (ADR 0006). It then yields an enriched `usage` frame:
 
 ```python
 elif kind == "on_chat_model_end":
-    output = event.get("data", {}).get("output")
-    usage = getattr(output, "usage_metadata", None) if output else None
-    if usage:
-        yield ("usage", {
-            "input_tokens": usage.get("input_tokens", 0),
-            "output_tokens": usage.get("output_tokens", 0),
-            "total_tokens": usage.get("total_tokens", 0),
-        })
+    usage = getattr(output, "usage_metadata", None)
+    details = usage.get("input_token_details") or {}
+    usage_out = {
+        "input_tokens": int(usage.get("input_tokens", 0) or 0),
+        "output_tokens": int(usage.get("output_tokens", 0) or 0),
+        "cache_read_input_tokens": int(details.get("cache_read", 0) or 0),
+        "cache_creation_input_tokens": int(details.get("cache_creation", 0) or 0),
+    }
+    cost = pricing.cost_usd(model, usage_out)
+    metrics.record_llm_call(model, finish_reason, latency_s, ..., cost_usd=cost)
+    yield ("usage", {**usage_out, "cost_usd": cost})
 ```
 
-The A2A handler accumulates these onto `TaskRecord.usage` during the run, then emits them as a DataPart on the terminal artifact.
+The A2A handler accumulates these onto `TaskRecord.usage` during the run, then emits them (cache fields + the lifted-out `costUsd`) as a DataPart on the terminal artifact. Per-call **Langfuse** generation spans come from the LiteLLM gateway callback — protoAgent doesn't add a manual span that would bypass `trace_session` nesting.
 
 ### Why `stream_usage=True`
 

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -52,11 +52,16 @@ Every tracing helper becomes a no-op. No crashes, no latency. The rest of the ag
 Scrape `/metrics` on port 7870. Metric names are prefixed with a sanitized `AGENT_NAME`.
 
 ```
-my_agent_llm_calls_total{model="protolabs/my-agent",finish_reason="stop"} 42
-my_agent_llm_latency_seconds_bucket{model="protolabs/my-agent",le="5"} 38
+my_agent_llm_calls_total{model="claude-opus-4-8",finish_reason="stop"} 42
+my_agent_llm_latency_seconds_bucket{model="claude-opus-4-8",le="5"} 38
+my_agent_llm_tokens_total{model="claude-opus-4-8",direction="input"} 184320
+my_agent_llm_cache_tokens_total{model="claude-opus-4-8",kind="read"} 96000
+my_agent_llm_cost_usd_total{model="claude-opus-4-8"} 0.83
 my_agent_tool_calls_total{tool_name="web_search",success="True"} 17
 my_agent_active_sessions 3
 ```
+
+The LLM series (`*_llm_calls_total`, `*_llm_latency_seconds`, `*_llm_tokens_total`, `*_llm_cache_tokens_total`, `*_llm_cost_usd_total`) are emitted per LLM call from `server._run_turn_stream` (ADR 0006); cache + cost are best-effort and depend on the gateway surfacing prompt-cache token details. Tool series come from `AuditMiddleware`.
 
 Example Prometheus scrape config:
 

--- a/metrics.py
+++ b/metrics.py
@@ -15,6 +15,8 @@ _enabled = False
 _llm_calls = None
 _llm_latency = None
 _llm_tokens = None
+_llm_cache_tokens = None
+_llm_cost = None
 _tool_calls = None
 _tool_latency = None
 _active_sessions = None
@@ -26,7 +28,7 @@ def _prefix() -> str:
 
 
 def init():
-    global _enabled, _llm_calls, _llm_latency, _llm_tokens
+    global _enabled, _llm_calls, _llm_latency, _llm_tokens, _llm_cache_tokens, _llm_cost
     global _tool_calls, _tool_latency, _active_sessions
 
     try:
@@ -45,6 +47,14 @@ def init():
         _llm_tokens = Counter(
             f"{p}_llm_tokens_total", "Total LLM tokens consumed",
             ["model", "direction"],
+        )
+        _llm_cache_tokens = Counter(
+            f"{p}_llm_cache_tokens_total", "Prompt-cache tokens (read vs creation)",
+            ["model", "kind"],
+        )
+        _llm_cost = Counter(
+            f"{p}_llm_cost_usd_total", "Estimated LLM cost in USD",
+            ["model"],
         )
         _tool_calls = Counter(
             f"{p}_tool_calls_total", "Total tool executions",
@@ -68,7 +78,11 @@ def is_enabled() -> bool:
 
 
 def record_llm_call(model: str, finish_reason: str, latency_s: float,
-                     tokens_input: int = 0, tokens_output: int = 0):
+                     tokens_input: int = 0, tokens_output: int = 0,
+                     cache_read: int = 0, cache_creation: int = 0,
+                     cost_usd: float = 0.0):
+    """Record one LLM call (ADR 0006 Slice 1). Wired from the per-call seam in
+    ``server._run_turn_stream`` — previously defined but never called."""
     if not _enabled:
         return
     _llm_calls.labels(model=model, finish_reason=finish_reason).inc()
@@ -77,6 +91,12 @@ def record_llm_call(model: str, finish_reason: str, latency_s: float,
         _llm_tokens.labels(model=model, direction="input").inc(tokens_input)
     if tokens_output:
         _llm_tokens.labels(model=model, direction="output").inc(tokens_output)
+    if cache_read:
+        _llm_cache_tokens.labels(model=model, kind="read").inc(cache_read)
+    if cache_creation:
+        _llm_cache_tokens.labels(model=model, kind="creation").inc(cache_creation)
+    if cost_usd:
+        _llm_cost.labels(model=model).inc(cost_usd)
 
 
 def record_tool_call(tool_name: str, success: bool, latency_s: float):

--- a/pricing.py
+++ b/pricing.py
@@ -1,0 +1,61 @@
+"""Per-model token pricing → USD cost (ADR 0006, Slice 1).
+
+Rates mirror the structure + overlapping values of Workstacean's ``MODEL_RATES``
+(``protoWorkstacean/lib/types/budget.ts``) so protoAgent's emitted ``costUsd``
+agrees with the fleet's fallback computation. Cost is best-effort: an unknown
+model resolves by substring match (gateway aliases like
+``anthropic/claude-opus-4-8``), else falls back to the ``default`` rate. Never
+raises.
+
+``costUsd`` here bills ``input_tokens`` + ``output_tokens`` at the base rates —
+the portion every consumer agrees on. Prompt-cache tokens are captured + emitted
+separately (so the cache-hit ratio + savings are *visible*), but folding a
+cache discount into ``costUsd`` is deferred until the gateway's cache-token
+semantics are validated end-to-end (different gateways disagree on whether
+``input_tokens`` already includes cached reads). See ADR 0006.
+"""
+
+from __future__ import annotations
+
+# USD per token, (input, output). Keep in sync with Workstacean MODEL_RATES.
+MODEL_RATES: dict[str, dict[str, float]] = {
+    "claude-opus-4-8":           {"input": 0.000015,   "output": 0.000075},
+    "claude-opus-4-6":           {"input": 0.000015,   "output": 0.000075},
+    "claude-sonnet-4-6":         {"input": 0.000003,   "output": 0.000015},
+    "claude-haiku-4-5":          {"input": 0.00000025, "output": 0.00000125},
+    "claude-haiku-4-5-20251001": {"input": 0.00000025, "output": 0.00000125},
+    "gpt-4o":                    {"input": 0.0000025,  "output": 0.00001},
+    "gpt-4o-mini":               {"input": 0.00000015, "output": 0.0000006},
+    "default":                   {"input": 0.000003,   "output": 0.000015},
+}
+
+
+def rate_for(model: str | None) -> dict[str, float]:
+    """Resolve the (input, output) rate for a model name.
+
+    Exact match first, then substring (so a gateway alias like
+    ``anthropic/claude-opus-4-8`` or ``claude-opus-4-8-20260115`` still
+    resolves), else the ``default`` rate.
+    """
+    if not model:
+        return MODEL_RATES["default"]
+    m = str(model).lower()
+    if m in MODEL_RATES:
+        return MODEL_RATES[m]
+    # Longest key first so "claude-haiku-4-5-20251001" wins over a shorter key.
+    for key in sorted((k for k in MODEL_RATES if k != "default"), key=len, reverse=True):
+        if key in m:
+            return MODEL_RATES[key]
+    return MODEL_RATES["default"]
+
+
+def cost_usd(model: str | None, usage: dict) -> float:
+    """USD cost for one usage dict ``{input_tokens, output_tokens, ...}``.
+
+    Billed at base input/output rates (fleet-consistent). Returns a value
+    rounded to 6 decimals; 0.0 for empty usage.
+    """
+    rate = rate_for(model)
+    inp = int(usage.get("input_tokens", 0) or 0)
+    out = int(usage.get("output_tokens", 0) or 0)
+    return round(inp * rate["input"] + out * rate["output"], 6)

--- a/server.py
+++ b/server.py
@@ -1167,8 +1167,12 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
         if resume_value is not None
         else {"messages": [HumanMessage(content=message)], "session_id": session_id}
     )
+    import metrics
+    import pricing
+
     accumulated_raw = ""
     streamed_len = 0  # chars of visible <output> already emitted as text frames
+    _llm_started: dict[str, float] = {}  # run_id → monotonic start (per-call latency)
     async for event in _graph.astream_events(
         graph_input,
         config=config,
@@ -1176,7 +1180,12 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
     ):
         kind = event.get("event", "")
         name = event.get("name", "")
-        if kind == "on_tool_start":
+        if kind == "on_chat_model_start":
+            # Stamp the per-call start so on_chat_model_end can measure latency.
+            rid = event.get("run_id")
+            if rid:
+                _llm_started[rid] = time.monotonic()
+        elif kind == "on_tool_start":
             tool_input = event.get("data", {}).get("input", "")
             # Structured frame (id pairs start↔end) so consumers can render a
             # per-tool card; the A2A handler also derives a text status from it.
@@ -1206,11 +1215,49 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
         elif kind == "on_chat_model_end":
             output = event.get("data", {}).get("output")
             usage = getattr(output, "usage_metadata", None) if output else None
+            rid = event.get("run_id")
+            latency_s = max(0.0, time.monotonic() - _llm_started.pop(rid, time.monotonic())) if rid else 0.0
+            model = (
+                (event.get("metadata") or {}).get("ls_model_name")
+                or getattr(output, "response_metadata", {}).get("model_name", "")
+                or "model"
+            )
             if usage:
-                yield ("usage", {
+                # Prompt-cache token details (best-effort — OpenAI-compat exposes
+                # cached reads via prompt_tokens_details; cache_creation is
+                # Anthropic-specific and may not round-trip every gateway).
+                details = usage.get("input_token_details") or {}
+                cache_read = int(details.get("cache_read", 0) or 0)
+                cache_creation = int(details.get("cache_creation", 0) or 0)
+                usage_out = {
                     "input_tokens": int(usage.get("input_tokens", 0) or 0),
                     "output_tokens": int(usage.get("output_tokens", 0) or 0),
-                })
+                    "cache_read_input_tokens": cache_read,
+                    "cache_creation_input_tokens": cache_creation,
+                }
+                cost = pricing.cost_usd(model, usage_out)
+                finish_reason = (
+                    getattr(output, "response_metadata", {}).get("finish_reason", "")
+                    or "stop"
+                )
+                # Wire the per-call Prometheus seam (no-op when unconfigured);
+                # previously record_llm_call was defined but never called. The
+                # per-call Langfuse generation span comes from the LiteLLM
+                # gateway callback — we deliberately don't add a manual shim
+                # that would bypass trace_session's nesting (see tracing.py).
+                try:
+                    metrics.record_llm_call(
+                        model, finish_reason, latency_s,
+                        tokens_input=usage_out["input_tokens"],
+                        tokens_output=usage_out["output_tokens"],
+                        cache_read=cache_read, cache_creation=cache_creation,
+                        cost_usd=cost,
+                    )
+                except Exception:  # noqa: BLE001 — telemetry must never break a turn
+                    pass
+                # Carry cache fields + cost to the A2A handler for the cost-v1
+                # artifact (accumulated across the turn's calls).
+                yield ("usage", {**usage_out, "cost_usd": cost})
 
     # HITL pause (ADR 0003): the agent called ask_human → LangGraph interrupt().
     # The graph is checkpointed at the interrupt; surface the question so the A2A

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -954,10 +954,16 @@ async def test_store_add_usage_accumulates(store):
     the same cost-v1 artifact."""
     record = _make_record()
     await store.create(record)
-    await store.add_usage("test-task-id", input_tokens=100, output_tokens=50)
-    await store.add_usage("test-task-id", input_tokens=200, output_tokens=80)
+    await store.add_usage("test-task-id", input_tokens=100, output_tokens=50,
+                          cache_read_input_tokens=60, cost_usd=0.001)
+    await store.add_usage("test-task-id", input_tokens=200, output_tokens=80,
+                          cache_read_input_tokens=40, cache_creation_input_tokens=10, cost_usd=0.002)
     fetched = await store.get("test-task-id")
-    assert fetched.usage == {"input_tokens": 300, "output_tokens": 130, "total_tokens": 430}
+    assert fetched.usage == {
+        "input_tokens": 300, "output_tokens": 130, "total_tokens": 430,
+        "cache_read_input_tokens": 100, "cache_creation_input_tokens": 10,
+        "cost_usd": 0.003,
+    }
 
 
 @pytest.mark.asyncio
@@ -967,7 +973,11 @@ async def test_store_add_usage_ignores_zero_payloads(store):
     await store.create(record)
     await store.add_usage("test-task-id", input_tokens=0, output_tokens=0)
     fetched = await store.get("test-task-id")
-    assert fetched.usage == {"input_tokens": 0, "output_tokens": 0, "total_tokens": 0}
+    assert fetched.usage == {
+        "input_tokens": 0, "output_tokens": 0, "total_tokens": 0,
+        "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0,
+        "cost_usd": 0.0,
+    }
 
 
 def test_task_to_response_has_kind_discriminator():

--- a/tests/test_cost_v1_emission.py
+++ b/tests/test_cost_v1_emission.py
@@ -1,0 +1,73 @@
+"""cost-v1 DataPart: cache fields + costUsd emission (ADR 0006 Slice 1).
+
+Verifies the terminal artifact carries Workstacean's Anthropic-shaped cache
+fields and a top-level costUsd, and that metrics.record_llm_call accepts the
+enriched signature without a live Prometheus registry.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from a2a_handler import COST_EXT_URI, COST_MIME, _cost_payload
+
+
+def _record_with_usage(**usage):
+    """Minimal TaskRecord-like stub for _cost_payload (reads .usage,
+    .created_at, .updated_at)."""
+    from a2a_handler import TaskRecord
+
+    rec = TaskRecord(
+        id="t1", context_id="c1", state="completed",
+        created_at="2026-06-01T00:00:00+00:00",
+        updated_at="2026-06-01T00:00:02+00:00",
+        message_text="hi",
+    )
+    rec.usage = usage
+    return rec
+
+
+def test_cost_payload_includes_cache_fields_and_costusd() -> None:
+    payload = _cost_payload(_record_with_usage(
+        input_tokens=1500, output_tokens=420, total_tokens=1920,
+        cache_read_input_tokens=900, cache_creation_input_tokens=100,
+        cost_usd=0.0123,
+    ))
+    assert payload is not None
+    # usage block carries the Anthropic-shaped cache fields...
+    assert payload["usage"]["cache_read_input_tokens"] == 900
+    assert payload["usage"]["cache_creation_input_tokens"] == 100
+    # ...but NOT the internal cost accumulator (that's lifted to top-level).
+    assert "cost_usd" not in payload["usage"]
+    assert payload["costUsd"] == 0.0123
+    assert isinstance(payload["durationMs"], int)
+
+
+def test_cost_payload_omits_costusd_when_zero() -> None:
+    payload = _cost_payload(_record_with_usage(
+        input_tokens=10, output_tokens=5, total_tokens=15, cost_usd=0.0,
+    ))
+    assert payload is not None
+    assert "costUsd" not in payload
+
+
+def test_cost_payload_none_when_no_tokens() -> None:
+    assert _cost_payload(_record_with_usage(input_tokens=0, output_tokens=0, total_tokens=0)) is None
+
+
+def test_extension_uri_is_the_canonical_workstacean_uri() -> None:
+    # Must match protoWorkstacean's COST_URI for its interceptor to engage.
+    assert COST_EXT_URI == "https://proto-labs.ai/a2a/ext/cost-v1"
+    assert COST_MIME == "application/vnd.protolabs.cost-v1+json"
+
+
+def test_record_llm_call_accepts_enriched_signature_when_disabled() -> None:
+    import metrics
+
+    # No init() in tests → disabled → no-op, but the signature must accept the
+    # new cache/cost kwargs without error.
+    metrics.record_llm_call(
+        "claude-opus-4-8", "stop", 1.2,
+        tokens_input=100, tokens_output=50,
+        cache_read=60, cache_creation=10, cost_usd=0.002,
+    )

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -1,0 +1,35 @@
+"""Tests for pricing.py (ADR 0006 Slice 1 — per-model token → USD cost)."""
+
+from __future__ import annotations
+
+import pricing
+
+
+def test_rate_for_exact_match() -> None:
+    assert pricing.rate_for("claude-opus-4-8")["input"] == 0.000015
+
+
+def test_rate_for_substring_alias() -> None:
+    # Gateway aliases / dated suffixes resolve by substring.
+    assert pricing.rate_for("anthropic/claude-sonnet-4-6")["output"] == 0.000015
+    assert pricing.rate_for("claude-haiku-4-5-20251001")["input"] == 0.00000025
+
+
+def test_rate_for_unknown_falls_back_to_default() -> None:
+    assert pricing.rate_for("some-future-model") == pricing.MODEL_RATES["default"]
+    assert pricing.rate_for(None) == pricing.MODEL_RATES["default"]
+
+
+def test_cost_usd_base_rates() -> None:
+    usage = {"input_tokens": 1000, "output_tokens": 500}
+    # opus: 1000*0.000015 + 500*0.000075 = 0.015 + 0.0375 = 0.0525
+    assert pricing.cost_usd("claude-opus-4-8", usage) == 0.0525
+
+
+def test_cost_usd_empty_usage_is_zero() -> None:
+    assert pricing.cost_usd("claude-opus-4-8", {}) == 0.0
+
+
+def test_cost_usd_handles_none_and_missing_fields() -> None:
+    # Robust to partial usage dicts (no crash, sensible number).
+    assert pricing.cost_usd("gpt-4o", {"input_tokens": 100}) == round(100 * 0.0000025, 6)


### PR DESCRIPTION
Slice 1 of ADR 0006 — the measurement foundation. Closes the gaps blocking the flywheel and aligns the outbound telemetry with Workstacean's `cost-v1` A2A extension.

## The gaps it fixes
1. **`metrics.record_llm_call` was defined but never called** → now wired per LLM call.
2. **No USD cost** → `pricing.py` + `costUsd` on the artifact.
3. **No prompt-cache tokens** → captured from `usage_metadata.input_token_details` and emitted.
4. **No per-call latency** → measured by pairing `on_chat_model_start`/`end`.

## Changes
- **`pricing.py`** (new) — per-model token→USD. `MODEL_RATES` mirror Workstacean's `lib/types/budget.ts` + a `default` fallback; substring match for gateway aliases (`anthropic/claude-opus-4-8`).
- **`server._run_turn_stream`** — per-call latency, cache-token capture, model resolution, `costUsd`, and the `record_llm_call` wiring; yields an enriched `usage` frame.
- **`metrics.py`** — `record_llm_call` gains `cache_read`/`cache_creation`/`cost_usd`; new series `*_llm_cache_tokens_total`, `*_llm_cost_usd_total`.
- **`a2a_handler.py`** — accumulate cache + cost on `TaskRecord.usage`; emit Anthropic-shaped cache fields + top-level `costUsd` on the `cost-v1` DataPart; **declare the extension URI** `https://proto-labs.ai/a2a/ext/cost-v1` in the agent card so Workstacean's cost interceptor engages.

## Fleet alignment (the Workstacean tie-in)
Matches `protoWorkstacean/lib/types/cost-v1.ts` exactly: `usage` now carries `cache_creation_input_tokens` / `cache_read_input_tokens`, and `costUsd` is populated (their interceptor prefers ours over recomputing). Declaring the card extension is what gates `ExtensionRegistry.interceptorsFor(card)`. So protoAgent's numbers now feed the planner's cost ranking + fleet cost-per-outcome dashboard.

## Notes / deliberate scope
- **Langfuse LLM spans** stay sourced from the LiteLLM gateway callback — I did *not* add a manual `trace_llm_call` shim (it'd bypass `trace_session` nesting; the existing `test_no_legacy_shims_exist` guard enforces this).
- **`costUsd` bills input/output at base rates** (fleet-consistent). Cache-discounted cost is deferred until gateway cache-token semantics are validated end-to-end — cache tokens are still captured + emitted for visibility/hit-ratio.

## Verification
- New: `tests/test_pricing.py`, `tests/test_cost_v1_emission.py`; updated `add_usage` accumulation tests. **Full suite: 834 passed.**
- `npm run docs:build` clean. cost-and-trace + observability guide refreshed; ADR 0006 Slice 1 marked shipped.

Next: Slice 2 (local telemetry store), then Slice 3 (console surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)