### PR TITLE
test(web): fix the ~50% flaky tenant-guard e2e (addInitScript re-seed race)

### DIFF
--- a/apps/web/e2e/tenant-guard.spec.ts
+++ b/apps/web/e2e/tenant-guard.spec.ts
@@ -5,23 +5,32 @@ import { expect, test } from "@playwright/test";
 // chat view is dropped (one reload) and the operator is told. Same uid = untouched.
 
 test("a different backend uid clears the previous tenant's chat view", async ({ page }) => {
-  await page.addInitScript(() => {
+  // Seed the previous tenant's state ONCE (via evaluate on the live origin), NOT via
+  // addInitScript: addInitScript re-runs on every navigation, so when the guard does
+  // its clear-and-reload it would re-seed the old uid+chats and race the clear (~50%
+  // flake). A one-time seed lets the guard's clear stick.
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.evaluate(() => {
     window.localStorage.setItem("protoagent.tenant.uid", "previous-agent-uid");
     window.localStorage.setItem(
       "protoagent.chat.sessions",
       JSON.stringify({ version: 1, currentSessionId: null, sessions: [{ id: "c1", title: "Old tenant secrets", messages: [], createdAt: 1, updatedAt: 1 }] }),
     );
   });
-  await page.goto("/app/", { waitUntil: "load" });
+  await page.reload({ waitUntil: "load" });
 
   // The guard clears + reloads, then toasts on the fresh page.
   await expect(page.getByText("Different agent on this address")).toBeVisible({ timeout: 10_000 });
-  const state = await page.evaluate(() => ({
-    chats: window.localStorage.getItem("protoagent.chat.sessions"),
-    uid: window.localStorage.getItem("protoagent.tenant.uid"),
-  }));
-  expect(state.chats).toBeNull();
-  expect(state.uid).toBe("mock-uid-1");
+  // The reload navigation can still be in flight when we read localStorage, which throws
+  // "execution context was destroyed, most likely because of a navigation". Retry until it settles.
+  await expect(async () => {
+    const state = await page.evaluate(() => ({
+      chats: window.localStorage.getItem("protoagent.chat.sessions"),
+      uid: window.localStorage.getItem("protoagent.tenant.uid"),
+    }));
+    expect(state.chats).toBeNull();
+    expect(state.uid).toBe("mock-uid-1");
+  }).toPass({ timeout: 10_000 });
 });
 
 test("the same backend uid keeps the chat view (restart/upgrade case)", async ({ page }) => {


### PR DESCRIPTION
## What
`apps/web/e2e/tenant-guard.spec.ts` (landed in #831) is **~50% flaky** and intermittently reds the **Web E2E gate for every PR** (it just blocked an unrelated Python-only config PR 3×).

## Root cause
The test seeded the previous tenant's `uid`+`chats` via `page.addInitScript`, which **re-runs on every navigation** — including the guard's own clear-and-reload. On that reload it **re-seeded the old state**, racing the guard's clear: ~50% of runs `protoagent.chat.sessions` was never cleared and the assertion failed (`state.chats` stayed non-null).

## Fix
- Seed **once** on the live origin via `page.evaluate` (then `reload`) instead of `addInitScript`, so the guard's clear sticks.
- Wrap the post-reload `localStorage` read in `expect(...).toPass()` to absorb the transient *"execution context was destroyed, most likely because of a navigation"*.

## Validation
**24/24 green** over `--repeat-each=12` locally (was ~50% flaky: 5/10 and 3/3 fails before). Test intent unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)