### PR TITLE
feat(goals): broadcast goal.achieved/goal.failed on the event bus (ADR 0039)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its own editor page). The context-menu registry moved back host-internal. Guide rewritten.
 
 ### Added
+- **Goals broadcast on the event bus** — a terminal goal now emits `goal.achieved` / `goal.failed`
+  (ADR 0039) with `{session_id, condition, status, reason, evidence, mode}`, alongside the existing
+  plugin `goal_hooks`. **Any plugin (or the console) can react to a goal completing without writing a
+  goal-hook plugin** — the decoupled flywheel (no cross-plugin dependency).
 - **Telemetry opt-out in Settings** — `telemetry.enabled` (+ retention) are now a console toggle
   (System → Telemetry), not YAML-only. Off = no store is opened and the per-turn record path no-ops;
   telemetry is local and never sent anywhere. (Memory/knowledge middleware were already toggles.)

--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -269,6 +269,22 @@ class GoalController:
         self._store.set(state)
         # Plugin lifecycle reactions (ADR 0028 D4) — notify / record / set next goal.
         await fire_goal_hooks(status, state)
+        # Broadcast on the event bus (ADR 0039) so ANY plugin or the console can react to a terminal
+        # goal — no goal_hook plugin required, no cross-dependency. `goal.achieved` on success;
+        # `goal.failed` on exhausted/unachievable. Best-effort: a bus hiccup must never break finish.
+        try:
+            from graph.plugins.host import HOST
+            if HOST.publish:
+                HOST.publish("goal.achieved" if status == "achieved" else "goal.failed", {
+                    "session_id": state.session_id,
+                    "condition": state.condition,
+                    "status": status,
+                    "reason": reason,
+                    "evidence": evidence or state.last_evidence or "",
+                    "mode": state.mode,
+                })
+        except Exception:  # noqa: BLE001
+            log.debug("[goals] goal.* bus emit failed", exc_info=True)
         glyph = {"achieved": "✓", "exhausted": "⏳", "unachievable": "✗"}.get(status, "•")
         return Decision(action="done", state=state, note=f"{glyph} goal {status}: {reason}")
 

--- a/tests/test_goal_hooks.py
+++ b/tests/test_goal_hooks.py
@@ -78,3 +78,29 @@ async def test_controller_finish_fires_on_achieved(tmp_path):
     finally:
         set_goal_hooks([])
         set_plugin_verifiers({})
+
+
+@pytest.mark.asyncio
+async def test_finish_emits_goal_event_on_the_bus(tmp_path):
+    """A terminal goal broadcasts goal.achieved/goal.failed (ADR 0039) so ANY plugin can react —
+    no goal_hook required."""
+    from graph.plugins.host import HOST
+
+    events: list[tuple[str, dict]] = []
+
+    async def _met(spec, ctx):
+        return VerifyResult(True, "passed", "credits=1000000")
+
+    set_plugin_verifiers({"p:always": _met})
+    orig = HOST.publish
+    HOST.publish = lambda topic, data: events.append((topic, data))
+    try:
+        c = GoalController(config=None, store=GoalStore(base_dir=str(tmp_path)))
+        c.set_goal_safe("s", "reach target", {"type": "plugin", "check": "p:always"})
+        await c.evaluate("s", last_text="done")
+        assert events and events[0][0] == "goal.achieved"
+        assert events[0][1]["condition"] == "reach target"
+        assert events[0][1]["status"] == "achieved"
+    finally:
+        HOST.publish = orig
+        set_plugin_verifiers({})


### PR DESCRIPTION
A terminal goal now publishes **goal.achieved** (success) / **goal.failed** (exhausted/unachievable) to the bus — {session_id, condition, status, reason, evidence, mode} — alongside the existing plugin goal_hooks.

So **any plugin or the console can react to a goal completing without writing a goal-hook plugin** — the decoupled flywheel, no cross-plugin dependency. Best-effort emit (a bus hiccup never breaks finish). The agent set_goal tool stays plugin-only.

This is the keystone for goal-driven reactions (run a workflow/subagent on achieve/fail) + the console goal toast.

79 goal tests green.