### PR TITLE
feat(runtime): wire the ACP runtime into the request path (ADR 0033 slice 4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **ACP runtime wired into the request path** (ADR 0033 slice 4) — with `agent_runtime: acp:<agent>`,
+  A2A/chat turns are driven by an external coding agent (proto/codex/claude/…), which reaches
+  protoAgent's tools through the operator MCP bus mounted into the ACP session. One stateful ACP
+  session per thread. Live-verified end-to-end: proto created + persisted a bead via the bus.
 - **ACP agent runtime** (ADR 0033 slice 3) — `agent_runtime: acp:<agent>` lets an external
   coding agent (proto/codex/claude/copilot/opencode) drive the turn over ACP: mounts the operator
   MCP bus (slice 1) into `session/new`, builds the prompt via the context contract (slice 2) —

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -162,6 +162,28 @@ are mounted by the client directly. Empty `tools` ⇒ nothing exposed (don't han
 etc. to an outside brain unless you mean to). The sidecar boots **stores only** — it never starts
 the agent's background loops — so it's safe to run against a live instance's data.
 
+## Run on a coding agent (ACP runtime)
+
+protoAgent can hand the *whole turn* to an external coding agent — **proto, Codex, Claude,
+Copilot, OpenCode** — over ACP (ADR 0033). The coding agent is the brain (with its own
+tools); protoAgent stays the shell (A2A, scheduling, goals, console, memory), and exposes
+its operator tools to that brain via the MCP server above, mounted into the ACP session.
+
+```yaml
+agent_runtime: acp:proto         # native (default) | acp:<agent>
+operator_mcp:
+  tools: [memory_recall, memory_ingest, beads_create, beads_list, notes_read, run_workflow]
+# acp:                           # optional — override an agent's launch command
+#   agents:
+#     codex: { command: npx, args: ["-y", "@zed-industries/codex-acp"] }
+```
+
+With this set, each turn is driven by the coding agent: protoAgent assembles the context
+(a cacheable persona prefix sent once, then per-turn deltas — ADR 0033 D5), the agent reasons
++ uses its own tools, and reaches back into protoAgent's notes/beads/memory/workflows through
+the mounted operator MCP server. Defaults are `native` (the built-in LangGraph loop), so this
+is inert until you opt in. Each agent needs its CLI installed + authenticated on the host.
+
 ## Notes & limits
 
 - **Tools only** for now — MCP *Resources* and *Prompts* aren't wired yet.

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -19,10 +19,13 @@ from __future__ import annotations
 import logging
 import os
 import sys
+from pathlib import Path
 
 from runtime.context import ContextAssembler
 
 log = logging.getLogger(__name__)
+
+_REPO_ROOT = Path(__file__).resolve().parents[1]  # repo root (where the `server` pkg lives)
 
 # Best-effort launch commands per agent — ACP servers drift, so these are *defaults*
 # the operator can override in config (``acp.agents.<name>: {command, args}``).
@@ -71,10 +74,19 @@ def operator_mcp_server_spec(config) -> dict | None:
     tools are allowlisted (nothing to expose)."""
     if not (getattr(config, "operator_mcp_tools", None) or []):
         return None
-    env: dict[str, str] = {}
+    # ACP's stdio MCP-server schema wants env as an array of {name, value} (not a dict).
+    # The agent spawns this command in its OWN cwd, so put the repo on PYTHONPATH — else
+    # `-m server.operator_mcp` can't import (unless protoagent is pip-installed).
+    repo_root = str(_REPO_ROOT)
+    pythonpath = repo_root + (os.pathsep + os.environ["PYTHONPATH"] if os.environ.get("PYTHONPATH") else "")
+    env: list[dict] = [{"name": "PYTHONPATH", "value": pythonpath}]
     inst = os.environ.get("PROTOAGENT_INSTANCE")
     if inst:
-        env["PROTOAGENT_INSTANCE"] = inst  # the sidecar shares this instance's data
+        env.append({"name": "PROTOAGENT_INSTANCE", "value": inst})  # share this instance's data
+    # Pass the runtime's allowlist to the child explicitly — the spawned server otherwise
+    # reads operator_mcp.tools from YAML, which may not match this runtime's intent.
+    tools = ",".join(getattr(config, "operator_mcp_tools", []) or [])
+    env.append({"name": "OPERATOR_MCP_TOOLS", "value": tools})
     return {
         "name": "protoagent-operator",
         "command": sys.executable,

--- a/server/chat.py
+++ b/server/chat.py
@@ -53,6 +53,20 @@ def _resolve_thread_id(request_metadata: dict | None, session_id: str) -> str:
     return f"a2a:{session_id}"
 
 
+# One ACP runtime per thread (the ACP session is stateful — the coding agent holds
+# history, so we reuse it across turns; ADR 0033 slice 4).
+_ACP_RUNTIMES: dict[str, Any] = {}
+
+
+def _get_acp_runtime(thread_id: str):
+    rt = _ACP_RUNTIMES.get(thread_id)
+    if rt is None:
+        from runtime.acp_runtime import AcpRuntime
+        rt = AcpRuntime(STATE.graph_config)
+        _ACP_RUNTIMES[thread_id] = rt
+    return rt
+
+
 def _setup_required_message() -> list[dict[str, Any]]:
     """Returned by chat endpoints when the wizard hasn't been run.
 
@@ -512,6 +526,21 @@ async def _chat_langgraph_stream(
                 sub_out = await _run_parsed_subagent(sub_type, sub_prompt)
                 yield ("tool_end", {"id": sub_tool_id, "name": sub_tool_id, "output": sub_out[:300]})
                 yield ("done", sub_out)
+                return
+
+            # ACP runtime (ADR 0033 slice 4) — when `agent_runtime: acp:<agent>`, an
+            # external coding agent (proto/codex/claude/…) drives the turn over ACP
+            # instead of the native LangGraph loop. One stateful ACP session per thread.
+            from runtime.acp_runtime import is_acp_runtime
+            if is_acp_runtime(STATE.graph_config):
+                rt = _get_acp_runtime(_resolve_thread_id(request_metadata, session_id))
+                try:
+                    answer = await rt.run_turn(message)
+                except Exception as exc:  # noqa: BLE001 — surface as a turn error, don't 500
+                    log.exception("[acp-runtime] turn failed")
+                    yield ("error", f"ACP runtime ({rt.agent}) failed: {exc}")
+                    return
+                yield ("done", answer)
                 return
 
             # thread_id keys this session's history in the checkpointer (bound

--- a/server/operator_mcp.py
+++ b/server/operator_mcp.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 
 import argparse
 import logging
+import os
 
 from runtime.state import STATE
 
@@ -120,6 +121,11 @@ def main(argv: list[str] | None = None) -> None:
     from graph.config_io import CONFIG_YAML_PATH
 
     config = LangGraphConfig.from_yaml(CONFIG_YAML_PATH)
+    # An explicit allowlist from the caller (e.g. the ACP runtime spawning this) overrides
+    # the YAML — so the exposed set matches the runtime's intent, not whatever's on disk.
+    env_tools = os.environ.get("OPERATOR_MCP_TOOLS")
+    if env_tools is not None:
+        config.operator_mcp_tools = [t.strip() for t in env_tools.split(",") if t.strip()]
     _boot_stores_only(config)
     server, exposed = build_server(config)
     if not exposed:

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -96,3 +96,23 @@ def test_default_factory_mounts_operator_mcp(monkeypatch):
 def test_constructing_for_native_raises():
     with pytest.raises(ValueError):
         AcpRuntime(types.SimpleNamespace(agent_runtime="native"))
+
+
+def test_chat_caches_acp_runtime_per_thread(monkeypatch):
+    import importlib
+
+    chat = importlib.import_module("server.chat")  # the `server.chat` attr is the re-exported fn
+    from runtime.state import STATE
+
+    monkeypatch.setattr(
+        STATE, "graph_config",
+        types.SimpleNamespace(agent_runtime="acp:codex", operator_mcp_tools=[], acp_agents={}),
+        raising=False,
+    )
+    chat._ACP_RUNTIMES.clear()
+    r1 = chat._get_acp_runtime("t1")
+    r2 = chat._get_acp_runtime("t1")
+    r3 = chat._get_acp_runtime("t2")
+    assert r1 is r2          # same thread → same stateful ACP session
+    assert r1 is not r3      # different thread → its own session
+    assert r1.agent == "codex"


### PR DESCRIPTION
**Slice 4 — the payoff.** `agent_runtime: acp:<agent>` now drives real A2A/chat turns through an external coding agent (proto/codex/claude/copilot/opencode), which operates protoAgent's tools through the operator MCP bus.

- **`server/chat.py`** — when `is_acp_runtime(config)`, the turn routes to a **per-thread `AcpRuntime`** (stateful ACP session reused across turns) → `(done, answer)`. The native path is untouched + guarded (default `native` ⇒ zero behavior change).
- **Fixes found via live smoke:** ACP's stdio `mcpServers` schema wants `env` as an **array of `{name,value}`** (not a dict); the spawned `server.operator_mcp` needs **`PYTHONPATH`** to import from the agent's cwd; and the allowlist is passed explicitly via **`OPERATOR_MCP_TOOLS`** so the child exposes the runtime's intended tools, not whatever's in YAML.

### Live-verified end-to-end (real proto)
- A turn returned exactly `ACP_OK`.
- With the bus mounted, proto called `beads_create` over MCP-over-ACP and **bead `bd-1` "acp-smoke-bead" actually persisted** in protoAgent's store (reported id == real id, not a hallucination).

Tests: per-thread runtime caching + the slice-3 suite (mocked client; CI can't run a real agent). **Full suite 1279**, ruff clean, docs build clean.

**ADR 0033 complete** — slices 1–4: tool bus → context contract → ACP runtime → request-path wiring, live-proven.

🤖 Generated with [Claude Code](https://claude.com/claude-code)