### PR TITLE
feat(mcp): operator tools as an MCP server (ADR 0033 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Operator tools as an MCP server** (ADR 0033 slice 1) — publish this agent's tools (core +
+  plugin, allowlist-gated) as an MCP server via `python -m server.operator_mcp` (stdio or HTTP),
+  so any MCP client (Claude Desktop, Cursor) or an ACP runtime can operate the instance. Config:
+  `operator_mcp.enabled` + `operator_mcp.tools`. Stores-only boot (no background loops).
+
 ### Docs
 - **ADR 0033** (Proposed) — pluggable agent runtime over ACP: drive the runtime with an external coding agent (proto/codex/claude/copilot/opencode), runtime≠model axis, operator-tools MCP bus, and a cache-disciplined runtime context contract.
 

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -135,6 +135,33 @@ mcp:
 Start protoAgent and check `GET /api/runtime/status` — you'll see the `echo`
 server with one tool (`echo__echo`).
 
+## Expose THIS agent as an MCP server (operator tools)
+
+The reverse direction (ADR 0033): publish this agent's own tools as an MCP server, so any
+MCP client — Claude Desktop, Cursor, or an ACP coding-agent runtime — can **operate the
+instance** (read/write notes & beads, recall/ingest memory, run workflows, delegate to
+subagents, set goals, schedule work). It's **opt-in + allowlist-gated** — only the tools you
+name are exposed:
+
+```yaml
+operator_mcp:
+  enabled: true
+  tools: [memory_recall, memory_ingest, beads_list, beads_create, notes_read, run_workflow]
+```
+
+Run it standalone:
+
+```bash
+python -m server.operator_mcp                 # stdio (for an MCP client / ACP session)
+python -m server.operator_mcp --http --port 8848
+```
+
+**Core + plugin tools ride the same bridge** — a plugin's `register_tools` tools are exposed
+through this one server (no per-plugin MCP); plugins that *are* an MCP server (`register_mcp_server`)
+are mounted by the client directly. Empty `tools` ⇒ nothing exposed (don't hand `execute_code`
+etc. to an outside brain unless you mean to). The sidecar boots **stores only** — it never starts
+the agent's background loops — so it's safe to run against a live instance's data.
+
 ## Notes & limits
 
 - **Tools only** for now — MCP *Resources* and *Prompts* aren't wired yet.

--- a/graph/config.py
+++ b/graph/config.py
@@ -341,6 +341,13 @@ class LangGraphConfig:
     mcp_timeout_seconds: float = 20.0
     mcp_denylist: list[str] = field(default_factory=list)
 
+    # Operator MCP server (ADR 0033 slice 1) — expose THIS agent's tools as an MCP
+    # server so any MCP client (Claude Desktop, Cursor) or an ACP coding-agent runtime
+    # can operate the instance. Opt-in + allowlist-gated: only the named tools are
+    # exposed (empty = none). Served standalone via ``python -m server.operator_mcp``.
+    operator_mcp_enabled: bool = False
+    operator_mcp_tools: list[str] = field(default_factory=list)
+
     # Plugins — drop-in packages (manifest + register()) that contribute tools
     # and bundled skills. Run IN-PROCESS with the agent's privileges, so a
     # plugin loads only when enabled: listed here, or ``enabled: true`` in its
@@ -482,6 +489,7 @@ class LangGraphConfig:
         knowledge = data.get("knowledge", {})
         skills = data.get("skills", {})
         mcp = data.get("mcp", {})
+        operator_mcp = data.get("operator_mcp", {})
         plugins = data.get("plugins", {})
         identity = data.get("identity", {})
         # `or {}` (not a default arg): a section present but empty/commented in
@@ -577,6 +585,8 @@ class LangGraphConfig:
             mcp_servers=list(mcp.get("servers", []) or []),
             mcp_timeout_seconds=mcp.get("timeout_seconds", cls.mcp_timeout_seconds),
             mcp_denylist=list(mcp.get("denylist", []) or []),
+            operator_mcp_enabled=operator_mcp.get("enabled", cls.operator_mcp_enabled),
+            operator_mcp_tools=list(operator_mcp.get("tools", []) or []),
             plugins_enabled=list(plugins.get("enabled", []) or []),
             plugins_disabled=list(plugins.get("disabled", []) or []),
             plugins_dir=plugins.get("dir", cls.plugins_dir),

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -43,6 +43,7 @@ langgraph-checkpoint-sqlite>=2.0
 # streamable-HTTP); their tools become agent tools. See tools/mcp_tools.py.
 # Pulls the `mcp` SDK transitively (also used by examples/mcp/echo_server.py).
 langchain-mcp-adapters>=0.2,<0.3
+mcp>=1.2
 
 # Starter tools (tools/lg_tools.py)
 ddgs>=9.0

--- a/server/operator_mcp.py
+++ b/server/operator_mcp.py
@@ -1,0 +1,135 @@
+"""Operator tools as an MCP server (ADR 0033, slice 1).
+
+Exposes THIS agent's tool registry — core tools + plugin ``register_tools`` tools —
+as a single MCP server, so any MCP client (Claude Desktop, Cursor) or an ACP
+coding-agent runtime (mounted via ``session/new`` ``mcpServers``) can *operate* the
+instance: read/write notes & beads, recall/ingest memory, run workflows, delegate to
+subagents, set goals, schedule work — whatever you allowlist.
+
+Design (ADR 0033 D3 + D5):
+
+- **Opt-in + allowlist-gated.** Only tools named in ``operator_mcp.tools`` are exposed
+  (empty → nothing, mirroring how the comps default external brains to no framework
+  tools). Don't hand ``execute_code`` etc. to an outside agent unless you mean to.
+- **Core + plugin, uniformly.** Plugin tools live in the same registry, so they ride
+  this one bridge for free — no per-plugin MCP. (Plugins that *are* an MCP server, via
+  ``register_mcp_server``, are mounted directly by the client, not re-wrapped here.)
+- **Stores-only boot.** A standalone sidecar must NOT start the agent's background loops
+  (checkpoint prune / monitor-goals) against shared data, so we build just the stores +
+  plugins the tools bind to — never the graph or the loops.
+
+Run it::
+
+    python -m server.operator_mcp            # stdio (for an MCP client / ACP session)
+    python -m server.operator_mcp --http --port 8848
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+
+from runtime.state import STATE
+
+log = logging.getLogger(__name__)
+
+
+def _boot_stores_only(config):
+    """Wire just the stores + plugins the tools need — no graph, no background loops.
+
+    Safe to run as a sidecar against the same data dir as a live instance (reads/writes
+    the same notes/beads/knowledge — that's the point); WAL + busy_timeout cover concurrency.
+    """
+    import server.agent_init as ai
+    from tools.lg_tools import get_all_tools
+
+    STATE.graph_config = config
+    STATE.knowledge_store = ai._build_knowledge_store(config)
+    STATE.scheduler = ai._build_scheduler(config)
+    STATE.inbox_store = ai._build_inbox_store(config)
+    if STATE.beads_store is None:
+        from beads import BeadsStore
+        STATE.beads_store = BeadsStore()
+
+    plugins = ai._build_plugins(
+        config,
+        existing_tools=get_all_tools(
+            STATE.knowledge_store, scheduler=STATE.scheduler,
+            goal_enabled=getattr(config, "goal_enabled", True),
+        ),
+    )
+    STATE.plugin_tools = plugins.tools
+    STATE.plugin_meta = plugins.meta
+    STATE.knowledge_store = ai._apply_plugin_knowledge_backend(config, STATE.knowledge_store, plugins)
+
+
+def operator_tools(config):
+    """The allowlisted tools (core + plugin) to expose — empty allowlist ⇒ none."""
+    from tools.lg_tools import get_all_tools
+
+    allow = set(getattr(config, "operator_mcp_tools", []) or [])
+    if not allow:
+        return []
+    tools = list(get_all_tools(
+        STATE.knowledge_store,
+        scheduler=STATE.scheduler,
+        inbox_store=STATE.inbox_store,
+        beads_store=STATE.beads_store,
+        goal_enabled=bool(getattr(config, "goal_enabled", False)),
+    ))
+    tools += list(getattr(STATE, "plugin_tools", None) or [])
+    seen: set[str] = set()
+    out = []
+    for t in tools:
+        name = getattr(t, "name", None)
+        if name in allow and name not in seen:
+            seen.add(name)
+            out.append(t)
+    return out
+
+
+def build_server(config, *, name: str = "protoAgent-operator"):
+    """Return (FastMCP server, [exposed tool names]) for the allowlisted tools."""
+    from langchain_mcp_adapters.tools import to_fastmcp
+    from mcp.server.fastmcp import FastMCP
+
+    fast_tools, exposed = [], []
+    for t in operator_tools(config):
+        try:
+            fast_tools.append(to_fastmcp(t))
+            exposed.append(t.name)
+        except Exception:  # noqa: BLE001 — one bad tool shouldn't sink the server
+            log.exception("[operator-mcp] could not expose %s", getattr(t, "name", "?"))
+    server = FastMCP(name, tools=fast_tools)
+    log.info(
+        "[operator-mcp] exposing %d tool(s): %s",
+        len(exposed), ", ".join(exposed) or "(none — set operator_mcp.tools)",
+    )
+    return server, exposed
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description="Serve protoAgent's operator tools over MCP")
+    parser.add_argument("--http", action="store_true", help="serve over streamable HTTP instead of stdio")
+    parser.add_argument("--host", default="127.0.0.1")
+    parser.add_argument("--port", type=int, default=8848)
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO)
+    from graph.config import LangGraphConfig
+    from graph.config_io import CONFIG_YAML_PATH
+
+    config = LangGraphConfig.from_yaml(CONFIG_YAML_PATH)
+    _boot_stores_only(config)
+    server, exposed = build_server(config)
+    if not exposed:
+        log.warning("[operator-mcp] no tools exposed — add names to operator_mcp.tools in config")
+    if args.http:
+        server.settings.host, server.settings.port = args.host, args.port
+        server.run(transport="streamable-http")
+    else:
+        server.run(transport="stdio")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_operator_mcp.py
+++ b/tests/test_operator_mcp.py
@@ -1,0 +1,51 @@
+"""Operator MCP server (ADR 0033 slice 1) — allowlist-gated tool exposure."""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.tools import tool
+
+from graph.config import LangGraphConfig
+from runtime.state import STATE
+from server.operator_mcp import build_server, operator_tools
+
+
+def _cfg(tools):
+    c = LangGraphConfig()
+    c.operator_mcp_tools = list(tools)
+    c.goal_enabled = False
+    return c
+
+
+@pytest.fixture(autouse=True)
+def _bare_state(monkeypatch):
+    # No stores → get_all_tools returns just the keyless core tools; no plugin tools.
+    for attr in ("knowledge_store", "scheduler", "inbox_store", "beads_store"):
+        monkeypatch.setattr(STATE, attr, None, raising=False)
+    monkeypatch.setattr(STATE, "plugin_tools", [], raising=False)
+
+
+def test_allowlist_filters_to_named_tools():
+    names = {t.name for t in operator_tools(_cfg(["calculator", "current_time"]))}
+    assert names == {"calculator", "current_time"}
+
+
+def test_empty_allowlist_exposes_nothing():
+    assert operator_tools(_cfg([])) == []
+
+
+def test_plugin_tools_ride_the_same_bridge(monkeypatch):
+    @tool
+    def my_plugin_tool(x: str) -> str:
+        """A plugin-contributed tool."""
+        return x
+
+    monkeypatch.setattr(STATE, "plugin_tools", [my_plugin_tool], raising=False)
+    names = {t.name for t in operator_tools(_cfg(["my_plugin_tool", "calculator"]))}
+    assert names == {"my_plugin_tool", "calculator"}  # core + plugin, one allowlist
+
+
+def test_build_server_exposes_allowlisted_as_mcp():
+    server, exposed = build_server(_cfg(["calculator"]))
+    assert exposed == ["calculator"]
+    assert server is not None


### PR DESCRIPTION
**Slice 1 of ADR 0033** — publish this agent's own tools as an MCP server so any MCP client (Claude Desktop, Cursor) or an ACP coding-agent runtime can **operate the instance**. It's the keystone the ACP runtime later mounts via `session/new mcpServers`, and it's useful on its own right now.

- **`server/operator_mcp.py`** — `build_server()` converts allowlisted **core + plugin `register_tools`** tools to MCP (`langchain-mcp-adapters` `to_fastmcp`); run with `python -m server.operator_mcp` (stdio default, `--http`).
- **Stores-only boot** — constructs just the stores/plugins the tools bind to, **never the graph or background loops**, so it's safe to run as a sidecar against a live instance's data (WAL + busy_timeout cover concurrency).
- **Opt-in + allowlist-gated** — `operator_mcp.enabled` + `operator_mcp.tools`; empty ⇒ nothing exposed (don't hand `execute_code` etc. to an external brain). **Plugin tools ride the same bridge for free.**
- config fields + parse; `mcp>=1.2` pinned in requirements-core; MCP guide section.

Tests: allowlist filtering, empty⇒none, plugin tools ride the bridge, build_server exposes as MCP (4). Real stores-only boot smoke-verified (`beads_list/calculator/memory_recall/notes_read` exposed). **Suite 1267**, ruff clean, docs build clean.

Next: slice 2 (runtime context contract), slice 3 (the ACP runtime that mounts this).

🤖 Generated with [Claude Code](https://claude.com/claude-code)