### PR TITLE
security: opt-in CIDR allowlist for A2A callbacks + peer_consult (#572)

### DIFF
--- a/a2a_stores.py
+++ b/a2a_stores.py
@@ -107,7 +107,17 @@ def is_safe_webhook_url(url: str) -> bool:
 
     The allowlist is re-read on each call so an operator can widen trust via
     env without a restart (and so tests can flip it with monkeypatch).
+
+    When the opt-in ``security.callback_allowlist`` (#572) is configured, it
+    becomes the policy: allow iff the destination resolves entirely into the
+    allowlist. This intentionally overrides the default private-IP denylist (so
+    an operator can permit a specific internal/tailnet range) and rejects
+    everything outside it. Unset ⇒ the default denylist below.
     """
+    import security
+    if security.is_enabled():
+        return security.is_allowed(url)
+
     allowed_hosts, allowed_cidrs = _parse_allowlist()
 
     try:

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -101,6 +101,17 @@ a2a:
   #     # result_mime: application/vnd.protolabs.triage-v1+json
   #     # output_schema: { type: object, properties: { ... }, required: [ ... ] }
 
+# Outbound A2A SSRF guard (#572) — opt-in CIDR allowlist for the destinations
+# the agent POSTs to: push-notification callbacks (caller-supplied) + peer_consult
+# (PEER_<HANDLE>_URL). Empty/unset = today's behavior (callbacks keep their
+# default private-IP denylist; peer_consult is unrestricted). When set, a
+# destination is allowed only if every resolved IP falls inside a listed CIDR —
+# e.g. lock outbound to your tailnet / private fleet network.
+security:
+  # callback_allowlist:
+  #   - 100.64.0.0/10   # tailnet
+  #   - 10.0.0.0/8      # private fleet
+
 # Workflows — reusable declarative multi-step subagent recipes (ADR 0002),
 # run via the run_workflow tool. Bundled examples ship in the repo workflows/
 # dir; `dir` is the writable root for user/agent-emitted recipes (same

--- a/graph/config.py
+++ b/graph/config.py
@@ -401,6 +401,13 @@ class LangGraphConfig:
     # for the generated OpenShell network policy (scripts/gen_openshell_policy).
     egress_allowed_hosts: list[str] = field(default_factory=list)
 
+    # Opt-in CIDR allowlist for outbound A2A destinations — push callbacks +
+    # peer_consult (#572). Empty/unset = today's behavior (callbacks keep their
+    # default private-IP denylist; peer_consult unrestricted). When set, an
+    # outbound destination is allowed iff every resolved IP is inside a listed
+    # CIDR. Enforced via ``security.set_callback_allowlist``.
+    security_callback_allowlist: list[str] = field(default_factory=list)
+
     def __post_init__(self):
         # PROTOAGENT_MODEL wins over the YAML/default model so an eval sweep can
         # boot the same agent against different models without editing config
@@ -548,6 +555,7 @@ class LangGraphConfig:
             ),
             filesystem_projects=list(data.get("filesystem", {}).get("projects", []) or []),
             egress_allowed_hosts=list(data.get("egress", {}).get("allowed_hosts", []) or []),
+            security_callback_allowlist=list((data.get("security") or {}).get("callback_allowlist", []) or []),
             plugin_config=_resolve_plugin_config(data, secrets, p.parent),
         )
 

--- a/security.py
+++ b/security.py
@@ -1,0 +1,108 @@
+"""Opt-in CIDR allowlist for outbound A2A destinations (#572).
+
+A *positive* CIDR allowlist for the two outbound surfaces that POST to an
+address the agent doesn't fully control — A2A push callbacks (caller-supplied
+webhook URLs) and ``peer_consult`` (operator-configured peer URLs). When the
+allowlist is set, a destination is permitted IFF **every** resolved IP of its
+host falls inside an allowlisted CIDR.
+
+**Empty/unset is permissive** (off): push callbacks keep their default
+private-IP denylist (``a2a_stores.is_safe_webhook_url``) and ``peer_consult``
+is unrestricted — so existing deployments are unchanged until they opt in via
+``security.callback_allowlist``.
+
+Mirrors ``egress.py`` (host allowlist for ``fetch_url``) and the
+``PUSH_NOTIFICATION_ALLOWED_CIDRS`` bypass in ``a2a_stores`` — this is the
+unified, config-driven knob covering both outbound A2A surfaces. Set once at
+startup and on live config reload (``server/agent_init``).
+"""
+
+from __future__ import annotations
+
+import ipaddress
+import logging
+import socket
+from urllib.parse import urlparse
+
+log = logging.getLogger("protoagent.security")
+
+# Parsed ip_network objects; empty = off (permissive). Re-set on config reload.
+_cidrs: list = []
+
+
+def set_callback_allowlist(cidrs) -> None:
+    """Set the allowlist (called at startup + on live config reload). Empty = off."""
+    global _cidrs
+    parsed = []
+    for c in cidrs or []:
+        c = str(c).strip()
+        if not c:
+            continue
+        try:
+            parsed.append(ipaddress.ip_network(c, strict=False))
+        except ValueError:
+            log.warning("[security] ignoring malformed CIDR in callback_allowlist: %s", c)
+    _cidrs = parsed
+
+
+def allowlist() -> list[str]:
+    return [str(c) for c in _cidrs]
+
+
+def is_enabled() -> bool:
+    return bool(_cidrs)
+
+
+def _resolve_ips(host: str) -> list[str] | None:
+    """Resolve ``host`` to IP literals (one-shot). ``None`` on failure. A literal
+    IP is returned as-is. (One-time resolution isn't a full DNS-rebinding defence
+    but closes the trivial literal-address vector — same posture as a2a_stores.)"""
+    try:
+        ipaddress.ip_address(host)
+        return [host]
+    except ValueError:
+        pass
+    try:
+        return [info[4][0] for info in socket.getaddrinfo(host, None)]
+    except socket.gaierror:
+        return None
+
+
+def check_url(url: str) -> str | None:
+    """Return an error string if ``url``'s host is outside the allowlist, else
+    ``None``. Permissive (``None``) when the allowlist is unset.
+
+    When set, EVERY resolved IP of the host must fall inside an allowlisted CIDR
+    — a host resolving to a mix of in- and out-of-allowlist addresses is rejected.
+    """
+    if not _cidrs:
+        return None
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return f"Error: malformed URL: {url!r}"
+    if parsed.scheme not in ("http", "https"):
+        return f"Error: refusing non-http(s) destination: {url!r}"
+    host = parsed.hostname
+    if not host:
+        return f"Error: no host in URL: {url!r}"
+    ips = _resolve_ips(host)
+    if not ips:
+        return f"Error: could not resolve host {host!r}"
+    for addr in ips:
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            return f"Error: unparseable address {addr!r} for {host!r}"
+        if not any(ip in cidr for cidr in _cidrs):
+            return (
+                f"Error: destination {host} ({addr}) is not in the callback "
+                f"allowlist ({', '.join(str(c) for c in _cidrs)}). Set "
+                f"security.callback_allowlist to permit it."
+            )
+    return None
+
+
+def is_allowed(url: str) -> bool:
+    """Convenience boolean wrapper around :func:`check_url`."""
+    return check_url(url) is None

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -70,6 +70,9 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # Egress allowlist (ADR 0008): deny-by-default outbound hosts for fetch_url.
     import egress
     egress.set_allowed_hosts(STATE.graph_config.egress_allowed_hosts)
+    # Opt-in CIDR allowlist for outbound A2A destinations — callbacks + peer_consult (#572).
+    import security
+    security.set_callback_allowlist(STATE.graph_config.security_callback_allowlist)
     # Multi-instance scoping (ADR 0004): seed PROTOAGENT_INSTANCE from config so
     # every store (incl. the env-reading knowledge/scheduler/memory modules) nests
     # under the same id. Opt-in — empty config.instance_id leaves paths unchanged.
@@ -852,8 +855,10 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     )
     try:
         import egress
+        import security
 
         egress.set_allowed_hosts(new_config.egress_allowed_hosts)  # live-reload (ADR 0008)
+        security.set_callback_allowlist(new_config.security_callback_allowlist)  # live-reload (#572)
     except Exception:  # noqa: BLE001 — never block a reload on the egress update
         pass
     try:

--- a/tests/test_security_allowlist.py
+++ b/tests/test_security_allowlist.py
@@ -1,0 +1,77 @@
+"""Opt-in CIDR allowlist for outbound A2A destinations (#572) — callbacks +
+peer_consult. Unset = permissive (today's behavior); when set, a destination is
+allowed iff every resolved IP is inside a listed CIDR. Uses IP-literal URLs so
+no DNS is involved."""
+
+import pytest
+
+import security
+import a2a_stores
+from graph.config import LangGraphConfig
+
+
+@pytest.fixture(autouse=True)
+def _reset_allowlist():
+    security.set_callback_allowlist([])
+    yield
+    security.set_callback_allowlist([])
+
+
+# ── the allowlist primitive ─────────────────────────────────────────────────
+
+def test_unset_is_permissive():
+    assert security.is_enabled() is False
+    assert security.check_url("http://8.8.8.8/cb") is None  # no opinion when off
+
+
+def test_in_allowlist_allowed_out_blocked():
+    security.set_callback_allowlist(["10.0.0.0/8", "100.64.0.0/10"])
+    assert security.is_enabled() is True
+    assert security.check_url("http://10.5.6.7/cb") is None       # in 10/8
+    assert security.check_url("https://100.64.1.1:8443/x") is None  # in tailnet
+    blocked = security.check_url("http://8.8.8.8/cb")             # public, not listed
+    assert blocked and "not in the callback allowlist" in blocked
+
+
+def test_non_http_and_malformed_rejected_when_enabled():
+    security.set_callback_allowlist(["10.0.0.0/8"])
+    assert "non-http" in (security.check_url("ftp://10.0.0.1/x") or "")
+    assert security.check_url("file:///etc/passwd")  # rejected (some error)
+
+
+def test_malformed_cidr_is_ignored():
+    security.set_callback_allowlist(["10.0.0.0/8", "not-a-cidr", ""])
+    assert security.allowlist() == ["10.0.0.0/8"]
+
+
+# ── config parse ────────────────────────────────────────────────────────────
+
+def test_config_parses_security_section(tmp_path):
+    p = tmp_path / "langgraph-config.yaml"
+    p.write_text("security:\n  callback_allowlist:\n    - 10.0.0.0/8\n    - 100.64.0.0/10\n")
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.security_callback_allowlist == ["10.0.0.0/8", "100.64.0.0/10"]
+
+
+def test_config_empty_security_section_tolerated(tmp_path):
+    # an all-commented / value-less `security:` parses to None — must not throw
+    p = tmp_path / "langgraph-config.yaml"
+    p.write_text("model:\n  provider: openai\nsecurity:\n")
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.security_callback_allowlist == []
+
+
+# ── push-callback integration (a2a_stores.is_safe_webhook_url) ──────────────
+
+def test_callback_default_denylist_when_allowlist_unset():
+    # unset → existing private-IP denylist holds; public is fine
+    assert a2a_stores.is_safe_webhook_url("http://10.0.0.1/cb") is False  # RFC1918 denied
+    assert a2a_stores.is_safe_webhook_url("http://8.8.8.8/cb") is True    # public ok
+
+
+def test_callback_allowlist_overrides_denylist_and_restricts():
+    security.set_callback_allowlist(["10.0.0.0/8"])
+    # in-allowlist private IP is now PERMITTED (allowlist overrides the denylist)
+    assert a2a_stores.is_safe_webhook_url("http://10.5.6.7/cb") is True
+    # a public IP NOT in the allowlist is now REJECTED (positive allowlist is the policy)
+    assert a2a_stores.is_safe_webhook_url("http://8.8.8.8/cb") is False

--- a/tools/peer_tools.py
+++ b/tools/peer_tools.py
@@ -101,6 +101,12 @@ def get_peer_tools() -> list:
         import httpx
 
         url = f"{base.rstrip('/')}/a2a"
+        # Opt-in SSRF/CIDR allowlist (#572): when configured, the peer must
+        # resolve into the allowlist. Unset ⇒ unrestricted (today's behavior).
+        import security
+        _blocked = security.check_url(url)
+        if _blocked:
+            return _blocked.replace("destination", f"peer {name!r}", 1)
         headers = {"Content-Type": "application/json"}
         if token:
             headers["Authorization"] = f"Bearer {token}"


### PR DESCRIPTION
Closes #572 — completes the #573 operator-fork contract (after #569/#570/#571). The roxy fork hardened two outbound POST paths with an SSRF/CIDR allowlist (push callbacks + peer_consult) as inline edits to upstream-owned files → conflicted every sync. Adopt it upstream as opt-in config.

## What
New security.py (mirrors egress.py): a positive CIDR allowlist driven by security.callback_allowlist, wired at startup + live reload. Applied at both outbound surfaces:
- push callbacks (a2a_stores.is_safe_webhook_url): when set, the allowlist IS the policy — allow iff the destination resolves entirely into it (overrides the default private-IP denylist so an operator can permit a specific internal range; rejects everything else).
- peer_consult (tools/peer_tools.py): currently UNGUARDED — now checked when the allowlist is set.

## Default posture (maintainer call: opt-in)
Empty/unset = today behavior EXACTLY — callbacks keep their existing private-IP denylist, peer_consult unrestricted (peer URLs are operator-configured env, often internal/tailnet, so a default denylist would break legit fleets). Forks/operators lock outbound to their fleet network via config, not code edits.

## Verification
- tests/test_security_allowlist.py — primitive (in/out of allowlist, non-http, malformed CIDR), config parse (+ empty-section tolerance), and the a2a_stores callback integration (unset=denylist; set=positive allowlist overrides + restricts).
- 1047 tests green (8 new); boot-smoked a throwaway (startup wiring runs clean).

Note the example config documents the seam (security.callback_allowlist).
