### PR TITLE
fix(coding_agent): close the subprocess transport in AcpClient.close()

### DIFF
--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -160,6 +160,12 @@ class AcpClient:
                     pass
             except ProcessLookupError:
                 pass
+        # Close the subprocess transport too, so its pipe transports don't linger to
+        # a post-loop-close GC — reaping the process (above) leaves the stdin write-
+        # pipe transport open, whose __del__ then fires "Event loop is closed".
+        transport = getattr(proc, "_transport", None) if proc else None
+        if transport is not None:
+            transport.close()
 
     # -- I/O loops -----------------------------------------------------------
 


### PR DESCRIPTION
Follow-up to #727. Awaiting `proc.wait()` reaps the child, but its **pipe transports** (notably the stdin write-pipe) stay open and their `__del__` fires `RuntimeError: Event loop is closed` when GC'd after the loop closes. Close the subprocess transport after reaping so nothing lingers past loop teardown.

**Verified** against a real coding-agent dispatch (a board loop shipping a feature): the `Event loop is closed` warning goes from present → **0 occurrences**. `coding_agent` suite green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)