### PR TITLE
feat(github-plugin): CI-triage tools — github_ci_runs + github_run_failure

### DIFF
--- a/plugins/github/__init__.py
+++ b/plugins/github/__init__.py
@@ -1,6 +1,6 @@
 """GitHub read tools as a first-party plugin (lean-core audit).
 
-The read-only GitHub tools (PR / issue / list-issues / commit-diff over the `gh`
+The read-only GitHub tools (PR / issue / list-issues / commit-diff / CI runs + failures over the `gh`
 CLI) aren't universal, so they're opt-in rather than shipped in the default tool
 set. The implementation stays in ``tools/github_tools.py`` (a shared library that
 uses ``tools/gh_cli.py``); this plugin just registers it. Enable with
@@ -18,4 +18,4 @@ def register(registry) -> None:
     from tools.github_tools import get_github_tools
 
     registry.register_tools(get_github_tools())
-    log.info("[plugins] github: registered %d read tools", 4)
+    log.info("[plugins] github: registered %d read tools", 6)

--- a/tests/test_github_plugin.py
+++ b/tests/test_github_plugin.py
@@ -33,4 +33,5 @@ def test_github_plugin_registers_the_read_tools():
     names = {t.name for t in reg.tools}
     assert names == {
         "github_get_pr", "github_get_issue", "github_list_issues", "github_get_commit_diff",
+        "github_ci_runs", "github_run_failure",
     }

--- a/tests/test_github_tools.py
+++ b/tests/test_github_tools.py
@@ -23,6 +23,8 @@ async def test_repo_required_no_silent_default():
                 arg = {"repo": ""}
             if name == "github_get_commit_diff":
                 arg = {"repo": "", "ref": "abc"}
+            if name == "github_run_failure":
+                arg = {"repo": "", "run_id": 1}
             out = await t.ainvoke(arg)
             assert out.startswith("Error:"), name
             assert "no default" in out.lower() or "owner/name" in out.lower()
@@ -88,3 +90,47 @@ async def test_run_gh_missing_binary():
     with patch("asyncio.create_subprocess_exec", side_effect=FileNotFoundError):
         rc, out, err = await run_gh(["pr", "view", "1"])
     assert rc == 1 and "not installed" in err
+
+
+@pytest.mark.asyncio
+async def test_ci_runs_happy_path():
+    payload = json.dumps([
+        {"databaseId": 101, "name": "CI", "status": "completed", "conclusion": "failure",
+         "headBranch": "main", "event": "push", "createdAt": "t", "url": "http://x/101"},
+        {"databaseId": 102, "name": "CI", "status": "completed", "conclusion": "success",
+         "headBranch": "main", "event": "push", "createdAt": "t", "url": "http://x/102"},
+    ])
+    with patch("tools.github_tools.run_gh", return_value=(0, payload, "")):
+        out = await _tools()["github_ci_runs"].ainvoke({"repo": "o/r"})
+    assert "#101 [failure]" in out and "http://x/101" in out
+    assert "2 recent run(s)" in out
+
+
+@pytest.mark.asyncio
+async def test_ci_runs_empty():
+    with patch("tools.github_tools.run_gh", return_value=(0, "[]", "")):
+        out = await _tools()["github_ci_runs"].ainvoke({"repo": "o/r", "branch": "main"})
+    assert "No recent runs" in out and "main" in out
+
+
+@pytest.mark.asyncio
+async def test_run_failure_extracts_error_lines():
+    log = (
+        "build\tCompile\t2026-01-01T00:00:00Z all good here\n"
+        "test\tRun tests\t2026-01-01T00:00:01Z AssertionError: expected 1 to equal 2\n"
+        "test\tRun tests\t2026-01-01T00:00:02Z 1 passed, 1 failed\n"
+        "test\tRun tests\t2026-01-01T00:00:03Z just a normal line\n"
+    )
+    with patch("tools.github_tools.run_gh", return_value=(0, log, "")):
+        out = await _tools()["github_run_failure"].ainvoke({"repo": "o/r", "run_id": 101})
+    assert "AssertionError: expected 1 to equal 2" in out
+    assert "1 passed, 1 failed" in out      # matched on "fail"
+    assert "all good here" not in out        # non-error line filtered out
+
+
+@pytest.mark.asyncio
+async def test_run_failure_falls_back_to_tail():
+    log = "job\tstep\t2026Z benign line one\njob\tstep\t2026Z benign line two\n"
+    with patch("tools.github_tools.run_gh", return_value=(0, log, "")):
+        out = await _tools()["github_run_failure"].ainvoke({"repo": "o/r", "run_id": 5})
+    assert "benign line two" in out          # tail fallback when nothing matches

--- a/tools/github_tools.py
+++ b/tools/github_tools.py
@@ -1,4 +1,4 @@
-"""GitHub read tools — PRs, issues, commits — over the ``gh`` CLI.
+"""GitHub read tools — PRs, issues, commits, CI runs/failures — over the ``gh`` CLI.
 
 Closes the long-standing fleet requests for GitHub read access
 (protoAgent #158, #159). Each tool requires an explicit ``repo``
@@ -23,6 +23,15 @@ from tools.fallbacks import with_fallback
 from tools.gh_cli import check_gh_error, run_gh
 
 _REPO_RE = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+
+# Error-relevant lines to surface from a failed CI log (github_run_failure) — the
+# deterministic version of hand-grepping a CI log for what actually broke.
+_CI_ERR_RE = re.compile(
+    r"(error|fail|✕|✗|×|not ok|exit code|command not found|exception|traceback|"
+    r"assertion|timeout|expected .* to|cannot |refused|unauthorized|forbidden|"
+    r"panic|fatal)",
+    re.IGNORECASE,
+)
 
 
 def _bad_repo(repo: str) -> str | None:
@@ -163,4 +172,94 @@ def get_github_tools() -> list:
             diff = diff[:max_chars] + f"\n… (truncated at {max_chars} chars)"
         return f"Commit {repo}@{ref}:\n\n{diff}"
 
-    return [github_get_pr, github_get_issue, github_list_issues, github_get_commit_diff]
+    @tool
+    @with_fallback()
+    async def github_ci_runs(repo: str, branch: str = "", limit: int = 15) -> str:
+        """List recent GitHub Actions runs for a repo — for CI triage.
+
+        Args:
+            repo: Repository as ``owner/name`` (required, no default).
+            branch: Optional branch filter (e.g. ``main``).
+            limit: Max runs to return (capped at 50).
+
+        Feed a failing run's id to ``github_run_failure`` to see why it failed.
+        """
+        err = _bad_repo(repo)
+        if err:
+            return err
+        args = [
+            "run", "list", "--repo", repo,
+            "--limit", str(max(1, min(int(limit), 50))),
+            "--json", "databaseId,name,status,conclusion,headBranch,event,createdAt,url",
+        ]
+        if branch.strip():
+            args += ["--branch", branch.strip()]
+        rc, out, serr = await run_gh(args)
+        gh_err = check_gh_error(rc, serr)
+        if gh_err:
+            return gh_err
+        try:
+            runs = json.loads(out)
+        except json.JSONDecodeError:
+            return f"Error: could not parse gh output: {out[:200]}"
+        if not runs:
+            return f"No recent runs for {repo}" + (f" on {branch}" if branch.strip() else "")
+        lines = [
+            f"#{r.get('databaseId')} [{r.get('conclusion') or r.get('status')}] "
+            f"{r.get('name')} ({r.get('headBranch')} · {r.get('event')}) — {r.get('url')}"
+            for r in runs
+        ]
+        return f"{repo} — {len(runs)} recent run(s):\n" + "\n".join(lines)
+
+    @tool
+    @with_fallback()
+    async def github_run_failure(repo: str, run_id: int, max_lines: int = 40) -> str:
+        """Explain why a GitHub Actions run failed — the error lines from its
+        failed steps (the deterministic version of hand-grepping a CI log).
+
+        Args:
+            repo: Repository as ``owner/name`` (required, no default).
+            run_id: The run id (``databaseId`` from ``github_ci_runs``).
+            max_lines: Cap on error lines returned (capped at 80).
+
+        Pulls only the failed steps' logs (``gh run view --log-failed``), keeps the
+        error-relevant lines (matched, deduped), and falls back to the log tail
+        when nothing matches.
+        """
+        err = _bad_repo(repo)
+        if err:
+            return err
+        cap = max(5, min(int(max_lines), 80))
+        rc, out, serr = await run_gh(
+            ["run", "view", str(run_id), "--repo", repo, "--log-failed"], timeout=60
+        )
+        gh_err = check_gh_error(rc, serr)
+        if gh_err:
+            return gh_err
+        # gh prefixes each line "<job>\t<step>\t<timestamp> <message>"; keep the tail.
+        raw = [ln.rstrip() for ln in out.splitlines() if ln.strip()]
+        seen: set = set()
+        uniq: list[str] = []
+        for ln in raw:
+            msg = ln.split("\t")[-1]
+            if _CI_ERR_RE.search(msg):
+                key = msg[:120]
+                if key not in seen:
+                    seen.add(key)
+                    uniq.append(msg[:200])
+        picked = uniq[-cap:] if uniq else [ln.split("\t")[-1][:200] for ln in raw[-cap:]]
+        if not picked:
+            return (
+                f"Run {run_id} in {repo}: no failed-step log lines "
+                "(run may not have failed, or its logs expired)."
+            )
+        return f"{repo} run {run_id} — failure log ({len(picked)} line(s)):\n" + "\n".join(picked)
+
+    return [
+        github_get_pr,
+        github_get_issue,
+        github_list_issues,
+        github_get_commit_diff,
+        github_ci_runs,
+        github_run_failure,
+    ]


### PR DESCRIPTION
The first-party `github` read plugin has PR/issue/list/diff but no CI surface. These add the two universal CI-triage tools (proven on live fleet CI in roxy, now contributed up so every agent gets them rather than each fork carrying its own):

- **`github_ci_runs(repo, branch?, limit?)`** — recent Actions runs (id/status/conclusion/branch/event/url) via `gh run list --json`.
- **`github_run_failure(repo, run_id, max_lines?)`** — why a run failed: pulls only the failed steps' logs (`gh run view --log-failed`), keeps the error-relevant lines (matched + deduped, tail-fallback) — the deterministic version of hand-grepping a CI log.

Same gh-CLI style as the existing tools (`run_gh` + `check_gh_error` + `_bad_repo`; graceful when gh/auth absent). Plugin now registers **6** read tools; manifest/docstrings updated. Tests added (happy/empty/extract/tail-fallback) — **11/11 pass**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)