### PR TITLE
feat(notes): agent-global notes; drop the project selector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Notes are now agent-global, like beads.** The notes workspace is a single
+  persistent, instance-scoped store (`$NOTES_PATH`, default
+  `/sandbox/notes/workspace.json`) that the `notes_*` tools and the console
+  Notes panel share — no longer per-project (`.automaker/notes/` inside project
+  dirs is gone). Scattering the agent's notebook across whatever directory was
+  "the project" was confusing; the agent has one notebook now. The `notes_*`
+  tools and the notes/beads APIs drop their `project_path` argument (still
+  accepted-and-ignored on the HTTP layer for back-compat). The console's
+  right-panel **project selector is removed**: `operator.allowed_dirs` is purely
+  the filesystem security fence for file/shell tools, unrelated to notes/beads.
+
 ### Added
 - **Workflow builder in the console (Sprint C).** The Workflows surface gains a
   **＋ New workflow** builder — name + inputs + steps (id, subagent picker,

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -365,17 +365,19 @@ export function App() {
     }
   }
 
-  async function refreshProjectState(path = projectPath) {
-    if (!path.trim()) return;
+  // Notes + Beads are agent-global (one persistent store each) — not scoped to
+  // a project. The project / allowed-dirs list is purely the filesystem
+  // security fence; it doesn't gate the agent's notebook or task board.
+  async function refreshProjectState() {
     const [notesPayload, beadsStatus] = await Promise.all([
-      api.getNotes(path),
-      api.beadsStatus(path),
+      api.getNotes(),
+      api.beadsStatus(),
     ]);
     setWorkspace(notesPayload.workspace);
     setNotesDirty(false);
     setBeadsReady(beadsStatus.initialized);
     if (beadsStatus.initialized) {
-      const issuesPayload = await api.beadsIssues(path);
+      const issuesPayload = await api.beadsIssues();
       setBeadsIssues(issuesPayload.issues);
     } else {
       setBeadsIssues([]);
@@ -387,24 +389,13 @@ export function App() {
     setError("");
     try {
       const runtimePayload = await refreshRuntime();
-      const serverDefault = runtimePayload.project.path;
-      let nextProjectPath = projectPath.trim() || serverDefault;
-      try {
-        await refreshProjectState(nextProjectPath);
-      } catch (projErr) {
-        // The persisted project path is stale/invalid — e.g. a previous frozen
-        // (desktop) run stored a PyInstaller _MEI temp dir that no longer
-        // exists. Self-heal by adopting the server's current default project.
-        if (serverDefault && nextProjectPath !== serverDefault) {
-          nextProjectPath = serverDefault;
-          await refreshProjectState(nextProjectPath);
-        } else {
-          throw projErr;
-        }
+      // Adopt the server's default project as the fs working dir if none is
+      // set (it seeds the setup wizard's allowed-dirs); notes/beads load
+      // globally regardless.
+      if (!projectPath.trim() && runtimePayload.project.path) {
+        setProjectPath(runtimePayload.project.path);
       }
-      if (nextProjectPath && nextProjectPath !== projectPath) {
-        setProjectPath(nextProjectPath);
-      }
+      await refreshProjectState();
       setStatus("ready");
     } catch (exc) {
       setStatus("error");
@@ -436,23 +427,23 @@ export function App() {
   }, []);
 
   useEffect(() => {
-    if (!notesDirty || !workspace || !projectPath.trim()) return;
+    if (!notesDirty || !workspace) return;
     const handle = window.setTimeout(() => {
       void saveWorkspaceSnapshot(workspace, { quiet: true });
     }, 800);
     return () => window.clearTimeout(handle);
-  }, [notesBusy, notesDirty, projectPath, workspace]);
+  }, [notesBusy, notesDirty, workspace]);
 
   // Live notes refresh — the agent (via notes_write) or another tab can change
   // the workspace on disk. Poll while the Notes panel is open and adopt newer
   // server state, but never clobber the user's unsaved edits (notesDirty) and
   // keep their active tab selection.
   useEffect(() => {
-    if (rightPanel !== "notes" || !projectPath.trim()) return;
+    if (rightPanel !== "notes") return;
     const handle = window.setInterval(async () => {
       if (notesDirty || notesBusy) return;
       try {
-        const { workspace: latest } = await api.getNotes(projectPath);
+        const { workspace: latest } = await api.getNotes();
         setWorkspace((current) => {
           if (!current || latest.workspaceVersion <= current.workspaceVersion) return current;
           const keepActive = latest.tabs[current.activeTabId] ? current.activeTabId : latest.activeTabId;
@@ -463,7 +454,7 @@ export function App() {
       }
     }, 4000);
     return () => window.clearInterval(handle);
-  }, [rightPanel, projectPath, notesDirty, notesBusy]);
+  }, [rightPanel, notesDirty, notesBusy]);
 
   useEffect(() => {
     if (surface === "activity" && activityTab === "schedule") void refreshSchedules();
@@ -601,7 +592,7 @@ export function App() {
   }
 
   function saveActiveNote(content: string) {
-    if (!workspace || !activeTab || !projectPath.trim()) return;
+    if (!workspace || !activeTab) return;
     const nextWorkspace: NotesWorkspace = {
       ...workspace,
       workspaceVersion: workspace.workspaceVersion + 1,
@@ -626,11 +617,11 @@ export function App() {
     snapshot: NotesWorkspace,
     options: { quiet?: boolean } = {},
   ) {
-    if (!projectPath.trim() || notesBusy) return;
+    if (notesBusy) return;
     setNotesBusy(true);
     if (!options.quiet) setError("");
     try {
-      await api.saveNotes(projectPath, snapshot);
+      await api.saveNotes(snapshot);
       setNotesDirty(false);
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : String(exc));
@@ -714,11 +705,11 @@ export function App() {
   }
 
   async function initBeads() {
-    if (!projectPath.trim() || beadsBusy) return;
+    if (beadsBusy) return;
     setBeadsBusy(true);
     setError("");
     try {
-      await api.initBeads(projectPath);
+      await api.initBeads();
       await refreshProjectState();
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : String(exc));
@@ -729,11 +720,11 @@ export function App() {
 
   async function createIssue() {
     const title = issueDraft.title.trim();
-    if (!projectPath.trim() || !title || beadsBusy) return;
+    if (!title || beadsBusy) return;
     setBeadsBusy(true);
     setError("");
     try {
-      const response = await api.createIssue(projectPath, {
+      const response = await api.createIssue({
         title,
         type: issueDraft.type,
         priority: issueDraft.priority,
@@ -765,11 +756,11 @@ export function App() {
   }
 
   async function updateIssueStatus(issue: BeadsIssue, nextStatus: string) {
-    if (!projectPath.trim() || beadsBusy) return;
+    if (beadsBusy) return;
     setBeadsBusy(true);
     setError("");
     try {
-      const response = await api.updateIssue(projectPath, issue.id, { status: nextStatus });
+      const response = await api.updateIssue(issue.id, { status: nextStatus });
       replaceIssue(response.issue.id ? response.issue : { ...issue, status: nextStatus });
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : String(exc));
@@ -779,11 +770,11 @@ export function App() {
   }
 
   async function closeIssue(issue: BeadsIssue) {
-    if (!projectPath.trim() || beadsBusy) return;
+    if (beadsBusy) return;
     setBeadsBusy(true);
     setError("");
     try {
-      const response = await api.closeIssue(projectPath, issue.id);
+      const response = await api.closeIssue(issue.id);
       replaceIssue(response.issue.id ? response.issue : { ...issue, status: "closed" });
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : String(exc));
@@ -793,7 +784,7 @@ export function App() {
   }
 
   function deleteIssue(issue: BeadsIssue) {
-    if (!projectPath.trim() || beadsBusy) return;
+    if (beadsBusy) return;
     setConfirmState({
       title: `Delete ${issue.id}?`,
       message: `${issue.title ? `"${issue.title}"` : "This issue"} will be permanently deleted from the beads store.`,
@@ -803,11 +794,10 @@ export function App() {
   }
 
   async function doDeleteIssue(issue: BeadsIssue) {
-    if (!projectPath.trim()) return;
     setBeadsBusy(true);
     setError("");
     try {
-      await api.deleteIssue(projectPath, issue.id);
+      await api.deleteIssue(issue.id);
       setBeadsIssues((items) => items.filter((item) => item.id !== issue.id));
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : String(exc));
@@ -1375,30 +1365,25 @@ export function App() {
               data-testid="right-resize"
             />
           ) : null}
-          <div className="project-bar">
-            <input
-              value={projectPath}
-              onChange={(event) => setProjectPath(event.target.value)}
-              placeholder="Project path"
-              list="operator-allowed-dirs"
-            />
-            <datalist id="operator-allowed-dirs">
-              {(runtime?.project.allowed_dirs || []).map((dir) => (
-                <option key={dir} value={dir} />
-              ))}
-            </datalist>
-            <button className="icon-button" type="button" onClick={() => void loadProject()} title="Load project">
+          <div className="right-panel-nav">
+            <div className="segmented">
+              <button type="button" className={rightPanel === "notes" ? "active" : ""} onClick={() => setRightPanel("notes")}>
+                <FileText size={15} />
+                Notes
+              </button>
+              <button type="button" className={rightPanel === "beads" ? "active" : ""} onClick={() => setRightPanel("beads")}>
+                <Boxes size={15} />
+                Beads
+              </button>
+            </div>
+            <button
+              className="icon-button"
+              type="button"
+              onClick={() => void loadProject()}
+              disabled={notesBusy || beadsBusy}
+              title="Refresh notes & beads"
+            >
               {notesBusy || beadsBusy ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
-            </button>
-          </div>
-          <div className="segmented">
-            <button type="button" className={rightPanel === "notes" ? "active" : ""} onClick={() => setRightPanel("notes")}>
-              <FileText size={15} />
-              Notes
-            </button>
-            <button type="button" className={rightPanel === "beads" ? "active" : ""} onClick={() => setRightPanel("beads")}>
-              <Boxes size={15} />
-              Beads
             </button>
           </div>
 

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1866,10 +1866,14 @@ textarea {
   font-size: 13px;
 }
 
-.project-bar {
+/* Right-panel tab row: the Notes/Beads segmented control + a refresh button.
+   (The per-project selector was removed — notes/beads are agent-global; the
+   project/allowed-dirs list is purely the filesystem fence.) */
+.right-panel-nav {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 8px;
+  align-items: stretch;
 }
 
 .segmented {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -464,53 +464,48 @@ export const api = {
     });
   },
 
-  getNotes(projectPath: string) {
-    const params = new URLSearchParams({ project_path: projectPath });
-    return request<{ workspace: NotesWorkspace }>(`/api/notes/workspace?${params}`);
+  // Notes + Beads are agent-global (one persistent store each) — no project
+  // scope. The project / allowed-dirs list is purely the filesystem fence.
+  getNotes() {
+    return request<{ workspace: NotesWorkspace }>("/api/notes/workspace");
   },
 
-  saveNotes(projectPath: string, workspace: NotesWorkspace) {
+  saveNotes(workspace: NotesWorkspace) {
     return request<{ ok: boolean }>("/api/notes/workspace", {
       method: "POST",
-      body: { project_path: projectPath, workspace },
+      body: { workspace },
     });
   },
 
-  beadsStatus(projectPath: string) {
-    const params = new URLSearchParams({ project_path: projectPath });
-    return request<{ initialized: boolean }>(`/api/beads/status?${params}`);
+  beadsStatus() {
+    return request<{ initialized: boolean }>("/api/beads/status");
   },
 
-  initBeads(projectPath: string) {
+  initBeads() {
     return request<{ initialized: boolean; already_initialized?: boolean }>("/api/beads/init", {
       method: "POST",
-      body: { project_path: projectPath },
+      body: {},
     });
   },
 
-  beadsIssues(projectPath: string) {
-    const params = new URLSearchParams({ project_path: projectPath });
-    return request<{ issues: BeadsIssue[] }>(`/api/beads/issues?${params}`);
+  beadsIssues() {
+    return request<{ issues: BeadsIssue[] }>("/api/beads/issues");
   },
 
-  createIssue(
-    projectPath: string,
-    issue: {
-      title: string;
-      type?: string;
-      priority?: number;
-      description?: string;
-      assignee?: string;
-    },
-  ) {
+  createIssue(issue: {
+    title: string;
+    type?: string;
+    priority?: number;
+    description?: string;
+    assignee?: string;
+  }) {
     return request<{ issue: BeadsIssue }>("/api/beads/issues", {
       method: "POST",
-      body: { project_path: projectPath, ...issue },
+      body: { ...issue },
     });
   },
 
   updateIssue(
-    projectPath: string,
     issueId: string,
     update: {
       title?: string;
@@ -523,21 +518,20 @@ export const api = {
   ) {
     return request<{ issue: BeadsIssue }>(`/api/beads/issues/${encodeURIComponent(issueId)}`, {
       method: "PATCH",
-      body: { project_path: projectPath, ...update },
+      body: { ...update },
     });
   },
 
-  closeIssue(projectPath: string, issueId: string, reason?: string) {
+  closeIssue(issueId: string, reason?: string) {
     return request<{ issue: BeadsIssue }>(`/api/beads/issues/${encodeURIComponent(issueId)}/close`, {
       method: "POST",
-      body: { project_path: projectPath, reason },
+      body: { reason },
     });
   },
 
-  deleteIssue(projectPath: string, issueId: string) {
-    const params = new URLSearchParams({ project_path: projectPath });
+  deleteIssue(issueId: string) {
     return request<{ deleted?: string; project_path?: string }>(
-      `/api/beads/issues/${encodeURIComponent(issueId)}?${params}`,
+      `/api/beads/issues/${encodeURIComponent(issueId)}`,
       { method: "DELETE" },
     );
   },

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -247,11 +247,10 @@ export function SetupWizard({
         setError(response.message);
         return;
       }
-      // `br` ships in the container, so init is expected to succeed — surface
-      // a failure rather than swallowing it. The allowlist no longer blocks it
-      // (the project path is folded into allowed_dirs above).
-      if (state.initBeads && projectPath.trim()) {
-        await api.initBeads(projectPath);
+      // The beads store is agent-global and always ready, so this is a no-op
+      // confirmation now (kept so the setup step still feels acknowledged).
+      if (state.initBeads) {
+        await api.initBeads();
       }
       setMessage(response.message);
       onFinished();

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -141,10 +141,10 @@ Add these before the React UI depends on them:
 | `GET /api/subagents` | list `SUBAGENT_REGISTRY` entries, tool allowlists, max turns, enabled state |
 | `POST /api/subagents/run` | manually launch one subagent with `{session_id, type, description, prompt, emit_skill}` |
 | `POST /api/subagents/batch` | manually launch independent subagent jobs concurrently |
-| `GET /api/beads/status?project_path=` | detect initialized `.beads/` store through `br list --json` |
-| `POST /api/beads/init` | run `br init` idempotently |
-| `GET/POST /api/beads/issues` | list/create/update/close/delete issues through `br --json` |
-| `GET/POST /api/notes/workspace` | load/save the notes workspace file |
+| `GET /api/beads/status` | report the in-process beads store ready (agent-global; always initialized) |
+| `POST /api/beads/init` | no-op confirmation (the store is always ready) |
+| `GET/POST /api/beads/issues` | list/create/update/close/delete issues in the in-process store |
+| `GET/POST /api/notes/workspace` | load/save the agent-global notes workspace (no project scope) |
 | `GET/POST /api/scheduler/jobs`, `DELETE /api/scheduler/jobs/{id}` | list/create/cancel scheduled jobs over the active `SchedulerBackend` |
 | `GET /api/goals`, `DELETE /api/goals/{session_id}` | list goals across sessions / clear one (goals are *set* in chat via `/goal`) |
 | `GET /api/chat/commands` | registered slash commands (`{name, description, usage}`) for the composer's `/` autocomplete |
@@ -329,20 +329,29 @@ block React UI validation.
 7. **Tauri shell**: wrap `/app`, add tray/hotkey/hide-on-close.
 8. **Gradio retirement**: remove only after React covers setup, config, chat, diagnostics.
 
-## Directory Allowlist
+## Notes & beads are agent-global; the allowlist is the filesystem fence
 
-The beads and notes APIs take a `project_path` from the (free-text) UI, so the
-server — not the client — decides which directories they may read and write.
-`operator.allowed_dirs` in `config/langgraph-config.yaml` is that boundary:
+Notes and beads used to be **per-project** (the panels took a `project_path`
+from a free-text selector). That was confusing — the agent's notebook and task
+board would silently change depending on which directory was "the project". So
+both are now **agent-global**: one persistent, instance-scoped store each (notes
+at `$NOTES_PATH`, beads at `$BEADS_DB_PATH`), shared by the agent's tools and
+the console. There's no per-project `.automaker/notes/` or `.beads/` anymore,
+and the right panel has no project selector.
 
-- The protoAgent repo root is always allowed (the default project).
-- Add other project roots you operate on to `operator.allowed_dirs`, or edit
-  the list in-app from the setup wizard's **Workspace** step.
-- An out-of-allowlist path is rejected with a 400 before any subprocess or file
-  I/O. `resolve_project_path` resolves symlinks and `..` *before* the
-  containment check, so neither can escape an allowed root.
-- The runtime-status `project.allowed_dirs` field feeds the project-path
-  picker's suggestions; it does not relax the server-side check.
+`operator.allowed_dirs` in `config/langgraph-config.yaml` is now purely the
+**filesystem security fence** for the agent's file/shell tools — it has nothing
+to do with notes/beads:
+
+- The protoAgent repo root is always allowed (the default workspace).
+- Add other roots the agent may read/write to `operator.allowed_dirs`, or set
+  the working directory from the setup wizard's **Workspace** step (it's folded
+  into the allowlist automatically).
+- An out-of-allowlist path is rejected before any file I/O. `resolve_project_path`
+  resolves symlinks and `..` *before* the containment check, so neither can
+  escape an allowed root.
+- The runtime-status `project.allowed_dirs` field reports the fence; it does not
+  relax the server-side check.
 
 ## Studio & Activity surfaces (the control stack)
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -56,6 +56,22 @@ The bundled `KnowledgeStore` (sqlite + FTS5) is enabled by default. See [Configu
 
 To opt out entirely, set `middleware.knowledge: false` in YAML. The memory tools (`memory_ingest`, `memory_recall`, etc.) are dropped from the agent loop when the store is disabled.
 
+## Notes, beads & goals (agent-global working stores)
+
+The agent's notebook, task board, and goals are **agent-global** — one
+persistent, instance-scoped store each, shared by the agent's tools and the
+operator console. They are *not* per-project (there's no `.automaker/notes/` or
+`.beads/` inside project directories); `operator.allowed_dirs` is purely the
+filesystem fence for file/shell tools, unrelated to these stores. Each falls
+back from a non-writable `/sandbox` to `~/.protoagent/…` for local dev and is
+instance-scoped via `PROTOAGENT_INSTANCE`.
+
+| Variable | Default | What |
+|---|---|---|
+| `NOTES_PATH` | `/sandbox/notes/workspace.json` | The console Notes panel workspace + the `notes_*` tools. |
+| `BEADS_DB_PATH` | `/sandbox/beads/issues.db` | The in-process beads issue store (the `beads_*` tools + the console Beads panel). |
+| `GOAL_PATH` | `/sandbox/goals` | Directory of per-session goal JSON files (goal mode). |
+
 ## Audit log
 
 | Variable | Default | What |

--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -8,7 +8,7 @@ Sixteen tools ship by default:
 - Three **scheduler tools** — `schedule_task`, `list_schedules`, `cancel_schedule` — bound to the bundled scheduler backend (local sqlite or the Workstacean adapter, see [Schedule future work](/guides/scheduler)).
 - One **inbox tool** — `check_inbox` — bound to the durable inbound inbox (ADR 0003) when configured; pulls stimuli pushed to `POST /api/inbox`.
 - One **HITL tool** — `ask_human` — pauses the turn (A2A `input-required`) to ask the operator and resumes with their answer (lead-agent only).
-- Four **project-notes tools** — `notes_list`, `notes_read`, `notes_write`, `notes_revert` — bridge the operator console's Notes panel tabs to the agent, gated per-tab by the operator's Agent-read/write toggles; writes are versioned (undoable) and surface live in the panel.
+- Four **notes tools** — `notes_list`, `notes_read`, `notes_write`, `notes_revert` — bridge the operator console's Notes panel tabs to the agent (one agent-global notebook), gated per-tab by the operator's Agent-read/write toggles; writes are versioned (undoable) and surface live in the panel.
 
 `get_all_tools(knowledge_store, scheduler)` is the registry. When `knowledge_store` is `None` the memory tools are omitted; when `scheduler` is `None` the scheduler tools are omitted. Both backends are constructed by default in `server.py`; opt out via `middleware.knowledge: false` / `middleware.scheduler: false` in `config/langgraph-config.yaml`.
 
@@ -244,10 +244,10 @@ toggles in the panel; these tools **honor them per tab**:
 
 ```python
 @tool
-async def notes_list(project_path: str = "") -> str          # tabs + read/write flags
-async def notes_read(tab: str = "", project_path: str = "") -> str   # agent-readable tabs only
-async def notes_write(tab: str, content: str, mode: str = "append", project_path: str = "") -> str
-async def notes_revert(tab: str, steps: int = 1, project_path: str = "") -> str  # undo recent writes
+async def notes_list() -> str                                 # tabs + read/write flags
+async def notes_read(tab: str = "") -> str                    # agent-readable tabs only
+async def notes_write(tab: str, content: str, mode: str = "append") -> str
+async def notes_revert(tab: str, steps: int = 1) -> str       # undo recent writes
 ```
 
 - `notes_read` returns only tabs with **Agent read** on (a named tab with it off
@@ -259,8 +259,10 @@ async def notes_revert(tab: str, steps: int = 1, project_path: str = "") -> str 
   panel also has an **Undo** button that does the same client-side).
 - Writes land **live** in the Notes panel (it polls + adopts newer versions
   without clobbering unsaved edits).
-- `project_path` defaults to the current project (the repo root the Notes panel
-  shows); notes live at `<project>/.automaker/notes/workspace.json`.
+- Notes are **agent-global**: one persistent, instance-scoped notebook the
+  agent and the console's Notes panel share (not per-project). It lives at
+  `$NOTES_PATH` (default `/sandbox/notes/workspace.json`, falling back to
+  `~/.protoagent/notes/workspace.json`) — the same shape as the beads store.
 
 These bridge the Notes panel's permission toggles to the agent — without them,
 "what's on my Todo tab?" never reaches the notes (the agent would only see its

--- a/operator_api/notes.py
+++ b/operator_api/notes.py
@@ -1,4 +1,13 @@
-"""Project notes workspace storage for the React operator console."""
+"""Agent-global notes workspace storage for the React operator console.
+
+One persistent, instance-scoped notes workspace the agent and the console
+share — *not* per-project. There's no ``.automaker/notes/`` inside project
+directories anymore (it was confusing to scatter the agent's notes across
+whatever directory happened to be "the project"); the agent has a single
+notebook, the same one the console's Notes panel shows. This mirrors the
+in-process ``BeadsStore`` (``beads/store.py``). The project / allowed-dirs
+list is purely the filesystem security fence, not a notes scope.
+"""
 
 from __future__ import annotations
 
@@ -6,11 +15,23 @@ import json
 import os
 import time
 import uuid
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 
-from operator_api.paths import resolve_project_path
+from paths import scope_leaf
+
+DEFAULT_NOTES_PATH = "/sandbox/notes/workspace.json"
+
+
+def _resolve_notes_path(path: str | None) -> Path:
+    """``NOTES_PATH`` env → constructor arg → default. Falls back from a
+    non-writable ``/sandbox`` to ``~/.protoagent`` for local dev, then
+    instance-scoped — the same shape as the beads + knowledge stores."""
+    raw = os.environ.get("NOTES_PATH") or path or DEFAULT_NOTES_PATH
+    p = Path(raw).expanduser()
+    if str(p).startswith("/sandbox") and not Path("/sandbox").is_dir():
+        p = Path.home() / ".protoagent" / "notes" / "workspace.json"
+    return scope_leaf(p)
 
 
 def create_default_workspace() -> dict[str, Any]:
@@ -39,31 +60,34 @@ def create_default_workspace() -> dict[str, Any]:
 
 
 class NotesService:
-    """Load/save a ProtoMaker-compatible notes workspace."""
+    """Load/save the agent's single persistent notes workspace.
 
-    def __init__(self, *, allowed_dirs: Callable[[], list[str]] | None = None):
-        self._allowed_dirs = allowed_dirs
+    Instance-scoped (one notebook per agent), not per-project. ``allowed_dirs``
+    is accepted and ignored for backward compatibility with older call sites —
+    notes no longer live inside a project directory, so there's nothing to
+    fence here.
+    """
 
-    def workspace_path(self, project_path: str) -> Path:
-        allowed = self._allowed_dirs() if self._allowed_dirs is not None else None
-        return resolve_project_path(project_path, allowed) / ".automaker" / "notes" / "workspace.json"
+    def __init__(self, *, path: str | None = None, allowed_dirs: Any = None):
+        self.path = _resolve_notes_path(path)
 
-    def load_workspace(self, project_path: str) -> dict[str, Any]:
-        path = self.workspace_path(project_path)
+    def workspace_path(self) -> Path:
+        return self.path
+
+    def load_workspace(self) -> dict[str, Any]:
         try:
-            with path.open(encoding="utf-8") as fh:
+            with self.path.open(encoding="utf-8") as fh:
                 data = json.load(fh)
             return data if isinstance(data, dict) else create_default_workspace()
         except (OSError, json.JSONDecodeError, ValueError):
             return create_default_workspace()
 
-    def save_workspace(self, project_path: str, workspace: dict[str, Any]) -> None:
+    def save_workspace(self, workspace: dict[str, Any]) -> None:
         if not isinstance(workspace, dict):
             raise ValueError("workspace must be an object")
-        path = self.workspace_path(project_path)
-        path.parent.mkdir(parents=True, exist_ok=True)
-        tmp = path.with_suffix(".json.tmp")
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self.path.with_suffix(".json.tmp")
         with tmp.open("w", encoding="utf-8") as fh:
             json.dump(workspace, fh, indent=2)
             fh.write("\n")
-        os.replace(tmp, path)
+        os.replace(tmp, self.path)

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -29,8 +29,8 @@ class SubagentBatchRequest(BaseModel):
 
 
 class NotesSaveRequest(BaseModel):
-    project_path: str
     workspace: dict[str, Any]
+    project_path: str = ""  # ignored — notes are agent-global; kept for back-compat
 
 
 class ScheduleAddRequest(BaseModel):
@@ -51,12 +51,12 @@ class InboxAddRequest(BaseModel):
 
 
 class BeadsInitRequest(BaseModel):
-    project_path: str
+    project_path: str = ""  # ignored — the beads store is agent-global
     prefix: str | None = None
 
 
 class BeadsCreateRequest(BaseModel):
-    project_path: str
+    project_path: str = ""  # ignored — the beads store is agent-global
     title: str
     type: str = "task"
     priority: int = 2
@@ -65,7 +65,7 @@ class BeadsCreateRequest(BaseModel):
 
 
 class BeadsUpdateRequest(BaseModel):
-    project_path: str
+    project_path: str = ""  # ignored — the beads store is agent-global
     title: str | None = None
     description: str | None = None
     status: str | None = None
@@ -75,7 +75,7 @@ class BeadsUpdateRequest(BaseModel):
 
 
 class BeadsCloseRequest(BaseModel):
-    project_path: str
+    project_path: str = ""  # ignored — the beads store is agent-global
     reason: str | None = None
 
 
@@ -234,9 +234,9 @@ def register_operator_routes(
             raise _http_error(exc) from exc
 
     @app.get("/api/notes/workspace")
-    async def _notes_get(project_path: str):
+    async def _notes_get():
         try:
-            workspace = await asyncio.to_thread(notes.load_workspace, project_path)
+            workspace = await asyncio.to_thread(notes.load_workspace)
             return {"workspace": workspace}
         except Exception as exc:
             raise _http_error(exc) from exc
@@ -244,13 +244,13 @@ def register_operator_routes(
     @app.post("/api/notes/workspace")
     async def _notes_save(req: NotesSaveRequest):
         try:
-            await asyncio.to_thread(notes.save_workspace, req.project_path, req.workspace)
+            await asyncio.to_thread(notes.save_workspace, req.workspace)
             return {"ok": True}
         except Exception as exc:
             raise _http_error(exc) from exc
 
     @app.get("/api/beads/status")
-    async def _beads_status(project_path: str):
+    async def _beads_status(project_path: str = ""):
         try:
             return await asyncio.to_thread(beads.status, project_path)
         except Exception as exc:
@@ -264,7 +264,7 @@ def register_operator_routes(
             raise _http_error(exc) from exc
 
     @app.get("/api/beads/issues")
-    async def _beads_list(project_path: str):
+    async def _beads_list(project_path: str = ""):
         try:
             issues = await asyncio.to_thread(beads.list, project_path)
             return {"issues": issues}
@@ -298,7 +298,7 @@ def register_operator_routes(
             raise _http_error(exc) from exc
 
     @app.delete("/api/beads/issues/{issue_id}")
-    async def _beads_delete(issue_id: str, project_path: str):
+    async def _beads_delete(issue_id: str, project_path: str = ""):
         try:
             return await asyncio.to_thread(beads.delete, project_path, issue_id)
         except Exception as exc:

--- a/tests/test_notes_tools.py
+++ b/tests/test_notes_tools.py
@@ -1,14 +1,23 @@
-"""Tests for the project-notes agent tools — per-tab read/write permission gating."""
+"""Tests for the notes agent tools — per-tab read/write permission gating.
+
+Notes are agent-global (one instance-scoped workspace, no project_path), so we
+point the module-level ``_notes`` service at a tmp workspace per test.
+"""
 
 from __future__ import annotations
 
 import pytest
 
 from operator_api.notes import NotesService
+from tools import notes_tools
 from tools.notes_tools import _MAX_NOTE_HISTORY, notes_list, notes_read, notes_revert, notes_write
 
 
-def _seed(tmp_path):
+@pytest.fixture
+def notes(tmp_path, monkeypatch):
+    """A tmp-scoped notes service wired into the tools' module global."""
+    service = NotesService(path=str(tmp_path / "notes" / "workspace.json"))
+    monkeypatch.setattr(notes_tools, "_notes", service)
     ws = {
         "version": 1,
         "workspaceVersion": 0,
@@ -21,64 +30,57 @@ def _seed(tmp_path):
                    "permissions": {"agentRead": False, "agentWrite": False}, "metadata": {}},
         },
     }
-    NotesService().save_workspace(str(tmp_path), ws)
-    return str(tmp_path)
+    service.save_workspace(ws)
+    return service
 
 
 @pytest.mark.asyncio
-async def test_list_shows_tabs_and_permission_flags(tmp_path):
-    proj = _seed(tmp_path)
-    out = await notes_list.ainvoke({"project_path": proj})
+async def test_list_shows_tabs_and_permission_flags(notes):
+    out = await notes_list.ainvoke({})
     assert "Todo [read, write]" in out
     assert "Private [no-read, no-write]" in out
 
 
 @pytest.mark.asyncio
-async def test_read_named_readable_tab(tmp_path):
-    proj = _seed(tmp_path)
-    out = await notes_read.ainvoke({"tab": "todo", "project_path": proj})  # case-insensitive
+async def test_read_named_readable_tab(notes):
+    out = await notes_read.ainvoke({"tab": "todo"})  # case-insensitive
     assert "buy milk" in out
 
 
 @pytest.mark.asyncio
-async def test_read_blocked_when_agentRead_off(tmp_path):
-    proj = _seed(tmp_path)
-    out = await notes_read.ainvoke({"tab": "Private", "project_path": proj})
+async def test_read_blocked_when_agentRead_off(notes):
+    out = await notes_read.ainvoke({"tab": "Private"})
     assert "the secret" not in out
     assert "isn't shared" in out.lower() or "agent read is off" in out.lower()
 
 
 @pytest.mark.asyncio
-async def test_read_all_excludes_non_readable(tmp_path):
-    proj = _seed(tmp_path)
-    out = await notes_read.ainvoke({"project_path": proj})
+async def test_read_all_excludes_non_readable(notes):
+    out = await notes_read.ainvoke({})
     assert "buy milk" in out
     assert "the secret" not in out
 
 
 @pytest.mark.asyncio
-async def test_write_appends_to_writable_tab(tmp_path):
-    proj = _seed(tmp_path)
-    out = await notes_write.ainvoke({"tab": "Todo", "content": "call mom", "project_path": proj})
+async def test_write_appends_to_writable_tab(notes):
+    out = await notes_write.ainvoke({"tab": "Todo", "content": "call mom"})
     assert "Updated" in out
-    reloaded = NotesService().load_workspace(proj)
+    reloaded = notes.load_workspace()
     assert reloaded["tabs"]["t1"]["content"] == "buy milk\ncall mom"
     assert reloaded["tabs"]["t1"]["metadata"]["characterCount"] == len("buy milk\ncall mom")
 
 
 @pytest.mark.asyncio
-async def test_write_blocked_when_agentWrite_off(tmp_path):
-    proj = _seed(tmp_path)
-    out = await notes_write.ainvoke({"tab": "Private", "content": "x", "project_path": proj})
+async def test_write_blocked_when_agentWrite_off(notes):
+    out = await notes_write.ainvoke({"tab": "Private", "content": "x"})
     assert "read-only" in out.lower()
     # content untouched
-    assert NotesService().load_workspace(proj)["tabs"]["t2"]["content"] == "the secret"
+    assert notes.load_workspace()["tabs"]["t2"]["content"] == "the secret"
 
 
 @pytest.mark.asyncio
-async def test_write_unknown_tab_errors(tmp_path):
-    proj = _seed(tmp_path)
-    out = await notes_write.ainvoke({"tab": "Nope", "content": "x", "project_path": proj})
+async def test_write_unknown_tab_errors(notes):
+    out = await notes_write.ainvoke({"tab": "Nope", "content": "x"})
     assert "no notes tab named" in out.lower()
 
 
@@ -86,54 +88,48 @@ async def test_write_unknown_tab_errors(tmp_path):
 
 
 @pytest.mark.asyncio
-async def test_write_records_prior_version_for_undo(tmp_path):
-    proj = _seed(tmp_path)
-    await notes_write.ainvoke({"tab": "Todo", "content": "call mom", "project_path": proj})
-    ws = NotesService().load_workspace(proj)
+async def test_write_records_prior_version_for_undo(notes):
+    await notes_write.ainvoke({"tab": "Todo", "content": "call mom"})
+    ws = notes.load_workspace()
     history = ws["tabs"]["t1"]["metadata"]["history"]
     assert history and history[-1]["content"] == "buy milk"  # pre-write snapshot
 
 
 @pytest.mark.asyncio
-async def test_history_is_capped(tmp_path):
-    proj = _seed(tmp_path)
+async def test_history_is_capped(notes):
     for i in range(_MAX_NOTE_HISTORY + 5):
-        await notes_write.ainvoke({"tab": "Todo", "content": f"item {i}", "project_path": proj})
-    ws = NotesService().load_workspace(proj)
+        await notes_write.ainvoke({"tab": "Todo", "content": f"item {i}"})
+    ws = notes.load_workspace()
     assert len(ws["tabs"]["t1"]["metadata"]["history"]) == _MAX_NOTE_HISTORY
 
 
 @pytest.mark.asyncio
-async def test_revert_restores_previous_version(tmp_path):
-    proj = _seed(tmp_path)
-    await notes_write.ainvoke({"tab": "Todo", "content": "call mom", "project_path": proj})
+async def test_revert_restores_previous_version(notes):
+    await notes_write.ainvoke({"tab": "Todo", "content": "call mom"})
     # content is now "buy milk\ncall mom"; revert → back to "buy milk"
-    out = await notes_revert.ainvoke({"tab": "Todo", "project_path": proj})
+    out = await notes_revert.ainvoke({"tab": "Todo"})
     assert "Reverted" in out
-    ws = NotesService().load_workspace(proj)
+    ws = notes.load_workspace()
     assert ws["tabs"]["t1"]["content"] == "buy milk"
     assert ws["tabs"]["t1"]["metadata"]["history"] == []  # rolled-past version dropped
 
 
 @pytest.mark.asyncio
-async def test_revert_multiple_steps(tmp_path):
-    proj = _seed(tmp_path)
-    await notes_write.ainvoke({"tab": "Todo", "content": "a", "project_path": proj})  # hist: ["buy milk"]
-    await notes_write.ainvoke({"tab": "Todo", "content": "b", "project_path": proj})  # hist: ["buy milk", "buy milk\na"]
-    out = await notes_revert.ainvoke({"tab": "Todo", "steps": 2, "project_path": proj})
+async def test_revert_multiple_steps(notes):
+    await notes_write.ainvoke({"tab": "Todo", "content": "a"})  # hist: ["buy milk"]
+    await notes_write.ainvoke({"tab": "Todo", "content": "b"})  # hist: ["buy milk", "buy milk\na"]
+    out = await notes_revert.ainvoke({"tab": "Todo", "steps": 2})
     assert "2 version" in out
-    assert NotesService().load_workspace(proj)["tabs"]["t1"]["content"] == "buy milk"
+    assert notes.load_workspace()["tabs"]["t1"]["content"] == "buy milk"
 
 
 @pytest.mark.asyncio
-async def test_revert_with_no_history(tmp_path):
-    proj = _seed(tmp_path)
-    out = await notes_revert.ainvoke({"tab": "Todo", "project_path": proj})
+async def test_revert_with_no_history(notes):
+    out = await notes_revert.ainvoke({"tab": "Todo"})
     assert "No earlier version" in out
 
 
 @pytest.mark.asyncio
-async def test_revert_blocked_when_agentWrite_off(tmp_path):
-    proj = _seed(tmp_path)
-    out = await notes_revert.ainvoke({"tab": "Private", "project_path": proj})
+async def test_revert_blocked_when_agentWrite_off(notes):
+    out = await notes_revert.ainvoke({"tab": "Private"})
     assert "read-only" in out.lower()

--- a/tests/test_operator_api_notes.py
+++ b/tests/test_operator_api_notes.py
@@ -3,8 +3,8 @@ from __future__ import annotations
 from operator_api.notes import NotesService
 
 
-def test_notes_service_returns_default_workspace_for_new_project(tmp_path) -> None:
-    workspace = NotesService().load_workspace(str(tmp_path))
+def test_notes_service_returns_default_workspace_when_empty(tmp_path) -> None:
+    workspace = NotesService(path=str(tmp_path / "workspace.json")).load_workspace()
 
     assert workspace["version"] == 1
     assert workspace["activeTabId"] in workspace["tabs"]
@@ -12,7 +12,8 @@ def test_notes_service_returns_default_workspace_for_new_project(tmp_path) -> No
 
 
 def test_notes_service_saves_and_loads_workspace(tmp_path) -> None:
-    service = NotesService()
+    # Agent-global notebook: one instance-scoped workspace, no project_path.
+    service = NotesService(path=str(tmp_path / "notes" / "workspace.json"))
     workspace = {
         "version": 1,
         "workspaceVersion": 2,
@@ -29,7 +30,7 @@ def test_notes_service_saves_and_loads_workspace(tmp_path) -> None:
         },
     }
 
-    service.save_workspace(str(tmp_path), workspace)
+    service.save_workspace(workspace)
 
-    assert service.load_workspace(str(tmp_path)) == workspace
-    assert service.workspace_path(str(tmp_path)).exists()
+    assert service.load_workspace() == workspace
+    assert service.workspace_path().exists()

--- a/tests/test_operator_api_paths.py
+++ b/tests/test_operator_api_paths.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import pytest
 
-from operator_api.notes import NotesService
 from operator_api.paths import resolve_project_path
 
 
@@ -77,19 +76,3 @@ def test_symlink_cannot_escape_allowed_root(tmp_path) -> None:
     # resolve() follows it before the containment check, so it's rejected.
     with pytest.raises(ValueError, match="outside the allowed"):
         resolve_project_path(str(link), [str(allowed)])
-
-
-def test_notes_service_enforces_allowlist(tmp_path) -> None:
-    allowed = tmp_path / "allowed"
-    other = tmp_path / "other"
-    allowed.mkdir()
-    other.mkdir()
-    service = NotesService(allowed_dirs=lambda: [str(allowed)])
-
-    # in-allowlist project saves/loads fine
-    service.save_workspace(str(allowed), {"version": 1})
-    assert service.load_workspace(str(allowed)) == {"version": 1}
-
-    # out-of-allowlist project is blocked before touching disk
-    with pytest.raises(ValueError, match="outside the allowed"):
-        service.workspace_path(str(other))

--- a/tests/test_operator_api_routes.py
+++ b/tests/test_operator_api_routes.py
@@ -10,11 +10,11 @@ class _Notes:
     def __init__(self) -> None:
         self.saved = None
 
-    def load_workspace(self, project_path: str):
-        return {"project_path": project_path}
+    def load_workspace(self):
+        return {"loaded": True}
 
-    def save_workspace(self, project_path: str, workspace):
-        self.saved = (project_path, workspace)
+    def save_workspace(self, workspace):
+        self.saved = workspace
 
 
 class _Beads:
@@ -81,17 +81,13 @@ def test_operator_routes_return_expected_shapes(tmp_path) -> None:
     )
     assert batch.json()["output"] == "batch:2"
 
-    notes_path = str(tmp_path)
-    assert client.get("/api/notes/workspace", params={"project_path": notes_path}).json() == {
-        "workspace": {"project_path": notes_path},
-    }
-    save = client.post(
-        "/api/notes/workspace",
-        json={"project_path": notes_path, "workspace": {"tabs": {}}},
-    )
+    # Notes are agent-global — no project_path in the request or response.
+    assert client.get("/api/notes/workspace").json() == {"workspace": {"loaded": True}}
+    save = client.post("/api/notes/workspace", json={"workspace": {"tabs": {}}})
     assert save.json() == {"ok": True}
-    assert notes.saved == (notes_path, {"tabs": {}})
+    assert notes.saved == {"tabs": {}}
 
+    notes_path = str(tmp_path)
     assert client.get("/api/beads/status", params={"project_path": notes_path}).json() == {
         "initialized": True,
         "project_path": notes_path,

--- a/tools/notes_tools.py
+++ b/tools/notes_tools.py
@@ -1,21 +1,18 @@
-"""Project-notes tools — let the agent read/write the operator console's Notes
-panel tabs, respecting each tab's per-tab ``agentRead`` / ``agentWrite``
-permission toggles.
+"""Notes tools — let the agent read/write the operator console's Notes panel
+tabs, respecting each tab's per-tab ``agentRead`` / ``agentWrite`` permission
+toggles.
 
-The Notes panel persists a workspace at ``<project>/.automaker/notes/workspace.json``
-(see ``operator_api/notes.py``). Each tab carries
-``permissions: {agentRead, agentWrite}`` — the operator decides which tabs the
-agent may see or edit. These tools are the bridge that makes those toggles
-mean something; without them the agent can't see the operator's notes at all
-(it would otherwise confuse them with its private ``memory_*`` store).
-
-The project defaults to the server's working directory (the repo root the Notes
-panel shows by default); pass ``project_path`` to target another project.
+The Notes panel persists a single, agent-global workspace (see
+``operator_api/notes.py``) — one notebook the agent and the console share, not
+a per-project file. Each tab carries ``permissions: {agentRead, agentWrite}`` —
+the operator decides which tabs the agent may see or edit. These tools are the
+bridge that makes those toggles mean something; without them the agent can't
+see the operator's notes at all (it would otherwise confuse them with its
+private ``memory_*`` store).
 """
 
 from __future__ import annotations
 
-import os
 import time
 
 from langchain_core.tools import tool
@@ -23,10 +20,6 @@ from langchain_core.tools import tool
 from operator_api.notes import NotesService
 
 _notes = NotesService()
-
-
-def _project(project_path: str) -> str:
-    return project_path.strip() or os.getcwd()
 
 
 def _find_tab(workspace: dict, name: str):
@@ -39,20 +32,16 @@ def _find_tab(workspace: dict, name: str):
 
 
 @tool
-async def notes_list(project_path: str = "") -> str:
+async def notes_list() -> str:
     """List the operator's Notes panel tabs and which ones the agent may
     read/write. Use this to discover the operator's notes (e.g. a "Todo" tab)
     before reading them. These are the human-curated notes in the console's
     Notes panel — distinct from your private ``memory_*`` store.
-
-    Args:
-        project_path: Project whose notes to list. Defaults to the current
-            project (the repo root shown in the Notes panel).
     """
-    ws = _notes.load_workspace(_project(project_path))
+    ws = _notes.load_workspace()
     tabs = ws.get("tabs") or {}
     if not tabs:
-        return "No notes tabs exist for this project."
+        return "No notes tabs exist yet."
     order = ws.get("tabOrder") or list(tabs.keys())
     lines = [f"{len(tabs)} notes tab(s):"]
     for tid in order:
@@ -69,7 +58,7 @@ async def notes_list(project_path: str = "") -> str:
 
 
 @tool
-async def notes_read(tab: str = "", project_path: str = "") -> str:
+async def notes_read(tab: str = "") -> str:
     """Read the operator's Notes panel tab content (only tabs the operator has
     marked agent-readable). Use this when the operator asks what's in their
     notes / a specific tab (e.g. "what's on my Todo tab?").
@@ -77,9 +66,8 @@ async def notes_read(tab: str = "", project_path: str = "") -> str:
     Args:
         tab: Tab name to read (case-insensitive). Leave blank to read every
             agent-readable tab.
-        project_path: Project whose notes to read. Defaults to the current project.
     """
-    ws = _notes.load_workspace(_project(project_path))
+    ws = _notes.load_workspace()
     tabs = ws.get("tabs") or {}
 
     if tab.strip():
@@ -104,7 +92,7 @@ async def notes_read(tab: str = "", project_path: str = "") -> str:
 
 
 @tool
-async def notes_write(tab: str, content: str, mode: str = "append", project_path: str = "") -> str:
+async def notes_write(tab: str, content: str, mode: str = "append") -> str:
     """Write to an operator Notes panel tab (only tabs the operator has marked
     agent-writable). Use this to record something into the operator's notes
     (e.g. add an item to their Todo tab).
@@ -113,10 +101,8 @@ async def notes_write(tab: str, content: str, mode: str = "append", project_path
         tab: Tab name to write (case-insensitive). Must already exist.
         content: Text to write.
         mode: "append" (default — add to the end on a new line) or "replace".
-        project_path: Project whose notes to write. Defaults to the current project.
     """
-    proj = _project(project_path)
-    ws = _notes.load_workspace(proj)
+    ws = _notes.load_workspace()
     tid, found = _find_tab(ws, tab)
     if found is None:
         return f"No notes tab named {tab!r}. Use notes_list to see available tabs."
@@ -138,14 +124,14 @@ async def notes_write(tab: str, content: str, mode: str = "append", project_path
     ws["workspaceVersion"] = int(ws.get("workspaceVersion", 0)) + 1
 
     try:
-        _notes.save_workspace(proj, ws)
+        _notes.save_workspace(ws)
     except Exception as e:  # noqa: BLE001 — surface a readable tool error
         return f"Error: could not save notes: {e}"
     return f"Updated the {found.get('name')!r} tab ({mode}). It now has {len(new_content)} chars."
 
 
 @tool
-async def notes_revert(tab: str, steps: int = 1, project_path: str = "") -> str:
+async def notes_revert(tab: str, steps: int = 1) -> str:
     """Undo recent writes to a Notes tab, restoring an earlier version.
 
     Use when asked to undo/revert a change to a tab. Reverts ``steps`` versions
@@ -154,10 +140,8 @@ async def notes_revert(tab: str, steps: int = 1, project_path: str = "") -> str:
     Args:
         tab: Tab name (case-insensitive).
         steps: How many versions to roll back (default 1).
-        project_path: Project whose notes to revert. Defaults to the current project.
     """
-    proj = _project(project_path)
-    ws = _notes.load_workspace(proj)
+    ws = _notes.load_workspace()
     _tid, found = _find_tab(ws, tab)
     if found is None:
         return f"No notes tab named {tab!r}. Use notes_list to see available tabs."
@@ -179,7 +163,7 @@ async def notes_revert(tab: str, steps: int = 1, project_path: str = "") -> str:
     ws["workspaceVersion"] = int(ws.get("workspaceVersion", 0)) + 1
 
     try:
-        _notes.save_workspace(proj, ws)
+        _notes.save_workspace(ws)
     except Exception as e:  # noqa: BLE001
         return f"Error: could not save notes: {e}"
     return f"Reverted the {found.get('name')!r} tab {steps} version(s) back ({len(restored)} chars)."


### PR DESCRIPTION
## What

Makes the agent's **Notes** agent-global — one persistent, instance-scoped store the agent's `notes_*` tools and the console Notes panel share — exactly like the in-process Beads store already is. Drops the per-project model (no more `.automaker/notes/workspace.json` scattered under each "project") and removes the right-panel project selector.

This is the first of two PRs reshaping the console so the agent has its **own persistent Notes + Beads + Goals** in the right sidebar, with the project/allowed-dirs list serving purely as the filesystem security fence. (PR 2 moves Goals into the sidebar.)

## Why

Scattering the agent's notebook across whatever directory was "the project" was confusing — the notebook silently changed with the selector. The agent should have one notebook. Beads already worked this way (Sprint B); this brings notes in line.

## Changes

- **`NotesService`** → instance-scoped single workspace at `$NOTES_PATH` (default `/sandbox/notes/workspace.json`, `~/.protoagent` fallback, `scope_leaf`). No `project_path`.
- **`notes_*` agent tools** drop the `project_path` argument.
- **Notes/Beads HTTP routes**: `project_path` is now optional and ignored (back-compat for any external caller).
- **Console**: removes the right-panel project selector bar; notes/beads load globally; a small refresh button replaces it. `projectPath` is kept only as the fs working dir the setup wizard folds into `operator.allowed_dirs`.
- **`operator.allowed_dirs`** is now documented as purely the filesystem fence for file/shell tools, decoupled from notes/beads.

## Verification

- Backend: full suite green (946 passed). Notes/routes/paths tests updated for the global signature; the obsolete notes-allowlist test removed.
- Web: `tsc --noEmit` + `vite build` clean.
- Docs: VitePress build clean; `starter-tools`, `react-tauri-ui`, env-vars + CHANGELOG updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)