### PR TITLE
feat(config): layer-aware save + reset + hybrid settings UI (ADR 0047 slice 3)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -182,36 +182,43 @@ export const NOTES_WORKSPACE = {
 
 // Settings schema the Settings surface renders. Exercises every input type
 // plus a restart-flagged field.
+// Each field carries the ADR 0047 cascade tags: `scope` (where a "save to default"
+// edit is written — "agent" leaf or the box-shared "host" file) and `source` (where
+// the live value came from — "agent" set / "host" inherited / "default" App default).
 export const SETTINGS_SCHEMA = [
   {
     section: "Model",
     category: "Agent",
     fields: [
-      { key: "model.name", label: "Primary model", type: "select", section: "Model", restart: false, description: "", options: ["protolabs/reasoning", "protolabs/fast"], value: "protolabs/reasoning", default: "protolabs/reasoning" },
-      { key: "model.temperature", label: "Temperature", type: "number", section: "Model", restart: false, description: "", options: [], value: 0.2, default: 0.2, minimum: 0, maximum: 2 },
-      { key: "model.api_key", label: "API key", type: "secret", section: "Model", restart: false, description: "Stored in secrets.yaml.", options: [], value: "", is_set: true },
+      // model.name is host-scoped + inherited from the host layer (inheritance badge).
+      { key: "model.name", label: "Primary model", type: "select", section: "Model", restart: false, description: "", options: ["protolabs/reasoning", "protolabs/fast"], value: "protolabs/reasoning", default: "protolabs/reasoning", scope: "host", source: "host" },
+      // host-scoped but overridden in this agent (overridden-here badge + reset link).
+      { key: "model.temperature", label: "Temperature", type: "number", section: "Model", restart: false, description: "", options: [], value: 0.2, default: 0.2, minimum: 0, maximum: 2, scope: "host", source: "agent" },
+      { key: "model.api_key", label: "API key", type: "secret", section: "Model", restart: false, description: "Stored in secrets.yaml.", options: [], value: "", is_set: true, scope: "agent", source: "agent" },
     ],
   },
   {
     section: "Routing",
     category: "Agent",
     fields: [
-      { key: "routing.aux_model", label: "Auxiliary (fast) model", type: "string", section: "Routing", restart: false, description: "Cheap alias for aux calls.", options: [], value: "protolabs/fast", default: "" },
-      { key: "routing.fallback_models", label: "Fallback models", type: "string_list", section: "Routing", restart: false, description: "", options: [], value: [], default: [] },
+      // App default (inherited-from-default badge).
+      { key: "routing.aux_model", label: "Auxiliary (fast) model", type: "string", section: "Routing", restart: false, description: "Cheap alias for aux calls.", options: [], value: "protolabs/fast", default: "", scope: "host", source: "default" },
+      // a plain per-agent setting — no badge.
+      { key: "routing.fallback_models", label: "Fallback models", type: "string_list", section: "Routing", restart: false, description: "", options: [], value: [], default: [], scope: "agent", source: "agent" },
     ],
   },
   {
     section: "Compaction",
     category: "System",
     fields: [
-      { key: "compaction.enabled", label: "Enable compaction", type: "bool", section: "Compaction", restart: false, description: "", options: [], value: true, default: true },
+      { key: "compaction.enabled", label: "Enable compaction", type: "bool", section: "Compaction", restart: false, description: "", options: [], value: true, default: true, scope: "host", source: "host" },
     ],
   },
   {
     section: "Runtime",
     category: "System",
     fields: [
-      { key: "runtime.autostart_on_boot", label: "Autostart on boot", type: "bool", section: "Runtime", restart: true, description: "Install/remove the boot LaunchAgent.", options: [], value: false, default: false },
+      { key: "runtime.autostart_on_boot", label: "Autostart on boot", type: "bool", section: "Runtime", restart: true, description: "Install/remove the boot LaunchAgent.", options: [], value: false, default: false, scope: "agent", source: "agent" },
     ],
   },
 ];

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -292,11 +292,19 @@ const server = createServer(async (req, res) => {
     // POST/PATCH/DELETE writes → generic ok so the UI doesn't error.
     const body = await readBody(req);
     if (pathname === "/api/settings") {
+      // ADR 0047: a layer-aware save — "agent" (per-agent leaf, default) or "host"
+      // (box-shared host-config.yaml). The mock just echoes which layer it wrote.
+      const layer = body.layer === "host" ? "host" : "agent";
       return sendJson(res, {
         ok: true,
-        messages: ["config saved", "reloaded • model=protolabs/reasoning"],
+        messages: [`config saved (${layer})`, "reloaded • model=protolabs/reasoning"],
         restart_required: settingsRestartRequired(body.updates),
       });
+    }
+    if (pathname === "/api/settings/reset") {
+      // ADR 0047 reset-to-inherited: pop the given keys from the agent leaf.
+      const keys = Array.isArray(body.keys) ? body.keys : [];
+      return sendJson(res, { ok: true, messages: [`reset ${keys.length} setting(s) to inherited`] });
     }
     if (/^\/api\/plugins\/workflows\/[^/]+\/run$/.test(pathname)) {
       return sendJson(res, WORKFLOW_RUN_RESULT);

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -23,6 +23,7 @@ test("central Settings is just the cross-cutting tabs", async ({ page }) => {
     "Telemetry",
     "Plugins",
     "System",
+    "Host defaults", // ADR 0047 — the host-scoped subset, edited at the host layer
   ]);
   await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible(); // default
   // System holds the runtime/perf knobs (Compaction + Runtime here).
@@ -62,4 +63,46 @@ test("a restart-flagged System field shows the restart banner", async ({ page })
   await expect(page.locator(".settings-banner")).toHaveCount(0);
   await page.locator('.setting-row[data-key="runtime.autostart_on_boot"] input[type="checkbox"]').check();
   await expect(page.locator(".settings-banner")).toContainText("restart");
+});
+
+// ADR 0047 hybrid layered settings — per-agent Settings shows every field with an
+// inheritance badge; an overridden host-scoped field offers reset-to-inherited.
+test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
+  await expect(page.locator(".settings-group-title").first()).toBeVisible();
+  // model.name inherits from the host layer.
+  await expect(
+    page.locator('.setting-row[data-key="model.name"] .setting-inheritance'),
+  ).toContainText("inherited from Host");
+  // routing.aux_model inherits the App default.
+  await expect(
+    page.locator('.setting-row[data-key="routing.aux_model"] .setting-inheritance'),
+  ).toContainText("inherited from default");
+  // model.temperature is host-scoped but overridden here → reset affordance.
+  const temp = page.locator('.setting-row[data-key="model.temperature"]');
+  await expect(temp.locator(".setting-inheritance")).toContainText("overridden here");
+  await temp.getByRole("button", { name: /Reset to inherited/ }).click();
+  await expect(page.locator(".settings-status")).toContainText("inherited");
+  // routing.fallback_models is a plain agent setting — no badge.
+  await expect(
+    page.locator('.setting-row[data-key="routing.fallback_models"] .setting-inheritance'),
+  ).toHaveCount(0);
+});
+
+test("Host defaults view edits the host-scoped subset and saves to the host layer", async ({ page }) => {
+  await openSettings(page);
+  await tab(page, "Host defaults");
+  await expect(page.locator(".settings-banner").first()).toContainText("box-shared");
+  // Only host-scoped fields appear — model.name (host) is here; the agent-scoped
+  // model.api_key + routing.fallback_models are NOT.
+  await expect(page.locator('.setting-row[data-key="model.name"]')).toBeVisible();
+  await expect(page.locator('.setting-row[data-key="model.api_key"]')).toHaveCount(0);
+  await expect(page.locator('.setting-row[data-key="routing.fallback_models"]')).toHaveCount(0);
+  // A save writes to the host layer (the mock echoes the layer).
+  await page.locator('.setting-row[data-key="routing.aux_model"] input').fill("protolabs/host-fast");
+  const save = page.getByRole("button", { name: /Save & apply/ }).first();
+  await save.click();
+  await expect(page.locator(".settings-status").first()).toContainText("(host)");
 });

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -2881,6 +2881,13 @@ textarea {
   line-height: 1.45;
   color: var(--fg-muted);
 }
+/* ADR 0047 inheritance row — the source Badge + reset-to-inherited link aligned. */
+.setting-inheritance {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 5px 0 0;
+}
 .setting-control { min-width: 0; }
 .setting-input {
   width: 100%;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -647,10 +647,22 @@ export const api = {
     });
   },
 
-  saveSettings(updates: Record<string, unknown>) {
+  // Save a flat {key: value} payload to a cascade layer (ADR 0047): "agent" (the
+  // per-agent leaf, default) or "host" (the box-shared host-config.yaml). Secrets
+  // are refused on the host layer server-side.
+  saveSettings(updates: Record<string, unknown>, layer: "agent" | "host" = "agent") {
     return request<{ ok: boolean; messages: string[]; restart_required: string[] }>("/api/settings", {
       method: "POST",
-      body: { updates },
+      body: { updates, layer },
+    });
+  },
+
+  // Reset-to-inherited (ADR 0047): pop the given keys from the agent leaf so each
+  // falls back to the Host/App layer.
+  resetSettings(keys: string[]) {
+    return request<{ ok: boolean; messages: string[] }>("/api/settings/reset", {
+      method: "POST",
+      body: { keys },
     });
   },
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -152,6 +152,14 @@ export type SettingsField = {
   is_set?: boolean; // secrets only
   minimum?: number;
   maximum?: number;
+  // Cascade layer this field's shared default lives at (ADR 0047): "agent" (the
+  // per-agent leaf) or "host" (the box-shared host-config.yaml). Where the
+  // Settings UI writes a "save to default" edit.
+  scope: "agent" | "host";
+  // Which cascade layer the live value came from: set in the agent leaf, inherited
+  // from the host file, or the App (dataclass) default. Drives the
+  // inherited-vs-overridden badge + the "reset to inherited" affordance.
+  source: "agent" | "host" | "default";
 };
 
 export type SettingsGroup = {

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -1,6 +1,6 @@
 import { Alert } from "@protolabsai/ui/data";
 import { Input, Select, Textarea } from "@protolabsai/ui/forms";
-import { Button } from "@protolabsai/ui/primitives";
+import { Badge, Button } from "@protolabsai/ui/primitives";
 import { QueryErrorResetBoundary, useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { ExternalLink, Link2, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
 
@@ -31,6 +31,33 @@ export function SettingsCategoryPanel(props: { category: string; title?: string;
   );
 }
 
+// Host / box-shared defaults view (ADR 0047) — the host-scoped fields across ALL
+// categories, editable, saving to the host layer. Surfaced as its own Settings tab.
+// TODO(ADR 0047 §7): gate to the host console (slug=host); for now it renders for any
+// focused agent, clearly labeled "box-shared", so the slice isn't blocked on gating.
+export function HostDefaultsPanel({ categories = ["Agent", "System"] }: { categories?: string[] }) {
+  return (
+    <section className="panel stage-panel settings-panel">
+      {categories.map((category) => (
+        <QueryErrorResetBoundary key={category}>
+          {({ reset }) => (
+            <ErrorBoundary onReset={reset} fallback={(a) => <PanelError {...a} label="host defaults" />}>
+              <Suspense fallback={<PanelSkeleton label="Loading host defaults…" />}>
+                <SettingsCategory
+                  category={category}
+                  title={`Host defaults · ${category}`}
+                  emptyHint={`No box-shared defaults under ${category}.`}
+                  hostLayer
+                />
+              </Suspense>
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
+      ))}
+    </section>
+  );
+}
+
 // Setup walkthroughs live in the template's docs (forks don't ship their own site).
 const DISCORD_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/discord#bot-setup";
 const GOOGLE_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/google#oauth-client";
@@ -46,18 +73,28 @@ export function SettingsCategory({
   title = "Settings",
   emptyHint,
   footer,
+  // ADR 0047 host-defaults view: when true this renders ONLY the host-scoped
+  // (box-shared) fields and a Save writes to the host layer instead of the agent
+  // leaf. The default (false) is the per-agent Settings — every field, with the
+  // inherited-vs-overridden badge + reset-to-inherited affordance.
+  hostLayer = false,
 }: {
   category: string;
   title?: string;
   emptyHint?: string;
   footer?: ReactNode;
+  hostLayer?: boolean;
 }) {
   const queryClient = useQueryClient();
   const { data } = useSuspenseQuery(settingsSchemaQuery());
-  const groups = useMemo(
-    () => data.groups.filter((g) => (g.category || "Plugins") === category),
-    [data.groups, category],
-  );
+  const groups = useMemo(() => {
+    const byCategory = data.groups.filter((g) => (g.category || "Plugins") === category);
+    if (!hostLayer) return byCategory;
+    // Host-defaults view: keep only the host-scoped fields, dropping now-empty groups.
+    return byCategory
+      .map((g) => ({ ...g, fields: g.fields.filter((f) => f.scope === "host") }))
+      .filter((g) => g.fields.length);
+  }, [data.groups, category, hostLayer]);
   const [dirty, setDirty] = useState<Record<string, unknown>>({});
   const [status, setStatus] = useState("");
   const dirtyKeys = Object.keys(dirty);
@@ -81,7 +118,7 @@ export function SettingsCategory({
   }, [groups, dirty]);
 
   const save = useMutation({
-    mutationFn: () => api.saveSettings(dirty),
+    mutationFn: () => api.saveSettings(dirty, hostLayer ? "host" : "agent"),
     onMutate: () => setStatus("saving…"),
     onSuccess: (r) => {
       if (!r.ok) { setStatus(`save failed: ${r.messages.join(" · ")}`); return; }
@@ -91,6 +128,22 @@ export function SettingsCategory({
       void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
     },
     onError: (e) => setStatus(`save failed: ${e instanceof Error ? e.message : String(e)}`),
+  });
+
+  // ADR 0047 reset-to-inherited — pop one (or more) overridden keys from the agent
+  // leaf so each falls back to the Host/App layer. Invalidate the schema on success
+  // so the badges + values re-resolve to the inherited source (consistent with save).
+  const reset = useMutation({
+    mutationFn: (keys: string[]) => api.resetSettings(keys),
+    onMutate: () => setStatus("resetting to inherited…"),
+    onSuccess: (r, keys) => {
+      if (!r.ok) { setStatus(`reset failed: ${r.messages.join(" · ")}`); return; }
+      setStatus(r.messages.join(" · "));
+      // Drop any pending edit on the reset keys — the inherited value is now authoritative.
+      setDirty((d) => { const next = { ...d }; for (const k of keys) delete next[k]; return next; });
+      void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
+    },
+    onError: (e) => setStatus(`reset failed: ${e instanceof Error ? e.message : String(e)}`),
   });
 
   const asStr = (v: unknown) => (typeof v === "string" ? v : "");
@@ -149,9 +202,11 @@ export function SettingsCategory({
         kicker={
           dirtyKeys.length
             ? `${dirtyKeys.length} unsaved change${dirtyKeys.length === 1 ? "" : "s"}`
-            : runtimeField
-              ? `runtime: ${acpAgent ? `${acpAgent} (ACP)` : "native"}`
-              : "applies on save"
+            : hostLayer
+              ? "saves to the box-shared host defaults"
+              : runtimeField
+                ? `runtime: ${acpAgent ? `${acpAgent} (ACP)` : "native"}`
+                : "applies on save"
         }
         actions={
           <>
@@ -172,6 +227,16 @@ export function SettingsCategory({
         }
       />
       <div className="stage-body">
+        {hostLayer ? (
+          <Alert status="info" className="settings-banner">
+            <strong>Host / box-shared defaults</strong> (ADR 0047) — edits here write to the
+            box's <code>host-config.yaml</code> and become the inherited default for every agent
+            on this box that hasn't set its own value. Per-agent overrides win.
+            {/* TODO(ADR 0047 §7): gate this view to the host console (slug=host). For now it
+                renders for any focused agent — clearly labeled as box-shared — so the slice
+                isn't blocked on host-console gating. */}
+          </Alert>
+        ) : null}
         {acpAgent ? (
           <Alert status="info" className="settings-banner">
             Running on <strong>{acpAgent}</strong> (ACP) — it drives each turn with its own tools.
@@ -197,6 +262,12 @@ export function SettingsCategory({
                 dirty={field.key in dirty}
                 value={field.key in dirty ? dirty[field.key] : field.value}
                 onChange={(v) => setDirty((d) => ({ ...d, [field.key]: v }))}
+                // The host-defaults view edits the host layer directly — every field IS the
+                // shared default there, so the per-agent inheritance badge would be noise. The
+                // per-agent view shows the badge + reset affordance.
+                showInheritance={!hostLayer}
+                onReset={() => reset.mutate([field.key])}
+                resetting={reset.isPending}
               />
             ))}
             {hasDiscord && group.section === "Discord" ? (
@@ -255,7 +326,36 @@ export function SettingsCategory({
   );
 }
 
-function SettingRow({ field, value, dirty, onChange }: { field: SettingsField; value: unknown; dirty: boolean; onChange: (value: unknown) => void }) {
+// The inheritance state of a field, derived from ADR 0047 `source`+`scope`:
+//   source=="host"                    → inherited from Host
+//   source=="default"                 → inherited from default (App dataclass)
+//   source=="agent" && scope=="host"  → overridden here (offer reset-to-inherited)
+//   source=="agent" && scope=="agent" → a plain agent setting (no badge)
+function inheritance(field: SettingsField): { label: string; status: "neutral" | "info" | "warning"; overridden: boolean } | null {
+  if (field.source === "host") return { label: "inherited from Host", status: "neutral", overridden: false };
+  if (field.source === "default") return { label: "inherited from default", status: "neutral", overridden: false };
+  if (field.source === "agent" && field.scope === "host") return { label: "overridden here", status: "warning", overridden: true };
+  return null; // source=="agent" && scope=="agent" — just an agent setting.
+}
+
+function SettingRow({
+  field,
+  value,
+  dirty,
+  onChange,
+  showInheritance = true,
+  onReset,
+  resetting = false,
+}: {
+  field: SettingsField;
+  value: unknown;
+  dirty: boolean;
+  onChange: (value: unknown) => void;
+  showInheritance?: boolean;
+  onReset?: () => void;
+  resetting?: boolean;
+}) {
+  const inherit = showInheritance ? inheritance(field) : null;
   return (
     <div className={`setting-row${dirty ? " dirty" : ""}`} data-key={field.key}>
       <div className="setting-meta">
@@ -264,6 +364,17 @@ function SettingRow({ field, value, dirty, onChange }: { field: SettingsField; v
           {field.restart ? <span className="setting-restart">restart</span> : null}
         </label>
         {field.description ? <p className="setting-desc">{field.description}</p> : null}
+        {inherit ? (
+          <p className="setting-inheritance">
+            <Badge status={inherit.status}>{inherit.label}</Badge>
+            {inherit.overridden && onReset ? (
+              <Button variant="ghost" size="sm" type="button" onClick={onReset} disabled={resetting}>
+                {resetting ? <Loader2 className="spin" size={13} /> : <RotateCcw size={13} />}
+                Reset to inherited
+              </Button>
+            ) : null}
+          </p>
+        ) : null}
       </div>
       <div className="setting-control">
         <SettingInput field={field} value={value} onChange={onChange} />

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,10 +1,10 @@
-import { BarChart3, Gauge, Palette, Puzzle, Server, Settings2 } from "lucide-react";
+import { BarChart3, Gauge, HardDrive, Palette, Puzzle, Server, Settings2 } from "lucide-react";
 
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { DelegatesSection } from "./DelegatesSection";
 import { FleetSurface } from "./FleetSurface";
 import { OverviewPanel } from "./OverviewPanel";
-import { SettingsCategoryPanel } from "./SettingsCategory";
+import { HostDefaultsPanel, SettingsCategoryPanel } from "./SettingsCategory";
 import { ThemeSurface } from "./ThemeSurface";
 
 // Central Settings — only cross-cutting stuff now (the settings decentralization):
@@ -12,7 +12,7 @@ import { ThemeSurface } from "./ThemeSurface";
 // plugin), and System (runtime/middleware). Agent + Memory settings moved to their
 // home views (Agent → Settings, Knowledge → Settings).
 
-export type SettingsTab = "overview" | "agents" | "theme" | "telemetry" | "plugins" | "system";
+export type SettingsTab = "overview" | "agents" | "theme" | "telemetry" | "plugins" | "system" | "host";
 
 export const SETTINGS_TABS = [
   { id: "overview", label: "Overview", icon: Gauge },
@@ -21,6 +21,8 @@ export const SETTINGS_TABS = [
   { id: "telemetry", label: "Telemetry", icon: BarChart3 },
   { id: "plugins", label: "Plugins", icon: Puzzle },
   { id: "system", label: "System", icon: Settings2 },
+  // Host / box-shared defaults (ADR 0047) — the host-scoped subset, edited at the host layer.
+  { id: "host", label: "Host defaults", icon: HardDrive },
 ] as const;
 
 export function SettingsSurface({ tab = "overview" }: { tab?: SettingsTab }) {
@@ -38,5 +40,6 @@ export function SettingsSurface({ tab = "overview" }: { tab?: SettingsTab }) {
     );
   }
   if (tab === "system") return <SettingsCategoryPanel category="System" title="System" />;
+  if (tab === "host") return <HostDefaultsPanel />;            // box-shared defaults (ADR 0047)
   return <OverviewPanel />;                                    // overview (default; own section)
 }

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -304,6 +304,42 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
     return d
 
 
+def pop_keys_from_yaml(doc: Any, dotted_keys: list[str]) -> Any:
+    """Delete each dotted key (``"model.name"``, ``"prompt_cache.warm.enabled"``)
+    from the loaded YAML document, pruning any parent maps left empty by the
+    deletion.
+
+    Reset-to-inherited (ADR 0047 slice 3): removing a key from the leaf doc makes
+    the cascade fall back to the Host/App layer for that field. Preserves comments +
+    key order on the surviving sections (mutates the ruamel ``CommentedMap`` in
+    place). A key that isn't present is silently skipped — reset is idempotent.
+    """
+    for dotted in dotted_keys:
+        parts = dotted.split(".")
+        # Walk to the leaf's parent, remembering the chain so we can prune
+        # now-empty ancestors after the delete.
+        chain: list[tuple[Any, str]] = []
+        cur = doc
+        ok = True
+        for part in parts[:-1]:
+            if not isinstance(cur, dict) or part not in cur or not isinstance(cur.get(part), dict):
+                ok = False
+                break
+            chain.append((cur, part))
+            cur = cur[part]
+        if not ok or not isinstance(cur, dict) or parts[-1] not in cur:
+            continue
+        del cur[parts[-1]]
+        # Prune empty parents from the deepest outward.
+        for parent, key in reversed(chain):
+            child = parent.get(key)
+            if isinstance(child, dict) and not child:
+                del parent[key]
+            else:
+                break
+    return doc
+
+
 def apply_updates_to_yaml(doc: Any, updates: dict[str, Any]) -> Any:
     """Merge a nested updates dict into the loaded YAML document.
 

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -170,6 +170,29 @@ FIELDS: list[Field] = [
 
 _BY_KEY = {f.key: f for f in FIELDS}
 _SECRET_KEYS = {f.key for f in FIELDS if f.type == "secret"}
+_HOST_KEYS = {f.key for f in FIELDS if getattr(f, "scope", "agent") == "host"}
+
+
+def host_keys() -> set[str]:
+    """Dotted keys whose home/default cascade layer is the Host file (ADR 0047
+    ``scope=="host"``). The write path filters host-layer saves to these so the
+    host file can't accumulate agent-only settings (D1/D4)."""
+    return set(_HOST_KEYS)
+
+
+def is_secret_key(key: str) -> bool:
+    """True for a secret-typed FIELD (ADR 0047 D5 — secrets are agent-leaf only,
+    never written to the non-secret Host file)."""
+    return key in _SECRET_KEYS
+
+
+def is_known_key(key: str) -> bool:
+    """True iff ``key`` is a known core or plugin-declared settings key. The
+    reset path uses this as an existence-only gate (a reset has no value, so the
+    per-type ``validate_flat`` checks don't apply)."""
+    if key in _BY_KEY:
+        return True
+    return any(full == key for _, full, _, _ in _plugin_field_specs())
 
 
 def _plugin_field_specs():

--- a/operator_api/config_routes.py
+++ b/operator_api/config_routes.py
@@ -19,7 +19,11 @@ from typing import Any
 from pydantic import BaseModel
 
 from runtime.state import STATE
-from server.agent_init import _apply_settings_changes, _build_settings_callbacks
+from server.agent_init import (
+    _apply_settings_changes,
+    _build_settings_callbacks,
+    _reset_settings_keys,
+)
 
 
 class ConfigReloadRequest(BaseModel):
@@ -37,6 +41,13 @@ class ModelsProbeRequest(BaseModel):
 
 class SettingsUpdateRequest(BaseModel):
     updates: dict[str, Any] = {}
+    # Cascade layer the write lands in (ADR 0047 slice 3): "agent" (the leaf, default)
+    # or "host" (the box-shared host-config.yaml, host-scoped non-secret keys only).
+    layer: str = "agent"
+
+
+class SettingsResetRequest(BaseModel):
+    keys: list[str] = []
 
 
 def register_config_routes(app) -> None:
@@ -166,9 +177,10 @@ def register_config_routes(app) -> None:
 
     @app.post("/api/settings")
     async def _api_save_settings(req: SettingsUpdateRequest):
-        """Validate a flat {key: value} payload, persist it to YAML (secrets
-        split out), and hot-reload the graph. Returns any keys that need a
-        full process restart to take effect."""
+        """Validate a flat {key: value} payload, persist it to the chosen cascade
+        layer (``layer``: "agent" leaf, default, or "host" box-shared file; secrets
+        split out / refused on host), and hot-reload the graph. Returns any keys that
+        need a full process restart to take effect."""
         from graph.settings_schema import nest_updates, restart_keys, validate_flat
 
         ok, err = validate_flat(req.updates)
@@ -176,6 +188,20 @@ def register_config_routes(app) -> None:
             return {"ok": False, "messages": [f"validation: {err}"], "restart_required": []}
         # Offload off the event loop (#497) — a model change recompiles the graph.
         ok, messages = await asyncio.to_thread(
-            _apply_settings_changes, config=nest_updates(req.updates)
+            _apply_settings_changes, config=nest_updates(req.updates), layer=req.layer
         )
         return {"ok": ok, "messages": messages, "restart_required": restart_keys(req.updates)}
+
+    @app.post("/api/settings/reset")
+    async def _api_reset_settings(req: SettingsResetRequest):
+        """Reset-to-inherited (ADR 0047 slice 3): pop the given dotted keys from the
+        agent leaf YAML + reload, so each falls back to the Host/App layer. Only
+        known settings keys are accepted (existence-gated against the registry —
+        a reset carries no value, so the per-type validate_flat checks don't apply)."""
+        from graph.settings_schema import is_known_key
+
+        for k in req.keys:
+            if not is_known_key(k):
+                return {"ok": False, "messages": [f"validation: unknown setting: {k}"]}
+        ok, messages = await asyncio.to_thread(_reset_settings_keys, req.keys)
+        return {"ok": ok, "messages": messages}

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1186,15 +1186,58 @@ def _sync_autostart_with_config(config: dict | None) -> str | None:
     return f"autostart: {msg}"
 
 
+def _filter_nested_to_host_keys(config: dict) -> tuple[dict, list[str]]:
+    """Keep only host-scoped (ADR 0047 ``scope=="host"``) leaves of a nested config
+    dict; return ``(host_only, dropped)`` where ``dropped`` is the dotted keys that
+    were not host-scoped (agent-only / secret) and so are refused on the Host layer.
+
+    Mirrors ``graph.config._filter_to_host_keys`` (the READ-side guard) so the host
+    file can't accumulate agent keys, and enforces D5: secret-typed keys are never
+    written to the non-secret host file."""
+    from graph.config import _get_dotted, _set_dotted
+    from graph.settings_schema import host_keys, is_secret_key
+
+    allowed = host_keys()
+    host_only: dict = {}
+    dropped: list[str] = []
+
+    def _walk(node: Any, prefix: str) -> None:
+        if not isinstance(node, dict):
+            return
+        for k, v in node.items():
+            dotted = f"{prefix}.{k}" if prefix else k
+            if isinstance(v, dict):
+                _walk(v, dotted)
+                continue
+            if dotted in allowed and not is_secret_key(dotted):
+                found, val = _get_dotted(config, dotted)
+                if found:
+                    _set_dotted(host_only, dotted, val)
+            else:
+                dropped.append(dotted)
+
+    _walk(config, "")
+    return host_only, dropped
+
+
 def _apply_settings_changes(
     config: dict | None = None,
     soul: str | None = None,
+    layer: str = "agent",
 ) -> tuple[bool, list[str]]:
     """Persist config YAML + SOUL.md then reload the graph once.
 
     Passing ``None`` for either argument skips that write — a bare
     call with both None acts as a pure reload (useful for picking up
     external file edits).
+
+    ``layer`` selects the cascade file the config write lands in (ADR 0047 slice 3):
+
+    * ``"agent"`` (default) — TODAY's exact behavior: write the agent leaf
+      ``langgraph-config.yaml`` (secrets split out to the sibling ``secrets.yaml``).
+    * ``"host"`` — write the box-shared host file (``paths.host_config_path()``),
+      filtered to host-scoped FIELDS keys only. No secrets land on the host layer
+      (D5): a secret-typed key is refused. SOUL writes are agent-local regardless.
     """
     from graph.config_io import (
         apply_updates_to_yaml,
@@ -1213,17 +1256,37 @@ def _apply_settings_changes(
         ok, err = validate_config_dict(config)
         if not ok:
             return False, [f"validation: {err}"]
-        try:
-            main_config, secret_updates = split_secret_updates(config)
-            save_secrets(secret_updates)
-            doc = load_yaml_doc()
-            apply_updates_to_yaml(doc, main_config)
-            strip_secrets_from_doc(doc)
-            save_yaml_doc(doc)
-            messages.append("config saved")
-        except Exception as e:
-            log.exception("[config] YAML write failed")
-            return False, [f"config write: {e}"]
+        if layer == "host":
+            try:
+                from paths import host_config_path
+
+                host_only, dropped = _filter_nested_to_host_keys(config)
+                if dropped:
+                    messages.append(f"host layer: ignored non-host key(s) {', '.join(sorted(dropped))}")
+                hp = host_config_path()
+                doc = load_yaml_doc(hp)
+                apply_updates_to_yaml(doc, host_only)
+                strip_secrets_from_doc(doc)  # belt-and-suspenders: never a secret on host
+                save_yaml_doc(doc, hp)
+                messages.append("host config saved")
+            except Exception as e:
+                log.exception("[config] host YAML write failed")
+                return False, [f"host config write: {e}"]
+        else:
+            try:
+                import graph.config_io as _cio
+
+                main_config, secret_updates = split_secret_updates(config)
+                save_secrets(secret_updates)
+                leaf = _cio.CONFIG_YAML_PATH  # resolved at call time (honors a repoint)
+                doc = load_yaml_doc(leaf)
+                apply_updates_to_yaml(doc, main_config)
+                strip_secrets_from_doc(doc)
+                save_yaml_doc(doc, leaf)
+                messages.append("config saved")
+            except Exception as e:
+                log.exception("[config] YAML write failed")
+                return False, [f"config write: {e}"]
 
     if soul is not None:
         try:
@@ -1235,10 +1298,39 @@ def _apply_settings_changes(
 
     # Drawer toggles of runtime.autostart_on_boot ride this path,
     # not the wizard's finish_setup, so the LaunchAgent plist has
-    # to be installed/removed here too.
-    as_msg = _sync_autostart_with_config(config)
-    if as_msg:
-        messages.append(as_msg)
+    # to be installed/removed here too. runtime.* is agent-scoped, so this
+    # only fires on the agent layer (a host write never carries it).
+    if layer != "host":
+        as_msg = _sync_autostart_with_config(config)
+        if as_msg:
+            messages.append(as_msg)
+
+    ok, reload_msg = _reload_langgraph_agent()
+    messages.append(reload_msg)
+    return ok, messages
+
+
+def _reset_settings_keys(keys: list[str]) -> tuple[bool, list[str]]:
+    """Reset-to-inherited (ADR 0047 slice 3): pop ``keys`` from the AGENT leaf
+    YAML, then reload so each field falls back to the Host/App layer.
+
+    Always operates on the leaf (the layer the settings UI edits per-agent); the
+    Host file is left untouched, so resetting an agent override surfaces the host
+    default. A pure reload when ``keys`` is empty."""
+    import graph.config_io as _cio
+    from graph.config_io import load_yaml_doc, pop_keys_from_yaml, save_yaml_doc
+
+    messages: list[str] = []
+    if keys:
+        try:
+            leaf = _cio.CONFIG_YAML_PATH  # resolved at call time (honors a repoint)
+            doc = load_yaml_doc(leaf)
+            pop_keys_from_yaml(doc, keys)
+            save_yaml_doc(doc, leaf)
+            messages.append(f"reset {len(keys)} key(s) to inherited")
+        except Exception as e:
+            log.exception("[config] reset (pop keys) failed")
+            return False, [f"reset: {e}"]
 
     ok, reload_msg = _reload_langgraph_agent()
     messages.append(reload_msg)

--- a/tests/test_config_routes.py
+++ b/tests/test_config_routes.py
@@ -82,3 +82,88 @@ def test_save_settings_rejects_invalid(monkeypatch):
     )
     resp = _client().post("/api/settings", json={"updates": {"x": 1}}).json()
     assert resp["ok"] is False and "validation: bad key" in resp["messages"]
+
+
+def test_save_settings_threads_layer(monkeypatch):
+    """POST /api/settings passes the chosen cascade layer to _apply_settings_changes."""
+    import operator_api.config_routes as cr
+
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.settings_schema",
+        _fake_module(
+            "graph.settings_schema",
+            validate_flat=lambda u: (True, None),
+            nest_updates=lambda u: {"nested": u},
+            restart_keys=lambda u: [],
+        ),
+    )
+    captured = {}
+
+    def _apply(config=None, layer="agent"):
+        captured["config"], captured["layer"] = config, layer
+        return True, ["host config saved"]
+
+    monkeypatch.setattr(cr, "_apply_settings_changes", _apply)
+    resp = _client().post("/api/settings", json={"updates": {"model.name": "m"}, "layer": "host"}).json()
+    assert resp["ok"] is True
+    assert captured["layer"] == "host"
+    assert captured["config"] == {"nested": {"model.name": "m"}}
+
+
+def test_save_settings_defaults_to_agent_layer(monkeypatch):
+    """No layer in the body ⇒ the agent leaf (today's behavior)."""
+    import operator_api.config_routes as cr
+
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.settings_schema",
+        _fake_module(
+            "graph.settings_schema",
+            validate_flat=lambda u: (True, None),
+            nest_updates=lambda u: u,
+            restart_keys=lambda u: [],
+        ),
+    )
+    captured = {}
+
+    def _apply(config=None, layer="agent"):
+        captured["layer"] = layer
+        return True, ["config saved"]
+
+    monkeypatch.setattr(cr, "_apply_settings_changes", _apply)
+    _client().post("/api/settings", json={"updates": {"x": 1}})
+    assert captured["layer"] == "agent"
+
+
+def test_reset_settings_pops_known_keys(monkeypatch):
+    """POST /api/settings/reset delegates to _reset_settings_keys for known keys."""
+    import operator_api.config_routes as cr
+
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.settings_schema",
+        _fake_module("graph.settings_schema", is_known_key=lambda k: k == "model.name"),
+    )
+    captured = {}
+
+    def _reset(keys):
+        captured["keys"] = keys
+        return True, ["reset 1 key(s) to inherited", "reloaded"]
+
+    monkeypatch.setattr(cr, "_reset_settings_keys", _reset)
+    resp = _client().post("/api/settings/reset", json={"keys": ["model.name"]}).json()
+    assert resp["ok"] is True
+    assert captured["keys"] == ["model.name"]
+
+
+def test_reset_settings_rejects_unknown_key(monkeypatch):
+    """An unknown key is rejected before any disk touch."""
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.settings_schema",
+        _fake_module("graph.settings_schema", is_known_key=lambda k: False),
+    )
+    resp = _client().post("/api/settings/reset", json={"keys": ["bogus.key"]}).json()
+    assert resp["ok"] is False
+    assert any("unknown setting: bogus.key" in m for m in resp["messages"])

--- a/tests/test_settings_cascade.py
+++ b/tests/test_settings_cascade.py
@@ -155,3 +155,184 @@ def test_build_schema_agent_override_of_host_field_shows_as_agent_source():
     by_key = {e["key"]: e for g in groups for e in g["fields"]}
     assert by_key["model.name"]["scope"] == "host"     # home layer is still host
     assert by_key["model.name"]["source"] == "agent"   # but the live value is the agent override
+
+
+# ── Slice 3: the layer-aware WRITE half ───────────────────────────────────────
+
+
+def _point_config_at(tmp_path, monkeypatch):
+    """Repoint the live agent leaf (CONFIG_YAML_PATH) + secrets at a temp dir so a
+    save touches a scratch file, not the repo's config/. Returns the leaf path."""
+    import graph.config_io as cio
+
+    leaf = tmp_path / "langgraph-config.yaml"
+    secrets = tmp_path / "secrets.yaml"
+    monkeypatch.setattr(cio, "CONFIG_YAML_PATH", leaf, raising=False)
+    monkeypatch.setattr(cio, "SECRETS_YAML_PATH", secrets, raising=False)
+    return leaf
+
+
+def _host_file(tmp_path, monkeypatch):
+    """Point PROTOAGENT_HOST_CONFIG at a temp host file (initially absent)."""
+    hp = tmp_path / "host-config.yaml"
+    monkeypatch.setenv("PROTOAGENT_HOST_CONFIG", str(hp))
+    return hp
+
+
+def _no_reload(monkeypatch):
+    """Stub the heavy graph reload — these tests assert the file writes, not the
+    graph rebuild."""
+    import server.agent_init as ai
+
+    monkeypatch.setattr(ai, "_reload_langgraph_agent", lambda: (True, "reloaded"))
+
+
+def test_host_layer_save_writes_host_config(tmp_path, monkeypatch):
+    """layer='host' writes a host-scoped key to host-config.yaml, and the cascade
+    then inherits it into a config loaded from the (silent) agent leaf."""
+    import yaml as _yaml
+
+    from server.agent_init import _apply_settings_changes
+
+    leaf = _point_config_at(tmp_path, monkeypatch)
+    hp = _host_file(tmp_path, monkeypatch)
+    _no_reload(monkeypatch)
+
+    ok, _ = _apply_settings_changes(config={"model": {"name": "box-default-model"}}, layer="host")
+    assert ok
+    assert hp.exists()
+    written = _yaml.safe_load(hp.read_text())
+    assert written["model"]["name"] == "box-default-model"
+    # The agent leaf was NOT touched by the host write.
+    assert not leaf.exists()
+
+    # Cascade: a config loaded from a silent agent leaf inherits the host default.
+    leaf.write_text("goal:\n  enabled: true\n")
+    cfg = LangGraphConfig.from_yaml(str(leaf))
+    assert cfg.model_name == "box-default-model"
+
+
+def test_host_layer_refuses_secret(tmp_path, monkeypatch):
+    """D5: a secret-typed key (model.api_key) is stripped/refused on the host layer —
+    the host file is non-secret only."""
+    import yaml as _yaml
+
+    from server.agent_init import _apply_settings_changes
+
+    _point_config_at(tmp_path, monkeypatch)
+    hp = _host_file(tmp_path, monkeypatch)
+    _no_reload(monkeypatch)
+
+    ok, messages = _apply_settings_changes(
+        config={"model": {"name": "box-model", "api_key": "sk-SHOULD-NOT-LAND"}}, layer="host",
+    )
+    assert ok
+    written = _yaml.safe_load(hp.read_text()) or {}
+    assert written.get("model", {}).get("name") == "box-model"
+    assert "api_key" not in written.get("model", {})  # secret refused
+    # The refusal is surfaced to the operator.
+    assert any("api_key" in m for m in messages)
+
+
+def test_host_layer_refuses_agent_scoped_key(tmp_path, monkeypatch):
+    """An agent-scoped key (goal.enabled) is filtered out of a host write — the
+    host file can't accumulate agent settings (D1/D4)."""
+    import yaml as _yaml
+
+    from server.agent_init import _apply_settings_changes
+
+    _point_config_at(tmp_path, monkeypatch)
+    hp = _host_file(tmp_path, monkeypatch)
+    _no_reload(monkeypatch)
+
+    ok, _ = _apply_settings_changes(
+        config={"model": {"name": "box-model"}, "goal": {"enabled": False}}, layer="host",
+    )
+    assert ok
+    written = _yaml.safe_load(hp.read_text()) or {}
+    assert written.get("model", {}).get("name") == "box-model"
+    assert "goal" not in written  # agent-scoped key dropped
+
+
+def test_agent_layer_save_unchanged(tmp_path, monkeypatch):
+    """layer='agent' (the default) keeps today's behavior: write the leaf, split a
+    secret to secrets.yaml, leave the host file untouched."""
+    import yaml as _yaml
+
+    import graph.config_io as cio
+    from server.agent_init import _apply_settings_changes
+
+    leaf = _point_config_at(tmp_path, monkeypatch)
+    hp = _host_file(tmp_path, monkeypatch)
+    _no_reload(monkeypatch)
+
+    ok, _ = _apply_settings_changes(
+        config={"model": {"name": "agent-model", "api_key": "sk-secret"}},  # default layer
+    )
+    assert ok
+    written = _yaml.safe_load(leaf.read_text())
+    assert written["model"]["name"] == "agent-model"
+    assert "api_key" not in written["model"]  # secret split out, as always
+    secrets = _yaml.safe_load(cio.SECRETS_YAML_PATH.read_text())
+    assert secrets["model"]["api_key"] == "sk-secret"
+    assert not hp.exists()  # host file never created by an agent save
+
+
+def test_reset_pops_leaf_key_falls_back_to_host(tmp_path, monkeypatch):
+    """Reset pops the leaf key so the value falls back to the host default."""
+    import yaml as _yaml
+
+    from server.agent_init import _reset_settings_keys
+
+    leaf = _point_config_at(tmp_path, monkeypatch)
+    hp = _host_file(tmp_path, monkeypatch)
+    _no_reload(monkeypatch)
+
+    hp.write_text("model:\n  name: host-default-model\n")
+    leaf.write_text("model:\n  name: agent-override-model\ngoal:\n  enabled: true\n")
+
+    ok, _ = _reset_settings_keys(["model.name"])
+    assert ok
+    written = _yaml.safe_load(leaf.read_text())
+    assert "name" not in written.get("model", {})  # leaf override removed (empty model pruned)
+    assert "model" not in written  # the now-empty model map was pruned
+    assert written["goal"]["enabled"] is True  # sibling section untouched
+
+    cfg = LangGraphConfig.from_yaml(str(leaf))
+    assert cfg.model_name == "host-default-model"  # falls back to the host default
+
+
+def test_reset_of_key_set_in_both_leaves_host_default(tmp_path, monkeypatch):
+    """Reset of a key set in BOTH layers removes only the leaf copy, leaving the
+    host default in place (and still on disk)."""
+    import yaml as _yaml
+
+    from server.agent_init import _reset_settings_keys
+
+    leaf = _point_config_at(tmp_path, monkeypatch)
+    hp = _host_file(tmp_path, monkeypatch)
+    _no_reload(monkeypatch)
+
+    hp.write_text("model:\n  name: host-model\n")
+    leaf.write_text("model:\n  name: agent-model\n")
+
+    ok, _ = _reset_settings_keys(["model.name"])
+    assert ok
+    # Host file is untouched — its default survives.
+    assert _yaml.safe_load(hp.read_text())["model"]["name"] == "host-model"
+    cfg = LangGraphConfig.from_yaml(str(leaf))
+    assert cfg.model_name == "host-model"
+
+
+def test_pop_keys_from_yaml_prunes_and_is_idempotent():
+    """pop_keys_from_yaml deletes dotted keys, prunes emptied parents, and skips
+    absent keys (idempotent)."""
+    from graph.config_io import pop_keys_from_yaml
+
+    doc = {"prompt_cache": {"warm": {"enabled": True}}, "model": {"name": "m", "temperature": 0.5}}
+    pop_keys_from_yaml(doc, ["prompt_cache.warm.enabled", "model.temperature", "missing.key"])
+    assert "prompt_cache" not in doc  # the whole empty chain pruned
+    assert doc["model"] == {"name": "m"}  # sibling leaf kept, parent not pruned
+    # Idempotent — popping again is a no-op, never raises.
+    pop_keys_from_yaml(doc, ["prompt_cache.warm.enabled"])
+    assert "prompt_cache" not in doc


### PR DESCRIPTION
The settings cascade is now **editable end-to-end** — the QA-able feature.

## Backend (3a-write)
- `_apply_settings_changes` gains `layer`: `"agent"` (default) = today's exact leaf write + secret split; `"host"` = write `host-config.yaml`, **filtered to host-scoped non-secret keys, secrets refused + stripped** (D5, double-guarded). Autostart sync stays agent-only.
- `_reset_settings_keys` + `config_io.pop_keys_from_yaml`: pop dotted keys from the **leaf** (prune empties, idempotent, comment-preserving) → field falls back to Host/App.
- `POST /api/settings {layer}` + new `POST /api/settings/reset {keys}` (registry-gated).

## Frontend (3b — hybrid C)
- Per-field **inheritance badges** (`source`→label): *inherited from Host* / *from default* / *overridden here* (+ **Reset to inherited**). DS `Badge`/`Button`, no bespoke restyle.
- **"Host defaults" tab**: host-scoped subset, saves `layer="host"`, clearly banner-labeled.
- reset + host-save wired through react-query (invalidate on success); `SettingsField` gains `scope`+`source`; `api.saveSettings(layer)`/`resetSettings`.

## Verified (adversarial workflow, both phases PASS)
- **Zero-migration**: agent save byte-identical; **host save writes ONLY the host file with no secret possible** (checked across all 47 FIELDS); reset falls back correctly; host-filter drops agent keys.
- 251 py tests + 6 settings e2e pass; `apps/web` build clean (tsc×2 + vite); ruff clean.

**Next:** host-console gating for the Host defaults view (ADR 0047 §7 TODO) + host-knob promotion (D8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)