### PR TITLE
feat(plugins): plugin-devkit — featured full-bundle reference + authoring kit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Plugin Devkit** — `plugins/plugin-devkit`, a featured first-class plugin that
+  is both the canonical **full-bundle example** and the **plugin-authoring kit**.
+  In one plugin it demonstrates every contribution type — a tool
+  (**`scaffold_plugin`**, writes a new plugin skeleton on disk), a subagent
+  (**`plugin-architect`**), a bundled **`building-plugins` skill** (the authoring
+  contract), a **`design-plugin` workflow** (request → spec), a **console view**,
+  and **config/settings**. Enable it (it ships disabled, like `hello`) to let the
+  agent build its own plugins. See [Install & publish plugins](docs/guides/plugin-registry.md).
 - **Clean plugin delete** (ADR 0027) — `plugin uninstall <id>` now also removes the
   plugin's `plugins.enabled`/`disabled` reference (no more dangling-enabled errors
   on the next restart), on top of the code dir + `plugins.lock` entry. A new

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -41,6 +41,13 @@ gitignored (re-cloned from the lock).
 
 ## Publish one
 
+> **Start from the devkit.** Enable the bundled **`plugin-devkit`** plugin
+> (`plugins: { enabled: [plugin-devkit] }`) — it's the canonical full-bundle
+> example *and* it gives the agent a `scaffold_plugin` tool, a `plugin-architect`
+> subagent + `design-plugin` workflow, and the `building-plugins` skill. With it
+> on, just ask the agent to *"build a plugin that …"* and it scaffolds a working
+> skeleton for you to fill in.
+
 A plugin is a directory (its own repo) with a manifest + a `register()`. The
 **conventional layout** — everything here is picked up when the plugin is enabled:
 

--- a/plugins/plugin-devkit/__init__.py
+++ b/plugins/plugin-devkit/__init__.py
@@ -1,0 +1,246 @@
+"""Plugin Devkit — the plugin-authoring kit + the reference plugin (ADR 0027).
+
+The featured full-bundle example: in ONE plugin it contributes a **tool**
+(`scaffold_plugin`), a **subagent** (`plugin-architect`), a bundled **skill**
+(`skills/building-plugins`), a **workflow** (`workflows/design-plugin`), a
+**console view** (`/guide`), and **config/settings** — every contribution type.
+Enable it to let the agent build its own plugins: it has the *how* (the skill) and
+the *doing* (the scaffold tool).
+
+Read this file as a template — it's intentionally a worked example of each seam.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+from langchain_core.tools import tool
+
+from graph.subagents.config import SubagentConfig
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def _slug(name: str) -> str:
+    return re.sub(r"[^a-z0-9-]+", "-", (name or "").lower()).strip("-") or "plugin"
+
+
+def _target_root(config: dict | None) -> Path:
+    """Where scaffolded plugins are written: the configured ``target_dir`` (ADR
+    0019) or, blank, the live plugins dir the loader discovers."""
+    t = (config or {}).get("target_dir") or ""
+    if t:
+        return Path(t).expanduser()
+    from graph.plugins.installer import live_plugins_dir
+    return live_plugins_dir()
+
+
+_INIT_STUB = '''"""{name} — a protoAgent plugin (scaffolded by plugin-devkit)."""
+
+from __future__ import annotations
+
+from langchain_core.tools import tool
+{view_import}
+
+def register(registry):
+    """Wire this plugin's contributions into the agent (ADR 0018)."""
+{registrations}
+'''
+
+_TOOL_STUB = '''
+    @tool
+    def {id_us}_hello(name: str = "world") -> str:
+        """Say hello — replace with your tool's real work."""
+        return f"hello, {{name}}, from {id}"
+    registry.register_tool({id_us}_hello)
+'''
+
+_VIEW_STUB = '''
+    from fastapi import APIRouter
+    from fastapi.responses import HTMLResponse
+    router = APIRouter()
+
+    @router.get("/view")
+    async def _view():
+        return HTMLResponse("<!doctype html><body style='background:#0a0a0c;color:#ededed;"
+                            "font-family:system-ui;padding:32px'><h1>{name}</h1>"
+                            "<p>Your plugin view — replace this page.</p></body>")
+    registry.register_router(router)  # mounted at /plugins/{id}
+'''
+
+_MANIFEST_STUB = """id: {id}
+name: {name}
+version: 0.1.0
+description: >-
+  {summary}
+enabled: false
+config_section: {id_us}
+{views_block}"""
+
+_SKILL_STUB = """---
+name: {id}-skill
+description: >-
+  Describe WHEN to use this skill (the trigger). Replace this with the cases that
+  should invoke {name}.
+---
+
+# {name}
+
+Replace this body with the procedure the agent should follow.
+"""
+
+_WORKFLOW_STUB = """name: {id}-workflow
+description: A scaffolded workflow — replace the steps with your recipe.
+version: 1
+inputs:
+  - name: request
+    description: What to do.
+    required: true
+steps:
+  - id: do
+    subagent: researcher
+    prompt: |
+      {{{{inputs.request}}}}
+output: "{{{{steps.do.output}}}}"
+"""
+
+
+def _build_scaffold_tool(config: dict | None):
+    """Closes over the plugin's config so the tool knows where to write."""
+
+    @tool
+    def scaffold_plugin(
+        name: str,
+        summary: str = "A protoAgent plugin.",
+        with_tool: bool = True,
+        with_view: bool = False,
+        with_skill: bool = False,
+        with_workflow: bool = False,
+    ) -> str:
+        """Scaffold a new protoAgent plugin SKELETON on disk (manifest + register()
+        + optional view/skill/workflow stubs), ready to fill in and enable.
+
+        Writes into the live plugins dir (or the configured target_dir). Does NOT
+        enable it or run any code — review, fill in the logic, then add the id to
+        plugins.enabled and restart. Returns the path + next steps. Use this when
+        asked to create/build/scaffold a plugin; see the building-plugins skill for
+        the contract.
+        """
+        pid = _slug(name)
+        id_us = pid.replace("-", "_")
+        root = _target_root(config)
+        target = root / pid
+        if target.exists():
+            return f"✗ {pid!r} already exists at {target} — pick another name or remove it first."
+        (target).mkdir(parents=True)
+
+        views_block = (
+            f"views:\n  - {{ id: main, label: \"{name}\", icon: Boxes, path: /plugins/{pid}/view }}\n"
+            if with_view else ""
+        )
+        (target / "protoagent.plugin.yaml").write_text(
+            _MANIFEST_STUB.format(id=pid, name=name, summary=summary, id_us=id_us, views_block=views_block)
+        )
+
+        registrations = ""
+        if with_tool:
+            registrations += _TOOL_STUB.format(id=pid, id_us=id_us)
+        if with_view:
+            registrations += _VIEW_STUB.format(id=pid, name=name)
+        if not registrations.strip():
+            registrations = "    pass  # add registry.register_* calls here\n"
+        (target / "__init__.py").write_text(
+            _INIT_STUB.format(name=name, view_import="", registrations=registrations)
+        )
+
+        made = ["protoagent.plugin.yaml", "__init__.py"]
+        if with_skill:
+            sk = target / "skills" / f"{pid}-skill"
+            sk.mkdir(parents=True)
+            (sk / "SKILL.md").write_text(_SKILL_STUB.format(id=pid, name=name))
+            made.append("skills/")
+        if with_workflow:
+            (target / "workflows").mkdir()
+            (target / "workflows" / f"{pid}.yaml").write_text(_WORKFLOW_STUB.format(id=pid))
+            made.append("workflows/")
+
+        return (
+            f"✓ scaffolded plugin {pid!r} at {target}\n"
+            f"  wrote: {', '.join(made)}\n"
+            f"  next: fill in the logic, then enable — add '{pid}' to plugins.enabled and restart.\n"
+            f"  (see the building-plugins skill for the full contract)"
+        )
+
+    return scaffold_plugin
+
+
+def _plugin_architect() -> SubagentConfig:
+    """A text-only subagent that turns a plain-English request into a concrete
+    plugin spec. Used by the design-plugin workflow."""
+    return SubagentConfig(
+        name="plugin-architect",
+        description=(
+            "Designs a protoAgent plugin from a plain-English request — picks the "
+            "contribution types, drafts a complete protoagent.plugin.yaml, and "
+            "sketches register(). Use before scaffolding a non-trivial plugin."
+        ),
+        system_prompt=(
+            "You design protoAgent plugins. Given a request, output: (1) the plugin "
+            "id + name, (2) which contributions it needs (tools / subagents / "
+            "SKILL.md skills / workflows / console views / config+secrets), (3) a "
+            "complete `protoagent.plugin.yaml`, and (4) a `register(registry)` "
+            "sketch. Follow the plugin contract: the manifest is data; code runs "
+            "only on enable; config_section is a string; skills/ and workflows/ "
+            "subdirs auto-load; declare requires_pip, don't assume it's installed. "
+            "Keep it to the smallest plugin that satisfies the request."
+        ),
+        tools=[],  # pure reasoning — it produces a spec, it doesn't act
+    )
+
+
+def _build_guide_router():
+    from fastapi import APIRouter
+    from fastapi.responses import HTMLResponse
+
+    router = APIRouter()
+
+    @router.get("/guide")
+    async def _guide():
+        html = """<!doctype html><html><head><meta charset="utf-8"><style>
+          html,body{margin:0;background:#0a0a0c;color:#ededed;font-family:ui-sans-serif,system-ui,sans-serif}
+          .wrap{max-width:52ch;margin:0 auto;padding:40px 28px;line-height:1.6}
+          h1{color:#a78bfa;font-size:22px;margin:0 0 4px} h2{color:#a78bfa;font-size:15px;margin:22px 0 6px}
+          code{background:#19191d;color:#a78bfa;padding:2px 6px;border-radius:5px;font-size:13px}
+          p,li{color:#a3a3ad;font-size:14px} ul{padding-left:18px}
+        </style></head><body><div class="wrap">
+          <h1>Plugin Devkit</h1>
+          <p>This plugin gives the agent what it needs to build plugins — and is itself
+          the full-bundle example. Ask the agent: <em>"build a plugin that …"</em>.</p>
+          <h2>It contributes</h2>
+          <ul>
+            <li><code>scaffold_plugin</code> tool — writes a new plugin skeleton</li>
+            <li><code>plugin-architect</code> subagent + <code>design-plugin</code> workflow — request → spec</li>
+            <li>the <code>building-plugins</code> skill — the authoring contract</li>
+            <li>this console view + config/settings</li>
+          </ul>
+          <h2>The plugin contract</h2>
+          <ul>
+            <li><code>protoagent.plugin.yaml</code> — manifest (data; read without importing)</li>
+            <li><code>__init__.py</code> — <code>register(registry)</code> (tools, subagents, routes, MCP)</li>
+            <li><code>skills/</code> + <code>workflows/</code> — auto-discovered data</li>
+            <li><code>views:</code> in the manifest — console rail views</li>
+          </ul>
+          <p>Full guide: <code>/guides/plugin-registry</code> · install ≠ enable ≠ trust.</p>
+        </div></body></html>"""
+        return HTMLResponse(html)
+
+    return router
+
+
+def register(registry) -> None:
+    """Every contribution type, in one plugin (the point of the devkit)."""
+    registry.register_tool(_build_scaffold_tool(registry.config))  # a tool
+    registry.register_subagent(_plugin_architect())                # a subagent
+    registry.register_router(_build_guide_router())                # routes + the view page
+    # skills/ + workflows/ auto-discover — no call needed (ADR 0027).

--- a/plugins/plugin-devkit/protoagent.plugin.yaml
+++ b/plugins/plugin-devkit/protoagent.plugin.yaml
@@ -1,0 +1,28 @@
+id: plugin-devkit
+name: Plugin Devkit
+version: 0.1.0
+description: >-
+  The plugin-authoring kit + the canonical reference plugin. It demonstrates EVERY
+  contribution type in one repo — a tool (`scaffold_plugin`), a subagent
+  (`plugin-architect`), a bundled `SKILL.md` skill, a workflow (`design-plugin`),
+  a console view, and config/settings — and it gives the agent what it needs to
+  build its own plugins: the building-plugins skill (the how) + the scaffold tool
+  (the doing). Enable it, then ask the agent to build a plugin.
+enabled: false
+
+# Declarative (surfaced, not enforced): scaffold_plugin writes plugin skeletons
+# into the live plugins dir.
+capabilities:
+  network: []
+  filesystem: scoped
+
+# Config + Settings (ADR 0019) — where scaffolded plugins are written.
+config_section: plugin_devkit
+config:
+  target_dir: ""
+settings:
+  - { key: target_dir, label: "Scaffold target dir", type: string, description: "Where scaffold_plugin writes new plugins (blank = the live plugins dir)." }
+
+# Console view (ADR 0026) — a quick-reference card for the plugin contract.
+views:
+  - { id: guide, label: "Plugin Devkit", icon: Boxes, path: /plugins/plugin-devkit/guide }

--- a/plugins/plugin-devkit/skills/building-plugins/SKILL.md
+++ b/plugins/plugin-devkit/skills/building-plugins/SKILL.md
@@ -1,0 +1,104 @@
+---
+name: building-plugins
+description: >-
+  Use this when asked to build, create, write, scaffold, or publish a protoAgent
+  plugin — e.g. "make a plugin that …", "add a plugin for X", "package this as a
+  plugin", "write a plugin that adds a tool/dashboard/workflow", "publish a plugin
+  so others can install it". Covers the plugin contract (manifest + register()),
+  the full contribution surface (tools, subagents, SKILL.md skills, workflows,
+  console views, routes, MCP servers, config/secrets/settings), the conventional
+  repo layout, testing, and distribution by git URL — with the safety model.
+  Not for: using an already-installed plugin, or extending via a one-off SKILL.md
+  skill or MCP server (smaller asks — see the Skills / MCP guides).
+---
+
+# Building a protoAgent plugin
+
+A plugin is a self-contained directory (optionally its own git repo) that extends
+a running agent **without forking** core. Authoritative refs: ADR 0018 (surfaces),
+0019 (config/secrets/settings), 0026 (console views), 0027 (distribution); guides
+`plugins`, `plugin-views`, `plugin-registry`. The shipped `plugins/hello/` is the
+worked example — read it first.
+
+## Scale to the ask
+A one-tool plugin is ~15 lines (manifest + `register()`). A "full bundle"
+(tools + subagents + skills + workflows + a console view + config) is a directory
+of conventional subdirs. Build the smallest thing that satisfies the ask; don't
+scaffold a dashboard for a single tool.
+
+## 1. Decide what it contributes
+Map the ask to the contribution surface:
+- **tool / subagent / route / MCP server** → code, via `register(registry)`.
+- **SKILL.md skills** / **`*.yaml` workflows** → data, auto-discovered from
+  conventional `skills/` and `workflows/` subdirs (no code).
+- **console view** (rail icon + page) → declared in the manifest `views:`.
+- **config / secrets / Settings fields** → declared in the manifest.
+
+## 2. Lay out the directory
+```
+my-plugin/
+  protoagent.plugin.yaml   # manifest (data — read without importing)
+  __init__.py              # def register(registry): … (code contributions)
+  skills/   <name>/SKILL.md # optional — auto-discovered
+  workflows/ <name>.yaml    # optional — auto-discovered
+```
+Place it in `plugins/<id>/` (bundled with a fork) or install it from a git URL
+into the live plugins dir (step 6).
+
+## 3. Write the manifest (`protoagent.plugin.yaml`)
+```yaml
+id: my-plugin               # unique; must match the directory name
+name: My Plugin
+version: 1.0.0
+enabled: false              # author default; operators opt in via plugins.enabled
+config_section: my-plugin   # top-level YAML section it claims (NOT a list)
+config: { api_base: "https://…" }      # defaults (ADR 0019)
+secrets: [api_key]          # keys routed to secrets.yaml, never tracked YAML
+settings:                   # render in Settings → its group
+  - { key: api_base, label: "API base", type: string }
+  - { key: api_key, label: "API key", type: secret }
+views:                      # console rail view (ADR 0026), optional
+  - { id: board, label: "Board", icon: LayoutDashboard, path: /plugins/my-plugin/board }
+requires_pip: ["httpx>=0.27"]   # deps — declared, NOT auto-installed (ADR 0027)
+repository: https://github.com/owner/my-plugin
+```
+
+## 4. Write `register(registry)`
+The registry collects code contributions (mounted once at init):
+```python
+def register(registry):
+    cfg = registry.config                       # this plugin's resolved config (ADR 0019)
+    registry.register_tool(my_tool)             # a LangChain @tool
+    registry.register_subagent(my_subagent)     # a SubagentConfig
+    registry.register_router(my_router)          # FastAPI routes at /plugins/<id>/…
+    registry.register_mcp_server(my_factory)     # a managed MCP server
+    # skills/ and workflows/ subdirs auto-load — no call needed.
+```
+A `views:` page is served by your router (e.g. `@router.get("/board")` returning
+HTML). For the auth/theme handshake into a view iframe, see the `plugin-views` guide.
+
+## 5. Test it
+- Enable it: `plugins: { enabled: [my-plugin] }`, restart, then
+  `GET /api/runtime/status` → the plugin shows `loaded: true` with its tools/views.
+- Unit-test the tool/registration like `tests/test_plugins.py` does.
+- If it declares `requires_pip`, `python -m server plugin install-deps my-plugin`
+  first (a missing dep gives a clear error on enable).
+
+## 6. Distribute (optional)
+Publish as a git repo; others install by URL:
+`python -m server plugin install <git-url> --ref <tag>` (or the console Plugins
+panel). Install pins a commit SHA in `plugins.lock`; `plugin sync` reproduces it.
+**install ≠ enable ≠ trust** — installing only fetches code, never runs it; enabling
+is the trust decision. For untrusted code, ship an MCP server instead (sandboxed).
+Remove cleanly with `plugin uninstall <id>` (`--purge` also drops config + secrets).
+
+## Gotchas (learned the hard way)
+- `config_section` must be a **string**, never a list (reserved-section check).
+- An `@tool`'s description comes from its **docstring** — use a plain string
+  literal, not an f-string (`__doc__` is None for f-string "docstrings").
+- Discovery reads the manifest as **data**; code runs only on **enable**. Keep the
+  manifest importable-free.
+- Adding routes/surfaces/views needs a **restart** (they mount once at init); the
+  rail picks up a new view from `runtime-status` without a console rebuild.
+- Don't edit core files to wire a plugin in — if you need to, you're missing a
+  seam; file it (see the operator-fork contract) instead of re-porting each sync.

--- a/plugins/plugin-devkit/workflows/design-plugin.yaml
+++ b/plugins/plugin-devkit/workflows/design-plugin.yaml
@@ -1,0 +1,22 @@
+# Bundled by plugin-devkit — turn a plain-English request into a concrete plugin
+# spec using the plugin-architect subagent. Run it:
+#   run_workflow("design-plugin", {"request": "a plugin that posts daily standups to Slack"})
+# Then hand the spec to `scaffold_plugin` (or fill in the scaffolded skeleton).
+name: design-plugin
+description: Turn a plain-English request into a protoAgent plugin spec (manifest + register sketch).
+version: 1
+inputs:
+  - name: request
+    description: What the plugin should do.
+    required: true
+steps:
+  - id: design
+    subagent: plugin-architect
+    prompt: |
+      Design a protoAgent plugin for this request:
+      {{inputs.request}}
+
+      Output, concretely: the plugin id + name, the contribution types it needs,
+      a complete protoagent.plugin.yaml, and a register() sketch. Smallest plugin
+      that satisfies the request.
+output: "{{steps.design.output}}"

--- a/tests/test_plugin_devkit.py
+++ b/tests/test_plugin_devkit.py
@@ -1,0 +1,71 @@
+"""plugin-devkit — the featured full-bundle reference + scaffolder (ADR 0027)."""
+
+from __future__ import annotations
+
+import importlib.util
+import shutil
+from pathlib import Path
+
+from graph.config import LangGraphConfig
+from graph.plugins import loader as plugin_loader
+from graph.plugins.loader import load_plugins
+
+REPO = Path(__file__).resolve().parent.parent
+
+
+def _cfg(**kw):
+    return LangGraphConfig(**kw)
+
+
+def _load_devkit_module(tmp_path):
+    spec = importlib.util.spec_from_file_location(
+        "pdk_test", str(REPO / "plugins" / "plugin-devkit" / "__init__.py")
+    )
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_devkit_loads_as_a_full_bundle(monkeypatch, tmp_path):
+    root = tmp_path / "plugins"
+    shutil.copytree(REPO / "plugins" / "plugin-devkit", root / "plugin-devkit")
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg(plugins_enabled=["plugin-devkit"]))
+    meta = next(m for m in res.meta if m["id"] == "plugin-devkit")
+    assert meta["loaded"], meta.get("error")
+    assert "scaffold_plugin" in meta["tools"]
+    assert any(s.name == "plugin-architect" for s in res.subagents)
+    assert any(p.name == "skills" and "plugin-devkit" in str(p) for p in res.skill_dirs)
+    assert any(p.name == "workflows" and "plugin-devkit" in str(p) for p in res.workflow_dirs)
+    assert meta["routers"] >= 1  # the /guide view
+
+
+def test_scaffold_produces_a_loadable_plugin(monkeypatch, tmp_path):
+    mod = _load_devkit_module(tmp_path)
+    out_root = tmp_path / "out"
+    out_root.mkdir()
+    scaffold = mod._build_scaffold_tool({"target_dir": str(out_root)})
+    msg = scaffold.invoke(
+        {"name": "My Cool Plugin", "summary": "demo", "with_view": True,
+         "with_skill": True, "with_workflow": True}
+    )
+    assert "scaffolded" in msg
+    pdir = out_root / "my-cool-plugin"
+    assert (pdir / "protoagent.plugin.yaml").exists()
+    assert (pdir / "__init__.py").exists()
+    assert (pdir / "skills").is_dir() and (pdir / "workflows").is_dir()
+
+    # the scaffolded skeleton must itself LOAD (enable it + run the loader)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [out_root])
+    res = load_plugins(_cfg(plugins_enabled=["my-cool-plugin"]))
+    meta = next(m for m in res.meta if m["id"] == "my-cool-plugin")
+    assert meta["loaded"], meta.get("error")
+    assert "my_cool_plugin_hello" in meta["tools"]
+
+
+def test_scaffold_refuses_overwrite(tmp_path):
+    mod = _load_devkit_module(tmp_path)
+    out_root = tmp_path / "out"; out_root.mkdir()
+    scaffold = mod._build_scaffold_tool({"target_dir": str(out_root)})
+    scaffold.invoke({"name": "dup"})
+    assert "already exists" in scaffold.invoke({"name": "dup"})


### PR DESCRIPTION
A first-class, downloadable plugin that **is** the full example *and* gives the agent what it needs to build its own plugins.

## `plugins/plugin-devkit/` — every contribution type in one plugin
- **tool** `scaffold_plugin` — writes a new plugin **skeleton** on disk (manifest + `register()` + optional view/skill/workflow stubs). Fetch-only: never enables or runs anything.
- **subagent** `plugin-architect` — turns *"build a plugin that …"* into a concrete spec.
- **skill** `building-plugins` (`skills/SKILL.md`) — the authoring contract; moved here so it ships **with** the kit (and demonstrates skill-bundling).
- **workflow** `design-plugin` — request → spec via the architect.
- **console view** `/guide` + **config/settings** (`target_dir`).

Ships **disabled** (like `hello`). Enable it (`plugins: { enabled: [plugin-devkit] }`) and the agent has the *how* (skill) + the *doing* (scaffold tool) — ask it to build a plugin and it scaffolds a working skeleton.

## Tests
```
$ pytest tests/test_plugin_devkit.py    # loads as full bundle · scaffold → a LOADABLE plugin · refuses overwrite
$ pytest -q                              # 1147 passed
$ ruff — clean
```
**Live-smoked**: enabled → `runtime-status` shows `scaffold_plugin` + `plugin-architect`; `/api/workflows` has `design-plugin`; the skill is in the index; `/guide` serves 200.

Rides under `[Unreleased]` (next release). Note: ships disabled by default for safety (it adds a file-writing tool) — flip `enabled: true` in the manifest if you want it on out of the box.

🤖 Generated with [Claude Code](https://claude.com/claude-code)