### PR TITLE
ci(release): drop auto-merge from prepare-release; pin release-tools v1.1.0

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -2,10 +2,12 @@ name: 'Prepare Release'
 
 # Manual, on-demand releases (workflow_dispatch only). Bumps the version in
 # pyproject.toml, rolls CHANGELOG.md [Unreleased] → the new version, opens a
-# prepare-release/vX.Y.Z branch, commits it as "chore: release vX.Y.Z",
-# auto-merges back to main once the required CI checks pass, then pushes the
-# semver tag. The tag push is what triggers release.yml — it builds the stable
-# semver Docker image, creates the GitHub release, and posts notes to Discord.
+# prepare-release/vX.Y.Z branch, and commits it as "chore: release vX.Y.Z".
+# It does NOT merge or tag — a human merges the bump PR through the normal
+# CI/review gate, then dispatches release.yml (tag vX.Y.Z) which builds the
+# stable semver Docker image, creates the GitHub release, and posts notes to
+# Discord. We do not auto-merge (fleet policy, 2026-06-02: auto-merge fires
+# on stale SHAs + breaks stacked PRs).
 #
 # Releases are deliberately NOT cut on every merge — pick the bump level and
 # run this when a batch is ready. See docs/guides/releasing.md.
@@ -94,45 +96,12 @@ jobs:
             --base main \
             --head "${BRANCH}" \
             --title "chore: release v${VERSION}" \
-            --body "Automated version bump to \`v${VERSION}\`.")
-          echo "PR: ${PR_URL}"
+            --body "Automated version bump to \`v${VERSION}\`. Review + merge through the normal CI/review gate, then dispatch release.yml (tag \`v${VERSION}\`) to tag main and cut the release.")
+          echo "Opened: ${PR_URL}"
 
-          # Merge strategy:
-          # - Try `--auto` first: the `main` ruleset requires the 3 CI checks,
-          #   so auto-merge waits for them and merges when they pass (the
-          #   release PR — pyproject.toml + CHANGELOG.md — passes all three).
-          # - Fallback to a direct squash only if `--auto` can't be enabled.
-          #   With the ruleset in place a direct merge is itself gated by the
-          #   required checks, so it either merges cleanly or fails loud (the
-          #   poll below then times out) — never a silent bypass.
-          # - `--admin` is avoided entirely; it breaks when checks are
-          #   "expected" but haven't started (protoPen PR #18 history).
-          if ! gh pr merge "${PR_URL}" --squash --auto 2>/tmp/merge-err; then
-            echo "Auto-merge not enabled (expected on repos without branch"
-            echo "protection or PRs with no pending checks):"
-            sed 's/^/  /' /tmp/merge-err
-            echo "Falling back to direct squash merge."
-            gh pr merge "${PR_URL}" --squash
-          fi
-
-          # Poll until the PR is merged (CI must pass first; timeout 10 min)
-          echo "Waiting for PR to merge…"
-          for i in $(seq 1 120); do
-            STATE=$(gh pr view "${PR_URL}" --json state -q .state)
-            if [ "$STATE" = "MERGED" ]; then
-              echo "PR merged."
-              break
-            fi
-            if [ "$i" -eq 120 ]; then
-              echo "Timeout waiting for PR to merge." && exit 1
-            fi
-            sleep 5
-          done
-
-          # Push the semver tag — this is what triggers release.yml.
-          # Tag is cut from the merged main commit (which already
-          # includes the bump), so release.yml sees the correct SHA.
-          git fetch origin main
-          git tag -a "v${VERSION}" "origin/main" -m "v${VERSION}"
-          git push origin "v${VERSION}"
-          echo "Tagged v${VERSION} → release.yml will fire"
+          # We do NOT auto-merge or tag here (fleet policy, 2026-06-02:
+          # auto-merge fires on stale SHAs + breaks stacked PRs). A human
+          # merges this bump PR through the normal CI/review gate, then
+          # dispatches release.yml with tag v${VERSION} to tag main and
+          # cut the GitHub release + Discord notes.
+          echo "Next: review + merge that PR (we do not auto-merge), then run release.yml (tag v${VERSION})."

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -139,7 +139,7 @@ jobs:
 
       - name: Generate + post release notes
         continue-on-error: true
-        uses: protoLabsAI/release-tools@v1
+        uses: protoLabsAI/release-tools@b7c3531dd67accb57ca09242f47d8c0eb1ace8eb # v1.1.0
         with:
           version: ${{ steps.version.outputs.tag }}
           previous-version: ${{ steps.version.outputs.prev_tag }}


### PR DESCRIPTION
## Fleet workflow alignment — no auto-merge + release-tools v1.1.0 pin

Aligns this repo to the fleet no-auto-merge policy (2026-06-02) and the canonical release-tools pin. Mirrors the pattern from protoLabsAI/protoWorkstacean#755.

### `prepare-release.yml` — stop auto-merging the bump PR
GitHub auto-merge fires against the SHA captured when enabled (orphaning later commits on a moving branch), fights review gates, and breaks stacked PRs. The workflow now **only opens** the version-bump PR and prints next-steps. A human merges it through the normal CI/review gate, then dispatches `release.yml` (tag `vX.Y.Z`) to tag main and cut the release. Removed the `gh pr merge --auto` call **and** the direct-squash fallback (which also bypassed the gate), along with the now-dead poll + tag-push tail.

### `release.yml` — pin release-tools to v1.1.0 (SHA)
`protoLabsAI/release-tools` is now pinned to `b7c3531dd67accb57ca09242f47d8c0eb1ace8eb # v1.1.0`. `DISCORD_RELEASE_WEBHOOK` unchanged.

Independent cleanup, safe to merge after the gate. Do **not** enable auto-merge on this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)