### PR TITLE
feat(discord): inbound gateway listener (ADR 0015, slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Inbound Discord gateway (ADR 0015, slice 2).** A native, opt-in listener
+  (`surfaces/discord/`) — DMs + channel @-mentions reach the agent, replies post
+  back. Raw Discord Gateway/REST v10 over `httpx` + `websockets` (both already
+  core); **off unless `DISCORD_BOT_TOKEN` is set**. A Discord DM is
+  conversational, so it invokes the agent as a **chat surface** with a
+  per-conversation `session_id` (the LangGraph thread key) rather than the single
+  `system:activity` inbox thread — preserving per-DM continuity — and publishes a
+  `discord.message` bus event for console visibility. Ported the proven
+  `-deprecated-gina` UX: burst debounce, conversation continuity, slow-response
+  reactions (👀→✅ only when slow), auto-threading, admin allowlist
+  (`DISCORD_ADMIN_IDS`). The agent invoker is injected, keeping the surface
+  decoupled + tested. Long-window context + return-address delivery are
+  follow-up slices. New guide: [Discord surface](docs/guides/discord.md).
 - **Outbound Discord tools (ADR 0015, slice 1).** `discord_send` / `discord_read`
   / `discord_react` — the stateless REST half of the optional Discord surface.
   Raw Discord REST v10 over `httpx` (no `discord.py`). **Off by default:**

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -57,6 +57,7 @@ export default defineConfig({
             { text: "Plugins", link: "/guides/plugins" },
             { text: "Goal mode", link: "/guides/goal-mode" },
             { text: "Scheduler", link: "/guides/scheduler" },
+            { text: "Discord surface", link: "/guides/discord" },
             { text: "Operator console (React/Tauri)", link: "/guides/react-tauri-ui" },
             { text: "Wire Langfuse + Prometheus", link: "/guides/observability" },
             { text: "Run multiple instances", link: "/guides/multi-instance" },

--- a/docs/adr/0015-discord-ingress-surface.md
+++ b/docs/adr/0015-discord-ingress-surface.md
@@ -52,20 +52,28 @@ configured — the same opt-in posture as the `--ui` tiers (ADR 0010) and the
 scheduler. Port the proven UX **in full** (the patterns above are cheaper to
 carry forward than to re-derive). Two layers:
 
-### 2.1 Inbound gateway → routed through the reactive inbox
+### 2.1 Inbound gateway → invokes the agent as a chat surface
 
 A native background task (uvicorn lifespan hook, shares the event loop), **off
 unless `DISCORD_BOT_TOKEN` is set**. It owns the persistent Gateway v10
 connection and the stateful UX (debounce, continuity, reactions, threads,
-allowlist, identity capture).
+allowlist).
 
-**Modernization vs the original:** `-deprecated-gina` predated the inbox and
-called `/v1/chat/completions` directly. Here, an accepted inbound message is
-**published to the event bus as an inbox stimulus** ([ADR 0003](./0003-reactive-agent-activity-thread.md))
-— Discord becomes another *stimulus source* alongside the scheduler and the
-authed HTTP inbox, with one ingress substrate, one audit trail, one auth model.
-The gateway is a thin, well-tested **adapter**; the agent-invocation,
-threading, and provenance live in the shared substrate.
+**Refined during implementation (#490-series):** the original framing here was
+"route Discord inbound *through* the ADR-0003 inbox as a stimulus." On building
+it, that turned out wrong for a 1:1 DM, which is **conversational** — the inbox
+fires into a *single* `system:activity` thread, which would collapse every
+Discord conversation into one thread and destroy the per-DM continuity that
+makes Discord useful. So the gateway instead invokes the agent as a **chat
+surface**: it calls the in-process `chat(prompt, session_id)` entry with a
+**per-conversation `session_id`** (the LangGraph thread key, surface-tagged
+`discord-dm:…` / `discord-channel-…` for provenance), so each conversation keeps
+its own thread. It still **publishes a `discord.message` bus event** so the
+console can surface Discord activity (the ADR-0003 visibility touchpoint). The
+inbox stays the right substrate for *non-conversational* pushes (webhooks, cron);
+a live DM is a chat turn, not a one-shot stimulus. The agent invoker is injected
+(`start_in_background(invoke, publish=…)`), keeping the surface decoupled and
+unit-testable.
 
 ### 2.2 Outbound tools (stateless REST v10)
 

--- a/docs/guides/discord.md
+++ b/docs/guides/discord.md
@@ -1,0 +1,72 @@
+# Discord surface
+
+An **optional native Discord surface** ([ADR 0015](/adr/0015-discord-ingress-surface)) —
+DMs and @-mentions reach the agent, replies post back. Self-contained: raw
+Discord Gateway + REST **v10** over `httpx` + `websockets` (both already core),
+no `discord.py`. **Off unless `DISCORD_BOT_TOKEN` is set** — when unset the
+gateway never starts and the outbound tools aren't registered.
+
+Two halves:
+
+- **Inbound gateway** (`surfaces/discord/`) — a persistent listener. A Discord
+  DM is conversational, so it invokes the agent as a **chat surface** with a
+  per-conversation `session_id` (the LangGraph thread key) — multi-turn memory
+  persists per Discord conversation. It also publishes a `discord.message` bus
+  event so the console can surface Discord activity.
+- **Outbound tools** (`tools/discord_tools.py`) — `discord_send` / `discord_read`
+  / `discord_react`, for pushing into channels. See [starter tools](/reference/starter-tools).
+
+## Bot setup
+
+1. **[Discord Developer Portal](https://discord.com/developers/applications)** →
+   New Application → name it.
+2. **Bot** tab → copy the token → this is your `DISCORD_BOT_TOKEN`
+   (put it in `config/secrets.yaml` or the env — never commit it).
+3. **Privileged Gateway Intents** → enable **Message Content Intent** (otherwise
+   messages arrive with empty `content` and the agent can't read them).
+4. **OAuth2 → URL Generator** → scopes `bot`; permissions `Send Messages`,
+   `Read Message History`, `Add Reactions`, `Create Public Threads`.
+5. Open the generated URL to add the bot to a server — or just **DM the bot**
+   (DMs work without a server).
+
+The gateway requests these intents: `GUILDS | GUILD_MESSAGES |
+GUILD_MESSAGE_REACTIONS | DIRECT_MESSAGES | MESSAGE_CONTENT`.
+
+## Conversation model
+
+- **DMs** always continue (no mention needed). **Channel** messages start a
+  conversation on an @-mention; follow-ups in the same channel from the same
+  user continue it within the timeout window.
+- The `conversation_id` is the agent's `session_id` (surface-tagged
+  `discord-dm:…` / `discord-channel-…:…` for provenance in traces), so the
+  LangGraph thread stays keyed across turns.
+- **Burst debounce** — a rapid run of messages is coalesced into one invocation
+  after a few seconds of silence (reply attaches to the last).
+- **Slow-response reactions** — fast replies leave the channel clean; only when a
+  turn is slow does a 👀 land on the message(s), swapped to ✅ on completion.
+  (DMs never get reactions — the typing indicator is signal enough.)
+- **Auto-thread** — the first reply in a new channel conversation opens a thread
+  (24h auto-archive) so long answers don't clutter the channel.
+
+## Configuration
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `DISCORD_BOT_TOKEN` | — | **Required.** Enables the whole surface (gateway + tools). |
+| `DISCORD_ADMIN_IDS` | _(unset)_ | CSV of Discord user IDs. When set, only those users are answered; unset ⇒ anyone. **Default-closed is recommended for a personal assistant.** |
+| `DISCORD_CHANNEL_CONVERSATION_TIMEOUT_S` | `300` | Channel conversation-continuity window. |
+| `DISCORD_DM_CONVERSATION_TIMEOUT_S` | `900` | DM conversation-continuity window. |
+| `DISCORD_BURST_DEBOUNCE_S` | `3` | Silence before a message burst is flushed. |
+| `DISCORD_SLOW_REACTION_S` | `4` | Grace window before the 👀 "still working" reaction. |
+
+## One bot per agent
+
+Discord's gateway permits **one concurrent connection per token**. A second
+listener on the same token evicts the first — so don't share a token across
+agents; give each its own bot (cf. [multiple instances](/guides/multi-instance)).
+
+## Not yet (follow-ups)
+
+Long-window context warming (history beyond the live conversation) and
+return-address delivery (so scheduled / proactive turns deliver to your DM) are
+tracked as follow-up slices in the ADR-0015 build.

--- a/server.py
+++ b/server.py
@@ -2428,6 +2428,25 @@ def _main():
             import asyncio
             _checkpoint_prune_task = asyncio.create_task(_checkpoint_prune_loop())
 
+        # Inbound Discord gateway (ADR 0015) — opt-in via DISCORD_BOT_TOKEN. A
+        # Discord DM is conversational, so it invokes the agent as a chat surface
+        # with a per-conversation session_id (the LangGraph thread key), NOT the
+        # single system:activity inbox thread. Best-effort bus publish for
+        # console visibility.
+        try:
+            from surfaces.discord import start_in_background as _start_discord
+
+            async def _discord_invoke(prompt: str, session_id: str) -> str:
+                result = await chat(prompt, session_id)
+                return "\n\n".join(
+                    m["content"] for m in result
+                    if m.get("role") == "assistant" and m.get("content")
+                )
+
+            _start_discord(_discord_invoke, publish=_event_bus.publish)
+        except Exception:
+            log.exception("[discord] gateway startup failed")
+
     @fastapi_app.on_event("shutdown")
     async def _scheduler_shutdown() -> None:
         if _scheduler is not None:
@@ -2440,6 +2459,11 @@ def _main():
                 await _cache_warmer.stop()
             except Exception:
                 log.exception("[cache-warmer] shutdown failed")
+        try:
+            from surfaces.discord import stop as _stop_discord
+            await _stop_discord()
+        except Exception:
+            log.exception("[discord] shutdown failed")
         if _checkpoint_prune_task is not None:
             _checkpoint_prune_task.cancel()
 

--- a/surfaces/__init__.py
+++ b/surfaces/__init__.py
@@ -1,0 +1,1 @@
+"""Agent surfaces — optional inbound/outbound channels (e.g. Discord, ADR 0015)."""

--- a/surfaces/discord/__init__.py
+++ b/surfaces/discord/__init__.py
@@ -1,0 +1,10 @@
+"""Optional native Discord surface (ADR 0015).
+
+Off unless ``DISCORD_BOT_TOKEN`` is set. The inbound gateway listener
+(``gateway.start_in_background``) is the native half; the stateless outbound
+tools live in ``tools/discord_tools.py``.
+"""
+
+from surfaces.discord.gateway import start_in_background, stop
+
+__all__ = ["start_in_background", "stop"]

--- a/surfaces/discord/conversation.py
+++ b/surfaces/discord/conversation.py
@@ -1,0 +1,122 @@
+"""Conversation continuity for the Discord gateway (ADR 0015).
+
+Per-``(channel, user)`` conversation state: when a user @-mentions the agent in
+a channel, follow-up messages within the timeout window continue the same
+conversation without another mention. The ``conversation_id`` is passed to the
+agent as the session/thread key so the LangGraph thread stays consistent across
+turns. DMs use a wider window (they're 1:1 sessions).
+
+Ported from ``-deprecated-gina`` (which mirrors Workstacean's ConversationManager
+— same key shape, same timeout semantics, same get_or_create / has / end API).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+import uuid
+from dataclasses import dataclass
+
+log = logging.getLogger("protoagent.discord.conversation")
+
+
+@dataclass
+class ConversationEntry:
+    conversation_id: str
+    channel_id: str
+    user_id: str
+    started_at: float
+    last_activity: float
+    timeout_s: float
+    turn_number: int
+
+
+class ConversationManager:
+    """Tracks active multi-turn conversations by ``(channel_id, user_id)``.
+
+    A periodic sweep (every ``sweep_interval_s``) drops expired conversations.
+    """
+
+    def __init__(self, sweep_interval_s: float = 30.0):
+        self._conversations: dict[str, ConversationEntry] = {}
+        self._sweep_interval_s = sweep_interval_s
+        self._sweep_task: asyncio.Task | None = None
+
+    def start(self) -> None:
+        """Start the periodic sweep. Idempotent."""
+        if self._sweep_task is None or self._sweep_task.done():
+            self._sweep_task = asyncio.create_task(self._sweep_loop())
+
+    async def stop(self) -> None:
+        if self._sweep_task is not None:
+            self._sweep_task.cancel()
+            try:
+                await self._sweep_task
+            except asyncio.CancelledError:
+                pass
+            self._sweep_task = None
+
+    @staticmethod
+    def _key(channel_id: str, user_id: str) -> str:
+        return f"{channel_id}:{user_id}"
+
+    def get_or_create(
+        self, channel_id: str, user_id: str, *, timeout_s: float = 300.0
+    ) -> tuple[str, bool, int]:
+        """Return ``(conversation_id, is_new, turn_number)``. An active
+        (unexpired) conversation bumps the turn number; otherwise a fresh one
+        starts."""
+        key = self._key(channel_id, user_id)
+        now = time.monotonic()
+        existing = self._conversations.get(key)
+        if existing and (now - existing.last_activity) < existing.timeout_s:
+            existing.last_activity = now
+            existing.turn_number += 1
+            return existing.conversation_id, False, existing.turn_number
+
+        conversation_id = str(uuid.uuid4())
+        self._conversations[key] = ConversationEntry(
+            conversation_id=conversation_id,
+            channel_id=channel_id,
+            user_id=user_id,
+            started_at=now,
+            last_activity=now,
+            timeout_s=timeout_s,
+            turn_number=1,
+        )
+        return conversation_id, True, 1
+
+    def has(self, channel_id: str, user_id: str) -> bool:
+        entry = self._conversations.get(self._key(channel_id, user_id))
+        if entry is None:
+            return False
+        return (time.monotonic() - entry.last_activity) < entry.timeout_s
+
+    def end(self, channel_id: str, user_id: str) -> bool:
+        return self._conversations.pop(self._key(channel_id, user_id), None) is not None
+
+    async def _sweep_loop(self) -> None:
+        try:
+            while True:
+                await asyncio.sleep(self._sweep_interval_s)
+                self._sweep_once()
+        except asyncio.CancelledError:
+            return
+        except Exception:
+            log.exception("[conversation] sweep loop crashed")
+
+    def _sweep_once(self) -> None:
+        now = time.monotonic()
+        expired = [
+            key
+            for key, entry in self._conversations.items()
+            if (now - entry.last_activity) >= entry.timeout_s
+        ]
+        for key in expired:
+            entry = self._conversations.pop(key, None)
+            if entry is not None:
+                log.info(
+                    "[conversation] timed out %s (%d turn(s), user %s in %s)",
+                    entry.conversation_id, entry.turn_number, entry.user_id, entry.channel_id,
+                )

--- a/surfaces/discord/gateway.py
+++ b/surfaces/discord/gateway.py
@@ -1,0 +1,420 @@
+"""Inbound Discord gateway listener — the native half of the Discord surface (ADR 0015).
+
+Self-contained: raw ``httpx`` + ``websockets`` over Discord Gateway/REST **v10**,
+no ``discord.py``. Listens for DMs and channel @-mentions and forwards each
+user's conversation to the agent, posting the reply back. **Off unless
+``DISCORD_BOT_TOKEN`` is set.**
+
+Unlike a one-shot inbox stimulus (ADR 0003), a Discord DM is *conversational*, so
+the gateway invokes the agent as a **chat surface**: it calls an injected
+``invoke(prompt, session_id)`` with a per-conversation ``session_id`` so the
+LangGraph thread stays keyed across turns (server wires this to ``chat()``). It
+also publishes a best-effort ``discord.message`` bus event so the console can
+surface Discord activity. (Routing the conversation itself through the single
+``system:activity`` inbox thread was rejected — it would collapse every Discord
+conversation into one thread and lose per-DM continuity.)
+
+Ported UX (from ``-deprecated-gina``): **burst debounce**, **conversation
+continuity**, **slow-response reactions** (👀→✅ only when slow), **auto-threading**,
+and an **admin allowlist**. Long-window context warming and return-address
+delivery are follow-up slices (#489).
+
+Tunables (env): ``DISCORD_ADMIN_IDS`` (CSV; unset ⇒ anyone),
+``DISCORD_CHANNEL_CONVERSATION_TIMEOUT_S`` (300), ``DISCORD_DM_CONVERSATION_TIMEOUT_S``
+(900), ``DISCORD_BURST_DEBOUNCE_S`` (3), ``DISCORD_SLOW_REACTION_S`` (4).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from typing import Any, Awaitable, Callable
+from urllib.parse import quote
+
+import httpx
+
+from surfaces.discord.conversation import ConversationManager
+
+log = logging.getLogger("protoagent.discord")
+
+_DISCORD_API = "https://discord.com/api/v10"
+# GUILDS | GUILD_MESSAGES | GUILD_MESSAGE_REACTIONS | DIRECT_MESSAGES | MESSAGE_CONTENT
+_GATEWAY_INTENTS = (1 << 0) | (1 << 9) | (1 << 10) | (1 << 12) | (1 << 15)
+
+_MAX_LEN = 1900  # Discord's 2000 cap with headroom
+_REACTION_THINKING = "👀"
+_REACTION_DONE = "✅"
+
+
+def _f(env: str, default: float) -> float:
+    try:
+        return float(os.environ.get(env, default))
+    except (TypeError, ValueError):
+        return default
+
+
+def _token() -> str | None:
+    return os.environ.get("DISCORD_BOT_TOKEN")
+
+
+def _admin_ids() -> set[str]:
+    raw = os.environ.get("DISCORD_ADMIN_IDS", "").strip()
+    return {s.strip() for s in raw.split(",") if s.strip()} if raw else set()
+
+
+# Injected by start_in_background — the agent invocation + (optional) bus publish.
+InvokeFn = Callable[[str, str], Awaitable[str]]
+_invoke: InvokeFn | None = None
+_publish: Callable[[str, dict], None] | None = None
+
+# Module-level conversation + burst state, started from _run_gateway's loop.
+_conversations = ConversationManager()
+# Per-(channel_id, user_id) burst buffer; each entry combines a rapid run of
+# messages into one invocation after DISCORD_BURST_DEBOUNCE_S of silence.
+_message_buffers: dict[str, dict] = {}
+
+
+# ── REST helpers ──────────────────────────────────────────────────────────────
+
+
+async def _api(method: str, path: str, body: dict | None = None) -> dict | None:
+    token = _token()
+    if not token:
+        return None
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.request(
+                method,
+                f"{_DISCORD_API}{path}",
+                headers={"Authorization": f"Bot {token}"},
+                json=body,
+            )
+    except httpx.HTTPError as e:
+        log.warning("Discord %s %s -> %s", method, path, e)
+        return None
+    if resp.status_code in (200, 201, 204):
+        return resp.json() if resp.content else None
+    log.warning("Discord %s %s -> %d %s", method, path, resp.status_code, resp.text[:200])
+    return None
+
+
+async def _react(channel_id: str, message_id: str, emoji: str) -> None:
+    await _api("PUT", f"/channels/{channel_id}/messages/{message_id}/reactions/{quote(emoji)}/@me")
+
+
+async def _unreact(channel_id: str, message_id: str, emoji: str) -> None:
+    await _api("DELETE", f"/channels/{channel_id}/messages/{message_id}/reactions/{quote(emoji)}/@me")
+
+
+async def _start_thread(channel_id: str, message_id: str, name: str) -> dict | None:
+    return await _api(
+        "POST",
+        f"/channels/{channel_id}/messages/{message_id}/threads",
+        body={"name": name[:100], "auto_archive_duration": 1440},  # 24h
+    )
+
+
+async def _reply(channel_id: str, message_id: str, content: str, *, is_dm: bool = False) -> str | None:
+    """Send the response, splitting long content at line boundaries. Returns the
+    first chunk's message ID (used to start a thread on the first guild reply).
+    Guild replies use ``message_reference`` so the answer threads under the
+    user's message; DMs send plain messages (a reply-quote in 1:1 reads awkward)."""
+    chunks: list[str] = []
+    remaining = content
+    while remaining:
+        if len(remaining) <= _MAX_LEN:
+            chunks.append(remaining)
+            break
+        split_at = remaining[:_MAX_LEN].rfind("\n")
+        if split_at < 100:
+            split_at = _MAX_LEN
+        chunks.append(remaining[:split_at])
+        remaining = remaining[split_at:].lstrip()
+
+    first_id: str | None = None
+    for i, chunk in enumerate(chunks):
+        body: dict = {"content": chunk}
+        if i == 0 and not is_dm:
+            body["message_reference"] = {"message_id": message_id}
+        result = await _api("POST", f"/channels/{channel_id}/messages", body=body)
+        if i == 0 and isinstance(result, dict):
+            first_id = result.get("id")
+    return first_id
+
+
+async def _keep_typing(channel_id: str) -> None:
+    """Send the typing indicator every 8s until cancelled."""
+    try:
+        while True:
+            await _api("POST", f"/channels/{channel_id}/typing")
+            await asyncio.sleep(8)
+    except asyncio.CancelledError:
+        pass
+
+
+# ── invocation ────────────────────────────────────────────────────────────────
+
+
+async def _ask_agent(content: str, session_id: str) -> str:
+    """Invoke the agent via the injected callable with a per-conversation
+    ``session_id`` (the LangGraph thread key). Degrades to a readable error."""
+    if _invoke is None:
+        return "(internal error: Discord gateway has no agent invoker)"
+    try:
+        return await _invoke(content, session_id)
+    except Exception as e:  # noqa: BLE001
+        log.error("[discord] agent invocation failed: %s", e)
+        return f"(internal error: {e})"
+
+
+def _strip_mentions(content: str, bot_id: str) -> str:
+    out = content
+    for tag in (f"<@{bot_id}>", f"<@!{bot_id}>"):
+        out = out.replace(tag, "")
+    return out.strip()
+
+
+def _emit(event: str, data: dict) -> None:
+    """Best-effort bus publish for console visibility (ADR 0003). Never raises."""
+    if _publish is None:
+        return
+    try:
+        _publish(event, data)
+    except Exception:  # noqa: BLE001
+        log.debug("[discord] bus publish failed (non-fatal)", exc_info=True)
+
+
+# ── message handling ──────────────────────────────────────────────────────────
+
+
+async def _handle_message(d: dict, bot_id: str) -> None:
+    """MESSAGE_CREATE handler. Validates + buffers the message; the actual
+    invocation happens after the burst-debounce window in ``_flush_burst``."""
+    author = d.get("author", {})
+    if author.get("bot") or author.get("id") == bot_id:
+        return
+
+    channel_id = d.get("channel_id", "")
+    message_id = d.get("id", "")
+    user_id = author.get("id", "")
+    raw_content = d.get("content") or ""
+    if not channel_id or not message_id or not user_id:
+        return
+
+    is_dm = d.get("guild_id") is None
+    is_mentioned = any(m.get("id") == bot_id for m in d.get("mentions", []))
+    buffer_key = f"{channel_id}:{user_id}"
+    has_active_buffer = buffer_key in _message_buffers
+
+    # Guild messages need a mention, an active conversation, or an in-progress
+    # burst; DMs always continue.
+    if not is_dm and not (is_mentioned or _conversations.has(channel_id, user_id) or has_active_buffer):
+        return
+
+    admins = _admin_ids()
+    if admins and user_id not in admins:
+        log.info("[discord] ignored message from %s (not in DISCORD_ADMIN_IDS)", user_id)
+        return
+
+    content = _strip_mentions(raw_content, bot_id)
+    if not content:
+        return
+
+    log.info("[discord] msg from %s (%s) in %s: %s",
+             author.get("username"), user_id, channel_id, content[:80])
+    _emit("discord.message", {"channel_id": channel_id, "user_id": user_id,
+                              "username": author.get("username"), "is_dm": is_dm})
+
+    # Buffer + (re)arm the debounce timer. No immediate reaction — fast replies
+    # leave the channel clean; the slow 👀 is armed in _flush_burst.
+    entry = _message_buffers.get(buffer_key)
+    if entry is None:
+        timeout_s = _f("DISCORD_DM_CONVERSATION_TIMEOUT_S", 900) if is_dm \
+            else _f("DISCORD_CHANNEL_CONVERSATION_TIMEOUT_S", 300)
+        conversation_id, is_new, _turn = _conversations.get_or_create(
+            channel_id, user_id, timeout_s=timeout_s)
+        entry = {
+            "messages": [], "channel_id": channel_id, "user_id": user_id,
+            "is_dm": is_dm, "conversation_id": conversation_id,
+            "is_new_conversation": is_new, "timer": None,
+        }
+        _message_buffers[buffer_key] = entry
+
+    entry["messages"].append({"id": message_id, "content": content})
+    if entry.get("timer") is not None:
+        entry["timer"].cancel()
+    entry["timer"] = asyncio.create_task(_burst_timer(buffer_key))
+
+
+async def _slow_reaction_arm(channel_id: str, msgs: list[dict], is_dm: bool, state: dict) -> None:
+    """Sleep the slow-response window, then 👀 every message in the burst.
+    Cancellation means the reply came back fast — no reaction needed. DMs skip
+    this (the typing indicator is signal enough)."""
+    if is_dm:
+        return
+    try:
+        await asyncio.sleep(_f("DISCORD_SLOW_REACTION_S", 4))
+    except asyncio.CancelledError:
+        return
+    state["placed"] = True
+    await asyncio.gather(*[_react(channel_id, m["id"], _REACTION_THINKING) for m in msgs],
+                         return_exceptions=True)
+
+
+async def _burst_timer(buffer_key: str) -> None:
+    try:
+        await asyncio.sleep(_f("DISCORD_BURST_DEBOUNCE_S", 3))
+    except asyncio.CancelledError:
+        return
+    try:
+        await _flush_burst(buffer_key)
+    except Exception:
+        log.exception("[discord] burst flush failed")
+
+
+async def _flush_burst(buffer_key: str) -> None:
+    """Pop the buffer, combine its messages into one prompt, invoke the agent,
+    and reply on the last message — with typing, slow-reaction, and auto-thread."""
+    entry = _message_buffers.pop(buffer_key, None)
+    if entry is None or not entry["messages"]:
+        return
+
+    msgs: list[dict] = entry["messages"]
+    channel_id: str = entry["channel_id"]
+    is_dm: bool = entry["is_dm"]
+    conversation_id: str = entry["conversation_id"]
+    is_new: bool = entry["is_new_conversation"]
+    last_message_id: str = msgs[-1]["id"]
+
+    combined = "\n\n".join(m["content"] for m in msgs).strip()
+    if not combined:
+        return
+
+    typing_task = asyncio.create_task(_keep_typing(channel_id))
+    slow_state = {"placed": False}
+    slow_task = asyncio.create_task(_slow_reaction_arm(channel_id, msgs, is_dm, slow_state))
+
+    # Surface-tagged session_id: keeps the LangGraph thread keyed per conversation
+    # while showing "discord" provenance in audit/traces instead of a bare UUID.
+    surface_tag = "discord-dm" if is_dm else f"discord-channel-{channel_id}"
+    session_id = f"{surface_tag}:{conversation_id}"
+    try:
+        reply_text = await _ask_agent(combined, session_id)
+    finally:
+        slow_task.cancel()
+        typing_task.cancel()
+
+    if not reply_text.strip():
+        log.warning("[discord] empty reply for conversation %s — graceful fallback", conversation_id)
+        reply_text = ("Sorry — I lost the thread on that one. Could you say it again, "
+                      "maybe with a little more detail?")
+
+    reply_message_id = await _reply(channel_id, last_message_id, reply_text, is_dm=is_dm)
+
+    # Swap a placed 👀 for ✅; if it never fired (fast reply), leave it clean.
+    if not is_dm and slow_state["placed"]:
+        ops: list = []
+        for m in msgs:
+            ops.append(_unreact(channel_id, m["id"], _REACTION_THINKING))
+            ops.append(_react(channel_id, m["id"], _REACTION_DONE))
+        await asyncio.gather(*ops, return_exceptions=True)
+
+    # Auto-thread the first turn of a guild conversation to keep the channel tidy.
+    if not is_dm and is_new and reply_message_id:
+        thread_name = msgs[-1]["content"].split("\n", 1)[0][:80] or "thread"
+        await _start_thread(channel_id, reply_message_id, thread_name)
+
+
+# ── gateway loop ──────────────────────────────────────────────────────────────
+
+
+async def _heartbeat(ws, interval: float, get_seq) -> None:
+    try:
+        while True:
+            await asyncio.sleep(interval)
+            await ws.send(json.dumps({"op": 1, "d": get_seq()}))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+async def _run_gateway() -> None:
+    try:
+        import websockets
+    except ImportError:
+        log.error("[discord] websockets not installed — gateway disabled")
+        return
+
+    bot = await _api("GET", "/users/@me")
+    if not bot:
+        log.error("[discord] could not fetch bot user; check DISCORD_BOT_TOKEN")
+        return
+    bot_id = bot["id"]
+    log.info("[discord] bot user: %s (%s)", bot.get("username"), bot_id)
+
+    _conversations.start()
+
+    async with httpx.AsyncClient(timeout=10) as client:
+        resp = await client.get(f"{_DISCORD_API}/gateway/bot",
+                                headers={"Authorization": f"Bot {_token()}"})
+        gateway_url = resp.json().get("url", "wss://gateway.discord.gg")
+
+    sequence: int | None = None
+    while True:
+        try:
+            async with websockets.connect(f"{gateway_url}?v=10&encoding=json") as ws:
+                log.info("[discord] gateway connected")
+                async for raw in ws:
+                    data = json.loads(raw)
+                    op = data.get("op")
+                    if data.get("s") is not None:
+                        sequence = data["s"]
+
+                    if op == 10:  # HELLO
+                        interval = data["d"]["heartbeat_interval"] / 1000
+                        await ws.send(json.dumps({
+                            "op": 2,
+                            "d": {
+                                "token": _token(),
+                                "intents": _GATEWAY_INTENTS,
+                                "properties": {"os": "linux", "browser": "protoagent",
+                                               "device": "protoagent"},
+                            },
+                        }))
+                        asyncio.create_task(_heartbeat(ws, interval, lambda: sequence))
+                    elif op == 0:  # DISPATCH
+                        t = data.get("t")
+                        d = data.get("d") or {}
+                        if t == "READY":
+                            log.info("[discord] gateway READY (%d guilds)", len(d.get("guilds", [])))
+                        elif t == "MESSAGE_CREATE":
+                            try:
+                                await _handle_message(d, bot_id)
+                            except Exception:
+                                log.exception("[discord] message handler failed")
+                    elif op in (7, 9):  # RECONNECT / INVALID_SESSION
+                        log.info("[discord] reconnect requested (op %s)", op)
+                        break
+        except Exception as e:  # noqa: BLE001
+            log.warning("[discord] gateway error: %s; sleeping 5s", e)
+            await asyncio.sleep(5)
+
+
+def start_in_background(invoke: InvokeFn, *, publish: Callable[[str, dict], None] | None = None) -> "asyncio.Task | None":
+    """Launch the gateway listener as a background task, wiring the agent
+    ``invoke(prompt, session_id)`` callable (and an optional bus ``publish``).
+    Returns ``None`` when no ``DISCORD_BOT_TOKEN`` is set (opt-in)."""
+    global _invoke, _publish
+    if not _token():
+        log.info("[discord] DISCORD_BOT_TOKEN not set — gateway listener disabled")
+        return None
+    _invoke = invoke
+    _publish = publish
+    log.info("[discord] starting gateway listener")
+    return asyncio.create_task(_run_gateway())
+
+
+async def stop() -> None:
+    """Stop the conversation sweeper (the gateway task is cancelled by the loop)."""
+    await _conversations.stop()

--- a/tests/test_discord_gateway.py
+++ b/tests/test_discord_gateway.py
@@ -1,0 +1,204 @@
+"""Tests for the inbound Discord gateway (ADR 0015).
+
+The WebSocket loop itself isn't unit-tested (it's thin glue over Discord's
+gateway); the message-handling logic is. ``_api`` (the REST helper every
+send/react/thread routes through) is mocked to record calls, and the agent
+invoker is a fake — so routing, debounce buffering, burst combining, reactions,
+and auto-threading are all exercised without network or LLM.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from surfaces.discord import gateway as gw
+
+BOT = "botid"
+
+
+@pytest.fixture(autouse=True)
+def _reset(monkeypatch):
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "t")
+    monkeypatch.delenv("DISCORD_ADMIN_IDS", raising=False)
+    gw._message_buffers.clear()
+    gw._conversations._conversations.clear()
+    gw._invoke = None
+    gw._publish = None
+    yield
+    for e in gw._message_buffers.values():
+        if e.get("timer"):
+            e["timer"].cancel()
+    gw._message_buffers.clear()
+
+
+def _api_recorder(monkeypatch):
+    calls: list = []
+
+    async def fake_api(method, path, body=None):
+        calls.append({"method": method, "path": path, "body": body})
+        if method == "POST" and path.endswith("/messages"):
+            return {"id": "reply1"}
+        if path.endswith("/threads"):
+            return {"id": "thread1"}
+        return None
+
+    monkeypatch.setattr(gw, "_api", fake_api)
+    return calls
+
+
+def _msg(*, content, channel="chan", mid="m1", user="u1", dm=True, mentions=()):
+    return {
+        "channel_id": channel, "id": mid, "content": content,
+        "author": {"id": user, "username": "kj"},
+        "guild_id": None if dm else "g1",
+        "mentions": [{"id": m} for m in mentions],
+    }
+
+
+def _cancel_timers():
+    for e in gw._message_buffers.values():
+        if e.get("timer"):
+            e["timer"].cancel()
+
+
+# ── routing ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dm_is_buffered(monkeypatch):
+    _api_recorder(monkeypatch)
+    await gw._handle_message(_msg(content="hi", dm=True), BOT)
+    assert "chan:u1" in gw._message_buffers
+    _cancel_timers()
+
+
+@pytest.mark.asyncio
+async def test_guild_without_mention_is_ignored(monkeypatch):
+    _api_recorder(monkeypatch)
+    await gw._handle_message(_msg(content="hello channel", dm=False), BOT)
+    assert gw._message_buffers == {}
+
+
+@pytest.mark.asyncio
+async def test_guild_mention_is_buffered_and_stripped(monkeypatch):
+    _api_recorder(monkeypatch)
+    await gw._handle_message(
+        _msg(content=f"<@{BOT}> what's up", dm=False, mentions=[BOT]), BOT)
+    entry = gw._message_buffers.get("chan:u1")
+    assert entry and entry["messages"][0]["content"] == "what's up"  # mention stripped
+    _cancel_timers()
+
+
+@pytest.mark.asyncio
+async def test_bot_and_self_messages_ignored(monkeypatch):
+    _api_recorder(monkeypatch)
+    d = _msg(content="hi")
+    d["author"]["bot"] = True
+    await gw._handle_message(d, BOT)
+    self_msg = _msg(content="hi", user=BOT)
+    await gw._handle_message(self_msg, BOT)
+    assert gw._message_buffers == {}
+
+
+@pytest.mark.asyncio
+async def test_admin_allowlist_blocks_others(monkeypatch):
+    monkeypatch.setenv("DISCORD_ADMIN_IDS", "admin1, admin2")
+    _api_recorder(monkeypatch)
+    await gw._handle_message(_msg(content="hi", user="stranger"), BOT)
+    assert gw._message_buffers == {}
+    await gw._handle_message(_msg(content="hi", user="admin1"), BOT)
+    assert "chan:admin1" in gw._message_buffers
+    _cancel_timers()
+
+
+# ── flush / invocation ──────────────────────────────────────────────────────────
+
+
+def _seed_buffer(*, channel="chan", user="u1", is_dm=True, is_new=True, contents=("hi",)):
+    cid, _new, _t = gw._conversations.get_or_create(channel, user, timeout_s=900)
+    gw._message_buffers[f"{channel}:{user}"] = {
+        "messages": [{"id": f"m{i}", "content": c} for i, c in enumerate(contents)],
+        "channel_id": channel, "user_id": user, "is_dm": is_dm,
+        "conversation_id": cid, "is_new_conversation": is_new, "timer": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_flush_combines_burst_and_tags_session(monkeypatch):
+    calls = _api_recorder(monkeypatch)
+    seen: dict = {}
+
+    async def fake_invoke(prompt, session_id):
+        seen["prompt"], seen["session_id"] = prompt, session_id
+        return "answer"
+
+    gw._invoke = fake_invoke
+    _seed_buffer(contents=("first", "second", "third"))
+    await gw._flush_burst("chan:u1")
+
+    assert seen["prompt"] == "first\n\nsecond\n\nthird"  # burst combined
+    assert seen["session_id"].startswith("discord-dm:")  # surface-tagged session
+    posts = [c for c in calls if c["method"] == "POST" and c["path"].endswith("/messages")]
+    assert posts and posts[0]["body"]["content"] == "answer"
+    assert "message_reference" not in posts[0]["body"]  # DM: no reply-quote
+
+
+@pytest.mark.asyncio
+async def test_guild_reply_quotes_and_auto_threads(monkeypatch):
+    calls = _api_recorder(monkeypatch)
+    gw._invoke = lambda p, s: _coro("ok")
+    _seed_buffer(is_dm=False, is_new=True, contents=("question here",))
+    await gw._flush_burst("chan:u1")
+
+    post = next(c for c in calls if c["method"] == "POST" and c["path"].endswith("/messages"))
+    assert post["body"]["message_reference"] == {"message_id": "m0"}  # guild reply quotes
+    thread = next((c for c in calls if c["path"].endswith("/threads")), None)
+    assert thread and thread["body"]["name"] == "question here"  # auto-threaded on first reply
+
+
+@pytest.mark.asyncio
+async def test_empty_reply_gets_graceful_fallback(monkeypatch):
+    calls = _api_recorder(monkeypatch)
+    gw._invoke = lambda p, s: _coro("   ")
+    _seed_buffer(contents=("hi",))
+    await gw._flush_burst("chan:u1")
+    post = next(c for c in calls if c["method"] == "POST" and c["path"].endswith("/messages"))
+    assert "lost the thread" in post["body"]["content"]
+
+
+# ── slow reaction ────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_slow_reaction_places_eyes_for_guild(monkeypatch):
+    monkeypatch.setenv("DISCORD_SLOW_REACTION_S", "0")
+    calls = _api_recorder(monkeypatch)
+    state: dict = {"placed": False}
+    await gw._slow_reaction_arm("chan", [{"id": "m1"}, {"id": "m2"}], False, state)
+    assert state["placed"] is True
+    reacts = [c for c in calls if "/reactions/" in c["path"] and c["method"] == "PUT"]
+    assert len(reacts) == 2  # 👀 on both burst messages
+
+
+@pytest.mark.asyncio
+async def test_slow_reaction_skips_dm(monkeypatch):
+    calls = _api_recorder(monkeypatch)
+    state: dict = {"placed": False}
+    await gw._slow_reaction_arm("chan", [{"id": "m1"}], True, state)
+    assert state["placed"] is False and calls == []
+
+
+# ── opt-in gate ──────────────────────────────────────────────────────────────────
+
+
+def test_start_in_background_off_without_token(monkeypatch):
+    monkeypatch.delenv("DISCORD_BOT_TOKEN", raising=False)
+    assert gw.start_in_background(lambda p, s: _coro("x")) is None
+
+
+def _coro(value):
+    async def _c():
+        return value
+    return _c()


### PR DESCRIPTION
Second slice of #489 — the native inbound half. DMs + channel @-mentions reach the agent and replies post back. Raw Discord Gateway/REST **v10** over `httpx` + `websockets` (both already core); no `discord.py`. **Off unless `DISCORD_BOT_TOKEN` is set.**

## Design refinement (ADR 0015 §2.1 updated)
ADR 0015 originally said "route Discord inbound through the ADR-0003 inbox." Building it showed that's wrong for a **1:1 DM** — the inbox fires into a *single* `system:activity` thread, which would collapse every Discord conversation into one and destroy per-DM continuity. So the gateway invokes the agent as a **chat surface**: the in-process `chat(prompt, session_id)` with a **per-conversation `session_id`** (the LangGraph thread key, surface-tagged for provenance), so each conversation keeps its own thread. It still **publishes a `discord.message` bus event** for console visibility (the ADR-0003 touchpoint). The inbox stays right for *non-conversational* pushes; a live DM is a chat turn.

## What's in
- `surfaces/discord/gateway.py` + `conversation.py` — ported from `-deprecated-gina`, template-neutralized, invoker **injected** (`start_in_background(invoke, publish=…)`) so it's decoupled + unit-testable.
- Proven UX: **burst debounce**, **conversation continuity**, **slow-response reactions** (👀→✅ only when slow; DMs never), **auto-threading**, **admin allowlist** (`DISCORD_ADMIN_IDS`).
- Wired into the server `startup`/`shutdown` hooks alongside the scheduler (opt-in on the token).
- Guide: `docs/guides/discord.md` (bot setup, Message Content Intent, env knobs, one-bot-per-token) + sidebar.

## Off by default
No token → the gateway never starts (verified: `start_in_background` returns `None`). Zero behavior change for forks that don't use it.

## Tests
`tests/test_discord_gateway.py` — 11 cases: routing (DM/guild-mention/allowlist/self-and-bot), mention stripping, burst combine + session tagging, DM-vs-guild reply (quote/no-quote), auto-thread, empty-reply fallback, slow-reaction lifecycle, opt-in gate. **Full suite 912 passed.** `npm run docs:build` clean.

## Deferred (next slices on #489)
Long-window context warming; return-address delivery (scheduled/proactive turns → your DM).

🤖 Generated with [Claude Code](https://claude.com/claude-code)