### PR TITLE
feat(delegates): background health prober + deprecate code_with/peer_consult (ADR 0025, PR4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,6 +40,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   are never echoed back. Saving hot-reloads, so the roster is live next turn. The
   Integrations tab appears whenever the `delegates` plugin is reachable, even with
   no other integration enabled. (`apps/web`; e2e `delegates.spec.ts`.)
+- **Delegate health prober** (ADR 0025, PR4) — a background surface probes every
+  delegate periodically (initial delay + fixed interval) into a cache that
+  `GET /api/delegates` merges in, so the panel shows a **live health dot** (green
+  reachable / red down / grey unchecked) per delegate, not just on-demand Test.
+  Completes ADR 0025. `code_with` and `peer_consult` are now **deprecated** in
+  favor of `delegate_to` (still functional; removed in a future release).
 
 ## [0.16.0] - 2026-06-06
 

--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -18,6 +18,8 @@ test("lists configured delegates with type + secret badges", async ({ page }) =>
   await expect(row).toBeVisible();
   await expect(row.locator(".delegate-type-badge")).toHaveText("openai");
   await expect(row.getByText("secret set")).toBeVisible();
+  // Health prober (PR4): the cached status surfaces as a dot.
+  await expect(row.locator(".delegate-health.ok")).toBeVisible();
 });
 
 test("Add opens a type picker and a schema-driven form", async ({ page }) => {

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -481,6 +481,7 @@ export const DELEGATES = {
       name: "opus", type: "openai", description: "Heavy reasoning model.",
       configured: true, error: null, has_secret: true,
       url: "https://api.proto-labs.ai/v1", model: "protolabs/reasoning",
+      health: { ok: true, latency_ms: 42, detail: "endpoint reachable" },
     },
   ],
 };

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3084,3 +3084,7 @@ textarea {
 .delegate-type-tile-label { font-size: 13px; font-weight: 600; }
 .delegate-type-tile-blurb { font-size: 11px; color: var(--fg-muted); }
 .delegate-field-help { font-size: 11px; color: var(--fg-muted); }
+.delegate-health { font-size: 10px; line-height: 1; }
+.delegate-health.ok { color: #46c46a; }
+.delegate-health.down { color: #e0533a; }
+.delegate-health.unknown { color: var(--fg-muted); }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -398,6 +398,7 @@ export type DelegateFieldSpec = {
   default?: unknown;
 };
 export type DelegateTypeSpec = { type: string; label: string; blurb: string; fields: DelegateFieldSpec[] };
+export type DelegateProbe = { ok: boolean | null; latency_ms?: number; error?: string; detail?: string; checked_at?: number };
 export type DelegateView = {
   name: string;
   type: string;
@@ -405,6 +406,6 @@ export type DelegateView = {
   configured: boolean;
   error: string | null;
   has_secret: boolean;
+  health?: DelegateProbe;
   [key: string]: unknown;
 };
-export type DelegateProbe = { ok: boolean | null; latency_ms?: number; error?: string; detail?: string };

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -106,6 +106,16 @@ export function DelegatesSection() {
             <div className="subagent-row" key={d.name}>
               <div>
                 <strong>
+                  {d.health ? (
+                    <span
+                      className={`delegate-health ${d.health.ok ? "ok" : d.health.ok === false ? "down" : "unknown"}`}
+                      title={d.health.ok
+                        ? `${d.health.detail || "reachable"}${d.health.latency_ms != null ? ` (${d.health.latency_ms} ms)` : ""}`
+                        : d.health.error || "unreachable"}
+                    >
+                      ●
+                    </span>
+                  ) : null}
                   {d.name} <span className="delegate-type-badge">{d.type}</span>
                   {!d.configured ? <span className="delegate-badge-warn">⚠ unconfigured</span> : null}
                   {d.has_secret ? <span className="delegate-badge-ok">secret set</span> : null}

--- a/docs/adr/0025-unified-delegate-registry-and-panel.md
+++ b/docs/adr/0025-unified-delegate-registry-and-panel.md
@@ -137,8 +137,11 @@ Mounted by the plugin router:
   Settings → Integrations (list + type picker + schema-driven form + Test button +
   secret handling). Surfaces the Integrations tab whenever the plugin is reachable
   even with no schema-driven integration enabled. e2e: `delegates.spec.ts`.
-- **PR4: health prober** — background reachability loop + health badges; then
-  deprecate `code_with`/`peer_consult` in favor of `delegate_to`.
+- **PR4 (shipped): health prober** — a background surface probes every delegate
+  periodically (fixed interval + initial delay) into a cache that `GET /api/delegates`
+  merges in; the panel shows a live health dot. `code_with`/`peer_consult`
+  deprecated (docstrings) in favor of `delegate_to` — still functional, removed in
+  a future release.
 
 ## Consequences
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -33,4 +33,4 @@ decision, numbered, never deleted (supersede instead).
 | [0022](./0022-activity-provenance-feed.md) | Activity is a provenance feed, not a second chat | Accepted |
 | [0023](./0023-server-decomposition.md) | Decompose server.py: AppState + composition root | Accepted |
 | [0024](./0024-spawn-cli-coding-agents-acp.md) | Spawn CLI coding agents over ACP (`code_with`) | Accepted (PR1 + PR3) |
-| [0025](./0025-unified-delegate-registry-and-panel.md) | Unified delegate registry + hot-swappable panel (`delegate_to`) | Accepted (sliced; PR1–PR3) |
+| [0025](./0025-unified-delegate-registry-and-panel.md) | Unified delegate registry + hot-swappable panel (`delegate_to`) | Accepted (complete; PR1–PR4) |

--- a/docs/guides/delegates.md
+++ b/docs/guides/delegates.md
@@ -23,7 +23,9 @@ the next turn, no restart). See [ADR 0025](/adr/0025-unified-delegate-registry-a
 With the plugin enabled, open **Settings → Integrations → Delegates**. The panel:
 
 - **lists** your delegates with a type badge, a `secret set` / `⚠ unconfigured`
-  marker, and a per-row **Test** button (reachability probe);
+  marker, a **live health dot** (a background prober probes each delegate
+  periodically — green reachable / red down / grey not-yet-checked), and a per-row
+  **Test** button for an on-demand probe;
 - **adds** one via a **type picker** (A2A agent / Model endpoint / Coding agent)
   and a form generated from each type's field schema;
 - **edits / deletes** existing ones; secrets you enter are routed to
@@ -119,6 +121,6 @@ curl -s -X POST localhost:7788/api/delegates/test -d '{"type":"a2a","url":"https
 ## Relationship to `code_with` / `peer_consult`
 
 `delegate_to` supersedes them: an `acp` delegate is what `code_with` did, and an
-`a2a` delegate is what `peer_consult` did. Both older tools still work for now and
-will be deprecated once the panel lands (ADR 0025, PR4). New setups should prefer
-`delegates` + `delegate_to`.
+`a2a` delegate is what `peer_consult` did. **Both are now deprecated** (their
+docstrings say so) — they still work for back-compat and will be removed in a
+future release. New setups should use `delegates` + `delegate_to`.

--- a/plugins/coding_agent/__init__.py
+++ b/plugins/coding_agent/__init__.py
@@ -169,6 +169,11 @@ def _build_code_with(agents: dict[str, dict], default_timeout_s: float):
     async def code_with(agent: str, task: str) -> str:
         """Delegate a coding task to a CLI coding agent and return its result.
 
+        Deprecated: prefer `delegate_to(target, query)` with an `acp` delegate
+        (the unified delegate registry, ADR 0025) — it does the same over one tool
+        alongside a2a/openai delegates, with a console panel. This tool stays for
+        back-compat and will be removed in a future release.
+
         Use this to hand a real, repo-scoped coding job — read/edit/run code,
         fix a failing test, add an endpoint — to a purpose-built coding agent
         that has its own file access, shell, and edit/verify loop. Prefer this

--- a/plugins/delegates/__init__.py
+++ b/plugins/delegates/__init__.py
@@ -74,14 +74,21 @@ def _load_delegates_config() -> list:
 
 def register(registry) -> None:
     """Entry point — called once per graph build with the live config."""
-    # CRUD API for the console panel (PR2). Mounted once at process init; the
-    # roster it edits is config, which hot-reloads — so the static routes are fine.
+    # CRUD API for the console panel (PR2) + the background health prober (PR4).
+    # Mounted/started once at process init; the roster they serve is config, which
+    # hot-reloads — so the static routes + the loop's per-tick re-read are fine.
     try:
         from .api import build_router
 
         registry.register_router(build_router(), prefix="")
     except Exception:  # noqa: BLE001 — API is best-effort; the tool still works
         log.exception("[delegates] mounting CRUD API failed")
+    try:
+        from .health import start as _health_start, stop as _health_stop
+
+        registry.register_surface(_health_start, stop=_health_stop, name="delegate-health")
+    except Exception:  # noqa: BLE001 — health is best-effort
+        log.exception("[delegates] registering health prober failed")
 
     delegates = _load_delegates_config()
     if not delegates:

--- a/plugins/delegates/api.py
+++ b/plugins/delegates/api.py
@@ -63,7 +63,19 @@ def _public_view(raw: dict) -> dict:
 
 
 def _list_payload() -> dict:
-    return {"delegates": [_public_view(r) for r in store.read_delegates_raw() if isinstance(r, dict)]}
+    from .health import health_snapshot
+
+    health = health_snapshot()
+    out = []
+    for r in store.read_delegates_raw():
+        if not isinstance(r, dict):
+            continue
+        view = _public_view(r)
+        h = health.get(view.get("name"))
+        if h:
+            view["health"] = h
+        out.append(view)
+    return {"delegates": out}
 
 
 def _validate(entry: dict):

--- a/plugins/delegates/health.py
+++ b/plugins/delegates/health.py
@@ -1,0 +1,81 @@
+"""Background health prober for delegates (ADR 0025, PR4).
+
+A lifecycle surface (register_surface) that periodically probes every configured
+delegate and caches the result, so the panel shows a live status badge instead of
+only on-demand Test. Reads ``merged_delegates()`` each tick, so it tracks
+add/edit/remove without a restart; entries for removed delegates are pruned.
+
+Ported in spirit from ORBIS's ``health_loop`` (simplified: fixed interval + jitter,
+no per-delegate backoff yet).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+
+from .adapters import ADAPTERS
+
+log = logging.getLogger("protoagent.plugins.delegates")
+
+# name -> {ok, latency_ms?, error?, detail?, checked_at}
+_HEALTH: dict[str, dict] = {}
+_INTERVAL_S = 120.0
+_INITIAL_DELAY_S = 15.0
+_task: asyncio.Task | None = None
+
+
+def health_snapshot() -> dict[str, dict]:
+    """Current cached health per delegate name (copy)."""
+    return {k: dict(v) for k, v in _HEALTH.items()}
+
+
+async def _probe_all() -> None:
+    from .store import merged_delegates
+
+    seen: set[str] = set()
+    for raw in merged_delegates():
+        if not isinstance(raw, dict):
+            continue
+        name = raw.get("name")
+        adapter = ADAPTERS.get(str(raw.get("type", "")))
+        if not (name and adapter):
+            continue
+        seen.add(name)
+        try:
+            d = adapter.parse(raw)
+            res = await adapter.probe(d)
+        except Exception as exc:  # noqa: BLE001 — a bad delegate shouldn't kill the loop
+            res = {"ok": False, "error": str(exc)[:200]}
+        res["checked_at"] = time.time()
+        _HEALTH[name] = res
+    for stale in [n for n in _HEALTH if n not in seen]:
+        _HEALTH.pop(stale, None)
+
+
+async def _loop(interval: float = _INTERVAL_S, initial_delay: float = _INITIAL_DELAY_S) -> None:
+    await asyncio.sleep(initial_delay)  # let boot settle before the first sweep
+    while True:
+        try:
+            await _probe_all()
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            log.exception("[delegates/health] probe sweep failed")
+        await asyncio.sleep(interval)
+
+
+async def start() -> None:
+    global _task
+    if _task and not _task.done():
+        return
+    _task = asyncio.create_task(_loop())
+    log.info("[delegates/health] prober started (every %ss)", int(_INTERVAL_S))
+
+
+async def stop() -> None:
+    global _task
+    if _task and not _task.done():
+        _task.cancel()
+    _task = None

--- a/tests/test_delegates_api.py
+++ b/tests/test_delegates_api.py
@@ -127,6 +127,14 @@ def test_test_endpoint_unknown_type_400(client):
     assert client.post("/api/delegates/test", json={"type": "nope"}).status_code == 400
 
 
+def test_list_includes_health_snapshot(client, monkeypatch):
+    import plugins.delegates.health as H
+    client.post("/api/delegates", json={"name": "opus", "type": "openai", "url": "https://g/v1", "model": "m"})
+    monkeypatch.setattr(H, "health_snapshot", lambda: {"opus": {"ok": True, "latency_ms": 12, "detail": "ok"}})
+    body = client.get("/api/delegates").json()["delegates"][0]
+    assert body["health"]["ok"] is True and body["health"]["latency_ms"] == 12
+
+
 def test_test_endpoint_probes_saved_delegate_by_name(client):
     # The per-row Test button sends only {name, type}; the endpoint must probe the
     # STORED config (command/workdir), not fail on the missing fields.

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -186,3 +186,43 @@ async def test_acp_dispatch_reuses_client(monkeypatch):
     monkeypatch.setattr(CA, "_client_for", lambda spec: _StubClient())
     d = ADAPTERS["acp"].parse({"name": "proto", "type": "acp", "command": "proto", "workdir": "/tmp"})
     assert await ADAPTERS["acp"].dispatch(d, "fix the bug") == "coding done"
+
+
+# ── health prober (PR4) ───────────────────────────────────────────────────────
+
+import plugins.delegates.health as H  # noqa: E402
+
+
+async def test_health_probe_all_populates_and_prunes(monkeypatch):
+    H._HEALTH.clear()
+    import plugins.delegates.store as store
+
+    monkeypatch.setattr(store, "merged_delegates",
+                        lambda: [{"name": "opus", "type": "openai", "url": "https://g/v1", "model": "m"}])
+
+    async def fake_probe(d):
+        return {"ok": True, "latency_ms": 5, "detail": "ok"}
+
+    monkeypatch.setattr(ADAPTERS["openai"], "probe", fake_probe)
+    await H._probe_all()
+    assert H._HEALTH["opus"]["ok"] is True
+    assert "checked_at" in H._HEALTH["opus"]
+
+    # delegate removed → pruned on the next sweep
+    monkeypatch.setattr(store, "merged_delegates", lambda: [])
+    await H._probe_all()
+    assert "opus" not in H._HEALTH
+
+
+async def test_health_probe_records_failure(monkeypatch):
+    H._HEALTH.clear()
+    import plugins.delegates.store as store
+    monkeypatch.setattr(store, "merged_delegates",
+                        lambda: [{"name": "p", "type": "acp", "command": "proto", "workdir": "/tmp"}])
+
+    async def boom(d):
+        raise RuntimeError("nope")
+
+    monkeypatch.setattr(ADAPTERS["acp"], "probe", boom)
+    await H._probe_all()
+    assert H._HEALTH["p"]["ok"] is False and "nope" in H._HEALTH["p"]["error"]

--- a/tools/peer_tools.py
+++ b/tools/peer_tools.py
@@ -88,6 +88,11 @@ def get_peer_tools() -> list:
     async def peer_consult(name: str, message: str) -> str:
         """Ask another agent (by peer handle) a question and return its reply.
 
+        Deprecated: prefer ``delegate_to(target, query)`` with an ``a2a`` delegate
+        (the unified delegate registry, ADR 0025) — same A2A consult over one tool
+        alongside openai/acp delegates, with a console panel. This tool stays for
+        back-compat and will be removed in a future release.
+
         Args:
             name: Peer handle (must match a configured ``PEER_<HANDLE>_URL``).
             message: The question — be specific; the peer answers from its own context.


### PR DESCRIPTION
The final slice of ADR 0025 — live status badges, and pointing the superseded tools at the unified one.

## Health prober
`plugins/delegates/health.py` — a lifecycle surface (`register_surface`) that probes every delegate periodically (15s initial delay, 120s interval) into a cache. It reads `merged_delegates()` each tick, so it tracks add/edit/remove and **prunes removed** entries; registered alongside the CRUD router (always, even with no delegates yet). `GET /api/delegates` merges the snapshot per delegate.

## Panel
The Delegates rows now show a **live health dot** — green reachable / red down / grey not-yet-checked — with a latency/error tooltip, alongside the existing on-demand **Test** button.

## Deprecation
`code_with` (coding_agent) and `peer_consult` (peer_tools) docstrings now mark them **deprecated** in favor of `delegate_to` (an `acp` / `a2a` delegate). Still functional for back-compat; removed in a future release. (No behavior change — docstring + guide only.)

## Test
```
$ pytest tests/test_delegates_plugin.py tests/test_delegates_api.py -q   # 27 passed
$ npm run build && npx playwright test delegates.spec.ts                 # 2 passed
$ ruff check plugins/delegates/                                          # clean
```
New: health `_probe_all` populate + prune + failure-capture (unit); API list includes the snapshot; e2e asserts the health dot.

**Live-validated**: after a restart the prober populated both delegates green — `proto` (acp) "on PATH; workdir OK", `opus` (openai) "reachable (131 ms)".

## ADR 0025 complete
PR1 registry → PR2 API → PR3 panel → **PR4 health**. Your "hot-swap the agents and endpoints my agent can talk to" vision: shipped end-to-end with live status.

🤖 Generated with [Claude Code](https://claude.com/claude-code)