### PR TITLE
feat(console): tenant guard — a new backend on the same address drops the old chat view

### DIFF
--- a/apps/web/e2e/activate.spec.ts
+++ b/apps/web/e2e/activate.spec.ts
@@ -5,16 +5,19 @@ import { expect, test } from "@playwright/test";
 // fixture's "roxy" is STOPPED, so this is the exact navigate-to-a-cold-agent path.
 
 test("opening a slug page activates (resumes) the agent", async ({ page }) => {
-  const activated = page.waitForRequest(
-    (r) => r.method() === "POST" && r.url().includes("/api/fleet/roxy/activate"),
+  const activated = page.waitForResponse(
+    (r) => r.request().method() === "POST" && r.url().includes("/api/fleet/roxy/activate"),
   );
   await page.goto("/app/agent/roxy/", { waitUntil: "load" });
-  await activated; // boot fired the resume call
+  await activated; // boot fired the resume call AND the mock processed it
 
   // And the mock fleet now reports it running.
-  const fleet = await page.evaluate(() => fetch("/api/fleet").then((r) => r.json()));
-  const roxy = fleet.agents.find((a: { id: string }) => a.id === "roxy");
-  expect(roxy.running).toBe(true);
+  await expect
+    .poll(async () => {
+      const fleet = await page.evaluate(() => fetch("/api/fleet").then((r) => r.json()));
+      return fleet.agents.find((a: { id: string }) => a.id === "roxy")?.running;
+    })
+    .toBe(true);
 });
 
 test("the host window never calls activate", async ({ page }) => {

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -9,6 +9,7 @@ export const TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json";
 
 export const RUNTIME_STATUS = {
   setup_complete: true,
+  instance_uid: "mock-uid-1", // TenantGuard keys per-origin client state on this
   graph_loaded: true,
   project: { path: "/tmp/e2e-project", allowed_dirs: ["/tmp/e2e-project"] },
   model: {

--- a/apps/web/e2e/tenant-guard.spec.ts
+++ b/apps/web/e2e/tenant-guard.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+// Tenant guard: the mock backend's instance_uid is "mock-uid-1". A stored uid from a
+// DIFFERENT backend means another agent previously owned this origin — its persisted
+// chat view is dropped (one reload) and the operator is told. Same uid = untouched.
+
+test("a different backend uid clears the previous tenant's chat view", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("protoagent.tenant.uid", "previous-agent-uid");
+    window.localStorage.setItem(
+      "protoagent.chat.sessions",
+      JSON.stringify({ version: 1, currentSessionId: null, sessions: [{ id: "c1", title: "Old tenant secrets", messages: [], createdAt: 1, updatedAt: 1 }] }),
+    );
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // The guard clears + reloads, then toasts on the fresh page.
+  await expect(page.getByText("Different agent on this address")).toBeVisible({ timeout: 10_000 });
+  const state = await page.evaluate(() => ({
+    chats: window.localStorage.getItem("protoagent.chat.sessions"),
+    uid: window.localStorage.getItem("protoagent.tenant.uid"),
+  }));
+  expect(state.chats).toBeNull();
+  expect(state.uid).toBe("mock-uid-1");
+});
+
+test("the same backend uid keeps the chat view (restart/upgrade case)", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("protoagent.tenant.uid", "mock-uid-1");
+    window.localStorage.setItem(
+      "protoagent.chat.sessions",
+      JSON.stringify({ version: 1, currentSessionId: null, sessions: [{ id: "c2", title: "Kept", messages: [], createdAt: 1, updatedAt: 1 }] }),
+    );
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.locator(".pl-rail").first()).toBeVisible();
+  await expect(page.getByText("Different agent on this address")).toHaveCount(0);
+  expect(await page.evaluate(() => window.localStorage.getItem("protoagent.chat.sessions"))).not.toBeNull();
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -64,6 +64,7 @@ import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import type { ComponentType, LazyExoticComponent, ReactNode } from "react";
 import { FleetTurnWatch } from "./FleetTurnWatch";
 import { IntroSplash } from "./IntroSplash";
+import { TenantGuard } from "./TenantGuard";
 import { BootGate } from "./BootGate";
 
 import { ActivitySurface } from "../activity/ActivitySurface";
@@ -629,6 +630,9 @@ export function App() {
           finishes (per-window SSE can't see it — this watches the other slugs'
           persisted in-flight turns and polls their durable tasks via the hub). */}
       <FleetTurnWatch />
+      {/* Tenant guard: if a DIFFERENT backend now owns this origin (port handed
+          between agents), drop the previous tenant's persisted chat view. */}
+      <TenantGuard uid={runtime?.instance_uid} />
       {/* Cold-start gate: holds over the app until the runtime probe first
           resolves (engine up), so the ~30s frozen-sidecar boot shows
           "Starting <agent>…" rather than a "Load failed" flash. */}

--- a/apps/web/src/app/TenantGuard.tsx
+++ b/apps/web/src/app/TenantGuard.tsx
@@ -1,0 +1,45 @@
+import { useToast } from "@protolabsai/ui/overlays";
+import { useEffect } from "react";
+
+import { SWITCHED_FLAG, tenantCheck } from "../lib/tenant";
+
+// Tenant guard: localStorage is keyed by ORIGIN, but the backend behind an origin can
+// change (a port handed from one agent to another — e.g. a fork booted on the old
+// port). The chat store persists full transcripts client-side, so without a check the
+// new tenant's window renders the PREVIOUS agent's conversations. The server exposes a
+// stable per-data-root uid (runtime-status `instance_uid`); on mismatch we drop the
+// previous tenant's chat view (all slugs) + the turn-watcher state, then reload so the
+// already-hydrated stores restart clean. Layout/theme/authToken stay — layout is
+// cosmetic, theme is server-side per agent, and clearing a bearer token could lock the
+// operator out. Same data root ⇒ same uid, so restarts/upgrades of the SAME agent
+// never trip this.
+
+export function TenantGuard({ uid }: { uid: string | undefined }) {
+  const toast = useToast();
+
+  // Post-reload notice — the clearing happened just before the reload below.
+  useEffect(() => {
+    try {
+      if (sessionStorage.getItem(SWITCHED_FLAG)) {
+        sessionStorage.removeItem(SWITCHED_FLAG);
+        toast({
+          tone: "info",
+          title: "Different agent on this address",
+          message: "The previous agent's chat view was cleared — its data is untouched on its own instance.",
+        });
+      }
+    } catch {
+      /* best-effort */
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    if (tenantCheck(uid) === "switched") {
+      // The chat store hydrated from the stale keys at module init — reload to restart
+      // clean (a one-time event, only on an actual tenant switch).
+      window.location.reload();
+    }
+  }, [uid]);
+
+  return null;
+}

--- a/apps/web/src/lib/tenant.test.ts
+++ b/apps/web/src/lib/tenant.test.ts
@@ -1,0 +1,49 @@
+// Tenant guard (pure check): a different backend uid on the same origin drops the
+// previous tenant's persisted chat view; same/first uid is a no-op.
+import { beforeEach, describe, expect, it } from "vitest";
+
+import { tenantCheck } from "../lib/tenant";
+
+describe("tenantCheck", () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+  });
+
+  it("first visit stores the uid and keeps state", () => {
+    localStorage.setItem("protoagent.chat.sessions", "{}");
+    expect(tenantCheck("uid-a")).toBe("ok");
+    expect(localStorage.getItem("protoagent.tenant.uid")).toBe("uid-a");
+    expect(localStorage.getItem("protoagent.chat.sessions")).toBe("{}");
+  });
+
+  it("same uid (restart/upgrade of the same agent) keeps state", () => {
+    localStorage.setItem("protoagent.tenant.uid", "uid-a");
+    localStorage.setItem("protoagent.chat.sessions:ava", "{}");
+    expect(tenantCheck("uid-a")).toBe("ok");
+    expect(localStorage.getItem("protoagent.chat.sessions:ava")).toBe("{}");
+  });
+
+  it("a different uid clears every slug's chat view + the watcher state", () => {
+    localStorage.setItem("protoagent.tenant.uid", "uid-a");
+    localStorage.setItem("protoagent.chat.sessions", "{}");
+    localStorage.setItem("protoagent.chat.sessions:ava", "{}");
+    localStorage.setItem("protoagent.ui", "{layout}"); // layout survives — cosmetic
+    sessionStorage.setItem("protoagent.turnwatch.notified", "[]");
+
+    expect(tenantCheck("uid-b")).toBe("switched");
+    expect(localStorage.getItem("protoagent.chat.sessions")).toBeNull();
+    expect(localStorage.getItem("protoagent.chat.sessions:ava")).toBeNull();
+    expect(localStorage.getItem("protoagent.ui")).toBe("{layout}");
+    expect(sessionStorage.getItem("protoagent.turnwatch.notified")).toBeNull();
+    expect(sessionStorage.getItem("protoagent.tenant.switched")).toBe("1");
+    expect(localStorage.getItem("protoagent.tenant.uid")).toBe("uid-b");
+  });
+
+  it("no uid from the backend (older server) never clears", () => {
+    localStorage.setItem("protoagent.tenant.uid", "uid-a");
+    localStorage.setItem("protoagent.chat.sessions", "{}");
+    expect(tenantCheck(undefined)).toBe("ok");
+    expect(localStorage.getItem("protoagent.chat.sessions")).toBe("{}");
+  });
+});

--- a/apps/web/src/lib/tenant.ts
+++ b/apps/web/src/lib/tenant.ts
@@ -1,0 +1,38 @@
+// Tenant check (pure — unit-tested without React): localStorage is origin-keyed but
+// the backend behind an origin can change; on uid mismatch the previous tenant's
+// persisted chat view is dropped. See app/TenantGuard.tsx for the React shell.
+
+const UID_KEY = "protoagent.tenant.uid";
+export const SWITCHED_FLAG = "protoagent.tenant.switched"; // sessionStorage — the post-reload toast
+
+export function tenantCheck(uid: string | undefined): "ok" | "switched" {
+  if (!uid) return "ok"; // older backend / unreadable root — never destructive
+  let stored = "";
+  try {
+    stored = localStorage.getItem(UID_KEY) || "";
+  } catch {
+    return "ok";
+  }
+  if (!stored) {
+    localStorage.setItem(UID_KEY, uid);
+    return "ok";
+  }
+  if (stored === uid) return "ok";
+
+  // A different backend owns this origin now — drop the previous tenant's chat view.
+  const stale: string[] = [];
+  for (let i = 0; i < localStorage.length; i++) {
+    const k = localStorage.key(i) || "";
+    if (k.startsWith("protoagent.chat.sessions")) stale.push(k);
+  }
+  stale.forEach((k) => localStorage.removeItem(k));
+  try {
+    sessionStorage.removeItem("protoagent.turnwatch.notified");
+    sessionStorage.setItem(SWITCHED_FLAG, "1");
+  } catch {
+    /* best-effort */
+  }
+  localStorage.setItem(UID_KEY, uid);
+  return "switched";
+}
+

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -50,6 +50,9 @@ export type RuntimeStatus = {
   /** User-facing operational alerts (e.g. a live co-located instance sharing
    *  this data root, #706) — the shell banners them under the topbar. */
   warnings?: string[];
+  /** Stable per-data-root uid — the TenantGuard keys per-origin client state on it
+   *  (a different backend reusing this address must not render this one's chats). */
+  instance_uid?: string;
   skills?: {
     enabled: boolean;
     count: number;

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -48,7 +48,7 @@ def _operator_runtime_status():
     # Live co-location check (#706) — re-evaluated per poll so the shell banner
     # appears/clears as siblings come and go. Quiet (empty `.instances/`) costs one
     # is_dir(); the `ps` guard only runs when sibling heartbeats actually exist.
-    from paths import colocation_warning
+    from paths import colocation_warning, instance_uid
     try:
         warnings = [w for w in (colocation_warning(),) if w]
     except Exception:  # noqa: BLE001 — status must never raise
@@ -73,6 +73,7 @@ def _operator_runtime_status():
         telemetry_store=STATE.telemetry_store,
         checkpoint_path=STATE.checkpoint_path,
         warnings=warnings,
+        instance_uid=instance_uid(),
     )
 
 

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -22,6 +22,7 @@ def build_runtime_status(
     telemetry_store: Any = None,
     checkpoint_path: str = "",
     warnings: list[str] | None = None,
+    instance_uid: str = "",
 ) -> dict[str, Any]:
     """Return UI-safe runtime status.
 
@@ -63,6 +64,7 @@ def build_runtime_status(
             "goal": {"enabled": False, "controller_loaded": False},
             "cache_warmer": {"enabled": False, "loaded": False},
             "warnings": warnings_block,
+            "instance_uid": instance_uid,
         }
 
     return {
@@ -132,6 +134,9 @@ def build_runtime_status(
             "telemetry_retention_days": getattr(config, "telemetry_retention_days", None),
         },
         "warnings": warnings_block,
+        # Stable per-data-root uid — the console keys per-origin client state on it
+        # (a different backend on the same address must not render this one's chats).
+        "instance_uid": instance_uid,
     }
 
 

--- a/paths.py
+++ b/paths.py
@@ -128,11 +128,39 @@ def workspace_dir(*, create: bool = False) -> Path:
 # at shutdown, and anyone can ask who else is alive in the same root.
 
 
-def _instances_dir() -> Path:
-    """`.instances/` under THIS instance's data root (scoped or shared)."""
+def instance_root() -> Path:
+    """THIS instance's data root: ``data_home()/<iid>`` when scoped, else the shared home."""
     home = data_home()
     iid = instance_id()
-    return (home / _safe_segment(iid) if iid else home) / ".instances"
+    return home / _safe_segment(iid) if iid else home
+
+
+def _instances_dir() -> Path:
+    """`.instances/` under THIS instance's data root (scoped or shared)."""
+    return instance_root() / ".instances"
+
+
+def instance_uid() -> str:
+    """A stable, opaque uid for THIS data root (``<root>/.instance-uid``, created on
+    first read). The console keys its per-origin client state against it: when a
+    DIFFERENT backend reuses the same address (port handed from one agent to another),
+    the uid mismatch tells the new tenant's window to drop the previous tenant's
+    persisted chat view instead of rendering another agent's transcripts. Same root →
+    same uid (same data, by design). Best-effort: "" when the root isn't writable."""
+    import uuid
+
+    try:
+        f = instance_root() / ".instance-uid"
+        if f.exists():
+            got = f.read_text().strip()
+            if got:
+                return got
+        f.parent.mkdir(parents=True, exist_ok=True)
+        fresh = uuid.uuid4().hex[:16]
+        f.write_text(fresh)
+        return fresh
+    except Exception:  # noqa: BLE001 — a status field, never worth failing for
+        return ""
 
 
 def _pid_alive(pid: int) -> bool:

--- a/tests/test_instance_scope.py
+++ b/tests/test_instance_scope.py
@@ -124,3 +124,22 @@ def test_runtime_status_carries_warnings():
     assert s["warnings"] == ["sibling alert"]            # empties filtered
     s2 = build_runtime_status(config=None, setup_complete=False, graph_loaded=False)
     assert s2["warnings"] == []
+
+
+def test_instance_uid_stable_and_scoped(monkeypatch, tmp_path):
+    _home(monkeypatch, tmp_path)
+    uid = paths.instance_uid()
+    assert uid and paths.instance_uid() == uid          # created once, then stable
+    assert (tmp_path / ".instance-uid").read_text().strip() == uid
+
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "roxy")
+    scoped = paths.instance_uid()
+    assert scoped and scoped != uid                     # different data root → different uid
+    assert (tmp_path / "roxy" / ".instance-uid").exists()
+
+
+def test_runtime_status_carries_instance_uid():
+    from operator_api.runtime import build_runtime_status
+    s = build_runtime_status(config=None, setup_complete=False, graph_loaded=False,
+                             instance_uid="abc123")
+    assert s["instance_uid"] == "abc123"


### PR DESCRIPTION
The last leg of the two-hubs bug (the deferred 'host-window localStorage' item,
descoped per review tonight): localStorage is origin-keyed but the backend behind
an origin can change — a fork booted on the old port inherits the previous
agent's PERSISTED TRANSCRIPTS (the chat store keeps full message bodies
client-side). With data stores already scoped (#813) and live siblings bannered
(#818), this sequential-reuse leak was the remaining gap.

Scoped deliberately small (vs re-keying every persisted store by backend id —
rejected: it threads skipHydration through the hottest store paths for a
scenario that's inherently a tenant switch):

- server: `paths.instance_uid()` — a stable per-data-root uid
  (`<root>/.instance-uid`, created on first read; same root → same uid, so
  restarts/upgrades never trip) exposed as runtime-status `instance_uid`.
- console: `lib/tenant.ts` tenantCheck (pure, vitest-covered) + TenantGuard in
  the shell — on uid mismatch it clears `protoagent.chat.sessions*` (all slugs)
  + the turn-watcher dedupe, reloads once (the stores already hydrated from the
  stale keys), and toasts on the fresh page. Layout/theme/authToken survive:
  layout is cosmetic, theme is server-side per agent, and clearing a bearer
  token could lock the operator out.
- e2e fixture carries `instance_uid`; activate.spec's request-vs-mock race fixed
  (waitForResponse + poll) — surfaced by the larger suite.

Verified live: uid present in runtime status and stable across a server restart
of the same instance. 1338 py + 30 vitest + 84 e2e (×3 runs, no flakes).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
