### PR TITLE
feat(console): plugin views can use any lucide icon (lazy, no allowlist)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Plugin view icons: any lucide icon, no allowlist** — a plugin view can name any
+  [lucide](https://lucide.dev) icon (PascalCase or kebab-case). A curated common set renders
+  instantly; anything else lazy-loads in a separate on-demand chunk, so authors aren't limited
+  to a hardcoded list and the main console bundle stays lean.
+
 ### Fixed
 - **Scheduler: `schedule_task` dedupes identical jobs** — won't create a second active job
   with the same prompt + schedule, so a self-rescheduling loop can't pile up duplicates that

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -57,8 +57,8 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { useEffect, useRef, useState } from "react";
-import type { CSSProperties, ReactNode } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
+import type { ComponentType, CSSProperties, LazyExoticComponent, ReactNode } from "react";
 import { IntroSplash } from "./IntroSplash";
 import { BootGate } from "./BootGate";
 
@@ -98,8 +98,11 @@ import { runtimeStatusQuery } from "../lib/queries";
 // autocomplete while allowing those runtime keys.
 type Surface = "chat" | "activity" | "studio" | "knowledge" | "runtime" | "plugins" | "settings" | (string & {});
 
-// Lucide icon names a plugin view may use for its rail glyph (ADR 0026, PR1 set;
-// PR2 widens the allowlist). Unknown/missing → a generic plugin glyph.
+// A plugin view names its rail glyph by lucide icon name. The curated set below
+// is the common-case fast path (already bundled); anything else falls back to the
+// full lucide set by name, so a plugin author can use ANY lucide icon — PascalCase
+// (`LineChart`) or kebab-case (`line-chart`) — without us extending an allowlist.
+// Unknown/missing → a generic plugin glyph.
 const PLUGIN_VIEW_ICONS: Record<string, LucideIcon> = {
   // general
   Sparkles, LayoutDashboard, Puzzle, Boxes, Gauge, Target, Activity, Settings2,
@@ -118,9 +121,39 @@ const PLUGIN_VIEW_ICONS: Record<string, LucideIcon> = {
   // security
   Shield,
 };
+// "line-chart" / "line_chart" / "LineChart" → "LineChart" (lucide's key style).
+function toPascalCase(name: string): string {
+  return name.replace(/(^|[-_ ])([a-z0-9])/g, (_m, _sep, ch: string) => ch.toUpperCase());
+}
+
+// Off the curated path, resolve ANY lucide icon by name — but lazily: the dynamic
+// import pulls the full lucide set into a separate chunk that only loads when a
+// plugin actually uses a non-curated glyph, so the main bundle stays lean.
+type IconComp = LazyExoticComponent<ComponentType<{ size?: number }>>;
+// NB: `Map` is shadowed by the lucide Map icon import — use the global explicitly.
+const lazyIconCache = new globalThis.Map<string, IconComp>();
+function lazyLucideIcon(key: string): IconComp {
+  let comp = lazyIconCache.get(key);
+  if (!comp) {
+    comp = lazy(async () => {
+      const m = await import("lucide-react");
+      const Icon = (m.icons as Record<string, LucideIcon>)[key] || m.Puzzle;
+      return { default: Icon as ComponentType<{ size?: number }> };
+    });
+    lazyIconCache.set(key, comp);
+  }
+  return comp;
+}
 function pluginViewIcon(name?: string): ReactNode {
-  const Icon = (name && PLUGIN_VIEW_ICONS[name]) || Puzzle;
-  return <Icon size={18} />;
+  if (!name) return <Puzzle size={18} />;
+  const Curated = PLUGIN_VIEW_ICONS[name];
+  if (Curated) return <Curated size={18} />;
+  const Lazy = lazyLucideIcon(toPascalCase(name));
+  return (
+    <Suspense fallback={<Puzzle size={18} />}>
+      <Lazy size={18} />
+    </Suspense>
+  );
 }
 // Studio = the workflow authoring/inspection surface. Per ADR 0020 execution is
 // a chat gesture (run subagents/workflows via /<name>), not a surface — so the

--- a/docs/guides/plugin-views.md
+++ b/docs/guides/plugin-views.md
@@ -24,11 +24,13 @@ views:
 The console reads this from `/api/runtime/status` and renders a rail icon per
 view (keyed `plugin:<id>:<viewId>`). When selected, it hosts `path` in a
 same-origin **iframe** that fills the stage; `tabs` render as a sub-nav that swaps
-the iframe page. `icon` is a [lucide](https://lucide.dev) name from the console's
-allowlist — covering dashboards, data, comms, dev, AI, finance, space/fleet, and
-security (e.g. `LayoutDashboard`, `BarChart3`, `Database`, `Workflow`, `Bot`,
-`Rocket`, `Satellite`, `Coins`, `Shield`); an unknown name falls back to a generic
-plugin glyph.
+the iframe page. `icon` is **any** [lucide](https://lucide.dev) icon name — either
+PascalCase (`LineChart`) or kebab-case (`line-chart`). A curated common set
+(dashboards, data, comms, dev, AI, finance, space/fleet, security — e.g.
+`LayoutDashboard`, `BarChart3`, `Database`, `Workflow`, `Bot`, `Rocket`, `Coins`,
+`Shield`) renders instantly; anything else is lazy-loaded on demand, so you're not
+limited to an allowlist and the console bundle stays lean. An unknown name falls back
+to a generic plugin glyph.
 
 ## Serve the page
 


### PR DESCRIPTION
Plugin-view rail glyphs were capped at a hardcoded ~50-icon allowlist — adding one meant editing core. Now a plugin can name **any** lucide icon (PascalCase `LineChart` or kebab `line-chart`):

- The curated common set stays statically imported (instant, main bundle).
- Anything else resolves via a **lazy** dynamic import of the full lucide set — a separate on-demand chunk that only loads when a non-curated glyph actually renders. (The naive static `icons` map added **+640 KB** to the main bundle; this keeps it lean — the barrel is a ~742 KB chunk that most users never fetch.)
- Unknown names fall back to a generic plugin glyph.

Docs (plugin-views guide) updated. Web build + **full e2e 58/58** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)