### PR TITLE
feat(beads): beads_* agent tools over the in-process store (Sprint B.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Beads agent tools (Sprint B).** The lead agent gets `beads_create` /
+  `beads_list` / `beads_update` / `beads_close` over the in-process store — its
+  planning/task surface (the todo replacement). Booted instance-scoped in
+  `server.py` and threaded through `create_agent_graph(beads_store=…)`.
 - **In-process beads store (Sprint B).** A server-owned SQLite issue tracker
   (`beads/store.py`, instance-scoped) — create/list/update/close/delete with the
   beads issue shape — replacing the file-based `br` CLI. Foundation for the beads

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -625,6 +625,7 @@ def create_agent_graph(
     checkpointer=None,
     workflow_registry=None,
     inbox_store=None,
+    beads_store=None,
 ):
     """Create the protoAgent LangGraph agent.
 
@@ -644,7 +645,9 @@ def create_agent_graph(
     """
     llm = create_llm(config)
 
-    all_tools = get_all_tools(knowledge_store, scheduler=scheduler, inbox_store=inbox_store)
+    all_tools = get_all_tools(
+        knowledge_store, scheduler=scheduler, inbox_store=inbox_store, beads_store=beads_store,
+    )
 
     if extra_tools:
         all_tools.extend(extra_tools)

--- a/server.py
+++ b/server.py
@@ -76,6 +76,7 @@ _skills_index = None     # SkillsIndex (human-authored SKILL.md store), or None.
 _workflow_registry = None  # WorkflowRegistry (declarative workflow recipes), or None.
 _telemetry_store = None  # TelemetryStore (per-turn cost/latency rollups, ADR 0006), or None.
 _inbox_store = None    # InboxStore — durable inbound inbox (ADR 0003), or None.
+_beads_store = None    # BeadsStore — in-process issue tracker (Sprint B), or None.
 _storm_guard = None    # StormGuard for the now→Activity fire path (ADR 0003).
 _mcp_clients = []        # Live MultiServerMCPClient handles (kept alive for reconnect).
 _mcp_tools = []          # MCP-server tools appended to the active graph.
@@ -258,8 +259,10 @@ def _init_langgraph_agent(headless_setup: bool = False):
 
     _workflow_registry = _build_workflow_registry(_graph_config)
 
-    global _inbox_store, _storm_guard
+    global _inbox_store, _storm_guard, _beads_store
     _inbox_store = _build_inbox_store(_graph_config)
+    from beads import BeadsStore
+    _beads_store = BeadsStore()  # in-process issue tracker (Sprint B), instance-scoped
     if _storm_guard is None:
         from inbox import StormGuard
         _storm_guard = StormGuard()
@@ -268,7 +271,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
         _graph_config, knowledge_store=_knowledge_store, scheduler=_scheduler,
         skills_index=_skills_index, extra_tools=_mcp_tools + _plugin_tools,
         checkpointer=_checkpointer, workflow_registry=_workflow_registry,
-        inbox_store=_inbox_store,
+        inbox_store=_inbox_store, beads_store=_beads_store,
     )
 
     # Cache-warming heartbeat — off by default; start() no-ops unless enabled

--- a/tests/test_beads_store.py
+++ b/tests/test_beads_store.py
@@ -74,3 +74,25 @@ def test_persists_across_reopen(tmp_path):
     path = str(tmp_path / "issues.db")
     BeadsStore(db_path=path).create("survive me")
     assert [i["title"] for i in BeadsStore(db_path=path).list()] == ["survive me"]
+
+
+# ── agent tools over the store ────────────────────────────────────────────────
+
+
+def test_beads_tools_wired_and_functional(store):
+    from tools.lg_tools import get_all_tools
+
+    by_name = {getattr(t, "name", ""): t for t in get_all_tools(beads_store=store)}
+    for name in ("beads_create", "beads_list", "beads_update", "beads_close"):
+        assert name in by_name
+    # Not added when no store is passed.
+    assert "beads_create" not in {getattr(t, "name", "") for t in get_all_tools()}
+
+    out = by_name["beads_create"].invoke({"title": "ship beads", "priority": 1})
+    assert "bd-1" in out
+    by_name["beads_update"].invoke({"issue_id": "bd-1", "status": "in_progress"})
+    listing = by_name["beads_list"].invoke({})
+    assert "in_progress" in listing and "ship beads" in listing
+    closed = by_name["beads_close"].invoke({"issue_id": "bd-1", "reason": "done"})
+    assert "Closed bd-1" in closed
+    assert store.get("bd-1")["status"] == "closed"

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -594,7 +594,70 @@ def _build_scheduler_tools(scheduler) -> list:
 # ── registry ─────────────────────────────────────────────────────────────────
 
 
-def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None):
+def _build_beads_tools(beads_store) -> list:
+    """Bind the beads issue tracker to a ``BeadsStore`` (Sprint B) — the agent's
+    in-process planning/task surface. Returns a list."""
+
+    @tool
+    def beads_create(title: str, description: str = "", priority: int = 2, issue_type: str = "task") -> str:
+        """Track a task/issue on your beads board — your planning surface for
+        multi-step work. ``priority`` 0=highest…3=low; ``issue_type`` is one of
+        task|bug|feature|chore|epic. Returns the new issue id."""
+        try:
+            i = beads_store.create(title, description=description, priority=priority, issue_type=issue_type)
+        except ValueError as exc:
+            return f"Error: {exc}"
+        return f"Created {i['id']}: {i['title']} ({i['issue_type']}, p{i['priority']})"
+
+    @tool
+    def beads_list(include_closed: bool = False) -> str:
+        """List issues on your beads board (open ones by default). Use it to see
+        and track outstanding work."""
+        items = beads_store.list(include_closed=include_closed)
+        if not items:
+            return "No issues on the board."
+        return "\n".join(
+            f"[{i['status']}] {i['id']} (p{i['priority']}, {i['issue_type']}) {i['title']}"
+            for i in items
+        )
+
+    @tool
+    def beads_update(
+        issue_id: str, status: str = "", title: str = "",
+        description: str = "", priority: int = -1, issue_type: str = "",
+    ) -> str:
+        """Update an issue. ``status`` is open|in_progress|blocked|deferred|closed.
+        Leave a field empty (``priority`` -1) to keep it unchanged."""
+        fields: dict = {}
+        if status:
+            fields["status"] = status
+        if title:
+            fields["title"] = title
+        if description:
+            fields["description"] = description
+        if priority is not None and priority >= 0:
+            fields["priority"] = priority
+        if issue_type:
+            fields["issue_type"] = issue_type
+        try:
+            i = beads_store.update(issue_id, **fields)
+        except (KeyError, ValueError) as exc:
+            return f"Error: {exc}"
+        return f"Updated {i['id']}: [{i['status']}] {i['title']}"
+
+    @tool
+    def beads_close(issue_id: str, reason: str = "") -> str:
+        """Close an issue (done, or won't-do). Optional ``reason``."""
+        try:
+            i = beads_store.close(issue_id, reason=reason or None)
+        except (KeyError, ValueError) as exc:
+            return f"Error: {exc}"
+        return f"Closed {i['id']}: {i['title']}"
+
+    return [beads_create, beads_list, beads_update, beads_close]
+
+
+def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, beads_store=None):
     """Return every LangChain tool the lead agent + subagents can use.
 
     Optional dependencies:
@@ -633,6 +696,8 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None):
         tools.extend(_build_scheduler_tools(scheduler))
     if inbox_store is not None:
         tools.extend(_build_inbox_tools(inbox_store))
+    if beads_store is not None:
+        tools.extend(_build_beads_tools(beads_store))
     return tools
 
 


### PR DESCRIPTION
**Sprint B, slice 2.** The lead agent now has a planning/task surface backed by the in-process beads store (B.1) — the todo replacement, not a file-based CLI.

- `_build_beads_tools(beads_store)` → **`beads_create` / `beads_list` / `beads_update` / `beads_close`**; `get_all_tools` gains a `beads_store` param.
- `create_agent_graph(beads_store=…)` threads it; `server.py` boots a `BeadsStore` (instance-scoped) and passes it. Allowlist-gated out of subagents (it's the lead's planning surface).

Tests: tools present only when a store is passed + a create→update→list→close round-trip through the tools. Full suite green (945).

Next (B.3): rewire the **console Beads panel + operator API** to the in-process store (drop the `br` CLI/`.beads/` dependency end-to-end).

🤖 Generated with [Claude Code](https://claude.com/claude-code)