### PR TITLE
ci(release): make build-provenance attestation opt-in (fork-friendly)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,7 +99,15 @@ jobs:
           build-args: |
             VERSION=${{ steps.version.outputs.version }}
 
+      # Build-provenance attestation needs the GitHub attestations feature, which
+      # is unavailable on private repos without a paid plan — so a fork would get
+      # a noisy red error here for a step it can't use. Opt-in (fork-friendly):
+      # set the `ATTESTATIONS_ENABLED` repo variable to `true` to run it; forks
+      # leave it unset and the step is skipped. Enable without editing this file
+      # so upstream changes don't conflict on re-sync (same pattern as
+      # `RELEASE_ENABLED`). `continue-on-error` stays as a belt-and-suspenders.
       - name: Attest build provenance
+        if: vars.ATTESTATIONS_ENABLED == 'true'
         continue-on-error: true
         uses: actions/attest-build-provenance@v1
         with:


### PR DESCRIPTION
## Problem
The `Release` workflow's **Attest build provenance** step (`actions/attest-build-provenance`) needs the GitHub attestations feature, which is **unavailable on private repos without a paid plan**. A fork that cuts a release gets a noisy red error on a step it can't use:

> Error: Failed to persist attestation: Feature not available for the protoLabsAI organization. To enable this feature, please upgrade the billing plan, or make this repository public.

The step is already `continue-on-error: true`, so the release still publishes — but the failed annotation is misleading and looks like a broken release. Observed live cutting protoTrader v0.15.2.

## Fix
Gate the step behind an opt-in `ATTESTATIONS_ENABLED` repo variable, mirroring the existing `RELEASE_ENABLED` guard:
- **Forks** leave it unset → step is skipped cleanly, no red error.
- **Repos with the feature** set `ATTESTATIONS_ENABLED=true` → attestation runs as before.

Enabled via a repo variable (not a workflow edit), so it doesn't conflict when forks re-sync from upstream — same fork-friendly pattern already used for `RELEASE_ENABLED`. `continue-on-error` is kept as a belt-and-suspenders.

Note: the buildkit `provenance: true` / `sbom: true` on the Docker build step are **unaffected** — those push OCI artifacts to the registry and work fine on private GHCR (verified in the v0.15.2 run).

🤖 Generated with [Claude Code](https://claude.com/claude-code)