### PR TITLE
feat(fleet): activate on slug navigation — cold agents resume when you open their window

### DIFF
--- a/apps/web/e2e/activate.spec.ts
+++ b/apps/web/e2e/activate.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+// Slug navigation → activate (#806): a window opening /app/agent/<slug>/ ensures its
+// agent is running (cold resume from checkpoint) + touches it for keep-N-warm. The
+// fixture's "roxy" is STOPPED, so this is the exact navigate-to-a-cold-agent path.
+
+test("opening a slug page activates (resumes) the agent", async ({ page }) => {
+  const activated = page.waitForRequest(
+    (r) => r.method() === "POST" && r.url().includes("/api/fleet/roxy/activate"),
+  );
+  await page.goto("/app/agent/roxy/", { waitUntil: "load" });
+  await activated; // boot fired the resume call
+
+  // And the mock fleet now reports it running.
+  const fleet = await page.evaluate(() => fetch("/api/fleet").then((r) => r.json()));
+  const roxy = fleet.agents.find((a: { id: string }) => a.id === "roxy");
+  expect(roxy.running).toBe(true);
+});
+
+test("the host window never calls activate", async ({ page }) => {
+  const activateCalls: string[] = [];
+  page.on("request", (r) => {
+    if (r.method() === "POST" && r.url().includes("/activate")) activateCalls.push(r.url());
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.locator(".pl-rail").first()).toBeVisible(); // app booted
+  expect(activateCalls).toEqual([]);
+});

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -140,6 +140,26 @@ export function agentHref(slug: string): string {
   return slug === "host" ? base : `${base}agent/${encodeURIComponent(slug)}/`;
 }
 
+/** Boot hook (ADR 0042 slug routing → #806): a window opening `/app/agent/<slug>/` ensures
+ * its agent is RUNNING — `POST /api/fleet/<name>/activate` resumes a cold agent from its
+ * checkpoint and touches it for keep-N-warm LRU. Every slug navigation is a full page load
+ * (FleetSwitcher navigates), so this one boot call covers switch, reload and new-window.
+ * Fire-and-forget: the shell's queries already retry through the resume window, and any
+ * failure (non-fleet backend, unknown slug) just leaves today's behavior. The slug is the
+ * agent's `id`; activate wants its `name` — map via the hub's fleet status. */
+export async function activateSlugAgent(): Promise<void> {
+  const slug = currentSlug();
+  if (slug === "host") return;
+  try {
+    const fleet = await api.fleet(); // hub control-plane path — never slug-scoped
+    const agent = fleet.agents.find((a) => a.id === slug || a.name === slug);
+    if (!agent || agent.host) return;
+    await api.activateAgent(agent.name);
+  } catch {
+    // best-effort — the proxy 502s + query retries surface a truly unreachable agent
+  }
+}
+
 function isHubPath(path: string) {
   // The fleet control plane is served by the supervisor itself — never scoped to an agent.
   return path.startsWith("/api/fleet") || path.startsWith("/api/archetypes");
@@ -667,7 +687,8 @@ export const api = {
     );
   },
   activateAgent(name: string) {
-    return request<{ ok: boolean; active: string; evicted: string[] }>(`/api/fleet/${encodeURIComponent(name)}/activate`, {
+    // #806: ensure-running + keep-N-warm touch (no server-side active pointer since slug routing).
+    return request<{ ok: boolean; evicted: string[] }>(`/api/fleet/${encodeURIComponent(name)}/activate`, {
       method: "POST",
     });
   },

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -10,10 +10,12 @@ import "@protolabsai/design/css/tokens";
 import "./app/tailwind.css";
 import "@protolabsai/ui/styles.css";
 import "./app/theme.css";
+import { activateSlugAgent } from "./lib/api";
 import { queryClient } from "./lib/queryClient";
 import { watchThemeChanges } from "./lib/agentTheme";
 
 watchThemeChanges(); // fire `protoagent:theme` on any theme change → plugin iframes repaint live
+void activateSlugAgent(); // cold-agent resume + keep-warm touch on slug navigation (#806)
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
#806 repurposed POST /api/fleet/{name}/activate into ensure-running + keep-N-warm
but nothing called it: navigating to a stopped agent's window just hit a dead
proxy. Now main.tsx fires activateSlugAgent() at boot — every slug navigation is
a full page load (FleetSwitcher navigates), so the one hook covers switch, reload
and open-in-new-window:

- maps the URL slug (the agent's id) to its name via the hub's /api/fleet (never
  slug-scoped), skips host/unknown, then POSTs activate — resume from checkpoint
  + keep-warm LRU touch.
- fire-and-forget: the shell's runtime query already retries 30×/1s, which spans
  the resume window; failures (non-fleet backend) leave today's behavior.
- activateAgent response type drops the stale `active` field (#806 removed it).

e2e: activate.spec.ts — opening /app/agent/roxy/ (fixture's STOPPED agent) fires
the activate POST and the mock fleet flips it to running; the host window never
calls activate. 79 e2e green + tsc clean.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
