### PR TITLE
refactor(server): extract chat/goal/health/OpenAI-compat routes → operator_api/chat_routes.py (ADR 0023 phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `STATE` now) become testable without booting the server. Extracted so far:
   `operator_api/telemetry_routes.py` (`/api/telemetry/*`),
   `operator_api/knowledge_routes.py` (`/api/knowledge/search` + `/api/playbooks`),
-  and `operator_api/config_routes.py` (`/api/config*` + `/api/settings*`).
+  `operator_api/config_routes.py` (`/api/config*` + `/api/settings*`), and
+  `operator_api/chat_routes.py` (`/api/chat`, `/api/goal/*`, `/healthz`, and the
+  OpenAI-compat `/v1/chat/completions` + `/v1/models`).
 - **Internal: agent init / builders / reload / settings moved to
   `server/agent_init.py`** (ADR 0023, phase 2 — final backend extraction).
   `_init_langgraph_agent`, the ten `_build_*` component builders

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -1,0 +1,146 @@
+"""Chat / goal / health / OpenAI-compat routes.
+
+The non-A2A HTTP chat surface: the operator console's `/api/chat`, session
+retirement, goal-mode status/clear, the `/healthz` readiness probe (ADR 0010),
+and the OpenAI-compatible `/v1/chat/completions` + `/v1/models` endpoints that
+let this agent register as a model in the LiteLLM gateway / OpenWebUI. Extracted
+from ``server._main`` (ADR 0023 phase 3) into a ``register_chat_routes(app, ui)``
+registrar.
+
+The turn logic lives in ``server.chat`` (``chat``); these handlers are the thin
+HTTP layer over it. ``ui`` (the deployment tier) is passed in because
+``/healthz`` echoes it.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+
+from fastapi.responses import JSONResponse, StreamingResponse
+from pydantic import BaseModel
+
+from runtime.state import STATE
+from server import agent_name
+from server.agent_init import _retire_thread
+from server.chat import chat
+
+
+class ChatRequest(BaseModel):
+    message: str
+    session_id: str = "api-default"
+
+
+def register_chat_routes(app, ui: str) -> None:
+    """Register the chat / goal / health / OpenAI-compat routes on ``app``.
+
+    ``ui`` is the active deployment tier (full/console/none); ``/healthz`` echoes
+    it so probes can see which surface is running.
+    """
+
+    # --- Chat API -----------------------------------------------------------
+    @app.post("/api/chat")
+    async def _api_chat(req: ChatRequest):
+        result = await chat(req.message, req.session_id)
+        parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
+        return {"response": "\n\n".join(parts), "messages": result}
+
+    @app.delete("/api/chat/sessions/{session_id}")
+    async def _api_delete_session(session_id: str):
+        """Retire a chat session: harvest its conversation into the knowledge
+        base (if enabled), then purge its checkpoints. Called when the operator
+        deletes a chat tab, so deleted conversations don't linger to the TTL —
+        their substance lives on as searchable memory instead."""
+        chunk_id = await _retire_thread(f"a2a:{session_id}")
+        return {"deleted": True, "harvested": chunk_id is not None}
+
+    # --- Goal mode API ------------------------------------------------------
+    # Programmatic status/clear for a session's goal (setting is done via the
+    # `/goal ...` control message through chat/A2A). Returns 404-style payloads
+    # as plain JSON to keep the surface dependency-free.
+    @app.get("/api/goal/{session_id}")
+    async def _api_goal_status(session_id: str):
+        if STATE.goal_controller is None:
+            return {"enabled": False, "goal": None}
+        state = STATE.goal_controller.store.get(session_id)
+        return {"enabled": True, "goal": state.to_dict() if state else None}
+
+    @app.delete("/api/goal/{session_id}")
+    async def _api_goal_clear(session_id: str):
+        if STATE.goal_controller is None:
+            return {"enabled": False, "cleared": False}
+        return {"enabled": True, "cleared": STATE.goal_controller.store.clear(session_id)}
+
+    # --- Health / readiness (ADR 0010) -------------------------------------
+    # Reflects whether the graph actually compiled — the only readiness signal
+    # in the 'none' tier (no UI to eyeball). 503 until ready, for k8s probes.
+    @app.get("/healthz", include_in_schema=False)
+    async def _healthz():
+        from graph.config_io import is_setup_complete
+        ready = STATE.graph is not None
+        return JSONResponse(
+            {
+                "ok": ready,
+                "graph_compiled": ready,
+                "setup_complete": is_setup_complete(),
+                "ui": ui,
+                # Surface the active model so eval reports can be tagged with the
+                # model under test without guessing (evals.runner auto-detects).
+                "model": STATE.graph_config.model_name if STATE.graph_config else None,
+            },
+            status_code=200 if ready else 503,
+        )
+
+    # --- OpenAI-compatible chat completions --------------------------------
+    # Lets this agent be registered as a model in the LiteLLM gateway /
+    # OpenWebUI without any protocol adapter.
+    @app.post("/v1/chat/completions")
+    async def _openai_chat_completions(req: dict):
+        messages = req.get("messages", [])
+        user_msgs = [m for m in messages if m.get("role") == "user"]
+        if not user_msgs:
+            return {"error": "No user message provided"}, 400
+        prompt = user_msgs[-1].get("content", "")
+        session_id = f"openai-compat-{int(time.time())}"
+        stream = req.get("stream", False)
+
+        result = await chat(prompt, session_id)
+        parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
+        content = "\n\n".join(parts)
+        created = int(time.time())
+        completion_id = f"{agent_name()}-{session_id}"
+
+        if stream:
+            async def _stream():
+                chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": agent_name(),
+                    "choices": [{"index": 0, "delta": {"role": "assistant", "content": content}, "finish_reason": None}],
+                }
+                yield f"data: {json.dumps(chunk)}\n\n"
+                done_chunk = {
+                    "id": completion_id, "object": "chat.completion.chunk",
+                    "created": created, "model": agent_name(),
+                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
+                }
+                yield f"data: {json.dumps(done_chunk)}\n\n"
+                yield "data: [DONE]\n\n"
+            return StreamingResponse(_stream(), media_type="text/event-stream")
+
+        return {
+            "id": completion_id, "object": "chat.completion",
+            "created": created, "model": agent_name(),
+            "choices": [{
+                "index": 0,
+                "message": {"role": "assistant", "content": content},
+                "finish_reason": "stop",
+            }],
+            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
+        }
+
+    @app.get("/v1/models")
+    async def _openai_models():
+        return {
+            "object": "list",
+            "data": [{"id": agent_name(), "object": "model", "created": 1774600000, "owned_by": "protolabs"}],
+        }

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -396,6 +396,7 @@ def _main():
 
     # --- React operator-console API ----------------------------------------
     from graph.config_io import is_setup_complete as _operator_setup_complete
+    from operator_api.chat_routes import register_chat_routes
     from operator_api.config_routes import register_config_routes
     from operator_api.knowledge_routes import register_knowledge_routes
     from operator_api.routes import register_operator_routes
@@ -836,62 +837,10 @@ def _main():
         if STATE.checkpoint_prune_task is not None:
             STATE.checkpoint_prune_task.cancel()
 
-    # --- Chat API -----------------------------------------------------------
-    class ChatRequest(PydanticBaseModel):
-        message: str
-        session_id: str = "api-default"
-
-    @fastapi_app.post("/api/chat")
-    async def _api_chat(req: ChatRequest):
-        result = await chat(req.message, req.session_id)
-        parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
-        return {"response": "\n\n".join(parts), "messages": result}
-
-    @fastapi_app.delete("/api/chat/sessions/{session_id}")
-    async def _api_delete_session(session_id: str):
-        """Retire a chat session: harvest its conversation into the knowledge
-        base (if enabled), then purge its checkpoints. Called when the operator
-        deletes a chat tab, so deleted conversations don't linger to the TTL —
-        their substance lives on as searchable memory instead."""
-        chunk_id = await _retire_thread(f"a2a:{session_id}")
-        return {"deleted": True, "harvested": chunk_id is not None}
-
-    # --- Goal mode API ------------------------------------------------------
-    # Programmatic status/clear for a session's goal (setting is done via the
-    # `/goal ...` control message through chat/A2A). Returns 404-style payloads
-    # as plain JSON to keep the surface dependency-free.
-    @fastapi_app.get("/api/goal/{session_id}")
-    async def _api_goal_status(session_id: str):
-        if STATE.goal_controller is None:
-            return {"enabled": False, "goal": None}
-        state = STATE.goal_controller.store.get(session_id)
-        return {"enabled": True, "goal": state.to_dict() if state else None}
-
-    @fastapi_app.delete("/api/goal/{session_id}")
-    async def _api_goal_clear(session_id: str):
-        if STATE.goal_controller is None:
-            return {"enabled": False, "cleared": False}
-        return {"enabled": True, "cleared": STATE.goal_controller.store.clear(session_id)}
-
-    # --- Health / readiness (ADR 0010) -------------------------------------
-    # Reflects whether the graph actually compiled — the only readiness signal
-    # in the 'none' tier (no UI to eyeball). 503 until ready, for k8s probes.
-    @fastapi_app.get("/healthz", include_in_schema=False)
-    async def _healthz():
-        from graph.config_io import is_setup_complete
-        ready = STATE.graph is not None
-        return JSONResponse(
-            {
-                "ok": ready,
-                "graph_compiled": ready,
-                "setup_complete": is_setup_complete(),
-                "ui": ui,
-                # Surface the active model so eval reports can be tagged with the
-                # model under test without guessing (evals.runner auto-detects).
-                "model": STATE.graph_config.model_name if STATE.graph_config else None,
-            },
-            status_code=200 if ready else 503,
-        )
+    # Chat / goal / health / OpenAI-compat HTTP surface. Extracted to
+    # operator_api/chat_routes.py (ADR 0023 phase 3); ``ui`` is passed in
+    # because /healthz echoes the active tier.
+    register_chat_routes(fastapi_app, ui)
 
     # Knowledge store + Playbooks (ADR 0020). Extracted to
     # operator_api/knowledge_routes.py (ADR 0023 phase 3).
@@ -907,59 +856,8 @@ def _main():
     # (ADR 0023 phase 3).
     register_config_routes(fastapi_app)
 
-    # --- OpenAI-compatible chat completions --------------------------------
-    # Lets this agent be registered as a model in the LiteLLM gateway /
-    # OpenWebUI without any protocol adapter.
-    @fastapi_app.post("/v1/chat/completions")
-    async def _openai_chat_completions(req: dict):
-        messages = req.get("messages", [])
-        user_msgs = [m for m in messages if m.get("role") == "user"]
-        if not user_msgs:
-            return {"error": "No user message provided"}, 400
-        prompt = user_msgs[-1].get("content", "")
-        session_id = f"openai-compat-{int(time.time())}"
-        stream = req.get("stream", False)
-
-        result = await chat(prompt, session_id)
-        parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
-        content = "\n\n".join(parts)
-        created = int(time.time())
-        completion_id = f"{agent_name()}-{session_id}"
-
-        if stream:
-            async def _stream():
-                chunk = {
-                    "id": completion_id, "object": "chat.completion.chunk",
-                    "created": created, "model": agent_name(),
-                    "choices": [{"index": 0, "delta": {"role": "assistant", "content": content}, "finish_reason": None}],
-                }
-                yield f"data: {json.dumps(chunk)}\n\n"
-                done_chunk = {
-                    "id": completion_id, "object": "chat.completion.chunk",
-                    "created": created, "model": agent_name(),
-                    "choices": [{"index": 0, "delta": {}, "finish_reason": "stop"}],
-                }
-                yield f"data: {json.dumps(done_chunk)}\n\n"
-                yield "data: [DONE]\n\n"
-            return StreamingResponse(_stream(), media_type="text/event-stream")
-
-        return {
-            "id": completion_id, "object": "chat.completion",
-            "created": created, "model": agent_name(),
-            "choices": [{
-                "index": 0,
-                "message": {"role": "assistant", "content": content},
-                "finish_reason": "stop",
-            }],
-            "usage": {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0},
-        }
-
-    @fastapi_app.get("/v1/models")
-    async def _openai_models():
-        return {
-            "object": "list",
-            "data": [{"id": agent_name(), "object": "model", "created": 1774600000, "owned_by": "protolabs"}],
-        }
+    # OpenAI-compatible /v1/chat/completions + /v1/models are registered above
+    # by register_chat_routes (operator_api/chat_routes.py, ADR 0023 phase 3).
 
     # --- A2A protocol (a2a-sdk 1.0) -----------------------------------------
     # a2a-sdk owns all protocol mechanics: JSON-RPC dispatch, SSE streaming,

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -1,0 +1,67 @@
+"""Chat / goal / health / OpenAI-compat routes (ADR 0023 phase 3 extraction)."""
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _client(monkeypatch, *, graph=object(), goal=None, chat_reply=None):
+    import operator_api.chat_routes as cr
+    import runtime.state as rs
+
+    async def _fake_chat(message, session_id):
+        return chat_reply or [{"role": "assistant", "content": f"echo:{message}"}]
+
+    monkeypatch.setattr(cr, "chat", _fake_chat)
+    monkeypatch.setattr(cr, "agent_name", lambda: "protoagent")
+    monkeypatch.setattr(rs.STATE, "graph", graph, raising=False)
+    monkeypatch.setattr(rs.STATE, "goal_controller", goal, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", None, raising=False)
+    app = FastAPI()
+    cr.register_chat_routes(app, ui="none")
+    return TestClient(app)
+
+
+def test_api_chat_joins_assistant_parts(monkeypatch):
+    c = _client(monkeypatch)
+    body = c.post("/api/chat", json={"message": "hi"}).json()
+    assert body["response"] == "echo:hi"
+
+
+def test_healthz_ready_and_echoes_ui(monkeypatch):
+    c = _client(monkeypatch, graph=object())
+    r = c.get("/healthz")
+    assert r.status_code == 200
+    assert r.json()["graph_compiled"] is True and r.json()["ui"] == "none"
+
+
+def test_healthz_503_when_graph_none(monkeypatch):
+    c = _client(monkeypatch, graph=None)
+    r = c.get("/healthz")
+    assert r.status_code == 503 and r.json()["ok"] is False
+
+
+def test_goal_disabled_when_no_controller(monkeypatch):
+    c = _client(monkeypatch, goal=None)
+    assert c.get("/api/goal/s1").json() == {"enabled": False, "goal": None}
+    assert c.delete("/api/goal/s1").json() == {"enabled": False, "cleared": False}
+
+
+def test_openai_models_and_completion(monkeypatch):
+    c = _client(monkeypatch)
+    models = c.get("/v1/models").json()
+    assert models["data"][0]["id"] == "protoagent"
+    comp = c.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "yo"}]}).json()
+    assert comp["choices"][0]["message"]["content"] == "echo:yo"
+    assert comp["model"] == "protoagent"
+
+
+def test_openai_streaming(monkeypatch):
+    c = _client(monkeypatch)
+    r = c.post("/v1/chat/completions", json={"messages": [{"role": "user", "content": "yo"}], "stream": True})
+    assert r.headers["content-type"].startswith("text/event-stream")
+    frames = [ln for ln in r.text.splitlines() if ln.startswith("data: ")]
+    first = json.loads(frames[0][len("data: "):])
+    assert first["choices"][0]["delta"]["content"] == "echo:yo"
+    assert frames[-1] == "data: [DONE]"


### PR DESCRIPTION
## What

ADR 0023 phase 3, route group 4. Moves the non-A2A HTTP chat surface out of `_main` into **`operator_api/chat_routes.py`** behind `register_chat_routes(app, ui)`:

- `/api/chat` + `/api/chat/sessions/{id}` (retire → harvest + purge)
- `/api/goal/{id}` status + clear
- `/healthz` readiness probe (ADR 0010) — `ui` tier passed in since the payload echoes it
- `/v1/chat/completions` (+ SSE streaming) and `/v1/models` (OpenAI-compat)

The turn logic stays in `server.chat` (`chat`); these handlers are the thin HTTP layer. The `_stream` generator's captures (`completion_id`/`content`/`created`) are local to its own handler and move intact.

## Tests

Adds `tests/test_chat_routes.py`: chat join, healthz ready/503, goal-disabled, OpenAI models + completion + SSE streaming frames.

## Verification

- **1017 tests green** (1000 + 17 phase-3 route tests).
- **Live smoke** (`python -m server`): `/healthz` ready (`ui: none`), `/api/chat` → `CHATAPIOK`, `/v1/models` → `protoagent`, `/v1/chat/completions` → `V1OK`.

Follows #554/#555/#556. Rebased on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)