### PR TITLE
feat(console): protoLabs.studio splash + util-bar links; fix titlebar drag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **protoLabs.studio launch splash + console footer links.** A brand bumper
+  (`IntroSplash`) shows the protoLabs.studio mark for ~2.5s on launch, then hands
+  off to the app via the View Transitions API (clean cross-fade; plain unmount
+  where unsupported). The console's bottom utility bar gains icon-only **Docs**
+  and **GitHub** links on the left.
 - **`evals/sweep.py --repeat N`** — best-of-N model comparison. Runs the suite N
   times per model against the same booted agent (isolating model-sampling
   variance from boot variance) and prints a per-case `passes/N` table, scoring
@@ -50,6 +55,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already `protolabs/reasoning`; this just clears the dead alias from examples.
 
 ### Fixed
+- **Desktop window wasn't draggable under the invisible title bar** — with the
+  brand at the very top there was no clear grab area. Now (macOS desktop) the app
+  is pushed down by the title-bar height and a dedicated transparent
+  `data-tauri-drag-region` strip sits behind the traffic lights, so the topbar
+  lives below the stoplights with room to drag (mirrors Orbis's approach).
 - **Frozen desktop: console project APIs hit a nonexistent path** — the operator
   console's default project root was `__file__`'s dir, which in a PyInstaller
   onefile is the ephemeral `_MEIxxxx` extraction dir, so notes/beads failed with

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   BarChart3,
   BookMarked,
+  BookOpen,
   Bot,
   Boxes,
   CalendarClock,
@@ -12,6 +13,7 @@ import {
   Database,
   FileText,
   Gauge,
+  Github,
   Inbox,
   Loader2,
   MessageSquare,
@@ -29,6 +31,7 @@ import {
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
+import { IntroSplash } from "./IntroSplash";
 
 import { ActivitySurface } from "../activity/ActivitySurface";
 import { ConfirmDialog } from "./ConfirmDialog";
@@ -868,7 +871,12 @@ export function App() {
 
   return (
     <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
-      <header className="topbar" data-tauri-drag-region>
+      <IntroSplash />
+      {/* macOS desktop: a transparent strip behind the native traffic lights
+          that drags the window. The app content is pushed below it (the topbar
+          sits under the stoplights) so there's a clear area to grab. */}
+      {isTauriMac && <div className="tauri-drag-strip" data-tauri-drag-region />}
+      <header className="topbar">
         <div className="brand-lockup">
           <img src="/app/protolabs-icon-outline.svg" alt="" className="brand-mark" />
           <div>
@@ -1653,6 +1661,26 @@ export function App() {
       </div>
 
       <footer className="utility-bar">
+        <a
+          className="util-btn"
+          href="https://protolabsai.github.io/protoAgent/"
+          target="_blank"
+          rel="noreferrer"
+          title="Documentation"
+          aria-label="Documentation"
+        >
+          <BookOpen size={14} />
+        </a>
+        <a
+          className="util-btn"
+          href="https://github.com/protoLabsAI/protoAgent"
+          target="_blank"
+          rel="noreferrer"
+          title="GitHub repository"
+          aria-label="GitHub repository"
+        >
+          <Github size={14} />
+        </a>
         <div className="util-spacer" />
         <button
           type="button"

--- a/apps/web/src/app/IntroSplash.tsx
+++ b/apps/web/src/app/IntroSplash.tsx
@@ -1,0 +1,43 @@
+import { useEffect, useState } from "react";
+
+/**
+ * protoLabs.studio brand bumper — a brief splash shown over everything on
+ * launch (adapted from ORBIS's IntroSplash). Holds ~2.5s, then hands off to the
+ * app via the View Transitions API for a clean cross-fade (plain unmount where
+ * the API isn't supported).
+ *
+ * Brand rule: the wordmark is `protoLabs.studio` (lowercase p, capital L, the
+ * `.studio` dot is part of the mark), filled with the brand gradient.
+ */
+
+const HOLD_MS = 2500; // entrance + hold before handing off to the app
+
+export function IntroSplash() {
+  const [gone, setGone] = useState(false);
+
+  useEffect(() => {
+    const t = window.setTimeout(() => {
+      const doc = document as Document & {
+        startViewTransition?: (cb: () => void) => unknown;
+      };
+      if (typeof doc.startViewTransition === "function") {
+        // Cross-fade the splash out and the app in (default root transition).
+        doc.startViewTransition(() => setGone(true));
+      } else {
+        setGone(true);
+      }
+    }, HOLD_MS);
+    return () => window.clearTimeout(t);
+  }, []);
+
+  if (gone) return null;
+
+  return (
+    <div className="intro-splash" role="img" aria-label="protoLabs.studio">
+      <div className="intro-splash-rise">
+        <img src="/app/protolabs-icon-outline.svg" alt="" className="intro-splash-mark" />
+        <div className="intro-splash-word">protoLabs.studio</div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/IntroSplash.tsx
+++ b/apps/web/src/app/IntroSplash.tsx
@@ -13,9 +13,14 @@ import { useEffect, useState } from "react";
 const HOLD_MS = 2500; // entrance + hold before handing off to the app
 
 export function IntroSplash() {
-  const [gone, setGone] = useState(false);
+  // Skip under automation (Playwright/Selenium set navigator.webdriver) so the
+  // 2.5s overlay doesn't intercept E2E interactions. Real users see it.
+  const [gone, setGone] = useState(
+    () => typeof navigator !== "undefined" && (navigator as Navigator).webdriver === true,
+  );
 
   useEffect(() => {
+    if (gone) return; // skipped (automation) — no timer, nothing to unmount
     const t = window.setTimeout(() => {
       const doc = document as Document & {
         startViewTransition?: (cb: () => void) => unknown;

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -175,11 +175,71 @@ h2 {
   background: var(--bg);
 }
 
-/* macOS desktop (invisible title bar): inset the brand so it clears the native
-   traffic lights that float top-left over the content. The topbar carries
-   `data-tauri-drag-region`, so this strip also drags the window. */
-.app-shell.is-tauri-mac .topbar {
-  padding-left: 84px;
+/* macOS desktop (invisible title bar): push the whole app down by the title-bar
+   height so the topbar (brand + icon) sits *below* the native traffic lights,
+   leaving a clear strip up top to drag. */
+.app-shell.is-tauri-mac {
+  padding-top: 30px;
+}
+
+/* The transparent drag strip behind the traffic lights (full width, the height
+   we reserved above). data-tauri-drag-region makes it move the window. */
+.tauri-drag-strip {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 30px;
+  z-index: 50;
+}
+
+/* protoLabs.studio brand bumper (IntroSplash) — full-screen splash on launch,
+   handed off to the app via the View Transitions API. */
+.intro-splash {
+  position: fixed;
+  inset: 0;
+  z-index: 90;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+}
+
+.intro-splash-rise {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 20px;
+  animation: intro-rise 0.7s cubic-bezier(0.2, 0.6, 0.2, 1) both;
+}
+
+.intro-splash-mark {
+  width: 88px;
+  height: 88px;
+  filter: drop-shadow(0 0 14px rgba(167, 139, 250, 0.35));
+}
+
+.intro-splash-word {
+  font-size: 2rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  background: linear-gradient(135deg, #9b87f2 0%, #818cf8 50%, #6366f1 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+}
+
+@keyframes intro-rise {
+  0% { opacity: 0; transform: translateY(10px) scale(0.985); }
+  100% { opacity: 1; transform: none; }
+}
+
+/* The splash → app hand-off cross-fade (default root view transition); a touch
+   longer than the default for a cleaner settle. */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 450ms;
 }
 
 .brand-lockup {


### PR DESCRIPTION
Three console/desktop polish items (the splash, footer links, and the drag fix you flagged).

## protoLabs.studio launch splash
`IntroSplash` — the protoLabs robot outline mark + gradient `protoLabs.studio` wordmark, with a subtle rise-in. Holds **~2.5s**, then hands off to the app via the **View Transitions API** (default root cross-fade, 450ms; falls back to a plain unmount where unsupported). Adapted from ORBIS's `IntroSplash` (Tailwind) to protoAgent's plain CSS.

## Util-bar links
Icon-only **Docs** (→ the docs site) and **GitHub** (→ the repo) links on the **left** of the console's bottom utility bar.

## Titlebar drag fix
PR #437 put `data-tauri-drag-region` on the topbar, but the brand content covered it — so the window wasn't draggable. Now (mirroring Orbis): on the macOS desktop the app is **pushed down by the title-bar height** and a dedicated **transparent drag strip** sits behind the traffic lights, so the topbar (brand + icon) lives **below the stoplights** with a clear area to grab.

## Checks
`npm run web:build` (tsc) clean. All web-side — no sidecar re-freeze needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)