### PR TITLE
fix(evals): give ask()'s blocking SendMessage POST the full timeout_s budget

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Eval `ask()` capped every turn at 30s — slow cases ReadTimeout'd.** A2A 1.0's
+  non-streaming `SendMessage` *blocks* until the task is terminal (the 0.3
+  `message/send` returned immediately and the client polled), but `ask()` still
+  built its httpx client with a fixed `timeout=30` — so any turn longer than 30s
+  (`web_search`, subagent delegation) raised `ReadTimeout` even when the case
+  budgeted 90–300s. The POST now uses the call's `timeout_s`, and a client-side
+  timeout returns a clean `state="timeout"` instead of a raw exception. Verified
+  live: `research_delegation` now passes at ~92s (was a 30s timeout). Regression
+  test pins the constructed timeout.
 - **Eval harness spoke the retired A2A 0.3 wire shape — every case failed.** The
   A2A 1.0 migration (ADR 0014) moved the server to `a2a-sdk` (≥1.1), which serves
   proto method names (`SendMessage`/`GetTask`/`SendStreamingMessage`/`CancelTask`),

--- a/evals/client.py
+++ b/evals/client.py
@@ -177,8 +177,19 @@ class AgentClient:
                 duration_ms=int((time.time() - start) * 1000),
             )
 
-        async with httpx.AsyncClient(timeout=30) as client:
-            r = await client.post(f"{self.base_url}/a2a", headers=self.headers, json=payload)
+        # Non-streaming SendMessage *blocks* until the task is terminal (a2a-sdk
+        # 1.1), so the POST itself must hold the whole turn budget — a fixed 30s
+        # would ReadTimeout on any slow turn (web_search, subagents) even though
+        # the case allows longer. (The 0.3 message/send returned immediately and
+        # this client polled; 1.0 collapsed that into one blocking call.)
+        async with httpx.AsyncClient(timeout=timeout_s) as client:
+            try:
+                r = await client.post(f"{self.base_url}/a2a", headers=self.headers, json=payload)
+            except httpx.TimeoutException:
+                return TaskResult(
+                    task_id="", state="timeout",
+                    duration_ms=int((time.time() - start) * 1000),
+                )
             r.raise_for_status()
             resp = r.json()
             if "error" in resp:

--- a/tests/test_eval_client_a2a_1_0.py
+++ b/tests/test_eval_client_a2a_1_0.py
@@ -133,6 +133,28 @@ async def test_params_level_context_id_is_rejected(routed_client):
 
 
 @pytest.mark.asyncio
+async def test_ask_gives_the_blocking_post_the_full_budget(monkeypatch):
+    """Non-streaming SendMessage blocks until terminal, so ask()'s client must
+    be built with the case's ``timeout_s`` — a fixed 30s ReadTimeouts on slow
+    turns (web_search, subagents) regardless of the budget. Pins the timeout
+    that the underlying httpx client is constructed with."""
+    app = _build_app(_hello_stream)
+    seen: list = []
+    orig = ec.httpx.AsyncClient
+
+    def _patched(*a, **kw):
+        seen.append(kw.get("timeout"))
+        kw["transport"] = httpx.ASGITransport(app=app)
+        kw.setdefault("base_url", "http://test")
+        return orig(*a, **kw)
+
+    monkeypatch.setattr(ec.httpx, "AsyncClient", _patched)
+    r = await ec.AgentClient(base_url="http://test").ask("hi", timeout_s=137)
+    assert r.state == "completed"
+    assert 137 in seen  # not the old hardcoded 30
+
+
+@pytest.mark.asyncio
 async def test_legacy_0_3_shape_is_rejected(routed_client):
     """Pins the contract: the old ``message/send`` (no version header) 404s, so
     the migration above is load-bearing, not cosmetic."""


### PR DESCRIPTION
Found by running the full eval suite live against a running instance (the capstone after #524/#525 made the harness work at all).

## Problem

A2A 1.0's non-streaming `SendMessage` **blocks until the task is terminal** — a2a-sdk 1.1 collapsed the 0.3 "submit immediately, then poll" flow into one blocking call. But `ask()` still built its httpx client with a fixed `timeout=30`, so any turn longer than 30s raised `ReadTimeout` regardless of the case's `timeout_s` (90s default, 300s for subagents).

Full-suite run, three failures — two were this bug:

| case | category | result |
|---|---|---|
| `web_search_intent` | tool | ❌ `ReadTimeout` |
| `research_delegation` | subagent | ❌ `ReadTimeout` |
| `auth_negative` | a2a-protocol | ❌ expected — instance booted with auth disabled |

The **workflow** cases passed at 22s/43s precisely because `run_workflow()` already uses `timeout=timeout_s` — the smoking gun.

## Fix

`ask()`'s SendMessage POST now uses the call's `timeout_s`, and a client-side timeout returns a clean `state="timeout"` instead of propagating a raw exception. (`stream()` was already correct.)

## Verification

- Live re-run of the two cases: `web_search_intent` PASS (~20s), **`research_delegation` PASS (~92s)** — was a 30s ReadTimeout. Full suite is now 21/22 (only the expected auth-disabled case fails).
- Regression test pins the timeout the underlying httpx client is constructed with (137s, not the old 30).
- Suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)