### PR TITLE
feat(beads): in-process SQLite issue store (Sprint B.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **In-process beads store (Sprint B).** A server-owned SQLite issue tracker
+  (`beads/store.py`, instance-scoped) — create/list/update/close/delete with the
+  beads issue shape — replacing the file-based `br` CLI. Foundation for the beads
+  agent tools + the console panel rewire (next slices).
 - **`request_user_input` HITL form tool (Sprint A, server side).** Generalizes
   `ask_human` from a free-text question to a **JSON-schema form** (multi-step =
   wizard): the agent calls `request_user_input(title, steps, description?)`, the

--- a/beads/__init__.py
+++ b/beads/__init__.py
@@ -1,0 +1,11 @@
+"""In-process beads — the agent's issue/task tracker (Sprint B).
+
+Replaces the file-based `br` CLI integration (operator_api/beads.py, which shelled
+out against a project's `.beads/`) with a server-owned SQLite store, so beads is a
+real in-process agent tool + console surface — no CLI, no filesystem-project
+dependency.
+"""
+
+from beads.store import BeadsStore, VALID_STATUSES
+
+__all__ = ["BeadsStore", "VALID_STATUSES"]

--- a/beads/store.py
+++ b/beads/store.py
@@ -1,0 +1,189 @@
+"""In-process beads issue store (Sprint B).
+
+A small SQLite-backed issue tracker the server owns — the agent's planning/task
+surface and the console's Beads panel both read/write it. Instance-scoped
+(``paths.scope_leaf``) so several agents don't share one board. No `br` CLI, no
+per-project `.beads/` directory.
+
+Issue shape (the fields the console + tools use):
+  id, title, description, status, priority, issue_type, assignee,
+  created_at, updated_at, closed_at, close_reason
+"""
+
+from __future__ import annotations
+
+import os
+import sqlite3
+import threading
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from paths import scope_leaf
+
+DEFAULT_DB_PATH = "/sandbox/beads/issues.db"
+
+# Open lifecycle states (closed is terminal). Mirrors the console's
+# issueStatusOrder; `tombstone` is intentionally absent (we hard-delete).
+VALID_STATUSES = ("open", "in_progress", "blocked", "deferred", "closed")
+_VALID_TYPES = ("task", "bug", "feature", "chore", "epic")
+
+
+def _now() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+def _resolve_db_path(db_path: str | None) -> Path:
+    """``BEADS_DB_PATH`` env → constructor arg → default. Falls back from a
+    non-writable ``/sandbox`` to ``~/.protoagent`` for local dev, then
+    instance-scoped — same shape as the knowledge store."""
+    raw = os.environ.get("BEADS_DB_PATH") or db_path or DEFAULT_DB_PATH
+    p = Path(raw).expanduser()
+    if str(p).startswith("/sandbox") and not Path("/sandbox").is_dir():
+        p = Path.home() / ".protoagent" / "beads" / "issues.db"
+    return scope_leaf(p)
+
+
+class BeadsStore:
+    """SQLite-backed issue tracker. Thread-safe via a single lock (the server
+    runs one process; contention is low)."""
+
+    def __init__(self, db_path: str | None = None):
+        self.path = _resolve_db_path(db_path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+        self._conn = sqlite3.connect(str(self.path), check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        self._init_schema()
+
+    def _init_schema(self) -> None:
+        with self._lock:
+            self._conn.execute(
+                """
+                CREATE TABLE IF NOT EXISTS issues (
+                    id           TEXT PRIMARY KEY,
+                    title        TEXT NOT NULL,
+                    description  TEXT NOT NULL DEFAULT '',
+                    status       TEXT NOT NULL DEFAULT 'open',
+                    priority     INTEGER NOT NULL DEFAULT 2,
+                    issue_type   TEXT NOT NULL DEFAULT 'task',
+                    assignee     TEXT NOT NULL DEFAULT '',
+                    created_at   TEXT NOT NULL,
+                    updated_at   TEXT NOT NULL,
+                    closed_at    TEXT,
+                    close_reason TEXT
+                )
+                """
+            )
+            self._conn.commit()
+
+    # ── helpers ───────────────────────────────────────────────────────────────
+
+    def _row(self, issue_id: str) -> sqlite3.Row | None:
+        return self._conn.execute("SELECT * FROM issues WHERE id = ?", (issue_id,)).fetchone()
+
+    def _next_id(self) -> str:
+        rows = self._conn.execute("SELECT id FROM issues WHERE id LIKE 'bd-%'").fetchall()
+        nums = [int(r["id"][3:]) for r in rows if r["id"][3:].isdigit()]
+        return f"bd-{(max(nums) + 1) if nums else 1}"
+
+    @staticmethod
+    def _norm_status(status: str | None) -> str:
+        s = (status or "open").strip().lower()
+        return s if s in VALID_STATUSES else "open"
+
+    @staticmethod
+    def _norm_type(t: str | None) -> str:
+        t = (t or "task").strip().lower()
+        return t if t in _VALID_TYPES else "task"
+
+    # ── operations ──────────────────────────────────────────────────────────────
+
+    def create(
+        self,
+        title: str,
+        *,
+        description: str = "",
+        priority: int = 2,
+        issue_type: str = "task",
+        assignee: str = "",
+    ) -> dict[str, Any]:
+        title = (title or "").strip()
+        if not title:
+            raise ValueError("title is required")
+        now = _now()
+        with self._lock:
+            issue_id = self._next_id()
+            self._conn.execute(
+                "INSERT INTO issues (id, title, description, status, priority, issue_type, "
+                "assignee, created_at, updated_at) VALUES (?,?,?,?,?,?,?,?,?)",
+                (
+                    issue_id, title, description or "", "open",
+                    int(priority) if priority is not None else 2,
+                    self._norm_type(issue_type), assignee or "", now, now,
+                ),
+            )
+            self._conn.commit()
+            return dict(self._row(issue_id))
+
+    def list(self, *, include_closed: bool = True) -> list[dict[str, Any]]:
+        if include_closed:
+            rows = self._conn.execute("SELECT * FROM issues ORDER BY created_at").fetchall()
+        else:
+            rows = self._conn.execute(
+                "SELECT * FROM issues WHERE status != 'closed' ORDER BY created_at"
+            ).fetchall()
+        return [dict(r) for r in rows]
+
+    def get(self, issue_id: str) -> dict[str, Any] | None:
+        row = self._row(issue_id)
+        return dict(row) if row else None
+
+    def update(self, issue_id: str, **fields: Any) -> dict[str, Any]:
+        if not issue_id:
+            raise ValueError("issue_id is required")
+        allowed = {"title", "description", "status", "priority", "issue_type", "assignee"}
+        # Accept `type` as an alias for issue_type (the console/tools use both).
+        if "type" in fields and "issue_type" not in fields:
+            fields["issue_type"] = fields.pop("type")
+        sets: list[str] = []
+        vals: list[Any] = []
+        for key, value in fields.items():
+            if key not in allowed or value is None:
+                continue
+            if key == "status":
+                value = self._norm_status(str(value))
+            elif key == "issue_type":
+                value = self._norm_type(str(value))
+            elif key == "priority":
+                value = int(value)
+            sets.append(f"{key} = ?")
+            vals.append(value)
+        with self._lock:
+            if self._row(issue_id) is None:
+                raise KeyError(f"unknown issue {issue_id!r}")
+            sets.append("updated_at = ?")
+            vals.append(_now())
+            self._conn.execute(f"UPDATE issues SET {', '.join(sets)} WHERE id = ?", (*vals, issue_id))
+            self._conn.commit()
+            return dict(self._row(issue_id))
+
+    def close(self, issue_id: str, reason: str | None = None) -> dict[str, Any]:
+        if not issue_id:
+            raise ValueError("issue_id is required")
+        now = _now()
+        with self._lock:
+            if self._row(issue_id) is None:
+                raise KeyError(f"unknown issue {issue_id!r}")
+            self._conn.execute(
+                "UPDATE issues SET status='closed', closed_at=?, close_reason=?, updated_at=? WHERE id=?",
+                (now, reason or "", now, issue_id),
+            )
+            self._conn.commit()
+            return dict(self._row(issue_id))
+
+    def delete(self, issue_id: str) -> bool:
+        with self._lock:
+            cur = self._conn.execute("DELETE FROM issues WHERE id = ?", (issue_id,))
+            self._conn.commit()
+            return cur.rowcount > 0

--- a/tests/test_beads_store.py
+++ b/tests/test_beads_store.py
@@ -1,0 +1,76 @@
+"""In-process beads store (Sprint B): SQLite issue tracker — create/list/update/
+close/delete, replacing the file-based `br` CLI."""
+
+from __future__ import annotations
+
+import pytest
+
+from beads.store import BeadsStore
+
+
+@pytest.fixture
+def store(tmp_path):
+    return BeadsStore(db_path=str(tmp_path / "issues.db"))
+
+
+def test_create_assigns_sequential_id_and_defaults(store):
+    a = store.create("first task")
+    b = store.create("second", priority=1, issue_type="bug", description="boom")
+    assert a["id"] == "bd-1" and b["id"] == "bd-2"
+    assert a["status"] == "open" and a["priority"] == 2 and a["issue_type"] == "task"
+    assert b["priority"] == 1 and b["issue_type"] == "bug" and b["description"] == "boom"
+    assert a["created_at"] and a["updated_at"]
+
+
+def test_create_requires_title(store):
+    with pytest.raises(ValueError):
+        store.create("   ")
+
+
+def test_list_and_include_closed(store):
+    store.create("open one")
+    closed = store.create("done one")
+    store.close(closed["id"], reason="shipped")
+    assert len(store.list()) == 2
+    open_only = store.list(include_closed=False)
+    assert [i["id"] for i in open_only] == ["bd-1"]
+
+
+def test_update_fields_and_type_alias(store):
+    i = store.create("t")
+    out = store.update(i["id"], status="in_progress", priority=0, type="feature", title="renamed")
+    assert out["status"] == "in_progress" and out["priority"] == 0
+    assert out["issue_type"] == "feature" and out["title"] == "renamed"
+    assert out["updated_at"] >= i["updated_at"]
+
+
+def test_update_normalizes_bad_status_and_type(store):
+    i = store.create("t")
+    out = store.update(i["id"], status="bogus", issue_type="nope")
+    assert out["status"] == "open" and out["issue_type"] == "task"
+
+
+def test_close_sets_terminal_fields(store):
+    i = store.create("t")
+    out = store.close(i["id"], reason="obsolete")
+    assert out["status"] == "closed" and out["closed_at"] and out["close_reason"] == "obsolete"
+
+
+def test_update_and_close_unknown_raise(store):
+    with pytest.raises(KeyError):
+        store.update("bd-999", status="open")
+    with pytest.raises(KeyError):
+        store.close("bd-999")
+
+
+def test_delete(store):
+    i = store.create("t")
+    assert store.delete(i["id"]) is True
+    assert store.get(i["id"]) is None
+    assert store.delete("bd-999") is False
+
+
+def test_persists_across_reopen(tmp_path):
+    path = str(tmp_path / "issues.db")
+    BeadsStore(db_path=path).create("survive me")
+    assert [i["title"] for i in BeadsStore(db_path=path).list()] == ["survive me"]


### PR DESCRIPTION
**Sprint B, slice 1.** A server-owned SQLite issue tracker (`beads/store.py`, instance-scoped via `paths.scope_leaf`) — `create/list/update/close/delete` with the beads issue shape (id/title/description/status/priority/issue_type/assignee/timestamps; sequential `bd-N` ids; statuses open/in_progress/blocked/deferred/closed).

Replaces the **file-based `br` CLI** dependency (today `operator_api/beads.py` shells out against a project's `.beads/`) — "pull it in process, not the file-based system," as requested.

Foundation only; next slices: the **`beads_*` agent tools** over this store (the agent's planning surface), then rewiring the **console Beads panel + operator API** to it.

Tests: 9 — CRUD, id sequencing, status/type normalization, include-closed filter, persistence across reopen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)