### PR TITLE
feat(console): migrate Telemetry surface to TanStack Query (ADR 0013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Telemetry surface migrated to TanStack Query (ADR 0013).** System →
+  Telemetry reads the summary + recent turns + insights via a single
+  `useSuspenseQuery` (`telemetryQuery`), refreshes via `refetch`, and renders
+  loading/errors through `<Suspense>` + `<ErrorBoundary>` — dropping its
+  `useEffect`/`onError` plumbing.
 - **Workflows surface migrated to TanStack Query (ADR 0013).** The Studio →
   Workflows surface now reads the recipe list + subagent registry via
   `useSuspenseQuery`, runs/deletes via `useMutation` (invalidating the list),

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1025,7 +1025,7 @@ export function App() {
             </section>
           ) : null}
 
-          {surface === "system" && systemTab === "telemetry" ? <TelemetrySurface onError={setError} /> : null}
+          {surface === "system" && systemTab === "telemetry" ? <TelemetrySurface /> : null}
           {surface === "knowledge" ? <PlaybooksSurface onError={setError} /> : null}
           {surface === "system" && systemTab === "settings" ? <SettingsSurface onError={setError} /> : null}
         </main>

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -10,6 +10,7 @@ export const queryKeys = {
   beadsIssues: ["beads", "issues"] as const,
   workflows: ["workflows"] as const,
   subagents: ["subagents"] as const,
+  telemetry: ["telemetry"] as const,
 };
 
 // Goals the agent works toward (goal mode). Lives in the right sidebar and
@@ -43,4 +44,24 @@ export const subagentsQuery = () =>
   queryOptions({
     queryKey: queryKeys.subagents,
     queryFn: () => api.subagents(),
+  });
+
+// Telemetry dashboard (ADR 0006) — the summary + recent turns + insights in one
+// read (mirrors the surface's original Promise.all). Refreshed by invalidation.
+export const telemetryQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.telemetry,
+    queryFn: async () => {
+      const [s, r, i] = await Promise.all([
+        api.telemetrySummary(),
+        api.telemetryRecent(50),
+        api.telemetryInsights(),
+      ]);
+      return {
+        enabled: s.enabled && r.enabled,
+        summary: s.summary,
+        turns: r.turns || [],
+        insights: i.insights,
+      };
+    },
   });

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -1,3 +1,4 @@
+import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
 import {
   Activity,
   AlertTriangle,
@@ -10,14 +11,15 @@ import {
   RefreshCw,
   Wrench,
 } from "lucide-react";
-import { useEffect, useState } from "react";
+import { Suspense } from "react";
 
-import { api } from "../lib/api";
-import type { TelemetryInsights, TelemetrySummary, TelemetryTurn } from "../lib/types";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
+import { telemetryQuery } from "../lib/queries";
 
 // Telemetry dashboard (ADR 0006 Slice 3) — reads /api/telemetry/* (the local
-// per-turn rollup store). Summary cards + a recent-turns table. Functional
-// first: real numbers, theme-consistent, no charts yet.
+// per-turn rollup store) on the TanStack Query data layer (ADR 0013). Summary
+// cards + a recent-turns table; loading via <Suspense>, errors via
+// <ErrorBoundary>. Functional: real numbers, theme-consistent, no charts yet.
 
 function usd(n: number): string {
   if (!n) return "$0";
@@ -40,46 +42,19 @@ function pct(n: number): string {
   return `${Math.round((n || 0) * 100)}%`;
 }
 
-export function TelemetrySurface({ onError }: { onError: (message: string) => void }) {
-  const [summary, setSummary] = useState<TelemetrySummary | null>(null);
-  const [turns, setTurns] = useState<TelemetryTurn[]>([]);
-  const [insights, setInsights] = useState<TelemetryInsights | null>(null);
-  const [enabled, setEnabled] = useState(true);
-  const [loading, setLoading] = useState(false);
-
-  async function load() {
-    setLoading(true);
-    try {
-      const [s, r, i] = await Promise.all([
-        api.telemetrySummary(),
-        api.telemetryRecent(50),
-        api.telemetryInsights(),
-      ]);
-      setEnabled(s.enabled && r.enabled);
-      setSummary(s.summary);
-      setTurns(r.turns || []);
-      setInsights(i.insights);
-      onError("");
-    } catch (e) {
-      onError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
-    }
-  }
-
-  useEffect(() => {
-    void load();
-  }, []);
+function TelemetryBody() {
+  const { data, isFetching, refetch } = useSuspenseQuery(telemetryQuery());
+  const { enabled, summary, turns, insights } = data;
 
   return (
-    <section className="panel stage-panel" data-testid="telemetry-surface">
+    <>
       <div className="panel-header">
         <div>
           <h1>Telemetry</h1>
           <p className="panel-kicker">per-turn cost &amp; latency · {summary?.turns ?? 0} turns recorded</p>
         </div>
-        <button className="secondary-button" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
-          <RefreshCw size={15} className={loading ? "spin" : ""} /> Refresh
+        <button className="secondary-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
+          <RefreshCw size={15} className={isFetching ? "spin" : ""} /> Refresh
         </button>
       </div>
 
@@ -187,6 +162,22 @@ export function TelemetrySurface({ onError }: { onError: (message: string) => vo
           </>
         )}
       </div>
+    </>
+  );
+}
+
+export function TelemetrySurface() {
+  return (
+    <section className="panel stage-panel" data-testid="telemetry-surface">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="telemetry" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading telemetry…" />}>
+              <TelemetryBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
     </section>
   );
 }


### PR DESCRIPTION
System slice of the ADR 0013 migration. **System → Telemetry** moves onto the query layer.

- One `useSuspenseQuery(telemetryQuery)` folds the summary + recent-turns + insights reads (the surface's original `Promise.all`) into the cache.
- Refresh button uses the query's `refetch` / `isFetching`.
- Loading → `<Suspense>` skeleton; errors → contained `<ErrorBoundary>`. Drops the `useEffect` fetch + the `onError` global-banner prop.

`tsc` + build clean; **39 E2E green** (`telemetry.spec.ts` exercises the surface).

Remaining on ADR 0013: **Settings**, then **Runtime + Run** (shared subagents — retires App's `subagents`/`refreshRuntime`), then **Activity**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)