### PR TITLE
fix: inputs respect light mode + workflow depends_on string→list

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1432,7 +1432,8 @@ select {
   width: 100%;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: #0c0c0f;
+  /* token-bridged so inputs flip in light mode (was a hardcoded #0c0c0f dark). */
+  background: var(--pl-color-bg-inset, #0c0c0f);
   color: var(--fg);
   padding: 8px 10px;
 }

--- a/graph/workflows/registry.py
+++ b/graph/workflows/registry.py
@@ -62,7 +62,10 @@ class WorkflowRegistry:
                     for i in (r.get("inputs") or []) if isinstance(i, dict)
                 ],
                 "steps": [
-                    {"id": s.get("id"), "subagent": s.get("subagent"), "depends_on": list(s.get("depends_on", []) or [])}
+                    # depends_on may be authored as a single id string (e.g. `depends_on: step-a`)
+                    # — list() would shatter that into characters, so coerce a str to [str].
+                    {"id": s.get("id"), "subagent": s.get("subagent"),
+                     "depends_on": ([dep] if isinstance(dep := s.get("depends_on"), str) else list(dep or []))}
                     for s in (r.get("steps") or []) if isinstance(s, dict)
                 ],
             })


### PR DESCRIPTION
Two visual-pass catches:
- **Inputs in light mode** — `input/textarea/select` bg was a hardcoded `#0c0c0f`; token-bridged to `var(--pl-color-bg-inset)` so fields (incl. the chat composer) flip. The last hardcoded-dark gap from the light-mode bridge.
- **Workflow `depends_on`** — a step id authored as a string got `list()`'d into characters ("after o, p, e, n, …"). Coerced str→[str] in `registry.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)