### PR TITLE
feat(site): Beta pill + Docs/GitHub open in new tab

### DIFF
--- a/sites/marketing/src/components/Footer.astro
+++ b/sites/marketing/src/components/Footer.astro
@@ -8,9 +8,9 @@ const year = 2026;
       <span>Built by <a href="https://protolabs.studio" class="text-zinc-300 hover:text-white">protoLabs.studio</a></span>
     </div>
     <div class="flex items-center gap-5">
-      <a href="/docs/" class="hover:text-white">Docs</a>
+      <a href="/docs/" target="_blank" rel="noopener noreferrer" class="hover:text-white">Docs</a>
       <a href="/changelog" class="hover:text-white">Changelog</a>
-      <a href="https://github.com/protoLabsAI/protoAgent" class="hover:text-white">GitHub</a>
+      <a href="https://github.com/protoLabsAI/protoAgent" target="_blank" rel="noopener noreferrer" class="hover:text-white">GitHub</a>
     </div>
   </div>
   <div class="text-center text-xs text-zinc-600 pb-8">© {year} protoLabs.studio</div>

--- a/sites/marketing/src/components/Nav.astro
+++ b/sites/marketing/src/components/Nav.astro
@@ -7,12 +7,14 @@ const repo = 'https://github.com/protoLabsAI/protoAgent';
     <a href="/" class="flex items-center gap-2 font-semibold tracking-tight">
       <img src="/favicon.svg" alt="" width="22" height="22" />
       <span>protoAgent</span>
+      <span class="px-1.5 py-0.5 rounded-full text-[10px] font-mono uppercase tracking-wider"
+            style="color: var(--pl-color-brand-lavender); background: color-mix(in srgb, var(--pl-color-brand-lavender) 12%, transparent); border: 1px solid color-mix(in srgb, var(--pl-color-brand-lavender) 35%, transparent);">Beta</span>
     </a>
     <div class="flex items-center gap-6 text-sm text-zinc-400">
-      <a href="/docs/" class="hover:text-white transition-colors">Docs</a>
-      <a href="/docs/guides/plugin-registry" class="hover:text-white transition-colors hidden sm:inline">Plugins</a>
+      <a href="/docs/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors">Docs</a>
+      <a href="/docs/guides/plugin-registry" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors hidden sm:inline">Plugins</a>
       <a href="/changelog" class="hover:text-white transition-colors hidden sm:inline">Changelog</a>
-      <a href={repo} class="hover:text-white transition-colors">GitHub</a>
+      <a href={repo} target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors">GitHub</a>
     </div>
   </nav>
 </header>

--- a/sites/marketing/src/pages/index.astro
+++ b/sites/marketing/src/pages/index.astro
@@ -43,10 +43,10 @@ const steps = [
         MCP servers, and git-installable plugins.
       </p>
       <div class="mt-9 flex items-center justify-center gap-3">
-        <a href="/docs/tutorials/first-agent" class="rounded-lg bg-[var(--color-accent)] px-5 py-3 font-medium text-[#0a0a0c] hover:brightness-110 transition">
+        <a href="/docs/tutorials/first-agent" target="_blank" rel="noopener noreferrer" class="rounded-lg bg-[var(--color-accent)] px-5 py-3 font-medium text-[#0a0a0c] hover:brightness-110 transition">
           Get started
         </a>
-        <a href={repo} class="rounded-lg border border-[var(--color-edge)] px-5 py-3 font-medium text-zinc-200 hover:border-[var(--color-accent)]/50 transition">
+        <a href={repo} target="_blank" rel="noopener noreferrer" class="rounded-lg border border-[var(--color-edge)] px-5 py-3 font-medium text-zinc-200 hover:border-[var(--color-accent)]/50 transition">
           View on GitHub
         </a>
       </div>
@@ -95,8 +95,8 @@ python -m server            <span class="text-zinc-500"># walk the wizard at htt
     <h2 class="text-3xl font-bold tracking-tight">Build your agent tonight.</h2>
     <p class="mt-3 text-zinc-400">Free starter tools, a working A2A server, and a console — on a fresh clone.</p>
     <div class="mt-7 flex items-center justify-center gap-3">
-      <a href="/docs/" class="rounded-lg bg-[var(--color-accent)] px-5 py-3 font-medium text-[#0a0a0c] hover:brightness-110 transition">Read the docs</a>
-      <a href="/docs/guides/plugin-registry" class="rounded-lg border border-[var(--color-edge)] px-5 py-3 font-medium text-zinc-200 hover:border-[var(--color-accent)]/50 transition">Build a plugin</a>
+      <a href="/docs/" target="_blank" rel="noopener noreferrer" class="rounded-lg bg-[var(--color-accent)] px-5 py-3 font-medium text-[#0a0a0c] hover:brightness-110 transition">Read the docs</a>
+      <a href="/docs/guides/plugin-registry" target="_blank" rel="noopener noreferrer" class="rounded-lg border border-[var(--color-edge)] px-5 py-3 font-medium text-zinc-200 hover:border-[var(--color-accent)]/50 transition">Build a plugin</a>
     </div>
   </section>
 </BaseLayout>


### PR DESCRIPTION
Beta badge in the nav (brand-styled, ORBIS-like) + Docs/GitHub links open in a new tab across nav/footer/CTAs. Auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)