### PR TITLE
refactor(server): extract operator-console handlers → operator_api/console_handlers.py (ADR 0023 phase 3, final)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,16 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Internal: `_main()`'s inline route handlers are moving into `operator_api/*`
-  registrars** (ADR 0023, phase 3 — shrinking the composition root toward app
-  assembly). Each group becomes a `register_*_routes(app)` function matching the
-  existing `register_operator_routes`, so the handler bodies (which only touch
-  `STATE` now) become testable without booting the server. Extracted so far:
+- **Internal: `_main()`'s inline route handlers moved into `operator_api/*`**
+  (ADR 0023, phase 3 — composition root down to app assembly). Each route group
+  is now a `register_*_routes(app)` function matching the existing
+  `register_operator_routes`, so the handler bodies (which only touch `STATE`)
+  are testable without booting the server:
   `operator_api/telemetry_routes.py` (`/api/telemetry/*`),
-  `operator_api/knowledge_routes.py` (`/api/knowledge/search` + `/api/playbooks`),
-  `operator_api/config_routes.py` (`/api/config*` + `/api/settings*`), and
-  `operator_api/chat_routes.py` (`/api/chat`, `/api/goal/*`, `/healthz`, and the
-  OpenAI-compat `/v1/chat/completions` + `/v1/models`).
+  `knowledge_routes.py` (`/api/knowledge/search` + `/api/playbooks`),
+  `config_routes.py` (`/api/config*` + `/api/settings*`), and
+  `chat_routes.py` (`/api/chat`, `/api/goal/*`, `/healthz`, OpenAI-compat
+  `/v1/*`). The 21 React-console handler closures also moved out — into
+  `operator_api/console_handlers.py` — finishing the half-done `operator_api/`
+  extraction. Net: **`server.py` went from 3,353 lines to a ~700-line `server/`
+  package composition root** (`_main` is ~430 lines of pure app assembly).
+  Phase 3 is complete; ADR 0023 is fully shipped.
 - **Internal: agent init / builders / reload / settings moved to
   `server/agent_init.py`** (ADR 0023, phase 2 — final backend extraction).
   `_init_langgraph_agent`, the ten `_build_*` component builders

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -1,0 +1,350 @@
+"""Operator-console request handlers (the bodies behind `register_operator_routes`).
+
+ADR 0023 phase 3 finishes the half-done `operator_api/` extraction: the React
+console's runtime-status / subagent / scheduler / goal / workflow / activity /
+inbox / chat-command handlers used to be inline closures in ``server._main`` that
+closed over the (then-ambient) globals. Now that runtime state lives in
+``runtime.state.STATE``, they're plain module-level functions here; ``_main``
+imports this module and passes the functions to ``register_operator_routes``
+instead of defining 21 closures.
+
+Bodies are unchanged from their former in-``_main`` form — dependencies are
+imported under the same alias names the bodies use, and the one captured local
+(the operator project root) is resolved live via
+``server._resolve_operator_project_root()``.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from events import ACTIVITY_CONTEXT
+from graph.config_io import is_setup_complete as _operator_setup_complete
+from graph.output_format import extract_output
+from operator_api.runtime import build_runtime_status as _build_operator_status
+from operator_api.subagents import (
+    list_subagents as _operator_list_subagents,
+    run_manual_subagent as _operator_run_manual_subagent,
+    run_manual_subagent_batch as _operator_run_manual_subagent_batch,
+)
+from runtime.state import STATE
+from server import AGENT_NAME_ENV, _event_bus, _resolve_operator_project_root
+
+log = logging.getLogger("protoagent.server")
+
+
+def _operator_allowed_dirs() -> list[str]:
+    # The repo root is always operable (it's the default project);
+    # config adds any extra project roots. Read live so a settings
+    # reload takes effect without restarting the server.
+    roots = [_resolve_operator_project_root()]
+    if STATE.graph_config is not None:
+        roots.extend(getattr(STATE.graph_config, "operator_allowed_dirs", []) or [])
+    return roots
+
+
+def _operator_runtime_status():
+    return _build_operator_status(
+        config=STATE.graph_config,
+        setup_complete=_operator_setup_complete(),
+        graph_loaded=STATE.graph is not None,
+        project_path=_resolve_operator_project_root(),
+        allowed_dirs=_operator_allowed_dirs(),
+        knowledge_store=STATE.knowledge_store,
+        scheduler=STATE.scheduler,
+        cache_warmer=STATE.cache_warmer,
+        goal_controller=STATE.goal_controller,
+        skills_index=STATE.skills_index,
+        mcp={
+            "enabled": bool(getattr(STATE.graph_config, "mcp_enabled", False)) if STATE.graph_config else False,
+            "servers": STATE.mcp_meta,
+            "tool_count": len(STATE.mcp_tools),
+        },
+        plugins=STATE.plugin_meta,
+    )
+
+
+def _operator_subagent_list():
+    return _operator_list_subagents(STATE.graph_config)
+
+
+async def _operator_subagent_run(req: dict):
+    if STATE.graph is None:
+        raise RuntimeError("agent graph is not loaded; finish setup first")
+    return await _operator_run_manual_subagent(
+        config=STATE.graph_config,
+        knowledge_store=STATE.knowledge_store,
+        scheduler=STATE.scheduler,
+        description=req.get("description", ""),
+        prompt=req.get("prompt", ""),
+        subagent_type=req.get("type") or req.get("subagent_type", "researcher"),
+        emit_skill=bool(req.get("emit_skill", False)),
+    )
+
+
+async def _operator_subagent_batch(req: dict):
+    if STATE.graph is None:
+        raise RuntimeError("agent graph is not loaded; finish setup first")
+    return await _operator_run_manual_subagent_batch(
+        config=STATE.graph_config,
+        knowledge_store=STATE.knowledge_store,
+        scheduler=STATE.scheduler,
+        tasks=req.get("tasks", []),
+    )
+
+
+async def _operator_scheduler_list() -> dict:
+    import asyncio
+    if STATE.scheduler is None:
+        return {"jobs": [], "backend": "disabled"}
+    jobs = await asyncio.to_thread(STATE.scheduler.list_jobs)
+    return {
+        "jobs": [j.as_dict() for j in jobs],
+        "backend": getattr(STATE.scheduler, "name", "local"),
+    }
+
+
+async def _operator_scheduler_add(req: dict) -> dict:
+    import asyncio
+    if STATE.scheduler is None:
+        raise RuntimeError("scheduler is not loaded (disabled or setup incomplete)")
+    prompt = (req.get("prompt") or "").strip()
+    schedule = (req.get("schedule") or "").strip()
+    if not prompt:
+        raise ValueError("prompt is required")
+    if not schedule:
+        raise ValueError("schedule is required")
+    job = await asyncio.to_thread(
+        STATE.scheduler.add_job, prompt, schedule, job_id=req.get("job_id") or None
+    )
+    return job.as_dict()
+
+
+async def _operator_scheduler_cancel(job_id: str) -> dict:
+    import asyncio
+    if STATE.scheduler is None:
+        raise RuntimeError("scheduler is not loaded (disabled or setup incomplete)")
+    canceled = await asyncio.to_thread(STATE.scheduler.cancel_job, job_id)
+    return {"canceled": bool(canceled)}
+
+
+async def _operator_goals_list() -> dict:
+    import asyncio
+    if STATE.goal_controller is None:
+        return {"goals": [], "enabled": False}
+    states = await asyncio.to_thread(STATE.goal_controller.store.all)
+    return {"goals": [s.to_dict() for s in states], "enabled": True}
+
+
+async def _operator_goals_clear(session_id: str) -> dict:
+    import asyncio
+    if STATE.goal_controller is None:
+        return {"cleared": False, "enabled": False}
+    cleared = await asyncio.to_thread(STATE.goal_controller.store.clear, session_id)
+    return {"cleared": bool(cleared)}
+
+
+def _operator_workflows_list() -> dict:
+    if STATE.workflow_registry is None:
+        return {"workflows": []}
+    return {"workflows": STATE.workflow_registry.list()}
+
+
+async def _operator_workflow_run(name: str, inputs: dict) -> dict:
+    if STATE.graph is None:
+        raise RuntimeError("agent graph is not loaded; finish setup first")
+    from graph.agent import run_manual_workflow
+    return await run_manual_workflow(
+        STATE.graph_config, STATE.workflow_registry,
+        knowledge_store=STATE.knowledge_store, scheduler=STATE.scheduler,
+        name=name, inputs=inputs or {},
+    )
+
+
+def _operator_workflow_save(recipe: dict) -> dict:
+    # Validate against the live subagent registry before writing, so a
+    # UI-authored recipe can't reference an unknown subagent / bad DAG.
+    if STATE.workflow_registry is None:
+        raise RuntimeError("workflows are not available")
+    from graph.subagents.config import SUBAGENT_REGISTRY
+    from graph.workflows.engine import validate_recipe
+    errors = validate_recipe(recipe, known_subagents=set(SUBAGENT_REGISTRY))
+    if errors:
+        raise ValueError("invalid recipe: " + "; ".join(errors))
+    path = STATE.workflow_registry.save(recipe)
+    return {"saved": True, "name": recipe.get("name"), "path": path}
+
+
+def _operator_workflow_delete(name: str) -> dict:
+    if STATE.workflow_registry is None:
+        raise RuntimeError("workflows are not available")
+    return {"deleted": STATE.workflow_registry.delete(name)}
+
+
+async def _operator_activity_list() -> dict:
+    """Return the Activity provenance feed (ADR 0022) — newest-first entries
+    with origin/trigger/priority — plus the thread's message history from the
+    checkpointer (for the continue view). The console renders the feed and
+    opens the thread on demand."""
+    entries = STATE.activity_log.recent(limit=100) if STATE.activity_log is not None else []
+    messages: list[dict] = []
+    if STATE.checkpointer is not None:
+        thread_id = f"a2a:{ACTIVITY_CONTEXT}"
+        try:
+            tup = await STATE.checkpointer.aget_tuple({"configurable": {"thread_id": thread_id}})
+            raw = (tup.checkpoint or {}).get("channel_values", {}).get("messages", []) if tup else []
+        except Exception:
+            log.exception("[activity] failed to read thread %s", thread_id)
+            raw = []
+        for m in raw:
+            role = getattr(m, "type", "")
+            content = getattr(m, "content", "")
+            if not isinstance(content, str):
+                content = str(content)
+            if role == "human":
+                messages.append({"role": "user", "content": content})
+            elif role == "ai":
+                visible = extract_output(content) or content
+                if visible.strip():
+                    messages.append({"role": "assistant", "content": visible})
+            # tool/system messages are omitted from the surface view
+    return {"context_id": ACTIVITY_CONTEXT, "entries": entries, "messages": messages}
+
+
+def _inbox_authorized(token: str | None) -> bool:
+    """Validate the inbound bearer token (ADR 0003). Mirrors the A2A posture:
+    when no token is configured the endpoint is open (dev), else it must match."""
+    active = ((STATE.graph_config.auth_token if STATE.graph_config else "") or os.environ.get("A2A_AUTH_TOKEN", "") or "").strip()
+    if not active:
+        return True
+    return (token or "") == active
+
+
+async def _fire_activity_from_inbox(item: dict) -> bool:
+    """Fire a now-priority inbox item as a turn into the Activity thread.
+    Self-POSTs to /a2a (parity with the scheduler), guarded against storms."""
+    import time
+    from uuid import uuid4
+    import httpx
+
+    if STATE.storm_guard is not None and not STATE.storm_guard.allow(time.monotonic()):
+        log.warning("[inbox] storm guard suppressed now-fire for item %s", item.get("id"))
+        return False
+    # A2A 1.0 (a2a-sdk ≥1.1): the version header + proto method name are
+    # mandatory — the 0.3 `message/send` 404s with -32601. Mirrors the
+    # scheduler's fire (scheduler/local.py).
+    headers = {"Content-Type": "application/json", "A2A-Version": "1.0"}
+    bearer = ((STATE.graph_config.auth_token if STATE.graph_config else "") or os.environ.get("A2A_AUTH_TOKEN", "")).strip()
+    if bearer:
+        headers["Authorization"] = f"Bearer {bearer}"
+    api_key = os.environ.get(f"{AGENT_NAME_ENV.upper()}_API_KEY", "").strip()
+    if api_key:
+        headers["X-API-Key"] = api_key
+    mid = str(uuid4())
+    body = {
+        "jsonrpc": "2.0", "id": mid, "method": "SendMessage",
+        "params": {
+            # contextId is a field of Message in 1.0 (params-level => -32602).
+            "message": {
+                "role": "ROLE_USER",
+                "parts": [{"text": item["text"]}],
+                "messageId": mid,
+                "contextId": ACTIVITY_CONTEXT,
+            },
+            "metadata": {"origin": "inbox", "inbox_id": item.get("id"), "inbox_source": item.get("source", ""), "priority": item.get("priority", "now")},
+        },
+    }
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            r = await client.post(f"http://127.0.0.1:{STATE.active_port}/a2a", headers=headers, json=body)
+        # A JSON-RPC error rides a 200, so status alone isn't enough.
+        if r.status_code >= 400:
+            return False
+        err = r.json().get("error") if r.headers.get("content-type", "").startswith("application/json") else None
+        if err:
+            log.warning("[inbox] now-fire rejected for item %s: %s", item.get("id"), err)
+            return False
+        return True
+    except Exception:
+        log.exception("[inbox] now-fire failed for item %s", item.get("id"))
+        return False
+
+
+async def _operator_inbox_add(payload: dict) -> dict:
+    """Ingest an inbound item (ADR 0003). now-priority fires an Activity turn;
+    others queue for check_inbox. Dedup is handled by the store."""
+    if STATE.inbox_store is None:
+        raise RuntimeError("inbox not loaded; finish setup first")
+    item = STATE.inbox_store.add(
+        payload.get("text", ""),
+        priority=payload.get("priority", "next") or "next",
+        source=payload.get("source", "") or "",
+        dedup_key=payload.get("dedup_key", "") or "",
+    )
+    if item is None:
+        return {"ok": True, "deduped": True}
+    _event_bus.publish("inbox.item", {
+        "id": item["id"], "priority": item["priority"],
+        "source": item.get("source") or "", "text": item["text"],
+    })
+    fired = await _fire_activity_from_inbox(item) if item["priority"] == "now" else False
+    return {"ok": True, "item": item, "fired": fired}
+
+
+async def _operator_inbox_list(floor: str, include_delivered: bool) -> dict:
+    if STATE.inbox_store is None:
+        return {"items": []}
+    items = STATE.inbox_store.list(
+        priority_floor=floor or "later", include_delivered=include_delivered, limit=200,
+    )
+    return {"items": items}
+
+
+async def _operator_inbox_deliver(item_id: int) -> dict:
+    if STATE.inbox_store is None:
+        raise RuntimeError("inbox not loaded; finish setup first")
+    return {"ok": True, "delivered": STATE.inbox_store.mark_delivered([item_id])}
+
+
+def _operator_chat_commands() -> dict:
+    """Slash commands the chat understands — drives the composer autocomplete.
+
+    Currently just `/goal` (when goal mode is loaded). Register a new
+    server-handled control command here and the console picks it up.
+    """
+    commands = []
+    if STATE.goal_controller is not None:
+        commands.append({
+            "name": "goal",
+            "description": "Set, check, or clear a self-driving goal for this chat session.",
+            "usage": "/goal <condition>   ·   /goal  (status)   ·   /goal clear",
+        })
+    # Each registered workflow is runnable as /<name> (ADR 0002).
+    wf_names: set[str] = set()
+    if STATE.workflow_registry is not None:
+        for wf in STATE.workflow_registry.list():
+            wf_names.add(wf["name"])
+            declared = wf.get("inputs", []) or []
+            req = "".join(f" <{i['name']}>" for i in declared if i.get("required"))
+            opt = "".join(f" [{i['name']}]" for i in declared if not i.get("required"))
+            commands.append({
+                "name": wf["name"],
+                "description": wf.get("description") or f"Run the {wf['name']} workflow.",
+                "usage": f"/{wf['name']}{req}{opt}",
+            })
+    # Each registered subagent is runnable as /<name> <prompt> (ADR 0020),
+    # unless a workflow already claims the name (workflow wins in dispatch).
+    try:
+        from graph.subagents.config import SUBAGENT_REGISTRY
+    except Exception:
+        SUBAGENT_REGISTRY = {}
+    for name, cfg in SUBAGENT_REGISTRY.items():
+        if name in wf_names:
+            continue
+        commands.append({
+            "name": name,
+            "description": getattr(cfg, "description", "") or f"Run the {name} subagent.",
+            "usage": f"/{name} <prompt>",
+        })
+    return {"commands": commands}

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -395,315 +395,15 @@ def _main():
     )
 
     # --- React operator-console API ----------------------------------------
-    from graph.config_io import is_setup_complete as _operator_setup_complete
+    # Console handler bodies live in operator_api/console_handlers.py (ADR 0023
+    # phase 3); imported here as `_console` and wired into register_operator_routes
+    # below. The register_*_routes registrars mount the rest of the console API.
+    from operator_api import console_handlers as _console
     from operator_api.chat_routes import register_chat_routes
     from operator_api.config_routes import register_config_routes
     from operator_api.knowledge_routes import register_knowledge_routes
     from operator_api.routes import register_operator_routes
-    from operator_api.runtime import build_runtime_status as _build_operator_status
     from operator_api.telemetry_routes import register_telemetry_routes
-    from operator_api.subagents import (
-        list_subagents as _operator_list_subagents,
-        run_manual_subagent as _operator_run_manual_subagent,
-        run_manual_subagent_batch as _operator_run_manual_subagent_batch,
-    )
-
-    _operator_repo_root = _resolve_operator_project_root()
-
-    def _operator_allowed_dirs() -> list[str]:
-        # The repo root is always operable (it's the default project);
-        # config adds any extra project roots. Read live so a settings
-        # reload takes effect without restarting the server.
-        roots = [_operator_repo_root]
-        if STATE.graph_config is not None:
-            roots.extend(getattr(STATE.graph_config, "operator_allowed_dirs", []) or [])
-        return roots
-
-    def _operator_runtime_status():
-        return _build_operator_status(
-            config=STATE.graph_config,
-            setup_complete=_operator_setup_complete(),
-            graph_loaded=STATE.graph is not None,
-            project_path=_operator_repo_root,
-            allowed_dirs=_operator_allowed_dirs(),
-            knowledge_store=STATE.knowledge_store,
-            scheduler=STATE.scheduler,
-            cache_warmer=STATE.cache_warmer,
-            goal_controller=STATE.goal_controller,
-            skills_index=STATE.skills_index,
-            mcp={
-                "enabled": bool(getattr(STATE.graph_config, "mcp_enabled", False)) if STATE.graph_config else False,
-                "servers": STATE.mcp_meta,
-                "tool_count": len(STATE.mcp_tools),
-            },
-            plugins=STATE.plugin_meta,
-        )
-
-    def _operator_subagent_list():
-        return _operator_list_subagents(STATE.graph_config)
-
-    async def _operator_subagent_run(req: dict):
-        if STATE.graph is None:
-            raise RuntimeError("agent graph is not loaded; finish setup first")
-        return await _operator_run_manual_subagent(
-            config=STATE.graph_config,
-            knowledge_store=STATE.knowledge_store,
-            scheduler=STATE.scheduler,
-            description=req.get("description", ""),
-            prompt=req.get("prompt", ""),
-            subagent_type=req.get("type") or req.get("subagent_type", "researcher"),
-            emit_skill=bool(req.get("emit_skill", False)),
-        )
-
-    async def _operator_subagent_batch(req: dict):
-        if STATE.graph is None:
-            raise RuntimeError("agent graph is not loaded; finish setup first")
-        return await _operator_run_manual_subagent_batch(
-            config=STATE.graph_config,
-            knowledge_store=STATE.knowledge_store,
-            scheduler=STATE.scheduler,
-            tasks=req.get("tasks", []),
-        )
-
-    async def _operator_scheduler_list() -> dict:
-        import asyncio
-        if STATE.scheduler is None:
-            return {"jobs": [], "backend": "disabled"}
-        jobs = await asyncio.to_thread(STATE.scheduler.list_jobs)
-        return {
-            "jobs": [j.as_dict() for j in jobs],
-            "backend": getattr(STATE.scheduler, "name", "local"),
-        }
-
-    async def _operator_scheduler_add(req: dict) -> dict:
-        import asyncio
-        if STATE.scheduler is None:
-            raise RuntimeError("scheduler is not loaded (disabled or setup incomplete)")
-        prompt = (req.get("prompt") or "").strip()
-        schedule = (req.get("schedule") or "").strip()
-        if not prompt:
-            raise ValueError("prompt is required")
-        if not schedule:
-            raise ValueError("schedule is required")
-        job = await asyncio.to_thread(
-            STATE.scheduler.add_job, prompt, schedule, job_id=req.get("job_id") or None
-        )
-        return job.as_dict()
-
-    async def _operator_scheduler_cancel(job_id: str) -> dict:
-        import asyncio
-        if STATE.scheduler is None:
-            raise RuntimeError("scheduler is not loaded (disabled or setup incomplete)")
-        canceled = await asyncio.to_thread(STATE.scheduler.cancel_job, job_id)
-        return {"canceled": bool(canceled)}
-
-    async def _operator_goals_list() -> dict:
-        import asyncio
-        if STATE.goal_controller is None:
-            return {"goals": [], "enabled": False}
-        states = await asyncio.to_thread(STATE.goal_controller.store.all)
-        return {"goals": [s.to_dict() for s in states], "enabled": True}
-
-    async def _operator_goals_clear(session_id: str) -> dict:
-        import asyncio
-        if STATE.goal_controller is None:
-            return {"cleared": False, "enabled": False}
-        cleared = await asyncio.to_thread(STATE.goal_controller.store.clear, session_id)
-        return {"cleared": bool(cleared)}
-
-    def _operator_workflows_list() -> dict:
-        if STATE.workflow_registry is None:
-            return {"workflows": []}
-        return {"workflows": STATE.workflow_registry.list()}
-
-    async def _operator_workflow_run(name: str, inputs: dict) -> dict:
-        if STATE.graph is None:
-            raise RuntimeError("agent graph is not loaded; finish setup first")
-        from graph.agent import run_manual_workflow
-        return await run_manual_workflow(
-            STATE.graph_config, STATE.workflow_registry,
-            knowledge_store=STATE.knowledge_store, scheduler=STATE.scheduler,
-            name=name, inputs=inputs or {},
-        )
-
-    def _operator_workflow_save(recipe: dict) -> dict:
-        # Validate against the live subagent registry before writing, so a
-        # UI-authored recipe can't reference an unknown subagent / bad DAG.
-        if STATE.workflow_registry is None:
-            raise RuntimeError("workflows are not available")
-        from graph.subagents.config import SUBAGENT_REGISTRY
-        from graph.workflows.engine import validate_recipe
-        errors = validate_recipe(recipe, known_subagents=set(SUBAGENT_REGISTRY))
-        if errors:
-            raise ValueError("invalid recipe: " + "; ".join(errors))
-        path = STATE.workflow_registry.save(recipe)
-        return {"saved": True, "name": recipe.get("name"), "path": path}
-
-    def _operator_workflow_delete(name: str) -> dict:
-        if STATE.workflow_registry is None:
-            raise RuntimeError("workflows are not available")
-        return {"deleted": STATE.workflow_registry.delete(name)}
-
-    async def _operator_activity_list() -> dict:
-        """Return the Activity provenance feed (ADR 0022) — newest-first entries
-        with origin/trigger/priority — plus the thread's message history from the
-        checkpointer (for the continue view). The console renders the feed and
-        opens the thread on demand."""
-        entries = STATE.activity_log.recent(limit=100) if STATE.activity_log is not None else []
-        messages: list[dict] = []
-        if STATE.checkpointer is not None:
-            thread_id = f"a2a:{ACTIVITY_CONTEXT}"
-            try:
-                tup = await STATE.checkpointer.aget_tuple({"configurable": {"thread_id": thread_id}})
-                raw = (tup.checkpoint or {}).get("channel_values", {}).get("messages", []) if tup else []
-            except Exception:
-                log.exception("[activity] failed to read thread %s", thread_id)
-                raw = []
-            for m in raw:
-                role = getattr(m, "type", "")
-                content = getattr(m, "content", "")
-                if not isinstance(content, str):
-                    content = str(content)
-                if role == "human":
-                    messages.append({"role": "user", "content": content})
-                elif role == "ai":
-                    visible = extract_output(content) or content
-                    if visible.strip():
-                        messages.append({"role": "assistant", "content": visible})
-                # tool/system messages are omitted from the surface view
-        return {"context_id": ACTIVITY_CONTEXT, "entries": entries, "messages": messages}
-
-    def _inbox_authorized(token: str | None) -> bool:
-        """Validate the inbound bearer token (ADR 0003). Mirrors the A2A posture:
-        when no token is configured the endpoint is open (dev), else it must match."""
-        active = ((STATE.graph_config.auth_token if STATE.graph_config else "") or os.environ.get("A2A_AUTH_TOKEN", "") or "").strip()
-        if not active:
-            return True
-        return (token or "") == active
-
-    async def _fire_activity_from_inbox(item: dict) -> bool:
-        """Fire a now-priority inbox item as a turn into the Activity thread.
-        Self-POSTs to /a2a (parity with the scheduler), guarded against storms."""
-        import time
-        from uuid import uuid4
-        import httpx
-
-        if STATE.storm_guard is not None and not STATE.storm_guard.allow(time.monotonic()):
-            log.warning("[inbox] storm guard suppressed now-fire for item %s", item.get("id"))
-            return False
-        # A2A 1.0 (a2a-sdk ≥1.1): the version header + proto method name are
-        # mandatory — the 0.3 `message/send` 404s with -32601. Mirrors the
-        # scheduler's fire (scheduler/local.py).
-        headers = {"Content-Type": "application/json", "A2A-Version": "1.0"}
-        bearer = ((STATE.graph_config.auth_token if STATE.graph_config else "") or os.environ.get("A2A_AUTH_TOKEN", "")).strip()
-        if bearer:
-            headers["Authorization"] = f"Bearer {bearer}"
-        api_key = os.environ.get(f"{AGENT_NAME_ENV.upper()}_API_KEY", "").strip()
-        if api_key:
-            headers["X-API-Key"] = api_key
-        mid = str(uuid4())
-        body = {
-            "jsonrpc": "2.0", "id": mid, "method": "SendMessage",
-            "params": {
-                # contextId is a field of Message in 1.0 (params-level => -32602).
-                "message": {
-                    "role": "ROLE_USER",
-                    "parts": [{"text": item["text"]}],
-                    "messageId": mid,
-                    "contextId": ACTIVITY_CONTEXT,
-                },
-                "metadata": {"origin": "inbox", "inbox_id": item.get("id"), "inbox_source": item.get("source", ""), "priority": item.get("priority", "now")},
-            },
-        }
-        try:
-            async with httpx.AsyncClient(timeout=30) as client:
-                r = await client.post(f"http://127.0.0.1:{STATE.active_port}/a2a", headers=headers, json=body)
-            # A JSON-RPC error rides a 200, so status alone isn't enough.
-            if r.status_code >= 400:
-                return False
-            err = r.json().get("error") if r.headers.get("content-type", "").startswith("application/json") else None
-            if err:
-                log.warning("[inbox] now-fire rejected for item %s: %s", item.get("id"), err)
-                return False
-            return True
-        except Exception:
-            log.exception("[inbox] now-fire failed for item %s", item.get("id"))
-            return False
-
-    async def _operator_inbox_add(payload: dict) -> dict:
-        """Ingest an inbound item (ADR 0003). now-priority fires an Activity turn;
-        others queue for check_inbox. Dedup is handled by the store."""
-        if STATE.inbox_store is None:
-            raise RuntimeError("inbox not loaded; finish setup first")
-        item = STATE.inbox_store.add(
-            payload.get("text", ""),
-            priority=payload.get("priority", "next") or "next",
-            source=payload.get("source", "") or "",
-            dedup_key=payload.get("dedup_key", "") or "",
-        )
-        if item is None:
-            return {"ok": True, "deduped": True}
-        _event_bus.publish("inbox.item", {
-            "id": item["id"], "priority": item["priority"],
-            "source": item.get("source") or "", "text": item["text"],
-        })
-        fired = await _fire_activity_from_inbox(item) if item["priority"] == "now" else False
-        return {"ok": True, "item": item, "fired": fired}
-
-    async def _operator_inbox_list(floor: str, include_delivered: bool) -> dict:
-        if STATE.inbox_store is None:
-            return {"items": []}
-        items = STATE.inbox_store.list(
-            priority_floor=floor or "later", include_delivered=include_delivered, limit=200,
-        )
-        return {"items": items}
-
-    async def _operator_inbox_deliver(item_id: int) -> dict:
-        if STATE.inbox_store is None:
-            raise RuntimeError("inbox not loaded; finish setup first")
-        return {"ok": True, "delivered": STATE.inbox_store.mark_delivered([item_id])}
-
-    def _operator_chat_commands() -> dict:
-        """Slash commands the chat understands — drives the composer autocomplete.
-
-        Currently just `/goal` (when goal mode is loaded). Register a new
-        server-handled control command here and the console picks it up.
-        """
-        commands = []
-        if STATE.goal_controller is not None:
-            commands.append({
-                "name": "goal",
-                "description": "Set, check, or clear a self-driving goal for this chat session.",
-                "usage": "/goal <condition>   ·   /goal  (status)   ·   /goal clear",
-            })
-        # Each registered workflow is runnable as /<name> (ADR 0002).
-        wf_names: set[str] = set()
-        if STATE.workflow_registry is not None:
-            for wf in STATE.workflow_registry.list():
-                wf_names.add(wf["name"])
-                declared = wf.get("inputs", []) or []
-                req = "".join(f" <{i['name']}>" for i in declared if i.get("required"))
-                opt = "".join(f" [{i['name']}]" for i in declared if not i.get("required"))
-                commands.append({
-                    "name": wf["name"],
-                    "description": wf.get("description") or f"Run the {wf['name']} workflow.",
-                    "usage": f"/{wf['name']}{req}{opt}",
-                })
-        # Each registered subagent is runnable as /<name> <prompt> (ADR 0020),
-        # unless a workflow already claims the name (workflow wins in dispatch).
-        try:
-            from graph.subagents.config import SUBAGENT_REGISTRY
-        except Exception:
-            SUBAGENT_REGISTRY = {}
-        for name, cfg in SUBAGENT_REGISTRY.items():
-            if name in wf_names:
-                continue
-            commands.append({
-                "name": name,
-                "description": getattr(cfg, "description", "") or f"Run the {name} subagent.",
-                "usage": f"/{name} <prompt>",
-            })
-        return {"commands": commands}
 
     # The in-process beads store is agent-global + graph-independent, but it's
     # otherwise created in _init_langgraph_agent (which only runs once setup is
@@ -715,30 +415,32 @@ def _main():
         from beads import BeadsStore
         STATE.beads_store = BeadsStore()
 
+    # Console handler bodies live in operator_api/console_handlers.py (ADR 0023
+    # phase 3); _main just wires them to their routes.
     register_operator_routes(
         fastapi_app,
-        runtime_status=_operator_runtime_status,
-        subagent_list=_operator_subagent_list,
-        subagent_run=_operator_subagent_run,
-        subagent_batch=_operator_subagent_batch,
+        runtime_status=_console._operator_runtime_status,
+        subagent_list=_console._operator_subagent_list,
+        subagent_run=_console._operator_subagent_run,
+        subagent_batch=_console._operator_subagent_batch,
         beads_store=STATE.beads_store,
-        allowed_dirs=_operator_allowed_dirs,
-        scheduler_list=_operator_scheduler_list,
-        scheduler_add=_operator_scheduler_add,
-        scheduler_cancel=_operator_scheduler_cancel,
-        goal_list=_operator_goals_list,
-        goal_clear=_operator_goals_clear,
-        chat_commands=_operator_chat_commands,
-        workflows_list=_operator_workflows_list,
-        workflows_run=_operator_workflow_run,
-        workflows_save=_operator_workflow_save,
-        workflows_delete=_operator_workflow_delete,
+        allowed_dirs=_console._operator_allowed_dirs,
+        scheduler_list=_console._operator_scheduler_list,
+        scheduler_add=_console._operator_scheduler_add,
+        scheduler_cancel=_console._operator_scheduler_cancel,
+        goal_list=_console._operator_goals_list,
+        goal_clear=_console._operator_goals_clear,
+        chat_commands=_console._operator_chat_commands,
+        workflows_list=_console._operator_workflows_list,
+        workflows_run=_console._operator_workflow_run,
+        workflows_save=_console._operator_workflow_save,
+        workflows_delete=_console._operator_workflow_delete,
         events_subscribe=_event_bus.subscribe,
-        activity_list=_operator_activity_list,
-        inbox_add=_operator_inbox_add,
-        inbox_authorized=_inbox_authorized,
-        inbox_list=_operator_inbox_list,
-        inbox_deliver=_operator_inbox_deliver,
+        activity_list=_console._operator_activity_list,
+        inbox_add=_console._operator_inbox_add,
+        inbox_authorized=_console._inbox_authorized,
+        inbox_list=_console._operator_inbox_list,
+        inbox_deliver=_console._operator_inbox_deliver,
     )
 
     # Wire the plugin host (agent invoke + event bus) before any surface starts.

--- a/tests/test_console_handlers.py
+++ b/tests/test_console_handlers.py
@@ -1,0 +1,69 @@
+"""Operator console handlers (ADR 0023 phase 3) — the bodies behind
+register_operator_routes, extracted from _main into operator_api/console_handlers.py.
+These exercise the STATE-driven degradation paths directly (no app needed)."""
+
+import pytest
+
+from operator_api import console_handlers as ch
+
+
+@pytest.fixture(autouse=True)
+def _reset_state(monkeypatch):
+    import runtime.state as rs
+
+    for field in ("graph_config", "graph", "scheduler", "goal_controller",
+                  "workflow_registry", "inbox_store", "storm_guard"):
+        monkeypatch.setattr(rs.STATE, field, None, raising=False)
+    yield
+
+
+def test_inbox_authorized_open_when_no_token():
+    assert ch._inbox_authorized(None) is True
+    assert ch._inbox_authorized("anything") is True
+
+
+def test_inbox_authorized_requires_match(monkeypatch):
+    import runtime.state as rs
+
+    class _Cfg:
+        auth_token = "secret"
+    monkeypatch.setattr(rs.STATE, "graph_config", _Cfg(), raising=False)
+    assert ch._inbox_authorized("secret") is True
+    assert ch._inbox_authorized("nope") is False
+    assert ch._inbox_authorized(None) is False
+
+
+def test_workflows_list_empty_when_registry_off():
+    assert ch._operator_workflows_list() == {"workflows": []}
+
+
+def test_workflow_save_rejects_without_registry():
+    with pytest.raises(RuntimeError):
+        ch._operator_workflow_save({"name": "x"})
+
+
+async def test_scheduler_list_disabled():
+    assert await ch._operator_scheduler_list() == {"jobs": [], "backend": "disabled"}
+
+
+async def test_goals_list_disabled():
+    assert await ch._operator_goals_list() == {"goals": [], "enabled": False}
+
+
+async def test_inbox_add_requires_store():
+    with pytest.raises(RuntimeError):
+        await ch._operator_inbox_add({"text": "hi"})
+
+
+def test_chat_commands_lists_workflows_and_subagents(monkeypatch):
+    import runtime.state as rs
+
+    class _Reg:
+        def list(self):
+            return [{"name": "deep-research", "description": "d", "inputs": [{"name": "topic", "required": True}]}]
+    monkeypatch.setattr(rs.STATE, "workflow_registry", _Reg(), raising=False)
+    out = ch._operator_chat_commands()
+    names = [c["name"] for c in out["commands"]]
+    assert "deep-research" in names
+    dr = next(c for c in out["commands"] if c["name"] == "deep-research")
+    assert dr["usage"] == "/deep-research <topic>"


### PR DESCRIPTION
## What

Final ADR 0023 phase 3 PR — finishes the half-done `operator_api/` extraction the ADR called out. The 21 React-console handler bodies (runtime-status, subagent, scheduler, goal, workflow, activity, inbox, chat-commands) were inline closures in `_main` that closed over the once-ambient globals. They move into **`operator_api/console_handlers.py`** as module-level functions; `_main` passes them to `register_operator_routes` instead of defining 21 closures.

Bodies are **byte-identical** — dependencies are imported under the same alias names the closures used (`_build_operator_status`, `_operator_setup_complete`, `_operator_list_subagents`, …), and the one captured local (the operator project root) resolves live via `server._resolve_operator_project_root()`.

## Result: composition root reached

`server/__init__.py` drops ~300 lines. **`_main` is now ~430 lines of pure app assembly; the whole file is ~700 (from the original `server.py`'s 3,353).** That's ADR 0023's target end state — phase 3 complete, the ADR is fully shipped.

## Tests

Adds `tests/test_console_handlers.py` (inbox-auth open vs. match, store-off degradation paths, chat-command listing). `register_operator_routes` and its existing tests are untouched (they pass their own callbacks).

## Verification

- **1025 tests green.**
- **Live smoke** (`python -m server`): `/api/runtime/status` (setup+graph loaded), `/api/workflows` (2), `/api/chat/commands` (8: goal + 2 workflows + 5 subagents), `/api/activity`, and `POST /api/inbox` priority=now → **`fired: true`** (the full `_fire_activity_from_inbox` → self-POST `/a2a` → activity turn).

Completes #554/#555/#556/#557.

🤖 Generated with [Claude Code](https://claude.com/claude-code)