### PR TITLE
chore(ui): @protolabsai/ui 0.18 + Identity/SOUL editor + dual-panel toggles & polish

### DIFF
--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -22,7 +22,7 @@ test("right panel resizes by dragging its handle and the width persists", async 
   const right = page.locator(".pl-appshell__col--right");
   const before = (await right.boundingBox())!.width;
 
-  const handle = page.getByRole("separator", { name: "Resize right panel" });
+  const handle = page.getByRole("separator", { name: "Resize panels" });
   const hb = (await handle.boundingBox())!;
   // Drag the handle left ~120px → the panel grows.
   await page.mouse.move(hb.x + hb.width / 2, hb.y + hb.height / 2);
@@ -42,7 +42,7 @@ test("right panel resizes by dragging its handle and the width persists", async 
 test("right panel is keyboard-resizable + double-click collapses (ADR 0035 S3)", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   const right = page.locator(".pl-appshell__col--right");
-  const handle = page.getByRole("separator", { name: "Resize right panel" });
+  const handle = page.getByRole("separator", { name: "Resize panels" });
   const before = (await right.boundingBox())!.width;
 
   // ArrowLeft widens the panel (handle is on its left edge).

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -38,8 +38,10 @@ test("goals tab in the right sidebar lists active goals", async ({ page }) => {
 });
 
 test("beads tab in the right sidebar lists issues (query-backed)", async ({ page }) => {
-  // Beads panel reads via TanStack Query / Suspense (ADR 0013).
-  await page.getByRole("button", { name: "Beads", exact: true }).click();
+  // Beads (TanStack Query / Suspense, ADR 0013) is the default-active right panel, and clicking an
+  // already-open panel now toggles it closed — so switch to Goals first, then back to Beads.
+  await page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true }).click();
+  await page.locator(".pl-rail--right").getByRole("button", { name: "Beads", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Beads" })).toBeVisible();
   await expect(page.getByText("Wire the telemetry rollup")).toBeVisible();
 });
@@ -78,14 +80,15 @@ test("plugins section: Local / Market / Download tabs", async ({ page }) => {
 test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Move off the defaults: a left surface (Agent) + a right-panel tab (Beads).
+  // Move off the defaults: a left surface (Agent) + a non-default right-panel tab (Goals — Beads
+  // is the default, and clicking the default-active one would toggle it closed).
   await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
-  await page.locator(".pl-rail--right").getByRole("button", { name: "Beads", exact: true }).click();
+  await page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true }).click();
 
   // Reload — the persisted store restores both, instead of snapping back to Chat/Notes.
   await page.reload({ waitUntil: "load" });
   await expect(page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true })).toHaveClass(/active/);
-  await expect(page.locator(".pl-rail--right").getByRole("button", { name: "Beads", exact: true })).toHaveClass(/active/);
+  await expect(page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true })).toHaveClass(/active/);
 });
 
 

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -12,7 +12,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.0",
-    "@protolabsai/ui": "^0.17.0",
+    "@protolabsai/ui": "^0.18.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/agent/IdentityPanel.tsx
+++ b/apps/web/src/agent/IdentityPanel.tsx
@@ -3,15 +3,16 @@ import { Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 
 import { useEffect, useState } from "react";
-import { Save } from "lucide-react";
+import { Eye, Pencil, Save } from "lucide-react";
 
 import { PanelHeader } from "@protolabsai/ui/navigation";
+import { Markdown } from "../chat/LazyMarkdown";
 import { api } from "../lib/api";
 import { queryKeys } from "../lib/queries";
 
-// Agent → Identity: who this agent is. Edit the name + SOUL.md (persona) inline;
-// saving merges the name into config, writes SOUL.md, and hot-reloads the graph
-// (POST /api/config). Distinct from the read-only status snapshot in Settings → Overview.
+// Agent → Identity: who this agent is. The SOUL.md (persona) renders as Markdown by default and
+// fills the panel; "Edit" flips it to a raw textarea. Saving merges the name into config, writes
+// SOUL.md, and hot-reloads the graph (POST /api/config).
 
 export function IdentityPanel() {
   const qc = useQueryClient();
@@ -20,6 +21,7 @@ export function IdentityPanel() {
   const [name, setName] = useState("");
   const [soul, setSoul] = useState("");
   const [seeded, setSeeded] = useState(false);
+  const [editing, setEditing] = useState(false); // default: rendered Markdown
 
   useEffect(() => {
     if (data && !seeded) {
@@ -62,7 +64,7 @@ export function IdentityPanel() {
           </Button>
         }
       />
-      <div className="stage-body">
+      <div className="stage-body identity-body">
         {isLoading || !seeded ? (
           <p className="muted">Loading…</p>
         ) : (
@@ -71,18 +73,29 @@ export function IdentityPanel() {
               <span>Agent name</span>
               <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="my-agent" data-testid="identity-name" />
             </label>
-            <label className="field">
-              <span>SOUL.md — the agent's persona &amp; system identity</span>
-              <Textarea
-                value={soul}
-                onChange={(e) => setSoul(e.target.value)}
-                rows={22}
-                spellCheck={false}
-                placeholder="# You are …"
-                data-testid="identity-soul"
-                style={{ fontFamily: "var(--font-mono, monospace)", fontSize: "13px", lineHeight: 1.5, width: "100%" }}
-              />
-            </label>
+            <div className="field soul-field">
+              <div className="soul-head">
+                <span>SOUL.md — the agent's persona &amp; system identity</span>
+                <Button variant="ghost" type="button" onClick={() => setEditing((e) => !e)} data-testid="identity-soul-toggle">
+                  {editing ? <><Eye size={14} /> Preview</> : <><Pencil size={14} /> Edit</>}
+                </Button>
+              </div>
+              {editing ? (
+                <Textarea
+                  value={soul}
+                  onChange={(e) => setSoul(e.target.value)}
+                  spellCheck={false}
+                  placeholder="# You are …"
+                  data-testid="identity-soul"
+                  className="soul-textarea"
+                  style={{ fontFamily: "var(--font-mono, monospace)", fontSize: "13px", lineHeight: 1.5 }}
+                />
+              ) : (
+                <div className="soul-preview markdown-body" data-testid="identity-soul-preview" onDoubleClick={() => setEditing(true)}>
+                  <Markdown>{soul.trim() || "_Empty — click **Edit** to write this agent's persona._"}</Markdown>
+                </div>
+              )}
+            </div>
             {save.isError ? <p className="error-strip" role="alert">Save failed — check the server log.</p> : null}
             {save.isSuccess && !dirty ? <p className="muted">Saved — agent reloaded.</p> : null}
             <p className="muted" style={{ fontSize: "12px" }}>

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -694,9 +694,15 @@ export function App() {
         activeLeft={leftCollapsed ? "" : leftActive}
         activeRight={rightCollapsed ? "" : rightActive}
         onSelect={(side, id) => {
-          // Mirror the right: selecting a rail view re-opens its panel if collapsed.
-          if (side === "left") { setSurface(id); setLeftCollapsed(false); }
-          else { setRightPanel(id); setRightCollapsed(false); }
+          // Click the already-open view's icon → toggle the panel closed; otherwise open the
+          // panel on the clicked view (re-opening it if it was collapsed).
+          if (side === "left") {
+            if (!leftCollapsed && leftActive === id) setLeftCollapsed(true);
+            else { setSurface(id); setLeftCollapsed(false); }
+          } else {
+            if (!rightCollapsed && rightActive === id) setRightCollapsed(true);
+            else { setRightPanel(id); setRightCollapsed(false); }
+          }
         }}
         onRailContextMenu={(side, e, id) => openContextMenu("rail-surface", e, { id, side })}
         onRailReorder={setRailOrder}

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -691,10 +691,11 @@ export function App() {
           dot: s.id === "chat" ? chatStreaming && surface !== "chat" : pluginDots[s.id] || undefined,
         }))}
         rightItems={railSurfaces("right").map((s) => ({ ...s, dot: pluginDots[s.id] || undefined }))}
-        activeLeft={leftActive}
+        activeLeft={leftCollapsed ? "" : leftActive}
         activeRight={rightCollapsed ? "" : rightActive}
         onSelect={(side, id) => {
-          if (side === "left") setSurface(id);
+          // Mirror the right: selecting a rail view re-opens its panel if collapsed.
+          if (side === "left") { setSurface(id); setLeftCollapsed(false); }
           else { setRightPanel(id); setRightCollapsed(false); }
         }}
         onRailContextMenu={(side, e, id) => openContextMenu("rail-surface", e, { id, side })}

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -14,6 +14,7 @@ import {
   LayoutDashboard,
   Loader2,
   MessageSquare,
+  PanelLeft,
   PanelRight,
   Plus,
   Puzzle,
@@ -235,6 +236,8 @@ export function App() {
   const setRightPanel = useUI((s) => s.setRightPanel);
   const rightCollapsed = useUI((s) => s.rightCollapsed);
   const setRightCollapsed = useUI((s) => s.setRightCollapsed);
+  const leftCollapsed = useUI((s) => s.leftCollapsed);
+  const setLeftCollapsed = useUI((s) => s.setLeftCollapsed);
   const rightWidth = useUI((s) => s.rightWidth);
   const setRightWidth = useUI((s) => s.setRightWidth);
   const railOrder = useUI((s) => s.railOrder);
@@ -700,6 +703,8 @@ export function App() {
         onRightWidthChange={setRightWidth}
         rightCollapsed={rightCollapsed}
         onCollapse={setRightCollapsed}
+        leftCollapsed={leftCollapsed}
+        onLeftCollapse={setLeftCollapsed}
         mobileItems={[...railSurfaces("left"), ...railSurfaces("right")].map((s) => ({
           ...s,
           dot: pluginDots[s.id] || undefined,
@@ -754,16 +759,28 @@ export function App() {
               </>
             }
             end={
-              <button
-                type="button"
-                className={`util-btn ${rightCollapsed ? "is-off" : ""}`}
-                onClick={() => setRightCollapsed(!rightCollapsed)}
-                title={rightCollapsed ? "Show side panel" : "Hide side panel"}
-                aria-label="Toggle side panel"
-                data-testid="toggle-right"
-              >
-                <PanelRight size={14} />
-              </button>
+              <>
+                <button
+                  type="button"
+                  className={`util-btn ${leftCollapsed ? "is-off" : ""}`}
+                  onClick={() => setLeftCollapsed(!leftCollapsed)}
+                  title={leftCollapsed ? "Show left panel" : "Hide left panel"}
+                  aria-label="Toggle left panel"
+                  data-testid="toggle-left"
+                >
+                  <PanelLeft size={14} />
+                </button>
+                <button
+                  type="button"
+                  className={`util-btn ${rightCollapsed ? "is-off" : ""}`}
+                  onClick={() => setRightCollapsed(!rightCollapsed)}
+                  title={rightCollapsed ? "Show side panel" : "Hide side panel"}
+                  aria-label="Toggle side panel"
+                  data-testid="toggle-right"
+                >
+                  <PanelRight size={14} />
+                </button>
+              </>
             }
           />
         }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1333,6 +1333,7 @@ select:disabled {
   gap: 10px;
   padding: 12px;
   border-top: 1px solid var(--border);
+  align-items: start; /* don't let the textarea + Send button stretch each other tall */
 }
 
 /* Slash-command autocomplete (floats above the composer). */
@@ -1493,6 +1494,15 @@ textarea {
   resize: none;
 }
 
+/* The chat input is a compact fixed height (it doesn't auto-grow) — without this it has no cap
+   and rendered far too tall. .notes-editor keeps its own sizing above. */
+.composer textarea {
+  height: 60px;
+  min-height: 44px;
+  max-height: 200px;
+  line-height: 1.45;
+}
+
 .field {
   display: grid;
   gap: 6px;
@@ -1505,6 +1515,48 @@ textarea {
   min-height: 0;
   padding: 0 12px;
 }
+
+/* Identity panel — the SOUL.md field fills the panel; rendered Markdown by default (max space),
+   "Edit" flips to a raw textarea. */
+.identity-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  overflow: hidden; /* the SOUL preview/textarea scrolls internally, not the whole body */
+}
+.soul-field {
+  flex: 1;
+  min-height: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.soul-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+}
+.soul-field .soul-textarea {
+  flex: 1;
+  min-height: 0;
+  width: 100%;
+  resize: none;
+}
+.soul-preview {
+  flex: 1;
+  min-height: 0;
+  overflow: auto;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 12px 18px;
+  background: color-mix(in srgb, var(--fg) 3%, transparent);
+  color: var(--fg);
+  font-family: var(--font-sans, inherit);
+  cursor: text;
+}
+.soul-preview > :first-child { margin-top: 0; }
+.soul-preview > :last-child { margin-bottom: 0; }
 
 .field-hint {
   color: var(--fg-subtle, var(--fg-muted));
@@ -3497,13 +3549,19 @@ textarea {
 
 /* "delegate" marker on a fleet row — this agent is a delegate_to target of the focused agent. */
 .fleet-delegate-tag {
+  /* It lives in .fleet-row-actions (a flex row), so center it + don't stretch to the action
+     buttons' height (that left a tall box with the text top-aligned). */
+  align-self: center;
+  display: inline-flex;
+  align-items: center;
   font-size: 10px;
+  line-height: 1.6;
   text-transform: uppercase;
   letter-spacing: 0.04em;
   color: var(--brand-violet, #9b87f2);
   border: 1px solid color-mix(in srgb, var(--brand-violet, #9b87f2) 40%, transparent);
   border-radius: 4px;
-  padding: 0 5px;
+  padding: 1px 6px;
 }
 
 /* Network-discovery sub-section in the fleet manager (ADR 0042 §I). */

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -59,6 +59,7 @@ type UIState = {
   settingsTab: SettingsTab;
   activityTab: ActivityTab;
   rightCollapsed: boolean;
+  leftCollapsed: boolean;
   rightWidth: number;
   // Ordered surface lists per rail (ADR 0035 D2 + 0036) — a surface is on exactly one side, at a
   // position. Core surfaces seeded below; plugin views append by their manifest `placement`. Chat
@@ -83,6 +84,7 @@ type UIState = {
   setSettingsTab: (t: SettingsTab) => void;
   setActivityTab: (t: ActivityTab) => void;
   setRightCollapsed: (b: boolean) => void;
+  setLeftCollapsed: (b: boolean) => void;
   setRightWidth: (w: number) => void;
   // Notification dots (ADR 0039) — a plugin surface key (`plugin:<id>:<view>`) with unseen
   // bus activity shows a rail dot until opened. Persisted so the dot survives a refresh.
@@ -101,6 +103,7 @@ export const useUI = create<UIState>()(
       settingsTab: "overview" as SettingsTab,
       activityTab: "thread",
       rightCollapsed: false,
+      leftCollapsed: false,
       rightWidth: 360,
       railOrder: {
         left: ["chat", "activity", "studio", "knowledge", "agent", "plugins", "settings"],
@@ -154,6 +157,7 @@ export const useUI = create<UIState>()(
       setSettingsTab: (settingsTab) => set({ settingsTab }),
       setActivityTab: (activityTab) => set({ activityTab }),
       setRightCollapsed: (rightCollapsed) => set({ rightCollapsed }),
+      setLeftCollapsed: (leftCollapsed) => set({ leftCollapsed }),
       setRightWidth: (w) => set({ rightWidth: clampWidth(w) }),
       pluginDots: {},
       setPluginDot: (key, on) =>

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.0",
-        "@protolabsai/ui": "^0.17.0",
+        "@protolabsai/ui": "^0.18.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -66,9 +66,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.17.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.17.0.tgz",
-      "integrity": "sha512-zJuMS2NGBHY9ykRq/6LjCzlU2sHg8dJL4o0Hm+pzsQc8dkH95mdBdOrTCS1o31IAcIX5AwA3WnBcrBgOVNw1Lg==",
+      "version": "0.18.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.18.0.tgz",
+      "integrity": "sha512-oqcO7oMBPD34ToD854K3BSN5zeuXYwIyh8BQXfOLQ5zJT8WEkdCNYqeW43fhH4U+XVsKgHWelv1mqmECY2NKag==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Stacked on #806 (re-targets to main once it lands). The UI round from local testing:

- **`@protolabsai/ui` 0.17 → 0.18.**
- **Identity / SOUL.md editor** — renders as Markdown by default and fills the panel; **Edit** toggles a raw textarea (double-click the preview also edits). No more fixed `rows=22` + dead space.
- **Dual-panel toggles** — a left-panel toggle next to the right-panel one in the utility bar. Both reflect the **drag-aware** collapse state (`leftCollapsed` mirrors `rightCollapsed`, persisted per-agent), and the left now mirrors the right's activation: collapsing deselects the active view, clicking a rail view re-opens the panel.
- **Fixes** — chat composer textarea no longer stretches sky-high (`align-items:start` + height cap); the "delegate" badge centers in its flex row instead of a tall box with top-aligned text.

🤖 Generated with [Claude Code](https://claude.com/claude-code)