### PR TITLE
feat(console): Runtime top-level with tabs + dedicated Plugins section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Console IA: Runtime is top-level with tabs; Plugins is its own section** — the dense
+  System panel is split into **Runtime → Overview · Tools · MCP · Subagents · Telemetry**
+  (a new `/api/tools` endpoint feeds the live tool inventory), and plugins get a dedicated
+  **Plugins** rail section (loaded overview + git-URL install/manage, moved out of Settings).
 - **Scheduler is a first-class right-rail panel** — moved from Activity → Schedule to the
   right rail (Notes · Beads · Goals · Schedule), one click from chat.
 

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -80,6 +80,14 @@ function handleApiGet(pathname) {
       return RUNTIME_STATUS;
     case "/api/subagents":
       return { subagents: SUBAGENTS };
+    case "/api/tools":
+      return {
+        tools: [
+          { name: "web_search", description: "Search the web.", source: "core" },
+          { name: "echo__ping", description: "Echo ping.", source: "mcp" },
+        ],
+        count: 2,
+      };
     case "/api/chat/commands":
       return { commands: SLASH_COMMANDS };
     case "/api/scheduler/jobs":

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -44,12 +44,20 @@ test("beads tab in the right sidebar lists issues (query-backed)", async ({ page
   await expect(page.getByText("Wire the telemetry rollup")).toBeVisible();
 });
 
-test("runtime surface surfaces skills, MCP servers, and plugins", async ({ page }) => {
-  await openSub(page, "System", "Runtime");
+test("runtime surface: overview, tools, and MCP tabs", async ({ page }) => {
+  await page.getByRole("button", { name: "Runtime", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Runtime" })).toBeVisible();
+  await expect(page.getByText("SKILL.md skills loaded")).toBeVisible(); // overview
 
-  // Extensibility blocks — the features added across the initiative.
-  await expect(page.getByText("SKILL.md skills loaded")).toBeVisible();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Tools", exact: true }).click();
+  await expect(page.getByText("web_search")).toBeVisible();
+
+  await page.locator(".stage-subnav").getByRole("button", { name: "MCP", exact: true }).click();
   await expect(page.getByText("echo · stdio")).toBeVisible(); // MCP server
-  await expect(page.getByText("Demo Plugin", { exact: false })).toBeVisible(); // plugin
+});
+
+test("plugins are their own section listing loaded plugins", async ({ page }) => {
+  await page.locator(".rail").getByRole("button", { name: "Plugins", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
+  await expect(page.getByText("Demo Plugin", { exact: false })).toBeVisible();
 });

--- a/apps/web/e2e/plugin-install.spec.ts
+++ b/apps/web/e2e/plugin-install.spec.ts
@@ -1,12 +1,11 @@
 import { expect, test } from "@playwright/test";
 
-// Console Plugins panel (ADR 0027, PR2) — install a plugin from a git URL under
-// Settings → Integrations; the installed list round-trips install → uninstall.
+// Console Plugins section — install a plugin from a git URL in the dedicated
+// Plugins rail section; the installed list round-trips install → uninstall.
 
 async function openPluginsPanel(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".stage-subnav").getByRole("button", { name: "Integrations", exact: true }).click();
+  await page.locator(".rail").getByRole("button", { name: "Plugins", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
 }
 

--- a/apps/web/e2e/telemetry.spec.ts
+++ b/apps/web/e2e/telemetry.spec.ts
@@ -3,12 +3,12 @@ import { expect, test } from "@playwright/test";
 // The System ▸ Telemetry tab renders the per-turn rollups from
 // /api/telemetry/* (ADR 0006 Slice 3): summary cards + a recent-turns table.
 
-test("System → Telemetry shows summary cards and recent turns", async ({ page }) => {
+test("Runtime → Telemetry shows summary cards and recent turns", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Into System, then the Telemetry sub-tab.
-  await page.getByRole("button", { name: "System" }).click();
-  await page.getByRole("button", { name: "Telemetry" }).click();
+  // Into Runtime, then the Telemetry sub-tab.
+  await page.locator(".rail").getByRole("button", { name: "Runtime", exact: true }).click();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Telemetry", exact: true }).click();
 
   const surface = page.getByTestId("telemetry-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -23,6 +23,7 @@ import {
   Target,
   Undo2,
   Trash2,
+  Wrench,
   // Plugin-view rail icons (ADR 0026) — a broader lucide allowlist so plugins
   // (dashboards, data, comms, dev, finance, space/fleet, AI) find a fitting glyph.
   Bot,
@@ -83,6 +84,10 @@ import { GoalsPanel } from "./GoalsPanel";
 import { BeadsPanel } from "./BeadsPanel";
 import { SchedulePanel } from "../schedule/SchedulePanel";
 import { RuntimePanel } from "./RuntimePanel";
+import { ToolsPanel } from "./ToolsPanel";
+import { McpPanel } from "./McpPanel";
+import { SubagentsPanel } from "./SubagentsPanel";
+import { PluginsSurface } from "../plugins/PluginsSurface";
 import { SetupWizard } from "../setup/SetupWizard";
 import { runtimeStatusQuery } from "../lib/queries";
 
@@ -91,7 +96,7 @@ import { runtimeStatusQuery } from "../lib/queries";
 // Core surfaces are the fixed literals; plugin views (ADR 0026) add dynamic
 // surfaces keyed `plugin:<pluginId>:<viewId>`. The `(string & {})` keeps literal
 // autocomplete while allowing those runtime keys.
-type Surface = "chat" | "activity" | "studio" | "knowledge" | "system" | "settings" | (string & {});
+type Surface = "chat" | "activity" | "studio" | "knowledge" | "runtime" | "plugins" | "settings" | (string & {});
 
 // Lucide icon names a plugin view may use for its rail glyph (ADR 0026, PR1 set;
 // PR2 widens the allowlist). Unknown/missing → a generic plugin glyph.
@@ -120,7 +125,7 @@ function pluginViewIcon(name?: string): ReactNode {
 // Studio = the workflow authoring/inspection surface. Per ADR 0020 execution is
 // a chat gesture (run subagents/workflows via /<name>), not a surface — so the
 // old "Run" tab is gone and Studio is just Workflows.
-type SystemTab = "runtime" | "telemetry";
+type RuntimeTab = "overview" | "tools" | "mcp" | "subagents" | "telemetry";
 // Activity = the "triggers / events" surface (ADR 0009): what happened (thread),
 // inbound (inbox), and timed (schedule — cron is a trigger, not a work-type).
 type ActivityTab = "thread" | "inbox";
@@ -173,7 +178,7 @@ export function App() {
   // Background-streaming indicator for the Chat rail (narrow selector → only
   // re-renders when the boolean flips, not per token).
   const chatStreaming = useAnyChatStreaming();
-  const [systemTab, setSystemTab] = useState<SystemTab>("runtime");
+  const [runtimeTab, setRuntimeTab] = useState<RuntimeTab>("overview");
   const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
   const [knowledgeTab, setKnowledgeTab] = useState<KnowledgeTab>("store");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
@@ -636,10 +641,16 @@ export function App() {
             onClick={() => setSurface("knowledge")}
           />
           <RailButton
-            active={surface === "system"}
-            label="System"
+            active={surface === "runtime"}
+            label="Runtime"
             icon={<Gauge size={18} />}
-            onClick={() => setSurface("system")}
+            onClick={() => setSurface("runtime")}
+          />
+          <RailButton
+            active={surface === "plugins"}
+            label="Plugins"
+            icon={<Puzzle size={18} />}
+            onClick={() => setSurface("plugins")}
           />
           <RailButton
             active={surface === "settings"}
@@ -696,12 +707,15 @@ export function App() {
               ]}
             />
           ) : null}
-          {surface === "system" ? (
+          {surface === "runtime" ? (
             <StageSubnav
-              active={systemTab}
-              onSelect={(id) => setSystemTab(id as typeof systemTab)}
+              active={runtimeTab}
+              onSelect={(id) => setRuntimeTab(id as typeof runtimeTab)}
               tabs={[
-                { id: "runtime", label: "Runtime", icon: Gauge },
+                { id: "overview", label: "Overview", icon: Gauge },
+                { id: "tools", label: "Tools", icon: Wrench },
+                { id: "mcp", label: "MCP", icon: Plug },
+                { id: "subagents", label: "Subagents", icon: Bot },
                 { id: "telemetry", label: "Telemetry", icon: BarChart3 },
               ]}
             />
@@ -718,9 +732,12 @@ export function App() {
           {surface === "activity" && activityTab === "inbox" ? <InboxPanel /> : null}
 
 
-          {surface === "system" && systemTab === "runtime" ? <RuntimePanel /> : null}
-
-          {surface === "system" && systemTab === "telemetry" ? <TelemetrySurface /> : null}
+          {surface === "runtime" && runtimeTab === "overview" ? <RuntimePanel /> : null}
+          {surface === "runtime" && runtimeTab === "tools" ? <ToolsPanel /> : null}
+          {surface === "runtime" && runtimeTab === "mcp" ? <McpPanel /> : null}
+          {surface === "runtime" && runtimeTab === "subagents" ? <SubagentsPanel /> : null}
+          {surface === "runtime" && runtimeTab === "telemetry" ? <TelemetrySurface /> : null}
+          {surface === "plugins" ? <PluginsSurface /> : null}
           {surface === "knowledge" && knowledgeTab === "store" ? <KnowledgeStore onError={setError} /> : null}
           {surface === "knowledge" && knowledgeTab === "playbooks" ? <PlaybooksSurface onError={setError} /> : null}
           {surface === "settings" ? <SettingsSurface /> : null}

--- a/apps/web/src/app/McpPanel.tsx
+++ b/apps/web/src/app/McpPanel.tsx
@@ -1,0 +1,58 @@
+import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+
+import { PanelHeader } from "./PanelHeader";
+import { runtimeStatusQuery } from "../lib/queries";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
+import { StatusPill } from "./StatusPill";
+
+// Runtime → MCP: external Model Context Protocol servers whose tools are wired
+// into the agent (namespaced <server>__<tool>).
+
+function McpBody() {
+  const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
+  const servers = runtime.mcp?.servers ?? [];
+  const total = runtime.mcp?.tool_count ?? 0;
+
+  return (
+    <>
+      <PanelHeader
+        title="MCP servers"
+        kicker={`${servers.length} server${servers.length === 1 ? "" : "s"} · ${total} tool${total === 1 ? "" : "s"}`}
+      />
+      <div className="stage-body">
+        <div className="table-list">
+          {servers.length ? (
+            servers.map((server) => (
+              <div className="table-row" key={server.name}>
+                <span>{server.name} · {server.transport}</span>
+                <StatusPill label={`${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`} tone="success" />
+              </div>
+            ))
+          ) : (
+            <div className="table-row">
+              <span>no MCP servers configured</span>
+              <StatusPill label={runtime.mcp?.enabled ? "enabled" : "off"} tone="muted" />
+            </div>
+          )}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function McpPanel() {
+  return (
+    <section className="panel stage-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="MCP" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading MCP…" />}>
+              <McpBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </section>
+  );
+}

--- a/apps/web/src/app/RuntimePanel.tsx
+++ b/apps/web/src/app/RuntimePanel.tsx
@@ -4,13 +4,14 @@ import { Suspense, type ReactNode } from "react";
 
 import { brandName } from "../lib/brand";
 import { PanelHeader } from "./PanelHeader";
-import { runtimeStatusQuery, subagentsQuery } from "../lib/queries";
+import { runtimeStatusQuery } from "../lib/queries";
 import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
 import { StatusPill } from "./StatusPill";
 
-// System → Runtime: the agent's configured surface (model, middleware, skills,
-// MCP servers, plugins, subagents). On the TanStack Query data layer (ADR 0013)
-// via useSuspenseQuery on the same `runtime` key the shell reads non-suspense.
+// Runtime → Overview: the agent's configured surface at a glance (model,
+// middleware, storage, skills). Tools / MCP / Subagents are their own tabs.
+// On the TanStack Query data layer (ADR 0013) via useSuspenseQuery on the same
+// `runtime` key the shell reads non-suspense.
 
 function formatBool(value: boolean) {
   return value ? "on" : "off";
@@ -41,8 +42,6 @@ function Metric({ icon, label, value }: { icon: ReactNode; label: string; value:
 
 function RuntimeBody() {
   const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
-  const { data: subData } = useSuspenseQuery(subagentsQuery());
-  const subagents = subData.subagents;
   const middleware = Object.entries(runtime.middleware).sort(([a], [b]) => a.localeCompare(b));
 
   return (
@@ -91,61 +90,6 @@ function RuntimeBody() {
               tone={(runtime.skills?.count ?? 0) > 0 ? "success" : "muted"}
             />
           </div>
-        </div>
-
-        <p className="panel-kicker">MCP servers</p>
-        <div className="table-list">
-          {runtime.mcp?.servers?.length ? (
-            runtime.mcp.servers.map((server) => (
-              <div className="table-row" key={server.name}>
-                <span>{server.name} · {server.transport}</span>
-                <StatusPill label={`${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`} tone="success" />
-              </div>
-            ))
-          ) : (
-            <div className="table-row">
-              <span>no MCP servers</span>
-              <StatusPill label={runtime.mcp?.enabled ? "enabled" : "off"} tone="muted" />
-            </div>
-          )}
-        </div>
-
-        <p className="panel-kicker">Plugins</p>
-        <div className="table-list">
-          {runtime.plugins?.length ? (
-            runtime.plugins.map((plugin) => (
-              <div className="table-row" key={plugin.id}>
-                <span>
-                  {plugin.name}
-                  {plugin.loaded && plugin.tools.length ? ` · ${plugin.tools.length} tool${plugin.tools.length === 1 ? "" : "s"}` : ""}
-                  {plugin.loaded && plugin.skills ? ` · ${plugin.skills} skill${plugin.skills === 1 ? "" : "s"}` : ""}
-                  {plugin.error ? ` · ${plugin.error}` : ""}
-                </span>
-                <StatusPill
-                  label={plugin.loaded ? "loaded" : plugin.error ? "error" : plugin.enabled ? "enabled" : "disabled"}
-                  tone={plugin.loaded ? "success" : plugin.error ? "error" : "muted"}
-                />
-              </div>
-            ))
-          ) : (
-            <div className="table-row">
-              <span>no plugins</span>
-              <StatusPill label="none" tone="muted" />
-            </div>
-          )}
-        </div>
-
-        <p className="panel-kicker">Subagents</p>
-        <div className="subagent-list">
-          {subagents.map((subagent) => (
-            <div className="subagent-row" key={subagent.name}>
-              <div>
-                <strong>{subagent.name}</strong>
-                <span>{subagent.tools.join(", ") || "no tools"}</span>
-              </div>
-              <StatusPill label={`${subagent.max_turns} turns`} tone={subagent.enabled ? "success" : "muted"} />
-            </div>
-          ))}
         </div>
       </div>
     </>

--- a/apps/web/src/app/SubagentsPanel.tsx
+++ b/apps/web/src/app/SubagentsPanel.tsx
@@ -1,0 +1,53 @@
+import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+
+import { PanelHeader } from "./PanelHeader";
+import { subagentsQuery } from "../lib/queries";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
+import { StatusPill } from "./StatusPill";
+
+// Runtime → Subagents: the delegate roster the lead agent can fan work out to,
+// with each one's tools, turn budget, and (if pinned) model override.
+
+function SubagentsBody() {
+  const { data } = useSuspenseQuery(subagentsQuery());
+  const subagents = data.subagents;
+
+  return (
+    <>
+      <PanelHeader
+        title="Subagents"
+        kicker={`${subagents.length} subagent${subagents.length === 1 ? "" : "s"}`}
+      />
+      <div className="stage-body">
+        <div className="subagent-list">
+          {subagents.map((subagent) => (
+            <div className="subagent-row" key={subagent.name}>
+              <div>
+                <strong>{subagent.name}</strong>
+                <span>{subagent.tools.join(", ") || "no tools"}</span>
+              </div>
+              <StatusPill label={`${subagent.max_turns} turns`} tone={subagent.enabled ? "success" : "muted"} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function SubagentsPanel() {
+  return (
+    <section className="panel stage-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="subagents" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading subagents…" />}>
+              <SubagentsBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </section>
+  );
+}

--- a/apps/web/src/app/ToolsPanel.tsx
+++ b/apps/web/src/app/ToolsPanel.tsx
@@ -1,0 +1,67 @@
+import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense, useState } from "react";
+
+import { PanelHeader } from "./PanelHeader";
+import { toolsQuery } from "../lib/queries";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
+import { StatusPill } from "./StatusPill";
+
+// Runtime → Tools: the live tool inventory the lead agent + subagents can call,
+// grouped by source (core / plugin / mcp). Searchable — the list grows as you
+// add plugins and MCP servers.
+
+const SOURCE_TONE = { core: "success", plugin: "muted", mcp: "muted" } as const;
+
+function ToolsBody() {
+  const { data } = useSuspenseQuery(toolsQuery());
+  const [q, setQ] = useState("");
+  const query = q.trim().toLowerCase();
+  const tools = query
+    ? data.tools.filter((t) => `${t.name} ${t.description} ${t.source}`.toLowerCase().includes(query))
+    : data.tools;
+
+  return (
+    <>
+      <PanelHeader title="Tools" kicker={`${data.count} wired tool${data.count === 1 ? "" : "s"}`} />
+      <div className="stage-body">
+        <input
+          className="playbook-search"
+          type="search"
+          placeholder="Search tools…"
+          value={q}
+          onChange={(e) => setQ(e.target.value)}
+        />
+        <div className="table-list">
+          {tools.map((t) => (
+            <div className="table-row" key={t.name}>
+              <span>
+                <strong>{t.name}</strong>
+                {t.description ? <span className="muted"> — {t.description}</span> : null}
+              </span>
+              <StatusPill label={t.source} tone={SOURCE_TONE[t.source] ?? "muted"} />
+            </div>
+          ))}
+          {tools.length === 0 ? (
+            <div className="table-row"><span>no tools match</span></div>
+          ) : null}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function ToolsPanel() {
+  return (
+    <section className="panel stage-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="tools" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading tools…" />}>
+              <ToolsBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </section>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -21,6 +21,7 @@ import type {
   SlashCommand,
   Playbook,
   Subagent,
+  ToolInfo,
   TelemetryInsights,
   TelemetrySummary,
   TelemetryTurn,
@@ -465,6 +466,10 @@ export const api = {
 
   subagents() {
     return request<{ subagents: Subagent[] }>("/api/subagents");
+  },
+
+  tools() {
+    return request<{ tools: ToolInfo[]; count: number }>("/api/tools");
   },
 
   runSubagent(body: {

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -10,6 +10,7 @@ export const queryKeys = {
   beadsIssues: ["beads", "issues"] as const,
   workflows: ["workflows"] as const,
   subagents: ["subagents"] as const,
+  tools: ["tools"] as const,
   telemetry: ["telemetry"] as const,
   settings: ["settings", "schema"] as const,
   inbox: ["inbox"] as const,
@@ -51,6 +52,12 @@ export const subagentsQuery = () =>
   queryOptions({
     queryKey: queryKeys.subagents,
     queryFn: () => api.subagents(),
+  });
+
+export const toolsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.tools,
+    queryFn: () => api.tools(),
   });
 
 // Telemetry dashboard (ADR 0006) — the summary + recent turns + insights in one

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -223,6 +223,13 @@ export type Subagent = {
   allow_skill_emission: boolean;
 };
 
+// A live wired tool (Runtime → Tools), grouped by where it comes from.
+export type ToolInfo = {
+  name: string;
+  description: string;
+  source: "core" | "plugin" | "mcp";
+};
+
 export type ToolCall = {
   id: string;
   name: string;

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -1,0 +1,92 @@
+import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+import { ExternalLink } from "lucide-react";
+
+import { PanelHeader } from "../app/PanelHeader";
+import { runtimeStatusQuery } from "../lib/queries";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
+import { StatusPill } from "../app/StatusPill";
+import { PluginsSection } from "../settings/PluginsSection";
+
+// Plugins: the installed plugins home — what's loaded, what each adds, and what
+// errored. Browse + install more from the public directory.
+
+function PluginsBody() {
+  const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
+  const plugins = runtime.plugins ?? [];
+  const loaded = plugins.filter((p) => p.loaded).length;
+
+  return (
+    <>
+      <PanelHeader
+        title="Plugins"
+        kicker={`${plugins.length} installed · ${loaded} loaded`}
+        actions={
+          <a
+            className="icon-button"
+            href="https://agent.protolabs.studio/plugins"
+            target="_blank"
+            rel="noopener noreferrer"
+            title="Browse the plugin directory"
+          >
+            <ExternalLink size={16} />
+          </a>
+        }
+      />
+      <div className="stage-body">
+        {plugins.length ? (
+          <div className="subagent-list">
+            {plugins.map((plugin) => (
+              <div className="subagent-row" key={plugin.id}>
+                <div>
+                  <strong>
+                    {plugin.name}
+                    {plugin.version ? <span className="muted"> v{plugin.version}</span> : null}
+                  </strong>
+                  <span>
+                    {[
+                      plugin.loaded && plugin.tools.length ? `${plugin.tools.length} tool${plugin.tools.length === 1 ? "" : "s"}` : null,
+                      plugin.loaded && plugin.skills ? `${plugin.skills} skill${plugin.skills === 1 ? "" : "s"}` : null,
+                      plugin.views?.length ? `${plugin.views.length} view${plugin.views.length === 1 ? "" : "s"}` : null,
+                      plugin.error || null,
+                    ].filter(Boolean).join(" · ") || "no contributions"}
+                  </span>
+                </div>
+                <StatusPill
+                  label={plugin.loaded ? "loaded" : plugin.error ? "error" : plugin.enabled ? "enabled" : "disabled"}
+                  tone={plugin.loaded ? "success" : plugin.error ? "error" : "muted"}
+                />
+              </div>
+            ))}
+          </div>
+        ) : (
+          <div className="table-list">
+            <div className="table-row">
+              <span>no plugins enabled — install one below, then add it to <code>plugins.enabled</code></span>
+              <StatusPill label="none" tone="muted" />
+            </div>
+          </div>
+        )}
+
+        {/* Install / manage from a git URL (ADR 0027) — the management half. */}
+        <PluginsSection />
+      </div>
+    </>
+  );
+}
+
+export function PluginsSurface() {
+  return (
+    <section className="panel stage-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="plugins" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading plugins…" />}>
+              <PluginsBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </section>
+  );
+}

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -45,7 +45,7 @@ export function PluginsSection() {
   return (
     <section className="settings-section">
       <header className="settings-section-head">
-        <h3><Package size={16} /> Plugins</h3>
+        <h3><Package size={16} /> Install from a git URL</h3>
         <p className="settings-section-sub">
           Install a plugin from a git URL. Fetching code never runs it — review, then{" "}
           <strong>enable</strong> it (add to <code>plugins.enabled</code> and restart). Untrusted code?

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -14,7 +14,6 @@ import { api } from "../lib/api";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
 import type { SettingsField, SettingsGroup } from "../lib/types";
 import { DelegatesSection } from "./DelegatesSection";
-import { PluginsSection } from "./PluginsSection";
 
 // Generic settings surface — renders whatever GET /api/settings/schema returns,
 // so it stays in sync as config grows. Saving POSTs the changed fields and the
@@ -68,8 +67,8 @@ function SettingsBody() {
       const c = g.category || "Integrations";
       if (!seen.includes(c)) seen.push(c);
     }
-    // Integrations always shows — the Plugins panel (ADR 0027) is core, and the
-    // delegates panel appears there when its plugin is enabled.
+    // Integrations always shows — the delegate registry (ADR 0025) lives here as
+    // a custom CRUD panel (plugins moved to their own top-level section).
     if (!seen.includes("Integrations")) seen.push("Integrations");
     return seen;
   }, [groups]);
@@ -307,8 +306,7 @@ function SettingsBody() {
         {/* The delegate registry (ADR 0025) isn't part of the settings schema —
             it's a CRUD surface, rendered as a custom panel under Integrations. */}
         {category === "Integrations" ? <DelegatesSection /> : null}
-        {/* Git-installed plugins (ADR 0027) — install/manage from a URL, under Integrations. */}
-        {category === "Integrations" ? <PluginsSection /> : null}
+        {/* Plugin install/manage moved to its own top-level Plugins section. */}
       </div>
       </section>
     </>

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -71,6 +71,42 @@ def _operator_subagent_list():
     return _operator_list_subagents(STATE.graph_config)
 
 
+def _operator_tools_list():
+    """Live tool inventory grouped by source (core / plugin / mcp) for the
+    Runtime → Tools tab. Best-effort: degrades to an empty list pre-setup."""
+    cfg = STATE.graph_config
+    out: list[dict] = []
+    seen: set[str] = set()
+
+    def add(tool, source):
+        name = getattr(tool, "name", None)
+        if not name or name in seen:
+            return
+        seen.add(name)
+        desc = (getattr(tool, "description", "") or "").strip().split("\n")[0]
+        out.append({"name": name, "description": desc, "source": source})
+
+    try:
+        from tools.lg_tools import get_all_tools
+
+        core = get_all_tools(
+            STATE.knowledge_store,
+            scheduler=STATE.scheduler,
+            inbox_store=STATE.inbox_store,
+            beads_store=STATE.beads_store,
+            goal_enabled=bool(getattr(cfg, "goal_enabled", False)) if cfg else False,
+        )
+        for t in core:
+            add(t, "core")
+    except Exception:  # noqa: BLE001
+        log.exception("[tools] core enumeration failed")
+    for t in (getattr(STATE, "plugin_tools", None) or []):
+        add(t, "plugin")
+    for t in (getattr(STATE, "mcp_tools", None) or []):
+        add(t, "mcp")
+    return {"tools": out, "count": len(out)}
+
+
 async def _operator_subagent_run(req: dict):
     if STATE.graph is None:
         raise RuntimeError("agent graph is not loaded; finish setup first")

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -170,6 +170,7 @@ def register_operator_routes(
     *,
     runtime_status: Callable[[], dict[str, Any]],
     subagent_list: Callable[[], list[dict[str, Any]]],
+    tools_list: Callable[[], dict[str, Any]] = lambda: {"tools": [], "count": 0},
     subagent_run: Callable[[dict[str, Any]], Awaitable[str]],
     subagent_batch: Callable[[dict[str, Any]], Awaitable[str]],
     beads_service: BeadsService | None = None,
@@ -217,6 +218,10 @@ def register_operator_routes(
     @app.get("/api/subagents")
     async def _subagents():
         return {"subagents": subagent_list()}
+
+    @app.get("/api/tools")
+    async def _tools():
+        return tools_list()
 
     @app.post("/api/subagents/run")
     async def _subagent_run(req: SubagentRunRequest):

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -438,6 +438,7 @@ def _main():
         fastapi_app,
         runtime_status=_console._operator_runtime_status,
         subagent_list=_console._operator_subagent_list,
+        tools_list=_console._operator_tools_list,
         subagent_run=_console._operator_subagent_run,
         subagent_batch=_console._operator_subagent_batch,
         beads_store=STATE.beads_store,


### PR DESCRIPTION
Console IA reshape for scale (your three asks — scheduler already shipped in #676):

- **Runtime** is now a top-level section, split into tabs: **Overview · Tools · MCP · Subagents · Telemetry** (the dense System panel was going to clutter as tools/MCP grow). New `ToolsPanel` / `McpPanel` / `SubagentsPanel`; `RuntimePanel` trimmed to Overview.
- New **`GET /api/tools`** endpoint — live tool inventory grouped by source (core / plugin / mcp); the Tools tab is searchable.
- New top-level **Plugins** section: loaded/contributing overview + the git-URL install/manage panel, **moved out of Settings → Integrations** (de-duped; Integrations keeps Delegates).

e2e updated (runtime tabs, plugins section, telemetry-under-runtime, plugin-install via the Plugins rail); `/api/tools` mocked. Python suite + web build + **full e2e 58/58** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)