### PR TITLE
chore(ui): adopt DS Alert for the shell + settings banners (contribute-back loop)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -87,6 +87,7 @@ import { SettingsCategoryPanel } from "../settings/SettingsCategory";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
 import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
+import { Alert } from "@protolabsai/ui/data";
 import { Logo } from "@protolabsai/ui/primitives";
 import { useIsMobile } from "../lib/useIsMobile";
 import { useActiveTheme } from "../lib/useActiveTheme";
@@ -679,12 +680,12 @@ export function App() {
       </div>
 
       {/* Operational warnings from the runtime status (#706 co-located instances etc.) —
-          a slim alert strip under the topbar. Server-driven: appears/clears with the poll. */}
+          a slim alert strip under the topbar. Server-driven: appears/clears with the poll.
+          DS Alert owns the visuals; the class is placement + the e2e hook. */}
       {(runtime?.warnings ?? []).map((w) => (
-        <div className="shell-warning-banner" role="alert" key={w}>
-          <CircleAlert size={14} />
-          <span>{w}</span>
-        </div>
+        <Alert status="warning" className="shell-warning-banner" key={w}>
+          {w}
+        </Alert>
       ))}
 
       {/* The dual-rail shell is now the DS AppShell (ADR 0035 + #144): rails (drag-to-reorder +

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -110,19 +110,14 @@ h2 {
 
 /* Operational warning strip under the topbar (#706 co-located instances etc.) —
    server-driven via runtime-status `warnings`; appears/clears with the poll. */
+/* Placement only — DS Alert (pl-alert) owns the visuals. Square it off: it's a strip
+   between the topbar and the shell, not a floating card. */
 .shell-warning-banner {
   flex: 0 0 auto;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  padding: 6px 14px;
-  font-size: 12.5px;
-  line-height: 1.4;
-  color: var(--warning, #d29922);
-  background: color-mix(in srgb, var(--warning, #d29922) 12%, transparent);
-  border-bottom: 1px solid color-mix(in srgb, var(--warning, #d29922) 35%, transparent);
+  border-radius: 0;
+  border-left: 0;
+  border-right: 0;
 }
-.shell-warning-banner svg { flex: none; }
 
 /* Topbar health light — one dot, detail on hover, click to refresh. */
 .status-dot {
@@ -2888,24 +2883,9 @@ textarea {
 }
 
 /* ── Settings surface ─────────────────────────────────────────────────────── */
+/* Banners are DS Alert (pl-alert) now — only the stage spacing lives here. */
 .settings-banner {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  padding: 8px 10px;
   margin-bottom: 10px;
-  border-radius: var(--radius);
-  background: rgba(212, 189, 79, 0.14);
-  border: 1px solid rgba(212, 189, 79, 0.32);
-  color: #eadf9a;
-  font-size: 0.82rem;
-}
-.settings-banner svg { flex: none; }
-/* Active-runtime banner (ADR 0033) — info tone (brand violet), not the amber warning. */
-.settings-banner.runtime-banner {
-  background: color-mix(in srgb, var(--pl-color-brand-lavender) 14%, transparent);
-  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 32%, transparent);
-  color: inherit;
 }
 .settings-status {
   margin: 0 0 10px;

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -1,7 +1,8 @@
+import { Alert } from "@protolabsai/ui/data";
 import { Input, Select, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
 import { QueryErrorResetBoundary, useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { AlertTriangle, Bot, ExternalLink, Link2, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
+import { ExternalLink, Link2, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
 
 import { Suspense, useMemo, useState } from "react";
 import type { ReactNode } from "react";
@@ -172,20 +173,16 @@ export function SettingsCategory({
       />
       <div className="stage-body">
         {acpAgent ? (
-          <div className="settings-banner runtime-banner">
-            <Bot size={14} />
-            <span>
-              Running on <strong>{acpAgent}</strong> (ACP) — it drives each turn with its own tools.
-              The model settings below power protoAgent's own calls (compaction, goal checks); with no
-              gateway key configured, those run on {acpAgent} too.
-            </span>
-          </div>
+          <Alert status="info" className="settings-banner">
+            Running on <strong>{acpAgent}</strong> (ACP) — it drives each turn with its own tools.
+            The model settings below power protoAgent's own calls (compaction, goal checks); with no
+            gateway key configured, those run on {acpAgent} too.
+          </Alert>
         ) : null}
         {pendingRestart.length ? (
-          <div className="settings-banner" role="alert">
-            <AlertTriangle size={14} />
-            <span>Needs a restart to take effect: {pendingRestart.join(", ")}</span>
-          </div>
+          <Alert status="warning" className="settings-banner">
+            Needs a restart to take effect: {pendingRestart.join(", ")}
+          </Alert>
         ) : null}
         {status ? <p className="settings-status">{status}</p> : null}
         {!groups.length && !footer ? <p className="muted">{emptyHint || "Nothing to configure here."}</p> : null}


### PR DESCRIPTION
The DS already ships Alert (status-tinted, role=alert, icon/action/dismiss) — both
of our hand-rolled banners were re-implementing it:

- App.tsx shell warning strip (#818 runtime warnings) → <Alert status="warning">;
  .shell-warning-banner is now placement-only (squared edges for the strip position)
  + stays as the e2e hook.
- SettingsCategory ACP runtime banner + needs-restart banner → <Alert status="info"/
  "warning">; the bespoke .settings-banner visuals (amber rgba + lavender mix) are
  deleted, margin stays.

Net: -30 lines of bespoke banner css, three call sites on the DS component. The
genuinely-missing piece (inline rename control) is filed upstream instead:
protoContent#195 (EditableText).

26 vitest + 81 e2e green (incl. warnings.spec asserting the strip + role=alert).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
