### PR TITLE
feat(plugins): pluggable middleware + per-request metadata (ADR 0032)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Pluggable middleware** (ADR 0032) — plugins contribute LangGraph `AgentMiddleware` via
+  `register_middleware(factory)` (appended just before message-capture), and per-request A2A
+  metadata is exposed to middleware through `current_request_metadata()` (a per-turn contextvar).
+  Middleware was the last core extension point that forced a fork to edit core — a per-turn
+  directive (e.g. roxy's project-scope banner) is now a ~15-line plugin with zero core edits.
+
 ### Fixed
 - **Chat tabs open to the right** — a new chat tab is appended (right) instead of prepended.
 - **Favicon renders in the browser tab** — the console favicon link was missing

--- a/docs/adr/0032-pluggable-middleware.md
+++ b/docs/adr/0032-pluggable-middleware.md
@@ -1,0 +1,53 @@
+# ADR 0032 — Pluggable middleware
+
+**Status:** Accepted
+
+## Context
+
+Middleware was the **last core extension point a fork still had to edit core to use**.
+The agent's per-turn hook layer — `before_model` / `after_model` / `wrap_tool_call`
+(LangGraph `AgentMiddleware`) — is assembled as a static list in
+`graph/agent.py::_build_middleware` (prompt-cache, knowledge, enforcement, deferral,
+audit, memory, ingest, compaction, model-fallback, message-capture). Everything else a
+fork needs is plugin-contributable (tools, subagents, MCP servers, knowledge backends,
+goal verifiers, …), but a fork that wanted a custom per-turn behavior had to patch
+`graph/agent.py` or `a2a_executor.py`.
+
+Concretely: **roxy** (the canonical operator fork) carried a core edit in
+`a2a_executor.py` — a project-**scope banner** that reads the A2A request metadata and
+injects a per-turn directive. That kept roxy from being a pure-plugin fork.
+
+Two gaps blocked closing it: (1) no `register_middleware`, and (2) per-request metadata
+stopped at `_chat_langgraph_stream` — it never reached middleware.
+
+## Decision
+
+1. **`registry.register_middleware(factory)`** — a plugin contributes a LangGraph
+   `AgentMiddleware`. `factory(config) -> AgentMiddleware | None` (mirrors
+   `register_knowledge_store` / `register_embedder`); returning `None` opts out. The
+   loader collects factories into `PluginLoadResult.middleware`; `agent_init` resolves
+   them to instances (best-effort — a raising/None factory is skipped + logged) and
+   threads them as `create_agent_graph(extra_middleware=…)`. `_build_middleware` appends
+   them **after the core chain but before `MessageCaptureMiddleware`**, so their hooks run
+   and the turn is still captured. Applies to the lead agent (subagents keep their lean
+   built-in chain).
+
+2. **Per-request metadata via a contextvar.** `graph/middleware/request_context.py`
+   exposes `current_request_metadata()` (the merged A2A request metadata for the in-flight
+   turn) backed by a contextvar, bound by `request_metadata_scope(...)` in the A2A stream
+   (`_chat_langgraph_stream`, alongside `trace_session`). Mirrors
+   `tracing.current_session_id`. Middleware — core or plugin — reads request-scoped data
+   without touching the executor or the graph state schema.
+
+Result: a fork's per-turn directive (roxy's scope banner) becomes a ~15-line plugin
+`AgentMiddleware` reading `current_request_metadata()` — **zero core edits**.
+
+## Consequences
+
+- Plugin middleware runs **in-process with the agent's privileges** (like all plugins) —
+  opt-in, trust-gated.
+- Ordering is fixed (core chain → plugin middleware → message-capture). A priority/position
+  hint is a deferred follow-up if a plugin needs to wrap the model *outermost*.
+- The contextvar is set only on the A2A stream path (where request metadata exists);
+  non-A2A invokes see `{}`.
+- Subagents don't get plugin middleware (kept minimal by design).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -40,3 +40,4 @@ decision, numbered, never deleted (supersede instead).
 | [0029](./0029-communication-plugins-standard.md) | A standard for communication (chat-surface) plugins | Accepted |
 | [0030](./0030-monitor-goals.md) | Monitor goals — cadence-evaluated, hook-reactive objectives (closes 0028 D6) | Accepted (sliced) |
 | [0031](./0031-pluggable-knowledge-backend.md) | Pluggable knowledge backend (register_knowledge_store + Protocol + selector) | Accepted |
+| [0032](./0032-pluggable-middleware.md) | Pluggable middleware (register_middleware + per-request metadata contextvar) | Accepted |

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -2,11 +2,10 @@
 
 Plugins are **drop-in packages** that extend protoAgent without forking it. A
 plugin contributes **tools**, bundled **skills**, FastAPI **routes**, background
-**surfaces**, **subagents**, and managed **MCP servers** — plus its own
-**config / secrets / Settings** (ADR 0018/0019). (Middleware is the only
-extension point not yet plugin-contributable.) Plugins run **in-process** with
-the agent's privileges, so they're **disabled by default** and you opt in
-explicitly — only enable plugins you trust.
+**surfaces**, **subagents**, **middleware**, knowledge backends/embedders, goal
+verifiers — plus its own **config / secrets / Settings** (ADR 0018/0019/0032).
+Plugins run **in-process** with the agent's privileges, so they're **disabled by
+default** and you opt in explicitly — only enable plugins you trust.
 
 > The first-party **Discord** and **Google** integrations ship as plugins
 > (`plugins/discord/`, `plugins/google/`) — disable either with
@@ -73,6 +72,7 @@ a fork adds any of them as a plugin, never editing the core `server/` package:
 | `register_router(router, prefix=None)` | A FastAPI `APIRouter` | **mounted once** at init (default prefix `/plugins/<id>`) |
 | `register_surface(start, stop=None, name=None, reload=None)` | A background surface (a Discord-style gateway) | `start` in startup, `stop` in shutdown, `reload(cfg)` on config save |
 | `register_subagent(config)` | A `SubagentConfig` (a delegate) | added to `SUBAGENT_REGISTRY` |
+| `register_middleware(factory)` | A LangGraph **`AgentMiddleware`** (per-turn before/after-model + tool hooks) — `factory(config) → middleware \| None` | graph build; appended before message-capture (ADR 0032) |
 | `register_mcp_server(factory)` | A **managed MCP server** the agent connects to | `factory(config)` called at each graph build → entry dict or `None` |
 | `register_thread_id_resolver(fn)` | A `(request_metadata, session_id) → str` checkpointer-scope resolver (e.g. per-project memory) | each turn; one wins (last plugin) |
 
@@ -100,6 +100,36 @@ is how the first-party **Google** plugin ships its OAuth-gated Gmail/Calendar
 server (`plugins/google/`). For a frozen desktop build (no `python` on PATH),
 launch via `args: ["--mcp-plugin", "<id>"]` and expose a `mcp_main()` in your
 plugin module — the binary re-invokes itself and the shim runs it.
+
+### Middleware — `register_middleware` (ADR 0032)
+
+A plugin can contribute a LangGraph **`AgentMiddleware`** — the per-turn hook layer
+(`before_model` / `after_model` / `wrap_tool_call` / …) the core uses for knowledge
+injection, enforcement, compaction, and audit. The factory gets the live config and
+returns a middleware instance (or `None` to opt out); it's appended to the chain just
+before the internal message-capture middleware, so its hooks run and the turn is still
+captured.
+
+For **per-request** data (the A2A request's merged metadata — project scope, origin,
+caller keys), read `current_request_metadata()` — a contextvar bound for the duration
+of each turn. This is how a fork injects a per-turn directive without editing the core
+executor:
+
+```python
+from langchain.agents.middleware import AgentMiddleware
+from graph.middleware.request_context import current_request_metadata
+
+class ScopeBannerMiddleware(AgentMiddleware):
+    def before_model(self, state, runtime):
+        project = current_request_metadata().get("project")
+        if not project:
+            return None
+        banner = SystemMessage(content=f"Active project scope: {project}. Stay within it.")
+        return {"messages": [banner, *state["messages"]]}
+
+def register(registry):
+    registry.register_middleware(lambda config: ScopeBannerMiddleware())
+```
 
 ## Host services — `registry.host`
 

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -18,7 +18,7 @@ from graph.subagents.config import SUBAGENT_REGISTRY
 from tools.lg_tools import get_all_tools
 
 
-def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_index=None):
+def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_index=None, extra_middleware=None):
     middleware = []
 
     # Prompt caching + knowledge-context delivery (wrap_model_call). Added
@@ -107,6 +107,14 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
         from langchain.agents.middleware import ModelFallbackMiddleware
         fallbacks = [create_llm(config, model_name=m) for m in config.routing_fallback_models]
         middleware.append(ModelFallbackMiddleware(*fallbacks))
+
+    # Plugin-contributed middleware (ADR 0032) — appended after the core chain but
+    # before MessageCapture, so their before/after-model + tool hooks run and the
+    # turn is still captured. Each is already an instance (factories resolved in
+    # agent_init); skip falsy entries (a factory may opt out by returning None).
+    for mw in (extra_middleware or []):
+        if mw is not None:
+            middleware.append(mw)
 
     middleware.append(MessageCaptureMiddleware())
 
@@ -648,6 +656,7 @@ def create_agent_graph(
     scheduler=None,
     skills_index=None,
     extra_tools=None,
+    extra_middleware=None,
     include_subagents: bool = True,
     checkpointer=None,
     workflow_registry=None,
@@ -706,7 +715,7 @@ def create_agent_graph(
         keep = resolve_deferred_keep(config.tools_deferred_keep)
         all_tools.append(build_search_tools_tool(all_tools, keep))
 
-    middleware = _build_middleware(config, knowledge_store, skills_index=skills_index)
+    middleware = _build_middleware(config, knowledge_store, skills_index=skills_index, extra_middleware=extra_middleware)
 
     system_prompt = build_system_prompt(
         include_subagents=include_subagents,

--- a/graph/middleware/request_context.py
+++ b/graph/middleware/request_context.py
@@ -1,0 +1,54 @@
+"""Per-turn request metadata, exposed to middleware via a contextvar (ADR 0032).
+
+The A2A request's merged metadata (project scope, origin, caller-supplied keys) is
+request-scoped, not part of the agent state. Middleware — including plugin-contributed
+ones registered via ``register_middleware`` — read it through
+``current_request_metadata()``; the chat/executor layer binds it for the duration of a
+turn via ``request_metadata_scope()``. Mirrors ``tracing.current_session_id``.
+
+This is what lets a plugin middleware replicate a per-request directive (e.g. roxy's
+project-scope banner) without editing the core executor.
+"""
+
+from __future__ import annotations
+
+import contextvars
+
+_request_metadata_ctx: contextvars.ContextVar[dict] = contextvars.ContextVar(
+    "protoagent_request_metadata", default={},
+)
+
+
+def current_request_metadata() -> dict:
+    """The merged A2A request metadata for the in-flight turn (``{}`` when none)."""
+    return _request_metadata_ctx.get()
+
+
+class request_metadata_scope:
+    """Bind ``metadata`` as the current request metadata for the enclosed turn.
+
+    Works as both a sync (`with`) and async (`async with`) context manager — the
+    A2A stream enters it via `async with` alongside `trace_session`, while sync
+    callers/tests use plain `with`. set/reset are sync; the contextvar propagates
+    into awaited graph invokes on the same task.
+    """
+
+    def __init__(self, metadata: dict | None):
+        self._metadata = dict(metadata) if metadata else {}
+        self._token: contextvars.Token | None = None
+
+    def __enter__(self):
+        self._token = _request_metadata_ctx.set(self._metadata)
+        return self
+
+    def __exit__(self, *_exc):
+        if self._token is not None:
+            _request_metadata_ctx.reset(self._token)
+            self._token = None
+        return False
+
+    async def __aenter__(self):
+        return self.__enter__()
+
+    async def __aexit__(self, *exc):
+        return self.__exit__(*exc)

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -37,6 +37,7 @@ class PluginLoadResult:
     routers: list = field(default_factory=list)    # {plugin_id, router, prefix} (ADR 0018)
     surfaces: list = field(default_factory=list)    # {plugin_id, name, start, stop}
     subagents: list = field(default_factory=list)   # SubagentConfig
+    middleware: list = field(default_factory=list)  # factories: (config) -> AgentMiddleware|None (ADR 0032)
     mcp_servers: list = field(default_factory=list)  # factories: config -> entry|None (ADR 0019)
     thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571); last plugin wins
     meta: list[dict] = field(default_factory=list)
@@ -232,6 +233,7 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         for s in registry.surfaces:
             result.surfaces.append({"plugin_id": manifest.id, **s})
         result.subagents.extend(registry.subagents)
+        result.middleware.extend(registry.middleware)  # ADR 0032
         for name, fn in registry.goal_verifiers.items():  # ADR 0028
             if name in result.goal_verifiers:
                 log.warning("[plugins] %s: goal verifier %s collides — skipped", manifest.id, name)

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -52,6 +52,7 @@ class PluginRegistry:
         self.routers: list[dict] = []     # {"router", "prefix"}
         self.surfaces: list[dict] = []    # {"name", "start", "stop"}
         self.subagents: list = []         # SubagentConfig instances
+        self.middleware: list = []        # factories: (config) -> AgentMiddleware|None (ADR 0032)
         self.mcp_servers: list = []       # factories: config -> entry dict | None
         self.thread_id_resolver = None    # (request_metadata, session_id) -> str (#571)
         self.goal_verifiers: dict = {}    # name -> async (spec, ctx) -> VerifyResult (ADR 0028)
@@ -232,3 +233,22 @@ class PluginRegistry:
                         self.plugin_id, config)
             return
         self.subagents.append(config)
+
+    def register_middleware(self, factory) -> None:
+        """Add a plugin-contributed LangGraph ``AgentMiddleware`` (ADR 0032).
+
+        ``factory`` is ``(config) -> AgentMiddleware | None`` — it receives the live
+        ``LangGraphConfig`` and returns a middleware instance (or None to opt out).
+        Plugin middleware is appended to the chain just before the internal
+        message-capture middleware (so before/after-model + tool hooks run, and the
+        turn is still captured). For per-request data, read
+        ``graph.middleware.request_context.current_request_metadata()``.
+
+        This is the last core extension point that previously forced a fork to edit
+        ``graph/agent.py`` / ``a2a_executor.py``.
+        """
+        if not callable(factory):
+            log.warning("[plugins] %s: register_middleware needs a callable factory, got %r",
+                        self.plugin_id, factory)
+            return
+        self.middleware.append(factory)

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -38,6 +38,7 @@ class AppState:
     mcp_meta: list = field(default_factory=list)
     plugin_tools: list = field(default_factory=list)
     plugin_skill_dirs: list = field(default_factory=list)
+    plugin_middleware: list = field(default_factory=list)  # resolved AgentMiddleware instances (ADR 0032)
     plugin_workflow_dirs: list = field(default_factory=list)  # *.yaml recipe dirs (ADR 0027)
     plugin_a2a_skills: list = field(default_factory=list)  # A2A card skills from plugins (#570)
     thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571)

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -166,6 +166,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     STATE.plugin_routers, STATE.plugin_surfaces = _plugins.routers, _plugins.surfaces
     _register_plugin_subagents(_plugins.subagents)
     _apply_config_subagents(STATE.graph_config)  # YAML subagent overrides (tools/max_turns/model)
+    STATE.plugin_middleware = _resolve_plugin_middleware(STATE.graph_config, _plugins.middleware)  # ADR 0032
 
     # MCP — external Model Context Protocol servers; their tools become agent
     # tools (namespaced <server>__<tool>). Off unless mcp.enabled OR a plugin
@@ -193,6 +194,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     STATE.graph = create_agent_graph(
         STATE.graph_config, knowledge_store=STATE.knowledge_store, scheduler=STATE.scheduler,
         skills_index=STATE.skills_index, extra_tools=STATE.mcp_tools + STATE.plugin_tools,
+        extra_middleware=STATE.plugin_middleware,
         checkpointer=STATE.checkpointer, workflow_registry=STATE.workflow_registry,
         inbox_store=STATE.inbox_store, beads_store=STATE.beads_store,
     )
@@ -396,6 +398,24 @@ def _register_plugin_subagents(subagents) -> None:
         SUBAGENT_REGISTRY[name] = cfg
         _plugin_subagent_names.add(name)
         log.info("[plugins] registered subagent: %s", name)
+
+
+def _resolve_plugin_middleware(config, factories) -> list:
+    """Resolve plugin middleware factories ``(config) -> AgentMiddleware|None`` to
+    instances (ADR 0032). Best-effort: a factory that raises or returns None is
+    skipped + logged, so one bad plugin can't take down the graph build."""
+    out = []
+    for factory in (factories or []):
+        try:
+            mw = factory(config)
+        except Exception:  # noqa: BLE001
+            log.exception("[plugins] middleware factory failed; skipping")
+            continue
+        if mw is not None:
+            out.append(mw)
+    if out:
+        log.info("[plugins] %d middleware contributed", len(out))
+    return out
 
 
 # Built-in subagents whose runtime config the operator can override in YAML
@@ -971,12 +991,14 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
             new_store = _apply_plugin_knowledge_backend(new_config, new_store, new_plugins)
             _register_plugin_subagents(new_plugins.subagents)
             _apply_config_subagents(new_config)  # YAML subagent overrides take effect on reload
+            new_middleware = _resolve_plugin_middleware(new_config, new_plugins.middleware)  # ADR 0032
             new_skills = _build_skills_index(new_config, extra_skill_dirs=new_plugin_skill_dirs)
             new_workflow_registry = _build_workflow_registry(new_config)
             new_inbox_store = _build_inbox_store(new_config)
             new_graph = create_agent_graph(
                 new_config, knowledge_store=new_store, scheduler=next_scheduler,
                 skills_index=new_skills, extra_tools=new_mcp_tools + new_plugin_tools,
+                extra_middleware=new_middleware,
                 checkpointer=STATE.checkpointer, workflow_registry=new_workflow_registry,
                 inbox_store=new_inbox_store,
             )
@@ -1016,6 +1038,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
         # _main wires routes) — harmless.
         pass
     STATE.graph = new_graph
+    STATE.plugin_middleware = new_middleware  # ADR 0032
     STATE.workflow_registry = new_workflow_registry
     STATE.inbox_store = new_inbox_store
     # Commit the scheduler swap. start/stop are async — fire-and-forget

--- a/server/chat.py
+++ b/server/chat.py
@@ -430,6 +430,7 @@ async def _chat_langgraph_stream(
     import tracing
 
     from graph.goals.goal_turn import goal_turn
+    from graph.middleware.request_context import request_metadata_scope
 
     trace_meta: dict = {"message_preview": message[:100]}
     if caller_trace:
@@ -446,7 +447,7 @@ async def _chat_langgraph_stream(
         session_id=session_id,
         name="a2a-stream",
         metadata=trace_meta,
-    ):
+    ), request_metadata_scope(request_metadata):
         try:
             # Goal control messages (/goal ...) short-circuit the turn: set /
             # status / clear a goal and return the reply without running the graph.

--- a/tests/test_plugin_middleware.py
+++ b/tests/test_plugin_middleware.py
@@ -1,0 +1,68 @@
+"""Plugin-contributed middleware (ADR 0032): register_middleware on the registry,
+extra_middleware threaded into the chain before MessageCapture, factories resolved
+best-effort, and per-request metadata exposed to middleware via a contextvar."""
+
+from __future__ import annotations
+
+
+from graph.config import LangGraphConfig
+from graph.middleware.request_context import current_request_metadata, request_metadata_scope
+
+
+def _no_llm_config() -> LangGraphConfig:
+    c = LangGraphConfig()
+    # Disable every middleware that constructs an LLM so _build_middleware needs no gateway.
+    c.compaction_enabled = False
+    c.routing_fallback_models = []
+    c.enforcement_enabled = False
+    c.tools_deferred_enabled = False
+    c.audit_middleware = False
+    c.memory_middleware = False
+    c.ingest_enabled = False
+    c.knowledge_middleware = False
+    c.skills_enabled = False
+    return c
+
+
+def test_register_middleware_collects_callables_only():
+    from graph.plugins.registry import PluginRegistry
+
+    r = PluginRegistry("test", "/tmp")
+    r.register_middleware(lambda config: "MW")
+    r.register_middleware("not-callable")  # skipped + logged
+    assert len(r.middleware) == 1 and callable(r.middleware[0])
+
+
+def test_build_middleware_appends_extra_before_message_capture():
+    from graph.agent import _build_middleware
+
+    class FakeMW:
+        pass
+
+    mw = _build_middleware(_no_llm_config(), extra_middleware=[FakeMW()])
+    names = [type(m).__name__ for m in mw]
+    assert names[-1] == "MessageCaptureMiddleware", names
+    assert names[-2] == "FakeMW", names  # plugin middleware sits just before capture
+
+
+def test_resolve_plugin_middleware_is_best_effort():
+    from server.agent_init import _resolve_plugin_middleware
+
+    def good(config):
+        return "MW"
+
+    def opts_out(config):
+        return None
+
+    def boom(config):
+        raise RuntimeError("bad plugin")
+
+    out = _resolve_plugin_middleware(_no_llm_config(), [good, opts_out, boom])
+    assert out == ["MW"]  # None filtered, exception swallowed
+
+
+def test_request_metadata_scope_sets_and_resets():
+    assert current_request_metadata() == {}
+    with request_metadata_scope({"project": "alpha", "origin": "scheduler"}):
+        assert current_request_metadata()["project"] == "alpha"
+    assert current_request_metadata() == {}


### PR DESCRIPTION
Closes the **last core extension point** a fork had to edit core to use. roxy (the canonical operator fork) carried a project-scope banner in `a2a_executor.py` for exactly this — now it's a plugin.

- **`registry.register_middleware(factory)`** — a plugin contributes a LangGraph `AgentMiddleware`. `factory(config) → AgentMiddleware | None` (mirrors `register_knowledge_store`/`register_embedder`); loader collects → `agent_init` resolves best-effort (raising/None skipped+logged) → `create_agent_graph(extra_middleware=…)` → appended **before `MessageCaptureMiddleware`** so hooks run and the turn is still captured. Lead agent only.
- **Per-request metadata** — `graph/middleware/request_context.py::current_request_metadata()` (a per-turn contextvar, mirrors `tracing.current_session_id`), bound by `request_metadata_scope()` in the A2A stream (a dual sync/async CM entered next to `trace_session`). Middleware reads the merged A2A request metadata without touching the executor or state schema.

**Result:** roxy's scope banner → a ~15-line plugin `AgentMiddleware`, **zero core edits**.

Tests: register_middleware (callables only), `_build_middleware` ordering, best-effort factory resolution, contextvar set/reset. **Suite 1236**; ADR 0032 + plugins guide (with a worked `ScopeBannerMiddleware` example). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)