### PR TITLE
feat(runtime): ACP-only setups need no gateway (aux falls back to the coding agent)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ACP-only setups need no gateway** (ADR 0033) — when the runtime is `acp:<agent>` and no
+  OpenAI-compatible gateway key is set, protoAgent's auxiliary LLM calls (compaction, goal
+  verification, fact extraction) fall back to the same coding agent via an `AcpChatModel`
+  adapter, and headless validation no longer requires a gateway. (Embeddings still need an
+  embed endpoint, else semantic recall degrades to keyword — unchanged.)
+
 ### Fixed
 - **Instance-scoped config** (ADR 0004) — with `PROTOAGENT_INSTANCE` set, the live config +
   secrets + setup-marker are now per-instance (seeded from the default's on first boot), so a

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -708,6 +708,12 @@ def validate_for_headless(config) -> tuple[bool, str]:
     Used by ``--setup`` and the boot-time auto-complete; on failure the caller
     fails fast rather than marking a broken config complete.
     """
+    # ACP-only setup (ADR 0033): an external coding agent drives turns + backs aux calls,
+    # so no OpenAI-compatible gateway is required. (Semantic recall degrades to keyword
+    # without an embed endpoint — fine, not a blocker.)
+    if str(getattr(config, "agent_runtime", "native") or "native").startswith("acp:"):
+        return True, "ok"
+
     if not str(getattr(config, "api_base", "") or "").strip():
         return False, "model.api_base is not set"
     key = str(getattr(config, "api_key", "") or "").strip() or os.environ.get("OPENAI_API_KEY", "").strip()

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -4,12 +4,15 @@ All models route through the LiteLLM gateway (OpenAI-compatible),
 so we use ChatOpenAI for everything.
 """
 
+import logging
 import os
 from collections.abc import Callable
 
 from langchain_openai import ChatOpenAI, OpenAIEmbeddings
 
 from graph.config import LangGraphConfig
+
+log = logging.getLogger(__name__)
 
 # Same allowlisted UA the chat client uses (Cloudflare WAF blocks the SDK default).
 _GATEWAY_UA = "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)"
@@ -86,6 +89,18 @@ def create_llm(config: LangGraphConfig, *, model_name: str | None = None) -> Cha
     for a different model on the same gateway (used for compaction /
     fallback models).
     """
+    # ACP-only fallback (ADR 0033): when the runtime is an ACP coding agent AND no gateway
+    # key is configured, back protoAgent's auxiliary LLM calls (compaction, goal-eval, fact
+    # extraction) with that same ACP agent — so an ACP-only setup needs no OpenAI-compatible
+    # endpoint. Tightly guarded: native runtimes, and ACP-with-a-gateway-key, are unchanged.
+    try:
+        from runtime.acp_runtime import _gateway_configured, is_acp_runtime, make_acp_aux_model
+
+        if is_acp_runtime(config) and not _gateway_configured(config):
+            return make_acp_aux_model(config)
+    except Exception:  # noqa: BLE001 — never let the ACP path break native model creation
+        log.debug("[llm] ACP aux-model resolution skipped", exc_info=True)
+
     kwargs = _build_llm_kwargs(config)
     if model_name:
         kwargs["model"] = model_name

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -153,3 +153,70 @@ class AcpRuntime:
         if self._client is not None and hasattr(self._client, "close"):
             await self._client.close()
             self._client = None
+
+
+# ── ACP-backed aux model ───────────────────────────────────────────────────────
+# So an ACP-only setup (no gateway) still has a model for protoAgent's *auxiliary* calls
+# (compaction, goal-verification, fact extraction). Text-only — no tool-calling needed.
+
+_AUX_CLIENTS: dict[str, object] = {}  # one reused aux session per agent
+
+
+def _gateway_configured(config) -> bool:
+    """True when a real OpenAI-compatible gateway key is available (config or env)."""
+    key = (getattr(config, "api_key", "") or "").strip() or os.environ.get("OPENAI_API_KEY", "").strip()
+    return bool(key)
+
+
+async def _aux_prompt(agent: str, config, text: str) -> str:
+    client = _AUX_CLIENTS.get(agent)
+    if client is None:
+        spec = adapter_for(agent, config)
+        from plugins.coding_agent.acp_client import AcpClient
+        client = AcpClient(spec["command"], spec.get("args"), cwd=os.getcwd(), name=f"{agent}-aux")
+        _AUX_CLIENTS[agent] = client
+    return await client.prompt(text)
+
+
+def _messages_to_text(messages) -> str:
+    parts = []
+    for m in messages:
+        content = getattr(m, "content", m)
+        parts.append(content if isinstance(content, str) else str(content))
+    return "\n\n".join(p for p in parts if p)
+
+
+def make_acp_aux_model(config):
+    """A `BaseChatModel` backed by the configured ACP agent — for aux LLM calls under an
+    ACP-only setup. Lazy + import-guarded so langchain stays optional at import time."""
+    from langchain_core.language_models import BaseChatModel
+    from langchain_core.messages import AIMessage
+    from langchain_core.outputs import ChatGeneration, ChatResult
+
+    agent = resolve_runtime(config)[1] or "proto"
+
+    class AcpChatModel(BaseChatModel):
+        """Text-only chat model over the ACP coding agent (no tools)."""
+
+        @property
+        def _llm_type(self) -> str:
+            return f"acp:{agent}"
+
+        async def _agenerate(self, messages, stop=None, run_manager=None, **kwargs) -> "ChatResult":
+            text = await _aux_prompt(agent, config, _messages_to_text(messages))
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content=text))])
+
+        def _generate(self, messages, stop=None, run_manager=None, **kwargs) -> "ChatResult":
+            # Sync path — run the async prompt on a private loop in a worker thread so it's
+            # safe whether or not the caller is already inside an event loop.
+            import asyncio
+            import concurrent.futures
+
+            def _run():
+                return asyncio.run(_aux_prompt(agent, config, _messages_to_text(messages)))
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as ex:
+                text = ex.submit(_run).result()
+            return ChatResult(generations=[ChatGeneration(message=AIMessage(content=text))])
+
+    return AcpChatModel()

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -116,3 +116,54 @@ def test_chat_caches_acp_runtime_per_thread(monkeypatch):
     assert r1 is r2          # same thread → same stateful ACP session
     assert r1 is not r3      # different thread → its own session
     assert r1.agent == "codex"
+
+
+def test_gateway_configured_detection(monkeypatch):
+    from runtime.acp_runtime import _gateway_configured
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+    assert _gateway_configured(types.SimpleNamespace(api_key="sk-x")) is True
+    assert _gateway_configured(types.SimpleNamespace(api_key="")) is False
+    monkeypatch.setenv("OPENAI_API_KEY", "env-key")
+    assert _gateway_configured(types.SimpleNamespace(api_key="")) is True
+
+
+def test_create_llm_acp_fallback_only_without_gateway(monkeypatch):
+    from graph.config import LangGraphConfig
+    from graph.llm import create_llm
+    monkeypatch.delenv("OPENAI_API_KEY", raising=False)
+
+    # ACP runtime + no gateway key → ACP-backed aux model.
+    c = LangGraphConfig(); c.agent_runtime = "acp:proto"; c.api_key = ""
+    assert type(create_llm(c)).__name__ == "AcpChatModel"
+
+    # ACP runtime BUT a gateway key is set → use the gateway (they configured one).
+    c2 = LangGraphConfig(); c2.agent_runtime = "acp:proto"; c2.api_key = "sk-real"; c2.api_base = "https://x/v1"
+    assert type(create_llm(c2)).__name__ != "AcpChatModel"
+
+    # Native runtime → always the gateway model, untouched.
+    c3 = LangGraphConfig(); c3.agent_runtime = "native"; c3.api_key = "sk-real"; c3.api_base = "https://x/v1"
+    assert type(create_llm(c3)).__name__ != "AcpChatModel"
+
+
+async def test_acp_aux_model_generates_via_client(monkeypatch):
+    import runtime.acp_runtime as rt
+    from langchain_core.messages import HumanMessage
+
+    async def _fake_prompt(agent, config, text):
+        return f"AUX[{text}]"
+
+    monkeypatch.setattr(rt, "_aux_prompt", _fake_prompt)
+    model = rt.make_acp_aux_model(types.SimpleNamespace(agent_runtime="acp:proto"))
+    res = await model._agenerate([HumanMessage(content="summarize this")])
+    assert res.generations[0].message.content == "AUX[summarize this]"
+
+
+def test_validate_headless_allows_acp_only():
+    import types as _t
+    from graph.config_io import validate_for_headless
+    # ACP-only: no api_base / api_key required.
+    ok, _ = validate_for_headless(_t.SimpleNamespace(agent_runtime="acp:proto", api_base="", api_key=""))
+    assert ok is True
+    # native still requires a gateway.
+    ok2, _ = validate_for_headless(_t.SimpleNamespace(agent_runtime="native", api_base="", api_key=""))
+    assert ok2 is False


### PR DESCRIPTION
From your point: someone running purely on proto/codex/claude shouldn't have to set up an OpenAI-compatible gateway just for protoAgent's *auxiliary* LLM calls.

- **`AcpChatModel`** — a text-only `BaseChatModel` over the ACP client (reused aux session per agent; async `_agenerate`, sync `_generate` via a worker-thread loop).
- **`create_llm` fallback** — when `is_acp_runtime(config)` **and** no gateway key (config or `OPENAI_API_KEY`), it returns the ACP-backed model. Because every aux site goes through `create_llm`, **compaction / goal-verification / fact-extraction all fall back transparently**. Tightly guarded + best-effort: native, and ACP-with-a-key, are unchanged; any error falls through to `ChatOpenAI`.
- **`validate_for_headless`** — an `acp:<agent>` runtime no longer requires `api_base`/`api_key`, so an ACP-only instance boots without a gateway.
- **Embeddings** — separate axis (`knowledge.embed_model`); without an embed endpoint, semantic recall degrades to keyword (today's behavior, unchanged).

**Live-verified** against real proto: the aux model summarized text ("the cat sat on the mat" → "Cat sits on mat."). Tests: gateway detection, `create_llm` fallback only-when-ACP-and-no-key, `_agenerate` via mock, headless allows ACP-only. Suite green, ruff clean.

Next: the runtime-lead UX (reorder + active-runtime banner) so the Settings relationship is obvious.

🤖 Generated with [Claude Code](https://claude.com/claude-code)