### PR TITLE
reliability: bound the LLM call (timeout+retries) + close the push client (P1)

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -18,6 +18,8 @@ model:
   temperature: 0.2
   max_tokens: 32768  # 32k — required headroom for the Qwen models we run
   max_iterations: 50
+  request_timeout: 120   # per-call timeout (s) on the model client — bounds a hung/slow gateway
+  max_retries: 2         # transient-error retries inside the client
   # Advanced sampling — all optional; omit to use the gateway / model-card
   # defaults. top_p + presence_penalty are standard OpenAI params; top_k +
   # repetition_penalty + chat_template_kwargs ride extra_body for vLLM-style

--- a/graph/config.py
+++ b/graph/config.py
@@ -87,6 +87,12 @@ class LangGraphConfig:
     max_tokens: int = 32768  # 32k — required headroom for the Qwen models we run
     max_iterations: int = 50
 
+    # Per-call timeout (seconds) on the model client + transient-retry cap. Bounds
+    # a hung/slow gateway so a turn surfaces a clean error instead of blocking the
+    # A2A task / SSE stream indefinitely (prod-readiness). 0/None ⇒ SDK default.
+    request_timeout: float = 120.0
+    llm_max_retries: int = 2
+
     # Advanced sampling — all opt-in. ``None`` (or a negative top_k) means
     # "let the gateway / model card decide". top_p and presence_penalty are
     # standard OpenAI params; top_k and repetition_penalty aren't, so they
@@ -472,6 +478,8 @@ class LangGraphConfig:
             temperature=model.get("temperature", cls.temperature),
             max_tokens=model.get("max_tokens", cls.max_tokens),
             max_iterations=model.get("max_iterations", cls.max_iterations),
+            request_timeout=model.get("request_timeout", cls.request_timeout),
+            llm_max_retries=model.get("max_retries", cls.llm_max_retries),
             top_p=model.get("top_p", cls.top_p),
             top_k=model.get("top_k", cls.top_k),
             presence_penalty=model.get("presence_penalty", cls.presence_penalty),

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -25,6 +25,10 @@ def _build_llm_kwargs(config: LangGraphConfig) -> dict:
         "model": config.model_name,
         "temperature": config.temperature,
         "max_tokens": config.max_tokens,
+        # Bound a hung/slow gateway: a per-call timeout + transient-retry cap so a
+        # turn fails cleanly instead of hanging the A2A task / SSE stream forever.
+        "timeout": config.request_timeout,
+        "max_retries": config.llm_max_retries,
         # Forces token-usage info onto the final streaming chunk so
         # `astream_events(v2)` populates `output.usage_metadata` on
         # `on_chat_model_end`. Without this, streaming chunks arrive as

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -544,6 +544,14 @@ def _main():
             log.exception("[discord] shutdown failed")
         if STATE.checkpoint_prune_task is not None:
             STATE.checkpoint_prune_task.cancel()
+        # Close the long-lived A2A push-notification client (created below in
+        # _main) so its connection pool doesn't leak on shutdown/reload — matters
+        # in the desktop-sidecar restart loop. Best-effort; NameError if boot
+        # never reached its construction is swallowed.
+        try:
+            await _a2a_push_client.aclose()
+        except Exception:
+            log.exception("[a2a] push client close failed")
 
     # Chat / goal / health / OpenAI-compat HTTP surface. Extracted to
     # operator_api/chat_routes.py (ADR 0023 phase 3); ``ui`` is passed in

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -16,6 +16,16 @@ def test_defaults_omit_optional_sampling_params():
     assert "extra_body" not in kwargs
 
 
+def test_request_timeout_and_max_retries_bound_the_gateway():
+    # Prod-readiness: the client must carry a per-call timeout + retry cap so a
+    # hung/slow gateway can't block a turn (and the A2A task) indefinitely.
+    kwargs = _build_llm_kwargs(LangGraphConfig())
+    assert kwargs["timeout"] == 120.0
+    assert kwargs["max_retries"] == 2
+    custom = _build_llm_kwargs(LangGraphConfig(request_timeout=45.0, llm_max_retries=0))
+    assert custom["timeout"] == 45.0 and custom["max_retries"] == 0
+
+
 def test_standard_openai_params_passed_directly():
     cfg = LangGraphConfig(top_p=0.95, presence_penalty=0.5)
     kwargs = _build_llm_kwargs(cfg)


### PR DESCRIPTION
Prod-readiness audit **P1** (resilience batch).

- **No LLM timeout** — the model client carried no `timeout=`, so a hung/slow LiteLLM gateway blocked the turn (and its A2A task / SSE stream) **indefinitely**; under load they pile up. Adds `model.request_timeout` (default 120s) + `model.max_retries` (default 2), wired as `timeout=`/`max_retries=` on `ChatOpenAI` (`graph/llm.py`).
- **Leaked push client** — `_a2a_push_client` (`httpx.AsyncClient`) was created but never `aclose()`d → connection-pool leak on shutdown/reload (bites the desktop-sidecar restart loop). Closed best-effort in the shutdown hook.

Verified: 1047+ tests (new `test_llm` asserts the bounds); boot + clean SIGTERM smoke shows no push-client errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)