### PR TITLE
feat(goals): monitor disposition + cadence tick (ADR 0030 D1/D2.1/D3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Monitor goals** (ADR 0030 D1/D2.1/D3) — a goal can be `"mode": "monitor"` for a
+  metric an *external* process drives (a background engine, training run, deployment).
+  Monitor goals aren't added to the agent continuation loop (no wasted turns), **never
+  exhaust** (a long-horizon target is expected to sit unmet across checks), and are
+  evaluated **out-of-band** on a cadence (`goal.monitor_interval`, default 60s) — firing
+  the ADR-0028 `on_achieved` hook when met. Closes ADR-0028's deferred D6. `drive` goals
+  are unchanged. Surfaced by the SpaceTraders fleet fork (a `credits ≥ 1M` goal that
+  stormed the drive loop in minutes).
 - **Per-goal `no_progress_limit`** (ADR 0030 D4) — a goal can carry its own patience
   (`/goal {"…", "no_progress_limit": N}` or via `set_goal_safe`), overriding the global
   `goal_no_progress_limit` for that one goal. First slice of monitor goals.

--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -33,6 +33,17 @@ Send a control message through any channel (A2A, Gradio chat, OpenAI-compat):
   ```
   /goal {"condition": "unit tests pass", "verifier": {"type": "test", "command": "python -m pytest -q"}}
   ```
+- **Monitor goal** (ADR 0030) — for a metric driven by an *external* process (a
+  background engine, a training run, a deployment), not the agent's turns. Add
+  `"mode": "monitor"`: the agent **isn't** re-invoked, the goal **never exhausts**,
+  and it's checked **out-of-band** on a cadence (`goal.monitor_interval`, default 60s),
+  firing the verifier's `on_achieved` hook when it passes.
+  ```
+  /goal {"condition": "treasury ≥ 1,000,000", "mode": "monitor", "verifier": {"type": "plugin", "check": "spacetraders:credits", "args": {"min": 1000000}}}
+  ```
+  (Default is `"mode": "drive"` — the agent *is* the work, the bounded loop above.)
+- **Per-goal patience:** add `"no_progress_limit": N` to widen/narrow one goal's
+  no-progress tolerance without changing the global default.
 - **Status:** `/goal`
 - **Clear:** `/goal clear` (aliases: `stop`, `off`, `cancel`, `reset`, `none`)
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -241,6 +241,7 @@ class LangGraphConfig:
     goal_enabled: bool = True
     goal_max_iterations: int = 8          # continuation budget per goal
     goal_no_progress_limit: int = 3       # identical verifier evidence N times -> unachievable
+    goal_monitor_interval: int = 60       # seconds between out-of-band monitor-goal checks (ADR 0030)
     goal_eval_model: str = ""             # blank = main model (llm verifier / fuzzy goals)
     goal_verify_timeout: float = 120.0    # seconds for command/test/ci verifiers
 
@@ -528,6 +529,7 @@ class LangGraphConfig:
             goal_enabled=data.get("goal", {}).get("enabled", cls.goal_enabled),
             goal_max_iterations=data.get("goal", {}).get("max_iterations", cls.goal_max_iterations),
             goal_no_progress_limit=data.get("goal", {}).get("no_progress_limit", cls.goal_no_progress_limit),
+            goal_monitor_interval=data.get("goal", {}).get("monitor_interval", cls.goal_monitor_interval),
             goal_eval_model=data.get("goal", {}).get("eval_model", cls.goal_eval_model),
             goal_verify_timeout=data.get("goal", {}).get("verify_timeout", cls.goal_verify_timeout),
             subagent_max_concurrency=subagents.get("max_concurrency", cls.subagent_max_concurrency),

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -79,7 +79,7 @@ class GoalController:
             return "Goal cleared." if existed else "No active goal to clear."
 
         # /goal {json}  or  /goal <free text>  → set
-        spec, condition, max_iters, no_progress = self._parse_set(rest)
+        spec, condition, max_iters, no_progress, mode = self._parse_set(rest)
         if condition is None:
             return ("Could not parse goal. Use `/goal <text>` or "
                     '`/goal {"condition": "...", "verifier": {"type": "command", '
@@ -88,6 +88,7 @@ class GoalController:
             session_id=session_id,
             condition=condition,
             verifier=spec,
+            mode=mode,  # "drive" (default) | "monitor" (ADR 0030)
             max_iterations=max_iters or getattr(self._config, "goal_max_iterations", 8),
             no_progress_limit=no_progress,  # per-goal patience (ADR 0030 D4); None → config
         )
@@ -101,7 +102,8 @@ class GoalController:
 
     def set_goal_safe(self, session_id: str, condition: str, verifier: dict,
                       max_iterations: int | None = None,
-                      no_progress_limit: int | None = None) -> tuple[bool, str]:
+                      no_progress_limit: int | None = None,
+                      mode: str = "drive") -> tuple[bool, str]:
         """Set a goal from a NON-operator caller (an agent tool, a plugin, REST).
         Accepts ONLY a `plugin` verifier — refuses command/test/ci/data/llm so a
         programmatic set can never reach a shell or `eval` sink (ADR 0028 D3). The
@@ -116,6 +118,7 @@ class GoalController:
             return (False, "a plugin verifier needs a 'check' (the <plugin-id>:<name>).")
         state = GoalState(
             session_id=session_id, condition=condition, verifier=verifier,
+            mode=("monitor" if mode == "monitor" else "drive"),  # ADR 0030 (still plugin-gated)
             max_iterations=max_iterations or getattr(self._config, "goal_max_iterations", 8),
             no_progress_limit=no_progress_limit,  # per-goal patience (ADR 0030 D4)
         )
@@ -123,21 +126,22 @@ class GoalController:
         return (True, f"Goal set. {state.status_line()}")
 
     def _parse_set(self, rest: str):
-        """Return (verifier_spec, condition, max_iterations|None, no_progress_limit|None)."""
+        """Return (verifier_spec, condition, max_iterations|None, no_progress_limit|None, mode)."""
         if rest.lstrip().startswith("{"):
             try:
                 data = json.loads(rest)
             except json.JSONDecodeError:
-                return ({}, None, None, None)
+                return ({}, None, None, None, "drive")
             condition = data.get("condition")
             if not condition:
-                return ({}, None, None, None)
+                return ({}, None, None, None, "drive")
             verifier = data.get("verifier") or {"type": "llm"}
             if "type" not in verifier:
                 verifier["type"] = "llm"
-            return (verifier, condition, data.get("max_iterations"), data.get("no_progress_limit"))
+            mode = "monitor" if data.get("mode") == "monitor" else "drive"
+            return (verifier, condition, data.get("max_iterations"), data.get("no_progress_limit"), mode)
         # plain text → fuzzy goal judged by the llm verifier
-        return ({"type": "llm"}, rest, None, None)
+        return ({"type": "llm"}, rest, None, None, "drive")
 
     # --- evaluation --------------------------------------------------------
 
@@ -161,6 +165,19 @@ class GoalController:
         if result.met:
             return await self._finish(state, "achieved", result.reason or "verifier passed",
                                 evidence=result.evidence)
+
+        # Monitor goals (ADR 0030): an external process drives the metric, not the
+        # agent's turns — so on not-met there's nothing for the agent to do. Record
+        # the check and wait for the next one; no continuation, no iteration/no-
+        # progress bookkeeping, no exhaustion. It ends only on achieved / cleared
+        # (/ a future deadline). This is what closes ADR-0028 D6.
+        if state.mode == "monitor":
+            from time import time
+            state.last_reason = result.reason
+            state.last_evidence = result.evidence
+            state.last_checked = time()
+            self._store.set(state)
+            return None
 
         # 2. Verifier not met — honour an explicit give-up from the agent.
         giveup = _GIVEUP_RE.search(last_text or "")
@@ -198,6 +215,24 @@ class GoalController:
             message=self._continuation(state, result),
             note=f"goal not met (iteration {state.iteration}/{state.max_iterations}): {result.reason}",
         )
+
+    async def tick_monitor_goals(self) -> int:
+        """Evaluate every active monitor goal out-of-band — verifier-only, no agent
+        turn (ADR 0030 D2.1). The server runs this on a cadence so a met goal
+        doesn't sit ``active`` until the next session turn. Returns how many reached
+        a terminal state this tick."""
+        finished = 0
+        for state in list(self._store.all()):
+            if not (state.active and state.mode == "monitor"):
+                continue
+            try:
+                decision = await self.evaluate(state.session_id, last_text="")
+            except Exception:  # noqa: BLE001 — one bad goal must not stop the tick
+                log.exception("[goal] monitor tick failed for %s", state.session_id)
+                continue
+            if decision is not None and decision.action == "done":
+                finished += 1
+        return finished
 
     async def _finish(self, state: GoalState, status: str, reason: str, *, evidence: str = "") -> Decision:
         from time import time

--- a/graph/goals/types.py
+++ b/graph/goals/types.py
@@ -47,6 +47,11 @@ class GoalState:
     condition: str
     verifier: dict = field(default_factory=lambda: {"type": "llm"})
     status: str = "active"
+    # Disposition (ADR 0030): "drive" = the agent does the work (bounded
+    # continuation loop); "monitor" = an external process drives the metric, the
+    # agent only supervises (verifier-only, out-of-band, no exhaustion).
+    mode: str = "drive"
+    last_checked: float | None = None  # last out-of-band verifier check (monitor)
     checklist: str = ""
     iteration: int = 0
     max_iterations: int = 8
@@ -74,10 +79,9 @@ class GoalState:
     def status_line(self) -> str:
         """One-line human summary for /goal status + continuation footers."""
         vt = self.verifier.get("type", "llm")
-        base = (
-            f"goal [{self.status}] via {vt}: {self.condition!r} "
-            f"(iteration {self.iteration}/{self.max_iterations})"
-        )
+        # Monitor goals have no iteration budget — show the disposition instead.
+        progress = "monitor" if self.mode == "monitor" else f"iteration {self.iteration}/{self.max_iterations}"
+        base = f"goal [{self.status}] via {vt}: {self.condition!r} ({progress})"
         if self.last_reason:
             base += f" — {self.last_reason}"
         return base

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -22,6 +22,7 @@ class AppState:
     checkpointer: Any = None
     checkpoint_path: Any = None
     checkpoint_prune_task: Any = None
+    monitor_goals_task: Any = None  # ADR 0030 monitor-goal cadence loop
     # Stores / registries bound into the active graph.
     knowledge_store: Any = None
     skills_index: Any = None

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -249,6 +249,7 @@ from server.agent_init import (  # noqa: E402,F401 — re-export of the extracte
     _build_workflow_registry,
     _checkpoint_prune_loop,
     _init_langgraph_agent,
+    _monitor_goals_loop,
     _plugin_agent_invoke,
     _populate_plugin_host,
     _register_plugin_subagents,
@@ -507,6 +508,12 @@ def _main():
             import asyncio
             STATE.checkpoint_prune_task = asyncio.create_task(_checkpoint_prune_loop())
 
+        # Monitor-goal cadence (ADR 0030) — out-of-band verifier ticks so a met
+        # long-horizon goal finishes without a session turn.
+        if STATE.graph_config is not None and getattr(STATE.graph_config, "goal_enabled", True):
+            import asyncio
+            STATE.monitor_goals_task = asyncio.create_task(_monitor_goals_loop())
+
         # (The inbound Discord gateway now starts as the discord plugin's surface,
         # below — ADR 0018/0019.)
 
@@ -555,6 +562,8 @@ def _main():
             log.exception("[discord] shutdown failed")
         if STATE.checkpoint_prune_task is not None:
             STATE.checkpoint_prune_task.cancel()
+        if STATE.monitor_goals_task is not None:
+            STATE.monitor_goals_task.cancel()
         # Close the long-lived A2A push-notification client (created below in
         # _main) so its connection pool doesn't leak on shutdown/reload — matters
         # in the desktop-sidecar restart loop. Best-effort; NameError if boot

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -462,6 +462,26 @@ async def _checkpoint_prune_loop() -> None:
         await asyncio.sleep(max(1, interval_h) * 3600)
 
 
+async def _monitor_goals_loop() -> None:
+    """Out-of-band cadence for monitor goals (ADR 0030 D2.1): periodically run each
+    active monitor goal's verifier — no agent turn, no model call — so a met
+    long-horizon objective finishes (firing its on_achieved hook) without waiting
+    for a session turn. Verifier-only; the `drive` loop is untouched."""
+    await asyncio.sleep(15)  # let boot settle before the first tick
+    while True:
+        ctrl = STATE.goal_controller
+        cfg = STATE.graph_config
+        interval = getattr(cfg, "goal_monitor_interval", 60) if cfg else 60
+        if ctrl is not None:
+            try:
+                n = await ctrl.tick_monitor_goals()
+                if n:
+                    log.info("[goal-monitor] %d monitor goal(s) reached a terminal state", n)
+            except Exception:
+                log.exception("[goal-monitor] tick failed")
+        await asyncio.sleep(max(5, interval))
+
+
 async def _retire_thread(thread_id: str) -> str | None:
     """Harvest a thread to the knowledge base (best-effort) then delete its
     checkpoints. Shared by the prune sweep and explicit tab deletion. Returns

--- a/tests/test_goal_monitor.py
+++ b/tests/test_goal_monitor.py
@@ -1,0 +1,91 @@
+"""Monitor goal disposition + cadence tick (ADR 0030 D1/D2.1/D3)."""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.goals.controller import GoalController
+from graph.goals.hooks import set_goal_hooks
+from graph.goals.store import GoalStore
+from graph.goals.types import VerifyResult
+from graph.goals.verifiers import set_plugin_verifiers
+
+
+def _ctrl(tmp_path):
+    return GoalController(config=None, store=GoalStore(base_dir=str(tmp_path)))
+
+
+@pytest.mark.asyncio
+async def test_monitor_not_met_returns_none_and_records(tmp_path):
+    async def _no(spec, ctx):
+        return VerifyResult(False, "waiting", "42")
+    set_plugin_verifiers({"p:c": _no})
+    try:
+        c = _ctrl(tmp_path)
+        c.set_goal_safe("s", "grow", {"type": "plugin", "check": "p:c"}, mode="monitor")
+        d = await c.evaluate("s", last_text="")
+        assert d is None                       # no continuation — the agent has nothing to do
+        g = c.active_goal("s")
+        assert g and g.active and g.last_evidence == "42" and g.last_checked is not None
+    finally:
+        set_plugin_verifiers({})
+
+
+@pytest.mark.asyncio
+async def test_monitor_never_exhausts(tmp_path):
+    async def _no(spec, ctx):
+        return VerifyResult(False, "x", "e")   # never met, identical evidence
+    set_plugin_verifiers({"p:c": _no})
+    try:
+        c = _ctrl(tmp_path)
+        # tiny budgets that WOULD trip a drive goal — monitor must ignore them
+        c.set_goal_safe("s", "grow", {"type": "plugin", "check": "p:c"},
+                        mode="monitor", max_iterations=2, no_progress_limit=1)
+        for _ in range(10):
+            assert await c.evaluate("s", last_text="") is None
+        assert c.active_goal("s").active       # still active — no exhausted/unachievable
+    finally:
+        set_plugin_verifiers({})
+
+
+@pytest.mark.asyncio
+async def test_monitor_achieved_fires_hook(tmp_path):
+    fired = []
+    set_goal_hooks([{"plugin_id": "p", "on_achieved": lambda st: fired.append(st.status), "on_failed": None}])
+
+    async def _yes(spec, ctx):
+        return VerifyResult(True, "done", "1M")
+    set_plugin_verifiers({"p:c": _yes})
+    try:
+        c = _ctrl(tmp_path)
+        c.set_goal_safe("s", "grow", {"type": "plugin", "check": "p:c"}, mode="monitor")
+        d = await c.evaluate("s", last_text="")
+        assert d.action == "done" and d.state.status == "achieved" and fired == ["achieved"]
+    finally:
+        set_plugin_verifiers({})
+        set_goal_hooks([])
+
+
+@pytest.mark.asyncio
+async def test_tick_evaluates_monitor_goals_only(tmp_path):
+    async def _yes(spec, ctx):
+        return VerifyResult(True, "ok", "")
+    set_plugin_verifiers({"p:c": _yes})
+    try:
+        c = _ctrl(tmp_path)
+        c.set_goal_safe("mon", "m", {"type": "plugin", "check": "p:c"}, mode="monitor")
+        await c.parse_control('/goal {"condition":"d","verifier":{"type":"plugin","check":"p:c"}}', "drv")
+        n = await c.tick_monitor_goals()
+        assert n == 1                          # only the monitor goal was ticked + finished
+        assert c.active_goal("mon") is None     # achieved → no longer active
+        assert c.active_goal("drv") is not None  # drive goal untouched by the tick
+    finally:
+        set_plugin_verifiers({})
+
+
+@pytest.mark.asyncio
+async def test_parse_control_and_status_line_monitor(tmp_path):
+    c = _ctrl(tmp_path)
+    await c.parse_control('/goal {"condition":"x","mode":"monitor","verifier":{"type":"plugin","check":"a:b"}}', "s")
+    g = c.active_goal("s")
+    assert g.mode == "monitor" and "(monitor)" in g.status_line()


### PR DESCRIPTION
The core of ADR 0030 — closes ADR-0028's deferred **D6** (out-of-band evaluation).

## What
- **`GoalState.mode` = `"drive"` | `"monitor"`.** A `monitor` goal is for a metric an *external* process drives (a background engine, training run, deployment) — the agent supervises, it doesn't do the work.
  - In `evaluate`: not-met → record evidence + **return None** (no continuation, no iteration/no-progress bookkeeping, **no exhaustion**); met → `_finish(achieved)` (ADR-0028 hooks fire). The `drive` path is untouched.
- **`controller.tick_monitor_goals()`** — verifier-only evaluation of every active monitor goal, **no agent turn**. Run by a new `_monitor_goals_loop` background task (`goal.monitor_interval`, default 60s), started/cancelled in the server lifespan.
- `mode` threaded through `/goal` JSON + `set_goal_safe` (monitor stays plugin-verifier gated — no new code-exec surface). `status_line` shows `(monitor)`.

This is the fix for the live failure that surfaced the ADR: a `spacetraders:credits ≥ 1M` goal went `exhausted` in minutes under `drive` (the engine earns over hours). As a `monitor` goal it's set once, polled out-of-band, and fires `on_achieved` when the treasury crosses the line.

## Test
```
pytest tests/test_goal_monitor.py   # not-met→None · never-exhausts · achieved→hook · tick monitor-only · parse/status
pytest -q   # 1199 passed ; docs build green ; ruff clean
```

Next: PR3 — `evaluate_now()` for prompt event-driven detection (D2.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)