### PR TITLE
feat(console): plugin trust gate — ui:react in-process only if host-trusted (ADR 0034 S3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Plugin trust gate (ADR 0034 slice 3)** — a `ui: react` plugin mounts **in-process only if
+  host-trusted** (a shipped first-party allowlist ∪ the operator's `plugins.trusted`); an untrusted
+  `ui: react` view **degrades to a sandboxed iframe**. Trust is **host-decided, never plugin-
+  declared** — deny-by-default. New `POST /api/plugins/{id}/trusted` + a **"Trust React"** toggle
+  in the Plugins surface so the operator can promote a plugin.
 - **Plugin-UI SDK: host bridge + reference remote (ADR 0034 slice 2)** — `@protoagent/plugin-ui`
   now exposes a **host bridge** (`setHostBridge`/`getHostBridge`: the authed API client, `authToken`,
   `apiUrl`, `brandName`) so a remote gets host context without importing host internals. The

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -54,7 +54,15 @@ export const RUNTIME_STATUS = {
         // the host tree, not an iframe. Points at the built hello-react remote the host serves.
         {
           id: "react-panel", label: "React Panel", icon: "Atom", placement: "right",
-          ui: "react", path: "/plugins/boardy/scratch",
+          // trusted:true — the host's allowlist promoted this plugin to the in-process React mount
+          // (ADR 0034 D5). An untrusted ui:react view would fall back to the iframe of `path`.
+          ui: "react", path: "/plugins/boardy/scratch", trusted: true,
+          remote: { url: "/app/remotes/hello-react/assets/remoteEntry.js", module: "./Panel" },
+        },
+        // The same React view but UNTRUSTED — the trust gate (D5) must degrade it to an iframe.
+        {
+          id: "react-untrusted", label: "React Untrusted", icon: "Atom", placement: "right",
+          ui: "react", path: "/plugins/boardy/scratch", trusted: false,
           remote: { url: "/app/remotes/hello-react/assets/remoteEntry.js", module: "./Panel" },
         },
       ],

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -103,3 +103,11 @@ test("a ui:react remote contributes a context-menu item via the SDK (ADR 0034 S2
     page.getByTestId("context-menu").getByText("Hello from the React plugin", { exact: false }),
   ).toBeVisible();
 });
+
+test("the trust gate degrades an untrusted ui:react view to an iframe (ADR 0034 D5)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".rail-right").getByRole("button", { name: "React Untrusted", exact: true }).click();
+  // Untrusted ui:react → the sandboxed iframe of its path, NOT the in-process federated remote.
+  await expect(page.locator(".plugin-view-frame")).toBeVisible();
+  await expect(page.getByText("Hello from a React plugin remote", { exact: false })).toHaveCount(0);
+});

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -56,10 +56,11 @@ export function PluginView({ view }: { view: PluginViewType }) {
     }
   }
 
-  // ADR 0034 — a `ui: react` view mounts a federated React remote into the host tree
-  // (one React, shared query cache) instead of an iframe. The iframe path below is
-  // unchanged and stays the default for `ui: iframe` / untrusted plugins.
-  if (view.ui === "react" && view.remote) {
+  // ADR 0034 — a `ui: react` view mounts a federated React remote into the host tree (one React,
+  // shared query cache) instead of an iframe. The trust gate (D5) is enforced here: only a
+  // host-trusted plugin gets the in-process mount; an untrusted `ui: react` view falls through to
+  // the sandboxed iframe of its `path` below. Trust is host-decided (never the plugin's word).
+  if (view.ui === "react" && view.remote && view.trusted) {
     return (
       <section className="panel stage-panel plugin-view">
         <div className="plugin-view-body">

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -866,6 +866,13 @@ export const api = {
       { method: "POST", body: { enabled } },
     );
   },
+  // ADR 0034 D5 — allow/revoke a plugin's in-process React mount (operator trust opt-in).
+  setPluginTrusted(id: string, trusted: boolean) {
+    return request<{ ok: boolean; trusted: boolean; reloaded: boolean }>(
+      `/api/plugins/${encodeURIComponent(id)}/trusted`,
+      { method: "POST", body: { trusted } },
+    );
+  },
   addMcpServer(entry: Record<string, unknown>) {
     return request<{ ok: boolean; name: string; servers: string[] }>(
       "/api/mcp/servers",

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -62,6 +62,8 @@ export type RuntimeStatus = {
     version?: string;
     enabled: boolean;
     loaded: boolean;
+    // ADR 0034 D5 — host-decided trust; gates whether the plugin's ui:react views mount in-process.
+    trusted?: boolean;
     tools: string[];
     skills: number;
     error?: string;
@@ -87,6 +89,9 @@ export type PluginView = {
   // For ui:"react" — the Module Federation remote: the remoteEntry URL + the exposed module
   // key (e.g. "./Panel"). `scope` (the federation remote name) defaults to the view id.
   remote?: { url: string; module: string; scope?: string };
+  // ADR 0034 D5 — host-decided trust (shipped allowlist ∪ operator's plugins.trusted). Only a
+  // trusted plugin gets the in-process React mount; untrusted `ui: react` degrades to the iframe.
+  trusted?: boolean;
 };
 
 // A git-installed plugin (ADR 0027) — a plugins.lock entry enriched with its

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -26,8 +26,18 @@ function contributionsLabel(p: Plugin): string {
   );
 }
 
-function PluginRow({ p, busy, onToggle }: { p: Plugin; busy: boolean; onToggle: (p: Plugin) => void }) {
+function PluginRow({
+  p, busy, onToggle, onTrust, trustBusy,
+}: {
+  p: Plugin;
+  busy: boolean;
+  onToggle: (p: Plugin) => void;
+  onTrust: (p: Plugin) => void;
+  trustBusy: boolean;
+}) {
   const on = p.enabled;
+  // Trust only matters for plugins that ship an in-process React view (ADR 0034 D5).
+  const hasReactView = p.views?.some((v) => v.ui === "react") ?? false;
   return (
     <div className="subagent-row" key={p.id}>
       <div>
@@ -42,6 +52,21 @@ function PluginRow({ p, busy, onToggle }: { p: Plugin; busy: boolean; onToggle: 
           label={p.loaded ? "loaded" : p.error ? "error" : p.enabled ? "enabled" : "disabled"}
           tone={p.loaded ? "success" : p.error ? "error" : "muted"}
         />
+        {hasReactView ? (
+          <button
+            type="button"
+            className="ghost-button"
+            disabled={trustBusy}
+            onClick={() => onTrust(p)}
+            title={
+              p.trusted
+                ? `Revoke trust — ${p.name}'s React views fall back to a sandboxed iframe`
+                : `Trust ${p.name} to mount its React views in-process (shares the console's React/auth)`
+            }
+          >
+            {trustBusy ? <Loader2 size={14} className="spin" /> : p.trusted ? "Trusted ✓" : "Trust React"}
+          </button>
+        ) : null}
         <button
           type="button"
           className="ghost-button"
@@ -78,6 +103,22 @@ function LocalTab() {
   const onToggle = (p: Plugin) => { setHint(null); toggle.mutate(p); };
   const pendingId = toggle.isPending ? toggle.variables?.id : undefined;
 
+  // Trust opt-in (ADR 0034 D5) — promote a plugin's ui:react views to the in-process mount.
+  const trust = useMutation({
+    mutationFn: (p: Plugin) => api.setPluginTrusted(p.id, !p.trusted),
+    onSuccess: (res, p) => {
+      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      setHint(
+        res.trusted
+          ? `${p.name} trusted — its React views now mount in-process.`
+          : `${p.name} trust revoked — its React views fall back to a sandboxed iframe.`,
+      );
+    },
+    onError: (err: unknown, p) => setHint(`Couldn't change trust for ${p.name}: ${err instanceof Error ? err.message : String(err)}`),
+  });
+  const onTrust = (p: Plugin) => { setHint(null); trust.mutate(p); };
+  const trustPendingId = trust.isPending ? trust.variables?.id : undefined;
+
   const plugins = runtime.plugins ?? [];
   const byName = (a: Plugin, b: Plugin) => a.name.localeCompare(b.name);
   const loaded = plugins.filter((p) => p.loaded).sort(byName);
@@ -93,13 +134,13 @@ function LocalTab() {
             {loaded.length ? (
               <>
                 <p className="panel-kicker">Loaded <span className="muted">· {loaded.length}</span></p>
-                <div className="subagent-list">{loaded.map((p) => <PluginRow key={p.id} p={p} busy={pendingId === p.id} onToggle={onToggle} />)}</div>
+                <div className="subagent-list">{loaded.map((p) => <PluginRow key={p.id} p={p} busy={pendingId === p.id} onToggle={onToggle} onTrust={onTrust} trustBusy={trustPendingId === p.id} />)}</div>
               </>
             ) : null}
             {disabled.length ? (
               <>
                 <p className="panel-kicker">Disabled <span className="muted">· {disabled.length}</span></p>
-                <div className="subagent-list">{disabled.map((p) => <PluginRow key={p.id} p={p} busy={pendingId === p.id} onToggle={onToggle} />)}</div>
+                <div className="subagent-list">{disabled.map((p) => <PluginRow key={p.id} p={p} busy={pendingId === p.id} onToggle={onToggle} onTrust={onTrust} trustBusy={trustPendingId === p.id} />)}</div>
               </>
             ) : null}
           </>

--- a/graph/config.py
+++ b/graph/config.py
@@ -364,6 +364,11 @@ class LangGraphConfig:
     # Lets a fork disable a bundled first-party plugin (e.g. the Discord surface)
     # without deleting its directory or editing core.
     plugins_disabled: list[str] = field(default_factory=list)
+    # Trust allowlist (ADR 0034 D5) — plugin ids the operator allows to mount as
+    # IN-PROCESS React (`ui: react`), sharing the host's React/query/auth. Shipped
+    # first-party ids are trusted automatically (loader ``_SHIPPED_TRUSTED_PLUGINS``);
+    # every other plugin defaults to the sandboxed iframe until added here.
+    plugins_trusted: list[str] = field(default_factory=list)
     plugins_dir: str = ""
     # Optional source allowlist for git-URL installs (ADR 0027 D3) — host/org globs
     # (e.g. ``github.com/protoLabsAI/*``); empty = any URL allowed (gated install).
@@ -595,6 +600,7 @@ class LangGraphConfig:
             agent_runtime=str(data.get("agent_runtime", cls.agent_runtime) or "native"),
             plugins_enabled=list(plugins.get("enabled", []) or []),
             plugins_disabled=list(plugins.get("disabled", []) or []),
+            plugins_trusted=list(plugins.get("trusted", []) or []),
             plugins_dir=plugins.get("dir", cls.plugins_dir),
             plugins_sources_allow=list((plugins.get("sources", {}) or {}).get("allow", []) or []),
             identity_name=identity.get("name", cls.identity_name),

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -137,6 +137,14 @@ def run_plugin_mcp_main(plugin_id: str) -> None:
     raise RuntimeError(f"plugin {plugin_id!r} not found for --mcp-plugin")
 
 
+# First-party plugin ids we SHIP pre-trusted for in-process `ui: react` mounting (ADR 0034 D5).
+# A `ui: react` view runs in-process with the host's React/query/auth, so trust is host-decided
+# here — NEVER self-declared by a plugin manifest. Every plugin not in this set (and not in the
+# operator's ``plugins.trusted`` allowlist) defaults to the sandboxed iframe. Add an id only when
+# we ship + vet that plugin as first-party (e.g. ``notes`` once ADR 0034 S4 ports it).
+_SHIPPED_TRUSTED_PLUGINS: frozenset[str] = frozenset()
+
+
 def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLoadResult:
     """Load enabled plugins and collect their contributions.
 
@@ -147,23 +155,28 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
     roots = _plugin_roots(config)
     enabled_ids = set(getattr(config, "plugins_enabled", []) or [])
     disabled_ids = set(getattr(config, "plugins_disabled", []) or [])
+    trusted_ids = set(getattr(config, "plugins_trusted", []) or [])
     seen_tool_names = set(core_tool_names or set())
 
     for manifest in discover_plugins(roots):
         # plugins.disabled wins — turn off a bundled plugin (e.g. a first-party
         # surface) without deleting it or editing core.
         enabled = (manifest.enabled or manifest.id in enabled_ids) and manifest.id not in disabled_ids
+        # Trust is HOST-decided (ADR 0034 D5): shipped first-party ids + the operator's allowlist.
+        # A plugin can NOT self-declare trust; an untrusted `ui: react` view degrades to iframe.
+        trusted = manifest.id in _SHIPPED_TRUSTED_PLUGINS or manifest.id in trusted_ids
         entry = {
             "id": manifest.id,
             "name": manifest.name,
             "version": manifest.version,
             "enabled": enabled,
+            "trusted": trusted,
             "loaded": False,
             "tools": [],
             "skills": 0,
-            # Console surfaces (ADR 0026) — the rail reads these from
-            # /api/runtime/status to render a dynamic icon + iframe per view.
-            "views": list(manifest.views) if enabled else [],
+            # Console surfaces (ADR 0026) — the rail reads these from /api/runtime/status. Each
+            # view carries the host-decided `trusted` flag; the renderer gates the React path on it.
+            "views": [{**v, "trusted": trusted} for v in manifest.views] if enabled else [],
         }
 
         if not enabled:

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -33,12 +33,13 @@ def register_plugin_routes(app) -> None:
 
     @app.get("/api/plugins/installed")
     async def _installed():
-        # enabled state comes from the loader's per-plugin meta (id → enabled)
+        # enabled + trust state come from the loader's per-plugin meta (ADR 0034 D5)
         enabled = {p["id"]: bool(p.get("enabled")) for p in (STATE.plugin_meta or [])}
+        trusted = {p["id"]: bool(p.get("trusted")) for p in (STATE.plugin_meta or [])}
         root = installer.live_plugins_dir()
         out = []
         for e in installer.list_installed():
-            item = {**e, "enabled": enabled.get(e["id"], False)}
+            item = {**e, "enabled": enabled.get(e["id"], False), "trusted": trusted.get(e["id"], False)}
             m = load_manifest(root / e["id"]) if e.get("present") else None
             if m is not None:
                 item["manifest"] = {
@@ -100,6 +101,26 @@ def register_plugin_routes(app) -> None:
         meta = next((p for p in (STATE.plugin_meta or []) if p.get("id") == plugin_id), None)
         restart = bool(want and meta and meta.get("views"))
         return {"ok": True, "enabled": want, "reloaded": True, "restart_recommended": restart}
+
+    @app.post("/api/plugins/{plugin_id}/trusted")
+    async def _set_trusted(plugin_id: str, body: dict | None = None):
+        """Allow/revoke a plugin's IN-PROCESS React mount by editing ``plugins.trusted`` (ADR 0034
+        D5). An untrusted ``ui: react`` plugin renders in a sandboxed iframe; trusting it lets the
+        renderer mount it as a federated React remote (host React/query/auth). Operator-gated — a
+        plugin can't trust itself. A console view only re-renders after the meta refreshes, so the
+        new trust applies on the next status poll (no restart needed for the gate itself)."""
+        want = bool((body or {}).get("trusted"))
+        cfg = STATE.graph_config
+        trusted = [p for p in (getattr(cfg, "plugins_trusted", []) or []) if p != plugin_id]
+        if want:
+            trusted.append(plugin_id)
+
+        from server.agent_init import _apply_settings_changes
+
+        ok, messages = _apply_settings_changes(config={"plugins": {"trusted": trusted}})
+        if not ok:
+            raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
+        return {"ok": True, "trusted": want, "reloaded": True}
 
     @app.delete("/api/plugins/{plugin_id}")
     async def _uninstall(plugin_id: str, purge: bool = False):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -308,6 +308,27 @@ def test_loader_meta_exposes_views_for_enabled_plugin(monkeypatch, tmp_path) -> 
     assert [v["id"] for v in meta["views"]] == ["board"]
 
 
+def test_loader_stamps_host_decided_trust_on_views(monkeypatch, tmp_path) -> None:
+    # A `ui: react` plugin can NOT self-declare trust (ADR 0034 D5) — the host decides, via the
+    # shipped allowlist + the operator's plugins.trusted. Default is untrusted → sandboxed iframe.
+    root = tmp_path / "plugins"
+    _make_plugin(
+        root, "reacty", enabled=True, tool="rt",
+        manifest_extra="views:\n  - {id: panel, label: Panel, path: /plugins/reacty/panel, ui: react}\n",
+    )
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+
+    # Not shipped-trusted, not operator-trusted → untrusted (renderer falls back to iframe).
+    res = load_plugins(_cfg(plugins_enabled=["reacty"]))
+    assert res.meta[0]["trusted"] is False
+    assert res.meta[0]["views"][0]["trusted"] is False
+
+    # Operator adds it to plugins.trusted → trusted (the React path is unlocked).
+    res = load_plugins(_cfg(plugins_enabled=["reacty"], plugins_trusted=["reacty"]))
+    assert res.meta[0]["trusted"] is True
+    assert res.meta[0]["views"][0]["trusted"] is True
+
+
 # ── full-bundle auto-discovery (ADR 0027) ─────────────────────────────────────
 
 


### PR DESCRIPTION
**S3 — the trust gate (D5 security boundary).** The model you confirmed: a shipped allowlist + manual operator opt-in for anything else, deny-by-default.

- A `ui: react` view runs **in-process** (host React/query/auth), so **trust is host-decided, never plugin-declared**: the loader stamps `trusted` onto each view from `_SHIPPED_TRUSTED_PLUGINS` (first-party) **∪** the operator's `plugins.trusted`.
- **Untrusted `ui: react` → sandboxed iframe** of its path (D6 fallback). Deny-by-default.
- **`POST /api/plugins/{id}/trusted`** (operator opt-in) + a **"Trust React"** toggle in the Plugins surface (only for plugins that ship a react view).

**26 python tests** (incl. host-decided stamping) + **68 e2e** (trusted mounts, untrusted degrades to iframe). No `@protolabsai/ui` dependency. The shipped allowlist is empty for now — **Notes (S4)** will be the first first-party react plugin added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)