### PR TITLE
fix(console): display-case the agent name in title/brand (gina → Gina)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -37,6 +37,7 @@ import { SettingsSurface } from "../settings/SettingsSurface";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
+import { brandName } from "../lib/brand";
 import { onConnectionChange, onServerEvent } from "../lib/events";
 import type { NotesWorkspace } from "../lib/types";
 import { StatusPill } from "./StatusPill";
@@ -135,9 +136,9 @@ export function App() {
   const runtime = runtimeQ.data ?? null;
   // White-label the window/tab title to the configured identity (default
   // protoAgent), so a fork's title follows its name without a rebuild.
+  // brandName() display-cases a bare lower-case slug (e.g. `gina` → `Gina`).
   useEffect(() => {
-    const name = runtime?.identity?.name;
-    if (name) document.title = name;
+    document.title = brandName(runtime?.identity?.name);
   }, [runtime]);
   // BootGate gating: show the app once the engine is ready (graph compiled) OR
   // the setup wizard is due (no graph expected pre-setup). `bootOverride` is the
@@ -472,7 +473,7 @@ export function App() {
       <BootGate
         ready={bootReady}
         failed={!runtime && runtimeQ.isError}
-        name={runtime?.identity?.name || "protoAgent"}
+        name={brandName(runtime?.identity?.name)}
         onRetry={() => void runtimeQ.refetch()}
         onContinue={() => setBootOverride(true)}
       />
@@ -488,7 +489,7 @@ export function App() {
             {/* White-label: the brand name follows the configured identity
                 (Settings → Identity), defaulting to protoAgent for the template.
                 A fork sets its name once and the whole UI follows. */}
-            <div className="brand-name">{runtime?.identity?.name || "protoAgent"}</div>
+            <div className="brand-name">{brandName(runtime?.identity?.name)}</div>
             <div className="brand-subline">protoLabs.studio</div>
           </div>
         </div>

--- a/apps/web/src/app/RuntimePanel.tsx
+++ b/apps/web/src/app/RuntimePanel.tsx
@@ -2,6 +2,7 @@ import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query
 import { Bot, Database, Settings2, Sparkles } from "lucide-react";
 import { Suspense, type ReactNode } from "react";
 
+import { brandName } from "../lib/brand";
 import { runtimeStatusQuery, subagentsQuery } from "../lib/queries";
 import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
 import { StatusPill } from "./StatusPill";
@@ -41,7 +42,7 @@ function RuntimeBody() {
       </div>
       <div className="stage-body">
         <div className="metric-grid">
-          <Metric icon={<Bot size={16} />} label="Agent" value={runtime.identity?.name || "protoagent"} />
+          <Metric icon={<Bot size={16} />} label="Agent" value={brandName(runtime.identity?.name)} />
           <Metric icon={<Settings2 size={16} />} label="Provider" value={runtime.model?.provider || "none"} />
           <Metric icon={<Database size={16} />} label="Knowledge" value={runtime.knowledge.resolved_path || runtime.knowledge.configured_path || "disabled"} />
           <Metric icon={<Sparkles size={16} />} label="Goal mode" value={formatBool(Boolean(runtime.goal.enabled))} />

--- a/apps/web/src/lib/brand.ts
+++ b/apps/web/src/lib/brand.ts
@@ -1,0 +1,20 @@
+/**
+ * Display-casing for the agent's name.
+ *
+ * The backend treats the agent name as a slug — metrics lower-case + sanitize
+ * it, the API-key env upper-cases it, data paths key off PROTOAGENT_INSTANCE —
+ * so a fork commonly configures a lower-case identity (`gina`, `roxy`, `quinn`).
+ * That slug looks wrong as a UI brand / browser-tab title. `brandName` renders
+ * it for display: the protoAgent default keeps its camelCase brand, an
+ * intentionally-cased name is respected as-is, and a bare lower-case slug gets a
+ * capitalized first letter (`gina` → `Gina`). One helper, used everywhere the
+ * name is shown (tab title, topbar, boot gate, runtime panel).
+ */
+export function brandName(name?: string | null): string {
+  const n = (name ?? "").trim();
+  if (!n || n.toLowerCase() === "protoagent") return "protoAgent";
+  // Already carries intentional casing (any upper-case char) — respect it.
+  if (n !== n.toLowerCase()) return n;
+  // Bare lower-case slug → capitalize the first letter for display.
+  return n.charAt(0).toUpperCase() + n.slice(1);
+}


### PR DESCRIPTION
## What

The React console rendered the agent name **slug** verbatim — so a fork with a lower-case identity (`gina`, `roxy`, `quinn`) showed `gina` in the browser-tab title, topbar brand, boot-gate, and RuntimePanel "Agent", instead of `Gina`.

The name is a slug on purpose (metrics lower-case + sanitize it, the API-key env upper-cases it, data paths key off `PROTOAGENT_INSTANCE`), so fixing it for display — not changing the slug — is the right move.

## How

New `brandName()` helper (`apps/web/src/lib/brand.ts`):
- `protoagent` / blank → `protoAgent` (keeps the template's camelCase brand)
- intentionally-cased name (`Gina`, `protoAgent`) → respected as-is
- bare lower-case slug (`gina`) → capitalized first letter → `Gina`

Wired into the tab title, topbar brand, `BootGate`, and `RuntimePanel`. Frontend-only; the backend slug is untouched.

## Verification

`npm run build` (tsc typecheck + vite) clean. Found while spinning up gina (tab read "gina"); this is the template fix so every fork gets it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)