### PR TITLE
feat(discord): long-window context warming (ADR 0015, slice 4 — completes #489)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Discord long-window context (ADR 0015, slice 4 — completes #489).** Every
+  Discord exchange is logged to a small SQLite turn store
+  (`surfaces/discord/turn_log.py`, separate from the knowledge DB,
+  instance-scoped, `DISCORD_LOG_PATH` to override). When a conversation has gone
+  cold (continuity window expired) or the process restarted, the next message is
+  **warmed** with the last few turns for that `(channel, user)` — prepended as a
+  `<recent_conversation>` envelope (`context.py`) — restoring continuity across
+  timeouts/restarts. Best-effort: a store-init failure just disables warming.
+  (The recent-turns query tie-breaks by insertion id so same-millisecond bursts
+  stay deterministic.)
 - **Discord return-address delivery (ADR 0015, slice 3).** When the operator DMs
   the agent, the gateway records that DM channel as a **return address**; reactive
   Activity-thread output (scheduler-fired reminders, inbox `now` items, scheduled

--- a/docs/guides/discord.md
+++ b/docs/guides/discord.md
@@ -81,7 +81,11 @@ Discord's gateway permits **one concurrent connection per token**. A second
 listener on the same token evicts the first — so don't share a token across
 agents; give each its own bot (cf. [multiple instances](/guides/multi-instance)).
 
-## Not yet (follow-up)
+## Long-window context
 
-Long-window context warming — seeding a fresh conversation with the last N turns
-across a conversation timeout or restart — is the remaining ADR-0015 slice.
+Every Discord exchange is logged to a small SQLite turn store (separate from the
+knowledge DB; `DISCORD_LOG_PATH` to override). When a conversation has gone cold
+(the continuity window expired) or the process restarted, the next message is
+**warmed** with the last few turns for that `(channel, user)` — prepended as a
+`<recent_conversation>` block — so continuity survives timeouts and restarts.
+It's best-effort: if the store can't init, the gateway just runs without warming.

--- a/surfaces/discord/context.py
+++ b/surfaces/discord/context.py
@@ -1,0 +1,35 @@
+"""Context-envelope assembly for Discord turns (ADR 0015).
+
+Wraps the user's incoming message with a ``<recent_conversation>`` block when
+prior turns exist, so the model has long-window context across conversation
+timeouts and process restarts. Plain text — passed through as the user content;
+sections emit only when non-empty (no empty tags, no "no prior conversation"
+boilerplate). Ported from ``-deprecated-gina``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+from surfaces.discord.turn_log import Turn
+
+
+def assemble_discord_context(recent_turns: list[Turn], current_message: str) -> str:
+    """Build a context envelope. ``recent_turns`` is oldest-first (what
+    ``TurnLog.get_recent_turns`` returns); an empty list skips the history block.
+    Empty ``current_message`` yields ``""`` (caller decides whether to drop)."""
+    if not current_message or not current_message.strip():
+        return ""
+
+    parts: list[str] = []
+    if recent_turns:
+        lines = []
+        for t in recent_turns:
+            ts_iso = datetime.fromtimestamp(t.ts / 1000, tz=timezone.utc).isoformat(timespec="seconds")
+            label = "User" if t.role == "user" else "Assistant"
+            content = t.content.replace("\n", " ").strip()
+            lines.append(f"[{ts_iso}] {label}: {content}")
+        parts.append("<recent_conversation>\n" + "\n".join(lines) + "\n</recent_conversation>")
+
+    parts.append(f"<current_message>\n{current_message}\n</current_message>")
+    return "\n\n".join(parts)

--- a/surfaces/discord/gateway.py
+++ b/surfaces/discord/gateway.py
@@ -70,6 +70,21 @@ InvokeFn = Callable[[str, str], Awaitable[str]]
 _invoke: InvokeFn | None = None
 _publish: Callable[[str, dict], None] | None = None
 _delivery_task: "asyncio.Task | None" = None
+# Long-window turn log: None=uninitialized, False=disabled (init failed), else a
+# TurnLog instance. Lazy so an import/DB failure can't break the gateway.
+_turn_log: Any = None
+
+
+def _get_turn_log():
+    global _turn_log
+    if _turn_log is None:
+        try:
+            from surfaces.discord.turn_log import TurnLog
+            _turn_log = TurnLog()
+        except Exception:  # noqa: BLE001
+            log.exception("[discord] turn-log init failed — long-window context disabled")
+            _turn_log = False
+    return _turn_log if _turn_log is not False else None
 
 # Module-level conversation + burst state, started from _run_gateway's loop.
 _conversations = ConversationManager()
@@ -334,6 +349,27 @@ async def _flush_burst(buffer_key: str) -> None:
     if not combined:
         return
 
+    # Long-window context warming: prepend the last N turns for this
+    # (channel, user) so a fresh conversation (after a timeout or restart) still
+    # sees prior exchanges. Record the user turns AFTER reading recent ones so
+    # this burst doesn't appear in its own context block.
+    user_id: str = entry["user_id"]
+    forward_content = combined
+    tlog = _get_turn_log()
+    if tlog is not None:
+        try:
+            recent = tlog.get_recent_turns(channel_id, user_id, limit=8, max_age_hours=24)
+            if recent:
+                from surfaces.discord.context import assemble_discord_context
+                forward_content = assemble_discord_context(recent, combined)
+        except Exception:
+            log.exception("[discord] context assembly failed — proceeding without history")
+        for m in msgs:
+            try:
+                tlog.record_user_turn(channel_id, user_id, m["content"], conversation_id=conversation_id)
+            except Exception:
+                log.exception("[discord] record_user_turn failed (non-fatal)")
+
     typing_task = asyncio.create_task(_keep_typing(channel_id))
     slow_state = {"placed": False}
     slow_task = asyncio.create_task(_slow_reaction_arm(channel_id, msgs, is_dm, slow_state))
@@ -343,7 +379,7 @@ async def _flush_burst(buffer_key: str) -> None:
     surface_tag = "discord-dm" if is_dm else f"discord-channel-{channel_id}"
     session_id = f"{surface_tag}:{conversation_id}"
     try:
-        reply_text = await _ask_agent(combined, session_id)
+        reply_text = await _ask_agent(forward_content, session_id)
     finally:
         slow_task.cancel()
         typing_task.cancel()
@@ -354,6 +390,13 @@ async def _flush_burst(buffer_key: str) -> None:
                       "maybe with a little more detail?")
 
     reply_message_id = await _reply(channel_id, last_message_id, reply_text, is_dm=is_dm)
+
+    # Record the reply so the next turn's warming includes it.
+    if tlog is not None and reply_text.strip():
+        try:
+            tlog.record_assistant_turn(channel_id, user_id, reply_text, conversation_id=conversation_id)
+        except Exception:
+            log.exception("[discord] record_assistant_turn failed (non-fatal)")
 
     # Swap a placed 👀 for ✅; if it never fired (fast reply), leave it clean.
     if not is_dm and slow_state["placed"]:

--- a/surfaces/discord/turn_log.py
+++ b/surfaces/discord/turn_log.py
@@ -1,0 +1,164 @@
+"""Discord turn log — persistent record of inbound + outbound Discord messages (ADR 0015).
+
+Long-window context: when a conversation goes cold (the ConversationManager
+window expires) or the process restarts, the next message would otherwise reach
+the agent with no prior context. Logging every user message + assistant reply to
+SQLite lets us query the last N turns for a ``(channel, user)`` pair and prepend
+them, restoring continuity across timeouts and restarts.
+
+Separate DB from the knowledge store so chat-history bulk doesn't pollute
+semantic memory. Instance-scoped via ``paths.scope_leaf`` (ADR 0004), ``/sandbox``
+→ ``~/.protoagent`` fallback; override with ``DISCORD_LOG_PATH``. Ported from
+``-deprecated-gina``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sqlite3
+import time
+from dataclasses import dataclass
+from pathlib import Path
+
+log = logging.getLogger("protoagent.discord.turn_log")
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS discord_turns (
+    id              INTEGER PRIMARY KEY AUTOINCREMENT,
+    ts              INTEGER NOT NULL,
+    channel_id      TEXT    NOT NULL,
+    user_id         TEXT    NOT NULL,
+    role            TEXT    NOT NULL CHECK (role IN ('user', 'assistant')),
+    content         TEXT    NOT NULL,
+    conversation_id TEXT
+);
+
+CREATE INDEX IF NOT EXISTS idx_discord_turns_lookup
+  ON discord_turns(channel_id, user_id, ts DESC);
+"""
+
+
+@dataclass(frozen=True)
+class Turn:
+    """One side of one Discord message exchange."""
+    ts: int                # ms since epoch
+    channel_id: str
+    user_id: str
+    role: str              # "user" | "assistant"
+    content: str
+    conversation_id: str | None = None
+
+
+def _default_db_path() -> Path:
+    override = os.environ.get("DISCORD_LOG_PATH")
+    if override:
+        p = Path(override)
+        p.parent.mkdir(parents=True, exist_ok=True)
+        return p
+
+    from paths import scope_leaf
+
+    leaf = Path("discord") / "turns.db"
+    configured = scope_leaf(Path("/sandbox") / leaf)
+    try:
+        configured.parent.mkdir(parents=True, exist_ok=True)
+        if os.access(configured.parent, os.W_OK):
+            return configured
+    except OSError:
+        pass
+    fallback = scope_leaf(Path.home() / ".protoagent" / leaf)
+    fallback.parent.mkdir(parents=True, exist_ok=True)
+    return fallback
+
+
+class TurnLog:
+    """SQLite-backed log of Discord turns. Connection opened per-call (writes are
+    infrequent; keeps the threading story simple)."""
+
+    def __init__(self, db_path: str | Path | None = None):
+        self.db_path = Path(db_path) if db_path else _default_db_path()
+        self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._init_db()
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(str(self.db_path))
+        db.row_factory = sqlite3.Row
+        try:
+            db.execute("PRAGMA journal_mode=WAL")
+        except sqlite3.OperationalError:
+            pass
+        return db
+
+    def _init_db(self) -> None:
+        try:
+            db = self._connect()
+            db.executescript(_SCHEMA)
+            db.commit()
+            db.close()
+        except sqlite3.DatabaseError:
+            log.exception("[discord-log] schema init failed at %s", self.db_path)
+
+    def record_user_turn(self, channel_id, user_id, content, conversation_id=None, ts_ms=None) -> None:
+        self._record("user", channel_id, user_id, content, conversation_id, ts_ms)
+
+    def record_assistant_turn(self, channel_id, user_id, content, conversation_id=None, ts_ms=None) -> None:
+        self._record("assistant", channel_id, user_id, content, conversation_id, ts_ms)
+
+    def _record(self, role, channel_id, user_id, content, conversation_id, ts_ms) -> None:
+        if not content or not content.strip():
+            return
+        if ts_ms is None:
+            ts_ms = int(time.time() * 1000)
+        try:
+            db = self._connect()
+            db.execute(
+                "INSERT INTO discord_turns (ts, channel_id, user_id, role, content, conversation_id) "
+                "VALUES (?, ?, ?, ?, ?, ?)",
+                (ts_ms, channel_id, user_id, role, content, conversation_id),
+            )
+            db.commit()
+            db.close()
+        except sqlite3.DatabaseError:
+            log.exception("[discord-log] insert failed (%s, %s)", channel_id, user_id)
+
+    def get_recent_turns(self, channel_id, user_id, *, limit: int = 8, max_age_hours: int = 24) -> list[Turn]:
+        """Most-recent-N turns for a ``(channel, user)`` pair, **oldest first** (so
+        they read as a transcript). Empty list when nothing matches."""
+        if limit <= 0:
+            return []
+        since_ms = int(time.time() * 1000) - max_age_hours * 3600 * 1000
+        try:
+            db = self._connect()
+            rows = db.execute(
+                "SELECT ts, channel_id, user_id, role, content, conversation_id "
+                "FROM discord_turns WHERE channel_id = ? AND user_id = ? AND ts >= ? "
+                # tie-break by id (insertion order) so same-millisecond turns stay
+                # deterministic — bursts often land in the same ms.
+                "ORDER BY ts DESC, id DESC LIMIT ?",
+                (channel_id, user_id, since_ms, limit),
+            ).fetchall()
+            db.close()
+        except sqlite3.DatabaseError:
+            log.exception("[discord-log] query failed (%s, %s)", channel_id, user_id)
+            return []
+
+        return [
+            Turn(ts=r["ts"], channel_id=r["channel_id"], user_id=r["user_id"],
+                 role=r["role"], content=r["content"], conversation_id=r["conversation_id"])
+            for r in reversed(rows)
+        ]
+
+    def prune_older_than(self, max_age_days: int) -> int:
+        """Delete turns older than ``max_age_days``; returns rows removed. Best-effort."""
+        cutoff_ms = int(time.time() * 1000) - max_age_days * 86_400 * 1000
+        try:
+            db = self._connect()
+            cur = db.execute("DELETE FROM discord_turns WHERE ts < ?", (cutoff_ms,))
+            db.commit()
+            n = cur.rowcount
+            db.close()
+            return n
+        except sqlite3.DatabaseError:
+            log.exception("[discord-log] prune failed")
+            return 0

--- a/tests/test_discord_context.py
+++ b/tests/test_discord_context.py
@@ -1,0 +1,115 @@
+"""Tests for Discord long-window context (ADR 0015, slice 4).
+
+The turn log (SQLite) + context-envelope assembler, and the gateway warming path
+that prepends recent turns and records new ones. The DB is pointed at a tmp file
+via ``DISCORD_LOG_PATH``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from surfaces.discord import gateway as gw
+from surfaces.discord.context import assemble_discord_context
+from surfaces.discord.turn_log import Turn, TurnLog
+
+
+@pytest.fixture
+def tlog(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISCORD_LOG_PATH", str(tmp_path / "turns.db"))
+    return TurnLog()
+
+
+# ── turn log ───────────────────────────────────────────────────────────────────
+
+
+def test_record_and_recent_roundtrip(tlog):
+    tlog.record_user_turn("c", "u", "hello", conversation_id="conv1")
+    tlog.record_assistant_turn("c", "u", "hi there", conversation_id="conv1")
+    recent = tlog.get_recent_turns("c", "u")
+    assert [t.role for t in recent] == ["user", "assistant"]  # oldest-first
+    assert recent[0].content == "hello" and recent[1].content == "hi there"
+
+
+def test_recent_scoped_by_channel_user(tlog):
+    tlog.record_user_turn("c1", "u", "one")
+    tlog.record_user_turn("c2", "u", "two")
+    tlog.record_user_turn("c1", "other", "three")
+    assert [t.content for t in tlog.get_recent_turns("c1", "u")] == ["one"]
+
+
+def test_recent_respects_limit_and_blank_skipped(tlog):
+    for i in range(5):
+        tlog.record_user_turn("c", "u", f"m{i}")
+    tlog.record_user_turn("c", "u", "   ")  # blank ⇒ not stored
+    recent = tlog.get_recent_turns("c", "u", limit=3)
+    assert [t.content for t in recent] == ["m2", "m3", "m4"]  # last 3, oldest-first
+
+
+# ── context assembler ───────────────────────────────────────────────────────────
+
+
+def test_assemble_wraps_history_and_current():
+    turns = [Turn(ts=1_700_000_000_000, channel_id="c", user_id="u", role="user", content="prior q"),
+             Turn(ts=1_700_000_001_000, channel_id="c", user_id="u", role="assistant", content="prior a")]
+    out = assemble_discord_context(turns, "now what?")
+    assert "<recent_conversation>" in out and "User: prior q" in out and "Assistant: prior a" in out
+    assert "<current_message>\nnow what?\n</current_message>" in out
+
+
+def test_assemble_no_history_is_bare_current():
+    out = assemble_discord_context([], "just this")
+    assert "<recent_conversation>" not in out
+    assert out == "<current_message>\njust this\n</current_message>"
+
+
+def test_assemble_empty_current_is_empty():
+    assert assemble_discord_context([], "") == ""
+
+
+# ── gateway warming integration ─────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_flush_warms_with_history_and_records(tmp_path, monkeypatch):
+    monkeypatch.setenv("DISCORD_LOG_PATH", str(tmp_path / "turns.db"))
+    monkeypatch.setenv("DISCORD_BOT_TOKEN", "t")
+    gw._message_buffers.clear()
+    gw._conversations._conversations.clear()
+    gw._turn_log = None  # force a fresh lazy-init against the tmp DB
+
+    async def fake_api(method, path, body=None):
+        return {"id": "r1"}
+
+    monkeypatch.setattr(gw, "_api", fake_api)
+
+    seen: dict = {}
+
+    async def fake_invoke(prompt, session_id):
+        seen["prompt"] = prompt
+        return "the answer"
+
+    gw._invoke = fake_invoke
+
+    # Pre-seed a prior exchange in the log so warming has something to prepend.
+    tl = gw._get_turn_log()
+    tl.record_user_turn("dm", "u1", "earlier question", conversation_id="old")
+    tl.record_assistant_turn("dm", "u1", "earlier answer", conversation_id="old")
+
+    cid, _n, _t = gw._conversations.get_or_create("dm", "u1", timeout_s=900)
+    gw._message_buffers["dm:u1"] = {
+        "messages": [{"id": "m0", "content": "follow up"}], "channel_id": "dm",
+        "user_id": "u1", "is_dm": True, "conversation_id": cid,
+        "is_new_conversation": True, "timer": None,
+    }
+    await gw._flush_burst("dm:u1")
+
+    # The invocation prompt was warmed with the prior turns.
+    assert "<recent_conversation>" in seen["prompt"]
+    assert "earlier question" in seen["prompt"] and "follow up" in seen["prompt"]
+    # This turn (user msg + assistant reply) is now recorded.
+    recent = tl.get_recent_turns("dm", "u1")
+    assert "follow up" in [t.content for t in recent]
+    assert "the answer" in [t.content for t in recent]
+
+    gw._turn_log = None

--- a/tests/test_discord_gateway.py
+++ b/tests/test_discord_gateway.py
@@ -26,7 +26,9 @@ def _reset(monkeypatch):
     gw._conversations._conversations.clear()
     gw._invoke = None
     gw._publish = None
+    gw._turn_log = False  # disable long-window warming here — covered in its own test
     yield
+    gw._turn_log = None
     for e in gw._message_buffers.values():
         if e.get("timer"):
             e["timer"].cancel()


### PR DESCRIPTION
Final slice of #489. Every Discord exchange is logged; a fresh conversation (after a timeout or restart) is warmed with the last few turns so continuity doesn't reset.

## What
- **`surfaces/discord/turn_log.py`** — SQLite turn store (separate from the knowledge DB so chat bulk doesn't pollute semantic memory). Instance-scoped path (`paths.scope_leaf` + sandbox→home fallback); `DISCORD_LOG_PATH` to override. `record_user_turn`/`record_assistant_turn`/`get_recent_turns`/`prune_older_than`.
- **`surfaces/discord/context.py`** — `assemble_discord_context(recent, current)` → a `<recent_conversation>` + `<current_message>` envelope (only emits history when present).
- **`_flush_burst` warming** — reads recent turns, prepends them, invokes; records the burst's user messages (after the read, so they don't appear in their own context) + the assistant reply. Lazy-init with a poison-value fallback so a store failure just disables warming (no gateway impact).

## Fixed (latent, from the source)
`get_recent_turns` now tie-breaks `ORDER BY ts DESC, id DESC` — same-millisecond bursts were otherwise non-deterministic. A test caught it.

## Tests
`tests/test_discord_context.py` — 7 cases: store roundtrip + scoping + limit/blank, envelope assembly (history / bare / empty), and the gateway warming integration (prior turns prepended, this turn recorded). **Full suite 927 passed.** Docs build clean.

## #489 complete
All four slices shipped: outbound tools (#490) · inbound gateway (#491) · return-address (#492) · long-window context (this). Closes #489.

🤖 Generated with [Claude Code](https://claude.com/claude-code)