### PR TITLE
refactor(config): make config_to_dict FIELDS-driven — the single source (B1 PR-3)

### DIFF
--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -216,79 +216,75 @@ def save_yaml_doc(doc: Any, path: Path = CONFIG_YAML_PATH) -> None:
 # Config dict <-> dataclass
 # ---------------------------------------------------------------------------
 
-def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
-    """Serialize a LangGraphConfig into the nested dict shape the UI
-    works with. Mirrors the YAML schema so round-tripping is trivial.
+def _deep_merge(dst: dict[str, Any], src: dict[str, Any]) -> dict[str, Any]:
+    """Recursively merge ``src`` into ``dst`` (src wins on leaf conflicts)."""
+    for k, v in src.items():
+        if isinstance(v, dict) and isinstance(dst.get(k), dict):
+            _deep_merge(dst[k], v)
+        else:
+            dst[k] = v
+    return dst
 
-    Secret fields (model API key, A2A bearer) are redacted to ``""`` — the
-    UI never needs the value back, only whether one is set (runtime status
-    carries that as a boolean). Combined with the blank-means-unchanged save
-    semantics in ``split_secret_updates``, a save that echoes the blank back
-    leaves the stored secret intact.
+
+def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
+    """Serialize a LangGraphConfig into the nested dict shape the UI works with.
+
+    SINGLE SOURCE (B1): every settings-schema field (``graph.settings_schema.FIELDS``)
+    is emitted from its declared ``key -> attr`` mapping, so adding a ``Field``
+    auto-serializes it — this function no longer hand-mirrors the schema (it used
+    to, and silently drifted: 27 fields were unserialized). Secret-typed fields are
+    redacted to ``""`` — the UI only needs to know one is set, and the blank-means-
+    unchanged save semantics (``split_secret_updates``) keep the stored secret
+    intact when the blank is echoed back. The non-FIELDS legacy keys
+    (mcp / knowledge.db_path / skills / plugins / researcher) and the ADR-0019
+    plugin sections are layered on explicitly below.
     """
-    d: dict[str, Any] = {
-        "model": {
-            "provider": config.model_provider,
-            "name": config.model_name,
-            "api_base": config.api_base,
-            "api_key": "",
-            "temperature": config.temperature,
-            "max_tokens": config.max_tokens,
-            "max_iterations": config.max_iterations,
-        },
-        "subagents": {
-            "researcher": {
-                "enabled": config.researcher.enabled,
-                "tools": list(config.researcher.tools),
-                "max_turns": config.researcher.max_turns,
-                "model": config.researcher.model,
-            },
-        },
-        "middleware": {
-            "knowledge": config.knowledge_middleware,
-            "audit": config.audit_middleware,
-            "memory": config.memory_middleware,
-            "scheduler": config.scheduler_enabled,
-        },
-        "knowledge": {
-            "db_path": config.knowledge_db_path,
-            "embed_model": config.embed_model,
-            "top_k": config.knowledge_top_k,
-        },
-        "skills": {
-            "enabled": config.skills_enabled,
-            "db_path": config.skills_db_path,
-            "top_k": config.skills_top_k,
-            "dir": config.skills_dir,
-        },
+    from graph.settings_schema import FIELDS
+
+    # (A) Schema-driven: every settings-exposed key, from its declared key->attr.
+    d: dict[str, Any] = {}
+    for f in FIELDS:
+        val = "" if f.type == "secret" else getattr(config, f.attr)
+        if isinstance(val, (list, tuple)):
+            val = list(val)
+        cursor = d
+        parts = f.key.split(".")
+        for part in parts[:-1]:
+            cursor = cursor.setdefault(part, {})
+        cursor[parts[-1]] = val
+
+    # (B) Non-FIELDS legacy keys the UI/round-trip needs but the settings schema
+    # doesn't expose. Their attrs still round-trip via from_yaml; they're just not
+    # in FIELDS, so they stay explicit.
+    r = config.researcher
+    _deep_merge(d, {
+        "knowledge": {"db_path": config.knowledge_db_path},
         "mcp": {
             "enabled": config.mcp_enabled,
             "servers": list(config.mcp_servers),
             "timeout_seconds": config.mcp_timeout_seconds,
             "denylist": list(config.mcp_denylist),
         },
+        "skills": {
+            "enabled": config.skills_enabled,
+            "db_path": config.skills_db_path,
+            "dir": config.skills_dir,
+        },
         "plugins": {
             "enabled": list(config.plugins_enabled),
             "dir": config.plugins_dir,
         },
-        "identity": {
-            "name": config.identity_name,
-            "operator": config.identity_operator,
-            "org": getattr(config, "identity_org", ""),
+        "subagents": {
+            "researcher": {
+                "enabled": r.enabled,
+                "tools": list(r.tools),
+                "max_turns": r.max_turns,
+                "model": r.model,
+            },
         },
-        "auth": {
-            "token": "",
-        },
-        # `discord` and `google` are now plugin sections (ADR 0019) — surfaced
-        # via the plugin_config loop below, not hardcoded blocks.
-        "runtime": {
-            "autostart_on_boot": config.autostart_on_boot,
-        },
-        "operator": {
-            "allowed_dirs": list(config.operator_allowed_dirs),
-        },
-    }
-    # Plugin-declared sections (ADR 0019) — reflect the PASSED config's resolved
+    })
+
+    # (C) Plugin-declared sections (ADR 0019) — reflect the PASSED config's resolved
     # plugin_config (not a re-discovery), with declared secrets redacted
     # (blank-means-unchanged, like api_key). A default config has none.
     plugin_cfg = getattr(config, "plugin_config", {}) or {}

--- a/tests/test_config_drift_guard.py
+++ b/tests/test_config_drift_guard.py
@@ -24,14 +24,13 @@ failure the moment the refactor closes them):
   + the ``from_yaml`` parse line were added, so the white-label org label persists
   now. ``ATTR_MISSING_KEYS`` is empty and test #1's ``identity.org`` param passes
   normally (the strict xfail is gone).
-* ``config_to_dict`` is PARTIAL — it serializes only a legacy subset of sections
-  (model/subagents/middleware-core/knowledge/skills/mcp/plugins/identity/auth/
-  runtime/operator). 27 otherwise-valid FIELDS keys (routing, compaction, goal,
-  execute_code, prompt_cache, several checkpoint/knowledge/telemetry keys,
-  agent_runtime, operator_mcp.tools, middleware.enforcement) are NOT emitted,
-  despite its docstring claiming it "mirrors the YAML schema". Each missing key
-  is a ``strict=True`` xfail in test #2; making ``config_to_dict`` FIELDS-complete
-  flips them to passing.
+* ``config_to_dict`` was PARTIAL — RESOLVED in PR-3: it is now FIELDS-driven and
+  serializes ALL FIELDS keys (the 27 previously-missing keys — routing, compaction,
+  goal, execute_code, prompt_cache, several checkpoint/knowledge/telemetry keys,
+  agent_runtime, operator_mcp.tools, middleware.enforcement — are now emitted).
+  ``CONFIG_TO_DICT_MISSING_KEYS`` is therefore empty, the per-key strict xfails in
+  test #2 are gone (every key passes normally), and
+  ``test_config_to_dict_missing_set_is_exactly_as_expected`` asserts it stays empty.
 """
 
 from __future__ import annotations
@@ -55,39 +54,12 @@ from graph.settings_schema import FIELDS
 # test_no_unexpected_attr_drift asserts this stays empty.
 ATTR_MISSING_KEYS: set[str] = set()
 
-# B1: non-secret FIELDS keys that config_to_dict does NOT serialize (partial
-# serializer — 27 keys). identity.org is intentionally NOT here: config_to_dict
-# DOES emit it (via a defensive getattr default of ""), so its resolution passes
-# even though its dataclass attr is missing (that drift is covered by test #1).
-CONFIG_TO_DICT_MISSING_KEYS = {
-    "agent_runtime",
-    "operator_mcp.tools",
-    "routing.aux_model",
-    "routing.fallback_models",
-    "compaction.enabled",
-    "compaction.trigger",
-    "compaction.keep_messages",
-    "compaction.model",
-    "goal.enabled",
-    "goal.max_iterations",
-    "goal.eval_model",
-    "execute_code.enabled",
-    "execute_code.timeout",
-    "prompt_cache.enabled",
-    "prompt_cache.ttl",
-    "prompt_cache.warm.enabled",
-    "prompt_cache.warm.interval_seconds",
-    "knowledge.embeddings",
-    "checkpoint.db_path",
-    "checkpoint.keep_per_thread",
-    "checkpoint.max_age_days",
-    "checkpoint.prune_interval_hours",
-    "checkpoint.harvest_enabled",
-    "knowledge.facts",
-    "middleware.enforcement",
-    "telemetry.enabled",
-    "telemetry.retention_days",
-}
+# B1: non-secret FIELDS keys that config_to_dict does NOT serialize. RESOLVED in
+# PR-3 — config_to_dict is now FIELDS-driven and emits every FIELDS key, so this
+# is EMPTY. The per-field strict xfail in test #2 is therefore gone (all keys pass
+# normally), and test_config_to_dict_missing_set_is_exactly_as_expected asserts
+# this set stays empty so any future serializer regression fails loudly.
+CONFIG_TO_DICT_MISSING_KEYS: set[str] = set()
 
 _SECRET_KEYS = {f.key for f in FIELDS if f.type == "secret"}
 

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -128,9 +128,17 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # Top-level schema surface — all the sections the YAML exposes.
     # Adding a new section here without updating config_to_dict would
     # strand fork-added fields outside the drawer's round-trip.
+    # B1 PR-3: config_to_dict is now FIELDS-complete, so this is the FULL
+    # top-level key set (agent_runtime / checkpoint / compaction / execute_code
+    # / goal / operator_mcp / prompt_cache / routing / telemetry are now emitted
+    # too). discord/google are NOT here — they're plugin sections, present only
+    # when their plugin is enabled (surfaced via plugin_config), and a default
+    # LangGraphConfig() carries no plugin_config.
     assert set(d.keys()) == {
         "model", "subagents", "middleware", "knowledge", "skills", "mcp", "plugins",
-        "identity", "auth", "runtime", "operator",
+        "identity", "auth", "runtime", "operator", "agent_runtime", "checkpoint",
+        "compaction", "execute_code", "goal", "operator_mcp", "prompt_cache",
+        "routing", "telemetry",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -141,16 +141,43 @@ FROM_YAML_EXAMPLE_FIELDS = {
 # Fields handled by their own dedicated assertions, not the golden map.
 _GOLDEN_EXEMPT = {"api_key", "auth_token", "plugin_config"}
 
-# config_to_dict(from_yaml(example)) exact output — freezes the partial
-# (today's) emitted surface so a later expansion shows up as a reviewable diff.
+# config_to_dict(from_yaml(example)) exact output — freezes the now-FIELDS-
+# complete emitted surface (B1 PR-3) so a later change shows up as a reviewable
+# diff. The diff vs the old (partial, 11-section) golden is purely ADDITIVE:
+# the new sections agent_runtime / checkpoint / compaction / execute_code / goal
+# / knowledge.embeddings+facts / middleware.enforcement / operator_mcp /
+# prompt_cache / routing / telemetry appeared; no pre-existing value changed.
 CONFIG_TO_DICT_GOLDEN = {
+    "agent_runtime": "native",
     "auth": {
         "token": "",
+    },
+    "checkpoint": {
+        "db_path": "/sandbox/checkpoints.db",
+        "harvest_enabled": True,
+        "keep_per_thread": 5,
+        "max_age_days": 30,
+        "prune_interval_hours": 6,
+    },
+    "compaction": {
+        "enabled": True,
+        "keep_messages": 20,
+        "model": "",
+        "trigger": "fraction:0.8",
     },
     "discord": {
         "admin_ids": [],
         "bot_token": "",
         "enabled": False,
+    },
+    "execute_code": {
+        "enabled": False,
+        "timeout": 30,
+    },
+    "goal": {
+        "enabled": True,
+        "eval_model": "",
+        "max_iterations": 8,
     },
     "google": {
         "client_id": "",
@@ -166,6 +193,8 @@ CONFIG_TO_DICT_GOLDEN = {
     "knowledge": {
         "db_path": "/sandbox/knowledge/agent.db",
         "embed_model": "qwen3-embedding",
+        "embeddings": True,
+        "facts": True,
         "top_k": 5,
     },
     "mcp": {
@@ -176,6 +205,7 @@ CONFIG_TO_DICT_GOLDEN = {
     },
     "middleware": {
         "audit": True,
+        "enforcement": False,
         "knowledge": True,
         "memory": True,
         "scheduler": True,
@@ -192,9 +222,24 @@ CONFIG_TO_DICT_GOLDEN = {
     "operator": {
         "allowed_dirs": [],
     },
+    "operator_mcp": {
+        "tools": [],
+    },
     "plugins": {
         "dir": "",
         "enabled": [],
+    },
+    "prompt_cache": {
+        "enabled": True,
+        "ttl": "5m",
+        "warm": {
+            "enabled": False,
+            "interval_seconds": 3300,
+        },
+    },
+    "routing": {
+        "aux_model": "",
+        "fallback_models": [],
     },
     "runtime": {
         "autostart_on_boot": False,
@@ -218,6 +263,10 @@ CONFIG_TO_DICT_GOLDEN = {
                 "memory_list",
             ],
         },
+    },
+    "telemetry": {
+        "enabled": True,
+        "retention_days": 90,
     },
 }
 
@@ -270,6 +319,46 @@ EMITTED_ATTRS = {
     "autostart_on_boot",
     # operator.*
     "operator_allowed_dirs",
+    # --- B1 PR-3: config_to_dict is now FIELDS-complete, so these 27
+    # newly-emitted keys (derived key->attr from FIELDS) must also round-trip. ---
+    # agent_runtime
+    "agent_runtime",
+    # operator_mcp.tools
+    "operator_mcp_tools",
+    # routing.*
+    "aux_model",
+    "routing_fallback_models",
+    # compaction.*
+    "compaction_enabled",
+    "compaction_trigger",
+    "compaction_keep_messages",
+    "compaction_model",
+    # goal.*
+    "goal_enabled",
+    "goal_max_iterations",
+    "goal_eval_model",
+    # execute_code.*
+    "execute_code_enabled",
+    "execute_code_timeout",
+    # prompt_cache.* (incl. prompt_cache.warm.*)
+    "prompt_cache_enabled",
+    "prompt_cache_ttl",
+    "cache_warming_enabled",
+    "cache_warming_interval_seconds",
+    # knowledge.embeddings / knowledge.facts
+    "knowledge_embeddings",
+    "knowledge_facts",
+    # checkpoint.*
+    "checkpoint_db_path",
+    "checkpoint_keep_per_thread",
+    "checkpoint_max_age_days",
+    "checkpoint_prune_interval_hours",
+    "checkpoint_harvest_enabled",
+    # middleware.enforcement
+    "enforcement_enabled",
+    # telemetry.*
+    "telemetry_enabled",
+    "telemetry_retention_days",
 }
 
 
@@ -592,10 +681,15 @@ def test_case9_empty_a2a_section_handled_via_or(tmp_path):
 def test_real_merge_path_preserves_omitted_and_overwrites_emitted(tmp_path):
     """The REAL save path merges config_to_dict INTO the existing doc (not an
     empty one). config_to_dict-EMITTED keys are overwritten; sections it OMITS
-    (e.g. goal) and unknown keys are preserved. (Behavior captured live.)"""
+    and unknown keys are preserved. (Behavior captured live.)
+
+    B1 PR-3: config_to_dict is now FIELDS-complete, so the formerly-omitted
+    ``goal`` section is now emitted. ``a2a`` is a real still-omitted section
+    (no FIELDS keys, parsed by from_yaml) — it now stands in as the
+    omitted-but-preserved case."""
     cfg = LangGraphConfig.from_yaml(EXAMPLE_PATH)
     doc = {
-        "goal": {"max_iterations": 99},  # omitted by config_to_dict
+        "a2a": {"description": "kept_desc"},  # omitted by config_to_dict
         "model": {"name": "OLD_NAME", "extra_key": "keep_me"},  # emitted section + unknown key
     }
     apply_updates_to_yaml(doc, config_to_dict(cfg))
@@ -603,7 +697,7 @@ def test_real_merge_path_preserves_omitted_and_overwrites_emitted(tmp_path):
     save_yaml_doc(doc, out)
     reloaded = LangGraphConfig.from_yaml(str(out))
 
-    assert reloaded.goal_max_iterations == 99  # omitted section preserved
+    assert reloaded.a2a_description == "kept_desc"  # omitted section preserved
     assert reloaded.model_name == "protolabs/reasoning"  # emitted key overwritten
     assert doc["model"]["extra_key"] == "keep_me"  # unknown key untouched by the merge
 


### PR DESCRIPTION
## What
The B1 payoff. `config_to_dict` hand-mirrored the YAML schema and had **silently drifted**: 27 `settings_schema.FIELDS` keys (routing, compaction, goal, execute_code, prompt_cache, checkpoint, telemetry, `agent_runtime`, `operator_mcp.tools`, `middleware.enforcement`, `knowledge.embeddings`+`facts`) were **never serialized** — a Settings save for any of them was dropped on the next load.

Rewrite it **FIELDS-driven**: every settings key is emitted from its declared `key -> attr` (secrets redacted to `""`), so **adding a `Field` auto-serializes it** — no more hand-syncing the triplet. The non-FIELDS legacy keys (mcp / knowledge.db_path / skills / plugins / researcher) + ADR-0019 plugin sections stay explicit.

## Why it's safe (adversarially verified, 4 ways)
- **Purely additive**: 27 leaf keys added, **0 changed/removed**; the new golden is a byte-for-byte match to real output.
- **Round-trip holds for all 47 FIELDS keys** *even under adversarial value mutation* (negate bools, bump numbers, swap selects) — proving FIELDS keys agree with `from_yaml`'s parse paths, not just because example==default.
- **No secret leaks** — every `type=="secret"` field redacts to `""`.
- **Consumers green** — `config_routes` (GET /api/config), `console_handlers`, settings save.

## Tests
Goldens + `EMITTED_ATTRS` regenerated by *running* the code. The drift guard's 27-key `CONFIG_TO_DICT_MISSING_KEYS` is now **empty** — the strict-xfails flipped to real passes. **Suite: 234 passed, 0 xfailed** (was 205/28 at PR-1). The schema *is* the serializer now, so triplet drift is structurally impossible.

Completes the mechanical half of B1 (PR-1 net → PR-2 seam+identity_org → PR-3 single-source). Next: the App→Host→Agent cascade ADR + `Field.scope`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)