### PR TITLE
chore: release v0.26.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.26.0] - 2026-06-08
+
 ### Changed
 - **Settings decentralized** — settings now live where the thing lives. **Agent** settings
   (model, routing, goal mode, tools) are a Settings tab in the Agent view; **Memory** settings

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.25.0"
+version = "0.26.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -3,12 +3,9 @@
     "version": "v0.26.0",
     "date": "2026-06-08",
     "changes": [
-      "Settings decentralized",
-      "Paste-JSON import for MCP servers",
-      "Add MCP servers from the console",
-      "One-click plugin enable/disable",
-      "Plugins view reorganized into tabs",
-      "Marketing changelog: clean entries + no staleness"
+      "Settings now live where they belong — agent settings in the Agent view, memory settings in Knowledge, and a leaner central Settings (Overview, Telemetry, Plugins, System).",
+      "The Plugins page is tabbed (Local, Market, Download) with one-click enable/disable — no config editing or restart for most plugins.",
+      "Add MCP servers right from the console — fill a quick form or paste a standard JSON config blob, and they connect live."
     ]
   },
   {

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "v0.26.0",
+    "date": "2026-06-08",
+    "changes": [
+      "Settings decentralized",
+      "Paste-JSON import for MCP servers",
+      "Add MCP servers from the console",
+      "One-click plugin enable/disable",
+      "Plugins view reorganized into tabs",
+      "Marketing changelog: clean entries + no staleness"
+    ]
+  },
+  {
     "version": "v0.25.0",
     "date": "2026-06-08",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.26.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.26.0 -m 'Release v0.26.0' && git push origin v0.26.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).