### PR TITLE
Plugin migration prereqs: plugins.disabled denylist + surface reload hook (#509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`plugins.disabled` denylist + plugin surface `reload` hook (#509 prereqs).**
+  `plugins.disabled` turns off a bundled first-party plugin even if its manifest
+  says `enabled: true` — so a fork drops a built-in surface without deleting it.
+  `register_surface(..., reload=fn)` lets a surface reconnect on a config change
+  (the server calls `reload(new_config)` on the loop), so a config-driven surface
+  keeps live-reconnect instead of needing a restart. Both pave the way for
+  migrating the Discord/Google surfaces to plugins (#509).
 - **Plugins can contribute config, settings & secrets (ADR 0019, #508).** A
   plugin **declares its config in the manifest** (`config_section` / `config`
   defaults / `secrets` / `settings`) — known at config-load time without importing

--- a/graph/config.py
+++ b/graph/config.py
@@ -48,7 +48,9 @@ def _resolve_plugin_config(data: dict, secrets: dict, config_dir: Path) -> dict:
 
         plugins = data.get("plugins") or {}
         roots = plugin_roots_from(config_dir, str(plugins.get("dir") or ""))
-        schemas = discover_plugin_config(roots, set(plugins.get("enabled") or []))
+        schemas = discover_plugin_config(
+            roots, set(plugins.get("enabled") or []), set(plugins.get("disabled") or []),
+        )
     except Exception:  # noqa: BLE001 — plugin config is best-effort
         return {}
 
@@ -321,6 +323,10 @@ class LangGraphConfig:
     # ``<config_dir>/plugins``); shipped examples live in ``plugins/``.
     # See graph/plugins/ and docs/guides/plugins.md.
     plugins_enabled: list[str] = field(default_factory=list)
+    # Denylist — turn OFF a plugin even if its manifest says ``enabled: true``.
+    # Lets a fork disable a bundled first-party plugin (e.g. the Discord surface)
+    # without deleting its directory or editing core.
+    plugins_disabled: list[str] = field(default_factory=list)
     plugins_dir: str = ""
     # Plugin-declared config sections (ADR 0019), keyed by the claimed top-level
     # section. Each value is the section's resolved config (manifest defaults ⊕
@@ -519,6 +525,7 @@ class LangGraphConfig:
             mcp_timeout_seconds=mcp.get("timeout_seconds", cls.mcp_timeout_seconds),
             mcp_denylist=list(mcp.get("denylist", []) or []),
             plugins_enabled=list(plugins.get("enabled", []) or []),
+            plugins_disabled=list(plugins.get("disabled", []) or []),
             plugins_dir=plugins.get("dir", cls.plugins_dir),
             identity_name=identity.get("name", cls.identity_name),
             identity_operator=identity.get("operator", cls.identity_operator),

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -87,10 +87,13 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
     result = PluginLoadResult()
     roots = _plugin_roots(config)
     enabled_ids = set(getattr(config, "plugins_enabled", []) or [])
+    disabled_ids = set(getattr(config, "plugins_disabled", []) or [])
     seen_tool_names = set(core_tool_names or set())
 
     for manifest in discover_plugins(roots):
-        enabled = manifest.enabled or manifest.id in enabled_ids
+        # plugins.disabled wins — turn off a bundled plugin (e.g. a first-party
+        # surface) without deleting it or editing core.
+        enabled = (manifest.enabled or manifest.id in enabled_ids) and manifest.id not in disabled_ids
         entry = {
             "id": manifest.id,
             "name": manifest.name,

--- a/graph/plugins/pconfig.py
+++ b/graph/plugins/pconfig.py
@@ -39,22 +39,24 @@ class PluginConfigSchema:
     settings: list = field(default_factory=list)
 
 
-def discover_plugin_config(roots, enabled_ids) -> list[PluginConfigSchema]:
-    """Config schemas of **enabled** plugins that declare config/secrets/settings.
+def discover_plugin_config(roots, enabled_ids, disabled_ids=None) -> list[PluginConfigSchema]:
+    """Config schemas of **active** plugins that declare config/secrets/settings.
 
-    ``roots`` are plugin directories (bundle + live); ``enabled_ids`` the
-    operator's ``plugins.enabled`` set (a manifest ``enabled: true`` also counts).
-    A section colliding with a built-in (or a second plugin) is dropped (logged).
-    Never raises — bad discovery yields no plugin config, not a broken boot.
+    ``roots`` are plugin directories (bundle + live); ``enabled_ids`` the operator's
+    ``plugins.enabled`` set (a manifest ``enabled: true`` also counts);
+    ``disabled_ids`` (``plugins.disabled``) turns one off regardless. A section
+    colliding with a built-in (or a second plugin) is dropped (logged). Never
+    raises — bad discovery yields no plugin config, not a broken boot.
     """
     try:
         from graph.plugins.loader import discover_plugins
 
         enabled = set(enabled_ids or set())
+        disabled = set(disabled_ids or set())
         out: list[PluginConfigSchema] = []
         claimed: dict[str, str] = {}
         for m in discover_plugins(list(roots)):
-            if not (m.enabled or m.id in enabled):
+            if m.id in disabled or not (m.enabled or m.id in enabled):
                 continue
             if not (m.config or m.settings or m.secrets):
                 continue
@@ -94,7 +96,9 @@ def live_plugin_config_schemas() -> list[PluginConfigSchema]:
         data = load_yaml_doc() or {}
         plugins = data.get("plugins") or {}
         roots = plugin_roots_from(_live_config_dir(), str(plugins.get("dir") or ""))
-        return discover_plugin_config(roots, set(plugins.get("enabled") or []))
+        return discover_plugin_config(
+            roots, set(plugins.get("enabled") or []), set(plugins.get("disabled") or []),
+        )
     except Exception:  # noqa: BLE001
         log.exception("[plugins] live config-schema discovery failed")
         return []

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -80,18 +80,23 @@ class PluginRegistry:
         eff = f"/plugins/{self.plugin_id}" if prefix is None else str(prefix)
         self.routers.append({"router": router, "prefix": eff})
 
-    def register_surface(self, start, stop=None, name: str | None = None) -> None:
+    def register_surface(self, start, stop=None, name: str | None = None, reload=None) -> None:
         """Register a lifecycle-managed background surface (ADR 0018).
 
         ``start`` (sync or async, no args) runs in the server's startup hook — so
         it has the running loop, like the Discord gateway — and may return a task/
-        handle. ``stop`` (optional, sync or async) runs in shutdown. Best-effort:
-        a failing surface logs and never breaks boot. Started once at init.
+        handle. ``stop`` (optional) runs in shutdown. ``reload`` (optional, called
+        with the new ``LangGraphConfig`` on a config reload) lets a surface
+        reconnect when its config changes — without it, surfaces wire once and a
+        config change needs a restart. Best-effort: a failing surface logs, never
+        breaks boot.
         """
         if not callable(start):
             log.warning("[plugins] %s: register_surface needs a callable start", self.plugin_id)
             return
-        self.surfaces.append({"name": name or self.plugin_id, "start": start, "stop": stop})
+        self.surfaces.append(
+            {"name": name or self.plugin_id, "start": start, "stop": stop, "reload": reload}
+        )
 
     def register_subagent(self, config) -> None:
         """Add a ``SubagentConfig`` to ``SUBAGENT_REGISTRY`` (ADR 0018).

--- a/server.py
+++ b/server.py
@@ -973,6 +973,10 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     if discord_changed:
         _restart_discord_async()
 
+    # Plugin surfaces with a reload hook (ADR 0018/0019) — let them reconnect on a
+    # config change (e.g. a migrated Discord/Google surface) without a restart.
+    _reload_plugin_surfaces(new_config)
+
     if new_graph is None:
         log.info("[reload] setup not complete — config reloaded, graph not compiled")
         return True, "config reloaded • setup not complete"
@@ -1023,6 +1027,31 @@ def _start_discord_surface() -> None:
     _discord_task = _start_discord(
         _discord_invoke, publish=_event_bus.publish, subscribe=_event_bus.subscribe
     )
+
+
+def _reload_plugin_surfaces(new_config) -> None:
+    """Notify started plugin surfaces of a config change (ADR 0018/0019).
+
+    Each surface that registered a ``reload`` callback gets it called with the new
+    ``LangGraphConfig`` on the server loop, so a migrated Discord/Google-style
+    surface can reconnect on a Settings save without a restart. Best-effort.
+    """
+    for h in _plugin_surface_handles:
+        reload_cb = h.get("reload")
+        if not callable(reload_cb):
+            continue
+
+        def _make(cb=reload_cb, name=h.get("name")):
+            async def _run():
+                try:
+                    res = cb(new_config)
+                    if asyncio.iscoroutine(res):
+                        await res
+                except Exception:
+                    log.exception("[plugins] surface %s reload failed", name)
+            return _run()
+
+        _run_on_server_loop(_make, f"surface reload ({h.get('name')})")
 
 
 def _restart_discord_async() -> None:
@@ -2655,7 +2684,9 @@ def _main():
                 res = s["start"]()
                 if asyncio.iscoroutine(res):
                     res = await res
-                _plugin_surface_handles.append({"name": s["name"], "stop": s.get("stop"), "handle": res})
+                _plugin_surface_handles.append(
+                    {"name": s["name"], "stop": s.get("stop"), "reload": s.get("reload"), "handle": res}
+                )
                 log.info("[plugins] started surface: %s", s["name"])
             except Exception:
                 log.exception("[plugins] surface %s failed to start", s.get("name"))

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -221,3 +221,13 @@ def test_plugin_section_collision_with_builtin_ignored(tmp_path) -> None:
                  manifest_extra="config_section: model\nconfig: {x: 1}\n")
     # 'model' is a reserved built-in section — the plugin can't claim it.
     assert discover_plugin_config([root], {"evil"}) == []
+
+
+def test_plugins_disabled_overrides_manifest_enabled(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "plugins"
+    _make_plugin(root, "onplug", enabled=True, tool="on_tool")
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    # manifest enabled: true → loads
+    assert [t.name for t in load_plugins(_cfg()).tools] == ["on_tool"]
+    # plugins.disabled wins → not loaded
+    assert load_plugins(_cfg(plugins_disabled=["onplug"])).tools == []


### PR DESCRIPTION
Two small foundations the **Discord/Google → plugin migration (#509)** needs — landing them separately keeps the migration PR focused.

- **`plugins.disabled`** — a denylist that turns off a plugin even if its manifest says `enabled: true`. So a fork disables a bundled first-party surface plugin **without deleting it or editing core** (the migrated Discord/Google ship enabled-by-default; this is how you turn one off). Threaded through the loader + config-schema discovery.
- **`register_surface(..., reload=fn)`** — an optional reload callback invoked with the new `LangGraphConfig` on a config reload (on the server loop). So a config-driven surface keeps **live-reconnect-on-save** instead of regressing to restart-only when it moves to a plugin.

## Verified
`plugins.disabled` overrides `enabled: true` (test added); **937 suite** green.

Next: the Discord migration (#509 slice 1), then Google.

🤖 Generated with [Claude Code](https://claude.com/claude-code)