### PR TITLE
Fix: collect `tools` so the discord plugin loads in the frozen app (#513 follow-up)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Discord plugin failed to load in the frozen desktop app (`No module named
+  'tools.discord_tools'`).** Migrating Discord to a plugin (#513) removed the only
+  static import of `tools.discord_tools` from `tools/lg_tools.py`, so PyInstaller's
+  import-scan no longer saw it (the plugin imports it, but plugins are loaded by
+  file path — invisible to the scan) and it was dropped from the bundle. The
+  sidecar build now collects the whole `tools` package, so plugin-only tool
+  imports resolve in the frozen app. Caught by running the frozen binary directly;
+  the Google plugin was unaffected (its modules are collected via `mcp_servers`).
+
 ### Added
 - **Plugins can contribute managed MCP servers — `register_mcp_server` (ADR
   0019, #509).** A plugin ships an **MCP server the agent connects to** via a

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -67,6 +67,11 @@ COLLECT_ALL = [
     # Collect both so Discord works in the frozen app.
     "surfaces",
     "websockets",
+    # The `tools` package — the discord plugin imports `tools.discord_tools`
+    # (and future plugins may import other tool modules). Plugins are loaded by
+    # file path, so PyInstaller's import-scan never sees these; collect the whole
+    # package so plugin-only tool imports resolve in the frozen app.
+    "tools",
     # Google surface (ADR 0017): the MCP SDK (FastMCP) + the repo's google MCP
     # server module, loaded by the google plugin and re-invoked frozen via the
     # ``--mcp-plugin google`` self-reinvoke entry.


### PR DESCRIPTION
## Frozen desktop: the discord plugin failed to load (`No module named 'tools.discord_tools'`)

Migrating Discord to a plugin (#513) removed the only **static** import of `tools.discord_tools` (it lived in `tools/lg_tools.py::get_all_tools`). After that, the *only* importer is the discord plugin — which is loaded by **file path** (`importlib`), invisible to PyInstaller's import-scan. So the module was dropped from the frozen bundle, and the plugin failed to load at boot in the desktop app:

```
[plugins] discord failed to load: No module named 'tools.discord_tools' — skipping
```

The Google plugin was unaffected — its modules are pulled in via the already-collected `mcp_servers` package.

### Fix
Collect the whole `tools` package in the sidecar build (same pattern as `surfaces` / `mcp_servers`), so plugin-only tool imports resolve in the frozen app.

### How it was found / verified
Built the sidecar binary on the gina fork and **ran the frozen binary directly** with an isolated config:
- Before: `discord failed to load … No module named 'tools.discord_tools'`; `/api/config/test-discord` → 404.
- After (rebuilt with this fix): both plugins load — `loaded discord: 1 route, 1 surface` + `loaded google: 1 route, 1 mcp server`, both routers mount, `/api/config/test-discord` and `/api/config/google/status` respond, and the gateway stays correctly off with no token.

(Source-only change; no test-suite coverage since CI doesn't build the DMG. Verified by direct frozen-binary run.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)