### PR TITLE
feat(hitl): render HITL forms in the console + resume (Sprint A.2b)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,8 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   now passes richer shapes through (`{kind:"form", …}` alongside `{question}`) so
   the console can render a form vs a prompt. The input-required A2A status
   frame now carries the payload as a `hitl-v1` **DataPart** (alongside the text),
-  so any client can render the form/approval, not just read the question. (Console form-card + desktop
-  notification + the run_command approval gate are the next Sprint-A slices.)
+  so any client can render the form/approval, not just read the question.
+- **HITL forms render in the console + resume (Sprint A).** A paused
+  (input-required) turn surfaces its `hitl-v1` payload; the chat renders a
+  JSON-schema form (`request_user_input`) or a prompt (`ask_human`) above the
+  composer, and submitting resumes the turn on the same session. (Desktop
+  notification when the window is hidden + the `run_command` approval gate are
+  the next Sprint-A slices.)
 - **protoLabs.studio launch splash + console footer links.** A brand bumper
   (`IntroSplash`) shows the protoLabs.studio mark for ~2.5s on launch, then hands
   off to the app via the View Transitions API (clean cross-fade; plain unmount

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1187,6 +1187,84 @@ select:disabled {
 }
 
 /* Slash-command autocomplete (floats above the composer). */
+/* HITL request card (request_user_input form / ask_human prompt) — sits above
+   the composer when a turn pauses as input-required. */
+.hitl-card {
+  margin: 0 12px 8px;
+  padding: 12px 14px;
+  border: 1px solid var(--brand-indigo, #6366f1);
+  border-radius: var(--radius);
+  background: var(--bg-raised);
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.hitl-title {
+  font-weight: 600;
+}
+
+.hitl-prompt {
+  color: var(--fg-secondary);
+  font-size: 13px;
+}
+
+.hitl-step {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.hitl-step-title {
+  font-weight: 600;
+  font-size: 12px;
+  color: var(--fg-secondary);
+}
+
+.hitl-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.hitl-field > span {
+  color: var(--fg-secondary);
+}
+
+.hitl-field-bool {
+  flex-direction: row;
+  align-items: center;
+  gap: 8px;
+}
+
+.hitl-field input,
+.hitl-field select,
+.hitl-field textarea,
+.hitl-freetext {
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 6px 8px;
+  font: inherit;
+}
+
+.hitl-field small {
+  color: var(--fg-muted);
+}
+
+.hitl-freetext {
+  min-height: 60px;
+  resize: vertical;
+}
+
+.hitl-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
 .composer-wrap {
   position: relative;
 }

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -10,7 +10,8 @@ import { useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "../lib/api";
 import { ConfirmDialog } from "../app/ConfirmDialog";
-import type { ChatMessage, SlashCommand, ToolCall } from "../lib/types";
+import type { ChatMessage, HitlPayload, SlashCommand, ToolCall } from "../lib/types";
+import { HitlForm } from "./HitlForm";
 import { chatStore, useChatState } from "./chat-store";
 import { Markdown } from "./LazyMarkdown";
 import { ToolCalls } from "./ToolCalls";
@@ -149,6 +150,7 @@ function ChatSessionSlot({
   const [draft, setDraft] = useState("");
   const [statusMessage, setStatusMessage] = useState("");
   const [taskId, setTaskId] = useState("");
+  const [hitl, setHitl] = useState<HitlPayload | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -205,10 +207,25 @@ function ChatSessionSlot({
 
   async function send() {
     if (!session || !canSend) return;
+    const content = draft.trim();
+    setDraft("");
+    void runTurn(content);
+  }
+
+  // Resume a paused (input-required) turn: submitting the HITL form/question
+  // sends the response as a follow-up on the same session — the server feeds it
+  // to the agent via Command(resume=…). A form response is serialized to JSON.
+  async function resumeHitl(response: Record<string, unknown> | string) {
+    setHitl(null);
+    void runTurn(typeof response === "string" ? response : JSON.stringify(response));
+  }
+
+  async function runTurn(content: string) {
+    if (!session || !content) return;
     const userMessage: ChatMessage = {
       id: messageId(),
       role: "user",
-      content: draft.trim(),
+      content,
       createdAt: Date.now(),
       status: "done",
     };
@@ -235,6 +252,7 @@ function ChatSessionSlot({
         signal: controller.signal,
         onTaskId: setTaskId,
         onStatus: setStatusMessage,
+        onInputRequired: (payload) => setHitl(payload),
         onText: (text, append) => {
           const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
           if (!latest) return;
@@ -390,6 +408,15 @@ function ChatSessionSlot({
           ))
         )}
       </div>
+
+      {hitl && (
+        <HitlForm
+          payload={hitl}
+          busy={status === "streaming"}
+          onSubmit={resumeHitl}
+          onCancel={() => setHitl(null)}
+        />
+      )}
 
       <div className="composer-wrap">
         {status === "streaming" && statusMessage ? (

--- a/apps/web/src/chat/HitlForm.tsx
+++ b/apps/web/src/chat/HitlForm.tsx
@@ -1,0 +1,177 @@
+import { useState } from "react";
+
+import type { HitlFormStep, HitlPayload } from "../lib/types";
+
+// A lightweight JSON-schema form for HITL requests (request_user_input) and a
+// plain prompt for ask_human. Renders the common field types
+// (string/number/boolean/enum/textarea) — not a full @rjsf, but enough for the
+// config/choice/approval forms agents actually ask for. Multi-step = a single
+// scrollable form (all steps collected, submitted together).
+
+type FieldSchema = {
+  type?: string;
+  title?: string;
+  description?: string;
+  enum?: unknown[];
+  format?: string;
+  default?: unknown;
+};
+
+function fieldsOf(step: HitlFormStep): Array<[string, FieldSchema, boolean]> {
+  const schema = (step.schema || {}) as {
+    properties?: Record<string, FieldSchema>;
+    required?: string[];
+  };
+  const required = new Set(schema.required || []);
+  return Object.entries(schema.properties || {}).map(([key, fs]) => [key, fs, required.has(key)]);
+}
+
+function Field({
+  name,
+  schema,
+  required,
+  value,
+  onChange,
+}: {
+  name: string;
+  schema: FieldSchema;
+  required: boolean;
+  value: unknown;
+  onChange: (v: unknown) => void;
+}) {
+  const label = (schema.title || name) + (required ? " *" : "");
+
+  if (schema.type === "boolean") {
+    return (
+      <label className="hitl-field hitl-field-bool">
+        <input type="checkbox" checked={Boolean(value)} onChange={(e) => onChange(e.target.checked)} />
+        <span>{label}</span>
+      </label>
+    );
+  }
+
+  let control;
+  if (Array.isArray(schema.enum)) {
+    control = (
+      <select value={String(value ?? "")} onChange={(e) => onChange(e.target.value)}>
+        <option value="" disabled>
+          Select…
+        </option>
+        {schema.enum.map((opt) => (
+          <option key={String(opt)} value={String(opt)}>
+            {String(opt)}
+          </option>
+        ))}
+      </select>
+    );
+  } else if (schema.type === "number" || schema.type === "integer") {
+    control = (
+      <input
+        type="number"
+        value={value === undefined || value === null ? "" : String(value)}
+        onChange={(e) => onChange(e.target.value === "" ? undefined : Number(e.target.value))}
+      />
+    );
+  } else if (schema.format === "textarea") {
+    control = <textarea value={String(value ?? "")} onChange={(e) => onChange(e.target.value)} rows={3} />;
+  } else {
+    control = <input type="text" value={String(value ?? "")} onChange={(e) => onChange(e.target.value)} />;
+  }
+
+  return (
+    <label className="hitl-field">
+      <span>{label}</span>
+      {control}
+      {schema.description && <small>{schema.description}</small>}
+    </label>
+  );
+}
+
+export function HitlForm({
+  payload,
+  busy,
+  onSubmit,
+  onCancel,
+}: {
+  payload: HitlPayload;
+  busy?: boolean;
+  onSubmit: (response: Record<string, unknown> | string) => void;
+  onCancel: () => void;
+}) {
+  const isForm = payload.kind === "form" && (payload.steps?.length ?? 0) > 0;
+  const [values, setValues] = useState<Record<string, unknown>>({});
+  const [text, setText] = useState("");
+
+  // ask_human / free-text question.
+  if (!isForm) {
+    const prompt = payload.question || payload.description || payload.title || "Input requested.";
+    return (
+      <div className="hitl-card" role="dialog" aria-label="Input requested">
+        <div className="hitl-title">{payload.title || "Input requested"}</div>
+        <div className="hitl-prompt">{prompt}</div>
+        <textarea
+          className="hitl-freetext"
+          value={text}
+          autoFocus
+          placeholder="Your answer…"
+          onChange={(e) => setText(e.target.value)}
+        />
+        <div className="hitl-actions">
+          <button type="button" className="ghost-button" onClick={onCancel} disabled={busy}>
+            Dismiss
+          </button>
+          <button
+            type="button"
+            className="primary-button"
+            onClick={() => onSubmit(text.trim())}
+            disabled={busy || !text.trim()}
+          >
+            Send
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  const set = (k: string, v: unknown) => setValues((prev) => ({ ...prev, [k]: v }));
+  // Required fields across all steps must be filled before submit.
+  const missing = (payload.steps || []).some((step) =>
+    fieldsOf(step).some(([key, , req]) => req && (values[key] === undefined || values[key] === "")),
+  );
+
+  return (
+    <div className="hitl-card" role="dialog" aria-label={payload.title || "Form requested"}>
+      <div className="hitl-title">{payload.title || "Input requested"}</div>
+      {payload.description && <div className="hitl-prompt">{payload.description}</div>}
+      {(payload.steps || []).map((step, i) => (
+        <div className="hitl-step" key={i}>
+          {step.title && <div className="hitl-step-title">{step.title}</div>}
+          {step.description && <div className="hitl-prompt">{step.description}</div>}
+          {fieldsOf(step).map(([key, schema, req]) => (
+            <Field
+              key={key}
+              name={key}
+              schema={schema}
+              required={req}
+              value={values[key]}
+              onChange={(v) => set(key, v)}
+            />
+          ))}
+        </div>
+      ))}
+      <div className="hitl-actions">
+        <button type="button" className="ghost-button" onClick={onCancel} disabled={busy}>
+          Dismiss
+        </button>
+        <button
+          type="button"
+          className="primary-button"
+          onClick={() => onSubmit(values)}
+          disabled={busy || missing}
+        >
+          Submit
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   ChatMessage,
   ConfigPayload,
   GoalState,
+  HitlPayload,
   InboxItem,
   NotesWorkspace,
   RuntimeStatus,
@@ -126,6 +127,7 @@ function textFromParts(parts?: Array<{ kind?: string; text?: string }>) {
 }
 
 const TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json";
+const HITL_MIME = "application/vnd.protolabs.hitl-v1+json";
 
 /** Pull a structured tool event ({id, name, phase, input|output}) off a frame's parts. */
 function toolEventFromParts(
@@ -135,6 +137,16 @@ function toolEventFromParts(
     (p) => p.kind === "data" && p.metadata?.mimeType === TOOL_CALL_MIME,
   );
   return part ? (part.data as ToolEvent) : null;
+}
+
+/** Pull the HITL form/question payload off an input-required frame's parts. */
+function hitlFromParts(
+  parts?: Array<{ kind?: string; data?: unknown; metadata?: { mimeType?: string } }>,
+): HitlPayload | null {
+  const part = (parts || []).find(
+    (p) => p.kind === "data" && p.metadata?.mimeType === HITL_MIME,
+  );
+  return part ? (part.data as HitlPayload) : null;
 }
 
 function textFromTerminalTask(result: NonNullable<A2AFrame["result"]>) {
@@ -365,6 +377,7 @@ export const api = {
       onStatus?: (status: string) => void;
       onText?: (text: string, append: boolean) => void;
       onToolCall?: (evt: ToolEvent) => void;
+      onInputRequired?: (payload: HitlPayload) => void;
       onDone?: () => void;
     } = {},
   ) {
@@ -408,6 +421,13 @@ export const api = {
         handlers.onStatus?.(messageText || state);
         const toolEvent = toolEventFromParts(result.status?.message?.parts);
         if (toolEvent) handlers.onToolCall?.(toolEvent);
+        // HITL pause: the turn parked awaiting the operator. Surface the form /
+        // question payload so the console can render it (falls back to the text).
+        if (state === "input-required") {
+          handlers.onInputRequired?.(
+            hitlFromParts(result.status?.message?.parts) || { question: messageText },
+          );
+        }
         if (result.final) handlers.onDone?.();
       }
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -180,6 +180,23 @@ export type ChatMessage = {
   status?: "streaming" | "done" | "error";
 };
 
+// HITL (human-in-the-loop) request surfaced when a turn pauses as input-required
+// — a `request_user_input` JSON-schema form (kind "form", multi-step = wizard) or
+// an `ask_human` free-text question.
+export type HitlFormStep = {
+  schema: Record<string, unknown>; // JSON Schema (draft-07) of the step's fields
+  uiSchema?: Record<string, unknown>;
+  title?: string;
+  description?: string;
+};
+export type HitlPayload = {
+  kind?: "form";
+  title?: string;
+  description?: string;
+  steps?: HitlFormStep[];
+  question?: string; // ask_human shape
+};
+
 export type NotesWorkspace = {
   version: number;
   workspaceVersion: number;


### PR DESCRIPTION
**Sprint A, slice 2b** — the user-visible half: render HITL requests in the React console and resume.

The chat had no HITL handling (input-required just showed a status line). Now:
- **api.ts** — `streamChat` fires `onInputRequired(payload)` on `state===input-required`, reading the `hitl-v1` DataPart (falls back to `{question}`).
- **ChatSurface** — refactored `send`→`runTurn(content)` so a HITL submit reuses the turn path; the response (JSON for a form, text for a question) is sent as a follow-up on the **same session**, which the server resumes via `Command(resume=…)`.
- **HitlForm.tsx** — a lightweight JSON-schema renderer (string/number/boolean/enum/textarea; multi-step collected together) for `request_user_input`, and a prompt + textarea for `ask_human`. Sits above the composer.

`web:build` (tsc) clean. **Next:** desktop native notification when the window is hidden (so a form surfaces even menu-bar-only), then the `run_command` approval gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)