### PR TITLE
fix(autostart): launch python -m server, not the deleted server.py

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -36,17 +36,23 @@ jobs:
           node /tmp/release-tools/bin/verify-workspace-config.mjs --root "$GITHUB_WORKSPACE"
       - name: Guard against the deleted server.py entrypoint
         # ADR 0023 promoted the monolith to the server/ package (launch:
-        # `python -m server`). A deploy file launching the old single-file binary
-        # CrashLoopBackOffs. Fail CI if any deploy artifact still does. Scoped to
-        # deploy surfaces (excludes .github so this guard can't match itself).
+        # `python -m server`). A launcher pointing at the old single-file binary
+        # CrashLoopBackOffs (deploy) or silently no-ops (autostart.py's exists()
+        # check — missed by the original *.sh/*.yml-only net, fixed alongside this
+        # guard's *.py extension). Two patterns: shell-style `python server.py`
+        # launches, and Python-side quoted "server.py" path constructions
+        # (e.g. `REPO_ROOT / "server.py"`). Excludes .github (self-match) and
+        # tests/ (regression tests assert on the literal string).
         run: |
-          if grep -rnE 'python[0-9]* +server\.py' \
+          if grep -rnE '(python[0-9]* +server\.py|"server\.py")' \
                --include='*.sh' --include='*.yaml' --include='*.yml' \
-               --include='Dockerfile*' --exclude-dir=.github . ; then
+               --include='Dockerfile*' --include='*.py' \
+               --exclude-dir=.github --exclude-dir=tests \
+               --exclude-dir=node_modules --exclude-dir=.venv . ; then
             echo "::error::Stale single-file launch found — use 'python -m server' (ADR 0023)."
             exit 1
           fi
-          echo "ok: no stale single-file launches in deploy artifacts"
+          echo "ok: no stale single-file launches in deploy artifacts or launchers"
 
   lint:
     name: Lint (ruff)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Autostart launches the server again** — the macOS LaunchAgent installer still
+  pointed at the single-file `server.py` that ADR 0023 promoted into the `server/`
+  package: the install-time existence check always failed (the login-launch toggle
+  was dead), and any plist installed before the rename crash-looped at login. The
+  plist now runs `python -m server` with the repo root as `WorkingDirectory` +
+  `PYTHONPATH` (the `entrypoint.sh` recipe); re-enabling autostart overwrites a
+  stale plist in place. The CI stale-path guard — which only scanned
+  `*.sh`/`*.yml`/`Dockerfile*` and so missed this — now also covers `*.py`.
+
 ## [0.32.0] - 2026-06-10
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   plist now runs `python -m server` with the repo root as `WorkingDirectory` +
   `PYTHONPATH` (the `entrypoint.sh` recipe); re-enabling autostart overwrites a
   stale plist in place. The CI stale-path guard — which only scanned
-  `*.sh`/`*.yml`/`Dockerfile*` and so missed this — now also covers `*.py`.
+  `*.sh`/`*.yml`/`Dockerfile*` and so missed this — now also covers `*.py`. (#855)
 
 ## [0.32.0] - 2026-06-10
 

--- a/autostart.py
+++ b/autostart.py
@@ -104,7 +104,7 @@ def autostart_status(agent_name: str = "protoagent") -> dict:
             "installed": plist.exists(),
             "plist_path": str(plist),
             "python": sys.executable,
-            "server_path": str(REPO_ROOT / "server.py"),
+            "server_package": str(REPO_ROOT / "server"),
         }
     return {"supported": False, "installed": False, "reason": "unreachable"}
 
@@ -146,9 +146,9 @@ def _install_macos_launchagent(agent_name: str, port: int) -> tuple[bool, str]:
     missing label on unload is a no-op.
     """
     python = sys.executable
-    server_py = REPO_ROOT / "server.py"
-    if not server_py.exists():
-        return False, f"server.py not found at {server_py}"
+    server_pkg = REPO_ROOT / "server" / "__init__.py"
+    if not server_pkg.exists():
+        return False, f"server package not found at {server_pkg}"
 
     label = _macos_label(agent_name)
     plist_path = _macos_plist_path(agent_name)
@@ -158,7 +158,6 @@ def _install_macos_launchagent(agent_name: str, port: int) -> tuple[bool, str]:
     plist = _render_launchagent_plist(
         label=label,
         python=python,
-        server_py=str(server_py),
         port=port,
         working_dir=str(REPO_ROOT),
         agent_name=agent_name,
@@ -186,7 +185,7 @@ def _install_macos_launchagent(agent_name: str, port: int) -> tuple[bool, str]:
                or f"launchctl load exit={result.returncode}")
         return False, f"plist written but launchctl load failed: {err.strip()}"
 
-    return True, f"installed • {plist_path.name} • runs `{shlex.quote(python)} server.py` on login"
+    return True, f"installed • {plist_path.name} • runs `{shlex.quote(python)} -m server` on login"
 
 
 def _uninstall_macos_launchagent(agent_name: str) -> tuple[bool, str]:
@@ -211,7 +210,6 @@ def _render_launchagent_plist(
     *,
     label: str,
     python: str,
-    server_py: str,
     port: int,
     working_dir: str,
     agent_name: str,
@@ -226,6 +224,13 @@ def _render_launchagent_plist(
     otherwise produce a malformed or injection-vulnerable plist.
     ``port`` is an int so it's safe as-is, but we coerce+escape it
     anyway for consistency.
+
+    ADR 0023: the server is launched as a module (``python -m server``),
+    not the deleted single-file ``server.py``. ``WorkingDirectory`` is the
+    repo root (``python -m`` puts the cwd on ``sys.path``) and
+    ``PYTHONPATH`` is set to it as well — same belt-and-braces as
+    ``entrypoint.sh`` — so the ``server`` package and its sibling
+    top-level modules (``paths``, ``events``, ``graph``, …) resolve.
     """
     e = xml_escape
     return f"""<?xml version="1.0" encoding="UTF-8"?>
@@ -237,7 +242,8 @@ def _render_launchagent_plist(
     <key>ProgramArguments</key>
     <array>
         <string>{e(python)}</string>
-        <string>{e(server_py)}</string>
+        <string>-m</string>
+        <string>server</string>
         <string>--port</string>
         <string>{e(str(port))}</string>
     </array>
@@ -249,6 +255,8 @@ def _render_launchagent_plist(
         <string>{e(agent_name)}</string>
         <key>PATH</key>
         <string>/usr/local/bin:/usr/bin:/bin:/opt/homebrew/bin</string>
+        <key>PYTHONPATH</key>
+        <string>{e(working_dir)}</string>
     </dict>
     <key>RunAtLoad</key>
     <true/>

--- a/evals/sweep.py
+++ b/evals/sweep.py
@@ -8,7 +8,7 @@ swap the default.
 
 How it works (per model):
 
-1. Launch ``server.py --port <p> --ui none`` with ``PROTOAGENT_MODEL=<model>``
+1. Launch ``python -m server --port <p> --ui none`` with ``PROTOAGENT_MODEL=<model>``
    (the env override added in ``graph/config.py``) and a unique
    ``PROTOAGENT_INSTANCE`` so the models never share scoped data.
 2. Wait for ``GET /healthz`` to report the graph compiled.

--- a/graph/config.py
+++ b/graph/config.py
@@ -336,7 +336,7 @@ class LangGraphConfig:
     # The default path lives under ``/sandbox/`` to play well with the
     # bundled Docker volume; the store falls back to
     # ``~/.protoagent/knowledge/agent.db`` automatically when /sandbox
-    # is read-only or absent (e.g. local ``python server.py``).
+    # is read-only or absent (e.g. local ``python -m server``).
     knowledge_db_path: str = "/sandbox/knowledge/agent.db"
     # Knowledge backend selector (ADR 0031) — "" = the built-in SQLite/FTS5 store;
     # otherwise the name of a plugin-registered backend (register_knowledge_store).

--- a/graph/prompts.py
+++ b/graph/prompts.py
@@ -57,7 +57,7 @@ def build_system_prompt(
 
     # 1. Identity — prefer the runtime workspace (entrypoint.sh copies
     # config/SOUL.md to /sandbox/SOUL.md at container start). Fall back
-    # to the repo source so local `python server.py` runs without a
+    # to the repo source so local `python -m server` runs without a
     # /sandbox mount still pick up persona edits made via the drawer.
     soul = _read_file(f"{workspace}/SOUL.md")
     if not soul:

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -16,7 +16,7 @@ The store is path-aware and degradation-aware:
   config default ``/sandbox/knowledge/agent.db``.
 - If the configured path is unwritable (running locally outside the
   container, no /sandbox), falls back to ``~/.protoagent/knowledge/agent.db``
-  so a fresh ``python server.py`` works without sudo.
+  so a fresh ``python -m server`` works without sudo.
 - All write operations swallow ``sqlite3.DatabaseError`` (covers
   OperationalError, IntegrityError, and corruption variants) and log;
   the store never crashes the agent loop on a corrupt or read-only DB.

--- a/tests/test_autostart.py
+++ b/tests/test_autostart.py
@@ -1,0 +1,82 @@
+"""Autostart LaunchAgent generation — module-launch regression guard.
+
+ADR 0023 promoted the single-file ``server.py`` into the ``server/``
+package; ``autostart.py`` kept launching the deleted file, which made
+the feature dead (the install-time exists() check always failed) and
+left any legacy plist crash-looping at login. These tests pin the
+plist to the ``python -m server`` module launch so a future rename
+can't silently regress the launcher again, and exercise the
+install-time existence check against the package layout.
+"""
+from __future__ import annotations
+
+import plistlib
+
+import autostart
+
+
+def _render(**overrides) -> bytes:
+    kwargs = dict(
+        label="ai.protolabs.protoagent",
+        python="/repo/.venv/bin/python",
+        port=7870,
+        working_dir="/repo",
+        agent_name="protoagent",
+        stdout_log="/repo/logs/autostart.out.log",
+        stderr_log="/repo/logs/autostart.err.log",
+    )
+    kwargs.update(overrides)
+    return autostart._render_launchagent_plist(**kwargs).encode("utf-8")
+
+
+def test_plist_launches_the_server_module_not_server_py():
+    data = plistlib.loads(_render())
+    args = data["ProgramArguments"]
+
+    assert args[0] == "/repo/.venv/bin/python"
+    assert args[1:3] == ["-m", "server"], (
+        "plist must launch `python -m server` (ADR 0023)"
+    )
+    assert not any(a.endswith("server.py") for a in args), (
+        "stale single-file launch — server.py was deleted by ADR 0023"
+    )
+    # Port flag preserved, after the module args.
+    assert args[3:] == ["--port", "7870"]
+
+
+def test_plist_resolves_the_module_via_cwd_and_pythonpath():
+    data = plistlib.loads(_render(working_dir="/some/repo"))
+
+    # `python -m` puts the cwd on sys.path; PYTHONPATH is the same
+    # belt-and-braces entrypoint.sh uses.
+    assert data["WorkingDirectory"] == "/some/repo"
+    assert data["EnvironmentVariables"]["PYTHONPATH"] == "/some/repo"
+
+
+def test_plist_keepalive_semantics_preserved():
+    data = plistlib.loads(_render())
+
+    assert data["RunAtLoad"] is True
+    assert data["KeepAlive"] == {"SuccessfulExit": False}
+
+
+def test_status_reports_the_server_package(monkeypatch):
+    monkeypatch.setattr(autostart.platform, "system", lambda: "Darwin")
+    status = autostart.autostart_status("protoagent")
+
+    assert status["supported"] is True
+    assert status["server_package"] == str(autostart.REPO_ROOT / "server")
+    assert "server_path" not in status  # the old single-file key
+
+
+def test_install_checks_for_the_server_package(monkeypatch, tmp_path):
+    """With REPO_ROOT pointing somewhere without server/__init__.py,
+    install must fail with a message naming the package — proving the
+    exists() gate checks the post-ADR-0023 layout, not server.py."""
+    monkeypatch.setattr(autostart.platform, "system", lambda: "Darwin")
+    monkeypatch.setattr(autostart, "REPO_ROOT", tmp_path)
+
+    ok, message = autostart.install_autostart("protoagent", port=7870)
+
+    assert ok is False
+    assert str(tmp_path / "server" / "__init__.py") in message


### PR DESCRIPTION
## The bug

ADR 0023 promoted the single-file `server.py` into the `server/` package. Every other launcher was migrated — except `autostart.py`, which still built its macOS LaunchAgent around `REPO_ROOT/server.py`:

- The install-time `server_py.exists()` check has failed unconditionally since the rename, so **the autostart feature has been dead** — the wizard/drawer toggle returned "server.py not found" every time.
- Any plist installed *before* ADR 0023 points at the deleted file and **crash-loops at login** (`KeepAlive.SuccessfulExit=false` keeps relaunching a python that exits non-zero).

It slipped through because the CI stale-path guard only grepped `*.sh` / `*.yaml` / `*.yml` / `Dockerfile*` — and its launch-shaped regex (`python[0-9]* +server\.py`) wouldn't have matched autostart.py's `REPO_ROOT / "server.py"` path constructions anyway.

## The fix

- Plist `ProgramArguments` now run `python -m server --port <p>`. `WorkingDirectory` **and** `PYTHONPATH` are set to the repo root — the same belt-and-braces recipe as `entrypoint.sh` — so the `server` package and its sibling top-level modules (`paths`, `events`, `graph`, …) resolve.
- The existence gate checks `server/__init__.py`; `autostart_status()` reports `server_package` instead of the stale `server_path`; install/status messages updated.
- Port + python resolution (`sys.executable` at install time) and KeepAlive semantics are unchanged.
- **Stale legacy plists self-heal on reinstall**: `_install_macos_launchagent` already `launchctl unload`s and overwrites the plist in place, so toggling autostart back on replaces a crash-looping pre-ADR-0023 plist — no extra migration needed.

## CI guard extension

`checks.yml`'s stale-entrypoint guard now also scans `*.py` and matches a second pattern, quoted `"server.py"` path constructions (the exact form autostart.py used). Verified locally that the new grep **catches the pre-fix autostart.py** and **passes on the fixed tree** (`tests/` excluded — the regression test asserts on the literal string). The wider net surfaced three stale `python server.py` doc comments (`graph/config.py`, `graph/prompts.py`, `knowledge/store.py`) — fixed to `python -m server`.

## Tests

New `tests/test_autostart.py` (5 tests, parsed with `plistlib`): ProgramArguments are `[python, "-m", "server", "--port", ...]` with no `server.py`; `WorkingDirectory`/`PYTHONPATH` carry the repo root; `RunAtLoad`/`KeepAlive` semantics pinned; status reports the package; the install gate fails with the package path when `server/__init__.py` is absent.

`pytest tests/ -k autostart -q` → 9 passed. `ruff check` clean on all touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)