### PR TITLE
feat(plugins): communication-plugin standard (ChatAdapter) + Telegram (ADR 0029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Communication-plugin standard** (ADR 0029) — a `ChatAdapter` contract +
+  `register_chat_surface` helper (`graph/plugins/chat_surface.py`) so a chat
+  integration only implements transport (connect / receive / send); admin-gating,
+  per-conversation threads, agent invoke, reply-chunking, lifecycle + reconnect, and
+  the Test route are shared. Ships a **Telegram** plugin (`plugins/telegram`, opt-in)
+  as the ~80-line reference — Slack/WhatsApp/etc. follow the same shape. Discord stays
+  bespoke (richer extras) and can migrate incrementally.
+
 ## [0.22.0] - 2026-06-07
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -122,8 +122,15 @@ First-party plugins ship in `plugins/` (off by default — enable via `plugins.e
 | [`delegates`](./plugins/delegates/) | tool · settings | Hot-swappable registry of agents/endpoints (`delegate_to` over a2a / openai / acp) |
 | [`coding_agent`](./plugins/coding_agent/) | tool | Spawn a CLI coding agent (protoCLI, Claude Code, Codex, Gemini) over ACP |
 | [`discord`](./plugins/discord/) | surface · tool | Run the agent as a Discord bot — inbound DMs + outbound posting |
+| [`telegram`](./plugins/telegram/) | surface | Run the agent as a Telegram bot — the reference [communication plugin](./docs/guides/communication-plugins.md) |
 | [`google`](./plugins/google/) | mcp | Gmail + Calendar via a managed MCP server with in-app OAuth |
 | [`hello`](./plugins/hello/) | tool · skill · view | Minimal example — copy it to start your own |
+
+**Chat integrations** (Discord, Telegram, Slack, …) share a contract — implement a
+small `ChatAdapter` (connect / receive / send) + a manifest and the admin-gating,
+per-conversation threads, reply-chunking, lifecycle, and Test button are handled for
+you. See [Build a communication plugin](./docs/guides/communication-plugins.md)
+([ADR 0029](./docs/adr/0029-communication-plugins-standard.md)).
 
 **Publish your own:** tag your repo with the [`protoagent-plugin`](https://github.com/topics/protoagent-plugin)
 GitHub topic, then open a PR adding it to [`plugins.json`](./sites/marketing/data/plugins.json)

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -60,6 +60,7 @@ export default defineConfig({
             { text: "MCP servers", link: "/guides/mcp" },
             { text: "Plugins", link: "/guides/plugins" },
             { text: "Plugin console views", link: "/guides/plugin-views" },
+            { text: "Build a communication plugin", link: "/guides/communication-plugins" },
             { text: "Install & publish plugins (git URLs)", link: "/guides/plugin-registry" },
             { text: "Goal mode", link: "/guides/goal-mode" },
             { text: "Scheduler", link: "/guides/scheduler" },

--- a/docs/adr/0029-communication-plugins-standard.md
+++ b/docs/adr/0029-communication-plugins-standard.md
@@ -1,0 +1,89 @@
+# ADR 0029 — A standard for communication (chat-surface) plugins
+
+**Status:** Accepted (Telegram shipped as the reference)
+
+## Context
+
+Chat-ingress integrations are a recurring *class* of plugin: run the agent as a
+Discord bot, a Slack app, a Telegram bot, WhatsApp, etc. Discord shipped first
+(ADR 0015/0016 → 0018/0019) and encodes the whole shape — but as a bespoke
+surface. Every platform differs **only in transport** (how you connect, receive a
+message, and send one). The surrounding glue is identical every time:
+
+- gate inbound by an admin allowlist,
+- map a message to a stable per-conversation **session/thread** so LangGraph keeps
+  context across turns,
+- invoke the agent and **chunk** the reply to the platform's length limit,
+- lifecycle + **reconnect-on-save**,
+- a **Test connection** route, and the manifest's config/secrets/Settings.
+
+Without a standard, every new comms plugin re-implements that glue (and re-makes
+the same mistakes). The user's goal: *"add Slack/Telegram easily."*
+
+## Decision
+
+Name the transport piece as a small protocol and put the glue in one helper —
+`graph/plugins/chat_surface.py`.
+
+### D1 — The contract
+
+```python
+@dataclass
+class InboundMessage:
+    text: str
+    user_id: str        # for admin-gating
+    channel_id: str     # for the session/thread key
+    reply: Callable[[str], Awaitable[None]]   # platform send-back
+
+class ChatAdapter(Protocol):
+    id: str             # config section + route suffix, e.g. "telegram"
+    chunk_limit: int    # platform max message length (0 = no chunking)
+    def configured(self, cfg) -> bool: ...
+    async def validate(self, cfg) -> tuple[bool, str | None, str | None]: ...   # Test button
+    async def run(self, handle, *, cfg, host) -> None: ...   # connect → call handle per msg
+    # optional: outbound_tools(self) -> list
+```
+
+### D2 — One wirer owns the glue
+
+`register_chat_surface(registry, adapter)` does everything Discord hand-rolls:
+builds `handle` = admin-gate → session key → `host.invoke` → chunk → `reply`;
+registers the surface with start/stop + reconnect-on-reload; mounts
+`POST /api/config/test-<id>`; registers `outbound_tools()` if present. A new comms
+plugin's `register()` is therefore one line.
+
+### D3 — Session key = `"<id>:<channel_id>"`
+
+Per-conversation continuity (a Telegram chat, a Slack channel, a Discord DM each
+get their own LangGraph thread). Deliberately *not* one shared thread — that would
+collapse every conversation together. (Future: route through the
+`thread_id_resolver` seam from #571 for custom mapping.)
+
+### D4 — Discord stays bespoke for now
+
+Discord predates this contract and carries platform-specific richness the minimal
+adapter doesn't model — slow-response reactions, auto-threading, return-address,
+context warming. It keeps working as-is; the standard captures the **common
+subset**, and Discord can migrate onto the wirer incrementally (the glue is the
+same; its extras layer on top). Telegram is the clean reference adapter (~80 lines
+of transport + a manifest — no `surfaces/` module, since the Bot API is just HTTP).
+
+### D5 — Manifest convention
+
+A communication plugin claims `config_section: <id>`, `secrets: [<token>]`, and
+`settings: [enabled, <token>, admin_ids]` — so the console renders the Settings
+group + wizard step + Test button with no core edit.
+
+## Consequences
+
+- **Adding Slack/WhatsApp/etc. = implement `ChatAdapter` (4 methods) + a manifest +
+  a one-line `register()`.** No lifecycle, gating, threading, chunking, or reload code.
+- The **console Test button** is still wired per-Discord; a generic "test action"
+  affordance in the settings schema (so any comms plugin's Test button calls
+  `/api/config/test-<id>` with no console edit) is a follow-up.
+- The devkit can scaffold a comms-plugin skeleton (follow-up).
+
+See [Build a communication plugin](../guides/communication-plugins.md),
+[Plugins](../guides/plugins.md), ADR
+[0018](./0018-plugin-surfaces-routes-subagents.md) /
+[0019](./0019-plugin-config-settings-secrets.md).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -37,3 +37,4 @@ decision, numbered, never deleted (supersede instead).
 | [0026](./0026-plugin-contributed-console-surfaces.md) | Plugin-contributed console surfaces (rail views + tabs) | Accepted (complete; PR1–PR3) |
 | [0027](./0027-install-plugins-from-git-url.md) | Install plugins from a git URL (shareable plugin repos) | Accepted (sliced) |
 | [0028](./0028-plugin-goal-verifiers.md) | Plugin-contributed goal verifiers (+ safe programmatic goals) | Accepted (sliced) |
+| [0029](./0029-communication-plugins-standard.md) | A standard for communication (chat-surface) plugins | Accepted |

--- a/docs/guides/communication-plugins.md
+++ b/docs/guides/communication-plugins.md
@@ -1,0 +1,83 @@
+# Build a communication plugin
+
+A **communication plugin** turns your agent into a chat bot on a platform — Discord,
+Slack, Telegram, WhatsApp, … It's a normal [plugin](./plugins.md), but because every
+chat platform shares the same shape, there's a standard ([ADR 0029](../adr/0029-communication-plugins-standard.md))
+so you only write the **transport**. Everything else — admin-gating, per-conversation
+threads, invoking the agent, chunking replies, lifecycle + reconnect, the Test button —
+is shared.
+
+## The two pieces
+
+**1. An adapter** implementing `ChatAdapter` (the platform-specific half):
+
+```python
+# plugins/telegram/__init__.py
+from graph.plugins.chat_surface import InboundMessage, register_chat_surface
+
+class TelegramAdapter:
+    id = "telegram"
+    chunk_limit = 4096                      # platform message-length cap
+
+    def configured(self, cfg) -> bool:      # do we have creds to connect?
+        return bool((cfg.get("bot_token") or "").strip())
+
+    async def validate(self, cfg):          # the console "Test connection" button
+        # → (ok, identity_or_None, error_or_None)
+        ...
+
+    async def run(self, handle, *, cfg, host):
+        # connect, then loop: for each inbound message build an InboundMessage
+        # (with a `reply` that sends back) and `await handle(msg)`. Runs until cancelled.
+        async def reply(text, _chat=chat_id):
+            await send(_chat, text)
+        await handle(InboundMessage(text=text, user_id=str(uid),
+                                    channel_id=str(chat_id), reply=reply))
+
+def register(registry):
+    register_chat_surface(registry, TelegramAdapter())   # ← the whole wiring
+```
+
+**2. A manifest** declaring the config surface (the console renders Settings + Test
+from this):
+
+```yaml
+# plugins/telegram/protoagent.plugin.yaml
+id: telegram
+name: Telegram
+config_section: telegram
+config: { enabled: false, admin_ids: [] }
+secrets: [bot_token]
+settings:
+  - { key: enabled,   label: "Enable Telegram", type: bool }
+  - { key: bot_token, label: "Bot token",       type: secret }
+  - { key: admin_ids, label: "Admin user IDs",  type: string_list }
+```
+
+## What `register_chat_surface` does for you
+
+| Concern | Handled by the wirer |
+| --- | --- |
+| Admin allowlist | `admin_ids` gate on `msg.user_id` (empty = anyone) |
+| Conversation memory | session/thread key `"<id>:<channel_id>"` — per-chat continuity |
+| Running the agent | `host.invoke(text, session_id)` |
+| Long replies | split to `adapter.chunk_limit` (newline/space-aware) |
+| Lifecycle | start/stop + **reconnect on Settings save** |
+| Test connection | `POST /api/config/test-<id>` → `adapter.validate` |
+| Send tools | registers `adapter.outbound_tools()` if you define it |
+
+So your adapter only implements **connect / receive → `handle` / send**.
+
+## Use it
+
+```bash
+# enable the bundled Telegram plugin (or install your own from a git URL)
+# config.yaml → plugins: { enabled: [telegram] }
+```
+
+Set the bot token in **Settings → Telegram**, hit **Test connection**, enable, save —
+the gateway reconnects live. Message your bot; replies come back in the same chat,
+each chat its own thread.
+
+See [ADR 0029](../adr/0029-communication-plugins-standard.md),
+[Plugins](./plugins.md), [Install & publish plugins](./plugin-registry.md).

--- a/graph/plugins/chat_surface.py
+++ b/graph/plugins/chat_surface.py
@@ -1,0 +1,153 @@
+"""A standard for **communication plugins** — chat-ingress surfaces (Discord,
+Slack, Telegram, …) — built on the plugin system (ADR 0018/0019, ADR 0029).
+
+Every chat platform differs only in *transport*. The glue — admin-gating, mapping
+an inbound message to a stable session/thread, invoking the agent, chunking the
+reply to the platform's limit, lifecycle + reconnect-on-save, and the Test route —
+is identical. So this module names the transport piece as a small protocol
+(``ChatAdapter``) and puts the glue in one helper (``register_chat_surface``).
+
+A new comms plugin then implements **only** the adapter (connect, receive → call
+``handle``, send) and a manifest, and its ``register()`` is one line::
+
+    from graph.plugins.chat_surface import register_chat_surface
+    def register(registry):
+        register_chat_surface(registry, MyAdapter())
+
+The manifest convention (ADR 0029): ``config_section: <id>``, ``secrets: [<token>]``,
+``settings: [enabled, <token>, admin_ids]``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+from typing import Awaitable, Callable, Protocol, runtime_checkable
+
+log = logging.getLogger("protoagent.plugins.chat_surface")
+
+
+@dataclass
+class InboundMessage:
+    """One inbound chat message, normalized across platforms."""
+
+    text: str
+    user_id: str   # platform user id — for admin-gating
+    channel_id: str  # platform channel/DM id — for the session/thread key
+    reply: Callable[[str], Awaitable[None]]  # adapter-provided send-back
+
+
+@runtime_checkable
+class ChatAdapter(Protocol):
+    """The transport half of a communication plugin. Implement these; the wirer
+    does everything else."""
+
+    id: str          # config section + route suffix, e.g. "telegram"
+    chunk_limit: int  # max outbound message length (0 = no chunking)
+
+    def configured(self, cfg: dict) -> bool:
+        """True when the credentials needed to connect are present in ``cfg``."""
+
+    async def validate(self, cfg: dict) -> tuple[bool, str | None, str | None]:
+        """Verify the credentials (the console Test button). Returns
+        ``(ok, identity, error)`` — identity is e.g. the bot's username."""
+
+    async def run(self, handle: Callable[[InboundMessage], Awaitable[None]], *,
+                  cfg: dict, host) -> None:
+        """Connect and loop: for each inbound message, build an ``InboundMessage``
+        (with a ``reply`` that sends back) and ``await handle(msg)``. Runs until
+        cancelled. ``host`` exposes ``publish``/``subscribe`` for extras."""
+
+    # Optional: ``outbound_tools(self) -> list`` to also give the agent send tools.
+
+
+def _chunk(text: str, limit: int) -> list[str]:
+    """Split ``text`` into pieces ≤ ``limit``, preferring newline then space
+    boundaries. ``limit<=0`` → one piece."""
+    text = text or ""
+    if limit <= 0 or len(text) <= limit:
+        return [text] if text else []
+    out: list[str] = []
+    rest = text
+    while len(rest) > limit:
+        window = rest[:limit]
+        cut = window.rfind("\n")
+        if cut < limit // 2:
+            cut = window.rfind(" ")
+        if cut < limit // 2:
+            cut = limit
+        out.append(rest[:cut].rstrip())
+        rest = rest[cut:].lstrip()
+    if rest:
+        out.append(rest)
+    return out
+
+
+def register_chat_surface(registry, adapter: ChatAdapter) -> None:
+    """Wire a ``ChatAdapter`` as a first-party-style communication plugin: the
+    inbound→invoke→reply glue, lifecycle + reconnect-on-save, a Test route, and
+    any outbound tools. Reads config from the plugin's manifest section
+    (``enabled``, credentials, ``admin_ids``)."""
+    host = registry.host
+    state: dict = {"task": None}
+
+    async def handle(msg: InboundMessage) -> None:
+        admin_ids = {str(a).strip() for a in (registry.config.get("admin_ids") or []) if str(a).strip()}
+        if admin_ids and str(msg.user_id) not in admin_ids:
+            log.info("[%s] ignoring non-admin user %s", adapter.id, msg.user_id)
+            return
+        session_id = f"{adapter.id}:{msg.channel_id}"  # stable per-conversation thread
+        try:
+            answer = await host.invoke(msg.text, session_id)
+        except Exception:  # noqa: BLE001 — a turn error must not kill the gateway
+            log.exception("[%s] invoke failed", adapter.id)
+            await msg.reply("⚠️ Something went wrong handling that — try again.")
+            return
+        for piece in _chunk(answer, adapter.chunk_limit):
+            await msg.reply(piece)
+
+    def _should_start(cfg: dict) -> bool:
+        return bool(cfg.get("enabled")) and adapter.configured(cfg)
+
+    def _start():
+        cfg = registry.config
+        if not _should_start(cfg):
+            log.info("[%s] not started (enabled=%s, configured=%s)",
+                     adapter.id, cfg.get("enabled"), adapter.configured(cfg))
+            return None
+        if not (host and host.invoke):
+            log.warning("[%s] no agent invoke available — not started", adapter.id)
+            return None
+        state["task"] = asyncio.ensure_future(adapter.run(handle, cfg=dict(cfg), host=host))
+        return state["task"]
+
+    async def _stop():
+        task = state.get("task")
+        if task is not None:
+            task.cancel()
+            state["task"] = None
+
+    async def _reload(new_config):
+        new = (getattr(new_config, "plugin_config", {}) or {}).get(adapter.id, {})
+        await _stop()
+        registry.config = dict(new)
+        _start()
+
+    registry.register_surface(_start, stop=_stop, reload=_reload, name=f"{adapter.id}-gateway")
+
+    # Test route — mounted at the convention path so a console Test button works.
+    from fastapi import APIRouter
+
+    router = APIRouter()
+
+    @router.post(f"/api/config/test-{adapter.id}")
+    async def _test(body: dict | None = None):
+        ok, identity, error = await adapter.validate({**registry.config, **(body or {})})
+        return {"ok": ok, "identity": identity, "error": error}
+
+    registry.register_router(router, prefix="")
+
+    tools = adapter.outbound_tools() if hasattr(adapter, "outbound_tools") else []
+    if tools:
+        registry.register_tools(tools)

--- a/plugins/telegram/__init__.py
+++ b/plugins/telegram/__init__.py
@@ -1,0 +1,94 @@
+"""Telegram communication plugin (ADR 0029) — the reference ``ChatAdapter``.
+
+Self-contained: the Telegram Bot API is plain HTTP (httpx long-poll), so unlike
+Discord there's no ``surfaces/`` module — the adapter *is* the transport. This is
+the template for new comms plugins: implement ``ChatAdapter`` (connect, receive →
+``handle``, send) + a manifest, and ``register()`` is one line. Slack/WhatsApp/etc.
+follow the same shape.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from graph.plugins.chat_surface import InboundMessage, register_chat_surface
+
+log = logging.getLogger("protoagent.plugins.telegram")
+
+_API = "https://api.telegram.org/bot{token}/{method}"
+
+
+class TelegramAdapter:
+    """Telegram Bot API over httpx long-poll. The whole platform-specific surface."""
+
+    id = "telegram"
+    chunk_limit = 4096  # Telegram's per-message character cap
+
+    def _token(self, cfg: dict) -> str:
+        return (cfg.get("bot_token") or "").strip()
+
+    def configured(self, cfg: dict) -> bool:
+        return bool(self._token(cfg))
+
+    async def validate(self, cfg: dict) -> tuple[bool, str | None, str | None]:
+        import httpx
+
+        token = self._token(cfg)
+        if not token:
+            return (False, None, "No bot token set.")
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.get(_API.format(token=token, method="getMe"))
+            data = resp.json()
+            if data.get("ok"):
+                return (True, (data.get("result") or {}).get("username"), None)
+            return (False, None, data.get("description") or "Invalid bot token")
+        except Exception as exc:  # noqa: BLE001
+            return (False, None, str(exc))
+
+    async def run(self, handle, *, cfg: dict, host) -> None:
+        import httpx
+
+        token = self._token(cfg)
+        offset = 0
+        # timeout > the 30s long-poll so the connection isn't cut mid-poll.
+        async with httpx.AsyncClient(timeout=40) as client:
+
+            async def _send(chat_id, text: str) -> None:
+                await client.post(_API.format(token=token, method="sendMessage"),
+                                  json={"chat_id": chat_id, "text": text})
+
+            log.info("[telegram] gateway started (long-poll)")
+            while True:
+                try:
+                    resp = await client.get(
+                        _API.format(token=token, method="getUpdates"),
+                        params={"offset": offset, "timeout": 30},
+                    )
+                    updates = (resp.json() or {}).get("result") or []
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001 — transient network/API error; back off + retry
+                    log.exception("[telegram] getUpdates failed; backing off 5s")
+                    await asyncio.sleep(5)
+                    continue
+                for upd in updates:
+                    offset = upd["update_id"] + 1
+                    message = upd.get("message") or {}
+                    text = message.get("text")
+                    if not text:
+                        continue
+                    chat_id = (message.get("chat") or {}).get("id")
+                    user_id = str((message.get("from") or {}).get("id") or "")
+
+                    async def reply(out: str, _cid=chat_id) -> None:
+                        await _send(_cid, out)
+
+                    await handle(InboundMessage(
+                        text=text, user_id=user_id, channel_id=str(chat_id), reply=reply,
+                    ))
+
+
+def register(registry) -> None:
+    register_chat_surface(registry, TelegramAdapter())

--- a/plugins/telegram/protoagent.plugin.yaml
+++ b/plugins/telegram/protoagent.plugin.yaml
@@ -1,0 +1,21 @@
+id: telegram
+name: Telegram
+version: 0.1.0
+description: >-
+  Run your agent as a Telegram bot — inbound DMs/groups via long-poll, replies
+  back out. The reference **communication plugin** (ADR 0029): built on the
+  ChatAdapter standard, so it's ~80 lines of transport + a manifest. Off until you
+  set a bot token in Settings → Telegram. Disable with `plugins: { disabled: [telegram] }`.
+# Bundled but opt-in — enable with `plugins: { enabled: [telegram] }` (Discord is
+# the always-loaded legacy default; new comms plugins are download-to-use).
+enabled: false
+requires_env: []
+config_section: telegram
+config:
+  enabled: false
+  admin_ids: []
+secrets: [bot_token]
+settings:
+  - { key: enabled, label: "Enable Telegram", type: bool, description: "Inbound gateway. Needs the bot token below; reconnects live on save." }
+  - { key: bot_token, label: "Bot token", type: secret, description: "From @BotFather (/newbot). Use “Test connection” to verify before saving." }
+  - { key: admin_ids, label: "Admin user IDs", type: string_list, description: "Telegram numeric user IDs allowed to message the bot (one per line). Empty = anyone." }

--- a/sites/marketing/data/plugins.json
+++ b/sites/marketing/data/plugins.json
@@ -52,6 +52,19 @@
     }
   },
   {
+    "id": "telegram",
+    "name": "Telegram",
+    "official": true,
+    "tagline": "Run your agent as a Telegram bot — inbound DMs/groups, replies back out. The reference communication plugin (ADR 0029) — ~80 lines of transport on the ChatAdapter standard.",
+    "adds": ["surface", "config"],
+    "bundled": true,
+    "enable": "telegram",
+    "links": {
+      "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/telegram",
+      "docs": "/docs/guides/communication-plugins"
+    }
+  },
+  {
     "id": "google",
     "name": "Google (Gmail + Calendar)",
     "official": true,

--- a/tests/test_chat_surface.py
+++ b/tests/test_chat_surface.py
@@ -1,0 +1,141 @@
+"""The communication-plugin standard — ChatAdapter + register_chat_surface (ADR 0029)."""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.plugins.chat_surface import InboundMessage, _chunk, register_chat_surface
+
+
+# --- fakes -------------------------------------------------------------------
+
+class FakeHost:
+    def __init__(self, answer="RESPONSE"):
+        self.answer = answer
+        self.invoked: list[tuple] = []
+        self.publish = None
+        self.subscribe = None
+        self.raise_exc = False
+
+    async def invoke(self, prompt, session_id):
+        self.invoked.append((prompt, session_id))
+        if self.raise_exc:
+            raise RuntimeError("boom")
+        return self.answer
+
+
+class FakeAdapter:
+    id = "fake"
+    chunk_limit = 10
+
+    def __init__(self):
+        self.handle = None
+
+    def configured(self, cfg):
+        return bool(cfg.get("bot_token"))
+
+    async def validate(self, cfg):
+        return (True, "fakebot", None) if cfg.get("bot_token") else (False, None, "no token")
+
+    async def run(self, handle, *, cfg, host):
+        self.handle = handle  # capture so tests can drive it
+
+
+class FakeRegistry:
+    def __init__(self, config, host):
+        self.config = config
+        self.host = host
+        self.surface = None
+        self.routers = []
+        self.tools = []
+
+    def register_surface(self, start, stop=None, name=None, reload=None):
+        self.surface = {"start": start, "stop": stop, "reload": reload, "name": name}
+
+    def register_router(self, router, prefix=""):
+        self.routers.append((router, prefix))
+
+    def register_tools(self, tools):
+        self.tools.extend(tools)
+
+
+def _wire(config, host=None):
+    host = host or FakeHost()
+    adapter = FakeAdapter()
+    reg = FakeRegistry(config, host)
+    register_chat_surface(reg, adapter)
+    return reg, adapter, host
+
+
+# --- chunking ----------------------------------------------------------------
+
+def test_chunk_respects_limit_and_prefers_boundaries():
+    assert _chunk("", 10) == []
+    assert _chunk("short", 10) == ["short"]
+    parts = _chunk("hello world foo bar baz", 12)
+    assert all(len(p) <= 12 for p in parts) and "".join(p.replace(" ", "") for p in parts) == "helloworldfoobarbaz"
+    assert _chunk("abc", 0) == ["abc"]  # no chunking
+
+
+# --- wiring ------------------------------------------------------------------
+
+def test_registers_surface_test_route_and_no_tools():
+    reg, _, _ = _wire({"enabled": True, "bot_token": "t"})
+    assert reg.surface and reg.surface["name"] == "fake-gateway"
+    paths = [r.path for (router, _p) in reg.routers for r in router.routes]
+    assert "/api/config/test-fake" in paths
+    assert reg.tools == []
+
+
+# --- handle glue (admin-gate, session key, invoke, chunked reply) ------------
+
+@pytest.mark.asyncio
+async def test_handle_invokes_and_replies_with_session_key():
+    reg, adapter, host = _wire({"enabled": True, "bot_token": "t"})
+    reg.surface["start"]()
+    await __import__("asyncio").sleep(0)  # let run() capture handle
+    sent = []
+    await adapter.handle(InboundMessage("hi there", "u1", "c9", lambda s: _collect(sent, s)))
+    assert host.invoked == [("hi there", "fake:c9")]   # session = "<id>:<channel>"
+    assert sent == ["RESPONSE"]
+
+
+@pytest.mark.asyncio
+async def test_handle_chunks_long_answers():
+    reg, adapter, host = _wire({"enabled": True, "bot_token": "t"}, FakeHost(answer="A" * 25))
+    reg.surface["start"](); await __import__("asyncio").sleep(0)
+    sent = []
+    await adapter.handle(InboundMessage("x", "u", "c", lambda s: _collect(sent, s)))
+    assert len(sent) == 3 and all(len(p) <= 10 for p in sent)  # 25 / chunk_limit 10
+
+
+@pytest.mark.asyncio
+async def test_handle_admin_gating():
+    reg, adapter, host = _wire({"enabled": True, "bot_token": "t", "admin_ids": ["123"]})
+    reg.surface["start"](); await __import__("asyncio").sleep(0)
+    sent = []
+    await adapter.handle(InboundMessage("hi", "999", "c", lambda s: _collect(sent, s)))  # not admin
+    assert host.invoked == [] and sent == []
+    await adapter.handle(InboundMessage("hi", "123", "c", lambda s: _collect(sent, s)))  # admin
+    assert len(host.invoked) == 1
+
+
+@pytest.mark.asyncio
+async def test_handle_invoke_error_replies_gracefully():
+    host = FakeHost(); host.raise_exc = True
+    reg, adapter, _ = _wire({"enabled": True, "bot_token": "t"}, host)
+    reg.surface["start"](); await __import__("asyncio").sleep(0)
+    sent = []
+    await adapter.handle(InboundMessage("x", "u", "c", lambda s: _collect(sent, s)))
+    assert len(sent) == 1 and "went wrong" in sent[0]
+
+
+def test_start_skips_when_not_configured_or_disabled():
+    reg, _, _ = _wire({"enabled": True})            # no token
+    assert reg.surface["start"]() is None
+    reg2, _, _ = _wire({"enabled": False, "bot_token": "t"})  # disabled
+    assert reg2.surface["start"]() is None
+
+
+async def _collect(bucket, s):
+    bucket.append(s)

--- a/tests/test_telegram_plugin.py
+++ b/tests/test_telegram_plugin.py
@@ -1,0 +1,94 @@
+"""Telegram communication plugin — the reference ChatAdapter (ADR 0029)."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+from plugins.telegram import TelegramAdapter
+
+
+def test_manifest_is_a_comms_plugin():
+    m = yaml.safe_load(Path("plugins/telegram/protoagent.plugin.yaml").read_text())
+    assert m["id"] == "telegram" and m["config_section"] == "telegram"
+    assert "bot_token" in m["secrets"]
+    keys = {s["key"] for s in m["settings"]}
+    assert {"enabled", "bot_token", "admin_ids"} <= keys
+
+
+def test_configured():
+    a = TelegramAdapter()
+    assert a.configured({"bot_token": "t"}) is True
+    assert a.configured({"bot_token": "  "}) is False
+    assert a.configured({}) is False
+
+
+class _Resp:
+    def __init__(self, data): self._data = data
+    def json(self): return self._data
+
+
+def _fake_client_class(updates):
+    instances = []
+
+    class FakeClient:
+        def __init__(self, *a, **k):
+            self.posts = []
+            self._update_calls = 0
+            instances.append(self)
+
+        async def __aenter__(self): return self
+        async def __aexit__(self, *a): return False
+
+        async def get(self, url, params=None):
+            if "getMe" in url:
+                return _Resp({"ok": True, "result": {"username": "mybot"}})
+            self._update_calls += 1                       # getUpdates
+            if self._update_calls == 1:
+                return _Resp({"ok": True, "result": updates})
+            raise asyncio.CancelledError()                # 2nd poll → surface cancelled
+
+        async def post(self, url, json=None):
+            self.posts.append(json)
+            return _Resp({"ok": True})
+
+    return FakeClient, instances
+
+
+@pytest.mark.asyncio
+async def test_validate_ok(monkeypatch):
+    FakeClient, _ = _fake_client_class([])
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+    ok, who, err = await TelegramAdapter().validate({"bot_token": "t"})
+    assert ok and who == "mybot" and err is None
+
+
+@pytest.mark.asyncio
+async def test_validate_no_token():
+    ok, who, err = await TelegramAdapter().validate({})
+    assert not ok and "No bot token" in err
+
+
+@pytest.mark.asyncio
+async def test_run_dispatches_inbound_and_reply_sends(monkeypatch):
+    update = {"update_id": 1, "message": {"text": "hi", "chat": {"id": 7}, "from": {"id": 42}}}
+    FakeClient, instances = _fake_client_class([update])
+    monkeypatch.setattr(httpx, "AsyncClient", FakeClient)
+
+    captured = []
+
+    async def handle(msg):
+        captured.append(msg)
+        await msg.reply("pong")
+
+    with pytest.raises(asyncio.CancelledError):
+        await TelegramAdapter().run(handle, cfg={"bot_token": "t"}, host=None)
+
+    assert len(captured) == 1
+    m = captured[0]
+    assert m.text == "hi" and m.user_id == "42" and m.channel_id == "7"
+    assert instances[-1].posts == [{"chat_id": 7, "text": "pong"}]


### PR DESCRIPTION
A standard for **communication plugins** so new chat integrations (Slack, Telegram, WhatsApp…) are trivial to add — you write only the transport.

## What
- **`ChatAdapter` contract + `register_chat_surface` wirer** (`graph/plugins/chat_surface.py`). The wirer owns the glue every chat surface needs: admin-gating, per-conversation thread key (`<id>:<channel>`), `host.invoke`, reply-chunking, lifecycle + reconnect-on-save, the `/api/config/test-<id>` route, outbound tools. An adapter implements only **connect / receive → handle / send**.
- **`plugins/telegram`** — the reference adapter (~80 lines, httpx long-poll, no `surfaces/` module). Opt-in (`plugins.enabled: [telegram]`).
- **Discord stays bespoke** (slow-response reactions, auto-threading, return-address) — keeps working; migrates onto the wirer incrementally. The standard captures the common subset.
- **ADR 0029** + a [Build a communication plugin](docs/guides/communication-plugins.md) guide; added to the plugin directory + README.

Adding **Slack** is now: implement `SlackAdapter` (4 methods) + a manifest + a one-line `register()`.

## Test
```
pytest tests/test_chat_surface.py tests/test_telegram_plugin.py   # wirer vs fake adapter · telegram validate/run (mocked httpx)
pytest -q   # 1181 passed ; ruff clean ; docs + site build green
```

## Follow-ups (in the ADR)
- Generic console **Test button** affordance (so any comms plugin's button calls `/api/config/test-<id>` with no console edit).
- Devkit **scaffold** for a comms plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)