### PR TITLE
feat(fleet): reverse proxy + activate — the in-place switch (ADR 0042 slice 2b)

### DIFF
--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -1,0 +1,93 @@
+"""Reverse proxy for the in-place switch (ADR 0042 slice 2b).
+
+The hub forwards console traffic to the **active** agent under the ``/active/<path>``
+prefix — so switching agents is a single ``activate`` call that re-points where
+``/active/*`` lands (chat → ``/active/api/chat``, SSE → ``/active/api/events``, A2A →
+``/active/a2a``). The active pointer lives in ``<workspaces_root>/fleet-active`` so it
+survives restarts; it only resolves while that agent is actually running.
+
+Streaming-safe: responses (incl. SSE) are piped through unbuffered, and the upstream
+client is closed when the stream ends.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import httpx
+from starlette.responses import JSONResponse, StreamingResponse
+
+from graph.fleet import supervisor
+from graph.workspaces import manager
+
+log = logging.getLogger("protoagent.server")
+
+# Headers we must not copy verbatim across the proxy boundary.
+_HOP = {"host", "content-length", "connection", "keep-alive", "transfer-encoding", "te",
+        "trailer", "upgrade", "proxy-authorization", "proxy-authenticate"}
+
+
+def _active_path():
+    return manager.workspaces_root() / "fleet-active"
+
+
+def get_active() -> str | None:
+    """The active agent name, or None — only if it's recorded *and* still running."""
+    f = _active_path()
+    if not f.exists():
+        return None
+    name = f.read_text().strip()
+    return name if name and supervisor.is_running(name) else None
+
+
+def set_active(name: str) -> dict:
+    """Point the proxy at a running agent. Raises FleetError if it isn't running."""
+    name = manager._safe(name)
+    if not supervisor.is_running(name):
+        raise supervisor.FleetError(f"{name!r} is not running — start it first")
+    _active_path().write_text(name)
+    log.info("[fleet] active agent → %s", name)
+    return {"active": name}
+
+
+def _active_port() -> int | None:
+    name = get_active()
+    if not name:
+        return None
+    return next((w["port"] for w in supervisor.status()
+                 if w["name"] == name and w["running"]), None)
+
+
+async def forward(request, path: str):
+    """Reverse-proxy ``request`` to ``/<path>`` on the active agent, streaming the
+    response back (SSE-safe). 409 if no agent is active."""
+    port = _active_port()
+    if port is None:
+        return JSONResponse(
+            {"detail": "no active agent — start one and POST /api/fleet/{name}/activate"},
+            status_code=409)
+
+    url = f"http://127.0.0.1:{port}/{path}"
+    body = await request.body()
+    headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP}
+
+    client = httpx.AsyncClient(timeout=httpx.Timeout(None))
+    upstream_req = client.build_request(
+        request.method, url, headers=headers, content=body,
+        params=dict(request.query_params))
+    try:
+        upstream = await client.send(upstream_req, stream=True)
+    except httpx.ConnectError:
+        await client.aclose()
+        return JSONResponse({"detail": "active agent is not reachable"}, status_code=502)
+
+    async def _pipe():
+        try:
+            async for chunk in upstream.aiter_raw():
+                yield chunk
+        finally:
+            await upstream.aclose()
+            await client.aclose()
+
+    resp_headers = {k: v for k, v in upstream.headers.items() if k.lower() not in _HOP}
+    return StreamingResponse(_pipe(), status_code=upstream.status_code, headers=resp_headers)

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -134,9 +134,15 @@ def status() -> list[dict]:
         if rec and not running:  # stale entry — agent died; clean it
             state.pop(ws["name"], None)
             dirty = True
+        port = ws.get("port")
         out.append({"name": ws["name"], "id": ws.get("id", ws["name"]),
-                    "port": ws.get("port"), "pid": rec.get("pid") if running else None,
-                    "running": running, "bundle": ws.get("bundle", "")})
+                    "port": port, "pid": rec.get("pid") if running else None,
+                    "running": running, "bundle": ws.get("bundle", ""),
+                    # Direct A2A endpoint — every agent is an independent endpoint on its
+                    # own port (ADR 0042), reachable regardless of console focus, so a
+                    # focused agent can `delegate_to` an unfocused sibling here. Live only
+                    # while running, but the address is stable.
+                    "a2a": f"http://127.0.0.1:{port}/a2a" if port else None})
     if dirty:
         _save_state(state)
     return out

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -14,19 +14,50 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from fastapi import Request  # module-level so the stringized `request: Request` annotation
+                             # on the proxy route resolves (function-local imports don't,
+                             # under `from __future__ import annotations`).
+
 log = logging.getLogger("protoagent.server")
 
 
 def register_fleet_routes(app) -> None:
     from fastapi import Body, HTTPException
 
-    from graph.fleet import supervisor
+    from graph.fleet import proxy, supervisor
     from graph.workspaces import manager
 
     @app.get("/api/fleet")
     async def _list_fleet():
         """Every workspace agent + live status (running/stopped, port, pid, bundle)."""
-        return {"agents": supervisor.status()}
+        return {"agents": supervisor.status(), "active": proxy.get_active()}
+
+    @app.get("/api/fleet/active")
+    async def _get_active():
+        """The agent the console proxy currently points at (None if unset/stopped)."""
+        return {"active": proxy.get_active()}
+
+    @app.post("/api/fleet/{name}/activate")
+    async def _activate(name: str):
+        """Point the console proxy at a running agent — the in-place switch."""
+        try:
+            return {"ok": True, **proxy.set_active(name)}
+        except supervisor.FleetError as exc:
+            raise HTTPException(400, str(exc))
+
+    @app.api_route("/active/{path:path}",
+                   methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+    async def _proxy(path: str, request: Request):
+        """Reverse-proxy the *console* to the active agent (chat → /active/api/chat,
+        SSE → /active/api/events). This is the human's lens only — switching re-points
+        it with no change to the caller's URL.
+
+        It does NOT gate agent↔agent A2A: every agent stays an independent endpoint on
+        its own port (``127.0.0.1:<port>/a2a``), reachable regardless of focus, so a
+        focused agent's ``delegate_to`` hits an unfocused sibling directly — the proxy
+        never sees that traffic.
+        """
+        return await proxy.forward(request, path)
 
     @app.post("/api/fleet")
     async def _create_agent(body: dict = Body(...)):

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -52,3 +52,17 @@ def test_create_list_start_stop_remove(client):
 
 def test_create_bad_name_is_400(client):
     assert client.post("/api/fleet", json={"name": "bad name"}).status_code == 400
+
+
+def test_activate_requires_running_and_proxy_409s(client):
+    r = client.post("/api/fleet", json={"name": "beta", "start": False})
+    assert r.status_code == 200 and not r.json()["agent"]["running"]
+    assert client.post("/api/fleet/beta/activate").status_code == 400  # not running
+    assert client.get("/active/whatever").status_code == 409           # nothing active
+
+
+def test_activate_running_sets_active(client):
+    client.post("/api/fleet", json={"name": "gamma", "port": 7891})  # create + (mocked) start
+    assert client.post("/api/fleet/gamma/activate").json()["active"] == "gamma"
+    assert client.get("/api/fleet/active").json()["active"] == "gamma"
+    assert client.get("/api/fleet").json()["active"] == "gamma"


### PR DESCRIPTION
Completes the fleet control plane — the **in-place switch**.

```
POST /api/fleet/{name}/activate   point the console proxy at a running agent
GET  /api/fleet/active            current focus
ANY  /active/<path>               reverse-proxy the console to the active agent
```

- `/active/*` streams (SSE-safe) to the focused agent; switching = one `activate` call, the caller's URL never changes. Active pointer persists; resolves only while the agent runs (409 if none active, 502 if it died).

### Two planes — kept separate (per @ review feedback in design)
The proxy is the **human's lens only**. Every agent stays an **independent A2A endpoint on its own port** (`127.0.0.1:<port>/a2a`), reachable **regardless of console focus** — so a focused agent's `delegate_to` hits an unfocused sibling **directly**, never through the proxy. `GET /api/fleet` now surfaces each agent's `a2a` address so siblings can discover each other.

### Verified end-to-end
Hub proxied `/active/.well-known/agent-card.json` → focused agent (200); the agent stayed **directly reachable** on its own port (200); `active` + `a2a` surfaced in `GET /api/fleet`.

### Tests
`test_fleet_routes.py`: activate-requires-running (400), proxy-409-when-none, activate-sets-active. Plus the slice-1/2a suites.

This unblocks the front-end switcher's *switch* action (the contract promised on #787). Remaining 0042: keep-alive policy (slice 5) + the desktop shell wiring (§H).

🤖 Generated with [Claude Code](https://claude.com/claude-code)