### PR TITLE
ci: A2A live-smoke job (boot real server vs fake model, drive a turn)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -71,6 +71,33 @@ jobs:
           . .venv/bin/activate
           python -m pytest tests/ -q
 
+  live-smoke:
+    name: A2A live smoke (lean tier)
+    runs-on: namespace-profile-protolabs-linux
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+          cache: pip
+      - name: Install lean (core) deps
+        # requirements-core.txt is the PRODUCTION image's dependency set (the
+        # `--ui none` tier). Installing it here — not the full requirements.txt —
+        # also guards the lean-image import gap class (e.g. the FastAPI-missing
+        # bug that only push-to-main caught, #426).
+        run: |
+          python -m venv .venv
+          . .venv/bin/activate
+          python -m pip install --upgrade pip
+          pip install -r requirements-core.txt
+      - name: Boot the real server vs a fake model + drive a real A2A turn
+        # Catches the green-but-wire-broken class unit/mock tests miss — CRLF SSE
+        # framing, A2A routing + version negotiation, agent-card build, lean boot.
+        run: |
+          . .venv/bin/activate
+          python scripts/live_smoke.py
+
   web-e2e:
     name: Web E2E smoke
     runs-on: namespace-profile-protolabs-linux

--- a/scripts/fake_openai_server.py
+++ b/scripts/fake_openai_server.py
@@ -1,0 +1,103 @@
+#!/usr/bin/env python3
+"""A zero-dependency fake OpenAI-compatible endpoint for the CI live-smoke.
+
+Boots the REAL protoAgent server against this so a live A2A turn exercises the
+real wire path (executor → chat stream → SSE framing → a2a-sdk handler) without
+a real model or gateway. The model just needs to return a valid completion so
+the turn reaches a terminal state and emits artifact/COMPLETED frames — that's
+what catches the green-but-wire-broken class (CRLF SSE, A2A routing/version,
+lean-image boot) that unit/mock tests miss.
+
+Serves:
+  GET  /v1/models               → a one-model list (drawer/validation)
+  POST /v1/chat/completions     → a streaming (or non-streaming) chat completion
+
+Run: python scripts/fake_openai_server.py <port>
+"""
+
+from __future__ import annotations
+
+import json
+import sys
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+
+# The agent wraps its answer in <output>…</output> (graph/output_format.py); emit
+# that shape so the parser extracts a clean final answer.
+_ANSWER = "<output>live smoke ok</output>"
+_MODEL = "protolabs/reasoning"
+
+
+def _chunk(delta: dict, finish=None, usage=None) -> bytes:
+    obj = {
+        "id": "smoke-1",
+        "object": "chat.completion.chunk",
+        "model": _MODEL,
+        "choices": [{"index": 0, "delta": delta, "finish_reason": finish}],
+    }
+    if usage is not None:
+        obj["usage"] = usage
+    return b"data: " + json.dumps(obj).encode() + b"\n\n"
+
+
+class _Handler(BaseHTTPRequestHandler):
+    def log_message(self, *a):  # quiet
+        pass
+
+    def do_GET(self):
+        if self.path.rstrip("/").endswith("/models"):
+            body = json.dumps({"object": "list", "data": [{"id": _MODEL, "object": "model"}]}).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+        else:
+            self.send_error(404)
+
+    def do_POST(self):
+        length = int(self.headers.get("Content-Length", 0) or 0)
+        raw = self.rfile.read(length) if length else b"{}"
+        try:
+            req = json.loads(raw or b"{}")
+        except ValueError:
+            req = {}
+        streaming = bool(req.get("stream"))
+        usage = {"prompt_tokens": 7, "completion_tokens": 4, "total_tokens": 11}
+
+        if not self.path.rstrip("/").endswith("/chat/completions"):
+            self.send_error(404)
+            return
+
+        if streaming:
+            self.send_response(200)
+            self.send_header("Content-Type", "text/event-stream")
+            self.end_headers()
+            # role chunk, content chunk, finish chunk (with usage), [DONE].
+            self.wfile.write(_chunk({"role": "assistant", "content": ""}))
+            self.wfile.write(_chunk({"content": _ANSWER}))
+            self.wfile.write(_chunk({}, finish="stop", usage=usage))
+            self.wfile.write(b"data: [DONE]\n\n")
+            self.wfile.flush()
+        else:
+            body = json.dumps({
+                "id": "smoke-1", "object": "chat.completion", "model": _MODEL,
+                "choices": [{"index": 0, "message": {"role": "assistant", "content": _ANSWER},
+                             "finish_reason": "stop"}],
+                "usage": usage,
+            }).encode()
+            self.send_response(200)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(body)))
+            self.end_headers()
+            self.wfile.write(body)
+
+
+def main() -> None:
+    port = int(sys.argv[1]) if len(sys.argv) > 1 else 8900
+    srv = ThreadingHTTPServer(("127.0.0.1", port), _Handler)
+    print(f"[fake-openai] listening on 127.0.0.1:{port}", flush=True)
+    srv.serve_forever()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -1,0 +1,119 @@
+#!/usr/bin/env python3
+"""CI live-smoke: boot the REAL server (lean `--ui none` tier) against a fake
+OpenAI endpoint and drive a real A2A turn end-to-end.
+
+This catches the green-but-wire-broken class that unit/mock tests miss — CRLF SSE
+framing, A2A routing + version negotiation, the agent-card build, and lean-image
+import gaps — by exercising the actual transport, not a mock. The fake model
+(scripts/fake_openai_server.py) returns a canned completion so the turn reaches a
+terminal state without a real gateway.
+
+Exit 0 on success, non-zero (with a diagnostic) on any failure.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import socket
+import subprocess
+import sys
+import tempfile
+import time
+import urllib.request
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def _free_port() -> int:
+    s = socket.socket()
+    s.bind(("127.0.0.1", 0))
+    port = s.getsockname()[1]
+    s.close()
+    return port
+
+
+def _wait_healthz(port: int, timeout: float = 90.0) -> bool:
+    end = time.time() + timeout
+    url = f"http://127.0.0.1:{port}/healthz"
+    while time.time() < end:
+        try:
+            with urllib.request.urlopen(url, timeout=2) as r:
+                if r.status == 200:
+                    return True
+        except Exception:
+            pass
+        time.sleep(1.0)
+    return False
+
+
+def main() -> int:
+    fake_port, agent_port = _free_port(), _free_port()
+    cfg_dir = Path(tempfile.mkdtemp(prefix="smoke-cfg-"))
+    (cfg_dir / "langgraph-config.yaml").write_text(
+        "model:\n"
+        "  name: protolabs/reasoning\n"
+        f"  api_base: http://127.0.0.1:{fake_port}/v1\n"
+        "middleware:\n  knowledge: false\n  scheduler: false\n"
+    )
+    env = {
+        **os.environ,
+        "OPENAI_API_KEY": "fake-smoke-key",
+        "PROTOAGENT_CONFIG_DIR": str(cfg_dir),
+        "PROTOAGENT_INSTANCE": "cismoke",
+        "PROTOAGENT_HEADLESS_SETUP": "1",
+        "PYTHONPATH": str(ROOT),
+    }
+
+    fake = subprocess.Popen([sys.executable, str(ROOT / "scripts" / "fake_openai_server.py"), str(fake_port)])
+    agent = subprocess.Popen(
+        [sys.executable, "-m", "server", "--ui", "none", "--port", str(agent_port)],
+        cwd=str(ROOT), env=env,
+    )
+    try:
+        if not _wait_healthz(agent_port):
+            print("FAIL: /healthz never returned 200 (server did not become ready)")
+            return 1
+        print("ok: /healthz 200 (lean server booted + graph compiled)")
+
+        # Agent card serves + has identity.
+        with urllib.request.urlopen(f"http://127.0.0.1:{agent_port}/.well-known/agent-card.json", timeout=5) as r:
+            card = json.loads(r.read())
+        assert card.get("name"), "agent card has no name"
+        assert card.get("skills"), "agent card has no skills"
+        print(f"ok: agent card serves (name={card['name']}, skills={[s.get('id') for s in card['skills']]})")
+
+        # Real A2A streaming turn over the actual transport.
+        body = json.dumps({
+            "jsonrpc": "2.0", "id": "smoke", "method": "SendStreamingMessage",
+            "params": {"message": {"role": "ROLE_USER", "parts": [{"text": "ping"}],
+                                   "messageId": "m1", "contextId": "smoke"}},
+        }).encode()
+        req = urllib.request.Request(
+            f"http://127.0.0.1:{agent_port}/a2a", data=body,
+            headers={"A2A-Version": "1.0", "Content-Type": "application/json"},
+        )
+        with urllib.request.urlopen(req, timeout=60) as r:
+            raw = r.read().decode("utf-8", "replace")
+
+        assert "data:" in raw, f"no SSE data frames in response: {raw[:300]!r}"
+        terminal = ("COMPLETED" in raw or "live smoke ok" in raw or '"artifact' in raw.lower())
+        assert terminal, f"no terminal/answer frame; first 600 chars: {raw[:600]!r}"
+        print("ok: A2A SendStreamingMessage turn decoded + reached a terminal frame")
+        print("\nLIVE SMOKE PASSED ✓")
+        return 0
+    except Exception as e:  # noqa: BLE001 — smoke must report, not traceback-crash
+        print(f"FAIL: {type(e).__name__}: {e}")
+        return 1
+    finally:
+        for p in (agent, fake):
+            p.terminate()
+            try:
+                p.wait(timeout=5)
+            except Exception:
+                p.kill()
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Prod-readiness audit **P1** — the durable fix the `smoke-test-before-shipping` memory note keeps naming. Every wire bug this repo shipped (CRLF SSE #563, A2A 404s/eval rot #524, lean-image FastAPI gap #426) was **unit-green but wire-broken** because nothing booted the real server and hit the actual transport.

- `scripts/fake_openai_server.py` — zero-dep OpenAI-compat endpoint streaming a canned completion, so a real A2A turn reaches a terminal state without a gateway.
- `scripts/live_smoke.py` — boots `python -m server --ui none` against the fake model, waits `/healthz`, fetches the agent card, POSTs a real `SendStreamingMessage` turn, asserts the SSE frames **decode + reach a terminal frame**.
- New CI job **A2A live smoke (lean tier)** installs `requirements-core.txt` (the *production* image's deps — so it also guards the lean-import gap class) and runs the smoke.

Verified locally: lean server boots, card serves, streaming turn completes end-to-end. 🤖 Generated with [Claude Code](https://claude.com/claude-code)