### PR TITLE
fix(a2a): peer_tools + delegates clients speak A2A 1.0 (SendMessage), not v0.3 message/send

### DIFF
--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -162,10 +162,12 @@ class A2aAdapter(Adapter):
         return d
 
     async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
+        import asyncio
+
         import httpx
 
         import security
-        from tools.peer_tools import _TERMINAL, _extract_text
+        from tools.peer_tools import _extract_text, _is_terminal
 
         blocked = security.check_url(d.url)
         if blocked:
@@ -188,23 +190,27 @@ class A2aAdapter(Adapter):
                 raise DelegateError(str(data["error"]))
             return data.get("result") or {}
 
-        async with httpx.AsyncClient(timeout=timeout or 30) as client:
-            result = await _rpc(client, "message/send", {"message": {
-                "role": "user", "parts": [{"kind": "text", "text": query}],
+        # A2A 1.0 (a2a-sdk >=1.0): JSON-RPC `SendMessage` / `GetTask`, the ROLE_USER
+        # enum, and a `result.task` envelope. (`message/send` + lowercase `user` is
+        # the v0.3 legacy dialect, which 1.0 servers reject with -32601.)
+        async with httpx.AsyncClient(timeout=timeout or 60) as client:
+            result = await _rpc(client, "SendMessage", {"message": {
+                "role": "ROLE_USER", "parts": [{"text": query}],
                 "messageId": str(uuid.uuid4()),
             }})
             text = _extract_text(result)
             if text:
                 return text
-            task_id = result.get("id")
-            state = (result.get("status") or {}).get("state")
-            import asyncio
+            task = result.get("task", result) or {}
+            task_id = task.get("id")
+            state = (task.get("status") or {}).get("state")
             polls = 0
-            while task_id and state not in _TERMINAL and polls < 30:
+            while task_id and not _is_terminal(state) and polls < 30:
                 await asyncio.sleep(1.0)
                 polls += 1
-                result = await _rpc(client, "tasks/get", {"id": task_id})
-                state = (result.get("status") or {}).get("state")
+                result = await _rpc(client, "GetTask", {"name": task_id})
+                task = result.get("task", result) or {}
+                state = (task.get("status") or {}).get("state")
             text = _extract_text(result)
             if text:
                 return text

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -12,6 +12,7 @@ ADR 0024 ``AcpClient``; the a2a adapter reuses the ``peer_tools`` JSON-RPC path)
 
 from __future__ import annotations
 
+import asyncio
 import logging
 import os
 import uuid
@@ -162,8 +163,6 @@ class A2aAdapter(Adapter):
         return d
 
     async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
-        import asyncio
-
         import httpx
 
         import security

--- a/tests/test_peer_federation.py
+++ b/tests/test_peer_federation.py
@@ -121,3 +121,45 @@ async def test_peer_consult_routes_skill_hint(monkeypatch):
     params = captured["json"]["params"]
     assert params["message"]["metadata"]["skillHint"] == "bug_triage"
     assert params["metadata"]["skillHint"] == "bug_triage"
+
+
+@pytest.mark.asyncio
+async def test_peer_consult_uses_a2a_1_0_method(monkeypatch):
+    """A2A 1.0: method `SendMessage` (not v0.3 `message/send`), `ROLE_USER` enum,
+    and text-only parts (no `kind`)."""
+    monkeypatch.setenv("PEER_ALICE_URL", "https://alice.example")
+    captured = {}
+
+    class _Cap(_FakeClient):
+        async def post(self, url, json=None, headers=None):
+            captured["body"] = json
+            return self._responses.pop(0)
+
+    import httpx
+    monkeypatch.setattr(httpx, "AsyncClient",
+                        lambda *a, **k: _Cap([_Resp(_task("completed", "ok"))]))
+    out = await _tools()["peer_consult"].ainvoke({"name": "alice", "message": "q"})
+    assert out == "[alice] ok"
+    assert captured["body"]["method"] == "SendMessage"
+    msg = captured["body"]["params"]["message"]
+    assert msg["role"] == "ROLE_USER"
+    assert msg["parts"] == [{"text": "q"}]
+
+
+def test_extract_text_unwraps_a2a_1_0_task_envelope():
+    from tools.peer_tools import _extract_text
+    # 1.0 wraps the task: result.task.artifacts[].parts[].text (parts carry no `kind`)
+    assert _extract_text({"task": {"artifacts": [{"parts": [{"text": "hello"}]}]}}) == "hello"
+    assert _extract_text(
+        {"task": {"status": {"message": {"parts": [{"text": "via status"}]}}}}) == "via status"
+    # bare-Message / v0.3 shape (no task envelope) still parses
+    assert _extract_text({"artifacts": [{"parts": [{"kind": "text", "text": "legacy"}]}]}) == "legacy"
+
+
+def test_is_terminal_handles_1_0_and_legacy_states():
+    from tools.peer_tools import _is_terminal
+    assert _is_terminal("TASK_STATE_COMPLETED")
+    assert _is_terminal("TASK_STATE_FAILED")
+    assert _is_terminal("completed")            # v0.3 lowercase
+    assert not _is_terminal("TASK_STATE_WORKING")
+    assert not _is_terminal(None)

--- a/tools/peer_tools.py
+++ b/tools/peer_tools.py
@@ -51,21 +51,30 @@ def list_env_peers() -> list[dict]:
 
 
 def _extract_text(result) -> str | None:
-    """Pull text content out of an A2A Task/message result dict."""
+    """Pull text out of an A2A 1.0 result — a ``{"task": ...}`` envelope (the
+    ``SendMessage`` / ``GetTask`` response) or a bare Message. Tolerant of parts
+    with or without an explicit ``kind`` tag (1.0 text parts carry just ``text``)."""
     if not isinstance(result, dict):
         return None
-    for art in result.get("artifacts") or []:
-        chunks = [p.get("text", "") for p in art.get("parts", []) if p.get("kind") == "text"]
+    task = result.get("task", result) or {}
+    for art in task.get("artifacts") or []:
+        chunks = [p.get("text", "") for p in art.get("parts", []) if p.get("text")]
         if any(chunks):
             return "\n".join(c for c in chunks if c)
-    status = result.get("status") or {}
-    msg = status.get("message") or {}
-    parts = [p.get("text", "") for p in (msg.get("parts") or []) if p.get("kind") == "text"]
+    msg = (task.get("status") or {}).get("message") or {}
+    parts = [p.get("text", "") for p in (msg.get("parts") or []) if p.get("text")]
     text = "\n".join(p for p in parts if p)
     return text or None
 
 
-_TERMINAL = {"completed", "failed", "canceled"}
+_TERMINAL = {"completed", "failed", "canceled"}  # v0.3 spellings (back-compat)
+
+
+def _is_terminal(state) -> bool:
+    """True for A2A 1.0 terminal task states (``TASK_STATE_COMPLETED`` / ``FAILED``
+    / ``CANCELLED`` / ``REJECTED``) and their v0.3 lowercase spellings."""
+    return str(state or "").upper().endswith(
+        ("COMPLETED", "FAILED", "CANCELED", "CANCELLED", "REJECTED"))
 
 
 def get_peer_tools() -> list:
@@ -131,8 +140,8 @@ def get_peer_tools() -> list:
             return data.get("result") or {}
 
         msg: dict = {
-            "role": "user",
-            "parts": [{"kind": "text", "text": message}],
+            "role": "ROLE_USER",
+            "parts": [{"text": message}],
             "messageId": str(uuid.uuid4()),
         }
         params: dict = {"message": msg}
@@ -144,25 +153,28 @@ def get_peer_tools() -> list:
             params["metadata"] = hint
 
         try:
-            # A delegated skill answers synchronously on message/send and can run
+            # A delegated skill answers synchronously on SendMessage and can run
             # for a minute+ (e.g. Quinn's bug_triage ≈ 58s) — the peer holds the
             # connection until done rather than returning a task to poll. Give the
             # request room; the polling loop below covers peers that DO go async.
             async with httpx.AsyncClient(timeout=httpx.Timeout(200.0, connect=10.0)) as client:
-                result = await _rpc(client, "message/send", params)
+                result = await _rpc(client, "SendMessage", params)
                 # Inline reply? (some peers answer synchronously)
                 text = _extract_text(result)
                 if text:
                     return f"[{name}] {text}"
-                # Otherwise poll the task to a terminal state.
-                task_id = result.get("id")
-                state = (result.get("status") or {}).get("state")
+                # Otherwise poll the task to a terminal state (A2A 1.0: GetTask,
+                # task in a `result.task` envelope, TASK_STATE_* enums).
+                task = result.get("task", result) or {}
+                task_id = task.get("id")
+                state = (task.get("status") or {}).get("state")
                 polls = 0
-                while task_id and state not in _TERMINAL and polls < _MAX_POLLS:
+                while task_id and not _is_terminal(state) and polls < _MAX_POLLS:
                     await asyncio.sleep(_POLL_INTERVAL_S)
                     polls += 1
-                    result = await _rpc(client, "tasks/get", {"id": task_id})
-                    state = (result.get("status") or {}).get("state")
+                    result = await _rpc(client, "GetTask", {"name": task_id})
+                    task = result.get("task", result) or {}
+                    state = (task.get("status") or {}).get("state")
                 text = _extract_text(result)
                 if text:
                     return f"[{name}] {text}"


### PR DESCRIPTION
**Bug:** the a2a servers run on `a2a-sdk>=1.1` (A2A 1.0 → JSON-RPC `SendMessage`), but both a2a *clients* — `tools/peer_tools.py` and the `delegates` a2a adapter — hand-roll the **v0.3 legacy** `message/send` (`role:user`, `kind:text`, `tasks/get`). a2a-sdk keeps that only under `compat/v0_3` ("legacy >=0.3 and <1.0"), so every `peer_consult` / a2a `delegate_to` call to a 1.0 server — **including protoAgent's own** — fails with `-32601 Method not found`.

**Fix:** update both clients to A2A 1.0 — `SendMessage`/`GetTask`, `ROLE_USER`, text-only parts, and `_extract_text` unwraps the `result.task` envelope (kept back-compatible with the bare-Message/v0.3 shape; `_is_terminal` accepts `TASK_STATE_*` enums + lowercase).

**Verified live:** `delegate_to('quinn')` now returns the reviewer's response end-to-end (was -32601). Tests added (SendMessage/ROLE_USER on the wire, task-envelope extraction, 1.0 terminal enums) — **11/11**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)