### PR TITLE
feat(beads): console/operator API use the in-process store (Sprint B.3 — closes Sprint B)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Console Beads panel + API now use the in-process store (Sprint B).** The
+  operator beads endpoints go through a `_BeadsStoreAdapter` to the same
+  instance-scoped `BeadsStore` the agent uses — the agent and console share one
+  board, no `br` CLI / per-project `.beads/`. `project_path` is accepted but
+  ignored; the `br`-backed service stays as a fork fallback. **Completes the
+  beads-in-process work** (store + agent tools + console).
 - **Beads agent tools (Sprint B).** The lead agent gets `beads_create` /
   `beads_list` / `beads_update` / `beads_close` over the in-process store — its
   planning/task surface (the todo replacement). Booted instance-scoped in

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -122,6 +122,49 @@ def _model_payload(model: BaseModel) -> dict[str, Any]:
     return model.dict()
 
 
+class _BeadsStoreAdapter:
+    """Adapts the in-process ``BeadsStore`` (Sprint B) to the BeadsService method
+    shape the beads routes call. ``project_path`` is ignored — the store is a
+    single instance-scoped board the agent + console share (no `br` CLI, no
+    per-project ``.beads/``)."""
+
+    def __init__(self, store: Any):
+        self._s = store
+
+    def status(self, project_path: str) -> dict[str, bool]:
+        return {"initialized": True}
+
+    def init(self, project_path: str, prefix: str | None = None) -> dict[str, bool]:
+        return {"initialized": True, "already_initialized": True}
+
+    def list(self, project_path: str) -> list[dict[str, Any]]:
+        return self._s.list()
+
+    def create(self, project_path: str, issue: dict[str, Any]) -> dict[str, Any]:
+        return self._s.create(
+            str(issue.get("title", "")),
+            description=issue.get("description") or "",
+            priority=issue.get("priority") if issue.get("priority") is not None else 2,
+            issue_type=issue.get("type") or issue.get("issue_type") or "task",
+            assignee=issue.get("assignee") or "",
+        )
+
+    def update(self, project_path: str, issue_id: str, update: dict[str, Any]) -> dict[str, Any]:
+        fields = {
+            k: v
+            for k, v in update.items()
+            if k in ("title", "description", "status", "priority", "issue_type", "type", "assignee")
+            and v is not None
+        }
+        return self._s.update(issue_id, **fields)
+
+    def close(self, project_path: str, issue_id: str, reason: str | None = None) -> dict[str, Any]:
+        return self._s.close(issue_id, reason=reason)
+
+    def delete(self, project_path: str, issue_id: str) -> dict[str, Any]:
+        return {"deleted": self._s.delete(issue_id)}
+
+
 def register_operator_routes(
     app,
     *,
@@ -130,6 +173,7 @@ def register_operator_routes(
     subagent_run: Callable[[dict[str, Any]], Awaitable[str]],
     subagent_batch: Callable[[dict[str, Any]], Awaitable[str]],
     beads_service: BeadsService | None = None,
+    beads_store: Any | None = None,
     notes_service: NotesService | None = None,
     allowed_dirs: Callable[[], list[str]] | None = None,
     scheduler_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
@@ -154,7 +198,13 @@ def register_operator_routes(
     list, so it re-reads live config after a settings reload. Injected
     services keep their own allowlist; it only wires the defaults.
     """
-    beads = beads_service or BeadsService(allowed_dirs=allowed_dirs)
+    # Prefer the in-process store (Sprint B) — the agent + console share one
+    # instance-scoped board; the `br` CLI service stays as a fallback for forks.
+    beads = (
+        _BeadsStoreAdapter(beads_store)
+        if beads_store is not None
+        else (beads_service or BeadsService(allowed_dirs=allowed_dirs))
+    )
     notes = notes_service or NotesService(allowed_dirs=allowed_dirs)
 
     @app.get("/api/runtime/status")

--- a/server.py
+++ b/server.py
@@ -2346,6 +2346,7 @@ def _main():
         subagent_list=_operator_subagent_list,
         subagent_run=_operator_subagent_run,
         subagent_batch=_operator_subagent_batch,
+        beads_store=_beads_store,
         allowed_dirs=_operator_allowed_dirs,
         scheduler_list=_operator_scheduler_list,
         scheduler_add=_operator_scheduler_add,

--- a/tests/test_beads_store.py
+++ b/tests/test_beads_store.py
@@ -96,3 +96,20 @@ def test_beads_tools_wired_and_functional(store):
     closed = by_name["beads_close"].invoke({"issue_id": "bd-1", "reason": "done"})
     assert "Closed bd-1" in closed
     assert store.get("bd-1")["status"] == "closed"
+
+
+def test_operator_adapter_maps_to_store(store):
+    """The console's beads routes go through _BeadsStoreAdapter → the in-process
+    store (project_path ignored), so the agent + console share one board."""
+    from operator_api.routes import _BeadsStoreAdapter
+
+    a = _BeadsStoreAdapter(store)
+    assert a.status("/anything") == {"initialized": True}
+    issue = a.create("/anything", {"title": "from console", "type": "bug", "priority": 1})
+    assert issue["id"] == "bd-1" and issue["issue_type"] == "bug"
+    assert a.list("/anything")[0]["title"] == "from console"
+    a.update("/x", "bd-1", {"status": "in_progress", "project_path": "/x"})  # project_path ignored
+    assert store.get("bd-1")["status"] == "in_progress"
+    a.close("/x", "bd-1", "shipped")
+    assert store.get("bd-1")["status"] == "closed"
+    assert a.delete("/x", "bd-1") == {"deleted": True}


### PR DESCRIPTION
**Sprint B, final slice.** Rewire the console's Beads panel + operator API to the in-process `BeadsStore` — the **agent and console now share one instance-scoped board**; the `br` CLI / per-project `.beads/` is no longer used by the app.

- `_BeadsStoreAdapter` maps the in-process store to the `BeadsService` method shape the routes call (`project_path` ignored — one board). `register_operator_routes` gains a `beads_store` param and **prefers it** (the `br`-backed `BeadsService` stays as a fork fallback). `server.py` passes the booted `_beads_store`.
- **No web change needed** — the console still sends `project_path`, the adapter ignores it; the panel now reflects the shared board the agent writes to.

**Closes Sprint B** (#52): in-process store (B.1) → `beads_*` agent tools (B.2) → console/API rewire (B.3). "Pull beads in process, not the file-based system" — done. Tests: the adapter maps CRUD to the store. Full suite green (946).

Next: **Sprint C — workflow-builder UI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)