### PR TITLE
feat(console): TanStack Query + Suspense + ErrorBoundary foundation (ADR 0013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Console data layer: TanStack Query + Suspense + ErrorBoundary (ADR 0013).**
+  The operator console adopts `@tanstack/react-query` (suspense mode) for its
+  reads — loading is a `<Suspense>` fallback, failures are caught by a contained
+  `<ErrorBoundary>` with a Retry button, mutations invalidate query keys, and
+  live surfaces use `refetchInterval` instead of hand-rolled polls. Replaces the
+  per-surface `useEffect` + busy-flag + `try/catch → global banner` plumbing.
+  This PR lands the foundation (`QueryClient` at the app root, a reusable
+  `ErrorBoundary` + `PanelError`/`PanelSkeleton`, `lib/queries.ts`) and migrates
+  the **Goals** sidebar panel as the reference implementation. Remaining
+  surfaces (beads, studio, system, activity) follow in later PRs; **Notes stays
+  imperative** (it owns edit/undo/autosave state) but is wrapped in the boundary.
+
 ### Changed
 - **Goals moved into the right sidebar (Notes · Beads · Goals).** Goals were a
   Studio tab; in practice a goal is *agent state* the operator watches and

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,6 +11,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.100.14",
     "lucide-react": "^0.468.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -43,8 +43,10 @@ import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { onConnectionChange, onServerEvent } from "../lib/events";
-import type { BeadsIssue, GoalState, NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
+import type { BeadsIssue, NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
 import { ScrollArea } from "./ScrollArea";
+import { StatusPill, type StatusTone } from "./StatusPill";
+import { GoalsPanel } from "./GoalsPanel";
 import { SetupWizard } from "../setup/SetupWizard";
 
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
@@ -61,7 +63,6 @@ type ActivityTab = "thread" | "inbox" | "schedule";
 // its notebook, its task board, and its goals.
 type RightPanel = "notes" | "beads" | "goals";
 type SubagentMode = "single" | "batch";
-type StatusTone = "success" | "warning" | "error" | "muted";
 
 type BatchTask = {
   id: string;
@@ -282,8 +283,6 @@ export function App() {
   const [scheduleJobId, setScheduleJobId] = useState("");
   const [scheduleBusy, setScheduleBusy] = useState(false);
 
-  const [goalsList, setGoalsList] = useState<GoalState[]>([]);
-  const [goalsBusy, setGoalsBusy] = useState(false);
 
   const activeTab = workspace?.tabs[workspace.activeTabId] || null;
   const canUndoNote = Boolean(
@@ -342,28 +341,6 @@ export function App() {
       setError(exc instanceof Error ? exc.message : String(exc));
     } finally {
       setScheduleBusy(false);
-    }
-  }
-
-  async function refreshGoals() {
-    try {
-      const payload = await api.goals();
-      setGoalsList(payload.goals);
-    } catch (exc) {
-      setError(exc instanceof Error ? exc.message : String(exc));
-    }
-  }
-
-  async function clearGoal(sessionId: string) {
-    if (goalsBusy) return;
-    setGoalsBusy(true);
-    try {
-      await api.clearGoal(sessionId);
-      await refreshGoals();
-    } catch (exc) {
-      setError(exc instanceof Error ? exc.message : String(exc));
-    } finally {
-      setGoalsBusy(false);
     }
   }
 
@@ -462,16 +439,8 @@ export function App() {
     if (surface === "activity" && activityTab === "schedule") void refreshSchedules();
   }, [surface, activityTab]);
 
-  // Goals live in the right sidebar (the agent's working memory). Refresh on
-  // open and poll while visible — the agent advances/clears goals mid-turn.
-  useEffect(() => {
-    if (rightPanel !== "goals") return;
-    void refreshGoals();
-    const handle = window.setInterval(() => {
-      if (!goalsBusy) void refreshGoals();
-    }, 5000);
-    return () => window.clearInterval(handle);
-  }, [rightPanel]); // eslint-disable-line react-hooks/exhaustive-deps
+  // Goals now own their data via TanStack Query inside <GoalsPanel> (ADR 0013) —
+  // no App-level fetch/poll here.
 
   // Open the server→client event stream (ADR 0003) and track its connection
   // state for the "live" indicator. Surfaces subscribe to named events.
@@ -1571,59 +1540,7 @@ export function App() {
             </section>
           ) : null}
 
-          {rightPanel === "goals" ? (
-            <section className="panel side-panel goals-panel">
-              <div className="panel-header compact">
-                <div>
-                  <h2>Goals</h2>
-                  <p className="panel-kicker">
-                    {goalsList.length} goal{goalsList.length === 1 ? "" : "s"} · set with <code>/goal</code> in chat
-                  </p>
-                </div>
-              </div>
-              <ScrollArea className="goals-list" ariaLabel="Goals">
-                {goalsList.length ? (
-                  goalsList.map((goal) => (
-                    <div className="goal-row" key={goal.session_id}>
-                      <div className="goal-row-head">
-                        <strong>{goal.condition || goal.session_id}</strong>
-                        <StatusPill
-                          label={goal.status}
-                          tone={
-                            goal.status === "achieved"
-                              ? "success"
-                              : goal.status === "active"
-                                ? "warning"
-                                : goal.status === "unachievable"
-                                  ? "error"
-                                  : "muted"
-                          }
-                        />
-                      </div>
-                      <span className="goal-row-meta">
-                        {goal.session_id} · {goal.verifier?.type || "llm"} · iter {goal.iteration ?? 0}/{goal.max_iterations ?? 0}
-                        {goal.last_reason ? ` · ${goal.last_reason.length > 80 ? `${goal.last_reason.slice(0, 80)}…` : goal.last_reason}` : ""}
-                      </span>
-                      <button
-                        className="icon-button goal-row-clear"
-                        type="button"
-                        onClick={() => void clearGoal(goal.session_id)}
-                        disabled={goalsBusy}
-                        title="Clear goal"
-                      >
-                        <Trash2 size={15} />
-                      </button>
-                    </div>
-                  ))
-                ) : (
-                  <div className="goal-row empty">
-                    <strong>No goals</strong>
-                    <span className="goal-row-meta">set one in chat with <code>/goal …</code></span>
-                  </div>
-                )}
-              </ScrollArea>
-            </section>
-          ) : null}
+          {rightPanel === "goals" ? <GoalsPanel /> : null}
         </aside>
       </div>
 
@@ -1681,10 +1598,6 @@ export function App() {
       />
     </div>
   );
-}
-
-function StatusPill({ label, tone }: { label: string; tone: StatusTone }) {
-  return <span className={`status-pill ${tone}`}>{label}</span>;
 }
 
 function RailButton({

--- a/apps/web/src/app/ErrorBoundary.tsx
+++ b/apps/web/src/app/ErrorBoundary.tsx
@@ -1,0 +1,77 @@
+import { AlertTriangle, Loader2, RefreshCw } from "lucide-react";
+import { Component, type ReactNode } from "react";
+
+// A small render-prop error boundary (ADR 0013). Pairs with TanStack Query's
+// <QueryErrorResetBoundary> so a failed `useSuspenseQuery` surfaces a contained
+// retry card instead of crashing the app or routing through a global banner.
+// `resetKeys` clears the error when any key changes (e.g. switching tabs).
+
+type FallbackArgs = { error: Error; reset: () => void };
+
+type Props = {
+  children: ReactNode;
+  fallback: (args: FallbackArgs) => ReactNode;
+  onReset?: () => void;
+  resetKeys?: unknown[];
+};
+
+type State = { error: Error | null };
+
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidUpdate(prev: Props) {
+    // Auto-clear when a reset key changes so a stale error doesn't stick.
+    if (this.state.error && !shallowEqual(prev.resetKeys, this.props.resetKeys)) {
+      this.setState({ error: null });
+    }
+  }
+
+  reset = () => {
+    this.props.onReset?.();
+    this.setState({ error: null });
+  };
+
+  render() {
+    if (this.state.error) {
+      return this.props.fallback({ error: this.state.error, reset: this.reset });
+    }
+    return this.props.children;
+  }
+}
+
+function shallowEqual(a?: unknown[], b?: unknown[]) {
+  if (a === b) return true;
+  if (!a || !b || a.length !== b.length) return false;
+  return a.every((v, i) => Object.is(v, b[i]));
+}
+
+/** Default in-panel error card with a retry button. */
+export function PanelError({ error, reset, label = "panel" }: FallbackArgs & { label?: string }) {
+  return (
+    <div className="panel-error" role="alert">
+      <AlertTriangle size={18} />
+      <div>
+        <strong>Couldn't load the {label}</strong>
+        <span>{error.message}</span>
+      </div>
+      <button className="secondary-button" type="button" onClick={reset}>
+        <RefreshCw size={14} /> Retry
+      </button>
+    </div>
+  );
+}
+
+/** Default <Suspense> fallback for a panel that's loading. */
+export function PanelSkeleton({ label = "Loading…" }: { label?: string }) {
+  return (
+    <div className="panel-skeleton" aria-busy="true">
+      <Loader2 className="spin" size={18} />
+      <span>{label}</span>
+    </div>
+  );
+}

--- a/apps/web/src/app/GoalsPanel.tsx
+++ b/apps/web/src/app/GoalsPanel.tsx
@@ -1,0 +1,103 @@
+import {
+  QueryErrorResetBoundary,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { Trash2 } from "lucide-react";
+import { Suspense } from "react";
+
+import { api } from "../lib/api";
+import { goalsQuery, queryKeys } from "../lib/queries";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
+import { ScrollArea } from "./ScrollArea";
+import { StatusPill } from "./StatusPill";
+
+// The agent's goals (autonomy layer), in the right sidebar. First surface on
+// the TanStack Query + Suspense + ErrorBoundary data layer (ADR 0013): the read
+// is a `useSuspenseQuery` (loading → <Suspense>, failure → <ErrorBoundary>),
+// and clearing a goal is a `useMutation` that invalidates the goals query. No
+// useEffect / busy flag / try-catch / manual refresh.
+
+function goalTone(status: string) {
+  if (status === "achieved") return "success" as const;
+  if (status === "active") return "warning" as const;
+  if (status === "unachievable") return "error" as const;
+  return "muted" as const;
+}
+
+function GoalsList() {
+  const { data } = useSuspenseQuery(goalsQuery());
+  const goals = data.goals;
+  const queryClient = useQueryClient();
+  const clear = useMutation({
+    mutationFn: (sessionId: string) => api.clearGoal(sessionId),
+    onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.goals }),
+  });
+
+  if (!goals.length) {
+    return (
+      <div className="goal-row empty">
+        <strong>No goals</strong>
+        <span className="goal-row-meta">
+          set one in chat with <code>/goal …</code>
+        </span>
+      </div>
+    );
+  }
+
+  return (
+    <>
+      {goals.map((goal) => (
+        <div className="goal-row" key={goal.session_id}>
+          <div className="goal-row-head">
+            <strong>{goal.condition || goal.session_id}</strong>
+            <StatusPill label={goal.status} tone={goalTone(goal.status)} />
+          </div>
+          <span className="goal-row-meta">
+            {goal.session_id} · {goal.verifier?.type || "llm"} · iter {goal.iteration ?? 0}/
+            {goal.max_iterations ?? 0}
+            {goal.last_reason
+              ? ` · ${goal.last_reason.length > 80 ? `${goal.last_reason.slice(0, 80)}…` : goal.last_reason}`
+              : ""}
+          </span>
+          <button
+            className="icon-button goal-row-clear"
+            type="button"
+            onClick={() => clear.mutate(goal.session_id)}
+            disabled={clear.isPending}
+            title="Clear goal"
+          >
+            <Trash2 size={15} />
+          </button>
+        </div>
+      ))}
+    </>
+  );
+}
+
+export function GoalsPanel() {
+  return (
+    <section className="panel side-panel goals-panel">
+      <div className="panel-header compact">
+        <div>
+          <h2>Goals</h2>
+          <p className="panel-kicker">
+            the agent's standing goals · set with <code>/goal</code> in chat
+          </p>
+        </div>
+      </div>
+      <ScrollArea className="goals-list" ariaLabel="Goals">
+        <QueryErrorResetBoundary>
+          {({ reset }) => (
+            <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="goals" />}>
+              <Suspense fallback={<PanelSkeleton label="Loading goals…" />}>
+                <GoalsList />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
+      </ScrollArea>
+    </section>
+  );
+}

--- a/apps/web/src/app/StatusPill.tsx
+++ b/apps/web/src/app/StatusPill.tsx
@@ -1,0 +1,5 @@
+export type StatusTone = "success" | "warning" | "error" | "muted";
+
+export function StatusPill({ label, tone }: { label: string; tone: StatusTone }) {
+  return <span className={`status-pill ${tone}`}>{label}</span>;
+}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1989,6 +1989,54 @@ textarea {
   height: 100%;
 }
 
+/* Suspense + ErrorBoundary fallbacks for query-backed surfaces (ADR 0013). */
+.panel-skeleton {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  padding: 28px 16px;
+  color: var(--fg-muted);
+  font-size: 13px;
+}
+
+.panel-error {
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 8px 10px;
+  margin: 12px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: rgba(220, 60, 60, 0.06);
+}
+
+.panel-error svg:first-child {
+  color: #e0564f;
+}
+
+.panel-error > div {
+  display: grid;
+  gap: 2px;
+  min-width: 0;
+}
+
+.panel-error strong {
+  font-size: 13px;
+}
+
+.panel-error span {
+  color: var(--fg-muted);
+  font-size: 12px;
+  word-break: break-word;
+}
+
+.panel-error button {
+  grid-column: 1 / -1;
+  justify-self: start;
+}
+
 /* Goals side-panel (the agent's autonomy layer, moved out of Studio). */
 .goals-list {
   display: grid;

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -1,0 +1,20 @@
+import { queryOptions } from "@tanstack/react-query";
+
+import { api } from "./api";
+
+// Centralized query keys + option factories (ADR 0013). Surfaces read these via
+// `useSuspenseQuery(...)`; mutations invalidate the matching key. Keep keys
+// stable and hierarchical so a mutation can invalidate a whole subtree.
+export const queryKeys = {
+  goals: ["goals"] as const,
+};
+
+// Goals the agent works toward (goal mode). Lives in the right sidebar and
+// refetches every 5s while mounted — the agent advances/clears goals mid-turn,
+// so the panel should track that without a manual refresh.
+export const goalsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.goals,
+    queryFn: () => api.goals(),
+    refetchInterval: 5_000,
+  });

--- a/apps/web/src/lib/queryClient.ts
+++ b/apps/web/src/lib/queryClient.ts
@@ -1,0 +1,20 @@
+import { QueryClient } from "@tanstack/react-query";
+
+// One QueryClient for the whole console (ADR 0013). Surfaces fetch with
+// `useSuspenseQuery` so loading is a <Suspense> fallback and errors are caught
+// by an <ErrorBoundary> — replacing the per-surface useEffect + busy-flag +
+// try/catch→setError plumbing.
+//
+// Defaults: data is fresh for 5s (avoids refetch storms when surfaces remount
+// as you switch tabs), one retry on failure, and no refetch-on-focus (a local
+// operator console, not a long-lived dashboard). Individual queries opt into
+// `refetchInterval` for live surfaces (e.g. goals the agent advances mid-turn).
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 5_000,
+      retry: 1,
+      refetchOnWindowFocus: false,
+    },
+  },
+});

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,11 +1,15 @@
+import { QueryClientProvider } from "@tanstack/react-query";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./app/App";
 import "./app/theme.css";
+import { queryClient } from "./lib/queryClient";
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <App />
+    <QueryClientProvider client={queryClient}>
+      <App />
+    </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/docs/adr/0013-console-data-layer-react-query.md
+++ b/docs/adr/0013-console-data-layer-react-query.md
@@ -1,0 +1,102 @@
+# ADR 0013 — Console data layer: TanStack Query + Suspense + ErrorBoundary
+
+- **Status:** Accepted (2026-06-02) — foundation + first surface (Goals) shipped; remaining surfaces migrate in follow-up PRs
+- **Date:** 2026-06-02
+- **Deciders:** Josh Mabry; protoAgent maintainers
+- **Tags:** console, frontend, dx
+- **Supersedes / Superseded by:** —
+
+> Every surface in the React operator console fetched the same way by hand: a
+> `useEffect` that calls the API, a `busy` boolean, a `try/catch` that funnels
+> into a single global `setError` banner, and — for live data — a hand-rolled
+> `setInterval` poll. That's a lot of identical plumbing per surface, the error
+> story is one app-wide banner with no per-panel retry, and loading is ad-hoc.
+> We adopt **TanStack Query** (v5, suspense mode) as the console's data layer:
+> reads are `useSuspenseQuery`, loading is a **`<Suspense>`** fallback, failures
+> are caught by an **`<ErrorBoundary>`** with a contained retry, and mutations
+> are `useMutation` that invalidate the relevant query key. Live surfaces use
+> `refetchInterval` instead of bespoke polls.
+
+---
+
+## 1. Context & problem
+
+The console (`apps/web`) has ~10 read surfaces — runtime status, subagents,
+notes, beads, goals, schedules, workflows, telemetry, playbooks, settings,
+activity/inbox. Each independently reimplements:
+
+- **Loading**: a `*Busy` flag toggled around the fetch, rendered as a spinner.
+- **Errors**: `catch (e) { setError(...) }` → one global banner, no retry, no
+  per-panel containment (a goals fetch failure looks like a chat failure).
+- **Freshness**: surfaces that must track agent-side changes (notes the agent
+  writes, goals it advances) hand-roll a `setInterval` with their own
+  "don't refetch while busy/dirty" guards.
+- **Refetch on navigate**: a manual refresh button, or a re-fetch in an effect
+  keyed on the active tab.
+
+This is boilerplate-heavy, inconsistent, and puts all error UX in one banner.
+
+## 2. Decision
+
+Introduce **`@tanstack/react-query`** as the single data layer for console
+reads, with the canonical Suspense pattern:
+
+- A single **`QueryClient`** (`lib/queryClient.ts`) at the app root via
+  `QueryClientProvider` (`main.tsx`). Defaults: `staleTime: 5s`,
+  `retry: 1`, `refetchOnWindowFocus: false` (a local operator console, not a
+  long-lived dashboard).
+- **Reads** use `useSuspenseQuery(options)`. Loading suspends to a
+  `<Suspense fallback={<PanelSkeleton/>}>`; a thrown fetch error is caught by an
+  **`<ErrorBoundary>`** (`app/ErrorBoundary.tsx`) wired to
+  `<QueryErrorResetBoundary>` so its retry re-runs the query. The fallback is a
+  contained `<PanelError>` card with a Retry button — no global banner.
+- **Query options** live in `lib/queries.ts` (stable, hierarchical query keys +
+  `queryOptions(...)` factories), so a mutation can invalidate a whole subtree.
+- **Mutations** use `useMutation` and invalidate the matching key on settle.
+- **Live surfaces** set `refetchInterval` on the query (e.g. goals every 5s)
+  instead of a manual `setInterval`.
+
+### Not in scope / kept as-is
+
+- **Notes** stays imperative. Its panel owns local edit state (dirty tracking,
+  per-tab undo history, debounced autosave, "adopt newer server version without
+  clobbering unsaved edits") that a read-cache doesn't model. It keeps its
+  bespoke load/poll but is wrapped in the same `<ErrorBoundary>` for error
+  containment. We can revisit once the read-only surfaces are migrated.
+- **Streaming chat** (A2A SSE) is not a query; unchanged.
+
+## 3. Migration plan (slices)
+
+Console-wide, but shipped incrementally so each PR is reviewable + green:
+
+1. **Foundation + Goals** (this ADR's PR) — add the dep, `QueryClientProvider`,
+   `ErrorBoundary`/`PanelError`/`PanelSkeleton`, `lib/queries.ts`, and migrate
+   the **Goals** sidebar panel as the reference implementation (extracted to
+   `app/GoalsPanel.tsx`).
+2. **Beads** sidebar panel (status + issues reads → suspense; create/update/
+   close/delete → `useMutation`).
+3. **Studio** surfaces — subagents, workflows, run.
+4. **System** surfaces — runtime status, telemetry, settings.
+5. **Activity** — thread, inbox, schedules.
+
+Each slice deletes the surface's `useEffect`/`busy`/`try-catch`/poll and routes
+its errors through a local boundary.
+
+## 4. Consequences
+
+**Positive** — far less per-surface boilerplate; consistent, declarative
+loading + per-panel error/retry; free caching, dedup, and background refetch;
+`refetchInterval` replaces hand-rolled polls; surfaces shrink (logic moves into
+small panel components + query factories), trimming the 1600-line `App.tsx`.
+
+**Negative / costs** — a new runtime dependency on the public template
+(~`react-query`, modest bundle increase); a second rendering concept
+(Suspense/boundaries) contributors must understand; the migration spans several
+PRs during which the console mixes both patterns; notes remains the imperative
+exception.
+
+## 5. Related
+
+- [React + Tauri console](/guides/react-tauri-ui)
+- [ADR 0009 — Studio control stack](/adr/0009-studio-control-stack)
+- [ADR 0003 — Reactive agent & Activity thread](/adr/0003-reactive-agent-activity-thread) (the event stream that drives some live surfaces)

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -21,3 +21,4 @@ decision, numbered, never deleted (supersede instead).
 | [0010](./0010-headless-setup-and-ui-tiers.md) | Headless setup & UI deployment tiers (lighter stack) | Accepted |
 | [0011](./0011-deep-research-workflow.md) | Deep-research workflow with adversarial review | Accepted |
 | [0012](./0012-eval-strategy-and-model-comparison.md) | Eval strategy: model-tagged tracking & model comparison | Accepted |
+| [0013](./0013-console-data-layer-react-query.md) | Console data layer: TanStack Query + Suspense + ErrorBoundary | Accepted |

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
       "name": "@protoagent/web",
       "version": "0.1.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.100.14",
         "lucide-react": "^0.468.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
@@ -1583,6 +1584,32 @@
       "integrity": "sha512-83yeghZ2xxin3Nj8z1NMd/NCuca+gsYXswywDy5bHvwlWL8tpTQmzGeUuHd9FC3E/SBEMvzJRwWEOz5gGes9Qg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.100.14.tgz",
+      "integrity": "sha512-5X41dGpxgeaHISCRW2oYwcSycZeULZzAunaudXT9ov1KOTj9xwt0CH6hbwqP1/z74ZWF7rYFnDpyYH07XFcZew==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.100.14",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.100.14.tgz",
+      "integrity": "sha512-oOr6aRdSFEwWhzxEkD/9ZcItM3+LjBSkeVmadWKwUssAHTsqd/7bOjWrX4AbvEkoEhgAxzN0Xk6H/aYzXiYBAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.100.14"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
+      }
     },
     "node_modules/@tauri-apps/cli": {
       "version": "2.11.2",


### PR DESCRIPTION
## What

Adopts **TanStack Query** (v5, suspense mode) as the operator console's data layer — the migration you chose. Lands the **foundation** + the **first migrated surface (Goals)** as the reference implementation. Per [ADR 0013](docs/adr/0013-console-data-layer-react-query.md).

## Why

Every surface fetched the same way by hand: `useEffect` + a `busy` flag + `try/catch → one global error banner`, plus hand-rolled `setInterval` polls for live data. That's a lot of identical plumbing, the error story is a single app-wide banner with no per-panel retry, and loading is ad-hoc. The query layer makes reads declarative: loading is a `<Suspense>` fallback, failures are caught by a contained `<ErrorBoundary>` with Retry, mutations invalidate query keys, and live surfaces use `refetchInterval`.

## This PR (foundation + Goals)

- **`QueryClient`** at the app root — `QueryClientProvider` in `main.tsx`; defaults in `lib/queryClient.ts` (`staleTime 5s`, `retry 1`, no refetch-on-focus).
- **`ErrorBoundary`** (`app/ErrorBoundary.tsx`) wired to `<QueryErrorResetBoundary>`, with reusable `PanelError` (retry card) + `PanelSkeleton` (loading) fallbacks.
- **`lib/queries.ts`** — query keys + `queryOptions` factories.
- **Goals** sidebar panel extracted to `app/GoalsPanel.tsx`: `useSuspenseQuery(goals, { refetchInterval: 5s })` + `useMutation(clearGoal)` → invalidate. Drops its App-level state, handler, and poll effect. `StatusPill` extracted to its own module so the panel can share it.

## Scope / what's deferred

- **Console-wide** is the target, shipped in slices (ADR §3): **beads → studio → system → activity** follow in later PRs, each deleting that surface's effect/busy/try-catch/poll.
- **Notes stays imperative** — it owns local edit state (dirty tracking, per-tab undo, debounced autosave, "adopt newer server version without clobbering edits") that a read-cache doesn't model. It'll be wrapped in the boundary for error containment.

## Verification

- `tsc --noEmit` + `vite build` clean; bundle grows ~43 kB gzipped (react-query) as expected.
- Full Playwright E2E suite green (38) — the Goals tab now renders through the Suspense/query path.
- VitePress docs build clean; ADR 0013 + index + CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)