### PR TITLE
feat(console): fleet console — slug-routed agents, manager, per-agent everything (ADR 0042)

### DIFF
--- a/a2a_auth.py
+++ b/a2a_auth.py
@@ -39,14 +39,16 @@ _ALLOWED_ORIGINS: list[list[str] | None] = [None]
 # console + OpenAI-compat APIs (which drive subagents, rewrite config/SOUL,
 # schedule jobs, and run turns). The agent card, /healthz, /metrics, and the
 # static console assets live OUTSIDE these prefixes and stay public.
-_GUARDED_PREFIXES = ("/a2a", "/api/", "/v1/")
+# /active/* is the fleet hub's reverse proxy to the focused agent (ADR 0042). It must
+# be guarded too — it drives the agent's full API (chat, config, subagents/run, …), and
+# spawned peers carry no token of their own, so the hub is the only gate.
+_GUARDED_PREFIXES = ("/a2a", "/api/", "/v1/", "/active/")
 
-# Exempt from the guard: the read-only Server-Sent-Events stream. Browsers'
-# EventSource cannot set an Authorization header, so a bearer can't be presented
-# here — and it only exposes activity/inbox events, not any action. The
-# agent-driving endpoints (/api/subagents/run, /api/config, /api/chat, /a2a, …)
-# stay guarded.
-_GUARD_EXEMPT = ("/api/events",)
+# Exempt from the guard: the read-only Server-Sent-Events stream (direct + proxied).
+# Browsers' EventSource cannot set an Authorization header, so a bearer can't be presented
+# here — and it only exposes activity/inbox events, not any action. The agent-driving
+# endpoints (/api/subagents/run, /api/config, /api/chat, /a2a, /active/* …) stay guarded.
+_GUARD_EXEMPT = ("/api/events", "/active/api/events")
 
 
 def set_bearer_token(token: str | None) -> None:

--- a/a2a_auth.py
+++ b/a2a_auth.py
@@ -39,16 +39,20 @@ _ALLOWED_ORIGINS: list[list[str] | None] = [None]
 # console + OpenAI-compat APIs (which drive subagents, rewrite config/SOUL,
 # schedule jobs, and run turns). The agent card, /healthz, /metrics, and the
 # static console assets live OUTSIDE these prefixes and stay public.
-# /active/* is the fleet hub's reverse proxy to the focused agent (ADR 0042). It must
-# be guarded too — it drives the agent's full API (chat, config, subagents/run, …), and
-# spawned peers carry no token of their own, so the hub is the only gate.
-_GUARDED_PREFIXES = ("/a2a", "/api/", "/v1/", "/active/")
+# /active/* and /agents/<slug>/* are the fleet hub's reverse proxies to an agent (ADR 0042).
+# They must be guarded too — they drive the agent's full API (chat, config, subagents/run, …),
+# and spawned peers carry no token of their own, so the hub is the only gate.
+_GUARDED_PREFIXES = ("/a2a", "/api/", "/v1/", "/active/", "/agents/")
 
-# Exempt from the guard: the read-only Server-Sent-Events stream (direct + proxied).
-# Browsers' EventSource cannot set an Authorization header, so a bearer can't be presented
-# here — and it only exposes activity/inbox events, not any action. The agent-driving
-# endpoints (/api/subagents/run, /api/config, /api/chat, /a2a, /active/* …) stay guarded.
-_GUARD_EXEMPT = ("/api/events", "/active/api/events")
+# Exempt from the guard: the read-only Server-Sent-Events stream (direct + proxied under any
+# slug). Browsers' EventSource cannot set an Authorization header, so a bearer can't be presented
+# here — and it only exposes activity/inbox events, not any action. The proxied path carries a
+# slug (/agents/<slug>/api/events), so match the SSE suffix rather than a fixed prefix.
+_GUARD_EXEMPT = ("/api/events",)
+
+
+def _is_exempt(path: str) -> bool:
+    return path.endswith("/api/events") or any(path.startswith(p) for p in _GUARD_EXEMPT)
 
 
 def set_bearer_token(token: str | None) -> None:
@@ -99,7 +103,7 @@ class A2AAuthMiddleware(BaseHTTPMiddleware):
         path = request.url.path
         if not any(path.startswith(p) for p in _GUARDED_PREFIXES):
             return await call_next(request)
-        if any(path.startswith(p) for p in _GUARD_EXEMPT):
+        if _is_exempt(path):
             return await call_next(request)
 
         # X-API-Key (legacy) — enforced only when configured.

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -89,6 +89,22 @@ export const INBOX_ITEMS = {
   ],
 };
 
+// Fleet (ADR 0042) — mutable so create/start/stop/remove round-trip in e2e. The host (this
+// instance) self-registers (host:true); `active: null` = the host is focused.
+export const FLEET = {
+  agents: [
+    { name: "main", id: "main", port: 7871, pid: 3000, running: true, bundle: "", host: true },
+    { name: "ava", id: "ava", port: 7890, pid: 4001, running: true, bundle: "" },
+    { name: "roxy", id: "roxy", port: 7891, pid: null, running: false, bundle: "pm-stack" },
+  ],
+  active: null,
+};
+
+export const ARCHETYPES = [
+  { id: "basic", label: "Basic", icon: "Sparkles", blurb: "A plain agent — add tools later.", bundle: null },
+  { id: "pm-stack", label: "Project Manager", icon: "LayoutGrid", blurb: "PM tools + board.", bundle: "https://github.com/x/pm-stack" },
+];
+
 export const WORKFLOWS = [
   {
     name: "research-and-brief",

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -47,7 +47,7 @@ test("stop a running agent flips its status dot", async ({ page }) => {
   }
 });
 
-test("topbar switcher activates an agent in place", async ({ page }) => {
+test("topbar switcher navigates to an agent by slug", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   const trigger = page.getByTestId("fleet-switcher");
   await expect(trigger).toBeVisible(); // present because the mock fleet has agents
@@ -55,5 +55,8 @@ test("topbar switcher activates an agent in place", async ({ page }) => {
   const roxy = page.getByRole("menuitem", { name: /roxy/ });
   await expect(roxy).toBeVisible();
   await roxy.click();
-  await expect(trigger).toContainText("roxy"); // active flipped → trigger repaints
+  // Slug routing (ADR 0042): picking an agent navigates to its own URL — each window is its
+  // own agent. After the nav, the console is focused on roxy.
+  await expect(page).toHaveURL(/\/app\/agent\/roxy\//);
+  await expect(page.getByTestId("fleet-switcher")).toContainText("roxy");
 });

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -1,0 +1,59 @@
+import { expect, test } from "@playwright/test";
+
+// Fleet manager + archetype picker (Settings → Agents, ADR 0042). Drives the live
+// control-plane endpoints (mocked): list, create from an archetype, stop. The mock
+// FLEET is shared module state, so run serially + assert by presence (not exact counts).
+
+test.describe.configure({ mode: "serial" });
+
+async function openAgents(page) {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Agents", exact: true }).click();
+}
+
+test("Agents tab lists the host (this instance) + peers, host active by default", async ({ page }) => {
+  await openAgents(page);
+  await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible();
+  // The host self-registers — it's always present + marked "this instance", and focused
+  // (active) when no peer is — so the panel is never "0 agents".
+  await expect(page.locator(".fleet-host-tag").first()).toBeVisible();
+  await expect(page.locator(".fleet-row.active .fleet-name")).toContainText("main");
+  await expect(page.locator(".fleet-row", { hasText: "ava" })).toBeVisible();
+  await expect(page.locator(".fleet-row", { hasText: "roxy" })).toBeVisible();
+  // The host row has no stop/remove (can't act on itself); peers do.
+  await expect(page.locator(".fleet-row", { hasText: "main" }).getByRole("button")).toHaveCount(0);
+});
+
+test("New agent → archetype picker → create returns to the list", async ({ page }) => {
+  await openAgents(page);
+  await page.getByRole("button", { name: "New agent" }).click();
+  await expect(page.getByRole("heading", { name: "New agent" })).toBeVisible();
+  await expect(page.locator(".archetype-card")).toHaveCount(2); // from GET /api/archetypes
+  await page.locator(".archetype-card", { hasText: "Project Manager" }).click();
+  await page.getByLabel("Agent name").fill("newbot");
+  await page.getByRole("button", { name: /Create/ }).click();
+  await expect(page.locator(".fleet-row", { hasText: "newbot" })).toBeVisible();
+});
+
+test("stop a running agent flips its status dot", async ({ page }) => {
+  await openAgents(page);
+  const ava = page.locator(".fleet-row", { hasText: "ava" });
+  // ava starts running; if a prior test already stopped it, the Start button is shown instead.
+  const stop = ava.getByRole("button", { name: "Stop" });
+  if (await stop.count()) {
+    await stop.click();
+    await expect(ava.locator(".fleet-dot.stopped")).toBeVisible();
+  }
+});
+
+test("topbar switcher activates an agent in place", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const trigger = page.getByTestId("fleet-switcher");
+  await expect(trigger).toBeVisible(); // present because the mock fleet has agents
+  await trigger.click();
+  const roxy = page.getByRole("menuitem", { name: /roxy/ });
+  await expect(roxy).toBeVisible();
+  await roxy.click();
+  await expect(trigger).toContainText("roxy"); // active flipped → trigger repaints
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -15,9 +15,11 @@ import { fileURLToPath } from "node:url";
 
 import {
   ACTIVITY_HISTORY,
+  ARCHETYPES,
   buildFrames,
   DELEGATES,
   DELEGATE_TYPES,
+  FLEET,
   GOALS,
   INBOX_ITEMS,
   NOTES_WORKSPACE,
@@ -127,6 +129,14 @@ function handleApiGet(pathname) {
       return { plugins: INSTALLED_PLUGINS };
     case "/api/plugins/workflows/list":
       return { workflows: WORKFLOWS };
+    case "/api/theme":
+      return { theme: null }; // per-agent theme (ADR 0042); null → DS defaults
+    case "/api/fleet":
+      return { agents: FLEET.agents, active: FLEET.active };
+    case "/api/fleet/active":
+      return { active: FLEET.active };
+    case "/api/archetypes":
+      return { archetypes: ARCHETYPES };
     case "/api/activity":
       return ACTIVITY_HISTORY;
     case "/api/inbox":
@@ -207,7 +217,9 @@ async function serveStatic(pathname, res) {
 
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
-  const { pathname } = url;
+  // Fleet proxy (ADR 0042): /active/<path> is the hub re-proxying the console to the active
+  // agent. The mock just strips the prefix and serves the same handlers (one agent here).
+  const pathname = url.pathname.startsWith("/active/") ? url.pathname.slice("/active".length) : url.pathname;
 
   if (pathname === "/a2a" && req.method === "POST") {
     const body = await readBody(req);
@@ -277,6 +289,35 @@ const server = createServer(async (req, res) => {
     }
     if (req.method === "DELETE" && /^\/api\/plugins\/workflows\/[^/]+$/.test(pathname)) {
       return sendJson(res, { deleted: true });
+    }
+    // Fleet (ADR 0042) — mutate the in-memory FLEET so create/start/stop/activate/remove round-trip.
+    if (pathname === "/api/fleet" && req.method === "POST") {
+      const name = String(body.name || "").trim();
+      if (!/^[A-Za-z0-9-_]+$/.test(name)) return sendJson(res, { detail: "invalid name" }, 400);
+      const agent = { name, id: name, port: 7899, pid: 5000, running: true, bundle: body.bundle || "" };
+      FLEET.agents.push(agent);
+      return sendJson(res, { ok: true, agent, installed: [] });
+    }
+    if (pathname === "/api/fleet/down" && req.method === "POST") {
+      FLEET.agents.forEach((a) => { a.running = false; a.pid = null; });
+      return sendJson(res, { ok: true, stopped: FLEET.agents.map((a) => a.name) });
+    }
+    {
+      const m = pathname.match(/^\/api\/fleet\/([^/]+)\/(start|stop|activate)$/);
+      if (m && req.method === "POST") {
+        const a = FLEET.agents.find((x) => x.name === m[1]);
+        if (!a) return sendJson(res, { detail: "no such agent" }, 400);
+        if (m[2] === "start") { a.running = true; a.pid = 5001; return sendJson(res, { ok: true, agent: a }); }
+        if (m[2] === "stop") { a.running = false; a.pid = null; return sendJson(res, { ok: true, name: a.name, stopped: true }); }
+        // activate: host → clear (focus host); peer → set active.
+        if (a.host) { FLEET.active = null; return sendJson(res, { ok: true, active: null, evicted: [] }); }
+        FLEET.active = a.name; a.running = true; return sendJson(res, { ok: true, active: a.name, evicted: [] });
+      }
+    }
+    if (req.method === "DELETE" && /^\/api\/fleet\/[^/]+$/.test(pathname)) {
+      const name = decodeURIComponent(pathname.split("/").pop());
+      FLEET.agents = FLEET.agents.filter((a) => a.name !== name);
+      return sendJson(res, { ok: true, name, removed: [name] });
     }
     if (req.method === "DELETE" && /^\/api\/playbooks\/\d+$/.test(pathname)) {
       return sendJson(res, { enabled: true, deleted: true });

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -217,9 +217,9 @@ async function serveStatic(pathname, res) {
 
 const server = createServer(async (req, res) => {
   const url = new URL(req.url, `http://localhost:${PORT}`);
-  // Fleet proxy (ADR 0042): /active/<path> is the hub re-proxying the console to the active
-  // agent. The mock just strips the prefix and serves the same handlers (one agent here).
-  const pathname = url.pathname.startsWith("/active/") ? url.pathname.slice("/active".length) : url.pathname;
+  // Fleet slug proxy (ADR 0042): /agents/<slug>/<path> is the hub re-proxying the console to a
+  // specific agent. The mock strips the /agents/<slug> prefix and serves the same handlers.
+  const pathname = url.pathname.replace(/^\/agents\/[^/]+/, "") || url.pathname;
 
   if (pathname === "/a2a" && req.method === "POST") {
     const body = await readBody(req);

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -18,6 +18,8 @@ test("central Settings is just the cross-cutting tabs", async ({ page }) => {
   await openSettings(page);
   expect(await page.locator(".pl-tabs button").allTextContents()).toEqual([
     "Overview",
+    "Agents",
+    "Theme",
     "Telemetry",
     "Plugins",
     "System",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.0",
-    "@protolabsai/ui": "^0.15.0",
+    "@protolabsai/ui": "^0.17.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -72,6 +72,7 @@ import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { SettingsSurface, SETTINGS_TABS, type SettingsTab } from "../settings/SettingsSurface";
+import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
   type ActivityTab,
@@ -87,6 +88,7 @@ import { PluginView } from "./PluginView";
 import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
 import { Logo } from "@protolabsai/ui/primitives";
 import { useIsMobile } from "../lib/useIsMobile";
+import { useActiveTheme } from "../lib/useActiveTheme";
 import { registeredSurfaces } from "../ext"; // build-time fork seam (ADR 0038 D3); also self-loads fork surfaces
 import { ContextMenuRenderer, openContextMenu } from "../contextMenu";
 import { Tabs } from "@protolabsai/ui/navigation";
@@ -238,6 +240,7 @@ export function App() {
   const railOrder = useUI((s) => s.railOrder);
   const reconcilePluginViews = useUI((s) => s.reconcilePluginViews);
   const isMobile = useIsMobile();
+  useActiveTheme(); // apply the focused agent's saved theme on boot + repaint on switch (ADR 0042)
   const mobileActive = useUI((s) => s.mobileActive);
   const setMobileActive = useUI((s) => s.setMobileActive);
   const quickBar = useUI((s) => s.quickBar);
@@ -631,7 +634,15 @@ export function App() {
       <Header
         dragRegion
         logo={<Logo src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`} alt="" size={22} />}
-        name={brandName(runtime?.identity?.name)}
+        name={
+          <FleetSwitcher
+            fallbackName={brandName(runtime?.identity?.name)}
+            onNewAgent={() => {
+              setSurface("settings");
+              setSettingsTab("agents");
+            }}
+          />
+        }
         org={runtime?.identity?.org || "protoLabs.studio"}
         status={
           <button

--- a/apps/web/src/app/FleetSwitcher.tsx
+++ b/apps/web/src/app/FleetSwitcher.tsx
@@ -1,0 +1,116 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Check, ChevronDown, Plus } from "lucide-react";
+import { useEffect, useRef, useState, type ReactNode } from "react";
+
+import { api, setActivePrefix } from "../lib/api";
+import { queryKeys } from "../lib/queries";
+import { setLayoutAgent, useUI } from "../state/uiStore";
+
+// Topbar agent switcher (ADR 0042). The agent name becomes a dropdown of the fleet;
+// picking one POSTs /activate and flips the console's API base to /active/* so the whole
+// console reads/writes the focused agent (the in-place switch). In single-agent mode (no
+// hub → /api/fleet errors) it falls back to the plain name with no dropdown.
+export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: ReactNode; onNewAgent?: () => void }) {
+  const qc = useQueryClient();
+  // Own observer: no poll (the Agents panel polls); retry off so single-agent fails fast to the fallback.
+  const fleet = useQuery({ queryKey: queryKeys.fleet, queryFn: () => api.fleet(), retry: false, staleTime: 5_000 });
+  const [open, setOpen] = useState(false);
+  const ref = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    const onDoc = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
+    };
+    document.addEventListener("mousedown", onDoc);
+    return () => document.removeEventListener("mousedown", onDoc);
+  }, [open]);
+
+  const agents = fleet.data?.agents ?? [];
+  const active = fleet.data?.active ?? null;
+
+  // Each agent keeps its own layout (rail order/widths/plugins). Namespace the persisted
+  // key by the focused agent; on a real *switch* reload from the new agent's key. The first
+  // observation only syncs the key — the store already hydrated from it at module load
+  // (setLayoutAgent reads localStorage synchronously), so rehydrating there would reset it.
+  const prevAgent = useRef<string | null>(null);
+  useEffect(() => {
+    const a = active ?? "";
+    if (prevAgent.current === null) {
+      prevAgent.current = a;
+      setLayoutAgent(a);
+      return;
+    }
+    if (prevAgent.current !== a) {
+      prevAgent.current = a;
+      setLayoutAgent(a);
+      void useUI.persist.rehydrate(); // a switch → load the new agent's saved layout
+    }
+  }, [active]);
+
+  const host = agents.find((a) => a.host);
+  const isActive = (a: { name: string; host?: boolean }) => a.name === active || (!!a.host && active === null);
+
+  const activate = useMutation({
+    mutationFn: (a: { name: string; host?: boolean }) => api.activateAgent(a.name),
+    onSuccess: (_res, a) => {
+      // Host → talk to /api directly (proxy cleared); peer → route through /active.
+      setActivePrefix(a.host ? "" : "/active");
+      setOpen(false);
+      qc.invalidateQueries();
+    },
+  });
+
+  // Solo (just the host) or no hub → plain name, no switcher. It only appears once there's
+  // a real fleet (host + at least one peer).
+  if (fleet.isError || agents.length <= 1) return <>{fallbackName}</>;
+
+  return (
+    <div className="fleet-switcher" ref={ref}>
+      <button
+        type="button"
+        className="fleet-switcher-trigger"
+        onClick={() => setOpen((o) => !o)}
+        aria-haspopup="menu"
+        aria-expanded={open}
+        data-testid="fleet-switcher"
+      >
+        <span>{active ?? host?.name ?? fallbackName}</span>
+        <ChevronDown size={14} />
+      </button>
+      {open ? (
+        <div className="fleet-switcher-menu" role="menu">
+          {agents.map((a) => (
+            <button
+              key={a.name}
+              type="button"
+              role="menuitem"
+              className={`fleet-switcher-item${isActive(a) ? " active" : ""}`}
+              disabled={activate.isPending}
+              onClick={() => activate.mutate(a)}
+            >
+              <span className={`fleet-dot ${a.running ? "running" : "stopped"}`} aria-hidden />
+              <span className="fleet-switcher-name">
+                {a.name}
+                {a.host ? <span className="fleet-host-tag">this instance</span> : null}
+              </span>
+              {isActive(a) ? <Check size={14} /> : null}
+            </button>
+          ))}
+          <div className="fleet-switcher-sep" />
+          <button
+            type="button"
+            role="menuitem"
+            className="fleet-switcher-item"
+            onClick={() => {
+              setOpen(false);
+              onNewAgent?.();
+            }}
+          >
+            <Plus size={14} /> New agent
+          </button>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/src/app/FleetSwitcher.tsx
+++ b/apps/web/src/app/FleetSwitcher.tsx
@@ -1,21 +1,20 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Check, ChevronDown, Plus } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import { Check, ChevronDown, ExternalLink, Plus } from "lucide-react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 
-import { api, setActivePrefix } from "../lib/api";
-import { reopenEvents } from "../lib/events";
+import { agentHref, api, currentSlug } from "../lib/api";
 import { queryKeys } from "../lib/queries";
-import { setLayoutAgent, useUI } from "../state/uiStore";
 
-// Topbar agent switcher (ADR 0042). The agent name becomes a dropdown of the fleet;
-// picking one POSTs /activate and flips the console's API base to /active/* so the whole
-// console reads/writes the focused agent (the in-place switch). In single-agent mode (no
-// hub → /api/fleet errors) it falls back to the plain name with no dropdown.
+// The URL slug is the agent's STABLE id, never its (editable) display name — renaming an agent
+// must not change its URL/bookmarks. `host` is the reserved slug for this instance.
+const slugOf = (a: { id: string; host?: boolean }) => (a.host ? "host" : a.id);
+
+// Topbar agent switcher (ADR 0042 slug routing). The focused agent lives in the URL
+// (/app/agent/<slug>/), so picking one NAVIGATES there — each window is its own agent, a reload
+// can't desync, and you can open a second agent in a new window. Single-agent (just the host) →
+// plain name, no dropdown.
 export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: ReactNode; onNewAgent?: () => void }) {
-  const qc = useQueryClient();
-  // Poll the fleet so the topbar reflects it live — a newly-added agent makes the switcher
-  // appear without needing the Agents panel open (it was relying on that panel's poll before,
-  // so adding an agent from elsewhere left the switcher stale at 1 → no dropdown).
+  // Poll so the topbar reflects the fleet live (a newly-added agent makes the switcher appear).
   const fleet = useQuery({ queryKey: queryKeys.fleet, queryFn: () => api.fleet(), retry: false, refetchInterval: 3_000 });
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
@@ -30,54 +29,10 @@ export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: Reac
   }, [open]);
 
   const agents = fleet.data?.agents ?? [];
-  const active = fleet.data?.active ?? null;
+  const slug = currentSlug(); // the agent THIS window is on
+  const current = agents.find((a) => slugOf(a) === slug);
 
-  // Each agent keeps its own layout (rail order/widths/plugins). Namespace the persisted
-  // key by the focused agent; on a real *switch* reload from the new agent's key. The first
-  // observation only syncs the key — the store already hydrated from it at module load
-  // (setLayoutAgent reads localStorage synchronously), so rehydrating there would reset it.
-  const prevAgent = useRef<string | null>(null);
-  useEffect(() => {
-    const a = active ?? "";
-    if (prevAgent.current === null) {
-      prevAgent.current = a;
-      setLayoutAgent(a);
-      // #4 — on boot/reload, sync the client to the SERVER's fleet-active: the active prefix is
-      // in-memory (lost on reload), so without this the console would talk to /api (host) while
-      // the server reports a peer active — switcher checkmark, layout, and data source all
-      // disagree. Seed the prefix + re-point the SSE to match.
-      if (active) {
-        setActivePrefix("/active");
-        reopenEvents();
-      }
-      return;
-    }
-    if (prevAgent.current !== a) {
-      prevAgent.current = a;
-      setLayoutAgent(a);
-      void useUI.persist.rehydrate(); // a switch → load the new agent's saved layout
-    }
-  }, [active]);
-
-  const host = agents.find((a) => a.host);
-  const isActive = (a: { name: string; host?: boolean }) => a.name === active || (!!a.host && active === null);
-
-  const activate = useMutation({
-    mutationFn: (a: { name: string; host?: boolean }) => api.activateAgent(a.name),
-    onSuccess: (_res, a) => {
-      // Host → talk to /api directly (proxy cleared); peer → route through /active. Set the
-      // prefix BEFORE invalidating so refetches hit the focused agent (#2/#4).
-      setActivePrefix(a.host ? "" : "/active");
-      reopenEvents(); // #3 — re-point the SSE stream at the focused agent
-      setOpen(false);
-      // The whole console now reads the focused agent, so a full invalidate is intentional;
-      // the eviction freeze it used to stack on is gone (#6 moves stop() off the loop).
-      qc.invalidateQueries();
-    },
-  });
-
-  // Solo (just the host) or no hub → plain name, no switcher. It only appears once there's
-  // a real fleet (host + at least one peer).
+  // Solo (just the host) or no hub → plain name, no switcher.
   if (fleet.isError || agents.length <= 1) return <>{fallbackName}</>;
 
   return (
@@ -90,28 +45,49 @@ export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: Reac
         aria-expanded={open}
         data-testid="fleet-switcher"
       >
-        <span>{active ?? host?.name ?? fallbackName}</span>
+        <span>{current?.name ?? fallbackName}</span>
         <ChevronDown size={14} />
       </button>
       {open ? (
         <div className="fleet-switcher-menu" role="menu">
-          {agents.map((a) => (
-            <button
-              key={a.name}
-              type="button"
-              role="menuitem"
-              className={`fleet-switcher-item${isActive(a) ? " active" : ""}`}
-              disabled={activate.isPending}
-              onClick={() => activate.mutate(a)}
-            >
-              <span className={`fleet-dot ${a.running ? "running" : "stopped"}`} aria-hidden />
-              <span className="fleet-switcher-name">
-                {a.name}
-                {a.host ? <span className="fleet-host-tag">this instance</span> : null}
-              </span>
-              {isActive(a) ? <Check size={14} /> : null}
-            </button>
-          ))}
+          {agents.map((a) => {
+            const isCurrent = slugOf(a) === slug;
+            return (
+              <button
+                key={a.name}
+                type="button"
+                role="menuitem"
+                className={`fleet-switcher-item${isCurrent ? " active" : ""}`}
+                onClick={() => {
+                  if (!isCurrent) window.location.href = agentHref(slugOf(a)); // navigate → this agent
+                }}
+              >
+                <span className={`fleet-dot ${a.running ? "running" : "stopped"}`} aria-hidden />
+                <span className="fleet-switcher-name">
+                  {a.name}
+                  {a.host ? <span className="fleet-host-tag">this instance</span> : null}
+                </span>
+                {isCurrent ? (
+                  <Check size={14} />
+                ) : (
+                  // Open this agent in a second window (two agents at once — the whole point of
+                  // slug routing). A span, not a nested button, to keep the markup valid.
+                  <span
+                    className="fleet-switcher-newwin"
+                    role="button"
+                    tabIndex={0}
+                    title="Open in a new window"
+                    onClick={(e) => {
+                      e.stopPropagation();
+                      window.open(agentHref(slugOf(a)), "_blank", "noopener");
+                    }}
+                  >
+                    <ExternalLink size={13} />
+                  </span>
+                )}
+              </button>
+            );
+          })}
           <div className="fleet-switcher-sep" />
           <button
             type="button"

--- a/apps/web/src/app/FleetSwitcher.tsx
+++ b/apps/web/src/app/FleetSwitcher.tsx
@@ -13,8 +13,10 @@ import { setLayoutAgent, useUI } from "../state/uiStore";
 // hub → /api/fleet errors) it falls back to the plain name with no dropdown.
 export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: ReactNode; onNewAgent?: () => void }) {
   const qc = useQueryClient();
-  // Own observer: no poll (the Agents panel polls); retry off so single-agent fails fast to the fallback.
-  const fleet = useQuery({ queryKey: queryKeys.fleet, queryFn: () => api.fleet(), retry: false, staleTime: 5_000 });
+  // Poll the fleet so the topbar reflects it live — a newly-added agent makes the switcher
+  // appear without needing the Agents panel open (it was relying on that panel's poll before,
+  // so adding an agent from elsewhere left the switcher stale at 1 → no dropdown).
+  const fleet = useQuery({ queryKey: queryKeys.fleet, queryFn: () => api.fleet(), retry: false, refetchInterval: 3_000 });
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
 

--- a/apps/web/src/app/FleetSwitcher.tsx
+++ b/apps/web/src/app/FleetSwitcher.tsx
@@ -3,6 +3,7 @@ import { Check, ChevronDown, Plus } from "lucide-react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 
 import { api, setActivePrefix } from "../lib/api";
+import { reopenEvents } from "../lib/events";
 import { queryKeys } from "../lib/queries";
 import { setLayoutAgent, useUI } from "../state/uiStore";
 
@@ -39,6 +40,14 @@ export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: Reac
     if (prevAgent.current === null) {
       prevAgent.current = a;
       setLayoutAgent(a);
+      // #4 — on boot/reload, sync the client to the SERVER's fleet-active: the active prefix is
+      // in-memory (lost on reload), so without this the console would talk to /api (host) while
+      // the server reports a peer active — switcher checkmark, layout, and data source all
+      // disagree. Seed the prefix + re-point the SSE to match.
+      if (active) {
+        setActivePrefix("/active");
+        reopenEvents();
+      }
       return;
     }
     if (prevAgent.current !== a) {
@@ -54,9 +63,13 @@ export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: Reac
   const activate = useMutation({
     mutationFn: (a: { name: string; host?: boolean }) => api.activateAgent(a.name),
     onSuccess: (_res, a) => {
-      // Host → talk to /api directly (proxy cleared); peer → route through /active.
+      // Host → talk to /api directly (proxy cleared); peer → route through /active. Set the
+      // prefix BEFORE invalidating so refetches hit the focused agent (#2/#4).
       setActivePrefix(a.host ? "" : "/active");
+      reopenEvents(); // #3 — re-point the SSE stream at the focused agent
       setOpen(false);
+      // The whole console now reads the focused agent, so a full invalidate is intentional;
+      // the eviction freeze it used to stack on is gone (#6 moves stop() off the loop).
       qc.invalidateQueries();
     },
   });

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -103,6 +103,24 @@ export function PluginView({ view }: { view: PluginViewType }) {
     };
   }, [src, pluginId]);
 
+  // Live theme updates — re-post the current tokens to the iframe whenever the console theme
+  // changes (a live edit, a save, or an agent switch). The page handles `protoagent:theme`
+  // the same way it handles the initial `protoagent:init.theme`.
+  useEffect(() => {
+    const repost = () => {
+      const win = frameRef.current?.contentWindow;
+      if (!win) return;
+      try {
+        const origin = new URL(apiUrl(src), window.location.href).origin;
+        win.postMessage({ type: "protoagent:theme", theme: consoleTheme() }, origin);
+      } catch {
+        /* cross-origin / detached — best effort */
+      }
+    };
+    window.addEventListener("protoagent:theme", repost);
+    return () => window.removeEventListener("protoagent:theme", repost);
+  }, [src]);
+
   function handleLoad(e: React.SyntheticEvent<HTMLIFrameElement>) {
     setLoaded(true);
     const win = e.currentTarget.contentWindow;

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3276,3 +3276,223 @@ textarea {
 .mobile-drawer-list button:hover {
   background: var(--pl-color-bg-hover, rgba(255, 255, 255, 0.06));
 }
+
+/* Fleet manager + archetype picker (Settings → Agents, ADR 0042) */
+.fleet-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.fleet-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 4px;
+  border-bottom: 1px solid var(--border);
+}
+.fleet-row.active {
+  background: var(--bg-hover);
+}
+.fleet-dot {
+  flex: 0 0 auto;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: var(--fg-muted);
+}
+.fleet-dot.running {
+  background: #34d399;
+  box-shadow: 0 0 6px rgba(52, 211, 153, 0.5);
+}
+.fleet-dot.stopped {
+  opacity: 0.45;
+}
+.fleet-row-main {
+  flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.fleet-name {
+  font-weight: 600;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.fleet-active-tag {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--accent);
+  border: 1px solid var(--accent);
+  border-radius: 4px;
+  padding: 0 5px;
+}
+.fleet-meta {
+  font-size: 12px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+}
+.fleet-row-actions {
+  flex: 0 0 auto;
+  display: flex;
+  gap: 4px;
+}
+.fleet-empty,
+.fleet-section-label {
+  color: var(--fg-muted);
+}
+.fleet-section-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 4px 0 8px;
+}
+.fleet-error {
+  color: #f87171;
+  margin-bottom: 10px;
+}
+.fleet-purge {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 10px;
+  font-size: 13px;
+}
+.fleet-purge input {
+  width: auto;
+}
+
+.archetype-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  gap: 10px;
+  margin-bottom: 18px;
+}
+.archetype-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  text-align: left;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-panel);
+  cursor: pointer;
+}
+.archetype-card:hover {
+  border-color: var(--fg-muted);
+}
+.archetype-card.selected {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 1px var(--accent);
+}
+.archetype-icon {
+  color: var(--accent);
+  display: inline-flex;
+}
+.archetype-label {
+  font-weight: 600;
+}
+.archetype-blurb {
+  font-size: 12px;
+  color: var(--fg-muted);
+  line-height: 1.4;
+}
+.archetype-name-field {
+  max-width: 380px;
+}
+.field-hint {
+  font-size: 11px;
+  color: var(--fg-muted);
+}
+
+/* Topbar fleet switcher (ADR 0042) — the agent name as a dropdown */
+.fleet-switcher {
+  position: relative;
+  display: inline-flex;
+}
+.fleet-switcher-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  background: none;
+  border: none;
+  padding: 2px 4px;
+  margin: -2px -4px;
+  border-radius: var(--radius);
+  color: inherit;
+  font: inherit;
+  font-weight: 600;
+  cursor: pointer;
+}
+.fleet-switcher-trigger:hover {
+  background: var(--bg-hover);
+}
+.fleet-switcher-menu {
+  position: absolute;
+  top: calc(100% + 6px);
+  left: 0;
+  z-index: 60;
+  min-width: 200px;
+  padding: 4px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-panel);
+  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+}
+.fleet-switcher-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 9px;
+  background: none;
+  border: none;
+  border-radius: 5px;
+  color: var(--fg);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.fleet-switcher-item:hover {
+  background: var(--bg-hover);
+}
+.fleet-switcher-item.active {
+  color: var(--accent);
+}
+.fleet-switcher-name {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+.fleet-switcher-sep {
+  height: 1px;
+  margin: 4px 2px;
+  background: var(--border);
+}
+
+/* The host (this instance) tag in the fleet manager + switcher (ADR 0042) */
+.fleet-host-tag {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 0 5px;
+  margin-left: 8px;
+}
+
+/* Theme crossfade (ADR 0042) — applyAgentTheme() applies the focused agent's look inside a
+   View Transition (when supported), so switching agents snapshots before/after and crossfades
+   instead of hard-cutting. Ease the root transition so it glides. (Live picker drags bypass
+   this — they set --pl-* directly for instant feedback.) */
+::view-transition-old(root),
+::view-transition-new(root) {
+  animation-duration: 0.35s;
+  animation-timing-function: ease;
+}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3409,6 +3409,14 @@ textarea {
 }
 
 /* Topbar fleet switcher (ADR 0042) — the agent name as a dropdown */
+/* The DS Header name slot (.pl-header__name) sets `overflow: hidden` for text ellipsis — but
+   it now hosts the FleetSwitcher, whose dropdown menu is positioned BELOW the trigger and so
+   gets clipped invisible. Let the slot (and the lockup above it) overflow when the switcher
+   lives there, so the menu actually shows. */
+.pl-header__lockup:has(.fleet-switcher),
+.pl-header__name:has(.fleet-switcher) {
+  overflow: visible;
+}
 .fleet-switcher {
   position: relative;
   display: inline-flex;

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -26,7 +26,18 @@ export type ChatState = PersistedChatState & {
   sessionStatusMap: Record<string, SessionStatus>;
 };
 
-const STORAGE_KEY = "protoagent.chat.sessions";
+// Chat sessions are PER AGENT — namespace the persisted key by the URL slug (ADR 0042 slug
+// routing), exactly like the per-agent layout. Without this every agent's window restores the
+// same sessions from localStorage and you see one agent's chat under another. host (no /agent/
+// slug) keeps the legacy un-suffixed key. The slug is fixed per page load (switching navigates).
+const STORAGE_KEY = (() => {
+  try {
+    const m = window.location.pathname.match(/\/agent\/([^/?#]+)/);
+    return m ? `protoagent.chat.sessions:${decodeURIComponent(m[1])}` : "protoagent.chat.sessions";
+  } catch {
+    return "protoagent.chat.sessions";
+  }
+})();
 
 function id(prefix: string) {
   return `${prefix}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;

--- a/apps/web/src/lib/agentTheme.ts
+++ b/apps/web/src/lib/agentTheme.ts
@@ -1,0 +1,79 @@
+import { applyStoredTheme } from "@protolabsai/ui/theming";
+
+// Bridge the per-agent server theme (/api/theme, ADR 0042) to the DS ThemePanel, which is
+// localStorage-backed (key "pl-theme", an opaque {mode, overrides} blob). The host round-trips
+// that blob: GET seeds localStorage + repaints; the panel's edits persist to localStorage; a
+// "Save" PUTs the current blob back. The blob is opaque — the panel owns its schema.
+const PL_THEME_KEY = "pl-theme"; // @protolabsai/ui theming.tsx LS_THEME
+
+function root(): HTMLElement {
+  return document.documentElement;
+}
+
+/** Clear any inline --pl-* overrides the panel applied, so switching to an agent with a
+ *  different (or no) theme doesn't leave the previous one's colors stuck. */
+function clearOverrides() {
+  const s = root().style;
+  for (let i = s.length - 1; i >= 0; i--) {
+    const p = s[i];
+    if (p.startsWith("--pl-")) s.removeProperty(p);
+  }
+}
+
+/** Apply a server theme blob to the document (+ seed the panel's localStorage). `null`/empty
+ *  resets to the design-system defaults. Crossfades via the View Transitions API where
+ *  available (`animate`), so switching agents eases between looks — pass `animate: false` for
+ *  the initial boot apply (nothing to crossfade from, and the snapshot can disrupt first paint). */
+export function applyAgentTheme(theme: unknown, animate = true) {
+  const apply = () => {
+    clearOverrides();
+    if (theme && typeof theme === "object") {
+      try {
+        localStorage.setItem(PL_THEME_KEY, JSON.stringify(theme));
+      } catch {
+        /* ignore */
+      }
+      applyStoredTheme(); // re-reads the seeded blob → mode + overrides
+    } else {
+      try {
+        localStorage.removeItem(PL_THEME_KEY);
+      } catch {
+        /* ignore */
+      }
+      root().removeAttribute("data-theme"); // back to the OS/default
+    }
+  };
+
+  const doc = document as Document & { startViewTransition?: (cb: () => void) => unknown };
+  if (animate && typeof doc.startViewTransition === "function") {
+    doc.startViewTransition(apply);
+  } else {
+    apply();
+  }
+}
+
+// Broadcast a single `protoagent:theme` window event whenever the document's theme changes —
+// applyAgentTheme (switch/save/reset) AND the ThemePanel's live picker edits both mutate the
+// root's `style`/`data-theme`, so one MutationObserver catches everything. PluginView listens
+// and re-posts the theme to its iframe, so embedded plugin views repaint live too (ADR 0026/0042).
+let _watching = false;
+export function watchThemeChanges() {
+  if (_watching || typeof window === "undefined") return;
+  _watching = true;
+  let raf = 0;
+  const fire = () => {
+    cancelAnimationFrame(raf);
+    raf = requestAnimationFrame(() => window.dispatchEvent(new Event("protoagent:theme")));
+  };
+  new MutationObserver(fire).observe(root(), { attributes: true, attributeFilter: ["style", "data-theme"] });
+}
+
+/** The panel's current blob (what "Save to this agent" PUTs), or null if untouched. */
+export function currentThemeBlob(): unknown {
+  try {
+    const raw = localStorage.getItem(PL_THEME_KEY);
+    return raw ? JSON.parse(raw) : null;
+  } catch {
+    return null;
+  }
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -131,14 +131,20 @@ export function getActivePrefix() {
   return _activePrefix;
 }
 function isHubPath(path: string) {
+  // The fleet control plane is served by the supervisor itself — never proxied to an agent.
   return path.startsWith("/api/fleet") || path.startsWith("/api/archetypes");
+}
+function isAgentPath(path: string) {
+  // Everything that drives the focused AGENT: its console API, its A2A brain (streaming chat
+  // posts here — #2), and its OpenAI-compat endpoint. /api/fleet stays on the hub.
+  return (path.startsWith("/api/") && !isHubPath(path)) || path.startsWith("/a2a") || path.startsWith("/v1");
 }
 
 export function apiUrl(path: string) {
   if (/^https?:\/\//.test(path)) return path;
-  // Agent-level /api/* routes through the active agent's proxy in fleet mode.
+  // Agent-level paths route through the active agent's proxy in fleet mode.
   let p = path;
-  if (_activePrefix && path.startsWith("/api/") && !isHubPath(path)) {
+  if (_activePrefix && isAgentPath(path)) {
     p = `${_activePrefix}${path}`;
   }
   const base = defaultApiBase();

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -118,34 +118,44 @@ function defaultApiBase() {
   return "";
 }
 
-// Fleet in-place switch (ADR 0042). When an agent is "active", agent-level /api/* calls
-// route through the hub's reverse proxy (/active/api/*) so the whole console reads/writes
-// the focused agent — one flag, no per-call change. Hub control-plane paths (the fleet
-// itself) are served by the supervisor and must NOT be proxied to an agent.
-let _activePrefix = "";
+// Fleet slug routing (ADR 0042). The focused agent lives in the URL — /app/agent/<slug>/ —
+// so each console window targets its own agent: deterministic, survives reload, and two
+// agents can be open in two windows at once. apiUrl() reads that slug and routes agent-level
+// calls through the hub's per-agent proxy (/agents/<slug>/api/*). `host` (or no slug) = this
+// instance, talking to /api directly. Hub control-plane paths (the fleet itself) are never
+// scoped — they're served by the supervisor.
+export function currentSlug(): string {
+  try {
+    const m = window.location.pathname.match(/\/agent\/([^/?#]+)/);
+    return m ? decodeURIComponent(m[1]) : "host";
+  } catch {
+    return "host";
+  }
+}
 
-export function setActivePrefix(prefix: string) {
-  _activePrefix = prefix; // "" = talk to /api directly; "/active" = via the active-agent proxy
+/** URL of the console focused on `slug` (for navigation / opening a new window). */
+export function agentHref(slug: string): string {
+  const base = import.meta.env.BASE_URL || "/"; // "/app/"
+  return slug === "host" ? base : `${base}agent/${encodeURIComponent(slug)}/`;
 }
-export function getActivePrefix() {
-  return _activePrefix;
-}
+
 function isHubPath(path: string) {
-  // The fleet control plane is served by the supervisor itself — never proxied to an agent.
+  // The fleet control plane is served by the supervisor itself — never scoped to an agent.
   return path.startsWith("/api/fleet") || path.startsWith("/api/archetypes");
 }
 function isAgentPath(path: string) {
-  // Everything that drives the focused AGENT: its console API, its A2A brain (streaming chat
-  // posts here — #2), and its OpenAI-compat endpoint. /api/fleet stays on the hub.
+  // Everything that drives the focused AGENT: its console API, its A2A brain (streaming chat),
+  // and its OpenAI-compat endpoint. /api/fleet stays on the hub.
   return (path.startsWith("/api/") && !isHubPath(path)) || path.startsWith("/a2a") || path.startsWith("/v1");
 }
 
 export function apiUrl(path: string) {
   if (/^https?:\/\//.test(path)) return path;
-  // Agent-level paths route through the active agent's proxy in fleet mode.
+  // Agent-level paths route through the focused agent's proxy, keyed by the URL slug.
   let p = path;
-  if (_activePrefix && isAgentPath(path)) {
-    p = `${_activePrefix}${path}`;
+  const slug = currentSlug();
+  if (slug !== "host" && isAgentPath(path)) {
+    p = `/agents/${encodeURIComponent(slug)}${path}`;
   }
   const base = defaultApiBase();
   return base ? `${base}${p.startsWith("/") ? p : `/${p}`}` : p;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,12 +1,15 @@
 import type {
   ActivityHistory,
   AgentConfig,
+  Archetype,
   BeadsIssue,
   ChatMessage,
   ConfigPayload,
   DelegateProbe,
   DelegateTypeSpec,
   DelegateView,
+  FleetAgent,
+  FleetStatus,
   GoalState,
   HitlPayload,
   InboxItem,
@@ -115,10 +118,31 @@ function defaultApiBase() {
   return "";
 }
 
+// Fleet in-place switch (ADR 0042). When an agent is "active", agent-level /api/* calls
+// route through the hub's reverse proxy (/active/api/*) so the whole console reads/writes
+// the focused agent — one flag, no per-call change. Hub control-plane paths (the fleet
+// itself) are served by the supervisor and must NOT be proxied to an agent.
+let _activePrefix = "";
+
+export function setActivePrefix(prefix: string) {
+  _activePrefix = prefix; // "" = talk to /api directly; "/active" = via the active-agent proxy
+}
+export function getActivePrefix() {
+  return _activePrefix;
+}
+function isHubPath(path: string) {
+  return path.startsWith("/api/fleet") || path.startsWith("/api/archetypes");
+}
+
 export function apiUrl(path: string) {
   if (/^https?:\/\//.test(path)) return path;
+  // Agent-level /api/* routes through the active agent's proxy in fleet mode.
+  let p = path;
+  if (_activePrefix && path.startsWith("/api/") && !isHubPath(path)) {
+    p = `${_activePrefix}${path}`;
+  }
   const base = defaultApiBase();
-  return base ? `${base}${path.startsWith("/") ? path : `/${path}`}` : path;
+  return base ? `${base}${p.startsWith("/") ? p : `/${p}`}` : p;
 }
 
 /** True inside the desktop (Tauri/WKWebView) shell. WKWebView does NOT deliver a
@@ -591,6 +615,57 @@ export const api = {
       method: "POST",
       body: { updates },
     });
+  },
+
+  // --- Fleet (ADR 0042) — many workspace agents on one host ------------------
+  fleet() {
+    return request<FleetStatus>("/api/fleet");
+  },
+  archetypes() {
+    return request<{ archetypes: Archetype[] }>("/api/archetypes");
+  },
+  createAgent(body: { name: string; bundle?: string | null; port?: number; start?: boolean; shared_skills?: boolean }) {
+    return request<{ ok: boolean; agent: FleetAgent; installed: string[] }>("/api/fleet", {
+      method: "POST",
+      body,
+    });
+  },
+  startAgent(name: string) {
+    return request<{ ok: boolean; agent: FleetAgent }>(`/api/fleet/${encodeURIComponent(name)}/start`, {
+      method: "POST",
+    });
+  },
+  stopAgent(name: string) {
+    return request<{ ok: boolean; name: string; stopped: boolean }>(`/api/fleet/${encodeURIComponent(name)}/stop`, {
+      method: "POST",
+    });
+  },
+  removeAgent(name: string, purge = false) {
+    return request<{ ok: boolean; name: string; removed: string[] }>(
+      `/api/fleet/${encodeURIComponent(name)}${purge ? "?purge=true" : ""}`,
+      { method: "DELETE" },
+    );
+  },
+  activateAgent(name: string) {
+    return request<{ ok: boolean; active: string; evicted: string[] }>(`/api/fleet/${encodeURIComponent(name)}/activate`, {
+      method: "POST",
+    });
+  },
+  fleetDown() {
+    return request<{ ok: boolean; stopped: string[] }>("/api/fleet/down", { method: "POST" });
+  },
+
+  // Per-agent theme (ADR 0042). The blob is opaque — the DS ThemePanel owns its schema; the
+  // server just round-trips JSON. These auto-route to the focused agent via the active prefix
+  // (host → /api/theme, peer → /active/api/theme).
+  getTheme() {
+    return request<{ theme: unknown | null }>("/api/theme");
+  },
+  saveTheme(theme: unknown) {
+    return request<{ ok: boolean }>("/api/theme", { method: "PUT", body: { theme } });
+  },
+  resetTheme() {
+    return request<{ ok: boolean }>("/api/theme", { method: "DELETE" });
   },
 
   chat(message: string, sessionId: string) {

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -59,18 +59,6 @@ function ensureOpen() {
   source.onmessage = (event) => dispatch((event as MessageEvent).data);
 }
 
-/** Re-point the SSE stream at the currently-active agent — call after a fleet switch (ADR 0042)
- *  so live activity/notifications follow the focused agent. The single EventSource resolves its
- *  URL once at open; closing + reopening picks up the new active prefix (`/active/api/events`). */
-export function reopenEvents() {
-  if (source) {
-    source.close();
-    source = null;
-    setConnected(false);
-  }
-  if (subs.size || connListeners.size) ensureOpen(); // reopen only if anything's listening
-}
-
 /** Subscribe to a topic (exact, or a `*`/`#` pattern). Returns an unsubscribe function. */
 export function onTopic(pattern: string, fn: Listener): () => void {
   ensureOpen();

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -59,6 +59,18 @@ function ensureOpen() {
   source.onmessage = (event) => dispatch((event as MessageEvent).data);
 }
 
+/** Re-point the SSE stream at the currently-active agent — call after a fleet switch (ADR 0042)
+ *  so live activity/notifications follow the focused agent. The single EventSource resolves its
+ *  URL once at open; closing + reopening picks up the new active prefix (`/active/api/events`). */
+export function reopenEvents() {
+  if (source) {
+    source.close();
+    source = null;
+    setConnected(false);
+  }
+  if (subs.size || connListeners.size) ensureOpen(); // reopen only if anything's listening
+}
+
 /** Subscribe to a topic (exact, or a `*`/`#` pattern). Returns an unsubscribe function. */
 export function onTopic(pattern: string, fn: Listener): () => void {
   ensureOpen();

--- a/apps/web/src/lib/lucideIcon.tsx
+++ b/apps/web/src/lib/lucideIcon.tsx
@@ -1,0 +1,38 @@
+import { lazy, Suspense, type ComponentType, type LazyExoticComponent, type ReactNode } from "react";
+
+import { Package, type LucideIcon } from "lucide-react";
+
+// Resolve ANY lucide icon by name (e.g. an archetype/plugin-supplied "Sparkles",
+// "LayoutGrid") — lazily, so the full lucide set lands in a separate chunk that only
+// loads when a non-curated glyph is actually used. Falls back to Package on an unknown
+// name. Shared by the fleet archetype picker + any surface that renders backend-named icons.
+
+function toPascalCase(s: string): string {
+  return s.replace(/(^|[-_\s])(\w)/g, (_m, _sep, c: string) => c.toUpperCase());
+}
+
+type IconComp = LazyExoticComponent<ComponentType<{ size?: number }>>;
+const cache = new globalThis.Map<string, IconComp>();
+
+function lazyIcon(key: string): IconComp {
+  let comp = cache.get(key);
+  if (!comp) {
+    comp = lazy(async () => {
+      const m = await import("lucide-react");
+      const Icon = (m.icons as Record<string, LucideIcon>)[key] || m.Package;
+      return { default: Icon as ComponentType<{ size?: number }> };
+    });
+    cache.set(key, comp);
+  }
+  return comp;
+}
+
+export function lucideIcon(name: string | undefined, size = 18): ReactNode {
+  if (!name) return <Package size={size} />;
+  const Lazy = lazyIcon(toPascalCase(name));
+  return (
+    <Suspense fallback={<Package size={size} />}>
+      <Lazy size={size} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -19,7 +19,25 @@ export const queryKeys = {
   delegates: ["delegates"] as const,
   delegateTypes: ["delegates", "types"] as const,
   installedPlugins: ["plugins", "installed"] as const,
+  fleet: ["fleet"] as const,
+  archetypes: ["archetypes"] as const,
 };
+
+// The fleet of workspace agents (ADR 0042). `running` is a live-pid probe, so poll
+// while mounted — a crashed agent flips to running:false on the next read.
+export const fleetQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.fleet,
+    queryFn: () => api.fleet(),
+    refetchInterval: 3_000,
+  });
+
+// Archetypes for the new-agent picker (Basic + installed bundles) — config, not live.
+export const archetypesQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.archetypes,
+    queryFn: () => api.archetypes(),
+  });
 
 // Goals the agent works toward (goal mode). Lives in the right sidebar and
 // refetches every 5s while mounted — the agent advances/clears goals mid-turn,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -471,3 +471,26 @@ export type DelegateView = {
   health?: DelegateProbe;
   [key: string]: unknown;
 };
+
+// Fleet (ADR 0042) — many workspace agents on one host, switchable in place.
+export type FleetAgent = {
+  name: string; // also the instance id; unique, [A-Za-z0-9-_]
+  id: string;
+  port: number;
+  pid: number | null; // null when stopped
+  running: boolean;
+  bundle: string; // "" for a Basic agent
+  a2a?: string; // the agent's own A2A endpoint (focus-independent)
+  host?: boolean; // the instance serving this console — can't be stopped/removed from itself
+};
+
+// `active` is the focused peer, or null when the host itself is focused (talk /api direct).
+export type FleetStatus = { agents: FleetAgent[]; active: string | null };
+
+export type Archetype = {
+  id: string; // "basic", or a bundle id e.g. "pm-stack"
+  label: string;
+  icon: string; // lucide-react icon name
+  blurb: string;
+  bundle: string | null; // null = Basic; else the bundle git URL
+};

--- a/apps/web/src/lib/useActiveTheme.ts
+++ b/apps/web/src/lib/useActiveTheme.ts
@@ -1,0 +1,23 @@
+import { useQuery } from "@tanstack/react-query";
+import { useEffect, useRef } from "react";
+
+import { api } from "./api";
+import { applyAgentTheme } from "./agentTheme";
+
+// Apply the focused agent's saved theme on boot + on every switch (ADR 0042). The switcher
+// invalidates all queries after flipping the active agent, so ["theme"] refetches → the new
+// agent's blob → repaint. retry:false so a backend without /api/theme just no-ops to defaults.
+export function useActiveTheme() {
+  const q = useQuery({ queryKey: ["theme"], queryFn: () => api.getTheme(), retry: false, staleTime: 2_000 });
+  const applied = useRef<string | null>(null);
+  const first = useRef(true);
+  useEffect(() => {
+    if (q.data === undefined) return;
+    const sig = JSON.stringify(q.data.theme ?? null);
+    if (sig !== applied.current) {
+      applyAgentTheme(q.data.theme, !first.current); // no crossfade on the initial boot apply
+      applied.current = sig;
+      first.current = false;
+    }
+  }, [q.data]);
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -11,6 +11,9 @@ import "./app/tailwind.css";
 import "@protolabsai/ui/styles.css";
 import "./app/theme.css";
 import { queryClient } from "./lib/queryClient";
+import { watchThemeChanges } from "./lib/agentTheme";
+
+watchThemeChanges(); // fire `protoagent:theme` on any theme change → plugin iframes repaint live
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -1,0 +1,134 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { Play, Plus, Square, Trash2 } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@protolabsai/ui/primitives";
+import { ConfirmDialog } from "@protolabsai/ui/overlays";
+import { PanelHeader } from "@protolabsai/ui/navigation";
+
+import { api } from "../lib/api";
+import { fleetQuery, queryKeys } from "../lib/queries";
+import type { FleetAgent } from "../lib/types";
+
+// Fleet manager (ADR 0042) — Settings → Agents. Lists the workspace agents with live
+// status (the query polls every 3s, so a crashed agent flips to stopped on its own) and
+// per-row start / stop / remove. "+ New agent" opens the archetype picker via `onNew`.
+export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
+  const qc = useQueryClient();
+  const fleet = useQuery(fleetQuery());
+  const [busy, setBusy] = useState<string | null>(null); // name currently being acted on
+  const [error, setError] = useState<string | null>(null);
+  const [confirmRemove, setConfirmRemove] = useState<FleetAgent | null>(null);
+  const [purge, setPurge] = useState(false);
+
+  const agents = fleet.data?.agents ?? [];
+  const active = fleet.data?.active ?? null;
+
+  const run = useMutation({
+    mutationFn: async (fn: () => Promise<unknown>) => fn(),
+    onMutate: () => setError(null),
+    onError: (e: Error) => setError(e.message),
+    onSettled: () => {
+      setBusy(null);
+      qc.invalidateQueries({ queryKey: queryKeys.fleet });
+    },
+  });
+  const act = (name: string, fn: () => Promise<unknown>) => {
+    setBusy(name);
+    run.mutate(fn);
+  };
+
+  return (
+    <section className="panel stage-panel">
+      <PanelHeader
+        title="Agents"
+        kicker={`${agents.length} agent${agents.length === 1 ? "" : "s"} on this host · the fleet (ADR 0042)`}
+        actions={
+          <Button variant="primary" onClick={onNew}>
+            <Plus size={15} /> New agent
+          </Button>
+        }
+      />
+      <div className="stage-body">
+        {error ? (
+          <p className="fleet-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+        {fleet.isLoading ? (
+          <p className="fleet-empty">Loading the fleet…</p>
+        ) : agents.length === 0 ? (
+          <p className="fleet-empty">No agents yet — create one to get started.</p>
+        ) : (
+          <ul className="fleet-list">
+            {agents.map((a) => {
+              // The host is focused when no peer is active (active === null).
+              const isActive = a.name === active || (!!a.host && active === null);
+              return (
+                <li key={a.name} className={`fleet-row${isActive ? " active" : ""}`}>
+                  <span
+                    className={`fleet-dot ${a.running ? "running" : "stopped"}`}
+                    title={a.running ? "running" : "stopped"}
+                    aria-label={a.running ? "running" : "stopped"}
+                  />
+                  <div className="fleet-row-main">
+                    <span className="fleet-name">
+                      {a.name}
+                      {a.host ? <span className="fleet-host-tag">this instance</span> : null}
+                      {isActive ? <span className="fleet-active-tag">active</span> : null}
+                    </span>
+                    <span className="fleet-meta">
+                      :{a.port}
+                      {a.pid ? ` · pid ${a.pid}` : ""}
+                      {a.bundle ? ` · ${a.bundle}` : ""}
+                    </span>
+                  </div>
+                  {/* The host serves this console — it can't stop or remove itself. */}
+                  {a.host ? null : (
+                    <div className="fleet-row-actions">
+                      {a.running ? (
+                        <Button icon variant="ghost" title="Stop" disabled={busy === a.name}
+                          onClick={() => act(a.name, () => api.stopAgent(a.name))}>
+                          <Square size={14} />
+                        </Button>
+                      ) : (
+                        <Button icon variant="ghost" title="Start" disabled={busy === a.name}
+                          onClick={() => act(a.name, () => api.startAgent(a.name))}>
+                          <Play size={14} />
+                        </Button>
+                      )}
+                      <Button icon variant="ghost" title="Remove" disabled={busy === a.name}
+                        onClick={() => { setPurge(false); setConfirmRemove(a); }}>
+                        <Trash2 size={14} />
+                      </Button>
+                    </div>
+                  )}
+                </li>
+              );
+            })}
+          </ul>
+        )}
+      </div>
+
+      <ConfirmDialog
+        open={confirmRemove !== null}
+        title={confirmRemove ? `Remove ${confirmRemove.name}?` : ""}
+        confirmLabel={purge ? "Remove + purge data" : "Remove"}
+        destructive
+        onConfirm={() => {
+          const a = confirmRemove;
+          const wipe = purge;
+          setConfirmRemove(null);
+          if (a) act(a.name, () => api.removeAgent(a.name, wipe));
+        }}
+        onClose={() => setConfirmRemove(null)}
+      >
+        <p>Stops the agent and removes it from the fleet.</p>
+        <label className="fleet-purge">
+          <input type="checkbox" checked={purge} onChange={(e) => setPurge(e.target.checked)} />
+          Also purge its workspace data (irreversible)
+        </label>
+      </ConfirmDialog>
+    </section>
+  );
+}

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -6,7 +6,7 @@ import { Button } from "@protolabsai/ui/primitives";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 
-import { api } from "../lib/api";
+import { api, currentSlug } from "../lib/api";
 import { fleetQuery, queryKeys } from "../lib/queries";
 import type { FleetAgent } from "../lib/types";
 
@@ -22,7 +22,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   const [purge, setPurge] = useState(false);
 
   const agents = fleet.data?.agents ?? [];
-  const active = fleet.data?.active ?? null;
+  const slug = currentSlug(); // the agent this window is focused on (the URL slug)
 
   const run = useMutation({
     mutationFn: async (fn: () => Promise<unknown>) => fn(),
@@ -62,8 +62,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
         ) : (
           <ul className="fleet-list">
             {agents.map((a) => {
-              // The host is focused when no peer is active (active === null).
-              const isActive = a.name === active || (!!a.host && active === null);
+              const isActive = (a.host ? "host" : a.id) === slug; // slug = stable id, not name
               return (
                 <li key={a.name} className={`fleet-row${isActive ? " active" : ""}`}>
                   <span

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -42,7 +42,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
     <section className="panel stage-panel">
       <PanelHeader
         title="Agents"
-        kicker={`${agents.length} agent${agents.length === 1 ? "" : "s"} on this host · the fleet (ADR 0042)`}
+        kicker={`${agents.length} agent${agents.length === 1 ? "" : "s"} on this host · the fleet`}
         actions={
           <Button variant="primary" onClick={onNew}>
             <Plus size={15} /> New agent

--- a/apps/web/src/settings/FleetSurface.tsx
+++ b/apps/web/src/settings/FleetSurface.tsx
@@ -1,0 +1,14 @@
+import { useState } from "react";
+
+import { FleetManagerPanel } from "./FleetManagerPanel";
+import { NewAgentPanel } from "./NewAgentPanel";
+
+// Settings → Agents (ADR 0042). The fleet manager + the new-agent picker, toggled in
+// place — "+ New agent" opens the picker, which returns to the list on create/cancel.
+export function FleetSurface() {
+  const [view, setView] = useState<"list" | "new">("list");
+  if (view === "new") {
+    return <NewAgentPanel onDone={() => setView("list")} onCancel={() => setView("list")} />;
+  }
+  return <FleetManagerPanel onNew={() => setView("new")} />;
+}

--- a/apps/web/src/settings/NewAgentPanel.tsx
+++ b/apps/web/src/settings/NewAgentPanel.tsx
@@ -1,0 +1,103 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft } from "lucide-react";
+import { useState } from "react";
+
+import { Button } from "@protolabsai/ui/primitives";
+import { PanelHeader } from "@protolabsai/ui/navigation";
+
+import { api } from "../lib/api";
+import { archetypesQuery, queryKeys } from "../lib/queries";
+import { lucideIcon } from "../lib/lucideIcon";
+import type { Archetype } from "../lib/types";
+
+const NAME_RE = /^[A-Za-z0-9-_]+$/;
+
+// Onboarding / archetype picker (ADR 0042). Pick an archetype (Basic + installed bundles),
+// name the agent, create. Creating from a bundle clones+installs it (a few seconds) — the
+// POST returns once the agent is up, so the button shows a spinner until then.
+export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) => void; onCancel?: () => void }) {
+  const qc = useQueryClient();
+  const archetypes = useQuery(archetypesQuery());
+  const [picked, setPicked] = useState<string>("basic");
+  const [name, setName] = useState("");
+  const [error, setError] = useState<string | null>(null);
+
+  const list = archetypes.data?.archetypes ?? [];
+  const archetype = list.find((a) => a.id === picked) ?? list[0];
+  const nameOk = NAME_RE.test(name);
+
+  const create = useMutation({
+    mutationFn: () => api.createAgent({ name: name.trim(), bundle: archetype?.bundle ?? null }),
+    onMutate: () => setError(null),
+    onError: (e: Error) => setError(e.message),
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: queryKeys.fleet });
+      onDone?.(res.agent?.name ?? name.trim());
+    },
+  });
+
+  return (
+    <section className="panel stage-panel">
+      <PanelHeader
+        title="New agent"
+        kicker="pick an archetype, name it, and launch — a new workspace agent on this host"
+        actions={
+          onCancel ? (
+            <Button variant="ghost" onClick={onCancel}>
+              <ArrowLeft size={15} /> Back
+            </Button>
+          ) : undefined
+        }
+      />
+      <div className="stage-body">
+        {error ? (
+          <p className="fleet-error" role="alert">
+            {error}
+          </p>
+        ) : null}
+
+        <p className="fleet-section-label">Archetype</p>
+        <div className="archetype-grid">
+          {list.map((a: Archetype) => (
+            <button
+              key={a.id}
+              type="button"
+              className={`archetype-card${a.id === picked ? " selected" : ""}`}
+              aria-pressed={a.id === picked}
+              onClick={() => setPicked(a.id)}
+            >
+              <span className="archetype-icon">{lucideIcon(a.icon, 22)}</span>
+              <span className="archetype-label">{a.label}</span>
+              <span className="archetype-blurb">{a.blurb}</span>
+            </button>
+          ))}
+        </div>
+
+        <label className="field archetype-name-field">
+          <span>Name</span>
+          <input
+            value={name}
+            autoFocus
+            placeholder="e.g. ava, roxy, research-bot"
+            aria-label="Agent name"
+            onChange={(e) => setName(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === "Enter" && nameOk && !create.isPending) create.mutate();
+            }}
+          />
+          <span className="field-hint">Letters, numbers, dashes and underscores — it's the agent's id and URL.</span>
+        </label>
+
+        <div className="panel-actions">
+          <Button
+            variant="primary"
+            disabled={!nameOk || create.isPending}
+            onClick={() => create.mutate()}
+          >
+            {create.isPending ? "Creating…" : archetype?.bundle ? `Create from ${archetype.label}` : "Create agent"}
+          </Button>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,25 +1,31 @@
-import { BarChart3, Gauge, Puzzle, Settings2 } from "lucide-react";
+import { BarChart3, Gauge, Palette, Puzzle, Server, Settings2 } from "lucide-react";
 
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { DelegatesSection } from "./DelegatesSection";
+import { FleetSurface } from "./FleetSurface";
 import { OverviewPanel } from "./OverviewPanel";
 import { SettingsCategoryPanel } from "./SettingsCategory";
+import { ThemeSurface } from "./ThemeSurface";
 
 // Central Settings — only cross-cutting stuff now (the settings decentralization):
 // Overview (status), Telemetry, Plugins (delegates + the settings for any view-less
 // plugin), and System (runtime/middleware). Agent + Memory settings moved to their
 // home views (Agent → Settings, Knowledge → Settings).
 
-export type SettingsTab = "overview" | "telemetry" | "plugins" | "system";
+export type SettingsTab = "overview" | "agents" | "theme" | "telemetry" | "plugins" | "system";
 
 export const SETTINGS_TABS = [
   { id: "overview", label: "Overview", icon: Gauge },
+  { id: "agents", label: "Agents", icon: Server },
+  { id: "theme", label: "Theme", icon: Palette },
   { id: "telemetry", label: "Telemetry", icon: BarChart3 },
   { id: "plugins", label: "Plugins", icon: Puzzle },
   { id: "system", label: "System", icon: Settings2 },
 ] as const;
 
 export function SettingsSurface({ tab = "overview" }: { tab?: SettingsTab }) {
+  if (tab === "agents") return <FleetSurface />;              // the fleet (ADR 0042)
+  if (tab === "theme") return <ThemeSurface />;               // per-agent look (ADR 0042)
   if (tab === "telemetry") return <TelemetrySurface />;       // self-contained (own section + boundary)
   if (tab === "plugins") {
     return (

--- a/apps/web/src/settings/ThemeSurface.tsx
+++ b/apps/web/src/settings/ThemeSurface.tsx
@@ -1,0 +1,58 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+
+import { PanelHeader } from "@protolabsai/ui/navigation";
+import { useToast } from "@protolabsai/ui/overlays";
+import { Button } from "@protolabsai/ui/primitives";
+import { ThemePanel } from "@protolabsai/ui/theming";
+
+import { api } from "../lib/api";
+import { applyAgentTheme, currentThemeBlob } from "../lib/agentTheme";
+
+// Settings → Theme (ADR 0042). The DS ThemePanel edits the look live (it persists to its own
+// localStorage); "Save to this agent" PUTs that blob to /api/theme so the FOCUSED agent keeps
+// it, and the switch repaints automatically (useActiveTheme). The blob is opaque to us.
+export function ThemeSurface() {
+  const qc = useQueryClient();
+  const toast = useToast();
+
+  const save = useMutation({
+    mutationFn: () => api.saveTheme(currentThemeBlob()),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ["theme"] });
+      toast({ tone: "success", title: "Theme saved", message: "This agent will keep this look." });
+    },
+    onError: (e: Error) => toast({ tone: "error", title: "Save failed", message: e.message }),
+  });
+
+  const reset = useMutation({
+    mutationFn: () => api.resetTheme(),
+    onSuccess: () => {
+      applyAgentTheme(null);
+      qc.invalidateQueries({ queryKey: ["theme"] });
+      toast({ tone: "success", title: "Theme reset", message: "Back to the defaults." });
+    },
+    onError: (e: Error) => toast({ tone: "error", title: "Reset failed", message: e.message }),
+  });
+
+  return (
+    <section className="panel stage-panel">
+      <PanelHeader
+        title="Theme"
+        kicker="this agent's look — saved per agent, repaints when you switch"
+        actions={
+          <>
+            <Button variant="ghost" onClick={() => reset.mutate()} disabled={reset.isPending}>
+              Reset
+            </Button>
+            <Button variant="primary" onClick={() => save.mutate()} disabled={save.isPending}>
+              Save to this agent
+            </Button>
+          </>
+        }
+      />
+      <div className="stage-body">
+        <ThemePanel />
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -10,9 +10,41 @@
 // with no visible change.
 
 import { create } from "zustand";
-import { persist } from "zustand/middleware";
+import { createJSONStorage, persist } from "zustand/middleware";
 
 import type { SettingsTab } from "../settings/SettingsSurface";
+
+// Per-agent layout (ADR 0042). Each fleet agent keeps its OWN layout — rail order, widths,
+// active surface, plugins out. In the single-agent product that fell out for free (each agent
+// is its own origin → its own localStorage); the unified console (one origin + the /active
+// proxy) collapses that, so we namespace the persisted key by the active agent instead. The
+// switcher calls setLayoutAgent(name) + useUI.persist.rehydrate() on a switch, so flipping
+// agents loads that agent's saved layout. Empty = single-agent (the legacy un-suffixed key).
+const _ACTIVE_AGENT_KEY = "protoagent.activeAgent";
+// Read synchronously at module load so the store hydrates from the right agent's key on
+// reload (no flash / no race with the async fleet fetch).
+let _layoutAgent = (() => {
+  try {
+    return globalThis.localStorage.getItem(_ACTIVE_AGENT_KEY) || "";
+  } catch {
+    return "";
+  }
+})();
+export function setLayoutAgent(name: string) {
+  _layoutAgent = name || "";
+  try {
+    if (_layoutAgent) globalThis.localStorage.setItem(_ACTIVE_AGENT_KEY, _layoutAgent);
+    else globalThis.localStorage.removeItem(_ACTIVE_AGENT_KEY);
+  } catch {
+    /* no-op */
+  }
+}
+const _layoutStorage = createJSONStorage(() => ({
+  getItem: (name: string) => globalThis.localStorage.getItem(_layoutAgent ? `${name}:${_layoutAgent}` : name),
+  setItem: (name: string, value: string) =>
+    globalThis.localStorage.setItem(_layoutAgent ? `${name}:${_layoutAgent}` : name, value),
+  removeItem: (name: string) => globalThis.localStorage.removeItem(_layoutAgent ? `${name}:${_layoutAgent}` : name),
+}));
 
 // Core surfaces are fixed literals; plugin views (ADR 0026) add dynamic surfaces keyed
 // `plugin:<pluginId>:<viewId>`. The `(string & {})` keeps literal autocomplete while allowing
@@ -145,7 +177,8 @@ export const useUI = create<UIState>()(
         }),
     }),
     {
-      name: "protoagent.ui", // localStorage key — the single source of truth (ADR 0035 D5)
+      name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
+      storage: _layoutStorage,
       version: 2, // v2: railOf (side map) → railOrder (ordered lists per rail)
       migrate: (persisted: unknown) => {
         // Drop the obsolete railOf; railOrder falls back to the default via merge.

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -16,29 +16,18 @@ import type { SettingsTab } from "../settings/SettingsSurface";
 
 // Per-agent layout (ADR 0042). Each fleet agent keeps its OWN layout — rail order, widths,
 // active surface, plugins out. In the single-agent product that fell out for free (each agent
-// is its own origin → its own localStorage); the unified console (one origin + the /active
-// proxy) collapses that, so we namespace the persisted key by the active agent instead. The
-// switcher calls setLayoutAgent(name) + useUI.persist.rehydrate() on a switch, so flipping
-// agents loads that agent's saved layout. Empty = single-agent (the legacy un-suffixed key).
-const _ACTIVE_AGENT_KEY = "protoagent.activeAgent";
-// Read synchronously at module load so the store hydrates from the right agent's key on
-// reload (no flash / no race with the async fleet fetch).
+// is its own origin → its own localStorage); the unified console collapses that, so we namespace
+// the persisted key by the agent. With slug routing (ADR 0042) the agent IS the URL slug
+// (/app/agent/<slug>/), so derive the layout key from the URL at module load — each window keys
+// its own layout, deterministically, no switch event needed. host = the legacy un-suffixed key.
 let _layoutAgent = (() => {
   try {
-    return globalThis.localStorage.getItem(_ACTIVE_AGENT_KEY) || "";
+    const m = globalThis.location?.pathname?.match(/\/agent\/([^/?#]+)/);
+    return m ? decodeURIComponent(m[1]) : "";
   } catch {
     return "";
   }
 })();
-export function setLayoutAgent(name: string) {
-  _layoutAgent = name || "";
-  try {
-    if (_layoutAgent) globalThis.localStorage.setItem(_ACTIVE_AGENT_KEY, _layoutAgent);
-    else globalThis.localStorage.removeItem(_ACTIVE_AGENT_KEY);
-  } catch {
-    /* no-op */
-  }
-}
 const _layoutStorage = createJSONStorage(() => ({
   getItem: (name: string) => globalThis.localStorage.getItem(_layoutAgent ? `${name}:${_layoutAgent}` : name),
   setItem: (name: string, value: string) =>

--- a/apps/web/src/vite-env.d.ts
+++ b/apps/web/src/vite-env.d.ts
@@ -1,1 +1,5 @@
 /// <reference types="vite/client" />
+
+// @protolabsai/ui ships source (`./src/*.tsx`), so we typecheck its deps too. culori
+// (used by the DS ThemePanel) ships no types — declare it so tsc doesn't choke.
+declare module "culori";

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,11 +16,11 @@ export default defineConfig(({ mode }) => {
         "/api": apiBase,
         "/a2a": apiBase,
         "/v1": apiBase,
-        // The fleet hub's reverse proxy to the focused agent (ADR 0042). When a peer is
-        // active, the console rewrites agent calls to /active/* (XHR AND plugin-view iframe
-        // srcs). In prod the backend serves /active; the dev server must proxy it too, else
-        // every switched-into call (and iframe) 404s on Vite's /app/ base.
-        "/active": apiBase,
+        // The fleet hub's per-agent reverse proxy (ADR 0042 slug routing). A console window on
+        // /app/agent/<slug>/ rewrites agent calls to /agents/<slug>/* (XHR AND plugin-view iframe
+        // srcs). In prod the backend serves /agents; the dev server must proxy it too, else every
+        // call (and iframe) from a peer window 404s on Vite's /app/ base.
+        "/agents": apiBase,
         // Plugin-contributed views are iframes the backend serves at /plugins/<id>/…
         // (ADR 0026). In prod the backend serves /app + /plugins together; the dev
         // server must proxy them too, else a plugin view 404s on Vite's /app/ base.

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -16,6 +16,11 @@ export default defineConfig(({ mode }) => {
         "/api": apiBase,
         "/a2a": apiBase,
         "/v1": apiBase,
+        // The fleet hub's reverse proxy to the focused agent (ADR 0042). When a peer is
+        // active, the console rewrites agent calls to /active/* (XHR AND plugin-view iframe
+        // srcs). In prod the backend serves /active; the dev server must proxy it too, else
+        // every switched-into call (and iframe) 404s on Vite's /app/ base.
+        "/active": apiBase,
         // Plugin-contributed views are iframes the backend serves at /plugins/<id>/…
         // (ADR 0026). In prod the backend serves /app + /plugins together; the dev
         // server must proxy them too, else a plugin view 404s on Vite's /app/ base.

--- a/docs/adr/0042-fleet-supervisor-unified-console.md
+++ b/docs/adr/0042-fleet-supervisor-unified-console.md
@@ -134,6 +134,50 @@ and headless never diverge.
 Net: the desktop just **renders the control plane the CLI already drives** — one model, two
 front-ends.
 
+### I. Remote fleet members — agents on other machines
+
+The slices above manage **local** agents: the supervisor `run_exec`s a subprocess on *this*
+host, tracks it by pid, and the proxy forwards to `127.0.0.1:<port>`. But the model already
+generalizes to **remote** protoAgents on other machines — the only thing that's intrinsically
+local is *process spawning*. Everything else is address-based:
+
+- **Each agent is already an independent A2A endpoint** (the `a2a` field is a URL). Nothing
+  makes it loopback-only — point it at `https://host:port` and agent↔agent `delegate_to`
+  works cross-machine today.
+- **The reverse proxy is address-based** — `/active/*` forwards to "the active agent's
+  address." Localhost now; a remote `host:port` needs no console change.
+- **The host already self-registers** as a first-class agent (`host: true`) — a *remote*
+  member is the same idea with `remote: true` and a non-local address.
+
+**A remote member is *registered*, not spawned.** Add it by URL + token (not create+launch):
+
+- **Agent kind** — `supervisor.status()` gains a `remote: true` member kind: `{name, kind:
+  "remote", url, running, a2a: <url>/a2a}`. No local pid.
+- **Status** — health is a poll of the remote's `GET /api/runtime/status` (+ the hub token),
+  not the local `_alive(pid)` probe. Unreachable ⇒ `running: false` (same UX as a crash).
+- **Lifecycle** — you can't `kill` a remote process. Two tiers: (a) **register-only** — the
+  remote runs itself; the hub bookmarks + proxies + monitors it, no start/stop; (b) **remote
+  hub** — if the other machine runs its *own* fleet hub, start/stop proxies to *its*
+  control-plane API (turtles all the way down).
+- **Transport/auth** — real network now: TLS + a per-remote token (reuse the existing A2A /
+  console bearer-gate). The proxy attaches the token on forward.
+
+**Relationship to the delegate registry (ADR 0025).** protoAgent *already* connects to remote
+agents — `delegate_to` over a2a/openai/acp (Settings → Integrations). That's the **delegation**
+axis (hand a remote a task). The fleet is the **management** axis (switch your console *into* an
+agent, see its status, control its lifecycle). Remote fleet members are the **convergence**: a
+registered remote could surface in *both* — delegate to it as a peer **and** focus the console
+on it. A future cleanup is one registry feeding both views.
+
+**Frontend is mostly free** — the panels render `/api/fleet`; a remote agent is just an agent
+with a remote address + `remote: true`. Show a "remote" tag (like the `host` tag), gate
+start/stop on the lifecycle tier, and the switcher's address swap already routes through the
+proxy. The only real new UI is the **"add remote agent"** form (URL + token) alongside "+ New."
+
+Honest scope: this is **not built** — it's the designed-for next axis. The proxy +
+independent-endpoint + self-registration design were chosen so it's an extension, not a
+rewrite.
+
 ## Options considered
 
 - **Separate consoles per agent** (ADR 0041 slice-4 simple) — navigate to each agent's own
@@ -166,6 +210,10 @@ front-ends.
 3. **Switcher UI** — the agent-name dropdown (list, status, switch, start/stop) over the API.
 4. **Archetypes** — `GET /api/archetypes` + the "+ New agent" picker → create-from-archetype.
 5. **Keep-alive policy** — keep-N-warm + resume, lifecycle polish.
+6. **Remote fleet members** (§I, *not yet built*) — a `remote: true` agent kind registered by
+   URL+token: status via the remote's `/api/runtime/status`, proxy-to-remote with the bearer,
+   register-only lifecycle first (remote-hub start/stop later), an "add remote agent" form, and
+   convergence with the delegate registry (ADR 0025).
 
 Slices 1–3 deliver the core (switch between running agents in one console); 4 adds the
-starter-type creation flow; 5 makes it scale.
+starter-type creation flow; 5 makes it scale; 6 extends the fleet across machines.

--- a/docs/dev/fleet-frontend-handoff.md
+++ b/docs/dev/fleet-frontend-handoff.md
@@ -1,0 +1,135 @@
+# Fleet console — front-end handoff (ADR 0042)
+
+For whoever builds the native-app fleet panels. The **backend control plane is live**
+(protoAgent PR #787) — you can build the onboarding / switcher / fleet-manager panels
+against it **today**. This doc is the contract + the task split + what's still backend-pending.
+
+Read alongside: [ADR 0042](../adr/0042-fleet-supervisor-unified-console.md) (§B API, §E switcher,
+§H native desktop) and the [Fleet guide](../guides/fleet.md).
+
+---
+
+## 1. The API you code against (live now — #787)
+
+All JSON. Errors come back as **HTTP 400** with `{"detail": "<readable message>"}` — show it
+inline, never expect a 500 for user error.
+
+| Method & path | Body / query | Returns |
+|---|---|---|
+| `GET /api/fleet` | — | `{agents: [Agent]}` |
+| `POST /api/fleet` | `{name, bundle?, port?, start?=true, shared_skills?}` | `{ok, agent: Agent, installed: [pluginId]}` |
+| `POST /api/fleet/{name}/start` | — | `{ok, agent: Agent}` |
+| `POST /api/fleet/{name}/stop` | — | `{ok, name, stopped: true}` |
+| `DELETE /api/fleet/{name}` | `?purge=true` (also wipe its data) | `{ok, name, removed: [...]}` |
+| `GET /api/archetypes` | — | `{archetypes: [Archetype]}` |
+
+```ts
+type Agent = {
+  name: string;          // also the instance id; unique, [A-Za-z0-9-_]
+  id: string;
+  port: number;
+  pid: number | null;    // null when stopped
+  running: boolean;
+  bundle: string;        // "" for a Basic agent
+};
+
+type Archetype = {
+  id: string;            // "basic", or a bundle id e.g. "pm-stack"
+  label: string;         // "Basic", "Project Manager"
+  icon: string;          // lucide-react icon name (e.g. "Sparkles", "LayoutGrid")
+  blurb: string;
+  bundle: string | null; // null = Basic (no bundle); else the bundle git URL to pass to create
+};
+```
+
+**Create flow:** the archetype picker lists `GET /api/archetypes`; on submit, `POST /api/fleet`
+with `{name, bundle: archetype.bundle}` (omit/`null` bundle = Basic). `start: true` (default)
+creates **and** launches it. Creating from a bundle clones+installs it (a few seconds) — show a
+spinner; the request returns when the agent is up.
+
+---
+
+## 2. Panels to build (parallelizable now)
+
+All three are buildable against the API above with **no backend dependency** beyond #787.
+
+1. **Onboarding / "New agent"** — archetype cards from `GET /api/archetypes` (render `icon` via
+   lucide-react, `label`, `blurb`) → name field → `POST /api/fleet`. First-run shows this instead
+   of the single-agent setup wizard; it's also the "+ New agent" target from the switcher.
+2. **Fleet manager** (Settings → **Agents**) — `GET /api/fleet` rows with a status dot
+   (`running`), port, pid; per-row **Start** / **Stop** (`/start`,`/stop`) and **Remove**
+   (`DELETE`, with a purge confirm); a **+ New** that opens panel 1. Poll `GET /api/fleet` (~3s) or
+   refetch after each action.
+3. **Topbar switcher** — the agent-name dropdown: `GET /api/fleet` list + status dots + "+ New
+   agent". You can build the **list + selection UI** now; the actual *view-switch* lands with the
+   proxy (§3).
+
+Per-agent **config** is **not new** — it's the existing Settings drawer (model/plugins/secrets),
+just pointed at the active agent's workspace. No new panel needed.
+
+---
+
+## 3. In-place switch — **live now** (#788)
+
+The switcher's actual *view-switch* is ready:
+
+```
+POST /api/fleet/{name}/activate   point the console proxy at a running agent
+GET  /api/fleet/active            → {active: <name>|null}   (also on GET /api/fleet)
+ANY  /active/<path>               reverse-proxy the console to the active agent
+```
+
+- Talk to the **active** agent via the **`/active/<path>`** prefix: chat → `/active/api/chat`,
+  SSE → `/active/api/events`. Switching = one `activate` call; the caller's URL never changes.
+- `409` if nothing is active, `502` if the active agent died — surface either inline.
+- **Two planes:** `/active/*` is the human's lens only. Each agent stays an **independent A2A
+  endpoint on its own port** (`GET /api/fleet` exposes each agent's `a2a` URL), reachable
+  regardless of focus — so agent↔agent `delegate_to` goes direct, never through the proxy.
+
+## 3a. Per-agent theme — **live now** (#789)
+
+Each agent saves its own look; the switch repaints automatically because theme reads/writes go
+through the proxy to the focused agent.
+
+```
+GET    /active/api/theme    → {theme: <blob>|null}   the focused agent's saved theme
+PUT    /active/api/theme    {theme:{...}} | <blob>   persist it
+DELETE /active/api/theme                              reset to defaults
+```
+
+- **Pull the ThemePanel over** (@protolabsai/ui 0.17.0).
+- **On focus / after `activate`** → `GET /active/api/theme`; apply the blob if non-null, else
+  defaults — so each agent shows its own theme.
+- **On ThemePanel save** → `PUT /active/api/theme` with the token blob.
+- Storage is **opaque** — the panel owns the token schema; the server just round-trips the JSON,
+  so new tokens/formats (oklch, rgba, …) need no server change.
+
+## 3b. Still backend-pending
+
+- **Tauri shell as hub** (desktop/Rust) — spawning agent sidecars + proxy plumbing in the shell is
+  the desktop team's piece (it reuses the existing server-sidecar machinery). The shell can also
+  just sidecar a thin Python hub; either way it talks to the same API above.
+- **Keep-alive policy** (keep-N-warm) — mine, in progress (slice 5). Transparent to the panels.
+
+---
+
+## 4. Notes / gotchas
+
+- **Names** are the identity + the URL path param — validate `[A-Za-z0-9-_]`, non-empty (the
+  server rejects bad names with a 400 you can surface).
+- **Ports** auto-assign if you omit `port`; the panel rarely needs to set one.
+- **Status truth** is `running` (a live-pid probe) — a crashed agent flips to `running:false` on
+  the next `GET /api/fleet`, so polling is the source of truth, not the last action's response.
+- **Icons** are passed as lucide-react names; fall back to a default (e.g. `Package`) if unknown.
+- **Bundle catalog** today = installed bundles + Basic. A "browse more archetypes" catalog (offer
+  uninstalled bundles) is a later enhancement — for now the picker shows Basic + what's installed.
+
+---
+
+## 5. TL;DR task split
+
+| Who | What |
+|---|---|
+| **Front-end (you)** | Onboarding/archetype picker · fleet manager · switcher (list + **switch via `activate`**) · **ThemePanel** wired to `/active/api/theme` — all over live endpoints |
+| **Me (backend)** | ✅ control-plane API (#787) · ✅ reverse proxy + `activate` (#788) · ✅ per-agent theme (#789) · keep-alive policy (slice 5, in progress) |
+| **Desktop/Rust** | Tauri shell as hub: agent sidecars + proxy plumbing (ADR 0042 §H) |

--- a/graph/fleet/discovery.py
+++ b/graph/fleet/discovery.py
@@ -1,0 +1,149 @@
+"""Fleet discovery (ADR 0042 §I) — find OTHER protoAgents to add as remote fleet members.
+
+Two channels, merged:
+  • **Local port-scan** — probe ``127.0.0.1`` ports for ``/.well-known/agent-card.json`` (a
+    co-located agent, e.g. a freshly-spun Roxy on another port).
+  • **mDNS / Bonjour** — every agent advertises a ``_protoagent._tcp`` service on boot; we
+    browse the LAN for siblings on *other* machines.
+
+Pure discovery: returns reachable protoAgents (name + url). Registering one as a remote fleet
+member + proxying into it is the supervisor/proxy's job. All best-effort — a discovery hiccup
+never blocks the server.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import socket
+
+import httpx
+
+log = logging.getLogger(__name__)
+
+_SERVICE_TYPE = "_protoagent._tcp.local."
+_zc = None  # the advertised Zeroconf instance (None until advertise())
+_info = None
+
+
+def _local_ip() -> str:
+    """Best-effort LAN IP (the address other machines reach us on); 127.0.0.1 if offline."""
+    s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+    try:
+        s.connect(("8.8.8.8", 80))  # no packet leaves; just selects the egress interface
+        return s.getsockname()[0]
+    except OSError:
+        return "127.0.0.1"
+    finally:
+        s.close()
+
+
+# ── mDNS advertise (wired into server startup) ────────────────────────────────
+def advertise(name: str, port: int) -> None:
+    """Announce this agent on mDNS so LAN siblings can discover it. Idempotent + best-effort."""
+    global _zc, _info
+    if _zc is not None or not port:
+        return
+    try:
+        from zeroconf import ServiceInfo, Zeroconf
+
+        ip = _local_ip()
+        _info = ServiceInfo(
+            _SERVICE_TYPE,
+            f"{name}.{_SERVICE_TYPE}",
+            addresses=[socket.inet_aton(ip)],
+            port=int(port),
+            properties={"name": name, "v": "1"},
+        )
+        _zc = Zeroconf()
+        _zc.register_service(_info)
+        log.info("[discovery] advertising %s on mDNS (%s:%d)", name, ip, port)
+    except Exception:  # noqa: BLE001 — never block boot on mDNS
+        log.exception("[discovery] mDNS advertise failed — continuing without it")
+        _zc = None
+
+
+def stop_advertise() -> None:
+    global _zc, _info
+    try:
+        if _zc is not None:
+            if _info is not None:
+                _zc.unregister_service(_info)
+            _zc.close()
+    except Exception:  # noqa: BLE001
+        pass
+    finally:
+        _zc, _info = None, None
+
+
+# ── discover ──────────────────────────────────────────────────────────────────
+async def _probe(client: httpx.AsyncClient, host: str, port: int) -> dict | None:
+    """Is there a protoAgent at host:port? Return {name, url, host, port} from its agent-card."""
+    url = f"http://{host}:{port}"
+    try:
+        r = await client.get(f"{url}/.well-known/agent-card.json", timeout=1.0)
+        if r.status_code != 200:
+            return None
+        card = r.json()
+    except (httpx.HTTPError, ValueError):
+        return None
+    return {"name": card.get("name") or f"{host}:{port}", "url": url, "host": host, "port": port}
+
+
+async def _scan_local(port_range: tuple[int, int], skip_ports: set[int]) -> list[dict]:
+    async with httpx.AsyncClient() as client:
+        tasks = [_probe(client, "127.0.0.1", p)
+                 for p in range(port_range[0], port_range[1] + 1) if p not in skip_ports]
+        return [r for r in await asyncio.gather(*tasks) if r]
+
+
+def _browse_mdns(timeout: float) -> list[dict]:
+    """One-shot LAN browse for `_protoagent._tcp` (sync zeroconf — call via asyncio.to_thread)."""
+    found: list[dict] = []
+    try:
+        import time
+
+        from zeroconf import ServiceBrowser, ServiceListener, Zeroconf
+
+        zc = Zeroconf()
+
+        class _L(ServiceListener):
+            def add_service(self, zc_, type_, name):
+                info = zc_.get_service_info(type_, name, timeout=int(timeout * 1000))
+                if not info or not info.addresses:
+                    return
+                ip = socket.inet_ntoa(info.addresses[0])
+                props = info.properties or {}
+                nm = (props.get(b"name") or b"").decode() or name.split(".")[0]
+                found.append({"name": nm, "url": f"http://{ip}:{info.port}", "host": ip, "port": info.port})
+
+            def update_service(self, *a):
+                pass
+
+            def remove_service(self, *a):
+                pass
+
+        ServiceBrowser(zc, _SERVICE_TYPE, _L())
+        time.sleep(timeout)
+        zc.close()
+    except Exception:  # noqa: BLE001
+        log.exception("[discovery] mDNS browse failed")
+    return found
+
+
+async def discover(*, known: set | None = None,
+                   port_range: tuple[int, int] = (7860, 7910), timeout: float = 1.5) -> list[dict]:
+    """Other protoAgents (local + LAN) minus the ones already in the fleet.
+
+    ``known`` is a set of ``(host, port)`` already known (the host itself + existing members);
+    those are filtered out. Returns deduped ``[{name, url, host, port}]``."""
+    known = known or set()
+    skip_local = {p for (h, p) in known if h in ("127.0.0.1", "localhost")}
+    local = await _scan_local(port_range, skip_local)
+    network = await asyncio.to_thread(_browse_mdns, timeout)
+    out: dict[tuple, dict] = {}
+    for a in network + local:  # local wins on a url clash (it's the more specific probe)
+        if (a["host"], a["port"]) in known:
+            continue
+        out[(a["host"], a["port"])] = a
+    return list(out.values())

--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -13,6 +13,7 @@ client is closed when the stream ends.
 from __future__ import annotations
 
 import logging
+import time
 
 import httpx
 from starlette.responses import JSONResponse, StreamingResponse
@@ -46,6 +47,7 @@ def set_active(name: str) -> dict:
     if not supervisor.is_running(name):
         raise supervisor.FleetError(f"{name!r} is not running — start it first")
     _active_path().write_text(name)
+    invalidate_port_cache()  # a switch must take effect at once (#7 cache)
     log.info("[fleet] active agent → %s", name)
     return {"active": name}
 
@@ -56,16 +58,43 @@ def clear_active() -> dict:
     f = _active_path()
     if f.exists():
         f.unlink()
+    invalidate_port_cache()  # focusing the host must take effect at once (#7 cache)
     log.info("[fleet] active agent → host (cleared)")
     return {"active": None}
 
 
+# Active-port cache (#7) — forward() runs per proxied request (every chat POST, panel fetch,
+# SSE), so don't pay a full supervisor.status() scan (workspaces dir + YAML parse + os.kill per
+# pid) each time. Resolve the port straight from the active record with a 1s TTL, invalidated
+# immediately on a switch so a focus change still takes effect at once.
+_port_cache: dict = {"name": None, "port": None, "at": 0.0}
+
+
+def invalidate_port_cache() -> None:
+    _port_cache["at"] = 0.0
+
+
 def _active_port() -> int | None:
-    name = get_active()
-    if not name:
-        return None
-    return next((w["port"] for w in supervisor.status()
-                 if w["name"] == name and w["running"]), None)
+    now = time.monotonic()
+    if now - _port_cache["at"] < 1.0:
+        return _port_cache["port"]
+    name = get_active()  # verifies the agent is still running
+    port = (supervisor._load_state().get(name) or {}).get("port") if name else None
+    _port_cache.update(name=name, port=port, at=now)
+    return port
+
+
+# Shared client (#8) — one pooled AsyncClient instead of a fresh one (TCP setup + FD churn) per
+# request. Unlimited read/write (SSE streams forever) but a finite connect timeout so a peer
+# that accepts then stalls doesn't hang non-streaming requests indefinitely.
+_client: httpx.AsyncClient | None = None
+
+
+def _get_client() -> httpx.AsyncClient:
+    global _client
+    if _client is None or _client.is_closed:
+        _client = httpx.AsyncClient(timeout=httpx.Timeout(None, connect=5.0))
+    return _client
 
 
 async def forward(request, path: str):
@@ -81,14 +110,13 @@ async def forward(request, path: str):
     body = await request.body()
     headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP}
 
-    client = httpx.AsyncClient(timeout=httpx.Timeout(None))
+    client = _get_client()
     upstream_req = client.build_request(
         request.method, url, headers=headers, content=body,
         params=dict(request.query_params))
     try:
         upstream = await client.send(upstream_req, stream=True)
     except httpx.ConnectError:
-        await client.aclose()
         return JSONResponse({"detail": "active agent is not reachable"}, status_code=502)
 
     async def _pipe():
@@ -96,8 +124,7 @@ async def forward(request, path: str):
             async for chunk in upstream.aiter_raw():
                 yield chunk
         finally:
-            await upstream.aclose()
-            await client.aclose()
+            await upstream.aclose()  # close the response, not the shared client
 
     resp_headers = {k: v for k, v in upstream.headers.items() if k.lower() not in _HOP}
     return StreamingResponse(_pipe(), status_code=upstream.status_code, headers=resp_headers)

--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -50,6 +50,16 @@ def set_active(name: str) -> dict:
     return {"active": name}
 
 
+def clear_active() -> dict:
+    """Focus the host (this instance) — drop the proxy pointer so the console talks to
+    ``/api`` directly again, with no peer focused (ADR 0042)."""
+    f = _active_path()
+    if f.exists():
+        f.unlink()
+    log.info("[fleet] active agent → host (cleared)")
+    return {"active": None}
+
+
 def _active_port() -> int | None:
     name = get_active()
     if not name:

--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -97,15 +97,29 @@ def _get_client() -> httpx.AsyncClient:
     return _client
 
 
-async def forward(request, path: str):
-    """Reverse-proxy ``request`` to ``/<path>`` on the active agent, streaming the
-    response back (SSE-safe). 409 if no agent is active."""
-    port = _active_port()
-    if port is None:
-        return JSONResponse(
-            {"detail": "no active agent — start one and POST /api/fleet/{name}/activate"},
-            status_code=409)
+# Per-slug port resolution (ADR 0042 slug routing) — each console window targets an agent by URL
+# slug (/agents/<slug>/…) instead of a single global "active". 'host' = this instance; a peer =
+# its workspace port. 1s TTL cache, keyed by slug, to keep the proxy hot path cheap.
+_slug_cache: dict = {}
 
+
+def _port_for_slug(slug: str) -> int | None:
+    now = time.monotonic()
+    hit = _slug_cache.get(slug)
+    if hit and now - hit[1] < 1.0:
+        return hit[0]
+    if slug == "host":
+        from runtime.state import STATE
+        port = getattr(STATE, "active_port", None)
+    else:
+        rec = supervisor._load_state().get(slug)
+        port = rec.get("port") if rec and supervisor._alive(rec.get("pid")) else None
+    _slug_cache[slug] = (port, now)
+    return port
+
+
+async def _forward_to_port(port: int, request, path: str):
+    """Stream-proxy ``request`` to ``/<path>`` on 127.0.0.1:<port> (SSE-safe)."""
     url = f"http://127.0.0.1:{port}/{path}"
     body = await request.body()
     headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP}
@@ -116,8 +130,8 @@ async def forward(request, path: str):
         params=dict(request.query_params))
     try:
         upstream = await client.send(upstream_req, stream=True)
-    except httpx.ConnectError:
-        return JSONResponse({"detail": "active agent is not reachable"}, status_code=502)
+    except (httpx.ConnectError, httpx.ConnectTimeout):
+        return JSONResponse({"detail": "agent is not reachable"}, status_code=502)
 
     async def _pipe():
         try:
@@ -128,3 +142,23 @@ async def forward(request, path: str):
 
     resp_headers = {k: v for k, v in upstream.headers.items() if k.lower() not in _HOP}
     return StreamingResponse(_pipe(), status_code=upstream.status_code, headers=resp_headers)
+
+
+async def forward_to(slug: str, request, path: str):
+    """Reverse-proxy to the agent named by ``slug`` (/agents/<slug>/* route, ADR 0042 slug
+    routing). ``host`` targets this instance; 409 if the agent isn't running."""
+    port = _port_for_slug(slug)
+    if port is None:
+        return JSONResponse({"detail": f"agent {slug!r} is not running"}, status_code=409)
+    return await _forward_to_port(port, request, path)
+
+
+async def forward(request, path: str):
+    """Reverse-proxy to the single active agent (back-compat /active/* route, superseded by
+    /agents/<slug>/* slug routing). 409 if no agent is active."""
+    port = _active_port()
+    if port is None:
+        return JSONResponse(
+            {"detail": "no active agent — start one and POST /api/fleet/{name}/activate"},
+            status_code=409)
+    return await _forward_to_port(port, request, path)

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -18,8 +18,10 @@ import os
 import signal
 import subprocess
 import time
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
+
+from filelock import FileLock, Timeout
 
 from graph.workspaces import manager
 
@@ -32,6 +34,29 @@ class FleetError(Exception):
 
 def _state_path() -> Path:
     return manager.workspaces_root() / "fleet.json"
+
+
+def _state_lock() -> FileLock:
+    """Cross-process lock around fleet.json read-modify-write (#12) — the hub, the CLI, and
+    concurrent requests all touch it, and an unlocked load-modify-save can drop entries."""
+    return FileLock(str(_state_path()) + ".lock", timeout=5)
+
+
+def _is_our_agent(pid: int) -> bool:
+    """PID-reuse guard (#10): fleet.json survives reboots, so a recycled pid can make a dead
+    agent look alive — and stop() could SIGKILL whatever unrelated process now owns it. Only
+    treat/kill a pid as ours if its command line is actually a protoAgent server. Best-effort:
+    if we can't inspect it, fall back to trusting the pid (don't break stop on odd platforms)."""
+    try:
+        out = subprocess.run(
+            ["ps", "-o", "command=", "-p", str(pid)],
+            capture_output=True, text=True, timeout=2,
+        ).stdout
+    except (OSError, subprocess.SubprocessError):
+        return True
+    if not out.strip():
+        return False  # pid not found
+    return "-m server" in out or ("python" in out.lower() and "server" in out)
 
 
 def _load_state() -> dict:
@@ -78,48 +103,60 @@ def start(name: str) -> dict:
     if ws is None:
         raise FleetError(f"no workspace {name!r} — create it: workspace new {name}")
 
-    state = _load_state()
-    rec = state.get(name)
-    if rec and _alive(rec.get("pid")):
-        return {**rec, "name": name, "running": True, "already": True}
+    with _state_lock():
+        state = _load_state()
+        rec = state.get(name)
+        if rec and _alive(rec.get("pid")):
+            return {**rec, "name": name, "running": True, "already": True}
 
-    env, argv = manager.run_exec(name, ["--ui", "none"])
-    full_env = {**os.environ, **env}
-    log_path = _log_path(name)
-    log_path.parent.mkdir(parents=True, exist_ok=True)
-    logf = open(log_path, "a")  # noqa: SIM115 — handed to the child; closed on its exit
-    # start_new_session detaches it from this CLI's process group so it survives exit.
-    proc = subprocess.Popen(argv, env=full_env, stdout=logf, stderr=logf, start_new_session=True)
-    now = datetime.now(timezone.utc).isoformat()
-    rec = {"pid": proc.pid, "port": ws.get("port"), "id": ws.get("id", name),
-           "started_at": now, "last_active": now, "log": str(log_path)}
-    state[name] = rec
-    _save_state(state)
+        env, argv = manager.run_exec(name, ["--ui", "none"])
+        full_env = {**os.environ, **env}
+        log_path = _log_path(name)
+        log_path.parent.mkdir(parents=True, exist_ok=True)
+        logf = open(log_path, "a")  # noqa: SIM115 — handed to the child; closed on its exit
+        # start_new_session detaches it from this CLI's process group so it survives exit.
+        proc = subprocess.Popen(argv, env=full_env, stdout=logf, stderr=logf, start_new_session=True)
+        now = datetime.now(timezone.utc).isoformat()
+        rec = {"pid": proc.pid, "port": ws.get("port"), "id": ws.get("id", name),
+               "started_at": now, "last_active": now, "log": str(log_path)}
+        state[name] = rec
+        _save_state(state)
     log.info("[fleet] started %s (pid %d, :%s)", name, proc.pid, rec["port"])
     return {**rec, "name": name, "running": True, "already": False}
 
 
 def stop(name: str, *, timeout: float = 8.0) -> dict:
-    """SIGTERM the agent and reap its registry entry (SIGKILL if it lingers)."""
+    """SIGTERM the agent and reap its registry entry (SIGKILL if it lingers).
+
+    NOTE: this blocks (busy-wait) up to ``timeout`` — call it off the event loop
+    (``asyncio.to_thread``); the routes do. The registry entry is removed under the lock
+    first, then the kill happens OUTSIDE the lock so the wait can't freeze other state ops.
+    """
     name = manager._safe(name)
-    state = _load_state()
-    rec = state.get(name)
-    if not rec or not _alive(rec.get("pid")):
-        state.pop(name, None)
+    with _state_lock():
+        state = _load_state()
+        rec = state.get(name)
+        if not rec or not _alive(rec.get("pid")):
+            state.pop(name, None)
+            _save_state(state)
+            raise FleetError(f"{name!r} is not running")
+        pid = int(rec["pid"])
+        state.pop(name, None)  # reserve the stop while we hold the lock
         _save_state(state)
-        raise FleetError(f"{name!r} is not running")
-    pid = int(rec["pid"])
-    try:
-        os.kill(pid, signal.SIGTERM)
-        deadline = time.monotonic() + timeout
-        while _alive(pid) and time.monotonic() < deadline:
-            time.sleep(0.2)
-        if _alive(pid):
-            os.kill(pid, signal.SIGKILL)
-    except OSError:
-        pass
-    state.pop(name, None)
-    _save_state(state)
+    # Kill outside the lock. Verify the pid is actually our agent first (#10 — a recycled
+    # pid after a reboot could otherwise get SIGKILLed even though it's unrelated).
+    if _is_our_agent(pid):
+        try:
+            os.kill(pid, signal.SIGTERM)
+            deadline = time.monotonic() + timeout
+            while _alive(pid) and time.monotonic() < deadline:
+                time.sleep(0.2)
+            if _alive(pid):
+                os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+    else:
+        log.warning("[fleet] %s pid %d is not our agent (pid reuse?) — reaped entry, no kill", name, pid)
     log.info("[fleet] stopped %s (pid %d)", name, pid)
     return {"name": name, "stopped": True}
 
@@ -150,15 +187,19 @@ def _host_entry() -> dict:
 
 def status() -> list[dict]:
     """The host (this instance) + every workspace, with live status (running/stopped)."""
-    state = _load_state()
-    dirty = False
+    with _state_lock():
+        state = _load_state()
+        dirty = False
+        for name in list(state):  # prune dead entries under the lock (#12 — atomic cleanup)
+            if not _alive(state[name].get("pid")):
+                state.pop(name, None)
+                dirty = True
+        if dirty:
+            _save_state(state)
     out: list[dict] = [_host_entry()]
     for ws in manager.list_workspaces():
         rec = state.get(ws["name"]) or {}
         running = _alive(rec.get("pid"))
-        if rec and not running:  # stale entry — agent died; clean it
-            state.pop(ws["name"], None)
-            dirty = True
         port = ws.get("port")
         out.append({"name": ws["name"], "id": ws.get("id", ws["name"]),
                     "port": port, "pid": rec.get("pid") if running else None,
@@ -168,8 +209,6 @@ def status() -> list[dict]:
                     # focused agent can `delegate_to` an unfocused sibling here. Live only
                     # while running, but the address is stable.
                     "a2a": f"http://127.0.0.1:{port}/a2a" if port else None})
-    if dirty:
-        _save_state(state)
     return out
 
 
@@ -208,11 +247,12 @@ def max_warm() -> int:
 def touch(name: str) -> None:
     """Mark an agent as most-recently-active (drives LRU eviction)."""
     name = manager._safe(name)
-    state = _load_state()
-    rec = state.get(name)
-    if rec:
-        rec["last_active"] = datetime.now(timezone.utc).isoformat()
-        _save_state(state)
+    with _state_lock():
+        state = _load_state()
+        rec = state.get(name)
+        if rec:
+            rec["last_active"] = datetime.now(timezone.utc).isoformat()
+            _save_state(state)
 
 
 def enforce_warm_cap(keep: int | None = None, *, protect: str | None = None) -> list[str]:
@@ -224,9 +264,17 @@ def enforce_warm_cap(keep: int | None = None, *, protect: str | None = None) -> 
     running = [(n, r) for n, r in _load_state().items() if _alive(r.get("pid"))]
     if len(running) <= keep:
         return []
-    # Oldest last_active first; the protected agent is never a candidate.
+    # Oldest last_active first; the protected target is never a candidate. Grace window (#13):
+    # an agent touched within PROTOAGENT_FLEET_WARM_GRACE seconds is spared too — it may be mid
+    # background turn. (Beyond the grace, eviction can interrupt a turn; the session resumes
+    # from its instance.id-scoped checkpoint on the next switch — that's by design.)
     running.sort(key=lambda kv: kv[1].get("last_active", ""))
-    candidates = [n for n, _ in running if n != protect]
+    # Opt-in grace (default 0 = pure LRU, unchanged): a positive value spares agents touched
+    # within that window, trading a temporarily-over-cap fleet for not killing a recently-active
+    # (possibly mid-turn) agent. Off by default so rapid switching still bounds the warm set.
+    grace = int(os.environ.get("PROTOAGENT_FLEET_WARM_GRACE", "0") or "0")
+    cutoff = (datetime.now(timezone.utc) - timedelta(seconds=grace)).isoformat()
+    candidates = [n for n, r in running if n != protect and r.get("last_active", "") < cutoff]
     evicted: list[str] = []
     for n in candidates[: len(running) - keep]:
         try:

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -21,7 +21,7 @@ import time
 from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
-from filelock import FileLock, Timeout
+from filelock import FileLock
 
 from graph.workspaces import manager
 

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -124,11 +124,35 @@ def stop(name: str, *, timeout: float = 8.0) -> dict:
     return {"name": name, "stopped": True}
 
 
+def _host_entry() -> dict:
+    """The instance serving this console — the agent you're *in* (ADR 0042). Always
+    present + running, marked ``host: True`` so it can't be stopped/removed from within
+    itself. This is the "single agent, like before" you manage until you add peers, so the
+    fleet is never empty (you're always at least one — yourself)."""
+    import os
+
+    from runtime.state import STATE
+
+    cfg = getattr(STATE, "graph_config", None)
+    name = getattr(cfg, "identity_name", "") or "main"
+    port = getattr(STATE, "active_port", None)
+    return {
+        "name": name,
+        "id": getattr(cfg, "instance_id", "") or name,
+        "port": port,
+        "pid": os.getpid(),
+        "running": True,
+        "bundle": "",
+        "host": True,
+        "a2a": f"http://127.0.0.1:{port}/a2a" if port else None,
+    }
+
+
 def status() -> list[dict]:
-    """Every workspace + its live status (running/stopped, pid, port)."""
+    """The host (this instance) + every workspace, with live status (running/stopped)."""
     state = _load_state()
     dirty = False
-    out: list[dict] = []
+    out: list[dict] = [_host_entry()]
     for ws in manager.list_workspaces():
         rec = state.get(ws["name"]) or {}
         running = _alive(rec.get("pid"))

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -189,7 +189,7 @@ def _overlay_model(cfg: Path, ws: Path, src: str) -> None:
     new = load_yaml_doc(cfg)
     if isinstance(host, dict) and isinstance(new, dict) and host.get("model"):
         new["model"] = host["model"]
-        save_yaml_doc(cfg, new)
+        save_yaml_doc(new, cfg)
     src_sec = (src_path if src_path.is_dir() else src_path.parent) / "secrets.yaml"
     if src_sec.exists():  # carries the api_key so the gateway actually works
         shutil.copyfile(src_sec, ws / "secrets.yaml")

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -183,13 +183,17 @@ def _overlay_model(cfg: Path, ws: Path, src: str) -> None:
     src_cfg = src_path / "langgraph-config.yaml" if src_path.is_dir() else src_path
     if not src_cfg.exists():
         return
+    import yaml
+
     from graph.config_io import load_yaml_doc, save_yaml_doc
 
-    host = load_yaml_doc(src_cfg)
+    # Read the host's model as PLAIN data (not ruamel) — a ruamel node carries a parent ref and
+    # can't be grafted into another document. The destination stays ruamel (comment-preserving).
+    host = yaml.safe_load(src_cfg.read_text()) or {}
     new = load_yaml_doc(cfg)
     if isinstance(host, dict) and isinstance(new, dict) and host.get("model"):
         new["model"] = host["model"]
-        save_yaml_doc(new, cfg)
+        save_yaml_doc(new, cfg)  # save_yaml_doc(doc, path) — doc first
     src_sec = (src_path if src_path.is_dir() else src_path.parent) / "secrets.yaml"
     if src_sec.exists():  # carries the api_key so the gateway actually works
         shutil.copyfile(src_sec, ws / "secrets.yaml")

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -139,16 +139,22 @@ def create(name: str, *, from_config: str | None = None, bundle: str | None = No
         if shared_skills:
             _stamp_identity(cfg, name, True)
 
+    import yaml
     assigned = _pick_port(port)
     rec = {"id": name, "name": name, "port": assigned,
            "created": datetime.now(timezone.utc).isoformat(), "bundle": bundle or ""}
-
-    installed: list[str] = []
-    if bundle:
-        installed = _install_bundle_into(ws, bundle)
-
-    import yaml
+    # Reserve the port NOW — write workspace.yaml BEFORE the (possibly minutes-long) bundle
+    # install, so a concurrent create can't _pick_port the same port (#11). Then clean up the
+    # whole dir on any failure, so a retry doesn't 400 with "already exists" on a poisoned
+    # workspace that's invisible in the list (no workspace.yaml).
     (ws / "workspace.yaml").write_text(yaml.safe_dump(rec, sort_keys=False))
+    installed: list[str] = []
+    try:
+        if bundle:
+            installed = _install_bundle_into(ws, bundle)
+    except Exception:
+        shutil.rmtree(ws, ignore_errors=True)
+        raise
     return {**rec, "path": str(ws), "installed": installed}
 
 

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -75,6 +75,14 @@ def _pick_port(explicit: int | None) -> int:
     if explicit:
         return int(explicit)
     used = {w["port"] for w in list_workspaces() if w.get("port")}
+    # Don't collide with the HUB itself — the host instance (this process) self-registers as a
+    # fleet agent on its own port but isn't a workspace, so it's invisible to list_workspaces().
+    try:
+        from runtime.state import STATE
+        if getattr(STATE, "active_port", None):
+            used.add(int(STATE.active_port))
+    except Exception:  # noqa: BLE001 — best-effort; CLI/no-STATE context just skips it
+        pass
     p = PORT_BASE + 1
     while p in used:
         p += 1

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -26,6 +26,13 @@ class WorkspaceError(Exception):
     """A workspace op was rejected (bad name, collision, missing workspace)."""
 
 
+# Names that collide with the fleet's routing vocabulary (ADR 0042 slug routing). `host` is the
+# reserved slug that addresses THIS instance (`/app/agent/host/` / `/agents/host/*`); a workspace
+# named `host` would shadow it → the peer is permanently unreachable + two switcher entries both
+# claim to be current. Reject at creation.
+_RESERVED_NAMES = {"host"}
+
+
 def workspaces_root() -> Path:
     """Where workspaces live. ``PROTOAGENT_WORKSPACES_DIR`` overrides; default
     ``~/.protoagent/workspaces``."""
@@ -131,6 +138,8 @@ def create(name: str, *, from_config: str | None = None, inherit_model: str | No
       * neither — the plain blank template.
     """
     name = _safe(name)
+    if name.lower() in _RESERVED_NAMES:
+        raise WorkspaceError(f"{name!r} is reserved — it's how the fleet addresses this instance")
     ws = _ws_dir(name)
     if ws.exists():
         raise WorkspaceError(f"workspace {name!r} already exists at {ws}")

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -118,11 +118,18 @@ plugins:
 """
 
 
-def create(name: str, *, from_config: str | None = None, bundle: str | None = None,
-           port: int | None = None, shared_skills: bool = False) -> dict:
+def create(name: str, *, from_config: str | None = None, inherit_model: str | None = None,
+           bundle: str | None = None, port: int | None = None, shared_skills: bool = False) -> dict:
     """Scaffold a workspace: its config dir, ``workspace.yaml``, and (with ``bundle``)
-    an installed plugin bundle. Does not start it. ``from_config`` clones an existing
-    agent's config + secrets as the base (instance.id/identity are re-stamped to *name*)."""
+    an installed plugin bundle. Does not start it.
+
+    Config base, in precedence:
+      * ``from_config`` — a FULL clone of another agent's config + secrets (identity re-stamped).
+      * ``inherit_model`` — a BLANK template, but with only that agent's ``model:`` section +
+        secrets popped over (the gateway), so it boots ready-to-chat WITHOUT inheriting its
+        plugins/skills. This is the fleet's default "new agent" (a blank agent, model carried).
+      * neither — the plain blank template.
+    """
     name = _safe(name)
     ws = _ws_dir(name)
     if ws.exists():
@@ -144,6 +151,8 @@ def create(name: str, *, from_config: str | None = None, bundle: str | None = No
     else:
         cfg.write_text(_CONFIG_TEMPLATE.format(name=name))
         (ws / "secrets.yaml").write_text("# Per-workspace secrets overlay.\n")
+        if inherit_model:
+            _overlay_model(cfg, ws, inherit_model)  # gateway only — not plugins/skills
         if shared_skills:
             _stamp_identity(cfg, name, True)
 
@@ -164,6 +173,26 @@ def create(name: str, *, from_config: str | None = None, bundle: str | None = No
         shutil.rmtree(ws, ignore_errors=True)
         raise
     return {**rec, "path": str(ws), "installed": installed}
+
+
+def _overlay_model(cfg: Path, ws: Path, src: str) -> None:
+    """Pop only the ``model:`` section + secrets from another agent's config into this blank one
+    — the gateway (provider/api_base/key) carries over so the agent boots ready-to-chat, but its
+    plugins/skills/identity stay the blank-template defaults. Best-effort + comment-preserving."""
+    src_path = Path(src).expanduser()
+    src_cfg = src_path / "langgraph-config.yaml" if src_path.is_dir() else src_path
+    if not src_cfg.exists():
+        return
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+
+    host = load_yaml_doc(src_cfg)
+    new = load_yaml_doc(cfg)
+    if isinstance(host, dict) and isinstance(new, dict) and host.get("model"):
+        new["model"] = host["model"]
+        save_yaml_doc(cfg, new)
+    src_sec = (src_path if src_path.is_dir() else src_path.parent) / "secrets.yaml"
+    if src_sec.exists():  # carries the api_key so the gateway actually works
+        shutil.copyfile(src_sec, ws / "secrets.yaml")
 
 
 def _stamp_identity(cfg: Path, name: str, shared_skills: bool) -> None:

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -82,28 +82,28 @@ def register_fleet_routes(app) -> None:
 
         Body: ``{name, bundle?: <git-url>, port?: int, start?: bool=true,
         shared_skills?: bool, inherit_config?: bool=true}``. A blank ``bundle`` is the built-in
-        **Basic** archetype. By default a new agent **inherits the host's model config + secrets**
-        (re-stamped to its own identity) so it boots ready-to-chat on the same gateway — set
-        ``inherit_config: false`` for a blank agent you'll configure yourself.
+        **Basic** archetype. By default a new agent is a **blank agent with the host's model
+        config + secrets popped over** (the gateway only — NOT the host's plugins/skills), so it
+        boots ready-to-chat. Set ``inherit_config: false`` for a fully blank agent you'll set up.
         """
         name = str(body.get("name", "")).strip()
         bundle = (str(body.get("bundle") or "").strip()) or None
         port = body.get("port")
         start = bool(body.get("start", True))
         shared = bool(body.get("shared_skills", False))
-        # Inherit the host's config so peers work immediately — only if the host is actually
-        # configured (a fresh, un-set-up host falls back to the blank template).
-        from_config = None
+        # Carry the host's MODEL only (gateway) so a new agent works immediately without inheriting
+        # its plugins — only if the host is actually configured (fresh host → plain blank template).
+        inherit_model = None
         if bool(body.get("inherit_config", True)):
             from graph.config_io import _live_config_dir
             cfg_dir = _live_config_dir()
             if (cfg_dir / "langgraph-config.yaml").exists():
-                from_config = str(cfg_dir)
+                inherit_model = str(cfg_dir)
         try:
-            # create() may clone the host config + install a bundle (subprocess) — off the loop.
+            # create() may overlay the host model + install a bundle (subprocess) — off the loop.
             ws = await asyncio.to_thread(
                 manager.create, name, bundle=bundle, port=port, shared_skills=shared,
-                from_config=from_config)
+                inherit_model=inherit_model)
             agent = (await asyncio.to_thread(supervisor.start, name)) if start else {
                 "name": name, "id": ws["id"], "port": ws["port"], "running": False}
             return {"ok": True, "agent": agent, "installed": ws.get("installed", [])}

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -52,10 +52,12 @@ def register_fleet_routes(app) -> None:
             if host and name == host["name"]:
                 return {"ok": True, **proxy.clear_active(), "evicted": []}
             if not supervisor.is_running(name):
-                supervisor.start(name)  # resume a cold agent on switch (from checkpoint)
+                await asyncio.to_thread(supervisor.start, name)  # resume from checkpoint
             result = proxy.set_active(name)
             supervisor.touch(name)
-            evicted = supervisor.enforce_warm_cap(protect=name)
+            # Eviction can busy-wait on a SIGTERM (#6) — off the loop so a switch never
+            # freezes the hub / its proxied SSE streams.
+            evicted = await asyncio.to_thread(supervisor.enforce_warm_cap, protect=name)
             return {"ok": True, **result, "evicted": evicted}
         except (supervisor.FleetError, manager.WorkspaceError) as exc:
             raise HTTPException(400, str(exc))
@@ -90,7 +92,7 @@ def register_fleet_routes(app) -> None:
             # create() may clone+install a bundle (subprocess) — keep it off the loop.
             ws = await asyncio.to_thread(
                 manager.create, name, bundle=bundle, port=port, shared_skills=shared)
-            agent = supervisor.start(name) if start else {
+            agent = (await asyncio.to_thread(supervisor.start, name)) if start else {
                 "name": name, "id": ws["id"], "port": ws["port"], "running": False}
             return {"ok": True, "agent": agent, "installed": ws.get("installed", [])}
         except (manager.WorkspaceError, supervisor.FleetError) as exc:
@@ -99,14 +101,14 @@ def register_fleet_routes(app) -> None:
     @app.post("/api/fleet/{name}/start")
     async def _start_agent(name: str):
         try:
-            return {"ok": True, "agent": supervisor.start(name)}
+            return {"ok": True, "agent": await asyncio.to_thread(supervisor.start, name)}
         except supervisor.FleetError as exc:
             raise HTTPException(400, str(exc))
 
     @app.post("/api/fleet/{name}/stop")
     async def _stop_agent(name: str):
         try:
-            return {"ok": True, **supervisor.stop(name)}
+            return {"ok": True, **await asyncio.to_thread(supervisor.stop, name)}  # #6 — off the loop
         except supervisor.FleetError as exc:
             raise HTTPException(400, str(exc))
 
@@ -114,16 +116,18 @@ def register_fleet_routes(app) -> None:
     async def _stop_fleet():
         """Shut down the **entire** fleet (every running agent). Mirrors the CLI's
         ``fleet down`` with no args."""
-        return {"ok": True, "stopped": [r["name"] for r in supervisor.down()]}
+        stopped = await asyncio.to_thread(supervisor.down)  # busy-waits per agent (#6)
+        return {"ok": True, "stopped": [r["name"] for r in stopped]}
 
     @app.delete("/api/fleet/{name}")
     async def _remove_agent(name: str, purge: bool = False):
         try:
             try:
-                supervisor.stop(name)  # stop if running; ignore if not
+                await asyncio.to_thread(supervisor.stop, name)  # stop if running (#6)
             except supervisor.FleetError:
                 pass
-            return {"ok": True, **manager.remove(name, purge=purge)}
+            # remove() rmtree's the workspace (purge) — also blocking.
+            return {"ok": True, **await asyncio.to_thread(manager.remove, name, purge=purge)}
         except manager.WorkspaceError as exc:
             raise HTTPException(400, str(exc))
 

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -76,6 +76,18 @@ def register_fleet_routes(app) -> None:
         """
         return await proxy.forward(request, path)
 
+    @app.api_route("/agents/{slug}/{path:path}",
+                   methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
+    async def _agent_proxy(slug: str, path: str, request: Request):
+        """Reverse-proxy the console to a specific agent BY SLUG (ADR 0042 slug routing).
+
+        The slug lives in the console URL (``/app/agent/<slug>/``), so each window targets its
+        own agent — two agents can be open in two windows at once, and a reload can't desync
+        (the URL is the source of truth). ``host`` = this instance. Supersedes the single-active
+        ``/active/*`` lens above.
+        """
+        return await proxy.forward_to(slug, request, path)
+
     @app.post("/api/fleet")
     async def _create_agent(body: dict = Body(...)):
         """Create an agent (optionally from a bundle archetype) and start it.

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -46,6 +46,11 @@ def register_fleet_routes(app) -> None:
         beyond the warm cap (their sessions persist + resume on a later switch).
         """
         try:
+            # Focusing the host (this instance) drops the proxy pointer — the console
+            # talks to /api directly again, no peer in focus.
+            host = next((a for a in supervisor.status() if a.get("host")), None)
+            if host and name == host["name"]:
+                return {"ok": True, **proxy.clear_active(), "evicted": []}
             if not supervisor.is_running(name):
                 supervisor.start(name)  # resume a cold agent on switch (from checkpoint)
             result = proxy.set_active(name)

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -81,17 +81,29 @@ def register_fleet_routes(app) -> None:
         """Create an agent (optionally from a bundle archetype) and start it.
 
         Body: ``{name, bundle?: <git-url>, port?: int, start?: bool=true,
-        shared_skills?: bool}``. A blank ``bundle`` is the built-in **Basic** archetype.
+        shared_skills?: bool, inherit_config?: bool=true}``. A blank ``bundle`` is the built-in
+        **Basic** archetype. By default a new agent **inherits the host's model config + secrets**
+        (re-stamped to its own identity) so it boots ready-to-chat on the same gateway — set
+        ``inherit_config: false`` for a blank agent you'll configure yourself.
         """
         name = str(body.get("name", "")).strip()
         bundle = (str(body.get("bundle") or "").strip()) or None
         port = body.get("port")
         start = bool(body.get("start", True))
         shared = bool(body.get("shared_skills", False))
+        # Inherit the host's config so peers work immediately — only if the host is actually
+        # configured (a fresh, un-set-up host falls back to the blank template).
+        from_config = None
+        if bool(body.get("inherit_config", True)):
+            from graph.config_io import _live_config_dir
+            cfg_dir = _live_config_dir()
+            if (cfg_dir / "langgraph-config.yaml").exists():
+                from_config = str(cfg_dir)
         try:
-            # create() may clone+install a bundle (subprocess) — keep it off the loop.
+            # create() may clone the host config + install a bundle (subprocess) — off the loop.
             ws = await asyncio.to_thread(
-                manager.create, name, bundle=bundle, port=port, shared_skills=shared)
+                manager.create, name, bundle=bundle, port=port, shared_skills=shared,
+                from_config=from_config)
             agent = (await asyncio.to_thread(supervisor.start, name)) if start else {
                 "name": name, "id": ws["id"], "port": ws["port"], "running": False}
             return {"ok": True, "agent": agent, "installed": ws.get("installed", [])}

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.0",
-        "@protolabsai/ui": "^0.15.0",
+        "@protolabsai/ui": "^0.17.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -66,9 +66,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.15.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.15.0.tgz",
-      "integrity": "sha512-uo2arQOhGHygtE24iWJWFTbGbeNT8VmFoZuiXXv1VsVgFqc33Y0584mMEN36QuArp5xeNrsP1COcp/8/nNJODw==",
+      "version": "0.17.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.17.0.tgz",
+      "integrity": "sha512-zJuMS2NGBHY9ykRq/6LjCzlU2sHg8dJL4o0Hm+pzsQc8dkH95mdBdOrTCS1o31IAcIX5AwA3WnBcrBgOVNw1Lg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
@@ -78,7 +78,8 @@
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@radix-ui/react-popover": "^1.1.16",
         "@types/react": "^19.0.0",
-        "@types/react-dom": "^19.0.0"
+        "@types/react-dom": "^19.0.0",
+        "culori": "^4.0.2"
       },
       "peerDependencies": {
         "react": "^19.0.0",
@@ -3450,6 +3451,15 @@
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "license": "MIT"
+    },
+    "node_modules/culori": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/culori/-/culori-4.0.2.tgz",
+      "integrity": "sha512-1+BhOB8ahCn4O0cep0Sh2l9KCOfOdY+BXJnKMHFFzDEouSr/el18QwXEMRlOj9UY5nCeA8UN3a/82rUWRBeyBw==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",

--- a/plugins/hello/__init__.py
+++ b/plugins/hello/__init__.py
@@ -68,14 +68,22 @@ def _build_router(greeting: str):
   <p id="bridge">awaiting console handshake…</p>
 </div>
 <script>
+  function applyTheme(t) {{
+    if (!t) return;
+    if (t.bg) document.body.style.background = t.bg;
+    if (t.fg) document.body.style.color = t.fg;
+  }}
   window.addEventListener("message", function (e) {{
     var m = e.data || {{}};
-    if (m.type !== "protoagent:init") return;
-    document.getElementById("bridge").textContent =
-      (m.token ? "✓ authed by the console" : "no token (open API)") +
-      (m.theme ? " · theme received" : "");
-    if (m.theme && m.theme.bg) document.body.style.background = m.theme.bg;
-    if (m.theme && m.theme.fg) document.body.style.color = m.theme.fg;
+    if (m.type === "protoagent:init") {{
+      document.getElementById("bridge").textContent =
+        (m.token ? "✓ authed by the console" : "no token (open API)") +
+        (m.theme ? " · theme received" : "");
+      applyTheme(m.theme);
+    }} else if (m.type === "protoagent:theme") {{
+      // Live theme update — the console re-posts on any edit / agent switch.
+      applyTheme(m.theme);
+    }}
   }});
 </script>
 </body></html>"""

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -57,3 +57,4 @@ croniter>=2.0
 # fleet.json process registry, ADR 0042). The full tier got this transitively
 # via Gradio → huggingface_hub; the lean tiers must declare it (the #426 class).
 filelock>=3.12
+zeroconf>=0.131  # mDNS fleet discovery (ADR 0042 §I)

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -52,3 +52,8 @@ beautifulsoup4>=4.12
 # Scheduler (scheduler/local.py — cron expression parsing for the
 # bundled local backend; the Workstacean adapter doesn't need this)
 croniter>=2.0
+
+# Fleet supervisor (graph/fleet/supervisor.py — cross-process lock around the
+# fleet.json process registry, ADR 0042). The full tier got this transitively
+# via Gradio → huggingface_hub; the lean tiers must declare it (the #426 class).
+filelock>=3.12

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -24,7 +24,7 @@ from typing import TYPE_CHECKING, Any
 
 from paths import scope_leaf
 from runtime.state import STATE
-from server import AGENT_NAME_ENV, _bundle_root, _event_bus, agent_name
+from server import AGENT_NAME_ENV, _event_bus, agent_name
 from server.chat import chat
 
 if TYPE_CHECKING:

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -80,3 +80,8 @@ def test_stop_entire_fleet(client):
     assert client.post("/api/fleet/down").json()["ok"]
     # The host can't stop itself; every peer is down.
     assert all(not a["running"] for a in client.get("/api/fleet").json()["agents"] if not a.get("host"))
+
+
+def test_reserved_host_name_is_400(client):
+    # `host` is the reserved slug for this instance — a peer named `host` would shadow it.
+    assert client.post("/api/fleet", json={"name": "host"}).status_code == 400

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -47,7 +47,8 @@ def test_create_list_start_stop_remove(client):
     assert not next(x for x in client.get("/api/fleet").json()["agents"] if x["name"] == "alpha")["running"]
 
     assert client.delete("/api/fleet/alpha").json()["ok"]
-    assert not client.get("/api/fleet").json()["agents"]
+    # The host (this instance) always self-registers, so only the peers are gone.
+    assert not [a for a in client.get("/api/fleet").json()["agents"] if not a.get("host")]
 
 
 def test_create_bad_name_is_400(client):
@@ -76,4 +77,5 @@ def test_stop_entire_fleet(client):
     client.post("/api/fleet", json={"name": "x", "port": 7895})
     client.post("/api/fleet", json={"name": "y", "port": 7896})
     assert client.post("/api/fleet/down").json()["ok"]
-    assert all(not a["running"] for a in client.get("/api/fleet").json()["agents"])
+    # The host can't stop itself; every peer is down.
+    assert all(not a["running"] for a in client.get("/api/fleet").json()["agents"] if not a.get("host"))

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -22,6 +22,7 @@ def client(tmp_path, monkeypatch):
             alive.add(4242)
 
     monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
+    monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
     monkeypatch.setattr(supervisor.os, "kill", lambda pid, sig: alive.discard(int(pid)))
 
     app = FastAPI()

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -20,6 +20,7 @@ def fleet(tmp_path, monkeypatch):
             alive.add(99001)
 
     monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
+    monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
 
     def fake_kill(pid, sig):  # SIGTERM/SIGKILL "kills" the fake process
         alive.discard(int(pid))
@@ -70,6 +71,7 @@ def test_keep_n_warm_evicts_lru(tmp_path, monkeypatch):
             alive.add(self.pid)
 
     monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
+    monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
     monkeypatch.setattr(supervisor.os, "kill", lambda pid, sig: alive.discard(int(pid)))
 
     for nm in ("a", "b", "c"):           # a started first → least-recently-active

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -42,7 +42,8 @@ def test_start_status_stop(fleet):
 
     supervisor.stop("alpha")
     assert not supervisor.is_running("alpha")
-    assert not any(s["running"] for s in supervisor.status())
+    # The host self-registers as an always-running entry (ADR 0042); only peers stop.
+    assert not any(s["running"] for s in supervisor.status() if not s.get("host"))
 
 
 def test_start_unknown_workspace_errors(fleet):

--- a/uv.lock
+++ b/uv.lock
@@ -4,5 +4,5 @@ requires-python = ">=3.11"
 
 [[package]]
 name = "protoagent"
-version = "0.2.1"
+version = "0.30.0"
 source = { virtual = "." }


### PR DESCRIPTION
## The fleet console (ADR 0042)
Manage a fleet of agents from one console — create them, switch between them, and run each with its own chat / layout / theme.

### Slug routing (the model)
The focused agent lives in the **URL**: `/app/agent/<slug>/`. Each window targets its own agent — deterministic, survives reload, and **two agents can be open in two windows at once**. This replaced an earlier global "active-prefix" model that caused a class of split-brain bugs (chat/SSE/reload desync); putting the agent in the URL eliminates them at the root.
- Backend: `proxy.forward_to(slug)` + `/agents/{slug}/{path}` reverse proxy (host = this instance, peer = its workspace port); `/agents/` is bearer-guarded, proxied SSE exempt by suffix.
- Frontend: `apiUrl` scopes agent calls by `currentSlug()` → `/agents/<slug>/*`; the switcher **navigates** (+ open-in-new-window); slug keyed on the stable `id`, not the editable name.

### What's in it
- **Settings → Agents**: live fleet manager (status / start / stop / remove+purge) + archetype-card picker → create.
- **New agent = model-only inheritance**: a blank agent with the host's `model:` + secrets popped over (the gateway only, not its plugins) — boots ready-to-chat with its own identity.
- **Per-agent, slug-scoped**: chat sessions, rail layout, and theme are each namespaced by agent.
- Host self-registers as a first-class agent (always running, can't stop itself).

### Verified
Live + headless: peer window → `/agents/<slug>/*`, host window → `/api/*`, chat POSTs to the peer's brain, two windows isolated, model-only inheritance confirmed. **1305 py + 72 e2e green.**

### Deferred follow-ups (tracked, non-blocking)
Opaque-id generation + editable display-name + rename · wiring mDNS/local **discovery** (`graph/fleet/discovery.py` written, not wired) + fleet agents as `delegate_to` targets · deleting the now-dead `/active` machinery · in-progress-return chat re-attach · cross-agent "agent finished" notifications.

### CI note
The red check is **gitleaks**, which fails on `main` itself (7 fake `sk-…` strings in the redaction-test fixtures — false positives, by design). Not introduced by this branch; a 2-line `.gitleaks.toml` allowlist is pending sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)