### PR TITLE
feat(console): src/ext build-time fork seam (ADR 0038 S3) [HOLD]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its own editor page). The context-menu registry moved back host-internal. Guide rewritten.
 
 ### Added
+- **Fork extension seam (ADR 0038 slice 3)** — a build-time **`src/ext/`** seam: a fork drops a
+  `*.tsx` that calls `registerSurface()` / `registerContextMenu()`; the console auto-loads it via
+  `import.meta.glob`. **Core ships the directory empty**, so `git pull upstream` never conflicts on
+  a fork's additions. The trusted, in-process, fork-owned path — distinct from sandboxed plugins.
+  Completes the two-mode plugin-UI model (ADR 0038).
 - **Generative-UI artifacts (ADR 0038)** — a first-party `artifact` plugin: the agent calls
   `show_artifact(kind, code)` to render HTML / SVG / Mermaid / React on demand into a sandboxed
   iframe (the Claude Artifacts / Open WebUI model). Plus a `rendering-artifacts` skill so the

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -88,6 +88,7 @@ import { PluginView } from "./PluginView";
 import { SurfaceRail } from "../components/SurfaceRail";
 import { MobileNav } from "../components/MobileNav";
 import { useIsMobile } from "../lib/useIsMobile";
+import { registeredSurfaces } from "../ext"; // build-time fork seam (ADR 0038 D3); also self-loads fork surfaces
 import { ContextMenuRenderer, openContextMenu } from "../contextMenu";
 import { StageSubnav } from "./StageSubnav";
 import { PanelHeader } from "./PanelHeader";
@@ -445,7 +446,11 @@ export function App() {
     const extra = (side === "left" ? pluginRail : pluginRightPanels)
       .filter((v) => !placed.has(v.key))
       .map((v): RailItem => ({ id: v.key, label: v.label, icon: pluginViewIcon(v.icon) }));
-    return [...ordered, ...extra];
+    // Fork-contributed surfaces (ADR 0038 D3 — the src/ext seam), appended for their rail side.
+    const ext = registeredSurfaces()
+      .filter((s) => (s.placement ?? "left") === side)
+      .map((s): RailItem => ({ id: s.id, label: s.label, icon: s.icon }));
+    return [...ordered, ...extra, ...ext];
   }
 
   function renderSurface(id: string): ReactNode {
@@ -520,6 +525,9 @@ export function App() {
       case "schedule":
         return <SchedulePanel />;
       default: {
+        // Fork-contributed surface (src/ext seam, ADR 0038 D3) — rendered in-process.
+        const ext = registeredSurfaces().find((s) => s.id === id);
+        if (ext) return ext.render();
         const v = allPluginViews.find((x) => x.key === id);
         return v ? <PluginView key={v.key} view={v} /> : null;
       }

--- a/apps/web/src/ext/README.md
+++ b/apps/web/src/ext/README.md
@@ -1,0 +1,32 @@
+# `src/ext/` — fork extension seam
+
+Add your fork's **own console components without editing core** (ADR 0038 D3). Drop a `*.tsx` file
+here; the console auto-loads it at startup. **Core ships this directory with no `*.tsx` files**, so
+`git pull upstream` never conflicts on your additions — and you rebuild your own app.
+
+This is the **trusted, build-time, in-process** path — for *your* fork. (For shippable, sandboxed,
+git-installable extensions, write a **plugin** instead — see `docs/guides/building-react-plugin-views.md`.)
+
+## Example — add a rail surface
+
+```tsx
+// src/ext/my-dashboard.tsx
+import { BarChart3 } from "lucide-react";
+import { registerSurface, registerContextMenu } from "./index";
+
+registerSurface({
+  id: "my-dashboard",
+  label: "Dashboard",
+  icon: <BarChart3 size={18} />,
+  placement: "left",                  // or "right"
+  render: () => <div className="stage-body">…your React, in-process…</div>,
+});
+
+// You can also contribute context-menu items (ADR 0036):
+registerContextMenu({
+  type: "rail-surface",
+  items: [{ id: "my-action", label: "My action", run: () => { /* … */ } }],
+});
+```
+
+That's it — rebuild and your surface appears in the rail. No core files touched.

--- a/apps/web/src/ext/index.ts
+++ b/apps/web/src/ext/index.ts
@@ -1,0 +1,15 @@
+// The fork seam's public API + auto-loader (ADR 0038 D3).
+//
+// Core ships src/ext/ with no `*.tsx` files. A FORK adds `src/ext/<name>.tsx` modules that import
+// from here and self-register (registerSurface / registerContextMenu). The glob below imports them
+// eagerly at startup so they register. Upstream never edits this directory → `git pull upstream`
+// never conflicts; the fork rebuilds its own app. (Trusted, in-process — see the Security & trust
+// model doc: this is the fork path, NOT the sandboxed-plugin path.)
+export { registerSurface, registeredSurfaces } from "./registry";
+export type { ExtSurface } from "./registry";
+export { registerContextMenu, openContextMenu } from "../contextMenu";
+export type { MenuItem, MenuEntry, ContextType } from "../contextMenu";
+
+// Eagerly load every fork-authored surface module so it self-registers. Empty in core.
+const _fork = import.meta.glob("./*.tsx", { eager: true });
+void _fork;

--- a/apps/web/src/ext/registry.ts
+++ b/apps/web/src/ext/registry.ts
@@ -1,0 +1,24 @@
+import type { ReactNode } from "react";
+
+// Build-time fork seam (ADR 0038 D3). A fork drops a `src/ext/<name>.tsx` that calls
+// registerSurface() to add a console rail surface — WITHOUT editing core App.tsx, so a
+// `git pull upstream` stays conflict-free. Fork surfaces are compiled into the fork's build
+// (trusted, in-process) — distinct from plugins (runtime, sandboxed iframes, ADR 0026/0038).
+export type ExtSurface = {
+  id: string;
+  label: string;
+  icon: ReactNode;
+  placement?: "left" | "right"; // which rail (default: left)
+  render: () => ReactNode;
+};
+
+const _surfaces: ExtSurface[] = [];
+
+export function registerSurface(surface: ExtSurface): void {
+  if (_surfaces.some((s) => s.id === surface.id)) return; // first wins (HMR-safe)
+  _surfaces.push(surface);
+}
+
+export function registeredSurfaces(): ExtSurface[] {
+  return _surfaces;
+}


### PR DESCRIPTION
**ADR 0038 slice 3 — the build-time fork seam. Completes ADR 0038.** Stacked on #756 (the federation nuke).

A fork adds its own console components **without editing core**:
- Drop `src/ext/<name>.tsx` → it calls `registerSurface(...)` / `registerContextMenu(...)`.
- `src/ext/index.ts` auto-loads every `src/ext/*.tsx` via `import.meta.glob` (eager) → they self-register at startup.
- App merges registered surfaces into the rails + renders them in-process.
- **Core ships `src/ext/` empty** (just the registry + loader + README) → `git pull upstream` never conflicts on a fork's additions. The fork rebuilds its own app.

This is the **trusted, in-process, build-time fork path** — the counterpart to **plugins** (runtime, sandboxed iframes). Two clean modes, exactly as ADR 0038 lays out.

Verified: a temp `src/ext/_demo.tsx` auto-loaded + bundled (proving the glob path); removed it so core ships empty. Clean build + **65 e2e green**.

**Note:** stacked on #756 — merge that first. After both, ADR 0038 is done: artifact plugin (#755, merged) + federation retired + Notes-iframe + guide + threat-model (#756) + this seam.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
