### PR TITLE
feat(chat): surface the tool card on the model's first streamed tool-call token

### DIFF
--- a/server/chat.py
+++ b/server/chat.py
@@ -178,6 +178,7 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
     accumulated_raw = ""
     streamed_len = 0  # chars of visible <output> already emitted as text frames
     _llm_started: dict[str, float] = {}  # run_id → monotonic start (per-call latency)
+    announced_tools: set[str] = set()  # tool_call ids already surfaced as a start frame
     async for event in STATE.graph.astream_events(
         graph_input,
         config=config,
@@ -191,24 +192,35 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
             if rid:
                 _llm_started[rid] = time.monotonic()
         elif kind == "on_tool_start":
-            tool_input = event.get("data", {}).get("input", "")
-            # Structured frame (id pairs start↔end) so consumers can render a
-            # per-tool card; the A2A handler also derives a text status from it.
-            yield ("tool_start", {
-                "id": event.get("run_id") or name,
-                "name": name,
-                "input": _coerce_tool_value(tool_input),
-            })
+            # No frame here: the tool card is surfaced earlier — on the model's first
+            # streamed tool-call token (on_chat_model_stream) and finalized with full
+            # args on on_chat_model_end, both keyed by the tool_call id so on_tool_end
+            # closes the same card. Execution-start carries only a run_id (no
+            # tool_call id to correlate), so it would just make a duplicate card.
+            pass
         elif kind == "on_tool_end":
             output = event.get("data", {}).get("output", "")
+            # Close the card keyed by the tool_call id (the ToolMessage carries it);
+            # fall back to run_id/name for non-tool-message producers.
             yield ("tool_end", {
-                "id": event.get("run_id") or name,
+                "id": getattr(output, "tool_call_id", None) or event.get("run_id") or name,
                 "name": name,
                 "output": _coerce_tool_output(output),
             })
         elif kind == "on_chat_model_stream":
             chunk = event.get("data", {}).get("chunk")
-            if chunk and hasattr(chunk, "content") and chunk.content:
+            if chunk is None:
+                continue
+            # Surface the tool card the moment the model streams a tool *name* —
+            # before the call is fully formed or executed — so the UI shows
+            # "<tool> · running" instead of a bare loading wheel. Keyed by the
+            # tool_call id; on_chat_model_end fills the args, on_tool_end closes it.
+            for tcc in (getattr(chunk, "tool_call_chunks", None) or []):
+                tcid, tcname = tcc.get("id"), tcc.get("name")
+                if tcid and tcname and tcid not in announced_tools:
+                    announced_tools.add(tcid)
+                    yield ("tool_start", {"id": tcid, "name": tcname, "input": ""})
+            if hasattr(chunk, "content") and chunk.content:
                 accumulated_raw += chunk.content if isinstance(chunk.content, str) else str(chunk.content)
                 # Stream only the user-facing <output> region, token by token —
                 # never the scratch_pad. The terminal artifact (extract_output)
@@ -219,6 +231,14 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
                     streamed_len = len(visible)
         elif kind == "on_chat_model_end":
             output = event.get("data", {}).get("output")
+            # Finalize each tool card with its full args, keyed by the tool_call id
+            # (and announce any the stream didn't catch — e.g. a non-streaming model).
+            for tc in (getattr(output, "tool_calls", None) or []):
+                tcid = tc.get("id")
+                if tcid:
+                    announced_tools.add(tcid)
+                    yield ("tool_start", {"id": tcid, "name": tc.get("name", ""),
+                                          "input": _coerce_tool_value(tc.get("args", ""))})
             usage = getattr(output, "usage_metadata", None) if output else None
             rid = event.get("run_id")
             latency_s = max(0.0, time.monotonic() - _llm_started.pop(rid, time.monotonic())) if rid else 0.0

--- a/server/chat.py
+++ b/server/chat.py
@@ -231,8 +231,10 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
                     streamed_len = len(visible)
         elif kind == "on_chat_model_end":
             output = event.get("data", {}).get("output")
-            # Finalize each tool card with its full args, keyed by the tool_call id
-            # (and announce any the stream didn't catch — e.g. a non-streaming model).
+            # Finalize each tool card with its full args, keyed by the tool_call id.
+            # `announced_tools` is scoped to THIS turn: this pass also surfaces a card
+            # for any tool the stream path didn't announce (e.g. a non-streaming model)
+            # without re-emitting an early start already sent earlier this turn.
             for tc in (getattr(output, "tool_calls", None) or []):
                 tcid = tc.get("id")
                 if tcid:


### PR DESCRIPTION
## Problem
The per-tool card in the console only appears once the tool **executes** (`on_tool_start`) — which is after the model has fully formed the tool call (name **and** args). On a streaming turn that leaves a bare loading wheel with no signal of what's happening until the call is complete.

## Fix
Surface the card on the model's **first streamed tool-call token**:
- **`on_chat_model_stream`** — when `tool_call_chunks` first reveal a *name*, emit `tool_start {id: tool_call_id, name, input: ""}`. The UI renders "<tool> · running" instantly (name only).
- **`on_chat_model_end`** — emit `tool_start` again with the **full args**, keyed by the same `tool_call_id` (updates the card; also announces tools for non-streaming models).
- **`on_tool_end`** — close keyed by the ToolMessage's `tool_call_id` (was `run_id`), so start↔end share one card.
- **`on_tool_start`** — dropped: it only carries a `run_id` (no `tool_call_id` to correlate), so it would have produced a duplicate card.

All frames now key by the model's `tool_call_id`, which flows through the existing tool-call-v1 DataPart → `ChatSurface` card pipeline unchanged.

## Verification
Against `astream_events(v2)` with a real tool call, the frame order is: name-only `tool_start` (early) → filled-args `tool_start` → `tool_end`, all sharing the `tool_call_id` (one card). The early frame fires well before the result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)