### PR TITLE
chore: release v0.32.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.32.0] - 2026-06-10
+
 ### Added
 - **Layered settings cascade — host-shared defaults agents inherit and override**
   (ADR 0047). Settings now resolve **App → Host → Agent** per field. A new **Host

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.31.0"
+version = "0.32.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,28 @@
 [
   {
+    "version": "v0.32.0",
+    "date": "2026-06-10",
+    "changes": [
+      "Layered settings cascade — host-shared defaults agents inherit and override",
+      "Remote fleet members — the agent there, the UI here",
+      "Tenant guard",
+      "Tailnet discovery",
+      "Co-located-instance warning",
+      "Cross-agent \"turn finished\" toasts",
+      "Opaque agent ids + rename",
+      "Enable delegates without a restart",
+      "Cold agents resume on navigation",
+      "Discover no longer lists a co-located agent twice",
+      "mDNS advertise actually works",
+      "A2A task reconcile had rotted against a2a-sdk 1.1",
+      "Each fleet hub owns its own registry",
+      "pyproject.toml is the dependency source of truth",
+      "Config is a single source of truth",
+      "Shell + settings banners are the design system's Alert",
+      "Retired the deprecated peer_consult / peer_list tools"
+    ]
+  },
+  {
     "version": "v0.31.0",
     "date": "2026-06-10",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.32.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.32.0 -m 'Release v0.32.0' && git push origin v0.32.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).