### PR TITLE
feat(plugins): clean plugin delete — purge config/secrets/refs (ADR 0027, PR5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Clean plugin delete** (ADR 0027) — `plugin uninstall <id>` now also removes the
+  plugin's `plugins.enabled`/`disabled` reference (no more dangling-enabled errors
+  on the next restart), on top of the code dir + `plugins.lock` entry. A new
+  **`--purge`** flag (CLI) / `?purge=true` (the `DELETE /api/plugins/{id}` route)
+  *also* removes the plugin's config section + its secrets (comment-safe via ruamel).
+  Config/secrets are kept by default so a reinstall restores settings; pip deps are
+  never auto-removed (shared venv) but are reported. Returns a removal report.
+
 ## [0.20.0] - 2026-06-07
 
 ### Added

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -12,10 +12,17 @@ MCP servers, and config — all from the one repo. See
 ```sh
 python -m server plugin install https://github.com/owner/protoagent-plugin-x --ref v1.0
 python -m server plugin list
-python -m server plugin uninstall protoagent-plugin-x
+python -m server plugin uninstall protoagent-plugin-x            # code + lock + enabled ref
+python -m server plugin uninstall protoagent-plugin-x --purge    # also config section + secrets
 python -m server plugin sync          # re-clone the locked set (CI / fresh checkout)
 python -m server plugin install-deps protoagent-plugin-x   # explicit, separate
 ```
+
+**Uninstall removes** the plugin's code, its `plugins.lock` entry, and its
+`plugins.enabled` reference (so nothing dangles). It **keeps** the plugin's config
+section + secrets by default (a reinstall restores your settings); pass `--purge`
+to remove those too. Declared pip deps are **never** auto-removed (shared venv) —
+they're reported so you can `pip uninstall` them if unused.
 
 **Console:** Settings → Integrations → **Plugins** — paste the URL, review the
 manifest + capabilities, install, uninstall.

--- a/graph/plugins/cli.py
+++ b/graph/plugins/cli.py
@@ -25,8 +25,9 @@ def _build_parser() -> argparse.ArgumentParser:
     pi.add_argument("--force", action="store_true", help="replace an already-installed plugin of the same id")
 
     sub.add_parser("list", help="list git-installed plugins (from plugins.lock)")
-    pu = sub.add_parser("uninstall", help="remove a git-installed plugin")
+    pu = sub.add_parser("uninstall", help="remove a git-installed plugin (code + lock + enabled ref)")
     pu.add_argument("id")
+    pu.add_argument("--purge", action="store_true", help="also remove the plugin's config section + secrets")
     sub.add_parser("sync", help="re-clone locked plugins at their pinned SHA (reproducible set)")
     pd = sub.add_parser("install-deps", help="pip-install a plugin's declared requires_pip (explicit code-exec)")
     pd.add_argument("id")
@@ -63,8 +64,12 @@ def run_plugin_cli(argv: list[str]) -> int:
                 print(f"  {e['id']:20} {e['resolved_sha'][:10]}  {e['source_url']}{mark}")
             return 0
         if args.cmd == "uninstall":
-            installer.uninstall(args.id)
-            print(f"✓ uninstalled {args.id}")
+            rep = installer.uninstall(args.id, purge=args.purge)
+            print(f"✓ uninstalled {args.id} — removed: {', '.join(rep['removed'])}")
+            if rep["deps_left"]:
+                print(f"  declared deps left installed (shared venv — remove manually if unused): {', '.join(rep['deps_left'])}")
+            if not args.purge:
+                print("  config + secrets kept (reinstall restores them). Use --purge to remove them too.")
             return 0
         if args.cmd == "sync":
             for r in installer.sync(allow=installer.configured_allowlist()):

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -199,26 +199,84 @@ def install(url: str, ref: str | None = None, *, force: bool = False,
     return summary
 
 
-def uninstall(plugin_id: str) -> bool:
-    """Remove a git-installed plugin (live dir + lock entry). Built-ins are refused."""
+def _clean_config_refs(plugin_id: str, section: str, purge: bool) -> bool:
+    """Remove the plugin's references from the live langgraph-config.yaml (ADR 0027):
+    always the `plugins.enabled`/`disabled` entry (a dangling enabled entry is just
+    broken); with ``purge`` also the plugin's `config_section` block. Comment-safe
+    (ruamel). Returns True if anything changed."""
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+    cfg = _live_config_dir() / "langgraph-config.yaml"
+    if not cfg.exists():
+        return False
+    doc = load_yaml_doc(cfg)
+    if not isinstance(doc, dict):
+        return False
+    changed = False
+    plugins = doc.get("plugins")
+    if isinstance(plugins, dict):
+        for key in ("enabled", "disabled"):
+            lst = plugins.get(key)
+            if isinstance(lst, list) and plugin_id in lst:
+                while plugin_id in lst:
+                    lst.remove(plugin_id)
+                changed = True
+    if purge and section in doc:
+        del doc[section]
+        changed = True
+    if changed:
+        save_yaml_doc(doc, cfg)
+    return changed
+
+
+def _clean_secrets(section: str) -> bool:
+    """Remove the plugin's section from the live secrets.yaml overlay (purge only)."""
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+    sec = _live_config_dir() / "secrets.yaml"
+    if not sec.exists():
+        return False
+    doc = load_yaml_doc(sec)
+    if isinstance(doc, dict) and section in doc:
+        del doc[section]
+        save_yaml_doc(doc, sec)
+        return True
+    return False
+
+
+def uninstall(plugin_id: str, *, purge: bool = False) -> dict:
+    """Remove a git-installed plugin and its references. ALWAYS removes the code
+    dir, the `plugins.lock` entry, and the `plugins.enabled`/`disabled` reference.
+    With ``purge=True`` ALSO removes the plugin's config section + its secrets.
+    Built-ins are refused; pip deps are NEVER auto-removed (shared venv) — they're
+    returned for the operator to remove. Returns a report dict."""
     if (REPO_ROOT / "plugins" / plugin_id).exists():
         raise InstallError(f"{plugin_id!r} is a built-in plugin — not removable via uninstall.")
     target = live_plugins_dir() / plugin_id
-    removed = False
+    # Read the manifest BEFORE deleting — purge needs the config section + we report
+    # the declared deps.
+    manifest = load_manifest(target) if (target / "protoagent.plugin.yaml").exists() else None
+    section = (manifest.config_section if manifest else "") or plugin_id
+    deps_left = list(manifest.requires_pip) if manifest else []
+
+    removed: list[str] = []
     if target.exists():
         shutil.rmtree(target)
-        removed = True
+        removed.append("code")
     lock = _read_lock()
     before = len(lock["plugins"])
     lock["plugins"] = [e for e in lock["plugins"] if e.get("id") != plugin_id]
     if len(lock["plugins"]) != before:
         _write_lock(lock)
-        removed = True
+        removed.append("lock")
+    if _clean_config_refs(plugin_id, section, purge):
+        removed.append("config" if purge else "enabled-ref")
+    if purge and _clean_secrets(section):
+        removed.append("secrets")
+
     if not removed:
         raise InstallError(f"plugin {plugin_id!r} is not installed.")
-    _audit("uninstall", {"id": plugin_id}, f"uninstalled {plugin_id}")
-    log.info("[plugins] uninstalled %s", plugin_id)
-    return True
+    _audit("uninstall", {"id": plugin_id, "purge": purge}, f"uninstalled {plugin_id} ({', '.join(removed)})")
+    log.info("[plugins] uninstalled %s (%s)", plugin_id, ", ".join(removed))
+    return {"id": plugin_id, "removed": removed, "deps_left": deps_left, "purged": purge}
 
 
 def install_deps(plugin_id: str) -> list[str]:

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -69,9 +69,10 @@ def register_plugin_routes(app) -> None:
         return {"installed": summary, "restart_required": True}
 
     @app.delete("/api/plugins/{plugin_id}")
-    async def _uninstall(plugin_id: str):
+    async def _uninstall(plugin_id: str, purge: bool = False):
+        # purge=true also removes the plugin's config section + secrets (ADR 0027).
         try:
-            installer.uninstall(plugin_id)
+            report = installer.uninstall(plugin_id, purge=purge)
         except installer.InstallError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        return {"ok": True}
+        return {"ok": True, **report}

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -31,9 +31,12 @@ def _make_plugin_repo(root: Path, pid: str = "demo_ext", manifest_extra: str = "
 
 @pytest.fixture
 def env(tmp_path, monkeypatch):
-    """Point the installer's lock + install dir at a temp area (never the real repo)."""
+    """Point the installer's lock + install dir + config dir at a temp area (never
+    the real repo)."""
     monkeypatch.setattr(installer, "LOCK_PATH", tmp_path / "plugins.lock")
     monkeypatch.setenv("PROTOAGENT_PLUGINS_DIR", str(tmp_path / "installed"))
+    (tmp_path / "cfg").mkdir()
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path / "cfg"))
     return tmp_path
 
 
@@ -149,6 +152,41 @@ def test_install_deps_runs_pip_with_declared_deps(env, monkeypatch):
     assert deps == ["requests>=2", "rich"]
     assert calls and calls[0][1:4] == ["-m", "pip", "install"]
     assert calls[0][4:] == ["requests>=2", "rich"]
+
+
+def test_uninstall_removes_enabled_ref_keeps_config(env):
+    cfg = env / "cfg" / "langgraph-config.yaml"
+    cfg.write_text(
+        "plugins:\n  enabled: [demo_ext, other]\n"
+        "demo_ext:\n  greeting: hi\n"
+    )
+    repo = _make_plugin_repo(env)
+    installer.install(str(repo))
+    rep = installer.uninstall("demo_ext")  # no purge
+    assert "enabled-ref" in rep["removed"]
+    text = cfg.read_text()
+    assert "demo_ext" not in _enabled_list(text)   # dropped from plugins.enabled
+    assert "other" in _enabled_list(text)          # siblings untouched
+    assert "demo_ext:" in text                      # config section KEPT (no purge)
+
+
+def test_uninstall_purge_removes_config_and_secrets(env):
+    cfg = env / "cfg" / "langgraph-config.yaml"
+    cfg.write_text("plugins:\n  enabled: [demo_ext]\ndemo_ext:\n  greeting: hi\n")
+    secrets = env / "cfg" / "secrets.yaml"
+    secrets.write_text("demo_ext:\n  api_key: SEKRET\nmodel:\n  api_key: keep\n")
+    repo = _make_plugin_repo(env)
+    installer.install(str(repo))
+    rep = installer.uninstall("demo_ext", purge=True)
+    assert set(rep["removed"]) >= {"code", "config", "secrets"}
+    assert "demo_ext" not in cfg.read_text()        # section + enabled ref gone
+    assert "demo_ext" not in secrets.read_text()     # secrets gone
+    assert "model" in secrets.read_text()            # other secrets kept
+
+
+def _enabled_list(yaml_text: str) -> str:
+    import yaml as _y
+    return str((_y.safe_load(yaml_text).get("plugins") or {}).get("enabled") or [])
 
 
 def test_configured_allowlist_reads_config(tmp_path, monkeypatch):


### PR DESCRIPTION
You asked for a clean way to remove *all* of a plugin's artifacts — `uninstall` was leaving config, secrets, and the `plugins.enabled` reference behind (the dangling enabled entry erroring on the next restart).

## What
`installer.uninstall(id, *, purge=False)` now returns a removal report and:
- **Always** removes: the code dir, the `plugins.lock` entry, **and** the `plugins.enabled`/`disabled` reference.
- **`--purge`** *also* removes the plugin's **config section** + its **secrets** (reads the manifest *before* deleting the dir to learn the section/secret keys; comment-safe ruamel edits).
- **Never** auto-removes pip deps (shared venv) — reports them as `deps_left`.

Default keeps config/secrets (a reinstall restores your settings); `--purge` wipes them.

```
python -m server plugin uninstall my-plugin           # code + lock + enabled ref
python -m server plugin uninstall my-plugin --purge    # + config section + secrets
DELETE /api/plugins/my-plugin?purge=true               # same, from the console/API
```

## Test
```
$ pytest tests/test_plugin_installer.py tests/test_plugins.py   # 36 passed
$ pytest -q                                                      # 1144 passed
$ ruff — clean
```
New tests: enabled-ref removal keeps the config section; `--purge` removes the section + secrets while keeping the `model` secret. **CLI-smoked**: `uninstall --purge` cleared both config + secrets, kept the model key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)