### PR TITLE
feat(fleet): control-plane API — /api/fleet + /api/archetypes (ADR 0042 slice 2)

### DIFF
--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -254,6 +254,9 @@ def _install_bundle(bundle: dict, bundle_url: str, bundle_sha: str, ref: str | N
     lock["bundles"].append({
         "id": bid, "source_url": bundle_url, "requested_ref": ref or "",
         "resolved_sha": bundle_sha, "plugins": [s["id"] for s in installed],
+        # Archetype metadata (ADR 0042) cached here so the new-agent picker can offer
+        # this bundle as a starter type without re-reading its manifest.
+        "archetype": bundle.get("archetype") or {},
         "installed_at": datetime.now(timezone.utc).isoformat(), "by": by,
     })
     _write_lock(lock)

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -1,0 +1,103 @@
+"""Fleet control-plane API (ADR 0042 slice 2).
+
+The endpoints the CLI (`python -m server fleet`) and the desktop GUI panels both
+drive — list / create / start / stop agents, and list archetypes for the new-agent
+picker. Mounted by ``register_fleet_routes(app)``. The reverse proxy (in-place switch
+of the *active* agent) is a separate slice; these are the lifecycle + catalog routes.
+
+Errors degrade to HTTP 400 with a readable message (never a 500), so a panel can show
+it inline. Blocking work (a bundle clone on create) runs off the event loop.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+log = logging.getLogger("protoagent.server")
+
+
+def register_fleet_routes(app) -> None:
+    from fastapi import Body, HTTPException
+
+    from graph.fleet import supervisor
+    from graph.workspaces import manager
+
+    @app.get("/api/fleet")
+    async def _list_fleet():
+        """Every workspace agent + live status (running/stopped, port, pid, bundle)."""
+        return {"agents": supervisor.status()}
+
+    @app.post("/api/fleet")
+    async def _create_agent(body: dict = Body(...)):
+        """Create an agent (optionally from a bundle archetype) and start it.
+
+        Body: ``{name, bundle?: <git-url>, port?: int, start?: bool=true,
+        shared_skills?: bool}``. A blank ``bundle`` is the built-in **Basic** archetype.
+        """
+        name = str(body.get("name", "")).strip()
+        bundle = (str(body.get("bundle") or "").strip()) or None
+        port = body.get("port")
+        start = bool(body.get("start", True))
+        shared = bool(body.get("shared_skills", False))
+        try:
+            # create() may clone+install a bundle (subprocess) — keep it off the loop.
+            ws = await asyncio.to_thread(
+                manager.create, name, bundle=bundle, port=port, shared_skills=shared)
+            agent = supervisor.start(name) if start else {
+                "name": name, "id": ws["id"], "port": ws["port"], "running": False}
+            return {"ok": True, "agent": agent, "installed": ws.get("installed", [])}
+        except (manager.WorkspaceError, supervisor.FleetError) as exc:
+            raise HTTPException(400, str(exc))
+
+    @app.post("/api/fleet/{name}/start")
+    async def _start_agent(name: str):
+        try:
+            return {"ok": True, "agent": supervisor.start(name)}
+        except supervisor.FleetError as exc:
+            raise HTTPException(400, str(exc))
+
+    @app.post("/api/fleet/{name}/stop")
+    async def _stop_agent(name: str):
+        try:
+            return {"ok": True, **supervisor.stop(name)}
+        except supervisor.FleetError as exc:
+            raise HTTPException(400, str(exc))
+
+    @app.delete("/api/fleet/{name}")
+    async def _remove_agent(name: str, purge: bool = False):
+        try:
+            try:
+                supervisor.stop(name)  # stop if running; ignore if not
+            except supervisor.FleetError:
+                pass
+            return {"ok": True, **manager.remove(name, purge=purge)}
+        except manager.WorkspaceError as exc:
+            raise HTTPException(400, str(exc))
+
+    @app.get("/api/archetypes")
+    async def _list_archetypes():
+        """Starter agent types for the new-agent picker: the built-in **Basic** +
+        every installed bundle's ``archetype:`` metadata."""
+        return {"archetypes": _archetypes()}
+
+
+def _archetypes() -> list[dict]:
+    """Built-in Basic + installed-bundle archetypes (cached in plugins.lock)."""
+    out = [{
+        "id": "basic", "label": "Basic", "icon": "Sparkles", "bundle": None,
+        "blurb": "A blank-slate agent — the core loop + built-in tools, no plugins.",
+    }]
+    try:
+        from graph.plugins.installer import _read_lock
+        for b in (_read_lock().get("bundles") or []):
+            arch = b.get("archetype") or {}
+            if arch.get("label"):
+                out.append({
+                    "id": b.get("id"), "label": arch.get("label"),
+                    "icon": arch.get("icon", "Package"), "blurb": arch.get("blurb", ""),
+                    "bundle": b.get("source_url"),
+                })
+    except Exception:  # noqa: BLE001 — archetype discovery is best-effort
+        log.warning("[fleet] archetype discovery failed", exc_info=True)
+    return out

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -610,6 +610,11 @@ def _main():
     # operator_api/knowledge_routes.py (ADR 0023 phase 3).
     register_knowledge_routes(fastapi_app)
     register_plugin_routes(fastapi_app)
+
+    # Fleet control plane (ADR 0042) — /api/fleet (list/create/start/stop) +
+    # /api/archetypes. The CLI + the desktop GUI panels both drive these.
+    from operator_api.fleet_routes import register_fleet_routes
+    register_fleet_routes(fastapi_app)
     register_mcp_routes(fastapi_app)
 
     # --- Telemetry (ADR 0006 Slice 2) --------------------------------------

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -1,0 +1,54 @@
+"""Fleet control-plane API (ADR 0042 slice 2) — list/create/start/stop + archetypes."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from graph.fleet import supervisor
+    from operator_api.fleet_routes import register_fleet_routes
+
+    alive: set[int] = set()
+    monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
+
+    class FakeProc:
+        def __init__(self, *a, **k):
+            self.pid = 4242
+            alive.add(4242)
+
+    monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
+    monkeypatch.setattr(supervisor.os, "kill", lambda pid, sig: alive.discard(int(pid)))
+
+    app = FastAPI()
+    register_fleet_routes(app)
+    return TestClient(app)
+
+
+def test_archetypes_include_basic(client):
+    arr = client.get("/api/archetypes").json()["archetypes"]
+    assert any(a["id"] == "basic" and a["bundle"] is None for a in arr)
+
+
+def test_create_list_start_stop_remove(client):
+    # create (no bundle = Basic) + auto-start
+    r = client.post("/api/fleet", json={"name": "alpha", "port": 7890})
+    assert r.status_code == 200 and r.json()["agent"]["running"]
+
+    fleet = client.get("/api/fleet").json()["agents"]
+    a = next(x for x in fleet if x["name"] == "alpha")
+    assert a["running"] and a["port"] == 7890
+
+    assert client.post("/api/fleet/alpha/stop").json()["ok"]
+    assert not next(x for x in client.get("/api/fleet").json()["agents"] if x["name"] == "alpha")["running"]
+
+    assert client.delete("/api/fleet/alpha").json()["ok"]
+    assert not client.get("/api/fleet").json()["agents"]
+
+
+def test_create_bad_name_is_400(client):
+    assert client.post("/api/fleet", json={"name": "bad name"}).status_code == 400


### PR DESCRIPTION
The HTTP control plane the CLI **and the desktop GUI panels** drive (ADR 0042 §B/§H). Unblocks the front-end team.

```
GET    /api/fleet              → {agents:[{name,id,port,pid,running,bundle}]}
POST   /api/fleet              {name, bundle?, port?, start?, shared_skills?} → create+start
POST   /api/fleet/{n}/start    → {ok, agent}
POST   /api/fleet/{n}/stop     → {ok, stopped}
DELETE /api/fleet/{n}?purge=   → {ok, removed}
GET    /api/archetypes         → {archetypes:[{id,label,icon,blurb,bundle}]}  (Basic + bundles)
```

- Wraps the slice-1 supervisor + the workspace manager. Errors → **HTTP 400** with a readable message (panels show inline; never a 500). A bundle clone on create runs **off the event loop**.
- Bundle install now **caches the `archetype:` block in plugins.lock**, so `/api/archetypes` lists installed bundles as starter types without re-fetching.
- **Scope**: the lifecycle + catalog routes. The **reverse proxy** (in-place switch of the active agent) is the next slice — but these endpoints are what the desktop onboarding / switcher / fleet-manager panels code against **today**.

## Tests
`test_fleet_routes.py` (TestClient, mocked spawn): archetypes-include-Basic, create→list→start→stop→remove, bad-name→400.

🤖 Generated with [Claude Code](https://claude.com/claude-code)