### PR TITLE
feat(workspaces): slice 2 — the workspace CLI (ADR 0041)

### DIFF
--- a/graph/workspaces/__init__.py
+++ b/graph/workspaces/__init__.py
@@ -1,0 +1,7 @@
+"""Workspaces (ADR 0041) — a named, self-contained agent on the host.
+
+A workspace bundles the three isolation knobs into one object: a config dir
+(``PROTOAGENT_CONFIG_DIR``), an instance id (``instance.id`` → scoped data), and a
+port. The ``workspace`` CLI manages them; this package is the thin orchestration
+layer over the existing primitives — it adds no new runtime.
+"""

--- a/graph/workspaces/cli.py
+++ b/graph/workspaces/cli.py
@@ -1,0 +1,80 @@
+"""``python -m server workspace …`` — manage workspaces (ADR 0041).
+
+A thin CLI over ``graph.workspaces.manager``. ``new`` scaffolds (never starts);
+``run`` ``exec``s the normal server with the workspace's config dir + instance + port.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+from graph.workspaces import manager
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m server workspace",
+        description="Workspaces — named, isolated agents on one host (ADR 0041).",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+
+    pn = sub.add_parser("new", help="scaffold a new workspace (does NOT start it)")
+    pn.add_argument("name", help="workspace name (letters, digits, '-', '_')")
+    pn.add_argument("--from", dest="from_config", default=None,
+                    help="clone an existing config dir/file as the base")
+    pn.add_argument("--bundle", default=None, help="install a plugin bundle/plugin git URL into it")
+    pn.add_argument("--port", type=int, default=None, help="bind port (default: auto)")
+    pn.add_argument("--shared-skills", action="store_true",
+                    help="share the skills commons across the fleet (ADR 0041)")
+
+    sub.add_parser("ls", help="list workspaces")
+
+    pr = sub.add_parser("run", help="start a workspace's server (config dir + instance + port)")
+    pr.add_argument("name")
+    pr.add_argument("rest", nargs=argparse.REMAINDER, help="extra args forwarded to the server")
+
+    pd = sub.add_parser("rm", help="remove a workspace")
+    pd.add_argument("name")
+    pd.add_argument("--purge", action="store_true", help="also remove its scoped private data")
+    return p
+
+
+def run_workspace_cli(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.cmd == "new":
+            s = manager.create(args.name, from_config=args.from_config, bundle=args.bundle,
+                               port=args.port, shared_skills=args.shared_skills)
+            print(f"✓ created workspace {s['name']} (id={s['id']}, port={s['port']})")
+            print(f"  {s['path']}")
+            if s.get("installed"):
+                print(f"  installed: {', '.join(s['installed'])}")
+            print(f"  edit langgraph-config.yaml (model + secrets), then: "
+                  f"python -m server workspace run {s['name']}")
+            return 0
+        if args.cmd == "ls":
+            rows = manager.list_workspaces()
+            if not rows:
+                print("(no workspaces — create one: python -m server workspace new <name>)")
+                return 0
+            for w in rows:
+                b = f"  bundle={w['bundle']}" if w["bundle"] else ""
+                print(f"  {w['name']:16} id={w['id']:16} :{w['port']}{b}")
+            return 0
+        if args.cmd == "run":
+            env, cmd = manager.run_exec(args.name, args.rest or [])
+            os.environ.update(env)
+            print(f"→ workspace {args.name}: {env['PROTOAGENT_CONFIG_DIR']} "
+                  f"(instance={env['PROTOAGENT_INSTANCE']})", file=sys.stderr)
+            os.execvp(cmd[0], cmd)  # replace this process with the server
+            return 0  # unreachable
+        if args.cmd == "rm":
+            rep = manager.remove(args.name, purge=args.purge)
+            print(f"✓ removed workspace {args.name} ({', '.join(rep['removed'])})")
+            return 0
+    except manager.WorkspaceError as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        return 1
+    return 0

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -1,0 +1,217 @@
+"""Workspace lifecycle (ADR 0041) — create / list / run / remove.
+
+A workspace is a directory ``<root>/<name>/`` that *is* an agent: its
+``langgraph-config.yaml`` + ``secrets.yaml`` + (once a bundle installs) ``plugins.lock``
++ ``config/plugins/`` live there (so ``PROTOAGENT_CONFIG_DIR=<ws>`` makes it the whole
+identity), and ``instance.id = <name>`` scopes its private data to ``~/.protoagent/<name>/*``.
+``workspace.yaml`` is the registry record (id, port, bundle, created).
+
+This module only orchestrates the existing knobs — no new runtime, no new storage
+format. ``run`` returns the env + argv for the CLI to ``exec`` the normal server.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+from datetime import datetime, timezone
+from pathlib import Path
+
+PORT_BASE = 7870  # workspaces get PORT_BASE+1, +2, … unless an explicit port is given
+
+
+class WorkspaceError(Exception):
+    """A workspace op was rejected (bad name, collision, missing workspace)."""
+
+
+def workspaces_root() -> Path:
+    """Where workspaces live. ``PROTOAGENT_WORKSPACES_DIR`` overrides; default
+    ``~/.protoagent/workspaces``."""
+    override = os.environ.get("PROTOAGENT_WORKSPACES_DIR", "").strip()
+    return Path(override).expanduser() if override else (Path.home() / ".protoagent" / "workspaces")
+
+
+def _safe(name: str) -> str:
+    n = (name or "").strip()
+    if not n or n != "".join(c for c in n if c.isalnum() or c in "-_"):
+        raise WorkspaceError(f"invalid workspace name {name!r} — use letters, digits, '-' or '_'")
+    return n
+
+
+def _ws_dir(name: str) -> Path:
+    return workspaces_root() / _safe(name)
+
+
+def _read_record(ws: Path) -> dict | None:
+    import yaml
+    f = ws / "workspace.yaml"
+    if not f.exists():
+        return None
+    try:
+        d = yaml.safe_load(f.read_text()) or {}
+        return d if isinstance(d, dict) else None
+    except yaml.YAMLError:
+        return None
+
+
+def list_workspaces() -> list[dict]:
+    """Every workspace under the root (each dir with a ``workspace.yaml``)."""
+    root = workspaces_root()
+    out: list[dict] = []
+    if not root.exists():
+        return out
+    for d in sorted(p for p in root.iterdir() if p.is_dir()):
+        rec = _read_record(d)
+        if rec:
+            out.append({"name": rec.get("name", d.name), "id": rec.get("id", d.name),
+                        "port": rec.get("port"), "bundle": rec.get("bundle") or "",
+                        "created": rec.get("created", ""), "path": str(d)})
+    return out
+
+
+def _pick_port(explicit: int | None) -> int:
+    if explicit:
+        return int(explicit)
+    used = {w["port"] for w in list_workspaces() if w.get("port")}
+    p = PORT_BASE + 1
+    while p in used:
+        p += 1
+    return p
+
+
+_CONFIG_TEMPLATE = """\
+# Workspace {name} — a protoAgent agent (ADR 0041).
+# Edit the model / plugins / secrets below, then `workspace run {name}`.
+
+identity:
+  name: {name}
+
+# Data isolation (ADR 0004/0041) — scopes this agent's private stores to
+# ~/.protoagent/{name}/* so it never collides with other agents on this host.
+instance:
+  id: {name}
+
+model:
+  provider: openai
+  name: protolabs/reasoning
+  api_base: ""        # set your gateway / OpenAI-compat base URL
+  api_key: ""         # or set OPENAI_API_KEY in this workspace's secrets.yaml
+
+plugins:
+  enabled: []
+  sources:
+    allow: [github.com/protoLabsAI/*]
+
+# Shared skills commons (ADR 0041) — opt in to share the fleet's skill library:
+# skills:
+#   shared: true
+"""
+
+
+def create(name: str, *, from_config: str | None = None, bundle: str | None = None,
+           port: int | None = None, shared_skills: bool = False) -> dict:
+    """Scaffold a workspace: its config dir, ``workspace.yaml``, and (with ``bundle``)
+    an installed plugin bundle. Does not start it. ``from_config`` clones an existing
+    agent's config + secrets as the base (instance.id/identity are re-stamped to *name*)."""
+    name = _safe(name)
+    ws = _ws_dir(name)
+    if ws.exists():
+        raise WorkspaceError(f"workspace {name!r} already exists at {ws}")
+    ws.mkdir(parents=True)
+
+    cfg = ws / "langgraph-config.yaml"
+    if from_config:
+        src = Path(from_config).expanduser()
+        src_cfg = src / "langgraph-config.yaml" if src.is_dir() else src
+        if not src_cfg.exists():
+            shutil.rmtree(ws, ignore_errors=True)
+            raise WorkspaceError(f"--from: no langgraph-config.yaml at {src_cfg}")
+        shutil.copyfile(src_cfg, cfg)
+        src_sec = (src if src.is_dir() else src.parent) / "secrets.yaml"
+        if src_sec.exists():
+            shutil.copyfile(src_sec, ws / "secrets.yaml")
+        _stamp_identity(cfg, name, shared_skills)
+    else:
+        cfg.write_text(_CONFIG_TEMPLATE.format(name=name))
+        (ws / "secrets.yaml").write_text("# Per-workspace secrets overlay.\n")
+        if shared_skills:
+            _stamp_identity(cfg, name, True)
+
+    assigned = _pick_port(port)
+    rec = {"id": name, "name": name, "port": assigned,
+           "created": datetime.now(timezone.utc).isoformat(), "bundle": bundle or ""}
+
+    installed: list[str] = []
+    if bundle:
+        installed = _install_bundle_into(ws, bundle)
+
+    import yaml
+    (ws / "workspace.yaml").write_text(yaml.safe_dump(rec, sort_keys=False))
+    return {**rec, "path": str(ws), "installed": installed}
+
+
+def _stamp_identity(cfg: Path, name: str, shared_skills: bool) -> None:
+    """Force identity.name + instance.id to *name* on a (possibly cloned) config, and
+    optionally set skills.shared — comment-preserving (ruamel)."""
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+    doc = load_yaml_doc(cfg)
+    if not isinstance(doc, dict):
+        return
+    doc.setdefault("identity", {})["name"] = name
+    doc.setdefault("instance", {})["id"] = name
+    if shared_skills:
+        doc.setdefault("skills", {})["shared"] = True
+    save_yaml_doc(doc, cfg)
+
+
+def _install_bundle_into(ws: Path, bundle: str) -> list[str]:
+    """Install a bundle (or plugin) into the workspace via a scoped subprocess —
+    fresh env so the installer's module-level lock path picks up this workspace."""
+    env = {**os.environ,
+           "PROTOAGENT_CONFIG_DIR": str(ws),
+           "PROTOAGENT_PLUGINS_DIR": str(ws / "plugins"),
+           "PROTOAGENT_PLUGINS_LOCK": str(ws / "plugins.lock")}
+    proc = subprocess.run([sys.executable, "-m", "server", "plugin", "install", bundle],
+                          env=env, capture_output=True, text=True, timeout=300)
+    if proc.returncode != 0:
+        raise WorkspaceError(f"bundle install failed: {(proc.stderr or proc.stdout).strip()[:400]}")
+    import json
+    lock = ws / "plugins.lock"
+    try:
+        return [p["id"] for p in json.loads(lock.read_text()).get("plugins", [])] if lock.exists() else []
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def run_exec(name: str, passthrough: list[str]) -> tuple[dict, list[str]]:
+    """Return ``(env_overrides, argv)`` to launch this workspace's server. The CLI
+    applies the env and ``exec``s — so the workspace runs as a normal server with
+    its config dir + instance + port wired in."""
+    ws = _ws_dir(name)
+    rec = _read_record(ws)
+    if rec is None:
+        raise WorkspaceError(f"no workspace {name!r} at {ws}")
+    env = {"PROTOAGENT_CONFIG_DIR": str(ws), "PROTOAGENT_INSTANCE": str(rec.get("id", name)),
+           "PROTOAGENT_PLUGINS_DIR": str(ws / "plugins"), "PROTOAGENT_PLUGINS_LOCK": str(ws / "plugins.lock")}
+    argv = [sys.executable, "-m", "server", "--port", str(rec.get("port", PORT_BASE + 1)), *passthrough]
+    return env, argv
+
+
+def remove(name: str, *, purge: bool = False) -> dict:
+    """Delete the workspace dir. With ``purge``, also remove its scoped private data
+    at ``~/.protoagent/<id>/``."""
+    ws = _ws_dir(name)
+    rec = _read_record(ws)
+    if not ws.exists():
+        raise WorkspaceError(f"no workspace {name!r}")
+    iid = (rec or {}).get("id", name)
+    shutil.rmtree(ws)
+    removed = ["workspace"]
+    if purge:
+        data = Path.home() / ".protoagent" / _safe(str(iid))
+        if data.exists():
+            shutil.rmtree(data)
+            removed.append("data")
+    return {"name": name, "removed": removed}

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -282,6 +282,15 @@ def _main():
 
         raise SystemExit(run_plugin_cli(sys.argv[2:]))
 
+    # Workspace management subcommand (ADR 0041): `python -m server workspace
+    # new/ls/run/rm` — named, isolated agents on one host. `new`/`ls`/`rm` act on
+    # disk and exit; `run` execs the normal server with the workspace's config dir +
+    # instance + port wired in (so the dispatch below runs unchanged for it).
+    if len(sys.argv) > 1 and sys.argv[1] == "workspace":
+        from graph.workspaces.cli import run_workspace_cli
+
+        raise SystemExit(run_workspace_cli(sys.argv[2:]))
+
     # Frozen-binary entrypoint for a plugin's managed MCP server (ADR 0019): the
     # bundled desktop app has no `python` on PATH, so a plugin's managed-server
     # factory re-invokes this binary with `--mcp-plugin <id>` instead of `-m

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -1,0 +1,54 @@
+"""Workspaces (ADR 0041) — create / list / run / remove."""
+
+from __future__ import annotations
+
+import pytest
+import yaml
+
+from graph.workspaces import manager
+
+
+@pytest.fixture
+def root(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    return tmp_path / "ws"
+
+
+def test_new_ls_run_rm(root):
+    s = manager.create("alpha")
+    assert s["id"] == "alpha" and s["port"] == 7871
+    ws = root / "alpha"
+    assert (ws / "langgraph-config.yaml").exists() and (ws / "workspace.yaml").exists()
+    cfg = yaml.safe_load((ws / "langgraph-config.yaml").read_text())
+    assert cfg["instance"]["id"] == "alpha" and cfg["identity"]["name"] == "alpha"
+
+    assert [w["name"] for w in manager.list_workspaces()] == ["alpha"]
+
+    env, argv = manager.run_exec("alpha", [])
+    assert env["PROTOAGENT_CONFIG_DIR"] == str(ws)
+    assert env["PROTOAGENT_INSTANCE"] == "alpha"
+    assert "--port" in argv and "7871" in argv
+
+    assert manager.create("beta")["port"] == 7872  # next free port
+    with pytest.raises(manager.WorkspaceError):
+        manager.create("alpha")  # collision
+
+    assert "workspace" in manager.remove("alpha")["removed"] and not ws.exists()
+
+
+def test_from_config_clones_and_restamps(root, tmp_path):
+    src = tmp_path / "src"; src.mkdir()
+    (src / "langgraph-config.yaml").write_text(
+        "identity: { name: orig }\ninstance: { id: orig }\nmodel: { name: keep-me }\n")
+    (src / "secrets.yaml").write_text("model: { api_key: k }\n")
+    manager.create("clone", from_config=str(src), shared_skills=True)
+    cfg = yaml.safe_load((root / "clone" / "langgraph-config.yaml").read_text())
+    assert cfg["identity"]["name"] == "clone" and cfg["instance"]["id"] == "clone"
+    assert cfg["model"]["name"] == "keep-me"          # other config preserved
+    assert cfg["skills"]["shared"] is True
+    assert (root / "clone" / "secrets.yaml").exists()  # secrets cloned too
+
+
+def test_bad_name_rejected(root):
+    with pytest.raises(manager.WorkspaceError):
+        manager.create("bad name")


### PR DESCRIPTION
Second slice of **ADR 0041** (#771). Makes "an agent on this host" a **first-class object** instead of three hand-juggled env knobs.

## CLI
```
python -m server workspace new <name> [--from <cfg>] [--bundle <url>] [--port auto] [--shared-skills]
python -m server workspace ls
python -m server workspace run <name>          # execs the normal server, env wired in
python -m server workspace rm <name> [--purge]
```

## What a workspace is
A directory that *is* an agent: `langgraph-config.yaml` + `secrets.yaml` + (via a bundle) `plugins.lock`/`config/plugins/` live there, so `PROTOAGENT_CONFIG_DIR=<ws>` is its whole identity; `instance.id=<name>` scopes its private data to `~/.protoagent/<name>/*`. `workspace.yaml` is the registry record (id, port, bundle).

## Design
Thin orchestration over existing primitives — **no new runtime**. `run` just `exec`s `python -m server` with the workspace's config dir + instance + port. **`--bundle` composes ADR 0040** (installs a bundle into the workspace, scoped). **`--from`** clones an existing agent's config (re-stamping identity/instance). Port auto-assigns.

## Tests
`test_workspaces.py`: new/ls/run/rm, auto-port, name validation, collision, and `--from` clone-and-restamp (preserves other config, sets identity/instance/skills.shared). End-to-end CLI smoke verified.

Next: read-through layering + promotion (slice 3), optional console switcher (slice 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)