### PR TITLE
feat(goals): per-goal no_progress_limit (ADR 0030 D4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Per-goal `no_progress_limit`** (ADR 0030 D4) — a goal can carry its own patience
+  (`/goal {"…", "no_progress_limit": N}` or via `set_goal_safe`), overriding the global
+  `goal_no_progress_limit` for that one goal. First slice of monitor goals.
+
+### Added
 - **Generic plugin "Test connection" button** (ADR 0029) — a plugin manifest can
   declare `test: true` and the console renders a Test-connection button for its
   Settings group (POSTs the group's fields to `/api/config/test-<section>`, unset

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,8 +15,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Per-goal `no_progress_limit`** (ADR 0030 D4) — a goal can carry its own patience
   (`/goal {"…", "no_progress_limit": N}` or via `set_goal_safe`), overriding the global
   `goal_no_progress_limit` for that one goal. First slice of monitor goals.
-
-### Added
 - **Generic plugin "Test connection" button** (ADR 0029) — a plugin manifest can
   declare `test: true` and the console renders a Test-connection button for its
   Settings group (POSTs the group's fields to `/api/config/test-<section>`, unset

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -79,7 +79,7 @@ class GoalController:
             return "Goal cleared." if existed else "No active goal to clear."
 
         # /goal {json}  or  /goal <free text>  → set
-        spec, condition, max_iters = self._parse_set(rest)
+        spec, condition, max_iters, no_progress = self._parse_set(rest)
         if condition is None:
             return ("Could not parse goal. Use `/goal <text>` or "
                     '`/goal {"condition": "...", "verifier": {"type": "command", '
@@ -89,6 +89,7 @@ class GoalController:
             condition=condition,
             verifier=spec,
             max_iterations=max_iters or getattr(self._config, "goal_max_iterations", 8),
+            no_progress_limit=no_progress,  # per-goal patience (ADR 0030 D4); None → config
         )
         self._store.set(state)
         return f"Goal set. {state.status_line()}"
@@ -99,7 +100,8 @@ class GoalController:
     SAFE_PROGRAMMATIC_VERIFIERS = frozenset({"plugin"})
 
     def set_goal_safe(self, session_id: str, condition: str, verifier: dict,
-                      max_iterations: int | None = None) -> tuple[bool, str]:
+                      max_iterations: int | None = None,
+                      no_progress_limit: int | None = None) -> tuple[bool, str]:
         """Set a goal from a NON-operator caller (an agent tool, a plugin, REST).
         Accepts ONLY a `plugin` verifier — refuses command/test/ci/data/llm so a
         programmatic set can never reach a shell or `eval` sink (ADR 0028 D3). The
@@ -115,26 +117,27 @@ class GoalController:
         state = GoalState(
             session_id=session_id, condition=condition, verifier=verifier,
             max_iterations=max_iterations or getattr(self._config, "goal_max_iterations", 8),
+            no_progress_limit=no_progress_limit,  # per-goal patience (ADR 0030 D4)
         )
         self._store.set(state)
         return (True, f"Goal set. {state.status_line()}")
 
     def _parse_set(self, rest: str):
-        """Return (verifier_spec, condition, max_iterations|None)."""
+        """Return (verifier_spec, condition, max_iterations|None, no_progress_limit|None)."""
         if rest.lstrip().startswith("{"):
             try:
                 data = json.loads(rest)
             except json.JSONDecodeError:
-                return ({}, None, None)
+                return ({}, None, None, None)
             condition = data.get("condition")
             if not condition:
-                return ({}, None, None)
+                return ({}, None, None, None)
             verifier = data.get("verifier") or {"type": "llm"}
             if "type" not in verifier:
                 verifier["type"] = "llm"
-            return (verifier, condition, data.get("max_iterations"))
+            return (verifier, condition, data.get("max_iterations"), data.get("no_progress_limit"))
         # plain text → fuzzy goal judged by the llm verifier
-        return ({"type": "llm"}, rest, None)
+        return ({"type": "llm"}, rest, None, None)
 
     # --- evaluation --------------------------------------------------------
 
@@ -178,7 +181,7 @@ class GoalController:
         state.last_evidence = result.evidence
         state.iteration += 1
 
-        limit = getattr(self._config, "goal_no_progress_limit", 3)
+        limit = state.no_progress_limit or getattr(self._config, "goal_no_progress_limit", 3)
         if state.iteration >= state.max_iterations:
             return await self._finish(state, "exhausted",
                                 f"ran out of iteration budget ({state.max_iterations})",

--- a/graph/goals/types.py
+++ b/graph/goals/types.py
@@ -50,6 +50,8 @@ class GoalState:
     checklist: str = ""
     iteration: int = 0
     max_iterations: int = 8
+    # Per-goal patience (ADR 0030 D4); None → the config goal_no_progress_limit.
+    no_progress_limit: int | None = None
     no_progress_streak: int = 0
     last_reason: str = ""
     last_evidence: str = ""

--- a/tests/test_goal_no_progress_limit.py
+++ b/tests/test_goal_no_progress_limit.py
@@ -1,0 +1,50 @@
+"""Per-goal no_progress_limit (ADR 0030 D4)."""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.goals.controller import GoalController
+from graph.goals.store import GoalStore
+from graph.goals.types import VerifyResult
+from graph.goals.verifiers import set_plugin_verifiers
+
+
+def _ctrl(tmp_path):
+    return GoalController(config=None, store=GoalStore(base_dir=str(tmp_path)))
+
+
+@pytest.mark.asyncio
+async def test_parse_control_accepts_no_progress_limit(tmp_path):
+    c = _ctrl(tmp_path)
+    await c.parse_control('/goal {"condition": "x", "no_progress_limit": 5}', "s")
+    g = c.active_goal("s")
+    assert g.no_progress_limit == 5
+
+
+def test_set_goal_safe_accepts_no_progress_limit(tmp_path):
+    c = _ctrl(tmp_path)
+    ok, _ = c.set_goal_safe("s", "cond", {"type": "plugin", "check": "x:y"}, no_progress_limit=7)
+    assert ok and c.active_goal("s").no_progress_limit == 7
+
+
+def test_default_is_none(tmp_path):
+    c = _ctrl(tmp_path)
+    c.set_goal_safe("s", "cond", {"type": "plugin", "check": "x:y"})
+    assert c.active_goal("s").no_progress_limit is None  # → config fallback
+
+
+@pytest.mark.asyncio
+async def test_per_goal_limit_drives_unachievable(tmp_path):
+    async def _never(spec, ctx):
+        return VerifyResult(False, "x", "e")  # never met, identical evidence
+    set_plugin_verifiers({"p:never": _never})
+    try:
+        c = _ctrl(tmp_path)
+        c.set_goal_safe("s", "cond", {"type": "plugin", "check": "p:never"}, no_progress_limit=1)
+        d1 = await c.evaluate("s", last_text="")
+        assert d1.action == "continue"          # 1st: sets the evidence baseline
+        d2 = await c.evaluate("s", last_text="")
+        assert d2.action == "done" and d2.state.status == "unachievable"  # streak hit limit=1
+    finally:
+        set_plugin_verifiers({})


### PR DESCRIPTION
First slice of ADR 0030. A goal can carry its own `no_progress_limit` (None → the global `goal_no_progress_limit`), so one goal can widen its patience without changing the default — independently useful, and the groundwork for monitor goals.

- `GoalState.no_progress_limit`; `evaluate` uses `state.no_progress_limit or config`.
- Threaded through `/goal {…, "no_progress_limit": N}` and `set_goal_safe`.

Tests: parse + set_goal_safe accept it, default None, per-goal limit drives `unachievable`. Suite 1194; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)