### PR TITLE
fix(console): panel body top padding (content clears the header)

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -528,9 +528,9 @@ h2 {
   min-height: 0;
   overflow-y: auto;
   /* Horizontal inset matches the DS PanelHeader (--pl-space-4) so body content lines
-     up with the header instead of sitting flush against the panel edge; bottom gives
-     breathing room above the utility bar. */
-  padding: 0 var(--pl-space-4) 12px;
+     up with the header; a top gap clears the header divider; bottom gives breathing
+     room above the utility bar. */
+  padding: var(--pl-space-3) var(--pl-space-4) 12px;
 }
 
 /* Section headings stacked inside a scrolling stage body (Runtime, Schedule,


### PR DESCRIPTION
Local-pass follow-up. The panel body (`.stage-body`) had `padding-top: 0`, so the first section sat flush under the header divider (e.g. Settings ▸ System → **COMPACTION**). Bumped top padding to `--pl-space-3`. CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)