### PR TITLE
feat(goals): plugin goal verifiers + plugin verifier type (ADR 0028, PR1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Plugin-contributed goal verifiers** (ADR 0028, PR1) — a plugin can
+  `registry.register_goal_verifier("<name>", fn)` to contribute an in-process goal
+  verifier (auto-namespaced `<plugin-id>:<name>`), referenced by a new **`plugin`**
+  verifier type: `{"type":"plugin","check":"<id>:<name>","args":{…}}`. `args` are
+  declarative data the verifier validates — no shell, no `eval` — so a plugin can
+  ground-truth its own domain state without the `command` verifier's shell-out. A
+  bad/erroring verifier never marks a goal met. Wired through the loader + re-set on
+  config reload. (PR2 will allow setting a `plugin`-verifier goal programmatically.)
+
 ## [0.21.0] - 2026-06-07
 
 ### Added

--- a/graph/goals/verifiers.py
+++ b/graph/goals/verifiers.py
@@ -205,12 +205,41 @@ async def _verify_llm(spec: dict, ctx: VerifyContext) -> VerifyResult:
         return VerifyResult(False, f"evaluator error: {type(exc).__name__}", "")
 
 
+# Plugin-contributed verifiers (ADR 0028), keyed by their namespaced name
+# (``<plugin-id>:<name>``). Populated by the loader at graph build via
+# ``set_plugin_verifiers`` (re-set on config reload). In-process, reviewed code
+# with declarative args — no shell, no eval (that's why a ``plugin`` goal is the
+# only verifier type safe to set programmatically; see ADR 0028 D3).
+_PLUGIN_VERIFIERS: dict = {}
+
+
+def set_plugin_verifiers(mapping: dict | None) -> None:
+    """Replace the registered plugin verifier set (called at build + reload)."""
+    _PLUGIN_VERIFIERS.clear()
+    _PLUGIN_VERIFIERS.update(mapping or {})
+
+
+async def _verify_plugin(spec: dict, ctx: VerifyContext) -> VerifyResult:
+    """Dispatch a ``{"type":"plugin","check":"<id>:<name>","args":{…}}`` goal to a
+    plugin-registered verifier. ``args`` are declarative data the verifier validates."""
+    name = (spec or {}).get("check") or ""
+    fn = _PLUGIN_VERIFIERS.get(name)
+    if fn is None:
+        return VerifyResult(False, f"unknown plugin verifier {name!r}", "")
+    try:
+        return await fn(spec, ctx)
+    except Exception as exc:  # a bad verifier must never mark a goal met
+        log.warning("[goal] plugin verifier %s error: %s", name, exc)
+        return VerifyResult(False, f"verifier error: {type(exc).__name__}", "")
+
+
 VERIFIERS = {
     "command": _verify_command,
     "test": _verify_test,
     "ci": _verify_ci,
     "data": _verify_data,
     "llm": _verify_llm,
+    "plugin": _verify_plugin,
 }
 
 

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -29,6 +29,7 @@ class PluginLoadResult:
     tools: list = field(default_factory=list)
     skill_dirs: list = field(default_factory=list)
     workflow_dirs: list = field(default_factory=list)  # *.yaml recipe dirs (ADR 0027)
+    goal_verifiers: dict = field(default_factory=dict)  # name -> verifier fn (ADR 0028)
     a2a_skills: list = field(default_factory=list)  # A2A card skill specs (#570)
     routers: list = field(default_factory=list)    # {plugin_id, router, prefix} (ADR 0018)
     surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
@@ -228,6 +229,11 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         for s in registry.surfaces:
             result.surfaces.append({"plugin_id": manifest.id, **s})
         result.subagents.extend(registry.subagents)
+        for name, fn in registry.goal_verifiers.items():  # ADR 0028
+            if name in result.goal_verifiers:
+                log.warning("[plugins] %s: goal verifier %s collides — skipped", manifest.id, name)
+                continue
+            result.goal_verifiers[name] = fn
         for f in registry.mcp_servers:
             result.mcp_servers.append({"plugin_id": manifest.id, "factory": f})
         entry["loaded"] = True

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -54,6 +54,7 @@ class PluginRegistry:
         self.subagents: list = []         # SubagentConfig instances
         self.mcp_servers: list = []       # factories: config -> entry dict | None
         self.thread_id_resolver = None    # (request_metadata, session_id) -> str (#571)
+        self.goal_verifiers: dict = {}    # name -> async (spec, ctx) -> VerifyResult (ADR 0028)
 
     def register_tool(self, tool) -> None:
         """Expose a LangChain tool to the agent."""
@@ -87,6 +88,20 @@ class PluginRegistry:
         if not p.is_absolute():
             p = self.plugin_dir / p
         self.workflow_dirs.append(p)
+
+    def register_goal_verifier(self, name: str, fn) -> None:
+        """Contribute an in-process goal verifier (ADR 0028) — an async
+        ``(spec, ctx) -> VerifyResult`` referenced by a ``{"type":"plugin",
+        "check":"<name>"}`` goal. Name it ``<plugin-id>:<verifier>`` to avoid
+        collisions; ``args`` in the spec are declarative data your verifier
+        validates (no shell, no eval). This is the only verifier type safe to set
+        programmatically (D3)."""
+        if not name or not callable(fn):
+            log.warning("[plugins] %s: register_goal_verifier needs a name + callable: %r / %r",
+                        self.plugin_id, name, fn)
+            return
+        key = name if ":" in name else f"{self.plugin_id}:{name}"
+        self.goal_verifiers[key] = fn
 
     def register_a2a_skill(self, spec: dict) -> None:
         """Contribute an A2A *card* skill — advertised on the agent card and,

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -146,6 +146,10 @@ def _init_langgraph_agent(headless_setup: bool = False):
     STATE.plugin_workflow_dirs = _plugins.workflow_dirs
     STATE.plugin_a2a_skills = _plugins.a2a_skills  # A2A card skills (#570)
     STATE.thread_id_resolver = _plugins.thread_id_resolver  # thread_id seam (#571)
+    # Register plugin-contributed goal verifiers (ADR 0028) — re-set on each
+    # (re)load so a config change refreshes the available `plugin` verifiers.
+    from graph.goals import verifiers as _goal_verifiers
+    _goal_verifiers.set_plugin_verifiers(_plugins.goal_verifiers)
     # Surfaces / routes / subagents (ADR 0018). Routers + surfaces are captured
     # here and consumed once by _main (mount) + the startup hook (start) — they
     # don't hot-reload. Subagents register into SUBAGENT_REGISTRY before the graph

--- a/tests/test_goal_verifiers.py
+++ b/tests/test_goal_verifiers.py
@@ -1,130 +1,45 @@
-"""Verifier registry — goal mode."""
+"""Plugin-contributed goal verifiers (ADR 0028, PR1)."""
 
-import json
+from __future__ import annotations
 
-import pytest
+import asyncio
+from pathlib import Path
 
-from graph.goals.verifiers import VerifyContext, run_verifier
-
-
-@pytest.mark.asyncio
-async def test_command_exit_zero_is_met():
-    res = await run_verifier({"type": "command", "command": "exit 0"}, VerifyContext())
-    assert res.met is True
+from graph.goals.types import VerifyResult
+from graph.goals.verifiers import VerifyContext, run_verifier, set_plugin_verifiers
+from graph.plugins.registry import PluginRegistry
 
 
-@pytest.mark.asyncio
-async def test_command_nonzero_not_met():
-    res = await run_verifier({"type": "command", "command": "exit 3"}, VerifyContext())
-    assert res.met is False
-    assert "exited 3" in res.reason
+async def _ok(spec, ctx):
+    return VerifyResult(True, "met", str(spec.get("args", {}).get("min", "")))
 
 
-@pytest.mark.asyncio
-async def test_command_missing_field():
-    res = await run_verifier({"type": "command"}, VerifyContext())
-    assert res.met is False
-    assert "missing" in res.reason
+def test_plugin_verifier_dispatches(monkeypatch):
+    set_plugin_verifiers({"demo:check": _ok})
+    res = asyncio.run(run_verifier({"type": "plugin", "check": "demo:check", "args": {"min": 5}}, VerifyContext()))
+    assert res.met and res.reason == "met" and res.evidence == "5"
+    set_plugin_verifiers({})  # cleanup
 
 
-@pytest.mark.asyncio
-async def test_test_verifier_surfaces_last_line():
-    res = await run_verifier(
-        {"type": "test", "command": "echo '5 passed in 1.2s'; exit 0"}, VerifyContext()
-    )
-    assert res.met is True
-    assert "5 passed" in res.reason
+def test_unknown_plugin_verifier_is_not_met():
+    set_plugin_verifiers({})
+    res = asyncio.run(run_verifier({"type": "plugin", "check": "nope"}, VerifyContext()))
+    assert not res.met and "unknown" in res.reason
 
 
-@pytest.mark.asyncio
-async def test_data_contains(tmp_path):
-    f = tmp_path / "out.txt"
-    f.write_text("status: DONE\n")
-    met = await run_verifier({"type": "data", "path": str(f), "contains": "DONE"}, VerifyContext())
-    missing = await run_verifier({"type": "data", "path": str(f), "contains": "NOPE"}, VerifyContext())
-    assert met.met is True and missing.met is False
+def test_plugin_verifier_error_never_marks_met():
+    async def _boom(spec, ctx):
+        raise RuntimeError("kaboom")
+    set_plugin_verifiers({"demo:boom": _boom})
+    res = asyncio.run(run_verifier({"type": "plugin", "check": "demo:boom"}, VerifyContext()))
+    assert not res.met and "error" in res.reason
+    set_plugin_verifiers({})
 
 
-@pytest.mark.asyncio
-async def test_data_expr(tmp_path):
-    f = tmp_path / "out.json"
-    f.write_text(json.dumps({"open": 0, "items": [1, 2, 3]}))
-    res = await run_verifier(
-        {"type": "data", "path": str(f), "expr": "data['open'] == 0 and len(data['items']) == 3"},
-        VerifyContext(),
-    )
-    assert res.met is True
-
-
-@pytest.mark.asyncio
-async def test_data_expr_no_builtins_blocked(tmp_path):
-    f = tmp_path / "out.json"
-    f.write_text("{}")
-    res = await run_verifier(
-        {"type": "data", "path": str(f), "expr": "__import__('os').system('echo hi')"},
-        VerifyContext(),
-    )
-    assert res.met is False
-    assert "error" in res.reason.lower()
-
-
-@pytest.mark.asyncio
-async def test_data_missing_file(tmp_path):
-    res = await run_verifier({"type": "data", "path": str(tmp_path / "nope.json"), "contains": "x"}, VerifyContext())
-    assert res.met is False
-
-
-@pytest.mark.asyncio
-async def test_unknown_type():
-    res = await run_verifier({"type": "bogus"}, VerifyContext())
-    assert res.met is False
-    assert "unknown" in res.reason
-
-
-@pytest.mark.asyncio
-async def test_ci_pr_checks(monkeypatch):
-    async def fake_run_gh(args, timeout=60):
-        assert args[:2] == ["pr", "checks"]
-        return (0, "all checks passed", "")
-    monkeypatch.setattr("tools.gh_cli.run_gh", fake_run_gh)
-    res = await run_verifier({"type": "ci", "pr": 42}, VerifyContext())
-    assert res.met is True
-
-
-@pytest.mark.asyncio
-async def test_ci_branch_run_conclusion(monkeypatch):
-    async def fake_run_gh(args, timeout=60):
-        return (0, json.dumps([{"status": "completed", "conclusion": "success", "name": "CI"}]), "")
-    monkeypatch.setattr("tools.gh_cli.run_gh", fake_run_gh)
-    res = await run_verifier({"type": "ci", "branch": "main"}, VerifyContext())
-    assert res.met is True
-
-    async def fake_fail(args, timeout=60):
-        return (0, json.dumps([{"status": "completed", "conclusion": "failure"}]), "")
-    monkeypatch.setattr("tools.gh_cli.run_gh", fake_fail)
-    res2 = await run_verifier({"type": "ci", "branch": "main"}, VerifyContext())
-    assert res2.met is False
-
-
-@pytest.mark.asyncio
-async def test_llm_verifier_fail_safe_without_config():
-    res = await run_verifier({"type": "llm"}, VerifyContext(config=None))
-    assert res.met is False
-
-
-@pytest.mark.asyncio
-async def test_llm_verifier_parses_json(monkeypatch):
-    class _Resp:
-        content = 'sure: {"met": true, "reason": "done"}'
-
-    class _LLM:
-        async def ainvoke(self, msgs, config=None):
-            return _Resp()
-
-    monkeypatch.setattr("graph.llm.create_llm", lambda config, model_name=None: _LLM())
-    res = await run_verifier(
-        {"type": "llm"},
-        VerifyContext(config=object(), condition="ship it", last_text="shipped"),
-    )
-    assert res.met is True
-    assert res.reason == "done"
+def test_registry_auto_namespaces_and_guards():
+    reg = PluginRegistry("myplugin", Path("."))
+    reg.register_goal_verifier("credits", _ok)          # → myplugin:credits
+    reg.register_goal_verifier("other:explicit", _ok)   # kept as-is
+    reg.register_goal_verifier("", _ok)                  # invalid — ignored
+    reg.register_goal_verifier("bad", None)             # invalid — ignored
+    assert set(reg.goal_verifiers) == {"myplugin:credits", "other:explicit"}

--- a/tests/test_goal_verifiers.py
+++ b/tests/test_goal_verifiers.py
@@ -1,45 +1,182 @@
-"""Plugin-contributed goal verifiers (ADR 0028, PR1)."""
+"""Verifier registry — goal mode."""
 
-from __future__ import annotations
+import json
 
-import asyncio
-from pathlib import Path
+import pytest
 
-from graph.goals.types import VerifyResult
-from graph.goals.verifiers import VerifyContext, run_verifier, set_plugin_verifiers
-from graph.plugins.registry import PluginRegistry
+from graph.goals.verifiers import VerifyContext, run_verifier
 
 
-async def _ok(spec, ctx):
+@pytest.mark.asyncio
+async def test_command_exit_zero_is_met():
+    res = await run_verifier({"type": "command", "command": "exit 0"}, VerifyContext())
+    assert res.met is True
+
+
+@pytest.mark.asyncio
+async def test_command_nonzero_not_met():
+    res = await run_verifier({"type": "command", "command": "exit 3"}, VerifyContext())
+    assert res.met is False
+    assert "exited 3" in res.reason
+
+
+@pytest.mark.asyncio
+async def test_command_missing_field():
+    res = await run_verifier({"type": "command"}, VerifyContext())
+    assert res.met is False
+    assert "missing" in res.reason
+
+
+@pytest.mark.asyncio
+async def test_test_verifier_surfaces_last_line():
+    res = await run_verifier(
+        {"type": "test", "command": "echo '5 passed in 1.2s'; exit 0"}, VerifyContext()
+    )
+    assert res.met is True
+    assert "5 passed" in res.reason
+
+
+@pytest.mark.asyncio
+async def test_data_contains(tmp_path):
+    f = tmp_path / "out.txt"
+    f.write_text("status: DONE\n")
+    met = await run_verifier({"type": "data", "path": str(f), "contains": "DONE"}, VerifyContext())
+    missing = await run_verifier({"type": "data", "path": str(f), "contains": "NOPE"}, VerifyContext())
+    assert met.met is True and missing.met is False
+
+
+@pytest.mark.asyncio
+async def test_data_expr(tmp_path):
+    f = tmp_path / "out.json"
+    f.write_text(json.dumps({"open": 0, "items": [1, 2, 3]}))
+    res = await run_verifier(
+        {"type": "data", "path": str(f), "expr": "data['open'] == 0 and len(data['items']) == 3"},
+        VerifyContext(),
+    )
+    assert res.met is True
+
+
+@pytest.mark.asyncio
+async def test_data_expr_no_builtins_blocked(tmp_path):
+    f = tmp_path / "out.json"
+    f.write_text("{}")
+    res = await run_verifier(
+        {"type": "data", "path": str(f), "expr": "__import__('os').system('echo hi')"},
+        VerifyContext(),
+    )
+    assert res.met is False
+    assert "error" in res.reason.lower()
+
+
+@pytest.mark.asyncio
+async def test_data_missing_file(tmp_path):
+    res = await run_verifier({"type": "data", "path": str(tmp_path / "nope.json"), "contains": "x"}, VerifyContext())
+    assert res.met is False
+
+
+@pytest.mark.asyncio
+async def test_unknown_type():
+    res = await run_verifier({"type": "bogus"}, VerifyContext())
+    assert res.met is False
+    assert "unknown" in res.reason
+
+
+@pytest.mark.asyncio
+async def test_ci_pr_checks(monkeypatch):
+    async def fake_run_gh(args, timeout=60):
+        assert args[:2] == ["pr", "checks"]
+        return (0, "all checks passed", "")
+    monkeypatch.setattr("tools.gh_cli.run_gh", fake_run_gh)
+    res = await run_verifier({"type": "ci", "pr": 42}, VerifyContext())
+    assert res.met is True
+
+
+@pytest.mark.asyncio
+async def test_ci_branch_run_conclusion(monkeypatch):
+    async def fake_run_gh(args, timeout=60):
+        return (0, json.dumps([{"status": "completed", "conclusion": "success", "name": "CI"}]), "")
+    monkeypatch.setattr("tools.gh_cli.run_gh", fake_run_gh)
+    res = await run_verifier({"type": "ci", "branch": "main"}, VerifyContext())
+    assert res.met is True
+
+    async def fake_fail(args, timeout=60):
+        return (0, json.dumps([{"status": "completed", "conclusion": "failure"}]), "")
+    monkeypatch.setattr("tools.gh_cli.run_gh", fake_fail)
+    res2 = await run_verifier({"type": "ci", "branch": "main"}, VerifyContext())
+    assert res2.met is False
+
+
+@pytest.mark.asyncio
+async def test_llm_verifier_fail_safe_without_config():
+    res = await run_verifier({"type": "llm"}, VerifyContext(config=None))
+    assert res.met is False
+
+
+@pytest.mark.asyncio
+async def test_llm_verifier_parses_json(monkeypatch):
+    class _Resp:
+        content = 'sure: {"met": true, "reason": "done"}'
+
+    class _LLM:
+        async def ainvoke(self, msgs, config=None):
+            return _Resp()
+
+    monkeypatch.setattr("graph.llm.create_llm", lambda config, model_name=None: _LLM())
+    res = await run_verifier(
+        {"type": "llm"},
+        VerifyContext(config=object(), condition="ship it", last_text="shipped"),
+    )
+    assert res.met is True
+    assert res.reason == "done"
+
+
+# ── plugin-contributed verifiers (ADR 0028, PR1) ─────────────────────────────
+
+from graph.goals.types import VerifyResult  # noqa: E402
+from graph.goals.verifiers import set_plugin_verifiers  # noqa: E402
+
+
+async def _ok_verifier(spec, ctx):
     return VerifyResult(True, "met", str(spec.get("args", {}).get("min", "")))
 
 
-def test_plugin_verifier_dispatches(monkeypatch):
-    set_plugin_verifiers({"demo:check": _ok})
-    res = asyncio.run(run_verifier({"type": "plugin", "check": "demo:check", "args": {"min": 5}}, VerifyContext()))
-    assert res.met and res.reason == "met" and res.evidence == "5"
-    set_plugin_verifiers({})  # cleanup
+@pytest.mark.asyncio
+async def test_plugin_verifier_dispatches():
+    set_plugin_verifiers({"demo:check": _ok_verifier})
+    try:
+        res = await run_verifier(
+            {"type": "plugin", "check": "demo:check", "args": {"min": 5}}, VerifyContext()
+        )
+        assert res.met is True and res.reason == "met" and res.evidence == "5"
+    finally:
+        set_plugin_verifiers({})
 
 
-def test_unknown_plugin_verifier_is_not_met():
+@pytest.mark.asyncio
+async def test_unknown_plugin_verifier_is_not_met():
     set_plugin_verifiers({})
-    res = asyncio.run(run_verifier({"type": "plugin", "check": "nope"}, VerifyContext()))
-    assert not res.met and "unknown" in res.reason
+    res = await run_verifier({"type": "plugin", "check": "nope"}, VerifyContext())
+    assert res.met is False and "unknown" in res.reason
 
 
-def test_plugin_verifier_error_never_marks_met():
+@pytest.mark.asyncio
+async def test_plugin_verifier_error_never_marks_met():
     async def _boom(spec, ctx):
         raise RuntimeError("kaboom")
     set_plugin_verifiers({"demo:boom": _boom})
-    res = asyncio.run(run_verifier({"type": "plugin", "check": "demo:boom"}, VerifyContext()))
-    assert not res.met and "error" in res.reason
-    set_plugin_verifiers({})
+    try:
+        res = await run_verifier({"type": "plugin", "check": "demo:boom"}, VerifyContext())
+        assert res.met is False and "error" in res.reason
+    finally:
+        set_plugin_verifiers({})
 
 
 def test_registry_auto_namespaces_and_guards():
+    from pathlib import Path
+    from graph.plugins.registry import PluginRegistry
     reg = PluginRegistry("myplugin", Path("."))
-    reg.register_goal_verifier("credits", _ok)          # → myplugin:credits
-    reg.register_goal_verifier("other:explicit", _ok)   # kept as-is
-    reg.register_goal_verifier("", _ok)                  # invalid — ignored
-    reg.register_goal_verifier("bad", None)             # invalid — ignored
+    reg.register_goal_verifier("credits", _ok_verifier)        # → myplugin:credits
+    reg.register_goal_verifier("other:explicit", _ok_verifier) # kept as-is
+    reg.register_goal_verifier("", _ok_verifier)               # invalid — ignored
+    reg.register_goal_verifier("bad", None)                    # invalid — ignored
     assert set(reg.goal_verifiers) == {"myplugin:credits", "other:explicit"}

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -330,3 +330,18 @@ def test_register_workflow_dir(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
     res = load_plugins(_cfg(plugins_enabled=["wfp"]))
     assert any(p.name == "recipes" for p in res.workflow_dirs)
+
+
+def test_plugin_goal_verifier_is_collected(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "plugins"
+    body = (
+        "async def _v(spec, ctx):\n"
+        "    from graph.goals.types import VerifyResult\n"
+        "    return VerifyResult(True, 'ok', '')\n"
+        "def register(reg):\n"
+        "    reg.register_goal_verifier('credits', _v)\n"
+    )
+    _make_plugin(root, "gverify", enabled=True, body=body)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg(plugins_enabled=["gverify"]))
+    assert "gverify:credits" in res.goal_verifiers   # auto-namespaced (ADR 0028)


### PR DESCRIPTION
First slice of ADR 0028. Plugins can contribute **in-process goal verifiers** — ground-truth their own domain state without the `command` verifier's shell-out (the pattern that forces goals operator-only).

## What
- **`registry.register_goal_verifier(name, fn)`** — auto-namespaced `<plugin-id>:<name>`, guarded.
- **`plugin` verifier type** — `{"type":"plugin","check":"<id>:<name>","args":{…}}` resolves against a loader-populated registry (`set_plugin_verifiers`, re-set on config reload). `args` are declarative data the verifier validates — **no shell, no eval**. A missing/erroring verifier returns **not-met** (never marks a goal met).
- Threaded through the loader (`PluginLoadResult.goal_verifiers`, collision-guarded) + `agent_init`.

```python
def register(registry):
    registry.register_goal_verifier("credits", verify_credits)

async def verify_credits(spec, ctx):
    have = await current_credits()                 # in-process; no shell
    want = int(spec.get("args", {}).get("min", 0))
    return VerifyResult(have >= want, f"{have}/{want}", str(have))
```

## Test
```
$ pytest tests/test_goal_verifiers.py tests/test_plugins.py   # dispatch · unknown→not-met · error→safe · namespacing · loader collect
$ pytest -q   # 1139 passed ; ruff clean
```

## Next
PR2 — a **safe programmatic goal-set gated to the `plugin` verifier only** (never command/test/ci/**data** — `data` evals an expr → RCE escape, per the amended ADR D3). PR3 — lifecycle hooks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)