### PR TITLE
feat(chat): subagents runnable as slash commands (ADR 0020 PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Subagents are runnable as chat slash commands** (ADR 0020). A message like
+  `/researcher find the latest on X` runs the named subagent and returns its
+  output — the composer analogue of the `task` tool, so "run a worker" is a
+  gesture, not a separate surface. Every registered subagent (built-in + plugin)
+  is offered in the `/` autocomplete alongside `/goal` and the workflow
+  commands. A workflow of the same name wins; a bare `/<subagent>` shows a usage
+  hint; an unknown `/name` falls through to a normal turn. First step toward
+  collapsing Studio to Workflows-only (the Run tab becomes redundant).
+
 ### Changed
 - **Console loading screen: better-styled logo (matches ORBIS).** The launch
   brand splash (`IntroSplash`) and cold-start `BootGate` rendered the bot mark

--- a/server.py
+++ b/server.py
@@ -1619,6 +1619,51 @@ async def _run_parsed_workflow(name: str, inputs: dict, *, on_step=None) -> str:
     return out
 
 
+# --- Subagent slash commands (ADR 0020) --------------------------------------
+# A chat message like ``/researcher find me X`` runs the named subagent instead
+# of a normal model turn — the slash-command analogue of the ``task`` tool, so
+# "run a worker" is a composer gesture, not a separate surface. Free text after
+# the name is the subagent's prompt. A workflow of the same name wins (the turn
+# dispatch checks workflows first). Short-circuits the turn like /goal does.
+
+
+def _parse_subagent_command(message: str):
+    """Return ``(subagent_type, prompt)`` if ``message`` is ``/<known-subagent>
+    …`` (and not a workflow of the same name), else ``None``."""
+    name, rest = _parse_slash_command(message)
+    if not name:
+        return None
+    # Workflow wins on a name collision (dispatch checks workflows first).
+    if _workflow_registry is not None and _workflow_registry.get(name) is not None:
+        return None
+    try:
+        from graph.subagents.config import SUBAGENT_REGISTRY
+    except Exception:
+        return None
+    if name not in SUBAGENT_REGISTRY:
+        return None
+    return name, rest.strip()
+
+
+async def _run_parsed_subagent(subagent_type: str, prompt: str) -> str:
+    """Run one subagent from a chat slash command, formatted as the reply."""
+    from graph.agent import run_manual_subagent
+
+    try:
+        raw = await run_manual_subagent(
+            _graph_config,
+            knowledge_store=_knowledge_store,
+            scheduler=_scheduler,
+            description=f"/{subagent_type} chat command",
+            prompt=prompt,
+            subagent_type=subagent_type,
+        )
+    except ValueError as exc:
+        return f"⚠️ {exc}"
+    # Strip the worker's scratch_pad/output tags so chat shows clean text.
+    return extract_output(raw) or raw or "(subagent produced no output)"
+
+
 async def _chat_langgraph_stream(
     message: str,
     session_id: str,
@@ -1711,6 +1756,22 @@ async def _chat_langgraph_stream(
                 wf_out = await runner
                 yield ("tool_end", {"id": f"workflow:{wf_name}", "name": f"workflow:{wf_name}", "output": wf_out[:300]})
                 yield ("done", wf_out)
+                return
+
+            # Subagent slash command (/<subagent> <prompt>) short-circuits the
+            # turn: run the one worker and return its output (ADR 0020 — run from
+            # chat). Renders a single tool card. A workflow of the same name wins.
+            parsed_sub = _parse_subagent_command(message)
+            if parsed_sub is not None:
+                sub_type, sub_prompt = parsed_sub
+                if not sub_prompt:
+                    yield ("done", f"Usage: `/{sub_type} <prompt>` — describe the task for the {sub_type} subagent.")
+                    return
+                sub_tool_id = f"subagent:{sub_type}"
+                yield ("tool_start", {"id": sub_tool_id, "name": sub_tool_id, "input": sub_prompt})
+                sub_out = await _run_parsed_subagent(sub_type, sub_prompt)
+                yield ("tool_end", {"id": sub_tool_id, "name": sub_tool_id, "output": sub_out[:300]})
+                yield ("done", sub_out)
                 return
 
             # thread_id keys this session's history in the checkpointer (bound
@@ -2544,8 +2605,10 @@ def _main():
                 "usage": "/goal <condition>   ·   /goal  (status)   ·   /goal clear",
             })
         # Each registered workflow is runnable as /<name> (ADR 0002).
+        wf_names: set[str] = set()
         if _workflow_registry is not None:
             for wf in _workflow_registry.list():
+                wf_names.add(wf["name"])
                 declared = wf.get("inputs", []) or []
                 req = "".join(f" <{i['name']}>" for i in declared if i.get("required"))
                 opt = "".join(f" [{i['name']}]" for i in declared if not i.get("required"))
@@ -2554,6 +2617,20 @@ def _main():
                     "description": wf.get("description") or f"Run the {wf['name']} workflow.",
                     "usage": f"/{wf['name']}{req}{opt}",
                 })
+        # Each registered subagent is runnable as /<name> <prompt> (ADR 0020),
+        # unless a workflow already claims the name (workflow wins in dispatch).
+        try:
+            from graph.subagents.config import SUBAGENT_REGISTRY
+        except Exception:
+            SUBAGENT_REGISTRY = {}
+        for name, cfg in SUBAGENT_REGISTRY.items():
+            if name in wf_names:
+                continue
+            commands.append({
+                "name": name,
+                "description": getattr(cfg, "description", "") or f"Run the {name} subagent.",
+                "usage": f"/{name} <prompt>",
+            })
         return {"commands": commands}
 
     # The in-process beads store is agent-global + graph-independent, but it's

--- a/tests/test_subagent_slash.py
+++ b/tests/test_subagent_slash.py
@@ -1,0 +1,49 @@
+"""Tests for subagent slash-command parsing (ADR 0020 — /<subagent> in chat).
+
+The companion to ``test_workflow_slash``: a chat message ``/researcher …`` runs
+the named subagent (the composer analogue of the ``task`` tool) instead of a
+normal model turn, so "run a worker" is a gesture, not a surface.
+"""
+
+from __future__ import annotations
+
+import server
+
+
+def test_known_subagent_parses_to_type_and_prompt():
+    # SUBAGENT_REGISTRY always carries the builtin `researcher`; _workflow_registry
+    # is None in a bare import, so there's no name collision to defer to.
+    assert server._workflow_registry is None
+    assert server._parse_subagent_command("/researcher find the latest on X") == (
+        "researcher",
+        "find the latest on X",
+    )
+
+
+def test_bare_name_yields_empty_prompt():
+    # The dispatch turns an empty prompt into a usage hint rather than running.
+    assert server._parse_subagent_command("/researcher") == ("researcher", "")
+
+
+def test_unknown_name_and_non_command_return_none():
+    assert server._parse_subagent_command("/definitely-not-a-subagent hi") is None
+    assert server._parse_subagent_command("just chatting") is None
+    assert server._parse_subagent_command("   ") is None
+
+
+def test_workflow_of_same_name_takes_precedence(monkeypatch):
+    """A workflow claiming the name wins — the turn dispatch checks workflows
+    first, so _parse_subagent_command must defer (return None) to avoid running
+    the worker for a name the workflow owns."""
+
+    class _Reg:
+        def get(self, name):
+            return {"name": name} if name == "researcher" else None
+
+    monkeypatch.setattr(server, "_workflow_registry", _Reg())
+    assert server._parse_subagent_command("/researcher hi") is None
+    # A subagent name the workflow registry doesn't claim still parses.
+    assert server._parse_subagent_command("/antagonist poke holes in Y") == (
+        "antagonist",
+        "poke holes in Y",
+    )


### PR DESCRIPTION
**PR 1 of 4** implementing [ADR 0020](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0020-console-ia-run-from-chat.md) — *run from Chat, manage from surfaces*.

## What

A chat message `/researcher <prompt>` now runs the named subagent and returns its output — the composer analogue of the `task` tool, mirroring how workflows already run as `/<name>` (ADR 0002). This makes "run a worker" a gesture rather than a surface, which is what lets the next PR collapse Studio to Workflows-only and drop the redundant Run tab.

## How

- **`_parse_subagent_command` + `_run_parsed_subagent`** — parse `/<known-subagent> <prompt>` and run it via the existing `run_manual_subagent` primitive (same audit / prompt / max-turn path as `task`), stripping scratch_pad/output tags for clean chat text.
- **Turn dispatch** (`_chat_langgraph_stream`) — after the workflow check, short-circuit on a subagent command and render a single tool card. Precedence: a workflow of the same name wins; a bare `/<subagent>` returns a usage hint; an unknown `/name` falls through to a normal turn.
- **`_operator_chat_commands`** — lists every registered subagent (built-in + plugin) for the `/` autocomplete, skipping names a workflow already claims.

## Verification

Live against a running instance:
- `/hello_helper say hi` → ran the plugin subagent ✓
- bare `/researcher` → usage hint, no run ✓
- `/notasub …` → fell through to a normal turn ✓
- `/api/chat/commands` now lists researcher, antagonist, verifier, synthesizer, hello_helper alongside goal + workflows ✓

Unit tests (`test_subagent_slash.py`) cover parse + workflow-precedence. Full suite: 958 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)