### PR TITLE
feat(goals): controller.evaluate_now — event-driven check (ADR 0030 D2.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`controller.evaluate_now(session_id)`** (ADR 0030 D2.2) — a plugin can trigger an
+  immediate verifier-only goal check from its own state-change path (e.g. right after a
+  sale clears), so achievement is caught promptly instead of at the next monitor tick.
+  No agent turn, no drive bookkeeping; met → finish (hooks fire). Completes ADR 0030.
 - **Monitor goals** (ADR 0030 D1/D2.1/D3) — a goal can be `"mode": "monitor"` for a
   metric an *external* process drives (a background engine, training run, deployment).
   Monitor goals aren't added to the agent continuation loop (no wasted turns), **never

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -216,6 +216,30 @@ class GoalController:
             note=f"goal not met (iteration {state.iteration}/{state.max_iterations}): {result.reason}",
         )
 
+    async def evaluate_now(self, session_id: str) -> Decision | None:
+        """Run the active goal's verifier immediately — no agent turn, no drive
+        bookkeeping (ADR 0030 D2.2). A plugin calls this from its own state-change
+        path (e.g. right after a sale clears) so achievement is caught promptly
+        instead of at the next monitor tick. Met → finish (hooks fire); not-met →
+        record evidence + return None (iteration/no-progress untouched)."""
+        state = self.active_goal(session_id)
+        if state is None:
+            return None
+        ctx = VerifyContext(
+            config=self._config, condition=state.condition,
+            last_text="", tool_summary="", cwd=os.getcwd(),
+        )
+        result = await run_verifier(state.verifier, ctx)
+        if result.met:
+            return await self._finish(state, "achieved", result.reason or "verifier passed",
+                                      evidence=result.evidence)
+        from time import time
+        state.last_reason = result.reason
+        state.last_evidence = result.evidence
+        state.last_checked = time()
+        self._store.set(state)
+        return None
+
     async def tick_monitor_goals(self) -> int:
         """Evaluate every active monitor goal out-of-band — verifier-only, no agent
         turn (ADR 0030 D2.1). The server runs this on a cadence so a met goal

--- a/tests/test_goal_evaluate_now.py
+++ b/tests/test_goal_evaluate_now.py
@@ -1,0 +1,55 @@
+"""controller.evaluate_now — prompt event-driven check (ADR 0030 D2.2)."""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.goals.controller import GoalController
+from graph.goals.hooks import set_goal_hooks
+from graph.goals.store import GoalStore
+from graph.goals.types import VerifyResult
+from graph.goals.verifiers import set_plugin_verifiers
+
+
+def _ctrl(tmp_path):
+    return GoalController(config=None, store=GoalStore(base_dir=str(tmp_path)))
+
+
+@pytest.mark.asyncio
+async def test_evaluate_now_no_active_goal(tmp_path):
+    assert await _ctrl(tmp_path).evaluate_now("nope") is None
+
+
+@pytest.mark.asyncio
+async def test_evaluate_now_met_finishes_and_fires_hook(tmp_path):
+    fired = []
+    set_goal_hooks([{"plugin_id": "p", "on_achieved": lambda st: fired.append(st.status), "on_failed": None}])
+
+    async def _yes(spec, ctx):
+        return VerifyResult(True, "done", "1M")
+    set_plugin_verifiers({"p:c": _yes})
+    try:
+        c = _ctrl(tmp_path)
+        c.set_goal_safe("s", "grow", {"type": "plugin", "check": "p:c"}, mode="monitor")
+        d = await c.evaluate_now("s")
+        assert d.action == "done" and d.state.status == "achieved" and fired == ["achieved"]
+    finally:
+        set_plugin_verifiers({})
+        set_goal_hooks([])
+
+
+@pytest.mark.asyncio
+async def test_evaluate_now_not_met_records_without_drive_bookkeeping(tmp_path):
+    async def _no(spec, ctx):
+        return VerifyResult(False, "waiting", "5")
+    set_plugin_verifiers({"p:c": _no})
+    try:
+        c = _ctrl(tmp_path)
+        # a DRIVE goal — evaluate_now must NOT advance its iteration/exhaust it
+        c.set_goal_safe("s", "grow", {"type": "plugin", "check": "p:c"})
+        d = await c.evaluate_now("s")
+        assert d is None
+        g = c.active_goal("s")
+        assert g.active and g.iteration == 0 and g.last_evidence == "5" and g.last_checked is not None
+    finally:
+        set_plugin_verifiers({})


### PR DESCRIPTION
The final slice of ADR 0030. A plugin calls `controller.evaluate_now(session_id)` from its own state-change path (e.g. right after a sale clears) to check the active goal **immediately** — verifier-only, no agent turn, no drive bookkeeping — so a monitor goal's achievement is caught promptly instead of waiting for the next cadence tick. Met → `_finish` (0028 hooks fire); not-met → record evidence + None.

Tests: no-active-goal → None; met → finish + hook; not-met on a drive goal records without advancing its iteration. Suite 1202; ruff clean.

**ADR 0030 complete:** D4 per-goal limit (#652) · monitor disposition + cadence tick (#653) · evaluate_now (this). D5 (stall/deadline) left as documented future.

🤖 Generated with [Claude Code](https://claude.com/claude-code)