### PR TITLE
feat(stores): tiered stores slice 1 — skills as a shared commons (ADR 0041)

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -88,6 +88,15 @@ skills:
   db_path: /sandbox/skills.db
   top_k: 5
   max_tokens: 2000
+  # Tiered stores (ADR 0041). `shared: true` lifts the skills library into the
+  # COMMONS — one DB read/written by every agent on this host (a fleet's compounding
+  # skill library) — instead of per-instance scope. Default false = private per
+  # instance. Pairs with multiple agents isolated via `instance.id`.
+  shared: false
+
+# Shared commons (ADR 0041) — base dir for `shared` stores; blank → ~/.protoagent/commons.
+# commons:
+#   path: ""
 
 # A2A card identity (#570) — declare your fork's advertised skills + card
 # description HERE (or contribute skills from a plugin via register_a2a_skill)

--- a/graph/config.py
+++ b/graph/config.py
@@ -318,6 +318,12 @@ class LangGraphConfig:
     skills_db_path: str = "/sandbox/skills.db"
     skills_top_k: int = 5
     skills_dir: str = ""
+    # Tiered stores (ADR 0041) — `shared` lifts a store out of per-instance scoping
+    # into the COMMONS (read by every agent on the host); `scoped` keeps it private.
+    # Slice 1: skills can be shared (a fleet's compounding skill library). Default
+    # False = legacy per-instance behavior (no surprise migration).
+    skills_shared: bool = False
+    commons_path: str = ""  # commons base dir; blank → ~/.protoagent/commons
 
     # Workflows — declarative multi-step subagent recipes (see ADR 0002),
     # exposed via the run_workflow tool. Bundled examples ship in the repo
@@ -586,6 +592,8 @@ class LangGraphConfig:
             skills_db_path=skills.get("db_path", cls.skills_db_path),
             skills_top_k=skills.get("top_k", cls.skills_top_k),
             skills_dir=skills.get("dir", cls.skills_dir),
+            skills_shared=skills.get("shared", cls.skills_shared),
+            commons_path=(data.get("commons", {}) or {}).get("path", cls.commons_path),
             mcp_enabled=mcp.get("enabled", cls.mcp_enabled),
             mcp_servers=list(mcp.get("servers", []) or []),
             mcp_timeout_seconds=mcp.get("timeout_seconds", cls.mcp_timeout_seconds),

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -340,7 +340,11 @@ def _build_skills_index(config, extra_skill_dirs=None):
         from graph.skills.index import SkillsIndex
         from graph.skills.loader import seed_skills_index
 
-        db_path = _resolve_skills_db(config.skills_db_path)
+        db_path = _resolve_skills_db(
+            config.skills_db_path,
+            shared=getattr(config, "skills_shared", False),
+            commons=_commons_dir(config),
+        )
         index = SkillsIndex(db_path=db_path)
 
         live_root = Path(config.skills_dir).expanduser() if config.skills_dir else (
@@ -756,12 +760,30 @@ def _build_workflow_registry(config):
         return None
 
 
-def _resolve_skills_db(configured: str) -> str:
-    """Pick a writable skills DB path; fall back to ~/.protoagent when the
-    configured dir (default /sandbox) isn't creatable — same idea as the
-    knowledge store's ``_resolve_path``."""
+def _commons_dir(config):
+    """The shared commons base (ADR 0041) — read by every agent on the host, never
+    per-instance scoped. Configurable via ``commons.path``; defaults to
+    ``~/.protoagent/commons``."""
+    from pathlib import Path
+
+    raw = (getattr(config, "commons_path", "") or "").strip()
+    return Path(raw).expanduser() if raw else (Path.home() / ".protoagent" / "commons")
+
+
+def _resolve_skills_db(configured: str, *, shared: bool = False, commons=None) -> str:
+    """Pick a writable skills DB path.
+
+    When ``shared`` (ADR 0041, tiered stores), the skills library is the COMMONS:
+    resolved un-scoped so every agent on the host shares one DB. Otherwise it's
+    per-instance scoped (``scope_leaf``), falling back to ~/.protoagent when the
+    configured dir (default /sandbox) isn't creatable."""
     import os
     from pathlib import Path
+
+    if shared:
+        path = Path(commons or (Path.home() / ".protoagent" / "commons")) / "skills.db"
+        path.parent.mkdir(parents=True, exist_ok=True)
+        return str(path)
 
     candidate = Path(configured)
     try:

--- a/tests/test_instance_scope.py
+++ b/tests/test_instance_scope.py
@@ -36,3 +36,29 @@ def test_unscoped_warning_only_when_root_has_state(monkeypatch, tmp_path):
     assert "UNSCOPED" in (paths.unscoped_warning() or "")
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "alice")
     assert paths.unscoped_warning() is None           # scoped → quiet
+
+
+def test_shared_skills_resolve_to_commons_not_scoped(monkeypatch, tmp_path):
+    """ADR 0041 — a `shared` skills store resolves to the COMMONS (un-scoped),
+    identical for every instance; a scoped store stays per-instance."""
+    from server.agent_init import _resolve_skills_db
+
+    commons = tmp_path / "commons"
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "agentA")
+    shared_a = _resolve_skills_db("/x/skills.db", shared=True, commons=commons)
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "agentB")
+    shared_b = _resolve_skills_db("/x/skills.db", shared=True, commons=commons)
+    scoped_b = _resolve_skills_db(str(tmp_path / "cfg" / "skills.db"), shared=False)
+
+    assert shared_a == shared_b == str(commons / "skills.db")  # one commons for all agents
+    assert "agentB" in scoped_b and scoped_b != shared_a        # scoped is per-instance
+
+
+def test_skills_tier_config_parses(tmp_path):
+    """`skills.shared` + `commons.path` parse into the config (ADR 0041)."""
+    from graph.config import LangGraphConfig
+    cfg = tmp_path / "c.yaml"
+    cfg.write_text("skills: { shared: true }\ncommons: { path: /tmp/commons }\n")
+    c = LangGraphConfig.from_yaml(str(cfg))
+    assert c.skills_shared is True
+    assert c.commons_path == "/tmp/commons"


### PR DESCRIPTION
First implementation slice of **ADR 0041** (#771): a per-store **tier** flag, shipping with **skills**.

## What
`skills.shared: true` lifts the skills library out of per-instance scoping into the **commons** — one DB read/written by every agent on the host (a fleet's compounding skill library) — while goals/checkpoints/memory/knowledge stay **scoped** per instance. The shared-root data 'leak' becomes a deliberate shared brain.

## How
- **config**: `skills.shared` (bool) + `commons.path` (commons base dir, default `~/.protoagent/commons`).
- **`_resolve_skills_db`** gains a `shared` mode → resolves to the un-scoped commons path instead of `scope_leaf`; `_commons_dir` helper.
- **`_build_skills_index`** passes the tier from config.

## Safety
**Default `false`** = today's per-instance behavior — no surprise migration. Opt-in per deployment; pairs with multiple agents isolated via `instance.id`.

## Tests
`test_instance_scope.py`: shared resolves to **one** commons for every instance (`agentA`==`agentB`); scoped stays per-instance; config parses `skills.shared`+`commons.path`. Suite green.

Next: slice 2 (the `workspace` CLI). Builds toward the full ADR 0041 model.

🤖 Generated with [Claude Code](https://claude.com/claude-code)