### PR TITLE
feat(hitl): request_user_input form tool + form-shaped input-required (Sprint A.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`request_user_input` HITL form tool (Sprint A, server side).** Generalizes
+  `ask_human` from a free-text question to a **JSON-schema form** (multi-step =
+  wizard): the agent calls `request_user_input(title, steps, description?)`, the
+  turn pauses via the existing LangGraph `interrupt()` → A2A `input-required`, and
+  the submitted form object is returned. The interrupt→`input_required` payload
+  now passes richer shapes through (`{kind:"form", …}` alongside `{question}`) so
+  the console can render a form vs a prompt. (Console form-card + desktop
+  notification + the run_command approval gate are the next Sprint-A slices.)
 - **protoLabs.studio launch splash + console footer links.** A brand bumper
   (`IntroSplash`) shows the protoLabs.studio mark for ~2.5s on launch, then hands
   off to the app via the View Transitions API (clean cross-fade; plain unmount

--- a/server.py
+++ b/server.py
@@ -1258,6 +1258,18 @@ def _coerce_tool_output(value) -> str:
     return _coerce_tool_value(getattr(value, "content", value))
 
 
+def _interrupt_payload(val) -> dict:
+    """Shape a LangGraph interrupt value into the ``input-required`` payload the
+    A2A layer parks and the console renders. Richer HITL shapes pass through:
+    ``ask_human`` → ``{"question": …}``; ``request_user_input`` → ``{"kind":"form",
+    "title", "description", "steps":[…]}``. Anything else degrades to a question
+    with the stringified value. The console renders by shape (prompt vs JSON-schema
+    form); the resume value is a string for a question, a dict for a form."""
+    if isinstance(val, dict) and (val.get("question") or val.get("kind") == "form"):
+        return val
+    return {"question": (str(val) if val is not None else "Input required.")}
+
+
 async def _run_turn_stream(message: str, session_id: str, config: dict, *, resume_value=None):
     """Run one graph turn over ``astream_events``.
 
@@ -1388,8 +1400,7 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
         pending = []
     if pending:
         val = getattr(pending[0], "value", pending[0])
-        question = val.get("question") if isinstance(val, dict) else str(val)
-        yield ("input_required", {"question": question or "Input required."})
+        yield ("input_required", _interrupt_payload(val))
         return
 
     yield ("__raw__", accumulated_raw)

--- a/tests/test_hitl_forms.py
+++ b/tests/test_hitl_forms.py
@@ -1,0 +1,44 @@
+"""Server-side HITL form primitive (Sprint A): the `request_user_input` tool +
+the interrupt→input-required payload shaping that lets a JSON-schema form survive
+to the A2A layer / console (generalizing `ask_human`)."""
+
+from __future__ import annotations
+
+import server
+from tools.lg_tools import DEFERRED_BASE_TOOL_NAMES, get_all_tools
+
+
+def _tool_names() -> set[str]:
+    return {getattr(t, "name", "") for t in get_all_tools()}
+
+
+def test_request_user_input_registered_as_default_lead_tool():
+    names = _tool_names()
+    assert "request_user_input" in names
+    assert "ask_human" in names  # the free-text sibling stays too
+
+
+def test_request_user_input_in_deferred_base():
+    # Must stay visible when tool-deferral is on (it's a core HITL capability).
+    assert "request_user_input" in DEFERRED_BASE_TOOL_NAMES
+
+
+# ── interrupt → input-required payload shaping ────────────────────────────────
+
+
+def test_form_payload_passes_through():
+    val = {"kind": "form", "title": "Pick", "description": "", "steps": [{"schema": {}}]}
+    assert server._interrupt_payload(val) is val
+
+
+def test_question_payload_passes_through():
+    assert server._interrupt_payload({"question": "Merge it?"}) == {"question": "Merge it?"}
+
+
+def test_plain_value_degrades_to_question():
+    assert server._interrupt_payload("just text") == {"question": "just text"}
+    assert server._interrupt_payload(None) == {"question": "Input required."}
+    # A dict that's neither a question nor a form is stringified into a question
+    # (never silently dropped).
+    out = server._interrupt_payload({"foo": 1})
+    assert "question" in out and "foo" in out["question"]

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -75,6 +75,34 @@ def ask_human(question: str) -> str:
 
 
 @tool
+def request_user_input(title: str, steps: list[dict], description: str = "") -> str:
+    """Ask the operator for **structured** input via a form dialog, then continue
+    with their response. Use when you need specific values, choices, credentials,
+    or config — anything better captured as form fields than free text. The task
+    pauses (surfaced as ``input-required``) until they submit; their response (a
+    JSON object keyed by field name) is returned from this call.
+
+    ``steps`` is a list of form steps — multiple steps render as a wizard. Each
+    step is ``{"schema": <JSON Schema draft-07 of the fields>, "uiSchema"?: <layout
+    hints>, "title"?: str, "description"?: str}``. Phrase the ask clearly and only
+    request fields you actually need. For a single free-text or yes/no question,
+    use ``ask_human`` instead.
+    """
+    import json
+    from langgraph.types import interrupt
+
+    response = interrupt({
+        "kind": "form",
+        "title": title,
+        "description": description,
+        "steps": steps,
+    })
+    # The resume value is the submitted form object; return it as JSON so the
+    # model reads structured fields. (A plain string resume is passed through.)
+    return response if isinstance(response, str) else json.dumps(response)
+
+
+@tool
 @with_fallback()
 async def current_time(timezone: str = "UTC") -> str:
     """Return the current wall-clock time in the given IANA timezone.
@@ -584,7 +612,7 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None):
     # LangGraph interrupt that only the lead turn's runner resumes. Subagents
     # (run outside that runner) must not get it, so it's gated by allowlist:
     # present in the full set for the lead agent, absent from subagent allowlists.
-    tools = [current_time, calculator, web_search, fetch_url, ask_human]
+    tools = [current_time, calculator, web_search, fetch_url, ask_human, request_user_input]
     # GitHub read tools (PRs/issues/commits) over the gh CLI. Always
     # included — they degrade to a readable error if gh/auth is missing.
     from tools.github_tools import get_github_tools
@@ -616,7 +644,7 @@ SEARCH_TOOLS_NAME = "search_tools"
 # delegation/workflow tools + the search meta-tool itself — enough to operate
 # and to *discover* the rest. Everything else is deferred until searched.
 DEFERRED_BASE_TOOL_NAMES = frozenset({
-    "current_time", "calculator", "web_search", "fetch_url", "ask_human",
+    "current_time", "calculator", "web_search", "fetch_url", "ask_human", "request_user_input",
     "task", "task_batch", "run_workflow", "save_workflow",
     SEARCH_TOOLS_NAME,
 })


### PR DESCRIPTION
**Sprint A, slice 1** (HITL approval + notification system, ProtoMaker-style schema forms).

Generalizes protoAgent's existing `ask_human` HITL machinery from a free-text question to a **JSON-schema form** — no new pause mechanism needed (it rides the LangGraph `interrupt()` → A2A `input-required` → `Command(resume=…)` flow that's already wired).

## What
- **`request_user_input(title, steps, description?)`** — a lead-agent tool that interrupts with `{kind:"form", title, description, steps:[{schema (JSON-Schema draft-07), uiSchema?, title?, description?}]}` and returns the submitted form object. Multiple steps = a wizard. (Mirrors ProtoMaker's `request_user_input`.) Registered as a default tool + in the deferred base; allowlist-gated out of subagents like `ask_human`.
- **`server._interrupt_payload()`** — the interrupt→`input_required` frame now passes richer shapes through (`{kind:"form", …}` alongside `{question}`), so the A2A layer parks them and the console can render a form vs. a prompt. Backward-compatible with `ask_human`.

## Tests
`tests/test_hitl_forms.py` — tool registration, deferred-base membership, and payload shaping (form/question passthrough + degrade-to-question). Full suite green (932).

## Next Sprint-A slices
Console form-card renderer + resume → desktop notification when the window is hidden → the `run_command` approval gate (flips shell on-behind-approval, per ADR 0007 update + the UX research).

🤖 Generated with [Claude Code](https://claude.com/claude-code)