### PR TITLE
feat(deploy): headless setup + UI tiers + lean stack (ADR 0010)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Headless setup + UI deployment tiers** (ADR 0010): `--ui {full,console,none}`
+  (env `PROTOAGENT_UI`). `none` serves API + A2A + `/metrics` only — no Gradio,
+  no React console — the lean headless stack. `python server.py --setup` (and
+  boot-time auto-complete in the `none` tier) finishes setup from a validated
+  config — no wizard. `GET /healthz` readiness probe (503 until the graph
+  compiles). `gradio` is now an optional dep (`requirements-core.txt` vs
+  `requirements-ui.txt`); the Docker image defaults to the lean tier
+  (`--build-arg UI=full` for the all-in-one). `--headless` is a deprecated alias
+  for `--ui console`.
+
 ## [0.7.0] - 2026-06-01
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -51,8 +51,18 @@ RUN useradd -m -s /bin/bash -u ${SANDBOX_UID} sandbox
 # the requirements first so this layer stays cached across source-only
 # changes. Forks that need extras (agent-browser, sqlite-vec, pyjwt[crypto])
 # add them to requirements.txt.
-COPY requirements.txt /tmp/requirements.txt
-RUN pip install --no-cache-dir -r /tmp/requirements.txt
+# UI tier (ADR 0010): default 'none' builds the LEAN image (core deps, no
+# Gradio) for a headless server. `--build-arg UI=full` adds the Gradio UI for an
+# all-in-one image. Both requirements files are copied so requirements.txt's
+# `-r` includes resolve. PROTOAGENT_UI is baked so the server runs the matching
+# tier (server.py reads it).
+ARG UI=none
+COPY requirements*.txt /tmp/
+RUN if [ "$UI" = "full" ]; then \
+      pip install --no-cache-dir -r /tmp/requirements.txt; \
+    else \
+      pip install --no-cache-dir -r /tmp/requirements-core.txt; \
+    fi
 
 # Single COPY with a matching .dockerignore covers everything that
 # should ship and excludes .git/, tests/, docs, and dev state. Adding a
@@ -86,6 +96,9 @@ RUN chown -R sandbox:sandbox /opt/protoagent/config
 VOLUME ["/opt/protoagent/config"]
 
 ENV PYTHONPATH=/opt/protoagent
+# UI tier baked from the build arg (ADR 0010): the image runs `--ui $UI` (default
+# 'none' = API + A2A + /metrics only). server.py reads PROTOAGENT_UI.
+ENV PROTOAGENT_UI=${UI}
 
 USER sandbox
 WORKDIR /sandbox

--- a/docs/guides/operator-fork.md
+++ b/docs/guides/operator-fork.md
@@ -83,10 +83,16 @@ a dirty tree on main. Summarize per project (flowing / stalled / blocked), then
 - **(Optional) richer board actions** — add the `protolabs_studio` MCP server to
   `mcp.servers` for `query_board` / `start_agent` / `get_sitrep` etc.
 
-## 6. Deploy isolated
+## 6. Deploy isolated + headless
 
 Give Roxy its own `PROTOAGENT_INSTANCE` (ADR 0004) so its stores don't collide
-with other agents on shared storage; run it on its own port / container.
+with other agents on shared storage; run it on its own port / container. A
+monitor has no operator at a browser, so run the **lean, UI-less tier**
+([ADR 0010](/adr/0010-headless-setup-and-ui-tiers)): `--ui none` (or
+`PROTOAGENT_UI=none`) serves only API + A2A + `/metrics` — no Gradio, no console,
+core deps only. Drop the live config + supply the gateway key via env, and setup
+auto-completes on boot (or run `python server.py --setup` once); `GET /healthz`
+reports readiness. The default Docker image already builds this lean tier.
 
 ---
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -15,6 +15,16 @@ Every env var the template reads at runtime.
 | `AGENT_NAME` | `protoagent` | Short slug. Used as the Prometheus metric prefix, Langfuse trace tag, and in log labels. Should match what you used when forking. |
 | `<AGENT_NAME>_API_KEY` | (unset — no auth) | Expected value of the `X-API-Key` header if you want to require auth on `/a2a` and `/v1/*`. Uppercased, non-alphanumeric → underscore. e.g. `MY_AGENT_API_KEY`. |
 
+## Deployment / UI tier (ADR 0010)
+
+| Variable | Default | What |
+|---|---|---|
+| `PROTOAGENT_UI` | `full` | UI deployment tier (or `--ui`): `full` (Gradio + React console + API/A2A), `console` (console + API/A2A, no Gradio), `none` (API + A2A + `/metrics` only — the lean headless stack). The Docker image defaults to `none`. |
+| `PROTOAGENT_HEADLESS` | (unset) | **Deprecated** alias for `PROTOAGENT_UI=console` (or `--headless`). |
+| `PROTOAGENT_HEADLESS_SETUP` | (unset) | Set `1`/`true` to auto-complete setup from a validated config even outside the `none` tier (no wizard). The `none` tier implies this. |
+
+Setup without the wizard: `python server.py --setup` validates the live config (`model.api_base` set + key resolvable via `secrets.yaml`/`OPENAI_API_KEY`) and writes `.setup-complete`, then exits. In the `none` tier the server auto-completes the same way on boot, or **fails fast** if the config is invalid. Readiness is exposed at `GET /healthz` (503 until the graph compiles).
+
 ## Authentication — A2A bearer token
 
 | Variable | Default | What |

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -564,6 +564,22 @@ def mark_setup_complete() -> None:
     SETUP_MARKER_PATH.touch()
 
 
+def validate_for_headless(config) -> tuple[bool, str]:
+    """Can a headless tier compile the graph from this config without a wizard?
+
+    Returns ``(ok, reason)`` (ADR 0010). Requires a model endpoint and a
+    resolvable key — the wizard's job, done here from config + env instead.
+    Used by ``--setup`` and the boot-time auto-complete; on failure the caller
+    fails fast rather than marking a broken config complete.
+    """
+    if not str(getattr(config, "api_base", "") or "").strip():
+        return False, "model.api_base is not set"
+    key = str(getattr(config, "api_key", "") or "").strip() or os.environ.get("OPENAI_API_KEY", "").strip()
+    if not key:
+        return False, "no model api_key — set model.api_key in config/secrets.yaml or the OPENAI_API_KEY env var"
+    return True, "ok"
+
+
 def reset_setup() -> None:
     """Remove the marker, forcing the wizard to run on next page load.
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -1,0 +1,34 @@
+# Core runtime — API / A2A / LangGraph / stores. Everything the agent needs to
+# run in the `console` and `none` UI tiers (ADR 0010). The Gradio UI lives in
+# requirements-ui.txt; `requirements.txt` = core + ui (the all-in-one install).
+httpx>=0.27
+uvicorn>=0.30
+langfuse>=3.0
+prometheus-client>=0.20
+pyyaml>=6.0
+ruamel.yaml>=0.18  # round-trip YAML that preserves comments in config/langgraph-config.yaml when the drawer writes back edits
+websockets>=12.0
+
+# LangGraph agent backend. Keep the langchain-* lower bounds on the 1.x
+# line — a 0.3.x core/openai resolves against langchain 1.x into a broken
+# `langchain_core` namespace (surfaced by checks.yml in PR #171).
+langchain>=1.2.3
+langchain-core>=1.0
+langgraph>=1.1.0
+langchain-openai>=1.0
+# Durable conversation history — SQLite checkpointer so multi-turn chats
+# survive a server restart (graph/checkpointer.py).
+langgraph-checkpoint-sqlite>=2.0
+
+# MCP client — connect external Model Context Protocol servers (stdio /
+# streamable-HTTP); their tools become agent tools. See tools/mcp_tools.py.
+# Pulls the `mcp` SDK transitively (also used by examples/mcp/echo_server.py).
+langchain-mcp-adapters>=0.2,<0.3
+
+# Starter tools (tools/lg_tools.py)
+ddgs>=9.0
+beautifulsoup4>=4.12
+
+# Scheduler (scheduler/local.py — cron expression parsing for the
+# bundled local backend; the Workstacean adapter doesn't need this)
+croniter>=2.0

--- a/requirements-ui.txt
+++ b/requirements-ui.txt
@@ -1,0 +1,5 @@
+# UI deps — the Gradio chat console, needed only by the `full` UI tier
+# (ADR 0010). `console`/`none` tiers never import it. Kept separate so a
+# headless server (e.g. `--ui none`) installs only requirements-core.txt and
+# skips Gradio (the heaviest, PyInstaller-hostile dependency).
+gradio>=5.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,32 +1,6 @@
-gradio>=5.0
-httpx>=0.27
-uvicorn>=0.30
-langfuse>=3.0
-prometheus-client>=0.20
-pyyaml>=6.0
-ruamel.yaml>=0.18  # round-trip YAML that preserves comments in config/langgraph-config.yaml when the drawer writes back edits
-websockets>=12.0
-
-# LangGraph agent backend. Keep the langchain-* lower bounds on the 1.x
-# line — a 0.3.x core/openai resolves against langchain 1.x into a broken
-# `langchain_core` namespace (surfaced by checks.yml in PR #171).
-langchain>=1.2.3
-langchain-core>=1.0
-langgraph>=1.1.0
-langchain-openai>=1.0
-# Durable conversation history — SQLite checkpointer so multi-turn chats
-# survive a server restart (graph/checkpointer.py).
-langgraph-checkpoint-sqlite>=2.0
-
-# MCP client — connect external Model Context Protocol servers (stdio /
-# streamable-HTTP); their tools become agent tools. See tools/mcp_tools.py.
-# Pulls the `mcp` SDK transitively (also used by examples/mcp/echo_server.py).
-langchain-mcp-adapters>=0.2,<0.3
-
-# Starter tools (tools/lg_tools.py)
-ddgs>=9.0
-beautifulsoup4>=4.12
-
-# Scheduler (scheduler/local.py — cron expression parsing for the
-# bundled local backend; the Workstacean adapter doesn't need this)
-croniter>=2.0
+# All-in-one install (the `full` UI tier) = core + the Gradio UI (ADR 0010).
+# `pip install -r requirements.txt` is unchanged — it still gets everything.
+# For a lean headless deploy (--ui none/console) install requirements-core.txt
+# instead, which skips Gradio.
+-r requirements-core.txt
+-r requirements-ui.txt

--- a/server.py
+++ b/server.py
@@ -30,6 +30,7 @@ import json
 import logging
 import os
 import re
+import sys
 import time
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
@@ -99,8 +100,13 @@ _event_bus = EventBus()  # Server→client SSE push channel (ADR 0003). Process-
                          # streams to connected consoles.
 
 
-def _init_langgraph_agent():
+def _init_langgraph_agent(headless_setup: bool = False):
     """Initialize the LangGraph backend — setup-aware.
+
+    ``headless_setup`` (ADR 0010): when True (the ``none`` UI tier or
+    ``PROTOAGENT_HEADLESS_SETUP``), there is no wizard to finish setup, so a
+    validated config auto-completes setup; an invalid one fails fast (SystemExit)
+    rather than silently serving a dead graph.
 
     Always loads the config + checkpointer so the wizard and drawer
     can introspect what's on disk. The compiled graph is only built
@@ -115,7 +121,13 @@ def _init_langgraph_agent():
     global _plugin_tools, _plugin_skill_dirs, _plugin_meta
 
     from graph.config import LangGraphConfig
-    from graph.config_io import CONFIG_YAML_PATH, ensure_live_config, is_setup_complete
+    from graph.config_io import (
+        CONFIG_YAML_PATH,
+        ensure_live_config,
+        is_setup_complete,
+        mark_setup_complete,
+        validate_for_headless,
+    )
 
     # Seed the untracked live config from the .example template on first run.
     # CONFIG_YAML_PATH honors PROTOAGENT_CONFIG_DIR (the desktop sidecar points
@@ -136,13 +148,23 @@ def _init_langgraph_agent():
     _checkpointer = _build_checkpointer(_graph_config)
 
     if not is_setup_complete():
-        _graph = None
-        _knowledge_store = None
-        log.info(
-            "Setup wizard has not been completed — graph not compiled. "
-            "Open the UI to finish setup.",
-        )
-        return
+        if headless_setup:
+            # No wizard in this tier — auto-complete from a validated config,
+            # else fail fast (ADR 0010) rather than serve a dead graph.
+            ok, reason = validate_for_headless(_graph_config)
+            if not ok:
+                log.error("Headless setup cannot complete: %s", reason)
+                raise SystemExit(2)
+            mark_setup_complete()
+            log.info("Headless setup auto-completed from a validated config.")
+        else:
+            _graph = None
+            _knowledge_store = None
+            log.info(
+                "Setup wizard has not been completed — graph not compiled. "
+                "Open the UI to finish setup (or run headless: --ui none / --setup).",
+            )
+            return
 
     from graph.agent import create_agent_graph
     from tools.lg_tools import get_all_tools
@@ -1877,16 +1899,58 @@ def _main():
     parser.add_argument("--port", type=int, default=7870)
     parser.add_argument("--config", type=str, default=None)
     parser.add_argument(
+        "--ui",
+        choices=["full", "console", "none"],
+        default=os.environ.get("PROTOAGENT_UI", "").lower() or None,
+        help="UI deployment tier (ADR 0010): 'full' = Gradio + React console + "
+             "API/A2A (local default); 'console' = React console + API/A2A, no "
+             "Gradio (desktop sidecar); 'none' = API + A2A + /metrics only "
+             "(headless servers / the lighter stack). Env: PROTOAGENT_UI.",
+    )
+    parser.add_argument(
         "--headless",
         action="store_true",
         default=os.environ.get("PROTOAGENT_HEADLESS", "").lower() in ("1", "true", "yes"),
-        help="Serve only the API / A2A / React console — skip the Gradio UI. "
-             "Used by the desktop sidecar (the React console is the UI there, "
-             "and Gradio is the heaviest dependency to freeze).",
+        help="DEPRECATED alias for --ui console.",
+    )
+    parser.add_argument(
+        "--setup",
+        action="store_true",
+        help="Headless setup (ADR 0010): validate the live config + mark setup "
+             "complete, then exit. No wizard/UI needed.",
     )
     args = parser.parse_args()
     _active_port = args.port
-    headless = args.headless
+
+    # Resolve the UI tier: explicit --ui/PROTOAGENT_UI wins; else the deprecated
+    # --headless/PROTOAGENT_HEADLESS maps to 'console'; else default 'full'.
+    if args.ui:
+        ui = args.ui
+    elif args.headless:
+        ui = "console"
+        log.warning("--headless / PROTOAGENT_HEADLESS is deprecated — use --ui console.")
+    else:
+        ui = "full"
+
+    # `--setup` one-shot: complete setup headlessly and exit.
+    if args.setup:
+        from graph.config import LangGraphConfig
+        from graph.config_io import (
+            CONFIG_YAML_PATH, ensure_live_config, mark_setup_complete, validate_for_headless,
+        )
+        ensure_live_config()
+        cfg = LangGraphConfig.from_yaml(CONFIG_YAML_PATH)
+        ok, reason = validate_for_headless(cfg)
+        if not ok:
+            print(f"setup: config invalid — {reason}", file=sys.stderr)
+            raise SystemExit(2)
+        mark_setup_complete()
+        print("setup: complete — .setup-complete written; the graph will compile on next start.")
+        raise SystemExit(0)
+
+    # Headless setup applies when there is no wizard to finish it: the 'none'
+    # tier, or an explicit opt-in env (ADR 0010).
+    headless_setup = ui == "none" or os.environ.get("PROTOAGENT_HEADLESS_SETUP", "").lower() in ("1", "true", "yes")
 
     # Initialize observability
     import tracing
@@ -1894,22 +1958,29 @@ def _main():
     tracing.init()
     metrics.init()
 
-    _init_langgraph_agent()
+    _init_langgraph_agent(headless_setup=headless_setup)
 
-    # Optional Gradio chat UI — skipped entirely in headless mode so the
-    # frozen sidecar never imports Gradio (its biggest, PyInstaller-hostile
-    # dependency). The React console is the UI in that mode.
+    # Gradio chat UI — only the 'full' tier (ADR 0010). 'console'/'none' never
+    # import Gradio (its biggest, PyInstaller-hostile dep). If it's not installed
+    # in 'full' (lean deps), degrade to 'console' rather than crash.
     blocks = None
-    if not headless:
-        from chat_ui import create_chat_app
-        blocks = create_chat_app(
-            chat_fn=chat,
-            title=agent_name(),
-            subtitle="protoAgent",
-            placeholder="Send a message...",
-            pwa=True,
-            settings=_build_settings_callbacks(),
-        )
+    if ui == "full":
+        try:
+            from chat_ui import create_chat_app
+            blocks = create_chat_app(
+                chat_fn=chat,
+                title=agent_name(),
+                subtitle="protoAgent",
+                placeholder="Send a message...",
+                pwa=True,
+                settings=_build_settings_callbacks(),
+            )
+        except ImportError:
+            log.warning(
+                "gradio not installed — degrading --ui full to console. "
+                "Install it (`pip install -r requirements-ui.txt`) for the Gradio UI.",
+            )
+            ui = "console"
 
     import uvicorn
     from fastapi import FastAPI, Request
@@ -2304,6 +2375,18 @@ def _main():
             return {"enabled": False, "cleared": False}
         return {"enabled": True, "cleared": _goal_controller.store.clear(session_id)}
 
+    # --- Health / readiness (ADR 0010) -------------------------------------
+    # Reflects whether the graph actually compiled — the only readiness signal
+    # in the 'none' tier (no UI to eyeball). 503 until ready, for k8s probes.
+    @fastapi_app.get("/healthz", include_in_schema=False)
+    async def _healthz():
+        from graph.config_io import is_setup_complete
+        ready = _graph is not None
+        return JSONResponse(
+            {"ok": ready, "graph_compiled": ready, "setup_complete": is_setup_complete(), "ui": ui},
+            status_code=200 if ready else 503,
+        )
+
     # --- Playbooks (skills surface, ADR 0009) ------------------------------
     # Browse + manage the procedural-memory skill index (skills.db) the operator
     # was otherwise blind to. "Playbooks" is the operator-facing name for the
@@ -2605,16 +2688,17 @@ def _main():
         except ImportError:
             pass
 
-    # --- React operator console --------------------------------------------
-    from operator_api.web import mount_react_app
-
-    web_dist_dir = Path(__file__).parent / "apps" / "web" / "dist"
-    if mount_react_app(fastapi_app, web_dist_dir):
-        log.info("React operator console mounted at /app")
-
-    # --- Static + PWA assets -----------------------------------------------
+    # --- React operator console (tiers full/console; skipped in 'none') ------
     static_dir = Path(__file__).parent / "static"
-    if static_dir.exists():
+    if ui != "none":
+        from operator_api.web import mount_react_app
+
+        web_dist_dir = Path(__file__).parent / "apps" / "web" / "dist"
+        if mount_react_app(fastapi_app, web_dist_dir):
+            log.info("React operator console mounted at /app")
+
+    # --- Static + PWA assets (skipped in 'none') ---------------------------
+    if ui != "none" and static_dir.exists():
         manifest_path = static_dir / "manifest.json"
         if manifest_path.exists():
             @fastapi_app.get("/manifest.json", include_in_schema=False)
@@ -2632,11 +2716,8 @@ def _main():
 
         fastapi_app.mount("/static", StaticFiles(directory=str(static_dir)), name="static")
 
-    # --- Mount Gradio at root (skipped when headless) -----------------------
-    if headless:
-        app = fastapi_app
-        log.info("Starting %s (headless — no Gradio) on http://0.0.0.0:%d", agent_name(), args.port)
-    else:
+    # --- Mount Gradio at root (only the 'full' tier) ------------------------
+    if ui == "full" and blocks is not None:
         import gradio as gr
 
         app = gr.mount_gradio_app(
@@ -2644,7 +2725,10 @@ def _main():
             footer_links=[],
             favicon_path=str(static_dir / "favicon.svg") if (static_dir / "favicon.svg").exists() else None,
         )
-        log.info("Starting %s on http://0.0.0.0:%d", agent_name(), args.port)
+        log.info("Starting %s (ui=full) on http://0.0.0.0:%d", agent_name(), args.port)
+    else:
+        app = fastapi_app
+        log.info("Starting %s (ui=%s) on http://0.0.0.0:%d", agent_name(), ui, args.port)
 
     uvicorn.run(app, host="0.0.0.0", port=args.port)
 

--- a/tests/test_headless_setup.py
+++ b/tests/test_headless_setup.py
@@ -1,0 +1,52 @@
+"""Tests for headless setup validation (ADR 0010)."""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.config import LangGraphConfig
+from graph.config_io import validate_for_headless
+
+
+@pytest.fixture(autouse=True)
+def _no_openai_key(monkeypatch):
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    yield
+
+
+def test_ok_with_api_base_and_config_key():
+    ok, reason = validate_for_headless(LangGraphConfig(api_key="sk-test"))
+    assert ok and reason == "ok"
+
+
+def test_ok_with_env_key(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-env")
+    ok, _ = validate_for_headless(LangGraphConfig(api_key=""))
+    assert ok
+
+
+def test_fail_without_any_key():
+    ok, reason = validate_for_headless(LangGraphConfig(api_key=""))
+    assert not ok and "api_key" in reason
+
+
+def test_fail_without_api_base():
+    ok, reason = validate_for_headless(LangGraphConfig(api_base="", api_key="sk-test"))
+    assert not ok and "api_base" in reason
+
+
+def test_marker_roundtrip(tmp_path, monkeypatch):
+    # Point the config dir at a temp location so we don't touch the real marker.
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path))
+    import importlib
+
+    import graph.config_io as cio
+    importlib.reload(cio)
+    try:
+        assert cio.is_setup_complete() is False
+        cio.mark_setup_complete()
+        assert cio.is_setup_complete() is True
+        cio.reset_setup()
+        assert cio.is_setup_complete() is False
+    finally:
+        importlib.reload(cio)  # restore module state for other tests


### PR DESCRIPTION
Implements ADR 0010 — complete setup without the wizard, and a UI-less lean stack.

## UI tiers — `--ui {full,console,none}` (env `PROTOAGENT_UI`)
- **full** — Gradio + React console + API/A2A (local default)
- **console** — console + API/A2A, no Gradio (= today's `--headless`, now a deprecated alias)
- **none** — **API + A2A + `/metrics` only** (no Gradio, no console) — the lean headless stack

`server.py` gates the Gradio mount on `full` and the console/`/static` mounts on `!= none`; `full` degrades to `console` if gradio isn't installed.

## Headless setup (no wizard)
- `python server.py --setup` → validate the live config (`validate_for_headless`: `api_base` + key via `secrets.yaml`/`OPENAI_API_KEY`) → write `.setup-complete` → exit.
- The `none` tier (or `PROTOAGENT_HEADLESS_SETUP`) **auto-completes on boot** from a validated config, or **fails fast** (`SystemExit`) on an invalid one — never serves a dead graph.
- `GET /healthz` readiness (503 until the graph compiles) — the only signal in `none`.

## Lean dependency stack
`gradio` is now optional: **`requirements-core.txt`** (lean) + **`requirements-ui.txt`** (gradio); `requirements.txt` = both, so existing `pip install -r requirements.txt` is unchanged. **Dockerfile `--build-arg UI`** (default `none` → lean image, bakes `PROTOAGENT_UI`); `UI=full` for the all-in-one.

## Verification
- Live smoke: `--setup` writes the marker + exits 0 on a valid config; exits **2** with the concrete reason + **no marker** on a missing key.
- `tests/test_headless_setup.py`: `validate_for_headless` (key via config/env, fail reasons) + marker roundtrip. Full Python **886**; web e2e **38**; `docs:build` clean.
- Docs: env-vars (`PROTOAGENT_UI`/`HEADLESS_SETUP`, `--setup`, `/healthz`) + operator-fork (Roxy → `--ui none`).

Directly unblocks Roxy's headless run. Staged in `[Unreleased]` for the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)