### PR TITLE
fix(a2a): caller bearer token authoritative + origin guard browser-only (#482)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `protolabs_a2a` helper exists; this is the non-blocking declaration/card half.
 
 ### Fixed
+- **A2A auth: caller bearer token is authoritative + origin guard is browser-only (#482).**
+  Two `a2a_auth.py` correctness bugs (found via CodeRabbit on protoPen's port,
+  fixed there in protoPen#145). (1) `configure()` collapsed `bearer_token` with
+  the env fallback (`bearer_token or A2A_AUTH_TOKEN`), so an apiKey-only agent
+  passing `""` would silently enable bearer auth from a stray env var the card
+  never advertises — now only `None` (unspecified) falls back; an explicit `""`
+  means bearer-off. (2) The origin allowlist rejected requests with **no**
+  `Origin` header, blocking server-to-server callers (the hub, the scheduler
+  loopback) — `Origin` is browser-only, so the guard now fires only when an
+  `Origin` is actually present. protoAgent's install site maps its `""` default
+  to `None` so the documented `A2A_AUTH_TOKEN` env path is preserved (no
+  regression). New `tests/test_a2a_auth.py` pins both.
 - **A2A request-level metadata was being dropped (trace + skill dispatch).**
   `_extract_caller_trace` read only `context.message.metadata`, missing
   `SendMessageRequest`-level `context.metadata` — where clients (the hub) put

--- a/a2a_auth.py
+++ b/a2a_auth.py
@@ -48,13 +48,18 @@ def configure(*, bearer_token: str | None, api_key: str, allowed_origins_raw: st
     """Seed the guard at route-registration time.
 
     Args:
-        bearer_token: from YAML ``auth.token`` (``A2A_AUTH_TOKEN`` env fallback
-            applied by the caller). Empty/whitespace → open mode.
+        bearer_token: from YAML ``auth.token``. The caller is authoritative:
+            ``None`` means "unspecified" and falls back to ``A2A_AUTH_TOKEN``;
+            an explicit ``""`` means "bearer off" (e.g. an apiKey-only agent)
+            and does NOT fall back — otherwise a stray env var would silently
+            enable bearer auth the card never advertises. Empty/whitespace →
+            open mode.
         api_key: the ``<AGENT>_API_KEY`` value; "" disables the X-API-Key check.
         allowed_origins_raw: ``A2A_ALLOWED_ORIGINS`` value ("" = disabled,
             "*" = disabled, else comma-separated allowlist).
     """
-    seed = (bearer_token or os.environ.get("A2A_AUTH_TOKEN", "") or "").strip()
+    raw_bearer = bearer_token if bearer_token is not None else os.environ.get("A2A_AUTH_TOKEN", "")
+    seed = (raw_bearer or "").strip()
     _BEARER[0] = seed or None
     if _BEARER[0] is None:
         logger.warning("[a2a] A2A auth token not configured — endpoint is open")
@@ -96,11 +101,14 @@ class A2AAuthMiddleware(BaseHTTPMiddleware):
             if not hmac.compare_digest(header[len("Bearer "):], active):
                 return _unauthorized("Unauthorized: invalid bearer token")
 
-        # Origin — enforced only when an allowlist is set.
+        # Origin — enforced only when an allowlist is set AND an Origin is
+        # present. Origin is a browser-only header; server-to-server callers
+        # (the hub, the LocalScheduler loopback) send none and must not be
+        # rejected for it.
         allowed = _ALLOWED_ORIGINS[0]
         if allowed is not None:
-            origin = request.headers.get("Origin", "").lower()
-            if origin not in allowed:
+            origin = request.headers.get("Origin")
+            if origin is not None and origin.lower() not in allowed:
                 return JSONResponse({"detail": "Forbidden: origin not allowed"}, status_code=403)
 
         return await call_next(request)

--- a/server.py
+++ b/server.py
@@ -2773,9 +2773,14 @@ def _main():
     # Request-time auth + origin enforcement (a2a-sdk advertises schemes on the
     # card but does not enforce them). Bearer = YAML auth.token / A2A_AUTH_TOKEN;
     # X-API-Key = <AGENT>_API_KEY; origin = A2A_ALLOWED_ORIGINS.
+    #
+    # ``auth_token`` defaults to "" when no YAML/secret token is set — collapse
+    # that to ``None`` so configure() applies the documented A2A_AUTH_TOKEN env
+    # fallback. (configure() treats an explicit "" as "bearer off, no fallback";
+    # protoAgent has no separate apiKey-only flag, so unset ⇒ env, not off.)
     a2a_auth.install(
         fastapi_app,
-        bearer_token=(_graph_config.auth_token if _graph_config else ""),
+        bearer_token=((_graph_config.auth_token if _graph_config else "") or None),
         api_key=os.environ.get(f"{AGENT_NAME_ENV.upper()}_API_KEY", ""),
         allowed_origins_raw=os.environ.get("A2A_ALLOWED_ORIGINS", ""),
     )

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -1,0 +1,98 @@
+"""Tests for the A2A auth/origin middleware (#482).
+
+Two correctness fixes, each pinned here:
+
+1. ``configure(bearer_token=...)`` is authoritative — only ``None`` falls back
+   to ``A2A_AUTH_TOKEN``; an explicit ``""`` keeps bearer off even if the env
+   var is set (an apiKey-only agent must not silently enable bearer auth its
+   card never advertises).
+2. The origin guard only fires when an ``Origin`` header is actually present —
+   server-to-server callers (hub, scheduler loopback) send none and must pass.
+"""
+
+from __future__ import annotations
+
+import pytest
+from starlette.applications import Starlette
+from starlette.responses import PlainTextResponse
+from starlette.routing import Route
+from starlette.testclient import TestClient
+
+import a2a_auth
+
+
+@pytest.fixture(autouse=True)
+def _reset_guard():
+    """Each test seeds the guard itself; reset module state around it."""
+    a2a_auth._BEARER[0] = None
+    a2a_auth._API_KEY[0] = ""
+    a2a_auth._ALLOWED_ORIGINS[0] = None
+    yield
+    a2a_auth._BEARER[0] = None
+    a2a_auth._API_KEY[0] = ""
+    a2a_auth._ALLOWED_ORIGINS[0] = None
+
+
+def _client() -> TestClient:
+    app = Starlette(routes=[Route("/a2a", lambda r: PlainTextResponse("ok"), methods=["POST"])])
+    app.add_middleware(a2a_auth.A2AAuthMiddleware)
+    return TestClient(app)
+
+
+# ── 1. bearer_token is authoritative ─────────────────────────────────────────
+
+
+def test_empty_bearer_does_not_fall_back_to_env(monkeypatch):
+    # apiKey-only agent passes "" explicitly; a stray env var must NOT turn bearer on.
+    monkeypatch.setenv("A2A_AUTH_TOKEN", "env-secret")
+    a2a_auth.configure(bearer_token="", api_key="", allowed_origins_raw="")
+    assert a2a_auth._BEARER[0] is None
+    # endpoint is open for bearer — no Authorization header still succeeds.
+    assert _client().post("/a2a").status_code == 200
+
+
+def test_none_bearer_falls_back_to_env(monkeypatch):
+    monkeypatch.setenv("A2A_AUTH_TOKEN", "env-secret")
+    a2a_auth.configure(bearer_token=None, api_key="", allowed_origins_raw="")
+    assert a2a_auth._BEARER[0] == "env-secret"
+    c = _client()
+    assert c.post("/a2a").status_code == 401  # missing header
+    assert c.post("/a2a", headers={"Authorization": "Bearer env-secret"}).status_code == 200
+
+
+def test_explicit_bearer_wins_over_env(monkeypatch):
+    monkeypatch.setenv("A2A_AUTH_TOKEN", "env-secret")
+    a2a_auth.configure(bearer_token="yaml-secret", api_key="", allowed_origins_raw="")
+    assert a2a_auth._BEARER[0] == "yaml-secret"
+
+
+def test_no_bearer_no_env_is_open_mode(monkeypatch):
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    a2a_auth.configure(bearer_token=None, api_key="", allowed_origins_raw="")
+    assert a2a_auth._BEARER[0] is None
+
+
+# ── 2. origin guard is browser-only (header-less callers pass) ────────────────
+
+
+def test_origin_guard_allows_header_less_caller():
+    a2a_auth.configure(bearer_token="", api_key="", allowed_origins_raw="https://app.example")
+    # server-to-server: no Origin header → must pass (was a 403 before the fix).
+    assert _client().post("/a2a").status_code == 200
+
+
+def test_origin_guard_allows_listed_origin():
+    a2a_auth.configure(bearer_token="", api_key="", allowed_origins_raw="https://app.example")
+    r = _client().post("/a2a", headers={"Origin": "https://app.example"})
+    assert r.status_code == 200
+
+
+def test_origin_guard_rejects_unlisted_origin():
+    a2a_auth.configure(bearer_token="", api_key="", allowed_origins_raw="https://app.example")
+    r = _client().post("/a2a", headers={"Origin": "https://evil.example"})
+    assert r.status_code == 403
+
+
+def test_origin_guard_disabled_when_unset():
+    a2a_auth.configure(bearer_token="", api_key="", allowed_origins_raw="")
+    assert _client().post("/a2a", headers={"Origin": "https://anything.example"}).status_code == 200


### PR DESCRIPTION
Closes #482. Two `a2a_auth.py` correctness bugs found via CodeRabbit on protoPen's port of this module (protoAgent's copy is the source). Fixed on protoPen in protoLabsAI/protoPen#145; ported here with tests.

## 1. Caller bearer token is authoritative
`configure()` did `bearer_token or os.environ.get("A2A_AUTH_TOKEN", …)`, so a caller passing `""` (an apiKey-only agent whose card advertises apiKey only) would still fall back to `A2A_AUTH_TOKEN` — silently enabling bearer auth the card never advertises. Now only `None` (unspecified) uses the env fallback; an explicit `""` means bearer-off.

```python
raw_bearer = bearer_token if bearer_token is not None else os.environ.get("A2A_AUTH_TOKEN", "")
seed = (raw_bearer or "").strip()
```

## 2. Origin guard is browser-only
When `A2A_ALLOWED_ORIGINS` is set, the dispatch rejected requests with **no** `Origin` header — but `Origin` is a browser-only header, and server-to-server callers (the hub, the `LocalScheduler` loopback) send none. The guard now fires only when an `Origin` is actually present:

```python
origin = request.headers.get("Origin")
if origin is not None and origin.lower() not in allowed:
    return JSONResponse({"detail": "Forbidden: origin not allowed"}, status_code=403)
```

## protoAgent integration (no regression)
`graph/config.py` defaults `auth_token: str = ""` (never `None`), and protoAgent's documented behavior is "YAML `auth.token`, else `A2A_AUTH_TOKEN` env" — protoAgent has no separate apiKey-only flag. So the `install()` site maps its `""` default to `None`, keeping the env-fallback path intact while `configure()` itself is now correct for callers (like protoPen) that *do* want to express bearer-off:

```python
bearer_token=((_graph_config.auth_token if _graph_config else "") or None)
```

## Tests
New `tests/test_a2a_auth.py` (8 cases): `""` does not fall back to env, `None` does, explicit token wins, header-less caller passes the origin guard, listed/unlisted origins, guard disabled when unset. Full suite **891 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)