### PR TITLE
Fix: desktop chat renders the reply (non-streaming /api/chat in WKWebView)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Desktop chat showed a blank assistant reply (no response).** WKWebView (the
+  Tauri shell) doesn't deliver a `text/event-stream` body through `fetch()` at all
+  — neither `body.getReader()` nor a buffered `clone().text()` fallback returns the
+  bytes — so the streaming `/a2a` turn rendered as an empty assistant bubble even
+  though the agent replied. In the desktop shell the chat now uses the
+  non-streaming `/api/chat` endpoint (ordinary JSON, which WKWebView handles fine —
+  it's how the rest of the console already talks to the sidecar): one request, full
+  reply, rendered once. Browsers keep the token-streaming `/a2a` path (with
+  tool-call cards). Found by building + driving the desktop app directly.
 - **Discord plugin failed to load in the frozen desktop app (`No module named
   'tools.discord_tools'`).** Migrating Discord to a plugin (#513) removed the only
   static import of `tools.discord_tools` from `tools/lg_tools.py`, so PyInstaller's

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -115,6 +115,22 @@ export function apiUrl(path: string) {
   return base ? `${base}${path.startsWith("/") ? path : `/${path}`}` : path;
 }
 
+/** True inside the desktop (Tauri/WKWebView) shell. WKWebView does NOT deliver a
+ * `text/event-stream` body through `fetch()` — neither via `body.getReader()` nor
+ * a buffered `clone().text()` (both come back empty) — so the streaming chat turn
+ * renders as a blank assistant bubble. In that environment we route the chat turn
+ * through the non-streaming `/api/chat` endpoint instead, which returns ordinary
+ * JSON that WKWebView handles fine (it's how the rest of the console already talks
+ * to the sidecar). Browsers keep the streaming `/a2a` path. */
+export function isDesktopWebview(): boolean {
+  try {
+    const { protocol, hostname } = window.location;
+    return protocol === "tauri:" || protocol === "file:" || hostname === "tauri.localhost";
+  } catch {
+    return false;
+  }
+}
+
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const headers = new Headers(options.headers);
   let body: BodyInit | undefined;
@@ -515,6 +531,42 @@ export const api = {
       onDone?: () => void;
     } = {},
   ) {
+    // Desktop (WKWebView) can't read a streaming SSE body via fetch (see
+    // isDesktopWebview) — the turn would render as a blank assistant bubble. Take
+    // the non-streaming `/api/chat` path: one request, full reply, render once.
+    // No token-by-token streaming or tool-call cards here, but the turn always
+    // shows. Browsers fall through to the streaming `/a2a` path below.
+    if (isDesktopWebview()) {
+      try {
+        const res = await fetch(apiUrl("/api/chat"), {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          signal: handlers.signal,
+          body: JSON.stringify({ message, session_id: sessionId }),
+        });
+        if (!res.ok) {
+          let detail = `${res.status} ${res.statusText}`;
+          try {
+            const p = (await res.json()) as { detail?: string };
+            if (p?.detail) detail = p.detail;
+          } catch {
+            /* keep status text */
+          }
+          handlers.onFailed?.(detail);
+          return;
+        }
+        const data = (await res.json()) as { response?: string };
+        const reply = (data.response || "").trim();
+        if (reply) handlers.onText?.(reply, false);
+        else handlers.onFailed?.("the turn returned no content");
+      } catch (err) {
+        handlers.onFailed?.(err instanceof Error ? err.message : String(err));
+      } finally {
+        handlers.onDone?.();
+      }
+      return;
+    }
+
     const rpcId = `web-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const response = await fetch(apiUrl("/a2a"), {
       method: "POST",


### PR DESCRIPTION
## Desktop chat showed a blank assistant reply (no response)

In the desktop app, sending a chat message produced an **empty assistant bubble** — the agent replied, but nothing rendered. Backend healthy throughout (`/a2a` streams the turn, `/api/chat` returns it); purely a webview rendering bug.

### Root cause
WKWebView (the Tauri shell) **doesn't deliver a `text/event-stream` body through `fetch()` at all** — neither `response.body.getReader()` nor a buffered `clone().text()` fallback surfaces the bytes. So the streaming `/a2a` turn parsed **zero frames** → blank reply → `onDone`.

### Fix
Detect the desktop shell (`isDesktopWebview()` — `tauri:` / `file:` / `tauri.localhost`) and route the chat turn through the **non-streaming `/api/chat`** endpoint: ordinary JSON, which WKWebView reads fine (it's how the rest of the console already talks to the sidecar). One request → full reply → rendered once via `onText`/`onDone`; `onFailed` surfaces errors. **Browsers keep the token-streaming `/a2a` path (with tool-call cards) unchanged.**

### How it was found / verified
Built the desktop app on the gina fork and drove a turn in the real window: the assistant rendered the reply (blank before the fix). Template-level webview bug; mirrors gina #20.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
