### PR TITLE
feat(theme): per-agent theme persistence — /api/theme (ADR 0042)

### DIFF
--- a/operator_api/theme_routes.py
+++ b/operator_api/theme_routes.py
@@ -1,0 +1,55 @@
+"""Per-agent theme persistence (ADR 0042 / fleet).
+
+Each agent (workspace) saves its **own** theme, so the in-place switch repaints the
+console to the focused agent's look — the theme is just another per-``PROTOAGENT_CONFIG_DIR``
+setting, and the proxy already routes ``/active/api/theme`` to the active agent.
+
+Storage is **opaque**: the front-end's ThemePanel owns the token schema (@protolabsai/ui);
+the server just persists the blob in ``<config_dir>/theme.json`` and hands it back. So new
+tokens/formats need no server change.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+log = logging.getLogger("protoagent.server")
+
+
+def _theme_path():
+    from graph.config_io import _live_config_dir
+    return _live_config_dir() / "theme.json"
+
+
+def register_theme_routes(app) -> None:
+    from fastapi import Body
+
+    @app.get("/api/theme")
+    async def _get_theme():
+        """This agent's saved theme, or ``null`` (front-end falls back to defaults)."""
+        f = _theme_path()
+        if not f.exists():
+            return {"theme": None}
+        try:
+            return {"theme": json.loads(f.read_text())}
+        except (json.JSONDecodeError, OSError):
+            log.warning("[theme] unreadable theme.json at %s", f)
+            return {"theme": None}
+
+    @app.put("/api/theme")
+    async def _put_theme(body: dict = Body(...)):
+        """Persist this agent's theme. Accepts ``{theme: {...}}`` or the raw blob."""
+        theme = body.get("theme", body)
+        f = _theme_path()
+        f.parent.mkdir(parents=True, exist_ok=True)
+        f.write_text(json.dumps(theme, indent=2) + "\n")
+        return {"ok": True}
+
+    @app.delete("/api/theme")
+    async def _reset_theme():
+        """Clear this agent's theme override (revert to defaults)."""
+        f = _theme_path()
+        if f.exists():
+            f.unlink()
+        return {"ok": True}

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -615,6 +615,11 @@ def _main():
     # /api/archetypes. The CLI + the desktop GUI panels both drive these.
     from operator_api.fleet_routes import register_fleet_routes
     register_fleet_routes(fastapi_app)
+
+    # Per-agent theme (ADR 0042) — each agent saves its own look; the switch repaints
+    # to the active agent's theme (proxied via /active/api/theme).
+    from operator_api.theme_routes import register_theme_routes
+    register_theme_routes(fastapi_app)
     register_mcp_routes(fastapi_app)
 
     # --- Telemetry (ADR 0006 Slice 2) --------------------------------------

--- a/tests/test_theme_routes.py
+++ b/tests/test_theme_routes.py
@@ -1,0 +1,33 @@
+"""Per-agent theme persistence (ADR 0042) — save/load/reset, scoped to the config dir."""
+
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.fixture
+def client(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path))
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+    from operator_api.theme_routes import register_theme_routes
+    app = FastAPI()
+    register_theme_routes(app)
+    return TestClient(app)
+
+
+def test_save_load_reset(client):
+    assert client.get("/api/theme").json()["theme"] is None  # none yet
+
+    theme = {"mode": "dark", "tokens": {"--accent": "#7c5cff", "--border": "rgba(0,0,0,0.08)"}}
+    assert client.put("/api/theme", json={"theme": theme}).json()["ok"]
+    assert client.get("/api/theme").json()["theme"] == theme   # round-trips verbatim
+
+    assert client.delete("/api/theme").json()["ok"]
+    assert client.get("/api/theme").json()["theme"] is None     # reset to defaults
+
+
+def test_accepts_raw_blob(client):
+    # a client that PUTs the blob directly (no {theme:…} wrapper) still persists
+    client.put("/api/theme", json={"mode": "light"})
+    assert client.get("/api/theme").json()["theme"] == {"mode": "light"}


### PR DESCRIPTION
Each agent (workspace) saves its **own** theme — so the fleet's in-place switch repaints the console to the focused agent's look **automatically** (the proxy already routes `/active/api/theme` to the active agent). A theme becomes just another per-`PROTOAGENT_CONFIG_DIR` setting.

```
GET    /api/theme    → {theme: <blob>|null}   this agent's saved theme
PUT    /api/theme    {theme:{...}} | <blob>   persist
DELETE /api/theme    → {ok}                    reset to defaults
```

- **Opaque storage** — the front-end's ThemePanel (@protolabsai/ui, the 28-token picker) owns the schema; the server just persists the blob in `<config_dir>/theme.json` and hands it back. New tokens/formats (oklch, rgba, …) need **no server change**.
- **Backend only** — stays out of the ThemePanel work. Front-end handoff: read on focus via `GET /active/api/theme` → apply; save via `PUT /active/api/theme`; re-fetch+repaint on agent switch.

Tests: save/load/reset round-trip + raw-blob acceptance (TestClient, config-dir-scoped).

Note: isolated new file + one `register_theme_routes` call in `server/__init__.py` (~line 621) — no overlap with the in-flight workflows-removal (different files/region).

🤖 Generated with [Claude Code](https://claude.com/claude-code)