### PR TITLE
feat(observability): System ▸ Telemetry console dashboard (ADR 0006 #3)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -333,3 +333,42 @@ export function buildFrames({ rpcId, contextId, taskId, prompt }) {
   );
   return frames;
 }
+
+// Telemetry fixtures (ADR 0006 Slice 3) — shape mirrors /api/telemetry/*.
+export const TELEMETRY_SUMMARY = {
+  turns: 3,
+  input_tokens: 12000,
+  output_tokens: 1800,
+  total_tokens: 13800,
+  cache_read_input_tokens: 7200,
+  cache_creation_input_tokens: 0,
+  cost_usd: 0.2154,
+  llm_calls: 7,
+  tool_calls: 4,
+  avg_duration_ms: 4200,
+  p50_duration_ms: 3800,
+  p95_duration_ms: 8100,
+  success_rate: 0.6667,
+  cache_hit_ratio: 0.6,
+  by_model: [
+    { model: "claude-opus-4-8", turns: 2, cost_usd: 0.21, total_tokens: 12000 },
+    { model: "claude-haiku-4-5", turns: 1, cost_usd: 0.0054, total_tokens: 1800 },
+  ],
+};
+
+export const TELEMETRY_TURNS = [
+  {
+    task_id: "task-3", session_id: "s1", state: "completed", success: 1,
+    model: "claude-opus-4-8", input_tokens: 6000, output_tokens: 900, total_tokens: 6900,
+    cache_read_input_tokens: 3600, cache_creation_input_tokens: 0, cost_usd: 0.12,
+    duration_ms: 8100, llm_calls: 3, tool_calls: 2,
+    created_at: "2026-06-01T05:00:00+00:00", ended_at: "2026-06-01T05:00:08+00:00",
+  },
+  {
+    task_id: "task-2", session_id: "s1", state: "failed", success: 0,
+    model: "claude-haiku-4-5", input_tokens: 1800, output_tokens: 0, total_tokens: 1800,
+    cache_read_input_tokens: 0, cache_creation_input_tokens: 0, cost_usd: 0.0054,
+    duration_ms: 700, llm_calls: 1, tool_calls: 0,
+    created_at: "2026-06-01T04:59:00+00:00", ended_at: "2026-06-01T04:59:01+00:00",
+  },
+];

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -25,6 +25,8 @@ import {
   settingsRestartRequired,
   SLASH_COMMANDS,
   SUBAGENTS,
+  TELEMETRY_SUMMARY,
+  TELEMETRY_TURNS,
   WORKFLOW_RUN_RESULT,
   WORKFLOWS,
 } from "./fixtures.mjs";
@@ -90,6 +92,10 @@ function handleApiGet(pathname) {
       return ACTIVITY_HISTORY;
     case "/api/inbox":
       return INBOX_ITEMS;
+    case "/api/telemetry/summary":
+      return { enabled: true, summary: TELEMETRY_SUMMARY };
+    case "/api/telemetry/recent":
+      return { enabled: true, turns: TELEMETRY_TURNS };
     default:
       return null;
   }

--- a/apps/web/e2e/telemetry.spec.ts
+++ b/apps/web/e2e/telemetry.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+// The System ▸ Telemetry tab renders the per-turn rollups from
+// /api/telemetry/* (ADR 0006 Slice 3): summary cards + a recent-turns table.
+
+test("System → Telemetry shows summary cards and recent turns", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // Into System, then the Telemetry sub-tab.
+  await page.getByRole("button", { name: "System" }).click();
+  await page.getByRole("button", { name: "Telemetry" }).click();
+
+  const surface = page.getByTestId("telemetry-surface");
+  await expect(surface).toBeVisible();
+
+  // Summary cards (from TELEMETRY_SUMMARY fixture).
+  await expect(surface.getByText("Total cost")).toBeVisible();
+  await expect(surface.getByText("$0.22")).toBeVisible();      // 0.2154 → $0.22
+  await expect(surface.getByText("Cache hit")).toBeVisible();
+  await expect(surface.getByText("60%")).toBeVisible();        // cache_hit_ratio 0.6
+
+  // Per-model + recent-turns tables.
+  await expect(surface.getByText("By model")).toBeVisible();
+  await expect(surface.getByText("claude-opus-4-8").first()).toBeVisible();
+  await expect(surface.getByText("Recent turns")).toBeVisible();
+  // The failed turn renders its state pill.
+  await expect(surface.getByText("failed")).toBeVisible();
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,5 +1,6 @@
 import {
   Activity,
+  BarChart3,
   Bot,
   Boxes,
   CalendarClock,
@@ -34,6 +35,7 @@ import { ConfirmDialog } from "./ConfirmDialog";
 import { InboxPanel } from "../inbox/InboxPanel";
 import { ChatSurface } from "../chat/ChatSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
+import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { onConnectionChange, onServerEvent } from "../lib/events";
@@ -45,7 +47,7 @@ import { SetupWizard } from "../setup/SetupWizard";
 // fanning out to sub-views via an in-surface segmented control.
 type Surface = "chat" | "activity" | "studio" | "system";
 type StudioTab = "subagents" | "workflows" | "schedule" | "goals";
-type SystemTab = "runtime" | "settings";
+type SystemTab = "runtime" | "telemetry" | "settings";
 type ActivityTab = "thread" | "inbox";
 type RightPanel = "notes" | "beads";
 type SubagentMode = "single" | "batch";
@@ -933,6 +935,9 @@ export function App() {
               <button className={systemTab === "runtime" ? "active" : ""} onClick={() => setSystemTab("runtime")}>
                 <Gauge size={15} /> Runtime
               </button>
+              <button className={systemTab === "telemetry" ? "active" : ""} onClick={() => setSystemTab("telemetry")}>
+                <BarChart3 size={15} /> Telemetry
+              </button>
               <button className={systemTab === "settings" ? "active" : ""} onClick={() => setSystemTab("settings")}>
                 <Settings2 size={15} /> Settings
               </button>
@@ -1306,6 +1311,7 @@ export function App() {
             </section>
           ) : null}
 
+          {surface === "system" && systemTab === "telemetry" ? <TelemetrySurface onError={setError} /> : null}
           {surface === "system" && systemTab === "settings" ? <SettingsSurface onError={setError} /> : null}
         </main>
 

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2399,3 +2399,57 @@ textarea {
   color: var(--fg-secondary);
   cursor: pointer;
 }
+
+/* Telemetry dashboard (ADR 0006 Slice 3) */
+.empty-note {
+  color: var(--fg-muted);
+  font-size: 13px;
+  padding: 16px 2px;
+}
+.telemetry-section {
+  margin-top: 22px;
+}
+.telemetry-section > .panel-kicker {
+  margin-bottom: 8px;
+}
+.telemetry-table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 12.5px;
+  font-variant-numeric: tabular-nums;
+}
+.telemetry-table th {
+  text-align: left;
+  font-weight: 500;
+  color: var(--fg-muted);
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  white-space: nowrap;
+}
+.telemetry-table td {
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border);
+  color: var(--fg-secondary);
+  white-space: nowrap;
+}
+.telemetry-table tbody tr:hover {
+  background: var(--bg-hover);
+}
+.telemetry-table tr.turn-failed td {
+  color: var(--error);
+}
+.turn-state {
+  font-size: 11px;
+  padding: 1px 7px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--fg-muted);
+}
+.turn-state-completed {
+  color: var(--success);
+  border-color: color-mix(in srgb, var(--success) 40%, transparent);
+}
+.turn-state-failed {
+  color: var(--error);
+  border-color: color-mix(in srgb, var(--error) 40%, transparent);
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -13,6 +13,8 @@ import type {
   SettingsGroup,
   SlashCommand,
   Subagent,
+  TelemetrySummary,
+  TelemetryTurn,
   ToolEvent,
   WorkflowRunResult,
   WorkflowSummary,
@@ -169,6 +171,19 @@ async function consumeSse(
 export const api = {
   runtimeStatus() {
     return request<RuntimeStatus>("/api/runtime/status");
+  },
+
+  telemetrySummary(since?: string) {
+    const q = since ? `?since=${encodeURIComponent(since)}` : "";
+    return request<{ enabled: boolean; summary: TelemetrySummary | null }>(
+      `/api/telemetry/summary${q}`,
+    );
+  },
+
+  telemetryRecent(limit = 50) {
+    return request<{ enabled: boolean; turns: TelemetryTurn[] }>(
+      `/api/telemetry/recent?limit=${limit}`,
+    );
   },
 
   setupStatus() {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -266,3 +266,41 @@ export type SetupStatus = {
   setup_complete: boolean;
   presets: string[];
 };
+
+// Telemetry (ADR 0006 Slice 3) — mirrors /api/telemetry/* (telemetry_store.py).
+export type TelemetrySummary = {
+  turns: number;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+  cost_usd: number;
+  llm_calls: number;
+  tool_calls: number;
+  avg_duration_ms: number;
+  p50_duration_ms: number;
+  p95_duration_ms: number;
+  success_rate: number;
+  cache_hit_ratio: number;
+  by_model: { model: string; turns: number; cost_usd: number; total_tokens: number }[];
+};
+
+export type TelemetryTurn = {
+  task_id: string;
+  session_id: string;
+  state: string;
+  success: number;
+  model: string;
+  input_tokens: number;
+  output_tokens: number;
+  total_tokens: number;
+  cache_read_input_tokens: number;
+  cache_creation_input_tokens: number;
+  cost_usd: number;
+  duration_ms: number;
+  llm_calls: number;
+  tool_calls: number;
+  created_at: string;
+  ended_at: string;
+};

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -1,0 +1,157 @@
+import {
+  Activity,
+  Clock,
+  Coins,
+  Database,
+  Hash,
+  Layers,
+  RefreshCw,
+  Wrench,
+} from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { api } from "../lib/api";
+import type { TelemetrySummary, TelemetryTurn } from "../lib/types";
+
+// Telemetry dashboard (ADR 0006 Slice 3) — reads /api/telemetry/* (the local
+// per-turn rollup store). Summary cards + a recent-turns table. Functional
+// first: real numbers, theme-consistent, no charts yet.
+
+function usd(n: number): string {
+  if (!n) return "$0";
+  if (n < 0.01) return `$${n.toFixed(4)}`;
+  return `$${n.toFixed(2)}`;
+}
+
+function tokens(n: number): string {
+  if (n >= 1_000_000) return `${(n / 1_000_000).toFixed(1)}M`;
+  if (n >= 1_000) return `${(n / 1_000).toFixed(1)}k`;
+  return String(n);
+}
+
+function ms(n: number): string {
+  if (!n) return "—";
+  return n >= 1000 ? `${(n / 1000).toFixed(1)}s` : `${n}ms`;
+}
+
+function pct(n: number): string {
+  return `${Math.round((n || 0) * 100)}%`;
+}
+
+export function TelemetrySurface({ onError }: { onError: (message: string) => void }) {
+  const [summary, setSummary] = useState<TelemetrySummary | null>(null);
+  const [turns, setTurns] = useState<TelemetryTurn[]>([]);
+  const [enabled, setEnabled] = useState(true);
+  const [loading, setLoading] = useState(false);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const [s, r] = await Promise.all([api.telemetrySummary(), api.telemetryRecent(50)]);
+      setEnabled(s.enabled && r.enabled);
+      setSummary(s.summary);
+      setTurns(r.turns || []);
+      onError("");
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  useEffect(() => {
+    void load();
+  }, []);
+
+  return (
+    <section className="panel stage-panel" data-testid="telemetry-surface">
+      <div className="panel-header">
+        <div>
+          <h1>Telemetry</h1>
+          <p className="panel-kicker">per-turn cost &amp; latency · {summary?.turns ?? 0} turns recorded</p>
+        </div>
+        <button className="secondary-button" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
+          <RefreshCw size={15} className={loading ? "spin" : ""} /> Refresh
+        </button>
+      </div>
+
+      <div className="stage-body">
+        {!enabled ? (
+          <p className="empty-note">Telemetry store is disabled (set <code>telemetry.enabled: true</code>).</p>
+        ) : !summary || summary.turns === 0 ? (
+          <p className="empty-note">No turns recorded yet — run a turn and refresh.</p>
+        ) : (
+          <>
+            <div className="metric-grid">
+              <Metric icon={<Coins size={16} />} label="Total cost" value={usd(summary.cost_usd)} />
+              <Metric icon={<Hash size={16} />} label="Turns" value={String(summary.turns)} />
+              <Metric icon={<Activity size={16} />} label="Success" value={pct(summary.success_rate)} />
+              <Metric icon={<Database size={16} />} label="Cache hit" value={pct(summary.cache_hit_ratio)} />
+              <Metric icon={<Clock size={16} />} label="Latency p50" value={ms(summary.p50_duration_ms)} />
+              <Metric icon={<Clock size={16} />} label="Latency p95" value={ms(summary.p95_duration_ms)} />
+              <Metric icon={<Layers size={16} />} label="Tokens" value={tokens(summary.total_tokens)} />
+              <Metric icon={<Wrench size={16} />} label="Tool calls" value={String(summary.tool_calls)} />
+            </div>
+
+            {summary.by_model.length > 0 ? (
+              <div className="telemetry-section">
+                <h2 className="panel-kicker">By model</h2>
+                <table className="telemetry-table">
+                  <thead>
+                    <tr><th>Model</th><th>Turns</th><th>Tokens</th><th>Cost</th></tr>
+                  </thead>
+                  <tbody>
+                    {summary.by_model.map((m) => (
+                      <tr key={m.model || "unknown"}>
+                        <td>{m.model || "—"}</td>
+                        <td>{m.turns}</td>
+                        <td>{tokens(m.total_tokens)}</td>
+                        <td>{usd(m.cost_usd)}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+
+            <div className="telemetry-section">
+              <h2 className="panel-kicker">Recent turns</h2>
+              <table className="telemetry-table">
+                <thead>
+                  <tr>
+                    <th>Ended</th><th>Model</th><th>Tokens (in→out)</th>
+                    <th>Cache</th><th>Cost</th><th>Duration</th><th>LLM/Tool</th><th>State</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {turns.map((t) => (
+                    <tr key={t.task_id} className={t.success ? "" : "turn-failed"}>
+                      <td title={t.ended_at}>{(t.ended_at || "").replace("T", " ").slice(5, 19)}</td>
+                      <td>{t.model || "—"}</td>
+                      <td>{tokens(t.input_tokens)}→{tokens(t.output_tokens)}</td>
+                      <td>{t.cache_read_input_tokens ? tokens(t.cache_read_input_tokens) : "—"}</td>
+                      <td>{usd(t.cost_usd)}</td>
+                      <td>{ms(t.duration_ms)}</td>
+                      <td>{t.llm_calls}/{t.tool_calls}</td>
+                      <td><span className={`turn-state turn-state-${t.state}`}>{t.state}</span></td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}
+
+function Metric({ icon, label, value }: { icon: React.ReactNode; label: string; value: string }) {
+  return (
+    <div className="metric">
+      {icon}
+      <span>{label}</span>
+      <strong>{value}</strong>
+    </div>
+  );
+}

--- a/docs/adr/0006-observability-and-the-self-improving-flywheel.md
+++ b/docs/adr/0006-observability-and-the-self-improving-flywheel.md
@@ -1,6 +1,6 @@
 # ADR 0006 — Observability & the Self-Improving Flywheel
 
-- **Status:** Accepted (2026-06-01) — implementing the ranked plan (Slices 1–2 shipped)
+- **Status:** Accepted (2026-06-01) — implementing the ranked plan (Slices 1–3 shipped)
 - **Date:** 2026-06-01
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** observability, cost, tracing, metrics, a2a, optimization, flywheel
@@ -115,10 +115,11 @@ outbound telemetry with the fleet so the data is useful beyond protoAgent.
    `/api/telemetry/summary` (totals, success rate, cache-hit ratio, p50/p95
    latency, per-model split) + `/api/telemetry/recent`. Survives restart; no TTL
    (history is the substrate), `prune()` available. *(fixes 5)*
-3. **Surface.** Operator-console telemetry: a per-turn footer (tokens · cost ·
-   latency) and a session/▾history panel (cumulative cost, p50/p95 latency,
-   cache-hit %, per-tool timings). Consumes the data already on the A2A stream.
-   *(fixes 6)*
+3. ✅ **Surface — shipped.** A **System ▸ Telemetry** dashboard
+   (`apps/web/src/telemetry/TelemetrySurface.tsx`): summary cards (cost, turns,
+   success rate, cache-hit %, p50/p95 latency, tokens, tool calls) + a by-model
+   table + a recent-turns table, reading `/api/telemetry/*`. Functional-first
+   (theme-consistent, no charts yet — a follow-up). *(fixes 6)*
 4. **Flywheel / feedback.** Flag turns whose cost/latency exceeds N× the rolling
    median; *prove the levers* (cache-hit %, deferral schema-token savings,
    routing/fallback rates, compaction triggers); feed signal back into the

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -344,6 +344,15 @@ server — not the client — decides which directories they may read and write.
 - The runtime-status `project.allowed_dirs` field feeds the project-path
   picker's suggestions; it does not relax the server-side check.
 
+## Telemetry surface
+
+The **System ▸ Telemetry** sub-tab (`apps/web/src/telemetry/TelemetrySurface.tsx`,
+ADR 0006) renders the local per-turn cost/latency rollup: summary cards (total
+cost, turns, success rate, cache-hit %, p50/p95 latency, tokens, tool calls), a
+by-model table, and a recent-turns table. It reads `GET /api/telemetry/summary`
++ `/api/telemetry/recent` — no chat-stream coupling — and degrades to a clear
+note when the store is disabled or empty.
+
 ## Settings surface
 
 The **Settings** rail surface lets an operator manage every config field from


### PR DESCRIPTION
Slice 3 of ADR 0006 — surface the local telemetry rollup in the operator console. **System ▸ Telemetry** dashboard, functional-first.

## What it adds
A new **System** sub-tab (`apps/web/src/telemetry/TelemetrySurface.tsx`) reading `/api/telemetry/*` — no chat-stream coupling, self-contained:
- **Summary cards** — total cost, turns, success rate, cache-hit %, p50/p95 latency, tokens, tool calls.
- **By-model table** (cost-ranked) + a **recent-turns table** (model · in→out tokens · cache · cost · duration · llm/tool counts · state pill).
- Degrades to a clear note when the store is disabled or has no turns yet.

Wiring: `TelemetrySummary`/`TelemetryTurn` types + `api.telemetrySummary`/`telemetryRecent`; `SystemTab` gains `"telemetry"` (Runtime · **Telemetry** · Settings); `theme.css` table/empty styles. Per the kickoff: **dashboard tab, functional-first** (theme-consistent, no charts — a follow-up).

## Verification
- `e2e/telemetry.spec.ts` — drives System ▸ Telemetry and asserts the cards (cost `$0.22`, cache-hit `60%`), the by-model row, and the failed-turn pill render from the mock backend. Mock server + fixtures gained the two telemetry endpoints.
- `npm run web:build` (tsc + vite) clean; **full e2e: 36 passed**.
- `npm run docs:build` clean. react-tauri-ui gains a telemetry-surface section; ADR 0006 → Slices 1–3 shipped.

Next (and last): Slice 4 — the feedback loop (flag expensive/slow turns, prove the levers, feed signal into skills/memory).

🤖 Generated with [Claude Code](https://claude.com/claude-code)