### PR TITLE
feat(console): plugin-ui SDK host bridge + reference remote (ADR 0034 S2 pt2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Plugin-UI SDK: host bridge + reference remote (ADR 0034 slice 2)** — `@protoagent/plugin-ui`
+  now exposes a **host bridge** (`setHostBridge`/`getHostBridge`: the authed API client, `authToken`,
+  `apiUrl`, `brandName`) so a remote gets host context without importing host internals. The
+  `hello-react` reference remote **consumes the SDK**: it registers a context-menu item that
+  appears in the host's rail menus — the end-to-end proof that a federated plugin extends the
+  console's menus across the boundary (ADR 0036).
 - **Plugin-UI SDK foundation (ADR 0034 slice 2)** — a new versioned **`@protoagent/plugin-ui`**
   package now holds the context-menu registry/store/types, and the host shares it as a **Module
   Federation singleton** — so a `ui: react` remote gets the *same* registry instance and a plugin

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -88,3 +88,18 @@ test("a ui:react view mounts a federated React remote (ADR 0034), not an iframe"
   await page.getByRole("button", { name: /clicked 0×/ }).click();
   await expect(page.getByRole("button", { name: /clicked 1×/ })).toBeVisible();
 });
+
+test("a ui:react remote contributes a context-menu item via the SDK (ADR 0034 S2 / 0036)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // Open the React view → the remote mounts and registers a menu item through @protoagent/plugin-ui.
+  await page.locator(".rail-right").getByRole("button", { name: "React Panel", exact: true }).click();
+  await expect(page.getByText("Hello from a React plugin remote", { exact: false })).toBeVisible();
+
+  // Right-click a rail surface → the HOST's menu now includes the PLUGIN's item, proving a remote
+  // registers into the host's shared registry across the federation boundary.
+  await page.locator(".rail-right").getByRole("button", { name: "Notes", exact: true }).click({ button: "right" });
+  await expect(
+    page.getByTestId("context-menu").getByText("Hello from the React plugin", { exact: false }),
+  ).toBeVisible();
+});

--- a/apps/web/remotes/hello-react/Panel.tsx
+++ b/apps/web/remotes/hello-react/Panel.tsx
@@ -1,16 +1,33 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
+import { getHostBridge, registerContextMenu } from "@protoagent/plugin-ui";
 
 // Exposed as ./Panel and mounted by the console's FederatedView (ADR 0034 slice 1).
 // The useState hook proves this remote shares the HOST's React — a second React copy
 // would throw "invalid hook call" the moment this renders.
 export default function Panel() {
   const [n, setN] = useState(0);
+
+  // ADR 0034 S2 — the remote consumes the @protoagent/plugin-ui SDK. Because the host shares the
+  // SDK as a federation singleton, this registers into the HOST's context-menu registry: the item
+  // shows up when you right-click a rail surface, proving cross-boundary plugin menu contribution
+  // (ADR 0036). Returns the unregister fn so it's cleaned up on unmount.
+  useEffect(() => registerContextMenu({
+    type: "rail-surface",
+    priority: -10, // after the host's own items
+    items: [{ id: "hello-plugin-demo", label: "Hello from the React plugin 👋", run: () => setN((x) => x + 1) }],
+  }), []);
+
+  // The host bridge gives the remote authed host context without importing host internals.
+  let brand = "the console";
+  try { brand = getHostBridge().brandName; } catch { /* bridge unset (standalone build) */ }
+
   return (
     <div style={{ padding: 16, display: "flex", flexDirection: "column", gap: 10 }}>
       <strong>Hello from a React plugin remote 👋</strong>
       <span style={{ fontSize: "0.85rem", opacity: 0.8 }}>
-        A federated Module Federation remote, mounted directly into the console's React tree —
-        not an iframe. It shares the host's React + query cache (ADR 0034).
+        A federated Module Federation remote, mounted directly into {brand}'s React tree — not an
+        iframe. It shares the host's React + query cache, and uses the @protoagent/plugin-ui SDK
+        (ADR 0034). Right-click a rail icon to see the menu item this plugin registered.
       </span>
       <button type="button" onClick={() => setN((x) => x + 1)} style={{ alignSelf: "flex-start" }}>
         clicked {n}× (shared-React hook works)

--- a/apps/web/remotes/hello-react/vite.config.ts
+++ b/apps/web/remotes/hello-react/vite.config.ts
@@ -23,6 +23,7 @@ export default defineConfig({
         react: { requiredVersion: false },
         "react-dom": { requiredVersion: false },
         "@tanstack/react-query": { requiredVersion: false },
+        "@protoagent/plugin-ui": { requiredVersion: false },
       },
     }),
   ],

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,14 +1,21 @@
 import { QueryClientProvider } from "@tanstack/react-query";
+import { setHostBridge } from "@protoagent/plugin-ui";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./app/App";
+import { api, apiUrl, authToken } from "./lib/api";
+import { brandName } from "./lib/brand";
 // ADR 0037 — design-system foundation. Order matters: brand tokens (--pl-*) first, then
 // Tailwind + the shadcn→token bridge, then the legacy theme.css (which may reference --pl-*).
 import "@protolabsai/design/css/tokens";
 import "./app/tailwind.css";
 import "./app/theme.css";
 import { queryClient } from "./lib/queryClient";
+
+// Inject the host bridge once at startup (ADR 0034 D4) — `ui: react` plugin remotes read it via
+// getHostBridge() for authed API access + host context, without importing host internals.
+setHostBridge({ api, authToken, apiUrl, brandName: brandName() });
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/packages/plugin-ui/src/host.ts
+++ b/packages/plugin-ui/src/host.ts
@@ -1,0 +1,26 @@
+// Host bridge (ADR 0034 D4). The host injects this once at startup; a `ui: react` remote reads it
+// via getHostBridge() to make authed API calls + read host context, without importing host
+// internals. The SDK is a federation singleton, so there's one bridge across host + remotes.
+export interface HostBridge {
+  // The host's API client (authed fetch wrapper). Typed loosely so the SDK doesn't depend on the
+  // host's concrete shape; remotes cast to the documented surface.
+  api: unknown;
+  authToken: () => string;
+  apiUrl: (path: string) => string;
+  brandName: string;
+}
+
+let bridge: HostBridge | null = null;
+
+export function setHostBridge(b: HostBridge): void {
+  bridge = b;
+}
+
+export function getHostBridge(): HostBridge {
+  if (!bridge) {
+    throw new Error(
+      "@protoagent/plugin-ui: host bridge not set — the console host must call setHostBridge() at startup.",
+    );
+  }
+  return bridge;
+}

--- a/packages/plugin-ui/src/index.ts
+++ b/packages/plugin-ui/src/index.ts
@@ -5,6 +5,8 @@
 // host and every remote — that's what makes cross-boundary registerContextMenu work.
 export { registerContextMenu, resolveMenu } from "./registry";
 export { openContextMenu, useContextMenuStore } from "./store";
+export { setHostBridge, getHostBridge } from "./host";
+export type { HostBridge } from "./host";
 export type {
   ContextType,
   MenuItem,


### PR DESCRIPTION
**S2 part 2 — the SDK proven end-to-end.** Green-safe (plumbing + a test-fixture remote; no console-visual change), so merging on green per your 'roll through'.

- **Host bridge** in `@protoagent/plugin-ui`: `setHostBridge`/`getHostBridge` — the host injects its authed API client + `authToken`/`apiUrl`/`brandName` at startup; a remote reads host context without importing internals.
- **`hello-react` reference remote consumes the SDK** — shares it as a federation singleton, calls `registerContextMenu`, reads the bridge.
- **New e2e proves it**: open the React view → right-click a rail icon → the **plugin's menu item shows up in the host's menu**. That's cross-boundary plugin menu contribution working — the payoff of the shared-registry singleton (#749) + ADR 0036.

No `@protolabsai/ui` dependency. Build clean, **67 e2e green**.

Next: **S3 — the trust gate** (manifest `ui: react|iframe`, third-party opt-in, iframe fallback, renderer dispatch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)