### PR TITLE
docs: headless mode — guide + advertise OpenAI-API / A2A drivability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Headless-mode docs + advertising** — a [Run headless](docs/guides/headless.md) guide
+  (UI tiers, the OpenAI-compatible `/v1/chat/completions` API, the A2A endpoint, auth,
+  headless `--setup`), a README "Run headless" section, and a marketing feature card —
+  surfacing that protoAgent runs API-first (no UI) drivable via OpenAI or A2A.
+
 ### Fixed
 - **Subagent YAML override now actually applies at runtime** — `subagents.<name>.{enabled,
   tools,max_turns}` was parsed into config but never reached the runtime registry (only the

--- a/README.md
+++ b/README.md
@@ -73,6 +73,26 @@ through every wizard step with screenshots.
 Once you're happy and want to ship it as your own image in your
 own GHCR: [Customize & deploy](./docs/guides/customize-and-deploy.md).
 
+## Run headless
+
+The web console is optional — protoAgent is an **API-first agent server**. Run it
+headless and drive it over HTTP via the **OpenAI-compatible** API, the **A2A** protocol,
+or both. Same agent, tools, skills, memory, and goals — no browser.
+
+```bash
+python -m server --ui none --host 0.0.0.0   # API + A2A + /metrics, no UI
+
+# OpenAI-compatible — point any OpenAI client at the base URL:
+curl localhost:7870/v1/chat/completions -H "Authorization: Bearer $TOKEN" \
+  -d '{"messages":[{"role":"user","content":"hi"}]}'
+
+# A2A — the agent card + JSON-RPC endpoint other agents/fleets call:
+curl localhost:7870/.well-known/agent-card.json
+```
+
+`--ui` tiers: `full` (Gradio + console, default) · `console` (React + API) · `none`
+(headless). See [Run headless](./docs/guides/headless.md).
+
 ## Architecture
 
 ```

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -55,6 +55,7 @@ export default defineConfig({
             { text: "Fork checklist (fast path)", link: "/guides/fork-the-template" },
             { text: "Add a custom skill", link: "/guides/add-a-skill" },
             { text: "Configure subagents", link: "/guides/subagents" },
+            { text: "Run headless (API + A2A)", link: "/guides/headless" },
             { text: "Reusable workflows", link: "/guides/workflows" },
             { text: "Skills (SKILL.md)", link: "/guides/skills" },
             { text: "MCP servers", link: "/guides/mcp" },

--- a/docs/guides/headless.md
+++ b/docs/guides/headless.md
@@ -1,0 +1,83 @@
+# Run headless (API + A2A, no UI)
+
+protoAgent is an **API-first agent server**. The web console is optional — run it
+headless and drive it entirely over HTTP: the **OpenAI-compatible** chat API, the
+**A2A** protocol, or both at once. Same agent, same tools/skills/memory/goals — just
+no browser.
+
+## UI tiers (ADR 0010)
+
+One flag picks how much UI is served; the **API + A2A always run**.
+
+| `--ui` | Serves | For |
+| --- | --- | --- |
+| `full` *(default)* | Gradio chat + React console + API + A2A | local dev |
+| `console` | React console + API + A2A | the desktop sidecar |
+| **`none`** | **API + A2A + `/metrics` only** | **headless servers, fleets, CI** |
+
+```bash
+python -m server --ui none --host 0.0.0.0 --port 7870
+# or: PROTOAGENT_UI=none python -m server
+```
+
+(`--host 0.0.0.0` to accept non-localhost traffic in a container; set an auth token
+first — see Auth.)
+
+### Headless setup
+
+No wizard needed. Provision the config (`config/langgraph-config.yaml` +
+`config/secrets.yaml`) and mark setup complete in one shot, then serve:
+
+```bash
+python -m server --setup     # validate the live config + mark setup, then exit
+python -m server --ui none   # serve
+```
+
+## Drive it via the OpenAI API
+
+A drop-in `POST /v1/chat/completions` (+ `GET /v1/models`). Point any OpenAI client at
+the base URL; the "model" is the agent itself.
+
+```bash
+curl http://localhost:7870/v1/chat/completions \
+  -H "Authorization: Bearer $PROTOAGENT_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"messages":[{"role":"user","content":"summarize today’s PRs"}]}'
+```
+
+Pass `"stream": true` for an SSE token stream (OpenAI chunk shape). With the OpenAI
+SDK: set `base_url` to `http://<host>:7870/v1` and `api_key` to your bearer token.
+
+## Drive it via A2A
+
+protoAgent is a first-class [A2A 1.0](https://a2a-protocol.org) server — the way fleets
+of agents talk to each other.
+
+- **Agent card:** `GET /.well-known/agent-card.json` (capabilities, skills, extensions).
+- **JSON-RPC:** `POST /a2a` (`message/send`, `message/stream`, `tasks/*` lifecycle, push
+  notifications).
+
+Point another protoAgent (or any A2A client) at `http://<host>:7870` and it can delegate
+to this one — see [Delegates](./delegates.md).
+
+## Auth
+
+Set an auth token and the API/A2A require `Authorization: Bearer <token>`:
+
+```yaml
+# config/secrets.yaml
+auth:
+  token: "your-strong-token"
+```
+
+Localhost with no token is open for dev convenience; **always set a token when binding to
+`0.0.0.0` or exposing the agent.**
+
+## What else runs headless
+
+Everything non-UI: **`/metrics`** (Prometheus), the **reactive inbox**
+(`POST /api/inbox` for webhooks/cron/sister agents), the **scheduler**, goals, plugins,
+and managed MCP servers. The agent is fully operational without a screen.
+
+See [ADR 0010](../adr/0010-headless-setup-and-ui-tiers.md), [Delegates](./delegates.md),
+ADR [0003](../adr/0003-reactive-agent-activity-thread.md) (reactive inbox).

--- a/sites/marketing/src/pages/index.astro
+++ b/sites/marketing/src/pages/index.astro
@@ -16,6 +16,10 @@ const features = [
     title: 'An operator console',
     body: 'A React console (+ a desktop app) with live token-by-token streaming, chat that survives navigation, knowledge, delegates, and a plugins panel. Run from chat, manage from surfaces.',
   },
+  {
+    title: 'Headless or hands-on',
+    body: 'API-first: run it with no UI and drive it over the OpenAI-compatible API (/v1/chat/completions) or A2A — point any OpenAI client or agent fleet at it. Same agent, tools, memory, and goals, no browser.',
+  },
 ];
 
 const steps = [


### PR DESCRIPTION
protoAgent **already** runs fully headless (`--ui none` = API + A2A + `/metrics`) and is drivable via the OpenAI-compatible `/v1/chat/completions` API and A2A — it just wasn't documented or advertised. This fixes that.

- **[Run headless](../guides/headless.md) guide** — the UI tiers (`full`/`console`/`none`), headless run + `--setup`, OpenAI-compat curl (+ streaming / SDK base_url), the A2A agent card + `/a2a`, bearer auth, and what else runs headless (metrics, inbox, scheduler). Added to the docs sidebar.
- **README "Run headless" section** — curl examples for both APIs + the tier table.
- **Marketing site** — a "Headless or hands-on" feature card.

Docs + marketing build green. (No code — the capability already shipped.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)