### PR TITLE
ci(gitleaks): allowlist the redaction-test fixtures (greens the secret-scan)

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -4,9 +4,13 @@
 useDefault = true
 
 [allowlist]
-description = "Examples, lockfiles, and docs — no real secrets here."
+description = "Examples, lockfiles, docs, and the redaction-test fixtures — no real secrets here."
 paths = [
   '''.*\.example\.ya?ml$''',
   '''(^|/)(package-lock\.json|uv\.lock|plugins\.lock)$''',
   '''^docs/''',
+  # These two test the secret-REDACTION middleware, so they hold fake sk-…-shaped strings by
+  # design — flagging them is a false positive (they're what proves we redact real secrets).
+  '''^tests/middleware/test_redaction\.py$''',
+  '''^tests/middleware/test_audit_redaction_integration\.py$''',
 ]


### PR DESCRIPTION
The gitleaks check has been red on **every run** (main + every PR) because two test files contain fake `sk-…`-shaped strings **by design** — they test the secret-redaction middleware:
- `tests/middleware/test_redaction.py`
- `tests/middleware/test_audit_redaction_integration.py`

This adds those two known fixture paths to `.gitleaks.toml`'s allowlist. It's a false-positive fix — it does **not** weaken the gate for real secrets anywhere else. This PR's own gitleaks check should go green (the allowlist takes effect).

🤖 Generated with [Claude Code](https://claude.com/claude-code)