### PR TITLE
feat(devkit): scaffold communication plugins (with_comms)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Slack plugin** (`plugins/slack`, opt-in) — a Socket Mode `ChatAdapter` (no public
   URL), proving the standard handles a **websocket** transport as cleanly as Telegram's
   HTTP long-poll. Needs a bot token (xoxb-) + an app-level token (xapp-).
+- **Devkit comms scaffold** — `scaffold_plugin(..., with_comms=True)` writes a
+  `ChatAdapter` skeleton on the shared wirer, so the agent can stub a new chat
+  integration itself.
 
 ## [0.22.0] - 2026-06-07
 

--- a/plugins/plugin-devkit/__init__.py
+++ b/plugins/plugin-devkit/__init__.py
@@ -105,6 +105,64 @@ steps:
 output: "{{{{steps.do.output}}}}"
 """
 
+# Communication plugin (ADR 0029) — a ChatAdapter on the shared wirer.
+_COMMS_MANIFEST_STUB = """id: {id}
+name: {name}
+version: 0.1.0
+description: >-
+  {summary}
+enabled: false
+config_section: {id}
+config:
+  enabled: false
+  admin_ids: []
+secrets: [bot_token]
+settings:
+  - {{ key: enabled, label: "Enable {name}", type: bool, description: "Inbound gateway. Needs the token below; reconnects live on save." }}
+  - {{ key: bot_token, label: "Bot token", type: secret, description: "Platform bot token. Use Test connection to verify." }}
+  - {{ key: admin_ids, label: "Admin user IDs", type: string_list, description: "User IDs allowed to message the bot (one per line). Empty = anyone." }}
+"""
+
+_COMMS_INIT_STUB = '''"""{name} — a communication plugin (scaffolded by plugin-devkit, ADR 0029).
+
+Implement the transport (connect / receive / send); the shared wirer handles
+admin-gating, per-conversation threads, agent invoke, reply-chunking, lifecycle,
+and the Test route. Reference: plugins/telegram. Guide:
+docs/guides/communication-plugins.md.
+"""
+
+from __future__ import annotations
+
+from graph.plugins.chat_surface import InboundMessage, register_chat_surface
+
+
+class {cls}Adapter:
+    id = "{id}"
+    chunk_limit = 4000  # your platform's message-length cap (0 = no chunking)
+
+    def configured(self, cfg) -> bool:
+        return bool((cfg.get("bot_token") or "").strip())
+
+    async def validate(self, cfg):
+        """Verify the token (the Test button). Return (ok, identity|None, error|None)."""
+        token = (cfg.get("bot_token") or "").strip()
+        if not token:
+            return (False, None, "No bot token set.")
+        # TODO: call your platform's auth/me endpoint and return its identity.
+        return (True, None, None)
+
+    async def run(self, handle, *, cfg, host):
+        """Connect, then loop. For each inbound message:
+            async def reply(text): ...send it back...
+            await handle(InboundMessage(text=..., user_id=..., channel_id=..., reply=reply))
+        Runs until cancelled."""
+        raise NotImplementedError("Implement {cls}Adapter.run — see plugins/telegram.")
+
+
+def register(registry):
+    register_chat_surface(registry, {cls}Adapter())
+'''
+
 
 def _build_scaffold_tool(config: dict | None):
     """Closes over the plugin's config so the tool knows where to write."""
@@ -117,9 +175,15 @@ def _build_scaffold_tool(config: dict | None):
         with_view: bool = False,
         with_skill: bool = False,
         with_workflow: bool = False,
+        with_comms: bool = False,
     ) -> str:
         """Scaffold a new protoAgent plugin SKELETON on disk (manifest + register()
         + optional view/skill/workflow stubs), ready to fill in and enable.
+
+        Set ``with_comms=True`` for a **communication plugin** (a chat integration —
+        Discord/Slack/Telegram-style): it writes a `ChatAdapter` skeleton on the
+        shared wirer (ADR 0029) instead of the default tool plugin, so you only fill
+        in connect/receive/send. See the communication-plugins guide.
 
         Writes into the live plugins dir (or the configured target_dir). Does NOT
         enable it or run any code — review, fill in the logic, then add the id to
@@ -134,6 +198,30 @@ def _build_scaffold_tool(config: dict | None):
         if target.exists():
             return f"✗ {pid!r} already exists at {target} — pick another name or remove it first."
         (target).mkdir(parents=True)
+
+        # Communication plugin (ADR 0029) — a ChatAdapter, different shape from the
+        # default tool plugin; the tool/view stubs don't apply.
+        if with_comms:
+            cls = "".join(w[:1].upper() + w[1:] for w in re.split(r"[-_ ]+", name) if w) or id_us.title()
+            (target / "protoagent.plugin.yaml").write_text(
+                _COMMS_MANIFEST_STUB.format(id=pid, name=name, summary=summary)
+            )
+            (target / "__init__.py").write_text(
+                _COMMS_INIT_STUB.format(id=pid, name=name, cls=cls)
+            )
+            made = ["protoagent.plugin.yaml", "__init__.py (ChatAdapter)"]
+            if with_skill:
+                sk = target / "skills" / f"{pid}-skill"
+                sk.mkdir(parents=True)
+                (sk / "SKILL.md").write_text(_SKILL_STUB.format(id=pid, name=name))
+                made.append("skills/")
+            return (
+                f"✓ scaffolded communication plugin {pid!r} at {target}\n"
+                f"  wrote: {', '.join(made)}\n"
+                f"  next: implement {cls}Adapter.run/validate (see plugins/telegram), then enable —\n"
+                f"        add '{pid}' to plugins.enabled and restart.\n"
+                f"  (see docs/guides/communication-plugins.md)"
+            )
 
         views_block = (
             f"views:\n  - {{ id: main, label: \"{name}\", icon: Boxes, path: /plugins/{pid}/view }}\n"

--- a/plugins/plugin-devkit/skills/building-plugins/SKILL.md
+++ b/plugins/plugin-devkit/skills/building-plugins/SKILL.md
@@ -33,6 +33,10 @@ Map the ask to the contribution surface:
   conventional `skills/` and `workflows/` subdirs (no code).
 - **console view** (rail icon + page) → declared in the manifest `views:`.
 - **config / secrets / Settings fields** → declared in the manifest.
+- **chat integration** (Discord/Slack/Telegram-style) → it's a *communication
+  plugin* — use `scaffold_plugin(..., with_comms=True)` to get a `ChatAdapter`
+  skeleton on the shared wirer (ADR 0029); you implement only connect/receive/send.
+  See `docs/guides/communication-plugins.md` and `plugins/telegram` for a reference.
 
 ## 2. Lay out the directory
 ```

--- a/tests/test_plugin_devkit.py
+++ b/tests/test_plugin_devkit.py
@@ -69,3 +69,22 @@ def test_scaffold_refuses_overwrite(tmp_path):
     scaffold = mod._build_scaffold_tool({"target_dir": str(out_root)})
     scaffold.invoke({"name": "dup"})
     assert "already exists" in scaffold.invoke({"name": "dup"})
+
+
+def test_scaffold_communication_plugin(monkeypatch, tmp_path):
+    mod = _load_devkit_module(tmp_path)
+    out_root = tmp_path / "out"; out_root.mkdir()
+    scaffold = mod._build_scaffold_tool({"target_dir": str(out_root)})
+    msg = scaffold.invoke({"name": "My Chat", "summary": "demo", "with_comms": True})
+    assert "communication plugin" in msg
+    pdir = out_root / "my-chat"
+    manifest = (pdir / "protoagent.plugin.yaml").read_text()
+    init = (pdir / "__init__.py").read_text()
+    assert "config_section: my-chat" in manifest and "bot_token" in manifest
+    assert "register_chat_surface" in init and "class MyChatAdapter" in init
+
+    # the scaffolded comms skeleton must itself LOAD (registers a surface)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [out_root])
+    res = load_plugins(_cfg(plugins_enabled=["my-chat"]))
+    meta = next(m for m in res.meta if m["id"] == "my-chat")
+    assert meta["loaded"], meta.get("error")


### PR DESCRIPTION
Completes the comms-plugin tooling — the devkit can now stub a chat integration.

`scaffold_plugin(name, with_comms=True)` writes a **ChatAdapter skeleton** on the shared wirer (ADR 0029): a comms manifest (`config_section` + `bot_token` + `admin_ids`) + a `{Cls}Adapter` with `configured`/`validate`/`run` stubs + a one-line `register()`. The agent fills in only connect/receive/send. The building-plugins skill routes chat-integration asks here.

Test: scaffolds a comms plugin, asserts the adapter manifest+init, and that the skeleton loads (registers a surface). Green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)