### PR TITLE
feat(settings): telemetry opt-out toggle in the console (lean once-over)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its own editor page). The context-menu registry moved back host-internal. Guide rewritten.
 
 ### Added
+- **Telemetry opt-out in Settings** — `telemetry.enabled` (+ retention) are now a console toggle
+  (System → Telemetry), not YAML-only. Off = no store is opened and the per-turn record path no-ops;
+  telemetry is local and never sent anywhere. (Memory/knowledge middleware were already toggles.)
 - **Plugin event bus (ADR 0039)** — promotes the ADR 0003 bus into a decoupled topic pub/sub:
   dot-namespaced topics with `*`/`#` wildcards, in-process handler subscriptions (`registry.on`),
   namespace-guarded publish (`registry.emit` auto-prefixes `<plugin>.`), a ring buffer for SSE

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -132,6 +132,15 @@ FIELDS: list[Field] = [
     Field("middleware.scheduler", "scheduler_enabled", "Scheduler", "bool", "Middleware"),
     Field("middleware.enforcement", "enforcement_enabled", "Tool enforcement", "bool", "Middleware"),
 
+    # ── Telemetry (local cost/latency store, ADR 0006) ───────────────────────
+    Field("telemetry.enabled", "telemetry_enabled", "Store telemetry locally", "bool", "Telemetry",
+          "Persist a per-turn cost/latency row to a local SQLite DB (queryable in Settings → "
+          "Telemetry). Off = nothing is recorded — no store is opened. Stays on your machine; "
+          "it is never sent anywhere.", restart=True),
+    Field("telemetry.retention_days", "telemetry_retention_days", "Telemetry retention (days)",
+          "number", "Telemetry", "Auto-prune rows older than this (0 = keep forever).",
+          minimum=0, restart=True),
+
     # ── Identity / operator ──────────────────────────────────────────────────
     Field("identity.name", "identity_name", "Agent name", "string", "Identity"),
     Field("identity.operator", "identity_operator", "Operator", "string", "Identity"),
@@ -200,6 +209,7 @@ _SECTION_CATEGORY = {
     "Caching": "System",
     "Middleware": "System",
     "Runtime": "System",
+    "Telemetry": "System",
     # Discord / Google / other plugin sections → "Plugins" (the default).
 }
 


### PR DESCRIPTION
Part of a lean once-over of the backend before more UI work (desktop-app-minded).

**The ask:** let someone turn off storing telemetry without editing YAML.

- **telemetry.enabled + retention** are now Settings fields (System → Telemetry). The opt-out was already airtight at the data layer — when off, the store is never built and the per-turn record path returns on a `None` store (zero writes, zero work) — this just surfaces it in the UI. Telemetry is **local and never transmitted**.

**Once-over findings (all good):**
- Core is push-based: one SSE `EventSource`; no always-on polling (react-query refetches pause when backgrounded; the `graph_loaded` poll stops once loaded; chat self-heal is capped).
- Background loops are cheap: hourly telemetry prune + a 60s monitor-goal tick that no-ops when no goals exist.
- Feature gates are honest: `memory_middleware` / `knowledge_middleware` already toggles; the knowledge store and telemetry store are both lazily skipped when their feature is off.

127 settings/config tests green; ruff clean.