### PR TITLE
a2a: drive card identity (skills + description) from config/plugins (#570)

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -83,6 +83,24 @@ skills:
   top_k: 5
   max_tokens: 2000
 
+# A2A card identity (#570) — declare your fork's advertised skills + card
+# description HERE (or contribute skills from a plugin via register_a2a_skill)
+# rather than editing server/a2a.py. Omit both and the template ships one
+# free-text "chat" placeholder so a fresh clone stays callable. The card `name`
+# already follows identity.name / AGENT_NAME.
+a2a:
+  # description: "Acme Bot — turns support tickets into triaged, drafted replies."
+  # skills:
+  #   - id: triage_ticket
+  #     name: Triage Ticket
+  #     description: Classify a support ticket and draft a reply.
+  #     tags: [support]
+  #     examples: ["triage ticket #1234"]
+  #     # Structured output (optional): the executor enforces the schema (#476)
+  #     # and emits a typed DataPart advertised in the card's output_modes.
+  #     # result_mime: application/vnd.protolabs.triage-v1+json
+  #     # output_schema: { type: object, properties: { ... }, required: [ ... ] }
+
 # Workflows — reusable declarative multi-step subagent recipes (ADR 0002),
 # run via the run_workflow tool. Bundled examples ship in the repo workflows/
 # dir; `dir` is the writable root for user/agent-emitted recipes (same

--- a/graph/config.py
+++ b/graph/config.py
@@ -341,6 +341,17 @@ class LangGraphConfig:
     identity_name: str = "protoagent"
     identity_operator: str = ""
 
+    # A2A card identity (#570). Forks declare their advertised skills + card
+    # description here (or a plugin contributes skills via register_a2a_skill)
+    # instead of editing server/a2a.py. ``a2a_skills`` is a list of skill specs
+    # (id/name/description/tags/examples, + optional output_schema/result_mime);
+    # empty falls back to the template placeholder so a fresh clone stays
+    # callable. ``a2a_description`` overrides the card description; blank uses the
+    # template default. The card ``name`` already resolves from identity (see
+    # agent_name()).
+    a2a_skills: list[dict] = field(default_factory=list)
+    a2a_description: str = ""
+
     # Instance id for multi-instance data scoping (ADR 0004). When set, every
     # store nests under <base>/<id>/ so several instances can share one
     # filesystem without clobbering each other. Empty = single-instance (legacy)
@@ -432,6 +443,7 @@ class LangGraphConfig:
         mcp = data.get("mcp", {})
         plugins = data.get("plugins", {})
         identity = data.get("identity", {})
+        a2a = data.get("a2a", {})
         auth = data.get("auth", {})
         runtime = data.get("runtime", {})
         operator = data.get("operator", {})
@@ -520,6 +532,8 @@ class LangGraphConfig:
             plugins_dir=plugins.get("dir", cls.plugins_dir),
             identity_name=identity.get("name", cls.identity_name),
             identity_operator=identity.get("operator", cls.identity_operator),
+            a2a_skills=list(a2a.get("skills", []) or []),
+            a2a_description=a2a.get("description", "") or "",
             instance_id=data.get("instance", {}).get("id", "") or data.get("instance_id", cls.instance_id),
             auth_token=secret_auth_token or auth.get("token", cls.auth_token),
             autostart_on_boot=runtime.get("autostart_on_boot", cls.autostart_on_boot),

--- a/graph/config.py
+++ b/graph/config.py
@@ -443,7 +443,10 @@ class LangGraphConfig:
         mcp = data.get("mcp", {})
         plugins = data.get("plugins", {})
         identity = data.get("identity", {})
-        a2a = data.get("a2a", {})
+        # `or {}` (not a default arg): a section present but empty/commented in
+        # YAML parses to None, and `.get(...)` on the default arg wouldn't catch
+        # that — the example ships an all-commented `a2a:` block.
+        a2a = data.get("a2a") or {}
         auth = data.get("auth", {})
         runtime = data.get("runtime", {})
         operator = data.get("operator", {})

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -28,6 +28,7 @@ log = logging.getLogger("protoagent.plugins")
 class PluginLoadResult:
     tools: list = field(default_factory=list)
     skill_dirs: list = field(default_factory=list)
+    a2a_skills: list = field(default_factory=list)  # A2A card skill specs (#570)
     routers: list = field(default_factory=list)    # {plugin_id, router, prefix} (ADR 0018)
     surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
     subagents: list = field(default_factory=list)   # SubagentConfig
@@ -190,6 +191,7 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
 
         result.tools.extend(kept)
         result.skill_dirs.extend(registry.skill_dirs)
+        result.a2a_skills.extend(registry.a2a_skills)
         # Surfaces / routes / subagents (ADR 0018) — tagged with the plugin id so
         # the server can namespace + report them.
         for r in registry.routers:

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -47,6 +47,7 @@ class PluginRegistry:
         self.host = HOST
         self.tools: list = []
         self.skill_dirs: list[Path] = []
+        self.a2a_skills: list[dict] = []  # A2A card skill specs (#570)
         self.routers: list[dict] = []     # {"router", "prefix"}
         self.surfaces: list[dict] = []    # {"name", "start", "stop"}
         self.subagents: list = []         # SubagentConfig instances
@@ -73,6 +74,20 @@ class PluginRegistry:
         if not p.is_absolute():
             p = self.plugin_dir / p
         self.skill_dirs.append(p)
+
+    def register_a2a_skill(self, spec: dict) -> None:
+        """Contribute an A2A *card* skill — advertised on the agent card and,
+        when it declares ``output_schema`` + ``result_mime``, enforced by the
+        executor's structured finalizer (#570). Distinct from
+        ``register_skill_dir`` (disk ``SKILL.md`` procedural memory): this is what
+        the card advertises to callers. ``spec`` is a dict with at least
+        ``id``/``name``/``description`` (+ optional ``tags``/``examples``/
+        ``output_schema``/``result_mime``)."""
+        if not isinstance(spec, dict) or not spec.get("id") or not spec.get("name"):
+            log.warning("[plugins] %s: register_a2a_skill needs a dict with id+name: %r",
+                        self.plugin_id, spec)
+            return
+        self.a2a_skills.append(spec)
 
     def register_router(self, router, prefix: str | None = None) -> None:
         """Mount a FastAPI ``APIRouter`` on the server (ADR 0018).

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -37,6 +37,7 @@ class AppState:
     mcp_meta: list = field(default_factory=list)
     plugin_tools: list = field(default_factory=list)
     plugin_skill_dirs: list = field(default_factory=list)
+    plugin_a2a_skills: list = field(default_factory=list)  # A2A card skills from plugins (#570)
     plugin_routers: list = field(default_factory=list)
     plugin_surfaces: list = field(default_factory=list)
     plugin_surface_handles: list = field(default_factory=list)

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -39,8 +39,11 @@ def _bearer_configured() -> bool:
 # text (today's default). The schema lives HERE (skill config), not on the card
 # — ``AgentSkill`` only carries ``output_modes`` (the MIME), per the A2A spec.
 #
-# REPLACE when forking. The template ships one free-text placeholder so a fresh
-# clone is callable; the commented fields below show a structured skill.
+# This is the TEMPLATE DEFAULT — one free-text placeholder so a fresh clone is
+# callable. Forks declare their real skills WITHOUT editing this file (#570):
+# either in ``langgraph-config.yaml`` (``a2a.skills: [...]``) or via a plugin
+# (``registry.register_a2a_skill(spec)``). ``_resolved_skill_specs()`` merges
+# both and falls back here when neither is set.
 _SKILL_SPECS: list[dict] = [
     {
         "id": "chat",
@@ -55,14 +58,29 @@ _SKILL_SPECS: list[dict] = [
 ]
 
 
+def _resolved_skill_specs() -> list[dict]:
+    """The agent's advertised A2A skills, resolved at runtime (#570) so a fork
+    never edits this file. Sources, in order: ``a2a.skills`` from
+    ``langgraph-config.yaml`` (``STATE.graph_config.a2a_skills``), then
+    plugin-contributed skills (``register_a2a_skill`` → ``STATE.plugin_a2a_skills``).
+    Falls back to the template placeholder ``_SKILL_SPECS`` when neither is set,
+    so a fresh clone stays callable."""
+    cfg = STATE.graph_config
+    resolved: list[dict] = []
+    if cfg is not None:
+        resolved.extend(getattr(cfg, "a2a_skills", None) or [])
+    resolved.extend(getattr(STATE, "plugin_a2a_skills", None) or [])
+    return resolved or _SKILL_SPECS
+
+
 def _agent_skills():
-    """Build the card's ``AgentSkill`` list from ``_SKILL_SPECS``. A spec with a
-    ``result_mime`` advertises it in ``output_modes`` (the A2A-native way to tell
-    consumers the skill emits that structured type)."""
+    """Build the card's ``AgentSkill`` list from the resolved skill specs. A spec
+    with a ``result_mime`` advertises it in ``output_modes`` (the A2A-native way
+    to tell consumers the skill emits that structured type)."""
     from a2a.types import AgentSkill
 
     skills = []
-    for s in _SKILL_SPECS:
+    for s in _resolved_skill_specs():
         kwargs = dict(
             id=s["id"],
             name=s["name"],
@@ -82,8 +100,8 @@ def structured_skill_schema(skill_id: str) -> dict | None:
     text). The executor's structured finalizer (#476) reads this to run the
     forced-tool-call against the schema and emit the validated object as a
     ``result_mime`` DataPart. The schema isn't on the card (``AgentSkill`` has no
-    schema field) — it lives in ``_SKILL_SPECS``."""
-    for s in _SKILL_SPECS:
+    schema field) — it lives in the resolved skill specs."""
+    for s in _resolved_skill_specs():
         if s["id"] == skill_id and s.get("output_schema") and s.get("result_mime"):
             return {"schema": s["output_schema"], "mime": s["result_mime"]}
     return None
@@ -136,16 +154,27 @@ def _a2a_card_url() -> str:
     return f"{base}/a2a"
 
 
+# Template default card description — used when a fork sets no ``a2a.description``
+# in config (#570). Forks override via config, not by editing this file.
+_DEFAULT_CARD_DESCRIPTION = (
+    "protoAgent template — A2A 1.0 LangGraph agent. "
+    "Replace this description with your agent's actual purpose."
+)
+
+
 def _build_agent_card_proto():
     """Build the A2A 1.0 ``AgentCard`` (proto) served at
     ``/.well-known/agent-card.json``, applying the protoLabs fleet conventions
     via ``protolabs_a2a.build_agent_card``.
 
-    **Fork this.** Replace ``name``, ``description``, and ``_agent_skills()``
-    with your agent's actual surface. The four custom extensions
-    (cost / confidence / worldstate-delta / tool-call) are declared by default
-    — this template emits cost-v1 + confidence-v1 from ``_chat_langgraph_stream``
-    and worldstate-delta / tool-call when a tool reports them.
+    Identity is config/plugin-driven (#570), so a fork shouldn't edit this file:
+    ``name`` resolves from identity (``agent_name()``), ``description`` from
+    ``a2a.description`` in ``langgraph-config.yaml`` (falling back to the template
+    default below), and ``skills`` from config/plugins (``_resolved_skill_specs``).
+    The four custom extensions (cost / confidence / worldstate-delta / tool-call)
+    are declared by default — the template emits cost-v1 + confidence-v1 from
+    ``_chat_langgraph_stream`` and worldstate-delta / tool-call when a tool reports
+    them.
 
     The interface ``url`` (``_a2a_card_url``) targets the JSON-RPC endpoint
     (``/a2a``) at the agent's reachable address — set ``A2A_PUBLIC_URL`` when
@@ -153,12 +182,11 @@ def _build_agent_card_proto():
     """
     import protolabs_a2a as pa
 
+    cfg = STATE.graph_config
+    description = (getattr(cfg, "a2a_description", "") or "").strip() or _DEFAULT_CARD_DESCRIPTION
     return pa.build_agent_card(
         name=agent_name(),
-        description=(
-            "protoAgent template — A2A 1.0 LangGraph agent. "
-            "Replace this description with your agent's actual purpose."
-        ),
+        description=description,
         url=_a2a_card_url(),
         version=_package_version(),
         skills=_agent_skills(),

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -140,6 +140,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     STATE.plugin_tools, STATE.plugin_skill_dirs, STATE.plugin_meta = (
         _plugins.tools, _plugins.skill_dirs, _plugins.meta,
     )
+    STATE.plugin_a2a_skills = _plugins.a2a_skills  # A2A card skills (#570)
     # Surfaces / routes / subagents (ADR 0018). Routers + surfaces are captured
     # here and consumed once by _main (mount) + the startup hook (start) — they
     # don't hot-reload. Subagents register into SUBAGENT_REGISTRY before the graph

--- a/tests/test_a2a_card_identity.py
+++ b/tests/test_a2a_card_identity.py
@@ -1,0 +1,105 @@
+"""A2A card identity is config/plugin-driven (#570) — a fork declares its
+advertised skills + card description in langgraph-config.yaml or via a plugin's
+register_a2a_skill, with ZERO edits to server/a2a.py. The template default
+(one free-text "chat" skill) holds when nothing is provided."""
+
+import server
+import server.a2a as a2a
+from graph.config import LangGraphConfig
+
+
+# ── config parse ────────────────────────────────────────────────────────────
+
+def test_config_parses_a2a_section(tmp_path):
+    p = tmp_path / "langgraph-config.yaml"
+    p.write_text(
+        "a2a:\n"
+        "  description: Acme triage bot\n"
+        "  skills:\n"
+        "    - id: triage\n"
+        "      name: Triage\n"
+        "      description: d\n"
+    )
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.a2a_description == "Acme triage bot"
+    assert [s["id"] for s in cfg.a2a_skills] == ["triage"]
+
+
+def test_config_a2a_defaults_empty(tmp_path):
+    p = tmp_path / "langgraph-config.yaml"
+    p.write_text("model:\n  provider: openai\n")
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.a2a_skills == [] and cfg.a2a_description == ""
+
+
+# ── plugin hook ─────────────────────────────────────────────────────────────
+
+def test_register_a2a_skill_accumulates_and_validates():
+    from graph.plugins.registry import PluginRegistry
+
+    reg = PluginRegistry.__new__(PluginRegistry)  # avoid HOST import in __init__
+    reg.plugin_id = "demo"
+    reg.a2a_skills = []
+    reg.register_a2a_skill({"id": "s1", "name": "S1", "description": "d"})
+    reg.register_a2a_skill({"name": "no-id"})          # rejected: no id
+    reg.register_a2a_skill("not-a-dict")               # rejected: not a dict
+    assert [s["id"] for s in reg.a2a_skills] == ["s1"]
+
+
+# ── resolver precedence: config + plugin, else default ──────────────────────
+
+def _cfg(skills=None, description=""):
+    c = LangGraphConfig()
+    c.a2a_skills = skills or []
+    c.a2a_description = description
+    return c
+
+
+def test_resolver_falls_back_to_template_default(monkeypatch):
+    monkeypatch.setattr(server.STATE, "graph_config", None, raising=False)
+    monkeypatch.setattr(server.STATE, "plugin_a2a_skills", [], raising=False)
+    assert [s["id"] for s in a2a._resolved_skill_specs()] == ["chat"]  # the placeholder
+
+
+def test_resolver_uses_config_then_plugin(monkeypatch):
+    monkeypatch.setattr(server.STATE, "graph_config",
+                        _cfg(skills=[{"id": "cfg1", "name": "Cfg1", "description": "d"}]), raising=False)
+    monkeypatch.setattr(server.STATE, "plugin_a2a_skills",
+                        [{"id": "plug1", "name": "Plug1", "description": "d"}], raising=False)
+    ids = [s["id"] for s in a2a._resolved_skill_specs()]
+    assert ids == ["cfg1", "plug1"]  # config first, then plugins; default dropped
+
+
+def test_agent_skills_built_from_resolver(monkeypatch):
+    monkeypatch.setattr(server.STATE, "graph_config",
+                        _cfg(skills=[{"id": "triage", "name": "Triage", "description": "d",
+                                      "result_mime": "application/vnd.x-v1+json"}]), raising=False)
+    monkeypatch.setattr(server.STATE, "plugin_a2a_skills", [], raising=False)
+    skills = a2a._agent_skills()
+    assert skills[0].id == "triage"
+    assert list(skills[0].output_modes) == ["application/vnd.x-v1+json"]
+    # structured schema resolves through the same source
+    monkeypatch.setattr(server.STATE, "graph_config",
+                        _cfg(skills=[{"id": "triage", "name": "T", "description": "d",
+                                      "result_mime": "application/vnd.x-v1+json",
+                                      "output_schema": {"type": "object"}}]), raising=False)
+    assert a2a.structured_skill_schema("triage") == {
+        "schema": {"type": "object"}, "mime": "application/vnd.x-v1+json"}
+
+
+# ── card description from config, default otherwise ─────────────────────────
+
+def test_card_description_from_config(monkeypatch):
+    monkeypatch.setattr(server.STATE, "graph_config", _cfg(description="Acme triage bot"), raising=False)
+    monkeypatch.setattr(server.STATE, "plugin_a2a_skills", [], raising=False)
+    monkeypatch.setattr(server.STATE, "active_port", 7870, raising=False)
+    card = a2a._build_agent_card_proto()
+    assert card.description == "Acme triage bot"
+
+
+def test_card_description_default(monkeypatch):
+    monkeypatch.setattr(server.STATE, "graph_config", _cfg(description=""), raising=False)
+    monkeypatch.setattr(server.STATE, "plugin_a2a_skills", [], raising=False)
+    monkeypatch.setattr(server.STATE, "active_port", 7870, raising=False)
+    card = a2a._build_agent_card_proto()
+    assert card.description == a2a._DEFAULT_CARD_DESCRIPTION


### PR DESCRIPTION
Closes #570 (part of the #573 operator-fork contract). server/a2a.py is the single biggest fork-conflict source — the advertised skills + card description ARE a fork identity, so it conflicts on essentially every sync (incl. an add/add collision during the ADR-0023 server decomposition; roxy carries +123 lines here).

## Make identity config/plugin-driven — forks declare, never edit core
- config: new a2a: section in langgraph-config.yaml → a2a_skills (skill specs) + a2a_description on LangGraphConfig.
- plugins: registry.register_a2a_skill(spec) (mirrors register_skill_dir) → aggregated by the loader into STATE.plugin_a2a_skills. Connects plugin skills to the card (previously plugins could only add disk SKILL.md dirs).
- server/a2a.py: _resolved_skill_specs() merges config + plugin skills, falling back to the template placeholder when neither is set; agent_skills / structured_skill_schema read it. Card description resolves from a2a.description else a default constant — mirroring how name already resolves from identity.

Zero behavior change for a fresh clone. Example config documents the seam.

## Tests
tests/test_a2a_card_identity.py — config parse, plugin hook + validation, resolver precedence (config → plugin → default), card description from config + fallback. 1033 tests green (1025 + 8).
