### PR TITLE
feat(stores): tiered stores slice 3 — layered skills + promotion (ADR 0041)

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -88,6 +88,11 @@ skills:
   db_path: /sandbox/skills.db
   top_k: 5
   max_tokens: 2000
+  # Tier (ADR 0041 slice 3): scope = scoped (private) | shared (one commons for all)
+  # | layered (read commons ∪ private, write private, promote to commons). Blank →
+  # derived from `shared` below. `python -m server skills promote <name>` lifts a
+  # private skill into the commons.
+  # scope: scoped
   # Tiered stores (ADR 0041). `shared: true` lifts the skills library into the
   # COMMONS — one DB read/written by every agent on this host (a fleet's compounding
   # skill library) — instead of per-instance scope. Default false = private per

--- a/graph/config.py
+++ b/graph/config.py
@@ -323,6 +323,10 @@ class LangGraphConfig:
     # Slice 1: skills can be shared (a fleet's compounding skill library). Default
     # False = legacy per-instance behavior (no surprise migration).
     skills_shared: bool = False
+    # Tier (ADR 0041 slice 3): "scoped" (private), "shared" (one commons for all), or
+    # "layered" (read commons ∪ private, write private, promote to commons). Blank →
+    # derived from skills_shared (back-compat): shared→"shared", else "scoped".
+    skills_scope: str = ""
     commons_path: str = ""  # commons base dir; blank → ~/.protoagent/commons
 
     # Workflows — declarative multi-step subagent recipes (see ADR 0002),
@@ -593,6 +597,7 @@ class LangGraphConfig:
             skills_top_k=skills.get("top_k", cls.skills_top_k),
             skills_dir=skills.get("dir", cls.skills_dir),
             skills_shared=skills.get("shared", cls.skills_shared),
+            skills_scope=skills.get("scope", cls.skills_scope),
             commons_path=(data.get("commons", {}) or {}).get("path", cls.commons_path),
             mcp_enabled=mcp.get("enabled", cls.mcp_enabled),
             mcp_servers=list(mcp.get("servers", []) or []),

--- a/graph/skills/cli.py
+++ b/graph/skills/cli.py
@@ -1,0 +1,64 @@
+"""``python -m server skills …`` — inspect/curate the skills index (ADR 0041).
+
+``ls`` lists skills (tagged by tier when layered); ``promote <name>`` lifts a private
+skill into the shared commons. Builds the same layered index the running agent uses,
+scoped to this config's ``instance.id``.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m server skills",
+        description="Inspect/curate the skills index — shared commons + private (ADR 0041).",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    sub.add_parser("ls", help="list skills (private + commons tiers)")
+    pp = sub.add_parser("promote", help="lift a private skill into the shared commons")
+    pp.add_argument("name", help="the skill name to promote")
+    return p
+
+
+def _layered_index():
+    """Build the layered (private ∪ commons) index from the live config, scoped to its
+    instance — so the CLI sees exactly what the running agent does."""
+    from graph.config import LangGraphConfig
+    from graph.config_io import _live_config_dir
+    from graph.skills.index import SkillsIndex
+    from graph.skills.layered import LayeredSkillsIndex
+    from server.agent_init import _commons_dir, _resolve_skills_db, _seed_instance_env
+
+    cfg = LangGraphConfig.from_yaml(str(_live_config_dir() / "langgraph-config.yaml"))
+    _seed_instance_env(cfg)  # so the private path resolves to THIS agent's scope
+    commons = _commons_dir(cfg)
+    private = SkillsIndex(db_path=_resolve_skills_db(cfg.skills_db_path, shared=False))
+    shared = SkillsIndex(db_path=_resolve_skills_db(cfg.skills_db_path, shared=True, commons=commons))
+    return LayeredSkillsIndex(private, shared)
+
+
+def run_skills_cli(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    idx = _layered_index()
+    try:
+        if args.cmd == "ls":
+            rows = idx.all_skills()
+            if not rows:
+                print("(no skills indexed)")
+                return 0
+            for s in rows:
+                print(f"  [{s.get('tier', '?'):7}] {s.get('name', '')}")
+            return 0
+        if args.cmd == "promote":
+            ok = idx.promote(args.name)
+            if ok:
+                print(f"✓ promoted {args.name!r} into the shared commons")
+                return 0
+            print(f"✗ no private skill named {args.name!r}", file=sys.stderr)
+            return 1
+    finally:
+        idx.close()
+    return 0

--- a/graph/skills/layered.py
+++ b/graph/skills/layered.py
@@ -1,0 +1,81 @@
+"""Layered skills (ADR 0041, slice 3) — read the COMMONS ∪ the PRIVATE index.
+
+The ``layered`` tier is the "shared brain, private hands" model: an agent reads
+both the shared commons skill library and its own private skills, but **writes go to
+private** — so one agent's half-baked learned skills never pollute the fleet. A
+proven skill is lifted into the commons explicitly via :meth:`promote` (curated, not
+automatic — the commons is trusted).
+
+This wraps two ordinary :class:`SkillsIndex` backends and presents the same surface
+the middleware uses (``load_skills`` + the write methods), so it's a drop-in.
+"""
+
+from __future__ import annotations
+
+import logging
+import types
+
+log = logging.getLogger(__name__)
+
+
+class LayeredSkillsIndex:
+    """A skills index whose reads union a private + a commons backend, whose writes
+    target private, and which can ``promote`` a private skill into the commons."""
+
+    def __init__(self, private, commons) -> None:
+        self._private = private
+        self._commons = commons
+
+    # ── read: commons ∪ private, merged + de-duped, best-first ────────────────
+    def load_skills(self, query: str, k: int = 5):
+        merged: dict[str, object] = {}
+        for rec in [*self._private.load_skills(query, k=k), *self._commons.load_skills(query, k=k)]:
+            cur = merged.get(rec.name)
+            if cur is None or rec.score < cur.score:  # BM25: lower = more relevant
+                merged[rec.name] = rec
+        return sorted(merged.values(), key=lambda r: r.score)[:k]
+
+    # ── writes → private only ─────────────────────────────────────────────────
+    def add_skill(self, artifact, source: str = "emitted") -> None:
+        self._private.add_skill(artifact, source)
+
+    def add_emitted_skill(self, artifact) -> None:
+        self._private.add_emitted_skill(artifact)
+
+    def replace_disk_skills(self, artifacts: list) -> None:
+        self._private.replace_disk_skills(artifacts)
+
+    def update_confidence(self, skill_id: int, confidence: float) -> None:
+        self._private.update_confidence(skill_id, confidence)
+
+    def delete_skill(self, skill_id: int) -> None:
+        self._private.delete_skill(skill_id)
+
+    def rebuild_index(self, artifacts: list) -> None:
+        self._private.rebuild_index(artifacts)
+
+    # ── introspection + promotion ─────────────────────────────────────────────
+    def all_skills(self) -> list[dict]:
+        return ([{**s, "tier": "private"} for s in self._private.all_skills()]
+                + [{**s, "tier": "commons"} for s in self._commons.all_skills()])
+
+    def promote(self, name: str) -> bool:
+        """Copy a private skill (by name) into the commons. Returns False if no
+        private skill by that name exists. Curated, explicit — the commons is trusted."""
+        match = next((s for s in self._private.all_skills() if s.get("name") == name), None)
+        if match is None:
+            return False
+        artifact = types.SimpleNamespace(
+            name=match.get("name", ""),
+            description=match.get("description", ""),
+            prompt_template=match.get("prompt_template", ""),
+            tools_used=tuple(match.get("tools_used") or ()),
+            source_session_id=match.get("source_session_id", ""),
+        )
+        self._commons.add_skill(artifact, source="promoted")
+        log.info("[skills] promoted %r to the commons", name)
+        return True
+
+    def close(self) -> None:
+        self._private.close()
+        self._commons.close()

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -282,6 +282,14 @@ def _main():
 
         raise SystemExit(run_plugin_cli(sys.argv[2:]))
 
+    # Skills subcommand (ADR 0041 slice 3): `python -m server skills ls|promote <name>`
+    # — inspect/curate the layered (commons ∪ private) skill library. Acts on the DBs
+    # and exits.
+    if len(sys.argv) > 1 and sys.argv[1] == "skills":
+        from graph.skills.cli import run_skills_cli
+
+        raise SystemExit(run_skills_cli(sys.argv[2:]))
+
     # Frozen-binary entrypoint for a plugin's managed MCP server (ADR 0019): the
     # bundled desktop app has no `python` on PATH, so a plugin's managed-server
     # factory re-invokes this binary with `--mcp-plugin <id>` instead of `-m

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -340,12 +340,22 @@ def _build_skills_index(config, extra_skill_dirs=None):
         from graph.skills.index import SkillsIndex
         from graph.skills.loader import seed_skills_index
 
-        db_path = _resolve_skills_db(
-            config.skills_db_path,
-            shared=getattr(config, "skills_shared", False),
-            commons=_commons_dir(config),
-        )
-        index = SkillsIndex(db_path=db_path)
+        # Tier (ADR 0041): scoped (private) | shared (one commons) | layered
+        # (read commons ∪ private, write private). Blank scope → derived from the
+        # slice-1 `shared` bool for back-compat.
+        scope = (getattr(config, "skills_scope", "") or "").strip().lower()
+        if scope not in ("scoped", "shared", "layered"):
+            scope = "shared" if getattr(config, "skills_shared", False) else "scoped"
+        commons = _commons_dir(config)
+        if scope == "layered":
+            from graph.skills.layered import LayeredSkillsIndex
+            private_path = _resolve_skills_db(config.skills_db_path, shared=False)
+            shared_path = _resolve_skills_db(config.skills_db_path, shared=True, commons=commons)
+            index = LayeredSkillsIndex(SkillsIndex(db_path=private_path), SkillsIndex(db_path=shared_path))
+            db_path = f"layered({private_path} ∪ {shared_path})"
+        else:
+            db_path = _resolve_skills_db(config.skills_db_path, shared=(scope == "shared"), commons=commons)
+            index = SkillsIndex(db_path=db_path)
 
         live_root = Path(config.skills_dir).expanduser() if config.skills_dir else (
             _live_config_dir() / "skills"

--- a/tests/test_skills_layered.py
+++ b/tests/test_skills_layered.py
@@ -46,3 +46,15 @@ def test_skills_scope_config_parses(tmp_path):
     cfg = tmp_path / "c.yaml"
     cfg.write_text("skills: { scope: layered }\n")
     assert LangGraphConfig.from_yaml(str(cfg)).skills_scope == "layered"
+
+
+def test_layered_dedup_best_match_wins(tmp_path):
+    """ADR 0041 contract — a skill present in BOTH tiers appears once in a layered
+    read (de-duped by name; the better BM25 match wins)."""
+    private, commons = _idx(tmp_path)
+    private.add_skill(_art("dup_skill", "private copy mentions apples"))
+    commons.add_skill(_art("dup_skill", "commons copy mentions apples"))
+    idx = LayeredSkillsIndex(private, commons)
+    hits = [r for r in idx.load_skills("apples", k=10) if r.name == "dup_skill"]
+    assert len(hits) == 1  # de-duped across tiers, single best-scoring record
+    idx.close()

--- a/tests/test_skills_layered.py
+++ b/tests/test_skills_layered.py
@@ -1,0 +1,48 @@
+"""Layered skills tier (ADR 0041 slice 3) — commons ∪ private, write private, promote."""
+
+from __future__ import annotations
+
+import types
+
+from graph.skills.index import SkillsIndex
+from graph.skills.layered import LayeredSkillsIndex
+
+
+def _art(name: str, desc: str):
+    return types.SimpleNamespace(name=name, description=desc, prompt_template="do " + name,
+                                 tools_used=(), source_session_id="")
+
+
+def _idx(tmp_path):
+    private = SkillsIndex(db_path=str(tmp_path / "priv.db"))
+    commons = SkillsIndex(db_path=str(tmp_path / "commons.db"))
+    for ix in (private, commons):
+        if hasattr(ix, "initialize_db"):
+            ix.initialize_db()
+    return private, commons
+
+
+def test_layered_union_write_private_promote(tmp_path):
+    private, commons = _idx(tmp_path)
+    private.add_skill(_art("scrape_web", "a private scraping skill"))
+    commons.add_skill(_art("triage_ticket", "a commons triage skill"))
+    idx = LayeredSkillsIndex(private, commons)
+
+    names = {r.name for r in idx.load_skills("skill", k=10)}
+    assert {"scrape_web", "triage_ticket"} <= names  # reads BOTH tiers
+
+    idx.add_skill(_art("new_one", "freshly learned skill"))  # write → private only
+    tiers = {(s["name"], s["tier"]) for s in idx.all_skills()}
+    assert ("new_one", "private") in tiers and ("new_one", "commons") not in tiers
+
+    assert idx.promote("new_one") is True                    # promote private → commons
+    assert ("new_one", "commons") in {(s["name"], s["tier"]) for s in idx.all_skills()}
+    assert idx.promote("does_not_exist") is False
+    idx.close()
+
+
+def test_skills_scope_config_parses(tmp_path):
+    from graph.config import LangGraphConfig
+    cfg = tmp_path / "c.yaml"
+    cfg.write_text("skills: { scope: layered }\n")
+    assert LangGraphConfig.from_yaml(str(cfg)).skills_scope == "layered"


### PR DESCRIPTION
Third slice of **ADR 0041** (#771) — the **layered** skills tier ("shared brain, private hands").

## What
On top of slice 1's `scoped`/`shared`, add **`skills.scope: layered`**: an agent **reads** the commons ∪ its private skill library, but **writes go to private** — so one agent's half-baked learned skills never pollute the fleet commons. A proven skill is lifted into the commons **explicitly**:
```
python -m server skills ls                  # private + commons, tagged
python -m server skills promote <name>      # private → commons (curated)
```

## How
- **`LayeredSkillsIndex`** wraps two `SkillsIndex` backends: `load_skills` unions + de-dups (best BM25 wins), writes route to private, `promote` copies a private skill into the commons. Same surface the knowledge middleware reads through — drop-in.
- **config**: `skills.scope: scoped|shared|layered` (blank → derived from slice-1 `shared` for back-compat).
- **`skills` CLI** + dispatch.

## Tests
`test_skills_layered.py`: union read across both tiers, private-only write, promote (and missing-skill no-op), `skills.scope` config parse. CLI smoke verified (ls + promote dispatch/build).

Default unchanged (`scoped`). Next: slice 4 (console switcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)