### PR TITLE
fix(site): footer 'Built by protoLabs.studio' (no icon)

### DIFF
--- a/sites/marketing/src/components/Footer.astro
+++ b/sites/marketing/src/components/Footer.astro
@@ -5,8 +5,7 @@ const year = 2026;
 <footer class="border-t border-[var(--color-edge)] mt-24">
   <div class="mx-auto max-w-6xl px-5 py-10 flex flex-col sm:flex-row items-center justify-between gap-4 text-sm text-zinc-500">
     <div class="flex items-center gap-2">
-      <img src="/favicon.svg" alt="" width="18" height="18" />
-      <span>A <a href="https://protolabs.studio" class="text-zinc-300 hover:text-white">protoLabs.studio</a> project.</span>
+      <span>Built by <a href="https://protolabs.studio" class="text-zinc-300 hover:text-white">protoLabs.studio</a></span>
     </div>
     <div class="flex items-center gap-5">
       <a href="/docs/" class="hover:text-white">Docs</a>


### PR DESCRIPTION
Footer now reads **Built by [protoLabs.studio]** (linked), icon removed. Auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)