### PR TITLE
docs: use the outline mark for the favicon/logo

### DIFF
--- a/docs/public/favicon.svg
+++ b/docs/public/favicon.svg
@@ -1,6 +1,5 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="protoLabs Icon">
-  <rect x="16" y="16" width="224" height="224" rx="56" fill="#9b87f2" />
-  <g transform="translate(224, 32) scale(-8, 8)" fill="none" stroke="#FFFFFF" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+  <g transform="translate(224, 32) scale(-8, 8)" fill="none" stroke="#9b87f2" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
     <path d="M12 8V4H8" />
     <rect width="16" height="12" x="4" y="8" rx="2" />
     <path d="M2 14h2" />


### PR DESCRIPTION
Switches the docs favicon/nav-logo from the filled/background protoLabs icon to the **outline** mark — the same one the app console + splash use — so the docs match the rest of the brand surfaces. `docs:build` clean (dist favicon is the outline).

🤖 Generated with [Claude Code](https://claude.com/claude-code)