### PR TITLE
Migrate the Discord surface to a first-party plugin (#509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Discord ingress is now a first-party plugin (`plugins/discord`, #509).** The
+  Discord DM gateway, the `POST /api/config/test-discord` route, the outbound
+  `discord_*` tools, and the `discord` config/secrets/Settings group all moved
+  out of `server.py` + the core config layer into a self-contained plugin (ADR
+  0018/0019). Behaviour is unchanged — the Settings group, wizard step, Test
+  button and live-reconnect-on-save all work as before — but a fork can now
+  **disable Discord entirely** with `plugins: { disabled: [discord] }` (drops the
+  surface *and* the tools), or swap in its own ingress plugin, with no core edit.
+  No config migration needed: the plugin claims the existing top-level `discord`
+  section, so saved tokens/admin IDs keep working.
+
 ### Added
 - **Plugin host context — `registry.host` (#509 prereq).** A plugin surface/route
   can now reach the **agent invoke** + the **event bus** (`host.invoke(prompt,

--- a/graph/config.py
+++ b/graph/config.py
@@ -129,15 +129,9 @@ class LangGraphConfig:
     memory_middleware: bool = True
     scheduler_enabled: bool = True
 
-    # Discord surface (ADR 0015 + 0016) — inbound DM gateway. Configured in-app
-    # (wizard step + Settings) rather than env-only, so the bundled desktop app
-    # has a per-user place for the token. ``bot_token`` lives in the secrets
-    # overlay; ``admin_ids`` are the Discord user IDs allowed to talk to the bot
-    # (empty ⇒ anyone). Off until a token is set. The env vars (DISCORD_BOT_TOKEN
-    # / DISCORD_ADMIN_IDS) remain a fallback for Docker.
-    discord_enabled: bool = False
-    discord_bot_token: str = ""
-    discord_admin_ids: list[str] = field(default_factory=list)
+    # The Discord surface (ADR 0015/0016) is now the first-party `discord` plugin
+    # (ADR 0018/0019, plugins/discord/) — its config lives in plugin_config["discord"],
+    # not a typed field here.
 
     # Google surface (ADR 0017) — Gmail + Calendar via the bundled MCP server,
     # connected in-app with an OAuth consent flow (no credentials.json / CLI).
@@ -424,7 +418,6 @@ class LangGraphConfig:
 
         secrets = _load_secrets_doc(p.parent)
 
-        discord = data.get("discord", {})
         google = data.get("google", {})
         model = data.get("model", {})
         subagents = data.get("subagents", {})
@@ -443,7 +436,6 @@ class LangGraphConfig:
         # value still lets create_llm / set_a2a_token fall back to env.
         secret_api_key = secrets.get("model", {}).get("api_key")
         secret_auth_token = secrets.get("auth", {}).get("token")
-        secret_discord_token = secrets.get("discord", {}).get("bot_token")
         secret_google_secret = secrets.get("google", {}).get("client_secret")
 
         config = cls(
@@ -463,9 +455,6 @@ class LangGraphConfig:
             audit_middleware=middleware.get("audit", cls.audit_middleware),
             memory_middleware=middleware.get("memory", cls.memory_middleware),
             scheduler_enabled=middleware.get("scheduler", cls.scheduler_enabled),
-            discord_enabled=discord.get("enabled", cls.discord_enabled),
-            discord_bot_token=secret_discord_token or discord.get("bot_token", cls.discord_bot_token),
-            discord_admin_ids=list(discord.get("admin_ids", []) or []),
             google_enabled=google.get("enabled", cls.google_enabled),
             google_client_id=google.get("client_id", cls.google_client_id),
             google_client_secret=secret_google_secret or google.get("client_secret", cls.google_client_secret),

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -87,8 +87,9 @@ SECRETS_YAML_PATH = _LIVE_CONFIG_DIR / "secrets.yaml"
 SECRET_PATHS: tuple[tuple[str, str], ...] = (
     ("model", "api_key"),
     ("auth", "token"),
-    ("discord", "bot_token"),
     ("google", "client_secret"),
+    # ("discord", "bot_token") is now declared by the discord plugin's manifest
+    # and added dynamically via secret_paths() (ADR 0019).
 )
 
 
@@ -254,11 +255,8 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
         "auth": {
             "token": "",
         },
-        "discord": {
-            "enabled": config.discord_enabled,
-            "bot_token": "",  # redacted — secret, mirrors api_key / auth.token
-            "admin_ids": list(config.discord_admin_ids),
-        },
+        # `discord` is now a plugin section (ADR 0019) — surfaced via the
+        # plugin_config loop below, not a hardcoded block.
         "google": {
             "enabled": config.google_enabled,
             "client_id": config.google_client_id,

--- a/graph/plugins/pconfig.py
+++ b/graph/plugins/pconfig.py
@@ -24,7 +24,9 @@ log = logging.getLogger("protoagent.plugins")
 _RESERVED_SECTIONS = {
     "model", "subagents", "middleware", "knowledge", "memory", "skills",
     "workflows", "compaction", "checkpoint", "routing", "goal", "execute_code",
-    "operator", "tools", "discord", "google", "mcp", "plugins", "identity",
+    # NB: `discord` is NOT reserved — it's a first-party plugin (ADR 0018/0019)
+    # that legitimately claims the `discord` section. (`google` migrates next.)
+    "operator", "tools", "google", "mcp", "plugins", "identity",
     "auth", "runtime", "telemetry", "instance", "prompt_cache", "enforcement",
     "ingest",
 }

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -123,14 +123,8 @@ FIELDS: list[Field] = [
     Field("auth.token", "auth_token", "A2A auth token", "secret", "Identity",
           "Bearer token for the A2A endpoint. Stored in secrets.yaml; applies live."),
 
-    # ── Discord (ADR 0015 + 0016) ────────────────────────────────────────────
-    Field("discord.enabled", "discord_enabled", "Enable Discord", "bool", "Discord",
-          "Inbound DM gateway. Needs the bot token below; reconnects live on save."),
-    Field("discord.bot_token", "discord_bot_token", "Bot token", "secret", "Discord",
-          "Discord bot token (Developer Portal → your app → Bot → Reset Token). Stored "
-          "in secrets.yaml. Use “Test connection” to verify before saving."),
-    Field("discord.admin_ids", "discord_admin_ids", "Admin user IDs", "string_list", "Discord",
-          "Discord user IDs allowed to DM the bot (one per line). Empty = anyone."),
+    # Discord's Settings group is now declared by the discord plugin's manifest
+    # (ADR 0019) and rendered via the plugin-fields path in build_schema.
 
     # ── Google (ADR 0017) ────────────────────────────────────────────────────
     # The OAuth client lives here; "Connect Google" (a button, not a field) runs

--- a/plugins/discord/__init__.py
+++ b/plugins/discord/__init__.py
@@ -1,0 +1,113 @@
+"""Discord ingress surface as a plugin (ADR 0015/0016 → 0018/0019).
+
+Wraps the self-contained gateway in ``surfaces/discord/`` — the gateway is the
+implementation, this plugin is the *wiring*. Moving it out of ``server.py`` lets
+a fork disable Discord (``plugins.disabled: [discord]``) or replace it with its
+own ingress plugin, with no core edit.
+
+Contributes: a **surface** (the gateway, lifecycle-managed + reconnect-on-save),
+a **route** (`POST /api/config/test-discord`, mounted at the existing path so the
+console's Test button keeps working), and the outbound **tools** (when a token is
+set). Config/secrets/Settings come from the manifest (ADR 0019).
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger("protoagent.plugins.discord")
+
+# Holds the running gateway task across start/stop/reload.
+_state: dict = {"task": None}
+
+
+def _should_start(cfg: dict) -> bool:
+    """Start rule (mirrors the old `_start_discord_surface`): the UI path needs
+    `enabled` + a token; a bare `DISCORD_BOT_TOKEN` env (no UI token) starts for
+    Docker back-compat."""
+    cfg_token = (cfg.get("bot_token") or "").strip()
+    env_token = (os.environ.get("DISCORD_BOT_TOKEN") or "").strip()
+    return (bool(cfg_token) and bool(cfg.get("enabled"))) or (not cfg_token and bool(env_token))
+
+
+def _launch(cfg: dict, host) -> None:
+    """Configure + (re)start the gateway from the given config + host services."""
+    from surfaces.discord import configure, start_in_background
+
+    configure(cfg.get("bot_token"), cfg.get("admin_ids"))
+    if not _should_start(cfg):
+        log.info("[discord] gateway not started (enabled=%s, token set=%s)",
+                 cfg.get("enabled"),
+                 bool((cfg.get("bot_token") or "").strip() or os.environ.get("DISCORD_BOT_TOKEN")))
+        return
+    if not (host and host.invoke):
+        log.warning("[discord] no agent invoke available — gateway not started")
+        return
+    _state["task"] = start_in_background(host.invoke, publish=host.publish, subscribe=host.subscribe)
+
+
+async def _teardown() -> None:
+    from surfaces.discord import stop as _discord_stop
+
+    task = _state.get("task")
+    if task is not None:
+        task.cancel()
+        _state["task"] = None
+    try:
+        await _discord_stop()
+    except Exception:  # noqa: BLE001
+        log.exception("[discord] stop failed")
+
+
+def _build_router(registry):
+    """`POST /api/config/test-discord` — verify a bot token (the console's Test
+    button). Mounted at the existing path (prefix="") so the UI is unchanged."""
+    from fastapi import APIRouter
+    from pydantic import BaseModel
+
+    router = APIRouter()
+
+    class DiscordProbe(BaseModel):
+        bot_token: str = ""
+
+    @router.post("/api/config/test-discord")
+    async def _test_discord(req: DiscordProbe | None = None):
+        from surfaces.discord import validate_token
+
+        body = req or DiscordProbe()
+        token = body.bot_token or (registry.config.get("bot_token") or "")
+        ok, bot_user, error = await validate_token(token)
+        return {"ok": ok, "error": error,
+                "bot_user": (bot_user or {}).get("username") if ok else None}
+
+    return router
+
+
+def register(registry) -> None:
+    host = registry.host
+
+    def _start():
+        _launch(registry.config, host)
+        return _state.get("task")
+
+    async def _reload(new_config):
+        # Reconnect on a config change (Settings save / wizard finish) — the
+        # surface reload hook (ADR 0018) keeps Discord's live-reconnect.
+        new = (getattr(new_config, "plugin_config", {}) or {}).get("discord", {})
+        await _teardown()
+        registry.config = dict(new)
+        _launch(registry.config, host)
+
+    registry.register_surface(_start, stop=_teardown, reload=_reload, name="discord-gateway")
+    registry.register_router(_build_router(registry), prefix="")  # existing /api path
+
+    # Outbound tools — only when a token is set (off by default, as before). Seed
+    # the client from the resolved config first so a UI-set token (not just the
+    # DISCORD_BOT_TOKEN env) surfaces the tools at graph build.
+    from surfaces.discord import configure
+    from tools.discord_tools import discord_configured, get_discord_tools
+
+    configure(registry.config.get("bot_token"), registry.config.get("admin_ids"))
+    if discord_configured():
+        registry.register_tools(get_discord_tools())

--- a/plugins/discord/protoagent.plugin.yaml
+++ b/plugins/discord/protoagent.plugin.yaml
@@ -1,0 +1,21 @@
+id: discord
+name: Discord
+version: 0.1.0
+description: >-
+  Inbound Discord DM gateway + outbound tools (ADR 0015/0016), as a first-party
+  plugin (ADR 0018/0019). Off until a bot token is set in System → Settings →
+  Discord. Disable entirely with `plugins: { disabled: [discord] }`, or replace
+  it with your own ingress plugin — no server.py edit.
+enabled: true
+requires_env: []
+# Config section (ADR 0019) — claims the top-level `discord` section, so the
+# existing Settings group + wizard step keep working unchanged.
+config_section: discord
+config:
+  enabled: false
+  admin_ids: []
+secrets: [bot_token]
+settings:
+  - { key: enabled, label: "Enable Discord", type: bool, description: "Inbound DM gateway. Needs the bot token below; reconnects live on save." }
+  - { key: bot_token, label: "Bot token", type: secret, description: "Discord bot token (Developer Portal → your app → Bot → Reset Token). Use “Test connection” to verify before saving." }
+  - { key: admin_ids, label: "Admin user IDs", type: string_list, description: "Discord user IDs allowed to DM the bot (one per line). Empty = anyone." }

--- a/server.py
+++ b/server.py
@@ -103,9 +103,6 @@ _cache_warmer = None   # Optional CacheWarmer (off by default). Same start/stop
                        # lifecycle as _scheduler; keeps the prompt cache warm.
 _goal_controller = None  # Optional GoalController (goal mode). Parses /goal
                          # control messages and runs the goal-completion loop.
-_discord_task = None     # The inbound Discord gateway task (ADR 0015/0016).
-                         # Held so a config change (Settings/wizard) can stop +
-                         # restart it live, not just at process boot.
 _main_loop = None        # The server's event loop, captured at startup (#497).
                          # A config reload's heavy graph compile is offloaded to a
                          # worker thread so it no longer freezes the loop; the
@@ -962,19 +959,9 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     if pending_start is not None:
         _start_scheduler_async(pending_start)
 
-    # Discord surface: reconnect live if its config changed (token / admin_ids /
-    # enabled), so a Settings save or wizard finish applies without a restart.
-    discord_changed = (
-        old_config is None
-        or old_config.discord_enabled != new_config.discord_enabled
-        or old_config.discord_bot_token != new_config.discord_bot_token
-        or list(old_config.discord_admin_ids) != list(new_config.discord_admin_ids)
-    )
-    if discord_changed:
-        _restart_discord_async()
-
-    # Plugin surfaces with a reload hook (ADR 0018/0019) — let them reconnect on a
-    # config change (e.g. a migrated Discord/Google surface) without a restart.
+    # Plugin surfaces with a reload hook (ADR 0018/0019) reconnect on a config
+    # change without a restart — this is how the Discord plugin live-reconnects
+    # when its token/admin/enabled changes (was a bespoke discord_changed block).
     _reload_plugin_surfaces(new_config)
 
     if new_graph is None:
@@ -983,50 +970,6 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
 
     log.info("LangGraph agent reloaded (model: %s)", _graph_config.model_name)
     return True, f"reloaded • model={_graph_config.model_name}"
-
-
-def _start_discord_surface() -> None:
-    """(Re)start the inbound Discord gateway from the live config (ADR 0016).
-
-    Start rule: the UI path starts only when ``discord.enabled`` is on AND a
-    token is configured; the env path (Docker ``DISCORD_BOT_TOKEN``, no UI token)
-    starts as before for back-compat. Injects token + admin_ids via
-    ``configure`` so the bundled desktop app uses its per-user secret, not an
-    ambient env var. Stores the task in ``_discord_task`` for live restart.
-    """
-    global _discord_task
-    import os as _os
-
-    from surfaces.discord import configure as _configure
-    from surfaces.discord import start_in_background as _start_discord
-
-    cfg_token = (_graph_config.discord_bot_token or "").strip() if _graph_config else ""
-    env_token = (_os.environ.get("DISCORD_BOT_TOKEN") or "").strip()
-    admin_ids = list(_graph_config.discord_admin_ids) if _graph_config else []
-    enabled = bool(_graph_config.discord_enabled) if _graph_config else False
-
-    _configure(cfg_token, admin_ids)
-
-    # UI token requires the enabled toggle; a bare env token (no UI token) starts
-    # for back-compat (Docker deploys that only set DISCORD_BOT_TOKEN).
-    should_start = (bool(cfg_token) and enabled) or (not cfg_token and bool(env_token))
-    if not should_start:
-        log.info("[discord] gateway not started (enabled=%s, token=%s)",
-                 enabled, "set" if (cfg_token or env_token) else "unset")
-        return
-
-    async def _discord_invoke(prompt: str, session_id: str) -> str:
-        result = await chat(prompt, session_id)
-        return "\n\n".join(
-            m["content"] for m in result
-            if m.get("role") == "assistant" and m.get("content")
-        )
-
-    # subscribe enables return-address delivery: reactive Activity-thread output
-    # (scheduler/inbox/proactive) is forwarded to the operator's captured DM.
-    _discord_task = _start_discord(
-        _discord_invoke, publish=_event_bus.publish, subscribe=_event_bus.subscribe
-    )
 
 
 async def _plugin_agent_invoke(prompt: str, session_id: str) -> str:
@@ -1075,31 +1018,6 @@ def _reload_plugin_surfaces(new_config) -> None:
             return _run()
 
         _run_on_server_loop(_make, f"surface reload ({h.get('name')})")
-
-
-def _restart_discord_async() -> None:
-    """Fire-and-forget: stop the running gateway, then start from new config.
-
-    Scheduled on the server loop via :func:`_run_on_server_loop`, so it works
-    from an offloaded (worker-thread) reload too — not just an on-loop one.
-    """
-    async def _swap() -> None:
-        global _discord_task
-        try:
-            from surfaces.discord import stop as _discord_stop
-
-            if _discord_task is not None:
-                _discord_task.cancel()
-                _discord_task = None
-            await _discord_stop()
-        except Exception:
-            log.exception("[discord] stop during restart failed")
-        try:
-            _start_discord_surface()
-        except Exception:
-            log.exception("[discord] restart failed")
-
-    _run_on_server_loop(_swap, "discord restart")
 
 
 def _sync_autostart_with_config(config: dict | None) -> str | None:
@@ -2691,15 +2609,8 @@ def _main():
             import asyncio
             _checkpoint_prune_task = asyncio.create_task(_checkpoint_prune_loop())
 
-        # Inbound Discord gateway (ADR 0015/0016) — started from the live config
-        # (UI token in secrets, or the DISCORD_BOT_TOKEN env fallback). A Discord
-        # DM is conversational, so it invokes the agent as a chat surface with a
-        # per-conversation session_id (the LangGraph thread key), NOT the single
-        # system:activity inbox thread.
-        try:
-            _start_discord_surface()
-        except Exception:
-            log.exception("[discord] gateway startup failed")
+        # (The inbound Discord gateway now starts as the discord plugin's surface,
+        # below — ADR 0018/0019.)
 
         # Plugin-contributed surfaces (ADR 0018) — start each on the loop. `start`
         # may be sync or async and may return a handle (kept for shutdown).
@@ -2962,27 +2873,8 @@ def _main():
         ok, error = await asyncio.to_thread(validate_model_connection, base, key, model)
         return {"ok": ok, "error": error}
 
-    class DiscordProbeRequest(PydanticBaseModel):
-        bot_token: str = ""
-
-    @fastapi_app.post("/api/config/test-discord")
-    async def _api_test_discord(req: DiscordProbeRequest | None = None):
-        """Verify a Discord bot token by fetching its identity (Test connection).
-
-        POST (body) so the token never lands in a URL/log. Blank falls back to
-        the saved token, so Settings can re-test the live config. Returns the bot
-        username so the UI can show "Connected as <bot>".
-        """
-        from surfaces.discord import validate_token
-
-        body = req or DiscordProbeRequest()
-        token = body.bot_token or (_graph_config.discord_bot_token if _graph_config else "")
-        ok, bot_user, error = await validate_token(token or "")
-        return {
-            "ok": ok,
-            "error": error,
-            "bot_user": (bot_user or {}).get("username") if ok else None,
-        }
+    # `/api/config/test-discord` is now mounted by the discord plugin's router
+    # (ADR 0018/0019), at the same path — the console Test button is unchanged.
 
     def _google_env_from_config() -> None:
         """Mirror the configured Google OAuth client + token path into the env so

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -130,17 +130,15 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # strand fork-added fields outside the drawer's round-trip.
     assert set(d.keys()) == {
         "model", "subagents", "middleware", "knowledge", "skills", "mcp", "plugins",
-        "identity", "auth", "discord", "google", "runtime", "operator",
+        "identity", "auth", "google", "runtime", "operator",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature
     # Secrets are redacted out of the UI-facing dict.
     assert d["model"]["api_key"] == ""
     assert d["auth"]["token"] == ""
-    # Discord bot token is a secret too — redacted, with enabled/admin_ids exposed.
-    assert d["discord"]["bot_token"] == ""
-    assert d["discord"]["enabled"] == cfg.discord_enabled
-    assert d["discord"]["admin_ids"] == list(cfg.discord_admin_ids)
+    # (Discord is now a plugin section — present only when the discord plugin is
+    # enabled, surfaced via plugin_config, not this core block.)
     assert d["subagents"]["researcher"]["tools"] == list(cfg.researcher.tools)
     assert d["middleware"]["audit"] == cfg.audit_middleware
     assert d["knowledge"]["top_k"] == cfg.knowledge_top_k

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -18,7 +18,11 @@ def test_schema_groups_and_values():
     # Grouped, ordered, every field carries the metadata the UI needs.
     assert [g["section"] for g in groups][:3] == ["Model", "Routing", "Compaction"]
     fields = [f for g in groups for f in g["fields"]]
-    assert len(fields) == len(FIELDS)
+    # Every core FIELD is present. (build_schema also appends plugin-declared
+    # settings — e.g. the discord plugin — so count only the core-keyed fields,
+    # which keeps this robust to whichever plugins are installed.)
+    core_keys = {f.key for f in FIELDS}
+    assert len([f for f in fields if f["key"] in core_keys]) == len(FIELDS)
     for f in fields:
         assert {"key", "label", "type", "value", "default", "restart", "description"} <= set(f)
     # The model select is populated from the probed options.

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -702,11 +702,9 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, beads_
     from tools.peer_tools import get_peer_tools, list_env_peers
     if list_env_peers():
         tools.extend(get_peer_tools())
-    # Outbound Discord tools — only when DISCORD_BOT_TOKEN is set (ADR 0015:
-    # off by default, so non-Discord forks aren't cluttered).
-    from tools.discord_tools import discord_configured, get_discord_tools
-    if discord_configured():
-        tools.extend(get_discord_tools())
+    # Outbound Discord tools now come from the discord plugin (ADR 0018/0019) —
+    # it registers them when a token is set, so disabling the plugin
+    # (`plugins.disabled: [discord]`) removes the surface AND the tools.
     if knowledge_store is not None:
         tools.extend(_build_memory_tools(knowledge_store))
     if scheduler is not None:


### PR DESCRIPTION
## Discord ingress → first-party plugin (#509, slice 1)

Moves the **Discord surface** out of `server.py` + the core config layer into a self-contained plugin (`plugins/discord/`), built on the plugin reach landed in ADR 0018 (surfaces/routes/host) + ADR 0019 (config/secrets/settings via manifest).

**Behaviour is unchanged** for an out-of-the-box agent — the Settings → Discord group, the wizard step, the **Test connection** button, the outbound `discord_*` tools, and **live-reconnect-on-save** all work exactly as before. What changes is the *seam*: a fork can now

- **disable Discord entirely** with `plugins: { disabled: [discord] }` — drops the gateway surface **and** the tools, no core edit; or
- **swap in its own ingress plugin** in its place.

No config migration: the plugin claims the existing top-level `discord` config section, so saved tokens / admin IDs keep working.

### What moved
| Was (core) | Now (plugin) |
|---|---|
| `_start_discord_surface` / `_restart_discord_async` / `_discord_task` (server.py) | `register_surface(start, stop, reload)` — lifecycle + live-reconnect |
| `POST /api/config/test-discord` endpoint (server.py) | plugin router mounted at the **same path** (`prefix=""`) |
| `discord_*` tools in `get_all_tools` (lg_tools.py) | `registry.register_tools(...)` when a token is set |
| `discord_*` typed fields + `config_to_dict` block + SECRET_PATHS entry + Settings group (config.py / config_io.py / settings_schema.py) | manifest `config_section: discord` + `config` / `secrets` / `settings` (ADR 0019) |

`discord` is also dropped from `pconfig._RESERVED_SECTIONS` (it's a legitimate plugin section now, not a built-in).

### Verification
- **Unit:** full suite green — **939 passed**. Updated `test_config_io` (no core `discord` block) and `test_settings_schema` (count core-keyed fields; `build_schema` now appends plugin fields).
- **Live (local server, isolated config dir):** plugin loads (`1 route, 1 surface`), router mounts at `/` (the existing `/api/config/test-discord` path), the gateway surface starts and **connects to Discord** (`gateway READY`), and `POST /api/config/test-discord` returns the expected probe (`{"ok":false,"error":"bot token is empty"}` for an empty token). The Settings schema includes the plugin's `discord.*` fields, confirming config/secrets/settings resolve via `plugin_config["discord"]`.

### Follow-up
- **Google → plugin** (slice 2 of #509) — same shape; the `_google_server_entry` MCP auto-inject is the trickier piece, so it's a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
