### PR TITLE
docs: reconcile drift after the recent releases

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+- Reconcile drift after the recent releases: fix the deploy guide's stale
+  "every merge auto-cuts a patch" note (releases are manual now), document the
+  UI tiers + `--build-arg UI=full` for the image, link the orphaned "Eval your
+  fork" guide, and run the OpenShell deploy example with `--ui none`.
+
 ## [0.8.0] - 2026-06-01
 
 ### Added

--- a/deploy/openshell/create-protoagent-sandbox.sh
+++ b/deploy/openshell/create-protoagent-sandbox.sh
@@ -34,6 +34,6 @@ openshell sandbox create \
   --image "$IMAGE" \
   --publish "127.0.0.1:${PORT}:7870" \
   --mount "$CONFIG:/sandbox/config/langgraph-config.yaml:ro" \
-  -- python server.py --port 7870
+  -- python server.py --port 7870 --ui none
 
 echo "✓ protoAgent sandbox created. Inspect: openshell sandbox list"

--- a/deploy/openshell/k8s/protoagent-sandbox.yaml
+++ b/deploy/openshell/k8s/protoagent-sandbox.yaml
@@ -27,7 +27,7 @@ spec:
       containers:
         - name: protoagent
           image: ghcr.io/protolabsai/protoagent:latest
-          command: ["python", "server.py", "--port", "7870"]
+          command: ["python", "server.py", "--port", "7870", "--ui", "none"]  # lean headless tier (ADR 0010)
           ports:
             - containerPort: 7870
           env:

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,7 @@ export default defineConfig({
             { text: "Releasing", link: "/guides/releasing" },
             { text: "Build an operator fork (Roxy)", link: "/guides/operator-fork" },
             { text: "Sandboxing & egress", link: "/guides/sandboxing" },
+            { text: "Eval your fork", link: "/guides/evals" },
           ],
         },
       ],

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -88,11 +88,19 @@ services:
 
 Watchtower polls `latest` every 60 seconds and recreates the container when the image hash changes.
 
+> **UI tier (ADR 0010):** the image defaults to **`--ui none`** — API + A2A +
+> `/metrics`, no console, no Gradio, core deps only (the lean server stack). For
+> the Gradio UI in the image, build with **`--build-arg UI=full`** (adds
+> `gradio`); it then runs `full`. Setup is headless in `none` — drop a config +
+> `OPENAI_API_KEY`, the graph compiles on boot (or run `--setup`); `GET /healthz`
+> reports readiness. See [Sandboxing & egress](/guides/sandboxing) and the
+> [env-vars reference](/reference/environment-variables#deployment-ui-tier-adr-0010).
+
 ## 7. Cut a release
 
-From the Actions tab, run `prepare-release.yml` manually and pick `patch` / `minor` / `major`. It opens a bump PR, auto-merges it, and tags `vX.Y.Z`, which triggers `release.yml` → stable semver Docker tags → GitHub release → Discord post (if configured).
+From the Actions tab, run `prepare-release.yml` manually and pick `patch` / `minor` / `major`. It opens a bump PR, auto-merges it once the required checks pass, and tags `vX.Y.Z`, which triggers `release.yml` → stable semver Docker tags → GitHub release → Discord post (if configured).
 
-After the first manual run, every non-release PR merge auto-triggers `prepare-release.yml` with a `patch` bump. Manual dispatch is only for `minor` / `major` bumps.
+Releases are **manual / on-demand** — merging a PR does **not** cut a release. See the [Releasing runbook](/guides/releasing) for the changelog protocol + the branch ruleset.
 
 ## Related
 


### PR DESCRIPTION
Tidy pass after ADRs 0005–0010 / v0.5–v0.8. Fixes real drift + small gaps.

- **Deploy guide §7 was stale**: claimed "every non-release merge auto-triggers a patch bump" — that's the *old* cadence; releases are **manual/on-demand** since v0.4.0. Corrected + linked the releasing runbook.
- **Deploy guide UI tiers (ADR 0010)**: documents that the image defaults to `--ui none` (lean API/A2A, no console/Gradio) and `--build-arg UI=full` for the Gradio image; headless setup + `/healthz` noted.
- **Orphaned guide linked**: "Eval your fork" (`docs/guides/evals.md`) wasn't in the sidebar.
- **OpenShell example** now runs `--ui none` (the lean tier) in the sandbox-create script + the k8s manifest.

Also refreshed the local (gitignored) `HANDOFF.md` to v0.8.0 state. Docs-only; `docs:build` clean. The 2 `codex/*` local branches are pre-session unmerged WIP — left untouched (not safe to prune blind).

🤖 Generated with [Claude Code](https://claude.com/claude-code)