### PR TITLE
Fix two first-run setup bugs: plugin routes 404 + leaky validation error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **First-run setup left plugin routes unmounted until restart.** Plugin routers
+  (e.g. `POST /api/config/test-discord`, `GET /api/config/google/status`,
+  `POST /api/config/google/connect`) mount once at process init — but on a fresh
+  pre-setup boot the graph-build path returned early *before* loading plugins, so
+  nothing mounted, and completing setup via the wizard reloaded the graph without
+  mounting them. Result: a brand-new agent's **Connect Discord / Connect Google /
+  Test-connection buttons 404'd during first-run setup** until the app was
+  relaunched. Plugins are now loaded for their routes + surfaces even without a
+  compiled graph (they need no graph; they're how the wizard *configures* the
+  agent), so the routes are live from boot. Found by driving a fresh agent through
+  setup against a live server.
+- **Model-connection error leaked a token hash into the setup UI.** A bad-but-
+  well-formed API key made the gateway (LiteLLM) return a 401 whose body included
+  the masked key, an internal **token hash**, and table names — surfaced verbatim
+  in the wizard's "Test connection" error. The validator now keeps the actionable
+  cause (e.g. "Authentication Error, Invalid proxy server token passed") and
+  strips everything from the first secret-ish marker on, so no token/hash/internal
+  detail reaches the UI.
+
 ## [0.13.0] - 2026-06-04
 
 ### Docs

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -603,6 +603,18 @@ def validate_model_connection(
         detail = ""
     if not detail:
         detail = (resp.text or "")[:300]
+    # Sanitize: gateways (e.g. LiteLLM) dump the masked key, a token *hash*, and
+    # internal table names into auth errors — never echo those into the setup UI.
+    # Keep the leading human-readable cause, drop everything from the first
+    # secret-ish marker on, and cap the length.
+    import re as _re
+    detail = _re.split(
+        r"\s*(?:Received API Key|Key Hash|Unable to find token|Token=)",
+        detail, maxsplit=1,
+    )[0].strip().rstrip(".,")
+    detail = detail[:200]
+    if resp.status_code in (401, 403) and not detail:
+        detail = "authentication failed — check the API key"
     return False, f"HTTP {resp.status_code}: {detail}" if detail else f"HTTP {resp.status_code}"
 
 

--- a/server.py
+++ b/server.py
@@ -190,6 +190,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     global _workflow_registry
     global _mcp_clients, _mcp_tools, _mcp_meta
     global _plugin_tools, _plugin_skill_dirs, _plugin_meta
+    global _plugin_routers, _plugin_surfaces
 
     from graph.config import LangGraphConfig
     from graph.config_io import (
@@ -235,8 +236,21 @@ def _init_langgraph_agent(headless_setup: bool = False):
         else:
             _graph = None
             _knowledge_store = None
+            # Load plugins for their ROUTES + SURFACES even without a compiled
+            # graph. The Connect Discord / Connect Google / Test-connection routes
+            # are how the setup wizard *configures* the agent, so they must be
+            # mounted during first-run setup — not only after a restart. (Without
+            # this the first-run wizard's Connect/Test buttons 404 until the app is
+            # relaunched.) register() needs no graph; the tools/subagents that feed
+            # the graph are (re)loaded when setup completes and the graph builds.
+            _pre = _build_plugins(_graph_config)
+            _plugin_routers, _plugin_surfaces, _plugin_meta = (
+                _pre.routers, _pre.surfaces, _pre.meta,
+            )
+            _register_plugin_subagents(_pre.subagents)
             log.info(
-                "Setup wizard has not been completed — graph not compiled. "
+                "Setup wizard has not been completed — graph not compiled "
+                "(plugin routes/surfaces still mounted). "
                 "Open the UI to finish setup (or run headless: --ui none / --setup).",
             )
             return
@@ -274,7 +288,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # here and consumed once by _main (mount) + the startup hook (start) — they
     # don't hot-reload. Subagents register into SUBAGENT_REGISTRY before the graph
     # build below so the first compile (and every reload) can delegate to them.
-    global _plugin_routers, _plugin_surfaces
+    # (`global _plugin_routers, _plugin_surfaces` is declared at the top of the fn.)
     _plugin_routers, _plugin_surfaces = _plugins.routers, _plugins.surfaces
     _register_plugin_subagents(_plugins.subagents)
 

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -1,0 +1,71 @@
+"""validate_model_connection — auth-error sanitization.
+
+A gateway (e.g. LiteLLM) dumps the masked key, a token *hash*, and internal
+table names into a 401 body. That must never reach the setup UI verbatim — the
+error is shown to the operator and echoing a token/hash is a leak + useless.
+"""
+
+from __future__ import annotations
+
+import contextlib
+
+from graph import config_io
+
+
+class _FakeResp:
+    def __init__(self, status_code: int, payload: dict | None = None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+def test_auth_error_strips_token_hash_and_key(monkeypatch):
+    # The exact leaky shape the proto-labs LiteLLM gateway returns for a bad key.
+    leaky = (
+        "Authentication Error, Invalid proxy server token passed. "
+        "Received API Key = sk-...-xxx, Key Hash (Token) =b4cbf50b702d5431ff6, "
+        "Unable to find token in cache or `LiteLLM_VerificationTokenTable`"
+    )
+    import httpx
+    monkeypatch.setattr(httpx, "Client", _client_returning(_FakeResp(401, {"error": {"message": leaky}})))
+
+    ok, err = config_io.validate_model_connection("https://gw.example/v1", "sk-bogus", "m")
+    assert ok is False
+    # The actionable cause survives…
+    assert "Authentication Error" in err
+    # …but nothing secret/internal leaks.
+    for leak in ("Key Hash", "sk-...-xxx", "LiteLLM_VerificationTokenTable", "Unable to find token"):
+        assert leak not in err, f"leaked {leak!r} in {err!r}"
+
+
+def test_clean_gateway_message_passes_through(monkeypatch):
+    import httpx
+    monkeypatch.setattr(
+        httpx, "Client",
+        _client_returning(_FakeResp(400, {"error": {"message": "expected to start with 'sk-'"}})),
+    )
+    ok, err = config_io.validate_model_connection("https://gw.example/v1", "bad", "m")
+    assert ok is False
+    assert "expected to start with 'sk-'" in err
+
+
+def _client_returning(resp: _FakeResp):
+    class _FakeClient:
+        def __init__(self, *a, **k):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, *a, **k):
+            return resp
+
+    return _FakeClient


### PR DESCRIPTION
Found while shaking out the agent-setup flow on a **fresh** agent (clean config → wizard → finish), driving the real server.

### Bug 1 — plugin routes 404 after first-run setup (the bigger one)
Plugin routers (`test-discord`, `google/status`, `google/connect`) mount once in `_main` at init. On a fresh **pre-setup** boot the graph-build path returns early *before* loading plugins, so nothing mounts; finishing setup via the wizard reloads the graph but doesn't mount them. Net: a brand-new agent's **Connect Discord / Connect Google / Test-connection buttons 404 during first-run setup** until the app is relaunched.

**Fix:** load plugins for their routes + surfaces even without a compiled graph (`register()` needs no graph, and these routes are *how the wizard configures the agent*). Verified live — `test-discord` works pre-setup **and** immediately after runtime finish-setup, no restart; graph still compiles, both plugins load.

### Bug 2 — model-validation error leaked a token hash into the setup UI
A bad-but-well-formed key made the LiteLLM gateway return a 401 whose message embedded the masked key, an internal **token hash** (`Key Hash (Token) =b4cb…`), and table names (`LiteLLM_VerificationTokenTable`) — shown verbatim in the wizard's Test-connection error. `validate_model_connection` now keeps the actionable cause ("Authentication Error, Invalid proxy server token passed") and strips everything from the first secret-ish marker on. Regression test added.

Both are template-level (`server.py` + `graph/config_io.py`) → flow to all forks. Full suite green (945).

🤖 Generated with [Claude Code](https://claude.com/claude-code)