### PR TITLE
Plugins contribute config, settings & secrets (ADR 0019, closes #508)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Plugins can contribute config, settings & secrets (ADR 0019, #508).** A
+  plugin **declares its config in the manifest** (`config_section` / `config`
+  defaults / `secrets` / `settings`) — known at config-load time without importing
+  the plugin. It claims a top-level config section and gets: a resolved config
+  (manifest defaults ⊕ YAML ⊕ secrets overlay, read via `registry.config`),
+  secret routing to `secrets.yaml` (via a dynamic `secret_paths()`), and an
+  auto-generated **System → Settings** group — with no `config.py` /
+  `config_io.py` / `settings_schema.py` edit. A section colliding with a built-in
+  is ignored. Completes the plugin reach (config + ADR 0018's surface/route/
+  subagent), so a fork ships a fully self-contained configurable surface as a
+  plugin — the prerequisite for migrating the built-in Discord/Google surfaces
+  (#509). The `plugins/hello` example now declares a config section + secret.
 - **Plugins can contribute surfaces, routes & subagents (ADR 0018, #506).** The
   plugin `register(registry)` contract gained `register_router` (a FastAPI
   `APIRouter`, mounted under `/plugins/<id>`), `register_surface` (a lifecycle

--- a/docs/adr/0019-plugin-config-settings-secrets.md
+++ b/docs/adr/0019-plugin-config-settings-secrets.md
@@ -1,0 +1,94 @@
+# ADR 0019 — Plugins contribute config, settings & secrets
+
+- **Status:** Accepted (2026-06-04)
+- **Date:** 2026-06-04
+- **Deciders:** Josh Mabry; protoAgent maintainers
+- **Tags:** extensibility, plugins, config, settings, secrets, fork, architecture
+- **Related:** completes the plugin reach started in [ADR 0001](./0001-extensibility-and-plugin-architecture.md) (tools+skills) and [ADR 0018](./0018-plugin-surfaces-routes-subagents.md) (surfaces/routes/subagents); prerequisite for migrating the [Discord](./0015-discord-ingress-surface.md)/[Google](./0017-google-ui-config.md) surfaces to plugins (#509).
+
+> Accepted. ADR 0018 let a plugin contribute a surface/route/subagent, but a
+> *configurable* surface (a Discord-style gateway) still needs **core edits** for
+> its config — the `discord_*`/`google_*` dataclass fields, `SECRET_PATHS`, the
+> Settings-schema group. So a fork's own ingress is half a plugin. Close the gap:
+> a plugin **declares its config in the manifest** and gets a typed config
+> section + secrets routing + a Settings group, with no `config.py` /
+> `config_io.py` / `settings_schema.py` edit.
+
+## 1. Context & Problem statement
+
+`LangGraphConfig.from_yaml` parses a fixed set of sections into a flat dataclass;
+`SECRET_PATHS` (a constant) routes named keys to the untracked `secrets.yaml`;
+`settings_schema.FIELDS` (a constant) drives System → Settings. All three are
+**closed** — a plugin can't add to them, so a configurable plugin must edit core.
+
+The ordering constraint is the crux: config/secrets/settings must be known
+**before** a plugin's `register()` code runs (config is loaded at boot; secrets
+are stripped on every save; the settings schema is built on demand). So plugin
+config can't be declared imperatively in `register()` — it must be **data**,
+available at manifest-discovery time without importing the plugin.
+
+## 2. Decision
+
+A plugin **declares its config in `protoagent.plugin.yaml`** (parsed at discovery,
+no import):
+
+```yaml
+config_section: discord          # top-level YAML section (default: the plugin id)
+config:                          # defaults for that section
+  enabled: false
+  admin_ids: []
+secrets: [bot_token]             # keys in the section routed to secrets.yaml
+settings:                        # Settings-schema fields (System → Settings group)
+  - { key: enabled,    label: "Enable",    type: bool }
+  - { key: bot_token,  label: "Bot token", type: secret }
+  - { key: admin_ids,  label: "Admin IDs", type: string_list }
+```
+
+A plugin **claims a top-level section** (not a nested `plugins.<id>` bag) — this
+matches how Discord/Google already store config (`discord:` / `google:`), so the
+migration (#509) is a lift, not a config move. The loader rejects a section that
+collides with a built-in (logged + skipped).
+
+Wiring:
+
+- **Config.** `LangGraphConfig` gains `plugin_config: dict[section → dict]`.
+  `from_yaml` reads each discovered plugin section, overlays the YAML on the
+  manifest defaults, and resolves secrets from the overlay. The plugin reads its
+  own config via `config.plugin_config["<section>"]` (passed to its surface/route).
+- **Secrets.** `config_io.secret_paths()` returns the base `SECRET_PATHS` **plus**
+  each plugin's `(section, secret_key)` pairs; `split_secret_updates` /
+  `strip_secrets_from_doc` use it, so a plugin secret is stripped to `secrets.yaml`
+  exactly like the model API key. `config_to_dict` includes plugin sections
+  (secrets redacted).
+- **Settings.** `build_schema` appends each plugin's declared fields under a group
+  named for the plugin (keys namespaced `<section>.<key>`), so they render +
+  save through the existing generic Settings surface — no per-plugin UI code.
+
+The **wizard step is out of scope** (deferred) — Settings + a docs link is enough;
+a schema-driven generic wizard step can come later.
+
+## 3. Consequences
+
+- A fork ships a **fully self-contained configurable surface** as a plugin —
+  config + secrets + Settings + (ADR 0018) surface/routes/tools — with **zero**
+  core edits. Closes the last extensibility gap.
+- The **config + config_io + settings_schema layers gain a dependency on plugin
+  manifest discovery** (data-only — no plugin import), so the closed constants
+  become "base + plugin-declared". Discovery is cached; manifests are pure YAML.
+- A plugin section that collides with a built-in is rejected — built-ins win.
+- `plugins.enabled` changes still need a restart (config sections are resolved at
+  boot) — consistent with ADR 0018.
+
+## 4. Alternatives considered
+
+- **Imperative `register_config()` in `register()`.** Rejected — config/secrets/
+  settings are needed *before* `register()` runs (boot/save/schema time); a
+  plugin's module may even need its config to import. Manifest data is available
+  at discovery, ahead of any import.
+- **Namespaced `plugins.config.<id>` bag** instead of a claimed top-level section.
+  Cleaner isolation, but changes where Discord/Google store config (breaks the
+  migration + existing configs) and needs nested secret-path handling. The
+  claimed top-level section matches the status quo and keeps secret paths flat.
+- **A typed dataclass field per plugin (generated).** Rejected — can't generate
+  dataclass fields for unknown plugins at import time; the `plugin_config` dict is
+  the honest shape for open extension.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -27,3 +27,4 @@ decision, numbered, never deleted (supersede instead).
 | [0016](./0016-discord-ui-config.md) | In-app Discord configuration (token, admin list, live connect) | Accepted |
 | [0017](./0017-google-ui-config.md) | In-app Google (Gmail + Calendar) connect flow | Accepted |
 | [0018](./0018-plugin-surfaces-routes-subagents.md) | Plugins contribute surfaces, routes & subagents | Accepted |
+| [0019](./0019-plugin-config-settings-secrets.md) | Plugins contribute config, settings & secrets | Accepted |

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -71,6 +71,35 @@ def register(registry):
     registry.register_subagent(_build_subagent())    # delegate via task/task_batch
 ```
 
+## Config, secrets & settings (ADR 0019)
+
+A configurable plugin **declares its config in the manifest** (data, so it's known
+at config-load time before `register()` imports). It claims a top-level config
+section (default: the plugin id) and gets a Settings group + secrets routing —
+no `config.py` / `settings_schema.py` edit:
+
+```yaml
+# protoagent.plugin.yaml
+config_section: hello          # top-level YAML section (default: the id)
+config: { greeting: "Hello", api_key: "" }   # defaults
+secrets: [api_key]             # → secrets.yaml (redacted in the UI)
+settings:                      # System → Settings group (named after the section)
+  - { key: greeting, label: "Greeting word", type: string }
+  - { key: api_key,  label: "API key",       type: secret }
+```
+
+Read the resolved config (manifest defaults ⊕ YAML ⊕ secrets) in `register()`:
+
+```python
+def register(registry):
+    greeting = registry.config.get("greeting", "Hello")  # ADR 0019
+    registry.register_router(_build_router(greeting))    # close over it
+```
+
+A plugin section colliding with a built-in (`model`, `discord`, …) is ignored.
+The **wizard step** is not yet plugin-contributable (Settings + a docs link
+suffice for now).
+
 **Routes + surfaces are wired once at process init and don't hot-reload** — a
 config reload reuses them, so changing `plugins.enabled` needs a restart
 (ADR 0018). Everything is best-effort: a failing plugin/route/surface logs and

--- a/graph/config.py
+++ b/graph/config.py
@@ -36,6 +36,37 @@ def _load_secrets_doc(config_dir: Path) -> dict:
         return {}
 
 
+def _resolve_plugin_config(data: dict, secrets: dict, config_dir: Path) -> dict:
+    """Resolve each enabled plugin's declared config section (ADR 0019).
+
+    For every plugin that claims a top-level section, merge: manifest defaults ⊕
+    the (secret-stripped) YAML section ⊕ the secrets overlay for its secret keys.
+    Best-effort — never breaks config load. Returns ``{section: resolved_dict}``.
+    """
+    try:
+        from graph.plugins.pconfig import discover_plugin_config, plugin_roots_from
+
+        plugins = data.get("plugins") or {}
+        roots = plugin_roots_from(config_dir, str(plugins.get("dir") or ""))
+        schemas = discover_plugin_config(roots, set(plugins.get("enabled") or []))
+    except Exception:  # noqa: BLE001 — plugin config is best-effort
+        return {}
+
+    out: dict = {}
+    for sch in schemas:
+        section_yaml = data.get(sch.section) or {}
+        sec_overlay = secrets.get(sch.section) or {}
+        resolved = dict(sch.defaults)
+        resolved.update({k: v for k, v in section_yaml.items() if k not in sch.secrets})
+        for k in sch.secrets:
+            v = sec_overlay.get(k)
+            if v is None:
+                v = section_yaml.get(k)  # belt-and-suspenders if not yet stripped
+            resolved[k] = v if v is not None else resolved.get(k, "")
+        out[sch.section] = resolved
+    return out
+
+
 @dataclass
 class SubagentDef:
     enabled: bool = True
@@ -291,6 +322,10 @@ class LangGraphConfig:
     # See graph/plugins/ and docs/guides/plugins.md.
     plugins_enabled: list[str] = field(default_factory=list)
     plugins_dir: str = ""
+    # Plugin-declared config sections (ADR 0019), keyed by the claimed top-level
+    # section. Each value is the section's resolved config (manifest defaults ⊕
+    # YAML ⊕ secrets overlay). A plugin reads its own via plugin_config["<section>"].
+    plugin_config: dict = field(default_factory=dict)
 
     # Identity — captured by the setup wizard, editable via the drawer.
     # ``identity_name`` falls back to the AGENT_NAME env var at runtime;
@@ -498,6 +533,7 @@ class LangGraphConfig:
             ),
             filesystem_projects=list(data.get("filesystem", {}).get("projects", []) or []),
             egress_allowed_hosts=list(data.get("egress", {}).get("allowed_hosts", []) or []),
+            plugin_config=_resolve_plugin_config(data, secrets, p.parent),
         )
 
         for name in ("researcher",):

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -91,6 +91,21 @@ SECRET_PATHS: tuple[tuple[str, str], ...] = (
     ("google", "client_secret"),
 )
 
+
+def secret_paths() -> tuple[tuple[str, str], ...]:
+    """Base ``SECRET_PATHS`` plus the (section, key) pairs each enabled plugin
+    declares as secrets (ADR 0019). Used by the split/strip logic so a plugin
+    secret is routed to ``secrets.yaml`` exactly like the model API key."""
+    try:
+        from graph.plugins.pconfig import live_plugin_config_schemas
+
+        extra = tuple(
+            (sch.section, key) for sch in live_plugin_config_schemas() for key in sch.secrets
+        )
+    except Exception:  # noqa: BLE001 — plugin discovery is best-effort
+        extra = ()
+    return SECRET_PATHS + extra
+
 # Setup wizard state.
 # Presence of this (empty) marker file = wizard has been run and the
 # server should boot straight into the chat UI. Absence = show the
@@ -188,7 +203,7 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
     semantics in ``split_secret_updates``, a save that echoes the blank back
     leaves the stored secret intact.
     """
-    return {
+    d: dict[str, Any] = {
         "model": {
             "provider": config.model_provider,
             "name": config.model_name,
@@ -257,6 +272,24 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
             "allowed_dirs": list(config.operator_allowed_dirs),
         },
     }
+    # Plugin-declared sections (ADR 0019) — reflect the PASSED config's resolved
+    # plugin_config (not a re-discovery), with declared secrets redacted
+    # (blank-means-unchanged, like api_key). A default config has none.
+    plugin_cfg = getattr(config, "plugin_config", {}) or {}
+    if plugin_cfg:
+        try:
+            from graph.plugins.pconfig import live_plugin_config_schemas
+
+            secrets_by_section = {s.section: set(s.secrets) for s in live_plugin_config_schemas()}
+        except Exception:  # noqa: BLE001
+            secrets_by_section = {}
+        for section, vals in plugin_cfg.items():
+            redacted = dict(vals)
+            for skey in secrets_by_section.get(section, set()):
+                if skey in redacted:
+                    redacted[skey] = ""
+            d[section] = redacted
+    return d
 
 
 def apply_updates_to_yaml(doc: Any, updates: dict[str, Any]) -> Any:
@@ -302,7 +335,7 @@ def split_secret_updates(config: dict[str, Any]) -> tuple[dict[str, Any], dict[s
 
     main = copy.deepcopy(config)
     secrets: dict[str, Any] = {}
-    for section, key in SECRET_PATHS:
+    for section, key in secret_paths():
         sect = main.get(section)
         if not isinstance(sect, dict) or key not in sect:
             continue
@@ -323,7 +356,7 @@ def strip_secrets_from_doc(doc: Any) -> Any:
     YAML still carries an ``api_key`` (or a hand-edit reintroduces one), every
     save scrubs it so the tracked file converges to secret-free.
     """
-    for section, key in SECRET_PATHS:
+    for section, key in secret_paths():
         sect = doc.get(section) if hasattr(doc, "get") else None
         if isinstance(sect, dict) and key in sect:
             del sect[key]

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -114,7 +114,10 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
 
         try:
             register = _import_register(manifest)
-            registry = PluginRegistry(manifest.id, manifest.path)
+            # Resolved config section (ADR 0019) — defaults if not in plugin_config.
+            section = manifest.config_section or manifest.id
+            pconf = (getattr(config, "plugin_config", {}) or {}).get(section) or dict(manifest.config or {})
+            registry = PluginRegistry(manifest.id, manifest.path, config=pconf)
             register(registry)
         except Exception as exc:  # noqa: BLE001 — a bad plugin must not break boot
             entry["error"] = str(exc)

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -30,6 +30,16 @@ class PluginManifest:
     # Declarative, for transparency in the console — not yet enforced.
     capabilities: dict = field(default_factory=dict)
     entrypoint: str = ""  # optional module filename; defaults to __init__.py / plugin.py
+    # Plugin config (ADR 0019) — declared as data so it's known at config-load /
+    # secret-strip / settings-schema time, before register() ever imports.
+    #   config_section: the top-level YAML section the plugin claims (default: id)
+    #   config:    defaults for that section (key → default value)
+    #   secrets:   keys in the section routed to the secrets.yaml overlay
+    #   settings:  Settings-schema field specs ({key, label, type, ...})
+    config_section: str = ""
+    config: dict = field(default_factory=dict)
+    secrets: list[str] = field(default_factory=list)
+    settings: list[dict] = field(default_factory=list)
 
 
 def load_manifest(plugin_dir: Path) -> PluginManifest | None:
@@ -61,6 +71,9 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     requires_env = [str(x) for x in req] if isinstance(req, (list, tuple)) else []
     caps = data.get("capabilities")
 
+    cfg = data.get("config")
+    secrets = data.get("secrets")
+    settings = data.get("settings")
     return PluginManifest(
         id=pid,
         name=name,
@@ -71,4 +84,8 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
         requires_env=requires_env,
         capabilities=caps if isinstance(caps, dict) else {},
         entrypoint=str(data.get("entrypoint", "")).strip(),
+        config_section=str(data.get("config_section", "")).strip() or pid,
+        config=cfg if isinstance(cfg, dict) else {},
+        secrets=[str(s) for s in secrets] if isinstance(secrets, (list, tuple)) else [],
+        settings=[s for s in settings if isinstance(s, dict)] if isinstance(settings, (list, tuple)) else [],
     )

--- a/graph/plugins/pconfig.py
+++ b/graph/plugins/pconfig.py
@@ -1,0 +1,100 @@
+"""Plugin config schema discovery (ADR 0019).
+
+A plugin declares its config section in the manifest (pure data), so config-load,
+secret-stripping, and the settings schema can know about it **without importing
+the plugin** — that happens later, at ``register()`` time. This module reads
+those declared schemas from manifests under the plugin roots.
+
+Used by:
+- ``graph/config.py::from_yaml`` — to read each plugin section into ``plugin_config``.
+- ``graph/config_io.py`` — to extend ``SECRET_PATHS`` + ``config_to_dict``.
+- ``graph/settings_schema.py`` — to append each plugin's Settings fields.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from pathlib import Path
+
+log = logging.getLogger("protoagent.plugins")
+
+# Built-in top-level config sections a plugin may NOT claim (collision → ignored,
+# built-in wins). Keep roughly in step with the YAML the template ships.
+_RESERVED_SECTIONS = {
+    "model", "subagents", "middleware", "knowledge", "memory", "skills",
+    "workflows", "compaction", "checkpoint", "routing", "goal", "execute_code",
+    "operator", "tools", "discord", "google", "mcp", "plugins", "identity",
+    "auth", "runtime", "telemetry", "instance", "prompt_cache", "enforcement",
+    "ingest",
+}
+
+
+@dataclass
+class PluginConfigSchema:
+    plugin_id: str
+    section: str
+    defaults: dict = field(default_factory=dict)
+    secrets: list = field(default_factory=list)
+    settings: list = field(default_factory=list)
+
+
+def discover_plugin_config(roots, enabled_ids) -> list[PluginConfigSchema]:
+    """Config schemas of **enabled** plugins that declare config/secrets/settings.
+
+    ``roots`` are plugin directories (bundle + live); ``enabled_ids`` the
+    operator's ``plugins.enabled`` set (a manifest ``enabled: true`` also counts).
+    A section colliding with a built-in (or a second plugin) is dropped (logged).
+    Never raises — bad discovery yields no plugin config, not a broken boot.
+    """
+    try:
+        from graph.plugins.loader import discover_plugins
+
+        enabled = set(enabled_ids or set())
+        out: list[PluginConfigSchema] = []
+        claimed: dict[str, str] = {}
+        for m in discover_plugins(list(roots)):
+            if not (m.enabled or m.id in enabled):
+                continue
+            if not (m.config or m.settings or m.secrets):
+                continue
+            section = (m.config_section or m.id).strip()
+            if section in _RESERVED_SECTIONS:
+                log.warning("[plugins] %s: config_section %r collides with a built-in — ignored",
+                            m.id, section)
+                continue
+            if section in claimed:
+                log.warning("[plugins] config_section %r claimed by %s and %s — keeping first",
+                            section, claimed[section], m.id)
+                continue
+            claimed[section] = m.id
+            out.append(PluginConfigSchema(
+                m.id, section, dict(m.config or {}), list(m.secrets or []), list(m.settings or []),
+            ))
+        return out
+    except Exception:  # noqa: BLE001 — discovery is best-effort
+        log.exception("[plugins] config-schema discovery failed")
+        return []
+
+
+def plugin_roots_from(config_dir: Path, dir_override: str = "") -> list[Path]:
+    """Bundle + live plugin roots, computed from a config dir (no config object)."""
+    from graph.config_io import _BUNDLE_CONFIG_DIR
+
+    live = Path(dir_override).expanduser() if dir_override else (config_dir / "plugins")
+    return [_BUNDLE_CONFIG_DIR.parent / "plugins", live]
+
+
+def live_plugin_config_schemas() -> list[PluginConfigSchema]:
+    """Discover schemas from the **live** config (for config_io + settings_schema,
+    which operate on the running config without a config object)."""
+    try:
+        from graph.config_io import _live_config_dir, load_yaml_doc
+
+        data = load_yaml_doc() or {}
+        plugins = data.get("plugins") or {}
+        roots = plugin_roots_from(_live_config_dir(), str(plugins.get("dir") or ""))
+        return discover_plugin_config(roots, set(plugins.get("enabled") or []))
+    except Exception:  # noqa: BLE001
+        log.exception("[plugins] live config-schema discovery failed")
+        return []

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -31,9 +31,13 @@ class PluginRegistry:
     them — changing ``plugins.enabled`` needs a restart (ADR 0018).
     """
 
-    def __init__(self, plugin_id: str, plugin_dir: Path):
+    def __init__(self, plugin_id: str, plugin_dir: Path, config: dict | None = None):
         self.plugin_id = plugin_id
         self.plugin_dir = plugin_dir
+        # The plugin's resolved config section (ADR 0019) — manifest defaults ⊕
+        # YAML ⊕ secrets. Read it in register() and close over it for your
+        # tools/routes/surface, e.g. ``registry.config.get("api_key")``.
+        self.config: dict = dict(config or {})
         self.tools: list = []
         self.skill_dirs: list[Path] = []
         self.routers: list[dict] = []     # {"router", "prefix"}

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -155,6 +155,28 @@ _BY_KEY = {f.key: f for f in FIELDS}
 _SECRET_KEYS = {f.key for f in FIELDS if f.type == "secret"}
 
 
+def _plugin_field_specs():
+    """Plugin-declared settings fields (ADR 0019) as (schema, full_key, key, spec)
+    — ``full_key`` is the dotted YAML path ``<section>.<key>`` the save writes to.
+    Best-effort; empty when no plugin declares settings."""
+    try:
+        from graph.plugins.pconfig import live_plugin_config_schemas
+
+        out = []
+        for sch in live_plugin_config_schemas():
+            for spec in sch.settings:
+                key = spec.get("key")
+                if key:
+                    out.append((sch, f"{sch.section}.{key}", key, spec))
+        return out
+    except Exception:  # noqa: BLE001 — plugin discovery is best-effort
+        return []
+
+
+def _plugin_group(sch, spec) -> str:
+    return spec.get("group") or sch.section.replace("_", " ").title()
+
+
 def build_schema(config, *, model_options: list[str] | None = None) -> list[dict[str, Any]]:
     """Return the settings schema grouped by section, with current values.
 
@@ -184,15 +206,55 @@ def build_schema(config, *, model_options: list[str] | None = None) -> list[dict
         if f.maximum is not None:
             entry["maximum"] = f.maximum
         groups.setdefault(f.section, {"section": f.section, "fields": []})["fields"].append(entry)
+
+    # Plugin-declared settings fields (ADR 0019) — value from config.plugin_config,
+    # rendered + saved through the same generic Settings surface (key = dotted
+    # YAML path, so apply_updates_to_yaml + secret routing handle it for free).
+    plugin_cfg = getattr(config, "plugin_config", {}) or {}
+    for sch, full_key, key, spec in _plugin_field_specs():
+        section_cfg = plugin_cfg.get(sch.section) or sch.defaults
+        current = section_cfg.get(key)
+        ftype = spec.get("type", "string")
+        group = _plugin_group(sch, spec)
+        entry = {
+            "key": full_key,
+            "label": spec.get("label", key),
+            "type": ftype,
+            "section": group,
+            "description": spec.get("description", ""),
+            "restart": bool(spec.get("restart", False)),
+            "options": list(spec.get("options", []) or []),
+            "default": _jsonable(sch.defaults.get(key)),
+        }
+        if ftype == "secret":
+            entry["value"] = ""
+            entry["is_set"] = bool(current)
+        else:
+            entry["value"] = _jsonable(current)
+        if spec.get("minimum") is not None:
+            entry["minimum"] = spec["minimum"]
+        if spec.get("maximum") is not None:
+            entry["maximum"] = spec["maximum"]
+        groups.setdefault(group, {"section": group, "fields": []})["fields"].append(entry)
+
     return list(groups.values())
 
 
 def validate_flat(updates: dict[str, Any]) -> tuple[bool, str | None]:
     """Light per-field validation against the registry before persisting."""
+    plugin_keys = {full: spec for _, full, _, spec in _plugin_field_specs()}
     for key, val in updates.items():
         f = _BY_KEY.get(key)
         if f is None:
-            return False, f"unknown setting: {key}"
+            spec = plugin_keys.get(key)
+            if spec is None:
+                return False, f"unknown setting: {key}"
+            t = spec.get("type", "string")
+            if t == "bool" and not isinstance(val, bool):
+                return False, f"{key} must be a boolean"
+            if t == "number" and (not isinstance(val, (int, float)) or isinstance(val, bool)):
+                return False, f"{key} must be a number"
+            continue
         if f.type == "bool" and not isinstance(val, bool):
             return False, f"{key} must be a boolean"
         if f.type == "number":

--- a/plugins/hello/__init__.py
+++ b/plugins/hello/__init__.py
@@ -29,15 +29,16 @@ async def hello(name: str = "world") -> str:
     return f"Hello, {name}! (from the example protoAgent plugin)"
 
 
-def _build_router():
-    """A tiny FastAPI router — mounted at ``/plugins/hello`` (ADR 0018)."""
+def _build_router(greeting: str):
+    """A tiny FastAPI router — mounted at ``/plugins/hello`` (ADR 0018). Closes
+    over the plugin's configured greeting (ADR 0019) to prove it reads its config."""
     from fastapi import APIRouter
 
     router = APIRouter()
 
     @router.get("/ping")
     async def _ping() -> dict:
-        return {"ok": True, "plugin": "hello"}
+        return {"ok": True, "plugin": "hello", "greeting": greeting}
 
     return router
 
@@ -68,8 +69,9 @@ def _build_subagent():
 
 def register(registry) -> None:
     """Entry point — called once at load with a PluginRegistry."""
+    greeting = registry.config.get("greeting", "Hello")   # plugin config (ADR 0019)
     registry.register_tool(hello)
     registry.register_skill_dir("skills")            # bundled SKILL.md folder
-    registry.register_router(_build_router())        # → /plugins/hello/ping (ADR 0018)
+    registry.register_router(_build_router(greeting))  # → /plugins/hello/ping (ADR 0018)
     registry.register_surface(_surface_start, stop=_surface_stop, name="hello-surface")
     registry.register_subagent(_build_subagent())

--- a/plugins/hello/protoagent.plugin.yaml
+++ b/plugins/hello/protoagent.plugin.yaml
@@ -11,3 +11,16 @@ enabled: false
 capabilities:
   network: []
   filesystem: none
+
+# Plugin config (ADR 0019) — the plugin claims a top-level `hello` config section.
+# These render in System → Settings (group "Hello") and round-trip through the
+# generic settings surface; `api_key` is routed to the gitignored secrets.yaml.
+# A fork gets config + secrets + Settings for its plugin with no core edit.
+config_section: hello
+config:
+  greeting: "Hello"
+  api_key: ""
+secrets: [api_key]
+settings:
+  - { key: greeting, label: "Greeting word", type: string, description: "Prefix used by the hello tool." }
+  - { key: api_key, label: "Example API key", type: secret, description: "Demo secret — stored in secrets.yaml, never the tracked YAML." }

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -176,3 +176,48 @@ def test_plugin_contributes_router_surface_subagent(tmp_path, monkeypatch) -> No
     # Meta reports the counts.
     m = res.meta[0]
     assert m["routers"] == 2 and m["surfaces"] == 1 and m["subagents"] == ["plug_sub"]
+
+
+# --- ADR 0019: config / secrets / settings ----------------------------------
+
+_CFG_MANIFEST = (
+    "config_section: cfgplug\n"
+    "config: {greeting: hi, api_key: ''}\n"
+    "secrets: [api_key]\n"
+    "settings:\n"
+    "  - {key: greeting, label: Greeting, type: string}\n"
+    "  - {key: api_key, label: Key, type: secret}\n"
+)
+
+
+def test_plugin_declares_config_schema(tmp_path) -> None:
+    from graph.plugins.pconfig import discover_plugin_config
+
+    root = tmp_path / "plugins"
+    _make_plugin(root, "cfgplug", enabled=True, manifest_extra=_CFG_MANIFEST)
+    schemas = discover_plugin_config([root], {"cfgplug"})
+    assert len(schemas) == 1
+    s = schemas[0]
+    assert s.section == "cfgplug"
+    assert s.defaults == {"greeting": "hi", "api_key": ""}
+    assert s.secrets == ["api_key"]
+    assert [f["key"] for f in s.settings] == ["greeting", "api_key"]
+
+
+def test_plugin_config_only_for_enabled(tmp_path) -> None:
+    from graph.plugins.pconfig import discover_plugin_config
+
+    root = tmp_path / "plugins"
+    _make_plugin(root, "cfgplug", enabled=False, manifest_extra=_CFG_MANIFEST)
+    assert discover_plugin_config([root], set()) == []          # disabled → none
+    assert len(discover_plugin_config([root], {"cfgplug"})) == 1  # operator-enabled
+
+
+def test_plugin_section_collision_with_builtin_ignored(tmp_path) -> None:
+    from graph.plugins.pconfig import discover_plugin_config
+
+    root = tmp_path / "plugins"
+    _make_plugin(root, "evil", enabled=True,
+                 manifest_extra="config_section: model\nconfig: {x: 1}\n")
+    # 'model' is a reserved built-in section — the plugin can't claim it.
+    assert discover_plugin_config([root], {"evil"}) == []


### PR DESCRIPTION
Closes #508. Implements **ADR 0019** — completes the plugin reach so a fork ships a *fully self-contained configurable surface* as a plugin. The prerequisite for migrating Discord/Google to plugins (#509).

## Why
ADR 0018 let a plugin contribute a surface/route/subagent, but a *configurable* one (a Discord-style gateway) still needed **core edits** for its config — dataclass fields, `SECRET_PATHS`, the Settings group. The ordering constraint: config/secrets/settings must be known **before** `register()` runs (boot/save/schema time), so they can't be declared in code.

## What — declared in the manifest (data)
```yaml
config_section: hello          # top-level section (default: the id)
config: { greeting: Hello, api_key: '' }
secrets: [api_key]             # → secrets.yaml
settings:                      # System → Settings group
  - { key: greeting, label: Greeting, type: string }
  - { key: api_key,  label: API key,  type: secret }
```
- **Config:** `LangGraphConfig.plugin_config[section]` resolves defaults ⊕ YAML ⊕ secrets; `registry.config` exposes it to `register()`.
- **Secrets:** a dynamic `secret_paths()` (base + plugin) routes the secret to `secrets.yaml` exactly like the model key; redacted in `config_to_dict`.
- **Settings:** `build_schema` appends the plugin's fields (group per section; key = dotted YAML path → saves + secret-routes through the generic surface, no per-plugin UI). A section colliding with a built-in is ignored.

Wizard step deferred (Settings + docs link suffice).

## Verified (live + unit)
End-to-end: a default-config `config_to_dict` is unchanged; with `hello` enabled, its config resolves (greeting from YAML, api_key from secrets), the secret routes + redacts, a **Hello** Settings group renders, and the plugin's route returns its configured greeting. 14 plugin tests + **934 suite** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)