### PR TITLE
feat(mcp): add/remove MCP servers from the console (hot reload)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Add MCP servers from the console** — Agent → MCP has an inline Add-server form (stdio
+  command/args, or http/sse URL) plus a per-server remove button; both hot-reload, so the
+  server connects (or drops) without a restart.
 - **One-click plugin enable/disable** — toggle a plugin straight from the console Plugins
   panel; it edits `plugins.enabled` and hot-reloads, so tools / middleware / MCP servers apply
   immediately (a console view or background surface needs a restart, and the toggle says so).

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -1,0 +1,20 @@
+import { expect, test } from "@playwright/test";
+
+// Agent → MCP tab: add/remove MCP servers inline (hot reload). The mock runtime
+// status ships one server (echo); add/remove hit the mocked /api/mcp/servers.
+
+test("MCP tab lists servers and adds one inline", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.getByRole("button", { name: "MCP", exact: true }).click();
+
+  await expect(page.getByRole("heading", { name: "MCP servers" })).toBeVisible();
+  await expect(page.getByText("echo · stdio")).toBeVisible();
+
+  // Add a stdio server inline.
+  await page.getByRole("button", { name: /Add server/ }).click();
+  await page.getByPlaceholder("name (e.g. echo)").fill("mathy");
+  await page.getByPlaceholder("command (e.g. python)").fill("python");
+  await page.getByRole("button", { name: "Connect", exact: true }).click();
+  await expect(page.locator(".plugin-hint")).toContainText("Connected mathy");
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -276,6 +276,15 @@ const server = createServer(async (req, res) => {
         });
       }
     }
+    if (pathname === "/api/mcp/servers" && req.method === "POST") {
+      return sendJson(res, { ok: true, name: body.name, servers: [body.name] });
+    }
+    {
+      const m = pathname.match(/^\/api\/mcp\/servers\/([^/]+)$/);
+      if (m && req.method === "DELETE") {
+        return sendJson(res, { ok: true, servers: [] });
+      }
+    }
     if (pathname === "/api/plugins/install") {
       const id = (String(body.url || "").replace(/\.git$/, "").split("/").pop()) || "ext_plugin";
       const sha = "abc1234567def8900000000000000000000abcd";

--- a/apps/web/src/app/McpPanel.tsx
+++ b/apps/web/src/app/McpPanel.tsx
@@ -1,18 +1,98 @@
-import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
-import { Suspense } from "react";
+import { QueryErrorResetBoundary, useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
+import { Suspense, useState } from "react";
+import { Loader2, Plus, Trash2 } from "lucide-react";
 
 import { PanelHeader } from "./PanelHeader";
 import { runtimeStatusQuery } from "../lib/queries";
 import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
 import { StatusPill } from "./StatusPill";
+import { api } from "../lib/api";
 
-// Runtime → MCP: external Model Context Protocol servers whose tools are wired
-// into the agent (namespaced <server>__<tool>).
+// Agent → MCP: external Model Context Protocol servers whose tools are wired into
+// the agent (namespaced <server>__<tool>). Add/remove here hot-reloads — the new
+// server's tools wire in immediately, no restart.
+
+type Transport = "stdio" | "http" | "sse";
+
+function AddServerForm({ onDone }: { onDone: (msg: string) => void }) {
+  const qc = useQueryClient();
+  const [open, setOpen] = useState(false);
+  const [name, setName] = useState("");
+  const [transport, setTransport] = useState<Transport>("stdio");
+  const [command, setCommand] = useState("");
+  const [args, setArgs] = useState("");
+  const [url, setUrl] = useState("");
+
+  const reset = () => { setName(""); setCommand(""); setArgs(""); setUrl(""); setTransport("stdio"); };
+  const add = useMutation({
+    mutationFn: () =>
+      api.addMcpServer(
+        transport === "stdio"
+          ? { name, transport, command, args }
+          : { name, transport, url },
+      ),
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      reset();
+      setOpen(false);
+      onDone(`Connected ${res.name} — its tools are live.`);
+    },
+    onError: (err: unknown) => onDone(`Couldn't add server: ${err instanceof Error ? err.message : String(err)}`),
+  });
+
+  const valid = name.trim() && (transport === "stdio" ? command.trim() : url.trim());
+
+  if (!open) {
+    return (
+      <button type="button" className="ghost-button" onClick={() => setOpen(true)}>
+        <Plus size={14} /> Add server
+      </button>
+    );
+  }
+  return (
+    <form className="mcp-add-form" onSubmit={(e) => { e.preventDefault(); if (valid) add.mutate(); }}>
+      <div className="mcp-add-row">
+        <input className="playbook-search" placeholder="name (e.g. echo)" value={name} onChange={(e) => setName(e.target.value)} />
+        <select className="playbook-search" value={transport} onChange={(e) => setTransport(e.target.value as Transport)}>
+          <option value="stdio">stdio</option>
+          <option value="http">http</option>
+          <option value="sse">sse</option>
+        </select>
+      </div>
+      {transport === "stdio" ? (
+        <div className="mcp-add-row">
+          <input className="playbook-search" placeholder="command (e.g. python)" value={command} onChange={(e) => setCommand(e.target.value)} />
+          <input className="playbook-search" placeholder="args (space-separated)" value={args} onChange={(e) => setArgs(e.target.value)} />
+        </div>
+      ) : (
+        <input className="playbook-search" placeholder="url (https://…)" value={url} onChange={(e) => setUrl(e.target.value)} />
+      )}
+      <div className="mcp-add-actions">
+        <button type="submit" className="ghost-button" disabled={!valid || add.isPending}>
+          {add.isPending ? <Loader2 size={14} className="spin" /> : "Connect"}
+        </button>
+        <button type="button" className="ghost-button" onClick={() => { reset(); setOpen(false); }}>Cancel</button>
+      </div>
+    </form>
+  );
+}
 
 function McpBody() {
   const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
+  const qc = useQueryClient();
+  const [hint, setHint] = useState<string | null>(null);
   const servers = runtime.mcp?.servers ?? [];
   const total = runtime.mcp?.tool_count ?? 0;
+
+  const remove = useMutation({
+    mutationFn: (n: string) => api.removeMcpServer(n),
+    onSuccess: (_res, n) => {
+      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      setHint(`Removed ${n}.`);
+    },
+    onError: (err: unknown, n) => setHint(`Couldn't remove ${n}: ${err instanceof Error ? err.message : String(err)}`),
+  });
+  const removingName = remove.isPending ? remove.variables : undefined;
 
   return (
     <>
@@ -21,17 +101,30 @@ function McpBody() {
         kicker={`${servers.length} server${servers.length === 1 ? "" : "s"} · ${total} tool${total === 1 ? "" : "s"}`}
       />
       <div className="stage-body">
+        {hint ? <p className="plugin-hint">{hint}</p> : null}
+        <AddServerForm onDone={setHint} />
         <div className="table-list">
           {servers.length ? (
             servers.map((server) => (
               <div className="table-row" key={server.name}>
                 <span>{server.name} · {server.transport}</span>
-                <StatusPill label={`${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`} tone="success" />
+                <div className="plugin-row-actions">
+                  <StatusPill label={`${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`} tone="success" />
+                  <button
+                    type="button"
+                    className="ghost-button"
+                    disabled={removingName === server.name}
+                    onClick={() => { setHint(null); remove.mutate(server.name); }}
+                    title={`Remove ${server.name}`}
+                  >
+                    {removingName === server.name ? <Loader2 size={14} className="spin" /> : <Trash2 size={14} />}
+                  </button>
+                </div>
               </div>
             ))
           ) : (
             <div className="table-row">
-              <span>no MCP servers configured</span>
+              <span>no MCP servers configured — add one above</span>
               <StatusPill label={runtime.mcp?.enabled ? "enabled" : "off"} tone="muted" />
             </div>
           )}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -842,6 +842,30 @@ select:disabled {
   border: 1px solid var(--pl-color-border);
 }
 
+/* MCP → Add server form */
+.mcp-add-form {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  margin-bottom: 10px;
+  padding: 10px;
+  border-radius: 8px;
+  border: 1px solid var(--pl-color-border);
+  background: var(--pl-color-bg-raised);
+}
+.mcp-add-row {
+  display: flex;
+  gap: 8px;
+}
+.mcp-add-row > * {
+  flex: 1;
+  min-width: 0;
+}
+.mcp-add-actions {
+  display: flex;
+  gap: 8px;
+}
+
 .scroll-area {
   min-width: 0;
   min-height: 0;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -866,6 +866,18 @@ export const api = {
       { method: "POST", body: { enabled } },
     );
   },
+  addMcpServer(entry: Record<string, unknown>) {
+    return request<{ ok: boolean; name: string; servers: string[] }>(
+      "/api/mcp/servers",
+      { method: "POST", body: entry },
+    );
+  },
+  removeMcpServer(name: string) {
+    return request<{ ok: boolean; servers: string[] }>(
+      `/api/mcp/servers/${encodeURIComponent(name)}`,
+      { method: "DELETE" },
+    );
+  },
   createDelegate(entry: Record<string, unknown>) {
     return request<{ ok: boolean; message: string; delegates: DelegateView[] }>("/api/delegates", {
       method: "POST",

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -11,8 +11,11 @@ Built on [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mc
 
 ## Enabling it
 
-MCP is **off by default** — configuring a server is the opt-in. Add an `mcp`
-section to your config (`config/langgraph-config.yaml`, or via the wizard/drawer):
+MCP is **off by default** — configuring a server is the opt-in. The quickest way is
+the console: **Agent → MCP → Add server** (name, transport, command/args or URL) wires
+it in **without a restart** (the change hot-reloads and the server connects), and the
+remove button drops one the same way. Prefer YAML? Add an `mcp` section to your config
+(`config/langgraph-config.yaml`, or via the wizard/drawer):
 
 ```yaml
 mcp:

--- a/operator_api/mcp_routes.py
+++ b/operator_api/mcp_routes.py
@@ -1,0 +1,88 @@
+"""Operator API for MCP servers — add/remove from the console (hot reload).
+
+Backs the Agent → MCP tab: edit ``mcp.servers`` without hand-editing YAML. Both
+endpoints persist the change and hot-reload (``_build_mcp`` reconnects on reload),
+so a new server's tools wire in immediately — no restart. The live config is
+gitignored, so ``env`` values stay local.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from fastapi import HTTPException
+
+from runtime.state import STATE
+
+log = logging.getLogger(__name__)
+
+_TRANSPORTS = {"stdio", "http", "streamable_http", "sse"}
+
+
+def _clean_entry(body: dict) -> dict:
+    """Validate + normalize an mcp.servers entry from the form."""
+    name = str(body.get("name", "")).strip()
+    transport = (str(body.get("transport", "stdio")).strip() or "stdio")
+    if not name:
+        raise HTTPException(status_code=400, detail="name is required")
+    if transport not in _TRANSPORTS:
+        raise HTTPException(status_code=400, detail=f"transport must be one of {sorted(_TRANSPORTS)}")
+
+    entry: dict = {"name": name, "transport": transport}
+    if transport == "stdio":
+        command = str(body.get("command", "")).strip()
+        if not command:
+            raise HTTPException(status_code=400, detail="stdio transport needs a command")
+        entry["command"] = command
+        args = body.get("args")
+        if isinstance(args, list):
+            args = [str(a).strip() for a in args if str(a).strip()]
+        elif isinstance(args, str):
+            args = args.split()
+        else:
+            args = []
+        if args:
+            entry["args"] = args
+    else:  # http / streamable_http / sse
+        url = str(body.get("url", "")).strip()
+        if not url:
+            raise HTTPException(status_code=400, detail=f"{transport} transport needs a url")
+        entry["url"] = url
+
+    env = body.get("env")
+    if isinstance(env, dict):
+        env = {str(k).strip(): str(v) for k, v in env.items() if str(k).strip()}
+        if env:
+            entry["env"] = env
+    return entry
+
+
+def register_mcp_routes(app) -> None:
+    """Register `POST /api/mcp/servers` and `DELETE /api/mcp/servers/{name}`."""
+
+    @app.post("/api/mcp/servers")
+    async def _add(body: dict | None = None):
+        entry = _clean_entry(body or {})
+        cfg = STATE.graph_config
+        servers = [s for s in (getattr(cfg, "mcp_servers", []) or []) if s.get("name") != entry["name"]]
+        servers.append(entry)
+
+        from server.agent_init import _apply_settings_changes
+
+        # enabling MCP + replacing the servers list; _build_mcp reconnects on reload.
+        ok, messages = _apply_settings_changes(config={"mcp": {"enabled": True, "servers": servers}})
+        if not ok:
+            raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
+        return {"ok": True, "name": entry["name"], "servers": [s["name"] for s in servers]}
+
+    @app.delete("/api/mcp/servers/{name}")
+    async def _remove(name: str):
+        cfg = STATE.graph_config
+        servers = [s for s in (getattr(cfg, "mcp_servers", []) or []) if s.get("name") != name]
+
+        from server.agent_init import _apply_settings_changes
+
+        ok, messages = _apply_settings_changes(config={"mcp": {"servers": servers}})
+        if not ok:
+            raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
+        return {"ok": True, "servers": [s["name"] for s in servers]}

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -419,6 +419,7 @@ def _main():
     from operator_api.config_routes import register_config_routes
     from operator_api.knowledge_routes import register_knowledge_routes
     from operator_api.plugin_routes import register_plugin_routes
+    from operator_api.mcp_routes import register_mcp_routes
     from operator_api.routes import register_operator_routes
     from operator_api.telemetry_routes import register_telemetry_routes
 
@@ -584,6 +585,7 @@ def _main():
     # operator_api/knowledge_routes.py (ADR 0023 phase 3).
     register_knowledge_routes(fastapi_app)
     register_plugin_routes(fastapi_app)
+    register_mcp_routes(fastapi_app)
 
     # --- Telemetry (ADR 0006 Slice 2) --------------------------------------
     # Per-turn cost/latency + advise-only insights (ADR 0006). Extracted to

--- a/tests/test_mcp_routes.py
+++ b/tests/test_mcp_routes.py
@@ -1,0 +1,70 @@
+"""Operator MCP routes — add/remove mcp.servers from the console (hot reload)."""
+
+import sys
+import types
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+
+def _client():
+    from operator_api.mcp_routes import register_mcp_routes
+
+    app = FastAPI()
+    register_mcp_routes(app)
+    return TestClient(app)
+
+
+def _wire(monkeypatch, *, servers):
+    captured: dict = {}
+    fake = types.ModuleType("server.agent_init")
+
+    def _apply(config=None, soul=None):
+        captured["config"] = config
+        return True, ["reloaded"]
+
+    fake._apply_settings_changes = _apply
+    monkeypatch.setitem(sys.modules, "server.agent_init", fake)
+
+    import runtime.state as rs
+    monkeypatch.setattr(rs.STATE, "graph_config",
+                        types.SimpleNamespace(mcp_servers=list(servers)), raising=False)
+    return captured
+
+
+def test_add_stdio_server_enables_mcp_and_hot_reloads(monkeypatch):
+    captured = _wire(monkeypatch, servers=[])
+    body = _client().post("/api/mcp/servers", json={
+        "name": "echo", "transport": "stdio", "command": "python", "args": "-m echo",
+    }).json()
+    assert body["ok"] and body["servers"] == ["echo"]
+    mcp = captured["config"]["mcp"]
+    assert mcp["enabled"] is True
+    assert mcp["servers"][0] == {"name": "echo", "transport": "stdio", "command": "python", "args": ["-m", "echo"]}
+
+
+def test_add_http_server_requires_url(monkeypatch):
+    _wire(monkeypatch, servers=[])
+    r = _client().post("/api/mcp/servers", json={"name": "remote", "transport": "http"})
+    assert r.status_code == 400
+    assert "url" in r.json()["detail"]
+
+
+def test_add_upserts_by_name(monkeypatch):
+    captured = _wire(monkeypatch, servers=[{"name": "echo", "transport": "stdio", "command": "old"}])
+    _client().post("/api/mcp/servers", json={"name": "echo", "transport": "stdio", "command": "new"}).json()
+    servers = captured["config"]["mcp"]["servers"]
+    assert len(servers) == 1 and servers[0]["command"] == "new"  # replaced, not duplicated
+
+
+def test_remove_server(monkeypatch):
+    captured = _wire(monkeypatch, servers=[{"name": "echo", "transport": "stdio", "command": "x"},
+                                           {"name": "keep", "transport": "stdio", "command": "y"}])
+    body = _client().delete("/api/mcp/servers/echo").json()
+    assert body["servers"] == ["keep"]
+    assert [s["name"] for s in captured["config"]["mcp"]["servers"]] == ["keep"]
+
+
+def test_name_required(monkeypatch):
+    _wire(monkeypatch, servers=[])
+    assert _client().post("/api/mcp/servers", json={"transport": "stdio", "command": "x"}).status_code == 400


### PR DESCRIPTION
The other half of the lane — no more hand-editing `mcp.servers` + restart. **Agent → MCP** gets an inline **Add server** form + a per-server **remove** button.

- **`POST /api/mcp/servers`** (validated: stdio needs `command`, http/sse needs `url`; upserts by name; enables MCP) + **`DELETE /api/mcp/servers/{name}`**. Both edit `mcp.servers` and **hot-reload** — `_build_mcp` reconnects, so a new server's tools wire in **with no restart**. (Live config is gitignored, so `env` stays local.)
- **McpPanel** — a collapsible, transport-aware form (stdio command/args or http/sse URL) + remove buttons + a result hint.

Tests: route validation / upsert / remove / enables-MCP (5 unit); an e2e adds a server inline and asserts the connected hint. Full e2e **59/59**, ruff clean, mcp guide updated.

Completes the config-from-UI lane: ~~Direct plugin enable~~ (#699) → **MCP servers via UI**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)