### PR TITLE
fix(console): settings sub-nav above header + tab margin + footer breathing room

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -471,6 +471,8 @@ h2 {
 .stage-body {
   min-height: 0;
   overflow-y: auto;
+  /* Breathing room so the last row never sits flush against the utility bar. */
+  padding-bottom: 12px;
 }
 
 /* Section headings stacked inside a scrolling stage body (Runtime, Schedule,
@@ -1648,6 +1650,7 @@ textarea {
   gap: 6px;
   flex-wrap: wrap;
   padding: 12px 16px 0;
+  margin-bottom: 10px;
 }
 
 .stage-subnav button {

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -144,6 +144,17 @@ function SettingsBody() {
 
   return (
     <>
+      {/* Sub-nav above the header, matching the other rail surfaces (System,
+          Knowledge, Activity) which render their stage-subnav above the panel. */}
+      {categories.length > 1 ? (
+        <div className="stage-subnav settings-subnav">
+          {categories.map((c) => (
+            <button key={c} className={c === category ? "active" : ""} onClick={() => setActiveCategory(c)}>
+              {c}
+            </button>
+          ))}
+        </div>
+      ) : null}
       <div className="panel-header">
         <div>
           <h1>Settings</h1>
@@ -166,15 +177,6 @@ function SettingsBody() {
           </button>
         </div>
       </div>
-      {categories.length > 1 ? (
-        <div className="stage-subnav settings-subnav">
-          {categories.map((c) => (
-            <button key={c} className={c === category ? "active" : ""} onClick={() => setActiveCategory(c)}>
-              {c}
-            </button>
-          ))}
-        </div>
-      ) : null}
       <div className="stage-body">
         {pendingRestart.length ? (
           <div className="settings-banner" role="alert">


### PR DESCRIPTION
Three console layout fixes (found while doing UI work on the base agent):

1. **Settings sub-nav placement** — Settings rendered its category tabs (Agent / Behavior / Memory / Integrations / System) *below* the panel header, while every other rail surface (System / Knowledge / Activity) renders its `stage-subnav` *above* the panel. Moved the Settings sub-nav above the header to match. (Verified live: `subnavTop < headerTop`.)
2. **Tab margin** — `.stage-subnav` had no margin below it, so the tabs sat tight against the header/content. Added `margin-bottom`.
3. **Footer breathing room** — scroll content (`.stage-body`) butted flush against the utility bar (the footer has its own 40px grid row, but the last row touched its top border with no gap). Added `padding-bottom`.

Verified: build green; e2e green (settings + tool-renderers + chat specs, 15 passed). Frontend-only; propagates to forks on their next sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)