### PR TITLE
feat(goals): goal lifecycle hooks — register_goal_hook (ADR 0028, PR3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Goal lifecycle hooks** (ADR 0028, PR3) — a plugin can
+  `registry.register_goal_hook(on_achieved=…, on_failed=…)` to react when a goal
+  reaches a terminal state (achieved → `on_achieved`; exhausted/unachievable →
+  `on_failed`), fired from the controller's `_finish`. Push a notification, record a
+  finding, or set the next goal — the goal system becomes a self-improving-loop
+  building block, not a dead-end status. Sync or async; a raising hook is logged +
+  swallowed (never breaks the goal loop). Completes ADR 0028.
 - **Safe programmatic goal-set** (ADR 0028, PR2) — `GoalController.set_goal_safe()`
   + `POST /api/goals` let an agent/plugin/REST caller establish a standing goal
   **only** with a `plugin` verifier. `command`/`test`/`ci` (shell) and `data`

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -156,14 +156,14 @@ class GoalController:
         result = await run_verifier(state.verifier, ctx)
 
         if result.met:
-            return self._finish(state, "achieved", result.reason or "verifier passed",
+            return await self._finish(state, "achieved", result.reason or "verifier passed",
                                 evidence=result.evidence)
 
         # 2. Verifier not met — honour an explicit give-up from the agent.
         giveup = _GIVEUP_RE.search(last_text or "")
         if giveup:
             reason = (giveup.group(1) or "agent flagged the goal unachievable").strip()
-            return self._finish(state, "unachievable", reason)
+            return await self._finish(state, "unachievable", reason)
 
         # 3. Not met — refresh checklist, track progress, decide continue vs stop.
         plan = _GOAL_PLAN_RE.search(last_text or "")
@@ -180,11 +180,11 @@ class GoalController:
 
         limit = getattr(self._config, "goal_no_progress_limit", 3)
         if state.iteration >= state.max_iterations:
-            return self._finish(state, "exhausted",
+            return await self._finish(state, "exhausted",
                                 f"ran out of iteration budget ({state.max_iterations})",
                                 evidence=result.evidence)
         if state.no_progress_streak >= limit:
-            return self._finish(state, "unachievable",
+            return await self._finish(state, "unachievable",
                                 f"no progress after {state.no_progress_streak} attempts: {result.reason}",
                                 evidence=result.evidence)
 
@@ -196,14 +196,17 @@ class GoalController:
             note=f"goal not met (iteration {state.iteration}/{state.max_iterations}): {result.reason}",
         )
 
-    def _finish(self, state: GoalState, status: str, reason: str, *, evidence: str = "") -> Decision:
+    async def _finish(self, state: GoalState, status: str, reason: str, *, evidence: str = "") -> Decision:
         from time import time
+        from graph.goals.hooks import fire_goal_hooks
         state.status = status
         state.last_reason = reason
         if evidence:
             state.last_evidence = evidence
         state.finished_at = time()
         self._store.set(state)
+        # Plugin lifecycle reactions (ADR 0028 D4) — notify / record / set next goal.
+        await fire_goal_hooks(status, state)
         glyph = {"achieved": "✓", "exhausted": "⏳", "unachievable": "✗"}.get(status, "•")
         return Decision(action="done", state=state, note=f"{glyph} goal {status}: {reason}")
 

--- a/graph/goals/hooks.py
+++ b/graph/goals/hooks.py
@@ -1,0 +1,42 @@
+"""Goal lifecycle hooks (ADR 0028 D4).
+
+A plugin can react when a goal reaches a terminal state — push a notification,
+record a finding, or set the next goal — turning the goal system into a building
+block for a self-improving loop instead of a dead-end status.
+
+Hooks are module-level (populated by the loader at graph build via ``set_goal_hooks``,
+re-set on config reload) and fired from ``GoalController._finish``. A hook fn takes
+the terminal ``GoalState``; it may be sync or async. A hook that raises is logged
+and swallowed — a bad hook must never break the goal loop.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+
+log = logging.getLogger(__name__)
+
+# Each entry: {"plugin_id", "on_achieved": fn|None, "on_failed": fn|None}.
+_GOAL_HOOKS: list[dict] = []
+
+
+def set_goal_hooks(hooks: list[dict] | None) -> None:
+    """Replace the registered goal hooks (called at build + reload)."""
+    _GOAL_HOOKS[:] = list(hooks or [])
+
+
+async def fire_goal_hooks(status: str, state) -> None:
+    """Fire the matching hook for a terminal goal. ``status`` is ``achieved`` (→
+    ``on_achieved``) or anything else — ``exhausted``/``unachievable`` (→ ``on_failed``)."""
+    key = "on_achieved" if status == "achieved" else "on_failed"
+    for hook in _GOAL_HOOKS:
+        fn = hook.get(key)
+        if fn is None:
+            continue
+        try:
+            result = fn(state)
+            if inspect.isawaitable(result):
+                await result
+        except Exception:  # noqa: BLE001 — a bad hook must not break the goal loop
+            log.exception("[goal] %s hook (plugin %s) failed", key, hook.get("plugin_id"))

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -30,6 +30,7 @@ class PluginLoadResult:
     skill_dirs: list = field(default_factory=list)
     workflow_dirs: list = field(default_factory=list)  # *.yaml recipe dirs (ADR 0027)
     goal_verifiers: dict = field(default_factory=dict)  # name -> verifier fn (ADR 0028)
+    goal_hooks: list = field(default_factory=list)       # {on_achieved, on_failed} (ADR 0028)
     a2a_skills: list = field(default_factory=list)  # A2A card skill specs (#570)
     routers: list = field(default_factory=list)    # {plugin_id, router, prefix} (ADR 0018)
     surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
@@ -234,6 +235,7 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
                 log.warning("[plugins] %s: goal verifier %s collides — skipped", manifest.id, name)
                 continue
             result.goal_verifiers[name] = fn
+        result.goal_hooks.extend(registry.goal_hooks)  # ADR 0028 D4
         for f in registry.mcp_servers:
             result.mcp_servers.append({"plugin_id": manifest.id, "factory": f})
         entry["loaded"] = True

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -55,6 +55,7 @@ class PluginRegistry:
         self.mcp_servers: list = []       # factories: config -> entry dict | None
         self.thread_id_resolver = None    # (request_metadata, session_id) -> str (#571)
         self.goal_verifiers: dict = {}    # name -> async (spec, ctx) -> VerifyResult (ADR 0028)
+        self.goal_hooks: list = []        # {on_achieved, on_failed} terminal reactions (ADR 0028)
 
     def register_tool(self, tool) -> None:
         """Expose a LangChain tool to the agent."""
@@ -102,6 +103,21 @@ class PluginRegistry:
             return
         key = name if ":" in name else f"{self.plugin_id}:{name}"
         self.goal_verifiers[key] = fn
+
+    def register_goal_hook(self, *, on_achieved=None, on_failed=None) -> None:
+        """React when a goal reaches a terminal state (ADR 0028 D4). ``on_achieved``
+        / ``on_failed`` take the terminal ``GoalState`` (sync or async) — push a
+        notification, record a finding, or set the next goal. A raising hook is
+        logged + swallowed."""
+        if not (callable(on_achieved) or callable(on_failed)):
+            log.warning("[plugins] %s: register_goal_hook needs on_achieved and/or on_failed",
+                        self.plugin_id)
+            return
+        self.goal_hooks.append({
+            "plugin_id": self.plugin_id,
+            "on_achieved": on_achieved if callable(on_achieved) else None,
+            "on_failed": on_failed if callable(on_failed) else None,
+        })
 
     def register_a2a_skill(self, spec: dict) -> None:
         """Contribute an A2A *card* skill — advertised on the agent card and,

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -148,8 +148,10 @@ def _init_langgraph_agent(headless_setup: bool = False):
     STATE.thread_id_resolver = _plugins.thread_id_resolver  # thread_id seam (#571)
     # Register plugin-contributed goal verifiers (ADR 0028) — re-set on each
     # (re)load so a config change refreshes the available `plugin` verifiers.
+    from graph.goals import hooks as _goal_hooks
     from graph.goals import verifiers as _goal_verifiers
     _goal_verifiers.set_plugin_verifiers(_plugins.goal_verifiers)
+    _goal_hooks.set_goal_hooks(_plugins.goal_hooks)
     # Surfaces / routes / subagents (ADR 0018). Routers + surfaces are captured
     # here and consumed once by _main (mount) + the startup hook (start) — they
     # don't hot-reload. Subagents register into SUBAGENT_REGISTRY before the graph

--- a/tests/test_goal_hooks.py
+++ b/tests/test_goal_hooks.py
@@ -1,0 +1,80 @@
+"""Goal lifecycle hooks (ADR 0028 D4, PR3)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from graph.goals.controller import GoalController
+from graph.goals.hooks import fire_goal_hooks, set_goal_hooks
+from graph.goals.store import GoalStore
+from graph.goals.types import VerifyResult
+from graph.goals.verifiers import set_plugin_verifiers
+from graph.plugins.registry import PluginRegistry
+
+
+@pytest.mark.asyncio
+async def test_fire_routes_achieved_vs_failed():
+    fired: list[str] = []
+    set_goal_hooks([{"plugin_id": "p",
+                     "on_achieved": lambda s: fired.append("ach"),
+                     "on_failed": lambda s: fired.append("fail")}])
+    try:
+        await fire_goal_hooks("achieved", object())
+        await fire_goal_hooks("exhausted", object())
+        await fire_goal_hooks("unachievable", object())
+        assert fired == ["ach", "fail", "fail"]
+    finally:
+        set_goal_hooks([])
+
+
+@pytest.mark.asyncio
+async def test_async_hook_runs_and_a_raising_hook_is_swallowed():
+    seen: list[str] = []
+
+    async def _ok(s):
+        seen.append("ok")
+
+    def _boom(s):
+        raise RuntimeError("kaboom")
+
+    set_goal_hooks([
+        {"plugin_id": "q", "on_achieved": _boom, "on_failed": None},   # raises first
+        {"plugin_id": "p", "on_achieved": _ok, "on_failed": None},     # still runs
+    ])
+    try:
+        await fire_goal_hooks("achieved", object())  # must not raise
+        assert seen == ["ok"]
+    finally:
+        set_goal_hooks([])
+
+
+def test_registry_register_goal_hook_guards():
+    reg = PluginRegistry("p", Path("."))
+    reg.register_goal_hook(on_achieved=lambda s: None)
+    reg.register_goal_hook()                 # no callables → ignored
+    reg.register_goal_hook(on_failed="nope")  # non-callable → ignored
+    assert len(reg.goal_hooks) == 1
+
+
+@pytest.mark.asyncio
+async def test_controller_finish_fires_on_achieved(tmp_path):
+    fired: list[str] = []
+    set_goal_hooks([{"plugin_id": "p",
+                     "on_achieved": lambda s: fired.append(s.status),
+                     "on_failed": None}])
+
+    async def _always_met(spec, ctx):
+        return VerifyResult(True, "ok", "")
+
+    set_plugin_verifiers({"p:always": _always_met})
+    try:
+        c = GoalController(config=None, store=GoalStore(base_dir=str(tmp_path)))
+        c.set_goal_safe("s", "cond", {"type": "plugin", "check": "p:always"})
+        decision = await c.evaluate("s", last_text="done")
+        assert decision.action == "done" and decision.state.status == "achieved"
+        assert fired == ["achieved"]
+    finally:
+        set_goal_hooks([])
+        set_plugin_verifiers({})

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -345,3 +345,12 @@ def test_plugin_goal_verifier_is_collected(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
     res = load_plugins(_cfg(plugins_enabled=["gverify"]))
     assert "gverify:credits" in res.goal_verifiers   # auto-namespaced (ADR 0028)
+
+
+def test_plugin_goal_hook_is_collected(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "plugins"
+    body = "def register(reg):\n    reg.register_goal_hook(on_achieved=lambda s: None)\n"
+    _make_plugin(root, "ghook", enabled=True, body=body)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg(plugins_enabled=["ghook"]))
+    assert len(res.goal_hooks) == 1 and res.goal_hooks[0]["plugin_id"] == "ghook"  # ADR 0028 D4


### PR DESCRIPTION
Final slice of ADR 0028 — plugins react when a goal finishes, turning the goal system into a self-improving-loop building block.

## What
- **`registry.register_goal_hook(on_achieved=…, on_failed=…)`** — guards (needs ≥1 callable).
- **`graph/goals/hooks.py`** — module-level registry (`set_goal_hooks`, re-set on reload); `fire_goal_hooks(status, state)` routes `achieved`→`on_achieved`, `exhausted`/`unachievable`→`on_failed`; sync **or** async; a **raising hook is logged + swallowed** (never breaks the goal loop).
- **`controller._finish` is now async** and fires the hooks at the single terminal choke point (all 4 outcomes flow through it). Loader collects `goal_hooks`; `agent_init` sets them.

```python
def register(registry):
    registry.register_goal_hook(on_achieved=announce, on_failed=open_bead)
```

## Test
```
$ pytest tests/test_goal_hooks.py    # routing · async + raising-swallowed · registry guard · end-to-end (evaluate→_finish→on_achieved)
$ pytest -q   # 1165 passed ; ruff clean
```

## ADR 0028 complete
PR1 verifier hook + `plugin` type · PR2 safe programmatic set (plugin-only) · **PR3 lifecycle hooks**. The LLM-facing `set_goal` *tool* (agent sets its own goal mid-turn) remains a small optional follow-up — plugins/REST have the full capability via `set_goal_safe`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)