### PR TITLE
feat(telemetry): CSV export + disk visibility + retention guardrail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Telemetry: export + disk visibility + retention guardrail** —
+  `GET /api/telemetry/export` + an **Export CSV** button download every recorded turn;
+  the **Runtime** panel now shows on-disk DB sizes (knowledge / telemetry / checkpoint /
+  skills); and `telemetry.retention_days` (default **90**) wires the maintenance loop to
+  prune turns older than the window so the per-turn store can't grow unbounded (0 = keep
+  forever).
+
 ### Changed
 - **Unified panel headers** — every surface's header (title + kicker + actions) now renders
   through one shared `PanelHeader` component, with a single `.panel-actions` wrapper.

--- a/apps/web/src/app/RuntimePanel.tsx
+++ b/apps/web/src/app/RuntimePanel.tsx
@@ -1,5 +1,5 @@
 import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
-import { Bot, Database, Settings2, Sparkles } from "lucide-react";
+import { Bot, Database, HardDrive, Settings2, Sparkles } from "lucide-react";
 import { Suspense, type ReactNode } from "react";
 
 import { brandName } from "../lib/brand";
@@ -14,6 +14,19 @@ import { StatusPill } from "./StatusPill";
 
 function formatBool(value: boolean) {
   return value ? "on" : "off";
+}
+
+function fmtBytes(n: number | null | undefined): string {
+  if (n == null) return "—";
+  if (n < 1024) return `${n} B`;
+  const units = ["KB", "MB", "GB"];
+  let v = n / 1024;
+  let i = 0;
+  while (v >= 1024 && i < units.length - 1) {
+    v /= 1024;
+    i += 1;
+  }
+  return `${v.toFixed(v < 10 ? 1 : 0)} ${units[i]}`;
 }
 
 function Metric({ icon, label, value }: { icon: ReactNode; label: string; value: string }) {
@@ -46,6 +59,19 @@ function RuntimeBody() {
           <Metric icon={<Database size={16} />} label="Knowledge" value={runtime.knowledge.resolved_path || runtime.knowledge.configured_path || "disabled"} />
           <Metric icon={<Sparkles size={16} />} label="Goal mode" value={formatBool(Boolean(runtime.goal.enabled))} />
         </div>
+        {runtime.storage ? (
+          <>
+            <p className="panel-kicker">
+              Storage{runtime.storage.telemetry_retention_days ? ` · telemetry kept ${runtime.storage.telemetry_retention_days}d` : ""}
+            </p>
+            <div className="metric-grid">
+              <Metric icon={<HardDrive size={16} />} label="Knowledge DB" value={fmtBytes(runtime.storage.knowledge_bytes)} />
+              <Metric icon={<HardDrive size={16} />} label="Telemetry DB" value={fmtBytes(runtime.storage.telemetry_bytes)} />
+              <Metric icon={<HardDrive size={16} />} label="Checkpoints DB" value={fmtBytes(runtime.storage.checkpoint_bytes)} />
+              <Metric icon={<HardDrive size={16} />} label="Skills DB" value={fmtBytes(runtime.storage.skills_bytes)} />
+            </div>
+          </>
+        ) : null}
         <p className="panel-kicker">Middleware</p>
         <div className="table-list">
           {middleware.map(([name, enabled]) => (

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -405,6 +405,15 @@ export const api = {
   },
 
   // Real completion probe — the true auth check (unlike `models`, which only
+  // Download all telemetry as CSV (carries the bearer; returns a Blob to save).
+  async exportTelemetry(): Promise<Blob> {
+    const res = await fetch(apiUrl("/api/telemetry/export"), {
+      headers: applyAuth(new Headers()),
+    });
+    if (!res.ok) throw new Error(`export failed: ${res.status}`);
+    return res.blob();
+  },
+
   // lists). Blank fields fall back to the saved config (Settings re-test).
   testModel(apiBase: string, apiKey: string, model: string) {
     return request<{ ok: boolean; error: string }>("/api/config/test-model", {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -39,6 +39,13 @@ export type RuntimeStatus = {
     loaded: boolean;
     interval_seconds?: number | null;
   };
+  storage?: {
+    knowledge_bytes?: number | null;
+    telemetry_bytes?: number | null;
+    checkpoint_bytes?: number | null;
+    skills_bytes?: number | null;
+    telemetry_retention_days?: number | null;
+  };
   skills?: {
     enabled: boolean;
     count: number;

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -6,6 +6,7 @@ import {
   Clock,
   Coins,
   Database,
+  Download,
   Hash,
   Layers,
   RefreshCw,
@@ -15,6 +16,7 @@ import { Suspense } from "react";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { PanelHeader } from "../app/PanelHeader";
+import { api } from "../lib/api";
 import { telemetryQuery } from "../lib/queries";
 
 // Telemetry dashboard (ADR 0006 Slice 3) — reads /api/telemetry/* (the local
@@ -43,6 +45,16 @@ function pct(n: number): string {
   return `${Math.round((n || 0) * 100)}%`;
 }
 
+async function downloadTelemetryCsv() {
+  const blob = await api.exportTelemetry();
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = "telemetry.csv";
+  a.click();
+  URL.revokeObjectURL(url);
+}
+
 function TelemetryBody() {
   const { data, isFetching, refetch } = useSuspenseQuery(telemetryQuery());
   const { enabled, summary, turns, insights } = data;
@@ -53,9 +65,15 @@ function TelemetryBody() {
         title="Telemetry"
         kicker={`per-turn cost & latency · ${summary?.turns ?? 0} turns recorded`}
         actions={
-          <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
-            <RefreshCw size={16} className={isFetching ? "spin" : ""} />
-          </button>
+          <>
+            <button className="icon-button" type="button" onClick={() => void downloadTelemetryCsv()}
+                    disabled={!enabled || !summary?.turns} title="Export CSV" data-testid="telemetry-export">
+              <Download size={16} />
+            </button>
+            <button className="icon-button" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
+              <RefreshCw size={16} className={isFetching ? "spin" : ""} />
+            </button>
+          </>
         }
       />
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -283,6 +283,9 @@ class LangGraphConfig:
     # and is instance-scoped (ADR 0004).
     telemetry_enabled: bool = True
     telemetry_db_path: str = "/sandbox/telemetry.db"
+    # Retention guardrail (ADR 0006) — turns older than this are pruned by the
+    # periodic maintenance loop so the store can't grow unbounded. 0 = keep forever.
+    telemetry_retention_days: int = 90
     # Checkpoint pruning — keeps the SQLite DB from growing unbounded. Keep the
     # latest N checkpoints per session, and TTL whole sessions idle past
     # max_age_days. Runs every prune_interval_hours (0 disables the sweep).
@@ -548,6 +551,7 @@ class LangGraphConfig:
             checkpoint_db_path=data.get("checkpoint", {}).get("db_path", cls.checkpoint_db_path),
             telemetry_enabled=data.get("telemetry", {}).get("enabled", cls.telemetry_enabled),
             telemetry_db_path=data.get("telemetry", {}).get("db_path", cls.telemetry_db_path),
+            telemetry_retention_days=data.get("telemetry", {}).get("retention_days", cls.telemetry_retention_days),
             checkpoint_keep_per_thread=data.get("checkpoint", {}).get("keep_per_thread", cls.checkpoint_keep_per_thread),
             checkpoint_max_age_days=data.get("checkpoint", {}).get("max_age_days", cls.checkpoint_max_age_days),
             checkpoint_prune_interval_hours=data.get("checkpoint", {}).get("prune_interval_hours", cls.checkpoint_prune_interval_hours),

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -62,6 +62,8 @@ def _operator_runtime_status():
             "tool_count": len(STATE.mcp_tools),
         },
         plugins=STATE.plugin_meta,
+        telemetry_store=STATE.telemetry_store,
+        checkpoint_path=STATE.checkpoint_path,
     )
 
 

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -19,6 +19,8 @@ def build_runtime_status(
     skills_index: Any = None,
     mcp: dict[str, Any] | None = None,
     plugins: list[dict[str, Any]] | None = None,
+    telemetry_store: Any = None,
+    checkpoint_path: str = "",
 ) -> dict[str, Any]:
     """Return UI-safe runtime status.
 
@@ -114,4 +116,23 @@ def build_runtime_status(
             "loaded": cache_warmer is not None,
             "interval_seconds": getattr(config, "cache_warming_interval_seconds", None),
         },
+        # On-disk store sizes (bytes) so growth is visible from the console.
+        "storage": {
+            "knowledge_bytes": _file_size(getattr(knowledge_store, "path", None)),
+            "telemetry_bytes": _file_size(getattr(telemetry_store, "path", None)),
+            "checkpoint_bytes": _file_size(checkpoint_path),
+            "skills_bytes": _file_size(getattr(skills_index, "path", None)),
+            "telemetry_retention_days": getattr(config, "telemetry_retention_days", None),
+        },
     }
+
+
+def _file_size(path: Any) -> int | None:
+    """File size in bytes, or None if the path is unset/missing (best-effort)."""
+    if not path:
+        return None
+    try:
+        import os
+        return os.path.getsize(str(path))
+    except OSError:
+        return None

--- a/operator_api/telemetry_routes.py
+++ b/operator_api/telemetry_routes.py
@@ -30,6 +30,31 @@ def register_telemetry_routes(app) -> None:
             return {"enabled": False, "turns": []}
         return {"enabled": True, "turns": STATE.telemetry_store.recent(limit=min(max(1, limit), 500))}
 
+    @app.get("/api/telemetry/export")
+    async def _api_telemetry_export(since: str | None = None):
+        """Download every recorded turn as CSV (optionally those ended at/after
+        ``since``). Read-only; empty CSV when the store is off."""
+        import csv
+        import io
+
+        from fastapi.responses import PlainTextResponse
+
+        from telemetry_store import _COLUMNS
+
+        rows = STATE.telemetry_store.recent(limit=10_000_000) if STATE.telemetry_store else []
+        if since:
+            rows = [r for r in rows if (r.get("ended_at") or "") >= since]
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=list(_COLUMNS), extrasaction="ignore")
+        writer.writeheader()
+        for r in rows:
+            writer.writerow(r)
+        return PlainTextResponse(
+            buf.getvalue(),
+            media_type="text/csv",
+            headers={"Content-Disposition": 'attachment; filename="telemetry.csv"'},
+        )
+
     @app.get("/api/telemetry/insights")
     async def _api_telemetry_insights():
         # Advise-only flywheel signal (ADR 0006 Slice 4): flag outlier turns +

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -499,11 +499,12 @@ def _main():
                 await STATE.cache_warmer.start()
             except Exception:
                 log.exception("[cache-warmer] startup failed")
-        # Checkpoint pruner — periodic sweep to keep the SQLite history DB bounded.
-        if (
-            STATE.checkpoint_path
-            and STATE.graph_config is not None
-            and STATE.graph_config.checkpoint_prune_interval_hours > 0
+        # Periodic maintenance — checkpoint pruning and/or telemetry retention.
+        # Starts if either is enabled (the loop guards each step independently).
+        _cfg = STATE.graph_config
+        if _cfg is not None and (
+            (STATE.checkpoint_path and _cfg.checkpoint_prune_interval_hours > 0)
+            or getattr(_cfg, "telemetry_retention_days", 0) > 0
         ):
             import asyncio
             STATE.checkpoint_prune_task = asyncio.create_task(_checkpoint_prune_loop())

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -519,7 +519,19 @@ async def _checkpoint_prune_loop() -> None:
                     )
             except Exception:
                 log.exception("[checkpoint-prune] sweep failed")
-        await asyncio.sleep(max(1, interval_h) * 3600)
+        # Telemetry retention guardrail (ADR 0006) — drop turns older than the
+        # configured window so the per-turn store can't grow unbounded. 0 = keep all.
+        keep_days = getattr(cfg, "telemetry_retention_days", 0) if cfg else 0
+        if STATE.telemetry_store is not None and keep_days > 0:
+            try:
+                removed = await asyncio.to_thread(STATE.telemetry_store.prune, keep_days)
+                if removed:
+                    log.info("[telemetry-prune] removed %d turn(s) older than %dd", removed, keep_days)
+            except Exception:
+                log.exception("[telemetry-prune] sweep failed")
+        # Tick at the checkpoint interval if set, else hourly (so telemetry pruning
+        # still runs when checkpoint pruning is off).
+        await asyncio.sleep(max(1, interval_h or 1) * 3600)
 
 
 async def _monitor_goals_loop() -> None:

--- a/tests/test_telemetry_routes.py
+++ b/tests/test_telemetry_routes.py
@@ -51,3 +51,42 @@ def test_recent_limit_is_clamped(monkeypatch):
     assert seen["limit"] == 500  # clamped to the 500 ceiling
     c.get("/api/telemetry/recent?limit=0")
     assert seen["limit"] == 1  # clamped to the floor
+
+
+def test_export_returns_csv(monkeypatch):
+    class _Store:
+        def recent(self, limit=50):
+            return [
+                {"task_id": "t1", "session_id": "s", "model": "m", "cost_usd": 0.01,
+                 "ended_at": "2026-06-07T10:00:00+00:00"},
+                {"task_id": "t2", "session_id": "s", "model": "m", "cost_usd": 0.02,
+                 "ended_at": "2026-06-08T10:00:00+00:00"},
+            ]
+
+    c = _client(monkeypatch, _Store())
+    res = c.get("/api/telemetry/export")
+    assert res.status_code == 200
+    assert "text/csv" in res.headers["content-type"]
+    assert "attachment; filename=" in res.headers.get("content-disposition", "")
+    body = res.text
+    assert body.splitlines()[0].startswith("task_id,")  # header from _COLUMNS
+    assert "t1" in body and "t2" in body
+
+
+def test_export_since_filter(monkeypatch):
+    class _Store:
+        def recent(self, limit=50):
+            return [
+                {"task_id": "old", "ended_at": "2026-06-01T00:00:00+00:00"},
+                {"task_id": "new", "ended_at": "2026-06-09T00:00:00+00:00"},
+            ]
+
+    c = _client(monkeypatch, _Store())
+    body = c.get("/api/telemetry/export?since=2026-06-05T00:00:00+00:00").text
+    assert "new" in body and "old" not in body
+
+
+def test_export_empty_when_store_off(monkeypatch):
+    c = _client(monkeypatch, None)
+    res = c.get("/api/telemetry/export")
+    assert res.status_code == 200 and res.text.splitlines()[0].startswith("task_id,")

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -276,3 +276,8 @@ def test_config_telemetry_default_on():
     from graph.config import LangGraphConfig
 
     assert LangGraphConfig().telemetry_enabled is True
+
+
+def test_retention_config_default_is_bounded():
+    from graph.config import LangGraphConfig
+    assert LangGraphConfig().telemetry_retention_days == 90  # guardrail on by default


### PR DESCRIPTION
Closes the three telemetry gaps: no export, unbounded growth, no disk visibility.

- **Export** — `GET /api/telemetry/export` streams all turns as CSV (since-filterable); an **Export** button on the Telemetry surface downloads it (auth-carrying blob fetch).
- **Retention guardrail** — `telemetry.retention_days` (default **90**) + the periodic maintenance loop now prunes turns older than the window. `prune()` existed but was never scheduled; this wires it (and the loop now starts for telemetry retention even when checkpoint pruning is off). `0` = keep forever.
- **Disk visibility** — `/api/runtime/status` carries a `storage` block (knowledge / telemetry / checkpoint / skills DB sizes + retention days); the **Runtime** panel shows them.

(The summary already computed p50/p95 latency, cache-ratio, tokens, and the by-model split — the UI surfaces all of it, so "more data" was largely already there.)

## Test
`pytest tests/test_telemetry_routes.py tests/test_telemetry_store.py` (export CSV header / since-filter / store-off / retention default); **suite 1220**; web build (tsc) + **full e2e 57/57** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
