### PR TITLE
feat(console): self-heal an interrupted chat stream via task reconciliation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Chat self-heals an interrupted stream** (console). A chat turn whose stream
+  was cut off — page reload, network blip, or a stale tab — left the assistant
+  message stuck "streaming" (spinner) **forever**, even after the agent's turn
+  completed server-side. The turn's A2A task id is now persisted on the message,
+  and on load a stuck `streaming` message **reconciles against the durable server
+  task** (`tasks/get`): it finalizes with the completed answer (flipping any
+  running tool cards to done), surfaces a failure, or briefly polls if the turn is
+  genuinely still running — instead of spinning indefinitely. e2e:
+  `chat-reconcile.spec.ts`.
 - **Chat continuity across navigation** (console). Switching from the Chat tab to
   another surface (Activity/Studio/Settings/…) **unmounted** `ChatSurface` — which
   tore down the still-mounted session pool, and its unmount cleanup aborted the

--- a/apps/web/e2e/chat-reconcile.spec.ts
+++ b/apps/web/e2e/chat-reconcile.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+// Stuck-stream self-heal (reconcile): a chat message left in `streaming` after an
+// interrupted stream (reload / network / a stale tab) must reconcile against the
+// server's durable task on load — A2A tasks/get — and finalize, instead of
+// spinning forever. We seed a stuck session into localStorage; the mock serves a
+// completed task carrying the answer.
+
+test("a stuck 'streaming' message reconciles to the server's completed answer on load", async ({ page }) => {
+  await page.addInitScript(() => {
+    const stuck = {
+      version: 1,
+      currentSessionId: "s-stuck",
+      sessions: [
+        {
+          id: "s-stuck",
+          title: "Interrupted turn",
+          createdAt: Date.now(),
+          updatedAt: Date.now(),
+          messages: [
+            { id: "u1", role: "user", content: "what's the answer?", status: "done" },
+            // assistant turn whose stream was cut off mid-flight: still "streaming",
+            // carries the A2A task id the reconcile will query.
+            { id: "a1", role: "assistant", content: "", status: "streaming", taskId: "task-stuck-1" },
+          ],
+        },
+      ],
+    };
+    window.localStorage.setItem("protoagent.chat.sessions", JSON.stringify(stuck));
+  });
+
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // On mount the reconcile fires: tasks/get → completed → finalize. The answer
+  // from the server's artifact appears, and the message is no longer streaming.
+  await expect(page.locator(".message-assistant")).toContainText("RECONCILED ANSWER");
+  // No longer spinning — the streaming loader is gone once finalized.
+  await expect(page.locator(".message-assistant .spin")).toHaveCount(0);
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -191,7 +191,21 @@ const server = createServer(async (req, res) => {
   const { pathname } = url;
 
   if (pathname === "/a2a" && req.method === "POST") {
-    return handleA2AStream(req, res, await readBody(req));
+    const body = await readBody(req);
+    // tasks/get — the reconcile path (self-heal a stuck streaming turn): return a
+    // terminal task carrying the final answer as an artifact.
+    if (body?.method === "tasks/get") {
+      return sendJson(res, {
+        jsonrpc: "2.0",
+        id: body.id,
+        result: {
+          id: body.params?.id, contextId: "reconcile", kind: "task",
+          status: { state: "completed" },
+          artifacts: [{ parts: [{ kind: "text", text: "RECONCILED ANSWER" }] }],
+        },
+      });
+    }
+    return handleA2AStream(req, res, body);
   }
   if (pathname === "/api/events" && req.method === "GET") {
     // Server→client SSE push channel (ADR 0003). Hold the connection open so

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -233,6 +233,61 @@ function ChatSessionSlot({
     };
   }, []);
 
+  // Self-heal an interrupted turn (reload / network blip / a stale tab): if the
+  // last assistant message is stuck in `streaming` with no live controller,
+  // reconcile it against the server's durable task (A2A tasks/get) — finalize
+  // when terminal, polling briefly if it's genuinely still running. Without this
+  // an interrupted stream spins forever even though the server completed.
+  useEffect(() => {
+    if (abortRef.current) return; // a live turn in this slot owns the stream
+    const snap = chatStore.getSnapshot().sessions.find((s) => s.id === sessionId);
+    const last = [...(snap?.messages || [])].reverse().find((m) => m.role === "assistant");
+    if (!last || last.status !== "streaming" || !last.taskId || !last.id) return;
+
+    const assistantId = last.id;
+    const taskId = last.taskId;
+    const TERMINAL = /completed|failed|canceled|cancelled/i;
+    let cancelled = false;
+    let polls = 0;
+    const MAX_POLLS = 40; // ~2 min at 3s — then give up and leave it as-is
+
+    function finalize(state: string, text: string) {
+      const cur = chatStore.getSnapshot().sessions.find((s) => s.id === sessionId);
+      if (!cur) return;
+      const failed = /fail|cancel/i.test(state);
+      chatStore.updateMessages(
+        sessionId,
+        cur.messages.map((m) => {
+          if (m.id !== assistantId) return m;
+          const toolCalls = m.toolCalls?.map((c) => (c.status === "running" ? { ...c, status: "done" as const } : c));
+          return { ...m, content: text || m.content, status: failed ? "error" : "done", toolCalls };
+        }),
+      );
+      chatStore.setSessionStatus(sessionId, failed ? "error" : "idle");
+    }
+
+    async function tick() {
+      if (cancelled) return;
+      let res: { state: string; text: string };
+      try {
+        res = await api.getTask(taskId);
+      } catch {
+        return; // best-effort — leave the message as-is on a hard error
+      }
+      if (cancelled) return;
+      if (!res.state || TERMINAL.test(res.state)) {
+        // terminal, or the task is gone (un-stick rather than spin forever)
+        finalize(res.state, res.text);
+        return;
+      }
+      if (++polls < MAX_POLLS) setTimeout(tick, 3000);
+    }
+    void tick();
+    return () => {
+      cancelled = true;
+    };
+  }, [sessionId]);
+
   const messages = session?.messages || [];
 
   const canSend = useMemo(() => Boolean(draft.trim()) && status !== "streaming", [draft, status]);
@@ -282,7 +337,18 @@ function ChatSessionSlot({
     try {
       await api.streamChat(userMessage.content, session.id, {
         signal: controller.signal,
-        onTaskId: setTaskId,
+        onTaskId: (id) => {
+          setTaskId(id);
+          // Persist the task id on the assistant message so a stuck `streaming`
+          // turn can be reconciled against the server task after a reload (below).
+          const cur = chatStore.getSnapshot().sessions.find((s) => s.id === session.id);
+          if (cur) {
+            chatStore.updateMessages(
+              session.id,
+              cur.messages.map((m) => (m.id === assistantId ? { ...m, taskId: id } : m)),
+            );
+          }
+        },
         onStatus: setStatusMessage,
         onFailed: (detail) => {
           // The turn failed terminally (e.g. the model 401'd on a bad key).

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -713,6 +713,25 @@ export const api = {
     });
   },
 
+  // Reconcile a turn against the server's durable task (A2A tasks/get). Used to
+  // self-heal a chat message stuck in `streaming` after the stream was
+  // interrupted (reload, network blip, a stale tab) — the server task is the
+  // source of truth. Returns the normalized state + the final answer text (empty
+  // until terminal).
+  async getTask(taskId: string): Promise<{ state: string; text: string }> {
+    const res = await request<A2AFrame>("/a2a", {
+      method: "POST",
+      body: { jsonrpc: "2.0", id: `get-${Date.now()}`, method: "tasks/get", params: { id: taskId } },
+    });
+    const result = res.result;
+    const task = (result?.task ?? (result?.kind === "task" ? result : result)) as
+      | NonNullable<A2AFrame["result"]>
+      | undefined;
+    if (!task) return { state: "", text: "" };
+    const state = (task.status?.state || "").toString();
+    return { state, text: textFromTerminalTask(task) };
+  },
+
   // Notes + Beads are agent-global (one persistent store each) — no project
   // scope. The project / allowed-dirs list is purely the filesystem fence.
   getNotes() {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -191,6 +191,9 @@ export type ChatMessage = {
   toolCalls?: ToolCall[];
   createdAt?: number;
   status?: "streaming" | "done" | "error";
+  /** A2A task id for this turn — persisted so a stuck `streaming` message can be
+   *  reconciled against the server's task state on reload (self-heal). */
+  taskId?: string;
 };
 
 // HITL (human-in-the-loop) request surfaced when a turn pauses as input-required


### PR DESCRIPTION
The follow-up you green-lit. Makes chat robust to **any** stream interruption, not just tab navigation (#613).

## The gap
If a chat stream is cut off — page reload, network blip, a backgrounded-tab throttle, or running stale code — the assistant message stays stuck **"streaming" (spinner) forever**, even though the agent's turn completed and is durable server-side. (This is exactly the "spinning, did it even work?" state you hit.)

## The fix — reconcile against the server task
The turn's **A2A task id is persisted on the message**, and on load a stuck `streaming` message reconciles against the server's durable task:

- **`api.getTask(taskId)`** → A2A `tasks/get` (mirrors the existing `cancelTask`); returns `{state, text}` via the existing `textFromTerminalTask` extractor.
- **`ChatSessionSlot`**, on mount with no live controller, finds a `streaming` message with a `taskId` and reconciles:
  - **terminal** → finalize: render the completed answer, flip any running tool cards to done, clear the spinner;
  - **failed/canceled** → mark error;
  - **still working** → poll ~every 3s (cap ~2 min) then give up;
  - **task gone** → un-stick rather than spin.

`session.id` is the A2A `contextId`, and the turn already received its task id via `onTaskId` — it just wasn't persisted. Now it is.

## Test
```
$ npm run build
$ npx playwright test chat.spec chat-delete chat-continuity chat-reconcile navigation
14 passed
```
New `chat-reconcile.spec.ts`: seed a stuck `streaming` session (with a `taskId`) into localStorage → load `/app` → reconcile fires (`tasks/get` → completed) → the server's answer renders and the spinner is gone. Mock serves `tasks/get`.

## Scope
Covers reload / interruption recovery against a **completed-or-completing** task (the common case + your incident). Re-attaching a *live token stream* mid-turn (A2A `tasks/resubscribe`) is a possible future enhancement; polling-to-terminal + finalize covers the actual pain without it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)