### PR TITLE
test(evals): add fact_recall — semantic-fact bucket recall (ADR 0021)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`fact_recall` eval** — locks the new semantic-fact bucket: a `domain="fact"`
+  chunk (what the harvest extractor produces) is passively recalled by the
+  KnowledgeMiddleware and surfaced in the answer. Tracked alongside the existing
+  recall cases (ADR 0012). The hybrid-vs-keyword recall comparison runs via
+  `evals.sweep` with `knowledge.embeddings` on (once the gateway serves an
+  embedding model).
+
 ### Fixed
 - **`<prior_sessions>` can no longer leak reasoning; one loader, not two** (ADR
   0021). The persisted session files (injected each turn as `<prior_sessions>`

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -195,6 +195,26 @@
   },
 
   {
+    "id": "fact_recall",
+    "category": "subsystem",
+    "kind": "ask",
+    "name": "A harvested semantic fact (domain=fact) is recalled passively",
+    "setup": [
+      {"kb_ingest": {
+        "content": "The operator's preferred editor is Neovim with the Catppuccin theme.",
+        "domain": "fact",
+        "heading": "editor-pref"
+      }}
+    ],
+    "prompt": "What editor and color theme do I use?",
+    "expected_tools": [],
+    "expected_patterns": ["neovim", "catppuccin"],
+    "teardown": [
+      {"kb_delete_by_heading": {"domain": "fact", "heading": "editor-pref"}}
+    ]
+  },
+
+  {
     "id": "goal_achieved",
     "category": "goal",
     "kind": "goal",


### PR DESCRIPTION
The recall eval that finishes the ADR 0021 memory work — proves the new `domain="fact"` bucket (the harvest extractor's output) is actually recalled.

## What

A new `fact_recall` subsystem eval: seed a `domain="fact"` chunk, ask a question, assert the KnowledgeMiddleware passively surfaces it in the answer. This locks the *new* semantic-fact pipeline into the tracked recall suite (ADR 0012), alongside the existing `memory_recall_intent` / `knowledge_middleware_recall` / `log_then_recall_chain` cases.

## Notes from building it (live-verified)

- **PASS** on a running instance.
- I first wrote it with a "what's my main project" query — it failed, but instructively: the operator-persona agent answers project questions by **checking Notes/beads** (and reporting them empty) rather than trusting injected knowledge. Switched to a preference-style fact ("what editor/theme do I use") — clean passive recall. Worth remembering for future memory evals: pick queries the persona doesn't route to a tool.
- Also confirmed along the way that the eval store must share the agent's **instance scoping** (`PROTOAGENT_INSTANCE`, not an explicit `KNOWLEDGE_DB_PATH`) for `kb_ingest` seeds to be visible to the agent.

## Hybrid vs. keyword

Deliberately *not* baked as a live case — it needs `knowledge.embeddings` on and the gateway serving an embedding model. It runs via `evals.sweep` once embeddings are enabled (the A/B is a config toggle + sweep, not a flaky inline case).

Eval coverage unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)