### PR TITLE
fix(web): proxy /plugins to the backend in dev (plugin views work on :5173)

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,6 +16,11 @@ export default defineConfig(({ mode }) => {
         "/api": apiBase,
         "/a2a": apiBase,
         "/v1": apiBase,
+        // Plugin-contributed views are iframes the backend serves at /plugins/<id>/…
+        // (ADR 0026). In prod the backend serves /app + /plugins together; the dev
+        // server must proxy them too, else a plugin view 404s on Vite's /app/ base.
+        "/plugins": apiBase,
+        "/healthz": apiBase,
       },
     },
   };


### PR DESCRIPTION
Plugin views are backend-served iframes at `/plugins/<id>/…`; the dev proxy only forwarded `/api`. Added `/plugins` (+ `/healthz`) so plugin views (e.g. agent_browser) load on the dev server like they do in prod. (Restart `npm run dev` to pick it up — Vite reads the proxy config at startup.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)