### PR TITLE
feat: ACP runtime in the console (settings + '*' allowlist) + instance-scoped config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ACP delegate teardown** — `coding_agent.evict_client(spec)` + `AcpAdapter.teardown(delegate)`
+  evict the cached `AcpClient` for a spec **and** terminate its subprocess (a plain cache `pop`
+  forgot the handle but left the child running). Completes the delegate lifecycle for callers that
+  dispatch into a transient, per-call `workdir` (e.g. a disposable git worktree, scoped via
+  `dataclasses.replace`): call `teardown` in a `finally` so each scoped `workdir` reaps its own
+  process instead of leaking one. Best-effort + idempotent; no change to existing callers (the
+  ACP runtime owns its own client separately and is unaffected).
+
 ## [0.27.0] - 2026-06-08
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Instance-scoped config** (ADR 0004) — with `PROTOAGENT_INSTANCE` set, the live config +
+  secrets + setup-marker are now per-instance (seeded from the default's on first boot), so a
+  scoped instance's saves no longer mutate the shared config. No-op for the default instance.
+
 ### Added
+- **Agent runtime selectable in the console** — Agent → Settings has an **Agent runtime** group:
+  a dropdown (native | acp:proto | acp:codex | acp:claude | acp:copilot | acp:opencode) + a
+  **tools allowlist** for the ACP brain. The allowlist accepts `*` to expose everything (minus
+  `execute_code`, which a coding agent already has) — no need to enumerate every tool.
 - **ACP delegate teardown** — `coding_agent.evict_client(spec)` + `AcpAdapter.teardown(delegate)`
   evict the cached `AcpClient` for a spec **and** terminate its subprocess (a plain cache `pop`
   forgot the handle but left the child running). Completes the delegate lifecycle for callers that

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -72,7 +72,13 @@ PRESETS_DIR = _BUNDLE_CONFIG_DIR / "soul-presets"
 # ``.example`` template on first run (see ``ensure_live_config``) and rewritten
 # by the wizard/drawer. Keeping it out of git means setup edits never dirty a
 # tracked file; the template carries the shipped defaults + comments.
-CONFIG_YAML_PATH = _LIVE_CONFIG_DIR / "langgraph-config.yaml"
+# Instance-scoped (ADR 0004): a per-instance config when PROTOAGENT_INSTANCE is set, so
+# `--instance foo` gets its own config/secrets instead of sharing the default's — a no-op
+# (the base path) for the unscoped default. The unscoped base is kept for graceful seeding.
+from paths import scope_leaf as _scope_leaf
+
+_BASE_CONFIG_YAML = _LIVE_CONFIG_DIR / "langgraph-config.yaml"
+CONFIG_YAML_PATH = _scope_leaf(_BASE_CONFIG_YAML)
 SOUL_RUNTIME_PATH = Path("/sandbox/SOUL.md")
 
 # Secrets overlay. The setup wizard / drawer collect a model API key and an
@@ -80,7 +86,8 @@ SOUL_RUNTIME_PATH = Path("/sandbox/SOUL.md")
 # configured checkout carries credentials in git. Instead they live in this
 # untracked sibling file (gitignored + dockerignored), read back by
 # ``LangGraphConfig.from_yaml`` and stripped from the main YAML on every save.
-SECRETS_YAML_PATH = _LIVE_CONFIG_DIR / "secrets.yaml"
+_BASE_SECRETS_YAML = _LIVE_CONFIG_DIR / "secrets.yaml"
+SECRETS_YAML_PATH = _scope_leaf(_BASE_SECRETS_YAML)
 
 # (section, key) pairs that must never be written to the tracked YAML.
 SECRET_PATHS: tuple[tuple[str, str], ...] = (
@@ -111,7 +118,8 @@ def secret_paths() -> tuple[tuple[str, str], ...]:
 # server should boot straight into the chat UI. Absence = show the
 # wizard on first page load. Lives in the live config dir so a Docker volume
 # mount (or the desktop app-data dir) persists setup across runs.
-SETUP_MARKER_PATH = _LIVE_CONFIG_DIR / ".setup-complete"
+_BASE_SETUP_MARKER = _LIVE_CONFIG_DIR / ".setup-complete"
+SETUP_MARKER_PATH = _scope_leaf(_BASE_SETUP_MARKER)
 
 
 # ---------------------------------------------------------------------------
@@ -130,24 +138,39 @@ except ImportError:
 
 
 def ensure_live_config() -> bool:
-    """Seed the live config from the tracked ``.example`` template on first run.
+    """Seed the live config on first run. Returns True only when it created the file.
 
-    The live ``langgraph-config.yaml`` is untracked, so a fresh clone / a new
-    container volume won't have one. Copy the template (comments + shipped
-    defaults intact) into place when it's missing. Idempotent — does nothing
-    once the live file exists, so wizard/drawer edits are never clobbered.
-    Returns True only when it created the file.
+    The live ``langgraph-config.yaml`` is untracked, so a fresh clone / new container
+    volume / **new instance** won't have one. Seed source:
+
+    - An **instance-scoped** path (PROTOAGENT_INSTANCE set) inherits the unscoped *base*
+      config + secrets + setup-marker when they exist — so `--instance foo` boots from
+      the default's setup, then diverges on its own saves (graceful, no re-setup).
+    - Otherwise (or no base yet) copy the tracked ``.example`` template.
+
+    Idempotent — does nothing once the live file exists, so edits are never clobbered.
     """
-    if CONFIG_YAML_PATH.exists() or not CONFIG_EXAMPLE_PATH.exists():
+    if CONFIG_YAML_PATH.exists():
         return False
     import shutil
 
+    from paths import instance_id
+
+    scoped = bool(instance_id())  # PROTOAGENT_INSTANCE set ⇒ this path is instance-scoped
+    source = _BASE_CONFIG_YAML if (scoped and _BASE_CONFIG_YAML.exists()) else CONFIG_EXAMPLE_PATH
+    if not source.exists():
+        return False
+
     CONFIG_YAML_PATH.parent.mkdir(parents=True, exist_ok=True)
-    shutil.copyfile(CONFIG_EXAMPLE_PATH, CONFIG_YAML_PATH)
-    log.info(
-        "[config] seeded live config %s from %s",
-        CONFIG_YAML_PATH, CONFIG_EXAMPLE_PATH.name,
-    )
+    shutil.copyfile(source, CONFIG_YAML_PATH)
+    # When seeding a scoped instance from the base, carry its secrets + setup state too,
+    # so the instance is usable immediately instead of dropping into the setup wizard.
+    if scoped and source == _BASE_CONFIG_YAML:
+        if _BASE_SECRETS_YAML.exists() and not SECRETS_YAML_PATH.exists():
+            shutil.copyfile(_BASE_SECRETS_YAML, SECRETS_YAML_PATH)
+        if _BASE_SETUP_MARKER.exists() and not SETUP_MARKER_PATH.exists():
+            shutil.copyfile(_BASE_SETUP_MARKER, SETUP_MARKER_PATH)
+    log.info("[config] seeded live config %s from %s", CONFIG_YAML_PATH, source.name)
     return True
 
 

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -55,6 +55,15 @@ FIELDS: list[Field] = [
     Field("routing.fallback_models", "routing_fallback_models", "Fallback models", "string_list",
           "Routing", "Retried in order when the primary model errors."),
 
+    # ── Agent runtime (ADR 0033) — which brain drives a turn ───────────────────
+    Field("agent_runtime", "agent_runtime", "Agent runtime", "select", "Agent runtime",
+          "Which brain drives a turn: the built-in LangGraph loop (native), or an external "
+          "coding agent over ACP (needs its CLI installed + authenticated on the host).",
+          options=["native", "acp:proto", "acp:codex", "acp:claude", "acp:copilot", "acp:opencode"]),
+    Field("operator_mcp.tools", "operator_mcp_tools", "Tools exposed to the ACP brain", "string_list",
+          "Agent runtime", "Allowlist of operator tools an external (ACP) brain may call via MCP — one "
+          "per line (e.g. memory_recall, beads_create). Empty = none. Ignored by the native runtime."),
+
     # ── Context compaction ───────────────────────────────────────────────────
     Field("compaction.enabled", "compaction_enabled", "Enable compaction", "bool", "Compaction",
           "Summarize old history near the context limit."),
@@ -181,6 +190,7 @@ _SECTION_CATEGORY = {
     "Identity": "Agent",
     "Model": "Agent",
     "Routing": "Agent",
+    "Agent runtime": "Agent",
     "Goal mode": "Agent",
     "Tools": "Agent",
     # Memory — knowledge/recall config (rendered in the Knowledge view's Settings tab).

--- a/plugins/coding_agent/__init__.py
+++ b/plugins/coding_agent/__init__.py
@@ -150,6 +150,27 @@ def _client_for(spec: dict) -> AcpClient:
     return client
 
 
+async def evict_client(spec: dict) -> bool:
+    """Drop the cached client for ``spec`` AND terminate its subprocess.
+
+    The dispatch/relaunch paths ``_CLIENTS.pop(...)`` on an ``AcpError`` only
+    *forget* the handle, leaving the child to be reaped by GC. A caller that
+    dispatches into a short-lived, per-call ``workdir`` (e.g. a disposable git
+    worktree) needs a *deterministic* reap — otherwise each scoped ``workdir``
+    leaves its own ``AcpClient`` subprocess behind (the cache key includes
+    ``workdir``). This pops the cached client and ``await``s ``client.close()`` so
+    the process actually dies. Returns True if a live client was closed; idempotent.
+    """
+    client = _CLIENTS.pop(_cache_key(spec), None)
+    if client is None:
+        return False
+    try:
+        await client.close()
+    except Exception:  # noqa: BLE001 — teardown is best-effort
+        log.warning("[coding_agent/%s] close during evict failed", spec.get("name"), exc_info=True)
+    return True
+
+
 def _approved(decision) -> bool:
     return str(decision).strip().lower() in _APPROVALS
 

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -352,22 +352,43 @@ class AcpAdapter(Adapter):
         d.confirm = str(raw.get("confirm", "")).strip().lower() in ("1", "true", "yes")
         return d
 
+    @staticmethod
+    def _spec(d: Delegate) -> dict:
+        """The coding_agent spec dict for this delegate. Shared by ``dispatch`` and
+        ``teardown`` so both compute the SAME client cache key (which includes
+        ``workdir``) — so a caller that scopes ``workdir`` per call (e.g. via
+        ``dataclasses.replace`` onto a disposable worktree) tears down the exact
+        client it dispatched."""
+        return {
+            "name": d.name, "command": d.command, "args": d.args, "workdir": d.workdir,
+            "env": d.env or None, "permissions": d.permissions,
+            "allow_kinds": d.allow_kinds, "deny_kinds": d.deny_kinds,
+        }
+
     async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
         # Reuse the ADR 0024 ACP client + by-kind permission policy.
         from plugins.coding_agent import _client_for, _make_permission
         from plugins.coding_agent.acp_client import AcpError
 
-        spec = {
-            "name": d.name, "command": d.command, "args": d.args, "workdir": d.workdir,
-            "env": d.env or None, "permissions": d.permissions,
-            "allow_kinds": d.allow_kinds, "deny_kinds": d.deny_kinds,
-        }
+        spec = self._spec(d)
         client = _client_for(spec)
         client._permission = _make_permission(spec)
         try:
             return await client.prompt(query, timeout=timeout or d.timeout_s)
         except AcpError as exc:
             raise DelegateError(str(exc))
+
+    async def teardown(self, d: Delegate) -> bool:
+        """Evict + terminate the cached ACP subprocess for this delegate.
+
+        ``dispatch`` caches a long-lived ``AcpClient`` (subprocess + session) keyed
+        partly on ``workdir``. A caller that dispatches into a transient, per-call
+        ``workdir`` should call this when done (e.g. in a ``finally``) so the child
+        is reaped rather than left running — a plain cache ``pop`` forgets the
+        handle but leaves the process alive. Returns True if a live client was
+        closed; no-op (False) if none was started. Idempotent."""
+        from plugins.coding_agent import evict_client
+        return await evict_client(self._spec(d))
 
     async def probe(self, d: Delegate) -> dict:
         import os

--- a/server/operator_mcp.py
+++ b/server/operator_mcp.py
@@ -79,14 +79,25 @@ def operator_tools(config):
         goal_enabled=bool(getattr(config, "goal_enabled", False)),
     ))
     tools += list(getattr(STATE, "plugin_tools", None) or [])
+    # "*" = expose everything (minus a small danger set you must opt into by name) — so you
+    # don't have to enumerate every tool. List specific names instead for tight control.
+    star = "*" in allow
     seen: set[str] = set()
     out = []
     for t in tools:
         name = getattr(t, "name", None)
-        if name in allow and name not in seen:
+        if not name or name in seen:
+            continue
+        if (name in allow) or (star and name not in _STAR_EXCLUDE):
             seen.add(name)
             out.append(t)
     return out
+
+
+# Tools "*" skips — a coding-agent brain already has its own code execution / file tools,
+# so exposing protoAgent's execute_code over the bus is redundant. Not a security gate
+# (you can still allowlist it by name); just avoids handing it a tool it already has.
+_STAR_EXCLUDE = {"execute_code"}
 
 
 def build_server(config, *, name: str = "protoAgent-operator"):

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -281,3 +281,45 @@ async def test_confirm_gate_approves_then_runs(monkeypatch):
     register(reg)
     out = await reg.tools[0].ainvoke({"agent": "proto", "task": "do it"})
     assert out == "did the work"
+
+
+async def test_evict_client_pops_and_closes():
+    """evict_client removes the cached client AND awaits close() — a plain pop
+    would forget the handle but leave the subprocess alive."""
+    spec = {
+        "name": "proto", "command": "proto", "args": ["--acp"], "workdir": "/tmp/wt-1",
+        "permissions": "allowlist", "allow_kinds": [], "deny_kinds": [],
+    }
+
+    class _FakeClient:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    fake = _FakeClient()
+    P._CLIENTS[P._cache_key(spec)] = fake
+
+    assert await P.evict_client(spec) is True
+    assert fake.closed is True
+    assert P._cache_key(spec) not in P._CLIENTS
+    # idempotent: nothing cached for this spec now
+    assert await P.evict_client(spec) is False
+
+
+async def test_evict_client_swallows_close_errors():
+    """A close() that raises must not propagate — teardown is best-effort, and the
+    cache entry is dropped regardless."""
+    spec = {
+        "name": "proto", "command": "proto", "args": [], "workdir": "/tmp/wt-2",
+        "permissions": "auto", "allow_kinds": [], "deny_kinds": [],
+    }
+
+    class _BadClient:
+        async def close(self):
+            raise RuntimeError("terminate blew up")
+
+    P._CLIENTS[P._cache_key(spec)] = _BadClient()
+    assert await P.evict_client(spec) is True          # did not raise
+    assert P._cache_key(spec) not in P._CLIENTS

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -527,3 +527,31 @@ def test_list_soul_presets_missing_dir_returns_empty(monkeypatch, tmp_path):
     monkeypatch.setattr(config_io, "PRESETS_DIR", fake)
 
     assert config_io.list_soul_presets() == []
+
+
+def test_ensure_live_config_scoped_inherits_base(monkeypatch, tmp_path: Path) -> None:
+    """A PROTOAGENT_INSTANCE-scoped config seeds from the unscoped base (config + secrets +
+    setup-marker) so a new instance boots usable instead of into the wizard (ADR 0004)."""
+    import paths
+    from graph import config_io
+
+    base = tmp_path / "langgraph-config.yaml"; base.write_text("model:\n  name: base-config\n")
+    base_secrets = tmp_path / "secrets.yaml"; base_secrets.write_text("model:\n  api_key: SEKRET\n")
+    base_marker = tmp_path / ".setup-complete"; base_marker.write_text("")
+    scoped = tmp_path / "foo" / "langgraph-config.yaml"
+    scoped_secrets = tmp_path / "foo" / "secrets.yaml"
+    scoped_marker = tmp_path / "foo" / ".setup-complete"
+
+    monkeypatch.setattr(config_io, "_BASE_CONFIG_YAML", base)
+    monkeypatch.setattr(config_io, "CONFIG_YAML_PATH", scoped)
+    monkeypatch.setattr(config_io, "_BASE_SECRETS_YAML", base_secrets)
+    monkeypatch.setattr(config_io, "SECRETS_YAML_PATH", scoped_secrets)
+    monkeypatch.setattr(config_io, "_BASE_SETUP_MARKER", base_marker)
+    monkeypatch.setattr(config_io, "SETUP_MARKER_PATH", scoped_marker)
+    monkeypatch.setattr(config_io, "CONFIG_EXAMPLE_PATH", tmp_path / "missing.example.yaml")
+    monkeypatch.setattr(paths, "instance_id", lambda: "foo")
+
+    assert config_io.ensure_live_config() is True
+    assert "base-config" in scoped.read_text()                     # inherited the base config
+    assert scoped_secrets.read_text() == base_secrets.read_text()  # + secrets
+    assert scoped_marker.exists()                                  # + setup state (no re-wizard)

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -188,6 +188,31 @@ async def test_acp_dispatch_reuses_client(monkeypatch):
     assert await ADAPTERS["acp"].dispatch(d, "fix the bug") == "coding done"
 
 
+async def test_acp_teardown_evicts_the_workdir_scoped_client():
+    """teardown reaps the exact cached client dispatch created — proving the
+    spec/cache-key (incl. workdir) line up, so a per-call scoped workdir tears
+    down its own subprocess."""
+    import plugins.coding_agent as CA
+
+    d = ADAPTERS["acp"].parse({"name": "proto", "type": "acp", "command": "proto", "workdir": "/tmp/wt-x"})
+    spec = ADAPTERS["acp"]._spec(d)
+
+    class _FakeClient:
+        def __init__(self):
+            self.closed = False
+
+        async def close(self):
+            self.closed = True
+
+    fake = _FakeClient()
+    CA._CLIENTS[CA._cache_key(spec)] = fake
+
+    assert await ADAPTERS["acp"].teardown(d) is True
+    assert fake.closed is True
+    assert CA._cache_key(spec) not in CA._CLIENTS
+    assert await ADAPTERS["acp"].teardown(d) is False   # idempotent
+
+
 # ── health prober (PR4) ───────────────────────────────────────────────────────
 
 import plugins.delegates.health as H  # noqa: E402

--- a/tests/test_operator_mcp.py
+++ b/tests/test_operator_mcp.py
@@ -49,3 +49,35 @@ def test_build_server_exposes_allowlisted_as_mcp():
     server, exposed = build_server(_cfg(["calculator"]))
     assert exposed == ["calculator"]
     assert server is not None
+
+
+def test_star_exposes_all_except_execute_code(monkeypatch):
+    from langchain_core.tools import tool
+
+    @tool
+    def execute_code(code: str) -> str:
+        """run code"""
+        return code
+
+    @tool
+    def plugin_thing(x: str) -> str:
+        """a plugin tool"""
+        return x
+
+    monkeypatch.setattr(STATE, "plugin_tools", [execute_code, plugin_thing], raising=False)
+    names = {t.name for t in operator_tools(_cfg(["*"]))}
+    assert "calculator" in names and "plugin_thing" in names   # core + plugin all flow
+    assert "execute_code" not in names                          # excluded from the wildcard
+
+
+def test_star_plus_explicit_name_still_includes_it(monkeypatch):
+    from langchain_core.tools import tool
+
+    @tool
+    def execute_code(code: str) -> str:
+        """run code"""
+        return code
+
+    monkeypatch.setattr(STATE, "plugin_tools", [execute_code], raising=False)
+    names = {t.name for t in operator_tools(_cfg(["*", "execute_code"]))}
+    assert "execute_code" in names   # naming it explicitly overrides the wildcard exclusion

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -16,8 +16,8 @@ def test_schema_groups_and_values():
     cfg = LangGraphConfig()
     groups = build_schema(cfg, model_options=["a", "b"])
     # Grouped + ordered by category: the Agent category leads, its sections in
-    # FIELDS order (Model, Routing, Goal mode, Tools, Identity).
-    assert [g["section"] for g in groups][:3] == ["Model", "Routing", "Goal mode"]
+    # FIELDS order (Model, Routing, Agent runtime, …).
+    assert [g["section"] for g in groups][:3] == ["Model", "Routing", "Agent runtime"]
     fields = [f for g in groups for f in g["fields"]]
     # Every core FIELD is present. (build_schema also appends plugin-declared
     # settings — e.g. the discord plugin — so count only the core-keyed fields,


### PR DESCRIPTION
Two related improvements from testing the ACP runtime in the UI.

### Agent runtime, from the console
**Agent → Settings** gains an **Agent runtime** group:
- a dropdown — `native` | `acp:proto` | `acp:codex` | `acp:claude` | `acp:copilot` | `acp:opencode`
- a **tools allowlist** for the ACP brain — and it accepts **`*`** to expose everything (core + plugin) instead of typing each tool. `*` skips `execute_code` (a coding agent already has its own code-exec — redundant; still allowlistable by name).

No YAML needed to switch brains.

### Instance-scoped config (ADR 0004)
`PROTOAGENT_INSTANCE` now scopes the **config** too, not just data — `langgraph-config.yaml` / `secrets.yaml` / `.setup-complete` go through `scope_leaf`. A scoped instance **seeds from the unscoped base** (config + secrets + setup state) on first boot, so it's usable immediately, and its saves no longer mutate the shared config. **No-op for the default instance** (scope_leaf returns the base path), so nothing migrates.

Tests: `*`-wildcard exposure (+ explicit-name override), settings section order, scoped-config base-seed. Full suite 1282 + new. ruff clean.

Live-tested on a `uitest` instance — the boot log confirmed `seeded live config config/uitest/langgraph-config.yaml from langgraph-config.yaml`, and the runtime selector renders under Agent → Settings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)