### PR TITLE
chore(a2a): bump protolabs-a2a to v0.2.0 (structured-skill conventions)

### DIFF
--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -14,7 +14,7 @@ a2a-sdk[http-server,fastapi,sqlite]>=1.1
 # schemes that keep every fleet agent interoperable byte-for-byte. Consumed from
 # the public published repo (single source of truth, no vendored copy). The repo
 # is public so the Docker build needs no auth to clone it.
-protolabs-a2a @ git+https://github.com/protoLabsAI/protolabs-a2a.git@v0.1.0
+protolabs-a2a @ git+https://github.com/protoLabsAI/protolabs-a2a.git@v0.2.0
 # Web framework for the API / A2A / operator routes (server.py, operator_api/).
 # Previously satisfied only transitively via Gradio — but the lean tiers
 # (--ui none/console) drop Gradio (requirements-ui.txt), so the lean image had


### PR DESCRIPTION
Bumps the git-dep pin `v0.1.0 → v0.2.0` (protolabs-a2a#1, merged + tagged). v0.2.0 adds the **LLM-free** structured-skill API — `submit_skill_tool` / `skill_tool_name` / `validate_skill_args` / `skill_result_mime` / `emit_skill_result` / `parse_skill_result` — that the protoAgent executor finalizer (#476) binds against.

Backward-compatible: the existing A2A 1.0 path is unchanged; full suite **875 pass**. This is the gating bump before wiring the finalizer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)