### PR TITLE
feat(console): Playbooks surface + default model → protolabs/reasoning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Playbooks surface** (ADR 0009) — a Knowledge ▸ Playbooks console surface to
+  browse + manage the procedural-memory skill index (`skills.db`): pinned
+  (SKILL.md) vs learned (agent-emitted), confidence/last-used, search, and
+  delete-with-confirm. New API: `GET /api/playbooks` + `DELETE /api/playbooks/{id}`.
+
+### Changed
+- Default model alias is now **`protolabs/reasoning`** (was `protolabs/agent`) —
+  forks point at the reasoning model out of the box (override per agent in YAML).
+
 ## [0.6.0] - 2026-06-01
 
 ### Added

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -135,7 +135,7 @@ include_subagents=False)` in `server.py`.
 ## 7. Set up the model
 
 The template points at a LiteLLM gateway alias called
-`protolabs/agent`. Two options:
+`protolabs/reasoning`. Two options:
 
 1. **Add a gateway alias** called `protolabs/<your-name>`
    pointing at whichever model you want, then update

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -146,7 +146,7 @@ export const SETTINGS_SCHEMA = [
   {
     section: "Model",
     fields: [
-      { key: "model.name", label: "Primary model", type: "select", section: "Model", restart: false, description: "", options: ["protolabs/reasoning", "protolabs/fast"], value: "protolabs/reasoning", default: "protolabs/agent" },
+      { key: "model.name", label: "Primary model", type: "select", section: "Model", restart: false, description: "", options: ["protolabs/reasoning", "protolabs/fast"], value: "protolabs/reasoning", default: "protolabs/reasoning" },
       { key: "model.temperature", label: "Temperature", type: "number", section: "Model", restart: false, description: "", options: [], value: 0.2, default: 0.2, minimum: 0, maximum: 2 },
       { key: "model.api_key", label: "API key", type: "secret", section: "Model", restart: false, description: "Stored in secrets.yaml.", options: [], value: "", is_set: true },
     ],
@@ -393,3 +393,17 @@ export const TELEMETRY_INSIGHTS = {
   },
   unproven_levers: [],
 };
+
+// Playbooks fixtures (ADR 0009) — shape mirrors /api/playbooks (skills.db).
+export const PLAYBOOKS = [
+  {
+    id: 1, name: "web-research", description: "Plan → search → read → synthesize → cite.",
+    tools_used: ["web_search", "fetch_url"], source: "disk", confidence: 1.0,
+    last_used: "2026-06-01T18:00:00+00:00", created_at: "2026-05-29T00:00:00+00:00",
+  },
+  {
+    id: 2, name: "pr-triage-flow", description: "Learned: how to triage a PR review backlog.",
+    tools_used: ["github_get_pr", "github_list_issues"], source: "emitted", confidence: 0.62,
+    last_used: "2026-05-31T12:00:00+00:00", created_at: "2026-05-30T00:00:00+00:00",
+  },
+];

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -24,6 +24,7 @@ import {
   SETTINGS_SCHEMA,
   settingsRestartRequired,
   SLASH_COMMANDS,
+  PLAYBOOKS,
   SUBAGENTS,
   TELEMETRY_INSIGHTS,
   TELEMETRY_SUMMARY,
@@ -99,6 +100,8 @@ function handleApiGet(pathname) {
       return { enabled: true, turns: TELEMETRY_TURNS };
     case "/api/telemetry/insights":
       return { enabled: true, insights: TELEMETRY_INSIGHTS };
+    case "/api/playbooks":
+      return { enabled: true, playbooks: PLAYBOOKS };
     default:
       return null;
   }
@@ -200,6 +203,9 @@ const server = createServer(async (req, res) => {
     }
     if (/^\/api\/workflows\/[^/]+\/run$/.test(pathname)) {
       return sendJson(res, WORKFLOW_RUN_RESULT);
+    }
+    if (req.method === "DELETE" && /^\/api\/playbooks\/\d+$/.test(pathname)) {
+      return sendJson(res, { enabled: true, deleted: true });
     }
     return sendJson(res, { ok: true });
   }

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -1,0 +1,44 @@
+import { expect, test } from "@playwright/test";
+
+// The Knowledge ▸ Playbooks surface (ADR 0009) browses the skill index:
+// pinned (SKILL.md) vs learned (agent-emitted), with search + delete-with-confirm.
+
+test("Knowledge → Playbooks lists pinned + learned skills and supports search", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Knowledge" }).click();
+
+  const surface = page.getByTestId("playbooks-surface");
+  await expect(surface).toBeVisible();
+
+  // Both fixtures render with their source badges.
+  await expect(surface.getByText("web-research")).toBeVisible();
+  await expect(surface.getByText("pr-triage-flow")).toBeVisible();
+  await expect(surface.getByText("pinned").first()).toBeVisible();
+  await expect(surface.getByText("learned").first()).toBeVisible();
+
+  // Search narrows the list.
+  await surface.getByPlaceholder(/Search playbooks/).fill("triage");
+  await expect(surface.getByText("pr-triage-flow")).toBeVisible();
+  await expect(surface.getByText("web-research")).toBeHidden();
+});
+
+test("deleting a playbook confirms first, then removes it", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Knowledge" }).click();
+  const surface = page.getByTestId("playbooks-surface");
+  await expect(surface).toBeVisible();
+
+  // Delete the learned one → custom confirm dialog (not window.confirm).
+  await surface.getByTestId("playbook-delete-2").click();
+  const dialog = page.getByTestId("confirm-dialog");
+  await expect(dialog).toBeVisible();
+
+  // Cancel keeps it.
+  await page.getByTestId("confirm-cancel").click();
+  await expect(surface.getByText("pr-triage-flow")).toBeVisible();
+
+  // Confirm removes the row.
+  await surface.getByTestId("playbook-delete-2").click();
+  await page.getByTestId("confirm-accept").click();
+  await expect(surface.getByText("pr-triage-flow")).toBeHidden();
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1,6 +1,7 @@
 import {
   Activity,
   BarChart3,
+  BookMarked,
   Bot,
   Boxes,
   CalendarClock,
@@ -34,6 +35,7 @@ import { ActivitySurface } from "../activity/ActivitySurface";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { InboxPanel } from "../inbox/InboxPanel";
 import { ChatSurface } from "../chat/ChatSurface";
+import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
@@ -45,7 +47,7 @@ import { SetupWizard } from "../setup/SetupWizard";
 
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
 // fanning out to sub-views via an in-surface segmented control.
-type Surface = "chat" | "activity" | "studio" | "system";
+type Surface = "chat" | "activity" | "studio" | "knowledge" | "system";
 type StudioTab = "subagents" | "workflows" | "schedule" | "goals";
 type SystemTab = "runtime" | "telemetry" | "settings";
 type ActivityTab = "thread" | "inbox";
@@ -887,6 +889,12 @@ export function App() {
             onClick={() => setSurface("studio")}
           />
           <RailButton
+            active={surface === "knowledge"}
+            label="Knowledge"
+            icon={<BookMarked size={18} />}
+            onClick={() => setSurface("knowledge")}
+          />
+          <RailButton
             active={surface === "system"}
             label="System"
             icon={<Gauge size={18} />}
@@ -1312,6 +1320,7 @@ export function App() {
           ) : null}
 
           {surface === "system" && systemTab === "telemetry" ? <TelemetrySurface onError={setError} /> : null}
+          {surface === "knowledge" ? <PlaybooksSurface onError={setError} /> : null}
           {surface === "system" && systemTab === "settings" ? <SettingsSurface onError={setError} /> : null}
         </main>
 

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2495,3 +2495,53 @@ textarea {
   color: var(--fg-muted);
   margin: 2px 0 0;
 }
+
+/* Playbooks surface (ADR 0009) */
+.playbook-search {
+  width: 100%;
+  padding: 8px 12px;
+  margin-bottom: 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+  color: var(--fg);
+  font-size: 13px;
+}
+.playbook-search:focus { outline: none; border-color: var(--border-strong); }
+.playbook-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.playbook-card {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 12px 14px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+}
+.playbook-card:hover { border-color: var(--border-strong); }
+.playbook-main { min-width: 0; }
+.playbook-title { display: flex; align-items: center; gap: 8px; }
+.playbook-title strong { font-size: 13.5px; }
+.playbook-badge {
+  display: inline-flex; align-items: center; gap: 4px;
+  font-size: 10.5px; padding: 1px 7px; border-radius: 999px;
+  border: 1px solid var(--border); color: var(--fg-muted); white-space: nowrap;
+}
+.playbook-badge.pinned { color: var(--info); border-color: color-mix(in srgb, var(--info) 40%, transparent); }
+.playbook-badge.learned { color: var(--success); border-color: color-mix(in srgb, var(--success) 40%, transparent); }
+.playbook-desc { margin: 6px 0 0; font-size: 12.5px; color: var(--fg-secondary); }
+.playbook-tools { margin-top: 7px; display: flex; flex-wrap: wrap; gap: 5px; }
+.playbook-tools code { font-size: 11px; padding: 1px 6px; border-radius: 4px; background: var(--bg-hover); color: var(--fg-muted); }
+.playbook-meta {
+  display: flex; flex-direction: column; align-items: flex-end; gap: 4px;
+  font-size: 11.5px; color: var(--fg-muted); white-space: nowrap;
+  font-variant-numeric: tabular-nums;
+}
+.icon-button {
+  display: inline-flex; align-items: center; justify-content: center;
+  padding: 4px; border: 1px solid var(--border); border-radius: var(--radius);
+  background: transparent; color: var(--fg-muted); cursor: pointer; margin-top: 2px;
+}
+.icon-button:hover { background: var(--bg-hover); color: var(--fg); }
+.icon-button.danger:hover { color: var(--error); border-color: color-mix(in srgb, var(--error) 40%, transparent); }
+.playbook-foot { margin-top: 16px; font-size: 11.5px; color: var(--fg-muted); display: flex; align-items: center; gap: 6px; }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -12,6 +12,7 @@ import type {
   SetupStatus,
   SettingsGroup,
   SlashCommand,
+  Playbook,
   Subagent,
   TelemetryInsights,
   TelemetrySummary,
@@ -190,6 +191,17 @@ export const api = {
   telemetryInsights() {
     return request<{ enabled: boolean; insights: TelemetryInsights | null }>(
       "/api/telemetry/insights",
+    );
+  },
+
+  playbooks() {
+    return request<{ enabled: boolean; playbooks: Playbook[] }>("/api/playbooks");
+  },
+
+  deletePlaybook(id: number) {
+    return request<{ enabled: boolean; deleted: boolean; error?: string }>(
+      `/api/playbooks/${id}`,
+      { method: "DELETE" },
     );
   },
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -317,3 +317,15 @@ export type TelemetryInsights = {
   };
   unproven_levers: string[];
 };
+
+// Playbooks (skills surface, ADR 0009) — mirrors /api/playbooks (skills.db).
+export type Playbook = {
+  id: number;
+  name: string;
+  description: string;
+  tools_used: string[];
+  source: string;        // "disk" (pinned SKILL.md) | "emitted" (agent-learned)
+  confidence: number;
+  last_used: string | null;
+  created_at: string | null;
+};

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -1,0 +1,173 @@
+import { BookMarked, Pin, RefreshCw, Sparkles, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { ConfirmDialog } from "../app/ConfirmDialog";
+import { api } from "../lib/api";
+import type { Playbook } from "../lib/types";
+
+// Playbooks surface (ADR 0009) — browse + manage the procedural-memory skill
+// index (skills.db) the operator was otherwise blind to. "Playbooks" is the
+// operator-facing name for skill-v1 artifacts: disk = pinned SKILL.md,
+// emitted = agent-learned (curated/decaying). Functional-first: list + search +
+// delete-with-confirm. Confidence tuning / curator audit are follow-ups.
+
+function ago(iso: string | null): string {
+  if (!iso) return "never";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "—";
+  const s = Math.max(0, (Date.now() - t) / 1000);
+  if (s < 90) return "just now";
+  if (s < 3600) return `${Math.round(s / 60)}m ago`;
+  if (s < 86400) return `${Math.round(s / 3600)}h ago`;
+  return `${Math.round(s / 86400)}d ago`;
+}
+
+export function PlaybooksSurface({ onError }: { onError: (message: string) => void }) {
+  const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
+  const [enabled, setEnabled] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState("");
+  const [pending, setPending] = useState<Playbook | null>(null);
+
+  async function load() {
+    setLoading(true);
+    try {
+      const r = await api.playbooks();
+      setEnabled(r.enabled);
+      setPlaybooks(r.playbooks || []);
+      onError("");
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+  useEffect(() => {
+    void load();
+  }, []);
+
+  const filtered = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    if (!q) return playbooks;
+    return playbooks.filter(
+      (p) =>
+        p.name.toLowerCase().includes(q) ||
+        p.description.toLowerCase().includes(q) ||
+        p.tools_used.some((t) => t.toLowerCase().includes(q)),
+    );
+  }, [playbooks, query]);
+
+  const pinned = filtered.filter((p) => p.source === "disk").length;
+  const learned = filtered.length - pinned;
+
+  async function confirmDelete() {
+    if (!pending) return;
+    const id = pending.id;
+    setPending(null);
+    try {
+      const r = await api.deletePlaybook(id);
+      if (!r.deleted) {
+        onError(r.error || "delete failed");
+        return;
+      }
+      setPlaybooks((ps) => ps.filter((p) => p.id !== id));
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  return (
+    <section className="panel stage-panel" data-testid="playbooks-surface">
+      <div className="panel-header">
+        <div>
+          <h1>Playbooks</h1>
+          <p className="panel-kicker">
+            retrieved methodology · {pinned} pinned · {learned} learned
+          </p>
+        </div>
+        <button className="secondary-button" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
+          <RefreshCw size={15} className={loading ? "spin" : ""} /> Refresh
+        </button>
+      </div>
+
+      <div className="stage-body">
+        <input
+          className="playbook-search"
+          type="search"
+          placeholder="Search playbooks (name, description, tools)…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+
+        {!enabled ? (
+          <p className="empty-note">The skills index is disabled (set <code>skills.enabled: true</code>).</p>
+        ) : filtered.length === 0 ? (
+          <p className="empty-note">
+            {playbooks.length === 0
+              ? "No playbooks yet — author a SKILL.md, or let the agent emit one from a run."
+              : "No playbooks match your search."}
+          </p>
+        ) : (
+          <ul className="playbook-list">
+            {filtered.map((p) => (
+              <li key={p.id} className="playbook-card">
+                <div className="playbook-main">
+                  <div className="playbook-title">
+                    {p.source === "disk" ? (
+                      <span className="playbook-badge pinned" title="Pinned SKILL.md (re-seeded on boot)">
+                        <Pin size={12} /> pinned
+                      </span>
+                    ) : (
+                      <span className="playbook-badge learned" title="Agent-emitted (curated/decaying)">
+                        <Sparkles size={12} /> learned
+                      </span>
+                    )}
+                    <strong>{p.name}</strong>
+                  </div>
+                  <p className="playbook-desc">{p.description}</p>
+                  {p.tools_used.length ? (
+                    <div className="playbook-tools">
+                      {p.tools_used.map((t) => (
+                        <code key={t}>{t}</code>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+                <div className="playbook-meta">
+                  <span title="confidence">conf {Math.round((p.confidence ?? 1) * 100)}%</span>
+                  <span title="last used">used {ago(p.last_used)}</span>
+                  <button
+                    type="button"
+                    className="icon-button danger"
+                    title={p.source === "disk" ? "Delete (re-seeds from SKILL.md on restart)" : "Delete playbook"}
+                    onClick={() => setPending(p)}
+                    data-testid={`playbook-delete-${p.id}`}
+                  >
+                    <Trash2 size={14} />
+                  </button>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={pending !== null}
+        title="Delete playbook?"
+        message={
+          pending
+            ? `Remove "${pending.name}"${pending.source === "disk" ? " — note: a pinned SKILL.md re-seeds on the next restart." : "."}`
+            : undefined
+        }
+        confirmLabel="Delete"
+        onConfirm={() => void confirmDelete()}
+        onCancel={() => setPending(null)}
+      />
+
+      <p className="playbook-foot">
+        <BookMarked size={13} /> Playbooks are methodology the agent retrieves into context (ADR 0009) — they don't run, they advise.
+      </p>
+    </section>
+  );
+}

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -8,11 +8,11 @@
 
 model:
   provider: openai
-  # Default LiteLLM gateway alias. Set an alias called ``protolabs/agent``
+  # Default LiteLLM gateway alias. Set an alias called ``protolabs/reasoning``
   # (or whatever you rename it to) in your gateway config pointing at the
   # real model — swapping the model becomes a gateway edit, not a code
   # change in the fork.
-  name: protolabs/agent
+  name: protolabs/reasoning
   api_base: http://gateway:4000/v1
   api_key: ""  # falls back to OPENAI_API_KEY env
   temperature: 0.2

--- a/docs/explanation/litellm-gateway.md
+++ b/docs/explanation/litellm-gateway.md
@@ -20,9 +20,9 @@ Option 3 wins because:
 
 ## The alias pattern
 
-The template points at `model.name: protolabs/agent`. Two things to know:
+The template points at `model.name: protolabs/reasoning`. Two things to know:
 
-1. **`protolabs/<name>` is a gateway alias**, not a real model. The gateway config maps `protolabs/agent` → whichever real model (e.g. `claude-opus-4-6`, `gpt-4o`) you want.
+1. **`protolabs/<name>` is a gateway alias**, not a real model. The gateway config maps `protolabs/reasoning` → whichever real model (e.g. `claude-opus-4-6`, `gpt-4o`) you want.
 2. **Each agent gets its own alias**. Quinn uses `protolabs/quinn`, a researcher agent might use `protolabs/researcher`. Same gateway, different underlying models, different rate limits, different cost tracking.
 
 To swap a model for an agent:
@@ -30,7 +30,7 @@ To swap a model for an agent:
 ```yaml
 # In the gateway's config.yaml
 model_list:
-  - model_name: protolabs/agent
+  - model_name: protolabs/reasoning
     litellm_params:
       model: anthropic/claude-opus-4-6   # ← was claude-sonnet-4-6
       api_key: os.environ/ANTHROPIC_API_KEY

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -353,6 +353,18 @@ by-model table, and a recent-turns table. It reads `GET /api/telemetry/summary`
 + `/api/telemetry/recent` — no chat-stream coupling — and degrades to a clear
 note when the store is disabled or empty.
 
+## Playbooks surface
+
+The **Knowledge ▸ Playbooks** surface (`apps/web/src/playbooks/PlaybooksSurface.tsx`,
+ADR 0009) browses the procedural-memory skill index (`skills.db`) the operator
+was otherwise blind to. It lists each skill as **pinned** (a `SKILL.md` on disk,
+re-seeded at boot) or **learned** (agent-emitted, curated/decaying), with
+confidence + last-used, a search filter, and delete-with-confirm. Reads
+`GET /api/playbooks`; deletes via `DELETE /api/playbooks/{id}`. "Playbooks" is
+the operator-facing name for skill-v1 artifacts — see ADR 0009 (it disambiguates
+from the A2A agent-card `skills` field). Confidence-tuning + curator-audit
+read-back are noted follow-ups.
+
 ## Settings surface
 
 The **Settings** rail surface lets an operator manage every config field from

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,7 +9,7 @@
 ```yaml
 model:
   provider: openai
-  name: protolabs/agent
+  name: protolabs/reasoning
   api_base: http://gateway:4000/v1
   api_key: ""
   temperature: 0.2
@@ -44,7 +44,7 @@ knowledge:
 | Key | Default | What |
 |---|---|---|
 | `provider` | `openai` | LangChain LLM provider. The template's `graph/llm.py` only uses `openai` (via LiteLLM gateway). |
-| `name` | `protolabs/agent` | Gateway alias or direct model name. |
+| `name` | `protolabs/reasoning` | Gateway alias or direct model name. |
 | `api_base` | `http://gateway:4000/v1` | OpenAI-compatible endpoint. |
 | `api_key` | `""` | **Secret — not stored here.** Managed in the untracked `config/secrets.yaml` (see [Secrets](#secrets)); falls back to the `OPENAI_API_KEY` env var. |
 | `temperature` | `0.2` | Sampling temperature. |

--- a/graph/config.py
+++ b/graph/config.py
@@ -46,7 +46,7 @@ class SubagentDef:
 class LangGraphConfig:
     # Model settings — route through the LiteLLM gateway by default
     model_provider: str = "openai"
-    model_name: str = "protolabs/agent"  # override in YAML per agent
+    model_name: str = "protolabs/reasoning"  # override in YAML per agent
     api_base: str = "http://gateway:4000/v1"
     api_key: str = ""  # set via OPENAI_API_KEY env (gateway master key)
     temperature: float = 0.2

--- a/server.py
+++ b/server.py
@@ -2304,6 +2304,39 @@ def _main():
             return {"enabled": False, "cleared": False}
         return {"enabled": True, "cleared": _goal_controller.store.clear(session_id)}
 
+    # --- Playbooks (skills surface, ADR 0009) ------------------------------
+    # Browse + manage the procedural-memory skill index (skills.db) the operator
+    # was otherwise blind to. "Playbooks" is the operator-facing name for the
+    # skill-v1 artifacts (disk = pinned SKILL.md, emitted = agent-learned).
+    @fastapi_app.get("/api/playbooks")
+    async def _api_playbooks():
+        if _skills_index is None:
+            return {"enabled": False, "playbooks": []}
+        try:
+            skills = _skills_index.all_skills()
+        except Exception:  # noqa: BLE001 — never 500 the console
+            log.exception("[playbooks] all_skills failed")
+            return {"enabled": True, "playbooks": []}
+        # Drop the (potentially large) prompt_template from the list payload;
+        # the table only needs metadata. Sort pinned-first, then by confidence.
+        out = [
+            {k: v for k, v in s.items() if k != "prompt_template"}
+            for s in skills
+        ]
+        out.sort(key=lambda s: (s.get("source") != "disk", -(s.get("confidence") or 0)))
+        return {"enabled": True, "playbooks": out}
+
+    @fastapi_app.delete("/api/playbooks/{skill_id}")
+    async def _api_playbook_delete(skill_id: int):
+        if _skills_index is None:
+            return {"enabled": False, "deleted": False}
+        try:
+            _skills_index.delete_skill(skill_id)
+            return {"enabled": True, "deleted": True}
+        except Exception as exc:  # noqa: BLE001
+            log.exception("[playbooks] delete failed")
+            return {"enabled": True, "deleted": False, "error": str(exc)}
+
     # --- Telemetry (ADR 0006 Slice 2) --------------------------------------
     # Per-turn cost/latency rollups from the local store. Powers the operator
     # console's cost/latency surface (Slice 3) and ad-hoc "what's expensive"


### PR DESCRIPTION
Two things, shipping together: the **Playbooks** surface (ADR 0009 gap #1) and the **default model** flip.

## Playbooks (Knowledge ▸ Playbooks)
The operator was blind to `skills.db`. New **Knowledge** rail surface → **Playbooks**: browse the procedural-memory skill index as **pinned** (SKILL.md) vs **learned** (agent-emitted), with confidence + last-used, search, and **delete-with-confirm** (shared `ConfirmDialog`).
- Backend: `GET /api/playbooks` + `DELETE /api/playbooks/{id}` over the existing `SkillsIndex.all_skills()` / `delete_skill()`.
- "Playbooks" = the operator-facing name for skill-v1 artifacts — disambiguates from the A2A agent-card `skills` field (ADR 0009). Internals (`skills.db`, `SKILL.md`, the artifact) unchanged.
- Confidence-tuning + curator-audit read-back are noted follow-ups.

## Default model → `protolabs/reasoning`
`graph/config.py` default + the example config flip from `protolabs/agent` → `protolabs/reasoning`, so forks point at the reasoning model out of the box (override per agent in YAML). Doc prose (litellm-gateway / configuration / TEMPLATE) + the settings-schema e2e fixture updated to match.

## Verification
- `e2e/playbooks.spec.ts`: lists pinned + learned with source badges; search narrows; delete confirms-then-removes (cancel keeps). Mock gained the GET fixture + DELETE handler.
- The index methods the surface relies on (`all_skills`/`delete_skill`) are already unit-tested.
- `web:build` clean; **38 e2e passed**; full Python **881 passed**; `docs:build` clean. CHANGELOG `[Unreleased]` updated.

Staged for the combined release (this + the pending operator-primitives / sandboxing / control-stack work). The Studio IA reshape (Goals/Workflows/Run, Schedule→Triggers) remains the separate follow-up before/with that release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)