### PR TITLE
feat(console): group the Tools tab by subsystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Tools tab grouped by subsystem** — the Agent → Tools inventory is sectioned
+  (General · GitHub · Notes · Memory · Scheduler · Inbox · Beads · Goals · Delegation ·
+  Workflows · Plugin · MCP) with per-group counts, instead of a flat wall of ~30; search
+  filters across. `/api/tools` returns a `category` per tool.
+
 ### Added
 - **Pluggable middleware** (ADR 0032) — plugins contribute LangGraph `AgentMiddleware` via
   `register_middleware(factory)` (appended just before message-capture), and per-request A2A

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -88,10 +88,11 @@ function handleApiGet(pathname) {
     case "/api/tools":
       return {
         tools: [
-          { name: "web_search", description: "Search the web.", source: "core" },
-          { name: "echo__ping", description: "Echo ping.", source: "mcp" },
+          { name: "web_search", description: "Search the web.", source: "core", category: "General" },
+          { name: "memory_recall", description: "Search long-term memory.", source: "core", category: "Memory" },
+          { name: "echo__ping", description: "Echo ping.", source: "mcp", category: "MCP" },
         ],
-        count: 2,
+        count: 3,
       };
     case "/api/chat/commands":
       return { commands: SLASH_COMMANDS };

--- a/apps/web/src/app/ToolsPanel.tsx
+++ b/apps/web/src/app/ToolsPanel.tsx
@@ -12,17 +12,36 @@ import { StatusPill } from "./StatusPill";
 
 const SOURCE_TONE = { core: "success", plugin: "muted", mcp: "muted" } as const;
 
+// Subsystem ordering — General leads; integrations next; plugin/MCP last.
+const CATEGORY_ORDER = [
+  "General", "GitHub", "Notes", "Memory", "Scheduler", "Inbox", "Beads", "Goals",
+  "Delegation", "Workflows", "Discovery", "Plugin", "MCP",
+];
+
 function ToolsBody() {
   const { data } = useSuspenseQuery(toolsQuery());
   const [q, setQ] = useState("");
   const query = q.trim().toLowerCase();
   const tools = query
-    ? data.tools.filter((t) => `${t.name} ${t.description} ${t.source}`.toLowerCase().includes(query))
+    ? data.tools.filter((t) =>
+        `${t.name} ${t.description} ${t.source} ${t.category ?? ""}`.toLowerCase().includes(query))
     : data.tools;
+
+  // Group by category, then order the groups (known order first, unknowns alpha).
+  const groups = new Map<string, typeof tools>();
+  for (const t of tools) {
+    const cat = t.category || "General";
+    (groups.get(cat) ?? groups.set(cat, []).get(cat)!).push(t);
+  }
+  const ordered = [...groups.keys()].sort((a, b) => {
+    const ia = CATEGORY_ORDER.indexOf(a), ib = CATEGORY_ORDER.indexOf(b);
+    if (ia !== -1 || ib !== -1) return (ia === -1 ? 99 : ia) - (ib === -1 ? 99 : ib);
+    return a.localeCompare(b);
+  });
 
   return (
     <>
-      <PanelHeader title="Tools" kicker={`${data.count} wired tool${data.count === 1 ? "" : "s"}`} />
+      <PanelHeader title="Tools" kicker={`${data.count} wired tool${data.count === 1 ? "" : "s"} · ${groups.size} group${groups.size === 1 ? "" : "s"}`} />
       <div className="stage-body">
         <input
           className="playbook-search"
@@ -31,20 +50,23 @@ function ToolsBody() {
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />
-        <div className="table-list">
-          {tools.map((t) => (
-            <div className="table-row" key={t.name}>
-              <span>
-                <strong>{t.name}</strong>
-                {t.description ? <span className="muted"> — {t.description}</span> : null}
-              </span>
-              <StatusPill label={t.source} tone={SOURCE_TONE[t.source] ?? "muted"} />
+        {ordered.map((cat) => (
+          <div key={cat}>
+            <p className="panel-kicker">{cat} <span className="muted">· {groups.get(cat)!.length}</span></p>
+            <div className="table-list">
+              {groups.get(cat)!.map((t) => (
+                <div className="table-row" key={t.name}>
+                  <span>
+                    <strong>{t.name}</strong>
+                    {t.description ? <span className="muted"> — {t.description}</span> : null}
+                  </span>
+                  <StatusPill label={t.source} tone={SOURCE_TONE[t.source] ?? "muted"} />
+                </div>
+              ))}
             </div>
-          ))}
-          {tools.length === 0 ? (
-            <div className="table-row"><span>no tools match</span></div>
-          ) : null}
-        </div>
+          </div>
+        ))}
+        {tools.length === 0 ? <p className="muted">No tools match.</p> : null}
       </div>
     </>
   );

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -223,11 +223,13 @@ export type Subagent = {
   allow_skill_emission: boolean;
 };
 
-// A live wired tool (Runtime → Tools), grouped by where it comes from.
+// A live wired tool (Agent → Tools): its source (core/plugin/mcp) + the subsystem
+// category it's grouped under in the console.
 export type ToolInfo = {
   name: string;
   description: string;
   source: "core" | "plugin" | "mcp";
+  category?: string;
 };
 
 export type ToolCall = {

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -71,9 +71,36 @@ def _operator_subagent_list():
     return _operator_list_subagents(STATE.graph_config)
 
 
+# Group the flat tool inventory by subsystem (matches get_all_tools' sections) so the
+# console can section the list instead of showing a wall of 30. Name → category;
+# unknown core names fall back to "General", plugin/mcp tools to their source.
+_TOOL_CATEGORY = {
+    "current_time": "General", "calculator": "General", "web_search": "General",
+    "fetch_url": "General", "ask_human": "General", "request_user_input": "General",
+    "github_get_pr": "GitHub", "github_get_issue": "GitHub",
+    "github_list_issues": "GitHub", "github_get_commit_diff": "GitHub",
+    "notes_list": "Notes", "notes_read": "Notes", "notes_write": "Notes", "notes_revert": "Notes",
+    "memory_ingest": "Memory", "memory_recall": "Memory", "memory_list": "Memory",
+    "memory_stats": "Memory", "daily_log": "Memory",
+    "schedule_task": "Scheduler", "list_schedules": "Scheduler", "cancel_schedule": "Scheduler",
+    "check_inbox": "Inbox",
+    "beads_create": "Beads", "beads_list": "Beads", "beads_update": "Beads", "beads_close": "Beads",
+    "set_goal": "Goals",
+    "task": "Delegation", "task_batch": "Delegation", "run_workflow": "Workflows",
+    "save_workflow": "Workflows", "search_tools": "Discovery",
+}
+
+
+def _tool_category(name: str, source: str) -> str:
+    if source == "core":
+        return _TOOL_CATEGORY.get(name, "General")
+    return "Plugin" if source == "plugin" else "MCP"
+
+
 def _operator_tools_list():
-    """Live tool inventory grouped by source (core / plugin / mcp) for the
-    Runtime → Tools tab. Best-effort: degrades to an empty list pre-setup."""
+    """Live tool inventory for the Tools tab — name, one-line description, source
+    (core/plugin/mcp), and a subsystem category for grouping. Best-effort; degrades
+    to an empty list pre-setup."""
     cfg = STATE.graph_config
     out: list[dict] = []
     seen: set[str] = set()
@@ -84,7 +111,10 @@ def _operator_tools_list():
             return
         seen.add(name)
         desc = (getattr(tool, "description", "") or "").strip().split("\n")[0]
-        out.append({"name": name, "description": desc, "source": source})
+        out.append({
+            "name": name, "description": desc, "source": source,
+            "category": _tool_category(name, source),
+        })
 
     try:
         from tools.lg_tools import get_all_tools


### PR DESCRIPTION
A flat list of ~30 tools read as cruft. Now the **Agent → Tools** inventory is sectioned by subsystem (matching `get_all_tools`' groups): **General · GitHub · Notes · Memory · Scheduler · Inbox · Beads · Goals · Delegation · Workflows · Plugin · MCP**, each with a count — search still filters across.

- `/api/tools` returns a `category` per tool (`_tool_category`: name→subsystem for core; source for plugin/mcp).
- `ToolsPanel` groups + orders the sections (General first, plugin/MCP last).

Web build + **full e2e 57/57**; console-handlers tests green.

(Most of those tools are subsystem-gated already — memory/scheduler/beads/goals/inbox only wire when their backend is on. If you still want to *trim* the default surface — e.g. move the 4 GitHub tools to a plugin — that's a clean follow-up; this PR makes the list legible first.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)