### PR TITLE
fix(knowledge): embeddings work against real gateways + memory docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Semantic-recall embeddings were non-functional against a real gateway**
+  (found by a full knowledge-store smoke test). `create_embed_fn` built
+  `OpenAIEmbeddings` with its default client-side tiktoken tokenization, which
+  posts `input` as int arrays — a LiteLLM/vLLM gateway rejects that with a 422
+  ("input should be a valid string"). Now passes `check_embedding_ctx_length=
+  False` so the raw string is sent. Also: the default `embed_model`
+  (`nomic-embed-text`) isn't what every gateway serves (the protoLabs gateway
+  serves `qwen3-embedding`) — documented that `embed_model` is gateway-specific.
+  Verified live: hybrid search now returns a fact via a paraphrased query that
+  keyword search misses.
+
 ### Added
+- **Docs: "Memory & the knowledge store"** (`docs/explanation/`) — the store, the
+  three memory types (semantic facts / episodic summaries / procedural
+  playbooks), write paths + the reasoning guardrail, retrieval, and how to turn
+  on semantic recall (with the gateway-model caveat).
 - **Activity is a provenance feed, not a second chat** (ADR 0022). Every
   reactive turn is tagged with *what triggered it* (scheduled job / webhook /
   inbox source / sister-agent / your reply) — the backend tracked this `origin`

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -57,6 +57,9 @@ knowledge:
   # Off by default (keyword-only) — turn on once your gateway serves an
   # embedding model. Degrades to keyword search on embedding outage.
   embeddings: false
+  # The embedding model your gateway serves (NOT the chat model). Default suits a
+  # local Ollama gateway; the protoLabs gateway serves `qwen3-embedding`. Check
+  # GET /v1/models — a wrong model silently degrades to keyword-only search.
   embed_model: nomic-embed-text
   # Extract durable facts from a conversation on retirement (aux model) and
   # consolidate them into the store. Rides the harvest pass (ADR 0021).

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -92,6 +92,7 @@ export default defineConfig({
           items: [
             { text: "Overview", link: "/explanation/" },
             { text: "Architecture", link: "/explanation/architecture" },
+            { text: "Memory & knowledge store", link: "/explanation/memory-and-knowledge" },
             { text: "A2A protocol", link: "/explanation/a2a-protocol" },
             { text: "Cost & trace propagation", link: "/explanation/cost-and-trace" },
             { text: "Tuning & cost", link: "/explanation/tuning-and-cost" },

--- a/docs/explanation/memory-and-knowledge.md
+++ b/docs/explanation/memory-and-knowledge.md
@@ -1,0 +1,124 @@
+# Memory & the knowledge store
+
+protoAgent has a single durable **knowledge store** and a set of conventions for
+*what* goes in it and *how* it comes back out. This page explains the whole
+pipeline — the store, the three kinds of memory, the write paths, the retrieval,
+and the configuration — so you can reason about (and tune) what your agent
+remembers.
+
+The design rules behind it are [ADR 0021](../adr/0021-agent-memory-architecture.md)
+("extract, don't dump").
+
+## The store
+
+`knowledge/store.py` is a SQLite database with **FTS5 full-text search** (with a
+`LIKE` fallback when FTS5 isn't compiled in). One `chunks` table holds everything
+the agent knows; rows are distinguished by a few columns:
+
+| Column | Meaning |
+|---|---|
+| `domain` | the bucket — `fact`, `conversation`, `hot`, `finding`, or anything a tool sets (`preferences`, `context`, …) |
+| `finding_type` | sub-type within a domain (e.g. `fact`, `ingest`) |
+| `namespace` | optional per-project / per-owner scope (ADR 0021) — a *filter* for multi-project forks, never required |
+| `source` / `source_type` | provenance (`harvest`, `tool:<name>`, …) |
+| `heading`, `content`, `created_at` | the chunk itself |
+
+## Three kinds of memory
+
+protoAgent follows the standard semantic / episodic / procedural split, mapped
+onto primitives it already has:
+
+- **Semantic** — discrete, durable **facts** (`domain="fact"`). "The user deploys
+  on Tuesdays." Extracted by the harvest pass; queryable like any chunk.
+- **Episodic** — **conversation summaries** (`domain="conversation"`). A retired
+  thread is summarized into one searchable chunk.
+- **Procedural** — **Playbooks / skills** (`skills.db`, a separate FTS5 index).
+  Methodology the agent retrieves but never "runs". See [Skills](../guides/skills.md).
+
+## Write paths
+
+Everything that writes to the store funnels through `KnowledgeStore.add_chunk`:
+
+1. **Memory tools** — the agent calls `memory_write` (and friends) to record a
+   fact the user shared. See [Starter tools](../reference/starter-tools.md).
+2. **Harvest on retirement** — when a chat thread is retired (aged out by the
+   checkpoint pruner, or deleted), `graph/conversation_harvest.py` runs a single
+   **session-end pass** (cheap aux model): it stores an episodic *summary* and,
+   when `knowledge.facts` is on, **extracts durable facts** and consolidates them
+   (near-duplicates are skipped). This is *extract, don't dump* — it never stores
+   raw turns.
+3. **Tool-output ingest** — the opt-in `KnowledgeIngestMiddleware`
+   (`middleware.ingest`) captures tool output as findings.
+
+### The reasoning guardrail
+
+The agent thinks inside `<scratch_pad>` and answers inside `<output>` (the
+[output protocol](output-protocol.md)). `add_chunk` **strips
+`<scratch_pad>`/`<think>` from every write** — so the model's internal reasoning
+can never reach the store (and never gets recycled into a later prompt via
+retrieval). A chunk that is *only* reasoning is dropped, not stored empty.
+
+## Retrieval
+
+The `KnowledgeMiddleware` runs before each LLM turn and injects relevant context:
+
+- **Relevance** — searches the store with the user's message and injects the
+  top-k matches.
+- **Hot memory** — always-on `domain="hot"` facts, injected every turn.
+- **Learned skills** — top-k Playbooks for the turn (a `<learned_skills>` block).
+- **Prior sessions** — recent session summaries for cross-session recency.
+
+The operator can browse and search the whole store in the console under
+**Knowledge → Store**.
+
+## Semantic recall (embeddings)
+
+By default the store is **keyword-only** (FTS5). Keyword search misses
+paraphrases — *"how do I ship a build?"* won't match a stored *"the release
+pipeline is manual via workflow_dispatch"*. Turning on **embeddings** upgrades
+the store to `HybridKnowledgeStore`: it fuses FTS5 with **vector similarity**
+using Reciprocal Rank Fusion, so lexical *and* semantic hits reinforce each
+other. An embedding circuit breaker falls back to FTS5 on an embedding outage —
+quality degrades, availability never does.
+
+```yaml
+knowledge:
+  embeddings: true             # off by default
+  embed_model: qwen3-embedding # MUST be a model your gateway serves (see below)
+```
+
+::: warning The embed model is gateway-specific
+`embed_model` must name a model your [LiteLLM gateway](litellm-gateway.md)
+actually serves — it is **not** the chat model. The template default
+(`nomic-embed-text`) suits a local Ollama gateway; the protoLabs gateway serves
+`qwen3-embedding`. Check `GET /v1/models` for what your key can access. With a
+wrong model every embed call 401/404s, the breaker opens, and you silently get
+keyword-only search.
+:::
+
+Embeddings are routed through the same gateway as the chat model
+(`graph.llm.create_embed_fn`), sending the **raw string** (not client-side
+tokenized arrays) so OpenAI-compatible gateways accept the request.
+
+## Configuration
+
+All under the `knowledge:` block (see [Configuration](../reference/configuration.md)):
+
+| Key | Default | Effect |
+|---|---|---|
+| `db_path` | `/sandbox/knowledge/agent.db` | store location (instance-scoped) |
+| `embeddings` | `false` | hybrid semantic + keyword search (vs keyword-only) |
+| `embed_model` | `nomic-embed-text` | gateway embedding model (set per your gateway) |
+| `facts` | `true` | extract semantic facts during the harvest pass |
+| `top_k` | `5` | how many chunks retrieval injects per turn |
+| `middleware.knowledge` | `true` | turn the whole subsystem on/off |
+
+Tip: enabling embeddings is measurable — add a recall eval and compare keyword vs
+hybrid via `evals.sweep`. See [Eval your fork](../guides/evals.md).
+
+## See also
+
+- [ADR 0021 — Agent memory: extract, don't dump](../adr/0021-agent-memory-architecture.md)
+- [Output protocol](output-protocol.md) — the `<scratch_pad>`/`<output>` contract the guardrail enforces
+- [Skills](../guides/skills.md) — procedural memory (Playbooks)
+- [Starter tools](../reference/starter-tools.md) — the `memory_*` tools

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -98,5 +98,10 @@ def create_embed_fn(config: LangGraphConfig) -> Callable[[str], list[float]] | N
         api_key=api_key,
         model=model,
         default_headers={"User-Agent": _GATEWAY_UA},
+        # Send the raw string, not client-side-tokenized int arrays. Langchain's
+        # default tokenizes with tiktoken and posts `input` as arrays of token
+        # ids, which a LiteLLM/vLLM-style gateway rejects with 422 ("input should
+        # be a valid string"). Off = the gateway tokenizes — the portable choice.
+        check_embedding_ctx_length=False,
     )
     return embeddings.embed_query

--- a/tests/test_embeddings_wiring.py
+++ b/tests/test_embeddings_wiring.py
@@ -36,6 +36,28 @@ def test_create_embed_fn_callable_with_model():
     assert callable(fn)
 
 
+def test_create_embed_fn_sends_raw_strings(monkeypatch):
+    """Regression: OpenAIEmbeddings defaults to client-side tiktoken tokenization
+    and posts `input` as int arrays, which LiteLLM/vLLM gateways 422. We must
+    pass check_embedding_ctx_length=False so it sends the raw string."""
+    import graph.llm as llm
+
+    captured = {}
+
+    class _FakeEmb:
+        def __init__(self, **kw):
+            captured.update(kw)
+
+        def embed_query(self, text):
+            return [0.0]
+
+    monkeypatch.setattr(llm, "OpenAIEmbeddings", _FakeEmb)
+    cfg = LangGraphConfig()
+    cfg.api_base, cfg.api_key = "http://gateway.test/v1", "k"
+    create_embed_fn(cfg)
+    assert captured.get("check_embedding_ctx_length") is False
+
+
 def test_store_is_keyword_only_by_default(tmp_path):
     store = server._build_knowledge_store(_cfg(tmp_path, embeddings=False))
     assert type(store).__name__ == "KnowledgeStore"


### PR DESCRIPTION
You asked whether we'd fully smoke-tested the knowledge store. We hadn't — so I ran the full battery against a live instance, and it caught a real one.

## The smoke test (all live, fresh instance)

| Check | Result |
|---|---|
| Store wiring | ✅ FTS5 default; hybrid when embeddings on |
| `memory_write` + recall + `memory_stats` tools | ✅ |
| Reasoning guardrail | ✅ 0 `<scratch_pad>` chunks |
| **Harvest end-to-end** (retire thread → summary + facts) | ✅ 3 discrete facts + 1 episodic summary |
| Store UI renders the populated store | ✅ (provenance badges per chunk) |
| **Semantic recall (embeddings) live** | ❌→✅ **was broken** |

## The bug it found

**ADR 0021 Phase 1.5's embeddings were non-functional against a real gateway** — the unit tests never actually called the gateway. Two issues:

1. `create_embed_fn` built `OpenAIEmbeddings` with its default client-side tiktoken tokenization, which posts `input` as **int arrays** → a LiteLLM/vLLM gateway rejects with **422** ("input should be a valid string"). Fixed: `check_embedding_ctx_length=False` sends the raw string.
2. The default `embed_model` (`nomic-embed-text`) isn't what every gateway serves — the protoLabs gateway serves **`qwen3-embedding`**. Documented that `embed_model` is gateway-specific (example config + docs).

**Verified live after the fix:** hybrid store loads via `qwen3-embedding`; the paraphrased query *"how do I ship a build"* returns a *"release pipeline is manual via workflow_dispatch"* fact that keyword search **misses**; `cos(deploy?, release-fact)=0.63` vs `0.29` for an unrelated fact.

## Docs (as requested)

New **`docs/explanation/memory-and-knowledge.md`** — the store, the three memory types (semantic facts / episodic summaries / procedural playbooks), the write paths + reasoning guardrail, retrieval, and how to turn on semantic recall (with the gateway-model caveat) — plus the sidebar entry. There was no memory docs page before.

999 Python tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)