### PR TITLE
docs(adr): 0037 — design-system foundation (Tailwind + @protolabsai/design + shadcn/Radix)

### DIFF
--- a/docs/adr/0036-context-menu-system.md
+++ b/docs/adr/0036-context-menu-system.md
@@ -58,11 +58,14 @@ trust gate as `ui: react`** (ADR 0034 D5 — trusted/first-party; untrusted thir
 in-process menu items). A manifest-declared *static* item path (label + a tool/route to invoke)
 is a later, lower-trust option for iframe plugins.
 
-### D5 — Lean, custom renderer (no heavy dep)
+### D5 — Renderer → shadcn Radix `DropdownMenu` (superseded by ADR 0037)
 
-Build a small custom menu component to match our design system (positioned popover, viewport-flip,
-keyboard nav, Escape + click-away) rather than pull in Radix — consistent with lean-core. (Radix's
-DropdownMenu is the fallback if a11y proves fiddly; the registry/store is library-agnostic.)
+> **Updated by [ADR 0037](./0037-design-system-foundation.md).** We adopt Radix + shadcn as the
+> component foundation, so the renderer is shadcn's Radix `DropdownMenu` (imperative open-at-coords)
+> themed by the `@protolabsai/design` tokens — accessibility (focus, keyboard, dismissal) for free,
+> closing the a11y gap Quinn flagged. The registry / `ContextType` / store design (D1–D4) is
+> **unchanged**; only the renderer implementation. (The original "lean custom renderer, no Radix"
+> intent is reversed.)
 
 ### D6 — First customers
 

--- a/docs/adr/0037-design-system-foundation.md
+++ b/docs/adr/0037-design-system-foundation.md
@@ -1,0 +1,99 @@
+# ADR 0037 — Design-system foundation: Tailwind + `@protolabsai/design` + shadcn/Radix
+
+**Status:** Proposed
+
+## Context
+
+The console (`apps/web`) is hand-rolled CSS (`theme.css`) with bespoke components. It works, but:
+it's not on the **protoLabs design system**, components aren't reusable/themeable in a standard
+way, and there's no accessible primitive layer (the ADR 0036 context menu would have to re-solve
+focus/keyboard a11y from scratch). We want to move the console onto **protoContent's design
+system** and adopt **Radix + shadcn** as the component foundation — so components are
+componentized, themable, accessible, and shareable (incl. to plugin remotes, ADR 0034).
+
+**What protoContent gives us.** `@protolabsai/design@^0.3.0` (already a root dependency, used by
+the docs theme) is a **tokens + Tailwind-preset + brand-assets** package — *not* components:
+
+- `@protolabsai/design/tailwind` — a **Tailwind preset** mapping brand tokens into the theme
+  (`bg-bg`, `text-fg-muted`, `brand`/`brand-lavender`, `font-mono`, `shadow-glow`,
+  `bg-brand-gradient`, …), generated from the locked token source so it never drifts.
+- `@protolabsai/design/css/tokens` — the CSS custom properties (`--pl-color-*`, `--pl-font-*`,
+  `--pl-motion-*`, …); `…/css/base`, `…/assets/*`.
+
+So **themable components = shadcn/Radix components styled with Tailwind utilities that resolve to
+the brand tokens.** This ADR adopts that stack and supersedes the vague "DS/theming pass" of ADR
+0035 S5.
+
+## Decision
+
+### D1 — Tailwind in `apps/web`, fed by the design preset
+
+Add Tailwind to the console with `presets: [require("@protolabsai/design/tailwind")]`, and import
+`@protolabsai/design/css/tokens` (the `--pl-*` vars) + base. Tailwind **coexists** with the
+existing `theme.css` during migration — scope/disable preflight so it doesn't clobber current
+styles; no big-bang rewrite.
+
+### D2 — shadcn + Radix as the component layer
+
+Adopt **shadcn** (Radix primitives + Tailwind) as the component foundation, generated into
+`apps/web/src/components/ui/`. Radix gives **accessibility for free** (focus management, keyboard
+nav, dismissal) — which directly resolves the ADR 0036 renderer-a11y gap Quinn flagged. shadcn
+components are *owned source* (copied in, not a black-box dep), so we restyle them with our tokens.
+
+### D3 — One theme, the `--pl-*` tokens
+
+The brand tokens are the **single source of truth**. Bridge shadcn's theming (its
+`--background`/`--foreground`/`--primary`/… CSS vars) onto `--pl-color-*`, so shadcn components,
+new Tailwind markup, and the legacy `theme.css` all render the *same* dark-first brand theme
+(brand violet `#9b87f2` / lavender). Theme changes happen in tokens, once.
+
+### D4 — Incremental migration, not a rewrite
+
+New components are shadcn/Radix + Tailwind. Existing surfaces migrate **opportunistically** (when
+we touch them), not all at once — `theme.css` and Tailwind live side by side until the legacy CSS
+is whittled down. Each migration is its own small, locally-tested PR (the UI local-test gate
+applies).
+
+### D5 — Plugin remotes get the same components + theme
+
+The `@protoagent/plugin-ui` SDK (ADR 0034) re-exports the shadcn component set + exposes the
+Tailwind preset / tokens, and Module Federation **shares** them — so a `ui: react` plugin remote
+renders with the *same* accessible, on-brand components as the host, for free. (This is partly
+*why* we standardize: a shared component contract for plugins.)
+
+### D6 — Supersedes / flips
+
+- **Supersedes ADR 0035 S5** ("design-system + theming pass") — that slice *is* this foundation.
+- **Flips ADR 0036 D5** — the context menu is **not** a lean custom renderer; it's built on
+  shadcn's Radix `DropdownMenu` (imperative open-at-coords) themed by the tokens. The 0036 registry
+  / `ContextType` / store design is unchanged; only the renderer's implementation changes.
+
+## Consequences
+
+- **On-brand, accessible, reusable components** — and a real shared contract for plugin UI (D5).
+- **A migration debt window** — Tailwind + `theme.css` coexist for a while; we accept two styling
+  systems mid-flight, with a clear direction to converge on tokens.
+- **New build deps** (tailwindcss, the shadcn deps: class-variance-authority, clsx, tailwind-merge,
+  the `@radix-ui/*` primitives) + Tailwind in the Vite build. Bundle managed via tree-shaking +
+  shadcn's copy-only-what-you-use model.
+- **`@protolabsai/design` becomes a console dependency** (already a repo dep) — fork/version
+  coupling, but it's the locked brand source so that's intended.
+
+## Build order (proposed slices)
+
+1. **Foundation** — Tailwind + the `@protolabsai/design` preset + token CSS wired into `apps/web`
+   (coexisting with `theme.css`); shadcn initialized; the token bridge (D3); a **pilot component**
+   (e.g. Button) themed + swapped in one place to prove the stack end-to-end.
+2. **Context menu on shadcn/Radix** — ADR 0036 slice 1's renderer built on shadcn `DropdownMenu`
+   (a11y for free) + the rail-surface menu.
+3. **Incremental surface migration** — convert high-traffic components (PanelHeader, buttons,
+   dialogs, the rails' chrome) to shadcn + tokens; shrink `theme.css`.
+4. **Plugin-ui exposure** — the SDK (ADR 0034 S2) re-exports the component set + preset/tokens for
+   federated remotes.
+
+## References
+
+- `@protolabsai/design` (tokens + `…/tailwind` preset + `…/css/tokens` + assets; brand violet
+  `#9b87f2`, see [[brand-assets-source]] in memory). shadcn/ui (owned-source Radix + Tailwind
+  components). ADR 0034 (plugin-ui SDK shares these to remotes), ADR 0035 (this is its S5),
+  ADR 0036 (context menu renderer now uses shadcn Radix `DropdownMenu`).

--- a/docs/adr/index.md
+++ b/docs/adr/index.md
@@ -45,3 +45,4 @@ decision, numbered, never deleted (supersede instead).
 | [0034](./0034-plugin-ui-first-class-react.md) | Plugin UI as first-class React (Module Federation) — `ui: react` remotes + shared singletons + plugin-ui SDK + trust gate; Notes is the reference port | Proposed |
 | [0035](./0035-console-layout-dual-rail-mobile-first.md) | Console layout — symmetric dual-rail (swappable surfaces), one tab style, mobile-first (bottom quick-bar + hamburger), persisted UI state (Zustand) | Proposed |
 | [0036](./0036-context-menu-system.md) | Unified context-menu system (right-click) — Zustand store + `ContextType` registry + one renderer; plugins contribute items via the plugin-ui SDK (trust-gated); replaces ad-hoc affordances | Proposed |
+| [0037](./0037-design-system-foundation.md) | Design-system foundation — Tailwind + `@protolabsai/design` preset + shadcn/Radix (themed by brand tokens); supersedes 0035 S5, flips 0036 D5; shared to plugin remotes | Proposed |


### PR DESCRIPTION
Per your call: **use Radix + shadcn**, and move the console onto **protoContent's design system** toward componentized, themable components.

**Key finding:** `@protolabsai/design@^0.3.0` is already a repo dep, but it's **tokens + a Tailwind preset + brand assets**, *not* components. So 'themable components' = **shadcn/Radix components styled with Tailwind utilities that resolve to the brand tokens** (`@protolabsai/design/tailwind` preset → `bg-bg`/`text-fg-muted`/`brand-lavender`/`bg-brand-gradient`; `--pl-*` CSS vars).

**Decisions:**
- **Tailwind** in `apps/web` with the design preset (coexists with `theme.css` — no big-bang).
- **shadcn + Radix** as the component layer (owned source) → a11y for free.
- **One theme** via the `--pl-*` tokens (bridge shadcn's theme vars onto them).
- **Incremental migration** (new = shadcn; old migrates opportunistically; each a locally-tested PR).
- **Plugin remotes get the same components + theme** via the `@protoagent/plugin-ui` SDK (0034) + federation sharing.
- **Supersedes 0035 S5**; **flips 0036 D5** (context-menu renderer = shadcn Radix `DropdownMenu`, closing the a11y gap Quinn flagged).

**Slices:** foundation (Tailwind+preset+tokens+shadcn init+pilot Button) → context menu on shadcn (0036 S1) → incremental surface migration → SDK exposure.

Status **Proposed** — review + Quinn. This becomes the foundation the context menu + remaining layout/federation slices build on. (Also amended 0036 D5 to point here.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)