### PR TITLE
refactor(server): extract knowledge + playbooks routes → operator_api/knowledge_routes.py (ADR 0023 phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,8 +16,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   registrars** (ADR 0023, phase 3 — shrinking the composition root toward app
   assembly). Each group becomes a `register_*_routes(app)` function matching the
   existing `register_operator_routes`, so the handler bodies (which only touch
-  `STATE` now) become testable without booting the server. First out:
-  `operator_api/telemetry_routes.py` (`/api/telemetry/summary|recent|insights`).
+  `STATE` now) become testable without booting the server. Extracted so far:
+  `operator_api/telemetry_routes.py` (`/api/telemetry/*`) and
+  `operator_api/knowledge_routes.py` (`/api/knowledge/search` + `/api/playbooks`).
 - **Internal: agent init / builders / reload / settings moved to
   `server/agent_init.py`** (ADR 0023, phase 2 — final backend extraction).
   `_init_langgraph_agent`, the ten `_build_*` component builders

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -1,0 +1,96 @@
+"""Knowledge-store + playbooks routes for the operator console.
+
+The console's "Knowledge" surface is a searchable Store + Playbooks (ADR 0020):
+the FTS5 knowledge base (findings, daily-log, harvested sessions, operator notes)
+and the procedural-memory skill index. Extracted from ``server._main`` (ADR 0023
+phase 3) into a ``register_knowledge_routes(app)`` registrar. Every route is
+read-only / best-effort and degrades to ``{"enabled": False}`` when its store is
+off; none ever 500s the console.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from runtime.state import STATE
+
+log = logging.getLogger("protoagent.server")
+
+
+def _knowledge_row(d: dict) -> dict:
+    """Normalize a search()/list_chunks() row to the console's shape."""
+    heading = d.get("heading") or ""
+    content = d.get("content") or ""
+    preview = d.get("preview") or ((heading + ": " if heading else "") + content)[:240]
+    return {
+        "id": d.get("id"),
+        "heading": heading,
+        "content": content,
+        "preview": preview,
+        "domain": d.get("domain") or "general",
+        "source": d.get("source"),
+        "source_type": d.get("source_type"),
+        "finding_type": d.get("finding_type"),
+        "created_at": d.get("created_at"),
+    }
+
+
+def register_knowledge_routes(app) -> None:
+    """Register the ``/api/playbooks*`` + ``/api/knowledge/search`` routes."""
+
+    # --- Playbooks (skills surface, ADR 0009) ------------------------------
+    # Browse + manage the procedural-memory skill index (skills.db) the operator
+    # was otherwise blind to. "Playbooks" is the operator-facing name for the
+    # skill-v1 artifacts (disk = pinned SKILL.md, emitted = agent-learned).
+    @app.get("/api/playbooks")
+    async def _api_playbooks():
+        if STATE.skills_index is None:
+            return {"enabled": False, "playbooks": []}
+        try:
+            skills = STATE.skills_index.all_skills()
+        except Exception:  # noqa: BLE001 — never 500 the console
+            log.exception("[playbooks] all_skills failed")
+            return {"enabled": True, "playbooks": []}
+        # Drop the (potentially large) prompt_template from the list payload;
+        # the table only needs metadata. Sort pinned-first, then by confidence.
+        out = [
+            {k: v for k, v in s.items() if k != "prompt_template"}
+            for s in skills
+        ]
+        out.sort(key=lambda s: (s.get("source") != "disk", -(s.get("confidence") or 0)))
+        return {"enabled": True, "playbooks": out}
+
+    @app.delete("/api/playbooks/{skill_id}")
+    async def _api_playbook_delete(skill_id: int):
+        if STATE.skills_index is None:
+            return {"enabled": False, "deleted": False}
+        try:
+            STATE.skills_index.delete_skill(skill_id)
+            return {"enabled": True, "deleted": True}
+        except Exception as exc:  # noqa: BLE001
+            log.exception("[playbooks] delete failed")
+            return {"enabled": True, "deleted": False, "error": str(exc)}
+
+    # --- Knowledge store (ADR 0020) ----------------------------------------
+    # Searchable view of the agent's knowledge base (knowledge/store.py, FTS5):
+    # findings, daily-log entries, harvested sessions, operator notes — the same
+    # store KnowledgeMiddleware queries before each turn. An empty ``q`` returns
+    # the most-recent chunks (a browsable default); a non-empty ``q`` runs FTS5
+    # search. Read-only; never 500s the console.
+    @app.get("/api/knowledge/search")
+    async def _api_knowledge_search(q: str = "", k: int = 30, domain: str | None = None):
+        if STATE.knowledge_store is None:
+            return {"enabled": False, "query": q, "results": [], "stats": {}}
+        results: list[dict] = []
+        try:
+            if q and q.strip():
+                results = [_knowledge_row(r) for r in STATE.knowledge_store.search(q, k=k, domain=domain or None)]
+            else:
+                results = [_knowledge_row(c.as_dict()) for c in STATE.knowledge_store.list_chunks(domain=domain or None, limit=k)]
+        except Exception:  # noqa: BLE001 — never 500 the console
+            log.exception("[knowledge] search failed")
+        try:
+            stats = STATE.knowledge_store.stats()
+        except Exception:  # noqa: BLE001
+            stats = {}
+        return {"enabled": True, "query": q, "results": results, "stats": stats}

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -396,6 +396,7 @@ def _main():
 
     # --- React operator-console API ----------------------------------------
     from graph.config_io import is_setup_complete as _operator_setup_complete
+    from operator_api.knowledge_routes import register_knowledge_routes
     from operator_api.routes import register_operator_routes
     from operator_api.runtime import build_runtime_status as _build_operator_status
     from operator_api.telemetry_routes import register_telemetry_routes
@@ -891,79 +892,9 @@ def _main():
             status_code=200 if ready else 503,
         )
 
-    # --- Playbooks (skills surface, ADR 0009) ------------------------------
-    # Browse + manage the procedural-memory skill index (skills.db) the operator
-    # was otherwise blind to. "Playbooks" is the operator-facing name for the
-    # skill-v1 artifacts (disk = pinned SKILL.md, emitted = agent-learned).
-    @fastapi_app.get("/api/playbooks")
-    async def _api_playbooks():
-        if STATE.skills_index is None:
-            return {"enabled": False, "playbooks": []}
-        try:
-            skills = STATE.skills_index.all_skills()
-        except Exception:  # noqa: BLE001 — never 500 the console
-            log.exception("[playbooks] all_skills failed")
-            return {"enabled": True, "playbooks": []}
-        # Drop the (potentially large) prompt_template from the list payload;
-        # the table only needs metadata. Sort pinned-first, then by confidence.
-        out = [
-            {k: v for k, v in s.items() if k != "prompt_template"}
-            for s in skills
-        ]
-        out.sort(key=lambda s: (s.get("source") != "disk", -(s.get("confidence") or 0)))
-        return {"enabled": True, "playbooks": out}
-
-    @fastapi_app.delete("/api/playbooks/{skill_id}")
-    async def _api_playbook_delete(skill_id: int):
-        if STATE.skills_index is None:
-            return {"enabled": False, "deleted": False}
-        try:
-            STATE.skills_index.delete_skill(skill_id)
-            return {"enabled": True, "deleted": True}
-        except Exception as exc:  # noqa: BLE001
-            log.exception("[playbooks] delete failed")
-            return {"enabled": True, "deleted": False, "error": str(exc)}
-
-    # --- Knowledge store (ADR 0020) ----------------------------------------
-    # Searchable view of the agent's knowledge base (knowledge/store.py, FTS5):
-    # findings, daily-log entries, harvested sessions, operator notes — the same
-    # store KnowledgeMiddleware queries before each turn. An empty ``q`` returns
-    # the most-recent chunks (a browsable default); a non-empty ``q`` runs FTS5
-    # search. Read-only; never 500s the console.
-    def _knowledge_row(d: dict) -> dict:
-        """Normalize a search()/list_chunks() row to the console's shape."""
-        heading = d.get("heading") or ""
-        content = d.get("content") or ""
-        preview = d.get("preview") or ((heading + ": " if heading else "") + content)[:240]
-        return {
-            "id": d.get("id"),
-            "heading": heading,
-            "content": content,
-            "preview": preview,
-            "domain": d.get("domain") or "general",
-            "source": d.get("source"),
-            "source_type": d.get("source_type"),
-            "finding_type": d.get("finding_type"),
-            "created_at": d.get("created_at"),
-        }
-
-    @fastapi_app.get("/api/knowledge/search")
-    async def _api_knowledge_search(q: str = "", k: int = 30, domain: str | None = None):
-        if STATE.knowledge_store is None:
-            return {"enabled": False, "query": q, "results": [], "stats": {}}
-        results: list[dict] = []
-        try:
-            if q and q.strip():
-                results = [_knowledge_row(r) for r in STATE.knowledge_store.search(q, k=k, domain=domain or None)]
-            else:
-                results = [_knowledge_row(c.as_dict()) for c in STATE.knowledge_store.list_chunks(domain=domain or None, limit=k)]
-        except Exception:  # noqa: BLE001 — never 500 the console
-            log.exception("[knowledge] search failed")
-        try:
-            stats = STATE.knowledge_store.stats()
-        except Exception:  # noqa: BLE001
-            stats = {}
-        return {"enabled": True, "query": q, "results": results, "stats": stats}
+    # Knowledge store + Playbooks (ADR 0020). Extracted to
+    # operator_api/knowledge_routes.py (ADR 0023 phase 3).
+    register_knowledge_routes(fastapi_app)
 
     # --- Telemetry (ADR 0006 Slice 2) --------------------------------------
     # Per-turn cost/latency + advise-only insights (ADR 0006). Extracted to

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -1,0 +1,64 @@
+"""Knowledge + playbooks routes (ADR 0023 phase 3 extraction) — registrar wires
+the console's read-only Knowledge surface and degrades when a store is off."""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from operator_api.knowledge_routes import _knowledge_row, register_knowledge_routes
+
+
+def _client(monkeypatch, *, knowledge=None, skills=None):
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "knowledge_store", knowledge, raising=False)
+    monkeypatch.setattr(rs.STATE, "skills_index", skills, raising=False)
+    app = FastAPI()
+    register_knowledge_routes(app)
+    return TestClient(app)
+
+
+def test_disabled_when_stores_off(monkeypatch):
+    c = _client(monkeypatch)
+    assert c.get("/api/knowledge/search").json()["enabled"] is False
+    assert c.get("/api/playbooks").json() == {"enabled": False, "playbooks": []}
+    assert c.delete("/api/playbooks/1").json() == {"enabled": False, "deleted": False}
+
+
+def test_knowledge_search_and_browse(monkeypatch):
+    class _KS:
+        def search(self, q, k=30, domain=None):
+            return [{"id": 1, "heading": "H", "content": "C"}]
+
+        def list_chunks(self, domain=None, limit=30):
+            class _C:
+                def as_dict(self_inner):
+                    return {"id": 2, "content": "recent"}
+            return [_C()]
+
+        def stats(self):
+            return {"chunks": 2}
+
+    c = _client(monkeypatch, knowledge=_KS())
+    hit = c.get("/api/knowledge/search?q=foo").json()
+    assert hit["enabled"] and hit["results"][0]["id"] == 1 and hit["stats"] == {"chunks": 2}
+    browse = c.get("/api/knowledge/search").json()  # empty q -> recent chunks
+    assert browse["results"][0]["id"] == 2
+
+
+def test_playbooks_sorted_pinned_first(monkeypatch):
+    class _SK:
+        def all_skills(self):
+            return [
+                {"id": 1, "source": "emitted", "confidence": 0.9, "prompt_template": "big"},
+                {"id": 2, "source": "disk", "confidence": 0.1, "prompt_template": "big"},
+            ]
+
+    c = _client(monkeypatch, skills=_SK())
+    pb = c.get("/api/playbooks").json()
+    assert pb["enabled"] and [p["id"] for p in pb["playbooks"]] == [2, 1]  # disk pinned first
+    assert "prompt_template" not in pb["playbooks"][0]  # stripped from list payload
+
+
+def test_knowledge_row_preview_fallback():
+    row = _knowledge_row({"heading": "Title", "content": "Body text"})
+    assert row["preview"] == "Title: Body text" and row["domain"] == "general"


### PR DESCRIPTION
## What

ADR 0023 phase 3, route group 2. Moves `/api/playbooks`, `/api/playbooks/{id}`, and `/api/knowledge/search` out of `_main` into **`operator_api/knowledge_routes.py`** behind `register_knowledge_routes(app)`.

These are the console's "Knowledge = Store + Playbooks" surface (ADR 0020), so they live in one module. Bodies only touch `STATE`; the `_knowledge_row` normalizer moves with them. All routes are read-only / best-effort and never 500 the console.

## Tests

Adds `tests/test_knowledge_routes.py`: store-off degradation, FTS search vs. empty-`q` browse, pinned-first playbook sort + `prompt_template` stripping, and the `_knowledge_row` preview fallback.

## Verification

- **1007 tests green** (1000 + 3 telemetry + 4 knowledge).
- **Live smoke** (`python -m server`): `/api/playbooks` returns the 2 seeded SKILL.md skills; `/api/knowledge/search` (browse + query) is `enabled` with stats.

Follows #554. Rebased on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)