### PR TITLE
feat(goals): set_goal tool — agent owns a plugin-verified goal (ADR 0028)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`set_goal` tool** (ADR 0028) — the lead agent can set its **own** standing goal,
+  ground-truthed by a plugin verifier: `set_goal(condition, check, check_args, …)`
+  builds a `plugin` verifier and routes through `set_goal_safe`, so the agent
+  literally can't open a shell/`eval` goal (those stay operator-only via `/goal`).
+  Registered only when goal mode is on; reads the current session at call time.
 - **Goal lifecycle hooks** (ADR 0028, PR3) — a plugin can
   `registry.register_goal_hook(on_achieved=…, on_failed=…)` to react when a goal
   reaches a terminal state (achieved → `on_achieved`; exhausted/unachievable →

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -138,7 +138,8 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # (<server>__<tool>) so they can't be shadowed by a plugin tool anyway.
     _plugins = _build_plugins(
         STATE.graph_config,
-        existing_tools=get_all_tools(STATE.knowledge_store, scheduler=STATE.scheduler),
+        existing_tools=get_all_tools(STATE.knowledge_store, scheduler=STATE.scheduler,
+                                     goal_enabled=getattr(STATE.graph_config, "goal_enabled", True)),
     )
     STATE.plugin_tools, STATE.plugin_skill_dirs, STATE.plugin_meta = (
         _plugins.tools, _plugins.skill_dirs, _plugins.meta,
@@ -827,7 +828,8 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
             # is injected into the MCP discovery below (matches _main ordering).
             new_plugins = _build_plugins(
                 new_config,
-                existing_tools=get_all_tools(new_store, scheduler=next_scheduler),
+                existing_tools=get_all_tools(new_store, scheduler=next_scheduler,
+                                             goal_enabled=getattr(new_config, "goal_enabled", True)),
             )
             new_mcp_clients, new_mcp_tools, new_mcp_meta = _build_mcp(
                 new_config, plugin_servers=[s["factory"] for s in new_plugins.mcp_servers]

--- a/tests/test_set_goal_tool.py
+++ b/tests/test_set_goal_tool.py
@@ -1,0 +1,41 @@
+"""The LLM-facing set_goal tool — agent owns a plugin-verified goal (ADR 0028)."""
+
+from __future__ import annotations
+
+import tracing
+from graph.goals.controller import GoalController
+from graph.goals.store import GoalStore
+from runtime.state import STATE
+from tools.lg_tools import _build_set_goal_tool, get_all_tools
+
+
+def test_get_all_tools_gates_set_goal_on_goal_enabled():
+    on = {t.name for t in get_all_tools(goal_enabled=True)}
+    off = {t.name for t in get_all_tools(goal_enabled=False)}
+    assert "set_goal" in on and "set_goal" not in off
+
+
+def test_set_goal_reports_when_goal_mode_off(monkeypatch):
+    monkeypatch.setattr(STATE, "goal_controller", None)
+    out = _build_set_goal_tool().invoke({"condition": "c", "check": "x:y"})
+    assert "not enabled" in out
+
+
+def test_set_goal_needs_an_active_session(monkeypatch, tmp_path):
+    monkeypatch.setattr(STATE, "goal_controller", GoalController(None, GoalStore(base_dir=str(tmp_path))))
+    monkeypatch.setattr(tracing, "current_session_id", lambda: "")
+    out = _build_set_goal_tool().invoke({"condition": "c", "check": "x:y"})
+    assert "No active session" in out
+
+
+def test_set_goal_sets_a_plugin_verified_goal(monkeypatch, tmp_path):
+    ctrl = GoalController(None, GoalStore(base_dir=str(tmp_path)))
+    monkeypatch.setattr(STATE, "goal_controller", ctrl)
+    monkeypatch.setattr(tracing, "current_session_id", lambda: "s1")
+    out = _build_set_goal_tool().invoke(
+        {"condition": "reach 1M", "check": "spacetraders:credits", "check_args": {"min": 1_000_000}}
+    )
+    assert "Goal set" in out
+    g = ctrl.active_goal("s1")
+    assert g is not None
+    assert g.verifier == {"type": "plugin", "check": "spacetraders:credits", "args": {"min": 1_000_000}}

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -682,7 +682,40 @@ def _build_beads_tools(beads_store) -> list:
     return [beads_create, beads_list, beads_update, beads_close]
 
 
-def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, beads_store=None):
+def _build_set_goal_tool():
+    """The lead agent sets its OWN standing goal — verified by a plugin verifier
+    only (ADR 0028). The agent literally can't open a shell/eval goal here: the
+    tool hardcodes ``type="plugin"`` and routes through ``set_goal_safe``."""
+
+    @tool
+    def set_goal(condition: str, check: str, check_args: dict | None = None,
+                 max_iterations: int | None = None) -> str:
+        """Set a standing goal for THIS session, ground-truthed by a plugin verifier.
+
+        You'll be re-invoked toward `condition` until the plugin verifier named by
+        `check` (a registered "<plugin-id>:<name>" verifier) passes. `check_args` is
+        declarative data the verifier reads (e.g. {"min": 1000000}). Only plugin
+        verifiers are allowed — shell/test/data goals are operator-only via /goal.
+        Returns the goal status, or an error if goal mode is off / `check` is unknown.
+        """
+        import tracing
+        from runtime.state import STATE
+        if STATE.goal_controller is None:
+            return "Goal mode is not enabled."
+        session_id = tracing.current_session_id()
+        if not session_id:
+            return "No active session — set_goal can only run during a turn."
+        verifier = {"type": "plugin", "check": check, "args": check_args or {}}
+        _ok, msg = STATE.goal_controller.set_goal_safe(
+            session_id, condition, verifier, max_iterations,
+        )
+        return msg
+
+    return set_goal
+
+
+def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None,
+                  beads_store=None, goal_enabled=False):
     """Return every LangChain tool the lead agent + subagents can use.
 
     Optional dependencies:
@@ -726,6 +759,8 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None, beads_
         tools.extend(_build_inbox_tools(inbox_store))
     if beads_store is not None:
         tools.extend(_build_beads_tools(beads_store))
+    if goal_enabled:
+        tools.append(_build_set_goal_tool())  # ADR 0028 — agent owns a plugin-verified goal
     # Fork denylist (config ``tools.disabled``): drop named core tools without
     # editing this function. Applied last so it covers every branch above.
     if _disabled_tools:


### PR DESCRIPTION
The optional follow-up — the LLM-facing `set_goal` tool. The lead agent can now set its **own** standing goal, but only a **plugin-verified** one.

## What
- **`set_goal(condition, check, check_args, max_iterations)`** — builds a `{type:"plugin", check, args}` verifier and routes through `set_goal_safe`. The agent **cannot** open a shell/`eval` goal: the tool hardcodes `type="plugin"`, and `set_goal_safe` already refuses everything else. Shell/test/data goals stay operator-only via `/goal`.
- Reads `STATE.goal_controller` + `tracing.current_session_id()` **at call time** (registration doesn't depend on controller-build order).
- `get_all_tools(..., goal_enabled=…)` registers `set_goal` **only when goal mode is on** (no roster pollution otherwise). Wired at both `agent_init` call sites.
- Param is `check_args`, not `args` — LangChain mangles a tool param literally named `args` (→ `v__args`); the tests caught it.

## Test
```
$ pytest tests/test_set_goal_tool.py    # gated on goal_enabled · off w/o controller · needs session · sets the right plugin spec
$ pytest -q   # 1169 passed ; ruff clean
```

ADR 0028 is now fully complete: verifier hook + `plugin` type · safe programmatic set · lifecycle hooks · **agent-facing set_goal tool**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)