### PR TITLE
fix(a2a): reconcile restart-interrupted tasks to failed (#486)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -104,6 +104,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `protolabs_a2a` helper exists; this is the non-blocking declaration/card half.
 
 ### Fixed
+- **A2A restart reconciliation restored — interrupted tasks fail instead of silently vanishing (#486).**
+  The #443 migration to the `a2a-sdk` `DatabaseTaskStore` dropped the bespoke
+  store's boot-time reconciliation, so a task left `submitted`/`working` when the
+  process stopped lingered as fake-active (its LangGraph runner is dead) until
+  the 24h TTL *deleted* it — never surfacing a terminal state to pollers or push
+  consumers. `initialize_a2a_stores` now runs `reconcile_interrupted_tasks`
+  **before** the TTL sweep: a dialect-agnostic JSON-path `UPDATE` (the SDK itself
+  filters on `status['state']`) transitions `submitted`/`working` rows to
+  `failed` with an "interrupted by restart" message. `input_required`/
+  `auth_required` pauses are left alone — their checkpoint survives and can
+  resume. Observed on a Roxy instance (a task stuck in `submitted`); fixes the
+  fork too.
 - **A2A auth: caller bearer token is authoritative + origin guard is browser-only (#482).**
   Two `a2a_auth.py` correctness bugs (found via CodeRabbit on protoPen's port,
   fixed there in protoPen#145). (1) `configure()` collapsed `bearer_token` with

--- a/a2a_stores.py
+++ b/a2a_stores.py
@@ -34,7 +34,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
-from sqlalchemy import delete
+from sqlalchemy import delete, update
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from a2a.server.context import ServerCallContext
@@ -291,19 +291,85 @@ async def sweep_expired_tasks(
         return result.rowcount or 0
 
 
+# Non-terminal states a restart leaves dead: a queued (``submitted``) or
+# mid-flight (``working``) task can never progress once its LangGraph runner is
+# gone. We deliberately do NOT touch ``input_required`` / ``auth_required`` —
+# those are HITL / auth *pauses* whose LangGraph checkpoint survives the restart
+# and can resume on the next message, so failing them would be wrong.
+_INTERRUPTED_STATES = ("TASK_STATE_SUBMITTED", "TASK_STATE_WORKING")
+
+
+def _interrupted_status_blob(now: datetime) -> dict:
+    """A serialized ``failed`` ``TaskStatus`` carrying a restart error, in the
+    same proto-JSON shape the SDK store writes (``MessageToDict``)."""
+    import uuid
+
+    from google.protobuf.json_format import MessageToDict
+    from google.protobuf.timestamp_pb2 import Timestamp
+
+    from a2a.types import Message, Part, Role, TaskState, TaskStatus
+
+    ts = Timestamp()
+    ts.FromDatetime(now)
+    msg = Message(
+        message_id=str(uuid.uuid4()),
+        role=Role.ROLE_AGENT,
+        parts=[Part(text="Task interrupted by an agent restart; its runner did not survive.")],
+    )
+    status = TaskStatus(state=TaskState.TASK_STATE_FAILED, message=msg, timestamp=ts)
+    return MessageToDict(status)
+
+
+async def reconcile_interrupted_tasks(
+    engine: AsyncEngine, *, now: datetime | None = None
+) -> int:
+    """Fail any task left non-terminal (``submitted`` / ``working``) by a restart.
+
+    The bespoke task store did this; the SDK store doesn't — so an interrupted
+    task lingers as fake-active until the 24h TTL silently *deletes* it, never
+    surfacing a terminal state. A LangGraph runner doesn't survive a restart, so
+    such a task is dead: transition it to ``failed`` with an error a caller can
+    react to. The SDK serializes ``status`` as proto-JSON and itself filters on
+    ``status['state']`` (in ``list_tasks``), so a dialect-agnostic JSON-path
+    UPDATE mirrors ``sweep_expired_tasks``. Returns the rows reconciled. (#486)
+    """
+    now = now or datetime.now(UTC)
+    blob = _interrupted_status_blob(now)
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    session_maker = async_sessionmaker(engine, expire_on_commit=False)
+    async with session_maker() as session:
+        result = await session.execute(
+            update(TaskModel)
+            .where(TaskModel.status["state"].as_string().in_(_INTERRUPTED_STATES))
+            .values(status=blob, last_updated=now)
+        )
+        await session.commit()
+        return result.rowcount or 0
+
+
 async def initialize_a2a_stores(
     task_store: DatabaseTaskStore,
     push_store: ValidatingPushNotificationConfigStore,
 ) -> None:
-    """Create the schemas + run the task TTL sweep at boot.
+    """Create the schemas, reconcile restart-interrupted tasks, and run the TTL
+    sweep at boot.
 
-    The bespoke task store also failed any non-terminal task on restart (its
-    LangGraph runner doesn't survive). The SDK store doesn't expose a state
-    index for that, and stale non-terminal rows age out via the 24h sweep, so
-    we run the sweep here and leave the rest to the SDK's own task lifecycle.
+    Restores the bespoke store's restart behavior the #443 migration dropped:
+    non-terminal ``submitted`` / ``working`` tasks (dead — their LangGraph runner
+    didn't survive) are failed *before* the TTL sweep, so they surface as
+    terminal ``failed`` rather than being silently deleted at 24h (#486).
+    ``input_required`` / ``auth_required`` pauses are left alone (resumable from
+    the checkpoint).
     """
     await task_store.initialize()
     await push_store.initialize()
+    try:
+        r = await reconcile_interrupted_tasks(task_store.engine)
+        if r:
+            log.info("[a2a] reconciled %d interrupted task(s) to failed (restart)", r)
+    except Exception:
+        log.exception("[a2a] interrupted-task reconciliation failed; continuing")
     try:
         n = await sweep_expired_tasks(task_store.engine)
         if n:

--- a/tests/test_a2a_stores.py
+++ b/tests/test_a2a_stores.py
@@ -21,8 +21,10 @@ from a2a.types import TaskPushNotificationConfig
 import a2a_stores
 from a2a_stores import (
     ValidatingPushNotificationConfigStore,
+    initialize_a2a_stores,
     is_safe_webhook_url,
     make_sqlite_engine,
+    reconcile_interrupted_tasks,
     sweep_expired_tasks,
 )
 from a2a.server.tasks import DatabaseTaskStore
@@ -129,6 +131,74 @@ async def test_task_ttl_sweep_evicts_old_rows(tmp_path):
     assert deleted == 1
     assert await store.get("stale", ctx) is None
     assert await store.get("fresh", ctx) is not None
+    await engine.dispose()
+
+
+# ── (a2) restart reconciliation: interrupted tasks fail, not linger (#486) ───────
+
+
+async def _seed_states(tmp_path) -> tuple:
+    """A store seeded with one task per interesting state."""
+    from a2a.types import a2a_pb2
+
+    ctx = _ctx()
+    engine = make_sqlite_engine(str(tmp_path / "a2a-tasks.db"))
+    store = DatabaseTaskStore(engine)
+    await store.initialize()
+    for tid, state in [
+        ("submitted", a2a_pb2.TASK_STATE_SUBMITTED),
+        ("working", a2a_pb2.TASK_STATE_WORKING),
+        ("waiting", a2a_pb2.TASK_STATE_INPUT_REQUIRED),
+        ("done", a2a_pb2.TASK_STATE_COMPLETED),
+    ]:
+        await store.save(
+            a2a_pb2.Task(id=tid, context_id="c", status=a2a_pb2.TaskStatus(state=state)), ctx
+        )
+    return store, engine, ctx
+
+
+@pytest.mark.asyncio
+async def test_reconcile_fails_only_interrupted_states(tmp_path):
+    """submitted + working → failed; input_required + completed left alone."""
+    from a2a.types import a2a_pb2
+
+    store, engine, ctx = await _seed_states(tmp_path)
+    n = await reconcile_interrupted_tasks(engine)
+    assert n == 2  # only submitted + working
+
+    assert (await store.get("submitted", ctx)).status.state == a2a_pb2.TASK_STATE_FAILED
+    assert (await store.get("working", ctx)).status.state == a2a_pb2.TASK_STATE_FAILED
+    # input_required is a resumable HITL/auth pause — must NOT be failed.
+    assert (await store.get("waiting", ctx)).status.state == a2a_pb2.TASK_STATE_INPUT_REQUIRED
+    assert (await store.get("done", ctx)).status.state == a2a_pb2.TASK_STATE_COMPLETED
+
+    # the terminal failure carries an error message a caller can react to.
+    failed = await store.get("submitted", ctx)
+    assert failed.status.message.parts[0].text
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_is_idempotent(tmp_path):
+    """A second pass touches nothing (already-failed isn't an interrupted state)."""
+    store, engine, ctx = await _seed_states(tmp_path)
+    assert await reconcile_interrupted_tasks(engine) == 2
+    assert await reconcile_interrupted_tasks(engine) == 0
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_initialize_reconciles_before_sweep(tmp_path):
+    """initialize_a2a_stores fails interrupted tasks at boot so they surface as
+    terminal `failed` (not silently deleted)."""
+    from a2a.types import a2a_pb2
+
+    store, engine, ctx = await _seed_states(tmp_path)
+    push_store = ValidatingPushNotificationConfigStore(engine)
+    await initialize_a2a_stores(store, push_store)
+
+    assert (await store.get("submitted", ctx)).status.state == a2a_pb2.TASK_STATE_FAILED
+    assert (await store.get("working", ctx)).status.state == a2a_pb2.TASK_STATE_FAILED
     await engine.dispose()
 
 


### PR DESCRIPTION
Closes #486. Confirmed it's our regression from #443 — the migration to the `a2a-sdk` `DatabaseTaskStore` restored TTL eviction but **not** the bespoke store's boot-time reconciliation (the shipped docstring even admitted it).

## The bug
A task left `submitted`/`working` when the process stops is dead — its LangGraph runner doesn't survive — but the SDK store keeps reporting it non-terminal. So it shows as fake-active to pollers/consoles, and is **silently *deleted*** at the 24h TTL instead of surfacing a terminal `failed` (A2A callers + push consumers never get a final event). Observed live on a Roxy instance.

## The fix
`initialize_a2a_stores` now runs `reconcile_interrupted_tasks` **before** the TTL sweep.

The issue suggested `UPDATE ... WHERE state IN (...)`; `status` (holding `state`) is a **JSON column**, not an indexed one (that's why it was punted). But the SDK *itself* filters on `status['state']` via a JSON path in `list_tasks` — so a dialect-agnostic JSON-path `UPDATE` works cleanly, no load-mutate-save:
```python
update(TaskModel)
  .where(TaskModel.status["state"].as_string().in_(("TASK_STATE_SUBMITTED", "TASK_STATE_WORKING")))
  .values(status=<failed-status proto-JSON, "interrupted by restart">, last_updated=now)
```

## Scope refinement
Fail **`submitted` + `working`** only. **Not** `input_required`/`auth_required` — the issue called those "arguably," but they're HITL/auth *pauses* whose LangGraph checkpoint survives a restart and can resume on the next message; failing them would be wrong.

## Tests
3 new cases: only interrupted states fail (input_required/completed untouched, failure carries an error message), idempotent, and `initialize_a2a_stores` reconciles at boot. **Full suite 930 passed.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)