### PR TITLE
feat(fs): fenced multi-project filesystem toolset + project registry (ADR 0007)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -54,6 +54,7 @@ export default defineConfig({
             { text: "Run multiple instances", link: "/guides/multi-instance" },
             { text: "Deploy via GHCR", link: "/guides/deploy" },
             { text: "Releasing", link: "/guides/releasing" },
+            { text: "Build an operator fork (Roxy)", link: "/guides/operator-fork" },
           ],
         },
       ],

--- a/docs/adr/0007-directory-aware-operator-agent.md
+++ b/docs/adr/0007-directory-aware-operator-agent.md
@@ -1,6 +1,6 @@
 # ADR 0007 — Directory-Aware Operator Primitives (enabling a "Roxy" fork)
 
-- **Status:** Accepted (2026-06-01) — design; implementation sliced (not started)
+- **Status:** Accepted (2026-06-01) — template primitives shipped (registry+fence, fenced fs toolset, fork guide); per-project subagent binding deferred
 - **Date:** 2026-06-01
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** architecture, filesystem, multi-project, operator, supervisor, security, template-vs-fork
@@ -134,16 +134,21 @@ same whether it's a fork or core:
 
 ## 5. Ranked plan (template slices)
 
-1. **Project registry + fence** — config `projects`, shared enforced resolver,
-   prompt injection of the managed set; default-off = no behavior change.
-2. **Native gated fs toolset** — `tools/fs_tools.py`, opt-in, audited, fenced.
-3. **Per-project subagent binding** — `task(..., project=…)`.
-4. **Fork guide** — docs: "Build an operator fork (like Roxy)": enable the
-   primitives, write the operator `SOUL`, add a `project-operations` skill,
-   register projects, schedule the sweep. (Doc, not code.)
+1. ✅ **Project registry + fence + gated fs toolset — shipped.** `config.filesystem`
+   (`enabled`/`allow_run`/`projects[{name,path,write}]`); `tools/fs_tools.py`
+   (`list_projects`/`list_dir`/`read_file`/`find_files`/`search_files`/
+   `write_file`/`edit_file`/`run_command`) with a `ProjectRegistry` fence on
+   every path; opt-in, off by default (empty registry → no behavior change);
+   managed set injected into the prompt (`_build_projects_section`).
+2. ✅ **Fork guide — shipped.** `docs/guides/operator-fork.md` walks a monitor
+   fork (Roxy) end to end (read-only fs, persona, `project-operations` skill,
+   A2A/bus/scheduler drivers).
+3. **Per-project subagent binding** *(deferred)* — `task(..., project=…)`.
+   Not needed for a monitor-and-unblock operator (Roxy doesn't fan out coding
+   workers); revisit if a coding fork needs parallel per-project edits.
 
-The **Roxy fork** (new repo) is then a downstream effort: clone/fork the
-template, apply the guide. It is out of scope for *this* repo beyond the guide.
+The **Roxy fork** (`protoLabsAI/roxy`, new repo) applies the guide: monitor +
+unblock, not code; summoned via A2A; managed via the protoWorkstacean bus.
 
 ## 6. Consequences
 

--- a/docs/guides/operator-fork.md
+++ b/docs/guides/operator-fork.md
@@ -1,0 +1,95 @@
+# Build an operator fork (like "Roxy")
+
+protoAgent ships the **primitives** for a multi-project operator agent — a
+fenced filesystem toolset, a project registry, and the reactive substrate
+(scheduler / inbox / Activity). The *operator* itself — a persona that monitors
+several workspaces and keeps work flowing — is a **fork**, assembled from those
+primitives + the standard specialization mechanisms ([ADR 0007](/adr/0007-directory-aware-operator-agent)).
+No operator code lives in the template; a fork is persona + skill + config.
+
+This guide builds "Roxy", a ProtoMaker portfolio manager that **monitors and
+unblocks** (it does not write code).
+
+## 1. Fork the template
+
+Create a new repo from protoAgent (it's a GitHub template). Keep upstream so you
+can pull future primitive updates.
+
+## 2. Enable the fenced filesystem toolset (read-only for a monitor)
+
+```yaml
+# config/langgraph-config.yaml
+filesystem:
+  enabled: true
+  allow_run: true          # Roxy needs git/gh/br reads — run_command, fenced cwd
+  projects:
+    - { name: orbis,    path: /work/ORBIS,    write: false }   # monitor, never edit
+    - { name: pixelgen, path: /work/pixelgen, write: false }
+```
+
+A monitor sets every project `write: false` — `read_file`/`list_dir`/
+`find_files`/`search_files` + `run_command` give it everything it needs to
+*sense* state; `write_file`/`edit_file` are refused. (A coding fork would set
+`write: true` and lean on git-as-seatbelt.)
+
+## 3. Write the operator persona (`config/SOUL.md`)
+
+The persona makes it a monitor-and-unblock manager, not a coder. Sketch:
+
+```markdown
+# Roxy — ProtoMaker Portfolio Manager
+
+You manage a portfolio of ProtoMaker workspaces. Your job is to **keep work
+flowing**: watch each project's board + PRs, spot stalls and blockers, and
+**unblock** — by nudging/creating features, escalating to a human, or
+dispatching the ProtoMaker team. You **do not write code yourself**; you
+monitor, coordinate, and escalate. Prefer the smallest action that unblocks;
+escalate anything consequential.
+```
+
+## 4. Add a `project-operations` skill (`config/skills/project-operations/SKILL.md`)
+
+This is where the ProtoMaker-specific knowledge lives — *how* to read a
+workspace's state with the generic tools (so the template stays domain-neutral):
+
+```markdown
+---
+name: project-operations
+description: >-
+  Use whenever asked to check status, sweep projects, or unblock work. How to
+  read a ProtoMaker workspace and decide if work is flowing.
+tools: [list_projects, read_file, find_files, search_files, run_command, check_inbox, schedule_task]
+---
+
+# Keeping a portfolio flowing
+
+For each project: read the board (`read_file .beads/issues.jsonl` → counts by
+status, blocked items), the feature pipeline (`find_files .automaker/**`), and
+git (`run_command "git status"`, `run_command "gh pr list"`). A project is
+**stalled** if: open features with no active work, PRs idle > N days, CI red, or
+a dirty tree on main. Summarize per project (flowing / stalled / blocked), then
+**unblock**: nudge the team, open an issue, or escalate to the operator.
+```
+
+## 5. Wire the drivers
+
+- **Summon via A2A** — Roxy is reached over the A2A endpoint (`message/send` /
+  `message/stream`); set an `auth.token` so inbound is authenticated.
+- **The Workstacean bus** — protoWorkstacean dispatches to Roxy as an A2A agent
+  (it already speaks the `cost-v1`/`confidence-v1` extensions Roxy emits).
+- **Scheduled sweeps** — a periodic `schedule_task` (or an external cron hitting
+  A2A) fires a "sweep all projects" turn; the skill + persona do the rest.
+- **Escalation** — surfaces via the inbox / Activity thread (ADR 0003).
+- **(Optional) richer board actions** — add the `protolabs_studio` MCP server to
+  `mcp.servers` for `query_board` / `start_agent` / `get_sitrep` etc.
+
+## 6. Deploy isolated
+
+Give Roxy its own `PROTOAGENT_INSTANCE` (ADR 0004) so its stores don't collide
+with other agents on shared storage; run it on its own port / container.
+
+---
+
+That's the whole operator: **primitives (template) + persona + skill + config
+(fork)**. Nothing about ProtoMaker or "portfolio management" ships in protoAgent
+core — it stays a neutral template, and Roxy is a thin specialization.

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -239,6 +239,27 @@ telemetry:
 | `enabled` | `true` | Write a per-turn row at terminal time. `false` → no store; endpoints return `{enabled:false}`. |
 | `db_path` | `/sandbox/telemetry.db` | SQLite path; `/sandbox`→`~/.protoagent` fallback, instance-scoped (ADR 0004). |
 
+## `filesystem`
+
+Fenced multi-project filesystem toolset ([ADR 0007](../adr/0007-directory-aware-operator-agent.md)) — a generic, **opt-in, off-by-default** primitive that gives the agent read/write/list/search + fenced command execution over a registry of project directories. Inert unless `enabled` **and** `projects` is non-empty. The capability a forked operator (e.g. "Roxy") composes into a multi-project manager — see the [operator-fork guide](../guides/operator-fork.md).
+
+```yaml
+filesystem:
+  enabled: true        # off by default
+  allow_run: false     # add the dual-use run_command power tool
+  projects:
+    - { name: orbis, path: /Users/kj/dev/ORBIS, write: false }   # read-only monitor
+    - { name: pixelgen, path: /Users/kj/dev/pixelgen, write: true }
+```
+
+| Key | Default | What |
+|---|---|---|
+| `enabled` | `false` | Expose the fs tools (`list_projects`/`read_file`/`list_dir`/`find_files`/`search_files`/`write_file`/`edit_file`). |
+| `allow_run` | `false` | Also expose `run_command` (fenced `cwd`, but arbitrary argv — dual-use, like `execute_code`). |
+| `projects` | `[]` | Managed workspaces: `{name, path, write}`. **Every path is fenced under a project root** (`..`/symlink escapes refused); `write:false` makes a project read-only; invalid paths are skipped. |
+
+**Security:** the project roots are the **hard fence** — every tool resolves paths under a root and refuses escapes; `write_file`/`edit_file` need `write:true`; the agent's own repo is not a project unless you add it. All mutations are audited. See ADR 0007 §4.
+
 ## `routing`
 
 Wires langchain's `ModelFallbackMiddleware`: on a primary-model error, retry on each fallback model (same gateway) in order. Opt-in (empty = no fallback).

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -654,6 +654,13 @@ def create_agent_graph(
             config, all_tools, skills_index=skills_index, workflow_registry=workflow_registry,
         ))
 
+    # Fenced multi-project filesystem toolset (ADR 0007 — operator primitives).
+    # Opt-in; inert unless filesystem.enabled + a non-empty projects registry.
+    # Added before execute_code/deferred so they're wrappable + discoverable.
+    if config.filesystem_enabled:
+        from tools.fs_tools import build_fs_tools
+        all_tools.extend(build_fs_tools(config))
+
     # Programmatic tool calling — opt-in. Built last so it can wrap every
     # other tool (including task/task_batch) but never itself.
     if config.execute_code_enabled:
@@ -673,6 +680,7 @@ def create_agent_graph(
 
     system_prompt = build_system_prompt(
         include_subagents=include_subagents,
+        projects=(config.filesystem_projects if config.filesystem_enabled else None),
     )
 
     agent = create_agent(

--- a/graph/config.py
+++ b/graph/config.py
@@ -297,6 +297,16 @@ class LangGraphConfig:
     # list — not the UI — is the security boundary. See operator_api/paths.
     operator_allowed_dirs: list[str] = field(default_factory=list)
 
+    # Fenced multi-project filesystem toolset (ADR 0007 — operator primitives).
+    # OFF by default; a generic capability a fork (e.g. "Roxy") opts into. When
+    # enabled with a non-empty ``projects`` registry, the agent gets fenced
+    # read/write/list/search tools over those dirs (every path contained under a
+    # project root). ``allow_run`` adds the dual-use ``run_command`` power tool.
+    # ``projects`` entries: ``{name, path, write: true|false}``. See tools/fs_tools.
+    filesystem_enabled: bool = False
+    filesystem_allow_run: bool = False
+    filesystem_projects: list[dict] = field(default_factory=list)
+
     @classmethod
     def from_yaml(cls, path: str | Path) -> "LangGraphConfig":
         """Load config from YAML file. Falls back to defaults if absent."""
@@ -405,6 +415,9 @@ class LangGraphConfig:
             auth_token=secret_auth_token or auth.get("token", cls.auth_token),
             autostart_on_boot=runtime.get("autostart_on_boot", cls.autostart_on_boot),
             operator_allowed_dirs=list(operator.get("allowed_dirs", []) or []),
+            filesystem_enabled=data.get("filesystem", {}).get("enabled", cls.filesystem_enabled),
+            filesystem_allow_run=data.get("filesystem", {}).get("allow_run", cls.filesystem_allow_run),
+            filesystem_projects=list(data.get("filesystem", {}).get("projects", []) or []),
         )
 
         for name in ("researcher",):

--- a/graph/prompts.py
+++ b/graph/prompts.py
@@ -40,12 +40,18 @@ def build_system_prompt(
     workspace: str = "/sandbox",
     include_subagents: bool = True,
     context: str = "",
+    projects=None,
 ) -> str:
     """Build the complete system prompt for the lead agent.
 
     ``context`` is injected verbatim at the end of the prompt (before
     the response-format block) — ``KnowledgeMiddleware`` is the typical
     caller, passing in retrieved knowledge-store hits.
+
+    ``projects`` (ADR 0007) — when the fenced filesystem toolset is enabled,
+    the list of managed project workspaces ``[{name, path, write}]`` is named in
+    the prompt so the agent knows the dirs it can operate on (and which are
+    read-only). Inert when None.
     """
     parts = []
 
@@ -70,6 +76,12 @@ def build_system_prompt(
     if include_subagents:
         parts.append(_build_subagent_section())
 
+    # 2b. Managed project workspaces (ADR 0007 — fenced filesystem toolset).
+    if projects:
+        section = _build_projects_section(projects)
+        if section:
+            parts.append(section)
+
     # 3. Dynamic context (typically from KnowledgeMiddleware)
     if context:
         parts.append(f"\n# Context\n\n{context}")
@@ -93,6 +105,31 @@ def build_system_prompt(
     parts.append(OUTPUT_FORMAT_INSTRUCTIONS)
 
     return "\n\n".join(parts)
+
+
+def _build_projects_section(projects) -> str:
+    """Render the managed-project workspaces the fs tools are fenced to."""
+    lines = [
+        "# Managed projects",
+        "",
+        "You operate on these project workspaces via the filesystem tools "
+        "(`list_projects`, `read_file`, `list_dir`, `find_files`, `search_files`, "
+        "and — in read-write projects — `write_file`/`edit_file`). All paths are "
+        "fenced to these roots; you cannot read or write outside them.",
+        "",
+    ]
+    rendered = 0
+    for p in projects:
+        if not isinstance(p, dict):
+            continue
+        name = str(p.get("name") or "").strip()
+        path = str(p.get("path") or "").strip()
+        if not name or not path:
+            continue
+        mode = "read-write" if p.get("write") else "read-only"
+        lines.append(f"- **{name}** ({mode}) — `{path}`")
+        rendered += 1
+    return "\n".join(lines) if rendered else ""
 
 
 def _build_subagent_section() -> str:

--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -1,0 +1,152 @@
+"""Tests for the fenced multi-project filesystem toolset (ADR 0007)."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass, field
+
+import pytest
+
+from tools.fs_tools import Project, ProjectRegistry, build_fs_tools
+
+
+@dataclass
+class _Cfg:
+    filesystem_enabled: bool = True
+    filesystem_allow_run: bool = False
+    filesystem_projects: list = field(default_factory=list)
+
+
+@pytest.fixture
+def workspace(tmp_path):
+    a = tmp_path / "projA"
+    (a / "src").mkdir(parents=True)
+    (a / "src" / "main.py").write_text("print('hello')\nTODO: fix\n")
+    (a / "README.md").write_text("# A")
+    b = tmp_path / "projB"
+    b.mkdir()
+    (b / "notes.txt").write_text("read only")
+    return tmp_path, a, b
+
+
+# ── registry / fence ──────────────────────────────────────────────────────────
+
+
+def test_registry_resolves_within_root(workspace):
+    _, a, _ = workspace
+    reg = ProjectRegistry([Project("a", a, write=True)])
+    assert reg.resolve("a", "src/main.py") == a / "src" / "main.py"
+    assert reg.resolve("a", ".") == a
+
+
+def test_registry_rejects_escape(workspace):
+    _, a, _ = workspace
+    reg = ProjectRegistry([Project("a", a)])
+    for bad in ["../etc/passwd", "../../x", "/etc/passwd", "~/secrets"]:
+        with pytest.raises(ValueError):
+            reg.resolve("a", bad)
+
+
+def test_registry_unknown_project(workspace):
+    _, a, _ = workspace
+    reg = ProjectRegistry([Project("a", a)])
+    with pytest.raises(ValueError, match="unknown project"):
+        reg.resolve("nope", ".")
+
+
+# ── build_fs_tools wiring ──────────────────────────────────────────────────────
+
+
+def _tools(cfg):
+    return {t.name: t for t in build_fs_tools(cfg)}
+
+
+def test_no_tools_without_valid_projects():
+    assert build_fs_tools(_Cfg(filesystem_projects=[])) == []
+    # Nonexistent path → skipped → no tools.
+    assert build_fs_tools(_Cfg(filesystem_projects=[{"name": "x", "path": "/nope/zzz"}])) == []
+
+
+def test_read_list_find_search(workspace):
+    _, a, _ = workspace
+    t = _tools(_Cfg(filesystem_projects=[{"name": "a", "path": str(a), "write": True}]))
+    assert "hello" in t["read_file"].invoke({"project": "a", "path": "src/main.py"})
+    assert "README.md" in t["list_dir"].invoke({"project": "a", "path": "."})
+    assert "src/main.py" in t["find_files"].invoke({"project": "a", "pattern": "**/*.py"})
+    hit = t["search_files"].invoke({"project": "a", "query": "TODO"})
+    assert "main.py" in hit and "TODO" in hit
+
+
+def test_read_file_escape_is_refused(workspace):
+    _, a, _ = workspace
+    t = _tools(_Cfg(filesystem_projects=[{"name": "a", "path": str(a)}]))
+    out = t["read_file"].invoke({"project": "a", "path": "../projB/notes.txt"})
+    assert out.startswith("Error:") and "escape" in out
+
+
+def test_write_and_edit_in_rw_project(workspace):
+    _, a, _ = workspace
+    t = _tools(_Cfg(filesystem_projects=[{"name": "a", "path": str(a), "write": True}]))
+    assert "Created" in t["write_file"].invoke({"project": "a", "path": "new.txt", "content": "v1"})
+    assert (a / "new.txt").read_text() == "v1"
+    assert "Edited" in t["edit_file"].invoke({"project": "a", "path": "new.txt", "old": "v1", "new": "v2"})
+    assert (a / "new.txt").read_text() == "v2"
+
+
+def test_write_blocked_in_readonly_project(workspace):
+    _, _, b = workspace
+    t = _tools(_Cfg(filesystem_projects=[{"name": "b", "path": str(b), "write": False}]))
+    out = t["write_file"].invoke({"project": "b", "path": "x.txt", "content": "nope"})
+    assert out.startswith("Error:") and "read-only" in out
+    assert not (b / "x.txt").exists()
+
+
+def test_edit_requires_unique_old(workspace):
+    _, a, _ = workspace
+    (a / "dup.txt").write_text("x\nx\n")
+    t = _tools(_Cfg(filesystem_projects=[{"name": "a", "path": str(a), "write": True}]))
+    out = t["edit_file"].invoke({"project": "a", "path": "dup.txt", "old": "x", "new": "y"})
+    assert out.startswith("Error:") and "not unique" in out
+
+
+# ── run_command gating ─────────────────────────────────────────────────────────
+
+
+def test_run_command_absent_unless_allowed(workspace):
+    _, a, _ = workspace
+    base = {"name": "a", "path": str(a), "write": True}
+    assert "run_command" not in _tools(_Cfg(filesystem_projects=[base], filesystem_allow_run=False))
+    assert "run_command" in _tools(_Cfg(filesystem_projects=[base], filesystem_allow_run=True))
+
+
+def test_run_command_executes_in_project_cwd(workspace):
+    _, a, _ = workspace
+    t = _tools(_Cfg(filesystem_projects=[{"name": "a", "path": str(a)}], filesystem_allow_run=True))
+    out = asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "ls"}))
+    assert "README.md" in out
+
+
+# ── config round-trip ──────────────────────────────────────────────────────────
+
+
+def test_config_parses_filesystem(tmp_path):
+    from graph.config import LangGraphConfig
+
+    p = tmp_path / "c.yaml"
+    p.write_text(
+        "filesystem:\n"
+        "  enabled: true\n"
+        "  allow_run: true\n"
+        "  projects:\n"
+        "    - {name: orbis, path: /tmp, write: false}\n"
+    )
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.filesystem_enabled is True
+    assert cfg.filesystem_allow_run is True
+    assert cfg.filesystem_projects[0]["name"] == "orbis"
+
+
+def test_config_filesystem_default_off():
+    from graph.config import LangGraphConfig
+
+    assert LangGraphConfig().filesystem_enabled is False

--- a/tools/fs_tools.py
+++ b/tools/fs_tools.py
@@ -1,0 +1,253 @@
+"""Fenced multi-project filesystem toolset (ADR 0007 — operator primitives).
+
+Generic, opt-in, OFF by default. Gives the agent read / write / list / search +
+fenced command execution over a **registry of project directories** — every
+path is joined to a managed project root and re-resolved, so nothing can escape
+the fence. This is the raw capability a forked operator agent (e.g. "Roxy")
+composes into a multi-project manager; the template ships only the inert
+primitive — no operator persona, no domain coupling.
+
+Security (ADR 0007 §4):
+- Every path resolves under a registry project's root; ``..``/symlink escapes are
+  refused (``Path.resolve`` then containment check).
+- ``write_file`` / ``edit_file`` require the project's ``write: true`` (a monitor
+  fork runs every project read-only).
+- ``run_command`` is the dual-use power tool (like ``execute_code``): fenced
+  ``cwd``, but arbitrary argv — gated behind ``filesystem.allow_run``.
+- Returns clean error strings (never raises into the runner); ``AuditMiddleware``
+  records every call; given to subagents only when their allowlist names it.
+"""
+
+from __future__ import annotations
+
+import logging
+import shlex
+from dataclasses import dataclass
+from pathlib import Path
+
+from langchain_core.tools import tool
+
+from tools.shell import run_command as _shell_run
+
+log = logging.getLogger("protoagent.fs")
+
+_MAX_READ_CHARS = 50_000
+_MAX_LIST = 400
+_MAX_MATCHES = 200
+
+
+@dataclass
+class Project:
+    name: str
+    root: Path
+    write: bool = False
+
+
+class ProjectRegistry:
+    """Resolve ``(project, relative_path)`` to an absolute path fenced under the
+    project's root. The single chokepoint every fs tool goes through."""
+
+    def __init__(self, projects: list[Project]):
+        self._by_name = {p.name: p for p in projects}
+
+    def names(self) -> list[str]:
+        return list(self._by_name)
+
+    def get(self, name: str) -> Project | None:
+        return self._by_name.get(name)
+
+    def resolve(self, project: str, rel_path: str = ".") -> Path:
+        """Resolve a workspace-relative path. Raises ValueError on unknown
+        project or a path that escapes the fence. Does NOT require existence
+        (writes create new files)."""
+        proj = self._by_name.get(project)
+        if proj is None:
+            raise ValueError(
+                f"unknown project {project!r}. Known: {', '.join(self._by_name) or '(none)'}"
+            )
+        rel = (rel_path or ".").strip()
+        if rel.startswith("/") or rel.startswith("~"):
+            raise ValueError("path must be relative to the project root")
+        target = (proj.root / rel).resolve()
+        if target != proj.root and proj.root not in target.parents:
+            raise ValueError(f"path escapes project {project!r}: {rel_path!r}")
+        return target
+
+
+def _registry_from_config(config) -> ProjectRegistry:
+    projects: list[Project] = []
+    for entry in getattr(config, "filesystem_projects", []) or []:
+        if not isinstance(entry, dict):
+            continue
+        name = str(entry.get("name") or "").strip()
+        raw_path = str(entry.get("path") or "").strip()
+        if not name or not raw_path:
+            log.warning("[fs] skipping project missing name/path: %r", entry)
+            continue
+        root = Path(raw_path).expanduser().resolve()
+        if not root.is_dir():
+            log.warning("[fs] project %r path is not a directory: %s — skipped", name, root)
+            continue
+        projects.append(Project(name=name, root=root, write=bool(entry.get("write", False))))
+    return ProjectRegistry(projects)
+
+
+def build_fs_tools(config) -> list:
+    """Build the fenced filesystem tools from config. Empty list when no valid
+    projects are registered (so the primitive is inert by default)."""
+    registry = _registry_from_config(config)
+    if not registry.names():
+        log.info("[fs] filesystem enabled but no valid projects registered — no tools")
+        return []
+    allow_run = bool(getattr(config, "filesystem_allow_run", False))
+
+    @tool
+    def list_projects() -> str:
+        """List the project workspaces you manage (name, path, read-only vs read-write)."""
+        lines = ["Managed projects:"]
+        for name in registry.names():
+            p = registry.get(name)
+            lines.append(f"- {name}  [{'rw' if p.write else 'ro'}]  {p.root}")
+        return "\n".join(lines)
+
+    @tool
+    def list_dir(project: str, path: str = ".") -> str:
+        """List a directory inside a managed project (path is relative to the project root)."""
+        try:
+            target = registry.resolve(project, path)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        if not target.is_dir():
+            return f"Error: not a directory: {path}"
+        entries = sorted(target.iterdir(), key=lambda p: (p.is_file(), p.name))
+        out = [f"{e.name}/" if e.is_dir() else e.name for e in entries[:_MAX_LIST]]
+        more = f"\n… (+{len(entries) - _MAX_LIST} more)" if len(entries) > _MAX_LIST else ""
+        return "\n".join(out) + more if out else "(empty)"
+
+    @tool
+    def read_file(project: str, path: str) -> str:
+        """Read a text file inside a managed project (relative path). Truncated if large."""
+        try:
+            target = registry.resolve(project, path)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        if not target.is_file():
+            return f"Error: no such file: {path}"
+        try:
+            text = target.read_text(encoding="utf-8", errors="replace")
+        except OSError as exc:
+            return f"Error: cannot read {path}: {exc}"
+        if len(text) > _MAX_READ_CHARS:
+            return text[:_MAX_READ_CHARS] + f"\n… (truncated at {_MAX_READ_CHARS} chars)"
+        return text
+
+    @tool
+    def find_files(project: str, pattern: str = "**/*") -> str:
+        """Glob for files in a managed project (e.g. '**/*.py', '.beads/*.jsonl')."""
+        try:
+            root = registry.resolve(project, ".")
+        except ValueError as exc:
+            return f"Error: {exc}"
+        try:
+            matches = [p for p in root.glob(pattern) if p.is_file()]
+        except (ValueError, OSError) as exc:
+            return f"Error: bad pattern: {exc}"
+        rels = [str(p.relative_to(root)) for p in matches[:_MAX_MATCHES]]
+        more = f"\n… (+{len(matches) - _MAX_MATCHES} more)" if len(matches) > _MAX_MATCHES else ""
+        return "\n".join(rels) + more if rels else "(no matches)"
+
+    @tool
+    def search_files(project: str, query: str, path: str = ".") -> str:
+        """Substring-search files under a managed project path; returns file:line matches."""
+        try:
+            base = registry.resolve(project, path)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        root = registry.resolve(project, ".")
+        files = [base] if base.is_file() else [p for p in base.rglob("*") if p.is_file()]
+        hits: list[str] = []
+        for f in files:
+            try:
+                for i, line in enumerate(f.read_text(encoding="utf-8", errors="replace").splitlines(), 1):
+                    if query in line:
+                        hits.append(f"{f.relative_to(root)}:{i}: {line.strip()[:200]}")
+                        if len(hits) >= _MAX_MATCHES:
+                            return "\n".join(hits) + "\n… (more matches; narrow the search)"
+            except OSError:
+                continue
+        return "\n".join(hits) if hits else "(no matches)"
+
+    @tool
+    def write_file(project: str, path: str, content: str) -> str:
+        """Write (create/overwrite) a text file in a read-write managed project."""
+        try:
+            target = registry.resolve(project, path)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        proj = registry.get(project)
+        if not proj.write:
+            return f"Error: project {project!r} is read-only (write:false)."
+        try:
+            target.parent.mkdir(parents=True, exist_ok=True)
+            existed = target.exists()
+            target.write_text(content, encoding="utf-8")
+        except OSError as exc:
+            return f"Error: cannot write {path}: {exc}"
+        return f"{'Overwrote' if existed else 'Created'} {path} ({len(content)} chars)."
+
+    @tool
+    def edit_file(project: str, path: str, old: str, new: str) -> str:
+        """Replace the first exact occurrence of `old` with `new` in a file (read-write project)."""
+        try:
+            target = registry.resolve(project, path)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        proj = registry.get(project)
+        if not proj.write:
+            return f"Error: project {project!r} is read-only (write:false)."
+        if not target.is_file():
+            return f"Error: no such file: {path}"
+        text = target.read_text(encoding="utf-8", errors="replace")
+        if old not in text:
+            return f"Error: `old` not found in {path}."
+        if text.count(old) > 1:
+            return f"Error: `old` is not unique in {path} ({text.count(old)} matches) — add context."
+        try:
+            target.write_text(text.replace(old, new, 1), encoding="utf-8")
+        except OSError as exc:
+            return f"Error: cannot write {path}: {exc}"
+        return f"Edited {path}."
+
+    tools = [list_projects, list_dir, read_file, find_files, search_files, write_file, edit_file]
+
+    if allow_run:
+        @tool
+        async def run_command(project: str, command: str, timeout: float = 60.0) -> str:
+            """Run a shell command inside a managed project's directory (fenced cwd).
+
+            Powerful + dual-use (like execute_code) — use it for read-only
+            inspection (`git status`, `gh pr list`, `br list`) and only mutate in
+            read-write projects. argv is shell-split; no shell metacharacters.
+            """
+            try:
+                root = registry.resolve(project, ".")
+            except ValueError as exc:
+                return f"Error: {exc}"
+            try:
+                argv = shlex.split(command)
+            except ValueError as exc:
+                return f"Error: cannot parse command: {exc}"
+            if not argv:
+                return "Error: empty command."
+            res = await _shell_run(argv, cwd=str(root), timeout=timeout)
+            if res.error:
+                return f"Error: {res.error}"
+            body = res.stdout or "(no output)"
+            if res.stderr:
+                body += f"\n[stderr]\n{res.stderr}"
+            return body[: _MAX_READ_CHARS] + (f"\n(exit {res.returncode})" if res.returncode else "")
+
+        tools.append(run_command)
+
+    log.info("[fs] %d project(s), %d tool(s), run=%s", len(registry.names()), len(tools), allow_run)
+    return tools


### PR DESCRIPTION
The generic, opt-in **operator primitive** from ADR 0007 — what a fork like **Roxy** needs to manage several project dirs, with **no operator/ProtoMaker behavior in core**.

## What ships (all off by default)
- **`tools/fs_tools.py`** — `ProjectRegistry` (the hard fence) + `list_projects` / `list_dir` / `read_file` / `find_files` / `search_files` / `write_file` / `edit_file`, plus `run_command` (fenced `cwd`, gated by `filesystem.allow_run`). Every path resolves under a managed project root; `..`/symlink escapes refused. `write_file`/`edit_file` require per-project `write:true` (a **monitor fork runs read-only**).
- **`config.filesystem`** — `enabled` (default `false`) / `allow_run` / `projects: [{name, path, write}]`. **Inert unless enabled AND a valid project exists** → ordinary forks are byte-unchanged.
- **`agent.py`** wires it before execute_code/deferred (wrappable + discoverable); **`build_system_prompt`** gains a "Managed projects" section naming the fenced roots + read/write mode.

## Fence (security, ADR 0007 §4)
Project roots are the boundary — every tool resolves under a root and refuses escapes; writes need `write:true`; the agent's own repo isn't a project unless added; mutations are audited.

## Docs
- Configuration `filesystem` section.
- **New guide: "Build an operator fork (Roxy)"** — monitor read-only fs + persona + a `project-operations` skill (ProtoMaker `.beads`/`.automaker`/git knowledge lives in the *fork* skill, not core) + A2A/bus/scheduler drivers.
- ADR 0007 → slices 1–2 + fork guide shipped; per-project subagent binding **deferred** (a monitor-and-unblock operator doesn't fan out coding workers).

## Verification
- `tests/test_fs_tools.py` (13): registry fence (resolve + reject escape + unknown project), read/list/find/search, write+edit in rw, write blocked in ro, edit unique-`old` guard, `run_command` gating + fenced cwd, config round-trip + default-off.
- **Full suite: 871 passed.** `docs:build` clean.

Next: create `protoLabsAI/roxy` from the template and apply the guide (monitor + unblock, not code; A2A + Workstacean bus).

🤖 Generated with [Claude Code](https://claude.com/claude-code)