### PR TITLE
feat(console): migrate Settings surface to TanStack Query (ADR 0013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Settings surface migrated to TanStack Query (ADR 0013).** System → Settings
+  reads the schema via `useSuspenseQuery` and saves via `useMutation` (which
+  invalidates the schema so hot-reloaded values reload); save status/errors show
+  inline. Loading/errors via `<Suspense>` + `<ErrorBoundary>`; drops the
+  `useEffect`/`onError` plumbing.
 - **Telemetry surface migrated to TanStack Query (ADR 0013).** System →
   Telemetry reads the summary + recent turns + insights via a single
   `useSuspenseQuery` (`telemetryQuery`), refreshes via `refetch`, and renders

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -1027,7 +1027,7 @@ export function App() {
 
           {surface === "system" && systemTab === "telemetry" ? <TelemetrySurface /> : null}
           {surface === "knowledge" ? <PlaybooksSurface onError={setError} /> : null}
-          {surface === "system" && systemTab === "settings" ? <SettingsSurface onError={setError} /> : null}
+          {surface === "system" && systemTab === "settings" ? <SettingsSurface /> : null}
         </main>
 
         <aside className="right-panel">

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -11,6 +11,7 @@ export const queryKeys = {
   workflows: ["workflows"] as const,
   subagents: ["subagents"] as const,
   telemetry: ["telemetry"] as const,
+  settings: ["settings", "schema"] as const,
 };
 
 // Goals the agent works toward (goal mode). Lives in the right sidebar and
@@ -64,4 +65,12 @@ export const telemetryQuery = () =>
         insights: i.insights,
       };
     },
+  });
+
+// The generic settings schema (GET /api/settings/schema). Invalidated after a
+// save so the surface reloads the server's hot-reloaded values.
+export const settingsSchemaQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.settings,
+    queryFn: () => api.settingsSchema(),
   });

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,37 +1,46 @@
-import { AlertTriangle, RefreshCw, RotateCcw, Save } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { QueryErrorResetBoundary, useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { AlertTriangle, RotateCcw, Save } from "lucide-react";
+import { Suspense, useMemo, useState } from "react";
 
+import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { api } from "../lib/api";
-import type { SettingsField, SettingsGroup } from "../lib/types";
+import { queryKeys, settingsSchemaQuery } from "../lib/queries";
+import type { SettingsField } from "../lib/types";
 
 // Generic settings surface — renders whatever GET /api/settings/schema returns,
 // so it stays in sync as config grows. Saving POSTs the changed fields and the
 // server hot-reloads the agent; fields flagged `restart` get a badge + banner.
+// On the TanStack Query data layer (ADR 0013): the schema is a useSuspenseQuery,
+// save is a useMutation that invalidates it; loading/errors via Suspense +
+// ErrorBoundary.
 
-export function SettingsSurface({ onError }: { onError: (message: string) => void }) {
-  const [groups, setGroups] = useState<SettingsGroup[] | null>(null);
+export function SettingsSurface() {
+  return (
+    <section className="panel stage-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="settings" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading settings…" />}>
+              <SettingsBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </section>
+  );
+}
+
+function SettingsBody() {
+  const queryClient = useQueryClient();
+  const { data } = useSuspenseQuery(settingsSchemaQuery());
+  const groups = data.groups;
   const [dirty, setDirty] = useState<Record<string, unknown>>({});
-  const [saving, setSaving] = useState(false);
   const [status, setStatus] = useState("");
-
-  async function load() {
-    try {
-      const r = await api.settingsSchema();
-      setGroups(r.groups);
-      setDirty({});
-    } catch (e) {
-      onError(e instanceof Error ? e.message : String(e));
-    }
-  }
-  useEffect(() => {
-    void load();
-  }, []);
 
   const dirtyKeys = Object.keys(dirty);
 
   // Pending changes that won't take effect until a process restart.
   const pendingRestart = useMemo(() => {
-    if (!groups) return [];
     const labels: string[] = [];
     for (const g of groups) {
       for (const f of g.fields) {
@@ -41,49 +50,31 @@ export function SettingsSurface({ onError }: { onError: (message: string) => voi
     return labels;
   }, [groups, dirty]);
 
-  async function save() {
-    if (!dirtyKeys.length) return;
-    setSaving(true);
-    setStatus("saving…");
-    onError("");
-    try {
-      const r = await api.saveSettings(dirty);
+  const save = useMutation({
+    mutationFn: () => api.saveSettings(dirty),
+    onMutate: () => setStatus("saving…"),
+    onSuccess: (r) => {
       if (!r.ok) {
-        onError(r.messages.join(" · "));
-        setStatus("save failed");
+        setStatus(`save failed: ${r.messages.join(" · ")}`);
         return;
       }
       const restartNote = r.restart_required.length
         ? ` — restart required for: ${r.restart_required.join(", ")}`
         : "";
       setStatus(`${r.messages.join(" · ")}${restartNote}`);
-      await load();
-    } catch (e) {
-      onError(e instanceof Error ? e.message : String(e));
-      setStatus("save failed");
-    } finally {
-      setSaving(false);
-    }
-  }
+      setDirty({});
+      void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
+    },
+    onError: (e) => setStatus(`save failed: ${e instanceof Error ? e.message : String(e)}`),
+  });
 
-  if (!groups) {
-    return (
-      <section className="panel stage-panel">
-        <div className="panel-header">
-          <h1>Settings</h1>
-        </div>
-        <div className="stage-body">
-          <div className="empty-state">
-            <RefreshCw size={16} className="spin" />
-            <span>Loading settings…</span>
-          </div>
-        </div>
-      </section>
-    );
+  function discard() {
+    setDirty({});
+    setStatus("");
   }
 
   return (
-    <section className="panel stage-panel">
+    <>
       <div className="panel-header">
         <div>
           <h1>Settings</h1>
@@ -92,11 +83,11 @@ export function SettingsSurface({ onError }: { onError: (message: string) => voi
           </p>
         </div>
         <div className="settings-actions">
-          <button className="secondary-button" type="button" onClick={() => void load()} disabled={saving || !dirtyKeys.length}>
+          <button className="secondary-button" type="button" onClick={discard} disabled={save.isPending || !dirtyKeys.length}>
             <RotateCcw size={15} />
             Discard
           </button>
-          <button className="primary-button" type="button" onClick={() => void save()} disabled={saving || !dirtyKeys.length}>
+          <button className="primary-button" type="button" onClick={() => save.mutate()} disabled={save.isPending || !dirtyKeys.length}>
             <Save size={16} />
             Save &amp; apply
           </button>
@@ -126,7 +117,7 @@ export function SettingsSurface({ onError }: { onError: (message: string) => voi
           </section>
         ))}
       </div>
-    </section>
+    </>
   );
 }
 


### PR DESCRIPTION
System slice continued. **System → Settings** moves onto the query layer.

- Schema read via `useSuspenseQuery(settingsSchemaQuery)`.
- Save via `useMutation(saveSettings)` — invalidates the schema so the server's hot-reloaded values reload; soft (`r.ok === false`) and thrown errors surface inline in the status line.
- Loading → `<Suspense>` skeleton; errors → `<ErrorBoundary>`. Drops the `useEffect` load + the `onError` global-banner prop. Discard just clears the dirty overlay.

`tsc` + build clean; **39 E2E green** (`settings.spec.ts`: render / edit round-trip / restart banner).

Remaining on ADR 0013: **Runtime + Run** (shared subagents — retires App's `subagents`/`refreshRuntime`), then **Activity**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)