### PR TITLE
fix(web): better-styled loading-screen logo (port ORBIS treatment)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Console loading screen: better-styled logo (matches ORBIS).** The launch
+  brand splash (`IntroSplash`) and cold-start `BootGate` rendered the bot mark
+  as a static `<img>` in the brand-default violet `#7c3aed` — muddy on the dark
+  background. Ported ORBIS's inline `ProtoLabsIcon` component (variants
+  `flat`/`outline`/`white`, plus a `decorative` a11y prop) and switched both
+  screens to the `outline` variant in the lavender chrome accent `#9b87f2`, so
+  the mark is a crisp inline SVG that pops against the chrome. Wordmark + glow
+  unchanged. (Topbar `brand-mark` + favicon still use the static asset — a
+  follow-up if we want full consistency.)
+
 ## [0.13.2] - 2026-06-04
 
 ### Fixed

--- a/apps/web/src/app/BootGate.tsx
+++ b/apps/web/src/app/BootGate.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { ProtoLabsIcon } from "./ProtoLabsIcon";
 
 /**
  * Cold-start boot gate (adapted from ORBIS's BootStatus). The desktop build
@@ -49,11 +50,7 @@ export function BootGate({ ready, failed, name, onRetry, onContinue }: BootGateP
   return (
     <div className="boot-gate" role="status" aria-live="polite">
       <div className="boot-gate-inner">
-        <img
-          src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`}
-          alt=""
-          className="boot-gate-mark"
-        />
+        <ProtoLabsIcon variant="outline" size={56} className="boot-gate-mark" decorative />
         {failed ? (
           <>
             <div className="boot-gate-title">{name} isn’t responding</div>

--- a/apps/web/src/app/IntroSplash.tsx
+++ b/apps/web/src/app/IntroSplash.tsx
@@ -1,4 +1,5 @@
 import { useEffect, useState } from "react";
+import { ProtoLabsIcon } from "./ProtoLabsIcon";
 
 /**
  * protoLabs.studio brand bumper — a brief splash shown over everything on
@@ -40,7 +41,7 @@ export function IntroSplash() {
   return (
     <div className="intro-splash" role="img" aria-label="protoLabs.studio">
       <div className="intro-splash-rise">
-        <img src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`} alt="" className="intro-splash-mark" />
+        <ProtoLabsIcon variant="outline" size={88} className="intro-splash-mark" decorative />
         <div className="intro-splash-word">protoLabs.studio</div>
       </div>
     </div>

--- a/apps/web/src/app/ProtoLabsIcon.tsx
+++ b/apps/web/src/app/ProtoLabsIcon.tsx
@@ -1,0 +1,63 @@
+/**
+ * The protoLabs.studio bot mark, from protoContent's brand assets
+ * (docs/assets/brand/protolabs-icon{,-outline}.svg). Ported from ORBIS's
+ * `ProtoLabsIcon` so the loading screens render a crisp inline SVG instead of
+ * a static <img> — and so the mark can be recolored to the app's lavender
+ * chrome accent (#9b87f2) rather than the brand-default violet (#7c3aed),
+ * which is muddy on the dark background.
+ *
+ * Per brand rules the mark itself is never deformed; only the icon background
+ * may be recolored.
+ *
+ * - `flat` (default): lavender rounded square + white robot — the app/brand
+ *   icon at moderate sizes.
+ * - `outline`: face-only lavender strokes on transparent — for inline-with-
+ *   text / no-compete contexts (what the launch splash + boot gate use).
+ * - `white`: white robot, no background — for dark chrome (e.g. a title bar).
+ */
+export function ProtoLabsIcon({
+  size = 64,
+  variant = "flat",
+  className,
+  decorative = false,
+}: {
+  size?: number;
+  variant?: "flat" | "outline" | "white";
+  className?: string;
+  /** When true the SVG is hidden from a11y (the labelled container carries the
+   *  name) — avoids a redundant nested "protoLabs.studio" announcement. */
+  decorative?: boolean;
+}) {
+  const robotStroke = variant === "outline" ? "#9b87f2" : "#ffffff";
+  const a11y = decorative
+    ? { "aria-hidden": true as const }
+    : { role: "img", "aria-label": "protoLabs.studio" };
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 256 256"
+      className={className}
+      {...a11y}
+    >
+      {variant === "flat" && (
+        <rect x="16" y="16" width="224" height="224" rx="56" fill="#9b87f2" />
+      )}
+      <g
+        transform="translate(224, 32) scale(-8, 8)"
+        fill="none"
+        stroke={robotStroke}
+        strokeWidth={2}
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      >
+        <path d="M12 8V4H8" />
+        <rect width="16" height="12" x="4" y="8" rx="2" />
+        <path d="M2 14h2" />
+        <path d="M20 14h2" />
+        <path d="M15 13v2" />
+        <path d="M9 13v2" />
+      </g>
+    </svg>
+  );
+}


### PR DESCRIPTION
## Problem

The console's loading screens — the launch brand splash (`IntroSplash`, 2.5s bumper) and the cold-start `BootGate` — rendered the protoLabs bot mark as a static `<img>` of `protolabs-icon-outline.svg`, whose strokes are the brand-default violet `#7c3aed`. On the dark `--bg` that reads muddy/low-contrast. ORBIS solved this with an inline `ProtoLabsIcon` component recolored to its lavender chrome accent `#9b87f2`.

## Fix

Ported ORBIS's treatment:
- **New `apps/web/src/app/ProtoLabsIcon.tsx`** — inline SVG of the mark with `flat` / `outline` / `white` variants (verbatim mark per brand rules; only the background is recolored), plus a `decorative` prop so the labelled splash container doesn't get a redundant nested a11y announcement.
- **`IntroSplash` + `BootGate`** now render `<ProtoLabsIcon variant="outline" size={…} decorative />` in lavender `#9b87f2` instead of the static `<img>`.

Wordmark and the drop-shadow glow are unchanged. `tsc` typecheck + `vite build` pass; verified live against a running instance (served bundle inlines the lavender mark).

## Scope note

The topbar `brand-mark` and the favicon still use the static `#7c3aed` asset — a separate surface (ORBIS uses the `white` variant in its title bar). Left as a follow-up so this PR stays scoped to the loading screen.

🤖 Generated with [Claude Code](https://claude.com/claude-code)