### PR TITLE
feat(plugins): Slack communication plugin (Socket Mode, ADR 0029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the Test route are shared. Ships a **Telegram** plugin (`plugins/telegram`, opt-in)
   as the ~80-line reference — Slack/WhatsApp/etc. follow the same shape. Discord stays
   bespoke (richer extras) and can migrate incrementally.
+- **Slack plugin** (`plugins/slack`, opt-in) — a Socket Mode `ChatAdapter` (no public
+  URL), proving the standard handles a **websocket** transport as cleanly as Telegram's
+  HTTP long-poll. Needs a bot token (xoxb-) + an app-level token (xapp-).
 
 ## [0.22.0] - 2026-06-07
 

--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ First-party plugins ship in `plugins/` (off by default — enable via `plugins.e
 | [`coding_agent`](./plugins/coding_agent/) | tool | Spawn a CLI coding agent (protoCLI, Claude Code, Codex, Gemini) over ACP |
 | [`discord`](./plugins/discord/) | surface · tool | Run the agent as a Discord bot — inbound DMs + outbound posting |
 | [`telegram`](./plugins/telegram/) | surface | Run the agent as a Telegram bot — the reference [communication plugin](./docs/guides/communication-plugins.md) |
+| [`slack`](./plugins/slack/) | surface | Run the agent as a Slack app over Socket Mode (websocket transport) |
 | [`google`](./plugins/google/) | mcp | Gmail + Calendar via a managed MCP server with in-app OAuth |
 | [`hello`](./plugins/hello/) | tool · skill · view | Minimal example — copy it to start your own |
 

--- a/plugins/slack/__init__.py
+++ b/plugins/slack/__init__.py
@@ -1,0 +1,110 @@
+"""Slack communication plugin (ADR 0029) — a Socket Mode ``ChatAdapter``.
+
+Shows the standard handling a **websocket** transport (vs Telegram's HTTP
+long-poll): Socket Mode opens a WSS via ``apps.connections.open``, receives event
+envelopes (which must be **acked** by echoing the ``envelope_id``), and replies via
+``chat.postMessage``. Needs a bot token (``xoxb-``) for the Web API and an
+app-level token (``xapp-``, ``connections:write``) for the socket. The adapter is
+the only platform-specific code; the wirer handles the rest.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+
+from graph.plugins.chat_surface import InboundMessage, register_chat_surface
+
+log = logging.getLogger("protoagent.plugins.slack")
+
+_API = "https://slack.com/api/{method}"
+
+
+class SlackAdapter:
+    id = "slack"
+    chunk_limit = 39000  # Slack's ~40k message cap, with headroom
+
+    def _bot(self, cfg: dict) -> str:
+        return (cfg.get("bot_token") or "").strip()
+
+    def _app(self, cfg: dict) -> str:
+        return (cfg.get("app_token") or "").strip()
+
+    def configured(self, cfg: dict) -> bool:
+        return bool(self._bot(cfg) and self._app(cfg))
+
+    async def validate(self, cfg: dict) -> tuple[bool, str | None, str | None]:
+        import httpx
+
+        bot = self._bot(cfg)
+        if not (bot and self._app(cfg)):
+            return (False, None, "Need both a bot token (xoxb-) and an app-level token (xapp-).")
+        try:
+            async with httpx.AsyncClient(timeout=10) as client:
+                resp = await client.post(_API.format(method="auth.test"),
+                                         headers={"Authorization": f"Bearer {bot}"})
+            data = resp.json()
+            if data.get("ok"):
+                return (True, data.get("user") or data.get("team"), None)
+            return (False, None, data.get("error") or "auth.test failed")
+        except Exception as exc:  # noqa: BLE001
+            return (False, None, str(exc))
+
+    async def run(self, handle, *, cfg: dict, host) -> None:
+        import httpx
+        import websockets
+
+        bot, app = self._bot(cfg), self._app(cfg)
+        async with httpx.AsyncClient(timeout=30) as client:
+
+            async def _open_socket() -> str:
+                resp = await client.post(_API.format(method="apps.connections.open"),
+                                         headers={"Authorization": f"Bearer {app}"})
+                data = resp.json()
+                if not data.get("ok"):
+                    raise RuntimeError(f"apps.connections.open: {data.get('error')}")
+                return data["url"]
+
+            async def _post(channel: str, text: str) -> None:
+                await client.post(_API.format(method="chat.postMessage"),
+                                  headers={"Authorization": f"Bearer {bot}"},
+                                  json={"channel": channel, "text": text})
+
+            log.info("[slack] gateway started (socket mode)")
+            while True:
+                try:
+                    url = await _open_socket()
+                    async with websockets.connect(url) as ws:
+                        async for raw in ws:
+                            env = json.loads(raw)
+                            etype = env.get("type")
+                            if etype == "disconnect":
+                                break  # Slack asked us to reconnect
+                            if env.get("envelope_id"):
+                                await ws.send(json.dumps({"envelope_id": env["envelope_id"]}))  # ack
+                            if etype != "events_api":
+                                continue
+                            ev = (env.get("payload") or {}).get("event") or {}
+                            # Skip non-messages, edits, and our own / other bots' posts (loop guard).
+                            if ev.get("type") != "message" or ev.get("subtype") or ev.get("bot_id"):
+                                continue
+                            text, channel, uid = ev.get("text"), ev.get("channel"), ev.get("user")
+                            if not (text and channel):
+                                continue
+
+                            async def reply(out: str, _ch=channel) -> None:
+                                await _post(_ch, out)
+
+                            await handle(InboundMessage(
+                                text=text, user_id=str(uid or ""), channel_id=str(channel), reply=reply,
+                            ))
+                except asyncio.CancelledError:
+                    raise
+                except Exception:  # noqa: BLE001 — transient socket/API error; reconnect
+                    log.exception("[slack] socket error; reconnecting in 5s")
+                    await asyncio.sleep(5)
+
+
+def register(registry) -> None:
+    register_chat_surface(registry, SlackAdapter())

--- a/plugins/slack/protoagent.plugin.yaml
+++ b/plugins/slack/protoagent.plugin.yaml
@@ -1,0 +1,21 @@
+id: slack
+name: Slack
+version: 0.1.0
+description: >-
+  Run your agent as a Slack app over **Socket Mode** (no public URL needed) —
+  inbound messages, replies back out. A communication plugin (ADR 0029) on the
+  ChatAdapter standard. Needs a bot token (xoxb-) + an app-level token (xapp-,
+  scope `connections:write`). Off until both are set in Settings → Slack.
+# Bundled but opt-in — enable with `plugins: { enabled: [slack] }`.
+enabled: false
+requires_pip: ["websockets>=12"]
+config_section: slack
+config:
+  enabled: false
+  admin_ids: []
+secrets: [bot_token, app_token]
+settings:
+  - { key: enabled, label: "Enable Slack", type: bool, description: "Inbound Socket Mode gateway. Needs both tokens below; reconnects live on save." }
+  - { key: bot_token, label: "Bot token (xoxb-)", type: secret, description: "OAuth bot token from your Slack app (scopes: chat:write, app_mentions:read or message.* events)." }
+  - { key: app_token, label: "App-level token (xapp-)", type: secret, description: "App-level token with `connections:write` (Slack app → Basic Information → App-Level Tokens). Required for Socket Mode." }
+  - { key: admin_ids, label: "Admin user IDs", type: string_list, description: "Slack user IDs allowed to message the bot (one per line). Empty = anyone." }

--- a/sites/marketing/data/plugins.json
+++ b/sites/marketing/data/plugins.json
@@ -65,6 +65,19 @@
     }
   },
   {
+    "id": "slack",
+    "name": "Slack",
+    "official": true,
+    "tagline": "Run your agent as a Slack app over Socket Mode (no public URL) — inbound messages, replies back out. A communication plugin (ADR 0029) with a websocket transport.",
+    "adds": ["surface", "config"],
+    "bundled": true,
+    "enable": "slack",
+    "links": {
+      "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/slack",
+      "docs": "/docs/guides/communication-plugins"
+    }
+  },
+  {
     "id": "google",
     "name": "Google (Gmail + Calendar)",
     "official": true,

--- a/tests/test_slack_plugin.py
+++ b/tests/test_slack_plugin.py
@@ -1,0 +1,61 @@
+"""Slack communication plugin — Socket Mode ChatAdapter (ADR 0029)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import httpx
+import pytest
+import yaml
+
+from plugins.slack import SlackAdapter
+
+
+def test_manifest_is_a_comms_plugin():
+    m = yaml.safe_load(Path("plugins/slack/protoagent.plugin.yaml").read_text())
+    assert m["id"] == "slack" and m["config_section"] == "slack"
+    assert {"bot_token", "app_token"} <= set(m["secrets"])
+    assert {"enabled", "bot_token", "app_token", "admin_ids"} <= {s["key"] for s in m["settings"]}
+
+
+def test_configured_needs_both_tokens():
+    a = SlackAdapter()
+    assert a.configured({"bot_token": "xoxb", "app_token": "xapp"}) is True
+    assert a.configured({"bot_token": "xoxb"}) is False
+    assert a.configured({"app_token": "xapp"}) is False
+
+
+class _Resp:
+    def __init__(self, data): self._data = data
+    def json(self): return self._data
+
+
+class _FakeClient:
+    def __init__(self, data): self._data = data; self.calls = []
+    def __call__(self, *a, **k): return self
+    async def __aenter__(self): return self
+    async def __aexit__(self, *a): return False
+    async def post(self, url, headers=None, json=None):
+        self.calls.append(url)
+        return _Resp(self._data)
+
+
+@pytest.mark.asyncio
+async def test_validate_ok(monkeypatch):
+    fake = _FakeClient({"ok": True, "user": "agentbot"})
+    monkeypatch.setattr(httpx, "AsyncClient", fake)
+    ok, who, err = await SlackAdapter().validate({"bot_token": "xoxb", "app_token": "xapp"})
+    assert ok and who == "agentbot" and err is None
+
+
+@pytest.mark.asyncio
+async def test_validate_missing_tokens():
+    ok, who, err = await SlackAdapter().validate({"bot_token": "xoxb"})
+    assert not ok and "app-level token" in err
+
+
+@pytest.mark.asyncio
+async def test_validate_auth_error(monkeypatch):
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient({"ok": False, "error": "invalid_auth"}))
+    ok, _who, err = await SlackAdapter().validate({"bot_token": "xoxb", "app_token": "xapp"})
+    assert not ok and err == "invalid_auth"


### PR DESCRIPTION
The second comms adapter on the ChatAdapter standard — a **websocket** transport (Socket Mode), proving the standard handles more than Telegram's HTTP long-poll.

- `plugins/slack/` — Socket Mode (`apps.connections.open` → WSS, ack envelopes, `chat.postMessage`). Bot token (xoxb-) + app-level token (xapp-, `connections:write`). Opt-in.
- ~90 lines of transport on the shared wirer — admin-gating / threads / chunking / lifecycle / Test route all inherited.
- Tests green (validate ok/missing/auth-error, configured, manifest); loads via the loader. In the directory + README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)