### PR TITLE
fix(acp): write Copilot's canonical instructions file so it adopts the persona

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **ACP persona reaches GitHub Copilot** — Copilot CLI didn't adopt the configured persona
+  (it answered as "GitHub Copilot CLI") because it reads `.github/copilot-instructions.md`, not
+  just `AGENTS.md`. The ACP runtime now also writes the agent's canonical file (Copilot's under
+  `.github/`); verified live — Copilot answers as your agent.
+
 ### Changed
 - **Console upgraded to React 19** — `apps/web` moved React 18.3 → 19.2 (already on `createRoot`
   with no removed-API usage, so a clean bump; all 60 e2e pass). Sets the shared singleton for the

--- a/docs/guides/acp-runtime.md
+++ b/docs/guides/acp-runtime.md
@@ -42,8 +42,10 @@ Each agent needs its CLI **installed + authenticated** on the host. Defaults are
 
 ## How a turn runs
 
-1. **Persona** — your `SOUL.md` is written as **`AGENTS.md`** (plus a vendor file like `CLAUDE.md`)
-   into the session's working dir, which the coding agent loads into **its own** system prompt — so
+1. **Persona** — your `SOUL.md` is written as **`AGENTS.md`** (plus the agent's own canonical
+   file where it differs — `CLAUDE.md`, `GEMINI.md`, or `.github/copilot-instructions.md` for
+   Copilot) into the session's working dir, which the coding agent loads into **its own** system
+   prompt — so
    it adopts *your* agent's identity instead of its built-in "I'm Codex/Claude" default. (Ask it
    "who are you?" — it answers as your agent.) The session runs in a dedicated, instance-scoped
    workspace, not your repo, so it never touches your project's own `AGENTS.md`.

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -95,8 +95,14 @@ def operator_mcp_server_spec(config) -> dict | None:
     }
 
 
-# A coding agent reads AGENTS.md universally; some prefer a vendor file too.
-_VENDOR_PERSONA_FILE = {"claude": "CLAUDE.md", "gemini": "GEMINI.md"}
+# Most coding agents read AGENTS.md, but some have a canonical file of their own and won't
+# reliably pick up AGENTS.md from a non-repo cwd. Write the vendor file too (relative path —
+# Copilot's lives under .github/, which we mkdir). Value can be a subpath, not just a name.
+_VENDOR_PERSONA_FILE = {
+    "claude": "CLAUDE.md",
+    "gemini": "GEMINI.md",
+    "copilot": ".github/copilot-instructions.md",
+}
 
 
 def _strip_injection(text: str) -> str:
@@ -178,7 +184,9 @@ class AcpRuntime:
             base = Path(self.cwd)
             base.mkdir(parents=True, exist_ok=True)
             for name in {"AGENTS.md", _VENDOR_PERSONA_FILE.get(self.agent, "AGENTS.md")}:
-                (base / name).write_text(doc, encoding="utf-8")
+                target = base / name
+                target.parent.mkdir(parents=True, exist_ok=True)  # vendor file may be in a subdir (.github/)
+                target.write_text(doc, encoding="utf-8")
         except Exception:  # noqa: BLE001 — persona is best-effort, never fail the turn
             log.warning("[acp-runtime] could not write persona files to %s", self.cwd, exc_info=True)
 

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -220,3 +220,16 @@ async def test_acp_client_streams_answer_text_deltas():
     await client._handle_update({"update": {"sessionUpdate": "agent_message_chunk", "content": {"text": "world"}}})
     assert deltas == ["Hello ", "world"]
     assert client._answer == "Hello world"   # still accumulated for the final return
+
+
+async def test_persona_written_to_copilot_instructions(tmp_path, monkeypatch):
+    import runtime.acp_runtime as rt_mod
+    monkeypatch.setattr(rt_mod, "persona_doc", lambda config: "# id\nYou are Aria.")
+    rt = AcpRuntime(
+        types.SimpleNamespace(agent_runtime="acp:copilot"),
+        cwd=str(tmp_path), client_factory=_FakeClient, context=_FakeCtx(),
+    )
+    rt._ensure_client()
+    # Copilot reads its own canonical file (under .github/) — and we still write AGENTS.md.
+    assert (tmp_path / "AGENTS.md").read_text() == "# id\nYou are Aria."
+    assert (tmp_path / ".github" / "copilot-instructions.md").read_text() == "# id\nYou are Aria."


### PR DESCRIPTION
Caught live: with `agent_runtime: acp:copilot`, the agent answered **as "GitHub Copilot CLI"**, not the configured persona.

**Cause:** GitHub Copilot CLI's canonical instructions file is **`.github/copilot-instructions.md`** (per [GitHub docs](https://docs.github.com/en/copilot/how-tos/copilot-cli/customize-copilot/add-custom-instructions)). It *also* reads `AGENTS.md`, but not reliably from a non-repo session cwd — so our slice-5 `AGENTS.md` didn't land for Copilot.

**Fix:** the persona writer maps `copilot → .github/copilot-instructions.md` (vendor file may now be a **subpath**; we mkdir its parent), still writing `AGENTS.md` too. Same pattern as `CLAUDE.md`/`GEMINI.md`.

**Live-verified:** with a "You are Aria" persona, `copilot --acp` answered **"I'm Aria, a calm operations assistant for protoLabs"** (was "I'm the GitHub Copilot CLI"). Test added for the `.github/` path; suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)