### PR TITLE
feat(console): Plugins view → Installed / Marketplace / Install

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Plugins view reorganized** — three sections: **Installed** (grouped Loaded → Disabled,
+  alphabetical within each) → **Marketplace** (browse the directory + the `protoagent-plugin`
+  GitHub topic) → **Install from a git URL**.
+
 ### Fixed
 - **Marketing changelog stays in sync** — `sites/marketing/data/changelog.json` is now
   derived from CHANGELOG.md (`scripts/changelog.py json`, run in prepare-release) instead of

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -35,6 +35,7 @@ export const RUNTIME_STATUS = {
   },
   plugins: [
     { id: "demo", name: "Demo Plugin", version: "1.0.0", enabled: true, loaded: true, tools: ["demo_tool"], skills: 1 },
+    { id: "zzz-off", name: "Zzz Disabled", version: "0.1.0", enabled: false, loaded: false, tools: [], skills: 0 },
     // A plugin that contributes a console view (ADR 0026) → a dynamic rail icon + iframe.
     {
       id: "boardy", name: "Boardy", version: "0.1.0", enabled: true, loaded: true, tools: [], skills: 0,

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -56,8 +56,14 @@ test("agent surface: identity lands, then tools and MCP tabs", async ({ page }) 
   await expect(page.getByText("echo · stdio")).toBeVisible(); // MCP server
 });
 
-test("plugins are their own section listing loaded plugins", async ({ page }) => {
+test("plugins section: Loaded/Disabled groups, marketplace, and install", async ({ page }) => {
   await page.locator(".rail").getByRole("button", { name: "Plugins", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
+  // Installed shows both a loaded and a disabled plugin (the two status groups).
   await expect(page.getByText("Demo Plugin", { exact: false })).toBeVisible();
+  await expect(page.getByText("Zzz Disabled", { exact: false })).toBeVisible();
+  await expect(page.locator(".panel-kicker", { hasText: "Marketplace" })).toBeVisible();
+  // Marketplace discovery + install-from-git section both present.
+  await expect(page.getByRole("link", { name: /Browse the directory/ })).toBeVisible();
+  await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
 });

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -776,6 +776,37 @@ select:disabled {
   overflow: auto;
 }
 
+/* Plugins → Marketplace: discovery links (directory + GitHub topic). */
+.plugin-market {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.plugin-market-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--pl-color-border);
+  background: var(--pl-color-bg-raised);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.15s;
+}
+.plugin-market-link:hover {
+  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 45%, transparent);
+}
+.plugin-market-link > span {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 1px;
+}
+.plugin-market-link .muted {
+  font-size: 12px;
+}
+
 .scroll-area {
   min-width: 0;
   min-height: 0;

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -1,74 +1,104 @@
 import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
 import { Suspense } from "react";
-import { ExternalLink } from "lucide-react";
+import { ExternalLink, Github, Store } from "lucide-react";
 
 import { PanelHeader } from "../app/PanelHeader";
 import { runtimeStatusQuery } from "../lib/queries";
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { StatusPill } from "../app/StatusPill";
 import { PluginsSection } from "../settings/PluginsSection";
+import type { RuntimeStatus } from "../lib/types";
 
-// Plugins: the installed plugins home — what's loaded, what each adds, and what
-// errored. Browse + install more from the public directory.
+type Plugin = NonNullable<RuntimeStatus["plugins"]>[number];
+
+const DIRECTORY_URL = "https://agent.protolabs.studio/plugins";
+const TOPIC_URL = "https://github.com/topics/protoagent-plugin";
+
+function contributionsLabel(p: Plugin): string {
+  return (
+    [
+      p.loaded && p.tools.length ? `${p.tools.length} tool${p.tools.length === 1 ? "" : "s"}` : null,
+      p.loaded && p.skills ? `${p.skills} skill${p.skills === 1 ? "" : "s"}` : null,
+      p.views?.length ? `${p.views.length} view${p.views.length === 1 ? "" : "s"}` : null,
+      p.error || null,
+    ].filter(Boolean).join(" · ") || "no contributions"
+  );
+}
+
+function PluginRow({ p }: { p: Plugin }) {
+  return (
+    <div className="subagent-row" key={p.id}>
+      <div>
+        <strong>
+          {p.name}
+          {p.version ? <span className="muted"> v{p.version}</span> : null}
+        </strong>
+        <span>{contributionsLabel(p)}</span>
+      </div>
+      <StatusPill
+        label={p.loaded ? "loaded" : p.error ? "error" : p.enabled ? "enabled" : "disabled"}
+        tone={p.loaded ? "success" : p.error ? "error" : "muted"}
+      />
+    </div>
+  );
+}
 
 function PluginsBody() {
   const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
   const plugins = runtime.plugins ?? [];
-  const loaded = plugins.filter((p) => p.loaded).length;
+  const byName = (a: Plugin, b: Plugin) => a.name.localeCompare(b.name);
+  // Installed, grouped by status: loaded first, then disabled — alpha within each.
+  const loaded = plugins.filter((p) => p.loaded).sort(byName);
+  const disabled = plugins.filter((p) => !p.loaded).sort(byName);
 
   return (
     <>
       <PanelHeader
         title="Plugins"
-        kicker={`${plugins.length} installed · ${loaded} loaded`}
-        actions={
-          <a
-            className="icon-button"
-            href="https://agent.protolabs.studio/plugins"
-            target="_blank"
-            rel="noopener noreferrer"
-            title="Browse the plugin directory"
-          >
-            <ExternalLink size={16} />
-          </a>
-        }
+        kicker={`${plugins.length} installed · ${loaded.length} loaded`}
       />
       <div className="stage-body">
+        {/* 1 — Installed (loaded → disabled, alphabetical) */}
         {plugins.length ? (
-          <div className="subagent-list">
-            {plugins.map((plugin) => (
-              <div className="subagent-row" key={plugin.id}>
-                <div>
-                  <strong>
-                    {plugin.name}
-                    {plugin.version ? <span className="muted"> v{plugin.version}</span> : null}
-                  </strong>
-                  <span>
-                    {[
-                      plugin.loaded && plugin.tools.length ? `${plugin.tools.length} tool${plugin.tools.length === 1 ? "" : "s"}` : null,
-                      plugin.loaded && plugin.skills ? `${plugin.skills} skill${plugin.skills === 1 ? "" : "s"}` : null,
-                      plugin.views?.length ? `${plugin.views.length} view${plugin.views.length === 1 ? "" : "s"}` : null,
-                      plugin.error || null,
-                    ].filter(Boolean).join(" · ") || "no contributions"}
-                  </span>
-                </div>
-                <StatusPill
-                  label={plugin.loaded ? "loaded" : plugin.error ? "error" : plugin.enabled ? "enabled" : "disabled"}
-                  tone={plugin.loaded ? "success" : plugin.error ? "error" : "muted"}
-                />
-              </div>
-            ))}
-          </div>
+          <>
+            {loaded.length ? (
+              <>
+                <p className="panel-kicker">Loaded <span className="muted">· {loaded.length}</span></p>
+                <div className="subagent-list">{loaded.map((p) => <PluginRow key={p.id} p={p} />)}</div>
+              </>
+            ) : null}
+            {disabled.length ? (
+              <>
+                <p className="panel-kicker">Disabled <span className="muted">· {disabled.length}</span></p>
+                <div className="subagent-list">{disabled.map((p) => <PluginRow key={p.id} p={p} />)}</div>
+              </>
+            ) : null}
+          </>
         ) : (
           <div className="table-list">
             <div className="table-row">
-              <span>no plugins enabled — install one below, then add it to <code>plugins.enabled</code></span>
+              <span>no plugins installed — browse the marketplace or install from a git URL below</span>
               <StatusPill label="none" tone="muted" />
             </div>
           </div>
         )}
 
-        {/* Install / manage from a git URL (ADR 0027) — the management half. */}
+        {/* 2 — Marketplace (discover) */}
+        <p className="panel-kicker">Marketplace</p>
+        <div className="plugin-market">
+          <a className="plugin-market-link" href={DIRECTORY_URL} target="_blank" rel="noopener noreferrer">
+            <Store size={16} />
+            <span><strong>Browse the directory</strong><span className="muted">Curated + community plugins, with install URLs</span></span>
+            <ExternalLink size={14} />
+          </a>
+          <a className="plugin-market-link" href={TOPIC_URL} target="_blank" rel="noopener noreferrer">
+            <Github size={16} />
+            <span><strong>GitHub topic</strong><span className="muted">Every repo tagged <code>protoagent-plugin</code></span></span>
+            <ExternalLink size={14} />
+          </a>
+        </div>
+
+        {/* 3 — Install (the PluginsSection ships its own "Install from a git URL" header) */}
         <PluginsSection />
       </div>
     </>


### PR DESCRIPTION
Reorganizes the Plugins view into three sections (per request):

1. **Installed** — grouped by status: **Loaded** first, then **Disabled**, alphabetical within each (was a flat registry-order list).
2. **Marketplace** — discovery links: the plugin **directory** + the `protoagent-plugin` **GitHub topic**.
3. **Install** — the existing install-from-a-git-URL form.

e2e: a disabled fixture plugin proves the two status groups; the test asserts both plugins, the Marketplace section, and the install form render. Full e2e **58/58**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)