### PR TITLE
security: default-bind 127.0.0.1; containers expose 0.0.0.0 explicitly (P0)

### DIFF
--- a/deploy/openshell/create-protoagent-sandbox.sh
+++ b/deploy/openshell/create-protoagent-sandbox.sh
@@ -34,6 +34,6 @@ openshell sandbox create \
   --image "$IMAGE" \
   --publish "127.0.0.1:${PORT}:7870" \
   --mount "$CONFIG:/sandbox/config/langgraph-config.yaml:ro" \
-  -- python -m server --port 7870 --ui none   # server.py is now the server/ package (ADR 0023); PYTHONPATH baked in the image
+  -- python -m server --host 0.0.0.0 --port 7870 --ui none   # server/ package (ADR 0023); --host 0.0.0.0 since this override bypasses entrypoint.sh (server defaults to loopback)
 
 echo "✓ protoAgent sandbox created. Inspect: openshell sandbox list"

--- a/deploy/openshell/k8s/protoagent-sandbox.yaml
+++ b/deploy/openshell/k8s/protoagent-sandbox.yaml
@@ -29,7 +29,7 @@ spec:
           image: ghcr.io/protolabsai/protoagent:latest
           # server.py is now the server/ package (ADR 0023) — launch as a module.
           # PYTHONPATH=/opt/protoagent is baked as an image ENV so it survives this override.
-          command: ["python", "-m", "server", "--port", "7870", "--ui", "none"]  # lean headless tier (ADR 0010)
+          command: ["python", "-m", "server", "--host", "0.0.0.0", "--port", "7870", "--ui", "none"]  # lean headless tier (ADR 0010); --host 0.0.0.0 because this override bypasses entrypoint.sh (the server now defaults to loopback)
           ports:
             - containerPort: 7870
           env:

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -29,6 +29,7 @@ Every env var the template reads at runtime.
 | Variable | Default | What |
 |---|---|---|
 | `PROTOAGENT_UI` | `full` | UI deployment tier (or `--ui`): `full` (Gradio + React console + API/A2A), `console` (console + API/A2A, no Gradio), `none` (API + A2A + `/metrics` only — the lean headless stack). The Docker image defaults to `none`. |
+| `PROTOAGENT_HOST` | `127.0.0.1` | Bind address (or `--host`). **Defaults to loopback** so a local/desktop run isn't exposed on all interfaces — the operator/console API (`/api/*`, `/api/chat`, `/v1/*`) is otherwise reachable by anything that can hit the port. The container entrypoint + deploy manifests set `0.0.0.0` because their boundary is the published port + network policy, not the in-container bind. Binding non-loopback **without** an A2A auth token logs a security warning at startup. |
 | `PROTOAGENT_HEADLESS` | (unset) | **Deprecated** alias for `PROTOAGENT_UI=console` (or `--headless`). |
 | `PROTOAGENT_HEADLESS_SETUP` | (unset) | Set `1`/`true` to auto-complete setup from a validated config even outside the `none` tier (no wizard). The `none` tier implies this. |
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -24,4 +24,9 @@ fi
 # module with the install dir on PYTHONPATH so the package (and its sibling
 # top-level modules: paths, events, graph, …) resolve, while keeping the
 # agent's workspace (/sandbox) as the working directory.
-exec env PYTHONPATH="/opt/protoagent${PYTHONPATH:+:$PYTHONPATH}" python -m server
+#
+# Bind all interfaces inside the container — the boundary is the published port
+# + network policy, not the in-container bind. (The server defaults to loopback
+# for local/desktop runs; PROTOAGENT_HOST overrides either way.)
+exec env PYTHONPATH="/opt/protoagent${PYTHONPATH:+:$PYTHONPATH}" \
+    python -m server --host "${PROTOAGENT_HOST:-0.0.0.0}"

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -290,6 +290,12 @@ def _main():
         description=f"{AGENT_NAME_ENV} — protoAgent server",
     )
     parser.add_argument("--port", type=int, default=7870)
+    # Bind host. Defaults to loopback so a local/desktop run is NOT exposed on
+    # all interfaces (prod-readiness: the console + operator API are otherwise
+    # reachable by anything that can reach the port). Containers set
+    # PROTOAGENT_HOST=0.0.0.0 (entrypoint / deploy manifests) because their
+    # boundary is the network policy + published port, not the in-container bind.
+    parser.add_argument("--host", type=str, default=os.environ.get("PROTOAGENT_HOST", "127.0.0.1"))
     parser.add_argument("--config", type=str, default=None)
     parser.add_argument(
         "--ui",
@@ -685,10 +691,22 @@ def _main():
             footer_links=[],
             favicon_path=str(static_dir / "favicon.svg") if (static_dir / "favicon.svg").exists() else None,
         )
-        log.info("Starting %s (ui=full) on http://0.0.0.0:%d", agent_name(), args.port)
+        log.info("Starting %s (ui=full) on http://%s:%d", agent_name(), args.host, args.port)
     else:
         app = fastapi_app
-        log.info("Starting %s (ui=%s) on http://0.0.0.0:%d", agent_name(), ui, args.port)
+        log.info("Starting %s (ui=%s) on http://%s:%d", agent_name(), ui, args.host, args.port)
+
+    # Loud warning when exposed on all interfaces with no A2A auth token: the
+    # operator/console API (/api/*, /api/chat, /v1/*) is reachable by untrusted
+    # callers. Loopback (the default) is safe; a container behind a network
+    # policy is the intended 0.0.0.0 case.
+    if args.host not in ("127.0.0.1", "localhost", "::1") and not _bearer_configured():
+        log.warning(
+            "[security] binding %s with NO A2A auth token — the agent + operator "
+            "API are open to anything that can reach this port. Set auth.token / "
+            "A2A_AUTH_TOKEN, or bind 127.0.0.1 (the default), or front it with a "
+            "network policy.", args.host,
+        )
 
     # Don't outlive the launcher. When run as a desktop sidecar the Tauri shell
     # sets PROTOAGENT_PARENT_PID; a PyInstaller-frozen onefile runs as a
@@ -696,7 +714,7 @@ def _main():
     # server orphaned (holding its port). Poll the launcher and exit if it dies.
     _install_parent_death_watchdog()
 
-    uvicorn.run(app, host="0.0.0.0", port=args.port)
+    uvicorn.run(app, host=args.host, port=args.port)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Prod-readiness audit **P0** — the network-boundary half of the console-auth decision (Auth + localhost-default).

The server hardcoded `host=0.0.0.0`, so a local/desktop run exposed the operator/console + OpenAI-compat API (`/api/*`, `/api/chat`, `/v1/*` — none auth-gated) to anything that could reach the port.

## Change
- New `--host` arg / `PROTOAGENT_HOST` env, **default `127.0.0.1`**. Local + desktop-sidecar runs are loopback-only by default (verified: `Uvicorn running on http://127.0.0.1`).
- Containers bind `0.0.0.0` **explicitly**: `entrypoint.sh` passes `--host 0.0.0.0`, and the k8s + OpenShell command-overrides (which bypass the entrypoint) pass it too. Their boundary is the published port + network policy.
- Loud startup **WARNING** when binding non-loopback with no A2A auth token.
- Documented `PROTOAGENT_HOST` in the env-vars reference.

1047 tests green. The **credential-boundary half** — bearer-gating `/api/*` + `/v1/*`, which needs console-side token plumbing so a token-configured deployment's console keeps working — follows in a focused next PR.
