### PR TITLE
feat(console): move Goals into the right sidebar (Notes · Beads · Goals)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Goals moved into the right sidebar (Notes · Beads · Goals).** Goals were a
+  Studio tab; in practice a goal is *agent state* the operator watches and
+  clears, like the notebook and task board — so it now sits with the agent's
+  persistent working memory in the right panel (set with `/goal` in chat, as
+  before). Studio is now **Workflows · Run**. The right panel also dropped its
+  per-project selector + manual refresh button (notes/beads/goals are
+  agent-global and self-refresh). See [ADR 0009](docs/adr/0009-studio-control-stack.md).
 - **Notes are now agent-global, like beads.** The notes workspace is a single
   persistent, instance-scoped store (`$NOTES_PATH`, default
   `/sandbox/notes/workspace.json`) that the `notes_*` tools and the console

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -16,7 +16,10 @@ async function openSub(page, group: string, tab: string) {
 }
 
 test("Studio → Run lists the registered subagent (single/batch)", async ({ page }) => {
-  await openSub(page, "Studio", "Run");
+  // Studio now lands on Workflows (Goals moved to the sidebar), whose surface
+  // has its own "Run" button — scope to the sub-nav to pick the tab.
+  await page.getByRole("button", { name: "Studio", exact: true }).click();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Run", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Run", exact: true })).toBeVisible();
   // The kicker reflects the mocked subagent list; the Single/Batch toggle is here.
   await expect(page.getByText(/1 subagent type/)).toBeVisible();
@@ -29,8 +32,9 @@ test("schedule moved to Activity → Schedule lists scheduled jobs", async ({ pa
   await expect(page.getByText("Summarize overnight activity")).toBeVisible();
 });
 
-test("goals surface lists active goals", async ({ page }) => {
-  await openSub(page, "Studio", "Goals");
+test("goals tab in the right sidebar lists active goals", async ({ page }) => {
+  // Goals moved out of Studio into the right sidebar (Notes / Beads / Goals).
+  await page.getByRole("button", { name: "Goals", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Goals" })).toBeVisible();
   await expect(page.getByText("All tests pass")).toBeVisible();
 });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -52,12 +52,14 @@ import { SetupWizard } from "../setup/SetupWizard";
 type Surface = "chat" | "activity" | "studio" | "knowledge" | "system";
 // Studio = the "make the agent do work" surface, ordered by altitude
 // (ADR 0009): goals (autonomy) → workflows (orchestration) → run (execution).
-type StudioTab = "goals" | "workflows" | "run";
+type StudioTab = "workflows" | "run";
 type SystemTab = "runtime" | "telemetry" | "settings";
 // Activity = the "triggers / events" surface (ADR 0009): what happened (thread),
 // inbound (inbox), and timed (schedule — cron is a trigger, not a work-type).
 type ActivityTab = "thread" | "inbox" | "schedule";
-type RightPanel = "notes" | "beads";
+// The agent's persistent working memory, grouped in the right sidebar:
+// its notebook, its task board, and its goals.
+type RightPanel = "notes" | "beads" | "goals";
 type SubagentMode = "single" | "batch";
 type StatusTone = "success" | "warning" | "error" | "muted";
 
@@ -233,7 +235,7 @@ function groupIssues(issues: BeadsIssue[]) {
 
 export function App() {
   const [surface, setSurface] = useState<Surface>("chat");
-  const [studioTab, setStudioTab] = useState<StudioTab>("goals");
+  const [studioTab, setStudioTab] = useState<StudioTab>("workflows");
   const [systemTab, setSystemTab] = useState<SystemTab>("runtime");
   const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
@@ -458,8 +460,18 @@ export function App() {
 
   useEffect(() => {
     if (surface === "activity" && activityTab === "schedule") void refreshSchedules();
-    if (surface === "studio" && studioTab === "goals") void refreshGoals();
-  }, [surface, studioTab, activityTab]);
+  }, [surface, activityTab]);
+
+  // Goals live in the right sidebar (the agent's working memory). Refresh on
+  // open and poll while visible — the agent advances/clears goals mid-turn.
+  useEffect(() => {
+    if (rightPanel !== "goals") return;
+    void refreshGoals();
+    const handle = window.setInterval(() => {
+      if (!goalsBusy) void refreshGoals();
+    }, 5000);
+    return () => window.clearInterval(handle);
+  }, [rightPanel]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Open the server→client event stream (ADR 0003) and track its connection
   // state for the "live" indicator. Surfaces subscribe to named events.
@@ -544,19 +556,6 @@ export function App() {
     setBatchTasks((tasks) => (tasks.length > 1 ? tasks.filter((task) => task.id !== id) : tasks));
   }
 
-  async function loadProject() {
-    setNotesBusy(true);
-    setBeadsBusy(true);
-    setError("");
-    try {
-      await refreshProjectState();
-    } catch (exc) {
-      setError(exc instanceof Error ? exc.message : String(exc));
-    } finally {
-      setNotesBusy(false);
-      setBeadsBusy(false);
-    }
-  }
 
   function updateWorkspace(nextWorkspace: NotesWorkspace) {
     setWorkspace(nextWorkspace);
@@ -955,11 +954,9 @@ export function App() {
             </div>
           ) : null}
           {surface === "studio" ? (
-            // Ordered by altitude (ADR 0009): outcome → recipe → worker.
+            // Orchestration → execution (ADR 0009). Goals (the autonomy layer)
+            // moved to the right sidebar alongside the agent's notes + beads.
             <div className="stage-subnav">
-              <button className={studioTab === "goals" ? "active" : ""} onClick={() => setStudioTab("goals")}>
-                <Target size={15} /> Goals
-              </button>
               <button className={studioTab === "workflows" ? "active" : ""} onClick={() => setStudioTab("workflows")}>
                 <Workflow size={15} /> Workflows
               </button>
@@ -1193,67 +1190,6 @@ export function App() {
             </section>
           ) : null}
 
-          {surface === "studio" && studioTab === "goals" ? (
-            <section className="panel stage-panel">
-              <div className="panel-header">
-                <div>
-                  <h1>Goals</h1>
-                  <p className="panel-kicker">{goalsList.length} goal{goalsList.length === 1 ? "" : "s"}</p>
-                </div>
-                <button className="icon-button" type="button" onClick={() => void refreshGoals()} title="Refresh">
-                  {goalsBusy ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
-                </button>
-              </div>
-              <div className="stage-body">
-                <div className="subagent-list">
-                  {goalsList.length ? (
-                    goalsList.map((goal) => (
-                      <div className="subagent-row" key={goal.session_id}>
-                        <div>
-                          <strong>{goal.condition || goal.session_id}</strong>
-                          <span>
-                            {goal.session_id} · {goal.verifier?.type || "llm"} · iter {goal.iteration ?? 0}/{goal.max_iterations ?? 0}
-                            {goal.last_reason ? ` · ${goal.last_reason.length > 70 ? `${goal.last_reason.slice(0, 70)}…` : goal.last_reason}` : ""}
-                          </span>
-                        </div>
-                        <div style={{ display: "flex", gap: 8, alignItems: "center" }}>
-                          <StatusPill
-                            label={goal.status}
-                            tone={
-                              goal.status === "achieved"
-                                ? "success"
-                                : goal.status === "active"
-                                  ? "warning"
-                                  : goal.status === "unachievable"
-                                    ? "error"
-                                    : "muted"
-                            }
-                          />
-                          <button
-                            className="icon-button"
-                            type="button"
-                            onClick={() => void clearGoal(goal.session_id)}
-                            disabled={goalsBusy}
-                            title="Clear goal"
-                          >
-                            <Trash2 size={16} />
-                          </button>
-                        </div>
-                      </div>
-                    ))
-                  ) : (
-                    <div className="subagent-row">
-                      <div>
-                        <strong>No goals</strong>
-                        <span>set one in chat with <code>/goal …</code></span>
-                      </div>
-                    </div>
-                  )}
-                </div>
-              </div>
-            </section>
-          ) : null}
-
           {surface === "system" && systemTab === "runtime" ? (
             <section className="panel stage-panel">
               <div className="panel-header">
@@ -1365,25 +1301,18 @@ export function App() {
               data-testid="right-resize"
             />
           ) : null}
-          <div className="right-panel-nav">
-            <div className="segmented">
-              <button type="button" className={rightPanel === "notes" ? "active" : ""} onClick={() => setRightPanel("notes")}>
-                <FileText size={15} />
-                Notes
-              </button>
-              <button type="button" className={rightPanel === "beads" ? "active" : ""} onClick={() => setRightPanel("beads")}>
-                <Boxes size={15} />
-                Beads
-              </button>
-            </div>
-            <button
-              className="icon-button"
-              type="button"
-              onClick={() => void loadProject()}
-              disabled={notesBusy || beadsBusy}
-              title="Refresh notes & beads"
-            >
-              {notesBusy || beadsBusy ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
+          <div className="segmented">
+            <button type="button" className={rightPanel === "notes" ? "active" : ""} onClick={() => setRightPanel("notes")}>
+              <FileText size={15} />
+              Notes
+            </button>
+            <button type="button" className={rightPanel === "beads" ? "active" : ""} onClick={() => setRightPanel("beads")}>
+              <Boxes size={15} />
+              Beads
+            </button>
+            <button type="button" className={rightPanel === "goals" ? "active" : ""} onClick={() => setRightPanel("goals")}>
+              <Target size={15} />
+              Goals
             </button>
           </div>
 
@@ -1637,6 +1566,60 @@ export function App() {
                       </section>
                     );
                   })
+                )}
+              </ScrollArea>
+            </section>
+          ) : null}
+
+          {rightPanel === "goals" ? (
+            <section className="panel side-panel goals-panel">
+              <div className="panel-header compact">
+                <div>
+                  <h2>Goals</h2>
+                  <p className="panel-kicker">
+                    {goalsList.length} goal{goalsList.length === 1 ? "" : "s"} · set with <code>/goal</code> in chat
+                  </p>
+                </div>
+              </div>
+              <ScrollArea className="goals-list" ariaLabel="Goals">
+                {goalsList.length ? (
+                  goalsList.map((goal) => (
+                    <div className="goal-row" key={goal.session_id}>
+                      <div className="goal-row-head">
+                        <strong>{goal.condition || goal.session_id}</strong>
+                        <StatusPill
+                          label={goal.status}
+                          tone={
+                            goal.status === "achieved"
+                              ? "success"
+                              : goal.status === "active"
+                                ? "warning"
+                                : goal.status === "unachievable"
+                                  ? "error"
+                                  : "muted"
+                          }
+                        />
+                      </div>
+                      <span className="goal-row-meta">
+                        {goal.session_id} · {goal.verifier?.type || "llm"} · iter {goal.iteration ?? 0}/{goal.max_iterations ?? 0}
+                        {goal.last_reason ? ` · ${goal.last_reason.length > 80 ? `${goal.last_reason.slice(0, 80)}…` : goal.last_reason}` : ""}
+                      </span>
+                      <button
+                        className="icon-button goal-row-clear"
+                        type="button"
+                        onClick={() => void clearGoal(goal.session_id)}
+                        disabled={goalsBusy}
+                        title="Clear goal"
+                      >
+                        <Trash2 size={15} />
+                      </button>
+                    </div>
+                  ))
+                ) : (
+                  <div className="goal-row empty">
+                    <strong>No goals</strong>
+                    <span className="goal-row-meta">set one in chat with <code>/goal …</code></span>
+                  </div>
                 )}
               </ScrollArea>
             </section>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1866,16 +1866,10 @@ textarea {
   font-size: 13px;
 }
 
-/* Right-panel tab row: the Notes/Beads segmented control + a refresh button.
-   (The per-project selector was removed — notes/beads are agent-global; the
-   project/allowed-dirs list is purely the filesystem fence.) */
-.right-panel-nav {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 8px;
-  align-items: stretch;
-}
-
+/* The right-panel tab control (Notes / Beads / Goals — the agent's working
+   memory). The per-project selector + manual refresh were removed: notes/beads
+   are agent-global, and the project/allowed-dirs list is purely the filesystem
+   fence. */
 .segmented {
   height: 34px;
   display: grid;
@@ -1993,6 +1987,60 @@ textarea {
   display: grid;
   align-content: start;
   height: 100%;
+}
+
+/* Goals side-panel (the agent's autonomy layer, moved out of Studio). */
+.goals-list {
+  display: grid;
+  align-content: start;
+  height: 100%;
+}
+
+.goal-row {
+  position: relative;
+  display: grid;
+  gap: 4px;
+  padding: 10px 34px 10px 12px;
+  border-bottom: 1px solid var(--border);
+  min-width: 0;
+}
+
+.goal-row:last-child {
+  border-bottom: 0;
+}
+
+.goal-row.empty {
+  gap: 2px;
+}
+
+.goal-row-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-width: 0;
+}
+
+.goal-row-head strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+
+.goal-row-meta {
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  line-height: 1.45;
+  word-break: break-word;
+}
+
+.goal-row-clear {
+  position: absolute;
+  top: 8px;
+  right: 6px;
 }
 
 .issue-group {

--- a/docs/adr/0009-studio-control-stack.md
+++ b/docs/adr/0009-studio-control-stack.md
@@ -97,6 +97,12 @@ Four peer tabs → **three layered tabs + two relocations**:
 - **Studio = Goals · Workflows · Run** — `Run` carries the existing Single/Batch
   toggle (batch is a *mode*, not a tab). Order Goals → Workflows → Run
   ("outcome → recipe → worker"), with a one-line subhead per tab.
+  - **Update (2026-06-02):** **Goals subsequently moved out of Studio into the
+    right sidebar**, alongside Notes and Beads. In practice a goal is *agent
+    state* the operator watches and clears (like the notebook and task board),
+    not a work-type you author in the main stage — so it belongs with the
+    agent's persistent working memory. The altitude model below is unchanged;
+    only the autonomy layer's surface moved. Studio is now **Workflows · Run**.
 - **Schedule leaves Studio → a Triggers/System grouping.** Cron is a *trigger*
   ("when"), orthogonal to work-types and parallel to the inbox/event-bus
   triggers (ADR 0003) — not a fourth kind of work.

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -209,7 +209,7 @@ Use the Orbis slot pattern:
 
 - `stage`: main work area
 - `left-rail`: navigation
-- `right-panel`: notes/beads/details
+- `right-panel`: the agent's working memory — Notes / Beads / Goals
 - `overlay-top`: status and connection banners
 - `modal`: setup wizard, command palette
 
@@ -353,15 +353,21 @@ to do with notes/beads:
 - The runtime-status `project.allowed_dirs` field reports the fence; it does not
   relax the server-side check.
 
-## Studio & Activity surfaces (the control stack)
+## Studio, Activity & the right sidebar (the control stack)
 
-Per [ADR 0009](/adr/0009-studio-control-stack), the Studio tabs are ordered by
-altitude — **Goals** (autonomy: when to stop) → **Workflows** (orchestration: the
-order) → **Run** (execution: one focused worker, with the Single/Batch toggle).
-They're layers of one control loop, not peers. **Schedule** moved to **Activity**
+Per [ADR 0009](/adr/0009-studio-control-stack), Studio holds the
+orchestration→execution layers — **Workflows** (the order) → **Run** (one
+focused worker, with the Single/Batch toggle). **Schedule** moved to **Activity**
 (Thread · Inbox · Schedule) — cron is a *trigger* ("when"), grouped with the
 inbox/event-bus (ADR 0003), not a Studio work-type. Skills moved to the
 **Knowledge ▸ Playbooks** surface (below) — they're retrieved memory, not work.
+
+The right sidebar is the agent's **persistent working memory** — **Notes**
+(its notebook) · **Beads** (its task board) · **Goals** (its autonomy layer:
+the standing conditions it works toward, set in chat with `/goal`). Goals used
+to be a Studio tab; they're really *agent state* the operator watches and
+clears, so they sit next to notes and beads. All three are agent-global
+(one instance-scoped store each), not per-project.
 
 ## Telemetry surface
 


### PR DESCRIPTION
## What

Moves **Goals** out of the Studio tab strip and into the **right sidebar**, next to Notes and Beads — so the agent's persistent working memory (notebook · task board · goals) lives in one place. Goals are set the same way (`/goal` in chat); the sidebar lists active goals across sessions with their status and a clear button.

Second of the two PRs reshaping the console per your steer: the agent owns its Notes + Beads + Goals (all agent-global), and the project/allowed-dirs list is purely the filesystem fence. (PR 1 — agent-global notes — is #456, merged.)

## Why

A goal is really *agent state* the operator watches and clears — like the notebook and task board — not a work-type you author in the main stage. It belongs with the agent's working memory, not in Studio's orchestration→execution strip.

## Changes

- **`RightPanel`** = `notes | beads | goals` (third segmented tab, `Target` icon). New goals side-panel: status pill + meta + clear, refresh-on-open + light poll while visible.
- **Studio** is now **Workflows · Run** (default tab → Workflows); removed the Goals sub-nav button + the Studio goals panel.
- **Removed the right-panel per-project selector + manual refresh button** — a leftover from project-directory loading. Notes/beads/goals are agent-global and self-refresh, so there's nothing to manually load. Dropped the dead `loadProject` + orphaned `.right-panel-nav` CSS.

## Verification

- Web: `tsc --noEmit` + `vite build` clean.
- E2E: full Playwright suite green (38). The goals test drives the sidebar tab; the `Studio → Run` test scopes its click to the sub-nav (the Workflows surface also exposes a "Run" button now).
- Docs: VitePress build clean; `react-tauri-ui` + ADR 0009 updated; CHANGELOG.

## Follow-up (your call, separate PR)

You picked **console-wide TanStack Query + Suspense + ErrorBoundary** for loading/error UX — that's a dedicated migration (new dep, `QueryClientProvider` at the root, every surface → `useSuspenseQuery`, boundaries + fallbacks). Tracking it as the next PR; this one keeps the existing imperative pattern so the Goals move stays reviewable on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)