### PR TITLE
feat(console): mobile shell — quick-bar + hamburger (ADR 0035 S4) [HOLD: local test]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Mobile shell (ADR 0035 slice 4)** — below 768px the console drops the dual-rail split for a
+  single-surface view with a **bottom quick-bar** (configurable, default Chat/Activity/Knowledge/
+  Plugins) + a **hamburger drawer** listing every surface. Chat stays mounted (streaming
+  continuity). Breakpoint-driven off the same store; desktop unchanged. (Drawer is interim —
+  swaps for `@protolabsai/ui`'s Drawer when it lands.)
 - **Everything-swappable rails (ADR 0036)** — plugin views are now first-class `railOrder`
   members (reconciled in/out as plugins come and go), and **Chat is movable too** (it mounts on
   whichever rail holds it, preserving streaming continuity). Right-click any surface → **Move up /

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -121,3 +121,23 @@ test("Chat is movable too — right-click → move to the right rail (ADR 0036)"
   await expect(rightRail.getByRole("button", { name: "Chat", exact: true })).toBeVisible();
   await expect(leftRail.getByRole("button", { name: "Chat", exact: true })).toHaveCount(0);
 });
+
+test("mobile shell: bottom quick-bar + hamburger drawer (ADR 0035 S4)", async ({ page }) => {
+  await page.setViewportSize({ width: 390, height: 800 });
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // Below the breakpoint: the desktop rails are gone; a bottom quick-bar appears.
+  await expect(page.locator(".rail")).toHaveCount(0);
+  const bar = page.locator(".mobile-bar");
+  await expect(bar).toBeVisible();
+
+  // A default quick-bar surface switches the single active surface.
+  await bar.getByRole("button", { name: "Knowledge", exact: true }).click();
+
+  // The hamburger opens a drawer with the full surface list.
+  await bar.getByRole("button", { name: "All surfaces" }).click();
+  const drawer = page.getByRole("dialog", { name: "Surfaces" });
+  await expect(drawer).toBeVisible();
+  await drawer.getByRole("button", { name: "Beads", exact: true }).click();
+  await expect(drawer).toHaveCount(0); // picking closes it
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -86,6 +86,8 @@ import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
 import { SurfaceRail } from "../components/SurfaceRail";
+import { MobileNav } from "../components/MobileNav";
+import { useIsMobile } from "../lib/useIsMobile";
 import { ContextMenuRenderer, openContextMenu } from "../contextMenu";
 import { StageSubnav } from "./StageSubnav";
 import { PanelHeader } from "./PanelHeader";
@@ -244,6 +246,10 @@ export function App() {
   const setRightWidth = useUI((s) => s.setRightWidth);
   const railOrder = useUI((s) => s.railOrder);
   const reconcilePluginViews = useUI((s) => s.reconcilePluginViews);
+  const isMobile = useIsMobile();
+  const mobileActive = useUI((s) => s.mobileActive);
+  const setMobileActive = useUI((s) => s.setMobileActive);
+  const quickBar = useUI((s) => s.quickBar);
   const [live, setLive] = useState(false);
   // Shared custom confirm for destructive actions (notes/beads delete).
   const [confirmState, setConfirmState] = useState<
@@ -854,6 +860,22 @@ export function App() {
         </div>
       </header>
 
+      {isMobile ? (
+        /* Mobile shell (ADR 0035 S4): one surface at a time + a bottom quick-bar + hamburger; no
+           rails, no split. Chat mounts unconditionally for streaming continuity. */
+        <div className="workspace mobile">
+          <main className="stage">
+            <ChatSurface onError={setError} active={mobileActive === "chat"} />
+            {mobileActive !== "chat" ? renderSurface(mobileActive) : null}
+          </main>
+          <MobileNav
+            items={[...railSurfaces("left"), ...railSurfaces("right")]}
+            activeId={mobileActive}
+            onSelect={setMobileActive}
+            quickBarIds={quickBar}
+          />
+        </div>
+      ) : (
       <div
         className={`workspace ${rightCollapsed ? "right-collapsed" : ""}`}
         style={{ "--right-width": rightCol } as CSSProperties}
@@ -921,6 +943,7 @@ export function App() {
           onContextMenu={(e, id) => openContextMenu("rail-surface", e, { id, side: "right" })}
         />
       </div>
+      )}
 
       <footer className="utility-bar">
         <a

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3327,3 +3327,100 @@ textarea {
   word-break: break-word;
 }
 
+
+/* Mobile shell (ADR 0035 S4) — single surface + bottom quick-bar + hamburger drawer. The
+   --pl-color-overlay / --pl-color-bg-hover tokens land in @protolabsai/design 0.4.0; fallbacks
+   keep it correct until then. */
+.workspace.mobile {
+  display: flex;
+  flex-direction: column;
+  grid-template-columns: none;
+}
+.workspace.mobile .stage {
+  flex: 1;
+  min-height: 0;
+  border-right: none;
+  padding-bottom: 60px; /* clear the fixed bottom bar */
+}
+.mobile-bar {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  display: flex;
+  border-top: 1px solid var(--border);
+  background: var(--bg-panel);
+  z-index: 40;
+}
+.mobile-tab {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 3px;
+  padding: 8px 4px;
+  background: transparent;
+  border: none;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  cursor: pointer;
+}
+.mobile-tab.active {
+  color: var(--brand-violet-light);
+}
+.mobile-drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background: var(--pl-color-overlay, rgba(0, 0, 0, 0.55));
+  z-index: 50;
+  display: flex;
+}
+.mobile-drawer {
+  width: 82%;
+  max-width: 320px;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-panel);
+  border-right: 1px solid var(--border);
+}
+.mobile-drawer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  font-size: 0.85rem;
+}
+.mobile-drawer-head button {
+  background: transparent;
+  border: none;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.mobile-drawer-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px;
+  overflow: auto;
+}
+.mobile-drawer-list button {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  background: transparent;
+  border: none;
+  border-radius: var(--radius);
+  color: var(--fg);
+  cursor: pointer;
+  text-align: left;
+  font-size: 0.85rem;
+}
+.mobile-drawer-list button.active,
+.mobile-drawer-list button:hover {
+  background: var(--pl-color-bg-hover, rgba(255, 255, 255, 0.06));
+}

--- a/apps/web/src/components/MobileNav.tsx
+++ b/apps/web/src/components/MobileNav.tsx
@@ -1,0 +1,59 @@
+import { useState } from "react";
+import { Menu, X } from "lucide-react";
+import type { ReactNode } from "react";
+
+export type MobileItem = { id: string; label: string; icon: ReactNode };
+
+// Mobile bottom quick-bar + hamburger drawer (ADR 0035 S4). Dumb + props-driven (extraction-ready).
+// The drawer is a minimal interim sheet — swap for @protolabsai/ui's Drawer when it lands (ADR 0037 D7).
+export function MobileNav({
+  items,
+  activeId,
+  onSelect,
+  quickBarIds,
+}: {
+  items: MobileItem[];
+  activeId: string;
+  onSelect: (id: string) => void;
+  quickBarIds: string[];
+}) {
+  const [open, setOpen] = useState(false);
+  const byId = new globalThis.Map(items.map((i) => [i.id, i] as const));
+  const quick = quickBarIds.map((id) => byId.get(id)).filter((i): i is MobileItem => Boolean(i)).slice(0, 5);
+  const pick = (id: string) => { onSelect(id); setOpen(false); };
+
+  return (
+    <>
+      <nav className="mobile-bar" aria-label="Quick surfaces">
+        {quick.map((it) => (
+          <button key={it.id} className={`mobile-tab${it.id === activeId ? " active" : ""}`} type="button" onClick={() => pick(it.id)}>
+            {it.icon}
+            <span>{it.label}</span>
+          </button>
+        ))}
+        <button className="mobile-tab" type="button" onClick={() => setOpen(true)} aria-label="All surfaces">
+          <Menu size={18} />
+          <span>More</span>
+        </button>
+      </nav>
+      {open ? (
+        <div className="mobile-drawer-overlay" onClick={() => setOpen(false)}>
+          <div className="mobile-drawer" role="dialog" aria-label="Surfaces" onClick={(e) => e.stopPropagation()}>
+            <div className="mobile-drawer-head">
+              <span>Surfaces</span>
+              <button type="button" onClick={() => setOpen(false)} aria-label="Close"><X size={18} /></button>
+            </div>
+            <div className="mobile-drawer-list">
+              {items.map((it) => (
+                <button key={it.id} className={it.id === activeId ? "active" : ""} type="button" onClick={() => pick(it.id)}>
+                  {it.icon}
+                  <span>{it.label}</span>
+                </button>
+              ))}
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/lib/useIsMobile.ts
+++ b/apps/web/src/lib/useIsMobile.ts
@@ -1,0 +1,16 @@
+import { useEffect, useState } from "react";
+
+// True below the mobile breakpoint (ADR 0035 S4). Drives the single-surface mobile shell vs the
+// desktop dual-rail split. SSR-safe (defaults to false until mounted).
+const QUERY = "(max-width: 767px)";
+export function useIsMobile(): boolean {
+  const [mobile, setMobile] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia(QUERY);
+    const on = () => setMobile(mq.matches);
+    on();
+    mq.addEventListener("change", on);
+    return () => mq.removeEventListener("change", on);
+  }, []);
+  return mobile;
+}

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -48,6 +48,11 @@ type UIState = {
   // Sync plugin views into railOrder (ADR 0036) — append newly-available ones to their placement
   // side, prune `plugin:` ids no longer present. Core surfaces are left untouched.
   reconcilePluginViews: (views: { id: string; side: "left" | "right" }[]) => void;
+  // Mobile shell (ADR 0035 S4): one active surface + a configurable bottom quick-bar.
+  mobileActive: string;
+  setMobileActive: (id: string) => void;
+  quickBar: string[]; // surfaces pinned to the mobile bottom bar (cap 5)
+  toggleQuickBar: (id: string) => void;
   setSurface: (s: Surface) => void;
   setRightPanel: (p: RightPanel) => void;
   setAgentTab: (t: AgentTab) => void;
@@ -93,6 +98,15 @@ export const useUI = create<UIState>()(
             return next;
           };
           return { railOrder: { left: swap(s.railOrder.left), right: swap(s.railOrder.right) } };
+        }),
+      mobileActive: "chat",
+      setMobileActive: (mobileActive) => set({ mobileActive }),
+      quickBar: ["chat", "activity", "knowledge", "plugins"],
+      toggleQuickBar: (id) =>
+        set((s) => {
+          if (s.quickBar.includes(id)) return { quickBar: s.quickBar.filter((x) => x !== id) };
+          if (s.quickBar.length >= 5) return s; // cap the bottom bar
+          return { quickBar: [...s.quickBar, id] };
         }),
       reconcilePluginViews: (views) =>
         set((s) => {


### PR DESCRIPTION
**Mobile shell — slice 4.** Draft / hold for local test (resize the browser narrow, or device-emulate).

Below **768px** the console drops the dual-rail split for a **single-surface** view:
- A fixed **bottom quick-bar** — configurable (`store.quickBar`, default Chat/Activity/Knowledge/Plugins).
- A **hamburger** → drawer listing every surface; tap to switch.
- **Chat stays mounted** for streaming continuity; desktop layout untouched.

Componentized **`<MobileNav>`** (props-driven, extraction-ready). The drawer is a **minimal interim sheet** — swaps for `@protolabsai/ui`'s Drawer when it lands (ADR 0037 D7).

Build clean, **65 desktop e2e + a mobile-viewport test** green.

**Test:** narrow the browser (<768px) or device-emulate on :7901 → bottom bar + hamburger; tap surfaces; reopen wide → dual rails back.

Next: with this, the 0035 layout arc is complete (S1–S4 + everything-swappable); remaining roadmap is the federation slices (0034 S2–S4) + adopting `@protolabsai/ui` when it merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)