### PR TITLE
fix(mcp): a tool error degrades to a recoverable result, not a failed turn

### DIFF
--- a/tests/test_mcp_tool_error_handling.py
+++ b/tests/test_mcp_tool_error_handling.py
@@ -1,0 +1,76 @@
+"""roxy #58 — an MCP tool error must degrade into a recoverable tool result,
+not fail the whole A2A turn.
+
+`langchain-mcp-adapters` raises `ToolException` when an MCP server returns an
+error (e.g. a board `404 Feature not found` from a stale id). `build_mcp_tools`
+sets `_mcp_tool_error_handler` as each MCP tool's `handle_tool_error`, so the
+exception is caught *inside* the tool (BaseTool.arun) and returned to the model —
+never propagating out of the ToolNode to fail the turn.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.tools import StructuredTool, ToolException
+
+from tools.mcp_tools import _mcp_tool_error_handler
+
+
+def _raising_tool() -> StructuredTool:
+    """A stand-in for an MCP tool that errors the way the adapter does."""
+
+    async def _boom(**kwargs) -> str:
+        raise ToolException('API error 404: {"success":false,"error":"Feature not found"}')
+
+    return StructuredTool.from_function(
+        coroutine=_boom, name="automaker__get_feature", description="stub"
+    )
+
+
+def test_handler_returns_recoverable_message():
+    msg = _mcp_tool_error_handler(ToolException("API error 404: Feature not found"))
+    assert "Tool error:" in msg
+    assert "Feature not found" in msg
+    assert "fatal" in msg.lower()  # explicitly tells the model not to give up
+
+
+@pytest.mark.asyncio
+async def test_tool_error_degrades_instead_of_raising():
+    tool = _raising_tool()
+    # Without the handler, ainvoke would raise ToolException (the turn-killing path).
+    with pytest.raises(ToolException):
+        await tool.ainvoke({})
+
+    # With the handler set (as build_mcp_tools does), the error becomes a result.
+    tool.handle_tool_error = _mcp_tool_error_handler
+    out = await tool.ainvoke({})
+    assert isinstance(out, str)
+    assert "Tool error:" in out and "Feature not found" in out
+
+
+def test_build_mcp_tools_wires_the_handler(monkeypatch):
+    """The kept MCP tools come back with handle_tool_error set."""
+    import tools.mcp_tools as mt
+
+    kept = _raising_tool()
+
+    class _FakeClient:
+        def get_tools(self):  # awaited via _run_blocking
+            async def _coro():
+                return [kept]
+            return _coro()
+
+    monkeypatch.setattr(mt, "MultiServerMCPClient", lambda *a, **k: _FakeClient(), raising=False)
+    # patch the imported symbol path used inside build_mcp_tools
+    import langchain_mcp_adapters.client as mcp_client
+    monkeypatch.setattr(mcp_client, "MultiServerMCPClient", lambda *a, **k: _FakeClient())
+
+    class _Cfg:
+        mcp_enabled = True
+        mcp_timeout_seconds = 5.0
+        mcp_denylist = []
+        mcp_servers = [{"name": "automaker", "command": "x", "args": []}]
+
+    _clients, tools_out, _meta = mt.build_mcp_tools(_Cfg())
+    assert tools_out, "expected the stub MCP tool to be kept"
+    assert tools_out[0].handle_tool_error is _mcp_tool_error_handler

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -20,6 +20,24 @@ from typing import Any
 log = logging.getLogger("protoagent.mcp")
 
 
+def _mcp_tool_error_handler(exc: Exception) -> str:
+    """Turn an MCP tool failure into a recoverable tool result (roxy #58).
+
+    ``langchain-mcp-adapters`` raises ``ToolException`` when the server returns an
+    error (e.g. a board ``404 Feature not found`` from a stale id). Left unhandled
+    that propagates out of the ToolNode and fails the WHOLE A2A turn. Setting this
+    as each MCP tool's ``handle_tool_error`` makes the tool return this string to
+    the model instead — so a single recoverable tool error (stale arg, transient
+    4xx) degrades into something the model can adapt to, not a dead turn.
+    """
+    return (
+        f"Tool error: {exc}. The tool call failed — commonly a stale/invalid "
+        "argument (e.g. an id that no longer exists) or a transient error. Do NOT "
+        "treat this as fatal: adjust the arguments and retry, try a different "
+        "approach, or continue without this tool's result."
+    )
+
+
 def _server_connection(server: dict) -> dict | None:
     """Map a config ``mcp.servers[]`` entry to a langchain-mcp-adapters
     connection dict. Returns ``None`` for an entry missing its essential fields
@@ -226,6 +244,12 @@ def build_mcp_tools(config, *, plugin_servers=None) -> tuple[list, list, list[di
             if tool.name in core_names:
                 log.warning("[mcp] %s: %s collides with a core tool — skipped", name, tool.name)
                 continue
+            # roxy #58: a tool error (e.g. board 404) must degrade into a tool
+            # result the model can recover from, not fail the whole turn.
+            try:
+                tool.handle_tool_error = _mcp_tool_error_handler
+            except Exception:  # noqa: BLE001 — best-effort; never block tool registration
+                log.debug("[mcp] %s: could not set handle_tool_error on %s", name, tool.name)
             kept.append(tool)
 
         clients.append(client)


### PR DESCRIPTION
Closes #594.

## Problem
`build_mcp_tools` (`tools/mcp_tools.py`) appends MCP tools **without `handle_tool_error`**. `langchain-mcp-adapters` raises `ToolException` on an `isError` result (e.g. a server `404 Feature not found` from a stale id), which then propagates out of the ToolNode, through `astream_events`, and fails the **whole A2A turn** (`TASK_FAILED`). A single recoverable tool error (stale arg, transient 4xx) shouldn't kill an otherwise-fine turn — especially during multi-step/triage work that touches many ids.

Hit in the roxy fork (protoLabsAI/roxy#58); root cause is here in unmodified template code, so all forks inherit the fix via sync.

## Fix
Set `handle_tool_error` on each kept MCP tool so the `ToolException` is caught inside `BaseTool.arun` and returned to the model as a tool result it can act on (retry / skip / adapt):

```python
tool.handle_tool_error = _mcp_tool_error_handler   # returns a non-fatal, actionable message
```

Scoped to MCP tools (the documented failure path); core/plugin tools already return strings rather than raising.

## Tests (`tests/test_mcp_tool_error_handling.py`)
- a `ToolException`-raising tool, with the handler set, returns the error string instead of raising;
- `build_mcp_tools` wires `handle_tool_error` onto kept tools;
- the handler message is non-fatal + actionable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)