### PR TITLE
feat(plugins): view-tabs + auth/theming bridge + docs (ADR 0026, PR3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,9 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   rebuild. Surfaces are keyed `plugin:<id>:<viewId>`; chat stays mounted (its
   continuity holds) while a plugin view is open. The `hello` example plugin now
   ships a demo view. The view is hosted by a dedicated `PluginView` component with
-  load/error states, and a stale-surface fallback returns to chat if a plugin
-  view's plugin is disabled while it's open. View-tabs + the auth/theming bridge
-  land in a follow-up slice. See
+  load/error states + a stale-surface fallback (returns to chat if a plugin view's
+  plugin is disabled while it's open). A view may declare **`tabs:`** (rendered as
+  a sub-nav that swaps the iframe page), and the console hands the hosted page the
+  operator **bearer + theme tokens via a post-load `postMessage`** (no token in the
+  URL) so it can call its own API and match the console look. The iframe is
+  sandboxed (`allow-scripts allow-forms allow-same-origin`). See
+  [the guide](docs/guides/plugin-views.md) and
   [ADR 0026](docs/adr/0026-plugin-contributed-console-surfaces.md).
 
 ## [0.18.0] - 2026-06-06

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -39,7 +39,13 @@ export const RUNTIME_STATUS = {
     {
       id: "boardy", name: "Boardy", version: "0.1.0", enabled: true, loaded: true, tools: [], skills: 0,
       views: [
-        { id: "board", label: "Board", icon: "LayoutDashboard", path: "/plugins/boardy/board" },
+        {
+          id: "board", label: "Board", icon: "LayoutDashboard", path: "/plugins/boardy/board",
+          tabs: [
+            { id: "open", label: "Open", path: "/plugins/boardy/board?tab=open" },
+            { id: "done", label: "Done", path: "/plugins/boardy/board?tab=done" },
+          ],
+        },
         { id: "stats", label: "Stats", icon: "BarChart3", path: "/plugins/boardy/stats" },
       ],
     },

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -249,6 +249,20 @@ const server = createServer(async (req, res) => {
     }
     return sendJson(res, { ok: true });
   }
+  // Plugin-served pages (ADR 0026) — a tiny listener page so the e2e can assert
+  // the console's post-load init handshake (token + theme via postMessage).
+  if (pathname.startsWith("/plugins/") && req.method === "GET") {
+    res.writeHead(200, { "content-type": "text/html; charset=utf-8" });
+    res.end(
+      `<!doctype html><html><body data-bridge="pending">` +
+      `<p id="p">${pathname}</p><script>` +
+      `window.addEventListener("message",function(e){var m=e.data||{};` +
+      `if(m.type!=="protoagent:init")return;` +
+      `document.body.setAttribute("data-bridge",m.token?"authed":"anon");});` +
+      `</script></body></html>`,
+    );
+    return;
+  }
   if (req.method !== "GET") {
     return sendJson(res, { detail: "method not allowed" }, 405);
   }

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -38,3 +38,23 @@ test("switches between two plugin views, each loading its own page", async ({ pa
   // exactly one plugin view is shown at a time
   await expect(frame).toHaveCount(1);
 });
+
+test("view-tabs switch the hosted page", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".rail").getByRole("button", { name: "Board", exact: true }).click();
+  const subnav = page.locator(".plugin-view .stage-subnav");
+  await expect(subnav.getByRole("button", { name: "Open", exact: true })).toBeVisible();
+  await expect(page.locator(".plugin-view-frame")).toHaveAttribute("src", /tab=open/);
+  await subnav.getByRole("button", { name: "Done", exact: true }).click();
+  await expect(page.locator(".plugin-view-frame")).toHaveAttribute("src", /tab=done/);
+});
+
+test("console hands the plugin view a bearer + theme via postMessage", async ({ page }) => {
+  // Seed an operator token so the console forwards it post-load.
+  await page.addInitScript(() => window.localStorage.setItem("protoagent.authToken", "e2e-token"));
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".rail").getByRole("button", { name: "Stats", exact: true }).click();
+  // The plugin page flips data-bridge on receiving protoagent:init with a token.
+  const body = page.frameLocator(".plugin-view-frame").locator("body");
+  await expect(body).toHaveAttribute("data-bridge", "authed");
+});

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -1,42 +1,96 @@
 import { AlertTriangle, Loader2 } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 
-import { apiUrl } from "../lib/api";
+import { apiUrl, authToken } from "../lib/api";
 import type { PluginView as PluginViewType } from "../lib/types";
 
+// Curated console theme tokens forwarded to a plugin view so it can match the
+// console look (ADR 0026 theming bridge).
+function consoleTheme(): Record<string, string> {
+  if (typeof window === "undefined") return {};
+  const s = getComputedStyle(document.documentElement);
+  const g = (n: string) => s.getPropertyValue(n).trim();
+  return {
+    bg: g("--bg"), bgPanel: g("--bg-panel"), fg: g("--fg"),
+    fgMuted: g("--fg-muted"), brand: g("--brand-violet-light"), border: g("--border"),
+  };
+}
+
 // Host for a plugin-contributed console surface (ADR 0026): a same-origin iframe
-// of the page the plugin serves, with a loading overlay and a failure fallback.
-// Mount with `key={view key}` so switching views resets load state.
+// of the page the plugin serves, with optional view-tabs, a loading overlay, a
+// failure fallback, and a post-load handshake that hands the page the operator
+// bearer + theme tokens via postMessage (never a token in the URL).
+// Mount with `key={view key}` so switching views resets state.
 export function PluginView({ view }: { view: PluginViewType }) {
+  const tabs = view.tabs ?? [];
+  const [activeTab, setActiveTab] = useState(tabs[0]?.id ?? "");
+  const src = useMemo(() => {
+    const t = tabs.find((x) => x.id === activeTab);
+    return t?.path ?? view.path;
+  }, [tabs, activeTab, view.path]);
+
   const [loaded, setLoaded] = useState(false);
   const [failed, setFailed] = useState(false);
+  // Reset load state when the loaded page changes (tab switch).
+  useEffect(() => {
+    setLoaded(false);
+    setFailed(false);
+  }, [src]);
+
+  function handleLoad(e: React.SyntheticEvent<HTMLIFrameElement>) {
+    setLoaded(true);
+    const win = e.currentTarget.contentWindow;
+    if (!win) return;
+    // Hand the page the bearer + theme AFTER load — same origin, targeted, not in
+    // the URL. The plugin page listens for `message` and uses them.
+    try {
+      const origin = new URL(apiUrl(src), window.location.href).origin;
+      win.postMessage(
+        { type: "protoagent:init", token: authToken() || null, theme: consoleTheme() },
+        origin,
+      );
+    } catch {
+      /* cross-origin / detached — best effort */
+    }
+  }
 
   return (
     <section className="panel stage-panel plugin-view">
-      {failed ? (
-        <div className="plugin-view-state" role="alert">
-          <AlertTriangle size={18} />
-          <span>Couldn’t load “{view.label}”. The plugin page at <code>{view.path}</code> didn’t respond.</span>
+      {tabs.length ? (
+        <div className="stage-subnav">
+          {tabs.map((t) => (
+            <button key={t.id} className={t.id === activeTab ? "active" : ""} onClick={() => setActiveTab(t.id)}>
+              {t.label}
+            </button>
+          ))}
         </div>
-      ) : (
-        <>
-          {!loaded ? (
-            <div className="plugin-view-state">
-              <Loader2 className="spin" size={18} />
-              <span>Loading {view.label}…</span>
-            </div>
-          ) : null}
-          <iframe
-            className="plugin-view-frame"
-            src={apiUrl(view.path)}
-            title={view.label}
-            sandbox="allow-scripts allow-forms allow-same-origin"
-            onLoad={() => setLoaded(true)}
-            onError={() => setFailed(true)}
-            style={{ visibility: loaded ? "visible" : "hidden" }}
-          />
-        </>
-      )}
+      ) : null}
+      <div className="plugin-view-body">
+        {failed ? (
+          <div className="plugin-view-state" role="alert">
+            <AlertTriangle size={18} />
+            <span>Couldn’t load “{view.label}”. The plugin page at <code>{src}</code> didn’t respond.</span>
+          </div>
+        ) : (
+          <>
+            {!loaded ? (
+              <div className="plugin-view-state">
+                <Loader2 className="spin" size={18} />
+                <span>Loading {view.label}…</span>
+              </div>
+            ) : null}
+            <iframe
+              className="plugin-view-frame"
+              src={apiUrl(src)}
+              title={view.label}
+              sandbox="allow-scripts allow-forms allow-same-origin"
+              onLoad={handleLoad}
+              onError={() => setFailed(true)}
+              style={{ visibility: loaded ? "visible" : "hidden" }}
+            />
+          </>
+        )}
+      </div>
     </section>
   );
 }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3106,7 +3106,8 @@ textarea {
 .delegate-health.down { color: #e0533a; }
 .delegate-health.unknown { color: var(--fg-muted); }
 
-/* Plugin-contributed console views (ADR 0026) — the iframe fills the stage. */
-.plugin-view { padding: 0; overflow: hidden; }
+/* Plugin-contributed console views (ADR 0026) — optional subnav above, iframe fills. */
+.plugin-view { padding: 0; overflow: hidden; display: flex; flex-direction: column; }
+.plugin-view-body { position: relative; flex: 1; min-height: 0; }
 .plugin-view-frame { width: 100%; height: 100%; border: 0; background: var(--bg); display: block; }
 .plugin-view-state { display: flex; align-items: center; gap: 8px; padding: 24px; color: var(--fg-muted); font-size: 13px; }

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,6 +55,7 @@ export default defineConfig({
             { text: "Skills (SKILL.md)", link: "/guides/skills" },
             { text: "MCP servers", link: "/guides/mcp" },
             { text: "Plugins", link: "/guides/plugins" },
+            { text: "Plugin console views", link: "/guides/plugin-views" },
             { text: "Goal mode", link: "/guides/goal-mode" },
             { text: "Scheduler", link: "/guides/scheduler" },
             { text: "Discord surface", link: "/guides/discord" },

--- a/docs/adr/0026-plugin-contributed-console-surfaces.md
+++ b/docs/adr/0026-plugin-contributed-console-surfaces.md
@@ -110,12 +110,13 @@ for the plugin page; core views are unaffected.
   the console renders **one** dynamic rail icon + iframe end-to-end. Proves the
   whole loop. (Hardcoded-to-registry refactor minimal: append plugin views after
   core surfaces.)
-- **PR2: rail registry + PluginView host.** Full data-driven rail
-  (`plugin:<id>:<viewId>` surfaces), the generic iframe `PluginView`, graceful
-  handling when a plugin is disabled/missing. e2e.
-- **PR3: view-tabs + auth/theming bridge + sandbox + docs.** Declared `tabs` →
-  `stage-subnav`; the `postMessage` token + theme handshake; sandbox attrs; a
-  `docs/guides/plugin-views.md` + a `reference/extensions` update.
+- **PR2 (shipped): rail registry + PluginView host.** Data-driven plugin rail
+  (`plugin:<id>:<viewId>`), the generic `PluginView` iframe host (load/error
+  states), stale-surface fallback (disabled/missing → chat). e2e (#620).
+- **PR3 (shipped): view-tabs + auth/theming bridge + sandbox + docs.** Declared
+  `tabs` → `stage-subnav`; the post-load `postMessage` token + theme handshake
+  (`protoagent:init`); sandbox attrs; the `hello` view is the reference receiver;
+  `docs/guides/plugin-views.md`.
 - **Later (optional): schema-driven views** (D1) for forks that want a native-look
   dashboard without serving their own page — a separate ADR if pursued.
 

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -34,4 +34,4 @@ decision, numbered, never deleted (supersede instead).
 | [0023](./0023-server-decomposition.md) | Decompose server.py: AppState + composition root | Accepted |
 | [0024](./0024-spawn-cli-coding-agents-acp.md) | Spawn CLI coding agents over ACP (`code_with`) | Accepted (PR1 + PR3) |
 | [0025](./0025-unified-delegate-registry-and-panel.md) | Unified delegate registry + hot-swappable panel (`delegate_to`) | Accepted (complete; PR1–PR4) |
-| [0026](./0026-plugin-contributed-console-surfaces.md) | Plugin-contributed console surfaces (rail views + tabs) | Accepted (sliced; PR1) |
+| [0026](./0026-plugin-contributed-console-surfaces.md) | Plugin-contributed console surfaces (rail views + tabs) | Accepted (complete; PR1–PR3) |

--- a/docs/guides/plugin-views.md
+++ b/docs/guides/plugin-views.md
@@ -1,0 +1,86 @@
+# Plugin console views (rail surfaces)
+
+A plugin can add its own **left-rail icon and view** to the operator console — a
+dashboard, board, or whatever UI the fork wants — by declaring it in the manifest
+and serving a page. **No console rebuild.** This is the frontend counterpart to
+[plugin tools/routes](/guides/plugins) and [plugin settings](/guides/plugins);
+see [ADR 0026](/adr/0026-plugin-contributed-console-surfaces).
+
+## Declare a view
+
+Add a `views:` block to `protoagent.plugin.yaml`:
+
+```yaml
+views:
+  - id: board                      # unique within the plugin
+    label: "Board"                 # rail + tab label
+    icon: LayoutDashboard          # a lucide-react icon name
+    path: /plugins/myplugin/board  # the page the iframe loads (you serve it)
+    tabs:                          # optional sub-nav (view-tabs)
+      - { id: open, label: "Open", path: /plugins/myplugin/board?tab=open }
+      - { id: done, label: "Done", path: /plugins/myplugin/board?tab=done }
+```
+
+The console reads this from `/api/runtime/status` and renders a rail icon per
+view (keyed `plugin:<id>:<viewId>`). When selected, it hosts `path` in a
+same-origin **iframe** that fills the stage; `tabs` render as a sub-nav that swaps
+the iframe page. `icon` is a [lucide](https://lucide.dev) name (unknown → a
+generic plugin glyph).
+
+## Serve the page
+
+The page is yours — any framework, or plain HTML. Serve it from the plugin's
+router (the same `register_router` that backs tools/routes):
+
+```python
+def _build_router():
+    from fastapi import APIRouter
+    from fastapi.responses import HTMLResponse
+    router = APIRouter()
+
+    @router.get("/board")          # mounted at /plugins/myplugin/board
+    async def _board():
+        return HTMLResponse("<!doctype html>… your UI …")
+    return router
+
+def register(registry):
+    registry.register_router(_build_router())
+```
+
+See the shipped [`plugins/hello`](https://github.com/protoLabsAI/protoAgent/tree/main/plugins/hello)
+for a worked example (a `views:` entry + a `/view` page).
+
+## The init handshake (bearer + theme)
+
+After the iframe loads, the console **posts a message** to it — so your page gets
+the operator bearer (for its own API calls) and the console theme tokens (to match
+the look) **without a token in the URL**:
+
+```js
+window.addEventListener("message", (e) => {
+  const m = e.data || {};
+  if (m.type !== "protoagent:init") return;
+  // m.token — operator bearer (or null when none is configured); use it as
+  //           `Authorization: Bearer <token>` for your /plugins/<id>/... calls.
+  // m.theme — { bg, bgPanel, fg, fgMuted, brand, border } from the console.
+  if (m.theme?.bg) document.body.style.background = m.theme.bg;
+});
+```
+
+The message is sent same-origin and targeted at your page's origin.
+
+## Trust & sandbox
+
+The view runs in an iframe with `sandbox="allow-scripts allow-forms allow-same-origin"`.
+This scopes the plugin's CSS/JS from the console — it is **not** a security
+boundary against a malicious enabled plugin: an enabled plugin already runs
+in-process as the agent (same trust model as [plugin backends](/guides/plugins)).
+Only enable plugins you trust.
+
+## Lifecycle
+
+- Views appear for **enabled** plugins; disabling one (or a config reload that
+  drops it) removes its rail icon and, if you were on it, falls back to Chat.
+- Mounting/serving is config-driven — adding a view to an existing plugin needs a
+  restart (routes mount once at init), but the rail picks up the declaration from
+  `runtime-status` with no console rebuild.

--- a/plugins/hello/__init__.py
+++ b/plugins/hello/__init__.py
@@ -47,21 +47,38 @@ def _build_router(greeting: str):
     async def _view():
         from fastapi.responses import HTMLResponse
 
+        # The page listens for the console's `protoagent:init` postMessage (ADR
+        # 0026 bridge) — the operator bearer (use it for your own API calls) + the
+        # console theme tokens (apply them to match the look). Reference receiver.
         html = f"""<!doctype html><html><head><meta charset="utf-8">
 <style>
   html,body{{margin:0;height:100%;background:#0a0f14;color:#e6e6e6;
     font-family:ui-sans-serif,system-ui,-apple-system,sans-serif;
     display:flex;align-items:center;justify-content:center;text-align:center}}
   .card{{padding:32px}} h1{{color:#9b87f2;margin:0 0 8px;font-size:22px}}
-  p{{color:#9aa0aa;font-size:14px;max-width:36ch;line-height:1.6}}
+  p{{color:#9aa0aa;font-size:14px;max-width:38ch;line-height:1.6}}
   code{{background:#161b22;padding:2px 6px;border-radius:5px;color:#9b87f2}}
+  #bridge{{margin-top:14px;font-size:12px;color:#46c46a}}
 </style></head><body><div class="card">
   <h1>{greeting} from a plugin view</h1>
-  <p>This page is served by <code>plugins/hello</code> at
-  <code>/plugins/hello/view</code> and embedded in the console rail via the
-  <code>views:</code> manifest block (ADR 0026). A fork drops a directory like
-  this and gets its own rail icon + dashboard — no console rebuild.</p>
-</div></body></html>"""
+  <p>Served by <code>plugins/hello</code> at <code>/plugins/hello/view</code> and
+  embedded in the console rail via the <code>views:</code> manifest block
+  (ADR 0026). A fork drops a directory like this and gets its own rail icon +
+  dashboard — no console rebuild.</p>
+  <p id="bridge">awaiting console handshake…</p>
+</div>
+<script>
+  window.addEventListener("message", function (e) {{
+    var m = e.data || {{}};
+    if (m.type !== "protoagent:init") return;
+    document.getElementById("bridge").textContent =
+      (m.token ? "✓ authed by the console" : "no token (open API)") +
+      (m.theme ? " · theme received" : "");
+    if (m.theme && m.theme.bg) document.body.style.background = m.theme.bg;
+    if (m.theme && m.theme.fg) document.body.style.color = m.theme.fg;
+  }});
+</script>
+</body></html>"""
         return HTMLResponse(html)
 
     return router


### PR DESCRIPTION
Final slice of ADR 0026 — completes plugin-contributed console surfaces.

## What
- **View-tabs** — a view may declare `tabs: [{id,label,path}]`; `PluginView` renders a `stage-subnav` that swaps the hosted page (load state resets per page).
- **Auth/theming bridge** — after the iframe loads, the console `postMessage`s `{type:"protoagent:init", token, theme}` to the page: the operator **bearer** (for the page's own API calls) + the console **theme tokens** (to match the look). Targeted at the page's origin, **never in the URL**. The `hello` `/view` page is the reference receiver (applies the theme, shows "authed").
- **Sandbox** documented: `allow-scripts allow-forms allow-same-origin` — CSS/JS isolation, *not* a security boundary (an enabled plugin already runs as the agent, ADR 0018 trust).
- **Docs** — `docs/guides/plugin-views.md` + sidebar; ADR 0026 marked complete.

## Test
```
$ npx playwright test plugin-views
4 passed   (rail icon → iframe · multi-view switch · view-tabs · postMessage handshake)
$ pytest tests/test_plugins.py   # green
$ npm run build — green
```
The bridge e2e: the mock serves a listener page that flips `data-bridge="authed"` on receiving `protoagent:init` with a token (seeded in localStorage) — asserting the full handshake.

## ADR 0026 complete
PR1 (#619) declaration + rail + iframe · PR2 (#620) PluginView host + stale fallback · **PR3 (this)** tabs + bridge + docs. Forks can now add their own rail dashboards — backend (0018) + settings (0019) + **surfaces (0026)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)