### PR TITLE
test(evals): workflow cases can assert tool-firing (expected_tools)

### DIFF
--- a/evals/README.md
+++ b/evals/README.md
@@ -63,7 +63,7 @@ python -m evals.compare results/run-OLD.json results/run-NEW.json
 | `subsystem` | KnowledgeMiddleware retrieval, hot-memory injection |
 | `goal` | Goal mode: set a goal, trigger the loop, assert the resulting goal state + footer |
 | `subagent` | Lead delegates open-ended work (`expected_any_tools`: `task` / `run_workflow`) |
-| `workflow` | A recipe runs end-to-end via `/api/workflows/{name}/run`; assert on its output |
+| `workflow` | A recipe runs end-to-end via `/api/workflows/{name}/run`; assert on its output **and** (optionally) on tool-firing — `expected_tools` / `expected_any_tools` check the audit log, so a case can require a step to have actually called a tool (e.g. a quant step that backtests, not one that only describes a backtest) |
 
 ## File layout
 

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -413,7 +413,11 @@ async def _run_workflow_case(client: AgentClient, case: dict) -> CaseResult:
     and assert on its synthesized output (patterns + optional rubric).
 
     Case schema: ``workflow`` (recipe name), ``inputs`` (dict),
-    ``expected_patterns`` / ``verify_rubric`` against the workflow output."""
+    ``expected_patterns`` / ``verify_rubric`` against the workflow output, and
+    ``expected_tools`` / ``expected_any_tools`` against the audit log (so a case
+    can assert the recipe's steps actually CALLED a tool, not just that the
+    synthesized text reads well — e.g. a quant step that backtests vs one that
+    only describes a backtest)."""
     cid, cat, name = case["id"], case.get("category", "workflow"), case.get("name", case["id"])
     wf = case.get("workflow")
     if not wf:
@@ -421,6 +425,7 @@ async def _run_workflow_case(client: AgentClient, case: dict) -> CaseResult:
     import time as _time
 
     start = _time.time()
+    since = verify.audit_now()  # mark before the run so we see tools the steps fire
     try:
         out = await client.run_workflow(
             wf, case.get("inputs") or {}, timeout_s=case.get("timeout_s", 300),
@@ -439,6 +444,35 @@ async def _run_workflow_case(client: AgentClient, case: dict) -> CaseResult:
         if pattern.lower() not in text_lower:
             problems.append(f"missing pattern {pattern!r}")
     problems += _check_rubric(case, text)
+
+    # Tool-firing assertions over the audit log — same shape as the ask path, so
+    # a workflow case can require its steps to have actually invoked a tool. A
+    # subagent that writes/describes code instead of calling the tool produces a
+    # plausible-reading output but fires nothing; this catches that.
+    expected_tools = case.get("expected_tools")
+    if expected_tools is not None:
+        require_success = case.get("tool_outcome", "success") == "success"
+        _entries, passed_t, detail_t = await _await_audit_assertion(
+            since, expected_tools, require_success=require_success,
+        )
+        if not passed_t:
+            problems.append(detail_t)
+
+    any_tools = case.get("expected_any_tools")
+    if any_tools:
+        require_success = case.get("tool_outcome", "success") == "success"
+        deadline = asyncio.get_running_loop().time() + _AUDIT_POLL_DEADLINE_S
+        passed_any, detail_a = False, ""
+        while True:
+            entries = verify.audit_entries_since(since)
+            passed_any, detail_a = verify.assert_any_tool_fired(
+                entries, any_tools, require_success=require_success,
+            )
+            if passed_any or asyncio.get_running_loop().time() >= deadline:
+                break
+            await asyncio.sleep(_AUDIT_POLL_INTERVAL_S)
+        if not passed_any:
+            problems.append(detail_a)
 
     detail = "; ".join(problems) if problems else f"OK ({duration_ms}ms, {len(text)} chars)"
     return CaseResult(

--- a/tests/test_eval_coverage.py
+++ b/tests/test_eval_coverage.py
@@ -158,6 +158,48 @@ def test_workflow_case_fails_on_empty_output():
     assert not res.passed and "empty" in res.detail
 
 
+def test_workflow_case_asserts_expected_tool_fired(monkeypatch):
+    monkeypatch.setattr(verify, "audit_now", lambda: "T0")
+    monkeypatch.setattr(verify, "audit_entries_since", lambda since: _audit("backtest_strategy"))
+    client = _FakeClient("# Desk call\nGO — Sharpe 1.2, beat buy-and-hold.")
+    case = {
+        "id": "wf", "category": "workflow", "kind": "workflow", "name": "wf",
+        "workflow": "quant-desk", "inputs": {"idea": "x"},
+        "expected_tools": ["backtest_strategy"],
+    }
+    res = asyncio.run(runner._run_workflow_case(client, case))
+    assert res.passed, res.detail
+
+
+def test_workflow_case_fails_when_expected_tool_missing(monkeypatch):
+    # A step that writes/describes code instead of calling the tool: the output
+    # reads fine, but the tool never fired in the audit log — must fail.
+    monkeypatch.setattr(verify, "audit_now", lambda: "T0")
+    monkeypatch.setattr(verify, "audit_entries_since", lambda since: _audit("web_search"))
+    monkeypatch.setattr(runner, "_AUDIT_POLL_DEADLINE_S", 0.0)
+    client = _FakeClient("# Desk call\nNO-GO — here's the backtest code I'd run: ...")
+    case = {
+        "id": "wf", "category": "workflow", "kind": "workflow", "name": "wf",
+        "workflow": "quant-desk", "inputs": {"idea": "x"},
+        "expected_tools": ["backtest_strategy"],
+    }
+    res = asyncio.run(runner._run_workflow_case(client, case))
+    assert not res.passed and "backtest_strategy" in res.detail
+
+
+def test_workflow_case_asserts_any_tool_fired(monkeypatch):
+    monkeypatch.setattr(verify, "audit_now", lambda: "T0")
+    monkeypatch.setattr(verify, "audit_entries_since", lambda since: _audit("factor_zoo"))
+    client = _FakeClient("# Factors\nmomentum alive, IR 1.1.")
+    case = {
+        "id": "wf", "category": "workflow", "kind": "workflow", "name": "wf",
+        "workflow": "quant-desk", "inputs": {"idea": "x"},
+        "expected_any_tools": ["factor_eval", "factor_zoo"],
+    }
+    res = asyncio.run(runner._run_workflow_case(client, case))
+    assert res.passed, res.detail
+
+
 def test_workflow_kind_is_dispatchable():
     assert "workflow" in runner._RUNNERS
 


### PR DESCRIPTION
## Problem
`kind: workflow` eval cases assert only on the synthesized **output** (`expected_patterns` + `verify_rubric`). A workflow step that **describes or writes code instead of calling its tool** produces plausible-reading text while firing nothing — and rubric-only judging passes it. Observed live: a `quant-desk` run where the quant step emitted backtest *code* instead of calling `backtest_strategy`, so the recipe produced no real numbers yet still passed its rubric.

## Change
`_run_workflow_case` now checks the **audit log** too — symmetric with the `ask` path:
- capture an `audit_now()` marker **before** the run,
- honor `expected_tools` (all must fire) and `expected_any_tools` (one of) using the same `verify` matchers the prompt path uses.

A workflow case can now require, e.g., that a quant step actually invoked `backtest_strategy` rather than narrating one.

**Opt-in / backward-compatible:** keys absent → assertions skipped → existing cases behave exactly as before.

## Tests
Adds 3 cases to `tests/test_eval_coverage.py` (tool fired → pass; missing tool → fail; any-of → pass). Full `test_eval_coverage.py`: **25 passed**. Schema documented in `evals/README.md`.

## Context
Surfaced while eval-testing a downstream finance fork; the fork fixed the root cause in its own subagent prompts, but the harness guardrail belongs upstream so every fork benefits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)