### PR TITLE
feat(fleet): host-as-delegator — hot-mount plugin routes on reload, console enable-and-retry

### DIFF
--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -60,3 +60,44 @@ test("topbar switcher navigates to an agent by slug", async ({ page }) => {
   await expect(page).toHaveURL(/\/app\/agent\/roxy\//);
   await expect(page.getByTestId("fleet-switcher")).toContainText("roxy");
 });
+
+test("host without delegates: add → 404 → Enable delegates → retried add succeeds (#797)", async ({ page }) => {
+  // The focused agent (host) doesn't serve /api/delegates until the plugin is enabled;
+  // enabling appends plugins.enabled via /api/config and the reload hot-mounts the routes,
+  // so the retry lands without a restart.
+  let enabled = false;
+  let delegatePosts = 0;
+  let configPosts = 0;
+  await page.route("**/api/fleet", async (route) => {
+    const response = await route.fetch();
+    const json = await response.json();
+    for (const a of json.agents) if (!a.host) a.a2a = `http://127.0.0.1:${a.port}/a2a`;
+    await route.fulfill({ json });
+  });
+  await page.route("**/api/delegates", async (route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    delegatePosts += 1;
+    if (!enabled) return route.fulfill({ status: 404, json: { detail: "Not Found" } });
+    return route.fulfill({ json: { ok: true } });
+  });
+  await page.route("**/api/config", async (route) => {
+    if (route.request().method() !== "POST") return route.fallback();
+    configPosts += 1;
+    enabled = true;
+    return route.fulfill({ json: { ok: true, messages: ["config saved", "reloaded"] } });
+  });
+
+  await openAgents(page);
+  await page
+    .locator(".fleet-row", { hasText: "ava" })
+    .getByRole("button", { name: "Add as a delegate of this agent (delegate_to)" })
+    .click();
+
+  const error = page.locator(".fleet-error");
+  await expect(error).toContainText("can't hold delegates");
+  await page.getByTestId("enable-delegates").click();
+
+  await expect.poll(() => configPosts).toBe(1); // plugins.enabled += delegates applied
+  await expect.poll(() => delegatePosts).toBe(2); // the 404'd attempt + the post-enable retry
+  await expect(error).toHaveCount(0); // retry succeeded -> error cleared
+});

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -43,22 +43,47 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   // delegate work to it. The delegates query/POST is slug-scoped, so it lands on the focused agent.
   const delegatesQ = useQuery({ queryKey: ["delegates"], queryFn: () => api.delegates(), retry: false });
   const delegateNames = new Set((delegatesQ.data?.delegates ?? []).map((d) => d.name));
+  // When an add 404s (the focused agent doesn't serve /api/delegates), we keep the attempted
+  // entry so "Enable delegates" can retry it after enabling the plugin. Fleet agents ship with
+  // delegates enabled at create (ADR 0042); the HOST carries no plugins by default — enabling
+  // appends to plugins.enabled via applyConfig, and the reload hot-mounts the routes (#797),
+  // so the retry succeeds without a restart.
+  const [needsEnable, setNeedsEnable] = useState<{ name: string; url: string } | null>(null);
   const addDelegate = useMutation({
-    // Fleet agents ship with the `delegates` plugin enabled (ADR 0042), so this is a straight add
-    // — no enable step, no restart. The host carries no plugins by default, so adding delegates
-    // FROM the host's window needs delegates enabled there first; surface that clearly on 404.
-    mutationFn: (a: FleetAgent) => api.createDelegate({ name: a.name, type: "a2a", url: a.a2a }),
-    onMutate: () => setError(null),
-    onError: (e: Error) =>
-      setError(
-        /404|not found/i.test(e.message)
-          ? "This agent can't hold delegates yet — enable the delegates plugin on it (new fleet agents get it automatically; the host needs it enabled + a restart)."
-          : e.message,
-      ),
+    mutationFn: (entry: { name: string; url: string }) =>
+      api.createDelegate({ name: entry.name, type: "a2a", url: entry.url }),
+    onMutate: () => {
+      setError(null);
+      setNeedsEnable(null);
+    },
+    onError: (e: Error, entry) => {
+      if (/404|not found/i.test(e.message)) {
+        setNeedsEnable(entry);
+        setError("This agent can't hold delegates yet — the delegates plugin isn't enabled on it.");
+      } else {
+        setError(e.message);
+      }
+    },
     onSettled: () => {
       qc.invalidateQueries({ queryKey: ["delegates"] });
       void delegatesQ.refetch();
     },
+  });
+  const enableDelegates = useMutation({
+    mutationFn: async (entry: { name: string; url: string }) => {
+      const { config } = await api.config(); // the FOCUSED agent's live config (slug-scoped)
+      const enabled = config.plugins?.enabled ?? [];
+      if (!enabled.includes("delegates")) {
+        await api.applyConfig({ plugins: { enabled: [...enabled, "delegates"] } }, null);
+      }
+      return entry;
+    },
+    onMutate: () => setError(null),
+    onSuccess: (entry) => {
+      setNeedsEnable(null);
+      addDelegate.mutate(entry); // routes are hot-mounted on the reload — retry the add now
+    },
+    onError: (e: Error) => setError(e.message),
   });
 
   // Network discovery (ADR 0042 §I) — scan the box + LAN for OTHER protoAgents (not in this
@@ -76,15 +101,9 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
       setScanning(false);
     }
   };
-  const addRemote = useMutation({
-    mutationFn: (d: DiscoveredAgent) => api.createDelegate({ name: d.name, type: "a2a", url: `${d.url}/a2a` }),
-    onMutate: () => setError(null),
-    onError: (e: Error) => setError(e.message),
-    onSettled: () => {
-      qc.invalidateQueries({ queryKey: ["delegates"] });
-      void delegatesQ.refetch();
-    },
-  });
+  // Remote adds funnel through the same mutation, so a host-window 404 gets the
+  // same enable-and-retry path as fleet-row adds.
+  const addRemote = (d: DiscoveredAgent) => addDelegate.mutate({ name: d.name, url: `${d.url}/a2a` });
 
   return (
     <section className="panel stage-panel">
@@ -101,6 +120,15 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
         {error ? (
           <p className="fleet-error" role="alert">
             {error}
+            {needsEnable ? (
+              <Button
+                variant="default"
+                disabled={enableDelegates.isPending || addDelegate.isPending}
+                onClick={() => enableDelegates.mutate(needsEnable)}
+                data-testid="enable-delegates">
+                {enableDelegates.isPending ? "Enabling…" : "Enable delegates on this agent"}
+              </Button>
+            ) : null}
           </p>
         ) : null}
         {fleet.isLoading ? (
@@ -139,7 +167,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                       ) : (
                         <Button icon variant="ghost" title="Add as a delegate of this agent (delegate_to)"
                           disabled={addDelegate.isPending || !a.a2a}
-                          onClick={() => addDelegate.mutate(a)}>
+                          onClick={() => addDelegate.mutate({ name: a.name, url: a.a2a! })}>
                           <Link2 size={14} />
                         </Button>
                       )
@@ -194,8 +222,8 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                         <span className="fleet-delegate-tag" title="A delegate of this agent">delegate</span>
                       ) : (
                         <Button icon variant="ghost" title="Add as a remote delegate (delegate_to)"
-                          disabled={addRemote.isPending}
-                          onClick={() => addRemote.mutate(d)}>
+                          disabled={addDelegate.isPending}
+                          onClick={() => addRemote(d)}>
                           <Link2 size={14} />
                         </Button>
                       )}

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -44,6 +44,10 @@ class AppState:
     plugin_a2a_skills: list = field(default_factory=list)  # A2A card skills from plugins (#570)
     thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571)
     plugin_routers: list = field(default_factory=list)
+    # The live FastAPI app + the (plugin_id, prefix) keys already mounted on it —
+    # lets a config reload hot-mount a newly-enabled plugin's routes (no restart).
+    fastapi_app: object = None
+    plugin_router_keys: set = field(default_factory=set)
     plugin_surfaces: list = field(default_factory=list)
     plugin_surface_handles: list = field(default_factory=list)
     plugin_meta: list = field(default_factory=list)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -249,6 +249,7 @@ from server.agent_init import (  # noqa: E402,F401 — re-export of the extracte
     _checkpoint_prune_loop,
     _init_langgraph_agent,
     _monitor_goals_loop,
+    _mount_plugin_routers,
     _plugin_agent_invoke,
     _populate_plugin_host,
     _register_plugin_subagents,
@@ -422,6 +423,7 @@ def _main():
     from pydantic import BaseModel as PydanticBaseModel
 
     fastapi_app = FastAPI(title=f"{agent_name()} — protoAgent")
+    STATE.fastapi_app = fastapi_app  # reload hot-mounts newly-enabled plugin routes onto it
     fastapi_app.add_middleware(
         CORSMiddleware,
         allow_origin_regex=(
@@ -487,14 +489,10 @@ def _main():
     _populate_plugin_host()
 
     # Plugin-contributed routes (ADR 0018) — mounted after the core routes,
-    # under each plugin's namespaced prefix (default /plugins/<id>). Once, here;
-    # routes don't hot-reload. Best-effort so one bad router can't break boot.
-    for r in STATE.plugin_routers:
-        try:
-            fastapi_app.include_router(r["router"], prefix=r["prefix"])
-            log.info("[plugins] mounted router from %s at %s", r["plugin_id"], r["prefix"] or "/")
-        except Exception:
-            log.exception("[plugins] failed to mount router from %s", r.get("plugin_id"))
+    # under each plugin's namespaced prefix (default /plugins/<id>). The same
+    # helper runs on every config reload, so enabling a route-bearing plugin
+    # (e.g. delegates) takes effect WITHOUT a restart (#797 fleet blocker).
+    _mount_plugin_routers(STATE.plugin_routers)
 
     # --- Scheduler lifecycle ------------------------------------------------
     # The local scheduler needs an asyncio polling task; the Workstacean

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -904,6 +904,32 @@ def _build_scheduler(config) -> "SchedulerBackend | None":
         return None
 
 
+def _mount_plugin_routers(routers: list[dict]) -> None:
+    """Mount plugin routers (ADR 0018) onto the live app, skipping any already
+    mounted (keyed ``(plugin_id, prefix)``). Called at boot AND on every config
+    reload, so enabling a route-bearing plugin (e.g. ``delegates``) takes effect
+    without a restart — the #797 fleet blocker ("hot-reload rebuilds the graph
+    but routes bind at startup"). FastAPI accepts ``include_router`` after
+    startup; new routes are appended (no existing /api catch-all shadows them).
+
+    Disabling can't UNmount (FastAPI has no route-removal API) — a disabled
+    plugin's routes stay until restart, same as before this helper existed.
+    Best-effort per router so one bad plugin can't break boot or a reload."""
+    app = STATE.fastapi_app
+    if app is None:
+        return
+    for r in routers:
+        key = (r.get("plugin_id"), r.get("prefix"))
+        if key in STATE.plugin_router_keys:
+            continue
+        try:
+            app.include_router(r["router"], prefix=r.get("prefix") or "")
+            STATE.plugin_router_keys.add(key)
+            log.info("[plugins] mounted router from %s at %s", r["plugin_id"], r.get("prefix") or "/")
+        except Exception:  # noqa: BLE001
+            log.exception("[plugins] failed to mount router from %s", r.get("plugin_id"))
+
+
 def _reload_langgraph_agent() -> tuple[bool, str]:
     """Rebuild the compiled graph from the latest config YAML.
 
@@ -1059,6 +1085,13 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     # change without a restart — this is how the Discord plugin live-reconnects
     # when its token/admin/enabled changes (was a bespoke discord_changed block).
     _reload_plugin_surfaces(new_config)
+
+    # Hot-mount routes from newly-enabled plugins (e.g. delegates) — already-mounted
+    # routers are skipped, so repeat reloads are no-ops. Keep STATE.plugin_routers
+    # current for anything introspecting the live route set.
+    if is_setup_complete():
+        _mount_plugin_routers(new_plugins.routers)
+        STATE.plugin_routers = new_plugins.routers
 
     if new_graph is None:
         log.info("[reload] setup not complete — config reloaded, graph not compiled")

--- a/tests/test_plugin_route_hotmount.py
+++ b/tests/test_plugin_route_hotmount.py
@@ -1,0 +1,68 @@
+"""Plugin-route hot-mount (ADR 0018 + #797) — enabling a route-bearing plugin on a
+config reload mounts its routes WITHOUT a restart; already-mounted routers are skipped."""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import APIRouter, FastAPI
+from fastapi.testclient import TestClient
+
+from runtime.state import STATE
+from server.agent_init import _mount_plugin_routers
+
+
+def _router(marker: str) -> APIRouter:
+    r = APIRouter()
+
+    @r.get("/ping")
+    def _ping():
+        return {"from": marker}
+
+    return r
+
+
+@pytest.fixture
+def app(monkeypatch):
+    a = FastAPI()
+    monkeypatch.setattr(STATE, "fastapi_app", a)
+    monkeypatch.setattr(STATE, "plugin_router_keys", set())
+    return a
+
+
+def test_mounts_and_serves(app):
+    _mount_plugin_routers([{"plugin_id": "delegates", "router": _router("delegates"),
+                            "prefix": "/api/delegates"}])
+    c = TestClient(app)
+    assert c.get("/api/delegates/ping").json() == {"from": "delegates"}
+
+
+def test_remount_skipped_new_added(app):
+    first = {"plugin_id": "a", "router": _router("a"), "prefix": "/api/a"}
+    _mount_plugin_routers([first])
+    n_routes = len(app.routes)
+
+    # Reload with the same plugin again + a newly-enabled one: the existing router
+    # is NOT re-mounted (no duplicate routes), the new one comes up live.
+    _mount_plugin_routers([first, {"plugin_id": "b", "router": _router("b"), "prefix": "/api/b"}])
+    assert len(app.routes) == n_routes + 1
+    c = TestClient(app)
+    assert c.get("/api/a/ping").json() == {"from": "a"}
+    assert c.get("/api/b/ping").json() == {"from": "b"}
+    assert STATE.plugin_router_keys == {("a", "/api/a"), ("b", "/api/b")}
+
+
+def test_noop_without_app(monkeypatch):
+    monkeypatch.setattr(STATE, "fastapi_app", None)
+    monkeypatch.setattr(STATE, "plugin_router_keys", set())
+    _mount_plugin_routers([{"plugin_id": "x", "router": _router("x"), "prefix": "/x"}])
+    assert STATE.plugin_router_keys == set()  # nothing mounted, nothing tracked
+
+
+def test_bad_router_does_not_break_the_batch(app):
+    _mount_plugin_routers([
+        {"plugin_id": "bad", "router": object(), "prefix": "/api/bad"},  # include_router raises
+        {"plugin_id": "good", "router": _router("good"), "prefix": "/api/good"},
+    ])
+    c = TestClient(app)
+    assert c.get("/api/good/ping").json() == {"from": "good"}
+    assert ("bad", "/api/bad") not in STATE.plugin_router_keys


### PR DESCRIPTION
The #797 blocker: a config reload rebuilt the graph/tools but plugin ROUTES only
bound at server startup, so enabling the delegates plugin on a running agent (the
HOST especially — it serves the console) needed a full restart. Peers dodge this
via auto-enable at create; the host had no path at all.

Backend — routes now hot-mount:
- _mount_plugin_routers() (agent_init): mounts plugin routers onto the live app,
  keyed (plugin_id, prefix), skipping ones already mounted. Used by BOTH the boot
  mount loop and _reload_langgraph_agent's commit, so a reload that enables a
  route-bearing plugin serves its routes immediately. STATE gains the fastapi_app
  handle + the mounted-keys set. (Disabling still can't UNmount — FastAPI has no
  route removal — same as before.)

Console — the fleet manager's host-404 becomes an action:
- a failed add-as-delegate (404) keeps the attempted entry and offers "Enable
  delegates on this agent": appends plugins.enabled via applyConfig (slug-scoped,
  so it lands on the focused agent), then retries the add. Remote (discovered)
  adds funnel through the same path.

Verified live: fresh agent → /api/delegates 404 → POST /api/config
plugins.enabled=[delegates] → /api/delegates 200 → delegate added. No restart.

Tests: 4 py (mount/dedupe/no-app/bad-router) + fleet.spec enable-flow e2e
(404 → enable → exactly one config POST + retried add → error cleared).
1333 py + 80 e2e green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
