### PR TITLE
feat(console): migrate Run surface to TanStack Query (ADR 0013)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Run surface migrated to TanStack Query (ADR 0013).** Studio → Run extracted
+  from `App` into `RunPanel`: the subagent registry is a `useSuspenseQuery`, the
+  single/batch launch is a `useMutation`. Loading/errors via `<Suspense>` +
+  `<ErrorBoundary>`. Retires the Run form state + handlers from `App` (the
+  shell-level `runtime` read is the remaining ADR 0013 item).
 - **Schedule surface migrated to TanStack Query (ADR 0013).** Activity →
   Schedule (extracted from `App` into `SchedulePanel`) reads jobs via
   `useSuspenseQuery` and adds/cancels via `useMutation` (invalidating the list);

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -44,6 +44,7 @@ import { StatusPill } from "./StatusPill";
 import { GoalsPanel } from "./GoalsPanel";
 import { BeadsPanel } from "./BeadsPanel";
 import { SchedulePanel } from "../schedule/SchedulePanel";
+import { RunPanel } from "./RunPanel";
 import { SetupWizard } from "../setup/SetupWizard";
 
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
@@ -59,25 +60,6 @@ type ActivityTab = "thread" | "inbox" | "schedule";
 // The agent's persistent working memory, grouped in the right sidebar:
 // its notebook, its task board, and its goals.
 type RightPanel = "notes" | "beads" | "goals";
-type SubagentMode = "single" | "batch";
-
-type BatchTask = {
-  id: string;
-  type: string;
-  description: string;
-  prompt: string;
-};
-
-const sessionId = "operator-default";
-
-function createBatchTask(type = "researcher"): BatchTask {
-  return {
-    id: `batch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
-    type,
-    description: "",
-    prompt: "",
-  };
-}
 
 function createNoteTab() {
   const now = Date.now();
@@ -150,15 +132,6 @@ export function App() {
   const [status, setStatus] = useState("ready");
   const [error, setError] = useState("");
 
-  const [subagentType, setSubagentType] = useState("researcher");
-  const [subagentMode, setSubagentMode] = useState<SubagentMode>("single");
-  const [subagentDescription, setSubagentDescription] = useState("");
-  const [subagentPrompt, setSubagentPrompt] = useState("");
-  const [batchTasks, setBatchTasks] = useState<BatchTask[]>(() => [createBatchTask()]);
-  const [emitSkill, setEmitSkill] = useState(false);
-  const [subagentOutput, setSubagentOutput] = useState("");
-  const [subagentBusy, setSubagentBusy] = useState(false);
-
   const [notesBusy, setNotesBusy] = useState(false);
   const [notesDirty, setNotesDirty] = useState(false);
 
@@ -176,9 +149,6 @@ export function App() {
     ]);
     setRuntime(runtimePayload);
     setSubagents(subagentPayload.subagents);
-    if (!subagentPayload.subagents.some((item) => item.name === subagentType)) {
-      setSubagentType(subagentPayload.subagents[0]?.name || "researcher");
-    }
     return runtimePayload;
   }
 
@@ -301,54 +271,6 @@ export function App() {
   useEffect(() => {
     if (viewingInbox()) setInboxUnread(0);
   }, [surface, activityTab]);
-
-  async function runSubagent() {
-    const prompt = subagentPrompt.trim();
-    const runnableBatchTasks = batchTasks.filter((task) => task.prompt.trim());
-    if (subagentBusy) return;
-    if (subagentMode === "single" && !prompt) return;
-    if (subagentMode === "batch" && runnableBatchTasks.length === 0) return;
-    setSubagentBusy(true);
-    setError("");
-    setSubagentOutput("");
-    try {
-      const response = subagentMode === "single"
-        ? await api.runSubagent({
-            session_id: sessionId,
-            type: subagentType,
-            description: subagentDescription.trim(),
-            prompt,
-            emit_skill: emitSkill,
-          })
-        : await api.runSubagentBatch({
-            session_id: sessionId,
-            tasks: runnableBatchTasks.map((task) => ({
-              type: task.type,
-              description: task.description.trim(),
-              prompt: task.prompt.trim(),
-              emit_skill: emitSkill,
-            })),
-          });
-      setSubagentOutput(response.output);
-    } catch (exc) {
-      setError(exc instanceof Error ? exc.message : String(exc));
-    } finally {
-      setSubagentBusy(false);
-    }
-  }
-
-  function updateBatchTask(id: string, patch: Partial<BatchTask>) {
-    setBatchTasks((tasks) => tasks.map((task) => (task.id === id ? { ...task, ...patch } : task)));
-  }
-
-  function addBatchTask() {
-    setBatchTasks((tasks) => [...tasks, createBatchTask(subagentType)]);
-  }
-
-  function removeBatchTask(id: string) {
-    setBatchTasks((tasks) => (tasks.length > 1 ? tasks.filter((task) => task.id !== id) : tasks));
-  }
-
 
   function updateWorkspace(nextWorkspace: NotesWorkspace) {
     setWorkspace(nextWorkspace);
@@ -672,120 +594,7 @@ export function App() {
             <ChatSurface onError={setError} />
           ) : null}
 
-          {surface === "studio" && studioTab === "run" ? (
-            <section className="panel stage-panel">
-              <div className="panel-header">
-                <div>
-                  <h1>Run</h1>
-                  <p className="panel-kicker">one focused worker, now · {subagents.length} subagent type{subagents.length === 1 ? "" : "s"}</p>
-                </div>
-                <StatusPill label={subagentBusy ? "running" : "ready"} tone={subagentBusy ? "warning" : "muted"} />
-              </div>
-              <div className="stage-body">
-              <div className="subagent-mode segmented">
-                <button type="button" className={subagentMode === "single" ? "active" : ""} onClick={() => setSubagentMode("single")}>
-                  Single
-                </button>
-                <button type="button" className={subagentMode === "batch" ? "active" : ""} onClick={() => setSubagentMode("batch")}>
-                  Batch
-                </button>
-              </div>
-              <div className="subagent-grid">
-                <label className="field">
-                  <span>Type</span>
-                  <select value={subagentType} onChange={(event) => setSubagentType(event.target.value)}>
-                    {subagents.map((subagent) => (
-                      <option key={subagent.name} value={subagent.name}>
-                        {subagent.name}
-                      </option>
-                    ))}
-                  </select>
-                </label>
-                <label className="field">
-                  <span>Description</span>
-                  <input
-                    value={subagentDescription}
-                    onChange={(event) => setSubagentDescription(event.target.value)}
-                    placeholder="Short task label"
-                  />
-                </label>
-                <label className="checkbox-field">
-                  <input
-                    type="checkbox"
-                    checked={emitSkill}
-                    onChange={(event) => setEmitSkill(event.target.checked)}
-                  />
-                  <span>Emit skill</span>
-                </label>
-              </div>
-              {subagentMode === "single" ? (
-                <label className="field grow">
-                  <span>Prompt</span>
-                  <textarea
-                    value={subagentPrompt}
-                    onChange={(event) => setSubagentPrompt(event.target.value)}
-                    placeholder="Subagent instructions"
-                    rows={8}
-                  />
-                </label>
-              ) : (
-                <div className="batch-task-list">
-                  {batchTasks.map((task, index) => (
-                    <div className="batch-task-row" key={task.id}>
-                      <div className="batch-task-header">
-                        <span>Task {index + 1}</span>
-                        <button className="icon-button" type="button" onClick={() => removeBatchTask(task.id)} disabled={batchTasks.length === 1} title="Remove task">
-                          <Trash2 size={15} />
-                        </button>
-                      </div>
-                      <div className="batch-task-fields">
-                        <label className="field">
-                          <span>Type</span>
-                          <select value={task.type} onChange={(event) => updateBatchTask(task.id, { type: event.target.value })}>
-                            {subagents.map((subagent) => (
-                              <option key={subagent.name} value={subagent.name}>
-                                {subagent.name}
-                              </option>
-                            ))}
-                          </select>
-                        </label>
-                        <label className="field">
-                          <span>Description</span>
-                          <input value={task.description} onChange={(event) => updateBatchTask(task.id, { description: event.target.value })} placeholder="Task label" />
-                        </label>
-                      </div>
-                      <label className="field">
-                        <span>Prompt</span>
-                        <textarea value={task.prompt} onChange={(event) => updateBatchTask(task.id, { prompt: event.target.value })} rows={4} />
-                      </label>
-                    </div>
-                  ))}
-                </div>
-              )}
-              <div className="panel-actions">
-                {subagentMode === "batch" ? (
-                  <button className="secondary-button" type="button" onClick={addBatchTask}>
-                    <Plus size={15} />
-                    Add task
-                  </button>
-                ) : null}
-                <button
-                  className="primary-button"
-                  type="button"
-                  onClick={() => void runSubagent()}
-                  disabled={
-                    subagentBusy ||
-                    (subagentMode === "single" ? !subagentPrompt.trim() : !batchTasks.some((task) => task.prompt.trim()))
-                  }
-                >
-                  {subagentBusy ? <Loader2 className="spin" size={16} /> : <Play size={16} />}
-                  {subagentMode === "single" ? "Run" : "Run batch"}
-                </button>
-              </div>
-              {subagentOutput ? <pre className="output-block">{subagentOutput}</pre> : null}
-              </div>
-            </section>
-          ) : null}
+          {surface === "studio" && studioTab === "run" ? <RunPanel /> : null}
 
           {surface === "studio" && studioTab === "workflows" ? <WorkflowsSurface /> : null}
 

--- a/apps/web/src/app/RunPanel.tsx
+++ b/apps/web/src/app/RunPanel.tsx
@@ -1,0 +1,200 @@
+import { QueryErrorResetBoundary, useMutation, useSuspenseQuery } from "@tanstack/react-query";
+import { Loader2, Play, Plus, Trash2 } from "lucide-react";
+import { Suspense, useState } from "react";
+
+import { api } from "../lib/api";
+import { subagentsQuery } from "../lib/queries";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
+import { StatusPill } from "./StatusPill";
+
+// Studio → Run: launch one subagent (or a batch) manually. On the TanStack
+// Query data layer (ADR 0013): the subagent registry is a useSuspenseQuery; the
+// run is a useMutation. Form state is local.
+
+type BatchTask = { id: string; type: string; description: string; prompt: string };
+
+const sessionId = "operator-default";
+
+function createBatchTask(type = "researcher"): BatchTask {
+  return {
+    id: `batch-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+    type,
+    description: "",
+    prompt: "",
+  };
+}
+
+function RunBody() {
+  const { data } = useSuspenseQuery(subagentsQuery());
+  const subagents = data.subagents;
+
+  const [mode, setMode] = useState<"single" | "batch">("single");
+  const [type, setType] = useState("researcher");
+  const [description, setDescription] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [batchTasks, setBatchTasks] = useState<BatchTask[]>(() => [createBatchTask()]);
+  const [emitSkill, setEmitSkill] = useState(false);
+  const [output, setOutput] = useState("");
+
+  // Default the type to the first registered subagent if the current pick isn't
+  // one (e.g. the registry changed under us).
+  const typeValue = subagents.some((s) => s.name === type) ? type : subagents[0]?.name || "researcher";
+
+  const run = useMutation({
+    mutationFn: () => {
+      if (mode === "single") {
+        return api.runSubagent({
+          session_id: sessionId,
+          type: typeValue,
+          description: description.trim(),
+          prompt: prompt.trim(),
+          emit_skill: emitSkill,
+        });
+      }
+      const tasks = batchTasks
+        .filter((t) => t.prompt.trim())
+        .map((t) => ({
+          type: t.type,
+          description: t.description.trim(),
+          prompt: t.prompt.trim(),
+          emit_skill: emitSkill,
+        }));
+      return api.runSubagentBatch({ session_id: sessionId, tasks });
+    },
+    onMutate: () => setOutput(""),
+    onSuccess: (r) => setOutput(r.output),
+  });
+
+  const updateBatchTask = (id: string, patch: Partial<BatchTask>) =>
+    setBatchTasks((tasks) => tasks.map((t) => (t.id === id ? { ...t, ...patch } : t)));
+  const addBatchTask = () => setBatchTasks((tasks) => [...tasks, createBatchTask(typeValue)]);
+  const removeBatchTask = (id: string) =>
+    setBatchTasks((tasks) => (tasks.length > 1 ? tasks.filter((t) => t.id !== id) : tasks));
+
+  const canRun = mode === "single" ? Boolean(prompt.trim()) : batchTasks.some((t) => t.prompt.trim());
+
+  return (
+    <>
+      <div className="panel-header">
+        <div>
+          <h1>Run</h1>
+          <p className="panel-kicker">one focused worker, now · {subagents.length} subagent type{subagents.length === 1 ? "" : "s"}</p>
+        </div>
+        <StatusPill label={run.isPending ? "running" : "ready"} tone={run.isPending ? "warning" : "muted"} />
+      </div>
+      <div className="stage-body">
+        <div className="subagent-mode segmented">
+          <button type="button" className={mode === "single" ? "active" : ""} onClick={() => setMode("single")}>
+            Single
+          </button>
+          <button type="button" className={mode === "batch" ? "active" : ""} onClick={() => setMode("batch")}>
+            Batch
+          </button>
+        </div>
+        <div className="subagent-grid">
+          <label className="field">
+            <span>Type</span>
+            <select value={typeValue} onChange={(event) => setType(event.target.value)}>
+              {subagents.map((subagent) => (
+                <option key={subagent.name} value={subagent.name}>
+                  {subagent.name}
+                </option>
+              ))}
+            </select>
+          </label>
+          <label className="field">
+            <span>Description</span>
+            <input
+              value={description}
+              onChange={(event) => setDescription(event.target.value)}
+              placeholder="Short task label"
+            />
+          </label>
+          <label className="checkbox-field">
+            <input type="checkbox" checked={emitSkill} onChange={(event) => setEmitSkill(event.target.checked)} />
+            <span>Emit skill</span>
+          </label>
+        </div>
+        {mode === "single" ? (
+          <label className="field grow">
+            <span>Prompt</span>
+            <textarea
+              value={prompt}
+              onChange={(event) => setPrompt(event.target.value)}
+              placeholder="Subagent instructions"
+              rows={8}
+            />
+          </label>
+        ) : (
+          <div className="batch-task-list">
+            {batchTasks.map((task, index) => (
+              <div className="batch-task-row" key={task.id}>
+                <div className="batch-task-header">
+                  <span>Task {index + 1}</span>
+                  <button className="icon-button" type="button" onClick={() => removeBatchTask(task.id)} disabled={batchTasks.length === 1} title="Remove task">
+                    <Trash2 size={15} />
+                  </button>
+                </div>
+                <div className="batch-task-fields">
+                  <label className="field">
+                    <span>Type</span>
+                    <select value={task.type} onChange={(event) => updateBatchTask(task.id, { type: event.target.value })}>
+                      {subagents.map((subagent) => (
+                        <option key={subagent.name} value={subagent.name}>
+                          {subagent.name}
+                        </option>
+                      ))}
+                    </select>
+                  </label>
+                  <label className="field">
+                    <span>Description</span>
+                    <input value={task.description} onChange={(event) => updateBatchTask(task.id, { description: event.target.value })} placeholder="Task label" />
+                  </label>
+                </div>
+                <label className="field">
+                  <span>Prompt</span>
+                  <textarea value={task.prompt} onChange={(event) => updateBatchTask(task.id, { prompt: event.target.value })} rows={4} />
+                </label>
+              </div>
+            ))}
+          </div>
+        )}
+        <div className="panel-actions">
+          {mode === "batch" ? (
+            <button className="secondary-button" type="button" onClick={addBatchTask}>
+              <Plus size={15} />
+              Add task
+            </button>
+          ) : null}
+          <button
+            className="primary-button"
+            type="button"
+            onClick={() => run.mutate()}
+            disabled={run.isPending || !canRun}
+          >
+            {run.isPending ? <Loader2 className="spin" size={16} /> : <Play size={16} />}
+            {mode === "single" ? "Run" : "Run batch"}
+          </button>
+        </div>
+        {run.isError ? <p className="workflow-failed">{(run.error as Error).message}</p> : null}
+        {output ? <pre className="output-block">{output}</pre> : null}
+      </div>
+    </>
+  );
+}
+
+export function RunPanel() {
+  return (
+    <section className="panel stage-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="subagents" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading subagents…" />}>
+              <RunBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </section>
+  );
+}


### PR DESCRIPTION
First half of the **Runtime + Run** finale. Studio → Run extracted from `App` into `RunPanel` on the query layer.

- Subagent registry via `useSuspenseQuery(subagentsQuery)`.
- Single/batch launch via `useMutation`; errors surface inline.
- Loading → `<Suspense>`; errors → `<ErrorBoundary>`. Form + batch state local to `RunPanel`.
- Retires the Run state/handlers from `App`; `refreshRuntime` no longer defaults `subagentType`.

`App` still holds `runtime`/`subagents` for the still-inline Runtime panel + topbar — **PR B** extracts the Runtime panel and converts the shell-level `runtime` to a non-suspense `useQuery` (the agreed approach), retiring that state + the boot-probe.

`tsc` + build clean; **39 E2E green** (navigation Studio→Run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)