### PR TITLE
feat(console): symmetric dual rails (ADR 0035 slice 2) [HOLD: local test]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Symmetric dual rails (ADR 0035 slice 2)** — the right panel's horizontal segmented tab
+  strip becomes a vertical **right rail** mirroring the left (same `RailButton` component) on the
+  far edge: [left rail | left surface | right surface | right rail]. Picking a right surface
+  (Notes/Beads/Goals/Schedule + plugin right-views) expands it. First step toward swappable
+  surfaces (slice 3) + mobile (slice 4).
 - **Persisted UI state (ADR 0035 slice 1)** — the console's navigation/layout state (active
   surface, sub-tabs, right-panel width/collapse) now lives in a Zustand `persist` store, so a
   **refresh restores where you were** instead of snapping back to Chat/Notes. Pure state migration

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -80,10 +80,10 @@ test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async 
 
   // Move off the defaults: a left surface (Agent) + a right-panel tab (Beads).
   await page.locator(".rail").getByRole("button", { name: "Agent", exact: true }).click();
-  await page.locator(".segmented").getByRole("button", { name: "Beads", exact: true }).click();
+  await page.locator(".rail-right").getByRole("button", { name: "Beads", exact: true }).click();
 
   // Reload — the persisted store restores both, instead of snapping back to Chat/Notes.
   await page.reload({ waitUntil: "load" });
   await expect(page.locator(".rail").getByRole("button", { name: "Agent", exact: true })).toHaveClass(/active/);
-  await expect(page.locator(".segmented").getByRole("button", { name: "Beads", exact: true })).toHaveClass(/active/);
+  await expect(page.locator(".rail-right").getByRole("button", { name: "Beads", exact: true })).toHaveClass(/active/);
 });

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -63,7 +63,7 @@ test("a plugin view with placement:right becomes a right-sidebar panel", async (
   await page.goto("/app/", { waitUntil: "load" });
 
   // The right-placed view is a right-rail tab (not a left-rail surface icon).
-  const tab = page.locator(".segmented").getByRole("button", { name: "Scratch", exact: true });
+  const tab = page.locator(".rail-right").getByRole("button", { name: "Scratch", exact: true });
   await expect(tab).toBeVisible();
   await tab.click();
 
@@ -77,7 +77,7 @@ test("a ui:react view mounts a federated React remote (ADR 0034), not an iframe"
   await page.goto("/app/", { waitUntil: "load" });
 
   // Right-panel tab for the React view.
-  await page.locator(".segmented").getByRole("button", { name: "React Panel", exact: true }).click();
+  await page.locator(".rail-right").getByRole("button", { name: "React Panel", exact: true }).click();
 
   // The federated remote mounts into the host React tree — its content renders directly
   // (no iframe). If React were dual-loaded, the remote's hook would throw on render.

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -844,32 +844,6 @@ export function App() {
               data-testid="right-resize"
             />
           ) : null}
-          <div className="segmented">
-            <button type="button" className={rightPanel === "notes" ? "active" : ""} onClick={() => setRightPanel("notes")}>
-              <FileText size={15} />
-              Notes
-            </button>
-            <button type="button" className={rightPanel === "beads" ? "active" : ""} onClick={() => setRightPanel("beads")}>
-              <Boxes size={15} />
-              Beads
-            </button>
-            <button type="button" className={rightPanel === "goals" ? "active" : ""} onClick={() => setRightPanel("goals")}>
-              <Target size={15} />
-              Goals
-            </button>
-            <button type="button" className={rightPanel === "schedule" ? "active" : ""} onClick={() => setRightPanel("schedule")}>
-              <CalendarClock size={15} />
-              Schedule
-            </button>
-            {/* Plugin-contributed right-rail panels (ADR 0026) — placement: "right". */}
-            {pluginRightPanels.map((v) => (
-              <button key={v.key} type="button" className={rightPanel === v.key ? "active" : ""} onClick={() => setRightPanel(v.key)}>
-                {pluginViewIcon(v.icon)}
-                {v.label}
-              </button>
-            ))}
-          </div>
-
           {activeRightPluginPanel ? (
             <PluginView key={activeRightPluginPanel.key} view={activeRightPluginPanel} />
           ) : null}
@@ -950,6 +924,35 @@ export function App() {
 
           {rightPanel === "goals" ? <GoalsPanel /> : null}
           {rightPanel === "schedule" ? <SchedulePanel /> : null}
+        </aside>
+
+        {/* Right rail (ADR 0035 D1) — mirrors the left rail on the far edge; its surfaces
+            (Notes/Beads/Goals/Schedule + plugin right-views) replace the old segmented strip.
+            Picking one ensures the right surface is expanded. */}
+        <aside className="rail rail-right" aria-label="Context surfaces">
+          {([
+            ["notes", "Notes", <FileText size={18} />],
+            ["beads", "Beads", <Boxes size={18} />],
+            ["goals", "Goals", <Target size={18} />],
+            ["schedule", "Schedule", <CalendarClock size={18} />],
+          ] as const).map(([key, label, icon]) => (
+            <RailButton
+              key={key}
+              active={rightPanel === key && !rightCollapsed}
+              label={label}
+              icon={icon}
+              onClick={() => { setRightPanel(key); setRightCollapsed(false); }}
+            />
+          ))}
+          {pluginRightPanels.map((v) => (
+            <RailButton
+              key={v.key}
+              active={rightPanel === v.key && !rightCollapsed}
+              label={v.label}
+              icon={pluginViewIcon(v.icon)}
+              onClick={() => { setRightPanel(v.key); setRightCollapsed(false); }}
+            />
+          ))}
         </aside>
       </div>
 

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -347,7 +347,10 @@ h2 {
      from the persisted/resized panel width; 0px when collapsed). Keeping the
      template in CSS — not inline — lets the media query below collapse to two
      columns instead of leaving a blank reserved column. */
-  grid-template-columns: 72px minmax(0, 1fr) var(--right-width, 360px);
+  /* ADR 0035 — symmetric dual rails: [left rail | left surface | right surface | right rail].
+     The right rail mirrors the left on the far edge; the right surface (content) track collapses
+     to 0 via --right-width while the right rail stays put. */
+  grid-template-columns: 72px minmax(0, 1fr) var(--right-width, 360px) 72px;
 }
 
 .rail {
@@ -356,6 +359,12 @@ h2 {
   gap: 6px;
   padding: 10px 8px;
   border-right: 1px solid var(--border);
+}
+
+/* Right rail mirrors the left, bordered on its left edge (ADR 0035 D1). */
+.rail-right {
+  border-right: none;
+  border-left: 1px solid var(--border);
 }
 
 .rail button {


### PR DESCRIPTION
**Slice 2 — the first *visible* layout change.** Draft / **do not merge until you've tested it on :7901**.

The right panel's horizontal **segmented strip → a vertical right rail** mirroring the left (same `RailButton`), on the far edge:

```
[ left rail | left surface | right surface | right rail ]
```

- Workspace grid gains a 4th 72px column for the right rail.
- Right surfaces (Notes/Beads/Goals/Schedule + plugin right-views) now live in the rail; clicking one expands the right surface.
- Reads active surface/tab from the slice-1 store; in-surface sub-tabs keep the unified segmented style.
- Groundwork for **swap-between-rails (S3)** + **mobile (S4)**.

62 e2e green (repointed the right-surface selectors to `.rail-right`), build clean.

**Test on :7901 (hard-refresh):** the right side should now be a vertical icon rail like the left; Notes/Beads/Goals/Schedule live there. Tell me how the split feels — this is where your eye matters. Then I mark ready + do S3 (move-surface + the wide resize handle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)