### PR TITLE
feat(console): Agent section + editable Identity; Knowledge single panel; Settings→Overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Console IA: "Agent" section + editable identity; Knowledge simplified; Settings→Overview**
+  — renamed Runtime→**Agent** with tabs **Identity** (edit name + SOUL.md inline, save = hot
+  reload) · Tools · MCP · Subagents · **Skills** (moved from Knowledge) · **Middleware**. Knowledge
+  is now a single Store panel. The read-only status snapshot + Telemetry moved to a new
+  **Settings → Overview** tab.
+
 ### Added
 - **Scheduler: per-job timezone** — cron jobs can name an IANA timezone (e.g.
   `America/Chicago`); `"0 9 * * *"` then means 9am local, DST-aware, stored as UTC.

--- a/apps/web/e2e/knowledge.spec.ts
+++ b/apps/web/e2e/knowledge.spec.ts
@@ -1,14 +1,14 @@
 import { expect, test } from "@playwright/test";
 
-// Knowledge → Store (ADR 0020): a searchable window onto the agent's knowledge
-// base (findings, notes, daily-log). Lands as the default Knowledge sub-tab.
+// Knowledge: a searchable window onto the agent's knowledge base (findings,
+// notes, daily-log). A single panel — Skills moved to the Agent section.
 
 test("Knowledge lands on the searchable Store and lists chunks", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Knowledge" }).click();
 
   const surface = page.getByTestId("knowledge-store");
-  await expect(surface).toBeVisible(); // Store is the default sub-tab
+  await expect(surface).toBeVisible(); // single Store panel
   await expect(surface.getByRole("heading", { name: "Knowledge" })).toBeVisible();
 
   // The mocked chunks render with their content + domain badges.
@@ -18,15 +18,4 @@ test("Knowledge lands on the searchable Store and lists chunks", async ({ page }
 
   // The search box is present (server-side FTS; the mock returns the fixture).
   await expect(surface.getByPlaceholder(/Search the knowledge base/)).toBeVisible();
-});
-
-test("Knowledge sub-nav switches between Store and Skills", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "Knowledge" }).click();
-
-  await expect(page.getByTestId("knowledge-store")).toBeVisible();
-  await page.locator(".stage-subnav").getByRole("button", { name: "Skills", exact: true }).click();
-  await expect(page.getByTestId("playbooks-surface")).toBeVisible();
-  await page.locator(".stage-subnav").getByRole("button", { name: "Store", exact: true }).click();
-  await expect(page.getByTestId("knowledge-store")).toBeVisible();
 });

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -78,6 +78,11 @@ function handleApiGet(pathname) {
   switch (pathname) {
     case "/api/runtime/status":
       return RUNTIME_STATUS;
+    case "/api/config":
+      return {
+        config: { identity: { name: "mock-agent", operator: "" } },
+        soul: "# Mock agent\nYou are a helpful test agent.",
+      };
     case "/api/subagents":
       return { subagents: SUBAGENTS };
     case "/api/tools":

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -44,10 +44,10 @@ test("beads tab in the right sidebar lists issues (query-backed)", async ({ page
   await expect(page.getByText("Wire the telemetry rollup")).toBeVisible();
 });
 
-test("runtime surface: overview, tools, and MCP tabs", async ({ page }) => {
-  await page.getByRole("button", { name: "Runtime", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Runtime" })).toBeVisible();
-  await expect(page.getByText("SKILL.md skills loaded")).toBeVisible(); // overview
+test("agent surface: identity lands, then tools and MCP tabs", async ({ page }) => {
+  await page.locator(".rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible(); // landing tab
+  await expect(page.getByTestId("identity-name")).toBeVisible();
 
   await page.locator(".stage-subnav").getByRole("button", { name: "Tools", exact: true }).click();
   await expect(page.getByText("web_search")).toBeVisible();

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -3,10 +3,10 @@ import { expect, test } from "@playwright/test";
 // The Knowledge ▸ Playbooks surface (ADR 0009) browses the skill index:
 // pinned (SKILL.md) vs learned (agent-emitted), with search + delete-with-confirm.
 
-test("Knowledge → Playbooks lists pinned + learned skills and supports search", async ({ page }) => {
+test("Agent → Skills lists pinned + learned skills and supports search", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "Knowledge" }).click();
-  // Knowledge lands on Store now (ADR 0020) — switch to the Playbooks sub-tab.
+  await page.locator(".rail").getByRole("button", { name: "Agent", exact: true }).click();
+  // Skills moved under the Agent section — switch to the Skills tab.
   await page.locator(".stage-subnav").getByRole("button", { name: "Skills", exact: true }).click();
 
   const surface = page.getByTestId("playbooks-surface");
@@ -26,7 +26,7 @@ test("Knowledge → Playbooks lists pinned + learned skills and supports search"
 
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "Knowledge" }).click();
+  await page.locator(".rail").getByRole("button", { name: "Agent", exact: true }).click();
   await page.locator(".stage-subnav").getByRole("button", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -15,17 +15,21 @@ async function category(page, name) {
   await page.locator(".stage-subnav").getByRole("button", { name, exact: true }).click();
 }
 
-test("groups are organized into a category sub-nav; Agent leads", async ({ page }) => {
+test("category sub-nav leads with Overview; Agent shows Model + Routing", async ({ page }) => {
   await openSettings(page);
-  // Category sub-nav from the mock schema: Agent · Behavior · System, plus
-  // Integrations (surfaced because the delegates plugin is reachable — ADR 0025).
+  // Overview leads (status + telemetry, moved from the old Runtime section), then
+  // the schema categories: Agent · Behavior · System, plus Integrations (delegates).
   expect(await page.locator(".stage-subnav button").allTextContents()).toEqual([
+    "Overview",
     "Agent",
     "Behavior",
     "System",
     "Integrations",
   ]);
-  // Agent is the default — only its sections show (Model + Routing), not System's.
+  // Overview is the default — the read-only status panel, not schema groups.
+  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible();
+  // Agent's sections (Model + Routing) appear when you switch to it.
+  await category(page, "Agent");
   expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Model", "Routing"]);
   const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
   await expect(aux).toHaveValue("protolabs/fast");
@@ -48,7 +52,8 @@ test("editing enables save and round-trips", async ({ page }) => {
   const save = page.getByRole("button", { name: /Save & apply/ });
   await expect(save).toBeDisabled(); // nothing dirty yet
 
-  const aux = page.locator('.setting-row[data-key="routing.aux_model"] input'); // Agent (default)
+  await category(page, "Agent");  // Overview leads now; Model/Routing live under Agent
+  const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
   await aux.fill("protolabs/turbo");
   await expect(save).toBeEnabled();
   await save.click();

--- a/apps/web/e2e/telemetry.spec.ts
+++ b/apps/web/e2e/telemetry.spec.ts
@@ -3,12 +3,12 @@ import { expect, test } from "@playwright/test";
 // The System ▸ Telemetry tab renders the per-turn rollups from
 // /api/telemetry/* (ADR 0006 Slice 3): summary cards + a recent-turns table.
 
-test("Runtime → Telemetry shows summary cards and recent turns", async ({ page }) => {
+test("Settings → Overview shows the telemetry summary cards and recent turns", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Into Runtime, then the Telemetry sub-tab.
-  await page.locator(".rail").getByRole("button", { name: "Runtime", exact: true }).click();
-  await page.locator(".stage-subnav").getByRole("button", { name: "Telemetry", exact: true }).click();
+  // Telemetry moved under Settings → Overview (the read-only status + telemetry).
+  await page.locator(".rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".stage-subnav").getByRole("button", { name: "Overview", exact: true }).click();
 
   const surface = page.getByTestId("telemetry-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/src/agent/IdentityPanel.tsx
+++ b/apps/web/src/agent/IdentityPanel.tsx
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useEffect, useState } from "react";
+import { Save } from "lucide-react";
+
+import { PanelHeader } from "../app/PanelHeader";
+import { api } from "../lib/api";
+import { queryKeys } from "../lib/queries";
+
+// Agent → Identity: who this agent is. Edit the name + SOUL.md (persona) inline;
+// saving merges the name into config, writes SOUL.md, and hot-reloads the graph
+// (POST /api/config). Distinct from the read-only status snapshot in Settings → Overview.
+
+export function IdentityPanel() {
+  const qc = useQueryClient();
+  const { data, isLoading } = useQuery({ queryKey: ["config"], queryFn: () => api.config() });
+
+  const [name, setName] = useState("");
+  const [soul, setSoul] = useState("");
+  const [seeded, setSeeded] = useState(false);
+
+  useEffect(() => {
+    if (data && !seeded) {
+      setName(data.config?.identity?.name || "");
+      setSoul(data.soul || "");
+      setSeeded(true);
+    }
+  }, [data, seeded]);
+
+  const baseName = data?.config?.identity?.name || "";
+  const baseSoul = data?.soul || "";
+  const dirty = seeded && (name !== baseName || soul !== baseSoul);
+
+  const save = useMutation({
+    mutationFn: () =>
+      api.applyConfig(
+        { identity: { name: name.trim(), operator: data?.config?.identity?.operator ?? "" } },
+        soul,
+      ),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["config"] });
+      qc.invalidateQueries({ queryKey: queryKeys.runtime });
+    },
+  });
+
+  return (
+    <section className="panel stage-panel">
+      <PanelHeader
+        title="Identity"
+        kicker="who this agent is — its name and persona (SOUL.md)"
+        actions={
+          <button
+            className="primary-button"
+            type="button"
+            disabled={!dirty || save.isPending}
+            onClick={() => save.mutate()}
+            data-testid="identity-save"
+          >
+            <Save size={15} /> {save.isPending ? "Saving…" : "Save & reload"}
+          </button>
+        }
+      />
+      <div className="stage-body">
+        {isLoading || !seeded ? (
+          <p className="muted">Loading…</p>
+        ) : (
+          <>
+            <label className="field">
+              <span>Agent name</span>
+              <input value={name} onChange={(e) => setName(e.target.value)} placeholder="my-agent" data-testid="identity-name" />
+            </label>
+            <label className="field">
+              <span>SOUL.md — the agent's persona &amp; system identity</span>
+              <textarea
+                value={soul}
+                onChange={(e) => setSoul(e.target.value)}
+                rows={22}
+                spellCheck={false}
+                placeholder="# You are …"
+                data-testid="identity-soul"
+                style={{ fontFamily: "var(--font-mono, monospace)", fontSize: "13px", lineHeight: 1.5, width: "100%" }}
+              />
+            </label>
+            {save.isError ? <p className="error-strip" role="alert">Save failed — check the server log.</p> : null}
+            {save.isSuccess && !dirty ? <p className="muted">Saved — agent reloaded.</p> : null}
+            <p className="muted" style={{ fontSize: "12px" }}>
+              Saving writes SOUL.md + config and hot-reloads the agent. The name updates the A2A card and console.
+            </p>
+          </>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -70,7 +70,6 @@ import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
-import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
@@ -83,10 +82,11 @@ import { StatusPill } from "./StatusPill";
 import { GoalsPanel } from "./GoalsPanel";
 import { BeadsPanel } from "./BeadsPanel";
 import { SchedulePanel } from "../schedule/SchedulePanel";
-import { RuntimePanel } from "./RuntimePanel";
+import { IdentityPanel } from "../agent/IdentityPanel";
 import { ToolsPanel } from "./ToolsPanel";
 import { McpPanel } from "./McpPanel";
 import { SubagentsPanel } from "./SubagentsPanel";
+import { MiddlewarePanel } from "./MiddlewarePanel";
 import { PluginsSurface } from "../plugins/PluginsSurface";
 import { SetupWizard } from "../setup/SetupWizard";
 import { runtimeStatusQuery } from "../lib/queries";
@@ -96,7 +96,7 @@ import { runtimeStatusQuery } from "../lib/queries";
 // Core surfaces are the fixed literals; plugin views (ADR 0026) add dynamic
 // surfaces keyed `plugin:<pluginId>:<viewId>`. The `(string & {})` keeps literal
 // autocomplete while allowing those runtime keys.
-type Surface = "chat" | "activity" | "studio" | "knowledge" | "runtime" | "plugins" | "settings" | (string & {});
+type Surface = "chat" | "activity" | "studio" | "knowledge" | "agent" | "plugins" | "settings" | (string & {});
 
 // A plugin view names its rail glyph by lucide icon name. The curated set below
 // is the common-case fast path (already bundled); anything else falls back to the
@@ -158,13 +158,13 @@ function pluginViewIcon(name?: string): ReactNode {
 // Studio = the workflow authoring/inspection surface. Per ADR 0020 execution is
 // a chat gesture (run subagents/workflows via /<name>), not a surface — so the
 // old "Run" tab is gone and Studio is just Workflows.
-type RuntimeTab = "overview" | "tools" | "mcp" | "subagents" | "telemetry";
+// Agent = the agent's own makeup: its identity (name + SOUL.md), tools, MCP
+// servers, subagents, skills, and middleware. (Runtime status + telemetry moved
+// to Settings → Overview.)
+type AgentTab = "identity" | "tools" | "mcp" | "subagents" | "skills" | "middleware";
 // Activity = the "triggers / events" surface (ADR 0009): what happened (thread),
 // inbound (inbox), and timed (schedule — cron is a trigger, not a work-type).
 type ActivityTab = "thread" | "inbox";
-// Knowledge = what the agent knows (ADR 0020): the searchable knowledge Store
-// (factual memory) + Playbooks (procedural memory). Store leads.
-type KnowledgeTab = "store" | "playbooks";
 // The agent's persistent working memory, grouped in the right sidebar:
 // its notebook, its task board, and its goals.
 type RightPanel = "notes" | "beads" | "goals" | "schedule";
@@ -211,9 +211,8 @@ export function App() {
   // Background-streaming indicator for the Chat rail (narrow selector → only
   // re-renders when the boolean flips, not per token).
   const chatStreaming = useAnyChatStreaming();
-  const [runtimeTab, setRuntimeTab] = useState<RuntimeTab>("overview");
+  const [agentTab, setAgentTab] = useState<AgentTab>("identity");
   const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
-  const [knowledgeTab, setKnowledgeTab] = useState<KnowledgeTab>("store");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
   // Collapsible/resizable right panel (persisted). Flag is "1"/"" string; width
   // is a px string clamped on read.
@@ -674,10 +673,10 @@ export function App() {
             onClick={() => setSurface("knowledge")}
           />
           <RailButton
-            active={surface === "runtime"}
-            label="Runtime"
-            icon={<Gauge size={18} />}
-            onClick={() => setSurface("runtime")}
+            active={surface === "agent"}
+            label="Agent"
+            icon={<Bot size={18} />}
+            onClick={() => setSurface("agent")}
           />
           <RailButton
             active={surface === "plugins"}
@@ -729,27 +728,17 @@ export function App() {
               ]}
             />
           ) : null}
-          {surface === "knowledge" ? (
-            // Store (factual memory) + Skills (procedural memory) — ADR 0020.
+          {surface === "agent" ? (
             <StageSubnav
-              active={knowledgeTab}
-              onSelect={(id) => setKnowledgeTab(id as typeof knowledgeTab)}
+              active={agentTab}
+              onSelect={(id) => setAgentTab(id as typeof agentTab)}
               tabs={[
-                { id: "store", label: "Store", icon: Database },
-                { id: "playbooks", label: "Skills", icon: BookMarked },
-              ]}
-            />
-          ) : null}
-          {surface === "runtime" ? (
-            <StageSubnav
-              active={runtimeTab}
-              onSelect={(id) => setRuntimeTab(id as typeof runtimeTab)}
-              tabs={[
-                { id: "overview", label: "Overview", icon: Gauge },
+                { id: "identity", label: "Identity", icon: Sparkles },
                 { id: "tools", label: "Tools", icon: Wrench },
                 { id: "mcp", label: "MCP", icon: Plug },
                 { id: "subagents", label: "Subagents", icon: Bot },
-                { id: "telemetry", label: "Telemetry", icon: BarChart3 },
+                { id: "skills", label: "Skills", icon: BookMarked },
+                { id: "middleware", label: "Middleware", icon: Layers },
               ]}
             />
           ) : null}
@@ -765,14 +754,14 @@ export function App() {
           {surface === "activity" && activityTab === "inbox" ? <InboxPanel /> : null}
 
 
-          {surface === "runtime" && runtimeTab === "overview" ? <RuntimePanel /> : null}
-          {surface === "runtime" && runtimeTab === "tools" ? <ToolsPanel /> : null}
-          {surface === "runtime" && runtimeTab === "mcp" ? <McpPanel /> : null}
-          {surface === "runtime" && runtimeTab === "subagents" ? <SubagentsPanel /> : null}
-          {surface === "runtime" && runtimeTab === "telemetry" ? <TelemetrySurface /> : null}
+          {surface === "agent" && agentTab === "identity" ? <IdentityPanel /> : null}
+          {surface === "agent" && agentTab === "tools" ? <ToolsPanel /> : null}
+          {surface === "agent" && agentTab === "mcp" ? <McpPanel /> : null}
+          {surface === "agent" && agentTab === "subagents" ? <SubagentsPanel /> : null}
+          {surface === "agent" && agentTab === "skills" ? <PlaybooksSurface onError={setError} /> : null}
+          {surface === "agent" && agentTab === "middleware" ? <MiddlewarePanel /> : null}
           {surface === "plugins" ? <PluginsSurface /> : null}
-          {surface === "knowledge" && knowledgeTab === "store" ? <KnowledgeStore onError={setError} /> : null}
-          {surface === "knowledge" && knowledgeTab === "playbooks" ? <PlaybooksSurface onError={setError} /> : null}
+          {surface === "knowledge" ? <KnowledgeStore onError={setError} /> : null}
           {surface === "settings" ? <SettingsSurface /> : null}
 
           {/* Plugin view (ADR 0026) — the plugin serves the page; PluginView hosts

--- a/apps/web/src/app/MiddlewarePanel.tsx
+++ b/apps/web/src/app/MiddlewarePanel.tsx
@@ -1,0 +1,48 @@
+import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense } from "react";
+
+import { PanelHeader } from "./PanelHeader";
+import { runtimeStatusQuery } from "../lib/queries";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
+import { StatusPill } from "./StatusPill";
+
+// Agent → Middleware: the graph middleware wired into each turn (knowledge,
+// memory, audit, compaction, …) and whether each is on.
+
+function MiddlewareBody() {
+  const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
+  const middleware = Object.entries(runtime.middleware).sort(([a], [b]) => a.localeCompare(b));
+  const on = middleware.filter(([, v]) => v).length;
+
+  return (
+    <>
+      <PanelHeader title="Middleware" kicker={`${on}/${middleware.length} enabled`} />
+      <div className="stage-body">
+        <div className="table-list">
+          {middleware.map(([name, enabled]) => (
+            <div className="table-row" key={name}>
+              <span>{name}</span>
+              <StatusPill label={enabled ? "on" : "off"} tone={enabled ? "success" : "muted"} />
+            </div>
+          ))}
+        </div>
+      </div>
+    </>
+  );
+}
+
+export function MiddlewarePanel() {
+  return (
+    <section className="panel stage-panel">
+      <QueryErrorResetBoundary>
+        {({ reset }) => (
+          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="middleware" />}>
+            <Suspense fallback={<PanelSkeleton label="Loading middleware…" />}>
+              <MiddlewareBody />
+            </Suspense>
+          </ErrorBoundary>
+        )}
+      </QueryErrorResetBoundary>
+    </section>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -464,6 +464,16 @@ export const api = {
     });
   },
 
+  // Merge-apply a config patch (+ optional SOUL.md) on the live agent, then reload.
+  // Partial config is merged into the live YAML (not a replace), so passing just
+  // `{ identity: { name } }` is safe. Pass null to skip either.
+  applyConfig(config: Partial<AgentConfig> | null, soul: string | null) {
+    return request<{ ok: boolean; messages: string[] }>("/api/config", {
+      method: "POST",
+      body: { config, soul },
+    });
+  },
+
   subagents() {
     return request<{ subagents: Subagent[] }>("/api/subagents");
   },

--- a/apps/web/src/settings/OverviewPanel.tsx
+++ b/apps/web/src/settings/OverviewPanel.tsx
@@ -3,19 +3,14 @@ import { Bot, Database, HardDrive, Settings2, Sparkles } from "lucide-react";
 import { Suspense, type ReactNode } from "react";
 
 import { brandName } from "../lib/brand";
-import { PanelHeader } from "./PanelHeader";
+import { PanelHeader } from "../app/PanelHeader";
 import { runtimeStatusQuery } from "../lib/queries";
-import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
-import { StatusPill } from "./StatusPill";
+import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
+import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 
-// Runtime → Overview: the agent's configured surface at a glance (model,
-// middleware, storage, skills). Tools / MCP / Subagents are their own tabs.
-// On the TanStack Query data layer (ADR 0013) via useSuspenseQuery on the same
-// `runtime` key the shell reads non-suspense.
-
-function formatBool(value: boolean) {
-  return value ? "on" : "off";
-}
+// Settings → Overview: the agent's read-only status at a glance (model, knowledge,
+// goal, on-disk store sizes) plus the cost/latency telemetry dashboard. The editable
+// bits (name, persona, middleware, tools) live under the Agent section.
 
 function fmtBytes(n: number | null | undefined): string {
   if (n == null) return "—";
@@ -40,23 +35,17 @@ function Metric({ icon, label, value }: { icon: ReactNode; label: string; value:
   );
 }
 
-function RuntimeBody() {
+function StatusBody() {
   const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
-  const middleware = Object.entries(runtime.middleware).sort(([a], [b]) => a.localeCompare(b));
-
   return (
     <>
-      <PanelHeader
-        title="Runtime"
-        kicker={runtime.model?.name || "model not configured"}
-        actions={<StatusPill label={runtime.scheduler.backend || "scheduler"} tone="muted" />}
-      />
+      <PanelHeader title="Overview" kicker={runtime.model?.name || "model not configured"} />
       <div className="stage-body">
         <div className="metric-grid">
           <Metric icon={<Bot size={16} />} label="Agent" value={brandName(runtime.identity?.name)} />
           <Metric icon={<Settings2 size={16} />} label="Provider" value={runtime.model?.provider || "none"} />
           <Metric icon={<Database size={16} />} label="Knowledge" value={runtime.knowledge.resolved_path || runtime.knowledge.configured_path || "disabled"} />
-          <Metric icon={<Sparkles size={16} />} label="Goal mode" value={formatBool(Boolean(runtime.goal.enabled))} />
+          <Metric icon={<Sparkles size={16} />} label="Goal mode" value={runtime.goal.enabled ? "on" : "off"} />
         </div>
         {runtime.storage ? (
           <>
@@ -71,43 +60,26 @@ function RuntimeBody() {
             </div>
           </>
         ) : null}
-        <p className="panel-kicker">Middleware</p>
-        <div className="table-list">
-          {middleware.map(([name, enabled]) => (
-            <div className="table-row" key={name}>
-              <span>{name}</span>
-              <StatusPill label={formatBool(enabled)} tone={enabled ? "success" : "muted"} />
-            </div>
-          ))}
-        </div>
-
-        <p className="panel-kicker">Skills</p>
-        <div className="table-list">
-          <div className="table-row">
-            <span>SKILL.md skills loaded</span>
-            <StatusPill
-              label={`${runtime.skills?.count ?? 0}`}
-              tone={(runtime.skills?.count ?? 0) > 0 ? "success" : "muted"}
-            />
-          </div>
-        </div>
       </div>
     </>
   );
 }
 
-export function RuntimePanel() {
+export function OverviewPanel() {
   return (
-    <section className="panel stage-panel">
-      <QueryErrorResetBoundary>
-        {({ reset }) => (
-          <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="runtime" />}>
-            <Suspense fallback={<PanelSkeleton label="Loading runtime…" />}>
-              <RuntimeBody />
-            </Suspense>
-          </ErrorBoundary>
-        )}
-      </QueryErrorResetBoundary>
-    </section>
+    <>
+      <section className="panel stage-panel">
+        <QueryErrorResetBoundary>
+          {({ reset }) => (
+            <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="overview" />}>
+              <Suspense fallback={<PanelSkeleton label="Loading overview…" />}>
+                <StatusBody />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
+      </section>
+      <TelemetrySurface />
+    </>
   );
 }

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -14,6 +14,7 @@ import { api } from "../lib/api";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
 import type { SettingsField, SettingsGroup } from "../lib/types";
 import { DelegatesSection } from "./DelegatesSection";
+import { OverviewPanel } from "./OverviewPanel";
 
 // Generic settings surface — renders whatever GET /api/settings/schema returns,
 // so it stays in sync as config grows. Saving POSTs the changed fields and the
@@ -62,7 +63,9 @@ function SettingsBody() {
   // Category sub-nav (ADR 0020): the server tags each group with a category and
   // orders them, so we derive the ordered category list by first appearance.
   const categories = useMemo(() => {
-    const seen: string[] = [];
+    // Overview leads — the read-only status snapshot + telemetry (moved here from
+    // the old Runtime section).
+    const seen: string[] = ["Overview"];
     for (const g of groups) {
       const c = g.category || "Integrations";
       if (!seen.includes(c)) seen.push(c);
@@ -303,6 +306,9 @@ function SettingsBody() {
           </section>
         ))}
 
+        {/* Overview (read-only status snapshot + telemetry) — moved here from the
+            old Runtime section; not part of the settings schema. */}
+        {category === "Overview" ? <OverviewPanel /> : null}
         {/* The delegate registry (ADR 0025) isn't part of the settings schema —
             it's a CRUD surface, rendered as a custom panel under Integrations. */}
         {category === "Integrations" ? <DelegatesSection /> : null}


### PR DESCRIPTION
Reshapes the console IA per the latest direction — the agent's own makeup in one place, read-only status under Settings.

- **Runtime → Agent** section. Tabs: **Identity** (new — edit agent name + SOUL.md inline; save merge-applies via `/api/config` and hot-reloads) · Tools · MCP · Subagents · **Skills** (moved from Knowledge) · **Middleware** (extracted from the old overview).
- **Knowledge** → a single Store panel (sub-nav gone; Skills now lives under Agent).
- **Settings → Overview** (new, leads the categories) = the read-only status snapshot (model / knowledge / goal / on-disk sizes) **+ the Telemetry dashboard**, both moved out of Runtime.
- New `IdentityPanel` / `MiddlewarePanel` / `settings/OverviewPanel`; `RuntimePanel` removed. `api.applyConfig()` merge-applies name+soul (confirmed `apply_updates_to_yaml` merges, so saving just name+soul is safe).

e2e reworked (agent surface, telemetry under Settings→Overview, knowledge single panel, skills under Agent, settings Overview-leads); `/api/config` mocked. Web build (tsc) + **full e2e 57/57** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)