### PR TITLE
feat(fleet): PM archetype + agents-as-delegate_to-targets (agent-to-agent flows)

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3495,6 +3495,17 @@ textarea {
   margin-left: 8px;
 }
 
+/* "delegate" marker on a fleet row — this agent is a delegate_to target of the focused agent. */
+.fleet-delegate-tag {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--brand-violet, #9b87f2);
+  border: 1px solid color-mix(in srgb, var(--brand-violet, #9b87f2) 40%, transparent);
+  border-radius: 4px;
+  padding: 0 5px;
+}
+
 /* Theme crossfade (ADR 0042) — applyAgentTheme() applies the focused agent's look inside a
    View Transition (when supported), so switching agents snapshots before/after and crossfades
    instead of hard-cutting. Ease the root transition so it glides. (Live picker drags bypass

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -359,6 +359,9 @@ export type AgentConfig = {
   operator?: {
     allowed_dirs: string[];
   };
+  plugins?: {
+    enabled?: string[];
+  };
 };
 
 export type ConfigPayload = {

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Play, Plus, Square, Trash2 } from "lucide-react";
+import { Link2, Play, Plus, Square, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@protolabsai/ui/primitives";
@@ -37,6 +37,29 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
     setBusy(name);
     run.mutate(fn);
   };
+
+  // Agent-to-agent flows (ADR 0042 + 0025): add another agent as a `delegate_to` target of the
+  // FOCUSED agent (this window's slug), pointing at its A2A endpoint — then this agent can
+  // delegate work to it. The delegates query/POST is slug-scoped, so it lands on the focused agent.
+  const delegatesQ = useQuery({ queryKey: ["delegates"], queryFn: () => api.delegates(), retry: false });
+  const delegateNames = new Set((delegatesQ.data?.delegates ?? []).map((d) => d.name));
+  const addDelegate = useMutation({
+    // Fleet agents ship with the `delegates` plugin enabled (ADR 0042), so this is a straight add
+    // — no enable step, no restart. The host carries no plugins by default, so adding delegates
+    // FROM the host's window needs delegates enabled there first; surface that clearly on 404.
+    mutationFn: (a: FleetAgent) => api.createDelegate({ name: a.name, type: "a2a", url: a.a2a }),
+    onMutate: () => setError(null),
+    onError: (e: Error) =>
+      setError(
+        /404|not found/i.test(e.message)
+          ? "This agent can't hold delegates yet — enable the delegates plugin on it (new fleet agents get it automatically; the host needs it enabled + a restart)."
+          : e.message,
+      ),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["delegates"] });
+      void delegatesQ.refetch();
+    },
+  });
 
   return (
     <section className="panel stage-panel">
@@ -82,26 +105,41 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                       {a.bundle ? ` · ${a.bundle}` : ""}
                     </span>
                   </div>
-                  {/* The host serves this console — it can't stop or remove itself. */}
-                  {a.host ? null : (
-                    <div className="fleet-row-actions">
-                      {a.running ? (
-                        <Button icon variant="ghost" title="Stop" disabled={busy === a.name}
-                          onClick={() => act(a.name, () => api.stopAgent(a.name))}>
-                          <Square size={14} />
-                        </Button>
+                  <div className="fleet-row-actions">
+                    {/* Add as a delegate of the focused agent → enables delegate_to flows. Any
+                        agent but the one you're on (it can't delegate to itself). */}
+                    {!isActive ? (
+                      delegateNames.has(a.name) ? (
+                        <span className="fleet-delegate-tag" title="A delegate of this agent">delegate</span>
                       ) : (
-                        <Button icon variant="ghost" title="Start" disabled={busy === a.name}
-                          onClick={() => act(a.name, () => api.startAgent(a.name))}>
-                          <Play size={14} />
+                        <Button icon variant="ghost" title="Add as a delegate of this agent (delegate_to)"
+                          disabled={addDelegate.isPending || !a.a2a}
+                          onClick={() => addDelegate.mutate(a)}>
+                          <Link2 size={14} />
                         </Button>
-                      )}
-                      <Button icon variant="ghost" title="Remove" disabled={busy === a.name}
-                        onClick={() => { setPurge(false); setConfirmRemove(a); }}>
-                        <Trash2 size={14} />
-                      </Button>
-                    </div>
-                  )}
+                      )
+                    ) : null}
+                    {/* The host serves this console — it can't stop or remove itself. */}
+                    {a.host ? null : (
+                      <>
+                        {a.running ? (
+                          <Button icon variant="ghost" title="Stop" disabled={busy === a.name}
+                            onClick={() => act(a.name, () => api.stopAgent(a.name))}>
+                            <Square size={14} />
+                          </Button>
+                        ) : (
+                          <Button icon variant="ghost" title="Start" disabled={busy === a.name}
+                            onClick={() => act(a.name, () => api.startAgent(a.name))}>
+                            <Play size={14} />
+                          </Button>
+                        )}
+                        <Button icon variant="ghost" title="Remove" disabled={busy === a.name}
+                          onClick={() => { setPurge(false); setConfirmRemove(a); }}>
+                          <Trash2 size={14} />
+                        </Button>
+                      </>
+                    )}
+                  </div>
                 </li>
               );
             })}

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -115,7 +115,10 @@ model:
   api_key: ""         # or set OPENAI_API_KEY in this workspace's secrets.yaml
 
 plugins:
-  enabled: []
+  # `delegates` is on by default for fleet agents (ADR 0042 + 0025) so they can delegate to
+  # each other out of the box — enabled at startup, so the /api/delegates routes are registered
+  # with no restart-to-enable (a hot-reload alone doesn't bind new plugin routes).
+  enabled: [delegates]
   sources:
     allow: [github.com/protoLabsAI/*]
 

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -164,10 +164,19 @@ def register_fleet_routes(app) -> None:
 
 def _archetypes() -> list[dict]:
     """Built-in Basic + installed-bundle archetypes (cached in plugins.lock)."""
-    out = [{
-        "id": "basic", "label": "Basic", "icon": "Sparkles", "bundle": None,
-        "blurb": "A blank-slate agent — the core loop + built-in tools, no plugins.",
-    }]
+    out = [
+        {
+            "id": "basic", "label": "Basic", "icon": "Sparkles", "bundle": None,
+            "blurb": "A blank-slate agent — the core loop + built-in tools, no plugins.",
+        },
+        {
+            # Built-in PM archetype — installed FRESH from the git URL on each create (no pin),
+            # so a new PM agent always gets the latest pm-stack.
+            "id": "pm-stack", "label": "Project Manager", "icon": "LayoutGrid",
+            "bundle": "https://github.com/protoLabsAI/pm-stack",
+            "blurb": "Project-management tools + board — clones the latest pm-stack on create.",
+        },
+    ]
     try:
         from graph.plugins.installer import _read_lock
         for b in (_read_lock().get("bundles") or []):


### PR DESCRIPTION
Follow-up to the merged fleet console (#792). Two things:

### Project Manager archetype
A built-in **Project Manager** archetype in the new-agent picker, pointing at `github.com/protoLabsAI/pm-stack`. It installs with no pinned ref → each PM create clones the default-branch **HEAD**, so a new PM agent always gets the latest pm-stack as it's updated.

### Agents as `delegate_to` targets — agent-to-agent flows
From agent A's window → fleet manager → a per-row **"add as delegate"** action adds agent B (its A2A endpoint) as A's delegate via the slug-scoped `/agents/A/api/delegates`. Then A's `delegate_to` tool can hand work to B — that's the flow primitive.

To make this seamless, **fleet agents now ship with the `delegates` plugin enabled** in the create template. (A plugin enabled *after* startup needs a restart to bind its API routes — a hot-reload rebuilds the graph but not routes — so auto-enabling at create avoids any restart-to-enable.)

**Verified live**: a fresh agent has `/api/delegates` at startup (no restart), and adding a peer as a delegate succeeds end-to-end (`delegates: ['alpha']`). The host carries no plugins by default, so delegating *from* the host needs delegates enabled there first (surfaced clearly on 404).

11 py + 72 e2e green. **Not in this PR:** mDNS/local discovery (`graph/fleet/discovery.py` is written but unwired) — a follow-up so remote agents can be added the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)