### PR TITLE
chore: protolabs/* gateway pricing + python-multipart dep (from roxy fork)

### DIFF
--- a/pricing.py
+++ b/pricing.py
@@ -26,6 +26,16 @@ MODEL_RATES: dict[str, dict[str, float]] = {
     "claude-haiku-4-5-20251001": {"input": 0.00000025, "output": 0.00000125},
     "gpt-4o":                    {"input": 0.0000025,  "output": 0.00001},
     "gpt-4o-mini":               {"input": 0.00000015, "output": 0.0000006},
+    # protolabs/* are self-hosted vLLM (RTX 6000 Blackwell) — no per-token API
+    # spend, so these are a low nominal local-compute estimate (trackable, not
+    # billing) rather than the Claude-ish `default` which would overstate cost
+    # ~30x. Substring match covers the gateway aliases (protolabs/reasoning →
+    # protolabs/smart backend, etc.). Keep in sync with Workstacean MODEL_RATES.
+    "protolabs/reasoning":       {"input": 0.0000001,  "output": 0.0000004},
+    "protolabs/smart":           {"input": 0.0000001,  "output": 0.0000004},
+    "protolabs/fast":            {"input": 0.00000005, "output": 0.0000002},
+    "protolabs/nano":            {"input": 0.00000003, "output": 0.0000001},
+    "protolabs":                 {"input": 0.0000001,  "output": 0.0000004},
     "default":                   {"input": 0.000003,   "output": 0.000015},
 }
 

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -20,6 +20,7 @@ protolabs-a2a @ git+https://github.com/protoLabsAI/protolabs-a2a.git@v0.2.0
 # (--ui none/console) drop Gradio (requirements-ui.txt), so the lean image had
 # no FastAPI and couldn't serve. Declared here as the core runtime dep it is.
 fastapi>=0.115
+python-multipart>=0.0.9   # FastAPI form/multipart parsing (fs/image routes + A2A parts)
 uvicorn>=0.30
 langfuse>=3.0
 prometheus-client>=0.20

--- a/tests/test_pricing.py
+++ b/tests/test_pricing.py
@@ -33,3 +33,10 @@ def test_cost_usd_empty_usage_is_zero() -> None:
 def test_cost_usd_handles_none_and_missing_fields() -> None:
     # Robust to partial usage dicts (no crash, sensible number).
     assert pricing.cost_usd("gpt-4o", {"input_tokens": 100}) == round(100 * 0.0000025, 6)
+
+
+def test_rate_for_protolabs_gateway_models() -> None:
+    # Self-hosted protolabs/* (vLLM) — low nominal local-compute estimate, not the
+    # Claude-ish default (which would overstate ~30x). Aliases resolve by substring.
+    assert pricing.rate_for("protolabs/reasoning") == pricing.MODEL_RATES["protolabs/reasoning"]
+    assert pricing.rate_for("protolabs/fast")["input"] < pricing.MODEL_RATES["default"]["input"]


### PR DESCRIPTION
Two small generic adoptions from the roxy fork (clearing fork-deltas):

- **pricing.py** — add `protolabs/{reasoning,smart,fast}` rates. Self-hosted vLLM (no per-token API spend) → a low nominal local-compute estimate, not the Claude-ish `default` which overstates gateway cost ~30×. Substring match covers the aliases.
- **requirements-core.txt** — add `python-multipart` (FastAPI form/multipart parsing for the core fs/image routes + A2A parts; was undeclared).

Test added (protolabs rate lookup); test_pricing **7/7**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)