### PR TITLE
docs(a2a): scrub residual a2a_handler references missed by #461

### DIFF
--- a/egress.py
+++ b/egress.py
@@ -7,7 +7,7 @@ unchanged until they opt in. This is also the single source of truth the
 OpenShell network policy is generated from (``scripts/gen_openshell_policy.py``).
 
 Mirrors the ``PUSH_NOTIFICATION_ALLOWED_HOSTS`` SSRF-guard pattern in
-``a2a_handler``. Wildcards: a leading ``*.`` matches any subdomain
+``a2a_stores``. Wildcards: a leading ``*.`` matches any subdomain
 (``*.proto-labs.ai`` allows ``api.proto-labs.ai`` and ``proto-labs.ai``).
 
 This is the in-process half. Process-level egress (subprocess escapes via

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -453,7 +453,7 @@ class LocalScheduler:
             "params": {
                 # Route into the durable Activity thread (ADR 0003) so the
                 # fired turn lands somewhere visible/continuable instead of a
-                # throwaway context. Without this, a2a_handler mints a fresh
+                # throwaway context. Without this, the agent mints a fresh
                 # context per fire and the response surfaces nowhere.
                 "contextId": ACTIVITY_CONTEXT,
                 "message": {
@@ -461,10 +461,9 @@ class LocalScheduler:
                     "parts": [{"kind": "text", "text": job.prompt}],
                     "messageId": message_id,
                 },
-                # Custom metadata goes at params.metadata — that's
-                # where a2a_handler._a2a_rpc reads it (see
-                # ``msg_metadata = params.get("metadata")``). Putting
-                # it inside params.message.metadata silently drops it.
+                # Scheduler bookkeeping for this fire, sent as params.metadata
+                # per the A2A message/send shape (origin + job id). These keys
+                # are informational — the handler does not require them.
                 "metadata": {
                     "scheduler_job_id": job.id,
                     "scheduler_kind": "local",

--- a/server.py
+++ b/server.py
@@ -56,7 +56,7 @@ if TYPE_CHECKING:
 # ---------------------------------------------------------------------------
 # Root-level log config. Python's default is WARNING, which silently filters
 # every `logger.info(...)` call — including "webhook delivered" lines from
-# a2a_handler, making the A2A/webhook path invisible in docker logs.
+# the A2A push sender, making the A2A/webhook path invisible in docker logs.
 # LOG_LEVEL env var lets operators tune without a code change.
 logging.basicConfig(
     level=os.environ.get("LOG_LEVEL", "INFO").upper(),


### PR DESCRIPTION
## What

Comment-only cleanup. #453 deleted the hand-rolled `a2a_handler.py` (now a2a-sdk + `a2a_executor` / `a2a_stores`). #461 reconciled ADR 0014, the CHANGELOG, and the main `server.py` docstrings — but three comments still named the deleted module:

- **`egress.py`** — SSRF-guard cross-ref `a2a_handler` → `a2a_stores` (where `is_safe_webhook_url` / the allowlist actually live now).
- **`scheduler/local.py`** — dropped the dead `a2a_handler._a2a_rpc` pointer + the `params.get("metadata")` placement note; rewrote to describe the scheduler bookkeeping (`origin` + job id) accurately.
- **`server.py`** — "webhook delivered lines from `a2a_handler`" → "from the A2A push sender".

## Why it's safe

- No functional change — comments only. The `scheduler/local.py` `metadata` dict is untouched, so `test_scheduler_local.py` (asserts `params.metadata.origin == "scheduler"`) still passes.
- Verified the scheduler path is not a regression: the old `_a2a_rpc` read `params.metadata` **only** for `a2a.trace`, which the scheduler never sets (only `scheduler_job_id` / `origin` / `scheduler_kind`, none consumed server-side).

## Out of scope (flagged, not fixed here)

The new executor reads `a2a.trace` from `message.metadata`; the old handler read it from `params.metadata`. External callers still placing trace at `params.metadata` would silently lose cross-agent Langfuse propagation — a #453 wire-shape question, not doc cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)