### PR TITLE
feat(knowledge): semantic recall (embeddings) on by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Semantic recall is on by default.** `knowledge.embeddings` now defaults to
+  `true` and `embed_model` to `qwen3-embedding` (what the protoLabs gateway
+  serves). The store fuses FTS5 + vector search so it finds paraphrases keyword
+  search misses; the circuit breaker degrades to keyword-only if the gateway
+  can't embed, so it's safe for forks (set `embed_model` to your gateway's, or
+  `knowledge.embeddings: false`).
+
 ## [0.14.0] - 2026-06-05
 
 ### Fixed

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -56,11 +56,12 @@ knowledge:
   # Semantic recall: hybrid FTS5 + vector search (RRF-fused) via embed_model.
   # Off by default (keyword-only) — turn on once your gateway serves an
   # embedding model. Degrades to keyword search on embedding outage.
-  embeddings: false
-  # The embedding model your gateway serves (NOT the chat model). Default suits a
-  # local Ollama gateway; the protoLabs gateway serves `qwen3-embedding`. Check
-  # GET /v1/models — a wrong model silently degrades to keyword-only search.
-  embed_model: nomic-embed-text
+  # Hybrid semantic + keyword recall (RRF). On by default; falls back to
+  # keyword-only via the circuit breaker if the gateway can't embed.
+  embeddings: true
+  # The embedding model your gateway serves (NOT the chat model). Default is the
+  # protoLabs gateway's; forks on another gateway set theirs (check GET /v1/models).
+  embed_model: qwen3-embedding
   # Extract durable facts from a conversation on retirement (aux model) and
   # consolidate them into the store. Rides the harvest pass (ADR 0021).
   facts: true

--- a/graph/config.py
+++ b/graph/config.py
@@ -244,12 +244,16 @@ class LangGraphConfig:
     # ``~/.protoagent/knowledge/agent.db`` automatically when /sandbox
     # is read-only or absent (e.g. local ``python server.py``).
     knowledge_db_path: str = "/sandbox/knowledge/agent.db"
-    embed_model: str = "nomic-embed-text"
+    # The gateway's embedding model (NOT the chat model). Default is what the
+    # protoLabs gateway serves; forks on a different gateway set this to a model
+    # their gateway has (check GET /v1/models). A wrong/absent model degrades to
+    # keyword search via the store's circuit breaker — never KB-less.
+    embed_model: str = "qwen3-embedding"
     # Semantic recall (ADR 0021): when True, the knowledge store is the
     # HybridKnowledgeStore (FTS5 + vector embeddings via `embed_model`, fused
-    # with RRF). Default off — needs the gateway to serve an embedding model;
-    # the store's circuit breaker falls back to FTS5 on outage. Off = keyword-only.
-    knowledge_embeddings: bool = False
+    # with RRF). On by default — semantic recall finds paraphrases keyword search
+    # misses; the circuit breaker falls back to FTS5 on an embedding outage.
+    knowledge_embeddings: bool = True
     knowledge_top_k: int = 5
 
     # Conversation checkpointer — persists each chat session's history per

--- a/tests/test_embeddings_wiring.py
+++ b/tests/test_embeddings_wiring.py
@@ -58,7 +58,16 @@ def test_create_embed_fn_sends_raw_strings(monkeypatch):
     assert captured.get("check_embedding_ctx_length") is False
 
 
-def test_store_is_keyword_only_by_default(tmp_path):
+def test_store_is_hybrid_by_default(tmp_path):
+    # knowledge.embeddings defaults on (ADR 0021); the config helper here mirrors it.
+    cfg = LangGraphConfig()
+    cfg.knowledge_db_path = str(tmp_path / "kb.db")
+    cfg.api_base, cfg.api_key = "http://gateway.test/v1", "k"
+    assert cfg.knowledge_embeddings is True
+    assert type(server._build_knowledge_store(cfg)).__name__ == "HybridKnowledgeStore"
+
+
+def test_store_is_keyword_when_embeddings_off(tmp_path):
     store = server._build_knowledge_store(_cfg(tmp_path, embeddings=False))
     assert type(store).__name__ == "KnowledgeStore"
 


### PR DESCRIPTION
Now that `create_embed_fn` works against real gateways (#543) and the full pipeline is smoke-tested, flip the default on.

- `knowledge.embeddings` → `true`, `embed_model` → `qwen3-embedding` (the protoLabs gateway's).
- Hybrid FTS5 + vector recall finds paraphrases keyword search misses (`cos(deploy?, release-pipeline-fact)=0.63` vs `0.29` unrelated, verified live in #543).
- **Safe for forks**: the circuit breaker degrades to keyword-only if the gateway can't embed; forks set `embed_model` to their gateway's model or `knowledge.embeddings: false`.

Tests: default is now hybrid; the explicit-off path stays keyword. 999 Python tests pass.