### PR TITLE
test(config): characterization + drift-guard safety net for the config triplet (B1 PR-1)

### DIFF
--- a/tests/test_config_drift_guard.py
+++ b/tests/test_config_drift_guard.py
@@ -1,0 +1,254 @@
+"""Drift guard for the config triplet (refactor: config single source of truth).
+
+Three structures must stay in lock-step:
+
+* ``graph.settings_schema.FIELDS`` — the operator console's settings registry,
+  mapping each dotted YAML ``key`` to the ``LangGraphConfig`` ``attr`` that holds
+  its live value plus its UI ``type``.
+* ``graph.config.LangGraphConfig`` — the live dataclass the runtime reads.
+* ``graph.config_io.config_to_dict`` — the nested-dict serializer the UI round-
+  trips through.
+
+When these drift apart the failure is silent in production: the Settings UI
+shows a field that never persists (missing dataclass attr), or a save round-trips
+through a serializer that drops the section on the floor. These tests turn any
+such drift into a CI failure.
+
+NOTE on the import path: ``config_to_dict`` lives in ``graph.config_io`` (not
+``graph.config``) — it is imported from there below.
+
+KNOWN GAPS (documented as ``strict=True`` xfails so they auto-flip to a LOUD
+failure the moment the refactor closes them):
+
+* ``identity.org`` (attr ``identity_org``) — the Field, the ``config_to_dict``
+  emit, the runtime status API, and the frontend Header all reference it, but the
+  dataclass has NO ``identity_org`` field and ``from_yaml`` never parses ``org``.
+  So today the white-label org label can never persist. Fix = add the dataclass
+  field + a ``from_yaml`` parse line; then test #1's ``identity.org`` param flips
+  to passing (xfail strict fails loudly to tell us to drop the marker).
+* ``config_to_dict`` is PARTIAL — it serializes only a legacy subset of sections
+  (model/subagents/middleware-core/knowledge/skills/mcp/plugins/identity/auth/
+  runtime/operator). 27 otherwise-valid FIELDS keys (routing, compaction, goal,
+  execute_code, prompt_cache, several checkpoint/knowledge/telemetry keys,
+  agent_runtime, operator_mcp.tools, middleware.enforcement) are NOT emitted,
+  despite its docstring claiming it "mirrors the YAML schema". Each missing key
+  is a ``strict=True`` xfail in test #2; making ``config_to_dict`` FIELDS-complete
+  flips them to passing.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.config import LangGraphConfig
+from graph.config_io import config_to_dict
+from graph.settings_schema import FIELDS
+
+# --------------------------------------------------------------------------- #
+# Known-broken sets (the ONLY currently-failing parts — everything else passes
+# normally). Keep these tight: a marker on a part that actually holds would mask
+# real, future drift.
+# --------------------------------------------------------------------------- #
+
+# B1: FIELDS entry whose .attr is absent on LangGraphConfig.
+ATTR_MISSING_KEYS = {"identity.org"}
+
+# B1: non-secret FIELDS keys that config_to_dict does NOT serialize (partial
+# serializer — 27 keys). identity.org is intentionally NOT here: config_to_dict
+# DOES emit it (via a defensive getattr default of ""), so its resolution passes
+# even though its dataclass attr is missing (that drift is covered by test #1).
+CONFIG_TO_DICT_MISSING_KEYS = {
+    "agent_runtime",
+    "operator_mcp.tools",
+    "routing.aux_model",
+    "routing.fallback_models",
+    "compaction.enabled",
+    "compaction.trigger",
+    "compaction.keep_messages",
+    "compaction.model",
+    "goal.enabled",
+    "goal.max_iterations",
+    "goal.eval_model",
+    "execute_code.enabled",
+    "execute_code.timeout",
+    "prompt_cache.enabled",
+    "prompt_cache.ttl",
+    "prompt_cache.warm.enabled",
+    "prompt_cache.warm.interval_seconds",
+    "knowledge.embeddings",
+    "checkpoint.db_path",
+    "checkpoint.keep_per_thread",
+    "checkpoint.max_age_days",
+    "checkpoint.prune_interval_hours",
+    "checkpoint.harvest_enabled",
+    "knowledge.facts",
+    "middleware.enforcement",
+    "telemetry.enabled",
+    "telemetry.retention_days",
+}
+
+_SECRET_KEYS = {f.key for f in FIELDS if f.type == "secret"}
+
+
+def _resolve(d: dict, dotted: str):
+    """Walk ``dotted`` (e.g. ``"prompt_cache.warm.enabled"``) through nested ``d``.
+
+    Returns ``(found, value)`` — ``found`` is False the moment any segment is
+    absent or a non-dict is hit mid-walk.
+    """
+    cur = d
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return False, None
+        cur = cur[part]
+    return True, cur
+
+
+def _id(f) -> str:
+    return f.key
+
+
+def _param(field, known_broken: set, reason: str):
+    """Wrap a Field in a pytest param, attaching a STRICT xfail marker iff the
+    field is in the documented known-broken set.
+
+    ``strict=True`` is the whole point: while the gap is open the test xfails
+    (suite stays green); the instant the refactor closes the gap the assertion
+    passes, the strict xfail turns that XPASS into a FAILURE, forcing whoever
+    fixed it to delete the now-stale marker. Parts that already hold get NO
+    marker, so real future drift fails normally.
+    """
+    marks = [pytest.mark.xfail(reason=reason, strict=True)] if field.key in known_broken else []
+    return pytest.param(field, id=field.key, marks=marks)
+
+
+_ATTR_REASON = (
+    "B1: FIELDS key maps to a LangGraphConfig attribute that does not exist "
+    "(no identity_org field / from_yaml parse). Fixed when identity_org is added "
+    "to the dataclass."
+)
+_SERIALIZE_REASON = (
+    "B1: config_to_dict does not serialize this key (partial serializer — omits "
+    "routing/compaction/goal/execute_code/prompt_cache/checkpoint/telemetry/"
+    "agent_runtime/operator_mcp/middleware.enforcement/knowledge.embeddings+facts). "
+    "Fixed when config_to_dict becomes FIELDS-complete."
+)
+
+
+# --------------------------------------------------------------------------- #
+# 1) Every FIELDS.attr exists on the dataclass.
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.parametrize(
+    "field", [_param(f, ATTR_MISSING_KEYS, _ATTR_REASON) for f in FIELDS]
+)
+def test_every_fields_attr_exists_on_dataclass(field):
+    """Each settings Field must point at a real ``LangGraphConfig`` attribute.
+
+    A missing attr means the Settings UI renders a control that reads
+    ``None``/default and whose save never round-trips into the live config.
+    """
+    cfg = LangGraphConfig()
+    assert hasattr(cfg, field.attr), (
+        f"FIELDS key {field.key!r} maps to LangGraphConfig.{field.attr}, "
+        f"but that attribute does not exist on the dataclass — settings drift."
+    )
+
+
+def test_attr_missing_set_is_exactly_as_expected():
+    """Belt-and-suspenders: the live missing-attr set equals the documented one.
+
+    If a NEW attr goes missing it lands here (not in the silently-xfailed
+    per-field param), so unexpected drift fails loudly instead of being absorbed
+    by the known-gap marker.
+    """
+    cfg = LangGraphConfig()
+    live_missing = {f.key for f in FIELDS if not hasattr(cfg, f.attr)}
+    assert live_missing == ATTR_MISSING_KEYS, (
+        f"missing-attr drift changed: {live_missing} (expected {ATTR_MISSING_KEYS}). "
+        "Add/remove the offending FIELDS key from ATTR_MISSING_KEYS, or fix the dataclass."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 2) Every non-secret FIELDS key resolves in config_to_dict's output.
+# --------------------------------------------------------------------------- #
+
+_NON_SECRET_FIELDS = [f for f in FIELDS if f.key not in _SECRET_KEYS]
+
+
+@pytest.mark.parametrize(
+    "field",
+    [_param(f, CONFIG_TO_DICT_MISSING_KEYS, _SERIALIZE_REASON) for f in _NON_SECRET_FIELDS],
+)
+def test_fields_keys_present_in_config_to_dict(field):
+    """Each non-secret settings key must round-trip through ``config_to_dict``.
+
+    Secrets are excluded (config_to_dict deliberately redacts them, and may
+    omit a never-set section). A key that the serializer drops means a Settings
+    save can be silently lost on the next load.
+    """
+    d = config_to_dict(LangGraphConfig())
+    found, _ = _resolve(d, field.key)
+    assert found, (
+        f"FIELDS key {field.key!r} does not resolve in config_to_dict() output "
+        f"(top-level keys: {sorted(d.keys())}) — serializer drift."
+    )
+
+
+def test_config_to_dict_missing_set_is_exactly_as_expected():
+    """The live set of non-secret keys config_to_dict omits == the documented set.
+
+    A newly-dropped key surfaces here (loud) rather than being silently absorbed
+    by a stale xfail marker; a newly-covered key also flips the per-field strict
+    xfail, so this stays in agreement with reality both ways.
+    """
+    d = config_to_dict(LangGraphConfig())
+    live_missing = {f.key for f in _NON_SECRET_FIELDS if not _resolve(d, f.key)[0]}
+    assert live_missing == CONFIG_TO_DICT_MISSING_KEYS, (
+        f"config_to_dict coverage drift: {live_missing} "
+        f"(expected {CONFIG_TO_DICT_MISSING_KEYS}). Update CONFIG_TO_DICT_MISSING_KEYS "
+        "or expand config_to_dict."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# 3) Field.type agrees with the dataclass default's Python type (best-effort).
+# --------------------------------------------------------------------------- #
+
+# Fields without a backing attr can't have their value's type checked here —
+# that drift is owned by test #1.
+_TYPED_FIELDS = [f for f in FIELDS if f.key not in ATTR_MISSING_KEYS]
+
+
+@pytest.mark.parametrize("field", _TYPED_FIELDS, ids=_id)
+def test_fields_types_match_dataclass(field):
+    """Best-effort: the declared UI ``type`` matches the dataclass default's type.
+
+    * ``bool``        → default is a ``bool``.
+    * ``number``      → default is ``int``/``float`` (and NOT ``bool``, which is
+      an ``int`` subclass).
+    * ``string_list`` → default is a ``list``.
+
+    ``string``/``select``/``secret`` are intentionally not type-asserted: a blank
+    default is often ``""`` and ``select`` values are plain strings, so there is
+    nothing load-bearing to check beyond what the above three cover.
+    """
+    cfg = LangGraphConfig()
+    val = getattr(cfg, field.attr)
+    if field.type == "bool":
+        assert isinstance(val, bool), (
+            f"{field.key!r} is type 'bool' but {field.attr} defaults to "
+            f"{type(val).__name__} ({val!r})."
+        )
+    elif field.type == "number":
+        assert isinstance(val, (int, float)) and not isinstance(val, bool), (
+            f"{field.key!r} is type 'number' but {field.attr} defaults to "
+            f"{type(val).__name__} ({val!r})."
+        )
+    elif field.type == "string_list":
+        assert isinstance(val, list), (
+            f"{field.key!r} is type 'string_list' but {field.attr} defaults to "
+            f"{type(val).__name__} ({val!r})."
+        )

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -1,0 +1,650 @@
+"""Characterization tests for graph/config.py + graph/config_io.py.
+
+These freeze TODAY's behavior of:
+  - LangGraphConfig.from_yaml (the YAML -> dataclass parse, including the
+    secret overlay, deep-nesting, list-coercion, key-rename and per-field
+    subagent fallbacks)
+  - config_to_dict (the dataclass -> nested-dict serialization the UI uses)
+  - the config_to_dict -> apply_updates_to_yaml -> from_yaml round-trip
+
+Values are captured by RUNNING the real code (not guessed) and embedded as
+literals so a future refactor that drops or mis-parses a field fails loudly.
+"""
+
+import dataclasses
+import textwrap
+from pathlib import Path
+
+from graph.config import LangGraphConfig, SubagentDef
+from graph.config_io import (
+    apply_updates_to_yaml,
+    config_to_dict,
+    save_yaml_doc,
+)
+
+EXAMPLE_PATH = "config/langgraph-config.example.yaml"
+
+
+# ---------------------------------------------------------------------------
+# Golden captures (RUN the real code to confirm; never weaken to force green)
+# ---------------------------------------------------------------------------
+
+# from_yaml(example) field map. api_key/auth_token are asserted == "" and
+# plugin_config is only asserted to be a dict (see test below), so they are
+# OMITTED from this map.
+FROM_YAML_EXAMPLE_FIELDS = {
+    "a2a_description": "",
+    "a2a_require_routable_url": False,
+    "a2a_skills": [],
+    "agent_runtime": "native",
+    "api_base": "http://gateway:4000/v1",
+    "audit_middleware": True,
+    "autostart_on_boot": False,
+    "aux_model": "",
+    "cache_warming_enabled": False,
+    "cache_warming_interval_seconds": 3300,
+    "chat_template_kwargs": None,
+    "checkpoint_db_path": "/sandbox/checkpoints.db",
+    "checkpoint_harvest_enabled": True,
+    "checkpoint_keep_per_thread": 5,
+    "checkpoint_max_age_days": 30,
+    "checkpoint_prune_interval_hours": 6,
+    "commons_path": "",
+    "compaction_enabled": True,
+    "compaction_keep_messages": 20,
+    "compaction_model": "",
+    "compaction_trigger": "fraction:0.8",
+    "egress_allowed_hosts": [],
+    "embed_model": "qwen3-embedding",
+    "enforcement_disallowed_tools": [],
+    "enforcement_enabled": False,
+    "enforcement_rate_limits": {},
+    "execute_code_enabled": False,
+    "execute_code_output_truncate": 6000,
+    "execute_code_timeout": 30,
+    "execute_code_tools": [],
+    "filesystem_allow_run": True,
+    "filesystem_enabled": True,
+    "filesystem_projects": [],
+    "filesystem_run_requires_approval": True,
+    "goal_enabled": True,
+    "goal_eval_model": "",
+    "goal_max_iterations": 8,
+    "goal_monitor_interval": 60,
+    "goal_no_progress_limit": 3,
+    "goal_verify_timeout": 120.0,
+    "identity_name": "protoagent",
+    "identity_operator": "",
+    "ingest_enabled": False,
+    "ingest_tools": [],
+    "instance_id": "",
+    "knowledge_backend": "",
+    "knowledge_db_path": "/sandbox/knowledge/agent.db",
+    "knowledge_embedder": "",
+    "knowledge_embeddings": True,
+    "knowledge_facts": True,
+    "knowledge_middleware": True,
+    "knowledge_top_k": 5,
+    "llm_max_retries": 2,
+    "max_iterations": 50,
+    "max_tokens": 32768,
+    "mcp_denylist": [],
+    "mcp_enabled": False,
+    "mcp_servers": [],
+    "mcp_timeout_seconds": 20.0,
+    "memory_middleware": True,
+    "model_name": "protolabs/reasoning",
+    "model_provider": "openai",
+    "operator_allowed_dirs": [],
+    "operator_mcp_enabled": False,
+    "operator_mcp_tools": [],
+    "plugins_dir": "",
+    "plugins_disabled": [],
+    "plugins_enabled": [],
+    "plugins_sources_allow": [],
+    "presence_penalty": None,
+    "prompt_cache_enabled": True,
+    "prompt_cache_force": False,
+    "prompt_cache_ttl": "5m",
+    "repetition_penalty": None,
+    "request_timeout": 120,
+    "researcher": SubagentDef(
+        enabled=True,
+        tools=["current_time", "web_search", "fetch_url", "memory_recall", "memory_list"],
+        max_turns=40,
+        model="",
+    ),
+    "routing_fallback_models": [],
+    "scheduler_enabled": True,
+    "security_callback_allowlist": [],
+    "skills_db_path": "/sandbox/skills.db",
+    "skills_dir": "",
+    "skills_enabled": True,
+    "skills_scope": "",
+    "skills_shared": False,
+    "skills_top_k": 5,
+    "subagent_max_concurrency": 4,
+    "subagent_output_truncate": 6000,
+    "telemetry_db_path": "/sandbox/telemetry.db",
+    "telemetry_enabled": True,
+    "telemetry_retention_days": 90,
+    "temperature": 0.2,
+    "tools_deferred_enabled": False,
+    "tools_deferred_keep": [],
+    "tools_disabled": [],
+    "top_k": -1,
+    "top_p": None,
+    "workflow_dir": "/sandbox/workflows",
+}
+
+# Fields handled by their own dedicated assertions, not the golden map.
+_GOLDEN_EXEMPT = {"api_key", "auth_token", "plugin_config"}
+
+# config_to_dict(from_yaml(example)) exact output — freezes the partial
+# (today's) emitted surface so a later expansion shows up as a reviewable diff.
+CONFIG_TO_DICT_GOLDEN = {
+    "auth": {
+        "token": "",
+    },
+    "discord": {
+        "admin_ids": [],
+        "bot_token": "",
+        "enabled": False,
+    },
+    "google": {
+        "client_id": "",
+        "client_secret": "",
+        "enabled": False,
+        "tz": "",
+    },
+    "identity": {
+        "name": "protoagent",
+        "operator": "",
+        "org": "",
+    },
+    "knowledge": {
+        "db_path": "/sandbox/knowledge/agent.db",
+        "embed_model": "qwen3-embedding",
+        "top_k": 5,
+    },
+    "mcp": {
+        "denylist": [],
+        "enabled": False,
+        "servers": [],
+        "timeout_seconds": 20.0,
+    },
+    "middleware": {
+        "audit": True,
+        "knowledge": True,
+        "memory": True,
+        "scheduler": True,
+    },
+    "model": {
+        "api_base": "http://gateway:4000/v1",
+        "api_key": "",
+        "max_iterations": 50,
+        "max_tokens": 32768,
+        "name": "protolabs/reasoning",
+        "provider": "openai",
+        "temperature": 0.2,
+    },
+    "operator": {
+        "allowed_dirs": [],
+    },
+    "plugins": {
+        "dir": "",
+        "enabled": [],
+    },
+    "runtime": {
+        "autostart_on_boot": False,
+    },
+    "skills": {
+        "db_path": "/sandbox/skills.db",
+        "dir": "",
+        "enabled": True,
+        "top_k": 5,
+    },
+    "subagents": {
+        "researcher": {
+            "enabled": True,
+            "max_turns": 40,
+            "model": "",
+            "tools": [
+                "current_time",
+                "web_search",
+                "fetch_url",
+                "memory_recall",
+                "memory_list",
+            ],
+        },
+    },
+}
+
+# The dataclass attrs config_to_dict ACTUALLY emits, derived from the
+# section/key structure of the golden dict. (a) maps each emitted golden
+# leaf to the dataclass attr it feeds, (b) excludes attrs config_to_dict
+# does NOT emit. The round-trip test asserts equality over exactly this set.
+#
+# discord/google are plugin sections -> they round-trip via plugin_config,
+# checked separately. identity.org has no dataclass attr (getattr default).
+EMITTED_ATTRS = {
+    # model.*
+    "model_provider",
+    "model_name",
+    "api_base",
+    "api_key",  # redacted -> resolves to ""
+    "temperature",
+    "max_tokens",
+    "max_iterations",
+    # subagents.researcher
+    "researcher",
+    # middleware.*
+    "knowledge_middleware",
+    "audit_middleware",
+    "memory_middleware",
+    "scheduler_enabled",
+    # knowledge.*
+    "knowledge_db_path",
+    "embed_model",
+    "knowledge_top_k",
+    # skills.*
+    "skills_enabled",
+    "skills_db_path",
+    "skills_top_k",
+    "skills_dir",
+    # mcp.*
+    "mcp_enabled",
+    "mcp_servers",
+    "mcp_timeout_seconds",
+    "mcp_denylist",
+    # plugins.*
+    "plugins_enabled",
+    "plugins_dir",
+    # identity.*
+    "identity_name",
+    "identity_operator",
+    # auth.token
+    "auth_token",  # redacted -> resolves to ""
+    # runtime.*
+    "autostart_on_boot",
+    # operator.*
+    "operator_allowed_dirs",
+}
+
+
+def _write_yaml(dir_path: Path, body: str, *, secrets: str | None = None) -> str:
+    """Write a langgraph-config.yaml (and optional sibling secrets.yaml) and
+    return the config path."""
+    cfg = dir_path / "langgraph-config.yaml"
+    cfg.write_text(textwrap.dedent(body))
+    if secrets is not None:
+        (dir_path / "secrets.yaml").write_text(textwrap.dedent(secrets))
+    return str(cfg)
+
+
+# ---------------------------------------------------------------------------
+# (a) Golden field map for the shipped example config
+# ---------------------------------------------------------------------------
+
+
+def test_from_yaml_example_golden():
+    cfg = LangGraphConfig.from_yaml(EXAMPLE_PATH)
+
+    # Redacted / unpinned fields get dedicated assertions.
+    assert cfg.api_key == ""
+    assert cfg.auth_token == ""
+    assert isinstance(cfg.plugin_config, dict)
+
+    # Every other dataclass field must match the captured golden exactly.
+    # Iterate dataclasses.fields so a dropped or mis-parsed field fails loudly,
+    # and the golden map must cover exactly the non-exempt field set.
+    field_names = {f.name for f in dataclasses.fields(cfg)}
+    assert field_names - _GOLDEN_EXEMPT == set(FROM_YAML_EXAMPLE_FIELDS), (
+        "golden field map is out of sync with the dataclass fields"
+    )
+    for f in dataclasses.fields(cfg):
+        if f.name in _GOLDEN_EXEMPT:
+            continue
+        actual = getattr(cfg, f.name)
+        expected = FROM_YAML_EXAMPLE_FIELDS[f.name]
+        assert actual == expected, f"{f.name}: {actual!r} != {expected!r}"
+
+
+# ---------------------------------------------------------------------------
+# (b) config_to_dict golden (frozen partial output)
+# ---------------------------------------------------------------------------
+
+
+def test_config_to_dict_golden():
+    cfg = LangGraphConfig.from_yaml(EXAMPLE_PATH)
+    assert config_to_dict(cfg) == CONFIG_TO_DICT_GOLDEN
+
+
+# ---------------------------------------------------------------------------
+# (c) Round-trip over exactly the attrs config_to_dict emits
+# ---------------------------------------------------------------------------
+
+
+def test_round_trip_preserves_emitted_fields(tmp_path):
+    cfg = LangGraphConfig.from_yaml(EXAMPLE_PATH)
+    d = config_to_dict(cfg)
+
+    # config_to_dict -> apply into an EMPTY doc -> dump -> reload via from_yaml.
+    doc: dict = {}
+    apply_updates_to_yaml(doc, d)
+    out = tmp_path / "langgraph-config.yaml"
+    save_yaml_doc(doc, out)
+    reloaded = LangGraphConfig.from_yaml(str(out))
+
+    # Every attr config_to_dict actually emits must survive the round-trip.
+    # (Do NOT assert attrs config_to_dict omits — they're free to differ.)
+    for attr in EMITTED_ATTRS:
+        original = getattr(cfg, attr)
+        round_tripped = getattr(reloaded, attr)
+        if attr in ("api_key", "auth_token"):
+            # Redacted secrets resolve to "" on both sides (no secrets.yaml).
+            assert original == "" and round_tripped == "", attr
+            continue
+        assert round_tripped == original, f"{attr}: {round_tripped!r} != {original!r}"
+
+    # discord/google are plugin sections — they round-trip via plugin_config.
+    assert reloaded.plugin_config == cfg.plugin_config
+
+
+# ---------------------------------------------------------------------------
+# (d) One test per special case from the ground truth
+# ---------------------------------------------------------------------------
+
+
+def test_case1a_secret_overlay_wins(tmp_path):
+    """Secret beats main YAML beats default — secrets.yaml sibling wins."""
+    path = _write_yaml(
+        tmp_path,
+        """
+        model:
+          api_key: main_yaml_key
+        auth:
+          token: main_yaml_token
+        """,
+        secrets="""
+        model:
+          api_key: secret_overlay_key
+        auth:
+          token: secret_overlay_token
+        """,
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.api_key == "secret_overlay_key"
+    assert cfg.auth_token == "secret_overlay_token"
+
+
+def test_case1b_main_yaml_wins_when_no_secrets_file(tmp_path):
+    """No secrets.yaml -> main YAML value wins (over the dataclass default)."""
+    path = _write_yaml(
+        tmp_path,
+        """
+        model:
+          api_key: main_yaml_key
+        auth:
+          token: main_yaml_token
+        """,
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.api_key == "main_yaml_key"
+    assert cfg.auth_token == "main_yaml_token"
+
+
+def test_case2_deep_nesting(tmp_path):
+    """prompt_cache.warm.* and tools.deferred.* deep-nested reads."""
+    path = _write_yaml(
+        tmp_path,
+        """
+        prompt_cache:
+          warm:
+            enabled: true
+            interval_seconds: 99
+        tools:
+          deferred:
+            enabled: true
+            keep:
+              - foo
+              - bar
+        """,
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.cache_warming_enabled is True
+    assert cfg.cache_warming_interval_seconds == 99
+    assert cfg.tools_deferred_enabled is True
+    assert cfg.tools_deferred_keep == ["foo", "bar"]
+
+
+def test_case3_list_coercion_empty_section_is_empty_list(tmp_path):
+    """A present-but-empty section parses to None; list(... or []) -> []."""
+    path = _write_yaml(
+        tmp_path,
+        """
+        mcp:
+          servers:
+        tools:
+          disabled:
+        """,
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.mcp_servers == []
+    assert cfg.tools_disabled == []
+
+
+def test_case4_agent_runtime_none_coerces_to_native(tmp_path):
+    """'agent_runtime:' parses to None; the 'or "native"' yields 'native'."""
+    path = _write_yaml(tmp_path, "agent_runtime:\n")
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.agent_runtime == "native"
+
+
+def test_case5a_instance_block_id_present(tmp_path):
+    """instance.id present -> wins over top-level instance_id."""
+    path = _write_yaml(
+        tmp_path,
+        """
+        instance:
+          id: from_instance_block
+        instance_id: from_toplevel
+        """,
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.instance_id == "from_instance_block"
+
+
+def test_case5b_only_toplevel_instance_id(tmp_path):
+    """Only top-level instance_id present."""
+    path = _write_yaml(tmp_path, "instance_id: from_toplevel\n")
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.instance_id == "from_toplevel"
+
+
+def test_case5c_empty_instance_id_falls_through(tmp_path):
+    """Empty-string instance.id is falsy -> falls through to top-level."""
+    path = _write_yaml(
+        tmp_path,
+        """
+        instance:
+          id: ""
+        instance_id: from_toplevel
+        """,
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.instance_id == "from_toplevel"
+
+
+def test_case6a_cross_section_both_present(tmp_path):
+    """Enabled flags from middleware.*; tool lists from own top-level sections."""
+    path = _write_yaml(
+        tmp_path,
+        """
+        middleware:
+          enforcement: true
+          ingest: true
+        enforcement:
+          disallowed_tools:
+            - dangerous_tool
+          rate_limits:
+            web_search: 5
+        ingest:
+          tools:
+            - memory_ingest
+        """,
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.enforcement_enabled is True
+    assert cfg.enforcement_disallowed_tools == ["dangerous_tool"]
+    assert cfg.enforcement_rate_limits == {"web_search": 5}
+    assert cfg.ingest_enabled is True
+    assert cfg.ingest_tools == ["memory_ingest"]
+
+
+def test_case6b_middleware_flags_only_no_toplevel_sections(tmp_path):
+    """Flags read True from middleware.*; lists default to []/{} because their
+    OWN top-level sections are absent (proves the split)."""
+    path = _write_yaml(
+        tmp_path,
+        """
+        middleware:
+          enforcement: true
+          ingest: true
+        """,
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.enforcement_enabled is True
+    assert cfg.enforcement_disallowed_tools == []
+    assert cfg.enforcement_rate_limits == {}
+    assert cfg.ingest_enabled is True
+    assert cfg.ingest_tools == []
+
+
+def test_case7_key_rename_max_retries(tmp_path):
+    """YAML model.max_retries -> attr llm_max_retries."""
+    path = _write_yaml(tmp_path, "model:\n  max_retries: 7\n")
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.llm_max_retries == 7
+
+
+def test_case8a_researcher_partial_only_model(tmp_path):
+    """Only model overridden; other fields fall back to RESEARCHER_CONFIG."""
+    path = _write_yaml(
+        tmp_path,
+        """
+        subagents:
+          researcher:
+            model: custom-model
+        """,
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.researcher == SubagentDef(
+        enabled=True,
+        tools=["current_time", "web_search", "fetch_url", "memory_recall", "memory_list", "memory_ingest"],
+        max_turns=40,
+        model="custom-model",
+    )
+
+
+def test_case8b_researcher_empty_dict(tmp_path):
+    """Present-but-empty dict: override branch runs, every field hits the
+    registry default."""
+    path = _write_yaml(tmp_path, "subagents:\n  researcher: {}\n")
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.researcher == SubagentDef(
+        enabled=True,
+        tools=["current_time", "web_search", "fetch_url", "memory_recall", "memory_list", "memory_ingest"],
+        max_turns=40,
+        model="",
+    )
+
+
+def test_case8c_researcher_absent(tmp_path):
+    """researcher absent -> override branch skipped, default_factory value used.
+    Identical to 8b."""
+    path = _write_yaml(tmp_path, "model:\n  name: foo\n")
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.researcher == SubagentDef(
+        enabled=True,
+        tools=["current_time", "web_search", "fetch_url", "memory_recall", "memory_list", "memory_ingest"],
+        max_turns=40,
+        model="",
+    )
+
+
+def test_case9_empty_a2a_section_handled_via_or(tmp_path):
+    """'a2a:' with no body parses to None; data.get('a2a') or {} protects the
+    subsequent .get() calls."""
+    path = _write_yaml(tmp_path, "a2a:\n")
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.a2a_skills == []
+    assert cfg.a2a_description == ""
+    assert cfg.a2a_require_routable_url is False
+
+
+# ---------------------------------------------------------------------------
+# (e) Reviewer-found gaps — real save/merge path, secret edge, coercions
+# ---------------------------------------------------------------------------
+
+
+def test_real_merge_path_preserves_omitted_and_overwrites_emitted(tmp_path):
+    """The REAL save path merges config_to_dict INTO the existing doc (not an
+    empty one). config_to_dict-EMITTED keys are overwritten; sections it OMITS
+    (e.g. goal) and unknown keys are preserved. (Behavior captured live.)"""
+    cfg = LangGraphConfig.from_yaml(EXAMPLE_PATH)
+    doc = {
+        "goal": {"max_iterations": 99},  # omitted by config_to_dict
+        "model": {"name": "OLD_NAME", "extra_key": "keep_me"},  # emitted section + unknown key
+    }
+    apply_updates_to_yaml(doc, config_to_dict(cfg))
+    out = tmp_path / "langgraph-config.yaml"
+    save_yaml_doc(doc, out)
+    reloaded = LangGraphConfig.from_yaml(str(out))
+
+    assert reloaded.goal_max_iterations == 99  # omitted section preserved
+    assert reloaded.model_name == "protolabs/reasoning"  # emitted key overwritten
+    assert doc["model"]["extra_key"] == "keep_me"  # unknown key untouched by the merge
+
+
+def test_empty_string_secret_falls_through_to_main_yaml(tmp_path):
+    """An empty-string secret is falsy, so `secret or main.get(...)` falls
+    through to the main-YAML value instead of clobbering it with ""."""
+    path = _write_yaml(
+        tmp_path,
+        "model:\n  api_key: main_key\n",
+        secrets="model:\n  api_key: ''\n",
+    )
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.api_key == "main_key"
+
+
+def test_agent_runtime_nonstring_coerces_to_str(tmp_path):
+    """agent_runtime = str(value or "native") coerces a non-string to str."""
+    path = _write_yaml(tmp_path, "agent_runtime: 123\n")
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.agent_runtime == "123"
+
+
+def test_a2a_require_routable_url_bool_coercion(tmp_path):
+    """a2a.require_routable_url = bool(value) coerces truthy/falsy ints."""
+    d1 = tmp_path / "truthy"; d1.mkdir()
+    d0 = tmp_path / "falsy"; d0.mkdir()
+    c1 = LangGraphConfig.from_yaml(_write_yaml(d1, "a2a:\n  require_routable_url: 1\n"))
+    c0 = LangGraphConfig.from_yaml(_write_yaml(d0, "a2a:\n  require_routable_url: 0\n"))
+    assert c1.a2a_require_routable_url is True
+    assert c0.a2a_require_routable_url is False
+
+
+def test_researcher_explicit_tools_override_replaces(tmp_path):
+    """An explicit researcher.tools list REPLACES the registry default (not merged)."""
+    path = _write_yaml(tmp_path, "subagents:\n  researcher:\n    tools: [only_this]\n")
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.researcher.tools == ["only_this"]
+
+
+def test_plugins_sources_empty_section_is_empty_list(tmp_path):
+    """plugins.sources present-but-empty -> (sources or {}).get('allow', []) -> []."""
+    path = _write_yaml(tmp_path, "plugins:\n  sources:\n")
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.plugins_sources_allow == []


### PR DESCRIPTION
## What
**B1 PR-1 — the safety net before refactoring the config triplet.** Tests-only, **zero production change.** Locks today's behavior of `from_yaml` / `config_to_dict` / `settings_schema.FIELDS` so the upcoming single-source refactor can't silently change anything.

Built by capturing exact current behavior empirically (running the real code), authoring grounded tests, then adversarially re-verifying every literal (3 reviewers, zero value diffs).

### `tests/test_config_roundtrip.py` (24 tests)
- **Golden `from_yaml(example)`** — field-by-field, iterating `dataclasses.fields` so a dropped/mis-parsed field fails loudly.
- **Golden `config_to_dict`** — freezes today's *partial* output (a later expansion becomes a reviewable diff).
- **Round-trip** over exactly the attrs `config_to_dict` emits, incl. the **real save/merge path** (omitted sections preserved, emitted overwritten, unknown keys untouched).
- **Every special case**: secret overlay precedence + empty-string fall-through, deep nesting, list coercion, `agent_runtime` None/non-string coercion, `instance.id` fallback, cross-section enforcement/ingest flags, `model.max_retries`→`llm_max_retries` rename, researcher `SubagentDef` (partial/empty/absent/explicit-tools), empty `a2a`, `require_routable_url` bool coercion, `plugins.sources` guard.

### `tests/test_config_drift_guard.py` (112 pass + 28 strict-xfail)
- Every `FIELDS.attr` exists on the dataclass; every `FIELDS.key` round-trips through `config_to_dict`; FIELDS types match.
- The **28 `xfail(strict=True)`** document the two known B1 gaps — `identity_org` (a UI field with no dataclass storage) and the 27 `FIELDS` keys `config_to_dict` doesn't serialize — and **auto-flip to loud failures** the moment they're fixed in PR-2/PR-3.

## Context
First of a staged B1 effort (data model = App→Host→Agent cascade, per-field, discussed separately). PR-2 = `from_dict` seam + the `identity_org` fix; PR-3 = make `config_to_dict` FIELDS-complete.

## Verification
205 passed, 28 xfailed; full existing config suite green; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)