### PR TITLE
refactor(server): promote server.py → server/ package (ADR 0023 phase 2 prep)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **`server.py` is now a `server/` package** (ADR 0023, phase 2 prep). The
+  monolith moved to `server/__init__.py` (the composition root) with a
+  `server/__main__.py` entry, so the backends can be extracted into
+  `server/a2a.py`, `server/chat.py`, `server/agent_init.py` next. **Launch it as
+  a module: `python -m server`** (was `python server.py`) — the container
+  entrypoint, eval sweep, and desktop-sidecar build were updated to match.
+  Pure move + the `__file__`→`_bundle_root()` path-anchor fix (the package adds
+  one directory level); `import server` / `from server import X` are unchanged
+  (1000 tests + a full live smoke green: boot, chat turn, A2A 1.0 round-trip).
 - **Internal: `server.py`'s 26 ambient module-globals → an `AppState` container**
   (ADR 0023, phase 1). Runtime state (graph, stores, registries, scheduler,
   MCP/plugin state) now lives in `runtime/state.py` as a named, injectable

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Quinn was the first agent built on this template — it's a good
 example of what a filled-in fork looks like end-to-end.
 
 **Try it in 5 minutes:** clone, `pip install -r requirements.txt`,
-`python server.py`, open <http://localhost:7870>, and walk the
+`python -m server`, open <http://localhost:7870>, and walk the
 setup wizard — no forking, no `sed`, no Docker required to get
 your first agent talking. See the [first-agent tutorial](./docs/tutorials/first-agent.md).
 
@@ -53,7 +53,7 @@ python -m venv .venv && source .venv/bin/activate
 pip install -r requirements.txt
 
 # 3. Run the server — no env vars required
-python server.py
+python -m server
 
 # 4. Open the wizard — pick your endpoint, pick a model, name the
 #    agent, pick a persona preset, hit Launch. The chat UI appears

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -140,7 +140,11 @@ def main() -> None:
         "--workpath", str(work / "build"),
         "--specpath", str(work),
         *exclude, *add_data, *collect,
-        str(REPO / "server.py"),
+        # ADR 0023: server.py is now the `server` package; freeze its module
+        # entry point. PyInstaller bundles the whole `server` package and the
+        # `--add-data` assets land at _MEIPASS top level (server/_bundle_root
+        # resolves there when frozen).
+        str(REPO / "server" / "__main__.py"),
     ]
     print("running:", " ".join(cmd))
     subprocess.run(cmd, check=True, cwd=str(REPO))

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -39,7 +39,7 @@ swap the model and compare ([ADR 0012](/adr/0012-eval-strategy-and-model-compari
 can point the same agent at a different model without editing config:
 
 ```bash
-PROTOAGENT_MODEL=vendor/some-model python server.py --ui none
+PROTOAGENT_MODEL=vendor/some-model python -m server --ui none
 ```
 
 **Sweep several models** with one command — `evals/sweep.py` boots a throwaway,

--- a/docs/guides/multi-instance.md
+++ b/docs/guides/multi-instance.md
@@ -19,8 +19,8 @@ or containers that mount the **same** volume — the default paths (and the
 Scope each instance with a distinct id:
 
 ```bash
-PROTOAGENT_INSTANCE=alice  python server.py --port 7871
-PROTOAGENT_INSTANCE=bob    python server.py --port 7872
+PROTOAGENT_INSTANCE=alice  python -m server --port 7871
+PROTOAGENT_INSTANCE=bob    python -m server --port 7872
 ```
 
 or in `config.yaml`:

--- a/docs/guides/operator-fork.md
+++ b/docs/guides/operator-fork.md
@@ -91,7 +91,7 @@ monitor has no operator at a browser, so run the **lean, UI-less tier**
 ([ADR 0010](/adr/0010-headless-setup-and-ui-tiers)): `--ui none` (or
 `PROTOAGENT_UI=none`) serves only API + A2A + `/metrics` — no Gradio, no console,
 core deps only. Drop the live config + supply the gateway key via env, and setup
-auto-completes on boot (or run `python server.py --setup` once); `GET /healthz`
+auto-completes on boot (or run `python -m server --setup` once); `GET /healthz`
 reports readiness. The default Docker image already builds this lean tier.
 
 ---

--- a/docs/guides/sandboxing.md
+++ b/docs/guides/sandboxing.md
@@ -80,7 +80,7 @@ The output maps directly:
 
 ```bash
 # install OpenShell (see its docs), then wrap the agent's container/command:
-openshell sandbox create --policy openshell-policy.yaml -- python server.py
+openshell sandbox create --policy openshell-policy.yaml -- python -m server
 ```
 
 Credentials are injected as env at runtime (never on disk); egress is

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -53,13 +53,13 @@ on** — opt out via either config path above for a stateless agent.
 
 ```bash
 # Solo / local dev — LocalScheduler (the default).
-python server.py
+python -m server
 
 # Workstacean install — opt in explicitly AND set the creds.
 export SCHEDULER_BACKEND=workstacean
 export WORKSTACEAN_API_BASE=http://your-workstacean-host:3000
 export WORKSTACEAN_API_KEY=<key>
-python server.py
+python -m server
 ```
 
 > **protoLabs operators**: the fleet's Workstacean lives on the

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -32,7 +32,7 @@ Every env var the template reads at runtime.
 | `PROTOAGENT_HEADLESS` | (unset) | **Deprecated** alias for `PROTOAGENT_UI=console` (or `--headless`). |
 | `PROTOAGENT_HEADLESS_SETUP` | (unset) | Set `1`/`true` to auto-complete setup from a validated config even outside the `none` tier (no wizard). The `none` tier implies this. |
 
-Setup without the wizard: `python server.py --setup` validates the live config (`model.api_base` set + key resolvable via `secrets.yaml`/`OPENAI_API_KEY`) and writes `.setup-complete`, then exits. In the `none` tier the server auto-completes the same way on boot, or **fails fast** if the config is invalid. Readiness is exposed at `GET /healthz` (503 until the graph compiles).
+Setup without the wizard: `python -m server --setup` validates the live config (`model.api_base` set + key resolvable via `secrets.yaml`/`OPENAI_API_KEY`) and writes `.setup-complete`, then exits. In the `none` tier the server auto-completes the same way on boot, or **fails fast** if the config is invalid. Readiness is exposed at `GET /healthz` (503 until the graph compiles).
 
 ## Authentication — A2A bearer token
 

--- a/docs/tutorials/first-agent.md
+++ b/docs/tutorials/first-agent.md
@@ -22,7 +22,7 @@ pip install -r requirements.txt
 ## 3. Run the server
 
 ```bash
-python server.py
+python -m server
 ```
 
 You should see:
@@ -41,7 +41,7 @@ Walk through the four steps:
 1. **Connect to your model.** Paste your API base URL (`https://api.openai.com/v1` for OpenAI direct, `http://localhost:4000/v1` for a local LiteLLM gateway) and API key. Click **Test connection & fetch models** — the dropdown fills with whatever the endpoint actually exposes. Pick one.
 2. **Name your agent.** Short lowercase slug (e.g. `product-director`). Pick a persona preset — **Generic Assistant** is the safe default; **Research** / **Coding** / **Blank** are the alternatives — and click **Load preset into SOUL.md**. Edit the loaded text if you want to make it specific to your agent.
 3. **Tools & middleware.** All twelve starter tools are enabled by default — four keyless general (`current_time`, `calculator`, `web_search`, `fetch_url`), five memory (`memory_ingest`, `memory_recall`, `memory_list`, `memory_stats`, `daily_log`), and three scheduler (`schedule_task`, `list_schedules`, `cancel_schedule`). Leave **Audit**, **Memory**, **Knowledge**, and **Scheduler** middleware on — the template ships a working sqlite + FTS5 store under `/sandbox/knowledge/agent.db` and a sqlite-backed scheduler under `/sandbox/scheduler/<agent_name>/jobs.db`, both with `~/.protoagent/...` fallbacks outside Docker.
-4. **Optional — you, security, autostart.** Your name makes the agent address you directly. A2A auth token blank for local dev, set it before you expose the port. "Launch this agent automatically on login" installs a macOS LaunchAgent so the server is up after every reboot without remembering to `python server.py`.
+4. **Optional — you, security, autostart.** Your name makes the agent address you directly. A2A auth token blank for local dev, set it before you expose the port. "Launch this agent automatically on login" installs a macOS LaunchAgent so the server is up after every reboot without remembering to `python -m server`.
 
 Hit **Launch agent**. The wizard closes, the chat UI appears, and the Configuration drawer on the right is now populated with your choices.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -20,4 +20,8 @@ if [ -f /opt/protoagent/config/SOUL.md ]; then
     cp /opt/protoagent/config/SOUL.md /sandbox/SOUL.md
 fi
 
-exec python /opt/protoagent/server.py
+# ADR 0023: server.py was promoted to a `server/` package. Launch it as a
+# module with the install dir on PYTHONPATH so the package (and its sibling
+# top-level modules: paths, events, graph, …) resolve, while keeping the
+# agent's workspace (/sandbox) as the working directory.
+exec env PYTHONPATH="/opt/protoagent${PYTHONPATH:+:$PYTHONPATH}" python -m server

--- a/evals/sweep.py
+++ b/evals/sweep.py
@@ -131,7 +131,7 @@ def _run_one_model(
     print(f"\n=== {model} :: booting on {base_url} (instance={instance}) ===")
     log_f = open(log_path, "w")
     proc = subprocess.Popen(
-        [sys.executable, "server.py", "--port", str(port), "--ui", "none"],
+        [sys.executable, "-m", "server", "--port", str(port), "--ui", "none"],
         cwd=str(_PROJECT_ROOT),
         env=env,
         stdout=log_f,

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -91,6 +91,24 @@ _event_bus = EventBus()  # Server→client SSE push channel (ADR 0003). Process-
                          # streams to connected consoles.
 
 
+def _bundle_root() -> Path:
+    """Root that read-only bundled assets (``static``, ``config``, ``plugins``,
+    bundled ``workflows``, ``pyproject.toml``) resolve against.
+
+    Source checkout: the repo root. This file is ``server/__init__.py``, so the
+    repo is its parent's parent. Frozen sidecar (PyInstaller onefile): the
+    ``_MEIPASS`` extraction dir where ``--add-data`` lands assets at the top
+    level. Before ADR 0023 promoted ``server.py`` into this package these
+    lookups were ``Path(__file__).parent``; the package adds one directory
+    level, so they route through here to stay anchored at the repo / bundle
+    root."""
+    if getattr(sys, "frozen", False):
+        meipass = getattr(sys, "_MEIPASS", None)
+        if meipass:
+            return Path(meipass)
+    return Path(__file__).resolve().parents[1]
+
+
 def _resolve_operator_project_root() -> str:
     """The operator console's default project root (+ its always-allowed dir).
 
@@ -109,7 +127,7 @@ def _resolve_operator_project_root() -> str:
         cfg = os.environ.get("PROTOAGENT_CONFIG_DIR")
         base = Path(cfg) if cfg else Path.home()
         return str(base.expanduser().resolve())
-    return str(Path(__file__).parent.resolve())
+    return str(_bundle_root())
 
 
 def _install_parent_death_watchdog() -> None:
@@ -674,7 +692,7 @@ def _build_workflow_registry(config):
         from graph.workflows.registry import WorkflowRegistry
 
         dirs: list[str] = []
-        bundled = Path(__file__).resolve().parent / "workflows"
+        bundled = _bundle_root() / "workflows"
         if bundled.is_dir():
             dirs.append(str(bundled))
         # Writable dir for user / agent-emitted recipes (same fallback shape).
@@ -2088,7 +2106,7 @@ def _package_version() -> str:
     except ImportError:  # pragma: no cover - importlib.metadata always present on 3.11+
         pass
 
-    pyproject = Path(__file__).parent / "pyproject.toml"
+    pyproject = _bundle_root() / "pyproject.toml"
     try:
         m = re.search(
             r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.MULTILINE
@@ -2240,7 +2258,10 @@ def _main():
         run_plugin_mcp_main(plugin_id)
         return
 
-    parser = argparse.ArgumentParser(description=f"{AGENT_NAME_ENV} — protoAgent server")
+    parser = argparse.ArgumentParser(
+        prog="python -m server",
+        description=f"{AGENT_NAME_ENV} — protoAgent server",
+    )
     parser.add_argument("--port", type=int, default=7870)
     parser.add_argument("--config", type=str, default=None)
     parser.add_argument(
@@ -3252,11 +3273,11 @@ def _main():
             pass
 
     # --- React operator console (tiers full/console; skipped in 'none') ------
-    static_dir = Path(__file__).parent / "static"
+    static_dir = _bundle_root() / "static"
     if ui != "none":
         from operator_api.web import mount_react_app
 
-        web_dist_dir = Path(__file__).parent / "apps" / "web" / "dist"
+        web_dist_dir = _bundle_root() / "apps" / "web" / "dist"
         if mount_react_app(fastapi_app, web_dist_dir):
             log.info("React operator console mounted at /app")
 

--- a/server/__main__.py
+++ b/server/__main__.py
@@ -1,0 +1,12 @@
+"""``python -m server`` entry point.
+
+ADR 0023 promoted the former top-level ``server.py`` into this package
+(``server/__init__.py`` is the composition root). The container entrypoint, the
+eval sweep, and the PyInstaller sidecar build all launch the server through this
+module so the package resolves as ``server`` rather than a loose script.
+"""
+
+from server import _main
+
+if __name__ == "__main__":
+    _main()


### PR DESCRIPTION
## What

`server.py` (3,306 lines) → a `server/` package: `server/__init__.py` (the composition root) + `server/__main__.py` (the `python -m server` entry). This is the structural prerequisite for ADR 0023 phase 2, which extracts the backends into `server/a2a.py`, `server/chat.py`, `server/agent_init.py` — those need a `server/` namespace, and a `server/` dir can't coexist with `server.py` (it would shadow it and break `import server` in ~20 tests + the `python server.py` launch).

Pure move — `import server` / `from server import X` are unchanged.

## Why `_bundle_root()`

The package adds one directory level, so the five `__file__`-relative asset lookups (operator project root, bundled `workflows`, `pyproject` version, `static` dir, web `dist`) would silently point one level too deep. They now route through one `_bundle_root()` helper: repo root in a source checkout, `_MEIPASS` when frozen — preserving the desktop sidecar's bundle layout.

## Launch command changed

**`python server.py` → `python -m server`.** Updated every launch site:
- `entrypoint.sh` (PYTHONPATH=/opt/protoagent so the package + sibling top-level modules resolve, workspace stays `cwd=/sandbox`)
- `evals/sweep.py` (throwaway-agent boot)
- `apps/desktop/sidecar/build_sidecar.py` (PyInstaller entry → `server/__main__.py`)
- README + docs tutorials/guides

## Verification

- **1000 tests green** (full suite).
- **Live smoke** against a throwaway instance booted via `python -m server`:
  - `/healthz` → `graph_compiled: true, setup_complete: true`
  - agent card served at the right version (pyproject via `_bundle_root`)
  - OpenAI-compat chat turn round-trip
  - full **A2A 1.0 `SendMessage`** round-trip → `TASK_STATE_COMPLETED` + cost-v1 extension DataPart

## Fork note

If you launch the server directly, switch to `python -m server`. Python imports of `server.*` symbols are unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)