### PR TITLE
feat(discord): outbound REST tools (ADR 0015, slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Outbound Discord tools (ADR 0015, slice 1).** `discord_send` / `discord_read`
+  / `discord_react` — the stateless REST half of the optional Discord surface.
+  Raw Discord REST v10 over `httpx` (no `discord.py`). **Off by default:**
+  registered only when `DISCORD_BOT_TOKEN` is set (`get_all_tools` gates on
+  `discord_configured()`), so non-Discord forks aren't cluttered; a direct call
+  with no token degrades to a readable error. `discord_send` auto-splits long
+  messages at 2000 chars, `discord_read` clamps to Discord's 1–100, 429s surface
+  the `retry_after`. The persistent inbound gateway (the native half) is a
+  separate follow-up slice. Ported from `-deprecated-gina`, template-neutralized.
+
 ### Docs
 - **ADR 0015 — optional native Discord surface.** Decision record for shipping
   Discord as an opt-in template surface (off unless `DISCORD_BOT_TOKEN` set): a

--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -268,6 +268,30 @@ These bridge the Notes panel's permission toggles to the agent — without them,
 "what's on my Todo tab?" never reaches the notes (the agent would only see its
 `memory_*` store).
 
+## `discord_send` / `discord_read` / `discord_react`
+
+**Off unless `DISCORD_BOT_TOKEN` is set** — the outbound (REST) half of the
+optional Discord surface ([ADR 0015](/adr/0015-discord-ingress-surface)). Raw
+Discord REST **v10** over `httpx` (no `discord.py`). When the token is absent
+these tools are **not registered** (`get_all_tools` gates on
+`discord_configured()`); a direct call degrades to a readable error.
+
+```python
+@tool
+async def discord_send(channel_id: str, content: str) -> str     # markdown; auto-splits at 2000 chars
+async def discord_read(channel_id: str, limit: int = 20) -> str  # newest first, 1–100
+async def discord_react(channel_id: str, message_id: str, emoji: str) -> str
+```
+
+- `channel_id` is required per call — there's no default-channel env var; the
+  persona/operator names the channel. `discord_send` chunks long messages at line
+  boundaries; `discord_read` clamps `limit` to Discord's 1–100; rate limits (429)
+  are surfaced with the `retry_after`.
+- This is the stateless request/response half. The persistent **inbound gateway**
+  (DMs + @-mentions, burst debounce, reactions, threads, return-address capture)
+  is a separate native surface — see [ADR 0015](/adr/0015-discord-ingress-surface).
+- Set up the bot token + Message Content Intent before use (Developer Portal).
+
 ## Adding your own
 
 For tools that shell out, build on `tools/shell.py::run_command` (async; handles timeout/kill, missing-binary → structured error, env merge, stdin/cwd) or `tools/gh_cli.py` for `gh` specifically — don't hand-roll `subprocess`.

--- a/tests/test_discord_tools.py
+++ b/tests/test_discord_tools.py
@@ -1,0 +1,165 @@
+"""Tests for the outbound Discord tools (ADR 0015).
+
+httpx is faked the same way the scheduler tests do it — patch
+``httpx.AsyncClient`` with a fake that records the request and replays a canned
+response. No network, no token needed beyond the env the test sets.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+import tools.discord_tools as dt
+
+
+class _Resp:
+    def __init__(self, status_code=200, payload=None, text="", content=b"x"):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+        self.content = content
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+def _fake_client(capture: list, resp):
+    """A fake ``httpx.AsyncClient`` (async ctx mgr) whose ``.request`` records the
+    call and returns ``resp`` (or, if a list, one per call in order)."""
+
+    class _Client:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def request(self, method, url, headers=None, json=None):
+            capture.append({"method": method, "url": url, "headers": headers, "json": json})
+            return resp.pop(0) if isinstance(resp, list) else resp
+
+    return _Client
+
+
+@pytest.fixture(autouse=True)
+def _token(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "test-token")
+
+
+# ── gate ──────────────────────────────────────────────────────────────────────
+
+
+def test_discord_configured_reflects_token(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "abc")
+    assert dt.discord_configured() is True
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    assert dt.discord_configured() is False
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "   ")
+    assert dt.discord_configured() is False  # whitespace-only ⇒ not configured
+
+
+@pytest.mark.asyncio
+async def test_no_token_is_a_clean_error(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    out = await dt.discord_send.ainvoke({"channel_id": "123", "content": "hi"})
+    assert "DISCORD_BOT_TOKEN" in out
+
+
+# ── send ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_send_posts_and_returns_id(monkeypatch):
+    cap: list = []
+    monkeypatch.setattr(httpx, "AsyncClient", _fake_client(cap, _Resp(200, {"id": "999"})))
+    out = await dt.discord_send.ainvoke({"channel_id": "123", "content": "hello"})
+    assert "OK: posted 1 message" in out and "999" in out
+    assert cap[0]["method"] == "POST"
+    assert cap[0]["url"].endswith("/channels/123/messages")
+    assert cap[0]["json"] == {"content": "hello"}
+    assert cap[0]["headers"]["Authorization"] == "Bot test-token"
+
+
+@pytest.mark.asyncio
+async def test_send_splits_long_content(monkeypatch):
+    cap: list = []
+    # two posts ⇒ two canned responses
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _fake_client(cap, [_Resp(200, {"id": "a"}), _Resp(200, {"id": "b"})])
+    )
+    body = ("x" * 1500 + "\n") + ("y" * 1500)  # > 2000, splits at the newline
+    out = await dt.discord_send.ainvoke({"channel_id": "123", "content": body})
+    assert "posted 2 message(s)" in out
+    assert len(cap) == 2
+    assert all(len(c["json"]["content"]) <= dt._MAX_MESSAGE_LEN for c in cap)
+
+
+@pytest.mark.asyncio
+async def test_send_surfaces_http_error(monkeypatch):
+    cap: list = []
+    monkeypatch.setattr(httpx, "AsyncClient", _fake_client(cap, _Resp(403, text="Forbidden")))
+    out = await dt.discord_send.ainvoke({"channel_id": "123", "content": "hi"})
+    assert "Error: HTTP 403" in out
+
+
+@pytest.mark.asyncio
+async def test_send_validates_inputs(monkeypatch):
+    assert "channel_id is required" in await dt.discord_send.ainvoke({"channel_id": "", "content": "x"})
+    assert "content is empty" in await dt.discord_send.ainvoke({"channel_id": "1", "content": "  "})
+
+
+# ── read ──────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_read_formats_messages(monkeypatch):
+    cap: list = []
+    payload = [
+        {"author": {"username": "kj"}, "timestamp": "2026-06-03T01:02:03.000Z", "content": "yo"},
+        {"author": {"username": "bot", "bot": True}, "timestamp": "2026-06-03T01:02:04.000Z", "content": "beep"},
+    ]
+    monkeypatch.setattr(httpx, "AsyncClient", _fake_client(cap, _Resp(200, payload)))
+    out = await dt.discord_read.ainvoke({"channel_id": "123", "limit": 5})
+    assert "2 message(s) in channel 123" in out
+    assert "@kj: yo" in out and "@bot [bot]: beep" in out
+    assert "limit=5" in cap[0]["url"]
+
+
+@pytest.mark.asyncio
+async def test_read_clamps_limit(monkeypatch):
+    cap: list = []
+    monkeypatch.setattr(httpx, "AsyncClient", _fake_client(cap, _Resp(200, [])))
+    await dt.discord_read.ainvoke({"channel_id": "1", "limit": 9999})
+    assert "limit=100" in cap[0]["url"]  # clamped to Discord's max
+
+
+# ── react ─────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_react_encodes_emoji(monkeypatch):
+    cap: list = []
+    monkeypatch.setattr(httpx, "AsyncClient", _fake_client(cap, _Resp(204, content=b"")))
+    out = await dt.discord_react.ainvoke({"channel_id": "1", "message_id": "2", "emoji": "✅"})
+    assert "OK: reacted" in out
+    assert cap[0]["method"] == "PUT"
+    assert "/reactions/" in cap[0]["url"] and "%E2%9C%85" in cap[0]["url"]  # URL-encoded ✅
+
+
+# ── rate limit ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_surfaced(monkeypatch):
+    cap: list = []
+    monkeypatch.setattr(
+        httpx, "AsyncClient", _fake_client(cap, _Resp(429, {"retry_after": 1.5}, text="slow down"))
+    )
+    out = await dt.discord_send.ainvoke({"channel_id": "1", "content": "hi"})
+    assert "HTTP 429" in out and "retry_after=1.5" in out

--- a/tools/discord_tools.py
+++ b/tools/discord_tools.py
@@ -1,0 +1,178 @@
+"""Outbound Discord tools — the stateless half of the Discord surface (ADR 0015).
+
+Talks to Discord's REST API **v10** directly via ``httpx`` (already a core dep) —
+no ``discord.py``. Three tools: ``discord_send`` / ``discord_read`` /
+``discord_react``. They're **off unless ``DISCORD_BOT_TOKEN`` is set**: when the
+token is absent the tools are not registered (``get_all_tools`` gates on
+``discord_configured()``), and any direct call degrades to a readable error.
+
+This is the request/response half. The persistent inbound **gateway** listener
+(DMs + @-mentions, burst debounce, reactions, threads, return-address capture)
+is a separate native surface — it can't live here or in an MCP server because it
+owns a stateful connection. See ADR 0015.
+
+Channel IDs are required per call — there is no default-channel env var; the
+persona / operator names the channel to use.
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any
+
+from langchain_core.tools import tool
+
+_DISCORD_API = "https://discord.com/api/v10"
+_MAX_MESSAGE_LEN = 2000  # Discord hard limit
+_USER_AGENT = "protoAgent (https://github.com/protoLabsAI/protoAgent, 0.1)"
+
+
+def _token() -> str | None:
+    return os.environ.get("DISCORD_BOT_TOKEN")
+
+
+def discord_configured() -> bool:
+    """True when a bot token is present — the gate ``get_all_tools`` uses to
+    decide whether to register these tools at all (ADR 0015: off by default)."""
+    return bool((_token() or "").strip())
+
+
+async def _request(
+    method: str, path: str, json_body: dict[str, Any] | None = None
+) -> tuple[int, Any]:
+    token = _token()
+    if not token:
+        return 0, "Error: DISCORD_BOT_TOKEN env var is not set."
+    try:
+        import httpx
+    except ImportError:
+        return 0, "Error: httpx not installed."
+
+    url = f"{_DISCORD_API}{path}"
+    headers = {
+        "Authorization": f"Bot {token}",
+        "Content-Type": "application/json",
+        "User-Agent": _USER_AGENT,
+    }
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.request(method, url, headers=headers, json=json_body)
+    except httpx.HTTPError as e:
+        return 0, f"Error: Discord request failed: {e}"
+
+    if resp.status_code in (200, 201, 204):
+        try:
+            return resp.status_code, resp.json() if resp.content else None
+        except ValueError:
+            return resp.status_code, resp.text
+    # 429 carries a retry-after; surface it rather than silently failing.
+    if resp.status_code == 429:
+        retry = ""
+        try:
+            retry = f" (retry_after={resp.json().get('retry_after')}s)"
+        except ValueError:
+            pass
+        return 429, f"rate limited{retry}: {resp.text[:300]}"
+    return resp.status_code, resp.text[:500]
+
+
+# ── send ──────────────────────────────────────────────────────────────────────
+
+
+@tool
+async def discord_send(channel_id: str, content: str) -> str:
+    """Post a message to a Discord channel.
+
+    Args:
+        channel_id: Numeric Discord channel ID (e.g. ``1469195643590541353``).
+        content: Message body. Markdown supported. Long messages are split into
+            multiple posts at line boundaries (Discord's 2000-char limit).
+
+    Returns the posted message ID(s), or a readable error.
+    """
+    if not channel_id.strip():
+        return "Error: channel_id is required."
+    if not content.strip():
+        return "Error: content is empty."
+
+    chunks: list[str] = []
+    remaining = content
+    while remaining:
+        if len(remaining) <= _MAX_MESSAGE_LEN:
+            chunks.append(remaining)
+            break
+        split_at = remaining[:_MAX_MESSAGE_LEN].rfind("\n")
+        if split_at < 100:
+            split_at = _MAX_MESSAGE_LEN
+        chunks.append(remaining[:split_at])
+        remaining = remaining[split_at:].lstrip()
+
+    posted: list[str] = []
+    for chunk in chunks:
+        status, body = await _request(
+            "POST", f"/channels/{channel_id}/messages", json_body={"content": chunk}
+        )
+        if status not in (200, 201):
+            return f"Error: HTTP {status}: {body}"
+        if isinstance(body, dict) and body.get("id"):
+            posted.append(body["id"])
+
+    return f"OK: posted {len(posted)} message(s) ({', '.join(posted)})"
+
+
+@tool
+async def discord_read(channel_id: str, limit: int = 20) -> str:
+    """Read recent messages from a Discord channel.
+
+    Args:
+        channel_id: Numeric Discord channel ID.
+        limit: Max messages to return (1–100, default 20). Newest first.
+    """
+    if not channel_id.strip():
+        return "Error: channel_id is required."
+    limit = max(1, min(limit, 100))
+    status, body = await _request("GET", f"/channels/{channel_id}/messages?limit={limit}")
+    if status != 200:
+        return f"Error: HTTP {status}: {body}"
+    if not isinstance(body, list):
+        return f"Error: unexpected response: {body}"
+
+    lines = [f"{len(body)} message(s) in channel {channel_id}:"]
+    for msg in body:
+        author = msg.get("author", {}).get("username", "?")
+        is_bot = " [bot]" if msg.get("author", {}).get("bot") else ""
+        ts = msg.get("timestamp", "")[:19]
+        text = (msg.get("content") or "").replace("\n", " ")[:300]
+        lines.append(f"  {ts} @{author}{is_bot}: {text}")
+    return "\n".join(lines)
+
+
+@tool
+async def discord_react(channel_id: str, message_id: str, emoji: str) -> str:
+    """Add a reaction to a Discord message.
+
+    Args:
+        channel_id: Numeric channel ID.
+        message_id: Numeric message ID.
+        emoji: Unicode emoji (e.g. ``"✅"``) or a custom ``name:id``.
+    """
+    if not channel_id.strip() or not message_id.strip():
+        return "Error: channel_id and message_id are required."
+    from urllib.parse import quote
+
+    encoded = quote(emoji)
+    status, body = await _request(
+        "PUT", f"/channels/{channel_id}/messages/{message_id}/reactions/{encoded}/@me"
+    )
+    if status not in (200, 201, 204):
+        return f"Error: HTTP {status}: {body}"
+    return f"OK: reacted with {emoji}."
+
+
+# ── registry ────────────────────────────────────────────────────────────────
+
+
+def get_discord_tools() -> list:
+    """The outbound Discord tools. ``get_all_tools`` includes these only when
+    ``discord_configured()`` (a bot token is set)."""
+    return [discord_send, discord_read, discord_react]

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -690,6 +690,11 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, beads_
     from tools.peer_tools import get_peer_tools, list_env_peers
     if list_env_peers():
         tools.extend(get_peer_tools())
+    # Outbound Discord tools — only when DISCORD_BOT_TOKEN is set (ADR 0015:
+    # off by default, so non-Discord forks aren't cluttered).
+    from tools.discord_tools import discord_configured, get_discord_tools
+    if discord_configured():
+        tools.extend(get_discord_tools())
     if knowledge_store is not None:
         tools.extend(_build_memory_tools(knowledge_store))
     if scheduler is not None:


### PR DESCRIPTION
First slice of #489 (ADR 0015) — the stateless, lowest-risk half of the Discord surface.

## What
`discord_send` / `discord_read` / `discord_react` in `tools/discord_tools.py` — raw Discord REST **v10** over `httpx` (already core; no `discord.py`). Ported from `-deprecated-gina` and template-neutralized (User-Agent, docstrings).

## Off by default
Registered in `get_all_tools()` **only when `DISCORD_BOT_TOKEN` is set** (gates on `discord_configured()`), so forks that don't use Discord aren't cluttered. A direct call with no token returns a readable "set `DISCORD_BOT_TOKEN`" error. Zero behavior change for everyone else — verified: tool set is identical with the token unset.

## Niceties carried over / added
- `discord_send` splits long messages at line boundaries (2000-char limit).
- `discord_read` clamps `limit` to Discord's 1–100, formats newest-first.
- `discord_react` URL-encodes the emoji.
- **429 rate limits surfaced** with `retry_after` (added on top of the source).

## Tests / docs
- `tests/test_discord_tools.py` — 10 cases (gate, no-token error, send + chunking + HTTP error + input validation, read formatting + clamp, react encoding, 429), faking `httpx.AsyncClient` the same way the scheduler tests do. **Full suite 901 passed.**
- `docs/reference/starter-tools.md` — new Discord section. `npm run docs:build` clean.

## Scope
Outbound only. The persistent **inbound gateway** (DMs/@-mentions → reactive inbox, debounce, reactions, threads, return-address capture) is the next slice on #489 — it's native (not these tools, not MCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)