### PR TITLE
feat(console): @protolabsai/ui 0.13 + design 0.5 — DS Header, light-mode readiness

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,8 +11,8 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@protolabsai/design": "^0.4.0",
-    "@protolabsai/ui": "^0.11.0",
+    "@protolabsai/design": "^0.5.0",
+    "@protolabsai/ui": "^0.13.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -85,7 +85,8 @@ import { SettingsCategoryPanel } from "../settings/SettingsCategory";
 import { WorkflowsSurface } from "../workflows/WorkflowsSurface";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
-import { AppShell, UtilityBar } from "@protolabsai/ui/app-shell";
+import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
+import { Logo } from "@protolabsai/ui/primitives";
 import { useIsMobile } from "../lib/useIsMobile";
 import { registeredSurfaces } from "../ext"; // build-time fork seam (ADR 0038 D3); also self-loads fork surfaces
 import { ContextMenuRenderer, openContextMenu } from "../contextMenu";
@@ -598,20 +599,18 @@ export function App() {
       {/* macOS desktop: the topbar IS the window's drag region (its brand insets
           right of the native traffic lights — see `.is-tauri-mac .topbar`).
           Interactive children (the status dot) stay clickable; harmless on web. */}
-      <header className="topbar" data-tauri-drag-region>
-        <div className="brand-lockup">
-          {/* BASE_URL is "/app/" in dev and "./" in the desktop build — a
-              hardcoded "/app/…" 404s in the bundle (assets sit at the root). */}
-          <img src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`} alt="" className="brand-mark" />
-          <div>
-            {/* White-label: the brand name follows the configured identity
-                (Settings → Identity), defaulting to protoAgent for the template.
-                A fork sets its name once and the whole UI follows. */}
-            <div className="brand-name">{brandName(runtime?.identity?.name)}</div>
-            <div className="brand-subline">{runtime?.identity?.org || "protoLabs.studio"}</div>
-          </div>
-        </div>
-        <div className="topbar-status">
+      {/* White-label top bar — DS Header (protoContent #159). name follows the configured
+          identity (Settings ▸ Identity), org is identity.org (falls back to protoLabs.studio),
+          logo is the brand mark, status is the glanceable health light. BASE_URL is "/app/" in
+          dev and "./" in the desktop build (assets sit at the root). dragRegion = the Tauri
+          window drag region. */}
+      <div className="app-topbar">
+      <Header
+        dragRegion
+        logo={<Logo src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`} alt="" size={22} />}
+        name={brandName(runtime?.identity?.name)}
+        org={runtime?.identity?.org || "protoLabs.studio"}
+        status={
           <button
             type="button"
             className={`status-dot tone-${health.tone}`}
@@ -630,8 +629,9 @@ export function App() {
             data-testid="live-indicator"
             data-live={live ? "true" : "false"}
           />
-        </div>
-      </header>
+        }
+      />
+      </div>
 
       {/* The dual-rail shell is now the DS AppShell (ADR 0035 + #144): rails (drag-to-reorder +
           cross-rail via dnd-kit), resizable right column, mobile shell, and the utility bar — all

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -5,24 +5,29 @@
   --brand-indigo-bright: #818cf8;
   --brand-gradient: linear-gradient(135deg, #a78bfa 0%, #818cf8 50%, #6366f1 100%);
 
-  --bg: #0a0a0c;
-  --bg-raised: #131316;
-  --bg-panel: #101013;
-  --bg-hover: #19191d;
-  --fg: #ededed;
-  --fg-secondary: #a3a3ad;
-  --fg-muted: #8b8b94;
-  --border: rgba(255, 255, 255, 0.08);
-  --border-strong: rgba(255, 255, 255, 0.18);
+  /* Light-mode ready: the legacy app vars are now ALIASES of the @protolabsai/design
+     `--pl-*` tokens (imported in main.tsx), so the whole console — DS components AND
+     the remaining hand-rolled CSS — flips with the OS / `data-theme`. The old dark
+     values stay as fallbacks if the tokens ever fail to load. */
+  --bg: var(--pl-color-bg, #0a0a0c);
+  --bg-raised: var(--pl-color-bg-raised, #131316);
+  --bg-panel: var(--pl-color-bg-raised, #101013);
+  --bg-hover: var(--pl-color-bg-hover, #19191d);
+  --fg: var(--pl-color-fg, #ededed);
+  --fg-secondary: var(--pl-color-fg-muted, #a3a3ad);
+  --fg-muted: var(--pl-color-fg-subtle, #8b8b94);
+  --border: var(--pl-color-border, rgba(255, 255, 255, 0.08));
+  --border-strong: var(--pl-color-border-strong, rgba(255, 255, 255, 0.18));
+  --accent: var(--pl-color-accent, #7c8cff);
 
-  --success: #41c48d;
-  --warning: #d4bd4f;
-  --error: #f07458;
-  --info: #7aa2ff;
+  --success: var(--pl-color-status-success, #41c48d);
+  --warning: var(--pl-color-status-warning, #d4bd4f);
+  --error: var(--pl-color-status-error, #f07458);
+  --info: var(--pl-color-status-info, #7aa2ff);
 
-  --font-sans: "Geist", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-  --font-mono: "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace;
-  --radius: 6px;
+  --font-sans: var(--pl-font-sans, "Geist", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif);
+  --font-mono: var(--pl-font-mono, "Geist Mono", ui-monospace, "SF Mono", Menlo, Consolas, monospace);
+  --radius: var(--pl-radius, 6px);
 }
 
 * {
@@ -95,6 +100,12 @@ h2 {
   flex: 1 1 0;
   min-height: 0;
   height: auto;
+}
+/* Fixed-height top row for the DS Header (.pl-header is height:100%, so it needs a
+   sized wrapper — otherwise it stretches to fill the flex column = full viewport). */
+.app-topbar {
+  flex: 0 0 48px;
+  min-height: 48px;
 }
 
 /* Topbar health light — one dot, detail on hover, click to refresh. */

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
       "name": "@protoagent/web",
       "version": "0.1.0",
       "dependencies": {
-        "@protolabsai/design": "^0.4.0",
-        "@protolabsai/ui": "^0.11.0",
+        "@protolabsai/design": "^0.5.0",
+        "@protolabsai/ui": "^0.13.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -57,18 +57,18 @@
       }
     },
     "apps/web/node_modules/@protolabsai/design": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.4.0.tgz",
-      "integrity": "sha512-aLD4H93iUdYli8llxrKTpYovmKCjhp5rznbtHS8CrsmT0fcZgSGj2Nannci+o2Yz7iOZm7NLNxC9wSdXD02dTw==",
+      "version": "0.5.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.5.0.tgz",
+      "integrity": "sha512-2ZgOlfcdvDaibvase8Vb+B2/L+cKaeTfCeT72vQepZB/e35dwHy2v9u8dofyI2nVDPDrCkL1e+Uy+vRBcHRnuQ==",
       "license": "MIT",
       "bin": {
         "protolabs-sync-assets": "bin/sync-assets.mjs"
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.11.0.tgz",
-      "integrity": "sha512-P/iQcq8PW4sKCyIa8ha1BPJMNN2ouKHT9rRgdspsbZEViYwuOWpsH6BoroEroLgsbRf2oLK44uSXdW8/jCthTw==",
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.13.0.tgz",
+      "integrity": "sha512-3z7XQSsOGqhAVzx2ROiwn5SgOLxiWkiYi/3LrlKpC7OBMEzQ1v/Bq7j3fjbNMEzRdiG46pWDUwhDFRG5U0UEmw==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -83,15 +83,6 @@
       "peerDependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0"
-      }
-    },
-    "apps/web/node_modules/@protolabsai/ui/node_modules/@protolabsai/design": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.5.0.tgz",
-      "integrity": "sha512-2ZgOlfcdvDaibvase8Vb+B2/L+cKaeTfCeT72vQepZB/e35dwHy2v9u8dofyI2nVDPDrCkL1e+Uy+vRBcHRnuQ==",
-      "license": "MIT",
-      "bin": {
-        "protolabs-sync-assets": "bin/sync-assets.mjs"
       }
     },
     "apps/web/node_modules/@radix-ui/react-arrow": {


### PR DESCRIPTION
Builds on #770 (now merged). Locally tested.

## What lands
- **Bump** `@protolabsai/ui` `0.11`→**`0.13`**, `@protolabsai/design` `0.4`→**`0.5`**.
- **DS `Header`** (protoContent #159) replaces the hand-rolled topbar — white-label `name` (identity) + `org` (`identity.org`) + `Logo` (the shipped img atom) + the health-dot `status` slot + `dragRegion` (Tauri). Wrapped in a fixed-height `.app-topbar` row (the DS `.pl-header` is `height:100%`, so it needs a sized parent — without it, it filled the whole flex column and intercepted clicks; fixed).
- **Light-mode readiness** — the legacy `theme.css` app vars (`--bg`/`--fg`/`--border`/`--accent`/…) are now **aliases of the `@protolabsai/design` `--pl-*` tokens** (old dark values as fallbacks), so the console — DS *and* the remaining hand-rolled CSS — flips with the OS / `data-theme`. Tail: a few hardcoded `rgba`/brand colors still to tokenize.

## Verification
68/68 e2e, `tsc` + `vite build` clean.

## Notes
- ADR 0041 (full workspace system) is Roxy's lane (she has the context).
- Header desktop note: the macOS traffic-light inset (`.is-tauri-mac .topbar`) isn't on `.pl-header` yet — minor, desktop-only, follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)