### PR TITLE
feat(console): friendly Schedule modal — calendar + presets, no cron required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Friendlier Schedule tab** — "New schedule" now opens a **modal** that builds the
+  schedule for you: a **calendar** picker for one-off (→ ISO datetime), **presets** for
+  recurring (hourly / daily / weekdays / weekly + a time picker, → cron), and a raw-cron
+  escape hatch — with a live plain-English preview ("every weekday at 9:00 AM"). No
+  hand-written cron required. The list now shows each job's schedule in plain English too.
+
 ### Added
 - **Desktop build CI** — `.github/workflows/desktop-build.yml` builds the macOS desktop
   app (`.dmg` — the Tauri shell + the PyInstaller server sidecar), signs + notarizes it

--- a/apps/web/e2e/schedule.spec.ts
+++ b/apps/web/e2e/schedule.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+
+// The Schedule tab's "New schedule" modal builds the cron/ISO `schedule` string for
+// you — calendar for one-off, presets for recurring, raw cron as the escape hatch —
+// with a live plain-English preview. (No hand-written cron required.)
+
+async function openScheduleModal(page) {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Activity", exact: true }).click();
+  await page.getByRole("button", { name: "Schedule", exact: true }).click();
+  await page.getByTestId("schedule-new").click();
+  await expect(page.getByTestId("schedule-modal")).toBeVisible();
+}
+
+test("modal opens on Once with a calendar input", async ({ page }) => {
+  await openScheduleModal(page);
+  await expect(page.getByTestId("schedule-once")).toBeVisible();
+  await expect(page.getByTestId("schedule-once")).toHaveAttribute("type", "datetime-local");
+});
+
+test("repeat presets build cron with a plain-English preview", async ({ page }) => {
+  await openScheduleModal(page);
+  await page.getByRole("tab", { name: "Repeat" }).click();
+  // default daily 09:00 → preview describes it + shows the cron
+  const preview = page.getByTestId("schedule-preview");
+  await expect(preview).toContainText("every day at");
+  await expect(preview.locator("code")).toContainText("0 9 * * *");
+  // switch to weekdays
+  await page.getByTestId("schedule-freq").selectOption("weekdays");
+  await expect(preview).toContainText("every weekday at");
+  await expect(preview.locator("code")).toContainText("* * 1-5");
+});
+
+test("cron mode describes a raw expression", async ({ page }) => {
+  await openScheduleModal(page);
+  await page.getByRole("tab", { name: "Cron" }).click();
+  await page.getByTestId("schedule-cron").fill("0 9 * * 1-5");
+  await expect(page.getByTestId("schedule-preview")).toContainText("every weekday at");
+});
+
+test("submit is gated until prompt + schedule are set", async ({ page }) => {
+  await openScheduleModal(page);
+  await page.getByTestId("schedule-once").fill("2099-01-01T09:00");
+  await expect(page.getByTestId("schedule-submit")).toBeDisabled(); // no prompt yet
+  await page.getByTestId("schedule-prompt").fill("Run the daily brief");
+  await expect(page.getByTestId("schedule-submit")).toBeEnabled();
+});

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2457,6 +2457,58 @@ textarea {
   color: #fff;
 }
 
+/* New-schedule modal (friendly builder) */
+.schedule-card {
+  width: min(560px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.schedule-card .confirm-head { position: relative; }
+.schedule-close {
+  margin-left: auto;
+}
+.schedule-modes {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  align-self: flex-start;
+}
+.schedule-modes button {
+  border: none;
+  background: transparent;
+  color: var(--fg-secondary);
+  padding: 5px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.schedule-modes button.active {
+  background: var(--accent, #9b87f2);
+  color: #0a0a0c;
+}
+.schedule-repeat {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.schedule-preview {
+  margin: 0;
+  font-size: 13px;
+  color: var(--fg-secondary);
+}
+.schedule-preview code {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--bg-raised, #131316);
+  border: 1px solid var(--border);
+  font-size: 12px;
+}
+.schedule-preview .muted { color: var(--fg-muted, #71717a); }
+
 .setup-frame {
   width: min(720px, 100%);
 }

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -4,41 +4,170 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { Plus, RefreshCw, Trash2 } from "lucide-react";
-import { Suspense, useState } from "react";
+import { CalendarClock, Plus, RefreshCw, Trash2, X } from "lucide-react";
+import { Suspense, useEffect, useMemo, useState } from "react";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { api } from "../lib/api";
 import { queryKeys, schedulesQuery } from "../lib/queries";
+import {
+  buildOnce,
+  buildRepeat,
+  describeSchedule,
+  WEEKDAYS,
+  type RepeatFreq,
+} from "./schedule-builder";
 
-// Scheduled jobs (Activity → Schedule), on the TanStack Query data layer
-// (ADR 0013): the job list is a useSuspenseQuery; add/cancel are useMutations
-// that invalidate it. Loading via <Suspense>, errors via <ErrorBoundary>.
+// Scheduled jobs (Activity → Schedule). The list is a useSuspenseQuery; add/cancel
+// are useMutations that invalidate it. Adding is a friendly modal that builds the
+// `schedule` string for you (a calendar for one-off, presets for recurring, raw cron
+// as the escape hatch) — no hand-written cron required.
+
+type Mode = "once" | "repeat" | "cron";
+
+function ScheduleModal({
+  open,
+  onClose,
+  onAdd,
+  busy,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onAdd: (body: { prompt: string; schedule: string; job_id?: string }) => void;
+  busy: boolean;
+}) {
+  const [mode, setMode] = useState<Mode>("once");
+  const [onceAt, setOnceAt] = useState("");
+  const [freq, setFreq] = useState<RepeatFreq>("daily");
+  const [time, setTime] = useState("09:00");
+  const [dow, setDow] = useState(1);
+  const [cronRaw, setCronRaw] = useState("");
+  const [prompt, setPrompt] = useState("");
+  const [jobId, setJobId] = useState("");
+
+  const schedule = useMemo(() => {
+    if (mode === "once") return buildOnce(onceAt);
+    if (mode === "repeat") return buildRepeat(freq, time, dow);
+    return cronRaw.trim();
+  }, [mode, onceAt, freq, time, dow, cronRaw]);
+
+  const preview = describeSchedule(schedule);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+
+  const canSubmit = !!prompt.trim() && !!schedule && !busy;
+
+  return (
+    <div className="confirm-overlay" role="dialog" aria-modal="true" aria-label="New schedule"
+         onClick={onClose} data-testid="schedule-modal">
+      <div className="confirm-card schedule-card" onClick={(e) => e.stopPropagation()}>
+        <div className="confirm-head">
+          <CalendarClock size={16} />
+          <h2>New schedule</h2>
+          <button className="icon-button schedule-close" type="button" onClick={onClose} title="Close">
+            <X size={16} />
+          </button>
+        </div>
+
+        <div className="schedule-modes" role="tablist">
+          <button type="button" role="tab" aria-selected={mode === "once"}
+                  className={mode === "once" ? "active" : ""} onClick={() => setMode("once")}>Once</button>
+          <button type="button" role="tab" aria-selected={mode === "repeat"}
+                  className={mode === "repeat" ? "active" : ""} onClick={() => setMode("repeat")}>Repeat</button>
+          <button type="button" role="tab" aria-selected={mode === "cron"}
+                  className={mode === "cron" ? "active" : ""} onClick={() => setMode("cron")}>Cron</button>
+        </div>
+
+        {mode === "once" && (
+          <label className="field">
+            <span>Date &amp; time</span>
+            <input type="datetime-local" value={onceAt} onChange={(e) => setOnceAt(e.target.value)}
+                   data-testid="schedule-once" />
+          </label>
+        )}
+
+        {mode === "repeat" && (
+          <div className="schedule-repeat">
+            <label className="field">
+              <span>Frequency</span>
+              <select value={freq} onChange={(e) => setFreq(e.target.value as RepeatFreq)} data-testid="schedule-freq">
+                <option value="hourly">Every hour</option>
+                <option value="daily">Every day</option>
+                <option value="weekdays">Every weekday (Mon–Fri)</option>
+                <option value="weekly">Every week</option>
+              </select>
+            </label>
+            {freq === "weekly" && (
+              <label className="field">
+                <span>Day</span>
+                <select value={dow} onChange={(e) => setDow(Number(e.target.value))}>
+                  {WEEKDAYS.map((d, i) => <option key={i} value={i}>{d}</option>)}
+                </select>
+              </label>
+            )}
+            <label className="field">
+              <span>{freq === "hourly" ? "Minute" : "Time"}</span>
+              <input type="time" value={time} onChange={(e) => setTime(e.target.value)} data-testid="schedule-time" />
+            </label>
+          </div>
+        )}
+
+        {mode === "cron" && (
+          <label className="field">
+            <span>Cron expression (5 fields)</span>
+            <input value={cronRaw} onChange={(e) => setCronRaw(e.target.value)}
+                   placeholder='e.g. "0 9 * * 1-5"' data-testid="schedule-cron" />
+          </label>
+        )}
+
+        <p className="schedule-preview" data-testid="schedule-preview">
+          {preview ? <>Runs <strong>{preview}</strong> <code>{schedule}</code></> : <span className="muted">Pick when it should run</span>}
+        </p>
+
+        <label className="field">
+          <span>Prompt (delivered to the agent when it fires)</span>
+          <textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={4}
+                    placeholder="What the agent should do when this fires" data-testid="schedule-prompt" />
+        </label>
+        <label className="field">
+          <span>Job id (optional)</span>
+          <input value={jobId} onChange={(e) => setJobId(e.target.value)} placeholder="auto" />
+        </label>
+
+        <div className="confirm-actions">
+          <button type="button" className="secondary-button" onClick={onClose}>Cancel</button>
+          <button type="button" className="primary-button" disabled={!canSubmit} data-testid="schedule-submit"
+                  onClick={() => onAdd({ prompt: prompt.trim(), schedule, job_id: jobId.trim() || undefined })}>
+            <Plus size={16} /> Schedule
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function ScheduleBody() {
   const queryClient = useQueryClient();
   const { data, isFetching, refetch } = useSuspenseQuery(schedulesQuery());
   const jobs = data.jobs;
   const backend = data.backend;
-
-  const [prompt, setPrompt] = useState("");
-  const [when, setWhen] = useState("");
-  const [jobId, setJobId] = useState("");
+  const [modalOpen, setModalOpen] = useState(false);
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.schedules });
 
   const add = useMutation({
-    mutationFn: () =>
-      api.addSchedule({ prompt: prompt.trim(), schedule: when.trim(), job_id: jobId.trim() || undefined }),
-    onSuccess: () => {
-      setPrompt("");
-      setWhen("");
-      setJobId("");
-    },
+    mutationFn: (body: { prompt: string; schedule: string; job_id?: string }) => api.addSchedule(body),
+    onSuccess: () => setModalOpen(false),
     onSettled: invalidate,
   });
   const cancel = useMutation({ mutationFn: (id: string) => api.cancelSchedule(id), onSettled: invalidate });
-
   const busy = add.isPending || cancel.isPending;
 
   return (
@@ -48,45 +177,19 @@ function ScheduleBody() {
           <h1>Schedule</h1>
           <p className="panel-kicker">{jobs.length} job{jobs.length === 1 ? "" : "s"} · {backend}</p>
         </div>
-        <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
-          <RefreshCw size={16} className={isFetching ? "spin" : ""} />
-        </button>
+        <div className="settings-actions">
+          <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
+            <RefreshCw size={16} className={isFetching ? "spin" : ""} />
+          </button>
+          <button className="primary-button" type="button" onClick={() => setModalOpen(true)}
+                  disabled={backend === "disabled"} data-testid="schedule-new">
+            <Plus size={16} /> New schedule
+          </button>
+        </div>
       </div>
 
       <div className="stage-body">
-        <div className="subagent-grid">
-          <label className="field">
-            <span>When (cron or ISO datetime)</span>
-            <input
-              value={when}
-              onChange={(event) => setWhen(event.target.value)}
-              placeholder='e.g. "0 9 * * 1-5"  or  "2026-06-01T15:00:00Z"'
-            />
-          </label>
-          <label className="field">
-            <span>Job id (optional)</span>
-            <input value={jobId} onChange={(event) => setJobId(event.target.value)} placeholder="auto" />
-          </label>
-          <button
-            className="primary-button"
-            type="button"
-            onClick={() => add.mutate()}
-            disabled={busy || !prompt.trim() || !when.trim()}
-          >
-            <Plus size={16} />
-            Schedule
-          </button>
-        </div>
-        <label className="field grow">
-          <span>Prompt (delivered to the agent when it fires)</span>
-          <textarea
-            value={prompt}
-            onChange={(event) => setPrompt(event.target.value)}
-            placeholder="What the agent should do when this fires"
-            rows={5}
-          />
-        </label>
-
+        {add.isError ? <p className="settings-status">Couldn't schedule: {add.error instanceof Error ? add.error.message : String(add.error)}</p> : null}
         <div className="subagent-list">
           {jobs.length ? (
             jobs.map((job) => (
@@ -94,19 +197,14 @@ function ScheduleBody() {
                 <div>
                   <strong>{job.id}</strong>
                   <span>
-                    {job.schedule}
+                    {describeSchedule(job.schedule)}
                     {job.next_fire ? ` · next ${job.next_fire}` : ""}
                     {" · "}
                     {job.prompt.length > 80 ? `${job.prompt.slice(0, 80)}…` : job.prompt}
                   </span>
                 </div>
-                <button
-                  className="icon-button"
-                  type="button"
-                  onClick={() => cancel.mutate(job.id)}
-                  disabled={busy}
-                  title="Cancel job"
-                >
+                <button className="icon-button" type="button" onClick={() => cancel.mutate(job.id)}
+                        disabled={busy} title="Cancel job">
                   <Trash2 size={16} />
                 </button>
               </div>
@@ -115,12 +213,14 @@ function ScheduleBody() {
             <div className="subagent-row">
               <div>
                 <strong>No scheduled jobs</strong>
-                <span>{backend !== "local" && backend !== "disabled" ? `jobs may be managed remotely by ${backend}` : "create one above"}</span>
+                <span>{backend !== "local" && backend !== "disabled" ? `jobs may be managed remotely by ${backend}` : "create one with “New schedule”"}</span>
               </div>
             </div>
           )}
         </div>
       </div>
+
+      <ScheduleModal open={modalOpen} onClose={() => setModalOpen(false)} onAdd={(b) => add.mutate(b)} busy={busy} />
     </>
   );
 }

--- a/apps/web/src/schedule/schedule-builder.ts
+++ b/apps/web/src/schedule/schedule-builder.ts
@@ -1,0 +1,69 @@
+// Builds the scheduler's `schedule` string from friendly inputs, and describes one
+// back in plain English. The backend accepts either a 5-field cron expression
+// (recurring) or an ISO-8601 datetime (one-shot) and auto-detects — so the modal
+// never makes the operator hand-write cron.
+
+export type RepeatFreq = "hourly" | "daily" | "weekdays" | "weekly";
+
+export const WEEKDAYS = ["Sunday", "Monday", "Tuesday", "Wednesday", "Thursday", "Friday", "Saturday"];
+
+/** A `<input type="datetime-local">` value (local wall-clock) → ISO-8601 UTC, for a one-shot fire. */
+export function buildOnce(local: string): string {
+  if (!local) return "";
+  const d = new Date(local);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toISOString().replace(/\.\d{3}Z$/, "Z"); // drop milliseconds
+}
+
+/** Friendly recurrence → a 5-field cron string. `time` is "HH:MM"; `dow` is 0–6 (Sun–Sat). */
+export function buildRepeat(freq: RepeatFreq, time: string, dow: number): string {
+  const [h, m] = (time || "09:00").split(":");
+  const hh = clamp(parseInt(h, 10), 0, 23, 9);
+  const mm = clamp(parseInt(m, 10), 0, 59, 0);
+  switch (freq) {
+    case "hourly":
+      return `${mm} * * * *`;
+    case "daily":
+      return `${mm} ${hh} * * *`;
+    case "weekdays":
+      return `${mm} ${hh} * * 1-5`;
+    case "weekly":
+      return `${mm} ${hh} * * ${clamp(dow, 0, 6, 1)}`;
+  }
+}
+
+function clamp(n: number, lo: number, hi: number, fallback: number): number {
+  return Number.isFinite(n) ? Math.min(hi, Math.max(lo, n)) : fallback;
+}
+
+/** Plain-English description of a schedule string (cron or ISO). Falls back to the raw string. */
+export function describeSchedule(schedule: string): string {
+  const s = (schedule || "").trim();
+  if (!s) return "";
+  if (/^\d{4}-\d{2}-\d{2}T/.test(s)) {
+    const d = new Date(s);
+    return Number.isNaN(d.getTime()) ? "once" : `once — ${d.toLocaleString()}`;
+  }
+  const parts = s.split(/\s+/);
+  if (parts.length !== 5) return s; // custom cron — show as-is
+  const [mn, hr, dom, mon, dow] = parts;
+  if (hr === "*" && dom === "*" && mon === "*" && dow === "*") {
+    return `every hour at :${mn.padStart(2, "0")}`;
+  }
+  const time = clockTime(hr, mn);
+  if (dom === "*" && mon === "*" && time) {
+    if (dow === "*") return `every day at ${time}`;
+    if (dow === "1-5") return `every weekday at ${time}`;
+    if (/^[0-6]$/.test(dow)) return `every ${WEEKDAYS[+dow]} at ${time}`;
+  }
+  return s; // anything fancier — show the cron
+}
+
+function clockTime(hr: string, mn: string): string | null {
+  const h = parseInt(hr, 10);
+  const m = parseInt(mn, 10);
+  if (!Number.isFinite(h) || !Number.isFinite(m)) return null;
+  const d = new Date();
+  d.setHours(h, m, 0, 0);
+  return d.toLocaleTimeString([], { hour: "numeric", minute: "2-digit" });
+}


### PR DESCRIPTION
The Schedule tab's add form was a raw "cron or ISO datetime" text box. This replaces it with a **"New schedule" modal** that builds the schedule string for you — so you can schedule without knowing cron.

- **Once** — a `datetime-local` **calendar** picker → ISO-8601 (one-shot fire).
- **Repeat** — frequency **presets** (hourly / daily / weekdays / weekly + day-of-week) + a time picker → a 5-field cron.
- **Cron** — raw expression, the power-user escape hatch.
- A live **plain-English preview** ("every weekday at 9:00 AM") next to the resulting schedule string; the job list now describes each schedule in plain English too.

No backend change — the scheduler already accepts a cron string **or** an ISO datetime and auto-detects. Pure builder logic in `schedule-builder.ts`.

## Test
4 e2e cover the modal modes + preview + submit-gating — **pass locally** (`playwright test e2e/schedule.spec.ts`). Web build (tsc) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
