### PR TITLE
chore: gitignore handoffs/ (local dev handoffs, not shipped to forks)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,6 +42,7 @@ build/
 worktrees/
 # Local session handoff / working notes — transient state, not shipped to forks
 HANDOFF.md
+handoffs/
 
 # VitePress build artifacts + node modules
 node_modules/


### PR DESCRIPTION
The `/handoff` skill writes to `handoffs/NNN-*.md` — transient session dev state. Ignore it (mirrors `HANDOFF.md`) so the template stays clean and forks don't pull it. One-line change.