### PR TITLE
feat(plugins): PluginView host + stale-surface fallback (ADR 0026, PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `/plugins/<id>/view`) — so a fork gets its own rail dashboard with no console
   rebuild. Surfaces are keyed `plugin:<id>:<viewId>`; chat stays mounted (its
   continuity holds) while a plugin view is open. The `hello` example plugin now
-  ships a demo view. Thin vertical — the full data-driven rail registry +
-  view-tabs + auth/theming bridge land in follow-up slices. See
+  ships a demo view. The view is hosted by a dedicated `PluginView` component with
+  load/error states, and a stale-surface fallback returns to chat if a plugin
+  view's plugin is disabled while it's open. View-tabs + the auth/theming bridge
+  land in a follow-up slice. See
   [ADR 0026](docs/adr/0026-plugin-contributed-console-surfaces.md).
 
 ## [0.18.0] - 2026-06-06

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -38,7 +38,10 @@ export const RUNTIME_STATUS = {
     // A plugin that contributes a console view (ADR 0026) → a dynamic rail icon + iframe.
     {
       id: "boardy", name: "Boardy", version: "0.1.0", enabled: true, loaded: true, tools: [], skills: 0,
-      views: [{ id: "board", label: "Board", icon: "LayoutDashboard", path: "/plugins/boardy/board" }],
+      views: [
+        { id: "board", label: "Board", icon: "LayoutDashboard", path: "/plugins/boardy/board" },
+        { id: "stats", label: "Stats", icon: "BarChart3", path: "/plugins/boardy/stats" },
+      ],
     },
   ],
 };

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -23,3 +23,18 @@ test("a plugin view adds a rail icon that opens its page in an iframe", async ({
   await page.locator(".rail").getByRole("button", { name: "Chat", exact: true }).click();
   await expect(page.locator(".plugin-view-frame")).toHaveCount(0);
 });
+
+test("switches between two plugin views, each loading its own page", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const rail = page.locator(".rail");
+  const frame = page.locator(".plugin-view-frame");
+
+  await rail.getByRole("button", { name: "Board", exact: true }).click();
+  await expect(frame).toHaveAttribute("src", /\/plugins\/boardy\/board/);
+
+  await rail.getByRole("button", { name: "Stats", exact: true }).click();
+  await expect(frame).toHaveAttribute("src", /\/plugins\/boardy\/stats/);
+
+  // exactly one plugin view is shown at a time
+  await expect(frame).toHaveCount(1);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -41,7 +41,8 @@ import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
-import { api, apiUrl } from "../lib/api";
+import { api } from "../lib/api";
+import { PluginView } from "./PluginView";
 import { brandName } from "../lib/brand";
 import { onConnectionChange, onServerEvent } from "../lib/events";
 import type { NotesWorkspace } from "../lib/types";
@@ -164,6 +165,16 @@ export function App() {
     .filter((p) => p.enabled && p.views?.length)
     .flatMap((p) => (p.views ?? []).map((v) => ({ ...v, key: `plugin:${p.id}:${v.id}` })));
   const activePluginView = pluginRail.find((v) => v.key === surface) ?? null;
+
+  // Stale-surface fallback: if we're on a plugin view that no longer exists (its
+  // plugin was disabled/removed, or a config reload dropped it) — once runtime is
+  // loaded so we don't bounce during boot — fall back to chat instead of a blank
+  // stage. (ADR 0026.)
+  useEffect(() => {
+    if (runtime && typeof surface === "string" && surface.startsWith("plugin:") && !activePluginView) {
+      setSurface("chat");
+    }
+  }, [runtime, surface, activePluginView]);
   // White-label the window/tab title to the configured identity (default
   // protoAgent), so a fork's title follows its name without a rebuild.
   // brandName() display-cases a bare lower-case slug (e.g. `gina` → `Gina`).
@@ -665,18 +676,12 @@ export function App() {
           {surface === "knowledge" && knowledgeTab === "playbooks" ? <PlaybooksSurface onError={setError} /> : null}
           {surface === "settings" ? <SettingsSurface /> : null}
 
-          {/* Plugin view (ADR 0026) — the plugin serves the page; the console
-              hosts it in a same-origin iframe. ChatSurface stays mounted above
-              (hidden) so chat continuity holds while a plugin view is open. */}
+          {/* Plugin view (ADR 0026) — the plugin serves the page; PluginView hosts
+              it in a same-origin iframe. ChatSurface stays mounted above (hidden)
+              so chat continuity holds while a plugin view is open. Keyed so
+              switching views resets the iframe's load state. */}
           {activePluginView ? (
-            <section className="panel stage-panel plugin-view">
-              <iframe
-                className="plugin-view-frame"
-                src={apiUrl(activePluginView.path)}
-                title={activePluginView.label}
-                sandbox="allow-scripts allow-forms allow-same-origin"
-              />
-            </section>
+            <PluginView key={activePluginView.key} view={activePluginView} />
           ) : null}
         </main>
 

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -1,0 +1,42 @@
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { useState } from "react";
+
+import { apiUrl } from "../lib/api";
+import type { PluginView as PluginViewType } from "../lib/types";
+
+// Host for a plugin-contributed console surface (ADR 0026): a same-origin iframe
+// of the page the plugin serves, with a loading overlay and a failure fallback.
+// Mount with `key={view key}` so switching views resets load state.
+export function PluginView({ view }: { view: PluginViewType }) {
+  const [loaded, setLoaded] = useState(false);
+  const [failed, setFailed] = useState(false);
+
+  return (
+    <section className="panel stage-panel plugin-view">
+      {failed ? (
+        <div className="plugin-view-state" role="alert">
+          <AlertTriangle size={18} />
+          <span>Couldn’t load “{view.label}”. The plugin page at <code>{view.path}</code> didn’t respond.</span>
+        </div>
+      ) : (
+        <>
+          {!loaded ? (
+            <div className="plugin-view-state">
+              <Loader2 className="spin" size={18} />
+              <span>Loading {view.label}…</span>
+            </div>
+          ) : null}
+          <iframe
+            className="plugin-view-frame"
+            src={apiUrl(view.path)}
+            title={view.label}
+            sandbox="allow-scripts allow-forms allow-same-origin"
+            onLoad={() => setLoaded(true)}
+            onError={() => setFailed(true)}
+            style={{ visibility: loaded ? "visible" : "hidden" }}
+          />
+        </>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3109,3 +3109,4 @@ textarea {
 /* Plugin-contributed console views (ADR 0026) — the iframe fills the stage. */
 .plugin-view { padding: 0; overflow: hidden; }
 .plugin-view-frame { width: 100%; height: 100%; border: 0; background: var(--bg); display: block; }
+.plugin-view-state { display: flex; align-items: center; gap: 8px; padding: 24px; color: var(--fg-muted); font-size: 13px; }


### PR DESCRIPTION
Second slice of ADR 0026 — hardens PR1's thin vertical into a proper host.

## What
- **`PluginView` component** (`apps/web/src/app/PluginView.tsx`) — the same-origin iframe with a **loading overlay** and a **failure fallback** ("couldn't load <label>"). Mounted with `key={view key}` so switching views resets load state.
- **App.tsx** renders `<PluginView/>` instead of an inline iframe, and adds a **stale-surface guard**: once runtime-status is loaded, if `surface` is `plugin:<id>:<viewId>` but no matching view exists (the plugin was disabled/removed), it falls back to chat instead of a blank stage.

## Test
```
$ npx playwright test plugin-views navigation chat-continuity
9 passed
$ npm run build — green
```
e2e now covers **two** plugin views with switching (Board ↔ Stats — exactly one shown at a time), plus the PR1 rail-icon→iframe flow.

## Next (PR3)
View-tabs (`stage-subnav` from declared `tabs`) + the post-load `postMessage` auth/theming bridge + sandbox doc + `docs/guides/plugin-views.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)