### PR TITLE
fix(deploy): launch server/ package not deleted server.py (+ CI guard)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -34,6 +34,19 @@ jobs:
           git clone --depth 1 \
             https://github.com/protoLabsAI/release-tools /tmp/release-tools
           node /tmp/release-tools/bin/verify-workspace-config.mjs --root "$GITHUB_WORKSPACE"
+      - name: Guard against the deleted server.py entrypoint
+        # ADR 0023 promoted the monolith to the server/ package (launch:
+        # `python -m server`). A deploy file launching the old single-file binary
+        # CrashLoopBackOffs. Fail CI if any deploy artifact still does. Scoped to
+        # deploy surfaces (excludes .github so this guard can't match itself).
+        run: |
+          if grep -rnE 'python[0-9]* +server\.py' \
+               --include='*.sh' --include='*.yaml' --include='*.yml' \
+               --include='Dockerfile*' --exclude-dir=.github . ; then
+            echo "::error::Stale single-file launch found — use 'python -m server' (ADR 0023)."
+            exit 1
+          fi
+          echo "ok: no stale single-file launches in deploy artifacts"
 
   tests:
     name: Python tests

--- a/deploy/openshell/create-protoagent-sandbox.sh
+++ b/deploy/openshell/create-protoagent-sandbox.sh
@@ -34,6 +34,6 @@ openshell sandbox create \
   --image "$IMAGE" \
   --publish "127.0.0.1:${PORT}:7870" \
   --mount "$CONFIG:/sandbox/config/langgraph-config.yaml:ro" \
-  -- python server.py --port 7870 --ui none
+  -- python -m server --port 7870 --ui none   # server.py is now the server/ package (ADR 0023); PYTHONPATH baked in the image
 
 echo "✓ protoAgent sandbox created. Inspect: openshell sandbox list"

--- a/deploy/openshell/k8s/protoagent-sandbox.yaml
+++ b/deploy/openshell/k8s/protoagent-sandbox.yaml
@@ -27,7 +27,9 @@ spec:
       containers:
         - name: protoagent
           image: ghcr.io/protolabsai/protoagent:latest
-          command: ["python", "server.py", "--port", "7870", "--ui", "none"]  # lean headless tier (ADR 0010)
+          # server.py is now the server/ package (ADR 0023) — launch as a module.
+          # PYTHONPATH=/opt/protoagent is baked as an image ENV so it survives this override.
+          command: ["python", "-m", "server", "--port", "7870", "--ui", "none"]  # lean headless tier (ADR 0010)
           ports:
             - containerPort: 7870
           env:


### PR DESCRIPTION
Prod-readiness audit **P0**. The k8s manifest (`deploy/openshell/k8s/protoagent-sandbox.yaml:30`) and the sandbox-create script (`create-protoagent-sandbox.sh:37`) still launched `python server.py` — deleted in ADR 0023 (now the `server/` package). That exits immediately → **CrashLoopBackOff** on any k8s/OpenShell deploy.

- Both switched to `python -m server …` (`PYTHONPATH=/opt/protoagent` is a baked image ENV, so it survives the `command:` override — same form as the smoke-tested launch).
- New **CI guard** in `checks.yml` fails on any `python server.py` invocation in scripts/manifests/Dockerfiles so it can't regress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)