### PR TITLE
feat(console): adopt responsive Tabs (collapse to dropdown on narrow panels)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.0",
-    "@protolabsai/ui": "^0.13.0",
+    "@protolabsai/ui": "^0.15.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -450,7 +450,7 @@ export function App() {
       case "activity":
         return (
           <>
-            <Tabs active={activityTab} onSelect={(t) => setActivityTab(t as ActivityTab)} items={[
+            <Tabs responsive active={activityTab} onSelect={(t) => setActivityTab(t as ActivityTab)} items={[
               { id: "thread", label: "Thread", icon: Activity },
               { id: "inbox", label: "Inbox", icon: Inbox, badge: inboxUnread ? (<span data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span>) : null },
             ].map(toTab)} />
@@ -462,7 +462,7 @@ export function App() {
       case "agent":
         return (
           <>
-            <Tabs active={agentTab} onSelect={(t) => setAgentTab(t as AgentTab)} items={[
+            <Tabs responsive active={agentTab} onSelect={(t) => setAgentTab(t as AgentTab)} items={[
               { id: "identity", label: "Identity", icon: Sparkles },
               { id: "settings", label: "Settings", icon: Settings2 },
               { id: "tools", label: "Tools", icon: Wrench },
@@ -483,7 +483,7 @@ export function App() {
       case "plugins":
         return (
           <>
-            <Tabs active={pluginsTab} onSelect={(t) => setPluginsTab(t as PluginsTab)} items={[
+            <Tabs responsive active={pluginsTab} onSelect={(t) => setPluginsTab(t as PluginsTab)} items={[
               { id: "local", label: "Local", icon: Boxes },
               { id: "market", label: "Market", icon: Store },
               { id: "download", label: "Download", icon: Download },
@@ -494,7 +494,7 @@ export function App() {
       case "knowledge":
         return (
           <>
-            <Tabs active={knowledgeTab} onSelect={(t) => setKnowledgeTab(t as KnowledgeTab)} items={[
+            <Tabs responsive active={knowledgeTab} onSelect={(t) => setKnowledgeTab(t as KnowledgeTab)} items={[
               { id: "store", label: "Store", icon: Database },
               { id: "settings", label: "Settings", icon: Settings2 },
             ].map(toTab)} />
@@ -504,7 +504,7 @@ export function App() {
       case "settings":
         return (
           <>
-            <Tabs active={settingsTab} onSelect={(t) => setSettingsTab(t as SettingsTab)} items={SETTINGS_TABS.map(toTab)} />
+            <Tabs responsive active={settingsTab} onSelect={(t) => setSettingsTab(t as SettingsTab)} items={SETTINGS_TABS.map(toTab)} />
             <SettingsSurface tab={settingsTab} />
           </>
         );

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -125,7 +125,7 @@ export function PluginView({ view }: { view: PluginViewType }) {
   return (
     <>
       {/* Sub-tab strip above the panel card — shared DS Tabs (single source of truth). */}
-      <Tabs active={activeTab} onSelect={setActiveTab}
+      <Tabs responsive active={activeTab} onSelect={setActiveTab}
             items={tabs.map((t) => ({ id: t.id, label: t.label }))} />
       <section className="panel stage-panel plugin-view">
       <div className="plugin-view-body">

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -495,11 +495,13 @@ h2 {
   grid-template-rows: auto minmax(0, 1fr) auto;
 }
 
-/* A tabbed surface renders the DS <Tabs> strip + the .panel card as siblings in the
-   AppShell column. Style the strip as the card's TOP edge and drop the panel's top
+/* A tabbed surface renders the DS Tabs + the .panel card as siblings in the AppShell
+   column. Style the tab strip as the card's TOP edge and drop the panel's top
    border/radius, so the two read as ONE full-height card — its top aligns with the
-   non-tabbed panels (which have no strip). */
-.pl-appshell__col > .pl-tabs {
+   non-tabbed panels. (Responsive Tabs wrap the strip in .pl-tabs-wrap and collapse to
+   a dropdown on narrow containers — match both as the column's direct child.) */
+.pl-appshell__col > .pl-tabs,
+.pl-appshell__col > .pl-tabs-wrap {
   flex: 0 0 auto;
   padding: 8px 12px 0;
   border: 1px solid var(--border);
@@ -507,7 +509,8 @@ h2 {
   border-radius: var(--radius) var(--radius) 0 0;
   background: var(--bg-panel);
 }
-.pl-appshell__col > .pl-tabs + .panel {
+.pl-appshell__col > .pl-tabs + .panel,
+.pl-appshell__col > .pl-tabs-wrap + .panel {
   border-top: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.0",
-        "@protolabsai/ui": "^0.13.0",
+        "@protolabsai/ui": "^0.15.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -66,9 +66,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.13.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.13.0.tgz",
-      "integrity": "sha512-3z7XQSsOGqhAVzx2ROiwn5SgOLxiWkiYi/3LrlKpC7OBMEzQ1v/Bq7j3fjbNMEzRdiG46pWDUwhDFRG5U0UEmw==",
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.15.0.tgz",
+      "integrity": "sha512-uo2arQOhGHygtE24iWJWFTbGbeNT8VmFoZuiXXv1VsVgFqc33Y0584mMEN36QuArp5xeNrsP1COcp/8/nNJODw==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Closes the loop on our first fleet DS contribution (responsive Tabs, protoContent #166 → shipped in **@protolabsai/ui@0.15.0**).

- Bump `@protolabsai/ui` `0.13`→`0.15`.
- All surface tab strips (Activity/Agent/Plugins/Knowledge/Settings + plugin views) now pass `responsive` → a narrow panel/window collapses the strip to a `<select>` via the DS container query (no JS).
- Card-top CSS matches the new `.pl-tabs-wrap` wrapper.

68/68 e2e (wide columns keep the strip, so selectors are unaffected), tsc + build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)