### PR TITLE
feat(acp): stream the agent's answer text instead of all-at-once

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ACP answer-text streams** — the coding agent's reply now streams to the chat as it's
+  produced (answer-text deltas forwarded as `text` frames, interleaved with tool cards in
+  order), instead of landing all at once when the turn completes. Granularity follows the
+  agent (proto sends coarse chunks; token-streaming agents render finer).
+
 ## [0.28.0] - 2026-06-08
 
 ### Added

--- a/docs/guides/acp-runtime.md
+++ b/docs/guides/acp-runtime.md
@@ -93,8 +93,9 @@ to. The agent runs with its own permissions on the host (its CLI's auth + sandbo
 ## Limits
 
 - The native and ACP runtimes don't run in the same turn — `agent_runtime` picks one.
-- Tool calls stream as cards, but the agent's **answer text** isn't token-streamed yet — the
-  final message lands when the turn completes.
+- The agent's answer **streams** as it emits text chunks (and tool calls render as cards in
+  order). Granularity is the agent's — proto sends a few coarse chunks rather than per-token;
+  agents that stream token-by-token render finer.
 - Instances run from the **same directory** share a derived workspace; give each an explicit
   `PROTOAGENT_INSTANCE` if you run several on one box (see [Run multiple instances](/guides/multi-instance)).
 - Validate live — a real coding agent's behavior (and ACP version) is the true test; CI mocks it.

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -100,6 +100,7 @@ class AcpClient:
         self._answer = ""
         self._progress: ProgressCallback | None = None
         self._on_tool: ToolCallback | None = None
+        self._on_text: ProgressCallback | None = None
 
     # -- lifecycle -----------------------------------------------------------
 
@@ -220,6 +221,7 @@ class AcpClient:
             text = (update.get("content") or {}).get("text", "")
             if text:
                 self._answer += text
+                await self._emit_text(text)   # stream the delta (token-ish) to the UI
         elif kind == "tool_call":
             # A tool call STARTED — narrate its title + emit a structured start event so the
             # UI can render a card (parity with the native runtime's tool_start).
@@ -284,6 +286,13 @@ class AcpClient:
             except Exception as exc:  # best-effort — tool cards never break a turn
                 logger.warning("[acp/%s] tool_callback raised: %s", self.name, exc)
 
+    async def _emit_text(self, delta: str) -> None:
+        if self._on_text and delta:
+            try:
+                await self._on_text(delta)
+            except Exception as exc:  # best-effort — streaming never breaks a turn
+                logger.warning("[acp/%s] text_callback raised: %s", self.name, exc)
+
     # -- JSON-RPC primitives -------------------------------------------------
 
     async def _send(self, obj: dict) -> None:
@@ -343,18 +352,21 @@ class AcpClient:
         *,
         progress_callback: ProgressCallback | None = None,
         tool_callback: ToolCallback | None = None,
+        text_callback: ProgressCallback | None = None,
         timeout: float = 600.0,
     ) -> str:
         """Send one user turn; return the agent's accumulated message text.
 
-        Streams ``tool_call`` titles to ``progress_callback`` (text narration) and
-        structured start/end events to ``tool_callback`` (for UI tool cards) while the
-        agent works. Raises ``AcpError`` on transport/protocol failure.
+        Streams ``tool_call`` titles to ``progress_callback`` (text narration), structured
+        start/end events to ``tool_callback`` (UI tool cards), and answer-text deltas to
+        ``text_callback`` (token-ish streaming) as the agent works. Raises ``AcpError`` on
+        transport/protocol failure.
         """
         await self._ensure_started()
         self._answer = ""
         self._progress = progress_callback
         self._on_tool = tool_callback
+        self._on_text = text_callback
         try:
             result = await self._request(
                 "session/prompt",
@@ -367,6 +379,7 @@ class AcpClient:
         finally:
             self._progress = None
             self._on_tool = None
+            self._on_text = None
         stop = (result or {}).get("stopReason")
         logger.info("[acp/%s] turn complete (stopReason=%s)", self.name, stop)
         return self._answer.strip()

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -197,14 +197,18 @@ class AcpRuntime:
             self._client = self._client_factory()
         return self._client
 
-    async def run_turn(self, message: str, *, progress_callback=None, tool_callback=None) -> str:
+    async def run_turn(self, message: str, *, progress_callback=None, tool_callback=None, text_callback=None) -> str:
         """Run one turn: per-turn context delta + message → ACP → write back. Persona is
         carried by the AGENTS.md file, not the prompt. ``tool_callback`` receives the agent's
-        structured tool start/end events (for UI cards)."""
+        structured tool start/end events (UI cards); ``text_callback`` receives answer-text
+        deltas (token-ish streaming)."""
         client = self._ensure_client()
         ctx = self._context.assemble(query=message)
         prompt = "\n\n".join(p for p in (ctx.volatile_delta, message) if p)
-        answer = await client.prompt(prompt, progress_callback=progress_callback, tool_callback=tool_callback)
+        answer = await client.prompt(
+            prompt, progress_callback=progress_callback,
+            tool_callback=tool_callback, text_callback=text_callback,
+        )
         self._context.after_turn(user=message, response=answer)
         return answer
 

--- a/server/chat.py
+++ b/server/chat.py
@@ -534,37 +534,43 @@ async def _chat_langgraph_stream(
             from runtime.acp_runtime import is_acp_runtime
             if is_acp_runtime(STATE.graph_config):
                 rt = _get_acp_runtime(_resolve_thread_id(request_metadata, session_id))
-                # Bridge the agent's tool events (emitted from the ACP reader loop) into the
-                # same tool_start/tool_end frames the native runtime yields → live tool cards.
+                # Bridge the agent's reader-loop callbacks (answer-text deltas + tool events)
+                # into the same text / tool_start / tool_end frames the native runtime yields,
+                # in arrival order → live streaming + tool cards.
                 _ACP_DONE = object()
-                tool_q: asyncio.Queue = asyncio.Queue()
+                frame_q: asyncio.Queue = asyncio.Queue()
+
+                async def _on_text(delta: str) -> None:
+                    await frame_q.put(("text", delta))
 
                 async def _on_tool(ev: dict) -> None:
-                    await tool_q.put(ev)
+                    if ev.get("phase") == "start":
+                        await frame_q.put(("tool_start", {"id": ev.get("id", ""), "name": ev.get("name", "tool"),
+                                                          "input": ev.get("input", "")}))
+                    elif ev.get("phase") == "end":
+                        await frame_q.put(("tool_end", {"id": ev.get("id", ""), "name": ev.get("name", "tool"),
+                                                        "output": ev.get("output", "")}))
 
                 async def _drive():
                     try:
-                        return await rt.run_turn(message, tool_callback=_on_tool)
+                        return await rt.run_turn(message, text_callback=_on_text, tool_callback=_on_tool)
                     finally:
-                        await tool_q.put(_ACP_DONE)
+                        await frame_q.put(_ACP_DONE)
 
                 driver = asyncio.create_task(_drive())
                 while True:
-                    ev = await tool_q.get()
-                    if ev is _ACP_DONE:
+                    frame = await frame_q.get()
+                    if frame is _ACP_DONE:
                         break
-                    if ev.get("phase") == "start":
-                        yield ("tool_start", {"id": ev.get("id", ""), "name": ev.get("name", "tool"),
-                                              "input": ev.get("input", "")})
-                    elif ev.get("phase") == "end":
-                        yield ("tool_end", {"id": ev.get("id", ""), "name": ev.get("name", "tool"),
-                                            "output": ev.get("output", "")})
+                    yield frame   # (kind, payload) — already normalized
                 try:
                     answer = await driver
                 except Exception as exc:  # noqa: BLE001 — surface as a turn error, don't 500
                     log.exception("[acp-runtime] turn failed")
                     yield ("error", f"ACP runtime ({rt.agent}) failed: {exc}")
                     return
+                # The answer already streamed as text deltas; `done` finalizes (executor appends
+                # only meta when text was streamed, so no duplication).
                 yield ("done", answer)
                 return
 

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -54,7 +54,7 @@ class _FakeClient:
         self.prompts = []
         self.closed = False
 
-    async def prompt(self, text, progress_callback=None, tool_callback=None):
+    async def prompt(self, text, progress_callback=None, tool_callback=None, text_callback=None):
         self.prompts.append(text)
         return "ANSWER"
 
@@ -204,3 +204,19 @@ async def test_acp_client_emits_structured_tool_events():
     assert captured[0] == {"phase": "start", "id": "t1", "name": "Editing app.py", "input": ""}
     assert captured[1]["phase"] == "end" and captured[1]["id"] == "t1"
     assert "wrote 3 lines" in captured[1]["output"]
+
+
+async def test_acp_client_streams_answer_text_deltas():
+    from plugins.coding_agent.acp_client import AcpClient
+
+    client = AcpClient("noop", cwd="/tmp", name="t")
+    deltas = []
+
+    async def on_text(d):
+        deltas.append(d)
+
+    client._on_text = on_text
+    await client._handle_update({"update": {"sessionUpdate": "agent_message_chunk", "content": {"text": "Hello "}}})
+    await client._handle_update({"update": {"sessionUpdate": "agent_message_chunk", "content": {"text": "world"}}})
+    assert deltas == ["Hello ", "world"]
+    assert client._answer == "Hello world"   # still accumulated for the final return


### PR DESCRIPTION
The last open item from the ACP-runtime guide's Limits. Tool cards already streamed; the **answer text** landed all at once at turn end.

- `acp_client` already received `agent_message_chunk` deltas — it only accumulated them. Now it also forwards each via a `text_callback` (still accumulated for the final return).
- `AcpRuntime.run_turn` threads `text_callback`; `chat.py` bridges text + tool callbacks onto **one queue in arrival order**, yielding `text` / `tool_start` / `tool_end` frames live, then `done`. Because text streams, the executor's `_finalize` appends only meta (no duplication) — identical to the native runtime's streaming path.

**Live-verified:** a long answer streamed in **4 progressive chunks** (vs one block before); short answers + tool cards still render. Granularity follows the agent — proto sends coarse chunks (not per-token); token-streaming agents render finer.

Tests: client emits text deltas + still accumulates. Suite **1289**, ruff + docs clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)