### PR TITLE
feat(a2a): structured-skill declaration scaffolding (#476, protoAgent side)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Structured-skill declaration scaffolding (#476, protoAgent side).** A skill
+  spec (`_SKILL_SPECS`) may declare an `output_schema` (JSON Schema) +
+  `result_mime`; `_agent_skills()` then advertises the MIME in that skill's
+  card `output_modes` (the A2A-native way), and `structured_skill_schema(id)`
+  hands the schema to the executor's forthcoming forced-tool-call finalizer.
+  The schema lives in the skill config (not the card — `AgentSkill` has no
+  schema field). No schema ⇒ free text (unchanged). The forced-tool-call
+  enforcement + `emit_skill_result` DataPart land once the shared
+  `protolabs_a2a` helper exists; this is the non-blocking declaration/card half.
+
 ### Fixed
 - **Scheduled jobs fire again on A2A 1.0 (#477).** `LocalScheduler._fire`'s
   loopback POST to the agent's own `/a2a` was still 0.3-shaped, so the a2a-sdk

--- a/server.py
+++ b/server.py
@@ -1780,20 +1780,62 @@ def _bearer_configured() -> bool:
     return bool(os.environ.get("A2A_AUTH_TOKEN", "") or (_graph_config and _graph_config.auth_token))
 
 
+# Skill declarations (ADR-0006 addendum / #476). A skill MAY declare an
+# ``output_schema`` (JSON Schema) + ``result_mime`` — when present, the agent
+# enforces the schema via a forced-tool-call finalizer in the executor and emits
+# the result as a typed DataPart (``protolabs_a2a.emit_skill_result``), and the
+# card advertises the MIME in that skill's ``output_modes``. No schema ⇒ free
+# text (today's default). The schema lives HERE (skill config), not on the card
+# — ``AgentSkill`` only carries ``output_modes`` (the MIME), per the A2A spec.
+#
+# REPLACE when forking. The template ships one free-text placeholder so a fresh
+# clone is callable; the commented fields below show a structured skill.
+_SKILL_SPECS: list[dict] = [
+    {
+        "id": "chat",
+        "name": "Chat",
+        "description": "General-purpose chat interface. Replace with your agent's real skills.",
+        "tags": ["template"],
+        "examples": ["hello", "what can you do?"],
+        # To make a skill return schema-enforced structured output, add:
+        #   "output_schema": {"type": "object", "properties": {...}, "required": [...]},
+        #   "result_mime": "application/vnd.protolabs.<your-skill>-v1+json",
+    },
+]
+
+
 def _agent_skills():
-    """The agent's A2A skills. REPLACE when forking — the template ships one
-    placeholder ``chat`` skill so a fresh clone is callable."""
+    """Build the card's ``AgentSkill`` list from ``_SKILL_SPECS``. A spec with a
+    ``result_mime`` advertises it in ``output_modes`` (the A2A-native way to tell
+    consumers the skill emits that structured type)."""
     from a2a.types import AgentSkill
 
-    return [
-        AgentSkill(
-            id="chat",
-            name="Chat",
-            description="General-purpose chat interface. Replace with your agent's real skills.",
-            tags=["template"],
-            examples=["hello", "what can you do?"],
-        ),
-    ]
+    skills = []
+    for s in _SKILL_SPECS:
+        kwargs = dict(
+            id=s["id"],
+            name=s["name"],
+            description=s["description"],
+            tags=s.get("tags", []),
+            examples=s.get("examples", []),
+        )
+        if s.get("result_mime"):
+            kwargs["output_modes"] = [s["result_mime"]]
+        skills.append(AgentSkill(**kwargs))
+    return skills
+
+
+def structured_skill_schema(skill_id: str) -> dict | None:
+    """For a skill that declares structured output, return
+    ``{"schema": <JSON Schema>, "mime": <result_mime>}``; else ``None`` (free
+    text). The executor's structured finalizer (#476) reads this to run the
+    forced-tool-call against the schema and emit the validated object as a
+    ``result_mime`` DataPart. The schema isn't on the card (``AgentSkill`` has no
+    schema field) — it lives in ``_SKILL_SPECS``."""
+    for s in _SKILL_SPECS:
+        if s["id"] == skill_id and s.get("output_schema") and s.get("result_mime"):
+            return {"schema": s["output_schema"], "mime": s["result_mime"]}
+    return None
 
 
 def _package_version() -> str:

--- a/tests/test_a2a_integration.py
+++ b/tests/test_a2a_integration.py
@@ -126,3 +126,32 @@ def test_agent_card_declares_cost_v1_extension() -> None:
 
     exts = _card_json()["capabilities"].get("extensions", [])
     assert any(e.get("uri") == pa.COST_EXT_URI for e in exts)
+
+
+# ── structured-skill declaration (ADR-0006 addendum / #476, protoAgent side) ──
+
+
+def test_structured_skill_advertises_mime_and_exposes_schema(monkeypatch) -> None:
+    """A skill declaring output_schema + result_mime advertises the MIME in the
+    card's output_modes, and structured_skill_schema() hands the executor the
+    schema to enforce. Free-text skills stay None (default)."""
+    import server
+
+    mime = "application/vnd.protolabs.market-review-v1+json"
+    schema = {"type": "object", "properties": {"verdict": {"type": "string"}}, "required": ["verdict"]}
+    monkeypatch.setattr(server, "_SKILL_SPECS", [{
+        "id": "market_review", "name": "Market Review", "description": "d",
+        "tags": [], "examples": [], "output_schema": schema, "result_mime": mime,
+    }])
+
+    skill = MessageToDict(server._agent_skills()[0])
+    assert skill["outputModes"] == [mime]                 # advertised on the card
+    got = server.structured_skill_schema("market_review")  # schema for the executor
+    assert got == {"schema": schema, "mime": mime}
+
+    # A skill with no schema → free text (no output_modes, no lookup).
+    monkeypatch.setattr(server, "_SKILL_SPECS", [{
+        "id": "chat", "name": "Chat", "description": "d", "tags": [], "examples": [],
+    }])
+    assert "outputModes" not in MessageToDict(server._agent_skills()[0])
+    assert server.structured_skill_schema("chat") is None


### PR DESCRIPTION
The **non-blocking half** of #476 — the declaration + card wiring the executor finalizer plugs into once `protolabs_a2a`'s `emit_skill_result` lands (jon's team owns that shared helper).

Per the locked ADR-0006 addendum (transport A2A-native + shared; enforcement runtime-local):
- **`_SKILL_SPECS`** — a skill may declare `output_schema` (JSON Schema) + `result_mime`.
- **`_agent_skills()`** advertises `result_mime` in the card skill's `output_modes` (the A2A-native structured-output advertisement). The schema stays in skill config — `AgentSkill` has no schema field.
- **`structured_skill_schema(id)`** → `{schema, mime} | None` — the lookup the executor's forced-tool-call finalizer reads.
- Template still ships one free-text placeholder (`chat`); a commented example shows a structured skill.

**Out of scope (lands with the shared helper):** the forced-tool-call finalizer + `emit_skill_result` DataPart — runtime-local, wires in once `protolabs_a2a` exists.

Test covers declaration → `output_modes` + schema lookup (free-text → None). Full suite **875 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)