### PR TITLE
feat(plugins): chat_example — reference chat-slot plugin (ADR 0045)

### DIFF
--- a/docs/guides/plugin-views.md
+++ b/docs/guides/plugin-views.md
@@ -72,6 +72,18 @@ key local state per agent slug).
 Forks have an in-process alternative: register a `src/ext` surface with `id: "chat"`
 (ADR 0038 D3) — it overrides the slot ahead of plugin claims, with full React context.
 
+A complete reference implementation ships in **`plugins/chat_example`** — a
+single-page vanilla-JS panel covering the handshake, live re-theming, slug-aware
+routing, and a turn over the non-streaming path. Try it:
+
+```yaml
+plugins:
+  enabled: [chat_example]
+```
+
+Reload — Chat becomes the example panel. Disable the plugin and the built-in chat
+is back.
+
 ## Serve the page
 
 The page is yours — any framework, or plain HTML. Serve it from the plugin's

--- a/plugins/chat_example/__init__.py
+++ b/plugins/chat_example/__init__.py
@@ -1,0 +1,52 @@
+"""Example chat-slot plugin (ADR 0045).
+
+The smallest real replacement for the console's chat panel: the manifest's view
+declares ``slot: "chat"``, so the page served here renders under the core Chat rail
+id — kept mounted for the app's lifetime — instead of adding its own icon.
+
+The page (``panel.html``) is plain HTML/JS and demonstrates the contract pieces a
+chat panel needs:
+
+- the ``protoagent:init`` postMessage handshake (bearer + theme; never in URLs) and
+  live ``protoagent:theme`` re-themes (ADR 0038),
+- slug-aware routing — derive the API base from the iframe's own path so the panel
+  talks to the agent its *window* is focused on (ADR 0042),
+- a turn via the documented **non-streaming** ``POST /api/chat`` fallback.
+
+It deliberately stops there: a production panel should drive the streaming A2A
+contract (``SendStreamingMessage`` + ``tasks/get`` reconciliation) and honor the
+ADR 0045 conformance checklist. This is the scaffold you grow that from.
+
+Enable with ``plugins: { enabled: [chat_example] }`` and reload — Chat becomes this
+panel. Disable it and the built-in chat is back.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+log = logging.getLogger("protoagent.plugins.chat_example")
+
+_PANEL = Path(__file__).parent / "panel.html"
+
+
+def _build_router():
+    from fastapi import APIRouter
+    from fastapi.responses import HTMLResponse
+
+    router = APIRouter()
+
+    @router.get("/panel")
+    async def _panel():
+        # Read per request — edit panel.html and refresh, no restart (it's an example).
+        return HTMLResponse(_PANEL.read_text(encoding="utf-8"))
+
+    return router
+
+
+def register(registry):
+    # Served OUTSIDE /api/ on purpose: the iframe's page load can't carry a bearer
+    # header, so the page itself is public chrome — the token arrives via the
+    # protoagent:init postMessage and is used for the page's own API calls.
+    registry.register_router(_build_router(), prefix="/plugins/chat_example")

--- a/plugins/chat_example/panel.html
+++ b/plugins/chat_example/panel.html
@@ -1,0 +1,151 @@
+<!doctype html>
+<html>
+<head>
+<meta charset="utf-8" />
+<title>Chat (example plugin)</title>
+<style>
+  /* Defaults match the console's dark ground; protoagent:init overrides them with
+     the live theme tokens so the panel re-skins with the agent's theme. */
+  :root {
+    --bg: #0a0f14; --bg-panel: #11161d; --fg: #e6e6e6; --fg-muted: #9aa0aa;
+    --brand: #9b87f2; --border: #232a33;
+  }
+  html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
+    font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; }
+  .wrap { display: flex; flex-direction: column; height: 100%; box-sizing: border-box; }
+  header { display: flex; align-items: center; gap: 8px; padding: 10px 14px;
+    border-bottom: 1px solid var(--border); font-size: 13px; color: var(--fg-muted); }
+  header .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--brand); }
+  header button { margin-left: auto; background: none; border: 1px solid var(--border);
+    color: var(--fg-muted); border-radius: 6px; padding: 3px 10px; font-size: 12px; cursor: pointer; }
+  header button:hover { color: var(--fg); border-color: var(--brand); }
+  #log { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 10px; }
+  .msg { max-width: 72ch; padding: 9px 13px; border-radius: 12px; font-size: 14px;
+    line-height: 1.55; white-space: pre-wrap; word-break: break-word; }
+  .msg.user { align-self: flex-end; background: var(--brand); color: #0a0f14; border-bottom-right-radius: 4px; }
+  .msg.assistant { align-self: flex-start; background: var(--bg-panel);
+    border: 1px solid var(--border); border-bottom-left-radius: 4px; }
+  .msg.pending { color: var(--fg-muted); font-style: italic; }
+  .msg.error { align-self: stretch; background: none; border: 1px solid #b3404a; color: #e08089; }
+  .empty { margin: auto; text-align: center; color: var(--fg-muted); font-size: 13px; max-width: 44ch; line-height: 1.7; }
+  .empty b { color: var(--brand); }
+  form { display: flex; gap: 8px; padding: 12px 14px; border-top: 1px solid var(--border); }
+  textarea { flex: 1; resize: none; background: var(--bg-panel); color: var(--fg);
+    border: 1px solid var(--border); border-radius: 10px; padding: 9px 12px; font: inherit;
+    font-size: 14px; min-height: 20px; max-height: 140px; }
+  textarea:focus { outline: none; border-color: var(--brand); }
+  form button { background: var(--brand); color: #0a0f14; border: 0; border-radius: 10px;
+    padding: 0 18px; font-weight: 600; font-size: 14px; cursor: pointer; }
+  form button:disabled { opacity: 0.5; cursor: default; }
+</style>
+</head>
+<body>
+<div class="wrap">
+  <header><span class="dot"></span> chat_example — a slot-claiming chat panel (ADR 0045)
+    <button id="reset" type="button" title="Start a fresh session">New session</button>
+  </header>
+  <div id="log">
+    <div class="empty">This is the <b>example chat plugin</b> rendering in the chat slot.
+      Send a message — it drives the agent over <b>POST /api/chat</b> with the bearer from
+      the <b>protoagent:init</b> handshake. Disable the plugin to restore the built-in chat.</div>
+  </div>
+  <form id="composer">
+    <textarea id="input" rows="1" placeholder="Message the agent…"></textarea>
+    <button id="send" type="submit">Send</button>
+  </form>
+</div>
+<script>
+  "use strict";
+  // ── Console handshake (ADR 0038): bearer + theme arrive via postMessage. ─────
+  let token = null;
+  function applyTheme(theme) {
+    if (!theme) return;
+    const map = { bg: "--bg", bgPanel: "--bg-panel", fg: "--fg", fgMuted: "--fg-muted",
+                  brand: "--brand", border: "--border" };
+    for (const [k, v] of Object.entries(map)) {
+      if (theme[k]) document.documentElement.style.setProperty(v, theme[k]);
+    }
+  }
+  window.addEventListener("message", (e) => {
+    const m = e.data || {};
+    if (m.type === "protoagent:init") { token = m.token || null; applyTheme(m.theme); }
+    else if (m.type === "protoagent:theme") applyTheme(m.theme); // live re-theme
+  });
+
+  // ── Slug-aware base (ADR 0042): the iframe lives at /plugins/... (host window)
+  // or /agents/<slug>/plugins/... (peer window) — keep API calls on OUR agent. ──
+  const base = location.pathname.split("/plugins/")[0];
+
+  // ── One session per agent, persisted; New session rotates it. ────────────────
+  const SKEY = "chat-example.session:" + (base || "host");
+  let sessionId = localStorage.getItem(SKEY) ||
+    "chx-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
+  localStorage.setItem(SKEY, sessionId);
+
+  const log = document.getElementById("log");
+  const input = document.getElementById("input");
+  const send = document.getElementById("send");
+
+  function bubble(cls, text) {
+    const div = document.createElement("div");
+    div.className = "msg " + cls;
+    div.textContent = text;
+    const empty = log.querySelector(".empty");
+    if (empty) empty.remove();
+    log.appendChild(div);
+    log.scrollTop = log.scrollHeight;
+    return div;
+  }
+
+  // The documented NON-STREAMING path (one request, full reply). A production
+  // panel streams via A2A SendStreamingMessage and reconciles with tasks/get —
+  // see the ADR 0045 conformance checklist before shipping one for real.
+  async function sendTurn(message) {
+    const pending = bubble("assistant pending", "thinking…");
+    try {
+      const res = await fetch(base + "/api/chat", {
+        method: "POST",
+        headers: { "Content-Type": "application/json",
+                   ...(token ? { Authorization: "Bearer " + token } : {}) },
+        body: JSON.stringify({ message, session_id: sessionId }),
+      });
+      if (!res.ok) {
+        let detail = res.status + " " + res.statusText;
+        try { detail = (await res.json()).detail || detail; } catch { /* keep status */ }
+        throw new Error(detail);
+      }
+      const data = await res.json();
+      pending.classList.remove("pending");
+      pending.textContent = (data.response || "").trim() || "(the turn returned no content)";
+    } catch (err) {
+      pending.remove();
+      bubble("error", "Turn failed: " + (err && err.message ? err.message : err));
+    } finally {
+      send.disabled = false;
+      input.focus();
+      log.scrollTop = log.scrollHeight;
+    }
+  }
+
+  document.getElementById("composer").addEventListener("submit", (e) => {
+    e.preventDefault();
+    const message = input.value.trim();
+    if (!message || send.disabled) return;
+    input.value = "";
+    send.disabled = true;
+    bubble("user", message);
+    void sendTurn(message);
+  });
+  input.addEventListener("keydown", (e) => {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      document.getElementById("composer").requestSubmit();
+    }
+  });
+  document.getElementById("reset").addEventListener("click", () => {
+    localStorage.removeItem(SKEY);
+    location.reload(); // a fresh session id mints on load
+  });
+</script>
+</body>
+</html>

--- a/plugins/chat_example/protoagent.plugin.yaml
+++ b/plugins/chat_example/protoagent.plugin.yaml
@@ -1,0 +1,20 @@
+id: chat_example
+name: Chat panel (example)
+version: 0.1.0
+description: >-
+  Reference chat-slot plugin (ADR 0045): a minimal vanilla-JS chat panel that
+  REPLACES the built-in chat surface via `slot: "chat"`. Demonstrates the
+  protoagent:init bearer/theme handshake, slug-aware API routing, and the
+  documented non-streaming /api/chat path. Copy this as the starting point for
+  your own chat panel; production panels should speak the full streaming A2A
+  contract — see the ADR 0045 conformance checklist.
+enabled: false
+capabilities:
+  network: []
+  filesystem: none
+
+# Claim the chat SLOT (ADR 0045): this view renders under the core "chat" rail id
+# (no separate icon), stays mounted for the app's lifetime, and replaces the
+# built-in panel. Disable the plugin to get the built-in chat back.
+views:
+  - { id: panel, label: "Chat (example)", icon: "MessageSquare", path: "/plugins/chat_example/panel", slot: chat }

--- a/tests/test_chat_example_plugin.py
+++ b/tests/test_chat_example_plugin.py
@@ -1,0 +1,61 @@
+"""chat_example plugin (ADR 0045) — the reference chat-slot panel."""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+from graph.plugins.manifest import load_manifest
+
+_PLUGIN_DIR = Path("plugins/chat_example")
+
+
+def _load_module():
+    spec = importlib.util.spec_from_file_location(
+        "chat_example_under_test", _PLUGIN_DIR / "__init__.py"
+    )
+    mod = importlib.util.module_from_spec(spec)
+    assert spec and spec.loader
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def test_manifest_claims_the_chat_slot() -> None:
+    """The view declares slot:"chat" and it survives manifest parsing — the whole
+    backend contract of ADR 0045 is that unknown view keys pass through intact."""
+    m = load_manifest(_PLUGIN_DIR)
+    assert m is not None and m.id == "chat_example"
+    assert m.enabled is False  # opt-in (lean core)
+    assert len(m.views) == 1
+    view = m.views[0]
+    assert view["slot"] == "chat"
+    assert view["path"] == "/plugins/chat_example/panel"
+
+
+def test_panel_route_serves_the_contract_page() -> None:
+    """register() mounts a router whose /panel page carries the handshake +
+    slug-aware base + non-streaming chat call — the example's teaching points."""
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    mod = _load_module()
+
+    routers: list[tuple] = []
+
+    class _Reg:
+        def register_router(self, router, prefix):
+            routers.append((router, prefix))
+
+    mod.register(_Reg())
+    assert len(routers) == 1
+    router, prefix = routers[0]
+    # Served OUTSIDE /api/ — the iframe page load can't carry a bearer header.
+    assert prefix == "/plugins/chat_example"
+
+    app = FastAPI()
+    app.include_router(router, prefix=prefix)
+    page = TestClient(app).get("/plugins/chat_example/panel")
+    assert page.status_code == 200
+    body = page.text
+    assert "protoagent:init" in body          # bearer + theme handshake (ADR 0038)
+    assert 'split("/plugins/")' in body       # slug-aware base (ADR 0042)
+    assert "/api/chat" in body                # the documented non-streaming turn


### PR DESCRIPTION
## What

The hands-on companion to #799: a minimal, **opt-in** plugin that claims the chat slot, so the slot can be tested live and copied as the starting point for community chat panels.

- `plugins/chat_example/` — manifest view with `slot: "chat"` + a single-page vanilla-JS panel (`panel.html`, served by the plugin's router at `/plugins/chat_example/panel`).
- The page demonstrates each contract piece a chat panel needs: the `protoagent:init` bearer/theme handshake + live `protoagent:theme` re-skinning (ADR 0038), **slug-aware API base** derived from the iframe's own path so a peer window talks to *its* agent (ADR 0042), per-agent session persistence, and a turn over the documented non-streaming `POST /api/chat`. Comments point production panels at the streaming A2A path + the ADR 0045 conformance checklist.
- Served **outside** `/api/` deliberately — an iframe page load can't carry a bearer header; the token arrives via postMessage (the `hello`/`notes` precedent).
- Shipped `enabled: false` (lean core). `plugins: { enabled: [chat_example] }` + reload swaps the chat surface; disabling restores the built-in.
- Guide: the "Claim the chat slot" section now links the reference + try-it config.

## Try it

```yaml
plugins:
  enabled: [chat_example]
```

Reload the console — Chat is now the example panel; send a message and it drives the agent. Works in both host and `/agents/<slug>/` windows.

## Tests

2 new: the `slot: "chat"` key survives manifest parsing (the entire backend contract of ADR 0045), and `register()` mounts the route serving the contract page (handshake + slug-base + chat call asserted). Full suite **1311 passed**, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)