### PR TITLE
feat(runtime): context contract — assemble_context (ADR 0033 slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Runtime context contract** (ADR 0033 slice 2) — `runtime/context.py`: `assemble_context()`
+  → `{stable_prefix, volatile_delta}` (a cacheable persona prefix + per-turn retrieved
+  knowledge/skills/prior-sessions) + an `after_turn()` write-back hook, so any runtime (native
+  or an external ACP brain) produces context the same cache-disciplined way. Reuses
+  `build_system_prompt` + the knowledge/skills retrieval; no change to the native loop.
 - **Operator tools as an MCP server** (ADR 0033 slice 1) — publish this agent's tools (core +
   plugin, allowlist-gated) as an MCP server via `python -m server.operator_mcp` (stdio or HTTP),
   so any MCP client (Claude Desktop, Cursor) or an ACP runtime can operate the instance. Config:

--- a/runtime/context.py
+++ b/runtime/context.py
@@ -1,0 +1,162 @@
+"""Runtime context contract (ADR 0033, slice 2).
+
+Two planes reach any brain: the **tool plane** (the operator MCP bus, slice 1) and the
+**context plane** — the *injected* stuff (persona, retrieved knowledge, skills, prior
+sessions). This module is the context plane's contract, so context is produced one way and
+consumed by any runtime (native LangGraph today, an ACP coding agent in slice 3).
+
+Caching discipline (ADR 0033 D5): the **stable prefix** (persona + static instructions) is
+byte-identical turn to turn — cache it. The **volatile delta** (what's retrieved for *this*
+turn) goes after it and never mutates the prefix. The native runtime satisfies this via
+middleware (`build_system_prompt` for the prefix, `KnowledgeMiddleware` for the delta); the
+ACP runtime calls `assemble_context()` to build its prompt + `after_turn()` to write back.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Protocol
+
+log = logging.getLogger(__name__)
+
+
+@dataclass
+class AssembledContext:
+    """The two halves of a turn's context, kept apart so the prefix stays cacheable."""
+
+    stable_prefix: str            # persona + static instructions — turn-stable, cache it
+    volatile_delta: str = ""      # knowledge/skills/prior-sessions retrieved for THIS turn
+    sources: list[str] = field(default_factory=list)  # what fed the delta (telemetry/debug)
+
+    def as_prompt(self, message: str) -> str:
+        """One-shot composition: prefix, then volatile, then the turn's message.
+
+        The prefix stays first + intact so a backend can mark just it for prompt caching.
+        """
+        parts = [self.stable_prefix]
+        if self.volatile_delta:
+            parts.append(self.volatile_delta)
+        if message:
+            parts.append(message)
+        return "\n\n".join(p for p in parts if p)
+
+
+class RuntimeContext(Protocol):
+    """What every runtime implements so the rest of the system is runtime-agnostic."""
+
+    def assemble(self, *, query: str = "") -> AssembledContext: ...
+    def after_turn(self, *, user: str = "", response: str = "") -> None: ...
+
+
+def build_stable_prefix(config=None, *, include_subagents: bool = True) -> str:
+    """The cacheable persona + static instructions — the system prompt. Turn-stable.
+
+    Reuses `graph.prompts.build_system_prompt` (reads SOUL) so the native loop and any
+    external runtime share one persona — no drift.
+    """
+    from graph.prompts import build_system_prompt
+
+    return build_system_prompt(include_subagents=include_subagents)
+
+
+def _format_skills(skills) -> str:
+    lines = ["[Relevant learned skills:]"]
+    for s in skills:
+        name = getattr(s, "name", "skill")
+        desc = getattr(s, "description", "") or ""
+        lines.append(f"- {name}: {desc}".rstrip())
+    return "\n".join(lines)
+
+
+def _format_knowledge(results) -> str:
+    # Mirrors KnowledgeMiddleware's block ({table, preview}) so an external brain sees
+    # exactly what the native loop would inject.
+    lines = ["[Relevant knowledge from previous sessions:]"]
+    for r in results:
+        lines.append(f"- [{r.get('table', '')}] {r.get('preview', '')}")
+    return "\n".join(lines)
+
+
+def retrieve_volatile(config=None, *, query: str = "", knowledge_store=None,
+                      skills_index=None, memory_path: str = "/sandbox/memory/"):
+    """The per-turn context blocks (prior sessions + skills + knowledge). Never raises.
+
+    Same stores + query as `KnowledgeMiddleware`, so an external brain is fed what the
+    native loop would inject. Returns ``(delta_text, sources)``.
+    """
+    blocks: list[str] = []
+    sources: list[str] = []
+    q = (query or "").strip()
+
+    try:
+        from graph.middleware.memory import load_prior_sessions
+
+        prior = load_prior_sessions(memory_path)
+        if prior:
+            blocks.append(prior)
+            sources.append("prior_sessions")
+    except Exception:  # noqa: BLE001
+        log.debug("[context] prior-sessions load skipped", exc_info=True)
+
+    if skills_index is not None and q:
+        try:
+            k = int(getattr(config, "skills_top_k", 5) or 5)
+            skills = skills_index.load_skills(q, k=k)
+            if skills:
+                blocks.append(_format_skills(skills))
+                sources.append(f"skills:{len(skills)}")
+        except Exception:  # noqa: BLE001
+            log.warning("[context] skills retrieval failed", exc_info=True)
+
+    if knowledge_store is not None and q:
+        try:
+            k = int(getattr(config, "knowledge_top_k", 5) or 5)
+            results = knowledge_store.search(q, k=k)
+            if results:
+                blocks.append(_format_knowledge(results))
+                sources.append(f"knowledge:{len(results)}")
+        except Exception:  # noqa: BLE001
+            log.warning("[context] knowledge retrieval failed", exc_info=True)
+
+    return "\n\n".join(blocks), sources
+
+
+def assemble_context(config=None, *, query: str = "", knowledge_store=None,
+                     skills_index=None, include_subagents: bool = True) -> AssembledContext:
+    """Build a turn's context as a cacheable prefix + a volatile delta (ADR 0033 D4)."""
+    prefix = build_stable_prefix(config, include_subagents=include_subagents)
+    delta, sources = retrieve_volatile(
+        config, query=query, knowledge_store=knowledge_store, skills_index=skills_index,
+    )
+    return AssembledContext(stable_prefix=prefix, volatile_delta=delta, sources=sources)
+
+
+def after_turn(knowledge_store=None, *, user: str = "", response: str = "") -> None:
+    """Durable write-back hook (ADR 0033 D5).
+
+    The native loop does fact write-back via the knowledge-ingest middleware. The ACP
+    runtime (slice 3) calls this after a turn. Intentionally a no-op in slice 2 — the
+    read side (`assemble_context`) is what unblocks the ACP runtime; fact extraction is
+    wired where the turn result is available (slice 3).
+    """
+    return None
+
+
+@dataclass
+class ContextAssembler:
+    """A concrete `RuntimeContext` bound to stores — what a runtime holds + calls."""
+
+    config: object = None
+    knowledge_store: object = None
+    skills_index: object = None
+    include_subagents: bool = True
+
+    def assemble(self, *, query: str = "") -> AssembledContext:
+        return assemble_context(
+            self.config, query=query, knowledge_store=self.knowledge_store,
+            skills_index=self.skills_index, include_subagents=self.include_subagents,
+        )
+
+    def after_turn(self, *, user: str = "", response: str = "") -> None:
+        after_turn(self.knowledge_store, user=user, response=response)

--- a/tests/test_runtime_context.py
+++ b/tests/test_runtime_context.py
@@ -1,0 +1,63 @@
+"""Runtime context contract (ADR 0033 slice 2) — cacheable prefix + volatile delta."""
+
+from __future__ import annotations
+
+import types
+
+from runtime.context import AssembledContext, ContextAssembler, assemble_context
+
+
+class _FakeStore:
+    def search(self, query, k=5):
+        return [{"table": "finding", "preview": f"hit for {query}"}]
+
+
+class _FakeSkill:
+    def __init__(self, name, desc):
+        self.name = name
+        self.description = desc
+
+
+class _FakeSkills:
+    def load_skills(self, query, k=5):
+        return [_FakeSkill("deploy", "how to deploy")]
+
+
+def _cfg():
+    return types.SimpleNamespace(knowledge_top_k=5, skills_top_k=5)
+
+
+def test_stable_prefix_is_turn_stable_for_caching():
+    a = assemble_context(_cfg(), query="alpha")
+    b = assemble_context(_cfg(), query="beta totally different")
+    # The prefix (persona/system prompt) must be byte-identical across turns — cacheable.
+    assert a.stable_prefix and a.stable_prefix == b.stable_prefix
+
+
+def test_volatile_delta_reflects_retrieval_and_query():
+    ctx = assemble_context(_cfg(), query="ship it", knowledge_store=_FakeStore(), skills_index=_FakeSkills())
+    assert "hit for ship it" in ctx.volatile_delta          # knowledge block, query-bound
+    assert "deploy: how to deploy" in ctx.volatile_delta     # skills block
+    assert any(s.startswith("knowledge:") for s in ctx.sources)
+    assert any(s.startswith("skills:") for s in ctx.sources)
+
+
+def test_no_query_means_no_knowledge_or_skills():
+    ctx = assemble_context(_cfg(), query="", knowledge_store=_FakeStore(), skills_index=_FakeSkills())
+    assert "hit for" not in ctx.volatile_delta
+    assert "deploy" not in ctx.volatile_delta
+
+
+def test_as_prompt_keeps_prefix_first_then_volatile_then_message():
+    ctx = AssembledContext(stable_prefix="PERSONA", volatile_delta="KB", sources=[])
+    prompt = ctx.as_prompt("do the thing")
+    assert prompt == "PERSONA\n\nKB\n\ndo the thing"
+    # prefix stays at the front + intact (so a backend can cache just it)
+    assert prompt.startswith("PERSONA")
+
+
+def test_assembler_object_implements_the_contract():
+    asm = ContextAssembler(config=_cfg(), knowledge_store=_FakeStore(), skills_index=_FakeSkills())
+    ctx = asm.assemble(query="x")
+    assert ctx.stable_prefix and "hit for x" in ctx.volatile_delta
+    asm.after_turn(user="x", response="y")  # no-op in slice 2, must not raise


### PR DESCRIPTION
**Slice 2 of ADR 0033** — the context plane's contract, so context is produced one way and consumed by any runtime (native LangGraph today, an ACP coding agent in slice 3).

- **`runtime/context.py`** — `AssembledContext{stable_prefix, volatile_delta}` + **`assemble_context()`**: a cacheable persona prefix (reuses `build_system_prompt` → SOUL, one source of truth) + the per-turn delta (knowledge/skills/prior-sessions from the *same* stores `KnowledgeMiddleware` uses). Plus `after_turn()` write-back hook and a concrete `ContextAssembler` (the `RuntimeContext` Protocol).
- **Caching discipline baked in (ADR 0033 D5):** the stable prefix is byte-identical turn to turn (locked by a test); the volatile delta is the only thing that changes, appended *after* the prefix so a backend can cache just the prefix.
- **Additive only** — the native loop is untouched (it already satisfies the contract via middleware); slice 3's ACP runtime calls `assemble_context()` to build its prompt.

Tests: prefix turn-stability, volatile reflects retrieval+query, no-query⇒no kb/skills, `as_prompt` ordering, assembler implements the contract (5). Suite green, ruff clean.

Next: slice 3 — the ACP runtime that mounts the operator MCP bus (slice 1) + satisfies this contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)