### PR TITLE
fix(web): right panel blanks into a reserved column at narrow widths

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -28,7 +28,7 @@ import {
   Workflow,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
-import type { ReactNode } from "react";
+import type { CSSProperties, ReactNode } from "react";
 
 import { ActivitySurface } from "../activity/ActivitySurface";
 import { ConfirmDialog } from "./ConfirmDialog";
@@ -826,7 +826,11 @@ export function App() {
     window.addEventListener("mouseup", onUp);
   }
 
-  const workspaceCols = `72px minmax(0, 1fr) ${rightCollapsed ? "0px" : `${rightWidth}px`}`;
+  // Drive only the right column's WIDTH via a CSS var — the grid template
+  // itself lives in CSS (.workspace), so the responsive media query can
+  // collapse to two columns below the breakpoint. Setting the full template
+  // inline here would beat the media query and leave a blank reserved column.
+  const rightCol = rightCollapsed ? "0px" : `${rightWidth}px`;
 
   // One glanceable health light for the topbar (detail on hover; full status in
   // System → Runtime). Worst-state wins.
@@ -869,7 +873,7 @@ export function App() {
 
       <div
         className={`workspace ${rightCollapsed ? "right-collapsed" : ""}`}
-        style={{ gridTemplateColumns: workspaceCols }}
+        style={{ "--right-width": rightCol } as CSSProperties}
       >
         <aside className="rail" aria-label="Workspace surfaces">
           <RailButton

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -213,7 +213,11 @@ h2 {
 .workspace {
   min-height: 0;
   display: grid;
-  grid-template-columns: 72px minmax(0, 1fr) minmax(320px, 380px);
+  /* The right column's width comes from --right-width (set inline in App.tsx
+     from the persisted/resized panel width; 0px when collapsed). Keeping the
+     template in CSS — not inline — lets the media query below collapse to two
+     columns instead of leaving a blank reserved column. */
+  grid-template-columns: 72px minmax(0, 1fr) var(--right-width, 360px);
 }
 
 .rail {
@@ -2193,7 +2197,12 @@ textarea {
   }
 }
 
-@media (max-width: 1040px) {
+/* Below this width there isn't room for the rail + chat + side panel, so drop
+   to two columns and hide the panel (reachable again by widening / the toggle).
+   Kept under the desktop's 980px min window so the panel stays put there; this
+   mainly affects narrow browser windows. The two-column template here now
+   actually wins because .workspace no longer sets its columns inline. */
+@media (max-width: 900px) {
   .workspace {
     grid-template-columns: 64px minmax(0, 1fr);
   }


### PR DESCRIPTION
## Symptom
At narrower window widths the right-hand panel (Notes/Beads) disappears but **leaves a blank reserved column** to the right of the chat; widening the window past ~1040px makes the content reappear. (Reported on the desktop app.)

## Cause
`.workspace` set its `grid-template-columns` **inline** (`App.tsx`: `72px 1fr <rightWidth>px`). Inline styles beat media queries, so the responsive rule meant to collapse the layout couldn't:

```css
@media (max-width: 1040px) {
  .workspace { grid-template-columns: 64px minmax(0,1fr); }  /* lost to the inline style */
  .right-panel { display: none; }                            /* still applied */
}
```

Below 1040px the grid kept a ~360px third track (from the inline style) while the panel's content was hidden → a blank column.

## Fix
- **App.tsx** — set only the column *width* via a `--right-width` CSS var inline; the grid template stays in CSS. The media query can now actually collapse to two columns (no orphaned track). `localStorage`/resize still drive the width (now through the var).
- **theme.css** — `.workspace` uses `var(--right-width, 360px)`; collapse breakpoint lowered **1040px → 900px**, which sits under the desktop's 980px min window so the side panel stays visible in the desktop and wider browsers; only genuinely narrow browser windows drop to two columns.

## Result
No more blank column. ≥900px: rail + chat + side panel. <900px: clean two-column (rail + chat), panel reachable via the toggle or by widening. `web:build` (tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)