### PR TITLE
feat(delegates): CRUD REST API + Test probe + secret routing (ADR 0025, PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,9 +21,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   schema. Declare delegates in a top-level `delegates:` list; editing it +
   Save & Reload swaps the roster live (no restart). Unifies what `code_with`
   (acp) and `peer_consult` (a2a) did and adds model-endpoint delegation. Ships
-  disabled; enable with `plugins: { enabled: [delegates] }`. A REST CRUD API and a
-  console panel to manage delegates from the UI land in follow-up slices.
+  disabled; enable with `plugins: { enabled: [delegates] }`. A console panel to
+  manage delegates from the UI lands in a follow-up slice.
   See [the guide](docs/guides/delegates.md).
+- **Delegate CRUD REST API** (ADR 0025, PR2) — `/api/delegates` (GET/POST/PUT/
+  DELETE) + `/api/delegates/test` (reachability probe — agent-card GET for a2a,
+  `/v1/models` ping for openai, binary-on-PATH + workdir for acp) +
+  `/api/delegate-types` (the field schema that drives the panel). Mutations write
+  the config + route each delegate's secret to the gitignored `secrets.yaml`
+  (a `delegate_secrets` overlay keyed `<name>.<field>` — never echoed back or kept
+  in tracked config), then hot-reload so the new roster is live next turn. Same
+  operator-console posture as `/api/config`.
 
 ## [0.16.0] - 2026-06-06
 

--- a/docs/adr/0025-unified-delegate-registry-and-panel.md
+++ b/docs/adr/0025-unified-delegate-registry-and-panel.md
@@ -129,8 +129,10 @@ Mounted by the plugin router:
   0024 `AcpClient`), the `delegate_to` tool, config-driven hot-reload, tests. No
   API/panel yet; configured via YAML. `code_with`/`peer_consult` untouched this
   slice.
-- **PR2: CRUD REST API** — the endpoints above + atomic config/secrets writes +
-  reload trigger + `probe()` for Test + `/delegate-types` schema.
+- **PR2 (shipped): CRUD REST API** — the endpoints above + config/secrets writes
+  (inline secrets → `secrets.yaml` `delegate_secrets` overlay) + reload trigger +
+  `probe()` for Test + `/delegate-types` schema. Mounted by the plugin router at
+  `/api/delegates*` (operator-console posture).
 - **PR3: React panel** — Delegates settings view in `apps/web` (type picker,
   generic form from the schema, Test button, list with status).
 - **PR4: health prober** — background reachability loop + health badges; then

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -33,4 +33,4 @@ decision, numbered, never deleted (supersede instead).
 | [0022](./0022-activity-provenance-feed.md) | Activity is a provenance feed, not a second chat | Accepted |
 | [0023](./0023-server-decomposition.md) | Decompose server.py: AppState + composition root | Accepted |
 | [0024](./0024-spawn-cli-coding-agents-acp.md) | Spawn CLI coding agents over ACP (`code_with`) | Accepted (PR1 + PR3) |
-| [0025](./0025-unified-delegate-registry-and-panel.md) | Unified delegate registry + hot-swappable panel (`delegate_to`) | Accepted (sliced; PR1) |
+| [0025](./0025-unified-delegate-registry-and-panel.md) | Unified delegate registry + hot-swappable panel (`delegate_to`) | Accepted (sliced; PR1 + PR2) |

--- a/docs/guides/delegates.md
+++ b/docs/guides/delegates.md
@@ -14,10 +14,9 @@ This unifies what used to be three separate things — `peer_consult` (a2a),
 `code_with` (acp), and "no way to ask another model" — into one hot-swappable
 roster.
 
-> **Where this is going:** PR1 (current) is **config-driven** — you declare
-> delegates in YAML and they hot-reload on Save & Reload. A REST CRUD API (PR2)
-> and a **console panel** to add/edit/test/remove delegates live (PR3) build on
-> this. See [ADR 0025](/adr/0025-unified-delegate-registry-and-panel).
+> **Where this is going:** delegates are managed by **config** (below) and a
+> **REST API** (below). A **console panel** to add/edit/test/remove them from the
+> UI (PR3) builds on the API. See [ADR 0025](/adr/0025-unified-delegate-registry-and-panel).
 
 ## Enable it
 
@@ -74,6 +73,34 @@ Google tokens. For PR1 you can either:
 - set the value in `secrets.yaml` (merged into the delegate at load), or
 - reference an env var: `auth: { scheme: bearer, credentialsEnv: HELM_TOKEN }`
   (a2a) / `api_key_env: GATEWAY_KEY` (openai).
+
+## Manage via the REST API
+
+The plugin mounts a CRUD surface (operator-console posture — localhost-default,
+bearer-when-exposed, like `/api/config`). The console panel (PR3) is built on it;
+you can also drive it directly:
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/delegate-types` | type list + field schema (drives the form) |
+| GET | `/api/delegates` | list delegates (secret-free; `configured` + `has_secret` flags) |
+| POST | `/api/delegates` | create (409 if the name exists) |
+| PUT | `/api/delegates/{name}` | update |
+| DELETE | `/api/delegates/{name}` | remove |
+| POST | `/api/delegates/test` | reachability probe of an entry (the **Test** button) |
+
+Create/update/delete **write the config + route the secret to `secrets.yaml`**,
+then hot-reload — so the roster is live on the next turn, no restart. A secret you
+send in `auth.token` / `api_key` is stored under the `delegate_secrets` overlay
+and **never returned** by `GET /api/delegates`; `has_secret` tells the panel one
+is stored.
+
+```bash
+curl -s localhost:7788/api/delegate-types | jq '.types[].type'
+curl -s -X POST localhost:7788/api/delegates -d '{"name":"opus","type":"openai",
+  "url":"https://api.proto-labs.ai/v1","model":"protolabs/reasoning","api_key":"…"}'
+curl -s -X POST localhost:7788/api/delegates/test -d '{"type":"a2a","url":"https://peer/a2a"}'
+```
 
 ## Relationship to `code_with` / `peer_consult`
 

--- a/plugins/delegates/__init__.py
+++ b/plugins/delegates/__init__.py
@@ -64,12 +64,9 @@ def _load_delegates_config() -> list:
     if a fork nests it under the plugin section.
     """
     try:
-        from graph.config_io import load_yaml_doc
+        from .store import merged_delegates
 
-        doc = load_yaml_doc() or {}
-        val = doc.get("delegates")
-        if isinstance(val, list):
-            return val
+        return merged_delegates()   # delegates + secrets overlaid from secrets.yaml
     except Exception:  # noqa: BLE001 — config read is best-effort
         log.exception("[delegates] reading delegates config failed")
     return []
@@ -77,6 +74,15 @@ def _load_delegates_config() -> list:
 
 def register(registry) -> None:
     """Entry point — called once per graph build with the live config."""
+    # CRUD API for the console panel (PR2). Mounted once at process init; the
+    # roster it edits is config, which hot-reloads — so the static routes are fine.
+    try:
+        from .api import build_router
+
+        registry.register_router(build_router(), prefix="")
+    except Exception:  # noqa: BLE001 — API is best-effort; the tool still works
+        log.exception("[delegates] mounting CRUD API failed")
+
     delegates = _load_delegates_config()
     if not delegates:
         cfg = registry.config or {}
@@ -87,7 +93,8 @@ def register(registry) -> None:
     if not reg.names():
         log.warning(
             "[delegates] enabled but no delegates configured — add entries under "
-            "`delegates` (see docs/guides/delegates.md). No tool registered."
+            "`delegates` (see docs/guides/delegates.md), or use the Delegates panel. "
+            "No delegate_to tool registered yet."
         )
         return
     registry.register_tool(_build_delegate_to(reg))

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -108,6 +108,14 @@ class Adapter:
     async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
         raise NotImplementedError
 
+    async def probe(self, d: Delegate) -> dict:
+        """Reachability check for the panel's Test button: {ok, latency_ms, error}."""
+        return {"ok": None, "error": "probe not implemented for this type"}
+
+    # secret field this type stores (for the CRUD secret overlay), as a dotted
+    # path into the raw entry. None ⇒ no secret.
+    secret_field: str | None = None
+
     # Shared helpers ---------------------------------------------------------
     @staticmethod
     def _base(raw: dict) -> dict:
@@ -118,10 +126,19 @@ class Adapter:
                 "description": str(raw.get("description", "")).strip()}
 
 
+async def _timed(coro) -> tuple[object, int]:
+    """Await ``coro``, returning (result, elapsed_ms)."""
+    import time
+    t0 = time.monotonic()
+    res = await coro
+    return res, int((time.monotonic() - t0) * 1000)
+
+
 class A2aAdapter(Adapter):
     type = "a2a"
     label = "A2A agent"
     blurb = "A fleet peer over the A2A JSON-RPC protocol."
+    secret_field = "auth.token"
 
     def config_schema(self) -> list[FieldSpec]:
         return [
@@ -193,11 +210,31 @@ class A2aAdapter(Adapter):
                 return text
             raise DelegateError(f"no text returned (state={state})")
 
+    async def probe(self, d: Delegate) -> dict:
+        import httpx
+
+        import security
+        origin = d.url.split("/a2a")[0].rstrip("/") if "/a2a" in d.url else d.url.rstrip("/")
+        card = f"{origin}/.well-known/agent-card.json"
+        blocked = security.check_url(card)
+        if blocked:
+            return {"ok": False, "error": blocked}
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                r, ms = await _timed(client.get(card))
+            if r.status_code >= 400:
+                return {"ok": False, "latency_ms": ms, "error": f"HTTP {r.status_code}"}
+            name = (r.json() or {}).get("name", "")
+            return {"ok": True, "latency_ms": ms, "detail": f"agent-card OK ({name})"}
+        except Exception as exc:  # noqa: BLE001
+            return {"ok": False, "error": str(exc)[:200]}
+
 
 class OpenAiAdapter(Adapter):
     type = "openai"
     label = "Model endpoint"
     blurb = "An OpenAI-compatible chat endpoint — ask another model."
+    secret_field = "api_key"
 
     def config_schema(self) -> list[FieldSpec]:
         return [
@@ -254,6 +291,19 @@ class OpenAiAdapter(Adapter):
             return (data["choices"][0]["message"]["content"] or "").strip()
         except (KeyError, IndexError, TypeError) as exc:
             raise DelegateError(f"unexpected response shape: {exc}")
+
+    async def probe(self, d: Delegate) -> dict:
+        import httpx
+        headers = {"Authorization": f"Bearer {d.api_key}"} if d.api_key else {}
+        url = d.url.rstrip("/") + "/models"
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                r, ms = await _timed(client.get(url, headers=headers))
+            if r.status_code >= 400:
+                return {"ok": False, "latency_ms": ms, "error": f"HTTP {r.status_code}: {r.text[:120]}"}
+            return {"ok": True, "latency_ms": ms, "detail": "endpoint reachable"}
+        except Exception as exc:  # noqa: BLE001
+            return {"ok": False, "error": str(exc)[:200]}
 
 
 class AcpAdapter(Adapter):
@@ -313,6 +363,16 @@ class AcpAdapter(Adapter):
             return await client.prompt(query, timeout=timeout or d.timeout_s)
         except AcpError as exc:
             raise DelegateError(str(exc))
+
+    async def probe(self, d: Delegate) -> dict:
+        import os
+        import shutil
+        if not shutil.which(d.command):
+            return {"ok": False, "error": f"binary not on PATH: {d.command!r}"}
+        wd = os.path.expanduser(d.workdir)
+        if not os.path.isdir(wd):
+            return {"ok": False, "error": f"workdir does not exist: {wd}"}
+        return {"ok": True, "detail": f"{d.command} on PATH; workdir OK"}
 
 
 ADAPTERS: dict[str, Adapter] = {a.type: a for a in (A2aAdapter(), OpenAiAdapter(), AcpAdapter())}

--- a/plugins/delegates/api.py
+++ b/plugins/delegates/api.py
@@ -1,0 +1,146 @@
+"""Delegate CRUD REST API (ADR 0025, PR2).
+
+Mounted on the app at ``/api/delegates*`` (operator-console surface — same posture
+as ``/api/config``: localhost-default bind + bearer-when-exposed, no per-route
+auth). Drives the panel (PR3): list / create / update / delete / test + the
+type schema. Mutations write config + secrets, then hot-reload the graph so the
+new roster is live on the next turn.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from . import store
+from .adapters import ADAPTERS, DelegateError, delegate_types
+
+log = logging.getLogger("protoagent.plugins.delegates")
+
+
+def _public_view(raw: dict) -> dict:
+    """A delegate as the panel sees it: config fields minus any secret, plus a
+    ``configured`` flag (does it parse?) and ``has_secret`` (is one stored?)."""
+    adapter = ADAPTERS.get(str(raw.get("type", "")))
+    configured, error = True, None
+    if adapter is None:
+        configured, error = False, f"unknown type {raw.get('type')!r}"
+    else:
+        try:
+            adapter.parse(dict(raw))
+        except DelegateError as e:
+            configured, error = False, str(e)
+    name = raw.get("name")
+    has_secret = bool(
+        adapter and adapter.secret_field
+        and store.secret_overlay().get(f"{name}.{adapter.secret_field}")
+    )
+    view = {k: v for k, v in raw.items()
+            if not (k in ("auth", "api_key") or "token" in str(k) or "key" in str(k).lower())}
+    # keep auth.scheme (not the token) for a2a so the form can prefill it
+    if isinstance(raw.get("auth"), dict) and raw["auth"].get("scheme"):
+        view["auth"] = {"scheme": raw["auth"]["scheme"]}
+    view.update({"name": name, "type": raw.get("type"),
+                 "description": raw.get("description", ""),
+                 "configured": configured, "error": error, "has_secret": has_secret})
+    return view
+
+
+def _list_payload() -> dict:
+    return {"delegates": [_public_view(r) for r in store.read_delegates_raw() if isinstance(r, dict)]}
+
+
+def _validate(entry: dict):
+    name = str(entry.get("name", "")).strip()
+    if not name:
+        raise ValueError("delegate needs a name")
+    adapter = ADAPTERS.get(str(entry.get("type", "")))
+    if adapter is None:
+        raise ValueError(f"unknown type {entry.get('type')!r} (want one of {', '.join(ADAPTERS)})")
+    try:
+        adapter.parse(dict(entry))   # secrets not required to validate shape
+    except DelegateError as e:
+        raise ValueError(str(e))
+    return name, adapter
+
+
+def _inject_stored_secret(entry: dict, adapter) -> dict:
+    """For Test: if the entry omits its secret, fill it from the stored overlay so
+    the probe uses the saved credential."""
+    if not adapter.secret_field:
+        return entry
+    import copy
+    entry = copy.deepcopy(entry)
+    if store._pop_dotted(copy.deepcopy(entry), adapter.secret_field):
+        return entry  # caller supplied one
+    val = store.secret_overlay().get(f"{entry.get('name')}.{adapter.secret_field}")
+    if val:
+        store._set_dotted(entry, adapter.secret_field, val)
+    return entry
+
+
+async def _reload():
+    import asyncio
+
+    from server.agent_init import _reload_langgraph_agent
+    return await asyncio.to_thread(_reload_langgraph_agent)
+
+
+def build_router():
+    from fastapi import APIRouter, Body, HTTPException
+
+    router = APIRouter()
+
+    @router.get("/api/delegate-types")
+    async def _types():
+        return {"types": delegate_types()}
+
+    @router.get("/api/delegates")
+    async def _list():
+        return _list_payload()
+
+    @router.post("/api/delegates/test")
+    async def _test(entry: dict = Body(...)):
+        adapter = ADAPTERS.get(str(entry.get("type", "")))
+        if adapter is None:
+            raise HTTPException(400, f"unknown type {entry.get('type')!r}")
+        merged = _inject_stored_secret(entry, adapter)
+        try:
+            d = adapter.parse(merged)
+        except DelegateError as e:
+            raise HTTPException(400, str(e))
+        return await adapter.probe(d)
+
+    @router.post("/api/delegates")
+    async def _create(entry: dict = Body(...)):
+        try:
+            name, _ = _validate(entry)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        if any(isinstance(e, dict) and e.get("name") == name for e in store.read_delegates_raw()):
+            raise HTTPException(409, f"delegate {name!r} already exists")
+        store.upsert_delegate(entry)
+        ok, msg = await _reload()
+        return {"ok": ok, "message": msg, **_list_payload()}
+
+    @router.put("/api/delegates/{name}")
+    async def _update(name: str, entry: dict = Body(...)):
+        if entry.get("name") and entry["name"] != name:
+            raise HTTPException(400, "name in body must match the path")
+        entry["name"] = name
+        try:
+            _validate(entry)
+        except ValueError as e:
+            raise HTTPException(400, str(e))
+        if not any(isinstance(e, dict) and e.get("name") == name for e in store.read_delegates_raw()):
+            raise HTTPException(404, f"delegate {name!r} not found")
+        store.upsert_delegate(entry)
+        ok, msg = await _reload()
+        return {"ok": ok, "message": msg, **_list_payload()}
+
+    @router.delete("/api/delegates/{name}")
+    async def _delete(name: str):
+        store.delete_delegate(name)
+        ok, msg = await _reload()
+        return {"ok": ok, "message": msg, **_list_payload()}
+
+    return router

--- a/plugins/delegates/store.py
+++ b/plugins/delegates/store.py
@@ -1,0 +1,116 @@
+"""Delegate config store — read/write the top-level ``delegates:`` list +
+route per-delegate secrets to the gitignored ``secrets.yaml`` (ADR 0025, PR2).
+
+The delegate list lives in ``langgraph-config.yaml`` **without secret values**;
+each delegate's secret (a2a ``auth.token``, openai ``api_key``) is stored in
+``secrets.yaml`` under a ``delegate_secrets`` map keyed ``<name>.<field>`` and
+overlaid back at load. So the tracked config never holds a secret, and the panel
+never has to round-trip one it already stored.
+"""
+
+from __future__ import annotations
+
+import copy
+
+from .adapters import ADAPTERS
+
+SECRETS_SECTION = "delegate_secrets"
+
+
+def _set_dotted(d: dict, dotted: str, value) -> None:
+    parts = dotted.split(".")
+    cur = d
+    for p in parts[:-1]:
+        nxt = cur.get(p)
+        if not isinstance(nxt, dict):
+            nxt = {}
+            cur[p] = nxt
+        cur = nxt
+    cur[parts[-1]] = value
+
+
+def _pop_dotted(d: dict, dotted: str):
+    parts = dotted.split(".")
+    cur = d
+    for p in parts[:-1]:
+        if not isinstance(cur.get(p), dict):
+            return None
+        cur = cur[p]
+    return cur.pop(parts[-1], None) if isinstance(cur, dict) else None
+
+
+def read_delegates_raw() -> list:
+    """The delegates list as stored in the live config (no secret values)."""
+    from graph.config_io import load_yaml_doc
+
+    doc = load_yaml_doc() or {}
+    val = doc.get("delegates")
+    return list(val) if isinstance(val, list) else []
+
+
+def secret_overlay() -> dict:
+    from graph.config_io import load_secrets
+
+    sec = (load_secrets() or {}).get(SECRETS_SECTION)
+    return sec if isinstance(sec, dict) else {}
+
+
+def merged_delegates() -> list:
+    """Delegates with their secrets overlaid from ``secrets.yaml`` — the registry
+    loader's input. Does not mutate the stored config (deep-copies before inject)."""
+    overlay = secret_overlay()
+    out = []
+    for raw in read_delegates_raw():
+        if not isinstance(raw, dict):
+            continue
+        adapter = ADAPTERS.get(str(raw.get("type", "")))
+        name = raw.get("name")
+        if adapter and adapter.secret_field and name:
+            val = overlay.get(f"{name}.{adapter.secret_field}")
+            if val:
+                raw = copy.deepcopy(raw)
+                _set_dotted(raw, adapter.secret_field, val)
+        out.append(raw)
+    return out
+
+
+def _save_list(delegates: list) -> None:
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+
+    doc = load_yaml_doc() or {}
+    if not isinstance(doc, dict):
+        doc = {}
+    doc["delegates"] = delegates
+    save_yaml_doc(doc)
+
+
+def _route_secret(name: str, entry: dict) -> dict:
+    """Pop the entry's secret value into ``secrets.yaml`` (if present); return the
+    entry with the secret stripped, safe to persist in the tracked config."""
+    from graph.config_io import save_secrets
+
+    adapter = ADAPTERS.get(str(entry.get("type", "")))
+    if not (adapter and adapter.secret_field):
+        return entry
+    entry = copy.deepcopy(entry)
+    val = _pop_dotted(entry, adapter.secret_field)
+    if val:
+        save_secrets({SECRETS_SECTION: {f"{name}.{adapter.secret_field}": val}})
+    return entry
+
+
+def upsert_delegate(entry: dict) -> list:
+    """Add or replace a delegate by name; route its secret; persist. Returns the
+    new list (secret-free, as stored)."""
+    name = str(entry.get("name", "")).strip()
+    entry = _route_secret(name, entry)
+    lst = [e for e in read_delegates_raw() if not (isinstance(e, dict) and e.get("name") == name)]
+    lst.append(entry)
+    _save_list(lst)
+    return lst
+
+
+def delete_delegate(name: str) -> list:
+    lst = [e for e in read_delegates_raw() if not (isinstance(e, dict) and e.get("name") == name)]
+    _save_list(lst)
+    return lst

--- a/tests/test_delegates_api.py
+++ b/tests/test_delegates_api.py
@@ -1,0 +1,127 @@
+"""Tests for the delegate CRUD store + REST API (ADR 0025, PR2)."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import plugins.delegates.api as api
+from plugins.delegates import store
+
+
+@pytest.fixture
+def fake_io(monkeypatch):
+    """In-memory config doc + secrets, swapped in for graph.config_io."""
+    st = {"doc": {}, "secrets": {}}
+    import graph.config_io as cio
+
+    monkeypatch.setattr(cio, "load_yaml_doc", lambda *a, **k: st["doc"])
+    monkeypatch.setattr(cio, "save_yaml_doc", lambda doc, *a, **k: st.update(doc=doc))
+    monkeypatch.setattr(cio, "load_secrets", lambda: st["secrets"])
+
+    def _save_secrets(upd):
+        for sec, vals in (upd or {}).items():
+            st["secrets"].setdefault(sec, {}).update(vals)
+
+    monkeypatch.setattr(cio, "save_secrets", _save_secrets)
+    return st
+
+
+# ── store ─────────────────────────────────────────────────────────────────────
+
+
+def test_upsert_routes_secret_to_overlay_and_strips_config(fake_io):
+    store.upsert_delegate({"name": "helm", "type": "a2a", "url": "https://h/a2a",
+                           "auth": {"scheme": "bearer", "token": "SEKRET"}})
+    stored = fake_io["doc"]["delegates"][0]
+    assert stored["auth"] == {"scheme": "bearer"}            # token stripped from config
+    assert "SEKRET" not in str(stored)
+    assert fake_io["secrets"]["delegate_secrets"]["helm.auth.token"] == "SEKRET"
+
+
+def test_merged_delegates_overlays_secret(fake_io):
+    store.upsert_delegate({"name": "opus", "type": "openai", "url": "https://g/v1",
+                           "model": "m", "api_key": "K"})
+    assert "K" not in str(fake_io["doc"]["delegates"])        # not in tracked config
+    merged = store.merged_delegates()
+    assert merged[0]["api_key"] == "K"                        # overlaid back at load
+
+
+def test_upsert_replaces_by_name_and_delete(fake_io):
+    store.upsert_delegate({"name": "p", "type": "acp", "command": "proto", "workdir": "/tmp"})
+    store.upsert_delegate({"name": "p", "type": "acp", "command": "proto2", "workdir": "/tmp"})
+    assert len(fake_io["doc"]["delegates"]) == 1
+    assert fake_io["doc"]["delegates"][0]["command"] == "proto2"
+    store.delete_delegate("p")
+    assert fake_io["doc"]["delegates"] == []
+
+
+# ── API ───────────────────────────────────────────────────────────────────────
+
+
+@pytest.fixture
+def client(fake_io, monkeypatch):
+    async def _noreload():
+        return True, "reloaded"
+    monkeypatch.setattr(api, "_reload", _noreload)
+    app = FastAPI()
+    app.include_router(api.build_router())
+    return TestClient(app)
+
+
+def test_delegate_types_endpoint(client):
+    r = client.get("/api/delegate-types")
+    assert r.status_code == 200
+    assert {t["type"] for t in r.json()["types"]} == {"a2a", "openai", "acp"}
+
+
+def test_create_list_update_delete_flow(client, fake_io):
+    # create
+    r = client.post("/api/delegates", json={"name": "opus", "type": "openai",
+                                            "url": "https://g/v1", "model": "m", "api_key": "K"})
+    assert r.status_code == 200 and r.json()["ok"] is True
+    names = [d["name"] for d in r.json()["delegates"]]
+    assert names == ["opus"]
+    # secret routed, not echoed
+    body = r.json()["delegates"][0]
+    assert "K" not in str(body) and body["has_secret"] is True
+    assert fake_io["secrets"]["delegate_secrets"]["opus.api_key"] == "K"
+
+    # duplicate → 409
+    assert client.post("/api/delegates", json={"name": "opus", "type": "openai",
+                                               "url": "https://g/v1", "model": "m"}).status_code == 409
+
+    # list
+    assert [d["name"] for d in client.get("/api/delegates").json()["delegates"]] == ["opus"]
+
+    # update missing → 404
+    assert client.put("/api/delegates/nope", json={"type": "openai", "url": "https://g/v1",
+                                                    "model": "m"}).status_code == 404
+    # update ok
+    r = client.put("/api/delegates/opus", json={"type": "openai", "url": "https://g/v1",
+                                                "model": "m2"})
+    assert r.status_code == 200
+    assert client.get("/api/delegates").json()["delegates"][0]["model"] == "m2"
+
+    # delete
+    assert client.request("DELETE", "/api/delegates/opus").status_code == 200
+    assert client.get("/api/delegates").json()["delegates"] == []
+
+
+def test_create_invalid_returns_400(client):
+    assert client.post("/api/delegates", json={"name": "x", "type": "nope"}).status_code == 400
+    assert client.post("/api/delegates", json={"name": "y", "type": "openai",
+                                               "url": "https://g/v1"}).status_code == 400  # no model
+
+
+def test_test_endpoint_acp_probe(client):
+    import sys
+    # acp probe is local (binary-on-PATH + workdir exists) — point at the python exe.
+    r = client.post("/api/delegates/test", json={"name": "t", "type": "acp",
+                                                 "command": sys.executable, "workdir": "/tmp"})
+    assert r.status_code == 200 and r.json()["ok"] is True
+
+
+def test_test_endpoint_unknown_type_400(client):
+    assert client.post("/api/delegates/test", json={"type": "nope"}).status_code == 400


### PR DESCRIPTION
Second slice of the delegate-registry initiative (ADR 0025), on top of PR1 (#602). Adds the **management API** the console panel (PR3) will drive.

## Endpoints (`/api/delegates*`)

Mounted by the plugin router; operator-console posture (localhost-default + bearer-when-exposed, like `/api/config`).

| Method | Path | Purpose |
|---|---|---|
| GET | `/api/delegate-types` | type list + field schema (drives the form) |
| GET | `/api/delegates` | list (secret-free; `configured` + `has_secret`) |
| POST | `/api/delegates` | create (409 on dup) |
| PUT | `/api/delegates/{name}` | update (404 if missing) |
| DELETE | `/api/delegates/{name}` | remove |
| POST | `/api/delegates/test` | reachability probe (the **Test** button) |

Mutations write config + reload **off-thread** (`asyncio.to_thread`, like `/api/config`) so the new roster is live on the next turn — no restart.

## Secrets (inline → `secrets.yaml`, per your decision)

Create/update **route the secret value** (`auth.token` / `api_key`) to the gitignored `secrets.yaml` under a `delegate_secrets` overlay keyed `<name>.<field>`, strip it from the tracked config, and overlay it back at load. `GET /api/delegates` **never returns** secrets — `has_secret` tells the panel one is stored. (`save_secrets` merges, so a stale key after delete is harmless; noted.)

## Probe (Test button)

Per-type `probe()`: a2a does an **agent-card GET**, openai pings **`/v1/models`**, acp checks **binary-on-PATH + workdir exists** (local, no spawn). Returns `{ok, latency_ms, error|detail}`.

## Test

```
$ pytest tests/test_delegates_api.py tests/test_delegates_plugin.py -q
21 passed
$ ruff check plugins/delegates/ tests/test_delegates_api.py        # ruff 0.15.10
All checks passed!
```

8 new: store secret-routing (value → `secrets.yaml`, stripped from config, overlaid back), replace-by-name + delete, and the full API flow over a `TestClient` (create/list/update/delete, 409/404/400, acp probe, secret-never-echoed). Verified `register()` mounts the router (`/api/delegate-types`, `/api/delegates`, `/api/delegates/test`, `/api/delegates/{name}`) + `delegate_to` through the real `PluginRegistry`.

## Next
- **PR3** — the React **panel** in the console (type picker, generic form from `/api/delegate-types`, Test button, status list) — the visible hot-swap UI.
- **PR4** — background health prober + deprecate `code_with`/`peer_consult`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)