### PR TITLE
Plugins contribute surfaces, routes & subagents (ADR 0018, closes #506)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Plugins can contribute surfaces, routes & subagents (ADR 0018, #506).** The
+  plugin `register(registry)` contract gained `register_router` (a FastAPI
+  `APIRouter`, mounted under `/plugins/<id>`), `register_surface` (a lifecycle
+  `start`/`stop` background surface, run on the server loop like the Discord
+  gateway), and `register_subagent` (a `SubagentConfig` added to
+  `SUBAGENT_REGISTRY`) — on top of the existing tools + skills. So a fork ships
+  its own ingress / HTTP endpoint / delegate as a `plugins/<id>/` directory with
+  **no `server.py` / registry / `SUBAGENT_REGISTRY` edit** — the last fork
+  re-sync friction point. Routes + surfaces wire once at init (a `plugins.enabled`
+  change needs a restart); contributions show in `GET /api/runtime/status`. The
+  shipped `plugins/hello` example now demonstrates all five contribution types.
+
 ### Changed
 - **Fork & re-sync ergonomics — customize via config/plugins/env, not core
   edits.** A fork-extensibility audit found the biggest re-sync tax was the fork

--- a/docs/adr/0018-plugin-surfaces-routes-subagents.md
+++ b/docs/adr/0018-plugin-surfaces-routes-subagents.md
@@ -1,0 +1,91 @@
+# ADR 0018 — Plugins contribute surfaces, routes & subagents
+
+- **Status:** Accepted (2026-06-04)
+- **Date:** 2026-06-04
+- **Deciders:** Josh Mabry; protoAgent maintainers
+- **Tags:** extensibility, plugins, surfaces, routes, subagents, fork, architecture
+- **Related:** extends [ADR 0001](./0001-extensibility-and-plugin-architecture.md) (plugin system: tools + skills); motivated by the fork-extensibility audit (#505/#506) — surfaces like [ADR 0015](./0015-discord-ingress-surface.md) Discord + [ADR 0017](./0017-google-ui-config.md) Google are wired into `server.py`, which a fork must edit.
+
+> Accepted. Plugins today contribute only **tools + skill dirs**, so the higher-
+> value customization axes — an **ingress surface** (a Discord-style gateway), a
+> **custom API route**, a **subagent** — still require editing core (`server.py`
+> startup, the route registration, `SUBAGENT_REGISTRY`). The fork audit ranked
+> this the last re-sync friction point. Extend the `register(registry)` contract
+> so a fork drops in a surface/route/subagent as a plugin and never touches core.
+
+## 1. Context & Problem statement
+
+A fork that wants its own ingress (say, a Slack gateway), an extra HTTP endpoint,
+or a domain subagent must edit `server.py`'s startup hook, its route wiring, and
+`graph/subagents/config.py` — exactly the core files that conflict on every
+upstream re-sync. The plugin system already gives a clean, in-process,
+opt-in `register(registry)` seam for tools + skills; the remaining axes just need
+registry methods + lifecycle wiring.
+
+## 2. Decision
+
+Extend `PluginRegistry` with three contribution types, and split them by
+lifecycle (the crux):
+
+1. **`register_router(router, prefix=None)`** — a FastAPI `APIRouter`, mounted
+   under a namespaced prefix (default `/plugins/<id>`) at app setup.
+2. **`register_surface(start, stop=None, name=None)`** — a lifecycle-managed
+   background surface. `start()` (sync or async) is called in the server's
+   startup hook (so it has the running loop, like the Discord gateway); `stop()`
+   in shutdown. Best-effort: a failing surface logs, never breaks boot.
+3. **`register_subagent(config)`** — a `SubagentConfig` added to
+   `SUBAGENT_REGISTRY`, picked up by every graph build.
+
+`PluginLoadResult` gains `routers`, `surfaces`, `subagents`.
+
+### Lifecycle: load once at init, not per-reload
+
+The existing code re-runs `load_plugins()` on every config reload (to re-collect
+tools). That's fine for tools, but **re-running `register()` would re-mount
+routers and re-start surfaces** — illegal (FastAPI routes are fixed after
+startup) or messy. So:
+
+- Plugins `register()` runs **once, at process init** (`_main`, before routes +
+  app start). All contributions are captured.
+- **Routers** mount on the app at init. **Surfaces** register for the startup/
+  shutdown lifecycle. **Subagents** register into `SUBAGENT_REGISTRY`. **Tools/
+  skills** feed the first graph build.
+- A config **reload reuses** the captured tools/skills/subagents (it does not
+  re-run plugins). Changing `plugins.enabled` therefore **requires a restart** —
+  the same constraint routes already have, documented.
+
+### Trust & security
+
+Plugins are **in-process, trusted, opt-in** (ADR 0001's standing decision) —
+untrusted extensions belong on MCP (out-of-process). A plugin router runs with
+full server authority; that's acceptable under the same trust model, but:
+
+- Routers mount under `/plugins/<id>` by default so a plugin can't silently
+  shadow a core route; a plugin may override the prefix (escape hatch, logged).
+- Surfaces + routers are surfaced in `GET /api/runtime/status` plugin meta
+  (`routers`, `surfaces` counts) so the operator can see what a plugin wired.
+
+## 3. Consequences
+
+- A fork ships a surface/route/subagent as a `plugins/<id>/` directory — **no
+  `server.py` / registry / `SUBAGENT_REGISTRY` edit**, so upstream re-syncs stay
+  clean. Closes the last audit friction point.
+- The built-in **Discord/Google surfaces could themselves become plugins** later
+  (they already match the surface shape: a `start`/`stop` pair). That migration
+  is a **follow-up**, not this ADR — v1 ships the extension points + a worked
+  example plugin that registers all three.
+- `plugins.enabled` changes need a restart (acceptable; routes can't hot-unmount).
+- Plugin routes carry full authority — documented; forks own that risk, same as
+  any in-process plugin tool.
+
+## 4. Alternatives considered
+
+- **Per-reload plugin re-load with idempotent router/surface registration.**
+  Rejected — more complex (track already-mounted ids), and routes still can't
+  unmount; load-once is simpler and the restart constraint is honest.
+- **A separate `surfaces/` plugin type distinct from `plugins/`.** Rejected —
+  one `register(registry)` seam for everything keeps the mental model small
+  (ADR 0001's principle); lifecycle is the loader's job, not the author's.
+- **Out-of-process surfaces (subprocess/MCP-style).** Deferred — heavier; the
+  in-process trusted model fits a fork's own surface. MCP remains the path for
+  untrusted code.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -26,3 +26,4 @@ decision, numbered, never deleted (supersede instead).
 | [0015](./0015-discord-ingress-surface.md) | Optional native Discord surface (ingress + outbound) | Accepted (design; impl to follow) |
 | [0016](./0016-discord-ui-config.md) | In-app Discord configuration (token, admin list, live connect) | Accepted |
 | [0017](./0017-google-ui-config.md) | In-app Google (Gmail + Calendar) connect flow | Accepted |
+| [0018](./0018-plugin-surfaces-routes-subagents.md) | Plugins contribute surfaces, routes & subagents | Accepted |

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -52,8 +52,30 @@ def register(registry):
     registry.register_skill_dir("skills")  # bundle SKILL.md skills (relative to the plugin)
 ```
 
-`register` is called once at load. The registry currently accepts
-`register_tool(tool)` / `register_tools(iterable)` and `register_skill_dir(path)`.
+`register` is called once at load. The registry accepts **five** contribution
+types — a fork adds any of them as a plugin, never editing core `server.py`:
+
+| Method | Contributes | Lifecycle |
+|---|---|---|
+| `register_tool(tool)` / `register_tools(iter)` | A LangChain tool | graph build (live-reloads) |
+| `register_skill_dir(path)` | A `SKILL.md` directory | graph build |
+| `register_router(router, prefix=None)` | A FastAPI `APIRouter` | **mounted once** at init (default prefix `/plugins/<id>`) |
+| `register_surface(start, stop=None, name=None)` | A background surface (a Discord-style gateway) | `start` in startup, `stop` in shutdown |
+| `register_subagent(config)` | A `SubagentConfig` (a delegate) | added to `SUBAGENT_REGISTRY` |
+
+```python
+def register(registry):
+    registry.register_tool(hello)
+    registry.register_router(_build_router())        # → GET /plugins/<id>/...
+    registry.register_surface(_start, stop=_stop, name="my-surface")
+    registry.register_subagent(_build_subagent())    # delegate via task/task_batch
+```
+
+**Routes + surfaces are wired once at process init and don't hot-reload** — a
+config reload reuses them, so changing `plugins.enabled` needs a restart
+(ADR 0018). Everything is best-effort: a failing plugin/route/surface logs and
+never breaks boot. The shipped [`plugins/hello`](https://github.com/protoLabsAI/protoAgent/tree/main/plugins/hello)
+example uses all five. Plugin contributions show in `GET /api/runtime/status`.
 
 ## Where plugins live & how they're enabled
 

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -26,6 +26,9 @@ log = logging.getLogger("protoagent.plugins")
 class PluginLoadResult:
     tools: list = field(default_factory=list)
     skill_dirs: list = field(default_factory=list)
+    routers: list = field(default_factory=list)    # {plugin_id, router, prefix} (ADR 0018)
+    surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
+    subagents: list = field(default_factory=list)   # SubagentConfig
     meta: list[dict] = field(default_factory=list)
 
 
@@ -130,12 +133,24 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
 
         result.tools.extend(kept)
         result.skill_dirs.extend(registry.skill_dirs)
+        # Surfaces / routes / subagents (ADR 0018) — tagged with the plugin id so
+        # the server can namespace + report them.
+        for r in registry.routers:
+            result.routers.append({"plugin_id": manifest.id, **r})
+        for s in registry.surfaces:
+            result.surfaces.append({"plugin_id": manifest.id, **s})
+        result.subagents.extend(registry.subagents)
         entry["loaded"] = True
         entry["tools"] = [t.name for t in kept]
         entry["skills"] = len(registry.skill_dirs)
+        entry["routers"] = len(registry.routers)
+        entry["surfaces"] = len(registry.surfaces)
+        entry["subagents"] = [getattr(c, "name", "?") for c in registry.subagents]
         result.meta.append(entry)
-        log.info("[plugins] loaded %s: %d tool(s), %d skill dir(s)",
-                 manifest.id, len(kept), len(registry.skill_dirs))
+        log.info("[plugins] loaded %s: %d tool(s), %d skill dir(s), %d route(s), "
+                 "%d surface(s), %d subagent(s)",
+                 manifest.id, len(kept), len(registry.skill_dirs),
+                 len(registry.routers), len(registry.surfaces), len(registry.subagents))
 
     return result
 

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -16,9 +16,19 @@ log = logging.getLogger("protoagent.plugins")
 class PluginRegistry:
     """Collects a single plugin's contributions during ``register()``.
 
-    Current contribution types: ``tools`` (LangChain ``BaseTool``s) and
-    ``skill_dirs`` (directories of ``SKILL.md`` skills to load). Subagent and
-    middleware contributions are planned follow-ups.
+    Contribution types (ADR 0001 + 0018):
+
+    - ``tools`` — LangChain ``BaseTool``s (``register_tool[s]``).
+    - ``skill_dirs`` — ``SKILL.md`` skill directories (``register_skill_dir``).
+    - ``routers`` — FastAPI ``APIRouter``s, mounted under ``/plugins/<id>``
+      (``register_router``).
+    - ``surfaces`` — lifecycle-managed background surfaces, a ``start`` (+ optional
+      ``stop``) run on the server loop (``register_surface``).
+    - ``subagents`` — ``SubagentConfig``s added to ``SUBAGENT_REGISTRY``
+      (``register_subagent``).
+
+    Routes mount + surfaces start **once** at process init; a config reload reuses
+    them — changing ``plugins.enabled`` needs a restart (ADR 0018).
     """
 
     def __init__(self, plugin_id: str, plugin_dir: Path):
@@ -26,6 +36,9 @@ class PluginRegistry:
         self.plugin_dir = plugin_dir
         self.tools: list = []
         self.skill_dirs: list[Path] = []
+        self.routers: list[dict] = []     # {"router", "prefix"}
+        self.surfaces: list[dict] = []    # {"name", "start", "stop"}
+        self.subagents: list = []         # SubagentConfig instances
 
     def register_tool(self, tool) -> None:
         """Expose a LangChain tool to the agent."""
@@ -48,3 +61,42 @@ class PluginRegistry:
         if not p.is_absolute():
             p = self.plugin_dir / p
         self.skill_dirs.append(p)
+
+    def register_router(self, router, prefix: str | None = None) -> None:
+        """Mount a FastAPI ``APIRouter`` on the server (ADR 0018).
+
+        Defaults to the namespaced prefix ``/plugins/<id>`` so a plugin can't
+        silently shadow a core route. Pass ``prefix=""`` (or your own) to mount
+        elsewhere — an escape hatch, logged. Mounted once at process init; routes
+        don't hot-reload (a ``plugins.enabled`` change needs a restart).
+        """
+        if router is None or not hasattr(router, "routes"):
+            log.warning("[plugins] %s: register_router got a non-router: %r", self.plugin_id, router)
+            return
+        eff = f"/plugins/{self.plugin_id}" if prefix is None else str(prefix)
+        self.routers.append({"router": router, "prefix": eff})
+
+    def register_surface(self, start, stop=None, name: str | None = None) -> None:
+        """Register a lifecycle-managed background surface (ADR 0018).
+
+        ``start`` (sync or async, no args) runs in the server's startup hook — so
+        it has the running loop, like the Discord gateway — and may return a task/
+        handle. ``stop`` (optional, sync or async) runs in shutdown. Best-effort:
+        a failing surface logs and never breaks boot. Started once at init.
+        """
+        if not callable(start):
+            log.warning("[plugins] %s: register_surface needs a callable start", self.plugin_id)
+            return
+        self.surfaces.append({"name": name or self.plugin_id, "start": start, "stop": stop})
+
+    def register_subagent(self, config) -> None:
+        """Add a ``SubagentConfig`` to ``SUBAGENT_REGISTRY`` (ADR 0018).
+
+        Picked up by every graph build, so the lead agent can delegate to it via
+        ``task`` / ``task_batch`` — no edit to ``graph/subagents/config.py``.
+        """
+        if config is None or not getattr(config, "name", None):
+            log.warning("[plugins] %s: register_subagent got an invalid config: %r",
+                        self.plugin_id, config)
+            return
+        self.subagents.append(config)

--- a/plugins/hello/__init__.py
+++ b/plugins/hello/__init__.py
@@ -1,15 +1,26 @@
 """Example protoAgent plugin.
 
-A plugin is a directory with a ``protoagent.plugin.yaml`` manifest and a
-module exposing ``register(registry)``. The registry collects what the plugin
-contributes — here: one tool and one bundled SKILL.md skill directory.
+A plugin is a directory with a ``protoagent.plugin.yaml`` manifest and a module
+exposing ``register(registry)``. The registry collects what the plugin
+contributes. This example shows **all five** contribution types (ADR 0001 + 0018):
 
-Enable it with ``plugins: { enabled: [hello] }`` in config.
+- a **tool** (``hello``),
+- a bundled **SKILL.md** directory (``skills/``),
+- an HTTP **route** (``GET /plugins/hello/ping``),
+- a lifecycle **surface** (logs on startup/shutdown),
+- a **subagent** (``hello_helper``).
+
+Enable it with ``plugins: { enabled: [hello] }`` in config. A fork drops a
+directory like this in ``plugins/`` and never edits core ``server.py``.
 """
 
 from __future__ import annotations
 
+import logging
+
 from langchain_core.tools import tool
+
+log = logging.getLogger("protoagent.plugins.hello")
 
 
 @tool
@@ -18,8 +29,47 @@ async def hello(name: str = "world") -> str:
     return f"Hello, {name}! (from the example protoAgent plugin)"
 
 
+def _build_router():
+    """A tiny FastAPI router — mounted at ``/plugins/hello`` (ADR 0018)."""
+    from fastapi import APIRouter
+
+    router = APIRouter()
+
+    @router.get("/ping")
+    async def _ping() -> dict:
+        return {"ok": True, "plugin": "hello"}
+
+    return router
+
+
+async def _surface_start() -> None:
+    """A no-op lifecycle surface — a real one would open a gateway/listener here
+    (it runs on the server loop, like the Discord gateway)."""
+    log.info("[hello] example surface started")
+
+
+async def _surface_stop() -> None:
+    log.info("[hello] example surface stopped")
+
+
+def _build_subagent():
+    """A minimal delegate the lead agent can call via ``task``/``task_batch``."""
+    from graph.subagents.config import SubagentConfig
+
+    return SubagentConfig(
+        name="hello_helper",
+        description="Example plugin subagent — echoes a friendly status. Proof a "
+        "plugin can register a delegate without editing SUBAGENT_REGISTRY.",
+        system_prompt="You are the hello_helper, a tiny example subagent. Reply "
+        "briefly and cheerfully, then stop.",
+        tools=["current_time"],
+    )
+
+
 def register(registry) -> None:
     """Entry point — called once at load with a PluginRegistry."""
     registry.register_tool(hello)
-    # Bundle a SKILL.md directory shipped alongside this plugin.
-    registry.register_skill_dir("skills")
+    registry.register_skill_dir("skills")            # bundled SKILL.md folder
+    registry.register_router(_build_router())        # → /plugins/hello/ping (ADR 0018)
+    registry.register_surface(_surface_start, stop=_surface_stop, name="hello-surface")
+    registry.register_subagent(_build_subagent())

--- a/server.py
+++ b/server.py
@@ -86,7 +86,12 @@ _mcp_tools = []          # MCP-server tools appended to the active graph.
 _mcp_meta = []           # Per-server {name, transport, tool_count} for runtime status.
 _plugin_tools = []       # Tools contributed by enabled plugins.
 _plugin_skill_dirs = []  # SKILL.md dirs bundled by enabled plugins.
-_plugin_meta = []        # Per-plugin {id, name, enabled, loaded, tools, skills} for status.
+_plugin_routers = []     # FastAPI routers contributed by plugins (ADR 0018) —
+                         # mounted ONCE at init; not hot-reloaded.
+_plugin_surfaces = []    # Lifecycle surfaces (start/stop) from plugins (ADR 0018)
+                         # — started in the startup hook, stopped on shutdown.
+_plugin_surface_handles = []  # Started surfaces ({name, stop, handle}) for shutdown.
+_plugin_meta = []        # Per-plugin {id, name, enabled, loaded, tools, skills, ...} for status.
 _active_port = 7870    # populated by _main() — the port this process is actually bound to.
                        # Read by the autostart installer so the LaunchAgent reboots
                        # on the same port the operator launched with, not the default.
@@ -269,6 +274,13 @@ def _init_langgraph_agent(headless_setup: bool = False):
     _plugin_tools, _plugin_skill_dirs, _plugin_meta = (
         _plugins.tools, _plugins.skill_dirs, _plugins.meta,
     )
+    # Surfaces / routes / subagents (ADR 0018). Routers + surfaces are captured
+    # here and consumed once by _main (mount) + the startup hook (start) — they
+    # don't hot-reload. Subagents register into SUBAGENT_REGISTRY before the graph
+    # build below so the first compile (and every reload) can delegate to them.
+    global _plugin_routers, _plugin_surfaces
+    _plugin_routers, _plugin_surfaces = _plugins.routers, _plugins.surfaces
+    _register_plugin_subagents(_plugins.subagents)
 
     # Skills — human-authored SKILL.md folders (bundle + live + plugin-bundled)
     # seeded into the FTS index; KnowledgeMiddleware retrieves + injects them.
@@ -390,6 +402,34 @@ def _build_mcp(config):
     except Exception as exc:  # noqa: BLE001 — MCP is optional, never fatal
         log.warning("[mcp] init failed: %s; running without MCP tools", exc)
         return [], [], []
+
+
+_plugin_subagent_names: set[str] = set()
+
+
+def _register_plugin_subagents(subagents) -> None:
+    """Add plugin-contributed SubagentConfigs to SUBAGENT_REGISTRY (ADR 0018).
+
+    Idempotent by name (re-registering a plugin's own subagent on a later call is
+    fine) but won't let a plugin shadow a built-in subagent (logged + skipped).
+    """
+    if not subagents:
+        return
+    try:
+        from graph.subagents.config import SUBAGENT_REGISTRY
+    except Exception:  # noqa: BLE001
+        log.warning("[plugins] subagent registry unavailable; skipping plugin subagents")
+        return
+    for cfg in subagents:
+        name = getattr(cfg, "name", None)
+        if not name:
+            continue
+        if name in SUBAGENT_REGISTRY and name not in _plugin_subagent_names:
+            log.warning("[plugins] subagent %r collides with a built-in — skipped", name)
+            continue
+        SUBAGENT_REGISTRY[name] = cfg
+        _plugin_subagent_names.add(name)
+        log.info("[plugins] registered subagent: %s", name)
 
 
 def _build_plugins(config, existing_tools=None):
@@ -2550,6 +2590,16 @@ def _main():
         inbox_deliver=_operator_inbox_deliver,
     )
 
+    # Plugin-contributed routes (ADR 0018) — mounted after the core routes,
+    # under each plugin's namespaced prefix (default /plugins/<id>). Once, here;
+    # routes don't hot-reload. Best-effort so one bad router can't break boot.
+    for r in _plugin_routers:
+        try:
+            fastapi_app.include_router(r["router"], prefix=r["prefix"])
+            log.info("[plugins] mounted router from %s at %s", r["plugin_id"], r["prefix"] or "/")
+        except Exception:
+            log.exception("[plugins] failed to mount router from %s", r.get("plugin_id"))
+
     # --- Scheduler lifecycle ------------------------------------------------
     # The local scheduler needs an asyncio polling task; the Workstacean
     # adapter is a no-op start/stop. Both implement the same contract so
@@ -2596,8 +2646,33 @@ def _main():
         except Exception:
             log.exception("[discord] gateway startup failed")
 
+        # Plugin-contributed surfaces (ADR 0018) — start each on the loop. `start`
+        # may be sync or async and may return a handle (kept for shutdown).
+        # Best-effort: a failing surface logs, never breaks boot.
+        global _plugin_surface_handles
+        for s in _plugin_surfaces:
+            try:
+                res = s["start"]()
+                if asyncio.iscoroutine(res):
+                    res = await res
+                _plugin_surface_handles.append({"name": s["name"], "stop": s.get("stop"), "handle": res})
+                log.info("[plugins] started surface: %s", s["name"])
+            except Exception:
+                log.exception("[plugins] surface %s failed to start", s.get("name"))
+
     @fastapi_app.on_event("shutdown")
     async def _scheduler_shutdown() -> None:
+        # Stop plugin surfaces first (ADR 0018) — best-effort.
+        for h in _plugin_surface_handles:
+            stop = h.get("stop")
+            if not callable(stop):
+                continue
+            try:
+                res = stop()
+                if asyncio.iscoroutine(res):
+                    await res
+            except Exception:
+                log.exception("[plugins] surface %s failed to stop", h.get("name"))
         if _scheduler is not None:
             try:
                 await _scheduler.stop()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -135,3 +135,44 @@ def test_from_yaml_parses_plugins(tmp_path) -> None:
     p.write_text("plugins:\n  enabled: [hello]\n  dir: /tmp/p\n")
     cfg = LangGraphConfig.from_yaml(p)
     assert cfg.plugins_enabled == ["hello"] and cfg.plugins_dir == "/tmp/p"
+
+
+# --- ADR 0018: routers / surfaces / subagents -------------------------------
+
+_EXT_PLUGIN = '''
+class _FakeRouter:
+    routes = []
+
+class _Sub:
+    name = "plug_sub"
+
+def _start():
+    return None
+
+def _stop():
+    return None
+
+def register(registry):
+    registry.register_router(_FakeRouter())            # default prefix /plugins/<id>
+    registry.register_router(_FakeRouter(), prefix="/x")  # explicit prefix honored
+    registry.register_surface(_start, stop=_stop, name="surf")
+    registry.register_subagent(_Sub())
+'''
+
+
+def test_plugin_contributes_router_surface_subagent(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "plugins"
+    _make_plugin(root, "ext", enabled=True, body=_EXT_PLUGIN)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg())
+
+    # Routers: default prefix is namespaced to the plugin id; explicit honored.
+    assert sorted(r["prefix"] for r in res.routers) == ["/plugins/ext", "/x"]
+    assert all(r["plugin_id"] == "ext" for r in res.routers)
+    # Surface + subagent collected, tagged with the plugin id.
+    assert [s["name"] for s in res.surfaces] == ["surf"]
+    assert all(s["plugin_id"] == "ext" for s in res.surfaces)
+    assert [getattr(s, "name", None) for s in res.subagents] == ["plug_sub"]
+    # Meta reports the counts.
+    m = res.meta[0]
+    assert m["routers"] == 2 and m["surfaces"] == 1 and m["subagents"] == ["plug_sub"]


### PR DESCRIPTION
Closes #506. Implements **ADR 0018** — the last fork re-sync friction point from the extensibility audit.

## Why
Plugins contributed only **tools + skills**, so an ingress **surface** (Discord-style gateway), a custom **route**, or a **subagent** still required editing core (`server.py` startup, route wiring, `SUBAGENT_REGISTRY`) — exactly what conflicts on every upstream re-sync.

## What
`register(registry)` gains three contribution types:
- **`register_router(router, prefix=None)`** — a FastAPI `APIRouter`, mounted under `/plugins/<id>` (namespaced so it can't shadow core).
- **`register_surface(start, stop=None, name=None)`** — a lifecycle background surface, `start` in the startup hook (on the loop, like the Discord gateway), `stop` in shutdown.
- **`register_subagent(config)`** — a `SubagentConfig` into `SUBAGENT_REGISTRY` (idempotent; won't shadow a built-in).

**Lifecycle:** routes + surfaces wire **once at init**; a config reload reuses them (a `plugins.enabled` change needs a restart). Best-effort — a bad plugin/route/surface logs, never breaks boot. Contributions surface in `GET /api/runtime/status`.

## Verified (live)
Ran the server with the (extended) `hello` plugin enabled:
- `GET /plugins/hello/ping` → `{ok:true}` ✓
- surface start logged; router mounted; subagent `hello_helper` joined the delegate list ✓
- runtime status reports `routers:1, surfaces:1, subagents:[hello_helper]` ✓

All **from config — no `server.py` edit.** Regression test added; 933+ suite green.

## Deferred (noted in the ADR)
Migrating the built-in **Discord/Google surfaces to plugins** (they already match the surface shape) — a follow-up, not this PR. This ships the extension points + a worked example.

🤖 Generated with [Claude Code](https://claude.com/claude-code)