### PR TITLE
fix(delegates): Test button probes the saved config, not just {name, type}

### DIFF
--- a/plugins/delegates/api.py
+++ b/plugins/delegates/api.py
@@ -117,6 +117,17 @@ def build_router():
 
     @router.post("/api/delegates/test")
     async def _test(entry: dict = Body(...)):
+        # Testing a SAVED delegate (the per-row button sends just {name, type}) →
+        # probe its stored config. Testing a draft from the form → use the draft
+        # (its fields override the stored base). Either way, fill in the secret.
+        name = str(entry.get("name", "")).strip()
+        if name:
+            stored = next(
+                (e for e in store.read_delegates_raw() if isinstance(e, dict) and e.get("name") == name),
+                None,
+            )
+            if stored:
+                entry = {**stored, **entry}
         adapter = ADAPTERS.get(str(entry.get("type", "")))
         if adapter is None:
             raise HTTPException(400, f"unknown type {entry.get('type')!r}")

--- a/tests/test_delegates_api.py
+++ b/tests/test_delegates_api.py
@@ -127,6 +127,16 @@ def test_test_endpoint_unknown_type_400(client):
     assert client.post("/api/delegates/test", json={"type": "nope"}).status_code == 400
 
 
+def test_test_endpoint_probes_saved_delegate_by_name(client):
+    # The per-row Test button sends only {name, type}; the endpoint must probe the
+    # STORED config (command/workdir), not fail on the missing fields.
+    import sys
+    client.post("/api/delegates", json={"name": "proto", "type": "acp",
+                                        "command": sys.executable, "workdir": "/tmp"})
+    r = client.post("/api/delegates/test", json={"name": "proto", "type": "acp"})
+    assert r.status_code == 200 and r.json()["ok"] is True
+
+
 def test_public_view_redacts_secrets_including_nested_env():
     raw = {
         "name": "proto", "type": "acp", "command": "proto", "workdir": "/tmp",


### PR DESCRIPTION
Follow-up fix to PR3 (#605), caught by you driving the panel: clicking **Test** on a saved `proto` (acp) delegate returned `✗ acp delegate 'proto' needs command + workdir`.

## Cause
The per-row Test button sends only `{name, type}` to `POST /api/delegates/test`. The handler parsed that directly, so the adapter's `parse()` failed on the missing required fields (`command`/`workdir` for acp; `url`/`model` for openai; `url` for a2a).

## Fix
When the entry names a **stored** delegate, the endpoint now merges its stored config as the base (`{**stored, **entry}` — any draft fields still win) before probing. So:
- per-row Test (saved) → probes the stored config ✓
- form Test (unsaved draft, full fields) → unchanged ✓

## Test
```
$ pytest tests/test_delegates_api.py -q
11 passed
```
New: save an acp delegate, then `POST /api/delegates/test {name, type}` → probes stored `command`/`workdir` → `{ok: true}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)