### PR TITLE
chore: release v0.30.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.30.0] - 2026-06-09
+
 ### Added
 - **Notes plugin — the first-class React reference plugin (ADR 0034 slice 4)** — a greenfield
   `notes` plugin replaces the legacy native Notes: one shared markdown doc (no tabs/undo/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.29.0"
+version = "0.30.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,27 @@
 [
   {
+    "version": "v0.30.0",
+    "date": "2026-06-09",
+    "changes": [
+      "Notes plugin — the first-class React reference plugin",
+      "Plugin trust gate",
+      "Plugin-UI SDK: host bridge + reference remote",
+      "Plugin-UI SDK foundation",
+      "Mobile shell",
+      "Everything-swappable rails",
+      "Right-click context menus",
+      "Design-system foundation",
+      "Swap surfaces between rails",
+      "Resizable right panel — real handle",
+      "Symmetric dual rails",
+      "Persisted UI state",
+      "Plugin UI — first-class React",
+      "ACP persona reaches GitHub Copilot",
+      "ACP turns attributed correctly in telemetry",
+      "Console upgraded to React 19"
+    ]
+  },
+  {
     "version": "v0.29.0",
     "date": "2026-06-08",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.30.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.30.0 -m 'Release v0.30.0' && git push origin v0.30.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).