### PR TITLE
Revert "pin data-theme=dark" (#841) — restore light mode

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -1,10 +1,5 @@
 <!doctype html>
-<!-- data-theme="dark" pins the @protolabsai/design tokens to dark from first paint.
-     Without it the tokens follow @media (prefers-color-scheme), so on a light-mode
-     OS the DS components (.pl-input/.pl-btn/text) drift light while the hand-rolled
-     dark chrome stays dark. The console is dark-first; an explicit user/agent theme
-     still overrides this at runtime (agentTheme.ts / ThemePanel). -->
-<html lang="en" data-theme="dark">
+<html lang="en">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />

--- a/apps/web/src/lib/agentTheme.ts
+++ b/apps/web/src/lib/agentTheme.ts
@@ -40,10 +40,7 @@ export function applyAgentTheme(theme: unknown, animate = true) {
       } catch {
         /* ignore */
       }
-      root().setAttribute("data-theme", "dark"); // the console's dark baseline — NOT the OS
-      // default. The @protolabsai/design tokens follow @media (prefers-color-scheme) when
-      // unpinned, so removing the attribute on a light-mode OS drifts DS components light
-      // while the hand-rolled chrome stays dark. Pin dark; an explicit theme still overrides.
+      root().removeAttribute("data-theme"); // back to the OS/default
     }
   };
 


### PR DESCRIPTION
Reverts #841. Pinning `data-theme="dark"` was the wrong fix — the console is dual-mode (light + dark), and the pin defeats light mode globally.

The actual bug (hand-rolled chrome that doesn't flip — undefined aliases falling back to dark literals + raw hardcoded colors) is tracked in #842 and fixed there per-surface, not by pinning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)