### PR TITLE
feat(knowledge): pluggable backend — register_knowledge_store (ADR 0031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Pluggable knowledge backend** (ADR 0031) — `registry.register_knowledge_store(name,
+  factory)` + a `knowledge.backend` config selector let a plugin supply the store
+  (pgvector / Qdrant / Chroma / a managed vector DB) instead of the built-in SQLite/FTS5,
+  with no core edit. Degrade-safe: an unregistered name / None / a factory error keeps the
+  built-in store. A new `KnowledgeBackend` Protocol (`knowledge.backend`) formalizes the
+  consumed surface. The embedder stays gateway-routed (model-swappable via `embed_model`).
 - **`controller.evaluate_now(session_id)`** (ADR 0030 D2.2) — a plugin can trigger an
   immediate verifier-only goal check from its own state-change path (e.g. right after a
   sale clears), so achievement is caught promptly instead of at the next monitor tick.

--- a/graph/config.py
+++ b/graph/config.py
@@ -251,6 +251,10 @@ class LangGraphConfig:
     # ``~/.protoagent/knowledge/agent.db`` automatically when /sandbox
     # is read-only or absent (e.g. local ``python server.py``).
     knowledge_db_path: str = "/sandbox/knowledge/agent.db"
+    # Knowledge backend selector (ADR 0031) — "" = the built-in SQLite/FTS5 store;
+    # otherwise the name of a plugin-registered backend (register_knowledge_store).
+    # An unregistered name / a factory error degrades to the built-in store.
+    knowledge_backend: str = ""
     # The gateway's embedding model (NOT the chat model). Default is what the
     # protoLabs gateway serves; forks on a different gateway set this to a model
     # their gateway has (check GET /v1/models). A wrong/absent model degrades to
@@ -535,6 +539,7 @@ class LangGraphConfig:
             subagent_max_concurrency=subagents.get("max_concurrency", cls.subagent_max_concurrency),
             subagent_output_truncate=subagents.get("output_truncate", cls.subagent_output_truncate),
             knowledge_db_path=knowledge.get("db_path", cls.knowledge_db_path),
+            knowledge_backend=knowledge.get("backend", cls.knowledge_backend),
             checkpoint_db_path=data.get("checkpoint", {}).get("db_path", cls.checkpoint_db_path),
             telemetry_enabled=data.get("telemetry", {}).get("enabled", cls.telemetry_enabled),
             telemetry_db_path=data.get("telemetry", {}).get("db_path", cls.telemetry_db_path),

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -31,6 +31,7 @@ class PluginLoadResult:
     workflow_dirs: list = field(default_factory=list)  # *.yaml recipe dirs (ADR 0027)
     goal_verifiers: dict = field(default_factory=dict)  # name -> verifier fn (ADR 0028)
     goal_hooks: list = field(default_factory=list)       # {on_achieved, on_failed} (ADR 0028)
+    knowledge_stores: dict = field(default_factory=dict)  # name -> backend factory (ADR 0031)
     a2a_skills: list = field(default_factory=list)  # A2A card skill specs (#570)
     routers: list = field(default_factory=list)    # {plugin_id, router, prefix} (ADR 0018)
     surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
@@ -236,6 +237,11 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
                 continue
             result.goal_verifiers[name] = fn
         result.goal_hooks.extend(registry.goal_hooks)  # ADR 0028 D4
+        for name, factory in registry.knowledge_stores.items():  # ADR 0031
+            if name in result.knowledge_stores:
+                log.warning("[plugins] %s: knowledge backend %s collides — skipped", manifest.id, name)
+                continue
+            result.knowledge_stores[name] = factory
         for f in registry.mcp_servers:
             result.mcp_servers.append({"plugin_id": manifest.id, "factory": f})
         entry["loaded"] = True

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -56,6 +56,7 @@ class PluginRegistry:
         self.thread_id_resolver = None    # (request_metadata, session_id) -> str (#571)
         self.goal_verifiers: dict = {}    # name -> async (spec, ctx) -> VerifyResult (ADR 0028)
         self.goal_hooks: list = []        # {on_achieved, on_failed} terminal reactions (ADR 0028)
+        self.knowledge_stores: dict = {}  # name -> (config) -> KnowledgeBackend (ADR 0031)
 
     def register_tool(self, tool) -> None:
         """Expose a LangChain tool to the agent."""
@@ -118,6 +119,19 @@ class PluginRegistry:
             "on_achieved": on_achieved if callable(on_achieved) else None,
             "on_failed": on_failed if callable(on_failed) else None,
         })
+
+    def register_knowledge_store(self, name: str, factory) -> None:
+        """Contribute a knowledge backend (ADR 0031) — ``factory(config) ->
+        KnowledgeBackend`` (see ``knowledge.backend.KnowledgeBackend`` for the
+        surface: pgvector, Qdrant, Chroma, a managed vector DB…). Selected by a
+        fork with ``knowledge.backend: "<name>"``; on a None/error return the agent
+        keeps the built-in SQLite store (degrade-safe). Name it simply (e.g.
+        ``pgvector``); a collision keeps the first."""
+        if not name or not callable(factory):
+            log.warning("[plugins] %s: register_knowledge_store needs a name + factory: %r / %r",
+                        self.plugin_id, name, factory)
+            return
+        self.knowledge_stores[name] = factory
 
     def register_a2a_skill(self, spec: dict) -> None:
         """Contribute an A2A *card* skill — advertised on the agent card and,

--- a/knowledge/__init__.py
+++ b/knowledge/__init__.py
@@ -7,6 +7,7 @@ eval harness can assert side effects against real DB state.
 See ``knowledge.store.KnowledgeStore`` for the public API.
 """
 
+from knowledge.backend import KnowledgeBackend
 from knowledge.store import KnowledgeStore, Chunk
 
-__all__ = ["KnowledgeStore", "Chunk"]
+__all__ = ["KnowledgeStore", "Chunk", "KnowledgeBackend"]

--- a/knowledge/backend.py
+++ b/knowledge/backend.py
@@ -1,0 +1,46 @@
+"""The knowledge backend contract (ADR 0031).
+
+Every consumer — the memory tools, ``KnowledgeMiddleware``, the knowledge routes,
+the eval harness — uses ``STATE.knowledge_store`` **duck-typed**. This Protocol
+formalizes that surface so a plugin can contribute an alternative backend
+(pgvector, Qdrant, Chroma, a managed vector DB) via
+``registry.register_knowledge_store(name, factory)`` and a fork can select it with
+``knowledge.backend: "<name>"``.
+
+The built-in ``knowledge.store.KnowledgeStore`` (SQLite + FTS5, and its
+``HybridKnowledgeStore`` semantic subclass) is the default reference implementation
+and satisfies this Protocol. It's a documentation + optional ``isinstance`` aid
+(``runtime_checkable``); duck-typing still works, and a backend may implement more.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+
+@runtime_checkable
+class KnowledgeBackend(Protocol):
+    """The methods the agent calls on the knowledge store. Implement these for a
+    custom backend; ``factory(config) -> KnowledgeBackend`` is what a plugin
+    registers."""
+
+    def add_chunk(self, content: str, domain: str = "general", **kwargs) -> int | None:
+        """Store a chunk; return its id (or None if not stored)."""
+
+    def search(self, query: str, k: int = 5, *, domain: str | None = None) -> list[dict]:
+        """Return up to ``k`` matching chunks (highest-ranked first), each a dict."""
+
+    def get_hot_memory(self, max_chars: int = 6000) -> str:
+        """Return the always-on context block injected by KnowledgeMiddleware."""
+
+    def list_chunks(self, *args, **kwargs) -> list[dict]:
+        """List stored chunks (for the knowledge console + tools)."""
+
+    def stats(self) -> dict:
+        """Return counts/health for the knowledge console + status."""
+
+    def delete_by_id(self, chunk_id: int) -> bool:
+        """Delete one chunk by id; return whether it existed."""
+
+    def add_finding(self, *args, **kwargs):
+        """Record a research finding (used by the curator / harvest paths)."""

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -147,6 +147,11 @@ def _init_langgraph_agent(headless_setup: bool = False):
     STATE.plugin_workflow_dirs = _plugins.workflow_dirs
     STATE.plugin_a2a_skills = _plugins.a2a_skills  # A2A card skills (#570)
     STATE.thread_id_resolver = _plugins.thread_id_resolver  # thread_id seam (#571)
+    # A plugin may provide the knowledge backend (ADR 0031) — swap it in now (the
+    # graph compiles below with STATE.knowledge_store). Default built-in store stays
+    # the collision-check binding + the degrade-safe fallback.
+    STATE.knowledge_store = _apply_plugin_knowledge_backend(
+        STATE.graph_config, STATE.knowledge_store, _plugins)
     # Register plugin-contributed goal verifiers (ADR 0028) — re-set on each
     # (re)load so a config change refreshes the available `plugin` verifiers.
     from graph.goals import hooks as _goal_hooks
@@ -246,6 +251,30 @@ def _build_knowledge_store(config):
     except Exception as exc:
         log.warning("[server] knowledge store init failed: %s; running KB-less", exc)
         return None
+
+
+def _apply_plugin_knowledge_backend(config, store, plugins):
+    """ADR 0031 — if ``knowledge.backend`` names a plugin-registered backend, build
+    it and use it instead of the built-in ``store``. Degrade-safe: an unregistered
+    name, a None return, or a factory error keeps ``store`` (never KB-less by
+    surprise). Called after plugins load, at both init and reload."""
+    backend = (getattr(config, "knowledge_backend", "") or "").strip()
+    if not backend:
+        return store
+    factory = (getattr(plugins, "knowledge_stores", {}) or {}).get(backend)
+    if factory is None:
+        log.warning("[server] knowledge.backend %r not registered by any plugin — built-in store", backend)
+        return store
+    try:
+        built = factory(config)
+    except Exception as exc:  # noqa: BLE001 — degrade to the built-in store
+        log.warning("[server] knowledge backend %r failed: %s — built-in store", backend, exc)
+        return store
+    if built is None:
+        log.warning("[server] knowledge backend %r returned None — built-in store", backend)
+        return store
+    log.info("[server] knowledge: plugin backend %r", backend)
+    return built
 
 
 def _build_skills_index(config, extra_skill_dirs=None):
@@ -857,6 +886,8 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
             new_plugin_tools = new_plugins.tools
             new_plugin_skill_dirs = new_plugins.skill_dirs
             new_plugin_meta = new_plugins.meta
+            # Plugin knowledge backend (ADR 0031) — swap before the graph rebuild.
+            new_store = _apply_plugin_knowledge_backend(new_config, new_store, new_plugins)
             new_skills = _build_skills_index(new_config, extra_skill_dirs=new_plugin_skill_dirs)
             new_workflow_registry = _build_workflow_registry(new_config)
             new_inbox_store = _build_inbox_store(new_config)

--- a/tests/test_knowledge_backend_plugin.py
+++ b/tests/test_knowledge_backend_plugin.py
@@ -1,0 +1,75 @@
+"""Pluggable knowledge backend — register_knowledge_store + selector (ADR 0031)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+from graph.config import LangGraphConfig
+from graph.plugins.registry import PluginRegistry
+from knowledge import KnowledgeBackend, KnowledgeStore
+from server.agent_init import _apply_plugin_knowledge_backend
+
+
+def _cfg(backend=""):
+    c = LangGraphConfig()
+    c.knowledge_backend = backend
+    return c
+
+
+class _FakeBackend:
+    def add_chunk(self, content, domain="general", **kw): return 1
+    def search(self, query, k=5, *, domain=None): return []
+    def get_hot_memory(self, max_chars=6000): return ""
+    def list_chunks(self, *a, **kw): return []
+    def stats(self): return {}
+    def delete_by_id(self, chunk_id): return True
+    def add_finding(self, *a, **kw): return None
+
+
+def test_builtin_store_satisfies_protocol(tmp_path):
+    store = KnowledgeStore(db_path=str(tmp_path / "kb.db"))
+    assert isinstance(store, KnowledgeBackend)
+
+
+def test_registry_register_guards():
+    reg = PluginRegistry("p", Path("."))
+    reg.register_knowledge_store("pgvector", lambda config: _FakeBackend())
+    reg.register_knowledge_store("", lambda config: _FakeBackend())  # bad name → ignored
+    reg.register_knowledge_store("x", None)                          # non-callable → ignored
+    assert set(reg.knowledge_stores) == {"pgvector"}
+
+
+def test_config_parses_backend(tmp_path):
+    import yaml
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump({"knowledge": {"backend": "pgvector"}}))
+    cfg = LangGraphConfig.from_yaml(str(p))
+    assert cfg.knowledge_backend == "pgvector"
+
+
+def test_apply_no_backend_keeps_builtin():
+    builtin = object()
+    plugins = SimpleNamespace(knowledge_stores={})
+    assert _apply_plugin_knowledge_backend(_cfg(""), builtin, plugins) is builtin
+
+
+def test_apply_selects_registered_backend():
+    builtin = object()
+    fake = _FakeBackend()
+    plugins = SimpleNamespace(knowledge_stores={"pgvector": lambda config: fake})
+    assert _apply_plugin_knowledge_backend(_cfg("pgvector"), builtin, plugins) is fake
+
+
+def test_apply_unregistered_degrades_to_builtin():
+    builtin = object()
+    plugins = SimpleNamespace(knowledge_stores={})
+    assert _apply_plugin_knowledge_backend(_cfg("nope"), builtin, plugins) is builtin
+
+
+def test_apply_none_or_error_degrades_to_builtin():
+    builtin = object()
+    def _none(config): return None
+    def _boom(config): raise RuntimeError("db down")
+    assert _apply_plugin_knowledge_backend(_cfg("b"), builtin, SimpleNamespace(knowledge_stores={"b": _none})) is builtin
+    assert _apply_plugin_knowledge_backend(_cfg("b"), builtin, SimpleNamespace(knowledge_stores={"b": _boom})) is builtin

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -354,3 +354,17 @@ def test_plugin_goal_hook_is_collected(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
     res = load_plugins(_cfg(plugins_enabled=["ghook"]))
     assert len(res.goal_hooks) == 1 and res.goal_hooks[0]["plugin_id"] == "ghook"  # ADR 0028 D4
+
+
+def test_plugin_knowledge_store_is_collected(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "plugins"
+    body = (
+        "def _factory(config):\n"
+        "    return object()\n"
+        "def register(reg):\n"
+        "    reg.register_knowledge_store('pgvector', _factory)\n"
+    )
+    _make_plugin(root, "kbplugin", enabled=True, body=body)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg(plugins_enabled=["kbplugin"]))
+    assert "pgvector" in res.knowledge_stores  # ADR 0031


### PR DESCRIPTION
Implements ADR 0031 — the knowledge **store backend** is now pluggable (it was already model-swappable via the gateway). A fork drops in pgvector/Qdrant/Chroma as a *plugin*, no core edit.

## What
- **`KnowledgeBackend` Protocol** (`knowledge/backend.py`) — formalizes the duck-typed surface consumers already use (`add_chunk`/`search`/`get_hot_memory`/`list_chunks`/`stats`/`delete_by_id`/`add_finding`). The built-in `KnowledgeStore` satisfies it.
- **`registry.register_knowledge_store(name, factory)`** (guarded) → loader collects (collision-guarded) → `PluginLoadResult.knowledge_stores`.
- **`knowledge.backend`** config selector (default `""` = built-in SQLite/FTS5).
- **`_apply_plugin_knowledge_backend()`** — after plugins load (init **and** reload), swap in the selected backend. **Degrade-safe:** unregistered name / `None` / factory error → keep the built-in store (never KB-less by surprise), matching the existing FTS5-fallback principle.

The store is built before plugins load, so the default is built first (collision-check binding + fallback) and the plugin backend swapped in right after `_build_plugins`, before the graph compiles — at both init and live-reload.

## Test
```
pytest tests/test_knowledge_backend_plugin.py tests/test_plugins.py   # protocol · guard · config · apply select/none/error/unregistered · loader collect
pytest -q   # 1210 passed ; ruff clean
```

Embedder stays gateway-routed; a `register_embedder` hook is noted as future in the ADR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)