### PR TITLE
docs: add committed internal dev-docs area (docs/dev/)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Docs
+- **Internal dev-docs area (`docs/dev/`).** A committed, team-shared home for
+  engineering working-context that isn't user-facing docs or a durable ADR:
+  `docs/dev/handoffs/` (dated session handoffs) + `docs/dev/notes/` (engineering
+  logs / investigations). Excluded from the published VitePress site via
+  `srcExclude: ["dev/**"]` (build verified — it doesn't render or ship to the
+  site). `docs/dev/README.md` documents the convention and how it relates to
+  ADRs, the gitignored local `HANDOFF.md`, and agent memory. Seeded with the
+  v0.10.0 handoff and a roxy upstream-sync playbook.
 - **Fix stale release instructions.** `docs/guides/releasing.md` + the
   `prepare-release.yml` header/PR-body/comments said the release was cut by
   *dispatching* `release.yml` (and implied Prepare Release auto-merges +

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -14,6 +14,10 @@ export default defineConfig({
   // VitePress treats dead links as fatal, so skip just the localhost ones.
   ignoreDeadLinks: "localhostLinks",
 
+  // docs/dev/ is the team's internal engineering area (handoffs + notes) — it
+  // lives in the repo (committed, shared) but is NOT part of the published site.
+  srcExclude: ["dev/**"],
+
   head: [["link", { rel: "icon", href: "/protoAgent/favicon.svg" }]],
 
   themeConfig: {

--- a/docs/dev/README.md
+++ b/docs/dev/README.md
@@ -1,0 +1,31 @@
+# Internal dev docs
+
+Team-internal engineering notes for protoAgent. **Committed and shared** (so a
+teammate or an agent on another machine gets them on `git pull`), but **excluded
+from the published docs site** (`srcExclude: ["dev/**"]` in
+`docs/.vitepress/config.mts`) — this is working context, not user-facing docs.
+
+## What goes where
+
+| Location | Purpose | Audience |
+|---|---|---|
+| **`docs/dev/handoffs/`** | Dated session handoffs — "here's where things stand, pick up from here." | Whoever works next (human or agent) |
+| **`docs/dev/notes/`** | Engineering logs / investigations — "why is this weird," debugging trails, design scratch that isn't yet an ADR. | Whoever hits the same thing |
+| `docs/adr/` | Durable **architecture decisions** (numbered, published). | Forkers + the world |
+| `docs/guides/`, `tutorials/`, … | User-facing docs (published). | People using the template |
+| `HANDOFF.md` (repo root, **gitignored**) | Live local scratchpad for the *current* session. | Just you, this machine |
+| `~/.claude/.../memory/` | The agent's cross-session memory (private, auto-loaded). | The agent |
+
+## Conventions
+
+- **Handoffs:** `docs/dev/handoffs/YYYY-MM-DD-<slug>.md`. At the end of a work
+  block, snapshot the live `HANDOFF.md` into a dated file here and commit it.
+  Keep `HANDOFF.md` (gitignored) as the always-current working copy; the dated
+  files here are the shared archive.
+- **Notes:** `docs/dev/notes/<topic>.md`. One topic per file. If a note
+  hardens into a decision, promote it to an ADR and leave a pointer.
+- **Don't** put secrets, tokens, or live config here — it's committed and ships
+  to forks. (Forkers can delete `docs/dev/` wholesale; it's our notes, not
+  theirs.)
+- This area is **not** part of `npm run docs:build` output — it won't render on
+  the site or break the build.

--- a/docs/dev/handoffs/2026-06-02-v0.10.0-release.md
+++ b/docs/dev/handoffs/2026-06-02-v0.10.0-release.md
@@ -1,0 +1,31 @@
+# Handoff — 2026-06-02 (v0.10.0 release)
+
+_Snapshot of `HANDOFF.md` at the end of this work block. `main` @ v0.10.0,
+clean & synced._
+
+## State
+- **`main` @ v0.10.0**, working tree clean, no leftover branches. **0 open PRs, 0 open issues.**
+- v0.10.0 released today — Docker `0.10.0`/`0.10`/`latest` on ghcr, GitHub Release + Discord posted. Fresh empty `CHANGELOG [Unreleased]`.
+- No protoAgent processes running (one unrelated `protomaker` vite preview on :3007 — not ours).
+
+## Shipped this session
+| Ref | What |
+|---|---|
+| roxy#27 | roxy inherited the #476 structured-skill machinery |
+| #483 | A2A auth fix — caller bearer authoritative + origin guard browser-only (closed #482) |
+| #484 | release v0.10.0 |
+| #485 | fixed stale release docs (push-the-tag, not dispatch) |
+| closed | #159/#362/#443 (stale); #476 + protoMaker#4056 (#476 initiative done fleet-wide) |
+
+v0.10.0 headline: full A2A 1.0 migration polish + console-wide TanStack-Query migration (ADR 0013 complete) + structured-skill finalizer (#476) + auth fix (#482).
+
+## Outstanding
+- **#476 structured-output initiative fully wrapped fleet-wide** (protoAgent + TS/hub #756 + jon live emitter + roxy). protoMaker dropped A2A → consumer #4056 closed obsolete.
+- No blocked work, no pending reviews, no open decisions.
+- Watch item: **Node 20 deprecation** in GitHub Actions (~2026-06-16) — bump `actions/*` in the workflows.
+
+## Gotchas
+1. **Releasing:** Prepare Release opens the bump PR only (no auto-merge/tag). Merge it, then `git tag -a vX.Y.Z && git push origin vX.Y.Z` — the **tag push** triggers `release.yml`. Don't also `workflow_dispatch` it (422s on the duplicate). See `docs/guides/releasing.md`.
+2. **roxy** is a self-maintained fork (`origin/main` protected; PR-based sync). See [notes/roxy-upstream-sync.md](../notes/roxy-upstream-sync.md). Still on the old `a2a_auth.py` → inherits #482 on next sync.
+3. **protoMaker is out of the A2A picture** (A2A removed there).
+4. **Secrets** in `config/secrets.yaml` (gitignored) — never commit/echo. Notes surface has a `LIVEPING-…` canary — don't transmit externally.

--- a/docs/dev/notes/roxy-upstream-sync.md
+++ b/docs/dev/notes/roxy-upstream-sync.md
@@ -1,0 +1,56 @@
+# Note: syncing roxy from upstream protoAgent
+
+**Topic:** operational playbook for porting protoAgent work into the roxy fork.
+**Status:** current as of 2026-06-02 (roxy caught up through #476 via roxy#27).
+
+## What roxy is
+
+`protoLabsAI/roxy` is a **manual fork** of protoAgent (a ProtoMaker portfolio
+manager — monitor + unblock, not code). It's **self-maintained** by its own
+agent/fleet: `origin/main` is **protected** (PR-based, no direct push), it has
+its own changelog narrative (last release `[0.8.0]`, does NOT carry protoAgent's
+version headers), and its own PR series (#1–#27+).
+
+Remotes in `~/dev/roxy`: `origin` = roxy, `upstream` = protoAgent.
+
+## The sync procedure
+
+1. **Fetch origin first — the local clone goes stale.** `~/dev/roxy` lagged
+   `origin/main` by ~20 commits in one case; a stale local main produces a
+   divergent merge you can't push.
+   ```sh
+   cd ~/dev/roxy && git fetch origin && git fetch upstream
+   ```
+2. Check the real delta: `git log --oneline origin/main..upstream/main`.
+3. Branch off **origin/main** (not local main) and merge upstream:
+   ```sh
+   git checkout -b chore/sync-upstream-<x> origin/main
+   git merge upstream/main
+   ```
+4. Resolve conflicts (hotspots below), run tests, open a PR against roxy, merge.
+
+## Conflict hotspots
+
+- **`server.py` — `_SKILL_SPECS` / `_agent_skills()`.** protoAgent's
+  `_agent_skills()` is spec-driven off `_SKILL_SPECS`. roxy must **keep its own 5
+  PM skills** (`portfolio_sitrep` / `board_sweep` / `project_decompose` /
+  `unblock_feature` / `chat`) in `_SKILL_SPECS` while adopting upstream's
+  machinery. They're free-text (no `output_schema`) for now — declaring a schema
+  later turns on the #476 finalizer with no further wiring.
+- **`CHANGELOG.md` — `[Unreleased]`.** roxy keeps its own narrative. Take **only
+  the genuinely-new entries** (from `git log origin/main..upstream/main`), merge
+  them into roxy's existing `[Unreleased]` sections. **Do not** import
+  protoAgent's `## [X.Y.Z]` version headers.
+
+## Running roxy's tests without its own venv
+
+roxy shares deps with protoAgent; the protoAgent venv has the needed packages:
+```sh
+PYTHONPATH=~/dev/roxy ~/dev/protoAgent/.venv/bin/python -m pytest -q
+```
+
+## Known follow-up
+
+roxy still runs the **old `a2a_auth.py`** (pre-#482). It'll inherit the
+caller-authoritative-bearer + browser-only-origin fix on its next upstream sync.
+Not urgent.


### PR DESCRIPTION
Adds a committed, team-shared home for internal engineering working-context — the gap between durable ADRs (published) and the gitignored, machine-local `HANDOFF.md`.

### What
- **`docs/dev/`** — committed (so a teammate or an agent on another machine gets it on `git pull`), but **excluded from the published VitePress site** via `srcExclude: ["dev/**"]`. It's working context, not user-facing docs.
  - `docs/dev/README.md` — the convention + how it relates to ADRs, `HANDOFF.md`, and agent memory.
  - `docs/dev/handoffs/` — dated session handoffs (seeded with `2026-06-02-v0.10.0-release.md`).
  - `docs/dev/notes/` — engineering logs / investigations (seeded with `roxy-upstream-sync.md`, the operational playbook that bit us today and isn't in the public docs).

### The doc layers now
| Layer | Committed? | Published? | Purpose |
|---|---|---|---|
| `docs/adr/` | ✅ | ✅ | durable architecture decisions |
| `docs/dev/` | ✅ | ❌ | shared engineering notes + handoff archive |
| `HANDOFF.md` (root) | ❌ (gitignored) | ❌ | live local scratchpad, current session |
| `memory/` (`~/.claude`) | n/a | ❌ | agent cross-session memory |

### Verified
- `npm run docs:build` clean; confirmed `docs/dev/` does **not** appear in `docs/.vitepress/dist` (excluded, won't render or break the build).
- `HANDOFF.md` stays gitignored (not in this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)