### PR TITLE
fix(evals): put contextId inside the message (A2A 1.0), not on params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   no version header), so `python -m evals.runner` failed *every* case with
   "method not found". Migrated the eval client/runner to the 1.0 wire shape
   (header + proto method names + `ROLE_USER` + untyped parts + `TASK_STATE_*`
-  normalization + the streaming `statusUpdate`/`artifactUpdate` oneof frames).
+  normalization + the streaming `statusUpdate`/`artifactUpdate` oneof frames +
+  `contextId` moved inside the message, where 1.0's `SendMessageRequest` expects
+  it — at params level it's a `-32602`, which would have broken goal-mode cases).
   Regression test (`tests/test_eval_client_a2a_1_0.py`) drives the real client
   against an in-process `a2a-sdk` app and pins that the legacy shape is rejected.
 - **Plugins: multi-module support.** The plugin loader now imports a plugin's

--- a/evals/client.py
+++ b/evals/client.py
@@ -148,20 +148,21 @@ class AgentClient:
         set a goal on one turn and trigger the loop on the next.
         """
         mid = str(uuid.uuid4())
-        params: dict = {
-            "message": {
-                "role": "ROLE_USER",
-                "parts": [{"text": prompt}],
-                "messageId": mid,
-            }
+        message: dict = {
+            "role": "ROLE_USER",
+            "parts": [{"text": prompt}],
+            "messageId": mid,
         }
+        # contextId is a field of Message in 1.0 — SendMessageRequest itself only
+        # has {tenant, message, configuration, metadata}, so putting it at params
+        # level is a -32602.
         if context_id is not None:
-            params["contextId"] = context_id
+            message["contextId"] = context_id
         payload = {
             "jsonrpc": "2.0",
             "id": mid,
             "method": "SendMessage",
-            "params": params,
+            "params": {"message": message},
         }
         start = time.time()
 
@@ -228,20 +229,18 @@ class AgentClient:
         runs in a known session (e.g. one a goal was set on).
         """
         mid = str(uuid.uuid4())
-        params: dict = {
-            "message": {
-                "role": "ROLE_USER",
-                "parts": [{"text": prompt}],
-                "messageId": mid,
-            }
+        message: dict = {
+            "role": "ROLE_USER",
+            "parts": [{"text": prompt}],
+            "messageId": mid,
         }
-        if context_id is not None:
-            params["contextId"] = context_id
+        if context_id is not None:  # see ask(): contextId lives inside the message
+            message["contextId"] = context_id
         payload = {
             "jsonrpc": "2.0",
             "id": mid,
             "method": "SendStreamingMessage",
-            "params": params,
+            "params": {"message": message},
         }
         events: list[dict] = []
         final: TaskResult | None = None

--- a/tests/test_eval_client_a2a_1_0.py
+++ b/tests/test_eval_client_a2a_1_0.py
@@ -109,6 +109,30 @@ async def test_stream_round_trips_against_a2a_1_0(routed_client):
 
 
 @pytest.mark.asyncio
+async def test_ask_with_context_id_round_trips(routed_client):
+    # contextId is a field of Message in 1.0 — at params level it's a -32602.
+    client, _ = routed_client
+    r = await client.ask("hi", timeout_s=5, context_id="ctx-1")
+    assert r.state == "completed"
+    assert r.text == "hello world"
+
+
+@pytest.mark.asyncio
+async def test_params_level_context_id_is_rejected(routed_client):
+    """Pins that contextId belongs inside the message, not on the request."""
+    _, app = routed_client
+    async with httpx.AsyncClient(
+        transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=5
+    ) as c:
+        r = await c.post("/a2a", headers={"A2A-Version": "1.0"}, json={
+            "jsonrpc": "2.0", "id": "x", "method": "SendMessage",
+            "params": {"contextId": "ctx-1", "message": {
+                "role": "ROLE_USER", "parts": [{"text": "hi"}], "messageId": "m"}},
+        })
+    assert r.json().get("error", {}).get("code") == -32602
+
+
+@pytest.mark.asyncio
 async def test_legacy_0_3_shape_is_rejected(routed_client):
     """Pins the contract: the old ``message/send`` (no version header) 404s, so
     the migration above is load-bearing, not cosmetic."""


### PR DESCRIPTION
Follow-up to #524. That PR auto-merged at its first commit before this fix was pushed (CI raced the second push), so the `contextId` placement bug landed on `main`.

## Problem

A2A 1.0 `SendMessageRequest` has only `{tenant, message, configuration, metadata}` — `contextId` is a field of **`Message`**. The migrated eval client still set `params["contextId"]` (the 0.3 placement), which `a2a-sdk` 1.1 rejects:

```
-32602 Invalid params: Message type "lf.a2a.v1.SendMessageRequest" has no field named "contextId"
```

This breaks any goal-mode eval case that pins a session via `context_id` (set a goal on one turn, trigger the loop on the next).

## Fix

Move `contextId` into the message in `ask()` + `stream()`. Verified live against a running instance (a goal/session-pinned turn now round-trips). Added a round-trip test (`context_id=` accepted) and a negative (params-level `contextId` → `-32602`).

Found by breadth-testing memory/goal flows against a live instance after #524.

🤖 Generated with [Claude Code](https://claude.com/claude-code)