### PR TITLE
feat: deep-research workflow with adversarial review (ADR 0011)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Deep-research workflow with adversarial review** (ADR 0011): a bundled
+  `deep-research` recipe (`run_workflow`/`/deep-research`) that orchestrates a
+  six-stage DAG — `research ∥ dissent → gap_fill → antagonist ∥ verify →
+  synthesize` — to fix the one-sided, self-graded ceiling of a single researcher.
+  Three new subagent roles back it: an **`antagonist`** (steelmans the opposing
+  case, attacks weak claims, hunts disconfirming evidence), an independent
+  **`verifier`** (labels material claims supported/unsupported/uncertain), and a
+  **`synthesizer`** that writes a balanced report — folding the opposition into a
+  "Counterpoints & caveats" section, dropping unverified claims, and only earning
+  a high `Confidence` when the opposition was answered.
+
 ### Changed
 - **Researcher subagent + web-research skill upgraded** to a proper deep-research
   pipeline (lessons from rabbit-hole.io): scope a question into orthogonal

--- a/docs/adr/0011-deep-research-workflow.md
+++ b/docs/adr/0011-deep-research-workflow.md
@@ -1,0 +1,119 @@
+# ADR 0011 — Deep-research workflow with adversarial review
+
+- **Status:** Accepted (2026-06-01) — design + implementation (recipe + roles ship with this ADR)
+- **Date:** 2026-06-01
+- **Deciders:** Josh Mabry; protoAgent maintainers
+- **Tags:** research, workflows, subagents, adversarial, orchestration
+- **Supersedes / Superseded by:** —
+
+> Accepted. A single `researcher` subagent — even with the upgraded
+> deep-research prompt (ADR-adjacent) — caps out: a live eval produced a
+> well-cited but **one-sided, consensus-shaped** report with `Confidence: high`
+> and **zero adversarial pressure**, and its gap-filling is an invisible
+> in-prompt self-loop. To get a *complete, balanced* report we make deep
+> research a **deliberate `run_workflow` recipe** (ADR 0002) that orchestrates
+> discrete subagent stages — including a real **antagonist** (steelman the
+> opposing case, red-team weak claims, hunt disconfirming evidence) and a
+> **claim verifier** — feeding a synthesizer that must *address* the opposition.
+> The single researcher stays for quick/inline lookups; the workflow is the
+> deliberate path.
+
+---
+
+## 1. Context & Problem Statement
+
+The upgraded `researcher` subagent decomposes into dimensions, cites `[N]`, and
+rates confidence — good for a quick answer. But a live run (*"approaches to
+sandboxing agents that run untrusted code + tradeoffs"*) exposed the ceiling of
+a single agent:
+
+- **One-sided.** It asserted a consensus ("containers insufficient", "MicroVMs
+  strongest") with **no steelman of the counter-view** and **no disconfirming
+  evidence** — yet rated itself `Confidence: high`. Unearned.
+- **No verification.** Specific claims (e.g. latency figures) weren't checked
+  against their sources.
+- **Opaque, bounded gap-filling.** Gap detection is the agent's *internal*
+  self-loop — not auditable, and limited by one agent's turn budget + context.
+
+A "more complete report with clear opposing-agent context" needs **separation of
+concerns across agents**: a gatherer shouldn't grade its own homework, and the
+opposing case needs a dedicated advocate, not a footnote the same agent writes.
+
+## 2. Decision
+
+Ship a bundled **`deep-research` workflow** (`workflows/deep-research.yaml`) — a
+fixed DAG of subagent stages with real parallel branches — plus three new
+subagent roles. The engine (ADR 0002) is static-DAG with `steps.<id>.output`
+template threading + parallel independent steps; we use that, not dynamic fan-out.
+
+### 2.1 The stage graph
+
+```
+research ─┐                          (scope+gather, primary/recent sources)
+dissent  ─┤  (parallel)              (deliberately hunt the critical/contrarian angle)
+          ├─→ gap_fill               (find 1-3 genuine gaps vs the original Q, fill them)
+          │      ├─→ antagonist ─┐   (steelman opposite + attack weak claims + seek disconfirming evidence)
+          │      ├─→ verify ─────┤   (extract key claims, check vs sources, label supported/uncertain)
+          └──────┴──────────────→ synthesize   (balanced report: addresses opposition, drops unverified claims)
+```
+
+- **research ∥ dissent** run in parallel from the topic — opposing context is
+  injected *at gather time*, not bolted on.
+- **antagonist ∥ verify** run in parallel after the evidence is in.
+- **synthesize** depends on everything and is the deliverable.
+
+### 2.2 New subagent roles
+- **`antagonist`** (the headline) — full red-team: argue the strongest *opposing*
+  position, attack weak/unsupported claims in the findings, and **search for
+  disconfirming evidence** (its own `web_search`/`fetch_url`). Outputs an
+  "Opposition & weaknesses" memo the synthesizer must answer.
+- **`verifier`** — extract the key factual claims and check each against sources;
+  label **supported / unsupported / uncertain** with citations. The synthesizer
+  drops or flags anything not supported.
+- **`synthesizer`** — write the balanced report: integrate findings + filled
+  gaps, **incorporate a "Counterpoints / caveats" section** from the antagonist,
+  keep only verifier-supported claims, numbered `[N]` citations, honest
+  `Confidence`, open questions. May `memory_ingest` one durable finding.
+
+The existing **`researcher`** handles the `research`, `dissent`, and `gap_fill`
+steps (its prompt already scopes + cites). Stays available for quick inline use.
+
+### 2.3 Why a workflow, not a bigger prompt
+Separation across agents is the point: the antagonist is *adversarial by role*
+(can't be the same agent that wrote the findings), the verifier is independent,
+and each stage is its own auditable card (per-step output in the console).
+Parallel branches keep wall-clock down.
+
+## 3. Constraints / honest edges
+- **DAGs, not loops** (ADR 0002): gap-filling is **one bounded stage**, not
+  unbounded iteration — the declarative version of the loop. A deeper loop would
+  need engine support (or goal-mode wrapping a workflow — itself an open gap from
+  ADR 0009).
+- **No dynamic per-dimension fan-out**: the recipe has fixed stages, so
+  per-dimension parallelism lives *inside* the researcher (its prompt), while the
+  workflow parallelizes the *role* branches (research∥dissent, antagonist∥verify).
+- More subagent calls = more latency + tokens than a single researcher — this is
+  the deliberate/complete path, not the quick one. Run it via
+  `run_workflow("deep-research", {topic, depth})`.
+
+## 4. Consequences
+**Positive** — reports carry steelmanned opposition + verified claims + filled
+gaps; the adversarial separation is structural (a role, not a prompt aside); each
+stage is auditable; parallel branches bound wall-clock.
+**Negative** — heavier than the single researcher (gate to genuinely deep asks);
+bounded (single) gap round; new roles to maintain.
+
+## 5. Alternatives considered
+- **Keep improving the single researcher prompt** — hits the self-grading
+  ceiling the eval exposed; an agent steelmanning against itself is weak.
+- **Dynamic fan-out per dimension** — needs an engine `for_each`/map step; deferred
+  (the role-branch parallelism covers most of the win).
+- **Goal-mode loop until a verifier passes** — the right shape for *unbounded*
+  gap-filling, but goals can't verify workflow output yet (ADR 0009 gap). Revisit.
+
+## 6. Related
+- [ADR 0002 — Reusable Subagent Workflows](/adr/0002-reusable-subagent-workflows) — the engine + recipe format.
+- [ADR 0009 — Studio control stack](/adr/0009-studio-control-stack) — workflow = orchestration; the goal→workflow bridge that would enable a true gap loop.
+- `graph/subagents/config.py` (roles), `workflows/deep-research.yaml` (recipe),
+  `graph/workflows/engine.py` (DAG + threading). Lessons from `rabbit-hole.io`'s
+  deep-research pipeline (scope → loop → synthesize + graph memory).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -19,3 +19,4 @@ decision, numbered, never deleted (supersede instead).
 | [0008](./0008-sandboxing-and-openshell.md) | Sandboxing posture & NVIDIA OpenShell | Accepted |
 | [0009](./0009-studio-control-stack.md) | The Studio control stack (goals · workflows · subagents · skills) | Accepted |
 | [0010](./0010-headless-setup-and-ui-tiers.md) | Headless setup & UI deployment tiers (lighter stack) | Accepted |
+| [0011](./0011-deep-research-workflow.md) | Deep-research workflow with adversarial review | Accepted |

--- a/docs/guides/subagents.md
+++ b/docs/guides/subagents.md
@@ -141,6 +141,26 @@ _graph = create_agent_graph(
 
 This drops the `task()` tool from the lead's toolset. No runtime hit.
 
+## The adversarial-research roles
+
+Beyond `researcher`, the template ships three roles that exist specifically to
+make a research report *honest* — used by the `deep-research`
+[workflow](/guides/workflows) ([ADR 0011](/adr/0011-deep-research-workflow)).
+They're separate agents on purpose: no agent should grade its own homework.
+
+- **`antagonist`** — adversarial reviewer. Steelmans the strongest *opposing*
+  case, attacks weak/unsupported claims, and uses its own `web_search`/`fetch_url`
+  to hunt disconfirming evidence. Outputs an "Opposition & weaknesses" memo.
+- **`verifier`** — independent claim-checker. Extracts the load-bearing factual
+  claims and labels each supported/unsupported/uncertain against sources.
+- **`synthesizer`** — writes the final balanced report, folding the antagonist's
+  opposition into a "Counterpoints & caveats" section, dropping anything the
+  verifier didn't support, and only earning a high `Confidence` if the
+  opposition was answered.
+
+They're ordinary `SubagentConfig`s in the registry — reuse, retune, or drop them
+like any other; the `deep-research` recipe just wires them into a DAG.
+
 ## What you get for free
 
 Every subagent call:

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -40,7 +40,7 @@ output: "{{ steps.brief.output }}"  # optional; default = last step's output
 ## Where recipes live
 
 - **Bundled examples**: the repo's `workflows/` dir (ships with
-  `research-and-brief.yaml`).
+  `research-and-brief.yaml` and `deep-research.yaml`).
 - **Your recipes**: `workflows.dir` in `config/langgraph-config.yaml` (default
   `/sandbox/workflows`, falling back to `~/.protoagent/workflows` for local dev).
   Drop a `*.yaml` recipe there; it's loaded on the next start/reload.
@@ -84,6 +84,33 @@ inputs, and runs it with a one-click form — the same path the agent's
 collapsible per-step breakdown, and flags any steps that failed (failures are
 recorded inline so the rest of the DAG still runs). It's backed by
 `GET /api/workflows` and `POST /api/workflows/{name}/run`.
+
+## Deep research with adversarial review
+
+`deep-research.yaml` is the heavyweight, decision-grade counterpart to a single
+`researcher` call. It's a six-stage DAG ([ADR 0011](/adr/0011-deep-research-workflow))
+that builds in the *opposing* context a lone researcher can't give itself:
+
+```
+research ∥ dissent  →  gap_fill  →  antagonist ∥ verify  →  synthesize
+```
+
+- **research ∥ dissent** — a mainstream gather and a deliberately contrarian
+  pass run in parallel, so the critical angle is sourced *at gather time*.
+- **gap_fill** — finds and fills 1-3 genuine gaps against the original question.
+- **antagonist ∥ verify** — a red-team [`antagonist`](/guides/subagents) (steelmans
+  the opposing case, attacks weak claims, hunts disconfirming evidence) and an
+  independent [`verifier`](/guides/subagents) (labels material claims
+  supported/unsupported/uncertain) run in parallel.
+- **synthesize** — a [`synthesizer`](/guides/subagents) writes the balanced
+  report: it *addresses* the opposition in a "Counterpoints & caveats" section,
+  drops unverified claims, and only earns `Confidence: high` if the opposition
+  was genuinely answered.
+
+Run it on a genuinely deep question — `` /deep-research is X the right
+architecture `` or `run_workflow("deep-research", {"topic": "…", "depth": "deep"})`.
+It's more subagent calls (and latency) than the single researcher, so gate it to
+asks that warrant it; use the plain `researcher` for quick inline lookups.
 
 ## The agent can author them (closed loop)
 

--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -131,6 +131,121 @@ question; expand only for genuinely deep ones.""",
 )
 
 
+# ── Deep-research workflow roles (ADR 0011) ───────────────────────────────────
+# These are the adversarial/synthesis stages of the `deep-research` workflow
+# (workflows/deep-research.yaml). The `researcher` above handles the gather /
+# dissent / gap-fill stages; these three are deliberately SEPARATE agents so no
+# agent grades its own homework.
+
+ANTAGONIST_CONFIG = SubagentConfig(
+    name="antagonist",
+    description=(
+        "Adversarial reviewer for a body of research. Steelmans the strongest "
+        "OPPOSING position, attacks weak/unsupported claims, and hunts "
+        "disconfirming evidence on the web. Used by the deep-research workflow; "
+        "the synthesizer must answer what it raises."
+    ),
+    system_prompt="""You are protoAgent's antagonist — the adversarial reviewer
+on a research team. You are given a body of findings on a question. Your job is
+to make the final report *honest* by attacking it, not echoing it. Assume the
+findings are over-confident and one-sided until proven otherwise.
+
+Do three things:
+1. **Steelman the opposing case.** Build the *strongest* argument against the
+   findings' apparent conclusion — the case a smart, informed skeptic would
+   make. Not a strawman; the real best counter-position.
+2. **Attack weak claims.** Flag every claim that is unsupported, over-stated,
+   cites a weak source (listicle/vendor blog), conflates correlation/causation,
+   or hides a key caveat/cost. Quote the claim; say what's wrong.
+3. **Hunt disconfirming evidence.** Use ``web_search``/``fetch_url`` to actively
+   look for sources that CONTRADICT the findings (failure cases, criticisms,
+   "X considered harmful", benchmarks that disagree). Cite what you find.
+
+Be specific and fair — the goal is a more correct report, not contrarianism for
+its own sake. If the findings are genuinely well-supported on a point, say so;
+don't manufacture doubt.
+
+Output in <output>: an "Opposition & weaknesses" memo —
+- **Strongest opposing case:** <the steelman>
+- **Weak/unsupported claims:** bulleted, each with what's wrong + a better source if found
+- **Disconfirming evidence:** bulleted, with citations
+- **Net:** what the synthesizer MUST address or qualify.
+Deliberation in <scratch_pad>. Hard stop at max_turns.""",
+    tools=["current_time", "web_search", "fetch_url", "memory_recall"],
+    max_turns=30,
+)
+
+VERIFIER_CONFIG = SubagentConfig(
+    name="verifier",
+    description=(
+        "Independent claim-checker for a body of research. Extracts the key "
+        "factual claims and checks each against sources, labeling "
+        "supported/unsupported/uncertain. Used by the deep-research workflow."
+    ),
+    system_prompt="""You are protoAgent's verifier — an independent fact-checker.
+You're given research findings (with citations). You did NOT gather them, so be
+skeptical: a citation next to a claim does not mean the source supports it.
+
+For the **material** factual claims (the load-bearing ones, not every aside):
+1. Extract the claim verbatim (or tightly paraphrased).
+2. Check it against the cited source — and a quick independent
+   ``web_search``/``fetch_url`` when the cite is weak, missing, or surprising.
+3. Label it: **SUPPORTED** (source backs it), **UNSUPPORTED** (no/weak/missing
+   source, or the source doesn't actually say it), or **UNCERTAIN** (mixed or
+   can't confirm in budget).
+
+Don't re-research the topic; verify what's claimed. Be efficient — focus on the
+claims a wrong answer would hinge on.
+
+Output in <output>: a verification table —
+| Claim | Verdict | Note (source / why) |
+then a one-line **For the synthesizer:** which claims to drop, qualify, or keep.
+Deliberation in <scratch_pad>. Hard stop at max_turns.""",
+    tools=["current_time", "web_search", "fetch_url"],
+    max_turns=30,
+)
+
+SYNTHESIZER_CONFIG = SubagentConfig(
+    name="synthesizer",
+    description=(
+        "Writes the final balanced research report from gathered findings, the "
+        "antagonist's opposition memo, and the verifier's claim checks. Used by "
+        "the deep-research workflow as the deliverable stage."
+    ),
+    system_prompt="""You are protoAgent's synthesizer. You write the final
+research report from several inputs: the findings (+ filled gaps), the
+antagonist's opposition memo, and the verifier's claim checks. The report is the
+deliverable — write it, don't plan it.
+
+Rules that make this report better than any single agent's:
+- **Lead with the bottom line**, honestly hedged by what the antagonist and
+  verifier surfaced — not the rosy version.
+- **Drop or explicitly qualify** any claim the verifier marked UNSUPPORTED;
+  soften UNCERTAIN ones ("reportedly", "one benchmark suggests").
+- **Include a "## Counterpoints & caveats" section** that fairly presents the
+  antagonist's strongest opposing case and disconfirming evidence — and say,
+  where you can, which side the evidence favors and why.
+- **Numbered `[N]` citations** for every material claim (carry the sources
+  through from the findings); `[1][3]` where evidence converges.
+- Use ``## `` headings for a multi-part answer. End with an honest
+  ``Confidence: high | medium | low`` that is *earned* — it must reflect what
+  survived adversarial review. **Cap it at `medium`** when the antagonist
+  surfaced a material risk the findings do not resolve, or when the verifier
+  left load-bearing claims UNSUPPORTED/UNCERTAIN; reserve `high` for when the
+  opposition was genuinely answered. State the one thing that would raise it.
+  Close with 3-5 open questions / related topics.
+- For substantial reports, ``memory_ingest`` one concise durable finding so the
+  KB compounds.
+
+Output the report in <output> (deliberation in <scratch_pad>).""",
+    tools=["current_time", "memory_recall", "memory_ingest"],
+    max_turns=12,
+)
+
+
 SUBAGENT_REGISTRY: dict[str, SubagentConfig] = {
     "researcher": RESEARCHER_CONFIG,
+    "antagonist": ANTAGONIST_CONFIG,
+    "verifier": VERIFIER_CONFIG,
+    "synthesizer": SYNTHESIZER_CONFIG,
 }

--- a/tests/test_deep_research.py
+++ b/tests/test_deep_research.py
@@ -1,0 +1,69 @@
+"""Tests for the deep-research workflow + its adversarial subagent roles (ADR 0011)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from graph.subagents.config import SUBAGENT_REGISTRY
+from graph.workflows.engine import validate_recipe
+
+RECIPE_PATH = Path(__file__).parent.parent / "workflows" / "deep-research.yaml"
+
+
+def _recipe() -> dict:
+    return yaml.safe_load(RECIPE_PATH.read_text())
+
+
+# ── the new adversarial/synthesis roles ───────────────────────────────────────
+
+
+def test_new_roles_registered():
+    for name in ("antagonist", "verifier", "synthesizer"):
+        assert name in SUBAGENT_REGISTRY, f"{name} missing from registry"
+
+
+def test_antagonist_can_search_for_disconfirming_evidence():
+    # The headline capability: it must be able to hunt opposing sources itself.
+    tools = SUBAGENT_REGISTRY["antagonist"].tools
+    assert "web_search" in tools and "fetch_url" in tools
+
+
+def test_verifier_can_check_against_sources():
+    tools = SUBAGENT_REGISTRY["verifier"].tools
+    assert "web_search" in tools and "fetch_url" in tools
+
+
+def test_synthesizer_can_persist():
+    assert "memory_ingest" in SUBAGENT_REGISTRY["synthesizer"].tools
+
+
+# ── the recipe ─────────────────────────────────────────────────────────────────
+
+
+def test_recipe_validates_against_the_live_registry():
+    # Every subagent the recipe references must exist; DAG + templates must resolve.
+    errors = validate_recipe(_recipe(), known_subagents=set(SUBAGENT_REGISTRY))
+    assert errors == [], errors
+
+
+def test_recipe_dag_shape():
+    steps = {s["id"]: s for s in _recipe()["steps"]}
+    # research + dissent are roots (parallel gather/contrarian).
+    assert not steps["research"].get("depends_on")
+    assert not steps["dissent"].get("depends_on")
+    # antagonist + verify both wait on the evidence (they run in parallel).
+    assert "gap_fill" in steps["antagonist"]["depends_on"]
+    assert "gap_fill" in steps["verify"]["depends_on"]
+    # synthesize is the sink — depends on the whole pipeline incl. both reviewers.
+    deps = set(steps["synthesize"]["depends_on"])
+    assert {"research", "dissent", "gap_fill", "antagonist", "verify"} <= deps
+
+
+def test_recipe_wires_the_right_roles():
+    by_id = {s["id"]: s["subagent"] for s in _recipe()["steps"]}
+    assert by_id["antagonist"] == "antagonist"
+    assert by_id["verify"] == "verifier"
+    assert by_id["synthesize"] == "synthesizer"
+    assert by_id["research"] == "researcher"

--- a/workflows/deep-research.yaml
+++ b/workflows/deep-research.yaml
@@ -1,0 +1,117 @@
+# Deep research with adversarial review (ADR 0011). A deliberate, complete
+# alternative to a single `researcher` call: gather + a contrarian pass run in
+# parallel, gaps get filled, then an antagonist (opposition + red-team) and an
+# independent verifier run in parallel, and a synthesizer writes a balanced
+# report that ADDRESSES the opposition and drops unverified claims.
+#
+#   run_workflow("deep-research", {"topic": "…", "depth": "deep"})
+#
+# Heavier than `researcher` (6 subagent stages) — use it for genuinely deep,
+# decision-grade questions. DAG (ADR 0002): research∥dissent, then antagonist∥verify.
+name: deep-research
+description: >-
+  Deliberate deep research with adversarial review — gather + contrarian pass,
+  gap-fill, antagonist (opposition + red-team) + independent claim verifier, then
+  a balanced synthesis that answers the opposition.
+version: 1
+inputs:
+  - name: topic
+    description: The research question.
+    required: true
+  - name: depth
+    description: '"standard" or "deep" — scales dimensions + thoroughness.'
+    default: deep
+steps:
+  - id: research
+    subagent: researcher
+    prompt: |
+      Research this question thoroughly (depth: {{inputs.depth}}):
+      {{inputs.topic}}
+
+      Scope it into orthogonal dimensions and gather from primary, authoritative,
+      and recent sources. Return a tight, numbered-citation synthesis per the
+      researcher pipeline.
+
+  - id: dissent
+    subagent: researcher
+    prompt: |
+      Research the CONTRARIAN angle on this question — deliberately seek the
+      critical, skeptical, "why the popular answer is wrong or oversold" view,
+      including practitioner gripes and community/code sources (HN, Reddit,
+      GitHub, Stack Overflow). Do NOT restate the mainstream take; surface what
+      it misses, the failure cases, and credible dissent, with citations.
+
+      Question: {{inputs.topic}}
+
+  - id: gap_fill
+    subagent: researcher
+    depends_on: [research, dissent]
+    prompt: |
+      Here is the research so far on "{{inputs.topic}}":
+
+      ## Mainstream findings
+      {{steps.research.output}}
+
+      ## Contrarian findings
+      {{steps.dissent.output}}
+
+      Identify 1-3 GENUINE gaps that still block a complete answer to the
+      ORIGINAL question (not tangents), then research and fill them with cited
+      sources. Return just the gap findings (what was missing + what you found).
+
+  - id: antagonist
+    subagent: antagonist
+    depends_on: [research, dissent, gap_fill]
+    prompt: |
+      Adversarially review the research below on "{{inputs.topic}}". Steelman the
+      strongest opposing case, attack weak/unsupported claims, and hunt
+      disconfirming evidence. Produce the "Opposition & weaknesses" memo.
+
+      ## Findings
+      {{steps.research.output}}
+
+      ## Contrarian findings
+      {{steps.dissent.output}}
+
+      ## Gap-fill
+      {{steps.gap_fill.output}}
+
+  - id: verify
+    subagent: verifier
+    depends_on: [research, gap_fill]
+    prompt: |
+      Verify the material factual claims in the research below on
+      "{{inputs.topic}}". Produce the verification table + the line for the
+      synthesizer.
+
+      ## Findings
+      {{steps.research.output}}
+
+      ## Gap-fill
+      {{steps.gap_fill.output}}
+
+  - id: synthesize
+    subagent: synthesizer
+    depends_on: [research, dissent, gap_fill, antagonist, verify]
+    prompt: |
+      Write the final balanced report on: {{inputs.topic}}
+
+      Integrate the findings + filled gaps, fold in a "## Counterpoints & caveats"
+      section from the antagonist's memo, and drop/qualify any claim the verifier
+      did not support. Numbered [N] citations; earned Confidence; open questions.
+
+      ## Findings
+      {{steps.research.output}}
+
+      ## Contrarian findings
+      {{steps.dissent.output}}
+
+      ## Gap-fill
+      {{steps.gap_fill.output}}
+
+      ## Opposition memo (antagonist)
+      {{steps.antagonist.output}}
+
+      ## Claim verification (verifier)
+      {{steps.verify.output}}
+output: "{{steps.synthesize.output}}"


### PR DESCRIPTION
## What

A bundled **`deep-research`** workflow that fixes the one-sided, self-graded ceiling of a single `researcher` call. A live eval of the upgraded researcher (the *"approaches to sandboxing agents that run untrusted code + tradeoffs"* question) produced a well-cited but **consensus-shaped** report with **`Confidence: high`** and **zero adversarial pressure** — no steelman of the counter-view, no disconfirming evidence, no claim verification.

This makes deep research a deliberate `run_workflow` recipe (ADR 0002) that orchestrates discrete subagent stages, including a real **antagonist** and an independent **verifier**, feeding a **synthesizer** that must *address* the opposition.

## The stage graph

```
research ∥ dissent  →  gap_fill  →  antagonist ∥ verify  →  synthesize
```

- **research ∥ dissent** — mainstream gather + a deliberately contrarian pass, in parallel (opposing context sourced at gather time).
- **gap_fill** — closes 1-3 genuine gaps against the original question.
- **antagonist ∥ verify** — red-team (steelman opposing case, attack weak claims, hunt disconfirming evidence) + independent claim verifier, in parallel.
- **synthesize** — the deliverable: balanced report with a "Counterpoints & caveats" section, unverified claims dropped, `Confidence` capped at `medium` when a material risk is unresolved.

## New subagent roles
`antagonist`, `verifier`, `synthesizer` — deliberately **separate agents** so none grades its own homework. The existing `researcher` handles research/dissent/gap_fill.

## Constraints (honest edges)
The engine is static-DAG (no loops / dynamic fan-out), so gap-filling is **one bounded stage** and per-dimension parallelism lives *inside* the researcher; the workflow parallelizes the *role* branches. See ADR 0011 §3.

## Live eval
Re-ran the same sandboxing topic through the workflow (`--ui none` throwaway, 47s, 6 stages). The report now carries a substantive **Counterpoints & Caveats** section sourced from the antagonist — the "intent gap" (sandboxing protects the system, not the mission), the complexity-security paradox, the Wasm capability gap, and risk-transfer to managed services — i.e. the opposing context the lone researcher structurally couldn't produce.

## Tests
`tests/test_deep_research.py` — roles registered, antagonist/verifier have web tools, synthesizer can persist, recipe validates against the **live** registry, DAG shape + role wiring. Full suite green (901 passed); docs build clean.

## Docs
ADR 0011 + index row; "Deep research with adversarial review" section in the workflows guide; "adversarial-research roles" section in the subagents guide; CHANGELOG `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)