### PR TITLE
feat(delegates): ACP delegate teardown — reap the cached client's subprocess

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ACP delegate teardown** — `coding_agent.evict_client(spec)` + `AcpAdapter.teardown(delegate)`
+  evict the cached `AcpClient` for a spec **and** terminate its subprocess (a plain cache `pop`
+  forgot the handle but left the child running). Completes the delegate lifecycle for callers that
+  dispatch into a transient, per-call `workdir` (e.g. a disposable git worktree, scoped via
+  `dataclasses.replace`): call `teardown` in a `finally` so each scoped `workdir` reaps its own
+  process instead of leaking one. Best-effort + idempotent; no change to existing callers (the
+  ACP runtime owns its own client separately and is unaffected).
+
 ## [0.27.0] - 2026-06-08
 
 ### Added

--- a/plugins/coding_agent/__init__.py
+++ b/plugins/coding_agent/__init__.py
@@ -150,6 +150,27 @@ def _client_for(spec: dict) -> AcpClient:
     return client
 
 
+async def evict_client(spec: dict) -> bool:
+    """Drop the cached client for ``spec`` AND terminate its subprocess.
+
+    The dispatch/relaunch paths ``_CLIENTS.pop(...)`` on an ``AcpError`` only
+    *forget* the handle, leaving the child to be reaped by GC. A caller that
+    dispatches into a short-lived, per-call ``workdir`` (e.g. a disposable git
+    worktree) needs a *deterministic* reap — otherwise each scoped ``workdir``
+    leaves its own ``AcpClient`` subprocess behind (the cache key includes
+    ``workdir``). This pops the cached client and ``await``s ``client.close()`` so
+    the process actually dies. Returns True if a live client was closed; idempotent.
+    """
+    client = _CLIENTS.pop(_cache_key(spec), None)
+    if client is None:
+        return False
+    try:
+        await client.close()
+    except Exception:  # noqa: BLE001 — teardown is best-effort
+        log.warning("[coding_agent/%s] close during evict failed", spec.get("name"), exc_info=True)
+    return True
+
+
 def _approved(decision) -> bool:
     return str(decision).strip().lower() in _APPROVALS
 

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -352,22 +352,43 @@ class AcpAdapter(Adapter):
         d.confirm = str(raw.get("confirm", "")).strip().lower() in ("1", "true", "yes")
         return d
 
+    @staticmethod
+    def _spec(d: Delegate) -> dict:
+        """The coding_agent spec dict for this delegate. Shared by ``dispatch`` and
+        ``teardown`` so both compute the SAME client cache key (which includes
+        ``workdir``) — so a caller that scopes ``workdir`` per call (e.g. via
+        ``dataclasses.replace`` onto a disposable worktree) tears down the exact
+        client it dispatched."""
+        return {
+            "name": d.name, "command": d.command, "args": d.args, "workdir": d.workdir,
+            "env": d.env or None, "permissions": d.permissions,
+            "allow_kinds": d.allow_kinds, "deny_kinds": d.deny_kinds,
+        }
+
     async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
         # Reuse the ADR 0024 ACP client + by-kind permission policy.
         from plugins.coding_agent import _client_for, _make_permission
         from plugins.coding_agent.acp_client import AcpError
 
-        spec = {
-            "name": d.name, "command": d.command, "args": d.args, "workdir": d.workdir,
-            "env": d.env or None, "permissions": d.permissions,
-            "allow_kinds": d.allow_kinds, "deny_kinds": d.deny_kinds,
-        }
+        spec = self._spec(d)
         client = _client_for(spec)
         client._permission = _make_permission(spec)
         try:
             return await client.prompt(query, timeout=timeout or d.timeout_s)
         except AcpError as exc:
             raise DelegateError(str(exc))
+
+    async def teardown(self, d: Delegate) -> bool:
+        """Evict + terminate the cached ACP subprocess for this delegate.
+
+        ``dispatch`` caches a long-lived ``AcpClient`` (subprocess + session) keyed
+        partly on ``workdir``. A caller that dispatches into a transient, per-call
+        ``workdir`` should call this when done (e.g. in a ``finally``) so the child
+        is reaped rather than left running — a plain cache ``pop`` forgets the
+        handle but leaves the process alive. Returns True if a live client was
+        closed; no-op (False) if none was started. Idempotent."""
+        from plugins.coding_agent import evict_client
+        return await evict_client(self._spec(d))
 
     async def probe(self, d: Delegate) -> dict:
         import os

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -281,3 +281,45 @@ async def test_confirm_gate_approves_then_runs(monkeypatch):
     register(reg)
     out = await reg.tools[0].ainvoke({"agent": "proto", "task": "do it"})
     assert out == "did the work"
+
+
+async def test_evict_client_pops_and_closes():
+    """evict_client removes the cached client AND awaits close() — a plain pop
+    would forget the handle but leave the subprocess alive."""
+    spec = {
+        "name": "proto", "command": "proto", "args": ["--acp"], "workdir": "/tmp/wt-1",
+        "permissions": "allowlist", "allow_kinds": [], "deny_kinds": [],
+    }
+
+    class _FakeClient:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    fake = _FakeClient()
+    P._CLIENTS[P._cache_key(spec)] = fake
+
+    assert await P.evict_client(spec) is True
+    assert fake.closed is True
+    assert P._cache_key(spec) not in P._CLIENTS
+    # idempotent: nothing cached for this spec now
+    assert await P.evict_client(spec) is False
+
+
+async def test_evict_client_swallows_close_errors():
+    """A close() that raises must not propagate — teardown is best-effort, and the
+    cache entry is dropped regardless."""
+    spec = {
+        "name": "proto", "command": "proto", "args": [], "workdir": "/tmp/wt-2",
+        "permissions": "auto", "allow_kinds": [], "deny_kinds": [],
+    }
+
+    class _BadClient:
+        async def close(self):
+            raise RuntimeError("terminate blew up")
+
+    P._CLIENTS[P._cache_key(spec)] = _BadClient()
+    assert await P.evict_client(spec) is True          # did not raise
+    assert P._cache_key(spec) not in P._CLIENTS

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -188,6 +188,31 @@ async def test_acp_dispatch_reuses_client(monkeypatch):
     assert await ADAPTERS["acp"].dispatch(d, "fix the bug") == "coding done"
 
 
+async def test_acp_teardown_evicts_the_workdir_scoped_client():
+    """teardown reaps the exact cached client dispatch created — proving the
+    spec/cache-key (incl. workdir) line up, so a per-call scoped workdir tears
+    down its own subprocess."""
+    import plugins.coding_agent as CA
+
+    d = ADAPTERS["acp"].parse({"name": "proto", "type": "acp", "command": "proto", "workdir": "/tmp/wt-x"})
+    spec = ADAPTERS["acp"]._spec(d)
+
+    class _FakeClient:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    fake = _FakeClient()
+    CA._CLIENTS[CA._cache_key(spec)] = fake
+
+    assert await ADAPTERS["acp"].teardown(d) is True
+    assert fake.closed is True
+    assert CA._cache_key(spec) not in CA._CLIENTS
+    assert await ADAPTERS["acp"].teardown(d) is False   # idempotent
+
+
 # ── health prober (PR4) ───────────────────────────────────────────────────────
 
 import plugins.delegates.health as H  # noqa: E402


### PR DESCRIPTION
## What

Adds a teardown counterpart to the ACP delegate dispatch path:

- `coding_agent.evict_client(spec)` — pops the cached `AcpClient` for a spec **and** `await`s `client.close()` so the child process is terminated, not just forgotten.
- `AcpAdapter.teardown(delegate)` — calls `evict_client` via a shared `AcpAdapter._spec(d)` so `dispatch` and `teardown` compute the **same** cache key (which includes `workdir`).

## Why

`dispatch()` caches an `AcpClient` (subprocess + session) keyed partly on `workdir`, but there was no way to evict it. A caller that dispatches into a **transient, per-call `workdir`** — e.g. a disposable git worktree scoped via `dataclasses.replace(delegate, workdir=worktree)` — leaves one `proto --acp` child **per workdir** running. The existing `_CLIENTS.pop(...)` on an `AcpError` only forgets the handle; it doesn't terminate the process.

With this, such a caller can do:

```python
scoped = dataclasses.replace(coder, workdir=worktree)
try:
    await ADAPTERS["acp"].dispatch(scoped, task)
finally:
    await ADAPTERS["acp"].teardown(scoped)   # reaps the exact client it dispatched
```

## Notes
- **Best-effort + idempotent.** `close()` errors are swallowed (logged); a second call returns `False`.
- **No change to existing callers.** `dispatch` behavior is identical (just factored through `_spec`). The ADR 0033 ACP *runtime* owns its own `AcpClient` directly (not via `_CLIENTS`) and is unaffected.

## Tests
- `evict_client` pops + closes + is idempotent; swallows a raising `close()`.
- `AcpAdapter.teardown` reaps the exact cached client `dispatch` would create (proves the `_spec`/cache-key alignment incl. `workdir`).

`ruff` clean; `tests/test_coding_agent_plugin.py` + `tests/test_delegates_plugin.py` green (37 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)