### PR TITLE
feat(console): right-click context-menu system on shadcn Radix (ADR 0036 S1) [HOLD: local test]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Everything-swappable rails (ADR 0036)** — plugin views are now first-class `railOrder`
+  members (reconciled in/out as plugins come and go), and **Chat is movable too** (it mounts on
+  whichever rail holds it, preserving streaming continuity). Right-click any surface → **Move up /
+  Move down / Move to other rail**. The rail is now an extraction-ready `<SurfaceRail>` component.
 - **Right-click context menus (ADR 0036 slice 1)** — an app-wide context-menu system on shadcn
   Radix `DropdownMenu`: a registry keyed by `ContextType` (core *and* plugins register items,
   merged by priority + deduped), an imperative `openContextMenu(type, e, ctx)`, and one

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Right-click context menus (ADR 0036 slice 1)** — an app-wide context-menu system on shadcn
+  Radix `DropdownMenu`: a registry keyed by `ContextType` (core *and* plugins register items,
+  merged by priority + deduped), an imperative `openContextMenu(type, e, ctx)`, and one
+  `<ContextMenuRenderer>`. First menu: **right-click a rail icon → Move to other rail** (the
+  surface-swap trigger, replacing the removed hover buttons). `registerContextMenu` is the plugin
+  extension point (to be exposed via the plugin-ui SDK).
 - **Design-system foundation (ADR 0037 slice 1)** — the console adopts **Tailwind + the
   `@protolabsai/design` preset/tokens + shadcn/Radix**. Tailwind runs with preflight off so it
   coexists with the legacy `theme.css` (incremental migration); a shadcn→token bridge maps the

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -107,3 +107,17 @@ test("right-click a rail surface opens a context menu that moves it (ADR 0036)",
   await expect(leftRail.getByRole("button", { name: "Notes", exact: true })).toBeVisible();
   await expect(rightRail.getByRole("button", { name: "Notes", exact: true })).toHaveCount(0);
 });
+
+test("Chat is movable too — right-click → move to the right rail (ADR 0036)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const leftRail = page.locator(".rail:not(.rail-right)");
+  const rightRail = page.locator(".rail-right");
+
+  await expect(leftRail.getByRole("button", { name: "Chat", exact: true })).toBeVisible();
+  await leftRail.getByRole("button", { name: "Chat", exact: true }).click({ button: "right" });
+  await page.getByTestId("context-menu").getByText("Move to right rail").click();
+
+  // Chat now lives on the right rail (no longer pinned left).
+  await expect(rightRail.getByRole("button", { name: "Chat", exact: true })).toBeVisible();
+  await expect(leftRail.getByRole("button", { name: "Chat", exact: true })).toHaveCount(0);
+});

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -88,3 +88,22 @@ test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async 
   await expect(page.locator(".rail-right").getByRole("button", { name: "Beads", exact: true })).toHaveClass(/active/);
 });
 
+
+test("right-click a rail surface opens a context menu that moves it (ADR 0036)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const rightRail = page.locator(".rail-right");
+  const leftRail = page.locator(".rail:not(.rail-right)");
+
+  // Notes starts on the right rail.
+  await expect(rightRail.getByRole("button", { name: "Notes", exact: true })).toBeVisible();
+
+  // Right-click it → the context menu opens with the move item.
+  await rightRail.getByRole("button", { name: "Notes", exact: true }).click({ button: "right" });
+  const menu = page.getByTestId("context-menu");
+  await expect(menu).toBeVisible();
+  await menu.getByText("Move to left rail").click();
+
+  // Notes moved to the left rail (store-backed → persists, but checking the move is enough here).
+  await expect(leftRail.getByRole("button", { name: "Notes", exact: true })).toBeVisible();
+  await expect(rightRail.getByRole("button", { name: "Notes", exact: true })).toHaveCount(0);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.3.0",
+    "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -85,6 +85,7 @@ import { SettingsCategoryPanel } from "../settings/SettingsCategory";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
+import { ContextMenuRenderer, openContextMenu } from "../contextMenu";
 import { StageSubnav } from "./StageSubnav";
 import { PanelHeader } from "./PanelHeader";
 import { brandName } from "../lib/brand";
@@ -777,6 +778,8 @@ export function App() {
   return (
     <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
       <IntroSplash />
+      {/* App-wide right-click menu (ADR 0036) — one renderer; menus come from the registry. */}
+      <ContextMenuRenderer />
       {/* Cold-start gate: holds over the app until the runtime probe first
           resolves (engine up), so the ~30s frozen-sidecar boot shows
           "Starting <agent>…" rather than a "Load failed" flash. */}
@@ -840,6 +843,7 @@ export function App() {
               label={s.label}
               icon={s.icon}
               onClick={() => setSurface(s.id)}
+              onContextMenu={(e) => openContextMenu("rail-surface", e, { id: s.id, side: "left" })}
               badge={s.id === "activity" ? activityUnread + inboxUnread : undefined}
               dot={s.id === "chat" ? chatStreaming && surface !== "chat" : undefined}
             />
@@ -893,6 +897,7 @@ export function App() {
               label={s.label}
               icon={s.icon}
               onClick={() => { setRightPanel(s.id); setRightCollapsed(false); }}
+              onContextMenu={(e) => openContextMenu("rail-surface", e, { id: s.id, side: "right" })}
             />
           ))}
         </aside>

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -85,6 +85,7 @@ import { SettingsCategoryPanel } from "../settings/SettingsCategory";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
+import { SurfaceRail } from "../components/SurfaceRail";
 import { ContextMenuRenderer, openContextMenu } from "../contextMenu";
 import { StageSubnav } from "./StageSubnav";
 import { PanelHeader } from "./PanelHeader";
@@ -242,6 +243,7 @@ export function App() {
   const rightWidth = useUI((s) => s.rightWidth);
   const setRightWidth = useUI((s) => s.setRightWidth);
   const railOrder = useUI((s) => s.railOrder);
+  const reconcilePluginViews = useUI((s) => s.reconcilePluginViews);
   const [live, setLive] = useState(false);
   // Shared custom confirm for destructive actions (notes/beads delete).
   const [confirmState, setConfirmState] = useState<
@@ -643,18 +645,24 @@ export function App() {
     { id: "goals", label: "Goals", icon: <Target size={18} /> },
     { id: "schedule", label: "Schedule", icon: <CalendarClock size={18} /> },
   ];
-  // Surfaces for a rail side, in the user's order (railOrder, ADR 0036). Core surfaces follow the
-  // saved order; plugin views append by their manifest placement (rail→left, right→right) — they
-  // aren't ordered by the user yet. Chat is pinned to the left rail's order.
-  const coreMeta = new globalThis.Map(CORE_SURFACES.map((s) => [s.id, s] as const));
-  function railSurfaces(side: "left" | "right"): { id: string; label: string; icon: ReactNode }[] {
-    const ordered = (railOrder[side] ?? [])
-      .map((id) => coreMeta.get(id))
-      .filter((s): s is { id: string; label: string; icon: ReactNode } => Boolean(s));
-    const plugins = (side === "left" ? pluginRail : pluginRightPanels).map((v) => ({
-      id: v.key, label: v.label, icon: pluginViewIcon(v.icon),
-    }));
-    return [...ordered, ...plugins];
+  // Surfaces for a rail side, in the user's order (railOrder, ADR 0036). Core AND plugin views are
+  // first-class railOrder members — reconciled below — so all are reorderable/movable, including
+  // Chat. Metadata resolves from core or the live plugin-view set; a freshly-appeared plugin not
+  // yet reconciled is appended so it still shows.
+  type RailItem = { id: string; label: string; icon: ReactNode };
+  const coreMeta = new globalThis.Map<string, RailItem>(CORE_SURFACES.map((s) => [s.id, s] as const));
+  const pluginMeta = new globalThis.Map<string, RailItem>(
+    allPluginViews.map((v) => [v.key, { id: v.key, label: v.label, icon: pluginViewIcon(v.icon) }] as const),
+  );
+  const metaFor = (id: string): RailItem | undefined => coreMeta.get(id) ?? pluginMeta.get(id);
+  function railSurfaces(side: "left" | "right"): RailItem[] {
+    const placed = new Set([...railOrder.left, ...railOrder.right]);
+    const ordered = (railOrder[side] ?? []).map(metaFor).filter((s): s is RailItem => Boolean(s));
+    // Safety net: a plugin view that appeared before reconcile ran — append it for this side.
+    const extra = (side === "left" ? pluginRail : pluginRightPanels)
+      .filter((v) => !placed.has(v.key))
+      .map((v): RailItem => ({ id: v.key, label: v.label, icon: pluginViewIcon(v.icon) }));
+    return [...ordered, ...extra];
   }
 
   function renderSurface(id: string): ReactNode {
@@ -772,12 +780,25 @@ export function App() {
     }
   }
 
-  // Active surface per rail, clamped to a member of that rail (so a moved surface doesn't
-  // leave a stale active). Chat is the left fallback; the first right member is the right one.
+  // Keep plugin views as first-class railOrder members (ADR 0036) — append new ones, prune gone.
+  // Keyed on a stable signature so the effect only fires when the view set actually changes.
+  const pluginViewSig = allPluginViews.map((v) => `${v.key}:${v.placement ?? "rail"}`).join(",");
+  useEffect(() => {
+    reconcilePluginViews([
+      ...pluginRail.map((v) => ({ id: v.key, side: "left" as const })),
+      ...pluginRightPanels.map((v) => ({ id: v.key, side: "right" as const })),
+    ]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [pluginViewSig, reconcilePluginViews]);
+
+  // Active surface per rail, clamped to a member of that side (a moved surface never leaves a
+  // stale active). Chat is no longer pinned — it lives on whichever rail holds it.
   const leftMembers = railSurfaces("left").map((s) => s.id);
   const rightMembers = railSurfaces("right").map((s) => s.id);
-  const leftActive = leftMembers.includes(surface) ? surface : "chat";
+  const leftActive = leftMembers.includes(surface) ? surface : (leftMembers[0] ?? "chat");
   const rightActive = rightMembers.includes(rightPanel) ? rightPanel : (rightMembers[0] ?? "notes");
+  // Chat mounts unconditionally on whichever side it's on (streaming continuity, #613).
+  const chatRail: "left" | "right" = railOrder.right.includes("chat") ? "right" : "left";
 
   return (
     <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
@@ -837,22 +858,20 @@ export function App() {
         className={`workspace ${rightCollapsed ? "right-collapsed" : ""}`}
         style={{ "--right-width": rightCol } as CSSProperties}
       >
-        {/* Left rail (ADR 0035) — members from railOf; hover a (non-Chat, non-plugin) icon to
-            send it to the right rail. Chat is pinned left. */}
-        <aside className="rail" aria-label="Workspace surfaces">
-          {railSurfaces("left").map((s) => (
-            <RailButton
-              key={s.id}
-              active={leftActive === s.id}
-              label={s.label}
-              icon={s.icon}
-              onClick={() => setSurface(s.id)}
-              onContextMenu={(e) => openContextMenu("rail-surface", e, { id: s.id, side: "left" })}
-              badge={s.id === "activity" ? activityUnread + inboxUnread : undefined}
-              dot={s.id === "chat" ? chatStreaming && surface !== "chat" : undefined}
-            />
-          ))}
-        </aside>
+        {/* Left rail (ADR 0035/0036) — members + order from railOrder; right-click a surface to
+            reorder or move it across. The rail is the extraction-ready <SurfaceRail>. */}
+        <SurfaceRail
+          side="left"
+          ariaLabel="Workspace surfaces"
+          items={railSurfaces("left").map((s) => ({
+            ...s,
+            badge: s.id === "activity" ? activityUnread + inboxUnread : undefined,
+            dot: s.id === "chat" ? chatStreaming && surface !== "chat" : undefined,
+          }))}
+          activeId={leftActive}
+          onSelect={(id) => setSurface(id)}
+          onContextMenu={(e, id) => openContextMenu("rail-surface", e, { id, side: "left" })}
+        />
 
         <main className="stage">
           {error ? (
@@ -865,7 +884,7 @@ export function App() {
           {/* Chat mounts UNCONDITIONALLY + hidden via `active` (streaming continuity, #613);
               it's pinned to the left rail. Every other left-rail surface renders through the
               shared renderSurface (ADR 0035 S3) — so it can live on either rail. */}
-          <ChatSurface onError={setError} active={leftActive === "chat"} />
+          {chatRail === "left" ? <ChatSurface onError={setError} active={leftActive === "chat"} /> : null}
           {leftActive !== "chat" ? renderSurface(leftActive) : null}
         </main>
 
@@ -886,25 +905,21 @@ export function App() {
               data-testid="right-resize"
             />
           ) : null}
-          {/* The right surface renders through the same renderSurface as the left (ADR 0035
-              S3) — so notes/beads/goals/schedule (or anything moved here) mount identically. */}
-          {!rightCollapsed ? renderSurface(rightActive) : null}
+          {/* The right surface renders through the same renderSurface as the left (ADR 0035 S3).
+              If Chat lives on this rail it mounts unconditionally (continuity), like the stage. */}
+          {chatRail === "right" ? <ChatSurface onError={setError} active={rightActive === "chat"} /> : null}
+          {!rightCollapsed && rightActive !== "chat" ? renderSurface(rightActive) : null}
         </aside>
 
-        {/* Right rail (ADR 0035 D1/D2) — mirrors the left on the far edge; members from railOf.
-            Hover a (non-plugin) icon to send it to the left rail. */}
-        <aside className="rail rail-right" aria-label="Context surfaces">
-          {railSurfaces("right").map((s) => (
-            <RailButton
-              key={s.id}
-              active={rightActive === s.id && !rightCollapsed}
-              label={s.label}
-              icon={s.icon}
-              onClick={() => { setRightPanel(s.id); setRightCollapsed(false); }}
-              onContextMenu={(e) => openContextMenu("rail-surface", e, { id: s.id, side: "right" })}
-            />
-          ))}
-        </aside>
+        {/* Right rail (ADR 0035/0036) — mirrors the left on the far edge; same <SurfaceRail>. */}
+        <SurfaceRail
+          side="right"
+          ariaLabel="Context surfaces"
+          items={railSurfaces("right")}
+          activeId={rightCollapsed ? "" : rightActive}
+          onSelect={(id) => { setRightPanel(id); setRightCollapsed(false); }}
+          onContextMenu={(e, id) => openContextMenu("rail-surface", e, { id, side: "right" })}
+        />
       </div>
 
       <footer className="utility-bar">
@@ -966,38 +981,4 @@ export function App() {
   );
 }
 
-function RailButton({
-  active,
-  label,
-  icon,
-  onClick,
-  badge,
-  dot,
-  onContextMenu,
-}: {
-  active: boolean;
-  label: string;
-  icon: ReactNode;
-  onClick: () => void;
-  badge?: number;
-  // A small pulsing indicator (no count) — e.g. a chat turn streaming in the
-  // background while you're on another tab.
-  dot?: boolean;
-  // Right-click hook (ADR 0036) — opens the rail-surface context menu.
-  onContextMenu?: (e: React.MouseEvent) => void;
-}) {
-  return (
-    <button className={active ? "active" : ""} type="button" onClick={onClick} onContextMenu={onContextMenu} title={label} aria-label={label}>
-      {icon}
-      <span>{label}</span>
-      {badge ? (
-        <span className="rail-badge" data-testid="activity-badge">
-          {badge > 9 ? "9+" : badge}
-        </span>
-      ) : dot ? (
-        <span className="rail-dot" data-testid="chat-streaming-dot" aria-label="streaming" />
-      ) : null}
-    </button>
-  );
-}
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -241,7 +241,7 @@ export function App() {
   const setRightCollapsed = useUI((s) => s.setRightCollapsed);
   const rightWidth = useUI((s) => s.rightWidth);
   const setRightWidth = useUI((s) => s.setRightWidth);
-  const railOf = useUI((s) => s.railOf);
+  const railOrder = useUI((s) => s.railOrder);
   const [live, setLive] = useState(false);
   // Shared custom confirm for destructive actions (notes/beads delete).
   const [confirmState, setConfirmState] = useState<
@@ -643,14 +643,18 @@ export function App() {
     { id: "goals", label: "Goals", icon: <Target size={18} /> },
     { id: "schedule", label: "Schedule", icon: <CalendarClock size={18} /> },
   ];
-  // Surfaces (+ plugin views) assigned to a rail side. Plugin views follow their manifest
-  // placement (rail→left, right→right); core surfaces follow railOf. Chat is always left.
+  // Surfaces for a rail side, in the user's order (railOrder, ADR 0036). Core surfaces follow the
+  // saved order; plugin views append by their manifest placement (rail→left, right→right) — they
+  // aren't ordered by the user yet. Chat is pinned to the left rail's order.
+  const coreMeta = new globalThis.Map(CORE_SURFACES.map((s) => [s.id, s] as const));
   function railSurfaces(side: "left" | "right"): { id: string; label: string; icon: ReactNode }[] {
-    const core = CORE_SURFACES.filter((s) => (s.id === "chat" ? side === "left" : (railOf[s.id] ?? "left") === side));
+    const ordered = (railOrder[side] ?? [])
+      .map((id) => coreMeta.get(id))
+      .filter((s): s is { id: string; label: string; icon: ReactNode } => Boolean(s));
     const plugins = (side === "left" ? pluginRail : pluginRightPanels).map((v) => ({
       id: v.key, label: v.label, icon: pluginViewIcon(v.icon),
     }));
-    return [...core, ...plugins];
+    return [...ordered, ...plugins];
   }
 
   function renderSurface(id: string): ReactNode {

--- a/apps/web/src/chat/Markdown.tsx
+++ b/apps/web/src/chat/Markdown.tsx
@@ -1,5 +1,5 @@
 import type { ComponentPropsWithoutRef } from "react";
-import ReactMarkdown from "react-markdown";
+import ReactMarkdown, { type Components } from "react-markdown";
 import rehypeHighlight from "rehype-highlight";
 import remarkGfm from "remark-gfm";
 
@@ -9,10 +9,11 @@ import remarkGfm from "remark-gfm";
 const REMARK = [remarkGfm];
 const REHYPE = [rehypeHighlight];
 
-const components = {
-  // External links open in a new tab; never let markdown navigate the app.
-  a: (props: ComponentPropsWithoutRef<"a">) => (
-    <a {...props} target="_blank" rel="noreferrer noopener" />
+const components: Components = {
+  // External links open in a new tab; never let markdown navigate the app. Strip react-markdown's
+  // `node` prop before spreading so it doesn't reach the DOM <a>.
+  a: ({ node: _node, ...props }) => (
+    <a {...(props as ComponentPropsWithoutRef<"a">)} target="_blank" rel="noreferrer noopener" />
   ),
 };
 

--- a/apps/web/src/components/SurfaceRail.tsx
+++ b/apps/web/src/components/SurfaceRail.tsx
@@ -1,0 +1,70 @@
+import type { MouseEvent, ReactNode } from "react";
+
+export type RailItem = { id: string; label: string; icon: ReactNode; badge?: number; dot?: boolean };
+
+// A vertical rail of surface icons (ADR 0035/0036). Dumb + fully props-driven — both the left and
+// right rails render through it, and it's extraction-ready for @protolabsai/ui's AppShell (no
+// protoAgent-specific coupling; theming is class/token-only).
+export function SurfaceRail({
+  side,
+  ariaLabel,
+  items,
+  activeId,
+  onSelect,
+  onContextMenu,
+}: {
+  side: "left" | "right";
+  ariaLabel: string;
+  items: RailItem[];
+  activeId: string;
+  onSelect: (id: string) => void;
+  onContextMenu: (e: MouseEvent, id: string) => void;
+}) {
+  return (
+    <aside className={`rail${side === "right" ? " rail-right" : ""}`} aria-label={ariaLabel}>
+      {items.map((it) => (
+        <RailButton
+          key={it.id}
+          active={it.id === activeId}
+          label={it.label}
+          icon={it.icon}
+          badge={it.badge}
+          dot={it.dot}
+          onClick={() => onSelect(it.id)}
+          onContextMenu={(e) => onContextMenu(e, it.id)}
+        />
+      ))}
+    </aside>
+  );
+}
+
+function RailButton({
+  active,
+  label,
+  icon,
+  onClick,
+  onContextMenu,
+  badge,
+  dot,
+}: {
+  active: boolean;
+  label: string;
+  icon: ReactNode;
+  onClick: () => void;
+  onContextMenu?: (e: MouseEvent) => void;
+  badge?: number;
+  // A small pulsing indicator (no count) — e.g. a chat turn streaming in the background.
+  dot?: boolean;
+}) {
+  return (
+    <button className={active ? "active" : ""} type="button" onClick={onClick} onContextMenu={onContextMenu} title={label} aria-label={label}>
+      {icon}
+      <span>{label}</span>
+      {badge ? (
+        <span className="rail-badge" data-testid="activity-badge">{badge > 9 ? "9+" : badge}</span>
+      ) : dot ? (
+        <span className="rail-dot" data-testid="chat-streaming-dot" aria-label="streaming" />
+      ) : null}
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/dropdown-menu.tsx
+++ b/apps/web/src/components/ui/dropdown-menu.tsx
@@ -1,0 +1,61 @@
+import * as React from "react";
+import * as DM from "@radix-ui/react-dropdown-menu";
+
+import { cn } from "../../lib/cn";
+
+// shadcn/Radix DropdownMenu (ADR 0037) — owned source, themed by the @protolabsai/design tokens
+// (bg-popover / text-popover-foreground / focus:bg-accent). Used by the context-menu renderer.
+export const DropdownMenu = DM.Root;
+export const DropdownMenuTrigger = DM.Trigger;
+
+export const DropdownMenuContent = React.forwardRef<
+  React.ElementRef<typeof DM.Content>,
+  React.ComponentPropsWithoutRef<typeof DM.Content>
+>(({ className, sideOffset = 4, ...props }, ref) => (
+  <DM.Portal>
+    <DM.Content
+      ref={ref}
+      sideOffset={sideOffset}
+      className={cn(
+        "z-50 min-w-[10rem] overflow-hidden rounded-md border border-border bg-popover p-1 text-popover-foreground shadow-md",
+        "data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
+        className,
+      )}
+      {...props}
+    />
+  </DM.Portal>
+));
+DropdownMenuContent.displayName = "DropdownMenuContent";
+
+export const DropdownMenuItem = React.forwardRef<
+  React.ElementRef<typeof DM.Item>,
+  React.ComponentPropsWithoutRef<typeof DM.Item> & { danger?: boolean }
+>(({ className, danger, ...props }, ref) => (
+  <DM.Item
+    ref={ref}
+    className={cn(
+      "relative flex cursor-pointer select-none items-center gap-2 rounded-sm px-2 py-1.5 text-sm outline-none",
+      "focus:bg-accent focus:text-accent-foreground data-[disabled]:pointer-events-none data-[disabled]:opacity-50",
+      danger && "text-destructive focus:text-destructive-foreground focus:bg-destructive",
+      className,
+    )}
+    {...props}
+  />
+));
+DropdownMenuItem.displayName = "DropdownMenuItem";
+
+export const DropdownMenuSeparator = React.forwardRef<
+  React.ElementRef<typeof DM.Separator>,
+  React.ComponentPropsWithoutRef<typeof DM.Separator>
+>(({ className, ...props }, ref) => (
+  <DM.Separator ref={ref} className={cn("-mx-1 my-1 h-px bg-border", className)} {...props} />
+));
+DropdownMenuSeparator.displayName = "DropdownMenuSeparator";
+
+export const DropdownMenuLabel = React.forwardRef<
+  React.ElementRef<typeof DM.Label>,
+  React.ComponentPropsWithoutRef<typeof DM.Label>
+>(({ className, ...props }, ref) => (
+  <DM.Label ref={ref} className={cn("px-2 py-1.5 text-xs font-medium text-muted-foreground", className)} {...props} />
+));
+DropdownMenuLabel.displayName = "DropdownMenuLabel";

--- a/apps/web/src/contextMenu/ContextMenuRenderer.tsx
+++ b/apps/web/src/contextMenu/ContextMenuRenderer.tsx
@@ -1,0 +1,45 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "../components/ui/dropdown-menu";
+import { resolveMenu } from "./registry";
+import { useContextMenuStore } from "./store";
+
+// One renderer at the app root (ADR 0036 D1). A shadcn Radix DropdownMenu opened at the cursor via
+// an invisible fixed-positioned trigger — so any element can summon it without wrapping targets.
+export function ContextMenuRenderer() {
+  const { open, type, x, y, ctx, close } = useContextMenuStore();
+  const entries = open ? resolveMenu(type, ctx) : [];
+  const visible = entries.filter((e) =>
+    "divider" in e ? true : typeof e.visible === "function" ? e.visible(ctx) : e.visible !== false,
+  );
+  if (!open || visible.length === 0) return null;
+  return (
+    <DropdownMenu open={open} onOpenChange={(o) => { if (!o) close(); }}>
+      <DropdownMenuTrigger asChild>
+        <span aria-hidden style={{ position: "fixed", left: x, top: y, width: 0, height: 0 }} />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" data-testid="context-menu">
+        {visible.map((e) =>
+          "divider" in e ? (
+            <DropdownMenuSeparator key={e.id} />
+          ) : (
+            <DropdownMenuItem
+              key={e.id}
+              danger={e.danger}
+              disabled={typeof e.disabled === "function" ? e.disabled(ctx) : e.disabled}
+              onSelect={() => { void e.run(ctx, { close }); }}
+            >
+              {typeof e.icon === "function" ? e.icon(ctx) : e.icon}
+              <span>{typeof e.label === "function" ? e.label(ctx) : e.label}</span>
+              {e.shortcut ? <span className="ml-auto text-xs text-muted-foreground">{e.shortcut}</span> : null}
+            </DropdownMenuItem>
+          ),
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/apps/web/src/contextMenu/index.ts
+++ b/apps/web/src/contextMenu/index.ts
@@ -1,0 +1,5 @@
+export { registerContextMenu, resolveMenu } from "./registry";
+export { openContextMenu, useContextMenuStore } from "./store";
+export { ContextMenuRenderer } from "./ContextMenuRenderer";
+export type { ContextType, MenuItem, MenuDivider, MenuEntry, MenuHelpers, ContextMenuRegistration } from "./types";
+import "./registrations";

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -10,12 +10,15 @@ import type { MenuEntry } from "./types";
 registerContextMenu({
   type: "rail-surface",
   items: (ctx: { id: string; side: "left" | "right" }): MenuEntry[] => {
-    if (!ctx || String(ctx.id).startsWith("plugin:")) return [];
+    if (!ctx) return [];
     const ui = useUI.getState();
     const list = ui.railOrder[ctx.side] ?? [];
     const i = list.indexOf(ctx.id);
-    if (i < 0) return [];
-    const entries: MenuEntry[] = [
+    if (i < 0) return []; // not yet tracked (a freshly-appeared plugin, pre-reconcile)
+    const to = ctx.side === "left" ? "right" : "left";
+    // Any surface — core, plugin, or chat — reorders within its rail and moves across. (Moving
+    // chat across rails remounts it: a brief blip on an in-flight stream; a deliberate action.)
+    return [
       {
         id: "move-up",
         label: "Move up",
@@ -30,11 +33,8 @@ registerContextMenu({
         disabled: i >= list.length - 1,
         run: () => useUI.getState().reorderSurface(ctx.id, 1),
       },
-    ];
-    if (ctx.id !== "chat") {
-      const to = ctx.side === "left" ? "right" : "left";
-      entries.push({ id: "rail-div", divider: true });
-      entries.push({
+      { id: "rail-div", divider: true },
+      {
         id: "move-rail",
         label: `Move to ${to} rail`,
         icon: <ArrowLeftRight size={14} />,
@@ -43,15 +43,14 @@ registerContextMenu({
           u.moveSurface(ctx.id, to);
           if (to === "left") {
             u.setSurface(ctx.id);
-            if (u.rightPanel === ctx.id) u.setRightPanel("notes");
+            if (u.rightPanel === ctx.id) u.setRightPanel(u.railOrder.right[0] ?? "notes");
           } else {
             u.setRightPanel(ctx.id);
             u.setRightCollapsed(false);
-            if (u.surface === ctx.id) u.setSurface("chat");
+            if (u.surface === ctx.id) u.setSurface(u.railOrder.left[0] ?? "chat");
           }
         },
-      });
-    }
-    return entries;
+      },
+    ];
   },
 });

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -1,33 +1,57 @@
-import { ArrowLeftRight } from "lucide-react";
+import { ArrowLeftRight, ChevronDown, ChevronUp } from "lucide-react";
 
 import { useUI } from "../state/uiStore";
 import { registerContextMenu } from "./registry";
+import type { MenuEntry } from "./types";
 
-// First customer (ADR 0036 D6 / ADR 0035 D2): right-click a rail icon → move it to the other rail.
-// Chat is pinned left and plugin views follow their placement, so they offer no move item.
+// First customer (ADR 0036 D6 / ADR 0035 D2): right-click a rail icon → reorder it within its
+// rail (Move up/down) and move it to the other rail (append to the bottom). Chat is pinned to the
+// left rail (no move-across); plugin views follow their manifest placement (no items yet).
 registerContextMenu({
   type: "rail-surface",
-  items: (ctx: { id: string; side: "left" | "right" }) => {
-    if (!ctx || ctx.id === "chat" || String(ctx.id).startsWith("plugin:")) return [];
-    const to = ctx.side === "left" ? "right" : "left";
-    return [
+  items: (ctx: { id: string; side: "left" | "right" }): MenuEntry[] => {
+    if (!ctx || String(ctx.id).startsWith("plugin:")) return [];
+    const ui = useUI.getState();
+    const list = ui.railOrder[ctx.side] ?? [];
+    const i = list.indexOf(ctx.id);
+    if (i < 0) return [];
+    const entries: MenuEntry[] = [
       {
+        id: "move-up",
+        label: "Move up",
+        icon: <ChevronUp size={14} />,
+        disabled: i <= 0,
+        run: () => useUI.getState().reorderSurface(ctx.id, -1),
+      },
+      {
+        id: "move-down",
+        label: "Move down",
+        icon: <ChevronDown size={14} />,
+        disabled: i >= list.length - 1,
+        run: () => useUI.getState().reorderSurface(ctx.id, 1),
+      },
+    ];
+    if (ctx.id !== "chat") {
+      const to = ctx.side === "left" ? "right" : "left";
+      entries.push({ id: "rail-div", divider: true });
+      entries.push({
         id: "move-rail",
         label: `Move to ${to} rail`,
         icon: <ArrowLeftRight size={14} />,
         run: () => {
-          const ui = useUI.getState();
-          ui.moveSurface(ctx.id, to);
+          const u = useUI.getState();
+          u.moveSurface(ctx.id, to);
           if (to === "left") {
-            ui.setSurface(ctx.id);
-            if (ui.rightPanel === ctx.id) ui.setRightPanel("notes");
+            u.setSurface(ctx.id);
+            if (u.rightPanel === ctx.id) u.setRightPanel("notes");
           } else {
-            ui.setRightPanel(ctx.id);
-            ui.setRightCollapsed(false);
-            if (ui.surface === ctx.id) ui.setSurface("chat");
+            u.setRightPanel(ctx.id);
+            u.setRightCollapsed(false);
+            if (u.surface === ctx.id) u.setSurface("chat");
           }
         },
-      },
-    ];
+      });
+    }
+    return entries;
   },
 });

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -1,0 +1,33 @@
+import { ArrowLeftRight } from "lucide-react";
+
+import { useUI } from "../state/uiStore";
+import { registerContextMenu } from "./registry";
+
+// First customer (ADR 0036 D6 / ADR 0035 D2): right-click a rail icon → move it to the other rail.
+// Chat is pinned left and plugin views follow their placement, so they offer no move item.
+registerContextMenu({
+  type: "rail-surface",
+  items: (ctx: { id: string; side: "left" | "right" }) => {
+    if (!ctx || ctx.id === "chat" || String(ctx.id).startsWith("plugin:")) return [];
+    const to = ctx.side === "left" ? "right" : "left";
+    return [
+      {
+        id: "move-rail",
+        label: `Move to ${to} rail`,
+        icon: <ArrowLeftRight size={14} />,
+        run: () => {
+          const ui = useUI.getState();
+          ui.moveSurface(ctx.id, to);
+          if (to === "left") {
+            ui.setSurface(ctx.id);
+            if (ui.rightPanel === ctx.id) ui.setRightPanel("notes");
+          } else {
+            ui.setRightPanel(ctx.id);
+            ui.setRightCollapsed(false);
+            if (ui.surface === ctx.id) ui.setSurface("chat");
+          }
+        },
+      },
+    ];
+  },
+});

--- a/apps/web/src/contextMenu/registry.ts
+++ b/apps/web/src/contextMenu/registry.ts
@@ -1,0 +1,28 @@
+import type { ContextMenuRegistration, ContextType, MenuEntry } from "./types";
+
+// The registry (ADR 0036 D2): core AND plugins register menus per ContextType; the menu for a
+// type is the merged union of all registrations, priority-sorted and deduped by id.
+const registrations = new Map<string, ContextMenuRegistration[]>();
+
+export function registerContextMenu(reg: ContextMenuRegistration): () => void {
+  const list = registrations.get(reg.type) || [];
+  list.push(reg);
+  list.sort((a, b) => (b.priority || 0) - (a.priority || 0));
+  registrations.set(reg.type, list);
+  return () => {
+    const cur = registrations.get(reg.type) || [];
+    registrations.set(reg.type, cur.filter((r) => r !== reg));
+  };
+}
+
+export function resolveMenu(type: ContextType, ctx: unknown): MenuEntry[] {
+  const out: MenuEntry[] = [];
+  const seen = new Set<string>();
+  for (const reg of registrations.get(type) || []) {
+    const items = typeof reg.items === "function" ? reg.items(ctx) : reg.items;
+    for (const it of items) {
+      if (!seen.has(it.id)) { seen.add(it.id); out.push(it); }
+    }
+  }
+  return out;
+}

--- a/apps/web/src/contextMenu/store.ts
+++ b/apps/web/src/contextMenu/store.ts
@@ -1,0 +1,26 @@
+import type * as React from "react";
+import { create } from "zustand";
+
+import type { ContextType } from "./types";
+
+interface ContextMenuState {
+  open: boolean;
+  type: ContextType;
+  x: number;
+  y: number;
+  ctx: unknown;
+  openMenu: (type: ContextType, x: number, y: number, ctx?: unknown) => void;
+  close: () => void;
+}
+
+export const useContextMenuStore = create<ContextMenuState>((set) => ({
+  open: false, type: "", x: 0, y: 0, ctx: undefined,
+  openMenu: (type, x, y, ctx) => set({ open: true, type, x, y, ctx }),
+  close: () => set({ open: false }),
+}));
+
+// Imperative open-at-cursor (ADR 0036 D1) — call from any onContextMenu handler.
+export function openContextMenu(type: ContextType, e: React.MouseEvent, ctx?: unknown) {
+  e.preventDefault();
+  useContextMenuStore.getState().openMenu(type, e.clientX, e.clientY, ctx);
+}

--- a/apps/web/src/contextMenu/types.ts
+++ b/apps/web/src/contextMenu/types.ts
@@ -1,0 +1,25 @@
+import type { ReactNode } from "react";
+
+// ADR 0036 — what was right-clicked. Open string so plugins can define their own types.
+export type ContextType = "rail-surface" | "chat-message" | "note" | "bead" | "background" | (string & {});
+
+export interface MenuHelpers { close: () => void; }
+
+export interface MenuItem {
+  id: string;
+  label: string | ((ctx: any) => string);
+  icon?: ReactNode | ((ctx: any) => ReactNode);
+  run: (ctx: any, helpers: MenuHelpers) => void | Promise<void>;
+  disabled?: boolean | ((ctx: any) => boolean);
+  visible?: boolean | ((ctx: any) => boolean);
+  danger?: boolean;
+  shortcut?: string;
+}
+export interface MenuDivider { id: string; divider: true; }
+export type MenuEntry = MenuItem | MenuDivider;
+
+export interface ContextMenuRegistration {
+  type: ContextType;
+  priority?: number;
+  items: MenuEntry[] | ((ctx: any) => MenuEntry[]);
+}

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -45,6 +45,9 @@ type UIState = {
   railOrder: { left: string[]; right: string[] };
   moveSurface: (id: string, side: "left" | "right") => void; // splice out → append to side's bottom
   reorderSurface: (id: string, dir: -1 | 1) => void; // swap with the neighbour within its rail
+  // Sync plugin views into railOrder (ADR 0036) — append newly-available ones to their placement
+  // side, prune `plugin:` ids no longer present. Core surfaces are left untouched.
+  reconcilePluginViews: (views: { id: string; side: "left" | "right" }[]) => void;
   setSurface: (s: Surface) => void;
   setRightPanel: (p: RightPanel) => void;
   setAgentTab: (t: AgentTab) => void;
@@ -90,6 +93,17 @@ export const useUI = create<UIState>()(
             return next;
           };
           return { railOrder: { left: swap(s.railOrder.left), right: swap(s.railOrder.right) } };
+        }),
+      reconcilePluginViews: (views) =>
+        set((s) => {
+          const ids = new Set(views.map((v) => v.id));
+          const keep = (arr: string[]) => arr.filter((x) => !x.startsWith("plugin:") || ids.has(x));
+          const left = keep(s.railOrder.left);
+          const right = keep(s.railOrder.right);
+          for (const v of views) {
+            if (!left.includes(v.id) && !right.includes(v.id)) (v.side === "left" ? left : right).push(v.id);
+          }
+          return { railOrder: { left, right } };
         }),
       setSurface: (surface) => set({ surface }),
       setRightPanel: (rightPanel) => set({ rightPanel }),

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -39,11 +39,12 @@ type UIState = {
   activityTab: ActivityTab;
   rightCollapsed: boolean;
   rightWidth: number;
-  // Which rail each surface lives on (ADR 0035 D2) — a surface is on exactly one side.
-  // Core surfaces seeded below; plugin views default by their manifest `placement`. Chat is
-  // pinned left (it mounts unconditionally for streaming continuity), so it isn't moved.
-  railOf: Record<string, "left" | "right">;
-  moveSurface: (id: string, side: "left" | "right") => void;
+  // Ordered surface lists per rail (ADR 0035 D2 + 0036) — a surface is on exactly one side, at a
+  // position. Core surfaces seeded below; plugin views append by their manifest `placement`. Chat
+  // is pinned left (mounts unconditionally for streaming continuity) — never moved across rails.
+  railOrder: { left: string[]; right: string[] };
+  moveSurface: (id: string, side: "left" | "right") => void; // splice out → append to side's bottom
+  reorderSurface: (id: string, dir: -1 | 1) => void; // swap with the neighbour within its rail
   setSurface: (s: Surface) => void;
   setRightPanel: (p: RightPanel) => void;
   setAgentTab: (t: AgentTab) => void;
@@ -67,12 +68,29 @@ export const useUI = create<UIState>()(
       activityTab: "thread",
       rightCollapsed: false,
       rightWidth: 360,
-      railOf: {
-        chat: "left", activity: "left", studio: "left", knowledge: "left",
-        agent: "left", plugins: "left", settings: "left",
-        notes: "right", beads: "right", goals: "right", schedule: "right",
+      railOrder: {
+        left: ["chat", "activity", "studio", "knowledge", "agent", "plugins", "settings"],
+        right: ["notes", "beads", "goals", "schedule"],
       },
-      moveSurface: (id, side) => set((s) => ({ railOf: { ...s.railOf, [id]: side } })),
+      moveSurface: (id, side) =>
+        set((s) => {
+          const left = s.railOrder.left.filter((x) => x !== id);
+          const right = s.railOrder.right.filter((x) => x !== id);
+          (side === "left" ? left : right).push(id); // append to the target's bottom
+          return { railOrder: { left, right } };
+        }),
+      reorderSurface: (id, dir) =>
+        set((s) => {
+          const swap = (arr: string[]) => {
+            const i = arr.indexOf(id);
+            const j = i + dir;
+            if (i < 0 || j < 0 || j >= arr.length) return arr;
+            const next = arr.slice();
+            [next[i], next[j]] = [next[j], next[i]];
+            return next;
+          };
+          return { railOrder: { left: swap(s.railOrder.left), right: swap(s.railOrder.right) } };
+        }),
       setSurface: (surface) => set({ surface }),
       setRightPanel: (rightPanel) => set({ rightPanel }),
       setAgentTab: (agentTab) => set({ agentTab }),
@@ -85,7 +103,15 @@ export const useUI = create<UIState>()(
     }),
     {
       name: "protoagent.ui", // localStorage key — the single source of truth (ADR 0035 D5)
-      version: 1,
+      version: 2, // v2: railOf (side map) → railOrder (ordered lists per rail)
+      migrate: (persisted: unknown) => {
+        // Drop the obsolete railOf; railOrder falls back to the default via merge.
+        if (persisted && typeof persisted === "object") {
+          const { railOf: _drop, ...rest } = persisted as Record<string, unknown>;
+          return rest as never;
+        }
+        return persisted as never;
+      },
     },
   ),
 );

--- a/docs/adr/0037-design-system-foundation.md
+++ b/docs/adr/0037-design-system-foundation.md
@@ -97,3 +97,19 @@ renders with the *same* accessible, on-brand components as the host, for free. (
   `#9b87f2`, see [[brand-assets-source]] in memory). shadcn/ui (owned-source Radix + Tailwind
   components). ADR 0034 (plugin-ui SDK shares these to remotes), ADR 0035 (this is its S5),
   ADR 0036 (context menu renderer now uses shadcn Radix `DropdownMenu`).
+
+## D7 — `@protolabsai/ui` is the component source; AppShell convergence
+
+protoContent is actively building **`@protolabsai/ui`** (alongside `@protolabsai/design`) — Dialog,
+Drawer, Toast, Tooltip, Table, Input/Select/Switch/Checkbox, etc. (→ 0.4.0). So:
+
+- Our **locally-built shadcn components** (`Button`, `dropdown-menu`, `SurfaceRail`) are **interim
+  scaffolding**. When `@protolabsai/ui` lands we **adopt its components and retire the locals**
+  (the `dropdown-menu` stays until it ships a menu/dropdown — not in the first batch).
+- **Principle: componentize + prove here, extract later.** Build reusable, props-driven,
+  token-only components in protoAgent first (no app-specific coupling), prove them against the real
+  console, then lift the stable ones into `@protolabsai/ui`. `SurfaceRail` is built this way.
+- **AppShell convergence (coordination):** protoContent deferred its **AppShell** (icon-rail +
+  3-column + resizable panel) to "spec against both dashboards" — that **is** our dual-rail layout
+  (ADR 0035: `railOrder`, the resize handle, mobile shell). Feed our proven design into their
+  AppShell so the two converge instead of diverging.

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.3.0",
+        "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -55,11 +56,314 @@
         "vite": "^5.4.21"
       }
     },
+    "apps/web/node_modules/@radix-ui/react-arrow": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-arrow/-/react-arrow-1.1.9.tgz",
+      "integrity": "sha512-yqHW5WQ/cTpU/un7dqqIKNy2iRU8BC0JB78PEzTfCCYvZu1U6W9KwObAniMk9nhSfyotKPQTYaUD/HB0f5muig==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-collection": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-collection/-/react-collection-1.1.9.tgz",
+      "integrity": "sha512-zuSVi7ziP7uQRqc+yGxsKJfNkdyHv3ZKDaHe0gzg4dRgws96TPKWIiz84tVHP4GEcEl8bC0mdt17NkcxaJHmaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-dismissable-layer": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dismissable-layer/-/react-dismissable-layer-1.1.12.tgz",
+      "integrity": "sha512-MhoruH6xEzsbvOmo4TNgMfmtvRGyDZw4MDSdf4ybMHfezjqwzv6hyd4lsMzBp8K9Sn6sGzCF62x1I7BYUECXOg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-escape-keydown": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-dropdown-menu": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-dropdown-menu/-/react-dropdown-menu-2.1.17.tgz",
+      "integrity": "sha512-S6b3Jm57sY5EdDyOMLkacbB0qMnKhy1RCKZCt795ZkmtUOAvojYIZ5p7dXHIh5Cyr3jCLLI5/g64V3FKLudZmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-menu": "2.1.17",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-focus-scope": {
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-scope/-/react-focus-scope-1.1.9.tgz",
+      "integrity": "sha512-9Se8t+Zry+1rEOL7Y6l/4ANYU/TOtAtf8O2fKdwLltcaMcm6kOqYGbzO4tMFQ0bvzO920pRAoHpFZ4W85S3keQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-menu": {
+      "version": "2.1.17",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-menu/-/react-menu-2.1.17.tgz",
+      "integrity": "sha512-fmbNnFyf+JYCN0DhhWnEdUTDnZD1mXaPQWivdsPIb8oOSbARfD3LIQJbLCG8a8QLCwoMxiJ7GVPIFcC8Dw8v2Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-dismissable-layer": "1.1.12",
+        "@radix-ui/react-focus-guards": "1.1.4",
+        "@radix-ui/react-focus-scope": "1.1.9",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-popper": "1.3.0",
+        "@radix-ui/react-portal": "1.1.11",
+        "@radix-ui/react-presence": "1.1.6",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-roving-focus": "1.1.12",
+        "@radix-ui/react-slot": "1.2.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "aria-hidden": "^1.2.4",
+        "react-remove-scroll": "^2.7.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-popper": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-popper/-/react-popper-1.3.0.tgz",
+      "integrity": "sha512-9PB589e1aWZbrlFUHdz6WiPCL+xLZHQFX7oibqG/6Q0SwOkxDyQX9W/cyPa+sAPPKuC8cpLCpRczE5a/1DiwVQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/react-dom": "^2.0.0",
+        "@radix-ui/react-arrow": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-layout-effect": "1.1.2",
+        "@radix-ui/react-use-rect": "1.1.2",
+        "@radix-ui/react-use-size": "1.1.2",
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-portal": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-portal/-/react-portal-1.1.11.tgz",
+      "integrity": "sha512-UEytdjgEh2tJGgD/gZK4FUx6t1rNIlM3U0DENhSrG7I75FGm1DnaDuVUWF1pWAWUwGmn1sCJ1VGHn8LhN1aTOw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-presence": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-presence/-/react-presence-1.1.6.tgz",
+      "integrity": "sha512-zdTk4PlUO0E18HnZ3wYbW0KkJJxWCdiNYp6g6X1PtONFhxVkg01vliTJAmwIszU6mHiyBOoW9P0rAugl5/hULQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-primitive": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-primitive/-/react-primitive-2.1.5.tgz",
+      "integrity": "sha512-zifXeB8Y88qCYx8PLZ5oQb32KwZub+s925mMoZsBBq9KUQqWKkREubTfs6ASjRPPBe7Jt9O8OHH89+95VG+grA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-slot": "1.2.5"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "apps/web/node_modules/@radix-ui/react-roving-focus": {
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-roving-focus/-/react-roving-focus-1.1.12.tgz",
+      "integrity": "sha512-FvgPt1bRmg8Xt2QpF7NUZW3dE0ZQHGm41dAdgT2J2GJPoIXz+9Em3NobAxf4fupcxhgHu03E5CRiU2MWvObXyg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/primitive": "1.1.4",
+        "@radix-ui/react-collection": "1.1.9",
+        "@radix-ui/react-compose-refs": "1.1.3",
+        "@radix-ui/react-context": "1.1.4",
+        "@radix-ui/react-direction": "1.1.2",
+        "@radix-ui/react-id": "1.1.2",
+        "@radix-ui/react-primitive": "2.1.5",
+        "@radix-ui/react-use-callback-ref": "1.1.2",
+        "@radix-ui/react-use-controllable-state": "1.2.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "@types/react-dom": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc",
+        "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
     "apps/web/node_modules/@types/react": {
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -69,7 +373,7 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
-      "dev": true,
+      "devOptional": true,
       "license": "MIT",
       "peerDependencies": {
         "@types/react": "^19.2.0"
@@ -1096,6 +1400,44 @@
         "node": ">=12"
       }
     },
+    "node_modules/@floating-ui/core": {
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.7.5.tgz",
+      "integrity": "sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/dom": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.7.6.tgz",
+      "integrity": "sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/core": "^1.7.5",
+        "@floating-ui/utils": "^0.2.11"
+      }
+    },
+    "node_modules/@floating-ui/react-dom": {
+      "version": "2.1.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.8.tgz",
+      "integrity": "sha512-cC52bHwM/n/CxS87FH0yWdngEZrjdtLW/qVruo68qg+prK7ZQ4YGdut2GyDVpoGeAYe/h899rVeOVm6Oi40k2A==",
+      "license": "MIT",
+      "dependencies": {
+        "@floating-ui/dom": "^1.7.6"
+      },
+      "peerDependencies": {
+        "react": ">=16.8.0",
+        "react-dom": ">=16.8.0"
+      }
+    },
+    "node_modules/@floating-ui/utils": {
+      "version": "0.2.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.11.tgz",
+      "integrity": "sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==",
+      "license": "MIT"
+    },
     "node_modules/@iconify-json/simple-icons": {
       "version": "1.2.78",
       "resolved": "https://registry.npmjs.org/@iconify-json/simple-icons/-/simple-icons-1.2.78.tgz",
@@ -1277,6 +1619,235 @@
       "peerDependencies": {
         "vitepress": ">=1.0.0"
       }
+    },
+    "node_modules/@radix-ui/primitive": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/primitive/-/primitive-1.1.4.tgz",
+      "integrity": "sha512-7AdCK9PQyiljKoBDbN8OuctCbd/esdwZPQ8RtOE3SsyQtUpiPb+ND75q0jEhC1m1ecBI0MFNeLJvwIh9iKHRcQ==",
+      "license": "MIT"
+    },
+    "node_modules/@radix-ui/react-compose-refs": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-compose-refs/-/react-compose-refs-1.1.3.tgz",
+      "integrity": "sha512-rYOP8OMnuuPMQF1uhPVlGNcCDlkokKqGFE3JcxFViIkAXP7EvFWUliJAstrapypaBLJNHbZL6jGhbVDGTwmVhA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-context": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-context/-/react-context-1.1.4.tgz",
+      "integrity": "sha512-QwH4PO5urrbO+FaGd5Aglg+YJgWTyyuZ3g/6mKvsqraLkglDdckw9JafgL5McL5VEJ6EPNduPaT3ZE9BttDAqg==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-direction": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-direction/-/react-direction-1.1.2.tgz",
+      "integrity": "sha512-C3vFhbyi4SW3PmbAi6Awpu4OzJtd0MxGurvSsYtr7p7nM8RNB3VAF3CUmnp2j50knpkrRcB7+ycVXzgLgF6yNA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-focus-guards": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-focus-guards/-/react-focus-guards-1.1.4.tgz",
+      "integrity": "sha512-cot/aB/mOm0IYVYTTmQcEEK1M48lZWi8FlYe5nDPQQ8NYZUlXEFgncJ9p2Kzer3RKSrY7cTTpEMLZKNo9QoP5Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-id": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-id/-/react-id-1.1.2.tgz",
+      "integrity": "sha512-orBC88futVpqCmhX1p4cvquNHsELQ+w+vBJnuj3ftETI5bJb0bZn3Tqu3SWN2IOcPycTnMGnhwoermvISt72sA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-slot": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-slot/-/react-slot-1.2.5.tgz",
+      "integrity": "sha512-rCMO3QsIVKv5JTY5CVbo2MvO77SpEqqYc8AvRE7OWqRDOIqAKjsp+DrmnY9uc8NPdxB5E2z47HTYGeE2+NTptg==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-compose-refs": "1.1.3"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-callback-ref": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-callback-ref/-/react-use-callback-ref-1.1.2.tgz",
+      "integrity": "sha512-xCso9j1/u8sEgP1RNHjFrXJLApL8LiqOkI1R4ywuN00rxWdYg4oQXuwKLS3i0j5NWLromUD27/4nlxj2UFVvIw==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-controllable-state": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-controllable-state/-/react-use-controllable-state-1.2.3.tgz",
+      "integrity": "sha512-PLzC90MS+ReootmjC597dvopoelpZ8Q61HJkDXZSExitIq7PL55vHNnesAHwguHK0aPfBnpdNzQtv1uliaqQrA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-effect-event": "0.0.3",
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-effect-event": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-effect-event/-/react-use-effect-event-0.0.3.tgz",
+      "integrity": "sha512-6c8ZqvPTWILEKnyVkP53EGRCcpnJiKTC21sS/6R1GF5xKyHJJWQEPfkqlcgUkdRQivd6tb23abUwe4ngWmY0JA==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-escape-keydown": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-escape-keydown/-/react-use-escape-keydown-1.1.2.tgz",
+      "integrity": "sha512-2uVLvLjgO7NZCWw01/FdqRwmA42J0BcjPMUCA+koFEOAb+zjqIP7SiFz/7zWPrKnVmSqr76Omq2ALyCuX4dhLw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-callback-ref": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-layout-effect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-layout-effect/-/react-use-layout-effect-1.1.2.tgz",
+      "integrity": "sha512-jrBWOxZITuGcnjRCM2t2U5ZPkCLxD+Ym6DjfssS5haTj2iiak/DOb64JeN6OdLfLgptb6/e2kKR+ZuTrGoZTPA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-rect/-/react-use-rect-1.1.2.tgz",
+      "integrity": "sha512-d8a+bBY/FxikNPlgJJoaBHZX+zKVbWHYJGTLnLvveQgFSTntkGdEKv3JDtHrMS0DNYpllz2nRsTLGLKYttbpmw==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/rect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/react-use-size": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-use-size/-/react-use-size-1.1.2.tgz",
+      "integrity": "sha512-giWQp+4mxjBPt4KZ0MmyuykFNWfbDxKt4x+fPkRYmgRFJSbCZFzUglvMb/Kjn38tm10YP4ufiQZDx3zna4LU6w==",
+      "license": "MIT",
+      "dependencies": {
+        "@radix-ui/react-use-layout-effect": "1.1.2"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@radix-ui/rect": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/rect/-/rect-1.1.2.tgz",
+      "integrity": "sha512-xnXE7wG13PI+cxieVssYXlQJuYVRhH9NBoxt3KNwzghDIA69GMm7d4wXRouHIYjE+KvS6U/MsMO73NdS2MH9ZA==",
+      "license": "MIT"
     },
     "node_modules/@rolldown/pluginutils": {
       "version": "1.0.0-beta.27",
@@ -2457,6 +3028,18 @@
       "integrity": "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==",
       "license": "MIT"
     },
+    "node_modules/aria-hidden": {
+      "version": "1.2.6",
+      "resolved": "https://registry.npmjs.org/aria-hidden/-/aria-hidden-1.2.6.tgz",
+      "integrity": "sha512-ik3ZgC9dY/lYVVM++OISsaYDeg1tb0VtP5uL3ouh1koGOaUMDPpbFIei4JkFimWUFPn90sbMNMXQAIVOlnYKJA==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/autoprefixer": {
       "version": "10.5.0",
       "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
@@ -2821,6 +3404,12 @@
         "node": ">=6"
       }
     },
+    "node_modules/detect-node-es": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/detect-node-es/-/detect-node-es-1.1.0.tgz",
+      "integrity": "sha512-ypdmJU/TbBby2Dxibuv7ZLW3Bs1QEmM7nHjEANfohJLvE0XVujisn1qPJcZxg+qDucsr+bP6fLD1rPS3AhJ7EQ==",
+      "license": "MIT"
+    },
     "node_modules/devlop": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
@@ -3070,6 +3659,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/get-nonce": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-nonce/-/get-nonce-1.0.1.tgz",
+      "integrity": "sha512-FJhYRoDaiatfEkUK8HKlicmu/3SGFD51q3itKDGoSTysQJBnfOcxU5GxnhE1E6soB76MbT0MBtnKJuXyAx+96Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/glob-parent": {
@@ -4789,9 +5387,7 @@
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-18.3.1.tgz",
       "integrity": "sha512-5m4nQKp+rZRb09LNH59GM4BxTh9251/ylbKIbpe7TpGxfJ+9kv6BLkLBXIjjspbgbnIBNqlI23tRnTWT0snUIw==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
@@ -4836,6 +5432,75 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-remove-scroll": {
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll/-/react-remove-scroll-2.7.2.tgz",
+      "integrity": "sha512-Iqb9NjCCTt6Hf+vOdNIZGdTiH1QSqr27H/Ek9sv/a97gfueI/5h1s3yRi1nngzMUaOOToin5dI1dXKdXiF+u0Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-remove-scroll-bar": "^2.3.7",
+        "react-style-singleton": "^2.2.3",
+        "tslib": "^2.1.0",
+        "use-callback-ref": "^1.3.3",
+        "use-sidecar": "^1.1.3"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-remove-scroll-bar": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/react-remove-scroll-bar/-/react-remove-scroll-bar-2.3.8.tgz",
+      "integrity": "sha512-9r+yi9+mgU33AKcj6IbT9oRCO78WriSj6t/cF8DWBZJ9aOGPOTEDvdUDz1FwKim7QXWwmHqtdHnRJfhAxEG46Q==",
+      "license": "MIT",
+      "dependencies": {
+        "react-style-singleton": "^2.2.2",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/react-style-singleton": {
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/react-style-singleton/-/react-style-singleton-2.2.3.tgz",
+      "integrity": "sha512-b6jSvxvVnyptAiLjbkWLE/lOnR4lfTtDAl+eUC7RZy+QQWc6wRzIV2CE6xBuMmDxc2qIihtDCZD5NPOFl7fRBQ==",
+      "license": "MIT",
+      "dependencies": {
+        "get-nonce": "^1.0.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/read-cache": {
@@ -5079,9 +5744,7 @@
       "version": "0.23.2",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.23.2.tgz",
       "integrity": "sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
       "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0"
@@ -5397,6 +6060,12 @@
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "license": "Apache-2.0"
     },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
+    },
     "node_modules/typescript": {
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
@@ -5541,6 +6210,49 @@
       },
       "peerDependencies": {
         "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/use-callback-ref": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/use-callback-ref/-/use-callback-ref-1.3.3.tgz",
+      "integrity": "sha512-jQL3lRnocaFtu3V00JToYz/4QkNWswxijDaCVNZRiRTO3HQDLsdu1ZtmIUvV4yPp+rvWm5j0y0TG/S61cuijTg==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/use-sidecar": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/use-sidecar/-/use-sidecar-1.1.3.tgz",
+      "integrity": "sha512-Fedw0aZvkhynoPYlA5WXrMCAMm+nSWdZt6lzJQ7Ok8S6Q+VsHmHpRWndVRJ8Be0ZbkfPc5LRYH+5XrzXcEeLRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "detect-node-es": "^1.1.0",
+        "tslib": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "@types/react": "*",
+        "react": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/util-deprecate": {


### PR DESCRIPTION
**Context-menu system — slice 1.** Draft / hold for local test. Built on the DS foundation (shadcn Radix), per your call.

- **Registry keyed by `ContextType`** — `registerContextMenu({ type, items, priority })`; the menu for a type is the **merged union** of all registrations (core *and* plugins), priority-sorted + deduped. *This is the plugin extension point.*
- **Imperative** `openContextMenu(type, e, ctx)` from any `onContextMenu`; one **`<ContextMenuRenderer>`** at the root on shadcn's Radix `DropdownMenu` (focus/keyboard/dismiss a11y for free, themed by tokens).
- **Item shape** with context-aware `label`/`disabled`/`visible`, dividers, danger, shortcuts.
- **First menu — `rail-surface`:** right-click a rail icon → **Move to other rail** (the swap trigger, done right — replaces the layout-breaking hover buttons; Chat/plugins offer no move). Uses the `railOf`/`moveSurface` store.
- Also fixed a React-19/react-markdown typing error the new dep surfaced.

Build clean, **64 e2e** (added right-click → menu → move).

**Test on :7901:** right-click any rail icon (Notes/Beads/Agent/etc.) → a themed menu → *Move to other rail* sends it across (persists on reload). Right-clicking Chat or a plugin gives no move item (pinned).

Next: expose `registerContextMenu` via the plugin-ui SDK (0034) so plugins add items; then chat-message/note/bead menus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)