### PR TITLE
fix(console): map tool-call wire fields so all tools render (not just one)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -280,6 +280,19 @@ export function buildFrames({ rpcId, contextId, taskId, prompt }) {
   const wrap = (result) => ({ jsonrpc: "2.0", id: rpcId, result });
 
   // A status-update frame carrying optional text + a tool-call DataPart.
+  // Emit the REAL a2a-sdk tool-call-v1 wire payload, not the frontend ToolEvent
+  // shape. The backend sends `{toolCallId, name, phase: "started"|"completed",
+  // args, result}`; the fixtures author events in the readable frontend shape
+  // (`{id, phase: "start"|"end", input, output}`), so map here. (An LF-style gap
+  // — fixtures in the frontend shape — is exactly what hid the client's field-
+  // mapping bug from CI; the mock must mirror the wire shape so the e2e guards it.)
+  const toWire = (ev) => ({
+    toolCallId: ev.id,
+    name: ev.name,
+    phase: ev.phase === "start" ? "started" : "completed",
+    args: ev.input,
+    result: ev.output,
+  });
   const statusFrame = (text, toolEvent) =>
     wrap({
       kind: "status-update",
@@ -291,7 +304,7 @@ export function buildFrames({ rpcId, contextId, taskId, prompt }) {
           role: "agent",
           parts: [
             { kind: "text", text },
-            ...(toolEvent ? [{ kind: "data", data: toolEvent, metadata: { mimeType: TOOL_CALL_MIME } }] : []),
+            ...(toolEvent ? [{ kind: "data", data: toWire(toolEvent), metadata: { mimeType: TOOL_CALL_MIME } }] : []),
           ],
         },
       },

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -191,9 +191,28 @@ function dataByMime(parts: RawPart[] | undefined, mime: string): unknown {
   return part.data ?? null;
 }
 
-/** Pull a structured tool event ({id, name, phase, input|output}) off a frame's parts. */
+/** Pull a structured tool event off a frame's parts and map the A2A 1.0 wire
+ * payload (`{toolCallId, name, phase: "started"|"completed", args, result}`)
+ * onto the frontend `ToolEvent` (`{id, name, phase: "start"|"end", input,
+ * output}`).
+ *
+ * The field rename is load-bearing: casting the raw payload straight to
+ * `ToolEvent` left `id`/`input`/`output` undefined and `phase` never `"start"`.
+ * With `id` undefined, `onToolCall`'s `findIndex(c => c.id === evt.id)` matched
+ * the FIRST card on every event, so all of a turn's tool calls collapsed into a
+ * single ever-overwriting card — the "only one tool at a time" symptom. */
 function toolEventFromParts(parts?: RawPart[]): ToolEvent | null {
-  return (dataByMime(parts, TOOL_CALL_MIME) as ToolEvent) || null;
+  const d = dataByMime(parts, TOOL_CALL_MIME) as
+    | { toolCallId?: string; name?: string; phase?: string; args?: string; result?: string }
+    | null;
+  if (!d) return null;
+  return {
+    id: d.toolCallId || "",
+    name: d.name || "",
+    phase: d.phase === "started" ? "start" : "end",
+    input: d.args,
+    output: d.result,
+  };
 }
 
 /** Pull the HITL form/question payload off an input-required frame's parts. */


### PR DESCRIPTION
## Symptom

During a multi-tool turn the console showed **only one tool card** — it kept overwriting itself instead of rendering each tool call.

## Root cause

The streaming chat renders tool cards from the `tool-call-v1` DataPart, but `toolEventFromParts` cast the raw A2A 1.0 payload straight to `ToolEvent` **without renaming the fields**:

| wire (`tool-call-v1`) | frontend `ToolEvent` |
|---|---|
| `toolCallId` | `id` |
| `args` | `input` |
| `result` | `output` |
| `phase: "started"\|"completed"` | `phase: "start"\|"end"` |

So every event arrived with `id` undefined, `phase` never `"start"`, and no input/output. The `id`-undefined part is the visible bug: `onToolCall` matches a card via `findIndex(c => c.id === evt.id)`, so with every `id` undefined each event matched the **first** card — all of a turn's tool calls collapsed into one ever-overwriting card.

## Fix

Map the fields (port of protoPen's `toolEventFromParts`) on top of protoAgent's more-robust `dataByMime` extraction (which handles the member-discriminated + flattened + legacy encodings protoPen's simpler `.find` doesn't).

## Verification

Against a **live 3-tool turn** (current_time + 2× calculator): old mapping accumulated **1 card**; new mapping accumulates **3 distinct cards** with running→done + input/output. Build green.

Found while spinning up the base agent for UI work. Frontend-only; propagates to the forks on their next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)