### PR TITLE
chore(tools): remove daily_log from core (roxy owns it as a plugin)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- **`daily_log` tool removed from core** — it was roxy-specific (roxy ships it as a plugin
+  now). Logging an event is `memory_ingest` with a domain; eval cases repointed accordingly.
+
 ### Changed
 - **Tools tab grouped by subsystem** — the Agent → Tools inventory is sectioned
   (General · GitHub · Notes · Memory · Scheduler · Inbox · Beads · Goals · Delegation ·

--- a/evals/README.md
+++ b/evals/README.md
@@ -22,7 +22,7 @@ A case passes only when every configured assertion holds.
 
 python -m evals.runner                                 # all cases
 python -m evals.runner --category tool                 # one category
-python -m evals.runner --tasks current_time,daily_log
+python -m evals.runner --tasks current_time,memory_ingest
 python -m evals.runner --base-url http://host:7870
 ```
 
@@ -137,7 +137,7 @@ against `GET /api/goal/{session}`; `expected_patterns` against the reply.
 ## Why side-effect verification
 
 When the model hallucinates a tool result (e.g. "Logged: ..." without
-actually calling `daily_log`), text-only checks pass while the DB
+actually calling `memory_ingest`), text-only checks pass while the DB
 stays empty. The audit-log + KB queries here catch it.
 
 ## Prompt rule

--- a/evals/runner.py
+++ b/evals/runner.py
@@ -10,7 +10,7 @@ Usage:
 
     python -m evals.runner                                # all cases
     python -m evals.runner --category tool                # one category
-    python -m evals.runner --tasks current_time,daily_log
+    python -m evals.runner --tasks current_time,memory_ingest
     python -m evals.runner --base-url http://host:7870
 
 Cases are described in ``tasks.json``. Each case picks one of three

--- a/evals/sweep.py
+++ b/evals/sweep.py
@@ -19,7 +19,7 @@ Usage::
 
     python -m evals.sweep --models protolabs/reasoning,protolabs/smart
     python -m evals.sweep --models a,b,c --category tool
-    python -m evals.sweep --models a,b --tasks current_time,daily_log --keep
+    python -m evals.sweep --models a,b --tasks current_time,memory_ingest --keep
     python -m evals.sweep --models a,b,c --category tool --repeat 3   # best-of-3
 
 ``--repeat N`` runs the suite N times per model (against the same booted agent)

--- a/evals/tasks.json
+++ b/evals/tasks.json
@@ -110,16 +110,15 @@
     ]
   },
   {
-    "id": "daily_log_intent",
+    "id": "memory_ingest_intent",
     "category": "tool",
     "kind": "ask",
-    "name": "Asks to log an event → daily_log writes today's chunk",
-    "prompt": "Log this for today: my standup just ended, team is unblocked on the auth migration.",
-    "expected_tools": ["daily_log"],
+    "name": "Asks to log an event → memory_ingest writes the chunk",
+    "prompt": "Note this for me: my standup just ended, team is unblocked on the auth migration.",
+    "expected_tools": ["memory_ingest"],
     "expected_patterns": [],
     "verify_kb": {
-      "find_chunk_containing": "auth migration",
-      "domain": "daily-log"
+      "find_chunk_containing": "auth migration"
     },
     "teardown": [
       {"kb_delete_by_content": {"contains": "auth migration"}}
@@ -175,9 +174,9 @@
     "id": "log_then_recall_chain",
     "category": "chained",
     "kind": "ask",
-    "name": "Log an event, then recall it later in the same turn",
-    "prompt": "Log this for today: 'eval-chain-flag-q9: chained log+recall test'. After logging, search memory for that flag and quote it back.",
-    "expected_tools": ["daily_log", "memory_recall"],
+    "name": "Note an event, then recall it later in the same turn",
+    "prompt": "Note this for me: 'eval-chain-flag-q9: chained log+recall test'. After saving it, search memory for that flag and quote it back.",
+    "expected_tools": ["memory_ingest", "memory_recall"],
     "expected_patterns": ["eval-chain-flag-q9"],
     "teardown": [
       {"kb_delete_by_content": {"contains": "eval-chain-flag-q9"}}

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -81,7 +81,7 @@ _TOOL_CATEGORY = {
     "github_list_issues": "GitHub", "github_get_commit_diff": "GitHub",
     "notes_list": "Notes", "notes_read": "Notes", "notes_write": "Notes", "notes_revert": "Notes",
     "memory_ingest": "Memory", "memory_recall": "Memory", "memory_list": "Memory",
-    "memory_stats": "Memory", "daily_log": "Memory",
+    "memory_stats": "Memory",
     "schedule_task": "Scheduler", "list_schedules": "Scheduler", "cancel_schedule": "Scheduler",
     "check_inbox": "Inbox",
     "beads_create": "Beads", "beads_list": "Beads", "beads_update": "Beads", "beads_close": "Beads",

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -119,7 +119,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     from tools.lg_tools import get_all_tools
 
     # Construct the default KnowledgeStore so memory tools (memory_ingest,
-    # memory_recall, daily_log) and KnowledgeMiddleware have something to
+    # memory_recall, memory_list, memory_stats) and KnowledgeMiddleware have something to
     # bind to. Forks that don't want a store can set
     # ``middleware.knowledge: false`` and remove the memory tools from
     # the worker subagent — the store is still cheap to construct.

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -19,7 +19,6 @@ Plus memory tools that bind to a ``KnowledgeStore`` (constructed in
 - ``memory_recall`` — search the store for relevant chunks
 - ``memory_list``   — list recent chunks (optionally per domain)
 - ``memory_stats``  — per-domain counts
-- ``daily_log``     — convenience: write a daily-log chunk
 
 Replace or extend this file with your agent's real tools and update
 ``get_all_tools()`` to return the full list.
@@ -377,7 +376,7 @@ SCHEDULER_TOOL_NAMES: tuple[str, ...] = (
     "schedule_task", "list_schedules", "cancel_schedule",
 )
 MEMORY_TOOL_NAMES: tuple[str, ...] = (
-    "memory_ingest", "memory_recall", "memory_list", "memory_stats", "daily_log",
+    "memory_ingest", "memory_recall", "memory_list", "memory_stats",
 )
 INBOX_TOOL_NAMES: tuple[str, ...] = ("check_inbox",)
 
@@ -419,7 +418,6 @@ def _build_inbox_tools(inbox_store) -> list:
 
 def _build_memory_tools(knowledge_store) -> list:
     """Bind memory tools to a ``KnowledgeStore``. Returns a list."""
-    from datetime import datetime, timezone
 
     @tool
     async def memory_ingest(
@@ -500,23 +498,7 @@ def _build_memory_tools(knowledge_store) -> list:
             lines.append(f"  {k}: {v}")
         return "\n".join(lines)
 
-    @tool
-    async def daily_log(content: str) -> str:
-        """Append a daily-log entry for today.
-
-        Stored under ``domain='daily-log'`` with today's UTC date as
-        the heading, so the same day's entries cluster together for
-        ``memory_list(domain='daily-log')`` queries.
-        """
-        today = datetime.now(timezone.utc).date().isoformat()
-        chunk_id = knowledge_store.add_chunk(
-            content, domain="daily-log", heading=today,
-        )
-        if chunk_id is None:
-            return "Error: failed to write daily log entry."
-        return f"Logged ({today}): {content[:120]}"
-
-    return [memory_ingest, memory_recall, memory_list, memory_stats, daily_log]
+    return [memory_ingest, memory_recall, memory_list, memory_stats]
 
 
 # ── scheduler tools ──────────────────────────────────────────────────────────
@@ -745,7 +727,7 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None,
     Optional dependencies:
 
     - ``knowledge_store`` enables the memory tools (memory_ingest,
-      memory_recall, memory_list, memory_stats, daily_log).
+      memory_recall, memory_list, memory_stats).
     - ``scheduler`` enables the scheduler tools (schedule_task,
       list_schedules, cancel_schedule). Accepts any backend that
       implements ``scheduler.interface.SchedulerBackend``.


### PR DESCRIPTION
**Phase 1 of the lean-core tool audit.** `daily_log` was roxy-specific — she ships it as a plugin now — so it shouldn't be in the shipped core. Logging an event is just `memory_ingest` with a domain.

- Dropped `daily_log` from `_build_memory_tools` + `MEMORY_TOOL_NAMES` + docstrings + the Tools-tab category map; tidied the agent_init comment.
- **Evals:** `daily_log_intent` → `memory_ingest_intent`; `log_then_recall_chain` → `memory_ingest`+`memory_recall`; example commands updated.

Suite **1236**; ruff clean.

Part of: daily_log removal → GitHub plugin → right-rail plugin panels → Notes plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)