### PR TITLE
security: default-on SSRF denylist for fetch_url + redirect re-check (P1)

### DIFF
--- a/egress.py
+++ b/egress.py
@@ -1,10 +1,13 @@
 """Egress allowlist for outbound HTTP from agent tools (ADR 0008).
 
-Deny-by-default host allowlist enforced in ``fetch_url`` — the tool where the
-model picks an arbitrary host, i.e. the main in-process exfiltration / SSRF
-vector. An **empty allowlist is permissive** (off), so existing deployments are
-unchanged until they opt in. This is also the single source of truth the
-OpenShell network policy is generated from (``scripts/gen_openshell_policy.py``).
+Enforced in ``fetch_url`` — the tool where the model picks an arbitrary host,
+i.e. the main in-process exfiltration / SSRF vector. Two layers: an optional
+host **allowlist** (deny-by-default when set; the single source of truth the
+OpenShell network policy is generated from, ``scripts/gen_openshell_policy.py``),
+and — when no allowlist is set — a **default-on private-IP denylist** so the
+model can't reach an internal service or cloud-metadata (``169.254.169.254``)
+out of the box. Public hosts still work with no allowlist; allowlisting a host
+explicitly trusts it (bypasses the denylist).
 
 Mirrors the ``PUSH_NOTIFICATION_ALLOWED_HOSTS`` SSRF-guard pattern in
 ``a2a_stores``. Wildcards: a leading ``*.`` matches any subdomain
@@ -17,6 +20,8 @@ under OpenShell's network namespace + proxy — see ADR 0008.
 
 from __future__ import annotations
 
+import ipaddress
+import socket
 from urllib.parse import urlparse
 
 _allowed: list[str] = []  # lowercased host patterns; empty = permissive (off)
@@ -50,20 +55,64 @@ def _host_allowed(host: str) -> bool:
     return False
 
 
-def check_url(url: str) -> str | None:
-    """Return an error string if the URL's host is not allowed, else ``None``.
-
-    Permissive (returns ``None``) when no allowlist is configured.
-    """
-    if not _allowed:
-        return None
+def _blocked_ip(host: str) -> str | None:
+    """Resolve ``host`` and return the first address that is a private/internal
+    SSRF target (loopback / link-local / private / multicast / reserved /
+    unspecified), or the literal ``"unresolvable"`` when DNS fails (treated as
+    unsafe, matching ``a2a_stores``). ``None`` ⇒ the host resolves only to
+    globally-routable addresses. One-shot resolution — not a DNS-rebinding
+    defence, but closes the trivial literal/redirect-to-internal vector."""
     try:
-        host = urlparse(url).hostname or ""
+        ipaddress.ip_address(host)
+        candidates = [host]
+    except ValueError:
+        try:
+            candidates = [info[4][0] for info in socket.getaddrinfo(host, None)]
+        except socket.gaierror:
+            return "unresolvable"
+    for addr in candidates:
+        try:
+            ip = ipaddress.ip_address(addr)
+        except ValueError:
+            return addr
+        if (ip.is_loopback or ip.is_link_local or ip.is_private
+                or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
+            return addr
+    return None
+
+
+def check_url(url: str) -> str | None:
+    """Return an error string if the URL's host is not permitted, else ``None``.
+
+    Two layers:
+    - **Allowlist set** → only allowlisted hosts pass (wildcards supported). An
+      allowlisted host is explicitly trusted and bypasses the IP denylist below
+      (you may allowlist an internal host on purpose).
+    - **No allowlist (default)** → a host is permitted unless it resolves to a
+      private / loopback / link-local / cloud-metadata / reserved address. This
+      default-on SSRF guard stops the model `fetch_url`-ing an internal service
+      or `169.254.169.254` even when no allowlist is configured.
+    """
+    try:
+        host = (urlparse(url).hostname or "").lower()
     except ValueError:
         return f"Error: malformed URL: {url!r}"
-    if _host_allowed(host):
-        return None
-    return (
-        f"Error: egress to {host or url!r} is blocked — not in the egress "
-        f"allowlist ({', '.join(_allowed)}). Set egress.allowed_hosts to permit it."
-    )
+    if not host:
+        return f"Error: no host in URL: {url!r}"
+    if _allowed:
+        if _host_allowed(host):
+            return None
+        return (
+            f"Error: egress to {host} is blocked — not in the egress allowlist "
+            f"({', '.join(_allowed)}). Set egress.allowed_hosts to permit it."
+        )
+    bad = _blocked_ip(host)
+    if bad == "unresolvable":
+        return f"Error: egress to {host} is blocked — host did not resolve."
+    if bad:
+        return (
+            f"Error: egress to {host} ({bad}) is blocked — it resolves to a "
+            f"private/internal address (SSRF guard). Allowlist it via "
+            f"egress.allowed_hosts if this is intentional."
+        )
+    return None

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -20,9 +20,23 @@ def _reset():
 # ── egress allowlist ───────────────────────────────────────────────────────────
 
 
-def test_permissive_when_unset():
+def test_unset_allows_public_blocks_private():
+    # No allowlist → public IPs pass, but the default-on SSRF denylist blocks
+    # private/loopback/link-local/metadata even without an allowlist. (IP
+    # literals so the test doesn't depend on DNS.)
     assert egress.is_enabled() is False
-    assert egress.check_url("http://anything.example/x") is None
+    assert egress.check_url("http://8.8.8.8/x") is None           # public
+    for bad in ("http://127.0.0.1/", "http://10.0.0.1/", "http://192.168.1.1/",
+                "http://169.254.169.254/latest/meta-data/", "http://[::1]/"):
+        assert egress.check_url(bad) is not None, bad
+
+
+def test_allowlisted_host_bypasses_ip_denylist():
+    # An operator can intentionally allowlist an internal host — the allowlist is
+    # the explicit-trust path and bypasses the private-IP denylist.
+    egress.set_allowed_hosts(["internal.svc"])
+    assert egress.check_url("http://internal.svc/x") is None
+    egress.set_allowed_hosts([])
 
 
 def test_exact_host_allow_and_deny():

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -278,12 +278,25 @@ async def fetch_url(url: str, max_chars: int = _MAX_OUTPUT_CHARS) -> str:
         return "Error: httpx not installed — cannot fetch URLs."
 
     try:
+        # Disable auto-redirects and follow manually so each hop's host is
+        # re-checked against egress — otherwise a public URL that 30x-redirects
+        # to http://169.254.169.254/ would bypass the SSRF guard above.
         async with httpx.AsyncClient(
-            follow_redirects=True, timeout=15, headers={
+            follow_redirects=False, timeout=15, headers={
                 "User-Agent": "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)",
             },
         ) as client:
             resp = await client.get(url)
+            hops = 0
+            while resp.is_redirect and hops < 5:
+                nxt = str(resp.url.join(resp.headers.get("location") or ""))
+                if not (nxt.startswith("http://") or nxt.startswith("https://")):
+                    return f"Error: refusing non-http(s) redirect to {nxt!r}"
+                blocked = egress.check_url(nxt)
+                if blocked:
+                    return blocked
+                resp = await client.get(nxt)
+                hops += 1
     except httpx.HTTPError as e:
         return f"Error: fetch failed: {e}"
 


### PR DESCRIPTION
Prod-readiness audit **P1**. `egress.check_url` was a host allowlist that was **permissive by default** — with no allowlist set, the model could `fetch_url("http://169.254.169.254/…")` (cloud metadata) or any RFC1918 service. And `fetch_url` used `follow_redirects=True`, so a public URL 30x-redirecting to an internal host **bypassed the check**.

- `egress.check_url` now applies a **default-on private-IP denylist** when no allowlist is set: resolve the host, block loopback/link-local/private/multicast/reserved/metadata (+ unresolvable). Public hosts still work with zero config; an allowlist (when set) is the explicit-trust path that bypasses the denylist — mirrors `a2a_stores.is_safe_webhook_url`.
- `fetch_url` disables auto-redirects and follows manually, **re-checking each hop** against egress (max 5; refuses non-http(s) redirects).

Verified: `test_egress` updated (public allowed, private/metadata blocked, allowlist bypass); 1047+ green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)