### PR TITLE
docs(adr): ADR 0023 — decompose server.py (AppState + composition root)

### DIFF
--- a/docs/adr/0023-server-decomposition.md
+++ b/docs/adr/0023-server-decomposition.md
@@ -1,0 +1,112 @@
+# ADR 0023 — Decompose server.py: an AppState container + a composition root
+
+- **Status:** Accepted (2026-06-05) — phased; each phase is its own live-smoked PR
+- **Date:** 2026-06-05
+- **Deciders:** Josh Mabry; protoAgent maintainers
+- **Tags:** architecture, refactor, server, maintainability
+- **Supersedes / Superseded by:** —
+
+> `server.py` is **3,353 lines — 3.2× the next-largest file** — and it isn't one
+> concern: it's the CLI entry, agent init/reload, the store/scheduler/skills/
+> workflow builders, the chat backend, the A2A wiring, *and* ~26 HTTP route
+> handlers, with `_main()` alone at **1,084 lines**. The root cause is **26
+> ambient module-global singletons**: every helper that touches runtime state
+> reaches for a global, so it must live in (or close over) `server.py`. This ADR
+> replaces the ambient globals with an **AppState** container and splits the file
+> into a thin composition root + focused modules — **zero functional change**.
+
+---
+
+## 1. Context & Problem statement
+
+`server.py` works (the suite is green), so this is a maintainability cost, not a
+bug — but a real one for a **template others fork and edit**: it's where merge
+conflicts cluster (it changed in roughly half the PRs of the session that
+prompted this ADR), where new contributors get lost, and where the
+unit-test-vs-wire-test gap lives.
+
+Two structural causes:
+
+1. **26 ambient module-global singletons** — `_graph`, `_graph_config`,
+   `_knowledge_store`, `_skills_index`, `_workflow_registry`, `_telemetry_store`,
+   `_inbox_store`, `_activity_log`, `_storm_guard`, `_checkpointer`, the MCP /
+   plugin lists, … Functions read them directly and write them via `global`. So
+   nothing that touches state can move out of `server.py`. This is the disease;
+   the 1,084-line `_main()` is the symptom.
+2. **The `operator_api/` extraction is half-done.** `register_operator_routes`
+   already exists and takes ~22 handler callbacks — but the callback *bodies* are
+   still defined inline in `_main()` as `_operator_*` closures over the globals.
+   Only the URL-wiring moved out; the logic stayed.
+
+## 2. Decision
+
+**Introduce an `AppState` container, then extract by concern; `server.py`
+becomes a composition root (~300–400 lines).**
+
+### 2.1 `runtime/state.py` — AppState
+
+A single dataclass holds the 26 fields (graph, config, the stores, registries,
+MCP/plugin state, scheduler, background-task handles). A module-level singleton
+`STATE` replaces the ambient globals; `get_state()` returns it (usable as a
+FastAPI dependency). Functions read `state.knowledge_store` instead of the
+global `_knowledge_store`; init/reload mutate `state.*` instead of `global _x`.
+The migration is mechanical and behavior-preserving — same objects, same
+lifecycle, named field access instead of ambient names.
+
+### 2.2 Extract by concern
+
+With state no longer ambient, the big regions move to their own modules, each
+importing `STATE`:
+
+- `server/agent_init.py` — `_build_*` (knowledge/scheduler/skills/workflow),
+  `_init_langgraph_agent`, `_reload_langgraph_agent`, settings callbacks.
+- `server/chat.py` — `_chat_langgraph_stream`, `_run_turn_stream`, the slash-
+  command parsing (workflow + subagent).
+- `server/a2a.py` — the a2a-sdk wiring, `ProtoAgentExecutor` hookup, the terminal
+  hook, `_record_a2a_telemetry`.
+- `operator_api/` route modules — finish the extraction: move the inline
+  `_operator_*` / `_api_*` route bodies into `knowledge.py`, `activity.py`,
+  `telemetry.py`, `config_routes.py`, `chat_routes.py`.
+
+`server.py` keeps only: arg parsing, the FastAPI app, and the wiring that
+composes the modules — the composition root.
+
+### 2.3 Safety protocol (load-bearing)
+
+This is a refactor of the app core with **zero intended functional change**, so
+the risk is regression, not design. Therefore:
+
+- **One phase per PR**, in dependency order: AppState → backends (chat/a2a/init)
+  → route groups. Each is independently reviewable and revertable.
+- **Every PR is green on the full suite AND live-smoked** against a throwaway
+  instance (boot, a chat turn, the A2A round-trip, the knowledge store, an inbox
+  fire) before merge — per the smoke-test lesson that caught three wire-level
+  bugs this same session.
+- No behavior changes ride along — pure moves + the state rename.
+
+## 3. Consequences
+
+- `server.py` becomes navigable; route/backend logic lives with its concern.
+- State is explicit and injectable — testable without monkeypatching module
+  globals, and a step toward catching the wire-level gaps in CI.
+- Finishes the `operator_api/` extraction the codebase already started.
+- Short-term churn + regression risk, mitigated by the phasing + live smoke.
+
+## 4. Implementation (phased)
+
+1. **AppState** — `runtime/state.py` + replace the 26 globals. Biggest, most
+   mechanical; the foundation everything else stands on.
+2. **Backends** — extract `server/chat.py`, `server/a2a.py`,
+   `server/agent_init.py` (one PR each, or grouped if small).
+3. **Route groups** — move inline route bodies into `operator_api/*`; `_main()`
+   shrinks to app assembly.
+
+## 5. Alternatives considered
+
+- **Finish route extraction only** (leave the global model). Rejected as the
+  end state: the extracted routes would still import the ambient globals, so the
+  coupling just spreads across files. (It's a valid *first* increment, but
+  AppState is the actual fix.)
+- **Split by concern without AppState.** Same problem — every moved function
+  drags the globals with it.
+- **Leave it.** Rejected: it's the fork-and-edit core; navigability compounds.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -31,3 +31,4 @@ decision, numbered, never deleted (supersede instead).
 | [0020](./0020-console-ia-run-from-chat.md) | Console IA: run from Chat, manage from surfaces | Accepted |
 | [0021](./0021-agent-memory-architecture.md) | Agent memory: extract, don't dump | Accepted |
 | [0022](./0022-activity-provenance-feed.md) | Activity is a provenance feed, not a second chat | Accepted |
+| [0023](./0023-server-decomposition.md) | Decompose server.py: AppState + composition root | Accepted |


### PR DESCRIPTION
The plan from the server.py audit, captured before any code.

**server.py is 3,353 lines — 3.2× the next file.** Root cause: **26 ambient module-global singletons** (everything that touches runtime state must live in or close over server.py) + a **half-done `operator_api/` extraction** (route wiring moved out, the handler bodies still inline in the 1,084-line `_main()`).

**Decision:** an `AppState` container kills the ambient globals, then extract by concern (chat/a2a/agent_init backends + operator_api route groups); server.py becomes a ~350-line composition root. **Zero functional change** — phased, one PR each, every PR green **and live-smoked** (per the smoke-test lesson that caught 3 wire-level bugs this session). Phasing + alternatives in §4–5.