### PR TITLE
feat(observability): per-turn model + deferral signals (ADR 0006 #4b)

### DIFF
--- a/a2a_handler.py
+++ b/a2a_handler.py
@@ -161,6 +161,9 @@ class TaskRecord:
     # tool_start. Live counters; written to the telemetry store at terminal time.
     llm_calls: int = 0
     tool_calls: int = 0
+    # Distinct model names actually used this turn (first-seen order) — proves
+    # routing incl. aux/fallback vs. the configured lead (ADR 0006 Slice 4b).
+    models: list[str] = field(default_factory=list)
     # ── asyncio primitives (not serialised) ──
     _cancel_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
     _update_event: asyncio.Event = field(default_factory=asyncio.Event, repr=False)
@@ -345,7 +348,7 @@ class A2ATaskStore:
     async def add_usage(
         self, task_id: str, input_tokens: int, output_tokens: int,
         cache_read_input_tokens: int = 0, cache_creation_input_tokens: int = 0,
-        cost_usd: float = 0.0,
+        cost_usd: float = 0.0, model: str = "",
     ) -> None:
         """Accumulate LLM token usage + cost for the task.
 
@@ -370,6 +373,8 @@ class A2ATaskStore:
             record.usage["cache_creation_input_tokens"] += int(cache_creation_input_tokens)
             record.usage["cost_usd"] = round(record.usage.get("cost_usd", 0.0) + float(cost_usd), 6)
             record.llm_calls += 1
+            if model and model not in record.models:
+                record.models.append(model)
 
     async def note_tool_call(self, task_id: str) -> None:
         """Bump the per-turn tool-call counter (telemetry rollup, ADR 0006)."""
@@ -948,12 +953,16 @@ def _record_telemetry(record: TaskRecord) -> None:
         return
     try:
         u = record.usage or {}
+        # Primary model = the first one actually used this turn; fall back to the
+        # configured lead when no per-call model was captured (ADR 0006 Slice 4b).
+        primary_model = record.models[0] if record.models else (_TELEMETRY_MODEL[0] or "")
         store.record({
             "task_id": record.id,
             "session_id": record.context_id,
             "state": record.state,
             "success": 1 if record.state == COMPLETED else 0,
-            "model": _TELEMETRY_MODEL[0] or "",
+            "model": primary_model,
+            "models": ",".join(record.models),
             "input_tokens": int(u.get("input_tokens", 0) or 0),
             "output_tokens": int(u.get("output_tokens", 0) or 0),
             "total_tokens": int(u.get("total_tokens", 0) or 0),
@@ -1145,6 +1154,7 @@ async def _run_task_background(
                         cache_read_input_tokens=payload.get("cache_read_input_tokens", 0),
                         cache_creation_input_tokens=payload.get("cache_creation_input_tokens", 0),
                         cost_usd=payload.get("cost_usd", 0.0),
+                        model=payload.get("model", ""),
                     )
 
             elif event_type == "confidence":

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -391,5 +391,5 @@ export const TELEMETRY_INSIGHTS = {
     },
     success_rate: 0.6667,
   },
-  unproven_levers: ["tool deferral (schema-token savings)", "compaction", "model routing detail"],
+  unproven_levers: ["compaction (needs a per-turn signal)"],
 };

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -292,6 +292,7 @@ export type TelemetryTurn = {
   state: string;
   success: number;
   model: string;
+  models?: string;
   input_tokens: number;
   output_tokens: number;
   total_tokens: number;

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -167,7 +167,12 @@ export function TelemetrySurface({ onError }: { onError: (message: string) => vo
                   {turns.map((t) => (
                     <tr key={t.task_id} className={t.success ? "" : "turn-failed"}>
                       <td title={t.ended_at}>{(t.ended_at || "").replace("T", " ").slice(5, 19)}</td>
-                      <td>{t.model || "—"}</td>
+                      <td title={t.models || t.model}>
+                        {t.model || "—"}
+                        {t.models && t.models.split(",").filter(Boolean).length > 1
+                          ? ` +${t.models.split(",").filter(Boolean).length - 1}`
+                          : ""}
+                      </td>
                       <td>{tokens(t.input_tokens)}→{tokens(t.output_tokens)}</td>
                       <td>{t.cache_read_input_tokens ? tokens(t.cache_read_input_tokens) : "—"}</td>
                       <td>{usd(t.cost_usd)}</td>

--- a/docs/adr/0006-observability-and-the-self-improving-flywheel.md
+++ b/docs/adr/0006-observability-and-the-self-improving-flywheel.md
@@ -130,6 +130,14 @@ outbound telemetry with the fleet so the data is useful beyond protoAgent.
    routing) are explicitly listed as *not yet measured* rather than faked — a
    follow-up that adds those signals can light them up. *(fixes 7)*
 
+   **Slice 4b (per-turn signals)** then made two of those levers real: the
+   telemetry row records the **actual model(s)** used per turn (`model` =
+   primary, `models` = distinct set), so routing — incl. aux/fallback models —
+   is proven per turn rather than stamped from the configured lead; and
+   `ToolDeferralMiddleware` emits `*_llm_tools_deferred_total` to Prometheus,
+   proving the deferral lever live. Compaction remains the one unproven lever
+   (needs a `SummarizationMiddleware` hook) — honestly surfaced as such.
+
 > **Why advise-only (not auto-optimize).** Letting telemetry change config
 > automatically (auto-enable deferral, auto-downgrade model) is higher leverage
 > but needs guardrails and risks surprising regressions. We start by making the

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -57,6 +57,7 @@ my_agent_llm_latency_seconds_bucket{model="claude-opus-4-8",le="5"} 38
 my_agent_llm_tokens_total{model="claude-opus-4-8",direction="input"} 184320
 my_agent_llm_cache_tokens_total{model="claude-opus-4-8",kind="read"} 96000
 my_agent_llm_cost_usd_total{model="claude-opus-4-8"} 0.83
+my_agent_llm_tools_deferred_total 128
 my_agent_tool_calls_total{tool_name="web_search",success="True"} 17
 my_agent_active_sessions 3
 ```

--- a/graph/middleware/tool_deferral.py
+++ b/graph/middleware/tool_deferral.py
@@ -94,9 +94,14 @@ class ToolDeferralMiddleware(AgentMiddleware):
         kept = [t for t in tools if (_tool_name(t) or "") in allowed or _tool_name(t) is None]
         if not kept or len(kept) == len(tools):
             return request  # nothing deferred this turn — safe no-op
-        log.debug(
-            "[tool-deferral] exposing %d/%d tools this turn", len(kept), len(tools)
-        )
+        deferred = len(tools) - len(kept)
+        log.debug("[tool-deferral] exposing %d/%d tools this turn", len(kept), len(tools))
+        # Prove the lever: count withheld tool schemas (ADR 0006 Slice 4b).
+        try:
+            import metrics
+            metrics.record_tools_deferred(deferred)
+        except Exception:  # noqa: BLE001 — telemetry must never break a model call
+            pass
         return request.override(tools=kept)
 
     def wrap_model_call(self, request, handler):

--- a/metrics.py
+++ b/metrics.py
@@ -17,6 +17,7 @@ _llm_latency = None
 _llm_tokens = None
 _llm_cache_tokens = None
 _llm_cost = None
+_tools_deferred = None
 _tool_calls = None
 _tool_latency = None
 _active_sessions = None
@@ -29,7 +30,7 @@ def _prefix() -> str:
 
 def init():
     global _enabled, _llm_calls, _llm_latency, _llm_tokens, _llm_cache_tokens, _llm_cost
-    global _tool_calls, _tool_latency, _active_sessions
+    global _tools_deferred, _tool_calls, _tool_latency, _active_sessions
 
     try:
         from prometheus_client import Counter, Histogram, Gauge
@@ -55,6 +56,10 @@ def init():
         _llm_cost = Counter(
             f"{p}_llm_cost_usd_total", "Estimated LLM cost in USD",
             ["model"],
+        )
+        _tools_deferred = Counter(
+            f"{p}_llm_tools_deferred_total",
+            "Tool schemas withheld from the model by deferral (ADR 0005/0006)",
         )
         _tool_calls = Counter(
             f"{p}_tool_calls_total", "Total tool executions",
@@ -97,6 +102,13 @@ def record_llm_call(model: str, finish_reason: str, latency_s: float,
         _llm_cache_tokens.labels(model=model, kind="creation").inc(cache_creation)
     if cost_usd:
         _llm_cost.labels(model=model).inc(cost_usd)
+
+
+def record_tools_deferred(count: int):
+    """Count tool schemas withheld from a model call by deferral (ADR 0006 Slice
+    4b) — proves the tool-deferral lever is reducing the per-turn schema load."""
+    if _enabled and _tools_deferred is not None and count > 0:
+        _tools_deferred.inc(count)
 
 
 def record_tool_call(tool_name: str, success: bool, latency_s: float):

--- a/server.py
+++ b/server.py
@@ -1283,9 +1283,11 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
                     )
                 except Exception:  # noqa: BLE001 — telemetry must never break a turn
                     pass
-                # Carry cache fields + cost to the A2A handler for the cost-v1
-                # artifact (accumulated across the turn's calls).
-                yield ("usage", {**usage_out, "cost_usd": cost})
+                # Carry cache fields + cost + the ACTUAL model to the A2A handler
+                # for the cost-v1 artifact (accumulated across the turn's calls).
+                # The model name proves routing per turn — incl. aux/fallback
+                # models — vs. the statically-configured lead (ADR 0006 Slice 4b).
+                yield ("usage", {**usage_out, "cost_usd": cost, "model": model})
 
     # HITL pause (ADR 0003): the agent called ask_human → LangGraph interrupt().
     # The graph is checkpointed at the interrupt; surface the question so the A2A
@@ -2340,8 +2342,11 @@ def _main():
                     "routing": {"by_model": by_model},
                     "success_rate": s.get("success_rate", 0.0),
                 },
-                # Levers that need extra per-turn signals before we can prove them.
-                "unproven_levers": ["tool deferral (schema-token savings)", "compaction", "model routing detail"],
+                # Routing is now proven per-turn (actual models on each row);
+                # tool deferral is proven live via Prometheus
+                # (*_llm_tools_deferred_total). Compaction still needs a
+                # per-turn signal (a SummarizationMiddleware hook) — a follow-up.
+                "unproven_levers": ["compaction (needs a per-turn signal)"],
             },
         }
 

--- a/telemetry_store.py
+++ b/telemetry_store.py
@@ -23,7 +23,7 @@ from pathlib import Path
 log = logging.getLogger(__name__)
 
 _COLUMNS = (
-    "task_id", "session_id", "state", "success", "model",
+    "task_id", "session_id", "state", "success", "model", "models",
     "input_tokens", "output_tokens", "total_tokens",
     "cache_read_input_tokens", "cache_creation_input_tokens",
     "cost_usd", "duration_ms", "llm_calls", "tool_calls",
@@ -53,6 +53,7 @@ class TelemetryStore:
                     state                       TEXT,
                     success                     INTEGER,
                     model                       TEXT,
+                    models                      TEXT,
                     input_tokens                INTEGER DEFAULT 0,
                     output_tokens               INTEGER DEFAULT 0,
                     total_tokens                INTEGER DEFAULT 0,
@@ -68,6 +69,12 @@ class TelemetryStore:
                 """
             )
             db.execute("CREATE INDEX IF NOT EXISTS ix_turns_ended ON turns(ended_at)")
+            # Lightweight migration for stores created before `models` existed
+            # (ADR 0006 Slice 4b). ALTER is idempotent-guarded by the try/except.
+            try:
+                db.execute("ALTER TABLE turns ADD COLUMN models TEXT")
+            except sqlite3.OperationalError:
+                pass  # column already present
             db.commit()
         finally:
             db.close()

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -183,6 +183,50 @@ def test_record_telemetry_writes_row_from_task_record(store, telemetry_holder):
     assert row["duration_ms"] == 3000  # 3s between created/ended
 
 
+def test_record_telemetry_uses_actual_models(store, telemetry_holder):
+    """Actual per-turn models override the configured lead, and the distinct
+    set is stored (ADR 0006 Slice 4b — routing proof)."""
+    a2a_handler = telemetry_holder
+    rec = a2a_handler.TaskRecord(
+        id="task-rt", context_id="s", state=a2a_handler.COMPLETED,
+        created_at="2026-06-01T00:00:00+00:00", updated_at="2026-06-01T00:00:01+00:00",
+        message_text="hi",
+    )
+    rec.usage = {"input_tokens": 100, "output_tokens": 10, "total_tokens": 110, "cost_usd": 0.001}
+    rec.models = ["protolabs/reasoning", "claude-haiku-4-5"]  # lead + aux
+    a2a_handler._record_telemetry(rec)
+    row = store.recent()[0]
+    assert row["model"] == "protolabs/reasoning"          # primary = first actual
+    assert row["models"] == "protolabs/reasoning,claude-haiku-4-5"
+
+
+def test_add_usage_collects_distinct_models():
+    """add_usage records each distinct model once, in first-seen order."""
+    import asyncio
+    import a2a_handler
+
+    async def run():
+        s = a2a_handler.A2ATaskStore()
+        rec = a2a_handler.TaskRecord(
+            id="t", context_id="c", state=a2a_handler.SUBMITTED,
+            created_at="2026-06-01T00:00:00+00:00", updated_at="2026-06-01T00:00:00+00:00",
+            message_text="x",
+        )
+        await s.create(rec)
+        await s.add_usage("t", 10, 5, model="m1")
+        await s.add_usage("t", 10, 5, model="m2")
+        await s.add_usage("t", 10, 5, model="m1")  # dup
+        return (await s.get("t")).models
+
+    assert asyncio.run(run()) == ["m1", "m2"]
+
+
+def test_record_tools_deferred_noop_when_disabled():
+    import metrics
+
+    metrics.record_tools_deferred(5)  # disabled in tests → no-op, no error
+
+
 def test_record_telemetry_noop_when_store_unset():
     import a2a_handler
 


### PR DESCRIPTION
Follow-up to the flywheel: add the **missing per-turn signals** the live smoke exposed, so the optimization levers are actually *proven* rather than listed as unmeasured.

## Context (from the live smoke)
A throwaway A2A turn against the real gateway confirmed cache reads (`cache_read_input_tokens: 6178`) + `costUsd` land on the cost-v1 artifact and the telemetry row — **but the row stamped the *configured* lead model, not what actually ran.** Routing wasn't really proven.

## Changes
- **Actual per-turn models** — `server._run_turn_stream` carries the real model on each `usage` frame; the A2A handler collects the **distinct set** on the `TaskRecord`; the telemetry row stores `model` (primary = first actual) + `models` (all distinct). Now reflects aux/fallback routing, not the static lead. `telemetry_store` gains a `models` column with an **idempotent `ALTER` migration** for existing DBs. Console recent-turns shows `+N` when a turn used multiple models.
- **Tool-deferral proof** — `ToolDeferralMiddleware` emits `*_llm_tools_deferred_total` to Prometheus (count of withheld tool schemas), proving the deferral lever live.
- **`insights.unproven_levers`** shrinks to just **compaction** (needs a `SummarizationMiddleware` hook — documented follow-up). Routing now proven per-turn; deferral via Prometheus.

## Verification
- Python: actual-model override + distinct collection (`add_usage`), `models` on the row, `record_tools_deferred` no-op-when-disabled. **854 passed.**
- `web:build` clean; **36 e2e passed**; `docs:build` clean. ADR 0006 + observability guide updated.

After this merges I'll cut a release (these slices since v0.4.0 are features → `minor`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)