### PR TITLE
chore(ui): no ADR references in user-facing copy

### DIFF
--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -117,7 +117,7 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
       </div>
 
       <p className="playbook-foot">
-        <Brain size={13} /> This is the memory the agent retrieves into context before each turn (ADR 0020) — search it to see what it knows.
+        <Brain size={13} /> This is the memory the agent retrieves into context before each turn — search it to see what it knows.
       </p>
     </section>
   );

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -169,7 +169,7 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
 
       <p className="playbook-foot">
         <BookMarked size={13} /> Skills (`SKILL.md`) are methodology the agent <strong>retrieves</strong> into
-        context (ADR 0009) — they advise, they don't run. For deterministic step-by-step runs
+        context — they advise, they don't run. For deterministic step-by-step runs
         across subagents, see <strong>Studio → Workflows</strong>.
       </p>
     </section>

--- a/plugins/chat_example/panel.html
+++ b/plugins/chat_example/panel.html
@@ -41,7 +41,7 @@
 </head>
 <body>
 <div class="wrap">
-  <header><span class="dot"></span> chat_example — a slot-claiming chat panel (ADR 0045)
+  <header><span class="dot"></span> chat_example — a slot-claiming chat panel
     <button id="reset" type="button" title="Start a fresh session">New session</button>
   </header>
   <div id="log">

--- a/plugins/hello/__init__.py
+++ b/plugins/hello/__init__.py
@@ -62,8 +62,8 @@ def _build_router(greeting: str):
 </style></head><body><div class="card">
   <h1>{greeting} from a plugin view</h1>
   <p>Served by <code>plugins/hello</code> at <code>/plugins/hello/view</code> and
-  embedded in the console rail via the <code>views:</code> manifest block
-  (ADR 0026). A fork drops a directory like this and gets its own rail icon +
+  embedded in the console rail via the <code>views:</code> manifest block.
+  A fork drops a directory like this and gets its own rail icon +
   dashboard — no console rebuild.</p>
   <p id="bridge">awaiting console handshake…</p>
 </div>


### PR DESCRIPTION
House rule (KJ, 2026-06-10): ADR numbers never appear in user-facing UI strings — they're engineering provenance for comments, commits, and docs, not operator-visible copy.

Swept every rendered occurrence (verified by parsing the actual served HTML/JSX text, not comments):

- `plugins/chat_example/panel.html` — header no longer says "(ADR 0045)"
- `apps/web/src/knowledge/KnowledgeStore.tsx` — store footer
- `apps/web/src/playbooks/PlaybooksSurface.tsx` — skills footer
- `plugins/hello/__init__.py` — the rendered view page

Code comments/docstrings keep their ADR references (that's where they belong). Notes' editor page checked clean via AST.

Tests: plugin suites + ruff green, web build clean, full 75-spec e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)