### PR TITLE
fix(fleet): run mDNS advertise/withdraw off the event loop — kill the 10s boot stall

### DIFF
--- a/graph/fleet/discovery.py
+++ b/graph/fleet/discovery.py
@@ -40,9 +40,20 @@ def _local_ip() -> str:
 
 # ── mDNS advertise (wired into server startup) ────────────────────────────────
 def advertise(name: str, port: int) -> None:
-    """Announce this agent on mDNS so LAN siblings can discover it. Idempotent + best-effort."""
+    """Announce this agent on mDNS so LAN siblings can discover it. Idempotent + best-effort.
+
+    Sync zeroconf — call via ``asyncio.to_thread`` from async code (the ``_browse_mdns``
+    convention): constructed on a running event loop it attaches to that loop, and
+    ``register_service`` then blocks the same loop waiting on its own future — a ~10s
+    ``EventLoopBlocked`` stall at boot. Guarded below so a regressed call site logs and
+    bails instantly instead.
+    """
     global _zc, _info
     if _zc is not None or not port:
+        return
+    if _on_event_loop():
+        log.warning("[discovery] advertise() called on an event loop thread — refusing "
+                    "(sync zeroconf would deadlock it); call via asyncio.to_thread")
         return
     try:
         from zeroconf import ServiceInfo, Zeroconf
@@ -63,8 +74,24 @@ def advertise(name: str, port: int) -> None:
         _zc = None
 
 
+def _on_event_loop() -> bool:
+    """True when the current thread is running an asyncio loop — where sync zeroconf
+    calls (register/unregister/close all wait on loop-scheduled futures) would deadlock."""
+    try:
+        asyncio.get_running_loop()
+    except RuntimeError:
+        return False
+    return True
+
+
 def stop_advertise() -> None:
+    """Withdraw the advertisement. Sync zeroconf — call via ``asyncio.to_thread`` (see
+    ``advertise``); ``unregister``/``close`` block on the loop the same way."""
     global _zc, _info
+    if _zc is not None and _on_event_loop():
+        log.warning("[discovery] stop_advertise() called on an event loop thread — refusing "
+                    "(sync zeroconf would deadlock it); call via asyncio.to_thread")
+        return
     try:
         if _zc is not None:
             if _info is not None:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -556,19 +556,23 @@ def _main():
                 log.exception("[plugins] surface %s failed to start", s.get("name"))
 
         # Fleet discovery (ADR 0042 §I) — advertise this agent on mDNS so siblings on the LAN can
-        # find it. Best-effort; never breaks boot.
+        # find it. Best-effort; never breaks boot. Off the loop (to_thread): sync Zeroconf
+        # constructed on a running event loop attaches to it, then register_service blocks that
+        # same loop waiting on its own future — a guaranteed ~10s EventLoopBlocked boot stall.
         try:
             from graph.fleet import discovery
-            discovery.advertise(agent_name(), int(getattr(STATE, "active_port", 0) or 0))
+            await asyncio.to_thread(
+                discovery.advertise, agent_name(), int(getattr(STATE, "active_port", 0) or 0))
         except Exception:
             log.exception("[discovery] mDNS advertise failed")
 
     @fastapi_app.on_event("shutdown")
     async def _scheduler_shutdown() -> None:
-        # Withdraw the mDNS advertisement (ADR 0042 §I).
+        # Withdraw the mDNS advertisement (ADR 0042 §I). Off the loop — same deadlock as
+        # advertise (zc.close() posts to and waits on the loop it's called from).
         try:
             from graph.fleet import discovery
-            discovery.stop_advertise()
+            await asyncio.to_thread(discovery.stop_advertise)
         except Exception:
             pass
         # Stop plugin surfaces first (ADR 0018) — best-effort.

--- a/tests/test_fleet_discovery.py
+++ b/tests/test_fleet_discovery.py
@@ -1,0 +1,86 @@
+"""Fleet discovery (ADR 0042 §I) — the mDNS advertise lifecycle + its event-loop guard.
+
+Sync zeroconf calls block on futures scheduled on the loop they're called from, so
+``advertise``/``stop_advertise`` must run off the loop (``asyncio.to_thread``); the guard
+turns a regressed on-loop call site into an instant warning instead of a ~10s
+``EventLoopBlocked`` boot stall (seen live, roxy :7874 2026-06-09).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import sys
+import types
+
+import pytest
+
+from graph.fleet import discovery
+
+
+@pytest.fixture(autouse=True)
+def _reset_zc(monkeypatch):
+    monkeypatch.setattr(discovery, "_zc", None)
+    monkeypatch.setattr(discovery, "_info", None)
+
+
+class _FakeZeroconf:
+    def __init__(self):
+        self.registered = None
+        self.closed = False
+
+    def register_service(self, info):
+        self.registered = info
+
+    def unregister_service(self, info):
+        self.registered = None
+
+    def close(self):
+        self.closed = True
+
+
+@pytest.fixture
+def fake_zeroconf(monkeypatch):
+    mod = types.ModuleType("zeroconf")
+    mod.Zeroconf = _FakeZeroconf
+    mod.ServiceInfo = lambda *a, **kw: {"args": a, "kw": kw}
+    monkeypatch.setitem(sys.modules, "zeroconf", mod)
+    return mod
+
+
+def test_advertise_registers_off_loop(fake_zeroconf):
+    discovery.advertise("alpha", 7871)
+    assert isinstance(discovery._zc, _FakeZeroconf)
+    assert discovery._zc.registered is not None
+
+    discovery.advertise("alpha", 7871)  # idempotent — second call is a no-op
+    discovery.stop_advertise()
+    assert discovery._zc is None and discovery._info is None
+
+
+def test_advertise_refuses_on_event_loop(fake_zeroconf, caplog):
+    async def _on_loop():
+        discovery.advertise("alpha", 7871)
+
+    asyncio.run(_on_loop())
+    assert discovery._zc is None  # bailed before touching zeroconf
+    assert "asyncio.to_thread" in caplog.text
+
+
+def test_stop_advertise_refuses_on_event_loop(caplog):
+    zc = _FakeZeroconf()
+    discovery._zc = zc
+
+    async def _on_loop():
+        discovery.stop_advertise()
+
+    asyncio.run(_on_loop())
+    assert discovery._zc is zc and not zc.closed  # untouched — refused, not deadlocked
+    assert "asyncio.to_thread" in caplog.text
+
+    discovery.stop_advertise()  # off the loop: cleans up
+    assert zc.closed and discovery._zc is None
+
+
+def test_advertise_without_port_is_noop(fake_zeroconf):
+    discovery.advertise("alpha", 0)
+    assert discovery._zc is None


### PR DESCRIPTION
## The bug (caught live on a fork boot)

`discovery.advertise()` is called raw inside the **async startup hook** (`server/__init__.py`). Sync `Zeroconf()` constructed on a running event loop attaches to that loop, and `register_service()` then blocks the same loop waiting on a future scheduled on it — a guaranteed deadlock. Every boot stalled ~10s, then zeroconf raised `EventLoopBlocked` and the except swallowed it as `mDNS advertise failed — continuing without it`. So since #805, **no agent has actually been advertising on mDNS** (LAN discovery between machines was silently dead), and every boot paid a 10-second stall.

`stop_advertise()` had the same problem at shutdown — `unregister_service`/`close` also wait on loop-scheduled futures.

## The fix

- Both call sites go through `asyncio.to_thread` — the convention `_browse_mdns` already documents for itself (the browse path was always correct).
- `discovery` grows an `_on_event_loop()` guard: a regressed on-loop call now logs `call via asyncio.to_thread` and bails **instantly** instead of stalling boot for 10s.

## Tests

New `tests/test_fleet_discovery.py` — first direct coverage for the advertise lifecycle (the prod-readiness tasklist's E2 gap): register/idempotence/withdraw with a fake zeroconf, both on-loop guards, no-port no-op.

## Verified live

Throwaway scoped instance: boots and logs `advertising protoagent on mDNS (192.168.5.31:7899)` immediately (previously: 10s gap → traceback), clean shutdown, zero `EventLoopBlocked`.

1314+ py green locally + ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)