### PR TITLE
feat(site): plugin directory at /plugins + README plugins section

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,36 @@ The A2A handler never talks to the LLM directly — it submits a
 message to the LangGraph runtime, which owns the tool loop, the
 subagent `task()` delegation, and the structured-output protocol.
 
+## Plugins
+
+A plugin is a drop-in package — a repo with a `protoagent.plugin.yaml` manifest — that
+extends a **running** agent without forking: tools, `SKILL.md` skills, subagents,
+workflows, FastAPI routes, background surfaces, managed MCP servers, **console rail
+views**, and its own config / secrets / Settings. Install one from a git URL:
+
+```bash
+python -m server plugin install https://github.com/you/your-plugin   # pinned in plugins.lock
+python -m server plugin uninstall your-plugin --purge                # removes code, config + secrets
+```
+
+**Browse the directory → [agent.protolabs.studio/plugins](https://agent.protolabs.studio/plugins)**
+
+First-party plugins ship in `plugins/` (off by default — enable via `plugins.enabled`):
+
+| Plugin | Adds | What it does |
+| --- | --- | --- |
+| [`plugin-devkit`](./plugins/plugin-devkit/) | tool · subagent · skill · workflow · view | The authoring kit + reference plugin — the agent can scaffold and build its own plugins |
+| [`delegates`](./plugins/delegates/) | tool · settings | Hot-swappable registry of agents/endpoints (`delegate_to` over a2a / openai / acp) |
+| [`coding_agent`](./plugins/coding_agent/) | tool | Spawn a CLI coding agent (protoCLI, Claude Code, Codex, Gemini) over ACP |
+| [`discord`](./plugins/discord/) | surface · tool | Run the agent as a Discord bot — inbound DMs + outbound posting |
+| [`google`](./plugins/google/) | mcp | Gmail + Calendar via a managed MCP server with in-app OAuth |
+| [`hello`](./plugins/hello/) | tool · skill · view | Minimal example — copy it to start your own |
+
+**Publish your own:** tag your repo with the [`protoagent-plugin`](https://github.com/topics/protoagent-plugin)
+GitHub topic, then open a PR adding it to [`plugins.json`](./sites/marketing/data/plugins.json)
+to list it on the directory. See [Install & publish plugins](./docs/guides/plugin-registry.md),
+[Plugins](./docs/guides/plugins.md), [Console views](./docs/guides/plugin-views.md).
+
 ## A2A extensions shipped by default
 
 | URI | Declared on card | Emitted at runtime |

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -89,6 +89,17 @@ requires_pip: ["httpx>=0.27"]
 min_protoagent_version: "0.20.0"
 ```
 
+## Get listed in the directory
+
+Anyone can install your plugin from its git URL once it's a public repo. To make it
+**discoverable** and feature it on the [plugin directory](https://agent.protolabs.studio/plugins):
+
+1. **Tag the repo** with the [`protoagent-plugin`](https://github.com/topics/protoagent-plugin)
+   GitHub topic — that surfaces it in the topic search across GitHub.
+2. **Open a PR** adding an entry to
+   [`sites/marketing/data/plugins.json`](https://github.com/protoLabsAI/protoAgent/blob/main/sites/marketing/data/plugins.json)
+   (`name`, `tagline`, `adds`, `install` = your git URL, `links`). It renders as a card on the directory.
+
 ## Safety
 
 The model is **informed trust + a verifiable supply chain**, not a sandbox — an

--- a/sites/marketing/data/plugins.json
+++ b/sites/marketing/data/plugins.json
@@ -1,0 +1,80 @@
+[
+  {
+    "id": "plugin-devkit",
+    "name": "Plugin Devkit",
+    "official": true,
+    "tagline": "Build your own plugins — the authoring kit + reference plugin. A scaffold tool, an architect subagent, the building-plugins skill, and a console guide, in one bundle.",
+    "adds": ["tool", "subagent", "skill", "workflow", "view"],
+    "bundled": true,
+    "enable": "plugin-devkit",
+    "links": {
+      "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/plugin-devkit",
+      "docs": "/docs/guides/plugins"
+    }
+  },
+  {
+    "id": "delegates",
+    "name": "Delegate Registry",
+    "official": true,
+    "tagline": "A hot-swappable registry of the agents and endpoints your agent can talk to — fleet A2A agents, OpenAI-compatible endpoints, ACP coding agents — managed from the console.",
+    "adds": ["tool", "settings"],
+    "bundled": true,
+    "enable": "delegates",
+    "links": {
+      "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/delegates",
+      "docs": "/docs/guides/delegates"
+    }
+  },
+  {
+    "id": "coding_agent",
+    "name": "CLI Coding Agent (ACP)",
+    "official": true,
+    "tagline": "Let the lead agent spawn a CLI coding agent — protoCLI, Claude Code, Codex, or Gemini CLI — and hand it a real coding job over the Agent Client Protocol.",
+    "adds": ["tool"],
+    "bundled": true,
+    "enable": "coding_agent",
+    "links": {
+      "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/coding_agent",
+      "docs": "/docs/guides/coding-agents"
+    }
+  },
+  {
+    "id": "discord",
+    "name": "Discord",
+    "official": true,
+    "tagline": "Run your agent as a Discord bot — an inbound DM/channel gateway plus outbound posting tools.",
+    "adds": ["surface", "tool", "secrets"],
+    "bundled": true,
+    "enable": "discord",
+    "links": {
+      "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/discord",
+      "docs": "/docs/guides/plugins"
+    }
+  },
+  {
+    "id": "google",
+    "name": "Google (Gmail + Calendar)",
+    "official": true,
+    "tagline": "Gmail + Calendar via a managed MCP server, connected in-app with an OAuth consent flow — no credentials.json to wrangle.",
+    "adds": ["mcp", "secrets"],
+    "bundled": true,
+    "enable": "google",
+    "links": {
+      "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/google",
+      "docs": "/docs/guides/plugins"
+    }
+  },
+  {
+    "id": "hello",
+    "name": "Hello (example)",
+    "official": true,
+    "tagline": "A minimal starting point — one tool, one bundled skill, and a console view. Copy it to scaffold your own plugin by hand.",
+    "adds": ["tool", "skill", "view"],
+    "bundled": true,
+    "enable": "hello",
+    "links": {
+      "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/hello",
+      "docs": "/docs/guides/plugins"
+    }
+  }
+]

--- a/sites/marketing/src/components/Footer.astro
+++ b/sites/marketing/src/components/Footer.astro
@@ -9,6 +9,7 @@ const year = 2026;
     </div>
     <div class="flex items-center gap-5">
       <a href="/docs/" target="_blank" rel="noopener noreferrer" class="hover:text-white">Docs</a>
+      <a href="/plugins" class="hover:text-white">Plugins</a>
       <a href="/changelog" class="hover:text-white">Changelog</a>
       <a href="https://github.com/protoLabsAI/protoAgent" target="_blank" rel="noopener noreferrer" class="hover:text-white">GitHub</a>
     </div>

--- a/sites/marketing/src/components/Nav.astro
+++ b/sites/marketing/src/components/Nav.astro
@@ -12,7 +12,7 @@ const repo = 'https://github.com/protoLabsAI/protoAgent';
     </a>
     <div class="flex items-center gap-6 text-sm text-zinc-400">
       <a href="/docs/" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors">Docs</a>
-      <a href="/docs/guides/plugin-registry" target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors hidden sm:inline">Plugins</a>
+      <a href="/plugins" class="hover:text-white transition-colors hidden sm:inline">Plugins</a>
       <a href="/changelog" class="hover:text-white transition-colors hidden sm:inline">Changelog</a>
       <a href={repo} target="_blank" rel="noopener noreferrer" class="hover:text-white transition-colors">GitHub</a>
     </div>

--- a/sites/marketing/src/pages/plugins.astro
+++ b/sites/marketing/src/pages/plugins.astro
@@ -1,0 +1,79 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import plugins from '../../data/plugins.json';
+
+const topic = 'https://github.com/topics/protoagent-plugin';
+const listFile = 'https://github.com/protoLabsAI/protoAgent/blob/main/sites/marketing/data/plugins.json';
+const publishDocs = '/docs/guides/plugin-registry';
+const lavender = 'var(--pl-color-brand-lavender)';
+---
+
+<BaseLayout
+  title="Plugins — protoAgent"
+  description="Plugins for protoAgent — drop-in packages that add tools, skills, subagents, workflows, console views, and more. Install from a git URL."
+>
+  <div class="max-w-5xl mx-auto px-6 py-24">
+    <h1 class="text-4xl font-bold mb-2">Plugins</h1>
+    <p class="text-zinc-400 mb-3 text-lg max-w-2xl">
+      Drop-in packages that extend a running agent — tools, skills, subagents, workflows,
+      FastAPI routes, console rail views, managed MCP servers, and their own config + secrets.
+    </p>
+    <p class="text-zinc-500 mb-14 text-sm max-w-2xl">
+      A plugin is just a repo — install one with
+      <code class="px-1.5 py-0.5 rounded bg-[var(--pl-color-bg-raised)] border border-[var(--pl-color-border)] font-mono text-zinc-300">python -m server plugin install &lt;git-url&gt;</code>
+      (pinned in <code class="font-mono text-zinc-400">plugins.lock</code>). The first-party ones below ship with protoAgent.
+    </p>
+
+    <div class="grid sm:grid-cols-2 gap-5">
+      {plugins.map((p) => (
+        <div class="card p-6 flex flex-col gap-3">
+          <div class="flex items-center gap-2.5">
+            <h2 class="font-semibold text-zinc-100">{p.name}</h2>
+            {p.official && (
+              <span class="px-1.5 py-0.5 rounded-full text-[10px] font-mono uppercase tracking-wider"
+                    style={`color:${lavender};background:color-mix(in srgb, ${lavender} 12%, transparent);border:1px solid color-mix(in srgb, ${lavender} 35%, transparent);`}>
+                Official
+              </span>
+            )}
+          </div>
+          <p class="text-sm text-zinc-400 flex-1">{p.tagline}</p>
+          <div class="flex flex-wrap gap-1.5">
+            {p.adds.map((a) => (
+              <span class="px-1.5 py-0.5 rounded text-[11px] font-mono text-zinc-400 bg-[var(--pl-color-bg-raised)] border border-[var(--pl-color-border)]">{a}</span>
+            ))}
+          </div>
+          <div class="mt-1 font-mono text-xs text-zinc-500">
+            {p.bundled
+              ? <span>Bundled · enable <span class="text-zinc-300">{p.enable}</span> in <span class="text-zinc-300">plugins.enabled</span></span>
+              : <span>plugin install <span class="text-zinc-300">{p.install}</span></span>}
+          </div>
+          <div class="flex items-center gap-4 text-sm pt-1">
+            <a href={p.links.source} target="_blank" rel="noopener noreferrer" class="text-zinc-400 hover:text-white transition-colors">Source ↗</a>
+            <a href={p.links.docs} target="_blank" rel="noopener noreferrer" class="text-zinc-400 hover:text-white transition-colors">Docs ↗</a>
+          </div>
+        </div>
+      ))}
+    </div>
+
+    <!-- Publish your own -->
+    <div class="mt-16 card p-8">
+      <h2 class="text-2xl font-semibold mb-2">Publish your own</h2>
+      <p class="text-zinc-400 mb-6 max-w-2xl text-sm">
+        A plugin is a public repo with a <code class="font-mono text-zinc-300">protoagent.plugin.yaml</code> manifest.
+        Anyone can install it from its git URL. To get it discovered + listed here:
+      </p>
+      <ol class="space-y-3 text-sm text-zinc-300 mb-6">
+        <li class="flex gap-3"><span style={`color:${lavender}`} class="font-mono">1.</span>
+          <span>Tag your repo with the <a href={topic} target="_blank" rel="noopener noreferrer" class="underline underline-offset-2 hover:text-white"><code class="font-mono">protoagent-plugin</code></a> GitHub topic — that makes it discoverable across GitHub.</span></li>
+        <li class="flex gap-3"><span style={`color:${lavender}`} class="font-mono">2.</span>
+          <span>Open a PR adding it to <a href={listFile} target="_blank" rel="noopener noreferrer" class="underline underline-offset-2 hover:text-white"><code class="font-mono">plugins.json</code></a> to feature it on this page.</span></li>
+      </ol>
+      <div class="flex flex-wrap items-center gap-4">
+        <a href={publishDocs} target="_blank" rel="noopener noreferrer"
+           class="rounded-lg px-4 py-2 text-sm font-medium text-[var(--pl-color-bg)]" style={`background:${lavender}`}>Publishing guide</a>
+        <a href={topic} target="_blank" rel="noopener noreferrer"
+           class="rounded-lg border border-[var(--pl-color-border)] px-4 py-2 text-sm font-medium text-zinc-200 hover:border-white/30 transition-colors">Browse the topic ↗</a>
+      </div>
+    </div>
+  </div>
+</BaseLayout>


### PR DESCRIPTION
The plugin **mechanics** all shipped (git-URL install, manifests, devkit) but nothing **surfaced** what exists — no directory. This adds one.

## What
- **`/plugins`** — a card gallery (name · tagline · what it adds · enable/install snippet · source/docs links) for the 6 first-party plugins, + a **"Publish your own"** section.
- **Hybrid discovery model** (your call): a curated `data/plugins.json` features plugins here, and a **`protoagent-plugin` GitHub topic** + PR-to-list opens it to the community.
- **Nav/Footer** "Plugins" now points at the directory (was the publish guide).
- **README `## Plugins`** section — install one-liner, first-party table, directory link, publish path; the publish guide gains a "Get listed" section.

## Verified
`astro build` (index + changelog + **plugins**) and the VitePress docs build both green. Auto-deploys to the live site on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)