### PR TITLE
chore: release v0.27.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.27.0] - 2026-06-08
+
 ### Added
 - **ACP runtime wired into the request path** (ADR 0033 slice 4) — with `agent_runtime: acp:<agent>`,
   A2A/chat turns are driven by an external coding agent (proto/codex/claude/…), which reaches

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.26.0"
+version = "0.27.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,17 @@
 [
   {
+    "version": "v0.27.0",
+    "date": "2026-06-08",
+    "changes": [
+      "ACP runtime wired into the request path",
+      "ACP agent runtime",
+      "Runtime context contract",
+      "Operator tools as an MCP server",
+      "ACP runtime guide",
+      "ADR 0033"
+    ]
+  },
+  {
     "version": "v0.26.0",
     "date": "2026-06-08",
     "changes": [

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -3,12 +3,9 @@
     "version": "v0.27.0",
     "date": "2026-06-08",
     "changes": [
-      "ACP runtime wired into the request path",
-      "ACP agent runtime",
-      "Runtime context contract",
-      "Operator tools as an MCP server",
-      "ACP runtime guide",
-      "ADR 0033"
+      "Run protoAgent's brain on a coding agent — proto, Codex, or Claude can now drive the runtime over ACP, while protoAgent stays the operable A2A / console / goals / scheduling shell around it.",
+      "Publish protoAgent's tools as an MCP server — point Claude Desktop, Cursor, or a coding agent at an instance and operate it (notes, beads, memory, workflows), allowlist-gated.",
+      "Context is assembled cache-friendly under the hood — a stable persona prefix plus per-turn deltas — so the coding agent's own prompt caching stays intact."
     ]
   },
   {


### PR DESCRIPTION
Automated version bump to `v0.27.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.27.0 -m 'Release v0.27.0' && git push origin v0.27.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).