### PR TITLE
feat(config): layer-aware settings schema — scope + source per field (ADR 0047 slice 3a)

### DIFF
--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -225,7 +225,36 @@ def _category_for(section: str) -> str:
     return _SECTION_CATEGORY.get(section, "Plugins")
 
 
-def build_schema(config, *, model_options: list[str] | None = None) -> list[dict[str, Any]]:
+def _resolve_dotted(doc: dict | None, dotted: str) -> bool:
+    """True iff ``dotted`` (e.g. ``"prompt_cache.warm.enabled"``) resolves in ``doc``."""
+    cur: Any = doc
+    if not isinstance(cur, dict):
+        return False
+    for part in dotted.split("."):
+        if not isinstance(cur, dict) or part not in cur:
+            return False
+        cur = cur[part]
+    return True
+
+
+def _source_for(key: str, agent_doc: dict | None, host_doc: dict | None) -> str:
+    """Which cascade layer the live value came from (ADR 0047): the agent leaf if it
+    sets the key, else the Host layer, else the App default. Drives the UI's
+    inherited-vs-overridden badge."""
+    if _resolve_dotted(agent_doc, key):
+        return "agent"
+    if _resolve_dotted(host_doc, key):
+        return "host"
+    return "default"
+
+
+def build_schema(
+    config,
+    *,
+    model_options: list[str] | None = None,
+    agent_doc: dict | None = None,
+    host_doc: dict | None = None,
+) -> list[dict[str, Any]]:
     """Return the settings schema grouped by section, with current values.
 
     Each group carries a ``category`` (ADR 0020) so the console can present a
@@ -247,6 +276,8 @@ def build_schema(config, *, model_options: list[str] | None = None) -> list[dict
             "restart": f.restart,
             "options": (model_options or []) if f.options_source == "models" else list(f.options),
             "default": _jsonable(getattr(defaults, f.attr, None)),
+            "scope": f.scope,  # ADR 0047: "agent" | "host"
+            "source": _source_for(f.key, agent_doc, host_doc),  # which layer set the live value
         }
         if f.type == "secret":
             entry["value"] = ""
@@ -277,6 +308,8 @@ def build_schema(config, *, model_options: list[str] | None = None) -> list[dict
             "restart": bool(spec.get("restart", False)),
             "options": list(spec.get("options", []) or []),
             "default": _jsonable(sch.defaults.get(key)),
+            "scope": "agent",  # plugin config is agent-local (ADR 0047 D6)
+            "source": "agent" if current is not None else "default",
         }
         if ftype == "secret":
             entry["value"] = ""

--- a/operator_api/config_routes.py
+++ b/operator_api/config_routes.py
@@ -144,13 +144,25 @@ def register_config_routes(app) -> None:
         """All editable settings, grouped, with current values + metadata
         (type, default, restart-vs-hot-reload, description). Drives the
         operator console's Settings surface."""
-        from graph.config_io import list_gateway_models
+        from graph.config import _load_host_layer
+        from graph.config_io import CONFIG_YAML_PATH, list_gateway_models, load_yaml_doc
         from graph.settings_schema import build_schema
 
         models: list[str] = []
         if STATE.graph_config is not None:
             models, _ = list_gateway_models(STATE.graph_config.api_base, STATE.graph_config.api_key)
-        return {"groups": build_schema(STATE.graph_config, model_options=models)}
+        # Per-layer provenance (ADR 0047): the raw agent leaf doc + the filtered Host
+        # layer let build_schema report each field's `source` (agent/host/default) so
+        # the UI can badge inherited-vs-overridden.
+        agent_doc = load_yaml_doc(CONFIG_YAML_PATH) if CONFIG_YAML_PATH.exists() else {}
+        host_doc = _load_host_layer()
+        return {
+            "groups": build_schema(
+                STATE.graph_config, model_options=models,
+                agent_doc=agent_doc if isinstance(agent_doc, dict) else {},
+                host_doc=host_doc,
+            )
+        }
 
     @app.post("/api/settings")
     async def _api_save_settings(req: SettingsUpdateRequest):

--- a/tests/test_settings_cascade.py
+++ b/tests/test_settings_cascade.py
@@ -117,3 +117,41 @@ def test_no_host_file_matches_from_dict(tmp_path):
         if f.name == "plugin_config":
             continue  # resolution is config_dir-relative; equal here but skip to be safe
         assert getattr(via_yaml, f.name) == getattr(via_dict, f.name), f.name
+
+
+def test_build_schema_reports_scope_and_source():
+    """build_schema (slice 3a) tags each field with its cascade scope + the layer
+    its live value came from — the data the UI's inherited-vs-overridden badge needs."""
+    from graph.settings_schema import build_schema
+
+    cfg = LangGraphConfig()  # App defaults
+    groups = build_schema(
+        cfg,
+        agent_doc={"goal": {"enabled": False}},      # agent leaf sets an agent-scoped key
+        host_doc={"model": {"name": "host-m"}},       # host layer sets a host-scoped key
+    )
+    by_key = {e["key"]: e for g in groups for e in g["fields"]}
+
+    # scope reflects ADR 0047 §2.1
+    assert by_key["model.name"]["scope"] == "host"
+    assert by_key["goal.enabled"]["scope"] == "agent"
+
+    # source = the layer the live value came from
+    assert by_key["model.name"]["source"] == "host"          # inherited from Host
+    assert by_key["goal.enabled"]["source"] == "agent"       # set in the agent leaf
+    assert by_key["compaction.enabled"]["source"] == "default"  # neither layer → App default
+
+
+def test_build_schema_agent_override_of_host_field_shows_as_agent_source():
+    """A host-scoped field overridden in the agent leaf reports source='agent'
+    (the UI badges it 'overridden here', not 'inherited from Host')."""
+    from graph.settings_schema import build_schema
+
+    groups = build_schema(
+        LangGraphConfig(),
+        agent_doc={"model": {"name": "agent-m"}},
+        host_doc={"model": {"name": "host-m"}},
+    )
+    by_key = {e["key"]: e for g in groups for e in g["fields"]}
+    assert by_key["model.name"]["scope"] == "host"     # home layer is still host
+    assert by_key["model.name"]["source"] == "agent"   # but the live value is the agent override


### PR DESCRIPTION
Slice 3a of ADR 0047: the **read contract** for the hybrid layered-settings UI. **Read-only + additive — no write path, no parse/merge behavior change.**

`build_schema` now tags each field with:
- **`scope`** — `agent` | `host` (from `Field.scope`)
- **`source`** — which layer the *live* value came from: `agent` (leaf sets it) → `host` → `default` (App)

`GET /api/settings/schema` computes `source` by passing the raw agent leaf doc + the filtered Host layer to `build_schema`. Plugin-config fields are `scope="agent"` (agent-local, D6).

This is exactly the data the hybrid UI's badges need (inherited-from-Host/App vs overridden-here). Tests lock it: an agent override of a host field flips `source` host→agent. 232 passed, ruff clean.

**Next:** the layer-aware *write* (save-to-host + reset-to-inherited) lands with **3b**, tested against the real UI flow; the frontend (badges + Host defaults view) is coordinated with the team (apps/web is their hot zone).

🤖 Generated with [Claude Code](https://claude.com/claude-code)