### PR TITLE
docs(fleet): remote fleet members guide + ADR 0042 slice-6 shipped + changelog (#831/#837/#839)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Remote fleet members — the agent there, the UI here** (ADR 0042 §I). Register any
+  reachable protoAgent by URL (Discover → *Add to this fleet*, or
+  `POST /api/fleet/remotes`) and it becomes a switchable member: a slug window like a
+  local peer, console + A2A reverse-proxied through the hub, with the remote's bearer
+  attached server-side. Run agents fully headless on other machines and operate them
+  all from one console. (#839)
+- **Tenant guard** — when a *different* backend reuses this console's address (a port
+  handed between agents), the previous tenant's persisted chat view is dropped (one
+  reload + a toast) instead of rendering another agent's transcripts. Same-agent
+  restarts/upgrades never trip it. (#831)
 - **Tailnet discovery** — fleet discovery gains a third channel: online **Tailscale**
   peers (via the local `tailscale` CLI) are probed for agent-cards over the fleet port
   range, since mDNS multicast never crosses a WireGuard overlay. All three channels
@@ -37,6 +47,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   proxy. (#819)
 
 ### Fixed
+- **Discover no longer lists a co-located agent twice** — its mDNS advert (LAN IP) now
+  collapses with the local-scan hit (loopback), and a fleet peer's own advert no longer
+  reappears as "discovered". (#837)
 - **mDNS advertise actually works** — `Zeroconf.register_service` was called on the
   event loop and deadlocked it: a ~10s stall at every boot, then a swallowed failure,
   so **no agent had ever advertised** since the feature shipped. Now runs off-loop,

--- a/docs/adr/0042-fleet-supervisor-unified-console.md
+++ b/docs/adr/0042-fleet-supervisor-unified-console.md
@@ -210,10 +210,13 @@ rewrite.
 3. **Switcher UI** — the agent-name dropdown (list, status, switch, start/stop) over the API.
 4. **Archetypes** — `GET /api/archetypes` + the "+ New agent" picker → create-from-archetype.
 5. **Keep-alive policy** — keep-N-warm + resume, lifecycle polish.
-6. **Remote fleet members** (§I, *not yet built*) — a `remote: true` agent kind registered by
-   URL+token: status via the remote's `/api/runtime/status`, proxy-to-remote with the bearer,
-   register-only lifecycle first (remote-hub start/stop later), an "add remote agent" form, and
-   convergence with the delegate registry (ADR 0025).
+6. **Remote fleet members** (§I, **shipped — #839, register-only tier**) — a `remote: true`
+   member registered by URL (+ optional bearer, stored hub-side and attached by the proxy):
+   `remotes.json` beside `fleet.json`, status via a TTL-cached agent-card probe (refreshed off
+   the event loop), `_target_for_slug` resolves remote slugs to URLs, Discover's "Add to this
+   fleet" + `POST/DELETE /api/fleet/remotes`. Composes with the delegate registry (ADR 0025) —
+   the same remote can be a member *and* a `delegate_to` target. Remote-hub start/stop (tier b)
+   remains future work.
 
 Slices 1–3 deliver the core (switch between running agents in one console); 4 adds the
 starter-type creation flow; 5 makes it scale; 6 extends the fleet across machines.

--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -121,12 +121,43 @@ a `fleet.json` registry. Because each agent's chat history is scoped to its own
 checkpoints, a **stopped agent's session resumes** when you restart it — and a **running**
 one keeps its background work (schedules, an in-flight loop) going while you're elsewhere.
 
-## What's next — the unified console
+## The unified console — every agent in one UI
 
-*(In progress, ADR 0042 slices 2–4.)* A **hub** serves one console and reverse-proxies the
-active console's chat / A2A / SSE to the **selected** agent backend — so you switch between
-running agents **in place**: Ava keeps running while you look at Roxy, and you drop back
-into Ava's live session right where you left it. "+ New agent" runs the archetype picker.
+*(Shipped — ADR 0042 slices 2–5.)* The **hub** (any running agent) serves one console and
+reverse-proxies each agent window's chat / A2A / SSE to that agent's backend, keyed by the
+**URL slug** (`/app/agent/<id>/`) — so every window targets its own agent: switch in place
+from the topbar, or open two agents in two windows at once. Per-agent chat, theme and
+layout follow the slug; a stopped agent **resumes from its checkpoint** when you navigate
+to it; "+ New agent" runs the archetype picker. Settings → Agents is the fleet manager
+(create / start / stop / rename / remove), and **Discover** finds other protoAgents on the
+box, the LAN (mDNS) and your **tailnet** (via the Tailscale CLI).
+
+## Remote fleet members — the agent there, the UI here
+
+*(ADR 0042 §I.)* A fleet member doesn't have to be local: register any reachable protoAgent
+by URL and it becomes a **switchable member** — a slug window like any peer, with the hub
+reverse-proxying its console + A2A. The remote runs fully headless; this console is its UI.
+
+On the other machine:
+
+```bash
+A2A_AUTH_TOKEN=<secret> python -m server --port 7871 --host 0.0.0.0 --ui none
+```
+
+On this one — Settings → Agents → **Discover** → **➕ Add to this fleet**, or register
+manually (the stored token is attached by the proxy; the browser never sees it):
+
+```bash
+curl -X POST http://127.0.0.1:7871/api/fleet/remotes \
+  -H 'content-type: application/json' \
+  -d '{"name": "ava", "url": "http://100.101.189.45:7871", "token": "<secret>"}'
+```
+
+Remote members show a `remote` tag + their URL in the fleet manager; `running` is a cached
+reachability probe. You can't start/stop/rename them from here — their deployment owns
+their lifecycle; **Remove** only unregisters (the remote agent is untouched). Registering
+as a member and adding as a [`delegate_to` target](delegates.md) compose: the same agent
+can be both a window you operate and a delegate your agents call.
 
 ## See also
 


### PR DESCRIPTION
The fleet guide's 'What's next' section still described the long-shipped unified
console as future work — replaced with the real state (slug windows, discovery
channels) + a new 'Remote fleet members' section (headless-there-UI-here recipe,
token posture, lifecycle limits, composition with delegates). ADR 0042 slice 6
flips to shipped (register-only tier; remote-hub start/stop stays future).
Changelog catches up on #831/#837/#839.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
