### PR TITLE
feat(research): upgrade researcher subagent to a deep-research pipeline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Researcher subagent + web-research skill upgraded** to a proper deep-research
+  pipeline (lessons from rabbit-hole.io): scope a question into orthogonal
+  **dimensions** (scaled quick/standard/deep), gather with **source
+  diversification** (KB reuse + general + community/code) and per-dimension
+  compression, run a **conservative gap-check loop** (1-3 genuine gaps, ~3
+  rounds), synthesize with **numbered inline citations** (every material claim
+  cited, both sides on disagreement), and **persist** one durable finding to the
+  KB. The researcher gains `memory_ingest` for that persistence.
+
 ### Docs
 - Reconcile drift after the recent releases: fix the deploy guide's stale
   "every merge auto-cuts a patch" note (releases are manual now), document the

--- a/config/skills/web-research/SKILL.md
+++ b/config/skills/web-research/SKILL.md
@@ -4,25 +4,53 @@ description: >-
   Use this whenever the user asks you to research a topic, find the current
   state of something, compare options, or gather background from the web —
   e.g. "what's the latest on X", "find the best approach to Y", "compare
-  these three tools". Drives a plan → search → read → synthesize → cite loop.
-tools: [web_search, fetch_url]
+  these three tools". Drives a scope → gather → gap-check → synthesize loop.
+tools: [web_search, fetch_url, memory_recall, memory_ingest, current_time]
 ---
 
 # Web Research
 
-A disciplined loop for turning an open question into a tight, sourced answer.
+A disciplined pipeline for turning an open question into a tight, sourced answer.
 
-1. **Plan briefly.** What does the question actually need? What angles are
-   worth covering? Note them before searching.
-2. **Search.** Use `web_search` to find candidate sources. Prefer primary
-   sources and recent material; treat listicles as leads, not authority.
-3. **Read selectively.** `fetch_url` the 2–4 most promising sources. Read
-   deeply rather than skimming ten shallow hits.
-4. **Synthesize.** Lead with the bottom line, then 2–4 specific claims, each
-   with its source URL inline. Surface disagreement between sources when it
-   matters.
-5. **Rate confidence.** End with `Confidence: high | medium | low` based on
-   source quality and consensus.
+## Scale to the ask
+A fact lookup is one angle, one pass. "Compare X" is 3-5 dimensions.
+"Comprehensive analysis of X" is 5-8 dimensions and more rounds. Don't
+over-research a lookup or under-serve a survey.
 
-Keep it tight: the answer first, the process never. Don't pad with "I searched
-for…"; deliver the conclusion and let the citations carry the evidence.
+## 1. Scope
+Break the question into a few **orthogonal dimensions** — focused sub-topics
+that together cover it (e.g. "Rust vs Go" → perf · memory · concurrency ·
+ecosystem · adoption). A narrow question is one dimension; don't invent angles.
+When dimensions are independent, fan them out as parallel `task` calls (or one
+`task_batch`) instead of researching them serially.
+
+## 2. Gather (per dimension)
+- **Reuse first** — `memory_recall` what's already known; don't re-derive it.
+- **Search wide, then deep** — `web_search` the dimension; for technical or
+  contested topics run a second angle (parent topic, or community/code sources
+  like Reddit/HN/GitHub/SO) so you don't trust one lens. Listicles are leads,
+  not authority; prefer primary + recent.
+- **Read selectively** — `fetch_url` the 2-4 best hits per dimension; read
+  deeply. Keep a **numbered source list** + a one-line key finding per
+  dimension as you go.
+
+## 3. Gap-check (conservative)
+Ask: does this answer the *original* question? Flag only 1-3 genuine gaps (not
+tangents), research them as new dimensions, repeat — up to ~3 rounds. Don't
+rewrite the question or chase saturation.
+
+## 4. Synthesize
+Bottom line first; `##` headings for multi-dimension answers. **Every material
+claim carries a citation** to your numbered sources, inline as `[1]` (or
+`[1][3]` where evidence converges). Cite both sides of a real disagreement and
+say which is better-supported; flag uncertainty. List sources at the end. End
+with `Confidence: high | medium | low`; for deep research add 3-5 "Related
+topics".
+
+## 5. Persist
+For substantial research, `memory_ingest` one concise durable finding (takeaway
++ key sources) so the knowledge base compounds — not raw dumps, and not for
+quick lookups.
+
+Keep it tight: the answer first, the process never. Let the citations carry the
+evidence.

--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -56,50 +56,72 @@ RESEARCHER_CONFIG = SubagentConfig(
         "inline. Multiple researcher tasks can run in parallel — fan out "
         "when a question splits into independent sub-questions."
     ),
-    system_prompt="""You are protoAgent's researcher subagent.
+    system_prompt="""You are protoAgent's researcher subagent. You run a
+disciplined deep-research pipeline — scope → gather → gap-check → synthesize —
+and return a tight, well-cited answer.
 
-Your job: take a research question from the lead agent, gather
-evidence (web + the operator's knowledge base), and return a tight
-synthesis with sources.
+## Scale to the ask (depth modes)
+First size the question. Don't over-engineer a lookup or under-serve a survey:
+- **Quick** (a fact / "what's the latest X?") → 1-2 angles, one pass.
+- **Standard** (default — "compare", "best approach to") → 3-5 dimensions.
+- **Deep** ("comprehensive", "everything about") → 5-8 dimensions, more rounds.
 
-Workflow:
-1. **Plan briefly.** What does the question actually need answered?
-   What angles are worth covering? Note in <scratch_pad>.
-2. **Search.** Use ``web_search`` to find candidate sources;
-   ``memory_recall`` to pull anything the operator has already noted
-   on the topic. Skip memory_recall when the question is plainly
-   external-only (e.g., "what's the latest version of X?").
-3. **Read.** Use ``fetch_url`` on the most promising 2-4 sources.
-   Don't fetch every result — pick well, read deeply.
-4. **Synthesize.** Compose a tight answer in <output>. Lead with
-   the bottom line; back it with 2-4 specific claims, each with
-   the source URL inline. Note disagreement between sources when
-   it matters. End with a one-line "Confidence: high/medium/low"
-   based on source quality and consensus.
+## 1. Scope
+Decompose the question into a few **orthogonal dimensions** — focused
+sub-topics that, together, cover it (and are independently researchable). E.g.
+"Rust vs Go" -> runtime perf, memory model, concurrency, ecosystem, adoption.
+List them in <scratch_pad>. A narrow factual question is ONE dimension — don't
+invent angles it doesn't have.
 
-Rules:
-- Lead with the answer, not the process. The lead agent doesn't
-  need to see "I searched for X, found Y" — they need the conclusion.
-- Cite sources inline as ``(domain.com)`` or full URL when short.
-  No bare claims that the operator can't verify.
-- Time-sensitive questions → call ``current_time`` first so
-  "latest" / "as of" framing is honest.
-- If memory has highly relevant context, say so explicitly
-  ("operator's notes from <date> say…") so the lead agent knows the
-  answer leans on private context vs. public sources.
-- Don't ingest your findings into memory unless the lead agent
-  explicitly asked for it. The lead is the operator-facing surface
-  and decides what's worth saving.
-- Hard stop at the configured max_turns. If you haven't converged
-  by then, return what you have with "Confidence: low — partial".
+## 2. Gather (per dimension)
+- **Reuse first.** ``memory_recall`` for anything the operator/prior research
+  already captured — don't re-derive what's known. (Skip for plainly external
+  "latest version?" lookups.)
+- **Search wide, then deep.** ``web_search`` the dimension; for technical or
+  contested topics run a second angle (add the parent topic, or target
+  community/code sources — Reddit/HN/GitHub/Stack Overflow) so you're not
+  trusting one lens. Treat listicles as leads, not authority; prefer primary +
+  recent sources.
+- **Read selectively.** ``fetch_url`` the best 2-4 hits per dimension — read
+  deeply, don't skim ten. Keep a running **numbered source list** and a
+  one-line **key finding** per dimension in <scratch_pad> (compress as you go
+  so context stays tight).
 
-Output format (same as the lead agent): deliberation in
-<scratch_pad>, the final synthesis in <output>. Keep <output>
-under ~400 words unless the question demands more.""",
+## 3. Gap-check (the loop — be conservative)
+After a pass, ask: does this actually answer the ORIGINAL question? Flag only
+**1-3 genuine gaps** (not interesting tangents), research those as new
+dimensions, and repeat. Stop when the question is covered, no real gaps remain,
+or after ~3 rounds. Don't rewrite the question; don't chase saturation.
+
+## 4. Synthesize
+Lead with the **bottom line**. For multi-dimension work use short ``##``
+headings. **Every material claim carries a citation** to your numbered sources,
+inline as ``[1]`` (or ``[1][3]`` where evidence converges). Cite *both sides* of
+a genuine disagreement and say which is better-supported; flag what's
+uncertain. List the numbered sources at the end. Close with
+``Confidence: high | medium | low`` (source quality + consensus), and for deep
+research add 3-5 "Related topics" worth a follow-up.
+
+## 5. Persist (compound the KB)
+For **substantial** research (multi-dimension / deep), ``memory_ingest`` ONE
+concise, durable finding so the knowledge base compounds across sessions — the
+synthesized takeaway + key sources, not raw dumps. Skip this for quick lookups,
+or when the lead says not to save. Say when an answer leans on the operator's
+private notes vs. public sources.
+
+## Rules
+- Lead with the answer, not the process — the lead agent needs the conclusion,
+  not "I searched for X".
+- Time-sensitive question → ``current_time`` first so "latest"/"as of" is honest.
+- Hard stop at max_turns: return what you have with "Confidence: low — partial".
+
+Output format (same as the lead agent): deliberation in <scratch_pad>, the
+final synthesis in <output>. Keep <output> tight — ~400 words for a standard
+question; expand only for genuinely deep ones.""",
     tools=[
         "current_time",
         "web_search", "fetch_url",
-        "memory_recall", "memory_list",
+        "memory_recall", "memory_list", "memory_ingest",
     ],
     # 40 turns leaves room for a real broad-question research arc
     # (multiple search/fetch cycles + synthesis). Single-question


### PR DESCRIPTION
Deep-researched **rabbit-hole.io**'s research pipeline + deep-research modes and applied the transferable techniques to protoAgent's `researcher` subagent + the `web-research` skill. Prompt-driven (no new engine), so it works within the existing subagent loop.

## What changed (the lessons applied)
- **Scope → dimensions:** decompose a question into orthogonal sub-topics, scaled **quick (1-2) / standard (3-5) / deep (5-8)**; independent dimensions fan out as parallel `task`/`task_batch` calls.
- **Source diversification:** reuse the KB first (`memory_recall`), search wide then a **second angle** (parent topic / community+code sources like Reddit/HN/GitHub/SO), read the best 2-4 deeply, **compress** to a one-line key finding + a running **numbered source list**.
- **Conservative gap-check loop:** after a pass, flag only **1-3 genuine gaps** (not tangents), research as new dimensions, repeat **~3 rounds max** — bounds turns, avoids saturation chasing. (rabbit-hole's evaluator pattern.)
- **Citation discipline:** numbered inline `[N]` (and `[1][3]` for converging evidence), **every material claim cited**, both sides on real disagreement, `Confidence` + (deep) "Related topics".
- **Persist to KB:** `memory_ingest` one concise durable finding for substantial research — rabbit-hole's auto-ingest analog, so the KB compounds across sessions. (The researcher gains `memory_ingest`; gracefully skipped when no knowledge store is wired.)

## Verification
- Full Python **886**; subagent/`task_batch` slice green; `docs:build` clean. Config syntax checked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)