### PR TITLE
fix(subagents): out-of-graph workflow/subagent runners miss plugin + MCP tools

### DIFF
--- a/graph/agent.py
+++ b/graph/agent.py
@@ -265,14 +265,23 @@ async def run_manual_subagent(
     subagent_type: str = "researcher",
     emit_skill: bool = False,
     truncate: int | None = None,
+    extra_tools=None,
 ) -> str:
     """Run a subagent outside the lead agent's ``task`` tool.
 
     The React operator console uses this to let a human explicitly fan out
     work. It intentionally uses the same private runner as ``task`` so audit,
     prompt, max-turn, and one-level delegation behavior stay aligned.
+
+    ``extra_tools`` are tools beyond the core ``get_all_tools`` set — plugin and
+    MCP tools — that the lead graph exposes via ``extra_tools`` but which this
+    out-of-graph runner would otherwise miss. Without them a subagent whose
+    allowlist names a plugin tool (e.g. a finance ``backtest_strategy``) sees
+    "not a valid tool" and silently degrades. Mirrors the lead graph's tool set.
     """
     all_tools = get_all_tools(knowledge_store, scheduler=scheduler)
+    if extra_tools:
+        all_tools = all_tools + list(extra_tools)
     tool_map = {t.name: t for t in all_tools}
     available_subagents = ", ".join(SUBAGENT_REGISTRY.keys()) or "(none configured)"
 
@@ -297,6 +306,7 @@ async def run_manual_workflow(
     name: str,
     inputs: dict | None = None,
     on_step=None,
+    extra_tools=None,
 ) -> dict:
     """Run a saved workflow recipe outside the lead agent's tool (operator UI).
 
@@ -339,6 +349,7 @@ async def run_manual_workflow(
             description=f"workflow {name}:{step_id}",
             prompt=prompt,
             subagent_type=subagent_type,
+            extra_tools=extra_tools,
         )
         await _emit({"phase": "end", "step_id": step_id, "subagent": subagent_type, "output": out})
         return out
@@ -354,6 +365,7 @@ async def run_manual_subagent_batch(
     scheduler=None,
     *,
     tasks: list[dict],
+    extra_tools=None,
 ) -> str:
     """Run independent manual subagent jobs concurrently.
 
@@ -386,6 +398,7 @@ async def run_manual_subagent_batch(
                 subagent_type=spec.get("subagent_type") or spec.get("type", "researcher"),
                 emit_skill=bool(spec.get("emit_skill", False)),
                 truncate=truncate,
+                extra_tools=extra_tools,
             )
 
     results = await asyncio.gather(*(_one(s) for s in tasks), return_exceptions=True)

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -80,6 +80,7 @@ async def _operator_subagent_run(req: dict):
         prompt=req.get("prompt", ""),
         subagent_type=req.get("type") or req.get("subagent_type", "researcher"),
         emit_skill=bool(req.get("emit_skill", False)),
+        extra_tools=STATE.plugin_tools + STATE.mcp_tools,
     )
 
 
@@ -91,6 +92,7 @@ async def _operator_subagent_batch(req: dict):
         knowledge_store=STATE.knowledge_store,
         scheduler=STATE.scheduler,
         tasks=req.get("tasks", []),
+        extra_tools=STATE.plugin_tools + STATE.mcp_tools,
     )
 
 
@@ -159,6 +161,7 @@ async def _operator_workflow_run(name: str, inputs: dict) -> dict:
         STATE.graph_config, STATE.workflow_registry,
         knowledge_store=STATE.knowledge_store, scheduler=STATE.scheduler,
         name=name, inputs=inputs or {},
+        extra_tools=STATE.plugin_tools + STATE.mcp_tools,
     )
 
 

--- a/operator_api/subagents.py
+++ b/operator_api/subagents.py
@@ -35,8 +35,14 @@ async def run_manual_subagent(
     prompt: str,
     subagent_type: str = "researcher",
     emit_skill: bool = False,
+    extra_tools: Any = None,
 ) -> str:
-    """Run one manually launched subagent task."""
+    """Run one manually launched subagent task.
+
+    ``extra_tools`` (plugin + MCP tools) are forwarded so an out-of-graph
+    subagent sees the same tool surface as the lead graph — without them a
+    plugin-tool allowlist silently degrades to "not a valid tool".
+    """
     if config is None:
         raise RuntimeError("agent config is not loaded")
     if not prompt or not prompt.strip():
@@ -54,6 +60,7 @@ async def run_manual_subagent(
         prompt=prompt,
         subagent_type=subagent_type,
         emit_skill=emit_skill,
+        extra_tools=extra_tools,
     )
 
 
@@ -63,6 +70,7 @@ async def run_manual_subagent_batch(
     knowledge_store: Any,
     scheduler: Any,
     tasks: list[dict[str, Any]],
+    extra_tools: Any = None,
 ) -> str:
     """Run a manually launched batch of independent subagent tasks."""
     if config is None:
@@ -77,4 +85,5 @@ async def run_manual_subagent_batch(
         knowledge_store=knowledge_store,
         scheduler=scheduler,
         tasks=tasks,
+        extra_tools=extra_tools,
     )

--- a/tests/test_manual_subagents.py
+++ b/tests/test_manual_subagents.py
@@ -46,6 +46,42 @@ async def test_run_manual_subagent_reuses_private_runner(monkeypatch) -> None:
 
 
 @pytest.mark.asyncio
+async def test_run_manual_subagent_merges_extra_tools(monkeypatch) -> None:
+    """Plugin/MCP tools passed as ``extra_tools`` must reach the subagent's
+    tool_map — without this the out-of-graph runner silently degrades a
+    plugin-tool allowlist to "not a valid tool" (the lead graph exposes them via
+    its own ``extra_tools``; this path has to mirror that surface)."""
+    calls = []
+
+    monkeypatch.setattr(agent_mod, "create_llm", lambda _config: object())
+    monkeypatch.setattr(
+        agent_mod,
+        "get_all_tools",
+        lambda _store, scheduler=None: [SimpleNamespace(name="current_time")],
+    )
+
+    async def fake_run(**kwargs):
+        calls.append(kwargs)
+        return "ok"
+
+    monkeypatch.setattr(agent_mod, "_run_subagent", fake_run)
+
+    out = await agent_mod.run_manual_subagent(
+        LangGraphConfig(),
+        knowledge_store=object(),
+        scheduler=object(),
+        description="Backtest it",
+        prompt="Test the idea",
+        subagent_type="researcher",
+        extra_tools=[SimpleNamespace(name="backtest_strategy")],
+    )
+
+    assert out == "ok"
+    # The core set AND the plugin tool are both visible to the subagent.
+    assert calls[0]["tool_map"].keys() == {"current_time", "backtest_strategy"}
+
+
+@pytest.mark.asyncio
 async def test_run_manual_subagent_batch_orders_and_normalizes_type(monkeypatch) -> None:
     calls = []
 


### PR DESCRIPTION
## Problem

The lead graph exposes plugin + MCP tools to subagents via `create_agent_graph(extra_tools=STATE.mcp_tools + STATE.plugin_tools)`, so the in-graph `task` / `run_workflow` tools delegate with the full tool surface.

But the **out-of-graph** runners — `run_manual_subagent`, `run_manual_subagent_batch`, and `run_manual_workflow` — rebuild their `tool_map` from a bare `get_all_tools()` that **omits plugin and MCP tools**. These runners back:
- the operator console's *Run subagent* / *Run workflow* endpoints (`/api/subagents/run`, `/api/subagents/batch`, `/api/workflows/{name}/run`), and
- the eval harness's `kind: workflow` cases.

A subagent whose allowlist names a plugin tool sees `Error: <tool> is not a valid tool` and **silently degrades** to a text-only answer. The workflow step still "completes", so it's easy to miss.

### How it surfaced

On a finance-plugin fork, the `quant-desk` workflow's quant step is told to call `backtest_strategy`. Via the REST endpoint the audit log showed:

```
backtest_strategy → "Error: backtest_strategy is not a valid tool, try one of [web_search, memory_recall, current_time]." (success: false)
```

…while the *same* subagent invoked through the in-graph `task` tool ran the backtest fine — pinning the divergence to the manual-runner tool_map.

## Fix

Thread an `extra_tools` argument through all three runners and have the operator handlers pass `STATE.plugin_tools + STATE.mcp_tools`, mirroring the lead graph. Default stays `None`, so every existing caller is unchanged.

## Verification

- New regression test (`tests/test_manual_subagents.py`) asserts `extra_tools` lands in the subagent's `tool_map`.
- `tests/test_manual_subagents.py`, `tests/test_console_handlers.py`, `tests/test_operator_api_routes.py` all pass.
- End-to-end on the fork: after the fix the workflow's quant step logs **two successful `backtest_strategy` calls** and the synthesis cites concrete metrics (return vs buy-and-hold, Sharpe) instead of "tool not available". The eval case flips FAIL → PASS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)