### PR TITLE
refactor(config): from_dict seam + fix the identity_org drift (B1 PR-2)

### DIFF
--- a/graph/config.py
+++ b/graph/config.py
@@ -390,6 +390,7 @@ class LangGraphConfig:
     # it's talking to — injected into the system prompt when non-empty.
     identity_name: str = "protoagent"
     identity_operator: str = ""
+    identity_org: str = ""  # white-label org label (settings_schema FIELDS + runtime status + Header)
 
     # A2A card identity (#570). Forks declare their advertised skills + card
     # description here (or a plugin contributes skills via register_a2a_skill)
@@ -488,7 +489,12 @@ class LangGraphConfig:
 
     @classmethod
     def from_yaml(cls, path: str | Path) -> "LangGraphConfig":
-        """Load config from YAML file. Falls back to defaults if absent."""
+        """Load config from YAML file. Falls back to defaults if absent.
+
+        Thin wrapper: read the file (+ sibling secrets.yaml), then parse via
+        :meth:`from_dict` — the dict-level seam tests and the layered-settings
+        loader build on.
+        """
         p = Path(path)
         if not p.exists():
             return cls()
@@ -497,6 +503,25 @@ class LangGraphConfig:
             data = yaml.safe_load(f) or {}
 
         secrets = _load_secrets_doc(p.parent)
+        return cls.from_dict(data, secrets=secrets, config_dir=p.parent)
+
+    @classmethod
+    def from_dict(
+        cls,
+        data: dict | None,
+        *,
+        secrets: dict | None = None,
+        config_dir: Path | str | None = None,
+    ) -> "LangGraphConfig":
+        """Build a config from an already-loaded YAML dict — the parse seam.
+
+        ``secrets`` overlays secret keys (model api_key, auth token); ``config_dir``
+        locates plugin config (ADR 0019). Both optional so callers/tests can parse a
+        bare dict. Behavior is identical to the old inline ``from_yaml`` parse.
+        """
+        data = data or {}
+        secrets = secrets or {}
+        config_dir = Path(config_dir) if config_dir is not None else Path(".")
 
         model = data.get("model", {})
         subagents = data.get("subagents", {})
@@ -611,6 +636,7 @@ class LangGraphConfig:
             plugins_sources_allow=list((plugins.get("sources", {}) or {}).get("allow", []) or []),
             identity_name=identity.get("name", cls.identity_name),
             identity_operator=identity.get("operator", cls.identity_operator),
+            identity_org=identity.get("org", cls.identity_org),
             a2a_skills=list(a2a.get("skills", []) or []),
             a2a_description=a2a.get("description", "") or "",
             a2a_require_routable_url=bool(a2a.get("require_routable_url", False)),
@@ -626,7 +652,7 @@ class LangGraphConfig:
             filesystem_projects=list(data.get("filesystem", {}).get("projects", []) or []),
             egress_allowed_hosts=list(data.get("egress", {}).get("allowed_hosts", []) or []),
             security_callback_allowlist=list((data.get("security") or {}).get("callback_allowlist", []) or []),
-            plugin_config=_resolve_plugin_config(data, secrets, p.parent),
+            plugin_config=_resolve_plugin_config(data, secrets, config_dir),
         )
 
         for name in ("researcher",):

--- a/tests/test_config_drift_guard.py
+++ b/tests/test_config_drift_guard.py
@@ -20,12 +20,10 @@ NOTE on the import path: ``config_to_dict`` lives in ``graph.config_io`` (not
 KNOWN GAPS (documented as ``strict=True`` xfails so they auto-flip to a LOUD
 failure the moment the refactor closes them):
 
-* ``identity.org`` (attr ``identity_org``) — the Field, the ``config_to_dict``
-  emit, the runtime status API, and the frontend Header all reference it, but the
-  dataclass has NO ``identity_org`` field and ``from_yaml`` never parses ``org``.
-  So today the white-label org label can never persist. Fix = add the dataclass
-  field + a ``from_yaml`` parse line; then test #1's ``identity.org`` param flips
-  to passing (xfail strict fails loudly to tell us to drop the marker).
+* ``identity.org`` (attr ``identity_org``) — RESOLVED in PR-2: the dataclass field
+  + the ``from_yaml`` parse line were added, so the white-label org label persists
+  now. ``ATTR_MISSING_KEYS`` is empty and test #1's ``identity.org`` param passes
+  normally (the strict xfail is gone).
 * ``config_to_dict`` is PARTIAL — it serializes only a legacy subset of sections
   (model/subagents/middleware-core/knowledge/skills/mcp/plugins/identity/auth/
   runtime/operator). 27 otherwise-valid FIELDS keys (routing, compaction, goal,
@@ -50,8 +48,12 @@ from graph.settings_schema import FIELDS
 # real, future drift.
 # --------------------------------------------------------------------------- #
 
-# B1: FIELDS entry whose .attr is absent on LangGraphConfig.
-ATTR_MISSING_KEYS = {"identity.org"}
+# B1: FIELDS entries whose .attr is absent on LangGraphConfig. Now EMPTY —
+# identity.org was the only one, and PR-2 added the `identity_org` dataclass
+# field + from_yaml parse line, so every FIELDS attr now exists. The per-field
+# strict xfail is therefore gone (identity.org passes normally), and
+# test_no_unexpected_attr_drift asserts this stays empty.
+ATTR_MISSING_KEYS: set[str] = set()
 
 # B1: non-secret FIELDS keys that config_to_dict does NOT serialize (partial
 # serializer — 27 keys). identity.org is intentionally NOT here: config_to_dict

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -75,6 +75,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "goal_verify_timeout": 120.0,
     "identity_name": "protoagent",
     "identity_operator": "",
+    "identity_org": "",
     "ingest_enabled": False,
     "ingest_tools": [],
     "instance_id": "",


### PR DESCRIPTION
## What
Second B1 increment, on top of the PR-1 (#833) safety net which guards both changes.

### 1. `from_dict` seam (behavior-preserving)
Split `LangGraphConfig.from_yaml` into a thin file-loader that delegates to a new `from_dict(data, *, secrets=None, config_dir=None)` holding the parse. Gives a **dict-level entry point** for tests and the upcoming layered-settings (App→Host→Agent) loader — with **zero behavior change** (the golden round-trip/characterization tests are unchanged and green; `from_dict(None)` → defaults, bare-dict parse works).

### 2. Fix the `identity_org` drift
`settings_schema.FIELDS`, `config_to_dict`, and the runtime status API all reference `identity.org` (a white-label org label → frontend Header), but the dataclass had no field and `from_yaml` never parsed it — so **the UI could never persist it.** Added `identity_org: str = ""` + the parse line. The drift guard's `strict=True` xfail for `identity.org` **flips to a normal pass** (auto-detected the fix, exactly as designed).

## Verification
**207 passed, 27 xfailed** (was 205/28 — the one `identity_org` xfail is now a real pass). Full existing config suite + `from_yaml`-consumer smoke green; `ruff` clean. The remaining 27 xfails are the `config_to_dict`-partial gap → **PR-3**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)