### PR TITLE
fix(acp): attribute turns to acp:<agent> in telemetry (not the gateway model)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (it answered as "GitHub Copilot CLI") because it reads `.github/copilot-instructions.md`, not
   just `AGENTS.md`. The ACP runtime now also writes the agent's canonical file (Copilot's under
   `.github/`); verified live — Copilot answers as your agent.
+- **ACP turns attributed correctly in telemetry** — they were recorded under the gateway
+  model (`protolabs/reasoning`, which never ran) with no model of their own. The ACP path now
+  emits a usage frame tagging the turn `acp:<agent>`; gateway tokens/cost stay 0 because the
+  external agent's own subscription meters usage (the `acp:` label is the signal it wasn't
+  gateway-metered).
 
 ### Changed
 - **Console upgraded to React 19** — `apps/web` moved React 18.3 → 19.2 (already on `createRoot`

--- a/server/chat.py
+++ b/server/chat.py
@@ -569,6 +569,16 @@ async def _chat_langgraph_stream(
                     log.exception("[acp-runtime] turn failed")
                     yield ("error", f"ACP runtime ({rt.agent}) failed: {exc}")
                     return
+                # Attribute the turn to the ACP agent in telemetry — else it defaults to the
+                # gateway model (`protolabs/reasoning`), which never ran. Gateway tokens/cost are
+                # 0: the external agent's own subscription meters its usage, not us. (The model
+                # label `acp:<agent>` is the honest signal that this turn wasn't gateway-metered.)
+                yield ("usage", {
+                    "model": f"acp:{rt.agent}",
+                    "input_tokens": 0, "output_tokens": 0,
+                    "cache_read_input_tokens": 0, "cache_creation_input_tokens": 0,
+                    "cost_usd": 0.0,
+                })
                 # The answer already streamed as text deltas; `done` finalizes (executor appends
                 # only meta when text was streamed, so no duplication).
                 yield ("done", answer)


### PR DESCRIPTION
ACP turns were **borking telemetry** — recorded under `protolabs/reasoning` (the gateway model, which never ran for an ACP turn) with 0 tokens / $0 / 0% cache.

**Cause:** the ACP path emitted no `usage` frame, so the executor fell back to the config model name and recorded nothing.

**Fix:** emit a `usage` frame tagging the turn **`acp:<agent>`**. Gateway tokens/cost stay **0** on purpose — the external agent's *own subscription* meters its usage, not our gateway; the `acp:` model label is the honest signal that this turn wasn't gateway-metered. (Latency + tool-call counts were already recorded correctly via the duration + the tool_start frames.)

**Live-verified:** the chat stream now emits `("usage", {model: "acp:copilot", …})` → the turn lands under `acp:copilot` in the By-model table instead of the phantom gateway model.

Follow-up worth considering: if proto/Copilot ever report real token/cache usage over ACP (`session/usage`), capture it; for now external runtimes are honestly "unmetered by the gateway."

🤖 Generated with [Claude Code](https://claude.com/claude-code)