### PR TITLE
feat(evals): requires_env skip + gated code_with delegation eval — ADR 0024 (PR4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Eval-case gating (`requires_env`)** — an eval case can now declare
+  `requires_env: [VAR, …]`; when any is unset the case is **skipped** (shown
+  `SKIP`, excluded from the pass/fail tally) instead of run, so a case needing an
+  optional integration doesn't break the default board. Uses it to ship a gated
+  `code_with_delegation` case (ADR 0024) that verifies end-to-end coding-agent
+  delegation over a live A2A turn — run it with `EVAL_CODING_AGENT=1` once a
+  coding agent is configured. See [Eval your fork](docs/guides/evals.md).
 - **Spawn CLI coding agents over ACP** — a new opt-in `coding_agent` plugin
   (ADR 0024) adds a `code_with(agent, task)` tool that hands a real, repo-scoped
   coding job to a purpose-built CLI coding agent (protoCLI `proto`, Claude Code,

--- a/docs/adr/0024-spawn-cli-coding-agents-acp.md
+++ b/docs/adr/0024-spawn-cli-coding-agents-acp.md
@@ -129,12 +129,16 @@ Synchronous — the final answer is returned; `tool_call` titles are logged.
 recipes (claude-code-acp, codex, gemini). Per-action live HITL is documented as
 deferred (the blocking-session constraint above).
 
+**PR4:** a gated eval case (`code_with_delegation`) verifying end-to-end
+delegation over a live A2A turn, plus a `requires_env` skip mechanism in the eval
+runner so the case (and any future case needing an optional integration) is
+skipped — not failed — when its prerequisite env var is unset.
+
 **Later PRs:** live narration of `tool_call` titles onto A2A working-status
 frames (so an operator watching a turn sees "Editing app.py") — blocked on the
 same mid-session channel as per-action HITL, so it wants a general progress
 mechanism (event-bus ride-along or a stream-factory `progress` event), not a
-one-off; a gated eval case (needs an eval-runner skip mechanism so it doesn't
-require a coding agent in the default run).
+one-off.
 
 ## Consequences
 

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -167,5 +167,19 @@ One `AcpClient` (subprocess + session) is **cached per agent** so follow-up call
 continue the thread; a per-agent lock serializes turns (a session is a single
 conversation — `task_batch` won't interleave two prompts on one).
 
+## Eval it
+
+A gated eval case (`code_with_delegation`) verifies end-to-end delegation against
+a live agent. It's skipped unless you opt in — configure an agent, then:
+
+```bash
+export EVAL_CODING_AGENT=1
+python -m evals.runner --tasks code_with_delegation
+```
+
+It drives a real A2A turn that asks the agent to use `code_with`, and asserts
+(via the audit channel) that the tool fired. Without `EVAL_CODING_AGENT` set it
+`SKIP`s, so it never breaks the default board. See [Eval your fork](/guides/evals).
+
 See [Plugins](/guides/plugins) for the plugin model in general, and
 [ADR 0024](/adr/0024-spawn-cli-coding-agents-acp) for the design rationale.

--- a/docs/guides/evals.md
+++ b/docs/guides/evals.md
@@ -154,6 +154,29 @@ The case `kind`s that ship:
   and assert on its synthesized output (patterns + rubric). Used to track the
   subagent workflows (research-and-brief, deep-research).
 
+### Gating a case on prerequisites — `requires_env`
+
+A case can declare `requires_env: [VAR, …]`. If any of those env vars is unset
+the case is **skipped** (shown `SKIP`, not counted as pass or fail) instead of
+run — so a case that needs an optional integration doesn't break the default
+board. For example the `code_with_delegation` case needs a live CLI coding agent
+([Spawn CLI coding agents](/guides/coding-agents)) configured on the instance, so
+it's gated:
+
+```json
+{
+  "id": "code_with_delegation",
+  "category": "tool",
+  "kind": "ask",
+  "requires_env": ["EVAL_CODING_AGENT"],
+  "prompt": "Use your code_with tool to have a coding agent run `pwd` …",
+  "expected_tools": ["code_with"]
+}
+```
+
+Configure the plugin + an agent, export `EVAL_CODING_AGENT=1`, and run
+`python -m evals.runner --tasks code_with_delegation`.
+
 ## Asserting the agent layer (subagents & workflows)
 
 Beyond single-tool selection, the suite tracks the layers recent work has been

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -33,6 +33,7 @@ from __future__ import annotations
 import argparse
 import asyncio
 import json
+import os
 import sys
 import time
 from dataclasses import asdict, dataclass, field
@@ -58,6 +59,19 @@ class CaseResult:
     duration_ms: int = 0
     tokens: int = 0
     raw: dict = field(default_factory=dict)
+    skipped: bool = False
+
+
+def _requirements_unmet(case: dict) -> str | None:
+    """A reason to skip the case, or None to run it. A case declares
+    ``requires_env: [VAR, …]`` for prerequisites that aren't always present —
+    e.g. an optional integration the operator opts into. Skipped (not failed)
+    when any is unset, so a case needing a live coding agent doesn't break the
+    default board."""
+    for var in case.get("requires_env") or []:
+        if not os.environ.get(var):
+            return f"requires_env {var}"
+    return None
 
 
 # ── case runners ────────────────────────────────────────────────────────────
@@ -473,8 +487,8 @@ def _print_board(results: list[CaseResult]) -> None:
     print("-" * 90)
     pass_count = 0
     for r in results:
-        mark = "PASS" if r.passed else "FAIL"
-        if r.passed:
+        mark = "SKIP" if r.skipped else ("PASS" if r.passed else "FAIL")
+        if r.passed and not r.skipped:
             pass_count += 1
         time_s = f"{r.duration_ms}ms".rjust(6)
         tokens = str(r.tokens).rjust(6) if r.tokens else "  -   "
@@ -483,7 +497,9 @@ def _print_board(results: list[CaseResult]) -> None:
             f"{mark}    {time_s}  {tokens}  {r.detail[:80]}"
         )
     print("-" * 90)
-    print(f"\n{pass_count}/{len(results)} passed")
+    skip_count = sum(1 for r in results if r.skipped)
+    ran = len(results) - skip_count
+    print(f"\n{pass_count}/{ran} passed" + (f" ({skip_count} skipped)" if skip_count else ""))
 
 
 def _save_report(results: list[CaseResult], path: Path, *, model: str = "", base_url: str = "") -> None:
@@ -496,7 +512,8 @@ def _save_report(results: list[CaseResult], path: Path, *, model: str = "", base
         "model": model,
         "base_url": base_url,
         "total": len(results),
-        "passed": sum(1 for r in results if r.passed),
+        "passed": sum(1 for r in results if r.passed and not r.skipped),
+        "skipped": sum(1 for r in results if r.skipped),
         "results": [asdict(r) for r in results],
     }
     path.write_text(json.dumps(payload, indent=2))
@@ -544,8 +561,16 @@ async def main():
     for case in cases:
         sys.stdout.write(f"  {case['id']}... ")
         sys.stdout.flush()
-        result = await run_one(client, case)
-        sys.stdout.write(f"{'PASS' if result.passed else 'FAIL'}  {result.detail[:60]}\n")
+        skip = _requirements_unmet(case)
+        if skip:
+            result = CaseResult(
+                case["id"], case.get("category", "?"), case.get("name", "?"),
+                passed=True, detail=f"skipped: {skip}", skipped=True,
+            )
+        else:
+            result = await run_one(client, case)
+        mark = "SKIP" if result.skipped else ("PASS" if result.passed else "FAIL")
+        sys.stdout.write(f"{mark}  {result.detail[:60]}\n")
         results.append(result)
 
     _print_board(results)

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -57,6 +57,16 @@
     "expected_patterns": ["UTC"]
   },
   {
+    "id": "code_with_delegation",
+    "category": "tool",
+    "kind": "ask",
+    "name": "Delegates a coding task via code_with (ACP)",
+    "requires_env": ["EVAL_CODING_AGENT"],
+    "timeout_s": 240,
+    "prompt": "Use your code_with tool to have a coding agent run `pwd` and report back the absolute working directory it printed.",
+    "expected_tools": ["code_with"]
+  },
+  {
     "id": "calculator_intent",
     "category": "tool",
     "kind": "ask",

--- a/tests/test_eval_coverage.py
+++ b/tests/test_eval_coverage.py
@@ -188,3 +188,40 @@ def test_workflow_cases_reference_real_recipes():
     for c in TASKS:
         if c.get("kind") == "workflow":
             assert c["workflow"] in bundled, f"{c['id']} → unknown recipe {c['workflow']!r}"
+
+
+# ── requires_env skip mechanism (ADR 0024 coding-agent eval) ──────────────────
+
+
+def test_requirements_unmet_skips_when_env_missing(monkeypatch):
+    monkeypatch.delenv("EVAL_X", raising=False)
+    assert runner._requirements_unmet({"requires_env": ["EVAL_X"]}) == "requires_env EVAL_X"
+
+
+def test_requirements_met_runs_when_env_set(monkeypatch):
+    monkeypatch.setenv("EVAL_X", "1")
+    assert runner._requirements_unmet({"requires_env": ["EVAL_X"]}) is None
+
+
+def test_no_requirements_runs():
+    assert runner._requirements_unmet({}) is None
+    assert runner._requirements_unmet({"requires_env": []}) is None
+
+
+def test_code_with_eval_case_present_and_gated():
+    case = {c["id"]: c for c in TASKS}.get("code_with_delegation")
+    assert case is not None, "code_with_delegation case missing"
+    assert case["requires_env"] == ["EVAL_CODING_AGENT"]   # skips by default
+    assert case["expected_tools"] == ["code_with"]
+    assert case["kind"] == "ask"
+
+
+def test_board_counts_skipped_separately(capsys):
+    results = [
+        runner.CaseResult("a", "tool", "A", passed=True, detail="ok"),
+        runner.CaseResult("b", "tool", "B", passed=True, detail="skipped: requires_env X", skipped=True),
+    ]
+    runner._print_board(results)
+    out = capsys.readouterr().out
+    assert "1/1 passed (1 skipped)" in out
+    assert "SKIP" in out


### PR DESCRIPTION
Completes the ADR 0024 PR plan (after #596 base + #599 permissions) with the **coding-agent eval**, plus the runner mechanism it needs.

## What

### `requires_env` skip mechanism
An eval case may declare `requires_env: [VAR, …]`. When any is unset the case is **skipped** — not run, not failed:
- new `CaseResult.skipped`; the board shows `SKIP` and tallies `X/Y passed (Z skipped)`;
- skipped cases don't trip the non-zero exit code or pollute the report's `passed` count.

Generally useful: any case needing an optional integration can gate on it without breaking the default board.

### Gated coding-agent eval
`code_with_delegation` (`kind: ask`, gated on `EVAL_CODING_AGENT`) drives a **live A2A turn** that asks the agent to use `code_with`, and asserts via the audit channel that the tool fired — proving end-to-end delegation wiring. Skips by default (no coding agent in CI/most boards).

```bash
# once a coding agent is configured (see the guide):
export EVAL_CODING_AGENT=1
python -m evals.runner --tasks code_with_delegation
```

## Why a skip mechanism

The eval runner had no conditional-skip support, so a case requiring a live coding agent would **fail** the default `python -m evals.runner` for anyone without one configured. `requires_env` makes it a clean `SKIP`.

## Test

```
$ pytest tests/test_eval_coverage.py tests/test_eval_sweep.py tests/test_eval_compare.py -q
36 passed
```

New coverage: `_requirements_unmet` (set/unset/empty), the board counting skipped separately, and the new case being present + gated + asserting `code_with`.

## Files
- `evals/runner.py` — `CaseResult.skipped`, `_requirements_unmet`, run-loop + board + report wiring
- `evals/tasks.json` — `code_with_delegation` case
- `tests/test_eval_coverage.py` — skip-mechanism + case-validity tests
- evals guide (`requires_env`), coding-agents guide (Eval it), ADR 0024 scope, CHANGELOG

## ADR 0024 status after this
PR1 (#596) base · PR2 deferred (live narration — wants a general progress channel) · PR3 (#599) permissions · **PR4 (this) eval**. The initiative's planned scope is complete bar the deferred live-narration channel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)