### PR TITLE
feat(plugins): console views — rail icon + iframe per plugin (ADR 0026, PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Plugin-contributed console surfaces** (ADR 0026, PR1) — a plugin can declare
+  a `views:` block in its manifest (`{id, label, icon, path}`); the console reads
+  it from `/api/runtime/status` and renders a **dynamic left-rail icon** whose
+  panel is a same-origin **iframe** of the page the plugin serves (e.g.
+  `/plugins/<id>/view`) — so a fork gets its own rail dashboard with no console
+  rebuild. Surfaces are keyed `plugin:<id>:<viewId>`; chat stays mounted (its
+  continuity holds) while a plugin view is open. The `hello` example plugin now
+  ships a demo view. Thin vertical — the full data-driven rail registry +
+  view-tabs + auth/theming bridge land in follow-up slices. See
+  [ADR 0026](docs/adr/0026-plugin-contributed-console-surfaces.md).
+
 ## [0.18.0] - 2026-06-06
 
 ### Added

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -35,6 +35,11 @@ export const RUNTIME_STATUS = {
   },
   plugins: [
     { id: "demo", name: "Demo Plugin", version: "1.0.0", enabled: true, loaded: true, tools: ["demo_tool"], skills: 1 },
+    // A plugin that contributes a console view (ADR 0026) → a dynamic rail icon + iframe.
+    {
+      id: "boardy", name: "Boardy", version: "0.1.0", enabled: true, loaded: true, tools: [], skills: 0,
+      views: [{ id: "board", label: "Board", icon: "LayoutDashboard", path: "/plugins/boardy/board" }],
+    },
   ],
 };
 

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+// Plugin-contributed console surfaces (ADR 0026): an enabled plugin that declares
+// a `views` entry (surfaced via /api/runtime/status) gets a dynamic rail icon
+// whose panel is an iframe of the page the plugin serves. The mock runtime-status
+// includes a "boardy" plugin with one view.
+
+test("a plugin view adds a rail icon that opens its page in an iframe", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // The plugin's view label appears as a rail button (beyond the core surfaces).
+  const railBtn = page.locator(".rail").getByRole("button", { name: "Board", exact: true });
+  await expect(railBtn).toBeVisible();
+
+  // Clicking it hosts the plugin page in a same-origin iframe at the declared path.
+  await railBtn.click();
+  const frame = page.locator(".plugin-view-frame");
+  await expect(frame).toBeVisible();
+  await expect(frame).toHaveAttribute("src", /\/plugins\/boardy\/board/);
+  await expect(frame).toHaveAttribute("sandbox", /allow-scripts/);
+
+  // Switching back to a core surface (Chat) hides the plugin view.
+  await page.locator(".rail").getByRole("button", { name: "Chat", exact: true }).click();
+  await expect(page.locator(".plugin-view-frame")).toHaveCount(0);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -11,16 +11,20 @@ import {
   Gauge,
   Github,
   Inbox,
+  LayoutDashboard,
   Loader2,
   MessageSquare,
   PanelRight,
   Plus,
+  Puzzle,
   Save,
   Settings2,
+  Sparkles,
   Target,
   Undo2,
   Trash2,
 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { useEffect, useRef, useState } from "react";
 import type { CSSProperties, ReactNode } from "react";
@@ -37,7 +41,7 @@ import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
-import { api } from "../lib/api";
+import { api, apiUrl } from "../lib/api";
 import { brandName } from "../lib/brand";
 import { onConnectionChange, onServerEvent } from "../lib/events";
 import type { NotesWorkspace } from "../lib/types";
@@ -51,7 +55,20 @@ import { runtimeStatusQuery } from "../lib/queries";
 
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
 // fanning out to sub-views via an in-surface segmented control.
-type Surface = "chat" | "activity" | "studio" | "knowledge" | "system" | "settings";
+// Core surfaces are the fixed literals; plugin views (ADR 0026) add dynamic
+// surfaces keyed `plugin:<pluginId>:<viewId>`. The `(string & {})` keeps literal
+// autocomplete while allowing those runtime keys.
+type Surface = "chat" | "activity" | "studio" | "knowledge" | "system" | "settings" | (string & {});
+
+// Lucide icon names a plugin view may use for its rail glyph (ADR 0026, PR1 set;
+// PR2 widens the allowlist). Unknown/missing → a generic plugin glyph.
+const PLUGIN_VIEW_ICONS: Record<string, LucideIcon> = {
+  Sparkles, LayoutDashboard, Puzzle, Boxes, BarChart3, Database, Gauge, BookOpen, Target,
+};
+function pluginViewIcon(name?: string): ReactNode {
+  const Icon = (name && PLUGIN_VIEW_ICONS[name]) || Puzzle;
+  return <Icon size={18} />;
+}
 // Studio = the workflow authoring/inspection surface. Per ADR 0020 execution is
 // a chat gesture (run subagents/workflows via /<name>), not a surface — so the
 // old "Run" tab is gone and Studio is just Workflows.
@@ -138,6 +155,15 @@ export function App() {
     refetchInterval: (q) => (q.state.data?.graph_loaded ? false : 2500),
   });
   const runtime = runtimeQ.data ?? null;
+
+  // Plugin-contributed rail surfaces (ADR 0026): each enabled plugin's declared
+  // views become a dynamic rail icon (keyed plugin:<id>:<viewId>) whose panel is
+  // an iframe of the page the plugin serves. PR1 thin vertical — PR2 generalizes
+  // the rail into a full registry.
+  const pluginRail = (runtime?.plugins ?? [])
+    .filter((p) => p.enabled && p.views?.length)
+    .flatMap((p) => (p.views ?? []).map((v) => ({ ...v, key: `plugin:${p.id}:${v.id}` })));
+  const activePluginView = pluginRail.find((v) => v.key === surface) ?? null;
   // White-label the window/tab title to the configured identity (default
   // protoAgent), so a fork's title follows its name without a rebuild.
   // brandName() display-cases a bare lower-case slug (e.g. `gina` → `Gina`).
@@ -563,6 +589,16 @@ export function App() {
             icon={<Settings2 size={18} />}
             onClick={() => setSurface("settings")}
           />
+          {/* Plugin-contributed rail surfaces (ADR 0026) — dynamic, from runtime-status. */}
+          {pluginRail.map((v) => (
+            <RailButton
+              key={v.key}
+              active={surface === v.key}
+              label={v.label}
+              icon={pluginViewIcon(v.icon)}
+              onClick={() => setSurface(v.key)}
+            />
+          ))}
         </aside>
 
         <main className="stage">
@@ -628,6 +664,20 @@ export function App() {
           {surface === "knowledge" && knowledgeTab === "store" ? <KnowledgeStore onError={setError} /> : null}
           {surface === "knowledge" && knowledgeTab === "playbooks" ? <PlaybooksSurface onError={setError} /> : null}
           {surface === "settings" ? <SettingsSurface /> : null}
+
+          {/* Plugin view (ADR 0026) — the plugin serves the page; the console
+              hosts it in a same-origin iframe. ChatSurface stays mounted above
+              (hidden) so chat continuity holds while a plugin view is open. */}
+          {activePluginView ? (
+            <section className="panel stage-panel plugin-view">
+              <iframe
+                className="plugin-view-frame"
+                src={apiUrl(activePluginView.path)}
+                title={activePluginView.label}
+                sandbox="allow-scripts allow-forms allow-same-origin"
+              />
+            </section>
+          ) : null}
         </main>
 
         <aside className="right-panel">

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3105,3 +3105,7 @@ textarea {
 .delegate-health.ok { color: #46c46a; }
 .delegate-health.down { color: #e0533a; }
 .delegate-health.unknown { color: var(--fg-muted); }
+
+/* Plugin-contributed console views (ADR 0026) — the iframe fills the stage. */
+.plugin-view { padding: 0; overflow: hidden; }
+.plugin-view-frame { width: 100%; height: 100%; border: 0; background: var(--bg); display: block; }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -58,7 +58,19 @@ export type RuntimeStatus = {
     tools: string[];
     skills: number;
     error?: string;
+    // Console surfaces (ADR 0026): rail views the plugin contributes.
+    views?: PluginView[];
   }[];
+};
+
+// A plugin-contributed console surface (ADR 0026): a rail icon opening an iframe
+// of `path` (served by the plugin), with optional sub-tabs.
+export type PluginView = {
+  id: string;
+  label: string;
+  icon?: string; // a lucide-react icon name
+  path: string;
+  tabs?: { id: string; label: string; path: string }[];
 };
 
 export type SlashCommand = {

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -155,6 +155,9 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
             "loaded": False,
             "tools": [],
             "skills": 0,
+            # Console surfaces (ADR 0026) — the rail reads these from
+            # /api/runtime/status to render a dynamic icon + iframe per view.
+            "views": list(manifest.views) if enabled else [],
         }
 
         if not enabled:

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -40,6 +40,11 @@ class PluginManifest:
     config: dict = field(default_factory=dict)
     secrets: list[str] = field(default_factory=list)
     settings: list[dict] = field(default_factory=list)
+    # Console surfaces (ADR 0026) — each entry adds a left-rail icon opening a
+    # full view (an iframe of a page the plugin serves at `path`). Declared as
+    # data so it's known without importing the plugin, and surfaced to the
+    # frontend via /api/runtime/status. Each: {id, label, icon, path, tabs?}.
+    views: list[dict] = field(default_factory=list)
 
 
 def load_manifest(plugin_dir: Path) -> PluginManifest | None:
@@ -74,6 +79,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     cfg = data.get("config")
     secrets = data.get("secrets")
     settings = data.get("settings")
+    views = data.get("views")
     return PluginManifest(
         id=pid,
         name=name,
@@ -88,4 +94,6 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
         config=cfg if isinstance(cfg, dict) else {},
         secrets=[str(s) for s in secrets] if isinstance(secrets, (list, tuple)) else [],
         settings=[s for s in settings if isinstance(s, dict)] if isinstance(settings, (list, tuple)) else [],
+        views=[v for v in views if isinstance(v, dict) and v.get("id") and v.get("path")]
+        if isinstance(views, (list, tuple)) else [],
     )

--- a/plugins/hello/__init__.py
+++ b/plugins/hello/__init__.py
@@ -40,6 +40,30 @@ def _build_router(greeting: str):
     async def _ping() -> dict:
         return {"ok": True, "plugin": "hello", "greeting": greeting}
 
+    # A console view (ADR 0026): the manifest's `views:` entry points the rail
+    # iframe here. A plugin serves whatever UI it wants; this demo is a tiny
+    # self-contained page that matches the console's dark ground.
+    @router.get("/view")
+    async def _view():
+        from fastapi.responses import HTMLResponse
+
+        html = f"""<!doctype html><html><head><meta charset="utf-8">
+<style>
+  html,body{{margin:0;height:100%;background:#0a0f14;color:#e6e6e6;
+    font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;
+    display:flex;align-items:center;justify-content:center;text-align:center}}
+  .card{{padding:32px}} h1{{color:#9b87f2;margin:0 0 8px;font-size:22px}}
+  p{{color:#9aa0aa;font-size:14px;max-width:36ch;line-height:1.6}}
+  code{{background:#161b22;padding:2px 6px;border-radius:5px;color:#9b87f2}}
+</style></head><body><div class="card">
+  <h1>{greeting} from a plugin view</h1>
+  <p>This page is served by <code>plugins/hello</code> at
+  <code>/plugins/hello/view</code> and embedded in the console rail via the
+  <code>views:</code> manifest block (ADR 0026). A fork drops a directory like
+  this and gets its own rail icon + dashboard — no console rebuild.</p>
+</div></body></html>"""
+        return HTMLResponse(html)
+
     return router
 
 

--- a/plugins/hello/protoagent.plugin.yaml
+++ b/plugins/hello/protoagent.plugin.yaml
@@ -24,3 +24,10 @@ secrets: [api_key]
 settings:
   - { key: greeting, label: "Greeting word", type: string, description: "Prefix used by the hello tool." }
   - { key: api_key, label: "Example API key", type: secret, description: "Demo secret — stored in secrets.yaml, never the tracked YAML." }
+
+# Console surfaces (ADR 0026) — a left-rail icon opening a full view (an iframe of
+# a page the plugin serves). The console reads this from /api/runtime/status and
+# renders the rail icon + iframe — no console rebuild. `icon` is a lucide-react
+# name; `path` is served by this plugin's router (see __init__.py `/view`).
+views:
+  - { id: hello, label: "Hello", icon: "Sparkles", path: "/plugins/hello/view" }

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -272,3 +272,37 @@ def test_registry_exposes_plugin_host() -> None:
     r = PluginRegistry("p", Path("/tmp"))
     assert r.host is HOST                      # the process singleton the server fills
     assert hasattr(r.host, "invoke") and hasattr(r.host, "publish") and hasattr(r.host, "subscribe")
+
+
+# ── console views (ADR 0026) ──────────────────────────────────────────────────
+
+
+def test_manifest_parses_views() -> None:
+    import tempfile
+    from pathlib import Path as _P
+    root = _P(tempfile.mkdtemp())
+    _make_plugin(
+        root, "viewy", enabled=True,
+        manifest_extra=(
+            "views:\n"
+            "  - {id: board, label: Board, icon: LayoutDashboard, path: /plugins/viewy/board}\n"
+            "  - {id: nopath, label: Bad}\n"   # missing path → dropped
+        ),
+    )
+    m = load_manifest(root / "viewy")
+    assert m is not None
+    assert [v["id"] for v in m.views] == ["board"]   # the path-less one is dropped
+    assert m.views[0]["icon"] == "LayoutDashboard"
+
+
+def test_loader_meta_exposes_views_for_enabled_plugin(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "plugins"
+    _make_plugin(
+        root, "viewy", enabled=True, tool="vt",
+        manifest_extra="views:\n  - {id: board, label: Board, path: /plugins/viewy/board}\n",
+    )
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg(plugins_enabled=["viewy"]))
+    meta = res.meta[0]
+    assert meta["id"] == "viewy" and meta["enabled"] is True
+    assert [v["id"] for v in meta["views"]] == ["board"]


### PR DESCRIPTION
First slice of ADR 0026 — the thin vertical proving plugins can add their own **console surface** end-to-end.

## What
A plugin declares a `views:` block in its manifest (data, like `config`/`settings`); the console renders a **dynamic rail icon** whose panel is a same-origin **iframe** of a page the plugin serves. **No console rebuild** for a fork to get its own rail dashboard.

```yaml
# protoagent.plugin.yaml
views:
  - { id: hello, label: "Hello", icon: "Sparkles", path: "/plugins/hello/view" }
```

## Flow (all three hops)
- **manifest** (`graph/plugins/manifest.py`) parses `views` (drops entries missing id/path).
- **loader** (`graph/plugins/loader.py`) threads `views` into per-plugin meta → exposed via `/api/runtime/status` (already flows to the frontend).
- **plugin** serves the page via its existing router (`register_router`); `hello` ships a `/view` demo.
- **console** (`App.tsx`) reads the views, renders a `RailButton` per view (keyed `plugin:<id>:<viewId>`, lucide-name icon), and hosts the active one as `<iframe sandbox="allow-scripts allow-forms allow-same-origin">`. ChatSurface stays mounted (continuity holds) while a plugin view is open.

## Test
```
$ pytest tests/test_plugins.py -q          # manifest views parse + loader meta exposure
$ npx playwright test plugin-views navigation
6 passed
$ npm run build — green ; ruff — clean
```
e2e: the view label appears as a rail button → click → iframe at `/plugins/boardy/board` with the sandbox attr → switching to Chat hides it.

**Live-verified**: with `hello` enabled, `/api/runtime/status` exposes its view and `/plugins/hello/view` serves the page (200).

## Next (this initiative)
- **PR2** — refactor the rail from hardcoded into a full data-driven registry + a generic `PluginView` host (disabled/missing handling).
- **PR3** — view-tabs (`stage-subnav`) + the post-load `postMessage` auth/theming bridge + docs (`plugin-views.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)