### PR TITLE
fix(console): BootGate loading splash is theme-aware

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -289,14 +289,14 @@ h2 {
   font-size: 1.05rem;
   font-weight: 600;
   letter-spacing: -0.01em;
-  color: var(--text, #e8e8ec);
+  color: var(--fg);
 }
 
 .boot-gate-detail {
   margin: 0;
   font-size: 0.85rem;
   line-height: 1.45;
-  color: var(--text-muted, #9a9aa6);
+  color: var(--fg-muted);
 }
 
 .boot-gate-retry {


### PR DESCRIPTION
The loading bumper's title/detail used phantom `--text`/`--text-muted` vars (we use `--fg`/`--fg-muted`), falling back to hardcoded light text → invisible on a light-mode bg. Repointed to the token-bridged `--fg`/`--fg-muted`. CSS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)