### PR TITLE
fix(desktop): bundle A2A 1.0 deps in the frozen sidecar

### DIFF
--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -48,6 +48,15 @@ COLLECT_ALL = [
     "ddgs",
     "langfuse",
     "croniter",
+    # A2A 1.0 (ADR 0014): the SDK + the protoLabs conventions layer (git-dep).
+    # Both pull submodules/metadata that a bare import-scan misses — without a
+    # full collect, the frozen `protolabs_a2a` is missing `build_agent_card`.
+    "a2a",
+    "protolabs_a2a",
+    # a2a-sdk[sqlite] durable task/push stores: imported lazily by the SDK, so
+    # the import-scan misses them — collect explicitly.
+    "aiosqlite",
+    "sqlalchemy",
 ]
 
 # Gradio (and the chat_ui module that imports it) is dead weight in headless


### PR DESCRIPTION
After the A2A 1.0 migration (#453/#462), the PyInstaller sidecar booted but crashed at the A2A mount: `module 'protolabs_a2a' has no attribute 'build_agent_card'`, then `No module named 'aiosqlite'`. The import-scan misses `a2a-sdk` + the `protolabs_a2a` git-dep submodules and the lazily-imported SQLite-store deps.

Adds to `--collect-all`: `a2a`, `protolabs_a2a`, `aiosqlite`, `sqlalchemy`. Verified the frozen binary now serves `/.well-known/agent-card.json` (all four fleet extensions) and inits the durable task/push stores. Desktop-build only (CI doesn't freeze).

🤖 Generated with [Claude Code](https://claude.com/claude-code)