### PR TITLE
chore(fleet): remove the dead /active machinery (superseded by slug routing)

### DIFF
--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -132,9 +132,7 @@ function handleApiGet(pathname) {
     case "/api/theme":
       return { theme: null }; // per-agent theme (ADR 0042); null → DS defaults
     case "/api/fleet":
-      return { agents: FLEET.agents, active: FLEET.active };
-    case "/api/fleet/active":
-      return { active: FLEET.active };
+      return { agents: FLEET.agents };
     case "/api/archetypes":
       return { archetypes: ARCHETYPES };
     case "/api/activity":
@@ -309,9 +307,9 @@ const server = createServer(async (req, res) => {
         if (!a) return sendJson(res, { detail: "no such agent" }, 400);
         if (m[2] === "start") { a.running = true; a.pid = 5001; return sendJson(res, { ok: true, agent: a }); }
         if (m[2] === "stop") { a.running = false; a.pid = null; return sendJson(res, { ok: true, name: a.name, stopped: true }); }
-        // activate: host → clear (focus host); peer → set active.
-        if (a.host) { FLEET.active = null; return sendJson(res, { ok: true, active: null, evicted: [] }); }
-        FLEET.active = a.name; a.running = true; return sendJson(res, { ok: true, active: a.name, evicted: [] });
+        // activate: ensure-running + keep-warm (no server-side active pointer — slug routing).
+        if (!a.host) a.running = true;
+        return sendJson(res, { ok: true, evicted: [] });
       }
     }
     if (req.method === "DELETE" && /^\/api\/fleet\/[^/]+$/.test(pathname)) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -492,8 +492,8 @@ export type FleetAgent = {
   host?: boolean; // the instance serving this console — can't be stopped/removed from itself
 };
 
-// `active` is the focused peer, or null when the host itself is focused (talk /api direct).
-export type FleetStatus = { agents: FleetAgent[]; active: string | null };
+// The focused agent is the URL slug now (ADR 0042 slug routing) — no server-side 'active'.
+export type FleetStatus = { agents: FleetAgent[] };
 
 // Another protoAgent found on the box / LAN (ADR 0042 §I) — a candidate remote delegate.
 export type DiscoveredAgent = { name: string; url: string; host: string; port: number };

--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -28,62 +28,6 @@ _HOP = {"host", "content-length", "connection", "keep-alive", "transfer-encoding
         "trailer", "upgrade", "proxy-authorization", "proxy-authenticate"}
 
 
-def _active_path():
-    return manager.workspaces_root() / "fleet-active"
-
-
-def get_active() -> str | None:
-    """The active agent name, or None — only if it's recorded *and* still running."""
-    f = _active_path()
-    if not f.exists():
-        return None
-    name = f.read_text().strip()
-    return name if name and supervisor.is_running(name) else None
-
-
-def set_active(name: str) -> dict:
-    """Point the proxy at a running agent. Raises FleetError if it isn't running."""
-    name = manager._safe(name)
-    if not supervisor.is_running(name):
-        raise supervisor.FleetError(f"{name!r} is not running — start it first")
-    _active_path().write_text(name)
-    invalidate_port_cache()  # a switch must take effect at once (#7 cache)
-    log.info("[fleet] active agent → %s", name)
-    return {"active": name}
-
-
-def clear_active() -> dict:
-    """Focus the host (this instance) — drop the proxy pointer so the console talks to
-    ``/api`` directly again, with no peer focused (ADR 0042)."""
-    f = _active_path()
-    if f.exists():
-        f.unlink()
-    invalidate_port_cache()  # focusing the host must take effect at once (#7 cache)
-    log.info("[fleet] active agent → host (cleared)")
-    return {"active": None}
-
-
-# Active-port cache (#7) — forward() runs per proxied request (every chat POST, panel fetch,
-# SSE), so don't pay a full supervisor.status() scan (workspaces dir + YAML parse + os.kill per
-# pid) each time. Resolve the port straight from the active record with a 1s TTL, invalidated
-# immediately on a switch so a focus change still takes effect at once.
-_port_cache: dict = {"name": None, "port": None, "at": 0.0}
-
-
-def invalidate_port_cache() -> None:
-    _port_cache["at"] = 0.0
-
-
-def _active_port() -> int | None:
-    now = time.monotonic()
-    if now - _port_cache["at"] < 1.0:
-        return _port_cache["port"]
-    name = get_active()  # verifies the agent is still running
-    port = (supervisor._load_state().get(name) or {}).get("port") if name else None
-    _port_cache.update(name=name, port=port, at=now)
-    return port
-
-
 # Shared client (#8) — one pooled AsyncClient instead of a fresh one (TCP setup + FD churn) per
 # request. Unlimited read/write (SSE streams forever) but a finite connect timeout so a peer
 # that accepts then stalls doesn't hang non-streaming requests indefinitely.
@@ -150,15 +94,4 @@ async def forward_to(slug: str, request, path: str):
     port = _port_for_slug(slug)
     if port is None:
         return JSONResponse({"detail": f"agent {slug!r} is not running"}, status_code=409)
-    return await _forward_to_port(port, request, path)
-
-
-async def forward(request, path: str):
-    """Reverse-proxy to the single active agent (back-compat /active/* route, superseded by
-    /agents/<slug>/* slug routing). 409 if no agent is active."""
-    port = _active_port()
-    if port is None:
-        return JSONResponse(
-            {"detail": "no active agent — start one and POST /api/fleet/{name}/activate"},
-            status_code=409)
     return await _forward_to_port(port, request, path)

--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -19,7 +19,6 @@ import httpx
 from starlette.responses import JSONResponse, StreamingResponse
 
 from graph.fleet import supervisor
-from graph.workspaces import manager
 
 log = logging.getLogger("protoagent.server")
 

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -29,13 +29,9 @@ def register_fleet_routes(app) -> None:
 
     @app.get("/api/fleet")
     async def _list_fleet():
-        """Every workspace agent + live status (running/stopped, port, pid, bundle)."""
-        return {"agents": supervisor.status(), "active": proxy.get_active()}
-
-    @app.get("/api/fleet/active")
-    async def _get_active():
-        """The agent the console proxy currently points at (None if unset/stopped)."""
-        return {"active": proxy.get_active()}
+        """Every workspace agent + live status (running/stopped, port, pid, bundle). The focused
+        agent is the URL slug now (ADR 0042 slug routing) — no server-side 'active' pointer."""
+        return {"agents": supervisor.status()}
 
     @app.get("/api/fleet/discover")
     async def _discover():
@@ -54,42 +50,23 @@ def register_fleet_routes(app) -> None:
 
     @app.post("/api/fleet/{name}/activate")
     async def _activate(name: str):
-        """Switch the console to an agent — the in-place switch.
-
-        Resumes the target if it was stopped (keep-N-warm), points the proxy at it,
-        marks it most-recently-active, then evicts the least-recently-used agents
-        beyond the warm cap (their sessions persist + resume on a later switch).
+        """Ensure an agent is running + mark it most-recently-active (keep-N-warm). Call this when
+        a console window navigates to an agent (ADR 0042 slug routing): it resumes a cold agent
+        from its checkpoint, then evicts the least-recently-used agents beyond the warm cap (their
+        sessions persist + resume on a later visit). The host is this instance (always up) → no-op.
         """
         try:
-            # Focusing the host (this instance) drops the proxy pointer — the console
-            # talks to /api directly again, no peer in focus.
             host = next((a for a in supervisor.status() if a.get("host")), None)
             if host and name == host["name"]:
-                return {"ok": True, **proxy.clear_active(), "evicted": []}
+                return {"ok": True, "evicted": []}
             if not supervisor.is_running(name):
                 await asyncio.to_thread(supervisor.start, name)  # resume from checkpoint
-            result = proxy.set_active(name)
             supervisor.touch(name)
-            # Eviction can busy-wait on a SIGTERM (#6) — off the loop so a switch never
-            # freezes the hub / its proxied SSE streams.
+            # Eviction can busy-wait on a SIGTERM (#6) — off the loop.
             evicted = await asyncio.to_thread(supervisor.enforce_warm_cap, protect=name)
-            return {"ok": True, **result, "evicted": evicted}
+            return {"ok": True, "evicted": evicted}
         except (supervisor.FleetError, manager.WorkspaceError) as exc:
             raise HTTPException(400, str(exc))
-
-    @app.api_route("/active/{path:path}",
-                   methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])
-    async def _proxy(path: str, request: Request):
-        """Reverse-proxy the *console* to the active agent (chat → /active/api/chat,
-        SSE → /active/api/events). This is the human's lens only — switching re-points
-        it with no change to the caller's URL.
-
-        It does NOT gate agent↔agent A2A: every agent stays an independent endpoint on
-        its own port (``127.0.0.1:<port>/a2a``), reachable regardless of focus, so a
-        focused agent's ``delegate_to`` hits an unfocused sibling directly — the proxy
-        never sees that traffic.
-        """
-        return await proxy.forward(request, path)
 
     @app.api_route("/agents/{slug}/{path:path}",
                    methods=["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"])

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -58,20 +58,23 @@ def test_create_bad_name_is_400(client):
 
 def test_activate_unknown_400_and_proxy_409(client):
     assert client.post("/api/fleet/ghost/activate").status_code == 400  # no such workspace
-    assert client.get("/active/whatever").status_code == 409            # nothing active
+    assert client.get("/agents/ghost/whatever").status_code == 409      # slug not running
 
 
 def test_activate_autostarts_a_stopped_agent(client):
     client.post("/api/fleet", json={"name": "delta", "start": False})  # created, not running
-    r = client.post("/api/fleet/delta/activate")                       # switch → resume + activate
-    assert r.status_code == 200 and r.json()["active"] == "delta"
+    # activate = ensure-running + keep-warm (no server 'active' pointer — slug routing).
+    r = client.post("/api/fleet/delta/activate")
+    assert r.status_code == 200 and r.json()["ok"]
+    assert next(x for x in client.get("/api/fleet").json()["agents"] if x["name"] == "delta")["running"]
 
 
-def test_activate_running_sets_active(client):
+def test_activate_ensures_running_and_keeps_warm(client):
     client.post("/api/fleet", json={"name": "gamma", "port": 7891})  # create + (mocked) start
-    assert client.post("/api/fleet/gamma/activate").json()["active"] == "gamma"
-    assert client.get("/api/fleet/active").json()["active"] == "gamma"
-    assert client.get("/api/fleet").json()["active"] == "gamma"
+    r = client.post("/api/fleet/gamma/activate").json()
+    assert r["ok"] and "evicted" in r
+    # no server-side active pointer anymore — the focused agent is the URL slug
+    assert "active" not in client.get("/api/fleet").json()
 
 
 def test_stop_entire_fleet(client):


### PR DESCRIPTION
Slug routing (#792) replaced the single global "active" agent with the URL slug (`/agents/<slug>/`), so the active-pointer machinery is dead code. This removes it:

- **proxy**: `get_active` / `set_active` / `clear_active` / `_active_path` + `_active_port` / `_port_cache` / `invalidate_port_cache` + the `/active` `forward()`. Keeps the slug functions + the shared client.
- **routes**: the `/active/{path}` proxy, `GET /api/fleet/active`, and the `active` field on `/api/fleet`.
- **frontend / e2e**: `FleetStatus.active`, the mock's active handling.

It also **repurposes `/api/fleet/{name}/activate`** from "set the pointer" → **ensure-running + keep-N-warm** (resume a cold agent + touch + evict). That re-wires keep-warm (which the pointer-less slug model otherwise never triggered) and gives the frontend a hook to call on slug navigation — closing the navigate-to-a-stopped-agent gap.

1312 py + 75 e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)