### PR TITLE
feat(observability): compaction signal — last lever proven (ADR 0006)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -391,5 +391,5 @@ export const TELEMETRY_INSIGHTS = {
     },
     success_rate: 0.6667,
   },
-  unproven_levers: ["compaction (needs a per-turn signal)"],
+  unproven_levers: [],
 };

--- a/docs/adr/0006-observability-and-the-self-improving-flywheel.md
+++ b/docs/adr/0006-observability-and-the-self-improving-flywheel.md
@@ -135,8 +135,12 @@ outbound telemetry with the fleet so the data is useful beyond protoAgent.
    primary, `models` = distinct set), so routing — incl. aux/fallback models —
    is proven per turn rather than stamped from the configured lead; and
    `ToolDeferralMiddleware` emits `*_llm_tools_deferred_total` to Prometheus,
-   proving the deferral lever live. Compaction remains the one unproven lever
-   (needs a `SummarizationMiddleware` hook) — honestly surfaced as such.
+   proving the deferral lever live. **Compaction** is likewise proven via
+   `CountingSummarizationMiddleware` (subclasses langchain's
+   `SummarizationMiddleware`, counts each real compaction →
+   `*_compactions_total`). With routing, deferral, and compaction all measured,
+   `insights.unproven_levers` is now empty — every optimization lever the agent
+   has is observable.
 
 > **Why advise-only (not auto-optimize).** Letting telemetry change config
 > automatically (auto-enable deferral, auto-downgrade model) is higher leverage

--- a/docs/guides/observability.md
+++ b/docs/guides/observability.md
@@ -58,6 +58,7 @@ my_agent_llm_tokens_total{model="claude-opus-4-8",direction="input"} 184320
 my_agent_llm_cache_tokens_total{model="claude-opus-4-8",kind="read"} 96000
 my_agent_llm_cost_usd_total{model="claude-opus-4-8"} 0.83
 my_agent_llm_tools_deferred_total 128
+my_agent_compactions_total 3
 my_agent_tool_calls_total{tool_name="web_search",success="True"} 17
 my_agent_active_sessions 3
 ```

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -75,12 +75,14 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
         ))
 
     # Context compaction — summarize old history near the context limit.
+    # CountingSummarizationMiddleware adds a Prometheus compaction counter on top
+    # of langchain's SummarizationMiddleware (ADR 0006 — proves the lever fires).
     if config.compaction_enabled:
-        from langchain.agents.middleware import SummarizationMiddleware
+        from graph.middleware.compaction import CountingSummarizationMiddleware
         summ_model = create_llm(config, model_name=_resolve_aux_model(config, config.compaction_model))
         keep = ("messages", config.compaction_keep_messages)
         try:
-            mw = SummarizationMiddleware(
+            mw = CountingSummarizationMiddleware(
                 model=summ_model,
                 trigger=_parse_compaction_trigger(config.compaction_trigger),
                 keep=keep,
@@ -97,7 +99,7 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
                 "falling back to messages:%d",
                 config.compaction_trigger, config.model_name, fallback,
             )
-            mw = SummarizationMiddleware(model=summ_model, trigger=("messages", fallback), keep=keep)
+            mw = CountingSummarizationMiddleware(model=summ_model, trigger=("messages", fallback), keep=keep)
         middleware.append(mw)
 
     # Model routing / failover — retry on fallback models (same gateway).

--- a/graph/middleware/compaction.py
+++ b/graph/middleware/compaction.py
@@ -1,0 +1,39 @@
+"""SummarizationMiddleware that counts compaction events (ADR 0006).
+
+langchain's ``SummarizationMiddleware`` summarizes old history near the context
+limit. Its ``before_model`` / ``abefore_model`` hooks return a non-``None`` state
+update **only** when they actually compact (otherwise ``None``). We subclass to
+emit a Prometheus counter on each real compaction — proving the compaction lever
+fires (and how often), the last unmeasured optimization lever in the flywheel.
+
+Telemetry is best-effort: a metrics failure never affects summarization.
+"""
+
+from __future__ import annotations
+
+from langchain.agents.middleware import SummarizationMiddleware
+
+
+def _count() -> None:
+    try:
+        import metrics
+
+        metrics.record_compaction()
+    except Exception:  # noqa: BLE001 — telemetry must never break a model call
+        pass
+
+
+class CountingSummarizationMiddleware(SummarizationMiddleware):
+    """``SummarizationMiddleware`` + a compaction counter (ADR 0006)."""
+
+    def before_model(self, state, runtime):  # type: ignore[override]
+        result = super().before_model(state, runtime)
+        if result is not None:
+            _count()
+        return result
+
+    async def abefore_model(self, state, runtime):  # type: ignore[override]
+        result = await super().abefore_model(state, runtime)
+        if result is not None:
+            _count()
+        return result

--- a/metrics.py
+++ b/metrics.py
@@ -18,6 +18,7 @@ _llm_tokens = None
 _llm_cache_tokens = None
 _llm_cost = None
 _tools_deferred = None
+_compactions = None
 _tool_calls = None
 _tool_latency = None
 _active_sessions = None
@@ -30,7 +31,7 @@ def _prefix() -> str:
 
 def init():
     global _enabled, _llm_calls, _llm_latency, _llm_tokens, _llm_cache_tokens, _llm_cost
-    global _tools_deferred, _tool_calls, _tool_latency, _active_sessions
+    global _tools_deferred, _compactions, _tool_calls, _tool_latency, _active_sessions
 
     try:
         from prometheus_client import Counter, Histogram, Gauge
@@ -60,6 +61,10 @@ def init():
         _tools_deferred = Counter(
             f"{p}_llm_tools_deferred_total",
             "Tool schemas withheld from the model by deferral (ADR 0005/0006)",
+        )
+        _compactions = Counter(
+            f"{p}_compactions_total",
+            "History-compaction (summarization) events (ADR 0006)",
         )
         _tool_calls = Counter(
             f"{p}_tool_calls_total", "Total tool executions",
@@ -109,6 +114,13 @@ def record_tools_deferred(count: int):
     4b) — proves the tool-deferral lever is reducing the per-turn schema load."""
     if _enabled and _tools_deferred is not None and count > 0:
         _tools_deferred.inc(count)
+
+
+def record_compaction():
+    """Count a history-compaction event (ADR 0006) — proves the compaction lever
+    fires + how often. Emitted from CountingSummarizationMiddleware."""
+    if _enabled and _compactions is not None:
+        _compactions.inc()
 
 
 def record_tool_call(tool_name: str, success: bool, latency_s: float):

--- a/server.py
+++ b/server.py
@@ -2342,11 +2342,10 @@ def _main():
                     "routing": {"by_model": by_model},
                     "success_rate": s.get("success_rate", 0.0),
                 },
-                # Routing is now proven per-turn (actual models on each row);
-                # tool deferral is proven live via Prometheus
-                # (*_llm_tools_deferred_total). Compaction still needs a
-                # per-turn signal (a SummarizationMiddleware hook) — a follow-up.
-                "unproven_levers": ["compaction (needs a per-turn signal)"],
+                # Every optimization lever is now measured: routing per-turn
+                # (actual models on each row); tool deferral + compaction live via
+                # Prometheus (*_llm_tools_deferred_total, *_compactions_total).
+                "unproven_levers": [],
             },
         }
 

--- a/tests/test_compaction_middleware.py
+++ b/tests/test_compaction_middleware.py
@@ -1,0 +1,53 @@
+"""Tests for CountingSummarizationMiddleware (ADR 0006 — compaction signal).
+
+The subclass must emit a metrics counter exactly when the parent actually
+compacts (returns a non-None state update) — and never when it returns None.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain.agents.middleware import SummarizationMiddleware
+
+import metrics
+from graph.middleware.compaction import CountingSummarizationMiddleware
+
+
+def _instance():
+    # Skip the heavy __init__ (needs a model); we only exercise the override.
+    return object.__new__(CountingSummarizationMiddleware)
+
+
+def test_counts_when_parent_compacts(monkeypatch):
+    calls = []
+    monkeypatch.setattr(metrics, "record_compaction", lambda: calls.append(1))
+    monkeypatch.setattr(SummarizationMiddleware, "before_model", lambda self, s, r: {"messages": []})
+    out = _instance().before_model({"messages": []}, None)
+    assert out == {"messages": []}     # parent result passed through
+    assert calls == [1]                # counted once
+
+
+def test_no_count_when_parent_returns_none(monkeypatch):
+    calls = []
+    monkeypatch.setattr(metrics, "record_compaction", lambda: calls.append(1))
+    monkeypatch.setattr(SummarizationMiddleware, "before_model", lambda self, s, r: None)
+    assert _instance().before_model({}, None) is None
+    assert calls == []
+
+
+@pytest.mark.asyncio
+async def test_async_counts_when_parent_compacts(monkeypatch):
+    calls = []
+    monkeypatch.setattr(metrics, "record_compaction", lambda: calls.append(1))
+
+    async def _fake(self, s, r):
+        return {"messages": []}
+
+    monkeypatch.setattr(SummarizationMiddleware, "abefore_model", _fake)
+    out = await _instance().abefore_model({}, None)
+    assert out == {"messages": []}
+    assert calls == [1]
+
+
+def test_record_compaction_noop_when_disabled():
+    metrics.record_compaction()  # metrics disabled in tests → no-op, no error

--- a/tests/test_compaction_routing.py
+++ b/tests/test_compaction_routing.py
@@ -1,6 +1,7 @@
 """Tests for compaction (SummarizationMiddleware) + routing (ModelFallbackMiddleware) wiring."""
 
 import yaml
+from langchain.agents.middleware import SummarizationMiddleware
 
 from graph.agent import _build_middleware, _parse_compaction_trigger, _resolve_aux_model
 from graph.config import LangGraphConfig
@@ -41,7 +42,7 @@ def test_compaction_on_by_default(monkeypatch):
     cfg = LangGraphConfig()
     assert cfg.compaction_enabled
     mw = _build_middleware(cfg, knowledge_store=None)
-    assert any(m.__class__.__name__ == "SummarizationMiddleware" for m in mw)
+    assert any(isinstance(m, SummarizationMiddleware) for m in mw)
 
 
 def test_compaction_fraction_trigger_falls_back_without_model_profile(monkeypatch):
@@ -53,7 +54,7 @@ def test_compaction_fraction_trigger_falls_back_without_model_profile(monkeypatc
     cfg = LangGraphConfig()  # default trigger "fraction:0.8"; model alias has no profile
     assert cfg.compaction_trigger.startswith("fraction:")
     mw = _build_middleware(cfg, knowledge_store=None)  # must not raise
-    assert any(m.__class__.__name__ == "SummarizationMiddleware" for m in mw)
+    assert any(isinstance(m, SummarizationMiddleware) for m in mw)
 
 
 def test_compaction_wired_when_enabled(tmp_path, monkeypatch):
@@ -63,7 +64,7 @@ def test_compaction_wired_when_enabled(tmp_path, monkeypatch):
     cfg = LangGraphConfig.from_yaml(p)
     assert cfg.compaction_enabled and cfg.compaction_keep_messages == 30
     mw = _build_middleware(cfg, knowledge_store=None)
-    assert any(m.__class__.__name__ == "SummarizationMiddleware" for m in mw)
+    assert any(isinstance(m, SummarizationMiddleware) for m in mw)
 
 
 def test_routing_off_by_default(monkeypatch):


### PR DESCRIPTION
Closes the last gap: a per-turn **compaction** signal, so every optimization lever the agent has is now observable.

## Change
`CountingSummarizationMiddleware` (`graph/middleware/compaction.py`) subclasses langchain's `SummarizationMiddleware` — its `before_model`/`abefore_model` return a non-`None` state update **only** when they actually compact, so the override counts exactly those → **`*_compactions_total`** Prometheus counter. Wired in place of the bare middleware in `_build_middleware`.

Result: with **routing** (per-turn actual models), **tool deferral** (`*_llm_tools_deferred_total`), and now **compaction** all measured, `/api/telemetry/insights` `unproven_levers` is **empty**.

## Verification
- `tests/test_compaction_middleware.py` — counts on compaction (sync + async), no-count when the parent returns `None`, `record_compaction` no-op when disabled.
- Existing compaction-wiring assertions switched from exact class-name to `isinstance(m, SummarizationMiddleware)` (the subclass satisfies it).
- **Full suite: 858 passed**; `web:build` + 36 e2e + `docs:build` clean. ADR 0006 + observability guide updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)