### PR TITLE
feat(goals): safe programmatic goal-set — plugin-verifier only (ADR 0028, PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Safe programmatic goal-set** (ADR 0028, PR2) — `GoalController.set_goal_safe()`
+  + `POST /api/goals` let an agent/plugin/REST caller establish a standing goal
+  **only** with a `plugin` verifier. `command`/`test`/`ci` (shell) and `data`
+  (`eval`) verifiers are refused programmatically — they stay operator-only via
+  `/goal` — so a non-operator goal-set can never reach a code-exec sink (D3). The
+  REST route 400s a rejected verifier.
 - **Plugin-contributed goal verifiers** (ADR 0028, PR1) — a plugin can
   `registry.register_goal_verifier("<name>", fn)` to contribute an in-process goal
   verifier (auto-namespaced `<plugin-id>:<name>`), referenced by a new **`plugin`**

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -93,6 +93,32 @@ class GoalController:
         self._store.set(state)
         return f"Goal set. {state.status_line()}"
 
+    # Verifier types safe to set PROGRAMMATICALLY (agent / plugin / REST). Only
+    # `plugin` qualifies (ADR 0028 D3): command/test/ci shell out, and `data`
+    # eval()s a spec expr — all code-exec sinks that stay operator-only (/goal).
+    SAFE_PROGRAMMATIC_VERIFIERS = frozenset({"plugin"})
+
+    def set_goal_safe(self, session_id: str, condition: str, verifier: dict,
+                      max_iterations: int | None = None) -> tuple[bool, str]:
+        """Set a goal from a NON-operator caller (an agent tool, a plugin, REST).
+        Accepts ONLY a `plugin` verifier — refuses command/test/ci/data/llm so a
+        programmatic set can never reach a shell or `eval` sink (ADR 0028 D3). The
+        operator `/goal` path keeps full access. Returns (ok, message)."""
+        vtype = (verifier or {}).get("type")
+        if vtype not in self.SAFE_PROGRAMMATIC_VERIFIERS:
+            return (False, f"programmatic goals must use a 'plugin' verifier (got {vtype!r}); "
+                    "command/test/ci/data verifiers are operator-only — set them with /goal.")
+        if not condition:
+            return (False, "a goal condition is required.")
+        if not (verifier.get("check")):
+            return (False, "a plugin verifier needs a 'check' (the <plugin-id>:<name>).")
+        state = GoalState(
+            session_id=session_id, condition=condition, verifier=verifier,
+            max_iterations=max_iterations or getattr(self._config, "goal_max_iterations", 8),
+        )
+        self._store.set(state)
+        return (True, f"Goal set. {state.status_line()}")
+
     def _parse_set(self, rest: str):
         """Return (verifier_spec, condition, max_iterations|None)."""
         if rest.lstrip().startswith("{"):

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -147,6 +147,21 @@ async def _operator_goals_clear(session_id: str) -> dict:
     return {"cleared": bool(cleared)}
 
 
+async def _operator_goals_set(body: dict) -> dict:
+    """Programmatic goal-set (ADR 0028 D3) — plugin-verifier goals only; the route
+    maps ok=False to 400."""
+    if STATE.goal_controller is None:
+        return {"ok": False, "error": "goal mode is not enabled"}
+    sid = str((body or {}).get("session_id") or "").strip()
+    if not sid:
+        return {"ok": False, "error": "session_id is required"}
+    ok, msg = STATE.goal_controller.set_goal_safe(
+        sid, (body or {}).get("condition"), (body or {}).get("verifier") or {},
+        (body or {}).get("max_iterations"),
+    )
+    return {"ok": ok, "message": msg} if ok else {"ok": False, "error": msg}
+
+
 def _operator_workflows_list() -> dict:
     if STATE.workflow_registry is None:
         return {"workflows": []}

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -181,6 +181,7 @@ def register_operator_routes(
     scheduler_cancel: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
     goal_list: Callable[[], Awaitable[dict[str, Any]]] | None = None,
     goal_clear: Callable[[str], Awaitable[dict[str, Any]]] | None = None,
+    goal_set: Callable[[dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
     chat_commands: Callable[[], dict[str, Any]] | None = None,
     workflows_list: Callable[[], dict[str, Any]] | None = None,
     workflows_run: Callable[[str, dict[str, Any]], Awaitable[dict[str, Any]]] | None = None,
@@ -355,6 +356,20 @@ def register_operator_routes(
                 return await goal_clear(session_id)
             except Exception as exc:
                 raise _http_error(exc) from exc
+
+    # Programmatic goal-set (ADR 0028 D3) — accepts ONLY a `plugin` verifier;
+    # command/test/ci/data stay operator-only (/goal). 400 on a rejected verifier.
+    if goal_set is not None:
+
+        @app.post("/api/goals")
+        async def _goal_set(body: dict):
+            try:
+                res = await goal_set(body or {})
+            except Exception as exc:
+                raise _http_error(exc) from exc
+            if not res.get("ok"):
+                raise HTTPException(status_code=400, detail=res.get("error") or res.get("message"))
+            return res
 
     # --- Slash commands ------------------------------------------------------
     # The chat console fetches the registered `/`-commands the server handles

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -446,6 +446,7 @@ def _main():
         scheduler_cancel=_console._operator_scheduler_cancel,
         goal_list=_console._operator_goals_list,
         goal_clear=_console._operator_goals_clear,
+        goal_set=_console._operator_goals_set,
         chat_commands=_console._operator_chat_commands,
         workflows_list=_console._operator_workflows_list,
         workflows_run=_console._operator_workflow_run,

--- a/tests/test_goal_set_programmatic.py
+++ b/tests/test_goal_set_programmatic.py
@@ -1,0 +1,59 @@
+"""Safe programmatic goal-set — plugin-verifier only (ADR 0028 D3, PR2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.goals.controller import GoalController
+from graph.goals.store import GoalStore
+
+
+def _ctrl(tmp_path):
+    return GoalController(config=None, store=GoalStore(base_dir=str(tmp_path)))
+
+
+def test_accepts_a_plugin_verifier(tmp_path):
+    c = _ctrl(tmp_path)
+    ok, msg = c.set_goal_safe(
+        "s1", "reach 1M credits",
+        {"type": "plugin", "check": "spacetraders:credits", "args": {"min": 1_000_000}},
+    )
+    assert ok is True
+    assert c.active_goal("s1") is not None
+
+
+@pytest.mark.parametrize("vtype", ["command", "test", "ci", "data", "llm"])
+def test_rejects_every_non_plugin_verifier(tmp_path, vtype):
+    c = _ctrl(tmp_path)
+    ok, msg = c.set_goal_safe("s1", "do x", {"type": vtype, "command": "rm -rf /", "expr": "1"})
+    assert ok is False and "operator-only" in msg
+    assert c.active_goal("s1") is None        # nothing was set
+
+
+def test_requires_condition_and_check(tmp_path):
+    c = _ctrl(tmp_path)
+    ok, _ = c.set_goal_safe("s1", "", {"type": "plugin", "check": "x:y"})
+    assert ok is False
+    ok, _ = c.set_goal_safe("s1", "cond", {"type": "plugin"})   # no check
+    assert ok is False
+    assert c.active_goal("s1") is None
+
+
+@pytest.mark.asyncio
+async def test_rest_handler_gates_non_plugin(tmp_path, monkeypatch):
+    from operator_api import console_handlers
+    from runtime.state import STATE
+    monkeypatch.setattr(STATE, "goal_controller", _ctrl(tmp_path))
+
+    good = await console_handlers._operator_goals_set(
+        {"session_id": "s", "condition": "c", "verifier": {"type": "plugin", "check": "x:y"}}
+    )
+    assert good["ok"] is True
+
+    bad = await console_handlers._operator_goals_set(
+        {"session_id": "s", "condition": "c", "verifier": {"type": "command", "command": "x"}}
+    )
+    assert bad["ok"] is False and "error" in bad
+
+    nosession = await console_handlers._operator_goals_set({"condition": "c", "verifier": {"type": "plugin", "check": "x:y"}})
+    assert nosession["ok"] is False


### PR DESCRIPTION
Second slice of ADR 0028 — an agent/plugin/REST caller can now **own a standing goal** without the operator-only RCE surface.

## What
- **`GoalController.set_goal_safe(session_id, condition, verifier, max_iters)`** — accepts a goal **only** with a `plugin` verifier (`SAFE_PROGRAMMATIC_VERIFIERS = {"plugin"}`). **Refuses** `command`/`test`/`ci` (shell) **and `data`** (`eval` escape) — those stay operator-only via `/goal`. So a non-operator set can never reach a code-exec sink (the amended D3).
- **`POST /api/goals`** (route + `_operator_goals_set` handler) → `set_goal_safe`; a rejected verifier → **400**. `GET`/`DELETE` unchanged.
- A plugin (in-process) calls `set_goal_safe` directly; REST covers external callers.

## Test
```
$ pytest tests/test_goal_set_programmatic.py    # accepts plugin · rejects command/test/ci/data/llm (parametrized) · requires condition+check · REST handler gates
$ pytest -q   # 1160 passed ; ruff clean
```

## Next
PR3 — `register_goal_hook(on_achieved=, on_failed=)`. (The LLM-facing `set_goal` *tool* — agent sets its own goal mid-turn — is a small follow-up; it needs tool-roster gating. Plugins use `set_goal_safe` directly today.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)