### PR TITLE
feat(console): Plugins view as tabs — Local | Market | Download

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,9 +23,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   immediately (a console view or background surface needs a restart, and the toggle says so).
 
 ### Changed
-- **Plugins view reorganized** — three sections: **Installed** (grouped Loaded → Disabled,
-  alphabetical within each) → **Marketplace** (browse the directory + the `protoagent-plugin`
-  GitHub topic) → **Install from a git URL**.
+- **Plugins view reorganized into tabs** — **Local** (installed plugins, grouped Loaded →
+  Disabled with enable/disable), **Market** (browse the directory + the `protoagent-plugin`
+  GitHub topic), and **Download** (install from a git URL).
 
 ### Fixed
 - **Marketing changelog: clean entries + no staleness** — the marketing changelog had gone

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -56,19 +56,21 @@ test("agent surface: identity lands, then tools and MCP tabs", async ({ page }) 
   await expect(page.getByText("echo · stdio")).toBeVisible(); // MCP server
 });
 
-test("plugins section: Loaded/Disabled groups, marketplace, and install", async ({ page }) => {
+test("plugins section: Local / Market / Download tabs", async ({ page }) => {
   await page.locator(".rail").getByRole("button", { name: "Plugins", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
-  // Installed shows both a loaded and a disabled plugin (the two status groups).
+
+  // Local (default tab) — both status groups + the enable toggle.
   await expect(page.getByText("Demo Plugin", { exact: false })).toBeVisible();
   await expect(page.getByText("Zzz Disabled", { exact: false })).toBeVisible();
-  await expect(page.locator(".panel-kicker", { hasText: "Marketplace" })).toBeVisible();
-  // Marketplace discovery + install-from-git section both present.
-  await expect(page.getByRole("link", { name: /Browse the directory/ })).toBeVisible();
-  await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
-
-  // Direct enable: the disabled plugin's row has an Enable button → hot-toggle hint.
   await page.locator(".subagent-row", { hasText: "Zzz Disabled" })
     .getByRole("button", { name: "Enable" }).click();
   await expect(page.locator(".plugin-hint")).toContainText("Zzz Disabled enabled");
+
+  // Market tab — discovery links.
+  await page.locator(".stage-subnav").getByRole("button", { name: "Market", exact: true }).click();
+  await expect(page.getByRole("link", { name: /Browse the directory/ })).toBeVisible();
+
+  // Download tab — install from a git URL.
+  await page.locator(".stage-subnav").getByRole("button", { name: "Download", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
 });

--- a/apps/web/e2e/plugin-install.spec.ts
+++ b/apps/web/e2e/plugin-install.spec.ts
@@ -6,7 +6,9 @@ import { expect, test } from "@playwright/test";
 async function openPluginsPanel(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".rail").getByRole("button", { name: "Plugins", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Plugins" })).toBeVisible();
+  // Install lives on the Download tab.
+  await page.locator(".stage-subnav").getByRole("button", { name: "Download", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
 }
 
 test("install a plugin from a git URL, then uninstall it", async ({ page }) => {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -17,6 +17,8 @@ import {
   PanelRight,
   Plus,
   Puzzle,
+  Download,
+  Store,
   Save,
   Settings2,
   Sparkles,
@@ -162,6 +164,8 @@ function pluginViewIcon(name?: string): ReactNode {
 // servers, subagents, skills, and middleware. (Runtime status + telemetry moved
 // to Settings → Overview.)
 type AgentTab = "identity" | "tools" | "mcp" | "subagents" | "skills" | "middleware";
+// Plugins = installed (local), discover (market), and install-from-git (download).
+type PluginsTab = "local" | "market" | "download";
 // Activity = the "triggers / events" surface (ADR 0009): what happened (thread),
 // inbound (inbox), and timed (schedule — cron is a trigger, not a work-type).
 type ActivityTab = "thread" | "inbox";
@@ -212,6 +216,7 @@ export function App() {
   // re-renders when the boolean flips, not per token).
   const chatStreaming = useAnyChatStreaming();
   const [agentTab, setAgentTab] = useState<AgentTab>("identity");
+  const [pluginsTab, setPluginsTab] = useState<PluginsTab>("local");
   const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
   const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
   // Collapsible/resizable right panel (persisted). Flag is "1"/"" string; width
@@ -748,6 +753,18 @@ export function App() {
             />
           ) : null}
 
+          {surface === "plugins" ? (
+            <StageSubnav
+              active={pluginsTab}
+              onSelect={(id) => setPluginsTab(id as PluginsTab)}
+              tabs={[
+                { id: "local", label: "Local", icon: Boxes },
+                { id: "market", label: "Market", icon: Store },
+                { id: "download", label: "Download", icon: Download },
+              ]}
+            />
+          ) : null}
+
           {/* ChatSurface is rendered UNCONDITIONALLY and hidden via `active` when
               off-tab — so an in-flight turn keeps streaming in the background and
               the chat is progressing when you navigate back (not torn down). */}
@@ -765,7 +782,7 @@ export function App() {
           {surface === "agent" && agentTab === "subagents" ? <SubagentsPanel /> : null}
           {surface === "agent" && agentTab === "skills" ? <PlaybooksSurface onError={setError} /> : null}
           {surface === "agent" && agentTab === "middleware" ? <MiddlewarePanel /> : null}
-          {surface === "plugins" ? <PluginsSurface /> : null}
+          {surface === "plugins" ? <PluginsSurface tab={pluginsTab} /> : null}
           {surface === "knowledge" ? <KnowledgeStore onError={setError} /> : null}
           {surface === "settings" ? <SettingsSurface /> : null}
 

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -56,7 +56,10 @@ function PluginRow({ p, busy, onToggle }: { p: Plugin; busy: boolean; onToggle: 
   );
 }
 
-function PluginsBody() {
+type PluginsTab = "local" | "market" | "download";
+
+// Local — installed plugins, grouped Loaded → Disabled (alpha), with enable/disable.
+function LocalTab() {
   const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
   const qc = useQueryClient();
   const [hint, setHint] = useState<string | null>(null);
@@ -77,19 +80,14 @@ function PluginsBody() {
 
   const plugins = runtime.plugins ?? [];
   const byName = (a: Plugin, b: Plugin) => a.name.localeCompare(b.name);
-  // Installed, grouped by status: loaded first, then disabled — alpha within each.
   const loaded = plugins.filter((p) => p.loaded).sort(byName);
   const disabled = plugins.filter((p) => !p.loaded).sort(byName);
 
   return (
     <>
-      <PanelHeader
-        title="Plugins"
-        kicker={`${plugins.length} installed · ${loaded.length} loaded`}
-      />
+      <PanelHeader title="Installed" kicker={`${plugins.length} installed · ${loaded.length} loaded`} />
       <div className="stage-body">
         {hint ? <p className="plugin-hint">{hint}</p> : null}
-        {/* 1 — Installed (loaded → disabled, alphabetical) */}
         {plugins.length ? (
           <>
             {loaded.length ? (
@@ -108,14 +106,22 @@ function PluginsBody() {
         ) : (
           <div className="table-list">
             <div className="table-row">
-              <span>no plugins installed — browse the marketplace or install from a git URL below</span>
+              <span>no plugins installed — see the Market or Download tabs</span>
               <StatusPill label="none" tone="muted" />
             </div>
           </div>
         )}
+      </div>
+    </>
+  );
+}
 
-        {/* 2 — Marketplace (discover) */}
-        <p className="panel-kicker">Marketplace</p>
+// Market — discover plugins (directory + GitHub topic).
+function MarketTab() {
+  return (
+    <>
+      <PanelHeader title="Market" kicker="discover plugins" />
+      <div className="stage-body">
         <div className="plugin-market">
           <a className="plugin-market-link" href={DIRECTORY_URL} target="_blank" rel="noopener noreferrer">
             <Store size={16} />
@@ -128,22 +134,41 @@ function PluginsBody() {
             <ExternalLink size={14} />
           </a>
         </div>
+        <p className="muted" style={{ marginTop: 10 }}>
+          Found one? Copy its git URL and install it from the <strong>Download</strong> tab.
+        </p>
+      </div>
+    </>
+  );
+}
 
-        {/* 3 — Install (the PluginsSection ships its own "Install from a git URL" header) */}
+// Download — install from a git URL (PluginsSection ships its own header + form).
+function DownloadTab() {
+  return (
+    <>
+      <PanelHeader title="Download" kicker="install from a git URL" />
+      <div className="stage-body">
         <PluginsSection />
       </div>
     </>
   );
 }
 
-export function PluginsSurface() {
+const TABS: Record<PluginsTab, () => JSX.Element> = {
+  local: LocalTab,
+  market: MarketTab,
+  download: DownloadTab,
+};
+
+export function PluginsSurface({ tab = "local" }: { tab?: PluginsTab }) {
+  const Body = TABS[tab] ?? LocalTab;
   return (
     <section className="panel stage-panel">
       <QueryErrorResetBoundary>
         {({ reset }) => (
           <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="plugins" />}>
             <Suspense fallback={<PanelSkeleton label="Loading plugins…" />}>
-              <PluginsBody />
+              <Body />
             </Suspense>
           </ErrorBoundary>
         )}

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -48,8 +48,8 @@ export function PluginsSection() {
         <h3><Package size={16} /> Install from a git URL</h3>
         <p className="settings-section-sub">
           Install a plugin from a git URL. Fetching code never runs it — review, then{" "}
-          <strong>enable</strong> it from the list above (tools apply live; a console view or
-          background surface needs a restart). Untrusted code?
+          <strong>enable</strong> it from the <strong>Local</strong> tab (tools apply live; a
+          console view or background surface needs a restart). Untrusted code?
           Use an <a href="https://protolabsai.github.io/protoAgent/guides/mcp" target="_blank" rel="noreferrer">MCP server</a> instead.{" "}
           <a href={REGISTRY_GUIDE_URL} target="_blank" rel="noreferrer">Guide</a>.
         </p>
@@ -125,8 +125,8 @@ function PluginRow({ p, onRemove, removing }: { p: InstalledPlugin; onRemove: ()
         ) : null}
         {!p.enabled ? (
           <p className="plugin-enable-hint">
-            To enable: use the <strong>Enable</strong> button in the list above (or add{" "}
-            <code>{p.id}</code> to <code>plugins.enabled</code> in config).
+            To enable: use the <strong>Enable</strong> button on the <strong>Local</strong> tab
+            (or add <code>{p.id}</code> to <code>plugins.enabled</code> in config).
           </p>
         ) : null}
       </div>


### PR DESCRIPTION
Missed the mark before — the three sections were stacked; they're meant to be **tabs**.

Now the Plugins surface has a sub-tab strip (StageSubnav, above the panel card like every other surface):
- **Local** — installed plugins, grouped Loaded → Disabled, with the one-click enable/disable toggle.
- **Market** — discover (directory + `protoagent-plugin` GitHub topic), pointing to Download to install.
- **Download** — install from a git URL.

`App.tsx` owns `pluginsTab` + the subnav; `PluginsSurface` renders the active tab. Copy that said "the list above" now points at the **Local** tab. e2e updated for tab nav; full e2e **60/60**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)