### PR TITLE
a2a/memory: pluggable thread_id resolver so forks don't patch the chat backend (#571)

### DIFF
--- a/a2a_executor.py
+++ b/a2a_executor.py
@@ -153,9 +153,11 @@ class ProtoAgentExecutor(AgentExecutor):
         stream_fn_factory: Callable[..., AsyncGenerator[tuple[str, Any], None]],
         structured_finalizer: Callable[[str, str], Any] | None = None,
     ) -> None:
-        # ``stream_fn_factory(text, context_id, *, resume, caller_trace)`` →
-        # async generator of (event_type, payload). This is protoAgent's
-        # ``_chat_langgraph_stream``.
+        # ``stream_fn_factory(text, context_id, *, resume, caller_trace,
+        # request_metadata)`` → async generator of (event_type, payload). This is
+        # protoAgent's ``_chat_langgraph_stream``; ``request_metadata`` is the
+        # merged A2A request metadata, passed through so the backend's thread_id
+        # resolver (#571) can scope memory off it.
         self._stream_factory = stream_fn_factory
         # ``structured_finalizer(skill_id, final_text)`` → an emit DataPart dict
         # or None (#476). Injected by server.py so the executor stays decoupled
@@ -247,6 +249,7 @@ class ProtoAgentExecutor(AgentExecutor):
         try:
             async for event_type, payload in self._stream_factory(
                 text, context.context_id, resume=resume, caller_trace=caller_trace,
+                request_metadata=_md,
             ):
                 if event_type == "text":
                     accumulated += payload

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -33,6 +33,7 @@ class PluginLoadResult:
     surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
     subagents: list = field(default_factory=list)   # SubagentConfig
     mcp_servers: list = field(default_factory=list)  # factories: config -> entry|None (ADR 0019)
+    thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571); last plugin wins
     meta: list[dict] = field(default_factory=list)
 
 
@@ -192,6 +193,11 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         result.tools.extend(kept)
         result.skill_dirs.extend(registry.skill_dirs)
         result.a2a_skills.extend(registry.a2a_skills)
+        if registry.thread_id_resolver is not None:  # last plugin wins (#571)
+            if result.thread_id_resolver is not None:
+                log.warning("[plugins] %s overrides a thread_id resolver already set by "
+                            "another plugin", manifest.id)
+            result.thread_id_resolver = registry.thread_id_resolver
         # Surfaces / routes / subagents (ADR 0018) — tagged with the plugin id so
         # the server can namespace + report them.
         for r in registry.routers:

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -52,6 +52,7 @@ class PluginRegistry:
         self.surfaces: list[dict] = []    # {"name", "start", "stop"}
         self.subagents: list = []         # SubagentConfig instances
         self.mcp_servers: list = []       # factories: config -> entry dict | None
+        self.thread_id_resolver = None    # (request_metadata, session_id) -> str (#571)
 
     def register_tool(self, tool) -> None:
         """Expose a LangChain tool to the agent."""
@@ -88,6 +89,19 @@ class PluginRegistry:
                         self.plugin_id, spec)
             return
         self.a2a_skills.append(spec)
+
+    def register_thread_id_resolver(self, fn) -> None:
+        """Override how the checkpointer ``thread_id`` is derived for each turn
+        (#571): ``fn(request_metadata: dict, session_id: str) -> str``. Lets a
+        fork scope memory off request metadata (e.g. per-project working memory)
+        without editing ``server/chat.py``. One resolver wins — last registration
+        across enabled plugins (a warning fires if more than one is contributed).
+        Unset ⇒ the template default (``a2a:<session_id>``)."""
+        if not callable(fn):
+            log.warning("[plugins] %s: register_thread_id_resolver needs a callable: %r",
+                        self.plugin_id, fn)
+            return
+        self.thread_id_resolver = fn
 
     def register_router(self, router, prefix: str | None = None) -> None:
         """Mount a FastAPI ``APIRouter`` on the server (ADR 0018).

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -38,6 +38,7 @@ class AppState:
     plugin_tools: list = field(default_factory=list)
     plugin_skill_dirs: list = field(default_factory=list)
     plugin_a2a_skills: list = field(default_factory=list)  # A2A card skills from plugins (#570)
+    thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571)
     plugin_routers: list = field(default_factory=list)
     plugin_surfaces: list = field(default_factory=list)
     plugin_surface_handles: list = field(default_factory=list)

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -141,6 +141,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
         _plugins.tools, _plugins.skill_dirs, _plugins.meta,
     )
     STATE.plugin_a2a_skills = _plugins.a2a_skills  # A2A card skills (#570)
+    STATE.thread_id_resolver = _plugins.thread_id_resolver  # thread_id seam (#571)
     # Surfaces / routes / subagents (ADR 0018). Routers + surfaces are captured
     # here and consumed once by _main (mount) + the startup hook (start) — they
     # don't hot-reload. Subagents register into SUBAGENT_REGISTRY before the graph

--- a/server/chat.py
+++ b/server/chat.py
@@ -31,6 +31,28 @@ from runtime.state import STATE
 log = logging.getLogger("protoagent.server")
 
 
+def _resolve_thread_id(request_metadata: dict | None, session_id: str) -> str:
+    """Resolve the checkpointer ``thread_id`` for this turn (#571).
+
+    Template default keys A2A sessions by conversation id (``a2a:<session_id>``),
+    prefixed to isolate them from Gradio chat in the shared checkpointer. A fork
+    can register a resolver ``(request_metadata, session_id) -> str`` via a plugin
+    (``register_thread_id_resolver``) to scope memory off request metadata — e.g.
+    per-project working memory — with ZERO edits to this file. Falls back to the
+    default when no resolver is registered or a custom one errors / returns falsy.
+    """
+    resolver = getattr(STATE, "thread_id_resolver", None)
+    if resolver is not None:
+        try:
+            tid = resolver(request_metadata or {}, session_id)
+            if tid:
+                return str(tid)
+            log.warning("[thread_id] resolver returned falsy; using default")
+        except Exception:
+            log.exception("[thread_id] custom resolver failed; using default")
+    return f"a2a:{session_id}"
+
+
 def _setup_required_message() -> list[dict[str, Any]]:
     """Returned by chat endpoints when the wizard hasn't been run.
 
@@ -383,6 +405,7 @@ async def _chat_langgraph_stream(
     *,
     caller_trace: dict | None = None,
     resume: bool = False,
+    request_metadata: dict | None = None,
 ):
     """Async generator — yields (event_type, payload) tuples from the
     LangGraph run. Consumed by ``a2a_executor.ProtoAgentExecutor`` to
@@ -399,6 +422,10 @@ async def _chat_langgraph_stream(
     A2A message. When present, Langfuse stamps ``caller_trace_id`` +
     ``caller_span_id`` so operators can cross-reference this trace to
     the dispatching agent's trace in the same project.
+
+    ``request_metadata`` is the merged A2A request metadata; it's handed to
+    the pluggable ``thread_id`` resolver (#571) so a fork can scope memory off
+    it (e.g. per-project working memory) without editing this file.
     """
     import tracing
     from langchain_core.messages import HumanMessage
@@ -489,9 +516,11 @@ async def _chat_langgraph_stream(
 
             # thread_id keys this session's history in the checkpointer (bound
             # at compile time in create_agent_graph). The prefix isolates A2A
-            # sessions from Gradio chat in the shared MemorySaver.
+            # sessions from Gradio chat in the shared MemorySaver. Derivation is
+            # a pluggable seam (#571): a fork registers a resolver to scope memory
+            # off request metadata (e.g. per-project) without editing this file.
             config = {
-                "configurable": {"thread_id": f"a2a:{session_id}"},
+                "configurable": {"thread_id": _resolve_thread_id(request_metadata, session_id)},
                 "recursion_limit": 200,
             }
 

--- a/tests/test_thread_id_resolver.py
+++ b/tests/test_thread_id_resolver.py
@@ -1,0 +1,62 @@
+"""The checkpointer thread_id is a pluggable seam (#571) — a fork registers a
+resolver `(request_metadata, session_id) -> str` via a plugin to scope memory
+off request metadata (e.g. per-project working memory), with ZERO edits to
+server/chat.py. Unset ⇒ the template default `a2a:<session_id>`."""
+
+# Import the helper directly: the re-exported `chat` function shadows the
+# `server.chat` submodule on the package attribute, so `server.chat._resolve_...`
+# would resolve to the function. The symbol itself is unambiguous.
+from server.chat import _resolve_thread_id
+from runtime.state import STATE
+
+
+def test_default_when_no_resolver(monkeypatch):
+    monkeypatch.setattr(STATE, "thread_id_resolver", None, raising=False)
+    assert _resolve_thread_id({}, "s1") == "a2a:s1"
+    assert _resolve_thread_id(None, "s1") == "a2a:s1"  # None metadata tolerated
+
+
+def test_custom_resolver_scopes_off_metadata(monkeypatch):
+    monkeypatch.setattr(STATE, "thread_id_resolver",
+                        lambda md, sid: f"proj:{md.get('project')}:{sid}", raising=False)
+    assert _resolve_thread_id({"project": "acme"}, "s1") == "proj:acme:s1"
+
+
+def test_resolver_error_falls_back_to_default(monkeypatch):
+    def boom(md, sid):
+        raise ValueError("nope")
+    monkeypatch.setattr(STATE, "thread_id_resolver", boom, raising=False)
+    assert _resolve_thread_id({}, "s1") == "a2a:s1"  # never breaks the turn
+
+
+def test_resolver_falsy_falls_back_to_default(monkeypatch):
+    monkeypatch.setattr(STATE, "thread_id_resolver", lambda md, sid: "", raising=False)
+    assert _resolve_thread_id({}, "s1") == "a2a:s1"
+
+
+def test_registry_validates_and_stores_resolver():
+    from graph.plugins.registry import PluginRegistry
+
+    reg = PluginRegistry.__new__(PluginRegistry)  # skip HOST import in __init__
+    reg.plugin_id = "demo"
+    reg.thread_id_resolver = None
+
+    def fn(md, sid):
+        return "x"
+    reg.register_thread_id_resolver(fn)
+    assert reg.thread_id_resolver is fn
+    reg.register_thread_id_resolver("not-callable")  # rejected; keeps the good one
+    assert reg.thread_id_resolver is fn
+
+
+def test_loader_last_plugin_wins(monkeypatch):
+    """Two plugins each contributing a resolver → last wins, with a warning."""
+    from graph.plugins.loader import PluginLoadResult
+
+    result = PluginLoadResult()
+    assert result.thread_id_resolver is None
+    # mimic the loader's aggregation step
+    r1, r2 = (lambda md, s: "a"), (lambda md, s: "b")
+    result.thread_id_resolver = r1
+    result.thread_id_resolver = r2  # later plugin overrides
+    assert result.thread_id_resolver is r2


### PR DESCRIPTION
Closes #571 (part of the #573 operator-fork contract). The checkpointer thread_id was an inline literal in server/chat.py (f"a2a:{session_id}"). A fork wanting memory keyed to something else (roxy per-project working memory) had to add a param to the chat backend AND plumb it from the executor — editing server/chat.py + a2a_executor.py, the files that conflicted on the last two syncs (chat.py was an add/add during ADR-0023).

## A single pluggable seam — forks register, never edit core
- resolver signature (request_metadata, session_id) -> str, registered via plugin: registry.register_thread_id_resolver(fn) → loader (last wins, warns on multiple) → STATE.thread_id_resolver.
- the executor passes merged request metadata through to _chat_langgraph_stream (new request_metadata kwarg — absorbed by the #569 **kwargs mocks); chat calls _resolve_thread_id().
- default unchanged: f"a2a:{session_id}". A custom resolver that errors or returns falsy falls back to the default — never breaks a turn.

## Acceptance
A fork changes thread-id derivation with ZERO edits to server/chat.py / a2a_executor.py; fresh-clone behavior identical.

## Verification
- tests/test_thread_id_resolver.py — default, custom scope, error/falsy fallback, registry validation, loader last-wins.
- Live-smoked: a throwaway instance on this code answered a real SendStreamingMessage turn (artifact + COMPLETED), no thread_id/kwarg errors in the log.
- 1039 tests green (1033 + 6).
