### PR TITLE
feat(console): unified surface renderer — any surface in either rail (ADR 0035 S3) [HOLD]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Swap surfaces between rails (ADR 0035 slice 3)** — one `renderSurface(id)` now mounts any
+  surface in either rail, and a hover affordance on a rail icon moves it to the other side
+  (persisted). A surface lives on exactly one side. Chat stays pinned left (it mounts
+  unconditionally for streaming continuity).
 - **Resizable right panel — real handle (ADR 0035 slice 3)** — the divider is now a proper
   grab target (14px hit area, visible grip that thickens on hover/focus) and **keyboard-resizable**
   (←/→ nudge, Shift = bigger step, Home/End = max/min) with **double-click to reset**. Width still

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -87,3 +87,25 @@ test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async 
   await expect(page.locator(".rail").getByRole("button", { name: "Agent", exact: true })).toHaveClass(/active/);
   await expect(page.locator(".rail-right").getByRole("button", { name: "Beads", exact: true })).toHaveClass(/active/);
 });
+
+test("a surface moves between rails + persists (ADR 0035 S3 swap)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const leftRail = page.locator(".rail:not(.rail-right)");
+  const rightRail = page.locator(".rail-right");
+
+  // Notes starts on the right rail.
+  await expect(rightRail.getByRole("button", { name: "Notes", exact: true })).toBeVisible();
+
+  // Hover its rail item → click the move-to-left affordance.
+  const item = rightRail.locator(".rail-item", { hasText: "Notes" });
+  await item.hover();
+  await item.getByRole("button", { name: "Move to left rail" }).click();
+
+  // Notes now lives on the LEFT rail and is gone from the right.
+  await expect(leftRail.getByRole("button", { name: "Notes", exact: true })).toBeVisible();
+  await expect(rightRail.getByRole("button", { name: "Notes", exact: true })).toHaveCount(0);
+
+  // Store-backed → survives a reload.
+  await page.reload({ waitUntil: "load" });
+  await expect(leftRail.getByRole("button", { name: "Notes", exact: true })).toBeVisible();
+});

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -88,24 +88,3 @@ test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async 
   await expect(page.locator(".rail-right").getByRole("button", { name: "Beads", exact: true })).toHaveClass(/active/);
 });
 
-test("a surface moves between rails + persists (ADR 0035 S3 swap)", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "load" });
-  const leftRail = page.locator(".rail:not(.rail-right)");
-  const rightRail = page.locator(".rail-right");
-
-  // Notes starts on the right rail.
-  await expect(rightRail.getByRole("button", { name: "Notes", exact: true })).toBeVisible();
-
-  // Hover its rail item → click the move-to-left affordance.
-  const item = rightRail.locator(".rail-item", { hasText: "Notes" });
-  await item.hover();
-  await item.getByRole("button", { name: "Move to left rail" }).click();
-
-  // Notes now lives on the LEFT rail and is gone from the right.
-  await expect(leftRail.getByRole("button", { name: "Notes", exact: true })).toBeVisible();
-  await expect(rightRail.getByRole("button", { name: "Notes", exact: true })).toHaveCount(0);
-
-  // Store-backed → survives a reload.
-  await page.reload({ waitUntil: "load" });
-  await expect(leftRail.getByRole("button", { name: "Notes", exact: true })).toBeVisible();
-});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -241,7 +241,6 @@ export function App() {
   const rightWidth = useUI((s) => s.rightWidth);
   const setRightWidth = useUI((s) => s.setRightWidth);
   const railOf = useUI((s) => s.railOf);
-  const moveSurface = useUI((s) => s.moveSurface);
   const [live, setLive] = useState(false);
   // Shared custom confirm for destructive actions (notes/beads delete).
   const [confirmState, setConfirmState] = useState<
@@ -843,13 +842,6 @@ export function App() {
               onClick={() => setSurface(s.id)}
               badge={s.id === "activity" ? activityUnread + inboxUnread : undefined}
               dot={s.id === "chat" ? chatStreaming && surface !== "chat" : undefined}
-              onMove={s.id === "chat" || s.id.startsWith("plugin:") ? undefined : () => {
-                moveSurface(s.id, "right");
-                setRightPanel(s.id);
-                setRightCollapsed(false);
-                if (surface === s.id) setSurface("chat");
-              }}
-              moveLabel="Move to right rail"
             />
           ))}
         </aside>
@@ -901,12 +893,6 @@ export function App() {
               label={s.label}
               icon={s.icon}
               onClick={() => { setRightPanel(s.id); setRightCollapsed(false); }}
-              onMove={s.id.startsWith("plugin:") ? undefined : () => {
-                moveSurface(s.id, "left");
-                setSurface(s.id);
-                if (rightPanel === s.id) setRightPanel(rightMembers.find((m) => m !== s.id) ?? "notes");
-              }}
-              moveLabel="Move to left rail"
             />
           ))}
         </aside>
@@ -978,8 +964,7 @@ function RailButton({
   onClick,
   badge,
   dot,
-  onMove,
-  moveLabel,
+  onContextMenu,
 }: {
   active: boolean;
   label: string;
@@ -989,35 +974,21 @@ function RailButton({
   // A small pulsing indicator (no count) — e.g. a chat turn streaming in the
   // background while you're on another tab.
   dot?: boolean;
-  // ADR 0035 S3 — when set, a hover "move to other rail" affordance appears.
-  onMove?: () => void;
-  moveLabel?: string;
+  // Right-click hook (ADR 0036) — opens the rail-surface context menu.
+  onContextMenu?: (e: React.MouseEvent) => void;
 }) {
   return (
-    <div className={`rail-item${active ? " active" : ""}`}>
-      <button className={active ? "active" : ""} type="button" onClick={onClick} title={label} aria-label={label}>
-        {icon}
-        <span>{label}</span>
-        {badge ? (
-          <span className="rail-badge" data-testid="activity-badge">
-            {badge > 9 ? "9+" : badge}
-          </span>
-        ) : dot ? (
-          <span className="rail-dot" data-testid="chat-streaming-dot" aria-label="streaming" />
-        ) : null}
-      </button>
-      {onMove ? (
-        <button
-          className="rail-move"
-          type="button"
-          title={moveLabel}
-          aria-label={moveLabel}
-          onClick={(e) => { e.stopPropagation(); onMove(); }}
-        >
-          <PanelRight size={11} />
-        </button>
+    <button className={active ? "active" : ""} type="button" onClick={onClick} onContextMenu={onContextMenu} title={label} aria-label={label}>
+      {icon}
+      <span>{label}</span>
+      {badge ? (
+        <span className="rail-badge" data-testid="activity-badge">
+          {badge > 9 ? "9+" : badge}
+        </span>
+      ) : dot ? (
+        <span className="rail-dot" data-testid="chat-streaming-dot" aria-label="streaming" />
       ) : null}
-    </div>
+    </button>
   );
 }
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -240,6 +240,8 @@ export function App() {
   const setRightCollapsed = useUI((s) => s.setRightCollapsed);
   const rightWidth = useUI((s) => s.rightWidth);
   const setRightWidth = useUI((s) => s.setRightWidth);
+  const railOf = useUI((s) => s.railOf);
+  const moveSurface = useUI((s) => s.moveSurface);
   const [live, setLive] = useState(false);
   // Shared custom confirm for destructive actions (notes/beads delete).
   const [confirmState, setConfirmState] = useState<
@@ -274,7 +276,6 @@ export function App() {
   const pluginRail = allPluginViews.filter((v) => (v.placement ?? "rail") !== "right");
   const pluginRightPanels = allPluginViews.filter((v) => v.placement === "right");
   const activePluginView = pluginRail.find((v) => v.key === surface) ?? null;
-  const activeRightPluginPanel = pluginRightPanels.find((v) => v.key === rightPanel) ?? null;
 
   // Stale-surface fallback: if we're on a plugin view that no longer exists (its
   // plugin was disabled/removed, or a config reload dropped it) — once runtime is
@@ -626,6 +627,154 @@ export function App() {
       Boolean((window as unknown as { __PROTOAGENT_API_BASE__?: string }).__PROTOAGENT_API_BASE__)) &&
     /Mac/i.test(navigator.userAgent);
 
+  // ADR 0035 S3 — surface metadata + one renderer, so any surface mounts in either rail.
+  // Chat is excluded here: it mounts unconditionally in its rail's area (streaming continuity)
+  // and is pinned left (railOf.chat is never moved).
+  const CORE_SURFACES: { id: string; label: string; icon: ReactNode }[] = [
+    { id: "chat", label: "Chat", icon: <MessageSquare size={18} /> },
+    { id: "activity", label: "Activity", icon: <Activity size={18} /> },
+    { id: "studio", label: "Studio", icon: <Boxes size={18} /> },
+    { id: "knowledge", label: "Knowledge", icon: <BookMarked size={18} /> },
+    { id: "agent", label: "Agent", icon: <Bot size={18} /> },
+    { id: "plugins", label: "Plugins", icon: <Puzzle size={18} /> },
+    { id: "settings", label: "Settings", icon: <Settings2 size={18} /> },
+    { id: "notes", label: "Notes", icon: <FileText size={18} /> },
+    { id: "beads", label: "Beads", icon: <Boxes size={18} /> },
+    { id: "goals", label: "Goals", icon: <Target size={18} /> },
+    { id: "schedule", label: "Schedule", icon: <CalendarClock size={18} /> },
+  ];
+  // Surfaces (+ plugin views) assigned to a rail side. Plugin views follow their manifest
+  // placement (rail→left, right→right); core surfaces follow railOf. Chat is always left.
+  function railSurfaces(side: "left" | "right"): { id: string; label: string; icon: ReactNode }[] {
+    const core = CORE_SURFACES.filter((s) => (s.id === "chat" ? side === "left" : (railOf[s.id] ?? "left") === side));
+    const plugins = (side === "left" ? pluginRail : pluginRightPanels).map((v) => ({
+      id: v.key, label: v.label, icon: pluginViewIcon(v.icon),
+    }));
+    return [...core, ...plugins];
+  }
+
+  function renderSurface(id: string): ReactNode {
+    switch (id) {
+      case "activity":
+        return (
+          <>
+            <StageSubnav active={activityTab} onSelect={(t) => setActivityTab(t as ActivityTab)} tabs={[
+              { id: "thread", label: "Thread", icon: Activity },
+              { id: "inbox", label: "Inbox", icon: Inbox, badge: inboxUnread ? (<span className="subnav-badge" data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span>) : null },
+            ]} />
+            {activityTab === "thread" ? <ActivitySurface onError={setError} /> : <InboxPanel />}
+          </>
+        );
+      case "studio":
+        return <WorkflowsSurface />;
+      case "agent":
+        return (
+          <>
+            <StageSubnav active={agentTab} onSelect={(t) => setAgentTab(t as AgentTab)} tabs={[
+              { id: "identity", label: "Identity", icon: Sparkles },
+              { id: "settings", label: "Settings", icon: Settings2 },
+              { id: "tools", label: "Tools", icon: Wrench },
+              { id: "mcp", label: "MCP", icon: Plug },
+              { id: "subagents", label: "Subagents", icon: Bot },
+              { id: "skills", label: "Skills", icon: BookMarked },
+              { id: "middleware", label: "Middleware", icon: Layers },
+            ]} />
+            {agentTab === "identity" ? <IdentityPanel /> : null}
+            {agentTab === "settings" ? <SettingsCategoryPanel category="Agent" title="Settings" /> : null}
+            {agentTab === "tools" ? <ToolsPanel /> : null}
+            {agentTab === "mcp" ? <McpPanel /> : null}
+            {agentTab === "subagents" ? <SubagentsPanel /> : null}
+            {agentTab === "skills" ? <PlaybooksSurface onError={setError} /> : null}
+            {agentTab === "middleware" ? <MiddlewarePanel /> : null}
+          </>
+        );
+      case "plugins":
+        return (
+          <>
+            <StageSubnav active={pluginsTab} onSelect={(t) => setPluginsTab(t as PluginsTab)} tabs={[
+              { id: "local", label: "Local", icon: Boxes },
+              { id: "market", label: "Market", icon: Store },
+              { id: "download", label: "Download", icon: Download },
+            ]} />
+            <PluginsSurface tab={pluginsTab} />
+          </>
+        );
+      case "knowledge":
+        return (
+          <>
+            <StageSubnav active={knowledgeTab} onSelect={(t) => setKnowledgeTab(t as KnowledgeTab)} tabs={[
+              { id: "store", label: "Store", icon: Database },
+              { id: "settings", label: "Settings", icon: Settings2 },
+            ]} />
+            {knowledgeTab === "store" ? <KnowledgeStore onError={setError} /> : <SettingsCategoryPanel category="Memory" title="Settings" />}
+          </>
+        );
+      case "settings":
+        return (
+          <>
+            <StageSubnav active={settingsTab} onSelect={(t) => setSettingsTab(t as SettingsTab)} tabs={SETTINGS_TABS.map((t) => ({ id: t.id, label: t.label, icon: t.icon }))} />
+            <SettingsSurface tab={settingsTab} />
+          </>
+        );
+      case "notes":
+        return (
+          <section className="panel side-panel notes-panel">
+            <PanelHeader
+              compact
+              title={activeTab?.name || "Notes"}
+              kicker={workspace ? `${workspace.tabOrder.length} tab${workspace.tabOrder.length === 1 ? "" : "s"}${notesDirty ? " • unsaved" : ""}` : "not loaded"}
+              actions={
+                <>
+                  <button className="icon-button" type="button" onClick={createNote} disabled={!workspace} title="New note"><Plus size={16} /></button>
+                  <button className="icon-button" type="button" onClick={deleteActiveNote} disabled={!workspace || workspace.tabOrder.length <= 1} title="Delete note"><Trash2 size={16} /></button>
+                  <button className="icon-button" type="button" onClick={undoActiveNote} disabled={!canUndoNote} title="Undo last change"><Undo2 size={16} /></button>
+                  <button className="icon-button" type="button" onClick={() => void persistNotes()} disabled={!workspace || notesBusy} title="Save notes">{notesBusy ? <Loader2 className="spin" size={16} /> : <Save size={16} />}</button>
+                </>
+              }
+            />
+            {workspace ? (
+              <div className="notes-tabbar">
+                {workspace.tabOrder.map((tabId) => {
+                  const tab = workspace.tabs[tabId];
+                  if (!tab) return null;
+                  return (
+                    <button className={tab.id === workspace.activeTabId ? "active" : ""} type="button" key={tab.id} onClick={() => updateWorkspace({ ...workspace, activeTabId: tab.id })}>
+                      {tab.name || "Notes"}
+                    </button>
+                  );
+                })}
+              </div>
+            ) : null}
+            {activeTab ? (
+              <div className="notes-meta">
+                <input value={activeTab.name} onChange={(e) => renameActiveNote(e.target.value)} aria-label="Note name" />
+                <label className="checkbox-field"><input type="checkbox" checked={activeTab.permissions.agentRead} onChange={(e) => toggleActiveNotePermission("agentRead", e.target.checked)} /><span>Agent read</span></label>
+                <label className="checkbox-field"><input type="checkbox" checked={activeTab.permissions.agentWrite} onChange={(e) => toggleActiveNotePermission("agentWrite", e.target.checked)} /><span>Agent write</span></label>
+              </div>
+            ) : null}
+            <textarea className="notes-editor" value={activeTab?.content || ""} onChange={(e) => saveActiveNote(e.target.value)} placeholder="Project notes" disabled={!workspace} />
+          </section>
+        );
+      case "beads":
+        return <BeadsPanel confirm={setConfirmState} />;
+      case "goals":
+        return <GoalsPanel />;
+      case "schedule":
+        return <SchedulePanel />;
+      default: {
+        const v = allPluginViews.find((x) => x.key === id);
+        return v ? <PluginView key={v.key} view={v} /> : null;
+      }
+    }
+  }
+
+  // Active surface per rail, clamped to a member of that rail (so a moved surface doesn't
+  // leave a stale active). Chat is the left fallback; the first right member is the right one.
+  const leftMembers = railSurfaces("left").map((s) => s.id);
+  const rightMembers = railSurfaces("right").map((s) => s.id);
+  const leftActive = leftMembers.includes(surface) ? surface : "chat";
+  const rightActive = rightMembers.includes(rightPanel) ? rightPanel : (rightMembers[0] ?? "notes");
+
   return (
     <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
       <IntroSplash />
@@ -682,59 +831,25 @@ export function App() {
         className={`workspace ${rightCollapsed ? "right-collapsed" : ""}`}
         style={{ "--right-width": rightCol } as CSSProperties}
       >
+        {/* Left rail (ADR 0035) — members from railOf; hover a (non-Chat, non-plugin) icon to
+            send it to the right rail. Chat is pinned left. */}
         <aside className="rail" aria-label="Workspace surfaces">
-          <RailButton
-            active={surface === "chat"}
-            label="Chat"
-            icon={<MessageSquare size={18} />}
-            onClick={() => setSurface("chat")}
-            dot={chatStreaming && surface !== "chat"}
-          />
-          <RailButton
-            active={surface === "activity"}
-            label="Activity"
-            icon={<Activity size={18} />}
-            onClick={() => setSurface("activity")}
-            badge={activityUnread + inboxUnread}
-          />
-          <RailButton
-            active={surface === "studio"}
-            label="Studio"
-            icon={<Boxes size={18} />}
-            onClick={() => setSurface("studio")}
-          />
-          <RailButton
-            active={surface === "knowledge"}
-            label="Knowledge"
-            icon={<BookMarked size={18} />}
-            onClick={() => setSurface("knowledge")}
-          />
-          <RailButton
-            active={surface === "agent"}
-            label="Agent"
-            icon={<Bot size={18} />}
-            onClick={() => setSurface("agent")}
-          />
-          <RailButton
-            active={surface === "plugins"}
-            label="Plugins"
-            icon={<Puzzle size={18} />}
-            onClick={() => setSurface("plugins")}
-          />
-          <RailButton
-            active={surface === "settings"}
-            label="Settings"
-            icon={<Settings2 size={18} />}
-            onClick={() => setSurface("settings")}
-          />
-          {/* Plugin-contributed rail surfaces (ADR 0026) — dynamic, from runtime-status. */}
-          {pluginRail.map((v) => (
+          {railSurfaces("left").map((s) => (
             <RailButton
-              key={v.key}
-              active={surface === v.key}
-              label={v.label}
-              icon={pluginViewIcon(v.icon)}
-              onClick={() => setSurface(v.key)}
+              key={s.id}
+              active={leftActive === s.id}
+              label={s.label}
+              icon={s.icon}
+              onClick={() => setSurface(s.id)}
+              badge={s.id === "activity" ? activityUnread + inboxUnread : undefined}
+              dot={s.id === "chat" ? chatStreaming && surface !== "chat" : undefined}
+              onMove={s.id === "chat" || s.id.startsWith("plugin:") ? undefined : () => {
+                moveSurface(s.id, "right");
+                setRightPanel(s.id);
+                setRightCollapsed(false);
+                if (surface === s.id) setSurface("chat");
+              }}
+              moveLabel="Move to right rail"
             />
           ))}
         </aside>
@@ -747,101 +862,11 @@ export function App() {
             </div>
           ) : null}
 
-          {/* Sub-nav for the grouped rail surfaces — the canonical strip above the
-              panel card (StageSubnav: single source of truth, shared with Settings +
-              plugin views). */}
-          {surface === "activity" ? (
-            <StageSubnav
-              active={activityTab}
-              onSelect={(id) => setActivityTab(id as typeof activityTab)}
-              tabs={[
-                { id: "thread", label: "Thread", icon: Activity },
-                {
-                  id: "inbox", label: "Inbox", icon: Inbox,
-                  badge: inboxUnread ? (
-                    <span className="subnav-badge" data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span>
-                  ) : null,
-                },
-              ]}
-            />
-          ) : null}
-          {surface === "agent" ? (
-            <StageSubnav
-              active={agentTab}
-              onSelect={(id) => setAgentTab(id as typeof agentTab)}
-              tabs={[
-                { id: "identity", label: "Identity", icon: Sparkles },
-                { id: "settings", label: "Settings", icon: Settings2 },
-                { id: "tools", label: "Tools", icon: Wrench },
-                { id: "mcp", label: "MCP", icon: Plug },
-                { id: "subagents", label: "Subagents", icon: Bot },
-                { id: "skills", label: "Skills", icon: BookMarked },
-                { id: "middleware", label: "Middleware", icon: Layers },
-              ]}
-            />
-          ) : null}
-
-          {surface === "plugins" ? (
-            <StageSubnav
-              active={pluginsTab}
-              onSelect={(id) => setPluginsTab(id as PluginsTab)}
-              tabs={[
-                { id: "local", label: "Local", icon: Boxes },
-                { id: "market", label: "Market", icon: Store },
-                { id: "download", label: "Download", icon: Download },
-              ]}
-            />
-          ) : null}
-
-          {surface === "knowledge" ? (
-            <StageSubnav
-              active={knowledgeTab}
-              onSelect={(id) => setKnowledgeTab(id as KnowledgeTab)}
-              tabs={[
-                { id: "store", label: "Store", icon: Database },
-                { id: "settings", label: "Settings", icon: Settings2 },
-              ]}
-            />
-          ) : null}
-
-          {surface === "settings" ? (
-            <StageSubnav
-              active={settingsTab}
-              onSelect={(id) => setSettingsTab(id as SettingsTab)}
-              tabs={SETTINGS_TABS.map((t) => ({ id: t.id, label: t.label, icon: t.icon }))}
-            />
-          ) : null}
-
-          {/* ChatSurface is rendered UNCONDITIONALLY and hidden via `active` when
-              off-tab — so an in-flight turn keeps streaming in the background and
-              the chat is progressing when you navigate back (not torn down). */}
-          <ChatSurface onError={setError} active={surface === "chat"} />
-
-          {surface === "studio" ? <WorkflowsSurface /> : null}
-
-          {surface === "activity" && activityTab === "thread" ? <ActivitySurface onError={setError} /> : null}
-          {surface === "activity" && activityTab === "inbox" ? <InboxPanel /> : null}
-
-
-          {surface === "agent" && agentTab === "identity" ? <IdentityPanel /> : null}
-          {surface === "agent" && agentTab === "settings" ? <SettingsCategoryPanel category="Agent" title="Settings" /> : null}
-          {surface === "agent" && agentTab === "tools" ? <ToolsPanel /> : null}
-          {surface === "agent" && agentTab === "mcp" ? <McpPanel /> : null}
-          {surface === "agent" && agentTab === "subagents" ? <SubagentsPanel /> : null}
-          {surface === "agent" && agentTab === "skills" ? <PlaybooksSurface onError={setError} /> : null}
-          {surface === "agent" && agentTab === "middleware" ? <MiddlewarePanel /> : null}
-          {surface === "plugins" ? <PluginsSurface tab={pluginsTab} /> : null}
-          {surface === "knowledge" && knowledgeTab === "store" ? <KnowledgeStore onError={setError} /> : null}
-          {surface === "knowledge" && knowledgeTab === "settings" ? <SettingsCategoryPanel category="Memory" title="Settings" /> : null}
-          {surface === "settings" ? <SettingsSurface tab={settingsTab} /> : null}
-
-          {/* Plugin view (ADR 0026) — the plugin serves the page; PluginView hosts
-              it in a same-origin iframe. ChatSurface stays mounted above (hidden)
-              so chat continuity holds while a plugin view is open. Keyed so
-              switching views resets the iframe's load state. */}
-          {activePluginView ? (
-            <PluginView key={activePluginView.key} view={activePluginView} />
-          ) : null}
+          {/* Chat mounts UNCONDITIONALLY + hidden via `active` (streaming continuity, #613);
+              it's pinned to the left rail. Every other left-rail surface renders through the
+              shared renderSurface (ADR 0035 S3) — so it can live on either rail. */}
+          <ChatSurface onError={setError} active={leftActive === "chat"} />
+          {leftActive !== "chat" ? renderSurface(leftActive) : null}
         </main>
 
         <aside className="right-panel">
@@ -861,113 +886,27 @@ export function App() {
               data-testid="right-resize"
             />
           ) : null}
-          {activeRightPluginPanel ? (
-            <PluginView key={activeRightPluginPanel.key} view={activeRightPluginPanel} />
-          ) : null}
-
-          {rightPanel === "notes" ? (
-            <section className="panel side-panel notes-panel">
-              <PanelHeader
-                compact
-                title={activeTab?.name || "Notes"}
-                kicker={workspace ? `${workspace.tabOrder.length} tab${workspace.tabOrder.length === 1 ? "" : "s"}${notesDirty ? " • unsaved" : ""}` : "not loaded"}
-                actions={
-                  <>
-                    <button className="icon-button" type="button" onClick={createNote} disabled={!workspace} title="New note">
-                      <Plus size={16} />
-                    </button>
-                    <button className="icon-button" type="button" onClick={deleteActiveNote} disabled={!workspace || workspace.tabOrder.length <= 1} title="Delete note">
-                      <Trash2 size={16} />
-                    </button>
-                    <button className="icon-button" type="button" onClick={undoActiveNote} disabled={!canUndoNote} title="Undo last change">
-                      <Undo2 size={16} />
-                    </button>
-                    <button className="icon-button" type="button" onClick={() => void persistNotes()} disabled={!workspace || notesBusy} title="Save notes">
-                      {notesBusy ? <Loader2 className="spin" size={16} /> : <Save size={16} />}
-                    </button>
-                  </>
-                }
-              />
-              {workspace ? (
-                <div className="notes-tabbar">
-                  {workspace.tabOrder.map((tabId) => {
-                    const tab = workspace.tabs[tabId];
-                    if (!tab) return null;
-                    const active = tab.id === workspace.activeTabId;
-                    return (
-                      <button className={active ? "active" : ""} type="button" key={tab.id} onClick={() => updateWorkspace({ ...workspace, activeTabId: tab.id })}>
-                        {tab.name || "Notes"}
-                      </button>
-                    );
-                  })}
-                </div>
-              ) : null}
-              {activeTab ? (
-                <div className="notes-meta">
-                  <input
-                    value={activeTab.name}
-                    onChange={(event) => renameActiveNote(event.target.value)}
-                    aria-label="Note name"
-                  />
-                  <label className="checkbox-field">
-                    <input
-                      type="checkbox"
-                      checked={activeTab.permissions.agentRead}
-                      onChange={(event) => toggleActiveNotePermission("agentRead", event.target.checked)}
-                    />
-                    <span>Agent read</span>
-                  </label>
-                  <label className="checkbox-field">
-                    <input
-                      type="checkbox"
-                      checked={activeTab.permissions.agentWrite}
-                      onChange={(event) => toggleActiveNotePermission("agentWrite", event.target.checked)}
-                    />
-                    <span>Agent write</span>
-                  </label>
-                </div>
-              ) : null}
-              <textarea
-                className="notes-editor"
-                value={activeTab?.content || ""}
-                onChange={(event) => saveActiveNote(event.target.value)}
-                placeholder="Project notes"
-                disabled={!workspace}
-              />
-            </section>
-          ) : null}
-
-          {rightPanel === "beads" ? <BeadsPanel confirm={setConfirmState} /> : null}
-
-          {rightPanel === "goals" ? <GoalsPanel /> : null}
-          {rightPanel === "schedule" ? <SchedulePanel /> : null}
+          {/* The right surface renders through the same renderSurface as the left (ADR 0035
+              S3) — so notes/beads/goals/schedule (or anything moved here) mount identically. */}
+          {!rightCollapsed ? renderSurface(rightActive) : null}
         </aside>
 
-        {/* Right rail (ADR 0035 D1) — mirrors the left rail on the far edge; its surfaces
-            (Notes/Beads/Goals/Schedule + plugin right-views) replace the old segmented strip.
-            Picking one ensures the right surface is expanded. */}
+        {/* Right rail (ADR 0035 D1/D2) — mirrors the left on the far edge; members from railOf.
+            Hover a (non-plugin) icon to send it to the left rail. */}
         <aside className="rail rail-right" aria-label="Context surfaces">
-          {([
-            ["notes", "Notes", <FileText size={18} />],
-            ["beads", "Beads", <Boxes size={18} />],
-            ["goals", "Goals", <Target size={18} />],
-            ["schedule", "Schedule", <CalendarClock size={18} />],
-          ] as const).map(([key, label, icon]) => (
+          {railSurfaces("right").map((s) => (
             <RailButton
-              key={key}
-              active={rightPanel === key && !rightCollapsed}
-              label={label}
-              icon={icon}
-              onClick={() => { setRightPanel(key); setRightCollapsed(false); }}
-            />
-          ))}
-          {pluginRightPanels.map((v) => (
-            <RailButton
-              key={v.key}
-              active={rightPanel === v.key && !rightCollapsed}
-              label={v.label}
-              icon={pluginViewIcon(v.icon)}
-              onClick={() => { setRightPanel(v.key); setRightCollapsed(false); }}
+              key={s.id}
+              active={rightActive === s.id && !rightCollapsed}
+              label={s.label}
+              icon={s.icon}
+              onClick={() => { setRightPanel(s.id); setRightCollapsed(false); }}
+              onMove={s.id.startsWith("plugin:") ? undefined : () => {
+                moveSurface(s.id, "left");
+                setSurface(s.id);
+                if (rightPanel === s.id) setRightPanel(rightMembers.find((m) => m !== s.id) ?? "notes");
+              }}
+              moveLabel="Move to left rail"
             />
           ))}
         </aside>
@@ -1039,6 +978,8 @@ function RailButton({
   onClick,
   badge,
   dot,
+  onMove,
+  moveLabel,
 }: {
   active: boolean;
   label: string;
@@ -1048,19 +989,35 @@ function RailButton({
   // A small pulsing indicator (no count) — e.g. a chat turn streaming in the
   // background while you're on another tab.
   dot?: boolean;
+  // ADR 0035 S3 — when set, a hover "move to other rail" affordance appears.
+  onMove?: () => void;
+  moveLabel?: string;
 }) {
   return (
-    <button className={active ? "active" : ""} type="button" onClick={onClick} title={label} aria-label={label}>
-      {icon}
-      <span>{label}</span>
-      {badge ? (
-        <span className="rail-badge" data-testid="activity-badge">
-          {badge > 9 ? "9+" : badge}
-        </span>
-      ) : dot ? (
-        <span className="rail-dot" data-testid="chat-streaming-dot" aria-label="streaming" />
+    <div className={`rail-item${active ? " active" : ""}`}>
+      <button className={active ? "active" : ""} type="button" onClick={onClick} title={label} aria-label={label}>
+        {icon}
+        <span>{label}</span>
+        {badge ? (
+          <span className="rail-badge" data-testid="activity-badge">
+            {badge > 9 ? "9+" : badge}
+          </span>
+        ) : dot ? (
+          <span className="rail-dot" data-testid="chat-streaming-dot" aria-label="streaming" />
+        ) : null}
+      </button>
+      {onMove ? (
+        <button
+          className="rail-move"
+          type="button"
+          title={moveLabel}
+          aria-label={moveLabel}
+          onClick={(e) => { e.stopPropagation(); onMove(); }}
+        >
+          <PanelRight size={11} />
+        </button>
       ) : null}
-    </button>
+    </div>
   );
 }
 

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3326,3 +3326,23 @@ textarea {
   color: var(--fg-muted);
   word-break: break-word;
 }
+
+/* Rail item wrapper + hover "move to other rail" affordance (ADR 0035 S3). */
+.rail-item { position: relative; }
+.rail .rail-move {
+  position: absolute;
+  top: 3px;
+  right: 3px;
+  min-height: 0;
+  width: auto;
+  gap: 0;
+  display: none;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  background: var(--bg-panel);
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.rail .rail-item:hover .rail-move { display: inline-flex; }
+.rail .rail-move:hover { color: var(--fg); border-color: var(--accent, #7c8cff); }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3327,22 +3327,3 @@ textarea {
   word-break: break-word;
 }
 
-/* Rail item wrapper + hover "move to other rail" affordance (ADR 0035 S3). */
-.rail-item { position: relative; }
-.rail .rail-move {
-  position: absolute;
-  top: 3px;
-  right: 3px;
-  min-height: 0;
-  width: auto;
-  gap: 0;
-  display: none;
-  padding: 3px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg-panel);
-  color: var(--fg-muted);
-  cursor: pointer;
-}
-.rail .rail-item:hover .rail-move { display: inline-flex; }
-.rail .rail-move:hover { color: var(--fg); border-color: var(--accent, #7c8cff); }

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -39,6 +39,11 @@ type UIState = {
   activityTab: ActivityTab;
   rightCollapsed: boolean;
   rightWidth: number;
+  // Which rail each surface lives on (ADR 0035 D2) — a surface is on exactly one side.
+  // Core surfaces seeded below; plugin views default by their manifest `placement`. Chat is
+  // pinned left (it mounts unconditionally for streaming continuity), so it isn't moved.
+  railOf: Record<string, "left" | "right">;
+  moveSurface: (id: string, side: "left" | "right") => void;
   setSurface: (s: Surface) => void;
   setRightPanel: (p: RightPanel) => void;
   setAgentTab: (t: AgentTab) => void;
@@ -62,6 +67,12 @@ export const useUI = create<UIState>()(
       activityTab: "thread",
       rightCollapsed: false,
       rightWidth: 360,
+      railOf: {
+        chat: "left", activity: "left", studio: "left", knowledge: "left",
+        agent: "left", plugins: "left", settings: "left",
+        notes: "right", beads: "right", goals: "right", schedule: "right",
+      },
+      moveSurface: (id, side) => set((s) => ({ railOf: { ...s.railOf, [id]: side } })),
       setSurface: (surface) => set({ surface }),
       setRightPanel: (rightPanel) => set({ rightPanel }),
       setAgentTab: (agentTab) => set({ agentTab }),


### PR DESCRIPTION
**The swap — slice 3's payoff.** Draft / **hold for your local test** (this is the big core-render change).

One **`renderSurface(id)`** closure now renders *any* surface, so both rails mount any surface identically. A **hover affordance** on each rail icon moves it to the other rail, **persisted** (`railOf`). A surface lives on exactly one side.

**Chat is pinned left** and still mounts unconditionally (streaming continuity, #613) — it's excluded from the renderer + not movable. That's the one invariant I protected.

- Consolidated the stage + right-panel per-surface render blocks (incl. the Notes block) into the single renderer — the old `{surface === X ? … }` sprawl is gone.
- `leftActive`/`rightActive` clamp to a rail member so a moved surface never leaves a stale active.
- 64 e2e green (added move-between-rails + persist); build clean.

**Test hard on :7901** (this touched the core render): every surface should render in both rails; hover a rail icon → a small move button → click sends it across (and persists on reload); Chat stays put + keeps streaming when you navigate away. Tell me anything that feels off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)