### PR TITLE
chore: release v0.15.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.15.1] - 2026-06-05
+
 ### Fixed
 - **Browser chat rendered blank** (console). The chat turn streams over `/a2a`
   `SendStreamingMessage` and the client hand-parses the SSE body, but

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.15.0"
+version = "0.15.1"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 


### PR DESCRIPTION
Automated version bump to `v0.15.1`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.15.1 -m 'Release v0.15.1' && git push origin v0.15.1`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).