### PR TITLE
fix(plugins): enabling a view plugin works live — no restart, real errors (P0)

### DIFF
--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -376,8 +376,9 @@ const server = createServer(async (req, res) => {
       if (m) {
         return sendJson(res, {
           ok: true, enabled: !!body.enabled, reloaded: true,
-          // a view plugin (boardy) recommends a restart; others don't
-          restart_recommended: !!body.enabled && m[1] === "boardy",
+          // Enable hot-mounts the view router live (#822) → no restart. Only DISABLE of a
+          // view plugin (boardy) leaves a stale route → restart recommended.
+          restart_recommended: !body.enabled && m[1] === "boardy",
         });
       }
     }

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -86,6 +86,21 @@ test("a COLLAPSED right panel still lights its plugin's dot (collapsed ≠ visib
   await expect(scratch.locator(".pl-rail__dot")).toBeVisible();
 });
 
+test("a 404-ing plugin view shows an actionable error, not a blank panel", async ({ page }) => {
+  // P0 regression: a same-origin 404 fires the iframe's onLoad (not onError), so trusting
+  // onLoad rendered the server's bare {"detail":"Not Found"} as the "view" (the blank
+  // "no details" panel). The host now status-PROBES the route and surfaces a real error.
+  await page.route("**/plugins/boardy/stats", (route) =>
+    route.fulfill({ status: 404, contentType: "application/json", body: '{"detail":"Not Found"}' }),
+  );
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-rail").getByRole("button", { name: "Stats", exact: true }).click();
+
+  // No iframe is mounted for an unreachable route; an actionable alert is shown instead.
+  await expect(page.locator(".plugin-view [role=alert]")).toContainText("Couldn’t load");
+  await expect(page.locator(".plugin-view-frame")).toHaveCount(0);
+});
+
 test("a plugin view with placement:right becomes a right-sidebar panel", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -281,7 +281,17 @@ export function App() {
   // "right" (a right-sidebar panel, alongside Notes/Beads/Goals/Schedule — ADR 0026).
   const allDeclaredViews = (runtime?.plugins ?? [])
     .filter((p) => p.enabled && p.views?.length)
-    .flatMap((p) => (p.views ?? []).map((v) => ({ ...v, key: `plugin:${p.id}:${v.id}` })));
+    .flatMap((p) =>
+      (p.views ?? []).map((v) => ({
+        ...v,
+        key: `plugin:${p.id}:${v.id}`,
+        // Carry the owning plugin's load state so PluginView can phrase a real error
+        // (enabled-but-not-loaded ⇒ missing env / bad deps / mount race; `error` is the
+        // loader's exact diagnostic) instead of a blank "no details" panel.
+        pluginLoaded: p.loaded,
+        pluginError: p.error,
+      })),
+    );
   // A view claiming the chat SLOT (ADR 0045) replaces the built-in chat panel — it
   // renders under the core "chat" rail id, so it's excluded from the dynamic rail
   // list below. First enabled claimant wins (deterministic: plugin load order).

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -39,14 +39,69 @@ export function PluginView({ view }: { view: PluginViewType }) {
   }, [tabs, activeTab, view.path]);
 
   const [loaded, setLoaded] = useState(false);
-  const [failed, setFailed] = useState(false);
+  // null = no error; a string = an actionable failure message to show in the panel.
+  const [error, setError] = useState<string | null>(null);
+  // Probed and reachable (HTTP ok) — only then do we mount the iframe. Until the probe
+  // resolves we show the loading state; this keeps a 404 from ever rendering the server's
+  // bare {"detail":"Not Found"} body as the "view".
+  const [reachable, setReachable] = useState(false);
   const frameRef = useRef<HTMLIFrameElement | null>(null);
   const pluginId = useMemo(() => pluginIdFromPath(view.path), [view.path]);
-  // Reset load state when the loaded page changes (tab switch).
+
+  // Probe the view URL before mounting the iframe. A same-origin HTTP error (a 404 from an
+  // unmounted /api/plugins/<id>/<view>, FastAPI's {"detail":"Not Found"}) fires the iframe's
+  // onLoad — NOT onError — so trusting onLoad would render the raw 404 as a blank panel. We
+  // must read res.status. On !ok we phrase the cause from the owning plugin's load state:
+  //   • plugin reported an error (missing env / deps not installed) → surface it verbatim
+  //   • enabled but not loaded → the view route isn't serving yet (mount race / restart)
+  //   • otherwise → the HTTP status. One retry covers a sub-second race with a hot-mount reload.
   useEffect(() => {
+    let cancelled = false;
     setLoaded(false);
-    setFailed(false);
-  }, [src]);
+    setError(null);
+    setReachable(false);
+
+    function describeFailure(status: number | null): string {
+      if (view.pluginError) return view.pluginError;
+      if (view.pluginLoaded === false)
+        return `The plugin view at ${src} isn’t mounted yet. If you just enabled it, give it a moment — or restart the server to finish enabling.`;
+      if (status != null) return `The plugin page at ${src} returned HTTP ${status}.`;
+      return `The plugin page at ${src} didn’t respond.`;
+    }
+
+    async function probe(attempt: number): Promise<void> {
+      try {
+        const res = await fetch(apiUrl(src), {
+          headers: { ...(authToken() ? { Authorization: `Bearer ${authToken()}` } : {}) },
+        });
+        if (cancelled) return;
+        if (res.ok) {
+          setReachable(true);
+          return;
+        }
+        // Retry once on a server-side miss — covers the brief window where the rail
+        // renders the view before the hot-mount include_router commits (#822 reload race).
+        if (attempt === 0 && (res.status === 404 || res.status >= 500)) {
+          setTimeout(() => void probe(1), 600);
+          return;
+        }
+        setError(describeFailure(res.status));
+      } catch {
+        if (cancelled) return;
+        // True network/CORS failure (connection refused, blocked) — no status to read.
+        if (attempt === 0) {
+          setTimeout(() => void probe(1), 600);
+          return;
+        }
+        setError(describeFailure(null));
+      }
+    }
+
+    void probe(0);
+    return () => {
+      cancelled = true;
+    };
+  }, [src, view.pluginLoaded, view.pluginError]);
 
   // Event-bus relay across the sandbox (ADR 0039). The page subscribes via
   // `protoagent:subscribe {patterns}`; the host forwards matching bus events in
@@ -133,10 +188,10 @@ export function PluginView({ view }: { view: PluginViewType }) {
       )}
       <section className="panel stage-panel plugin-view">
       <div className="plugin-view-body">
-        {failed ? (
+        {error ? (
           <div className="plugin-view-state" role="alert">
             <AlertTriangle size={18} />
-            <span>Couldn’t load “{view.label}”. The plugin page at <code>{src}</code> didn’t respond.</span>
+            <span>Couldn’t load “{view.label}”. {error}</span>
           </div>
         ) : (
           <>
@@ -146,16 +201,21 @@ export function PluginView({ view }: { view: PluginViewType }) {
                 <span>Loading {view.label}…</span>
               </div>
             ) : null}
-            <iframe
-              ref={frameRef}
-              className="plugin-view-frame"
-              src={apiUrl(src)}
-              title={view.label}
-              sandbox="allow-scripts allow-forms allow-same-origin"
-              onLoad={handleLoad}
-              onError={() => setFailed(true)}
-              style={{ visibility: loaded ? "visible" : "hidden" }}
-            />
+            {/* Mount the iframe ONLY after the status probe confirms the route serves —
+                a 404 fires onLoad (not onError), so an unprobed iframe would render the
+                server's raw 404 body as a blank "view". */}
+            {reachable ? (
+              <iframe
+                ref={frameRef}
+                className="plugin-view-frame"
+                src={apiUrl(src)}
+                title={view.label}
+                sandbox="allow-scripts allow-forms allow-same-origin"
+                onLoad={handleLoad}
+                onError={() => setError(`The plugin page at ${src} didn’t respond.`)}
+                style={{ visibility: loaded ? "visible" : "hidden" }}
+              />
+            ) : null}
           </>
         )}
       </div>

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -93,6 +93,12 @@ export type PluginView = {
   // rail id, stays mounted for the app's lifetime (streaming continuity, #613), and
   // does not get its own rail entry. First enabled claimant wins.
   slot?: "chat";
+  // Owning plugin's load state, stamped on by App so the view host can surface a real,
+  // actionable error (loaded=false ⇒ the view route isn't serving — missing env / bad
+  // deps / mount race; `pluginError` is the loader's exact diagnostic) instead of a
+  // blank panel. Optional: present only for runtime-status-sourced views.
+  pluginLoaded?: boolean;
+  pluginError?: string;
 };
 
 // A git-installed plugin (ADR 0027) — a plugins.lock entry enriched with its

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -69,9 +69,12 @@ function LocalTab() {
     mutationFn: (p: Plugin) => api.setPluginEnabled(p.id, !p.enabled),
     onSuccess: (res, p) => {
       qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      // Enable is fully live now (its router — which serves any console view — hot-mounts
+      // on reload, #822). Only DISABLE leaves a stale route/surface behind (FastAPI can't
+      // unmount), so restart_recommended is set only when turning a view/route plugin OFF.
       setHint(
         res.restart_recommended
-          ? `${p.name} ${res.enabled ? "enabled" : "disabled"} — restart to load its console view or background surface.`
+          ? `${p.name} disabled — restart to fully remove its console view or background surface.`
           : `${p.name} ${res.enabled ? "enabled" : "disabled"}.`,
       );
     },

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -49,8 +49,8 @@ export function PluginsSection() {
         <h3><Package size={16} /> Install from a git URL</h3>
         <p className="settings-section-sub">
           Install a plugin from a git URL. Fetching code never runs it — review, then{" "}
-          <strong>enable</strong> it from the <strong>Local</strong> tab (tools apply live; a
-          console view or background surface needs a restart). Untrusted code?
+          <strong>enable</strong> it from the <strong>Local</strong> tab (tools, console
+          views and background surfaces all come up live — no restart). Untrusted code?
           Use an <a href="https://protolabsai.github.io/protoAgent/guides/mcp" target="_blank" rel="noreferrer">MCP server</a> instead.{" "}
           <a href={REGISTRY_GUIDE_URL} target="_blank" rel="noreferrer">Guide</a>.
         </p>

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -3,8 +3,18 @@
 Backs the console Plugins panel: list installed plugins (with their manifest +
 declared capabilities for review), install from a git URL, uninstall, and
 enable/disable. Install fetches code only (install ≠ enable). Enable/disable edits
-``plugins.enabled`` and hot-reloads — tools/middleware/MCP apply live; a console
-view or background surface (its router mounts at init) needs a restart.
+``plugins.enabled`` and hot-reloads.
+
+ENABLE is fully live: tools/middleware/MCP rebuild with the graph, and a plugin's
+router — which is what serves a console view (the view iframe just points at a
+router route) — is hot-mounted on the same reload (``_mount_plugin_routers`` in
+``server.agent_init``, #822). So enabling a view-contributing plugin needs no
+restart; ``restart_recommended`` stays False for enable.
+
+DISABLE is the residual restart case: FastAPI has no route-removal API, so a
+disabled plugin's view/route lingers on the live app until a process restart
+(documented in ``_mount_plugin_routers``). We flag ``restart_recommended`` only
+when disabling a plugin that contributed a view/route/surface.
 """
 
 from __future__ import annotations
@@ -74,15 +84,22 @@ def register_plugin_routes(app) -> None:
     async def _set_enabled(plugin_id: str, body: dict | None = None):
         """Enable/disable a plugin by editing `plugins.enabled`/`disabled` + hot-reloading.
 
-        Tools / subagents / middleware / MCP servers take effect immediately (the graph
-        rebuilds). A plugin that serves a **console view** or runs a **background surface**
-        (its router/gateway mounts once at init) needs a restart to finish — flagged via
-        ``restart_recommended`` so the UI can say so.
+        ENABLE is fully live: tools / subagents / middleware / MCP rebuild with the graph,
+        and the plugin's router (which serves any **console view** — the view iframe just
+        points at a router route) is hot-mounted on the same reload (#822). So a freshly
+        enabled view-contributing plugin works immediately; ``restart_recommended`` is False.
+
+        DISABLE can't tear a router back down (FastAPI has no route-removal API), so a
+        disabled plugin's view/route/surface lingers until a process restart — only that
+        path flags ``restart_recommended`` so the UI can say so.
         """
         want = bool((body or {}).get("enabled"))
         cfg = STATE.graph_config
         enabled = [p for p in (getattr(cfg, "plugins_enabled", []) or []) if p != plugin_id]
         disabled = [p for p in (getattr(cfg, "plugins_disabled", []) or []) if p != plugin_id]
+        # Snapshot the plugin's pre-reload meta — on DISABLE the reload clears its views
+        # from STATE.plugin_meta, so we must read "did it contribute a surface?" first.
+        prev_meta = next((p for p in (STATE.plugin_meta or []) if p.get("id") == plugin_id), None)
         if want:
             enabled.append(plugin_id)
         else:
@@ -96,9 +113,13 @@ def register_plugin_routes(app) -> None:
         if not ok:
             raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
 
-        # A view (router) only mounts at init, so enabling a view plugin needs a restart.
-        meta = next((p for p in (STATE.plugin_meta or []) if p.get("id") == plugin_id), None)
-        restart = bool(want and meta and meta.get("views"))
+        # Enabling hot-mounts the router that serves the view (#822) — fully live, no
+        # restart. Only DISABLE leaves a stale route behind (no FastAPI unmount), so we
+        # recommend a restart when turning OFF a plugin that contributed a view/route/surface.
+        def _has_surface(m: dict | None) -> bool:
+            return bool(m and (m.get("views") or m.get("routers") or m.get("surfaces")))
+
+        restart = bool(not want and _has_surface(prev_meta))
         return {"ok": True, "enabled": want, "reloaded": True, "restart_recommended": restart}
 
 

--- a/tests/test_plugin_route_hotmount.py
+++ b/tests/test_plugin_route_hotmount.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 
 import pytest
 from fastapi import APIRouter, FastAPI
+from fastapi.responses import HTMLResponse
 from fastapi.testclient import TestClient
 
 from runtime.state import STATE
@@ -17,6 +18,18 @@ def _router(marker: str) -> APIRouter:
     @r.get("/ping")
     def _ping():
         return {"from": marker}
+
+    return r
+
+
+def _view_router(marker: str) -> APIRouter:
+    """A plugin router that serves a console VIEW page (HTML at /view) — the iframe's src
+    points here, so 'mounting the view' == 'mounting this router' (ADR 0026/0038)."""
+    r = APIRouter()
+
+    @r.get("/view", response_class=HTMLResponse)
+    def _view():
+        return f"<html><body>{marker} view</body></html>"
 
     return r
 
@@ -49,6 +62,18 @@ def test_remount_skipped_new_added(app):
     assert c.get("/api/a/ping").json() == {"from": "a"}
     assert c.get("/api/b/ping").json() == {"from": "b"}
     assert STATE.plugin_router_keys == {("a", "/api/a"), ("b", "/api/b")}
+
+
+def test_view_route_resolves_after_enable(app):
+    # The P0 fix: enabling a view-contributing plugin hot-mounts the router that serves
+    # its view page — so /api/plugins/<id>/view 200s immediately, no restart, no 404.
+    _mount_plugin_routers([{"plugin_id": "project_board",
+                            "router": _view_router("project_board"),
+                            "prefix": "/api/plugins/project_board"}])
+    c = TestClient(app)
+    res = c.get("/api/plugins/project_board/view")
+    assert res.status_code == 200
+    assert "project_board view" in res.text
 
 
 def test_noop_without_app(monkeypatch):

--- a/tests/test_plugin_routes.py
+++ b/tests/test_plugin_routes.py
@@ -54,8 +54,37 @@ def test_disable_moves_to_disabled(monkeypatch):
     assert plugins["disabled"] == ["github"]
 
 
-def test_enabling_a_view_plugin_recommends_restart(monkeypatch):
+def test_enabling_a_view_plugin_does_not_recommend_restart(monkeypatch):
+    # #822 hot-mounts the router that serves the view on the same reload, so enabling a
+    # view-contributing plugin is fully live — NO restart (the P0 fix: enable → it works).
     _wire(monkeypatch, enabled=[], disabled=["boardy"],
           meta=[{"id": "boardy", "views": [{"id": "board"}]}])
     body = _client().post("/api/plugins/boardy/enabled", json={"enabled": True}).json()
-    assert body["restart_recommended"] is True  # its view route mounts at init
+    assert body == {"ok": True, "enabled": True, "reloaded": True, "restart_recommended": False}
+
+
+def test_disabling_a_view_plugin_recommends_restart(monkeypatch):
+    # DISABLE is the residual restart case — FastAPI can't unmount the view's router, so
+    # the stale route lingers until a process restart.
+    _wire(monkeypatch, enabled=["boardy"], disabled=[],
+          meta=[{"id": "boardy", "views": [{"id": "board"}]}])
+    body = _client().post("/api/plugins/boardy/enabled", json={"enabled": False}).json()
+    assert body["enabled"] is False
+    assert body["restart_recommended"] is True
+
+
+def test_disabling_a_route_only_plugin_recommends_restart(monkeypatch):
+    # A plugin with no views but a contributed router (e.g. delegates) still leaves a
+    # stale route on disable → restart recommended.
+    _wire(monkeypatch, enabled=["delegates"], disabled=[],
+          meta=[{"id": "delegates", "views": [], "routers": 1}])
+    body = _client().post("/api/plugins/delegates/enabled", json={"enabled": False}).json()
+    assert body["restart_recommended"] is True
+
+
+def test_disabling_a_plain_plugin_does_not_recommend_restart(monkeypatch):
+    # A tools-only plugin (no view/route/surface) tears down cleanly on the reload — no restart.
+    _wire(monkeypatch, enabled=["github"], disabled=[],
+          meta=[{"id": "github", "views": []}])
+    body = _client().post("/api/plugins/github/enabled", json={"enabled": False}).json()
+    assert body["restart_recommended"] is False


### PR DESCRIPTION
## What & why

You hit this directly: enabled a plugin's agent (the PM), and its **board + browser panels showed "no details"** — and the only escape was a server restart. This is the acute P0 of the plugin-hardening pass. Two independent root causes, both fixed:

### 1. The restart prompt was stale — enable is *already* live
A plugin's console view is just an iframe pointed at one of the plugin's **router routes**. PR #822 (`_mount_plugin_routers`) already hot-mounts a plugin's router on the enable reload — so enabling a view-contributing plugin already serves its view **with no restart**. But `restart_recommended` predates #822 and still flagged enable, telling the UI to recommend a restart for a scenario that's already handled live.

- **Flipped it:** `ENABLE → restart_recommended=False` (fully live — the ComfyUI "enable → it works" posture).
- `restart_recommended=True` **only on DISABLE** of a plugin that contributed a view/route/surface — FastAPI has no route-removal API, so a disabled plugin's route lingers until a restart. Snapshots the pre-reload meta since disable clears the plugin's views from `plugin_meta`.

### 2. The panel rendered a 404 as a blank "no details" page
A same-origin **404 fires the iframe's `onLoad`, NOT `onError`** — so `PluginView` happily rendered FastAPI's bare `{"detail":"Not Found"}` body as the "view". That's the blank panel you saw.

- `PluginView` now **status-probes** the route with `fetch` *before* mounting the iframe; the iframe mounts only when the route is reachable.
- On failure it surfaces a **real, actionable error**: the owning plugin's exact loader diagnostic (missing env / `run: python -m server plugin install-deps <id>`) if present → else "isn't mounted yet — restart to finish enabling" (enabled-but-not-loaded) → else the HTTP status.
- One **600 ms retry** covers the sub-second window where the rail renders the view before the hot-mount `include_router` commits.

`App` stamps each view with the owning plugin's `loaded`/`error`; `PluginsSurface`/`PluginsSection` copy corrected to "enable is live; restart only on disable".

## Tests
- **Backend:** `test_enabling_a_view_plugin_does_not_recommend_restart`, `test_disabling_a_view_plugin_recommends_restart` (+ route-only + plain cases), `test_view_route_resolves_after_enable` (a view router 200s after hot-mount). 11/11 plugin-route tests pass, ruff clean.
- **Frontend:** new e2e — a 404-ing view shows an actionable alert and mounts **zero** iframes. Build green (tsc + vite).

## Scope note
The literal `project_board`/`agent_browser`/"no details" panels are downstream **fork** plugins (your PM agent), not in this repo — but the defect is entirely in the **core** `PluginView.tsx` + enable route and is identical for any 404-ing plugin view, so the fork inherits the fix. Worth a live re-test of your fleet PM scenario once this lands.

Part of the plugin-hardening pass — **P0 (make it work)**. P1 (auto-enable official/bundled + one-step install+enable + third-party "runs code" ack with *don't-show-again*) and P2 (docs reconciliation) follow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)