### PR TITLE
feat(discord): return-address delivery (ADR 0015, slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Discord return-address delivery (ADR 0015, slice 3).** When the operator DMs
+  the agent, the gateway records that DM channel as a **return address**; reactive
+  Activity-thread output (scheduler-fired reminders, inbox `now` items, scheduled
+  briefings) is then forwarded to the operator's Discord DM — so "remind me in 30
+  minutes" actually arrives. A bus subscriber forwards `activity.message` to the
+  captured channel; live Discord replies use per-conversation contexts (not the
+  Activity thread), so there's no double-post. Capture is DM-only, idempotent,
+  best-effort, and instance-scoped (`DISCORD_RETURN_ADDRESS_PATH` to override).
+  Opt-in by usage — no DM, no address, nothing forwarded.
 - **Inbound Discord gateway (ADR 0015, slice 2).** A native, opt-in listener
   (`surfaces/discord/`) — DMs + channel @-mentions reach the agent, replies post
   back. Raw Discord Gateway/REST v10 over `httpx` + `websockets` (both already

--- a/docs/guides/discord.md
+++ b/docs/guides/discord.md
@@ -58,6 +58,22 @@ GUILD_MESSAGE_REACTIONS | DIRECT_MESSAGES | MESSAGE_CONTENT`.
 | `DISCORD_DM_CONVERSATION_TIMEOUT_S` | `900` | DM conversation-continuity window. |
 | `DISCORD_BURST_DEBOUNCE_S` | `3` | Silence before a message burst is flushed. |
 | `DISCORD_SLOW_REACTION_S` | `4` | Grace window before the 👀 "still working" reaction. |
+| `DISCORD_RETURN_ADDRESS_PATH` | _(instance-scoped default)_ | Override the return-address store location. |
+
+## Proactive delivery (return address)
+
+When you DM the agent, it records that DM channel as your **return address**.
+Scheduler-fired and proactive turns have no originating caller — so reactive
+output that lands in the Activity thread (a fired reminder, an inbox `now` item,
+a scheduled briefing) is **forwarded to your Discord DM**. That's what makes
+"remind me in 30 minutes" actually arrive somewhere.
+
+- Capture is automatic + idempotent on any DM; only **DM** channels are stored
+  (a guild channel isn't a private inbox). Override the file location with
+  `DISCORD_RETURN_ADDRESS_PATH`.
+- Delivery is opt-in by usage: until you've DM'd the bot once, there's no address
+  and nothing is forwarded. Your live Discord replies aren't affected (they use
+  per-conversation contexts, not the Activity thread — no double-posting).
 
 ## One bot per agent
 
@@ -65,8 +81,7 @@ Discord's gateway permits **one concurrent connection per token**. A second
 listener on the same token evicts the first — so don't share a token across
 agents; give each its own bot (cf. [multiple instances](/guides/multi-instance)).
 
-## Not yet (follow-ups)
+## Not yet (follow-up)
 
-Long-window context warming (history beyond the live conversation) and
-return-address delivery (so scheduled / proactive turns deliver to your DM) are
-tracked as follow-up slices in the ADR-0015 build.
+Long-window context warming — seeding a fresh conversation with the last N turns
+across a conversation timeout or restart — is the remaining ADR-0015 slice.

--- a/server.py
+++ b/server.py
@@ -2443,7 +2443,11 @@ def _main():
                     if m.get("role") == "assistant" and m.get("content")
                 )
 
-            _start_discord(_discord_invoke, publish=_event_bus.publish)
+            # subscribe enables return-address delivery: reactive Activity-thread
+            # output (scheduler/inbox/proactive) is forwarded to the operator's
+            # captured Discord DM (ADR 0015).
+            _start_discord(_discord_invoke, publish=_event_bus.publish,
+                           subscribe=_event_bus.subscribe)
         except Exception:
             log.exception("[discord] gateway startup failed")
 

--- a/surfaces/discord/gateway.py
+++ b/surfaces/discord/gateway.py
@@ -35,6 +35,7 @@ from urllib.parse import quote
 
 import httpx
 
+from surfaces.discord import return_address
 from surfaces.discord.conversation import ConversationManager
 
 log = logging.getLogger("protoagent.discord")
@@ -68,6 +69,7 @@ def _admin_ids() -> set[str]:
 InvokeFn = Callable[[str, str], Awaitable[str]]
 _invoke: InvokeFn | None = None
 _publish: Callable[[str, dict], None] | None = None
+_delivery_task: "asyncio.Task | None" = None
 
 # Module-level conversation + burst state, started from _run_gateway's loop.
 _conversations = ConversationManager()
@@ -186,6 +188,40 @@ def _emit(event: str, data: dict) -> None:
         log.debug("[discord] bus publish failed (non-fatal)", exc_info=True)
 
 
+# ── return-address delivery (reactive output → operator's DM) ─────────────────
+
+
+async def _deliver_event(evt: dict) -> bool:
+    """Forward a reactive Activity-thread message to the operator's Discord DM.
+
+    Returns True if delivered. Live Discord replies use per-conversation contexts
+    (not ``system:activity``), so only scheduler/inbox/proactive output publishes
+    ``activity.message`` — there's no double-post of the gateway's own replies."""
+    if evt.get("event") != "activity.message":
+        return False
+    text = ((evt.get("data") or {}).get("text") or "").strip()
+    if not text:
+        return False
+    channel_id = return_address.get()
+    if not channel_id:
+        return False  # no DM captured yet — nothing to deliver to
+    await _reply(channel_id, "", text, is_dm=True)
+    return True
+
+
+async def _delivery_loop(subscribe: Callable[[], Any]) -> None:
+    """Subscribe to the event bus and deliver reactive output to the return
+    address. Runs for the process lifetime; cancelled on shutdown."""
+    try:
+        async for evt in subscribe():
+            try:
+                await _deliver_event(evt)
+            except Exception:
+                log.exception("[discord] activity delivery failed")
+    except asyncio.CancelledError:
+        return
+
+
 # ── message handling ──────────────────────────────────────────────────────────
 
 
@@ -226,6 +262,12 @@ async def _handle_message(d: dict, bot_id: str) -> None:
              author.get("username"), user_id, channel_id, content[:80])
     _emit("discord.message", {"channel_id": channel_id, "user_id": user_id,
                               "username": author.get("username"), "is_dm": is_dm})
+
+    # Capture the DM channel as the operator's return address so scheduler-fired /
+    # proactive turns have somewhere to deliver. Only DM channels — a guild
+    # channel is not a private inbox. Idempotent + best-effort.
+    if is_dm:
+        return_address.record(channel_id)
 
     # Buffer + (re)arm the debounce timer. No immediate reaction — fast replies
     # leave the channel clean; the slow 👀 is armed in _flush_burst.
@@ -401,20 +443,38 @@ async def _run_gateway() -> None:
             await asyncio.sleep(5)
 
 
-def start_in_background(invoke: InvokeFn, *, publish: Callable[[str, dict], None] | None = None) -> "asyncio.Task | None":
+def start_in_background(
+    invoke: InvokeFn,
+    *,
+    publish: Callable[[str, dict], None] | None = None,
+    subscribe: Callable[[], Any] | None = None,
+) -> "asyncio.Task | None":
     """Launch the gateway listener as a background task, wiring the agent
-    ``invoke(prompt, session_id)`` callable (and an optional bus ``publish``).
-    Returns ``None`` when no ``DISCORD_BOT_TOKEN`` is set (opt-in)."""
-    global _invoke, _publish
+    ``invoke(prompt, session_id)`` callable, an optional bus ``publish``, and an
+    optional bus ``subscribe`` (enables return-address delivery of reactive
+    output to the operator's DM). Returns ``None`` when no ``DISCORD_BOT_TOKEN``
+    is set (opt-in)."""
+    global _invoke, _publish, _delivery_task
     if not _token():
         log.info("[discord] DISCORD_BOT_TOKEN not set — gateway listener disabled")
         return None
     _invoke = invoke
     _publish = publish
+    if subscribe is not None:
+        _delivery_task = asyncio.create_task(_delivery_loop(subscribe))
     log.info("[discord] starting gateway listener")
     return asyncio.create_task(_run_gateway())
 
 
 async def stop() -> None:
-    """Stop the conversation sweeper (the gateway task is cancelled by the loop)."""
+    """Stop the delivery loop + conversation sweeper (the gateway task is
+    cancelled by the loop)."""
+    global _delivery_task
+    if _delivery_task is not None:
+        _delivery_task.cancel()
+        try:
+            await _delivery_task
+        except asyncio.CancelledError:
+            pass
+        _delivery_task = None
     await _conversations.stop()

--- a/surfaces/discord/return_address.py
+++ b/surfaces/discord/return_address.py
@@ -1,0 +1,70 @@
+"""Discord return-address store (ADR 0015).
+
+When the operator DMs the agent, the gateway records that **DM channel id** here.
+Scheduler-fired and proactive turns have no originating caller — they need a
+stored "where do I deliver?" address. With one captured, reactive Activity-thread
+output (ADR 0003) is forwarded to the operator's Discord DM, so "remind me in 30
+minutes" actually lands somewhere.
+
+Single small JSON file, instance-scoped via ``paths.scope_leaf`` (ADR 0004),
+mirroring the bespoke stores' ``/sandbox`` → ``~/.protoagent`` fallback. Override
+the location with ``DISCORD_RETURN_ADDRESS_PATH`` (used by tests).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+from pathlib import Path
+
+log = logging.getLogger("protoagent.discord.return_address")
+
+_LEAF = Path("discord") / "return-address.json"
+_KEY = "discord_dm_channel_id"
+
+
+def _path() -> Path:
+    override = os.environ.get("DISCORD_RETURN_ADDRESS_PATH")
+    if override:
+        p = Path(override)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return p
+
+    from paths import scope_leaf
+
+    configured = scope_leaf(Path("/sandbox") / _LEAF)
+    try:
+        configured.parent.mkdir(parents=True, exist_ok=True)
+        if os.access(configured.parent, os.W_OK):
+            return configured
+    except OSError:
+        pass
+    fallback = scope_leaf(Path.home() / ".protoagent" / _LEAF)
+    fallback.parent.mkdir(parents=True, exist_ok=True)
+    return fallback
+
+
+def get() -> str | None:
+    """The captured Discord DM channel id, or ``None`` if none recorded yet."""
+    try:
+        p = _path()
+        if not p.exists():
+            return None
+        return (json.loads(p.read_text()).get(_KEY) or None)
+    except Exception:  # noqa: BLE001 — a missing/corrupt file just means "no address"
+        return None
+
+
+def record(channel_id: str) -> None:
+    """Idempotently store ``channel_id`` as the operator's Discord return address.
+    Best-effort — never raises (a failure just means proactive delivery is off)."""
+    if not channel_id:
+        return
+    try:
+        if get() == channel_id:
+            return
+        _path().write_text(json.dumps({_KEY: channel_id}))
+        log.info("[discord] recorded return address (DM channel %s)", channel_id)
+    except Exception:
+        log.exception("[discord] failed to record return address (non-fatal)")

--- a/tests/test_discord_return_address.py
+++ b/tests/test_discord_return_address.py
@@ -1,0 +1,143 @@
+"""Tests for Discord return-address capture + delivery (ADR 0015, slice 3).
+
+The gateway records the operator's DM channel; reactive Activity-thread output
+(``activity.message`` on the bus) is forwarded to it. The store path is pointed
+at a tmp file via ``DISCORD_RETURN_ADDRESS_PATH``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from surfaces.discord import gateway as gw
+from surfaces.discord import return_address as ra
+
+
+@pytest.fixture(autouse=True)
+def _store(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISCORD_RETURN_ADDRESS_PATH", str(tmp_path / "ra.json"))
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "t")
+    monkeypatch.delenv("DISCORD_ADMIN_IDS", raising=False)
+    gw._message_buffers.clear()
+    gw._conversations._conversations.clear()
+    gw._invoke = None
+    yield
+    for e in gw._message_buffers.values():
+        if e.get("timer"):
+            e["timer"].cancel()
+    gw._message_buffers.clear()
+
+
+# ── store ──────────────────────────────────────────────────────────────────────
+
+
+def test_record_and_get_roundtrip():
+    assert ra.get() is None
+    ra.record("chan-123")
+    assert ra.get() == "chan-123"
+
+
+def test_record_is_idempotent_and_updatable():
+    ra.record("a")
+    ra.record("a")  # no-op
+    assert ra.get() == "a"
+    ra.record("b")  # newest DM wins
+    assert ra.get() == "b"
+
+
+def test_record_ignores_empty():
+    ra.record("")
+    assert ra.get() is None
+
+
+# ── capture (via the gateway) ───────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dm_captures_return_address(monkeypatch):
+    async def fake_api(method, path, body=None):
+        return None
+
+    monkeypatch.setattr(gw, "_api", fake_api)
+    d = {
+        "channel_id": "dm-chan", "id": "m1", "content": "hey",
+        "author": {"id": "u1", "username": "kj"}, "guild_id": None, "mentions": [],
+    }
+    await gw._handle_message(d, "bot")
+    assert ra.get() == "dm-chan"
+    for e in gw._message_buffers.values():
+        if e.get("timer"):
+            e["timer"].cancel()
+
+
+@pytest.mark.asyncio
+async def test_guild_message_does_not_capture(monkeypatch):
+    async def fake_api(method, path, body=None):
+        return None
+
+    monkeypatch.setattr(gw, "_api", fake_api)
+    d = {
+        "channel_id": "guild-chan", "id": "m1", "content": "<@bot> hi",
+        "author": {"id": "u1", "username": "kj"}, "guild_id": "g1",
+        "mentions": [{"id": "bot"}],
+    }
+    await gw._handle_message(d, "bot")
+    assert ra.get() is None  # guild channels are not a private return address
+    for e in gw._message_buffers.values():
+        if e.get("timer"):
+            e["timer"].cancel()
+
+
+# ── delivery ────────────────────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_activity_message_delivers_to_dm(monkeypatch):
+    sent: list = []
+
+    async def fake_api(method, path, body=None):
+        sent.append({"method": method, "path": path, "body": body})
+        return {"id": "x"}
+
+    monkeypatch.setattr(gw, "_api", fake_api)
+    ra.record("dm-chan")
+
+    delivered = await gw._deliver_event(
+        {"event": "activity.message", "data": {"text": "reminder: standup at 10"}}
+    )
+    assert delivered is True
+    post = next(c for c in sent if c["method"] == "POST" and c["path"].endswith("/messages"))
+    assert post["path"] == "/channels/dm-chan/messages"
+    assert post["body"]["content"] == "reminder: standup at 10"
+    assert "message_reference" not in post["body"]  # DM, no reply-quote
+
+
+@pytest.mark.asyncio
+async def test_no_delivery_without_return_address(monkeypatch):
+    sent: list = []
+
+    async def fake_api(method, path, body=None):
+        sent.append(path)
+        return None
+
+    monkeypatch.setattr(gw, "_api", fake_api)
+    # no ra.record() — nothing captured
+    delivered = await gw._deliver_event(
+        {"event": "activity.message", "data": {"text": "hi"}}
+    )
+    assert delivered is False and sent == []
+
+
+@pytest.mark.asyncio
+async def test_non_activity_events_ignored(monkeypatch):
+    sent: list = []
+
+    async def fake_api(method, path, body=None):
+        sent.append(path)
+        return None
+
+    monkeypatch.setattr(gw, "_api", fake_api)
+    ra.record("dm-chan")
+    assert await gw._deliver_event({"event": "inbox.item", "data": {"text": "x"}}) is False
+    assert await gw._deliver_event({"event": "activity.message", "data": {"text": "  "}}) is False
+    assert sent == []


### PR DESCRIPTION
Third slice of #489 — the "Discord reaches *you*" half. When the operator DMs the agent, the gateway records that DM channel as a **return address**; reactive Activity-thread output (scheduler-fired reminders, inbox `now` items, scheduled briefings) is forwarded there. This is what makes "remind me in 30 minutes" actually arrive.

## How
- **Capture:** `surfaces/discord/return_address.py` — a small instance-scoped JSON store (`paths.scope_leaf` + `/sandbox`→`~/.protoagent` fallback, like the other bespoke stores). The gateway calls `record(channel_id)` on any accepted **DM** (guild channels aren't a private inbox). Idempotent + best-effort.
- **Deliver:** a bus subscriber (`_delivery_loop` → `_deliver_event`) forwards `activity.message` events to the captured DM. `start_in_background` now takes an optional `subscribe` (wired to `_event_bus.subscribe`); `stop()` cancels it.

## No double-posting
Live Discord replies use per-conversation contexts (`discord-dm:…`), **not** `system:activity` — only scheduler/inbox/proactive turns publish `activity.message`. So the gateway's own replies are never re-delivered.

## Opt-in by usage
No return address until you've DM'd the bot once → nothing is forwarded. Override the store path with `DISCORD_RETURN_ADDRESS_PATH`.

## Tests
`tests/test_discord_return_address.py` — 8 cases: store roundtrip/idempotent/empty, DM captures vs guild doesn't, `activity.message` delivers to the DM, no-address and non-activity events are no-ops. **Full suite 920 passed.** Docs build clean.

## Remaining on #489
Long-window context warming (the final slice) — next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)