### PR TITLE
fix(goals): scope the goal store by PROTOAGENT_INSTANCE (cross-agent leak)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Goals no longer leak between agents** — the goal store wasn't instance-scoped, so two
+  agents on one machine shared `/sandbox/goals` and collided on shared session ids (e.g. the
+  `system:activity` thread used by scheduled turns). Now namespaced by `PROTOAGENT_INSTANCE`
+  (ADR 0004), matching the memory/knowledge/scheduler stores.
+
 ### Changed
 - **Console IA: "Agent" section + editable identity; Knowledge simplified; Settings→Overview**
   — renamed Runtime→**Agent** with tabs **Identity** (edit name + SOUL.md inline, save = hot

--- a/graph/goals/store.py
+++ b/graph/goals/store.py
@@ -21,13 +21,20 @@ log = logging.getLogger(__name__)
 
 
 def _resolve_base() -> Path:
+    # Per-instance scoping (ADR 0004): namespace by PROTOAGENT_INSTANCE so two
+    # agents on one machine don't share a goals dir — without this, scheduled /
+    # activity turns (shared session id "system:activity") collide and goals leak
+    # across agents. No-op when PROTOAGENT_INSTANCE is unset (single instance).
+    from paths import scope_leaf
+
     candidates = []
     env = os.environ.get("GOAL_PATH", "").strip()
     if env:
         candidates.append(Path(env))
     candidates.append(Path("/sandbox/goals"))
     candidates.append(Path.home() / ".protoagent" / "goals")
-    for path in candidates:
+    for raw in candidates:
+        path = scope_leaf(raw)
         try:
             path.mkdir(parents=True, exist_ok=True)
             # confirm writable
@@ -38,7 +45,7 @@ def _resolve_base() -> Path:
         except OSError:
             continue
     # Last resort: a temp dir (keeps the server alive even if nothing is writable).
-    fallback = Path(tempfile.gettempdir()) / "protoagent_goals"
+    fallback = scope_leaf(Path(tempfile.gettempdir()) / "protoagent_goals")
     fallback.mkdir(parents=True, exist_ok=True)
     return fallback
 

--- a/tests/test_goal_store.py
+++ b/tests/test_goal_store.py
@@ -62,3 +62,24 @@ def test_all_empty_and_skips_corrupt(tmp_path):
     (tmp_path / "broken.json").write_text("{ not json")  # must be skipped, not raise
     states = store.all()
     assert [s.session_id for s in states] == ["ok"]
+
+
+def test_resolve_base_is_instance_scoped(monkeypatch, tmp_path):
+    """Two agents on one machine must not share a goals dir (ADR 0004) — else
+    scheduled/activity turns (shared session id) collide and goals leak across
+    agents. _resolve_base namespaces by PROTOAGENT_INSTANCE."""
+    from graph.goals import store as goal_store
+
+    monkeypatch.setenv("GOAL_PATH", str(tmp_path))
+
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "alpha")
+    base_a = goal_store._resolve_base()
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "beta")
+    base_b = goal_store._resolve_base()
+    assert base_a != base_b
+    assert base_a.name == tmp_path.name and base_a.parent.name == "alpha"
+    assert base_b.parent.name == "beta"
+
+    # No instance id → unscoped (single-instance back-compat).
+    monkeypatch.delenv("PROTOAGENT_INSTANCE", raising=False)
+    assert goal_store._resolve_base() == tmp_path


### PR DESCRIPTION
**Data-isolation bug.** The goal store's `_resolve_base()` never applied `scope_leaf` (ADR 0004) the way the memory / knowledge / scheduler stores do — so every agent on one machine shared `/sandbox/goals`. Because scheduled + activity turns use a shared session id (`system:activity`), agent A's goal file collided with agent B's → **goals leaked between agents**.

Fix: namespace the base by `PROTOAGENT_INSTANCE` (no-op when unset, so single-instance is unchanged).

Test: two instance ids → distinct bases; unset → unscoped. ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)