### PR TITLE
feat(subagents): per-subagent model override in config (ADR 0001)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Per-subagent model override in config** (ADR 0001) — `subagents.<name>.model` pins a
+  subagent to a specific model (blank = `routing.aux_model` → main model), so an operator
+  can put a heavy-reasoning subagent on the main model while the rest route to a cheaper
+  alias — no code. Applied to the runtime registry at build + reload (the resolution path
+  in `_run_subagent` already existed); surfaced in the runtime status.
 - **Telemetry: export + disk visibility + retention guardrail** —
   `GET /api/telemetry/export` + an **Export CSV** button download every recorded turn;
   the **Runtime** panel now shows on-disk DB sizes (knowledge / telemetry / checkpoint /

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -40,6 +40,10 @@ subagents:
       - memory_recall
       - memory_list
     max_turns: 40
+    # Per-subagent model override (blank = routing.aux_model, then the main model).
+    # Pin a heavy-reasoning subagent to the main model even when aux_model routes
+    # the rest to a cheaper alias, e.g.:  model: protolabs/reasoning
+    model: ""
 
 middleware:
   # All four subsystems default ON. The template constructs the

--- a/graph/config.py
+++ b/graph/config.py
@@ -74,6 +74,9 @@ class SubagentDef:
     enabled: bool = True
     tools: list[str] = field(default_factory=list)
     max_turns: int = 30
+    # Per-subagent model override (ADR 0001) — blank = routing.aux_model → main model.
+    # Applied onto the registry's SubagentConfig at build (see _apply_config_subagents).
+    model: str = ""
 
 
 @dataclass
@@ -601,6 +604,7 @@ class LangGraphConfig:
                     enabled=sub.get("enabled", True),
                     tools=sub.get("tools", getattr(config, name).tools),
                     max_turns=sub.get("max_turns", getattr(config, name).max_turns),
+                    model=sub.get("model", getattr(config, name).model),
                 ))
 
         return config

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -218,6 +218,7 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
                 "enabled": config.researcher.enabled,
                 "tools": list(config.researcher.tools),
                 "max_turns": config.researcher.max_turns,
+                "model": config.researcher.model,
             },
         },
         "middleware": {

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -165,6 +165,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # (`global STATE.plugin_routers, STATE.plugin_surfaces` is declared at the top of the fn.)
     STATE.plugin_routers, STATE.plugin_surfaces = _plugins.routers, _plugins.surfaces
     _register_plugin_subagents(_plugins.subagents)
+    _apply_config_subagents(STATE.graph_config)  # YAML subagent overrides (tools/max_turns/model)
 
     # MCP — external Model Context Protocol servers; their tools become agent
     # tools (namespaced <server>__<tool>). Off unless mcp.enabled OR a plugin
@@ -395,6 +396,40 @@ def _register_plugin_subagents(subagents) -> None:
         SUBAGENT_REGISTRY[name] = cfg
         _plugin_subagent_names.add(name)
         log.info("[plugins] registered subagent: %s", name)
+
+
+# Built-in subagents whose runtime config the operator can override in YAML
+# (subagents.<name>.{enabled,tools,max_turns,model}). Add an entry here + a
+# SubagentDef field on LangGraphConfig when you make another built-in overridable.
+_OVERRIDABLE_SUBAGENTS = ("researcher",)
+
+
+def _apply_config_subagents(config) -> None:
+    """Apply the per-subagent **model** override from YAML (``subagents.<name>.model``)
+    onto the built-in registry entries — the operator-facing half of the override that
+    ``_run_subagent`` already honors (per-subagent → routing.aux_model → main model).
+    Blank model = the base model (idempotent across reloads); preserves the entry's
+    tools/prompt (incl. any plugin tweaks). Runs at init + reload.
+
+    Scoped to ``model`` on purpose: ``tools``/``max_turns`` in ``SubagentDef`` are not
+    wired here because the config-side defaults intentionally mirror — but don't track —
+    the registry's, so clobbering them would drop registry-only tools (e.g. memory_ingest)."""
+    try:
+        from dataclasses import replace
+
+        from graph.subagents import config as _sub
+        from graph.subagents.config import SUBAGENT_REGISTRY
+    except Exception:  # noqa: BLE001
+        return
+    bases = {"researcher": getattr(_sub, "RESEARCHER_CONFIG", None)}
+    for name in _OVERRIDABLE_SUBAGENTS:
+        base = bases.get(name)
+        sub = getattr(config, name, None)
+        entry = SUBAGENT_REGISTRY.get(name)
+        if base is None or sub is None or entry is None:
+            continue
+        model = (getattr(sub, "model", "") or "").strip()
+        SUBAGENT_REGISTRY[name] = replace(entry, model=model or base.model)
 
 
 def _build_plugins(config, existing_tools=None):
@@ -931,6 +966,8 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
             new_plugin_meta = new_plugins.meta
             # Plugin knowledge backend (ADR 0031) — swap before the graph rebuild.
             new_store = _apply_plugin_knowledge_backend(new_config, new_store, new_plugins)
+            _register_plugin_subagents(new_plugins.subagents)
+            _apply_config_subagents(new_config)  # YAML subagent overrides take effect on reload
             new_skills = _build_skills_index(new_config, extra_skill_dirs=new_plugin_skill_dirs)
             new_workflow_registry = _build_workflow_registry(new_config)
             new_inbox_store = _build_inbox_store(new_config)

--- a/tests/test_subagent_model_config.py
+++ b/tests/test_subagent_model_config.py
@@ -1,0 +1,51 @@
+"""Per-subagent model override via config (ADR 0001). _apply_config_subagents applies
+subagents.<name>.model onto the runtime SUBAGENT_REGISTRY; _run_subagent already
+resolves per-subagent → routing.aux_model → main model."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import yaml
+
+from graph.config import LangGraphConfig
+from graph.subagents.config import RESEARCHER_CONFIG, SUBAGENT_REGISTRY
+from server.agent_init import _apply_config_subagents
+
+
+def test_config_parses_subagent_model(tmp_path):
+    p = tmp_path / "config.yaml"
+    p.write_text(yaml.safe_dump({"subagents": {"researcher": {"model": "protolabs/reasoning"}}}))
+    cfg = LangGraphConfig.from_yaml(str(p))
+    assert cfg.researcher.model == "protolabs/reasoning"
+
+
+def test_apply_sets_model_preserving_tools_and_prompt():
+    original = SUBAGENT_REGISTRY.get("researcher")
+    try:
+        cfg = LangGraphConfig()
+        cfg.researcher = dataclasses.replace(cfg.researcher, model="protolabs/reasoning")
+        _apply_config_subagents(cfg)
+        entry = SUBAGENT_REGISTRY["researcher"]
+        assert entry.model == "protolabs/reasoning"
+        assert entry.tools == RESEARCHER_CONFIG.tools          # tools untouched (model-only)
+        assert entry.system_prompt == RESEARCHER_CONFIG.system_prompt
+    finally:
+        if original is not None:
+            SUBAGENT_REGISTRY["researcher"] = original
+
+
+def test_blank_model_is_base_and_idempotent():
+    original = SUBAGENT_REGISTRY.get("researcher")
+    try:
+        _apply_config_subagents(LangGraphConfig())            # default, model=""
+        assert SUBAGENT_REGISTRY["researcher"].model == RESEARCHER_CONFIG.model
+        cfg = LangGraphConfig()
+        cfg.researcher = dataclasses.replace(cfg.researcher, model="x")
+        _apply_config_subagents(cfg)
+        assert SUBAGENT_REGISTRY["researcher"].model == "x"
+        _apply_config_subagents(LangGraphConfig())            # cleared → reverts to base
+        assert SUBAGENT_REGISTRY["researcher"].model == RESEARCHER_CONFIG.model
+    finally:
+        if original is not None:
+            SUBAGENT_REGISTRY["researcher"] = original


### PR DESCRIPTION
The "next evolution" from your model-override question. The mechanism already existed in `_run_subagent` (per-subagent → `routing.aux_model` → main model) but wasn't exposed to operators — now it is.

- **`subagents.<name>.model`** in the YAML override (e.g. pin the researcher to the main reasoning model while everything else routes to a cheap alias). `SubagentDef.model` + parsing + the example config documents it.
- **`_apply_config_subagents`** applies the model onto the runtime `SUBAGENT_REGISTRY` at build + reload (preserves tools/prompt; blank = base model; idempotent).
- Runtime status surfaces `researcher.model`.

**Scoped to `model` deliberately:** while wiring this I found the `tools`/`max_turns` half of the same YAML override is *read-only today* (never applied at runtime), and the config-side default tools mirror-but-don't-track the registry's — so blanket-applying them would silently drop registry-only tools like `memory_ingest`. Wiring those safely is a separate change; flagged in the helper's docstring.

(Skills don't apply — they're retrieved guidance injected into the lead's turn, not an independent execution with its own model.)

## Test
`pytest tests/test_subagent_model_config.py` (parse · apply-preserving-tools/prompt · blank=base/idempotent); suite **1223**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
