### PR TITLE
feat(observability): local telemetry store — per-turn cost/latency rollups (ADR 0006 #2)

### DIFF
--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -156,6 +156,11 @@ class TaskRecord:
     # one (the DataPart is then omitted).
     confidence: float | None = None
     confidence_explanation: str | None = None
+    # Per-turn call counts for the local telemetry rollup (ADR 0006 Slice 2):
+    # llm_calls bumped on every recorded on_chat_model_end, tool_calls on every
+    # tool_start. Live counters; written to the telemetry store at terminal time.
+    llm_calls: int = 0
+    tool_calls: int = 0
     # ── asyncio primitives (not serialised) ──
     _cancel_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
     _update_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
@@ -304,6 +309,10 @@ class A2ATaskStore:
         # a task is actively running.
         if state in _STREAM_CLOSING:
             self._save(record)
+        # One telemetry row per terminal turn (completed/failed/canceled) — the
+        # single chokepoint every terminal transition flows through (ADR 0006).
+        if state in _TERMINAL:
+            _record_telemetry(record)
         return record
 
     async def cancel(self, task_id: str) -> bool:
@@ -360,6 +369,14 @@ class A2ATaskStore:
             record.usage["cache_read_input_tokens"] += int(cache_read_input_tokens)
             record.usage["cache_creation_input_tokens"] += int(cache_creation_input_tokens)
             record.usage["cost_usd"] = round(record.usage.get("cost_usd", 0.0) + float(cost_usd), 6)
+            record.llm_calls += 1
+
+    async def note_tool_call(self, task_id: str) -> None:
+        """Bump the per-turn tool-call counter (telemetry rollup, ADR 0006)."""
+        async with self._lock:
+            record = self._tasks.get(task_id)
+            if record is not None:
+                record.tool_calls += 1
 
     async def set_confidence(
         self,
@@ -916,6 +933,42 @@ _ON_TERMINAL: list[Callable[["TaskRecord"], None] | None] = [None]
 # task eviction + a restart (within the store's TTL). No-ops when unset.
 _PUSH_STORE: list = [None]
 
+# Optional local telemetry store (TelemetryStore, ADR 0006 Slice 2) + the lead
+# model name to stamp on each per-turn row. Set via register_a2a_routes; no-ops
+# when unset. One row is written per terminal turn from update_state.
+_TELEMETRY: list = [None]
+_TELEMETRY_MODEL: list[str] = [""]
+
+
+def _record_telemetry(record: TaskRecord) -> None:
+    """Write one per-turn telemetry row at terminal time. Best-effort: a failure
+    must never affect the turn's outcome."""
+    store = _TELEMETRY[0]
+    if store is None:
+        return
+    try:
+        u = record.usage or {}
+        store.record({
+            "task_id": record.id,
+            "session_id": record.context_id,
+            "state": record.state,
+            "success": 1 if record.state == COMPLETED else 0,
+            "model": _TELEMETRY_MODEL[0] or "",
+            "input_tokens": int(u.get("input_tokens", 0) or 0),
+            "output_tokens": int(u.get("output_tokens", 0) or 0),
+            "total_tokens": int(u.get("total_tokens", 0) or 0),
+            "cache_read_input_tokens": int(u.get("cache_read_input_tokens", 0) or 0),
+            "cache_creation_input_tokens": int(u.get("cache_creation_input_tokens", 0) or 0),
+            "cost_usd": float(u.get("cost_usd", 0.0) or 0.0),
+            "duration_ms": _duration_ms(record) or 0,
+            "llm_calls": int(record.llm_calls),
+            "tool_calls": int(record.tool_calls),
+            "created_at": record.created_at,
+            "ended_at": record.updated_at,
+        })
+    except Exception:  # noqa: BLE001 — telemetry is best-effort
+        logger.exception("[telemetry] failed to record turn %s", record.id)
+
 
 def _push_store_set(task_id: str, cfg: "PushNotificationConfig") -> None:
     store = _PUSH_STORE[0]
@@ -1055,6 +1108,7 @@ async def _run_task_background(
                 # status verbatim with no structured event.
                 if isinstance(payload, dict):
                     if event_type == "tool_start":
+                        await _store.note_tool_call(task_id)  # telemetry rollup
                         text = f"🔧 {payload.get('name', '')}: {str(payload.get('input', ''))[:200]}"
                         tool_event = {**payload, "phase": "start"}
                     else:
@@ -1285,6 +1339,8 @@ def register_a2a_routes(
     card_provider: Callable[[str], dict] | None = None,
     push_store=None,
     task_persistence=None,
+    telemetry=None,
+    telemetry_model: str = "",
 ) -> None:
     """Register all A2A routes on *app* and update *agent_card* capabilities.
 
@@ -1303,6 +1359,8 @@ def register_a2a_routes(
     # so mutations propagate to the closure below.
     _ON_TERMINAL[0] = on_terminal
     _PUSH_STORE[0] = push_store
+    _TELEMETRY[0] = telemetry
+    _TELEMETRY_MODEL[0] = telemetry_model or ""
     if task_persistence is not None:
         _store.attach_persistence(task_persistence)
         try:

--- a/docs/adr/0006-observability-and-the-self-improving-flywheel.md
+++ b/docs/adr/0006-observability-and-the-self-improving-flywheel.md
@@ -1,6 +1,6 @@
 # ADR 0006 — Observability & the Self-Improving Flywheel
 
-- **Status:** Accepted (2026-06-01) — implementing the ranked plan (Slice 1 shipping alongside)
+- **Status:** Accepted (2026-06-01) — implementing the ranked plan (Slices 1–2 shipped)
 - **Date:** 2026-06-01
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** observability, cost, tracing, metrics, a2a, optimization, flywheel
@@ -108,11 +108,13 @@ outbound telemetry with the fleet so the data is useful beyond protoAgent.
    a manual shim that would bypass `trace_session`'s nesting (guarded by
    `test_no_legacy_shims_exist`). Emit cache fields + `costUsd` on `cost-v1` and
    declare the extension URI in the card. *(fixes 1–4)*
-2. **Persist & aggregate.** A local telemetry SQLite (per-turn + per-call
-   rollups: tokens, cache, cost, latency, model, tool counts) queryable inside
-   protoAgent, scoped per instance like the other stores (ADR 0004). Survives
-   restart; powers historical "what's expensive" analysis without external
-   Prometheus/Langfuse. *(fixes 5)*
+2. ✅ **Persist & aggregate — shipped.** `telemetry_store.py` (`TelemetryStore`)
+   writes one per-turn row (tokens incl. cache, cost, duration, LLM/tool call
+   counts, model, outcome) at the single terminal chokepoint
+   (`A2ATaskStore.update_state`), instance-scoped (ADR 0004). Read via
+   `/api/telemetry/summary` (totals, success rate, cache-hit ratio, p50/p95
+   latency, per-model split) + `/api/telemetry/recent`. Survives restart; no TTL
+   (history is the substrate), `prune()` available. *(fixes 5)*
 3. **Surface.** Operator-console telemetry: a per-turn footer (tokens · cost ·
    latency) and a session/▾history panel (cumulative cost, p50/p95 latency,
    cache-hit %, per-tool timings). Consumes the data already on the A2A stream.

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -76,6 +76,31 @@ scrape_configs:
 
 `/metrics` returns a note saying metrics are disabled. No other side effects.
 
+## Local telemetry store
+
+Prometheus is live-scrape-only and Langfuse is opt-in/external — so protoAgent also keeps a **durable, queryable per-turn rollup** of its own (ADR 0006 Slice 2). One row is written per terminal A2A turn (completed / failed / canceled) with accumulated token usage (incl. prompt-cache), USD cost, wall-clock duration, and LLM-call + tool-call counts. This is the substrate for "what was expensive/slow over time" and the self-improving flywheel.
+
+ON by default (one cheap write per turn). The SQLite path follows the usual `/sandbox` → `~/.protoagent` fallback and is instance-scoped (ADR 0004). Disable or relocate via config:
+
+```yaml
+telemetry:
+  enabled: true             # default; false → no store, endpoints return {enabled:false}
+  db_path: /sandbox/telemetry.db
+```
+
+Query it over HTTP (read-only):
+
+```bash
+# Aggregate rollup — totals, success rate, cache-hit ratio, p50/p95 latency, per-model split
+curl localhost:7870/api/telemetry/summary
+curl 'localhost:7870/api/telemetry/summary?since=2026-06-01T00:00:00+00:00'
+
+# Most recent turns (newest first)
+curl 'localhost:7870/api/telemetry/recent?limit=20'
+```
+
+`summary` returns `{turns, input_tokens, output_tokens, total_tokens, cache_read_input_tokens, cache_creation_input_tokens, cost_usd, llm_calls, tool_calls, avg_duration_ms, p50_duration_ms, p95_duration_ms, success_rate, cache_hit_ratio, by_model[]}`. The operator console surfaces these (Slice 3). History isn't auto-expired (it's the analysis substrate); `TelemetryStore.prune(keep_days=…)` is available for hosts that want bounded retention.
+
 ## Audit log
 
 Every tool call is written to `/sandbox/audit/audit.jsonl`. One line per call:

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -224,6 +224,21 @@ tools:
 
 Every tool remains **executable** even while deferred — `create_agent` registers all executors; deferral only trims what the model *sees* per turn. The agent loads tools by calling `search_tools("github pull request")`; matches stay available for the rest of the thread. Leave off unless you have a large catalog (e.g. a chatty MCP server) — for a handful of tools it adds a discovery hop for no benefit.
 
+## `telemetry`
+
+Local per-turn cost/latency rollup ([ADR 0006](../adr/0006-observability-and-the-self-improving-flywheel.md)). One row per terminal A2A turn (tokens incl. cache, USD cost, duration, LLM/tool call counts), queryable at `/api/telemetry/summary` + `/api/telemetry/recent`.
+
+```yaml
+telemetry:
+  enabled: true                 # one cheap write per turn
+  db_path: /sandbox/telemetry.db
+```
+
+| Key | Default | What |
+|---|---|---|
+| `enabled` | `true` | Write a per-turn row at terminal time. `false` → no store; endpoints return `{enabled:false}`. |
+| `db_path` | `/sandbox/telemetry.db` | SQLite path; `/sandbox`→`~/.protoagent` fallback, instance-scoped (ADR 0004). |
+
 ## `routing`
 
 Wires langchain's `ModelFallbackMiddleware`: on a primary-model error, retry on each fallback model (same gateway) in order. Opt-in (empty = no fallback).

--- a/graph/config.py
+++ b/graph/config.py
@@ -203,6 +203,12 @@ class LangGraphConfig:
     # blank → in-memory (history cleared on restart). Bound at graph-compile
     # time (see graph/checkpointer.py); changing the path needs a restart.
     checkpoint_db_path: str = "/sandbox/checkpoints.db"
+    # Local telemetry store (ADR 0006 Slice 2) — one per-turn cost/latency row
+    # per terminal A2A turn, queryable via /api/telemetry/*. ON by default
+    # (cheap, one write per turn); path follows /sandbox→~/.protoagent fallback
+    # and is instance-scoped (ADR 0004).
+    telemetry_enabled: bool = True
+    telemetry_db_path: str = "/sandbox/telemetry.db"
     # Checkpoint pruning — keeps the SQLite DB from growing unbounded. Keep the
     # latest N checkpoints per session, and TTL whole sessions idle past
     # max_age_days. Runs every prune_interval_hours (0 disables the sweep).
@@ -373,6 +379,8 @@ class LangGraphConfig:
             subagent_output_truncate=subagents.get("output_truncate", cls.subagent_output_truncate),
             knowledge_db_path=knowledge.get("db_path", cls.knowledge_db_path),
             checkpoint_db_path=data.get("checkpoint", {}).get("db_path", cls.checkpoint_db_path),
+            telemetry_enabled=data.get("telemetry", {}).get("enabled", cls.telemetry_enabled),
+            telemetry_db_path=data.get("telemetry", {}).get("db_path", cls.telemetry_db_path),
             checkpoint_keep_per_thread=data.get("checkpoint", {}).get("keep_per_thread", cls.checkpoint_keep_per_thread),
             checkpoint_max_age_days=data.get("checkpoint", {}).get("max_age_days", cls.checkpoint_max_age_days),
             checkpoint_prune_interval_hours=data.get("checkpoint", {}).get("prune_interval_hours", cls.checkpoint_prune_interval_hours),

--- a/server.py
+++ b/server.py
@@ -73,6 +73,7 @@ _checkpoint_prune_task = None  # background prune loop handle
 _knowledge_store = None  # KnowledgeStore bound into the active graph, or None.
 _skills_index = None     # SkillsIndex (human-authored SKILL.md store), or None.
 _workflow_registry = None  # WorkflowRegistry (declarative workflow recipes), or None.
+_telemetry_store = None  # TelemetryStore (per-turn cost/latency rollups, ADR 0006), or None.
 _inbox_store = None    # InboxStore — durable inbound inbox (ADR 0003), or None.
 _storm_guard = None    # StormGuard for the now→Activity fire path (ADR 0003).
 _mcp_clients = []        # Live MultiServerMCPClient handles (kept alive for reconnect).
@@ -511,6 +512,33 @@ def _build_a2a_push_store():
         return store
     except Exception:
         log.exception("[a2a] failed to build push-config store at %s; configs in-memory only", path)
+        return None
+
+
+def _build_telemetry_store(config):
+    """Local per-turn telemetry store (ADR 0006 Slice 2). Path resolves like the
+    other stores (/sandbox → ~/.protoagent fallback) and is instance-scoped
+    (ADR 0004). Off when ``telemetry.enabled`` is false; best-effort otherwise."""
+    if not getattr(config, "telemetry_enabled", True):
+        return None
+    from telemetry_store import TelemetryStore
+
+    configured = scope_leaf(Path(getattr(config, "telemetry_db_path", "") or "/sandbox/telemetry.db"))
+    try:
+        configured.parent.mkdir(parents=True, exist_ok=True)
+        if not os.access(configured.parent, os.W_OK):
+            raise OSError
+        path = str(configured)
+    except OSError:
+        fallback = scope_leaf(Path.home() / ".protoagent" / "telemetry.db")
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        path = str(fallback)
+    try:
+        store = TelemetryStore(path)
+        log.info("[telemetry] store ready at %s", path)
+        return store
+    except Exception:
+        log.exception("[telemetry] failed to build store at %s; telemetry disabled", path)
         return None
 
 
@@ -2265,6 +2293,22 @@ def _main():
             return {"enabled": False, "cleared": False}
         return {"enabled": True, "cleared": _goal_controller.store.clear(session_id)}
 
+    # --- Telemetry (ADR 0006 Slice 2) --------------------------------------
+    # Per-turn cost/latency rollups from the local store. Powers the operator
+    # console's cost/latency surface (Slice 3) and ad-hoc "what's expensive"
+    # queries. Read-only; returns {enabled:false} when the store is off.
+    @fastapi_app.get("/api/telemetry/summary")
+    async def _api_telemetry_summary(since: str | None = None):
+        if _telemetry_store is None:
+            return {"enabled": False, "summary": None}
+        return {"enabled": True, "summary": _telemetry_store.summary(since_iso=since)}
+
+    @fastapi_app.get("/api/telemetry/recent")
+    async def _api_telemetry_recent(limit: int = 50):
+        if _telemetry_store is None:
+            return {"enabled": False, "turns": []}
+        return {"enabled": True, "turns": _telemetry_store.recent(limit=min(max(1, limit), 500))}
+
     # --- Live config / SOUL editing ----------------------------------------
     # GET returns the current config + persona so external clients (the
     # Gradio drawer is one; curl is another) can mirror what's running.
@@ -2449,6 +2493,8 @@ def _main():
     #    want it YAML-configurable can add a field later.
     yaml_bearer = _graph_config.auth_token if _graph_config else ""
     auth_env = f"{AGENT_NAME_ENV.upper()}_API_KEY"
+    global _telemetry_store
+    _telemetry_store = _build_telemetry_store(_graph_config)
     register_a2a_routes(
         app=fastapi_app,
         chat_stream_fn_factory=_chat_langgraph_stream,
@@ -2461,6 +2507,8 @@ def _main():
         card_provider=_build_agent_card,  # agent/getAuthenticatedExtendedCard
         push_store=_build_a2a_push_store(),  # durable push configs (24h TTL)
         task_persistence=_build_a2a_task_persistence(),  # durable task records (24h TTL)
+        telemetry=_telemetry_store,  # per-turn cost/latency rollups (ADR 0006)
+        telemetry_model=(_graph_config.model_name if _graph_config else ""),
     )
 
     # --- Prometheus metrics -------------------------------------------------

--- a/telemetry_store.py
+++ b/telemetry_store.py
@@ -1,0 +1,186 @@
+"""Local telemetry store — per-turn cost/latency rollups (ADR 0006 Slice 2).
+
+One row per terminal A2A turn: accumulated token usage (incl. prompt-cache),
+USD cost, wall-clock duration, LLM-call + tool-call counts, model, and outcome.
+This is the *durable, queryable* half of observability inside protoAgent — the
+substrate for "what was expensive/slow over time" and the flywheel's analysis
+(Prometheus is live-scrape-only; Langfuse is opt-in/external).
+
+Written from the single terminal chokepoint (``A2ATaskStore.update_state`` when
+the state goes terminal), so completed/failed/canceled turns are all captured.
+Best-effort: a write failure never breaks a turn. Instance-scoped via the path
+the host resolves (ADR 0004). No TTL — history is the point; ``prune`` exists for
+hosts that want to cap retention.
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_COLUMNS = (
+    "task_id", "session_id", "state", "success", "model",
+    "input_tokens", "output_tokens", "total_tokens",
+    "cache_read_input_tokens", "cache_creation_input_tokens",
+    "cost_usd", "duration_ms", "llm_calls", "tool_calls",
+    "created_at", "ended_at",
+)
+
+
+class TelemetryStore:
+    def __init__(self, db_path: str) -> None:
+        self.path = str(db_path)
+        Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(self.path)
+        db.row_factory = sqlite3.Row
+        return db
+
+    def _init_db(self) -> None:
+        db = self._connect()
+        try:
+            db.execute(
+                """
+                CREATE TABLE IF NOT EXISTS turns (
+                    task_id                     TEXT PRIMARY KEY,
+                    session_id                  TEXT,
+                    state                       TEXT,
+                    success                     INTEGER,
+                    model                       TEXT,
+                    input_tokens                INTEGER DEFAULT 0,
+                    output_tokens               INTEGER DEFAULT 0,
+                    total_tokens                INTEGER DEFAULT 0,
+                    cache_read_input_tokens     INTEGER DEFAULT 0,
+                    cache_creation_input_tokens INTEGER DEFAULT 0,
+                    cost_usd                    REAL    DEFAULT 0,
+                    duration_ms                 INTEGER DEFAULT 0,
+                    llm_calls                   INTEGER DEFAULT 0,
+                    tool_calls                  INTEGER DEFAULT 0,
+                    created_at                  TEXT,
+                    ended_at                    TEXT
+                )
+                """
+            )
+            db.execute("CREATE INDEX IF NOT EXISTS ix_turns_ended ON turns(ended_at)")
+            db.commit()
+        finally:
+            db.close()
+
+    def record(self, row: dict) -> None:
+        """Upsert one per-turn telemetry row (keyed by task_id). Best-effort."""
+        task_id = row.get("task_id")
+        if not task_id:
+            return
+        values = [row.get(c) for c in _COLUMNS]
+        placeholders = ",".join("?" for _ in _COLUMNS)
+        cols = ",".join(_COLUMNS)
+        updates = ",".join(f"{c}=excluded.{c}" for c in _COLUMNS if c != "task_id")
+        db = self._connect()
+        try:
+            db.execute(
+                f"INSERT INTO turns ({cols}) VALUES ({placeholders}) "
+                f"ON CONFLICT(task_id) DO UPDATE SET {updates}",
+                values,
+            )
+            db.commit()
+        finally:
+            db.close()
+
+    def recent(self, limit: int = 50) -> list[dict]:
+        """Most recent turns, newest first."""
+        db = self._connect()
+        try:
+            rows = db.execute(
+                "SELECT * FROM turns ORDER BY ended_at DESC LIMIT ?",
+                (max(1, int(limit)),),
+            ).fetchall()
+            return [dict(r) for r in rows]
+        finally:
+            db.close()
+
+    def summary(self, since_iso: str | None = None) -> dict:
+        """Aggregate rollup over all turns (or those ended at/after ``since_iso``):
+        totals, averages, success rate, cache-hit ratio, and a per-model split."""
+        where, params = "", []
+        if since_iso:
+            where, params = "WHERE ended_at >= ?", [since_iso]
+        db = self._connect()
+        try:
+            agg = db.execute(
+                f"""
+                SELECT
+                    COUNT(*)                          AS turns,
+                    COALESCE(SUM(input_tokens), 0)    AS input_tokens,
+                    COALESCE(SUM(output_tokens), 0)   AS output_tokens,
+                    COALESCE(SUM(total_tokens), 0)    AS total_tokens,
+                    COALESCE(SUM(cache_read_input_tokens), 0)     AS cache_read_input_tokens,
+                    COALESCE(SUM(cache_creation_input_tokens), 0) AS cache_creation_input_tokens,
+                    COALESCE(SUM(cost_usd), 0.0)      AS cost_usd,
+                    COALESCE(SUM(llm_calls), 0)       AS llm_calls,
+                    COALESCE(SUM(tool_calls), 0)      AS tool_calls,
+                    COALESCE(AVG(duration_ms), 0)     AS avg_duration_ms,
+                    COALESCE(SUM(success), 0)         AS successes
+                FROM turns {where}
+                """,
+                params,
+            ).fetchone()
+            out = dict(agg)
+            turns = out.get("turns", 0) or 0
+            out["cost_usd"] = round(out.get("cost_usd", 0.0) or 0.0, 6)
+            out["avg_duration_ms"] = int(out.get("avg_duration_ms", 0) or 0)
+            out["success_rate"] = round((out.get("successes", 0) or 0) / turns, 4) if turns else 0.0
+            # Cache-hit ratio: cached reads / total input tokens seen.
+            inp = out.get("input_tokens", 0) or 0
+            out["cache_hit_ratio"] = round((out.get("cache_read_input_tokens", 0) or 0) / inp, 4) if inp else 0.0
+            # Latency percentiles (Python-side; bounded by typical volumes).
+            durations = [
+                r[0] for r in db.execute(
+                    f"SELECT duration_ms FROM turns {where} ORDER BY duration_ms", params
+                ).fetchall() if r[0] is not None
+            ]
+            out["p50_duration_ms"] = _percentile(durations, 50)
+            out["p95_duration_ms"] = _percentile(durations, 95)
+            by_model = db.execute(
+                f"""
+                SELECT model,
+                       COUNT(*)                     AS turns,
+                       COALESCE(SUM(cost_usd), 0.0)  AS cost_usd,
+                       COALESCE(SUM(total_tokens),0) AS total_tokens
+                FROM turns {where}
+                GROUP BY model ORDER BY cost_usd DESC
+                """,
+                params,
+            ).fetchall()
+            out["by_model"] = [
+                {**dict(r), "cost_usd": round(r["cost_usd"] or 0.0, 6)} for r in by_model
+            ]
+            return out
+        finally:
+            db.close()
+
+    def prune(self, keep_days: int = 30, *, now: datetime | None = None) -> int:
+        """Delete turns older than ``keep_days``. Off by default — call from a
+        host that wants bounded retention. Returns the rows removed."""
+        now = now or datetime.now(UTC)
+        cutoff = (now - timedelta(days=keep_days)).isoformat()
+        db = self._connect()
+        try:
+            cur = db.execute("DELETE FROM turns WHERE ended_at < ?", (cutoff,))
+            db.commit()
+            return cur.rowcount
+        finally:
+            db.close()
+
+
+def _percentile(values: list[int], pct: float) -> int:
+    """Nearest-rank percentile over a pre-sorted list (empty → 0)."""
+    if not values:
+        return 0
+    k = max(0, min(len(values) - 1, int(round((pct / 100.0) * len(values) + 0.5)) - 1))
+    return int(values[k])

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -1,0 +1,180 @@
+"""Tests for telemetry_store.py (ADR 0006 Slice 2 — per-turn rollups)."""
+
+from __future__ import annotations
+
+import pytest
+
+from telemetry_store import TelemetryStore, _percentile
+
+
+@pytest.fixture
+def store(tmp_path):
+    return TelemetryStore(str(tmp_path / "telemetry.db"))
+
+
+def _row(task_id, **over):
+    base = dict(
+        task_id=task_id, session_id="s1", state="completed", success=1,
+        model="claude-opus-4-8", input_tokens=1000, output_tokens=200,
+        total_tokens=1200, cache_read_input_tokens=400,
+        cache_creation_input_tokens=0, cost_usd=0.03, duration_ms=2000,
+        llm_calls=2, tool_calls=1, created_at="2026-06-01T00:00:00+00:00",
+        ended_at="2026-06-01T00:00:02+00:00",
+    )
+    base.update(over)
+    return base
+
+
+def test_record_and_recent(store):
+    store.record(_row("t1"))
+    store.record(_row("t2", ended_at="2026-06-01T00:01:00+00:00"))
+    recent = store.recent(limit=10)
+    assert [r["task_id"] for r in recent] == ["t2", "t1"]  # newest first
+    assert recent[0]["cost_usd"] == 0.03
+
+
+def test_record_upserts_by_task_id(store):
+    store.record(_row("t1", cost_usd=0.01))
+    store.record(_row("t1", cost_usd=0.05))  # same task_id → update, not dup
+    recent = store.recent()
+    assert len(recent) == 1
+    assert recent[0]["cost_usd"] == 0.05
+
+
+def test_record_noop_without_task_id(store):
+    store.record({"cost_usd": 1.0})  # no task_id
+    assert store.recent() == []
+
+
+def test_summary_aggregates(store):
+    store.record(_row("t1", cost_usd=0.02, input_tokens=1000, cache_read_input_tokens=500,
+                       duration_ms=1000, success=1))
+    store.record(_row("t2", cost_usd=0.04, input_tokens=3000, cache_read_input_tokens=0,
+                       duration_ms=3000, success=0, state="failed"))
+    s = store.summary()
+    assert s["turns"] == 2
+    assert s["cost_usd"] == 0.06
+    assert s["input_tokens"] == 4000
+    assert s["success_rate"] == 0.5
+    # cache-hit ratio = cached reads / total input = 500 / 4000
+    assert s["cache_hit_ratio"] == round(500 / 4000, 4)
+    assert s["p50_duration_ms"] in (1000, 3000)
+    assert s["p95_duration_ms"] == 3000
+
+
+def test_summary_by_model(store):
+    store.record(_row("t1", model="claude-opus-4-8", cost_usd=0.05))
+    store.record(_row("t2", model="claude-haiku-4-5", cost_usd=0.001))
+    s = store.summary()
+    models = {m["model"]: m for m in s["by_model"]}
+    assert models["claude-opus-4-8"]["cost_usd"] == 0.05
+    # ordered by cost desc → opus first
+    assert s["by_model"][0]["model"] == "claude-opus-4-8"
+
+
+def test_summary_since_filter(store):
+    store.record(_row("old", ended_at="2026-05-01T00:00:00+00:00"))
+    store.record(_row("new", ended_at="2026-06-01T00:00:00+00:00"))
+    s = store.summary(since_iso="2026-05-15T00:00:00+00:00")
+    assert s["turns"] == 1
+
+
+def test_summary_empty(store):
+    s = store.summary()
+    assert s["turns"] == 0
+    assert s["cost_usd"] == 0.0
+    assert s["success_rate"] == 0.0
+    assert s["cache_hit_ratio"] == 0.0
+    assert s["by_model"] == []
+
+
+def test_prune(store):
+    store.record(_row("old", ended_at="2026-01-01T00:00:00+00:00"))
+    store.record(_row("new", ended_at="2026-06-01T00:00:00+00:00"))
+    import datetime
+    removed = store.prune(keep_days=30, now=datetime.datetime(2026, 6, 1, tzinfo=datetime.timezone.utc))
+    assert removed == 1
+    assert [r["task_id"] for r in store.recent()] == ["new"]
+
+
+def test_percentile_helper():
+    assert _percentile([], 50) == 0
+    assert _percentile([10], 95) == 10
+    assert _percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 50) in (5, 6)
+    assert _percentile([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], 95) == 10
+
+
+@pytest.fixture
+def telemetry_holder(store):
+    """Point a2a_handler's telemetry holder at the test store, then restore."""
+    import a2a_handler
+
+    prev_store, prev_model = a2a_handler._TELEMETRY[0], a2a_handler._TELEMETRY_MODEL[0]
+    a2a_handler._TELEMETRY[0] = store
+    a2a_handler._TELEMETRY_MODEL[0] = "claude-opus-4-8"
+    try:
+        yield a2a_handler
+    finally:
+        a2a_handler._TELEMETRY[0] = prev_store
+        a2a_handler._TELEMETRY_MODEL[0] = prev_model
+
+
+def test_record_telemetry_writes_row_from_task_record(store, telemetry_holder):
+    """The terminal writer maps a TaskRecord → a telemetry row (ADR 0006)."""
+    a2a_handler = telemetry_holder
+    rec = a2a_handler.TaskRecord(
+        id="task-x", context_id="sess-1", state=a2a_handler.COMPLETED,
+        created_at="2026-06-01T00:00:00+00:00", updated_at="2026-06-01T00:00:03+00:00",
+        message_text="hi",
+    )
+    rec.usage = {
+        "input_tokens": 1200, "output_tokens": 300, "total_tokens": 1500,
+        "cache_read_input_tokens": 600, "cache_creation_input_tokens": 0, "cost_usd": 0.042,
+    }
+    rec.llm_calls = 3
+    rec.tool_calls = 2
+
+    a2a_handler._record_telemetry(rec)
+
+    turns = store.recent()
+    assert len(turns) == 1
+    row = turns[0]
+    assert row["task_id"] == "task-x"
+    assert row["session_id"] == "sess-1"
+    assert row["success"] == 1
+    assert row["model"] == "claude-opus-4-8"
+    assert row["cost_usd"] == 0.042
+    assert row["llm_calls"] == 3 and row["tool_calls"] == 2
+    assert row["duration_ms"] == 3000  # 3s between created/ended
+
+
+def test_record_telemetry_noop_when_store_unset():
+    import a2a_handler
+
+    prev = a2a_handler._TELEMETRY[0]
+    a2a_handler._TELEMETRY[0] = None
+    try:
+        rec = a2a_handler.TaskRecord(
+            id="t", context_id="c", state=a2a_handler.COMPLETED,
+            created_at="2026-06-01T00:00:00+00:00", updated_at="2026-06-01T00:00:01+00:00",
+            message_text="x",
+        )
+        a2a_handler._record_telemetry(rec)  # must not raise
+    finally:
+        a2a_handler._TELEMETRY[0] = prev
+
+
+def test_config_parses_telemetry(tmp_path):
+    from graph.config import LangGraphConfig
+
+    p = tmp_path / "langgraph-config.yaml"
+    p.write_text("telemetry:\n  enabled: false\n  db_path: /tmp/t.db\n")
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.telemetry_enabled is False
+    assert cfg.telemetry_db_path == "/tmp/t.db"
+
+
+def test_config_telemetry_default_on():
+    from graph.config import LangGraphConfig
+
+    assert LangGraphConfig().telemetry_enabled is True


### PR DESCRIPTION
Slice 2 of ADR 0006 — the durable, queryable half of observability. Prometheus is live-scrape-only and Langfuse is opt-in/external; neither gives protoAgent a history to analyze. This adds one.

## What it does
One **per-turn row** at the single terminal chokepoint (`A2ATaskStore.update_state` when state goes terminal — so completed/failed/canceled are all captured): accumulated token usage (incl. prompt-cache), `costUsd`, wall-clock duration, **LLM-call + tool-call counts**, model, outcome.

- **`telemetry_store.py`** (`TelemetryStore`) — SQLite. `summary()` → totals, success rate, **cache-hit ratio**, **p50/p95 latency**, per-model split; `recent()`; `prune()`. No TTL (history is the analysis substrate).
- **`a2a_handler.py`** — `TaskRecord` gains `llm_calls`/`tool_calls` counters (bumped in `add_usage` / on `tool_start`); `_record_telemetry` writes the row best-effort (never breaks a turn). New telemetry holders + `register_a2a_routes(telemetry=, telemetry_model=)`.
- **`server.py`** — `_build_telemetry_store` (instance-scoped, `/sandbox`→`~/.protoagent` fallback); read API **`GET /api/telemetry/summary`** + **`/api/telemetry/recent`**.
- **`config.py`** — `telemetry.enabled` (default true) + `telemetry.db_path`.

```bash
curl localhost:7870/api/telemetry/summary
# {turns, cost_usd, cache_hit_ratio, p50_duration_ms, p95_duration_ms, success_rate, by_model[], ...}
```

## Why a single chokepoint
`_notify_terminal` only fires on the `done` path; `update_state` is the one place **every** terminal transition (incl. error/cancel/crash) flows through + persists. Writing there captures failed turns too — which matters, since a failed turn still cost tokens.

## Verification
- `tests/test_telemetry_store.py` (13): record/upsert/recent, summary (by-model, `since` filter, empty), prune, percentile helper, the `TaskRecord`→row writer + store-unset no-op, config parse + default-on.
- **Full suite: 847 passed.** `npm run docs:build` clean.
- Docs: observability guide (local store + endpoints), configuration reference, ADR 0006 → Slices 1–2 shipped.

Next: Slice 3 (operator-console surface — per-turn footer + session panel reading these endpoints), then Slice 4 (feedback loop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)