### PR TITLE
feat(desktop): dynamic sidecar port + console UI tier

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one-off flakes that still clear the majority.
 
 ### Changed
+- **Desktop sidecar now picks a free port + runs the `console` UI tier.** The
+  Tauri shell (`apps/desktop`) probes a free port instead of hardcoding 7870
+  (so it coexists with any agent already on 7870, and is the base for running
+  several agents at once), spawns the bundled server with `--ui console`
+  (replacing the deprecated `--headless` alias), and injects the chosen base URL
+  as `window.__PROTOAGENT_API_BASE__` before page load — the React console reads
+  it (`localStorage["protoagent.apiBase"]` still overrides). The "main" window is
+  now created in `src/lib.rs` (so the init script can run pre-load) rather than
+  declared in `tauri.conf.json`.
 - Retired the `protolabs/agent` gateway alias from docs, eval examples, and test
   fixtures (use `protolabs/smart` / `protolabs/reasoning`). The default model is
   already `protolabs/reasoning`; this just clears the dead alias from examples.

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -5,7 +5,7 @@ Tauri v2 wrapper for the React operator console.
 ## Commands
 
 ```bash
-# 1. Freeze the headless server into the bundled sidecar (per platform).
+# 1. Freeze the server into the bundled sidecar (per platform).
 #    Needs a venv with the runtime deps + PyInstaller:
 #      pip install -r requirements.txt pyinstaller
 npm run desktop:sidecar
@@ -23,13 +23,13 @@ npm run desktop:dev
 
 The app **bundles and launches the protoAgent server itself** as a Tauri sidecar — no separately-running server required.
 
-- `apps/desktop/sidecar/build_sidecar.py` freezes the server (`server.py --headless`) into a single binary via PyInstaller, named `binaries/protoagent-server-<target-triple>` (the `externalBin` Tauri bundles). Gradio is excluded — the React console is the UI — so the binary is ~55 MB rather than carrying the full UI stack.
-- On launch the Rust shell (`src-tauri/src/lib.rs`) spawns the sidecar with `--headless --port 7870`, sets `PROTOAGENT_CONFIG_DIR` to the per-user app-config dir (so the read-only binary still persists setup/secrets), drains its output to the log, and kills it on app exit.
-- The webview loads the bundled React build and calls the sidecar's `/api`, `/a2a`, and `/v1` on `127.0.0.1:7870`. The console probes with backoff on startup so the few-second cold start doesn't surface as an error.
+- `apps/desktop/sidecar/build_sidecar.py` freezes the server into a single binary via PyInstaller, named `binaries/protoagent-server-<target-triple>` (the `externalBin` Tauri bundles). Gradio is excluded — the React console is the UI — so the binary is ~60 MB rather than carrying the full UI stack.
+- On launch the Rust shell (`src-tauri/src/lib.rs`) **picks a free port**, spawns the sidecar with `--ui console --port <port>` (the console UI tier — API + A2A + console, no Gradio; ADR 0010), sets `PROTOAGENT_CONFIG_DIR` to the per-user app-config dir (so the read-only binary still persists setup/secrets), drains its output to the log, and kills it on app exit. A free port (not a fixed 7870) means the desktop coexists with any other agent already running — and is the foundation for several agents at once.
+- The shell creates the window itself and injects `window.__PROTOAGENT_API_BASE__` (the chosen `http://127.0.0.1:<port>`) before any page script runs; the webview's React build reads it (`apps/web/src/lib/api.ts`) and calls the sidecar's `/api`, `/a2a`, and `/v1`. The console probes with backoff on startup so the few-second cold start doesn't surface as an error.
 
 The sidecar binary is gitignored — it's a build artifact produced per platform by step 1 (locally or in CI before `tauri build`).
 
-To point the desktop UI at a *different* server instead of the bundled one, set `protoagent.apiBase` in localStorage to the desired base URL.
+To point the desktop UI at a *different* server instead of the bundled one, set `protoagent.apiBase` in localStorage (it wins over the injected port).
 
 ## Desktop Behavior
 

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -1,9 +1,10 @@
+use std::net::TcpListener;
 use std::sync::Mutex;
 
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    AppHandle, Manager, RunEvent, Runtime, WindowEvent,
+    AppHandle, Manager, RunEvent, Runtime, WebviewUrl, WebviewWindowBuilder, WindowEvent,
 };
 use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
 use tauri_plugin_shell::{
@@ -11,21 +12,32 @@ use tauri_plugin_shell::{
     ShellExt,
 };
 
-/// Port the bundled server binds and the React console talks to. Matches the
-/// connect-to-local-server default in `apps/web/src/lib/api.ts`.
-const SIDECAR_PORT: &str = "7870";
+/// Fallback port if probing for a free one fails (matches the historical
+/// hardcoded default + the web client's last-resort base).
+const FALLBACK_PORT: u16 = 7870;
+
+/// Pick a free localhost port for the bundled sidecar, so several agents (and a
+/// pre-existing server on 7870) can coexist without a collision. We bind :0,
+/// read the OS-assigned port, then drop the listener and hand the port to the
+/// sidecar — a tiny TOCTOU window, acceptable for a single local launch.
+fn pick_free_port() -> u16 {
+    TcpListener::bind("127.0.0.1:0")
+        .and_then(|l| l.local_addr())
+        .map(|addr| addr.port())
+        .unwrap_or(FALLBACK_PORT)
+}
 
 /// Holds the running sidecar so it can be killed when the app exits.
 #[derive(Default)]
 struct SidecarProcess(Mutex<Option<CommandChild>>);
 
-/// Launch the bundled headless protoAgent server as a sidecar.
+/// Launch the bundled protoAgent server (console UI tier) as a sidecar.
 ///
 /// The frozen binary is read-only, so its writable state (live config,
 /// secrets, setup marker) is pointed at the per-user app-config dir via
 /// `PROTOAGENT_CONFIG_DIR`. Failures are logged, not fatal — the window still
 /// opens (and shows the API error) rather than the whole app refusing to boot.
-fn spawn_sidecar<R: Runtime>(app: &AppHandle<R>) {
+fn spawn_sidecar<R: Runtime>(app: &AppHandle<R>, port: u16) {
     let config_dir = match app.path().app_config_dir() {
         Ok(dir) => dir,
         Err(e) => {
@@ -45,9 +57,13 @@ fn spawn_sidecar<R: Runtime>(app: &AppHandle<R>) {
             return;
         }
     };
+    let port_arg = port.to_string();
     let command = command
-        .args(["--headless", "--port", SIDECAR_PORT])
-        .env("PROTOAGENT_HEADLESS", "1")
+        // The desktop renders the React operator console, so run the server in
+        // its 'console' UI tier (API + A2A + console, no Gradio) — ADR 0010.
+        // (Was the now-deprecated --headless / PROTOAGENT_HEADLESS alias.)
+        .args(["--ui", "console", "--port", &port_arg])
+        .env("PROTOAGENT_UI", "console")
         .env("PROTOAGENT_CONFIG_DIR", config_dir.to_string_lossy().to_string());
 
     let (mut rx, child) = match command.spawn() {
@@ -179,7 +195,25 @@ pub fn run() {
                 )?;
             }
             app.manage(SidecarProcess::default());
-            spawn_sidecar(app.handle());
+
+            // Pick a free port, boot the sidecar on it, and create the window
+            // ourselves so we can inject the chosen API base *before* any page
+            // script runs (race-free). The web client reads
+            // `window.__PROTOAGENT_API_BASE__` (see apps/web/src/lib/api.ts).
+            let port = pick_free_port();
+            spawn_sidecar(app.handle(), port);
+            let init = format!(
+                "window.__PROTOAGENT_API_BASE__ = \"http://127.0.0.1:{port}\";"
+            );
+            WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
+                .title("protoAgent")
+                .inner_size(1280.0, 820.0)
+                .min_inner_size(980.0, 640.0)
+                .resizable(true)
+                .center()
+                .initialization_script(&init)
+                .build()?;
+
             build_tray(app)?;
             Ok(())
         })

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -10,19 +10,7 @@
     "beforeBuildCommand": "npm --workspace @protoagent/web run build -- --base ./"
   },
   "app": {
-    "windows": [
-      {
-        "label": "main",
-        "title": "protoAgent",
-        "width": 1280,
-        "height": 820,
-        "minWidth": 980,
-        "minHeight": 640,
-        "resizable": true,
-        "center": true,
-        "fullscreen": false
-      }
-    ],
+    "windows": [],
     "security": {
       "csp": null
     }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -70,6 +70,13 @@ function defaultApiBase() {
   }
   if (savedBase) return savedBase.replace(/\/$/, "");
 
+  // The Tauri desktop shell boots its bundled server on a dynamically-chosen
+  // free port and injects the base URL here before any page script runs
+  // (apps/desktop/src-tauri/src/lib.rs). Prefer it over the legacy fixed port.
+  const injected = (window as unknown as { __PROTOAGENT_API_BASE__?: string })
+    .__PROTOAGENT_API_BASE__;
+  if (injected) return injected.replace(/\/$/, "");
+
   const { hostname, protocol } = window.location;
   if (protocol === "tauri:" || protocol === "file:" || hostname === "tauri.localhost") {
     return "http://127.0.0.1:7870";


### PR DESCRIPTION
## What

Gets the Tauri desktop app running cleanly against the React console, and stops it colliding with an already-running agent.

The shell hardcoded its bundled sidecar on **7870** (so it clashed with, or would unintentionally drive, any agent already there — e.g. an autostart instance) and spawned it with the deprecated **`--headless`** flag.

- **Free-port probe** — the shell binds `127.0.0.1:0`, takes the OS-assigned port, and passes it to the sidecar. The desktop now coexists with an existing 7870 agent, and it's the foundation for running several agents at once.
- **`--ui console`** — replaces the deprecated `--headless` / `PROTOAGENT_HEADLESS` alias (ADR 0010 tier).
- **Port handoff to the webview** — the `main` window is now created in `src/lib.rs` (removed from `tauri.conf.json`) so an `initialization_script` can inject `window.__PROTOAGENT_API_BASE__ = http://127.0.0.1:<port>` *before any page script runs* (race-free). `apps/web/src/lib/api.ts::defaultApiBase()` reads it; `localStorage["protoagent.apiBase"]` still overrides (for pointing at a remote server).

## Validated live

`npm run desktop:dev` (with the sidecar re-frozen against current `server.py`):

```
[sidecar] Starting protoagent (ui=console) on http://0.0.0.0:49430
[sidecar] GET /api/runtime/status 200 OK
[sidecar] GET /api/subagents 200 OK
[sidecar] GET /api/config 200 OK
[sidecar] GET /api/events 200 OK
```

Sidecar booted on an OS-assigned port (**49430, not 7870** — the existing agent was untouched), and the React console loaded and drove it via the injected base URL. Compiles clean: `cargo check` + `web:build` (tsc) both pass.

## Context

This is the desktop half of consolidating agents under **Orbis's** menu-bar dropdown (one icon for the ecosystem) rather than one tray icon per agent. Coordination issue filed: **protoLabsAI/ORBIS#325** (registration / launch / port-assignment contract). The free-port + `--ui console` + sidecar model here is exactly what Orbis can drive.

> Note: the prebuilt sidecar binary is gitignored (built per-platform via `npm run desktop:sidecar` before `tauri build`), so this PR is shell + web + config only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)