### PR TITLE
fix(console): Settings its own rail surface; sub-nav no longer overlaps fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Settings is its own rail surface; category sub-nav no longer overlaps the
+  fields.** The category sub-nav (added with the Settings regroup) landed in the
+  `.stage-panel` grid's `1fr` content row, so it stretched over the fields. Gave
+  the Settings panel its own `auto auto 1fr` grid (header · sub-nav · scrolling
+  body) and promoted **Settings out of System into a top-level rail item** (its
+  own view), so it no longer competes with System's sub-nav. System is now
+  Runtime · Telemetry.
+
 ### Added
 - **Knowledge surface = searchable Store + Playbooks** (ADR 0020). The Knowledge
   rail was mislabeled — it showed only Playbooks while the actual knowledge base

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -6,7 +6,7 @@ import { expect, test } from "@playwright/test";
 
 async function openSettings(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "System", exact: true }).click();
+  // Settings is its own rail surface now (ADR 0020 follow-up).
   await page.getByRole("button", { name: "Settings", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Settings" })).toBeVisible();
 }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -49,11 +49,11 @@ import { runtimeStatusQuery } from "../lib/queries";
 
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
 // fanning out to sub-views via an in-surface segmented control.
-type Surface = "chat" | "activity" | "studio" | "knowledge" | "system";
+type Surface = "chat" | "activity" | "studio" | "knowledge" | "system" | "settings";
 // Studio = the workflow authoring/inspection surface. Per ADR 0020 execution is
 // a chat gesture (run subagents/workflows via /<name>), not a surface — so the
 // old "Run" tab is gone and Studio is just Workflows.
-type SystemTab = "runtime" | "telemetry" | "settings";
+type SystemTab = "runtime" | "telemetry";
 // Activity = the "triggers / events" surface (ADR 0009): what happened (thread),
 // inbound (inbox), and timed (schedule — cron is a trigger, not a work-type).
 type ActivityTab = "thread" | "inbox" | "schedule";
@@ -551,6 +551,12 @@ export function App() {
             icon={<Gauge size={18} />}
             onClick={() => setSurface("system")}
           />
+          <RailButton
+            active={surface === "settings"}
+            label="Settings"
+            icon={<Settings2 size={18} />}
+            onClick={() => setSurface("settings")}
+          />
         </aside>
 
         <main className="stage">
@@ -595,9 +601,6 @@ export function App() {
               <button className={systemTab === "telemetry" ? "active" : ""} onClick={() => setSystemTab("telemetry")}>
                 <BarChart3 size={15} /> Telemetry
               </button>
-              <button className={systemTab === "settings" ? "active" : ""} onClick={() => setSystemTab("settings")}>
-                <Settings2 size={15} /> Settings
-              </button>
             </div>
           ) : null}
 
@@ -617,7 +620,7 @@ export function App() {
           {surface === "system" && systemTab === "telemetry" ? <TelemetrySurface /> : null}
           {surface === "knowledge" && knowledgeTab === "store" ? <KnowledgeStore onError={setError} /> : null}
           {surface === "knowledge" && knowledgeTab === "playbooks" ? <PlaybooksSurface onError={setError} /> : null}
-          {surface === "system" && systemTab === "settings" ? <SettingsSurface /> : null}
+          {surface === "settings" ? <SettingsSurface /> : null}
         </main>
 
         <aside className="right-panel">

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -457,6 +457,13 @@ h2 {
   grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
+/* Settings panel: header · category sub-nav · scrolling body (ADR 0020). The
+   sub-nav is its own auto row so it doesn't land in the 1fr content row and
+   overlap the fields. */
+.stage-panel.settings-panel {
+  grid-template-rows: auto auto minmax(0, 1fr);
+}
+
 /* Scrollable body for panels whose content is a top-down stack (Schedule,
    Runtime) rather than a single fill-the-space element. Occupies the panel's
    1fr row and scrolls; block layout so children keep their natural height

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -21,7 +21,7 @@ import type { SettingsField } from "../lib/types";
 
 export function SettingsSurface() {
   return (
-    <section className="panel stage-panel">
+    <section className="panel stage-panel settings-panel">
       <QueryErrorResetBoundary>
         {({ reset }) => (
           <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="settings" />}>


### PR DESCRIPTION
Follow-up to the ADR 0020 Settings regroup (#533): the category sub-nav was overlapping the fields.

## Cause

`SettingsSurface` wraps a `.stage-panel` whose grid is `auto · 1fr · auto` (header / body / footer). `SettingsBody` returns three children (header, **category sub-nav**, body), so the sub-nav landed in the `1fr` content row and stretched over the fields, shoving the body into the bottom `auto` row.

## Fix

- **Grid**: a `.settings-panel` modifier with `grid-template-rows: auto auto minmax(0,1fr)` — header · sub-nav · scrolling body, so the sub-nav gets its own auto row.
- **Own surface** (as requested): promoted **Settings out of the System sub-nav into a top-level rail item** with its own view, so its category sub-nav no longer competes with System's. System is now just **Runtime · Telemetry**.

## Verification

Screenshot of the live instance — Settings is its own rail item (sliders icon), the Agent · Behavior · Memory · Integrations · System sub-nav renders as a clean single row, fields below it scroll. Build + 42 e2e pass (the Save/checkbox interactions in `settings.spec` would fail if the sub-nav still covered the content).

🤖 Generated with [Claude Code](https://claude.com/claude-code)