### PR TITLE
docs(a2a): reconcile ADR 0014 + CHANGELOG to shipped (post-#453)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,13 +22,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   aware (matches `metadata.mimeType`, reads `content.value`/flattened `data`,
   no longer requires the dropped 0.3 `kind:"data"`) — which also restores
   tool-call-v1 card rendering. `protolabs_a2a` stays the four fleet extensions.
-- **ADR 0014 — A2A 0.3 → 1.0 migration plan.** Records the protoAgent-local plan
-  to replace the ~2,083-LOC hand-rolled `a2a_handler.py` with the official
-  `a2a-sdk` (`AgentExecutor`) + a shared `protolabs-a2a` conventions layer
-  (inherited from protoWorkstacean ADR-0006; tracked by #443). Plan-only — a
-  surface-to-1.0 map + sliced checklist; execution is blocked (the
-  `protolabs-a2a` package doesn't exist yet) and is a flag-day cutover, so no
-  code lands until those clear.
+- **A2A 1.0 migration shipped (ADR 0014, #453).** Deleted the ~2,059-LOC
+  hand-rolled `a2a_handler.py` and adopted the official **`a2a-sdk` 1.1** +
+  a vendored **`protolabs_a2a/`** conventions layer (the four fleet extensions —
+  cost/confidence/worldstate-delta/tool-call — plus the 1.0 card builder, auth,
+  and member-discriminated parts, byte-for-byte with the hub's `@protolabs/a2a`).
+  `ProtoAgentExecutor` bridges the LangGraph stream onto the SDK; durable SQLite
+  task/push stores (24h TTL) with an SSRF guard on push callbacks; bearer/
+  X-API-Key/origin auth; card at `/.well-known/agent-card.json`. A protoAgent-
+  local `hitl-v1` DataPart keeps `request_user_input` forms + `run_command`
+  approval cards rendering in the console. **Merging ≠ deploying** — the
+  0.3→1.0 cutover is a coordinated publish/deploy-time step (the hub +
+  roxy/ORBIS/pwnDeck), not gated on this merge.
 - **Console data layer: TanStack Query + Suspense + ErrorBoundary (ADR 0013).**
   The operator console adopts `@tanstack/react-query` (suspense mode) for its
   reads — loading is a `<Suspense>` fallback, failures are caught by a contained

--- a/docs/adr/0014-a2a-1.0-migration.md
+++ b/docs/adr/0014-a2a-1.0-migration.md
@@ -1,6 +1,6 @@
 # ADR 0014 — A2A 0.3 → 1.0: adopt `a2a-sdk` + `protolabs-a2a`
 
-- **Status:** Accepted (upstream) — **execution not started; blocked.** The decision is inherited from protoWorkstacean **ADR-0006**; this ADR is the protoAgent-local plan + checklist. Tracked by [#443](https://github.com/protoLabsAI/protoAgent/issues/443).
+- **Status:** Accepted — **SHIPPED to `main` in [#453](https://github.com/protoLabsAI/protoAgent/pull/453)** (2026-06-02). The hand-rolled handler is deleted; protoAgent speaks A2A 1.0 via `a2a-sdk` + `protolabs_a2a`. The decision is inherited from protoWorkstacean **ADR-0006**; this ADR is the protoAgent-local plan + record. Tracked by [#443](https://github.com/protoLabsAI/protoAgent/issues/443) (closes at the fleet flag-day cutover). **Merging ≠ deploying** — the 0.3→1.0 cutover is a publish/deploy-time step coordinated with the hub + other agents, not gated on this merge.
 - **Date:** 2026-06-02
 - **Deciders:** Josh Mabry; protoAgent maintainers
 - **Tags:** a2a, protocol, migration, fleet
@@ -39,19 +39,21 @@ Re-implementing protocol mechanics by hand again is exactly what ADR-0006 says
 `DefaultRequestHandler`, `A2AStarletteApplication`) and put the *protolabs*
 specifics (extensions, card defaults, auth) in `protolabs-a2a`.
 
-## 2. Blockers (why this is plan-only today)
+## 2. Blockers (resolved — kept for the record)
 
-1. **`protoLabsAI/protolabs-a2a` does not exist yet.** The shared Python layer
-   this migration depends on hasn't been created. And #443 notes protoAgent's
-   extensions *define the shape* of that layer — so it likely has to be authored
-   (bootstrapped from protoAgent's extension payloads). Chicken-and-egg.
-2. **Flag-day — no 0.3↔1.0 interop.** Per #443: land on a **ready branch,
-   undeployed**; it ships in one coordinated cutover with the hub
-   (protoWorkstacean) + the other agents. So this is **not** a normal
-   merge-to-`main` PR.
-3. **Canonical wire contract lives in protoWorkstacean ADR-0006**, which isn't
-   in this repo. The implementer needs it (and the hub's reference impl on
-   `feature/a2a-1.0-alpha-spike`) open while porting.
+The plan originally listed three blockers; all cleared, and #453 merged:
+
+1. ~~`protoLabsAI/protolabs-a2a` does not exist yet.~~ **Created** and vendored
+   into protoAgent as `protolabs_a2a/` (the four fleet extensions + card + auth
+   + parts), byte-for-byte with the hub's `@protolabs/a2a`.
+2. ~~Flag-day — must not merge to `main`.~~ **Merging ≠ deploying.** Landing the
+   template's 1.0 code on `main` doesn't ship anything to prod; the 0.3→1.0
+   cutover is a publish/deploy-time step (the GHCR image / release), coordinated
+   with the hub + other agents. So #453 merged to `main` while the *deploy*
+   stays a coordinated, on-demand lever.
+3. ~~Canonical wire contract lives in protoWorkstacean ADR-0006.~~ Mirrored in
+   `protolabs_a2a` (member-discriminated parts, `metadata.mimeType`
+   discriminator, the `-v1` MIMEs) and verified against the hub's `@a2a-js/sdk`.
 
 ## 3. What we have today (the surface to replace)
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -22,4 +22,4 @@ decision, numbered, never deleted (supersede instead).
 | [0011](./0011-deep-research-workflow.md) | Deep-research workflow with adversarial review | Accepted |
 | [0012](./0012-eval-strategy-and-model-comparison.md) | Eval strategy: model-tagged tracking & model comparison | Accepted |
 | [0013](./0013-console-data-layer-react-query.md) | Console data layer: TanStack Query + Suspense + ErrorBoundary | Accepted |
-| [0014](./0014-a2a-1.0-migration.md) | A2A 0.3 → 1.0: adopt `a2a-sdk` + `protolabs-a2a` | Accepted (blocked) |
+| [0014](./0014-a2a-1.0-migration.md) | A2A 0.3 → 1.0: adopt `a2a-sdk` + `protolabs-a2a` | Accepted (shipped #453) |

--- a/server.py
+++ b/server.py
@@ -4,9 +4,10 @@ This is the main entry point. It:
 
 1. Initializes LangGraph (``graph/agent.py``) + the LiteLLM gateway
    connection via ``graph/llm.py``.
-2. Mounts the full A2A surface (``a2a_handler.register_a2a_routes``)
+2. Mounts the full A2A 1.0 surface (``a2a-sdk`` ``DefaultRequestHandler`` +
+   ``a2a_executor.ProtoAgentExecutor``, conventions via ``protolabs_a2a``)
    — JSON-RPC on ``POST /a2a``, SSE streaming, push notifications,
-   ``tasks/*`` CRUD, agent card at ``/.well-known/agent.json``.
+   ``tasks/*`` CRUD, agent card at ``/.well-known/agent-card.json``.
 3. Mounts an OpenAI-compatible chat-completions endpoint so the agent
    can be registered as a model in the LiteLLM gateway / OpenWebUI.
 4. Optionally mounts a Gradio chat UI for direct operator access.
@@ -15,8 +16,8 @@ This is the main entry point. It:
 
 ### Forking checklist
 
-- Change the agent identity in ``_build_agent_card`` (name, description,
-  skills, extensions).
+- Change the agent identity in ``_build_agent_card_proto`` /
+  ``protolabs_a2a.build_agent_card`` (name, description, skills, extensions).
 - Drop ``SOUL.md`` in the workspace to override the default agent prompt.
 - Add your real tools to ``tools/lg_tools.py`` and wire them into
   ``graph/subagents/config.py`` if you want specialized delegation.
@@ -1456,8 +1457,8 @@ async def _chat_langgraph_stream(
     resume: bool = False,
 ):
     """Async generator — yields (event_type, payload) tuples from the
-    LangGraph run. Consumed by ``a2a_handler.register_a2a_routes`` to
-    drive the background task runner + SSE streaming.
+    LangGraph run. Consumed by ``a2a_executor.ProtoAgentExecutor`` to
+    drive the SDK task lifecycle + SSE streaming.
 
     Event contract (matches what the A2A handler expects):
 


### PR DESCRIPTION
#453 merged the A2A 1.0 migration to `main`, so the plan-only / blocked framing is now stale. This reconciles the docs.

- **ADR 0014** status → *Accepted, SHIPPED in #453*; the three "blockers" marked resolved (`protolabs_a2a` created + vendored; merge ≠ deploy; wire contract mirrored & cross-SDK-verified).
- **adr/index.md** → "Accepted (shipped #453)".
- **CHANGELOG**: the "plan-only, no code lands" entry → the shipped migration (a2a-sdk 1.1 + protolabs_a2a, durable stores + SSRF, hitl-v1, card at `/.well-known/agent-card.json`).
- **server.py**: docstrings no longer reference the deleted `a2a_handler.register_a2a_routes` / `_build_agent_card` → the `a2a-sdk` executor + `protolabs_a2a` / `_build_agent_card_proto`.

Docs-only; VitePress build clean, `server.py` parses.

🤖 Generated with [Claude Code](https://claude.com/claude-code)