### PR TITLE
feat(acp): tool-call cards + steer the agent to protoAgent's operator tools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **ACP tool calls surface as cards** — the coding agent's tool calls (its own + the operator
+  MCP tools) now stream as `tool_start`/`tool_end` to the chat, same as the native runtime,
+  instead of only the final answer.
 - **ACP runtime adopts your persona** (ADR 0033) — `SOUL.md` is written as `AGENTS.md` (+ a
   vendor file) into the coding agent's session workspace, so it loads your agent's identity into
   its own system prompt and answers as your agent, not generic "Codex/Claude". The session runs
@@ -31,6 +34,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   embed endpoint, else semantic recall degrades to keyword — unchanged.)
 
 ### Fixed
+- **ACP runtime: agent now uses protoAgent's operator tools, not its own** — the persona file
+  directs the coding agent to use the `protoagent-operator` tools (`beads_create`, `memory_*`,
+  `notes_*`, `set_goal`, …) for anything that must persist, instead of its ephemeral built-in
+  todo/memory tools. Verified: 'create a task' now lands a bead in protoAgent, not the agent's
+  private session.
 - **ACP runtime: request-metadata scope cross-context reset** — an ACP turn awaits across
   context boundaries (the client's reader-loop tasks), so the ADR-0032 `request_metadata_scope`
   token could be reset in a different Context (`ValueError`). The scope now swallows that and

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -32,6 +32,21 @@ from typing import Awaitable, Callable
 logger = logging.getLogger("protoagent.plugins.coding_agent")
 
 ProgressCallback = Callable[[str], Awaitable[None]]
+ToolCallback = Callable[[dict], Awaitable[None]]  # structured tool start/end events
+
+
+def _tool_output_preview(update: dict, limit: int = 300) -> str:
+    """Best-effort short text from a tool_call_update's content blocks (for the end card)."""
+    out: list[str] = []
+    for block in (update.get("content") or []):
+        if not isinstance(block, dict):
+            continue
+        inner = block.get("content")
+        if isinstance(inner, dict) and isinstance(inner.get("text"), str):
+            out.append(inner["text"])
+        elif isinstance(block.get("text"), str):
+            out.append(block["text"])
+    return " ".join(o for o in out if o).strip()[:limit]
 
 # ACP protocol version protoAgent speaks. Negotiated in `initialize`.
 PROTOCOL_VERSION = 1
@@ -83,6 +98,7 @@ class AcpClient:
         # Per-turn state (one turn at a time).
         self._answer = ""
         self._progress: ProgressCallback | None = None
+        self._on_tool: ToolCallback | None = None
 
     # -- lifecycle -----------------------------------------------------------
 
@@ -191,10 +207,27 @@ class AcpClient:
             if text:
                 self._answer += text
         elif kind == "tool_call":
-            # Narrate the tool's human title ("Editing app.py", "Running pytest")
-            # — this is progress, not the answer text.
+            # A tool call STARTED — narrate its title + emit a structured start event so the
+            # UI can render a card (parity with the native runtime's tool_start).
             title = update.get("title") or update.get("kind") or "working"
             await self._narrate(str(title))
+            await self._emit_tool({
+                "phase": "start",
+                "id": str(update.get("toolCallId") or title),
+                "name": str(title),
+                "input": str(update.get("kind") or ""),
+            })
+        elif kind == "tool_call_update":
+            # Status transition — emit an end event when it finishes (tool_end card).
+            status = str(update.get("status") or "")
+            if status in ("completed", "failed"):
+                await self._emit_tool({
+                    "phase": "end",
+                    "id": str(update.get("toolCallId") or ""),
+                    "name": str(update.get("title") or ""),
+                    "output": _tool_output_preview(update),
+                    "status": status,
+                })
 
     async def _handle_request(self, msg: dict) -> None:
         method = msg.get("method")
@@ -229,6 +262,13 @@ class AcpClient:
                 await self._progress(text)
             except Exception as exc:  # progress is best-effort
                 logger.warning("[acp/%s] progress_callback raised: %s", self.name, exc)
+
+    async def _emit_tool(self, event: dict) -> None:
+        if self._on_tool:
+            try:
+                await self._on_tool(event)
+            except Exception as exc:  # best-effort — tool cards never break a turn
+                logger.warning("[acp/%s] tool_callback raised: %s", self.name, exc)
 
     # -- JSON-RPC primitives -------------------------------------------------
 
@@ -288,16 +328,19 @@ class AcpClient:
         text: str,
         *,
         progress_callback: ProgressCallback | None = None,
+        tool_callback: ToolCallback | None = None,
         timeout: float = 600.0,
     ) -> str:
         """Send one user turn; return the agent's accumulated message text.
 
-        Streams ``tool_call`` titles to ``progress_callback`` for narration while
-        the agent works. Raises ``AcpError`` on transport/protocol failure.
+        Streams ``tool_call`` titles to ``progress_callback`` (text narration) and
+        structured start/end events to ``tool_callback`` (for UI tool cards) while the
+        agent works. Raises ``AcpError`` on transport/protocol failure.
         """
         await self._ensure_started()
         self._answer = ""
         self._progress = progress_callback
+        self._on_tool = tool_callback
         try:
             result = await self._request(
                 "session/prompt",
@@ -309,6 +352,7 @@ class AcpClient:
             )
         finally:
             self._progress = None
+            self._on_tool = None
         stop = (result or {}).get("stopReason")
         logger.info("[acp/%s] turn complete (stopReason=%s)", self.name, stop)
         return self._answer.strip()

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -119,9 +119,16 @@ def persona_doc(config) -> str:
         return ""
     return (
         "# Your identity & operating rules\n\n"
-        "Adopt the persona and rules below as your own — they override your default identity. "
-        "You run inside protoAgent, which provides your runtime and operator tools (notes, "
-        "memory, beads, goals, scheduling, subagents) over MCP; use them when they fit.\n\n---\n\n"
+        "Adopt the persona and rules below as your own — they override your default identity.\n\n"
+        "You run inside **protoAgent**, which gives you a set of **operator tools over MCP** "
+        "(the `protoagent-operator` server): beads (your task/issue board — `beads_create`, "
+        "`beads_list`, …), `memory_*`, `notes_*`, `set_goal`, `schedule_task`, subagents, and more.\n\n"
+        "**IMPORTANT — for anything that must persist, use these protoAgent operator tools, NOT "
+        "your own built-in todo/task/memory tools.** Creating a task or issue → `beads_create` "
+        "(your own TaskCreate/todo is ephemeral to this session and is invisible in protoAgent). "
+        "Saving a note → `notes_*`; remembering a fact → `memory_ingest`; a standing goal → "
+        "`set_goal`; future work → `schedule_task`. Use your own file/shell tools for code as usual.\n\n"
+        "---\n\n"
         + soul
     )
 
@@ -190,13 +197,14 @@ class AcpRuntime:
             self._client = self._client_factory()
         return self._client
 
-    async def run_turn(self, message: str, *, progress_callback=None) -> str:
+    async def run_turn(self, message: str, *, progress_callback=None, tool_callback=None) -> str:
         """Run one turn: per-turn context delta + message → ACP → write back. Persona is
-        carried by the AGENTS.md file, not the prompt."""
+        carried by the AGENTS.md file, not the prompt. ``tool_callback`` receives the agent's
+        structured tool start/end events (for UI cards)."""
         client = self._ensure_client()
         ctx = self._context.assemble(query=message)
         prompt = "\n\n".join(p for p in (ctx.volatile_delta, message) if p)
-        answer = await client.prompt(prompt, progress_callback=progress_callback)
+        answer = await client.prompt(prompt, progress_callback=progress_callback, tool_callback=tool_callback)
         self._context.after_turn(user=message, response=answer)
         return answer
 

--- a/server/chat.py
+++ b/server/chat.py
@@ -534,8 +534,33 @@ async def _chat_langgraph_stream(
             from runtime.acp_runtime import is_acp_runtime
             if is_acp_runtime(STATE.graph_config):
                 rt = _get_acp_runtime(_resolve_thread_id(request_metadata, session_id))
+                # Bridge the agent's tool events (emitted from the ACP reader loop) into the
+                # same tool_start/tool_end frames the native runtime yields → live tool cards.
+                _ACP_DONE = object()
+                tool_q: asyncio.Queue = asyncio.Queue()
+
+                async def _on_tool(ev: dict) -> None:
+                    await tool_q.put(ev)
+
+                async def _drive():
+                    try:
+                        return await rt.run_turn(message, tool_callback=_on_tool)
+                    finally:
+                        await tool_q.put(_ACP_DONE)
+
+                driver = asyncio.create_task(_drive())
+                while True:
+                    ev = await tool_q.get()
+                    if ev is _ACP_DONE:
+                        break
+                    if ev.get("phase") == "start":
+                        yield ("tool_start", {"id": ev.get("id", ""), "name": ev.get("name", "tool"),
+                                              "input": ev.get("input", "")})
+                    elif ev.get("phase") == "end":
+                        yield ("tool_end", {"id": ev.get("id", ""), "name": ev.get("name", "tool"),
+                                            "output": ev.get("output", "")})
                 try:
-                    answer = await rt.run_turn(message)
+                    answer = await driver
                 except Exception as exc:  # noqa: BLE001 — surface as a turn error, don't 500
                     log.exception("[acp-runtime] turn failed")
                     yield ("error", f"ACP runtime ({rt.agent}) failed: {exc}")

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -54,7 +54,7 @@ class _FakeClient:
         self.prompts = []
         self.closed = False
 
-    async def prompt(self, text, progress_callback=None):
+    async def prompt(self, text, progress_callback=None, tool_callback=None):
         self.prompts.append(text)
         return "ANSWER"
 
@@ -184,3 +184,23 @@ def test_validate_headless_allows_acp_only():
     # native still requires a gateway.
     ok2, _ = validate_for_headless(_t.SimpleNamespace(agent_runtime="native", api_base="", api_key=""))
     assert ok2 is False
+
+
+async def test_acp_client_emits_structured_tool_events():
+    from plugins.coding_agent.acp_client import AcpClient
+
+    client = AcpClient("noop", cwd="/tmp", name="t")
+    captured = []
+
+    async def cap(ev):
+        captured.append(ev)
+
+    client._on_tool = cap
+    await client._handle_update({"update": {"sessionUpdate": "tool_call", "toolCallId": "t1", "title": "Editing app.py"}})
+    await client._handle_update({"update": {
+        "sessionUpdate": "tool_call_update", "toolCallId": "t1", "status": "completed",
+        "title": "Editing app.py", "content": [{"content": {"type": "text", "text": "wrote 3 lines"}}],
+    }})
+    assert captured[0] == {"phase": "start", "id": "t1", "name": "Editing app.py", "input": ""}
+    assert captured[1]["phase"] == "end" and captured[1]["id"] == "t1"
+    assert "wrote 3 lines" in captured[1]["output"]


### PR DESCRIPTION
Two issues you caught live-testing the ACP runtime.

### 1. Tool calls now surface as cards
The ACP chat branch only emitted the final answer — no tool activity. Now the agent's tool calls stream as **`tool_start`/`tool_end`** (parity with native):
- `acp_client` captures `session/update` **`tool_call`** (start) + **`tool_call_update`** (end + output preview) → a structured `tool_callback`.
- `AcpRuntime.run_turn` threads it; `chat.py` bridges it via an `asyncio.Queue` into `tool_start`/`tool_end` frames while the turn runs.

### 2. "Said it'd call the tool but didn't"
proto was calling its **own `TaskCreate`** (ephemeral to its session) instead of protoAgent's `beads_create`, so nothing landed in protoAgent. The mount was fine (27 operator tools incl. `beads_create` were exposed + proto could see them) — it just preferred its native tool. The **persona file now directs** the agent to use the `protoagent-operator` tools (beads/memory/notes/goals/schedule) for anything that must persist.

### Live-verified
"Create a task" now fires **`beads_create (protoagent-operator)`** and the bead **lands in protoAgent** (`bd-1`), with start/end cards surfaced — versus before, where it called `TaskCreate` and the store stayed empty.

Tests: client emits structured start/end from `session/update`. Suite **1287**, e2e green, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)