### PR TITLE
feat(fleet): remote agents as switchable fleet members (ADR 0042 §I, the proxy half)

### DIFF
--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -118,3 +118,32 @@ test("rename edits the display name; the id/slug stays", async ({ page }) => {
   await page.getByRole("menuitem", { name: /nova/ }).click();
   await expect(page).toHaveURL(/\/app\/agent\/ava\//);
 });
+
+test("discover → add to fleet → switch into the remote member (ADR 0042 §I)", async ({ page }) => {
+  await openAgents(page);
+  await page.getByRole("button", { name: /Discover agents/ }).click();
+  const found = page.locator(".fleet-row", { hasText: "remy" });
+  await expect(found).toBeVisible();
+
+  await found.getByRole("button", { name: "Add to this fleet (a switchable remote member)" }).click();
+
+  // Now a fleet member: remote tag + its URL, no start/stop controls.
+  const member = page.locator(".fleet-row", { hasText: "http://192.168.5.50:7871" });
+  await expect(member).toBeVisible();
+  await expect(member.getByText("remote", { exact: true })).toBeVisible();
+  await expect(member.getByRole("button", { name: "Stop" })).toHaveCount(0);
+
+  // And switchable: the topbar switcher navigates to its slug window, where the hub
+  // proxies the console (the mock strips /agents/<slug>/ — the app boots normally).
+  await page.getByTestId("fleet-switcher").click();
+  await page.getByRole("menuitem", { name: /remy/ }).click();
+  await expect(page).toHaveURL(/\/app\/agent\/remy-re01\//);
+  await expect(page.getByTestId("fleet-switcher")).toContainText("remy");
+
+  // Unregister from the fleet manager (the remote agent itself is untouched).
+  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Agents", exact: true }).click();
+  await page.locator(".fleet-row", { hasText: "remy" })
+    .getByRole("button", { name: /Remove from this fleet/ }).click();
+  await expect(page.locator(".fleet-row", { hasText: "remy" })).toHaveCount(0);
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -133,6 +133,12 @@ function handleApiGet(pathname) {
       return { theme: null }; // per-agent theme (ADR 0042); null → DS defaults
     case "/api/fleet":
       return { agents: FLEET.agents };
+    case "/api/fleet/discover":
+      // One discoverable sibling on the LAN (not in the fleet) — candidates for
+      // add-as-delegate or add-to-fleet (remote member).
+      return { discovered: FLEET.agents.some((a) => a.name === "remy") ? [] : [
+        { name: "remy", url: "http://192.168.5.50:7871", host: "192.168.5.50", port: 7871 },
+      ] };
     case "/api/archetypes":
       return { archetypes: ARCHETYPES };
     case "/api/activity":
@@ -309,6 +315,20 @@ const server = createServer(async (req, res) => {
       const agent = { name, id: `${name}-ab12`, port: 7899, pid: 5000, running: true, bundle: body.bundle || "" };
       FLEET.agents.push(agent);
       return sendJson(res, { ok: true, agent, installed: [] });
+    }
+    if (pathname === "/api/fleet/remotes" && req.method === "POST") {
+      const name = String(body.name || "").trim();
+      if (FLEET.agents.some((a) => a.name === name)) return sendJson(res, { detail: "an agent named " + name + " already exists" }, 400);
+      const agent = { name, id: `${name}-re01`, port: null, pid: null, running: true, bundle: "", remote: true, url: body.url, a2a: `${body.url}/a2a` };
+      FLEET.agents.push(agent);
+      return sendJson(res, { ok: true, agent });
+    }
+    if (req.method === "DELETE" && /^\/api\/fleet\/remotes\/[^/]+$/.test(pathname)) {
+      const ident = decodeURIComponent(pathname.split("/").pop());
+      const a = FLEET.agents.find((x) => x.remote && (x.id === ident || x.name === ident));
+      if (!a) return sendJson(res, { detail: "no remote member" }, 400);
+      FLEET.agents = FLEET.agents.filter((x) => x !== a);
+      return sendJson(res, { ok: true, id: a.id, name: a.name });
     }
     if (req.method === "PATCH" && /^\/api\/fleet\/[^/]+$/.test(pathname)) {
       const ident = decodeURIComponent(pathname.split("/").pop());

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -680,6 +680,19 @@ export const api = {
       method: "POST",
     });
   },
+  addRemoteAgent(body: { name: string; url: string; token?: string }) {
+    // Register a remote protoAgent as a SWITCHABLE fleet member (ADR 0042 §I) —
+    // it gets a slug window; the hub reverse-proxies its console + A2A.
+    return request<{ ok: boolean; agent: FleetAgent }>("/api/fleet/remotes", {
+      method: "POST",
+      body,
+    });
+  },
+  removeRemoteAgent(ident: string) {
+    return request<{ ok: boolean; id: string; name: string }>(`/api/fleet/remotes/${encodeURIComponent(ident)}`, {
+      method: "DELETE",
+    });
+  },
   renameAgent(ident: string, name: string) {
     // Display rename only — the id (URL slug + data scope) is immutable.
     return request<{ ok: boolean; id: string; name: string }>(`/api/fleet/${encodeURIComponent(ident)}`, {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -499,6 +499,8 @@ export type FleetAgent = {
   bundle: string; // "" for a Basic agent
   a2a?: string; // the agent's own A2A endpoint (focus-independent)
   host?: boolean; // the instance serving this console — can't be stopped/removed from itself
+  remote?: boolean; // a REMOTE member (ADR 0042 §I) — proxied by URL, no start/stop from here
+  url?: string; // the remote member's base URL
 };
 
 // The focused agent is the URL slug now (ADR 0042 slug routing) — no server-side 'active'.

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -118,6 +118,25 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   // same enable-and-retry path as fleet-row adds.
   const addRemote = (d: DiscoveredAgent) => addDelegate.mutate({ name: d.name, url: `${d.url}/a2a` });
 
+  // …or join the fleet outright (ADR 0042 §I): the remote becomes a SWITCHABLE member —
+  // a slug window, console + A2A reverse-proxied through this hub. Discovered names can
+  // collide with existing agents (every template fork is "protoagent") — suffix on 400.
+  const addMember = useMutation({
+    mutationFn: (d: DiscoveredAgent) => api.addRemoteAgent({ name: d.name, url: d.url }),
+    onMutate: () => setError(null),
+    onError: (e: Error) => setError(e.message),
+    onSettled: () => {
+      qc.invalidateQueries({ queryKey: queryKeys.fleet });
+      void scan(); // the new member drops out of the discover list
+    },
+  });
+  const removeMember = useMutation({
+    mutationFn: (a: FleetAgent) => api.removeRemoteAgent(a.id),
+    onMutate: () => setError(null),
+    onError: (e: Error) => setError(e.message),
+    onSettled: () => qc.invalidateQueries({ queryKey: queryKeys.fleet }),
+  });
+
   return (
     <section className="panel stage-panel">
       <PanelHeader
@@ -181,10 +200,11 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                         a.name
                       )}
                       {a.host ? <span className="fleet-host-tag">this instance</span> : null}
+                      {a.remote ? <span className="fleet-host-tag" title="A remote fleet member — proxied by URL">remote</span> : null}
                       {isActive ? <span className="fleet-active-tag">active</span> : null}
                     </span>
                     <span className="fleet-meta">
-                      :{a.port}
+                      {a.remote ? a.url : `:${a.port}`}
                       {a.pid ? ` · pid ${a.pid}` : ""}
                       {a.bundle ? ` · ${a.bundle}` : ""}
                     </span>
@@ -203,9 +223,18 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                         </Button>
                       )
                     ) : null}
+                    {/* A remote member can't be started/stopped/renamed from here — only
+                        unregistered (the remote agent itself is untouched). */}
+                    {a.remote ? (
+                      <Button icon variant="ghost" title="Remove from this fleet (the remote agent is untouched)"
+                        disabled={removeMember.isPending}
+                        onClick={() => removeMember.mutate(a)}>
+                        <Trash2 size={14} />
+                      </Button>
+                    ) : null}
                     {/* The host serves this console — it can't stop or remove itself; its
                         display name is edited in Settings → Identity instead. */}
-                    {a.host ? null : (
+                    {a.host || a.remote ? null : (
                       <>
                         <Button icon variant="ghost" title="Rename (display name only — the id/URL stays)"
                           disabled={rename.isPending}
@@ -258,6 +287,13 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                       <span className="fleet-meta">{d.url}</span>
                     </div>
                     <div className="fleet-row-actions">
+                      {/* Two ways in: a delegate of the FOCUSED agent (delegate_to flows), or a
+                          full fleet MEMBER — a switchable slug window proxied through this hub. */}
+                      <Button icon variant="ghost" title="Add to this fleet (a switchable remote member)"
+                        disabled={addMember.isPending}
+                        onClick={() => addMember.mutate(d)}>
+                        <Plus size={14} />
+                      </Button>
                       {delegateNames.has(d.name) ? (
                         <span className="fleet-delegate-tag" title="A delegate of this agent">delegate</span>
                       ) : (

--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -43,32 +43,44 @@ def _get_client() -> httpx.AsyncClient:
     return _client
 
 
-# Per-slug port resolution (ADR 0042 slug routing) — each console window targets an agent by URL
-# slug (/agents/<slug>/…) instead of a single global "active". 'host' = this instance; a peer =
-# its workspace port. 1s TTL cache, keyed by slug, to keep the proxy hot path cheap.
+# Per-slug target resolution (ADR 0042 slug routing) — each console window targets an agent by
+# URL slug (/agents/<slug>/…) instead of a single global "active". 'host' = this instance; a
+# local peer = its workspace port; a REMOTE member = its registered URL (+ its bearer, if one
+# was stored — replacing the browser's Authorization, which carries the HUB's token, not the
+# remote's). 1s TTL cache, keyed by slug, to keep the proxy hot path cheap.
 _slug_cache: dict = {}
 
 
-def _port_for_slug(slug: str) -> int | None:
+def _target_for_slug(slug: str) -> tuple[str, dict] | None:
+    """``(base_url, extra_headers)`` for a slug, or None when it isn't reachable."""
     now = time.monotonic()
     hit = _slug_cache.get(slug)
     if hit and now - hit[1] < 1.0:
         return hit[0]
+    target: tuple[str, dict] | None = None
     if slug == "host":
         from runtime.state import STATE
         port = getattr(STATE, "active_port", None)
+        target = (f"http://127.0.0.1:{port}", {}) if port else None
     else:
         rec = supervisor._load_state().get(slug)
-        port = rec.get("port") if rec and supervisor._alive(rec.get("pid")) else None
-    _slug_cache[slug] = (port, now)
-    return port
+        if rec and supervisor._alive(rec.get("pid")):
+            target = (f"http://127.0.0.1:{rec['port']}", {})
+        else:
+            remote = supervisor.remote_for_slug(slug)
+            if remote:
+                extra = {"authorization": f"Bearer {remote['token']}"} if remote.get("token") else {}
+                target = (remote["url"], extra)
+    _slug_cache[slug] = (target, now)
+    return target
 
 
-async def _forward_to_port(port: int, request, path: str):
-    """Stream-proxy ``request`` to ``/<path>`` on 127.0.0.1:<port> (SSE-safe)."""
-    url = f"http://127.0.0.1:{port}/{path}"
+async def _forward_to_base(base: str, request, path: str, extra_headers: dict | None = None):
+    """Stream-proxy ``request`` to ``<base>/<path>`` (SSE-safe)."""
+    url = f"{base}/{path}"
     body = await request.body()
     headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP}
+    headers.update(extra_headers or {})
 
     client = _get_client()
     upstream_req = client.build_request(
@@ -92,8 +104,10 @@ async def _forward_to_port(port: int, request, path: str):
 
 async def forward_to(slug: str, request, path: str):
     """Reverse-proxy to the agent named by ``slug`` (/agents/<slug>/* route, ADR 0042 slug
-    routing). ``host`` targets this instance; 409 if the agent isn't running."""
-    port = _port_for_slug(slug)
-    if port is None:
+    routing). ``host`` targets this instance; a remote member targets its URL; 409 if the
+    agent isn't running/registered."""
+    target = _target_for_slug(slug)
+    if target is None:
         return JSONResponse({"detail": f"agent {slug!r} is not running"}, status_code=409)
-    return await _forward_to_port(port, request, path)
+    base, extra = target
+    return await _forward_to_base(base, request, path, extra)

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -194,8 +194,108 @@ def _host_entry() -> dict:
     }
 
 
+# ── remote fleet members (ADR 0042 §I, the proxy half) ────────────────────────
+# A remote member is another protoAgent reachable by URL (LAN / tailnet / anywhere) that
+# joins this fleet as a SWITCHABLE agent: it gets a slug window like a local peer, with the
+# hub reverse-proxying its console + A2A. We can't start/stop it — `running` is a cached
+# reachability probe. Registry: `<workspaces_root>/remotes.json` (hub-scoped, #813);
+# an optional bearer token is stored alongside (plaintext, same posture as secrets.yaml)
+# and attached by the proxy — `status()` never returns it.
+
+
+def _remotes_path() -> Path:
+    return manager.workspaces_root() / "remotes.json"
+
+
+def _load_remotes() -> dict:
+    try:
+        return json.loads(_remotes_path().read_text())
+    except (OSError, json.JSONDecodeError):
+        return {}
+
+
+def _save_remotes(remotes: dict) -> None:
+    p = _remotes_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(remotes, indent=2))
+
+
+def list_remotes() -> list[dict]:
+    """Registered remote members, tokens INCLUDED — internal/proxy use only."""
+    return list(_load_remotes().values())
+
+
+def remote_for_slug(slug: str) -> dict | None:
+    """The remote record for a slug (id), or None. Token included — proxy use."""
+    return _load_remotes().get(slug)
+
+
+def add_remote(name: str, url: str, token: str = "") -> dict:
+    """Register a remote protoAgent as a fleet member. Name follows the workspace
+    charset + uniqueness rules; the id is opaque like a local agent's (#823)."""
+    name = manager._safe(name)
+    if name.lower() in manager._RESERVED_NAMES:
+        raise FleetError(f"{name!r} is reserved — it's how the fleet addresses this instance")
+    url = (url or "").strip().rstrip("/")
+    if not url.startswith(("http://", "https://")):
+        raise FleetError(f"remote url must be http(s), got {url!r}")
+    with _state_lock():
+        remotes = _load_remotes()
+        taken = ({r["name"] for r in remotes.values()}
+                 | {w["name"] for w in manager.list_workspaces()})
+        if name in taken:
+            raise FleetError(f"an agent named {name!r} already exists")
+        if any(r["url"] == url for r in remotes.values()):
+            raise FleetError(f"a remote at {url} is already in the fleet")
+        rid = manager._new_id(name)
+        rec = {"id": rid, "name": name, "url": url, "token": token,
+               "added": datetime.now(timezone.utc).isoformat()}
+        remotes[rid] = rec
+        _save_remotes(remotes)
+    log.info("[fleet] remote member added: %s (%s)", name, url)
+    return {k: v for k, v in rec.items() if k != "token"}
+
+
+def remove_remote(ident: str) -> dict:
+    """Unregister a remote member (by id or name) — the remote agent itself is untouched."""
+    with _state_lock():
+        remotes = _load_remotes()
+        rid = ident if ident in remotes else next(
+            (k for k, r in remotes.items() if r["name"] == ident), None)
+        if rid is None:
+            raise FleetError(f"no remote member {ident!r}")
+        rec = remotes.pop(rid)
+        _save_remotes(remotes)
+    log.info("[fleet] remote member removed: %s", rec["name"])
+    return {"id": rid, "name": rec["name"], "removed": ["remote"]}
+
+
+# Reachability probes are network calls — keep them OFF the status() path (it runs on
+# every 3s console poll). `refresh_remote_probes()` is sync + TTL-guarded; the fleet
+# route calls it via asyncio.to_thread before status(), so the loop never blocks.
+_PROBE_TTL = 10.0
+_probe_cache: dict[str, tuple[bool, float]] = {}
+
+
+def refresh_remote_probes(timeout: float = 1.0) -> None:
+    import httpx
+
+    now = time.monotonic()
+    for rec in list_remotes():
+        hit = _probe_cache.get(rec["id"])
+        if hit and now - hit[1] < _PROBE_TTL:
+            continue
+        try:
+            r = httpx.get(f"{rec['url']}/.well-known/agent-card.json", timeout=timeout)
+            alive = r.status_code == 200
+        except httpx.HTTPError:
+            alive = False
+        _probe_cache[rec["id"]] = (alive, now)
+
+
 def status() -> list[dict]:
-    """The host (this instance) + every workspace, with live status (running/stopped)."""
+    """The host (this instance) + every workspace + remote members, with live status
+    (running/stopped; for remotes, the last cached reachability probe)."""
     with _state_lock():
         state = _load_state()
         dirty = False
@@ -218,6 +318,11 @@ def status() -> list[dict]:
                     # focused agent can `delegate_to` an unfocused sibling here. Live only
                     # while running, but the address is stable.
                     "a2a": f"http://127.0.0.1:{port}/a2a" if port else None})
+    for rec in list_remotes():
+        alive = _probe_cache.get(rec["id"], (False, 0.0))[0]
+        out.append({"name": rec["name"], "id": rec["id"], "port": None, "pid": None,
+                    "running": alive, "bundle": "", "remote": True, "url": rec["url"],
+                    "a2a": f"{rec['url']}/a2a"})
     return out
 
 

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -29,17 +29,48 @@ def register_fleet_routes(app) -> None:
 
     @app.get("/api/fleet")
     async def _list_fleet():
-        """Every workspace agent + live status (running/stopped, port, pid, bundle). The focused
-        agent is the URL slug now (ADR 0042 slug routing) — no server-side 'active' pointer."""
+        """Every workspace agent + remote member + live status. The focused agent is the URL
+        slug now (ADR 0042 slug routing) — no server-side 'active' pointer. Remote probes are
+        TTL-cached + refreshed off the loop, so the 3s console poll stays cheap."""
+        await asyncio.to_thread(supervisor.refresh_remote_probes)
         return {"agents": supervisor.status()}
+
+    @app.post("/api/fleet/remotes")
+    async def _add_remote(req: dict):
+        """Register a remote protoAgent as a SWITCHABLE fleet member (ADR 0042 §I): it gets a
+        slug window like a local peer, with this hub reverse-proxying its console + A2A. An
+        optional bearer ``token`` is stored for the proxy to attach (never returned)."""
+        try:
+            rec = supervisor.add_remote(str((req or {}).get("name", "")),
+                                        str((req or {}).get("url", "")),
+                                        token=str((req or {}).get("token", "") or ""))
+            return {"ok": True, "agent": rec}
+        except (supervisor.FleetError, manager.WorkspaceError) as exc:
+            raise HTTPException(400, str(exc))
+
+    @app.delete("/api/fleet/remotes/{ident}")
+    async def _remove_remote(ident: str):
+        """Unregister a remote member (the remote agent itself is untouched)."""
+        try:
+            return {"ok": True, **supervisor.remove_remote(ident)}
+        except supervisor.FleetError as exc:
+            raise HTTPException(400, str(exc))
 
     @app.get("/api/fleet/discover")
     async def _discover():
-        """Discover OTHER protoAgents on the box + LAN (local port-scan + mDNS, ADR 0042 §I) —
-        candidates to add as remote delegates. Excludes agents already in this fleet (+ self)."""
+        """Discover OTHER protoAgents on the box + LAN + tailnet (ADR 0042 §I) — candidates to
+        add as remote delegates or remote fleet members. Excludes agents already in this fleet
+        (+ self + registered remotes)."""
+        from urllib.parse import urlparse
+
         from graph.fleet import discovery
         fleet = supervisor.status()
         known = {("127.0.0.1", a["port"]) for a in fleet if a.get("port")}
+        for a in fleet:  # registered remote members aren't 'discoveries' either
+            if a.get("remote") and a.get("url"):
+                u = urlparse(a["url"])
+                if u.hostname and u.port:
+                    known.add((u.hostname, u.port))
         try:  # also exclude our own mDNS self-advert (LAN ip + the host's port)
             host_port = next((a["port"] for a in fleet if a.get("host")), None)
             if host_port:
@@ -56,8 +87,13 @@ def register_fleet_routes(app) -> None:
         sessions persist + resume on a later visit). The host is this instance (always up) → no-op.
         """
         try:
-            host = next((a for a in supervisor.status() if a.get("host")), None)
+            agents = supervisor.status()
+            host = next((a for a in agents if a.get("host")), None)
             if host and name in (host["name"], host["id"]):
+                return {"ok": True, "evicted": []}
+            # A remote member can't be started/evicted from here — reachability is its
+            # own deployment's business. No-op so slug navigation stays uniform.
+            if any(a.get("remote") and name in (a["name"], a["id"]) for a in agents):
                 return {"ok": True, "evicted": []}
             if not supervisor.is_running(name):
                 await asyncio.to_thread(supervisor.start, name)  # resume from checkpoint

--- a/tests/test_fleet_proxy.py
+++ b/tests/test_fleet_proxy.py
@@ -67,32 +67,54 @@ class FakeClient:
         return self._upstream
 
 
-# --- _port_for_slug -------------------------------------------------------
+# --- _target_for_slug -------------------------------------------------------
 
 def test_host_slug_uses_active_port(monkeypatch):
     from runtime import state as state_mod
     monkeypatch.setattr(state_mod.STATE, "active_port", 7870, raising=False)
-    assert proxy._port_for_slug("host") == 7870
+    assert proxy._target_for_slug("host") == ("http://127.0.0.1:7870", {})
 
 
 def test_peer_slug_resolves_when_alive(monkeypatch):
     monkeypatch.setattr(proxy.supervisor, "_load_state",
                         lambda: {"alice": {"port": 7001, "pid": 42}})
     monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: True)
-    assert proxy._port_for_slug("alice") == 7001
+    monkeypatch.setattr(proxy.supervisor, "remote_for_slug", lambda slug: None)
+    assert proxy._target_for_slug("alice") == ("http://127.0.0.1:7001", {})
 
 
 def test_peer_slug_is_none_when_dead(monkeypatch):
     monkeypatch.setattr(proxy.supervisor, "_load_state",
                         lambda: {"alice": {"port": 7001, "pid": 42}})
     monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: False)
-    assert proxy._port_for_slug("alice") is None
+    monkeypatch.setattr(proxy.supervisor, "remote_for_slug", lambda slug: None)
+    assert proxy._target_for_slug("alice") is None
 
 
 def test_unknown_slug_is_none(monkeypatch):
     monkeypatch.setattr(proxy.supervisor, "_load_state", lambda: {})
     monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: True)
-    assert proxy._port_for_slug("ghost") is None
+    monkeypatch.setattr(proxy.supervisor, "remote_for_slug", lambda slug: None)
+    assert proxy._target_for_slug("ghost") is None
+
+
+def test_remote_slug_resolves_to_url_with_bearer(monkeypatch):
+    """A REMOTE member resolves to its registered URL; its stored bearer rides as an
+    Authorization override (the browser's header carries the HUB's token, not the remote's)."""
+    monkeypatch.setattr(proxy.supervisor, "_load_state", lambda: {})
+    monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: False)
+    monkeypatch.setattr(proxy.supervisor, "remote_for_slug",
+                        lambda slug: {"id": "ava-1a2b", "name": "ava",
+                                      "url": "http://100.101.189.45:7871", "token": "sek"})
+    assert proxy._target_for_slug("ava-1a2b") == (
+        "http://100.101.189.45:7871", {"authorization": "Bearer sek"})
+
+
+def test_remote_without_token_adds_no_header(monkeypatch):
+    monkeypatch.setattr(proxy.supervisor, "_load_state", lambda: {})
+    monkeypatch.setattr(proxy.supervisor, "remote_for_slug",
+                        lambda slug: {"id": "r1", "name": "r", "url": "http://h:1", "token": ""})
+    assert proxy._target_for_slug("r1") == ("http://h:1", {})
 
 
 def test_resolution_is_cached_within_ttl(monkeypatch):
@@ -104,8 +126,9 @@ def test_resolution_is_cached_within_ttl(monkeypatch):
 
     monkeypatch.setattr(proxy.supervisor, "_load_state", load)
     monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: True)
-    assert proxy._port_for_slug("alice") == 7001
-    assert proxy._port_for_slug("alice") == 7001
+    monkeypatch.setattr(proxy.supervisor, "remote_for_slug", lambda slug: None)
+    assert proxy._target_for_slug("alice") == ("http://127.0.0.1:7001", {})
+    assert proxy._target_for_slug("alice") == ("http://127.0.0.1:7001", {})
     assert calls["n"] == 1  # second hit served from the 1s TTL cache
 
 
@@ -113,35 +136,36 @@ def test_cache_expires_after_ttl(monkeypatch):
     monkeypatch.setattr(proxy.supervisor, "_load_state",
                         lambda: {"alice": {"port": 7001, "pid": 42}})
     monkeypatch.setattr(proxy.supervisor, "_alive", lambda pid: True)
-    assert proxy._port_for_slug("alice") == 7001
-    proxy._slug_cache["alice"] = (9999, time.monotonic() - 2.0)  # force stale
-    assert proxy._port_for_slug("alice") == 7001  # re-resolved, not the stale 9999
+    monkeypatch.setattr(proxy.supervisor, "remote_for_slug", lambda slug: None)
+    assert proxy._target_for_slug("alice") == ("http://127.0.0.1:7001", {})
+    proxy._slug_cache["alice"] = (("http://127.0.0.1:9999", {}), time.monotonic() - 2.0)  # stale
+    assert proxy._target_for_slug("alice") == ("http://127.0.0.1:7001", {})  # re-resolved
 
 
 # --- forward_to -----------------------------------------------------------
 
 async def test_forward_to_returns_409_when_not_running(monkeypatch):
-    monkeypatch.setattr(proxy, "_port_for_slug", lambda slug: None)
+    monkeypatch.setattr(proxy, "_target_for_slug", lambda slug: None)
     resp = await proxy.forward_to("ghost", FakeRequest(), "api/x")
     assert resp.status_code == 409
     assert b"is not running" in resp.body
 
 
-async def test_forward_to_delegates_to_port_when_running(monkeypatch):
-    monkeypatch.setattr(proxy, "_port_for_slug", lambda slug: 7001)
+async def test_forward_to_delegates_to_target_when_running(monkeypatch):
+    monkeypatch.setattr(proxy, "_target_for_slug", lambda slug: ("http://127.0.0.1:7001", {}))
     seen = {}
 
-    async def fake_fwd(port, request, path):
-        seen.update(port=port, path=path)
+    async def fake_fwd(base, request, path, extra=None):
+        seen.update(base=base, path=path, extra=extra)
         return "OK"
 
-    monkeypatch.setattr(proxy, "_forward_to_port", fake_fwd)
+    monkeypatch.setattr(proxy, "_forward_to_base", fake_fwd)
     out = await proxy.forward_to("alice", FakeRequest(), "api/chat")
     assert out == "OK"
-    assert seen == {"port": 7001, "path": "api/chat"}
+    assert seen == {"base": "http://127.0.0.1:7001", "path": "api/chat", "extra": {}}
 
 
-# --- _forward_to_port -----------------------------------------------------
+# --- _forward_to_base -----------------------------------------------------
 
 async def test_forward_strips_hop_headers_and_pipes_body(monkeypatch):
     up = FakeUpstream(
@@ -158,7 +182,7 @@ async def test_forward_strips_hop_headers_and_pipes_body(monkeypatch):
         query={"stream": "1"},
         body=b"{}",
     )
-    resp = await proxy._forward_to_port(7001, req, "api/chat")
+    resp = await proxy._forward_to_base("http://127.0.0.1:7001", req, "api/chat")
 
     # request: hop-by-hop headers dropped, app headers + target preserved
     assert "host" not in client.built["headers"]
@@ -180,7 +204,7 @@ async def test_forward_strips_hop_headers_and_pipes_body(monkeypatch):
 async def test_forward_returns_502_on_connect_error(monkeypatch):
     client = FakeClient(raise_exc=httpx.ConnectError("refused"))
     monkeypatch.setattr(proxy, "_get_client", lambda: client)
-    resp = await proxy._forward_to_port(7001, FakeRequest(), "api/x")
+    resp = await proxy._forward_to_base("http://127.0.0.1:7001", FakeRequest(), "api/x")
     assert resp.status_code == 502
     assert b"not reachable" in resp.body
 

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -84,3 +84,63 @@ def test_keep_n_warm_evicts_lru(tmp_path, monkeypatch):
     assert not supervisor.is_running("a")
     assert supervisor.is_running("b") and supervisor.is_running("c")
     assert supervisor.enforce_warm_cap(keep=0) == []   # 0 = unlimited, no-op
+
+
+# ── remote fleet members (ADR 0042 §I) ────────────────────────────────────────
+def test_remote_member_lifecycle(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    rec = supervisor.add_remote("ava", "http://100.101.189.45:7871/", token="sek")
+    assert rec["name"] == "ava" and rec["id"].startswith("ava-")
+    assert rec["url"] == "http://100.101.189.45:7871"  # trailing slash trimmed
+    assert "token" not in rec                           # never returned
+
+    # proxy-side lookup DOES carry the token
+    assert supervisor.remote_for_slug(rec["id"])["token"] == "sek"
+
+    with pytest.raises(supervisor.FleetError):
+        supervisor.add_remote("ava", "http://other:1")          # name taken
+    with pytest.raises(supervisor.FleetError):
+        supervisor.add_remote("ava2", "http://100.101.189.45:7871")  # url taken
+    with pytest.raises(supervisor.FleetError):
+        supervisor.add_remote("bad", "ftp://nope")              # not http(s)
+    with pytest.raises(supervisor.FleetError):
+        supervisor.add_remote("host", "http://h:1")             # reserved slug
+
+    # status(): remote rides along with the cached probe (no probe yet → stopped)
+    entry = next(a for a in supervisor.status() if a.get("remote"))
+    assert entry["name"] == "ava" and entry["running"] is False
+    assert entry["a2a"] == "http://100.101.189.45:7871/a2a" and entry["pid"] is None
+
+    supervisor._probe_cache[rec["id"]] = (True, supervisor.time.monotonic())
+    assert next(a for a in supervisor.status() if a.get("remote"))["running"] is True
+
+    out = supervisor.remove_remote("ava")  # by name (id works too)
+    assert out["removed"] == ["remote"] and supervisor.list_remotes() == []
+
+
+def test_remote_name_collides_with_workspace(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    manager.create("alpha")
+    with pytest.raises(supervisor.FleetError):
+        supervisor.add_remote("alpha", "http://h:1")
+
+
+def test_refresh_remote_probes_ttl(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    supervisor._probe_cache.clear()
+    rec = supervisor.add_remote("ava", "http://h:9")
+    calls = {"n": 0}
+
+    class FakeResp:
+        status_code = 200
+
+    def fake_get(url, timeout):
+        calls["n"] += 1
+        return FakeResp()
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", fake_get)
+    supervisor.refresh_remote_probes()
+    supervisor.refresh_remote_probes()  # within TTL — no second call
+    assert calls["n"] == 1
+    assert supervisor._probe_cache[rec["id"]][0] is True


### PR DESCRIPTION
Discovery shipped the delegate half; this is the other half the docstring promised:
a remote protoAgent (another machine over LAN/tailnet, or another local instance)
JOINS the fleet as a first-class, switchable member — it gets a slug window
(/app/agent/<id>/) with the hub reverse-proxying its console + A2A, so you run the
agent headless anywhere (--ui none) and operate it entirely from this console.
Everything per-slug (chat, theme, layout, turn-watch toasts) works unchanged —
the proxy is the only transport-aware layer.

- supervisor: remotes.json registry next to fleet.json (hub-scoped, #813) —
  add_remote (opaque #823-style id, name/url uniqueness, reserved-slug guard),
  remove_remote, remote_for_slug; status() appends remotes with a TTL-cached
  reachability probe, refreshed OFF the loop by the fleet route. An optional
  bearer token is stored for the proxy (plaintext like secrets.yaml; never
  returned by the API).
- proxy: _port_for_slug → _target_for_slug — local peers resolve to loopback
  ports, remote members to their URL, with the remote's bearer REPLACING the
  browser's Authorization (which carries the hub's token, not the remote's).
- routes: POST /api/fleet/remotes {name,url,token?}, DELETE /api/fleet/remotes/
  {ident}; activate no-ops for remotes; discover excludes registered remotes.
- console: Discover rows gain 'Add to this fleet' beside add-as-delegate; remote
  rows show a tag + URL (no start/stop/rename — only unregister); the switcher
  needs nothing, slug nav just works.

Verified live: a throwaway hub registered the RUNNING roxy (:7874) as a remote
member — probe running:true, her console API + agent card served through
/agents/roxy-77c7/*, unregister by name. 1482 py + 30 vitest + 86 e2e green.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
