### PR TITLE
docs: fix stale release instructions (push-tag, not dispatch)

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -4,10 +4,10 @@ name: 'Prepare Release'
 # pyproject.toml, rolls CHANGELOG.md [Unreleased] → the new version, opens a
 # prepare-release/vX.Y.Z branch, and commits it as "chore: release vX.Y.Z".
 # It does NOT merge or tag — a human merges the bump PR through the normal
-# CI/review gate, then dispatches release.yml (tag vX.Y.Z) which builds the
-# stable semver Docker image, creates the GitHub release, and posts notes to
-# Discord. We do not auto-merge (fleet policy, 2026-06-02: auto-merge fires
-# on stale SHAs + breaks stacked PRs).
+# CI/review gate, then pushes the tag vX.Y.Z. That tag push (release.yml runs
+# on: push tags) builds the stable semver Docker image, creates the GitHub
+# release, and posts notes to Discord. We do not auto-merge (fleet policy,
+# 2026-06-02: auto-merge fires on stale SHAs + breaks stacked PRs).
 #
 # Releases are deliberately NOT cut on every merge — pick the bump level and
 # run this when a batch is ready. See docs/guides/releasing.md.
@@ -45,9 +45,9 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          # GH_PAT required (not GITHUB_TOKEN) so the tag push at the end
-          # of this job can trigger release.yml — the default token can't
-          # fire downstream workflows.
+          # GH_PAT required (not GITHUB_TOKEN) so the release-branch push
+          # below fires the PR's CI checks — the default token can't trigger
+          # downstream workflows on pushes it makes.
           token: ${{ secrets.GH_PAT }}
 
       - uses: actions/setup-python@v5
@@ -96,12 +96,20 @@ jobs:
             --base main \
             --head "${BRANCH}" \
             --title "chore: release v${VERSION}" \
-            --body "Automated version bump to \`v${VERSION}\`. Review + merge through the normal CI/review gate, then dispatch release.yml (tag \`v${VERSION}\`) to tag main and cut the release.")
+            --body "Automated version bump to \`v${VERSION}\`. Review + merge through the normal CI/review gate, then push the tag to cut the release:
+
+\`\`\`sh
+git checkout main && git pull
+git tag -a v${VERSION} -m \"Release v${VERSION}\" && git push origin v${VERSION}
+\`\`\`
+
+The tag push triggers release.yml (Docker tags + GitHub Release + Discord). Don't \`workflow_dispatch\` release.yml afterward — that's redundant and 422s on the duplicate.")
           echo "Opened: ${PR_URL}"
 
           # We do NOT auto-merge or tag here (fleet policy, 2026-06-02:
           # auto-merge fires on stale SHAs + breaks stacked PRs). A human
-          # merges this bump PR through the normal CI/review gate, then
-          # dispatches release.yml with tag v${VERSION} to tag main and
-          # cut the GitHub release + Discord notes.
-          echo "Next: review + merge that PR (we do not auto-merge), then run release.yml (tag v${VERSION})."
+          # merges this bump PR through the normal CI/review gate, then pushes
+          # the tag v${VERSION} — the push (on: push tags) triggers release.yml,
+          # which cuts the GitHub release + Docker tags + Discord notes. Do NOT
+          # also workflow_dispatch release.yml (redundant; 422s on duplicate).
+          echo "Next: review + merge that PR (we do not auto-merge), then push tag v${VERSION} to cut the release."

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Docs
+- **Fix stale release instructions.** `docs/guides/releasing.md` + the
+  `prepare-release.yml` header/PR-body/comments said the release was cut by
+  *dispatching* `release.yml` (and implied Prepare Release auto-merges +
+  auto-tags). Both are wrong since the 2026-06-02 no-auto-merge/tag policy:
+  Prepare Release only opens the bump PR; a human merges it and **pushes the
+  tag**, which is what triggers `release.yml` (`on: push: tags`). Dispatching it
+  by hand afterward is redundant and 422s on the duplicate release. The release
+  PR body now prints the exact `git tag … && git push` to run.
+
 ## [0.10.0] - 2026-06-02
 
 ### Added

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -11,12 +11,12 @@ feature PR (adds a CHANGELOG [Unreleased] entry)  ──▶  merge to main
                                                           │
 run "Prepare Release" (workflow_dispatch, pick bump) ◀────┘
    │  bumps pyproject.toml + rolls CHANGELOG.md
-   │  opens chore: release vX.Y.Z PR → auto-merges when the 3 checks pass
+   │  opens chore: release vX.Y.Z PR   (does NOT merge or tag)
    ▼
-pushes tag vX.Y.Z  ──▶  Release workflow:
-                          • builds + pushes the semver Docker tags
-                          • creates the GitHub Release (notes minus chore/docs)
-                          • posts notes to Discord (release-tools)
+you merge the PR (CI green)  ──▶  you push tag vX.Y.Z  ──▶  Release workflow (on: push tag):
+                                                              • builds + pushes the semver Docker tags
+                                                              • creates the GitHub Release (notes minus chore/docs)
+                                                              • posts notes to Discord (release-tools)
 ```
 
 `latest` Docker tag is pushed on every `main` merge by `docker-publish.yml` —
@@ -24,14 +24,30 @@ independent of releases.
 
 ## Cutting a release
 
-1. **Actions → Prepare Release → Run workflow.**
-2. Choose the **bump**: `patch` (default) · `minor` · `major`. Use `dry_run`
-   to preview the version + changelog/​pyproject diff without opening a PR.
-3. The workflow bumps the version, rolls the changelog, opens
-   `chore: release vX.Y.Z`, and auto-merges once the required checks pass, then
-   tags `vX.Y.Z` — which triggers the **Release** workflow.
+1. **Actions → Prepare Release → Run workflow.** Choose the **bump**: `patch`
+   (default) · `minor` · `major`. Use `dry_run` to preview the version +
+   changelog/​pyproject diff without opening a PR.
+2. The workflow bumps the version, rolls the changelog, and opens
+   `chore: release vX.Y.Z`. It **does not merge or tag** — that's deliberate
+   (fleet policy: auto-merge fired on stale SHAs and broke stacked PRs).
+3. **Merge the release PR** once the three checks pass (squash).
+4. **Push the tag** on the merged release commit — this is what triggers the
+   release:
+   ```sh
+   git checkout main && git pull
+   git tag -a vX.Y.Z -m "Release vX.Y.Z" && git push origin vX.Y.Z
+   ```
+   `release.yml` runs `on: push: tags: 'v*.*.*'` → builds + pushes the semver
+   Docker tags, creates the GitHub Release, and posts to Discord.
 
-That's it. Don't bump `pyproject.toml` or tag by hand — the workflow owns both.
+> **Don't also dispatch the Release workflow by hand after pushing the tag.**
+> The tag push already triggers it; a manual `workflow_dispatch` is redundant
+> and fails with `422 Release.tag_name already exists` (it leaves a harmless red
+> ✗ in Actions — the `[push]`-triggered run is the real one). The dispatch
+> trigger exists only to *re-run* a release against a tag that already exists.
+
+Don't bump `pyproject.toml` by hand — Prepare Release owns the version. You do
+push the tag by hand (step 4); that tag push is the release trigger.
 
 ## The changelog protocol
 
@@ -66,6 +82,6 @@ a reviewer — the gate is CI, not human review.
 
 | Secret | Used by | Purpose |
 |---|---|---|
-| `GH_PAT` | `prepare-release.yml` | A PAT (not `GITHUB_TOKEN`) so the tag push can trigger the downstream Release workflow. |
+| `GH_PAT` | `prepare-release.yml` | A PAT (not `GITHUB_TOKEN`) so the release-branch push fires the PR's CI checks — the default token can't trigger workflows on its own pushes. (The release tag is pushed by a human, so it triggers `release.yml` normally.) |
 | `GATEWAY_API_KEY` | `release.yml` (release-tools) | Rewrites the commit range into themed release notes via the protoLabs gateway. |
 | `DISCORD_RELEASE_WEBHOOK` | `release.yml` (release-tools) | Posts the release embed to Discord. **Optional** — the step is `continue-on-error`, so releases still succeed without it; set it to enable the Discord post. |


### PR DESCRIPTION
Follow-up to v0.10.0. The release docs + workflow told operators to cut a release by **dispatching `release.yml`**, and implied Prepare Release **auto-merges + auto-tags**. Both are stale since the 2026-06-02 no-auto-merge/tag policy — and the dispatch path actively misleads: it 422s on a duplicate because the tag push already triggers the release (`release.yml` runs `on: push: tags`).

### Fixed wording
- **`docs/guides/releasing.md`** — flow diagram + steps now: Prepare Release opens the bump PR only → you merge → you **push the tag** (exact `git tag -a … && git push origin vX.Y.Z`) → that triggers `release.yml`. Added a callout: don't `workflow_dispatch` it afterward (redundant, 422s; the dispatch trigger is only to *re-run* against an existing tag). `GH_PAT` row corrected (gates the release-branch push for CI, not a tag push).
- **`.github/workflows/prepare-release.yml`** — header comment, the **release-PR body** (now prints the exact tag-push commands an operator runs at merge time), and the trailing comment/echo all corrected. GH_PAT checkout comment fixed (it pushes a *branch*, not a tag).

Pure docs/comments — no behavior change. Verified against the actual v0.9.0/v0.10.0 runs (the `[push]`-triggered `release.yml` run is the real one; the manual dispatch left the harmless red ✗).

🤖 Generated with [Claude Code](https://claude.com/claude-code)