### PR TITLE
feat(console): scheduler is a first-class right-rail panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Scheduler is a first-class right-rail panel** — moved from Activity → Schedule to the
+  right rail (Notes · Beads · Goals · Schedule), one click from chat.
+
 ## [0.24.0] - 2026-06-08
 
 ### Added

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -24,8 +24,8 @@ test("Studio lands directly on Workflows (Run tab removed — run is a chat gest
   await expect(page.locator(".stage-subnav").getByRole("button", { name: "Run", exact: true })).toHaveCount(0);
 });
 
-test("schedule moved to Activity → Schedule lists scheduled jobs", async ({ page }) => {
-  await openSub(page, "Activity", "Schedule");
+test("schedule is a right-rail panel that lists scheduled jobs", async ({ page }) => {
+  await page.getByRole("button", { name: "Schedule", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Schedule" })).toBeVisible();
   await expect(page.getByText("Summarize overnight activity")).toBeVisible();
 });

--- a/apps/web/e2e/schedule.spec.ts
+++ b/apps/web/e2e/schedule.spec.ts
@@ -6,7 +6,7 @@ import { expect, test } from "@playwright/test";
 
 async function openScheduleModal(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "Activity", exact: true }).click();
+  // Schedule is a first-class right-rail panel (notes/beads/goals/schedule).
   await page.getByRole("button", { name: "Schedule", exact: true }).click();
   await page.getByTestId("schedule-new").click();
   await expect(page.getByTestId("schedule-modal")).toBeVisible();

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -123,13 +123,13 @@ function pluginViewIcon(name?: string): ReactNode {
 type SystemTab = "runtime" | "telemetry";
 // Activity = the "triggers / events" surface (ADR 0009): what happened (thread),
 // inbound (inbox), and timed (schedule — cron is a trigger, not a work-type).
-type ActivityTab = "thread" | "inbox" | "schedule";
+type ActivityTab = "thread" | "inbox";
 // Knowledge = what the agent knows (ADR 0020): the searchable knowledge Store
 // (factual memory) + Playbooks (procedural memory). Store leads.
 type KnowledgeTab = "store" | "playbooks";
 // The agent's persistent working memory, grouped in the right sidebar:
 // its notebook, its task board, and its goals.
-type RightPanel = "notes" | "beads" | "goals";
+type RightPanel = "notes" | "beads" | "goals" | "schedule";
 
 function createNoteTab() {
   const now = Date.now();
@@ -682,7 +682,6 @@ export function App() {
                     <span className="subnav-badge" data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span>
                   ) : null,
                 },
-                { id: "schedule", label: "Schedule", icon: CalendarClock },
               ]}
             />
           ) : null}
@@ -718,7 +717,6 @@ export function App() {
           {surface === "activity" && activityTab === "thread" ? <ActivitySurface onError={setError} /> : null}
           {surface === "activity" && activityTab === "inbox" ? <InboxPanel /> : null}
 
-          {surface === "activity" && activityTab === "schedule" ? <SchedulePanel /> : null}
 
           {surface === "system" && systemTab === "runtime" ? <RuntimePanel /> : null}
 
@@ -759,6 +757,10 @@ export function App() {
             <button type="button" className={rightPanel === "goals" ? "active" : ""} onClick={() => setRightPanel("goals")}>
               <Target size={15} />
               Goals
+            </button>
+            <button type="button" className={rightPanel === "schedule" ? "active" : ""} onClick={() => setRightPanel("schedule")}>
+              <CalendarClock size={15} />
+              Schedule
             </button>
           </div>
 
@@ -837,6 +839,7 @@ export function App() {
           {rightPanel === "beads" ? <BeadsPanel confirm={setConfirmState} /> : null}
 
           {rightPanel === "goals" ? <GoalsPanel /> : null}
+          {rightPanel === "schedule" ? <SchedulePanel /> : null}
         </aside>
       </div>
 


### PR DESCRIPTION
Moves the Schedule panel from the Activity sub-tab to the **right rail** (Notes · Beads · Goals · **Schedule**) — one click from chat, where you reach for it.

- `RightPanel` gains `schedule`; rail tab (CalendarClock) + render added.
- Removed the schedule sub-tab from Activity (now Thread · Inbox).
- e2e updated to open Schedule from the rail.

Web build + **full e2e 57/57** green. (First of the console-IA changes; Runtime-tabs + Plugins-section reshape next.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)