### PR TITLE
feat(plugins): install from a git URL — installer core + CLI (ADR 0027, PR1)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,12 @@ config/langgraph-config.yaml
 # the wizard has been run. Not config to commit.
 config/.setup-complete
 
+# Git-installed plugins (ADR 0027) — code fetched from a URL into the live plugins
+# dir. NOT committed; it's reproducible from the committed `plugins.lock` via
+# `python -m server plugin sync`. (The lock IS committed — see !plugins.lock.)
+config/plugins/
+!plugins.lock
+
 # Local-run artifacts — autostart stdout/stderr logs + memory middleware
 # fallback directory when /sandbox is not available.
 logs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Install plugins from a git URL** (ADR 0027, PR1) — `python -m server plugin
+  install <git-url> [--ref <tag|sha>]` clones a plugin repo into the live plugins
+  dir (already discovered by the loader), **pinned to a resolved commit SHA** and
+  recorded in a committed **`plugins.lock`** for reproducible installs
+  (`plugin sync` re-clones the exact set). Also `plugin list` / `uninstall` /
+  `sync`. Safety baked in: **install ≠ enable ≠ trust** — it only fetches code +
+  reads the manifest (data), never imports the plugin and never pip-installs its
+  deps (`requires_pip` is declared, installed explicitly); it refuses to shadow a
+  built-in, rejects a repo with no manifest, drops git metadata, skips submodules,
+  and supports an optional `plugins.sources.allow` allowlist. Manifest gains
+  `requires_pip` / `repository` / `homepage` / `min_protoagent_version`. Console
+  panel + capability-review/audit land in follow-up slices. See
+  [ADR 0027](docs/adr/0027-install-plugins-from-git-url.md).
+
 ## [0.19.0] - 2026-06-06
 
 ### Added

--- a/docs/adr/0027-install-plugins-from-git-url.md
+++ b/docs/adr/0027-install-plugins-from-git-url.md
@@ -1,0 +1,134 @@
+# 0027 — Install plugins from a git URL (shareable plugin repos)
+
+Status: **Accepted** (sliced)
+
+## Context
+
+Plugins ([ADR 0018](./0018-plugin-surfaces-routes-subagents.md) backend,
+[0019](./0019-plugin-config-settings-secrets.md) settings,
+[0026](./0026-plugin-contributed-console-surfaces.md) console surfaces) are a
+full extension surface — but today a plugin must live **in-repo** (`plugins/`).
+There's no way to make one in its own GitHub repo and share it. ComfyUI
+popularized git-URL "custom nodes"; we want the same for protoAgent — author a
+plugin repo, install it by URL — without ComfyUI's "clone = arbitrary code runs"
+safety posture. This is the long-deferred Slice 5 (registry/marketplace) of
+[ADR 0001](./0001-extensibility-and-plugin-architecture.md).
+
+Two facts shape the design:
+- **The seam already exists.** `graph/plugins/loader.py::_plugin_roots()` already
+  discovers an **external** plugins dir (`<config_dir>/plugins`, outside the repo),
+  and discovery reads `protoagent.plugin.yaml` as **data without importing** the
+  plugin. So *fetching* a plugin never executes its code; only *enabling* it does.
+- **In-process plugins share the interpreter.** Installing one means trusting its
+  code — exactly like adding a pip dependency. You **cannot** sandbox it with a
+  per-plugin venv (the code runs in the main interpreter). True isolation of
+  *untrusted* code is what **MCP** already provides (out-of-process, declared
+  tools). So git-URL plugins are best framed as **trusted, reviewed code**.
+
+## Decision
+
+A `plugin install <git-url>` flow (CLI **and** console) that clones into the
+external plugins dir, pins to a resolved commit, records a lockfile, surfaces the
+manifest + capabilities for review, and **never auto-enables or auto-runs code**.
+
+### D1 — Trust model: install ≠ enable ≠ trust
+
+Git-URL plugins are **trusted, in-process code** (you reviewed it, like a pip dep).
+The three steps are distinct:
+- **Install** = `git clone` + checkout pinned ref → code on disk. No import, no
+  execution (deps are **not** pip-installed — D4).
+- **Discover** = read the manifest (data). No import.
+- **Enable** = `plugins.enabled` → `register()` runs. **This** is the trust decision.
+
+For **untrusted** third-party code, use **MCP** (out-of-process, sandboxable), not
+a git plugin. Stated prominently in the docs + the install review.
+
+### D2 — Install location + reproducibility (lockfile, pinned SHA)
+
+Clone into `<config_dir>/plugins/<id>/` (already on `_plugin_roots`; gitignored
+from the fork). Record every install in a committed **`plugins.lock`**:
+`{id, source_url, requested_ref, resolved_sha, installed_at, by}`. Always pin to a
+**resolved commit SHA** — never silently track a moving branch. `plugin sync`
+re-clones the exact set from the lock (reproducible forks / CI / containers).
+
+### D3 — Source posture: any URL + mandatory review gate (+ optional allowlist)
+
+Any git URL is allowed, but **every install requires an explicit confirm** showing:
+source URL, resolved SHA, manifest (id/name/version/description/repository), declared
+capabilities (network/fs/secrets), and what it contributes (tools/views/routes/
+subagents). A fork can lock down with `plugins.sources.allow: [github.com/org/*]`
+(refuse anything off-allowlist). **Default: open + gated** (builder-friendly, never
+silent).
+
+### D4 — Dependencies: declare-only, explicit install (no surprise code-exec)
+
+Manifest gains `requires_pip: ["pkg>=x"]`. **`plugin install` fetches code only — it
+does NOT pip-install** (pip runs arbitrary `setup.py`/build code, which would defeat
+"install ≠ execute"). The operator installs deps as a **separate explicit step**
+(`plugin install-deps <id>`, or the shown `pip install` line) after reviewing them.
+Missing deps → the plugin fails to import on **enable** with a clear "declared deps
+not installed: …" message, not a cryptic ImportError.
+
+### D5 — Capabilities surfaced + audited (enforcement iterates)
+
+Before enable, surface declared capabilities (network hosts, filesystem scope,
+secrets requested, tools/views/routes added) for operator review. Audit-log
+install / enable / disable / uninstall (url, sha, operator, time) to the existing
+audit log. **No hard in-process enforcement in v1** — honest: you can't sandbox
+in-process Python. A per-plugin egress allowlist + fs fencing is a documented
+fast-follow; untrusted code → MCP (D1).
+
+### D6 — Lifecycle: CLI **and** console
+
+- **CLI** (`python -m server plugin …`): `install <url> [--ref <tag|sha>] [--enable]`,
+  `list`, `enable/disable <id>`, `uninstall <id>`, `sync` (from lock),
+  `install-deps <id>`. `--enable` is opt-in; bare install does **not** enable (D1).
+- **Console** (Settings → **Plugins**): paste URL → review card (manifest + caps +
+  resolved SHA) → install → enable toggle → uninstall. Mirrors the delegates panel.
+
+### D7 — Manifest additions (all data, all optional)
+
+`requires_pip: [..]` (D4); `repository:` / `homepage:` (provenance, shown in review);
+`min_protoagent_version:` (compat — warn/refuse if the host is older).
+
+### D8 — Integrity rails
+
+- Pin to resolved SHA (D2); `--ref` accepts tag/branch/sha → resolved + recorded.
+- Clone `--depth 1` at the ref; **no submodules** by default (a vector).
+- Validate the manifest (id matches dir, required fields) before accepting; reject
+  a repo with no `protoagent.plugin.yaml` (not a plugin).
+- Refuse to overwrite a built-in or existing id without `--force` (no silent
+  shadowing).
+- Uninstall removes the dir + the lock entry. Cloned-but-disabled plugins are inert
+  (discovery is data-only).
+
+### D9 — Slices
+
+- **PR1:** manifest additions (`requires_pip`/`repository`/`min_protoagent_version`)
+  + installer core (clone → resolve SHA → validate manifest → write `plugins.lock`)
+  + `plugin list/install/uninstall/sync` CLI (no enable, no dep auto-run). Tests.
+- **PR2:** console **Plugins** panel + the install/review/uninstall API (paste URL →
+  review card → install → enable/disable → uninstall). e2e.
+- **PR3:** `requires_pip` + `install-deps` + missing-dep diagnostics; capability
+  review surfacing + audit logging; `plugins.sources.allow` enforcement; docs
+  (`guides/plugin-registry.md` "install + publish a plugin" + the untrusted→MCP note).
+
+## Consequences
+
+- People author plugins as **standalone GitHub repos** and forks install them by
+  URL with a **reproducible lock** + an **informed review gate**. Completes the
+  extensibility arc: author (0018) → settings (0019) → surfaces (0026) →
+  **distribute (0027)**.
+- Safety is **informed trust + verifiable supply chain + audit**, not a sandbox —
+  stated honestly; untrusted code routes to MCP.
+- A future curated **index/registry** is a thin layer on top (it still installs via
+  this path).
+
+## Alternatives considered
+
+- **Auto-enable on install** — rejected: install ≠ trust (D1).
+- **Auto pip-install on install** — rejected: surprise code-exec (D4).
+- **Per-plugin venv isolation** — impossible for in-process plugins (shared
+  interpreter); real isolation = out-of-process = MCP.
+- **Central registry/index first** — deferred: URL install is the primitive; an
+  index is curation on top.

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -35,3 +35,4 @@ decision, numbered, never deleted (supersede instead).
 | [0024](./0024-spawn-cli-coding-agents-acp.md) | Spawn CLI coding agents over ACP (`code_with`) | Accepted (PR1 + PR3) |
 | [0025](./0025-unified-delegate-registry-and-panel.md) | Unified delegate registry + hot-swappable panel (`delegate_to`) | Accepted (complete; PR1–PR4) |
 | [0026](./0026-plugin-contributed-console-surfaces.md) | Plugin-contributed console surfaces (rail views + tabs) | Accepted (complete; PR1–PR3) |
+| [0027](./0027-install-plugins-from-git-url.md) | Install plugins from a git URL (shareable plugin repos) | Accepted (sliced) |

--- a/graph/plugins/cli.py
+++ b/graph/plugins/cli.py
@@ -1,0 +1,74 @@
+"""`python -m server plugin …` — manage git-installed plugins (ADR 0027).
+
+A thin CLI over ``graph.plugins.installer``. Install fetches code only (it never
+enables the plugin or installs its deps — both are explicit, by design).
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from graph.plugins import installer
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m server plugin",
+        description="Install/manage plugins from git URLs (ADR 0027).",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pi = sub.add_parser("install", help="install a plugin from a git URL (does NOT enable it)")
+    pi.add_argument("url", help="git URL (https://, ssh://, git@, or a local path)")
+    pi.add_argument("--ref", default=None, help="tag, branch, or commit SHA to pin (default: default branch HEAD)")
+    pi.add_argument("--force", action="store_true", help="replace an already-installed plugin of the same id")
+
+    sub.add_parser("list", help="list git-installed plugins (from plugins.lock)")
+    pu = sub.add_parser("uninstall", help="remove a git-installed plugin")
+    pu.add_argument("id")
+    sub.add_parser("sync", help="re-clone locked plugins at their pinned SHA (reproducible set)")
+    return p
+
+
+def run_plugin_cli(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.cmd == "install":
+            s = installer.install(args.url, args.ref, force=args.force)
+            print(f"✓ installed {s['id']} v{s['version']} @ {s['resolved_sha'][:10]}")
+            if s["description"]:
+                print(f"  {s['description']}")
+            if s["repository"]:
+                print(f"  repo: {s['repository']}")
+            if s["requires_pip"]:
+                print(f"  ⚠ declared deps (NOT installed — review, then install): {', '.join(s['requires_pip'])}")
+                print(f"    pip install {' '.join(s['requires_pip'])}")
+            if s["contributes"]["views"]:
+                print(f"  contributes views: {', '.join(s['contributes']['views'])}")
+            if s["capabilities"]:
+                print(f"  declared capabilities: {s['capabilities']}")
+            print(f"  NOT enabled. To enable, add '{s['id']}' to plugins.enabled in your config, then restart.")
+            return 0
+        if args.cmd == "list":
+            rows = installer.list_installed()
+            if not rows:
+                print("(no git-installed plugins)")
+                return 0
+            for e in rows:
+                mark = "" if e.get("present") else "  [MISSING — run `plugin sync`]"
+                print(f"  {e['id']:20} {e['resolved_sha'][:10]}  {e['source_url']}{mark}")
+            return 0
+        if args.cmd == "uninstall":
+            installer.uninstall(args.id)
+            print(f"✓ uninstalled {args.id}")
+            return 0
+        if args.cmd == "sync":
+            for r in installer.sync():
+                extra = f" ({r['error']})" if r.get("error") else ""
+                print(f"  {r['id']}: {r['status']}{extra}")
+            return 0
+    except installer.InstallError as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        return 1
+    return 0

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -1,0 +1,218 @@
+"""Install plugins from a git URL (ADR 0027).
+
+Fetches a plugin repo into the **live** plugins dir (``<config_dir>/plugins/<id>``,
+the one ``loader._plugin_roots`` already discovers), pinned to a resolved commit
+SHA and recorded in a committed ``plugins.lock`` for reproducibility.
+
+Safety model (ADR 0027): **install ≠ enable ≠ trust**. This module only puts code
+on disk + reads the manifest (data) — it never imports the plugin and never
+pip-installs its deps (``requires_pip`` is declared, installed explicitly later).
+Enabling (``plugins.enabled`` → ``register()``) is the separate trust decision.
+For *untrusted* code use MCP (out-of-process), not a git plugin.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import re
+import shutil
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from graph.config_io import _BUNDLE_CONFIG_DIR, _live_config_dir
+from graph.plugins.manifest import PluginManifest, load_manifest
+
+log = logging.getLogger(__name__)
+
+REPO_ROOT = _BUNDLE_CONFIG_DIR.parent
+LOCK_PATH = Path(os.environ.get("PROTOAGENT_PLUGINS_LOCK", str(REPO_ROOT / "plugins.lock")))
+
+_SHA_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
+_ALLOWED_SCHEMES = ("https://", "http://", "git://", "ssh://", "git@", "file://", "/")
+
+
+class InstallError(RuntimeError):
+    """A plugin install/uninstall/sync failed (bad URL, manifest, git, collision)."""
+
+
+def live_plugins_dir() -> Path:
+    """Where git-installed plugins land — the live dir the loader discovers."""
+    override = os.environ.get("PROTOAGENT_PLUGINS_DIR", "")
+    return Path(override).expanduser() if override else (_live_config_dir() / "plugins")
+
+
+def _git(*args: str, cwd: Path | None = None) -> str:
+    proc = subprocess.run(
+        ["git", *args], cwd=str(cwd) if cwd else None,
+        capture_output=True, text=True,
+    )
+    if proc.returncode != 0:
+        raise InstallError(f"git {' '.join(args)} failed: {proc.stderr.strip() or proc.stdout.strip()}")
+    return proc.stdout.strip()
+
+
+def _validate_url(url: str) -> None:
+    if not any(url.startswith(s) for s in _ALLOWED_SCHEMES):
+        raise InstallError(
+            f"unsupported source {url!r} — use https://, ssh://, git@, or a local path."
+        )
+
+
+def _source_allowed(url: str, allow: list[str] | None) -> bool:
+    """Optional fork lock-down (ADR 0027 D3): if an allowlist is configured, the
+    URL must match one of its host/org globs (e.g. ``github.com/protoLabsAI/*``)."""
+    if not allow:
+        return True
+    import fnmatch
+    norm = re.sub(r"^(https?://|git://|ssh://|git@)", "", url).replace(":", "/")
+    return any(fnmatch.fnmatch(norm, pat) or fnmatch.fnmatch(norm, pat + "*") for pat in allow)
+
+
+def _read_lock() -> dict:
+    if LOCK_PATH.exists():
+        try:
+            return json.loads(LOCK_PATH.read_text())
+        except (json.JSONDecodeError, OSError):
+            log.warning("[plugins] %s is unreadable — starting a fresh lock", LOCK_PATH)
+    return {"plugins": []}
+
+
+def _write_lock(data: dict) -> None:
+    data["plugins"].sort(key=lambda e: e.get("id", ""))
+    LOCK_PATH.write_text(json.dumps(data, indent=2) + "\n")
+
+
+def _summary(m: PluginManifest, *, source: str, ref: str, sha: str) -> dict:
+    return {
+        "id": m.id, "name": m.name, "version": m.version, "description": m.description,
+        "source_url": source, "requested_ref": ref, "resolved_sha": sha,
+        "repository": m.repository, "homepage": m.homepage,
+        "capabilities": m.capabilities, "requires_env": m.requires_env,
+        "requires_pip": m.requires_pip, "min_protoagent_version": m.min_protoagent_version,
+        # what it contributes — surfaced in the install review (ADR 0027 D3)
+        "contributes": {
+            "tools": bool(m.config_section),  # heuristic; real tool list needs import
+            "views": [v.get("label") for v in m.views],
+            "secrets": m.secrets,
+            "settings": [s.get("key") for s in m.settings],
+        },
+    }
+
+
+def _clone(url: str, ref: str | None, dest: Path) -> str:
+    """Clone ``url`` at ``ref`` into ``dest``; return the resolved commit SHA."""
+    if ref and _SHA_RE.match(ref):
+        # A specific commit: full clone (shallow can't reliably check out an
+        # arbitrary SHA), then check it out.
+        _git("clone", "--no-recurse-submodules", url, str(dest))
+        _git("checkout", ref, cwd=dest)
+    elif ref:
+        # A tag or branch: shallow clone of just that ref.
+        _git("clone", "--depth", "1", "--no-recurse-submodules", "--branch", ref, url, str(dest))
+    else:
+        _git("clone", "--depth", "1", "--no-recurse-submodules", url, str(dest))
+    return _git("rev-parse", "HEAD", cwd=dest)
+
+
+def install(url: str, ref: str | None = None, *, force: bool = False,
+            by: str = "cli", allow: list[str] | None = None) -> dict:
+    """Clone a plugin from ``url`` (at ``ref``) into the live plugins dir, pinned
+    to its resolved SHA, and record it in ``plugins.lock``. Does NOT enable it or
+    install its deps. Returns the install summary."""
+    _validate_url(url)
+    if not _source_allowed(url, allow):
+        raise InstallError(
+            f"source {url!r} is not on plugins.sources.allow — add it or install from an allowed origin."
+        )
+
+    target_root = live_plugins_dir()
+    target_root.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.TemporaryDirectory(prefix="pa-plugin-") as tmp:
+        staging = Path(tmp) / "repo"
+        sha = _clone(url, ref, staging)
+
+        manifest = load_manifest(staging)
+        if manifest is None:
+            raise InstallError(
+                f"{url!r} has no valid protoagent.plugin.yaml — not a protoAgent plugin."
+            )
+        pid = manifest.id
+
+        # No silent shadowing of a built-in (repo) plugin.
+        if (REPO_ROOT / "plugins" / pid).exists():
+            raise InstallError(f"plugin id {pid!r} is a built-in — cannot install over it.")
+
+        target = target_root / pid
+        if target.exists():
+            if not force:
+                raise InstallError(f"plugin {pid!r} already installed — use --force to replace.")
+            shutil.rmtree(target)
+
+        shutil.rmtree(staging / ".git", ignore_errors=True)  # drop git metadata; lock holds provenance
+        shutil.move(str(staging), str(target))
+        manifest = load_manifest(target) or manifest  # re-read from final path
+
+    summary = _summary(manifest, source=url, ref=ref or "", sha=sha)
+    lock = _read_lock()
+    lock["plugins"] = [e for e in lock["plugins"] if e.get("id") != pid]
+    lock["plugins"].append({
+        "id": pid, "source_url": url, "requested_ref": ref or "",
+        "resolved_sha": sha, "installed_at": datetime.now(timezone.utc).isoformat(), "by": by,
+    })
+    _write_lock(lock)
+    log.info("[plugins] installed %s@%s from %s", pid, sha[:10], url)
+    return summary
+
+
+def uninstall(plugin_id: str) -> bool:
+    """Remove a git-installed plugin (live dir + lock entry). Built-ins are refused."""
+    if (REPO_ROOT / "plugins" / plugin_id).exists():
+        raise InstallError(f"{plugin_id!r} is a built-in plugin — not removable via uninstall.")
+    target = live_plugins_dir() / plugin_id
+    removed = False
+    if target.exists():
+        shutil.rmtree(target)
+        removed = True
+    lock = _read_lock()
+    before = len(lock["plugins"])
+    lock["plugins"] = [e for e in lock["plugins"] if e.get("id") != plugin_id]
+    if len(lock["plugins"]) != before:
+        _write_lock(lock)
+        removed = True
+    if not removed:
+        raise InstallError(f"plugin {plugin_id!r} is not installed.")
+    log.info("[plugins] uninstalled %s", plugin_id)
+    return True
+
+
+def list_installed() -> list[dict]:
+    """Lock entries, annotated with whether the code is present on disk."""
+    out = []
+    root = live_plugins_dir()
+    for e in _read_lock()["plugins"]:
+        out.append({**e, "present": (root / e["id"]).exists()})
+    return out
+
+
+def sync(*, allow: list[str] | None = None) -> list[dict]:
+    """Re-clone every locked plugin at its pinned SHA (reproducible install set).
+    Missing ones are fetched; present ones are left as-is."""
+    results = []
+    root = live_plugins_dir()
+    for e in _read_lock()["plugins"]:
+        pid = e["id"]
+        if (root / pid).exists():
+            results.append({"id": pid, "status": "present"})
+            continue
+        try:
+            install(e["source_url"], e.get("resolved_sha") or e.get("requested_ref") or None,
+                    force=True, by="sync", allow=allow)
+            results.append({"id": pid, "status": "installed"})
+        except InstallError as exc:
+            results.append({"id": pid, "status": "failed", "error": str(exc)})
+    return results

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -45,6 +45,15 @@ class PluginManifest:
     # data so it's known without importing the plugin, and surfaced to the
     # frontend via /api/runtime/status. Each: {id, label, icon, path, tabs?}.
     views: list[dict] = field(default_factory=list)
+    # Distribution (ADR 0027) — for plugins installed from a git URL.
+    #   requires_pip: declared pip deps. NOT auto-installed (install ≠ code exec);
+    #     the operator installs them explicitly. Missing → clear error on enable.
+    #   repository/homepage: provenance, shown in the install review.
+    #   min_protoagent_version: compat guard (warn/refuse on an older host).
+    requires_pip: list[str] = field(default_factory=list)
+    repository: str = ""
+    homepage: str = ""
+    min_protoagent_version: str = ""
 
 
 def load_manifest(plugin_dir: Path) -> PluginManifest | None:
@@ -80,6 +89,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     secrets = data.get("secrets")
     settings = data.get("settings")
     views = data.get("views")
+    requires_pip = data.get("requires_pip")
     return PluginManifest(
         id=pid,
         name=name,
@@ -96,4 +106,8 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
         settings=[s for s in settings if isinstance(s, dict)] if isinstance(settings, (list, tuple)) else [],
         views=[v for v in views if isinstance(v, dict) and v.get("id") and v.get("path")]
         if isinstance(views, (list, tuple)) else [],
+        requires_pip=[str(x) for x in requires_pip] if isinstance(requires_pip, (list, tuple)) else [],
+        repository=str(data.get("repository", "")).strip(),
+        homepage=str(data.get("homepage", "")).strip(),
+        min_protoagent_version=str(data.get("min_protoagent_version", "")).strip(),
     )

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -273,6 +273,14 @@ from server.agent_init import (  # noqa: E402,F401 — re-export of the extracte
 
 def _main():
 
+    # Plugin management subcommand (ADR 0027): `python -m server plugin install
+    # <git-url>` (+ list/uninstall/sync). Handled before the server argparse —
+    # it fetches code to disk and exits, never starting the server.
+    if len(sys.argv) > 1 and sys.argv[1] == "plugin":
+        from graph.plugins.cli import run_plugin_cli
+
+        raise SystemExit(run_plugin_cli(sys.argv[2:]))
+
     # Frozen-binary entrypoint for a plugin's managed MCP server (ADR 0019): the
     # bundled desktop app has no `python` on PATH, so a plugin's managed-server
     # factory re-invokes this binary with `--mcp-plugin <id>` instead of `-m

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -1,0 +1,119 @@
+"""Git-URL plugin installer (ADR 0027) — fetch ≠ enable ≠ trust."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from graph.plugins import installer
+
+
+def _git(cwd: Path, *args: str) -> None:
+    subprocess.run(["git", *args], cwd=str(cwd), check=True, capture_output=True)
+
+
+def _make_plugin_repo(root: Path, pid: str = "demo_ext", manifest_extra: str = "", tag: str | None = None) -> Path:
+    repo = root / f"src-{pid}"
+    repo.mkdir(parents=True)
+    (repo / "protoagent.plugin.yaml").write_text(
+        f"id: {pid}\nname: Demo Ext\nversion: 0.1.0\ndescription: a test plugin\n{manifest_extra}"
+    )
+    (repo / "__init__.py").write_text("def register(registry):\n    pass\n")
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init")
+    if tag:
+        _git(repo, "tag", tag)
+    return repo
+
+
+@pytest.fixture
+def env(tmp_path, monkeypatch):
+    """Point the installer's lock + install dir at a temp area (never the real repo)."""
+    monkeypatch.setattr(installer, "LOCK_PATH", tmp_path / "plugins.lock")
+    monkeypatch.setenv("PROTOAGENT_PLUGINS_DIR", str(tmp_path / "installed"))
+    return tmp_path
+
+
+def test_install_fetches_code_writes_lock_does_not_enable(env):
+    repo = _make_plugin_repo(env)
+    summary = installer.install(str(repo))
+
+    assert summary["id"] == "demo_ext"
+    assert len(summary["resolved_sha"]) == 40
+    # code landed in the live plugins dir, git metadata stripped
+    target = installer.live_plugins_dir() / "demo_ext"
+    assert (target / "protoagent.plugin.yaml").exists()
+    assert not (target / ".git").exists()
+    # lock recorded with provenance
+    locked = installer.list_installed()
+    assert locked[0]["id"] == "demo_ext" and locked[0]["present"] is True
+    assert locked[0]["resolved_sha"] == summary["resolved_sha"]
+    # install ≠ enable: nothing enabled it (no config touched, no register run)
+
+
+def test_install_pins_a_tag(env):
+    repo = _make_plugin_repo(env, tag="v1")
+    summary = installer.install(str(repo), "v1")
+    assert summary["requested_ref"] == "v1" and len(summary["resolved_sha"]) == 40
+
+
+def test_duplicate_requires_force(env):
+    repo = _make_plugin_repo(env)
+    installer.install(str(repo))
+    with pytest.raises(installer.InstallError, match="already installed"):
+        installer.install(str(repo))
+    installer.install(str(repo), force=True)  # ok with force
+
+
+def test_refuses_to_shadow_a_builtin(env):
+    # `hello` is a real built-in plugin in the repo — must not be installable over.
+    repo = _make_plugin_repo(env, pid="hello")
+    with pytest.raises(installer.InstallError, match="built-in"):
+        installer.install(str(repo))
+
+
+def test_repo_without_manifest_is_rejected(env, tmp_path):
+    bare = tmp_path / "src-bare"
+    bare.mkdir()
+    (bare / "README.md").write_text("not a plugin")
+    _git(bare, "init", "-q")
+    _git(bare, "add", "-A")
+    _git(bare, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "x")
+    with pytest.raises(installer.InstallError, match="not a protoAgent plugin"):
+        installer.install(str(bare))
+
+
+def test_bad_url_scheme_rejected(env):
+    with pytest.raises(installer.InstallError, match="unsupported source"):
+        installer.install("ftp://evil.example/x.git")
+
+
+def test_uninstall_removes_code_and_lock(env):
+    repo = _make_plugin_repo(env)
+    installer.install(str(repo))
+    installer.uninstall("demo_ext")
+    assert not (installer.live_plugins_dir() / "demo_ext").exists()
+    assert installer.list_installed() == []
+    with pytest.raises(installer.InstallError, match="not installed"):
+        installer.uninstall("demo_ext")
+
+
+def test_sync_recolones_missing_from_lock(env):
+    repo = _make_plugin_repo(env)
+    installer.install(str(repo))
+    # simulate a fresh checkout: code gone, lock present
+    import shutil
+    shutil.rmtree(installer.live_plugins_dir() / "demo_ext")
+    assert installer.list_installed()[0]["present"] is False
+    results = installer.sync()
+    assert results == [{"id": "demo_ext", "status": "installed"}]
+    assert (installer.live_plugins_dir() / "demo_ext").exists()
+
+
+def test_source_allowlist_blocks_offlist(env):
+    repo = _make_plugin_repo(env)
+    with pytest.raises(installer.InstallError, match="not on plugins.sources.allow"):
+        installer.install(str(repo), allow=["github.com/protoLabsAI/*"])


### PR DESCRIPTION
The capstone of the extensibility arc — author a plugin in its own GitHub repo, install it by URL (ComfyUI-style), but with a **real safety model**.

## Safety: install ≠ enable ≠ trust
- **Install** clones the repo, pins a **resolved commit SHA**, validates the manifest, and drops the code into the live plugins dir. It does **not** import the plugin and does **not** pip-install its deps — so fetching never runs plugin code.
- **Enable** (`plugins.enabled` → `register()`) is the separate trust decision.
- Untrusted code → **MCP** (out-of-process), not a git plugin (in-process plugins share the interpreter — installing one trusts it, like a pip dep). Stated in the ADR.

Rails: refuses to shadow a built-in · rejects a repo with no `protoagent.plugin.yaml` · `--depth 1`, no submodules · strips `.git` · optional `plugins.sources.allow` allowlist · validated URL schemes.

## Reproducible
Every install is recorded in a committed **`plugins.lock`** (`{id, source_url, requested_ref, resolved_sha, installed_at, by}`); `plugin sync` re-clones the exact pinned set (CI / containers / fresh checkouts). The code itself is gitignored.

## CLI
```
python -m server plugin install <git-url> [--ref <tag|sha>] [--force]
python -m server plugin list | uninstall <id> | sync
```
`install` does NOT enable (prints how to). Declared `requires_pip` is shown but **not** installed.

## Manifest additions
`requires_pip`, `repository`, `homepage`, `min_protoagent_version` (all optional data).

## Test
```
$ pytest tests/test_plugin_installer.py tests/test_plugins.py   # 28 passed
$ pytest -q                                                      # 1136 passed
$ ruff — clean
```
Plus a live CLI smoke (install → list → uninstall, isolated; no repo pollution).

## Next
- **PR2** — console **Plugins** panel (paste URL → review card → install/enable/uninstall) + API.
- **PR3** — `install-deps` + missing-dep diagnostics, capability review surfacing + audit, `plugins.sources.allow` enforcement wiring, docs (install + publish + untrusted→MCP).

🤖 Generated with [Claude Code](https://claude.com/claude-code)