### PR TITLE
feat(site): canonical brand tokens + changelog page

### DIFF
--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,0 +1,49 @@
+[
+  {
+    "version": "v0.21.0",
+    "date": "2026-06-07",
+    "changes": [
+      "Plugin Devkit — a featured plugin that teaches the agent to build its own plugins (a scaffold tool, a plugin-architect subagent, and the authoring skill, in one bundle).",
+      "Clean plugin delete — uninstall now also removes a plugin's enabled reference, with --purge to wipe its config + secrets too."
+    ]
+  },
+  {
+    "version": "v0.20.0",
+    "date": "2026-06-06",
+    "changes": [
+      "Install plugins from a git URL — `python -m server plugin install <url>`, pinned in a lockfile, with the safety model built in (install ≠ enable ≠ trust).",
+      "A plugin repo is a full bundle: tools, subagents, skills, workflows, and console views all come in.",
+      "Console Plugins panel — paste a URL, review, install, uninstall."
+    ]
+  },
+  {
+    "version": "v0.19.0",
+    "date": "2026-06-06",
+    "changes": [
+      "Plugins can add their own console rail views — a dashboard or page, no console rebuild."
+    ]
+  },
+  {
+    "version": "v0.18.0",
+    "date": "2026-06-06",
+    "changes": [
+      "Token-by-token answer streaming in the console chat.",
+      "Chat keeps going when you navigate away and back, and self-heals an interrupted stream.",
+      "Brand favicon across the app + docs."
+    ]
+  },
+  {
+    "version": "v0.17.0",
+    "date": "2026-06-06",
+    "changes": [
+      "Unified delegate registry + a hot-swappable console panel — manage the agents and endpoints your agent talks to (a2a / openai / acp) from Settings."
+    ]
+  },
+  {
+    "version": "v0.16.0",
+    "date": "2026-06-06",
+    "changes": [
+      "Spawn CLI coding agents over ACP — hand a real coding job to protoCLI, Claude Code, Codex, or Gemini CLI."
+    ]
+  }
+]

--- a/sites/marketing/package-lock.json
+++ b/sites/marketing/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@astrojs/check": "^0.9.4",
+        "@protolabsai/design": "^0.3.0",
         "@tailwindcss/vite": "^4.2.4",
         "astro": "^5.7.12",
         "tailwindcss": "^4.2.4",
@@ -1257,6 +1258,15 @@
       "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@protolabsai/design": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.3.0.tgz",
+      "integrity": "sha512-vitFVJ9c7L66idoskukAyd48uCTHXy0Y3oQKmcm9osmwZmfogFSPqrGEB1Ot7ZblWDFgsOBr7aRf6iBJMU+k2g==",
+      "license": "MIT",
+      "bin": {
+        "protolabs-sync-assets": "bin/sync-assets.mjs"
       }
     },
     "node_modules/@rolldown/binding-android-arm64": {

--- a/sites/marketing/package.json
+++ b/sites/marketing/package.json
@@ -11,6 +11,7 @@
   },
   "dependencies": {
     "@astrojs/check": "^0.9.4",
+    "@protolabsai/design": "^0.3.0",
     "@tailwindcss/vite": "^4.2.4",
     "astro": "^5.7.12",
     "tailwindcss": "^4.2.4",

--- a/sites/marketing/src/components/Footer.astro
+++ b/sites/marketing/src/components/Footer.astro
@@ -6,10 +6,11 @@ const year = 2026;
   <div class="mx-auto max-w-6xl px-5 py-10 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-zinc-500">
     <div class="flex items-center gap-2">
       <img src="/favicon.svg" alt="" width="18" height="18" />
-      <span>protoAgent — part of the <a href="https://protolabs.studio" class="text-zinc-300 hover:text-white">protoLabs.studio</a> autonomous development studio.</span>
+      <span>A <a href="https://protolabs.studio" class="text-zinc-300 hover:text-white">protoLabs.studio</a> project.</span>
     </div>
     <div class="flex items-center gap-5">
       <a href="/docs/" class="hover:text-white">Docs</a>
+      <a href="/changelog" class="hover:text-white">Changelog</a>
       <a href="https://github.com/protoLabsAI/protoAgent" class="hover:text-white">GitHub</a>
     </div>
   </div>

--- a/sites/marketing/src/components/Nav.astro
+++ b/sites/marketing/src/components/Nav.astro
@@ -11,6 +11,7 @@ const repo = 'https://github.com/protoLabsAI/protoAgent';
     <div class="flex items-center gap-6 text-sm text-zinc-400">
       <a href="/docs/" class="hover:text-white transition-colors">Docs</a>
       <a href="/docs/guides/plugin-registry" class="hover:text-white transition-colors hidden sm:inline">Plugins</a>
+      <a href="/changelog" class="hover:text-white transition-colors hidden sm:inline">Changelog</a>
       <a href={repo} class="hover:text-white transition-colors">GitHub</a>
     </div>
   </nav>

--- a/sites/marketing/src/pages/changelog.astro
+++ b/sites/marketing/src/pages/changelog.astro
@@ -1,0 +1,74 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import changelog from '../../data/changelog.json';
+
+const releases = 'https://github.com/protoLabsAI/protoAgent/releases';
+---
+
+<BaseLayout
+  title="Changelog — protoAgent"
+  description="Release history for protoAgent — the LangGraph + A2A agent template."
+>
+  <div class="max-w-2xl mx-auto px-6 py-24">
+    <h1 class="text-4xl font-bold mb-2">Changelog</h1>
+    <p class="text-zinc-400 mb-16 text-lg">Every release, newest first.</p>
+
+    <div class="relative">
+      <!-- Timeline spine -->
+      <div class="absolute left-[3.25rem] top-2 bottom-0 w-px" style="background: var(--pl-color-border)"></div>
+
+      <ol class="space-y-12">
+        {changelog.map(({ version, date, changes }, i) => (
+          <li class="flex gap-6 relative">
+            <!-- Dot -->
+            <div class="shrink-0 w-[1.625rem] h-[1.625rem] mt-0.5 rounded-full border flex items-center justify-center z-10"
+                 style={i === 0
+                   ? 'background: color-mix(in srgb, var(--pl-color-brand-lavender) 15%, transparent); border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 50%, transparent);'
+                   : 'background: var(--pl-color-bg-raised); border-color: var(--pl-color-border);'}>
+              <div class="w-1.5 h-1.5 rounded-full"
+                   style={i === 0 ? 'background: var(--pl-color-brand-lavender);' : 'background: #52525b;'}></div>
+            </div>
+
+            <!-- Content -->
+            <div class="flex-1 pb-2">
+              <div class="flex flex-wrap items-center gap-3 mb-3">
+                <a
+                  href={`${releases}/tag/${version}`}
+                  class="px-2 py-0.5 rounded font-mono text-sm border transition-colors"
+                  style={i === 0
+                    ? 'background: color-mix(in srgb, var(--pl-color-brand-lavender) 10%, transparent); border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 35%, transparent); color: var(--pl-color-brand-lavender);'
+                    : 'background: var(--pl-color-bg-raised); border-color: var(--pl-color-border); color: var(--pl-color-fg-muted);'}
+                >
+                  {version}
+                </a>
+                <span class="text-zinc-500 text-sm">{date}</span>
+                {i === 0 && (
+                  <span class="px-1.5 py-0.5 rounded text-xs font-mono border"
+                        style="background: color-mix(in srgb, var(--pl-color-brand-lavender) 8%, transparent); border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 25%, transparent); color: var(--pl-color-brand-lavender);">
+                    latest
+                  </span>
+                )}
+              </div>
+
+              <ul class="space-y-1.5">
+                {changes.map((change) => (
+                  <li class="flex items-start gap-2 text-sm text-zinc-300">
+                    <span class="text-zinc-600 mt-0.5 shrink-0">—</span>
+                    <span>{change}</span>
+                  </li>
+                ))}
+              </ul>
+            </div>
+          </li>
+        ))}
+      </ol>
+    </div>
+
+    <div class="mt-16 pt-8 border-t border-white/5">
+      <p class="text-zinc-500 text-sm">
+        Full release notes + source on{' '}
+        <a href={releases} class="text-zinc-400 hover:text-zinc-200 transition-colors underline underline-offset-2">GitHub</a>.
+      </p>
+    </div>
+  </div>
+</BaseLayout>

--- a/sites/marketing/src/styles/global.css
+++ b/sites/marketing/src/styles/global.css
@@ -1,50 +1,54 @@
 @import "tailwindcss";
+/* Canonical protoLabs brand tokens (from @protolabsai/design — source: protoContent).
+   Use these instead of hand-rolled hexes so the site tracks the brand. */
+@import "@protolabsai/design/css/tokens";
 
+/* Map the brand tokens into Tailwind's theme so utilities (bg-accent, text-fg…)
+   AND var() refs resolve to the canonical values. */
 @theme {
-  --color-surface-0: #0a0a0c;
-  --color-surface-1: #111113;
-  --color-surface-2: #161619;
-  --color-surface-3: #1d1d21;
-  --color-accent:     #9b87f2;  /* protoLabs brand violet */
-  --color-accent-dim: #7c6fd6;
-  --color-accent-alt: #b6a6ff;
-  --color-muted: #8b8b94;
-  --color-edge: rgba(255, 255, 255, 0.08);
-  --font-sans: 'Geist', system-ui, sans-serif;
-  --font-mono: 'Geist Mono', ui-monospace, monospace;
+  --color-bg: var(--pl-color-bg);
+  --color-bg-raised: var(--pl-color-bg-raised);
+  --color-fg: var(--pl-color-fg);
+  --color-fg-muted: var(--pl-color-fg-muted);
+  --color-accent: var(--pl-color-brand-lavender);
+  --color-accent-light: var(--pl-color-brand-lavender-light);
+  --color-edge: var(--pl-color-border);
+  --font-sans: var(--pl-font-sans);
+  --font-mono: var(--pl-font-mono);
 }
 
 html {
-  background: var(--color-surface-0);
-  color: #ededed;
+  background: var(--pl-color-bg);
+  color: var(--pl-color-fg);
   -webkit-font-smoothing: antialiased;
   scroll-behavior: smooth;
 }
 
 body {
-  font-family: var(--font-sans);
+  font-family: var(--pl-font-sans);
   min-height: 100vh;
 }
 
+/* Brand gradient (canonical) for hero wordmark + accents. */
 .gradient-text {
-  background: linear-gradient(135deg, #b6a6ff 0%, #9b87f2 45%, #7c6fd6 100%);
+  background: var(--pl-gradient-brand);
   -webkit-background-clip: text;
   -webkit-text-fill-color: transparent;
   background-clip: text;
 }
 
-/* Soft violet glow behind the hero */
+/* Soft brand glow behind the hero. */
 .hero-glow {
-  background: radial-gradient(60% 50% at 50% 0%, rgba(155, 135, 242, 0.18) 0%, transparent 70%);
+  background: radial-gradient(60% 50% at 50% 0%, rgba(155, 135, 242, 0.16) 0%, transparent 70%);
 }
 
 .card {
-  background: var(--color-surface-1);
-  border: 1px solid var(--color-edge);
+  background: var(--pl-color-bg-raised);
+  border: 1px solid var(--pl-color-border);
   border-radius: 14px;
-  transition: border-color 0.2s ease, transform 0.2s ease;
+  transition: border-color var(--pl-motion-base, 200ms) ease, transform var(--pl-motion-base, 200ms) ease;
 }
 .card:hover {
-  border-color: rgba(155, 135, 242, 0.35);
+  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 35%, transparent);
   transform: translateY(-2px);
 }


### PR DESCRIPTION
Tightens the agent.protolabs.studio site against the brand + adds a changelog (per your asks re: protoContent / the main site / ORBIS's changelog).

## What
- **Canonical brand tokens** — `global.css` now `@import`s **`@protolabsai/design/css/tokens`** (the protoContent-sourced brand) and maps the `--pl-*` vars into Tailwind's `@theme`, so the whole site tracks the real brand (lavender `#9b87f2`, the brand gradient, Geist, surfaces, motion) instead of my hand-rolled approximations. `@protolabsai/design` is a **public** package → CI installs resolve it.
- **Changelog** — `changelog.astro` + `data/changelog.json`, ported from ORBIS's timeline, re-themed to brand vars; versions link to GitHub release tags (no `.dmg` yet). Linked from the nav + footer.
- **Footer** — fixed the redundant "part of the protoLabs.studio autonomous development studio" → **"A protoLabs.studio project."**

## Verified
`astro build` → `index` + `changelog` pages; canonical `--pl-color-brand-lavender:#9b87f2` + `--pl-gradient-brand` present in the output CSS.

Once merged + redeployed, the live site picks up the canonical brand + the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)