### PR TITLE
obs: A2A turn-outcome metrics for /metrics alerting (P2)

### DIFF
--- a/metrics.py
+++ b/metrics.py
@@ -22,6 +22,8 @@ _compactions = None
 _tool_calls = None
 _tool_latency = None
 _active_sessions = None
+_a2a_turns = None
+_a2a_turn_latency = None
 
 
 def _prefix() -> str:
@@ -32,6 +34,7 @@ def _prefix() -> str:
 def init():
     global _enabled, _llm_calls, _llm_latency, _llm_tokens, _llm_cache_tokens, _llm_cost
     global _tools_deferred, _compactions, _tool_calls, _tool_latency, _active_sessions
+    global _a2a_turns, _a2a_turn_latency
 
     try:
         from prometheus_client import Counter, Histogram, Gauge
@@ -77,6 +80,17 @@ def init():
         _active_sessions = Gauge(
             f"{p}_active_sessions", "Active chat sessions",
         )
+        # A2A turn outcomes — the durable signal for "turns are failing" alerting
+        # straight off /metrics (state ∈ completed|failed|canceled|…). Low
+        # cardinality. Paired latency histogram for turn duration.
+        _a2a_turns = Counter(
+            f"{p}_a2a_turns_total", "A2A turn outcomes by terminal state",
+            ["state"],
+        )
+        _a2a_turn_latency = Histogram(
+            f"{p}_a2a_turn_seconds", "A2A turn wall-clock duration",
+            buckets=[0.5, 1, 2, 5, 10, 20, 30, 60, 120, 300],
+        )
         _enabled = True
         print(f"[metrics] Prometheus metrics initialized (prefix={p}_)")
     except ImportError:
@@ -121,6 +135,19 @@ def record_compaction():
     fires + how often. Emitted from CountingSummarizationMiddleware."""
     if _enabled and _compactions is not None:
         _compactions.inc()
+
+
+def record_a2a_turn(state: str, duration_s: float | None = None):
+    """Count one terminal A2A turn by ``state`` (completed/failed/canceled) and,
+    when known, observe its wall-clock duration. Emitted from
+    ``server/a2a.py::_record_a2a_telemetry`` so /metrics can alert on a failing
+    or backed-up agent without scraping the telemetry SQL store."""
+    if not _enabled:
+        return
+    if _a2a_turns is not None:
+        _a2a_turns.labels(state=str(state or "unknown")).inc()
+    if _a2a_turn_latency is not None and duration_s is not None and duration_s >= 0:
+        _a2a_turn_latency.observe(duration_s)
 
 
 def record_tool_call(tool_name: str, success: bool, latency_s: float):

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -198,6 +198,14 @@ def _record_a2a_telemetry(outcome) -> None:
     """Write one per-turn telemetry row from an executor ``TurnOutcome``
     (ADR 0006 Slice 2). No-op when the telemetry store is off; best-effort so a
     failure never affects the turn."""
+    # Prometheus turn counter (independent of the SQL telemetry store) — lets
+    # /metrics alert on a failing/backed-up agent. Best-effort.
+    try:
+        import metrics
+        metrics.record_a2a_turn(outcome.state, (outcome.duration_ms or 0) / 1000.0)
+    except Exception:
+        pass
+
     store = STATE.telemetry_store
     if store is None:
         return

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,29 @@
+"""The A2A-turn metrics emit safely (prod-readiness: /metrics can alert on a
+failing/backed-up agent) and never break a turn."""
+
+import metrics
+
+
+def test_record_a2a_turn_safe_when_disabled():
+    # No init() — must be a no-op, never raise (metrics are optional).
+    metrics.record_a2a_turn("completed", 1.5)
+    metrics.record_a2a_turn("failed")
+    metrics.record_a2a_turn("", None)
+
+
+def test_record_a2a_turn_increments_when_enabled():
+    if metrics.is_enabled() or _try_init():
+        from prometheus_client import REGISTRY
+        p = metrics._prefix()
+        before = REGISTRY.get_sample_value(f"{p}_a2a_turns_total", {"state": "completed"}) or 0.0
+        metrics.record_a2a_turn("completed", 2.0)
+        after = REGISTRY.get_sample_value(f"{p}_a2a_turns_total", {"state": "completed"}) or 0.0
+        assert after == before + 1.0
+
+
+def _try_init() -> bool:
+    try:
+        metrics.init()
+        return metrics.is_enabled()
+    except Exception:
+        return False  # already-registered or prometheus missing — skip


### PR DESCRIPTION
Prod-readiness audit **P2**. `metrics.py` covered LLM/tool/cost/sessions but had **no A2A-turn signal** — so "turns are failing" / "backing up" couldn't be alerted from `/metrics` (it lived only in the telemetry SQL store).

- **`metrics.py`**: `a2a_turns_total{state}` counter (completed/failed/canceled — low cardinality) + `a2a_turn_seconds` latency histogram + `record_a2a_turn(state, dur)`.
- **`server/a2a.py`**: emit from `_record_a2a_telemetry`, independent of the SQL store, best-effort.
- Adds `tests/test_metrics.py` (the audit flagged none existed).

1059 tests green; ruff clean. 🤖 Generated with [Claude Code](https://claude.com/claude-code)