### PR TITLE
fix(security): refuse token-less non-loopback binds + loopback-only compose publish

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   stale plist in place. The CI stale-path guard — which only scanned
   `*.sh`/`*.yml`/`Dockerfile*` and so missed this — now also covers `*.py`. (#855)
 
+### Security
+- **Token-less non-loopback binds now refuse to start.** Binding a host other
+  than loopback with no A2A auth token used to log a warning and boot anyway —
+  leaving the full operator API (plugin install+enable = code execution,
+  config/SOUL rewrite, subagent runs) open to anything that could reach the
+  port. The boot gate (`a2a_auth.evaluate_open_bind`) now exits with an error
+  unless `PROTOAGENT_ALLOW_OPEN=1` explicitly opts in for fenced deployments.
+  The bundled `docker-compose.yml` publishes the port to **127.0.0.1 only** by
+  default, passes `A2A_AUTH_TOKEN` through, and opts in (the localhost publish
+  is its boundary). **Upgrade note:** an existing deployment binding
+  `0.0.0.0` without a token must set `A2A_AUTH_TOKEN` (recommended) or
+  `PROTOAGENT_ALLOW_OPEN=1` to boot.
+
 ## [0.32.0] - 2026-06-10
 
 ### Added

--- a/a2a_auth.py
+++ b/a2a_auth.py
@@ -141,3 +141,40 @@ def install(app, *, bearer_token: str | None, api_key: str, allowed_origins_raw:
         allowed_origins_raw=allowed_origins_raw,
     )
     app.add_middleware(A2AAuthMiddleware)
+
+
+_LOOPBACK_HOSTS = ("127.0.0.1", "localhost", "::1")
+
+
+def evaluate_open_bind(
+    host: str, *, bearer_configured: bool, allow_open: bool
+) -> tuple[bool, str | None]:
+    """Boot-time gate for binding a non-loopback host without an auth token.
+
+    An unauthenticated non-loopback bind exposes the full operator API
+    (plugin install+enable = code execution, config/SOUL rewrite, subagent
+    runs) to anything that can reach the port — so it is refused unless the
+    operator explicitly opts in with ``PROTOAGENT_ALLOW_OPEN=1`` (the posture
+    for binds fenced by a published-port/network-policy boundary, e.g. a
+    container publishing to 127.0.0.1 only).
+
+    Returns ``(allowed, message)``: ``(True, None)`` silent, ``(True, msg)``
+    allowed with a warning to log, ``(False, msg)`` refuse startup.
+    """
+    if host in _LOOPBACK_HOSTS or bearer_configured:
+        return True, None
+    if allow_open:
+        return True, (
+            f"[security] binding {host} with NO A2A auth token "
+            "(PROTOAGENT_ALLOW_OPEN=1) — the agent + operator API are open to "
+            "anything that can reach this port. Make sure a network boundary "
+            "(localhost-published port, firewall, network policy) fences it."
+        )
+    return False, (
+        f"[security] refusing to bind {host} with NO A2A auth token — the "
+        "operator API (/api/*, /v1/*) includes plugin install/enable (code "
+        "execution) and config rewrite. Set auth.token in "
+        "langgraph-config.yaml or A2A_AUTH_TOKEN, bind 127.0.0.1 (the "
+        "default), or set PROTOAGENT_ALLOW_OPEN=1 if a network boundary "
+        "fences this port."
+    )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,12 +48,22 @@ services:
       - protoagent-sandbox:/sandbox
       - protoagent-config:/opt/protoagent/config
 
+    # Published to LOOPBACK only by default: the container binds 0.0.0.0
+    # internally (entrypoint), so this host-side port binding is the network
+    # boundary. To expose the agent beyond this machine, set A2A_AUTH_TOKEN
+    # below AND widen the binding (e.g. "7870:7870").
     ports:
-      - "7870:7870"
+      - "127.0.0.1:7870:7870"
 
     environment:
       - PYTHONDONTWRITEBYTECODE=1
       - AGENT_NAME=${AGENT_NAME:-protoagent}
+      # Bearer for the A2A + operator API — REQUIRED if the port is exposed
+      # beyond loopback. With the default 127.0.0.1 publish above, the
+      # in-container 0.0.0.0 bind is fenced by the port binding, so the
+      # token-less boot gate is opted out via PROTOAGENT_ALLOW_OPEN below.
+      - A2A_AUTH_TOKEN=${A2A_AUTH_TOKEN:-}
+      - PROTOAGENT_ALLOW_OPEN=${PROTOAGENT_ALLOW_OPEN:-1}
       - OPENAI_API_KEY=${OPENAI_API_KEY:-}
       # Optional Langfuse tracing — left blank disables it.
       - LANGFUSE_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -73,6 +73,10 @@ services:
     environment:
       AGENT_NAME: my-agent
       OPENAI_API_KEY: ${LITELLM_MASTER_KEY}
+      # REQUIRED for a port published beyond loopback: the server refuses a
+      # token-less non-loopback bind (set PROTOAGENT_ALLOW_OPEN=1 instead only
+      # if a firewall/network policy fences the port).
+      A2A_AUTH_TOKEN: ${A2A_AUTH_TOKEN}
       LANGFUSE_PUBLIC_KEY: ${LANGFUSE_PUBLIC_KEY}
       LANGFUSE_SECRET_KEY: ${LANGFUSE_SECRET_KEY}
     ports:

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -29,7 +29,8 @@ Every env var the template reads at runtime.
 | Variable | Default | What |
 |---|---|---|
 | `PROTOAGENT_UI` | `full` | UI deployment tier (or `--ui`): `full` (Gradio + React console + API/A2A), `console` (console + API/A2A, no Gradio), `none` (API + A2A + `/metrics` only — the lean headless stack). The Docker image defaults to `none`. |
-| `PROTOAGENT_HOST` | `127.0.0.1` | Bind address (or `--host`). **Defaults to loopback** so a local/desktop run isn't exposed on all interfaces — the operator/console API (`/api/*`, `/api/chat`, `/v1/*`) is otherwise reachable by anything that can hit the port. The container entrypoint + deploy manifests set `0.0.0.0` because their boundary is the published port + network policy, not the in-container bind. Binding non-loopback **without** an A2A auth token logs a security warning at startup. |
+| `PROTOAGENT_HOST` | `127.0.0.1` | Bind address (or `--host`). **Defaults to loopback** so a local/desktop run isn't exposed on all interfaces — the operator/console API (`/api/*`, `/api/chat`, `/v1/*`) is otherwise reachable by anything that can hit the port. The container entrypoint + deploy manifests set `0.0.0.0` because their boundary is the published port + network policy, not the in-container bind. Binding non-loopback **without** an A2A auth token **refuses to start** unless `PROTOAGENT_ALLOW_OPEN=1`. |
+| `PROTOAGENT_ALLOW_OPEN` | (unset) | Set `1` to allow a **non-loopback bind with no auth token** — the boot gate otherwise refuses it, because the open operator API includes plugin install+enable (code execution) and config rewrite. Only opt in when a network boundary fences the port (the bundled compose publishes to `127.0.0.1` only and sets this; a k8s NetworkPolicy is the other intended case). The startup log still carries a security WARNING. |
 | `PROTOAGENT_HEADLESS` | (unset) | **Deprecated** alias for `PROTOAGENT_UI=console` (or `--headless`). |
 | `PROTOAGENT_HEADLESS_SETUP` | (unset) | Set `1`/`true` to auto-complete setup from a validated config even outside the `none` tier (no wizard). The `none` tier implies this. |
 
@@ -41,7 +42,7 @@ Setup without the wizard: `python -m server --setup` validates the live config (
 |---|---|---|
 | `A2A_AUTH_TOKEN` | (unset — open mode) | Required bearer token for the A2A routes **and** the operator/console + OpenAI-compat APIs — `/a2a`, `/api/*`, `/api/chat`, `/v1/*`. When set, requests without `Authorization: Bearer <token>` get 401. Constant-time comparison (`hmac.compare_digest`). |
 
-When unset, startup logs a WARNING (`"A2A auth token not configured — endpoint is open"`) and accepts all traffic — fine for local dev (and safe behind the loopback-default bind, see `PROTOAGENT_HOST`), not for an exposed deployment. When set, the agent card advertises `securitySchemes.bearer`.
+When unset, startup logs a WARNING (`"A2A auth token not configured — endpoint is open"`) and accepts all traffic — fine for local dev (and safe behind the loopback-default bind, see `PROTOAGENT_HOST`), not for an exposed deployment. **A non-loopback bind with no token refuses to start** unless `PROTOAGENT_ALLOW_OPEN=1` (see above). When set, the agent card advertises `securitySchemes.bearer`.
 
 **Scope.** The guard covers everything that can drive the agent: `/a2a`, the operator API (`/api/*` — run subagents, rewrite config/SOUL, schedule jobs), `/api/chat`, and `/v1/*`. **Public (never guarded):** `/healthz`, `/.well-known/agent-card.json`, `/metrics`, the static console at `/app`, and the read-only `/api/events` SSE stream (browsers' `EventSource` can't send an `Authorization` header; it exposes only activity/inbox events, no action).
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -28,5 +28,11 @@ fi
 # Bind all interfaces inside the container — the boundary is the published port
 # + network policy, not the in-container bind. (The server defaults to loopback
 # for local/desktop runs; PROTOAGENT_HOST overrides either way.)
+#
+# NOTE: a non-loopback bind with no A2A_AUTH_TOKEN refuses to start unless
+# PROTOAGENT_ALLOW_OPEN=1 — the deployment artifact (compose/k8s) must either
+# set a token or explicitly opt in after fencing the port. The bundled
+# docker-compose.yml publishes to 127.0.0.1 only and opts in; a raw
+# `docker run -p 7870:7870` with no token is exactly the case the gate blocks.
 exec env PYTHONPATH="/opt/protoagent${PYTHONPATH:+:$PYTHONPATH}" \
     python -m server --host "${PROTOAGENT_HOST:-0.0.0.0}"

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -809,17 +809,22 @@ def _main():
         app = fastapi_app
         log.info("Starting %s (ui=%s) on http://%s:%d", agent_name(), ui, args.host, args.port)
 
-    # Loud warning when exposed on all interfaces with no A2A auth token: the
-    # operator/console API (/api/*, /api/chat, /v1/*) is reachable by untrusted
-    # callers. Loopback (the default) is safe; a container behind a network
-    # policy is the intended 0.0.0.0 case.
-    if args.host not in ("127.0.0.1", "localhost", "::1") and not _bearer_configured():
-        log.warning(
-            "[security] binding %s with NO A2A auth token — the agent + operator "
-            "API are open to anything that can reach this port. Set auth.token / "
-            "A2A_AUTH_TOKEN, or bind 127.0.0.1 (the default), or front it with a "
-            "network policy.", args.host,
-        )
+    # Boot gate: a non-loopback bind with no A2A auth token exposes the full
+    # operator API (plugin install+enable = code execution, config/SOUL
+    # rewrite) to anything that can reach the port — refuse to start unless
+    # PROTOAGENT_ALLOW_OPEN=1 explicitly opts in (the posture for binds fenced
+    # by a published-port/network-policy boundary, e.g. compose publishing to
+    # 127.0.0.1 only). Loopback (the default) and token-gated binds pass.
+    allowed, gate_msg = a2a_auth.evaluate_open_bind(
+        args.host,
+        bearer_configured=_bearer_configured(),
+        allow_open=os.environ.get("PROTOAGENT_ALLOW_OPEN", "") == "1",
+    )
+    if not allowed:
+        log.error("%s", gate_msg)
+        raise SystemExit(2)
+    if gate_msg:
+        log.warning("%s", gate_msg)
 
     # Don't outlive the launcher. When run as a desktop sidecar the Tauri shell
     # sets PROTOAGENT_PARENT_PID; a PyInstaller-frozen onefile runs as a

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -141,3 +141,29 @@ def test_apis_open_when_no_token(monkeypatch):
     # default (no token) → everything open (local console keeps working)
     for p in ("/a2a", "/api/config", "/v1/chat/completions", "/api/events", "/healthz"):
         assert c.post(p).status_code in (200, 405)  # 405 only if method not allowed
+
+
+# ── 4. boot gate: non-loopback bind without a token ──────────────────────────
+
+
+@pytest.mark.parametrize("host", ["127.0.0.1", "localhost", "::1"])
+def test_open_bind_loopback_always_allowed(host):
+    allowed, msg = a2a_auth.evaluate_open_bind(host, bearer_configured=False, allow_open=False)
+    assert allowed and msg is None
+
+
+def test_open_bind_with_token_allowed_silently():
+    allowed, msg = a2a_auth.evaluate_open_bind("0.0.0.0", bearer_configured=True, allow_open=False)
+    assert allowed and msg is None
+
+
+def test_open_bind_without_token_refused():
+    allowed, msg = a2a_auth.evaluate_open_bind("0.0.0.0", bearer_configured=False, allow_open=False)
+    assert not allowed
+    assert "refusing" in msg and "0.0.0.0" in msg
+
+
+def test_open_bind_optin_allowed_with_warning():
+    allowed, msg = a2a_auth.evaluate_open_bind("0.0.0.0", bearer_configured=False, allow_open=True)
+    assert allowed
+    assert msg is not None and "0.0.0.0" in msg and "PROTOAGENT_ALLOW_OPEN" in msg


### PR DESCRIPTION
## P1 from the 2026-06-10 production-readiness audit

**Before:** binding a non-loopback host with no A2A auth token logged a warning and booted anyway. The shipped `docker-compose.yml` published `7870:7870` (all interfaces) with no token — so `docker compose up` on any reachable host exposed the full operator API unauthenticated: `POST /api/plugins/install` (clone arbitrary git URL) + enable (executes it in-process) = RCE, plus config/SOUL rewrite and subagent runs.

**After:**
- `a2a_auth.evaluate_open_bind()` — a pure, unit-tested boot gate. Loopback (the default) and token-gated binds pass silently; a token-less non-loopback bind **refuses to start** (exit 2) unless `PROTOAGENT_ALLOW_OPEN=1` explicitly opts in (the posture for binds fenced by a published-port / network-policy boundary).
- `docker-compose.yml` publishes to **127.0.0.1 only** by default, passes `A2A_AUTH_TOKEN` through, and opts in via `PROTOAGENT_ALLOW_OPEN` — out-of-box `docker compose up` keeps working, fenced by the localhost publish.
- The k8s manifest is unaffected (its config secret carries the bearer). A raw `docker run -p 7870:7870` with no token is exactly the case the gate now blocks.
- Docs: env-vars reference documents `PROTOAGENT_ALLOW_OPEN`; deploy-guide Watchtower example now sets `A2A_AUTH_TOKEN`.

**Upgrade note** (in CHANGELOG): existing deployments binding `0.0.0.0` without a token must set `A2A_AUTH_TOKEN` (recommended) or `PROTOAGENT_ALLOW_OPEN=1`.

Tests: 4 new unit tests for the gate (`tests/test_a2a_auth.py`, 17 pass); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)