### PR TITLE
feat: eval model comparison + trend tracking (ADR 0012)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,10 @@ apps/desktop/src-tauri/binaries/
 # PyInstaller sidecar build workdir
 /build/sidecar/
 
+# Eval run artifacts (per-run reports, sweep outputs, captured server logs).
+# The harness recreates evals/results/ on demand; runs aren't source.
+evals/results/
+
 # Playwright E2E artifacts (apps/web smoke harness)
 apps/web/test-results/
 apps/web/playwright-report/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Eval model comparison + trend tracking** (ADR 0012): every eval report is
+  now tagged with the **model under test** (auto-detected from `/healthz`,
+  overridable with `--model-label`). A `PROTOAGENT_MODEL` env var overrides the
+  YAML `model.name` so the same agent boots against any model. New
+  `evals/sweep.py` boots a throwaway `--ui none` agent per model (own port +
+  `PROTOAGENT_INSTANCE`), runs the suite against each, and prints a
+  `model × category` pass-rate matrix; new `evals/report.py` aggregates every
+  model-tagged report into a leaderboard + per-model trend over time. `/healthz`
+  now returns the active `model`; `evals/results/` is gitignored.
 - **Deep-research workflow with adversarial review** (ADR 0011): a bundled
   `deep-research` recipe (`run_workflow`/`/deep-research`) that orchestrates a
   six-stage DAG — `research ∥ dissent → gap_fill → antagonist ∥ verify →

--- a/docs/adr/0012-eval-strategy-and-model-comparison.md
+++ b/docs/adr/0012-eval-strategy-and-model-comparison.md
@@ -1,0 +1,118 @@
+# ADR 0012 — Eval strategy: model-tagged tracking & model comparison
+
+- **Status:** Accepted (2026-06-01) — model-comparison harness shipped; coverage cases (subagent/workflow/rubric) land in a follow-up
+- **Date:** 2026-06-01
+- **Deciders:** Josh Mabry; protoAgent maintainers
+- **Tags:** evals, observability, models, testing
+- **Supersedes / Superseded by:** —
+
+> To improve an agent you have to **measure it the same way every time** and be
+> able to **swap the model and compare**. The harness already side-effect-verifies
+> a turn (audit log + reply text + KB writes), but its reports weren't tagged with
+> the model and there was no way to run the suite across models. We make every
+> report carry the **model under test** (auto-detected from `/healthz`), add a
+> `PROTOAGENT_MODEL` env override so the same agent boots against any model, and
+> ship a **sweep** that boots a throwaway UI-less agent per model and prints a
+> `model × category` matrix — plus a **trend** report that tracks pass rate over
+> time. Output quality that substring/audit checks can't judge gets an
+> **LLM-judge rubric** (follow-up slice).
+
+---
+
+## 1. Context & Problem Statement
+
+The eval harness (`evals/`) is solid where it counts: each case drives the
+running agent over A2A and asserts on three independent channels — the audit log
+(did the expected tool actually fire?), the reply text, and KB side effects — so
+a hallucinated tool result fails instead of passing. Reports land in
+`evals/results/run-<ts>.json` and `evals/compare.py` diffs two of them.
+
+But for *"track our agents as we work + swap models for testing"* two things were
+missing:
+
+1. **Reports weren't model-tagged.** A `run-*.json` recorded pass/fail/tokens but
+   not *which model produced it*. After two runs you couldn't tell which was
+   `reasoning` vs `agent` — so model comparison was guesswork.
+2. **No model swap.** The model is fixed at boot from
+   `config/langgraph-config.yaml` (`model.name`). Comparing models meant editing
+   YAML, rebooting, running, and hand-tracking which report was which.
+3. **No coverage for the layers we actually build.** The 15 cases test lead-agent
+   tool selection + goal mode — not subagent delegation or the research/
+   deep-research workflows (ADR 0002/0011), the work of recent cycles.
+
+## 2. Decision
+
+### 2.1 Tag every report with the model
+`evals.runner` stamps `model` (and `base_url`) onto every report.
+It auto-detects the model from **`GET /healthz`** (which now returns the active
+`model`) so a tag is never forgotten; `--model-label` overrides. `compare.py`
+and the new `report.py` key off this field.
+
+### 2.2 `PROTOAGENT_MODEL` env override
+`graph/config.py` lets `PROTOAGENT_MODEL` win over the YAML `model.name`. Swapping
+the model under test becomes an env var, not a config edit — which is what makes
+an automated sweep possible without mutating tracked files.
+
+### 2.3 `evals/sweep.py` — the model-comparison run
+Given `--models a,b,c`, for each model it: boots `server.py --ui none` with
+`PROTOAGENT_MODEL=<model>` + a unique `PROTOAGENT_INSTANCE` (no shared data) on
+its own port, waits for `/healthz`, runs the suite tagged with the model, then
+tears the agent down and deletes its instance data. It prints a `model × category`
+pass-rate matrix + an avg latency/token footnote and writes a combined
+`sweep-<ts>.json`. UI-less + per-model instance scoping (ADR 0004/0010) is what
+makes booting N disposable agents cheap and isolated. The sweep sets a bearer
+token in the child env so the auth-gating cases are genuinely exercised.
+
+### 2.4 `evals/report.py` — trend & leaderboard
+Aggregates all model-tagged `run-*.json` into a **leaderboard** (latest standing
+per model, best first) and a **per-model trend** (pass rate by run, with ▲/▼ vs
+the previous run). This is the "track as we work" surface — a regression after a
+prompt/model/code change is visible at a glance.
+
+### 2.5 Coverage for the agent layers (follow-up slice)
+- **Subagent delegation** — cases that assert the lead delegates (`task`) and the
+  subagent's tools fire in the shared audit log.
+- **Workflow recipes** — a `kind: "workflow"` case that drives a recipe end-to-end
+  via `POST /api/workflows/{name}/run` (e.g. `deep-research`) and asserts the
+  output's structure (a Counterpoints section, citations).
+- **Research quality (LLM-judge rubric)** — for output quality substring checks
+  can't judge ("is the report actually balanced / is the confidence earned?"), a
+  grader model scores the output against a per-case rubric; the case passes above
+  a threshold. This is the only way to track research quality across models.
+
+## 3. Constraints / honest edges
+- **Boot-per-model latency.** A sweep boots one agent per model (~seconds of
+  startup each). That's the price of clean isolation; runtime per-request model
+  binding was rejected as more plumbing + shared state between models.
+- **LLM-judge is non-deterministic + costs tokens.** Rubric scores are a tracked
+  signal, not a gate — pin the grader model and treat scores as trend data. Keep
+  deterministic structural checks (audit/substring/KB) as the hard pass/fail.
+- **Gateway aliases must exist.** `--models` are gateway aliases; a typo'd alias
+  just fails to boot (reported, skipped) rather than silently scoring zero.
+- Reports are local artifacts (`evals/results/` is gitignored); the trend report
+  reads whatever is on the box. CI/cron persistence is a later concern.
+
+## 4. Consequences
+**Positive** — model comparison is one command (`python -m evals.sweep --models
+…`); every run is attributable to a model; regressions are visible over time;
+swapping the default model is a measured decision, not a vibe. Builds directly on
+existing primitives (side-effect verification, `/healthz`, instance scoping, the
+UI-less tier).
+**Negative** — sweeps are slower than a single run; the LLM-judge adds a grader
+dependency + cost; more eval surface to maintain as the agent grows.
+
+## 5. Alternatives considered
+- **Runtime per-request model override** — compare models without rebooting.
+  Rejected: per-turn model binding is real plumbing and the models would share
+  instance state, muddying side-effect assertions. Boot-per-model is cleaner.
+- **Tag + compare only (no sweep)** — smallest change, but leaves the
+  boot/run/track loop manual; the whole point was to make comparison turnkey.
+- **Deterministic-only scoring** — cheap + reproducible, but can't measure the
+  thing we just built in ADR 0011 (a *balanced* report). Rubric judging fills
+  that, as a tracked signal not a gate.
+
+## 6. Related
+- [ADR 0006 — Observability & the self-improving flywheel](/adr/0006-observability-and-the-self-improving-flywheel) — measure → surface → advise; evals are the offline half of the loop.
+- [ADR 0004 — Multi-instance data scoping](/adr/0004-multi-instance-data-scoping) & [ADR 0010 — Headless setup & UI tiers](/adr/0010-headless-setup-and-ui-tiers) — what makes a disposable per-model agent cheap + isolated.
+- [ADR 0011 — Deep-research workflow](/adr/0011-deep-research-workflow) — the workflow + research-quality the coverage slice targets.
+- `evals/` (`runner.py`, `sweep.py`, `report.py`, `compare.py`), `docs/guides/evals.md`.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -20,3 +20,4 @@ decision, numbered, never deleted (supersede instead).
 | [0009](./0009-studio-control-stack.md) | The Studio control stack (goals · workflows · subagents · skills) | Accepted |
 | [0010](./0010-headless-setup-and-ui-tiers.md) | Headless setup & UI deployment tiers (lighter stack) | Accepted |
 | [0011](./0011-deep-research-workflow.md) | Deep-research workflow with adversarial review | Accepted |
+| [0012](./0012-eval-strategy-and-model-comparison.md) | Eval strategy: model-tagged tracking & model comparison | Accepted |

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -25,9 +25,56 @@ python -m evals.runner --category tool
 python -m evals.runner --tasks current_time_intent,daily_log_intent
 ```
 
-Reports land in `evals/results/run-<ts>.json`. The CLI prints a
-pass/fail board; the JSON report carries reply previews and timing
-for post-hoc inspection.
+Reports land in `evals/results/run-<ts>.json` (gitignored — they're run
+artifacts, not source). The CLI prints a pass/fail board; the JSON report
+carries reply previews, timing, and the **model under test** (auto-detected from
+`/healthz`, overridable with `--model-label`) so runs stay comparable.
+
+## Compare models, track over time
+
+Improving an agent means measuring it the same way every time and being able to
+swap the model and compare ([ADR 0012](/adr/0012-eval-strategy-and-model-comparison)).
+
+**Swap one model:** `PROTOAGENT_MODEL` wins over the YAML `model.name`, so you
+can point the same agent at a different model without editing config:
+
+```bash
+PROTOAGENT_MODEL=vendor/some-model python server.py --ui none
+```
+
+**Sweep several models** with one command — `evals/sweep.py` boots a throwaway,
+UI-less agent per model (its own port + `PROTOAGENT_INSTANCE`, so they never
+share data), runs the suite tagged with each model, tears each down, and prints a
+`model × category` matrix:
+
+```bash
+python -m evals.sweep --models protolabs/reasoning,protolabs/agent
+python -m evals.sweep --models a,b,c --category tool      # one category
+python -m evals.sweep --models a,b --tasks current_time_intent --keep
+```
+
+```
+| Model                 | a2a-protocol | tool        | **Overall**     |
+|-----------------------|--------------|-------------|-----------------|
+| `protolabs/reasoning` | 3/3 (100%)   | 6/6 (100%)  | **9/9 (100%)**  |
+| `protolabs/agent`     | 3/3 (100%)   | 4/6 (67%)   | **7/9 (78%)**   |
+```
+
+**Track the trend** across every run on the box — `evals/report.py` aggregates
+the model-tagged reports into a leaderboard (latest standing per model, best
+first) plus a per-model trend (pass rate by run, ▲/▼ vs the last one):
+
+```bash
+python -m evals.report                          # all models
+python -m evals.report --model protolabs/reasoning
+```
+
+For a single before/after of one change, `evals/compare.py` diffs two reports
+(pass-rate delta, per-category, which cases flipped):
+
+```bash
+python -m evals.compare evals/results/run-OLD.json evals/results/run-NEW.json
+```
 
 ## The three assertion channels
 

--- a/evals/README.md
+++ b/evals/README.md
@@ -26,7 +26,25 @@ python -m evals.runner --tasks current_time,daily_log
 python -m evals.runner --base-url http://host:7870
 ```
 
-Reports land in `evals/results/run-<ts>.json` per run.
+Reports land in `evals/results/run-<ts>.json` per run (gitignored), each
+tagged with the model under test (auto-detected from `/healthz`,
+overridable with `--model-label`).
+
+## Compare models
+
+```bash
+# Boot one agent per model, run the suite against each, print a
+# model × category matrix. Each model gets its own throwaway --ui none
+# instance (PROTOAGENT_MODEL env override + a unique PROTOAGENT_INSTANCE).
+python -m evals.sweep --models protolabs/reasoning,protolabs/agent
+python -m evals.sweep --models a,b,c --category tool
+
+# Leaderboard + per-model trend across every report on the box.
+python -m evals.report
+
+# One before/after diff of two reports.
+python -m evals.compare results/run-OLD.json results/run-NEW.json
+```
 
 ## Categories
 
@@ -44,11 +62,14 @@ Reports land in `evals/results/run-<ts>.json` per run.
 
 ```
 evals/
-  client.py     A2A client (message/send + poll, message/stream, agent card, cancel)
-  runner.py     CLI runner — print board, write JSON report
+  client.py     A2A client (message/send + poll, message/stream, agent card, health, workflows, cancel)
+  runner.py     CLI runner — print board, write model-tagged JSON report
   verify.py     Audit-log + KB side-effect assertions, setup/teardown
+  sweep.py      Boot one agent per model + run the suite → model × category matrix
+  report.py     Aggregate all reports → leaderboard + per-model trend over time
+  compare.py    Diff two reports (pass-rate delta, per-category, flips)
   tasks.json    Cases — 15 covering the starter tools end-to-end
-  results/      Per-run reports
+  results/      Per-run reports (gitignored)
 ```
 
 ## Adding a case

--- a/evals/client.py
+++ b/evals/client.py
@@ -104,6 +104,31 @@ class AgentClient:
             r.raise_for_status()  # surface the last error
             return {}
 
+    async def health(self) -> dict:
+        """GET ``/healthz`` → ``{ok, graph_compiled, setup_complete, ui, model}``.
+
+        The eval runner reads ``model`` from here to tag the report with the
+        model under test (no guessing which model produced a run)."""
+        async with httpx.AsyncClient(timeout=10) as client:
+            r = await client.get(f"{self.base_url}/healthz")
+            return r.json()
+
+    # ── workflows ─────────────────────────────────────────────────────────────
+
+    async def run_workflow(self, name: str, inputs: dict, *, timeout_s: int = 300) -> dict:
+        """POST ``/api/workflows/{name}/run`` → the workflow result dict.
+
+        Used by ``kind: "workflow"`` eval cases to drive a recipe (e.g.
+        ``deep-research``) end-to-end and assert on its synthesized output."""
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            r = await client.post(
+                f"{self.base_url}/api/workflows/{name}/run",
+                headers=self.headers,
+                json={"inputs": inputs},
+            )
+            r.raise_for_status()
+            return r.json()
+
     # ── message/send + poll ─────────────────────────────────────────────────
 
     async def ask(self, prompt: str, *, timeout_s: int = 90, context_id: str | None = None) -> TaskResult:

--- a/evals/report.py
+++ b/evals/report.py
@@ -1,0 +1,139 @@
+"""Eval trend report — track agent quality across runs and models.
+
+Aggregates every model-tagged report in ``evals/results/`` into:
+
+- a **leaderboard** of the latest standing per model (overall + per-category
+  pass rate, avg latency/tokens), best first; and
+- a **trend** per model — pass rate of each run over time, so a regression
+  after a prompt/model/code change is visible at a glance.
+
+Reports are keyed by the ``model`` field that ``evals.runner`` now stamps on
+every report (auto-detected from ``/healthz``). Runs with no model tag are
+grouped under ``(untagged)``.
+
+    python -m evals.report                 # all results/
+    python -m evals.report --dir some/dir
+    python -m evals.report --model protolabs/reasoning   # one model's trend
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from evals.compare import _category_passed, _pct  # noqa: E402
+
+_RESULTS_DIR = Path(__file__).parent / "results"
+
+
+def _load_runs(results_dir: Path) -> list[dict]:
+    """Single-run reports (``run-*.json``), oldest first by ``ts``.
+
+    Skips ``sweep-*.json`` (combined) — their per-model reports are written
+    separately as ``run-sweep-*`` and picked up here individually."""
+    runs: list[dict] = []
+    for path in sorted(results_dir.glob("run-*.json")):
+        try:
+            rep = json.loads(path.read_text())
+        except Exception:
+            continue
+        if "results" not in rep:
+            continue
+        rep["_file"] = path.name
+        runs.append(rep)
+    runs.sort(key=lambda r: r.get("ts", ""))
+    return runs
+
+
+def _avg_latency(rep: dict) -> int:
+    timed = [r for r in rep.get("results", []) if r.get("duration_ms")]
+    return round(sum(r["duration_ms"] for r in timed) / len(timed)) if timed else 0
+
+
+def _avg_tokens(rep: dict) -> int:
+    toks = [r for r in rep.get("results", []) if r.get("tokens")]
+    return round(sum(r["tokens"] for r in toks) / len(toks)) if toks else 0
+
+
+def build_report(runs: list[dict], only_model: str | None = None) -> str:
+    by_model: dict[str, list[dict]] = defaultdict(list)
+    for rep in runs:
+        model = rep.get("model") or "(untagged)"
+        if only_model and model != only_model:
+            continue
+        by_model[model].append(rep)
+
+    if not by_model:
+        return "_No model-tagged eval runs found._"
+
+    lines: list[str] = ["# Eval trend report", ""]
+
+    # Leaderboard: latest run per model, best overall first.
+    latest = {m: reps[-1] for m, reps in by_model.items()}
+    cats = sorted({c for rep in latest.values() for c in _category_passed(rep)})
+    lines.append("## Leaderboard (latest run per model)")
+    lines.append("")
+    lines.append("| Model | " + " | ".join(cats) + " | **Overall** | Latency | Tokens | Runs |")
+    lines.append("|" + "---|" * (len(cats) + 4))
+    ordered = sorted(
+        latest.items(),
+        key=lambda kv: (kv[1].get("passed", 0) / kv[1].get("total", 1)) if kv[1].get("total") else 0,
+        reverse=True,
+    )
+    for model, rep in ordered:
+        cper = _category_passed(rep)
+        cells = []
+        for c in cats:
+            pp, tt = cper.get(c, (0, 0))
+            cells.append(f"{pp}/{tt}" if tt else "—")
+        overall = f"**{rep.get('passed', 0)}/{rep.get('total', 0)} ({_pct(rep.get('passed', 0), rep.get('total', 0))})**"
+        lines.append(
+            f"| `{model}` | " + " | ".join(cells)
+            + f" | {overall} | {_avg_latency(rep)}ms | {_avg_tokens(rep) or '—'} | {len(by_model[model])} |"
+        )
+    lines.append("")
+
+    # Per-model trend over time.
+    lines.append("## Trend (pass rate by run)")
+    for model, reps in sorted(by_model.items()):
+        lines.append("")
+        lines.append(f"### `{model}`")
+        lines.append("")
+        lines.append("| When | Pass | Rate | Report |")
+        lines.append("|---|---|---|---|")
+        prev = None
+        for rep in reps:
+            p, t = rep.get("passed", 0), rep.get("total", 0)
+            arrow = ""
+            if prev is not None:
+                d = p - prev
+                arrow = " ▲" if d > 0 else (" ▼" if d < 0 else " ■")
+            prev = p
+            when = (rep.get("ts") or "")[:19].replace("T", " ")
+            lines.append(f"| {when} | {p}/{t}{arrow} | {_pct(p, t)} | `{rep.get('_file', '?')}` |")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Aggregate eval results into a leaderboard + trend.")
+    p.add_argument("--dir", default=str(_RESULTS_DIR), help="results directory")
+    p.add_argument("--model", default=None, help="restrict the trend to one model")
+    args = p.parse_args(argv)
+
+    runs = _load_runs(Path(args.dir))
+    if not runs:
+        sys.stderr.write(f"no run-*.json reports found in {args.dir}\n")
+        return 1
+    print(build_report(runs, only_model=args.model))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -406,10 +406,15 @@ def _print_board(results: list[CaseResult]) -> None:
     print(f"\n{pass_count}/{len(results)} passed")
 
 
-def _save_report(results: list[CaseResult], path: Path) -> None:
+def _save_report(results: list[CaseResult], path: Path, *, model: str = "", base_url: str = "") -> None:
     path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "ts": datetime.now(UTC).isoformat(),
+        # The model under test — tagged so reports are comparable across model
+        # swaps (evals.compare / evals.report key off this). Auto-detected from
+        # /healthz, overridable with --model-label.
+        "model": model,
+        "base_url": base_url,
         "total": len(results),
         "passed": sum(1 for r in results if r.passed),
         "results": [asdict(r) for r in results],
@@ -424,6 +429,10 @@ async def main():
     p.add_argument("--tasks", default=None, help="comma-separated case IDs")
     p.add_argument("--category", default=None)
     p.add_argument("--out", default=None)
+    p.add_argument(
+        "--model-label", default=None,
+        help="tag the report with this model name (default: auto-detect from /healthz)",
+    )
     args = p.parse_args()
 
     tasks_path = Path(__file__).parent / "tasks.json"
@@ -441,7 +450,16 @@ async def main():
 
     client = AgentClient(base_url=args.base_url)
 
-    print(f"Running {len(cases)} case(s) against {client.base_url}")
+    # Tag the report with the model under test. --model-label wins; otherwise
+    # ask /healthz what the running agent is serving so swaps are traceable.
+    model_label = args.model_label or ""
+    if not model_label:
+        try:
+            model_label = (await client.health()).get("model") or ""
+        except Exception:
+            model_label = ""
+
+    print(f"Running {len(cases)} case(s) against {client.base_url}" + (f" [model: {model_label}]" if model_label else ""))
     results: list[CaseResult] = []
     for case in cases:
         sys.stdout.write(f"  {case['id']}... ")
@@ -455,7 +473,7 @@ async def main():
     out_path = Path(args.out) if args.out else (
         Path(__file__).parent / "results" / f"run-{int(time.time())}.json"
     )
-    _save_report(results, out_path)
+    _save_report(results, out_path, model=model_label, base_url=client.base_url)
 
     return 0 if all(r.passed for r in results) else 1
 

--- a/evals/sweep.py
+++ b/evals/sweep.py
@@ -1,0 +1,248 @@
+"""Model-comparison eval sweep.
+
+Boots a throwaway, UI-less agent per model, runs the eval suite against
+it, tags the report with the model, tears the agent down, and prints a
+``model × category`` pass-rate matrix — the one-command way to answer
+"which model is best for this agent?" and to catch a regression when you
+swap the default.
+
+How it works (per model):
+
+1. Launch ``server.py --port <p> --ui none`` with ``PROTOAGENT_MODEL=<model>``
+   (the env override added in ``graph/config.py``) and a unique
+   ``PROTOAGENT_INSTANCE`` so the models never share scoped data.
+2. Wait for ``GET /healthz`` to report the graph compiled.
+3. Run ``python -m evals.runner`` against that base URL, tagged with the model.
+4. Terminate the agent and delete its instance data.
+
+Usage::
+
+    python -m evals.sweep --models protolabs/reasoning,protolabs/agent
+    python -m evals.sweep --models a,b,c --category tool
+    python -m evals.sweep --models a,b --tasks current_time,daily_log --keep
+
+The combined result lands in ``evals/results/sweep-<ts>.json``; each model's
+own report is written alongside as ``run-sweep-<ts>-<model>.json``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import httpx
+
+_PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(_PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(_PROJECT_ROOT))
+
+from evals.compare import _category_passed, _pct  # noqa: E402
+
+_RESULTS_DIR = Path(__file__).parent / "results"
+_HEALTH_DEADLINE_S = 90.0
+_HEALTH_INTERVAL_S = 1.0
+
+
+def _slug(model: str) -> str:
+    """Filesystem-safe token for a model alias (``protolabs/reasoning`` →
+    ``protolabs-reasoning``)."""
+    return re.sub(r"[^A-Za-z0-9._-]+", "-", model).strip("-")
+
+
+def _instance_dirs(instance: str) -> list[Path]:
+    """The scoped-data dirs an instance creates under ``~/.protoagent``."""
+    base = Path(os.path.expanduser("~/.protoagent"))
+    return [
+        base / instance,
+        base / "inbox" / instance,
+        base / "scheduler" / instance,
+        base / "knowledge" / instance,
+    ]
+
+
+def _cleanup_instance(instance: str) -> None:
+    for p in _instance_dirs(instance):
+        if p.exists():
+            shutil.rmtree(p, ignore_errors=True)
+
+
+def _wait_healthy(base_url: str, deadline_s: float = _HEALTH_DEADLINE_S) -> dict | None:
+    """Poll ``/healthz`` until the graph is compiled (200). Returns the health
+    body, or None if it never came up."""
+    deadline = time.monotonic() + deadline_s
+    while time.monotonic() < deadline:
+        try:
+            r = httpx.get(f"{base_url}/healthz", timeout=2)
+            if r.status_code == 200:
+                return r.json()
+        except Exception:
+            pass
+        time.sleep(_HEALTH_INTERVAL_S)
+    return None
+
+
+def _run_one_model(
+    model: str,
+    *,
+    port: int,
+    instance: str,
+    ts: int,
+    category: str | None,
+    tasks: str | None,
+    keep: bool,
+) -> dict | None:
+    """Boot an agent on ``model``, run the suite, return the report dict."""
+    base_url = f"http://127.0.0.1:{port}"
+    report_path = _RESULTS_DIR / f"run-sweep-{ts}-{_slug(model)}.json"
+    log_path = _RESULTS_DIR / f"server-sweep-{ts}-{_slug(model)}.log"
+    _RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+
+    env = {
+        **os.environ,
+        "PROTOAGENT_MODEL": model,
+        "PROTOAGENT_INSTANCE": instance,
+        "PROTOAGENT_UI": "none",
+    }
+    # Give the throwaway agent a bearer token so the auth-gating eval cases are
+    # actually exercised (an unconfigured instance accepts any token → the
+    # negative-auth case can't pass). The runner's client reads the same env
+    # var, so the good-token cases still authenticate. Respect a token the
+    # operator already set.
+    env.setdefault("A2A_AUTH_TOKEN", f"eval-sweep-{ts}")
+    print(f"\n=== {model} :: booting on {base_url} (instance={instance}) ===")
+    log_f = open(log_path, "w")
+    proc = subprocess.Popen(
+        [sys.executable, "server.py", "--port", str(port), "--ui", "none"],
+        cwd=str(_PROJECT_ROOT),
+        env=env,
+        stdout=log_f,
+        stderr=subprocess.STDOUT,
+    )
+    try:
+        health = _wait_healthy(base_url)
+        if health is None:
+            print(f"  ✗ agent never became healthy (see {log_path})")
+            return None
+        print(f"  ✓ healthy (model={health.get('model')})")
+
+        cmd = [
+            sys.executable, "-m", "evals.runner",
+            "--base-url", base_url,
+            "--model-label", model,
+            "--out", str(report_path),
+        ]
+        if category:
+            cmd += ["--category", category]
+        if tasks:
+            cmd += ["--tasks", tasks]
+        subprocess.run(cmd, cwd=str(_PROJECT_ROOT), env=env, check=False)
+
+        if not report_path.exists():
+            print(f"  ✗ no report written for {model}")
+            return None
+        return json.loads(report_path.read_text())
+    finally:
+        proc.terminate()
+        try:
+            proc.wait(timeout=15)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+        log_f.close()
+        if not keep:
+            _cleanup_instance(instance)
+
+
+def _render_matrix(reports: dict[str, dict]) -> str:
+    """A ``model × category`` pass-rate matrix + an overall leaderboard."""
+    cats = sorted({c for rep in reports.values() for c in _category_passed(rep)})
+    lines = ["# Model sweep", ""]
+
+    # Per-category matrix.
+    header = "| Model | " + " | ".join(cats) + " | **Overall** |"
+    lines.append(header)
+    lines.append("|" + "---|" * (len(cats) + 2))
+    # Sort the leaderboard by overall pass rate, best first.
+    ordered = sorted(
+        reports.items(),
+        key=lambda kv: (kv[1].get("passed", 0) / kv[1].get("total", 1)) if kv[1].get("total") else 0,
+        reverse=True,
+    )
+    for model, rep in ordered:
+        cper = _category_passed(rep)
+        cells = []
+        for c in cats:
+            p, t = cper.get(c, (0, 0))
+            cells.append(f"{p}/{t} ({_pct(p, t)})" if t else "—")
+        overall = f"**{rep.get('passed', 0)}/{rep.get('total', 0)} ({_pct(rep.get('passed', 0), rep.get('total', 0))})**"
+        lines.append(f"| `{model}` | " + " | ".join(cells) + f" | {overall} |")
+    lines.append("")
+
+    # Cost/latency footnote (avg per case across the suite).
+    lines.append("| Model | Avg latency | Avg tokens |")
+    lines.append("|---|---|---|")
+    for model, rep in ordered:
+        rs = rep.get("results", [])
+        timed = [r for r in rs if r.get("duration_ms")]
+        toks = [r for r in rs if r.get("tokens")]
+        avg_ms = round(sum(r["duration_ms"] for r in timed) / len(timed)) if timed else 0
+        avg_t = round(sum(r["tokens"] for r in toks) / len(toks)) if toks else 0
+        lines.append(f"| `{model}` | {avg_ms}ms | {avg_t or '—'} |")
+    return "\n".join(lines)
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Run the eval suite across multiple models.")
+    p.add_argument("--models", required=True, help="comma-separated model aliases")
+    p.add_argument("--category", default=None, help="restrict to one eval category")
+    p.add_argument("--tasks", default=None, help="comma-separated case IDs")
+    p.add_argument("--port-base", type=int, default=7990, help="first port (each model uses port-base+i)")
+    p.add_argument("--keep", action="store_true", help="keep each model's instance data + logs")
+    args = p.parse_args(argv)
+
+    models = [m.strip() for m in args.models.split(",") if m.strip()]
+    if not models:
+        sys.stderr.write("no models given\n")
+        return 2
+
+    ts = int(time.time())
+    reports: dict[str, dict] = {}
+    for i, model in enumerate(models):
+        rep = _run_one_model(
+            model,
+            port=args.port_base + i,
+            instance=f"eval-sweep-{ts}-{i}",
+            ts=ts,
+            category=args.category,
+            tasks=args.tasks,
+            keep=args.keep,
+        )
+        if rep is not None:
+            reports[model] = rep
+
+    if not reports:
+        sys.stderr.write("no model produced a report\n")
+        return 1
+
+    matrix = _render_matrix(reports)
+    print("\n" + matrix)
+
+    combined = _RESULTS_DIR / f"sweep-{ts}.json"
+    combined.write_text(json.dumps({
+        "ts": ts,
+        "models": models,
+        "reports": {m: rep for m, rep in reports.items()},
+    }, indent=2))
+    (_RESULTS_DIR / f"sweep-{ts}.md").write_text(matrix + "\n")
+    print(f"\nSweep: {combined}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/graph/config.py
+++ b/graph/config.py
@@ -314,6 +314,16 @@ class LangGraphConfig:
     # for the generated OpenShell network policy (scripts/gen_openshell_policy).
     egress_allowed_hosts: list[str] = field(default_factory=list)
 
+    def __post_init__(self):
+        # PROTOAGENT_MODEL wins over the YAML/default model so an eval sweep can
+        # boot the same agent against different models without editing config
+        # (evals/sweep.py). Applied here so it holds on *every* construction
+        # path — including the defaults fallback when no YAML is present (CI,
+        # fresh forks), not just the from_yaml parse branch.
+        env_model = os.environ.get("PROTOAGENT_MODEL")
+        if env_model:
+            self.model_name = env_model
+
     @classmethod
     def from_yaml(cls, path: str | Path) -> "LangGraphConfig":
         """Load config from YAML file. Falls back to defaults if absent."""
@@ -346,10 +356,7 @@ class LangGraphConfig:
 
         config = cls(
             model_provider=model.get("provider", cls.model_provider),
-            # PROTOAGENT_MODEL wins over the YAML so an eval sweep can boot the
-            # same agent against different models without rewriting config
-            # (evals/sweep.py). Blank/unset falls through to the YAML value.
-            model_name=os.environ.get("PROTOAGENT_MODEL") or model.get("name", cls.model_name),
+            model_name=model.get("name", cls.model_name),
             api_base=model.get("api_base", cls.api_base),
             api_key=secret_api_key or model.get("api_key", cls.api_key),
             temperature=model.get("temperature", cls.temperature),

--- a/graph/config.py
+++ b/graph/config.py
@@ -10,6 +10,7 @@ The defaults here point at the protoLabs LiteLLM gateway via the
 YAML (or swap the gateway alias) per agent without code changes.
 """
 
+import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -345,7 +346,10 @@ class LangGraphConfig:
 
         config = cls(
             model_provider=model.get("provider", cls.model_provider),
-            model_name=model.get("name", cls.model_name),
+            # PROTOAGENT_MODEL wins over the YAML so an eval sweep can boot the
+            # same agent against different models without rewriting config
+            # (evals/sweep.py). Blank/unset falls through to the YAML value.
+            model_name=os.environ.get("PROTOAGENT_MODEL") or model.get("name", cls.model_name),
             api_base=model.get("api_base", cls.api_base),
             api_key=secret_api_key or model.get("api_key", cls.api_key),
             temperature=model.get("temperature", cls.temperature),

--- a/server.py
+++ b/server.py
@@ -2383,7 +2383,15 @@ def _main():
         from graph.config_io import is_setup_complete
         ready = _graph is not None
         return JSONResponse(
-            {"ok": ready, "graph_compiled": ready, "setup_complete": is_setup_complete(), "ui": ui},
+            {
+                "ok": ready,
+                "graph_compiled": ready,
+                "setup_complete": is_setup_complete(),
+                "ui": ui,
+                # Surface the active model so eval reports can be tagged with the
+                # model under test without guessing (evals.runner auto-detects).
+                "model": _graph_config.model_name if _graph_config else None,
+            },
             status_code=200 if ready else 503,
         )
 

--- a/tests/test_eval_sweep.py
+++ b/tests/test_eval_sweep.py
@@ -1,0 +1,115 @@
+"""Tests for the model-comparison eval tooling (sweep + trend + tagging).
+
+These exercise the pure rendering/aggregation logic and the model-tag wiring
+without booting an agent — the live boot path is covered manually via
+``python -m evals.sweep``.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+
+import pytest
+
+from evals.report import build_report
+from evals.runner import CaseResult, _save_report
+from evals.sweep import _render_matrix, _slug
+
+
+def _fake_report(model: str, *, ts: str, rows: list[tuple[str, str, bool]]) -> dict:
+    """rows: (id, category, passed)."""
+    return {
+        "ts": ts,
+        "model": model,
+        "total": len(rows),
+        "passed": sum(1 for _, _, p in rows if p),
+        "results": [
+            {"id": i, "category": c, "name": i, "passed": p, "detail": "", "duration_ms": 100, "tokens": 50}
+            for i, c, p in rows
+        ],
+    }
+
+
+# ── model-swap env override ──────────────────────────────────────────────────
+
+
+def test_protoagent_model_env_overrides_yaml(monkeypatch):
+    from graph.config import LangGraphConfig
+
+    monkeypatch.setenv("PROTOAGENT_MODEL", "vendor/some-test-model")
+    cfg = LangGraphConfig.from_yaml("config/langgraph-config.yaml")
+    assert cfg.model_name == "vendor/some-test-model"
+
+
+def test_yaml_model_used_when_env_unset(monkeypatch):
+    from graph.config import LangGraphConfig
+
+    monkeypatch.delenv("PROTOAGENT_MODEL", raising=False)
+    cfg = LangGraphConfig.from_yaml("config/langgraph-config.yaml")
+    # Whatever the YAML/default is, it must not be the env sentinel above.
+    assert cfg.model_name and cfg.model_name != "vendor/some-test-model"
+
+
+# ── report tagging ───────────────────────────────────────────────────────────
+
+
+def test_save_report_tags_model_and_base_url(tmp_path):
+    out = tmp_path / "run.json"
+    _save_report(
+        [CaseResult("c1", "tool", "n", True, "OK")],
+        out, model="vendor/m1", base_url="http://x:7990",
+    )
+    payload = json.loads(out.read_text())
+    assert payload["model"] == "vendor/m1"
+    assert payload["base_url"] == "http://x:7990"
+
+
+# ── sweep matrix ─────────────────────────────────────────────────────────────
+
+
+def test_slug_is_filesystem_safe():
+    assert _slug("protolabs/reasoning") == "protolabs-reasoning"
+    assert "/" not in _slug("a/b:c")
+
+
+def test_render_matrix_ranks_best_model_first():
+    reports = {
+        "good": _fake_report("good", ts="2026-06-01T00:00:00", rows=[("a", "tool", True), ("b", "tool", True)]),
+        "bad": _fake_report("bad", ts="2026-06-01T00:00:00", rows=[("a", "tool", False), ("b", "tool", False)]),
+    }
+    md = _render_matrix(reports)
+    assert "# Model sweep" in md
+    # Best model (good) appears above the worse one in the leaderboard.
+    assert md.index("`good`") < md.index("`bad`")
+    assert "tool" in md and "Overall" in md
+
+
+# ── trend report ─────────────────────────────────────────────────────────────
+
+
+def test_build_report_leaderboard_and_trend():
+    runs = [
+        _fake_report("m1", ts="2026-06-01T00:00:00", rows=[("a", "tool", True), ("b", "simple", False)]),
+        _fake_report("m1", ts="2026-06-02T00:00:00", rows=[("a", "tool", True), ("b", "simple", True)]),
+        _fake_report("m2", ts="2026-06-02T00:00:00", rows=[("a", "tool", False), ("b", "simple", False)]),
+    ]
+    md = build_report(runs)
+    assert "Leaderboard" in md and "Trend" in md
+    # m1's latest (2/2) beats m2 (0/2) → ranked first.
+    assert md.index("`m1`") < md.index("`m2`")
+    # Trend shows the improvement arrow for m1's second run.
+    assert "▲" in md
+
+
+def test_build_report_filters_to_one_model():
+    runs = [
+        _fake_report("m1", ts="2026-06-01T00:00:00", rows=[("a", "tool", True)]),
+        _fake_report("m2", ts="2026-06-01T00:00:00", rows=[("a", "tool", True)]),
+    ]
+    md = build_report(runs, only_model="m1")
+    assert "`m1`" in md and "`m2`" not in md
+
+
+def test_build_report_handles_no_runs():
+    assert "No model-tagged" in build_report([])


### PR DESCRIPTION
## What

Turns the eval harness into something you can **track over time** and use to **swap models and compare** — the two things the existing (solid) side-effect-verified harness couldn't do, because reports weren't model-tagged and there was no cross-model orchestration.

## Changes
- **Model-tagged reports.** Every `run-*.json` now records the **model under test**, auto-detected from `GET /healthz` (which now returns the active `model`); `--model-label` overrides. So you can always tell which model produced a run.
- **`PROTOAGENT_MODEL` env override** (`graph/config.py`) wins over the YAML `model.name` — swap the model under test without a config edit. This is what makes an automated sweep possible.
- **`evals/sweep.py`** — one command boots a throwaway `--ui none` agent per model (its own port + `PROTOAGENT_INSTANCE`, so models never share data), runs the suite tagged with each, tears each down + cleans instance data, and prints a `model × category` pass-rate matrix + avg latency/tokens. It sets a bearer token in the child env so the auth-gating cases are genuinely exercised.
- **`evals/report.py`** — aggregates every model-tagged report into a **leaderboard** (latest standing per model, best first) + a **per-model trend** (pass rate by run, ▲/▼ vs the previous run).
- `evals/results/` is gitignored (run artifacts, not source); the A2A client gains `health()` + `run_workflow()` helpers.

## Example

```
| Model                 | a2a-protocol | **Overall**    |
|-----------------------|--------------|----------------|
| `protolabs/reasoning` | 3/3 (100%)   | **3/3 (100%)** |
| `protolabs/agent`     | 1/3 (33%)    | **1/3 (33%)**  |
```

## Validated live
Swept `protolabs/reasoning` vs `protolabs/agent` on the `a2a-protocol` category — the orchestration boots both, tags + scores + tears down, renders the matrix, and the trend report shows the leaderboard with the ▲ improvement arrow after the auth-token fix. Reasoning's ~7.5s vs agent's ~0.3s avg latency shows up in the footnote (a thinking model vs not).

## Design
Builds directly on existing primitives — side-effect verification, `/healthz`, per-instance data scoping (ADR 0004), the UI-less tier (ADR 0010). Boot-per-model (vs runtime per-request model binding) was chosen for clean isolation; see [ADR 0012](https://github.com/protoLabsAI/protoAgent/blob/feat/eval-model-comparison/docs/adr/0012-eval-strategy-and-model-comparison.md).

## Follow-up (ADR 0012 §2.5)
Coverage for the layers we've been building — subagent delegation cases, workflow-recipe cases (`deep-research` end-to-end), and an LLM-judge rubric for research quality — lands in the next PR, now that reports are model-tagged.

## Tests
`tests/test_eval_sweep.py` (8) — env override wins/falls-through, report tagging, sweep matrix ranking, trend leaderboard + filter + empty. Full suite green (902 + 8); docs build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)