### PR TITLE
feat(console): reshape Studio to the control stack (ADR 0009)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   delete-with-confirm. New API: `GET /api/playbooks` + `DELETE /api/playbooks/{id}`.
 
 ### Changed
+- **Studio console reshaped to the control stack** (ADR 0009): tabs ordered
+  Goals → Workflows → **Run** (Single/Batch is a mode on Run, not a tab);
+  **Schedule** moved to **Activity** (it's a trigger, not a work-type). Skills
+  now live under **Knowledge ▸ Playbooks**.
 - Default model alias is now **`protolabs/reasoning`** (was `protolabs/agent`) —
   forks point at the reasoning model out of the box (override per agent in YAML).
 

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -15,15 +15,16 @@ async function openSub(page, group: string, tab: string) {
   await page.getByRole("button", { name: tab, exact: true }).click();
 }
 
-test("subagents surface lists the registered subagent", async ({ page }) => {
-  await openSub(page, "Studio", "Subagents");
-  await expect(page.getByRole("heading", { name: "Manual Subagent" })).toBeVisible();
-  // The registered-count kicker reflects the mocked subagent list.
-  await expect(page.getByText("1 registered")).toBeVisible();
+test("Studio → Run lists the registered subagent (single/batch)", async ({ page }) => {
+  await openSub(page, "Studio", "Run");
+  await expect(page.getByRole("heading", { name: "Run", exact: true })).toBeVisible();
+  // The kicker reflects the mocked subagent list; the Single/Batch toggle is here.
+  await expect(page.getByText(/1 subagent type/)).toBeVisible();
+  await expect(page.getByRole("button", { name: "Batch", exact: true })).toBeVisible();
 });
 
-test("schedule surface lists scheduled jobs", async ({ page }) => {
-  await openSub(page, "Studio", "Schedule");
+test("schedule moved to Activity → Schedule lists scheduled jobs", async ({ page }) => {
+  await openSub(page, "Activity", "Schedule");
   await expect(page.getByRole("heading", { name: "Schedule" })).toBeVisible();
   await expect(page.getByText("Summarize overnight activity")).toBeVisible();
 });

--- a/apps/web/e2e/workflows.spec.ts
+++ b/apps/web/e2e/workflows.spec.ts
@@ -26,7 +26,7 @@ test("lists a recipe with its steps and inputs", async ({ page }) => {
 
 test("requires the required input before running", async ({ page }) => {
   await openWorkflows(page);
-  const run = page.getByRole("button", { name: "Run", exact: true });
+  const run = page.locator(".panel-actions").getByRole("button", { name: "Run", exact: true });
   await expect(run).toBeDisabled(); // topic is empty
 });
 
@@ -35,7 +35,7 @@ test("runs the workflow and renders the result", async ({ page }) => {
   // Fill the required input → Run enables.
   const topic = page.locator(".subagent-grid .field").first().locator("input");
   await topic.fill("AI");
-  const run = page.getByRole("button", { name: "Run", exact: true });
+  const run = page.locator(".panel-actions").getByRole("button", { name: "Run", exact: true });
   await expect(run).toBeEnabled();
   await run.click();
   // The run result output renders.

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -16,7 +16,6 @@ import {
   Loader2,
   MessageSquare,
   PanelRight,
-  Network,
   Play,
   Plus,
   RefreshCw,
@@ -48,9 +47,13 @@ import { SetupWizard } from "../setup/SetupWizard";
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
 // fanning out to sub-views via an in-surface segmented control.
 type Surface = "chat" | "activity" | "studio" | "knowledge" | "system";
-type StudioTab = "subagents" | "workflows" | "schedule" | "goals";
+// Studio = the "make the agent do work" surface, ordered by altitude
+// (ADR 0009): goals (autonomy) → workflows (orchestration) → run (execution).
+type StudioTab = "goals" | "workflows" | "run";
 type SystemTab = "runtime" | "telemetry" | "settings";
-type ActivityTab = "thread" | "inbox";
+// Activity = the "triggers / events" surface (ADR 0009): what happened (thread),
+// inbound (inbox), and timed (schedule — cron is a trigger, not a work-type).
+type ActivityTab = "thread" | "inbox" | "schedule";
 type RightPanel = "notes" | "beads";
 type SubagentMode = "single" | "batch";
 type StatusTone = "success" | "warning" | "error" | "muted";
@@ -227,7 +230,7 @@ function groupIssues(issues: BeadsIssue[]) {
 
 export function App() {
   const [surface, setSurface] = useState<Surface>("chat");
-  const [studioTab, setStudioTab] = useState<StudioTab>("subagents");
+  const [studioTab, setStudioTab] = useState<StudioTab>("goals");
   const [systemTab, setSystemTab] = useState<SystemTab>("runtime");
   const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
@@ -447,9 +450,9 @@ export function App() {
   }, [rightPanel, projectPath, notesDirty, notesBusy]);
 
   useEffect(() => {
-    if (surface === "studio" && studioTab === "schedule") void refreshSchedules();
+    if (surface === "activity" && activityTab === "schedule") void refreshSchedules();
     if (surface === "studio" && studioTab === "goals") void refreshGoals();
-  }, [surface, studioTab]);
+  }, [surface, studioTab, activityTab]);
 
   // Open the server→client event stream (ADR 0003) and track its connection
   // state for the "live" indicator. Surfaces subscribe to named events.
@@ -920,21 +923,22 @@ export function App() {
                 <Inbox size={15} /> Inbox
                 {inboxUnread ? <span className="subnav-badge" data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span> : null}
               </button>
+              <button className={activityTab === "schedule" ? "active" : ""} onClick={() => setActivityTab("schedule")}>
+                <CalendarClock size={15} /> Schedule
+              </button>
             </div>
           ) : null}
           {surface === "studio" ? (
+            // Ordered by altitude (ADR 0009): outcome → recipe → worker.
             <div className="stage-subnav">
-              <button className={studioTab === "subagents" ? "active" : ""} onClick={() => setStudioTab("subagents")}>
-                <Network size={15} /> Subagents
+              <button className={studioTab === "goals" ? "active" : ""} onClick={() => setStudioTab("goals")}>
+                <Target size={15} /> Goals
               </button>
               <button className={studioTab === "workflows" ? "active" : ""} onClick={() => setStudioTab("workflows")}>
                 <Workflow size={15} /> Workflows
               </button>
-              <button className={studioTab === "schedule" ? "active" : ""} onClick={() => setStudioTab("schedule")}>
-                <CalendarClock size={15} /> Schedule
-              </button>
-              <button className={studioTab === "goals" ? "active" : ""} onClick={() => setStudioTab("goals")}>
-                <Target size={15} /> Goals
+              <button className={studioTab === "run" ? "active" : ""} onClick={() => setStudioTab("run")}>
+                <Play size={15} /> Run
               </button>
             </div>
           ) : null}
@@ -956,12 +960,12 @@ export function App() {
             <ChatSurface onError={setError} />
           ) : null}
 
-          {surface === "studio" && studioTab === "subagents" ? (
+          {surface === "studio" && studioTab === "run" ? (
             <section className="panel stage-panel">
               <div className="panel-header">
                 <div>
-                  <h1>Manual Subagent</h1>
-                  <p className="panel-kicker">{subagents.length} registered</p>
+                  <h1>Run</h1>
+                  <p className="panel-kicker">one focused worker, now · {subagents.length} subagent type{subagents.length === 1 ? "" : "s"}</p>
                 </div>
                 <StatusPill label={subagentBusy ? "running" : "ready"} tone={subagentBusy ? "warning" : "muted"} />
               </div>
@@ -1076,7 +1080,7 @@ export function App() {
           {surface === "activity" && activityTab === "thread" ? <ActivitySurface onError={setError} /> : null}
           {surface === "activity" && activityTab === "inbox" ? <InboxPanel onError={setError} /> : null}
 
-          {surface === "studio" && studioTab === "schedule" ? (
+          {surface === "activity" && activityTab === "schedule" ? (
             <section className="panel stage-panel">
               <div className="panel-header">
                 <div>

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -344,6 +344,16 @@ server — not the client — decides which directories they may read and write.
 - The runtime-status `project.allowed_dirs` field feeds the project-path
   picker's suggestions; it does not relax the server-side check.
 
+## Studio & Activity surfaces (the control stack)
+
+Per [ADR 0009](/adr/0009-studio-control-stack), the Studio tabs are ordered by
+altitude — **Goals** (autonomy: when to stop) → **Workflows** (orchestration: the
+order) → **Run** (execution: one focused worker, with the Single/Batch toggle).
+They're layers of one control loop, not peers. **Schedule** moved to **Activity**
+(Thread · Inbox · Schedule) — cron is a *trigger* ("when"), grouped with the
+inbox/event-bus (ADR 0003), not a Studio work-type. Skills moved to the
+**Knowledge ▸ Playbooks** surface (below) — they're retrieved memory, not work.
+
 ## Telemetry surface
 
 The **System ▸ Telemetry** sub-tab (`apps/web/src/telemetry/TelemetrySurface.tsx`,


### PR DESCRIPTION
The last pending console work — make the Studio tabs reflect ADR 0009's locked model. Four slapped-together peers → **three layered tabs + a relocated trigger**.

## Changes
- **Studio = Goals → Workflows → Run**, ordered by altitude (autonomy → orchestration → execution). The old "Subagents" tab is renamed **Run** (it already had the Single/Batch toggle — batch is a *mode*, not a tab). Default tab is now Goals.
- **Schedule moved out of Studio → Activity** (Thread · Inbox · **Schedule**): cron is a *trigger* ("when"), grouped with the inbox/event-bus (ADR 0003), not a work-type.
- Skills already live under **Knowledge ▸ Playbooks** (prior PR), so Studio is now purely the "make the agent do work" surface.

## Verification
- e2e: navigation specs updated (Studio→Run, Schedule under Activity); workflows specs scope the Run-button locator to `.panel-actions` so it doesn't collide with the new Run subnav tab. Dropped the now-unused `Network` icon.
- `web:build` clean; **38 e2e passed**; full Python **881**; `docs:build` clean. Console guide + CHANGELOG updated.

This completes the [Unreleased] batch (operator primitives · sandboxing · OpenShell deploy · control-stack ADR · Playbooks · `protolabs/reasoning` default · this reshape) — ready to **cut the release** after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)