### PR TITLE
docs: retarget canonical reference quinn → roxy + drop docs banner

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,10 @@ stable across every agent in the fleet, so forking an agent is
 close to a rewrite of `SOUL.md`, `graph/prompts.py`, and
 `tools/lg_tools.py` and not much else.
 
-**Canonical reference implementation**: [protoLabsAI/quinn](https://github.com/protoLabsAI/quinn).
-Quinn was the first agent built on this template — it's a good
-example of what a filled-in fork looks like end-to-end.
+**Canonical reference implementation**: [protoLabsAI/roxy](https://github.com/protoLabsAI/roxy).
+Roxy is a filled-in fork — an autonomous ProtoMaker portfolio manager with its
+own persona, A2A skills, and project registry — a good example of what a fork
+looks like end-to-end.
 
 **Try it in 5 minutes:** clone, `pip install -r requirements.txt`,
 `python -m server`, open <http://localhost:7870>, and walk the

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -18,32 +18,7 @@ export default defineConfig({
   // lives in the repo (committed, shared) but is NOT part of the published site.
   srcExclude: ["dev/**"],
 
-  head: [
-    ["link", { rel: "icon", href: "/protoAgent/favicon.svg" }],
-    // Social / OpenGraph preview — the banner renders as the large card image
-    // on GitHub, Slack, Discord, X, etc. Absolute URL (GitHub Pages base).
-    ["meta", { property: "og:type", content: "website" }],
-    ["meta", { property: "og:title", content: "protoAgent" }],
-    ["meta", {
-      property: "og:description",
-      content: "Template repository for building protoLabs A2A agents on LangGraph.",
-    }],
-    ["meta", {
-      property: "og:image",
-      content: "https://protolabsai.github.io/protoAgent/protoagent-banner.png",
-    }],
-    ["meta", { property: "og:url", content: "https://protolabsai.github.io/protoAgent/" }],
-    ["meta", { name: "twitter:card", content: "summary_large_image" }],
-    ["meta", { name: "twitter:title", content: "protoAgent" }],
-    ["meta", {
-      name: "twitter:description",
-      content: "Template repository for building protoLabs A2A agents on LangGraph.",
-    }],
-    ["meta", {
-      name: "twitter:image",
-      content: "https://protolabsai.github.io/protoAgent/protoagent-banner.png",
-    }],
-  ],
+  head: [["link", { rel: "icon", href: "/protoAgent/favicon.svg" }]],
 
   themeConfig: {
     logo: "/favicon.svg",

--- a/docs/explanation/litellm-gateway.md
+++ b/docs/explanation/litellm-gateway.md
@@ -23,7 +23,7 @@ Option 3 wins because:
 The template points at `model.name: protolabs/reasoning`. Two things to know:
 
 1. **`protolabs/<name>` is a gateway alias**, not a real model. The gateway config maps `protolabs/reasoning` → whichever real model (e.g. `claude-opus-4-6`, `gpt-4o`) you want.
-2. **Each agent gets its own alias**. Quinn uses `protolabs/quinn`, a researcher agent might use `protolabs/researcher`. Same gateway, different underlying models, different rate limits, different cost tracking.
+2. **Each agent gets its own alias**. Roxy uses `protolabs/roxy`, a researcher agent might use `protolabs/researcher`. Same gateway, different underlying models, different rate limits, different cost tracking.
 
 To swap a model for an agent:
 
@@ -77,4 +77,4 @@ The gateway solves all of these centrally. For a fleet, it's worth the hop.
 
 - [Configuration reference](/reference/configuration) — the `model.*` keys
 - [Environment variables](/reference/environment-variables) — `OPENAI_API_KEY` points at the gateway
-- [Quinn's README](https://github.com/protoLabsAI/quinn#llm-gateway-setup) — example of a real gateway alias config
+- [Roxy's config](https://github.com/protoLabsAI/roxy/blob/main/config/langgraph-config.example.yaml) — a real fork's `model.*` gateway-alias config

--- a/docs/guides/add-a-skill.md
+++ b/docs/guides/add-a-skill.md
@@ -30,7 +30,7 @@ Edit the `_SKILL_SPECS` list in `server.py` (the card builder `_build_agent_card
         "description": "Fetch a GitHub PR and return a three-bullet summary of what it changes and why.",
         "tags": ["github", "summarization"],
         "examples": [
-            "summarize https://github.com/protoLabsAI/quinn/pull/64",
+            "summarize https://github.com/protoLabsAI/protoAgent/pull/64",
         ],
     },
 ],
@@ -105,7 +105,7 @@ curl -X POST http://localhost:7870/a2a \
       "params": {
         "message": {
           "role": "user",
-          "parts": [{"text": "summarize https://github.com/protoLabsAI/quinn/pull/64"}]
+          "parts": [{"text": "summarize https://github.com/protoLabsAI/protoAgent/pull/64"}]
         },
         "metadata": {"skill": "summarize_pr"}
       }

--- a/docs/guides/customize-and-deploy.md
+++ b/docs/guides/customize-and-deploy.md
@@ -117,4 +117,4 @@ Once the checklist is done, `rm TEMPLATE.md` and rewrite `README.md` to describe
 
 ## Canonical reference implementation
 
-[protoLabsAI/quinn](https://github.com/protoLabsAI/quinn) is the first agent built on this template, now running in production. When this guide doesn't cover a specific decision, Quinn is the filled-in example — worth a skim before you invent something new.
+[protoLabsAI/roxy](https://github.com/protoLabsAI/roxy) is a fork built on this template, running in production as an autonomous ProtoMaker portfolio manager. When this guide doesn't cover a specific decision, Roxy is the filled-in example — worth a skim before you invent something new.

--- a/docs/index.md
+++ b/docs/index.md
@@ -4,9 +4,6 @@ hero:
   name: protoAgent
   text: LangGraph + A2A template for protoLabs agents
   tagline: Clone. Run. Walk the wizard. Chat. Fork when you're ready to ship.
-  image:
-    src: /protoagent-banner.png
-    alt: protoAgent
   actions:
     - theme: brand
       text: Spin up your first agent
@@ -41,4 +38,4 @@ This site follows the [Diátaxis](https://diataxis.fr) framework:
 
 ## Canonical reference implementation
 
-[protoLabsAI/quinn](https://github.com/protoLabsAI/quinn) was the first agent built on this template. When the docs here don't cover something specific, Quinn is the filled-in example to consult.
+[protoLabsAI/roxy](https://github.com/protoLabsAI/roxy) is a filled-in fork built on this template — an autonomous ProtoMaker portfolio manager (persona, A2A skills, project registry). When the docs here don't cover something specific, Roxy is the filled-in example to consult.


### PR DESCRIPTION
## quinn → roxy
`protoLabsAI/quinn` was renamed to **deprecated-quinn**, so every link to it 404s/redirects to a deprecated repo. Retarget the 'canonical reference implementation / filled-in example' framing at **protoLabsAI/roxy** — public, current (v0.15.0), a real fork (persona + A2A skills + project registry):
- `README.md`, `docs/index.md`, `docs/guides/customize-and-deploy.md` — the reference framing (reworded: roxy is an operator/PM fork, not 'the first researcher agent')
- `docs/explanation/litellm-gateway.md` — the gateway-alias example (`protolabs/quinn` → `protolabs/roxy`) + the README link now points at roxy's actual `langgraph-config.example.yaml` (roxy has no gateway-setup README anchor)
- `docs/guides/add-a-skill.md` — the example PR URLs now point at protoAgent's own repo (stable)

## Drop the docs banner
Per request: remove the banner from the **docs site** (home-hero image + the OG/Twitter image meta, reverting the head to favicon-only, consistent with the forks) while **keeping it in the README masthead**. The banner file stays in `docs/public/` (the README references it).

Docs build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)