### PR TITLE
chore: gitignore HANDOFF.md (local session working doc)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,8 @@ build/
 .claude/
 .worktrees/
 worktrees/
+# Local session handoff / working notes — transient state, not shipped to forks
+HANDOFF.md
 
 # VitePress build artifacts + node modules
 node_modules/


### PR DESCRIPTION
Ignore `HANDOFF.md` — a local session-handoff working doc, kept out of the tracked template so it doesn't ship to forks. Trivial .gitignore-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)