### PR TITLE
fix(desktop): resolve a stable console project root when frozen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already `protolabs/reasoning`; this just clears the dead alias from examples.
 
 ### Fixed
+- **Frozen desktop: console project APIs hit a nonexistent path** — the operator
+  console's default project root was `__file__`'s dir, which in a PyInstaller
+  onefile is the ephemeral `_MEIxxxx` extraction dir, so notes/beads failed with
+  "project_path does not exist". It now resolves a stable dir when frozen
+  (`PROTOAGENT_PROJECT_DIR` override → the desktop's `PROTOAGENT_CONFIG_DIR` →
+  home); a source checkout still uses the repo root.
 - **Desktop orphaned its sidecar server on exit** — a PyInstaller onefile runs
   as a bootloader + re-exec'd child, so the Tauri shell killing the tracked
   process on quit left the real server alive (holding its port; they accumulated

--- a/server.py
+++ b/server.py
@@ -100,6 +100,27 @@ _event_bus = EventBus()  # Server→client SSE push channel (ADR 0003). Process-
                          # streams to connected consoles.
 
 
+def _resolve_operator_project_root() -> str:
+    """The operator console's default project root (+ its always-allowed dir).
+
+    In a source checkout this is the repo root (``__file__``'s dir). But in a
+    PyInstaller-frozen sidecar (the desktop app) ``__file__`` lives inside the
+    ephemeral ``_MEIxxxx`` onefile extraction dir — which doesn't persist and
+    isn't a real workspace, so the console's project-scoped APIs (notes/beads)
+    fail with "project_path does not exist". Resolve a stable, writable dir
+    instead: an explicit ``PROTOAGENT_PROJECT_DIR`` wins; else (when frozen) the
+    per-user app dir the desktop already provides via ``PROTOAGENT_CONFIG_DIR``,
+    else the home dir."""
+    env = os.environ.get("PROTOAGENT_PROJECT_DIR")
+    if env:
+        return str(Path(env).expanduser().resolve())
+    if getattr(sys, "frozen", False):
+        cfg = os.environ.get("PROTOAGENT_CONFIG_DIR")
+        base = Path(cfg) if cfg else Path.home()
+        return str(base.expanduser().resolve())
+    return str(Path(__file__).parent.resolve())
+
+
 def _install_parent_death_watchdog() -> None:
     """Exit if the launcher process (``PROTOAGENT_PARENT_PID``) goes away.
 
@@ -2045,7 +2066,7 @@ def _main():
         run_manual_subagent_batch as _operator_run_manual_subagent_batch,
     )
 
-    _operator_repo_root = str(Path(__file__).parent.resolve())
+    _operator_repo_root = _resolve_operator_project_root()
 
     def _operator_allowed_dirs() -> list[str]:
         # The repo root is always operable (it's the default project);

--- a/tests/test_operator_project_root.py
+++ b/tests/test_operator_project_root.py
@@ -1,0 +1,40 @@
+"""The operator console's default project root must resolve to a real, stable
+dir — never PyInstaller's ephemeral _MEIxxxx onefile extraction dir (which broke
+notes/beads in the frozen desktop sidecar with "project_path does not exist")."""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import server
+
+
+def test_dev_checkout_uses_repo_root(monkeypatch):
+    monkeypatch.delenv("PROTOAGENT_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("PROTOAGENT_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+    assert server._resolve_operator_project_root() == str(Path("server.py").resolve().parent)
+
+
+def test_explicit_override_wins(monkeypatch, tmp_path):
+    monkeypatch.setenv("PROTOAGENT_PROJECT_DIR", str(tmp_path))
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", "/some/other/dir")
+    assert server._resolve_operator_project_root() == str(tmp_path.resolve())
+
+
+def test_frozen_falls_back_to_config_dir(monkeypatch, tmp_path):
+    monkeypatch.delenv("PROTOAGENT_PROJECT_DIR", raising=False)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path))
+    root = server._resolve_operator_project_root()
+    assert root == str(tmp_path.resolve())
+    assert "_MEI" not in root  # never the PyInstaller temp dir
+
+
+def test_frozen_without_config_uses_home(monkeypatch):
+    monkeypatch.delenv("PROTOAGENT_PROJECT_DIR", raising=False)
+    monkeypatch.delenv("PROTOAGENT_CONFIG_DIR", raising=False)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    assert server._resolve_operator_project_root() == str(Path.home().resolve())


### PR DESCRIPTION
## Symptom
In the desktop app, the console threw **`project_path does not exist: /private/tmp/claude-501/_MEIPzCXTH`** — notes/beads (and any project-scoped API) failed.

## Cause
`/…/_MEIPzCXTH` is PyInstaller's **onefile temp-extraction dir**. The operator console's default project root was `Path(__file__).parent` (`server.py`), which in a frozen onefile resolves *inside* that ephemeral `_MEI…` dir — it doesn't persist, changes per launch, and isn't a real workspace.

## Fix
`_resolve_operator_project_root()`:
1. explicit `PROTOAGENT_PROJECT_DIR` wins;
2. else **when frozen** → the desktop's per-user `PROTOAGENT_CONFIG_DIR` (real, writable, stable — already set by the Tauri shell), else home;
3. else (source checkout) → the repo root, unchanged.

## Tests
`tests/test_operator_project_root.py` — all four branches, including asserting the resolved root never contains `_MEI`. Full suite green.

> Server-only source change; the frozen sidecar binary is a gitignored build artifact (re-frozen at build/release time — I've re-frozen locally so the running desktop picks it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)