### PR TITLE
chore: release v0.28.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.28.0] - 2026-06-08
+
 ### Added
 - **ACP tool calls surface as cards** — the coding agent's tool calls (its own + the operator
   MCP tools) now stream as `tool_start`/`tool_end` to the chat, same as the native runtime,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.27.0"
+version = "0.28.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,22 @@
 [
   {
+    "version": "v0.28.0",
+    "date": "2026-06-08",
+    "changes": [
+      "ACP tool calls surface as cards",
+      "ACP runtime adopts your persona",
+      "Runtime selector leads the Agent settings",
+      "Auto-scoping for co-located instances",
+      "ACP-only setups need no gateway",
+      "Agent runtime selectable in the console",
+      "ACP delegate teardown",
+      "ACP runtime: agent now uses protoAgent's operator tools, not its own",
+      "ACP runtime: request-metadata scope cross-context reset",
+      "Instance-scoped config",
+      "code_with tool + the coding_agent plugin"
+    ]
+  },
+  {
     "version": "v0.27.0",
     "date": "2026-06-08",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.28.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.28.0 -m 'Release v0.28.0' && git push origin v0.28.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).