### PR TITLE
fix(fleet): instance-scope the workspaces root — each hub owns its own fleet.json

### DIFF
--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -35,9 +35,20 @@ _RESERVED_NAMES = {"host"}
 
 def workspaces_root() -> Path:
     """Where workspaces live. ``PROTOAGENT_WORKSPACES_DIR`` overrides; default
-    ``~/.protoagent/workspaces``."""
+    ``~/.protoagent/workspaces``.
+
+    Instance-scoped (ADR 0004) like every other store — ``scope_leaf`` on the final
+    resolved path, so a scoped hub owns its own fleet (``~/.protoagent/<iid>/workspaces``
+    + its ``fleet.json``) instead of sharing one registry with every co-located instance
+    (two hubs pruning/evicting each other's agents). This also fences peers: workspace
+    agents run with ``PROTOAGENT_INSTANCE=<name>``, so a peer's fleet view is its own,
+    not the parent hub's. Unscoped stays the shared legacy root (#706 warning covers it).
+    """
+    from paths import scope_leaf
+
     override = os.environ.get("PROTOAGENT_WORKSPACES_DIR", "").strip()
-    return Path(override).expanduser() if override else (Path.home() / ".protoagent" / "workspaces")
+    base = Path(override).expanduser() if override else (Path.home() / ".protoagent" / "workspaces")
+    return scope_leaf(base)
 
 
 def _safe(name: str) -> str:

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -52,3 +52,26 @@ def test_from_config_clones_and_restamps(root, tmp_path):
 def test_bad_name_rejected(root):
     with pytest.raises(manager.WorkspaceError):
         manager.create("bad name")
+
+
+def test_root_is_instance_scoped(root, monkeypatch):
+    """ADR 0004: a scoped instance owns its own workspaces root (and so its own
+    fleet.json) — two co-located hubs must not share one fleet registry."""
+    assert manager.workspaces_root() == root  # unscoped → the plain root
+
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "roxy")
+    scoped = manager.workspaces_root()
+    assert scoped == root.parent / "roxy" / root.name  # scope_leaf nesting
+    assert scoped != root
+
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "other")
+    assert manager.workspaces_root() != scoped  # siblings don't share
+
+
+def test_fleet_state_follows_scoped_root(root, monkeypatch):
+    """fleet.json lives under the scoped root — a scoped hub's registry is its own."""
+    from graph.fleet import supervisor
+
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "roxy")
+    assert supervisor._state_path() == manager.workspaces_root() / "fleet.json"
+    assert "roxy" in supervisor._state_path().parts


### PR DESCRIPTION
## The bug (found live)

Spinning up a second protoAgent instance on the same box (the template test host + the roxy fork) made the two **compete for one backend**: both read/wrote `~/.protoagent/workspaces/fleet.json`. Each hub saw the other's agents, pruned/keep-warm-evicted them, and allocated ports against the same registry. Worse: **peers** run with `PROTOAGENT_INSTANCE=<name>` (manager.py run_exec), but `workspaces_root()` ignored scoping — so a peer's `/api/fleet` saw and could manage its **parent's whole fleet** (stop its own siblings).

## The fix

`workspaces_root()` now routes its final resolved path through `paths.scope_leaf()` — the one ADR 0004 knob every other store already uses:

- scoped hub → `~/.protoagent/<iid>/workspaces` + its own `fleet.json`
- peer → its own (empty-but-self) fleet, fenced from the parent
- unscoped → unchanged shared legacy root, already covered by the #706 `unscoped_warning` at boot

`PROTOAGENT_WORKSPACES_DIR` override composes with scoping the same way `PROTOAGENT_CONFIG_DIR` does in `config_io`.

## Known limit (out of scope)

TCP ports are box-global; per-registry port reservation means two scoped hubs can both hand out 7871 — the second start fails at bind. Pick explicit ports per hub. (Bind-failure fallback is a possible follow-up.)

## Tests

- `test_root_is_instance_scoped` — unscoped = plain root; scoped nests per-iid; siblings differ
- `test_fleet_state_follows_scoped_root` — `fleet.json` lives under the scoped root

1314 py green locally + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)