### PR TITLE
Migrate the Google surface to a first-party plugin (#509)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Plugins can contribute managed MCP servers — `register_mcp_server` (ADR
+  0019, #509).** A plugin ships an **MCP server the agent connects to** via a
+  factory `factory(config) -> entry | None` called at every graph build — return
+  an entry when the server should run, `None` when it shouldn't, so it comes and
+  goes with config. Its presence activates MCP even when `mcp.enabled` is off, and
+  a same-named entry replaces a configured one. For frozen desktop builds (no
+  `python` on PATH), a generic `--mcp-plugin <id>` shim re-invokes the binary and
+  runs the plugin's `mcp_main()`. This is what lets the Google surface ship its
+  OAuth-gated server as a plugin. The plugin host also gained `host.config()` (the
+  live config) + `host.apply_settings(patch)` (persist + reload) so a plugin route
+  can read live config and apply a config change.
+
 ### Changed
+- **Google ingress is now a first-party plugin (`plugins/google`, #509).** The
+  Gmail/Calendar managed MCP server, its OAuth-gated launch, the `GET
+  /api/config/google/status` + `POST /api/config/google/connect` routes, and the
+  `google` config/secrets/Settings group all moved out of `server.py`,
+  `tools/mcp_tools.py`, and the core config layer into a self-contained plugin
+  (ADR 0019), built on the new `register_mcp_server`. Behaviour is unchanged — the
+  Settings group, wizard step, Connect button and live-reconnect-on-save all work
+  as before — but a fork can now **disable Google entirely** with `plugins: {
+  disabled: [google] }`, or swap in its own integration, with no core edit. No
+  config migration: the plugin claims the existing top-level `google` section. The
+  desktop sidecar now bundles the `plugins/` tree so the Discord + Google plugins
+  load in the frozen app.
 - **Discord ingress is now a first-party plugin (`plugins/discord`, #509).** The
   Discord DM gateway, the `POST /api/config/test-discord` route, the outbound
   `discord_*` tools, and the `discord` config/secrets/Settings group all moved

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -36,6 +36,11 @@ BUNDLED_DATA: list[tuple[str, str]] = [
     ("config/SOUL.md", "config"),
     ("config/soul-presets", "config/soul-presets"),
     ("static", "static"),
+    # First-party plugins (ADR 0018/0019) — incl. the Discord + Google surfaces.
+    # Loaded by file path (importlib) at runtime, so PyInstaller's import-scan
+    # misses them; ship the tree as data so the frozen app finds them under
+    # _MEIPASS/plugins (the loader's bundle root).
+    ("plugins", "plugins"),
 ]
 
 # Packages PyInstaller's static analysis under-collects (dynamic imports +
@@ -57,13 +62,14 @@ COLLECT_ALL = [
     # the import-scan misses them — collect explicitly.
     "aiosqlite",
     "sqlalchemy",
-    # The native Discord surface (ADR 0015) is lazy-imported in the server
-    # startup hook, so the import-scan misses it; the gateway also imports
-    # ``websockets`` lazily. Collect both so Discord works in the frozen app.
+    # The Discord surface (ADR 0015) is loaded by the discord plugin (and the
+    # gateway imports ``websockets`` lazily), so the import-scan misses it.
+    # Collect both so Discord works in the frozen app.
     "surfaces",
     "websockets",
     # Google surface (ADR 0017): the MCP SDK (FastMCP) + the repo's google MCP
-    # server module, lazily imported via the --mcp-google self-reinvoke entry.
+    # server module, loaded by the google plugin and re-invoked frozen via the
+    # ``--mcp-plugin google`` self-reinvoke entry.
     "mcp",
     "mcp_servers",
 ]

--- a/docs/adr/0019-plugin-config-settings-secrets.md
+++ b/docs/adr/0019-plugin-config-settings-secrets.md
@@ -79,6 +79,28 @@ a schema-driven generic wizard step can come later.
 - `plugins.enabled` changes still need a restart (config sections are resolved at
   boot) — consistent with ADR 0018.
 
+## 3a. Addendum — managed MCP servers + host additions (#509)
+
+Migrating the **Google** surface to a plugin needed one capability ADR 0018's
+contribution set didn't cover: the agent reaches Google through a *managed MCP
+server*, injected into MCP discovery based on live config (OAuth-gated, started
+only once a token exists). Added under this ADR:
+
+- **`register_mcp_server(factory)`** — a plugin contributes a factory
+  `factory(config) -> entry | None`, called at every graph build with the live
+  `LangGraphConfig`. A returned entry is injected like a configured `mcp.servers`
+  entry (and replaces a same-named one); its presence activates MCP even when
+  `mcp.enabled` is off. Plugins now load **before** MCP discovery so their
+  factories are available (MCP tools are namespaced `<server>__<tool>`, so the
+  earlier collision set is unaffected).
+- **Generic frozen entrypoint** — the google-specific `--mcp-google` shim became
+  `--mcp-plugin <id>`, which imports the named plugin's module and calls its
+  `mcp_main()`. No core reference to any specific plugin remains.
+- **Host additions** — `host.config()` (the live config) + `host.apply_settings(
+  patch)` (persist + reload) so a plugin *route* can read live config and apply a
+  change (Google's Connect flow flips `enabled` and reloads). The desktop sidecar
+  bundles the `plugins/` tree so plugins load in the frozen app.
+
 ## 4. Alternatives considered
 
 - **Imperative `register_config()` in `register()`.** Rejected — config/secrets/

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -60,8 +60,9 @@ types — a fork adds any of them as a plugin, never editing core `server.py`:
 | `register_tool(tool)` / `register_tools(iter)` | A LangChain tool | graph build (live-reloads) |
 | `register_skill_dir(path)` | A `SKILL.md` directory | graph build |
 | `register_router(router, prefix=None)` | A FastAPI `APIRouter` | **mounted once** at init (default prefix `/plugins/<id>`) |
-| `register_surface(start, stop=None, name=None)` | A background surface (a Discord-style gateway) | `start` in startup, `stop` in shutdown |
+| `register_surface(start, stop=None, name=None, reload=None)` | A background surface (a Discord-style gateway) | `start` in startup, `stop` in shutdown, `reload(cfg)` on config save |
 | `register_subagent(config)` | A `SubagentConfig` (a delegate) | added to `SUBAGENT_REGISTRY` |
+| `register_mcp_server(factory)` | A **managed MCP server** the agent connects to | `factory(config)` called at each graph build → entry dict or `None` |
 
 ```python
 def register(registry):
@@ -69,7 +70,22 @@ def register(registry):
     registry.register_router(_build_router())        # → GET /plugins/<id>/...
     registry.register_surface(_start, stop=_stop, name="my-surface")
     registry.register_subagent(_build_subagent())    # delegate via task/task_batch
+    registry.register_mcp_server(_server_factory)    # a managed MCP server (e.g. Google)
 ```
+
+### Managed MCP servers — `register_mcp_server`
+
+A plugin can ship a **managed MCP server** the agent connects to, instead of
+making the operator hand-edit `mcp.servers`. The factory is called at every graph
+build with the live `LangGraphConfig`; return a `mcp.servers[]` entry (`{name,
+transport, command, args, env, ...}`) when the server should run, or `None` when
+it shouldn't (off / not yet connected) — so the server comes and goes with config.
+A returned entry whose `name` matches a configured server replaces it, and a
+factory that returns an entry activates MCP even when `mcp.enabled` is off. This
+is how the first-party **Google** plugin ships its OAuth-gated Gmail/Calendar
+server (`plugins/google/`). For a frozen desktop build (no `python` on PATH),
+launch via `args: ["--mcp-plugin", "<id>"]` and expose a `mcp_main()` in your
+plugin module — the binary re-invokes itself and the shim runs it.
 
 ## Host services — `registry.host`
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -133,17 +133,10 @@ class LangGraphConfig:
     # (ADR 0018/0019, plugins/discord/) — its config lives in plugin_config["discord"],
     # not a typed field here.
 
-    # Google surface (ADR 0017) — Gmail + Calendar via the bundled MCP server,
-    # connected in-app with an OAuth consent flow (no credentials.json / CLI).
-    # The OAuth client (client_id + client_secret) comes from the operator's
-    # Google Cloud "Desktop app" client; the refreshable token is cached in the
-    # per-user config dir. `client_secret` lives in the secrets overlay. When
-    # enabled + connected, the config layer auto-wires the google MCP server, so
-    # the operator never edits `mcp.servers`. `tz` sets day bounds for "today".
-    google_enabled: bool = False
-    google_client_id: str = ""
-    google_client_secret: str = ""
-    google_tz: str = ""
+    # The Google surface (ADR 0017) is now the first-party `google` plugin (ADR
+    # 0019, plugins/google/) — a managed MCP server it injects via
+    # register_mcp_server. Its config lives in plugin_config["google"], not typed
+    # fields here.
 
     # Enforcement gate — opt-in safety middleware that blocks tool calls
     # before they execute (deny list + per-tool rate limits). Off by default;
@@ -418,7 +411,6 @@ class LangGraphConfig:
 
         secrets = _load_secrets_doc(p.parent)
 
-        google = data.get("google", {})
         model = data.get("model", {})
         subagents = data.get("subagents", {})
         middleware = data.get("middleware", {})
@@ -436,7 +428,6 @@ class LangGraphConfig:
         # value still lets create_llm / set_a2a_token fall back to env.
         secret_api_key = secrets.get("model", {}).get("api_key")
         secret_auth_token = secrets.get("auth", {}).get("token")
-        secret_google_secret = secrets.get("google", {}).get("client_secret")
 
         config = cls(
             model_provider=model.get("provider", cls.model_provider),
@@ -455,10 +446,6 @@ class LangGraphConfig:
             audit_middleware=middleware.get("audit", cls.audit_middleware),
             memory_middleware=middleware.get("memory", cls.memory_middleware),
             scheduler_enabled=middleware.get("scheduler", cls.scheduler_enabled),
-            google_enabled=google.get("enabled", cls.google_enabled),
-            google_client_id=google.get("client_id", cls.google_client_id),
-            google_client_secret=secret_google_secret or google.get("client_secret", cls.google_client_secret),
-            google_tz=google.get("tz", cls.google_tz),
             enforcement_enabled=middleware.get("enforcement", cls.enforcement_enabled),
             enforcement_disallowed_tools=(
                 data.get("enforcement", {}).get("disallowed_tools", [])

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -87,9 +87,9 @@ SECRETS_YAML_PATH = _LIVE_CONFIG_DIR / "secrets.yaml"
 SECRET_PATHS: tuple[tuple[str, str], ...] = (
     ("model", "api_key"),
     ("auth", "token"),
-    ("google", "client_secret"),
-    # ("discord", "bot_token") is now declared by the discord plugin's manifest
-    # and added dynamically via secret_paths() (ADR 0019).
+    # The discord (`discord.bot_token`) and google (`google.client_secret`)
+    # secrets are now declared by their plugin manifests and added dynamically
+    # via secret_paths() (ADR 0019).
 )
 
 
@@ -255,14 +255,8 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
         "auth": {
             "token": "",
         },
-        # `discord` is now a plugin section (ADR 0019) — surfaced via the
-        # plugin_config loop below, not a hardcoded block.
-        "google": {
-            "enabled": config.google_enabled,
-            "client_id": config.google_client_id,
-            "client_secret": "",  # redacted — secret
-            "tz": config.google_tz,
-        },
+        # `discord` and `google` are now plugin sections (ADR 0019) — surfaced
+        # via the plugin_config loop below, not hardcoded blocks.
         "runtime": {
             "autostart_on_boot": config.autostart_on_boot,
         },

--- a/graph/plugins/host.py
+++ b/graph/plugins/host.py
@@ -25,6 +25,15 @@ class PluginHost:
     publish: Optional[Callable[[str, dict], Any]] = None
     # () -> subscription — subscribe to the event bus (e.g. return-address delivery).
     subscribe: Optional[Callable[[], Any]] = None
+    # () -> LangGraphConfig — the *live* server config. A route handler reads this
+    # for the current resolved values (incl. plugin_config) rather than closing
+    # over a load-time snapshot, so it sees Settings changes without a restart.
+    config: Optional[Callable[[], Any]] = None
+    # (patch: dict) -> (ok, messages) — persist a nested config patch to YAML
+    # (secrets routed automatically) and reload the graph once. Heavy (a full
+    # reload) — a route should call it via ``asyncio.to_thread``. Lets a plugin
+    # route apply config + reload (e.g. Google's Connect flow flipping enabled).
+    apply_settings: Optional[Callable[[dict], Any]] = None
 
 
 # Process-lifetime singleton. The server fills it in; plugins read it.

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -29,6 +29,7 @@ class PluginLoadResult:
     routers: list = field(default_factory=list)    # {plugin_id, router, prefix} (ADR 0018)
     surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
     subagents: list = field(default_factory=list)   # SubagentConfig
+    mcp_servers: list = field(default_factory=list)  # factories: config -> entry|None (ADR 0019)
     meta: list[dict] = field(default_factory=list)
 
 
@@ -76,6 +77,40 @@ def _import_register(manifest: PluginManifest):
     if not callable(register):
         raise RuntimeError("plugin module has no callable register(registry)")
     return register
+
+
+def run_plugin_mcp_main(plugin_id: str) -> None:
+    """Frozen-binary entrypoint for a plugin's managed MCP server (ADR 0019).
+
+    Find the plugin by id across the default roots, import its entry module, and
+    call its ``mcp_main()`` (the subprocess body of its managed MCP server). Used
+    by the ``--mcp-plugin <id>`` shim when there's no ``python`` on PATH. Importing
+    the module does NOT call ``register`` — only defines its functions — so this
+    is side-effect-free apart from running the server.
+    """
+    from graph.config_io import _BUNDLE_CONFIG_DIR, _live_config_dir
+
+    roots = [_BUNDLE_CONFIG_DIR.parent / "plugins", _live_config_dir() / "plugins"]
+    for manifest in discover_plugins(roots):
+        if manifest.id != plugin_id:
+            continue
+        entry = _entry_file(manifest)
+        if entry is None:
+            raise RuntimeError(f"plugin {plugin_id!r} has no entry module")
+        mod_name = f"protoagent_plugin_{manifest.id}"
+        spec = importlib.util.spec_from_file_location(
+            mod_name, str(entry), submodule_search_locations=[str(manifest.path)]
+        )
+        if spec is None or spec.loader is None:
+            raise RuntimeError(f"could not import plugin {plugin_id!r}")
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        mcp_main = getattr(module, "mcp_main", None)
+        if not callable(mcp_main):
+            raise RuntimeError(f"plugin {plugin_id!r} has no mcp_main()")
+        mcp_main()
+        return
+    raise RuntimeError(f"plugin {plugin_id!r} not found for --mcp-plugin")
 
 
 def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLoadResult:
@@ -146,17 +181,21 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         for s in registry.surfaces:
             result.surfaces.append({"plugin_id": manifest.id, **s})
         result.subagents.extend(registry.subagents)
+        for f in registry.mcp_servers:
+            result.mcp_servers.append({"plugin_id": manifest.id, "factory": f})
         entry["loaded"] = True
         entry["tools"] = [t.name for t in kept]
         entry["skills"] = len(registry.skill_dirs)
         entry["routers"] = len(registry.routers)
         entry["surfaces"] = len(registry.surfaces)
         entry["subagents"] = [getattr(c, "name", "?") for c in registry.subagents]
+        entry["mcp_servers"] = len(registry.mcp_servers)
         result.meta.append(entry)
         log.info("[plugins] loaded %s: %d tool(s), %d skill dir(s), %d route(s), "
-                 "%d surface(s), %d subagent(s)",
+                 "%d surface(s), %d subagent(s), %d mcp server(s)",
                  manifest.id, len(kept), len(registry.skill_dirs),
-                 len(registry.routers), len(registry.surfaces), len(registry.subagents))
+                 len(registry.routers), len(registry.surfaces),
+                 len(registry.subagents), len(registry.mcp_servers))
 
     return result
 

--- a/graph/plugins/pconfig.py
+++ b/graph/plugins/pconfig.py
@@ -24,9 +24,9 @@ log = logging.getLogger("protoagent.plugins")
 _RESERVED_SECTIONS = {
     "model", "subagents", "middleware", "knowledge", "memory", "skills",
     "workflows", "compaction", "checkpoint", "routing", "goal", "execute_code",
-    # NB: `discord` is NOT reserved — it's a first-party plugin (ADR 0018/0019)
-    # that legitimately claims the `discord` section. (`google` migrates next.)
-    "operator", "tools", "google", "mcp", "plugins", "identity",
+    # NB: `discord` and `google` are NOT reserved — they're first-party plugins
+    # (ADR 0018/0019) that legitimately claim those sections.
+    "operator", "tools", "mcp", "plugins", "identity",
     "auth", "runtime", "telemetry", "instance", "prompt_cache", "enforcement",
     "ingest",
 }

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -48,6 +48,7 @@ class PluginRegistry:
         self.routers: list[dict] = []     # {"router", "prefix"}
         self.surfaces: list[dict] = []    # {"name", "start", "stop"}
         self.subagents: list = []         # SubagentConfig instances
+        self.mcp_servers: list = []       # factories: config -> entry dict | None
 
     def register_tool(self, tool) -> None:
         """Expose a LangChain tool to the agent."""
@@ -102,6 +103,22 @@ class PluginRegistry:
         self.surfaces.append(
             {"name": name or self.plugin_id, "start": start, "stop": stop, "reload": reload}
         )
+
+    def register_mcp_server(self, factory) -> None:
+        """Contribute a **managed MCP server** the agent connects to (ADR 0019).
+
+        ``factory`` is a callable ``factory(config) -> dict | None`` returning a
+        ``mcp.servers[]`` entry (``{name, transport, command, args, env, ...}``) or
+        ``None`` when the server shouldn't start (off / not yet connected). It's
+        called at every graph build with the live ``LangGraphConfig``, so the
+        server comes and goes with config — this is how the Google surface ships
+        its OAuth-gated MCP server without a core edit. A returned entry whose
+        ``name`` matches a user-defined ``mcp.servers`` entry replaces it.
+        """
+        if not callable(factory):
+            log.warning("[plugins] %s: register_mcp_server needs a callable", self.plugin_id)
+            return
+        self.mcp_servers.append(factory)
 
     def register_subagent(self, config) -> None:
         """Add a ``SubagentConfig`` to ``SUBAGENT_REGISTRY`` (ADR 0018).

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -126,19 +126,9 @@ FIELDS: list[Field] = [
     # Discord's Settings group is now declared by the discord plugin's manifest
     # (ADR 0019) and rendered via the plugin-fields path in build_schema.
 
-    # ── Google (ADR 0017) ────────────────────────────────────────────────────
-    # The OAuth client lives here; "Connect Google" (a button, not a field) runs
-    # the consent flow and caches the token. Editing client id/secret is rare —
-    # most operators use the wizard/Settings "Connect Google" button.
-    Field("google.enabled", "google_enabled", "Enable Google", "bool", "Google",
-          "Gmail + Calendar tools. Needs the OAuth client below + a completed "
-          "“Connect Google”. Reconnects the tools live on save."),
-    Field("google.client_id", "google_client_id", "OAuth client ID", "string", "Google",
-          "From your Google Cloud “Desktop app” OAuth client."),
-    Field("google.client_secret", "google_client_secret", "OAuth client secret", "secret", "Google",
-          "From the same OAuth client. Stored in secrets.yaml."),
-    Field("google.tz", "google_tz", "Timezone (IANA)", "string", "Google",
-          "e.g. America/Los_Angeles — sets the day bounds for “today”. Blank = UTC."),
+    # Google's Settings group is now declared by the google plugin's manifest
+    # (ADR 0019) and rendered via the plugin-fields path in build_schema. The
+    # "Connect Google" button (consent flow) is a console affordance, not a field.
 
     # ── Runtime (restart) ────────────────────────────────────────────────────
     Field("runtime.autostart_on_boot", "autostart_on_boot", "Autostart on boot", "bool", "Runtime",

--- a/plugins/google/__init__.py
+++ b/plugins/google/__init__.py
@@ -1,0 +1,178 @@
+"""Google (Gmail + Calendar) surface as a plugin (ADR 0017 → 0019).
+
+The integration is a **managed MCP server** (``mcp_servers/google/``) the agent
+connects to; this plugin is the *wiring* that lives in a plugin instead of
+``server.py`` + ``tools/mcp_tools.py``. Moving it here lets a fork disable Google
+(``plugins.disabled: [google]``) or replace it with its own integration, with no
+core edit.
+
+Contributes:
+- a **managed MCP server** (``register_mcp_server``) — OAuth-gated, frozen-aware
+  launch, started only once connected (a cached token exists);
+- two **routes** (``GET /api/config/google/status`` + ``POST
+  /api/config/google/connect``) mounted at their existing paths so the console's
+  Connect/Status UI is unchanged;
+- a frozen-binary entrypoint (``mcp_main``) the ``--mcp-plugin google`` shim runs.
+
+Config/secrets/Settings come from the manifest (ADR 0019); it claims the existing
+top-level ``google`` section, so saved OAuth clients keep working.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+log = logging.getLogger("protoagent.plugins.google")
+
+
+def mcp_main() -> None:
+    """Frozen-binary entrypoint (``--mcp-plugin google``) — run the managed
+    Google MCP server in this process. The desktop binary has no ``python`` on
+    PATH, so the server factory re-invokes the binary with ``--mcp-plugin
+    google`` and the shim calls this."""
+    from mcp_servers.google.server import main as _google_mcp_main
+
+    _google_mcp_main()
+
+
+def _gcfg(config) -> dict:
+    """The resolved ``google`` plugin-config section from a live LangGraphConfig."""
+    return (getattr(config, "plugin_config", {}) or {}).get("google", {}) or {}
+
+
+def _token_path() -> str:
+    try:
+        from graph.config_io import _live_config_dir
+
+        return str(_live_config_dir() / "google-token.json")
+    except Exception:  # noqa: BLE001
+        return "google-token.json"
+
+
+def _server_factory(config) -> dict | None:
+    """Build the managed Google MCP server entry, or None if google is off / not
+    yet connected. Called at every graph build with the live config (ADR 0019).
+
+    The OAuth client (id/secret) + token path + tz go to the subprocess via
+    ``env``. Launch is frozen-aware: the bundled binary has no ``python`` on PATH,
+    so it re-invokes itself (``<binary> --mcp-plugin google``); a normal
+    interpreter runs ``-m mcp_servers.google.server``.
+    """
+    g = _gcfg(config)
+    if not g.get("enabled"):
+        return None
+    client_id = (g.get("client_id") or "").strip()
+    client_secret = (g.get("client_secret") or "").strip()
+    if not (client_id and client_secret):
+        log.info("[google] enabled but OAuth client not set — server not started")
+        return None
+
+    # Start the headless MCP server only once authorized (a cached token exists).
+    # Before "Connect Google" there's nothing to load — it would just register
+    # tools that error on every call. The connect route reloads once the token is
+    # written, so the server comes up then.
+    token_path = _token_path()
+    if not os.path.exists(token_path):
+        log.info("[google] enabled but not connected yet — server starts after Connect Google")
+        return None
+
+    import sys
+
+    if getattr(sys, "frozen", False):
+        command, args = sys.executable, ["--mcp-plugin", "google"]
+    else:
+        command, args = sys.executable, ["-m", "mcp_servers.google.server"]
+
+    env = {
+        "GOOGLE_CLIENT_ID": client_id,
+        "GOOGLE_CLIENT_SECRET": client_secret,
+        "GOOGLE_TOKEN_PATH": token_path,
+    }
+    tz = (g.get("tz") or "").strip()
+    if tz:
+        env["GOOGLE_TZ"] = tz
+
+    return {
+        "name": "google",
+        "enabled": True,
+        "transport": "stdio",
+        "command": command,
+        "args": args,
+        "env": env,
+    }
+
+
+def _env_from_config(config) -> None:
+    """Mirror the configured OAuth client + token path into the env so
+    ``mcp_servers.google.auth`` (which reads env) can run consent/status
+    in-process for the connect + status routes."""
+    g = _gcfg(config)
+    cid = (g.get("client_id") or "").strip()
+    sec = (g.get("client_secret") or "").strip()
+    if cid:
+        os.environ["GOOGLE_CLIENT_ID"] = cid
+    if sec:
+        os.environ["GOOGLE_CLIENT_SECRET"] = sec
+    os.environ["GOOGLE_TOKEN_PATH"] = _token_path()
+
+
+def _build_router(host):
+    """The Connect/Status routes, mounted at their existing paths (prefix="")."""
+    import asyncio
+
+    from fastapi import APIRouter
+
+    router = APIRouter()
+
+    def _live_config():
+        return host.config() if host and host.config else None
+
+    @router.get("/api/config/google/status")
+    async def _google_status():
+        """Report (configured, connected, email) for the Google surface."""
+        try:
+            from mcp_servers.google.auth import connection_status
+        except Exception as e:  # noqa: BLE001 — google extra may be absent
+            return {"configured": False, "connected": False, "email": None,
+                    "error": f"google support unavailable: {e}"}
+        _env_from_config(_live_config())
+        try:
+            return await asyncio.to_thread(connection_status)
+        except Exception as e:  # noqa: BLE001
+            return {"configured": False, "connected": False, "email": None, "error": str(e)}
+
+    @router.post("/api/config/google/connect")
+    async def _google_connect():
+        """Run the OAuth consent (opens the operator's browser), cache the token,
+        enable the Google surface, and reload so the tools register. Long-lived:
+        it blocks until the operator approves in the browser (3-min cap)."""
+        try:
+            from mcp_servers.google.auth import run_consent
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "error": f"google support unavailable: {e}"}
+        cfg = _live_config()
+        g = _gcfg(cfg)
+        if not ((g.get("client_id") or "").strip() and (g.get("client_secret") or "").strip()):
+            return {"ok": False, "error": "Set the OAuth client ID + secret first, then connect."}
+        _env_from_config(cfg)
+        try:
+            email = await asyncio.wait_for(asyncio.to_thread(run_consent), timeout=180)
+        except asyncio.TimeoutError:
+            return {"ok": False, "error": "Timed out waiting for Google consent (3 min). Try again."}
+        except Exception as e:  # noqa: BLE001
+            return {"ok": False, "error": str(e)}
+        # Persist enabled + reload so the managed google MCP server starts and the
+        # tools register without a restart.
+        msg = None
+        if host and host.apply_settings:
+            ok, msg = await asyncio.to_thread(host.apply_settings, {"google": {"enabled": True}})
+            msg = msg if ok else None
+        return {"ok": True, "email": email, "reload": msg}
+
+    return router
+
+
+def register(registry) -> None:
+    registry.register_mcp_server(_server_factory)
+    registry.register_router(_build_router(registry.host), prefix="")  # existing /api paths

--- a/plugins/google/protoagent.plugin.yaml
+++ b/plugins/google/protoagent.plugin.yaml
@@ -1,0 +1,24 @@
+id: google
+name: Google
+version: 0.1.0
+description: >-
+  Gmail + Calendar via a managed MCP server (ADR 0017), connected in-app with an
+  OAuth consent flow (no credentials.json / CLI) — as a first-party plugin (ADR
+  0019). Off until you set an OAuth client + click “Connect Google”. Disable
+  entirely with `plugins: { disabled: [google] }`, or replace it with your own
+  Google integration — no server.py edit.
+enabled: true
+requires_env: []
+# Config section (ADR 0019) — claims the top-level `google` section, so the
+# existing Settings group + wizard step + Connect button keep working unchanged.
+config_section: google
+config:
+  enabled: false
+  client_id: ""
+  tz: ""
+secrets: [client_secret]
+settings:
+  - { key: enabled, label: "Enable Google", type: bool, description: "Gmail + Calendar tools. Needs the OAuth client below + a completed “Connect Google”. Reconnects the tools live on save." }
+  - { key: client_id, label: "OAuth client ID", type: string, description: "From your Google Cloud “Desktop app” OAuth client." }
+  - { key: client_secret, label: "OAuth client secret", type: secret, description: "From the same OAuth client. Stored in secrets.yaml." }
+  - { key: tz, label: "Timezone (IANA)", type: string, description: "e.g. America/Los_Angeles — sets the day bounds for “today”. Blank = UTC." }

--- a/server.py
+++ b/server.py
@@ -258,15 +258,14 @@ def _init_langgraph_agent(headless_setup: bool = False):
     global _scheduler
     _scheduler = _build_scheduler(_graph_config)
 
-    # MCP — external Model Context Protocol servers; their tools become agent
-    # tools (namespaced <server>__<tool>). Off unless mcp.enabled.
-    _mcp_clients, _mcp_tools, _mcp_meta = _build_mcp(_graph_config)
-
-    # Plugins — drop-in packages (tools + bundled skills). Loaded after the
-    # core + MCP tools so plugin tools that would shadow them are skipped.
+    # Plugins — drop-in packages (tools + bundled skills + surfaces/routes +
+    # managed MCP servers). Loaded BEFORE MCP so a plugin's managed MCP server
+    # (register_mcp_server, e.g. Google) is injected into the MCP discovery
+    # below. Collision check uses core tools only — MCP tools are namespaced
+    # (<server>__<tool>) so they can't be shadowed by a plugin tool anyway.
     _plugins = _build_plugins(
         _graph_config,
-        existing_tools=get_all_tools(_knowledge_store, scheduler=_scheduler) + _mcp_tools,
+        existing_tools=get_all_tools(_knowledge_store, scheduler=_scheduler),
     )
     _plugin_tools, _plugin_skill_dirs, _plugin_meta = (
         _plugins.tools, _plugins.skill_dirs, _plugins.meta,
@@ -278,6 +277,13 @@ def _init_langgraph_agent(headless_setup: bool = False):
     global _plugin_routers, _plugin_surfaces
     _plugin_routers, _plugin_surfaces = _plugins.routers, _plugins.surfaces
     _register_plugin_subagents(_plugins.subagents)
+
+    # MCP — external Model Context Protocol servers; their tools become agent
+    # tools (namespaced <server>__<tool>). Off unless mcp.enabled OR a plugin
+    # contributes a managed server (ADR 0019).
+    _mcp_clients, _mcp_tools, _mcp_meta = _build_mcp(
+        _graph_config, plugin_servers=[s["factory"] for s in _plugins.mcp_servers]
+    )
 
     # Skills — human-authored SKILL.md folders (bundle + live + plugin-bundled)
     # seeded into the FTS index; KnowledgeMiddleware retrieves + injects them.
@@ -382,8 +388,12 @@ def _build_skills_index(config, extra_skill_dirs=None):
         return None
 
 
-def _build_mcp(config):
+def _build_mcp(config, plugin_servers=None):
     """Discover tools from configured MCP servers. Returns (clients, tools, meta).
+
+    ``plugin_servers`` are managed-MCP-server factories contributed by plugins
+    (``register_mcp_server``, ADR 0019) — e.g. the Google surface's OAuth-gated
+    server — injected alongside the configured ``mcp.servers``.
 
     Best-effort and per-server isolated (see tools/mcp_tools.build_mcp_tools):
     a bad/unreachable server is logged and skipped, never fatal. Returns empty
@@ -392,7 +402,7 @@ def _build_mcp(config):
     try:
         from tools.mcp_tools import build_mcp_tools
 
-        clients, tools, meta = build_mcp_tools(config)
+        clients, tools, meta = build_mcp_tools(config, plugin_servers=plugin_servers)
         if tools:
             log.info("[mcp] %d tool(s) from %d server(s)", len(tools), len(meta))
         return clients, tools, meta
@@ -893,10 +903,14 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     if is_setup_complete():
         try:
             new_store = _build_knowledge_store(new_config)
-            new_mcp_clients, new_mcp_tools, new_mcp_meta = _build_mcp(new_config)
+            # Plugins before MCP — a plugin's managed MCP server (e.g. Google)
+            # is injected into the MCP discovery below (matches _main ordering).
             new_plugins = _build_plugins(
                 new_config,
-                existing_tools=get_all_tools(new_store, scheduler=next_scheduler) + new_mcp_tools,
+                existing_tools=get_all_tools(new_store, scheduler=next_scheduler),
+            )
+            new_mcp_clients, new_mcp_tools, new_mcp_meta = _build_mcp(
+                new_config, plugin_servers=[s["factory"] for s in new_plugins.mcp_servers]
             )
             new_plugin_tools = new_plugins.tools
             new_plugin_skill_dirs = new_plugins.skill_dirs
@@ -991,6 +1005,8 @@ def _populate_plugin_host() -> None:
         HOST.invoke = _plugin_agent_invoke
         HOST.publish = _event_bus.publish
         HOST.subscribe = _event_bus.subscribe
+        HOST.config = lambda: _graph_config
+        HOST.apply_settings = lambda patch: _apply_settings_changes(config=patch)
     except Exception:  # noqa: BLE001
         log.exception("[plugins] failed to populate plugin host")
 
@@ -2119,14 +2135,17 @@ def _a2a_terminal(outcome) -> None:
 def _main():
     global _active_port
 
-    # Frozen-binary entrypoint for the managed Google MCP server (ADR 0017): the
-    # bundled desktop app has no `python` on PATH, so the google MCP entry
-    # re-invokes this binary with --mcp-google instead of `-m
-    # mcp_servers.google.server`. Handle it before argparse/server startup.
-    if "--mcp-google" in sys.argv:
-        from mcp_servers.google.server import main as _google_mcp_main
+    # Frozen-binary entrypoint for a plugin's managed MCP server (ADR 0019): the
+    # bundled desktop app has no `python` on PATH, so a plugin's managed-server
+    # factory re-invokes this binary with `--mcp-plugin <id>` instead of `-m
+    # <module>`. We import that plugin's module and call its `mcp_main()`. Handle
+    # it before argparse/server startup. (The Google plugin is the first user.)
+    if "--mcp-plugin" in sys.argv:
+        i = sys.argv.index("--mcp-plugin")
+        plugin_id = sys.argv[i + 1] if i + 1 < len(sys.argv) else ""
+        from graph.plugins.loader import run_plugin_mcp_main
 
-        _google_mcp_main()
+        run_plugin_mcp_main(plugin_id)
         return
 
     parser = argparse.ArgumentParser(description=f"{AGENT_NAME_ENV} — protoAgent server")
@@ -2873,61 +2892,10 @@ def _main():
         ok, error = await asyncio.to_thread(validate_model_connection, base, key, model)
         return {"ok": ok, "error": error}
 
-    # `/api/config/test-discord` is now mounted by the discord plugin's router
-    # (ADR 0018/0019), at the same path — the console Test button is unchanged.
-
-    def _google_env_from_config() -> None:
-        """Mirror the configured Google OAuth client + token path into the env so
-        ``mcp_servers.google.auth`` (which reads env) can run the consent/status
-        in-process for the connect + status endpoints."""
-        from graph.config_io import _live_config_dir
-
-        cid = (_graph_config.google_client_id if _graph_config else "") or ""
-        sec = (_graph_config.google_client_secret if _graph_config else "") or ""
-        if cid:
-            os.environ["GOOGLE_CLIENT_ID"] = cid
-        if sec:
-            os.environ["GOOGLE_CLIENT_SECRET"] = sec
-        os.environ["GOOGLE_TOKEN_PATH"] = str(_live_config_dir() / "google-token.json")
-
-    @fastapi_app.get("/api/config/google/status")
-    async def _api_google_status():
-        """Report (configured, connected, email) for the Google surface."""
-        try:
-            from mcp_servers.google.auth import connection_status
-        except Exception as e:  # noqa: BLE001 — google extra may be absent
-            return {"configured": False, "connected": False, "email": None,
-                    "error": f"google support unavailable: {e}"}
-        _google_env_from_config()
-        try:
-            return await asyncio.to_thread(connection_status)
-        except Exception as e:  # noqa: BLE001
-            return {"configured": False, "connected": False, "email": None, "error": str(e)}
-
-    @fastapi_app.post("/api/config/google/connect")
-    async def _api_google_connect():
-        """Run the OAuth consent (opens the operator's browser), cache the token,
-        enable the Google surface, and reload so the tools register. Long-lived:
-        it blocks until the operator approves in the browser (3-min cap)."""
-        try:
-            from mcp_servers.google.auth import run_consent
-        except Exception as e:  # noqa: BLE001
-            return {"ok": False, "error": f"google support unavailable: {e}"}
-        if not (_graph_config and _graph_config.google_client_id and _graph_config.google_client_secret):
-            return {"ok": False, "error": "Set the OAuth client ID + secret first, then connect."}
-        _google_env_from_config()
-        try:
-            email = await asyncio.wait_for(asyncio.to_thread(run_consent), timeout=180)
-        except asyncio.TimeoutError:
-            return {"ok": False, "error": "Timed out waiting for Google consent (3 min). Try again."}
-        except Exception as e:  # noqa: BLE001
-            return {"ok": False, "error": str(e)}
-        # Persist enabled + reload so the managed google MCP server starts and the
-        # tools register without a restart.
-        ok, msg = await asyncio.to_thread(
-            _apply_settings_changes, config={"google": {"enabled": True}}
-        )
-        return {"ok": True, "email": email, "reload": msg if ok else None}
+    # `/api/config/test-discord` (discord plugin) and `/api/config/google/status`
+    # + `/connect` (google plugin) are now mounted by their plugin routers (ADR
+    # 0018/0019), at the same paths — the console Test/Connect buttons are
+    # unchanged.
 
     # --- Setup wizard state -------------------------------------------------
     @fastapi_app.get("/api/config/setup-status")

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -130,15 +130,15 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # strand fork-added fields outside the drawer's round-trip.
     assert set(d.keys()) == {
         "model", "subagents", "middleware", "knowledge", "skills", "mcp", "plugins",
-        "identity", "auth", "google", "runtime", "operator",
+        "identity", "auth", "runtime", "operator",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature
     # Secrets are redacted out of the UI-facing dict.
     assert d["model"]["api_key"] == ""
     assert d["auth"]["token"] == ""
-    # (Discord is now a plugin section — present only when the discord plugin is
-    # enabled, surfaced via plugin_config, not this core block.)
+    # (Discord and Google are now plugin sections — present only when their
+    # plugin is enabled, surfaced via plugin_config, not core blocks.)
     assert d["subagents"]["researcher"]["tools"] == list(cfg.researcher.tools)
     assert d["middleware"]["audit"] == cfg.audit_middleware
     assert d["knowledge"]["top_k"] == cfg.knowledge_top_k

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -113,6 +113,45 @@ def test_build_collects_tools_and_meta(monkeypatch) -> None:
     assert len(clients) == 1
 
 
+def test_plugin_server_injected_and_activates_mcp(monkeypatch) -> None:
+    # A plugin-contributed managed server (register_mcp_server) is connected even
+    # when mcp.enabled is off — its presence alone activates MCP discovery.
+    _fake_client_factory(monkeypatch, by_server={"g": [SimpleNamespace(name="g__send")]})
+    entry = {"name": "g", "transport": "stdio", "command": "python", "args": ["g.py"]}
+    cfg = LangGraphConfig(mcp_enabled=False, mcp_servers=[])
+    _clients, tools, meta = build_mcp_tools(cfg, plugin_servers=[lambda c: entry])
+    assert [t.name for t in tools] == ["g__send"]
+    assert meta[0]["name"] == "g"
+
+
+def test_plugin_server_none_skipped(monkeypatch) -> None:
+    # A factory returning None (surface off / not connected) contributes nothing,
+    # and with no configured servers MCP stays inert.
+    _fake_client_factory(monkeypatch, by_server={})
+    cfg = LangGraphConfig(mcp_enabled=False, mcp_servers=[])
+    clients, tools, meta = build_mcp_tools(cfg, plugin_servers=[lambda c: None])
+    assert (clients, tools, meta) == ([], [], [])
+
+
+def test_plugin_server_replaces_same_named_config_entry(monkeypatch) -> None:
+    # A plugin entry named like a configured server replaces it (managed wins).
+    _fake_client_factory(monkeypatch, by_server={"g": [SimpleNamespace(name="g__managed")]})
+    managed = {"name": "g", "transport": "stdio", "command": "python", "args": ["managed.py"]}
+    cfg = _cfg([{"name": "g", "transport": "stdio", "command": "python", "args": ["user.py"]}])
+    _clients, tools, _meta = build_mcp_tools(cfg, plugin_servers=[lambda c: managed])
+    assert [t.name for t in tools] == ["g__managed"]
+
+
+def test_plugin_server_factory_error_isolated(monkeypatch) -> None:
+    # A throwing factory is logged + skipped, never fatal; other config servers run.
+    _fake_client_factory(monkeypatch, by_server={"echo": [SimpleNamespace(name="echo__echo")]})
+    def _boom(c):
+        raise RuntimeError("bad factory")
+    cfg = _cfg([{"name": "echo", "transport": "stdio", "command": "python", "args": ["s.py"]}])
+    _clients, tools, _meta = build_mcp_tools(cfg, plugin_servers=[_boom])
+    assert [t.name for t in tools] == ["echo__echo"]
+
+
 def test_denylist_and_core_collision_filtered(monkeypatch) -> None:
     _fake_client_factory(monkeypatch, by_server={
         "s": [

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -20,63 +20,6 @@ from typing import Any
 log = logging.getLogger("protoagent.mcp")
 
 
-def _google_server_entry(config) -> dict | None:
-    """Build the managed Google MCP server entry, or None if google is off.
-
-    The OAuth client (id/secret) + token path + tz are passed to the subprocess
-    via ``env``. Launch is frozen-aware: the bundled desktop binary has no
-    ``python`` on PATH, so it re-invokes itself (``<binary> --mcp-google``); in a
-    normal interpreter it runs ``-m mcp_servers.google.server``.
-    """
-    if not getattr(config, "google_enabled", False):
-        return None
-    client_id = (getattr(config, "google_client_id", "") or "").strip()
-    client_secret = (getattr(config, "google_client_secret", "") or "").strip()
-    if not (client_id and client_secret):
-        log.info("[google] enabled but OAuth client not set — server not started")
-        return None
-
-    import sys
-
-    try:
-        from graph.config_io import _live_config_dir
-
-        token_path = str(_live_config_dir() / "google-token.json")
-    except Exception:  # noqa: BLE001
-        token_path = "google-token.json"
-
-    # Only start the headless MCP server once authorized (a cached token exists).
-    # Before "Connect Google" there's nothing to load — starting it would just
-    # register tools that error on every call. The connect endpoint reloads once
-    # the token is written, so the server comes up then.
-    if not os.path.exists(token_path):
-        log.info("[google] enabled but not connected yet — server starts after Connect Google")
-        return None
-
-    if getattr(sys, "frozen", False):
-        command, args = sys.executable, ["--mcp-google"]
-    else:
-        command, args = sys.executable, ["-m", "mcp_servers.google.server"]
-
-    env = {
-        "GOOGLE_CLIENT_ID": client_id,
-        "GOOGLE_CLIENT_SECRET": client_secret,
-        "GOOGLE_TOKEN_PATH": token_path,
-    }
-    tz = (getattr(config, "google_tz", "") or "").strip()
-    if tz:
-        env["GOOGLE_TZ"] = tz
-
-    return {
-        "name": "google",
-        "enabled": True,
-        "transport": "stdio",
-        "command": command,
-        "args": args,
-        "env": env,
-    }
-
-
 def _server_connection(server: dict) -> dict | None:
     """Map a config ``mcp.servers[]`` entry to a langchain-mcp-adapters
     connection dict. Returns ``None`` for an entry missing its essential fields
@@ -177,7 +120,7 @@ def _core_tool_names() -> set[str]:
         return set()
 
 
-def build_mcp_tools(config) -> tuple[list, list, list[dict]]:
+def build_mcp_tools(config, *, plugin_servers=None) -> tuple[list, list, list[dict]]:
     """Discover tools from configured MCP servers.
 
     Returns ``(clients, tools, servers_meta)``:
@@ -186,27 +129,42 @@ def build_mcp_tools(config) -> tuple[list, list, list[dict]]:
     - ``tools`` — LangChain ``BaseTool``s to append to the agent.
     - ``servers_meta`` — ``[{name, transport, tool_count}]`` for runtime status.
 
+    ``plugin_servers`` is a list of factories ``factory(config) -> entry|None``
+    contributed by plugins (``register_mcp_server``) — e.g. the Google plugin's
+    OAuth-gated managed server. A factory's entry is injected like a configured
+    server (and replaces a same-named ``mcp.servers`` entry), and its presence
+    alone is enough to treat MCP as active, so the operator never edits
+    ``mcp.servers`` to use a plugin's managed server.
+
     Each server is isolated: a bad/unreachable one is logged and skipped, never
-    fatal. MCP is off unless ``config.mcp_enabled``.
+    fatal. MCP is off unless ``config.mcp_enabled`` (or a plugin contributes one).
     """
     clients: list = []
     tools: list = []
     meta: list[dict] = []
 
-    # The Google surface (ADR 0017) is a managed MCP server: when google is
-    # enabled in config, inject its entry (frozen-aware launch + OAuth env) and
-    # treat MCP as enabled, so the operator never edits mcp.servers. A
-    # user-defined 'google' entry is replaced by the managed one.
+    # Plugin-contributed managed MCP servers (ADR 0019) — e.g. the Google surface.
+    # A factory returns an entry only when its surface is on + connected, so the
+    # server comes and goes with config without the operator touching mcp.servers.
     servers = list(getattr(config, "mcp_servers", []) or [])
-    google_entry = _google_server_entry(config)
-    if google_entry is not None:
+    plugin_entries = []
+    for factory in (plugin_servers or []):
+        try:
+            entry = factory(config)
+        except Exception:  # noqa: BLE001 — a bad factory must not break MCP
+            log.exception("[mcp] plugin MCP server factory failed — skipped")
+            continue
+        if entry:
+            plugin_entries.append(entry)
+    for entry in plugin_entries:
+        name = str(entry.get("name") or "")
         servers = [
             s for s in servers
-            if not (isinstance(s, dict) and str(s.get("name") or "") == "google")
+            if not (isinstance(s, dict) and str(s.get("name") or "") == name)
         ]
-        servers.append(google_entry)
+        servers.append(entry)
 
-    if not (getattr(config, "mcp_enabled", False) or google_entry is not None):
+    if not (getattr(config, "mcp_enabled", False) or plugin_entries):
         return clients, tools, meta
 
     timeout = float(getattr(config, "mcp_timeout_seconds", 20.0))


### PR DESCRIPTION
## Google ingress → first-party plugin (#509, slice 2 — completes the migration)

Moves the **Google (Gmail + Calendar) surface** out of `server.py`, `tools/mcp_tools.py`, and the core config layer into a self-contained plugin (`plugins/google/`). With #513 (Discord), this completes the Discord/Google → plugins migration (#509).

**Behaviour is unchanged** for an out-of-the-box agent — the Settings → Google group, the wizard step, the **Connect Google** consent flow, status, and live-reconnect-on-save all work exactly as before. What changes is the seam: a fork can now **disable Google entirely** with `plugins: { disabled: [google] }`, or swap in its own integration, with no core edit. No config migration — the plugin claims the existing top-level `google` section, so saved OAuth clients keep working.

### New plugin reach (ADR 0019 addendum)
Google reaches the agent through a *managed MCP server*, which ADR 0018's contribution set didn't cover. Added:

| Capability | What it does |
|---|---|
| `register_mcp_server(factory)` | Plugin contributes `factory(config) -> entry \| None`, called at each graph build. Injected like a configured `mcp.servers` entry (replaces a same-named one); its presence activates MCP even when `mcp.enabled` is off. |
| Plugins load **before** MCP | So the factories are available to MCP discovery. MCP tools are namespaced `<server>__<tool>`, so the plugin-tool collision set is unaffected. |
| `--mcp-plugin <id>` | The google-specific `--mcp-google` frozen shim is now generic — imports the named plugin's module and runs its `mcp_main()`. **No core reference to any specific plugin remains.** |
| `host.config()` / `host.apply_settings(patch)` | A plugin *route* can read live config + persist-and-reload (Google's Connect flips `enabled` and reloads). |
| Sidecar bundles `plugins/` | Plugins are loaded by file path (PyInstaller's import-scan misses them), so the frozen desktop app needs the tree shipped as data. **Also fixes the already-merged Discord plugin in frozen builds.** |

### What moved
| Was (core) | Now (plugin) |
|---|---|
| `_google_server_entry` + injection (`tools/mcp_tools.py`) | `register_mcp_server(_server_factory)` |
| `GET /api/config/google/status` + `POST /connect` + `_google_env_from_config` (server.py) | plugin router at the **same paths** (`prefix=""`) |
| `--mcp-google` shim (server.py) | generic `--mcp-plugin google` → plugin `mcp_main()` |
| typed `google_*` fields + `config_to_dict` block + SECRET_PATHS + Settings group | manifest `config_section: google` + `config`/`secrets`/`settings` |

### Verification
- **Unit:** full suite green — **943 passed** (4 new MCP tests for the plugin-server path: inject-and-activate, `None`-skips, same-name-replaces, factory-error-isolated). Updated `test_config_io` (no core `google` block).
- **Live (local server, isolated config dir):** the google plugin loads (`1 route, 1 mcp server`), its router mounts at the existing `/api/config/google/*` paths, `GET /status` responds (`configured:false` when off), and the Settings schema resolves the `google.*` fields. The discord plugin still loads cleanly alongside it.
- **MCP factory gating (direct):** `disabled → None`, `enabled + creds, no token → None` (waits for Connect), `enabled + creds + token → managed stdio entry` with the OAuth client + tz in `env`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
