### PR TITLE
Fix: Discord Test-connection ignored the token (PEP 563 + function-local body model)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Discord "Test connection" ignored the entered token** (always reported "bot
+  token is empty", even for a valid token). The discord plugin route's request
+  model was a *function-local* Pydantic class, but the plugin module uses
+  `from __future__ import annotations` (PEP 563) — so the annotation is a string
+  FastAPI resolves via `get_type_hints()` against *module globals*, where the
+  local class doesn't exist; FastAPI couldn't build the body model and silently
+  dropped the body. Moved `DiscordProbe` to module level. (Lesson for plugin
+  routes: with PEP 563, body models must be module-level.) Regression test added.
+
 ## [0.13.1] - 2026-06-04
 
 ### Fixed

--- a/plugins/discord/__init__.py
+++ b/plugins/discord/__init__.py
@@ -16,7 +16,19 @@ from __future__ import annotations
 import logging
 import os
 
+from pydantic import BaseModel
+
 log = logging.getLogger("protoagent.plugins.discord")
+
+
+class DiscordProbe(BaseModel):
+    """Body for the Test-connection route. **Must be module-level**: this file
+    uses `from __future__ import annotations` (PEP 563), so a function-local
+    model can't be resolved by FastAPI's `get_type_hints()` (which looks in
+    module globals) — the body would be silently ignored and every token read
+    as empty."""
+
+    bot_token: str = ""
 
 # Holds the running gateway task across start/stop/reload.
 _state: dict = {"task": None}
@@ -64,12 +76,8 @@ def _build_router(registry):
     """`POST /api/config/test-discord` — verify a bot token (the console's Test
     button). Mounted at the existing path (prefix="") so the UI is unchanged."""
     from fastapi import APIRouter
-    from pydantic import BaseModel
 
     router = APIRouter()
-
-    class DiscordProbe(BaseModel):
-        bot_token: str = ""
 
     @router.post("/api/config/test-discord")
     async def _test_discord(req: DiscordProbe | None = None):

--- a/tests/test_discord_plugin_route.py
+++ b/tests/test_discord_plugin_route.py
@@ -1,0 +1,54 @@
+"""The discord plugin's Test-connection route must read the request body.
+
+Regression for a PEP 563 footgun: the plugin module uses
+`from __future__ import annotations`, so a *function-local* Pydantic body model
+can't be resolved by FastAPI's `get_type_hints()` (module-globals only) — the
+body is silently ignored and every token reads as empty, breaking "Test
+connection" even for a valid token. The model must stay MODULE-LEVEL.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import types
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _load_discord_plugin():
+    from graph.config_io import _BUNDLE_CONFIG_DIR
+
+    path = _BUNDLE_CONFIG_DIR.parent / "plugins" / "discord" / "__init__.py"
+    spec = importlib.util.spec_from_file_location(
+        "discord_plugin_under_test", str(path),
+        submodule_search_locations=[str(path.parent)],
+    )
+    m = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(m)
+    return m
+
+
+def test_test_discord_route_reads_the_token_from_the_body(monkeypatch):
+    m = _load_discord_plugin()
+
+    # Echo the token validate_token actually receives.
+    import surfaces.discord as sd
+
+    async def _echo(token):
+        return (False, None, f"RECEIVED={token!r}")
+
+    monkeypatch.setattr(sd, "validate_token", _echo)
+
+    reg = types.SimpleNamespace(config={}, host=types.SimpleNamespace(config=lambda: None))
+    app = FastAPI()
+    app.include_router(m._build_router(reg))
+    client = TestClient(app)
+
+    r = client.post("/api/config/test-discord", json={"bot_token": "TOK123"})
+    assert r.status_code == 200
+    # The bug symptom: a non-empty token arriving as '' (body ignored).
+    assert "TOK123" in r.json()["error"], "route did not read bot_token from the body"
+
+    r2 = client.post("/api/config/test-discord", json={"bot_token": ""})
+    assert "''" in r2.json()["error"]  # empty still handled


### PR DESCRIPTION
Found smoke-testing gina's setup. The console's **Discord "Test connection" button always reported "bot token is empty"** — even for a valid token — so it could never verify a token.

**Root cause:** the discord plugin route's body model `DiscordProbe` was a *function-local* class, but the plugin module uses `from __future__ import annotations` (PEP 563). The annotation `req: DiscordProbe | None` is therefore the **string** `"DiscordProbe | None"`, which FastAPI resolves via `get_type_hints()` against the module's **globals** — where the local class doesn't exist. Resolution fails, FastAPI can't build the request-body model, and **silently ignores the body** → `req` is None → token reads as empty. (`test-model` works because `server.py` has no PEP 563 import, so its function-local model is a live type object.)

**Fix:** move `DiscordProbe` to module level. Verified against the *real* plugin router with TestClient — the token is now read from the body, empty still handled. Regression test added. Google plugin has no body-taking route → unaffected.

Template bug from the discord migration (#513) → flows to all forks. Suite green (946).

🤖 Generated with [Claude Code](https://claude.com/claude-code)