### PR TITLE
feat(console): persisted UI-state store (ADR 0035 slice 1) [HOLD: local test]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Persisted UI state (ADR 0035 slice 1)** — the console's navigation/layout state (active
+  surface, sub-tabs, right-panel width/collapse) now lives in a Zustand `persist` store, so a
+  **refresh restores where you were** instead of snapping back to Chat/Notes. Pure state migration
+  — no visible layout change yet; the foundation the dual-rail/mobile slices build on.
 - **Plugin UI — first-class React (ADR 0034, slice 1)** — the console is now a Module
   Federation *host*: a plugin view declaring `ui: react` mounts a federated React **remote**
   into the console's own tree (sharing the host's React 19 + react-query — one instance, one

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -74,3 +74,16 @@ test("plugins section: Local / Market / Download tabs", async ({ page }) => {
   await page.locator(".stage-subnav").getByRole("button", { name: "Download", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
 });
+
+test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // Move off the defaults: a left surface (Agent) + a right-panel tab (Beads).
+  await page.locator(".rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".segmented").getByRole("button", { name: "Beads", exact: true }).click();
+
+  // Reload — the persisted store restores both, instead of snapping back to Chat/Notes.
+  await page.reload({ waitUntil: "load" });
+  await expect(page.locator(".rail").getByRole("button", { name: "Agent", exact: true })).toHaveClass(/active/);
+  await expect(page.locator(".segmented").getByRole("button", { name: "Beads", exact: true })).toHaveClass(/active/);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -18,7 +18,8 @@
     "react-dom": "^19.0.0",
     "react-markdown": "^9.0.1",
     "rehype-highlight": "^7.0.2",
-    "remark-gfm": "^4.0.0"
+    "remark-gfm": "^4.0.0",
+    "zustand": "^5.0.14"
   },
   "devDependencies": {
     "@originjs/vite-plugin-federation": "^1.4.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -72,6 +72,15 @@ import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { SettingsSurface, SETTINGS_TABS, type SettingsTab } from "../settings/SettingsSurface";
+import {
+  useUI,
+  type ActivityTab,
+  type AgentTab,
+  type KnowledgeTab,
+  type PluginsTab,
+  type RightPanel,
+  type Surface,
+} from "../state/uiStore";
 import { SettingsCategoryPanel } from "../settings/SettingsCategory";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
@@ -99,7 +108,6 @@ import { runtimeStatusQuery } from "../lib/queries";
 // Core surfaces are the fixed literals; plugin views (ADR 0026) add dynamic
 // surfaces keyed `plugin:<pluginId>:<viewId>`. The `(string & {})` keeps literal
 // autocomplete while allowing those runtime keys.
-type Surface = "chat" | "activity" | "studio" | "knowledge" | "agent" | "plugins" | "settings" | (string & {});
 
 // A plugin view names its rail glyph by lucide icon name. The curated set below
 // is the common-case fast path (already bundled); anything else falls back to the
@@ -164,17 +172,12 @@ function pluginViewIcon(name?: string): ReactNode {
 // Agent = the agent's own makeup: its identity (name + SOUL.md), tools, MCP
 // servers, subagents, skills, and middleware. (Runtime status + telemetry moved
 // to Settings → Overview.)
-type AgentTab = "identity" | "settings" | "tools" | "mcp" | "subagents" | "skills" | "middleware";
 // Plugins = installed (local), discover (market), and install-from-git (download).
-type PluginsTab = "local" | "market" | "download";
 // Knowledge = the store + its settings (memory/knowledge config).
-type KnowledgeTab = "store" | "settings";
 // Activity = the "triggers / events" surface (ADR 0009): what happened (thread),
 // inbound (inbox), and timed (schedule — cron is a trigger, not a work-type).
-type ActivityTab = "thread" | "inbox";
 // The agent's persistent working memory, grouped in the right sidebar:
 // its notebook, its task board, and its goals.
-type RightPanel = "notes" | "beads" | "goals" | "schedule" | (string & {});  // + plugin:<id>:<viewId> (ADR 0026)
 
 function createNoteTab() {
   const now = Date.now();
@@ -214,21 +217,29 @@ function useLocalStorageState(key: string, fallback: string) {
 }
 
 export function App() {
-  const [surface, setSurface] = useState<Surface>("chat");
+  // Navigation/layout state lives in the persisted UI store (ADR 0035 D5) — a refresh
+  // restores the active surface, sub-tabs, and right-panel width/collapse.
+  const surface = useUI((s) => s.surface);
+  const setSurface = useUI((s) => s.setSurface);
   // Background-streaming indicator for the Chat rail (narrow selector → only
   // re-renders when the boolean flips, not per token).
   const chatStreaming = useAnyChatStreaming();
-  const [agentTab, setAgentTab] = useState<AgentTab>("identity");
-  const [pluginsTab, setPluginsTab] = useState<PluginsTab>("local");
-  const [knowledgeTab, setKnowledgeTab] = useState<KnowledgeTab>("store");
-  const [settingsTab, setSettingsTab] = useState<SettingsTab>("overview");
-  const [activityTab, setActivityTab] = useState<ActivityTab>("thread");
-  const [rightPanel, setRightPanel] = useState<RightPanel>("notes");
-  // Collapsible/resizable right panel (persisted). Flag is "1"/"" string; width
-  // is a px string clamped on read.
-  const [rightCollapsed, setRightCollapsed] = useLocalStorageState("protoagent.rightCollapsed", "");
-  const [rightWidthStr, setRightWidthStr] = useLocalStorageState("protoagent.rightWidth", "360");
-  const rightWidth = Math.min(720, Math.max(280, parseInt(rightWidthStr, 10) || 360));
+  const agentTab = useUI((s) => s.agentTab);
+  const setAgentTab = useUI((s) => s.setAgentTab);
+  const pluginsTab = useUI((s) => s.pluginsTab);
+  const setPluginsTab = useUI((s) => s.setPluginsTab);
+  const knowledgeTab = useUI((s) => s.knowledgeTab);
+  const setKnowledgeTab = useUI((s) => s.setKnowledgeTab);
+  const settingsTab = useUI((s) => s.settingsTab);
+  const setSettingsTab = useUI((s) => s.setSettingsTab);
+  const activityTab = useUI((s) => s.activityTab);
+  const setActivityTab = useUI((s) => s.setActivityTab);
+  const rightPanel = useUI((s) => s.rightPanel);
+  const setRightPanel = useUI((s) => s.setRightPanel);
+  const rightCollapsed = useUI((s) => s.rightCollapsed);
+  const setRightCollapsed = useUI((s) => s.setRightCollapsed);
+  const rightWidth = useUI((s) => s.rightWidth);
+  const setRightWidth = useUI((s) => s.setRightWidth);
   const [live, setLive] = useState(false);
   // Shared custom confirm for destructive actions (notes/beads delete).
   const [confirmState, setConfirmState] = useState<
@@ -557,7 +568,7 @@ export function App() {
     const startW = rightWidth;
     const onMove = (ev: MouseEvent) => {
       const next = Math.min(720, Math.max(280, startW + (startX - ev.clientX)));
-      setRightWidthStr(String(Math.round(next)));
+      setRightWidth(next);
     };
     const onUp = () => {
       window.removeEventListener("mousemove", onMove);
@@ -967,7 +978,7 @@ export function App() {
         <button
           type="button"
           className={`util-btn ${rightCollapsed ? "is-off" : ""}`}
-          onClick={() => setRightCollapsed(rightCollapsed ? "" : "1")}
+          onClick={() => setRightCollapsed(!rightCollapsed)}
           title={rightCollapsed ? "Show side panel" : "Hide side panel"}
           aria-label="Toggle side panel"
           data-testid="toggle-right"

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -1,0 +1,80 @@
+// Persisted UI/layout state (ADR 0035 D5 — slice 1).
+//
+// The single source of truth for *navigation/layout* state: which surface is active,
+// which sub-tab, the right panel's width/collapse. Zustand + `persist` → localStorage, so a
+// refresh restores exactly where the user was (these were React `useState` before, lost on
+// reload). UI state ONLY — server data stays in react-query; the two never mix.
+//
+// Later layout slices (dual rails, swap, mobile quick-bar) extend this store; today it mirrors
+// the existing single-left-surface + right-panel model 1:1 so slice 1 is a pure state migration
+// with no visible change.
+
+import { create } from "zustand";
+import { persist } from "zustand/middleware";
+
+import type { SettingsTab } from "../settings/SettingsSurface";
+
+// Core surfaces are fixed literals; plugin views (ADR 0026) add dynamic surfaces keyed
+// `plugin:<pluginId>:<viewId>`. The `(string & {})` keeps literal autocomplete while allowing
+// those runtime keys.
+export type Surface =
+  | "chat" | "activity" | "studio" | "knowledge" | "agent" | "plugins" | "settings" | (string & {});
+export type RightPanel = "notes" | "beads" | "goals" | "schedule" | (string & {}); // + plugin:<id>:<viewId>
+export type AgentTab = "identity" | "settings" | "tools" | "mcp" | "subagents" | "skills" | "middleware";
+export type PluginsTab = "local" | "market" | "download";
+export type KnowledgeTab = "store" | "settings";
+export type ActivityTab = "thread" | "inbox";
+
+const RIGHT_MIN = 280;
+const RIGHT_MAX = 720;
+const clampWidth = (w: number) => Math.min(RIGHT_MAX, Math.max(RIGHT_MIN, Math.round(w)));
+
+type UIState = {
+  surface: Surface;
+  rightPanel: RightPanel;
+  agentTab: AgentTab;
+  pluginsTab: PluginsTab;
+  knowledgeTab: KnowledgeTab;
+  settingsTab: SettingsTab;
+  activityTab: ActivityTab;
+  rightCollapsed: boolean;
+  rightWidth: number;
+  setSurface: (s: Surface) => void;
+  setRightPanel: (p: RightPanel) => void;
+  setAgentTab: (t: AgentTab) => void;
+  setPluginsTab: (t: PluginsTab) => void;
+  setKnowledgeTab: (t: KnowledgeTab) => void;
+  setSettingsTab: (t: SettingsTab) => void;
+  setActivityTab: (t: ActivityTab) => void;
+  setRightCollapsed: (b: boolean) => void;
+  setRightWidth: (w: number) => void;
+};
+
+export const useUI = create<UIState>()(
+  persist(
+    (set) => ({
+      surface: "chat",
+      rightPanel: "notes",
+      agentTab: "identity",
+      pluginsTab: "local",
+      knowledgeTab: "store",
+      settingsTab: "overview" as SettingsTab,
+      activityTab: "thread",
+      rightCollapsed: false,
+      rightWidth: 360,
+      setSurface: (surface) => set({ surface }),
+      setRightPanel: (rightPanel) => set({ rightPanel }),
+      setAgentTab: (agentTab) => set({ agentTab }),
+      setPluginsTab: (pluginsTab) => set({ pluginsTab }),
+      setKnowledgeTab: (knowledgeTab) => set({ knowledgeTab }),
+      setSettingsTab: (settingsTab) => set({ settingsTab }),
+      setActivityTab: (activityTab) => set({ activityTab }),
+      setRightCollapsed: (rightCollapsed) => set({ rightCollapsed }),
+      setRightWidth: (w) => set({ rightWidth: clampWidth(w) }),
+    }),
+    {
+      name: "protoagent.ui", // localStorage key — the single source of truth (ADR 0035 D5)
+      version: 1,
+    },
+  ),
+);

--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,8 @@
         "react-dom": "^19.0.0",
         "react-markdown": "^9.0.1",
         "rehype-highlight": "^7.0.2",
-        "remark-gfm": "^4.0.0"
+        "remark-gfm": "^4.0.0",
+        "zustand": "^5.0.14"
       },
       "devDependencies": {
         "@originjs/vite-plugin-federation": "^1.4.1",
@@ -4788,6 +4789,35 @@
       "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/zustand": {
+      "version": "5.0.14",
+      "resolved": "https://registry.npmjs.org/zustand/-/zustand-5.0.14.tgz",
+      "integrity": "sha512-/8tAspM5LMPr28b3fwLYrtdj77ECpfZviaP75CMTnwO8ISyaE4GDIG/9rDDYq/cH9D2Xw2A2RXglLInmVBQB/g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.20.0"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18.0.0",
+        "immer": ">=9.0.6",
+        "react": ">=18.0.0",
+        "use-sync-external-store": ">=1.2.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "immer": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "use-sync-external-store": {
+          "optional": true
+        }
+      }
     },
     "node_modules/zwitch": {
       "version": "2.0.4",


### PR DESCRIPTION
**Slice 1 of the layout reorg (ADR 0035).** Draft / **do not merge until locally tested** — UI work, CI can't judge it.

A Zustand `persist` store (`localStorage "protoagent.ui"`) becomes the single source of truth for nav/layout state — active surface, sub-tabs, right panel + its width/collapse — migrated out of `App.tsx` `useState`. So a **refresh restores where you were** instead of snapping to Chat/Notes.

**Pure state migration — no visible layout change yet.** It's the foundation the dual-rail / swap / mobile slices read from.

- New `src/state/uiStore.ts` (store + the nav type aliases, which App now imports).
- `App.tsx` nav state → store selectors; right-panel collapse is now a real boolean, width a clamped number.
- e2e: reload restores the active surface + right-panel tab. Build clean, 62 e2e green.

**To test locally (:7901):** navigate to a non-default surface + right-panel tab, hard-refresh — you should land back where you were. Then I'll mark ready.

Next: slice 2 (symmetric dual rails + unified tabs) reads from this store.

🤖 Generated with [Claude Code](https://claude.com/claude-code)