### PR TITLE
feat(scheduler): per-job timezone (cron in a named IANA zone)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Scheduler: per-job timezone** — cron jobs can name an IANA timezone (e.g.
+  `America/Chicago`); `"0 9 * * *"` then means 9am local, DST-aware, stored as UTC.
+  Exposed via `schedule_task(timezone=…)`, the `/api/scheduler/jobs` API, and a timezone
+  picker in the console's Schedule modal (recurring jobs). Defaults to UTC; Workstacean
+  gets it natively.
+
 ### Fixed
 - **Scheduler: fix duplicate/runaway scheduled fires** — `message/send` blocks until the
   turn is terminal, so the old 30s fire timeout false-failed any longer turn and re-fired it

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -505,7 +505,7 @@ export const api = {
     return request<{ jobs: ScheduledJob[]; backend: string }>("/api/scheduler/jobs");
   },
 
-  addSchedule(body: { prompt: string; schedule: string; job_id?: string }) {
+  addSchedule(body: { prompt: string; schedule: string; job_id?: string; timezone?: string }) {
     return request<{ job: ScheduledJob }>("/api/scheduler/jobs", {
       method: "POST",
       body,

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -34,7 +34,7 @@ function ScheduleModal({
 }: {
   open: boolean;
   onClose: () => void;
-  onAdd: (body: { prompt: string; schedule: string; job_id?: string }) => void;
+  onAdd: (body: { prompt: string; schedule: string; job_id?: string; timezone?: string }) => void;
   busy: boolean;
 }) {
   const [mode, setMode] = useState<Mode>("once");
@@ -45,6 +45,14 @@ function ScheduleModal({
   const [cronRaw, setCronRaw] = useState("");
   const [prompt, setPrompt] = useState("");
   const [jobId, setJobId] = useState("");
+  const [tz, setTz] = useState("");  // "" = UTC; only meaningful for recurring (cron)
+  // Offer the operator's own zone + a few common ones; de-duped, browser zone first.
+  const tzOptions = useMemo(() => {
+    let local = "";
+    try { local = Intl.DateTimeFormat().resolvedOptions().timeZone || ""; } catch { /* ignore */ }
+    const common = ["America/New_York", "America/Chicago", "America/Denver", "America/Los_Angeles", "Europe/London", "Europe/Berlin", "Asia/Tokyo"];
+    return Array.from(new Set([local, ...common].filter(Boolean)));
+  }, []);
 
   const schedule = useMemo(() => {
     if (mode === "once") return buildOnce(onceAt);
@@ -128,8 +136,18 @@ function ScheduleModal({
           </label>
         )}
 
+        {mode !== "once" && (
+          <label className="field">
+            <span>Timezone</span>
+            <select value={tz} onChange={(e) => setTz(e.target.value)} data-testid="schedule-tz">
+              <option value="">UTC (default)</option>
+              {tzOptions.map((z) => <option key={z} value={z}>{z}</option>)}
+            </select>
+          </label>
+        )}
+
         <p className="schedule-preview" data-testid="schedule-preview">
-          {preview ? <>Runs <strong>{preview}</strong> <code>{schedule}</code></> : <span className="muted">Pick when it should run</span>}
+          {preview ? <>Runs <strong>{preview}</strong> <code>{schedule}</code>{mode !== "once" && tz ? <span className="muted"> · {tz}</span> : null}</> : <span className="muted">Pick when it should run</span>}
         </p>
 
         <label className="field">
@@ -145,7 +163,7 @@ function ScheduleModal({
         <div className="confirm-actions">
           <button type="button" className="secondary-button" onClick={onClose}>Cancel</button>
           <button type="button" className="primary-button" disabled={!canSubmit} data-testid="schedule-submit"
-                  onClick={() => onAdd({ prompt: prompt.trim(), schedule, job_id: jobId.trim() || undefined })}>
+                  onClick={() => onAdd({ prompt: prompt.trim(), schedule, job_id: jobId.trim() || undefined, timezone: mode !== "once" && tz ? tz : undefined })}>
             <Plus size={16} /> Schedule
           </button>
         </div>
@@ -164,7 +182,7 @@ function ScheduleBody() {
   const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.schedules });
 
   const add = useMutation({
-    mutationFn: (body: { prompt: string; schedule: string; job_id?: string }) => api.addSchedule(body),
+    mutationFn: (body: { prompt: string; schedule: string; job_id?: string; timezone?: string }) => api.addSchedule(body),
     onSuccess: () => setModalOpen(false),
     onSettled: invalidate,
   });

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -156,7 +156,8 @@ async def _operator_scheduler_add(req: dict) -> dict:
     if not schedule:
         raise ValueError("schedule is required")
     job = await asyncio.to_thread(
-        STATE.scheduler.add_job, prompt, schedule, job_id=req.get("job_id") or None
+        STATE.scheduler.add_job, prompt, schedule,
+        job_id=req.get("job_id") or None, timezone=req.get("timezone") or None,
     )
     return job.as_dict()
 

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -37,6 +37,7 @@ class ScheduleAddRequest(BaseModel):
     prompt: str
     schedule: str  # 5-field cron expression OR an ISO-8601 datetime
     job_id: str | None = None
+    timezone: str | None = None  # IANA tz for cron eval (None = UTC)
 
 
 class WorkflowRunRequest(BaseModel):

--- a/scheduler/interface.py
+++ b/scheduler/interface.py
@@ -33,6 +33,9 @@ class Job:
     created_at: str = field(default_factory=lambda: datetime.now(UTC).isoformat())
     next_fire: str | None = None        # ISO; None means "compute on save"
     last_fire: str | None = None
+    # IANA timezone the cron expression is evaluated in (e.g. "America/Chicago").
+    # None = UTC. Ignored for one-shot ISO schedules (those carry their own offset).
+    timezone: str | None = None
     enabled: bool = True
 
     def as_dict(self) -> dict[str, Any]:
@@ -49,11 +52,15 @@ class SchedulerBackend(Protocol):
 
     name: str  # short label for logs / agent-facing strings: "local", "workstacean"
 
-    def add_job(self, prompt: str, schedule: str, *, job_id: str | None = None) -> Job:
+    def add_job(
+        self, prompt: str, schedule: str, *, job_id: str | None = None,
+        timezone: str | None = None,
+    ) -> Job:
         """Persist a new job. Returns the stored ``Job`` (with
         backend-assigned id and next_fire if the caller didn't set them).
 
-        Raises ``ValueError`` for malformed schedule strings."""
+        ``timezone`` is an IANA name the cron expression is evaluated in
+        (None = UTC). Raises ``ValueError`` for malformed schedule/timezone."""
         ...
 
     def cancel_job(self, job_id: str) -> bool:

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -144,16 +144,29 @@ def _now_iso() -> str:
     return datetime.now(UTC).isoformat()
 
 
-def _compute_next_fire(schedule: str, *, after: datetime | None = None) -> str:
-    """Resolve a schedule string to the next ISO timestamp it fires.
+def _compute_next_fire(
+    schedule: str, *, after: datetime | None = None, tz: str | None = None,
+) -> str:
+    """Resolve a schedule string to the next ISO (UTC) timestamp it fires.
 
     ``after`` controls when "next" starts — current time by default;
     pass an explicit reference when rescheduling a cron job after a
-    fire so successive fires don't drift.
+    fire so successive fires don't drift. ``tz`` (IANA name) evaluates a
+    cron expression in that timezone — so ``"0 9 * * *"`` means 9am local,
+    handling DST — then normalizes the result to UTC for storage. Ignored
+    for one-shot ISO schedules (those carry their own offset).
     """
     after = after or datetime.now(UTC)
     if is_cron(schedule):
-        return croniter(schedule, after).get_next(datetime).astimezone(UTC).isoformat()
+        base = after
+        if tz:
+            from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
+
+            try:
+                base = after.astimezone(ZoneInfo(tz))
+            except (ZoneInfoNotFoundError, ValueError, KeyError) as exc:
+                raise ValueError(f"invalid timezone {tz!r}: {exc}") from exc
+        return croniter(schedule, base).get_next(datetime).astimezone(UTC).isoformat()
     return parse_iso_to_utc(schedule).isoformat()
 
 
@@ -166,7 +179,8 @@ CREATE TABLE IF NOT EXISTS jobs (
     next_fire   TEXT NOT NULL,
     last_fire   TEXT,
     enabled     INTEGER NOT NULL DEFAULT 1,
-    created_at  TEXT NOT NULL
+    created_at  TEXT NOT NULL,
+    timezone    TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_jobs_next_fire   ON jobs(next_fire);
@@ -231,6 +245,11 @@ class LocalScheduler:
         try:
             db = self._connect()
             db.executescript(_SCHEMA)
+            # Lightweight migration for stores created before per-job timezone.
+            try:
+                db.execute("ALTER TABLE jobs ADD COLUMN timezone TEXT")
+            except sqlite3.OperationalError:
+                pass  # column already present
             db.commit()
             db.close()
         except sqlite3.DatabaseError:
@@ -238,10 +257,14 @@ class LocalScheduler:
 
     # ── public API (matches SchedulerBackend) ───────────────────────────────
 
-    def add_job(self, prompt: str, schedule: str, *, job_id: str | None = None) -> Job:
+    def add_job(
+        self, prompt: str, schedule: str, *, job_id: str | None = None,
+        timezone: str | None = None,
+    ) -> Job:
         if not prompt or not prompt.strip():
             raise ValueError("scheduler: prompt is required")
-        next_fire = _compute_next_fire(schedule)  # raises ValueError for malformed input
+        # Computes in `timezone` for cron (raises ValueError for a bad tz or schedule).
+        next_fire = _compute_next_fire(schedule, tz=timezone)
 
         job = Job(
             id=job_id or self._generate_id(),
@@ -249,14 +272,15 @@ class LocalScheduler:
             schedule=schedule,
             agent_name=self.agent_name,
             next_fire=next_fire,
+            timezone=timezone,
         )
         db = self._connect()
         try:
             db.execute(
                 "INSERT INTO jobs (id, prompt, schedule, agent_name, next_fire, "
-                "last_fire, enabled, created_at) VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
+                "last_fire, enabled, created_at, timezone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (job.id, job.prompt, job.schedule, job.agent_name,
-                 job.next_fire, job.last_fire, int(job.enabled), job.created_at),
+                 job.next_fire, job.last_fire, int(job.enabled), job.created_at, job.timezone),
             )
             db.commit()
         except sqlite3.IntegrityError as exc:
@@ -433,7 +457,7 @@ class LocalScheduler:
         db = self._connect()
         try:
             if is_cron(job.schedule):
-                next_iso = _compute_next_fire(job.schedule, after=fired_at)
+                next_iso = _compute_next_fire(job.schedule, after=fired_at, tz=job.timezone)
                 db.execute(
                     "UPDATE jobs SET next_fire = ?, last_fire = ? WHERE id = ?",
                     (next_iso, fired_at.isoformat(), job.id),
@@ -467,7 +491,7 @@ class LocalScheduler:
             for row in rows:
                 job = _row_to_job(row)
                 if is_cron(job.schedule):
-                    next_iso = _compute_next_fire(job.schedule)
+                    next_iso = _compute_next_fire(job.schedule, tz=job.timezone)
                     db.execute(
                         "UPDATE jobs SET next_fire = ? WHERE id = ?",
                         (next_iso, job.id),
@@ -556,6 +580,7 @@ class LocalScheduler:
 
 
 def _row_to_job(row: Any) -> Job:
+    keys = row.keys()
     return Job(
         id=row["id"],
         prompt=row["prompt"],
@@ -565,4 +590,5 @@ def _row_to_job(row: Any) -> Job:
         last_fire=row["last_fire"],
         enabled=bool(row["enabled"]),
         created_at=row["created_at"],
+        timezone=row["timezone"] if "timezone" in keys else None,
     )

--- a/scheduler/workstacean.py
+++ b/scheduler/workstacean.py
@@ -68,7 +68,10 @@ class WorkstaceanScheduler:
 
     # ── public API ──────────────────────────────────────────────────────────
 
-    def add_job(self, prompt: str, schedule: str, *, job_id: str | None = None) -> Job:
+    def add_job(
+        self, prompt: str, schedule: str, *, job_id: str | None = None,
+        timezone: str | None = None,
+    ) -> Job:
         if not prompt or not prompt.strip():
             raise ValueError("scheduler: prompt is required")
         # Validate the schedule eagerly so a malformed expr fails at
@@ -89,6 +92,8 @@ class WorkstaceanScheduler:
                 "action": "add",
                 "id": normalized_id,
                 "schedule": schedule,
+                # Workstacean evaluates cron in this IANA tz (omitted → its default).
+                **({"timezone": timezone} if timezone else {}),
                 "topic": topic,
                 "payload": {
                     "content": prompt,
@@ -109,6 +114,7 @@ class WorkstaceanScheduler:
             schedule=schedule,
             agent_name=self.agent_name,
             next_fire=None,  # Workstacean owns the schedule state
+            timezone=timezone,
         )
 
     def cancel_job(self, job_id: str) -> bool:

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -531,3 +531,33 @@ async def test_slow_fire_not_refired_while_in_flight(tmp_path, monkeypatch):
 
     assert len(calls) == 1          # fired once, not once-per-tick
     assert s.list_jobs() == []      # one-shot deleted after the turn finally landed
+
+
+def test_per_job_timezone_evaluates_cron_in_that_zone(tmp_path):
+    """A cron with a timezone fires at local wall-clock time, stored as UTC."""
+    from zoneinfo import ZoneInfo
+
+    s = _make_scheduler(tmp_path)
+    job = s.add_job("noon in chicago", "0 12 * * *", job_id="tz", timezone="America/Chicago")
+    assert job.timezone == "America/Chicago"
+    # next_fire is stored UTC; converted back to Chicago it must be 12:00 local.
+    nf_local = datetime.fromisoformat(job.next_fire).astimezone(ZoneInfo("America/Chicago"))
+    assert nf_local.hour == 12 and nf_local.minute == 0
+    # Round-trips through the DB.
+    assert s.list_jobs()[0].timezone == "America/Chicago"
+
+
+def test_invalid_timezone_raises(tmp_path):
+    s = _make_scheduler(tmp_path)
+    with pytest.raises(ValueError, match="invalid timezone"):
+        s.add_job("x", "0 9 * * *", job_id="bad", timezone="Mars/Phobos")
+
+
+def test_no_timezone_defaults_to_utc(tmp_path):
+    from zoneinfo import ZoneInfo
+
+    s = _make_scheduler(tmp_path)
+    job = s.add_job("noon utc", "0 12 * * *", job_id="utc")
+    assert job.timezone is None
+    nf_utc = datetime.fromisoformat(job.next_fire).astimezone(ZoneInfo("UTC"))
+    assert nf_utc.hour == 12

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -540,6 +540,7 @@ def _build_scheduler_tools(scheduler) -> list:
         prompt: str,
         when: str,
         job_id: str | None = None,
+        timezone: str | None = None,
     ) -> str:
         """Schedule a future task. The agent receives ``prompt`` as a
         new turn when the schedule fires.
@@ -561,21 +562,26 @@ def _build_scheduler_tools(scheduler) -> list:
                 cannot infer "now" from training data.
             job_id: Optional human-readable id for the job. Auto-
                 generated if omitted; you'll need it later to cancel.
+            timezone: Optional IANA timezone (e.g. ``"America/Chicago"``)
+                the cron expression is evaluated in, handling DST — so
+                ``"0 9 * * *"`` means 9am local. Omit for UTC. Ignored
+                for one-shot ISO times (those carry their own offset).
 
         Returns ``"Scheduled job <id> next at <iso>."`` on success,
-        an error string on malformed ``when`` or backend failure.
+        an error string on malformed ``when`` / ``timezone`` or backend failure.
         """
         # Dedup guard: don't create a second job identical to an existing active
-        # one (same prompt + schedule). This is the common cause of scheduled-task
-        # spam — a loop that re-schedules itself on each run/restart accumulates
-        # duplicates that all fire together. (Remote backends may return [] here;
-        # then we skip the check and let the backend own dedup.)
+        # one (same prompt + schedule + timezone). This is the common cause of
+        # scheduled-task spam — a loop that re-schedules itself on each run/restart
+        # accumulates duplicates that all fire together. (Remote backends may return
+        # [] here; then we skip the check and let the backend own dedup.)
         try:
             for j in await asyncio.to_thread(scheduler.list_jobs):
                 if (
                     getattr(j, "enabled", True)
                     and (j.prompt or "").strip() == prompt.strip()
                     and j.schedule == when
+                    and (getattr(j, "timezone", None) or None) == (timezone or None)
                 ):
                     return (
                         f"Already scheduled as {j.id} (next at "
@@ -584,7 +590,7 @@ def _build_scheduler_tools(scheduler) -> list:
         except Exception:  # noqa: BLE001 — dedup is best-effort; never block scheduling
             pass
         try:
-            job = await asyncio.to_thread(scheduler.add_job, prompt, when, job_id=job_id)
+            job = await asyncio.to_thread(scheduler.add_job, prompt, when, job_id=job_id, timezone=timezone)
         except ValueError as exc:
             return f"Error: {exc}"
         except Exception as exc:  # noqa: BLE001


### PR DESCRIPTION
Adopted from the protoWorkstacean study (it has per-job tz natively). A cron job can declare an IANA timezone so `0 9 * * *` means **9am local, DST-aware** — not UTC-only.

- `_compute_next_fire` evaluates cron against a tz-aware base (`zoneinfo`), stores UTC; invalid tz → `ValueError`. `Job.timezone` added; jobs table migrates (guarded `ALTER`); add_job / reschedule / missed-fire recovery all honor it.
- `schedule_task(timezone=…)` + dedup keyed on (prompt, schedule, timezone).
- `/api/scheduler/jobs` accepts `timezone`; the console **Schedule modal gains a timezone picker** (recurring modes; offers your own zone + common zones; defaults to UTC).
- Workstacean adapter passes it through.

Tests: cron-in-zone → correct local wall-clock stored as UTC; invalid tz raises; no-tz = UTC. Suite **1231**, e2e **58**, ruff clean.

**On B (early-ack fire-and-forget): deliberately deferred** — #681 already decoupled firing from the poll loop and killed the actual bug, so B is low marginal value vs the risk of reworking the A2A firing path to `message/stream`. Flagged as a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)