### PR TITLE
feat(console): generic plugin Test-connection button (ADR 0029)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Generic plugin "Test connection" button** (ADR 0029) — a plugin manifest can
+  declare `test: true` and the console renders a Test-connection button for its
+  Settings group (POSTs the group's fields to `/api/config/test-<section>`, unset
+  secrets falling back to saved config) — no React edit. Telegram + Slack get it via
+  the `chat_surface` wirer's test route; Discord keeps its bespoke button.
 - **Communication-plugin standard** (ADR 0029) — a `ChatAdapter` contract +
   `register_chat_surface` helper (`graph/plugins/chat_surface.py`) so a chat
   integration only implements transport (connect / receive / send); admin-gating,

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -413,6 +413,16 @@ export const api = {
     });
   },
 
+  // Generic plugin "Test connection" (ADR 0029) — POST the group's fields (short
+  // keys) to the plugin's test route. Blank/omitted fields fall back to the saved
+  // config. Returns {ok, identity, error}. Used by any group with a `test` endpoint.
+  testConfig(endpoint: string, fields: Record<string, unknown>) {
+    return request<{ ok: boolean; identity: string | null; error: string | null }>(endpoint, {
+      method: "POST",
+      body: fields,
+    });
+  },
+
   // Verify a Discord bot token by fetching its identity. Blank falls back to the
   // saved token. Returns the bot username on success ("Connected as <bot>").
   testDiscord(botToken: string) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -132,7 +132,12 @@ export type SettingsField = {
   maximum?: number;
 };
 
-export type SettingsGroup = { section: string; category?: string; fields: SettingsField[] };
+export type SettingsGroup = {
+  section: string;
+  category?: string;
+  fields: SettingsField[];
+  test?: { endpoint: string };  // ADR 0029 — generic "Test connection" button
+};
 
 export type WorkflowSummary = {
   name: string;

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -10,7 +10,7 @@ const GOOGLE_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/google
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { api } from "../lib/api";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
-import type { SettingsField } from "../lib/types";
+import type { SettingsField, SettingsGroup } from "../lib/types";
 import { DelegatesSection } from "./DelegatesSection";
 import { PluginsSection } from "./PluginsSection";
 
@@ -108,6 +108,28 @@ function SettingsBody() {
     onSuccess: (r) =>
       setStatus(r.ok ? "connection OK — the model responded." : `connection failed — ${r.error || "no response"}`),
     onError: (e) => setStatus(`connection test failed: ${e instanceof Error ? e.message : String(e)}`),
+  });
+
+  // Generic "Test connection" for any group whose plugin declares one (ADR 0029).
+  // Posts the group's fields (short keys; unset secrets fall back to saved config).
+  const [testingSection, setTestingSection] = useState<string | null>(null);
+  const groupFields = (group: SettingsGroup): Record<string, unknown> => {
+    const out: Record<string, unknown> = {};
+    for (const f of group.fields) {
+      const short = f.key.split(".").pop() as string;
+      if (f.key in dirty) out[short] = dirty[f.key];
+      else if (f.type !== "secret") out[short] = f.value;  // never echo an unset secret
+    }
+    return out;
+  };
+  const testGroup = useMutation({
+    mutationFn: (vars: { endpoint: string; fields: Record<string, unknown> }) =>
+      api.testConfig(vars.endpoint, vars.fields),
+    onMutate: () => setStatus("testing connection…"),
+    onSuccess: (r) =>
+      setStatus(r.ok ? `connection OK${r.identity ? ` — ${r.identity}` : ""}` : `connection failed — ${r.error || "no response"}`),
+    onError: (e) => setStatus(`connection test failed: ${e instanceof Error ? e.message : String(e)}`),
+    onSettled: () => setTestingSection(null),
   });
 
   // Verify a Discord bot token (pending edit or saved). Shows the bot name.
@@ -241,6 +263,29 @@ function SettingsBody() {
                 <a className="settings-help-link" href={GOOGLE_GUIDE_URL} target="_blank" rel="noreferrer">
                   Get an OAuth client <ExternalLink size={13} />
                 </a>
+              </div>
+            ) : null}
+            {/* Generic Test button (ADR 0029) — any plugin group that declares a
+                test endpoint (e.g. communication plugins). Discord/Google above are
+                bespoke and don't set `test`, so there's no overlap. */}
+            {group.test ? (
+              <div className="settings-group-actions">
+                <button
+                  className="secondary-button"
+                  type="button"
+                  onClick={() => {
+                    setTestingSection(group.section);
+                    testGroup.mutate({ endpoint: group.test!.endpoint, fields: groupFields(group) });
+                  }}
+                  disabled={(testGroup.isPending && testingSection === group.section) || save.isPending}
+                >
+                  {testGroup.isPending && testingSection === group.section ? (
+                    <Loader2 className="spin" size={15} />
+                  ) : (
+                    <ShieldCheck size={15} />
+                  )}
+                  Test connection
+                </button>
               </div>
             ) : null}
           </section>

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -40,6 +40,11 @@ class PluginManifest:
     config: dict = field(default_factory=dict)
     secrets: list[str] = field(default_factory=list)
     settings: list[dict] = field(default_factory=list)
+    # Test action (ADR 0029) — when true, the plugin serves a credential check at
+    # `POST /api/config/test-<config_section>` (e.g. the chat_surface wirer mounts
+    # one), and the console renders a generic "Test connection" button for the
+    # group. No console edit needed per plugin.
+    test: bool = False
     # Console surfaces (ADR 0026) — each entry adds a left-rail icon opening a
     # full view (an iframe of a page the plugin serves at `path`). Declared as
     # data so it's known without importing the plugin, and surfaced to the
@@ -104,6 +109,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
         config=cfg if isinstance(cfg, dict) else {},
         secrets=[str(s) for s in secrets] if isinstance(secrets, (list, tuple)) else [],
         settings=[s for s in settings if isinstance(s, dict)] if isinstance(settings, (list, tuple)) else [],
+        test=bool(data.get("test", False)),
         views=[v for v in views if isinstance(v, dict) and v.get("id") and v.get("path")]
         if isinstance(views, (list, tuple)) else [],
         requires_pip=[str(x) for x in requires_pip] if isinstance(requires_pip, (list, tuple)) else [],

--- a/graph/plugins/pconfig.py
+++ b/graph/plugins/pconfig.py
@@ -39,6 +39,7 @@ class PluginConfigSchema:
     defaults: dict = field(default_factory=dict)
     secrets: list = field(default_factory=list)
     settings: list = field(default_factory=list)
+    test: bool = False  # has a /api/config/test-<section> check (ADR 0029)
 
 
 def discover_plugin_config(roots, enabled_ids, disabled_ids=None) -> list[PluginConfigSchema]:
@@ -74,6 +75,7 @@ def discover_plugin_config(roots, enabled_ids, disabled_ids=None) -> list[Plugin
             claimed[section] = m.id
             out.append(PluginConfigSchema(
                 m.id, section, dict(m.config or {}), list(m.secrets or []), list(m.settings or []),
+                test=bool(getattr(m, "test", False)),
             ))
         return out
     except Exception:  # noqa: BLE001 — discovery is best-effort

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -256,6 +256,10 @@ def build_schema(config, *, model_options: list[str] | None = None) -> list[dict
         if spec.get("maximum") is not None:
             entry["maximum"] = spec["maximum"]
         groups.setdefault(group, {"section": group, "fields": []})["fields"].append(entry)
+        # A plugin that declares `test: true` (ADR 0029) gets a generic console
+        # "Test connection" button posting the group's fields to its test route.
+        if getattr(sch, "test", False):
+            groups[group]["test"] = {"endpoint": f"/api/config/test-{sch.section}"}
 
     out = list(groups.values())
     # Insertion order = first appearance in FIELDS (core), then plugins.

--- a/plugins/slack/protoagent.plugin.yaml
+++ b/plugins/slack/protoagent.plugin.yaml
@@ -10,6 +10,7 @@ description: >-
 enabled: false
 requires_pip: ["websockets>=12"]
 config_section: slack
+test: true   # /api/config/test-slack (chat_surface wirer)
 config:
   enabled: false
   admin_ids: []

--- a/plugins/telegram/protoagent.plugin.yaml
+++ b/plugins/telegram/protoagent.plugin.yaml
@@ -11,6 +11,7 @@ description: >-
 enabled: false
 requires_env: []
 config_section: telegram
+test: true   # /api/config/test-telegram (chat_surface wirer)
 config:
   enabled: false
   admin_ids: []

--- a/tests/test_settings_test_action.py
+++ b/tests/test_settings_test_action.py
@@ -1,0 +1,44 @@
+"""Generic console Test button — manifest `test: true` → schema test endpoint (ADR 0029)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from graph import settings_schema as ss
+from graph.config import LangGraphConfig
+from graph.plugins.manifest import load_manifest
+
+
+def test_manifest_parses_test_flag(tmp_path):
+    d = tmp_path / "demo"
+    d.mkdir()
+    (d / "protoagent.plugin.yaml").write_text(yaml.safe_dump({
+        "id": "demo", "name": "Demo", "config_section": "demo", "test": True,
+        "settings": [{"key": "bot_token", "type": "secret", "label": "Token"}],
+    }))
+    m = load_manifest(d)
+    assert m.test is True
+
+
+def test_comms_manifests_declare_test():
+    # telegram + slack use the generic Test button via the chat_surface wirer;
+    # Discord keeps its bespoke button (with a guide link), so it doesn't set test.
+    for p in ("telegram", "slack"):
+        m = yaml.safe_load(Path(f"plugins/{p}/protoagent.plugin.yaml").read_text())
+        assert m.get("test") is True, p
+
+
+def test_build_schema_adds_test_endpoint(monkeypatch):
+    class FakeSch:
+        section = "telegram"
+        defaults = {"bot_token": ""}
+        test = True
+
+    spec = {"key": "bot_token", "type": "secret", "label": "Bot token"}
+    monkeypatch.setattr(ss, "_plugin_field_specs",
+                        lambda: [(FakeSch(), "telegram.bot_token", "bot_token", spec)])
+    groups = ss.build_schema(LangGraphConfig())
+    g = next(g for g in groups if g["section"] == "Telegram")
+    assert g.get("test") == {"endpoint": "/api/config/test-telegram"}


### PR DESCRIPTION
Closes the rough edge flagged in ADR 0029 — the console Test button was special-cased per integration (Discord/Google). Now any plugin gets one for free.

- A manifest declares **`test: true`** → the settings schema surfaces `test: {endpoint: /api/config/test-<section>}` → the console renders a **Test connection** button for that group (POSTs the group's fields; unset secrets fall back to saved config). No React edit per plugin.
- **Telegram + Slack** set `test: true` — the route comes free from the `chat_surface` wirer. Discord/Google keep their bespoke buttons (guide link / connect flow); they don't set `test`, so no overlap.

## Test
```
pytest tests/test_settings_test_action.py   # manifest parse · comms declare test · build_schema endpoint
pytest -q   # 1189 passed ; web build (tsc) green ; ruff clean
```

That's all three follow-ups from the comms standard done: Slack adapter (#648), devkit comms-scaffold (#649), and this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
EOF
)