### PR TITLE
Desktop: connect to the sidecar (ATS + port-pin) + cold-start boot gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,34 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   window/tab title now follow the configured agent name (Settings → Identity),
   defaulting to `protoAgent` — a fork sets its name once and the whole UI follows,
   no hardcoded rebrand.
+- **Cold-start boot gate for the desktop app.** First launch unpacks the frozen
+  PyInstaller sidecar and compiles the LangGraph agent (~30s); until it answered,
+  the webview flashed WKWebView's opaque "Load failed" then snapped to the setup
+  wizard. A full-screen gate (`BootGate`, adapted from ORBIS's `BootStatus`) now
+  holds "Starting <agent>…" over the app until the **engine is ready** — it gates
+  on `graph_loaded` (not just "runtime reachable"), so it stays down while the
+  setup wizard is due and re-engages for the post-setup graph compile. The runtime
+  probe polls until the graph is live; an escape-hatch ("Continue anyway", after a
+  grace period) means a graph that never compiles can't trap the operator, and a
+  "Retry" affordance covers the engine never coming up. (Copy is name-driven.)
 
 ### Fixed
+- **Desktop webview connects to the sidecar (was "Load failed").** Two desktop
+  bugs: (1) macOS WKWebView's App Transport Security blocks plain
+  `http://127.0.0.1:<port>` loopback loads by default, silently failing every
+  API/chat request — added `NSAllowsLocalNetworking` to the bundle `Info.plist`.
+  (2) The dynamic-free-port → `window.__PROTOAGENT_API_BASE__` injection handoff
+  was unreliable across Tauri v2 webview contexts (page fell back to a dead port);
+  the sidecar is now pinned to the fixed fallback port (`7870`), and the client
+  also reads `?__apiPort=` off the URL as a more reliable channel.
+- **"Load failed" no longer sticks after finishing setup.** The setup-finish (and
+  model-change) path compiles the graph inline on the event loop, freezing the
+  sidecar for ~30s — concurrent pollers got connection refusals and the error
+  strip (only cleared by a user action) lingered long after recovery. The strip
+  now auto-clears when the engine reports ready (`graph_loaded` flips true), and
+  the boot gate holds over the compile window. (Inline compile is the root cause —
+  offloading it is tracked in #497.)
+- **Console chat fixed for A2A 1.0 (was a never-resolving spinner).** The React
 - **Console chat fixed for A2A 1.0 (was a never-resolving spinner).** The React
   console's `streamChat` still spoke A2A **0.3** (`message/stream` with
   `parts:[{kind:'text'}]`), but the server moved to A2A 1.0 (a2a-sdk) — which

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri-build = { version = "2.6.2", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.11.2", features = ["tray-icon", "image-png"] }
+tauri = { version = "2.11.2", features = ["tray-icon", "image-png", "devtools"] }
 tauri-plugin-global-shortcut = "2.3.2"
 tauri-plugin-log = "2"
 tauri-plugin-notification = "2"

--- a/apps/desktop/src-tauri/Info.plist
+++ b/apps/desktop/src-tauri/Info.plist
@@ -4,5 +4,14 @@
 <dict>
     <key>NSHumanReadableCopyright</key>
     <string>Copyright (c) 2026 protoLabs Studio</string>
+    <!-- The webview talks to the bundled sidecar over http://127.0.0.1:<port>.
+         WKWebView's App Transport Security blocks insecure (http) loads by
+         default, silently failing every API/chat request ("Load failed").
+         Allow local networking (loopback + .local) only. -->
+    <key>NSAppTransportSecurity</key>
+    <dict>
+        <key>NSAllowsLocalNetworking</key>
+        <true/>
+    </dict>
 </dict>
 </plist>

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -204,11 +204,15 @@ pub fn run() {
             }
             app.manage(SidecarProcess::default());
 
-            // Pick a free port, boot the sidecar on it, and create the window
-            // ourselves so we can inject the chosen API base *before* any page
-            // script runs (race-free). The web client reads
-            // `window.__PROTOAGENT_API_BASE__` (see apps/web/src/lib/api.ts).
-            let port = pick_free_port();
+            // Pin the sidecar to the fixed port the web client falls back to in
+            // the Tauri context (apps/web/src/lib/api.ts → http://127.0.0.1:7870).
+            // The dynamic-free-port + window-injection handoff proved unreliable
+            // across Tauri v2 webview contexts: the page couldn't see the injected
+            // `__PROTOAGENT_API_BASE__`, fell back to a (then-dead) port, and every
+            // request failed ("Load failed"). A fixed port makes the fallback the
+            // live server — no handoff needed. (Trades multi-agent port
+            // coexistence for a desktop console that actually connects.)
+            let port: u16 = 7870;
             spawn_sidecar(app.handle(), port);
             let init = format!(
                 "window.__PROTOAGENT_API_BASE__ = \"http://127.0.0.1:{port}\";"

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -466,10 +466,11 @@ export function App() {
       <IntroSplash />
       {/* Cold-start gate: holds over the app until the runtime probe first
           resolves (engine up), so the ~30s frozen-sidecar boot shows
-          "Starting Gina…" rather than a "Load failed" flash. */}
+          "Starting <agent>…" rather than a "Load failed" flash. */}
       <BootGate
         ready={bootReady}
         failed={!runtime && runtimeQ.isError}
+        name={runtime?.identity?.name || "protoAgent"}
         onRetry={() => void runtimeQ.refetch()}
         onContinue={() => setBootOverride(true)}
       />

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -26,6 +26,7 @@ import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
 import { IntroSplash } from "./IntroSplash";
+import { BootGate } from "./BootGate";
 
 import { ActivitySurface } from "../activity/ActivitySurface";
 import { ConfirmDialog } from "./ConfirmDialog";
@@ -119,8 +120,16 @@ export function App() {
   const [projectPath, setProjectPath] = useLocalStorageState("protoagent.projectPath", "");
   // Shell-level runtime read (ADR 0013): non-suspense useQuery so the topbar
   // always renders; the retry doubles as the desktop sidecar boot-probe. The
-  // System → Runtime panel reads the same key via useSuspenseQuery.
-  const runtimeQ = useQuery({ ...runtimeStatusQuery(), retry: 30, retryDelay: 1000 });
+  // System → Runtime panel reads the same key via useSuspenseQuery. Keep polling
+  // until the graph is compiled (`graph_loaded`) so the BootGate observes the
+  // engine coming up — the post-setup compile runs inline on the server loop and
+  // briefly freezes it, so we want to notice the moment it's live again.
+  const runtimeQ = useQuery({
+    ...runtimeStatusQuery(),
+    retry: 30,
+    retryDelay: 1000,
+    refetchInterval: (q) => (q.state.data?.graph_loaded ? false : 2500),
+  });
   const runtime = runtimeQ.data ?? null;
   // White-label the window/tab title to the configured identity (default
   // protoAgent), so a fork's title follows its name without a rebuild.
@@ -128,6 +137,15 @@ export function App() {
     const name = runtime?.identity?.name;
     if (name) document.title = name;
   }, [runtime]);
+  // BootGate gating: show the app once the engine is ready (graph compiled) OR
+  // the setup wizard is due (no graph expected pre-setup). `bootOverride` is the
+  // manual escape hatch (BootGate's "Continue anyway") for a graph that never
+  // compiles. The graph-ready transition also clears the stale connection-error
+  // strip left behind by the compile-window freeze (see effect below).
+  const [bootOverride, setBootOverride] = useState(false);
+  const setupPending = Boolean(runtime) && runtime?.setup_complete === false;
+  const engineReady = Boolean(runtime?.graph_loaded);
+  const bootReady = bootOverride || setupPending || engineReady;
   const [workspace, setWorkspace] = useState<NotesWorkspace | null>(null);
   const [error, setError] = useState("");
 
@@ -157,6 +175,15 @@ export function App() {
   useEffect(() => {
     void refreshProjectState();
   }, []);
+
+  // Clear the stale "Load failed" strip once the engine reports ready. The
+  // graph compile (cold start, finishing setup, or a model change) runs inline
+  // on the server loop and freezes it, so concurrent pollers fail and set the
+  // strip — which is otherwise only cleared by a user action. When `graph_loaded`
+  // flips true the connection is healthy again, so that transient error is moot.
+  useEffect(() => {
+    if (engineReady) setError((prev) => (prev ? "" : prev));
+  }, [engineReady]);
 
   // Adopt the server's default project as the fs working dir if none is set (it
   // seeds the setup wizard's allowed-dirs) once runtime resolves.
@@ -437,6 +464,15 @@ export function App() {
   return (
     <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
       <IntroSplash />
+      {/* Cold-start gate: holds over the app until the runtime probe first
+          resolves (engine up), so the ~30s frozen-sidecar boot shows
+          "Starting Gina…" rather than a "Load failed" flash. */}
+      <BootGate
+        ready={bootReady}
+        failed={!runtime && runtimeQ.isError}
+        onRetry={() => void runtimeQ.refetch()}
+        onContinue={() => setBootOverride(true)}
+      />
       {/* macOS desktop: the topbar IS the window's drag region (its brand insets
           right of the native traffic lights — see `.is-tauri-mac .topbar`).
           Interactive children (the status dot) stay clickable; harmless on web. */}

--- a/apps/web/src/app/BootGate.tsx
+++ b/apps/web/src/app/BootGate.tsx
@@ -27,13 +27,15 @@ type BootGateProps = {
   ready: boolean;
   /** True once the probe has exhausted its retries without ever reaching the engine. */
   failed: boolean;
+  /** Agent display name (from identity.name), so the gate copy is white-labelled. */
+  name: string;
   /** Re-arm the runtime probe (manual retry after a give-up). */
   onRetry: () => void;
   /** Dismiss the gate manually (escape hatch when the engine is slow to compile). */
   onContinue: () => void;
 };
 
-export function BootGate({ ready, failed, onRetry, onContinue }: BootGateProps) {
+export function BootGate({ ready, failed, name, onRetry, onContinue }: BootGateProps) {
   const [stuck, setStuck] = useState(false);
 
   useEffect(() => {
@@ -54,7 +56,7 @@ export function BootGate({ ready, failed, onRetry, onContinue }: BootGateProps) 
         />
         {failed ? (
           <>
-            <div className="boot-gate-title">Gina isn’t responding</div>
+            <div className="boot-gate-title">{name} isn’t responding</div>
             <p className="boot-gate-detail">
               The engine didn’t come up in time. It may still be warming up — give
               it another moment, then retry.
@@ -66,7 +68,7 @@ export function BootGate({ ready, failed, onRetry, onContinue }: BootGateProps) 
         ) : (
           <>
             <div className="boot-gate-spinner" aria-hidden="true" />
-            <div className="boot-gate-title">Starting Gina…</div>
+            <div className="boot-gate-title">Starting {name}…</div>
             <p className="boot-gate-detail">
               {stuck
                 ? "This is taking longer than usual. The engine may still be compiling, or it may need attention in Settings."

--- a/apps/web/src/app/BootGate.tsx
+++ b/apps/web/src/app/BootGate.tsx
@@ -1,0 +1,85 @@
+import { useEffect, useState } from "react";
+
+/**
+ * Cold-start boot gate (adapted from ORBIS's BootStatus). The desktop build
+ * launches a PyInstaller-frozen sidecar that needs ~30s on first run to unpack
+ * and compile the LangGraph agent; until the engine is up, every API call fails
+ * with WKWebView's opaque "Load failed" / "Could not connect". Worse, the graph
+ * compile runs inline on the server's event loop, so finishing the setup wizard
+ * (or a model change) freezes the sidecar for the compile's duration — every
+ * concurrent poller gets a connection refusal.
+ *
+ * Rather than flash those errors, we hold a full-screen gate until the engine
+ * reports ready (the shell's runtime probe sees `graph_loaded`). The gate stays
+ * down while the setup wizard should show (no graph expected yet), and
+ * re-engages for the post-setup compile. An escape hatch ("Continue anyway")
+ * appears after a grace period so a graph that never compiles (e.g. bad creds)
+ * can't trap the operator on the loading screen — they can reach Settings.
+ *
+ * Purely visual, like ORBIS: it sits over the always-mounted app as a sibling
+ * overlay and returns null once ready.
+ */
+
+const STUCK_AFTER_MS = 45_000; // offer "Continue anyway" past this
+
+type BootGateProps = {
+  /** True once the app should be shown — engine ready, or the wizard is due. */
+  ready: boolean;
+  /** True once the probe has exhausted its retries without ever reaching the engine. */
+  failed: boolean;
+  /** Re-arm the runtime probe (manual retry after a give-up). */
+  onRetry: () => void;
+  /** Dismiss the gate manually (escape hatch when the engine is slow to compile). */
+  onContinue: () => void;
+};
+
+export function BootGate({ ready, failed, onRetry, onContinue }: BootGateProps) {
+  const [stuck, setStuck] = useState(false);
+
+  useEffect(() => {
+    if (ready) return; // resolved before the grace period — no timer needed
+    const t = window.setTimeout(() => setStuck(true), STUCK_AFTER_MS);
+    return () => window.clearTimeout(t);
+  }, [ready]);
+
+  if (ready) return null;
+
+  return (
+    <div className="boot-gate" role="status" aria-live="polite">
+      <div className="boot-gate-inner">
+        <img
+          src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`}
+          alt=""
+          className="boot-gate-mark"
+        />
+        {failed ? (
+          <>
+            <div className="boot-gate-title">Gina isn’t responding</div>
+            <p className="boot-gate-detail">
+              The engine didn’t come up in time. It may still be warming up — give
+              it another moment, then retry.
+            </p>
+            <button type="button" className="boot-gate-retry" onClick={onRetry}>
+              Retry
+            </button>
+          </>
+        ) : (
+          <>
+            <div className="boot-gate-spinner" aria-hidden="true" />
+            <div className="boot-gate-title">Starting Gina…</div>
+            <p className="boot-gate-detail">
+              {stuck
+                ? "This is taking longer than usual. The engine may still be compiling, or it may need attention in Settings."
+                : "Warming up the engine — first launch (and finishing setup) can take up to a minute. Later launches are quick."}
+            </p>
+            {stuck ? (
+              <button type="button" className="boot-gate-retry" onClick={onContinue}>
+                Continue anyway
+              </button>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/IntroSplash.tsx
+++ b/apps/web/src/app/IntroSplash.tsx
@@ -40,7 +40,7 @@ export function IntroSplash() {
   return (
     <div className="intro-splash" role="img" aria-label="protoLabs.studio">
       <div className="intro-splash-rise">
-        <img src="/app/protolabs-icon-outline.svg" alt="" className="intro-splash-mark" />
+        <img src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`} alt="" className="intro-splash-mark" />
         <div className="intro-splash-word">protoLabs.studio</div>
       </div>
     </div>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -225,6 +225,79 @@ h2 {
   100% { opacity: 1; transform: none; }
 }
 
+/* Cold-start boot gate (sits below the 2.5s brand splash at z-90, above the
+   app). Holds "Starting Gina…" over the app while the frozen desktop sidecar
+   warms up, instead of flashing "Load failed". */
+.boot-gate {
+  position: fixed;
+  inset: 0;
+  z-index: 80;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--bg);
+  padding: 24px;
+}
+
+.boot-gate-inner {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+  max-width: 360px;
+  text-align: center;
+}
+
+.boot-gate-mark {
+  width: 56px;
+  height: 56px;
+  opacity: 0.9;
+  filter: drop-shadow(0 0 10px rgba(167, 139, 250, 0.25));
+}
+
+.boot-gate-spinner {
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  border: 2.5px solid var(--border, rgba(255, 255, 255, 0.12));
+  border-top-color: #818cf8;
+  animation: boot-spin 0.8s linear infinite;
+}
+
+@keyframes boot-spin {
+  to { transform: rotate(360deg); }
+}
+
+.boot-gate-title {
+  font-size: 1.05rem;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  color: var(--text, #e8e8ec);
+}
+
+.boot-gate-detail {
+  margin: 0;
+  font-size: 0.85rem;
+  line-height: 1.45;
+  color: var(--text-muted, #9a9aa6);
+}
+
+.boot-gate-retry {
+  margin-top: 4px;
+  padding: 7px 18px;
+  border-radius: 8px;
+  border: 1px solid var(--border, rgba(255, 255, 255, 0.14));
+  background: linear-gradient(135deg, #9b87f2 0%, #6366f1 100%);
+  color: #fff;
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.boot-gate-retry:hover {
+  filter: brightness(1.06);
+}
+
 /* The splash → app hand-off cross-fade (default root view transition); a touch
    longer than the default for a cleaner settle. */
 ::view-transition-old(root),

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -88,8 +88,16 @@ function defaultApiBase() {
   if (savedBase) return savedBase.replace(/\/$/, "");
 
   // The Tauri desktop shell boots its bundled server on a dynamically-chosen
-  // free port and injects the base URL here before any page script runs
-  // (apps/desktop/src-tauri/src/lib.rs). Prefer it over the legacy fixed port.
+  // free port and hands it to the webview two ways (lib.rs): a `window` global,
+  // and `?__apiPort=` on the URL. The URL is always visible to the page (the
+  // global sometimes isn't, in which case we'd otherwise fall back to a dead
+  // legacy port → "Load failed"). Try the URL first, then the global.
+  try {
+    const p = new URLSearchParams(window.location.search).get("__apiPort");
+    if (p && /^\d+$/.test(p)) return `http://127.0.0.1:${p}`;
+  } catch {
+    /* no-op */
+  }
   const injected = (window as unknown as { __PROTOAGENT_API_BASE__?: string })
     .__PROTOAGENT_API_BASE__;
   if (injected) return injected.replace(/\/$/, "");


### PR DESCRIPTION
Port PR 2/4 from the **gina** fork — the desktop app's connect + cold-start UX.

## Fixed
- **Webview connects to the sidecar (was "Load failed").** (1) macOS WKWebView ATS blocks plain `http://127.0.0.1:<port>` loopback by default → every request silently failed; added `NSAllowsLocalNetworking` to `Info.plist`. (2) The dynamic-free-port → window-global injection handoff was unreliable in Tauri v2 webviews; pinned the sidecar to the fixed fallback port (`7870`) + the client reads `?__apiPort=` off the URL.
- **"Load failed" no longer sticks after finishing setup** — the error strip auto-clears when the engine reports ready (`graph_loaded`), and the boot gate holds over the inline-compile freeze window (root cause tracked in #497).

## Added
- **Cold-start `BootGate`** (adapted from ORBIS's `BootStatus`) — holds "Starting <agent>…" until the engine is ready (gates on `graph_loaded`, re-engages for the post-setup compile), with a "Continue anyway" escape hatch + "Retry". **Copy is name-driven** (`identity.name`, default protoAgent) per the white-label rule from PR #499.

## Verified
`npm run web:build` clean; no `Gina` references remain. De-branded from gina #12 (cherry-pick `-x`); App.tsx conflict (title effect vs gate state) resolved keeping both.

Next: model validation (#13) · integrations (Discord #14 + Google #16).

🤖 Generated with [Claude Code](https://claude.com/claude-code)