### PR TITLE
docs(acp): operator-tool preference + ACP-only + tool cards; tidy changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   verification, fact extraction) fall back to the same coding agent via an `AcpChatModel`
   adapter, and headless validation no longer requires a gateway. (Embeddings still need an
   embed endpoint, else semantic recall degrades to keyword — unchanged.)
+- **Agent runtime selectable in the console** — Agent → Settings has an **Agent runtime** group:
+  a dropdown (native | acp:proto | acp:codex | acp:claude | acp:copilot | acp:opencode) + a
+  **tools allowlist** for the ACP brain. The allowlist accepts `*` to expose everything (minus
+  `execute_code`, which a coding agent already has) — no need to enumerate every tool.
+- **ACP delegate teardown** — `coding_agent.evict_client(spec)` + `AcpAdapter.teardown(delegate)`
+  evict the cached `AcpClient` for a spec **and** terminate its subprocess (a plain cache `pop`
+  forgot the handle but left the child running). Completes the delegate lifecycle for callers that
+  dispatch into a transient, per-call `workdir` (e.g. a disposable git worktree, scoped via
+  `dataclasses.replace`): call `teardown` in a `finally` so each scoped `workdir` reaps its own
+  process instead of leaking one. Best-effort + idempotent; no change to existing callers (the
+  ACP runtime owns its own client separately and is unaffected).
 
 ### Fixed
 - **ACP runtime: agent now uses protoAgent's operator tools, not its own** — the persona file
@@ -46,19 +57,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Instance-scoped config** (ADR 0004) — with `PROTOAGENT_INSTANCE` set, the live config +
   secrets + setup-marker are now per-instance (seeded from the default's on first boot), so a
   scoped instance's saves no longer mutate the shared config. No-op for the default instance.
-
-### Added
-- **Agent runtime selectable in the console** — Agent → Settings has an **Agent runtime** group:
-  a dropdown (native | acp:proto | acp:codex | acp:claude | acp:copilot | acp:opencode) + a
-  **tools allowlist** for the ACP brain. The allowlist accepts `*` to expose everything (minus
-  `execute_code`, which a coding agent already has) — no need to enumerate every tool.
-- **ACP delegate teardown** — `coding_agent.evict_client(spec)` + `AcpAdapter.teardown(delegate)`
-  evict the cached `AcpClient` for a spec **and** terminate its subprocess (a plain cache `pop`
-  forgot the handle but left the child running). Completes the delegate lifecycle for callers that
-  dispatch into a transient, per-call `workdir` (e.g. a disposable git worktree, scoped via
-  `dataclasses.replace`): call `teardown` in a `finally` so each scoped `workdir` reaps its own
-  process instead of leaking one. Best-effort + idempotent; no change to existing callers (the
-  ACP runtime owns its own client separately and is unaffected).
 
 ### Removed
 - **`code_with` tool + the `coding_agent` plugin** (breaking) — retired in favour of `delegate_to`

--- a/docs/guides/acp-runtime.md
+++ b/docs/guides/acp-runtime.md
@@ -53,11 +53,26 @@ Each agent needs its CLI **installed + authenticated** on the host. Defaults are
 3. **Tools** — protoAgent's operator tools are published as an MCP server (see
    [MCP → Expose this agent](/guides/mcp#expose-this-agent-as-an-mcp-server)) and **mounted into
    the ACP session** (`session/new` `mcpServers`). The coding agent calls `beads_create`,
-   `memory_recall`, `run_workflow`, … alongside its own tools.
+   `memory_recall`, `run_workflow`, … alongside its own tools. As it works, its tool calls stream
+   to the chat as **tool cards** (`tool_start`/`tool_end`), the same as the native runtime.
 4. **Drive** — the agent reasons + acts; protoAgent returns the result on its A2A/chat surface.
 5. **Write back** — durable facts persist to the knowledge store after the turn.
 
 One stateful ACP session is kept **per conversation thread** and reused across turns.
+
+> **Prefer protoAgent's tools for state.** A coding agent has its *own* todo/memory tools
+> (e.g. proto's `TaskCreate`) and will reach for them by default — state that then vanishes
+> with its session. The persona file steers it to use the `protoagent-operator` tools
+> (`beads_create`, `memory_ingest`, `set_goal`, …) for anything that must **persist** in
+> protoAgent. Set `operator_mcp.tools: ['*']` (or list them) so they're actually available.
+
+## No gateway? ACP-only works
+
+If your runtime is `acp:<agent>` and you have **no** OpenAI-compatible gateway key configured,
+protoAgent's own auxiliary LLM calls (compaction, goal verification, fact extraction) **fall
+back to the same coding agent** — so you can run entirely on e.g. your Claude/Codex login with
+no separate model endpoint. (Embeddings are a separate axis: without an embed endpoint, semantic
+recall degrades to keyword search.)
 
 ## What reaches the coding agent
 
@@ -78,5 +93,8 @@ to. The agent runs with its own permissions on the host (its CLI's auth + sandbo
 ## Limits
 
 - The native and ACP runtimes don't run in the same turn — `agent_runtime` picks one.
-- Token-by-token streaming of the agent's output isn't wired yet (the turn returns when complete).
+- Tool calls stream as cards, but the agent's **answer text** isn't token-streamed yet — the
+  final message lands when the turn completes.
+- Instances run from the **same directory** share a derived workspace; give each an explicit
+  `PROTOAGENT_INSTANCE` if you run several on one box (see [Run multiple instances](/guides/multi-instance)).
 - Validate live — a real coding agent's behavior (and ACP version) is the true test; CI mocks it.


### PR DESCRIPTION
Pre-release polish so the v0.28.0 docs match what shipped this session.

- **acp-runtime guide**: the operator-tool-preference gotcha (agent prefers its own `TaskCreate`/memory unless steered → use `operator_mcp.tools` + the persona steers it to persist via `beads_create`/`memory_ingest`); **ACP-only** (no gateway → aux falls back to the agent); tool calls now **stream as cards**; same-dir instances need an explicit `PROTOAGENT_INSTANCE`.
- **CHANGELOG**: fold the two `[Unreleased]` `### Added` blocks into one so the release notes read clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)