### PR TITLE
fix(scheduler): A2A 1.0 loopback wire shape — scheduled fires were rejected (#477)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Scheduled jobs fire again on A2A 1.0 (#477).** `LocalScheduler._fire`'s
+  loopback POST to the agent's own `/a2a` was still 0.3-shaped, so the a2a-sdk
+  1.1 handler rejected every scheduled fire (`-32009 VERSION_NOT_SUPPORTED`,
+  then `Method not found`). Now sends the 1.0 wire shape: `A2A-Version: 1.0`
+  header, method `SendMessage`, `role: ROLE_USER`, `parts: [{text}]`, with
+  `contextId` + scheduler `metadata` on the message. Regression test
+  `test_fire_emits_a2a_1_0_wire_shape` locks the shape (existing tests only
+  covered scheduling logic and missed it). Fleet-wide — same fix as protoPen #144.
 - **A2A agent card advertises a reachable interface URL.** The card's
   `supportedInterfaces[].url` was built from `f"{agent_name()}:7870"` — i.e. the
   *agent name* as the hostname plus a hardcoded port (`http://Gina:7870/a2a`),

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -439,7 +439,14 @@ class LocalScheduler:
         """
         import httpx
 
-        headers = {"Content-Type": "application/json"}
+        # A2A 1.0 wire shape (ADR 0014 / #477). The loopback POSTs to the agent's
+        # own a2a-sdk 1.1 handler, which rejects 0.3-shaped requests:
+        #   - `A2A-Version: 1.0` header (else -32009 VERSION_NOT_SUPPORTED)
+        #   - method `SendMessage` (the proto RPC name; 0.3's `message/send` →
+        #     Method not found)
+        #   - `role: ROLE_USER`, `parts: [{"text": …}]`, and contextId + metadata
+        #     live ON the message (not at params level).
+        headers = {"Content-Type": "application/json", "A2A-Version": "1.0"}
         if self._bearer:
             headers["Authorization"] = f"Bearer {self._bearer}"
         if self._api_key:
@@ -449,25 +456,24 @@ class LocalScheduler:
         body = {
             "jsonrpc": "2.0",
             "id": message_id,
-            "method": "message/send",
+            "method": "SendMessage",
             "params": {
-                # Route into the durable Activity thread (ADR 0003) so the
-                # fired turn lands somewhere visible/continuable instead of a
-                # throwaway context. Without this, the agent mints a fresh
-                # context per fire and the response surfaces nowhere.
-                "contextId": ACTIVITY_CONTEXT,
                 "message": {
-                    "role": "user",
-                    "parts": [{"kind": "text", "text": job.prompt}],
+                    "role": "ROLE_USER",
+                    "parts": [{"text": job.prompt}],
                     "messageId": message_id,
-                },
-                # Scheduler bookkeeping for this fire, sent as params.metadata
-                # per the A2A message/send shape (origin + job id). These keys
-                # are informational — the handler does not require them.
-                "metadata": {
-                    "scheduler_job_id": job.id,
-                    "scheduler_kind": "local",
-                    "origin": "scheduler",
+                    # Route into the durable Activity thread (ADR 0003) so the
+                    # fired turn lands somewhere visible/continuable instead of a
+                    # throwaway context. Without this, the agent mints a fresh
+                    # context per fire and the response surfaces nowhere.
+                    "contextId": ACTIVITY_CONTEXT,
+                    # Scheduler bookkeeping for this fire (origin + job id) —
+                    # informational; the handler doesn't require these keys.
+                    "metadata": {
+                        "scheduler_job_id": job.id,
+                        "scheduler_kind": "local",
+                        "origin": "scheduler",
+                    },
                 },
             },
         }

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -291,11 +291,12 @@ async def test_due_job_fires(tmp_path, monkeypatch):
     assert s.list_jobs() == []
 
     # Fires route into the durable Activity thread (ADR 0003) so the response
-    # surfaces, with an origin tag for the activity surface.
+    # surfaces, with an origin tag for the activity surface. A2A 1.0: contextId +
+    # metadata live on the message (#477).
     call = next(c for c in fired if "FIRED-ME" in str(c["json"]))
-    params = call["json"]["params"]
-    assert params["contextId"] == "system:activity"
-    assert params["metadata"]["origin"] == "scheduler"
+    msg = call["json"]["params"]["message"]
+    assert msg["contextId"] == "system:activity"
+    assert msg["metadata"]["origin"] == "scheduler"
 
 
 @pytest.mark.asyncio
@@ -413,3 +414,53 @@ def test_workstacean_opt_in_without_creds_falls_back_local(monkeypatch):
     monkeypatch.delenv("SCHEDULER_DISABLED", raising=False)
 
     assert isinstance(server._build_scheduler(cfg), LocalScheduler)
+
+
+# ── A2A 1.0 loopback wire shape (#477) ───────────────────────────────────────
+
+
+class _CaptureClient:
+    """Stub for httpx.AsyncClient that records the single POST _fire makes."""
+
+    def __init__(self):
+        self.url = self.headers = self.json = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def post(self, url, headers=None, json=None):
+        self.url, self.headers, self.json = url, headers, json
+        return type("R", (), {"status_code": 200, "text": "ok"})()
+
+
+@pytest.mark.asyncio
+async def test_fire_emits_a2a_1_0_wire_shape(tmp_path, monkeypatch):
+    """_fire must POST the A2A 1.0 shape (the sidecar's a2a-sdk 1.1 handler
+    rejects 0.3): A2A-Version header, SendMessage, ROLE_USER, parts:[{text}],
+    contextId + metadata ON the message. Regresses #477."""
+    import httpx
+
+    from events import ACTIVITY_CONTEXT
+
+    cap = _CaptureClient()
+    monkeypatch.setattr(httpx, "AsyncClient", lambda *a, **k: cap)
+
+    s = _make_scheduler(tmp_path)
+    job = s.add_job("do the thing", "0 9 * * *")
+    assert await s._fire(job) is True
+
+    assert cap.headers["A2A-Version"] == "1.0"
+    assert cap.url.endswith("/a2a")
+
+    body = cap.json
+    assert body["method"] == "SendMessage"          # not 0.3 "message/send"
+    assert "contextId" not in body["params"]          # moved onto the message
+    msg = body["params"]["message"]
+    assert msg["role"] == "ROLE_USER"                 # not "user"
+    assert msg["parts"] == [{"text": "do the thing"}] # not [{"kind":"text",...}]
+    assert msg["contextId"] == ACTIVITY_CONTEXT
+    assert msg["metadata"]["scheduler_job_id"] == job.id
+    assert msg["metadata"]["origin"] == "scheduler"


### PR DESCRIPTION
Closes #477.

`LocalScheduler._fire` POSTed a **0.3-shaped** JSON-RPC to the agent's own `/a2a`, so after the A2A 1.0 migration the a2a-sdk 1.1 handler **rejected every scheduled fire** (`-32009 VERSION_NOT_SUPPORTED`, then `Method not found`).

Fix — the verified 1.0 shape (same as protoPen #144):
- header `A2A-Version: 1.0`
- method `SendMessage` (not `message/send`)
- `role: ROLE_USER`, `parts: [{text}]` (not `[{kind:text,text}]`)
- `contextId` + scheduler `metadata` move **onto the message** (not params level)

Adds `test_fire_emits_a2a_1_0_wire_shape` (stub `httpx.AsyncClient`, assert the shape + no 0.3 leftovers); updates `test_due_job_fires` to read `contextId`/`metadata` off the message. Full suite **874 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)