### PR TITLE
feat(fleet): tailnet discovery channel — find protoAgents across Tailscale (ADR 0042 §I)

### DIFF
--- a/graph/fleet/discovery.py
+++ b/graph/fleet/discovery.py
@@ -1,10 +1,15 @@
 """Fleet discovery (ADR 0042 §I) — find OTHER protoAgents to add as remote fleet members.
 
-Two channels, merged:
+Three channels, merged:
   • **Local port-scan** — probe ``127.0.0.1`` ports for ``/.well-known/agent-card.json`` (a
     co-located agent, e.g. a freshly-spun Roxy on another port).
   • **mDNS / Bonjour** — every agent advertises a ``_protoagent._tcp`` service on boot; we
     browse the LAN for siblings on *other* machines.
+  • **Tailnet port-scan** — mDNS is link-local multicast and never crosses a Tailscale
+    overlay, so tailnet siblings are found by asking the local ``tailscale`` CLI for online
+    peers and probing their agent-cards over the same port range. (A machine on both the
+    LAN and the tailnet can surface twice — LAN IP via mDNS, ``100.x`` via this channel;
+    both URLs are real, we don't guess which one to keep.)
 
 Pure discovery: returns reachable protoAgents (name + url). Registering one as a remote fleet
 member + proxying into it is the supervisor/proxy's job. All best-effort — a discovery hiccup
@@ -14,8 +19,11 @@ never blocks the server.
 from __future__ import annotations
 
 import asyncio
+import json
 import logging
+import os
 import socket
+import subprocess
 
 import httpx
 
@@ -117,6 +125,49 @@ async def _probe(client: httpx.AsyncClient, host: str, port: int) -> dict | None
     return {"name": card.get("name") or f"{host}:{port}", "url": url, "host": host, "port": port}
 
 
+# macOS App-Store/standalone Tailscale ships the CLI inside the app bundle, not on PATH.
+_TAILSCALE_APP_CLI = "/Applications/Tailscale.app/Contents/MacOS/Tailscale"
+
+
+def _tailscale_cli() -> str | None:
+    """The tailscale CLI to ask about the tailnet, or None when not installed."""
+    import shutil
+
+    return shutil.which("tailscale") or (
+        _TAILSCALE_APP_CLI if os.path.exists(_TAILSCALE_APP_CLI) else None)
+
+
+def _tailnet_peer_ips(timeout: float = 3.0) -> list[str]:
+    """IPv4 tailnet addresses of ONLINE peers (sync subprocess — call via
+    ``asyncio.to_thread``). Empty when tailscale isn't installed or isn't up — the
+    channel just goes quiet, never errors."""
+    cli = _tailscale_cli()
+    if not cli:
+        return []
+    try:
+        out = subprocess.run([cli, "status", "--json"], capture_output=True, text=True,
+                             timeout=timeout)
+        if out.returncode != 0:
+            return []
+        peers = (json.loads(out.stdout).get("Peer") or {}).values()
+        return [ip for p in peers if p.get("Online")
+                for ip in (p.get("TailscaleIPs") or []) if "." in ip]
+    except Exception:  # noqa: BLE001 — discovery is best-effort, never blocks the endpoint
+        log.debug("[discovery] tailscale status failed", exc_info=True)
+        return []
+
+
+async def _scan_tailnet(port_range: tuple[int, int], known: set) -> list[dict]:
+    """Probe every online tailnet peer's agent-card over the fleet port range."""
+    ips = await asyncio.to_thread(_tailnet_peer_ips)
+    if not ips:
+        return []
+    async with httpx.AsyncClient() as client:
+        tasks = [_probe(client, ip, p) for ip in ips
+                 for p in range(port_range[0], port_range[1] + 1) if (ip, p) not in known]
+        return [r for r in await asyncio.gather(*tasks) if r]
+
+
 async def _scan_local(port_range: tuple[int, int], skip_ports: set[int]) -> list[dict]:
     async with httpx.AsyncClient() as client:
         tasks = [_probe(client, "127.0.0.1", p)
@@ -160,16 +211,19 @@ def _browse_mdns(timeout: float) -> list[dict]:
 
 async def discover(*, known: set | None = None,
                    port_range: tuple[int, int] = (7860, 7910), timeout: float = 1.5) -> list[dict]:
-    """Other protoAgents (local + LAN) minus the ones already in the fleet.
+    """Other protoAgents (local + LAN + tailnet) minus the ones already in the fleet.
 
     ``known`` is a set of ``(host, port)`` already known (the host itself + existing members);
     those are filtered out. Returns deduped ``[{name, url, host, port}]``."""
     known = known or set()
     skip_local = {p for (h, p) in known if h in ("127.0.0.1", "localhost")}
-    local = await _scan_local(port_range, skip_local)
-    network = await asyncio.to_thread(_browse_mdns, timeout)
+    local, network, tailnet = await asyncio.gather(  # independent channels — scan concurrently
+        _scan_local(port_range, skip_local),
+        asyncio.to_thread(_browse_mdns, timeout),
+        _scan_tailnet(port_range, known),
+    )
     out: dict[tuple, dict] = {}
-    for a in network + local:  # local wins on a url clash (it's the more specific probe)
+    for a in network + tailnet + local:  # local wins on a url clash (it's the more specific probe)
         if (a["host"], a["port"]) in known:
             continue
         out[(a["host"], a["port"])] = a

--- a/graph/fleet/discovery.py
+++ b/graph/fleet/discovery.py
@@ -214,7 +214,9 @@ async def discover(*, known: set | None = None,
     """Other protoAgents (local + LAN + tailnet) minus the ones already in the fleet.
 
     ``known`` is a set of ``(host, port)`` already known (the host itself + existing members);
-    those are filtered out. Returns deduped ``[{name, url, host, port}]``."""
+    those are filtered out. Returns ``[{name, url, host, port}]`` — duplicates by
+    ``(host, port)`` are collapsed; a dual-homed machine (LAN IP via mDNS + ``100.x``
+    via tailnet) intentionally keeps both addresses."""
     known = known or set()
     skip_local = {p for (h, p) in known if h in ("127.0.0.1", "localhost")}
     local, network, tailnet = await asyncio.gather(  # independent channels — scan concurrently

--- a/tests/test_fleet_discovery.py
+++ b/tests/test_fleet_discovery.py
@@ -84,3 +84,74 @@ def test_stop_advertise_refuses_on_event_loop(caplog):
 def test_advertise_without_port_is_noop(fake_zeroconf):
     discovery.advertise("alpha", 0)
     assert discovery._zc is None
+
+
+# ── tailnet channel ───────────────────────────────────────────────────────────
+_TS_STATUS = {
+    "Peer": {
+        "k1": {"HostName": "ava", "Online": True,
+               "TailscaleIPs": ["100.101.189.45", "fd7a::1"]},
+        "k2": {"HostName": "beefcake", "Online": False,
+               "TailscaleIPs": ["100.77.164.70"]},
+        "k3": {"HostName": "no-ips", "Online": True, "TailscaleIPs": []},
+    }
+}
+
+
+class _FakeRun:
+    def __init__(self, returncode=0, stdout=""):
+        self.returncode = returncode
+        self.stdout = stdout
+
+
+def test_tailnet_peer_ips_online_ipv4_only(monkeypatch):
+    import json as _json
+    monkeypatch.setattr(discovery, "_tailscale_cli", lambda: "/fake/tailscale")
+    monkeypatch.setattr(discovery.subprocess, "run",
+                        lambda *a, **kw: _FakeRun(0, _json.dumps(_TS_STATUS)))
+    assert discovery._tailnet_peer_ips() == ["100.101.189.45"]  # online + IPv4 only
+
+
+def test_tailnet_peer_ips_quiet_without_tailscale(monkeypatch):
+    monkeypatch.setattr(discovery, "_tailscale_cli", lambda: None)
+    assert discovery._tailnet_peer_ips() == []
+
+    monkeypatch.setattr(discovery, "_tailscale_cli", lambda: "/fake/tailscale")
+    monkeypatch.setattr(discovery.subprocess, "run", lambda *a, **kw: _FakeRun(1, ""))
+    assert discovery._tailnet_peer_ips() == []  # CLI errors → empty, never raises
+
+
+def test_scan_tailnet_probes_peers_and_skips_known(monkeypatch):
+    monkeypatch.setattr(discovery, "_tailnet_peer_ips", lambda: ["100.101.189.45"])
+    probed: list[tuple] = []
+
+    async def fake_probe(client, host, port):
+        probed.append((host, port))
+        if port == 7871:
+            return {"name": "ava-agent", "url": f"http://{host}:{port}",
+                    "host": host, "port": port}
+        return None
+
+    monkeypatch.setattr(discovery, "_probe", fake_probe)
+    found = asyncio.run(discovery._scan_tailnet((7870, 7872), known={("100.101.189.45", 7870)}))
+    assert found == [{"name": "ava-agent", "url": "http://100.101.189.45:7871",
+                      "host": "100.101.189.45", "port": 7871}]
+    assert ("100.101.189.45", 7870) not in probed  # known member skipped
+
+
+def test_discover_merges_three_channels(monkeypatch):
+    async def fake_local(port_range, skip):
+        return [{"name": "loc", "url": "http://127.0.0.1:7871", "host": "127.0.0.1", "port": 7871}]
+
+    async def fake_tailnet(port_range, known):
+        return [{"name": "ava-agent", "url": "http://100.101.189.45:7874",
+                 "host": "100.101.189.45", "port": 7874}]
+
+    monkeypatch.setattr(discovery, "_scan_local", fake_local)
+    monkeypatch.setattr(discovery, "_scan_tailnet", fake_tailnet)
+    monkeypatch.setattr(discovery, "_browse_mdns", lambda timeout: [
+        {"name": "lan", "url": "http://192.168.5.40:7871", "host": "192.168.5.40", "port": 7871},
+        {"name": "known", "url": "http://192.168.5.41:7871", "host": "192.168.5.41", "port": 7871},
+    ])
+    found = asyncio.run(discovery.discover(known={("192.168.5.41", 7871)}))
+    assert sorted(f["name"] for f in found) == ["ava-agent", "lan", "loc"]


### PR DESCRIPTION
mDNS is link-local multicast and never crosses a Tailscale overlay (WireGuard is
L3, no multicast), so agents on tailnet machines were undiscoverable no matter
what the LAN advertise did. discovery gains a third channel: ask the local
tailscale CLI (PATH, or the macOS app-bundle binary) for ONLINE peers and probe
their agent-cards over the same fleet port range the local scan uses.

- _tailnet_peer_ips(): `tailscale status --json` → online peers' IPv4 100.x
  addresses; quiet (empty, never raises) when tailscale is absent or down.
- _scan_tailnet(): existing _probe over peers × port range, skipping known
  (host, port) members.
- discover(): the three channels now scan CONCURRENTLY (the mDNS browse always
  costs its full timeout; local+tailnet ride along instead of queuing behind it).
- A dual-homed machine can surface twice (LAN IP via mDNS, 100.x via tailnet) —
  both URLs are real; documented, not deduped (identity names collide too easily).

Verified live on the real tailnet: 7 online peers enumerated; a 0.0.0.0-bound
throwaway probed successfully via this machine's own 100.x address (utun4);
peer scan returns [] cleanly. Note for actually reaching agents across the
tailnet: they must bind non-loopback — the existing security gate correctly
demands A2A_AUTH_TOKEN for that.

1322 py green + ruff clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
