### PR TITLE
Plugin host context: registry.host (agent invoke + event bus) — #509 prereq

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Plugin host context — `registry.host` (#509 prereq).** A plugin surface/route
+  can now reach the **agent invoke** + the **event bus** (`host.invoke(prompt,
+  session_id)` / `host.publish` / `host.subscribe`) — host services it can't build
+  itself. The server populates a process singleton before any surface starts. The
+  last foundation a real ingress surface (Discord-style gateway) needs to live in
+  a plugin instead of `server.py`.
 - **`plugins.disabled` denylist + plugin surface `reload` hook (#509 prereqs).**
   `plugins.disabled` turns off a bundled first-party plugin even if its manifest
   says `enabled: true` — so a fork drops a built-in surface without deleting it.

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -71,6 +71,24 @@ def register(registry):
     registry.register_subagent(_build_subagent())    # delegate via task/task_batch
 ```
 
+## Host services — `registry.host`
+
+A surface or route often needs to **call the agent** or the **event bus** — host
+services it can't build. `registry.host` exposes them (the server populates them
+before any surface starts; guard for `None`):
+
+- `host.invoke(prompt, session_id)` — run a chat turn (one conversation per
+  `session_id`), returns the assistant text.
+- `host.publish(event, data)` / `host.subscribe()` — the server→client event bus.
+
+```python
+def register(registry):
+    host = registry.host
+    async def _on_message(text, sid):
+        return await host.invoke(text, sid)        # call the agent
+    registry.register_surface(lambda: _gateway(_on_message), name="my-gateway")
+```
+
 ## Config, secrets & settings (ADR 0019)
 
 A configurable plugin **declares its config in the manifest** (data, so it's known

--- a/graph/plugins/host.py
+++ b/graph/plugins/host.py
@@ -1,0 +1,31 @@
+"""Host services a plugin surface/route can reach (ADR 0018+).
+
+A plugin's *tools* run inside the graph, but a *surface* (an ingress gateway like
+Discord) needs to call the agent and the event bus — host services it can't
+construct itself. The server **populates** these once, before the startup hook
+fires; a plugin reads them at surface-start time, via ``registry.host`` (the same
+singleton) or ``from graph.plugins.host import HOST``.
+
+Each is optional (``None`` until the server wires it / in a non-server context),
+so a plugin guards: ``if registry.host.invoke: ...``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Awaitable, Callable, Optional
+
+
+@dataclass
+class PluginHost:
+    # async (prompt, session_id) -> str — invoke the agent as a chat surface
+    # (one conversation per session_id, the LangGraph thread key).
+    invoke: Optional[Callable[[str, str], Awaitable[str]]] = None
+    # (event: str, data: dict) -> None — publish to the server→client event bus.
+    publish: Optional[Callable[[str, dict], Any]] = None
+    # () -> subscription — subscribe to the event bus (e.g. return-address delivery).
+    subscribe: Optional[Callable[[], Any]] = None
+
+
+# Process-lifetime singleton. The server fills it in; plugins read it.
+HOST = PluginHost()

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -38,6 +38,11 @@ class PluginRegistry:
         # YAML ⊕ secrets. Read it in register() and close over it for your
         # tools/routes/surface, e.g. ``registry.config.get("api_key")``.
         self.config: dict = dict(config or {})
+        # Host services (agent invoke + event bus) a surface/route can use — the
+        # server populates these before startup; guard for None (e.g. in tests).
+        from graph.plugins.host import HOST
+
+        self.host = HOST
         self.tools: list = []
         self.skill_dirs: list[Path] = []
         self.routers: list[dict] = []     # {"router", "prefix"}

--- a/server.py
+++ b/server.py
@@ -1029,6 +1029,29 @@ def _start_discord_surface() -> None:
     )
 
 
+async def _plugin_agent_invoke(prompt: str, session_id: str) -> str:
+    """Agent invoke exposed to plugin surfaces via the plugin host (ADR 0018) — a
+    chat turn joined to its assistant text (mirrors the Discord surface invoker)."""
+    result = await chat(prompt, session_id)
+    return "\n\n".join(
+        m["content"] for m in result
+        if m.get("role") == "assistant" and m.get("content")
+    )
+
+
+def _populate_plugin_host() -> None:
+    """Wire the plugin host (ADR 0018) — agent invoke + event bus — so a plugin
+    surface/route can reach them. Called once in _main, before startup."""
+    try:
+        from graph.plugins.host import HOST
+
+        HOST.invoke = _plugin_agent_invoke
+        HOST.publish = _event_bus.publish
+        HOST.subscribe = _event_bus.subscribe
+    except Exception:  # noqa: BLE001
+        log.exception("[plugins] failed to populate plugin host")
+
+
 def _reload_plugin_surfaces(new_config) -> None:
     """Notify started plugin surfaces of a config change (ADR 0018/0019).
 
@@ -2618,6 +2641,9 @@ def _main():
         inbox_list=_operator_inbox_list,
         inbox_deliver=_operator_inbox_deliver,
     )
+
+    # Wire the plugin host (agent invoke + event bus) before any surface starts.
+    _populate_plugin_host()
 
     # Plugin-contributed routes (ADR 0018) — mounted after the core routes,
     # under each plugin's namespaced prefix (default /plugins/<id>). Once, here;

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -231,3 +231,15 @@ def test_plugins_disabled_overrides_manifest_enabled(tmp_path, monkeypatch) -> N
     assert [t.name for t in load_plugins(_cfg()).tools] == ["on_tool"]
     # plugins.disabled wins → not loaded
     assert load_plugins(_cfg(plugins_disabled=["onplug"])).tools == []
+
+
+def test_registry_exposes_plugin_host() -> None:
+    """A surface/route reaches host services (agent invoke + bus) via registry.host."""
+    from pathlib import Path
+
+    from graph.plugins.host import HOST
+    from graph.plugins.registry import PluginRegistry
+
+    r = PluginRegistry("p", Path("/tmp"))
+    assert r.host is HOST                      # the process singleton the server fills
+    assert hasattr(r.host, "invoke") and hasattr(r.host, "publish") and hasattr(r.host, "subscribe")


### PR DESCRIPTION
The final foundation the **Discord/Google → plugin migration (#509)** needs.

## Why
A plugin's *tools* run in the graph, but a *surface* (an ingress gateway like Discord) needs to **call the agent** and the **event bus** — host services it can't build. The `hello` example surface was a no-op precisely because it couldn't reach them.

## What
A `PluginHost` singleton (`graph/plugins/host.py`), exposed as **`registry.host`**:
- `host.invoke(prompt, session_id)` — a chat turn → assistant text
- `host.publish(event, data)` / `host.subscribe()` — the server→client event bus

The server populates it (`_populate_plugin_host`, in `_main`) before any surface starts; plugins guard for `None`. Verified: `registry.host is HOST`, and a server-set `invoke` is visible to a plugin's surface. **938 suite** green.

Next: the actual Discord migration (#509 slice 1) — now pure assembly with every foundation in place (surface/route/subagent/config/secrets/settings/disable/reload/host).

🤖 Generated with [Claude Code](https://claude.com/claude-code)