### PR TITLE
feat(console): plugin views can render as right-rail panels (placement: right)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Plugin right-rail panels** (ADR 0026) — a plugin console view can set `placement: "right"`
+  to render as a right-sidebar panel (alongside Notes/Beads/Goals/Schedule) instead of a
+  left-rail surface. Same iframe host; the substrate for moving Notes to a plugin.
+
 ### Changed
 - **GitHub read tools → the opt-in `github` plugin** — removed from the default tool set
   (not every agent needs GitHub). Ships disabled; enable with `plugins.enabled: [github]`.

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -47,6 +47,8 @@ export const RUNTIME_STATUS = {
           ],
         },
         { id: "stats", label: "Stats", icon: "BarChart3", path: "/plugins/boardy/stats" },
+        // A right-rail panel (ADR 0026 placement:"right") — sits with Notes/Beads/Goals.
+        { id: "scratch", label: "Scratch", icon: "FileText", path: "/plugins/boardy/scratch", placement: "right" },
       ],
     },
   ],

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -58,3 +58,17 @@ test("console hands the plugin view a bearer + theme via postMessage", async ({ 
   const body = page.frameLocator(".plugin-view-frame").locator("body");
   await expect(body).toHaveAttribute("data-bridge", "authed");
 });
+
+test("a plugin view with placement:right becomes a right-sidebar panel", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // The right-placed view is a right-rail tab (not a left-rail surface icon).
+  const tab = page.locator(".segmented").getByRole("button", { name: "Scratch", exact: true });
+  await expect(tab).toBeVisible();
+  await tab.click();
+
+  // It hosts the plugin page in the same iframe host, at the declared path.
+  const frame = page.locator(".plugin-view-frame");
+  await expect(frame).toBeVisible();
+  await expect(frame).toHaveAttribute("src", /\/plugins\/boardy\/scratch/);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -167,7 +167,7 @@ type AgentTab = "identity" | "tools" | "mcp" | "subagents" | "skills" | "middlew
 type ActivityTab = "thread" | "inbox";
 // The agent's persistent working memory, grouped in the right sidebar:
 // its notebook, its task board, and its goals.
-type RightPanel = "notes" | "beads" | "goals" | "schedule";
+type RightPanel = "notes" | "beads" | "goals" | "schedule" | (string & {});  // + plugin:<id>:<viewId> (ADR 0026)
 
 function createNoteTab() {
   const now = Date.now();
@@ -245,10 +245,15 @@ export function App() {
   // views become a dynamic rail icon (keyed plugin:<id>:<viewId>) whose panel is
   // an iframe of the page the plugin serves. PR1 thin vertical — PR2 generalizes
   // the rail into a full registry.
-  const pluginRail = (runtime?.plugins ?? [])
+  // A plugin view declares its placement: "rail" (default — a left-rail surface) or
+  // "right" (a right-sidebar panel, alongside Notes/Beads/Goals/Schedule — ADR 0026).
+  const allPluginViews = (runtime?.plugins ?? [])
     .filter((p) => p.enabled && p.views?.length)
     .flatMap((p) => (p.views ?? []).map((v) => ({ ...v, key: `plugin:${p.id}:${v.id}` })));
+  const pluginRail = allPluginViews.filter((v) => (v.placement ?? "rail") !== "right");
+  const pluginRightPanels = allPluginViews.filter((v) => v.placement === "right");
   const activePluginView = pluginRail.find((v) => v.key === surface) ?? null;
+  const activeRightPluginPanel = pluginRightPanels.find((v) => v.key === rightPanel) ?? null;
 
   // Stale-surface fallback: if we're on a plugin view that no longer exists (its
   // plugin was disabled/removed, or a config reload dropped it) — once runtime is
@@ -801,7 +806,18 @@ export function App() {
               <CalendarClock size={15} />
               Schedule
             </button>
+            {/* Plugin-contributed right-rail panels (ADR 0026) — placement: "right". */}
+            {pluginRightPanels.map((v) => (
+              <button key={v.key} type="button" className={rightPanel === v.key ? "active" : ""} onClick={() => setRightPanel(v.key)}>
+                {pluginViewIcon(v.icon)}
+                {v.label}
+              </button>
+            ))}
           </div>
+
+          {activeRightPluginPanel ? (
+            <PluginView key={activeRightPluginPanel.key} view={activeRightPluginPanel} />
+          ) : null}
 
           {rightPanel === "notes" ? (
             <section className="panel side-panel notes-panel">

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -78,6 +78,9 @@ export type PluginView = {
   icon?: string; // a lucide-react icon name
   path: string;
   tabs?: { id: string; label: string; path: string }[];
+  // "rail" (default) = a left-rail surface; "right" = a right-sidebar panel
+  // alongside Notes/Beads/Goals/Schedule (ADR 0026).
+  placement?: "rail" | "right";
 };
 
 // A git-installed plugin (ADR 0027) — a plugins.lock entry enriched with its

--- a/docs/adr/0026-plugin-contributed-console-surfaces.md
+++ b/docs/adr/0026-plugin-contributed-console-surfaces.md
@@ -54,10 +54,17 @@ views:
     label: "Board"            # rail + tab label
     icon: LayoutDashboard     # a lucide icon name (see D4)
     path: /plugins/myplugin/board   # what the iframe loads (plugin-served)
+    placement: rail           # "rail" (default — a left-rail surface) | "right"
     tabs:                     # optional sub-nav (view-tabs)
       - { id: open, label: "Open", path: /plugins/myplugin/board?tab=open }
       - { id: done, label: "Done", path: /plugins/myplugin/board?tab=done }
 ```
+
+**Placement (later addition).** A view's optional `placement` puts it either in the
+**left rail** as a full surface (`rail`, default) or in the **right sidebar** as a panel
+alongside Notes / Beads / Goals / Schedule (`right`). Both render the same iframe host;
+`right` is the substrate for moving Notes itself to a plugin. (No backend change — the
+manifest passes view dicts through verbatim; the console filters by `placement`.)
 
 Declared as **pure data** (like `config`/`settings`, ADR 0019) so it's known
 without importing the plugin, and surfaced to the frontend via

--- a/docs/guides/plugin-views.md
+++ b/docs/guides/plugin-views.md
@@ -16,10 +16,15 @@ views:
     label: "Board"                 # rail + tab label
     icon: LayoutDashboard          # a lucide-react icon name
     path: /plugins/myplugin/board  # the page the iframe loads (you serve it)
+    placement: rail                # "rail" (default — left-rail surface) | "right" (right sidebar)
     tabs:                          # optional sub-nav (view-tabs)
       - { id: open, label: "Open", path: /plugins/myplugin/board?tab=open }
       - { id: done, label: "Done", path: /plugins/myplugin/board?tab=done }
 ```
+
+**`placement`** chooses where the view lives: **`rail`** (default) is a full left-rail
+surface; **`right`** is a panel in the right sidebar alongside Notes / Beads / Goals /
+Schedule. Same iframe host either way.
 
 The console reads this from `/api/runtime/status` and renders a rail icon per
 view (keyed `plugin:<id>:<viewId>`). When selected, it hosts `path` in a


### PR DESCRIPTION
**Phase 3 of the lean-core work** — the substrate for moving Notes (and any plugin) into the right sidebar.

A plugin console view (ADR 0026) gains an optional **`placement`**:
- `rail` (default) — a left-rail surface (unchanged).
- `right` — a right-sidebar panel alongside **Notes / Beads / Goals / Schedule**, same iframe host.

Frontend-only: the manifest already passes view dicts through verbatim, so `placement` flows with **no backend change**. `App.tsx` splits plugin views by placement and renders the right-placed ones as right-rail tabs.

e2e: a `placement: right` fixture view shows as a right-rail tab and loads its page. Full e2e **58/58**; ADR 0026 + plugin-views guide updated.

Part of: ~~daily_log~~ (#689) → ~~GitHub plugin~~ (#690) → **right-rail panels** → Notes plugin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)