### PR TITLE
feat(console): migrate Workflows surface to TanStack Query (ADR 0013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Workflows surface migrated to TanStack Query (ADR 0013).** The Studio →
+  Workflows surface now reads the recipe list + subagent registry via
+  `useSuspenseQuery`, runs/deletes via `useMutation` (invalidating the list),
+  and renders loading/errors through `<Suspense>` + a contained
+  `<ErrorBoundary>` — dropping its `useEffect` fetches + the `onError` global
+  banner. Shared `workflowsQuery`/`subagentsQuery` added.
 - **Beads panel migrated to TanStack Query (ADR 0013).** The console's Beads
   surface is now a self-contained `BeadsPanel` — the issue list is a
   `useSuspenseQuery` (refetching while mounted), and create/start/close/reopen/

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -838,7 +838,7 @@ export function App() {
             </section>
           ) : null}
 
-          {surface === "studio" && studioTab === "workflows" ? <WorkflowsSurface onError={setError} /> : null}
+          {surface === "studio" && studioTab === "workflows" ? <WorkflowsSurface /> : null}
 
           {surface === "activity" && activityTab === "thread" ? <ActivitySurface onError={setError} /> : null}
           {surface === "activity" && activityTab === "inbox" ? <InboxPanel onError={setError} /> : null}

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -8,6 +8,8 @@ import { api } from "./api";
 export const queryKeys = {
   goals: ["goals"] as const,
   beadsIssues: ["beads", "issues"] as const,
+  workflows: ["workflows"] as const,
+  subagents: ["subagents"] as const,
 };
 
 // Goals the agent works toward (goal mode). Lives in the right sidebar and
@@ -27,4 +29,18 @@ export const beadsIssuesQuery = () =>
     queryKey: queryKeys.beadsIssues,
     queryFn: () => api.beadsIssues(),
     refetchInterval: 5_000,
+  });
+
+// Registered workflow recipes + the subagent registry — config, not live, so no
+// poll; invalidated when the agent/console saves or deletes one.
+export const workflowsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.workflows,
+    queryFn: () => api.workflows(),
+  });
+
+export const subagentsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.subagents,
+    queryFn: () => api.subagents(),
   });

--- a/apps/web/src/workflows/WorkflowsSurface.tsx
+++ b/apps/web/src/workflows/WorkflowsSurface.tsx
@@ -1,108 +1,95 @@
+import {
+  QueryErrorResetBoundary,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
 import { Loader2, Play, Plus, RefreshCw, Trash2, Workflow } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { Suspense, useMemo, useState } from "react";
 
+import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { api } from "../lib/api";
-import type { WorkflowRunResult, WorkflowSummary } from "../lib/types";
+import { queryKeys, subagentsQuery, workflowsQuery } from "../lib/queries";
+import type { WorkflowRunResult } from "../lib/types";
 import { WorkflowBuilder } from "./WorkflowBuilder";
 
-// Operator surface for declarative workflow recipes (ADR 0002). Lists the
-// registered recipes, shows the selected one's step DAG, collects its inputs,
-// and runs it — surfacing each step's output plus any inline failures.
+// Operator surface for declarative workflow recipes (ADR 0002), on the TanStack
+// Query data layer (ADR 0013): the recipe list + subagent registry are
+// `useSuspenseQuery` reads; run/delete are `useMutation`s; loading is a
+// <Suspense> fallback and errors a contained <ErrorBoundary>.
 
-export function WorkflowsSurface({ onError }: { onError: (message: string) => void }) {
-  const [workflows, setWorkflows] = useState<WorkflowSummary[] | null>(null);
+function WorkflowsBody() {
+  const queryClient = useQueryClient();
+  const { data: wfData } = useSuspenseQuery(workflowsQuery());
+  const { data: subData } = useSuspenseQuery(subagentsQuery());
+  const workflows = wfData.workflows;
+  const subagentNames = (subData.subagents || []).map((s) => s.name).filter(Boolean);
+
   const [selected, setSelected] = useState<string>("");
   const [inputs, setInputs] = useState<Record<string, string>>({});
-  const [running, setRunning] = useState(false);
   const [result, setResult] = useState<WorkflowRunResult | null>(null);
   const [building, setBuilding] = useState(false);
-  const [subagentNames, setSubagentNames] = useState<string[]>([]);
 
-  async function load() {
-    try {
-      const r = await api.workflows();
-      setWorkflows(r.workflows);
-      if (r.workflows.length && !r.workflows.some((w) => w.name === selected)) {
-        setSelected(r.workflows[0].name);
-      }
-    } catch (e) {
-      onError(e instanceof Error ? e.message : String(e));
-    }
-  }
-  useEffect(() => {
-    void load();
-    void api
-      .subagents()
-      .then((r) => setSubagentNames((r.subagents || []).map((s) => s.name).filter(Boolean)))
-      .catch(() => setSubagentNames([]));
-  }, []);
-
-  async function removeWorkflow(name: string) {
-    onError("");
-    try {
-      await api.deleteWorkflow(name);
-      setSelected("");
-      await load();
-    } catch (e) {
-      onError(e instanceof Error ? e.message : String(e));
-    }
-  }
-
+  // Effective selection: explicit pick, else the first recipe.
+  const selectedName = selected || workflows[0]?.name || "";
   const current = useMemo(
-    () => workflows?.find((w) => w.name === selected) ?? null,
-    [workflows, selected],
+    () => workflows.find((w) => w.name === selectedName) ?? null,
+    [workflows, selectedName],
   );
 
-  // Reset the inputs form (seed defaults) when the selected recipe changes.
-  useEffect(() => {
-    if (!current) return;
+  const invalidateWorkflows = () => queryClient.invalidateQueries({ queryKey: queryKeys.workflows });
+
+  const run = useMutation({
+    mutationFn: (v: { name: string; inputs: Record<string, unknown> }) =>
+      api.runWorkflow(v.name, v.inputs),
+    onSuccess: (r) => setResult(r),
+  });
+  const remove = useMutation({
+    mutationFn: (name: string) => api.deleteWorkflow(name),
+    onSuccess: () => setSelected(""),
+    onSettled: invalidateWorkflows,
+  });
+
+  function selectRecipe(name: string) {
+    setSelected(name);
+    setResult(null);
+    const recipe = workflows.find((w) => w.name === name);
     const seed: Record<string, string> = {};
-    for (const inp of current.inputs) {
+    for (const inp of recipe?.inputs ?? []) {
       seed[inp.name] = inp.default != null ? String(inp.default) : "";
     }
     setInputs(seed);
-    setResult(null);
-  }, [selected]); // eslint-disable-line react-hooks/exhaustive-deps
+  }
 
-  const missingRequired = useMemo(() => {
-    if (!current) return [];
-    return current.inputs.filter((i) => i.required && !inputs[i.name]?.trim()).map((i) => i.name);
-  }, [current, inputs]);
+  const missingRequired = current
+    ? current.inputs.filter((i) => i.required && !inputs[i.name]?.trim()).map((i) => i.name)
+    : [];
 
-  async function run() {
+  function doRun() {
     if (!current) return;
-    setRunning(true);
     setResult(null);
-    onError("");
-    try {
-      const payload: Record<string, unknown> = {};
-      for (const inp of current.inputs) {
-        const v = inputs[inp.name];
-        if (v != null && v !== "") payload[inp.name] = v;
-      }
-      const r = await api.runWorkflow(current.name, payload);
-      setResult(r);
-    } catch (e) {
-      onError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setRunning(false);
+    const payload: Record<string, unknown> = {};
+    for (const inp of current.inputs) {
+      const v = inputs[inp.name];
+      if (v != null && v !== "") payload[inp.name] = v;
     }
+    run.mutate({ name: current.name, inputs: payload });
   }
 
   return (
-    <section className="panel stage-panel">
+    <>
       <div className="panel-header">
         <div>
           <h1>Workflows</h1>
           <p className="panel-kicker">
-            {workflows ? `${workflows.length} recipe${workflows.length === 1 ? "" : "s"}` : "loading…"}
+            {workflows.length} recipe{workflows.length === 1 ? "" : "s"}
           </p>
         </div>
         <div className="panel-actions">
           <button className="icon-button" type="button" onClick={() => setBuilding((b) => !b)} title="New workflow">
             <Plus size={16} />
           </button>
-          <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
+          <button className="icon-button" type="button" onClick={() => void invalidateWorkflows()} title="Refresh">
             <RefreshCw size={16} />
           </button>
         </div>
@@ -115,114 +102,130 @@ export function WorkflowsSurface({ onError }: { onError: (message: string) => vo
             onCancel={() => setBuilding(false)}
             onSaved={(name) => {
               setBuilding(false);
-              void load().then(() => setSelected(name));
+              void queryClient.invalidateQueries({ queryKey: queryKeys.workflows });
+              setSelected(name);
             }}
           />
         ) : (
           <>
-        {workflows && !workflows.length ? (
-          <div className="subagent-row">
-            <div>
-              <strong>No workflows registered</strong>
-              <span>Drop a recipe in the workflows directory, or have the agent save one.</span>
-            </div>
-          </div>
-        ) : null}
-
-        {workflows && workflows.length ? (
-          <label className="field">
-            <span>Recipe</span>
-            <select value={selected} onChange={(event) => setSelected(event.target.value)}>
-              {workflows.map((w) => (
-                <option key={w.name} value={w.name}>
-                  {w.name}
-                </option>
-              ))}
-            </select>
-          </label>
-        ) : null}
-
-        {current ? (
-          <>
-            {current.description ? <p className="workflow-desc">{current.description}</p> : null}
-
-            <div className="workflow-steps">
-              {current.steps.map((step) => (
-                <div className="workflow-step" key={step.id}>
-                  <Workflow size={14} />
-                  <strong>{step.id}</strong>
-                  <span className="workflow-step-sub">{step.subagent}</span>
-                  {step.depends_on.length ? (
-                    <span className="workflow-step-dep">after {step.depends_on.join(", ")}</span>
-                  ) : null}
+            {!workflows.length ? (
+              <div className="subagent-row">
+                <div>
+                  <strong>No workflows registered</strong>
+                  <span>Drop a recipe in the workflows directory, or have the agent save one.</span>
                 </div>
-              ))}
-            </div>
+              </div>
+            ) : (
+              <label className="field">
+                <span>Recipe</span>
+                <select value={selectedName} onChange={(event) => selectRecipe(event.target.value)}>
+                  {workflows.map((w) => (
+                    <option key={w.name} value={w.name}>
+                      {w.name}
+                    </option>
+                  ))}
+                </select>
+              </label>
+            )}
 
-            {current.inputs.length ? (
-              <div className="subagent-grid">
-                {current.inputs.map((inp) => (
-                  <label className="field" key={inp.name}>
-                    <span>
-                      {inp.name}
-                      {inp.required ? " *" : ""}
-                    </span>
-                    <input
-                      value={inputs[inp.name] ?? ""}
-                      onChange={(event) => setInputs((prev) => ({ ...prev, [inp.name]: event.target.value }))}
-                      placeholder={inp.default != null ? `default: ${String(inp.default)}` : inp.required ? "required" : "optional"}
-                    />
-                  </label>
-                ))}
+            {current ? (
+              <>
+                {current.description ? <p className="workflow-desc">{current.description}</p> : null}
+
+                <div className="workflow-steps">
+                  {current.steps.map((step) => (
+                    <div className="workflow-step" key={step.id}>
+                      <Workflow size={14} />
+                      <strong>{step.id}</strong>
+                      <span className="workflow-step-sub">{step.subagent}</span>
+                      {step.depends_on.length ? (
+                        <span className="workflow-step-dep">after {step.depends_on.join(", ")}</span>
+                      ) : null}
+                    </div>
+                  ))}
+                </div>
+
+                {current.inputs.length ? (
+                  <div className="subagent-grid">
+                    {current.inputs.map((inp) => (
+                      <label className="field" key={inp.name}>
+                        <span>
+                          {inp.name}
+                          {inp.required ? " *" : ""}
+                        </span>
+                        <input
+                          value={inputs[inp.name] ?? ""}
+                          onChange={(event) => setInputs((prev) => ({ ...prev, [inp.name]: event.target.value }))}
+                          placeholder={inp.default != null ? `default: ${String(inp.default)}` : inp.required ? "required" : "optional"}
+                        />
+                      </label>
+                    ))}
+                  </div>
+                ) : null}
+
+                <div className="panel-actions">
+                  <button
+                    className="primary-button"
+                    type="button"
+                    onClick={doRun}
+                    disabled={run.isPending || missingRequired.length > 0}
+                    title={missingRequired.length ? `missing: ${missingRequired.join(", ")}` : "Run workflow"}
+                  >
+                    {run.isPending ? <Loader2 className="spin" size={16} /> : <Play size={16} />}
+                    Run
+                  </button>
+                  <button
+                    className="ghost-button"
+                    type="button"
+                    onClick={() => remove.mutate(current.name)}
+                    title="Delete this workflow"
+                  >
+                    <Trash2 size={14} /> Delete
+                  </button>
+                </div>
+                {run.isError ? <p className="workflow-failed">{(run.error as Error).message}</p> : null}
+              </>
+            ) : null}
+
+            {result ? (
+              <div className="workflow-result">
+                {result.failed.length ? (
+                  <p className="workflow-failed">Failed steps: {result.failed.join(", ")}</p>
+                ) : null}
+                <h2>Output</h2>
+                <pre className="output-block">{result.output}</pre>
+                {Object.keys(result.steps).length ? (
+                  <details>
+                    <summary>Per-step output ({Object.keys(result.steps).length})</summary>
+                    {Object.entries(result.steps).map(([id, out]) => (
+                      <div className="workflow-step-out" key={id}>
+                        <strong>{id}</strong>
+                        <pre className="output-block">{out}</pre>
+                      </div>
+                    ))}
+                  </details>
+                ) : null}
               </div>
             ) : null}
-
-            <div className="panel-actions">
-              <button
-                className="primary-button"
-                type="button"
-                onClick={() => void run()}
-                disabled={running || missingRequired.length > 0}
-                title={missingRequired.length ? `missing: ${missingRequired.join(", ")}` : "Run workflow"}
-              >
-                {running ? <Loader2 className="spin" size={16} /> : <Play size={16} />}
-                Run
-              </button>
-              <button
-                className="ghost-button"
-                type="button"
-                onClick={() => void removeWorkflow(current.name)}
-                title="Delete this workflow"
-              >
-                <Trash2 size={14} /> Delete
-              </button>
-            </div>
-          </>
-        ) : null}
-
-        {result ? (
-          <div className="workflow-result">
-            {result.failed.length ? (
-              <p className="workflow-failed">Failed steps: {result.failed.join(", ")}</p>
-            ) : null}
-            <h2>Output</h2>
-            <pre className="output-block">{result.output}</pre>
-            {Object.keys(result.steps).length ? (
-              <details>
-                <summary>Per-step output ({Object.keys(result.steps).length})</summary>
-                {Object.entries(result.steps).map(([id, out]) => (
-                  <div className="workflow-step-out" key={id}>
-                    <strong>{id}</strong>
-                    <pre className="output-block">{out}</pre>
-                  </div>
-                ))}
-              </details>
-            ) : null}
-          </div>
-        ) : null}
           </>
         )}
       </div>
+    </>
+  );
+}
+
+export function WorkflowsSurface() {
+  return (
+    <section className="panel stage-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="workflows" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading workflows…" />}>
+              <WorkflowsBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
     </section>
   );
 }


### PR DESCRIPTION
Studio slice of the console data-layer migration ([ADR 0013](docs/adr/0013-console-data-layer-react-query.md)), after Goals (#459) and Beads (#465).

## Changes
- **Reads → `useSuspenseQuery`**: the recipe list (`workflowsQuery`) + the subagent registry for the builder's picker (`subagentsQuery`).
- **Mutations → `useMutation`**: run + delete (and the builder's save) invalidate the workflows query.
- **Loading → `<Suspense>`** skeleton; **errors → contained `<ErrorBoundary>`** retry card. Drops the `useEffect` fetches, the `load()`/refresh plumbing, and the **`onError` global-banner prop** (`WorkflowsSurface` no longer takes `onError`).
- Selection now derives from the data (first recipe) instead of a load effect.

## Scope
**Run** (the other Studio tab) reads the subagents list, which it *shares* with System → Runtime — deferred to the **System** slice so App's `subagents` state + `refreshRuntime` fetch retire in one go.

## Verification
- `tsc --noEmit` + `vite build` clean.
- **39 E2E green** — `workflows.spec.ts` exercises list / required-input / run against the mock.

## Remaining on ADR 0013
Run + System (runtime/telemetry/settings) · Activity (thread/inbox/schedules).

🤖 Generated with [Claude Code](https://claude.com/claude-code)