### PR TITLE
fix(a2a): advertise a reachable agent-card interface URL

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A2A agent card advertises a reachable interface URL.** The card's
+  `supportedInterfaces[].url` was built from `f"{agent_name()}:7870"` — i.e. the
+  *agent name* as the hostname plus a hardcoded port (`http://Gina:7870/a2a`),
+  unreachable for any peer and wrong for the dynamic-port desktop sidecar. It's
+  now `_a2a_card_url()`: an explicit **`A2A_PUBLIC_URL`** (set this for deployed
+  agents — the real external base) or, unset, the actually-bound loopback port
+  (`http://127.0.0.1:<port>/a2a`, correct for local/desktop).
+
 ### Changed
 - **Runtime surface + shell runtime read migrated — ADR 0013 console-wide
   migration complete.** System → Runtime extracted into `RuntimePanel`

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -33,6 +33,12 @@ Setup without the wizard: `python server.py --setup` validates the live config (
 
 When unset, the handler logs a WARNING at startup (`"A2A auth token not configured — endpoint is open"`) and accepts all traffic — appropriate for local development, not production. When set, the agent card advertises `securitySchemes.bearer` so A2A consumers know to present credentials.
 
+## A2A agent-card endpoint
+
+| Variable | Default | What |
+|---|---|---|
+| `A2A_PUBLIC_URL` | (unset — `http://127.0.0.1:<bound-port>`) | The externally-reachable base URL advertised in the agent card's `supportedInterfaces[].url` (where peers send `message/send`). **Set this for any deployed agent** — behind a proxy / in a container the bound port isn't the address clients use. The `/a2a` JSON-RPC suffix is appended automatically (e.g. `A2A_PUBLIC_URL=https://gina.example.com` → card url `https://gina.example.com/a2a`). Unset, it falls back to the actually-bound loopback port (correct for local + the dynamic-port desktop sidecar, where the caller is on the same host). |
+
 This is independent of the legacy `<AGENT_NAME>_API_KEY` header-based scheme (X-API-Key) documented above. You can enable one, both, or neither; bearer is the preferred mechanism going forward.
 
 ## Memory

--- a/server.py
+++ b/server.py
@@ -1826,7 +1826,24 @@ def _package_version() -> str:
     return "0.0.0"
 
 
-def _build_agent_card_proto(host: str):
+def _a2a_card_url() -> str:
+    """The reachable JSON-RPC endpoint to advertise in the A2A card's interface.
+
+    The card tells other agents *where to send* ``message/send``, so this must
+    be the agent's externally-reachable address — not the bind host. Prefer an
+    explicit ``A2A_PUBLIC_URL`` (set this for any deployed agent: behind a proxy
+    / in a container the public address isn't the bound port). Fall back to the
+    actually-bound loopback port (``_active_port``) for local + desktop runs —
+    correct there because the client is on the same host (and the desktop's port
+    is dynamic). The ``/a2a`` suffix is the JSON-RPC route.
+    """
+    base = (os.environ.get("A2A_PUBLIC_URL") or "").strip().rstrip("/")
+    if not base:
+        base = f"http://127.0.0.1:{_active_port}"
+    return f"{base}/a2a"
+
+
+def _build_agent_card_proto():
     """Build the A2A 1.0 ``AgentCard`` (proto) served at
     ``/.well-known/agent-card.json``, applying the protoLabs fleet conventions
     via ``protolabs_a2a.build_agent_card``.
@@ -1837,8 +1854,9 @@ def _build_agent_card_proto(host: str):
     — this template emits cost-v1 + confidence-v1 from ``_chat_langgraph_stream``
     and worldstate-delta / tool-call when a tool reports them.
 
-    The card ``url`` must target the JSON-RPC endpoint (``/a2a``), NOT the server
-    root — clients send ``message/send`` to whatever the interface url says.
+    The interface ``url`` (``_a2a_card_url``) targets the JSON-RPC endpoint
+    (``/a2a``) at the agent's reachable address — set ``A2A_PUBLIC_URL`` when
+    deployed; otherwise it's the bound loopback port.
     """
     import protolabs_a2a as pa
 
@@ -1848,7 +1866,7 @@ def _build_agent_card_proto(host: str):
             "protoAgent template — A2A 1.0 LangGraph agent. "
             "Replace this description with your agent's actual purpose."
         ),
-        url=f"http://{host}/a2a",
+        url=_a2a_card_url(),
         version=_package_version(),
         skills=_agent_skills(),
         bearer=_bearer_configured(),
@@ -2720,7 +2738,7 @@ def _main():
         allowed_origins_raw=os.environ.get("A2A_ALLOWED_ORIGINS", ""),
     )
 
-    a2a_card = _build_agent_card_proto(f"{agent_name()}:7870")
+    a2a_card = _build_agent_card_proto()
 
     # Durable SQLite-backed task + push-config stores (survive restart; 24h TTL
     # sweep on tasks). The push-config store rejects SSRF callback URLs at

--- a/tests/test_a2a_integration.py
+++ b/tests/test_a2a_integration.py
@@ -24,7 +24,9 @@ from google.protobuf.json_format import MessageToDict
 def _card_json(monkeypatch=None, *, bearer_token: str | None = None) -> dict:
     from server import _build_agent_card_proto
 
-    card = _build_agent_card_proto("protoagent:7870")
+    # The interface url derives from A2A_PUBLIC_URL or the bound port (no host
+    # arg) — _build_agent_card_proto() takes no parameters.
+    card = _build_agent_card_proto()
     return MessageToDict(card, preserving_proto_field_name=False)
 
 
@@ -41,6 +43,15 @@ def test_agent_card_jsonrpc_interface_points_at_rpc_endpoint() -> None:
     jsonrpc = next(i for i in ifaces if i["protocolBinding"] == "JSONRPC")
     assert jsonrpc["url"].endswith("/a2a")
     assert jsonrpc["protocolVersion"] == "1.0"
+
+
+def test_agent_card_url_honors_public_url_env(monkeypatch) -> None:
+    """A2A_PUBLIC_URL overrides the interface url (deployed agents advertise
+    their real external base, not the bound loopback port)."""
+    monkeypatch.setenv("A2A_PUBLIC_URL", "https://gina.example.com/")
+    card = _card_json()
+    jsonrpc = next(i for i in card["supportedInterfaces"] if i["protocolBinding"] == "JSONRPC")
+    assert jsonrpc["url"] == "https://gina.example.com/a2a"
 
 
 def test_agent_card_provider_is_fleet_provider() -> None:


### PR DESCRIPTION
## The bug
The A2A card's `supportedInterfaces[].url` was built from `f"{agent_name()}:7870"` — the **agent name** as the hostname plus a hardcoded `7870`, e.g. `http://Gina:7870/a2a`. Unreachable for any peer discovering the agent, and wrong for the dynamic-port desktop sidecar (real port e.g. `51177`). (The card *structure* is correct 1.0 — the endpoint is in `supportedInterfaces[].url`, not the deprecated top-level `url`.)

## Fix
`_a2a_card_url()`: prefer an explicit **`A2A_PUBLIC_URL`** (set this for deployed agents — behind a proxy/container the bound port isn't the public address), else fall back to the actually-bound loopback port (`_active_port` → `http://127.0.0.1:<port>/a2a`), which is correct for local + desktop (caller is on the same host). `/a2a` suffix appended automatically.

Documented `A2A_PUBLIC_URL` in env-vars; CHANGELOG. The library `build_agent_card` test is unaffected (it passes an explicit url). a2a tests green (44).

🤖 Generated with [Claude Code](https://claude.com/claude-code)