### PR TITLE
fix(async): stop blind-catching CancelledError; annotate best-effort excepts (C6)

### DIFF
--- a/graph/cache_warmer.py
+++ b/graph/cache_warmer.py
@@ -146,5 +146,7 @@ class CacheWarmer:
         task.cancel()
         try:
             await task
-        except (asyncio.CancelledError, Exception):
+        except asyncio.CancelledError:
+            pass  # expected — we just cancelled the warm-cache task
+        except Exception:  # noqa: BLE001 — a failing teardown must not break stop()
             pass

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -584,14 +584,14 @@ def _main():
         try:
             import paths as _paths
             _paths.unregister_instance()
-        except Exception:
+        except Exception:  # noqa: BLE001 — shutdown teardown is best-effort
             pass
         # Withdraw the mDNS advertisement (ADR 0042 §I). Off the loop — same deadlock as
         # advertise (zc.close() posts to and waits on the loop it's called from).
         try:
             from graph.fleet import discovery
             await asyncio.to_thread(discovery.stop_advertise)
-        except Exception:
+        except Exception:  # noqa: BLE001 — mDNS withdraw is best-effort on shutdown
             pass
         # Stop plugin surfaces first (ADR 0018) — best-effort.
         for h in STATE.plugin_surface_handles:

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -239,7 +239,7 @@ def _record_a2a_telemetry(outcome) -> None:
     try:
         import metrics
         metrics.record_a2a_turn(outcome.state, (outcome.duration_ms or 0) / 1000.0)
-    except Exception:
+    except Exception:  # noqa: BLE001 — the Prometheus metric must never break a turn
         pass
 
     store = STATE.telemetry_store

--- a/tools/execute_code.py
+++ b/tools/execute_code.py
@@ -179,7 +179,9 @@ async def run_code(code: str, tool_map: dict, *, timeout: float = 30.0, truncate
             service.cancel()
             try:
                 await service
-            except (asyncio.CancelledError, Exception):
+            except asyncio.CancelledError:
+                pass  # expected — we just cancelled the service task
+            except Exception:  # noqa: BLE001 — teardown failure must not mask the result
                 pass
 
         out = (stdout or b"").decode(errors="replace").strip()

--- a/tools/shell.py
+++ b/tools/shell.py
@@ -78,7 +78,7 @@ async def run_command(
         proc.kill()
         try:
             await proc.communicate()
-        except Exception:
+        except Exception:  # noqa: BLE001 — process already killed; draining is best-effort
             pass
         return ShellResult(1, "", "", timed_out=True, error=f"timed out after {timeout:g}s")
 


### PR DESCRIPTION
## What
Prod-readiness **C6**. Two cleanup paths caught `(asyncio.CancelledError, Exception)` in a single clause — lumping the **expected** child-task cancellation with the defensive catch, which reads as (and can drift into) a swallow that defeats shutdown. Split them so intent is explicit, and annotate the remaining best-effort `except: pass` sites.

## Changes
- `graph/cache_warmer.py::stop` + `tools/execute_code.py` finally — `except asyncio.CancelledError` (expected, we just cancelled the child) is now separate from the defensive `except Exception` (best-effort teardown).
- Annotated best-effort swallows with the repo's `# noqa: BLE001 — <why>` convention:
  - `server/__init__.py` shutdown — co-location unregister (#706) + mDNS withdraw (ADR 0042 §I)
  - `server/a2a.py` — the Prometheus turn metric
  - `tools/shell.py` — post-kill drain on timeout

## Risk
No happy-path behavior change — these are teardown/best-effort paths. `ruff` clean; 126 a2a/shell/exec tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)