### PR TITLE
docs: tighten for server/ package + config-driven identity (post #569-#572)

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,8 @@ rename / release-pipeline wiring.
 
 | Concern | Where it lives | What it does |
 |---|---|---|
-| A2A server | `a2a_handler.py` | JSON-RPC 2.0 over `/a2a`, SSE streaming, `tasks/*` lifecycle, push notifications, well-known agent card, dual token-shape parsing |
-| Agent runtime | `graph/agent.py`, `server.py` | LangGraph `create_agent()` wired to the A2A handler, with streaming token capture for cost-v1 |
+| A2A server | `server/a2a.py`, `a2a_executor.py` | JSON-RPC 2.0 over `/a2a`, SSE streaming, `tasks/*` lifecycle, push notifications, well-known agent card, dual token-shape parsing |
+| Agent runtime | `graph/agent.py`, `server/` | LangGraph `create_agent()` wired to the A2A handler, with streaming token capture for cost-v1 |
 | LLM gateway | `graph/llm.py` | OpenAI-compatible client pointed at LiteLLM — swap models by editing the gateway config, not the fork |
 | Subagents | `graph/subagents/config.py` | DeerFlow-pattern delegation via a `task()` tool; one worked example ships — a `researcher` (web + memory, plan→search→synthesize→cite) |
 | Starter tools | `tools/lg_tools.py`, `tools/github_tools.py` | Default-on set: 4 keyless general (`current_time`, `calculator` safe AST eval, `web_search` via DuckDuckGo, `fetch_url`) + 2 HITL (`ask_human`, `request_user_input`) + 4 GitHub read tools over the `gh` CLI + 4 notes + 5 memory + 3 scheduler + 4 beads + inbox/peer (conditional). Drop any via `tools.disabled`; add via a plugin. See [Starter tools](./docs/reference/starter-tools.md) |
@@ -76,7 +76,7 @@ own GHCR: [Customize & deploy](./docs/guides/customize-and-deploy.md).
 
 ```
 ┌──────────────┐     A2A JSON-RPC + SSE      ┌─────────────────┐
-│   Consumer   │ ──────────────────────────▶ │  a2a_handler    │
+│   Consumer   │ ──────────────────────────▶ │  A2A handler    │
 │  (any A2A    │                             │  (FastAPI)      │
 │   client)    │ ◀──── cost-v1 DataPart ─────│                 │
 └──────────────┘                             └────────┬────────┘
@@ -108,9 +108,9 @@ subagent `task()` delegation, and the structured-output protocol.
 | `a2a.trace` propagation | No (it's a protocol convention, not a card extension) | Yes — reads caller's Langfuse trace context from `params.metadata["a2a.trace"]` and nests this agent's trace under it |
 
 Declare additional extensions on the card in
-`server.py::_build_agent_card` when your agent's skills actually
-mutate shared state (see `effect-domain-v1` in the Workstacean
-docs for when this applies).
+`server/a2a.py::_build_agent_card_proto` when your agent's skills
+actually mutate shared state (see `effect-domain-v1` in the
+Workstacean docs for when this applies).
 
 ## Push notification support
 
@@ -130,7 +130,7 @@ The A2A handler supports both token shapes the spec permits:
 Both produce `Authorization: Bearer shared-secret` on outgoing
 webhooks. If your fork is getting 401s on callbacks, check which
 shape the consumer is sending before changing anything —
-`_extract_push_token` in `a2a_handler.py` reads both and the
+the dual-token parser in `a2a_auth.py` reads both and the
 test suite covers both.
 
 ## Observability
@@ -212,6 +212,6 @@ complete end-to-end example and cron setup.
 ## Contributing
 
 This is a template repo — bugs and improvements to the shared
-runtime (`a2a_handler.py`, `graph/agent.py`, extension support,
-release pipeline) land here. Domain-specific agent logic lives
-in the fork, not here.
+runtime (the `server/` package, `graph/agent.py`, extension
+support, release pipeline) land here. Domain-specific agent logic
+lives in the fork, not here.

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -120,20 +120,29 @@ its own recursion budget.
 
 If your agent doesn't need the subagent pattern at all, delete
 the registry entry and call `create_agent_graph(config,
-include_subagents=False)` in `server.py`.
+include_subagents=False)` in `server/agent_init.py`.
 
-## 6. Rewrite the agent card
+## 6. Declare the agent card
 
-`server.py::_build_agent_card` has a placeholder card. Replace:
+Don't edit the card builder — its identity is config-driven
+(#570). Declare your `description` + `skills` in the `a2a:`
+section of `config/langgraph-config.yaml` (or contribute skills
+from a plugin via `register_a2a_skill`):
 
-- `name` and `description` with the agent's real surface
-- `skills` — each skill is what A2A callers dispatch to. IDs
-  should match what your tools can actually accomplish.
-- `capabilities.extensions` — declare any A2A extensions your
-  agent implements. `cost-v1` is declared by default because
-  the runtime emits it automatically; add `effect-domain-v1`
-  if your skills mutate shared state you want Workstacean's
-  planner to be aware of.
+```yaml
+a2a:
+  description: "What your agent does, in one line."
+  skills:
+    - id: my_skill        # what A2A callers dispatch to
+      name: My Skill
+      description: ...
+```
+
+- `name` already follows `identity.name` (the setup wizard).
+- `capabilities.extensions` — `cost-v1` is declared by default
+  (the runtime emits it automatically); add `effect-domain-v1`
+  in `server/a2a.py::_build_agent_card_proto` if your skills
+  mutate shared state Workstacean's planner should know about.
 
 ## 7. Set up the model
 
@@ -197,12 +206,12 @@ sqlite poller or a Workstacean adapter, selected at startup via env:
 
 ```bash
 # Default: local sqlite, persists at /sandbox/scheduler/<agent_name>/jobs.db
-python server.py
+python -m server
 
 # Workstacean: set both and restart
 export WORKSTACEAN_API_BASE=http://your-workstacean:3000
 export WORKSTACEAN_API_KEY=...
-python server.py
+python -m server
 ```
 
 Multi-fork safety: every job is namespaced by `AGENT_NAME`, so

--- a/docs/explanation/a2a-protocol.md
+++ b/docs/explanation/a2a-protocol.md
@@ -72,7 +72,7 @@ A webhook URL is an outbound HTTP call this agent makes with a shared secret att
 
 ...the agent would happily POST task payloads (potentially with `Authorization: Bearer <secret>`) to any of them.
 
-`_is_safe_webhook_url` in `a2a_handler.py` resolves the URL's hostname once and rejects anything that lands in a private range. It's not a full DNS-rebinding defence, but it closes the "just use an RFC1918 literal" vector. Operator allowlists (`PUSH_NOTIFICATION_ALLOWED_HOSTS`) bypass the check for trusted docker-network targets that would otherwise fail.
+`is_safe_webhook_url` in `a2a_stores.py` resolves the URL's hostname once and rejects anything that lands in a private range. It's not a full DNS-rebinding defence, but it closes the "just use an RFC1918 literal" vector. Operator allowlists (`PUSH_NOTIFICATION_ALLOWED_HOSTS`) bypass the check for trusted docker-network targets that would otherwise fail.
 
 ## Task lifecycle
 

--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -4,14 +4,14 @@
 
 ```
 ┌──────────────┐     A2A JSON-RPC + SSE      ┌──────────────────┐
-│   Consumer   │ ──────────────────────────▶ │  a2a_handler.py  │
+│   Consumer   │ ──────────────────────────▶ │  A2A handler     │
 │  (any A2A    │                             │  (FastAPI app)   │
 │   client)    │ ◀──── cost-v1 DataPart ─────│                  │
 └──────────────┘                             └────────┬─────────┘
                                                       │ submits message
                                                       ▼
                                             ┌──────────────────┐
-                                            │  server.py       │
+                                            │  server/chat.py  │
                                             │  _chat_langgraph │
                                             │  _stream         │
                                             └────────┬─────────┘
@@ -47,7 +47,7 @@ A2A is a protocol, not a library. The handler owns:
 The LangGraph runtime has no idea any of this exists. It sees a message, runs a tool loop, produces output. That means:
 
 - If LangGraph's API changes, the A2A handler doesn't break.
-- If A2A's spec changes, only this file changes.
+- If A2A's spec changes, only this layer changes (the `server/a2a.py` + `a2a_executor.py` + `a2a_stores.py` modules).
 - Tests for the protocol are isolated from tests for the agent.
 
 ## Why LangGraph owns the tool loop
@@ -82,7 +82,7 @@ Memory is **enabled by default** (`middleware.memory: true` in `langgraph-config
 
 Three independent layers defend the A2A surface. Each can be enabled or left open for local dev, but production forks should enable all three.
 
-**Bearer authentication** — `a2a_handler.py` reads `A2A_AUTH_TOKEN` at startup. When set, every A2A route (`/a2a`, `message/send`, `tasks/*`, and SSE streaming endpoints) requires `Authorization: Bearer <token>`. Comparison uses `hmac.compare_digest` so timing analysis can't leak the token. When set, the agent card advertises `securitySchemes.bearer` so consumers know to present credentials.
+**Bearer authentication** — `a2a_auth.py` reads `A2A_AUTH_TOKEN` at startup. When set, every A2A route (`/a2a`, `message/send`, `tasks/*`, and SSE streaming endpoints) requires `Authorization: Bearer <token>`. Comparison uses `hmac.compare_digest` so timing analysis can't leak the token. When set, the agent card advertises `securitySchemes.bearer` so consumers know to present credentials.
 
 **Audit redaction** — `graph/middleware/redaction.py` scrubs credentials before anything is written to `audit.jsonl` or emitted as a Langfuse span attribute. Patterns covered: `Authorization: Bearer ...`, OpenAI-style `sk-...` keys, generic `api_key=...` forms, and nested dicts keyed by well-known env var names (`OPENAI_API_KEY`, `LANGFUSE_SECRET_KEY`, `A2A_AUTH_TOKEN`, etc.). This closes the class of bugs where a tool returns a secret in its payload and it leaks into the audit trail or trace.
 
@@ -115,7 +115,7 @@ Beyond the shipped tools, three opt-in seams add capability to a *running* agent
 
 - **Tools enter via one list.** `create_agent_graph` assembles `get_all_tools()` (built-in) plus an `extra_tools` argument, then hands the combined set to the LangGraph loop. Both external sources below feed `extra_tools`, so they're indistinguishable to the model and inherit the same Audit/Langfuse middleware.
 - **MCP** (`tools/mcp_tools.py`) — configured [Model Context Protocol](/guides/mcp) servers (stdio / streamable-HTTP) are connected via `langchain-mcp-adapters`; their tools are discovered at graph-build time, namespaced `<server>__<tool>`, and appended to `extra_tools`. The client is stateless (a fresh session per call), so discovery happens once and tools are event-loop-agnostic.
-- **Plugins** (`graph/plugins/`: `loader`, `registry`, `manifest`, `host`, `pconfig`) — drop-in packages (`protoagent.plugin.yaml` + `register(registry)`) that contribute, via the registry, **tools** (→ `extra_tools`), bundled **`SKILL.md`** dirs (→ the skill index), FastAPI **routers** (mounted under `/plugins/<id>`), background **surfaces** (lifecycle-managed ingress like the Discord gateway), **subagents** (→ `SUBAGENT_REGISTRY`), and managed **MCP servers** (→ `mcp.servers[]` factory), plus their own **config / secrets / Settings** claimed as a top-level YAML section (ADR 0018/0019). A surface/route reaches the agent + event bus + live config via the plugin **host** (`registry.host`: `invoke` / `publish` / `subscribe` / `config` / `apply_settings`). They run **in-process** with the agent's privileges, so a third-party plugin is disabled by default. The first-party **Discord** ingress (`plugins/discord`, a surface + route + tools) and **Google** Gmail/Calendar integration (`plugins/google`, a managed MCP server + route) ship this way — they are **not** wired in `server.py`. See [Plugins](/guides/plugins).
+- **Plugins** (`graph/plugins/`: `loader`, `registry`, `manifest`, `host`, `pconfig`) — drop-in packages (`protoagent.plugin.yaml` + `register(registry)`) that contribute, via the registry, **tools** (→ `extra_tools`), bundled **`SKILL.md`** dirs (→ the skill index), FastAPI **routers** (mounted under `/plugins/<id>`), background **surfaces** (lifecycle-managed ingress like the Discord gateway), **subagents** (→ `SUBAGENT_REGISTRY`), and managed **MCP servers** (→ `mcp.servers[]` factory), plus their own **config / secrets / Settings** claimed as a top-level YAML section (ADR 0018/0019). A surface/route reaches the agent + event bus + live config via the plugin **host** (`registry.host`: `invoke` / `publish` / `subscribe` / `config` / `apply_settings`). They run **in-process** with the agent's privileges, so a third-party plugin is disabled by default. The first-party **Discord** ingress (`plugins/discord`, a surface + route + tools) and **Google** Gmail/Calendar integration (`plugins/google`, a managed MCP server + route) ship this way — they are **not** wired into the core `server/` package. See [Plugins](/guides/plugins).
 
 All are surfaced in `GET /api/runtime/status` (`skills`, `mcp`, `plugins` — with per-plugin route/surface/subagent counts) and load best-effort — a bad skill/server/plugin is logged and skipped, never fatal. Untrusted third-party tools belong on MCP (out-of-process) rather than in-process plugins.
 
@@ -125,7 +125,7 @@ See [LiteLLM gateway](/explanation/litellm-gateway) for the full rationale. The 
 
 ## Why streaming specifically this way
 
-`_chat_langgraph_stream` in `server.py` consumes `astream_events(v2)` and yields structured frames: `tool_start`, `tool_end`, `usage`, `done`. The A2A handler then translates those into A2A SSE frames.
+`_chat_langgraph_stream` in `server/chat.py` consumes `astream_events(v2)` and yields structured frames: `tool_start`, `tool_end`, `usage`, `done`. The A2A executor (`a2a_executor.py`) then translates those into A2A SSE frames.
 
 This extra layer of indirection exists because:
 

--- a/docs/explanation/cost-and-trace.md
+++ b/docs/explanation/cost-and-trace.md
@@ -75,7 +75,7 @@ Agent A stamps its current Langfuse context into the outbound A2A request:
 }
 ```
 
-Agent B reads this in `a2a_handler.py`, opens its own trace, and stamps `caller_trace_id=abc123`, `caller_span_id=def456` into that trace's metadata.
+Agent B reads this in `server/chat.py`, opens its own trace, and stamps `caller_trace_id=abc123`, `caller_span_id=def456` into that trace's metadata.
 
 An operator looking at Agent A's Langfuse trace can copy the trace ID and search Agent B (and C, D, …) by `metadata.caller_trace_id == abc123` to find every downstream trace that branched off.
 

--- a/docs/guides/add-a-skill.md
+++ b/docs/guides/add-a-skill.md
@@ -10,31 +10,22 @@ A *skill* is a named capability A2A callers can dispatch to. Skills live on the 
 
 You don't need a skill for "things the chat UI does" — the Gradio chat is already covered by the default dispatch path.
 
-## 1. Add to the card
+## 1. Declare it in config
 
-Edit the `_SKILL_SPECS` list in `server.py` (the card builder `_build_agent_card_proto` turns it into the card's `skills` via `_agent_skills()`). Each spec is a dict — this is where entries go:
+Card skills are config-driven ([#570](/reference/configuration#a2a)) — declare them in the `a2a:` section of `config/langgraph-config.yaml`, **not** by editing `server/a2a.py`. Each entry is a spec:
 
-```python
-"skills": [
-    {
-        "id": "chat",
-        "name": "Chat",
-        "description": "General-purpose chat interface.",
-        "tags": ["template"],
-        "examples": ["hello", "what can you do?"],
-    },
-    # ↓ new skill
-    {
-        "id": "summarize_pr",
-        "name": "Summarize Pull Request",
-        "description": "Fetch a GitHub PR and return a three-bullet summary of what it changes and why.",
-        "tags": ["github", "summarization"],
-        "examples": [
-            "summarize https://github.com/protoLabsAI/protoAgent/pull/64",
-        ],
-    },
-],
+```yaml
+a2a:
+  skills:
+    - id: summarize_pr
+      name: Summarize Pull Request
+      description: Fetch a GitHub PR and return a three-bullet summary of what it changes and why.
+      tags: [github, summarization]
+      examples:
+        - "summarize https://github.com/protoLabsAI/protoAgent/pull/64"
 ```
+
+The server merges these (plus any contributed by plugins via `register_a2a_skill`) and falls back to the template's `chat` placeholder when none are set. A plugin can ship card skills the same way — `registry.register_a2a_skill(spec)` — so a distributable extension carries its own advertised capabilities.
 
 **IDs are sticky**. `cost-v1` samples, `effect-domain-v1` declarations, and Workstacean's routing all key off the `id`. Pick one and don't rename later.
 
@@ -114,13 +105,13 @@ curl -X POST http://localhost:7870/a2a \
 
 ## 5. Test it
 
-Add to `tests/test_a2a_integration.py`:
+Assert your config declares the skill (it flows to the card via `_resolved_skill_specs`):
 
 ```python
-def test_agent_card_includes_summarize_pr_skill():
-    from server import _SKILL_SPECS
-    skill_ids = {s["id"] for s in _SKILL_SPECS}
-    assert "summarize_pr" in skill_ids
+def test_config_advertises_summarize_pr():
+    from graph.config import LangGraphConfig
+    cfg = LangGraphConfig.from_yaml("config/langgraph-config.yaml")
+    assert "summarize_pr" in {s["id"] for s in cfg.a2a_skills}
 ```
 
 ## Related

--- a/docs/guides/discord.md
+++ b/docs/guides/discord.md
@@ -85,7 +85,7 @@ GUILD_MESSAGE_REACTIONS | DIRECT_MESSAGES | MESSAGE_CONTENT`.
 Discord ships as a **first-party plugin** (`plugins/discord/`, ADR 0018/0019) —
 the gateway, the `test-discord` route, the outbound tools, and this `discord`
 config section are all declared by `plugins/discord/protoagent.plugin.yaml`, not
-wired in `server.py`. Disable it entirely with `plugins: { disabled: [discord] }`,
+wired into the core `server/` package. Disable it entirely with `plugins: { disabled: [discord] }`,
 or replace it with your own ingress plugin — no core edit. See [Plugins](./plugins.md).
 
 The token, admin list, and on/off toggle are set **in the app** (Settings →

--- a/docs/guides/fork-the-template.md
+++ b/docs/guides/fork-the-template.md
@@ -67,7 +67,7 @@ See the [starter tools reference](/reference/starter-tools) for the shapes of th
 `graph/subagents/config.py` ships with one `researcher`. Either:
 
 - Add more by registering `SubagentConfig` instances in `SUBAGENT_REGISTRY` and matching fields in `graph/config.py::LangGraphConfig`, or
-- Call `create_agent_graph(config, include_subagents=False)` in `server.py::_init_langgraph_agent()` to skip subagents entirely.
+- Call `create_agent_graph(config, include_subagents=False)` in `server/agent_init.py::_init_langgraph_agent()` to skip subagents entirely.
 
 See [Configure subagents](/guides/subagents) for the full pattern.
 

--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -19,7 +19,7 @@ It's modelled on protocli's goal system but deliberately more rigorous for a lon
 4. **Not met** → the controller extracts/refreshes the agent's `<goal_plan>` checklist, then re-invokes the agent on the same thread (history preserved) with a continuation prompt that includes the verifier's reason + evidence and the current plan.
 5. This repeats until met, the **iteration budget** (`goal.max_iterations`) is spent (`exhausted`), the verifier returns the **same evidence too many times** (`goal.no_progress_limit` → `unachievable`), or the agent itself emits `<goal_unachievable reason="…"/>` (`unachievable`).
 
-The loop wraps graph invocation in `server.py` (both the A2A streaming path and the non-streaming chat path); the graph itself is unchanged.
+The loop wraps graph invocation in `server/chat.py` (both the A2A streaming path and the non-streaming chat path); the graph itself is unchanged.
 
 ## Setting a goal
 

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -59,24 +59,28 @@ def register(registry):
 ```
 
 `register` is called once at load. The registry accepts **six** contribution
-types — a fork adds any of them as a plugin, never editing core `server.py`:
+types — a fork adds any of them as a plugin, never editing the core `server/` package:
 
 | Method | Contributes | Lifecycle |
 |---|---|---|
 | `register_tool(tool)` / `register_tools(iter)` | A LangChain tool | graph build (live-reloads) |
-| `register_skill_dir(path)` | A `SKILL.md` directory | graph build |
+| `register_skill_dir(path)` | A `SKILL.md` directory (procedural memory) | graph build |
+| `register_a2a_skill(spec)` | An A2A **card** skill (what the card advertises; optional structured output) | agent-card build |
 | `register_router(router, prefix=None)` | A FastAPI `APIRouter` | **mounted once** at init (default prefix `/plugins/<id>`) |
 | `register_surface(start, stop=None, name=None, reload=None)` | A background surface (a Discord-style gateway) | `start` in startup, `stop` in shutdown, `reload(cfg)` on config save |
 | `register_subagent(config)` | A `SubagentConfig` (a delegate) | added to `SUBAGENT_REGISTRY` |
 | `register_mcp_server(factory)` | A **managed MCP server** the agent connects to | `factory(config)` called at each graph build → entry dict or `None` |
+| `register_thread_id_resolver(fn)` | A `(request_metadata, session_id) → str` checkpointer-scope resolver (e.g. per-project memory) | each turn; one wins (last plugin) |
 
 ```python
 def register(registry):
     registry.register_tool(hello)
+    registry.register_a2a_skill({"id": "greet", "name": "Greet", "description": "..."})
     registry.register_router(_build_router())        # → GET /plugins/<id>/...
     registry.register_surface(_start, stop=_stop, name="my-surface")
     registry.register_subagent(_build_subagent())    # delegate via task/task_batch
     registry.register_mcp_server(_server_factory)    # a managed MCP server (e.g. Google)
+    registry.register_thread_id_resolver(lambda md, sid: f"proj:{md.get('project')}:{sid}")
 ```
 
 ### Managed MCP servers — `register_mcp_server`

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -100,7 +100,7 @@ apps/web/                     React + Vite operator console
   src/subagents/              manual subagent launcher
   src/lib/api.ts              FastAPI/A2A client
 
-server.py                     FastAPI API + static React asset serving
+server/                       FastAPI API + static React asset serving
 graph/agent.py                LangGraph lead + subagent runtime
 src-tauri/                    Tauri shell after web app works
 ```
@@ -117,7 +117,7 @@ npm run web:build
 npm run web:preview
 ```
 
-The built app lives under `apps/web/dist/`. `server.py` serves it at `/app`
+The built app lives under `apps/web/dist/`. the `server/` package serves it at `/app`
 when that directory contains `index.html`; otherwise the server boots without
 mounting the React surface.
 

--- a/docs/guides/scheduler.md
+++ b/docs/guides/scheduler.md
@@ -32,7 +32,7 @@ not "do that thing we discussed").
 
 ## Backend selection
 
-`server.py::_build_scheduler` picks at startup:
+`server/agent_init.py::_build_scheduler` picks at startup:
 
 1. `middleware.scheduler: false` in YAML → no scheduler. The three
    tools don't ship. (Symmetric with `middleware.knowledge` /

--- a/docs/guides/subagents.md
+++ b/docs/guides/subagents.md
@@ -130,7 +130,7 @@ question. Handle short factual queries yourself.
 
 ## 5. Turn subagents off entirely
 
-If your agent is simple enough that subagents are pure overhead, flip `include_subagents=False` when the graph is built. In `server.py::_init_langgraph_agent`:
+If your agent is simple enough that subagents are pure overhead, flip `include_subagents=False` when the graph is built. In `server/agent_init.py::_init_langgraph_agent`:
 
 ```python
 _graph = create_agent_graph(

--- a/docs/reference/agent-card.md
+++ b/docs/reference/agent-card.md
@@ -1,6 +1,6 @@
 # Agent card
 
-Served at `/.well-known/agent-card.json` and `/.well-known/agent.json`. Built by `server.py::_build_agent_card_proto` (which assembles it via `protolabs_a2a.build_agent_card`; skills come from `_SKILL_SPECS` / `_agent_skills()`).
+Served at `/.well-known/agent-card.json` and `/.well-known/agent.json`. Built by `server/a2a.py::_build_agent_card_proto` (which assembles it via `protolabs_a2a.build_agent_card`). Its identity is **config/plugin-driven** ([#570](configuration.md#a2a)) — `name` from `identity.name`, `description` + `skills` from the `a2a:` config section or `register_a2a_skill`, so a fork declares its card without editing the package.
 
 ## Full shape
 
@@ -57,8 +57,9 @@ The card is the **A2A 1.0** (`a2a-sdk` proto) shape, assembled by
 
 > The `provider` block, the four `capabilities.extensions`, and the
 > `securitySchemes` / `securityRequirements` shapes are owned by
-> `protolabs_a2a` (not editable per-fork in `server.py`). Fork the `name`,
-> `description`, `version`, and `skills`.
+> `protolabs_a2a` (not editable per-fork). Customize `name` (`identity.name`),
+> `description` + `skills` (the [`a2a:`](configuration.md#a2a) config section or
+> `register_a2a_skill`), and `version` (your `pyproject`).
 
 ## Field reference
 
@@ -133,12 +134,12 @@ card *also* declares a `bearer` scheme (`{"httpAuthSecurityScheme": {"scheme":
 consumer reading the card learns bearer is accepted, not just `apiKey`. (Both
 shapes come from `protolabs_a2a.security_schemes(bearer=…)`.)
 
-## Fork this file
+## Customize (no core edit)
 
-The card lives in `server.py::_build_agent_card_proto`. The template declares four custom extensions by default — **cost** / **confidence** / **worldstate-delta** / **tool-call** (the URIs come from `protolabs_a2a`; see [Extensions](/reference/extensions)). At a minimum, every fork should replace:
+The card is assembled in `server/a2a.py::_build_agent_card_proto`, but you **don't edit it** — identity is config/plugin-driven ([#570](configuration.md#a2a)). The template declares four custom extensions by default — **cost** / **confidence** / **worldstate-delta** / **tool-call** (the URIs come from `protolabs_a2a`; see [Extensions](/reference/extensions)). At a minimum, every fork sets:
 
-- `name` + `description`
-- `skills` (sourced from `_SKILL_SPECS` / `_agent_skills()` — add your real ones)
+- `name` → `identity.name` (the setup wizard sets it)
+- `description` + `skills` → the [`a2a:`](configuration.md#a2a) config section (or a plugin's `register_a2a_skill`)
 
 ## Related
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -281,6 +281,21 @@ egress:
 
 Covers `fetch_url` only; `execute_code`/`run_command` process-level egress is fenced by running under OpenShell (see [Sandboxing & egress](../guides/sandboxing.md)).
 
+## `security`
+
+Opt-in CIDR allowlist for the outbound A2A destinations the agent POSTs to — push-notification **callbacks** (caller-supplied webhook URLs) and **`peer_consult`** (`PEER_<HANDLE>_URL`). Empty/unset = today's behavior: callbacks keep their default private-IP denylist (`a2a_stores`), `peer_consult` is unrestricted.
+
+```yaml
+security:
+  callback_allowlist:
+    - 100.64.0.0/10   # tailnet
+    - 10.0.0.0/8      # private fleet
+```
+
+| Key | Default | What |
+|---|---|---|
+| `callback_allowlist` | `[]` | CIDRs an outbound callback / peer destination may resolve into. **Empty = off.** When set it becomes the policy: a destination is allowed iff **every** resolved IP is inside a listed range (overrides the default callback denylist, so you can permit a specific internal/tailnet range; everything else is rejected). Hot-reloads. |
+
 ## `routing`
 
 Wires langchain's `ModelFallbackMiddleware`: on a primary-model error, retry on each fallback model (same gateway) in order. Opt-in (empty = no fallback). `aux_model` is a separate, optional cheap/fast alias for non-reasoning calls.
@@ -355,6 +370,29 @@ Human-authored skills in the AgentSkills [`SKILL.md`](../guides/skills.md) forma
 | `dir` | `""` | Optional override for the *writable* skills root. Default: `<config-dir>/skills` (where `<config-dir>` honors `PROTOAGENT_CONFIG_DIR`). |
 
 Skills load from two roots — bundled (`config/skills/`, shipped) and writable (`<config-dir>/skills/`, your drop-ins); live skills override bundled ones by `name`. `GET /api/runtime/status` reports `skills.count`. See the [Skills guide](../guides/skills.md) for authoring.
+
+## `a2a`
+
+Your fork's **A2A [agent card](agent-card.md) identity** — the advertised skills and description a caller sees. Declare them here (or contribute card skills from a plugin via `register_a2a_skill`) instead of editing `server/a2a.py`. Distinct from `skills` above: those are disk `SKILL.md` *procedural memory* retrieved at inference; these are what the *card* advertises. Omit both keys and the template ships one free-text `chat` placeholder so a fresh clone stays callable. The card `name` follows `identity.name` / `AGENT_NAME`.
+
+```yaml
+a2a:
+  description: "Acme Bot — turns support tickets into triaged, drafted replies."
+  skills:
+    - id: triage_ticket
+      name: Triage Ticket
+      description: Classify a support ticket and draft a reply.
+      tags: [support]
+      examples: ["triage ticket #1234"]
+      # Optional structured output — enforced + emitted as a typed DataPart (#476):
+      # result_mime: application/vnd.protolabs.triage-v1+json
+      # output_schema: { type: object, properties: { ... }, required: [ ... ] }
+```
+
+| Key | Default | What |
+|---|---|---|
+| `description` | template placeholder | The agent card's `description`. |
+| `skills` | one `chat` placeholder | Advertised `AgentSkill`s (`id`/`name`/`description` + optional `tags`/`examples`). A skill declaring `result_mime` + `output_schema` returns schema-enforced structured output as a typed DataPart ([#476](agent-card.md)); the MIME is advertised in its `output_modes`. |
 
 ## `mcp`
 

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -67,7 +67,7 @@ Declares the **scope of effect** of each skill so a consumer can gate higher-imp
 }
 ```
 
-Purely declarative — keep the declared radius honest with what each skill handler actually does. Uncomment the stanza in `server.py::_build_agent_card` and use your real skill IDs.
+Purely declarative — keep the declared radius honest with what each skill handler actually does. Uncomment the stanza in `server/a2a.py::_build_agent_card_proto` and use your real skill IDs.
 
 ## `hitl-mode-v1`
 
@@ -121,7 +121,7 @@ Fields:
 
 Only declare effects that actually mutate shared state. Over-declaring confuses the planner into routing your agent for goals it can't move.
 
-**Pair with runtime emission**: if you declare an effect, emit a matching `worldstate-delta-v1` DataPart when the tool succeeds at runtime (see `a2a_handler.py::TaskRecord.world_deltas`). Divergence between declared and observed mutations breaks the planner's scoring model.
+**Pair with runtime emission**: if you declare an effect, emit a matching `worldstate-delta-v1` DataPart when the tool succeeds at runtime — yield a `delta` event from the tool and the executor (`a2a_executor.py`) accumulates them onto the terminal artifact. Divergence between declared and observed mutations breaks the planner's scoring model.
 
 See `docs/extensions/effect-domain-v1` in the [protoWorkstacean repo](https://github.com/protoLabsAI/protoWorkstacean) for the full spec.
 
@@ -147,7 +147,7 @@ Emitted as a DataPart on the terminal artifact:
 }
 ```
 
-The template doesn't emit this by default because the shipped tools don't mutate anything. See `a2a_handler.py::TaskRecord.add_delta` for where to hook in.
+The template doesn't emit this by default because the shipped tools don't mutate anything. To hook in, yield a `("delta", {domain, path, op, value})` event from your tool; `a2a_executor.py` collects them into the artifact.
 
 ## `tool-call-v1`
 
@@ -180,7 +180,7 @@ Fields:
 | `input` | Truncated preview of the tool input (on `start`). Structured inputs (dict/list) are rendered as **compact JSON** so the console can pretty-print them; everything else is stringified. |
 | `output` | Truncated preview of the tool result (on `end`). Unwrapped from langchain's `ToolMessage` to its `.content` — the message repr would otherwise leak `name=`/`tool_call_id=` noise into the card. |
 
-**Producer** — `server.py::_run_turn_stream` yields structured `("tool_start"|"tool_end", {...})` tuples from langchain's `astream_events`. Inputs/outputs are coerced via `_coerce_tool_value` / `_coerce_tool_output` (JSON for structured values, `.content` for `ToolMessage`s) and truncated to `_TOOL_PREVIEW_CHARS`. The runner stores the latest on `TaskRecord.last_tool_event` and `_build_status_event` attaches it alongside the existing text status part (`🔧 name: input` / `✅ name → output`), so text-only consumers still see progress — the DataPart is purely additive and backward-compatible.
+**Producer** — `server/chat.py::_run_turn_stream` yields structured `("tool_start"|"tool_end", {...})` tuples from langchain's `astream_events`. Inputs/outputs are coerced via `_coerce_tool_value` / `_coerce_tool_output` (JSON for structured values, `.content` for `ToolMessage`s) and truncated to `_TOOL_PREVIEW_CHARS`. The runner stores the latest on `TaskRecord.last_tool_event` and `_build_status_event` attaches it alongside the existing text status part (`🔧 name: input` / `✅ name → output`), so text-only consumers still see progress — the DataPart is purely additive and backward-compatible.
 
 **Coalescing caveat** — the SSE watcher (`_watch_task`) coalesces bursts of updates, so a tool that starts and ends within a single event-loop tick may only surface one frame. Real tools are slow enough (network, I/O) that `start` and `end` land on separate frames. Consumers must tolerate a missing `start` (render the `end` as a completed card) and dedupe by `(id, phase)`.
 
@@ -220,7 +220,7 @@ Fields:
 | `created_at` | UTC ISO timestamp |
 | `source_session_id` | Provenance — which session produced the artifact |
 
-**Collection** — `a2a_handler.py` reads skills from the `_pending_skills` ContextVar at task completion and appends them as DataParts. Agents and middleware never access the ContextVar directly; they use `emit_skill_artifact()` to add and `get_pending_skills()` to read.
+**Collection** — an emitted skill is serialized by `graph/extensions/skills.py` and surfaced to A2A consumers as a DataPart on the terminal artifact (alongside being persisted to the local index). The mimeType is the contract.
 
 **Indexing** — protoAgent's own `SkillsIndex` (`graph/skills/index.py`) at `/sandbox/skills.db` picks these up on the next sweep and makes them retrievable by `KnowledgeMiddleware.load_skills(query)`. Consumers running their own skill registries can index the DataParts from the A2A stream directly — the mimeType is the contract.
 
@@ -251,11 +251,11 @@ When the caller stamps their trace context:
 }
 ```
 
-The agent reads it in `a2a_handler.py` and stamps `caller_trace_id` + `caller_span_id` into its own Langfuse trace metadata. Operators can then filter Langfuse by `metadata.caller_trace_id` to find every agent trace spawned from a single dispatch.
+The agent reads it in `server/chat.py` and stamps `caller_trace_id` + `caller_span_id` into its own Langfuse trace metadata. Operators can then filter Langfuse by `metadata.caller_trace_id` to find every agent trace spawned from a single dispatch.
 
 ## Adding a new extension
 
-1. Emit or parse in `a2a_handler.py` / `server.py`.
+1. Emit or parse in `a2a_executor.py` / `server/chat.py`.
 2. Declare on the card under `capabilities.extensions` with a URI consumers agree on.
 3. Document the shape in this file.
 4. Add a test to `tests/test_a2a_integration.py` asserting the declaration is present on the card.

--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -8,11 +8,11 @@ The default tool set (from `tools/lg_tools.py::get_all_tools`):
 - Four **notes tools** — `notes_list`, `notes_read`, `notes_write`, `notes_revert` — bridge the operator console's Notes panel tabs to the agent (one agent-global notebook), gated per-tab by the operator's Agent-read/write toggles; writes are versioned (undoable) and surface live in the panel.
 - Five **memory tools** — `memory_ingest`, `memory_recall`, `memory_list`, `memory_stats`, `daily_log` — bound to the bundled `KnowledgeStore` (sqlite + FTS5, see [Configuration](/reference/configuration#knowledge)). Omitted when no store.
 - Three **scheduler tools** — `schedule_task`, `list_schedules`, `cancel_schedule` — bound to the bundled scheduler backend (local sqlite or the Workstacean adapter, see [Schedule future work](/guides/scheduler)). Omitted when no scheduler.
-- Four **beads tools** — `beads_create`, `beads_list`, `beads_update`, `beads_close` — the agent's in-process planning board, bridged to the console Beads panel. Bound when a beads store is present (default in `server.py`).
+- Four **beads tools** — `beads_create`, `beads_list`, `beads_update`, `beads_close` — the agent's in-process planning board, bridged to the console Beads panel. Bound when a beads store is present (default in `server/agent_init.py`).
 - One **inbox tool** — `check_inbox` — bound to the durable inbound inbox (ADR 0003) when configured; pulls stimuli pushed to `POST /api/inbox`.
 - **Peer-consult tools** (`peer_list` / `peer_consult`) — added only when at least one `PEER_<HANDLE>_URL` is set (A2A federation).
 
-`get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, beads_store=None)` is the registry; the conditional groups above are included only when their backend is passed (all are constructed by default in `server.py`; opt out via `middleware.knowledge: false` / `middleware.scheduler: false`). To **drop** a core tool without editing this function, list it in `tools.disabled`; to **add** tools, ship a [plugin](/guides/plugins) (`register_tools`) — editing `get_all_tools` is the legacy core-edit path that conflicts on re-sync.
+`get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, beads_store=None)` is the registry; the conditional groups above are included only when their backend is passed (all are constructed by default in `server/agent_init.py`; opt out via `middleware.knowledge: false` / `middleware.scheduler: false`). To **drop** a core tool without editing this function, list it in `tools.disabled`; to **add** tools, ship a [plugin](/guides/plugins) (`register_tools`) — editing `get_all_tools` is the legacy core-edit path that conflicts on re-sync.
 
 ## `current_time`
 


### PR DESCRIPTION
A docs + README tightening sweep — bringing the prose in line with the ADR-0023 `server/` decomposition and the #570-#572 operator-fork seams (17 files, +130/-87).

## New / corrected reference
- **configuration.md**: new `a2a` (skills + description, #570) and `security` (`callback_allowlist`, #572) sections.
- **plugins.md**: hooks table + example gain `register_a2a_skill` and `register_thread_id_resolver`.
- **agent-card.md** / **add-a-skill.md** / **TEMPLATE.md**: rewritten to the config-driven card — declare `a2a.skills` / `register_a2a_skill`, do not edit `server/a2a.py`. Fixed the add-a-skill test example (imported the now-gone `_SKILL_SPECS`).

## Staleness fixed
- `server.py` → `server/` package across every living guide/reference (module paths point at `server/agent_init.py` / `server/chat.py` / `server/a2a.py`).
- **BROKEN command**: `python server.py` → `python -m server` in TEMPLATE.md.
- `a2a_handler.py` (deleted in the A2A 1.0 migration) re-pointed to its real homes — `a2a_auth.py` (bearer/token), `a2a_stores.py` (webhook SSRF), `a2a_executor.py` (worldstate-delta), `server/chat.py` (caller-trace); diagram boxes relabeled to the conceptual "A2A handler". Dropped references to removed internals (`TaskRecord.world_deltas`, `_pending_skills` ContextVar).

Docs build green; **no code touched**.
