### PR TITLE
feat(workflows): console workflow builder (Sprint C.2 — closes Sprint C)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Workflow builder in the console (Sprint C).** The Workflows surface gains a
+  **＋ New workflow** builder — name + inputs + steps (id, subagent picker,
+  prompt, `depends_on` checkboxes) + output — that saves via `POST /api/workflows`
+  (validated) and is immediately runnable; a Delete action removes a recipe.
+  Authoring workflows is no longer YAML-file-only. **Completes the workflow-builder.**
 - **Workflow authoring API (Sprint C).** `POST /api/workflows` validates a recipe
   (against the live subagent registry + DAG checks via `validate_recipe`) and
   saves it to the writable workflows dir (immediately runnable); `DELETE

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1677,6 +1677,71 @@ textarea {
   margin: 4px 12px;
 }
 
+/* Workflow builder (Sprint C) — author a recipe in the console. */
+.workflow-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 0 12px;
+}
+
+.builder-section {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 10px;
+}
+
+.builder-section-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  font-size: 12px;
+  font-weight: 600;
+  color: var(--fg-secondary);
+}
+
+.builder-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.builder-row input,
+.builder-row select,
+.builder-prompt {
+  flex: 1;
+  background: var(--bg);
+  color: var(--fg);
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 6px 8px;
+  font: inherit;
+}
+
+.builder-step {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  border-left: 2px solid var(--border);
+  padding-left: 8px;
+}
+
+.builder-prompt {
+  resize: vertical;
+}
+
+.builder-deps {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  font-size: 12px;
+  color: var(--fg-muted);
+}
+
 .workflow-step {
   display: flex;
   align-items: center;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -345,6 +345,19 @@ export const api = {
     });
   },
 
+  saveWorkflow(recipe: Record<string, unknown>) {
+    return request<{ saved: boolean; name: string; path?: string }>("/api/workflows", {
+      method: "POST",
+      body: recipe,
+    });
+  },
+
+  deleteWorkflow(name: string) {
+    return request<{ deleted: boolean }>(`/api/workflows/${encodeURIComponent(name)}`, {
+      method: "DELETE",
+    });
+  },
+
   saveSettings(updates: Record<string, unknown>) {
     return request<{ ok: boolean; messages: string[]; restart_required: string[] }>("/api/settings", {
       method: "POST",

--- a/apps/web/src/workflows/WorkflowBuilder.tsx
+++ b/apps/web/src/workflows/WorkflowBuilder.tsx
@@ -1,0 +1,207 @@
+import { Loader2, Plus, Save, Trash2, X } from "lucide-react";
+import { useState } from "react";
+
+import { api } from "../lib/api";
+
+// Author a workflow recipe from the console (Sprint C): name + inputs + steps
+// (id, subagent, prompt, depends_on) + output → POST /api/workflows, which
+// validates against the live subagent registry + DAG and saves it (immediately
+// runnable). Step ordering/parallelism is expressed via depends_on; the server
+// is the source of truth for validity.
+
+type Step = { id: string; subagent: string; prompt: string; dependsOn: string[] };
+type Input = { name: string; required: boolean };
+
+export function WorkflowBuilder({
+  subagents,
+  onSaved,
+  onCancel,
+}: {
+  subagents: string[];
+  onSaved: (name: string) => void;
+  onCancel: () => void;
+}) {
+  const fallback = subagents[0] || "researcher";
+  const [name, setName] = useState("");
+  const [description, setDescription] = useState("");
+  const [inputs, setInputs] = useState<Input[]>([{ name: "topic", required: true }]);
+  const [steps, setSteps] = useState<Step[]>([
+    { id: "step1", subagent: fallback, prompt: "", dependsOn: [] },
+  ]);
+  const [output, setOutput] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState("");
+
+  const setStep = (i: number, patch: Partial<Step>) =>
+    setSteps((s) => s.map((st, j) => (j === i ? { ...st, ...patch } : st)));
+  const addStep = () =>
+    setSteps((s) => [...s, { id: `step${s.length + 1}`, subagent: fallback, prompt: "", dependsOn: [] }]);
+  const removeStep = (i: number) => setSteps((s) => s.filter((_, j) => j !== i));
+
+  const toggleDep = (i: number, depId: string) =>
+    setStep(i, {
+      dependsOn: steps[i].dependsOn.includes(depId)
+        ? steps[i].dependsOn.filter((d) => d !== depId)
+        : [...steps[i].dependsOn, depId],
+    });
+
+  const valid =
+    name.trim() !== "" &&
+    steps.length > 0 &&
+    steps.every((st) => st.id.trim() && st.subagent && st.prompt.trim());
+
+  async function save() {
+    setSaving(true);
+    setError("");
+    const last = steps[steps.length - 1].id.trim();
+    const recipe: Record<string, unknown> = {
+      name: name.trim(),
+      version: 1,
+      inputs: inputs
+        .filter((i) => i.name.trim())
+        .map((i) => ({ name: i.name.trim(), required: i.required })),
+      steps: steps.map((st) => ({
+        id: st.id.trim(),
+        subagent: st.subagent,
+        prompt: st.prompt,
+        ...(st.dependsOn.length ? { depends_on: st.dependsOn } : {}),
+      })),
+      output: output.trim() || `{{steps.${last}.output}}`,
+    };
+    if (description.trim()) recipe.description = description.trim();
+    try {
+      const r = await api.saveWorkflow(recipe);
+      onSaved(r.name || name.trim());
+    } catch (e) {
+      setError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <div className="workflow-builder">
+      <div className="panel-header compact">
+        <h2>New workflow</h2>
+        <button className="icon-button" type="button" onClick={onCancel} title="Cancel">
+          <X size={16} />
+        </button>
+      </div>
+
+      <label className="field">
+        <span>Name *</span>
+        <input value={name} onChange={(e) => setName(e.target.value)} placeholder="my-workflow" />
+      </label>
+      <label className="field">
+        <span>Description</span>
+        <input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="optional" />
+      </label>
+
+      <div className="builder-section">
+        <div className="builder-section-head">
+          <span>Inputs</span>
+          <button className="ghost-button" type="button" onClick={() => setInputs((x) => [...x, { name: "", required: false }])}>
+            <Plus size={13} /> add input
+          </button>
+        </div>
+        {inputs.map((inp, i) => (
+          <div className="builder-row" key={i}>
+            <input
+              value={inp.name}
+              placeholder="input name"
+              onChange={(e) => setInputs((x) => x.map((v, j) => (j === i ? { ...v, name: e.target.value } : v)))}
+            />
+            <label className="checkbox-field">
+              <input
+                type="checkbox"
+                checked={inp.required}
+                onChange={(e) => setInputs((x) => x.map((v, j) => (j === i ? { ...v, required: e.target.checked } : v)))}
+              />
+              <span>required</span>
+            </label>
+            <button className="icon-button" type="button" onClick={() => setInputs((x) => x.filter((_, j) => j !== i))} title="Remove">
+              <Trash2 size={14} />
+            </button>
+          </div>
+        ))}
+      </div>
+
+      <div className="builder-section">
+        <div className="builder-section-head">
+          <span>Steps</span>
+          <button className="ghost-button" type="button" onClick={addStep}>
+            <Plus size={13} /> add step
+          </button>
+        </div>
+        {steps.map((step, i) => (
+          <div className="builder-step" key={i}>
+            <div className="builder-row">
+              <input
+                value={step.id}
+                placeholder="step id"
+                onChange={(e) => setStep(i, { id: e.target.value })}
+              />
+              <select value={step.subagent} onChange={(e) => setStep(i, { subagent: e.target.value })}>
+                {(subagents.length ? subagents : [fallback]).map((s) => (
+                  <option key={s} value={s}>
+                    {s}
+                  </option>
+                ))}
+              </select>
+              {steps.length > 1 && (
+                <button className="icon-button" type="button" onClick={() => removeStep(i)} title="Remove step">
+                  <Trash2 size={14} />
+                </button>
+              )}
+            </div>
+            <textarea
+              className="builder-prompt"
+              value={step.prompt}
+              rows={2}
+              placeholder="Prompt for this step — use {{inputs.x}} and {{steps.other.output}}"
+              onChange={(e) => setStep(i, { prompt: e.target.value })}
+            />
+            {steps.filter((_, j) => j !== i).length > 0 && (
+              <div className="builder-deps">
+                <span>depends on:</span>
+                {steps
+                  .filter((_, j) => j !== i)
+                  .map((other) => (
+                    <label className="checkbox-field" key={other.id}>
+                      <input
+                        type="checkbox"
+                        checked={step.dependsOn.includes(other.id)}
+                        onChange={() => toggleDep(i, other.id)}
+                      />
+                      <span>{other.id || "(unnamed)"}</span>
+                    </label>
+                  ))}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+
+      <label className="field">
+        <span>Output</span>
+        <input
+          value={output}
+          onChange={(e) => setOutput(e.target.value)}
+          placeholder={`default: {{steps.${steps[steps.length - 1].id.trim() || "lastStep"}.output}}`}
+        />
+      </label>
+
+      {error && <p className="workflow-failed">{error}</p>}
+
+      <div className="panel-actions">
+        <button className="ghost-button" type="button" onClick={onCancel} disabled={saving}>
+          Cancel
+        </button>
+        <button className="primary-button" type="button" onClick={() => void save()} disabled={!valid || saving}>
+          {saving ? <Loader2 className="spin" size={16} /> : <Save size={16} />}
+          Save workflow
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/workflows/WorkflowsSurface.tsx
+++ b/apps/web/src/workflows/WorkflowsSurface.tsx
@@ -1,8 +1,9 @@
-import { Loader2, Play, RefreshCw, Workflow } from "lucide-react";
+import { Loader2, Play, Plus, RefreshCw, Trash2, Workflow } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { api } from "../lib/api";
 import type { WorkflowRunResult, WorkflowSummary } from "../lib/types";
+import { WorkflowBuilder } from "./WorkflowBuilder";
 
 // Operator surface for declarative workflow recipes (ADR 0002). Lists the
 // registered recipes, shows the selected one's step DAG, collects its inputs,
@@ -14,6 +15,8 @@ export function WorkflowsSurface({ onError }: { onError: (message: string) => vo
   const [inputs, setInputs] = useState<Record<string, string>>({});
   const [running, setRunning] = useState(false);
   const [result, setResult] = useState<WorkflowRunResult | null>(null);
+  const [building, setBuilding] = useState(false);
+  const [subagentNames, setSubagentNames] = useState<string[]>([]);
 
   async function load() {
     try {
@@ -28,7 +31,22 @@ export function WorkflowsSurface({ onError }: { onError: (message: string) => vo
   }
   useEffect(() => {
     void load();
+    void api
+      .subagents()
+      .then((r) => setSubagentNames((r.subagents || []).map((s) => s.name).filter(Boolean)))
+      .catch(() => setSubagentNames([]));
   }, []);
+
+  async function removeWorkflow(name: string) {
+    onError("");
+    try {
+      await api.deleteWorkflow(name);
+      setSelected("");
+      await load();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  }
 
   const current = useMemo(
     () => workflows?.find((w) => w.name === selected) ?? null,
@@ -80,12 +98,28 @@ export function WorkflowsSurface({ onError }: { onError: (message: string) => vo
             {workflows ? `${workflows.length} recipe${workflows.length === 1 ? "" : "s"}` : "loading…"}
           </p>
         </div>
-        <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
-          <RefreshCw size={16} />
-        </button>
+        <div className="panel-actions">
+          <button className="icon-button" type="button" onClick={() => setBuilding((b) => !b)} title="New workflow">
+            <Plus size={16} />
+          </button>
+          <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
+            <RefreshCw size={16} />
+          </button>
+        </div>
       </div>
 
       <div className="stage-body">
+        {building ? (
+          <WorkflowBuilder
+            subagents={subagentNames}
+            onCancel={() => setBuilding(false)}
+            onSaved={(name) => {
+              setBuilding(false);
+              void load().then(() => setSelected(name));
+            }}
+          />
+        ) : (
+          <>
         {workflows && !workflows.length ? (
           <div className="subagent-row">
             <div>
@@ -154,6 +188,14 @@ export function WorkflowsSurface({ onError }: { onError: (message: string) => vo
                 {running ? <Loader2 className="spin" size={16} /> : <Play size={16} />}
                 Run
               </button>
+              <button
+                className="ghost-button"
+                type="button"
+                onClick={() => void removeWorkflow(current.name)}
+                title="Delete this workflow"
+              >
+                <Trash2 size={14} /> Delete
+              </button>
             </div>
           </>
         ) : null}
@@ -178,6 +220,8 @@ export function WorkflowsSurface({ onError }: { onError: (message: string) => vo
             ) : null}
           </div>
         ) : null}
+          </>
+        )}
       </div>
     </section>
   );

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -85,6 +85,13 @@ collapsible per-step breakdown, and flags any steps that failed (failures are
 recorded inline so the rest of the DAG still runs). It's backed by
 `GET /api/workflows` and `POST /api/workflows/{name}/run`.
 
+**Author one from the console** — the surface's **＋** opens a builder: name +
+inputs + steps (id, a subagent picker, prompt, and `depends_on` checkboxes for
+ordering/parallelism) + output. Saving validates the recipe against the live
+subagent registry + DAG and writes it to the workflows dir (immediately
+runnable) — `POST /api/workflows`; `DELETE /api/workflows/{name}` removes it.
+Same `WorkflowRegistry.save` path the agent's `save_workflow` tool uses.
+
 ## Deep research with adversarial review
 
 `deep-research.yaml` is the heavyweight, decision-grade counterpart to a single


### PR DESCRIPTION
**Sprint C, final slice** — author workflows from the console, not just YAML files.

The Workflows surface gains a **＋ New workflow** builder (`WorkflowBuilder.tsx`):
- **name + inputs** (`{name, required}`) **+ steps** (id, a **subagent picker** from `/api/subagents`, prompt textarea, **`depends_on` checkboxes** for ordering/parallelism) **+ output** (defaults to the last step).
- Saves via `api.saveWorkflow` → `POST /api/workflows` (validated server-side against the live subagent registry + DAG, C.1) → reload + select. The run/list view also gains a **Delete** action.
- `api.ts`: `saveWorkflow` / `deleteWorkflow`; builder + run views toggle in `WorkflowsSurface`; styles + workflows-guide note.

`web:build` + `docs:build` clean. **Closes Sprint C** (#53): save/delete API (C.1) + this builder UI (C.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)