### PR TITLE
refactor(console): unify panel sub-tabs (one StageSubnav, above the card)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Unified panel sub-tabs** — every surface's sub-tab strip now renders through one
+  shared `StageSubnav` component, always **above the panel card**. Previously Settings +
+  plugin views rendered their tabs *inside* the card (so they read as part of the heading)
+  while the rail surfaces rendered them above — now all consistent (single source of truth).
 - **Friendlier Schedule tab** — "New schedule" now opens a **modal** that builds the
   schedule for you: a **calendar** picker for one-off (→ ISO datetime), **presets** for
   recurring (hourly / daily / weekdays / weekly + a time picker, → cron), and a raw-cron

--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -7,7 +7,7 @@ import { expect, test } from "@playwright/test";
 async function openIntegrations(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".settings-subnav").getByRole("button", { name: "Integrations", exact: true }).click();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Integrations", exact: true }).click();
 }
 
 test("lists configured delegates with type + secret badges", async ({ page }) => {

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -42,7 +42,7 @@ test("switches between two plugin views, each loading its own page", async ({ pa
 test("view-tabs switch the hosted page", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".rail").getByRole("button", { name: "Board", exact: true }).click();
-  const subnav = page.locator(".plugin-view .stage-subnav");
+  const subnav = page.locator(".stage-subnav");
   await expect(subnav.getByRole("button", { name: "Open", exact: true })).toBeVisible();
   await expect(page.locator(".plugin-view-frame")).toHaveAttribute("src", /tab=open/);
   await subnav.getByRole("button", { name: "Done", exact: true }).click();

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -12,14 +12,14 @@ async function openSettings(page) {
 }
 
 async function category(page, name) {
-  await page.locator(".settings-subnav").getByRole("button", { name, exact: true }).click();
+  await page.locator(".stage-subnav").getByRole("button", { name, exact: true }).click();
 }
 
 test("groups are organized into a category sub-nav; Agent leads", async ({ page }) => {
   await openSettings(page);
   // Category sub-nav from the mock schema: Agent · Behavior · System, plus
   // Integrations (surfaced because the delegates plugin is reachable — ADR 0025).
-  expect(await page.locator(".settings-subnav button").allTextContents()).toEqual([
+  expect(await page.locator(".stage-subnav button").allTextContents()).toEqual([
     "Agent",
     "Behavior",
     "System",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -73,6 +73,7 @@ import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
+import { StageSubnav } from "./StageSubnav";
 import { brandName } from "../lib/brand";
 import { onConnectionChange, onServerEvent } from "../lib/events";
 import type { NotesWorkspace } from "../lib/types";
@@ -665,41 +666,45 @@ export function App() {
             </div>
           ) : null}
 
-          {/* In-surface sub-nav for the grouped rail surfaces. */}
+          {/* Sub-nav for the grouped rail surfaces — the canonical strip above the
+              panel card (StageSubnav: single source of truth, shared with Settings +
+              plugin views). */}
           {surface === "activity" ? (
-            <div className="stage-subnav">
-              <button className={activityTab === "thread" ? "active" : ""} onClick={() => setActivityTab("thread")}>
-                <Activity size={15} /> Thread
-              </button>
-              <button className={activityTab === "inbox" ? "active" : ""} onClick={() => setActivityTab("inbox")}>
-                <Inbox size={15} /> Inbox
-                {inboxUnread ? <span className="subnav-badge" data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span> : null}
-              </button>
-              <button className={activityTab === "schedule" ? "active" : ""} onClick={() => setActivityTab("schedule")}>
-                <CalendarClock size={15} /> Schedule
-              </button>
-            </div>
+            <StageSubnav
+              active={activityTab}
+              onSelect={(id) => setActivityTab(id as typeof activityTab)}
+              tabs={[
+                { id: "thread", label: "Thread", icon: Activity },
+                {
+                  id: "inbox", label: "Inbox", icon: Inbox,
+                  badge: inboxUnread ? (
+                    <span className="subnav-badge" data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span>
+                  ) : null,
+                },
+                { id: "schedule", label: "Schedule", icon: CalendarClock },
+              ]}
+            />
           ) : null}
           {surface === "knowledge" ? (
-            // Store (factual memory) + Playbooks (procedural memory) — ADR 0020.
-            <div className="stage-subnav">
-              <button className={knowledgeTab === "store" ? "active" : ""} onClick={() => setKnowledgeTab("store")}>
-                <Database size={15} /> Store
-              </button>
-              <button className={knowledgeTab === "playbooks" ? "active" : ""} onClick={() => setKnowledgeTab("playbooks")}>
-                <BookMarked size={15} /> Skills
-              </button>
-            </div>
+            // Store (factual memory) + Skills (procedural memory) — ADR 0020.
+            <StageSubnav
+              active={knowledgeTab}
+              onSelect={(id) => setKnowledgeTab(id as typeof knowledgeTab)}
+              tabs={[
+                { id: "store", label: "Store", icon: Database },
+                { id: "playbooks", label: "Skills", icon: BookMarked },
+              ]}
+            />
           ) : null}
           {surface === "system" ? (
-            <div className="stage-subnav">
-              <button className={systemTab === "runtime" ? "active" : ""} onClick={() => setSystemTab("runtime")}>
-                <Gauge size={15} /> Runtime
-              </button>
-              <button className={systemTab === "telemetry" ? "active" : ""} onClick={() => setSystemTab("telemetry")}>
-                <BarChart3 size={15} /> Telemetry
-              </button>
-            </div>
+            <StageSubnav
+              active={systemTab}
+              onSelect={(id) => setSystemTab(id as typeof systemTab)}
+              tabs={[
+                { id: "runtime", label: "Runtime", icon: Gauge },
+                { id: "telemetry", label: "Telemetry", icon: BarChart3 },
+              ]}
+            />
           ) : null}
 
           {/* ChatSurface is rendered UNCONDITIONALLY and hidden via `active` when

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, Loader2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { apiUrl, authToken } from "../lib/api";
+import { StageSubnav } from "./StageSubnav";
 import type { PluginView as PluginViewType } from "../lib/types";
 
 // Curated console theme tokens forwarded to a plugin view so it can match the
@@ -55,16 +56,11 @@ export function PluginView({ view }: { view: PluginViewType }) {
   }
 
   return (
-    <section className="panel stage-panel plugin-view">
-      {tabs.length ? (
-        <div className="stage-subnav">
-          {tabs.map((t) => (
-            <button key={t.id} className={t.id === activeTab ? "active" : ""} onClick={() => setActiveTab(t.id)}>
-              {t.label}
-            </button>
-          ))}
-        </div>
-      ) : null}
+    <>
+      {/* Sub-tab strip above the panel card — shared StageSubnav (single source of truth). */}
+      <StageSubnav active={activeTab} onSelect={setActiveTab}
+                   tabs={tabs.map((t) => ({ id: t.id, label: t.label }))} />
+      <section className="panel stage-panel plugin-view">
       <div className="plugin-view-body">
         {failed ? (
           <div className="plugin-view-state" role="alert">
@@ -91,6 +87,7 @@ export function PluginView({ view }: { view: PluginViewType }) {
           </>
         )}
       </div>
-    </section>
+      </section>
+    </>
   );
 }

--- a/apps/web/src/app/StageSubnav.tsx
+++ b/apps/web/src/app/StageSubnav.tsx
@@ -1,0 +1,48 @@
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
+
+// The canonical sub-tab strip. Every surface with sub-tabs renders it through this
+// one component, ALWAYS above the panel card — so Settings, Knowledge, Activity,
+// System, and plugin views all share the same layout (single source of truth, ADR 0020).
+// Previously some surfaces rendered the strip inside the panel card (Settings/PluginView)
+// and some above it (App-level rail surfaces); this unifies them.
+
+export type StageTab = {
+  id: string;
+  label: string;
+  icon?: LucideIcon;
+  badge?: ReactNode;   // e.g. an unread count
+  testId?: string;
+};
+
+export function StageSubnav({
+  tabs,
+  active,
+  onSelect,
+}: {
+  tabs: StageTab[];
+  active: string;
+  onSelect: (id: string) => void;
+}) {
+  if (!tabs.length) return null;
+  return (
+    <div className="stage-subnav">
+      {tabs.map((t) => {
+        const Icon = t.icon;
+        return (
+          <button
+            key={t.id}
+            type="button"
+            className={t.id === active ? "active" : ""}
+            onClick={() => onSelect(t.id)}
+            data-testid={t.testId}
+          >
+            {Icon ? <Icon size={15} /> : null}
+            {t.label}
+            {t.badge}
+          </button>
+        );
+      })}
+    </div>
+  );
+}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -8,6 +8,7 @@ const DISCORD_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/disco
 const GOOGLE_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/google#oauth-client";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
+import { StageSubnav } from "../app/StageSubnav";
 import { api } from "../lib/api";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
 import type { SettingsField, SettingsGroup } from "../lib/types";
@@ -22,18 +23,32 @@ import { PluginsSection } from "./PluginsSection";
 // ErrorBoundary.
 
 export function SettingsSurface() {
+  // SettingsBody owns its own panel <section> (so the sub-tab strip can sit ABOVE
+  // the card, consistent with the rail surfaces). The loading/error fallbacks carry
+  // their own card so the layout doesn't jump.
   return (
-    <section className="panel stage-panel settings-panel">
-      <QueryErrorResetBoundary>
-        {({ reset }) => (
-          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="settings" />}>
-            <Suspense fallback={<PanelSkeleton label="Loading settings…" />}>
-              <SettingsBody />
-            </Suspense>
-          </ErrorBoundary>
-        )}
-      </QueryErrorResetBoundary>
-    </section>
+    <QueryErrorResetBoundary>
+      {({ reset }) => (
+        <ErrorBoundary
+          onReset={reset}
+          fallback={(a) => (
+            <section className="panel stage-panel settings-panel">
+              <PanelError {...a} label="settings" />
+            </section>
+          )}
+        >
+          <Suspense
+            fallback={
+              <section className="panel stage-panel settings-panel">
+                <PanelSkeleton label="Loading settings…" />
+              </section>
+            }
+          >
+            <SettingsBody />
+          </Suspense>
+        </ErrorBoundary>
+      )}
+    </QueryErrorResetBoundary>
   );
 }
 
@@ -171,17 +186,16 @@ function SettingsBody() {
 
   return (
     <>
-      {/* Sub-nav above the header, matching the other rail surfaces (System,
-          Knowledge, Activity) which render their stage-subnav above the panel. */}
+      {/* Canonical sub-tab strip — above the panel card, shared with the rail
+          surfaces + plugin views (StageSubnav: single source of truth). */}
       {categories.length > 1 ? (
-        <div className="stage-subnav settings-subnav">
-          {categories.map((c) => (
-            <button key={c} className={c === category ? "active" : ""} onClick={() => setActiveCategory(c)}>
-              {c}
-            </button>
-          ))}
-        </div>
+        <StageSubnav
+          active={category}
+          onSelect={setActiveCategory}
+          tabs={categories.map((c) => ({ id: c, label: c }))}
+        />
       ) : null}
+      <section className="panel stage-panel settings-panel">
       <div className="panel-header">
         <div>
           <h1>Settings</h1>
@@ -297,6 +311,7 @@ function SettingsBody() {
         {/* Git-installed plugins (ADR 0027) — install/manage from a URL, under Integrations. */}
         {category === "Integrations" ? <PluginsSection /> : null}
       </div>
+      </section>
     </>
   );
 }


### PR DESCRIPTION
**Audit finding:** the sub-tab strip was rendered two different ways — App rendered it **above** the panel card for the rail surfaces (Activity / Knowledge / System), but **Settings** and **plugin views** rendered their own strip **inside** the card, so their tabs read as part of the heading. That's the inconsistency you flagged.

**Single source of truth:** a new shared **`<StageSubnav>`** component, rendered **above the panel card** on every surface.

- App's 3 rail subnavs route through it (placement unchanged — already above).
- **Settings** + **PluginView** hoisted: their strip now sits above the `<section>` card (Settings owns its own card so its loading/error fallbacks keep one). Dropped the no-op `settings-subnav` class.

Pure layout consolidation — same buttons, same behavior, no role/markup change beyond placement.

## Test
e2e updated for the moved strip (`.settings-subnav`→`.stage-subnav`; plugin subnav no longer under `.plugin-view`). **Full suite 57/57 pass locally**; web build (tsc) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
