### PR TITLE
feat(console): federation harness — first-class React plugin views (ADR 0034 slice 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Plugin UI — first-class React (ADR 0034, slice 1)** — the console is now a Module
+  Federation *host*: a plugin view declaring `ui: react` mounts a federated React **remote**
+  into the console's own tree (sharing the host's React 19 + react-query — one instance, one
+  cache), instead of an iframe. Ships the `FederatedView` runtime loader with a fail-safe error
+  card (a bad remote never white-screens the console), the `ui`/`remote` manifest fields, and a
+  `hello-react` reference remote (right panel). `ui: iframe` stays the default for untrusted
+  third-party plugins.
+
 ### Fixed
 - **ACP persona reaches GitHub Copilot** — Copilot CLI didn't adopt the configured persona
   (it answered as "GitHub Copilot CLI") because it reads `.github/copilot-instructions.md`, not

--- a/apps/web/.gitignore
+++ b/apps/web/.gitignore
@@ -1,0 +1,1 @@
+public/remotes/

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -50,6 +50,13 @@ export const RUNTIME_STATUS = {
         { id: "stats", label: "Stats", icon: "BarChart3", path: "/plugins/boardy/stats" },
         // A right-rail panel (ADR 0026 placement:"right") — sits with Notes/Beads/Goals.
         { id: "scratch", label: "Scratch", icon: "FileText", path: "/plugins/boardy/scratch", placement: "right" },
+        // A first-class React view (ADR 0034 `ui:"react"`) — a federated remote mounted into
+        // the host tree, not an iframe. Points at the built hello-react remote the host serves.
+        {
+          id: "react-panel", label: "React Panel", icon: "Atom", placement: "right",
+          ui: "react", path: "/plugins/boardy/scratch",
+          remote: { url: "/app/remotes/hello-react/assets/remoteEntry.js", module: "./Panel" },
+        },
       ],
     },
   ],

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -72,3 +72,19 @@ test("a plugin view with placement:right becomes a right-sidebar panel", async (
   await expect(frame).toBeVisible();
   await expect(frame).toHaveAttribute("src", /\/plugins\/boardy\/scratch/);
 });
+
+test("a ui:react view mounts a federated React remote (ADR 0034), not an iframe", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // Right-panel tab for the React view.
+  await page.locator(".segmented").getByRole("button", { name: "React Panel", exact: true }).click();
+
+  // The federated remote mounts into the host React tree — its content renders directly
+  // (no iframe). If React were dual-loaded, the remote's hook would throw on render.
+  await expect(page.getByText("Hello from a React plugin remote", { exact: false })).toBeVisible();
+  await expect(page.locator(".plugin-view-frame")).toHaveCount(0);
+
+  // The shared-React hook works: clicking increments the remote's useState counter.
+  await page.getByRole("button", { name: /clicked 0×/ }).click();
+  await expect(page.getByRole("button", { name: /clicked 1×/ })).toBeVisible();
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,10 +5,11 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
+    "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && npm run build:remotes && vite build",
     "preview": "vite preview --host 127.0.0.1",
     "test:e2e": "npm run build && playwright test",
-    "test:e2e:ui": "playwright test --ui"
+    "test:e2e:ui": "playwright test --ui",
+    "build:remotes": "vite build -c remotes/hello-react/vite.config.ts"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.100.14",
@@ -20,6 +21,7 @@
     "remark-gfm": "^4.0.0"
   },
   "devDependencies": {
+    "@originjs/vite-plugin-federation": "^1.4.1",
     "@playwright/test": "^1.60.0",
     "@types/react": "^19.0.0",
     "@types/react-dom": "^19.0.0",

--- a/apps/web/remotes/hello-react/Panel.tsx
+++ b/apps/web/remotes/hello-react/Panel.tsx
@@ -1,0 +1,20 @@
+import { useState } from "react";
+
+// Exposed as ./Panel and mounted by the console's FederatedView (ADR 0034 slice 1).
+// The useState hook proves this remote shares the HOST's React — a second React copy
+// would throw "invalid hook call" the moment this renders.
+export default function Panel() {
+  const [n, setN] = useState(0);
+  return (
+    <div style={{ padding: 16, display: "flex", flexDirection: "column", gap: 10 }}>
+      <strong>Hello from a React plugin remote 👋</strong>
+      <span style={{ fontSize: "0.85rem", opacity: 0.8 }}>
+        A federated Module Federation remote, mounted directly into the console's React tree —
+        not an iframe. It shares the host's React + query cache (ADR 0034).
+      </span>
+      <button type="button" onClick={() => setN((x) => x + 1)} style={{ alignSelf: "flex-start" }}>
+        clicked {n}× (shared-React hook works)
+      </button>
+    </div>
+  );
+}

--- a/apps/web/remotes/hello-react/index.html
+++ b/apps/web/remotes/hello-react/index.html
@@ -1,0 +1,3 @@
+<!doctype html>
+<html><head><meta charset="utf-8"><title>hello_react remote</title></head>
+<body><div id="root"></div></body></html>

--- a/apps/web/remotes/hello-react/vite.config.ts
+++ b/apps/web/remotes/hello-react/vite.config.ts
@@ -1,0 +1,30 @@
+import { dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { defineConfig } from "vite";
+import react from "@vitejs/plugin-react";
+import federation from "@originjs/vite-plugin-federation";
+
+// A trivial first-party React plugin REMOTE (ADR 0034 slice 1) — proves a federated
+// component mounts into the console and shares the host's React. `root` is pinned to this
+// dir so the build stays isolated from the host's src/. Built into the host's public/ so
+// it's served same-origin at /app/remotes/hello-react/remoteEntry.js.
+const here = dirname(fileURLToPath(import.meta.url));
+
+export default defineConfig({
+  root: here,
+  base: "/app/remotes/hello-react/",
+  plugins: [
+    react(),
+    federation({
+      name: "hello_react",
+      filename: "remoteEntry.js",
+      exposes: { "./Panel": `${here}/Panel.tsx` },
+      shared: {
+        react: { requiredVersion: false },
+        "react-dom": { requiredVersion: false },
+        "@tanstack/react-query": { requiredVersion: false },
+      },
+    }),
+  ],
+  build: { target: "esnext", outDir: "../../public/remotes/hello-react", emptyOutDir: true },
+});

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -2,6 +2,7 @@ import { AlertTriangle, Loader2 } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { apiUrl, authToken } from "../lib/api";
+import { FederatedView } from "../plugins/FederatedView";
 import { StageSubnav } from "./StageSubnav";
 import type { PluginView as PluginViewType } from "../lib/types";
 
@@ -53,6 +54,19 @@ export function PluginView({ view }: { view: PluginViewType }) {
     } catch {
       /* cross-origin / detached — best effort */
     }
+  }
+
+  // ADR 0034 — a `ui: react` view mounts a federated React remote into the host tree
+  // (one React, shared query cache) instead of an iframe. The iframe path below is
+  // unchanged and stays the default for `ui: iframe` / untrusted plugins.
+  if (view.ui === "react" && view.remote) {
+    return (
+      <section className="panel stage-panel plugin-view">
+        <div className="plugin-view-body">
+          <FederatedView label={view.label} remote={view.remote} />
+        </div>
+      </section>
+    );
   }
 
   return (

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3280,3 +3280,24 @@ textarea {
 .plugin-review .warn { color: #f5b450; display: inline-flex; align-items: center; gap: 3px; }
 .plugin-enable-hint { font-size: 11px; color: var(--fg-secondary); margin: 6px 0 0; }
 .btn-icon.danger:hover { color: #ef6b6b; }
+
+/* Federated plugin view (ADR 0034) — loading + bounded error card (D6). */
+.federated-loading,
+.federated-error {
+  display: flex;
+  align-items: flex-start;
+  gap: 8px;
+  padding: 14px;
+  font-size: 0.85rem;
+  color: var(--fg-muted);
+}
+.federated-loading { align-items: center; }
+.federated-error { color: #eadf9a; }
+.federated-error strong { color: var(--fg); }
+.federated-error-detail {
+  margin: 4px 0 8px;
+  font-family: var(--mono, monospace);
+  font-size: 0.78rem;
+  color: var(--fg-muted);
+  word-break: break-word;
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -81,6 +81,12 @@ export type PluginView = {
   // "rail" (default) = a left-rail surface; "right" = a right-sidebar panel
   // alongside Notes/Beads/Goals/Schedule (ADR 0026).
   placement?: "rail" | "right";
+  // ADR 0034 — how the view body renders. "iframe" (default) = same-origin iframe of
+  // `path`. "react" = a federated React remote mounted into the host tree (trusted plugins).
+  ui?: "iframe" | "react";
+  // For ui:"react" — the Module Federation remote: the remoteEntry URL + the exposed module
+  // key (e.g. "./Panel"). `scope` (the federation remote name) defaults to the view id.
+  remote?: { url: string; module: string; scope?: string };
 };
 
 // A git-installed plugin (ADR 0027) — a plugins.lock entry enriched with its

--- a/apps/web/src/plugins/FederatedView.tsx
+++ b/apps/web/src/plugins/FederatedView.tsx
@@ -1,0 +1,131 @@
+// Mount a `ui: react` plugin view as a Module Federation remote (ADR 0034).
+//
+// The plugin ships a pre-built federation *remote* (a remoteEntry.js exposing a component).
+// We register it at runtime (URL from the plugin manifest), load the exposed module, and mount
+// it into the host React tree — sharing the host's React + react-query singletons (configured
+// in vite.config.ts), so the remote behaves like a component written inside the console.
+//
+// D6 (fail safe): a remote that fails to load/throw renders a bounded error card with retry —
+// never a blank console or a crashed host.
+
+import {
+  Component,
+  type ComponentType,
+  type ErrorInfo,
+  type ReactNode,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { AlertTriangle, Loader2, RotateCcw } from "lucide-react";
+import {
+  __federation_method_getRemote,
+  __federation_method_setRemote,
+  __federation_method_unwrapDefault,
+} from "virtual:__federation__";
+
+export type RemoteSpec = { url: string; module: string; scope?: string };
+
+// Cache resolved remote components by scope+module so re-opening a view doesn't refetch.
+const _cache = new Map<string, ComponentType<Record<string, unknown>>>();
+
+async function loadRemoteComponent(spec: RemoteSpec): Promise<ComponentType<Record<string, unknown>>> {
+  const scope = spec.scope || spec.module;
+  const key = `${scope}::${spec.module}::${spec.url}`;
+  const cached = _cache.get(key);
+  if (cached) return cached;
+  // vite-plugin-federation calls `url().then(...)`, so the resolver must return a Promise.
+  __federation_method_setRemote(scope, { url: () => Promise.resolve(spec.url), format: "esm", from: "vite" });
+  const mod = await __federation_method_getRemote(scope, spec.module);
+  const resolved = (await __federation_method_unwrapDefault(mod)) as ComponentType<Record<string, unknown>>;
+  if (typeof resolved !== "function") {
+    throw new Error(`remote ${scope} ${spec.module} did not export a component`);
+  }
+  _cache.set(key, resolved);
+  return resolved;
+}
+
+function ErrorCard({ label, detail, onRetry }: { label: string; detail?: string; onRetry: () => void }) {
+  return (
+    <div className="federated-error" role="alert">
+      <AlertTriangle size={15} />
+      <div>
+        <strong>Couldn't load "{label}"</strong>
+        {detail ? <p className="federated-error-detail">{detail}</p> : null}
+        <button type="button" className="secondary-button" onClick={onRetry}>
+          <RotateCcw size={14} /> Retry
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Class boundary catches render-time throws from the remote (the hook/runtime errors a
+// promise can't). Resets via `resetKey` so Retry remounts the subtree.
+class RemoteBoundary extends Component<
+  { label: string; resetKey: number; onReset: () => void; children: ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null };
+  static getDerivedStateFromError(error: Error) {
+    return { error };
+  }
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("[federated-view] remote render error", error, info);
+  }
+  componentDidUpdate(prev: { resetKey: number }) {
+    if (prev.resetKey !== this.props.resetKey && this.state.error) this.setState({ error: null });
+  }
+  render() {
+    if (this.state.error) {
+      return <ErrorCard label={this.props.label} detail={String(this.state.error.message || this.state.error)} onRetry={this.props.onReset} />;
+    }
+    return this.props.children;
+  }
+}
+
+export function FederatedView({
+  label,
+  remote,
+  props,
+}: {
+  label: string;
+  remote: RemoteSpec;
+  props?: Record<string, unknown>;
+}) {
+  const [Comp, setComp] = useState<ComponentType<Record<string, unknown>> | null>(null);
+  const [error, setError] = useState<Error | null>(null);
+  const [attempt, setAttempt] = useState(0);
+  const alive = useRef(true);
+
+  useEffect(() => {
+    alive.current = true;
+    setComp(null);
+    setError(null);
+    loadRemoteComponent(remote)
+      .then((c) => alive.current && setComp(() => c))
+      .catch((e) => alive.current && setError(e instanceof Error ? e : new Error(String(e))));
+    return () => {
+      alive.current = false;
+    };
+  }, [remote.url, remote.module, remote.scope, attempt]);
+
+  const retry = () => {
+    _cache.delete(`${remote.scope || remote.module}::${remote.module}::${remote.url}`);
+    setAttempt((n) => n + 1);
+  };
+
+  if (error) return <ErrorCard label={label} detail={String(error.message || error)} onRetry={retry} />;
+  if (!Comp) {
+    return (
+      <div className="federated-loading">
+        <Loader2 className="spin" size={16} /> <span>Loading {label}…</span>
+      </div>
+    );
+  }
+  return (
+    <RemoteBoundary label={label} resetKey={attempt} onReset={retry}>
+      <Comp {...(props ?? {})} />
+    </RemoteBoundary>
+  );
+}

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,15 @@
 /// <reference types="vite/client" />
+
+// Module Federation runtime helpers injected by @originjs/vite-plugin-federation (ADR 0034).
+// Used by FederatedView to register + load a `ui: react` plugin remote at runtime.
+declare module "virtual:__federation__" {
+  interface RemoteConfig {
+    url: (() => Promise<string> | string) | string;
+    format?: "esm" | "systemjs" | "var";
+    from?: "vite" | "webpack";
+  }
+  export function __federation_method_setRemote(name: string, config: RemoteConfig): void;
+  export function __federation_method_getRemote(name: string, exposedPath: string): Promise<unknown>;
+  export function __federation_method_unwrapDefault(module: unknown): Promise<unknown>;
+  export function __federation_method_ensure(name: string): Promise<unknown>;
+}

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,5 +1,6 @@
 import { defineConfig, loadEnv } from "vite";
 import react from "@vitejs/plugin-react";
+import federation from "@originjs/vite-plugin-federation";
 
 export default defineConfig(({ mode }) => {
   const env = loadEnv(mode, new URL("../..", import.meta.url).pathname, "PROTOAGENT_");
@@ -7,20 +8,34 @@ export default defineConfig(({ mode }) => {
 
   return {
     base: "/app/",
-    plugins: [react()],
-    build: {
-      rollupOptions: {
-        output: {
-          // Split the React runtime into its own long-lived vendor chunk. The
-          // package-boundary regex avoids matching react-markdown / sibling
-          // packages so the lazily-loaded markdown chunk stays separate.
-          manualChunks(id) {
-            if (/[\\/]node_modules[\\/](react|react-dom|scheduler)[\\/]/.test(id)) {
-              return "react-vendor";
-            }
-          },
+    plugins: [
+      react(),
+      // Plugin UI as first-class React (ADR 0034). The console is the Module Federation
+      // *host*: it shares React + react-query as singletons so a `ui: react` plugin remote
+      // mounts into this tree with ONE React instance + ONE query cache. Remotes load
+      // dynamically at runtime (URL from the plugin manifest) via the federation runtime
+      // helpers in FederatedView — so none are declared statically here.
+      federation({
+        name: "console_host",
+        // A placeholder remote forces vite-plugin-federation to emit the shared-scope runtime
+        // (without ≥1 remote, the dynamic setRemote/getRemote path throws "__rf_placeholder__
+        // shareScope is not defined"). It's never imported — real remotes are registered at
+        // runtime from the plugin manifest in FederatedView.
+        remotes: { __pa_share_init__: "data:text/javascript,export default {}" },
+        // vite-plugin-federation shares by provision (no Webpack-style `singleton` flag — it's
+        // commented out in its types). The host provides these; a remote consumes the host's
+        // copy, so there's one React + one query cache. `requiredVersion: false` stops a
+        // version-string mismatch (host React 19 vs a remote's declared range) from dual-loading.
+        shared: {
+          react: { requiredVersion: false },
+          "react-dom": { requiredVersion: false },
+          "@tanstack/react-query": { requiredVersion: false },
         },
-      },
+      }),
+    ],
+    build: {
+      // Federation's shared-scope bootstrap emits modern output (top-level await).
+      target: "esnext",
     },
     server: {
       port: 5173,

--- a/package-lock.json
+++ b/package-lock.json
@@ -37,6 +37,7 @@
         "remark-gfm": "^4.0.0"
       },
       "devDependencies": {
+        "@originjs/vite-plugin-federation": "^1.4.1",
         "@playwright/test": "^1.60.0",
         "@types/react": "^19.0.0",
         "@types/react-dom": "^19.0.0",
@@ -1139,6 +1140,44 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@originjs/vite-plugin-federation": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@originjs/vite-plugin-federation/-/vite-plugin-federation-1.4.1.tgz",
+      "integrity": "sha512-Uo08jW5pj1t58OUKuZNkmzcfTN2pqeVuAWCCiKf/75/oll4Efq4cHOqSE1FXMlvwZNGDziNdDyBbQ5IANem3CQ==",
+      "dev": true,
+      "license": "MulanPSL-2.0",
+      "dependencies": {
+        "estree-walker": "^3.0.2",
+        "magic-string": "^0.27.0"
+      },
+      "engines": {
+        "node": ">=14.0.0",
+        "pnpm": ">=7.0.1"
+      }
+    },
+    "node_modules/@originjs/vite-plugin-federation/node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
+    "node_modules/@originjs/vite-plugin-federation/node_modules/magic-string": {
+      "version": "0.27.0",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.27.0.tgz",
+      "integrity": "sha512-8UnnX2PeRAPZuN12svgR9j7M1uWMovg/CEnIwIG0LFkXSJJe4PdfUGiTGl8V9bsBHFUtfVINcSyYxd7q+kx9fA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.4.13"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "node_modules/@playwright/test": {

--- a/plugins/hello/protoagent.plugin.yaml
+++ b/plugins/hello/protoagent.plugin.yaml
@@ -31,3 +31,11 @@ settings:
 # name; `path` is served by this plugin's router (see __init__.py `/view`).
 views:
   - { id: hello, label: "Hello", icon: "Sparkles", path: "/plugins/hello/view" }
+  # A first-class React plugin view (ADR 0034) — `ui: react` mounts a Module Federation
+  # remote into the console's own React tree (not an iframe), in the right panel. `path` is
+  # kept as an iframe fallback. The remote is built to apps/web/public/remotes/hello-react/.
+  - {
+      id: hello-react, label: "Hello (React)", icon: "Atom", placement: right,
+      ui: react, path: "/plugins/hello/view",
+      remote: { url: "/app/remotes/hello-react/assets/remoteEntry.js", module: "./Panel" },
+    }


### PR DESCRIPTION
**Slice 1 of the plugin-UI federation initiative (ADR 0034).** The console becomes a Module Federation *host*; a plugin view with `ui: react` mounts a federated React **remote** into the console's own tree — sharing the host's **React 19** + react-query (one instance, one cache) — instead of a same-origin iframe.

### What's in it
- **Host config** (`vite.config.ts`) — federation sharing `react`/`react-dom`/`@tanstack-react-query`. A placeholder remote forces the shared-scope runtime (without ≥1 remote, dynamic load throws `__rf_placeholder__shareScope is not defined` — a known vite-plugin-federation gotcha).
- **`FederatedView`** — runtime remote loader (`setRemote`/`getRemote` off the manifest) + a class error boundary rendering a **bounded retry card** (D6 — a bad remote never white-screens the host; verified: a wrong `url()` shape surfaced as the card, not a crash).
- **Dispatch** (`PluginView.tsx`) — `ui:"react"` → `FederatedView`; else the existing iframe, **untouched** (default for untrusted third-party, D5).
- **Types** — `PluginView.ui` + `remote{url,module}`. The manifest is `list[dict]` so these pass through — **no backend change**.
- **Reference remote** — `remotes/hello-react/` (built into `public/remotes/` via a chained `build:remotes`) exposing a `Panel`; the `hello` plugin advertises it as a right-panel `ui:react` view.

### Verified end-to-end
e2e (headless chromium): the remote **mounts in-browser** ("Hello from a React plugin remote"), the **shared-React hook increments** (0→1 — proves one React instance), and it's **not an iframe**. Plus live on :7901 (view advertised + remoteEntry served 200). **Suite 1290 + 61 e2e green.**

Next slices: `@protoagent/plugin-ui` SDK (2) → trust gate (3) → port Notes (4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)