### PR TITLE
feat(setup): add an ACP runtime option to the setup wizard

### DIFF
--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -313,6 +313,9 @@ export type BeadsIssue = {
 };
 
 export type AgentConfig = {
+  // Where turns run: "native" (the built-in LangGraph loop on the model gateway) or
+  // "acp:<agent>" (hand each turn to a CLI coding agent over ACP — ADR 0033).
+  agent_runtime?: string;
   model: {
     provider: string;
     name: string;

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -28,6 +28,14 @@ type Step = "welcome" | "identity" | "model" | "persona" | "tools" | "workspace"
 
 const steps: Step[] = ["welcome", "identity", "model", "persona", "tools", "workspace", "discord", "google", "finish"];
 
+// CLI coding agents that can be the runtime over ACP (ADR 0033) — agent_runtime: acp:<id>.
+const ACP_AGENTS: { id: string; label: string; hint: string }[] = [
+  { id: "proto", label: "proto", hint: "protoLabs CLI — proto --acp" },
+  { id: "codex", label: "Codex", hint: "OpenAI Codex — npx @zed-industries/codex-acp" },
+  { id: "claude", label: "Claude", hint: "Claude agent — npx @agentclientprotocol/claude-agent-acp" },
+  { id: "opencode", label: "OpenCode", hint: "OpenCode — opencode acp" },
+];
+
 // Setup walkthroughs live in the template's (protoAgent) canonical docs — forks
 // don't ship their own docs site, so the in-app help links point there.
 const DISCORD_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/discord#bot-setup";
@@ -36,6 +44,10 @@ const GOOGLE_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/google
 type WizardState = {
   agentName: string;
   operatorName: string;
+  // Where turns run. "native" = the LangGraph loop on the gateway below; "acp" = hand
+  // each turn to the chosen CLI coding agent (agent_runtime: acp:<acpAgent>) — ADR 0033.
+  runtimeKind: "native" | "acp";
+  acpAgent: string;
   apiBase: string;
   apiKey: string;
   modelName: string;
@@ -66,6 +78,8 @@ function defaultState(): WizardState {
   return {
     agentName: "protoagent",
     operatorName: "",
+    runtimeKind: "native",
+    acpAgent: "proto",
     apiBase: "https://api.proto-labs.ai/v1",
     apiKey: "",
     modelName: "protolabs/reasoning",
@@ -96,9 +110,12 @@ function defaultState(): WizardState {
 
 function hydrateState(payload: ConfigPayload, status: SetupStatus | null): WizardState {
   const config = payload.config;
+  const rt = String(config.agent_runtime || "native");
   return {
     agentName: config.identity.name || "protoagent",
     operatorName: config.identity.operator || "",
+    runtimeKind: rt.startsWith("acp:") ? "acp" : "native",
+    acpAgent: rt.startsWith("acp:") ? rt.slice(4) || "proto" : "proto",
     apiBase: config.model.api_base || "https://api.proto-labs.ai/v1",
     apiKey: "",
     modelName: config.model.name || "protolabs/reasoning",
@@ -187,10 +204,12 @@ export function SetupWizard({
   }, [state.discordToken]);
 
   const canGoNext = useMemo(() => {
-    if (step === "model") return state.apiBase.trim() && state.modelName.trim();
+    // ACP runtime needs no gateway, so don't gate the step on the model fields.
+    if (step === "model")
+      return Boolean(state.runtimeKind === "acp" || (state.apiBase.trim() && state.modelName.trim()));
     if (step === "workspace") return state.knowledgePath.trim();
     return true;
-  }, [state.apiBase, state.knowledgePath, state.modelName, step]);
+  }, [state.apiBase, state.knowledgePath, state.modelName, state.runtimeKind, step]);
 
   function update(patch: Partial<WizardState>) {
     setState((current) => ({ ...current, ...patch }));
@@ -300,6 +319,7 @@ export function SetupWizard({
       );
       const response = await api.finishSetup(
         {
+          agent_runtime: state.runtimeKind === "acp" ? `acp:${state.acpAgent}` : "native",
           model,
           identity: {
             name: state.agentName.trim() || "protoagent",
@@ -404,7 +424,68 @@ export function SetupWizard({
           ) : null}
 
           {step === "model" ? (
-            <StepBody icon={<KeyRound size={20} />} title="Model Gateway" kicker="OpenAI-compatible">
+            <StepBody
+              icon={<KeyRound size={20} />}
+              title="Runtime"
+              kicker={state.runtimeKind === "acp" ? "coding agent over ACP" : "OpenAI-compatible gateway"}
+            >
+              {/* How this agent thinks: native LangGraph loop on a gateway, or hand each
+                  turn to a CLI coding agent over ACP (ADR 0033). */}
+              <label className="field">
+                <span>How this agent thinks</span>
+                <div style={{ display: "flex", gap: "0.5rem" }}>
+                  {([
+                    ["native", "Native model", "Run turns on an OpenAI-compatible gateway."],
+                    ["acp", "Coding agent (ACP)", "Hand each turn to a CLI coding agent — it's the brain, no gateway key needed."],
+                  ] as const).map(([kind, label, blurb]) => (
+                    <button
+                      key={kind}
+                      type="button"
+                      onClick={() => update({ runtimeKind: kind })}
+                      style={{
+                        flex: 1,
+                        textAlign: "left",
+                        padding: "0.6rem 0.7rem",
+                        borderRadius: 8,
+                        cursor: "pointer",
+                        color: "inherit",
+                        border: `1px solid ${state.runtimeKind === kind ? "var(--brand-violet-light, #a78bfa)" : "var(--border, #333)"}`,
+                        background:
+                          state.runtimeKind === kind
+                            ? "color-mix(in srgb, var(--brand-violet-light, #a78bfa) 14%, transparent)"
+                            : "transparent",
+                      }}
+                    >
+                      <strong style={{ display: "block", fontSize: 13 }}>{label}</strong>
+                      <small style={{ opacity: 0.7 }}>{blurb}</small>
+                    </button>
+                  ))}
+                </div>
+              </label>
+              {state.runtimeKind === "acp" ? (
+                <label className="field">
+                  <span>Coding agent</span>
+                  <select
+                    value={state.acpAgent}
+                    onChange={(event) => update({ acpAgent: event.target.value })}
+                    style={{
+                      padding: "0.5rem",
+                      borderRadius: 8,
+                      color: "inherit",
+                      background: "var(--bg-panel, #1a1a1a)",
+                      border: "1px solid var(--border, #333)",
+                    }}
+                  >
+                    {ACP_AGENTS.map((a) => (
+                      <option key={a.id} value={a.id}>{a.label}</option>
+                    ))}
+                  </select>
+                  <small style={{ opacity: 0.7 }}>
+                    {ACP_AGENTS.find((a) => a.id === state.acpAgent)?.hint} — runtime set to{" "}
+                    <code>acp:{state.acpAgent}</code>. The gateway below is <strong>optional</strong> (only for native delegates / fallback).
+                  </small>
+                </label>
+              ) : null}
               <div className="setup-grid two">
                 <label className="field">
                   <span>API base</span>

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1283,7 +1283,12 @@ def _build_settings_callbacks() -> dict[str, Any]:
         # unreachable gateway is caught here and returned to the wizard verbatim
         # (e.g. "expected to start with 'sk-'"). Setup stays incomplete, so the
         # operator fixes it in the UI and retries — no file editing required.
-        if config is not None and isinstance(config.get("model"), dict):
+        # …unless the runtime is ACP (acp:<agent>): the coding agent is the brain and
+        # may have no gateway key at all (ADR 0033). Probing a gateway we won't use would
+        # wrongly block setup, so skip it — the model block is still persisted for native
+        # delegates/fallback if the operator filled it in.
+        _runtime = str((config or {}).get("agent_runtime", "native") or "native")
+        if not _runtime.startswith("acp:") and config is not None and isinstance(config.get("model"), dict):
             m = config["model"]
             test_base = m.get("api_base") or (STATE.graph_config.api_base if STATE.graph_config else "")
             test_key = m.get("api_key") or (STATE.graph_config.api_key if STATE.graph_config else "")


### PR DESCRIPTION
Closes #810.

The first-run setup wizard only offered the **native** (LangGraph gateway) runtime. This adds a **runtime selector** to the model step:

- **Native model** — the existing OpenAI-compatible gateway path.
- **Coding agent (ACP)** — pick **proto / Codex / Claude / OpenCode**; that agent becomes the runtime (`agent_runtime: acp:<agent>`, ADR 0033). **No gateway key required** — the coding agent is the brain.

### Changes
- **`apps/web` SetupWizard** — runtime selector + agent picker; gateway fields become optional under ACP (the step is no longer gated on `api_base`/`model`).
- **`finish_setup`** (`server/agent_init.py`) — skip the model-connection probe when `agent_runtime` starts with `acp:`; probing a gateway we won't use would wrongly block setup.
- **`AgentConfig` type** gains `agent_runtime`; the wizard sends it; persisted via the existing generic config write (`config_io` already honors `agent_runtime` — config_io.py:715).

### Verified
Console builds clean; backend compiles; tested live on a fresh-fork instance — picking ACP lets you finish setup with no model key.

🤖 Generated with [Claude Code](https://claude.com/claude-code)