### PR TITLE
chore: release v0.31.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.31.0] - 2026-06-10
+
 ### Changed
 - **Intro splash shows once per session** — the launch bumper is gated by `sessionStorage`, so a
   refresh no longer replays the 2.5s splash; a fresh tab session sees it once. (Automation still skips it.)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.30.0"
+version = "0.31.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,29 @@
 [
   {
+    "version": "v0.31.0",
+    "date": "2026-06-10",
+    "changes": [
+      "Intro splash shows once per session",
+      "Plugin devkit refreshed (v0.2.0)",
+      "Artifact plugin is now external",
+      "Design system → @protolabsai/ui 0.18, with console polish",
+      "The /active global-pointer proxy machinery",
+      "Retired Module Federation",
+      "Fleet console — run a fleet of agents from one console.",
+      "Chat panel is a slot",
+      "Plugin-driven console navigation",
+      "Goals come alive in the console",
+      "Goals broadcast on the event bus",
+      "Telemetry opt-out in Settings",
+      "Plugin notification dots + event relay",
+      "Plugin event bus",
+      "Fork extension seam",
+      "Generative-UI artifacts",
+      "Generative-UI artifacts",
+      "Secret-scan CI gate"
+    ]
+  },
+  {
     "version": "v0.30.0",
     "date": "2026-06-09",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.31.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.31.0 -m 'Release v0.31.0' && git push origin v0.31.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).