### PR TITLE
fix(ci): repair prepare-release.yml YAML (broken by #485)

### DIFF
--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -96,14 +96,7 @@ jobs:
             --base main \
             --head "${BRANCH}" \
             --title "chore: release v${VERSION}" \
-            --body "Automated version bump to \`v${VERSION}\`. Review + merge through the normal CI/review gate, then push the tag to cut the release:
-
-\`\`\`sh
-git checkout main && git pull
-git tag -a v${VERSION} -m \"Release v${VERSION}\" && git push origin v${VERSION}
-\`\`\`
-
-The tag push triggers release.yml (Docker tags + GitHub Release + Discord). Don't \`workflow_dispatch\` release.yml afterward — that's redundant and 422s on the duplicate.")
+            --body "Automated version bump to \`v${VERSION}\`. Review + merge through the normal CI/review gate, then push the tag to cut the release: \`git checkout main && git pull && git tag -a v${VERSION} -m 'Release v${VERSION}' && git push origin v${VERSION}\`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).")
           echo "Opened: ${PR_URL}"
 
           # We do NOT auto-merge or tag here (fleet policy, 2026-06-02:


### PR DESCRIPTION
#485 (release-docs fix) accidentally put the PR-body code-fence `git` commands at column 0 inside the `run: |` literal block, terminating it early → **invalid YAML** → GitHub couldn't register the `workflow_dispatch` trigger. The v0.11.0 release dispatch failed with `422: Workflow does not have 'workflow_dispatch' trigger`.

Fix: collapse the multi-line PR body to a single YAML-safe line with the tag-push commands inline. Validated with `yaml.safe_load`. Unblocks all releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)