### PR TITLE
fix(e2e): tenant-guard spec — seed the stale uid ONCE, not on every navigation

### DIFF
--- a/apps/web/e2e/tenant-guard.spec.ts
+++ b/apps/web/e2e/tenant-guard.spec.ts
@@ -6,6 +6,10 @@ import { expect, test } from "@playwright/test";
 
 test("a different backend uid clears the previous tenant's chat view", async ({ page }) => {
   await page.addInitScript(() => {
+    // Seed ONCE: addInitScript re-runs on every navigation — including the guard's own
+    // reload — and re-seeding the stale uid there would loop the guard forever.
+    if (window.sessionStorage.getItem("e2e-tenant-seeded")) return;
+    window.sessionStorage.setItem("e2e-tenant-seeded", "1");
     window.localStorage.setItem("protoagent.tenant.uid", "previous-agent-uid");
     window.localStorage.setItem(
       "protoagent.chat.sessions",


### PR DESCRIPTION
addInitScript re-runs on every navigation, including the guard's own reload —
so the spec re-seeded the stale uid post-reload and looped the guard forever.
Passed upstream on timing luck (the assertions won the race between reload
cycles); failed deterministically on slower CI (roxy#1: 'Execution context was
destroyed'). Now seeds once per tab session via a sessionStorage sentinel.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
