### PR TITLE
fix(console): parse CRLF-delimited SSE frames (browser chat was blank)

### DIFF
--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -144,7 +144,10 @@ async function handleA2AStream(req, res, body) {
     connection: "keep-alive",
   });
   for (const frame of frames) {
-    res.write(`data: ${JSON.stringify(frame)}\n\n`);
+    // CRLF frame separator — the a2a-sdk emits SSE with `\r\n\r\n`, not `\n\n`.
+    // The mock must mirror that so this e2e exercises the real wire shape: an
+    // LF-only mock hid a browser-blanking CRLF parse bug in the client.
+    res.write(`data: ${JSON.stringify(frame)}\r\n\r\n`);
     // Small gap so the "working/tool" frames are observably distinct from the
     // terminal artifact (mirrors real tool latency; lets running→done show).
     await new Promise((r) => setTimeout(r, 40));

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -209,18 +209,27 @@ function textFromTerminalTask(result: NonNullable<A2AFrame["result"]>) {
     .join("");
 }
 
-// Parse complete SSE events (`\n\n`-delimited) out of a buffer, dispatching each
-// frame. Returns the unconsumed remainder. Shared by the streaming + buffered
-// paths so both decode frames identically.
+// Parse complete SSE events (blank-line-delimited) out of a buffer, dispatching
+// each frame. Returns the unconsumed remainder. Shared by the streaming +
+// buffered paths so both decode frames identically.
+//
+// The event boundary is a blank line whose line ending VARIES: the a2a-sdk
+// emits CRLF (`\r\n\r\n`); the SSE spec also allows LF (`\n\n`) or CR (`\r\r`).
+// Scanning for `\n\n` only — which we used to do — never matched the CRLF
+// stream, so the browser parsed zero frames and chat rendered a blank bubble
+// (the agent had replied). Match any blank-line boundary, and split data lines
+// on any line ending. The regex matches on the raw buffer (not a normalized
+// copy), so a boundary split across two fetch chunks still reassembles correctly.
 function drainSseBuffer(buffer: string, onFrame: (frame: A2AFrame) => void): string {
-  let boundary = buffer.indexOf("\n\n");
-  while (boundary !== -1) {
-    const rawEvent = buffer.slice(0, boundary);
-    buffer = buffer.slice(boundary + 2);
-    boundary = buffer.indexOf("\n\n");
+  const BOUNDARY = /\r\n\r\n|\n\n|\r\r/;
+  let match = BOUNDARY.exec(buffer);
+  while (match) {
+    const rawEvent = buffer.slice(0, match.index);
+    buffer = buffer.slice(match.index + match[0].length);
+    match = BOUNDARY.exec(buffer);
 
     const data = rawEvent
-      .split("\n")
+      .split(/\r\n|\r|\n/)
       .filter((line) => line.startsWith("data:"))
       .map((line) => line.slice(5).trim())
       .join("\n");


### PR DESCRIPTION
## The bug

Browser chat rendered a **blank assistant bubble** even though the agent replied. The console streams a turn over `/a2a` `SendStreamingMessage` and hand-parses the `text/event-stream` body (fetch + reader — `EventSource` can't POST custom headers). The **a2a-sdk separates SSE events with CRLF (`\r\n\r\n`)**, but `drainSseBuffer` scanned for `\n\n` (LF) only. `\r\n\r\n` contains no `\n\n` substring → **no frame boundary ever found → zero frames parsed → blank bubble**.

Browser-only: the desktop (WKWebView) path takes the non-streaming `/api/chat` fallback, which sidesteps SSE parsing — so it was masked where most testing happened.

## Fix

- Match any blank-line boundary (`\r\n\r\n` | `\n\n` | `\r\r`) and split data lines on any line ending. The regex runs on the raw buffer, so a boundary split across two fetch chunks still reassembles.
- **Harden the e2e mock**: it emitted LF-only SSE (which is *why CI was green*). Now it emits CRLF to mirror the real a2a-sdk, so the web E2E smoke exercises the real wire shape and guards the regression.

## Verification

Against a **live a2a-sdk stream**: old splitter → `0 frames (BLANK CHAT)`; new splitter → `4 frames, full text rendered`. `/api/events` is unaffected (native `EventSource`, spec-compliant).

Found while testing a fork's console chat (blank replies). Frontend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)