### PR TITLE
feat(knowledge): register_embedder — in-process embedder hook (ADR 0031)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`register_embedder` hook** (ADR 0031 follow-up) — a plugin can supply an in-process
+  embedder (`registry.register_embedder(name, factory→embed_fn)`), selected with
+  `knowledge.embedder: "<name>"`, so the built-in hybrid store can embed locally
+  (fastembed / sentence-transformers) without the gateway round-trip. Degrade-safe:
+  unregistered / None / error falls back to the gateway embedder.
+
 ## [0.23.0] - 2026-06-07
 
 ### Changed

--- a/docs/adr/0031-pluggable-knowledge-backend.md
+++ b/docs/adr/0031-pluggable-knowledge-backend.md
@@ -79,11 +79,17 @@ live-reload path.
 - The store interface is now explicit (`KnowledgeBackend`), so a backend author knows the
   exact surface to implement.
 
+## Embedder (shipped as a follow-up)
+
+The embedder is gateway-routed by default (model-swappable via `embed_model`).
+**`register_embedder(name, factory)`** + a `knowledge.embedder` selector let a plugin
+supply an **in-process** embedder (fastembed / sentence-transformers, no gateway
+round-trip) for the built-in hybrid store — degrade-safe to the gateway embedder on an
+unregistered name / None / error. A plugin-supplied *backend* (above) owns its own
+embedding, so the selector applies to the built-in-store path only.
+
 ## Out of scope / future
 
-- **The embedder** stays gateway-routed (model-swappable via `embed_model`). A
-  `register_embedder` hook (for an in-process embedder like fastembed/sentence-transformers,
-  no gateway round-trip) is a natural follow-up but not part of this ADR.
 - Retrieval **fusion** (RRF) lives in the backend now — a custom backend owns its own
   ranking, so no separate seam is needed.
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -255,6 +255,10 @@ class LangGraphConfig:
     # otherwise the name of a plugin-registered backend (register_knowledge_store).
     # An unregistered name / a factory error degrades to the built-in store.
     knowledge_backend: str = ""
+    # In-process embedder selector (ADR 0031 follow-up) — "" = the gateway embedder
+    # (create_embed_fn); otherwise a plugin-registered embedder (register_embedder),
+    # used by the built-in hybrid store. Unregistered/error → gateway embedder.
+    knowledge_embedder: str = ""
     # The gateway's embedding model (NOT the chat model). Default is what the
     # protoLabs gateway serves; forks on a different gateway set this to a model
     # their gateway has (check GET /v1/models). A wrong/absent model degrades to
@@ -540,6 +544,7 @@ class LangGraphConfig:
             subagent_output_truncate=subagents.get("output_truncate", cls.subagent_output_truncate),
             knowledge_db_path=knowledge.get("db_path", cls.knowledge_db_path),
             knowledge_backend=knowledge.get("backend", cls.knowledge_backend),
+            knowledge_embedder=knowledge.get("embedder", cls.knowledge_embedder),
             checkpoint_db_path=data.get("checkpoint", {}).get("db_path", cls.checkpoint_db_path),
             telemetry_enabled=data.get("telemetry", {}).get("enabled", cls.telemetry_enabled),
             telemetry_db_path=data.get("telemetry", {}).get("db_path", cls.telemetry_db_path),

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -32,6 +32,7 @@ class PluginLoadResult:
     goal_verifiers: dict = field(default_factory=dict)  # name -> verifier fn (ADR 0028)
     goal_hooks: list = field(default_factory=list)       # {on_achieved, on_failed} (ADR 0028)
     knowledge_stores: dict = field(default_factory=dict)  # name -> backend factory (ADR 0031)
+    embedders: dict = field(default_factory=dict)        # name -> embed_fn factory (ADR 0031)
     a2a_skills: list = field(default_factory=list)  # A2A card skill specs (#570)
     routers: list = field(default_factory=list)    # {plugin_id, router, prefix} (ADR 0018)
     surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
@@ -242,6 +243,11 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
                 log.warning("[plugins] %s: knowledge backend %s collides — skipped", manifest.id, name)
                 continue
             result.knowledge_stores[name] = factory
+        for name, factory in registry.embedders.items():  # ADR 0031 follow-up
+            if name in result.embedders:
+                log.warning("[plugins] %s: embedder %s collides — skipped", manifest.id, name)
+                continue
+            result.embedders[name] = factory
         for f in registry.mcp_servers:
             result.mcp_servers.append({"plugin_id": manifest.id, "factory": f})
         entry["loaded"] = True

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -57,6 +57,7 @@ class PluginRegistry:
         self.goal_verifiers: dict = {}    # name -> async (spec, ctx) -> VerifyResult (ADR 0028)
         self.goal_hooks: list = []        # {on_achieved, on_failed} terminal reactions (ADR 0028)
         self.knowledge_stores: dict = {}  # name -> (config) -> KnowledgeBackend (ADR 0031)
+        self.embedders: dict = {}         # name -> (config) -> (text -> vector) embed_fn (ADR 0031)
 
     def register_tool(self, tool) -> None:
         """Expose a LangChain tool to the agent."""
@@ -132,6 +133,18 @@ class PluginRegistry:
                         self.plugin_id, name, factory)
             return
         self.knowledge_stores[name] = factory
+
+    def register_embedder(self, name: str, factory) -> None:
+        """Contribute an in-process embedder (ADR 0031 follow-up) — ``factory(config)
+        -> (text: str) -> list[float]``. Selected by a fork with
+        ``knowledge.embedder: "<name>"`` for the built-in hybrid store, avoiding the
+        gateway round-trip (e.g. fastembed / sentence-transformers). On a None/error
+        return the agent falls back to the gateway embedder (degrade-safe)."""
+        if not name or not callable(factory):
+            log.warning("[plugins] %s: register_embedder needs a name + factory: %r / %r",
+                        self.plugin_id, name, factory)
+            return
+        self.embedders[name] = factory
 
     def register_a2a_skill(self, spec: dict) -> None:
         """Contribute an A2A *card* skill — advertised on the agent card and,

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -254,27 +254,58 @@ def _build_knowledge_store(config):
 
 
 def _apply_plugin_knowledge_backend(config, store, plugins):
-    """ADR 0031 — if ``knowledge.backend`` names a plugin-registered backend, build
-    it and use it instead of the built-in ``store``. Degrade-safe: an unregistered
-    name, a None return, or a factory error keeps ``store`` (never KB-less by
-    surprise). Called after plugins load, at both init and reload."""
+    """ADR 0031 — swap in a plugin-provided knowledge **backend** (``knowledge.backend``)
+    or, failing that, a plugin **embedder** for the built-in hybrid store
+    (``knowledge.embedder``), selected by config. Degrade-safe: an unregistered name,
+    a None return, or a factory error keeps ``store`` (never KB-less by surprise).
+    Called after plugins load, at both init and reload."""
     backend = (getattr(config, "knowledge_backend", "") or "").strip()
-    if not backend:
-        return store
-    factory = (getattr(plugins, "knowledge_stores", {}) or {}).get(backend)
+    if backend:
+        factory = (getattr(plugins, "knowledge_stores", {}) or {}).get(backend)
+        if factory is None:
+            log.warning("[server] knowledge.backend %r not registered by any plugin — built-in store", backend)
+            return store
+        try:
+            built = factory(config)
+        except Exception as exc:  # noqa: BLE001 — degrade to the built-in store
+            log.warning("[server] knowledge backend %r failed: %s — built-in store", backend, exc)
+            return store
+        if built is None:
+            log.warning("[server] knowledge backend %r returned None — built-in store", backend)
+            return store
+        log.info("[server] knowledge: plugin backend %r", backend)
+        return built
+    # No plugin store selected — maybe a plugin embedder for the built-in hybrid store.
+    embedder = (getattr(config, "knowledge_embedder", "") or "").strip()
+    if embedder:
+        return _apply_plugin_embedder(config, store, plugins, embedder)
+    return store
+
+
+def _apply_plugin_embedder(config, store, plugins, name):
+    """ADR 0031 follow-up — rebuild the built-in store as a HybridKnowledgeStore using
+    a plugin-registered in-process embedder (``register_embedder``). Degrade-safe:
+    unregistered / None / error keeps ``store`` (the gateway-embedder one)."""
+    factory = (getattr(plugins, "embedders", {}) or {}).get(name)
     if factory is None:
-        log.warning("[server] knowledge.backend %r not registered by any plugin — built-in store", backend)
+        log.warning("[server] knowledge.embedder %r not registered by any plugin — gateway embedder", name)
         return store
     try:
-        built = factory(config)
-    except Exception as exc:  # noqa: BLE001 — degrade to the built-in store
-        log.warning("[server] knowledge backend %r failed: %s — built-in store", backend, exc)
+        embed_fn = factory(config)
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[server] embedder %r failed: %s — gateway embedder", name, exc)
         return store
-    if built is None:
-        log.warning("[server] knowledge backend %r returned None — built-in store", backend)
+    if embed_fn is None:
+        log.warning("[server] embedder %r returned None — gateway embedder", name)
         return store
-    log.info("[server] knowledge: plugin backend %r", backend)
-    return built
+    try:
+        from knowledge.hybrid_store import HybridKnowledgeStore
+        rebuilt = HybridKnowledgeStore(db_path=config.knowledge_db_path, embed_fn=embed_fn)
+        log.info("[server] knowledge: hybrid store with plugin embedder %r", name)
+        return rebuilt
+    except Exception as exc:  # noqa: BLE001
+        log.warning("[server] hybrid store w/ embedder %r failed: %s — built-in store", name, exc)
+        return store
 
 
 def _build_skills_index(config, extra_skill_dirs=None):

--- a/tests/test_knowledge_backend_plugin.py
+++ b/tests/test_knowledge_backend_plugin.py
@@ -73,3 +73,54 @@ def test_apply_none_or_error_degrades_to_builtin():
     def _boom(config): raise RuntimeError("db down")
     assert _apply_plugin_knowledge_backend(_cfg("b"), builtin, SimpleNamespace(knowledge_stores={"b": _none})) is builtin
     assert _apply_plugin_knowledge_backend(_cfg("b"), builtin, SimpleNamespace(knowledge_stores={"b": _boom})) is builtin
+
+
+# ── register_embedder (ADR 0031 follow-up) ───────────────────────────────────
+
+def _embed_factory(config):
+    return lambda text: [0.0, 1.0, 0.0]
+
+
+def test_registry_register_embedder_guards():
+    reg = PluginRegistry("p", Path("."))
+    reg.register_embedder("local", _embed_factory)
+    reg.register_embedder("", _embed_factory)   # bad name → ignored
+    reg.register_embedder("x", None)            # non-callable → ignored
+    assert set(reg.embedders) == {"local"}
+
+
+def test_config_parses_embedder(tmp_path):
+    import yaml
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump({"knowledge": {"embedder": "local"}}))
+    assert LangGraphConfig.from_yaml(str(p)).knowledge_embedder == "local"
+
+
+def test_apply_embedder_builds_hybrid(tmp_path):
+    from knowledge.hybrid_store import HybridKnowledgeStore
+    cfg = _cfg("")
+    cfg.knowledge_embedder = "local"
+    cfg.knowledge_db_path = str(tmp_path / "kb.db")
+    plugins = SimpleNamespace(knowledge_stores={}, embedders={"local": _embed_factory})
+    out = _apply_plugin_knowledge_backend(cfg, object(), plugins)
+    assert isinstance(out, HybridKnowledgeStore)
+
+
+def test_apply_embedder_unregistered_or_error_keeps_builtin(tmp_path):
+    builtin = object()
+    cfg = _cfg("")
+    cfg.knowledge_db_path = str(tmp_path / "kb.db")
+    cfg.knowledge_embedder = "nope"
+    assert _apply_plugin_knowledge_backend(cfg, builtin, SimpleNamespace(knowledge_stores={}, embedders={})) is builtin
+    def _boom(config): raise RuntimeError("no model")
+    cfg.knowledge_embedder = "b"
+    assert _apply_plugin_knowledge_backend(cfg, builtin, SimpleNamespace(knowledge_stores={}, embedders={"b": _boom})) is builtin
+
+
+def test_backend_takes_precedence_over_embedder(tmp_path):
+    fake = _FakeBackend()
+    cfg = _cfg("pg")
+    cfg.knowledge_embedder = "local"
+    cfg.knowledge_db_path = str(tmp_path / "kb.db")
+    plugins = SimpleNamespace(knowledge_stores={"pg": lambda c: fake}, embedders={"local": _embed_factory})
+    assert _apply_plugin_knowledge_backend(cfg, object(), plugins) is fake

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -368,3 +368,17 @@ def test_plugin_knowledge_store_is_collected(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
     res = load_plugins(_cfg(plugins_enabled=["kbplugin"]))
     assert "pgvector" in res.knowledge_stores  # ADR 0031
+
+
+def test_plugin_embedder_is_collected(monkeypatch, tmp_path) -> None:
+    root = tmp_path / "plugins"
+    body = (
+        "def _embed(config):\n"
+        "    return lambda text: [0.0, 1.0]\n"
+        "def register(reg):\n"
+        "    reg.register_embedder('local', _embed)\n"
+    )
+    _make_plugin(root, "embplugin", enabled=True, body=body)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    res = load_plugins(_cfg(plugins_enabled=["embplugin"]))
+    assert "local" in res.embedders  # ADR 0031 follow-up


### PR DESCRIPTION
Follow-up #1 — completes the knowledge pluggability. The store backend was already swappable (#656); now the **embedder** is too.

- **`register_embedder(name, factory)`** (guarded) → loader collects → `embedders`. The factory returns an `embed_fn` (text → vector).
- **`knowledge.embedder`** selector (default `""` = the gateway embedder via `create_embed_fn`).
- `_apply_plugin_knowledge_backend` extended: no plugin backend + an embedder selected → rebuild the built-in store as `HybridKnowledgeStore` with the plugin's `embed_fn` (in-process; fastembed / sentence-transformers, no gateway round-trip). **Degrade-safe** — unregistered / None / error → gateway embedder; a plugin **backend takes precedence** (it owns its own embedding).

## Test
```
pytest tests/test_knowledge_backend_plugin.py tests/test_plugins.py   # guard · config · builds hybrid · degrade · precedence · loader collect
pytest -q   # 1216 passed ; docs + ruff green
```

ADR 0031 updated (embedder moved from future → shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
