### PR TITLE
feat(plugins): spawn CLI coding agents over ACP (code_with) — ADR 0024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Spawn CLI coding agents over ACP** — a new opt-in `coding_agent` plugin
+  (ADR 0024) adds a `code_with(agent, task)` tool that hands a real, repo-scoped
+  coding job to a purpose-built CLI coding agent (protoCLI `proto`, Claude Code,
+  Codex, Gemini CLI) and returns its result. protoAgent is the
+  [ACP](https://agentclientprotocol.com) *client* — it launches the agent as a
+  subprocess and drives one session over JSON-RPC 2.0 on its stdio
+  (`initialize` → `session/new` → `session/prompt`), accumulating the agent's
+  message as the answer. The ACP client is a port of ORBIS's canonical
+  implementation. Ships **disabled with no agents configured** — each agent gets
+  file + shell access in its (config-pinned, auto-allowed) workdir, so it's a
+  deliberate opt-in; enable with `plugins: { enabled: [coding_agent] }` and
+  declare agents under the `coding_agent` config section. One client (subprocess +
+  session) is cached per agent so follow-up calls continue the same thread.
+  PR1 is synchronous (final answer returned; `tool_call` titles logged); live
+  narration onto A2A working frames + HITL permission policy land next.
+  See [the guide](docs/guides/coding-agents.md).
+
 ## [0.15.1] - 2026-06-05
 
 ### Fixed

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -59,6 +59,7 @@ export default defineConfig({
             { text: "Scheduler", link: "/guides/scheduler" },
             { text: "Discord surface", link: "/guides/discord" },
             { text: "Google (Gmail + Calendar)", link: "/guides/google" },
+            { text: "Spawn CLI coding agents (ACP)", link: "/guides/coding-agents" },
             { text: "Operator console (React/Tauri)", link: "/guides/react-tauri-ui" },
             { text: "Wire Langfuse + Prometheus", link: "/guides/observability" },
             { text: "Run multiple instances", link: "/guides/multi-instance" },

--- a/docs/adr/0024-spawn-cli-coding-agents-acp.md
+++ b/docs/adr/0024-spawn-cli-coding-agents-acp.md
@@ -1,0 +1,137 @@
+# 0024 — Spawn CLI coding agents over ACP (`code_with`)
+
+Status: **Accepted** (PR1 — thin vertical)
+
+## Context
+
+protoAgent's lead agent already delegates in two ways: to **in-process LLM
+subagents** via `task()` (DeerFlow pattern, `graph/subagents/`) and to **remote
+A2A peers** via `peer_consult` (`tools/peer_tools.py`). Both are *talk to another
+model* delegations — neither can pick up a repo, edit files, run the test suite,
+and hand back a diff.
+
+There is a whole class of work that wants exactly that: "add a `/healthz` route
+and run the tests", "fix the failing import in `server/chat.py`". A purpose-built
+**CLI coding agent** — protoCLI (`proto`), Claude Code, Codex, Gemini CLI — does
+this far better than a generic tool loop, because it carries its own file access,
+shell, repo-map, edit/verify harness, and approval UX.
+
+The protoLabs companion stack already solved this. **ORBIS** (the Python voice
+companion) is an **ACP client**: it launches a coding agent as a subprocess and
+drives one session over the [Agent Client Protocol](https://agentclientprotocol.com)
+— JSON-RPC 2.0, newline-delimited, on the child's stdin/stdout. The same
+`delegate_to` registry routes `a2a` / `openai` / `acp` delegate types. protoCLI,
+on the other side, speaks the matching server role (`proto --acp`).
+
+This ADR brings the **ACP-client leg** into protoAgent so our agents can spawn
+CLI coding agents. We do **not** port ORBIS's whole `delegate_to` registry —
+protoAgent already covers the `a2a` and `openai` legs differently (peers +
+subagents + the LiteLLM gateway). The new capability is just the ACP one.
+
+## Decision
+
+Ship ACP-client support as a **first-party, opt-in plugin** (`plugins/coding_agent`),
+not a core tool. It contributes one tool — `code_with(agent, task)` — backed by
+a small ACP client (a port of ORBIS's `acp/client.py`).
+
+### Why a plugin, not core
+
+- The plugin seam already gives config + secrets + Settings + enable/disable for
+  free, with **zero core edits** — matching the operator-fork contract (ADR 0019)
+  and the Discord/Google precedent (ADR 0018).
+- Spawning a coding agent with file + shell access in a workdir is a real
+  authority delegation. It should be **off by default** and explicitly opted into,
+  exactly like the shipped `hello` example plugin (`enabled: false`).
+- Not every fork wants this. A plugin keeps the default tool surface lean
+  (ADR 0005, tool pollution).
+
+### Shape
+
+```
+plugins/coding_agent/
+  protoagent.plugin.yaml   # config_section: coding_agent; agents: []; enabled: false
+  acp_client.py            # AcpClient — JSON-RPC 2.0 over the child's stdio
+  __init__.py              # register(): builds code_with from configured agents
+```
+
+Config (a top-level `coding_agent` section, ADR 0019):
+
+```yaml
+coding_agent:
+  default_timeout_s: 600        # coding is slow; per-agent override available
+  agents:
+    - name: proto              # the name the LLM passes to code_with(agent=…)
+      command: proto           # binary on PATH
+      args: ["--acp"]          # ACP server mode
+      workdir: ~/dev/my-repo   # session cwd — the confinement boundary
+      # env: { FOO: bar }      # optional extra env (merged over the process env)
+      # timeout_s: 900         # optional per-agent override
+```
+
+The tool the lead agent sees:
+
+```
+code_with(agent="proto", task="add a /healthz route and run the tests")
+  → the agent's final message text (the work happens in its own session)
+```
+
+### Confinement & permission posture (PR1)
+
+- **Workdir is config-pinned.** `code_with` takes only `agent` + `task` — never a
+  caller-chosen path. The cwd comes from the matched config entry, so the LLM
+  cannot point a coding agent at an arbitrary directory. Workdirs must be listed
+  in config; an unknown `agent` returns an error listing the configured ones.
+- **Auto-allow within the workdir.** The client advertises no client-served
+  `fs`/`terminal` capability, so the coding agent uses its *own* file/shell
+  access, scoped to the session cwd. Inbound `session/request_permission` is
+  auto-approved (first `allow` option), mirroring ORBIS's PR1 policy. The coding
+  agent self-governs inside its sandbox dir.
+- The subprocess inherits the server's env (plus any per-agent `env`). Run
+  protoAgent under an account whose ambient credentials you're willing to lend
+  the coding agent — or scope its `workdir` to a throwaway checkout.
+
+### Wire protocol (ACP, client side)
+
+```
+→ initialize        {protocolVersion: 1, clientCapabilities: {fs:{…false}, terminal:false}}
+→ session/new       {cwd, mcpServers: []}                       ← {sessionId}
+→ session/prompt    {sessionId, prompt: [{type:text, text}]}    ← {stopReason}
+← session/update    {update:{sessionUpdate:"agent_message_chunk", content:{text}}}   (accumulated → answer)
+← session/update    {update:{sessionUpdate:"tool_call", title}}                       (narration → logged)
+← session/request_permission  {options:[…]}  → auto-allow
+```
+
+One `AcpClient` owns one subprocess + one session, **cached per agent** so
+follow-up `code_with` calls continue the same thread (mirrors the A2A peer's
+sticky `contextId`). A per-agent lock serializes turns (a session is a single
+conversation; `task_batch` must not interleave two prompts on one session).
+
+## Scope
+
+**PR1 (this ADR):** ACP client + `code_with` + config + auto-allow + tests +
+docs. Synchronous — the final answer is returned; `tool_call` titles are logged,
+not yet streamed to callers.
+
+**Later PRs:** live narration of `tool_call` titles onto A2A working-status
+frames (so an operator watching a turn sees "Editing app.py"); richer permission
+policy (HITL gating via `ask_human`, allow-by-kind); more shipped agent recipes
+(claude-code-acp, codex, gemini); an eval case.
+
+## Consequences
+
+- protoAgent gains a third delegation altitude: **hand a real coding job to a
+  purpose-built CLI agent** and get the result back — without forking.
+- The security surface is explicit and opt-in: disabled by default, empty agent
+  list by default, workdir-confined, documented.
+- We take a dependency on the target agent being installed and on PATH; a missing
+  binary returns a clear error string, not a crash.
+
+## Alternatives considered
+
+- **Core tool module** (`tools/acp_tools.py`) — always present like `peer_tools`.
+  Rejected: edits core for a capability most forks won't use, and loses the
+  free config/Settings/enable-disable plumbing.
+- **Full `delegate_to` registry port** (a2a + openai + acp) — most faithful to
+  ORBIS. Rejected for now: largest blast radius, and it overlaps protoAgent's
+  existing peer + subagent + gateway seams. The ACP leg is the only genuinely
+  missing one.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -32,3 +32,4 @@ decision, numbered, never deleted (supersede instead).
 | [0021](./0021-agent-memory-architecture.md) | Agent memory: extract, don't dump | Accepted |
 | [0022](./0022-activity-provenance-feed.md) | Activity is a provenance feed, not a second chat | Accepted |
 | [0023](./0023-server-decomposition.md) | Decompose server.py: AppState + composition root | Accepted |
+| [0024](./0024-spawn-cli-coding-agents-acp.md) | Spawn CLI coding agents over ACP (`code_with`) | Accepted (PR1) |

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -1,0 +1,126 @@
+# Spawn CLI coding agents (ACP)
+
+An **optional, opt-in plugin** ([ADR 0024](/adr/0024-spawn-cli-coding-agents-acp))
+that lets the lead agent hand a real coding job to a purpose-built **CLI coding
+agent** — protoCLI (`proto`), Claude Code, Codex, Gemini CLI — and get the result
+back.
+
+Where `task()` delegates to an in-process LLM subagent and `peer_consult` talks
+to a remote A2A peer, **`code_with(agent, task)`** spawns a coding agent that
+carries its own file access, shell, repo-map, and edit/verify loop — so it can
+read/edit/run code in a repo far better than a generic tool loop. It drives the
+coding agent over the [Agent Client Protocol](https://agentclientprotocol.com)
+(ACP): JSON-RPC 2.0 over the child's stdin/stdout. protoAgent is the ACP
+*client*; `proto --acp` is the matching server.
+
+> **Security:** a configured coding agent gets **file + shell access in its
+> workdir** (auto-allowed, confined to that directory — see
+> [Permission posture](#permission-posture)). The plugin therefore ships
+> **disabled with no agents** — you enable it *and* declare agents explicitly.
+
+## Enable it
+
+The coding agent runs as a local subprocess, so this is configured in YAML, not
+the in-app Settings (each agent grants local authority and deserves a deliberate
+edit):
+
+```yaml
+# config/langgraph-config.yaml
+plugins:
+  enabled: [coding_agent]
+
+coding_agent:
+  default_timeout_s: 600          # coding is slow; per-agent override below
+  agents:
+    - name: proto                 # the name the LLM passes to code_with(agent=…)
+      command: proto              # binary on PATH
+      args: ["--acp"]             # ACP server mode
+      workdir: ~/dev/my-repo      # session cwd — the confinement boundary
+      # env: { SOME_KEY: value }  # optional extra env, merged over the process env
+      # timeout_s: 900            # optional per-agent override (seconds)
+```
+
+Enabling plugins needs a **restart** (plugin tools wire once at process init).
+On boot you'll see `[coding_agent] registered code_with for N agent(s)`.
+
+### Other coding agents
+
+Any agent that speaks ACP works — just point `command`/`args` at it:
+
+```yaml
+  agents:
+    - name: proto
+      command: proto
+      args: ["--acp"]
+      workdir: ~/dev/my-repo
+    - name: claude-code
+      command: npx
+      args: ["@zed-industries/claude-code-acp"]
+      workdir: ~/dev/my-repo
+```
+
+The binary must be installed and on the `PATH` of the process running protoAgent.
+A missing binary returns a clear error string to the agent (it doesn't crash).
+
+## Use it
+
+The lead agent calls the tool; the configured agent names appear in the tool's
+description so the model knows what it can pass:
+
+```
+code_with(agent="proto", task="Add a GET /healthz route to server/, wire it
+into the app, and run the tests. Report what you changed.")
+```
+
+Notes for whoever writes the `task`:
+
+- The coding agent **does not see this conversation** — make `task` a
+  self-contained brief: the goal, the relevant files if known, and the
+  definition of done ("run the tests", "and lint").
+- You **cannot** choose the directory — each agent works in its pre-configured
+  `workdir`. To work in a different repo, configure another agent.
+- The call **blocks** until the turn finishes (coding is slow). The default
+  timeout is `default_timeout_s` (600s) unless the agent overrides it.
+- **Follow-up calls to the same agent continue the same session** — so you can
+  iterate: `code_with(agent="proto", task="now also add a test for it")`.
+
+## Permission posture
+
+PR1 (the current cut) auto-allows the coding agent's actions, confined to its
+workdir:
+
+- **Workdir is config-pinned.** `code_with` takes only `agent` + `task` — never a
+  path. The cwd comes from config, so the model can't aim a coding agent at an
+  arbitrary directory.
+- **Auto-allow within the workdir.** protoAgent advertises no client-served
+  `fs`/`terminal` capability, so the coding agent uses its *own* file/shell
+  access, scoped to the session cwd. Inbound `session/request_permission` is
+  auto-approved. The coding agent self-governs inside its sandbox dir.
+- The subprocess **inherits protoAgent's environment** (plus any per-agent
+  `env`). Run protoAgent under an account whose ambient credentials you're
+  willing to lend the coding agent, or scope the `workdir` to a throwaway
+  checkout.
+
+Coming in later PRs (ADR 0024): live narration of the coding agent's progress
+("Editing app.py") onto A2A working-status frames; HITL permission gating via
+`ask_human`; allow-by-kind policy.
+
+## How it works
+
+```
+code_with(agent, task)
+  → AcpClient (plugins/coding_agent/acp_client.py)
+      → spawn `command args` in workdir, JSON-RPC 2.0 over its stdio:
+        initialize → session/new(cwd) → session/prompt(task)
+      ← session/update {agent_message_chunk}   → accumulated into the answer
+      ← session/update {tool_call, title}        → narrated (logged)
+      ← session/request_permission               → auto-allowed
+  → returns the agent's final message text
+```
+
+One `AcpClient` (subprocess + session) is **cached per agent** so follow-up calls
+continue the thread; a per-agent lock serializes turns (a session is a single
+conversation — `task_batch` won't interleave two prompts on one).
+
+See [Plugins](/guides/plugins) for the plugin model in general, and
+[ADR 0024](/adr/0024-spawn-cli-coding-agents-acp) for the design rationale.

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -10,7 +10,9 @@ explicitly — only enable plugins you trust.
 
 > The first-party **Discord** and **Google** integrations ship as plugins
 > (`plugins/discord/`, `plugins/google/`) — disable either with
-> `plugins: { disabled: [discord] }` / `[google]`, no core edit.
+> `plugins: { disabled: [discord] }` / `[google]`, no core edit. The opt-in
+> **coding_agent** plugin (`plugins/coding_agent/`) adds `code_with` to spawn a
+> CLI coding agent over ACP — see [Spawn CLI coding agents](/guides/coding-agents).
 
 > **Trust model.** This is the in-process / trusted model (matching Hermes): an
 > enabled plugin's `register()` runs as the agent. Don't enable code you

--- a/plugins/coding_agent/__init__.py
+++ b/plugins/coding_agent/__init__.py
@@ -1,0 +1,162 @@
+"""CLI coding-agent plugin — spawn a coding agent over ACP (ADR 0024).
+
+Contributes one tool, ``code_with(agent, task)``, that hands a coding job to a
+configured CLI coding agent (protoCLI ``proto``, Claude Code, Codex, Gemini CLI)
+and returns its result. The agent is driven over the Agent Client Protocol
+(JSON-RPC 2.0 over the child's stdio) by ``acp_client.AcpClient``.
+
+The plugin ships disabled with an empty agent list — each configured agent gets
+file + shell access in its workdir (auto-allowed, confined to that dir), so it's
+a deliberate opt-in. Enable with ``plugins: { enabled: [coding_agent] }`` and add
+agents under the ``coding_agent`` config section. See docs/guides/coding-agents.md.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from langchain_core.tools import tool
+
+from tools.fallbacks import with_fallback
+
+from .acp_client import AcpClient, AcpError
+
+log = logging.getLogger("protoagent.plugins.coding_agent")
+
+# One client (subprocess + session) per agent, keyed by its launch signature so a
+# config change spins up a fresh client. Module-global so the session persists
+# across graph builds / turns; a per-agent lock serializes turns (a session is a
+# single conversation — ``task_batch`` must not interleave two prompts on one).
+_CLIENTS: dict[tuple, AcpClient] = {}
+_LOCKS: dict[str, asyncio.Lock] = {}
+
+
+def _normalize_agents(raw) -> dict[str, dict]:
+    """Validate the configured ``agents`` list → {name: spec}. Drops bad entries
+    (logged) rather than raising, so one typo can't break the plugin."""
+    agents: dict[str, dict] = {}
+    for entry in raw or []:
+        if not isinstance(entry, dict):
+            log.warning("[coding_agent] ignoring non-mapping agent entry: %r", entry)
+            continue
+        name = str(entry.get("name", "")).strip()
+        command = str(entry.get("command", "")).strip()
+        workdir = str(entry.get("workdir", "")).strip()
+        if not (name and command and workdir):
+            log.warning("[coding_agent] agent entry needs name+command+workdir: %r", entry)
+            continue
+        if name in agents:
+            log.warning("[coding_agent] duplicate agent name %r — keeping first", name)
+            continue
+        args = entry.get("args") or []
+        if not isinstance(args, (list, tuple)):
+            log.warning("[coding_agent] %s: args must be a list — ignoring", name)
+            args = []
+        env = entry.get("env") if isinstance(entry.get("env"), dict) else None
+        agents[name] = {
+            "name": name,
+            "command": command,
+            "args": [str(a) for a in args],
+            "workdir": workdir,
+            "env": {str(k): str(v) for k, v in env.items()} if env else None,
+            "timeout_s": entry.get("timeout_s"),
+        }
+    return agents
+
+
+def _client_for(spec: dict) -> AcpClient:
+    """Get-or-create the cached client for an agent spec."""
+    key = (spec["name"], spec["command"], tuple(spec["args"]), spec["workdir"])
+    client = _CLIENTS.get(key)
+    if client is None:
+        client = AcpClient(
+            spec["command"],
+            spec["args"],
+            cwd=spec["workdir"],
+            env=spec["env"],
+            name=spec["name"],
+        )
+        _CLIENTS[key] = client
+    return client
+
+
+def _build_code_with(agents: dict[str, dict], default_timeout_s: float):
+    """Build the ``code_with`` tool, closing over the configured agents."""
+    listing = ", ".join(
+        f"`{name}` (in `{spec['workdir']}`)" for name, spec in agents.items()
+    )
+
+    @tool
+    @with_fallback("The coding agent did not return a result.")
+    async def code_with(agent: str, task: str) -> str:
+        """Delegate a coding task to a CLI coding agent and return its result.
+
+        Use this to hand a real, repo-scoped coding job — read/edit/run code,
+        fix a failing test, add an endpoint — to a purpose-built coding agent
+        that has its own file access, shell, and edit/verify loop. Prefer this
+        over doing multi-file code edits inline.
+
+        Args:
+            agent: which configured coding agent to use (see the available list
+                in this tool's description).
+            task: the full, self-contained instruction (the coding agent does
+                not see this conversation — restate the goal, the relevant files
+                if known, and the definition of done, e.g. "run the tests").
+
+        Each agent works in its own pre-configured directory; you cannot point it
+        elsewhere. The call blocks until the agent finishes the turn (coding is
+        slow) and returns its final message. Follow-up calls to the same agent
+        continue the same session, so you can iterate ("now also …").
+        """
+        spec = agents.get(agent)
+        if spec is None:
+            return (
+                f"Error: unknown coding agent {agent!r}. "
+                f"Configured agents: {', '.join(agents) or '(none)'}."
+            )
+        if not str(task).strip():
+            return "Error: `task` is empty — give the coding agent a concrete instruction."
+
+        lock = _LOCKS.setdefault(agent, asyncio.Lock())
+        timeout = float(spec.get("timeout_s") or default_timeout_s)
+        client = _client_for(spec)
+
+        async def _narrate(title: str) -> None:
+            # PR1: log narration. A later PR streams these onto A2A working frames.
+            log.info("[coding_agent/%s] %s", agent, title)
+
+        async with lock:
+            try:
+                answer = await client.prompt(
+                    task, progress_callback=_narrate, timeout=timeout
+                )
+            except AcpError as exc:
+                # Drop the cached client so the next call relaunches cleanly.
+                _CLIENTS.pop((spec["name"], spec["command"], tuple(spec["args"]), spec["workdir"]), None)
+                return f"Error: {agent} (coding agent) failed: {exc}"
+        return answer or f"{agent} finished but returned no text."
+
+    # The configured agent names belong in the LLM-facing description so the model
+    # knows what it can pass as `agent` (the docstring can't interpolate them).
+    code_with.description = f"{code_with.description}\n\nAvailable agents: {listing}."
+    return code_with
+
+
+def register(registry) -> None:
+    """Entry point — called once at load with a PluginRegistry."""
+    cfg = registry.config or {}
+    agents = _normalize_agents(cfg.get("agents"))
+    if not agents:
+        log.warning(
+            "[coding_agent] enabled but no agents configured — add entries under "
+            "`coding_agent.agents` (see docs/guides/coding-agents.md). No tool registered."
+        )
+        return
+    try:
+        default_timeout_s = float(cfg.get("default_timeout_s") or 600)
+    except (TypeError, ValueError):
+        default_timeout_s = 600.0
+    registry.register_tool(_build_code_with(agents, default_timeout_s))
+    log.info("[coding_agent] registered code_with for %d agent(s): %s",
+             len(agents), ", ".join(agents))

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -1,0 +1,304 @@
+"""ACP client — launch a CLI coding agent and drive one session.
+
+protoAgent is the ACP *client*: one ``AcpClient`` owns one agent subprocess and
+one session, cached per configured agent so follow-up ``code_with`` calls
+continue the same thread (mirrors the A2A peer's sticky ``contextId``). Transport
+is JSON-RPC 2.0, newline-delimited, over the child's stdin/stdout. The matching
+server side is e.g. ``proto --acp``. Spec: https://agentclientprotocol.com.
+
+Ported from ORBIS's ``acp/client.py`` (the canonical protoLabs ACP client).
+ADR 0024.
+
+PR1 scope (the thin vertical):
+  * handshake: ``initialize`` → ``session/new`` (cwd = the agent's config workdir)
+  * one turn: ``session/prompt`` → accumulate ``agent_message_chunk`` text as the
+    answer; narrate ``tool_call`` titles via ``progress_callback`` ("Editing
+    app.py", "Running pytest")
+  * auto-allow ``session/request_permission`` (the coding agent self-governs,
+    scoped to the session cwd — see ADR 0024). Policy + HITL gating land next.
+  * ``fs/*`` and ``terminal/*`` are NOT advertised — the coding agent uses its own
+    file access, confined to the session ``cwd``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import os
+from pathlib import Path
+from typing import Awaitable, Callable
+
+logger = logging.getLogger("protoagent.plugins.coding_agent")
+
+ProgressCallback = Callable[[str], Awaitable[None]]
+
+# ACP protocol version protoAgent speaks. Negotiated in `initialize`.
+PROTOCOL_VERSION = 1
+
+
+class AcpError(Exception):
+    """Any ACP transport / protocol failure. The caller speaks the message."""
+
+
+class AcpClient:
+    """Drive a single ACP agent subprocess + session.
+
+    Construct once per configured agent and reuse: the process + session persist
+    across turns. Not safe for concurrent prompts on one instance (a session is a
+    single conversation); callers serialize turns with a per-agent lock.
+    """
+
+    def __init__(
+        self,
+        command: str,
+        args: list[str] | None = None,
+        *,
+        cwd: str,
+        env: dict[str, str] | None = None,
+        name: str = "acp",
+    ) -> None:
+        self.command = command
+        self.args = list(args or [])
+        self.cwd = str(Path(cwd).expanduser())
+        self.env = env
+        self.name = name
+
+        self._proc: asyncio.subprocess.Process | None = None
+        self._session_id: str | None = None
+        self._next_id = 0
+        self._pending: dict[int, asyncio.Future] = {}
+        self._reader_task: asyncio.Task | None = None
+        self._start_lock = asyncio.Lock()
+
+        # Per-turn state (one turn at a time).
+        self._answer = ""
+        self._progress: ProgressCallback | None = None
+
+    # -- lifecycle -----------------------------------------------------------
+
+    async def _ensure_started(self) -> None:
+        async with self._start_lock:
+            if self._proc is not None and self._proc.returncode is None:
+                return
+            await self._start()
+
+    async def _start(self) -> None:
+        if not Path(self.cwd).is_dir():
+            raise AcpError(f"workdir does not exist: {self.cwd}")
+        try:
+            self._proc = await asyncio.create_subprocess_exec(
+                self.command,
+                *self.args,
+                cwd=self.cwd,
+                stdin=asyncio.subprocess.PIPE,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+                env={**os.environ, **(self.env or {})},
+            )
+        except FileNotFoundError as exc:
+            raise AcpError(
+                f"agent binary not found: {self.command!r} (is it installed and on PATH?)"
+            ) from exc
+
+        self._reader_task = asyncio.create_task(self._read_loop())
+        asyncio.create_task(self._drain_stderr())
+        await self._initialize()
+        await self._new_session()
+        logger.info(
+            "[acp/%s] up (pid=%s, session=%s, cwd=%s)",
+            self.name,
+            self._proc.pid,
+            self._session_id,
+            self.cwd,
+        )
+
+    async def close(self) -> None:
+        if self._reader_task and not self._reader_task.done():
+            self._reader_task.cancel()
+        if self._proc and self._proc.returncode is None:
+            try:
+                self._proc.terminate()
+            except ProcessLookupError:
+                pass
+
+    # -- I/O loops -----------------------------------------------------------
+
+    async def _drain_stderr(self) -> None:
+        assert self._proc and self._proc.stderr
+        async for raw in self._proc.stderr:
+            line = raw.decode(errors="replace").rstrip()
+            if line:
+                logger.debug("[acp/%s/stderr] %s", self.name, line)
+
+    async def _read_loop(self) -> None:
+        assert self._proc and self._proc.stdout
+        try:
+            async for raw in self._proc.stdout:
+                line = raw.decode(errors="replace").strip()
+                if not line:
+                    continue
+                try:
+                    msg = json.loads(line)
+                except json.JSONDecodeError:
+                    logger.warning("[acp/%s] non-JSON line: %.200s", self.name, line)
+                    continue
+                await self._handle(msg)
+        except asyncio.CancelledError:
+            raise
+        finally:
+            # Fail any in-flight requests if the process dies mid-turn.
+            for fut in self._pending.values():
+                if not fut.done():
+                    fut.set_exception(AcpError(f"{self.name} agent exited"))
+            self._pending.clear()
+
+    async def _handle(self, msg: dict) -> None:
+        # 1) Response to one of our outbound requests.
+        if "id" in msg and ("result" in msg or "error" in msg):
+            fut = self._pending.pop(msg["id"], None)
+            if fut and not fut.done():
+                if "error" in msg:
+                    fut.set_exception(AcpError(str(msg["error"])))
+                else:
+                    fut.set_result(msg.get("result"))
+            return
+        method = msg.get("method")
+        # 2) Inbound request from the agent (has id) — we must respond.
+        if method and "id" in msg:
+            await self._handle_request(msg)
+            return
+        # 3) Notification (no id).
+        if method == "session/update":
+            await self._handle_update(msg.get("params") or {})
+
+    # -- inbound updates + requests -----------------------------------------
+
+    async def _handle_update(self, params: dict) -> None:
+        update = params.get("update") or {}
+        kind = update.get("sessionUpdate")
+        if kind == "agent_message_chunk":
+            text = (update.get("content") or {}).get("text", "")
+            if text:
+                self._answer += text
+        elif kind == "tool_call":
+            # Narrate the tool's human title ("Editing app.py", "Running pytest")
+            # — this is progress, not the answer text.
+            title = update.get("title") or update.get("kind") or "working"
+            await self._narrate(str(title))
+
+    async def _handle_request(self, msg: dict) -> None:
+        method = msg.get("method")
+        rid = msg.get("id")
+        if method == "session/request_permission":
+            option_id = self._auto_allow(msg.get("params") or {})
+            outcome = (
+                {"outcome": "selected", "optionId": option_id}
+                if option_id
+                else {"outcome": "cancelled"}
+            )
+            await self._respond(rid, {"outcome": outcome})
+        else:
+            # We didn't advertise fs/terminal; decline anything else cleanly so
+            # the agent falls back to its own capabilities instead of hanging.
+            await self._respond_error(rid, -32601, f"method not supported: {method}")
+
+    @staticmethod
+    def _auto_allow(params: dict) -> str | None:
+        """PR1 permission policy: pick the first 'allow' option (else the first
+        option). The HITL / deny-policy layer replaces this (ADR 0024, later PR)."""
+        options = params.get("options") or []
+        for opt in options:
+            if str(opt.get("kind", "")).startswith("allow"):
+                return opt.get("optionId")
+        return options[0].get("optionId") if options else None
+
+    async def _narrate(self, text: str) -> None:
+        if self._progress and text:
+            try:
+                await self._progress(text)
+            except Exception as exc:  # progress is best-effort
+                logger.warning("[acp/%s] progress_callback raised: %s", self.name, exc)
+
+    # -- JSON-RPC primitives -------------------------------------------------
+
+    async def _send(self, obj: dict) -> None:
+        if not (self._proc and self._proc.stdin):
+            raise AcpError("agent not started")
+        self._proc.stdin.write((json.dumps(obj) + "\n").encode())
+        await self._proc.stdin.drain()
+
+    async def _request(self, method: str, params: dict, *, timeout: float = 120.0):
+        self._next_id += 1
+        rid = self._next_id
+        fut: asyncio.Future = asyncio.get_running_loop().create_future()
+        self._pending[rid] = fut
+        await self._send({"jsonrpc": "2.0", "id": rid, "method": method, "params": params})
+        try:
+            return await asyncio.wait_for(fut, timeout)
+        except asyncio.TimeoutError as exc:
+            self._pending.pop(rid, None)
+            raise AcpError(f"{method} timed out after {timeout}s") from exc
+
+    async def _respond(self, rid, result: dict) -> None:
+        await self._send({"jsonrpc": "2.0", "id": rid, "result": result})
+
+    async def _respond_error(self, rid, code: int, message: str) -> None:
+        await self._send({"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": message}})
+
+    # -- handshake -----------------------------------------------------------
+
+    async def _initialize(self) -> None:
+        await self._request(
+            "initialize",
+            {
+                "protocolVersion": PROTOCOL_VERSION,
+                # PR1: no client-served fs/terminal — the coding agent uses its own,
+                # confined to the session cwd.
+                "clientCapabilities": {
+                    "fs": {"readTextFile": False, "writeTextFile": False},
+                    "terminal": False,
+                },
+            },
+            timeout=30.0,
+        )
+
+    async def _new_session(self) -> None:
+        result = await self._request(
+            "session/new", {"cwd": self.cwd, "mcpServers": []}, timeout=30.0
+        )
+        self._session_id = (result or {}).get("sessionId")
+        if not self._session_id:
+            raise AcpError("session/new returned no sessionId")
+
+    # -- public: one turn ----------------------------------------------------
+
+    async def prompt(
+        self,
+        text: str,
+        *,
+        progress_callback: ProgressCallback | None = None,
+        timeout: float = 600.0,
+    ) -> str:
+        """Send one user turn; return the agent's accumulated message text.
+
+        Streams ``tool_call`` titles to ``progress_callback`` for narration while
+        the agent works. Raises ``AcpError`` on transport/protocol failure.
+        """
+        await self._ensure_started()
+        self._answer = ""
+        self._progress = progress_callback
+        try:
+            result = await self._request(
+                "session/prompt",
+                {
+                    "sessionId": self._session_id,
+                    "prompt": [{"type": "text", "text": text}],
+                },
+                timeout=timeout,
+            )
+        finally:
+            self._progress = None
+        stop = (result or {}).get("stopReason")
+        logger.info("[acp/%s] turn complete (stopReason=%s)", self.name, stop)
+        return self._answer.strip()

--- a/plugins/coding_agent/protoagent.plugin.yaml
+++ b/plugins/coding_agent/protoagent.plugin.yaml
@@ -1,0 +1,45 @@
+id: coding_agent
+name: CLI Coding Agent (ACP)
+version: 0.1.0
+description: >-
+  Let the lead agent spawn a CLI coding agent — protoCLI (`proto`), Claude Code,
+  Codex, Gemini CLI — and hand it a real coding job (read/edit/run code in a
+  repo), then get the result back. Adds one tool, `code_with(agent, task)`, that
+  drives the coding agent over ACP (Agent Client Protocol: JSON-RPC 2.0 over the
+  child's stdio). See ADR 0024 and docs/guides/coding-agents.md.
+
+  Ships DISABLED with an EMPTY agent list — enable it AND configure agents
+  explicitly, because each agent gets file + shell access in its workdir
+  (auto-allowed, confined to that dir). Enable with
+  `plugins: { enabled: [coding_agent] }`.
+enabled: false
+
+# Declarative only (not yet enforced) — surfaced in the console for transparency.
+# A spawned coding agent does real local I/O within its configured workdir.
+capabilities:
+  network: ["*"]            # the coding agent may fetch/install as it works
+  filesystem: workdir       # confined to each agent's configured workdir
+
+# Plugin config (ADR 0019) — claims the top-level `coding_agent` section.
+# `agents` is a list (round-trips through YAML); it is intentionally NOT a
+# Settings field — coding agents are declared in config, not the Settings UI,
+# because each one grants local file/shell authority and deserves a deliberate
+# edit. Only `default_timeout_s` is exposed as a scalar Setting.
+config_section: coding_agent
+config:
+  # Default per-turn timeout (seconds). Coding is slow; override per agent.
+  default_timeout_s: 600
+  # No agents by default — you MUST add your own (see the guide). Example:
+  #   agents:
+  #     - name: proto             # the name the LLM passes to code_with(agent=…)
+  #       command: proto          # binary on PATH
+  #       args: ["--acp"]         # ACP server mode
+  #       workdir: ~/dev/my-repo  # session cwd — the confinement boundary
+  #       # env: { SOME_KEY: value }   # optional extra env, merged over process env
+  #       # timeout_s: 900             # optional per-agent override
+  agents: []
+settings:
+  - key: default_timeout_s
+    label: "Default coding turn timeout (s)"
+    type: number
+    description: "Per-turn timeout for a coding agent. Coding is slow — 600s+ is typical."

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -1,0 +1,173 @@
+"""Tests for the coding_agent plugin (ADR 0024).
+
+Covers config normalization + the `code_with` tool wiring (unit), and a real
+ACP wire exchange: AcpClient drives a fake ACP agent subprocess through
+initialize → session/new → session/prompt, accumulating agent_message_chunk
+text and auto-allowing a session/request_permission.
+"""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from plugins.coding_agent import _normalize_agents, register
+from plugins.coding_agent.acp_client import AcpClient, AcpError
+
+# ── a minimal ACP "agent" (server side) we can drive over stdio ───────────────
+# Speaks just enough of the protocol: handshakes, opens a session, and on a
+# prompt emits a tool_call narration, asks one permission (server→client
+# request), then streams two agent_message_chunks — echoing the chosen option
+# id so the test can prove auto-allow picked the `allow` option.
+_FAKE_AGENT = r'''
+import sys, json
+
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n")
+    sys.stdout.flush()
+
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method, mid = msg.get("method"), msg.get("id")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"protocolVersion": 1}})
+    elif method == "session/new":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"sessionId": "s1"}})
+    elif method == "session/prompt":
+        send({"jsonrpc": "2.0", "method": "session/update", "params": {
+            "sessionId": "s1",
+            "update": {"sessionUpdate": "tool_call", "title": "Editing app.py"}}})
+        # Ask permission; the client must respond before we continue.
+        send({"jsonrpc": "2.0", "id": 999, "method": "session/request_permission",
+              "params": {"sessionId": "s1", "options": [
+                  {"optionId": "no", "kind": "deny"},
+                  {"optionId": "yes", "kind": "allow_once"}]}})
+        resp = json.loads(sys.stdin.readline().strip())
+        chosen = resp.get("result", {}).get("outcome", {}).get("optionId")
+        for chunk in ("Hello ", "world [" + str(chosen) + "]"):
+            send({"jsonrpc": "2.0", "method": "session/update", "params": {
+                "sessionId": "s1",
+                "update": {"sessionUpdate": "agent_message_chunk",
+                           "content": {"type": "text", "text": chunk}}}})
+        send({"jsonrpc": "2.0", "id": mid, "result": {"stopReason": "end_turn"}})
+'''
+
+
+# ── config normalization ──────────────────────────────────────────────────────
+
+
+def test_normalize_agents_keeps_valid_and_drops_bad():
+    agents = _normalize_agents([
+        {"name": "proto", "command": "proto", "args": ["--acp"], "workdir": "/tmp"},
+        {"name": "nofields"},                       # missing command/workdir
+        {"name": "x", "command": "x"},              # missing workdir
+        "not-a-dict",                                # wrong type
+        {"name": "proto", "command": "dup", "workdir": "/tmp"},  # duplicate name
+    ])
+    assert set(agents) == {"proto"}
+    assert agents["proto"]["command"] == "proto"     # first wins over the dup
+    assert agents["proto"]["args"] == ["--acp"]
+
+
+def test_normalize_agents_coerces_env_and_args():
+    agents = _normalize_agents([
+        {"name": "a", "command": "c", "workdir": "/tmp",
+         "args": "oops", "env": {"K": 1}},
+    ])
+    assert agents["a"]["args"] == []                 # non-list args ignored
+    assert agents["a"]["env"] == {"K": "1"}          # env values stringified
+
+
+# ── register() wiring ─────────────────────────────────────────────────────────
+
+
+class _StubRegistry:
+    def __init__(self, config):
+        self.config = config
+        self.tools = []
+
+    def register_tool(self, tool):
+        self.tools.append(tool)
+
+
+def test_register_no_agents_registers_nothing():
+    reg = _StubRegistry({"agents": []})
+    register(reg)
+    assert reg.tools == []
+
+
+def test_register_with_agents_exposes_code_with():
+    reg = _StubRegistry({"agents": [
+        {"name": "proto", "command": "proto", "args": ["--acp"], "workdir": "/tmp"},
+    ]})
+    register(reg)
+    assert [t.name for t in reg.tools] == ["code_with"]
+    # Configured agent names are surfaced in the LLM-facing description.
+    assert "proto" in reg.tools[0].description
+
+
+async def test_code_with_unknown_agent_returns_error():
+    reg = _StubRegistry({"agents": [
+        {"name": "proto", "command": "proto", "args": ["--acp"], "workdir": "/tmp"},
+    ]})
+    register(reg)
+    code_with = reg.tools[0]
+    out = await code_with.ainvoke({"agent": "nope", "task": "do it"})
+    assert "unknown coding agent" in out and "proto" in out
+
+
+async def test_code_with_empty_task_returns_error():
+    reg = _StubRegistry({"agents": [
+        {"name": "proto", "command": "proto", "args": ["--acp"], "workdir": "/tmp"},
+    ]})
+    register(reg)
+    code_with = reg.tools[0]
+    out = await code_with.ainvoke({"agent": "proto", "task": "   "})
+    assert "empty" in out.lower()
+
+
+# ── ACP wire exchange against the fake agent ──────────────────────────────────
+
+
+@pytest.fixture
+def fake_agent(tmp_path):
+    script = tmp_path / "fake_acp_agent.py"
+    script.write_text(_FAKE_AGENT, encoding="utf-8")
+    return script
+
+
+async def test_acp_client_drives_a_turn(fake_agent, tmp_path):
+    narrations: list[str] = []
+
+    async def on_progress(title: str) -> None:
+        narrations.append(title)
+
+    client = AcpClient(sys.executable, [str(fake_agent)], cwd=str(tmp_path), name="fake")
+    try:
+        answer = await client.prompt("add a healthz route", progress_callback=on_progress, timeout=30.0)
+    finally:
+        await client.close()
+
+    # agent_message_chunks accumulated; auto-allow picked the `allow_once` option.
+    assert answer == "Hello world [yes]"
+    # tool_call title narrated via the progress callback.
+    assert "Editing app.py" in narrations
+
+
+async def test_acp_client_missing_binary_raises_acp_error(tmp_path):
+    client = AcpClient("definitely-not-a-real-binary-xyz", [], cwd=str(tmp_path))
+    with pytest.raises(AcpError):
+        await client.prompt("hi", timeout=10.0)
+
+
+async def test_acp_client_bad_workdir_raises_acp_error():
+    client = AcpClient(sys.executable, [], cwd="/no/such/dir/anywhere")
+    with pytest.raises(AcpError):
+        await client.prompt("hi", timeout=10.0)


### PR DESCRIPTION
## What

Brings ORBIS's **ACP-client** pattern into protoAgent so the lead agent can hand a real, repo-scoped coding job to a purpose-built **CLI coding agent** — protoCLI (`proto`), Claude Code, Codex, Gemini CLI — and get the result back.

New **opt-in `coding_agent` plugin** adds one tool:

```
code_with(agent="proto", task="add a /healthz route and run the tests")
  → the coding agent's final message
```

Where `task()` delegates to an in-process LLM subagent and `peer_consult` talks to a remote A2A peer, `code_with` spawns a coding agent that carries its **own file access, shell, repo-map, and edit/verify loop**. protoAgent is the [ACP](https://agentclientprotocol.com) *client*; `proto --acp` is the matching server.

## How it works

`AcpClient` (a port of ORBIS's canonical `acp/client.py`) launches the agent as a subprocess and drives one session over JSON-RPC 2.0 on its stdio:

```
initialize → session/new(cwd) → session/prompt(task)
  ← session/update {agent_message_chunk}  → accumulated into the answer
  ← session/update {tool_call, title}      → narrated (logged)
  ← session/request_permission             → auto-allowed
```

One client (subprocess + session) is **cached per agent** so follow-up calls continue the thread; a per-agent lock serializes turns.

## Security posture (PR1)

Ships **disabled with an empty agent list** — enable *and* declare agents explicitly, because each gets file + shell access in its workdir.

- **Workdir is config-pinned** — the tool takes only `agent` + `task`, never a path, so the model can't aim a coding agent at an arbitrary directory.
- **Auto-allow within the workdir** — protoAgent advertises no client-served `fs`/`terminal`; the coding agent self-governs inside its sandbox dir (`session/request_permission` auto-approved). Mirrors ORBIS PR1.
- The subprocess inherits protoAgent's env (+ optional per-agent `env`).

## Placement

A **first-party opt-in plugin** (not core) — gets config + secrets + Settings + enable/disable for free with zero core edits, matching the operator-fork contract and the Discord/Google precedent. We do **not** port ORBIS's whole `delegate_to` registry; protoAgent already covers the a2a/openai legs (peers + subagents + gateway). The ACP leg was the only missing one.

## Scope

- **PR1 (this):** ACP client + `code_with` + config + auto-allow + tests + docs. Synchronous (answer returned; `tool_call` titles logged).
- **Later:** live narration onto A2A working-status frames; HITL permission gating (`ask_human`) + allow-by-kind; more shipped agent recipes; an eval case.

## Files

- `plugins/coding_agent/{__init__.py, acp_client.py, protoagent.plugin.yaml}`
- `tests/test_coding_agent_plugin.py` — config normalization, tool wiring, and a **real ACP wire exchange** against a fake agent subprocess (9 cases, all green)
- ADR 0024 + index; `docs/guides/coding-agents.md` + sidebar; plugins-guide note; CHANGELOG `[Unreleased]`

## Test

```
$ pytest tests/test_plugins.py tests/test_coding_agent_plugin.py -q
26 passed
$ ruff check plugins/ tests/test_coding_agent_plugin.py
All checks passed!
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)