### PR TITLE
feat(site): list spacetraders + prototrader-finance plugins

### DIFF
--- a/sites/marketing/data/plugins.json
+++ b/sites/marketing/data/plugins.json
@@ -65,6 +65,32 @@
     }
   },
   {
+    "id": "spacetraders",
+    "name": "SpaceTraders",
+    "official": true,
+    "tagline": "An autonomous SpaceTraders fleet commander — crew subagents, navigation/mining/trading tools, workflows, and a Fleet dashboard. The reference full-bundle plugin.",
+    "adds": ["tool", "subagent", "workflow", "skill", "view"],
+    "bundled": false,
+    "install": "https://github.com/protoLabsAI/spacetraders-plugin",
+    "links": {
+      "source": "https://github.com/protoLabsAI/spacetraders-plugin",
+      "docs": "https://github.com/protoLabsAI/spacetraders-plugin#readme"
+    }
+  },
+  {
+    "id": "prototrader-finance",
+    "name": "protoTrader Finance",
+    "official": true,
+    "tagline": "Trading research as a full bundle — market data, backtesting, factor IC, a behavioral journal, a gated paper broker, the research desk, and a Quant Desk dashboard.",
+    "adds": ["tool", "subagent", "workflow", "view"],
+    "bundled": false,
+    "install": "https://github.com/protoLabsAI/prototrader-finance",
+    "links": {
+      "source": "https://github.com/protoLabsAI/prototrader-finance",
+      "docs": "https://github.com/protoLabsAI/prototrader-finance#readme"
+    }
+  },
+  {
     "id": "hello",
     "name": "Hello (example)",
     "official": true,


### PR DESCRIPTION
Adds the first two **external** full-bundle plugins to the directory (install via git-URL), and tags both repos with the `protoagent-plugin` topic to seed discovery.

- **spacetraders** — autonomous SpaceTraders fleet commander
- **prototrader-finance** — trading research desk

Auto-deploys on merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)