### PR TITLE
fix(mcp): inherit parent env for stdio MCP servers by default

### DIFF
--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -9,6 +9,7 @@ The real stdio round-trip is covered by the end-to-end check in the PR.
 from __future__ import annotations
 
 import asyncio
+import os
 from types import SimpleNamespace
 
 from graph.config import LangGraphConfig
@@ -22,7 +23,20 @@ def test_stdio_connection_mapping() -> None:
     conn = _server_connection(
         {"name": "fs", "transport": "stdio", "command": "npx", "args": ["-y", "x"], "env": {"A": "1"}}
     )
-    assert conn == {"transport": "stdio", "command": "npx", "args": ["-y", "x"], "env": {"A": "1"}}
+    # stdio servers inherit the parent env by default, with the per-server
+    # override layered on top.
+    assert conn["transport"] == "stdio"
+    assert conn["command"] == "npx"
+    assert conn["args"] == ["-y", "x"]
+    assert conn["env"] == {**os.environ, "A": "1"}
+
+
+def test_stdio_connection_inherit_env_false() -> None:
+    # inherit_env: false → only the explicit per-server env (no parent env).
+    conn = _server_connection(
+        {"name": "fs", "transport": "stdio", "command": "npx", "inherit_env": False, "env": {"A": "1"}}
+    )
+    assert conn["env"] == {"A": "1"}
 
 
 def test_http_connection_mapping_and_alias() -> None:

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -14,6 +14,7 @@ Configuring a server is the opt-in act; MCP is off unless ``mcp.enabled`` is set
 from __future__ import annotations
 
 import logging
+import os
 from typing import Any
 
 log = logging.getLogger("protoagent.mcp")
@@ -50,8 +51,17 @@ def _server_connection(server: dict) -> dict | None:
     if not command:
         return None
     conn = {"transport": "stdio", "command": str(command), "args": list(server.get("args") or [])}
-    if server.get("env"):
-        conn["env"] = dict(server["env"])
+    # Pass the parent environment through to the stdio subprocess by default.
+    # The MCP SDK's stdio client uses a MINIMAL default env, so custom vars set
+    # on the agent process (API keys, base URLs) are stripped from the server —
+    # a common failure in containerized deploys where those are injected into
+    # the agent's env, not the config YAML. Set ``inherit_env: false`` on the
+    # server to opt out; a per-server ``env:`` block always overrides on top.
+    server_env = {str(k): str(v) for k, v in (server.get("env") or {}).items()}
+    if server.get("inherit_env", True):
+        conn["env"] = {**os.environ, **server_env}
+    elif server_env:
+        conn["env"] = server_env
     if server.get("cwd"):
         conn["cwd"] = str(server["cwd"])
     return conn


### PR DESCRIPTION
## Problem
stdio MCP servers don't see environment variables set on the protoAgent process. The MCP SDK's stdio client uses a **minimal default env** (PATH/HOME-ish), so custom vars like API keys / base URLs are stripped — the server reads them as unset, **discovery fails, and 0 tools bind**.

This is silent on a dev box (vars often in the YAML `env:` block) but bites hard in **containerized deploys**, where secrets are injected into the agent's environment by the orchestrator (compose/k8s/Infisical), not written into the config. Hit this bringing up a fork under Docker: the MCP server bound 0 tools until the env was passed through.

## Fix
`_server_connection` now merges `os.environ` into the stdio connection `env` **by default**:
- opt out per server with `inherit_env: false`
- a per-server `env:` block still overrides individual keys (`{**os.environ, **server_env}`)

No change for HTTP/SSE transports. Existing configs that relied on an explicit `env:` block keep working (it now layers on top of the inherited env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)