### PR TITLE
chore(site): drop ADR refs + jargon from plugin taglines

### DIFF
--- a/sites/marketing/data/plugins.json
+++ b/sites/marketing/data/plugins.json
@@ -75,7 +75,7 @@
     "name": "Telegram",
     "category": "Communication",
     "official": true,
-    "tagline": "Run your agent as a Telegram bot — inbound DMs/groups, replies back out. The reference communication plugin (ADR 0029) — ~80 lines of transport on the ChatAdapter standard.",
+    "tagline": "Run your agent as a Telegram bot — inbound DMs and groups, replies back out. A tiny reference communication plugin.",
     "adds": [
       "surface",
       "config"
@@ -92,7 +92,7 @@
     "name": "Slack",
     "category": "Communication",
     "official": true,
-    "tagline": "Run your agent as a Slack app over Socket Mode (no public URL) — inbound messages, replies back out. A communication plugin (ADR 0029) with a websocket transport.",
+    "tagline": "Run your agent as a Slack app over Socket Mode (no public URL) — inbound messages, replies back out.",
     "adds": [
       "surface",
       "config"


### PR DESCRIPTION
Visitors don't need ADR numbers or internal terms in the plugin directory. Cleaned the **telegram** + **slack** taglines (the only two referencing ADR 0029 / transport internals) to plain user-facing copy. Site builds green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)