### PR TITLE
feat(console): responsive chat session tabs (dropdown + add when narrow)

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -572,6 +572,10 @@ h2 {
 /* One consolidated tab bar: a tab per session (dot · title · close) + "new".
    Double-click a title to rename. Replaces the old header + tab strip + the
    per-session title row. */
+.chat-tabbar-wrap {
+  container-type: inline-size;
+}
+
 .chat-tabbar {
   display: flex;
   align-items: center;
@@ -579,6 +583,44 @@ h2 {
   overflow-x: auto;
   padding: 8px 10px;
   border-bottom: 1px solid var(--border);
+}
+
+/* Narrow: the per-session strip collapses to a session dropdown + add (container query). */
+.chat-tabbar-compact {
+  display: none;
+  align-items: center;
+  gap: 6px;
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--border);
+}
+.chat-session-select {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.chat-compact-btn {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 28px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: transparent;
+  color: var(--fg-muted);
+  cursor: pointer;
+}
+.chat-compact-btn:hover {
+  color: var(--fg);
+  background: var(--bg-hover);
+}
+@container (max-width: 26rem) {
+  .chat-tabbar-wrap > .chat-tabbar {
+    display: none;
+  }
+  .chat-tabbar-wrap > .chat-tabbar-compact {
+    display: flex;
+  }
 }
 
 .chat-tab {

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -82,8 +82,9 @@ export function ChatSurface({
   return (
     <section className="panel stage-panel chat-stage" style={active ? undefined : { display: "none" }} aria-hidden={!active}>
       {/* One row: a tab per session (status dot · title · close), then "+".
-          Double-click a title to rename. Replaces the old header + tab strip +
-          per-session title row. */}
+          Double-click a title to rename. Below ~26rem of container width it collapses
+          to a session dropdown + add (the per-session strip can't fit) — container query. */}
+      <div className="chat-tabbar-wrap">
       <div className="chat-tabbar" role="tablist" aria-label="Chat sessions">
         {chat.sessions.map((session) => {
           const active = session.id === chat.currentSessionId;
@@ -138,6 +139,41 @@ export function ChatSurface({
         >
           <Plus size={15} />
         </button>
+      </div>
+
+      {/* Narrow (container query) — the per-session strip collapses to a dropdown
+          (switch) + close-current + add. Distinct classes so e2e's .chat-tab-* keep
+          matching only the strip. */}
+      <div className="chat-tabbar-compact">
+        <select
+          className="chat-session-select"
+          value={chat.currentSessionId ?? ""}
+          aria-label="Chat session"
+          onChange={(e) => chatStore.switchSession(e.target.value)}
+        >
+          {chat.sessions.map((s) => (
+            <option key={s.id} value={s.id}>{s.title}</option>
+          ))}
+        </select>
+        <button
+          type="button"
+          className="chat-compact-btn"
+          title="Close session"
+          aria-label="Close current session"
+          onClick={() => chat.currentSessionId && setPendingClose(chat.currentSessionId)}
+        >
+          <X size={12} />
+        </button>
+        <button
+          type="button"
+          className="chat-compact-btn"
+          title="New chat"
+          aria-label="New chat"
+          onClick={() => chatStore.createSession()}
+        >
+          <Plus size={15} />
+        </button>
+      </div>
       </div>
 
       <div className="chat-session-pool">


### PR DESCRIPTION
The chat session tabbar (bespoke — per-session dot/title/close + new) now collapses to a **session dropdown + close-current + add (+)** when its container is narrow (< 26rem), via a CSS container query — same pattern as the DS Tabs, no JS. Compact controls use distinct classes so the e2e `.chat-tab-*` selectors still target only the strip. 68/68 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)