### PR TITLE
refactor(console): unify panel headers (one PanelHeader, one .panel-actions)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Unified panel headers** — every surface's header (title + kicker + actions) now renders
+  through one shared `PanelHeader` component, with a single `.panel-actions` wrapper.
+  Consolidated the duplicate `.settings-actions` / `.notes-actions` classes and standardized
+  refresh buttons to icon-only. Completes the panel-layout single-source-of-truth pass
+  (with `StageSubnav`).
 - **Unified panel sub-tabs** — every surface's sub-tab strip now renders through one
   shared `StageSubnav` component, always **above the panel card**. Previously Settings +
   plugin views rendered their tabs *inside* the card (so they read as part of the heading)

--- a/apps/web/src/activity/ActivitySurface.tsx
+++ b/apps/web/src/activity/ActivitySurface.tsx
@@ -3,6 +3,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { Markdown } from "../chat/LazyMarkdown";
 import { api } from "../lib/api";
+import { PanelHeader } from "../app/PanelHeader";
 import { onServerEvent } from "../lib/events";
 import type { ActivityEntry } from "../lib/types";
 
@@ -117,15 +118,15 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
 
   return (
     <section className="panel stage-panel" data-testid="activity-surface">
-      <div className="panel-header">
-        <div>
-          <h1>Activity</h1>
-          <p className="panel-kicker">what the agent did on its own — and why</p>
-        </div>
-        <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
-          {loading ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
-        </button>
-      </div>
+      <PanelHeader
+        title="Activity"
+        kicker="what the agent did on its own — and why"
+        actions={
+          <button className="icon-button" type="button" onClick={() => void load()} title="Refresh">
+            {loading ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
+          </button>
+        }
+      />
 
       <div className="stage-body activity-body">
         <div className="activity-feed" ref={scrollRef}>

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -74,6 +74,7 @@ import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
 import { StageSubnav } from "./StageSubnav";
+import { PanelHeader } from "./PanelHeader";
 import { brandName } from "../lib/brand";
 import { onConnectionChange, onServerEvent } from "../lib/events";
 import type { NotesWorkspace } from "../lib/types";
@@ -763,28 +764,27 @@ export function App() {
 
           {rightPanel === "notes" ? (
             <section className="panel side-panel notes-panel">
-              <div className="panel-header compact">
-                <div>
-                  <h2>{activeTab?.name || "Notes"}</h2>
-                  <p className="panel-kicker">
-                    {workspace ? `${workspace.tabOrder.length} tab${workspace.tabOrder.length === 1 ? "" : "s"}${notesDirty ? " • unsaved" : ""}` : "not loaded"}
-                  </p>
-                </div>
-                <div className="notes-actions">
-                  <button className="icon-button" type="button" onClick={createNote} disabled={!workspace} title="New note">
-                    <Plus size={16} />
-                  </button>
-                  <button className="icon-button" type="button" onClick={deleteActiveNote} disabled={!workspace || workspace.tabOrder.length <= 1} title="Delete note">
-                    <Trash2 size={16} />
-                  </button>
-                  <button className="icon-button" type="button" onClick={undoActiveNote} disabled={!canUndoNote} title="Undo last change">
-                    <Undo2 size={16} />
-                  </button>
-                  <button className="icon-button" type="button" onClick={() => void persistNotes()} disabled={!workspace || notesBusy} title="Save notes">
-                    {notesBusy ? <Loader2 className="spin" size={16} /> : <Save size={16} />}
-                  </button>
-                </div>
-              </div>
+              <PanelHeader
+                compact
+                title={activeTab?.name || "Notes"}
+                kicker={workspace ? `${workspace.tabOrder.length} tab${workspace.tabOrder.length === 1 ? "" : "s"}${notesDirty ? " • unsaved" : ""}` : "not loaded"}
+                actions={
+                  <>
+                    <button className="icon-button" type="button" onClick={createNote} disabled={!workspace} title="New note">
+                      <Plus size={16} />
+                    </button>
+                    <button className="icon-button" type="button" onClick={deleteActiveNote} disabled={!workspace || workspace.tabOrder.length <= 1} title="Delete note">
+                      <Trash2 size={16} />
+                    </button>
+                    <button className="icon-button" type="button" onClick={undoActiveNote} disabled={!canUndoNote} title="Undo last change">
+                      <Undo2 size={16} />
+                    </button>
+                    <button className="icon-button" type="button" onClick={() => void persistNotes()} disabled={!workspace || notesBusy} title="Save notes">
+                      {notesBusy ? <Loader2 className="spin" size={16} /> : <Save size={16} />}
+                    </button>
+                  </>
+                }
+              />
               {workspace ? (
                 <div className="notes-tabbar">
                   {workspace.tabOrder.map((tabId) => {

--- a/apps/web/src/app/BeadsPanel.tsx
+++ b/apps/web/src/app/BeadsPanel.tsx
@@ -17,6 +17,7 @@ import {
 import { Suspense, useState } from "react";
 
 import { api } from "../lib/api";
+import { PanelHeader } from "./PanelHeader";
 import { beadsIssuesQuery, queryKeys } from "../lib/queries";
 import type { BeadsIssue } from "../lib/types";
 import {
@@ -254,12 +255,7 @@ function BeadsBody({ confirm }: { confirm: (req: ConfirmRequest) => void }) {
 export function BeadsPanel({ confirm }: { confirm: (req: ConfirmRequest) => void }) {
   return (
     <section className="panel side-panel beads-panel">
-      <div className="panel-header compact">
-        <div>
-          <h2>Beads</h2>
-          <p className="panel-kicker">the agent's task board</p>
-        </div>
-      </div>
+      <PanelHeader compact title="Beads" kicker="the agent's task board" />
       <QueryErrorResetBoundary>
         {({ reset }) => (
           <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="beads" />}>

--- a/apps/web/src/app/GoalsPanel.tsx
+++ b/apps/web/src/app/GoalsPanel.tsx
@@ -8,6 +8,7 @@ import { Trash2 } from "lucide-react";
 import { Suspense } from "react";
 
 import { api } from "../lib/api";
+import { PanelHeader } from "./PanelHeader";
 import { goalsQuery, queryKeys } from "../lib/queries";
 import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
 import { ScrollArea } from "./ScrollArea";
@@ -79,14 +80,11 @@ function GoalsList() {
 export function GoalsPanel() {
   return (
     <section className="panel side-panel goals-panel">
-      <div className="panel-header compact">
-        <div>
-          <h2>Goals</h2>
-          <p className="panel-kicker">
-            the agent's standing goals · set with <code>/goal</code> in chat
-          </p>
-        </div>
-      </div>
+      <PanelHeader
+        compact
+        title="Goals"
+        kicker={<>the agent's standing goals · set with <code>/goal</code> in chat</>}
+      />
       <ScrollArea className="goals-list" ariaLabel="Goals">
         <QueryErrorResetBoundary>
           {({ reset }) => (

--- a/apps/web/src/app/PanelHeader.tsx
+++ b/apps/web/src/app/PanelHeader.tsx
@@ -1,0 +1,29 @@
+import type { ReactNode } from "react";
+
+// The canonical panel header — title + optional kicker on the left, optional actions
+// on the right. Every surface renders its header through this one component so titles,
+// kickers, and action-button placement are identical across panels (single source of
+// truth). `compact` is for nested/secondary panels (Inbox, Goals, Beads, Notes): a
+// smaller h2 + tighter padding (the .compact modifier).
+
+export function PanelHeader({
+  title,
+  kicker,
+  actions,
+  compact = false,
+}: {
+  title: ReactNode;
+  kicker?: ReactNode;
+  actions?: ReactNode;
+  compact?: boolean;
+}) {
+  return (
+    <div className={compact ? "panel-header compact" : "panel-header"}>
+      <div>
+        {compact ? <h2>{title}</h2> : <h1>{title}</h1>}
+        {kicker != null && kicker !== "" ? <p className="panel-kicker">{kicker}</p> : null}
+      </div>
+      {actions != null ? <div className="panel-actions">{actions}</div> : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/RuntimePanel.tsx
+++ b/apps/web/src/app/RuntimePanel.tsx
@@ -3,6 +3,7 @@ import { Bot, Database, Settings2, Sparkles } from "lucide-react";
 import { Suspense, type ReactNode } from "react";
 
 import { brandName } from "../lib/brand";
+import { PanelHeader } from "./PanelHeader";
 import { runtimeStatusQuery, subagentsQuery } from "../lib/queries";
 import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
 import { StatusPill } from "./StatusPill";
@@ -33,13 +34,11 @@ function RuntimeBody() {
 
   return (
     <>
-      <div className="panel-header">
-        <div>
-          <h1>Runtime</h1>
-          <p className="panel-kicker">{runtime.model?.name || "model not configured"}</p>
-        </div>
-        <StatusPill label={runtime.scheduler.backend || "scheduler"} tone="muted" />
-      </div>
+      <PanelHeader
+        title="Runtime"
+        kicker={runtime.model?.name || "model not configured"}
+        actions={<StatusPill label={runtime.scheduler.backend || "scheduler"} tone="muted" />}
+      />
       <div className="stage-body">
         <div className="metric-grid">
           <Metric icon={<Bot size={16} />} label="Agent" value={brandName(runtime.identity?.name)} />

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1505,8 +1505,9 @@ textarea {
 
 .panel-actions {
   display: flex;
+  align-items: center;
   justify-content: flex-end;
-  padding: 12px;
+  gap: 8px;
 }
 
 .output-block {
@@ -2060,11 +2061,6 @@ textarea {
   padding: 12px;
 }
 
-.notes-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
 
 .notes-tabbar {
   display: flex;
@@ -2839,11 +2835,6 @@ textarea {
 }
 
 /* ── Settings surface ─────────────────────────────────────────────────────── */
-.settings-actions {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
 .settings-banner {
   display: flex;
   align-items: center;

--- a/apps/web/src/inbox/InboxPanel.tsx
+++ b/apps/web/src/inbox/InboxPanel.tsx
@@ -8,6 +8,7 @@ import { Check, RefreshCw } from "lucide-react";
 import { Suspense, useEffect, useState } from "react";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
+import { PanelHeader } from "../app/PanelHeader";
 import { api } from "../lib/api";
 import { onServerEvent } from "../lib/events";
 import { inboxQuery, queryKeys } from "../lib/queries";
@@ -50,15 +51,16 @@ function InboxBody({
 
   return (
     <>
-      <div className="panel-header compact">
-        <div>
-          <h2>Inbox</h2>
-          <p className="panel-kicker">{items.length} pending</p>
-        </div>
-        <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
-          <RefreshCw size={16} className={isFetching ? "spin" : ""} />
-        </button>
-      </div>
+      <PanelHeader
+        compact
+        title="Inbox"
+        kicker={`${items.length} pending`}
+        actions={
+          <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
+            <RefreshCw size={16} className={isFetching ? "spin" : ""} />
+          </button>
+        }
+      />
 
       <div className="inbox-list">
         {items.length === 0 ? (

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -2,6 +2,7 @@ import { Brain, Database, RefreshCw } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { api } from "../lib/api";
+import { PanelHeader } from "../app/PanelHeader";
 import type { KnowledgeChunk } from "../lib/types";
 
 // Knowledge → Store (ADR 0020) — a searchable window onto the agent's knowledge
@@ -53,17 +54,15 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
 
   return (
     <section className="panel stage-panel" data-testid="knowledge-store">
-      <div className="panel-header">
-        <div>
-          <h1>Knowledge</h1>
-          <p className="panel-kicker">
-            searchable knowledge base{total ? ` · ${total} entr${total === 1 ? "y" : "ies"}` : ""}
-          </p>
-        </div>
-        <button className="secondary-button" type="button" onClick={() => void run(query)} disabled={loading} title="Refresh">
-          <RefreshCw size={15} className={loading ? "spin" : ""} /> Refresh
-        </button>
-      </div>
+      <PanelHeader
+        title="Knowledge"
+        kicker={`searchable knowledge base${total ? ` · ${total} entr${total === 1 ? "y" : "ies"}` : ""}`}
+        actions={
+          <button className="icon-button" type="button" onClick={() => void run(query)} disabled={loading} title="Refresh">
+            <RefreshCw size={16} className={loading ? "spin" : ""} />
+          </button>
+        }
+      />
 
       <div className="stage-body">
         <input

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -2,6 +2,7 @@ import { BookMarked, Pin, RefreshCw, Sparkles, Trash2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { ConfirmDialog } from "../app/ConfirmDialog";
+import { PanelHeader } from "../app/PanelHeader";
 import { api } from "../lib/api";
 import type { Playbook } from "../lib/types";
 
@@ -78,17 +79,15 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
 
   return (
     <section className="panel stage-panel" data-testid="playbooks-surface">
-      <div className="panel-header">
-        <div>
-          <h1>Skills</h1>
-          <p className="panel-kicker">
-            methodology the agent retrieves into context · {pinned} pinned · {learned} learned
-          </p>
-        </div>
-        <button className="secondary-button" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
-          <RefreshCw size={15} className={loading ? "spin" : ""} /> Refresh
-        </button>
-      </div>
+      <PanelHeader
+        title="Skills"
+        kicker={`methodology the agent retrieves into context · ${pinned} pinned · ${learned} learned`}
+        actions={
+          <button className="icon-button" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
+            <RefreshCw size={16} className={loading ? "spin" : ""} />
+          </button>
+        }
+      />
 
       <div className="stage-body">
         <input

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -8,6 +8,7 @@ import { CalendarClock, Plus, RefreshCw, Trash2, X } from "lucide-react";
 import { Suspense, useEffect, useMemo, useState } from "react";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
+import { PanelHeader } from "../app/PanelHeader";
 import { api } from "../lib/api";
 import { queryKeys, schedulesQuery } from "../lib/queries";
 import {
@@ -172,21 +173,21 @@ function ScheduleBody() {
 
   return (
     <>
-      <div className="panel-header">
-        <div>
-          <h1>Schedule</h1>
-          <p className="panel-kicker">{jobs.length} job{jobs.length === 1 ? "" : "s"} · {backend}</p>
-        </div>
-        <div className="settings-actions">
-          <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
-            <RefreshCw size={16} className={isFetching ? "spin" : ""} />
-          </button>
-          <button className="primary-button" type="button" onClick={() => setModalOpen(true)}
-                  disabled={backend === "disabled"} data-testid="schedule-new">
-            <Plus size={16} /> New schedule
-          </button>
-        </div>
-      </div>
+      <PanelHeader
+        title="Schedule"
+        kicker={`${jobs.length} job${jobs.length === 1 ? "" : "s"} · ${backend}`}
+        actions={
+          <>
+            <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
+              <RefreshCw size={16} className={isFetching ? "spin" : ""} />
+            </button>
+            <button className="primary-button" type="button" onClick={() => setModalOpen(true)}
+                    disabled={backend === "disabled"} data-testid="schedule-new">
+              <Plus size={16} /> New schedule
+            </button>
+          </>
+        }
+      />
 
       <div className="stage-body">
         {add.isError ? <p className="settings-status">Couldn't schedule: {add.error instanceof Error ? add.error.message : String(add.error)}</p> : null}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -9,6 +9,7 @@ const GOOGLE_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/google
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { StageSubnav } from "../app/StageSubnav";
+import { PanelHeader } from "../app/PanelHeader";
 import { api } from "../lib/api";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
 import type { SettingsField, SettingsGroup } from "../lib/types";
@@ -196,28 +197,26 @@ function SettingsBody() {
         />
       ) : null}
       <section className="panel stage-panel settings-panel">
-      <div className="panel-header">
-        <div>
-          <h1>Settings</h1>
-          <p className="panel-kicker">
-            {dirtyKeys.length ? `${dirtyKeys.length} unsaved change${dirtyKeys.length === 1 ? "" : "s"}` : "applies on save"}
-          </p>
-        </div>
-        <div className="settings-actions">
-          <button className="secondary-button" type="button" onClick={() => testConn.mutate()} disabled={testConn.isPending || save.isPending}>
-            {testConn.isPending ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
-            Test connection
-          </button>
-          <button className="secondary-button" type="button" onClick={discard} disabled={save.isPending || !dirtyKeys.length}>
-            <RotateCcw size={15} />
-            Discard
-          </button>
-          <button className="primary-button" type="button" onClick={() => save.mutate()} disabled={save.isPending || !dirtyKeys.length}>
-            <Save size={16} />
-            Save &amp; apply
-          </button>
-        </div>
-      </div>
+      <PanelHeader
+        title="Settings"
+        kicker={dirtyKeys.length ? `${dirtyKeys.length} unsaved change${dirtyKeys.length === 1 ? "" : "s"}` : "applies on save"}
+        actions={
+          <>
+            <button className="secondary-button" type="button" onClick={() => testConn.mutate()} disabled={testConn.isPending || save.isPending}>
+              {testConn.isPending ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
+              Test connection
+            </button>
+            <button className="secondary-button" type="button" onClick={discard} disabled={save.isPending || !dirtyKeys.length}>
+              <RotateCcw size={15} />
+              Discard
+            </button>
+            <button className="primary-button" type="button" onClick={() => save.mutate()} disabled={save.isPending || !dirtyKeys.length}>
+              <Save size={16} />
+              Save &amp; apply
+            </button>
+          </>
+        }
+      />
       <div className="stage-body">
         {pendingRestart.length ? (
           <div className="settings-banner" role="alert">

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -14,6 +14,7 @@ import {
 import { Suspense } from "react";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
+import { PanelHeader } from "../app/PanelHeader";
 import { telemetryQuery } from "../lib/queries";
 
 // Telemetry dashboard (ADR 0006 Slice 3) — reads /api/telemetry/* (the local
@@ -48,15 +49,15 @@ function TelemetryBody() {
 
   return (
     <>
-      <div className="panel-header">
-        <div>
-          <h1>Telemetry</h1>
-          <p className="panel-kicker">per-turn cost &amp; latency · {summary?.turns ?? 0} turns recorded</p>
-        </div>
-        <button className="secondary-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
-          <RefreshCw size={15} className={isFetching ? "spin" : ""} /> Refresh
-        </button>
-      </div>
+      <PanelHeader
+        title="Telemetry"
+        kicker={`per-turn cost & latency · ${summary?.turns ?? 0} turns recorded`}
+        actions={
+          <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
+            <RefreshCw size={16} className={isFetching ? "spin" : ""} />
+          </button>
+        }
+      />
 
       <div className="stage-body">
         {!enabled ? (

--- a/apps/web/src/workflows/WorkflowBuilder.tsx
+++ b/apps/web/src/workflows/WorkflowBuilder.tsx
@@ -2,6 +2,7 @@ import { Loader2, Plus, Save, Trash2, X } from "lucide-react";
 import { useState } from "react";
 
 import { api } from "../lib/api";
+import { PanelHeader } from "../app/PanelHeader";
 
 // Author a workflow recipe from the console (Sprint C): name + inputs + steps
 // (id, subagent, prompt, depends_on) + output → POST /api/workflows, which
@@ -81,12 +82,15 @@ export function WorkflowBuilder({
 
   return (
     <div className="workflow-builder">
-      <div className="panel-header compact">
-        <h2>New workflow</h2>
-        <button className="icon-button" type="button" onClick={onCancel} title="Cancel">
-          <X size={16} />
-        </button>
-      </div>
+      <PanelHeader
+        compact
+        title="New workflow"
+        actions={
+          <button className="icon-button" type="button" onClick={onCancel} title="Cancel">
+            <X size={16} />
+          </button>
+        }
+      />
 
       <label className="field">
         <span>Name *</span>

--- a/apps/web/src/workflows/WorkflowsSurface.tsx
+++ b/apps/web/src/workflows/WorkflowsSurface.tsx
@@ -8,6 +8,7 @@ import { Loader2, Play, Plus, RefreshCw, Trash2, Workflow } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
+import { PanelHeader } from "../app/PanelHeader";
 import { api } from "../lib/api";
 import { queryKeys, subagentsQuery, workflowsQuery } from "../lib/queries";
 import type { WorkflowRunResult } from "../lib/types";
@@ -78,22 +79,20 @@ function WorkflowsBody() {
 
   return (
     <>
-      <div className="panel-header">
-        <div>
-          <h1>Workflows</h1>
-          <p className="panel-kicker">
-            step-by-step recipes the engine runs over subagents · {workflows.length} recipe{workflows.length === 1 ? "" : "s"}
-          </p>
-        </div>
-        <div className="panel-actions">
-          <button className="icon-button" type="button" onClick={() => setBuilding((b) => !b)} title="New workflow">
-            <Plus size={16} />
-          </button>
-          <button className="icon-button" type="button" onClick={() => void invalidateWorkflows()} title="Refresh">
-            <RefreshCw size={16} />
-          </button>
-        </div>
-      </div>
+      <PanelHeader
+        title="Workflows"
+        kicker={`step-by-step recipes the engine runs over subagents · ${workflows.length} recipe${workflows.length === 1 ? "" : "s"}`}
+        actions={
+          <>
+            <button className="icon-button" type="button" onClick={() => setBuilding((b) => !b)} title="New workflow">
+              <Plus size={16} />
+            </button>
+            <button className="icon-button" type="button" onClick={() => void invalidateWorkflows()} title="Refresh">
+              <RefreshCw size={16} />
+            </button>
+          </>
+        }
+      />
 
       <div className="stage-body">
         {building ? (


### PR DESCRIPTION
Completes the panel-layout single-source-of-truth pass (after `StageSubnav`). Every surface's header now renders through a shared **`<PanelHeader title kicker actions compact>`** — title + kicker left, actions right — so headers are identical across panels.

- New `app/PanelHeader.tsx`; migrated **13 surfaces** (Settings, Schedule, Notes, Skills, Activity, Inbox, Runtime, Goals, Beads, Workflows, Telemetry, Knowledge, WorkflowBuilder).
- Consolidated the duplicate `.settings-actions` / `.notes-actions` into the canonical **`.panel-actions`** (flex + align-center + gap); removed the dead classes.
- Standardized refresh buttons to **icon-only** (Skills / Telemetry / Knowledge were text buttons).

Pure layout consolidation, no behavior change. Web build (tsc) + **full e2e 57/57** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)