### PR TITLE
feat(plugins): bundles — install a curated set of plugins as one (ADR 0040)

### DIFF
--- a/docs/adr/0040-plugin-bundles.md
+++ b/docs/adr/0040-plugin-bundles.md
@@ -1,0 +1,72 @@
+# 0040 — Plugin bundles (install a curated set of plugins as one)
+
+- Status: Accepted
+- Date: 2026-06-09
+- Builds on: ADR 0027 (git-installable plugins — `plugin install <url>` + `plugins.lock` + `sync`).
+
+## Context
+
+ADR 0027 made each plugin a standalone, git-URL-installable repo, pinned in a committed
+`plugins.lock`. That is the right *atom* — independent versioning, independent release cadence, one
+repo per capability. But a working agent is usually a **stack** of several plugins that are tested
+*together*: e.g. a "project manager" agent = a board-orchestration plugin + a browser plugin + the
+delegate spine. Today, standing that up means hand-installing each URL at the right ref and
+hand-assembling the `plugins.enabled` list and recommended config — error-prone, and impossible to
+*share* as a single, versioned thing.
+
+We want a way to publish and install a **bundle**: a named, versioned, curated set of plugins. The
+question is whether a bundle is a *monorepo of plugin code*, or a *reference manifest* over the
+existing standalone plugin repos.
+
+## Decision
+
+A **bundle is a reference repo**, not a code monorepo. A bundle repo's root holds a
+`protoagent.bundle.yaml` (in place of a `protoagent.plugin.yaml`) that *names* a set of plugin repos
+to install together, plus a suggested enable list + config:
+
+```yaml
+id: pm-stack
+name: Project Manager Stack
+description: Board orchestration + browser + delegate spine.
+plugins:
+  - { id: delegates,     builtin: true }                       # ships with protoAgent
+  - { id: project_board, url: …/projectBoard-plugin,  ref: v0.1.0 }
+  - { id: agent_browser, url: …/agent-browser-plugin, ref: v0.1.0 }
+enabled: [delegates, project_board, agent_browser]
+config:
+  agent_browser: { panel_mode: full }
+```
+
+`plugin install <bundle-url>` detects the bundle manifest and **fans out to per-plugin `install()`**
+for each member — so every member is allow-list-checked and pinned in `plugins.lock` *exactly* as a
+direct install would be (`by: "bundle:<id>"` records provenance). The bundle itself is recorded under
+a `bundles:` section of the lock for traceability + reproducible re-install. `builtin: true` members
+are skipped (they ship with the host). `plugin sync` already re-clones the locked set, so bundle
+members re-sync for free — no bundle-specific sync path.
+
+Crucially, **install ≠ enable ≠ trust still holds** (ADR 0027): a bundle install only puts code on
+disk and pins it. The `enabled` list and `config` are *returned as suggestions* (printed by the CLI),
+never written to the live config — turning the stack on remains the operator's explicit decision.
+
+## Consequences
+
+- **Composition over duplication** — bundles reference the standalone plugin repos; no code is copied
+  or moved. Plugins keep their own repos, CI, and release cadence; a bundle just pins a *tested combo*.
+- **One install entry point** — `plugin install <bundle-url>` brings up the whole stack; one repo to
+  share, one ref to bump when the combo is re-validated.
+- **Lock is still the source of truth** — members appear in `plugins.lock` like any plugin; the
+  `bundles:` entry is additive provenance. Existing `list`/`sync`/`uninstall` are unaffected.
+- **Trust boundary unchanged** — no auto-enable, no auto-config, no auto-dep-install. A bundle can't
+  silently turn anything on.
+- Minor: a bundle install is non-atomic across members (if member 3 fails, members 1–2 are already
+  installed). Acceptable — they're independently pinned and a re-run with `--force` is idempotent.
+
+## Options considered
+
+- **Monorepo of plugin code** (one repo, `plugins/<name>/` dirs). Atomic versioning + one CI, but it
+  fights the ADR 0027 one-repo-per-plugin model, forces a shared release cadence, and would need the
+  installer to learn sub-directory/multi-manifest installs. Rejected.
+- **Bare shareable `plugins.lock`** (hand someone a lock + `plugin sync`). Works with zero new code,
+  but the lock is a deployment's *whole* set with no name/description/enable/config metadata, and
+  bundles can't compose. Kept as the underlying mechanism; rejected as the user-facing bundle.
+- **Reference-manifest bundle** (this decision). Thin, composable, reuses every downstream primitive.

--- a/graph/plugins/cli.py
+++ b/graph/plugins/cli.py
@@ -19,8 +19,8 @@ def _build_parser() -> argparse.ArgumentParser:
     )
     sub = p.add_subparsers(dest="cmd", required=True)
 
-    pi = sub.add_parser("install", help="install a plugin from a git URL (does NOT enable it)")
-    pi.add_argument("url", help="git URL (https://, ssh://, git@, or a local path)")
+    pi = sub.add_parser("install", help="install a plugin — or a bundle of plugins — from a git URL (does NOT enable it)")
+    pi.add_argument("url", help="git URL (https://, ssh://, git@, or a local path) of a plugin or a bundle repo")
     pi.add_argument("--ref", default=None, help="tag, branch, or commit SHA to pin (default: default branch HEAD)")
     pi.add_argument("--force", action="store_true", help="replace an already-installed plugin of the same id")
 
@@ -40,6 +40,23 @@ def run_plugin_cli(argv: list[str]) -> int:
         if args.cmd == "install":
             s = installer.install(args.url, args.ref, force=args.force,
                                   allow=installer.configured_allowlist())
+            if "bundle" in s:  # a bundle: a set of plugins installed together
+                print(f"✓ installed bundle {s['bundle']}" + (f" — {s['name']}" if s["name"] else ""))
+                if s["description"]:
+                    print(f"  {s['description']}")
+                for p in s["installed"]:
+                    print(f"  ✓ {p['id']} v{p['version']} @ {p['resolved_sha'][:10]}")
+                if s["skipped_builtin"]:
+                    print(f"  · built-in (already ships with protoAgent): {', '.join(s['skipped_builtin'])}")
+                deps = sorted({d for p in s["installed"] for d in p.get("requires_pip", [])})
+                if deps:
+                    print(f"  ⚠ member deps (NOT installed — review, then `plugin install-deps <id>`): {', '.join(deps)}")
+                if s["enabled"]:
+                    print(f"  NOT enabled. To turn on the stack, set plugins.enabled to include: "
+                          f"[{', '.join(s['enabled'])}], then restart.")
+                if s["config"]:
+                    print(f"  recommended config: {s['config']}")
+                return 0
             print(f"✓ installed {s['id']} v{s['version']} @ {s['resolved_sha'][:10]}")
             if s["description"]:
                 print(f"  {s['description']}")

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -164,10 +164,17 @@ def install(url: str, ref: str | None = None, *, force: bool = False,
         staging = Path(tmp) / "repo"
         sha = _clone(url, ref, staging)
 
+        # A bundle repo (protoagent.bundle.yaml) carries no code — it names a set of
+        # plugin repos to install together. Fan out to per-plugin install().
+        bundle = load_bundle(staging)
+        if bundle is not None:
+            return _install_bundle(bundle, url, sha, ref, force=force, by=by, allow=allow)
+
         manifest = load_manifest(staging)
         if manifest is None:
             raise InstallError(
-                f"{url!r} has no valid protoagent.plugin.yaml — not a protoAgent plugin."
+                f"{url!r} has no protoagent.plugin.yaml or protoagent.bundle.yaml — "
+                "not a protoAgent plugin or bundle."
             )
         pid = manifest.id
 
@@ -197,6 +204,68 @@ def install(url: str, ref: str | None = None, *, force: bool = False,
            f"installed {pid}@{sha[:10]}")
     log.info("[plugins] installed %s@%s from %s", pid, sha[:10], url)
     return summary
+
+
+BUNDLE_FILENAME = "protoagent.bundle.yaml"
+
+
+def load_bundle(repo: Path) -> dict | None:
+    """Parse ``<repo>/protoagent.bundle.yaml`` → a bundle dict, or ``None`` if it's
+    absent/invalid. A **bundle** is a reference manifest: it names a set of plugin
+    repos (``{id, url, ref}`` or ``{id, builtin: true}``) to install together, plus a
+    suggested ``enabled`` list + ``config``. It carries no plugin code of its own."""
+    import yaml
+    f = repo / BUNDLE_FILENAME
+    if not f.exists():
+        return None
+    try:
+        doc = yaml.safe_load(f.read_text()) or {}
+    except yaml.YAMLError:
+        return None
+    if not isinstance(doc, dict) or not doc.get("id") or not isinstance(doc.get("plugins"), list):
+        return None
+    return doc
+
+
+def _install_bundle(bundle: dict, bundle_url: str, bundle_sha: str, ref: str | None,
+                    *, force: bool, by: str, allow: list[str] | None) -> dict:
+    """Install every plugin a bundle names (reusing single-plugin ``install()`` for
+    each — so each member is allow-checked + pinned in ``plugins.lock`` exactly as a
+    direct install), then record the bundle for provenance. Enable + config are
+    *suggested* in the return value, never applied (install ≠ enable ≠ trust)."""
+    bid = str(bundle.get("id"))
+    installed: list[dict] = []
+    skipped: list[str] = []
+    for entry in bundle.get("plugins") or []:
+        if not isinstance(entry, dict):
+            continue
+        if entry.get("builtin"):
+            skipped.append(str(entry.get("id", "?")))  # ships with protoAgent — nothing to fetch
+            continue
+        purl = entry.get("url")
+        if not purl:
+            raise InstallError(f"bundle {bid!r}: plugin {entry.get('id', '?')!r} has no url")
+        installed.append(install(str(purl), entry.get("ref"), force=force,
+                                 by=f"bundle:{bid}", allow=allow))
+
+    lock = _read_lock()
+    lock.setdefault("bundles", [])
+    lock["bundles"] = [b for b in lock["bundles"] if b.get("id") != bid]
+    lock["bundles"].append({
+        "id": bid, "source_url": bundle_url, "requested_ref": ref or "",
+        "resolved_sha": bundle_sha, "plugins": [s["id"] for s in installed],
+        "installed_at": datetime.now(timezone.utc).isoformat(), "by": by,
+    })
+    _write_lock(lock)
+    _audit("install-bundle", {"url": bundle_url, "sha": bundle_sha, "id": bid},
+           f"installed bundle {bid} ({len(installed)} plugin(s))")
+    log.info("[plugins] installed bundle %s@%s (%d plugins) from %s",
+             bid, bundle_sha[:10], len(installed), bundle_url)
+    return {
+        "bundle": bid, "name": bundle.get("name", ""), "description": bundle.get("description", ""),
+        "resolved_sha": bundle_sha, "installed": installed, "skipped_builtin": skipped,
+        "enabled": list(bundle.get("enabled") or []), "config": bundle.get("config") or {},
+    }
 
 
 def _clean_config_refs(plugin_id: str, section: str, purge: bool) -> bool:

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -197,3 +197,61 @@ def test_configured_allowlist_reads_config(tmp_path, monkeypatch):
     )
     monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(cfg_dir))
     assert installer.configured_allowlist() == ["github.com/protoLabsAI/*"]
+
+
+# ── bundles (a repo of plugin references, installed together) ─────────────────
+def _make_bundle_repo(root: Path, members: list[Path]) -> Path:
+    """A bundle repo: protoagent.bundle.yaml referencing member plugin repos by
+    local path, plus a builtin entry that must be skipped."""
+    repo = root / "src-bundle"
+    repo.mkdir(parents=True)
+    lines = ["id: demo_stack", "name: Demo Stack", "description: a test bundle", "plugins:"]
+    lines.append("  - { id: delegates, builtin: true }")
+    for m in members:
+        # id is read from each member's manifest on install; the bundle only needs url
+        lines.append(f"  - {{ id: x, url: {m} }}")
+    lines += ["enabled: [delegates, demo_a, demo_b]", "config:", "  demo_a: { k: v }"]
+    (repo / "protoagent.bundle.yaml").write_text("\n".join(lines) + "\n")
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init")
+    return repo
+
+
+def test_install_bundle_fans_out_and_records_provenance(env):
+    a = _make_plugin_repo(env, pid="demo_a")
+    b = _make_plugin_repo(env, pid="demo_b")
+    bundle = _make_bundle_repo(env, [a, b])
+
+    summary = installer.install(str(bundle))
+
+    # returns a bundle summary, installs both members, skips the builtin
+    assert summary["bundle"] == "demo_stack"
+    assert {p["id"] for p in summary["installed"]} == {"demo_a", "demo_b"}
+    assert summary["skipped_builtin"] == ["delegates"]
+    # enable list + config are surfaced (suggested), not applied
+    assert summary["enabled"] == ["delegates", "demo_a", "demo_b"]
+    assert summary["config"] == {"demo_a": {"k": "v"}}
+
+    # both members landed + are pinned individually; the bundle is recorded
+    assert (installer.live_plugins_dir() / "demo_a" / "protoagent.plugin.yaml").exists()
+    assert (installer.live_plugins_dir() / "demo_b" / "protoagent.plugin.yaml").exists()
+    lock = installer._read_lock()
+    assert {e["id"] for e in lock["plugins"]} >= {"demo_a", "demo_b"}
+    assert any(e["by"] == "bundle:demo_stack" for e in lock["plugins"])
+    bundles = lock.get("bundles") or []
+    assert bundles and bundles[0]["id"] == "demo_stack"
+    assert set(bundles[0]["plugins"]) == {"demo_a", "demo_b"}
+
+
+def test_install_bundle_member_missing_url_errors(env):
+    repo = env / "src-badbundle"
+    repo.mkdir(parents=True)
+    (repo / "protoagent.bundle.yaml").write_text(
+        "id: bad\nplugins:\n  - { id: nope }\n"  # no url, not builtin
+    )
+    _git(repo, "init", "-q")
+    _git(repo, "add", "-A")
+    _git(repo, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-qm", "init")
+    with pytest.raises(installer.InstallError):
+        installer.install(str(repo))


### PR DESCRIPTION
## What
Adds **plugin bundles**: install a *curated, versioned set* of plugins with one command, building on ADR 0027.

A bundle is a **reference repo** (not a code monorepo) whose root holds `protoagent.bundle.yaml`:
```yaml
id: pm-stack
name: Project Manager Stack
plugins:
  - { id: delegates,     builtin: true }
  - { id: project_board, url: …/projectBoard-plugin,  ref: v0.1.0 }
  - { id: agent_browser, url: …/agent-browser-plugin, ref: v0.1.0 }
enabled: [delegates, project_board, agent_browser]
config: { agent_browser: { panel_mode: full } }
```

## How
- `install()` detects `protoagent.bundle.yaml` in the cloned repo → **fans out to per-plugin `install()`** for each member. Each member is allow-list-checked and pinned in `plugins.lock` exactly like a direct install (`by: "bundle:<id>"`).
- The bundle is recorded under a `bundles:` section of the lock (provenance + reproducible re-install). `builtin: true` members are skipped; `sync` re-clones members for free.
- **install ≠ enable ≠ trust** preserved: `enabled` + `config` are *returned as suggestions* (printed by the CLI), never written to the live config.
- CLI: `plugin install <bundle-url>` prints the installed members + the enable/config suggestions.

## Why a reference repo (not a monorepo)
Composition over duplication — plugins keep their own repos, CI, and release cadence; a bundle just pins a *tested combo*. (Alternatives weighed in ADR 0040.)

## Tests
`tests/test_plugin_installer.py` — fan-out + provenance (`lock.bundles`, `by: bundle:*`, builtin skip, enable/config surfaced) and the missing-url error path. Full installer suite green (17 passed).

Files: `graph/plugins/installer.py`, `graph/plugins/cli.py`, `tests/test_plugin_installer.py`, `docs/adr/0040-plugin-bundles.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)