### PR TITLE
fix(desktop): grant drag/open capabilities; inset logo on mac; util-bar padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,6 +55,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already `protolabs/reasoning`; this just clears the dead alias from examples.
 
 ### Fixed
+- **Desktop drag + external links were blocked by missing Tauri capabilities.**
+  `data-tauri-drag-region` calls `startDragging()` and the Docs/GitHub links call
+  `shell.open` — neither permission was granted, so the window wouldn't move and
+  the links did nothing (`window.start_dragging not allowed`, `shell.open not
+  allowed` in the console). Granted `core:window:allow-start-dragging` and
+  `shell:allow-open` in the capability (and corrected the stale `--headless`
+  sidecar arg scope to `--ui console`). Also added a little bottom padding under
+  the utility-bar icons.
 - **Desktop window wasn't draggable under the invisible title bar** — with the
   brand at the very top there was no clear grab area. Now (macOS desktop) the app
   is pushed down by the title-bar height and a dedicated transparent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -55,19 +55,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   already `protolabs/reasoning`; this just clears the dead alias from examples.
 
 ### Fixed
-- **Desktop drag + external links were blocked by missing Tauri capabilities.**
-  `data-tauri-drag-region` calls `startDragging()` and the Docs/GitHub links call
-  `shell.open` — neither permission was granted, so the window wouldn't move and
-  the links did nothing (`window.start_dragging not allowed`, `shell.open not
-  allowed` in the console). Granted `core:window:allow-start-dragging` and
-  `shell:allow-open` in the capability (and corrected the stale `--headless`
-  sidecar arg scope to `--ui console`). Also added a little bottom padding under
-  the utility-bar icons.
-- **Desktop window wasn't draggable under the invisible title bar** — with the
-  brand at the very top there was no clear grab area. Now (macOS desktop) the app
-  is pushed down by the title-bar height and a dedicated transparent
-  `data-tauri-drag-region` strip sits behind the traffic lights, so the topbar
-  lives below the stoplights with room to drag (mirrors Orbis's approach).
+- **Desktop window wasn't draggable + external links didn't open under the
+  invisible title bar.** Two parts: (1) the Tauri capability didn't grant the
+  commands they invoke — `data-tauri-drag-region` → `startDragging()` and the
+  Docs/GitHub links → `shell.open` — so both silently failed
+  (`window.start_dragging not allowed`, `shell.open not allowed`); granted
+  `core:window:allow-start-dragging` + `shell:allow-open` (and corrected the
+  stale `--headless` sidecar arg scope to `--ui console`). (2) The topbar is the
+  drag region, with the brand **inset** right of the native traffic lights —
+  **macOS build only** (the browser has no traffic lights, so no inset there).
+  Plus a little more bottom padding under the utility-bar icons.
 - **Frozen desktop: console project APIs hit a nonexistent path** — the operator
   console's default project root was `__file__`'s dir, which in a PyInstaller
   onefile is the ephemeral `_MEIxxxx` extraction dir, so notes/beads failed with

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -7,13 +7,15 @@
   ],
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
+    "shell:allow-open",
     {
       "identifier": "shell:allow-execute",
       "allow": [
         {
           "name": "binaries/protoagent-server",
           "sidecar": true,
-          "args": ["--headless", "--port", { "validator": "\\d+" }]
+          "args": ["--ui", "console", "--port", { "validator": "\\d+" }]
         }
       ]
     }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -872,11 +872,10 @@ export function App() {
   return (
     <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
       <IntroSplash />
-      {/* macOS desktop: a transparent strip behind the native traffic lights
-          that drags the window. The app content is pushed below it (the topbar
-          sits under the stoplights) so there's a clear area to grab. */}
-      {isTauriMac && <div className="tauri-drag-strip" data-tauri-drag-region />}
-      <header className="topbar">
+      {/* macOS desktop: the topbar IS the window's drag region (its brand insets
+          right of the native traffic lights — see `.is-tauri-mac .topbar`).
+          Interactive children (the status dot) stay clickable; harmless on web. */}
+      <header className="topbar" data-tauri-drag-region>
         <div className="brand-lockup">
           <img src="/app/protolabs-icon-outline.svg" alt="" className="brand-mark" />
           <div>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -86,7 +86,7 @@ h2 {
   height: 100%;
   min-height: 100vh;
   display: grid;
-  grid-template-rows: 48px minmax(0, 1fr) 28px;
+  grid-template-rows: 48px minmax(0, 1fr) 40px;
   overflow: hidden;
   background: var(--bg);
 }
@@ -128,7 +128,7 @@ h2 {
   display: flex;
   align-items: center;
   gap: 8px;
-  padding: 0 10px;
+  padding: 0 10px 8px;
   border-top: 1px solid var(--border);
   background: var(--bg);
   font-size: 11px;

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -175,22 +175,12 @@ h2 {
   background: var(--bg);
 }
 
-/* macOS desktop (invisible title bar): push the whole app down by the title-bar
-   height so the topbar (brand + icon) sits *below* the native traffic lights,
-   leaving a clear strip up top to drag. */
-.app-shell.is-tauri-mac {
-  padding-top: 30px;
-}
-
-/* The transparent drag strip behind the traffic lights (full width, the height
-   we reserved above). data-tauri-drag-region makes it move the window. */
-.tauri-drag-strip {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  height: 30px;
-  z-index: 50;
+/* macOS desktop (invisible title bar): inset the brand so it clears the native
+   traffic lights that float top-left over the content. The topbar carries
+   `data-tauri-drag-region`, so this area drags the window. Mac build ONLY — the
+   browser has no traffic lights, so no inset there. */
+.app-shell.is-tauri-mac .topbar {
+  padding-left: 84px;
 }
 
 /* protoLabs.studio brand bumper (IntroSplash) — full-screen splash on launch,


### PR DESCRIPTION
The window wouldn't drag and the Docs/GitHub links did nothing — the console showed `window.start_dragging not allowed` and `shell.open not allowed`. Root cause was **missing Tauri capabilities**, not layout.

## Fixes
- **Capabilities** (`capabilities/default.json`): granted `core:window:allow-start-dragging` (drag) and `shell:allow-open` (external links). Also corrected the stale `--headless` sidecar arg scope → `--ui console`.
- **Inset the logo, mac-only**: now that drag works, reverted the push-down + transparent-strip workaround back to the cleaner **inset-logo** layout — the topbar is the drag region (Tauri auto-excludes the interactive status dot) and the brand insets right of the traffic lights via `.is-tauri-mac .topbar`. Applies **only on the macOS build**; the browser keeps a normal top, no inset.
- **Util-bar padding**: more room under the bottom icons (row 28→40px + 8px bottom pad).

## Checks
`cargo check` (validates the capability schema) + `npm run web:build` clean. Capabilities embed at build time → needs a rebuild to take effect (confirmed live: drag works).

🤖 Generated with [Claude Code](https://claude.com/claude-code)