### PR TITLE
feat(workflows): save/delete API for console authoring (Sprint C.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Workflow authoring API (Sprint C).** `POST /api/workflows` validates a recipe
+  (against the live subagent registry + DAG checks via `validate_recipe`) and
+  saves it to the writable workflows dir (immediately runnable); `DELETE
+  /api/workflows/{name}` removes it. Backs the upcoming console workflow-builder.
 - **Console Beads panel + API now use the in-process store (Sprint B).** The
   operator beads endpoints go through a `_BeadsStoreAdapter` to the same
   instance-scoped `BeadsStore` the agent uses — the agent and console share one

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -184,6 +184,8 @@ def register_operator_routes(
     chat_commands: Callable[[], dict[str, Any]] | None = None,
     workflows_list: Callable[[], dict[str, Any]] | None = None,
     workflows_run: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
+    workflows_save: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+    workflows_delete: Callable[[str], dict[str, Any]] | None = None,
     events_subscribe: Callable[[], AsyncIterator[dict[str, Any]]] | None = None,
     activity_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
     inbox_add: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
@@ -383,6 +385,26 @@ def register_operator_routes(
         async def _workflow_run(name: str, req: WorkflowRunRequest):
             try:
                 return await workflows_run(name, req.inputs)
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    # Author a workflow from the console (validates, then saves to the writable
+    # workflows dir; immediately runnable). The body is the recipe dict.
+    if workflows_save is not None:
+
+        @app.post("/api/workflows")
+        async def _workflow_save(recipe: dict[str, Any]):
+            try:
+                return workflows_save(recipe)
+            except Exception as exc:
+                raise _http_error(exc) from exc
+
+    if workflows_delete is not None:
+
+        @app.delete("/api/workflows/{name}")
+        async def _workflow_delete(name: str):
+            try:
+                return workflows_delete(name)
             except Exception as exc:
                 raise _http_error(exc) from exc
 

--- a/server.py
+++ b/server.py
@@ -2198,6 +2198,24 @@ def _main():
             name=name, inputs=inputs or {},
         )
 
+    def _operator_workflow_save(recipe: dict) -> dict:
+        # Validate against the live subagent registry before writing, so a
+        # UI-authored recipe can't reference an unknown subagent / bad DAG.
+        if _workflow_registry is None:
+            raise RuntimeError("workflows are not available")
+        from graph.subagents.config import SUBAGENT_REGISTRY
+        from graph.workflows.engine import validate_recipe
+        errors = validate_recipe(recipe, known_subagents=set(SUBAGENT_REGISTRY))
+        if errors:
+            raise ValueError("invalid recipe: " + "; ".join(errors))
+        path = _workflow_registry.save(recipe)
+        return {"saved": True, "name": recipe.get("name"), "path": path}
+
+    def _operator_workflow_delete(name: str) -> dict:
+        if _workflow_registry is None:
+            raise RuntimeError("workflows are not available")
+        return {"deleted": _workflow_registry.delete(name)}
+
     def _publish_activity_terminal(record) -> None:
         """Terminal hook (ADR 0003): when a turn in the Activity thread completes,
         push the assistant's visible output to the event bus so connected
@@ -2356,6 +2374,8 @@ def _main():
         chat_commands=_operator_chat_commands,
         workflows_list=_operator_workflows_list,
         workflows_run=_operator_workflow_run,
+        workflows_save=_operator_workflow_save,
+        workflows_delete=_operator_workflow_delete,
         events_subscribe=_event_bus.subscribe,
         activity_list=_operator_activity_list,
         inbox_add=_operator_inbox_add,

--- a/tests/test_operator_api_routes.py
+++ b/tests/test_operator_api_routes.py
@@ -207,3 +207,55 @@ def test_chat_commands_absent_when_not_wired() -> None:
         subagent_batch=lambda r: None,
     )
     assert TestClient(app).get("/api/chat/commands").status_code == 404
+
+
+def test_workflow_save_validates_saves_and_deletes() -> None:
+    """POST /api/workflows validates the recipe (against known subagents) then
+    saves it; an unknown-subagent recipe is rejected; DELETE removes it."""
+    from graph.workflows.engine import validate_recipe
+
+    saved: dict = {}
+
+    def _save(recipe):
+        errors = validate_recipe(recipe, known_subagents={"researcher"})
+        if errors:
+            raise ValueError("; ".join(errors))
+        saved[recipe["name"]] = recipe
+        return {"saved": True, "name": recipe["name"]}
+
+    def _delete(name):
+        return {"deleted": saved.pop(name, None) is not None}
+
+    async def _run(req):
+        return "ok"
+
+    async def _batch(req):
+        return "ok"
+
+    app = FastAPI()
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=_run,
+        subagent_batch=_batch,
+        workflows_save=_save,
+        workflows_delete=_delete,
+    )
+    client = TestClient(app)
+
+    good = {
+        "name": "demo",
+        "inputs": [{"name": "topic", "required": True}],
+        "steps": [{"id": "s1", "subagent": "researcher", "prompt": "{{inputs.topic}}"}],
+        "output": "{{steps.s1.output}}",
+    }
+    r = client.post("/api/workflows", json=good)
+    assert r.status_code == 200 and r.json()["saved"] is True
+    assert "demo" in saved
+
+    bad = dict(good, name="bad", steps=[{"id": "s1", "subagent": "ghost", "prompt": "x"}])
+    assert client.post("/api/workflows", json=bad).status_code >= 400
+
+    assert client.delete("/api/workflows/demo").json()["deleted"] is True
+    assert client.delete("/api/workflows/demo").json()["deleted"] is False


### PR DESCRIPTION
**Sprint C, slice 1** (backend for the workflow-builder UI).

- **`POST /api/workflows`** — validates a recipe against the live `SUBAGENT_REGISTRY` + DAG/template checks (`validate_recipe`), then saves it via `WorkflowRegistry.save` (writable dir, reloaded → immediately runnable).
- **`DELETE /api/workflows/{name}`** — removes a recipe.
- `routes.py`: `workflows_save` / `workflows_delete` params + endpoints; `server.py`: `_operator_workflow_save` (validate → save) + `_operator_workflow_delete` over the live registry.

Tests: valid recipe saves; unknown-subagent recipe → 400; delete returns true/false. Full suite green.

Next (C.2): the **console workflow-builder** (add/edit steps + subagent picker + depends_on + DAG preview → save via this API).

🤖 Generated with [Claude Code](https://claude.com/claude-code)