### PR TITLE
feat(runtime): ACP agent runtime — coding agent drives the turn (ADR 0033 slice 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **ACP agent runtime** (ADR 0033 slice 3) — `agent_runtime: acp:<agent>` lets an external
+  coding agent (proto/codex/claude/copilot/opencode) drive the turn over ACP: mounts the operator
+  MCP bus (slice 1) into `session/new`, builds the prompt via the context contract (slice 2) —
+  cacheable persona prefix sent once, then per-turn deltas — and writes back after. Opt-in
+  (default `native`, no behavior change); per-agent launch commands are config-overridable.
+  Request-path wiring (route live turns + stream to A2A) lands next.
 - **Runtime context contract** (ADR 0033 slice 2) — `runtime/context.py`: `assemble_context()`
   → `{stable_prefix, volatile_delta}` (a cacheable persona prefix + per-turn retrieved
   knowledge/skills/prior-sessions) + an `after_turn()` write-back hook, so any runtime (native

--- a/graph/config.py
+++ b/graph/config.py
@@ -348,6 +348,11 @@ class LangGraphConfig:
     operator_mcp_enabled: bool = False
     operator_mcp_tools: list[str] = field(default_factory=list)
 
+    # Agent runtime (ADR 0033) — which brain executes a turn. "native" = the built-in
+    # LangGraph loop (default). "acp:<agent>" (e.g. "acp:codex", "acp:claude") = an
+    # external coding agent drives the turn over ACP, mounting the operator MCP bus.
+    agent_runtime: str = "native"
+
     # Plugins — drop-in packages (manifest + register()) that contribute tools
     # and bundled skills. Run IN-PROCESS with the agent's privileges, so a
     # plugin loads only when enabled: listed here, or ``enabled: true`` in its
@@ -587,6 +592,7 @@ class LangGraphConfig:
             mcp_denylist=list(mcp.get("denylist", []) or []),
             operator_mcp_enabled=operator_mcp.get("enabled", cls.operator_mcp_enabled),
             operator_mcp_tools=list(operator_mcp.get("tools", []) or []),
+            agent_runtime=str(data.get("agent_runtime", cls.agent_runtime) or "native"),
             plugins_enabled=list(plugins.get("enabled", []) or []),
             plugins_disabled=list(plugins.get("disabled", []) or []),
             plugins_dir=plugins.get("dir", cls.plugins_dir),

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -58,12 +58,16 @@ class AcpClient:
         env: dict[str, str] | None = None,
         name: str = "acp",
         permission: Callable[[dict], str | None] | None = None,
+        mcp_servers: list[dict] | None = None,
     ) -> None:
         self.command = command
         self.args = list(args or [])
         self.cwd = str(Path(cwd).expanduser())
         self.env = env
         self.name = name
+        # MCP servers mounted into the ACP session (ADR 0033) — how the coding agent
+        # gets protoAgent's operator tools (notes/beads/goals/…) over `session/new`.
+        self.mcp_servers = list(mcp_servers or [])
         # Permission resolver: ``(request_params) -> optionId | None`` (None ⇒
         # cancel/deny). Defaults to ``_auto_allow`` — the coding agent self-governs
         # within its workdir. The plugin injects a by-kind policy here (ADR 0024).
@@ -271,7 +275,7 @@ class AcpClient:
 
     async def _new_session(self) -> None:
         result = await self._request(
-            "session/new", {"cwd": self.cwd, "mcpServers": []}, timeout=30.0
+            "session/new", {"cwd": self.cwd, "mcpServers": self.mcp_servers}, timeout=30.0
         )
         self._session_id = (result or {}).get("sessionId")
         if not self._session_id:

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -1,0 +1,143 @@
+"""ACP agent runtime (ADR 0033, slice 3).
+
+When ``agent_runtime: acp:<agent>``, an external coding agent (proto / codex / claude /
+copilot / opencode) drives the turn over ACP instead of the native LangGraph loop. This
+ties the two foundations together:
+
+- **Tool plane** (slice 1): the operator MCP server is mounted into the ACP session via
+  ``session/new`` ``mcpServers`` — the coding agent gets protoAgent's allowlisted tools.
+- **Context plane** (slice 2): the prompt is built from the runtime context contract — a
+  cacheable persona prefix sent ONCE at session start, then per-turn deltas (ADR 0033 D5:
+  ACP sessions are stateful, so don't resend the world).
+
+protoAgent stays the shell (A2A, scheduling, goals, console, memory). Opt-in: default is the
+native runtime, so this is inert unless configured.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import sys
+
+from runtime.context import ContextAssembler
+
+log = logging.getLogger(__name__)
+
+# Best-effort launch commands per agent — ACP servers drift, so these are *defaults*
+# the operator can override in config (``acp.agents.<name>: {command, args}``).
+_ACP_ADAPTERS: dict[str, dict] = {
+    "proto": {"command": "proto", "args": ["--acp"]},
+    "codex": {"command": "npx", "args": ["-y", "@zed-industries/codex-acp"]},
+    "claude": {"command": "npx", "args": ["-y", "@agentclientprotocol/claude-agent-acp"]},
+    "gemini": {"command": "gemini", "args": ["--experimental-acp"]},
+    "opencode": {"command": "opencode", "args": ["acp"]},
+    "copilot": {"command": "copilot", "args": ["--acp"]},
+}
+
+
+def resolve_runtime(config) -> tuple[str, str]:
+    """``("native", "")`` or ``("acp", "<agent>")`` from ``agent_runtime``."""
+    raw = (getattr(config, "agent_runtime", "native") or "native").strip()
+    if raw == "native" or not raw:
+        return ("native", "")
+    if raw.startswith("acp:"):
+        return ("acp", raw.split(":", 1)[1].strip() or "")
+    if raw == "acp":  # bare "acp" with no agent → invalid, treat as native + warn
+        log.warning("[acp-runtime] agent_runtime 'acp' needs an agent, e.g. 'acp:codex' — using native")
+        return ("native", "")
+    log.warning("[acp-runtime] unknown agent_runtime %r — using native", raw)
+    return ("native", "")
+
+
+def is_acp_runtime(config) -> bool:
+    return resolve_runtime(config)[0] == "acp"
+
+
+def adapter_for(agent: str, config=None) -> dict:
+    """Launch spec ({command, args}) for *agent* — config override beats the default."""
+    overrides = (getattr(config, "acp_agents", None) or {}) if config else {}
+    if agent in overrides and overrides[agent].get("command"):
+        o = overrides[agent]
+        return {"command": o["command"], "args": list(o.get("args", []) or [])}
+    if agent in _ACP_ADAPTERS:
+        d = _ACP_ADAPTERS[agent]
+        return {"command": d["command"], "args": list(d["args"])}
+    raise ValueError(f"no ACP adapter for {agent!r} — add acp.agents.{agent}.command in config")
+
+
+def operator_mcp_server_spec(config) -> dict | None:
+    """The ``mcpServers`` entry mounting slice 1's operator MCP server, or None when no
+    tools are allowlisted (nothing to expose)."""
+    if not (getattr(config, "operator_mcp_tools", None) or []):
+        return None
+    env: dict[str, str] = {}
+    inst = os.environ.get("PROTOAGENT_INSTANCE")
+    if inst:
+        env["PROTOAGENT_INSTANCE"] = inst  # the sidecar shares this instance's data
+    return {
+        "name": "protoagent-operator",
+        "command": sys.executable,
+        "args": ["-m", "server.operator_mcp"],
+        "env": env,
+    }
+
+
+class AcpRuntime:
+    """Drives turns through an external coding agent over ACP.
+
+    One instance per session/thread (the ACP session is stateful — the agent holds
+    history, so we send the cacheable prefix once then per-turn deltas).
+    """
+
+    def __init__(self, config, *, cwd: str | None = None, client_factory=None, context=None):
+        self.config = config
+        kind, agent = resolve_runtime(config)
+        if kind != "acp":
+            raise ValueError("AcpRuntime constructed for a non-ACP runtime")
+        self.agent = agent
+        self.cwd = cwd or os.getcwd()
+        self._context = context or self._default_context()
+        self._client_factory = client_factory or self._default_client_factory
+        self._client = None
+        self._prefix_sent = False
+
+    def _default_context(self) -> ContextAssembler:
+        from runtime.state import STATE
+        return ContextAssembler(
+            config=self.config,
+            knowledge_store=getattr(STATE, "knowledge_store", None),
+            skills_index=getattr(STATE, "skills_index", None),
+        )
+
+    def _default_client_factory(self):
+        spec = adapter_for(self.agent, self.config)
+        mcp = operator_mcp_server_spec(self.config)
+        from plugins.coding_agent.acp_client import AcpClient
+        return AcpClient(
+            spec["command"], spec.get("args"), cwd=self.cwd, name=self.agent,
+            mcp_servers=[mcp] if mcp else [],
+        )
+
+    def _ensure_client(self):
+        if self._client is None:
+            self._client = self._client_factory()
+        return self._client
+
+    async def run_turn(self, message: str, *, progress_callback=None) -> str:
+        """Run one turn: build the prompt (prefix once, then deltas) → ACP → write back."""
+        client = self._ensure_client()
+        ctx = self._context.assemble(query=message)
+        if not self._prefix_sent:
+            prompt = ctx.as_prompt(message)            # persona prefix + volatile + message
+            self._prefix_sent = True                   # session is stateful — don't resend the prefix
+        else:
+            prompt = "\n\n".join(p for p in (ctx.volatile_delta, message) if p)
+        answer = await client.prompt(prompt, progress_callback=progress_callback)
+        self._context.after_turn(user=message, response=answer)
+        return answer
+
+    async def close(self) -> None:
+        if self._client is not None and hasattr(self._client, "close"):
+            await self._client.close()
+            self._client = None

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -1,0 +1,98 @@
+"""ACP agent runtime (ADR 0033 slice 3) — runtime resolution + turn driving (mocked client)."""
+
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from runtime.acp_runtime import AcpRuntime, adapter_for, operator_mcp_server_spec, resolve_runtime
+from runtime.context import AssembledContext
+
+
+def _cfg(**kw):
+    base = dict(agent_runtime="acp:codex", operator_mcp_tools=["beads_list"], acp_agents={})
+    base.update(kw)
+    return types.SimpleNamespace(**base)
+
+
+def test_resolve_runtime_variants():
+    assert resolve_runtime(types.SimpleNamespace(agent_runtime="native")) == ("native", "")
+    assert resolve_runtime(types.SimpleNamespace(agent_runtime="acp:codex")) == ("acp", "codex")
+    assert resolve_runtime(types.SimpleNamespace(agent_runtime="acp")) == ("native", "")   # needs an agent
+    assert resolve_runtime(types.SimpleNamespace(agent_runtime="bogus")) == ("native", "")
+
+
+def test_adapter_default_and_override():
+    assert adapter_for("codex")["command"] == "npx"
+    cfg = types.SimpleNamespace(acp_agents={"codex": {"command": "mycodex", "args": ["x"]}})
+    assert adapter_for("codex", cfg) == {"command": "mycodex", "args": ["x"]}
+    with pytest.raises(ValueError):
+        adapter_for("nonexistent")
+
+
+def test_operator_mcp_spec_gated_on_allowlist():
+    assert operator_mcp_server_spec(types.SimpleNamespace(operator_mcp_tools=[])) is None
+    spec = operator_mcp_server_spec(types.SimpleNamespace(operator_mcp_tools=["beads_list"]))
+    assert spec["name"] == "protoagent-operator"
+    assert spec["args"] == ["-m", "server.operator_mcp"]
+
+
+class _FakeCtx:
+    def __init__(self):
+        self.after = []
+
+    def assemble(self, *, query=""):
+        return AssembledContext(stable_prefix="PERSONA", volatile_delta=f"KB[{query}]", sources=[])
+
+    def after_turn(self, *, user="", response=""):
+        self.after.append((user, response))
+
+
+class _FakeClient:
+    def __init__(self):
+        self.prompts = []
+        self.closed = False
+
+    async def prompt(self, text, progress_callback=None):
+        self.prompts.append(text)
+        return "ANSWER"
+
+    async def close(self):
+        self.closed = True
+
+
+async def test_run_turn_sends_prefix_once_then_deltas():
+    client, ctx = _FakeClient(), _FakeCtx()
+    rt = AcpRuntime(_cfg(), client_factory=lambda: client, context=ctx)
+    a1 = await rt.run_turn("hello")
+    a2 = await rt.run_turn("again")
+    assert a1 == a2 == "ANSWER"
+    # First turn carries the cacheable persona prefix; later turns don't (stateful session).
+    assert client.prompts[0] == "PERSONA\n\nKB[hello]\n\nhello"
+    assert client.prompts[1] == "KB[again]\n\nagain"
+    assert ctx.after == [("hello", "ANSWER"), ("again", "ANSWER")]
+    await rt.close()
+    assert client.closed
+
+
+def test_default_factory_mounts_operator_mcp(monkeypatch):
+    captured = {}
+
+    import plugins.coding_agent.acp_client as acp
+
+    class _Spy:
+        def __init__(self, command, args=None, *, cwd, name, mcp_servers=None, **kw):
+            captured.update(command=command, name=name, mcp_servers=mcp_servers)
+
+    monkeypatch.setattr(acp, "AcpClient", _Spy)
+    rt = AcpRuntime(_cfg(), context=_FakeCtx())
+    rt._ensure_client()
+    assert captured["name"] == "codex"
+    assert captured["command"] == "npx"
+    assert captured["mcp_servers"][0]["name"] == "protoagent-operator"
+
+
+def test_constructing_for_native_raises():
+    with pytest.raises(ValueError):
+        AcpRuntime(types.SimpleNamespace(agent_runtime="native"))


### PR DESCRIPTION
**Slice 3 of ADR 0033** — ties slices 1+2 together. `agent_runtime: acp:<agent>` routes a turn to an external coding agent (proto/codex/claude/copilot/opencode) over ACP.

- **`runtime/acp_runtime.py`** — `AcpRuntime.run_turn`: `assemble_context` (slice 2) → prompt → ACP → after-turn write-back. The **cacheable persona prefix is sent once** (the ACP session is stateful), then **per-turn deltas** (ADR 0033 D5). Mounts the **operator MCP server** (slice 1) into `session/new` `mcpServers` so the coding agent gets the allowlisted operator tools. `resolve_runtime()` + per-agent adapters (config-overridable via `acp.agents.<name>`).
- **acp_client** — `session/new` now passes configurable `mcp_servers` (was hardcoded `[]`).
- **config** — `agent_runtime` axis (default `native`).

**Opt-in** — default native ⇒ inert unless configured. CI can't run a real coding agent, so the runtime is unit-tested with a mocked client; the **request-path wiring** (route live A2A turns + stream back) is the next slice, where it's live-validated against a real agent.

Tests: runtime resolution, adapter default/override, operator-MCP spec gating, `run_turn` prefix-once-then-deltas + after-turn write-back, default factory mounts the operator MCP (6). Suite green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)