### PR TITLE
fix(agent): enforcement rail covers subagents, not just the lead

### DIFF
--- a/graph/agent.py
+++ b/graph/agent.py
@@ -171,10 +171,24 @@ async def _run_subagent(
     # Subagent model: per-subagent override → routing.aux_model → main model.
     sub_llm = create_llm(config, model_name=_resolve_aux_model(config, getattr(sub_config, "model", "")))
 
+    # Subagents do real work (tool calls), so the enforcement rail (ADR 0003) should
+    # cover them too — not just the lead agent. Mirror the lead's gate so a disallowed/
+    # rate-limited tool is blocked inside a delegation. (Per-instance limiter: each
+    # subagent run gets its own window — a per-delegation cap, not a shared budget.)
+    sub_middleware = [AuditMiddleware()]
+    if getattr(config, "enforcement_enabled", False) and (
+        config.enforcement_disallowed_tools or config.enforcement_rate_limits
+    ):
+        from graph.middleware.enforcement import EnforcementMiddleware
+        sub_middleware.insert(0, EnforcementMiddleware(
+            disallowed_tools=config.enforcement_disallowed_tools,
+            rate_limits=config.enforcement_rate_limits,
+        ))
+
     subagent = create_agent(
         model=sub_llm,
         tools=sub_tools,
-        middleware=[AuditMiddleware()],
+        middleware=sub_middleware,
         system_prompt=build_subagent_prompt(subagent_type),
     )
 


### PR DESCRIPTION
## The gap
The enforcement gate (ADR 0003 — disallowed-tools + rate-limits) is built into the **lead** agent's middleware stack, but `_run_subagent` gives subagents **only `AuditMiddleware`**. So a fork's enforcement config governs the lead's tool calls but **not** the delegated ones — and subagents are exactly where the real tool work happens. The rail doesn't cover the workers.

(Surfaced building an autonomous fleet agent on the substrate: rate-limits set as a safety cap on the lead didn't cover the navigator/trader/miner subagents doing the actual navigate/buy/sell calls.)

## The fix
Mirror the lead's gate in `_run_subagent`: when enforcement is enabled + configured, prepend `EnforcementMiddleware` to the subagent's middleware so a disallowed/rate-limited tool is blocked inside a delegation too. No-op when enforcement is off.

## Design note for review
The limiter is **per-instance**, so each subagent run gets its **own** window — a per-delegation cap, not a budget shared with the lead. That's the simplest correct thing for a safety rail, but if the team prefers a **shared** budget across lead + subagents (or a config flag to opt subagents in/out), happy to adjust — flagging it explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)