### PR TITLE
chore: retire the protolabs/agent alias from docs + fixtures

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- Retired the `protolabs/agent` gateway alias from docs, eval examples, and test
+  fixtures (use `protolabs/smart` / `protolabs/reasoning`). The default model is
+  already `protolabs/reasoning`; this just clears the dead alias from examples.
+
 ### Fixed
 - **Lean Docker image (`--ui none`/`console`) couldn't serve** — `fastapi` was
   never declared in any requirements file; it came in only transitively via

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -48,7 +48,7 @@ share data), runs the suite tagged with each model, tears each down, and prints 
 `model × category` matrix:
 
 ```bash
-python -m evals.sweep --models protolabs/reasoning,protolabs/agent
+python -m evals.sweep --models protolabs/reasoning,protolabs/smart
 python -m evals.sweep --models a,b,c --category tool      # one category
 python -m evals.sweep --models a,b --tasks current_time_intent --keep
 ```
@@ -57,7 +57,7 @@ python -m evals.sweep --models a,b --tasks current_time_intent --keep
 | Model                 | a2a-protocol | tool        | **Overall**     |
 |-----------------------|--------------|-------------|-----------------|
 | `protolabs/reasoning` | 3/3 (100%)   | 6/6 (100%)  | **9/9 (100%)**  |
-| `protolabs/agent`     | 3/3 (100%)   | 4/6 (67%)   | **7/9 (78%)**   |
+| `protolabs/smart`     | 3/3 (100%)   | 4/6 (67%)   | **7/9 (78%)**   |
 ```
 
 **Track the trend** across every run on the box — `evals/report.py` aggregates

--- a/evals/README.md
+++ b/evals/README.md
@@ -36,7 +36,7 @@ overridable with `--model-label`).
 # Boot one agent per model, run the suite against each, print a
 # model × category matrix. Each model gets its own throwaway --ui none
 # instance (PROTOAGENT_MODEL env override + a unique PROTOAGENT_INSTANCE).
-python -m evals.sweep --models protolabs/reasoning,protolabs/agent
+python -m evals.sweep --models protolabs/reasoning,protolabs/smart
 python -m evals.sweep --models a,b,c --category tool
 
 # Leaderboard + per-model trend across every report on the box.

--- a/evals/sweep.py
+++ b/evals/sweep.py
@@ -17,7 +17,7 @@ How it works (per model):
 
 Usage::
 
-    python -m evals.sweep --models protolabs/reasoning,protolabs/agent
+    python -m evals.sweep --models protolabs/reasoning,protolabs/smart
     python -m evals.sweep --models a,b,c --category tool
     python -m evals.sweep --models a,b --tasks current_time,daily_log --keep
 

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -45,7 +45,7 @@ def test_anthropic_caches_stable_prefix_and_delivers_context():
 
 def test_non_anthropic_delivers_context_without_cache_control():
     mw = PromptCacheMiddleware()
-    req = _Req("protolabs/agent", SystemMessage(content="PROMPT"),
+    req = _Req("protolabs/reasoning", SystemMessage(content="PROMPT"),
                state={"context": "knowledge here"})
     out = _run(mw, req)
     # plain string append, no cache_control blocks (safe for any provider)
@@ -79,7 +79,7 @@ def test_ttl_persistent_tier():
 
 def test_force_caches_non_anthropic():
     mw = PromptCacheMiddleware(force=True)
-    req = _Req("protolabs/agent", SystemMessage(content="P"), state={})
+    req = _Req("protolabs/reasoning", SystemMessage(content="P"), state={})
     out = _run(mw, req)
     assert out.system_message.content[0]["cache_control"] == {"type": "ephemeral"}
 


### PR DESCRIPTION
`protolabs/agent` is retired. This clears the dead alias from everything that presents it as a live option:

- **Eval sweep examples** (`docs/guides/evals.md`, `evals/README.md`, `evals/sweep.py` docstring) → `protolabs/smart`.
- **Sample matrix row** in the evals guide → `protolabs/smart`.
- **Prompt-cache test fixtures** (`tests/test_prompt_cache.py`) — they only need a *non-Anthropic* model name to assert no `cache_control` is applied → `protolabs/reasoning`.

The **historical CHANGELOG line** (v0.7.0: "Default model alias is now `protolabs/reasoning` (was `protolabs/agent`)") is **left intact** — it's an accurate record of the switch away from the alias, not a live reference. The default model is already `protolabs/reasoning`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)