### PR TITLE
feat(goals): enrich viewer + completion toast (ADR 0039) [HOLD]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   its own editor page). The context-menu registry moved back host-internal. Guide rewritten.
 
 ### Added
+- **Goals come alive in the console** — the Goals panel now shows a **monitor** badge + last-checked
+  (vs drive iteration count), and a goal finishing raises a **toast** (`goal.achieved`/`goal.failed`,
+  ADR 0039). Authoring stays in chat (`/goal`); the panel is observe + clear. Goal-mode guide updated.
 - **Goals broadcast on the event bus** — a terminal goal now emits `goal.achieved` / `goal.failed`
   (ADR 0039) with `{session_id, condition, status, reason, evidence, mode}`, alongside the existing
   plugin `goal_hooks`. **Any plugin (or the console) can react to a goal completing without writing a

--- a/apps/web/e2e/events.spec.ts
+++ b/apps/web/e2e/events.spec.ts
@@ -10,3 +10,12 @@ test("live indicator turns connected when the event stream opens", async ({ page
   // EventSource onopen flips it live shortly after the response headers arrive.
   await expect(dot).toHaveAttribute("data-live", "true");
 });
+
+test("a goal.achieved bus event surfaces a toast", async ({ page }) => {
+  // ADR 0039 — the mock pushes a one-shot goal.achieved; the console toasts it so a plain
+  // operator notices a terminal goal without writing a plugin hook.
+  await page.goto("/app/", { waitUntil: "load" });
+  const toast = page.locator(".pl-toast", { hasText: "Goal achieved" });
+  await expect(toast).toBeVisible();
+  await expect(toast).toContainText("unit tests pass");
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -246,11 +246,12 @@ const server = createServer(async (req, res) => {
       frame("inbox.item", { id: 99, priority: "next", source: "mock", text: "live inbox ping" });
       frame("boardy.created", { id: "b1" }); // ADR 0039 — exercises the rail notification dot
     }, 500);
-    // One-shot goal.achieved (ADR 0039) so the goal toast is deterministically testable.
-    const g = setTimeout(() => {
-      res.write('event: goal.achieved\ndata: {"condition":"unit tests pass","status":"achieved","mode":"drive"}\n\n');
-    }, 300);
-    req.on("close", () => { clearInterval(t); clearTimeout(g); });
+    // goal.achieved (ADR 0039) so the goal toast is testable. Must be an UNNAMED topic-in-payload
+    // frame like the others — the client routes via onmessage, not named SSE events. Fire a couple
+    // of times early so a slow connect can't miss the one-shot (the toast just needs to appear once).
+    const goals = [setTimeout(() => frame("goal.achieved", { condition: "unit tests pass", status: "achieved", mode: "drive" }), 300),
+                   setTimeout(() => frame("goal.achieved", { condition: "unit tests pass", status: "achieved", mode: "drive" }), 1200)];
+    req.on("close", () => { clearInterval(t); goals.forEach(clearTimeout); });
     return;
   }
   if (pathname.startsWith("/api/")) {

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -246,7 +246,11 @@ const server = createServer(async (req, res) => {
       frame("inbox.item", { id: 99, priority: "next", source: "mock", text: "live inbox ping" });
       frame("boardy.created", { id: "b1" }); // ADR 0039 — exercises the rail notification dot
     }, 500);
-    req.on("close", () => clearInterval(t));
+    // One-shot goal.achieved (ADR 0039) so the goal toast is deterministically testable.
+    const g = setTimeout(() => {
+      res.write('event: goal.achieved\ndata: {"condition":"unit tests pass","status":"achieved","mode":"drive"}\n\n');
+    }, 300);
+    req.on("close", () => { clearInterval(t); clearTimeout(g); });
     return;
   }
   if (pathname.startsWith("/api/")) {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -94,6 +94,7 @@ import { StageSubnav } from "./StageSubnav";
 import { PanelHeader } from "./PanelHeader";
 import { brandName } from "../lib/brand";
 import { onConnectionChange, onServerEvent, onTopic } from "../lib/events";
+import { useToast } from "@protolabsai/ui";
 import { StatusPill } from "./StatusPill";
 import { GoalsPanel } from "./GoalsPanel";
 import { BeadsPanel } from "./BeadsPanel";
@@ -345,6 +346,21 @@ export function App() {
       }),
     [],
   );
+
+  // Goal completions surface as a toast (goal.achieved / goal.failed on the bus, ADR 0039) so a
+  // plain operator notices a terminal goal without writing a plugin hook.
+  const toast = useToast();
+  useEffect(() => {
+    const offDone = onServerEvent("goal.achieved", (d) =>
+      toast({ tone: "success", title: "Goal achieved", message: String(d.condition || "the goal") }));
+    const offFail = onServerEvent("goal.failed", (d) =>
+      toast({
+        tone: "error",
+        title: "Goal failed",
+        message: `${String(d.condition || "the goal")}${d.reason ? ` — ${String(d.reason)}` : ""}`,
+      }));
+    return () => { offDone(); offFail(); };
+  }, [toast]);
   useEffect(() => {
     if (viewingInbox()) setInboxUnread(0);
   }, [surface, activityTab]);

--- a/apps/web/src/app/GoalsPanel.tsx
+++ b/apps/web/src/app/GoalsPanel.tsx
@@ -27,6 +27,16 @@ function goalTone(status: string) {
   return "muted" as const;
 }
 
+function ago(epochSeconds: number): string {
+  const s = Math.max(0, Math.floor(Date.now() / 1000 - epochSeconds));
+  if (s < 60) return `${s}s ago`;
+  if (s < 3600) return `${Math.floor(s / 60)}m ago`;
+  if (s < 86400) return `${Math.floor(s / 3600)}h ago`;
+  return `${Math.floor(s / 86400)}d ago`;
+}
+
+const trunc = (t: string, n = 80) => (t.length > n ? `${t.slice(0, n)}…` : t);
+
 function GoalsList() {
   const { data } = useSuspenseQuery(goalsQuery());
   const goals = data.goals;
@@ -53,14 +63,17 @@ function GoalsList() {
         <div className="goal-row" key={goal.session_id}>
           <div className="goal-row-head">
             <strong>{goal.condition || goal.session_id}</strong>
+            {goal.mode === "monitor" ? <StatusPill label="monitor" tone="muted" /> : null}
             <StatusPill label={goal.status} tone={goalTone(goal.status)} />
           </div>
           <span className="goal-row-meta">
-            {goal.session_id} · {goal.verifier?.type || "llm"} · iter {goal.iteration ?? 0}/
-            {goal.max_iterations ?? 0}
-            {goal.last_reason
-              ? ` · ${goal.last_reason.length > 80 ? `${goal.last_reason.slice(0, 80)}…` : goal.last_reason}`
-              : ""}
+            {goal.session_id} · {goal.verifier?.type || "llm"}
+            {goal.mode === "monitor" ? (
+              <> · watched{goal.last_checked ? ` · checked ${ago(goal.last_checked)}` : ""}</>
+            ) : (
+              <> · iter {goal.iteration ?? 0}/{goal.max_iterations ?? 0}</>
+            )}
+            {goal.last_reason ? ` · ${trunc(goal.last_reason)}` : ""}
           </span>
           <button
             className="icon-button goal-row-clear"

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -197,9 +197,12 @@ export type GoalState = {
   condition: string;
   status: string;
   verifier?: { type?: string } & Record<string, unknown>;
+  mode?: "drive" | "monitor";
   iteration?: number;
   max_iterations?: number;
   last_reason?: string;
+  last_evidence?: string;
+  last_checked?: number | null; // monitor: last out-of-band verifier check (epoch seconds)
   started_at?: number;
   finished_at?: number | null;
 };

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -1,4 +1,5 @@
 import { QueryClientProvider } from "@tanstack/react-query";
+import { ToastProvider } from "@protolabsai/ui";
 import React from "react";
 import ReactDOM from "react-dom/client";
 
@@ -14,7 +15,9 @@ import { queryClient } from "./lib/queryClient";
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
     <QueryClientProvider client={queryClient}>
-      <App />
+      <ToastProvider>
+        <App />
+      </ToastProvider>
     </QueryClientProvider>
   </React.StrictMode>,
 );

--- a/docs/guides/goal-mode.md
+++ b/docs/guides/goal-mode.md
@@ -1,6 +1,13 @@
 # Goal mode
 
-Goal mode gives the agent a **testable outcome** and lets it self-drive toward it: after every turn the agent stops on, a **verifier** checks whether the goal is met; if not, the agent is re-invoked with a continuation prompt until it passes, runs out of budget, or is flagged unachievable.
+A **goal** is a testable outcome you attach to the agent — a *condition* plus a **verifier** that ground-truths whether it's met (a shell command's exit code, a test run, a CI status, a data assertion, a plugin check, or an LLM judgment as the fallback). Goals turn "please do X" into "keep going / watch until X is provably true."
+
+There are **two kinds**, and the difference is *who moves the needle*:
+
+- **Drive** (default) — *the agent's own turns* do the work. After each turn the verifier runs; if not met, the agent is re-invoked with a continuation prompt until it passes, the iteration budget is spent, or it's flagged unachievable. Use for "make the tests pass," "finish the README."
+- **Monitor** (ADR 0030) — *an external process* moves the needle (a background engine, a training run, a deployment, a market). The agent only starts/supervises; the goal is checked **out-of-band on a cadence** and never re-invokes the agent. Use for "treasury ≥ 1,000,000," "rollout reaches 100%."
+
+When a goal reaches a terminal state it **broadcasts on the event bus** (`goal.achieved` / `goal.failed`, ADR 0039) — so the console, or any plugin, can react without writing code (see [Reacting to a goal](#reacting-to-a-goal)).
 
 It's modelled on protocli's goal system but deliberately more rigorous for a long-running server agent:
 
@@ -55,12 +62,29 @@ Programmatic status/clear is also available: `GET /api/goal/{session_id}` and `D
 
 ## Manage from the console
 
-The React console's **Goals** surface lists every session's goal — its condition, status (`active` / `achieved` / `exhausted` / `unachievable`), iteration count, verifier type, and the latest verifier reason — and lets you **clear** any of them. Goals are still *set* in chat with `/goal` (setting can run shell/test verifiers, so it stays an explicit in-chat action); the panel is a read-and-clear view. Backed by:
+The React console's **Goals** surface (right sidebar) lists every session's goal — its condition, status (`active` / `achieved` / `exhausted` / `unachievable`), a **`monitor` badge** for monitor goals, the verifier type, and either the drive **iteration count** or (for monitor) **when it was last checked** — plus the latest verifier reason. You can **clear** any of them. When a goal finishes, the console shows a **toast** (`goal.achieved` → success, `goal.failed` → error), driven by the bus events below.
+
+Goals are still *set* in chat with `/goal` (setting can run shell/test verifiers, so it stays an explicit operator action); the panel is a read-and-clear view. Backed by:
 
 | Method | Path | Purpose |
 |---|---|---|
 | `GET` | `/api/goals` | List all goals across sessions (`{goals, enabled}`) |
+| `POST` | `/api/goals` | Set a goal **programmatically** — `plugin` verifier only (safe set; command/test/ci/data/llm stay operator-only via `/goal`) |
 | `DELETE` | `/api/goals/{session_id}` | Clear one (`{cleared}`) |
+
+## Reacting to a goal
+
+A terminal goal is a **trigger**, not just a checkbox. Every finish publishes one of two events on the [event bus](/guides/plugins#events-the-plugin-bus) (ADR 0039):
+
+| Topic | When | Payload |
+|---|---|---|
+| `goal.achieved` | verifier passed | `{session_id, condition, status, reason, evidence, mode}` |
+| `goal.failed` | `exhausted` / `unachievable` | same shape |
+
+Two ways to react:
+
+- **No code (any plugin / the console).** Subscribe to the topic — `registry.on("goal.achieved", …)` in a plugin, or `protoagent:subscribe` from a sandboxed view. The built-in console toast is exactly this. Because it's the bus, **nobody imports the goal system** to listen.
+- **Plugin code (richer).** `register_goal_hook(on_achieved=…, on_failed=…)` hands your plugin the terminal `GoalState` to run arbitrary logic — set the next goal (phase progression), kick a follow-up agent turn via `host.invoke`, stop a background engine, alert. This is how a fork drives an autonomous loop: *set a monitor goal → external engine runs → the cadence tick verifies → the hook advances.*
 
 ## Verifier types
 


### PR DESCRIPTION
Goals #2 + #3 + #4 — make goals observable without scope creep (no modal, no reaction engine; authoring stays in chat).

- **Viewer**: a `monitor` badge + last-checked for monitor goals (vs drive iter count). Read-only.
- **Toast**: goal.achieved → success, goal.failed → error (rides the ADR 0039 bus events from #763). The operator notices a terminal goal with zero plugin code.
- **Docs**: goal-mode.md gets the drive/monitor framing, the enriched viewer, and a \"Reacting to a goal\" section (bus events for no-code reactions; register_goal_hook for plugin code).

66 e2e green (incl. a goal.achieved→toast test); build + docs clean. Held for local test on :7901: set a /goal that completes (e.g. an llm goal you can satisfy) → toast + the panel updates.

Note: uses onServerEvent (works on main today; stays compatible once the #761 dispatcher lands).