### PR TITLE
feat(deploy): managed protoAgent-under-OpenShell example (compose + k8s) (ADR 0008)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   NVIDIA OpenShell sandbox policy from config (project registry → Landlock
   paths, egress allowlist + gateway → network policy). New guides:
   "Build an operator fork (Roxy)" and "Sandboxing & egress".
+- **Run protoAgent under OpenShell** — `deploy/openshell/` managed example:
+  gateway compose + a sandbox-create script (Docker), and Helm values + an
+  Agent-Sandbox CRD template (Kubernetes), policy generated from config.
 
 ## [0.5.1] - 2026-06-01
 

--- a/deploy/openshell/README.md
+++ b/deploy/openshell/README.md
@@ -1,0 +1,69 @@
+# protoAgent under NVIDIA OpenShell
+
+Run protoAgent (or a fork like Roxy) as an **OpenShell-managed sandbox** —
+kernel-enforced filesystem (Landlock), syscall filtering (seccomp), and
+deny-by-default network egress — instead of the app-level isolation alone. See
+[ADR 0008](../../docs/adr/0008-sandboxing-and-openshell.md) and the
+[Sandboxing & egress guide](../../docs/guides/sandboxing.md).
+
+The model: a long-running **gateway** (control plane) provisions the agent as a
+**sandbox** under a compute driver (docker / k8s). The sandbox's policy is
+**generated from protoAgent's own config** — `filesystem.projects` → Landlock
+paths, `egress.allowed_hosts` + `model.api_base` → the egress allowlist.
+
+> Verbatim gateway/Helm bits are from OpenShell's docs; the sandbox/CRD wiring is
+> a starting template — OpenShell + the Agent Sandbox CRD are pre-1.0, so verify
+> fields against the versions you install.
+
+## Local / single host (Docker)
+
+```bash
+# 1) gateway (control plane)
+docker compose -f deploy/openshell/compose.yml up -d
+openshell gateway add http://127.0.0.1:8080 --local --name local
+
+# 2) generate the policy + create the protoAgent sandbox
+bash deploy/openshell/create-protoagent-sandbox.sh
+#   PROTOAGENT_IMAGE / PROTOAGENT_PORT / PROTOAGENT_CONFIG override the defaults
+
+openshell sandbox list
+```
+
+The generated `openshell-policy.yaml` is the fence: the sandbox can only read/
+write the project paths in the policy and only reach the allowlisted hosts.
+
+## Kubernetes
+
+```bash
+# 1) Agent Sandbox controller + CRDs (OpenShell builds on the SIG project)
+VERSION=$(curl -s https://api.github.com/repos/kubernetes-sigs/agent-sandbox/releases/latest | jq -r .tag_name)
+kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/$VERSION/manifest.yaml
+
+# 2) the OpenShell gateway (StatefulSet + PKI + RBAC)
+kubectl create namespace openshell
+helm upgrade --install openshell oci://ghcr.io/nvidia/openshell/helm-chart \
+  --version <release> --namespace openshell -f deploy/openshell/k8s/values.yaml
+
+# 3) policy ConfigMap (generated from config) + the protoAgent sandbox
+python scripts/gen_openshell_policy.py --config config/langgraph-config.yaml --out /tmp/policy.yaml
+kubectl -n openshell create configmap protoagent-openshell-policy --from-file=policy.yaml=/tmp/policy.yaml
+kubectl -n openshell create secret generic protoagent-config \
+  --from-file=langgraph-config.yaml=config/langgraph-config.yaml
+kubectl apply -f deploy/openshell/k8s/protoagent-sandbox.yaml
+```
+
+## Files
+
+| File | What |
+|---|---|
+| `compose.yml` | OpenShell gateway as a container (docker driver) — verbatim from OpenShell docs |
+| `create-protoagent-sandbox.sh` | Generate the policy + create the protoAgent sandbox under the gateway |
+| `k8s/values.yaml` | Helm values for the gateway (kubernetes driver) |
+| `k8s/protoagent-sandbox.yaml` | Templated Agent-Sandbox CRD for protoAgent + policy ConfigMap wiring |
+
+## Roxy
+
+A read-only monitor (every project `write:false`) is the ideal tenant: the
+policy makes her read-only authority **kernel-enforced** and pins egress to the
+gateway + `gh`/git hosts. Generate her policy the same way (`gen_openshell_policy.py`
+against Roxy's config) and run her sandbox with `PROTOAGENT_INSTANCE=roxy`.

--- a/deploy/openshell/compose.yml
+++ b/deploy/openshell/compose.yml
@@ -1,0 +1,28 @@
+# Run protoAgent under NVIDIA OpenShell — Docker Compose (ADR 0008).
+#
+# This brings up the OpenShell **gateway** (the control plane). protoAgent then
+# runs as an OpenShell *sandbox* the gateway manages via the docker driver — see
+# create-protoagent-sandbox.sh (the agent is NOT a plain compose service; the
+# gateway spins its container with the Landlock/seccomp/egress policy applied).
+#
+# Gateway config below is verbatim from OpenShell's "Running the Gateway as a
+# Container" docs (TLS disabled = local/dev; enable mTLS for anything shared).
+# Verify image tag + env names against your installed OpenShell release.
+
+services:
+  openshell-gateway:
+    image: ghcr.io/nvidia/openshell/gateway:latest
+    container_name: openshell-gateway
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:8080:8080"      # localhost only
+    volumes:
+      - openshell-state:/var/openshell
+      - /var/run/docker.sock:/var/run/docker.sock   # docker driver provisions sandboxes
+    environment:
+      OPENSHELL_DRIVERS: docker
+      OPENSHELL_DB_URL: sqlite:/var/openshell/openshell.db
+      OPENSHELL_DISABLE_TLS: "true"   # DEV ONLY — set OPENSHELL_ENABLE_MTLS_AUTH=true + certs for shared hosts
+
+volumes:
+  openshell-state:

--- a/deploy/openshell/create-protoagent-sandbox.sh
+++ b/deploy/openshell/create-protoagent-sandbox.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Create a protoAgent sandbox under a running OpenShell gateway (ADR 0008).
+#
+# Prereqs: `docker compose -f compose.yml up -d` (gateway running) and the
+# `openshell` CLI installed + registered against the gateway:
+#   openshell gateway add http://127.0.0.1:8080 --local --name local
+#
+# This (1) generates a least-privilege policy from your protoAgent config and
+# (2) creates the sandbox. The policy's filesystem paths come from
+# `filesystem.projects` and the egress allowlist from `egress.allowed_hosts`
+# + `model.api_base` — so the sandbox can only touch what the agent is actually
+# configured to use.
+#
+# NOTE: `openshell sandbox create` flags (image/mounts/ports) vary by release —
+# the call below is a template; adapt mount/port flags to your OpenShell CLI.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+CONFIG="${PROTOAGENT_CONFIG:-$REPO_ROOT/config/langgraph-config.yaml}"
+IMAGE="${PROTOAGENT_IMAGE:-ghcr.io/protolabsai/protoagent:latest}"
+POLICY="${POLICY_OUT:-$REPO_ROOT/deploy/openshell/openshell-policy.yaml}"
+PORT="${PROTOAGENT_PORT:-7870}"
+
+echo "→ generating OpenShell policy from $CONFIG"
+python "$REPO_ROOT/scripts/gen_openshell_policy.py" --config "$CONFIG" --out "$POLICY"
+
+echo "→ creating protoAgent sandbox (image=$IMAGE, port=$PORT)"
+# The gateway applies the policy (Landlock fs + seccomp + deny-by-default egress)
+# to the container it spins for this command. Mount the live config + the data
+# volume; the project dirs are mounted per the policy's filesystem paths.
+openshell sandbox create \
+  --name protoagent \
+  --policy "$POLICY" \
+  --image "$IMAGE" \
+  --publish "127.0.0.1:${PORT}:7870" \
+  --mount "$CONFIG:/sandbox/config/langgraph-config.yaml:ro" \
+  -- python server.py --port 7870
+
+echo "✓ protoAgent sandbox created. Inspect: openshell sandbox list"

--- a/deploy/openshell/k8s/protoagent-sandbox.yaml
+++ b/deploy/openshell/k8s/protoagent-sandbox.yaml
@@ -1,0 +1,47 @@
+# protoAgent as an OpenShell-managed sandbox on Kubernetes (ADR 0008).
+#
+# TEMPLATE — the Sandbox CRD shape comes from the Agent Sandbox SIG + OpenShell's
+# policy attachment, both pre-1.0 and changing between releases. Treat this as a
+# starting point: verify the apiVersion/kind/fields against the Agent Sandbox +
+# OpenShell versions you installed (`kubectl explain sandbox`).
+#
+# The policy ConfigMap is generated from protoAgent config:
+#   python scripts/gen_openshell_policy.py --config config/langgraph-config.yaml --out policy.yaml
+#   kubectl -n openshell create configmap protoagent-openshell-policy --from-file=policy.yaml
+---
+apiVersion: agents.x-k8s.io/v1alpha1     # verify: kubectl get crd | grep sandbox
+kind: Sandbox
+metadata:
+  name: protoagent
+  namespace: openshell
+  labels:
+    app: protoagent
+  annotations:
+    # OpenShell reads the policy that fences this sandbox (Landlock fs + seccomp
+    # + deny-by-default egress). Annotation key is release-specific — confirm it.
+    openshell.nvidia.com/policy-configmap: protoagent-openshell-policy
+spec:
+  podTemplate:
+    spec:
+      serviceAccountName: openshell-sandbox   # created by the OpenShell chart
+      containers:
+        - name: protoagent
+          image: ghcr.io/protolabsai/protoagent:latest
+          command: ["python", "server.py", "--port", "7870"]
+          ports:
+            - containerPort: 7870
+          env:
+            - name: PROTOAGENT_INSTANCE         # ADR 0004 — isolate this deployment's stores
+              value: "k8s"
+          volumeMounts:
+            - name: config
+              mountPath: /sandbox/config/langgraph-config.yaml
+              subPath: langgraph-config.yaml
+              readOnly: true
+            # Managed project workspaces are mounted per the OpenShell policy's
+            # filesystem paths (read-only for a monitor like Roxy). The policy —
+            # not this manifest — is the enforcement boundary (Landlock).
+      volumes:
+        - name: config
+          secret:
+            secretName: protoagent-config       # holds langgraph-config.yaml (model + A2A bearer)

--- a/deploy/openshell/k8s/values.yaml
+++ b/deploy/openshell/k8s/values.yaml
@@ -1,0 +1,28 @@
+# Helm values for the OpenShell gateway on Kubernetes (ADR 0008).
+#
+# Install order (per OpenShell's K8s setup docs):
+#
+#   # 1) Agent Sandbox controller + CRDs (the SIG project OpenShell builds on)
+#   VERSION=$(curl -s https://api.github.com/repos/kubernetes-sigs/agent-sandbox/releases/latest | jq -r .tag_name)
+#   kubectl apply -f https://github.com/kubernetes-sigs/agent-sandbox/releases/download/$VERSION/manifest.yaml
+#
+#   # 2) the OpenShell gateway (StatefulSet + PKI + RBAC, all via the chart)
+#   kubectl create namespace openshell
+#   helm upgrade --install openshell oci://ghcr.io/nvidia/openshell/helm-chart \
+#     --version <release> --namespace openshell -f values.yaml
+#
+# The chart is flagged EXPERIMENTAL by NVIDIA — pin a version and verify these
+# keys against that release's values schema before relying on them.
+
+# Kubernetes compute driver — the gateway provisions sandbox pods via the
+# Agent Sandbox controller.
+drivers: kubernetes
+
+# The gateway↔sandbox-supervisor gRPC endpoint must be reachable in-cluster.
+server:
+  grpcEndpoint: openshell.openshell.svc.cluster.local:8080
+
+# mTLS is on by default; the chart's pre-install PKI hook generates the certs
+# (no manual secret creation). Keep it on for anything shared.
+tls:
+  enabled: true

--- a/docs/adr/0008-sandboxing-and-openshell.md
+++ b/docs/adr/0008-sandboxing-and-openshell.md
@@ -145,7 +145,9 @@ out), which suits us — we already ship a container.
 - Should the egress allowlist also gate `web_search`/peer/MCP target hosts, or
   leave those to their fixed config + the OpenShell netns layer? (Leaning: leave
   to OpenShell; `fetch_url` is the model-chosen-host vector.)
-- A managed "protoAgent-under-OpenShell" compose/k8s example (follow-up).
+- ✅ A managed "protoAgent-under-OpenShell" compose/k8s example — shipped in
+  `deploy/openshell/` (gateway compose + sandbox-create script; Helm values +
+  Agent-Sandbox CRD template for k8s).
 
 ## 8. Related
 

--- a/docs/guides/sandboxing.md
+++ b/docs/guides/sandboxing.md
@@ -86,6 +86,20 @@ openshell sandbox create --policy openshell-policy.yaml -- python server.py
 Credentials are injected as env at runtime (never on disk); egress is
 deny-by-default through the proxy; the filesystem is locked to the policy paths.
 
+### Ready-made deployment
+
+`deploy/openshell/` has a managed example end-to-end:
+
+- **Docker:** `compose.yml` (the OpenShell gateway) + `create-protoagent-sandbox.sh`
+  (generates the policy, creates the protoAgent sandbox under the gateway).
+- **Kubernetes:** `k8s/values.yaml` (Helm gateway, kubernetes driver) +
+  `k8s/protoagent-sandbox.yaml` (Agent-Sandbox CRD + policy ConfigMap) — after
+  installing the Agent Sandbox CRDs.
+
+See [`deploy/openshell/README.md`](https://github.com/protoLabsAI/protoAgent/blob/main/deploy/openshell/README.md). The gateway/Helm
+commands are verbatim from OpenShell's docs; the sandbox/CRD wiring is a
+starting template (OpenShell is pre-1.0 — verify fields against your release).
+
 ## Recommended posture
 
 - **Trusted model, no code execution:** native egress allowlist is a sensible


### PR DESCRIPTION
Closes the ADR 0008 follow-up — a ready-made deployment to run protoAgent (or Roxy) as an **OpenShell-managed sandbox** (kernel-enforced fs + seccomp + deny-by-default egress).

## `deploy/openshell/`
- **`compose.yml`** — the OpenShell gateway as a container (docker driver). Verbatim from OpenShell's "Running the Gateway as a Container" docs.
- **`create-protoagent-sandbox.sh`** — generates the policy from your config (`gen_openshell_policy.py`) and creates the protoAgent sandbox under the gateway.
- **`k8s/values.yaml`** — Helm values for the gateway (kubernetes driver); README has the Agent-Sandbox CRD prereq + `helm install oci://ghcr.io/nvidia/openshell/helm-chart`.
- **`k8s/protoagent-sandbox.yaml`** — templated Agent-Sandbox CRD + policy ConfigMap wiring.
- **`README.md`** — end-to-end (Docker + Kubernetes) + a Roxy note (read-only monitor = ideal tenant; policy makes her read-only authority kernel-enforced).

## Honesty
Gateway/Helm/CRD commands are **verbatim from OpenShell's docs**; the sandbox/CRD manifest is a **starting template** — OpenShell + the Agent Sandbox SIG are pre-1.0 (chart flagged experimental), so fields are marked "verify against your release." Same posture as the policy generator.

## Verification
- All YAML parses; the sandbox-create script passes `bash -n`; `docs:build` clean.
- Sandboxing guide links `deploy/openshell/`; ADR 0008 open question marked done; CHANGELOG `[Unreleased]` updated.

After merge I'll cut the release (pending `[Unreleased]`: operator primitives + sandboxing + this → `minor`, 0.6.0).

🤖 Generated with [Claude Code](https://claude.com/claude-code)