### PR TITLE
data: WAL + busy_timeout on telemetry/activity/inbox/beads stores (P2)

### DIFF
--- a/activity/store.py
+++ b/activity/store.py
@@ -56,6 +56,8 @@ class ActivityLog:
 
     def _connect(self) -> sqlite3.Connection:
         db = sqlite3.connect(self.path)
+        db.execute("PRAGMA journal_mode=WAL")   # concurrent reads during writes
+        db.execute("PRAGMA busy_timeout=5000")  # wait (don't error) on lock contention
         db.row_factory = sqlite3.Row
         return db
 

--- a/beads/store.py
+++ b/beads/store.py
@@ -53,6 +53,8 @@ class BeadsStore:
         self.path.parent.mkdir(parents=True, exist_ok=True)
         self._lock = threading.Lock()
         self._conn = sqlite3.connect(str(self.path), check_same_thread=False)
+        self._conn.execute("PRAGMA journal_mode=WAL")   # concurrent reads during writes
+        self._conn.execute("PRAGMA busy_timeout=5000")  # wait (don't error) on lock contention
         self._conn.row_factory = sqlite3.Row
         self._init_schema()
 

--- a/inbox/store.py
+++ b/inbox/store.py
@@ -38,6 +38,8 @@ class InboxStore:
 
     def _connect(self) -> sqlite3.Connection:
         db = sqlite3.connect(self.path)
+        db.execute("PRAGMA journal_mode=WAL")   # concurrent reads during writes
+        db.execute("PRAGMA busy_timeout=5000")  # wait (don't error) on lock contention
         db.row_factory = sqlite3.Row
         return db
 

--- a/telemetry_store.py
+++ b/telemetry_store.py
@@ -39,6 +39,8 @@ class TelemetryStore:
 
     def _connect(self) -> sqlite3.Connection:
         db = sqlite3.connect(self.path)
+        db.execute("PRAGMA journal_mode=WAL")   # concurrent reads during writes
+        db.execute("PRAGMA busy_timeout=5000")  # wait (don't error) on lock contention
         db.row_factory = sqlite3.Row
         return db
 


### PR DESCRIPTION
Prod-readiness audit **P2** (data integrity). These four sqlite stores opened connections with **no PRAGMAs** — unlike `graph/checkpointer.py` + the knowledge store. Under concurrent access (scheduler tick + console read + agent write) they threw `database is locked` instead of waiting, with no WAL concurrency.

Added `journal_mode=WAL` + `busy_timeout=5000` to each connect (matching the checkpointer). `busy_timeout` especially helps beads' single shared connection.

Verified: PRAGMAs apply; 65 store tests green; ruff clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)