### PR TITLE
refactor(server): extract telemetry routes → operator_api/telemetry_routes.py (ADR 0023 phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Internal: `_main()`'s inline route handlers are moving into `operator_api/*`
+  registrars** (ADR 0023, phase 3 — shrinking the composition root toward app
+  assembly). Each group becomes a `register_*_routes(app)` function matching the
+  existing `register_operator_routes`, so the handler bodies (which only touch
+  `STATE` now) become testable without booting the server. First out:
+  `operator_api/telemetry_routes.py` (`/api/telemetry/summary|recent|insights`).
 - **Internal: agent init / builders / reload / settings moved to
   `server/agent_init.py`** (ADR 0023, phase 2 — final backend extraction).
   `_init_langgraph_agent`, the ten `_build_*` component builders

--- a/operator_api/telemetry_routes.py
+++ b/operator_api/telemetry_routes.py
@@ -1,0 +1,69 @@
+"""Telemetry read-only routes for the operator console (ADR 0006).
+
+Per-turn cost/latency rollups + the advise-only flywheel insight signal, read
+from the local telemetry store. Extracted from ``server._main`` (ADR 0023 phase
+3) into a ``register_telemetry_routes(app)`` registrar matching
+``register_operator_routes``. Every route degrades to ``{"enabled": False}`` when
+the store is off, so the surface is always safe to call.
+"""
+
+from __future__ import annotations
+
+from runtime.state import STATE
+
+
+def register_telemetry_routes(app) -> None:
+    """Register the ``/api/telemetry/*`` read-only routes on ``app``."""
+
+    # Per-turn cost/latency rollups from the local store. Powers the operator
+    # console's cost/latency surface (Slice 3) and ad-hoc "what's expensive"
+    # queries. Read-only; returns {enabled:false} when the store is off.
+    @app.get("/api/telemetry/summary")
+    async def _api_telemetry_summary(since: str | None = None):
+        if STATE.telemetry_store is None:
+            return {"enabled": False, "summary": None}
+        return {"enabled": True, "summary": STATE.telemetry_store.summary(since_iso=since)}
+
+    @app.get("/api/telemetry/recent")
+    async def _api_telemetry_recent(limit: int = 50):
+        if STATE.telemetry_store is None:
+            return {"enabled": False, "turns": []}
+        return {"enabled": True, "turns": STATE.telemetry_store.recent(limit=min(max(1, limit), 500))}
+
+    @app.get("/api/telemetry/insights")
+    async def _api_telemetry_insights():
+        # Advise-only flywheel signal (ADR 0006 Slice 4): flag outlier turns +
+        # prove the levers we can measure from the per-turn store. Read-only.
+        if STATE.telemetry_store is None:
+            return {"enabled": False, "insights": None}
+        import pricing
+
+        s = STATE.telemetry_store.summary()
+        flagged = STATE.telemetry_store.outliers()
+        # Cache lever (proven): estimated $ saved by prompt-cache reads, billed at
+        # the dominant model's input rate (the per-turn store keeps no per-call
+        # model breakdown of cache reads).
+        by_model = s.get("by_model") or []
+        dom_model = by_model[0]["model"] if by_model else ((STATE.graph_config.model_name if STATE.graph_config else "") or "")
+        cache_saved = pricing.cache_read_savings_usd(dom_model, s.get("cache_read_input_tokens", 0))
+        return {
+            "enabled": True,
+            "insights": {
+                "turns": s.get("turns", 0),
+                "flagged": flagged,
+                "flagged_count": len(flagged),
+                "levers": {
+                    "cache": {
+                        "hit_ratio": s.get("cache_hit_ratio", 0.0),
+                        "read_tokens": s.get("cache_read_input_tokens", 0),
+                        "est_savings_usd": cache_saved,
+                    },
+                    "routing": {"by_model": by_model},
+                    "success_rate": s.get("success_rate", 0.0),
+                },
+                # Every optimization lever is now measured: routing per-turn
+                # (actual models on each row); tool deferral + compaction live via
+                # Prometheus (*_llm_tools_deferred_total, *_compactions_total).
+                "unproven_levers": [],
+            },
+        }

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -398,6 +398,7 @@ def _main():
     from graph.config_io import is_setup_complete as _operator_setup_complete
     from operator_api.routes import register_operator_routes
     from operator_api.runtime import build_runtime_status as _build_operator_status
+    from operator_api.telemetry_routes import register_telemetry_routes
     from operator_api.subagents import (
         list_subagents as _operator_list_subagents,
         run_manual_subagent as _operator_run_manual_subagent,
@@ -965,58 +966,9 @@ def _main():
         return {"enabled": True, "query": q, "results": results, "stats": stats}
 
     # --- Telemetry (ADR 0006 Slice 2) --------------------------------------
-    # Per-turn cost/latency rollups from the local store. Powers the operator
-    # console's cost/latency surface (Slice 3) and ad-hoc "what's expensive"
-    # queries. Read-only; returns {enabled:false} when the store is off.
-    @fastapi_app.get("/api/telemetry/summary")
-    async def _api_telemetry_summary(since: str | None = None):
-        if STATE.telemetry_store is None:
-            return {"enabled": False, "summary": None}
-        return {"enabled": True, "summary": STATE.telemetry_store.summary(since_iso=since)}
-
-    @fastapi_app.get("/api/telemetry/recent")
-    async def _api_telemetry_recent(limit: int = 50):
-        if STATE.telemetry_store is None:
-            return {"enabled": False, "turns": []}
-        return {"enabled": True, "turns": STATE.telemetry_store.recent(limit=min(max(1, limit), 500))}
-
-    @fastapi_app.get("/api/telemetry/insights")
-    async def _api_telemetry_insights():
-        # Advise-only flywheel signal (ADR 0006 Slice 4): flag outlier turns +
-        # prove the levers we can measure from the per-turn store. Read-only.
-        if STATE.telemetry_store is None:
-            return {"enabled": False, "insights": None}
-        import pricing
-
-        s = STATE.telemetry_store.summary()
-        flagged = STATE.telemetry_store.outliers()
-        # Cache lever (proven): estimated $ saved by prompt-cache reads, billed at
-        # the dominant model's input rate (the per-turn store keeps no per-call
-        # model breakdown of cache reads).
-        by_model = s.get("by_model") or []
-        dom_model = by_model[0]["model"] if by_model else ((STATE.graph_config.model_name if STATE.graph_config else "") or "")
-        cache_saved = pricing.cache_read_savings_usd(dom_model, s.get("cache_read_input_tokens", 0))
-        return {
-            "enabled": True,
-            "insights": {
-                "turns": s.get("turns", 0),
-                "flagged": flagged,
-                "flagged_count": len(flagged),
-                "levers": {
-                    "cache": {
-                        "hit_ratio": s.get("cache_hit_ratio", 0.0),
-                        "read_tokens": s.get("cache_read_input_tokens", 0),
-                        "est_savings_usd": cache_saved,
-                    },
-                    "routing": {"by_model": by_model},
-                    "success_rate": s.get("success_rate", 0.0),
-                },
-                # Every optimization lever is now measured: routing per-turn
-                # (actual models on each row); tool deferral + compaction live via
-                # Prometheus (*_llm_tools_deferred_total, *_compactions_total).
-                "unproven_levers": [],
-            },
-        }
+    # Per-turn cost/latency + advise-only insights (ADR 0006). Extracted to
+    # operator_api/telemetry_routes.py (ADR 0023 phase 3).
+    register_telemetry_routes(fastapi_app)
 
     # --- Live config / SOUL editing ----------------------------------------
     # GET returns the current config + persona so external clients (the

--- a/tests/test_telemetry_routes.py
+++ b/tests/test_telemetry_routes.py
@@ -1,0 +1,53 @@
+"""Telemetry routes (ADR 0023 phase 3 extraction) — registrar wires the
+read-only /api/telemetry/* surface and degrades safely when the store is off."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from operator_api.telemetry_routes import register_telemetry_routes
+
+
+def _client(monkeypatch, store):
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "telemetry_store", store, raising=False)
+    app = FastAPI()
+    register_telemetry_routes(app)
+    return TestClient(app)
+
+
+def test_routes_disabled_when_store_off(monkeypatch):
+    c = _client(monkeypatch, None)
+    assert c.get("/api/telemetry/summary").json() == {"enabled": False, "summary": None}
+    assert c.get("/api/telemetry/recent").json() == {"enabled": False, "turns": []}
+    assert c.get("/api/telemetry/insights").json() == {"enabled": False, "insights": None}
+
+
+def test_summary_and_recent_delegate_to_store(monkeypatch):
+    class _Store:
+        def summary(self, since_iso=None):
+            return {"turns": 3, "since": since_iso}
+
+        def recent(self, limit=50):
+            return [{"task_id": "t1"}][:limit]
+
+    c = _client(monkeypatch, _Store())
+    body = c.get("/api/telemetry/summary?since=2026-01-01").json()
+    assert body == {"enabled": True, "summary": {"turns": 3, "since": "2026-01-01"}}
+    recent = c.get("/api/telemetry/recent?limit=1").json()
+    assert recent == {"enabled": True, "turns": [{"task_id": "t1"}]}
+
+
+def test_recent_limit_is_clamped(monkeypatch):
+    seen = {}
+
+    class _Store:
+        def recent(self, limit=50):
+            seen["limit"] = limit
+            return []
+
+    c = _client(monkeypatch, _Store())
+    c.get("/api/telemetry/recent?limit=99999")
+    assert seen["limit"] == 500  # clamped to the 500 ceiling
+    c.get("/api/telemetry/recent?limit=0")
+    assert seen["limit"] == 1  # clamped to the floor


### PR DESCRIPTION
## What

First ADR 0023 **phase 3** route extraction. Moves the three `/api/telemetry/*` handlers out of `_main` into **`operator_api/telemetry_routes.py`** behind `register_telemetry_routes(app)` — matching the existing `register_operator_routes` shape.

The handler bodies only touch `STATE`, so the `@fastapi_app` decorator was their only `_main`-closure capture; as a registrar they're now testable on a bare `FastAPI()` app without booting the server.

## Tests

Adds `tests/test_telemetry_routes.py`: store-off degradation (`enabled: false`), store delegation, and the `recent` limit clamp (1–500).

## Verification

- **1003 tests green** (1000 + 3 new).
- **Live smoke** (`python -m server`): `summary` / `recent` / `insights` all return `enabled: true` against a real store.

Kicks off phase 3 (after #549–#553 completed phase 2). Composition root continues shrinking toward app-assembly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)