### PR TITLE
fix(web): self-heal a stale persisted project path

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -39,7 +39,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   onefile is the ephemeral `_MEIxxxx` extraction dir, so notes/beads failed with
   "project_path does not exist". It now resolves a stable dir when frozen
   (`PROTOAGENT_PROJECT_DIR` override → the desktop's `PROTOAGENT_CONFIG_DIR` →
-  home); a source checkout still uses the repo root.
+  home); a source checkout still uses the repo root. The console also self-heals
+  a stale persisted project path (e.g. a `_MEI` dir saved by an earlier run):
+  if a project API call fails for it, it falls back to the server's default.
 - **Desktop orphaned its sidecar server on exit** — a PyInstaller onefile runs
   as a bootloader + re-exec'd child, so the Tauri shell killing the tracked
   process on quit left the real server alive (holding its port; they accumulated

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -384,11 +384,24 @@ export function App() {
     setError("");
     try {
       const runtimePayload = await refreshRuntime();
-      const nextProjectPath = projectPath.trim() || runtimePayload.project.path;
+      const serverDefault = runtimePayload.project.path;
+      let nextProjectPath = projectPath.trim() || serverDefault;
+      try {
+        await refreshProjectState(nextProjectPath);
+      } catch (projErr) {
+        // The persisted project path is stale/invalid — e.g. a previous frozen
+        // (desktop) run stored a PyInstaller _MEI temp dir that no longer
+        // exists. Self-heal by adopting the server's current default project.
+        if (serverDefault && nextProjectPath !== serverDefault) {
+          nextProjectPath = serverDefault;
+          await refreshProjectState(nextProjectPath);
+        } else {
+          throw projErr;
+        }
+      }
       if (nextProjectPath && nextProjectPath !== projectPath) {
         setProjectPath(nextProjectPath);
       }
-      await refreshProjectState(nextProjectPath);
       setStatus("ready");
     } catch (exc) {
       setStatus("error");


### PR DESCRIPTION
## Follow-on to #433 (client side)

#433 stopped the frozen sidecar from *reporting* a PyInstaller `_MEI` temp dir as the default project. But the console **persists the project path in localStorage** and preferred the stored value over the server default:

```js
const nextProjectPath = projectPath.trim() || runtimePayload.project.path;  // stored wins
```

So a bad path saved by an earlier frozen run stayed stuck, and notes/beads kept returning `400` on it (the symptom: `project_path does not exist: …/_MEIPzCXTH`, unchanged even after the server fix).

## Fix
`refreshAll` now tries the stored path and, on failure, **falls back to the server's current default project** (and persists that). General — no `_MEI` special-casing; any stale/invalid persisted path self-heals on the next refresh.

## Verified live
In the running desktop the stuck `_MEIPzCXTH` path fell back to the app config dir and the notes/beads calls went **400 → 200**:
```
GET /api/notes/workspace?project_path=…/studio.protolabs.protoagent  200 OK
```
`web:build` (tsc) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)