### PR TITLE
ci: enforce ruff + clean dead imports/vars (lint gate)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -48,6 +48,22 @@ jobs:
           fi
           echo "ok: no stale single-file launches in deploy artifacts"
 
+  lint:
+    name: Lint (ruff)
+    runs-on: namespace-profile-protolabs-linux
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - name: Ruff check
+        # Pinned so a new ruff release can't add a rule that fails the gate
+        # out from under a PR. Config + ignores live in pyproject.toml.
+        run: |
+          pip install ruff==0.15.10
+          ruff check .
+
   tests:
     name: Python tests
     runs-on: namespace-profile-protolabs-linux

--- a/audit.py
+++ b/audit.py
@@ -5,7 +5,6 @@ Enhanced with Langfuse trace context for cross-referencing.
 """
 
 import json
-import os
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any

--- a/chat_ui.py
+++ b/chat_ui.py
@@ -476,7 +476,7 @@ def create_chat_app(
                                 label="Launch this agent automatically on login",
                                 interactive=True,
                             )
-                            autostart_drawer_status = gr.Markdown("")
+                            gr.Markdown("")
 
                         with gr.Accordion("Persona (SOUL.md)", open=False):
                             soul_in = gr.Textbox(

--- a/evals/client.py
+++ b/evals/client.py
@@ -34,7 +34,6 @@ import os
 import time
 import uuid
 from dataclasses import dataclass, field
-from typing import Any
 
 import httpx
 

--- a/evals/verify.py
+++ b/evals/verify.py
@@ -25,7 +25,6 @@ import logging
 import os
 from datetime import datetime, timezone
 from pathlib import Path
-from typing import Any
 
 log = logging.getLogger(__name__)
 

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -27,7 +27,6 @@ from __future__ import annotations
 
 import logging
 import os
-from io import StringIO
 from pathlib import Path
 from typing import Any
 

--- a/graph/middleware/audit.py
+++ b/graph/middleware/audit.py
@@ -5,11 +5,9 @@ and observability integration. Reuses existing audit/tracing/metrics modules.
 """
 
 import time
-from typing import Any, Callable
 
 from langchain.agents.middleware import AgentMiddleware
 
-from langgraph.prebuilt.chat_agent_executor import AgentState
 
 from graph.middleware.redaction import redact
 

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -16,7 +16,6 @@ from typing import TYPE_CHECKING
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import AIMessage, HumanMessage
 
-from langgraph.prebuilt.chat_agent_executor import AgentState
 
 if TYPE_CHECKING:
     from graph.skills.index import SkillRecord, SkillsIndex

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -17,7 +17,6 @@ from typing import Any
 from langchain.agents.middleware import AgentMiddleware
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
-from langgraph.prebuilt.chat_agent_executor import AgentState
 
 
 log = logging.getLogger(__name__)

--- a/graph/middleware/message_capture.py
+++ b/graph/middleware/message_capture.py
@@ -6,7 +6,6 @@ those calls and stores the content for later extraction.
 """
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import ToolMessage
 
 class MessageCaptureMiddleware(AgentMiddleware):
     """Intercept message() tool calls and capture their content."""

--- a/graph/skills/curator.py
+++ b/graph/skills/curator.py
@@ -74,7 +74,6 @@ import math
 import os
 import uuid
 from datetime import datetime, timezone
-from typing import Any
 
 log = logging.getLogger(__name__)
 
@@ -333,7 +332,6 @@ class SkillCurator:
             texts = [_skill_text(s) for s in skills]
             embeddings = model.encode(texts, normalize_embeddings=True)
             # Cosine similarity via dot product (embeddings are normalised)
-            import numpy as np  # type: ignore
 
             matrix = (embeddings @ embeddings.T).tolist()
             log.debug("[curator] similarity matrix built with sentence-transformers")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,3 +8,29 @@ requires-python = ">=3.11"
 asyncio_mode = "auto"
 testpaths = ["tests"]
 pythonpath = ["."]
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+extend-exclude = [".venv", "apps", "build", "dist", "*.egg-info"]
+
+[tool.ruff.lint]
+# pyflakes (F) catches the real bugs — unused/undefined names; pycodestyle (E/W)
+# + isort (I) for hygiene. The stylistic rules the codebase intentionally and
+# pervasively uses are ignored rather than churned: lazy/late imports (E402),
+# semicolon/lambda style (E702/E731), and the bare-except guard form (E722 is
+# kept; bare `except:` is genuinely banned here).
+select = ["E", "F", "W"]
+ignore = [
+  "E402",  # module-level import not at top — late/lazy imports are idiomatic here
+  "E501",  # line-too-long — long, readable comment lines are intentional
+  "E702",  # multiple statements on one line (semicolon) — used deliberately
+  "E731",  # lambda assignment — used deliberately in a few places
+  "E741",  # ambiguous var name (l/O/I) — occasional, harmless
+]
+
+[tool.ruff.lint.per-file-ignores]
+# Package __init__ files re-export submodule symbols (esp. server/__init__.py,
+# which re-exports the whole public surface for the test suite) — F401 there is
+# intentional, not dead code.
+"**/__init__.py" = ["F401"]

--- a/scheduler/workstacean.py
+++ b/scheduler/workstacean.py
@@ -26,7 +26,6 @@ recommended bridge config.
 from __future__ import annotations
 
 import logging
-import os
 import uuid
 from typing import Any
 

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -841,9 +841,6 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
         new_workflow_registry = None
         new_inbox_store = None
 
-    # Capture the outgoing config before the swap so we can tell whether the
-    # Discord surface needs a live reconnect (token/admin/enabled changed).
-    old_config = STATE.graph_config
     # Commit: config → A2A bearer → graph. All three reference the
     # same ``new_config`` so they stay consistent.
     STATE.graph_config = new_config

--- a/server/chat.py
+++ b/server/chat.py
@@ -428,7 +428,6 @@ async def _chat_langgraph_stream(
     it (e.g. per-project working memory) without editing this file.
     """
     import tracing
-    from langchain_core.messages import HumanMessage
 
     from graph.goals.goal_turn import goal_turn
 

--- a/tests/middleware/test_audit_redaction_integration.py
+++ b/tests/middleware/test_audit_redaction_integration.py
@@ -1,9 +1,7 @@
 """Integration tests: verify redaction is applied in AuditMiddleware flow."""
 
 import json
-import tempfile
-from pathlib import Path
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -107,7 +105,7 @@ class TestAuditMiddlewareSyncRedaction:
             captured_trace_args.update(args)
 
         with (
-            patch("audit.audit_logger") as fake_audit,
+            patch("audit.audit_logger") as fake_audit,  # noqa: F841 (used below; ruff misreads the parenthesized with)
             patch("tracing.current_session_id", return_value="sess-3"),
             patch("tracing.trace_tool_call", side_effect=fake_trace),
             patch("metrics.record_tool_call"),
@@ -200,7 +198,7 @@ class TestAuditMiddlewareAsyncRedaction:
             raise ValueError("tool failure")
 
         with (
-            patch("audit.audit_logger") as fake_audit,
+            patch("audit.audit_logger") as fake_audit,  # noqa: F841 (used below; ruff misreads the parenthesized with)
             patch("tracing.current_session_id", return_value="sess-exc"),
             patch("tracing.trace_tool_call"),
             patch("metrics.record_tool_call"),

--- a/tests/middleware/test_redaction.py
+++ b/tests/middleware/test_redaction.py
@@ -1,6 +1,5 @@
 """Unit tests for graph.middleware.redaction module."""
 
-import pytest
 
 from graph.middleware.redaction import redact, PATTERNS
 

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -27,7 +27,6 @@ import asyncio
 
 import httpx
 import pytest
-from a2a.server.context import ServerCallContext
 from a2a.server.request_handlers import DefaultRequestHandler
 from a2a.server.routes.agent_card_routes import create_agent_card_routes
 from a2a.server.routes.fastapi_routes import add_a2a_routes_to_fastapi

--- a/tests/test_cache_warmer.py
+++ b/tests/test_cache_warmer.py
@@ -9,7 +9,6 @@ import asyncio
 
 import pytest
 
-import graph.cache_warmer as cw
 from graph.cache_warmer import CacheWarmer
 from graph.config import LangGraphConfig
 

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -17,7 +17,7 @@ Critical invariants:
 from __future__ import annotations
 
 from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import httpx
 import pytest

--- a/tests/test_discord_gateway.py
+++ b/tests/test_discord_gateway.py
@@ -9,7 +9,6 @@ and auto-threading are all exercised without network or LLM.
 
 from __future__ import annotations
 
-import asyncio
 
 import pytest
 

--- a/tests/test_eval_sweep.py
+++ b/tests/test_eval_sweep.py
@@ -8,9 +8,7 @@ without booting an agent — the live boot path is covered manually via
 from __future__ import annotations
 
 import json
-import os
 
-import pytest
 
 from evals.report import build_report
 from evals.runner import CaseResult, _save_report

--- a/tests/test_eval_webhook.py
+++ b/tests/test_eval_webhook.py
@@ -1,6 +1,5 @@
 """Tests for the eval webhook listener."""
 
-import json
 
 import httpx
 import pytest

--- a/tests/test_hot_memory.py
+++ b/tests/test_hot_memory.py
@@ -1,6 +1,5 @@
 """Tests for hot-memory (always-on domain='hot' facts)."""
 
-from unittest.mock import MagicMock
 
 from langchain_core.messages import HumanMessage
 

--- a/tests/test_hybrid_store.py
+++ b/tests/test_hybrid_store.py
@@ -2,7 +2,6 @@
 
 import sqlite3
 
-import pytest
 
 from knowledge.hybrid_store import HybridKnowledgeStore
 

--- a/tests/test_memory_load.py
+++ b/tests/test_memory_load.py
@@ -15,11 +15,8 @@ from __future__ import annotations
 
 import json
 import os
-import tempfile
-from pathlib import Path
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import pytest
 
 
 # ---------------------------------------------------------------------------

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -13,12 +13,9 @@ Covers:
 
 from __future__ import annotations
 
-import importlib
 import json
 import os
 import sys
-import tempfile
-from pathlib import Path
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -160,7 +157,6 @@ def test_atomic_write_no_partial_file_on_error(tmp_path):
     state = _make_state("atomic-test")
     dest = tmp_path / "atomic-test.json"
 
-    original_json_dump = json.dump
 
     def bad_dump(*args, **kwargs):
         raise OSError("simulated write error")

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -7,7 +7,6 @@ error is shown to the operator and echoing a token/hash is a leak + useless.
 
 from __future__ import annotations
 
-import contextlib
 
 from graph import config_io
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from tools.shell import ShellResult, run_command
+from tools.shell import run_command
 
 
 @pytest.mark.asyncio

--- a/tests/test_skill_curator.py
+++ b/tests/test_skill_curator.py
@@ -11,22 +11,17 @@ Covers:
 from __future__ import annotations
 
 import json
-import math
 import os
-import tempfile
 import uuid
 from datetime import datetime, timedelta, timezone
 
-import pytest
 
 from graph.skills.curator import (
-    HALF_LIFE_DAYS,
     PRUNE_THRESHOLD,
     SIMILARITY_THRESHOLD,
     SkillCurator,
     _clamp,
     _jaccard,
-    _parse_iso,
 )
 
 

--- a/tests/test_skill_emission.py
+++ b/tests/test_skill_emission.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 import logging
 from datetime import datetime, timezone
-from unittest.mock import AsyncMock, MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 from langchain_core.messages import AIMessage

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -16,10 +16,8 @@ from __future__ import annotations
 
 import os
 import sqlite3
-import tempfile
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Any
 from unittest.mock import MagicMock
 
 import pytest

--- a/tests/utils/check_audit_clean.py
+++ b/tests/utils/check_audit_clean.py
@@ -10,7 +10,6 @@ Use in CI/CD to gate deployments on clean audit logs.
 
 from __future__ import annotations
 
-import json
 import re
 import sys
 from pathlib import Path


### PR DESCRIPTION
Prod-readiness audit **P1** — no static analysis was enforced (no ruff/mypy config or CI gate), and the untyped wire boundaries are where the recent bugs lived.

- **`pyproject.toml` `[tool.ruff]`**: `select E/F/W`; ignore the stylistic rules the codebase intentionally uses (E402 lazy imports, E501 long comments, E702/E731); `per-file-ignore` F401 in `**/__init__.py` (the re-export surfaces — esp. `server/__init__.py`).
- **Cleaned the real signals**: 45 unused imports auto-removed + 4 dead assignments (incl. a stale `old_config` whose Discord-reconnect detection was never wired). One ruff F841 false-positive (parenthesized multi-`with`) `noqa`'d with a note.
- **`checks.yml`**: new **Lint (ruff)** job (ruff pinned so a release can't fail the gate).

`ruff check .` clean; 1049 tests green. (mypy on the wire modules is a sensible follow-up; ruff F-rules already catch the unused/undefined-name class.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)