### PR TITLE
fix(console): chat tabs open right; favicon renders in the tab

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Chat tabs open to the right** — a new chat tab is appended (right) instead of prepended.
+- **Favicon renders in the browser tab** — the console favicon link was missing
+  `type="image/svg+xml"` and used a base-relative href that 404'd at `/app` (no trailing
+  slash); now an absolute `%BASE_URL%` path + the type, with the type added to the docs link
+  too. Art unchanged (the protoLabs outline mark).
+
 ### Changed
 - **Console IA: "Agent" section + editable identity; Knowledge simplified; Settings→Overview**
   — renamed Runtime→**Agent** with tabs **Identity** (edit name + SOUL.md inline, save = hot

--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="color-scheme" content="dark" />
-    <link rel="icon" href="protolabs-icon-outline.svg" />
+    <link rel="icon" type="image/svg+xml" href="%BASE_URL%protolabs-icon-outline.svg" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -126,7 +126,8 @@ export const chatStore = {
   createSession() {
     const session = createSession();
     setState((current) => {
-      const sessions = [session, ...current.sessions].slice(0, MAX_SESSIONS);
+      // New tabs append to the RIGHT; cap at MAX_SESSIONS by dropping the oldest (left).
+      const sessions = [...current.sessions, session].slice(-MAX_SESSIONS);
       return {
         ...current,
         sessions,

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -23,7 +23,7 @@ export default defineConfig({
   srcExclude: ["dev/**"],
 
   head: [
-    ["link", { rel: "icon", href: `${base}favicon.svg` }],
+    ["link", { rel: "icon", type: "image/svg+xml", href: `${base}favicon.svg` }],
     // Social cards — canonical absolute image (the dark protoAgent banner) so it
     // resolves regardless of which base the build serves under.
     ["meta", { property: "og:type", content: "website" }],


### PR DESCRIPTION
Two fixes:

- **Chat tabs open to the right** — a new session is appended to the tab strip (was prepended/left); the cap drops the oldest tab, not the newest.
- **Favicon renders in the tab** — the console `<link rel="icon">` was missing `type="image/svg+xml"` **and** used a base-relative href that 404s at `/app` (no trailing slash) under Vite `base: "/app/"`. Now an absolute `%BASE_URL%protolabs-icon-outline.svg` + the type (built → `/app/protolabs-icon-outline.svg`); added the type to the docs favicon link too. **Art unchanged** — the protoLabs outline mark (the filled square is outdated). Forks pick this up on their next template sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)