### PR TITLE
fix(desktop): don't orphan the sidecar server on exit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already `protolabs/reasoning`; this just clears the dead alias from examples.
 
 ### Fixed
+- **Desktop orphaned its sidecar server on exit** — a PyInstaller onefile runs
+  as a bootloader + re-exec'd child, so the Tauri shell killing the tracked
+  process on quit left the real server alive (holding its port; they accumulated
+  across open/close cycles). The shell now passes `PROTOAGENT_PARENT_PID` and the
+  server runs a parent-death watchdog that exits when the launcher goes away
+  (clean quit, crash, or SIGKILL). No-op for standalone/container runs.
 - **Lean Docker image (`--ui none`/`console`) couldn't serve** — `fastapi` was
   never declared in any requirements file; it came in only transitively via
   Gradio, which the lean tiers drop (ADR 0010). The lean image therefore had no

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -64,6 +64,9 @@ fn spawn_sidecar<R: Runtime>(app: &AppHandle<R>, port: u16) {
         // (Was the now-deprecated --headless / PROTOAGENT_HEADLESS alias.)
         .args(["--ui", "console", "--port", &port_arg])
         .env("PROTOAGENT_UI", "console")
+        // So the sidecar exits if we die without a clean kill (the frozen
+        // onefile's child process otherwise outlives us, holding its port).
+        .env("PROTOAGENT_PARENT_PID", std::process::id().to_string())
         .env("PROTOAGENT_CONFIG_DIR", config_dir.to_string_lossy().to_string());
 
     let (mut rx, child) = match command.spawn() {

--- a/server.py
+++ b/server.py
@@ -100,6 +100,40 @@ _event_bus = EventBus()  # Server→client SSE push channel (ADR 0003). Process-
                          # streams to connected consoles.
 
 
+def _install_parent_death_watchdog() -> None:
+    """Exit if the launcher process (``PROTOAGENT_PARENT_PID``) goes away.
+
+    Set by the desktop's Tauri shell (apps/desktop/src-tauri/src/lib.rs) when it
+    spawns this server as a sidecar. A PyInstaller onefile runs as a bootloader
+    + re-exec'd child, so the shell killing the tracked bootloader on exit can
+    leave this process orphaned and holding its port. Polling the launcher PID
+    and exiting when it dies reaps the whole tree regardless of how the shell
+    went away (clean quit, crash, or SIGKILL). No-op when the env isn't set
+    (normal standalone / container runs)."""
+    ppid_s = os.environ.get("PROTOAGENT_PARENT_PID")
+    if not ppid_s:
+        return
+    try:
+        ppid = int(ppid_s)
+    except ValueError:
+        return
+
+    import threading
+
+    def _watch() -> None:
+        while True:
+            time.sleep(2)
+            try:
+                os.kill(ppid, 0)  # signal 0 = liveness probe; raises if gone
+            except OSError:
+                log.info("[watchdog] launcher pid %d gone — exiting sidecar", ppid)
+                os._exit(0)
+            except Exception:  # noqa: BLE001 — never let the watchdog crash the server
+                return
+
+    threading.Thread(target=_watch, daemon=True, name="parent-death-watchdog").start()
+
+
 def _init_langgraph_agent(headless_setup: bool = False):
     """Initialize the LangGraph backend — setup-aware.
 
@@ -2737,6 +2771,12 @@ def _main():
     else:
         app = fastapi_app
         log.info("Starting %s (ui=%s) on http://0.0.0.0:%d", agent_name(), ui, args.port)
+
+    # Don't outlive the launcher. When run as a desktop sidecar the Tauri shell
+    # sets PROTOAGENT_PARENT_PID; a PyInstaller-frozen onefile runs as a
+    # bootloader + child, so the shell killing the bootloader can leave this
+    # server orphaned (holding its port). Poll the launcher and exit if it dies.
+    _install_parent_death_watchdog()
 
     uvicorn.run(app, host="0.0.0.0", port=args.port)
 


### PR DESCRIPTION
## Symptom
Closing the desktop app (or quitting it) left its bundled server process **running and holding its port**. They accumulated across open/close cycles — I found three orphaned dev sidecars (ports 49430, 50897, …) reparented to `launchd` with no window attached.

## Cause
The PyInstaller **onefile** sidecar runs as a *bootloader + re-exec'd child*. The Tauri shell tracks/kills the bootloader on exit (`CommandChild::kill`), but the actual server (the child) survives — and on an unclean shell exit, nothing gets killed at all.

## Fix
A parent-death watchdog so the server can't outlive its launcher:
- `apps/desktop/src-tauri/src/lib.rs` passes `PROTOAGENT_PARENT_PID = std::process::id()` when spawning the sidecar.
- `server.py::_install_parent_death_watchdog()` — a daemon thread polls that pid (`os.kill(pid, 0)`) and `os._exit(0)`s when it's gone, reaping the whole tree no matter how the shell died (clean quit, crash, SIGKILL). No-op when `PROTOAGENT_PARENT_PID` is unset, so standalone/container runs are unaffected.

## Validated
Launched the server with `PROTOAGENT_PARENT_PID=<dummy>`, killed the dummy parent, and the server self-exited within ~2s:
```
[watchdog] launcher pid 16751 gone — exiting sidecar
```
`cargo check` + `server.py` parse clean. (Also cleaned up the existing orphans on my machine.)

> The frozen sidecar binary is a gitignored build artifact (re-frozen via `npm run desktop:sidecar` at build/release time), so this PR is source-only — server + shell + changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)