### PR TITLE
fix(web): pin data-theme=dark so DS tokens don't drift to OS light

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,5 +1,10 @@
 <!doctype html>
-<html lang="en">
+<!-- data-theme="dark" pins the @protolabsai/design tokens to dark from first paint.
+     Without it the tokens follow @media (prefers-color-scheme), so on a light-mode
+     OS the DS components (.pl-input/.pl-btn/text) drift light while the hand-rolled
+     dark chrome stays dark. The console is dark-first; an explicit user/agent theme
+     still overrides this at runtime (agentTheme.ts / ThemePanel). -->
+<html lang="en" data-theme="dark">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/src/lib/agentTheme.ts
+++ b/apps/web/src/lib/agentTheme.ts
@@ -40,7 +40,10 @@ export function applyAgentTheme(theme: unknown, animate = true) {
       } catch {
         /* ignore */
       }
-      root().removeAttribute("data-theme"); // back to the OS/default
+      root().setAttribute("data-theme", "dark"); // the console's dark baseline — NOT the OS
+      // default. The @protolabsai/design tokens follow @media (prefers-color-scheme) when
+      // unpinned, so removing the attribute on a light-mode OS drifts DS components light
+      // while the hand-rolled chrome stays dark. Pin dark; an explicit theme still overrides.
     }
   };
 


### PR DESCRIPTION
**Bug:** the schedule modal (and any DS-component surface) renders with **light** `@protolabsai/design` tokens on a light-appearance OS — white `.pl-input`s, dark-on-dark title, washed `.pl-btn` — while the hand-rolled dark chrome stays dark.

![schedule modal: dark card, white inputs, invisible title/button]

**Root cause:** the DS tokens follow `@media (prefers-color-scheme: light)` unless the app pins `:root[data-theme="dark"]` (attribute selectors beat the media query — by design). The console:
- only sets `<meta name="color-scheme" content="dark">` (that styles native scrollbars/controls, **not** the CSS token media-query), and
- `agentTheme.ts` resets to the **OS default** via `removeAttribute("data-theme")`.

So with no explicit agent theme, a light-mode Mac drifts the DS tokens light. The hand-rolled chrome (`.confirm-card { background: var(--bg-elevated, #16161a) }`, `rgba(10,10,12,.6)` scrims) is hardcoded dark → the mismatch in the screenshot.

**Fix (the console is dark-first — all hand-rolled chrome is hardcoded dark):**
- `index.html`: `<html data-theme="dark">` — pins dark from first paint (no light flash before JS).
- `agentTheme.ts`: reset sets `data-theme="dark"` (the console baseline) instead of removing it.

An explicit user/agent theme (`applyStoredTheme` / ThemePanel) still overrides at runtime. Full light-mode support would additionally need the hand-rolled chrome tokenized — that's the `theme.css` breakup (#832), separate from this fix.

## Verify
Set macOS Appearance → Light, open the Scheduler "New schedule" modal: before, white inputs + invisible title; after, fully dark + readable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)