### PR TITLE
fix(coding_agent): AcpClient.close() reaps the subprocess (await wait)

### DIFF
--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -93,6 +93,7 @@ class AcpClient:
         self._next_id = 0
         self._pending: dict[int, asyncio.Future] = {}
         self._reader_task: asyncio.Task | None = None
+        self._stderr_task: asyncio.Task | None = None
         self._start_lock = asyncio.Lock()
 
         # Per-turn state (one turn at a time).
@@ -127,7 +128,7 @@ class AcpClient:
             ) from exc
 
         self._reader_task = asyncio.create_task(self._read_loop())
-        asyncio.create_task(self._drain_stderr())
+        self._stderr_task = asyncio.create_task(self._drain_stderr())
         await self._initialize()
         await self._new_session()
         logger.info(
@@ -139,11 +140,24 @@ class AcpClient:
         )
 
     async def close(self) -> None:
-        if self._reader_task and not self._reader_task.done():
-            self._reader_task.cancel()
-        if self._proc and self._proc.returncode is None:
+        """Cancel the I/O tasks and reap the subprocess. Crucially this ``await``s
+        ``proc.wait()`` so the child is reaped *while the loop is alive* — without
+        it the subprocess transport lingers and its ``__del__`` fires after the loop
+        closes ("Event loop is closed"), and the stderr-drain task leaks."""
+        for task in (self._reader_task, self._stderr_task):
+            if task and not task.done():
+                task.cancel()
+        proc = self._proc
+        if proc and proc.returncode is None:
             try:
-                self._proc.terminate()
+                proc.terminate()
+                await asyncio.wait_for(proc.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                try:
+                    proc.kill()
+                    await proc.wait()
+                except ProcessLookupError:
+                    pass
             except ProcessLookupError:
                 pass
 

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -93,6 +93,18 @@ async def test_acp_client_drives_a_turn(fake_agent, tmp_path):
     assert "Editing app.py" in narrations
 
 
+async def test_close_reaps_the_subprocess(fake_agent, tmp_path):
+    """close() must terminate AND await the child so it's reaped while the loop is
+    still alive — otherwise the subprocess transport's __del__ fires after the loop
+    closes ('Event loop is closed') and the stderr-drain task leaks."""
+    client = AcpClient(sys.executable, [str(fake_agent)], cwd=str(tmp_path), name="reap")
+    await client.prompt("go", timeout=30.0)
+    assert client._proc is not None and client._proc.returncode is None  # alive after the turn
+    await client.close()
+    assert client._proc.returncode is not None      # reaped during close (the fix)
+    assert client._stderr_task is not None and client._stderr_task.done()  # not leaked
+
+
 async def test_acp_client_readonly_policy_denies_edit(fake_agent, tmp_path):
     # A readonly policy must reject the fake's `edit` permission request — the
     # client picks the reject_once option, which the fake echoes back.


### PR DESCRIPTION
## What
`AcpClient.close()` called `terminate()` but never `await proc.wait()`, so the child was reaped lazily — its subprocess transport lingered and `__del__` fired **after** the event loop closed (`RuntimeError: Event loop is closed`). The `_drain_stderr` task was also leaked (created but never stored/cancelled).

Now `close()`:
- cancels **both** I/O tasks (reader + the now-stored stderr task), and
- `await`s `proc.wait()` (`terminate` → wait, 5s timeout → `kill` → wait) so the child is reaped **while the loop is alive**.

## Why it's safe
Both callers already `await close()` and only benefit from a deterministic shutdown:
- `coding_agent.evict_client` (the delegate teardown), and
- `runtime.acp_runtime.AcpRuntime.close()` (ADR 0033 session shutdown).

No caller depended on `close()` being instant; the wait is bounded (5s → kill), so no hang risk.

## Surfaced by
A board-orchestration loop that dispatches a real coding agent per feature — the warning fired at loop teardown. (The fix is general, not loop-specific.)

## Test
`test_close_reaps_the_subprocess`: a started client has `returncode` set after `close()`, and the stderr task isn't leaked. Full `coding_agent`/`acp_runtime`/`delegates` suites green (42); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)