### PR TITLE
feat(console): intro splash once per session, not every refresh [HOLD]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Intro splash shows once per session** — the launch bumper is gated by `sessionStorage`, so a
+  refresh no longer replays the 2.5s splash; a fresh tab session sees it once. (Automation still skips it.)
 - **Plugin devkit refreshed (v0.2.0)** — the reference plugin + scaffolder now models current best
   practice: console views are sandboxed iframes served under `/api/plugins/<id>` (bearer-gated, ADR
   0038/0026), and the event bus (ADR 0039) is first-class — the scaffold stubs + the `building-plugins`

--- a/apps/web/src/app/IntroSplash.tsx
+++ b/apps/web/src/app/IntroSplash.tsx
@@ -12,16 +12,31 @@ import { ProtoLabsIcon } from "./ProtoLabsIcon";
  */
 
 const HOLD_MS = 2500; // entrance + hold before handing off to the app
+const SEEN_KEY = "protoagent.introSeen"; // sessionStorage — show the bumper once per tab session
+
+// Skip the splash when: (a) under automation (Playwright sets navigator.webdriver) so the 2.5s
+// overlay doesn't intercept E2E, or (b) it's already played this session — so a refresh doesn't
+// replay it. sessionStorage clears when the tab closes, so a fresh session sees it once.
+function alreadySeen(): boolean {
+  if (typeof navigator !== "undefined" && (navigator as Navigator).webdriver === true) return true;
+  try {
+    return sessionStorage.getItem(SEEN_KEY) === "1";
+  } catch {
+    return false; // private mode / storage blocked — fall through and show it
+  }
+}
 
 export function IntroSplash() {
-  // Skip under automation (Playwright/Selenium set navigator.webdriver) so the
-  // 2.5s overlay doesn't intercept E2E interactions. Real users see it.
-  const [gone, setGone] = useState(
-    () => typeof navigator !== "undefined" && (navigator as Navigator).webdriver === true,
-  );
+  const [gone, setGone] = useState(alreadySeen);
 
   useEffect(() => {
-    if (gone) return; // skipped (automation) — no timer, nothing to unmount
+    if (gone) return; // skipped (automation or already seen) — no timer, nothing to unmount
+    // Mark it seen immediately so a refresh *during* the hold also skips it.
+    try {
+      sessionStorage.setItem(SEEN_KEY, "1");
+    } catch {
+      /* storage blocked — it'll just replay next refresh */
+    }
     const t = window.setTimeout(() => {
       const doc = document as Document & {
         startViewTransition?: (cb: () => void) => unknown;


### PR DESCRIPTION
The launch bumper replayed its 2.5s hold on every refresh. Now gated by **sessionStorage** (`protoagent.introSeen`): marked seen the moment it shows, so a refresh — even mid-hold — skips it; a fresh tab session sees it once. Automation still skips it; storage-blocked contexts fall through and show it.

One file (IntroSplash.tsx). Build clean; e2e unaffected (splash already skipped under webdriver).

**Test on :7901:** load once (see the splash) → refresh → no splash. New tab/window → splash once.