### PR TITLE
obs: audit log rotation + instance-scope + tail reads; broaden redaction (P1/P2)

### DIFF
--- a/audit.py
+++ b/audit.py
@@ -1,32 +1,71 @@
 """Audit logging for protoAgent tool executions.
 
-Writes JSONL entries to /sandbox/audit/audit.jsonl with tool call metadata.
-Enhanced with Langfuse trace context for cross-referencing.
+Append-only JSONL of tool-call metadata, enriched with Langfuse trace context for
+cross-referencing. The path is **instance-scoped** (ADR 0004) and resolved lazily
+so it picks up ``PROTOAGENT_INSTANCE`` (seeded during boot, after this module is
+imported). The file **rotates** at a size cap so a busy agent can't fill the disk,
+and ``get_recent`` reads only a bounded tail so a large log can't OOM a read.
 """
 
 import json
+import os
+from collections import OrderedDict
 from datetime import datetime, timezone
 from pathlib import Path
 from typing import Any
 
+# Rotate the JSONL when it crosses this; keep one ``.1`` backup. Reads only ever
+# touch the live file's tail.
+_MAX_BYTES = 50 * 1024 * 1024      # 50 MB
+_TAIL_BYTES = 512 * 1024           # get_recent reads at most the last 512 KB
+_MAX_SESSIONS = 1000               # cap the in-memory per-session stats dict
+
+_DEFAULT_LEAF = Path("/sandbox") / "audit" / "audit.jsonl"
+
 
 class AuditLogger:
-    """Append-only JSONL audit log for tool executions."""
+    """Append-only JSONL audit log for tool executions (rotating, instance-scoped)."""
 
-    def __init__(self, path: str | Path = "/sandbox/audit/audit.jsonl"):
-        self.path = Path(path)
+    def __init__(self, path: str | Path | None = None):
+        # Configured base path; the real (instance-scoped, writable) path is
+        # resolved on first use so PROTOAGENT_INSTANCE is already seeded.
+        self._base = Path(path) if path else _DEFAULT_LEAF
+        self._resolved: Path | None = None
+        self._session_stats: "OrderedDict[str, dict]" = OrderedDict()
+
+    def _ensure_path(self) -> Path | None:
+        """Resolve + create the instance-scoped path, with the standard
+        ``/sandbox`` → ``~/.protoagent`` writable fallback. Memoized. ``None`` if
+        nothing is writable (audit then degrades to a no-op)."""
+        if self._resolved is not None:
+            return self._resolved
+        from paths import scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
+
+        candidate = scope_leaf(self._base)
         try:
-            self.path.parent.mkdir(parents=True, exist_ok=True)
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+            self._resolved = candidate
+            return candidate
         except OSError:
-            # /sandbox isn't writable (non-root CI runner, local `python
-            # server.py`, etc.) — fall back to a per-user path so audit
-            # logging degrades gracefully instead of crashing at import.
-            self.path = Path.home() / ".protoagent" / "audit" / self.path.name
+            fb = scope_leaf(Path.home() / ".protoagent" / "audit" / candidate.name)
             try:
-                self.path.parent.mkdir(parents=True, exist_ok=True)
+                fb.parent.mkdir(parents=True, exist_ok=True)
             except OSError:
-                pass
-        self._session_stats: dict[str, dict] = {}
+                return None
+            self._resolved = fb
+            return fb
+
+    @property
+    def path(self) -> Path:
+        """The resolved on-disk path (for callers/tests that read it directly)."""
+        return self._ensure_path() or scope_leaf_safe(self._base)
+
+    def _maybe_rotate(self, path: Path) -> None:
+        try:
+            if path.exists() and path.stat().st_size > _MAX_BYTES:
+                path.replace(path.with_suffix(path.suffix + ".1"))  # overwrite the single backup
+        except OSError:
+            pass
 
     def log(
         self,
@@ -57,32 +96,48 @@ class AuditLogger:
         if trace_id:
             entry["trace_id"] = trace_id
 
-        try:
-            with self.path.open("a") as f:
-                f.write(json.dumps(entry, default=str) + "\n")
-        except OSError:
-            pass
+        path = self._ensure_path()
+        if path is not None:
+            self._maybe_rotate(path)
+            try:
+                with path.open("a") as f:
+                    f.write(json.dumps(entry, default=str) + "\n")
+            except OSError:
+                pass
 
-        stats = self._session_stats.setdefault(session_id, {
-            "tool_calls": 0, "successes": 0, "failures": 0, "total_ms": 0,
-            "tools_used": set(),
-        })
+        stats = self._session_stats.get(session_id)
+        if stats is None:
+            stats = {"tool_calls": 0, "successes": 0, "failures": 0, "total_ms": 0, "tools_used": set()}
+            self._session_stats[session_id] = stats
+            # Cap the dict — evict the oldest sessions so a long-lived process
+            # serving many sessions doesn't leak memory.
+            while len(self._session_stats) > _MAX_SESSIONS:
+                self._session_stats.popitem(last=False)
+        else:
+            self._session_stats.move_to_end(session_id)
         stats["tool_calls"] += 1
         stats["successes" if success else "failures"] += 1
         stats["total_ms"] += duration_ms
         stats["tools_used"].add(tool)
 
-    def get_recent(
-        self, n: int = 20, session_id: str | None = None
-    ) -> list[dict[str, Any]]:
-        if not self.path.exists():
+    def get_recent(self, n: int = 20, session_id: str | None = None) -> list[dict[str, Any]]:
+        path = self._ensure_path()
+        if path is None or not path.exists():
             return []
         try:
-            lines = self.path.read_text().strip().splitlines()
+            with path.open("rb") as f:
+                f.seek(0, os.SEEK_END)
+                size = f.tell()
+                f.seek(max(0, size - _TAIL_BYTES))
+                blob = f.read()
         except OSError:
             return []
+        # Drop a possibly-partial first line when we didn't read from the start.
+        lines = blob.decode("utf-8", "replace").splitlines()
+        if size > _TAIL_BYTES and lines:
+            lines = lines[1:]
 
-        entries = []
+        entries: list[dict[str, Any]] = []
         for line in reversed(lines):
             if not line.strip():
                 continue
@@ -110,6 +165,15 @@ class AuditLogger:
             "avg_ms": stats["total_ms"] // max(stats["tool_calls"], 1),
             "tools_used": sorted(stats.get("tools_used", set())),
         }
+
+
+def scope_leaf_safe(p: Path) -> Path:
+    """``scope_leaf`` without raising — used only for the ``.path`` fallback."""
+    try:
+        from paths import scope_leaf
+        return scope_leaf(p)
+    except Exception:
+        return p
 
 
 def _sanitize_args(args: dict[str, Any]) -> dict[str, Any]:

--- a/graph/middleware/redaction.py
+++ b/graph/middleware/redaction.py
@@ -23,10 +23,21 @@ PATTERNS: dict[str, re.Pattern] = {
     "generic_api_key": re.compile(
         r"(?i)(?:api[_\-]?key|apikey)(?:[\"'\s:=]+)([A-Za-z0-9_\-]{16,})",
     ),
+    # Provider token shapes a tool error / payload might echo into the audit log.
+    "google_oauth": re.compile(r"\bya29\.[A-Za-z0-9_\-]+"),
+    "google_api_key": re.compile(r"\bAIza[A-Za-z0-9_\-]{20,}\b"),
+    "github_token": re.compile(r"\bgh[pousr]_[A-Za-z0-9]{30,}\b"),
+    "slack_token": re.compile(r"\bxox[baprs]-[A-Za-z0-9\-]{10,}\b"),
+    "aws_access_key": re.compile(r"\bAKIA[0-9A-Z]{16}\b"),
+    "discord_token": re.compile(r"\b[MNO][A-Za-z0-9_\-]{23}\.[A-Za-z0-9_\-]{6}\.[A-Za-z0-9_\-]{27,}\b"),
+    "client_secret": re.compile(
+        r"(?i)client[_\-]?secret(?:[\"'\s:=]+)([A-Za-z0-9_\-]{12,})",
+    ),
     "env_var_assignment": re.compile(
         r"(?i)\b(OPENAI_API_KEY|LANGFUSE_SECRET_KEY|LANGFUSE_PUBLIC_KEY|"
         r"A2A_AUTH_TOKEN|API_KEY|SECRET_KEY|AUTH_TOKEN|ACCESS_TOKEN|"
-        r"PRIVATE_KEY)\s*[=:]\s*\S+",
+        r"PRIVATE_KEY|DISCORD_BOT_TOKEN|BOT_TOKEN|GATEWAY_API_KEY|GH_PAT|"
+        r"CLIENT_SECRET)\s*[=:]\s*\S+",
     ),
 }
 
@@ -49,6 +60,14 @@ _SENSITIVE_ENV_KEYS: frozenset[str] = frozenset({
     "auth_token",
     "access_token",
     "private_key",
+    "DISCORD_BOT_TOKEN",
+    "bot_token",
+    "GATEWAY_API_KEY",
+    "GH_PAT",
+    "client_secret",
+    "CLIENT_SECRET",
+    "refresh_token",
+    "REFRESH_TOKEN",
 })
 
 _PLACEHOLDER = "[REDACTED]"
@@ -80,6 +99,18 @@ def _redact_string_simple(value: str) -> str:
         return key + _PLACEHOLDER
 
     value = PATTERNS["env_var_assignment"].sub(_replace_env_var, value)
+
+    # Provider token shapes — full-match redaction.
+    for _name in ("google_oauth", "google_api_key", "github_token",
+                  "slack_token", "aws_access_key", "discord_token"):
+        value = PATTERNS[_name].sub(_PLACEHOLDER, value)
+
+    # client_secret — redact the captured credential value group.
+    def _replace_client_secret(m: re.Match) -> str:
+        full, cred = m.group(0), m.group(1)
+        return full[: len(full) - len(cred)] + _PLACEHOLDER
+
+    value = PATTERNS["client_secret"].sub(_replace_client_secret, value)
     return value
 
 

--- a/tests/middleware/test_redaction.py
+++ b/tests/middleware/test_redaction.py
@@ -296,3 +296,26 @@ def test_langfuse_redaction():
     assert result["input"]["query"] == "get config"
     assert "mytoken1234567890" not in result["output"]
     assert "[REDACTED]" in result["output"]
+
+
+def test_provider_token_shapes_redacted():
+    """Discord / Google / GitHub / Slack / AWS / client_secret tokens that a tool
+    error could echo must not survive into the audit log (prod-readiness)."""
+    from graph.middleware.redaction import redact
+
+    # Obviously-fake values that still match the regex SHAPES (so they exercise
+    # the patterns) but aren't real tokens — avoids tripping secret scanning.
+    samples = [
+        "M" + "A" * 23 + ".AAAAAA." + "A" * 30,        # discord shape
+        "ghp_" + "A" * 36,                              # github shape (fails real checksum)
+        "ya29." + "A" * 30,                             # google oauth shape
+        "AIza" + "A" * 30,                              # google api-key shape
+        "AKIA" + "A" * 16,                              # aws shape
+        "xoxb-0000000000-" + "a" * 12,                  # slack shape
+    ]
+    for s in samples:
+        assert "[REDACTED]" in redact(s), s
+    # captured-value shape
+    assert "[REDACTED]" in redact("client_secret: " + "A" * 16)
+    # benign text is left intact (no over-redaction)
+    assert redact("the quick brown fox AKIA jumps") == "the quick brown fox AKIA jumps"

--- a/tests/test_audit_hardening.py
+++ b/tests/test_audit_hardening.py
@@ -1,0 +1,51 @@
+"""Prod-readiness: the audit log is instance-scoped, rotates at a size cap, and
+get_recent reads only a bounded tail (no unbounded growth / full-file OOM)."""
+
+import json
+
+from audit import AuditLogger
+
+
+def _log_n(a: AuditLogger, n: int):
+    for i in range(n):
+        a.log(session_id="s", tool=f"t{i}", args={}, result_summary="ok", duration_ms=1, success=True)
+
+
+def test_writes_and_get_recent_tail(tmp_path):
+    a = AuditLogger(path=tmp_path / "audit.jsonl")
+    _log_n(a, 50)
+    recent = a.get_recent(n=10)
+    assert len(recent) == 10
+    assert recent[-1]["tool"] == "t49"  # newest last, chronological
+    assert all(set(e) >= {"ts", "tool", "session_id"} for e in recent)
+
+
+def test_rotates_at_size_cap(tmp_path, monkeypatch):
+    import audit
+    monkeypatch.setattr(audit, "_MAX_BYTES", 2_000)  # tiny cap to force a rotation
+    a = AuditLogger(path=tmp_path / "audit.jsonl")
+    _log_n(a, 200)
+    live = tmp_path / "audit.jsonl"
+    backup = tmp_path / "audit.jsonl.1"
+    assert live.exists()
+    assert backup.exists(), "should have rotated a .1 backup"
+    # the live file stays bounded (≈ one cap worth), not the full 200 lines
+    assert live.stat().st_size <= 2_000 + 4_000
+
+
+def test_session_stats_capped(tmp_path, monkeypatch):
+    import audit
+    monkeypatch.setattr(audit, "_MAX_SESSIONS", 5)
+    a = AuditLogger(path=tmp_path / "audit.jsonl")
+    for i in range(20):
+        a.log(session_id=f"sess-{i}", tool="t", args={}, result_summary="", duration_ms=1, success=True)
+    assert len(a._session_stats) <= 5  # oldest evicted
+
+
+def test_instance_scoping(tmp_path, monkeypatch):
+    # PROTOAGENT_INSTANCE namespaces the path under an instance segment.
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "inst-a")
+    a = AuditLogger(path=tmp_path / "audit.jsonl")
+    a.log(session_id="s", tool="t", args={}, result_summary="", duration_ms=1, success=True)
+    assert "inst-a" in str(a.path)
+    assert json.loads(a.path.read_text().splitlines()[0])["tool"] == "t"


### PR DESCRIPTION
Prod-readiness audit **P1/P2** (observability + data integrity).

**`audit.py`** — was a module singleton writing an *unbounded* `/sandbox/audit/audit.jsonl` that ignored instance-scoping, with a `get_recent` that read the *entire* file:
- **Instance-scoped** path via `paths.scope_leaf` (ADR 0004) — two instances on a shared FS no longer interleave into one file. Resolved lazily so it picks up `PROTOAGENT_INSTANCE` (seeded after import).
- **Rotates** at a 50MB cap (one `.1` backup) — can't fill the disk.
- `get_recent` reads only the last **512KB tail** — no OOM on a large log.
- `_session_stats` capped (evict oldest) — no slow leak.

**`redaction.py`** — added provider token shapes a tool error could echo into the audit trail: Discord, Google OAuth (`ya29.`) + API key (`AIza`), GitHub (`gh?_`), Slack (`xox?-`), AWS (`AKIA`), `client_secret`; + `DISCORD_BOT_TOKEN`/`GATEWAY_API_KEY`/`GH_PAT`/`refresh_token` to the env lists.

Benign text untouched; 1054 tests green; ruff clean. (Test fixtures use obviously-fake, regex-shaped values so they don't trip secret scanning.) 🤖 Generated with [Claude Code](https://claude.com/claude-code)