### PR TITLE
feat(delegates): console management panel — Settings → Integrations (ADR 0025, PR3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (a `delegate_secrets` overlay keyed `<name>.<field>` — never echoed back or kept
   in tracked config), then hot-reload so the new roster is live next turn. Same
   operator-console posture as `/api/config`.
+- **Delegate management panel** (ADR 0025, PR3) — a **Delegates** view in the
+  console under **Settings → Integrations**: lists delegates with type/secret/
+  status badges + a per-row **Test** probe; adds one via a type picker
+  (A2A agent / Model endpoint / Coding agent) and a form generated from each
+  type's field schema; edits/deletes; secrets entered route to `secrets.yaml` and
+  are never echoed back. Saving hot-reloads, so the roster is live next turn. The
+  Integrations tab appears whenever the `delegates` plugin is reachable, even with
+  no other integration enabled. (`apps/web`; e2e `delegates.spec.ts`.)
 
 ## [0.16.0] - 2026-06-06
 

--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+// The Delegates panel (ADR 0025) lives under Settings → Integrations: it lists the
+// configured delegates (GET /api/delegates), and an Add form with a type picker
+// driven by GET /api/delegate-types. Mocked endpoints in e2e/mock-server.mjs.
+
+async function openIntegrations(page) {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".settings-subnav").getByRole("button", { name: "Integrations", exact: true }).click();
+}
+
+test("lists configured delegates with type + secret badges", async ({ page }) => {
+  await openIntegrations(page);
+  const panel = page.locator(".delegates-section");
+  await expect(panel.getByText("Delegates", { exact: true })).toBeVisible();
+  const row = panel.locator(".subagent-row", { hasText: "opus" });
+  await expect(row).toBeVisible();
+  await expect(row.locator(".delegate-type-badge")).toHaveText("openai");
+  await expect(row.getByText("secret set")).toBeVisible();
+});
+
+test("Add opens a type picker and a schema-driven form", async ({ page }) => {
+  await openIntegrations(page);
+  const panel = page.locator(".delegates-section");
+  await panel.getByRole("button", { name: /Add delegate/ }).click();
+
+  // Three type tiles from /api/delegate-types.
+  const tiles = panel.locator(".delegate-type-tile");
+  await expect(tiles).toHaveCount(3);
+
+  // Default type (a2a) renders its URL field; switching to acp renders Command.
+  await expect(panel.getByText("URL", { exact: false })).toBeVisible();
+  await panel.locator(".delegate-type-tile", { hasText: "Coding agent" }).click();
+  await expect(panel.getByText("Command", { exact: false })).toBeVisible();
+  await expect(panel.getByText("Workdir", { exact: false })).toBeVisible();
+});

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -444,3 +444,43 @@ export const KNOWLEDGE_CHUNKS = [
     created_at: "2026-06-02T09:00:00+00:00",
   },
 ];
+
+// Delegate registry (ADR 0025) — types schema + a sample roster for the panel.
+export const DELEGATE_TYPES = {
+  types: [
+    {
+      type: "a2a", label: "A2A agent", blurb: "A fleet peer over the A2A protocol.",
+      fields: [
+        { key: "url", label: "URL", kind: "text", required: true, help: "", placeholder: "https://peer/a2a", options: [], default: null },
+        { key: "auth.scheme", label: "Auth scheme", kind: "select", required: false, help: "", placeholder: "", options: ["", "bearer", "apiKey"], default: null },
+        { key: "auth.token", label: "Auth token", kind: "secret", required: false, help: "Stored in secrets.yaml.", placeholder: "", options: [], default: null },
+      ],
+    },
+    {
+      type: "openai", label: "Model endpoint", blurb: "Ask another OpenAI-compatible model.",
+      fields: [
+        { key: "url", label: "Base URL", kind: "text", required: true, help: "", placeholder: "https://api/v1", options: [], default: null },
+        { key: "model", label: "Model", kind: "text", required: true, help: "", placeholder: "protolabs/reasoning", options: [], default: null },
+        { key: "api_key", label: "API key", kind: "secret", required: false, help: "", placeholder: "", options: [], default: null },
+      ],
+    },
+    {
+      type: "acp", label: "Coding agent (ACP)", blurb: "A CLI coding agent over ACP.",
+      fields: [
+        { key: "command", label: "Command", kind: "text", required: true, help: "", placeholder: "proto", options: [], default: null },
+        { key: "args", label: "Args", kind: "args", required: false, help: "", placeholder: "--acp", options: [], default: null },
+        { key: "workdir", label: "Workdir", kind: "path", required: true, help: "", placeholder: "~/dev/repo", options: [], default: null },
+      ],
+    },
+  ],
+};
+
+export const DELEGATES = {
+  delegates: [
+    {
+      name: "opus", type: "openai", description: "Heavy reasoning model.",
+      configured: true, error: null, has_secret: true,
+      url: "https://api.proto-labs.ai/v1", model: "protolabs/reasoning",
+    },
+  ],
+};

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -16,6 +16,8 @@ import { fileURLToPath } from "node:url";
 import {
   ACTIVITY_HISTORY,
   buildFrames,
+  DELEGATES,
+  DELEGATE_TYPES,
   GOALS,
   INBOX_ITEMS,
   NOTES_WORKSPACE,
@@ -100,6 +102,10 @@ function handleApiGet(pathname) {
       };
     case "/api/settings/schema":
       return { groups: SETTINGS_SCHEMA };
+    case "/api/delegate-types":
+      return DELEGATE_TYPES;
+    case "/api/delegates":
+      return DELEGATES;
     case "/api/workflows":
       return { workflows: WORKFLOWS };
     case "/api/activity":

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -17,11 +17,13 @@ async function category(page, name) {
 
 test("groups are organized into a category sub-nav; Agent leads", async ({ page }) => {
   await openSettings(page);
-  // Category sub-nav from the mock schema: Agent · Behavior · System.
+  // Category sub-nav from the mock schema: Agent · Behavior · System, plus
+  // Integrations (surfaced because the delegates plugin is reachable — ADR 0025).
   expect(await page.locator(".settings-subnav button").allTextContents()).toEqual([
     "Agent",
     "Behavior",
     "System",
+    "Integrations",
   ]);
   // Agent is the default — only its sections show (Model + Routing), not System's.
   expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Model", "Routing"]);

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3042,3 +3042,45 @@ textarea {
 .icon-button:hover { background: var(--bg-hover); color: var(--fg); }
 .icon-button.danger:hover { color: var(--error); border-color: color-mix(in srgb, var(--error) 40%, transparent); }
 .playbook-foot { margin-top: 16px; font-size: 11.5px; color: var(--fg-muted); display: flex; align-items: center; gap: 6px; }
+
+/* ── Delegates panel (ADR 0025) — Settings → Integrations ──────────────────── */
+.delegates-section .subagent-row strong { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.delegate-type-badge {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 4px;
+  border: 1px solid var(--border);
+  color: var(--brand-violet-light);
+}
+.delegate-badge-warn { font-size: 10px; color: #e0a23a; }
+.delegate-badge-ok { font-size: 10px; color: var(--fg-muted); }
+.delegate-form {
+  margin-top: 14px;
+  padding: 14px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg);
+  display: grid;
+  gap: 12px;
+}
+.delegate-form-head { display: flex; align-items: center; justify-content: space-between; }
+.delegate-type-picker { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; }
+.delegate-type-tile {
+  display: grid;
+  gap: 3px;
+  text-align: left;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg);
+  color: var(--fg);
+  cursor: pointer;
+}
+.delegate-type-tile:hover { border-color: var(--brand-violet); }
+.delegate-type-tile.active { border-color: var(--brand-violet); background: color-mix(in srgb, var(--brand-violet) 12%, var(--bg)); }
+.delegate-type-tile-label { font-size: 13px; font-weight: 600; }
+.delegate-type-tile-blurb { font-size: 11px; color: var(--fg-muted); }
+.delegate-field-help { font-size: 11px; color: var(--fg-muted); }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -4,6 +4,9 @@ import type {
   BeadsIssue,
   ChatMessage,
   ConfigPayload,
+  DelegateProbe,
+  DelegateTypeSpec,
+  DelegateView,
   GoalState,
   HitlPayload,
   InboxItem,
@@ -780,5 +783,34 @@ export const api = {
       `/api/beads/issues/${encodeURIComponent(issueId)}`,
       { method: "DELETE" },
     );
+  },
+
+  // Delegate registry (ADR 0025) — the agents & endpoints the agent can talk to.
+  delegateTypes() {
+    return request<{ types: DelegateTypeSpec[] }>("/api/delegate-types");
+  },
+  delegates() {
+    return request<{ delegates: DelegateView[] }>("/api/delegates");
+  },
+  createDelegate(entry: Record<string, unknown>) {
+    return request<{ ok: boolean; message: string; delegates: DelegateView[] }>("/api/delegates", {
+      method: "POST",
+      body: entry,
+    });
+  },
+  updateDelegate(name: string, entry: Record<string, unknown>) {
+    return request<{ ok: boolean; message: string; delegates: DelegateView[] }>(
+      `/api/delegates/${encodeURIComponent(name)}`,
+      { method: "PUT", body: entry },
+    );
+  },
+  deleteDelegate(name: string) {
+    return request<{ ok: boolean; message: string; delegates: DelegateView[] }>(
+      `/api/delegates/${encodeURIComponent(name)}`,
+      { method: "DELETE" },
+    );
+  },
+  testDelegate(entry: Record<string, unknown>) {
+    return request<DelegateProbe>("/api/delegates/test", { method: "POST", body: entry });
   },
 };

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -15,6 +15,8 @@ export const queryKeys = {
   inbox: ["inbox"] as const,
   schedules: ["schedules"] as const,
   runtime: ["runtime"] as const,
+  delegates: ["delegates"] as const,
+  delegateTypes: ["delegates", "types"] as const,
 };
 
 // Goals the agent works toward (goal mode). Lives in the right sidebar and
@@ -101,4 +103,21 @@ export const runtimeStatusQuery = () =>
   queryOptions({
     queryKey: queryKeys.runtime,
     queryFn: () => api.runtimeStatus(),
+  });
+
+// Delegate registry (ADR 0025) — read non-suspense in the Settings → Integrations
+// panel so a 404 (delegates plugin disabled) degrades gracefully instead of
+// blanking Settings. Invalidated after create/update/delete.
+export const delegatesQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.delegates,
+    queryFn: () => api.delegates(),
+    retry: false,
+  });
+
+export const delegateTypesQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.delegateTypes,
+    queryFn: () => api.delegateTypes(),
+    retry: false,
   });

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -385,3 +385,26 @@ export type KnowledgeChunk = {
   finding_type: string | null;
   created_at: string | null;
 };
+
+// Delegate registry (ADR 0025) — the agents & endpoints the agent can talk to.
+export type DelegateFieldSpec = {
+  key: string;
+  label: string;
+  kind: string; // text | secret | args | path | number | textarea | select
+  required: boolean;
+  help: string;
+  placeholder: string;
+  options: string[];
+  default?: unknown;
+};
+export type DelegateTypeSpec = { type: string; label: string; blurb: string; fields: DelegateFieldSpec[] };
+export type DelegateView = {
+  name: string;
+  type: string;
+  description: string;
+  configured: boolean;
+  error: string | null;
+  has_secret: boolean;
+  [key: string]: unknown;
+};
+export type DelegateProbe = { ok: boolean | null; latency_ms?: number; error?: string; detail?: string };

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -1,0 +1,318 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Loader2, Pencil, Plug, Plus, ShieldCheck, Trash2, X } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { api } from "../lib/api";
+import { delegatesQuery, delegateTypesQuery, queryKeys } from "../lib/queries";
+import type { DelegateFieldSpec, DelegateProbe, DelegateTypeSpec, DelegateView } from "../lib/types";
+
+// Delegates panel (ADR 0025, PR3) — manage the agents & endpoints the agent can
+// talk to via delegate_to, under Settings → Integrations. Hot-swappable: create/
+// edit/delete write config + secrets and the server reloads, so changes take
+// effect on the next turn. Read non-suspense so a 404 (plugin disabled) shows a
+// hint rather than blanking Settings.
+
+const DELEGATES_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/delegates";
+
+// ── dotted-key helpers (delegate fields use keys like "auth.token") ───────────
+function setDotted(obj: Record<string, unknown>, key: string, val: unknown): void {
+  const parts = key.split(".");
+  let cur = obj;
+  for (let i = 0; i < parts.length - 1; i += 1) {
+    const k = parts[i];
+    if (typeof cur[k] !== "object" || cur[k] === null) cur[k] = {};
+    cur = cur[k] as Record<string, unknown>;
+  }
+  cur[parts[parts.length - 1]] = val;
+}
+function getDotted(obj: unknown, key: string): unknown {
+  return key.split(".").reduce<unknown>((cur, k) => (cur == null ? undefined : (cur as Record<string, unknown>)[k]), obj);
+}
+
+function coerce(field: DelegateFieldSpec, raw: unknown): unknown {
+  if (field.kind === "args") {
+    return String(raw ?? "").split(/\s+/).filter(Boolean);
+  }
+  if (field.kind === "number") {
+    return raw === "" || raw == null ? undefined : Number(raw);
+  }
+  return typeof raw === "string" ? raw : raw == null ? "" : String(raw);
+}
+
+function probeLine(p: DelegateProbe): string {
+  if (p.ok) {
+    const lat = p.latency_ms != null ? ` (${p.latency_ms} ms)` : "";
+    return `✓ ${p.detail || "reachable"}${lat}`;
+  }
+  return `✗ ${p.error || "unreachable"}`;
+}
+
+export function DelegatesSection() {
+  const qc = useQueryClient();
+  const list = useQuery(delegatesQuery());
+  const types = useQuery(delegateTypesQuery());
+  const [editing, setEditing] = useState<DelegateView | null>(null);
+  const [adding, setAdding] = useState(false);
+  const [status, setStatus] = useState("");
+  const [probes, setProbes] = useState<Record<string, DelegateProbe>>({});
+
+  const invalidate = () => qc.invalidateQueries({ queryKey: queryKeys.delegates });
+
+  const remove = useMutation({
+    mutationFn: (name: string) => api.deleteDelegate(name),
+    onSuccess: (r) => {
+      setStatus(r.message || "deleted");
+      void invalidate();
+    },
+    onError: (e) => setStatus(`delete failed: ${e instanceof Error ? e.message : String(e)}`),
+  });
+
+  const testRow = useMutation({
+    mutationFn: (d: DelegateView) => api.testDelegate({ name: d.name, type: d.type }),
+    onSuccess: (p, d) => setProbes((m) => ({ ...m, [d.name]: p })),
+    onError: (e, d) => setProbes((m) => ({ ...m, [d.name]: { ok: false, error: e instanceof Error ? e.message : String(e) } })),
+  });
+
+  // The delegates plugin isn't enabled (routes 404) — show a hint, not an error.
+  if (list.isError) {
+    return (
+      <section className="settings-group">
+        <p className="settings-group-title">Delegates</p>
+        <p className="setting-desc">
+          Enable the <code>delegates</code> plugin (<code>plugins: {"{ enabled: [delegates] }"}</code>) to
+          manage the agents and endpoints this agent can talk to.{" "}
+          <a className="settings-help-link" href={DELEGATES_GUIDE_URL} target="_blank" rel="noreferrer">
+            Guide
+          </a>
+        </p>
+      </section>
+    );
+  }
+
+  const delegates = list.data?.delegates ?? [];
+  const typeSpecs = types.data?.types ?? [];
+
+  return (
+    <section className="settings-group delegates-section">
+      <p className="settings-group-title">Delegates</p>
+      <p className="setting-desc">
+        Agents &amp; endpoints this agent can reach via <code>delegate_to</code> — changes apply on the next turn.
+      </p>
+
+      <div className="subagent-list">
+        {delegates.map((d) => {
+          const p = probes[d.name];
+          return (
+            <div className="subagent-row" key={d.name}>
+              <div>
+                <strong>
+                  {d.name} <span className="delegate-type-badge">{d.type}</span>
+                  {!d.configured ? <span className="delegate-badge-warn">⚠ unconfigured</span> : null}
+                  {d.has_secret ? <span className="delegate-badge-ok">secret set</span> : null}
+                </strong>
+                <span>{p ? probeLine(p) : d.description || d.error || ""}</span>
+              </div>
+              <div className="issue-actions">
+                <button className="icon-button" title="Test" onClick={() => testRow.mutate(d)} disabled={testRow.isPending}>
+                  {testRow.isPending && testRow.variables?.name === d.name ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
+                </button>
+                <button className="icon-button" title="Edit" onClick={() => { setEditing(d); setAdding(false); }}>
+                  <Pencil size={15} />
+                </button>
+                <button className="icon-button" title="Delete" onClick={() => remove.mutate(d.name)} disabled={remove.isPending}>
+                  <Trash2 size={15} />
+                </button>
+              </div>
+            </div>
+          );
+        })}
+        {!delegates.length ? <p className="setting-desc">No delegates yet — add one below.</p> : null}
+      </div>
+
+      {status ? <p className="settings-inline-status">{status}</p> : null}
+
+      {editing ? (
+        <DelegateForm
+          key={editing.name}
+          spec={typeSpecs}
+          initial={editing}
+          onClose={() => setEditing(null)}
+          onSaved={(msg) => { setEditing(null); setStatus(msg); void invalidate(); }}
+        />
+      ) : adding ? (
+        <DelegateForm
+          spec={typeSpecs}
+          initial={null}
+          onClose={() => setAdding(false)}
+          onSaved={(msg) => { setAdding(false); setStatus(msg); void invalidate(); }}
+        />
+      ) : (
+        <div className="settings-group-actions">
+          <button className="secondary-button" type="button" onClick={() => setAdding(true)} disabled={!typeSpecs.length}>
+            <Plus size={15} /> Add delegate
+          </button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function DelegateForm({
+  spec,
+  initial,
+  onClose,
+  onSaved,
+}: {
+  spec: DelegateTypeSpec[];
+  initial: DelegateView | null;
+  onClose: () => void;
+  onSaved: (msg: string) => void;
+}) {
+  const editing = Boolean(initial);
+  const [type, setType] = useState(initial?.type || spec[0]?.type || "a2a");
+  const [name, setName] = useState(initial?.name || "");
+  const [description, setDescription] = useState(initial?.description || "");
+  const [vals, setVals] = useState<Record<string, string>>(() => seed(initial, spec));
+  const [probe, setProbe] = useState<DelegateProbe | null>(null);
+  const [err, setErr] = useState("");
+
+  const current = useMemo(() => spec.find((s) => s.type === type), [spec, type]);
+
+  function buildEntry(): Record<string, unknown> {
+    const entry: Record<string, unknown> = { name, type, description };
+    for (const f of current?.fields ?? []) {
+      const v = coerce(f, vals[f.key]);
+      // skip blank secrets on edit so we don't overwrite a stored one with ""
+      if (f.kind === "secret" && (v === "" || v == null)) continue;
+      if (v === "" || v == null) continue;
+      setDotted(entry, f.key, v);
+    }
+    return entry;
+  }
+
+  const test = useMutation({
+    mutationFn: () => api.testDelegate(buildEntry()),
+    onSuccess: (p) => { setProbe(p); setErr(""); },
+    onError: (e) => setErr(e instanceof Error ? e.message : String(e)),
+  });
+
+  const save = useMutation({
+    mutationFn: () => (editing ? api.updateDelegate(name, buildEntry()) : api.createDelegate(buildEntry())),
+    onSuccess: (r) => onSaved(r.message || (editing ? "updated" : "created")),
+    onError: (e) => setErr(e instanceof Error ? e.message : String(e)),
+  });
+
+  return (
+    <div className="delegate-form">
+      <div className="delegate-form-head">
+        <strong>{editing ? `Edit ${initial?.name}` : "New delegate"}</strong>
+        <button className="icon-button" title="Cancel" onClick={onClose}><X size={15} /></button>
+      </div>
+
+      {!editing ? (
+        <div className="delegate-type-picker">
+          {spec.map((s) => (
+            <button
+              key={s.type}
+              type="button"
+              className={`delegate-type-tile${type === s.type ? " active" : ""}`}
+              onClick={() => { setType(s.type); setProbe(null); }}
+            >
+              <span className="delegate-type-tile-label">{s.label}</span>
+              <span className="delegate-type-tile-blurb">{s.blurb}</span>
+            </button>
+          ))}
+        </div>
+      ) : null}
+
+      <label className="field">
+        <span>Name</span>
+        <input value={name} disabled={editing} onChange={(e) => setName(e.target.value)} placeholder="e.g. opus" />
+      </label>
+      <label className="field">
+        <span>Description</span>
+        <input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What it's for (the model reads this to pick it)." />
+      </label>
+
+      {(current?.fields ?? []).map((f) => (
+        <DelegateField
+          key={f.key}
+          field={f}
+          value={vals[f.key] ?? ""}
+          hasStoredSecret={editing && f.kind === "secret" && Boolean(initial?.has_secret)}
+          onChange={(v) => setVals((m) => ({ ...m, [f.key]: v }))}
+        />
+      ))}
+
+      {probe ? <p className="settings-inline-status">{probeLine(probe)}</p> : null}
+      {err ? <p className="settings-status">{err}</p> : null}
+
+      <div className="settings-group-actions">
+        <button className="secondary-button" type="button" onClick={() => test.mutate()} disabled={test.isPending}>
+          {test.isPending ? <Loader2 className="spin" size={15} /> : <Plug size={15} />} Test
+        </button>
+        <button className="secondary-button" type="button" onClick={onClose}>Cancel</button>
+        <button className="primary-button" type="button" onClick={() => save.mutate()} disabled={save.isPending || !name.trim()}>
+          {save.isPending ? <Loader2 className="spin" size={15} /> : null} Save
+        </button>
+      </div>
+    </div>
+  );
+}
+
+function DelegateField({
+  field,
+  value,
+  hasStoredSecret,
+  onChange,
+}: {
+  field: DelegateFieldSpec;
+  value: string;
+  hasStoredSecret: boolean;
+  onChange: (v: string) => void;
+}) {
+  const common = { id: `del-${field.key}`, value, onChange: (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement>) => onChange(e.target.value) };
+  let control: React.ReactNode;
+  if (field.kind === "select" && field.options.length) {
+    control = (
+      <select {...common}>
+        {field.options.map((o) => <option key={o} value={o}>{o || "(none)"}</option>)}
+      </select>
+    );
+  } else if (field.kind === "textarea") {
+    control = <textarea rows={3} placeholder={field.placeholder} {...common} />;
+  } else if (field.kind === "secret") {
+    control = (
+      <input
+        type="password"
+        autoComplete="new-password"
+        placeholder={hasStoredSecret ? "•••••••• (set — leave blank to keep)" : field.placeholder || "unset"}
+        {...common}
+      />
+    );
+  } else if (field.kind === "number") {
+    control = <input type="number" placeholder={field.placeholder} {...common} />;
+  } else {
+    control = <input type="text" placeholder={field.placeholder} {...common} />;
+  }
+  return (
+    <label className="field">
+      <span>{field.label}{field.required ? " *" : ""}</span>
+      {control}
+      {field.help ? <small className="delegate-field-help">{field.help}</small> : null}
+    </label>
+  );
+}
+
+function seed(initial: DelegateView | null, spec: DelegateTypeSpec[]): Record<string, string> {
+  const out: Record<string, string> = {};
+  if (!initial) return out;
+  const t = spec.find((s) => s.type === initial.type);
+  for (const f of t?.fields ?? []) {
+    const v = getDotted(initial, f.key);
+    if (f.kind === "args" && Array.isArray(v)) out[f.key] = v.join(" ");
+    else if (f.kind === "secret") out[f.key] = ""; // redacted; blank = keep stored
+    else if (v != null) out[f.key] = String(v);
+  }
+  return out;
+}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -11,6 +11,7 @@ import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { api } from "../lib/api";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
 import type { SettingsField } from "../lib/types";
+import { DelegatesSection } from "./DelegatesSection";
 
 // Generic settings surface — renders whatever GET /api/settings/schema returns,
 // so it stays in sync as config grows. Saving POSTs the changed fields and the
@@ -42,6 +43,12 @@ function SettingsBody() {
   const [dirty, setDirty] = useState<Record<string, unknown>>({});
   const [status, setStatus] = useState("");
 
+  // The delegates plugin (ADR 0025) contributes no settings-schema group — it's a
+  // CRUD panel — so probe it to know whether to surface the Integrations tab even
+  // when no schema-driven integration (Discord/Google) is enabled. Shares the
+  // delegates query key, so it's deduped with DelegatesSection's list.
+  const delegatesProbe = useQuery({ queryKey: queryKeys.delegates, queryFn: () => api.delegates(), retry: false });
+
   // Category sub-nav (ADR 0020): the server tags each group with a category and
   // orders them, so we derive the ordered category list by first appearance.
   const categories = useMemo(() => {
@@ -50,8 +57,9 @@ function SettingsBody() {
       const c = g.category || "Integrations";
       if (!seen.includes(c)) seen.push(c);
     }
+    if (delegatesProbe.isSuccess && !seen.includes("Integrations")) seen.push("Integrations");
     return seen;
-  }, [groups]);
+  }, [groups, delegatesProbe.isSuccess]);
   const [activeCategory, setActiveCategory] = useState(categories[0] || "");
   // The active category must stay valid if the schema reshapes under us.
   const category = categories.includes(activeCategory) ? activeCategory : categories[0] || "";
@@ -240,6 +248,10 @@ function SettingsBody() {
             ) : null}
           </section>
         ))}
+
+        {/* The delegate registry (ADR 0025) isn't part of the settings schema —
+            it's a CRUD surface, rendered as a custom panel under Integrations. */}
+        {category === "Integrations" ? <DelegatesSection /> : null}
       </div>
     </>
   );

--- a/docs/adr/0025-unified-delegate-registry-and-panel.md
+++ b/docs/adr/0025-unified-delegate-registry-and-panel.md
@@ -133,8 +133,10 @@ Mounted by the plugin router:
   (inline secrets → `secrets.yaml` `delegate_secrets` overlay) + reload trigger +
   `probe()` for Test + `/delegate-types` schema. Mounted by the plugin router at
   `/api/delegates*` (operator-console posture).
-- **PR3: React panel** — Delegates settings view in `apps/web` (type picker,
-  generic form from the schema, Test button, list with status).
+- **PR3 (shipped): React panel** — `DelegatesSection` in `apps/web` under
+  Settings → Integrations (list + type picker + schema-driven form + Test button +
+  secret handling). Surfaces the Integrations tab whenever the plugin is reachable
+  even with no schema-driven integration enabled. e2e: `delegates.spec.ts`.
 - **PR4: health prober** — background reachability loop + health badges; then
   deprecate `code_with`/`peer_consult` in favor of `delegate_to`.
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -33,4 +33,4 @@ decision, numbered, never deleted (supersede instead).
 | [0022](./0022-activity-provenance-feed.md) | Activity is a provenance feed, not a second chat | Accepted |
 | [0023](./0023-server-decomposition.md) | Decompose server.py: AppState + composition root | Accepted |
 | [0024](./0024-spawn-cli-coding-agents-acp.md) | Spawn CLI coding agents over ACP (`code_with`) | Accepted (PR1 + PR3) |
-| [0025](./0025-unified-delegate-registry-and-panel.md) | Unified delegate registry + hot-swappable panel (`delegate_to`) | Accepted (sliced; PR1 + PR2) |
+| [0025](./0025-unified-delegate-registry-and-panel.md) | Unified delegate registry + hot-swappable panel (`delegate_to`) | Accepted (sliced; PR1–PR3) |

--- a/docs/guides/delegates.md
+++ b/docs/guides/delegates.md
@@ -14,9 +14,23 @@ This unifies what used to be three separate things — `peer_consult` (a2a),
 `code_with` (acp), and "no way to ask another model" — into one hot-swappable
 roster.
 
-> **Where this is going:** delegates are managed by **config** (below) and a
-> **REST API** (below). A **console panel** to add/edit/test/remove them from the
-> UI (PR3) builds on the API. See [ADR 0025](/adr/0025-unified-delegate-registry-and-panel).
+Manage delegates three ways: the **console panel** (Settings → Integrations →
+Delegates), a **REST API**, or **config** — all hot-swappable (changes apply on
+the next turn, no restart). See [ADR 0025](/adr/0025-unified-delegate-registry-and-panel).
+
+## Manage in the console (panel)
+
+With the plugin enabled, open **Settings → Integrations → Delegates**. The panel:
+
+- **lists** your delegates with a type badge, a `secret set` / `⚠ unconfigured`
+  marker, and a per-row **Test** button (reachability probe);
+- **adds** one via a **type picker** (A2A agent / Model endpoint / Coding agent)
+  and a form generated from each type's field schema;
+- **edits / deletes** existing ones; secrets you enter are routed to
+  `secrets.yaml` and never shown back (the form says *"set — leave blank to keep"*).
+
+Saving writes the config + secret and hot-reloads, so the new roster is live on
+the next turn.
 
 ## Enable it
 


### PR DESCRIPTION
The **visible hot-swap UI** — third slice of ADR 0025, on top of the registry (#602) + CRUD API (#603/#604). This is the panel you asked for: manage the agents and endpoints your agent can talk to, live, without YAML or curl.

## Panel (Settings → Integrations → Delegates)

- **List** — each delegate with a type badge, `secret set` / `⚠ unconfigured` markers, and a per-row **Test** button (reachability probe).
- **Add** — a **type picker** (A2A agent / Model endpoint / Coding agent) + a form **generated from each type's field schema** (`GET /api/delegate-types`), so new delegate fields render automatically.
- **Edit / Delete** — secrets you enter route to `secrets.yaml` and are **never shown back** (*"set — leave blank to keep"*).
- Saving hot-reloads → the roster is live on the next turn, no restart.

## Data layer (ADR 0013)
TanStack Query: **non-suspense** reads so a 404 (delegates plugin disabled) degrades to a hint instead of blanking Settings; mutations invalidate the list. The Integrations tab is surfaced whenever the plugin is reachable — even if no schema-driven integration (Discord/Google) is enabled (the registry contributes no settings-schema group, so this is explicit).

## Files
- `apps/web/src/settings/DelegatesSection.tsx` — the panel (list + form + type picker + Test)
- `SettingsSurface.tsx` — render under Integrations + surface the tab when reachable
- `lib/{api,queries,types}.ts` — endpoints, query keys, types
- `app/theme.css` — panel styles (type tiles, badges)
- e2e: `delegates.spec.ts` + `settings.spec.ts` update + mock routes/fixtures

## Test
```
$ npm run build                              # tsc + vite
✓ built
$ npx playwright test delegates.spec.ts settings.spec.ts
6 passed
```
e2e covers: lists the mocked delegate with type+secret badges; Add opens the 3-tile type picker and the schema-driven form (a2a URL → switch to acp → Command/Workdir).

**Live-validated** against a real instance (delegates plugin enabled): the panel rendered both real delegates (`proto` acp, `opus` openai) with type badges and **zero page errors**.

## Next
- **PR4** — background health prober (live status badges) + deprecate `code_with`/`peer_consult` in favor of `delegate_to`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)