### PR TITLE
security(delegates): redact secrets nested in the acp env dict from GET /api/delegates

### DIFF
--- a/plugins/delegates/api.py
+++ b/plugins/delegates/api.py
@@ -17,6 +17,20 @@ from .adapters import ADAPTERS, DelegateError, delegate_types
 log = logging.getLogger("protoagent.plugins.delegates")
 
 
+# Substrings that mark a config key (or an env-var name) as secret-bearing — its
+# value is never returned by the read API.
+_SECRETISH = ("key", "token", "secret", "password", "passwd", "credential", "auth")
+
+
+def _is_secretish(k) -> bool:
+    return any(s in str(k).lower() for s in _SECRETISH)
+
+
+def _redact_env(env: dict) -> dict:
+    """Redact env values whose name looks secret-bearing (e.g. OPENAI_API_KEY)."""
+    return {k: ("***" if _is_secretish(k) else v) for k, v in env.items()}
+
+
 def _public_view(raw: dict) -> dict:
     """A delegate as the panel sees it: config fields minus any secret, plus a
     ``configured`` flag (does it parse?) and ``has_secret`` (is one stored?)."""
@@ -34,11 +48,14 @@ def _public_view(raw: dict) -> dict:
         adapter and adapter.secret_field
         and store.secret_overlay().get(f"{name}.{adapter.secret_field}")
     )
-    view = {k: v for k, v in raw.items()
-            if not (k in ("auth", "api_key") or "token" in str(k) or "key" in str(k).lower())}
+    # Drop any secret-bearing top-level field (api_key, *_token, auth, …).
+    view = {k: v for k, v in raw.items() if not _is_secretish(k)}
     # keep auth.scheme (not the token) for a2a so the form can prefill it
     if isinstance(raw.get("auth"), dict) and raw["auth"].get("scheme"):
         view["auth"] = {"scheme": raw["auth"]["scheme"]}
+    # the acp env dict is free-form — redact secret-named values inside it too.
+    if isinstance(view.get("env"), dict):
+        view["env"] = _redact_env(view["env"])
     view.update({"name": name, "type": raw.get("type"),
                  "description": raw.get("description", ""),
                  "configured": configured, "error": error, "has_secret": has_secret})

--- a/tests/test_delegates_api.py
+++ b/tests/test_delegates_api.py
@@ -125,3 +125,24 @@ def test_test_endpoint_acp_probe(client):
 
 def test_test_endpoint_unknown_type_400(client):
     assert client.post("/api/delegates/test", json={"type": "nope"}).status_code == 400
+
+
+def test_public_view_redacts_secrets_including_nested_env():
+    raw = {
+        "name": "proto", "type": "acp", "command": "proto", "workdir": "/tmp",
+        "env": {"HOME": "/h", "OPENAI_BASE_URL": "https://g/v1", "OPENAI_API_KEY": "sk-LEAK"},
+    }
+    view = api._public_view(raw)
+    assert "sk-LEAK" not in str(view)               # nested env secret redacted
+    assert view["env"]["OPENAI_API_KEY"] == "***"
+    assert view["env"]["HOME"] == "/h"              # non-secret env preserved
+
+
+def test_public_view_drops_top_level_secrets():
+    raw = {"name": "o", "type": "openai", "url": "https://g/v1", "model": "m", "api_key": "sk-X"}
+    view = api._public_view(raw)
+    assert "sk-X" not in str(view) and "api_key" not in view
+    raw2 = {"name": "h", "type": "a2a", "url": "https://h/a2a",
+            "auth": {"scheme": "bearer", "token": "SEKRET-TOKEN"}}
+    view2 = api._public_view(raw2)
+    assert "SEKRET-TOKEN" not in str(view2) and view2["auth"] == {"scheme": "bearer"}


### PR DESCRIPTION
Follow-up fix to PR2 (#603), caught while driving the live API.

## Bug
`GET /api/delegates` (`_public_view`) stripped secret-bearing **top-level** fields (`api_key`, `*_token`, `auth`) but **not** secrets nested inside the acp `env` dict. A delegate configured with `env: {OPENAI_API_KEY: sk-…}` returned the key in plaintext in the list response.

```
$ curl -s :7788/api/delegates
... "env": {"OPENAI_API_KEY": "sk-Uwjq…"}   # ← leaked
```

## Fix
- Redact `env` values whose **name** looks secret-bearing (`key`/`token`/`secret`/`password`/`credential`/`auth`) → `"***"`; non-secret env (`HOME`, `*_BASE_URL`) preserved.
- Broaden the top-level strip to the same `_is_secretish()` predicate.

## Test
```
$ pytest tests/test_delegates_api.py tests/test_delegates_plugin.py -q
23 passed
```
New: nested-env redaction (`OPENAI_API_KEY` → `***`, `HOME` kept) + top-level (`api_key`, `auth.token`) redaction.

Note: only affects the **read** API response. Stored secrets were already correctly routed to `secrets.yaml` (PR2); this stops the env-nested case from being echoed back.

🤖 Generated with [Claude Code](https://claude.com/claude-code)