### PR TITLE
feat(instance): co-location heartbeats — banner when a live sibling shares the data root (#706)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,7 +51,10 @@ HANDOFF.md
 handoffs/
 
 # VitePress build artifacts + node modules
+# (both forms: `node_modules/` only matches real dirs — a worktree's symlinked
+# node_modules needs the bare pattern too)
 node_modules/
+node_modules
 docs/.vitepress/dist/
 docs/.vitepress/cache/
 

--- a/apps/web/e2e/warnings.spec.ts
+++ b/apps/web/e2e/warnings.spec.ts
@@ -1,0 +1,25 @@
+import { expect, test } from "@playwright/test";
+
+// Runtime-status `warnings` (#706 co-located instances etc.) render as a slim
+// alert strip under the topbar; server-driven, so no warnings → no strip.
+
+test("runtime warnings render as the shell alert strip", async ({ page }) => {
+  await page.route("**/api/runtime/status", async (route) => {
+    const response = await route.fetch();
+    const json = await response.json();
+    json.warnings = ["Another running instance shares this agent's data (~/.protoagent): roxy (pid 12345, port 7871)."];
+    await route.fulfill({ json });
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+
+  const banner = page.locator(".shell-warning-banner");
+  await expect(banner).toBeVisible();
+  await expect(banner).toContainText("Another running instance");
+  await expect(banner).toHaveAttribute("role", "alert");
+});
+
+test("no warnings → no alert strip (the default fixture)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.locator(".pl-rail").first()).toBeVisible(); // app booted
+  await expect(page.locator(".shell-warning-banner")).toHaveCount(0);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -678,6 +678,15 @@ export function App() {
       />
       </div>
 
+      {/* Operational warnings from the runtime status (#706 co-located instances etc.) —
+          a slim alert strip under the topbar. Server-driven: appears/clears with the poll. */}
+      {(runtime?.warnings ?? []).map((w) => (
+        <div className="shell-warning-banner" role="alert" key={w}>
+          <CircleAlert size={14} />
+          <span>{w}</span>
+        </div>
+      ))}
+
       {/* The dual-rail shell is now the DS AppShell (ADR 0035 + #144): rails (drag-to-reorder +
           cross-rail via dnd-kit), resizable right column, mobile shell, and the utility bar — all
           controlled. We own the surface registry + persistence (railOrder/widths/active in the UI

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -108,6 +108,22 @@ h2 {
   min-height: 48px;
 }
 
+/* Operational warning strip under the topbar (#706 co-located instances etc.) —
+   server-driven via runtime-status `warnings`; appears/clears with the poll. */
+.shell-warning-banner {
+  flex: 0 0 auto;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 14px;
+  font-size: 12.5px;
+  line-height: 1.4;
+  color: var(--warning, #d29922);
+  background: color-mix(in srgb, var(--warning, #d29922) 12%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--warning, #d29922) 35%, transparent);
+}
+.shell-warning-banner svg { flex: none; }
+
 /* Topbar health light — one dot, detail on hover, click to refresh. */
 .status-dot {
   width: 11px;

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -47,6 +47,9 @@ export type RuntimeStatus = {
     skills_bytes?: number | null;
     telemetry_retention_days?: number | null;
   };
+  /** User-facing operational alerts (e.g. a live co-located instance sharing
+   *  this data root, #706) — the shell banners them under the topbar. */
+  warnings?: string[];
   skills?: {
     enabled: boolean;
     count: number;

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -45,6 +45,14 @@ def _operator_allowed_dirs() -> list[str]:
 
 
 def _operator_runtime_status():
+    # Live co-location check (#706) — re-evaluated per poll so the shell banner
+    # appears/clears as siblings come and go. Quiet (empty `.instances/`) costs one
+    # is_dir(); the `ps` guard only runs when sibling heartbeats actually exist.
+    from paths import colocation_warning
+    try:
+        warnings = [w for w in (colocation_warning(),) if w]
+    except Exception:  # noqa: BLE001 — status must never raise
+        warnings = []
     return _build_operator_status(
         config=STATE.graph_config,
         setup_complete=_operator_setup_complete(),
@@ -64,6 +72,7 @@ def _operator_runtime_status():
         plugins=STATE.plugin_meta,
         telemetry_store=STATE.telemetry_store,
         checkpoint_path=STATE.checkpoint_path,
+        warnings=warnings,
     )
 
 

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -21,6 +21,7 @@ def build_runtime_status(
     plugins: list[dict[str, Any]] | None = None,
     telemetry_store: Any = None,
     checkpoint_path: str = "",
+    warnings: list[str] | None = None,
 ) -> dict[str, Any]:
     """Return UI-safe runtime status.
 
@@ -29,7 +30,11 @@ def build_runtime_status(
 
     ``allowed_dirs`` is the operator-console sandbox the client uses to
     populate the project-path picker; the server still enforces it.
+
+    ``warnings`` are user-facing operational alerts (e.g. a live co-located
+    instance sharing this data root, #706) — the shell banners them.
     """
+    warnings_block = [w for w in (warnings or []) if w]
     project = {"path": project_path, "allowed_dirs": list(allowed_dirs or [])}
 
     skill_count = 0
@@ -57,6 +62,7 @@ def build_runtime_status(
             "scheduler": {"enabled": False, "backend": "disabled"},
             "goal": {"enabled": False, "controller_loaded": False},
             "cache_warmer": {"enabled": False, "loaded": False},
+            "warnings": warnings_block,
         }
 
     return {
@@ -125,6 +131,7 @@ def build_runtime_status(
             "skills_bytes": _file_size(getattr(skills_index, "path", None)),
             "telemetry_retention_days": getattr(config, "telemetry_retention_days", None),
         },
+        "warnings": warnings_block,
     }
 
 

--- a/paths.py
+++ b/paths.py
@@ -117,3 +117,115 @@ def workspace_dir(*, create: bool = False) -> Path:
     if create:
         base.mkdir(parents=True, exist_ok=True)
     return base.resolve()
+
+
+# ── co-location detection (#706) ──────────────────────────────────────────────
+# `unscoped_warning` above is a static boot hint — it fires for every normal
+# single-instance setup, so it stays a log line. The signal worth a console
+# banner is a LIVE sibling sharing this data root (two unscoped instances, or
+# two scoped ones with the same id — the exact two-hubs bug): each instance
+# drops a `<pid>.json` heartbeat under `<root>/.instances/` at boot, removes it
+# at shutdown, and anyone can ask who else is alive in the same root.
+
+
+def _instances_dir() -> Path:
+    """`.instances/` under THIS instance's data root (scoped or shared)."""
+    home = data_home()
+    iid = instance_id()
+    return (home / _safe_segment(iid) if iid else home) / ".instances"
+
+
+def _pid_alive(pid: int) -> bool:
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    except OSError:
+        return False
+    return True
+
+
+def _is_protoagent_pid(pid: int) -> bool:
+    """PID-reuse guard (the supervisor's #10 pattern): a heartbeat survives a crash, so a
+    recycled pid could make a dead sibling look alive. Only trust a pid whose command line
+    is actually a protoAgent server; if we can't inspect it, trust the pid (don't go
+    quiet on odd platforms)."""
+    import subprocess
+
+    try:
+        out = subprocess.run(["ps", "-o", "command=", "-p", str(pid)],
+                             capture_output=True, text=True, timeout=2).stdout
+    except (OSError, subprocess.SubprocessError):
+        return True
+    if not out.strip():
+        return False
+    return "-m server" in out or ("python" in out.lower() and "server" in out)
+
+
+def register_instance(port: int | None = None, identity: str = "") -> None:
+    """Drop this process's heartbeat in the data root. Best-effort — never blocks boot."""
+    import json
+
+    try:
+        d = _instances_dir()
+        d.mkdir(parents=True, exist_ok=True)
+        (d / f"{os.getpid()}.json").write_text(json.dumps(
+            {"pid": os.getpid(), "port": port, "identity": identity}))
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def unregister_instance() -> None:
+    """Remove this process's heartbeat (shutdown). Best-effort."""
+    try:
+        (_instances_dir() / f"{os.getpid()}.json").unlink(missing_ok=True)
+    except Exception:  # noqa: BLE001
+        pass
+
+
+def colocated_instances() -> list[dict]:
+    """OTHER live protoAgent processes sharing this data root (stale entries pruned)."""
+    import json
+
+    out: list[dict] = []
+    try:
+        d = _instances_dir()
+        if not d.is_dir():
+            return out
+        for f in d.glob("*.json"):
+            try:
+                pid = int(f.stem)
+            except ValueError:
+                continue
+            if pid == os.getpid():
+                continue
+            if not _pid_alive(pid) or not _is_protoagent_pid(pid):
+                f.unlink(missing_ok=True)  # stale heartbeat (crash / pid recycled)
+                continue
+            try:
+                rec = json.loads(f.read_text())
+            except (OSError, ValueError):
+                rec = {}
+            out.append({"pid": pid, "port": rec.get("port"),
+                        "identity": rec.get("identity") or ""})
+    except Exception:  # noqa: BLE001
+        return out
+    return out
+
+
+def colocation_warning() -> str | None:
+    """A user-facing warning when another live instance shares this data root, else None."""
+    others = colocated_instances()
+    if not others:
+        return None
+    who = ", ".join(
+        f"{o['identity'] or 'unknown'} (pid {o['pid']}"
+        + (f", port {o['port']})" if o.get("port") else ")")
+        for o in others)
+    iid = instance_id()
+    root = (data_home() / _safe_segment(iid)) if iid else data_home()
+    return (f"Another running instance shares this agent's data ({root}): {who}. "
+            "They can clobber each other's chat history, knowledge and stores — give each "
+            "instance its own PROTOAGENT_INSTANCE id (or stop the extra one).")

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -566,8 +566,28 @@ def _main():
         except Exception:
             log.exception("[discovery] mDNS advertise failed")
 
+        # Co-location heartbeat (#706) — mark this process in the data root and warn
+        # loudly if a live sibling already shares it (the runtime status re-checks on
+        # every poll, so the console banners it too). Off the loop: the check shells
+        # out to `ps` per sibling.
+        try:
+            import paths as _paths
+            _paths.register_instance(int(getattr(STATE, "active_port", 0) or 0) or None,
+                                     agent_name())
+            _w = await asyncio.to_thread(_paths.colocation_warning)
+            if _w:
+                log.warning("[instance] %s", _w)
+        except Exception:
+            log.exception("[instance] co-location check failed")
+
     @fastapi_app.on_event("shutdown")
     async def _scheduler_shutdown() -> None:
+        # Drop the co-location heartbeat (#706). Best-effort.
+        try:
+            import paths as _paths
+            _paths.unregister_instance()
+        except Exception:
+            pass
         # Withdraw the mDNS advertisement (ADR 0042 §I). Off the loop — same deadlock as
         # advertise (zc.close() posts to and waits on the loop it's called from).
         try:

--- a/tests/test_instance_scope.py
+++ b/tests/test_instance_scope.py
@@ -62,3 +62,65 @@ def test_skills_tier_config_parses(tmp_path):
     c = LangGraphConfig.from_yaml(str(cfg))
     assert c.skills_shared is True
     assert c.commons_path == "/tmp/commons"
+
+
+# ── co-location heartbeats (#706) ─────────────────────────────────────────────
+def _home(monkeypatch, tmp_path):
+    monkeypatch.delenv("PROTOAGENT_INSTANCE", raising=False)
+    monkeypatch.delenv("PROTOAGENT_AUTO_SCOPE", raising=False)
+    monkeypatch.setattr(paths, "data_home", lambda: tmp_path)
+    return tmp_path
+
+
+def test_register_unregister_heartbeat(monkeypatch, tmp_path):
+    home = _home(monkeypatch, tmp_path)
+    paths.register_instance(7871, "protoagent")
+    import os
+    f = home / ".instances" / f"{os.getpid()}.json"
+    assert f.exists()
+    assert paths.colocated_instances() == []  # self doesn't count as a sibling
+    paths.unregister_instance()
+    assert not f.exists()
+
+
+def test_scoped_heartbeats_live_in_scoped_root(monkeypatch, tmp_path):
+    _home(monkeypatch, tmp_path)
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "roxy")
+    paths.register_instance(7874, "roxy")
+    import os
+    assert (tmp_path / "roxy" / ".instances" / f"{os.getpid()}.json").exists()
+    paths.unregister_instance()
+
+
+def test_colocated_sibling_detected_and_warned(monkeypatch, tmp_path):
+    home = _home(monkeypatch, tmp_path)
+    d = home / ".instances"; d.mkdir()
+    (d / "12345.json").write_text('{"pid": 12345, "port": 7871, "identity": "roxy"}')
+    monkeypatch.setattr(paths, "_pid_alive", lambda pid: True)
+    monkeypatch.setattr(paths, "_is_protoagent_pid", lambda pid: True)
+    sibs = paths.colocated_instances()
+    assert sibs == [{"pid": 12345, "port": 7871, "identity": "roxy"}]
+    w = paths.colocation_warning()
+    assert "roxy" in w and "PROTOAGENT_INSTANCE" in w and str(home) in w
+
+
+def test_stale_heartbeats_pruned(monkeypatch, tmp_path):
+    home = _home(monkeypatch, tmp_path)
+    d = home / ".instances"; d.mkdir()
+    (d / "12345.json").write_text('{"pid": 12345}')      # dead pid
+    (d / "23456.json").write_text('{"pid": 23456}')      # recycled pid (not a server)
+    (d / "not-a-pid.json").write_text("{}")              # garbage name → ignored
+    monkeypatch.setattr(paths, "_pid_alive", lambda pid: pid == 23456)
+    monkeypatch.setattr(paths, "_is_protoagent_pid", lambda pid: False)
+    assert paths.colocated_instances() == []
+    assert not (d / "12345.json").exists() and not (d / "23456.json").exists()
+    assert paths.colocation_warning() is None
+
+
+def test_runtime_status_carries_warnings():
+    from operator_api.runtime import build_runtime_status
+    s = build_runtime_status(config=None, setup_complete=False, graph_loaded=False,
+                             warnings=["sibling alert", ""])
+    assert s["warnings"] == ["sibling alert"]            # empties filtered
+    s2 = build_runtime_status(config=None, setup_complete=False, graph_loaded=False)
+    assert s2["warnings"] == []


### PR DESCRIPTION
The two-hubs bug's third leg: an unscoped fork (roxy) booted next to the host and
silently shared ~/.protoagent. The static unscoped_warning() fires for every normal
single-instance setup, so it stays a boot log line; the signal worth a BANNER is a
LIVE sibling in the same data root.

- paths.py: each server drops <root>/.instances/<pid>.json at startup, removes it at
  shutdown; colocated_instances() prunes stale entries (dead pid, or recycled pid
  whose command line isn't a protoAgent server — the supervisor's #10 ps guard) and
  colocation_warning() formats the alert. Scoped instances heartbeat in their scoped
  root, so two roxys with the same id are caught too.
- server startup/shutdown hooks: register/unregister + boot-time warning log (the ps
  check runs off the loop).
- runtime status: new `warnings` list (UI contract + types.ts), computed live per
  poll in _operator_runtime_status, so the banner appears/clears as siblings come and go.
- App.tsx: slim `.shell-warning-banner` alert strip under the topbar (existing
  CircleAlert icon, warning tokens).

Verified live: two instances with the same PROTOAGENT_INSTANCE on :7897/:7898 — the
second logs the warning at boot, BOTH report each other (pid + port) in runtime
status, and the warning clears within a poll of the sibling exiting. The ADR 0004
scheduler owner-lock fired alongside, as designed.

Tests: 6 new py (heartbeat round-trip, scoped roots, sibling detect + message, stale
prune, contract carries/filters warnings) + warnings.spec.ts e2e (strip renders with
role=alert; absent on the default fixture). 1323 py + 77 e2e green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
