### PR TITLE
fix(release): pass release notes via env, not ${{ }} interpolation (shell injection)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -134,12 +134,20 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub release
+        # NOTES must come through `env`, NOT be interpolated into the run-script via
+        # ${{ }} — GitHub substitutes ${{ }} into the script SOURCE, so a backtick or
+        # $() in the changelog/commit notes is command-substituted by bash (v0.32.0
+        # failed exactly this way: a reverted `data-theme=dark` line ran `stat …`).
+        # As an env value, "$NOTES" expands without re-parsing for substitutions, and
+        # --notes-file avoids even argv quoting issues.
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NOTES: ${{ steps.notes.outputs.notes }}
         run: |
+          printf '%s' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
-            --notes "${{ steps.notes.outputs.notes }}"
+            --notes-file "$RUNNER_TEMP/release-notes.md"
 
       # ── Discord ───────────────────────────────────────────────────────────────
       # Shared fleet tooling: rewrites the commit range into themed notes via


### PR DESCRIPTION
## What
`release.yml`'s *Create GitHub release* step interpolated the notes straight into the `run:` script — `--notes "${{ steps.notes.outputs.notes }}"`. GitHub substitutes `${{ }}` into the **script source**, so a backtick or `$()` in the changelog/commit notes is command-substituted by bash.

## Impact (real — just happened)
**v0.32.0's release failed** on this: a reverted ``data-theme=dark`` line ran `stat data-theme=dark …` → exit 1. The GHCR image had already built+pushed and the tag exists; only the GitHub release didn't get created (I created it manually via `--notes-file`). The Discord announce step (after it) was skipped.

## Fix
Pass `NOTES` through `env` (env values expand via `"$NOTES"` without re-parsing for substitutions) and write to a file for `--notes-file`. Standard GitHub-Actions script-injection hardening — future releases won't break on backticks/`$()` in notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)