### PR TITLE
feat(coding_agent): by-kind permission policy + per-call consent gate — ADR 0024 (PR3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,9 +25,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   deliberate opt-in; enable with `plugins: { enabled: [coding_agent] }` and
   declare agents under the `coding_agent` config section. One client (subprocess +
   session) is cached per agent so follow-up calls continue the same thread.
-  PR1 is synchronous (final answer returned; `tool_call` titles logged); live
-  narration onto A2A working frames + HITL permission policy land next.
+  Synchronous (final answer returned; `tool_call` titles logged).
   See [the guide](docs/guides/coding-agents.md).
+- **Coding-agent permission controls** (ADR 0024) — each configured agent takes a
+  by-kind permission policy applied to the coding agent's `session/request_permission`
+  requests: `auto` (allow all, default), `allowlist` (allow all but
+  `execute`/`delete`), or `readonly` (read-like kinds only) — overridable with
+  `allow_kinds` / `deny_kinds`. Plus a per-call consent gate (`confirm: true`)
+  that asks the operator via `ask_human` before each `code_with` call. Ships
+  agent recipes for protoCLI, Claude Code, Codex, and Gemini CLI. (Per-action
+  live HITL is deferred — pausing a blocking subprocess session mid-turn is
+  incompatible with LangGraph's resume model; use `readonly`/`allowlist` for
+  deterministic per-action control.)
 
 ## [0.15.1] - 2026-06-05
 

--- a/docs/adr/0024-spawn-cli-coding-agents-acp.md
+++ b/docs/adr/0024-spawn-cli-coding-agents-acp.md
@@ -75,17 +75,30 @@ code_with(agent="proto", task="add a /healthz route and run the tests")
   → the agent's final message text (the work happens in its own session)
 ```
 
-### Confinement & permission posture (PR1)
+### Confinement & permission posture
 
 - **Workdir is config-pinned.** `code_with` takes only `agent` + `task` — never a
   caller-chosen path. The cwd comes from the matched config entry, so the LLM
   cannot point a coding agent at an arbitrary directory. Workdirs must be listed
   in config; an unknown `agent` returns an error listing the configured ones.
-- **Auto-allow within the workdir.** The client advertises no client-served
+- **By-kind permission policy (PR3).** The client advertises no client-served
   `fs`/`terminal` capability, so the coding agent uses its *own* file/shell
   access, scoped to the session cwd. Inbound `session/request_permission` is
-  auto-approved (first `allow` option), mirroring ORBIS's PR1 policy. The coding
-  agent self-governs inside its sandbox dir.
+  answered by the agent's `permissions` policy, keyed on the request's
+  `toolCall.kind`: `auto` (allow all — the PR1 default, mirroring ORBIS), `allowlist`
+  (deny `execute`/`delete`, allow the rest), or `readonly` (allow only read-like
+  kinds). Overridable per agent with `allow_kinds` / `deny_kinds`.
+- **Per-call consent gate (PR3).** `confirm: true` makes `code_with` ask the
+  operator (via `ask_human` → `input-required`) to approve *before each call* to
+  that agent. The gate runs before any side effect, so the LangGraph resume
+  re-execution is idempotent.
+- **Per-action live HITL is deferred** — approving each individual edit/shell
+  command mid-turn would require pausing a *blocking subprocess session* while
+  asking the operator. LangGraph's `interrupt()` checkpoints and **re-runs the
+  node** on resume, which can't resume a half-finished ACP session awaiting a
+  specific permission response. `readonly`/`allowlist` give deterministic
+  per-action control; `confirm` gives a per-call human gate. (Same coupling blocks
+  live narration — see Scope.)
 - The subprocess inherits the server's env (plus any per-agent `env`). Run
   protoAgent under an account whose ambient credentials you're willing to lend
   the coding agent — or scope its `workdir` to a throwaway checkout.
@@ -108,14 +121,20 @@ conversation; `task_batch` must not interleave two prompts on one session).
 
 ## Scope
 
-**PR1 (this ADR):** ACP client + `code_with` + config + auto-allow + tests +
-docs. Synchronous — the final answer is returned; `tool_call` titles are logged,
-not yet streamed to callers.
+**PR1 (#596):** ACP client + `code_with` + config + auto-allow + tests + docs.
+Synchronous — the final answer is returned; `tool_call` titles are logged.
+
+**PR3 (this update):** by-kind permission policy (`auto`/`allowlist`/`readonly` +
+`allow_kinds`/`deny_kinds`); per-call consent gate (`confirm`); shipped agent
+recipes (claude-code-acp, codex, gemini). Per-action live HITL is documented as
+deferred (the blocking-session constraint above).
 
 **Later PRs:** live narration of `tool_call` titles onto A2A working-status
-frames (so an operator watching a turn sees "Editing app.py"); richer permission
-policy (HITL gating via `ask_human`, allow-by-kind); more shipped agent recipes
-(claude-code-acp, codex, gemini); an eval case.
+frames (so an operator watching a turn sees "Editing app.py") — blocked on the
+same mid-session channel as per-action HITL, so it wants a general progress
+mechanism (event-bus ride-along or a stream-factory `progress` event), not a
+one-off; a gated eval case (needs an eval-runner skip mechanism so it doesn't
+require a coding agent in the default run).
 
 ## Consequences
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -32,4 +32,4 @@ decision, numbered, never deleted (supersede instead).
 | [0021](./0021-agent-memory-architecture.md) | Agent memory: extract, don't dump | Accepted |
 | [0022](./0022-activity-provenance-feed.md) | Activity is a provenance feed, not a second chat | Accepted |
 | [0023](./0023-server-decomposition.md) | Decompose server.py: AppState + composition root | Accepted |
-| [0024](./0024-spawn-cli-coding-agents-acp.md) | Spawn CLI coding agents over ACP (`code_with`) | Accepted (PR1) |
+| [0024](./0024-spawn-cli-coding-agents-acp.md) | Spawn CLI coding agents over ACP (`code_with`) | Accepted (PR1 + PR3) |

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -38,6 +38,8 @@ coding_agent:
       workdir: ~/dev/my-repo      # session cwd — the confinement boundary
       # env: { SOME_KEY: value }  # optional extra env, merged over the process env
       # timeout_s: 900            # optional per-agent override (seconds)
+      # permissions: allowlist    # auto (default) | allowlist | readonly
+      # confirm: true             # ask the operator before each code_with call
 ```
 
 Enabling plugins needs a **restart** (plugin tools wire once at process init).
@@ -56,6 +58,14 @@ Any agent that speaks ACP works — just point `command`/`args` at it:
     - name: claude-code
       command: npx
       args: ["@zed-industries/claude-code-acp"]
+      workdir: ~/dev/my-repo
+    - name: codex
+      command: codex
+      args: ["acp"]
+      workdir: ~/dev/my-repo
+    - name: gemini
+      command: gemini
+      args: ["--experimental-acp"]
       workdir: ~/dev/my-repo
 ```
 
@@ -86,24 +96,59 @@ Notes for whoever writes the `task`:
 
 ## Permission posture
 
-PR1 (the current cut) auto-allows the coding agent's actions, confined to its
-workdir:
+A coding agent works in its **config-pinned workdir** (`code_with` takes only
+`agent` + `task`, never a path — the model can't aim it elsewhere) and uses its
+*own* file/shell access there: protoAgent advertises no client-served
+`fs`/`terminal` capability. When the coding agent asks to do something risky it
+sends a `session/request_permission`, which protoAgent answers with the agent's
+**permission policy**:
 
-- **Workdir is config-pinned.** `code_with` takes only `agent` + `task` — never a
-  path. The cwd comes from config, so the model can't aim a coding agent at an
-  arbitrary directory.
-- **Auto-allow within the workdir.** protoAgent advertises no client-served
-  `fs`/`terminal` capability, so the coding agent uses its *own* file/shell
-  access, scoped to the session cwd. Inbound `session/request_permission` is
-  auto-approved. The coding agent self-governs inside its sandbox dir.
-- The subprocess **inherits protoAgent's environment** (plus any per-agent
-  `env`). Run protoAgent under an account whose ambient credentials you're
-  willing to lend the coding agent, or scope the `workdir` to a throwaway
-  checkout.
+| `permissions` | Behaviour |
+|---|---|
+| `auto` *(default)* | Allow everything — the agent self-governs within its workdir. |
+| `allowlist` | Allow all action kinds **except** `execute` and `delete` (override with `allow_kinds` / `deny_kinds`). |
+| `readonly` | Allow only read-like kinds (`read`, `search`, `fetch`, …); deny edits, shell, and deletes. |
 
-Coming in later PRs (ADR 0024): live narration of the coding agent's progress
-("Editing app.py") onto A2A working-status frames; HITL permission gating via
-`ask_human`; allow-by-kind policy.
+Action kinds come from the ACP request (`toolCall.kind`: `read` / `edit` /
+`execute` / `delete` / `fetch` / `move` / `search` / …). Tune a policy per agent:
+
+```yaml
+    - name: proto
+      command: proto
+      args: ["--acp"]
+      workdir: ~/dev/my-repo
+      permissions: allowlist
+      deny_kinds: [execute, delete]   # the allowlist default, shown explicitly
+```
+
+### Per-call consent gate
+
+Set `confirm: true` on an agent and `code_with` asks the operator to approve
+**before each call** to that agent (via `ask_human` — the turn parks as
+`input-required` until you reply `yes`):
+
+```yaml
+    - name: proto
+      command: proto
+      args: ["--acp"]
+      workdir: ~/dev/my-repo
+      confirm: true
+```
+
+> **Per-action** live HITL (approve each individual edit/shell command as the
+> coding agent works) is **not** available: it would require pausing a blocking
+> subprocess session mid-turn, which LangGraph's checkpoint/resume model can't do
+> without re-running the tool. Use `permissions: readonly`/`allowlist` for
+> deterministic per-action control, and `confirm` for a per-call human gate.
+
+### Environment
+
+The subprocess **inherits protoAgent's environment** (plus any per-agent `env`).
+Run protoAgent under an account whose ambient credentials you're willing to lend
+the coding agent, or scope the `workdir` to a throwaway checkout.
+
+Coming in a later PR (ADR 0024): live narration of the coding agent's progress
+("Editing app.py") onto A2A working-status frames.
 
 ## How it works
 

--- a/plugins/coding_agent/__init__.py
+++ b/plugins/coding_agent/__init__.py
@@ -6,30 +6,48 @@ and returns its result. The agent is driven over the Agent Client Protocol
 (JSON-RPC 2.0 over the child's stdio) by ``acp_client.AcpClient``.
 
 The plugin ships disabled with an empty agent list — each configured agent gets
-file + shell access in its workdir (auto-allowed, confined to that dir), so it's
-a deliberate opt-in. Enable with ``plugins: { enabled: [coding_agent] }`` and add
-agents under the ``coding_agent`` config section. See docs/guides/coding-agents.md.
+file + shell access in its workdir, so it's a deliberate opt-in. Enable with
+``plugins: { enabled: [coding_agent] }`` and add agents under the ``coding_agent``
+config section. See docs/guides/coding-agents.md.
+
+Per-agent safety controls (ADR 0024):
+- ``permissions`` — by-kind permission policy the client applies to the coding
+  agent's ``session/request_permission`` requests: ``auto`` (allow all, default),
+  ``allowlist`` (allow all but deny ``execute``/``delete``), or ``readonly``
+  (allow only read-like kinds). Overridable with ``allow_kinds`` / ``deny_kinds``.
+- ``confirm`` — when true, ``code_with`` asks the operator (``ask_human``) to
+  approve *before* each call to that agent (a per-call consent gate). Per-action
+  live HITL is deferred — it would need to pause a blocking subprocess session,
+  which LangGraph's resume model can't do mid-tool.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+from typing import Callable
 
 from langchain_core.tools import tool
-
-from tools.fallbacks import with_fallback
 
 from .acp_client import AcpClient, AcpError
 
 log = logging.getLogger("protoagent.plugins.coding_agent")
 
-# One client (subprocess + session) per agent, keyed by its launch signature so a
-# config change spins up a fresh client. Module-global so the session persists
-# across graph builds / turns; a per-agent lock serializes turns (a session is a
-# single conversation — ``task_batch`` must not interleave two prompts on one).
+# One client (subprocess + session) per agent, keyed by its launch + policy
+# signature so a config change spins up a fresh client. Module-global so the
+# session persists across graph builds / turns; a per-agent lock serializes turns
+# (a session is a single conversation — ``task_batch`` must not interleave two
+# prompts on one).
 _CLIENTS: dict[tuple, AcpClient] = {}
 _LOCKS: dict[str, asyncio.Lock] = {}
+
+_VALID_POLICIES = {"auto", "allowlist", "readonly"}
+# ACP tool-call kinds treated as read-only (safe under ``readonly``).
+_READONLY_KINDS = {"read", "search", "fetch", "think", "glob", "grep", "list"}
+# Risky kinds denied by ``allowlist`` unless explicitly allowed.
+_DEFAULT_DENY = {"execute", "delete"}
+# Resume values that count as approval for the ``confirm`` gate.
+_APPROVALS = {"y", "yes", "approve", "approved", "ok", "okay", "allow", "proceed", "go"}
 
 
 def _normalize_agents(raw) -> dict[str, dict]:
@@ -54,6 +72,10 @@ def _normalize_agents(raw) -> dict[str, dict]:
             log.warning("[coding_agent] %s: args must be a list — ignoring", name)
             args = []
         env = entry.get("env") if isinstance(entry.get("env"), dict) else None
+        policy = str(entry.get("permissions", "auto")).strip().lower() or "auto"
+        if policy not in _VALID_POLICIES:
+            log.warning("[coding_agent] %s: unknown permissions %r — using 'auto'", name, policy)
+            policy = "auto"
         agents[name] = {
             "name": name,
             "command": command,
@@ -61,13 +83,59 @@ def _normalize_agents(raw) -> dict[str, dict]:
             "workdir": workdir,
             "env": {str(k): str(v) for k, v in env.items()} if env else None,
             "timeout_s": entry.get("timeout_s"),
+            "permissions": policy,
+            "allow_kinds": [str(k).lower() for k in (entry.get("allow_kinds") or [])],
+            "deny_kinds": [str(k).lower() for k in (entry.get("deny_kinds") or [])],
+            "confirm": bool(entry.get("confirm", False)),
         }
     return agents
 
 
+def _make_permission(spec: dict) -> Callable[[dict], str | None]:
+    """Build the ACP permission resolver for an agent: given a request's params,
+    return the optionId to select (or None to cancel/deny). Decides per the
+    agent's ``permissions`` policy, using the request's ``toolCall.kind``."""
+    policy = spec["permissions"]
+    allow_set = set(spec["allow_kinds"])
+    deny_set = set(spec["deny_kinds"])
+
+    def _allowed(kind: str) -> bool:
+        if policy == "readonly":
+            return kind in (allow_set or _READONLY_KINDS)
+        if policy == "allowlist":
+            if kind in (deny_set or _DEFAULT_DENY):
+                return False
+            return kind in allow_set if allow_set else True
+        return True  # auto
+
+    def resolver(params: dict) -> str | None:
+        options = params.get("options") or []
+        kind = str(((params.get("toolCall") or {}).get("kind") or "")).lower()
+        allow = _allowed(kind)
+        prefix = "allow" if allow else "reject"
+        for opt in options:
+            if str(opt.get("kind", "")).startswith(prefix):
+                return opt.get("optionId")
+        # No option of the desired kind: allow ⇒ fall back to the first option;
+        # deny ⇒ cancel (None).
+        if allow:
+            return options[0].get("optionId") if options else None
+        log.info("[coding_agent/%s] denied %r action (policy=%s)", spec["name"], kind or "?", policy)
+        return None
+
+    return resolver
+
+
+def _cache_key(spec: dict) -> tuple:
+    return (
+        spec["name"], spec["command"], tuple(spec["args"]), spec["workdir"],
+        spec["permissions"], tuple(sorted(spec["allow_kinds"])), tuple(sorted(spec["deny_kinds"])),
+    )
+
+
 def _client_for(spec: dict) -> AcpClient:
     """Get-or-create the cached client for an agent spec."""
-    key = (spec["name"], spec["command"], tuple(spec["args"]), spec["workdir"])
+    key = _cache_key(spec)
     client = _CLIENTS.get(key)
     if client is None:
         client = AcpClient(
@@ -76,19 +144,28 @@ def _client_for(spec: dict) -> AcpClient:
             cwd=spec["workdir"],
             env=spec["env"],
             name=spec["name"],
+            permission=_make_permission(spec),
         )
         _CLIENTS[key] = client
     return client
 
 
+def _approved(decision) -> bool:
+    return str(decision).strip().lower() in _APPROVALS
+
+
 def _build_code_with(agents: dict[str, dict], default_timeout_s: float):
-    """Build the ``code_with`` tool, closing over the configured agents."""
+    """Build the ``code_with`` tool, closing over the configured agents.
+
+    Not wrapped in ``with_fallback``: the ``confirm`` gate calls ``interrupt()``,
+    whose control-flow exception that wrapper would swallow. Expected failures
+    return error strings; the I/O is guarded locally as the equivalent net.
+    """
     listing = ", ".join(
         f"`{name}` (in `{spec['workdir']}`)" for name, spec in agents.items()
     )
 
     @tool
-    @with_fallback("The coding agent did not return a result.")
     async def code_with(agent: str, task: str) -> str:
         """Delegate a coding task to a CLI coding agent and return its result.
 
@@ -118,23 +195,37 @@ def _build_code_with(agents: dict[str, dict], default_timeout_s: float):
         if not str(task).strip():
             return "Error: `task` is empty — give the coding agent a concrete instruction."
 
+        # Per-call consent gate (before any side effect, so re-execution on resume
+        # is idempotent). interrupt() parks the turn as input-required.
+        if spec["confirm"]:
+            from langgraph.types import interrupt
+
+            decision = interrupt({
+                "question": (
+                    f"Allow coding agent '{agent}' to work in {spec['workdir']}?\n\n"
+                    f"Task: {task}\n\nReply 'yes' to proceed, anything else to decline."
+                )
+            })
+            if not _approved(decision):
+                return f"Declined: the operator did not approve running '{agent}' on this task."
+
         lock = _LOCKS.setdefault(agent, asyncio.Lock())
         timeout = float(spec.get("timeout_s") or default_timeout_s)
         client = _client_for(spec)
 
         async def _narrate(title: str) -> None:
-            # PR1: log narration. A later PR streams these onto A2A working frames.
+            # Log narration. A later PR streams these onto A2A working frames.
             log.info("[coding_agent/%s] %s", agent, title)
 
-        async with lock:
-            try:
-                answer = await client.prompt(
-                    task, progress_callback=_narrate, timeout=timeout
-                )
-            except AcpError as exc:
-                # Drop the cached client so the next call relaunches cleanly.
-                _CLIENTS.pop((spec["name"], spec["command"], tuple(spec["args"]), spec["workdir"]), None)
-                return f"Error: {agent} (coding agent) failed: {exc}"
+        try:
+            async with lock:
+                answer = await client.prompt(task, progress_callback=_narrate, timeout=timeout)
+        except AcpError as exc:
+            _CLIENTS.pop(_cache_key(spec), None)  # drop so the next call relaunches
+            return f"Error: {agent} (coding agent) failed: {exc}"
+        except Exception as exc:  # noqa: BLE001 — local safety net (with_fallback is dropped)
+            log.warning("[coding_agent/%s] unexpected failure: %s", agent, exc)
+            return f"Error (partial result): {agent} could not complete: {type(exc).__name__}: {exc}"
         return answer or f"{agent} finished but returned no text."
 
     # The configured agent names belong in the LLM-facing description so the model

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -57,12 +57,17 @@ class AcpClient:
         cwd: str,
         env: dict[str, str] | None = None,
         name: str = "acp",
+        permission: Callable[[dict], str | None] | None = None,
     ) -> None:
         self.command = command
         self.args = list(args or [])
         self.cwd = str(Path(cwd).expanduser())
         self.env = env
         self.name = name
+        # Permission resolver: ``(request_params) -> optionId | None`` (None ⇒
+        # cancel/deny). Defaults to ``_auto_allow`` — the coding agent self-governs
+        # within its workdir. The plugin injects a by-kind policy here (ADR 0024).
+        self._permission = permission
 
         self._proc: asyncio.subprocess.Process | None = None
         self._session_id: str | None = None
@@ -191,7 +196,8 @@ class AcpClient:
         method = msg.get("method")
         rid = msg.get("id")
         if method == "session/request_permission":
-            option_id = self._auto_allow(msg.get("params") or {})
+            resolver = self._permission or self._auto_allow
+            option_id = resolver(msg.get("params") or {})
             outcome = (
                 {"outcome": "selected", "optionId": option_id}
                 if option_id
@@ -205,8 +211,8 @@ class AcpClient:
 
     @staticmethod
     def _auto_allow(params: dict) -> str | None:
-        """PR1 permission policy: pick the first 'allow' option (else the first
-        option). The HITL / deny-policy layer replaces this (ADR 0024, later PR)."""
+        """Default permission policy: pick the first 'allow' option (else the
+        first option). The plugin's by-kind policy (ADR 0024) overrides this."""
         options = params.get("options") or []
         for opt in options:
             if str(opt.get("kind", "")).startswith("allow"):

--- a/plugins/coding_agent/protoagent.plugin.yaml
+++ b/plugins/coding_agent/protoagent.plugin.yaml
@@ -29,7 +29,7 @@ config_section: coding_agent
 config:
   # Default per-turn timeout (seconds). Coding is slow; override per agent.
   default_timeout_s: 600
-  # No agents by default — you MUST add your own (see the guide). Example:
+  # No agents by default — you MUST add your own (see the guide). Examples:
   #   agents:
   #     - name: proto             # the name the LLM passes to code_with(agent=…)
   #       command: proto          # binary on PATH
@@ -37,6 +37,22 @@ config:
   #       workdir: ~/dev/my-repo  # session cwd — the confinement boundary
   #       # env: { SOME_KEY: value }   # optional extra env, merged over process env
   #       # timeout_s: 900             # optional per-agent override
+  #       # permissions: allowlist     # auto (default) | allowlist | readonly
+  #       # allow_kinds: []            # override: kinds to allow (readonly/allowlist)
+  #       # deny_kinds: [execute, delete]  # override: kinds to deny (allowlist)
+  #       # confirm: true              # ask the operator before each code_with call
+  #     - name: claude-code
+  #       command: npx
+  #       args: ["@zed-industries/claude-code-acp"]
+  #       workdir: ~/dev/my-repo
+  #     - name: codex
+  #       command: codex
+  #       args: ["acp"]
+  #       workdir: ~/dev/my-repo
+  #     - name: gemini
+  #       command: gemini
+  #       args: ["--experimental-acp"]
+  #       workdir: ~/dev/my-repo
   agents: []
 settings:
   - key: default_timeout_s

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -12,7 +12,8 @@ import sys
 
 import pytest
 
-from plugins.coding_agent import _normalize_agents, register
+import plugins.coding_agent as P
+from plugins.coding_agent import _make_permission, _normalize_agents, register
 from plugins.coding_agent.acp_client import AcpClient, AcpError
 
 # ── a minimal ACP "agent" (server side) we can drive over stdio ───────────────
@@ -46,9 +47,11 @@ while True:
             "update": {"sessionUpdate": "tool_call", "title": "Editing app.py"}}})
         # Ask permission; the client must respond before we continue.
         send({"jsonrpc": "2.0", "id": 999, "method": "session/request_permission",
-              "params": {"sessionId": "s1", "options": [
-                  {"optionId": "no", "kind": "deny"},
-                  {"optionId": "yes", "kind": "allow_once"}]}})
+              "params": {"sessionId": "s1",
+                         "toolCall": {"toolCallId": "t1", "kind": "edit"},
+                         "options": [
+                             {"optionId": "reject", "kind": "reject_once"},
+                             {"optionId": "ok", "kind": "allow_once"}]}})
         resp = json.loads(sys.stdin.readline().strip())
         chosen = resp.get("result", {}).get("outcome", {}).get("optionId")
         for chunk in ("Hello ", "world [" + str(chosen) + "]"):
@@ -155,10 +158,25 @@ async def test_acp_client_drives_a_turn(fake_agent, tmp_path):
     finally:
         await client.close()
 
-    # agent_message_chunks accumulated; auto-allow picked the `allow_once` option.
-    assert answer == "Hello world [yes]"
+    # agent_message_chunks accumulated; default auto-allow picked the allow option.
+    assert answer == "Hello world [ok]"
     # tool_call title narrated via the progress callback.
     assert "Editing app.py" in narrations
+
+
+async def test_acp_client_readonly_policy_denies_edit(fake_agent, tmp_path):
+    # A readonly policy must reject the fake's `edit` permission request — the
+    # client picks the reject_once option, which the fake echoes back.
+    spec = {"name": "ro", "permissions": "readonly", "allow_kinds": [], "deny_kinds": []}
+    client = AcpClient(
+        sys.executable, [str(fake_agent)], cwd=str(tmp_path),
+        permission=_make_permission(spec),
+    )
+    try:
+        answer = await client.prompt("edit a file", timeout=30.0)
+    finally:
+        await client.close()
+    assert answer == "Hello world [reject]"
 
 
 async def test_acp_client_missing_binary_raises_acp_error(tmp_path):
@@ -171,3 +189,95 @@ async def test_acp_client_bad_workdir_raises_acp_error():
     client = AcpClient(sys.executable, [], cwd="/no/such/dir/anywhere")
     with pytest.raises(AcpError):
         await client.prompt("hi", timeout=10.0)
+
+
+# ── permission policy ─────────────────────────────────────────────────────────
+
+_OPTS = [{"optionId": "a", "kind": "allow_once"}, {"optionId": "r", "kind": "reject_once"}]
+
+
+def _perm(policy, kind, options=None, allow=None, deny=None):
+    spec = {
+        "name": "x", "permissions": policy,
+        "allow_kinds": [k.lower() for k in (allow or [])],
+        "deny_kinds": [k.lower() for k in (deny or [])],
+    }
+    return _make_permission(spec)({"toolCall": {"kind": kind}, "options": options or _OPTS})
+
+
+def test_policy_auto_allows_everything():
+    assert _perm("auto", "execute") == "a"
+    assert _perm("auto", "delete") == "a"
+    assert _perm("auto", "edit") == "a"
+
+
+def test_policy_allowlist_denies_risky_allows_safe():
+    assert _perm("allowlist", "edit") == "a"
+    assert _perm("allowlist", "read") == "a"
+    assert _perm("allowlist", "execute") == "r"      # risky → reject option
+    assert _perm("allowlist", "delete") == "r"
+
+
+def test_policy_readonly_allows_read_denies_writes():
+    assert _perm("readonly", "read") == "a"
+    assert _perm("readonly", "search") == "a"
+    assert _perm("readonly", "edit") == "r"
+    assert _perm("readonly", "execute") == "r"
+
+
+def test_policy_deny_cancels_when_no_reject_option():
+    only_allow = [{"optionId": "a", "kind": "allow_once"}]
+    assert _perm("readonly", "edit", options=only_allow) is None
+
+
+def test_policy_custom_allow_deny_kinds():
+    assert _perm("allowlist", "edit", deny=["edit"]) == "r"        # explicitly denied
+    assert _perm("readonly", "edit", allow=["read", "edit"]) == "a"  # explicitly allowed
+
+
+def test_normalize_agents_parses_safety_fields():
+    a = _normalize_agents([{
+        "name": "p", "command": "c", "workdir": "/tmp",
+        "permissions": "READONLY", "confirm": True,
+        "allow_kinds": ["Read"], "deny_kinds": ["Execute"],
+    }])["p"]
+    assert a["permissions"] == "readonly"          # lower-cased
+    assert a["confirm"] is True
+    assert a["allow_kinds"] == ["read"] and a["deny_kinds"] == ["execute"]
+
+
+def test_normalize_agents_bad_policy_falls_back_to_auto():
+    a = _normalize_agents([{"name": "p", "command": "c", "workdir": "/tmp", "permissions": "yolo"}])["p"]
+    assert a["permissions"] == "auto"
+    assert a["confirm"] is False                    # default
+
+
+# ── per-call consent gate (confirm) ───────────────────────────────────────────
+
+
+async def test_confirm_gate_declines(monkeypatch):
+    import langgraph.types as lt
+    monkeypatch.setattr(lt, "interrupt", lambda payload: "no")
+    reg = _StubRegistry({"agents": [
+        {"name": "proto", "command": "proto", "workdir": "/tmp", "confirm": True},
+    ]})
+    register(reg)
+    out = await reg.tools[0].ainvoke({"agent": "proto", "task": "do it"})
+    assert "Declined" in out
+
+
+async def test_confirm_gate_approves_then_runs(monkeypatch):
+    import langgraph.types as lt
+    monkeypatch.setattr(lt, "interrupt", lambda payload: "yes")
+
+    class _StubClient:
+        async def prompt(self, task, progress_callback=None, timeout=600.0):
+            return "did the work"
+
+    monkeypatch.setattr(P, "_client_for", lambda spec: _StubClient())
+    reg = _StubRegistry({"agents": [
+        {"name": "proto", "command": "proto", "workdir": "/tmp", "confirm": True},
+    ]})
+    register(reg)
+    out = await reg.tools[0].ainvoke({"agent": "proto", "task": "do it"})
+    assert out == "did the work"


### PR DESCRIPTION
Builds on #596 (the `coding_agent` plugin base). Adds the **permission story** for spawned CLI coding agents.

## What

### By-kind permission policy
Each configured agent answers the coding agent's `session/request_permission` requests per a policy, keyed on the request's `toolCall.kind`:

| `permissions` | Behaviour |
|---|---|
| `auto` *(default)* | Allow everything (unchanged from PR1). |
| `allowlist` | Allow all kinds **except** `execute`/`delete` (override via `allow_kinds`/`deny_kinds`). |
| `readonly` | Allow only read-like kinds (`read`, `search`, `fetch`, …); deny edits/shell/deletes. |

`AcpClient` gains a pluggable permission resolver; the default stays auto-allow, so PR1 behaviour is byte-for-byte unchanged.

### Per-call consent gate
`confirm: true` makes `code_with` ask the operator via `ask_human` **before each call** to that agent (parks the turn as `input-required`). The gate runs before any side effect, so LangGraph's resume re-execution is idempotent. `code_with` drops `@with_fallback` (it would swallow the `interrupt()` control-flow exception, like `ask_human` already avoids); the I/O is guarded with a local net.

### Agent recipes
Docs + manifest examples for protoCLI (`proto --acp`), Claude Code (`npx @zed-industries/claude-code-acp`), Codex (`codex acp`), Gemini CLI (`gemini --experimental-acp`).

## Deferred (documented, not dropped)

**Per-action live HITL** — approving each individual edit/shell command mid-turn — is incompatible with `interrupt()`'s checkpoint-and-**re-run** model: it can't resume a half-finished, blocking ACP subprocess session awaiting a specific permission response. Use `readonly`/`allowlist` for deterministic per-action control and `confirm` for a per-call human gate. (Same coupling blocks live narration — it wants a general progress channel, so it's its own PR.)

## Config

```yaml
coding_agent:
  agents:
    - name: proto
      command: proto
      args: ["--acp"]
      workdir: ~/dev/my-repo
      permissions: allowlist      # auto | allowlist | readonly
      # deny_kinds: [execute, delete]
      confirm: true               # ask before each code_with call
```

## Test

```
$ pytest tests/test_coding_agent_plugin.py tests/test_plugins.py -q
36 passed
```

New coverage: policy decisions across kinds (auto/allowlist/readonly + custom allow/deny), deny-cancels-when-no-reject-option, a **wire test** that a `readonly` policy rejects the fake agent's `edit` request, the confirm gate (approve + decline via a stubbed `interrupt`), and the new config fields.

## Files
- `plugins/coding_agent/acp_client.py` — pluggable permission resolver
- `plugins/coding_agent/__init__.py` — policy, consent gate, config parsing
- `plugins/coding_agent/protoagent.plugin.yaml` — fields + recipes
- ADR 0024 (scope/posture), guide (permission section rewritten), CHANGELOG

## Next (PR4, small)
Gated eval case — needs an eval-runner skip mechanism so it doesn't require a coding agent in the default board.

🤖 Generated with [Claude Code](https://claude.com/claude-code)