### PR TITLE
feat(console): Knowledge = searchable Store + Playbooks (ADR 0020 PR3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Knowledge surface = searchable Store + Playbooks** (ADR 0020). The Knowledge
+  rail was mislabeled — it showed only Playbooks while the actual knowledge base
+  (the `knowledge/store.py` FTS5 chunks: findings, daily-log, harvested sessions,
+  operator notes that feed `<learned_skills>`) was unbrowsable. Knowledge now has
+  two sub-tabs: **Store** (a searchable view, default) and **Playbooks**. New
+  read-only `GET /api/knowledge/search?q=…` endpoint (empty `q` → most-recent
+  chunks; non-empty → FTS5 search) backs the Store view. Also a debugging window
+  into "why did it recall that?".
 - **Subagents are runnable as chat slash commands** (ADR 0020). A message like
   `/researcher find the latest on X` runs the named subagent and returns its
   output — the composer analogue of the `task` tool, so "run a worker" is a

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -407,3 +407,19 @@ export const PLAYBOOKS = [
     last_used: "2026-05-31T12:00:00+00:00", created_at: "2026-05-30T00:00:00+00:00",
   },
 ];
+
+// Knowledge → Store (ADR 0020): chunks from the knowledge base (findings, notes).
+export const KNOWLEDGE_CHUNKS = [
+  {
+    id: 11, heading: "Release cadence", content: "Releases are cut manually via workflow_dispatch.",
+    preview: "Release cadence: Releases are cut manually via workflow_dispatch.",
+    domain: "process", source: "daily-log", source_type: "log", finding_type: "fact",
+    created_at: "2026-06-03T12:00:00+00:00",
+  },
+  {
+    id: 12, heading: "", content: "The gateway alias for the live model is protolabs/reasoning.",
+    preview: "The gateway alias for the live model is protolabs/reasoning.",
+    domain: "general", source: null, source_type: null, finding_type: null,
+    created_at: "2026-06-02T09:00:00+00:00",
+  },
+];

--- a/apps/web/e2e/knowledge.spec.ts
+++ b/apps/web/e2e/knowledge.spec.ts
@@ -1,0 +1,32 @@
+import { expect, test } from "@playwright/test";
+
+// Knowledge → Store (ADR 0020): a searchable window onto the agent's knowledge
+// base (findings, notes, daily-log). Lands as the default Knowledge sub-tab.
+
+test("Knowledge lands on the searchable Store and lists chunks", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Knowledge" }).click();
+
+  const surface = page.getByTestId("knowledge-store");
+  await expect(surface).toBeVisible(); // Store is the default sub-tab
+  await expect(surface.getByRole("heading", { name: "Knowledge" })).toBeVisible();
+
+  // The mocked chunks render with their content + domain badges.
+  await expect(surface.getByText("Releases are cut manually via workflow_dispatch.")).toBeVisible();
+  await expect(surface.getByText("protolabs/reasoning", { exact: false })).toBeVisible();
+  await expect(surface.getByText("process", { exact: true })).toBeVisible(); // domain badge
+
+  // The search box is present (server-side FTS; the mock returns the fixture).
+  await expect(surface.getByPlaceholder(/Search the knowledge base/)).toBeVisible();
+});
+
+test("Knowledge sub-nav switches between Store and Playbooks", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Knowledge" }).click();
+
+  await expect(page.getByTestId("knowledge-store")).toBeVisible();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Playbooks", exact: true }).click();
+  await expect(page.getByTestId("playbooks-surface")).toBeVisible();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Store", exact: true }).click();
+  await expect(page.getByTestId("knowledge-store")).toBeVisible();
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -25,6 +25,7 @@ import {
   settingsRestartRequired,
   SLASH_COMMANDS,
   PLAYBOOKS,
+  KNOWLEDGE_CHUNKS,
   SUBAGENTS,
   TELEMETRY_INSIGHTS,
   TELEMETRY_SUMMARY,
@@ -113,6 +114,11 @@ function handleApiGet(pathname) {
       return { enabled: true, insights: TELEMETRY_INSIGHTS };
     case "/api/playbooks":
       return { enabled: true, playbooks: PLAYBOOKS };
+    case "/api/knowledge/search":
+      return {
+        enabled: true, query: "", results: KNOWLEDGE_CHUNKS,
+        stats: { total: KNOWLEDGE_CHUNKS.length },
+      };
     default:
       return null;
   }

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -6,6 +6,8 @@ import { expect, test } from "@playwright/test";
 test("Knowledge → Playbooks lists pinned + learned skills and supports search", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Knowledge" }).click();
+  // Knowledge lands on Store now (ADR 0020) — switch to the Playbooks sub-tab.
+  await page.locator(".stage-subnav").getByRole("button", { name: "Playbooks", exact: true }).click();
 
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
@@ -25,6 +27,7 @@ test("Knowledge → Playbooks lists pinned + learned skills and supports search"
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Knowledge" }).click();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Playbooks", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -2,6 +2,7 @@ import {
   Activity,
   BarChart3,
   BookMarked,
+  Database,
   BookOpen,
   Boxes,
   CalendarClock,
@@ -30,6 +31,7 @@ import { ActivitySurface } from "../activity/ActivitySurface";
 import { ConfirmDialog } from "./ConfirmDialog";
 import { InboxPanel } from "../inbox/InboxPanel";
 import { ChatSurface } from "../chat/ChatSurface";
+import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
@@ -55,6 +57,9 @@ type SystemTab = "runtime" | "telemetry" | "settings";
 // Activity = the "triggers / events" surface (ADR 0009): what happened (thread),
 // inbound (inbox), and timed (schedule — cron is a trigger, not a work-type).
 type ActivityTab = "thread" | "inbox" | "schedule";
+// Knowledge = what the agent knows (ADR 0020): the searchable knowledge Store
+// (factual memory) + Playbooks (procedural memory). Store leads.
+type KnowledgeTab = "store" | "playbooks";
 // The agent's persistent working memory, grouped in the right sidebar:
 // its notebook, its task board, and its goals.
 type RightPanel = "notes" | "beads" | "goals";
@@ -100,6 +105,7 @@ export function App() {
   const [surface, setSurface] = useState<Surface>("chat");
   const [systemTab, setSystemTab] = useState<SystemTab>("runtime");
   const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
+  const [knowledgeTab, setKnowledgeTab] = useState<KnowledgeTab>("store");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
   // Collapsible/resizable right panel (persisted). Flag is "1"/"" string; width
   // is a px string clamped on read.
@@ -570,6 +576,17 @@ export function App() {
               </button>
             </div>
           ) : null}
+          {surface === "knowledge" ? (
+            // Store (factual memory) + Playbooks (procedural memory) — ADR 0020.
+            <div className="stage-subnav">
+              <button className={knowledgeTab === "store" ? "active" : ""} onClick={() => setKnowledgeTab("store")}>
+                <Database size={15} /> Store
+              </button>
+              <button className={knowledgeTab === "playbooks" ? "active" : ""} onClick={() => setKnowledgeTab("playbooks")}>
+                <BookMarked size={15} /> Playbooks
+              </button>
+            </div>
+          ) : null}
           {surface === "system" ? (
             <div className="stage-subnav">
               <button className={systemTab === "runtime" ? "active" : ""} onClick={() => setSystemTab("runtime")}>
@@ -598,7 +615,8 @@ export function App() {
           {surface === "system" && systemTab === "runtime" ? <RuntimePanel /> : null}
 
           {surface === "system" && systemTab === "telemetry" ? <TelemetrySurface /> : null}
-          {surface === "knowledge" ? <PlaybooksSurface onError={setError} /> : null}
+          {surface === "knowledge" && knowledgeTab === "store" ? <KnowledgeStore onError={setError} /> : null}
+          {surface === "knowledge" && knowledgeTab === "playbooks" ? <PlaybooksSurface onError={setError} /> : null}
           {surface === "system" && systemTab === "settings" ? <SettingsSurface /> : null}
         </main>
 

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -1,0 +1,122 @@
+import { Brain, Database, RefreshCw } from "lucide-react";
+import { useEffect, useState } from "react";
+
+import { api } from "../lib/api";
+import type { KnowledgeChunk } from "../lib/types";
+
+// Knowledge → Store (ADR 0020) — a searchable window onto the agent's knowledge
+// base (knowledge/store.py, FTS5): findings, daily-log entries, harvested
+// sessions, operator notes. The same store KnowledgeMiddleware queries before
+// every turn, so this is also where you debug "why did it recall that?". Empty
+// query → most-recent chunks; typing runs server-side FTS5 search (debounced).
+
+function ago(iso: string | null): string {
+  if (!iso) return "—";
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "—";
+  const s = Math.max(0, (Date.now() - t) / 1000);
+  if (s < 90) return "just now";
+  if (s < 3600) return `${Math.round(s / 60)}m ago`;
+  if (s < 86400) return `${Math.round(s / 3600)}h ago`;
+  return `${Math.round(s / 86400)}d ago`;
+}
+
+export function KnowledgeStore({ onError }: { onError: (message: string) => void }) {
+  const [results, setResults] = useState<KnowledgeChunk[]>([]);
+  const [stats, setStats] = useState<Record<string, number>>({});
+  const [enabled, setEnabled] = useState(true);
+  const [loading, setLoading] = useState(false);
+  const [query, setQuery] = useState("");
+
+  async function run(q: string) {
+    setLoading(true);
+    try {
+      const r = await api.knowledgeSearch(q);
+      setEnabled(r.enabled);
+      setResults(r.results || []);
+      setStats(r.stats || {});
+      onError("");
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  // Fires on mount (query="" → recent) and debounced on every keystroke.
+  useEffect(() => {
+    const t = window.setTimeout(() => void run(query), 250);
+    return () => window.clearTimeout(t);
+  }, [query]);
+
+  const total = stats.chunks ?? stats.total ?? 0;
+
+  return (
+    <section className="panel stage-panel" data-testid="knowledge-store">
+      <div className="panel-header">
+        <div>
+          <h1>Knowledge</h1>
+          <p className="panel-kicker">
+            searchable knowledge base{total ? ` · ${total} entr${total === 1 ? "y" : "ies"}` : ""}
+          </p>
+        </div>
+        <button className="secondary-button" type="button" onClick={() => void run(query)} disabled={loading} title="Refresh">
+          <RefreshCw size={15} className={loading ? "spin" : ""} /> Refresh
+        </button>
+      </div>
+
+      <div className="stage-body">
+        <input
+          className="playbook-search"
+          type="search"
+          placeholder="Search the knowledge base (findings, notes, daily log)…"
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+        />
+
+        {!enabled ? (
+          <p className="empty-note">
+            The knowledge store is off (enable <code>middleware.knowledge</code>).
+          </p>
+        ) : results.length === 0 ? (
+          <p className="empty-note">
+            {query.trim()
+              ? "No entries match your search."
+              : "The knowledge base is empty — findings, daily-log entries, and harvested sessions will appear here as the agent works."}
+          </p>
+        ) : (
+          <ul className="playbook-list">
+            {results.map((c) => (
+              <li key={c.id} className="playbook-card">
+                <div className="playbook-main">
+                  <div className="playbook-title">
+                    <span className="playbook-badge learned" title={`domain: ${c.domain}`}>
+                      <Database size={12} /> {c.domain}
+                    </span>
+                    {c.finding_type ? (
+                      <span className="playbook-badge" title="finding type">{c.finding_type}</span>
+                    ) : null}
+                    {c.heading ? <strong>{c.heading}</strong> : null}
+                  </div>
+                  <p className="playbook-desc">{c.content || c.preview}</p>
+                  {c.source ? (
+                    <div className="playbook-tools">
+                      <code>{c.source}</code>
+                    </div>
+                  ) : null}
+                </div>
+                <div className="playbook-meta">
+                  <span title="added">{ago(c.created_at)}</span>
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+
+      <p className="playbook-foot">
+        <Brain size={13} /> This is the memory the agent retrieves into context before each turn (ADR 0020) — search it to see what it knows.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -7,6 +7,7 @@ import type {
   GoalState,
   HitlPayload,
   InboxItem,
+  KnowledgeChunk,
   NotesWorkspace,
   RuntimeStatus,
   ScheduledJob,
@@ -314,6 +315,15 @@ export const api = {
 
   playbooks() {
     return request<{ enabled: boolean; playbooks: Playbook[] }>("/api/playbooks");
+  },
+
+  knowledgeSearch(q: string) {
+    return request<{
+      enabled: boolean;
+      query: string;
+      results: KnowledgeChunk[];
+      stats: Record<string, number>;
+    }>(`/api/knowledge/search?q=${encodeURIComponent(q)}`);
   },
 
   deletePlaybook(id: number) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -358,3 +358,17 @@ export type Playbook = {
   last_used: string | null;
   created_at: string | null;
 };
+
+// One row from the knowledge store (knowledge/store.py chunks table), as the
+// searchable Knowledge → Store view consumes it (ADR 0020).
+export type KnowledgeChunk = {
+  id: number;
+  heading: string;
+  content: string;
+  preview: string;
+  domain: string;
+  source: string | null;
+  source_type: string | null;
+  finding_type: string | null;
+  created_at: string | null;
+};

--- a/server.py
+++ b/server.py
@@ -2859,6 +2859,47 @@ def _main():
             log.exception("[playbooks] delete failed")
             return {"enabled": True, "deleted": False, "error": str(exc)}
 
+    # --- Knowledge store (ADR 0020) ----------------------------------------
+    # Searchable view of the agent's knowledge base (knowledge/store.py, FTS5):
+    # findings, daily-log entries, harvested sessions, operator notes — the same
+    # store KnowledgeMiddleware queries before each turn. An empty ``q`` returns
+    # the most-recent chunks (a browsable default); a non-empty ``q`` runs FTS5
+    # search. Read-only; never 500s the console.
+    def _knowledge_row(d: dict) -> dict:
+        """Normalize a search()/list_chunks() row to the console's shape."""
+        heading = d.get("heading") or ""
+        content = d.get("content") or ""
+        preview = d.get("preview") or ((heading + ": " if heading else "") + content)[:240]
+        return {
+            "id": d.get("id"),
+            "heading": heading,
+            "content": content,
+            "preview": preview,
+            "domain": d.get("domain") or "general",
+            "source": d.get("source"),
+            "source_type": d.get("source_type"),
+            "finding_type": d.get("finding_type"),
+            "created_at": d.get("created_at"),
+        }
+
+    @fastapi_app.get("/api/knowledge/search")
+    async def _api_knowledge_search(q: str = "", k: int = 30, domain: str | None = None):
+        if _knowledge_store is None:
+            return {"enabled": False, "query": q, "results": [], "stats": {}}
+        results: list[dict] = []
+        try:
+            if q and q.strip():
+                results = [_knowledge_row(r) for r in _knowledge_store.search(q, k=k, domain=domain or None)]
+            else:
+                results = [_knowledge_row(c.as_dict()) for c in _knowledge_store.list_chunks(domain=domain or None, limit=k)]
+        except Exception:  # noqa: BLE001 — never 500 the console
+            log.exception("[knowledge] search failed")
+        try:
+            stats = _knowledge_store.stats()
+        except Exception:  # noqa: BLE001
+            stats = {}
+        return {"enabled": True, "query": q, "results": results, "stats": stats}
+
     # --- Telemetry (ADR 0006 Slice 2) --------------------------------------
     # Per-turn cost/latency rollups from the local store. Powers the operator
     # console's cost/latency surface (Slice 3) and ad-hoc "what's expensive"


### PR DESCRIPTION
**PR 3 of 4** for [ADR 0020](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0020-console-ia-run-from-chat.md) — *run from Chat, manage from surfaces*.

## What

The Knowledge rail was mislabeled: it showed **only Playbooks** while the actual knowledge base — the `knowledge/store.py` FTS5 chunks (findings, daily-log entries, harvested sessions, operator notes that feed `<learned_skills>`) — was unbrowsable. Knowledge now has two sub-tabs: **Store** (searchable, the default) and **Playbooks**. It's also a debugging window into *"why did it recall that?"*.

## Changes

**Backend** — read-only `GET /api/knowledge/search?q=&k=&domain=`: empty `q` returns the most-recent chunks (`list_chunks`), non-empty runs FTS5 `search`; includes store `stats`. Never 500s the console.

**Frontend**
- New `KnowledgeStore` surface — debounced server-side search, chunk cards with domain / finding-type badges + age, sensible empty states.
- Knowledge sub-nav (Store · Playbooks); `KnowledgeChunk` type + `api.knowledgeSearch`.

**e2e** — `knowledge.spec` (Store lists chunks, sub-nav toggles); `playbooks.spec` updated to enter via the Playbooks sub-tab; mock route + fixture added.

## Verification

- Live against a running instance: empty query → **24 recent chunks**; `q=canary` → found a fact saved earlier via FTS5.
- Build + **9 e2e** (knowledge/playbooks/navigation) + **958 Python** tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)