### PR TITLE
feat(plugins): full-bundle repos — workflows + skills auto-discovery + docs (ADR 0027, PR4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   clear "declared deps not installed — run install-deps" diagnostic when an enabled
   plugin's deps are missing; **audit logging** of install/uninstall/install-deps;
   and a **`plugins.sources.allow`** allowlist (host/org globs) enforced on CLI +
-  console installs. See
+  console installs. PR4 makes a plugin repo a **full bundle**: `register()` already
+  contributes tools / subagents / routes / MCP / views, and conventional
+  **`skills/`** (SKILL.md) + **`workflows/`** (`*.yaml`) subdirs are now
+  auto-discovered (data — no boilerplate; `register_workflow_dir()` for non-standard
+  paths), so installing a repo pulls in skills + workflows too. Publish + install
+  guide: [`plugin-registry.md`](docs/guides/plugin-registry.md). See
   [ADR 0027](docs/adr/0027-install-plugins-from-git-url.md).
 
 ## [0.19.0] - 2026-06-06

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,7 @@ export default defineConfig({
             { text: "MCP servers", link: "/guides/mcp" },
             { text: "Plugins", link: "/guides/plugins" },
             { text: "Plugin console views", link: "/guides/plugin-views" },
+            { text: "Install & publish plugins (git URLs)", link: "/guides/plugin-registry" },
             { text: "Goal mode", link: "/guides/goal-mode" },
             { text: "Scheduler", link: "/guides/scheduler" },
             { text: "Discord surface", link: "/guides/discord" },

--- a/docs/adr/0027-install-plugins-from-git-url.md
+++ b/docs/adr/0027-install-plugins-from-git-url.md
@@ -110,8 +110,14 @@ fast-follow; untrusted code → MCP (D1).
 - **PR2:** console **Plugins** panel + the install/review/uninstall API (paste URL →
   review card → install → enable/disable → uninstall). e2e.
 - **PR3:** `requires_pip` + `install-deps` + missing-dep diagnostics; capability
-  review surfacing + audit logging; `plugins.sources.allow` enforcement; docs
-  (`guides/plugin-registry.md` "install + publish a plugin" + the untrusted→MCP note).
+  review surfacing + audit logging; `plugins.sources.allow` enforcement.
+- **PR4 — full bundle:** a plugin repo contributes the *whole* extension set, not
+  just tools. `register()` already covers tools / subagents / routes / MCP / views;
+  PR4 auto-discovers conventional **`skills/`** (SKILL.md) and **`workflows/`**
+  (`*.yaml`) subdirs (data — no `register_*` boilerplate; a `register_workflow_dir()`
+  exists for non-standard locations) so installing a repo pulls in skills +
+  workflows too. Docs: `guides/plugin-registry.md` (install + publish the full
+  bundle + the untrusted→MCP note).
 
 ## Consequences
 

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -1,0 +1,98 @@
+# Install & publish plugins (git URLs)
+
+Plugins can live in their own GitHub repo and be installed by URL — so you can
+make one and share it, and pull others in. A plugin repo is a **full bundle**: it
+can contribute tools, subagents, SKILL.md skills, workflows, console views, routes,
+MCP servers, and config — all from the one repo. See
+[ADR 0027](/adr/0027-install-plugins-from-git-url) for the design + safety model.
+
+## Install one
+
+**CLI:**
+```sh
+python -m server plugin install https://github.com/owner/protoagent-plugin-x --ref v1.0
+python -m server plugin list
+python -m server plugin uninstall protoagent-plugin-x
+python -m server plugin sync          # re-clone the locked set (CI / fresh checkout)
+python -m server plugin install-deps protoagent-plugin-x   # explicit, separate
+```
+
+**Console:** Settings → Integrations → **Plugins** — paste the URL, review the
+manifest + capabilities, install, uninstall.
+
+Either way, **install fetches code only — it does not enable or run it.** To
+enable: add the plugin's id to `plugins.enabled` in your config and restart.
+
+```yaml
+plugins:
+  enabled: [protoagent-plugin-x]
+```
+
+Install pins the **resolved commit SHA** and records it in a committed
+`plugins.lock`, so `plugin sync` reproduces the exact set. The code itself is
+gitignored (re-cloned from the lock).
+
+## Publish one
+
+A plugin is a directory (its own repo) with a manifest + a `register()`. The
+**conventional layout** — everything here is picked up when the plugin is enabled:
+
+```
+my-plugin/
+  protoagent.plugin.yaml      # manifest (id, name, version, requires_pip, views, …)
+  __init__.py                 # def register(registry): … — tools, subagents, etc.
+  skills/                     # SKILL.md skills — auto-discovered (data, no code)
+    my-skill/SKILL.md
+  workflows/                  # *.yaml workflow recipes — auto-discovered (data)
+    my-recipe.yaml
+```
+
+`register(registry)` contributes the **code** extensions:
+
+```python
+def register(registry):
+    registry.register_tool(my_tool)            # a LangChain tool
+    registry.register_subagent(my_subagent)    # a SubagentConfig
+    registry.register_router(my_router)         # FastAPI routes at /plugins/<id>
+    registry.register_mcp_server(my_factory)    # a managed MCP server
+    # skills/ and workflows/ are auto-discovered — no call needed. For a
+    # non-standard location: registry.register_workflow_dir("recipes")
+```
+
+`skills/` and `workflows/` are **data**, so they're auto-discovered from those
+conventional subdirs — no boilerplate. **Console views** (a rail icon + page) are
+declared in the manifest — see [Plugin console views](/guides/plugin-views).
+
+Declare pip dependencies (they are **not** auto-installed — see Safety):
+
+```yaml
+# protoagent.plugin.yaml
+id: my-plugin
+name: My Plugin
+version: 1.0.0
+repository: https://github.com/owner/my-plugin
+requires_pip: ["httpx>=0.27"]
+min_protoagent_version: "0.20.0"
+```
+
+## Safety
+
+The model is **informed trust + a verifiable supply chain**, not a sandbox — an
+enabled plugin runs in-process *as the agent* (like a pip dependency). So:
+
+- **Install ≠ enable ≠ trust.** Installing only fetches code + reads the manifest
+  (data); it never imports the plugin. Enabling (`plugins.enabled`) is the trust
+  decision — review the manifest + capabilities first.
+- **Deps are explicit.** `requires_pip` is declared, never auto-installed (pip runs
+  arbitrary build code). Run `plugin install-deps <id>` after reviewing them; a
+  missing dep gives a clear "run install-deps" message on enable.
+- **Pinned + reproducible.** Installs pin a commit SHA in `plugins.lock`.
+- **Optional source allowlist.** Lock installs down to trusted orgs:
+  ```yaml
+  plugins:
+    sources:
+      allow: ["github.com/yourorg/*"]
+  ```
+- **Audited.** install / uninstall / install-deps are written to the audit log.
+- **Untrusted code? Use [MCP](/guides/mcp) instead** — it runs out-of-process and
+  is sandboxable. Git plugins are for code you've reviewed and trust.

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -28,6 +28,7 @@ log = logging.getLogger("protoagent.plugins")
 class PluginLoadResult:
     tools: list = field(default_factory=list)
     skill_dirs: list = field(default_factory=list)
+    workflow_dirs: list = field(default_factory=list)  # *.yaml recipe dirs (ADR 0027)
     a2a_skills: list = field(default_factory=list)  # A2A card skill specs (#570)
     routers: list = field(default_factory=list)    # {plugin_id, router, prefix} (ADR 0018)
     surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
@@ -203,6 +204,17 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
 
         result.tools.extend(kept)
         result.skill_dirs.extend(registry.skill_dirs)
+        result.workflow_dirs.extend(registry.workflow_dirs)
+        # Full-bundle auto-discovery (ADR 0027): a plugin repo can ship SKILL.md
+        # skills + *.yaml workflows in conventional subdirs and they're picked up
+        # without any register_* boilerplate — so installing a repo pulls in the
+        # whole bundle (tools+subagents via register(), skills+workflows as data).
+        conv_skills = manifest.path / "skills"
+        if conv_skills.is_dir() and conv_skills not in result.skill_dirs:
+            result.skill_dirs.append(conv_skills)
+        conv_workflows = manifest.path / "workflows"
+        if conv_workflows.is_dir() and conv_workflows not in result.workflow_dirs:
+            result.workflow_dirs.append(conv_workflows)
         result.a2a_skills.extend(registry.a2a_skills)
         if registry.thread_id_resolver is not None:  # last plugin wins (#571)
             if result.thread_id_resolver is not None:

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -47,6 +47,7 @@ class PluginRegistry:
         self.host = HOST
         self.tools: list = []
         self.skill_dirs: list[Path] = []
+        self.workflow_dirs: list[Path] = []  # dirs of *.yaml workflow recipes (ADR 0027)
         self.a2a_skills: list[dict] = []  # A2A card skill specs (#570)
         self.routers: list[dict] = []     # {"router", "prefix"}
         self.surfaces: list[dict] = []    # {"name", "start", "stop"}
@@ -75,6 +76,17 @@ class PluginRegistry:
         if not p.is_absolute():
             p = self.plugin_dir / p
         self.skill_dirs.append(p)
+
+    def register_workflow_dir(self, path: str | Path) -> None:
+        """Add a directory of ``*.yaml`` workflow recipes bundled with the plugin
+        (ADR 0027). Relative paths resolve against the plugin's own directory. A
+        conventional ``<plugin>/workflows/`` dir is auto-discovered without this
+        call; use it for a non-standard location.
+        """
+        p = Path(path)
+        if not p.is_absolute():
+            p = self.plugin_dir / p
+        self.workflow_dirs.append(p)
 
     def register_a2a_skill(self, spec: dict) -> None:
         """Contribute an A2A *card* skill — advertised on the agent card and,

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -37,6 +37,7 @@ class AppState:
     mcp_meta: list = field(default_factory=list)
     plugin_tools: list = field(default_factory=list)
     plugin_skill_dirs: list = field(default_factory=list)
+    plugin_workflow_dirs: list = field(default_factory=list)  # *.yaml recipe dirs (ADR 0027)
     plugin_a2a_skills: list = field(default_factory=list)  # A2A card skills from plugins (#570)
     thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571)
     plugin_routers: list = field(default_factory=list)

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -143,6 +143,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     STATE.plugin_tools, STATE.plugin_skill_dirs, STATE.plugin_meta = (
         _plugins.tools, _plugins.skill_dirs, _plugins.meta,
     )
+    STATE.plugin_workflow_dirs = _plugins.workflow_dirs
     STATE.plugin_a2a_skills = _plugins.a2a_skills  # A2A card skills (#570)
     STATE.thread_id_resolver = _plugins.thread_id_resolver  # thread_id seam (#571)
     # Surfaces / routes / subagents (ADR 0018). Routers + surfaces are captured
@@ -569,6 +570,12 @@ def _build_workflow_registry(config):
         bundled = _bundle_root() / "workflows"
         if bundled.is_dir():
             dirs.append(str(bundled))
+        # Plugin-bundled workflow recipes (ADR 0027) — enabled plugins' workflows/
+        # dirs, so installing a plugin repo pulls in its workflows too. Before the
+        # writable dir below, so a user-saved recipe still wins on a name clash.
+        for d in (getattr(STATE, "plugin_workflow_dirs", None) or []):
+            if Path(d).is_dir():
+                dirs.append(str(d))
         # Writable dir for user / agent-emitted recipes (same fallback shape).
         writable = scope_leaf(Path(config.workflow_dir).expanduser())
         try:

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -306,3 +306,27 @@ def test_loader_meta_exposes_views_for_enabled_plugin(monkeypatch, tmp_path) -> 
     meta = res.meta[0]
     assert meta["id"] == "viewy" and meta["enabled"] is True
     assert [v["id"] for v in meta["views"]] == ["board"]
+
+
+# ── full-bundle auto-discovery (ADR 0027) ─────────────────────────────────────
+
+
+def test_plugin_autodiscovers_workflows_and_skills_dirs(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "plugins"
+    d = _make_plugin(root, "bundle", enabled=True, tool="bt")
+    (d / "workflows").mkdir()
+    (d / "workflows" / "wf.yaml").write_text("name: wf\n", encoding="utf-8")
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg(plugins_enabled=["bundle"]))
+    assert any(p.name == "workflows" and "bundle" in str(p) for p in res.workflow_dirs)
+    assert any(p.name == "skills" and "bundle" in str(p) for p in res.skill_dirs)
+
+
+def test_register_workflow_dir(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "plugins"
+    body = "def register(reg):\n    reg.register_workflow_dir('recipes')\n"
+    d = _make_plugin(root, "wfp", enabled=True, body=body)
+    (d / "recipes").mkdir()
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg(plugins_enabled=["wfp"]))
+    assert any(p.name == "recipes" for p in res.workflow_dirs)


### PR DESCRIPTION
Closes the loop on "pull in all from the repo" — a plugin repo is now a **full bundle**.

## What
`register()` already contributes **tools / subagents / routes / MCP servers / console views**. PR4 adds auto-discovery of the conventional **data** subdirs in each enabled plugin (no `register_*` boilerplate):
- **`skills/`** (SKILL.md) → skills index
- **`workflows/`** (`*.yaml`) → WorkflowRegistry *(the one gap)*

Plus `registry.register_workflow_dir()` for non-standard locations. Plugin workflow dirs are inserted before the writable dir, so a user-saved recipe still wins a name clash.

So: drop tools + subagents + skills + workflows + views in a repo, install it, enable it — everything comes in.

## Docs
`docs/guides/plugin-registry.md` — install (CLI + console) **and** publish the full bundle (repo layout, `register()`, `skills/`+`workflows/`, `requires_pip`, views) + the safety model (install≠enable, pin/lock, allowlist, untrusted→MCP). Sidebar + ADR 0027 updated.

## Test
```
$ pytest tests/test_plugins.py tests/test_plugin_installer.py   # 34 passed
$ pytest -q                                                      # 1142 passed
$ ruff — clean
```
**Live-smoked end-to-end**: installed a repo shipping a tool + `workflows/recipe.yaml` + `skills/` → enabled → tool loaded **and** `plugin-recipe` shows up in `/api/workflows`.

## ADR 0027 complete
PR1 installer+CLI · PR2 console panel · PR3 deps+audit+allowlist · **PR4 full bundle**. Completes the extensibility arc: **author (0018) → settings (0019) → surfaces (0026) → distribute (0027)**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)