### PR TITLE
feat(fleet): network discovery — find + add remote agents as delegates (ADR 0042 §I)

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -3506,6 +3506,13 @@ textarea {
   padding: 0 5px;
 }
 
+/* Network-discovery sub-section in the fleet manager (ADR 0042 §I). */
+.fleet-discover {
+  margin-top: 14px;
+  padding-top: 12px;
+  border-top: 1px solid var(--border);
+}
+
 /* Theme crossfade (ADR 0042) — applyAgentTheme() applies the focused agent's look inside a
    View Transition (when supported), so switching agents snapshots before/after and crossfades
    instead of hard-cutting. Ease the root transition so it glides. (Live picker drags bypass

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   DelegateProbe,
   DelegateTypeSpec,
   DelegateView,
+  DiscoveredAgent,
   FleetAgent,
   FleetStatus,
   GoalState,
@@ -636,6 +637,9 @@ export const api = {
   // --- Fleet (ADR 0042) — many workspace agents on one host ------------------
   fleet() {
     return request<FleetStatus>("/api/fleet");
+  },
+  discoverAgents() {
+    return request<{ discovered: DiscoveredAgent[] }>("/api/fleet/discover");
   },
   archetypes() {
     return request<{ archetypes: Archetype[] }>("/api/archetypes");

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -495,6 +495,9 @@ export type FleetAgent = {
 // `active` is the focused peer, or null when the host itself is focused (talk /api direct).
 export type FleetStatus = { agents: FleetAgent[]; active: string | null };
 
+// Another protoAgent found on the box / LAN (ADR 0042 §I) — a candidate remote delegate.
+export type DiscoveredAgent = { name: string; url: string; host: string; port: number };
+
 export type Archetype = {
   id: string; // "basic", or a bundle id e.g. "pm-stack"
   label: string;

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -1,5 +1,5 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Link2, Play, Plus, Square, Trash2 } from "lucide-react";
+import { Link2, Play, Plus, Radar, Square, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@protolabsai/ui/primitives";
@@ -8,7 +8,7 @@ import { PanelHeader } from "@protolabsai/ui/navigation";
 
 import { api, currentSlug } from "../lib/api";
 import { fleetQuery, queryKeys } from "../lib/queries";
-import type { FleetAgent } from "../lib/types";
+import type { DiscoveredAgent, FleetAgent } from "../lib/types";
 
 // Fleet manager (ADR 0042) — Settings → Agents. Lists the workspace agents with live
 // status (the query polls every 3s, so a crashed agent flips to stopped on its own) and
@@ -55,6 +55,31 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
           ? "This agent can't hold delegates yet — enable the delegates plugin on it (new fleet agents get it automatically; the host needs it enabled + a restart)."
           : e.message,
       ),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: ["delegates"] });
+      void delegatesQ.refetch();
+    },
+  });
+
+  // Network discovery (ADR 0042 §I) — scan the box + LAN for OTHER protoAgents (not in this
+  // fleet), then add a found one as a delegate of the focused agent (its A2A = url + /a2a).
+  const [scanning, setScanning] = useState(false);
+  const [discovered, setDiscovered] = useState<DiscoveredAgent[] | null>(null);
+  const scan = async () => {
+    setScanning(true);
+    setError(null);
+    try {
+      setDiscovered((await api.discoverAgents()).discovered);
+    } catch (e) {
+      setError((e as Error).message);
+    } finally {
+      setScanning(false);
+    }
+  };
+  const addRemote = useMutation({
+    mutationFn: (d: DiscoveredAgent) => api.createDelegate({ name: d.name, type: "a2a", url: `${d.url}/a2a` }),
+    onMutate: () => setError(null),
+    onError: (e: Error) => setError(e.message),
     onSettled: () => {
       qc.invalidateQueries({ queryKey: ["delegates"] });
       void delegatesQ.refetch();
@@ -145,6 +170,42 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
             })}
           </ul>
         )}
+
+        {/* Network discovery — scan the box + LAN for OTHER protoAgents and add one as a remote
+            delegate of the focused agent (ADR 0042 §I). */}
+        <div className="fleet-discover">
+          <Button variant="ghost" onClick={scan} disabled={scanning}>
+            <Radar size={14} /> {scanning ? "Scanning…" : "Discover agents on the network"}
+          </Button>
+          {discovered ? (
+            discovered.length === 0 ? (
+              <p className="fleet-empty">No other protoAgents found on the network.</p>
+            ) : (
+              <ul className="fleet-list">
+                {discovered.map((d) => (
+                  <li key={d.url} className="fleet-row">
+                    <span className="fleet-dot running" aria-hidden />
+                    <div className="fleet-row-main">
+                      <span className="fleet-name">{d.name}</span>
+                      <span className="fleet-meta">{d.url}</span>
+                    </div>
+                    <div className="fleet-row-actions">
+                      {delegateNames.has(d.name) ? (
+                        <span className="fleet-delegate-tag" title="A delegate of this agent">delegate</span>
+                      ) : (
+                        <Button icon variant="ghost" title="Add as a remote delegate (delegate_to)"
+                          disabled={addRemote.isPending}
+                          onClick={() => addRemote.mutate(d)}>
+                          <Link2 size={14} />
+                        </Button>
+                      )}
+                    </div>
+                  </li>
+                ))}
+              </ul>
+            )
+          ) : null}
+        </div>
       </div>
 
       <ConfirmDialog

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -37,6 +37,21 @@ def register_fleet_routes(app) -> None:
         """The agent the console proxy currently points at (None if unset/stopped)."""
         return {"active": proxy.get_active()}
 
+    @app.get("/api/fleet/discover")
+    async def _discover():
+        """Discover OTHER protoAgents on the box + LAN (local port-scan + mDNS, ADR 0042 §I) —
+        candidates to add as remote delegates. Excludes agents already in this fleet (+ self)."""
+        from graph.fleet import discovery
+        fleet = supervisor.status()
+        known = {("127.0.0.1", a["port"]) for a in fleet if a.get("port")}
+        try:  # also exclude our own mDNS self-advert (LAN ip + the host's port)
+            host_port = next((a["port"] for a in fleet if a.get("host")), None)
+            if host_port:
+                known.add((discovery._local_ip(), host_port))
+        except Exception:  # noqa: BLE001
+            pass
+        return {"discovered": await discovery.discover(known=known)}
+
     @app.post("/api/fleet/{name}/activate")
     async def _activate(name: str):
         """Switch the console to an agent — the in-place switch.

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -555,8 +555,22 @@ def _main():
             except Exception:
                 log.exception("[plugins] surface %s failed to start", s.get("name"))
 
+        # Fleet discovery (ADR 0042 §I) — advertise this agent on mDNS so siblings on the LAN can
+        # find it. Best-effort; never breaks boot.
+        try:
+            from graph.fleet import discovery
+            discovery.advertise(agent_name(), int(getattr(STATE, "active_port", 0) or 0))
+        except Exception:
+            log.exception("[discovery] mDNS advertise failed")
+
     @fastapi_app.on_event("shutdown")
     async def _scheduler_shutdown() -> None:
+        # Withdraw the mDNS advertisement (ADR 0042 §I).
+        try:
+            from graph.fleet import discovery
+            discovery.stop_advertise()
+        except Exception:
+            pass
         # Stop plugin surfaces first (ADR 0018) — best-effort.
         for h in STATE.plugin_surface_handles:
             stop = h.get("stop")

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -85,3 +85,16 @@ def test_stop_entire_fleet(client):
 def test_reserved_host_name_is_400(client):
     # `host` is the reserved slug for this instance — a peer named `host` would shadow it.
     assert client.post("/api/fleet", json={"name": "host"}).status_code == 400
+
+
+def test_discover_endpoint(client, monkeypatch):
+    # /api/fleet/discover returns OTHER protoAgents (mock the scan); the route's host self-exclusion
+    # + supervisor scan run, discover() internals are unit-tested elsewhere.
+    from graph.fleet import discovery
+
+    async def fake_discover(**_kw):
+        return [{"name": "remote", "url": "http://1.2.3.4:7899", "host": "1.2.3.4", "port": 7899}]
+
+    monkeypatch.setattr(discovery, "discover", fake_discover)
+    body = client.get("/api/fleet/discover").json()
+    assert body["discovered"][0]["name"] == "remote"


### PR DESCRIPTION
Stacked on #797. Wires `discovery.py`: mDNS advertise on startup + `GET /api/fleet/discover` (local port-scan + mDNS) + a 'Discover agents on the network' section in the fleet manager that adds a found protoAgent as a remote delegate. Verified live (found a standalone on :7899). 9 py + 72 e2e green. Re-targets to main once #797 lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)