### PR TITLE
feat(knowledge): wire the dormant embeddings / hybrid store (ADR 0021 Phase 1.5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Semantic recall: the dormant embeddings layer is now wired** (ADR 0021). The
+  `HybridKnowledgeStore` (FTS5 + vector search, RRF-fused, with an embedding
+  circuit breaker) and the `embed_model` config existed but were connected to
+  nothing — knowledge recall was keyword-only. A new `knowledge.embeddings` flag
+  (default **off**) flips `_build_knowledge_store` to the hybrid store with an
+  `embed_fn` wired to the gateway (`graph.llm.create_embed_fn`, same OpenAI-compat
+  endpoint + WAF-safe UA as the chat model). Off → keyword-only (unchanged); on →
+  hybrid semantic + keyword. Any failure degrades to FTS5, never KB-less, and the
+  breaker handles runtime embedding outages. Exposed in Settings → Memory.
+
 ### Fixed
 - **Knowledge store no longer fills with raw reasoning** (ADR 0021). The memory
   middleware dumped *every* assistant turn into the knowledge base — raw,

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -53,6 +53,10 @@ middleware:
 
 knowledge:
   db_path: /sandbox/knowledge/agent.db
+  # Semantic recall: hybrid FTS5 + vector search (RRF-fused) via embed_model.
+  # Off by default (keyword-only) — turn on once your gateway serves an
+  # embedding model. Degrades to keyword search on embedding outage.
+  embeddings: false
   embed_model: nomic-embed-text
   top_k: 5
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -245,6 +245,11 @@ class LangGraphConfig:
     # is read-only or absent (e.g. local ``python server.py``).
     knowledge_db_path: str = "/sandbox/knowledge/agent.db"
     embed_model: str = "nomic-embed-text"
+    # Semantic recall (ADR 0021): when True, the knowledge store is the
+    # HybridKnowledgeStore (FTS5 + vector embeddings via `embed_model`, fused
+    # with RRF). Default off — needs the gateway to serve an embedding model;
+    # the store's circuit breaker falls back to FTS5 on outage. Off = keyword-only.
+    knowledge_embeddings: bool = False
     knowledge_top_k: int = 5
 
     # Conversation checkpointer — persists each chat session's history per
@@ -491,6 +496,7 @@ class LangGraphConfig:
             workflows_enabled=data.get("workflows", {}).get("enabled", cls.workflows_enabled),
             workflow_dir=data.get("workflows", {}).get("dir", cls.workflow_dir),
             embed_model=knowledge.get("embed_model", cls.embed_model),
+            knowledge_embeddings=knowledge.get("embeddings", cls.knowledge_embeddings),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
             skills_enabled=skills.get("enabled", cls.skills_enabled),
             skills_db_path=skills.get("db_path", cls.skills_db_path),

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -5,10 +5,14 @@ so we use ChatOpenAI for everything.
 """
 
 import os
+from collections.abc import Callable
 
-from langchain_openai import ChatOpenAI
+from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
 from graph.config import LangGraphConfig
+
+# Same allowlisted UA the chat client uses (Cloudflare WAF blocks the SDK default).
+_GATEWAY_UA = "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)"
 
 
 def _build_llm_kwargs(config: LangGraphConfig) -> dict:
@@ -74,3 +78,25 @@ def create_llm(config: LangGraphConfig, *, model_name: str | None = None) -> Cha
     if model_name:
         kwargs["model"] = model_name
     return ChatOpenAI(**kwargs)
+
+
+def create_embed_fn(config: LangGraphConfig) -> Callable[[str], list[float]] | None:
+    """Build a sync ``text -> vector`` function against the same gateway, or None.
+
+    Routes ``knowledge.embed_model`` through the OpenAI-compatible LiteLLM
+    gateway (ADR 0021), so semantic search reuses the model infra we already
+    have. Returns ``None`` when no embed model is configured — callers fall back
+    to FTS5. Runtime embedding outages are handled by the
+    ``HybridKnowledgeStore`` circuit breaker, not here.
+    """
+    model = (getattr(config, "embed_model", "") or "").strip()
+    if not model:
+        return None
+    api_key = config.api_key or os.environ.get("OPENAI_API_KEY", "")
+    embeddings = OpenAIEmbeddings(
+        base_url=config.api_base,
+        api_key=api_key,
+        model=model,
+        default_headers={"User-Agent": _GATEWAY_UA},
+    )
+    return embeddings.embed_query

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -93,7 +93,12 @@ FIELDS: list[Field] = [
     # ── Knowledge / memory ───────────────────────────────────────────────────
     Field("knowledge.top_k", "knowledge_top_k", "Knowledge recall top-k", "number", "Knowledge",
           minimum=1),
-    Field("knowledge.embed_model", "embed_model", "Embedding model", "string", "Knowledge"),
+    Field("knowledge.embeddings", "knowledge_embeddings", "Semantic recall (embeddings)", "bool", "Knowledge",
+          "Hybrid FTS5 + vector search via the embedding model (RRF-fused). Off = "
+          "keyword-only. Needs the gateway to serve the embedding model; falls back "
+          "to keyword search on outage.", restart=True),
+    Field("knowledge.embed_model", "embed_model", "Embedding model", "string", "Knowledge",
+          "Gateway alias used when semantic recall is on."),
     Field("skills.top_k", "skills_top_k", "Skill recall top-k", "number", "Knowledge", minimum=1),
     Field("checkpoint.db_path", "checkpoint_db_path", "Conversation history DB", "string", "Knowledge",
           "SQLite path for per-session chat history (survives restarts). Blank = in-memory.",

--- a/server.py
+++ b/server.py
@@ -358,6 +358,22 @@ def _build_knowledge_store(config):
         return None
     try:
         from knowledge import KnowledgeStore
+        # Semantic recall (ADR 0021): when knowledge.embeddings is on, use the
+        # HybridKnowledgeStore (FTS5 + vector, fused with RRF) with an embed_fn
+        # wired to the gateway. Any failure degrades to keyword-only FTS5 — never
+        # KB-less — and the store's circuit breaker handles runtime outages.
+        if getattr(config, "knowledge_embeddings", False):
+            try:
+                from graph.llm import create_embed_fn
+                from knowledge.hybrid_store import HybridKnowledgeStore
+
+                embed_fn = create_embed_fn(config)
+                if embed_fn is not None:
+                    log.info("[server] knowledge: hybrid store (FTS5 + embeddings via %s)", config.embed_model)
+                    return HybridKnowledgeStore(db_path=config.knowledge_db_path, embed_fn=embed_fn)
+                log.warning("[server] knowledge.embeddings on but no embed_model — FTS5 only")
+            except Exception as exc:  # noqa: BLE001 — degrade to FTS5, never fail
+                log.warning("[server] hybrid store init failed: %s; FTS5 only", exc)
         return KnowledgeStore(db_path=config.knowledge_db_path)
     except Exception as exc:
         log.warning("[server] knowledge store init failed: %s; running KB-less", exc)

--- a/tests/test_embeddings_wiring.py
+++ b/tests/test_embeddings_wiring.py
@@ -1,0 +1,52 @@
+"""ADR 0021 Phase 1.5: the dormant embeddings layer is now wired.
+
+`knowledge.embeddings` flips the store from keyword-only FTS5 to the
+HybridKnowledgeStore (FTS5 + vector via the gateway, RRF-fused). Default off;
+any failure degrades to FTS5, never KB-less.
+"""
+
+from __future__ import annotations
+
+import server
+from graph.config import LangGraphConfig
+from graph.llm import create_embed_fn
+
+
+def _cfg(tmp_path, *, embeddings: bool, model: str = "nomic-embed-text") -> LangGraphConfig:
+    cfg = LangGraphConfig()
+    cfg.knowledge_db_path = str(tmp_path / "kb.db")
+    cfg.knowledge_embeddings = embeddings
+    cfg.embed_model = model
+    cfg.api_base = "http://gateway.test/v1"
+    cfg.api_key = "test-key"
+    return cfg
+
+
+def test_create_embed_fn_none_without_model():
+    cfg = LangGraphConfig()
+    cfg.embed_model = ""
+    assert create_embed_fn(cfg) is None
+
+
+def test_create_embed_fn_callable_with_model():
+    # Constructs the OpenAIEmbeddings client; no network call until invoked.
+    cfg = LangGraphConfig()
+    cfg.api_base, cfg.api_key = "http://gateway.test/v1", "k"
+    fn = create_embed_fn(cfg)
+    assert callable(fn)
+
+
+def test_store_is_keyword_only_by_default(tmp_path):
+    store = server._build_knowledge_store(_cfg(tmp_path, embeddings=False))
+    assert type(store).__name__ == "KnowledgeStore"
+
+
+def test_store_is_hybrid_when_embeddings_enabled(tmp_path):
+    store = server._build_knowledge_store(_cfg(tmp_path, embeddings=True))
+    assert type(store).__name__ == "HybridKnowledgeStore"
+
+
+def test_hybrid_degrades_to_keyword_when_no_embed_model(tmp_path):
+    # Embeddings on but no model → fall back to FTS5, never crash.
+    store = server._build_knowledge_store(_cfg(tmp_path, embeddings=True, model=""))
+    assert type(store).__name__ == "KnowledgeStore"


### PR DESCRIPTION
**Phase 1.5** of [ADR 0021](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0021-agent-memory-architecture.md) — lighting up capability we already had switched off (from the `/due-diligence` audit).

## Finding

`knowledge/hybrid_store.py` is a complete `HybridKnowledgeStore` — FTS5 + vector embeddings, fused with Reciprocal Rank Fusion, with an embedding circuit breaker. The `embed_model: nomic-embed-text` config (even shown in the Settings UI) existed. But `_build_knowledge_store` **always** returned the plain keyword-only store, and nothing built an `embed_fn`. So "what does the agent know" recall was lexical matching — *"how do I deploy"* would miss a *"release pipeline is manual"* fact.

Research backs the upgrade: hybrid (BM25/FTS5 + vector + RRF) decisively beats keyword-only ("FTS5-only unusable past ~3k files"); RRF needs the least tuning; measure on an eval set (Phase 2 task).

## Change

- **`graph.llm.create_embed_fn`** — `text → vector` via `OpenAIEmbeddings` on the same OpenAI-compatible gateway as the chat model (same WAF-safe UA), or `None` when no embed model.
- **`knowledge.embeddings` flag** (default **off**) — flips `_build_knowledge_store` to the hybrid store with the gateway `embed_fn`. Off = keyword-only (unchanged for every existing fork); on = hybrid semantic + keyword.
- **Safe by construction** — any failure degrades to FTS5 (never KB-less); the store's breaker handles runtime embedding outages. Exposed in **Settings → Memory**; example config documents it.

## Verification

- Tests: `create_embed_fn` None/callable; store is keyword by default, hybrid when enabled, degrades when no model (`test_embeddings_wiring.py`). 971 Python tests pass.
- Default-off keeps the template safe for forks whose gateway doesn't serve embeddings; the **recall eval** (next) measures the on-vs-off quality delta live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)