### PR TITLE
docs: adopt the protoLabs.studio theme + brand assets; drop card emojis

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -125,6 +125,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   KB. The researcher gains `memory_ingest` for that persistence.
 
 ### Docs
+- **Adopt the shared protoLabs.studio docs theme + brand assets.** The docs now
+  use `@protolabsai/vitepress-theme` (maps VitePress `--vp-*` vars to the
+  `@protolabsai/design` `--pl-*` tokens, so the site is brand-consistent from one
+  source; `appearance: "force-dark"`). The placeholder teal favicon is replaced
+  with the canonical protoLabs marks (`favicon.svg` + `protolabs-icon-outline.svg`
+  from the design package), and the landing-page feature cards drop their emoji
+  icons. The "Built by protoLabs.studio" footer stays (now using the brand
+  gradient token).
 - **"Built by protoLabs.studio" footer on every docs page** — a custom theme
   (`docs/.vitepress/theme/`) injects a `StudioFooter` via the `layout-bottom`
   slot (the built-in footer hides on sidebar pages), with the brand-gradient

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -6,6 +6,10 @@ export default defineConfig({
     "Template repository for building protoLabs A2A agents on LangGraph.",
   base: "/protoAgent/",
 
+  // The protoLabs.studio theme (@protolabsai/vitepress-theme) is dark-first like
+  // the marketing site; pin the dark, brand-first ground.
+  appearance: "force-dark",
+
   // Tutorials legitimately reference the local dev server (http://localhost:7870);
   // VitePress treats dead links as fatal, so skip just the localhost ones.
   ignoreDeadLinks: "localhostLinks",

--- a/docs/.vitepress/theme/StudioFooter.vue
+++ b/docs/.vitepress/theme/StudioFooter.vue
@@ -31,8 +31,10 @@
 
 .wordmark {
   font-weight: 600;
-  /* protoLabs brand gradient: lavender → indigo. */
-  background: linear-gradient(135deg, #9b87f2 0%, #818cf8 50%, #6366f1 100%);
+  /* The brand gradient from the shared theme tokens (@protolabsai/design),
+     with a literal fallback so the wordmark still reads on-brand if a future
+     theme version renames the token. */
+  background: var(--pl-gradient-brand, linear-gradient(135deg, #9b87f2 0%, #818cf8 50%, #6366f1 100%));
   -webkit-background-clip: text;
   background-clip: text;
   -webkit-text-fill-color: transparent;

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -1,13 +1,16 @@
-// Custom docs theme: the default VitePress theme + a "Built by protoLabs.studio"
-// footer on every page. Injected via the `layout-bottom` slot (rather than
-// themeConfig.footer, which VitePress hides on sidebar/doc layouts).
+// Docs theme = the shared protoLabs.studio VitePress theme
+// (@protolabsai/vitepress-theme: maps VitePress --vp-* vars → @protolabsai/design
+// --pl-* tokens, so every studio docs site is brand-consistent from one source)
+// + a "Built by protoLabs.studio" footer on every page via the `layout-bottom`
+// slot (the built-in themeConfig.footer hides on sidebar/doc layouts).
 import DefaultTheme from "vitepress/theme";
 import type { Theme } from "vitepress";
 import { h } from "vue";
+import protoTheme from "@protolabsai/vitepress-theme";
 import StudioFooter from "./StudioFooter.vue";
 
 export default {
-  extends: DefaultTheme,
+  ...protoTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
       "layout-bottom": () => h(StudioFooter),

--- a/docs/index.md
+++ b/docs/index.md
@@ -13,17 +13,13 @@ hero:
       link: /guides/customize-and-deploy
 
 features:
-  - icon: 🔌
-    title: A2A out of the box
+  - title: A2A out of the box
     details: JSON-RPC 2.0 over /a2a, SSE streaming, tasks/* lifecycle, push notifications, dual token-shape parsing — all spec-compliant, all already tested.
-  - icon: 💰
-    title: cost-v1 + trace propagation
+  - title: cost-v1 + trace propagation
     details: Every terminal task emits a cost-v1 DataPart with token usage and wall time. a2a.trace metadata nests this agent's Langfuse trace under the caller's.
-  - icon: 🧰
-    title: Free starter tools
+  - title: Free starter tools
     details: DuckDuckGo web search, URL fetch, safe calculator, and IANA-timezone clock — zero API keys, enough to demo a real research loop on a fresh clone.
-  - icon: 🚀
-    title: Autonomous release pipeline
+  - title: Autonomous release pipeline
     details: Merge a PR → semver bump → GHCR image → GitHub release → Discord embed. Update the repo guard in three workflow files and you're done.
 ---
 

--- a/docs/public/protolabs-icon-outline.svg
+++ b/docs/public/protolabs-icon-outline.svg
@@ -1,6 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="protoLabs Icon">
-  <rect x="16" y="16" width="224" height="224" rx="56" fill="#9b87f2" />
-  <g transform="translate(224, 32) scale(-8, 8)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <g transform="translate(224, 32) scale(-8, 8)" fill="none" stroke="#9b87f2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M12 8V4H8" />
     <rect width="16" height="12" x="4" y="8" rx="2" />
     <path d="M2 14h2" />

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,8 @@
         "apps/desktop"
       ],
       "devDependencies": {
+        "@protolabsai/design": "^0.3.0",
+        "@protolabsai/vitepress-theme": "^0.3.0",
         "vitepress": "^1.6.4"
       }
     },
@@ -1114,6 +1116,29 @@
     "node_modules/@protoagent/web": {
       "resolved": "apps/web",
       "link": true
+    },
+    "node_modules/@protolabsai/design": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.3.0.tgz",
+      "integrity": "sha512-vitFVJ9c7L66idoskukAyd48uCTHXy0Y3oQKmcm9osmwZmfogFSPqrGEB1Ot7ZblWDFgsOBr7aRf6iBJMU+k2g==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "protolabs-sync-assets": "bin/sync-assets.mjs"
+      }
+    },
+    "node_modules/@protolabsai/vitepress-theme": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/vitepress-theme/-/vitepress-theme-0.3.0.tgz",
+      "integrity": "sha512-kDkmQ2RNnapmcpvfY7wdzWyJSdpbatVyzsaL5vuFZ+A7wA8V6/exl0l7PFNhSVKjXFNpkFo+CJ0E176wlf3n5Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@protolabsai/design": "0.3.0"
+      },
+      "peerDependencies": {
+        "vitepress": ">=1.0.0"
+      }
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
     "desktop:build": "npm --workspace @protoagent/desktop run build"
   },
   "devDependencies": {
+    "@protolabsai/design": "^0.3.0",
+    "@protolabsai/vitepress-theme": "^0.3.0",
     "vitepress": "^1.6.4"
   }
 }


### PR DESCRIPTION
Brings the docs onto the shared **protoContent docs theme** + canonical brand marks, and de-emojis the landing page.

## Changes
- **Shared theme** — `@protolabsai/vitepress-theme` (+ `@protolabsai/design`), which maps VitePress `--vp-*` variables to the `@protolabsai/design` `--pl-*` tokens, so every studio docs site is brand-consistent from one source. `appearance: "force-dark"` (dark-first, like the marketing site). `theme/index.ts` spreads the shared theme and keeps the **"Built by protoLabs.studio"** footer via the `layout-bottom` slot.
- **Brand assets** — the docs favicon was a **placeholder teal square**; replaced with the canonical protoLabs marks (`favicon.svg` + `protolabs-icon-outline.svg`) straight from the design package.
- **Landing page** — dropped the emoji `icon:`s from the feature cards.

## Verified
`npm run docs:build` clean; the `--pl-*` tokens map into the built CSS, the canonical favicon ships, the footer renders on sidebar pages, and zero emojis remain on the landing page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)