### PR TITLE
feat(desktop): invisible title bar + macOS bundle hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one-off flakes that still clear the majority.
 
 ### Changed
+- **Desktop: invisible title bar + macOS bundle hardening (production prep).**
+  The window uses an overlay/hidden title bar on macOS (`titleBarStyle: Overlay`
+  + `hiddenTitle`) — no chrome, native traffic lights float over the content;
+  the console insets its topbar for the lights and acts as the drag region
+  (`.is-tauri-mac`). The macOS bundle now sets `hardenedRuntime`, an explicit
+  `entitlements.plist` (network client/server + WKWebView JIT only) and
+  `Info.plist` (copyright), and `minimumSystemVersion: 13.0` — the config
+  prerequisites for signing/notarization (the signing itself still needs certs).
 - **Desktop is now a menu-bar app with the protoLabs robot tray icon.** The
   Tauri shell uses the robot mark at the proper menu-bar size (44×44, template /
   system-tinted — `icons/tray-robot.png`) instead of the squished default app

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>NSHumanReadableCopyright</key>
+    <string>Copyright (c) 2026 protoLabs Studio</string>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/entitlements.plist
+++ b/apps/desktop/src-tauri/entitlements.plist
@@ -1,0 +1,17 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <!-- The bundled server makes outbound calls (LLM gateway, web tools) and
+         binds a localhost port for the console/A2A. -->
+    <key>com.apple.security.network.client</key>
+    <true/>
+    <key>com.apple.security.network.server</key>
+    <true/>
+    <!-- Tauri's WKWebView runs JavaScriptCore under the hardened runtime, so it
+         needs the JIT exception. Keep this narrow; do not add camera/microphone
+         or broader code-signing exceptions unless a shipped feature requires it. -->
+    <key>com.apple.security.cs.allow-jit</key>
+    <true/>
+</dict>
+</plist>

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -209,14 +209,24 @@ pub fn run() {
             let init = format!(
                 "window.__PROTOAGENT_API_BASE__ = \"http://127.0.0.1:{port}\";"
             );
-            WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
+            let mut win = WebviewWindowBuilder::new(app, "main", WebviewUrl::default())
                 .title("protoAgent")
                 .inner_size(1280.0, 820.0)
                 .min_inner_size(980.0, 640.0)
                 .resizable(true)
                 .center()
-                .initialization_script(&init)
-                .build()?;
+                .initialization_script(&init);
+            // Invisible title bar (macOS): no opaque chrome — content fills the
+            // frame and the native traffic lights float top-left. The web shell
+            // restores window-dragging + insets its topbar for the lights
+            // (apps/web `.is-tauri`). ADR-adjacent polish for the desktop build.
+            #[cfg(target_os = "macos")]
+            {
+                win = win
+                    .title_bar_style(tauri::TitleBarStyle::Overlay)
+                    .hidden_title(true);
+            }
+            win.build()?;
 
             // Menu-bar-only: build the tray, and only drop the dock icon
             // (Accessory) if it succeeds — so a tray failure leaves us reachable

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -19,6 +19,12 @@
     "active": true,
     "targets": "all",
     "externalBin": ["binaries/protoagent-server"],
+    "macOS": {
+      "hardenedRuntime": true,
+      "entitlements": "./entitlements.plist",
+      "infoPlist": "./Info.plist",
+      "minimumSystemVersion": "13.0"
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -854,9 +854,21 @@ export function App() {
     : status === "streaming" || status === "refreshing" || status.includes("…") ? { tone: "warning", label: status }
     : { tone: "ok", label: "ready" };
 
+  // Desktop (macOS) runs with an overlay/invisible title bar — no chrome, the
+  // native traffic lights float over the content. Detect that build so the
+  // topbar can inset for the lights + act as the window's drag region. (Tauri
+  // injects __PROTOAGENT_API_BASE__; the macOS guard avoids insetting on other
+  // platforms where the window keeps a normal title bar.)
+  const isTauriMac =
+    typeof window !== "undefined" &&
+    (window.location.protocol === "tauri:" ||
+      window.location.hostname === "tauri.localhost" ||
+      Boolean((window as unknown as { __PROTOAGENT_API_BASE__?: string }).__PROTOAGENT_API_BASE__)) &&
+    /Mac/i.test(navigator.userAgent);
+
   return (
-    <div className="app-shell">
-      <header className="topbar">
+    <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
+      <header className="topbar" data-tauri-drag-region>
         <div className="brand-lockup">
           <img src="/app/protolabs-icon-outline.svg" alt="" className="brand-mark" />
           <div>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -175,6 +175,13 @@ h2 {
   background: var(--bg);
 }
 
+/* macOS desktop (invisible title bar): inset the brand so it clears the native
+   traffic lights that float top-left over the content. The topbar carries
+   `data-tauri-drag-region`, so this strip also drags the window. */
+.app-shell.is-tauri-mac .topbar {
+  padding-left: 84px;
+}
+
 .brand-lockup {
   min-width: 0;
   display: flex;


### PR DESCRIPTION
Production-prep for the desktop build, mirroring ORBIS's last-day-of-work config.

## Invisible title bar (macOS)
- Window uses `titleBarStyle: Overlay` + `hiddenTitle` (set on the Rust `WebviewWindowBuilder`, `cfg(macos)`) — no opaque chrome; the native traffic lights float over the content.
- The console detects the macOS desktop build (`.is-tauri-mac`, via the injected `__PROTOAGENT_API_BASE__` + UA), **insets the topbar 84px** so the brand clears the traffic lights, and marks the topbar `data-tauri-drag-region` so it drags the window. No effect in the browser or on other platforms (which keep a normal title bar).

## macOS bundle hardening
The config prerequisites for code-signing / notarization (Orbis enforces these in its release check):
- `hardenedRuntime: true`
- explicit **`entitlements.plist`** — `network.client` + `network.server` (sidecar's outbound calls + localhost bind) and the WKWebView **JIT** exception only; deliberately no camera/mic or broad exceptions.
- explicit **`Info.plist`** — `NSHumanReadableCopyright`.
- `minimumSystemVersion: 13.0`.

> Actual signing/notarization still needs certs + CI secrets — **deferred** (flagged). Also deferred: DMG-only release target, Tauri capability scoping.

## Checks
`cargo check` + `npm run web:build` (tsc) clean; both plists pass `plutil -lint`. Icon/window changes are in the Rust shell + web — no sidecar re-freeze needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)