### PR TITLE
feat(mcp): paste-JSON import for MCP servers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Paste-JSON import for MCP servers** — Agent → MCP → Add server has a Paste JSON mode
+  that accepts the standard `{"mcpServers": {…}}` blob (Claude-Desktop style), a single
+  server object, or our own export, and imports them all at once (hot-reloaded).
 - **Add MCP servers from the console** — Agent → MCP has an inline Add-server form (stdio
   command/args, or http/sse URL) plus a per-server remove button; both hot-reload, so the
   server connects (or drops) without a restart.

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -18,3 +18,17 @@ test("MCP tab lists servers and adds one inline", async ({ page }) => {
   await page.getByRole("button", { name: "Connect", exact: true }).click();
   await expect(page.locator(".plugin-hint")).toContainText("Connected mathy");
 });
+
+test("MCP tab imports servers from pasted JSON", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.getByRole("button", { name: "MCP", exact: true }).click();
+
+  await page.getByRole("button", { name: /Add server/ }).click();
+  await page.getByRole("button", { name: "Paste JSON", exact: true }).click();
+  await page.locator("textarea.mcp-json").fill(
+    '{"mcpServers": {"filesystem": {"command": "npx", "args": ["-y", "@mcp/fs"]}, "weather": {"url": "https://x/mcp"}}}',
+  );
+  await page.getByRole("button", { name: "Import", exact: true }).click();
+  await expect(page.locator(".plugin-hint")).toContainText("Imported 2 servers: filesystem, weather");
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -279,6 +279,14 @@ const server = createServer(async (req, res) => {
     if (pathname === "/api/mcp/servers" && req.method === "POST") {
       return sendJson(res, { ok: true, name: body.name, servers: [body.name] });
     }
+    if (pathname === "/api/mcp/servers/import" && req.method === "POST") {
+      let added = ["imported"];
+      try {
+        const d = JSON.parse(body.raw || "{}");
+        added = d.mcpServers ? Object.keys(d.mcpServers) : [d.name || "imported"];
+      } catch { return sendJson(res, { detail: "invalid JSON" }, 400); }
+      return sendJson(res, { ok: true, added, servers: added });
+    }
     {
       const m = pathname.match(/^\/api\/mcp\/servers\/([^/]+)$/);
       if (m && req.method === "DELETE") {

--- a/apps/web/src/app/McpPanel.tsx
+++ b/apps/web/src/app/McpPanel.tsx
@@ -17,30 +17,37 @@ type Transport = "stdio" | "http" | "sse";
 function AddServerForm({ onDone }: { onDone: (msg: string) => void }) {
   const qc = useQueryClient();
   const [open, setOpen] = useState(false);
+  const [mode, setMode] = useState<"form" | "json">("form");
   const [name, setName] = useState("");
   const [transport, setTransport] = useState<Transport>("stdio");
   const [command, setCommand] = useState("");
   const [args, setArgs] = useState("");
   const [url, setUrl] = useState("");
+  const [json, setJson] = useState("");
 
-  const reset = () => { setName(""); setCommand(""); setArgs(""); setUrl(""); setTransport("stdio"); };
+  const reset = () => {
+    setName(""); setCommand(""); setArgs(""); setUrl(""); setTransport("stdio"); setJson("");
+  };
+  const onSuccess = (msg: string) => {
+    qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+    reset();
+    setOpen(false);
+    onDone(msg);
+  };
   const add = useMutation({
     mutationFn: () =>
-      api.addMcpServer(
-        transport === "stdio"
-          ? { name, transport, command, args }
-          : { name, transport, url },
-      ),
-    onSuccess: (res) => {
-      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
-      reset();
-      setOpen(false);
-      onDone(`Connected ${res.name} — its tools are live.`);
-    },
+      api.addMcpServer(transport === "stdio" ? { name, transport, command, args } : { name, transport, url }),
+    onSuccess: (res) => onSuccess(`Connected ${res.name} — its tools are live.`),
     onError: (err: unknown) => onDone(`Couldn't add server: ${err instanceof Error ? err.message : String(err)}`),
   });
+  const importJson = useMutation({
+    mutationFn: () => api.importMcpServers(json),
+    onSuccess: (res) => onSuccess(`Imported ${res.added.length} server${res.added.length === 1 ? "" : "s"}: ${res.added.join(", ")}.`),
+    onError: (err: unknown) => onDone(`Import failed: ${err instanceof Error ? err.message : String(err)}`),
+  });
 
-  const valid = name.trim() && (transport === "stdio" ? command.trim() : url.trim());
+  const formValid = name.trim() && (transport === "stdio" ? command.trim() : url.trim());
+  const busy = add.isPending || importJson.isPending;
 
   if (!open) {
     return (
@@ -50,26 +57,51 @@ function AddServerForm({ onDone }: { onDone: (msg: string) => void }) {
     );
   }
   return (
-    <form className="mcp-add-form" onSubmit={(e) => { e.preventDefault(); if (valid) add.mutate(); }}>
-      <div className="mcp-add-row">
-        <input className="playbook-search" placeholder="name (e.g. echo)" value={name} onChange={(e) => setName(e.target.value)} />
-        <select className="playbook-search" value={transport} onChange={(e) => setTransport(e.target.value as Transport)}>
-          <option value="stdio">stdio</option>
-          <option value="http">http</option>
-          <option value="sse">sse</option>
-        </select>
+    <form
+      className="mcp-add-form"
+      onSubmit={(e) => {
+        e.preventDefault();
+        if (mode === "json") { if (json.trim()) importJson.mutate(); }
+        else if (formValid) add.mutate();
+      }}
+    >
+      <div className="segmented mcp-add-modes">
+        <button type="button" className={mode === "form" ? "active" : ""} onClick={() => setMode("form")}>Form</button>
+        <button type="button" className={mode === "json" ? "active" : ""} onClick={() => setMode("json")}>Paste JSON</button>
       </div>
-      {transport === "stdio" ? (
-        <div className="mcp-add-row">
-          <input className="playbook-search" placeholder="command (e.g. python)" value={command} onChange={(e) => setCommand(e.target.value)} />
-          <input className="playbook-search" placeholder="args (space-separated)" value={args} onChange={(e) => setArgs(e.target.value)} />
-        </div>
+
+      {mode === "json" ? (
+        <textarea
+          className="playbook-search mcp-json"
+          rows={8}
+          placeholder={'Paste a server config, e.g.\n{\n  "mcpServers": {\n    "filesystem": { "command": "npx", "args": ["-y", "@modelcontextprotocol/server-filesystem", "/data"] }\n  }\n}'}
+          value={json}
+          onChange={(e) => setJson(e.target.value)}
+        />
       ) : (
-        <input className="playbook-search" placeholder="url (https://…)" value={url} onChange={(e) => setUrl(e.target.value)} />
+        <>
+          <div className="mcp-add-row">
+            <input className="playbook-search" placeholder="name (e.g. echo)" value={name} onChange={(e) => setName(e.target.value)} />
+            <select className="playbook-search" value={transport} onChange={(e) => setTransport(e.target.value as Transport)}>
+              <option value="stdio">stdio</option>
+              <option value="http">http</option>
+              <option value="sse">sse</option>
+            </select>
+          </div>
+          {transport === "stdio" ? (
+            <div className="mcp-add-row">
+              <input className="playbook-search" placeholder="command (e.g. python)" value={command} onChange={(e) => setCommand(e.target.value)} />
+              <input className="playbook-search" placeholder="args (space-separated)" value={args} onChange={(e) => setArgs(e.target.value)} />
+            </div>
+          ) : (
+            <input className="playbook-search" placeholder="url (https://…)" value={url} onChange={(e) => setUrl(e.target.value)} />
+          )}
+        </>
       )}
+
       <div className="mcp-add-actions">
-        <button type="submit" className="ghost-button" disabled={!valid || add.isPending}>
-          {add.isPending ? <Loader2 size={14} className="spin" /> : "Connect"}
+        <button type="submit" className="ghost-button" disabled={busy || (mode === "json" ? !json.trim() : !formValid)}>
+          {busy ? <Loader2 size={14} className="spin" /> : mode === "json" ? "Import" : "Connect"}
         </button>
         <button type="button" className="ghost-button" onClick={() => { reset(); setOpen(false); }}>Cancel</button>
       </div>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -865,6 +865,16 @@ select:disabled {
   display: flex;
   gap: 8px;
 }
+.mcp-add-modes {
+  align-self: flex-start;
+}
+.mcp-json {
+  width: 100%;
+  resize: vertical;
+  font-family: var(--pl-font-mono, ui-monospace, SFMono-Regular, Menlo, monospace);
+  font-size: 12px;
+  line-height: 1.5;
+}
 
 .scroll-area {
   min-width: 0;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -878,6 +878,12 @@ export const api = {
       { method: "DELETE" },
     );
   },
+  importMcpServers(raw: string) {
+    return request<{ ok: boolean; added: string[]; servers: string[] }>(
+      "/api/mcp/servers/import",
+      { method: "POST", body: { raw } },
+    );
+  },
   createDelegate(entry: Record<string, unknown>) {
     return request<{ ok: boolean; message: string; delegates: DelegateView[] }>("/api/delegates", {
       method: "POST",

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -14,7 +14,10 @@ Built on [`langchain-mcp-adapters`](https://github.com/langchain-ai/langchain-mc
 MCP is **off by default** — configuring a server is the opt-in. The quickest way is
 the console: **Agent → MCP → Add server** (name, transport, command/args or URL) wires
 it in **without a restart** (the change hot-reloads and the server connects), and the
-remove button drops one the same way. Prefer YAML? Add an `mcp` section to your config
+remove button drops one the same way. Got a config blob instead? Use **Paste JSON** —
+it accepts the standard `{"mcpServers": {…}}` format (as shared by Claude Desktop / most
+MCP docs), a single server object, or our own export, and imports them all at once.
+Prefer YAML? Add an `mcp` section to your config
 (`config/langgraph-config.yaml`, or via the wizard/drawer):
 
 ```yaml

--- a/operator_api/mcp_routes.py
+++ b/operator_api/mcp_routes.py
@@ -54,11 +54,62 @@ def _clean_entry(body: dict) -> dict:
         env = {str(k).strip(): str(v) for k, v in env.items() if str(k).strip()}
         if env:
             entry["env"] = env
+    headers = body.get("headers")
+    if transport != "stdio" and isinstance(headers, dict):
+        headers = {str(k).strip(): str(v) for k, v in headers.items() if str(k).strip()}
+        if headers:
+            entry["headers"] = headers
     return entry
 
 
+# Map the various "transport"/"type" spellings found in shared MCP JSON to ours.
+_TRANSPORT_ALIASES = {
+    "streamable-http": "streamable_http", "streamablehttp": "streamable_http",
+    "http-stream": "streamable_http",
+}
+
+
+def _normalize_named(name: str, spec: dict) -> dict:
+    """A `{name: {...}}` entry (Claude-Desktop / mcp.json style) → a clean entry.
+
+    Infers transport when absent: an explicit ``transport``/``type``, else ``stdio``
+    if there's a ``command``, else ``http`` if there's a ``url``.
+    """
+    s = dict(spec or {})
+    s["name"] = s.get("name") or name
+    if "transport" not in s:
+        t = str(s.get("type", "")).strip().lower()
+        if t:
+            s["transport"] = _TRANSPORT_ALIASES.get(t, t)
+        elif s.get("command"):
+            s["transport"] = "stdio"
+        elif s.get("url"):
+            s["transport"] = "http"
+    return _clean_entry(s)
+
+
+def _entries_from_blob(data: object) -> list[dict]:
+    """Normalize a pasted MCP JSON blob into clean mcp.servers entries.
+
+    Accepts the common shapes: the standard ``{"mcpServers": {name: spec}}`` wrapper,
+    our own ``{"servers": [ {name, ...} ]}`` export, a single server object, or a bare
+    ``{name: spec}`` map.
+    """
+    if not isinstance(data, dict):
+        raise HTTPException(status_code=400, detail="expected a JSON object")
+    if isinstance(data.get("mcpServers"), dict):
+        return [_normalize_named(n, s) for n, s in data["mcpServers"].items()]
+    if isinstance(data.get("servers"), list):
+        return [_clean_entry(s) for s in data["servers"]]
+    if data.get("command") or data.get("url"):
+        return [_clean_entry(data)]  # a single server object (must carry a name)
+    if data and all(isinstance(v, dict) for v in data.values()):
+        return [_normalize_named(n, s) for n, s in data.items()]
+    raise HTTPException(status_code=400, detail="no MCP server found in the JSON")
+
+
 def register_mcp_routes(app) -> None:
-    """Register `POST /api/mcp/servers` and `DELETE /api/mcp/servers/{name}`."""
+    """Register add / import / delete for `mcp.servers`."""
 
     @app.post("/api/mcp/servers")
     async def _add(body: dict | None = None):
@@ -74,6 +125,32 @@ def register_mcp_routes(app) -> None:
         if not ok:
             raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
         return {"ok": True, "name": entry["name"], "servers": [s["name"] for s in servers]}
+
+    @app.post("/api/mcp/servers/import")
+    async def _import(body: dict | None = None):
+        """Add one or more servers from a pasted MCP JSON blob (`{"raw": "<json>"}`)."""
+        import json as _json
+
+        raw = (body or {}).get("raw")
+        if not isinstance(raw, str) or not raw.strip():
+            raise HTTPException(status_code=400, detail="raw JSON is required")
+        try:
+            data = _json.loads(raw)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"invalid JSON: {exc}") from exc
+
+        entries = _entries_from_blob(data)
+        names = {e["name"] for e in entries}
+        cfg = STATE.graph_config
+        servers = [s for s in (getattr(cfg, "mcp_servers", []) or []) if s.get("name") not in names]
+        servers.extend(entries)
+
+        from server.agent_init import _apply_settings_changes
+
+        ok, messages = _apply_settings_changes(config={"mcp": {"enabled": True, "servers": servers}})
+        if not ok:
+            raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
+        return {"ok": True, "added": sorted(names), "servers": [s["name"] for s in servers]}
 
     @app.delete("/api/mcp/servers/{name}")
     async def _remove(name: str):

--- a/tests/test_mcp_routes.py
+++ b/tests/test_mcp_routes.py
@@ -68,3 +68,47 @@ def test_remove_server(monkeypatch):
 def test_name_required(monkeypatch):
     _wire(monkeypatch, servers=[])
     assert _client().post("/api/mcp/servers", json={"transport": "stdio", "command": "x"}).status_code == 400
+
+
+def test_import_mcpservers_wrapper(monkeypatch):
+    """Standard Claude-Desktop / mcp.json blob: {"mcpServers": {name: spec}}."""
+    captured = _wire(monkeypatch, servers=[])
+    raw = """{
+      "mcpServers": {
+        "filesystem": {"command": "npx", "args": ["-y", "@mcp/fs", "/data"]},
+        "weather": {"url": "https://example.com/mcp", "type": "streamable-http"}
+      }
+    }"""
+    body = _client().post("/api/mcp/servers/import", json={"raw": raw}).json()
+    assert body["added"] == ["filesystem", "weather"]
+    servers = {s["name"]: s for s in captured["config"]["mcp"]["servers"]}
+    assert servers["filesystem"] == {"name": "filesystem", "transport": "stdio", "command": "npx", "args": ["-y", "@mcp/fs", "/data"]}
+    assert servers["weather"]["transport"] == "streamable_http"  # alias normalized
+    assert servers["weather"]["url"] == "https://example.com/mcp"
+
+
+def test_import_single_object_with_name(monkeypatch):
+    captured = _wire(monkeypatch, servers=[])
+    body = _client().post("/api/mcp/servers/import",
+                          json={"raw": '{"name": "echo", "command": "python", "args": ["-m", "echo"]}'}).json()
+    assert body["added"] == ["echo"]
+    assert captured["config"]["mcp"]["servers"][0]["command"] == "python"
+
+
+def test_import_passes_headers_for_remote(monkeypatch):
+    captured = _wire(monkeypatch, servers=[])
+    raw = '{"mcpServers": {"api": {"url": "https://x/mcp", "type": "http", "headers": {"Authorization": "Bearer t"}}}}'
+    _client().post("/api/mcp/servers/import", json={"raw": raw}).json()
+    api = captured["config"]["mcp"]["servers"][0]
+    assert api["headers"] == {"Authorization": "Bearer t"}
+
+
+def test_import_invalid_json_is_400(monkeypatch):
+    _wire(monkeypatch, servers=[])
+    r = _client().post("/api/mcp/servers/import", json={"raw": "{not json"})
+    assert r.status_code == 400 and "invalid JSON" in r.json()["detail"]
+
+
+def test_import_requires_raw(monkeypatch):
+    _wire(monkeypatch, servers=[])
+    assert _client().post("/api/mcp/servers/import", json={}).status_code == 400


### PR DESCRIPTION
MCP servers are almost always shared as a JSON blob — so let operators paste it instead of re-typing into the form. **Agent → MCP → Add server** now has a **Form / Paste JSON** toggle.

- **`POST /api/mcp/servers/import` `{raw}`** — parses + normalizes the common shapes: the standard **`{"mcpServers": {name: spec}}`** wrapper (Claude-Desktop / mcp.json), a single server object, our own `{"servers":[…]}` export, or a bare `{name: spec}` map. Infers transport (`type`/`transport` alias → ours, else stdio-if-command / http-if-url), carries `env` + `headers` (remote auth), upserts by name, enables MCP, **hot-reloads**.
- **McpPanel** — a Paste JSON textarea mode beside the form; `api.importMcpServers`.

Tests: wrapper / single-object / headers / invalid-JSON / required (5 new, 10 total); an e2e pastes a 2-server blob and asserts the import hint. Full e2e **60/60**, ruff clean, mcp guide updated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)