### PR TITLE
docs: "Built by protoLabs.studio" footer on every page

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   KB. The researcher gains `memory_ingest` for that persistence.
 
 ### Docs
+- **"Built by protoLabs.studio" footer on every docs page** — a custom theme
+  (`docs/.vitepress/theme/`) injects a `StudioFooter` via the `layout-bottom`
+  slot (the built-in footer hides on sidebar pages), with the brand-gradient
+  `protoLabs.studio` wordmark linking to protolabs.studio.
 - Reconcile drift after the recent releases: fix the deploy guide's stale
   "every merge auto-cuts a patch" note (releases are manual now), document the
   UI tiers + `--build-arg UI=full` for the image, link the orphaned "Eval your

--- a/docs/.vitepress/theme/StudioFooter.vue
+++ b/docs/.vitepress/theme/StudioFooter.vue
@@ -1,0 +1,46 @@
+<script setup lang="ts">
+// Studio attribution shown at the bottom of every docs page. Injected via the
+// `layout-bottom` slot in theme/index.ts so it follows sidebar pages too —
+// VitePress's built-in themeConfig.footer hides itself on sidebar layouts.
+//
+// Brand rule: the wordmark is always `protoLabs.studio` (lowercase p, capital L;
+// the `.studio` dot is part of the mark). Public surfaces link to protolabs.studio.
+</script>
+
+<template>
+  <footer class="studio-footer">
+    <span>Built by</span>
+    <a class="wordmark" href="https://protolabs.studio" target="_blank" rel="noreferrer">
+      protoLabs.studio
+    </a>
+  </footer>
+</template>
+
+<style scoped>
+.studio-footer {
+  border-top: 1px solid var(--vp-c-divider);
+  padding: 24px 24px 28px;
+  text-align: center;
+  font-size: 13px;
+  color: var(--vp-c-text-2);
+  display: flex;
+  gap: 0.4em;
+  align-items: baseline;
+  justify-content: center;
+}
+
+.wordmark {
+  font-weight: 600;
+  /* protoLabs brand gradient: lavender → indigo. */
+  background: linear-gradient(135deg, #9b87f2 0%, #818cf8 50%, #6366f1 100%);
+  -webkit-background-clip: text;
+  background-clip: text;
+  -webkit-text-fill-color: transparent;
+  color: transparent;
+  transition: opacity 0.15s ease;
+}
+
+.wordmark:hover {
+  opacity: 0.8;
+}
+</style>

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,0 +1,16 @@
+// Custom docs theme: the default VitePress theme + a "Built by protoLabs.studio"
+// footer on every page. Injected via the `layout-bottom` slot (rather than
+// themeConfig.footer, which VitePress hides on sidebar/doc layouts).
+import DefaultTheme from "vitepress/theme";
+import type { Theme } from "vitepress";
+import { h } from "vue";
+import StudioFooter from "./StudioFooter.vue";
+
+export default {
+  extends: DefaultTheme,
+  Layout() {
+    return h(DefaultTheme.Layout, null, {
+      "layout-bottom": () => h(StudioFooter),
+    });
+  },
+} satisfies Theme;


### PR DESCRIPTION
Adds the **Built by protoLabs.studio** attribution to the bottom of every docs page, matching ORBIS (#334).

- New custom VitePress theme (`docs/.vitepress/theme/index.ts`) that extends the default theme and injects a **`StudioFooter`** via the **`layout-bottom`** slot. (VitePress's built-in `themeConfig.footer` hides itself on sidebar/doc layouts, so the slot is used to render it everywhere.)
- The wordmark `protoLabs.studio` (brand lavender→indigo gradient) links to https://protolabs.studio.

`npm run docs:build` clean; the footer renders into every generated page (verified `index.html`, ADR pages, etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)