### PR TITLE
Fork ergonomics: customize via config/plugins/env, not core edits

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,5 @@
+# Append-only files conflict on every fork merge / upstream cherry-pick because
+# both sides add entries at the top. `merge=union` keeps BOTH sides instead of
+# raising a conflict — a fork's entries and upstream's coexist (re-order/dedupe
+# by hand at release time if needed). Confirmed pain across every downstream port.
+CHANGELOG.md merge=union

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -34,8 +34,10 @@ jobs:
   prepare:
     name: Prepare Release
     runs-on: namespace-profile-protolabs-linux
-    # Repo-scope guard: don't run in forks.
-    if: github.repository == 'protoLabsAI/protoAgent'
+    # Opt-in guard (fork-friendly): set the `RELEASE_ENABLED` repo variable to
+    # `true` to enable the release pipeline. Forks enable it without editing this
+    # workflow — so upstream changes to the file don't conflict on re-sync.
+    if: vars.RELEASE_ENABLED == 'true'
     permissions:
       contents: write
       pull-requests: write

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,9 @@ jobs:
   release:
     name: Release
     runs-on: namespace-profile-protolabs-linux
-    if: github.repository == 'protoLabsAI/protoAgent'
+    # Opt-in guard (fork-friendly): set the `RELEASE_ENABLED` repo variable to
+    # `true` to enable releases. Forks enable without editing this workflow.
+    if: vars.RELEASE_ENABLED == 'true'
     permissions:
       contents: write
       packages: write

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Fork & re-sync ergonomics — customize via config/plugins/env, not core
+  edits.** A fork-extensibility audit found the biggest re-sync tax was the fork
+  guide telling forks to `sed s/protoagent/<name>/` (~120 files diverge → every
+  upstream merge conflicts) for a purely cosmetic internal rename — the
+  user-facing name is already `identity.name`-driven. Quick wins:
+  - **`.gitattributes`: `CHANGELOG.md merge=union`** — the changelog no longer
+    conflicts on a fork merge / upstream cherry-pick (both sides' entries coexist).
+  - **Tool denylist** — drop named core tools via config (`tools.disabled`,
+    live-reloadable) instead of editing `tools/lg_tools.py::get_all_tools()`.
+    "Keep what you want, drop the rest, add your own (plugin)" is now fully
+    config + plugin driven.
+  - **Release pipeline gates on the `RELEASE_ENABLED` repo variable** (not a
+    `github.repository == 'protoLabsAI/protoAgent'` literal), so forks enable
+    releases without editing `prepare-release.yml` / `release.yml`.
+  - **Fork guide + `TEMPLATE.md` rewritten** to set the name in config + SOUL.md,
+    keep the internal `protoagent` identifier, and use the repo variable.
+
 ## [0.12.0] - 2026-06-04
 
 ### Added

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -17,41 +17,38 @@ Now what?
 This is the change list to turn a fresh template clone into a
 working agent. Work top-down — later steps assume earlier ones.
 
-## 0. Decide on an agent name
+> **Customize via config, SOUL.md, plugins, and env — not by editing core
+> files.** The fewer tracked files you touch, the cleaner you can pull upstream
+> fixes (`git merge upstream/main`). `CHANGELOG.md` is `merge=union`, so it never
+> conflicts. The steps below reflect that — in particular, **don't rename the
+> internal `protoagent` identifier.**
 
-Pick a short slug (`quinn`, `jon`, `matt`). It will end up in:
+## 0. Decide on an agent name (set it in config, don't rename)
 
-- `AGENT_NAME` env var at runtime
-- Prometheus metric prefix (`<name>_llm_calls_total`, etc.)
-- Langfuse trace tag
-- Docker image label + GHCR path
-- Release pipeline repo guards
+Pick a short slug (`quinn`, `jon`, `matt`). Set the **user-facing** name in
+**config** — `identity.name` in `config/langgraph-config.yaml` (or the setup
+wizard) — and it flows to the console brand, window title, agent card, and
+system prompt. Persona goes in `config/SOUL.md` (loaded into the prompt).
 
-The template uses `protoagent` as the placeholder. Do a
-case-insensitive find-and-replace of `protoagent` / `protoAgent`
-across the repo when forking:
+**Do NOT find-and-replace `protoagent` across the repo.** That internal name is
+the logger namespace, the `~/.protoagent` data dir, the `PROTOAGENT_*` env vars,
+and the plugin namespace — all internal, never shown to a user. A `sed` rewrites
+~120 files and turns every upstream merge into a conflict, for zero functional
+gain. Leave it. The only slug that's worth wiring is the **`AGENT_NAME` env var**
+(Prometheus prefix / Langfuse tag / A2A `<NAME>_API_KEY`) — an env value, not a
+file edit. The Docker image label / GHCR path lives in *your* deploy config.
+
+## 1. Enable the release pipeline (a repo variable, not a workflow edit)
+
+Set the **`RELEASE_ENABLED` repo variable** to `true`:
 
 ```bash
-git grep -li protoagent | xargs sed -i 's/protoagent/<your-name>/g'
-git grep -li protoAgent | xargs sed -i 's/protoAgent/<YourName>/g'
+gh variable set RELEASE_ENABLED --body true
 ```
 
-Review the diff before committing — the replacement hits
-Dockerfile paths (`/opt/protoagent`), GHCR image name, workflow
-repo guards, and the Gradio UI branding. All of those want the
-new name.
-
-## 1. Claim the repo name in workflow guards
-
-Three workflow files have `github.repository == 'protoLabsAI/protoAgent'`
-guards so the template itself doesn't trigger releases:
-
-- `.github/workflows/prepare-release.yml`
-- `.github/workflows/release.yml`
-- `.github/workflows/docker-publish.yml`
-
-Change all three to your fork's owner/repo. Until you do, releases
-won't fire — intentional, not a bug.
+`prepare-release.yml` and `release.yml` gate on it, so you enable releases
+without editing the workflow files — and upstream changes to them re-sync
+cleanly. Until the variable is set, releases won't fire (intentional).
 
 All workflows must stay on the org-owned runner
 (`runs-on: namespace-profile-protolabs-linux`); `checks.yml` runs
@@ -80,8 +77,14 @@ handler's output extraction depends on it.
 `tools/lg_tools.py` ships with a small keyless starter set so a
 fresh clone can demonstrate a real research loop: `current_time`,
 `calculator` (safe AST eval — no `eval()`), `web_search` (DuckDuckGo
-via `ddgs`), and `fetch_url`. Keep the ones you want, drop the rest,
-and add your own:
+via `ddgs`), and `fetch_url`.
+
+**Keep / drop / add without editing core:** drop tools you don't want via
+config — list them under `tools.disabled` in `config/langgraph-config.yaml`
+(live-reloadable). Add your own as a **plugin** (`plugins/<id>/` with a
+`register(registry)` — see [Plugins](./docs/guides/plugins.md)). Both keep
+upstream re-syncs clean. Editing `get_all_tools()` directly (below) still works,
+but it's a core edit that conflicts on every upstream merge.
 
 ```python
 from langchain_core.tools import tool

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -136,6 +136,19 @@ execute_code:
   timeout: 30
   tools: []
 
+# Tools — fork customization without editing tools/lg_tools.py.
+#   disabled: drop named core tools from the agent (a fork "keeps what it wants"
+#     by listing the rest here; plugins still ADD tools). Live-reloadable.
+#   deferred: withhold tool schemas until the agent searches for them (cuts the
+#     per-turn footprint past ~15 tools). OFF by default.
+tools:
+  disabled: []
+  # - calculator
+  # - daily_log
+  # deferred:
+  #   enabled: false
+  #   keep: []
+
 # React operator console — the beads/notes APIs accept a project path from
 # the (free-text) UI, so the server, not the client, decides which
 # directories they may touch. The protoAgent repo root is always allowed;

--- a/docs/guides/fork-the-template.md
+++ b/docs/guides/fork-the-template.md
@@ -2,52 +2,62 @@
 
 Same checklist as `TEMPLATE.md` in the repo, kept in sync. Use this when you've forked before and don't need the tutorial walkthrough — just the list.
 
-## 0. Pick a name
+> **Re-sync is the design goal.** Everything below customizes via **config,
+> SOUL.md, plugins, and env** — *not* by editing core files. The fewer tracked
+> files you touch, the cleaner `git merge upstream/main` (or a cherry-pick)
+> stays. `CHANGELOG.md` is set to `merge=union` (`.gitattributes`), so your
+> entries and upstream's coexist instead of conflicting.
 
-One short slug. Ends up in:
+## 0. Name + identity (config, not a rename)
 
-- `AGENT_NAME` env var
-- Prometheus metric prefix (`<name>_llm_calls_total`, etc.)
-- Langfuse trace tag
-- Docker image label + GHCR path
-- Release pipeline repo guards
+Set your agent's **user-facing** name in **config** — it flows to the console
+brand, window/tab title, agent card, and system prompt:
 
-## 1. Rename
+- `identity.name` in `config/langgraph-config.yaml` (or the setup wizard), and
+- `config/SOUL.md` for persona — it's loaded into the system prompt, so you don't
+  edit `graph/prompts.py`. (Keep the `<scratch_pad>`/`<output>` protocol block if
+  you ever do touch prompts — the A2A handler's output extraction depends on it.)
+
+**Do NOT `sed` the internal `protoagent` identifier.** It's the stable template
+name for logger namespaces, the `~/.protoagent` data dir, `PROTOAGENT_*` env
+vars, and the plugin namespace — all internal, never user-facing. Renaming it
+rewrites ~120 files and makes *every* upstream merge conflict, for zero
+functional gain. Leave it.
+
+The few places that genuinely want your slug are **env-driven**, no file edit:
+
+- `AGENT_NAME` env var (Prometheus prefix, Langfuse tag, A2A `<NAME>_API_KEY`).
+- Docker image label / GHCR path — set in *your* deploy, not the template.
+
+## 1. Enable the release pipeline (no workflow edit)
+
+Set the **`RELEASE_ENABLED` repo variable** to `true`:
 
 ```bash
-git grep -li protoagent | xargs sed -i 's/protoagent/<your-name>/g'
-git grep -li protoAgent | xargs sed -i 's/protoAgent/<YourName>/g'
+gh variable set RELEASE_ENABLED --body true
 ```
 
-Review the diff. Key hits: `Dockerfile` (`/opt/protoagent`), `IMAGE_NAME` in the workflow files, `chat_ui.py` branding.
+The release workflows gate on it, so you enable releases without touching
+`prepare-release.yml` / `release.yml` — and upstream changes to those files
+re-sync cleanly. Until the variable is set, releases won't fire (intentional).
 
-## 2. Un-freeze release pipeline
+## 2. Tools — keep / drop / add (config + plugins, no core edit)
 
-Change the `github.repository == 'protoLabsAI/protoAgent'` guard in:
+The starter tools ship by default: `current_time`, `calculator`, `web_search`,
+`fetch_url` (keyless general) plus the memory, scheduler, notes, GitHub, and
+beads tools.
 
-- `.github/workflows/prepare-release.yml`
-- `.github/workflows/release.yml`
+- **Drop** the ones you don't want via config — list them under `tools.disabled`
+  in `config/langgraph-config.yaml` (live-reloadable). No `get_all_tools()` edit.
+- **Add** your own as a **plugin** (`plugins/<id>/` with a `register(registry)`),
+  so they're discovered without touching core. See [Plugins](/guides/plugins).
 
-Until this lands, releases won't fire. Intentional, not a bug.
-
-## 3. Rewrite identity
-
-| File | What goes in it |
-|---|---|
-| `config/SOUL.md` | Persona doc loaded into workspace at session start |
-| `graph/prompts.py::build_system_prompt` | Lead agent system prompt |
-| `graph/prompts.py::build_subagent_prompt` | Per-subagent delegation prompt |
-| `server.py::_build_agent_card` | `name`, `description`, `skills`, declared extensions |
-
-Keep the `<scratch_pad>` / `<output>` protocol block in `prompts.py` — the A2A handler's output extraction depends on it.
-
-## 4. Replace the starter tools
-
-Twelve tools ship by default: `current_time`, `calculator`, `web_search`, `fetch_url` (keyless general) plus `memory_ingest`, `memory_recall`, `memory_list`, `memory_stats`, `daily_log` (bound to the bundled `KnowledgeStore`) plus `schedule_task`, `list_schedules`, `cancel_schedule` (bound to the scheduler backend). Keep what you want, drop the rest, add your own. Update `get_all_tools()` at the bottom of `tools/lg_tools.py`.
+(Editing `tools/lg_tools.py::get_all_tools()` directly still works, but it's a
+core edit that conflicts on every upstream re-sync — prefer config + plugins.)
 
 See the [starter tools reference](/reference/starter-tools) for the shapes of the shipped ones.
 
-## 5. Configure subagents (optional)
+## 3. Configure subagents (optional)
 
 `graph/subagents/config.py` ships with one `researcher`. Either:
 
@@ -56,7 +66,7 @@ See the [starter tools reference](/reference/starter-tools) for the shapes of th
 
 See [Configure subagents](/guides/subagents) for the full pattern.
 
-## 6. Point at a model
+## 4. Point at a model
 
 Edit `config/langgraph-config.yaml::model.name`. Two options:
 
@@ -65,10 +75,10 @@ Edit `config/langgraph-config.yaml::model.name`. Two options:
 
 Option 1 is preferred.
 
-## 7. Deploy
+## 5. Deploy
 
 See [Deploy via GHCR](/guides/deploy). The Dockerfile uses a single `COPY . /opt/protoagent/` so new files don't need Dockerfile updates.
 
-## 8. Delete `TEMPLATE.md`
+## 6. Delete `TEMPLATE.md`
 
 Once the checklist is done, delete it and rewrite `README.md` to describe your specific agent.

--- a/graph/config.py
+++ b/graph/config.py
@@ -187,6 +187,13 @@ class LangGraphConfig:
     tools_deferred_enabled: bool = False
     tools_deferred_keep: list[str] = field(default_factory=list)
 
+    # Tool denylist — drop named core tools from the agent without editing
+    # ``tools/lg_tools.py::get_all_tools``. A fork keeps what it wants by listing
+    # the rest here (config ``tools.disabled``); plugins still ADD tools. So
+    # "keep what you want, drop the rest, add your own" is fully config + plugin
+    # driven — no core edit that conflicts on upstream re-sync.
+    tools_disabled: list[str] = field(default_factory=list)
+
     # Model routing / failover — wires langchain's ModelFallbackMiddleware.
     # On primary error, retry on each fallback model (same gateway) in order.
     routing_fallback_models: list[str] = field(default_factory=list)
@@ -446,6 +453,7 @@ class LangGraphConfig:
             execute_code_output_truncate=data.get("execute_code", {}).get("output_truncate", cls.execute_code_output_truncate),
             tools_deferred_enabled=data.get("tools", {}).get("deferred", {}).get("enabled", cls.tools_deferred_enabled),
             tools_deferred_keep=list(data.get("tools", {}).get("deferred", {}).get("keep", []) or []),
+            tools_disabled=list(data.get("tools", {}).get("disabled", []) or []),
             routing_fallback_models=data.get("routing", {}).get("fallback_models", []),
             aux_model=data.get("routing", {}).get("aux_model", cls.aux_model),
             goal_enabled=data.get("goal", {}).get("enabled", cls.goal_enabled),

--- a/server.py
+++ b/server.py
@@ -203,6 +203,10 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # it at per-user app-data), so load through it rather than a fixed path.
     ensure_live_config()
     _graph_config = LangGraphConfig.from_yaml(CONFIG_YAML_PATH)
+    # Fork tool denylist (config ``tools.disabled``) — applied before any
+    # get_all_tools() call so dropped tools never reach the graph.
+    from tools.lg_tools import set_disabled_tools
+    set_disabled_tools(_graph_config.tools_disabled)
     # Egress allowlist (ADR 0008): deny-by-default outbound hosts for fetch_url.
     import egress
     egress.set_allowed_hosts(_graph_config.egress_allowed_hosts)
@@ -806,6 +810,11 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     except Exception as e:
         log.exception("[reload] config load failed")
         return False, f"config load failed: {e}"
+
+    # Fork tool denylist — apply the new config's denylist before the rebuild's
+    # get_all_tools() calls (live-reloadable like the rest of the config).
+    from tools.lg_tools import set_disabled_tools
+    set_disabled_tools(new_config.tools_disabled)
 
     # Build the graph FIRST (when setup is complete) — only commit
     # runtime state after the rebuild succeeds. Doing the swap first

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -343,6 +343,18 @@ def _extract_text_from_html(content: bytes) -> str:
 _MEMORY_RECALL_MAX_K = 20
 _MEMORY_LIST_MAX_LIMIT = 200
 
+# Fork tool denylist — names dropped from ``get_all_tools``. Set once from config
+# (``tools.disabled``) by ``set_disabled_tools`` at config load/reload, so a fork
+# removes core tools via YAML instead of editing ``get_all_tools`` (a core edit
+# that would conflict on every upstream re-sync). Plugins still ADD tools.
+_disabled_tools: set[str] = set()
+
+
+def set_disabled_tools(names) -> None:
+    """Set the fork tool denylist (config ``tools.disabled``)."""
+    global _disabled_tools
+    _disabled_tools = {str(n).strip() for n in (names or []) if str(n).strip()}
+
 # Stable list of scheduler tool names. Exposed as a module-level
 # constant so ``graph/config_io.py::list_available_tools`` can show
 # the wizard the right surface even when the runtime hasn't yet
@@ -703,6 +715,10 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, beads_
         tools.extend(_build_inbox_tools(inbox_store))
     if beads_store is not None:
         tools.extend(_build_beads_tools(beads_store))
+    # Fork denylist (config ``tools.disabled``): drop named core tools without
+    # editing this function. Applied last so it covers every branch above.
+    if _disabled_tools:
+        tools = [t for t in tools if getattr(t, "name", None) not in _disabled_tools]
     return tools
 
 


### PR DESCRIPTION
Quick wins from the **extensibility audit** — the goal: fork → customize → pull upstream fixes with minimal headache, provided you don't touch core logic. Grounded in the friction I hit porting fixes through gina/jon/roxy.

## What the audit found
protoAgent's extension *mechanisms* are good (config, plugins, MCP, SOUL.md, subagent registry). The pain was the fork **guide** prescribing **core-file edits** — chiefly a cosmetic `sed s/protoagent/<name>/` that diverges ~120 files (the user-facing name is already `identity.name`-driven) — plus CHANGELOG conflicting on every merge.

## Quick wins (this PR)
- **`.gitattributes`: `CHANGELOG.md merge=union`** — changelog stops conflicting on fork merges / cherry-picks (hit 4/4 ports).
- **Tool denylist** — `tools.disabled` in config (live-reloadable) drops core tools without editing `get_all_tools()`. Add-your-own stays plugin-driven. *(`set_disabled_tools()` at config load + reload; filtered in `get_all_tools`.)*
- **Release gate → `RELEASE_ENABLED` repo variable** (set `true` on protoAgent) instead of the `protoLabsAI/protoAgent` literal — forks enable releases without editing the workflows.
- **Fork guide + `TEMPLATE.md` rewritten** — name via config + SOUL.md, **keep** the internal `protoagent` identifier, repo-var for releases, tools via config/plugins.

## Verified
933 tests pass; example YAML valid; denylist filters confirmed (drop calculator/web_search → gone, current_time stays). `RELEASE_ENABLED=true` set on protoAgent so v0.12.0+ releases keep firing.

## Deferred (separate ADR)
Plugin-contributed **surfaces / routes / subagents** (so Discord/Google-style surfaces are plugins, not `server.py` edits) — the one remaining 🟡 from the audit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)