### PR TITLE
chore: release v0.13.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.13.1] - 2026-06-04
+
 ### Fixed
 - **First-run setup left plugin routes unmounted until restart.** Plugin routers
   (e.g. `POST /api/config/test-discord`, `GET /api/config/google/status`,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.13.0"
+version = "0.13.1"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
Automated version bump to `v0.13.1`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.13.1 -m 'Release v0.13.1' && git push origin v0.13.1`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).