### PR TITLE
fix(subagents): wire the YAML override to runtime (tools/max_turns/enabled)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Subagent YAML override now actually applies at runtime** — `subagents.<name>.{enabled,
+  tools,max_turns}` was parsed into config but never reached the runtime registry (only the
+  status API read it back, so the documented knob silently did nothing). Wired through
+  `_apply_config_subagents` (init + reload); `enabled: false` removes the subagent. The
+  config-side default now derives from the registry entry (single source of truth) so it
+  can't drift — the old hardcoded default was already missing `memory_ingest`.
+
 ### Added
 - **Per-subagent model override in config** (ADR 0001) — `subagents.<name>.model` pins a
   subagent to a specific model (blank = `routing.aux_model` → main model), so an operator

--- a/graph/config.py
+++ b/graph/config.py
@@ -16,6 +16,11 @@ from pathlib import Path
 
 import yaml
 
+# The built-in researcher's runtime defaults are the single source of truth; the
+# config-side SubagentDef mirrors them so the YAML override layer can't drift
+# (graph/subagents/config has no graph.config dep — no import cycle).
+from graph.subagents.config import RESEARCHER_CONFIG
+
 # Secrets (model API key, A2A bearer) live in an untracked ``secrets.yaml``
 # sibling of the main config, never in the tracked YAML. See graph/config_io
 # for the write side. ``from_yaml`` overlays them below; both still fall back
@@ -112,13 +117,12 @@ class LangGraphConfig:
     # graph/subagents/config.py). Add fields here as you add entries to
     # SUBAGENT_REGISTRY. Tool/max_turns here mirror the registry default and
     # are the YAML-overridable layer.
+    # Defaults derived from the registry entry (SSOT) so the YAML-overridable layer
+    # always matches the runtime default — an un-overridden config is a true no-op.
     researcher: SubagentDef = field(default_factory=lambda: SubagentDef(
-        tools=[
-            "current_time",
-            "web_search", "fetch_url",
-            "memory_recall", "memory_list",
-        ],
-        max_turns=40,
+        tools=list(RESEARCHER_CONFIG.tools),
+        max_turns=RESEARCHER_CONFIG.max_turns,
+        model=RESEARCHER_CONFIG.model,
     ))
 
     # Sub-agent fan-out — the `task_batch` tool runs delegations concurrently.

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -405,15 +405,12 @@ _OVERRIDABLE_SUBAGENTS = ("researcher",)
 
 
 def _apply_config_subagents(config) -> None:
-    """Apply the per-subagent **model** override from YAML (``subagents.<name>.model``)
-    onto the built-in registry entries — the operator-facing half of the override that
-    ``_run_subagent`` already honors (per-subagent → routing.aux_model → main model).
-    Blank model = the base model (idempotent across reloads); preserves the entry's
-    tools/prompt (incl. any plugin tweaks). Runs at init + reload.
-
-    Scoped to ``model`` on purpose: ``tools``/``max_turns`` in ``SubagentDef`` are not
-    wired here because the config-side defaults intentionally mirror — but don't track —
-    the registry's, so clobbering them would drop registry-only tools (e.g. memory_ingest)."""
+    """Apply the YAML subagent override (``subagents.<name>``: enabled / tools /
+    max_turns / model) onto the built-in registry entries — what makes the documented
+    knobs actually take effect at runtime (the resolution path in ``_run_subagent``
+    already existed). Derives each entry from its static default (SSOT, so it's
+    idempotent across reloads and an un-overridden config is a true no-op);
+    ``enabled: false`` removes the subagent (not delegatable). Runs at init + reload."""
     try:
         from dataclasses import replace
 
@@ -425,11 +422,17 @@ def _apply_config_subagents(config) -> None:
     for name in _OVERRIDABLE_SUBAGENTS:
         base = bases.get(name)
         sub = getattr(config, name, None)
-        entry = SUBAGENT_REGISTRY.get(name)
-        if base is None or sub is None or entry is None:
+        if base is None or sub is None:
             continue
-        model = (getattr(sub, "model", "") or "").strip()
-        SUBAGENT_REGISTRY[name] = replace(entry, model=model or base.model)
+        if not getattr(sub, "enabled", True):
+            SUBAGENT_REGISTRY.pop(name, None)  # disabled → not delegatable
+            continue
+        SUBAGENT_REGISTRY[name] = replace(
+            base,
+            tools=list(sub.tools) if sub.tools else list(base.tools),
+            max_turns=sub.max_turns or base.max_turns,
+            model=(sub.model or "").strip() or base.model,
+        )
 
 
 def _build_plugins(config, existing_tools=None):

--- a/tests/test_subagent_model_config.py
+++ b/tests/test_subagent_model_config.py
@@ -49,3 +49,50 @@ def test_blank_model_is_base_and_idempotent():
     finally:
         if original is not None:
             SUBAGENT_REGISTRY["researcher"] = original
+
+
+# ── full override wiring (tools / max_turns / enabled), no drift ──────────────
+
+def test_default_config_preserves_registry_tools_no_drift():
+    """An un-overridden config must equal the registry default — incl. memory_ingest,
+    which the old hardcoded config default was missing (the drift bug)."""
+    original = SUBAGENT_REGISTRY.get("researcher")
+    try:
+        _apply_config_subagents(LangGraphConfig())
+        assert SUBAGENT_REGISTRY["researcher"].tools == RESEARCHER_CONFIG.tools
+        assert "memory_ingest" in SUBAGENT_REGISTRY["researcher"].tools
+    finally:
+        if original is not None:
+            SUBAGENT_REGISTRY["researcher"] = original
+
+
+def test_tools_and_max_turns_override_applies(tmp_path):
+    import yaml as y
+    original = SUBAGENT_REGISTRY.get("researcher")
+    try:
+        p = tmp_path / "c.yaml"
+        p.write_text(y.safe_dump({"subagents": {"researcher": {"tools": ["current_time"], "max_turns": 7}}}))
+        cfg = LangGraphConfig.from_yaml(str(p))
+        _apply_config_subagents(cfg)
+        entry = SUBAGENT_REGISTRY["researcher"]
+        assert entry.tools == ["current_time"] and entry.max_turns == 7
+        assert entry.system_prompt == RESEARCHER_CONFIG.system_prompt  # base preserved
+    finally:
+        if original is not None:
+            SUBAGENT_REGISTRY["researcher"] = original
+
+
+def test_disabled_removes_subagent():
+    import dataclasses
+    original = SUBAGENT_REGISTRY.get("researcher")
+    try:
+        cfg = LangGraphConfig()
+        cfg.researcher = dataclasses.replace(cfg.researcher, enabled=False)
+        _apply_config_subagents(cfg)
+        assert "researcher" not in SUBAGENT_REGISTRY
+        # re-enable restores from base
+        _apply_config_subagents(LangGraphConfig())
+        assert "researcher" in SUBAGENT_REGISTRY
+    finally:
+        if original is not None:
+            SUBAGENT_REGISTRY["researcher"] = original


### PR DESCRIPTION
The bug found while adding the model override: `subagents.<name>.{enabled,tools,max_turns}` is **parsed into config but never applied at runtime** — only the status API reads it back, so the documented knob silently does nothing. (`model` was wired in #665; this finishes the rest.)

## Fix
- **`_apply_config_subagents`** now applies `tools`/`max_turns`/`model` and removes the subagent on `enabled: false`. Derives each entry from its static registry default (SSOT) — idempotent across reloads, and an un-overridden config is a true no-op.
- **No drift:** `SubagentDef.researcher`'s default now derives from `RESEARCHER_CONFIG` (no import cycle) so config and registry can't diverge. The old hardcoded default was already missing `memory_ingest` — a blanket-apply would have silently dropped it; this is why the wiring had to come *with* the SSOT fix.

## Test
`pytest tests/test_subagent_model_config.py` — no-drift (memory_ingest preserved) · tools/max_turns override applies · enabled:false removes + re-enable restores · model (from #665). Suite **1226**; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)