### PR TITLE
feat: fenced filesystem on by default, scoped to a workspace dir

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   one-off flakes that still clear the majority.
 
 ### Changed
+- **Fenced filesystem is now ON by default (ADR 0007 update).** A fresh agent
+  gets `read_file`/`write_file`/`edit_file`/`list_dir`/`search_files`/`find_files`
+  fenced to a default **workspace** dir (`paths.workspace_dir` —
+  `PROTOAGENT_WORKSPACE` env, else `/sandbox/workspace` or `~/.protoagent/workspace`,
+  instance-scoped) when no `filesystem.projects` are configured — a capable,
+  safe first run (informed by benchmarking OpenClaw/Hermes, which both ship FS
+  on, + the "anticlimactic first run" UX complaint). The two **unsandboxed**
+  power tools stay opt-in: `run_command` (`filesystem.allow_run`) and
+  `execute_code` are fenced-cwd-but-arbitrary-argv/code as the server user, so
+  they remain off until gated behind HITL approval or run in the hardened
+  container.
 - **Desktop: invisible title bar + macOS bundle hardening (production prep).**
   The window uses an overlay/hidden title bar on macOS (`titleBarStyle: Overlay`
   + `hiddenTitle`) — no chrome, native traffic lights float over the content;

--- a/docs/adr/0007-directory-aware-operator-agent.md
+++ b/docs/adr/0007-directory-aware-operator-agent.md
@@ -1,6 +1,7 @@
 # ADR 0007 — Directory-Aware Operator Primitives (enabling a "Roxy" fork)
 
 - **Status:** Accepted (2026-06-01) — template primitives shipped (registry+fence, fenced fs toolset, fork guide); per-project subagent binding deferred
+- **Update (2026-06-02):** the **fenced filesystem is now ON by default**, scoped to a default **workspace** dir (`paths.workspace_dir`) when no projects are configured — a capable, safe first run (the agent can work with files, but only inside the fence). Benchmarking OpenClaw/Hermes (both ship FS default-on) + the UX research ("anticlimactic first run", "value off by default") motivated flipping the *read/write/edit/search* default. The two **unsandboxed** power tools stay opt-in: `run_command` (`filesystem.allow_run`) and `execute_code` are *fenced cwd but arbitrary argv/code as the server user* — not a real sandbox — so they stay off until gated behind **HITL approval** (intermediate confirmation on consequential actions, per the research) or run inside the hardened container (ADR 0008).
 - **Date:** 2026-06-01
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** architecture, filesystem, multi-project, operator, supervisor, security, template-vs-fork

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -680,7 +680,7 @@ def create_agent_graph(
 
     system_prompt = build_system_prompt(
         include_subagents=include_subagents,
-        projects=(config.filesystem_projects if config.filesystem_enabled else None),
+        projects=(config.effective_filesystem_projects() if config.filesystem_enabled else None),
     )
 
     agent = create_agent(

--- a/graph/config.py
+++ b/graph/config.py
@@ -298,13 +298,16 @@ class LangGraphConfig:
     # list — not the UI — is the security boundary. See operator_api/paths.
     operator_allowed_dirs: list[str] = field(default_factory=list)
 
-    # Fenced multi-project filesystem toolset (ADR 0007 — operator primitives).
-    # OFF by default; a generic capability a fork (e.g. "Roxy") opts into. When
-    # enabled with a non-empty ``projects`` registry, the agent gets fenced
-    # read/write/list/search tools over those dirs (every path contained under a
-    # project root). ``allow_run`` adds the dual-use ``run_command`` power tool.
-    # ``projects`` entries: ``{name, path, write: true|false}``. See tools/fs_tools.
-    filesystem_enabled: bool = False
+    # Fenced filesystem toolset (ADR 0007 — operator primitives). ON by default,
+    # fenced to a default **workspace** dir (paths.workspace_dir) when no explicit
+    # ``projects`` are configured — read/write/list/search, every path contained
+    # under the workspace root (``..``/symlink escapes refused). A capable, safe
+    # first run: the agent can actually work with files, but only inside the fence.
+    # ``projects`` entries: ``{name, path, write: true|false}`` register extra dirs.
+    # ``allow_run`` adds the dual-use ``run_command`` power tool — OFF by default:
+    # run_command (like execute_code) is fenced cwd but arbitrary argv, i.e. NOT a
+    # real sandbox, so it stays opt-in until gated behind HITL approval.
+    filesystem_enabled: bool = True
     filesystem_allow_run: bool = False
     filesystem_projects: list[dict] = field(default_factory=list)
 
@@ -323,6 +326,18 @@ class LangGraphConfig:
         env_model = os.environ.get("PROTOAGENT_MODEL")
         if env_model:
             self.model_name = env_model
+
+    def effective_filesystem_projects(self, *, create: bool = False) -> list[dict]:
+        """The fs project registry the agent actually gets. Explicit
+        ``filesystem_projects`` win; otherwise (when filesystem is enabled) a
+        single default ``workspace`` project so the on-by-default fs toolset has a
+        fenced place to work. ``create=True`` mkdirs the workspace dir."""
+        if self.filesystem_projects:
+            return self.filesystem_projects
+        if not self.filesystem_enabled:
+            return []
+        from paths import workspace_dir
+        return [{"name": "workspace", "path": str(workspace_dir(create=create)), "write": True}]
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> "LangGraphConfig":

--- a/paths.py
+++ b/paths.py
@@ -42,3 +42,23 @@ def scope_leaf(path: str | Path) -> Path:
     if not iid:
         return p
     return p.parent / _safe_segment(iid) / p.name
+
+
+def workspace_dir(*, create: bool = False) -> Path:
+    """The agent's default fenced workspace — where the on-by-default filesystem
+    toolset can read/write/edit (the fence the agent lives inside).
+
+    Resolution: ``PROTOAGENT_WORKSPACE`` env wins (point it at a friendlier dir,
+    e.g. from the desktop); else ``/sandbox/workspace`` in a container, falling
+    back to ``~/.protoagent/workspace`` for local dev — instance-scoped either
+    way. ``create=True`` mkdirs it (writes need the dir to exist)."""
+    raw = os.environ.get("PROTOAGENT_WORKSPACE")
+    if raw:
+        base = Path(raw).expanduser()
+    else:
+        sandbox = Path("/sandbox/workspace")
+        base = sandbox if sandbox.parent.is_dir() else Path.home() / ".protoagent" / "workspace"
+        base = scope_leaf(base)
+    if create:
+        base.mkdir(parents=True, exist_ok=True)
+    return base.resolve()

--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -146,7 +146,27 @@ def test_config_parses_filesystem(tmp_path):
     assert cfg.filesystem_projects[0]["name"] == "orbis"
 
 
-def test_config_filesystem_default_off():
+def test_config_filesystem_default_on_fenced_workspace(tmp_path, monkeypatch):
+    """Filesystem is ON by default (fenced to a workspace); run_command stays opt-in."""
     from graph.config import LangGraphConfig
 
-    assert LangGraphConfig().filesystem_enabled is False
+    cfg = LangGraphConfig()
+    assert cfg.filesystem_enabled is True
+    # run_command (arbitrary argv, unsandboxed like execute_code) stays opt-in.
+    assert cfg.filesystem_allow_run is False
+    # No explicit projects → a single default `workspace` project, fenced + writable.
+    monkeypatch.setenv("PROTOAGENT_WORKSPACE", str(tmp_path / "ws"))
+    projects = cfg.effective_filesystem_projects(create=True)
+    assert len(projects) == 1
+    assert projects[0]["name"] == "workspace" and projects[0]["write"] is True
+    assert (tmp_path / "ws").is_dir()  # created
+
+
+def test_effective_projects_explicit_wins_and_disabled_is_empty(tmp_path):
+    from graph.config import LangGraphConfig
+
+    explicit = [{"name": "repo", "path": str(tmp_path), "write": False}]
+    cfg = LangGraphConfig(filesystem_projects=explicit)
+    assert cfg.effective_filesystem_projects() == explicit  # explicit registry wins
+    off = LangGraphConfig(filesystem_enabled=False)
+    assert off.effective_filesystem_projects() == []  # disabled → no projects

--- a/tools/fs_tools.py
+++ b/tools/fs_tools.py
@@ -76,7 +76,14 @@ class ProjectRegistry:
 
 def _registry_from_config(config) -> ProjectRegistry:
     projects: list[Project] = []
-    for entry in getattr(config, "filesystem_projects", []) or []:
+    # Explicit projects, or the default workspace dir (created) when none are
+    # configured — the on-by-default fenced workspace.
+    entries = (
+        config.effective_filesystem_projects(create=True)
+        if hasattr(config, "effective_filesystem_projects")
+        else (getattr(config, "filesystem_projects", []) or [])
+    )
+    for entry in entries:
         if not isinstance(entry, dict):
             continue
         name = str(entry.get("name") or "").strip()


### PR DESCRIPTION
**Build #1 of the default-toolset decision.** Both OpenClaw + Hermes ship filesystem default-on, and the UX research flagged "anticlimactic first run / value off by default" — so flip protoAgent's fenced FS to **on by default**, done safely.

## What
- **`paths.workspace_dir()`** — the agent's default workspace (`PROTOAGENT_WORKSPACE` env, else `/sandbox/workspace` in a container or `~/.protoagent/workspace` locally; instance-scoped).
- **`filesystem_enabled` → default `true`.** `config.effective_filesystem_projects()` returns the explicit `filesystem.projects` if set, else a single **fenced + writable `workspace`** project (created on build) when none are configured. `build_fs_tools` + the system prompt both use it. A fresh agent gets `read_file`/`write_file`/`edit_file`/`list_dir`/`search_files`/`find_files` — **fenced to the workspace** (`..`/symlink escapes refused).

## Safety (the important part)
The two **unsandboxed** power tools **stay opt-in**:
- `run_command` (`filesystem.allow_run`) and `execute_code` are *fenced-cwd-but-arbitrary-argv/code as the server user* — **not a real sandbox**.
- So they remain off until gated behind **HITL approval** (the next build) or run inside the hardened container (ADR 0008). This keeps a fresh public-template fork **capable, not dangerous-by-default** — the "deleted my files" risk stays off the table.

## Notes
- ADR 0007 updated with the posture change; CHANGELOG entry.
- Forks using the example config (no `filesystem:` block) pick up the new default automatically.
- Tests: new default + workspace fence + explicit-projects-win + disabled-is-empty. Full suite green (927).

Next: **build #2** — beads as an in-process agent tool; then **the HITL approval + notification system** (which flips `run_command` on, behind approval).

🤖 Generated with [Claude Code](https://claude.com/claude-code)