### PR TITLE
Integrations: connect Discord + Google from the app (ADRs 0016/0017)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Connect Discord from the app — no env vars, no file editing (ADR 0016).**
+  The Discord surface (ADR 0015) was env-only (`DISCORD_BOT_TOKEN`), started once
+  at boot — invisible to the desktop app (no shell to export into; the frozen
+  sidecar can't read a repo `.env`, so it connected as whatever bot was in the
+  ambient env). Now Discord is configured in-app: a `discord` config section
+  (`enabled` / `bot_token` → secrets.yaml / `admin_ids`), a **"Connect Discord"**
+  step in the setup wizard and a **Discord section in System → Settings**, each
+  with a **"Test connection"** button (a real `GET /users/@me` identity probe via
+  `POST /api/config/test-discord` — shows the bot's name, catches a bad token in
+  the UI). The gateway reads the config (env vars remain a Docker fallback) and
+  **reconnects live on save** — no restart. Both surfaces link to a docs
+  walkthrough for creating the bot + enabling the Message Content intent.
 - **Setup validates the model connection before completing — no more silently
   broken agents.** The wizard accepted any API key (the models-list probe passes
   for keys that can't actually complete), so a bad/blank key only surfaced as a

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Connect Google (Gmail + Calendar) from the app — no files, no CLI (ADR 0017).**
+  The Google MCP surface (Slice 2) needed a `credentials.json`, a CLI consent run,
+  and a hand-edited `mcp.servers` — unreachable from the desktop app, so the agent
+  had no calendar/mail. Now: a `google` config section (`client_id` / `client_secret`
+  → secrets.yaml / `tz`), a **"Connect Google"** button in Settings + an OAuth-client
+  step in the wizard that runs the consent flow (`POST /api/config/google/connect`
+  opens your browser, caches a refreshable token in the per-user config dir), and a
+  status probe (`GET /api/config/google/status` → connected account email). When
+  enabled + connected the google MCP server is **auto-wired** (no `mcp.servers`
+  editing) and **frozen-aware** (the bundled binary re-invokes itself, `--mcp-google`,
+  since it has no `python`); the headless subprocess is load-only so it never pops a
+  browser. Env/`credentials.json` remain a Docker fallback.
 - **Connect Discord from the app — no env vars, no file editing (ADR 0016).**
   The Discord surface (ADR 0015) was env-only (`DISCORD_BOT_TOKEN`), started once
   at boot — invisible to the desktop app (no shell to export into; the frozen

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,7 +80,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the boot gate holds over the compile window. (Inline compile is the root cause —
   offloading it is tracked in #497.)
 - **Console chat fixed for A2A 1.0 (was a never-resolving spinner).** The React
-- **Console chat fixed for A2A 1.0 (was a never-resolving spinner).** The React
   console's `streamChat` still spoke A2A **0.3** (`message/stream` with
   `parts:[{kind:'text'}]`), but the server moved to A2A 1.0 (a2a-sdk) — which
   returns `-32601 Method not found` (HTTP 200), so the SSE reader waited forever.

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -57,6 +57,25 @@ COLLECT_ALL = [
     # the import-scan misses them — collect explicitly.
     "aiosqlite",
     "sqlalchemy",
+    # The native Discord surface (ADR 0015) is lazy-imported in the server
+    # startup hook, so the import-scan misses it; the gateway also imports
+    # ``websockets`` lazily. Collect both so Discord works in the frozen app.
+    "surfaces",
+    "websockets",
+    # Google surface (ADR 0017): the MCP SDK (FastMCP) + the repo's google MCP
+    # server module, lazily imported via the --mcp-google self-reinvoke entry.
+    "mcp",
+    "mcp_servers",
+]
+
+# Google client libraries (ADR 0017) — bundled only when installed in the build
+# env (``requirements-google.txt``). Keeps a lean build (no google) working;
+# install the extra to ship Gmail/Calendar in the frozen app.
+OPTIONAL_COLLECT_ALL = [
+    "google.auth",
+    "google.oauth2",
+    "google_auth_oauthlib",
+    "googleapiclient",
 ]
 
 # Gradio (and the chat_ui module that imports it) is dead weight in headless
@@ -88,6 +107,16 @@ def main() -> None:
     collect: list[str] = []
     for pkg in COLLECT_ALL:
         collect += ["--collect-all", pkg]
+    # Optional Google libs: collect only what's importable in this build env.
+    import importlib.util
+
+    for pkg in OPTIONAL_COLLECT_ALL:
+        if importlib.util.find_spec(pkg) is not None:
+            collect += ["--collect-all", pkg]
+        else:
+            print(f"note: optional package not installed, skipping: {pkg} "
+                  "(install requirements-google.txt to ship Gmail/Calendar)",
+                  file=sys.stderr)
     exclude: list[str] = []
     for mod in EXCLUDE:
         exclude += ["--exclude-module", mod]

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -226,7 +226,7 @@ h2 {
 }
 
 /* Cold-start boot gate (sits below the 2.5s brand splash at z-90, above the
-   app). Holds "Starting Gina…" over the app while the frozen desktop sidecar
+   app). Holds "Starting <agent>…" over the app while the frozen desktop sidecar
    warms up, instead of flashing "Load failed". */
 .boot-gate {
   position: fixed;

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2747,6 +2747,26 @@ textarea {
 .settings-group {
   margin-bottom: 40px;
 }
+/* Per-group action row (e.g. the Discord "Test connection" + help link). */
+.settings-group-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 10px;
+}
+.settings-help-link,
+.setup-link {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 0.8rem;
+  color: #818cf8;
+  text-decoration: none;
+}
+.settings-help-link:hover,
+.setup-link:hover {
+  text-decoration: underline;
+}
 .settings-group-title {
   margin: 0 0 4px;
   font-size: 0.72rem;

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2754,6 +2754,10 @@ textarea {
   gap: 14px;
   margin-top: 10px;
 }
+.settings-inline-status {
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+}
 .settings-help-link,
 .setup-link {
   display: inline-flex;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -344,6 +344,21 @@ export const api = {
     });
   },
 
+  // Google surface (ADR 0017). status → {configured, connected, email}.
+  googleStatus() {
+    return request<{ configured: boolean; connected: boolean; email: string | null; error?: string }>(
+      "/api/config/google/status",
+    );
+  },
+  // Runs the OAuth consent (opens the operator's browser) — long-lived until they
+  // approve. Returns the connected account email on success.
+  googleConnect() {
+    return request<{ ok: boolean; email?: string; error?: string }>("/api/config/google/connect", {
+      method: "POST",
+      body: {},
+    });
+  },
+
   finishSetup(config: Partial<AgentConfig>, soul: string) {
     return request<{ ok: boolean; message: string }>("/api/config/setup", {
       method: "POST",

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -335,6 +335,15 @@ export const api = {
     });
   },
 
+  // Verify a Discord bot token by fetching its identity. Blank falls back to the
+  // saved token. Returns the bot username on success ("Connected as <bot>").
+  testDiscord(botToken: string) {
+    return request<{ ok: boolean; error: string; bot_user: string | null }>("/api/config/test-discord", {
+      method: "POST",
+      body: { bot_token: botToken },
+    });
+  },
+
   finishSetup(config: Partial<AgentConfig>, soul: string) {
     return request<{ ok: boolean; message: string }>("/api/config/setup", {
       method: "POST",

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -267,6 +267,11 @@ export type AgentConfig = {
   auth: {
     token: string;
   };
+  discord?: {
+    enabled: boolean;
+    bot_token?: string;
+    admin_ids: string[];
+  };
   runtime: {
     autostart_on_boot: boolean;
   };

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -272,6 +272,12 @@ export type AgentConfig = {
     bot_token?: string;
     admin_ids: string[];
   };
+  google?: {
+    enabled: boolean;
+    client_id: string;
+    client_secret?: string;
+    tz: string;
+  };
   runtime: {
     autostart_on_boot: boolean;
   };

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,9 +1,11 @@
-import { QueryErrorResetBoundary, useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { AlertTriangle, ExternalLink, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
+import { QueryErrorResetBoundary, useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { AlertTriangle, ExternalLink, Link2, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 
-// Bot-setup walkthrough; the Discord group links here for the full how-to.
-const DISCORD_GUIDE_URL = "https://protolabsai.github.io/gina/guides/discord#bot-setup";
+// Setup walkthroughs live in the template's (protoAgent) docs — forks don't ship
+// their own docs site, so the in-app help links point at the canonical docs.
+const DISCORD_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/discord#bot-setup";
+const GOOGLE_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/google#oauth-client";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { api } from "../lib/api";
@@ -101,6 +103,25 @@ function SettingsBody() {
     onError: (e) => setStatus(`Discord test failed: ${e instanceof Error ? e.message : String(e)}`),
   });
 
+  // Google surface (ADR 0017): show connection status + a "Connect Google"
+  // button that runs the OAuth consent (opens the operator's browser).
+  const googleStatus = useQuery({ queryKey: ["google-status"], queryFn: () => api.googleStatus() });
+  const googleConnect = useMutation({
+    mutationFn: () => api.googleConnect(),
+    onMutate: () => setStatus("opening Google consent in your browser…"),
+    onSuccess: (r) => {
+      setStatus(
+        r.ok
+          ? `Google connected${r.email ? ` as ${r.email}` : ""}.`
+          : `Google connect failed — ${r.error || "try again"}`,
+      );
+      void googleStatus.refetch();
+      void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
+    },
+    onError: (e) => setStatus(`Google connect failed: ${e instanceof Error ? e.message : String(e)}`),
+  });
+  const dirtyGoogleClient = "google.client_id" in dirty || "google.client_secret" in dirty;
+
   function discard() {
     setDirty({});
     setStatus("");
@@ -164,6 +185,30 @@ function SettingsBody() {
                 </button>
                 <a className="settings-help-link" href={DISCORD_GUIDE_URL} target="_blank" rel="noreferrer">
                   How to create a bot <ExternalLink size={13} />
+                </a>
+              </div>
+            ) : null}
+            {group.section === "Google" ? (
+              <div className="settings-group-actions">
+                <button
+                  className="secondary-button"
+                  type="button"
+                  onClick={() => googleConnect.mutate()}
+                  disabled={googleConnect.isPending || save.isPending || dirtyGoogleClient}
+                  title={dirtyGoogleClient ? "Save the client ID + secret first" : undefined}
+                >
+                  {googleConnect.isPending ? <Loader2 className="spin" size={15} /> : <Link2 size={15} />}
+                  {googleStatus.data?.connected ? "Reconnect Google" : "Connect Google"}
+                </button>
+                <span className="settings-inline-status">
+                  {googleStatus.data?.connected
+                    ? `Connected${googleStatus.data.email ? ` as ${googleStatus.data.email}` : ""}`
+                    : dirtyGoogleClient
+                      ? "Save the client ID + secret, then connect"
+                      : "Not connected"}
+                </span>
+                <a className="settings-help-link" href={GOOGLE_GUIDE_URL} target="_blank" rel="noreferrer">
+                  Get an OAuth client <ExternalLink size={13} />
                 </a>
               </div>
             ) : null}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,6 +1,9 @@
 import { QueryErrorResetBoundary, useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { AlertTriangle, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
+import { AlertTriangle, ExternalLink, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
+
+// Bot-setup walkthrough; the Discord group links here for the full how-to.
+const DISCORD_GUIDE_URL = "https://protolabsai.github.io/gina/guides/discord#bot-setup";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { api } from "../lib/api";
@@ -85,6 +88,19 @@ function SettingsBody() {
     onError: (e) => setStatus(`connection test failed: ${e instanceof Error ? e.message : String(e)}`),
   });
 
+  // Verify a Discord bot token (pending edit or saved). Shows the bot name.
+  const testDiscord = useMutation({
+    mutationFn: () => api.testDiscord(asStr(dirty["discord.bot_token"])),
+    onMutate: () => setStatus("testing Discord…"),
+    onSuccess: (r) =>
+      setStatus(
+        r.ok
+          ? `Discord OK — connected as ${r.bot_user || "your bot"}.`
+          : `Discord connection failed — ${r.error || "check the token"}`,
+      ),
+    onError: (e) => setStatus(`Discord test failed: ${e instanceof Error ? e.message : String(e)}`),
+  });
+
   function discard() {
     setDirty({});
     setStatus("");
@@ -135,6 +151,22 @@ function SettingsBody() {
                 onChange={(v) => setDirty((d) => ({ ...d, [field.key]: v }))}
               />
             ))}
+            {group.section === "Discord" ? (
+              <div className="settings-group-actions">
+                <button
+                  className="secondary-button"
+                  type="button"
+                  onClick={() => testDiscord.mutate()}
+                  disabled={testDiscord.isPending || save.isPending}
+                >
+                  {testDiscord.isPending ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
+                  Test connection
+                </button>
+                <a className="settings-help-link" href={DISCORD_GUIDE_URL} target="_blank" rel="noreferrer">
+                  How to create a bot <ExternalLink size={13} />
+                </a>
+              </div>
+            ) : null}
           </section>
         ))}
       </div>

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -5,8 +5,10 @@ import {
   ChevronLeft,
   ChevronRight,
   Database,
+  ExternalLink,
   KeyRound,
   Loader2,
+  MessageCircle,
   Network,
   Search,
   ShieldCheck,
@@ -18,9 +20,13 @@ import type { ReactNode } from "react";
 import { api } from "../lib/api";
 import type { AgentConfig, ConfigPayload, SetupStatus } from "../lib/types";
 
-type Step = "welcome" | "identity" | "model" | "persona" | "tools" | "workspace" | "finish";
+type Step = "welcome" | "identity" | "model" | "persona" | "tools" | "workspace" | "discord" | "finish";
 
-const steps: Step[] = ["welcome", "identity", "model", "persona", "tools", "workspace", "finish"];
+const steps: Step[] = ["welcome", "identity", "model", "persona", "tools", "workspace", "discord", "finish"];
+
+// Bot-setup walkthrough (Developer Portal steps + Message Content intent). The
+// wizard + Settings link here for users who want the full how-to.
+const DISCORD_GUIDE_URL = "https://protolabsai.github.io/gina/guides/discord#bot-setup";
 
 type WizardState = {
   agentName: string;
@@ -39,6 +45,11 @@ type WizardState = {
   knowledgeTopK: number;
   allowedDirs: string;
   initBeads: boolean;
+  // Discord surface (optional, skippable). `discordAdminId` accepts one or more
+  // IDs (comma/newline) — the operator's own user ID(s) allowed to DM the bot.
+  discordEnabled: boolean;
+  discordToken: string;
+  discordAdminId: string;
 };
 
 function defaultState(): WizardState {
@@ -64,6 +75,9 @@ function defaultState(): WizardState {
     knowledgeTopK: 5,
     allowedDirs: "",
     initBeads: false,
+    discordEnabled: false,
+    discordToken: "",
+    discordAdminId: "",
   };
 }
 
@@ -91,6 +105,9 @@ function hydrateState(payload: ConfigPayload, status: SetupStatus | null): Wizar
     knowledgeTopK: Number(config.knowledge.top_k ?? 5),
     allowedDirs: (config.operator?.allowed_dirs || []).join("\n"),
     initBeads: false,
+    discordEnabled: Boolean(config.discord?.enabled),
+    discordToken: "",
+    discordAdminId: (config.discord?.admin_ids || []).join(", "),
   };
 }
 
@@ -115,6 +132,8 @@ export function SetupWizard({
   // Result of the last "Test connection" probe (a real completion). null = not
   // yet tested; invalidated whenever the key/base/model changes.
   const [tested, setTested] = useState<null | { ok: boolean; error: string }>(null);
+  // Discord "Test connection" result (null = not tested; carries the bot name).
+  const [discordTested, setDiscordTested] = useState<null | { ok: boolean; error: string; bot: string | null }>(null);
 
   const index = steps.indexOf(step);
 
@@ -145,6 +164,11 @@ export function SetupWizard({
   useEffect(() => {
     setTested(null);
   }, [state.apiBase, state.apiKey, state.modelName]);
+
+  // A changed token invalidates a prior Discord test.
+  useEffect(() => {
+    setDiscordTested(null);
+  }, [state.discordToken]);
 
   const canGoNext = useMemo(() => {
     if (step === "model") return state.apiBase.trim() && state.modelName.trim();
@@ -195,6 +219,22 @@ export function SetupWizard({
       setTested({ ok: r.ok, error: r.error || "" });
     } catch (exc) {
       setTested({ ok: false, error: exc instanceof Error ? exc.message : String(exc) });
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  // Verify the Discord bot token before finishing — fetches the bot identity so
+  // a bad token is caught in the UI (and the operator sees the bot's name).
+  async function testDiscord() {
+    setBusy(true);
+    setError("");
+    setDiscordTested(null);
+    try {
+      const r = await api.testDiscord(state.discordToken.trim());
+      setDiscordTested({ ok: r.ok, error: r.error || "", bot: r.bot_user });
+    } catch (exc) {
+      setDiscordTested({ ok: false, error: exc instanceof Error ? exc.message : String(exc), bot: null });
     } finally {
       setBusy(false);
     }
@@ -264,6 +304,17 @@ export function SetupWizard({
           },
           operator: {
             allowed_dirs: allowedDirs,
+          },
+          // Discord is enabled when a token is present (this run or already
+          // stored). bot_token is only sent when entered — blank preserves the
+          // existing secret, same as the model api_key.
+          discord: {
+            enabled: Boolean(state.discordToken.trim()) || state.discordEnabled,
+            ...(state.discordToken.trim() ? { bot_token: state.discordToken.trim() } : {}),
+            admin_ids: state.discordAdminId
+              .split(/[\n,]/)
+              .map((id) => id.trim())
+              .filter(Boolean),
           },
         },
         state.soul,
@@ -475,6 +526,57 @@ export function SetupWizard({
                 <input type="checkbox" checked={state.initBeads} onChange={(event) => update({ initBeads: event.target.checked })} />
                 <span>Initialize beads</span>
               </label>
+            </StepBody>
+          ) : null}
+
+          {step === "discord" ? (
+            <StepBody icon={<MessageCircle size={20} />} title="Discord" kicker="Optional">
+              <p className="field-hint" style={{ marginTop: 0 }}>
+                Connect a Discord bot so you can DM {state.agentName || "your agent"} from
+                Discord. Optional — skip it and set it up later in System → Settings.{" "}
+                <a href={DISCORD_GUIDE_URL} target="_blank" rel="noreferrer" className="setup-link">
+                  How to create a bot <ExternalLink size={12} />
+                </a>
+              </p>
+              <label className="field">
+                <span>Bot token</span>
+                <input
+                  type="password"
+                  value={state.discordToken}
+                  onChange={(event) => update({ discordToken: event.target.value })}
+                  autoComplete="off"
+                  placeholder="Leave blank to skip Discord"
+                />
+              </label>
+              <div className="setup-grid model-row">
+                <label className="field">
+                  <span>Your Discord user ID(s)</span>
+                  <input
+                    value={state.discordAdminId}
+                    onChange={(event) => update({ discordAdminId: event.target.value })}
+                    placeholder="e.g. 249386616806834177 — comma-separated; empty = anyone"
+                  />
+                </label>
+                <button
+                  className="secondary-button"
+                  type="button"
+                  onClick={() => void testDiscord()}
+                  disabled={busy || !state.discordToken.trim()}
+                >
+                  {busy ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
+                  Test connection
+                </button>
+              </div>
+              {discordTested ? (
+                <div className={`setup-test ${discordTested.ok ? "ok" : "err"}`} role="status">
+                  {discordTested.ok ? <Check size={15} /> : <AlertTriangle size={15} />}
+                  <span>
+                    {discordTested.ok
+                      ? `Connected as ${discordTested.bot || "your bot"}.`
+                      : `Connection failed — ${discordTested.error || "check the token."}`}
+                  </span>
+                </div>
+              ) : null}
             </StepBody>
           ) : null}
 

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -1,6 +1,7 @@
 import {
   AlertTriangle,
   Bot,
+  CalendarDays,
   Check,
   ChevronLeft,
   ChevronRight,
@@ -20,13 +21,14 @@ import type { ReactNode } from "react";
 import { api } from "../lib/api";
 import type { AgentConfig, ConfigPayload, SetupStatus } from "../lib/types";
 
-type Step = "welcome" | "identity" | "model" | "persona" | "tools" | "workspace" | "discord" | "finish";
+type Step = "welcome" | "identity" | "model" | "persona" | "tools" | "workspace" | "discord" | "google" | "finish";
 
-const steps: Step[] = ["welcome", "identity", "model", "persona", "tools", "workspace", "discord", "finish"];
+const steps: Step[] = ["welcome", "identity", "model", "persona", "tools", "workspace", "discord", "google", "finish"];
 
-// Bot-setup walkthrough (Developer Portal steps + Message Content intent). The
-// wizard + Settings link here for users who want the full how-to.
-const DISCORD_GUIDE_URL = "https://protolabsai.github.io/gina/guides/discord#bot-setup";
+// Setup walkthroughs live in the template's (protoAgent) canonical docs — forks
+// don't ship their own docs site, so the in-app help links point there.
+const DISCORD_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/discord#bot-setup";
+const GOOGLE_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/google#oauth-client";
 
 type WizardState = {
   agentName: string;
@@ -50,6 +52,11 @@ type WizardState = {
   discordEnabled: boolean;
   discordToken: string;
   discordAdminId: string;
+  // Google surface (optional). Collect the OAuth client here; authorizing
+  // ("Connect Google") happens in Settings after setup (it opens the browser).
+  googleClientId: string;
+  googleClientSecret: string;
+  googleTz: string;
 };
 
 function defaultState(): WizardState {
@@ -78,6 +85,9 @@ function defaultState(): WizardState {
     discordEnabled: false,
     discordToken: "",
     discordAdminId: "",
+    googleClientId: "",
+    googleClientSecret: "",
+    googleTz: "",
   };
 }
 
@@ -108,6 +118,9 @@ function hydrateState(payload: ConfigPayload, status: SetupStatus | null): Wizar
     discordEnabled: Boolean(config.discord?.enabled),
     discordToken: "",
     discordAdminId: (config.discord?.admin_ids || []).join(", "),
+    googleClientId: config.google?.client_id || "",
+    googleClientSecret: "",
+    googleTz: config.google?.tz || "",
   };
 }
 
@@ -315,6 +328,15 @@ export function SetupWizard({
               .split(/[\n,]/)
               .map((id) => id.trim())
               .filter(Boolean),
+          },
+          // Google: store the OAuth client; enabling happens, but the managed MCP
+          // server only starts once "Connect Google" (Settings) mints a token.
+          // client_secret only sent when entered (blank preserves the stored one).
+          google: {
+            enabled: Boolean(state.googleClientId.trim()),
+            client_id: state.googleClientId.trim(),
+            ...(state.googleClientSecret.trim() ? { client_secret: state.googleClientSecret.trim() } : {}),
+            tz: state.googleTz.trim(),
           },
         },
         state.soul,
@@ -577,6 +599,48 @@ export function SetupWizard({
                   </span>
                 </div>
               ) : null}
+            </StepBody>
+          ) : null}
+
+          {step === "google" ? (
+            <StepBody icon={<CalendarDays size={20} />} title="Google" kicker="Optional">
+              <p className="field-hint" style={{ marginTop: 0 }}>
+                Give {state.agentName || "your agent"} read access to Gmail + Calendar. Paste your
+                Google Cloud <strong>Desktop app</strong> OAuth client below — after setup, click
+                <strong> Connect Google</strong> in System → Settings to authorize (it opens your
+                browser). Optional — skip to do it later.{" "}
+                <a href={GOOGLE_GUIDE_URL} target="_blank" rel="noreferrer" className="setup-link">
+                  Get an OAuth client <ExternalLink size={12} />
+                </a>
+              </p>
+              <div className="setup-grid two">
+                <label className="field">
+                  <span>OAuth client ID</span>
+                  <input
+                    value={state.googleClientId}
+                    onChange={(event) => update({ googleClientId: event.target.value })}
+                    placeholder="…apps.googleusercontent.com"
+                  />
+                </label>
+                <label className="field">
+                  <span>OAuth client secret</span>
+                  <input
+                    type="password"
+                    value={state.googleClientSecret}
+                    onChange={(event) => update({ googleClientSecret: event.target.value })}
+                    autoComplete="off"
+                    placeholder="Leave blank to skip Google"
+                  />
+                </label>
+              </div>
+              <label className="field">
+                <span>Timezone (IANA, optional)</span>
+                <input
+                  value={state.googleTz}
+                  onChange={(event) => update({ googleTz: event.target.value })}
+                  placeholder="e.g. America/Los_Angeles — sets the day bounds for “today”"
+                />
+              </label>
             </StepBody>
           ) : null}
 

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -144,3 +144,14 @@ execute_code:
 operator:
   allowed_dirs: []
   # - /home/kj/projects/my-other-repo
+
+# Discord surface (ADR 0015/0016) — inbound DM gateway. Configure this in-app
+# (setup wizard step / System → Settings → Discord) rather than by hand: the
+# bot_token is stored in the gitignored secrets.yaml overlay, never here.
+# `admin_ids` are the Discord user IDs allowed to DM the bot (empty = anyone).
+# Off until enabled with a token. The DISCORD_BOT_TOKEN / DISCORD_ADMIN_IDS env
+# vars remain a fallback for Docker deploys.
+discord:
+  enabled: false
+  # bot_token: stored in secrets.yaml (set via the UI), not here
+  admin_ids: []

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -155,3 +155,15 @@ discord:
   enabled: false
   # bot_token: stored in secrets.yaml (set via the UI), not here
   admin_ids: []
+
+# Google surface (ADR 0017) — Gmail + Calendar via the bundled MCP server.
+# Configure in-app (setup wizard / System → Settings → Google): paste your Google
+# Cloud "Desktop app" OAuth client (id + secret → secrets.yaml), then click
+# "Connect Google" to run the consent flow (opens your browser) — the token is
+# cached in the per-user config dir. When enabled + connected the google MCP
+# server is auto-wired (no mcp.servers editing). `tz` sets day bounds for "today".
+google:
+  enabled: false
+  # client_id: set via the UI
+  # client_secret: stored in secrets.yaml (set via the UI)
+  tz: ""

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -58,6 +58,7 @@ export default defineConfig({
             { text: "Goal mode", link: "/guides/goal-mode" },
             { text: "Scheduler", link: "/guides/scheduler" },
             { text: "Discord surface", link: "/guides/discord" },
+            { text: "Google (Gmail + Calendar)", link: "/guides/google" },
             { text: "Operator console (React/Tauri)", link: "/guides/react-tauri-ui" },
             { text: "Wire Langfuse + Prometheus", link: "/guides/observability" },
             { text: "Run multiple instances", link: "/guides/multi-instance" },

--- a/docs/adr/0016-discord-ui-config.md
+++ b/docs/adr/0016-discord-ui-config.md
@@ -58,9 +58,9 @@ in the codebase:
    minimal — token + admin-id + Test — and links out to a **docs walkthrough**
    ([guide](/guides/discord#bot-setup)) for the full how-to. (No generated invite
    URL or guild auto-detect yet — deferred.)
-5. **Scope.** **DM-first** (Gina's working model); designating a server channel
-   is a follow-up. An optional, skippable **wizard step** plus a persistent
-   **Settings → Discord** section.
+5. **Scope.** **DM-first** (the assistant's working model); designating a server
+   channel is a follow-up. An optional, skippable **wizard step** plus a
+   persistent **Settings → Discord** section.
 
 ## 3. Consequences
 

--- a/docs/adr/0016-discord-ui-config.md
+++ b/docs/adr/0016-discord-ui-config.md
@@ -1,0 +1,85 @@
+# ADR 0016 — In-app Discord configuration (token, admin list, live connect)
+
+- **Status:** Accepted (2026-06-03)
+- **Date:** 2026-06-03
+- **Deciders:** Josh Mabry; protoAgent maintainers
+- **Tags:** surface, discord, config, onboarding, operator, desktop, opt-in
+- **Related:** makes [ADR 0015](./0015-discord-ingress-surface.md) (the Discord surface) configurable in-app; uses the secrets-overlay + settings-schema patterns from [ADR 0013](./0013-console-data-layer-react-query.md); same opt-in posture as [ADR 0010](./0010-headless-setup-and-ui-tiers.md).
+
+> Accepted. ADR 0015 shipped a great Discord surface — but it was **env-var only**
+> (`DISCORD_BOT_TOKEN` / `DISCORD_ADMIN_IDS`), started once at boot. That's fine
+> for Docker, but invisible and unreachable for someone who just installed the
+> **desktop app**: there's no shell to export env into, the frozen sidecar can't
+> read a repo `.env`, and a bad/absent token fails silently. Discord is now
+> **configured in the app** — a token field + "Test connection" in the setup
+> wizard and Settings — stored in the per-agent secrets overlay, applied live.
+
+## 1. Context & Problem statement
+
+ADR 0015's gateway reads `os.environ["DISCORD_BOT_TOKEN"]` directly and is
+started exactly once, inside the server's startup event, opt-in by token
+presence. There is no config section, no secret, no validation, no status, and
+no way to change it without a process restart.
+
+For the **bundled desktop app** this is a dead end:
+
+- The GUI-launched sidecar has no shell env to inherit a token from, and the
+  PyInstaller-frozen binary can't read the repo's gitignored `.env` (the
+  `env_loader` path only helps repo/Docker runs). In practice the desktop app
+  fell back to whatever `DISCORD_BOT_TOKEN` happened to be in the ambient
+  environment — connecting as the **wrong bot**.
+- A wrong/absent token fails **silently** (the gateway logs "disabled" and the
+  user has no signal), echoing the same "silently broken" trap we just closed
+  for the model API key.
+
+A personal-assistant template whose whole pitch is "install it and talk to it on
+Discord" cannot require hand-editing YAML/env to connect.
+
+## 2. Decision
+
+Make Discord a first-class, UI-configured surface, reusing the patterns already
+in the codebase:
+
+1. **Config + secrets.** A `discord` section in the config dataclass +
+   `langgraph-config.yaml`: `enabled` (bool), `bot_token` (→ **secrets.yaml**
+   overlay, added to `SECRET_PATHS`), `admin_ids` (list). The gateway reads these
+   via an injected `configure(token, admin_ids)`, **falling back to the env vars**
+   so Docker/headless deploys are unchanged.
+2. **Live connect.** The gateway is started from the live config and **restarted
+   on config reload** when the Discord fields change — so a Settings save or
+   wizard finish reconnects without a process restart (same fire-and-forget-onto-
+   the-loop idiom as the scheduler swap).
+3. **Validation.** A real identity probe (`GET /users/@me` → bot username) behind
+   `POST /api/config/test-discord`, powering a **"Test connection"** button in
+   both the wizard and Settings — a bad token is caught in the UI (with the bot's
+   name shown on success), mirroring the model "Test connection".
+4. **Onboarding.** Discord-side setup (create app → bot → token → **Message
+   Content intent** → invite) is the real friction. v1 keeps the in-app flow
+   minimal — token + admin-id + Test — and links out to a **docs walkthrough**
+   ([guide](/guides/discord#bot-setup)) for the full how-to. (No generated invite
+   URL or guild auto-detect yet — deferred.)
+5. **Scope.** **DM-first** (Gina's working model); designating a server channel
+   is a follow-up. An optional, skippable **wizard step** plus a persistent
+   **Settings → Discord** section.
+
+## 3. Consequences
+
+- **The desktop app gets a per-user home for the token** (secrets.yaml in the
+  app-config dir) — fixing the "connects as the wrong bot" problem, and making
+  Discord reachable for non-developers with no env/YAML editing.
+- **No silent failures**: an invalid token is caught by Test connection / on save.
+- **Back-compatible**: env vars still work as a fallback; existing Docker deploys
+  need no change. In-app config takes precedence when set.
+- The env-only tunables from ADR 0015 (timeouts, debounce, log path) stay env-only
+  for now — only token / admin_ids / enabled moved to the UI.
+
+## 4. Alternatives considered
+
+- **Leave it env-only, document harder.** Rejected — unreachable for the desktop
+  app's target user; the frozen sidecar has no env path.
+- **Full guided onboarding (generated invite URL, intent toggles, guild/channel
+  picker).** Deferred — valuable, but the token + Test + docs-link covers the
+  90% case; revisit once usage shows where people get stuck.
+- **A dedicated "Integrations" surface.** Deferred — one Discord section in
+  Settings + a wizard step is enough for a single integration; revisit when a
+  second (Slack/etc.) lands.

--- a/docs/adr/0017-google-ui-config.md
+++ b/docs/adr/0017-google-ui-config.md
@@ -1,0 +1,72 @@
+# ADR 0017 — In-app Google (Gmail + Calendar) connect flow
+
+- **Status:** Accepted (2026-06-03)
+- **Date:** 2026-06-03
+- **Deciders:** Josh Mabry; protoAgent maintainers
+- **Tags:** surface, google, oauth, mcp, onboarding, operator, desktop, opt-in
+- **Related:** follows [ADR 0016](./0016-discord-ui-config.md) (in-app Discord config) as the second UI-driven integration; the surface is the Google MCP server (Slice 2); uses the secrets-overlay + settings-schema patterns from [ADR 0013](./0013-console-data-layer-react-query.md).
+
+> Accepted. The Google surface (Gmail + Calendar) existed but its setup was
+> **file + CLI** — download `credentials.json`, run `python -m
+> mcp_servers.google.server` for consent, hand-edit `mcp.servers`. Unreachable
+> from the desktop app (no shell, no `python` on PATH, read-only frozen bundle),
+> so the agent simply had no calendar/mail. Google is now **connected in-app**:
+> paste a Desktop-app OAuth client, click **Connect Google**, approve in the
+> browser — token cached per-user, MCP auto-wired.
+
+## 1. Context & Problem statement
+
+`mcp_servers/google/` is a good MCP server, but onboarding assumed a developer
+at a shell: a `credentials.json` file, a blocking `run_local_server` consent run
+from the CLI, and a manual `mcp.servers` entry. In the bundled desktop app none
+of that is possible — and the result is the agent telling the operator "I can't
+read your calendar." The same gap [ADR 0016](./0016-discord-ui-config.md) closed
+for Discord, now for Google — with the extra wrinkle of an OAuth consent dance.
+
+## 2. Decision
+
+1. **Config + secrets.** A `google` section (`enabled`, `client_id`,
+   `client_secret` → **secrets.yaml**, `tz`). The OAuth client comes from the
+   operator's Google Cloud **Desktop app** client — entered in the UI, not a
+   file.
+2. **Connect flow.** `POST /api/config/google/connect` runs the installed-app
+   consent (`InstalledAppFlow.run_local_server`, which **opens the operator's
+   browser** + loopback-captures the grant) off the event loop, caches a
+   refreshable token in the **per-user config dir**, enables the surface, and
+   reloads so the tools register. `GET /api/config/google/status` reports
+   `{configured, connected, email}` for the UI. A **"Connect Google"** button in
+   Settings (+ an OAuth-client step in the wizard) drives it.
+3. **Managed MCP server.** When google is enabled **and** a token is cached, the
+   config layer **auto-injects** the google MCP server entry (the operator never
+   edits `mcp.servers`) and forces MCP on. The headless subprocess is **load-only**
+   — it never runs consent (no surprise browser); consent is the explicit Connect
+   action.
+4. **Frozen desktop launch.** The bundled binary has no `python`, so the managed
+   entry re-invokes the binary itself (`<binary> --mcp-google`) instead of
+   `python -m mcp_servers.google.server`. The Google libs + MCP SDK are bundled
+   into the sidecar.
+5. **Scope.** Read Gmail + Calendar, draft-only mail (no send) — unchanged from
+   Slice 2. Env/`credentials.json` remain a Docker/headless fallback.
+
+## 3. Consequences
+
+- The desktop app can connect Google with **no files, no CLI, no `mcp.servers`
+  editing** — the operator pastes a client and clicks Connect.
+- The token lives per-user (config dir), so it works in the read-only frozen
+  bundle and isn't shared across forks.
+- The sidecar grows by the Google client libraries (bundled). Acceptable for an
+  out-of-the-box integration; still opt-in (off until connected).
+- The OAuth client is still the operator's own (their Google Cloud project) — the
+  template ships the *flow*, not shared credentials (quota/security).
+
+## 4. Alternatives considered
+
+- **Keep it file/CLI, document harder.** Rejected — unreachable for the desktop
+  app's target user.
+- **Ship a shared OAuth client in the template.** Rejected — shared quota +
+  verification + secret-distribution problems; each operator using their own
+  Desktop-app client is the Google-sanctioned path.
+- **In-process Google tools instead of the MCP subprocess.** Tempting (no
+  frozen-subprocess problem), but it abandons the MCP-server design Slice 2
+  deliberately chose as the worked MCP example. The `--mcp-google` self-reinvoke
+  keeps the architecture and works frozen.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -25,3 +25,4 @@ decision, numbered, never deleted (supersede instead).
 | [0014](./0014-a2a-1.0-migration.md) | A2A 0.3 → 1.0: adopt `a2a-sdk` + `protolabs-a2a` | Accepted (shipped #453) |
 | [0015](./0015-discord-ingress-surface.md) | Optional native Discord surface (ingress + outbound) | Accepted (design; impl to follow) |
 | [0016](./0016-discord-ui-config.md) | In-app Discord configuration (token, admin list, live connect) | Accepted |
+| [0017](./0017-google-ui-config.md) | In-app Google (Gmail + Calendar) connect flow | Accepted |

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -24,3 +24,4 @@ decision, numbered, never deleted (supersede instead).
 | [0013](./0013-console-data-layer-react-query.md) | Console data layer: TanStack Query + Suspense + ErrorBoundary | Accepted |
 | [0014](./0014-a2a-1.0-migration.md) | A2A 0.3 → 1.0: adopt `a2a-sdk` + `protolabs-a2a` | Accepted (shipped #453) |
 | [0015](./0015-discord-ingress-surface.md) | Optional native Discord surface (ingress + outbound) | Accepted (design; impl to follow) |
+| [0016](./0016-discord-ui-config.md) | In-app Discord configuration (token, admin list, live connect) | Accepted |

--- a/docs/guides/discord.md
+++ b/docs/guides/discord.md
@@ -1,10 +1,28 @@
 # Discord surface
 
-An **optional native Discord surface** ([ADR 0015](/adr/0015-discord-ingress-surface)) —
-DMs and @-mentions reach the agent, replies post back. Self-contained: raw
-Discord Gateway + REST **v10** over `httpx` + `websockets` (both already core),
-no `discord.py`. **Off unless `DISCORD_BOT_TOKEN` is set** — when unset the
-gateway never starts and the outbound tools aren't registered.
+An **optional native Discord surface** ([ADR 0015](/adr/0015-discord-ingress-surface),
+[ADR 0016](/adr/0016-discord-ui-config)) — DMs and @-mentions reach the agent,
+replies post back. Self-contained: raw Discord Gateway + REST **v10** over `httpx`
++ `websockets` (both already core), no `discord.py`. **Off until you give it a bot
+token** — when unset the gateway never starts and the outbound tools aren't
+registered.
+
+## Connect it in the app
+
+The quickest path — no files, no env vars:
+
+1. **Create a bot and copy its token** — follow [Bot setup](#bot-setup) below
+   (≈2 minutes in Discord's Developer Portal).
+2. In the app, open **System → Settings → Discord** (or the **Discord** step in
+   first-run setup), paste the **Bot token**, and optionally your **Discord user
+   ID(s)** (so only you can talk to it).
+3. Click **Test connection** — it verifies the token and shows the bot's name.
+   Turn **Enable Discord** on, then **Save & apply** — the gateway connects live,
+   no restart.
+
+The token is stored in the per-agent `secrets.yaml` (never committed). The
+`DISCORD_BOT_TOKEN` / `DISCORD_ADMIN_IDS` **env vars still work as a fallback**
+for Docker/headless deploys.
 
 Two halves:
 
@@ -18,16 +36,30 @@ Two halves:
 
 ## Bot setup
 
+Creating the bot is the one part that happens on Discord's side. It takes about
+two minutes:
+
 1. **[Discord Developer Portal](https://discord.com/developers/applications)** →
-   New Application → name it.
-2. **Bot** tab → copy the token → this is your `DISCORD_BOT_TOKEN`
-   (put it in `config/secrets.yaml` or the env — never commit it).
-3. **Privileged Gateway Intents** → enable **Message Content Intent** (otherwise
-   messages arrive with empty `content` and the agent can't read them).
-4. **OAuth2 → URL Generator** → scopes `bot`; permissions `Send Messages`,
-   `Read Message History`, `Add Reactions`, `Create Public Threads`.
-5. Open the generated URL to add the bot to a server — or just **DM the bot**
-   (DMs work without a server).
+   **New Application** → give it a name (this becomes the bot's name).
+2. **Bot** tab → **Reset Token** → **Copy** — this is the token you paste into
+   the app (**System → Settings → Discord**, or the setup wizard's Discord step).
+   Treat it like a password; never commit or share it. If you ever leak it, come
+   back here and **Reset Token** to invalidate the old one.
+3. **Privileged Gateway Intents** (same Bot tab) → turn on **Message Content
+   Intent**. Without it, messages arrive with empty `content` and the agent
+   can't read them — this is the most common "the bot sees nothing" mistake.
+4. **Find your own Discord user ID** (so you can lock the bot to just you): in
+   Discord, **User Settings → Advanced → Developer Mode** on, then right-click
+   your name → **Copy User ID**. Paste it into the app's **Admin user ID(s)**
+   field. (Leave it blank to let anyone DM the bot — not recommended for a
+   personal assistant.)
+5. **Add the bot somewhere it can talk to you** — either:
+   - **Just DM it** — DMs work without adding the bot to any server. Simplest.
+   - **Invite it to a server**: **OAuth2 → URL Generator** → scope `bot`;
+     permissions `Send Messages`, `Read Message History`, `Add Reactions`,
+     `Create Public Threads` → open the generated URL and pick your server.
+6. Back in the app, **Test connection** (confirms the token + shows the bot
+   name), enable Discord, and save. Then DM your bot.
 
 The gateway requests these intents: `GUILDS | GUILD_MESSAGES |
 GUILD_MESSAGE_REACTIONS | DIRECT_MESSAGES | MESSAGE_CONTENT`.
@@ -50,10 +82,23 @@ GUILD_MESSAGE_REACTIONS | DIRECT_MESSAGES | MESSAGE_CONTENT`.
 
 ## Configuration
 
+The token, admin list, and on/off toggle are set **in the app** (Settings →
+Discord, or the setup wizard) and stored in the per-agent config — `bot_token`
+in the gitignored `secrets.yaml`, the rest in `langgraph-config.yaml`:
+
+| Field (Settings → Discord) | YAML | Purpose |
+|---|---|---|
+| Enable Discord | `discord.enabled` | Master on/off. Reconnects live on save. |
+| Bot token | `discord.bot_token` _(→ secrets.yaml)_ | **Required to enable.** The whole surface (gateway + tools). |
+| Admin user ID(s) | `discord.admin_ids` | Discord user IDs allowed to talk to the bot; empty ⇒ anyone. **Lock it to yourself for a personal assistant.** |
+
+The matching **env vars are a fallback** for Docker/headless deploys (the
+in-app config takes precedence when set):
+
 | Env var | Default | Purpose |
 |---|---|---|
-| `DISCORD_BOT_TOKEN` | — | **Required.** Enables the whole surface (gateway + tools). |
-| `DISCORD_ADMIN_IDS` | _(unset)_ | CSV of Discord user IDs. When set, only those users are answered; unset ⇒ anyone. **Default-closed is recommended for a personal assistant.** |
+| `DISCORD_BOT_TOKEN` | — | Enables the surface when no in-app token is set. |
+| `DISCORD_ADMIN_IDS` | _(unset)_ | CSV of Discord user IDs (overridden by the in-app admin list). |
 | `DISCORD_CHANNEL_CONVERSATION_TIMEOUT_S` | `300` | Channel conversation-continuity window. |
 | `DISCORD_DM_CONVERSATION_TIMEOUT_S` | `900` | DM conversation-continuity window. |
 | `DISCORD_BURST_DEBOUNCE_S` | `3` | Silence before a message burst is flushed. |

--- a/docs/guides/google.md
+++ b/docs/guides/google.md
@@ -1,0 +1,57 @@
+# Google surface (Gmail + Calendar)
+
+An optional **MCP server** (`mcp_servers/google/`) that gives the agent read
+access to Gmail + Calendar and the ability to draft (never send) mail. Off until
+you connect it. Least-privilege scopes: Gmail **readonly** + **compose**,
+Calendar **readonly**.
+
+Tools (bound as `google__…`): `gmail_search`, `gmail_read`, `gmail_draft`,
+`calendar_today`, `calendar_freebusy`.
+
+## Connect it in the app
+
+No files, no CLI ([ADR 0017](/adr/0017-google-ui-config)):
+
+1. **Create an OAuth client** — follow [Get an OAuth client](#oauth-client) below
+   (a few minutes in the Google Cloud Console).
+2. In the app, open **System → Settings → Google** (or the **Google** step in
+   first-run setup) and paste the **OAuth client ID** + **client secret**.
+   Optionally set your **timezone** (for correct "today" bounds). Save & apply.
+3. Click **Connect Google** → your browser opens for consent → approve. The app
+   caches a refreshable token in the per-user config dir, enables the surface,
+   and the agent's tool list gains `google__gmail_search`,
+   `google__calendar_today`, etc. — no restart.
+
+The client secret is stored in the gitignored `secrets.yaml`; the token never
+leaves the per-user config dir. Both are managed for you — the agent auto-wires
+the Google MCP server (you never edit `mcp.servers`).
+
+## <a id="oauth-client"></a>Get an OAuth client
+
+This is the one part that happens on Google's side:
+
+1. **[Google Cloud Console](https://console.cloud.google.com/)** → create or
+   select a project → **APIs & Services**.
+2. **Enable** the **Gmail API** and the **Google Calendar API** (APIs & Services
+   → Library).
+3. **OAuth consent screen** → **External** (or **Internal** for a Workspace) →
+   add your own Google account as a **test user** (required while the app is in
+   "testing").
+4. **Credentials → Create credentials → OAuth client ID → Desktop app**. Copy
+   the **Client ID** and **Client secret** — paste those into the app's Google
+   settings. (Desktop-app clients allow the loopback redirect the consent flow
+   uses, so there's nothing else to configure.)
+
+## Notes
+
+- **Drafts only, never send** — `gmail_draft` creates a reviewable draft; there's
+  no send tool (irreversible). Send from Gmail yourself.
+- **Timezone** (IANA, e.g. `America/Los_Angeles`) sets the day bounds for
+  "today" — without it, bounds are UTC.
+- The client secret + token are **gitignored / per-user**; never commit them.
+- This surface backs the [morning briefing](/guides/scheduler) — with Google off,
+  the briefing just skips the mail/calendar sections.
+- **Env/CLI fallback** (Docker/headless): set `GOOGLE_CREDENTIALS_PATH` to a
+  Desktop-app `credentials.json` and run `python -m mcp_servers.google.server`
+  once to mint `token.json`, then add a `google` entry under `mcp.servers`. The
+  in-app flow above is the recommended path.

--- a/graph/config.py
+++ b/graph/config.py
@@ -96,6 +96,15 @@ class LangGraphConfig:
     memory_middleware: bool = True
     scheduler_enabled: bool = True
 
+    # Discord surface (ADR 0015 + 0016) — inbound DM gateway. Configured in-app
+    # (wizard step + Settings) rather than env-only, so the bundled desktop app
+    # has a per-user place for the token. ``bot_token`` lives in the secrets
+    # overlay; ``admin_ids`` are the Discord user IDs allowed to talk to the bot
+    # (empty ⇒ anyone). Off until a token is set. The env vars (DISCORD_BOT_TOKEN
+    # / DISCORD_ADMIN_IDS) remain a fallback for Docker.
+    discord_enabled: bool = False
+    discord_bot_token: str = ""
+    discord_admin_ids: list[str] = field(default_factory=list)
     # Enforcement gate — opt-in safety middleware that blocks tool calls
     # before they execute (deny list + per-tool rate limits). Off by default;
     # forks enable it and supply a deny list / rate limits (and can attach a
@@ -354,6 +363,7 @@ class LangGraphConfig:
 
         secrets = _load_secrets_doc(p.parent)
 
+        discord = data.get("discord", {})
         model = data.get("model", {})
         subagents = data.get("subagents", {})
         middleware = data.get("middleware", {})
@@ -371,6 +381,7 @@ class LangGraphConfig:
         # value still lets create_llm / set_a2a_token fall back to env.
         secret_api_key = secrets.get("model", {}).get("api_key")
         secret_auth_token = secrets.get("auth", {}).get("token")
+        secret_discord_token = secrets.get("discord", {}).get("bot_token")
 
         config = cls(
             model_provider=model.get("provider", cls.model_provider),
@@ -389,6 +400,9 @@ class LangGraphConfig:
             audit_middleware=middleware.get("audit", cls.audit_middleware),
             memory_middleware=middleware.get("memory", cls.memory_middleware),
             scheduler_enabled=middleware.get("scheduler", cls.scheduler_enabled),
+            discord_enabled=discord.get("enabled", cls.discord_enabled),
+            discord_bot_token=secret_discord_token or discord.get("bot_token", cls.discord_bot_token),
+            discord_admin_ids=list(discord.get("admin_ids", []) or []),
             enforcement_enabled=middleware.get("enforcement", cls.enforcement_enabled),
             enforcement_disallowed_tools=(
                 data.get("enforcement", {}).get("disallowed_tools", [])

--- a/graph/config.py
+++ b/graph/config.py
@@ -105,6 +105,19 @@ class LangGraphConfig:
     discord_enabled: bool = False
     discord_bot_token: str = ""
     discord_admin_ids: list[str] = field(default_factory=list)
+
+    # Google surface (ADR 0017) — Gmail + Calendar via the bundled MCP server,
+    # connected in-app with an OAuth consent flow (no credentials.json / CLI).
+    # The OAuth client (client_id + client_secret) comes from the operator's
+    # Google Cloud "Desktop app" client; the refreshable token is cached in the
+    # per-user config dir. `client_secret` lives in the secrets overlay. When
+    # enabled + connected, the config layer auto-wires the google MCP server, so
+    # the operator never edits `mcp.servers`. `tz` sets day bounds for "today".
+    google_enabled: bool = False
+    google_client_id: str = ""
+    google_client_secret: str = ""
+    google_tz: str = ""
+
     # Enforcement gate — opt-in safety middleware that blocks tool calls
     # before they execute (deny list + per-tool rate limits). Off by default;
     # forks enable it and supply a deny list / rate limits (and can attach a
@@ -364,6 +377,7 @@ class LangGraphConfig:
         secrets = _load_secrets_doc(p.parent)
 
         discord = data.get("discord", {})
+        google = data.get("google", {})
         model = data.get("model", {})
         subagents = data.get("subagents", {})
         middleware = data.get("middleware", {})
@@ -382,6 +396,7 @@ class LangGraphConfig:
         secret_api_key = secrets.get("model", {}).get("api_key")
         secret_auth_token = secrets.get("auth", {}).get("token")
         secret_discord_token = secrets.get("discord", {}).get("bot_token")
+        secret_google_secret = secrets.get("google", {}).get("client_secret")
 
         config = cls(
             model_provider=model.get("provider", cls.model_provider),
@@ -403,6 +418,10 @@ class LangGraphConfig:
             discord_enabled=discord.get("enabled", cls.discord_enabled),
             discord_bot_token=secret_discord_token or discord.get("bot_token", cls.discord_bot_token),
             discord_admin_ids=list(discord.get("admin_ids", []) or []),
+            google_enabled=google.get("enabled", cls.google_enabled),
+            google_client_id=google.get("client_id", cls.google_client_id),
+            google_client_secret=secret_google_secret or google.get("client_secret", cls.google_client_secret),
+            google_tz=google.get("tz", cls.google_tz),
             enforcement_enabled=middleware.get("enforcement", cls.enforcement_enabled),
             enforcement_disallowed_tools=(
                 data.get("enforcement", {}).get("disallowed_tools", [])

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -88,6 +88,7 @@ SECRET_PATHS: tuple[tuple[str, str], ...] = (
     ("model", "api_key"),
     ("auth", "token"),
     ("discord", "bot_token"),
+    ("google", "client_secret"),
 )
 
 # Setup wizard state.
@@ -242,6 +243,12 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
             "enabled": config.discord_enabled,
             "bot_token": "",  # redacted — secret, mirrors api_key / auth.token
             "admin_ids": list(config.discord_admin_ids),
+        },
+        "google": {
+            "enabled": config.google_enabled,
+            "client_id": config.google_client_id,
+            "client_secret": "",  # redacted — secret
+            "tz": config.google_tz,
         },
         "runtime": {
             "autostart_on_boot": config.autostart_on_boot,

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -87,6 +87,7 @@ SECRETS_YAML_PATH = _LIVE_CONFIG_DIR / "secrets.yaml"
 SECRET_PATHS: tuple[tuple[str, str], ...] = (
     ("model", "api_key"),
     ("auth", "token"),
+    ("discord", "bot_token"),
 )
 
 # Setup wizard state.
@@ -236,6 +237,11 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
         },
         "auth": {
             "token": "",
+        },
+        "discord": {
+            "enabled": config.discord_enabled,
+            "bot_token": "",  # redacted — secret, mirrors api_key / auth.token
+            "admin_ids": list(config.discord_admin_ids),
         },
         "runtime": {
             "autostart_on_boot": config.autostart_on_boot,

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -132,6 +132,20 @@ FIELDS: list[Field] = [
     Field("discord.admin_ids", "discord_admin_ids", "Admin user IDs", "string_list", "Discord",
           "Discord user IDs allowed to DM the bot (one per line). Empty = anyone."),
 
+    # ── Google (ADR 0017) ────────────────────────────────────────────────────
+    # The OAuth client lives here; "Connect Google" (a button, not a field) runs
+    # the consent flow and caches the token. Editing client id/secret is rare —
+    # most operators use the wizard/Settings "Connect Google" button.
+    Field("google.enabled", "google_enabled", "Enable Google", "bool", "Google",
+          "Gmail + Calendar tools. Needs the OAuth client below + a completed "
+          "“Connect Google”. Reconnects the tools live on save."),
+    Field("google.client_id", "google_client_id", "OAuth client ID", "string", "Google",
+          "From your Google Cloud “Desktop app” OAuth client."),
+    Field("google.client_secret", "google_client_secret", "OAuth client secret", "secret", "Google",
+          "From the same OAuth client. Stored in secrets.yaml."),
+    Field("google.tz", "google_tz", "Timezone (IANA)", "string", "Google",
+          "e.g. America/Los_Angeles — sets the day bounds for “today”. Blank = UTC."),
+
     # ── Runtime (restart) ────────────────────────────────────────────────────
     Field("runtime.autostart_on_boot", "autostart_on_boot", "Autostart on boot", "bool", "Runtime",
           "Install/remove the boot LaunchAgent.", restart=True),

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -123,6 +123,15 @@ FIELDS: list[Field] = [
     Field("auth.token", "auth_token", "A2A auth token", "secret", "Identity",
           "Bearer token for the A2A endpoint. Stored in secrets.yaml; applies live."),
 
+    # ── Discord (ADR 0015 + 0016) ────────────────────────────────────────────
+    Field("discord.enabled", "discord_enabled", "Enable Discord", "bool", "Discord",
+          "Inbound DM gateway. Needs the bot token below; reconnects live on save."),
+    Field("discord.bot_token", "discord_bot_token", "Bot token", "secret", "Discord",
+          "Discord bot token (Developer Portal → your app → Bot → Reset Token). Stored "
+          "in secrets.yaml. Use “Test connection” to verify before saving."),
+    Field("discord.admin_ids", "discord_admin_ids", "Admin user IDs", "string_list", "Discord",
+          "Discord user IDs allowed to DM the bot (one per line). Empty = anyone."),
+
     # ── Runtime (restart) ────────────────────────────────────────────────────
     Field("runtime.autostart_on_boot", "autostart_on_boot", "Autostart on boot", "bool", "Runtime",
           "Install/remove the boot LaunchAgent.", restart=True),

--- a/mcp_servers/google/__init__.py
+++ b/mcp_servers/google/__init__.py
@@ -1,0 +1,1 @@
+"""Google MCP server — Gmail + Calendar (Slice 2, ADR 0001 MCP). Off until configured."""

--- a/mcp_servers/google/auth.py
+++ b/mcp_servers/google/auth.py
@@ -1,0 +1,183 @@
+"""OAuth2 + service construction for the Google MCP server (Slice 2 / ADR 0017).
+
+Installed-app ("Desktop app") OAuth. The operator's OAuth client
+(``client_id`` + ``client_secret``) and the cached, refreshable token now come
+from the **in-app config** (``GOOGLE_CLIENT_ID`` / ``GOOGLE_CLIENT_SECRET`` env,
+injected by the server; ``GOOGLE_TOKEN_PATH`` in the per-user config dir) rather
+than ``credentials.json`` / ``token.json`` files — so it works in the bundled
+desktop app with no CLI step. The legacy file path is kept as a fallback.
+
+"Connect Google" in the UI calls :func:`run_consent` (opens the browser, runs the
+loopback consent, caches the token). The MCP subprocess calls
+:func:`build_services` (loads/refreshes the cached token). Thin wrapper around
+``google-auth*`` — not unit-tested (the testable logic is in ``gmail.py`` /
+``calendar.py``).
+
+Scopes (least privilege for v1): Gmail **readonly** + **compose** (drafts only,
+never send) and Calendar **readonly**.
+"""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+SCOPES = [
+    "https://www.googleapis.com/auth/gmail.readonly",
+    "https://www.googleapis.com/auth/gmail.compose",
+    "https://www.googleapis.com/auth/calendar.readonly",
+]
+
+_HERE = Path(__file__).resolve().parent
+
+
+def _path(env: str, default_name: str) -> Path:
+    return Path(os.environ.get(env) or (_HERE / default_name))
+
+
+def token_path() -> Path:
+    """Where the refreshable token is cached (config dir via env, else local)."""
+    return _path("GOOGLE_TOKEN_PATH", "token.json")
+
+
+def _client_config() -> dict | None:
+    """Build an installed-app client config from env, or None if unset.
+
+    Mirrors the shape of a Desktop-app ``credentials.json`` so we can use
+    ``InstalledAppFlow.from_client_config`` without a file on disk.
+    """
+    client_id = os.environ.get("GOOGLE_CLIENT_ID", "").strip()
+    client_secret = os.environ.get("GOOGLE_CLIENT_SECRET", "").strip()
+    if not (client_id and client_secret):
+        return None
+    return {
+        "installed": {
+            "client_id": client_id,
+            "client_secret": client_secret,
+            "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+            "token_uri": "https://oauth2.googleapis.com/token",
+            "redirect_uris": ["http://localhost"],
+        }
+    }
+
+
+def _load_cached():
+    """Load + refresh the cached token; return valid Credentials or None."""
+    from google.auth.transport.requests import Request
+    from google.oauth2.credentials import Credentials
+
+    tp = token_path()
+    if not tp.exists():
+        return None
+    creds = Credentials.from_authorized_user_file(str(tp), SCOPES)
+    if creds and creds.valid:
+        return creds
+    if creds and creds.expired and creds.refresh_token:
+        creds.refresh(Request())
+        tp.write_text(creds.to_json())
+        return creds
+    return None
+
+
+def run_consent() -> str:
+    """Run the interactive OAuth consent (opens a browser, loopback redirect),
+    cache the token, and return the connected account's email.
+
+    Blocking — the caller should run it off the event loop. Requires the OAuth
+    client in the env (``GOOGLE_CLIENT_ID`` / ``GOOGLE_CLIENT_SECRET``).
+    """
+    from google_auth_oauthlib.flow import InstalledAppFlow
+
+    client_config = _client_config()
+    if not client_config:
+        raise ValueError(
+            "Google OAuth client not configured — set the OAuth client ID + secret "
+            "(System → Settings → Google) before connecting."
+        )
+    flow = InstalledAppFlow.from_client_config(client_config, SCOPES)
+    creds = flow.run_local_server(port=0, open_browser=True)
+    tp = token_path()
+    tp.parent.mkdir(parents=True, exist_ok=True)
+    tp.write_text(creds.to_json())
+    return _email_for(creds)
+
+
+def _email_for(creds) -> str:
+    """Best-effort connected-account email (via the Gmail profile)."""
+    try:
+        from googleapiclient.discovery import build
+
+        gmail = build("gmail", "v1", credentials=creds, cache_discovery=False)
+        return gmail.users().getProfile(userId="me").execute().get("emailAddress", "")
+    except Exception:  # noqa: BLE001 — status is best-effort
+        return ""
+
+
+def connection_status() -> dict:
+    """Report (configured, connected, email) for the UI without forcing consent."""
+    configured = _client_config() is not None or _path(
+        "GOOGLE_CREDENTIALS_PATH", "credentials.json"
+    ).exists()
+    creds = None
+    try:
+        creds = _load_cached()
+    except Exception:  # noqa: BLE001
+        creds = None
+    return {
+        "configured": configured,
+        "connected": bool(creds and creds.valid),
+        "email": _email_for(creds) if creds and creds.valid else None,
+    }
+
+
+def get_credentials():
+    """Return valid Google credentials, refreshing or running consent as needed.
+
+    Prefers the cached token; if absent and an OAuth client is configured (env or
+    legacy ``credentials.json``), runs the consent flow. The desktop app primes
+    the token via :func:`run_consent` first, so the MCP subprocess just loads it.
+    """
+    from google_auth_oauthlib.flow import InstalledAppFlow
+
+    creds = _load_cached()
+    if creds:
+        return creds
+
+    client_config = _client_config()
+    if client_config:
+        flow = InstalledAppFlow.from_client_config(client_config, SCOPES)
+    else:
+        creds_path = _path("GOOGLE_CREDENTIALS_PATH", "credentials.json")
+        if not creds_path.exists():
+            raise FileNotFoundError(
+                "Google OAuth client not configured. Set the OAuth client ID + secret "
+                "in System → Settings → Google (or provide a credentials.json)."
+            )
+        flow = InstalledAppFlow.from_client_secrets_file(str(creds_path), SCOPES)
+
+    creds = flow.run_local_server(port=0, open_browser=True)
+    tp = token_path()
+    tp.parent.mkdir(parents=True, exist_ok=True)
+    tp.write_text(creds.to_json())
+    return creds
+
+
+def build_services():
+    """Build authorized ``(gmail, calendar)`` service resources.
+
+    **Load-only** — never runs interactive consent. The MCP server runs headless
+    (it's a subprocess), so it must not pop a browser; the operator authorizes
+    once via "Connect Google" (:func:`run_consent`). If there's no cached token,
+    raise a clear error so the tool fails cleanly instead of hanging.
+    """
+    from googleapiclient.discovery import build
+
+    creds = _load_cached()
+    if not creds:
+        raise RuntimeError(
+            "Google not connected — open System → Settings → Google and click "
+            "“Connect Google” to authorize."
+        )
+    gmail = build("gmail", "v1", credentials=creds, cache_discovery=False)
+    calendar = build("calendar", "v3", credentials=creds, cache_discovery=False)
+    return gmail, calendar

--- a/mcp_servers/google/calendar.py
+++ b/mcp_servers/google/calendar.py
@@ -1,0 +1,62 @@
+"""Google Calendar operations for the Google MCP server (Slice 2).
+
+Pure functions over a ``googleapiclient`` Calendar ``service`` resource (injected
+→ unit-testable with a mock). Read-only: today's agenda + free/busy.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, time, timedelta, timezone
+from typing import Any
+
+
+def _day_bounds(now: datetime) -> tuple[str, str]:
+    start = datetime.combine(now.date(), time.min, tzinfo=now.tzinfo)
+    end = start + timedelta(days=1)
+    return start.isoformat(), end.isoformat()
+
+
+def todays_events(service: Any, now: datetime, calendar_id: str = "primary") -> list[dict]:
+    """Events between local midnight and the next, ordered by start time.
+    ``now`` carries the operator's tz (caller supplies it from identity)."""
+    time_min, time_max = _day_bounds(now)
+    resp = (
+        service.events()
+        .list(calendarId=calendar_id, timeMin=time_min, timeMax=time_max,
+              singleEvents=True, orderBy="startTime")
+        .execute()
+    )
+    out: list[dict] = []
+    for ev in resp.get("items", []) or []:
+        start = ev.get("start", {})
+        out.append({
+            "summary": ev.get("summary", "(no title)"),
+            # all-day events carry "date"; timed events carry "dateTime"
+            "start": start.get("dateTime") or start.get("date") or "",
+            "all_day": "date" in start and "dateTime" not in start,
+            "location": ev.get("location", ""),
+            "attendees": [a.get("email", "") for a in ev.get("attendees", []) or []],
+        })
+    return out
+
+
+def free_busy(
+    service: Any, now: datetime, hours: int = 24, calendar_id: str = "primary"
+) -> list[dict]:
+    """Busy intervals over the next ``hours`` for ``calendar_id``."""
+    time_min = now.astimezone(timezone.utc)
+    time_max = time_min + timedelta(hours=max(1, int(hours)))
+    resp = (
+        service.freebusy()
+        .query(body={
+            "timeMin": time_min.isoformat(),
+            "timeMax": time_max.isoformat(),
+            "items": [{"id": calendar_id}],
+        })
+        .execute()
+    )
+    cal = (resp.get("calendars", {}) or {}).get(calendar_id, {})
+    return [
+        {"start": b.get("start", ""), "end": b.get("end", "")}
+        for b in cal.get("busy", []) or []
+    ]

--- a/mcp_servers/google/gmail.py
+++ b/mcp_servers/google/gmail.py
@@ -1,0 +1,107 @@
+"""Gmail operations for the Google MCP server (Slice 2).
+
+Pure functions over a ``googleapiclient`` Gmail ``service`` resource — the
+service is injected (built in ``auth.py``) so this layer is unit-testable with a
+mock and carries no OAuth/dep weight. Read + draft only; **no send** in v1 (a
+draft is reviewable, a send isn't reversible).
+"""
+
+from __future__ import annotations
+
+import base64
+from email.mime.text import MIMEText
+from typing import Any
+
+
+def _header(payload: dict, name: str) -> str:
+    for h in payload.get("headers", []):
+        if h.get("name", "").lower() == name.lower():
+            return h.get("value", "")
+    return ""
+
+
+def search_messages(service: Any, query: str, max_results: int = 10) -> list[dict]:
+    """Search the mailbox (Gmail query syntax, e.g. ``is:unread newer_than:1d``)
+    and return lightweight headers — id, from, subject, date, snippet."""
+    max_results = max(1, min(int(max_results), 50))
+    resp = (
+        service.users().messages()
+        .list(userId="me", q=query or "", maxResults=max_results)
+        .execute()
+    )
+    out: list[dict] = []
+    for ref in resp.get("messages", []) or []:
+        msg = (
+            service.users().messages()
+            .get(userId="me", id=ref["id"], format="metadata",
+                 metadataHeaders=["From", "Subject", "Date"])
+            .execute()
+        )
+        p = msg.get("payload", {})
+        out.append({
+            "id": msg.get("id", ""),
+            "from": _header(p, "From"),
+            "subject": _header(p, "Subject"),
+            "date": _header(p, "Date"),
+            "snippet": (msg.get("snippet") or "").strip(),
+            "unread": "UNREAD" in (msg.get("labelIds") or []),
+        })
+    return out
+
+
+def _decode_part(part: dict) -> str:
+    data = (part.get("body") or {}).get("data")
+    if not data:
+        return ""
+    try:
+        return base64.urlsafe_b64decode(data.encode()).decode("utf-8", "replace")
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def _extract_body(payload: dict) -> str:
+    """Best-effort plain-text body: prefer text/plain, walk multipart, fall back."""
+    mime = payload.get("mimeType", "")
+    if mime == "text/plain":
+        return _decode_part(payload)
+    for part in payload.get("parts", []) or []:
+        if part.get("mimeType") == "text/plain":
+            text = _decode_part(part)
+            if text:
+                return text
+    # nested multipart
+    for part in payload.get("parts", []) or []:
+        if (part.get("mimeType") or "").startswith("multipart/"):
+            text = _extract_body(part)
+            if text:
+                return text
+    return _decode_part(payload)
+
+
+def get_message(service: Any, message_id: str, max_chars: int = 4000) -> dict:
+    """Full message: headers + a plain-text body (truncated)."""
+    msg = service.users().messages().get(userId="me", id=message_id, format="full").execute()
+    p = msg.get("payload", {})
+    body = _extract_body(p).strip()
+    return {
+        "id": msg.get("id", ""),
+        "from": _header(p, "From"),
+        "to": _header(p, "To"),
+        "subject": _header(p, "Subject"),
+        "date": _header(p, "Date"),
+        "body": body[:max_chars] + ("…" if len(body) > max_chars else ""),
+    }
+
+
+def create_draft(service: Any, to: str, subject: str, body: str) -> dict:
+    """Create a Gmail **draft** (not sent — the operator reviews + sends)."""
+    mime = MIMEText(body)
+    mime["to"] = to
+    mime["subject"] = subject
+    raw = base64.urlsafe_b64encode(mime.as_bytes()).decode()
+    draft = (
+        service.users().drafts()
+        .create(userId="me", body={"message": {"raw": raw}})
+        .execute()
+    )
+    return {"draft_id": draft.get("id", ""), "to": to, "subject": subject}

--- a/mcp_servers/google/server.py
+++ b/mcp_servers/google/server.py
@@ -1,0 +1,76 @@
+"""Google MCP server (stdio) — Gmail + Calendar (Slice 2).
+
+A standalone MCP server the agent launches as a subprocess (registered in
+``config/langgraph-config.yaml`` under ``mcp.servers``). Its tools bind as
+``google__<tool>``. Off until configured (needs ``credentials.json`` — see
+``docs/guides/google.md``).
+
+Run directly for a manual check:  ``python -m mcp_servers.google.server``
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+logging.basicConfig(level=logging.INFO)
+log = logging.getLogger("protoagent.mcp.google")
+
+
+def _operator_now() -> datetime:
+    """Operator-local 'now'. ``GOOGLE_TZ`` (IANA, e.g. ``America/Los_Angeles``)
+    sets the timezone for day bounds; defaults to UTC."""
+    import os
+
+    tz = os.environ.get("GOOGLE_TZ", "")
+    if tz:
+        try:
+            from zoneinfo import ZoneInfo
+
+            return datetime.now(ZoneInfo(tz))
+        except Exception:  # noqa: BLE001
+            log.warning("[google] bad GOOGLE_TZ %r — using UTC", tz)
+    return datetime.now(timezone.utc)
+
+
+def main() -> None:
+    from mcp.server.fastmcp import FastMCP
+
+    from mcp_servers.google import calendar as cal
+    from mcp_servers.google import gmail as gm
+    from mcp_servers.google.auth import build_services
+
+    gmail_svc, calendar_svc = build_services()
+    mcp = FastMCP("google")
+
+    @mcp.tool()
+    def gmail_search(query: str = "is:unread newer_than:1d", max_results: int = 10) -> list[dict]:
+        """Search Gmail (Gmail query syntax) → id/from/subject/date/snippet/unread."""
+        return gm.search_messages(gmail_svc, query, max_results)
+
+    @mcp.tool()
+    def gmail_read(message_id: str) -> dict:
+        """Read a full message (headers + plain-text body) by id."""
+        return gm.get_message(gmail_svc, message_id)
+
+    @mcp.tool()
+    def gmail_draft(to: str, subject: str, body: str) -> dict:
+        """Create a Gmail draft (never sends — the operator reviews + sends)."""
+        return gm.create_draft(gmail_svc, to, subject, body)
+
+    @mcp.tool()
+    def calendar_today() -> list[dict]:
+        """Today's calendar events (operator-local day), ordered by start."""
+        return cal.todays_events(calendar_svc, _operator_now())
+
+    @mcp.tool()
+    def calendar_freebusy(hours: int = 24) -> list[dict]:
+        """Busy intervals over the next N hours."""
+        return cal.free_busy(calendar_svc, _operator_now(), hours)
+
+    log.info("[google] MCP server ready (gmail + calendar)")
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/requirements-google.txt
+++ b/requirements-google.txt
@@ -1,0 +1,6 @@
+# Google MCP server deps (Slice 2) — install only when enabling the Google
+# surface: `pip install -r requirements-google.txt`. The server runs as a
+# subprocess; the core agent doesn't import these.
+mcp>=1.2
+google-api-python-client>=2.120
+google-auth-oauthlib>=1.2

--- a/server.py
+++ b/server.py
@@ -98,6 +98,9 @@ _cache_warmer = None   # Optional CacheWarmer (off by default). Same start/stop
                        # lifecycle as _scheduler; keeps the prompt cache warm.
 _goal_controller = None  # Optional GoalController (goal mode). Parses /goal
                          # control messages and runs the goal-completion loop.
+_discord_task = None     # The inbound Discord gateway task (ADR 0015/0016).
+                         # Held so a config change (Settings/wizard) can stop +
+                         # restart it live, not just at process boot.
 
 _event_bus = EventBus()  # Server→client SSE push channel (ADR 0003). Process-
                          # lifetime singleton; producers publish, /api/events
@@ -854,6 +857,9 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
         new_workflow_registry = None
         new_inbox_store = None
 
+    # Capture the outgoing config before the swap so we can tell whether the
+    # Discord surface needs a live reconnect (token/admin/enabled changed).
+    old_config = _graph_config
     # Commit: config → A2A bearer → graph. All three reference the
     # same ``new_config`` so they stay consistent.
     _graph_config = new_config
@@ -890,12 +896,102 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     if pending_start is not None:
         _start_scheduler_async(pending_start)
 
+    # Discord surface: reconnect live if its config changed (token / admin_ids /
+    # enabled), so a Settings save or wizard finish applies without a restart.
+    discord_changed = (
+        old_config is None
+        or old_config.discord_enabled != new_config.discord_enabled
+        or old_config.discord_bot_token != new_config.discord_bot_token
+        or list(old_config.discord_admin_ids) != list(new_config.discord_admin_ids)
+    )
+    if discord_changed:
+        _restart_discord_async()
+
     if new_graph is None:
         log.info("[reload] setup not complete — config reloaded, graph not compiled")
         return True, "config reloaded • setup not complete"
 
     log.info("LangGraph agent reloaded (model: %s)", _graph_config.model_name)
     return True, f"reloaded • model={_graph_config.model_name}"
+
+
+def _start_discord_surface() -> None:
+    """(Re)start the inbound Discord gateway from the live config (ADR 0016).
+
+    Start rule: the UI path starts only when ``discord.enabled`` is on AND a
+    token is configured; the env path (Docker ``DISCORD_BOT_TOKEN``, no UI token)
+    starts as before for back-compat. Injects token + admin_ids via
+    ``configure`` so the bundled desktop app uses its per-user secret, not an
+    ambient env var. Stores the task in ``_discord_task`` for live restart.
+    """
+    global _discord_task
+    import os as _os
+
+    from surfaces.discord import configure as _configure
+    from surfaces.discord import start_in_background as _start_discord
+
+    cfg_token = (_graph_config.discord_bot_token or "").strip() if _graph_config else ""
+    env_token = (_os.environ.get("DISCORD_BOT_TOKEN") or "").strip()
+    admin_ids = list(_graph_config.discord_admin_ids) if _graph_config else []
+    enabled = bool(_graph_config.discord_enabled) if _graph_config else False
+
+    _configure(cfg_token, admin_ids)
+
+    # UI token requires the enabled toggle; a bare env token (no UI token) starts
+    # for back-compat (Docker deploys that only set DISCORD_BOT_TOKEN).
+    should_start = (bool(cfg_token) and enabled) or (not cfg_token and bool(env_token))
+    if not should_start:
+        log.info("[discord] gateway not started (enabled=%s, token=%s)",
+                 enabled, "set" if (cfg_token or env_token) else "unset")
+        return
+
+    async def _discord_invoke(prompt: str, session_id: str) -> str:
+        result = await chat(prompt, session_id)
+        return "\n\n".join(
+            m["content"] for m in result
+            if m.get("role") == "assistant" and m.get("content")
+        )
+
+    # subscribe enables return-address delivery: reactive Activity-thread output
+    # (scheduler/inbox/proactive) is forwarded to the operator's captured DM.
+    _discord_task = _start_discord(
+        _discord_invoke, publish=_event_bus.publish, subscribe=_event_bus.subscribe
+    )
+
+
+def _restart_discord_async() -> None:
+    """Fire-and-forget: stop the running gateway, then start from new config.
+
+    Reload paths are sync but run inside a request handler, so the loop is live
+    (same idiom as ``_start_scheduler_async``). Skips the work entirely when no
+    loop is running (early-boot reload) — startup will start it.
+    """
+    import asyncio
+
+    global _discord_task
+
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+
+    async def _swap() -> None:
+        global _discord_task
+        try:
+            from surfaces.discord import stop as _discord_stop
+
+            if _discord_task is not None:
+                _discord_task.cancel()
+                _discord_task = None
+            await _discord_stop()
+        except Exception:
+            log.exception("[discord] stop during restart failed")
+        try:
+            _start_discord_surface()
+        except Exception:
+            log.exception("[discord] restart failed")
+
+    loop.create_task(_swap())
 
 
 def _sync_autostart_with_config(config: dict | None) -> str | None:
@@ -2457,26 +2553,13 @@ def _main():
             import asyncio
             _checkpoint_prune_task = asyncio.create_task(_checkpoint_prune_loop())
 
-        # Inbound Discord gateway (ADR 0015) — opt-in via DISCORD_BOT_TOKEN. A
-        # Discord DM is conversational, so it invokes the agent as a chat surface
-        # with a per-conversation session_id (the LangGraph thread key), NOT the
-        # single system:activity inbox thread. Best-effort bus publish for
-        # console visibility.
+        # Inbound Discord gateway (ADR 0015/0016) — started from the live config
+        # (UI token in secrets, or the DISCORD_BOT_TOKEN env fallback). A Discord
+        # DM is conversational, so it invokes the agent as a chat surface with a
+        # per-conversation session_id (the LangGraph thread key), NOT the single
+        # system:activity inbox thread.
         try:
-            from surfaces.discord import start_in_background as _start_discord
-
-            async def _discord_invoke(prompt: str, session_id: str) -> str:
-                result = await chat(prompt, session_id)
-                return "\n\n".join(
-                    m["content"] for m in result
-                    if m.get("role") == "assistant" and m.get("content")
-                )
-
-            # subscribe enables return-address delivery: reactive Activity-thread
-            # output (scheduler/inbox/proactive) is forwarded to the operator's
-            # captured Discord DM (ADR 0015).
-            _start_discord(_discord_invoke, publish=_event_bus.publish,
-                           subscribe=_event_bus.subscribe)
+            _start_discord_surface()
         except Exception:
             log.exception("[discord] gateway startup failed")
 
@@ -2709,6 +2792,28 @@ def _main():
         model = body.model or (_graph_config.model_name if _graph_config else "")
         ok, error = await asyncio.to_thread(validate_model_connection, base, key, model)
         return {"ok": ok, "error": error}
+
+    class DiscordProbeRequest(PydanticBaseModel):
+        bot_token: str = ""
+
+    @fastapi_app.post("/api/config/test-discord")
+    async def _api_test_discord(req: DiscordProbeRequest | None = None):
+        """Verify a Discord bot token by fetching its identity (Test connection).
+
+        POST (body) so the token never lands in a URL/log. Blank falls back to
+        the saved token, so Settings can re-test the live config. Returns the bot
+        username so the UI can show "Connected as <bot>".
+        """
+        from surfaces.discord import validate_token
+
+        body = req or DiscordProbeRequest()
+        token = body.bot_token or (_graph_config.discord_bot_token if _graph_config else "")
+        ok, bot_user, error = await validate_token(token or "")
+        return {
+            "ok": ok,
+            "error": error,
+            "bot_user": (bot_user or {}).get("username") if ok else None,
+        }
 
     # --- Setup wizard state -------------------------------------------------
     @fastapi_app.get("/api/config/setup-status")

--- a/server.py
+++ b/server.py
@@ -2093,6 +2093,16 @@ def _a2a_terminal(outcome) -> None:
 def _main():
     global _active_port
 
+    # Frozen-binary entrypoint for the managed Google MCP server (ADR 0017): the
+    # bundled desktop app has no `python` on PATH, so the google MCP entry
+    # re-invokes this binary with --mcp-google instead of `-m
+    # mcp_servers.google.server`. Handle it before argparse/server startup.
+    if "--mcp-google" in sys.argv:
+        from mcp_servers.google.server import main as _google_mcp_main
+
+        _google_mcp_main()
+        return
+
     parser = argparse.ArgumentParser(description=f"{AGENT_NAME_ENV} — protoAgent server")
     parser.add_argument("--port", type=int, default=7870)
     parser.add_argument("--config", type=str, default=None)
@@ -2814,6 +2824,57 @@ def _main():
             "error": error,
             "bot_user": (bot_user or {}).get("username") if ok else None,
         }
+
+    def _google_env_from_config() -> None:
+        """Mirror the configured Google OAuth client + token path into the env so
+        ``mcp_servers.google.auth`` (which reads env) can run the consent/status
+        in-process for the connect + status endpoints."""
+        from graph.config_io import _live_config_dir
+
+        cid = (_graph_config.google_client_id if _graph_config else "") or ""
+        sec = (_graph_config.google_client_secret if _graph_config else "") or ""
+        if cid:
+            os.environ["GOOGLE_CLIENT_ID"] = cid
+        if sec:
+            os.environ["GOOGLE_CLIENT_SECRET"] = sec
+        os.environ["GOOGLE_TOKEN_PATH"] = str(_live_config_dir() / "google-token.json")
+
+    @fastapi_app.get("/api/config/google/status")
+    async def _api_google_status():
+        """Report (configured, connected, email) for the Google surface."""
+        try:
+            from mcp_servers.google.auth import connection_status
+        except Exception as e:  # noqa: BLE001 — google extra may be absent
+            return {"configured": False, "connected": False, "email": None,
+                    "error": f"google support unavailable: {e}"}
+        _google_env_from_config()
+        try:
+            return await asyncio.to_thread(connection_status)
+        except Exception as e:  # noqa: BLE001
+            return {"configured": False, "connected": False, "email": None, "error": str(e)}
+
+    @fastapi_app.post("/api/config/google/connect")
+    async def _api_google_connect():
+        """Run the OAuth consent (opens the operator's browser), cache the token,
+        enable the Google surface, and reload so the tools register. Long-lived:
+        it blocks until the operator approves in the browser (3-min cap)."""
+        try:
+            from mcp_servers.google.auth import run_consent
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "error": f"google support unavailable: {e}"}
+        if not (_graph_config and _graph_config.google_client_id and _graph_config.google_client_secret):
+            return {"ok": False, "error": "Set the OAuth client ID + secret first, then connect."}
+        _google_env_from_config()
+        try:
+            email = await asyncio.wait_for(asyncio.to_thread(run_consent), timeout=180)
+        except asyncio.TimeoutError:
+            return {"ok": False, "error": "Timed out waiting for Google consent (3 min). Try again."}
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "error": str(e)}
+        # Persist enabled + reload so the managed google MCP server starts and the
+        # tools register without a restart.
+        ok, msg = _apply_settings_changes(config={"google": {"enabled": True}})
+        return {"ok": True, "email": email, "reload": msg if ok else None}
 
     # --- Setup wizard state -------------------------------------------------
     @fastapi_app.get("/api/config/setup-status")

--- a/surfaces/discord/__init__.py
+++ b/surfaces/discord/__init__.py
@@ -1,10 +1,12 @@
-"""Optional native Discord surface (ADR 0015).
+"""Optional native Discord surface (ADR 0015 + 0016).
 
-Off unless ``DISCORD_BOT_TOKEN`` is set. The inbound gateway listener
-(``gateway.start_in_background``) is the native half; the stateless outbound
-tools live in ``tools/discord_tools.py``.
+Off unless a bot token is set — via the in-app config (Settings / setup wizard,
+ADR 0016) or the ``DISCORD_BOT_TOKEN`` env var (Docker fallback). The inbound
+gateway listener (``gateway.start_in_background``) is the native half; the
+stateless outbound tools live in ``tools/discord_tools.py``. ``configure`` injects
+the UI config; ``validate_token`` powers the "Test connection" probe.
 """
 
-from surfaces.discord.gateway import start_in_background, stop
+from surfaces.discord.gateway import configure, start_in_background, stop, validate_token
 
-__all__ = ["start_in_background", "stop"]
+__all__ = ["configure", "start_in_background", "stop", "validate_token"]

--- a/surfaces/discord/gateway.py
+++ b/surfaces/discord/gateway.py
@@ -56,13 +56,64 @@ def _f(env: str, default: float) -> float:
         return default
 
 
+# In-app config (ADR 0016), injected by the server from the live config before
+# start. `None` means "not configured via the UI" — fall back to the env vars so
+# Docker/repo deploys keep working. The UI path is what lets the bundled desktop
+# app carry a per-user token (secrets.yaml) instead of an ambient env var.
+_cfg_token: str | None = None
+_cfg_admin_ids: set[str] | None = None
+
+
+def configure(token: str | None, admin_ids: list[str] | None) -> None:
+    """Set the in-app Discord config (call before ``start_in_background``).
+
+    A blank/None token leaves the env var as the source (back-compat). A
+    non-None ``admin_ids`` (even empty) overrides the env CSV.
+    """
+    global _cfg_token, _cfg_admin_ids
+    _cfg_token = (token or "").strip() or None
+    _cfg_admin_ids = (
+        {str(a).strip() for a in admin_ids if str(a).strip()}
+        if admin_ids is not None
+        else None
+    )
+
+
 def _token() -> str | None:
-    return os.environ.get("DISCORD_BOT_TOKEN")
+    return _cfg_token or os.environ.get("DISCORD_BOT_TOKEN")
 
 
 def _admin_ids() -> set[str]:
+    if _cfg_admin_ids is not None:
+        return _cfg_admin_ids
     raw = os.environ.get("DISCORD_ADMIN_IDS", "").strip()
     return {s.strip() for s in raw.split(",") if s.strip()} if raw else set()
+
+
+async def validate_token(token: str) -> tuple[bool, dict | None, str]:
+    """Verify a bot token by fetching its own user (Developer Portal identity).
+
+    Returns ``(ok, bot_user, error)`` — ``bot_user`` is Discord's ``/users/@me``
+    payload (``username`` / ``id``) on success. Powers the UI "Test connection"
+    so a bad token is caught before it's saved, mirroring the model probe.
+    """
+    token = (token or "").strip()
+    if not token:
+        return False, None, "bot token is empty"
+    try:
+        async with httpx.AsyncClient(timeout=15) as client:
+            resp = await client.get(
+                f"{_DISCORD_API}/users/@me",
+                headers={"Authorization": f"Bot {token}"},
+            )
+    except httpx.HTTPError as e:
+        return False, None, f"connection failed: {e}"
+    if resp.status_code == 200:
+        return True, resp.json(), ""
+    if resp.status_code == 401:
+        return False, None, "invalid bot token (Discord returned 401 Unauthorized)"
+    detail = (resp.text or "")[:200]
+    return False, None, f"HTTP {resp.status_code}: {detail}" if detail else f"HTTP {resp.status_code}"
 
 
 # Injected by start_in_background — the agent invocation + (optional) bus publish.

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -130,13 +130,17 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # strand fork-added fields outside the drawer's round-trip.
     assert set(d.keys()) == {
         "model", "subagents", "middleware", "knowledge", "skills", "mcp", "plugins",
-        "identity", "auth", "runtime", "operator",
+        "identity", "auth", "discord", "runtime", "operator",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature
     # Secrets are redacted out of the UI-facing dict.
     assert d["model"]["api_key"] == ""
     assert d["auth"]["token"] == ""
+    # Discord bot token is a secret too — redacted, with enabled/admin_ids exposed.
+    assert d["discord"]["bot_token"] == ""
+    assert d["discord"]["enabled"] == cfg.discord_enabled
+    assert d["discord"]["admin_ids"] == list(cfg.discord_admin_ids)
     assert d["subagents"]["researcher"]["tools"] == list(cfg.researcher.tools)
     assert d["middleware"]["audit"] == cfg.audit_middleware
     assert d["knowledge"]["top_k"] == cfg.knowledge_top_k

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -130,7 +130,7 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # strand fork-added fields outside the drawer's round-trip.
     assert set(d.keys()) == {
         "model", "subagents", "middleware", "knowledge", "skills", "mcp", "plugins",
-        "identity", "auth", "discord", "runtime", "operator",
+        "identity", "auth", "discord", "google", "runtime", "operator",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -20,6 +20,63 @@ from typing import Any
 log = logging.getLogger("protoagent.mcp")
 
 
+def _google_server_entry(config) -> dict | None:
+    """Build the managed Google MCP server entry, or None if google is off.
+
+    The OAuth client (id/secret) + token path + tz are passed to the subprocess
+    via ``env``. Launch is frozen-aware: the bundled desktop binary has no
+    ``python`` on PATH, so it re-invokes itself (``<binary> --mcp-google``); in a
+    normal interpreter it runs ``-m mcp_servers.google.server``.
+    """
+    if not getattr(config, "google_enabled", False):
+        return None
+    client_id = (getattr(config, "google_client_id", "") or "").strip()
+    client_secret = (getattr(config, "google_client_secret", "") or "").strip()
+    if not (client_id and client_secret):
+        log.info("[google] enabled but OAuth client not set — server not started")
+        return None
+
+    import sys
+
+    try:
+        from graph.config_io import _live_config_dir
+
+        token_path = str(_live_config_dir() / "google-token.json")
+    except Exception:  # noqa: BLE001
+        token_path = "google-token.json"
+
+    # Only start the headless MCP server once authorized (a cached token exists).
+    # Before "Connect Google" there's nothing to load — starting it would just
+    # register tools that error on every call. The connect endpoint reloads once
+    # the token is written, so the server comes up then.
+    if not os.path.exists(token_path):
+        log.info("[google] enabled but not connected yet — server starts after Connect Google")
+        return None
+
+    if getattr(sys, "frozen", False):
+        command, args = sys.executable, ["--mcp-google"]
+    else:
+        command, args = sys.executable, ["-m", "mcp_servers.google.server"]
+
+    env = {
+        "GOOGLE_CLIENT_ID": client_id,
+        "GOOGLE_CLIENT_SECRET": client_secret,
+        "GOOGLE_TOKEN_PATH": token_path,
+    }
+    tz = (getattr(config, "google_tz", "") or "").strip()
+    if tz:
+        env["GOOGLE_TZ"] = tz
+
+    return {
+        "name": "google",
+        "enabled": True,
+        "transport": "stdio",
+        "command": command,
+        "args": args,
+        "env": env,
+    }
+
+
 def _server_connection(server: dict) -> dict | None:
     """Map a config ``mcp.servers[]`` entry to a langchain-mcp-adapters
     connection dict. Returns ``None`` for an entry missing its essential fields
@@ -136,10 +193,22 @@ def build_mcp_tools(config) -> tuple[list, list, list[dict]]:
     tools: list = []
     meta: list[dict] = []
 
-    if not getattr(config, "mcp_enabled", False):
+    # The Google surface (ADR 0017) is a managed MCP server: when google is
+    # enabled in config, inject its entry (frozen-aware launch + OAuth env) and
+    # treat MCP as enabled, so the operator never edits mcp.servers. A
+    # user-defined 'google' entry is replaced by the managed one.
+    servers = list(getattr(config, "mcp_servers", []) or [])
+    google_entry = _google_server_entry(config)
+    if google_entry is not None:
+        servers = [
+            s for s in servers
+            if not (isinstance(s, dict) and str(s.get("name") or "") == "google")
+        ]
+        servers.append(google_entry)
+
+    if not (getattr(config, "mcp_enabled", False) or google_entry is not None):
         return clients, tools, meta
 
-    servers = getattr(config, "mcp_servers", []) or []
     timeout = float(getattr(config, "mcp_timeout_seconds", 20.0))
     denylist = set(getattr(config, "mcp_denylist", []) or [])
     core_names = _core_tool_names()


### PR DESCRIPTION
Final port PR (4/4) from the **gina** fork — ships protoAgent with **Discord + Google connectable out of the box**, all UI-driven. No env vars, no `credentials.json`, no `mcp.servers` editing.

## Added
### Discord (ADR 0016)
- `discord` config section (`enabled` / `bot_token` → secrets.yaml / `admin_ids`); a **"Connect Discord"** wizard step + Settings section with **"Test connection"** (real `GET /users/@me` probe → bot name). Gateway reconnects live on save; env vars remain a Docker fallback.

### Google (ADR 0017)
- `google` config section (OAuth client → secrets.yaml); a **"Connect Google"** button (Settings) + wizard step that runs the consent flow (`POST /api/config/google/connect` opens the browser, caches a per-user token). The Google MCP server is **auto-wired** when connected and **frozen-aware** (`<binary> --mcp-google`); headless subprocess is load-only (no surprise browser).
- Brings the **Google Slice-2 base** (Gmail/Calendar MCP server + `requirements-google.txt`) — Google was downstream-only, so the template lacked it.
- `build_sidecar` now bundles the Discord surface + MCP/Google libs into the frozen sidecar.

## De-branding
All user-facing copy is template-clean / name-driven; `-deprecated-gina` provenance comments kept. ADR deciders + docs links point at protoAgent.

## Verified
`npm run web:build` clean; **931 tests pass**; config round-trips (discord + google), secrets route to the overlay, both Settings groups render. Cherry-picked from gina #14/#16 + Slice-2 base, conflicts resolved (briefing is gina-only — excluded).

Completes the 4-PR port (#499 console fixes · #500 desktop+boot-gate · #501 model validation · this). Note: the inline graph-compile reload bug is tracked separately in #497.

🤖 Generated with [Claude Code](https://claude.com/claude-code)