### PR TITLE
chore: release v0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-06-02
+
 ### Added
 - **Structured-skill executor finalizer (#476).** Completes the protoAgent side
   of schema-enforced skill outputs. When a turn carries a `skillHint` for a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.9.0"
+version = "0.10.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
Automated version bump to `v0.10.0`. Review + merge through the normal CI/review gate, then dispatch release.yml (tag `v0.10.0`) to tag main and cut the release.