### PR TITLE
chore: release v0.9.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-02
+
 ### Changed
 - **`protolabs_a2a` now consumed as a published git-dep, not vendored.** Dropped
   the vendored `protolabs_a2a/` copy (added by #453) and pinned the public

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.8.0"
+version = "0.9.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
Automated version bump to `v0.9.0`. Review + merge through the normal CI/review gate, then dispatch release.yml (tag `v0.9.0`) to tag main and cut the release.