### PR TITLE
fix(plugins): support multi-module plugins with relative imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Plugins: multi-module support.** The plugin loader now imports a plugin's
+  `__init__.py` as a package — registered in `sys.modules` before exec with a
+  sanitized module name — so a plugin can have sibling modules and use relative
+  imports (`from .tools import …`). Previously a hyphenated plugin id produced an
+  illegal module name and the relative import failed at load. Regression test added.
 - **Discord "Test connection" ignored the entered token** (always reported "bot
   token is empty", even for a valid token). The discord plugin route's request
   model was a *function-local* Pydantic class, but the plugin module uses

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 import importlib.util
 import logging
 import os
+import re
+import sys
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -60,19 +62,40 @@ def _entry_file(manifest: PluginManifest) -> Path | None:
     return None
 
 
-def _import_register(manifest: PluginManifest):
-    """Import a plugin's entry module and return its ``register`` callable."""
-    entry = _entry_file(manifest)
-    if entry is None:
-        raise RuntimeError("no entry module (expected __init__.py or plugin.py)")
-    mod_name = f"protoagent_plugin_{manifest.id}"
+def _plugin_module_name(plugin_id: str) -> str:
+    """A valid Python module name for a plugin id. Non-identifier chars (e.g. the
+    hyphen in ``finance-data``) become ``_`` — a hyphen in the module name breaks
+    the relative-import machinery."""
+    return "protoagent_plugin_" + re.sub(r"\W", "_", plugin_id)
+
+
+def _load_plugin_module(manifest: PluginManifest, entry: Path):
+    """Import a plugin's entry ``__init__.py`` as a **package** so it can have
+    sibling modules and use relative imports (``from .tools import …``). The
+    module is registered in ``sys.modules`` BEFORE exec — relative imports resolve
+    the parent package there — and the name is sanitized to a valid identifier."""
+    mod_name = _plugin_module_name(manifest.id)
     spec = importlib.util.spec_from_file_location(
         mod_name, str(entry), submodule_search_locations=[str(manifest.path)]
     )
     if spec is None or spec.loader is None:
         raise RuntimeError(f"could not create import spec for {entry}")
     module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
+    sys.modules[mod_name] = module  # so `from .x import y` finds the parent
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(mod_name, None)
+        raise
+    return module
+
+
+def _import_register(manifest: PluginManifest):
+    """Import a plugin's entry module and return its ``register`` callable."""
+    entry = _entry_file(manifest)
+    if entry is None:
+        raise RuntimeError("no entry module (expected __init__.py or plugin.py)")
+    module = _load_plugin_module(manifest, entry)
     register = getattr(module, "register", None)
     if not callable(register):
         raise RuntimeError("plugin module has no callable register(registry)")
@@ -97,14 +120,7 @@ def run_plugin_mcp_main(plugin_id: str) -> None:
         entry = _entry_file(manifest)
         if entry is None:
             raise RuntimeError(f"plugin {plugin_id!r} has no entry module")
-        mod_name = f"protoagent_plugin_{manifest.id}"
-        spec = importlib.util.spec_from_file_location(
-            mod_name, str(entry), submodule_search_locations=[str(manifest.path)]
-        )
-        if spec is None or spec.loader is None:
-            raise RuntimeError(f"could not import plugin {plugin_id!r}")
-        module = importlib.util.module_from_spec(spec)
-        spec.loader.exec_module(module)
+        module = _load_plugin_module(manifest, entry)
         mcp_main = getattr(module, "mcp_main", None)
         if not callable(mcp_main):
             raise RuntimeError(f"plugin {plugin_id!r} has no mcp_main()")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -92,6 +92,35 @@ def test_enabled_via_manifest(tmp_path, monkeypatch) -> None:
     assert [t.name for t in res.tools] == ["m_tool"]
 
 
+def test_multi_module_plugin_with_relative_import(tmp_path, monkeypatch) -> None:
+    """A plugin whose id has a hyphen AND whose __init__.py uses a relative import
+    (``from .tools import …``) must load. Regression: the loader used the raw id as
+    the module name (a hyphen is illegal) and didn't register it in sys.modules, so
+    the relative import failed with "No module named protoagent_plugin_<id>".
+    """
+    root = tmp_path / "plugins"
+    d = root / "multi-mod"
+    d.mkdir(parents=True)
+    (d / "protoagent.plugin.yaml").write_text(
+        "id: multi-mod\nname: Multi mod\nversion: 0.1.0\nenabled: true\n", encoding="utf-8")
+    (d / "tools.py").write_text(
+        "from langchain_core.tools import tool\n"
+        "@tool\n"
+        "def mm_tool() -> str:\n"
+        "    '''sibling-module tool'''\n"
+        "    return 'ok'\n"
+        "def get_tools():\n"
+        "    return [mm_tool]\n", encoding="utf-8")
+    (d / "__init__.py").write_text(
+        "from .tools import get_tools\n"
+        "def register(registry):\n"
+        "    registry.register_tools(get_tools())\n", encoding="utf-8")
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg())
+    assert [t.name for t in res.tools] == ["mm_tool"]
+    assert res.meta[0]["loaded"] is True
+
+
 def test_tool_collision_skipped(tmp_path, monkeypatch) -> None:
     root = tmp_path / "plugins"
     _make_plugin(root, "c", enabled=True, tool="current_time")  # core tool name


### PR DESCRIPTION
## What

The plugin loader now imports a plugin's `__init__.py` **as a package** so a plugin can span multiple files and use relative imports (`from .tools import …`).

## Why

Two latent bugs in the import machinery:

1. **Hyphenated ids → illegal module name.** The loader used `f"protoagent_plugin_{manifest.id}"` directly, so `finance-data` became `protoagent_plugin_finance-data` — not a valid Python module name.
2. **Parent not in `sys.modules`.** Even with a valid id, the module wasn't registered in `sys.modules` before `exec_module`, so a relative import inside `__init__.py` resolved its parent package to nothing and failed.

Net effect: **any plugin split across more than one file silently failed to load** with `No module named protoagent_plugin_<id>`. Single-file plugins were unaffected, which is why it went unnoticed.

## How

A shared `_load_plugin_module(manifest, entry)`:
- `_plugin_module_name()` sanitizes the id to a valid identifier (`re.sub(r"\W", "_", …)`).
- Registers the module in `sys.modules` **before** `exec_module` (so relative imports find the parent), popping it back off on failure.
- Used by both `_import_register` (normal load) and `run_plugin_mcp_main` (the `--mcp-plugin` frozen-binary entrypoint), so the two paths can't drift.

## Provenance

Surfaced while building protoTrader's multi-file finance plugins (`finance-data`, `backtest`, `broker`, …). Porting the fix back to the template so every fork benefits.

## Test

`tests/test_plugins.py::test_multi_module_plugin_with_relative_import` — a hyphenated plugin whose `__init__.py` does `from .tools import get_tools` loads and registers its tool. Verified it **fails on the old loader** (`No module named 'protoagent_plugin_multi-mod'`) and **passes on the fix**. Full `test_plugins.py` green (17).

🤖 Generated with [Claude Code](https://claude.com/claude-code)