### PR TITLE
fix(memory): remove per-turn raw dump + scratch_pad guardrail (ADR 0021 Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Knowledge store no longer fills with raw reasoning** (ADR 0021). The memory
+  middleware dumped *every* assistant turn into the knowledge base — raw,
+  truncated at 2000 chars, with the model's internal `<scratch_pad>` reasoning
+  intact — which the retrieval layer then recycled into later prompts. That
+  per-turn dump is removed (conversation knowledge is captured by the summarized,
+  scratch_pad-stripped `conversation_harvest` on thread retirement instead). A
+  guardrail at the store's single write chokepoint (`KnowledgeStore.add_chunk`)
+  now strips `<scratch_pad>`/`<think>` from *every* writer defensively — internal
+  reasoning can never reach the store again. Regression tests added.
 - **Settings is its own rail surface; category sub-nav no longer overlaps the
   fields.** The category sub-nav (added with the Settings regroup) landed in the
   `.stage-panel` grid's `1fr` content row, so it stretched over the fields. Gave

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 import tempfile
-import threading
 from datetime import datetime, timezone
 from typing import Any
 
@@ -318,11 +317,20 @@ class MemoryMiddleware(AgentMiddleware):
     # --- Knowledge extraction (existing) ---
 
     def after_agent(self, state, runtime) -> dict | None:
-        """Queue conversation for async knowledge extraction. Persists session on terminal turn."""
+        """Persist a session summary on the terminal turn.
+
+        Knowledge capture is **not** done here. The per-turn ``add_finding``
+        dump that used to live here stored raw assistant turns — scratch_pad and
+        all, truncated mid-content — which the retrieval layer then recycled into
+        future prompts. ADR 0021 removed it: conversation knowledge is captured
+        by ``conversation_harvest`` (summarized, scratch_pad-stripped) when a
+        thread retires, and semantic facts by the extractor — extract, don't
+        dump; background, not hot-path.
+        """
         messages = state.get("messages", [])
 
-        # --- Session persistence: detect terminal turn ---
-        # Terminal = last message is AIMessage with content and no pending tool calls
+        # Session persistence: terminal = last message is an AIMessage with
+        # content and no pending tool calls.
         if messages:
             last_msg = messages[-1]
             if (
@@ -333,44 +341,6 @@ class MemoryMiddleware(AgentMiddleware):
                 import tracing
                 trace_id = tracing.current_trace_id()
                 _persist_session(state, trace_id)
-
-        # --- Knowledge extraction (only when a store is configured) ---
-        if self._store is None:
-            return None
-        if len(messages) < 2:
-            return None
-
-        # Extract the last exchange (human + AI)
-        last_human = None
-        last_ai = None
-        for msg in reversed(messages):
-            if isinstance(msg, AIMessage) and last_ai is None:
-                last_ai = msg.content if isinstance(msg.content, str) else str(msg.content)
-            elif isinstance(msg, HumanMessage) and last_human is None:
-                last_human = msg.content if isinstance(msg.content, str) else str(msg.content)
-            if last_human and last_ai:
-                break
-
-        if not last_human or not last_ai:
-            return None
-
-        # Only store if the response contains substantial content
-        if len(last_ai) < 100:
-            return None
-
-        # Async storage — don't block the response
-        def _store():
-            try:
-                self._store.add_finding(
-                    content=last_ai[:2000],
-                    source="conversation",
-                    source_type="chat",
-                    finding_type="insight",
-                )
-            except Exception:
-                pass
-
-        threading.Thread(target=_store, daemon=True).start()
         return None
 
     async def aafter_agent(self, state, runtime) -> dict | None:

--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -135,6 +135,18 @@ def _strip_reasoning(text: str) -> str:
     return text
 
 
+def strip_reasoning(text: str) -> str:
+    """Public reasoning-stripper for *storage* guardrails (ADR 0021).
+
+    Removes leaked ``<scratch_pad>`` / ``<think>`` / confidence markers but
+    keeps everything else intact — unlike ``extract_output``, it does NOT pull
+    out only the ``<output>`` block, so a stored note that legitimately mentions
+    the protocol isn't reshaped. The contract: the model's internal reasoning
+    must never be persisted to the knowledge base. Idempotent.
+    """
+    return _strip_reasoning(text or "")
+
+
 def _strip_reasoning_balanced(text: str) -> str:
     """Strip only *balanced* reasoning blocks — no orphan eat-to-end variants.
 

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -43,6 +43,29 @@ log = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = "/sandbox/knowledge/agent.db"
 
+# Fallback reasoning-stripper used if graph.output_format isn't importable (the
+# store must never hard-depend on the graph package). Mirrors its scratch_pad /
+# think / orphan-open rules.
+_FALLBACK_REASONING_RE = re.compile(
+    r"<scratch_pad>[\s\S]*?</scratch_pad>|<think>[\s\S]*?</think>"
+    r"|<scratch_pad>[\s\S]*$|<think>[\s\S]*$",
+    re.IGNORECASE,
+)
+
+
+def _strip_stored_reasoning(content: str) -> str:
+    """ADR 0021 storage guardrail: scrub leaked model reasoning before persist.
+
+    Prefers the canonical ``graph.output_format.strip_reasoning`` (lazy import,
+    no knowledge→graph load cycle); falls back to a local regex if unavailable.
+    """
+    try:
+        from graph.output_format import strip_reasoning
+
+        return strip_reasoning(content).strip()
+    except Exception:  # noqa: BLE001 — never let stripping break a write
+        return _FALLBACK_REASONING_RE.sub("", content).strip()
+
 
 @dataclass
 class Chunk:
@@ -255,8 +278,18 @@ class KnowledgeStore:
         source_type: str | None = None,
         finding_type: str | None = None,
     ) -> int | None:
-        """Insert a chunk. Returns the new row id, or None on failure."""
+        """Insert a chunk. Returns the new row id, or None on failure.
+
+        Every write funnels through here, so this is where the ADR 0021
+        guardrail lives: the model's internal reasoning must never reach the
+        store. We strip ``<scratch_pad>``/``<think>`` defensively — covering all
+        writers (memory tools, ingest, harvest, future ones), not just the ones
+        that remember to clean their input.
+        """
         if not content or not content.strip():
+            return None
+        content = _strip_stored_reasoning(content)
+        if not content.strip():
             return None
         db = self._get_db()
         if db is None:

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -447,6 +447,29 @@ def test_after_agent_persists_on_terminal_turn(tmp_path):
     mock_persist.assert_called_once_with(state, "trace-after")
 
 
+def test_after_agent_does_not_dump_findings_to_store(tmp_path):
+    """ADR 0021: the per-turn raw knowledge dump is gone. after_agent must NOT
+    write to the knowledge store — conversation knowledge is captured by the
+    summarized harvest on retirement, not a raw per-turn dump."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+
+    store = MagicMock()
+    mw = mod.MemoryMiddleware(knowledge_store=store)
+
+    messages = [
+        HumanMessage(content="What's the release cadence?"),
+        AIMessage(content="x" * 300),  # substantial — the old code would have dumped this
+    ]
+    state = _make_state("after-agent-no-dump", messages=messages)
+
+    with patch.object(mod, "_persist_session"), \
+         patch("tracing.current_trace_id", return_value="t"):
+        mw.after_agent(state, MagicMock())
+
+    store.add_finding.assert_not_called()
+    store.add_chunk.assert_not_called()
+
+
 def test_after_agent_does_not_persist_when_tool_calls_pending(tmp_path):
     """after_agent must NOT persist when the last AIMessage has pending tool_calls."""
     mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})

--- a/tests/test_store_reasoning_guardrail.py
+++ b/tests/test_store_reasoning_guardrail.py
@@ -1,0 +1,70 @@
+"""ADR 0021 guardrail: the model's internal reasoning must never reach the
+knowledge store.
+
+Every write funnels through ``KnowledgeStore.add_chunk``, which strips
+``<scratch_pad>``/``<think>`` defensively — so no writer (memory tools, ingest,
+harvest, or a future one) can leak reasoning into the searchable base, where the
+retrieval layer would recycle it into future prompts.
+"""
+
+from __future__ import annotations
+
+from knowledge.store import KnowledgeStore
+
+
+def _only_chunk(store: KnowledgeStore) -> str:
+    chunks = store.list_chunks(limit=10)
+    assert chunks, "expected a stored chunk"
+    return chunks[0].content
+
+
+def test_add_chunk_strips_scratch_pad_keeps_output(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    raw = (
+        "<scratch_pad>The user wants the release cadence. Let me recall…</scratch_pad>\n"
+        "<output>Releases are cut manually via workflow_dispatch.</output>"
+    )
+    store.add_chunk(raw, domain="finding")
+    stored = _only_chunk(store)
+    assert "scratch_pad" not in stored.lower()
+    assert "Releases are cut manually" in stored
+
+
+def test_add_chunk_strips_think_tags(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("<think>internal</think>The gateway alias is protolabs/reasoning.", domain="general")
+    stored = _only_chunk(store)
+    assert "<think>" not in stored and "internal" not in stored
+    assert "protolabs/reasoning" in stored
+
+
+def test_add_chunk_strips_orphan_open_scratch_pad(tmp_path):
+    # Truncated mid-reasoning (max_tokens) — the orphan opener eats to end.
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("Visible fact.\n<scratch_pad>then it got cut off mid-thought", domain="general")
+    stored = _only_chunk(store)
+    assert "scratch_pad" not in stored.lower()
+    assert "Visible fact." in stored
+
+
+def test_add_finding_inherits_the_guardrail(tmp_path):
+    # add_finding funnels through add_chunk, so it's covered too.
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_finding("<scratch_pad>noise</scratch_pad>Real finding.", finding_type="fact")
+    stored = _only_chunk(store)
+    assert "scratch_pad" not in stored.lower()
+    assert "Real finding." in stored
+
+
+def test_chunk_that_is_only_reasoning_is_dropped(tmp_path):
+    # If stripping leaves nothing, nothing is stored (no empty-row pollution).
+    store = KnowledgeStore(tmp_path / "kb.db")
+    rid = store.add_chunk("<scratch_pad>pure internal reasoning, no output</scratch_pad>", domain="finding")
+    assert rid is None
+    assert store.list_chunks(limit=10) == []
+
+
+def test_clean_content_passes_through_unchanged(tmp_path):
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("A plain fact with no tags.", domain="general")
+    assert _only_chunk(store) == "A plain fact with no tags."


### PR DESCRIPTION
**Phase 1** of [ADR 0021](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0021-agent-memory-architecture.md) — *extract, don't dump*. Stops the bleeding.

## Problem

`MemoryMiddleware.after_agent` dumped **every** assistant turn ≥100 chars into the knowledge base — `last_ai[:2000]` **raw**, with the model's internal `<scratch_pad>` reasoning intact and the content truncated mid-sentence. `KnowledgeMiddleware` then injects store matches into future prompts, so the leaked reasoning got **recycled**. (Surfaced when ADR 0020 made the Store browsable — it was full of scratch_pad and half-sentences.)

## Fix

- **Remove the per-turn dump** (keep session persistence). Conversation knowledge is already captured *correctly* by `conversation_harvest` — summarized via the aux model, scratch_pad-stripped — when a thread retires.
- **Guardrail at the single write chokepoint**: `KnowledgeStore.add_chunk` now strips `<scratch_pad>`/`<think>` from **every** writer (memory tools, ingest, harvest, future ones), via `graph.output_format.strip_reasoning` (lazy import + regex fallback, no knowledge→graph cycle). A chunk that's *only* reasoning is dropped, not stored empty.

## Verification

- New `test_store_reasoning_guardrail.py` (strip / drop-empty / clean-passthrough / add_finding inherits it) + `after_agent` no longer writes to the store.
- **Live**: a fresh instance ran a substantial turn → **0 findings before, 0 after, 0 scratch_pad chunks**.
- 966 Python tests pass.

Next: Phase 1.5 (wire the dormant embeddings/hybrid store), Phase 2 (semantic extractor), then a recall eval.

🤖 Generated with [Claude Code](https://claude.com/claude-code)