### PR TITLE
fix(fleet): discover() collapses a co-located agent's mDNS advert with its local-scan hit

### DIFF
--- a/graph/fleet/discovery.py
+++ b/graph/fleet/discovery.py
@@ -224,6 +224,15 @@ async def discover(*, known: set | None = None,
         asyncio.to_thread(_browse_mdns, timeout),
         _scan_tailnet(port_range, known),
     )
+    # An mDNS advert carrying THIS machine's own IP is a co-located agent — the same
+    # agent the local scan finds at 127.0.0.1:<port>. Normalize it to loopback so the
+    # (host, port) dedupe collapses the pair (it surfaced twice otherwise, once per
+    # channel). Genuinely-remote LAN/tailnet siblings keep their own addresses.
+    own_ip = _local_ip()
+    for a in network:
+        if a["host"] == own_ip:
+            a["host"] = "127.0.0.1"
+            a["url"] = f"http://127.0.0.1:{a['port']}"
     out: dict[tuple, dict] = {}
     for a in network + tailnet + local:  # local wins on a url clash (it's the more specific probe)
         if (a["host"], a["port"]) in known:

--- a/tests/test_fleet_discovery.py
+++ b/tests/test_fleet_discovery.py
@@ -155,3 +155,32 @@ def test_discover_merges_three_channels(monkeypatch):
     ])
     found = asyncio.run(discovery.discover(known={("192.168.5.41", 7871)}))
     assert sorted(f["name"] for f in found) == ["ava-agent", "lan", "loc"]
+
+
+def test_discover_collapses_colocated_mdns_with_local_scan(monkeypatch):
+    """A co-located agent surfaces via BOTH channels (loopback scan + its own mDNS advert
+    carrying the machine's LAN IP) — discover() must normalize the advert to loopback so
+    the (host, port) dedupe collapses the pair into one entry."""
+    monkeypatch.setattr(discovery, "_local_ip", lambda: "192.168.5.31")
+
+    async def fake_local(port_range, skip):
+        return [{"name": "roxy", "url": "http://127.0.0.1:7874", "host": "127.0.0.1", "port": 7874}]
+
+    async def fake_tailnet(port_range, known):
+        return []
+
+    monkeypatch.setattr(discovery, "_scan_local", fake_local)
+    monkeypatch.setattr(discovery, "_scan_tailnet", fake_tailnet)
+    monkeypatch.setattr(discovery, "_browse_mdns", lambda timeout: [
+        {"name": "roxy", "url": "http://192.168.5.31:7874", "host": "192.168.5.31", "port": 7874},
+        {"name": "remote", "url": "http://192.168.5.40:7871", "host": "192.168.5.40", "port": 7871},
+    ])
+    found = asyncio.run(discovery.discover())
+    assert sorted((f["name"], f["host"]) for f in found) == [
+        ("remote", "192.168.5.40"),   # a genuinely-remote sibling keeps its LAN address
+        ("roxy", "127.0.0.1"),        # the co-located pair collapsed to the loopback entry
+    ]
+
+    # And a KNOWN fleet peer's own advert (LAN ip + its port) is excluded the same way.
+    found = asyncio.run(discovery.discover(known={("127.0.0.1", 7874)}))
+    assert [f["name"] for f in found] == ["remote"]


### PR DESCRIPTION
A local agent surfaced TWICE in the Discover panel: once from the loopback
port-scan (127.0.0.1:7874) and once from its own mDNS advertisement (which
carries the machine's LAN IP, 192.168.5.31:7874) — different (host, port) keys,
so the dedupe kept both. The hub already normalized its OWN self-advert but not
other co-located agents'.

Fix: any mDNS hit whose host is THIS machine's own IP is by definition
co-located — rewrite it to 127.0.0.1 before the dedupe, which collapses it with
the local-scan entry (and, bonus, makes a fleet PEER's own advert hit the
`known` exclusion correctly instead of reappearing as 'discovered'). Genuinely
remote LAN/tailnet siblings keep their addresses.

Live-verified with a running roxy on :7874 + host on :7871: each listed exactly
once at its loopback address. 1477 py green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
