### PR TITLE
docs(adr): 0036 — unified context-menu system (+ plugin-contributed items)

### DIFF
--- a/docs/adr/0036-context-menu-system.md
+++ b/docs/adr/0036-context-menu-system.md
@@ -1,0 +1,100 @@
+# ADR 0036 — A unified context-menu system (+ plugin-contributed items)
+
+**Status:** Proposed
+
+## Context
+
+We keep reaching for per-feature affordances to expose actions — and they don't scale. The
+ADR 0035 "move surface to the other rail" started as hover buttons on each rail icon; they
+broke the rail layout and added visual noise. The real need is broader: a **right-click context
+menu** as a first-class, app-wide primitive — tight, consistent, and **extensible, including by
+plugins** (a plugin should be able to add items to an existing menu or define its own).
+
+**Reference (studied):** `rabbit-hole.io` (`~/dev/rabbit-hole.io`) ships exactly this — a
+Zustand-backed context-menu module with a **registry keyed by a `ContextType`** string,
+`ContextMenuRegistration`s (with optional route + priority), a single imperative
+`openContextMenu(type, x, y, ctx)` + one renderer, and menu items as `{ id, label, icon, action,
+disabled, visible, variant, shortcut }`. It uses Radix's *DropdownMenu* (not ContextMenu) so the
+menu opens at arbitrary coordinates without wrapping every target. We adopt that shape.
+
+## Decision
+
+### D1 — One imperative, state-driven menu
+
+A single menu, driven by store state `{ open, type, x, y, context }`. Any element opens it from
+an `onContextMenu` handler via `openContextMenu(type, e, ctx)` (we `preventDefault` the native
+menu). One `<ContextMenuRenderer>` mounted at the app root renders the active menu at the
+cursor. Imperative open-at-coords (not wrap-each-target) so *anything* can be a trigger.
+
+### D2 — A registry keyed by `ContextType`
+
+`registerContextMenu({ type, items, priority? })` where `type` is an open string
+(`"rail-surface"`, `"chat-message"`, `"note"`, `"bead"`, `"background"`, … + plugin types) and
+`items` is a `MenuItem[]` or `(ctx) => MenuItem[]`. On open, the registry **merges all
+registrations for that type**, priority-sorted and **deduped by item id**, into the rendered menu.
+This is the extension point: core features and plugins register independently; the menu for a
+type is the union.
+
+### D3 — Item shape
+
+```ts
+type MenuItem =
+  | { id; label: string | ((ctx) => string); icon?; run: (ctx, helpers) => void | Promise<void>;
+      disabled?: boolean | ((ctx) => boolean); visible?: boolean | ((ctx) => boolean);
+      danger?: boolean; shortcut?: string; submenu?: MenuItem[] }
+  | { id; divider: true }
+  | { id; section: string; items: MenuItem[] };
+```
+
+`helpers` = `{ close, toast, navigate, … }`. `label`/`disabled`/`visible` may be functions of the
+right-clicked `context`, so one registration adapts per target.
+
+### D4 — Plugins contribute items (the point)
+
+The **`@protoagent/plugin-ui` SDK** (ADR 0034) re-exports `registerContextMenu`, so a first-class
+React plugin adds items to a **core** menu type (e.g. an extra action on `"bead"`) **or** defines
+its **own** type for its surfaces. Items run with console privileges, so this rides the **same
+trust gate as `ui: react`** (ADR 0034 D5 — trusted/first-party; untrusted third-party doesn't get
+in-process menu items). A manifest-declared *static* item path (label + a tool/route to invoke)
+is a later, lower-trust option for iframe plugins.
+
+### D5 — Lean, custom renderer (no heavy dep)
+
+Build a small custom menu component to match our design system (positioned popover, viewport-flip,
+keyboard nav, Escape + click-away) rather than pull in Radix — consistent with lean-core. (Radix's
+DropdownMenu is the fallback if a11y proves fiddly; the registry/store is library-agnostic.)
+
+### D6 — First customers
+
+- **`rail-surface`** (ADR 0035): right-click a rail icon → **Move to other rail** (replacing the
+  removed hover buttons), Collapse, and later **Pin to mobile quick-bar** (0035 S4).
+- Then **`chat-message`** (copy / retry / cite), **`note`**, **`bead`** — replacing today's
+  ad-hoc inline buttons with a consistent menu.
+
+## Consequences
+
+- **One primitive, many menus** — consistent right-click behavior; new actions are a registration,
+  not bespoke UI. Kills layout-noise affordances like the rail hover buttons.
+- **A real plugin extension surface** — plugins shape the console's menus, not just add views.
+- **A maintained contract** (`MenuItem`, `ContextType`, the registry API) — versioned with the
+  plugin-ui SDK.
+- **Trust boundary** — in-process menu items are privileged; gated like `ui: react` (D4).
+- **Discoverability caveat** — right-click is less discoverable on touch; the mobile shell (0035
+  S4) keeps primary actions reachable without it (long-press can map to the same menu later).
+
+## Build order (proposed slices)
+
+1. **Core** — store state + `registerContextMenu` registry + `<ContextMenuRenderer>` (custom,
+   lean) + an `openContextMenu` helper. Wire the **`rail-surface`** menu (Move to other rail —
+   uses the `railOf`/`moveSurface` foundation already in the store from ADR 0035 S3).
+2. **SDK export** — `registerContextMenu` from `@protoagent/plugin-ui` (depends on ADR 0034 S2)
+   under the trust gate (0034 S3); a reference plugin item.
+3. **More core menus** — `chat-message`, `note`, `bead` (retire their ad-hoc buttons).
+4. *(optional)* manifest-declared static items for iframe/untrusted plugins.
+
+## References
+
+- `rabbit-hole.io` context-menu module (`apps/rabbit-hole/app/context-menu/` — the registry +
+  imperative-open pattern this adopts).
+- ADR 0034 (plugin UI as first-class React — the SDK that re-exports `registerContextMenu`, and
+  the trust gate it inherits), ADR 0035 (rail surfaces — the `rail-surface` menu is customer #1).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -44,3 +44,4 @@ decision, numbered, never deleted (supersede instead).
 | [0033](./0033-pluggable-agent-runtime-acp.md) | Pluggable agent runtime (ACP executor) — runtime≠model axis, operator-tools MCP bus, context contract + caching | Proposed |
 | [0034](./0034-plugin-ui-first-class-react.md) | Plugin UI as first-class React (Module Federation) — `ui: react` remotes + shared singletons + plugin-ui SDK + trust gate; Notes is the reference port | Proposed |
 | [0035](./0035-console-layout-dual-rail-mobile-first.md) | Console layout — symmetric dual-rail (swappable surfaces), one tab style, mobile-first (bottom quick-bar + hamburger), persisted UI state (Zustand) | Proposed |
+| [0036](./0036-context-menu-system.md) | Unified context-menu system (right-click) — Zustand store + `ContextType` registry + one renderer; plugins contribute items via the plugin-ui SDK (trust-gated); replaces ad-hoc affordances | Proposed |


### PR DESCRIPTION
Per your call — invest in a real **right-click context-menu system** for the whole app (and kill the layout-breaking rail hover buttons, already removed on #743). Modeled on **rabbit-hole.io**'s pattern (which I studied at `~/dev/rabbit-hole.io`).

**The design:**
- One imperative, state-driven menu: `openContextMenu(type, e, ctx)` from any `onContextMenu`; a single `<ContextMenuRenderer>` at the root.
- A **registry keyed by `ContextType`** (open string): `registerContextMenu({ type, items, priority })`. The menu for a type is the **merged union** of all registrations (priority-sorted, id-deduped) — so core *and* plugins extend the same menu.
- Item shape with `label/disabled/visible` as functions of the right-clicked context, dividers, sections, submenus, danger, shortcuts.
- **Plugins contribute** via `@protoagent/plugin-ui`'s `registerContextMenu` (ADR 0034) — add items to a core menu or define their own type. **Trust-gated** like `ui: react` (in-process = privileged).
- **Lean custom renderer** (no Radix) to match our DS + bundle.
- **First customer:** the `rail-surface` menu → *Move to other rail* (replaces the removed buttons, using the `railOf`/`moveSurface` store foundation), then `chat-message` / `note` / `bead`.

**Slices:** core (store+registry+renderer + rail-surface menu) → SDK export (trust-gated) → more core menus → optional manifest static-items for iframe plugins.

Status **Proposed** — review + Quinn before I build slice 1. This slots in alongside the 0035 layout work (the rail-surface menu is where the swap trigger lands).

🤖 Generated with [Claude Code](https://claude.com/claude-code)