### PR TITLE
feat(console): runtime selector leads Agent settings + fix ACP context-var reset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Runtime selector leads the Agent settings** — the Agent runtime group is now first in
+  Agent → Settings, with an active-runtime badge in the header and a banner (when an ACP
+  runtime is active) explaining the model settings still power protoAgent's own aux calls.
 - **Auto-scoping for co-located instances** (#706) — set `PROTOAGENT_AUTO_SCOPE=1` and an
   instance with no explicit `PROTOAGENT_INSTANCE` derives a stable per-working-directory id, so
   instances on one machine never silently share `~/.protoagent` and clobber each other's goals/
@@ -24,6 +27,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   embed endpoint, else semantic recall degrades to keyword — unchanged.)
 
 ### Fixed
+- **ACP runtime: request-metadata scope cross-context reset** — an ACP turn awaits across
+  context boundaries (the client's reader-loop tasks), so the ADR-0032 `request_metadata_scope`
+  token could be reset in a different Context (`ValueError`). The scope now swallows that and
+  clears the value instead — no traceback on ACP turns.
 - **Instance-scoped config** (ADR 0004) — with `PROTOAGENT_INSTANCE` set, the live config +
   secrets + setup-marker are now per-instance (seeded from the default's on first boot), so a
   scoped instance's saves no longer mutate the shared config. No-op for the default instance.

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2948,6 +2948,12 @@ textarea {
   font-size: 0.82rem;
 }
 .settings-banner svg { flex: none; }
+/* Active-runtime banner (ADR 0033) — info tone (brand violet), not the amber warning. */
+.settings-banner.runtime-banner {
+  background: color-mix(in srgb, var(--pl-color-brand-lavender) 14%, transparent);
+  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 32%, transparent);
+  color: inherit;
+}
 .settings-status {
   margin: 0 0 10px;
   font-size: 0.8rem;

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -1,5 +1,5 @@
 import { QueryErrorResetBoundary, useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { AlertTriangle, ExternalLink, Link2, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
+import { AlertTriangle, Bot, ExternalLink, Link2, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
 import { Suspense, useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
@@ -61,6 +61,14 @@ export function SettingsCategory({
   const hasModel = groups.some((g) => g.fields.some((f) => f.key === "model.name"));
   const hasDiscord = groups.some((g) => g.section === "Discord");
   const hasGoogle = groups.some((g) => g.section === "Google");
+
+  // Active agent runtime (ADR 0033) — for the banner + header badge when this category
+  // carries the selector (the Agent settings). Reflects the pending (dirty) choice live.
+  const runtimeField = groups.flatMap((g) => g.fields).find((f) => f.key === "agent_runtime");
+  const activeRuntime = runtimeField
+    ? String((dirty["agent_runtime"] ?? runtimeField.value) ?? "native")
+    : null;
+  const acpAgent = activeRuntime && activeRuntime.startsWith("acp:") ? activeRuntime.slice(4) : null;
 
   const pendingRestart = useMemo(() => {
     const labels: string[] = [];
@@ -134,7 +142,13 @@ export function SettingsCategory({
     <>
       <PanelHeader
         title={title}
-        kicker={dirtyKeys.length ? `${dirtyKeys.length} unsaved change${dirtyKeys.length === 1 ? "" : "s"}` : "applies on save"}
+        kicker={
+          dirtyKeys.length
+            ? `${dirtyKeys.length} unsaved change${dirtyKeys.length === 1 ? "" : "s"}`
+            : runtimeField
+              ? `runtime: ${acpAgent ? `${acpAgent} (ACP)` : "native"}`
+              : "applies on save"
+        }
         actions={
           <>
             {hasModel ? (
@@ -153,6 +167,16 @@ export function SettingsCategory({
         }
       />
       <div className="stage-body">
+        {acpAgent ? (
+          <div className="settings-banner runtime-banner">
+            <Bot size={14} />
+            <span>
+              Running on <strong>{acpAgent}</strong> (ACP) — it drives each turn with its own tools.
+              The model settings below power protoAgent's own calls (compaction, goal checks); with no
+              gateway key configured, those run on {acpAgent} too.
+            </span>
+          </div>
+        ) : null}
         {pendingRestart.length ? (
           <div className="settings-banner" role="alert">
             <AlertTriangle size={14} />

--- a/graph/middleware/request_context.py
+++ b/graph/middleware/request_context.py
@@ -43,7 +43,13 @@ class request_metadata_scope:
 
     def __exit__(self, *_exc):
         if self._token is not None:
-            _request_metadata_ctx.reset(self._token)
+            try:
+                _request_metadata_ctx.reset(self._token)
+            except ValueError:
+                # The token was created in a different Context — happens when the body
+                # awaited across context boundaries (e.g. the ACP runtime's reader-loop
+                # tasks). Resetting is best-effort; fall back to clearing the value.
+                _request_metadata_ctx.set({})
             self._token = None
         return False
 

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -35,6 +35,15 @@ class Field:
 
 # Ordered registry. Section order here is the order the UI renders groups in.
 FIELDS: list[Field] = [
+    # ── Agent runtime (ADR 0033) — leads the Agent settings: "who runs the turn?" ──
+    Field("agent_runtime", "agent_runtime", "Agent runtime", "select", "Agent runtime",
+          "Which brain drives a turn: the built-in LangGraph loop (native), or an external "
+          "coding agent over ACP (needs its CLI installed + authenticated on the host).",
+          options=["native", "acp:proto", "acp:codex", "acp:claude", "acp:copilot", "acp:opencode"]),
+    Field("operator_mcp.tools", "operator_mcp_tools", "Tools exposed to the ACP brain", "string_list",
+          "Agent runtime", "Allowlist of operator tools an external (ACP) brain may call via MCP — "
+          "one per line, or `*` for all (minus execute_code). Empty = none. Ignored by native."),
+
     # ── Model ────────────────────────────────────────────────────────────────
     Field("model.name", "model_name", "Primary model", "select", "Model",
           "The main reasoning model (gateway alias).", options_source="models"),
@@ -54,15 +63,6 @@ FIELDS: list[Field] = [
           "Blank = use the main model."),
     Field("routing.fallback_models", "routing_fallback_models", "Fallback models", "string_list",
           "Routing", "Retried in order when the primary model errors."),
-
-    # ── Agent runtime (ADR 0033) — which brain drives a turn ───────────────────
-    Field("agent_runtime", "agent_runtime", "Agent runtime", "select", "Agent runtime",
-          "Which brain drives a turn: the built-in LangGraph loop (native), or an external "
-          "coding agent over ACP (needs its CLI installed + authenticated on the host).",
-          options=["native", "acp:proto", "acp:codex", "acp:claude", "acp:copilot", "acp:opencode"]),
-    Field("operator_mcp.tools", "operator_mcp_tools", "Tools exposed to the ACP brain", "string_list",
-          "Agent runtime", "Allowlist of operator tools an external (ACP) brain may call via MCP — one "
-          "per line (e.g. memory_recall, beads_create). Empty = none. Ignored by the native runtime."),
 
     # ── Context compaction ───────────────────────────────────────────────────
     Field("compaction.enabled", "compaction_enabled", "Enable compaction", "bool", "Compaction",

--- a/tests/test_plugin_middleware.py
+++ b/tests/test_plugin_middleware.py
@@ -66,3 +66,14 @@ def test_request_metadata_scope_sets_and_resets():
     with request_metadata_scope({"project": "alpha", "origin": "scheduler"}):
         assert current_request_metadata()["project"] == "alpha"
     assert current_request_metadata() == {}
+
+
+def test_request_metadata_scope_survives_cross_context_exit():
+    # Token created in one Context, exited in another (e.g. the ACP runtime awaiting across
+    # its reader-loop tasks) → reset() would ValueError; __exit__ must swallow it, not crash.
+    import contextvars
+
+    scope = request_metadata_scope({"project": "x"})
+    contextvars.copy_context().run(scope.__enter__)  # token born in a different Context
+    scope.__exit__(None, None, None)                 # must not raise
+    assert current_request_metadata() == {}

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -15,9 +15,8 @@ from graph.settings_schema import (
 def test_schema_groups_and_values():
     cfg = LangGraphConfig()
     groups = build_schema(cfg, model_options=["a", "b"])
-    # Grouped + ordered by category: the Agent category leads, its sections in
-    # FIELDS order (Model, Routing, Agent runtime, …).
-    assert [g["section"] for g in groups][:3] == ["Model", "Routing", "Agent runtime"]
+    # Grouped + ordered by category: the Agent category leads, runtime first.
+    assert [g["section"] for g in groups][:3] == ["Agent runtime", "Model", "Routing"]
     fields = [f for g in groups for f in g["fields"]]
     # Every core FIELD is present. (build_schema also appends plugin-declared
     # settings — e.g. the discord plugin — so count only the core-keyed fields,


### PR DESCRIPTION
Both from live-testing the ACP runtime in the UI.

### UX — make the active runtime obvious
- The **Agent runtime** group moves to the **front** of Agent → Settings (before Model/Routing) — pick the brain first.
- An **active-runtime badge** in the header (`runtime: proto (ACP)`) + a **banner** when an ACP runtime is active, explaining that the model settings below still power protoAgent's own aux calls (compaction/goal-checks), and run on the ACP agent itself when no gateway key is set. Resolves the "is this model selector for native or ACP?" ambiguity.

### Fix — ACP turns threw on cleanup
Live testing showed proto drove the turn fine (`stopReason=end_turn`) **but** logged a `ValueError: Token ... created in a different Context`: an ACP turn awaits across the client's reader-loop tasks, so the ADR-0032 `request_metadata_scope` token gets reset in a different `Context`. `__exit__` now swallows that + clears the value — no traceback, scope stays correct on later turns.

Tests: section-order (runtime first), cross-context scope reset (regression). Suite **1284**, e2e 10, ruff clean. Live-verified on a real proto turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)