### PR TITLE
test: skip marketing-changelog guard when the site is absent

### DIFF
--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -106,5 +106,7 @@ def test_scaffold_prepends_when_absent_and_is_idempotent(tmp_path, monkeypatch):
 def test_no_released_version_is_missing_from_marketing_changelog():
     """Staleness guard (the original 'stuck at 0.21' bug): every dated CHANGELOG.md
     version must have a marketing changelog.json entry."""
+    if not changelog.MARKETING_JSON.exists():
+        pytest.skip("no marketing site (a fork dropped it) — staleness guard N/A")
     missing = changelog.missing_versions()
     assert not missing, f"changelog.json missing: {missing} — run `changelog.py scaffold <v>` then curate"


### PR DESCRIPTION
Quality-of-life for the fleet. Marketing-less forks (gina, protoTrader) drop `sites/marketing`, so `test_no_released_version_is_missing_from_marketing_changelog` fails on every upstream sync — they've been deleting the test by hand each time (just did, during the v0.28.0 fleet sync).

Skip the test when `changelog.MARKETING_JSON` doesn't exist: the **template still enforces** the staleness guard (file present), while forks without a marketing site pass automatically — no per-sync divergence on this file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)