### PR TITLE
feat(fleet): keep-N-warm policy + stop-entire-fleet (ADR 0042 slice 5)

### DIFF
--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -90,8 +90,9 @@ def start(name: str) -> dict:
     logf = open(log_path, "a")  # noqa: SIM115 — handed to the child; closed on its exit
     # start_new_session detaches it from this CLI's process group so it survives exit.
     proc = subprocess.Popen(argv, env=full_env, stdout=logf, stderr=logf, start_new_session=True)
+    now = datetime.now(timezone.utc).isoformat()
     rec = {"pid": proc.pid, "port": ws.get("port"), "id": ws.get("id", name),
-           "started_at": datetime.now(timezone.utc).isoformat(), "log": str(log_path)}
+           "started_at": now, "last_active": now, "log": str(log_path)}
     state[name] = rec
     _save_state(state)
     log.info("[fleet] started %s (pid %d, :%s)", name, proc.pid, rec["port"])
@@ -165,3 +166,51 @@ def down(names: list[str] | None = None) -> list[dict]:
         except FleetError:
             pass
     return out
+
+
+# ── Keep-N-warm policy (ADR 0042 §G) ──────────────────────────────────────────
+# Bound how many agents stay hot (a laptop won't run a big fleet). On a switch the
+# target is resumed and the least-recently-active agents beyond the cap are stopped —
+# their sessions persist (instance.id-scoped checkpoints) and resume on the next switch.
+
+def max_warm() -> int:
+    """Warm-agent cap from ``PROTOAGENT_FLEET_MAX_WARM`` (0/unset = unlimited)."""
+    try:
+        return max(0, int(os.environ.get("PROTOAGENT_FLEET_MAX_WARM", "0")))
+    except ValueError:
+        return 0
+
+
+def touch(name: str) -> None:
+    """Mark an agent as most-recently-active (drives LRU eviction)."""
+    name = manager._safe(name)
+    state = _load_state()
+    rec = state.get(name)
+    if rec:
+        rec["last_active"] = datetime.now(timezone.utc).isoformat()
+        _save_state(state)
+
+
+def enforce_warm_cap(keep: int | None = None, *, protect: str | None = None) -> list[str]:
+    """Stop the least-recently-active running agents beyond ``keep`` (default
+    ``max_warm()``). ``protect`` is never stopped. No-op when keep is 0/unlimited."""
+    keep = max_warm() if keep is None else keep
+    if keep <= 0:
+        return []
+    running = [(n, r) for n, r in _load_state().items() if _alive(r.get("pid"))]
+    if len(running) <= keep:
+        return []
+    # Oldest last_active first; the protected agent is never a candidate.
+    running.sort(key=lambda kv: kv[1].get("last_active", ""))
+    candidates = [n for n, _ in running if n != protect]
+    evicted: list[str] = []
+    for n in candidates[: len(running) - keep]:
+        try:
+            stop(n)
+            evicted.append(n)
+        except FleetError:
+            pass
+    if evicted:
+        log.info("[fleet] keep-%d-warm: evicted %s (sessions resume on next switch)",
+                 keep, ", ".join(evicted))
+    return evicted

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -39,10 +39,20 @@ def register_fleet_routes(app) -> None:
 
     @app.post("/api/fleet/{name}/activate")
     async def _activate(name: str):
-        """Point the console proxy at a running agent — the in-place switch."""
+        """Switch the console to an agent — the in-place switch.
+
+        Resumes the target if it was stopped (keep-N-warm), points the proxy at it,
+        marks it most-recently-active, then evicts the least-recently-used agents
+        beyond the warm cap (their sessions persist + resume on a later switch).
+        """
         try:
-            return {"ok": True, **proxy.set_active(name)}
-        except supervisor.FleetError as exc:
+            if not supervisor.is_running(name):
+                supervisor.start(name)  # resume a cold agent on switch (from checkpoint)
+            result = proxy.set_active(name)
+            supervisor.touch(name)
+            evicted = supervisor.enforce_warm_cap(protect=name)
+            return {"ok": True, **result, "evicted": evicted}
+        except (supervisor.FleetError, manager.WorkspaceError) as exc:
             raise HTTPException(400, str(exc))
 
     @app.api_route("/active/{path:path}",
@@ -94,6 +104,12 @@ def register_fleet_routes(app) -> None:
             return {"ok": True, **supervisor.stop(name)}
         except supervisor.FleetError as exc:
             raise HTTPException(400, str(exc))
+
+    @app.post("/api/fleet/down")
+    async def _stop_fleet():
+        """Shut down the **entire** fleet (every running agent). Mirrors the CLI's
+        ``fleet down`` with no args."""
+        return {"ok": True, "stopped": [r["name"] for r in supervisor.down()]}
 
     @app.delete("/api/fleet/{name}")
     async def _remove_agent(name: str, purge: bool = False):

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -54,11 +54,15 @@ def test_create_bad_name_is_400(client):
     assert client.post("/api/fleet", json={"name": "bad name"}).status_code == 400
 
 
-def test_activate_requires_running_and_proxy_409s(client):
-    r = client.post("/api/fleet", json={"name": "beta", "start": False})
-    assert r.status_code == 200 and not r.json()["agent"]["running"]
-    assert client.post("/api/fleet/beta/activate").status_code == 400  # not running
-    assert client.get("/active/whatever").status_code == 409           # nothing active
+def test_activate_unknown_400_and_proxy_409(client):
+    assert client.post("/api/fleet/ghost/activate").status_code == 400  # no such workspace
+    assert client.get("/active/whatever").status_code == 409            # nothing active
+
+
+def test_activate_autostarts_a_stopped_agent(client):
+    client.post("/api/fleet", json={"name": "delta", "start": False})  # created, not running
+    r = client.post("/api/fleet/delta/activate")                       # switch → resume + activate
+    assert r.status_code == 200 and r.json()["active"] == "delta"
 
 
 def test_activate_running_sets_active(client):
@@ -66,3 +70,10 @@ def test_activate_running_sets_active(client):
     assert client.post("/api/fleet/gamma/activate").json()["active"] == "gamma"
     assert client.get("/api/fleet/active").json()["active"] == "gamma"
     assert client.get("/api/fleet").json()["active"] == "gamma"
+
+
+def test_stop_entire_fleet(client):
+    client.post("/api/fleet", json={"name": "x", "port": 7895})
+    client.post("/api/fleet", json={"name": "y", "port": 7896})
+    assert client.post("/api/fleet/down").json()["ok"]
+    assert all(not a["running"] for a in client.get("/api/fleet").json()["agents"])

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -54,3 +54,29 @@ def test_stop_not_running_errors(fleet):
     manager.create("beta")
     with pytest.raises(supervisor.FleetError):
         supervisor.stop("beta")  # never started
+
+
+def test_keep_n_warm_evicts_lru(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    alive: set[int] = set()
+    seq = {"n": 5000}
+    monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
+
+    class FakeProc:
+        def __init__(self, *a, **k):
+            seq["n"] += 1
+            self.pid = seq["n"]
+            alive.add(self.pid)
+
+    monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
+    monkeypatch.setattr(supervisor.os, "kill", lambda pid, sig: alive.discard(int(pid)))
+
+    for nm in ("a", "b", "c"):           # a started first → least-recently-active
+        manager.create(nm)
+        supervisor.start(nm)
+
+    evicted = supervisor.enforce_warm_cap(keep=2, protect="c")
+    assert evicted == ["a"]              # LRU evicted, protected one kept
+    assert not supervisor.is_running("a")
+    assert supervisor.is_running("b") and supervisor.is_running("c")
+    assert supervisor.enforce_warm_cap(keep=0) == []   # 0 = unlimited, no-op


### PR DESCRIPTION
Final core slice of the fleet supervisor.

## Keep-N-warm (ADR 0042 §G)
A laptop won't run a big fleet hot. `PROTOAGENT_FLEET_MAX_WARM` caps the warm set (0/unset = unlimited). On a **switch**, `activate` now:
1. **resumes** the target if it was stopped (from its `instance.id`-scoped checkpoints),
2. points the proxy at it + marks it most-recently-active,
3. **evicts the least-recently-used** agents beyond the cap — their sessions persist and resume on a later switch (never evicts the active one).

So over a session only the N most-recently-used agents stay hot; the rest cycle down and resume on demand. History is never lost (scoped checkpoints).

## Stop the entire fleet
`POST /api/fleet/down` → `{ok, stopped:[names]}` — the API counterpart to the CLI's `fleet down` (no args). For a console **"Shut down all"** button.

## Behavior change
Switching to a **stopped** agent now **auto-resumes** it (previously 400). `400` is now reserved for an *unknown* workspace. Front-end switcher: a click on any agent "just works" (warm = instant, cold = resumes).

## Tests
LRU eviction (protect the active, evict oldest, 0 = unlimited), auto-resume on activate, stop-entire-fleet, + updated activate tests.

This completes ADR 0042's core (slices 1–5). Remaining is the desktop shell wiring (§H, Tauri/Rust).

🤖 Generated with [Claude Code](https://claude.com/claude-code)