### PR TITLE
feat(a2a): opt-in deploy-time guard — refuse to start on a loopback card URL

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -89,6 +89,11 @@ skills:
 # free-text "chat" placeholder so a fresh clone stays callable. The card `name`
 # already follows identity.name / AGENT_NAME.
 a2a:
+  # Deploy-time guard: refuse to start if the card would advertise a loopback URL
+  # (e.g. A2A_PUBLIC_URL unset on a deployed agent → http://127.0.0.1:.../a2a,
+  # unreachable to remote consumers). Leave off for local/desktop runs (loopback
+  # is correct same-host); turn ON for any agent other agents dial over the network.
+  # require_routable_url: true
   # description: "Acme Bot — turns support tickets into triaged, drafted replies."
   # skills:
   #   - id: triage_ticket

--- a/graph/config.py
+++ b/graph/config.py
@@ -351,6 +351,12 @@ class LangGraphConfig:
     # agent_name()).
     a2a_skills: list[dict] = field(default_factory=list)
     a2a_description: str = ""
+    # When true, refuse to start if the card would advertise a loopback URL
+    # (e.g. A2A_PUBLIC_URL unset on a deployed agent → http://127.0.0.1:.../a2a,
+    # silently unreachable to remote consumers). Off by default — local/desktop
+    # runs SHOULD advertise loopback (the client is same-host). Enforced by
+    # server/a2a.py::assert_routable_card_url() at startup.
+    a2a_require_routable_url: bool = False
 
     # Instance id for multi-instance data scoping (ADR 0004). When set, every
     # store nests under <base>/<id>/ so several instances can share one
@@ -544,6 +550,7 @@ class LangGraphConfig:
             identity_operator=identity.get("operator", cls.identity_operator),
             a2a_skills=list(a2a.get("skills", []) or []),
             a2a_description=a2a.get("description", "") or "",
+            a2a_require_routable_url=bool(a2a.get("require_routable_url", False)),
             instance_id=data.get("instance", {}).get("id", "") or data.get("instance_id", cls.instance_id),
             auth_token=secret_auth_token or auth.get("token", cls.auth_token),
             autostart_on_boot=runtime.get("autostart_on_boot", cls.autostart_on_boot),

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -224,6 +224,7 @@ from server.a2a import (  # noqa: E402,F401 — re-export of the extracted A2A s
     _agent_skills,
     _bearer_configured,
     _build_agent_card_proto,
+    assert_routable_card_url,
     _package_version,
     _record_a2a_telemetry,
     structured_skill_schema,
@@ -601,6 +602,10 @@ def _main():
     )
 
     a2a_card = _build_agent_card_proto()
+    # Deploy-time guard (opt-in): refuse to start if the card would advertise a
+    # loopback URL — a deployed agent that does so is silently unreachable to
+    # remote consumers. No-op unless a2a.require_routable_url is set.
+    assert_routable_card_url()
 
     # Durable SQLite-backed task + push-config stores (survive restart; 24h TTL
     # sweep on tasks). The push-config store rejects SSRF callback URLs at

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -154,6 +154,42 @@ def _a2a_card_url() -> str:
     return f"{base}/a2a"
 
 
+_LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", "0.0.0.0", ""}
+
+
+def assert_routable_card_url() -> None:
+    """Fail fast at startup if the card would advertise a loopback URL (opt-in).
+
+    A *deployed* agent that advertises ``http://127.0.0.1:.../a2a`` — e.g. because
+    ``A2A_PUBLIC_URL`` wasn't set after a redeploy — is silently unreachable to any
+    remote consumer that dials the card's interface URL. That's a deployment-config
+    regression no test catches; it surfaces only at first cross-host dispatch.
+
+    When ``a2a.require_routable_url`` is set, refuse to start (exit non-zero) rather
+    than discover it later. **Off by default** — local + desktop runs *should*
+    advertise loopback (the client is same-host, and the desktop port is dynamic).
+    Deployed agents opt in via config.
+    """
+    cfg = STATE.graph_config
+    if not (cfg and getattr(cfg, "a2a_require_routable_url", False)):
+        return
+    from urllib.parse import urlparse
+
+    url = _a2a_card_url()
+    host = (urlparse(url).hostname or "").lower()
+    if host in _LOOPBACK_HOSTS:
+        log.critical(
+            "[a2a] refusing to start: the agent card would advertise a loopback "
+            "URL %r (host=%r), unreachable to remote consumers. "
+            "a2a.require_routable_url is set — a deployed agent must advertise its "
+            "externally-reachable address. Set A2A_PUBLIC_URL to the host other "
+            "agents reach (e.g. http://roxy:7870).",
+            url, host or "<empty>",
+        )
+        raise SystemExit(1)
+    log.info("[a2a] card URL %s is routable (require_routable_url check passed)", url)
+
+
 # Template default card description — used when a fork sets no ``a2a.description``
 # in config (#570). Forks override via config, not by editing this file.
 _DEFAULT_CARD_DESCRIPTION = (

--- a/tests/test_routable_card_url.py
+++ b/tests/test_routable_card_url.py
@@ -1,0 +1,60 @@
+"""assert_routable_card_url — deploy-time guard against a loopback agent card.
+
+A deployed agent that advertises `http://127.0.0.1:.../a2a` (e.g. A2A_PUBLIC_URL
+unset after a redeploy) is silently unreachable to remote consumers. When
+`a2a.require_routable_url` is set, the agent refuses to start. Off by default so
+local/desktop runs still advertise loopback correctly.
+"""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+import server.a2a as a2a
+from runtime.state import STATE
+
+
+class _Cfg:
+    def __init__(self, require: bool):
+        self.a2a_require_routable_url = require
+
+
+def _set(monkeypatch, *, require: bool, public_url: str | None, port: int = 7870):
+    monkeypatch.setattr(STATE, "graph_config", _Cfg(require), raising=False)
+    monkeypatch.setattr(STATE, "active_port", port, raising=False)
+    if public_url is None:
+        monkeypatch.delenv("A2A_PUBLIC_URL", raising=False)
+    else:
+        monkeypatch.setenv("A2A_PUBLIC_URL", public_url)
+
+
+def test_noop_when_flag_off(monkeypatch):
+    # Loopback URL, but the guard is off → must NOT exit (local/desktop default).
+    _set(monkeypatch, require=False, public_url=None)
+    a2a.assert_routable_card_url()  # no raise
+
+
+def test_exits_on_loopback_when_required(monkeypatch):
+    _set(monkeypatch, require=True, public_url=None)  # falls back to 127.0.0.1
+    with pytest.raises(SystemExit) as ei:
+        a2a.assert_routable_card_url()
+    assert ei.value.code == 1
+
+
+@pytest.mark.parametrize("bad", [
+    "http://127.0.0.1:7870",
+    "http://localhost:7870",
+    "http://[::1]:7870",
+    "http://0.0.0.0:7870",
+])
+def test_exits_on_each_loopback_form(monkeypatch, bad):
+    _set(monkeypatch, require=True, public_url=bad)
+    with pytest.raises(SystemExit):
+        a2a.assert_routable_card_url()
+
+
+def test_passes_on_routable_host(monkeypatch):
+    _set(monkeypatch, require=True, public_url="http://roxy:7870")
+    a2a.assert_routable_card_url()  # routable → no raise

--- a/tests/test_routable_card_url.py
+++ b/tests/test_routable_card_url.py
@@ -8,8 +8,6 @@ local/desktop runs still advertise loopback correctly.
 
 from __future__ import annotations
 
-import types
-
 import pytest
 
 import server.a2a as a2a


### PR DESCRIPTION
Closes #597. (Resolves the roxy-side ask in protoLabsAI/roxy#31.)

## Problem
A deployed agent that advertises `http://127.0.0.1:.../a2a` (e.g. `A2A_PUBLIC_URL` unset after a redeploy) is **silently unreachable** to remote consumers that dial the card's interface URL — a config regression no test catches, surfacing only at first cross-host dispatch.

## Change (opt-in)
- New config `a2a.require_routable_url` (default **false**; `graph/config.py`).
- `server/a2a.py::assert_routable_card_url()` — when the flag is set, checks the resolved card URL at startup; loopback host (`127.0.0.1`/`localhost`/`::1`/`0.0.0.0`) → log a clear error pointing at `A2A_PUBLIC_URL` and `SystemExit(1)`.
- Wired into the boot path (`server/__init__._main`, right after the card is built, before `uvicorn.run`).
- Documented in `config/langgraph-config.example.yaml`.

**Off by default** — local + desktop runs *should* advertise loopback (same-host client, dynamic port). Deployed agents opt in.

## Tests (`tests/test_routable_card_url.py`)
Each loopback form exits; flag-off is a no-op; a routable host passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)