### PR TITLE
feat(console): widen plugin-view icon allowlist (ADR 0026 D4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Plugin console-view icon allowlist widened** (ADR 0026 D4) — the `views[].icon`
+  set grew from 9 to ~35 lucide names spanning dashboards, data, comms, dev, AI,
+  finance, **space/fleet** (`Rocket`/`Ship`/`Satellite`/`Radar`), and security, so a
+  plugin's rail icon fits its domain (unknown names still fall back to a generic glyph).
+
 ### Added
 - **`set_goal` tool** (ADR 0028) — the lead agent can set its **own** standing goal,
   ground-truthed by a plugin verifier: `set_goal(condition, check, check_args, …)`

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -23,6 +23,36 @@ import {
   Target,
   Undo2,
   Trash2,
+  // Plugin-view rail icons (ADR 0026) — a broader lucide allowlist so plugins
+  // (dashboards, data, comms, dev, finance, space/fleet, AI) find a fitting glyph.
+  Bot,
+  Brain,
+  Code,
+  Coins,
+  Compass,
+  Cpu,
+  DollarSign,
+  Folder,
+  GitBranch,
+  Globe,
+  Layers,
+  LineChart,
+  Map,
+  Network,
+  Package,
+  PieChart,
+  Plug,
+  Radar,
+  Rocket,
+  Satellite,
+  Shield,
+  Ship,
+  Table,
+  Terminal,
+  TrendingUp,
+  Wallet,
+  Workflow,
+  Zap,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
@@ -64,7 +94,22 @@ type Surface = "chat" | "activity" | "studio" | "knowledge" | "system" | "settin
 // Lucide icon names a plugin view may use for its rail glyph (ADR 0026, PR1 set;
 // PR2 widens the allowlist). Unknown/missing → a generic plugin glyph.
 const PLUGIN_VIEW_ICONS: Record<string, LucideIcon> = {
-  Sparkles, LayoutDashboard, Puzzle, Boxes, BarChart3, Database, Gauge, BookOpen, Target,
+  // general
+  Sparkles, LayoutDashboard, Puzzle, Boxes, Gauge, Target, Activity, Settings2,
+  // data / viz
+  BarChart3, LineChart, PieChart, TrendingUp, Database, Table, Layers,
+  // comms / content
+  MessageSquare, Inbox, CalendarClock, FileText, Folder, BookOpen, BookMarked,
+  // dev / tools
+  Code, Terminal, GitBranch, Package, Plug, Workflow, Network, Cpu, Zap,
+  // ai
+  Bot, Brain,
+  // finance
+  DollarSign, Coins, Wallet,
+  // space / fleet / geo
+  Rocket, Ship, Satellite, Radar, Globe, Compass, Map,
+  // security
+  Shield,
 };
 function pluginViewIcon(name?: string): ReactNode {
   const Icon = (name && PLUGIN_VIEW_ICONS[name]) || Puzzle;

--- a/docs/adr/0026-plugin-contributed-console-surfaces.md
+++ b/docs/adr/0026-plugin-contributed-console-surfaces.md
@@ -74,10 +74,12 @@ Core surfaces are unchanged in behavior.
 
 ### D4 — Icons: a lucide-name allowlist (+ optional plugin SVG)
 
-`icon` is a **lucide-react icon name** the console maps from a curated set;
-unknown/missing → a default "plugin" glyph. A plugin may instead point `icon` at
-an SVG it serves (`/plugins/<id>/icon.svg`) for a custom mark. Lucide-name is the
-common path (matches the rest of the rail).
+`icon` is a **lucide-react icon name** the console maps from a curated allowlist
+(broadened to cover dashboards, data, comms, dev, AI, finance, space/fleet, and
+security — e.g. `LayoutDashboard`, `BarChart3`, `Rocket`, `Satellite`, `Bot`,
+`Coins`, `Workflow`, `Shield`); an unknown/missing name → a default "plugin" glyph.
+A plugin may instead point `icon` at an SVG it serves (`/plugins/<id>/icon.svg`)
+for a custom mark. Lucide-name is the common path (matches the rest of the rail).
 
 ### D5 — Auth: same-origin, token handed in post-load (no token-in-URL)
 

--- a/docs/guides/plugin-views.md
+++ b/docs/guides/plugin-views.md
@@ -24,8 +24,11 @@ views:
 The console reads this from `/api/runtime/status` and renders a rail icon per
 view (keyed `plugin:<id>:<viewId>`). When selected, it hosts `path` in a
 same-origin **iframe** that fills the stage; `tabs` render as a sub-nav that swaps
-the iframe page. `icon` is a [lucide](https://lucide.dev) name (unknown → a
-generic plugin glyph).
+the iframe page. `icon` is a [lucide](https://lucide.dev) name from the console's
+allowlist — covering dashboards, data, comms, dev, AI, finance, space/fleet, and
+security (e.g. `LayoutDashboard`, `BarChart3`, `Database`, `Workflow`, `Bot`,
+`Rocket`, `Satellite`, `Coins`, `Shield`); an unknown name falls back to a generic
+plugin glyph.
 
 ## Serve the page
 


### PR DESCRIPTION
The ADR-0026 plugin-view icon allowlist was 9 lucide names — a space/fleet plugin (e.g. spacetraders) naturally wants Rocket/Ship/Satellite. Widened to ~35 across dashboards, data, comms, dev, AI, finance, **space/fleet** (Rocket/Ship/Satellite/Radar/Globe/Compass/Map), and security. Unknown names still fall back to the generic glyph. The App.tsx comment literally promised 'PR2 widens the allowlist' — this is it.

Docs (ADR 0026 D4 + plugin-views guide) list the categories. Web build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)