### PR TITLE
security: bearer-gate the operator/console + OpenAI-compat APIs (P0)

### DIFF
--- a/a2a_auth.py
+++ b/a2a_auth.py
@@ -35,8 +35,18 @@ _API_KEY: list[str] = [""]
 # Allowed origins: None = verification disabled; list = allowlist.
 _ALLOWED_ORIGINS: list[list[str] | None] = [None]
 
-# Path prefix the guard applies to. The agent card + health are public.
-_GUARDED_PREFIX = "/a2a"
+# Path prefixes the guard applies to: the A2A JSON-RPC surface plus the operator
+# console + OpenAI-compat APIs (which drive subagents, rewrite config/SOUL,
+# schedule jobs, and run turns). The agent card, /healthz, /metrics, and the
+# static console assets live OUTSIDE these prefixes and stay public.
+_GUARDED_PREFIXES = ("/a2a", "/api/", "/v1/")
+
+# Exempt from the guard: the read-only Server-Sent-Events stream. Browsers'
+# EventSource cannot set an Authorization header, so a bearer can't be presented
+# here — and it only exposes activity/inbox events, not any action. The
+# agent-driving endpoints (/api/subagents/run, /api/config, /api/chat, /a2a, …)
+# stay guarded.
+_GUARD_EXEMPT = ("/api/events",)
 
 
 def set_bearer_token(token: str | None) -> None:
@@ -84,7 +94,10 @@ class A2AAuthMiddleware(BaseHTTPMiddleware):
     """Enforces bearer / X-API-Key / origin on the guarded A2A path."""
 
     async def dispatch(self, request: Request, call_next):
-        if not request.url.path.startswith(_GUARDED_PREFIX):
+        path = request.url.path
+        if not any(path.startswith(p) for p in _GUARDED_PREFIXES):
+            return await call_next(request)
+        if any(path.startswith(p) for p in _GUARD_EXEMPT):
             return await call_next(request)
 
         # X-API-Key (legacy) — enforced only when configured.

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -132,8 +132,27 @@ export function isDesktopWebview(): boolean {
   }
 }
 
+/** Operator bearer token, set in localStorage (`protoagent.authToken`). Sent on
+ * every fetch-based API + A2A call so a token-configured deployment's console
+ * authenticates against the server guard. Blank ⇒ no header — the default
+ * local/desktop case (no token) stays open. (The `/api/events` EventSource is
+ * exempt server-side since EventSource can't set headers.) */
+export function authToken(): string {
+  try {
+    return window.localStorage.getItem("protoagent.authToken") || "";
+  } catch {
+    return "";
+  }
+}
+
+function applyAuth(headers: Headers): Headers {
+  const t = authToken();
+  if (t) headers.set("Authorization", `Bearer ${t}`);
+  return headers;
+}
+
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
-  const headers = new Headers(options.headers);
+  const headers = applyAuth(new Headers(options.headers));
   let body: BodyInit | undefined;
   if (options.body !== undefined) {
     headers.set("Content-Type", "application/json");
@@ -578,7 +597,7 @@ export const api = {
       try {
         const res = await fetch(apiUrl("/api/chat"), {
           method: "POST",
-          headers: { "Content-Type": "application/json" },
+          headers: applyAuth(new Headers({ "Content-Type": "application/json" })),
           signal: handlers.signal,
           body: JSON.stringify({ message, session_id: sessionId }),
         });
@@ -608,7 +627,7 @@ export const api = {
     const rpcId = `web-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const response = await fetch(apiUrl("/a2a"), {
       method: "POST",
-      headers: { "Content-Type": "application/json", "A2A-Version": "1.0" },
+      headers: applyAuth(new Headers({ "Content-Type": "application/json", "A2A-Version": "1.0" })),
       signal: handlers.signal,
       // A2A 1.0 (a2a-sdk): the streaming RPC is `SendStreamingMessage` (0.3's
       // `message/stream` is gone → -32601 Method not found, the cause of a

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -39,9 +39,13 @@ Setup without the wizard: `python -m server --setup` validates the live config (
 
 | Variable | Default | What |
 |---|---|---|
-| `A2A_AUTH_TOKEN` | (unset — open mode) | Required bearer token for all A2A routes (POST `/a2a`, `message/send`, `tasks/*`, SSE streaming). When set, requests without `Authorization: Bearer <token>` get 401. Token comparison uses `hmac.compare_digest` (constant-time). |
+| `A2A_AUTH_TOKEN` | (unset — open mode) | Required bearer token for the A2A routes **and** the operator/console + OpenAI-compat APIs — `/a2a`, `/api/*`, `/api/chat`, `/v1/*`. When set, requests without `Authorization: Bearer <token>` get 401. Constant-time comparison (`hmac.compare_digest`). |
 
-When unset, the handler logs a WARNING at startup (`"A2A auth token not configured — endpoint is open"`) and accepts all traffic — appropriate for local development, not production. When set, the agent card advertises `securitySchemes.bearer` so A2A consumers know to present credentials.
+When unset, startup logs a WARNING (`"A2A auth token not configured — endpoint is open"`) and accepts all traffic — fine for local dev (and safe behind the loopback-default bind, see `PROTOAGENT_HOST`), not for an exposed deployment. When set, the agent card advertises `securitySchemes.bearer`.
+
+**Scope.** The guard covers everything that can drive the agent: `/a2a`, the operator API (`/api/*` — run subagents, rewrite config/SOUL, schedule jobs), `/api/chat`, and `/v1/*`. **Public (never guarded):** `/healthz`, `/.well-known/agent-card.json`, `/metrics`, the static console at `/app`, and the read-only `/api/events` SSE stream (browsers' `EventSource` can't send an `Authorization` header; it exposes only activity/inbox events, no action).
+
+**Console.** When a token is set, the React console reads it from `localStorage["protoagent.authToken"]` and sends it as a bearer on every API + A2A call. Set it once in the browser (`localStorage.setItem("protoagent.authToken", "<token>")`) for a token-protected deployment; local/desktop runs (no token) need nothing.
 
 ## A2A agent-card endpoint
 

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -96,3 +96,48 @@ def test_origin_guard_rejects_unlisted_origin():
 def test_origin_guard_disabled_when_unset():
     a2a_auth.configure(bearer_token="", api_key="", allowed_origins_raw="")
     assert _client().post("/a2a", headers={"Origin": "https://anything.example"}).status_code == 200
+
+
+# ── 3. guard covers the console + OpenAI-compat APIs (prod-readiness) ──────────
+
+
+def _client_multi() -> TestClient:
+    routes = [
+        Route(p, lambda r: PlainTextResponse("ok"), methods=["GET", "POST"])
+        for p in ("/a2a", "/api/config", "/api/events", "/v1/chat/completions", "/healthz")
+    ]
+    app = Starlette(routes=routes)
+    app.add_middleware(a2a_auth.A2AAuthMiddleware)
+    return TestClient(app)
+
+
+def test_api_and_v1_are_guarded_when_token_set(monkeypatch):
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    a2a_auth.configure(bearer_token="secret", api_key="", allowed_origins_raw="")
+    c = _client_multi()
+    # operator API + OpenAI-compat now require the bearer (the P0 gap)
+    assert c.post("/api/config").status_code == 401
+    assert c.post("/v1/chat/completions").status_code == 401
+    assert c.post("/a2a").status_code == 401
+    hdr = {"Authorization": "Bearer secret"}
+    assert c.post("/api/config", headers=hdr).status_code == 200
+    assert c.post("/v1/chat/completions", headers=hdr).status_code == 200
+
+
+def test_events_stream_and_healthz_stay_public_when_token_set(monkeypatch):
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    a2a_auth.configure(bearer_token="secret", api_key="", allowed_origins_raw="")
+    c = _client_multi()
+    # EventSource can't send a bearer; the read-only event stream is exempt.
+    assert c.get("/api/events").status_code == 200
+    # /healthz is outside the guarded prefixes (probes/scrapers stay open).
+    assert c.get("/healthz").status_code == 200
+
+
+def test_apis_open_when_no_token(monkeypatch):
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    a2a_auth.configure(bearer_token=None, api_key="", allowed_origins_raw="")
+    c = _client_multi()
+    # default (no token) → everything open (local console keeps working)
+    for p in ("/a2a", "/api/config", "/v1/chat/completions", "/api/events", "/healthz"):
+        assert c.post(p).status_code in (200, 405)  # 405 only if method not allowed


### PR DESCRIPTION
Prod-readiness audit **P0** — the credential boundary, completing the console-auth fix after #581 (localhost-default bind).

The A2A guard only covered `/a2a`, so the operator API (`/api/*` — run subagents, rewrite config/SOUL, schedule jobs), `/api/chat`, and `/v1/*` were **unauthenticated even when an A2A token was set**.

## Change
- **`a2a_auth`**: guard `/a2a` + `/api/` + `/v1/` — engages only when a token is configured, so the no-token default stays open and the local console keeps working. **Exempt** the read-only `/api/events` SSE stream (`EventSource` cannot send a bearer; it exposes activity/inbox events, no action). `/healthz`, `/.well-known`, `/metrics`, static `/app` sit outside the prefixes → public.
- **console (`api.ts`)**: sends `Authorization: Bearer` from `localStorage["protoagent.authToken"]` on every fetch-based API + A2A call, so a token-protected deployment authenticates. Default (no token) unchanged.
- **docs**: env-vars auth section documents the scope + console token.

## Verified
- 11 auth tests (`/api`+`/v1` guarded when token set; `/api/events`+`/healthz` public; all-open when no token).
- web build + chat e2e green.
- **Live-smoked** a booted server with `A2A_AUTH_TOKEN`: `/api/runtime/status` 401 without → 200 with, `/a2a` 401 without, `/healthz` 200.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
