### PR TITLE
feat(console): migrate Schedule surface to TanStack Query (ADR 0013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Schedule surface migrated to TanStack Query (ADR 0013).** Activity →
+  Schedule (extracted from `App` into `SchedulePanel`) reads jobs via
+  `useSuspenseQuery` and adds/cancels via `useMutation` (invalidating the list);
+  loading/errors via `<Suspense>` + `<ErrorBoundary>`. Retires the schedule
+  state + handlers + refresh-on-tab effect from `App`.
 - **Inbox panel migrated to TanStack Query (ADR 0013).** Activity → Inbox reads
   via `useSuspenseQuery`, invalidates on the live `inbox.item` event, and
   dismisses via a `useMutation` (optimistic hide held above the Suspense

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -17,7 +17,6 @@ import {
   PanelRight,
   Play,
   Plus,
-  RefreshCw,
   Save,
   Settings2,
   Sparkles,
@@ -40,10 +39,11 @@ import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { onConnectionChange, onServerEvent } from "../lib/events";
-import type { NotesWorkspace, RuntimeStatus, ScheduledJob, Subagent } from "../lib/types";
+import type { NotesWorkspace, RuntimeStatus, Subagent } from "../lib/types";
 import { StatusPill } from "./StatusPill";
 import { GoalsPanel } from "./GoalsPanel";
 import { BeadsPanel } from "./BeadsPanel";
+import { SchedulePanel } from "../schedule/SchedulePanel";
 import { SetupWizard } from "../setup/SetupWizard";
 
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
@@ -162,12 +162,6 @@ export function App() {
   const [notesBusy, setNotesBusy] = useState(false);
   const [notesDirty, setNotesDirty] = useState(false);
 
-  const [scheduleJobs, setScheduleJobs] = useState<ScheduledJob[]>([]);
-  const [scheduleBackend, setScheduleBackend] = useState("local");
-  const [schedulePrompt, setSchedulePrompt] = useState("");
-  const [scheduleWhen, setScheduleWhen] = useState("");
-  const [scheduleJobId, setScheduleJobId] = useState("");
-  const [scheduleBusy, setScheduleBusy] = useState(false);
 
 
   const activeTab = workspace?.tabs[workspace.activeTabId] || null;
@@ -186,48 +180,6 @@ export function App() {
       setSubagentType(subagentPayload.subagents[0]?.name || "researcher");
     }
     return runtimePayload;
-  }
-
-  async function refreshSchedules() {
-    try {
-      const payload = await api.schedules();
-      setScheduleJobs(payload.jobs);
-      setScheduleBackend(payload.backend);
-    } catch (exc) {
-      setError(exc instanceof Error ? exc.message : String(exc));
-    }
-  }
-
-  async function createSchedule() {
-    const prompt = schedulePrompt.trim();
-    const schedule = scheduleWhen.trim();
-    if (!prompt || !schedule || scheduleBusy) return;
-    setScheduleBusy(true);
-    setError("");
-    try {
-      await api.addSchedule({ prompt, schedule, job_id: scheduleJobId.trim() || undefined });
-      setSchedulePrompt("");
-      setScheduleWhen("");
-      setScheduleJobId("");
-      await refreshSchedules();
-    } catch (exc) {
-      setError(exc instanceof Error ? exc.message : String(exc));
-    } finally {
-      setScheduleBusy(false);
-    }
-  }
-
-  async function cancelScheduleJob(jobId: string) {
-    if (scheduleBusy) return;
-    setScheduleBusy(true);
-    try {
-      await api.cancelSchedule(jobId);
-      await refreshSchedules();
-    } catch (exc) {
-      setError(exc instanceof Error ? exc.message : String(exc));
-    } finally {
-      setScheduleBusy(false);
-    }
   }
 
   // Notes are agent-global (one persistent store). Beads + Goals own their data
@@ -310,9 +262,6 @@ export function App() {
     return () => window.clearInterval(handle);
   }, [rightPanel, notesDirty, notesBusy]);
 
-  useEffect(() => {
-    if (surface === "activity" && activityTab === "schedule") void refreshSchedules();
-  }, [surface, activityTab]);
 
   // Goals now own their data via TanStack Query inside <GoalsPanel> (ADR 0013) —
   // no App-level fetch/poll here.
@@ -843,92 +792,7 @@ export function App() {
           {surface === "activity" && activityTab === "thread" ? <ActivitySurface onError={setError} /> : null}
           {surface === "activity" && activityTab === "inbox" ? <InboxPanel /> : null}
 
-          {surface === "activity" && activityTab === "schedule" ? (
-            <section className="panel stage-panel">
-              <div className="panel-header">
-                <div>
-                  <h1>Schedule</h1>
-                  <p className="panel-kicker">{scheduleJobs.length} job{scheduleJobs.length === 1 ? "" : "s"} · {scheduleBackend}</p>
-                </div>
-                <button className="icon-button" type="button" onClick={() => void refreshSchedules()} title="Refresh">
-                  {scheduleBusy ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
-                </button>
-              </div>
-
-              <div className="stage-body">
-              <div className="subagent-grid">
-                <label className="field">
-                  <span>When (cron or ISO datetime)</span>
-                  <input
-                    value={scheduleWhen}
-                    onChange={(event) => setScheduleWhen(event.target.value)}
-                    placeholder='e.g. "0 9 * * 1-5"  or  "2026-06-01T15:00:00Z"'
-                  />
-                </label>
-                <label className="field">
-                  <span>Job id (optional)</span>
-                  <input
-                    value={scheduleJobId}
-                    onChange={(event) => setScheduleJobId(event.target.value)}
-                    placeholder="auto"
-                  />
-                </label>
-                <button
-                  className="primary-button"
-                  type="button"
-                  onClick={() => void createSchedule()}
-                  disabled={scheduleBusy || !schedulePrompt.trim() || !scheduleWhen.trim()}
-                >
-                  <Plus size={16} />
-                  Schedule
-                </button>
-              </div>
-              <label className="field grow">
-                <span>Prompt (delivered to the agent when it fires)</span>
-                <textarea
-                  value={schedulePrompt}
-                  onChange={(event) => setSchedulePrompt(event.target.value)}
-                  placeholder="What the agent should do when this fires"
-                  rows={5}
-                />
-              </label>
-
-              <div className="subagent-list">
-                {scheduleJobs.length ? (
-                  scheduleJobs.map((job) => (
-                    <div className="subagent-row" key={job.id}>
-                      <div>
-                        <strong>{job.id}</strong>
-                        <span>
-                          {job.schedule}
-                          {job.next_fire ? ` · next ${job.next_fire}` : ""}
-                          {" · "}
-                          {job.prompt.length > 80 ? `${job.prompt.slice(0, 80)}…` : job.prompt}
-                        </span>
-                      </div>
-                      <button
-                        className="icon-button"
-                        type="button"
-                        onClick={() => void cancelScheduleJob(job.id)}
-                        disabled={scheduleBusy}
-                        title="Cancel job"
-                      >
-                        <Trash2 size={16} />
-                      </button>
-                    </div>
-                  ))
-                ) : (
-                  <div className="subagent-row">
-                    <div>
-                      <strong>No scheduled jobs</strong>
-                      <span>{scheduleBackend !== "local" && scheduleBackend !== "disabled" ? `jobs may be managed remotely by ${scheduleBackend}` : "create one above"}</span>
-                    </div>
-                  </div>
-                )}
-              </div>
-              </div>
-            </section>
-          ) : null}
+          {surface === "activity" && activityTab === "schedule" ? <SchedulePanel /> : null}
 
           {surface === "system" && systemTab === "runtime" ? (
             <section className="panel stage-panel">

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -13,6 +13,7 @@ export const queryKeys = {
   telemetry: ["telemetry"] as const,
   settings: ["settings", "schema"] as const,
   inbox: ["inbox"] as const,
+  schedules: ["schedules"] as const,
 };
 
 // Goals the agent works toward (goal mode). Lives in the right sidebar and
@@ -82,4 +83,11 @@ export const inboxQuery = () =>
   queryOptions({
     queryKey: queryKeys.inbox,
     queryFn: () => api.inbox("later", false),
+  });
+
+// Scheduled jobs over the active SchedulerBackend. Invalidated on add/cancel.
+export const schedulesQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.schedules,
+    queryFn: () => api.schedules(),
   });

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -1,0 +1,142 @@
+import {
+  QueryErrorResetBoundary,
+  useMutation,
+  useQueryClient,
+  useSuspenseQuery,
+} from "@tanstack/react-query";
+import { Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Suspense, useState } from "react";
+
+import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
+import { api } from "../lib/api";
+import { queryKeys, schedulesQuery } from "../lib/queries";
+
+// Scheduled jobs (Activity → Schedule), on the TanStack Query data layer
+// (ADR 0013): the job list is a useSuspenseQuery; add/cancel are useMutations
+// that invalidate it. Loading via <Suspense>, errors via <ErrorBoundary>.
+
+function ScheduleBody() {
+  const queryClient = useQueryClient();
+  const { data, isFetching, refetch } = useSuspenseQuery(schedulesQuery());
+  const jobs = data.jobs;
+  const backend = data.backend;
+
+  const [prompt, setPrompt] = useState("");
+  const [when, setWhen] = useState("");
+  const [jobId, setJobId] = useState("");
+
+  const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.schedules });
+
+  const add = useMutation({
+    mutationFn: () =>
+      api.addSchedule({ prompt: prompt.trim(), schedule: when.trim(), job_id: jobId.trim() || undefined }),
+    onSuccess: () => {
+      setPrompt("");
+      setWhen("");
+      setJobId("");
+    },
+    onSettled: invalidate,
+  });
+  const cancel = useMutation({ mutationFn: (id: string) => api.cancelSchedule(id), onSettled: invalidate });
+
+  const busy = add.isPending || cancel.isPending;
+
+  return (
+    <>
+      <div className="panel-header">
+        <div>
+          <h1>Schedule</h1>
+          <p className="panel-kicker">{jobs.length} job{jobs.length === 1 ? "" : "s"} · {backend}</p>
+        </div>
+        <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
+          <RefreshCw size={16} className={isFetching ? "spin" : ""} />
+        </button>
+      </div>
+
+      <div className="stage-body">
+        <div className="subagent-grid">
+          <label className="field">
+            <span>When (cron or ISO datetime)</span>
+            <input
+              value={when}
+              onChange={(event) => setWhen(event.target.value)}
+              placeholder='e.g. "0 9 * * 1-5"  or  "2026-06-01T15:00:00Z"'
+            />
+          </label>
+          <label className="field">
+            <span>Job id (optional)</span>
+            <input value={jobId} onChange={(event) => setJobId(event.target.value)} placeholder="auto" />
+          </label>
+          <button
+            className="primary-button"
+            type="button"
+            onClick={() => add.mutate()}
+            disabled={busy || !prompt.trim() || !when.trim()}
+          >
+            <Plus size={16} />
+            Schedule
+          </button>
+        </div>
+        <label className="field grow">
+          <span>Prompt (delivered to the agent when it fires)</span>
+          <textarea
+            value={prompt}
+            onChange={(event) => setPrompt(event.target.value)}
+            placeholder="What the agent should do when this fires"
+            rows={5}
+          />
+        </label>
+
+        <div className="subagent-list">
+          {jobs.length ? (
+            jobs.map((job) => (
+              <div className="subagent-row" key={job.id}>
+                <div>
+                  <strong>{job.id}</strong>
+                  <span>
+                    {job.schedule}
+                    {job.next_fire ? ` · next ${job.next_fire}` : ""}
+                    {" · "}
+                    {job.prompt.length > 80 ? `${job.prompt.slice(0, 80)}…` : job.prompt}
+                  </span>
+                </div>
+                <button
+                  className="icon-button"
+                  type="button"
+                  onClick={() => cancel.mutate(job.id)}
+                  disabled={busy}
+                  title="Cancel job"
+                >
+                  <Trash2 size={16} />
+                </button>
+              </div>
+            ))
+          ) : (
+            <div className="subagent-row">
+              <div>
+                <strong>No scheduled jobs</strong>
+                <span>{backend !== "local" && backend !== "disabled" ? `jobs may be managed remotely by ${backend}` : "create one above"}</span>
+              </div>
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function SchedulePanel() {
+  return (
+    <section className="panel stage-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="schedule" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading schedule…" />}>
+              <ScheduleBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </section>
+  );
+}


### PR DESCRIPTION
Activity → Schedule, extracted from `App` into a `SchedulePanel` on the query layer.

- Job list via `useSuspenseQuery(schedulesQuery)`.
- Add/cancel via `useMutation` (invalidating the list); the create form is local state cleared on success.
- Loading → `<Suspense>`; errors → `<ErrorBoundary>`. Retires the schedule state (jobs/backend/prompt/when/jobId/busy), the 3 handlers, and the refresh-on-tab effect from `App`.

`tsc` + build clean; **39 E2E green** (navigation.spec schedule test).

Remaining on ADR 0013: just the **Runtime + Run** finale (retires App's `runtime`/`subagents`/`refreshRuntime`) — the one that touches the topbar health light + boot, so it needs a design call on suspending-at-the-shell. Will flag that before implementing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)