### PR TITLE
docs(design): record the contribute-back loop as a standing rule + the #195 filing

### DIFF
--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -221,18 +221,31 @@ const server = createServer(async (req, res) => {
 
   if (pathname === "/a2a" && req.method === "POST") {
     const body = await readBody(req);
-    // tasks/get — the reconcile path (self-heal a stuck streaming turn): return a
-    // terminal task carrying the final answer as an artifact.
-    if (body?.method === "tasks/get") {
+    // GetTask — the reconcile path (self-heal a stuck streaming turn + the cross-agent
+    // turn watcher): return a terminal task carrying the final answer as an artifact.
+    // Mirrors the REAL a2a-sdk 1.1 wire: proto method name, TASK_STATE_* state, the task
+    // FLAT on `result`, member-style `{text}` parts. The legacy `tasks/get` is -32601 on
+    // the live server — answering it here is how the self-heal rotted unnoticed.
+    if (body?.method === "GetTask") {
       return sendJson(res, {
         jsonrpc: "2.0",
         id: body.id,
         result: {
-          id: body.params?.id, contextId: "reconcile", kind: "task",
-          status: { state: "completed" },
-          artifacts: [{ parts: [{ kind: "text", text: "RECONCILED ANSWER" }] }],
+          id: body.params?.id, contextId: "reconcile",
+          status: { state: "TASK_STATE_COMPLETED" },
+          artifacts: [{ parts: [{ text: "RECONCILED ANSWER" }] }],
         },
       });
+    }
+    if (body?.method === "CancelTask") {
+      return sendJson(res, {
+        jsonrpc: "2.0", id: body.id,
+        result: { id: body.params?.id, status: { state: "TASK_STATE_CANCELLED" } },
+      });
+    }
+    if (body?.method === "tasks/get" || body?.method === "tasks/cancel") {
+      // The 0.3 names are GONE on the live server — keep the mock honest.
+      return sendJson(res, { jsonrpc: "2.0", id: body.id, error: { code: -32601, message: "Method not found" } });
     }
     return handleA2AStream(req, res, body);
   }

--- a/apps/web/e2e/turn-watch.spec.ts
+++ b/apps/web/e2e/turn-watch.spec.ts
@@ -1,0 +1,50 @@
+import { expect, test } from "@playwright/test";
+
+// Cross-agent turn-finished notifications: a window watches the OTHER slugs'
+// persisted in-flight turns (localStorage) and polls their durable tasks via the
+// hub proxy; a terminal task surfaces as a toast. The mock's tasks/get always
+// answers `completed`, so a seeded "streaming" turn on another slug resolves on
+// the watcher's first round.
+
+test("a finished turn on another agent raises a toast in this window", async ({ page }) => {
+  await page.addInitScript(() => {
+    const session = {
+      version: 1,
+      currentSessionId: "chat-x",
+      sessions: [{
+        id: "chat-x",
+        title: "Summarize the quarterly numbers",
+        createdAt: 1, updatedAt: 2,
+        messages: [
+          { id: "u1", role: "user", content: "summarize", status: "done" },
+          { id: "a1", role: "assistant", content: "working…", status: "streaming", taskId: "task-bg-1" },
+        ],
+      }],
+    };
+    // Another agent's window persisted this (slug `roxy`); we open the HOST window.
+    window.localStorage.setItem("protoagent.chat.sessions:roxy", JSON.stringify(session));
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // The watcher's first round polls /agents/roxy/a2a tasks/get → completed → toast,
+  // with the agent's display name from /api/fleet.
+  await expect(page.getByText("roxy finished a turn")).toBeVisible({ timeout: 10_000 });
+  await expect(page.getByText(/Summarize the quarterly numbers/)).toBeVisible();
+});
+
+test("the focused agent's own turns do not toast", async ({ page }) => {
+  await page.addInitScript(() => {
+    const session = {
+      version: 1,
+      currentSessionId: "chat-y",
+      sessions: [{
+        id: "chat-y", title: "Own work", createdAt: 1, updatedAt: 2,
+        messages: [{ id: "a2", role: "assistant", content: "…", status: "streaming", taskId: "task-self-1" }],
+      }],
+    };
+    window.localStorage.setItem("protoagent.chat.sessions", JSON.stringify(session)); // the HOST's own key
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.waitForTimeout(1500); // give a watcher round time to (wrongly) fire
+  await expect(page.getByText(/finished a turn/)).toHaveCount(0);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -62,6 +62,7 @@ import type { LucideIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import type { ComponentType, LazyExoticComponent, ReactNode } from "react";
+import { FleetTurnWatch } from "./FleetTurnWatch";
 import { IntroSplash } from "./IntroSplash";
 import { BootGate } from "./BootGate";
 
@@ -624,6 +625,10 @@ export function App() {
     <>
     <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
       <IntroSplash />
+      {/* Cross-agent awareness: toast + native-notify when ANOTHER agent's turn
+          finishes (per-window SSE can't see it — this watches the other slugs'
+          persisted in-flight turns and polls their durable tasks via the hub). */}
+      <FleetTurnWatch />
       {/* Cold-start gate: holds over the app until the runtime probe first
           resolves (engine up), so the ~30s frozen-sidecar boot shows
           "Starting <agent>…" rather than a "Load failed" flash. */}

--- a/apps/web/src/app/FleetTurnWatch.tsx
+++ b/apps/web/src/app/FleetTurnWatch.tsx
@@ -1,0 +1,153 @@
+import { useToast } from "@protolabsai/ui/overlays";
+import { useEffect } from "react";
+
+import { api, authToken, currentSlug } from "../lib/api";
+import { notifyIfHidden } from "../lib/notify";
+import type { ChatMessage } from "../lib/types";
+
+// Cross-agent "turn finished" notifications (ADR 0042 follow-up). Each window's SSE +
+// chat stream is scoped to ITS slug, so a window has no live channel to a turn running
+// on another agent. But every window on this origin can see the other slugs'
+// persisted chat state (`protoagent.chat.sessions[:slug]`), and the hub proxies every
+// agent's A2A — so we watch the other slugs' in-flight turns and poll their durable
+// tasks (the same `tasks/get` the in-window self-heal uses; the a2a-sdk has no
+// `tasks/resubscribe`, so polling is the re-attach ceiling). Two signals, deduped:
+//   • poll: a watched taskId reaches a terminal state on its agent;
+//   • storage event: the owning window (still open) finalized the turn itself.
+
+const POLL_MS = 5000;
+const TERMINAL = /completed|failed|canceled|cancelled/i;
+const NOTIFIED_KEY = "protoagent.turnwatch.notified"; // sessionStorage — survives soft reloads
+
+type Watch = { slug: string; taskId: string; title: string };
+
+function notifiedSet(): Set<string> {
+  try {
+    return new Set(JSON.parse(sessionStorage.getItem(NOTIFIED_KEY) || "[]"));
+  } catch {
+    return new Set();
+  }
+}
+
+function markNotified(taskId: string) {
+  try {
+    const s = notifiedSet();
+    s.add(taskId);
+    sessionStorage.setItem(NOTIFIED_KEY, JSON.stringify([...s].slice(-50)));
+  } catch {
+    /* best-effort */
+  }
+}
+
+/** In-flight turns persisted by OTHER slugs' windows (this window's own turns stream live). */
+export function scanOtherSlugs(current: string): Watch[] {
+  const out: Watch[] = [];
+  const seen = notifiedSet();
+  for (let i = 0; i < localStorage.length; i++) {
+    const key = localStorage.key(i) || "";
+    if (!key.startsWith("protoagent.chat.sessions")) continue;
+    const slug = key === "protoagent.chat.sessions" ? "host" : key.slice("protoagent.chat.sessions:".length);
+    if (slug === current) continue;
+    try {
+      const state = JSON.parse(localStorage.getItem(key) || "null");
+      for (const s of state?.sessions ?? []) {
+        const last = [...(s.messages ?? [])].reverse().find((m: ChatMessage) => m.role === "assistant");
+        if (last?.status === "streaming" && last.taskId && !seen.has(last.taskId)) {
+          out.push({ slug, taskId: last.taskId, title: s.title || "a chat" });
+        }
+      }
+    } catch {
+      /* skip unparseable blobs */
+    }
+  }
+  return out;
+}
+
+/** GetTask (A2A 1.0 proto name + version header) against a SPECIFIC agent — not the
+ *  window's slug — via the hub proxy. Unary result = the task flat on `result`. */
+async function taskState(slug: string, taskId: string): Promise<string> {
+  const path = slug === "host" ? "/a2a" : `/agents/${encodeURIComponent(slug)}/a2a`;
+  const headers: Record<string, string> = { "content-type": "application/json", "A2A-Version": "1.0" };
+  const t = authToken();
+  if (t) headers.Authorization = `Bearer ${t}`;
+  const r = await fetch(path, {
+    method: "POST",
+    headers,
+    body: JSON.stringify({ jsonrpc: "2.0", id: `watch-${taskId}`, method: "GetTask", params: { id: taskId } }),
+  });
+  if (!r.ok) return "";
+  const j = await r.json().catch(() => null);
+  const res = j?.result;
+  const task = res?.task ?? res;
+  return String(task?.status?.state ?? "");
+}
+
+export function FleetTurnWatch() {
+  const toast = useToast();
+
+  useEffect(() => {
+    const current = currentSlug();
+    let stopped = false;
+    let names: Record<string, string> = {}; // slug(id) → display name, lazy
+
+    async function displayName(slug: string): Promise<string> {
+      if (!Object.keys(names).length) {
+        try {
+          names = Object.fromEntries((await api.fleet()).agents.map((a) => [a.host ? "host" : a.id, a.name]));
+        } catch {
+          /* non-fleet backend — slugs are fine */
+        }
+      }
+      return names[slug] || slug;
+    }
+
+    async function announce(w: Watch, state: string) {
+      if (notifiedSet().has(w.taskId)) return;
+      markNotified(w.taskId);
+      const name = await displayName(w.slug);
+      const failed = /fail|cancel/i.test(state);
+      toast({
+        tone: failed ? "error" : "success",
+        title: `${name} finished a turn`,
+        message: failed ? `"${w.title}" ended with ${state}` : `"${w.title}" is done — switch over to read it.`,
+      });
+      notifyIfHidden(`${name} finished a turn`, w.title);
+    }
+
+    let prev: Watch[] = [];
+    async function round() {
+      if (stopped) return;
+      const candidates = scanOtherSlugs(current);
+      // A watched turn that VANISHED from storage was finalized by its (open) owner window.
+      for (const old of prev) {
+        if (!candidates.some((c) => c.taskId === old.taskId)) void announce(old, "completed");
+      }
+      prev = candidates;
+      for (const w of candidates) {
+        try {
+          const state = await taskState(w.slug, w.taskId);
+          if (TERMINAL.test(state)) {
+            void announce(w, state);
+            prev = prev.filter((p) => p.taskId !== w.taskId);
+          }
+        } catch {
+          /* unreachable agent — keep watching */
+        }
+      }
+    }
+
+    const timer = setInterval(() => void round(), POLL_MS);
+    const onStorage = (e: StorageEvent) => {
+      if (e.key?.startsWith("protoagent.chat.sessions")) void round();
+    };
+    window.addEventListener("storage", onStorage);
+    void round();
+    return () => {
+      stopped = true;
+      clearInterval(timer);
+      window.removeEventListener("storage", onStorage);
+    };
+  }, [toast]);
+
+  return null;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -861,26 +861,36 @@ export const api = {
   },
 
   cancelTask(taskId: string) {
+    // A2A 1.0 (a2a-sdk 1.1): proto method name + the version header — `tasks/cancel`
+    // is -32601 Method not found on the live server (same rot class as the eval
+    // harness's; the mock now mirrors the 1.0 wire so this can't rot silently again).
     return request<{ result?: unknown; error?: unknown }>("/a2a", {
       method: "POST",
+      headers: { "A2A-Version": "1.0" },
       body: {
         jsonrpc: "2.0",
         id: `cancel-${Date.now()}`,
-        method: "tasks/cancel",
+        method: "CancelTask",
         params: { id: taskId },
       },
     });
   },
 
-  // Reconcile a turn against the server's durable task (A2A tasks/get). Used to
+  // Reconcile a turn against the server's durable task (A2A GetTask). Used to
   // self-heal a chat message stuck in `streaming` after the stream was
   // interrupted (reload, network blip, a stale tab) — the server task is the
   // source of truth. Returns the normalized state + the final answer text (empty
   // until terminal).
+  //
+  // A2A 1.0: the method is `GetTask` (+ A2A-Version header) and the unary result
+  // is the task FLAT on `result` with TASK_STATE_* states. The old `tasks/get`
+  // was Method-not-found against a2a-sdk 1.1 — which made this self-heal finalize
+  // a still-running turn instantly with empty state (caught live 2026-06-09).
   async getTask(taskId: string): Promise<{ state: string; text: string }> {
     const res = await request<A2AFrame>("/a2a", {
       method: "POST",
-      body: { jsonrpc: "2.0", id: `get-${Date.now()}`, method: "tasks/get", params: { id: taskId } },
+      headers: { "A2A-Version": "1.0" },
+      body: { jsonrpc: "2.0", id: `get-${Date.now()}`, method: "GetTask", params: { id: taskId } },
     });
     const result = res.result;
     const task = (result?.task ?? (result?.kind === "task" ? result : result)) as

--- a/docs/design/ui-component-audit.md
+++ b/docs/design/ui-component-audit.md
@@ -109,6 +109,16 @@ Context-menu **registry/store** (`ContextType` keying is app domain logic — on
 
 **Coordination thread:** [protoContent #137](https://github.com/protoLabsAI/protoContent/issues/137) — the umbrella discussion where both teams work through priorities, API shapes, and AppShell convergence. The rows below are its actionable children.
 
+> **The contribute-back loop (standing rule).** Before hand-rolling any console UI:
+> **(1)** check `@protolabsai/ui` for an existing component — adopt it (the Alert
+> banners were re-implemented twice before anyone looked); **(2)** if it's genuinely
+> missing and the pattern has (or will have) a second consumer, **file a gap issue on
+> protoContent** in the #131/#186/#188 format (Gap / Evidence / Proposed API /
+> Priority / Context) and link it here; **(3)** an app-local interim implementation is
+> fine — mark it with the issue # so the adoption sweep can retire it when the DS
+> ships. Every bespoke component is either a filed gap or a deliberate
+> "not-for-the-DS" entry — never silent.
+
 **`@protolabsai/ui@0.5.0` (published 2026-06-08) delivered 3 of 6** — the P0 + both P1 composites. Adoption now unblocked.
 
 | # | Request | Priority | Status |

--- a/docs/dev/prod-readiness-tasklist.md
+++ b/docs/dev/prod-readiness-tasklist.md
@@ -79,9 +79,12 @@ Suggested order (dependency-aware):
 ## F. Design-system migration
 
 > **`@protolabsai/ui@0.21.0` shipped 3 of the 4 filed gaps:** #184 `Grid`, #186 `TabBar`, #188 `Empty` — **closed**. #187 `ToolCard` **held for design** (crew answering: do activity/inbox rows share the chat-tool shape; generic vs chat-specific of the 52 classes; status set-once vs live-streaming).
+>
+> **Contribute-back loop is a standing rule** (recorded in `docs/design/ui-component-audit.md` § Filed upstream): check the DS first, file genuine gaps on protoContent, mark app-local interims with the issue #. 2026-06-09: DS `Alert` adopted for the shell + settings banners (PR #825 — both were bespoke re-implementations); **protoContent #195 filed** (`EditableText` inline-rename — consumers: fleet rename #823, chat-tab rename pre-F6).
 
 | ID | Task | Evidence | Effort | Disp. |
 |----|------|----------|:------:|:-----:|
+| F8 | Adopt DS `EditableText` when protoContent #195 ships → retire `.fleet-rename-input` (+ chat-tab rename with F6) | `FleetManagerPanel`, `ChatSurface` | S | ⚪ Backlog (blocked on #195) |
 | F5 | **Adopt DS `Grid` (#184)** → delete `.archetype-grid`/`.subagent-grid`/`.metric-grid` (bump →0.21) | 3 sites | S | 🟡 Next (reference) |
 | F1 | DS Phase 1 — token sweep (`muted`/`empty`/`spin`/status → DS) | `theme.css` | M | 🟡 Next |
 | F6 | Adopt DS `TabBar` (#186) → retire `.chat-tab*` | `chat/ChatSurface` | M | ⚪ Backlog |


### PR DESCRIPTION
- ui-component-audit.md § Filed upstream: the loop (check DS → file gap → mark
  interim with the issue #; every bespoke component is a filed gap or a deliberate
  not-for-the-DS entry, never silent).
- prod-readiness F-section: Alert adoption (PR #825) + protoContent #195
  (EditableText) recorded; new F8 adoption row blocked on #195.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
