### PR TITLE
feat(console): migrate Inbox panel to TanStack Query (ADR 0013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Inbox panel migrated to TanStack Query (ADR 0013).** Activity → Inbox reads
+  via `useSuspenseQuery`, invalidates on the live `inbox.item` event, and
+  dismisses via a `useMutation` (optimistic hide held above the Suspense
+  boundary so a delivered item stays gone). Loading/errors via `<Suspense>` +
+  `<ErrorBoundary>`; drops the `useEffect`/`onError` plumbing. (Activity →
+  Thread stays imperative — it's a live message stream with a streaming send,
+  like Chat/Notes.)
 - **Settings surface migrated to TanStack Query (ADR 0013).** System → Settings
   reads the schema via `useSuspenseQuery` and saves via `useMutation` (which
   invalidates the schema so hot-reloaded values reload); save status/errors show

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -841,7 +841,7 @@ export function App() {
           {surface === "studio" && studioTab === "workflows" ? <WorkflowsSurface /> : null}
 
           {surface === "activity" && activityTab === "thread" ? <ActivitySurface onError={setError} /> : null}
-          {surface === "activity" && activityTab === "inbox" ? <InboxPanel onError={setError} /> : null}
+          {surface === "activity" && activityTab === "inbox" ? <InboxPanel /> : null}
 
           {surface === "activity" && activityTab === "schedule" ? (
             <section className="panel stage-panel">

--- a/apps/web/src/inbox/InboxPanel.tsx
+++ b/apps/web/src/inbox/InboxPanel.tsx
@@ -1,65 +1,67 @@
-import { Check, Loader2, RefreshCw } from "lucide-react";
-import { useEffect, useState } from "react";
+import {
+  QueryErrorResetBoundary,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { Check, RefreshCw } from "lucide-react";
+import { Suspense, useEffect, useState } from "react";
 
+import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { api } from "../lib/api";
 import { onServerEvent } from "../lib/events";
-import type { InboxItem } from "../lib/types";
+import { inboxQuery, queryKeys } from "../lib/queries";
 
 // Right-sidebar view of the inbound inbox (ADR 0003). Lists pending stimuli
 // (webhooks / external systems / sister agents), live-updates as items arrive
-// over the `inbox.item` push event, and lets the operator dismiss one
-// (mark it delivered). External intake is POST /api/inbox (token-gated); this
-// surface is read + dismiss only.
+// over the `inbox.item` push event, and lets the operator dismiss one (mark it
+// delivered). External intake is POST /api/inbox (token-gated); this surface is
+// read + dismiss only. On the TanStack Query data layer (ADR 0013): the list is
+// a useSuspenseQuery the `inbox.item` event invalidates; dismiss is a mutation.
 
 const PRIORITY_TONE: Record<string, string> = { now: "now", next: "next", later: "later" };
 
-export function InboxPanel({ onError }: { onError: (message: string) => void }) {
-  const [items, setItems] = useState<InboxItem[]>([]);
-  const [loading, setLoading] = useState(true);
+function InboxBody({
+  dismissed,
+  onDismiss,
+}: {
+  dismissed: Set<number>;
+  onDismiss: (id: number) => void;
+}) {
+  const queryClient = useQueryClient();
+  const { data, isFetching, refetch } = useSuspenseQuery(inboxQuery());
 
-  async function load() {
-    setLoading(true);
-    try {
-      const r = await api.inbox("later", false); // all pending tiers
-      setItems(r.items);
-    } catch (e) {
-      onError(e instanceof Error ? e.message : String(e));
-    } finally {
-      setLoading(false);
-    }
-  }
-  useEffect(() => {
-    void load();
-  }, []);
+  // Delivered items stay hidden even if a refetch re-includes them (the server
+  // drops them once delivered). `dismissed` is held by the parent so it
+  // survives the live-event refetch cycle.
+  const items = data.items.filter((i) => !dismissed.has(i.id));
 
-  // Live: a new item arrived. Reload to pick it up with its server-assigned id.
-  useEffect(() => onServerEvent("inbox.item", () => void load()), []);
+  // Live: a new item arrived — refresh to pick it up with its server id.
+  useEffect(
+    () => onServerEvent("inbox.item", () => void queryClient.invalidateQueries({ queryKey: queryKeys.inbox })),
+    [queryClient],
+  );
 
-  async function dismiss(id: number) {
-    try {
-      await api.deliverInbox(id);
-      setItems((prev) => prev.filter((i) => i.id !== id));
-    } catch (e) {
-      onError(e instanceof Error ? e.message : String(e));
-    }
-  }
+  const dismiss = useMutation({
+    mutationFn: (id: number) => api.deliverInbox(id),
+    // Hide immediately on click (optimistic); it won't return once delivered.
+    onMutate: (id) => onDismiss(id),
+  });
 
   return (
-    <section className="panel side-panel inbox-panel">
+    <>
       <div className="panel-header compact">
         <div>
           <h2>Inbox</h2>
-          <p className="panel-kicker">
-            {loading ? "loading…" : `${items.length} pending`}
-          </p>
+          <p className="panel-kicker">{items.length} pending</p>
         </div>
-        <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
-          {loading ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
+        <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
+          <RefreshCw size={16} className={isFetching ? "spin" : ""} />
         </button>
       </div>
 
       <div className="inbox-list">
-        {!loading && items.length === 0 ? (
+        {items.length === 0 ? (
           <div className="inbox-empty">
             Nothing pending. Inbound stimuli (webhooks, scripts, sister agents) posted to
             <code>/api/inbox</code> show up here.
@@ -75,7 +77,7 @@ export function InboxPanel({ onError }: { onError: (message: string) => void }) 
               <button
                 className="icon-button inbox-dismiss"
                 type="button"
-                onClick={() => void dismiss(item.id)}
+                onClick={() => dismiss.mutate(item.id)}
                 title="Mark delivered (dismiss)"
               >
                 <Check size={15} />
@@ -85,6 +87,28 @@ export function InboxPanel({ onError }: { onError: (message: string) => void }) 
           </div>
         ))}
       </div>
+    </>
+  );
+}
+
+export function InboxPanel() {
+  // Held above the Suspense boundary so a delivered item stays dismissed across
+  // the live-event refetch cycle (the inner body remounts on re-suspend).
+  const [dismissed, setDismissed] = useState<Set<number>>(() => new Set());
+  return (
+    <section className="panel side-panel inbox-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="inbox" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading inbox…" />}>
+              <InboxBody
+                dismissed={dismissed}
+                onDismiss={(id) => setDismissed((s) => new Set(s).add(id))}
+              />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
     </section>
   );
 }

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -12,6 +12,7 @@ export const queryKeys = {
   subagents: ["subagents"] as const,
   telemetry: ["telemetry"] as const,
   settings: ["settings", "schema"] as const,
+  inbox: ["inbox"] as const,
 };
 
 // Goals the agent works toward (goal mode). Lives in the right sidebar and
@@ -73,4 +74,12 @@ export const settingsSchemaQuery = () =>
   queryOptions({
     queryKey: queryKeys.settings,
     queryFn: () => api.settingsSchema(),
+  });
+
+// The inbound inbox (ADR 0003) — all pending tiers. Live: the panel invalidates
+// this on the `inbox.item` push event so a new stimulus appears immediately.
+export const inboxQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.inbox,
+    queryFn: () => api.inbox("later", false),
   });


### PR DESCRIPTION
Activity slice of the ADR 0013 migration. **Activity → Inbox** moves onto the query layer.

- List via `useSuspenseQuery(inboxQuery)`; the live `inbox.item` push event invalidates it so a new stimulus appears immediately.
- Dismiss via `useMutation(deliverInbox)` — optimistic hide; the `dismissed` set is held **above** the Suspense boundary so a delivered item stays gone across the live refetch cycle.
- Loading → `<Suspense>`; errors → `<ErrorBoundary>`. Drops the `useEffect` load + `onError` global-banner prop.

**Activity → Thread stays imperative** — it's a live message stream with a streaming send (like Chat and Notes), not a read-cache candidate.

`tsc` + build clean; **39 E2E green** (`inbox.spec.ts`: list / unread badge / dismiss).

Remaining on ADR 0013: **Schedule** (inline in App) + the **Runtime + Run** finale (retires App's `runtime`/`subagents`/`refreshRuntime`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)