### PR TITLE
Console fixes (A2A 1.0 chat, SSE render, beads/setup) + white-label brand name

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **White-label brand name (driven by `identity.name`).** The console topbar +
+  window/tab title now follow the configured agent name (Settings → Identity),
+  defaulting to `protoAgent` — a fork sets its name once and the whole UI follows,
+  no hardcoded rebrand.
+
+### Fixed
+- **Console chat fixed for A2A 1.0 (was a never-resolving spinner).** The React
+  console's `streamChat` still spoke A2A **0.3** (`message/stream` with
+  `parts:[{kind:'text'}]`), but the server moved to A2A 1.0 (a2a-sdk) — which
+  returns `-32601 Method not found` (HTTP 200), so the SSE reader waited forever.
+  Updated to 1.0: `SendStreamingMessage`, `role:'ROLE_USER'`, member-discriminated
+  `parts:[{text}]` + `messageId`/`contextId`, `A2A-Version: 1.0` header, and frame
+  parsing for the 1.0 `task`/`statusUpdate`/`artifactUpdate` shapes (0.3 kept as
+  fallback). Turn-complete = SSE stream close. Also fixes the brand logo path
+  (hardcoded `/app/…` 404s in the desktop bundle → `import.meta.env.BASE_URL`).
+- **Desktop chat renders the agent's reply (was a silent "no response").** The
+  console reads the A2A turn over SSE via `response.body.getReader()`, but
+  WKWebView (the desktop shell) doesn't reliably expose a readable fetch stream
+  (`response.body` can be null, or the reader reports `done` with no chunks).
+  `consumeSse` now clones the response up front and **falls back to a buffered
+  read** when streaming yields nothing — the turn always renders (streaming is
+  kept wherever the browser supports it).
+- **Beads no longer requires a `project_path` for an unconfigured agent.** The
+  in-process (agent-global) beads store is now ensured before route registration,
+  so first launch (pre-setup) no longer binds the CLI fallback that raises
+  `project_path is required` and breaks the console's Beads panel during setup.
+
 ## [0.11.0] - 2026-06-03
 
 ### Added

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -122,6 +122,12 @@ export function App() {
   // System → Runtime panel reads the same key via useSuspenseQuery.
   const runtimeQ = useQuery({ ...runtimeStatusQuery(), retry: 30, retryDelay: 1000 });
   const runtime = runtimeQ.data ?? null;
+  // White-label the window/tab title to the configured identity (default
+  // protoAgent), so a fork's title follows its name without a rebuild.
+  useEffect(() => {
+    const name = runtime?.identity?.name;
+    if (name) document.title = name;
+  }, [runtime]);
   const [workspace, setWorkspace] = useState<NotesWorkspace | null>(null);
   const [error, setError] = useState("");
 
@@ -440,7 +446,10 @@ export function App() {
               hardcoded "/app/…" 404s in the bundle (assets sit at the root). */}
           <img src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`} alt="" className="brand-mark" />
           <div>
-            <div className="brand-name">Gina</div>
+            {/* White-label: the brand name follows the configured identity
+                (Settings → Identity), defaulting to protoAgent for the template.
+                A fork sets its name once and the whole UI follows. */}
+            <div className="brand-name">{runtime?.identity?.name || "protoAgent"}</div>
             <div className="brand-subline">protoLabs.studio</div>
           </div>
         </div>

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -436,9 +436,11 @@ export function App() {
           Interactive children (the status dot) stay clickable; harmless on web. */}
       <header className="topbar" data-tauri-drag-region>
         <div className="brand-lockup">
-          <img src="/app/protolabs-icon-outline.svg" alt="" className="brand-mark" />
+          {/* BASE_URL is "/app/" in dev and "./" in the desktop build — a
+              hardcoded "/app/…" 404s in the bundle (assets sit at the root). */}
+          <img src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`} alt="" className="brand-mark" />
           <div>
-            <div className="brand-name">protoAgent</div>
+            <div className="brand-name">Gina</div>
             <div className="brand-subline">protoLabs.studio</div>
           </div>
         </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -27,31 +27,47 @@ type RequestOptions = Omit<RequestInit, "body"> & {
   body?: unknown;
 };
 
+type A2APart = {
+  kind?: string;
+  text?: string;
+  data?: unknown;
+  metadata?: { mimeType?: string };
+};
+type A2AStatus = {
+  state?: string;
+  message?: { parts?: A2APart[] };
+};
 type A2AFrame = {
   jsonrpc?: string;
   id?: string;
   result?: {
+    // A2A 1.0 streaming frames nest the payload under task / statusUpdate /
+    // artifactUpdate; A2A 0.3 used a flat `kind`-tagged result. We read both.
+    task?: {
+      id?: string;
+      contextId?: string;
+      status?: A2AStatus;
+    };
+    statusUpdate?: {
+      taskId?: string;
+      contextId?: string;
+      status?: A2AStatus;
+      final?: boolean;
+    };
+    artifactUpdate?: {
+      taskId?: string;
+      artifact?: { parts?: A2APart[] };
+      append?: boolean;
+      lastChunk?: boolean;
+    };
+    // ── A2A 0.3 (back-compat) ──
     kind?: string;
     id?: string;
     taskId?: string;
     contextId?: string;
-    status?: {
-      state?: string;
-      message?: {
-        parts?: Array<{
-          kind?: string;
-          text?: string;
-          data?: unknown;
-          metadata?: { mimeType?: string };
-        }>;
-      };
-    };
-    artifact?: {
-      parts?: Array<{ kind?: string; text?: string }>;
-    };
-    artifacts?: Array<{
-      parts?: Array<{ kind?: string; text?: string }>;
-    }>;
+    status?: A2AStatus;
+    artifact?: { parts?: A2APart[] };
+    artifacts?: Array<{ parts?: A2APart[] }>;
     append?: boolean;
     lastChunk?: boolean;
     final?: boolean;
@@ -408,17 +424,22 @@ export const api = {
     const rpcId = `web-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const response = await fetch(apiUrl("/a2a"), {
       method: "POST",
-      headers: { "Content-Type": "application/json" },
+      headers: { "Content-Type": "application/json", "A2A-Version": "1.0" },
       signal: handlers.signal,
+      // A2A 1.0 (a2a-sdk): the streaming RPC is `SendStreamingMessage` (0.3's
+      // `message/stream` is gone → -32601 Method not found, the cause of a
+      // never-resolving spinner). Message uses ROLE_USER, member-discriminated
+      // parts (`{text}`, not `{kind,text}`), and carries messageId + contextId.
       body: JSON.stringify({
         jsonrpc: "2.0",
         id: rpcId,
-        method: "message/stream",
+        method: "SendStreamingMessage",
         params: {
-          contextId: sessionId,
           message: {
-            role: "user",
-            parts: [{ kind: "text", text: message }],
+            role: "ROLE_USER",
+            parts: [{ text: message }],
+            messageId: rpcId,
+            contextId: sessionId,
           },
         },
       }),
@@ -433,34 +454,42 @@ export const api = {
       const result = frame.result;
       if (!result) return;
 
-      if (result.kind === "task" && result.id) {
-        handlers.onTaskId?.(result.id);
-        const terminalText = textFromTerminalTask(result);
+      // A2A 1.0 nests the event (task / statusUpdate / artifactUpdate); fall
+      // back to the flat 0.3 `kind`-tagged shape.
+      const task = result.task ?? (result.kind === "task" ? result : undefined);
+      const statusUpdate =
+        result.statusUpdate ?? (result.kind === "status-update" ? result : undefined);
+      const artifactUpdate =
+        result.artifactUpdate ?? (result.kind === "artifact-update" ? result : undefined);
+
+      if (task?.id) {
+        handlers.onTaskId?.(task.id);
+        const terminalText = textFromTerminalTask(task);
         if (terminalText) handlers.onText?.(terminalText, false);
       }
 
-      if (result.kind === "status-update") {
-        const state = result.status?.state || "";
-        const messageText = textFromParts(result.status?.message?.parts);
+      if (statusUpdate) {
+        const state = statusUpdate.status?.state || "";
+        const parts = statusUpdate.status?.message?.parts;
+        const messageText = textFromParts(parts);
         handlers.onStatus?.(messageText || state);
-        const toolEvent = toolEventFromParts(result.status?.message?.parts);
+        const toolEvent = toolEventFromParts(parts);
         if (toolEvent) handlers.onToolCall?.(toolEvent);
-        // HITL pause: the turn parked awaiting the operator. Surface the form /
-        // question payload so the console can render it (falls back to the text).
-        if (state === "input-required") {
-          handlers.onInputRequired?.(
-            hitlFromParts(result.status?.message?.parts) || { question: messageText },
-          );
+        // HITL pause: the turn parked awaiting the operator (0.3 `input-required`
+        // / 1.0 `TASK_STATE_INPUT_REQUIRED`). Surface the form/question payload.
+        if (state === "input-required" || state === "TASK_STATE_INPUT_REQUIRED") {
+          handlers.onInputRequired?.(hitlFromParts(parts) || { question: messageText });
         }
-        if (result.final) handlers.onDone?.();
       }
 
-      if (result.kind === "artifact-update") {
-        const text = textFromParts(result.artifact?.parts);
-        if (text) handlers.onText?.(text, result.append !== false);
-        if (result.lastChunk) handlers.onDone?.();
+      if (artifactUpdate) {
+        const text = textFromParts(artifactUpdate.artifact?.parts);
+        if (text) handlers.onText?.(text, artifactUpdate.append !== false);
       }
     });
+    // The SSE stream closing is the canonical "turn complete" signal in A2A 1.0
+    // (terminal-by-state, no `final` flag) — resolve the spinner here.
+    handlers.onDone?.();
   },
 
   cancelTask(taskId: string) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -184,35 +184,83 @@ function textFromTerminalTask(result: NonNullable<A2AFrame["result"]>) {
     .join("");
 }
 
+// Parse complete SSE events (`\n\n`-delimited) out of a buffer, dispatching each
+// frame. Returns the unconsumed remainder. Shared by the streaming + buffered
+// paths so both decode frames identically.
+function drainSseBuffer(buffer: string, onFrame: (frame: A2AFrame) => void): string {
+  let boundary = buffer.indexOf("\n\n");
+  while (boundary !== -1) {
+    const rawEvent = buffer.slice(0, boundary);
+    buffer = buffer.slice(boundary + 2);
+    boundary = buffer.indexOf("\n\n");
+
+    const data = rawEvent
+      .split("\n")
+      .filter((line) => line.startsWith("data:"))
+      .map((line) => line.slice(5).trim())
+      .join("\n");
+    if (data) onFrame(JSON.parse(data) as A2AFrame);
+  }
+  return buffer;
+}
+
+async function consumeBuffered(
+  response: Response,
+  onFrame: (frame: A2AFrame) => void,
+): Promise<void> {
+  // Await the whole body, then parse every frame at once. Loses token-by-token
+  // streaming but always renders the turn — the fallback for environments that
+  // don't expose a readable fetch stream.
+  const text = await response.text();
+  drainSseBuffer(text.endsWith("\n\n") ? text : `${text}\n\n`, onFrame);
+}
+
 async function consumeSse(
   response: Response,
   onFrame: (frame: A2AFrame) => void,
 ): Promise<void> {
+  // WKWebView (the desktop shell) doesn't reliably expose a readable stream on a
+  // fetch response — `response.body` can be null, or the reader can throw before
+  // the first chunk — which left the desktop chat with NO response at all (the
+  // agent replied, but the SSE never rendered). Clone up front so we can fall
+  // back to a buffered read (the clone keeps its own body once we lock the
+  // original via getReader()).
+  let fallback: Response | null = null;
+  try {
+    fallback = response.clone();
+  } catch {
+    fallback = null;
+  }
+
   const reader = response.body?.getReader();
-  if (!reader) throw new Error("streaming response has no body");
+  if (!reader) {
+    return consumeBuffered(fallback ?? response, onFrame);
+  }
 
   const decoder = new TextDecoder();
   let buffer = "";
+  let streamed = false;
 
-  while (true) {
-    const { value, done } = await reader.read();
-    if (done) break;
-    buffer += decoder.decode(value, { stream: true });
-
-    let boundary = buffer.indexOf("\n\n");
-    while (boundary !== -1) {
-      const rawEvent = buffer.slice(0, boundary);
-      buffer = buffer.slice(boundary + 2);
-      boundary = buffer.indexOf("\n\n");
-
-      const data = rawEvent
-        .split("\n")
-        .filter((line) => line.startsWith("data:"))
-        .map((line) => line.slice(5).trim())
-        .join("\n");
-      if (!data) continue;
-      onFrame(JSON.parse(data) as A2AFrame);
+  try {
+    while (true) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      streamed = true;
+      buffer += decoder.decode(value, { stream: true });
+      buffer = drainSseBuffer(buffer, onFrame);
     }
+  } catch (err) {
+    // Reader threw. If we never saw a chunk and have a clone, retry buffered;
+    // otherwise a mid-stream failure is real — propagate it.
+    if (streamed || !fallback) throw err;
+    return consumeBuffered(fallback, onFrame);
+  }
+
+  // Reader completed but delivered nothing (WKWebView can hand back a reader
+  // that immediately reports `done` without ever surfacing the buffered body) —
+  // render via the buffered fallback so the turn isn't silently lost.
+  if (!streamed && fallback) {
+    return consumeBuffered(fallback, onFrame);
   }
 }
 

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/server.py
+++ b/server.py
@@ -265,7 +265,8 @@ def _init_langgraph_agent(headless_setup: bool = False):
     global _inbox_store, _storm_guard, _beads_store
     _inbox_store = _build_inbox_store(_graph_config)
     from beads import BeadsStore
-    _beads_store = BeadsStore()  # in-process issue tracker (Sprint B), instance-scoped
+    if _beads_store is None:  # may have been created early (pre-setup) for the routes
+        _beads_store = BeadsStore()  # in-process issue tracker (Sprint B), instance-scoped
     if _storm_guard is None:
         from inbox import StormGuard
         _storm_guard = StormGuard()
@@ -2372,6 +2373,17 @@ def _main():
                     "usage": f"/{wf['name']}{req}{opt}",
                 })
         return {"commands": commands}
+
+    # The in-process beads store is agent-global + graph-independent, but it's
+    # otherwise created in _init_langgraph_agent (which only runs once setup is
+    # complete). For a fresh, unconfigured agent (first launch, before the wizard)
+    # ensure it exists now — otherwise the beads routes bind the CLI fallback
+    # service that raises "project_path is required" (the agent-global adapter
+    # ignores project_path). Reused by _init_langgraph_agent later.
+    global _beads_store
+    if _beads_store is None:
+        from beads import BeadsStore
+        _beads_store = BeadsStore()
 
     register_operator_routes(
         fastapi_app,

--- a/tests/test_operator_api_routes.py
+++ b/tests/test_operator_api_routes.py
@@ -62,6 +62,34 @@ def _client(*, run=None):
     return TestClient(app), notes
 
 
+class _FakeBeadsStore:
+    """In-process agent-global store (no project scope) — what server.py wires
+    when available, so the routes use the adapter that ignores project_path."""
+
+    def list(self):
+        return [{"id": "bd-1"}]
+
+
+def test_beads_store_route_ignores_project_path() -> None:
+    """With an in-process store wired, beads endpoints don't require a
+    project_path (regression: an unconfigured agent bound the CLI service and
+    returned 400 'project_path is required')."""
+    app = FastAPI()
+    register_operator_routes(
+        app,
+        runtime_status=lambda: {},
+        subagent_list=lambda: [],
+        subagent_run=lambda req: "",
+        subagent_batch=lambda req: "",
+        notes_service=_Notes(),
+        beads_store=_FakeBeadsStore(),  # in-process → agent-global adapter
+    )
+    client = TestClient(app)
+    # no project_path supplied — must not 400
+    assert client.get("/api/beads/status").json() == {"initialized": True}
+    assert client.get("/api/beads/issues").status_code == 200
+
+
 def test_operator_routes_return_expected_shapes(tmp_path) -> None:
     client, notes = _client()
 


### PR DESCRIPTION
First of four PRs porting verified fixes from the **gina** fork back to the template (gina was re-baseplated on v0.11.0, so these apply line-for-line). All inherited bugs that affect protoAgent + every fork.

## Fixed
- **A2A 1.0 console chat** (gina #11) — `streamChat` still spoke A2A 0.3 (`message/stream`), but the server is on 1.0 → `-32601`, so the chat spinner never resolved. Updated to `SendStreamingMessage` + 1.0 frame parsing (0.3 fallback kept). Also fixes the brand logo path (`/app/…` 404s in the desktop bundle → `BASE_URL`).
- **Desktop chat renders the reply** (gina #15) — WKWebView doesn't reliably expose a readable fetch stream, so the console showed *no response* though the agent replied (Discord/curl worked). `consumeSse` clones up front + falls back to a buffered read when streaming yields nothing.
- **Beads doesn't require `project_path` for an unconfigured agent** (gina #9) — the agent-global store is now ensured before route registration, so first-launch setup no longer breaks the Beads panel.

## Added
- **White-label brand name** — the topbar + window/tab title follow `identity.name` (default `protoAgent`), so a fork sets its name once instead of hardcoding it. (The gina fork had hardcoded its own name here; this generalizes it.)

## Verified
`npm run web:build` clean; **931 tests pass**. Cherry-picked (`-x`) from gina, CHANGELOG consolidated for the template.

Next ports: desktop connect + BootGate (#12) · model validation (#13) · integrations: Discord + Google (#14/#16, ADRs 0016/0017).

🤖 Generated with [Claude Code](https://claude.com/claude-code)