### PR TITLE
fix: declare fastapi in requirements-core (lean image couldn't serve)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Lean Docker image (`--ui none`/`console`) couldn't serve** — `fastapi` was
+  never declared in any requirements file; it came in only transitively via
+  Gradio, which the lean tiers drop (ADR 0010). The lean image therefore had no
+  FastAPI and the server couldn't start. Declared `fastapi` in
+  `requirements-core.txt` (caught by the runtime-image pytest-collection check).
+
 ### Added
 - **Eval coverage for the agent layer** (ADR 0012 §2.5): new `subagent` +
   `workflow` eval categories track the research stack. A `workflow` case kind

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -2,6 +2,11 @@
 # run in the `console` and `none` UI tiers (ADR 0010). The Gradio UI lives in
 # requirements-ui.txt; `requirements.txt` = core + ui (the all-in-one install).
 httpx>=0.27
+# Web framework for the API / A2A / operator routes (server.py, operator_api/).
+# Previously satisfied only transitively via Gradio — but the lean tiers
+# (--ui none/console) drop Gradio (requirements-ui.txt), so the lean image had
+# no FastAPI and couldn't serve. Declared here as the core runtime dep it is.
+fastapi>=0.115
 uvicorn>=0.30
 langfuse>=3.0
 prometheus-client>=0.20


### PR DESCRIPTION
## The bug

`fastapi` is declared in **no** requirements file. It was only ever installed **transitively via Gradio**. The ADR 0010 UI-tier split (v0.8.0) moved Gradio into `requirements-ui.txt`, so the lean tiers — `--ui none` / `--ui console`, and the **default Docker image** (`ARG UI=none` → `requirements-core.txt`) — install core only and end up with **no FastAPI**.

Result: the lean server can't import its own framework, and the `docker-publish` "Verify — pytest collection in runtime image" step went red on every main push since v0.8.0:

```
ModuleNotFoundError: No module named 'fastapi'
  (across test_a2a_handler, test_activity, test_confidence, … — every server-importing module)
```

Local dev and `checks.yml` never caught it because both use the full install (`requirements.txt` → Gradio → FastAPI).

## The fix
Declare `fastapi>=0.115` in `requirements-core.txt` — it's the core API/A2A/operator-routes framework (`server.py`, `operator_api/`), which the file's own header already claims to cover. (`fastapi.staticfiles`/`responses` are all the server imports; FastAPI pulls Starlette + Pydantic transitively, and no `sse-starlette`/`python-multipart` imports exist.)

## Validation
The failing signal is the docker-publish runtime-image collection step, which runs on push to main (not on PRs) — so it's validated when this merges and the next main publish goes green. Causation is unambiguous: Gradio was the sole transitive provider, the lean tier drops it, and adding the direct dep restores it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)