### PR TITLE
docs(adr): A2A 0.3 → 1.0 migration plan (ADR 0014, #443)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **ADR 0014 — A2A 0.3 → 1.0 migration plan.** Records the protoAgent-local plan
+  to replace the ~2,083-LOC hand-rolled `a2a_handler.py` with the official
+  `a2a-sdk` (`AgentExecutor`) + a shared `protolabs-a2a` conventions layer
+  (inherited from protoWorkstacean ADR-0006; tracked by #443). Plan-only — a
+  surface-to-1.0 map + sliced checklist; execution is blocked (the
+  `protolabs-a2a` package doesn't exist yet) and is a flag-day cutover, so no
+  code lands until those clear.
 - **Console data layer: TanStack Query + Suspense + ErrorBoundary (ADR 0013).**
   The operator console adopts `@tanstack/react-query` (suspense mode) for its
   reads — loading is a `<Suspense>` fallback, failures are caught by a contained

--- a/docs/adr/0014-a2a-1.0-migration.md
+++ b/docs/adr/0014-a2a-1.0-migration.md
@@ -1,0 +1,114 @@
+# ADR 0014 — A2A 0.3 → 1.0: adopt `a2a-sdk` + `protolabs-a2a`
+
+- **Status:** Accepted (upstream) — **execution not started; blocked.** The decision is inherited from protoWorkstacean **ADR-0006**; this ADR is the protoAgent-local plan + checklist. Tracked by [#443](https://github.com/protoLabsAI/protoAgent/issues/443).
+- **Date:** 2026-06-02
+- **Deciders:** Josh Mabry; protoAgent maintainers
+- **Tags:** a2a, protocol, migration, fleet
+- **Supersedes / Superseded by:** —
+
+> protoAgent speaks A2A through a **~2,083-LOC hand-rolled handler**
+> (`a2a_handler.py`) implementing 0.3-era shapes. The fleet is moving to **A2A
+> 1.0**, and the canonical strategy (protoWorkstacean ADR-0006) is *adopt the
+> official SDK, delete the hand-rolled handler, add a thin shared conventions
+> layer* — **`a2a-sdk`** (Python canon) + **`protolabs-a2a`** (the fleet's
+> extensions / card defaults / auth scheme). protoAgent is the **template**, so
+> it migrates first and proves the vertical slice; **roxy forked this handler
+> and inherits the migration**, so getting protoAgent right unblocks roxy
+> cheaply. This ADR records the plan; **no code lands until the blockers below
+> clear**, and then only on an **undeployed** branch for a coordinated cutover.
+
+---
+
+## 1. Why not just patch the handler
+
+0.3 → 1.0 is a wire-shape break, not a tweak:
+
+- **Terminal-by-state** — `final` is removed; terminality is derived from
+  `TASK_STATE_*`. Our handler threads a `final` flag through `_build_status_event`.
+- **Member-discriminated Parts** + `ROLE_*` / `TASK_STATE_*` enums.
+- **Agent card** — served at `/.well-known/agent-card.json` (we serve
+  `agent.json`), with `supportedInterfaces[]` and declared
+  `capabilities.extensions[]`.
+- **Custom DataParts** — discriminator moves to `metadata.mimeType`
+  `https://proto-labs.ai/a2a/ext/<ext>` with the payload in `content.value`. We
+  currently key them as `application/vnd.protolabs.<ext>+json` (see the MIME
+  constants in `a2a_handler.py`).
+
+Re-implementing protocol mechanics by hand again is exactly what ADR-0006 says
+**not** to do. Adopt `a2a-sdk` (`AgentExecutor.execute/cancel`,
+`DefaultRequestHandler`, `A2AStarletteApplication`) and put the *protolabs*
+specifics (extensions, card defaults, auth) in `protolabs-a2a`.
+
+## 2. Blockers (why this is plan-only today)
+
+1. **`protoLabsAI/protolabs-a2a` does not exist yet.** The shared Python layer
+   this migration depends on hasn't been created. And #443 notes protoAgent's
+   extensions *define the shape* of that layer — so it likely has to be authored
+   (bootstrapped from protoAgent's extension payloads). Chicken-and-egg.
+2. **Flag-day — no 0.3↔1.0 interop.** Per #443: land on a **ready branch,
+   undeployed**; it ships in one coordinated cutover with the hub
+   (protoWorkstacean) + the other agents. So this is **not** a normal
+   merge-to-`main` PR.
+3. **Canonical wire contract lives in protoWorkstacean ADR-0006**, which isn't
+   in this repo. The implementer needs it (and the hub's reference impl on
+   `feature/a2a-1.0-alpha-spike`) open while porting.
+
+## 3. What we have today (the surface to replace)
+
+All in `a2a_handler.py` unless noted; `server.py::register_a2a_routes(...)` wires it:
+
+| Concern | Today (hand-rolled) | 1.0 target |
+|---|---|---|
+| Routing / JSON-RPC dispatch | manual `message/send`, `message/stream`, `tasks/*` | `a2a-sdk` `DefaultRequestHandler` + `A2AStarletteApplication` |
+| Turn execution | `_run_task_background` + `TaskRecord` state machine | `AgentExecutor.execute/cancel` wrapping the LangGraph graph |
+| Status / artifact frames | `_build_status_event` (carries `final`), `_build_artifact_event`, `_build_terminal_artifact_event` | sdk event queue; terminal-by-state |
+| Task store | `A2ATaskStore` + optional `A2ATaskPersistence` (`a2a_task_store.py`) | sdk `TaskStore` interface (keep our durable impl behind it) |
+| Push notifications | `A2APushStore` (`a2a_push_store.py`), `_spawn_webhook`, SSRF allowlist | sdk push-notification support (keep the SSRF guard) |
+| Auth | `set_a2a_token` / `_check_auth` bearer | `protolabs-a2a` auth scheme |
+| Agent card | `server.py::_build_agent_card` (0.3 shape, `agent.json`) | `protolabs-a2a` card defaults (1.0, `agent-card.json`) |
+| Custom DataParts | `WORLDSTATE_DELTA_MIME`, `COST_MIME`, `CONFIDENCE_MIME`, `TOOL_CALL_MIME`, `HITL_MIME` (`application/vnd.protolabs.*`) | `metadata.mimeType` `…/ext/<ext>` + `content.value`, defined in `protolabs-a2a` |
+
+**Extensions protoAgent emits** (these drive `protolabs-a2a`'s shape):
+`cost-v1`, `confidence-v1`, `worldstate-delta-v1`, `tool-call-v1` — plus
+`hitl-v1` (added this cycle for the HITL forms). The card also declares
+`hitl-mode-v1` (capability) and leaves `blast-v1` / `effect-domain-v1`
+commented for forks to fill.
+
+## 4. Migration plan (slices, on an undeployed `feature/a2a-1.0` branch)
+
+0. **Prereqs (gate):** `protolabs-a2a` exists (or we bootstrap it); pin the
+   `a2a-sdk` Python version; have protoWorkstacean ADR-0006 + the hub spike
+   branch open.
+1. **Executor spike** — `AgentExecutor` that wraps the existing LangGraph graph;
+   serve the 1.0 agent card via `protolabs-a2a`. Prove `message/send` +
+   `message/stream` round-trip.
+2. **Port the extension DataParts** to the 1.0 discriminator
+   (`metadata.mimeType` + `content.value`) via `protolabs-a2a`; keep emission
+   wired where it is today (cost on `on_chat_model_end`, confidence/tool-call/
+   hitl in the run loop).
+3. **Stores** — adapt `A2ATaskStore`/`A2APushStore` behind the sdk's
+   `TaskStore` / push interfaces (keep durability + the SSRF allowlist).
+4. **HITL** — re-express `input-required` pause/resume (LangGraph `interrupt` +
+   the `hitl-v1` form payload) on the 1.0 task lifecycle.
+5. **Conformance** — a real **ws ↔ protoAgent 1.0 round-trip** (the vertical
+   slice). Port `tests/test_a2a_*.py` to 1.0 shapes; add a 1.0 round-trip test.
+6. **Cutover (flag-day)** — coordinate the deploy with the hub + the other
+   agents; **roxy** rebases its fork onto the migrated handler.
+
+## 5. Consequences
+
+**Positive** — delete ~2,083 LOC of hand-rolled protocol; conform to A2A 1.0;
+share extension/card/auth conventions across the fleet via one package; roxy
+inherits the migration nearly for free.
+
+**Negative / costs** — new dependencies (`a2a-sdk`, `protolabs-a2a`); a
+flag-day cutover with real coordination cost (no interop, so timing matters);
+the conventions package must be authored first; a long-lived undeployed branch
+that has to be kept in sync with `main` until cutover.
+
+## 6. Related
+
+- [#443](https://github.com/protoLabsAI/protoAgent/issues/443) — tracking issue (fleet template task)
+- protoWorkstacean **ADR-0006** — the canonical fleet decision + wire contract (upstream)
+- [React + Tauri console](/guides/react-tauri-ui) — the DataPart extensions also surface in the console (cost / tool-call / hitl cards)
+- [ADR 0003 — Reactive agent & Activity thread](/adr/0003-reactive-agent-activity-thread) — the terminal-task hook + push notifications

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -22,3 +22,4 @@ decision, numbered, never deleted (supersede instead).
 | [0011](./0011-deep-research-workflow.md) | Deep-research workflow with adversarial review | Accepted |
 | [0012](./0012-eval-strategy-and-model-comparison.md) | Eval strategy: model-tagged tracking & model comparison | Accepted |
 | [0013](./0013-console-data-layer-react-query.md) | Console data layer: TanStack Query + Suspense + ErrorBoundary | Accepted |
+| [0014](./0014-a2a-1.0-migration.md) | A2A 0.3 → 1.0: adopt `a2a-sdk` + `protolabs-a2a` | Accepted (blocked) |


### PR DESCRIPTION
## What

A **plan-only** ADR for the A2A 1.0 migration tracked in #443 — no handler code changes.

Records the protoAgent-local plan to replace the **~2,083-LOC hand-rolled `a2a_handler.py`** with the official **`a2a-sdk`** (`AgentExecutor`) + a shared **`protolabs-a2a`** conventions layer, per the fleet decision in protoWorkstacean **ADR-0006**.

## Contents

- **Why not patch** — 0.3→1.0 is a wire-shape break (terminal-by-state / `final` removed, member-discriminated Parts, `agent-card.json`, extensions in `metadata.mimeType` + `content.value`).
- **Surface-to-replace → 1.0 target** table (routing, executor, status/artifact frames, `A2ATaskStore`/`A2APushStore`, bearer auth, the agent card, and the 5 custom DataPart extensions: cost / confidence / worldstate-delta / tool-call / hitl).
- **Sliced checklist** — undeployed `feature/a2a-1.0` branch → executor spike → port extensions → stores → HITL → vertical ws↔protoAgent round-trip → flag-day cutover (roxy inherits the fork).
- **Blockers** — `protoLabsAI/protolabs-a2a` doesn't exist yet (and protoAgent's extensions define its shape), and there's no 0.3↔1.0 interop (coordinated cutover). So it's plan-only until those clear.

## Verification

VitePress docs build clean; ADR indexed (0014, "Accepted (blocked)"); CHANGELOG noted.

## Issue housekeeping done alongside

Closed the A2A noise: #162/#164/#165 (not-reproducible — they target TypeScript files that don't exist in this Python repo; `_build_agent_card` returns a non-empty `skills` array) and the stale CI-failure cluster (#163/#166/#167/#168/#169/#170/#160/#235/#236 — main is green). A2A is now down to just #443.

🤖 Generated with [Claude Code](https://claude.com/claude-code)