### PR TITLE
fix(evals): speak the A2A 1.0 wire shape (eval harness was on retired 0.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Eval harness spoke the retired A2A 0.3 wire shape — every case failed.** The
+  A2A 1.0 migration (ADR 0014) moved the server to `a2a-sdk` (≥1.1), which serves
+  proto method names (`SendMessage`/`GetTask`/`SendStreamingMessage`/`CancelTask`),
+  requires an `A2A-Version: 1.0` request header (a missing header is read as 0.3,
+  so the 1.0 methods 404 with `-32601`), and emits untyped parts (`{"text": …}`,
+  no `kind`) with `TASK_STATE_*` states. `evals/client.py` + `evals/runner.py`
+  were left on the 0.3 shape (`message/send`, `role: "user"`, `{"kind": "text"}`,
+  no version header), so `python -m evals.runner` failed *every* case with
+  "method not found". Migrated the eval client/runner to the 1.0 wire shape
+  (header + proto method names + `ROLE_USER` + untyped parts + `TASK_STATE_*`
+  normalization + the streaming `statusUpdate`/`artifactUpdate` oneof frames).
+  Regression test (`tests/test_eval_client_a2a_1_0.py`) drives the real client
+  against an in-process `a2a-sdk` app and pins that the legacy shape is rejected.
 - **Plugins: multi-module support.** The plugin loader now imports a plugin's
   `__init__.py` as a package — registered in `sys.modules` before exec with a
   sanitized module name — so a plugin can have sibling modules and use relative

--- a/evals/client.py
+++ b/evals/client.py
@@ -4,11 +4,18 @@ Drives the running agent over the same JSON-RPC + SSE surface that
 real A2A callers use:
 
 - ``agent_card()`` — GET ``/.well-known/agent-card.json``
-- ``ask()``        — ``message/send`` + ``tasks/get`` poll
-- ``stream()``     — ``message/stream`` SSE
-- ``cancel()``     — ``tasks/cancel``
+- ``ask()``        — ``SendMessage`` + ``GetTask`` poll
+- ``stream()``     — ``SendStreamingMessage`` SSE
+- ``cancel()``     — ``CancelTask``
 
 Returns structured ``TaskResult`` objects the runner asserts against.
+
+This speaks the **A2A 1.0** wire shape that ``a2a-sdk`` (≥1.1) serves:
+proto method names (``SendMessage`` etc.), an ``A2A-Version: 1.0``
+header (without it the SDK falls back to 0.3 and rejects these
+methods), ``role: "ROLE_USER"``, and untyped ``parts: [{"text": …}]``
+(no ``kind`` discriminator). See ``tests/test_a2a_handler.py`` for the
+canonical request/response shapes.
 
 Auth picks up both surfaces the template exposes (see ``server.py``):
 
@@ -80,7 +87,9 @@ class AgentClient:
         env_bearer, env_api_key = _resolve_auth_env()
         token = bearer if bearer is not None else env_bearer
         x_api = api_key if api_key is not None else env_api_key
-        self.headers = {"Content-Type": "application/json"}
+        # A2A-Version: 1.0 is mandatory — a2a-sdk's dispatcher treats a missing
+        # header as 0.3 and then 404s the 1.0 proto methods (SendMessage, …).
+        self.headers = {"Content-Type": "application/json", "A2A-Version": "1.0"}
         if token:
             self.headers["Authorization"] = f"Bearer {token}"
         if x_api:
@@ -141,8 +150,8 @@ class AgentClient:
         mid = str(uuid.uuid4())
         params: dict = {
             "message": {
-                "role": "user",
-                "parts": [{"kind": "text", "text": prompt}],
+                "role": "ROLE_USER",
+                "parts": [{"text": prompt}],
                 "messageId": mid,
             }
         }
@@ -151,17 +160,35 @@ class AgentClient:
         payload = {
             "jsonrpc": "2.0",
             "id": mid,
-            "method": "message/send",
+            "method": "SendMessage",
             "params": params,
         }
         start = time.time()
+
+        def _finish(res: dict, task_id: str) -> TaskResult:
+            text, usage = _extract(res)
+            return TaskResult(
+                task_id=task_id,
+                state=_norm_state((res.get("status") or {}).get("state", "")),
+                text=text,
+                artifacts=res.get("artifacts", []),
+                usage=usage,
+                duration_ms=int((time.time() - start) * 1000),
+            )
+
         async with httpx.AsyncClient(timeout=30) as client:
             r = await client.post(f"{self.base_url}/a2a", headers=self.headers, json=payload)
             r.raise_for_status()
             resp = r.json()
             if "error" in resp:
                 return TaskResult(task_id="", state="failed", error=str(resp["error"]))
-            task_id = resp.get("result", {}).get("id", "")
+            # SendMessage wraps the task in result.task (vs GetTask, which returns
+            # the task directly at result). Non-streaming SendMessage blocks until
+            # terminal, so the first response is usually already complete.
+            task = resp.get("result", {}).get("task", {})
+            task_id = task.get("id", "")
+            if _is_terminal((task.get("status") or {}).get("state", "")):
+                return _finish(task, task_id)
 
             deadline = start + timeout_s
             while time.time() < deadline:
@@ -172,36 +199,30 @@ class AgentClient:
                     json={
                         "jsonrpc": "2.0",
                         "id": "p",
-                        "method": "tasks/get",
+                        "method": "GetTask",
                         "params": {"id": task_id},
                     },
                 )
                 poll.raise_for_status()
                 res = poll.json().get("result", {})
-                state = (res.get("status") or {}).get("state", "")
-                if state in ("completed", "failed", "canceled"):
-                    text, usage = _extract(res)
-                    return TaskResult(
-                        task_id=task_id,
-                        state=state,
-                        text=text,
-                        artifacts=res.get("artifacts", []),
-                        usage=usage,
-                        duration_ms=int((time.time() - start) * 1000),
-                    )
+                if _is_terminal((res.get("status") or {}).get("state", "")):
+                    return _finish(res, task_id)
             return TaskResult(
                 task_id=task_id, state="timeout",
                 duration_ms=int((time.time() - start) * 1000),
             )
 
-    # ── message/stream (SSE) ────────────────────────────────────────────────
+    # ── SendStreamingMessage (SSE) ──────────────────────────────────────────
 
     async def stream(self, prompt: str, *, timeout_s: int = 90, context_id: str | None = None) -> tuple[list[dict], TaskResult | None]:
         """Stream a turn over SSE. Returns (event_log, final TaskResult).
 
-        Each event is a dict shaped ``{kind, result}``. Use this to assert
-        on the streaming protocol itself (status-update sequence, final
-        flag, artifact chunks). Most cases should use ``ask()`` instead.
+        Each SSE ``data:`` frame is an A2A 1.0 oneof under ``result`` — one of
+        ``task`` (initial snapshot), ``statusUpdate``, ``artifactUpdate``, or
+        ``message``. We log each as ``{kind, result}`` (``kind`` is the oneof
+        field name), accumulate artifact parts, and finalize when a status
+        frame is ``final`` or terminal. Use this to assert on the streaming
+        protocol itself; most cases should use ``ask()`` instead.
 
         ``context_id`` pins the A2A contextId (= session_id) so the turn
         runs in a known session (e.g. one a goal was set on).
@@ -209,8 +230,8 @@ class AgentClient:
         mid = str(uuid.uuid4())
         params: dict = {
             "message": {
-                "role": "user",
-                "parts": [{"kind": "text", "text": prompt}],
+                "role": "ROLE_USER",
+                "parts": [{"text": prompt}],
                 "messageId": mid,
             }
         }
@@ -219,11 +240,13 @@ class AgentClient:
         payload = {
             "jsonrpc": "2.0",
             "id": mid,
-            "method": "message/stream",
+            "method": "SendStreamingMessage",
             "params": params,
         }
         events: list[dict] = []
         final: TaskResult | None = None
+        artifacts: list[dict] = []  # accumulated across artifactUpdate frames
+        task_id = ""
         start = time.time()
         async with httpx.AsyncClient(timeout=timeout_s) as client:
             async with client.stream(
@@ -238,24 +261,42 @@ class AgentClient:
                 async for line in r.aiter_lines():
                     if not line or line.startswith(":"):
                         continue
-                    if line.startswith("data:"):
-                        raw = line[5:].strip()
-                        if not raw:
-                            continue
-                        try:
-                            data = json.loads(raw)
-                        except json.JSONDecodeError:
-                            events.append({"kind": "raw", "raw": raw})
-                            continue
-                        result = (data.get("result") or {})
-                        kind = result.get("kind", "?")
-                        events.append({"kind": kind, "result": result})
-                        if kind in ("status-update", "task") and result.get("final"):
-                            text, usage = _extract(result)
+                    if not line.startswith("data:"):
+                        continue
+                    raw = line[5:].strip()
+                    if not raw:
+                        continue
+                    try:
+                        data = json.loads(raw)
+                    except json.JSONDecodeError:
+                        events.append({"kind": "raw", "raw": raw})
+                        continue
+                    result = data.get("result") or {}
+                    kind = next(iter(result), "?") if result else "?"
+                    payload_obj = result.get(kind, {}) if kind != "?" else {}
+                    events.append({"kind": kind, "result": payload_obj})
+
+                    if kind == "task":
+                        task_id = payload_obj.get("id", "") or task_id
+                        artifacts = payload_obj.get("artifacts") or artifacts
+                    elif kind == "artifactUpdate":
+                        task_id = payload_obj.get("taskId", "") or task_id
+                        art = payload_obj.get("artifact")
+                        if art:
+                            artifacts.append(art)
+                    elif kind == "statusUpdate":
+                        task_id = payload_obj.get("taskId", "") or task_id
+                        status = payload_obj.get("status") or {}
+                        state = status.get("state", "")
+                        if payload_obj.get("final") or _is_terminal(state):
+                            text, usage = _extract(
+                                {"artifacts": artifacts, "status": status}
+                            )
                             final = TaskResult(
-                                task_id=result.get("taskId") or result.get("id", ""),
-                                state=(result.get("status") or {}).get("state", "unknown"),
+                                task_id=task_id,
+                                state=_norm_state(state) or "unknown",
                                 text=text,
+                                artifacts=artifacts,
                                 usage=usage,
                                 duration_ms=int((time.time() - start) * 1000),
                             )
@@ -281,7 +322,7 @@ class AgentClient:
             r.raise_for_status()
             return r.json()
 
-    # ── tasks/cancel ────────────────────────────────────────────────────────
+    # ── CancelTask ──────────────────────────────────────────────────────────
 
     async def cancel(self, task_id: str) -> dict:
         async with httpx.AsyncClient(timeout=10) as client:
@@ -291,30 +332,50 @@ class AgentClient:
                 json={
                     "jsonrpc": "2.0",
                     "id": "c",
-                    "method": "tasks/cancel",
+                    "method": "CancelTask",
                     "params": {"id": task_id},
                 },
             )
             return r.json()
 
 
+def _norm_state(state: str) -> str:
+    """``TASK_STATE_COMPLETED`` → ``completed``; pass through already-lowercased
+    legacy states unchanged. The runner asserts on the lowercase names."""
+    if state.startswith("TASK_STATE_"):
+        return state[len("TASK_STATE_"):].lower()
+    return state
+
+
+def _is_terminal(state: str) -> bool:
+    """A task in one of these states won't change on further polling. Mirrors
+    ``tests/test_a2a_handler.py::_poll_terminal`` (input_required parks the
+    task — it's terminal for polling purposes)."""
+    return _norm_state(state) in ("completed", "failed", "canceled", "input_required")
+
+
 def _extract(result: dict) -> tuple[str, dict]:
-    """Pull text + cost data out of an A2A result envelope."""
+    """Pull text + cost data out of an A2A result envelope.
+
+    Tolerant of both the A2A 1.0 part shape (untyped — a part carries a
+    ``text`` or ``data`` field directly) and the legacy 0.x shape (parts
+    tagged with ``kind``)."""
     text_parts: list[str] = []
     usage: dict = {}
-    artifacts = result.get("artifacts") or []
-    for art in artifacts:
-        for p in art.get("parts", []):
-            if p.get("kind") == "text" and p.get("text"):
+
+    def _scan(parts: list[dict] | None) -> None:
+        nonlocal usage
+        for p in parts or []:
+            if p.get("text"):
                 text_parts.append(p["text"])
-            elif p.get("kind") == "data" and isinstance(p.get("data"), dict):
-                if "usage" in p["data"]:
-                    usage = dict(p["data"]["usage"])
-                    if "durationMs" in p["data"]:
-                        usage["durationMs"] = p["data"]["durationMs"]
+            elif isinstance(p.get("data"), dict) and "usage" in p["data"]:
+                usage = dict(p["data"]["usage"])
+                if "durationMs" in p["data"]:
+                    usage["durationMs"] = p["data"]["durationMs"]
+
+    for art in result.get("artifacts") or []:
+        _scan(art.get("parts"))
     status = result.get("status") or {}
     msg = status.get("message") or {}
-    for p in msg.get("parts") or []:
-        if p.get("kind") == "text" and p.get("text"):
-            text_parts.append(p["text"])
+    _scan(msg.get("parts"))
     return "\n".join(text_parts).strip(), usage

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -105,17 +105,18 @@ async def _run_auth_check(client: AgentClient, case: dict) -> CaseResult:
     bad = case.get("bad_token", "")
     headers = {
         "Content-Type": "application/json",
+        "A2A-Version": "1.0",
         "Authorization": f"Bearer {bad}",
     }
     headers.update(case.get("headers") or {})
     payload = {
         "jsonrpc": "2.0",
         "id": "auth-check",
-        "method": "message/send",
+        "method": "SendMessage",
         "params": {
             "message": {
-                "role": "user",
-                "parts": [{"kind": "text", "text": "ping"}],
+                "role": "ROLE_USER",
+                "parts": [{"text": "ping"}],
                 "messageId": "auth-check",
             }
         },
@@ -136,15 +137,15 @@ async def _run_auth_check(client: AgentClient, case: dict) -> CaseResult:
 
 
 async def _run_ask(client: AgentClient, case: dict) -> CaseResult:
-    """Send via ``message/send`` + poll. Teardown always runs."""
+    """Send via ``SendMessage`` + poll. Teardown always runs."""
     return await _run_prompt_case(client, case, streaming=False)
 
 
 async def _run_stream(client: AgentClient, case: dict) -> CaseResult:
-    """Send via ``message/stream`` + SSE. Same assertion shape as ``ask``,
-    plus an optional ``expected_event_kinds`` list that asserts the SSE
-    stream surfaced the named event kinds (``status-update``, ``task``,
-    etc.) at least once."""
+    """Send via ``SendStreamingMessage`` + SSE. Same assertion shape as
+    ``ask``, plus an optional ``expected_event_kinds`` list that asserts the
+    SSE stream surfaced the named event kinds (``statusUpdate``,
+    ``artifactUpdate``, ``task``, …) at least once."""
     return await _run_prompt_case(client, case, streaming=True)
 
 

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -21,11 +21,11 @@
     "id": "streaming_status_updates",
     "category": "a2a-protocol",
     "kind": "stream",
-    "name": "message/stream surfaces status-update events ending in final=true",
+    "name": "SendStreamingMessage surfaces statusUpdate events ending in final=true",
     "prompt": "Hi.",
     "expected_tools": [],
     "expected_patterns": [],
-    "expected_event_kinds": ["status-update"]
+    "expected_event_kinds": ["statusUpdate"]
   },
 
   {

--- a/tests/test_eval_client_a2a_1_0.py
+++ b/tests/test_eval_client_a2a_1_0.py
@@ -1,0 +1,124 @@
+"""Regression: the eval A2A client speaks the A2A 1.0 wire shape.
+
+The A2A 1.0 migration (ADR 0014) swapped the hand-rolled handler for
+``a2a-sdk`` (≥1.1), which serves **proto** method names (``SendMessage`` /
+``GetTask`` / ``SendStreamingMessage`` / ``CancelTask``), gates every method on
+an ``A2A-Version: 1.0`` request header (a missing header is read as 0.3 and the
+1.0 methods 404 with ``-32601``), and emits untyped parts (``{"text": …}`` —
+no ``kind`` discriminator) with ``TASK_STATE_*`` state names.
+
+``evals/client.py`` was left on the 0.3 shape (``message/send`` + ``role:
+"user"`` + ``{"kind": "text"}`` + no version header) and so failed *every* eval
+case against a current server. These tests drive the real ``AgentClient``
+against an in-process ``a2a-sdk`` app: a wrong method/role/header surfaces as
+``-32601`` → ``state="failed"``, so a green round-trip is itself the assertion
+that the client speaks 1.0. The companion negative case pins why the header is
+load-bearing.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from a2a.server.request_handlers import DefaultRequestHandler
+from a2a.server.routes.agent_card_routes import create_agent_card_routes
+from a2a.server.routes.fastapi_routes import add_a2a_routes_to_fastapi
+from a2a.server.routes.jsonrpc_routes import create_jsonrpc_routes
+from a2a.server.tasks import InMemoryPushNotificationConfigStore, InMemoryTaskStore
+from a2a.types import AgentSkill
+from fastapi import FastAPI
+
+import protolabs_a2a as pa
+import evals.client as ec
+from a2a_executor import ProtoAgentExecutor, set_terminal_hook
+
+
+async def _hello_stream(text, ctx, *, resume=False, caller_trace=None):
+    """A minimal lead stream: some text + a usage frame → terminal."""
+    yield ("text", "hello world")
+    yield ("usage", {"input_tokens": 10, "output_tokens": 5, "cost_usd": 0.001})
+    yield ("done", "hello world")
+
+
+def _build_app(stream_fn) -> FastAPI:
+    card = pa.build_agent_card(
+        name="test", description="d", url="http://test/a2a", version="0.0.0",
+        skills=[AgentSkill(id="chat", name="Chat", description="c", tags=["t"])],
+        bearer=False,
+    )
+    handler = DefaultRequestHandler(
+        agent_executor=ProtoAgentExecutor(stream_fn),
+        task_store=InMemoryTaskStore(),
+        agent_card=card,
+        push_config_store=InMemoryPushNotificationConfigStore(),
+    )
+    app = FastAPI()
+    add_a2a_routes_to_fastapi(
+        app,
+        agent_card_routes=create_agent_card_routes(card),
+        jsonrpc_routes=create_jsonrpc_routes(handler, rpc_url="/a2a"),
+    )
+    return app
+
+
+@pytest.fixture(autouse=True)
+def _no_terminal_hook():
+    set_terminal_hook(None)
+    yield
+    set_terminal_hook(None)
+
+
+@pytest.fixture
+def routed_client(monkeypatch):
+    """An ``AgentClient`` whose httpx calls route to an in-process a2a-sdk app."""
+    app = _build_app(_hello_stream)
+    orig = ec.httpx.AsyncClient
+
+    def _patched(*a, **kw):
+        kw["transport"] = httpx.ASGITransport(app=app)
+        kw.setdefault("base_url", "http://test")
+        return orig(*a, **kw)
+
+    monkeypatch.setattr(ec.httpx, "AsyncClient", _patched)
+    return ec.AgentClient(base_url="http://test"), app
+
+
+def test_client_sets_the_version_header():
+    # The single omission that 404'd every eval case against a 1.1 server.
+    assert ec.AgentClient(base_url="http://test").headers["A2A-Version"] == "1.0"
+
+
+@pytest.mark.asyncio
+async def test_ask_round_trips_against_a2a_1_0(routed_client):
+    client, _ = routed_client
+    r = await client.ask("hi", timeout_s=5)
+    assert r.state == "completed"          # 0.3 method/role → -32601 → "failed"
+    assert r.text == "hello world"         # untyped {"text": …} part parsed
+    assert r.usage.get("input_tokens") == 10  # cost-v1 DataPart parsed
+
+
+@pytest.mark.asyncio
+async def test_stream_round_trips_against_a2a_1_0(routed_client):
+    client, _ = routed_client
+    events, final = await client.stream("hi", timeout_s=5)
+    kinds = {e["kind"] for e in events}
+    # 1.0 SSE frames are oneof field names, not 0.3's hyphenated kinds.
+    assert "statusUpdate" in kinds
+    assert final is not None and final.state == "completed"
+    assert final.text == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_legacy_0_3_shape_is_rejected(routed_client):
+    """Pins the contract: the old ``message/send`` (no version header) 404s, so
+    the migration above is load-bearing, not cosmetic."""
+    _, app = routed_client
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5
+    ) as c:
+        r = await c.post("/a2a", json={
+            "jsonrpc": "2.0", "id": "x", "method": "message/send",
+            "params": {"message": {
+                "role": "user", "parts": [{"kind": "text", "text": "hi"}], "messageId": "m"}},
+        })
+    assert r.json().get("error", {}).get("code") == -32601


### PR DESCRIPTION
## Problem

Found while smoke-testing a live instance: `python -m evals.runner` fails **every** case with `-32601 "method not found"`.

The A2A 1.0 migration (**ADR 0014**) moved the server to `a2a-sdk` (≥1.1) and updated the server + `tests/test_a2a_handler.py`, but `evals/` was missed — it still spoke the retired **0.3** wire shape. `a2a-sdk` 1.1:

- serves **proto** method names — `SendMessage` / `GetTask` / `SendStreamingMessage` / `CancelTask` (not `message/send` / `tasks/get` / …)
- gates every method on an **`A2A-Version: 1.0`** request header (a missing header is read as `0.3`, so the 1.0 methods 404 with `-32601`)
- emits **untyped** parts (`{"text": …}` — no `kind` discriminator) with **`TASK_STATE_*`** state names

`evals/client.py` + `evals/runner.py` sent `message/send` + `role: "user"` + `{"kind": "text"}` with no version header, and parsed `kind`-tagged parts / lowercase states.

## Fix

Migrated the eval client + runner to the 1.0 wire shape:

- add the `A2A-Version: 1.0` header (the single omission that 404'd every case)
- proto method names; `SendMessage` returns the terminal task synchronously (`result.task` wrapper) so `ask()` finalizes without polling, with a `GetTask` poll as fallback
- `ROLE_USER` + untyped `{"text": …}` parts
- normalize `TASK_STATE_*` → lowercase (the runner asserts on `"completed"`); treat `input_required` as terminal-for-polling
- `_extract()` tolerates both 1.0 (untyped) and legacy (`kind`-tagged) parts
- `stream()` consumes the 1.0 SSE **oneof** frames (`task` / `statusUpdate` / `artifactUpdate`), accumulating artifacts and finalizing on `final`/terminal
- updated the one streaming eval case + docstrings to the 1.0 event vocabulary

## Verification

- New regression test `tests/test_eval_client_a2a_1_0.py` drives the **real** `AgentClient` against an in-process `a2a-sdk` app — a wrong method/role/header surfaces as `-32601` → `state="failed"`, so a green round-trip is itself the assertion that the client speaks 1.0. A companion negative case pins that the legacy 0.3 shape is rejected.
- Verified live against a running instance: `ask()` (chat + tool calls) and `stream()` both round-trip; cost-v1 usage parsed.
- Full suite: **951 passed** (947 + 4 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)