### PR TITLE
feat(console): real resize handle (ADR 0035 slice 3, part 1) [HOLD: local test]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Resizable right panel — real handle (ADR 0035 slice 3)** — the divider is now a proper
+  grab target (14px hit area, visible grip that thickens on hover/focus) and **keyboard-resizable**
+  (←/→ nudge, Shift = bigger step, Home/End = max/min) with **double-click to reset**. Width still
+  persists via the UI store.
 - **Symmetric dual rails (ADR 0035 slice 2)** — the right panel's horizontal segmented tab
   strip becomes a vertical **right rail** mirroring the left (same `RailButton` component) on the
   far edge: [left rail | left surface | right surface | right rail]. Picking a right surface

--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -38,3 +38,21 @@ test("right panel resizes by dragging its handle and the width persists", async 
   const reloaded = (await page.locator(".right-panel").boundingBox())!.width;
   expect(Math.abs(reloaded - after)).toBeLessThan(8);
 });
+
+test("right panel is keyboard-resizable + double-click resets (ADR 0035 S3)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const right = page.locator(".right-panel");
+  const handle = page.getByTestId("right-resize");
+  const before = (await right.boundingBox())!.width;
+
+  // ArrowLeft widens the panel (handle is on its left edge).
+  await handle.focus();
+  for (let i = 0; i < 6; i++) await page.keyboard.press("ArrowLeft");
+  const wider = (await right.boundingBox())!.width;
+  expect(wider).toBeGreaterThan(before);
+
+  // Double-click resets toward the default width.
+  await handle.dblclick();
+  const reset = (await right.boundingBox())!.width;
+  expect(reset).toBeLessThan(wider);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -580,6 +580,17 @@ export function App() {
     window.addEventListener("mouseup", onUp);
   }
 
+  // Keyboard-resizable (ADR 0035 S3): arrows nudge, Home/End jump to max/min, double-click
+  // resets. The handle sits on the right panel's LEFT edge, so ← widens / → narrows.
+  const RIGHT_DEFAULT_WIDTH = 360;
+  function onResizeKey(e: React.KeyboardEvent) {
+    const step = e.shiftKey ? 48 : 16;
+    if (e.key === "ArrowLeft") { setRightWidth(rightWidth + step); e.preventDefault(); }
+    else if (e.key === "ArrowRight") { setRightWidth(rightWidth - step); e.preventDefault(); }
+    else if (e.key === "Home") { setRightWidth(720); e.preventDefault(); }
+    else if (e.key === "End") { setRightWidth(280); e.preventDefault(); }
+  }
+
   // Drive only the right column's WIDTH via a CSS var — the grid template
   // itself lives in CSS (.workspace), so the responsive media query can
   // collapse to two columns below the breakpoint. Setting the full template
@@ -839,8 +850,14 @@ export function App() {
               className="resize-handle"
               role="separator"
               aria-orientation="vertical"
-              aria-label="Resize side panel"
+              aria-label="Resize side panel (arrows to nudge, double-click to reset)"
+              aria-valuenow={rightWidth}
+              aria-valuemin={280}
+              aria-valuemax={720}
+              tabIndex={0}
               onMouseDown={startRightResize}
+              onKeyDown={onResizeKey}
+              onDoubleClick={() => setRightWidth(RIGHT_DEFAULT_WIDTH)}
               data-testid="right-resize"
             />
           ) : null}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -430,20 +430,36 @@ h2 {
 }
 
 /* Drag handle on the boundary between the stage and the right panel. */
+/* A real grab target (ADR 0035 S3): a 14px hit area centered on the divider, with a
+   thin always-visible grip line that thickens on hover/focus/active. */
 .resize-handle {
   position: absolute;
   left: 0;
   top: 0;
   bottom: 0;
-  width: 7px;
-  margin-left: -4px;
+  width: 14px;
+  margin-left: -7px;
   cursor: col-resize;
   z-index: 5;
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-
-.resize-handle:hover,
-.resize-handle:active {
-  background: color-mix(in srgb, var(--accent, #7c8cff) 45%, transparent);
+.resize-handle::before {
+  content: "";
+  width: 2px;
+  height: 100%;
+  background: var(--border);
+  transition: background 120ms ease, width 120ms ease;
+}
+.resize-handle:hover::before,
+.resize-handle:focus-visible::before,
+.resize-handle:active::before {
+  width: 4px;
+  background: color-mix(in srgb, var(--accent, #7c8cff) 60%, transparent);
+}
+.resize-handle:focus-visible {
+  outline: none;
 }
 
 /* Dim a collapse toggle when its panel is hidden. */


### PR DESCRIPTION
**Slice 3, part 1 — the wide resize handle.** Draft / hold for local test.

The right-panel divider is now a **real grab target**: 14px hit area, a thin always-visible grip that thickens on hover/focus, **keyboard-resizable** (←/→ nudge, Shift = bigger step, Home/End = max/min), **double-click to reset**. Width still persists via the slice-1 store.

**Held the swap deliberately.** A true "move any surface to either rail" needs unifying surface rendering (today the stage renders the left surfaces, the right panel renders the right ones — different component sets), which is exactly the kind of refactor your *"don't want to overcomplicate it"* was wary of. So this PR is just the handle; see the question on the swap before I touch that.

63 e2e green (added keyboard-resize + double-click-reset), build clean.

**Test on :7901:** grab the divider (easier now), try ←/→ with the handle focused, double-click to reset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)