### PR TITLE
deploy: HEALTHCHECK + k8s readiness/liveness probes (P1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -104,4 +104,11 @@ USER sandbox
 WORKDIR /sandbox
 
 EXPOSE 7870
+
+# Readiness/health: /healthz returns 200 only once the agent graph is compiled
+# (503 during the model-cold-start window). start-period covers the
+# frozen-sidecar / first-compile boot so a slow start isn't marked unhealthy.
+HEALTHCHECK --interval=30s --timeout=3s --start-period=60s --retries=3 \
+    CMD curl -fsS http://localhost:7870/healthz || exit 1
+
 CMD ["/opt/protoagent/entrypoint.sh"]

--- a/deploy/openshell/k8s/protoagent-sandbox.yaml
+++ b/deploy/openshell/k8s/protoagent-sandbox.yaml
@@ -32,6 +32,19 @@ spec:
           command: ["python", "-m", "server", "--host", "0.0.0.0", "--port", "7870", "--ui", "none"]  # lean headless tier (ADR 0010); --host 0.0.0.0 because this override bypasses entrypoint.sh (the server now defaults to loopback)
           ports:
             - containerPort: 7870
+          # /healthz returns 200 only once the agent graph is compiled (503 during
+          # cold start). Readiness gates traffic until ready; liveness is generous
+          # so a slow first compile (model warm-up) can't trigger a restart loop.
+          readinessProbe:
+            httpGet: { path: /healthz, port: 7870 }
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 3
+          livenessProbe:
+            httpGet: { path: /healthz, port: 7870 }
+            initialDelaySeconds: 90
+            periodSeconds: 30
+            failureThreshold: 6
           env:
             - name: PROTOAGENT_INSTANCE         # ADR 0004 — isolate this deployment's stores
               value: "k8s"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,6 +17,16 @@ services:
     container_name: protoagent
     restart: unless-stopped
 
+    # Readiness — /healthz is 200 only once the agent graph is ready (503 during
+    # cold start). With restart:unless-stopped this lets the daemon detect a
+    # hung-but-alive process. start_period covers the first-compile boot.
+    healthcheck:
+      test: ["CMD", "curl", "-fsS", "http://localhost:7870/healthz"]
+      interval: 30s
+      timeout: 3s
+      start_period: 60s
+      retries: 3
+
     # ── Hardening ──────────────────────────────────────────────────────────
     security_opt:
       - no-new-privileges:true


### PR DESCRIPTION
Prod-readiness audit **P1**. The app has a correct readiness endpoint (`/healthz` → 200 only when the agent graph is compiled, 503 during cold start) but **nothing wired it** — compose couldn't detect a hung process, and k8s wouldn't gate traffic on readiness (requests hit the pod during the model-cold-start window). The biggest payoff of the existing readiness work was unused.

- **Dockerfile** `HEALTHCHECK` (curl `/healthz`; `start-period=60s` for the first-compile boot).
- **docker-compose** `healthcheck` block.
- **k8s** `readinessProbe` (gates traffic) + `livenessProbe` (generous — `initialDelaySeconds: 90` + `failureThreshold: 6` so a slow first compile can't trigger a restart loop).

`curl` is already in the image; both YAML files parse.

🤖 Generated with [Claude Code](https://claude.com/claude-code)