### PR TITLE
fix(memory): clean <prior_sessions> + one shared loader (ADR 0021 Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`<prior_sessions>` can no longer leak reasoning; one loader, not two** (ADR
+  0021). The persisted session files (injected each turn as `<prior_sessions>`
+  for cross-session recency) stored raw assistant content — so the model's
+  `<scratch_pad>` could ride into later prompts. Now stripped at the write
+  source *and* at read (defensive for files written by older builds). The two
+  copy-pasted loaders in `MemoryMiddleware` and `KnowledgeMiddleware` are
+  collapsed into a single `load_prior_sessions` (the duplication the code itself
+  lamented). `<prior_sessions>` is kept — it's the only *immediate* cross-session
+  recency the checkpointer/harvest don't provide.
+
 ### Added
 - **Semantic fact extraction — the memory upgrade** (ADR 0021). The session-end
   pass (`conversation_harvest`) now does both halves: the episodic summary *and*

--- a/docs/adr/0021-agent-memory-architecture.md
+++ b/docs/adr/0021-agent-memory-architecture.md
@@ -90,8 +90,11 @@ One store, one retrieval path (`KnowledgeMiddleware`) over **typed** entries
 - Less storage and fewer embeddings; cheaper retrieval.
 - Phase 2 adds an aux-model extraction pass on session end — a modest background
   cost, the same cheap model `conversation_harvest` already uses.
-- `<prior_sessions>` (raw JSON injection) is redundant with the checkpointer
-  (same-thread) and harvest (cross-thread) — it goes.
+- `<prior_sessions>` keeps a real role implementation surfaced: it gives
+  *immediate* cross-session recency (written every terminal turn), which the
+  checkpointer (same-thread only) and harvest (retirement-delayed) don't cover.
+  So Phase 3 **cleans** it rather than dropping it — strip reasoning at the
+  source + read, and collapse the two copy-pasted loaders into one.
 
 ## 5. Implementation (phased)
 
@@ -100,7 +103,10 @@ One store, one retrieval path (`KnowledgeMiddleware`) over **typed** entries
    regression-test that scratch_pad can't reach the store. Sweep existing junk.
 2. **Semantic extractor** — Mem0-style fact extraction on session end (background,
    aux model) + consolidate/dedupe + importance gating, `finding_type="fact"`.
-3. **Rationalize overlap** — drop/replace the raw `<prior_sessions>` injection.
+3. **Rationalize overlap** — `<prior_sessions>` stays (it's the only *immediate*
+   cross-session recency), but cleaned: strip reasoning at the persist source +
+   at read (defensive for old files), and collapse the two duplicate loaders
+   into one `load_prior_sessions`.
 4. *(this ADR)* — the decision that never existed.
 
 Phase 1 alone removes the junk and loses nothing real (the raw insights were

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -10,9 +10,7 @@ Retrieves relevant learned skills from the SkillsIndex and injects
 them as a <learned_skills> block alongside <prior_sessions>.
 """
 
-import json
 import logging
-import os
 from typing import TYPE_CHECKING
 
 from langchain.agents.middleware import AgentMiddleware
@@ -87,105 +85,16 @@ class KnowledgeMiddleware(AgentMiddleware):
         max_sessions: int = 10,
         max_tokens: int = 2000,
     ) -> str:
-        """Load prior session summaries and format as a <prior_sessions> block.
+        """Format the most-recent persisted sessions as a ``<prior_sessions>``
+        block for injection.
 
-        Reads up to *max_sessions* most recent JSON files from *memory_path*,
-        enforces *max_tokens* budget by dropping oldest sessions first, and
-        returns a formatted XML block ready for injection into the system
-        prompt context.
-
-        Returns an empty string when the directory is missing (first run) or
-        when no readable sessions exist.  Never raises — all errors are logged
-        and treated as empty memory.
-
-        Token counting uses the character-based approximation (chars // 4)
-        because tiktoken is not guaranteed to be installed.
+        Delegates to the shared :func:`graph.middleware.memory.load_prior_sessions`
+        (ADR 0021) — one source of truth, with read-time reasoning stripping —
+        so this and ``MemoryMiddleware`` can't drift. Never raises.
         """
-        # --- Guard: directory must exist ---
-        if not os.path.isdir(memory_path):
-            log.info(
-                "[knowledge] memory directory not found: %s — starting with empty prior_sessions",
-                memory_path,
-            )
-            return ""
+        from graph.middleware.memory import load_prior_sessions
 
-        # --- List JSON session files, sorted newest-first by mtime ---
-        try:
-            entries: list[tuple[float, str]] = []
-            for fname in os.listdir(memory_path):
-                if not fname.endswith(".json"):
-                    continue
-                fpath = os.path.join(memory_path, fname)
-                try:
-                    entries.append((os.path.getmtime(fpath), fpath))
-                except OSError:
-                    continue
-            entries.sort(reverse=True)  # newest first
-        except OSError as exc:
-            log.warning(
-                "[knowledge] cannot list memory directory %s: %s — treating as empty",
-                memory_path,
-                exc,
-            )
-            return ""
-
-        if not entries:
-            return "<prior_sessions/>"
-
-        # --- Parse session files (skip malformed) ---
-        summaries: list[dict] = []
-        for _, fpath in entries[:max_sessions]:
-            try:
-                with open(fpath, encoding="utf-8") as fh:
-                    data = json.load(fh)
-                summaries.append(data)
-            except (OSError, json.JSONDecodeError, ValueError) as exc:
-                log.debug(
-                    "[knowledge] skipping malformed session file %s: %s", fpath, exc
-                )
-                continue
-
-        if not summaries:
-            return "<prior_sessions/>"
-
-        # --- Format each summary as XML ---
-        def _format_summary(s: dict) -> str:
-            ts = s.get("timestamp", "unknown")
-            sid = s.get("session_id", "unknown")
-            lines = [f'<session id="{sid}" timestamp="{ts}">']
-
-            msgs: list[dict] = s.get("messages", [])
-            if msgs:
-                lines.append("  <messages>")
-                for m in msgs:
-                    role = m.get("role", "unknown")
-                    content = (m.get("content", "") or "")[:500]
-                    lines.append(f"    <{role}>{content}</{role}>")
-                lines.append("  </messages>")
-
-            final = (s.get("final_output") or "")[:300]
-            if final:
-                lines.append(f"  <final_output>{final}</final_output>")
-
-            lines.append("</session>")
-            return "\n".join(lines)
-
-        # Token approximation — chars // 4 (no tiktoken dependency)
-        def _count_tokens(text: str) -> int:
-            return max(1, len(text) // 4)
-
-        # --- Enforce token budget: drop oldest sessions (end of list) ---
-        formatted = [_format_summary(s) for s in summaries]
-        while formatted:
-            joined = "\n".join(formatted)
-            if _count_tokens(joined) <= max_tokens:
-                break
-            formatted.pop()  # remove oldest (newest-first ordering)
-
-        if not formatted:
-            return "<prior_sessions/>"
-
-        return "<prior_sessions>\n" + "\n".join(formatted) + "\n</prior_sessions>"
+        return load_prior_sessions(memory_path, max_sessions, max_tokens)
 
     # ---------------------------------------------------------------------------
     # Skill retrieval

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -91,6 +91,11 @@ def _persist_session(state: dict, trace_id: str) -> None:
     messages_raw: list = state.get("messages", []) or []
 
     # --- Extract user-visible messages ---
+    # Assistant content is run through strip_reasoning so the session file (later
+    # injected as <prior_sessions>) never carries the model's <scratch_pad> —
+    # the ADR 0021 never-persist-reasoning rule applied to this path too.
+    from graph.output_format import strip_reasoning
+
     user_messages: list[dict] = []
     for msg in messages_raw:
         if isinstance(msg, HumanMessage):
@@ -98,7 +103,7 @@ def _persist_session(state: dict, trace_id: str) -> None:
             user_messages.append({"role": "user", "content": content})
         elif isinstance(msg, AIMessage) and msg.content:
             content = msg.content if isinstance(msg.content, str) else str(msg.content)
-            user_messages.append({"role": "assistant", "content": content})
+            user_messages.append({"role": "assistant", "content": strip_reasoning(content)})
 
     # --- Extract tool call records ---
     # Reconstruct from AI messages (which carry tool_calls) and ToolMessages
@@ -133,7 +138,8 @@ def _persist_session(state: dict, trace_id: str) -> None:
     final_output: str | None = None
     for msg in reversed(messages_raw):
         if isinstance(msg, AIMessage) and msg.content:
-            final_output = msg.content if isinstance(msg.content, str) else str(msg.content)
+            raw_final = msg.content if isinstance(msg.content, str) else str(msg.content)
+            final_output = strip_reasoning(raw_final)
             break
 
     # --- Build summary ---
@@ -186,6 +192,82 @@ def _persist_session(state: dict, trace_id: str) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Prior-sessions loader — single source of truth (ADR 0021)
+# ---------------------------------------------------------------------------
+
+def load_prior_sessions(
+    memory_path: str = MEMORY_PATH,
+    max_sessions: int = 10,
+    max_tokens: int = 2000,
+) -> str:
+    """Format the most-recent persisted sessions as a ``<prior_sessions>`` block.
+
+    The canonical loader used by *both* ``MemoryMiddleware`` and
+    ``KnowledgeMiddleware`` — previously two copy-pasted implementations. Reads
+    up to ``max_sessions`` newest JSON files, drops oldest-first to fit
+    ``max_tokens`` (char/4 approximation), and **strips reasoning at read** so a
+    file written before the persist-time strip (or by an older build) still
+    can't inject ``<scratch_pad>`` into the prompt. Never raises.
+    """
+    from graph.output_format import strip_reasoning
+
+    if not os.path.isdir(memory_path):
+        return ""
+    try:
+        entries: list[tuple[float, str]] = []
+        for fname in os.listdir(memory_path):
+            if not fname.endswith(".json"):
+                continue
+            fpath = os.path.join(memory_path, fname)
+            try:
+                entries.append((os.path.getmtime(fpath), fpath))
+            except OSError:
+                continue
+        entries.sort(reverse=True)  # newest first
+    except OSError:
+        return ""
+    if not entries:
+        return "<prior_sessions/>"
+
+    summaries: list[dict] = []
+    for _, fpath in entries[:max_sessions]:
+        try:
+            with open(fpath, encoding="utf-8") as fh:
+                summaries.append(json.load(fh))
+        except (OSError, json.JSONDecodeError, ValueError):
+            continue
+    if not summaries:
+        return "<prior_sessions/>"
+
+    def _format(s: dict) -> str:
+        ts = s.get("timestamp", "unknown")
+        sid = s.get("session_id", "unknown")
+        lines = [f'<session id="{sid}" timestamp="{ts}">']
+        msgs = s.get("messages", []) or []
+        if msgs:
+            lines.append("  <messages>")
+            for m in msgs:
+                role = m.get("role", "unknown")
+                content = strip_reasoning(m.get("content", "") or "")[:500]
+                lines.append(f"    <{role}>{content}</{role}>")
+            lines.append("  </messages>")
+        final = strip_reasoning(s.get("final_output") or "")[:300]
+        if final:
+            lines.append(f"  <final_output>{final}</final_output>")
+        lines.append("</session>")
+        return "\n".join(lines)
+
+    formatted = [_format(s) for s in summaries]
+    while formatted:
+        if max(1, len("\n".join(formatted)) // 4) <= max_tokens:
+            break
+        formatted.pop()  # drop oldest (newest-first ordering)
+    if not formatted:
+        return "<prior_sessions/>"
+    return "<prior_sessions>\n" + "\n".join(formatted) + "\n</prior_sessions>"
+
+
+# ---------------------------------------------------------------------------
 # Middleware class
 # ---------------------------------------------------------------------------
 
@@ -206,70 +288,13 @@ class MemoryMiddleware(AgentMiddleware):
     # --- Session memory loading (only used when no KnowledgeMiddleware is active) ---
 
     def _load_prior_sessions(self) -> str:
-        """Lazy-load prior session summaries when standalone (no KnowledgeMiddleware).
+        """Prior-session continuity when standalone (no KnowledgeMiddleware).
 
-        When KnowledgeMiddleware is also in the chain it owns `<prior_sessions>`
-        injection. This method runs only when `self._store is None`, so there is
-        no double-injection risk.
-
-        Reads from MEMORY_PATH, returns an XML block or empty string on first
-        run. Mirrors KnowledgeMiddleware.load_memory() but without the store
-        dependency — single source of truth would be cleaner but would couple
-        the two files.
+        Delegates to the shared :func:`load_prior_sessions` (ADR 0021) — one
+        source of truth for both middlewares. Runs only when ``self._store is
+        None``, so there's no double-injection with KnowledgeMiddleware.
         """
-        if not os.path.isdir(MEMORY_PATH):
-            return ""
-        try:
-            entries = []
-            for fname in os.listdir(MEMORY_PATH):
-                if not fname.endswith(".json"):
-                    continue
-                fpath = os.path.join(MEMORY_PATH, fname)
-                try:
-                    entries.append((os.path.getmtime(fpath), fpath))
-                except OSError:
-                    continue
-            entries.sort(reverse=True)
-        except OSError:
-            return ""
-        if not entries:
-            return "<prior_sessions/>"
-        summaries = []
-        for _, fpath in entries[:10]:
-            try:
-                with open(fpath, encoding="utf-8") as fh:
-                    summaries.append(json.load(fh))
-            except (OSError, json.JSONDecodeError, ValueError):
-                continue
-        if not summaries:
-            return "<prior_sessions/>"
-        lines_out = []
-        for s in summaries:
-            ts = s.get("timestamp", "unknown")
-            sid = s.get("session_id", "unknown")
-            lines = [f'<session id="{sid}" timestamp="{ts}">']
-            msgs = s.get("messages", []) or []
-            if msgs:
-                lines.append("  <messages>")
-                for m in msgs:
-                    role = m.get("role", "unknown")
-                    content = (m.get("content", "") or "")[:500]
-                    lines.append(f"    <{role}>{content}</{role}>")
-                lines.append("  </messages>")
-            final = (s.get("final_output") or "")[:300]
-            if final:
-                lines.append(f"  <final_output>{final}</final_output>")
-            lines.append("</session>")
-            lines_out.append("\n".join(lines))
-        # 2K token budget — chars // 4 approx, drop oldest first
-        while lines_out:
-            joined = "\n".join(lines_out)
-            if max(1, len(joined) // 4) <= 2000:
-                break
-            lines_out.pop()
-        if not lines_out:
-            return "<prior_sessions/>"
-        return "<prior_sessions>\n" + "\n".join(lines_out) + "\n</prior_sessions>"
+        return load_prior_sessions(MEMORY_PATH)
 
     def before_model(self, state, runtime) -> dict | None:
         """Inject `<prior_sessions>` into system prompt when running standalone.

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -114,6 +114,25 @@ def test_persist_session_captures_messages(tmp_path):
     assert any("4" in c for c in contents)
 
 
+def test_persist_session_strips_reasoning_from_assistant(tmp_path):
+    """ADR 0021: the persisted session (later injected as <prior_sessions>) must
+    not carry the model's <scratch_pad> — strip it at the write source."""
+    mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
+    messages = [
+        HumanMessage(content="What is 2+2?"),
+        AIMessage(content="<scratch_pad>add 2 and 2, that's 4</scratch_pad><output>It's 4.</output>"),
+    ]
+    state = _make_state("strip-test", messages=messages)
+    mod._persist_session(state, "t")
+
+    data = json.loads((tmp_path / "strip-test.json").read_text())
+    blob = json.dumps(data)
+    assert "scratch_pad" not in blob
+    assert "add 2 and 2" not in blob          # internal reasoning gone
+    assert "It's 4." in blob                   # user-facing answer kept
+    assert "scratch_pad" not in (data["final_output"] or "")
+
+
 def test_persist_session_final_output_is_last_ai_message(tmp_path):
     mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
 

--- a/tests/test_prior_sessions.py
+++ b/tests/test_prior_sessions.py
@@ -1,0 +1,68 @@
+"""ADR 0021 Phase 3: one shared <prior_sessions> loader, with read-time
+reasoning stripping.
+
+The loader is the single source of truth for both MemoryMiddleware and
+KnowledgeMiddleware (previously two copy-pasted copies). It strips reasoning at
+read so a session file written by an older build can't inject <scratch_pad> into
+the prompt.
+"""
+
+from __future__ import annotations
+
+import json
+
+from graph.middleware.memory import load_prior_sessions
+
+
+def _write(d, sid, messages, final_output=""):
+    (d / f"{sid}.json").write_text(json.dumps({
+        "session_id": sid,
+        "timestamp": "2026-06-05T00:00:00Z",
+        "messages": messages,
+        "final_output": final_output,
+    }))
+
+
+def test_loader_strips_reasoning_from_dirty_old_files(tmp_path):
+    # Simulate a file written before the persist-time strip existed.
+    _write(
+        tmp_path, "s1",
+        [{"role": "assistant", "content": "<scratch_pad>secret plan</scratch_pad>The answer is 42."}],
+        final_output="<scratch_pad>noise</scratch_pad>Done.",
+    )
+    block = load_prior_sessions(str(tmp_path))
+    assert "scratch_pad" not in block
+    assert "secret plan" not in block
+    assert "The answer is 42." in block
+    assert "Done." in block
+
+
+def test_loader_empty_and_missing_dir(tmp_path):
+    assert load_prior_sessions(str(tmp_path)) == "<prior_sessions/>"   # empty dir
+    assert load_prior_sessions(str(tmp_path / "nope")) == ""           # missing dir
+
+
+def test_loader_returns_block_for_clean_session(tmp_path):
+    _write(tmp_path, "s1", [{"role": "user", "content": "my color is teal"}])
+    block = load_prior_sessions(str(tmp_path))
+    assert block.startswith("<prior_sessions>")
+    assert "teal" in block
+
+
+def test_loader_token_budget_trims(tmp_path):
+    for i in range(20):
+        _write(tmp_path, f"s{i:02d}", [{"role": "user", "content": "x" * 2000}])
+    block = load_prior_sessions(str(tmp_path), max_tokens=400)
+    # Trimmed to fit the budget (rough char/4) rather than dumping all 20.
+    assert block != "<prior_sessions/>"
+    assert len(block) // 4 <= 700  # budget + one-session slack
+
+
+def test_both_middlewares_use_the_same_loader(tmp_path):
+    """KnowledgeMiddleware.load_memory delegates to load_prior_sessions, so the
+    two can't drift."""
+    from graph.middleware.knowledge import KnowledgeMiddleware
+
+    _write(tmp_path, "s1", [{"role": "user", "content": "shared loader check"}])
+    mw = KnowledgeMiddleware.__new__(KnowledgeMiddleware)  # no __init__ needed
+    assert mw.load_memory(str(tmp_path)) == load_prior_sessions(str(tmp_path))


### PR DESCRIPTION
**Phase 3** of [ADR 0021](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0021-agent-memory-architecture.md) — the last of the memory cleanup.

## What I found vs. the ADR

The ADR assumed `<prior_sessions>` was redundant and "goes." Digging in, it isn't: the persisted session files are written **every terminal turn**, so `<prior_sessions>` is the only **immediate** cross-session recency — the checkpointer is same-thread, and harvest is retirement-delayed. So it stays. (ADR §4/§5 revised to match.)

But it had two real problems:
1. The session files stored **raw assistant content**, so the model's `<scratch_pad>` could ride into later prompts via the injection.
2. The loader was **copy-pasted** across `MemoryMiddleware` and `KnowledgeMiddleware` (the code comment literally said "single source of truth would be cleaner but would couple the two files").

## Fix

- **Strip reasoning at the source** (`_persist_session`: assistant content + `final_output`) **and at read** (`load_prior_sessions` formats through `strip_reasoning`) — defensive for files written by older builds.
- **One loader**: collapsed both into `graph.middleware.memory.load_prior_sessions`; `KnowledgeMiddleware.load_memory` delegates to it. Dropped now-unused `os`/`json` imports from `knowledge.py`.

## Verification

- Tests: persist strips scratch_pad; loader strips dirty old files; token-budget trim; **both middlewares share the loader** (can't drift).
- 993 Python tests pass.

This completes the ADR 0021 memory work bar the recall eval (next).

🤖 Generated with [Claude Code](https://claude.com/claude-code)