### PR TITLE
feat(a2a): structured-skill executor finalizer + request-metadata fix (#476)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Structured-skill executor finalizer (#476).** Completes the protoAgent side
+  of schema-enforced skill outputs. When a turn carries a `skillHint` for a
+  skill that declares an `output_schema`, the `ProtoAgentExecutor` runs a
+  forced-tool-call finalizer (`graph/structured_skill.py`:
+  `create_llm(...).bind_tools([submit_skill_tool(id, schema)], tool_choice=…)`
+  → `validate_skill_args` → one repair → `emit_skill_result`) and appends the
+  validated object as a typed DataPart alongside the text (degrades to text-only
+  on failure). Uses the shared `protolabs_a2a` v0.2.0 helpers (LLM-free wire
+  layer); enforcement is runtime-local per ADR-0006. Mirrors jon's live-proven
+  reference.
 - **Structured-skill declaration scaffolding (#476, protoAgent side).** A skill
   spec (`_SKILL_SPECS`) may declare an `output_schema` (JSON Schema) +
   `result_mime`; `_agent_skills()` then advertises the MIME in that skill's
@@ -23,6 +33,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `protolabs_a2a` helper exists; this is the non-blocking declaration/card half.
 
 ### Fixed
+- **A2A request-level metadata was being dropped (trace + skill dispatch).**
+  `_extract_caller_trace` read only `context.message.metadata`, missing
+  `SendMessageRequest`-level `context.metadata` — where clients (the hub) put
+  `a2a.trace` and `skillHint`. New `_request_metadata()` merges request-level
+  (preferred) over message-level, fixing Langfuse cross-trace propagation and
+  enabling the structured-skill dispatch. Found via jon's reference; fleet-wide
+  correctness win.
 - **Scheduled jobs fire again on A2A 1.0 (#477).** `LocalScheduler._fire`'s
   loopback POST to the agent's own `/a2a` was still 0.3-shaped, so the a2a-sdk
   1.1 handler rejected every scheduled fire (`-32009 VERSION_NOT_SUPPORTED`,

--- a/a2a_executor.py
+++ b/a2a_executor.py
@@ -144,11 +144,34 @@ class ProtoAgentExecutor(AgentExecutor):
     def __init__(
         self,
         stream_fn_factory: Callable[..., AsyncGenerator[tuple[str, Any], None]],
+        structured_finalizer: Callable[[str, str], Any] | None = None,
     ) -> None:
         # ``stream_fn_factory(text, context_id, *, resume, caller_trace)`` →
         # async generator of (event_type, payload). This is protoAgent's
         # ``_chat_langgraph_stream``.
         self._stream_factory = stream_fn_factory
+        # ``structured_finalizer(skill_id, final_text)`` → an emit DataPart dict
+        # or None (#476). Injected by server.py so the executor stays decoupled
+        # from the skill registry (no circular import).
+        self._structured_finalizer = structured_finalizer
+
+    async def _append_structured(
+        self, parts: list[Part], context: RequestContext, final_text: str
+    ) -> list[Part]:
+        """If the turn targets a structured skill (``skillHint`` + a declared
+        schema), append the schema-enforced result as a DataPart (#476). No-op
+        otherwise; a finalizer error degrades to the text-only parts."""
+        if self._structured_finalizer is None or not final_text:
+            return parts
+        skill = _extract_skill_hint(context)
+        if not skill:
+            return parts
+        try:
+            emit = await self._structured_finalizer(skill, final_text)
+        except Exception:  # noqa: BLE001
+            logger.exception("[structured] finalizer raised for skill %s", skill)
+            return parts
+        return [*parts, _ext_data_part(emit)] if emit else parts
 
     async def execute(self, context: RequestContext, event_queue: EventQueue) -> None:
         updater = TaskUpdater(event_queue, context.task_id, context.context_id)
@@ -258,6 +281,7 @@ class ProtoAgentExecutor(AgentExecutor):
                         final_text, deltas, usage if had_usage else None,
                         cost_usd, confidence, confidence_expl, success=True,
                     )
+                    parts = await self._append_structured(parts, context, final_text)
                     if parts:
                         await updater.add_artifact(parts, last_chunk=True)
                     await updater.complete()
@@ -277,6 +301,7 @@ class ProtoAgentExecutor(AgentExecutor):
                 accumulated, deltas, usage if had_usage else None,
                 cost_usd, confidence, confidence_expl, success=True,
             )
+            parts = await self._append_structured(parts, context, accumulated)
             if parts:
                 await updater.add_artifact(parts, last_chunk=True)
             await updater.complete()
@@ -304,18 +329,43 @@ def _is_input_required(task: Any) -> bool:
         return False
 
 
+def _request_metadata(context: RequestContext) -> dict:
+    """Merged A2A request metadata: message-level (fallback) overlaid by
+    request-level (preferred). The a2a-sdk surfaces ``SendMessageRequest``-level
+    metadata on ``context.metadata`` (a dict) — that's where clients (e.g. the
+    hub) put routing keys like ``skillHint`` + ``a2a.trace``, so request-level
+    must win. Reading only ``context.message.metadata`` silently misses all of
+    it (the latent bug found via jon's reference)."""
+    merged: dict = {}
+    msg = getattr(context, "message", None)
+    if msg is not None and getattr(msg, "metadata", None):
+        try:
+            merged.update(json_format.MessageToDict(msg.metadata))
+        except Exception:  # noqa: BLE001
+            pass
+    req = getattr(context, "metadata", None)
+    if isinstance(req, dict):
+        merged.update(req)
+    elif req is not None:
+        try:
+            merged.update(json_format.MessageToDict(req))
+        except Exception:  # noqa: BLE001
+            pass
+    return merged
+
+
 def _extract_caller_trace(context: RequestContext) -> dict:
-    """Pull the ``a2a.trace`` metadata off the inbound message (Langfuse
-    cross-trace propagation), or {} when absent."""
-    msg = context.message
-    if msg is None:
-        return {}
-    try:
-        meta = json_format.MessageToDict(msg.metadata) if msg.metadata else {}
-    except Exception:  # noqa: BLE001
-        return {}
-    trace = meta.get("a2a.trace")
+    """The ``a2a.trace`` metadata (Langfuse cross-trace propagation), or {}."""
+    trace = _request_metadata(context).get("a2a.trace")
     return trace if isinstance(trace, dict) else {}
+
+
+def _extract_skill_hint(context: RequestContext) -> str:
+    """The ``skillHint`` the caller set to invoke a specific skill — the
+    structured-finalizer dispatch (A2A has no skill field on the message).
+    '' when absent."""
+    hint = _request_metadata(context).get("skillHint")
+    return hint if isinstance(hint, str) else ""
 
 
 def _tool_call_part(event_type: str, payload: Any) -> Part | None:

--- a/graph/structured_skill.py
+++ b/graph/structured_skill.py
@@ -1,0 +1,79 @@
+"""Forced-tool-call finalizer for schema-enforced skill outputs.
+
+The runtime-local half of the structured-skill design (ADR-0006 addendum /
+#476): the lead agent reasons freely and produces a text answer; when the turn
+is for a skill that declares an ``output_schema``, this finalizer reshapes that
+answer into the schema via a **forced tool call** (the provider-agnostic
+generation primitive — ``response_format`` is unreliable across our model zoo),
+validates it, repairs once, and returns the ``protolabs_a2a`` DataPart emit dict.
+Returns ``None`` to degrade to text-only (the schema isn't enforceable this turn).
+
+Enforcement lives here (not in ``protolabs_a2a``) because it's our LLM stack —
+``protolabs_a2a`` stays the wire/convention layer (``submit_skill_tool`` builds
+the tool spec, ``validate_skill_args``/``emit_skill_result`` are pure). Mirrors
+jon's reference executor pattern so the fleet's Python runtimes stay consistent.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+async def finalize_structured(
+    skill_id: str,
+    schema: dict[str, Any],
+    mime: str,
+    answer_text: str,
+    config: Any,
+) -> dict[str, Any] | None:
+    """Reshape ``answer_text`` into ``schema`` via a forced ``submit_<skill>``
+    tool call; validate + one repair; return the ``emit_skill_result`` DataPart
+    dict, or ``None`` (degrade to text-only)."""
+    import protolabs_a2a as pa
+
+    from graph.llm import create_llm
+
+    tool = pa.submit_skill_tool(skill_id, schema)
+    name = pa.skill_tool_name(skill_id)
+    # bind the SHARED tool spec (not LangChain with_structured_output, which would
+    # build its own tool — we want the fleet-wide submit_<skill> convention) and
+    # force tool_choice onto it.
+    llm = create_llm(config).bind_tools([tool], tool_choice=name)
+
+    system = (
+        f"You are finalizing the result of the '{skill_id}' skill. Reshape the "
+        f"answer below into the structured result by calling the {name} tool — "
+        f"fill every required field from the answer, and do not invent facts."
+    )
+    messages: list = [("system", system), ("human", answer_text)]
+
+    async def _call(msgs: list) -> Any | None:
+        try:
+            resp = await llm.ainvoke(msgs)
+        except Exception:  # noqa: BLE001 — any failure ⇒ degrade to text-only
+            logger.exception("[structured] %s finalize call failed", skill_id)
+            return None
+        calls = getattr(resp, "tool_calls", None) or []
+        return calls[0]["args"] if calls else None
+
+    args = await _call(messages)
+    if args is None:
+        return None
+
+    errors = pa.validate_skill_args(args, schema)
+    if errors:
+        repair = (
+            "human",
+            "That result was invalid:\n- "
+            + "\n- ".join(errors)
+            + f"\nCall {name} again with every required field present and corrected.",
+        )
+        args = await _call([*messages, repair])
+        if args is None or pa.validate_skill_args(args, schema):
+            logger.warning("[structured] %s still invalid after repair — text-only", skill_id)
+            return None
+
+    return pa.emit_skill_result(args, mime)

--- a/server.py
+++ b/server.py
@@ -2789,9 +2789,21 @@ def _main():
     asyncio.run(initialize_a2a_stores(task_store, push_config_store))
     log.info("[a2a] durable stores ready (tasks=%s, push=%s)", task_db, push_db)
 
+    async def _structured_finalizer(skill_id: str, final_text: str):
+        """Enforce a declared skill's output_schema on the lead's free-text
+        answer + emit it as a DataPart (#476). None ⇒ text-only. Closes over the
+        skill registry so the executor needn't import server (no circular dep)."""
+        spec = structured_skill_schema(skill_id)
+        if not spec:
+            return None
+        from graph.structured_skill import finalize_structured
+        return await finalize_structured(
+            skill_id, spec["schema"], spec["mime"], final_text, _graph_config
+        )
+
     _a2a_push_client = httpx.AsyncClient(timeout=30)
     a2a_request_handler = DefaultRequestHandler(
-        agent_executor=ProtoAgentExecutor(_chat_langgraph_stream),
+        agent_executor=ProtoAgentExecutor(_chat_langgraph_stream, structured_finalizer=_structured_finalizer),
         task_store=task_store,
         agent_card=a2a_card,
         push_config_store=push_config_store,

--- a/tests/test_structured_skill.py
+++ b/tests/test_structured_skill.py
@@ -1,0 +1,114 @@
+"""Tests for the structured-skill finalizer (ADR-0006 addendum / #476).
+
+The forced-tool-call loop is exercised with a mocked LLM (the real
+``protolabs_a2a`` helpers do the tool-spec + validate + DataPart). The metadata
+dispatch (request-level skillHint, the latent bug fix) is covered separately.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+import protolabs_a2a as pa
+from a2a_executor import _extract_caller_trace, _extract_skill_hint, _request_metadata
+from graph.structured_skill import finalize_structured
+
+_SCHEMA = {
+    "type": "object",
+    "properties": {"verdict": {"type": "string"}},
+    "required": ["verdict"],
+}
+_MIME = "application/vnd.protolabs.market-review-v1+json"
+
+
+class _Bound:
+    """A bound LLM that replays a queue of tool-call args (None ⇒ no tool call)."""
+
+    def __init__(self, replies):
+        self._replies = list(replies)
+        self.calls = 0
+
+    async def ainvoke(self, msgs):
+        self.calls += 1
+        args = self._replies.pop(0)
+        tc = [] if args is None else [{"name": "submit_x", "args": args, "id": "1"}]
+        return type("Resp", (), {"tool_calls": tc})()
+
+
+class _LLM:
+    def __init__(self, bound):
+        self._bound = bound
+
+    def bind_tools(self, tools, tool_choice=None):
+        return self._bound
+
+
+def _patch_llm(monkeypatch, bound):
+    monkeypatch.setattr("graph.llm.create_llm", lambda cfg, **k: _LLM(bound))
+
+
+@pytest.mark.asyncio
+async def test_valid_first_call_emits_datapart(monkeypatch):
+    bound = _Bound([{"verdict": "reject"}])
+    _patch_llm(monkeypatch, bound)
+    part = await finalize_structured("market_review", _SCHEMA, _MIME, "…reject…", config=None)
+    assert bound.calls == 1
+    assert pa.parse_skill_result(part, _MIME) == {"verdict": "reject"}  # roundtrips by MIME
+
+
+@pytest.mark.asyncio
+async def test_invalid_then_repaired(monkeypatch):
+    bound = _Bound([{}, {"verdict": "approve"}])  # missing required → repair → valid
+    _patch_llm(monkeypatch, bound)
+    part = await finalize_structured("market_review", _SCHEMA, _MIME, "…", config=None)
+    assert bound.calls == 2
+    assert pa.parse_skill_result(part, _MIME) == {"verdict": "approve"}
+
+
+@pytest.mark.asyncio
+async def test_invalid_twice_degrades_to_none(monkeypatch):
+    bound = _Bound([{}, {}])  # invalid both times → text-only
+    _patch_llm(monkeypatch, bound)
+    assert await finalize_structured("market_review", _SCHEMA, _MIME, "…", config=None) is None
+    assert bound.calls == 2
+
+
+@pytest.mark.asyncio
+async def test_no_tool_call_degrades_to_none(monkeypatch):
+    bound = _Bound([None])  # model didn't call the tool
+    _patch_llm(monkeypatch, bound)
+    assert await finalize_structured("market_review", _SCHEMA, _MIME, "…", config=None) is None
+
+
+# ── metadata dispatch (the latent bug: request-level was being missed) ────────
+
+
+def _ctx(*, request_meta=None, message_meta=None):
+    msg = None
+    if message_meta is not None:
+        msg = type("Msg", (), {"metadata": message_meta})()
+    return type("Ctx", (), {"metadata": request_meta, "message": msg})()
+
+
+def test_skill_hint_read_from_request_level_metadata():
+    # The hub puts skillHint at the request level — message-level only would miss it.
+    ctx = _ctx(request_meta={"skillHint": "market_review"}, message_meta=None)
+    assert _extract_skill_hint(ctx) == "market_review"
+
+
+def test_request_level_overrides_message_level():
+    ctx = _ctx(request_meta={"skillHint": "req"}, message_meta=None)
+    # message-level is a proto Struct in practice; a missing/None one is the
+    # common case. Request-level still resolves.
+    assert _request_metadata(ctx)["skillHint"] == "req"
+    assert _extract_skill_hint(ctx) == "req"
+
+
+def test_no_skill_hint_returns_empty():
+    assert _extract_skill_hint(_ctx(request_meta={}, message_meta=None)) == ""
+    assert _extract_skill_hint(_ctx(request_meta=None, message_meta=None)) == ""
+
+
+def test_caller_trace_reads_request_level():
+    ctx = _ctx(request_meta={"a2a.trace": {"traceId": "abc"}}, message_meta=None)
+    assert _extract_caller_trace(ctx) == {"traceId": "abc"}


### PR DESCRIPTION
Completes the **protoAgent side of #476**, mirroring jon's live-proven reference. Lands the runtime-local enforcement half (the shared `protolabs_a2a` v0.2.0 helpers + the #479 declaration half were already in).

## Finalizer
- **`graph/structured_skill.py`** — `finalize_structured()`: `create_llm().bind_tools([submit_skill_tool(id, schema)], tool_choice=name)` → `validate_skill_args` → **one repair** → `emit_skill_result`. The lead reasons freely; the finalizer reshapes its text answer into the schema. Binds the **shared `submit_<skill>` spec** (not LangChain `with_structured_output`, per the alignment note on workstacean#758). `None` ⇒ text-only.
- **`a2a_executor.py`** — `ProtoAgentExecutor` gains an injected `structured_finalizer`; both terminal paths (`done` + stream-end) append the schema-enforced DataPart when the turn's `skillHint` maps to a declared schema.
- **`server.py`** — `_structured_finalizer` closure (looks up `structured_skill_schema` + calls the finalizer), injected into the executor — no circular import.

## The latent bug jon flagged — fixed (fleet-wide correctness)
`_extract_caller_trace` read **only** `context.message.metadata`, dropping request-level `context.metadata` — where the hub's JS client puts `a2a.trace` **and** `skillHint`. So trace propagation was silently broken and the finalizer would never fire. New **`_request_metadata()`** merges request-level (preferred) over message-level. Mirrors jon's `_request_metadata()`.

## Dispatch convention
`skill_id = skillHint` from request metadata (jon's pinned-down convention) — A2A has no skill field on the message.

Tests: finalizer loop (valid / repair / give-up / no-tool-call, mocked LLM) + the request-level metadata dispatch. Full suite **883 pass**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)