### PR TITLE
feat(activity): provenance feed + fix the broken inbox now-fire (ADR 0022)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Activity is a provenance feed, not a second chat** (ADR 0022). Every
+  reactive turn is tagged with *what triggered it* (scheduled job / webhook /
+  inbox source / sister-agent / your reply) — the backend tracked this `origin`
+  on the A2A metadata but dropped it before the UI, so Activity just showed
+  `agent: <text>`. Now `origin`/`trigger`/`priority` ride `TurnOutcome`, land in
+  a small `activity` log, and the console renders a timeline where each entry
+  shows its trigger badge + time + priority, openable to continue. Answers "why
+  did the agent just do that?" at a glance.
+
+### Fixed
+- **Inbox `now`-fire was silently broken since the A2A 1.0 migration.** The
+  inbox→Activity fire self-POSTed with the retired 0.3 wire shape (`message/send`,
+  `role: "user"`, params-level `contextId`, no `A2A-Version` header), which
+  a2a-sdk 1.1 rejects with `-32601`/`-32602` — and the fire reported success
+  because a JSON-RPC error rides an HTTP 200. So `now`-priority inbox items never
+  reached the agent. Migrated to the 1.0 shape (matching the scheduler's fire)
+  and the success check now inspects the JSON-RPC error. Found by the Activity
+  audit; verified live (a `now` item now fires and lands in the feed).
+
+### Added
 - **`fact_recall` eval** — locks the new semantic-fact bucket: a `domain="fact"`
   chunk (what the harvest extractor produces) is passively recalled by the
   KnowledgeMiddleware and surfaced in the answer. Tracked alongside the existing

--- a/a2a_executor.py
+++ b/a2a_executor.py
@@ -71,6 +71,13 @@ class TurnOutcome:
     llm_calls: int = 0
     tool_calls: int = 0
     models: list[str] = field(default_factory=list)
+    # Provenance (ADR 0022) — what triggered this turn, from the inbound A2A
+    # message metadata. ``origin`` ∈ scheduler|inbox|webhook|a2a|"" (empty = a
+    # live/operator turn); ``trigger`` is a human label (job id / inbox source);
+    # ``priority`` is the inbox tier when applicable.
+    origin: str = ""
+    trigger: str = ""
+    priority: str = ""
 
 
 # A terminal hook the host can register (ADR 0003 / 0006): invoked with a
@@ -194,6 +201,17 @@ class ProtoAgentExecutor(AgentExecutor):
         text = context.get_user_input()
         caller_trace = _extract_caller_trace(context)
 
+        # Provenance for the Activity feed (ADR 0022): what triggered this turn.
+        _md = _request_metadata(context)
+        _origin = str(_md.get("origin", "") or "")
+        _priority = str(_md.get("priority", "") or "")
+        _trigger = str(
+            _md.get("trigger")
+            or _md.get("scheduler_job_id")
+            or _md.get("inbox_source")
+            or ""
+        )
+
         started = time.monotonic()
         accumulated = ""
         deltas: list[dict] = []
@@ -221,6 +239,9 @@ class ProtoAgentExecutor(AgentExecutor):
                 llm_calls=llm_calls,
                 tool_calls=tool_calls,
                 models=list(models),
+                origin=_origin,
+                trigger=_trigger,
+                priority=_priority,
             )
 
         try:

--- a/activity/__init__.py
+++ b/activity/__init__.py
@@ -1,0 +1,5 @@
+"""Activity provenance feed (ADR 0022)."""
+
+from activity.store import ActivityLog
+
+__all__ = ["ActivityLog"]

--- a/activity/store.py
+++ b/activity/store.py
@@ -1,0 +1,108 @@
+"""ActivityLog — the provenance feed behind the Activity surface (ADR 0022).
+
+One row per terminal turn in the Activity context: *what the agent produced* +
+*what triggered it* (origin / trigger label / inbox priority) + when. This is the
+timeline source for the console feed — a distinct concern from telemetry
+(cost/latency) and from the checkpointer (the continuable conversation), so it
+gets its own small store. The checkpointer still holds the thread for
+continuation; this holds the legible "why".
+"""
+
+from __future__ import annotations
+
+import logging
+import sqlite3
+from datetime import UTC, datetime
+from pathlib import Path
+
+log = logging.getLogger(__name__)
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS activity (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    created_at  TEXT NOT NULL,
+    context_id  TEXT NOT NULL,
+    origin      TEXT NOT NULL DEFAULT '',
+    trigger     TEXT,
+    priority    TEXT,
+    state       TEXT,
+    text        TEXT NOT NULL,
+    task_id     TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_activity_created_at ON activity(created_at);
+"""
+
+
+def _now_iso() -> str:
+    return datetime.now(UTC).isoformat()
+
+
+class ActivityLog:
+    """SQLite-backed provenance feed. Best-effort: never raises into the loop."""
+
+    def __init__(self, db_path: str) -> None:
+        self.path = str(db_path)
+        try:
+            Path(self.path).parent.mkdir(parents=True, exist_ok=True)
+        except OSError:
+            pass
+        try:
+            db = self._connect()
+            db.executescript(_SCHEMA)
+            db.commit()
+            db.close()
+        except sqlite3.DatabaseError:
+            log.exception("[activity] schema init failed at %s", self.path)
+
+    def _connect(self) -> sqlite3.Connection:
+        db = sqlite3.connect(self.path)
+        db.row_factory = sqlite3.Row
+        return db
+
+    def add(
+        self,
+        *,
+        context_id: str,
+        origin: str,
+        text: str,
+        trigger: str = "",
+        priority: str = "",
+        state: str = "completed",
+        task_id: str = "",
+    ) -> int | None:
+        """Append a feed entry. ``origin`` empty ⇒ "operator" (a reply/live turn)."""
+        if not text or not text.strip():
+            return None
+        try:
+            db = self._connect()
+            cur = db.execute(
+                "INSERT INTO activity "
+                "(created_at, context_id, origin, trigger, priority, state, text, task_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                (_now_iso(), context_id, origin or "operator", trigger, priority, state, text, task_id),
+            )
+            db.commit()
+            return int(cur.lastrowid)
+        except sqlite3.DatabaseError:
+            log.exception("[activity] add failed")
+            return None
+        finally:
+            try:
+                db.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def recent(self, limit: int = 50) -> list[dict]:
+        """Most-recent-first feed entries."""
+        try:
+            db = self._connect()
+            rows = db.execute(
+                "SELECT id, created_at, context_id, origin, trigger, priority, state, text, task_id "
+                "FROM activity ORDER BY id DESC LIMIT ?",
+                (limit,),
+            ).fetchall()
+            db.close()
+            return [dict(r) for r in rows]
+        except sqlite3.DatabaseError:
+            log.warning("[activity] recent failed")
+            return []

--- a/apps/web/e2e/activity.spec.ts
+++ b/apps/web/e2e/activity.spec.ts
@@ -1,32 +1,37 @@
 import { expect, test } from "@playwright/test";
 
-// The Activity surface (ADR 0003): the durable thread where agent-initiated
-// turns land. Loads history from GET /api/activity, shows an unread badge while
-// off-surface, and appends pushed `activity.message` events live.
+// The Activity provenance feed (ADR 0022): a timeline of agent-initiated turns,
+// each tagged with what triggered it. Loads entries from GET /api/activity,
+// shows an unread badge while off-surface, and appends pushed events live.
 
-test("unread badge counts pushed messages; surface shows history + live append", async ({ page }) => {
+test("feed shows entries with provenance + live append", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
   // Pushed activity messages arrive while we're on Chat → the rail badge shows.
   await expect(page.getByTestId("activity-badge")).toBeVisible();
 
   await page.getByRole("button", { name: "Activity", exact: true }).click();
-  // Activity opens on its Thread sub-tab by default.
   await expect(page.getByRole("heading", { name: "Activity" })).toBeVisible();
 
-  // History from GET /api/activity renders.
-  await expect(page.getByText("morning standup")).toBeVisible();
-  await expect(page.getByText("3 PRs merged overnight, CI green.")).toBeVisible();
+  const feed = page.getByTestId("activity-surface");
+  // Entry text + its provenance badges (origin + trigger) render.
+  await expect(feed.getByText("3 PRs merged overnight, CI green.")).toBeVisible();
+  await expect(feed.getByText("scheduled").first()).toBeVisible(); // origin badge
+  await expect(feed.getByText("daily-brief")).toBeVisible(); // trigger label
+  await expect(feed.getByText("Build failed on main — investigating.")).toBeVisible();
+  await expect(feed.getByText("inbox").first()).toBeVisible(); // inbox origin badge
 
   // A pushed event appends live while the surface is open.
-  await expect(page.getByText("live activity ping").first()).toBeVisible();
+  await expect(feed.getByText("live activity ping").first()).toBeVisible();
 });
 
-test("replying optimistically appends the operator's message", async ({ page }) => {
+test("replying clears the composer (the answer returns as a feed entry)", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Activity", exact: true }).click();
 
-  await page.locator(".activity-composer textarea").fill("ping from operator");
+  const composer = page.locator(".activity-composer textarea");
+  await composer.fill("ping from operator");
   await page.getByRole("button", { name: "Send", exact: true }).click();
-  await expect(page.getByText("ping from operator")).toBeVisible();
+  // The feed shows agent outputs (not an echo of your reply); send clears the box.
+  await expect(composer).toHaveValue("");
 });

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -53,6 +53,10 @@ export const SUBAGENTS = [
 
 export const ACTIVITY_HISTORY = {
   context_id: "system:activity",
+  entries: [
+    { id: 1, created_at: "2026-06-05T09:00:00+00:00", origin: "scheduler", trigger: "daily-brief", priority: "", state: "completed", text: "3 PRs merged overnight, CI green.", task_id: "t1" },
+    { id: 2, created_at: "2026-06-05T09:05:00+00:00", origin: "inbox", trigger: "ci", priority: "now", state: "completed", text: "Build failed on main — investigating.", task_id: "t2" },
+  ],
   messages: [
     { role: "user", content: "morning standup" },
     { role: "assistant", content: "3 PRs merged overnight, CI green." },

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -197,7 +197,7 @@ const server = createServer(async (req, res) => {
     // Push an activity.message periodically so both the unread badge (while off
     // the surface) and live append (while on it) are deterministically testable.
     const t = setInterval(() => {
-      res.write('event: activity.message\ndata: {"text":"live activity ping"}\n\n');
+      res.write('event: activity.message\ndata: {"text":"live activity ping","origin":"scheduler","trigger":"heartbeat"}\n\n');
       res.write('event: inbox.item\ndata: {"id":99,"priority":"next","source":"mock","text":"live inbox ping"}\n\n');
     }, 500);
     req.on("close", () => clearInterval(t));

--- a/apps/web/src/activity/ActivitySurface.tsx
+++ b/apps/web/src/activity/ActivitySurface.tsx
@@ -1,21 +1,56 @@
-import { Loader2, RefreshCw, Send } from "lucide-react";
+import { Clock, Inbox, Loader2, MessageSquare, RefreshCw, Send, Users, Webhook, Zap } from "lucide-react";
 import { useEffect, useRef, useState } from "react";
 
 import { Markdown } from "../chat/LazyMarkdown";
 import { api } from "../lib/api";
 import { onServerEvent } from "../lib/events";
-import type { ActivityMessage } from "../lib/types";
+import type { ActivityEntry } from "../lib/types";
 
-// The durable Activity thread (ADR 0003): where agent-initiated turns
-// (scheduled fires, inbox items) land. Loads history from GET /api/activity,
-// appends live via the `activity.message` push event, and lets the operator
-// reply — a normal turn into the `system:activity` context. We don't render the
-// reply's stream; the assistant's response arrives uniformly via the bus event,
-// the same path a scheduled fire takes, so there's no double-render.
+// The Activity provenance feed (ADR 0022): a timeline of agent-initiated turns,
+// each tagged with what triggered it (scheduled job / webhook / inbox / sister
+// agent / your reply). Loads from GET /api/activity, appends live via the
+// `activity.message` push event, and lets the operator reply into the
+// `system:activity` thread — the reply's answer arrives as a new feed entry.
+
+const ACTIVITY = "system:activity";
+
+// origin → badge (icon + label). "" / unknown falls back to a generic agent turn.
+const ORIGIN: Record<string, { icon: typeof Clock; label: string }> = {
+  scheduler: { icon: Clock, label: "scheduled" },
+  inbox: { icon: Inbox, label: "inbox" },
+  webhook: { icon: Webhook, label: "webhook" },
+  a2a: { icon: Users, label: "sister-agent" },
+  operator: { icon: MessageSquare, label: "you" },
+};
+
+function ago(iso: string): string {
+  const t = Date.parse(iso);
+  if (Number.isNaN(t)) return "";
+  const s = Math.max(0, (Date.now() - t) / 1000);
+  if (s < 60) return "just now";
+  if (s < 3600) return `${Math.round(s / 60)}m ago`;
+  if (s < 86400) return `${Math.round(s / 3600)}h ago`;
+  return `${Math.round(s / 86400)}d ago`;
+}
+
+function Badge({ entry }: { entry: ActivityEntry }) {
+  const o = ORIGIN[entry.origin] ?? { icon: Zap, label: entry.origin || "agent" };
+  const Icon = o.icon;
+  return (
+    <div className="activity-prov">
+      <span className={`activity-origin activity-origin-${entry.origin || "agent"}`}>
+        <Icon size={12} /> {o.label}
+      </span>
+      {entry.trigger ? <span className="activity-trigger">{entry.trigger}</span> : null}
+      {entry.priority ? <span className={`inbox-pri inbox-pri-${entry.priority}`}>{entry.priority}</span> : null}
+      {entry.created_at ? <span className="activity-time">{ago(entry.created_at)}</span> : null}
+    </div>
+  );
+}
 
 export function ActivitySurface({ onError }: { onError: (message: string) => void }) {
-  const [messages, setMessages] = useState<ActivityMessage[]>([]);
-  const [contextId, setContextId] = useState("system:activity");
+  // Held newest-first (as the API returns), rendered oldest-first.
+  const [entries, setEntries] = useState<ActivityEntry[]>([]);
   const [draft, setDraft] = useState("");
   const [sending, setSending] = useState(false);
   const [loading, setLoading] = useState(true);
@@ -25,8 +60,7 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
     setLoading(true);
     try {
       const r = await api.activity();
-      setContextId(r.context_id);
-      setMessages(r.messages);
+      setEntries(r.entries || []);
     } catch (e) {
       onError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -37,31 +71,41 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
     void load();
   }, []);
 
-  // Live append: every completed Activity turn (scheduled fire, inbox item, or
-  // our own reply) pushes an `activity.message` event with the assistant text.
+  // Live append: every completed Activity turn pushes `activity.message` with
+  // the assistant text + provenance. Prepend (newest-first store order).
   useEffect(
     () =>
       onServerEvent("activity.message", (data) => {
         const text = typeof data.text === "string" ? data.text : "";
-        if (text) setMessages((prev) => [...prev, { role: "assistant", content: text }]);
+        if (!text) return;
+        const entry: ActivityEntry = {
+          id: Date.now(),
+          created_at: new Date().toISOString(),
+          origin: typeof data.origin === "string" ? data.origin : "",
+          trigger: typeof data.trigger === "string" ? data.trigger : "",
+          priority: typeof data.priority === "string" ? data.priority : "",
+          state: "completed",
+          text,
+          task_id: "",
+        };
+        setEntries((prev) => [entry, ...prev]);
       }),
     [],
   );
 
-  // Keep the latest message in view.
+  // Keep the newest (bottom, since we render chronological) in view.
   useEffect(() => {
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
-  }, [messages]);
+  }, [entries]);
 
   async function send() {
     const text = draft.trim();
     if (!text || sending) return;
     setSending(true);
     setDraft("");
-    setMessages((prev) => [...prev, { role: "user", content: text }]);
     try {
-      // Fire the turn into the Activity context; the reply arrives via the bus.
-      await api.streamChat(text, contextId, {});
+      // Reply into the Activity thread; the answer returns as a feed entry.
+      await api.streamChat(text, ACTIVITY, {});
     } catch (e) {
       onError(e instanceof Error ? e.message : String(e));
     } finally {
@@ -69,12 +113,14 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
     }
   }
 
+  const chronological = [...entries].reverse();
+
   return (
-    <section className="panel stage-panel">
+    <section className="panel stage-panel" data-testid="activity-surface">
       <div className="panel-header">
         <div>
           <h1>Activity</h1>
-          <p className="panel-kicker">scheduled fires &amp; agent-initiated messages</p>
+          <p className="panel-kicker">what the agent did on its own — and why</p>
         </div>
         <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
           {loading ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
@@ -82,17 +128,17 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
       </div>
 
       <div className="stage-body activity-body">
-        <div className="activity-log" ref={scrollRef}>
-          {messages.length === 0 && !loading ? (
+        <div className="activity-feed" ref={scrollRef}>
+          {chronological.length === 0 && !loading ? (
             <div className="activity-empty">
-              Nothing yet. Scheduled prompts and other agent-initiated messages land here.
+              Nothing yet. Scheduled fires, inbox items, and sister-agent pushes land here — each tagged with what triggered it.
             </div>
           ) : null}
-          {messages.map((m, i) => (
-            <div className={`activity-msg activity-${m.role}`} key={i}>
-              <span className="activity-role">{m.role === "user" ? "you" : "agent"}</span>
+          {chronological.map((e) => (
+            <div className="activity-entry" key={e.id} data-origin={e.origin}>
+              <Badge entry={e} />
               <div className="activity-content">
-                <Markdown>{m.content}</Markdown>
+                <Markdown>{e.text}</Markdown>
               </div>
             </div>
           ))}
@@ -100,19 +146,19 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
 
         <form
           className="activity-composer"
-          onSubmit={(e) => {
-            e.preventDefault();
+          onSubmit={(ev) => {
+            ev.preventDefault();
             void send();
           }}
         >
           <textarea
             value={draft}
-            onChange={(e) => setDraft(e.target.value)}
+            onChange={(ev) => setDraft(ev.target.value)}
             placeholder="Reply in the activity thread…"
             rows={2}
-            onKeyDown={(e) => {
-              if (e.key === "Enter" && !e.shiftKey && !e.ctrlKey) {
-                e.preventDefault();
+            onKeyDown={(ev) => {
+              if (ev.key === "Enter" && !ev.shiftKey && !ev.ctrlKey) {
+                ev.preventDefault();
                 void send();
               }
             }}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1602,6 +1602,46 @@ textarea {
   resize: none;
 }
 
+/* Activity provenance feed (ADR 0022) ------------------------------------- */
+.activity-feed {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.activity-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.activity-prov {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 11px;
+}
+.activity-origin {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  color: var(--fg-secondary);
+}
+.activity-origin svg { flex: 0 0 auto; }
+.activity-origin-scheduler { color: #818cf8; border-color: color-mix(in srgb, #818cf8 45%, var(--border)); }
+.activity-origin-inbox     { color: #34d399; border-color: color-mix(in srgb, #34d399 45%, var(--border)); }
+.activity-origin-webhook   { color: #fbbf24; border-color: color-mix(in srgb, #fbbf24 45%, var(--border)); }
+.activity-origin-a2a       { color: #f472b6; border-color: color-mix(in srgb, #f472b6 45%, var(--border)); }
+.activity-origin-operator  { color: var(--accent, #7c8cff); border-color: color-mix(in srgb, var(--accent, #7c8cff) 45%, var(--border)); }
+.activity-trigger { font-family: var(--font-mono, ui-monospace, monospace); color: var(--fg-secondary); }
+.activity-time { margin-left: auto; color: var(--fg-tertiary, var(--fg-secondary)); }
+
 /* In-surface sub-nav (grouped rail surfaces) ------------------------------- */
 .stage-subnav {
   display: flex;

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -109,8 +109,21 @@ export type InboxItem = {
 
 export type ActivityMessage = { role: "user" | "assistant"; content: string };
 
+// One provenance feed entry (ADR 0022): an agent-initiated turn + what triggered it.
+export type ActivityEntry = {
+  id: number;
+  created_at: string;
+  origin: string;        // scheduler | inbox | webhook | a2a | operator
+  trigger: string;       // job id / inbox source (human label), may be ""
+  priority: string;      // inbox tier when applicable, else ""
+  state: string;
+  text: string;
+  task_id: string;
+};
+
 export type ActivityHistory = {
   context_id: string;
+  entries: ActivityEntry[];
   messages: ActivityMessage[];
 };
 

--- a/server.py
+++ b/server.py
@@ -81,6 +81,7 @@ _telemetry_store = None  # TelemetryStore (per-turn cost/latency rollups, ADR 00
 _inbox_store = None    # InboxStore — durable inbound inbox (ADR 0003), or None.
 _beads_store = None    # BeadsStore — in-process issue tracker (Sprint B), or None.
 _storm_guard = None    # StormGuard for the now→Activity fire path (ADR 0003).
+_activity_log = None   # ActivityLog — provenance feed (ADR 0022), or None.
 _mcp_clients = []        # Live MultiServerMCPClient handles (kept alive for reconnect).
 _mcp_tools = []          # MCP-server tools appended to the active graph.
 _mcp_meta = []           # Per-server {name, transport, tool_count} for runtime status.
@@ -305,8 +306,10 @@ def _init_langgraph_agent(headless_setup: bool = False):
 
     _workflow_registry = _build_workflow_registry(_graph_config)
 
-    global _inbox_store, _storm_guard, _beads_store
+    global _inbox_store, _storm_guard, _beads_store, _activity_log
     _inbox_store = _build_inbox_store(_graph_config)
+    if _activity_log is None:
+        _activity_log = _build_activity_log(_graph_config)
     from beads import BeadsStore
     if _beads_store is None:  # may have been created early (pre-setup) for the routes
         _beads_store = BeadsStore()  # in-process issue tracker (Sprint B), instance-scoped
@@ -642,6 +645,29 @@ def _build_inbox_store(config):
         return InboxStore(path)
     except Exception:
         log.exception("[inbox] failed to build store at %s; inbox disabled", path)
+        return None
+
+
+def _build_activity_log(config):
+    """Provenance feed store (ADR 0022). Path resolves like the inbox store
+    (/sandbox → ~/.protoagent fallback), namespaced by agent name."""
+    from activity import ActivityLog
+
+    name = re.sub(r"[^a-zA-Z0-9._-]", "_", agent_name()) or "agent"
+    configured = scope_leaf(Path("/sandbox/activity") / f"{name}.db")
+    try:
+        configured.parent.mkdir(parents=True, exist_ok=True)
+        if not os.access(configured.parent, os.W_OK):
+            raise OSError
+        path = str(configured)
+    except OSError:
+        fallback = scope_leaf(Path.home() / ".protoagent" / "activity" / f"{name}.db")
+        fallback.parent.mkdir(parents=True, exist_ok=True)
+        path = str(fallback)
+    try:
+        return ActivityLog(path)
+    except Exception:
+        log.exception("[activity] failed to build log at %s; feed disabled", path)
         return None
 
 
@@ -2213,9 +2239,26 @@ def _a2a_terminal(outcome) -> None:
     text = extract_output(outcome.text) or outcome.text
     if not text.strip():
         return
+    origin = getattr(outcome, "origin", "") or "operator"
+    trigger = getattr(outcome, "trigger", "") or ""
+    priority = getattr(outcome, "priority", "") or ""
+    # Provenance feed (ADR 0022): durably log the turn + what triggered it.
+    if _activity_log is not None:
+        _activity_log.add(
+            context_id=ACTIVITY_CONTEXT,
+            origin=origin,
+            trigger=trigger,
+            priority=priority,
+            state=getattr(outcome, "state", "completed"),
+            text=text,
+            task_id=getattr(outcome, "task_id", "") or "",
+        )
     _event_bus.publish(
         "activity.message",
-        {"role": "assistant", "text": text, "context_id": ACTIVITY_CONTEXT},
+        {
+            "role": "assistant", "text": text, "context_id": ACTIVITY_CONTEXT,
+            "origin": origin, "trigger": trigger, "priority": priority,
+        },
     )
 
 
@@ -2491,24 +2534,12 @@ def _main():
             raise RuntimeError("workflows are not available")
         return {"deleted": _workflow_registry.delete(name)}
 
-    def _publish_activity_terminal(record) -> None:
-        """Terminal hook (ADR 0003): when a turn in the Activity thread completes,
-        push the assistant's visible output to the event bus so connected
-        consoles append it live. No-op for every other context."""
-        if getattr(record, "context_id", "") != ACTIVITY_CONTEXT:
-            return
-        raw = getattr(record, "accumulated_text", "") or ""
-        text = extract_output(raw) or raw
-        if not text.strip():
-            return
-        _event_bus.publish(
-            "activity.message",
-            {"role": "assistant", "text": text, "context_id": ACTIVITY_CONTEXT},
-        )
-
     async def _operator_activity_list() -> dict:
-        """Return the Activity thread's message history from the checkpointer
-        (ADR 0003). The console loads this when opening the Activity surface."""
+        """Return the Activity provenance feed (ADR 0022) — newest-first entries
+        with origin/trigger/priority — plus the thread's message history from the
+        checkpointer (for the continue view). The console renders the feed and
+        opens the thread on demand."""
+        entries = _activity_log.recent(limit=100) if _activity_log is not None else []
         messages: list[dict] = []
         if _checkpointer is not None:
             thread_id = f"a2a:{ACTIVITY_CONTEXT}"
@@ -2530,7 +2561,7 @@ def _main():
                     if visible.strip():
                         messages.append({"role": "assistant", "content": visible})
                 # tool/system messages are omitted from the surface view
-        return {"context_id": ACTIVITY_CONTEXT, "messages": messages}
+        return {"context_id": ACTIVITY_CONTEXT, "entries": entries, "messages": messages}
 
     def _inbox_authorized(token: str | None) -> bool:
         """Validate the inbound bearer token (ADR 0003). Mirrors the A2A posture:
@@ -2550,7 +2581,10 @@ def _main():
         if _storm_guard is not None and not _storm_guard.allow(time.monotonic()):
             log.warning("[inbox] storm guard suppressed now-fire for item %s", item.get("id"))
             return False
-        headers = {"Content-Type": "application/json"}
+        # A2A 1.0 (a2a-sdk ≥1.1): the version header + proto method name are
+        # mandatory — the 0.3 `message/send` 404s with -32601. Mirrors the
+        # scheduler's fire (scheduler/local.py).
+        headers = {"Content-Type": "application/json", "A2A-Version": "1.0"}
         bearer = ((_graph_config.auth_token if _graph_config else "") or os.environ.get("A2A_AUTH_TOKEN", "")).strip()
         if bearer:
             headers["Authorization"] = f"Bearer {bearer}"
@@ -2559,17 +2593,29 @@ def _main():
             headers["X-API-Key"] = api_key
         mid = str(uuid4())
         body = {
-            "jsonrpc": "2.0", "id": mid, "method": "message/send",
+            "jsonrpc": "2.0", "id": mid, "method": "SendMessage",
             "params": {
-                "contextId": ACTIVITY_CONTEXT,
-                "message": {"role": "user", "parts": [{"kind": "text", "text": item["text"]}], "messageId": mid},
-                "metadata": {"origin": "inbox", "inbox_id": item.get("id"), "inbox_source": item.get("source", "")},
+                # contextId is a field of Message in 1.0 (params-level => -32602).
+                "message": {
+                    "role": "ROLE_USER",
+                    "parts": [{"text": item["text"]}],
+                    "messageId": mid,
+                    "contextId": ACTIVITY_CONTEXT,
+                },
+                "metadata": {"origin": "inbox", "inbox_id": item.get("id"), "inbox_source": item.get("source", ""), "priority": item.get("priority", "now")},
             },
         }
         try:
             async with httpx.AsyncClient(timeout=30) as client:
                 r = await client.post(f"http://127.0.0.1:{_active_port}/a2a", headers=headers, json=body)
-            return r.status_code < 400
+            # A JSON-RPC error rides a 200, so status alone isn't enough.
+            if r.status_code >= 400:
+                return False
+            err = r.json().get("error") if r.headers.get("content-type", "").startswith("application/json") else None
+            if err:
+                log.warning("[inbox] now-fire rejected for item %s: %s", item.get("id"), err)
+                return False
+            return True
         except Exception:
             log.exception("[inbox] now-fire failed for item %s", item.get("id"))
             return False

--- a/tests/test_activity_feed.py
+++ b/tests/test_activity_feed.py
@@ -1,0 +1,56 @@
+"""ADR 0022: the Activity provenance feed — store + terminal-hook wiring."""
+
+from __future__ import annotations
+
+import server
+from a2a_executor import TurnOutcome
+from activity.store import ActivityLog
+
+
+def test_log_add_and_recent_newest_first(tmp_path):
+    log = ActivityLog(str(tmp_path / "a.db"))
+    log.add(context_id="system:activity", origin="scheduler", trigger="daily-brief", text="all green")
+    log.add(context_id="system:activity", origin="inbox", trigger="ops@", priority="now", text="deploy ok")
+    rows = log.recent()
+    assert [r["origin"] for r in rows] == ["inbox", "scheduler"]  # newest first
+    assert rows[0]["trigger"] == "ops@" and rows[0]["priority"] == "now"
+
+
+def test_log_drops_empty_text(tmp_path):
+    log = ActivityLog(str(tmp_path / "a.db"))
+    assert log.add(context_id="c", origin="x", text="   ") is None
+    assert log.recent() == []
+
+
+def test_log_empty_origin_becomes_operator(tmp_path):
+    log = ActivityLog(str(tmp_path / "a.db"))
+    log.add(context_id="c", origin="", text="a reply")
+    assert log.recent()[0]["origin"] == "operator"
+
+
+def test_terminal_hook_logs_provenance_and_tags_event(tmp_path, monkeypatch):
+    log = ActivityLog(str(tmp_path / "a.db"))
+    monkeypatch.setattr(server, "_activity_log", log)
+    published: list = []
+    monkeypatch.setattr(server._event_bus, "publish", lambda ev, data: published.append((ev, data)))
+
+    out = TurnOutcome(
+        task_id="t1", context_id=server.ACTIVITY_CONTEXT, state="completed",
+        text="<scratch_pad>thinking</scratch_pad><output>Overnight: 3 PRs merged.</output>",
+        origin="scheduler", trigger="daily-brief", priority="",
+    )
+    server._a2a_terminal(out)
+
+    rows = log.recent()
+    assert rows and rows[0]["origin"] == "scheduler" and rows[0]["trigger"] == "daily-brief"
+    assert rows[0]["text"] == "Overnight: 3 PRs merged."  # scratch_pad stripped via extract_output
+    # The live event carries provenance too.
+    assert published and published[0][0] == "activity.message"
+    assert published[0][1]["origin"] == "scheduler" and published[0][1]["trigger"] == "daily-brief"
+
+
+def test_terminal_hook_ignores_non_activity_context(tmp_path, monkeypatch):
+    log = ActivityLog(str(tmp_path / "a.db"))
+    monkeypatch.setattr(server, "_activity_log", log)
+    server._a2a_terminal(TurnOutcome(task_id="t", context_id="a-chat", state="completed", text="hi"))
+    assert log.recent() == []


### PR DESCRIPTION
Implements [ADR 0022](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0022-activity-provenance-feed.md) (backend + UI in one PR to avoid an intermediate broken surface) — and fixes a real bug the audit surfaced.

## The feature: Activity is a provenance feed

The reactive backend (ADR 0003) tags every turn with `origin` (scheduler/inbox/webhook/a2a) and the inbox carries `source`+`priority` — but the UI dropped all of it and showed `agent: <text>`. Now:
- `origin`/`trigger`/`priority` ride **`TurnOutcome`** (the executor extracts them from the inbound A2A metadata).
- a small **`activity` log** (new `activity/`) is written by the terminal hook; the checkpointer stays the *continuable* thread.
- `GET /api/activity` returns feed entries; the `activity.message` event carries provenance.
- **`ActivitySurface`** renders a timeline — each entry shows its trigger badge (⏰ scheduled · ✉ inbox · ↪ webhook · 🤝 sister-agent · 💬 you) + time + priority, with a composer to reply. (Removed dead `_publish_activity_terminal`.)

## The bug it surfaced: inbox `now`-fire broken since A2A 1.0

While live-testing the feed, a `now` inbox item posted but **never reached the agent**. Cause: the inbox→Activity fire self-POSTed the **retired 0.3 wire shape** (`message/send`, `role: "user"`, params-level `contextId`, no `A2A-Version` header), which a2a-sdk 1.1 rejects with `-32601`/`-32602` — *and the fire reported success because a JSON-RPC error rides an HTTP 200*. The scheduler fire was migrated in the A2A 1.0 work; the inbox fire was missed (same class as the eval-harness bug #524). Migrated to the 1.0 shape + the success check now inspects the JSON-RPC error.

## Verification

- **Live**: posting `{"text":"Deploy v0.14 succeeded","priority":"now","source":"deploy-bot"}` now fires and lands in the feed as `[inbox] deploy-bot · now`.
- New backend tests (`test_activity_feed.py`: log + terminal-hook provenance) + e2e (feed renders entries with badges; reply clears the composer).
- **998 Python + 42 e2e** pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)