### PR TITLE
feat(console): regroup Settings into 5 categories (ADR 0020 PR4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   collapsing Studio to Workflows-only (the Run tab becomes redundant).
 
 ### Changed
+- **Settings regrouped into 5 categories** (ADR 0020). The Settings surface was a
+  flat ~12-section scroll mixing model config, cache TTLs, middleware toggles, and
+  plugin integrations. Sections now fold into a category sub-nav — **Agent**
+  (Identity · Model · Routing), **Behavior** (Compaction · Caching · Goal mode ·
+  Tools), **Memory** (Knowledge), **Integrations** (Discord · Google · plugins),
+  **System** (Middleware · Runtime). The schema (`build_schema`) tags each group
+  with a `category` and orders them; plugin-contributed sections default to
+  Integrations. Pure reorganization — no field added or removed.
 - **Studio is now Workflows-only; the Run tab is gone** (ADR 0020). The Studio →
   Run panel was a forms-based way to launch a subagent manually — redundant now
   that subagents (and workflows) run as chat slash commands. Studio's rail lands

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -145,6 +145,7 @@ export const NOTES_WORKSPACE = {
 export const SETTINGS_SCHEMA = [
   {
     section: "Model",
+    category: "Agent",
     fields: [
       { key: "model.name", label: "Primary model", type: "select", section: "Model", restart: false, description: "", options: ["protolabs/reasoning", "protolabs/fast"], value: "protolabs/reasoning", default: "protolabs/reasoning" },
       { key: "model.temperature", label: "Temperature", type: "number", section: "Model", restart: false, description: "", options: [], value: 0.2, default: 0.2, minimum: 0, maximum: 2 },
@@ -153,6 +154,7 @@ export const SETTINGS_SCHEMA = [
   },
   {
     section: "Routing",
+    category: "Agent",
     fields: [
       { key: "routing.aux_model", label: "Auxiliary (fast) model", type: "string", section: "Routing", restart: false, description: "Cheap alias for aux calls.", options: [], value: "protolabs/fast", default: "" },
       { key: "routing.fallback_models", label: "Fallback models", type: "string_list", section: "Routing", restart: false, description: "", options: [], value: [], default: [] },
@@ -160,12 +162,14 @@ export const SETTINGS_SCHEMA = [
   },
   {
     section: "Compaction",
+    category: "Behavior",
     fields: [
       { key: "compaction.enabled", label: "Enable compaction", type: "bool", section: "Compaction", restart: false, description: "", options: [], value: true, default: true },
     ],
   },
   {
     section: "Runtime",
+    category: "System",
     fields: [
       { key: "runtime.autostart_on_boot", label: "Autostart on boot", type: "bool", section: "Runtime", restart: true, description: "Install/remove the boot LaunchAgent.", options: [], value: false, default: false },
     ],

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,8 +1,8 @@
 import { expect, test } from "@playwright/test";
 
-// The Settings surface renders GET /api/settings/schema generically, saves
-// changed fields via POST /api/settings (auto-reload), and flags fields that
-// need a process restart.
+// The Settings surface renders GET /api/settings/schema generically, grouped
+// into a category sub-nav (ADR 0020), saves changed fields via POST /api/settings
+// (auto-reload), and flags fields that need a process restart.
 
 async function openSettings(page) {
   await page.goto("/app/", { waitUntil: "load" });
@@ -11,23 +11,34 @@ async function openSettings(page) {
   await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
 }
 
-test("renders schema groups and current values", async ({ page }) => {
+async function category(page, name) {
+  await page.locator(".settings-subnav").getByRole("button", { name, exact: true }).click();
+}
+
+test("groups are organized into a category sub-nav; Agent leads", async ({ page }) => {
   await openSettings(page);
-  // Grouped sections from the schema (scope to the group titles — some names
-  // like "Runtime" also appear in the nav rail).
-  // allTextContents (raw DOM text) — innerText would be uppercased by CSS.
-  const titles = await page.locator(".settings-group-title").allTextContents();
-  expect(titles).toEqual(["Model", "Routing", "Compaction", "Runtime"]);
-  // A string field shows its current value.
+  // Category sub-nav from the mock schema: Agent · Behavior · System.
+  expect(await page.locator(".settings-subnav button").allTextContents()).toEqual([
+    "Agent",
+    "Behavior",
+    "System",
+  ]);
+  // Agent is the default — only its sections show (Model + Routing), not System's.
+  expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Model", "Routing"]);
   const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
   await expect(aux).toHaveValue("protolabs/fast");
-  // The restart-flagged field shows the badge.
-  const autostart = page.locator('.setting-row[data-key="runtime.autostart_on_boot"]');
-  await expect(autostart.locator(".setting-restart")).toBeVisible();
   // Secret is never echoed — empty with a "set" placeholder.
   const key = page.locator('.setting-row[data-key="model.api_key"] input');
   await expect(key).toHaveValue("");
   await expect(key).toHaveAttribute("placeholder", /set/);
+});
+
+test("switching category reveals its sections + restart badge", async ({ page }) => {
+  await openSettings(page);
+  await category(page, "System");
+  expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Runtime"]);
+  const autostart = page.locator('.setting-row[data-key="runtime.autostart_on_boot"]');
+  await expect(autostart.locator(".setting-restart")).toBeVisible();
 });
 
 test("editing enables save and round-trips", async ({ page }) => {
@@ -35,7 +46,7 @@ test("editing enables save and round-trips", async ({ page }) => {
   const save = page.getByRole("button", { name: /Save & apply/ });
   await expect(save).toBeDisabled(); // nothing dirty yet
 
-  const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
+  const aux = page.locator('.setting-row[data-key="routing.aux_model"] input'); // Agent (default)
   await aux.fill("protolabs/turbo");
   await expect(save).toBeEnabled();
   await save.click();
@@ -45,6 +56,7 @@ test("editing enables save and round-trips", async ({ page }) => {
 
 test("toggling a restart-flagged field shows the restart banner", async ({ page }) => {
   await openSettings(page);
+  await category(page, "System");
   await expect(page.locator(".settings-banner")).toHaveCount(0);
   await page.locator('.setting-row[data-key="runtime.autostart_on_boot"] input[type="checkbox"]').check();
   await expect(page.locator(".settings-banner")).toContainText("restart");

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -82,7 +82,7 @@ export type SettingsField = {
   maximum?: number;
 };
 
-export type SettingsGroup = { section: string; fields: SettingsField[] };
+export type SettingsGroup = { section: string; category?: string; fields: SettingsField[] };
 
 export type WorkflowSummary = {
   name: string;

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -42,6 +42,21 @@ function SettingsBody() {
   const [dirty, setDirty] = useState<Record<string, unknown>>({});
   const [status, setStatus] = useState("");
 
+  // Category sub-nav (ADR 0020): the server tags each group with a category and
+  // orders them, so we derive the ordered category list by first appearance.
+  const categories = useMemo(() => {
+    const seen: string[] = [];
+    for (const g of groups) {
+      const c = g.category || "Integrations";
+      if (!seen.includes(c)) seen.push(c);
+    }
+    return seen;
+  }, [groups]);
+  const [activeCategory, setActiveCategory] = useState(categories[0] || "");
+  // The active category must stay valid if the schema reshapes under us.
+  const category = categories.includes(activeCategory) ? activeCategory : categories[0] || "";
+  const visibleGroups = groups.filter((g) => (g.category || "Integrations") === category);
+
   const dirtyKeys = Object.keys(dirty);
 
   // Pending changes that won't take effect until a process restart.
@@ -151,6 +166,15 @@ function SettingsBody() {
           </button>
         </div>
       </div>
+      {categories.length > 1 ? (
+        <div className="stage-subnav settings-subnav">
+          {categories.map((c) => (
+            <button key={c} className={c === category ? "active" : ""} onClick={() => setActiveCategory(c)}>
+              {c}
+            </button>
+          ))}
+        </div>
+      ) : null}
       <div className="stage-body">
         {pendingRestart.length ? (
           <div className="settings-banner" role="alert">
@@ -160,7 +184,7 @@ function SettingsBody() {
         ) : null}
         {status ? <p className="settings-status">{status}</p> : null}
 
-        {groups.map((group) => (
+        {visibleGroups.map((group) => (
           <section className="settings-group" key={group.section}>
             <p className="settings-group-title">{group.section}</p>
             {group.fields.map((field) => (

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -161,8 +161,36 @@ def _plugin_group(sch, spec) -> str:
     return spec.get("group") or sch.section.replace("_", " ").title()
 
 
+# Settings categories (ADR 0020) — fold the flat sections into a small,
+# navigable taxonomy so the surface isn't one long scroll. Order here is the
+# order the console renders the category sub-nav. Unknown sections (notably
+# plugin-contributed ones, ADR 0019) default to "Integrations".
+_CATEGORY_ORDER = ["Agent", "Behavior", "Memory", "Integrations", "System"]
+_SECTION_CATEGORY = {
+    "Identity": "Agent",
+    "Model": "Agent",
+    "Routing": "Agent",
+    "Compaction": "Behavior",
+    "Caching": "Behavior",
+    "Goal mode": "Behavior",
+    "Tools": "Behavior",
+    "Knowledge": "Memory",
+    "Middleware": "System",
+    "Runtime": "System",
+    # Discord / Google / other plugin sections → "Integrations" (the default).
+}
+
+
+def _category_for(section: str) -> str:
+    return _SECTION_CATEGORY.get(section, "Integrations")
+
+
 def build_schema(config, *, model_options: list[str] | None = None) -> list[dict[str, Any]]:
     """Return the settings schema grouped by section, with current values.
+
+    Each group carries a ``category`` (ADR 0020) so the console can present a
+    category sub-nav instead of a flat scroll. Groups are ordered by category
+    (``_CATEGORY_ORDER``), then by their first appearance in ``FIELDS``.
 
     Secrets report ``value: ""`` plus ``is_set`` rather than echoing the secret.
     """
@@ -221,7 +249,19 @@ def build_schema(config, *, model_options: list[str] | None = None) -> list[dict
             entry["maximum"] = spec["maximum"]
         groups.setdefault(group, {"section": group, "fields": []})["fields"].append(entry)
 
-    return list(groups.values())
+    out = list(groups.values())
+    # Insertion order = first appearance in FIELDS (core), then plugins.
+    section_pos = {g["section"]: i for i, g in enumerate(out)}
+    for g in out:
+        g["category"] = _category_for(g["section"])
+
+    def _sort_key(g: dict) -> tuple[int, int]:
+        cat = g["category"]
+        cat_rank = _CATEGORY_ORDER.index(cat) if cat in _CATEGORY_ORDER else len(_CATEGORY_ORDER)
+        return (cat_rank, section_pos[g["section"]])
+
+    out.sort(key=_sort_key)
+    return out
 
 
 def validate_flat(updates: dict[str, Any]) -> tuple[bool, str | None]:

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -15,8 +15,9 @@ from graph.settings_schema import (
 def test_schema_groups_and_values():
     cfg = LangGraphConfig()
     groups = build_schema(cfg, model_options=["a", "b"])
-    # Grouped, ordered, every field carries the metadata the UI needs.
-    assert [g["section"] for g in groups][:3] == ["Model", "Routing", "Compaction"]
+    # Grouped + ordered by category (ADR 0020): the Agent category leads, its
+    # sections in FIELDS order (Model, Routing, Identity).
+    assert [g["section"] for g in groups][:3] == ["Model", "Routing", "Identity"]
     fields = [f for g in groups for f in g["fields"]]
     # Every core FIELD is present. (build_schema also appends plugin-declared
     # settings — e.g. the discord plugin — so count only the core-keyed fields,
@@ -28,6 +29,27 @@ def test_schema_groups_and_values():
     # The model select is populated from the probed options.
     model = next(f for f in fields if f["key"] == "model.name")
     assert model["type"] == "select" and model["options"] == ["a", "b"]
+
+
+def test_groups_carry_category_in_taxonomy_order():
+    """ADR 0020: every group is tagged with a category, and categories appear
+    contiguously in _CATEGORY_ORDER (so the console sub-nav is stable)."""
+    from graph.settings_schema import _CATEGORY_ORDER
+
+    groups = build_schema(LangGraphConfig())
+    cats = [g["category"] for g in groups]
+    assert all(cats), "every group must carry a category"
+    assert cats[0] == "Agent"
+    # First-appearance order of categories matches _CATEGORY_ORDER (contiguous).
+    seen: list[str] = []
+    for c in cats:
+        if c not in seen:
+            seen.append(c)
+    assert seen == [c for c in _CATEGORY_ORDER if c in seen]
+    # Known mappings hold.
+    by_section = {g["section"]: g["category"] for g in groups}
+    assert by_section["Knowledge"] == "Memory"
+    assert by_section["Middleware"] == "System"
 
 
 def test_secrets_are_redacted_with_is_set():


### PR DESCRIPTION
**PR 4 of 4** (final) for [ADR 0020](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0020-console-ia-run-from-chat.md) — *run from Chat, manage from surfaces*.

## What

Settings was a flat **~12-section / ~40-field scroll** mixing model config, cache TTLs, middleware toggles, and plugin integrations — no hierarchy. Sections now fold into a **category sub-nav**:

| Category | Sections |
|---|---|
| **Agent** | Identity · Model · Routing |
| **Behavior** | Compaction · Caching · Goal mode · Tools |
| **Memory** | Knowledge |
| **Integrations** | Discord · Google · plugin-contributed |
| **System** | Middleware · Runtime |

Pure reorganization — no field added or removed.

## Changes

- **Backend**: `build_schema` tags each group with a `category` (via a `section → category` map) and orders groups by `_CATEGORY_ORDER` then FIELDS order. Plugin-contributed sections (ADR 0019) default to **Integrations**.
- **Frontend**: `SettingsSurface` derives the ordered category list, renders a category sub-nav, shows only the active category's sections; `SettingsGroup` gains `category`.
- **Tests**: Python asserts the taxonomy + contiguous category order; `settings.spec` drives the sub-nav (Agent default; switch to System for the restart-flagged field); mock schema groups tagged.

## Verification

- Build + **42 e2e** + **959 Python** tests pass.
- Live `/api/settings/schema` returns the 5 categories in order.

---

This completes the ADR 0020 sequence: **#530** (subagents as slash commands) · **#531** (Studio = Workflows) · **#532** (Knowledge = Store + Playbooks) · this PR (Settings). Activity remains a parked follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)