### PR TITLE
refactor(console): rename Playbooks → Skills + clarify vs Workflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Console: "Playbooks" renamed to "Skills"** — the surface always *was* the skill
+  index (`SKILL.md`); the "Playbook" label collided with Workflows. Now labeled Skills,
+  with kickers + a "Skills vs Workflows" doc clarifying the distinction (a skill **advises**
+  / is retrieved; a workflow **runs** / is executed). `/api/playbooks` route unchanged.
+
 ### Added
 - **Pluggable knowledge backend** (ADR 0031) — `registry.register_knowledge_store(name,
   factory)` + a `knowledge.backend` config selector let a plugin supply the store

--- a/apps/web/e2e/knowledge.spec.ts
+++ b/apps/web/e2e/knowledge.spec.ts
@@ -20,12 +20,12 @@ test("Knowledge lands on the searchable Store and lists chunks", async ({ page }
   await expect(surface.getByPlaceholder(/Search the knowledge base/)).toBeVisible();
 });
 
-test("Knowledge sub-nav switches between Store and Playbooks", async ({ page }) => {
+test("Knowledge sub-nav switches between Store and Skills", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Knowledge" }).click();
 
   await expect(page.getByTestId("knowledge-store")).toBeVisible();
-  await page.locator(".stage-subnav").getByRole("button", { name: "Playbooks", exact: true }).click();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Skills", exact: true }).click();
   await expect(page.getByTestId("playbooks-surface")).toBeVisible();
   await page.locator(".stage-subnav").getByRole("button", { name: "Store", exact: true }).click();
   await expect(page.getByTestId("knowledge-store")).toBeVisible();

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -7,7 +7,7 @@ test("Knowledge → Playbooks lists pinned + learned skills and supports search"
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Knowledge" }).click();
   // Knowledge lands on Store now (ADR 0020) — switch to the Playbooks sub-tab.
-  await page.locator(".stage-subnav").getByRole("button", { name: "Playbooks", exact: true }).click();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Skills", exact: true }).click();
 
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
@@ -19,7 +19,7 @@ test("Knowledge → Playbooks lists pinned + learned skills and supports search"
   await expect(surface.getByText("learned").first()).toBeVisible();
 
   // Search narrows the list.
-  await surface.getByPlaceholder(/Search playbooks/).fill("triage");
+  await surface.getByPlaceholder(/Search skills/).fill("triage");
   await expect(surface.getByText("pr-triage-flow")).toBeVisible();
   await expect(surface.getByText("web-research")).toBeHidden();
 });
@@ -27,7 +27,7 @@ test("Knowledge → Playbooks lists pinned + learned skills and supports search"
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Knowledge" }).click();
-  await page.locator(".stage-subnav").getByRole("button", { name: "Playbooks", exact: true }).click();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
 

--- a/apps/web/e2e/workflows.spec.ts
+++ b/apps/web/e2e/workflows.spec.ts
@@ -13,7 +13,8 @@ async function openWorkflows(page) {
 
 test("lists a recipe with its steps and inputs", async ({ page }) => {
   await openWorkflows(page);
-  await expect(page.getByText("1 recipe", { exact: true })).toBeVisible();
+  // The kicker reads "…recipes the engine runs over subagents · 1 recipe" (ADR 0009 contrast copy).
+  await expect(page.getByText(/\b1 recipe\b/)).toBeVisible();
   // The recipe's description + step DAG render.
   await expect(page.getByText("Research a topic, then write a brief.")).toBeVisible();
   const steps = page.locator(".workflow-step");

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -687,7 +687,7 @@ export function App() {
                 <Database size={15} /> Store
               </button>
               <button className={knowledgeTab === "playbooks" ? "active" : ""} onClick={() => setKnowledgeTab("playbooks")}>
-                <BookMarked size={15} /> Playbooks
+                <BookMarked size={15} /> Skills
               </button>
             </div>
           ) : null}

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -80,9 +80,9 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
     <section className="panel stage-panel" data-testid="playbooks-surface">
       <div className="panel-header">
         <div>
-          <h1>Playbooks</h1>
+          <h1>Skills</h1>
           <p className="panel-kicker">
-            retrieved methodology · {pinned} pinned · {learned} learned
+            methodology the agent retrieves into context · {pinned} pinned · {learned} learned
           </p>
         </div>
         <button className="secondary-button" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
@@ -94,7 +94,7 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
         <input
           className="playbook-search"
           type="search"
-          placeholder="Search playbooks (name, description, tools)…"
+          placeholder="Search skills (name, description, tools)…"
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
@@ -139,7 +139,7 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
                   <button
                     type="button"
                     className="icon-button danger"
-                    title={p.source === "disk" ? "Delete (re-seeds from SKILL.md on restart)" : "Delete playbook"}
+                    title={p.source === "disk" ? "Delete (re-seeds from SKILL.md on restart)" : "Delete skill"}
                     onClick={() => setPending(p)}
                     data-testid={`playbook-delete-${p.id}`}
                   >
@@ -154,7 +154,7 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
 
       <ConfirmDialog
         open={pending !== null}
-        title="Delete playbook?"
+        title="Delete skill?"
         message={
           pending
             ? `Remove "${pending.name}"${pending.source === "disk" ? " — note: a pinned SKILL.md re-seeds on the next restart." : "."}`
@@ -166,7 +166,9 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
       />
 
       <p className="playbook-foot">
-        <BookMarked size={13} /> Playbooks are methodology the agent retrieves into context (ADR 0009) — they don't run, they advise.
+        <BookMarked size={13} /> Skills (`SKILL.md`) are methodology the agent <strong>retrieves</strong> into
+        context (ADR 0009) — they advise, they don't run. For deterministic step-by-step runs
+        across subagents, see <strong>Studio → Workflows</strong>.
       </p>
     </section>
   );

--- a/apps/web/src/workflows/WorkflowsSurface.tsx
+++ b/apps/web/src/workflows/WorkflowsSurface.tsx
@@ -82,7 +82,7 @@ function WorkflowsBody() {
         <div>
           <h1>Workflows</h1>
           <p className="panel-kicker">
-            {workflows.length} recipe{workflows.length === 1 ? "" : "s"}
+            step-by-step recipes the engine runs over subagents · {workflows.length} recipe{workflows.length === 1 ? "" : "s"}
           </p>
         </div>
         <div className="panel-actions">

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -7,6 +7,11 @@ recurring task. Relevant skills are retrieved and injected into the system
 prompt at inference time (the `<learned_skills>` block), so the agent picks the
 right approach without you re-explaining it each turn.
 
+> The console surfaces the skill index under **Knowledge → Skills**. A skill
+> **advises** (retrieved guidance the model may adapt); it does **not** execute. For
+> deterministic, run-the-same-steps orchestration across subagents, that's a
+> [Workflow](/guides/workflows#skills-vs-workflows) — different tool, different altitude.
+
 ## Anatomy of a skill
 
 A skill is a **folder containing a `SKILL.md`** file: YAML frontmatter followed

--- a/docs/guides/workflows.md
+++ b/docs/guides/workflows.md
@@ -2,9 +2,24 @@
 
 A **workflow** is a reusable, multi-step recipe over your subagents: research →
 extract angles → write a brief, each step feeding the next, some running in
-parallel. Define it once as YAML, run it many times with different inputs. It's
-the multi-step generalization of a single-subagent skill — see
+parallel. Define it once as YAML, run it many times with different inputs. See
 [ADR 0002](/adr/0002-reusable-subagent-workflows) for the design.
+
+## Skills vs Workflows
+
+These get conflated — the console lists the skill index ("Skills") next to
+"Workflows" — but they're two different altitudes (ADR 0009):
+
+| | **Skill** ([`SKILL.md`](/guides/skills)) | **Workflow** (`*.yaml`) |
+| --- | --- | --- |
+| What | methodology — *how/when* to approach a task | a DAG of subagent steps with dependencies |
+| How it runs | **retrieved** by relevance + **injected into context**; the model reads it and decides whether/how to follow | **executed** by the engine — fixed steps, deterministic |
+| In control | the model (advisory) | the engine (orchestrated) |
+| Trigger | automatic (semantic retrieval mid-turn) | explicit (run by name) |
+
+Rule of thumb: a **skill advises**, a **workflow runs**. Reach for a skill when the
+model should *know how* to do something; a workflow when you need *the same steps,
+the same way, every time*.
 
 ## Anatomy
 


### PR DESCRIPTION
"Playbooks vs Workflows" was confusing because **"Playbooks" was always just the skill index** (`skills.db` / `SKILL.md`) under a friendlier label — and that label collided with Workflows. They're two different altitudes (ADR 0009), not redundant:

- a **skill** is **retrieved** guidance the model reads → it *advises*;
- a **workflow** is an **executed** DAG of subagent steps → it *runs*.

## What
- **Console:** Knowledge → "Playbooks" → **"Skills"** (tab, title, footer, search placeholder), with clarifying kickers on both the Skills and Workflows surfaces + a cross-link. Internal `/api/playbooks` route, testids, and type names are unchanged (no API churn).
- **Docs:** a "Skills vs Workflows" comparison table in the workflows guide + a reciprocal pointer in the skills guide.
- **e2e** specs updated to the new label/placeholder.

Web build (tsc) + docs build both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)