### PR TITLE
feat(observability): advise-only insights — close the flywheel (ADR 0006 #4)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -372,3 +372,24 @@ export const TELEMETRY_TURNS = [
     created_at: "2026-06-01T04:59:00+00:00", ended_at: "2026-06-01T04:59:01+00:00",
   },
 ];
+
+export const TELEMETRY_INSIGHTS = {
+  turns: 3,
+  flagged_count: 1,
+  flagged: [
+    {
+      ...TELEMETRY_TURNS[0],
+      reasons: ["cost 0.12 ≥ 5× median 0.012", "latency 8100ms ≥ 5× median 700ms"],
+    },
+  ],
+  levers: {
+    cache: { hit_ratio: 0.6, read_tokens: 7200, est_savings_usd: 0.0972 },
+    routing: {
+      by_model: [
+        { model: "claude-opus-4-8", turns: 2, cost_usd: 0.21, total_tokens: 12000 },
+      ],
+    },
+    success_rate: 0.6667,
+  },
+  unproven_levers: ["tool deferral (schema-token savings)", "compaction", "model routing detail"],
+};

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -25,6 +25,7 @@ import {
   settingsRestartRequired,
   SLASH_COMMANDS,
   SUBAGENTS,
+  TELEMETRY_INSIGHTS,
   TELEMETRY_SUMMARY,
   TELEMETRY_TURNS,
   WORKFLOW_RUN_RESULT,
@@ -96,6 +97,8 @@ function handleApiGet(pathname) {
       return { enabled: true, summary: TELEMETRY_SUMMARY };
     case "/api/telemetry/recent":
       return { enabled: true, turns: TELEMETRY_TURNS };
+    case "/api/telemetry/insights":
+      return { enabled: true, insights: TELEMETRY_INSIGHTS };
     default:
       return null;
   }

--- a/apps/web/e2e/telemetry.spec.ts
+++ b/apps/web/e2e/telemetry.spec.ts
@@ -17,7 +17,7 @@ test("System → Telemetry shows summary cards and recent turns", async ({ page 
   await expect(surface.getByText("Total cost")).toBeVisible();
   await expect(surface.getByText("$0.22")).toBeVisible();      // 0.2154 → $0.22
   await expect(surface.getByText("Cache hit")).toBeVisible();
-  await expect(surface.getByText("60%")).toBeVisible();        // cache_hit_ratio 0.6
+  await expect(surface.getByText("60%", { exact: true })).toBeVisible(); // cache-hit card
 
   // Per-model + recent-turns tables.
   await expect(surface.getByText("By model")).toBeVisible();
@@ -25,4 +25,10 @@ test("System → Telemetry shows summary cards and recent turns", async ({ page 
   await expect(surface.getByText("Recent turns")).toBeVisible();
   // The failed turn renders its state pill.
   await expect(surface.getByText("failed")).toBeVisible();
+
+  // Insights (Slice 4, advise-only): flagged-turn warning + proven cache lever.
+  const insights = surface.getByTestId("telemetry-insights");
+  await expect(insights).toBeVisible();
+  await expect(insights.getByText(/1 turn flagged/)).toBeVisible();
+  await expect(insights.getByText(/Prompt cache: 60% hit/)).toBeVisible();
 });

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2453,3 +2453,45 @@ textarea {
   color: var(--error);
   border-color: color-mix(in srgb, var(--error) 40%, transparent);
 }
+
+/* Telemetry insights (ADR 0006 Slice 4 — advise-only) */
+.telemetry-insights {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px 14px;
+  margin-bottom: 18px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+}
+.insight-row {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 13px;
+}
+.insight-row.ok { color: var(--success); }
+.insight-row.warn { color: var(--warning); }
+.insight-flags {
+  list-style: none;
+  margin: 4px 0 0;
+  padding: 0;
+  font-size: 12px;
+  font-variant-numeric: tabular-nums;
+}
+.insight-flags li {
+  display: flex;
+  gap: 12px;
+  padding: 3px 0;
+  color: var(--fg-secondary);
+  border-top: 1px solid var(--border);
+}
+.flag-when { color: var(--fg-muted); min-width: 96px; }
+.flag-model { min-width: 150px; }
+.flag-reason { color: var(--warning); }
+.insight-note {
+  font-size: 11.5px;
+  color: var(--fg-muted);
+  margin: 2px 0 0;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -13,6 +13,7 @@ import type {
   SettingsGroup,
   SlashCommand,
   Subagent,
+  TelemetryInsights,
   TelemetrySummary,
   TelemetryTurn,
   ToolEvent,
@@ -183,6 +184,12 @@ export const api = {
   telemetryRecent(limit = 50) {
     return request<{ enabled: boolean; turns: TelemetryTurn[] }>(
       `/api/telemetry/recent?limit=${limit}`,
+    );
+  },
+
+  telemetryInsights() {
+    return request<{ enabled: boolean; insights: TelemetryInsights | null }>(
+      "/api/telemetry/insights",
     );
   },
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -304,3 +304,15 @@ export type TelemetryTurn = {
   created_at: string;
   ended_at: string;
 };
+
+export type TelemetryInsights = {
+  turns: number;
+  flagged: (TelemetryTurn & { reasons: string[] })[];
+  flagged_count: number;
+  levers: {
+    cache: { hit_ratio: number; read_tokens: number; est_savings_usd: number };
+    routing: { by_model: { model: string; turns: number; cost_usd: number; total_tokens: number }[] };
+    success_rate: number;
+  };
+  unproven_levers: string[];
+};

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -1,5 +1,7 @@
 import {
   Activity,
+  AlertTriangle,
+  CheckCircle2,
   Clock,
   Coins,
   Database,
@@ -11,7 +13,7 @@ import {
 import { useEffect, useState } from "react";
 
 import { api } from "../lib/api";
-import type { TelemetrySummary, TelemetryTurn } from "../lib/types";
+import type { TelemetryInsights, TelemetrySummary, TelemetryTurn } from "../lib/types";
 
 // Telemetry dashboard (ADR 0006 Slice 3) — reads /api/telemetry/* (the local
 // per-turn rollup store). Summary cards + a recent-turns table. Functional
@@ -41,16 +43,22 @@ function pct(n: number): string {
 export function TelemetrySurface({ onError }: { onError: (message: string) => void }) {
   const [summary, setSummary] = useState<TelemetrySummary | null>(null);
   const [turns, setTurns] = useState<TelemetryTurn[]>([]);
+  const [insights, setInsights] = useState<TelemetryInsights | null>(null);
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(false);
 
   async function load() {
     setLoading(true);
     try {
-      const [s, r] = await Promise.all([api.telemetrySummary(), api.telemetryRecent(50)]);
+      const [s, r, i] = await Promise.all([
+        api.telemetrySummary(),
+        api.telemetryRecent(50),
+        api.telemetryInsights(),
+      ]);
       setEnabled(s.enabled && r.enabled);
       setSummary(s.summary);
       setTurns(r.turns || []);
+      setInsights(i.insights);
       onError("");
     } catch (e) {
       onError(e instanceof Error ? e.message : String(e));
@@ -82,6 +90,38 @@ export function TelemetrySurface({ onError }: { onError: (message: string) => vo
           <p className="empty-note">No turns recorded yet — run a turn and refresh.</p>
         ) : (
           <>
+            {insights ? (
+              <div className="telemetry-insights" data-testid="telemetry-insights">
+                <div className={`insight-row ${insights.flagged_count ? "warn" : "ok"}`}>
+                  {insights.flagged_count ? (
+                    <><AlertTriangle size={15} /> {insights.flagged_count} turn{insights.flagged_count > 1 ? "s" : ""} flagged (≥5× median cost or latency)</>
+                  ) : (
+                    <><CheckCircle2 size={15} /> No cost or latency outliers</>
+                  )}
+                </div>
+                <div className="insight-row ok">
+                  <CheckCircle2 size={15} /> Prompt cache: {pct(insights.levers.cache.hit_ratio)} hit ·
+                  ~{usd(insights.levers.cache.est_savings_usd)} saved
+                </div>
+                {insights.flagged.length ? (
+                  <ul className="insight-flags">
+                    {insights.flagged.slice(0, 5).map((f) => (
+                      <li key={f.task_id}>
+                        <span className="flag-when">{(f.ended_at || "").replace("T", " ").slice(5, 19)}</span>
+                        <span className="flag-model">{f.model || "—"}</span>
+                        <span className="flag-reason">{f.reasons.join(" · ")}</span>
+                      </li>
+                    ))}
+                  </ul>
+                ) : null}
+                {insights.unproven_levers.length ? (
+                  <p className="insight-note">
+                    Not yet measured: {insights.unproven_levers.join(", ")}.
+                  </p>
+                ) : null}
+              </div>
+            ) : null}
+
             <div className="metric-grid">
               <Metric icon={<Coins size={16} />} label="Total cost" value={usd(summary.cost_usd)} />
               <Metric icon={<Hash size={16} />} label="Turns" value={String(summary.turns)} />

--- a/docs/adr/0006-observability-and-the-self-improving-flywheel.md
+++ b/docs/adr/0006-observability-and-the-self-improving-flywheel.md
@@ -1,6 +1,6 @@
 # ADR 0006 — Observability & the Self-Improving Flywheel
 
-- **Status:** Accepted (2026-06-01) — implementing the ranked plan (Slices 1–3 shipped)
+- **Status:** Accepted (2026-06-01) — all 4 slices shipped (flywheel: measure → persist → surface → advise)
 - **Date:** 2026-06-01
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** observability, cost, tracing, metrics, a2a, optimization, flywheel
@@ -120,10 +120,21 @@ outbound telemetry with the fleet so the data is useful beyond protoAgent.
    success rate, cache-hit %, p50/p95 latency, tokens, tool calls) + a by-model
    table + a recent-turns table, reading `/api/telemetry/*`. Functional-first
    (theme-consistent, no charts yet — a follow-up). *(fixes 6)*
-4. **Flywheel / feedback.** Flag turns whose cost/latency exceeds N× the rolling
-   median; *prove the levers* (cache-hit %, deferral schema-token savings,
-   routing/fallback rates, compaction triggers); feed signal back into the
-   learned-skills / memory layer and operator recommendations. *(fixes 7)*
+4. ✅ **Flywheel / feedback — shipped (advise-only).** `/api/telemetry/insights`
+   + a Telemetry **Insights** panel: flags turns whose cost/latency ≥ 5× the
+   rolling median, and *proves the levers we can measure from the per-turn
+   store* — prompt-cache hit % + estimated USD saved (`pricing.cache_read_savings_usd`),
+   plus model-mix (routing visibility). **Read-only**: it surfaces signal, the
+   operator decides — no autonomous config changes. Levers needing extra
+   per-turn signals (tool-deferral schema-token savings, compaction, detailed
+   routing) are explicitly listed as *not yet measured* rather than faked — a
+   follow-up that adds those signals can light them up. *(fixes 7)*
+
+> **Why advise-only (not auto-optimize).** Letting telemetry change config
+> automatically (auto-enable deferral, auto-downgrade model) is higher leverage
+> but needs guardrails and risks surprising regressions. We start by making the
+> signal trustworthy and visible; auto-optimization is a deliberate future step,
+> not a default.
 
 Priorities (per the kickoff): **cost visibility ($)** and **latency breakdown**
 lead; Slice 1 makes both real. The console surface (Slice 3) follows so the

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -97,9 +97,12 @@ curl 'localhost:7870/api/telemetry/summary?since=2026-06-01T00:00:00+00:00'
 
 # Most recent turns (newest first)
 curl 'localhost:7870/api/telemetry/recent?limit=20'
+
+# Insights (advise-only): flagged outlier turns + proven optimization levers
+curl localhost:7870/api/telemetry/insights
 ```
 
-`summary` returns `{turns, input_tokens, output_tokens, total_tokens, cache_read_input_tokens, cache_creation_input_tokens, cost_usd, llm_calls, tool_calls, avg_duration_ms, p50_duration_ms, p95_duration_ms, success_rate, cache_hit_ratio, by_model[]}`. The operator console surfaces these (Slice 3). History isn't auto-expired (it's the analysis substrate); `TelemetryStore.prune(keep_days=…)` is available for hosts that want bounded retention.
+`summary` returns `{turns, input_tokens, output_tokens, total_tokens, cache_read_input_tokens, cache_creation_input_tokens, cost_usd, llm_calls, tool_calls, avg_duration_ms, p50_duration_ms, p95_duration_ms, success_rate, cache_hit_ratio, by_model[]}`. `insights` flags turns ≥ 5× the rolling-median cost/latency and proves the cache lever (`{levers: {cache: {hit_ratio, est_savings_usd}, …}}`) — **advise-only**, no autonomous config changes. The operator console surfaces all of this under **System ▸ Telemetry** (Slices 3–4). History isn't auto-expired (it's the analysis substrate); `TelemetryStore.prune(keep_days=…)` is available for hosts that want bounded retention.
 
 ## Audit log
 

--- a/pricing.py
+++ b/pricing.py
@@ -59,3 +59,16 @@ def cost_usd(model: str | None, usage: dict) -> float:
     inp = int(usage.get("input_tokens", 0) or 0)
     out = int(usage.get("output_tokens", 0) or 0)
     return round(inp * rate["input"] + out * rate["output"], 6)
+
+
+# Anthropic prompt-cache reads are billed at ~10% of the input rate, so a cached
+# read *saves* ~90% of what that token would otherwise cost. This is an estimate
+# (the discount varies by provider/tier) used only to prove the cache lever is
+# working in dollar terms — not for billing. See ADR 0006 Slice 4.
+CACHE_READ_DISCOUNT = 0.9
+
+
+def cache_read_savings_usd(model: str | None, cache_read_tokens: int) -> float:
+    """Estimated USD saved by prompt-cache reads vs. paying full input rate."""
+    rate = rate_for(model)
+    return round(int(cache_read_tokens or 0) * rate["input"] * CACHE_READ_DISCOUNT, 6)

--- a/server.py
+++ b/server.py
@@ -2309,6 +2309,42 @@ def _main():
             return {"enabled": False, "turns": []}
         return {"enabled": True, "turns": _telemetry_store.recent(limit=min(max(1, limit), 500))}
 
+    @fastapi_app.get("/api/telemetry/insights")
+    async def _api_telemetry_insights():
+        # Advise-only flywheel signal (ADR 0006 Slice 4): flag outlier turns +
+        # prove the levers we can measure from the per-turn store. Read-only.
+        if _telemetry_store is None:
+            return {"enabled": False, "insights": None}
+        import pricing
+
+        s = _telemetry_store.summary()
+        flagged = _telemetry_store.outliers()
+        # Cache lever (proven): estimated $ saved by prompt-cache reads, billed at
+        # the dominant model's input rate (the per-turn store keeps no per-call
+        # model breakdown of cache reads).
+        by_model = s.get("by_model") or []
+        dom_model = by_model[0]["model"] if by_model else ((_graph_config.model_name if _graph_config else "") or "")
+        cache_saved = pricing.cache_read_savings_usd(dom_model, s.get("cache_read_input_tokens", 0))
+        return {
+            "enabled": True,
+            "insights": {
+                "turns": s.get("turns", 0),
+                "flagged": flagged,
+                "flagged_count": len(flagged),
+                "levers": {
+                    "cache": {
+                        "hit_ratio": s.get("cache_hit_ratio", 0.0),
+                        "read_tokens": s.get("cache_read_input_tokens", 0),
+                        "est_savings_usd": cache_saved,
+                    },
+                    "routing": {"by_model": by_model},
+                    "success_rate": s.get("success_rate", 0.0),
+                },
+                # Levers that need extra per-turn signals before we can prove them.
+                "unproven_levers": ["tool deferral (schema-token savings)", "compaction", "model routing detail"],
+            },
+        }
+
     # --- Live config / SOUL editing ----------------------------------------
     # GET returns the current config + persona so external clients (the
     # Gradio drawer is one; curl is another) can mirror what's running.

--- a/telemetry_store.py
+++ b/telemetry_store.py
@@ -164,6 +164,32 @@ class TelemetryStore:
         finally:
             db.close()
 
+    def outliers(self, *, cost_multiple: float = 5.0, latency_multiple: float = 5.0,
+                 sample: int = 200, limit: int = 20) -> list[dict]:
+        """Flag recent turns whose cost or duration exceeds ``N×`` the median
+        (over the last ``sample`` turns). Advise-only signal for the flywheel —
+        read-only, no action taken. Each flagged turn carries a ``reasons`` list
+        and the medians it beat. Newest first."""
+        recent = self.recent(limit=sample)
+        if not recent:
+            return []
+        med_cost = _median([float(r.get("cost_usd") or 0.0) for r in recent])
+        med_dur = _median([int(r.get("duration_ms") or 0) for r in recent])
+        flagged = []
+        for r in recent:
+            reasons = []
+            cost = float(r.get("cost_usd") or 0.0)
+            dur = int(r.get("duration_ms") or 0)
+            if med_cost > 0 and cost >= med_cost * cost_multiple:
+                reasons.append(f"cost {cost:.4g} ≥ {cost_multiple:g}× median {med_cost:.4g}")
+            if med_dur > 0 and dur >= med_dur * latency_multiple:
+                reasons.append(f"latency {dur}ms ≥ {latency_multiple:g}× median {med_dur}ms")
+            if reasons:
+                flagged.append({**r, "reasons": reasons})
+            if len(flagged) >= limit:
+                break
+        return flagged
+
     def prune(self, keep_days: int = 30, *, now: datetime | None = None) -> int:
         """Delete turns older than ``keep_days``. Off by default — call from a
         host that wants bounded retention. Returns the rows removed."""
@@ -184,3 +210,13 @@ def _percentile(values: list[int], pct: float) -> int:
         return 0
     k = max(0, min(len(values) - 1, int(round((pct / 100.0) * len(values) + 0.5)) - 1))
     return int(values[k])
+
+
+def _median(values: list):
+    """Median of an unsorted numeric list (empty → 0)."""
+    if not values:
+        return 0
+    s = sorted(values)
+    n = len(s)
+    mid = n // 2
+    return s[mid] if n % 2 else (s[mid - 1] + s[mid]) / 2

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -97,6 +97,41 @@ def test_prune(store):
     assert [r["task_id"] for r in store.recent()] == ["new"]
 
 
+def test_outliers_flags_expensive_and_slow_turns(store):
+    # A baseline of cheap/fast turns + one expensive + one slow.
+    for i in range(8):
+        store.record(_row(f"base{i}", cost_usd=0.01, duration_ms=500))
+    store.record(_row("pricey", cost_usd=0.20, duration_ms=500))   # ≥5× median cost
+    store.record(_row("slow", cost_usd=0.01, duration_ms=9000))    # ≥5× median latency
+    flagged = {f["task_id"]: f for f in store.outliers(cost_multiple=5, latency_multiple=5)}
+    assert "pricey" in flagged and "slow" in flagged
+    assert "base0" not in flagged
+    assert any("cost" in r for r in flagged["pricey"]["reasons"])
+    assert any("latency" in r for r in flagged["slow"]["reasons"])
+
+
+def test_outliers_empty_store(store):
+    assert store.outliers() == []
+
+
+def test_cache_read_savings_usd():
+    import pricing
+
+    # opus input rate 0.000015, discount 0.9 → 10000 cached reads save ~0.135
+    saved = pricing.cache_read_savings_usd("claude-opus-4-8", 10000)
+    assert saved == round(10000 * 0.000015 * 0.9, 6)
+    assert pricing.cache_read_savings_usd("claude-opus-4-8", 0) == 0.0
+
+
+def test_median_helper():
+    from telemetry_store import _median
+
+    assert _median([]) == 0
+    assert _median([5]) == 5
+    assert _median([1, 3]) == 2
+    assert _median([3, 1, 2]) == 2
+
+
 def test_percentile_helper():
     assert _percentile([], 50) == 0
     assert _percentile([10], 95) == 10


### PR DESCRIPTION
Final slice of ADR 0006 — turn telemetry into **signal**, without letting it change behavior (the **advise-only** choice). Completes the flywheel: measure → persist → surface → **advise**.

## What it adds
**`/api/telemetry/insights`** + a **Telemetry ▸ Insights** panel atop the dashboard:
- **Flags outlier turns** — cost or latency ≥ 5× the rolling median (`TelemetryStore.outliers`, with per-turn reasons).
- **Proves the cache lever in $** — hit % + estimated USD saved (`pricing.cache_read_savings_usd`; cached reads bill ~10% of input → ~90% saved — clearly an *estimate*, not billing).
- **Model-mix** for routing visibility.
- **Read-only** — surfaces signal, the operator decides. No autonomous config changes.

## Deliberately honest about scope
Levers that need **extra per-turn signals** before they can be proven — tool-deferral schema-token savings, compaction, detailed routing — are listed as **"not yet measured"** rather than faked. A follow-up that captures those signals lights them up.

## Why advise-only (not auto-optimize)
Letting telemetry auto-change config (enable deferral, downgrade model) is higher leverage but needs guardrails and risks surprising regressions. Step one is trustworthy, visible signal; auto-optimization is a deliberate future step — captured in the ADR.

## Verification
- Python: `outliers` (flags expensive + slow, empty store), `cache_read_savings_usd`, `_median`. **851 passed.**
- e2e: telemetry spec extended — asserts the flagged-turn warning + the cache-lever line render. **36 passed.**
- `web:build` (tsc+vite) + `docs:build` clean. ADR 0006 → **all 4 slices shipped**; observability guide updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)