### PR TITLE
feat(plugins): plugin-driven console navigation — registry.navigate (ADR 0044)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -275,6 +275,26 @@ export function App() {
     .flatMap((p) => (p.views ?? []).map((v) => ({ ...v, key: `plugin:${p.id}:${v.id}` })));
   // Enabled plugin ids — gates ext surfaces that declare requiresPlugin (e.g. Studio → workflows).
   const enabledPluginIds = new Set((runtime?.plugins ?? []).filter((p) => p.enabled).map((p) => p.id));
+
+  // Plugin-driven console navigation (ADR 0044) — any plugin can ask to open one of its
+  // own views via the reserved `ui.navigate` host intent `{plugin, view}` (emitted by
+  // `registry.navigate(view)`). Core honors it GENERICALLY: resolve `plugin:<plugin>:<view>`
+  // (blank view → that plugin's first view) and focus it only if the surface exists. No
+  // per-plugin code — this is the single extensibility point for "the AI navigates the UI".
+  const pluginViewsRef = useRef(allPluginViews);
+  pluginViewsRef.current = allPluginViews;
+  useEffect(
+    () =>
+      onServerEvent("ui.navigate", (d) => {
+        const pid = String(d?.plugin || "");
+        if (!pid) return;
+        const own = pluginViewsRef.current.filter((v) => v.key.startsWith(`plugin:${pid}:`));
+        const target = d?.view ? own.find((v) => v.key === `plugin:${pid}:${d.view}`) : own[0];
+        if (target) setSurface(target.key);
+      }),
+    [],
+  );
+
   const pluginRail = allPluginViews.filter((v) => (v.placement ?? "rail") !== "right");
   const pluginRightPanels = allPluginViews.filter((v) => v.placement === "right");
   const activePluginView = pluginRail.find((v) => v.key === surface) ?? null;

--- a/docs/adr/0044-plugin-driven-console-navigation.md
+++ b/docs/adr/0044-plugin-driven-console-navigation.md
@@ -1,0 +1,74 @@
+# 0044 — Plugin-driven console navigation
+
+- Status: Proposed
+- Date: 2026-06-09
+- Builds on: ADR 0026 (plugin-contributed console surfaces), 0039 (event bus).
+
+## Context
+
+Plugins contribute console views (ADR 0026) that the operator opens from the rail.
+Increasingly a plugin — or the **agent**, via a plugin tool — needs to open its view
+*programmatically*: e.g. a tool that answers "can you run DOOM?" should focus the DOOM
+view and start the game; a board plugin might jump the operator to its board when a run
+starts. This is the first concrete step of a broader goal — *the AI navigates the UI for
+us*.
+
+The wrong way is for the console to learn each plugin's event (`if topic === "doom.play"
+→ open DOOM`). That hardcodes plugin ids into core, doesn't scale, and couples the
+console to specific plugins. We need **one general, extensible mechanism**.
+
+## Decision
+
+A reserved host intent **`ui.navigate`** on the event bus, produced by a first-class
+plugins API and consumed by a single generic console handler.
+
+- **Producer** — `registry.navigate(view="")` (the plugin registry, alongside `emit`).
+  It publishes `ui.navigate` with `{plugin: <this plugin id>, view}`. Unlike `emit`, the
+  topic is **not** namespaced — it's a host-level navigation request. It is **scoped**:
+  the payload carries the *calling* plugin's id, so a plugin can only ever ask to open
+  **its own** views, never hijack the console to another surface.
+
+- **Consumer** — the console subscribes to `ui.navigate` with **one** handler: resolve
+  `plugin:<plugin>:<view>` (a blank `view` → that plugin's *first* view), and focus it
+  **iff** that surface exists in the live plugin-view set. No per-plugin code; core never
+  names a plugin.
+
+```
+plugin tool ──registry.navigate("panel")──▶ bus: ui.navigate {plugin:"doom", view:"panel"}
+                                                        │
+                              console (one generic handler, ADR 0026 surfaces)
+                                                        ▼
+                              setSurface("plugin:doom:panel")  (if it exists)
+```
+
+The DOOM plugin's `can_you_play_doom` tool is the first user: it calls
+`registry.navigate("panel")` and the panel's js-dos auto-starts the game.
+
+## Why this shape
+
+- **Extensible** — any plugin gets agent-driven navigation for free by calling
+  `navigate()`; core needs no change per plugin.
+- **Scoped / safe** — a plugin can only open its own views (id comes from the registry,
+  not the payload author), so an enabled plugin can't seize the console.
+- **Decoupled** — core knows no plugin ids; plugins don't import core. Same
+  no-cross-dependency stance as ADR 0039 events.
+- **Graceful** — unknown plugin/view or a disconnected console: the intent is dropped,
+  the tool's textual answer still returns.
+
+## Consequences
+
+- One new plugins API (`registry.navigate`) + one general console subscriber. Tiny core
+  surface; no plugin-specific branches.
+- Fire-and-forget (no ack): a tool can't *know* the operator's console navigated. Fine —
+  it's a convenience, not a transaction.
+- Future: the intent could grow a `{surface}` form to focus **core** surfaces too (chat,
+  activity), gated for the agent rather than per-plugin — a superset of this. Out of scope
+  here; the plugin-scoped form is the safe first cut.
+
+## Alternatives rejected
+
+- **Per-plugin events in core** (`if doom.play …`) — hardcodes plugin ids into the
+  console. Rejected (the motivation for this ADR).
+- **Topic convention `<plugin>.navigate`** consumed via a `*.navigate` pattern — works,
+  but overloads the namespaced plugin-event channel for a host concern and is easy to fire
+  by accident. A reserved `ui.navigate` intent via an explicit `navigate()` is clearer.

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -88,6 +88,23 @@ class PluginRegistry:
         else:  # non-server context (tests, headless) — no bus wired
             log.debug("[plugins] %s: emit(%s) dropped — no bus", pid, topic)
 
+    def navigate(self, view: str = "") -> None:
+        """Ask the operator console to open one of THIS plugin's views — plugin-driven
+        UI navigation (ADR 0044). Fire-and-forget.
+
+        Publishes a reserved host intent ``ui.navigate`` with ``{plugin, view}``; the
+        console focuses ``plugin:<this plugin>:<view>`` when that surface exists (a blank
+        ``view`` opens the plugin's first view). Unlike :meth:`emit`, this is a host-level
+        navigation request, not a namespaced plugin event — and it is **scoped**: the
+        payload carries this plugin's id, so a plugin can only open its own views, never
+        hijack the console to another surface. The console honors it generically (one
+        handler, no per-plugin code), so any plugin gets agent-driven navigation for free.
+        """
+        if self.host and self.host.publish:
+            self.host.publish("ui.navigate", {"plugin": self.plugin_id, "view": view or ""})
+        else:  # non-server context (tests, headless) — no bus wired
+            log.debug("[plugins] %s: navigate(%s) dropped — no bus", self.plugin_id, view)
+
     def on(self, topic: str, handler) -> None:
         """Subscribe an in-process handler to bus topics (ADR 0039). ``topic`` may use
         ``*`` (one segment) / ``#`` (tail) wildcards and match ANY plugin's namespace —


### PR DESCRIPTION
A **general, extensible** mechanism for a plugin (or the agent via a plugin tool) to open one of its **own** console views — **zero per-plugin code in core**.

- **`registry.navigate(view="")`** publishes a reserved host intent **`ui.navigate {plugin, view}`**. **Scoped** — the plugin id comes from the registry, not the caller — so a plugin can only open *its own* views.
- **One generic console handler** resolves `plugin:<plugin>:<view>` (blank → first view) and focuses it iff it exists. Core never names a plugin.

Replaces the wrong instinct (`if topic==="doom.play"` in core). Decoupled, scoped, extensible (ADR 0044). `apps/web/App.tsx` change is one general handler — **flagged for console owners' review**. First user: DOOM's `can_you_play_doom` → `registry.navigate("panel")`. Verified end-to-end locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)