### PR TITLE
fix(scheduler): stop duplicate/runaway fires on long scheduled turns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Scheduler: fix duplicate/runaway scheduled fires** — `message/send` blocks until the
+  turn is terminal, so the old 30s fire timeout false-failed any longer turn and re-fired it
+  every tick (~30s) — duplicate scheduled turns + Activity spam. Fires now run off the poll
+  loop with an in-flight guard (a slow turn fires once, never re-claimed mid-turn), cron rolls
+  forward at claim time, and the timeout is generous + configurable (`SCHEDULER_FIRE_TIMEOUT_S`,
+  default 600s).
+
 ### Changed
 - **Plugin view icons: any lucide icon, no allowlist** — a plugin view can name any
   [lucide](https://lucide.dev) icon (PascalCase or kebab-case). A curated common set renders

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -110,6 +110,7 @@ The bundled scheduler is enabled by default. See [Schedule future work](/guides/
 | `WORKSTACEAN_TOPIC_PREFIX` | `cron.<agent_name>` | Override the bus topic the adapter fires on, when your Workstacean install uses a different convention. |
 | `SCHEDULER_DB_DIR` | `/sandbox/scheduler` | Local backend: parent directory for `<agent_name>/jobs.db`. Falls back to `~/.protoagent/scheduler/<agent_name>/jobs.db` when unwritable. |
 | `SCHEDULER_INVOKE_URL` | `http://127.0.0.1:<active_port>` | Local backend: where to POST `message/send` when a job fires. Override only if the agent's A2A endpoint isn't on localhost. |
+| `SCHEDULER_FIRE_TIMEOUT_S` | `600` | Local backend: how long a fire waits for the turn (`message/send` blocks until the turn is terminal). Must exceed a real turn — too low false-fails long turns. Fires run off the poll loop, so this doesn't stall the cadence. |
 | `SCHEDULER_DISABLED` | (unset) | Runtime escape hatch — set to `1` / `true` to drop the scheduler tools entirely without editing YAML. `middleware.scheduler: false` is the canonical opt-out. |
 
 > **protoLabs operators**: the fleet's Workstacean lives on the `ava` node. `WORKSTACEAN_API_KEY` is in the org's secrets manager under `secret-management → workstacean`.

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -202,6 +202,18 @@ class LocalScheduler:
         self._task: asyncio.Task | None = None
         self._stopping = False
         self._lock_fd = None  # owner-lock fd (ADR 0004) held while polling
+        # In-flight fires (job ids) + their background tasks. message/send blocks
+        # until the agent turn reaches a terminal state, so a fire can take as long
+        # as the turn — we run it off the poll loop and guard against re-claiming a
+        # job that's still firing (the cause of duplicate scheduled turns).
+        self._inflight_ids: set[str] = set()
+        self._fire_tasks: set[asyncio.Task] = set()
+        # Fire timeout must comfortably exceed a real turn (web research + subagents
+        # can run minutes); too-short here false-fails long turns into a re-fire loop.
+        try:
+            self._fire_timeout_s = float(os.environ.get("SCHEDULER_FIRE_TIMEOUT_S", "600"))
+        except ValueError:
+            self._fire_timeout_s = 600.0
         self._init_db()
 
     # ── DB plumbing ─────────────────────────────────────────────────────────
@@ -322,6 +334,13 @@ class LocalScheduler:
                 log.exception("[scheduler] polling task raised during stop")
             self._task = None
             log.info("[scheduler] local backend stopped")
+        # Let in-flight fires finish briefly, then cancel any stragglers (the turn
+        # continues server-side; we just stop awaiting it on shutdown).
+        if self._fire_tasks:
+            pending = list(self._fire_tasks)
+            done, still = await asyncio.wait(pending, timeout=5)
+            for t in still:
+                t.cancel()
         # Release the owner-lock (ADR 0004) so another instance can take over.
         if self._lock_fd is not None:
             _release_jobs_lock(self.path, self._lock_fd)
@@ -344,18 +363,53 @@ class LocalScheduler:
         now = datetime.now(UTC)
         due = self._claim_due_jobs(now)
         for job in due:
-            # Reschedule (or delete) only when delivery actually
-            # succeeded. A transient HTTP failure leaves the row in
-            # place so the next tick retries; a one-shot stays alive
-            # until it lands rather than vanishing on the first
-            # network blip.
-            if await self._fire(job):
+            # Fire OFF the poll loop: message/send blocks until the turn finishes,
+            # which can be minutes — awaiting it here would stall the cadence and
+            # (on the old 30s timeout) false-fail long turns into a re-fire storm.
+            # Mark in-flight so the next tick won't re-claim a still-firing job.
+            self._inflight_ids.add(job.id)
+            cron = is_cron(job.schedule)
+            # Advance cron NOW so it rolls to its next slot regardless of how long
+            # this turn runs (no duplicate fire mid-turn). One-shots are resolved
+            # when the fire settles (deleted on success, kept for retry on failure).
+            if cron:
                 self._reschedule_or_delete(job, fired_at=now)
-            else:
+            t = asyncio.create_task(self._fire_and_settle(job, cron), name=f"scheduler.fire.{job.id}")
+            self._fire_tasks.add(t)
+            t.add_done_callback(self._fire_tasks.discard)
+
+    async def _fire_and_settle(self, job: Job, cron: bool) -> None:
+        """Run a fire off the poll loop and settle the row when it lands.
+
+        Cron jobs were already advanced at claim time; here we only resolve
+        one-shots (delete on success, leave for retry on failure) and always clear
+        the in-flight guard so the job can be claimed again on its next due slot."""
+        try:
+            ok = await self._fire(job)
+            if not cron:
+                if ok:
+                    self._delete_job(job.id)
+                else:
+                    log.warning(
+                        "[scheduler] one-shot fire failed for job %s; leaving for retry",
+                        job.id,
+                    )
+            elif not ok:
                 log.warning(
-                    "[scheduler] fire failed for job %s; leaving in place for retry",
-                    job.id,
+                    "[scheduler] cron fire failed for job %s; will fire next slot", job.id,
                 )
+        finally:
+            self._inflight_ids.discard(job.id)
+
+    def _delete_job(self, job_id: str) -> None:
+        db = self._connect()
+        try:
+            db.execute("DELETE FROM jobs WHERE id = ? AND agent_name = ?", (job_id, self.agent_name))
+            db.commit()
+        except sqlite3.DatabaseError:
+            log.exception("[scheduler] delete failed for job %s", job_id)
+        finally:
+            db.close()
 
     def _claim_due_jobs(self, now: datetime) -> list[Job]:
         db = self._connect()
@@ -370,7 +424,9 @@ class LocalScheduler:
             return []
         finally:
             db.close()
-        return [_row_to_job(r) for r in rows]
+        # Skip jobs already firing — message/send blocks for the whole turn, so a
+        # slow turn would otherwise be re-claimed every tick and fire repeatedly.
+        return [j for j in (_row_to_job(r) for r in rows) if j.id not in self._inflight_ids]
 
     def _reschedule_or_delete(self, job: Job, *, fired_at: datetime) -> None:
         """Cron jobs roll forward; one-shot jobs are deleted."""
@@ -478,7 +534,7 @@ class LocalScheduler:
             },
         }
         try:
-            async with httpx.AsyncClient(timeout=30) as client:
+            async with httpx.AsyncClient(timeout=self._fire_timeout_s) as client:
                 r = await client.post(f"{self._invoke_url}/a2a", headers=headers, json=body)
             if r.status_code >= 400:
                 log.error(

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -486,3 +486,48 @@ async def test_schedule_task_dedupes_identical_jobs(tmp_path):
     r3 = await schedule.ainvoke({"prompt": "summarize logs", "when": "0 9 * * *"})
     assert "Scheduled job" in r3
     assert len(sched.list_jobs()) == 2
+
+
+@pytest.mark.asyncio
+async def test_slow_fire_not_refired_while_in_flight(tmp_path, monkeypatch):
+    """A scheduled turn that runs longer than the poll interval must fire ONCE.
+
+    message/send blocks until the turn is terminal, so a multi-tick turn would
+    otherwise be re-claimed every second and fire repeatedly (the duplicate
+    scheduled-turn / spam bug). The in-flight guard prevents re-claiming.
+    """
+    s = _make_scheduler(tmp_path)
+    past = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
+    s.add_job("SLOW", past, job_id="slow")  # one-shot, already due
+
+    calls: list[int] = []
+
+    class _SlowClient:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def post(self, url, headers=None, json=None):
+            calls.append(1)
+            await asyncio.sleep(2.2)  # turn spans multiple 1s poll ticks
+
+            class _R:
+                status_code = 200
+                text = "ok"
+
+            return _R()
+
+    import httpx
+    monkeypatch.setattr(httpx, "AsyncClient", _SlowClient)
+
+    await s.start()
+    await asyncio.sleep(2.8)  # several ticks elapse during the single slow turn
+    await s.stop()
+
+    assert len(calls) == 1          # fired once, not once-per-tick
+    assert s.list_jobs() == []      # one-shot deleted after the turn finally landed


### PR DESCRIPTION
**Audit finding — and the real root of the scheduled-task spam.**

`message/send` blocks until the agent turn is terminal (`a2a-sdk` `consume_and_break_on_interrupt`). The local scheduler fired with a **30s httpx timeout** and *leaves a failed fire in place to retry* — so any turn longer than 30s (a strategist loop doing web research easily is) timed out, was treated as failed, and **re-fired every tick (~30s)**. That's the `strategize-hourly`-4×-in-2-minutes pattern.

Fix:
- **Fire off the poll loop** (background task) — a multi-minute turn no longer stalls the 1s cadence or starves other due jobs.
- **In-flight guard** — a job being fired is excluded from re-claim, so a slow turn fires *once*, not once-per-tick.
- **Cron rolls forward at claim time** (can't re-fire mid-turn); one-shots settle when the fire lands (delete on success, keep for retry on genuine failure).
- **Generous, configurable timeout** — `SCHEDULER_FIRE_TIMEOUT_S` (default **600s**, was 30s).
- `stop()` drains in-flight fires (5s grace) then cancels stragglers.

Regression test: a 2.2s turn spanning several ticks fires exactly once; one-shot deleted after it lands. Suite **1228**; ruff clean.

(Pairs with #679's content-dedup — together they kill both causes of scheduled-task spam: duplicate *jobs* and duplicate *fires*.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)