### PR TITLE
test(fleet): direct coverage for the slug-routing reverse proxy (E2)

### DIFF
--- a/tests/test_fleet_proxy.py
+++ b/tests/test_fleet_proxy.py
@@ -1,0 +1,198 @@
+"""Fleet reverse proxy (ADR 0042 slug routing) — graph/fleet/proxy.py.
+
+The proxy is the hot path for the unified console: every console window on
+``/app/agent/<slug>/`` rewrites its calls to ``/agents/<slug>/*``, which this
+module forwards to the agent's workspace port. Covers slug→port resolution (host
+vs peer, the alive check, the 1s TTL cache), the 409/502 error paths, and the
+hop-by-hop header stripping on both the forwarded request and the response.
+"""
+
+from __future__ import annotations
+
+import time
+
+import httpx
+import pytest
+
+from graph.fleet import proxy
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    proxy._slug_cache.clear()
+    yield
+    proxy._slug_cache.clear()
+
+
+class FakeRequest:
+    def __init__(self, method="GET", headers=None, query=None, body=b""):
+        self.method = method
+        self.headers = headers or {}
+        self.query_params = query or {}
+        self._body = body
+
+    async def body(self):
+        return self._body
+
+
+class FakeUpstream:
+    def __init__(self, status_code=200, headers=None, chunks=(b"data: x\n\n",)):
+        self.status_code = status_code
+        self.headers = headers or {}
+        self._chunks = chunks
+        self.closed = False
+
+    async def aiter_raw(self):
+        for c in self._chunks:
+            yield c
+
+    async def aclose(self):
+        self.closed = True
+
+
+class FakeClient:
+    def __init__(self, upstream=None, raise_exc=None):
+        self._upstream = upstream
+        self._raise = raise_exc
+        self.built = None
+
+    def build_request(self, method, url, headers=None, content=None, params=None):
+        self.built = {"method": method, "url": url, "headers": headers,
+                      "content": content, "params": params}
+        return object()  # opaque request handle
+
+    async def send(self, req, stream=True):
+        if self._raise:
+            raise self._raise
+        return self._upstream
+
+
+# --- _port_for_slug -------------------------------------------------------
+
+def test_host_slug_uses_active_port(monkeypatch):
+    from runtime import state as state_mod
+    monkeypatch.setattr(state_mod.STATE, "active_port", 7870, raising=False)
+    assert proxy._port_for_slug("host") == 7870
+
+
+def test_peer_slug_resolves_when_alive(monkeypatch):
+    monkeypatch.setattr(proxy.supervisor, "_load_state",
+                        lambda: {"alice": {"port": 7001, "pid": 42}})
+    monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: True)
+    assert proxy._port_for_slug("alice") == 7001
+
+
+def test_peer_slug_is_none_when_dead(monkeypatch):
+    monkeypatch.setattr(proxy.supervisor, "_load_state",
+                        lambda: {"alice": {"port": 7001, "pid": 42}})
+    monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: False)
+    assert proxy._port_for_slug("alice") is None
+
+
+def test_unknown_slug_is_none(monkeypatch):
+    monkeypatch.setattr(proxy.supervisor, "_load_state", lambda: {})
+    monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: True)
+    assert proxy._port_for_slug("ghost") is None
+
+
+def test_resolution_is_cached_within_ttl(monkeypatch):
+    calls = {"n": 0}
+
+    def load():
+        calls["n"] += 1
+        return {"alice": {"port": 7001, "pid": 42}}
+
+    monkeypatch.setattr(proxy.supervisor, "_load_state", load)
+    monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: True)
+    assert proxy._port_for_slug("alice") == 7001
+    assert proxy._port_for_slug("alice") == 7001
+    assert calls["n"] == 1  # second hit served from the 1s TTL cache
+
+
+def test_cache_expires_after_ttl(monkeypatch):
+    monkeypatch.setattr(proxy.supervisor, "_load_state",
+                        lambda: {"alice": {"port": 7001, "pid": 42}})
+    monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: True)
+    assert proxy._port_for_slug("alice") == 7001
+    proxy._slug_cache["alice"] = (9999, time.monotonic() - 2.0)  # force stale
+    assert proxy._port_for_slug("alice") == 7001  # re-resolved, not the stale 9999
+
+
+# --- forward_to -----------------------------------------------------------
+
+async def test_forward_to_returns_409_when_not_running(monkeypatch):
+    monkeypatch.setattr(proxy, "_port_for_slug", lambda slug: None)
+    resp = await proxy.forward_to("ghost", FakeRequest(), "api/x")
+    assert resp.status_code == 409
+    assert b"is not running" in resp.body
+
+
+async def test_forward_to_delegates_to_port_when_running(monkeypatch):
+    monkeypatch.setattr(proxy, "_port_for_slug", lambda slug: 7001)
+    seen = {}
+
+    async def fake_fwd(port, request, path):
+        seen.update(port=port, path=path)
+        return "OK"
+
+    monkeypatch.setattr(proxy, "_forward_to_port", fake_fwd)
+    out = await proxy.forward_to("alice", FakeRequest(), "api/chat")
+    assert out == "OK"
+    assert seen == {"port": 7001, "path": "api/chat"}
+
+
+# --- _forward_to_port -----------------------------------------------------
+
+async def test_forward_strips_hop_headers_and_pipes_body(monkeypatch):
+    up = FakeUpstream(
+        status_code=200,
+        headers={"content-type": "text/event-stream", "connection": "keep-alive"},
+        chunks=(b"data: a\n\n", b"data: b\n\n"),
+    )
+    client = FakeClient(upstream=up)
+    monkeypatch.setattr(proxy, "_get_client", lambda: client)
+
+    req = FakeRequest(
+        method="POST",
+        headers={"host": "hub", "connection": "keep-alive", "authorization": "Bearer t"},
+        query={"stream": "1"},
+        body=b"{}",
+    )
+    resp = await proxy._forward_to_port(7001, req, "api/chat")
+
+    # request: hop-by-hop headers dropped, app headers + target preserved
+    assert "host" not in client.built["headers"]
+    assert "connection" not in client.built["headers"]
+    assert client.built["headers"]["authorization"] == "Bearer t"
+    assert client.built["url"] == "http://127.0.0.1:7001/api/chat"
+    assert client.built["params"] == {"stream": "1"}
+    assert client.built["method"] == "POST"
+
+    # response: hop-by-hop dropped, status + content-type preserved, body piped, upstream closed
+    assert resp.status_code == 200
+    assert "connection" not in resp.headers
+    assert resp.headers["content-type"] == "text/event-stream"
+    chunks = [c async for c in resp.body_iterator]
+    assert b"".join(chunks) == b"data: a\n\ndata: b\n\n"
+    assert up.closed
+
+
+async def test_forward_returns_502_on_connect_error(monkeypatch):
+    client = FakeClient(raise_exc=httpx.ConnectError("refused"))
+    monkeypatch.setattr(proxy, "_get_client", lambda: client)
+    resp = await proxy._forward_to_port(7001, FakeRequest(), "api/x")
+    assert resp.status_code == 502
+    assert b"not reachable" in resp.body
+
+
+# --- _get_client ----------------------------------------------------------
+
+def test_get_client_is_pooled_and_recreated_when_closed():
+    proxy._client = None
+    c1 = proxy._get_client()
+    assert proxy._get_client() is c1  # pooled
+    import asyncio
+    asyncio.run(c1.aclose())
+    c2 = proxy._get_client()
+    assert c2 is not c1  # recreated after close
+    asyncio.run(c2.aclose())


### PR DESCRIPTION
## What
Prod-readiness **E2**. `graph/fleet/proxy.py` — the hot path for the unified console (every `/agents/<slug>/*` call rewrites through it) — had **no direct tests**, only transitive exercise. That's the exact "green but wire-broken" gap the team's smoke-test lesson warns about. Adds `tests/test_fleet_proxy.py` (11 tests):

- **`_port_for_slug`** — `host` → `STATE.active_port`; peer → workspace port iff `_alive`; dead/unknown → `None`; the **1s TTL cache** (served-from-cache + expiry/re-resolve).
- **`forward_to`** — 409 when the agent isn't running; delegates to the port otherwise.
- **`_forward_to_port`** — hop-by-hop header stripping on **both** the forwarded request and the response, body piping + upstream close, **502** on `ConnectError`.
- **`_get_client`** — pooled, recreated when closed.

## Scope note
`discovery.py` already received 8 direct tests from the team's #815/#816, so this PR targets the remaining `proxy.py` gap rather than duplicating that coverage.

## Verification
11 new tests green; full fleet suite (32: new + existing) green. `ruff` clean. Additive (new file) — no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)