### PR TITLE
Validate the model connection in setup + Settings (no silently broken agents)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Setup validates the model connection before completing — no more silently
+  broken agents.** The wizard accepted any API key (the models-list probe passes
+  for keys that can't actually complete), so a bad/blank key only surfaced as a
+  cryptic failed chat turn with no UI signal. Now: a new `validate_model_connection`
+  runs a real 1-token completion (the same auth path as chat), enforced
+  **server-side in `finish_setup`** — setup can't complete if the model can't
+  respond, and the gateway's own message is returned to the wizard (e.g. "expected
+  to start with 'sk-'"); **"Test connection"** buttons in the wizard *and* Settings
+  (`POST /api/config/test-model`, offloaded so it never freezes the loop); and a
+  terminal `TASK_STATE_FAILED` chat turn now renders as an errored message with an
+  actionable hint (check your API key in Settings) instead of a silent "no
+  response". Everything fixable in the UI.
 - **White-label brand name (driven by `identity.name`).** The console topbar +
   window/tab title now follow the configured agent name (Settings → Identity),
   defaulting to `protoAgent` — a fork sets its name once and the whole UI follows,

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2540,6 +2540,34 @@ textarea {
   color: #a9e8c9;
 }
 
+/* "Test connection" result line in the model step. */
+.setup-test {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 10px 18px 0;
+  padding: 8px 10px;
+  border-radius: var(--radius);
+  font-size: 0.85rem;
+  line-height: 1.4;
+}
+
+.setup-test.ok {
+  border: 1px solid rgba(65, 196, 141, 0.28);
+  background: rgba(65, 196, 141, 0.12);
+  color: #a9e8c9;
+}
+
+.setup-test.err {
+  border: 1px solid rgba(240, 116, 88, 0.3);
+  background: rgba(240, 116, 88, 0.12);
+  color: #f4b09f;
+}
+
+.setup-test svg {
+  flex-shrink: 0;
+}
+
 .setup-actions {
   display: flex;
   justify-content: space-between;

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -21,6 +21,26 @@ function messageId() {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+// Append an actionable pointer when a turn fails on something the operator can
+// fix in the UI — chiefly model auth (a bad/blank API key 401s). Keeps the raw
+// gateway detail (it's specific, e.g. "expected to start with 'sk-'") but tells
+// the user where to fix it instead of leaving a cryptic error.
+function withConfigHint(detail: string): string {
+  const d = detail.toLowerCase();
+  const looksAuth =
+    d.includes("401") ||
+    d.includes("403") ||
+    d.includes("api key") ||
+    d.includes("api_key") ||
+    d.includes("auth") ||
+    d.includes("virtual key") ||
+    d.includes("sk-");
+  if (looksAuth) {
+    return `${detail}\n\n→ Check your model API key in **System → Settings** (or re-run setup), then “Test connection”.`;
+  }
+  return detail;
+}
+
 function useSession(sessionId: string) {
   const state = useChatState();
   return state.sessions.find((session) => session.id === sessionId) || null;
@@ -253,6 +273,25 @@ function ChatSessionSlot({
         signal: controller.signal,
         onTaskId: setTaskId,
         onStatus: setStatusMessage,
+        onFailed: (detail) => {
+          // The turn failed terminally (e.g. the model 401'd on a bad key).
+          // Surface it as an errored assistant message + an actionable hint,
+          // instead of a silent "no response" with the error lost to the
+          // transient status line.
+          const friendly = withConfigHint(detail);
+          onError(friendly);
+          setStatusMessage("failed");
+          chatStore.setSessionStatus(session.id, "error");
+          const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
+          if (latest) {
+            chatStore.updateMessages(
+              session.id,
+              latest.messages.map((item) =>
+                item.id === assistantId ? { ...item, content: friendly, status: "error" } : item,
+              ),
+            );
+          }
+        },
         onInputRequired: (payload) => {
           setHitl(payload);
           // Alert natively if the window is hidden/unfocused (menu-bar-only

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -326,6 +326,15 @@ export const api = {
     });
   },
 
+  // Real completion probe — the true auth check (unlike `models`, which only
+  // lists). Blank fields fall back to the saved config (Settings re-test).
+  testModel(apiBase: string, apiKey: string, model: string) {
+    return request<{ ok: boolean; error: string }>("/api/config/test-model", {
+      method: "POST",
+      body: { api_base: apiBase, api_key: apiKey, model },
+    });
+  },
+
   finishSetup(config: Partial<AgentConfig>, soul: string) {
     return request<{ ok: boolean; message: string }>("/api/config/setup", {
       method: "POST",
@@ -474,6 +483,11 @@ export const api = {
       onText?: (text: string, append: boolean) => void;
       onToolCall?: (evt: ToolEvent) => void;
       onInputRequired?: (payload: HitlPayload) => void;
+      // Terminal failure (A2A `TASK_STATE_FAILED`) — e.g. the model rejected the
+      // turn (bad API key → 401). Carries the gateway's error text. Without this
+      // the failure only flashed in the transient status line and the turn
+      // looked like a silent "no response".
+      onFailed?: (message: string) => void;
       onDone?: () => void;
     } = {},
   ) {
@@ -535,6 +549,9 @@ export const api = {
         // / 1.0 `TASK_STATE_INPUT_REQUIRED`). Surface the form/question payload.
         if (state === "input-required" || state === "TASK_STATE_INPUT_REQUIRED") {
           handlers.onInputRequired?.(hitlFromParts(parts) || { question: messageText });
+        }
+        if (state === "failed" || state === "TASK_STATE_FAILED") {
+          handlers.onFailed?.(messageText || "the turn failed");
         }
       }
 

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,5 +1,5 @@
 import { QueryErrorResetBoundary, useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { AlertTriangle, RotateCcw, Save } from "lucide-react";
+import { AlertTriangle, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
@@ -68,6 +68,23 @@ function SettingsBody() {
     onError: (e) => setStatus(`save failed: ${e instanceof Error ? e.message : String(e)}`),
   });
 
+  // Verify the model can actually complete — tests the pending edits if any
+  // (e.g. a freshly-typed key), else the saved config (blanks fall back server
+  // side). Real completion probe, the same auth path as chat.
+  const asStr = (v: unknown) => (typeof v === "string" ? v : "");
+  const testConn = useMutation({
+    mutationFn: () =>
+      api.testModel(
+        asStr(dirty["model.api_base"]),
+        asStr(dirty["model.api_key"]),
+        asStr(dirty["model.name"]),
+      ),
+    onMutate: () => setStatus("testing connection…"),
+    onSuccess: (r) =>
+      setStatus(r.ok ? "connection OK — the model responded." : `connection failed — ${r.error || "no response"}`),
+    onError: (e) => setStatus(`connection test failed: ${e instanceof Error ? e.message : String(e)}`),
+  });
+
   function discard() {
     setDirty({});
     setStatus("");
@@ -83,6 +100,10 @@ function SettingsBody() {
           </p>
         </div>
         <div className="settings-actions">
+          <button className="secondary-button" type="button" onClick={() => testConn.mutate()} disabled={testConn.isPending || save.isPending}>
+            {testConn.isPending ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
+            Test connection
+          </button>
           <button className="secondary-button" type="button" onClick={discard} disabled={save.isPending || !dirtyKeys.length}>
             <RotateCcw size={15} />
             Discard

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -1,4 +1,5 @@
 import {
+  AlertTriangle,
   Bot,
   Check,
   ChevronLeft,
@@ -111,6 +112,9 @@ export function SetupWizard({
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
   const [message, setMessage] = useState("");
+  // Result of the last "Test connection" probe (a real completion). null = not
+  // yet tested; invalidated whenever the key/base/model changes.
+  const [tested, setTested] = useState<null | { ok: boolean; error: string }>(null);
 
   const index = steps.indexOf(step);
 
@@ -136,6 +140,11 @@ export function SetupWizard({
       alive = false;
     };
   }, [open]);
+
+  // A changed key/base/model invalidates a prior connection test.
+  useEffect(() => {
+    setTested(null);
+  }, [state.apiBase, state.apiKey, state.modelName]);
 
   const canGoNext = useMemo(() => {
     if (step === "model") return state.apiBase.trim() && state.modelName.trim();
@@ -170,6 +179,22 @@ export function SetupWizard({
       }
     } catch (exc) {
       setError(exc instanceof Error ? exc.message : String(exc));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // The real auth check: a 1-token completion down the same path as chat, so a
+  // bad key / wrong model is caught here in the UI rather than as a failed turn.
+  async function testConnection() {
+    setBusy(true);
+    setError("");
+    setTested(null);
+    try {
+      const r = await api.testModel(state.apiBase.trim(), state.apiKey.trim(), state.modelName.trim());
+      setTested({ ok: r.ok, error: r.error || "" });
+    } catch (exc) {
+      setTested({ ok: false, error: exc instanceof Error ? exc.message : String(exc) });
     } finally {
       setBusy(false);
     }
@@ -334,7 +359,26 @@ export function SetupWizard({
                   {busy ? <Loader2 className="spin" size={15} /> : <Search size={15} />}
                   Probe
                 </button>
+                <button
+                  className="secondary-button"
+                  type="button"
+                  onClick={() => void testConnection()}
+                  disabled={busy || !state.apiBase.trim() || !state.modelName.trim()}
+                >
+                  {busy ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
+                  Test connection
+                </button>
               </div>
+              {tested ? (
+                <div className={`setup-test ${tested.ok ? "ok" : "err"}`} role="status">
+                  {tested.ok ? <Check size={15} /> : <AlertTriangle size={15} />}
+                  <span>
+                    {tested.ok
+                      ? "Connection OK — the model responded."
+                      : `Connection failed — ${tested.error || "the model did not respond."}`}
+                  </span>
+                </div>
+              ) : null}
               <div className="setup-grid three">
                 <label className="field">
                   <span>Temperature</span>

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -505,6 +505,69 @@ def list_gateway_models(
     return ids, ""
 
 
+def validate_model_connection(
+    api_base: str,
+    api_key: str = "",
+    model: str = "",
+    timeout: float = 20.0,
+) -> tuple[bool, str]:
+    """Probe the model with a minimal real completion — the *true* auth check.
+
+    ``list_gateway_models`` only hits ``/models``, which gateways answer for
+    keys that can't actually run a completion (e.g. the proto-labs LiteLLM
+    gateway lists models but rejects a non-``sk-`` virtual key at
+    ``/chat/completions`` with a 401). This sends a 1-token completion down the
+    same path the agent uses, so a bad key / wrong model / unreachable gateway
+    is caught *before* setup completes instead of surfacing as a cryptic failed
+    chat turn. Returns ``(ok, error_message)`` — the message is the gateway's
+    own human-readable detail (e.g. "expected to start with 'sk-'") when it has
+    one, so the UI can show something actionable.
+    """
+    import httpx
+
+    if not api_base:
+        return False, "api_base is empty"
+    if not model:
+        return False, "model is empty"
+
+    key = api_key or os.environ.get("OPENAI_API_KEY", "")
+    url = api_base.rstrip("/") + "/chat/completions"
+    headers = {"Content-Type": "application/json"}
+    if key:
+        headers["Authorization"] = f"Bearer {key}"
+    payload = {
+        "model": model,
+        "messages": [{"role": "user", "content": "ping"}],
+        "max_tokens": 1,
+        "temperature": 0,
+    }
+
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            resp = client.post(url, headers=headers, json=payload)
+    except httpx.HTTPError as e:
+        return False, f"connection failed: {e}"
+
+    if resp.status_code < 400:
+        return True, ""
+
+    # Surface the gateway's own error message when present (OpenAI-shaped
+    # ``{"error": {"message": ...}}``), else the raw body, capped.
+    detail = ""
+    try:
+        body = resp.json()
+        err = body.get("error") if isinstance(body, dict) else None
+        if isinstance(err, dict):
+            detail = err.get("message") or ""
+        elif isinstance(err, str):
+            detail = err
+    except ValueError:
+        detail = ""
+    if not detail:
+        detail = (resp.text or "")[:300]
+    return False, f"HTTP {resp.status_code}: {detail}" if detail else f"HTTP {resp.status_code}"
+
+
 # ---------------------------------------------------------------------------
 # Tool registry introspection
 # ---------------------------------------------------------------------------

--- a/server.py
+++ b/server.py
@@ -1049,10 +1049,27 @@ def _build_settings_callbacks() -> dict[str, Any]:
             split_secret_updates,
             strip_secrets_from_doc,
             validate_config_dict,
+            validate_model_connection,
             write_soul,
         )
 
         messages: list[str] = []
+
+        # 0. Verify the model can actually complete BEFORE we touch anything —
+        # otherwise the graph compiles fine but every chat 401s, with no UI
+        # signal (the bug that motivated this gate). A real 1-token completion
+        # exercises the same auth path as chat, so a bad key / wrong model /
+        # unreachable gateway is caught here and returned to the wizard verbatim
+        # (e.g. "expected to start with 'sk-'"). Setup stays incomplete, so the
+        # operator fixes it in the UI and retries — no file editing required.
+        if config is not None and isinstance(config.get("model"), dict):
+            m = config["model"]
+            test_base = m.get("api_base") or (_graph_config.api_base if _graph_config else "")
+            test_key = m.get("api_key") or (_graph_config.api_key if _graph_config else "")
+            test_model = m.get("name") or (_graph_config.model_name if _graph_config else "")
+            ok, verr = validate_model_connection(test_base, test_key, test_model)
+            if not ok:
+                return False, f"model connection failed — {verr}"
 
         # 1. Persist (secrets to the untracked overlay, never the tracked YAML)
         if config is not None:
@@ -2652,6 +2669,9 @@ def _main():
     class ModelsProbeRequest(PydanticBaseModel):
         api_base: str = ""
         api_key: str = ""
+        # Only used by the connection test (a real completion needs a model);
+        # the model-list probe ignores it. Blank falls back to the saved config.
+        model: str = ""
 
     @fastapi_app.post("/api/config/models")
     async def _api_list_models(req: ModelsProbeRequest | None = None):
@@ -2670,6 +2690,25 @@ def _main():
         key = body.api_key or (_graph_config.api_key if _graph_config else "")
         models, error = list_gateway_models(base, key)
         return {"models": models, "error": error}
+
+    @fastapi_app.post("/api/config/test-model")
+    async def _api_test_model(req: ModelsProbeRequest | None = None):
+        """Verify the model can actually complete (the true auth check).
+
+        Powers the wizard's + Settings' "Test connection" button. POST (body)
+        so the key never lands in a URL/log. A blank field falls back to the
+        saved config, so Settings can re-test the live agent with one click.
+        Offloaded to a thread — a real completion is a blocking network call,
+        and we never want the connection test to freeze the event loop.
+        """
+        from graph.config_io import validate_model_connection
+
+        body = req or ModelsProbeRequest()
+        base = body.api_base or (_graph_config.api_base if _graph_config else "")
+        key = body.api_key or (_graph_config.api_key if _graph_config else "")
+        model = body.model or (_graph_config.model_name if _graph_config else "")
+        ok, error = await asyncio.to_thread(validate_model_connection, base, key, model)
+        return {"ok": ok, "error": error}
 
     # --- Setup wizard state -------------------------------------------------
     @fastapi_app.get("/api/config/setup-status")


### PR DESCRIPTION
Port PR 3/4 from the **gina** fork — brand-free, applies verbatim.

## Why
The setup wizard accepted any API key — the models-list probe passes for keys that can't actually complete (the gateway lists models but rejects an invalid key at `/chat/completions`). The graph compiled fine, then every turn 401'd with no UI signal, and the only fix was hand-editing `secrets.yaml`.

## What
- **`validate_model_connection`** — a real 1-token completion (the same auth path as chat); returns the gateway's own message.
- **Hard gate in `finish_setup`** — runs the probe before marking setup complete; setup can't complete with a model that can't respond.
- **"Test connection"** buttons in the wizard + Settings (`POST /api/config/test-model`, offloaded off the loop).
- **Friendly runtime error** — a terminal `TASK_STATE_FAILED` turn renders as an errored message with a 'check your API key in Settings' hint, via a new `streamChat` `onFailed` handler.

## Verified
`npm run web:build` clean; config tests pass. No branding (cherry-pick `-x` from gina #13).

Next: integrations — Discord (#14) + Google (#16), ADRs 0016/0017.

🤖 Generated with [Claude Code](https://claude.com/claude-code)