### PR TITLE
feat(fleet): supervisor — workspace agents as background processes (ADR 0042 slice 1)

### DIFF
--- a/graph/fleet/__init__.py
+++ b/graph/fleet/__init__.py
@@ -1,0 +1,7 @@
+"""Fleet supervisor (ADR 0042) — run a fleet of workspace agents as persistent
+background processes, with start / stop / status from a control plane.
+
+This is slice 1: process lifecycle over ADR 0041 workspaces (``run_exec`` is the
+launch primitive). The hub/proxy + console switcher (slices 2-3) build on top. No new
+runtime — each agent is a normal ``python -m server --ui none`` on its workspace's port.
+"""

--- a/graph/fleet/cli.py
+++ b/graph/fleet/cli.py
@@ -1,0 +1,62 @@
+"""``python -m server fleet …`` — run a fleet of workspace agents (ADR 0042).
+
+A thin CLI over ``graph.fleet.supervisor``. ``up`` starts agents as detached
+background processes, ``down`` stops them, ``ls`` shows running status.
+"""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from graph.fleet import supervisor
+
+
+def _build_parser() -> argparse.ArgumentParser:
+    p = argparse.ArgumentParser(
+        prog="python -m server fleet",
+        description="Run a fleet of workspace agents as background processes (ADR 0042).",
+    )
+    sub = p.add_subparsers(dest="cmd", required=True)
+    pu = sub.add_parser("up", help="start agents — all workspaces, or named")
+    pu.add_argument("names", nargs="*")
+    pd = sub.add_parser("down", help="stop agents — all running, or named")
+    pd.add_argument("names", nargs="*")
+    sub.add_parser("ls", help="list workspaces + running status")
+    sub.add_parser("status", help="alias for ls")
+    return p
+
+
+def run_fleet_cli(argv: list[str]) -> int:
+    args = _build_parser().parse_args(argv)
+    try:
+        if args.cmd == "up":
+            rows = supervisor.up(args.names or None)
+            if not rows:
+                print("(no workspaces — create one: python -m server workspace new <name>)")
+            for r in rows:
+                tag = "already running" if r.get("already") else "started"
+                print(f"  ✓ {r['name']:16} {tag} (:{r.get('port')}, pid {r.get('pid')})")
+            return 0
+        if args.cmd == "down":
+            rows = supervisor.down(args.names or None)
+            if not rows:
+                print("(nothing running)")
+            for r in rows:
+                print(f"  ✓ {r['name']:16} stopped")
+            return 0
+        if args.cmd in ("ls", "status"):
+            rows = supervisor.status()
+            if not rows:
+                print("(no workspaces — python -m server workspace new <name>)")
+                return 0
+            for w in rows:
+                dot = "●" if w["running"] else "○"  # ● running / ○ stopped
+                state = f"pid {w['pid']}" if w["running"] else "stopped"
+                bundle = f"  [{w['bundle']}]" if w["bundle"] else ""
+                print(f"  {dot} {w['name']:16} :{w['port']:<6} {state}{bundle}")
+            return 0
+    except supervisor.FleetError as exc:
+        print(f"✗ {exc}", file=sys.stderr)
+        return 1
+    return 0

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -1,0 +1,161 @@
+"""Agent-process lifecycle (ADR 0042 slice 1).
+
+Starts a workspace agent as a **detached background process** (``python -m server
+--ui none`` with the workspace's config-dir + instance + port, via
+``workspaces.manager.run_exec``), stops it (SIGTERM → reap), and reports status. A
+small JSON registry (``<workspaces_root>/fleet.json``) survives the supervisor CLI's
+own exit — the agents outlive it, so subsequent ``ls``/``down`` can find them.
+
+Pure orchestration: an agent is an ordinary server; the supervisor just owns its
+process. Session continuity is free (each agent's stores are ``instance.id``-scoped).
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import signal
+import subprocess
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+
+from graph.workspaces import manager
+
+log = logging.getLogger(__name__)
+
+
+class FleetError(Exception):
+    """A supervisor op was rejected (no such workspace, not running, …)."""
+
+
+def _state_path() -> Path:
+    return manager.workspaces_root() / "fleet.json"
+
+
+def _load_state() -> dict:
+    f = _state_path()
+    if not f.exists():
+        return {}
+    try:
+        d = json.loads(f.read_text())
+        return d if isinstance(d, dict) else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+
+
+def _save_state(state: dict) -> None:
+    f = _state_path()
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text(json.dumps(state, indent=2) + "\n")
+
+
+def _alive(pid: int | None) -> bool:
+    if not pid:
+        return False
+    try:
+        os.kill(int(pid), 0)  # signal 0 = liveness probe
+        return True
+    except (OSError, ValueError):
+        return False
+
+
+def _log_path(name: str) -> Path:
+    return manager.workspaces_root() / manager._safe(name) / "agent.log"
+
+
+def is_running(name: str) -> bool:
+    rec = _load_state().get(manager._safe(name))
+    return bool(rec) and _alive(rec.get("pid"))
+
+
+def start(name: str) -> dict:
+    """Spawn the workspace's agent as a detached background process. No-op (returns
+    the live record) if it's already running."""
+    name = manager._safe(name)
+    ws = next((w for w in manager.list_workspaces() if w["name"] == name), None)
+    if ws is None:
+        raise FleetError(f"no workspace {name!r} — create it: workspace new {name}")
+
+    state = _load_state()
+    rec = state.get(name)
+    if rec and _alive(rec.get("pid")):
+        return {**rec, "name": name, "running": True, "already": True}
+
+    env, argv = manager.run_exec(name, ["--ui", "none"])
+    full_env = {**os.environ, **env}
+    log_path = _log_path(name)
+    log_path.parent.mkdir(parents=True, exist_ok=True)
+    logf = open(log_path, "a")  # noqa: SIM115 — handed to the child; closed on its exit
+    # start_new_session detaches it from this CLI's process group so it survives exit.
+    proc = subprocess.Popen(argv, env=full_env, stdout=logf, stderr=logf, start_new_session=True)
+    rec = {"pid": proc.pid, "port": ws.get("port"), "id": ws.get("id", name),
+           "started_at": datetime.now(timezone.utc).isoformat(), "log": str(log_path)}
+    state[name] = rec
+    _save_state(state)
+    log.info("[fleet] started %s (pid %d, :%s)", name, proc.pid, rec["port"])
+    return {**rec, "name": name, "running": True, "already": False}
+
+
+def stop(name: str, *, timeout: float = 8.0) -> dict:
+    """SIGTERM the agent and reap its registry entry (SIGKILL if it lingers)."""
+    name = manager._safe(name)
+    state = _load_state()
+    rec = state.get(name)
+    if not rec or not _alive(rec.get("pid")):
+        state.pop(name, None)
+        _save_state(state)
+        raise FleetError(f"{name!r} is not running")
+    pid = int(rec["pid"])
+    try:
+        os.kill(pid, signal.SIGTERM)
+        deadline = time.monotonic() + timeout
+        while _alive(pid) and time.monotonic() < deadline:
+            time.sleep(0.2)
+        if _alive(pid):
+            os.kill(pid, signal.SIGKILL)
+    except OSError:
+        pass
+    state.pop(name, None)
+    _save_state(state)
+    log.info("[fleet] stopped %s (pid %d)", name, pid)
+    return {"name": name, "stopped": True}
+
+
+def status() -> list[dict]:
+    """Every workspace + its live status (running/stopped, pid, port)."""
+    state = _load_state()
+    dirty = False
+    out: list[dict] = []
+    for ws in manager.list_workspaces():
+        rec = state.get(ws["name"]) or {}
+        running = _alive(rec.get("pid"))
+        if rec and not running:  # stale entry — agent died; clean it
+            state.pop(ws["name"], None)
+            dirty = True
+        out.append({"name": ws["name"], "id": ws.get("id", ws["name"]),
+                    "port": ws.get("port"), "pid": rec.get("pid") if running else None,
+                    "running": running, "bundle": ws.get("bundle", "")})
+    if dirty:
+        _save_state(state)
+    return out
+
+
+def up(names: list[str] | None = None) -> list[dict]:
+    """Start a set of agents (named, or all workspaces)."""
+    targets = names or [w["name"] for w in manager.list_workspaces()]
+    return [start(n) for n in targets]
+
+
+def down(names: list[str] | None = None) -> list[dict]:
+    """Stop a set of agents (named, or all running)."""
+    if names is None:
+        names = [k for k, r in _load_state().items() if _alive(r.get("pid"))]
+    out = []
+    for n in names:
+        try:
+            out.append(stop(n))
+        except FleetError:
+            pass
+    return out

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -299,6 +299,13 @@ def _main():
 
         raise SystemExit(run_skills_cli(sys.argv[2:]))
 
+    # Fleet subcommand (ADR 0042 slice 1): `python -m server fleet up|down|ls` —
+    # run workspace agents as persistent background processes (start/stop/status).
+    if len(sys.argv) > 1 and sys.argv[1] == "fleet":
+        from graph.fleet.cli import run_fleet_cli
+
+        raise SystemExit(run_fleet_cli(sys.argv[2:]))
+
     # Frozen-binary entrypoint for a plugin's managed MCP server (ADR 0019): the
     # bundled desktop app has no `python` on PATH, so a plugin's managed-server
     # factory re-invokes this binary with `--mcp-plugin <id>` instead of `-m

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -1,0 +1,56 @@
+"""Fleet supervisor (ADR 0042 slice 1) — start/stop/status over workspaces."""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.workspaces import manager
+from graph.fleet import supervisor
+
+
+@pytest.fixture
+def fleet(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    alive: set[int] = set()
+    monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
+
+    class FakeProc:
+        def __init__(self, *a, **k):
+            self.pid = 99001
+            alive.add(99001)
+
+    monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
+
+    def fake_kill(pid, sig):  # SIGTERM/SIGKILL "kills" the fake process
+        alive.discard(int(pid))
+
+    monkeypatch.setattr(supervisor.os, "kill", fake_kill)
+    return alive
+
+
+def test_start_status_stop(fleet):
+    manager.create("alpha", port=7890)
+
+    r = supervisor.start("alpha")
+    assert r["running"] and r["pid"] == 99001 and r["port"] == 7890 and not r["already"]
+    assert supervisor.is_running("alpha")
+
+    st = {s["name"]: s for s in supervisor.status()}
+    assert st["alpha"]["running"] and st["alpha"]["port"] == 7890
+
+    assert supervisor.start("alpha")["already"]  # idempotent
+
+    supervisor.stop("alpha")
+    assert not supervisor.is_running("alpha")
+    assert not any(s["running"] for s in supervisor.status())
+
+
+def test_start_unknown_workspace_errors(fleet):
+    with pytest.raises(supervisor.FleetError):
+        supervisor.start("ghost")
+
+
+def test_stop_not_running_errors(fleet):
+    manager.create("beta")
+    with pytest.raises(supervisor.FleetError):
+        supervisor.stop("beta")  # never started


### PR DESCRIPTION
First slice of **ADR 0042** (#782) — the fleet supervisor.

## What
Run workspace agents as **persistent background processes** with start/stop/status:
```
python -m server fleet up [names…]    # start — all workspaces, or named
python -m server fleet ls             # ● running / ○ stopped + port + pid
python -m server fleet down [names…]  # stop
```

## How
- `start` spawns the workspace's agent **detached** (`python -m server --ui none` via `workspaces.run_exec`, `start_new_session=True` so it outlives the CLI), logs to `<ws>/agent.log`, and records pid+port in a `fleet.json` registry (so later `ls`/`down` find it).
- `stop` = SIGTERM → reap (SIGKILL if it lingers); `status` cross-refs the registry with liveness and self-heals stale entries.
- **No new runtime** — each agent is an ordinary server on its workspace's port; **session continuity is free** (each agent's stores are `instance.id`-scoped per ADR 0004/0041).

## Tests
`test_fleet_supervisor.py`: start/status/stop lifecycle (mocked spawn), idempotent start, unknown-workspace + not-running errors. **Verified end-to-end too**: `fleet up` spawned a live agent serving HTTP 200 on its port, `fleet down` stopped it.

Next: slice 2 (the hub control-plane API + reverse proxy), then slice 3 (the console switcher).

🤖 Generated with [Claude Code](https://claude.com/claude-code)