### PR TITLE
perf: off-loop knowledge embedding + debounced chat-store persistence

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `PYTHONPATH` (the `entrypoint.sh` recipe); re-enabling autostart overwrites a
   stale plist in place. The CI stale-path guard — which only scanned
   `*.sh`/`*.yml`/`Dockerfile*` and so missed this — now also covers `*.py`. (#855)
+- **Knowledge embedding no longer blocks the event loop** — with a hybrid store,
+  the query embed (a sync HTTP call) ran *on* the loop before **every** LLM call
+  (`abefore_model` just called the sync hook), and inside the async
+  `memory_recall`/`memory_ingest` tools and `/api/knowledge/search` — one slow
+  embedding endpoint stalled every stream, health check and A2A peer on the
+  server. All four paths now dispatch via `asyncio.to_thread`, same as the
+  checkpointer. (#857)
+- **Chat no longer rewrites localStorage on every streamed token** — the console
+  chat store serialized *all* sessions to localStorage per SSE frame (~24 chars),
+  each write firing a cross-window `storage` event the other fleet windows
+  re-parse. Streamed updates now persist on a trailing 300ms timer; session
+  add/remove/rename/switch, stream done and page unload still flush immediately,
+  and the UI still streams live (only the write is deferred). (#857)
 
 ## [0.32.0] - 2026-06-10
 

--- a/apps/web/src/chat/chat-store.test.ts
+++ b/apps/web/src/chat/chat-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { ensureActiveSessions, MAX_ACTIVE_SESSIONS, type ChatState } from "./chat-store";
 
 // ensureActiveSessions is the LRU that decides which chat sessions stay mounted.
@@ -67,5 +67,122 @@ describe("ensureActiveSessions", () => {
     const next = ensureActiveSessions(mkState(full, full), "new");
     expect(next[0]).toBe("s1"); // s0 dropped despite streaming — no non-streaming option
     expect(next).not.toContain("s0");
+  });
+});
+
+// Persistence debouncing: the server flushes SSE every ~24 chars and every frame
+// lands in updateMessages, so the localStorage write (full-store serialize +
+// cross-window `storage` event) must NOT run per frame. Streamed updates write
+// on a trailing timer; structural changes and unload flush immediately. The
+// in-memory snapshot must still update synchronously (the UI streams live).
+
+const msg = (content: string) =>
+  [{ id: "m1", role: "assistant" as const, content }] as never[];
+
+describe("persist debouncing", () => {
+  let setItem: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    vi.useFakeTimers();
+    window.localStorage.clear();
+    vi.resetModules(); // fresh module-level store + timer state per test
+    setItem = vi.spyOn(Storage.prototype, "setItem");
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+    setItem.mockRestore();
+  });
+
+  async function freshStore() {
+    const mod = await import("./chat-store");
+    setItem.mockClear(); // ignore writes from module init / setup calls
+    return mod;
+  }
+
+  it("coalesces many rapid streamed updates into ONE write", async () => {
+    const { chatStore, PERSIST_DEBOUNCE_MS } = await freshStore();
+    const sessionId = chatStore.getSnapshot().currentSessionId!;
+
+    for (let i = 0; i < 50; i++) {
+      chatStore.updateMessages(sessionId, msg("token ".repeat(i + 1)));
+    }
+    expect(setItem).not.toHaveBeenCalled(); // nothing synchronous
+
+    vi.advanceTimersByTime(PERSIST_DEBOUNCE_MS);
+    expect(setItem).toHaveBeenCalledTimes(1); // one trailing write
+
+    // …and it wrote the LATEST state, not the first frame.
+    const written = JSON.parse(setItem.mock.calls[0][1] as string);
+    const session = written.sessions.find((s: { id: string }) => s.id === sessionId);
+    expect(session.messages[0].content).toBe("token ".repeat(50));
+  });
+
+  it("keeps the in-memory snapshot synchronous while the write is pending", async () => {
+    const { chatStore } = await freshStore();
+    const sessionId = chatStore.getSnapshot().currentSessionId!;
+
+    chatStore.updateMessages(sessionId, msg("live"));
+    const session = chatStore.getSnapshot().sessions.find((s) => s.id === sessionId)!;
+    expect(session.messages[0]).toMatchObject({ content: "live" }); // before any timer fires
+    expect(setItem).not.toHaveBeenCalled();
+  });
+
+  it("flushes immediately on structural changes (create/delete/rename/switch)", async () => {
+    const { chatStore } = await freshStore();
+    const sessionId = chatStore.getSnapshot().currentSessionId!;
+
+    chatStore.updateMessages(sessionId, msg("pending")); // debounced…
+    const created = chatStore.createSession(); // …structural change flushes NOW
+    expect(setItem).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(setItem.mock.calls[0][1] as string);
+    expect(written.sessions.map((s: { id: string }) => s.id)).toContain(created.id);
+    // The pending streamed content rode along with the flush.
+    const session = written.sessions.find((s: { id: string }) => s.id === sessionId);
+    expect(session.messages[0].content).toBe("pending");
+
+    chatStore.renameSession(created.id, "named");
+    expect(setItem).toHaveBeenCalledTimes(2);
+    chatStore.switchSession(sessionId);
+    expect(setItem).toHaveBeenCalledTimes(3);
+    chatStore.deleteSession(created.id);
+    expect(setItem).toHaveBeenCalledTimes(4);
+  });
+
+  it("flushes on stream done (setSessionStatus) so the final answer persists", async () => {
+    const { chatStore } = await freshStore();
+    const sessionId = chatStore.getSnapshot().currentSessionId!;
+
+    chatStore.updateMessages(sessionId, msg("final answer"));
+    chatStore.setSessionStatus(sessionId, "idle"); // ChatSurface's stream-done path
+    expect(setItem).toHaveBeenCalledTimes(1);
+    const written = JSON.parse(setItem.mock.calls[0][1] as string);
+    const session = written.sessions.find((s: { id: string }) => s.id === sessionId);
+    expect(session.messages[0].content).toBe("final answer");
+
+    // No stale trailing write after the flush.
+    vi.runOnlyPendingTimers();
+    expect(setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushes pending state on pagehide/beforeunload, and only when dirty", async () => {
+    const { chatStore } = await freshStore();
+    const sessionId = chatStore.getSnapshot().currentSessionId!;
+
+    chatStore.updateMessages(sessionId, msg("about to navigate"));
+    window.dispatchEvent(new Event("pagehide"));
+    expect(setItem).toHaveBeenCalledTimes(1);
+
+    // Clean store → unload is a no-op (a tenant-clear must never be re-written).
+    window.dispatchEvent(new Event("pagehide"));
+    window.dispatchEvent(new Event("beforeunload"));
+    expect(setItem).toHaveBeenCalledTimes(1);
+  });
+
+  it("flushChatPersist is a no-op when nothing is pending", async () => {
+    const { flushChatPersist } = await freshStore();
+    flushChatPersist();
+    expect(setItem).not.toHaveBeenCalled();
   });
 });

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -94,6 +94,56 @@ function persist(state: ChatState) {
   }
 }
 
+// ── debounced persistence ─────────────────────────────────────────────────────
+// The server flushes SSE every ~24 chars, and every streamed frame lands in
+// updateMessages → setState. Serializing EVERY session to localStorage per frame
+// is the dominant main-thread cost of a streaming turn (and each write fires a
+// cross-window `storage` event that FleetTurnWatch re-parses). So streaming
+// updates persist on a trailing ~300ms timer; structural changes (session
+// add/remove/rename/switch, stream start/done) and page unload flush
+// immediately. Only the localStorage WRITE is deferred — the in-memory state
+// and listener notify stay synchronous, so the UI streams live.
+
+export const PERSIST_DEBOUNCE_MS = 300;
+
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+let persistDirty = false;
+
+function schedulePersist() {
+  persistDirty = true;
+  if (persistTimer !== null) return; // trailing write already scheduled
+  persistTimer = setTimeout(() => {
+    persistTimer = null;
+    if (persistDirty) {
+      persistDirty = false;
+      persist(state);
+    }
+  }, PERSIST_DEBOUNCE_MS);
+}
+
+/** Write any pending (debounced) state to localStorage NOW. No-op when clean —
+ * so a tenant-clear + reload (lib/tenant.ts) is never undone by an unload
+ * flush that had nothing pending. Exported for tests + the unload hooks. */
+export function flushChatPersist() {
+  if (persistTimer !== null) {
+    clearTimeout(persistTimer);
+    persistTimer = null;
+  }
+  if (persistDirty) {
+    persistDirty = false;
+    persist(state);
+  }
+}
+
+// pagehide covers bfcache navigations Safari/iOS never fire beforeunload for;
+// beforeunload covers older flows. flushChatPersist is idempotent.
+try {
+  window.addEventListener("pagehide", flushChatPersist);
+  window.addEventListener("beforeunload", flushChatPersist);
+} catch {
+  // non-browser context (tests without a full window)
+}
+
 export function ensureActiveSessions(state: ChatState, sessionId: string | null): string[] {
   if (!sessionId) return state.activeSessions;
   if (state.activeSessions.includes(sessionId)) return state.activeSessions;
@@ -118,9 +168,17 @@ let state: ChatState = {
 
 const listeners = new Set<() => void>();
 
-function setState(updater: (current: ChatState) => ChatState) {
+function setState(
+  updater: (current: ChatState) => ChatState,
+  persistMode: "immediate" | "debounced" = "immediate",
+) {
   state = updater(state);
-  persist(state);
+  if (persistMode === "immediate") {
+    persistDirty = true;
+    flushChatPersist(); // cancels any pending timer and writes the full state
+  } else {
+    schedulePersist();
+  }
   listeners.forEach((listener) => listener());
 }
 
@@ -187,19 +245,25 @@ export const chatStore = {
   },
 
   updateMessages(sessionId: string, messages: ChatMessage[]) {
-    setState((current) => ({
-      ...current,
-      sessions: current.sessions.map((session) =>
-        session.id === sessionId
-          ? {
-              ...session,
-              title: session.title === "New chat" ? titleFromMessages(messages) : session.title,
-              messages,
-              updatedAt: Date.now(),
-            }
-          : session,
-      ),
-    }));
+    // Fires per streamed SSE frame (~24 chars) — debounce the localStorage
+    // write. The stream-done path flushes via setSessionStatus right after the
+    // final updateMessages, so the terminal state always lands immediately.
+    setState(
+      (current) => ({
+        ...current,
+        sessions: current.sessions.map((session) =>
+          session.id === sessionId
+            ? {
+                ...session,
+                title: session.title === "New chat" ? titleFromMessages(messages) : session.title,
+                messages,
+                updatedAt: Date.now(),
+              }
+            : session,
+        ),
+      }),
+      "debounced",
+    );
   },
 
   renameSession(sessionId: string, title: string) {

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -297,5 +297,17 @@ class KnowledgeMiddleware(AgentMiddleware):
         return {"context": "\n\n".join(parts)}
 
     async def abefore_model(self, state, runtime) -> dict | None:
-        """Async version — same logic."""
-        return self.before_model(state, runtime)
+        """Async version — same logic, off the event loop.
+
+        ``before_model`` blocks: the store search embeds the query over HTTP
+        (HybridKnowledgeStore + create_embed_fn), plus sqlite + disk reads for
+        hot memory / prior sessions / skills. Running it inline here stalled
+        the event loop before *every* LLM call, so it goes through
+        ``asyncio.to_thread`` (same pattern as graph/checkpointer.py). The
+        only state mutated is the prior-sessions cache (str + float
+        assignment), which is benign across threads; the store opens a sqlite
+        connection per call.
+        """
+        import asyncio
+
+        return await asyncio.to_thread(self.before_model, state, runtime)

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -336,7 +336,11 @@ class MemoryMiddleware(AgentMiddleware):
         return {"messages": new_msgs}
 
     async def abefore_model(self, state, runtime) -> dict | None:
-        return self.before_model(state, runtime)
+        # before_model reads prior sessions from disk — keep that I/O off the
+        # event loop (same pattern as graph/checkpointer.py).
+        import asyncio
+
+        return await asyncio.to_thread(self.before_model, state, runtime)
 
     # --- Knowledge extraction (existing) ---
 

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -10,6 +10,7 @@ off; none ever 500s the console.
 
 from __future__ import annotations
 
+import asyncio
 import logging
 
 from runtime.state import STATE
@@ -84,7 +85,12 @@ def register_knowledge_routes(app) -> None:
         results: list[dict] = []
         try:
             if q and q.strip():
-                results = [_knowledge_row(r) for r in STATE.knowledge_store.search(q, k=k, domain=domain or None)]
+                # search() embeds the query over HTTP on hybrid stores — run it
+                # off the event loop (same pattern as graph/checkpointer.py).
+                rows = await asyncio.to_thread(
+                    STATE.knowledge_store.search, q, k=k, domain=domain or None
+                )
+                results = [_knowledge_row(r) for r in rows]
             else:
                 results = [_knowledge_row(c.as_dict()) for c in STATE.knowledge_store.list_chunks(domain=domain or None, limit=k)]
         except Exception:  # noqa: BLE001 — never 500 the console

--- a/tests/test_memory_load.py
+++ b/tests/test_memory_load.py
@@ -304,3 +304,67 @@ def test_load_memory_standalone_no_knowledge_store(tmp_path):
 
     assert "<prior_sessions>" in result
     assert "standalone" in result
+
+
+# ---------------------------------------------------------------------------
+# 11. abefore_model runs the (blocking) store search OFF the event loop
+# ---------------------------------------------------------------------------
+# The store search embeds the query over HTTP on hybrid stores
+# (HybridKnowledgeStore + create_embed_fn) — running it inline in
+# abefore_model stalled the event loop before every LLM call. The async
+# hook must dispatch the sync before_model via asyncio.to_thread.
+
+async def test_abefore_model_runs_search_off_event_loop():
+    import threading
+
+    from langchain_core.messages import HumanMessage
+
+    from graph.middleware.knowledge import KnowledgeMiddleware
+
+    seen_threads: list[threading.Thread] = []
+
+    store = MagicMock()
+    store.get_hot_memory.return_value = ""
+
+    def _slow_search(query, k=5):
+        seen_threads.append(threading.current_thread())
+        return [{"table": "chunks", "preview": "remembered fact"}]
+
+    store.search.side_effect = _slow_search
+
+    mw = KnowledgeMiddleware(store, top_k=5)
+    state = {"messages": [HumanMessage(content="what do you remember?")]}
+
+    result = await mw.abefore_model(state, runtime=None)
+
+    # Same behavior as the sync path…
+    assert result is not None
+    assert "remembered fact" in result["context"]
+    # …but the blocking search ran on a worker thread, not the event loop.
+    assert seen_threads, "store.search was never called"
+    assert seen_threads[0] is not threading.main_thread()
+
+
+async def test_memory_middleware_abefore_model_off_loop(tmp_path, monkeypatch):
+    """MemoryMiddleware.abefore_model (standalone mode, disk reads) also
+    dispatches via to_thread."""
+    import threading
+
+    from langchain_core.messages import HumanMessage
+
+    import graph.middleware.memory as memmod
+
+    seen_threads: list[threading.Thread] = []
+
+    def _fake_load(self):
+        seen_threads.append(threading.current_thread())
+        return "<prior_sessions>old</prior_sessions>"
+
+    monkeypatch.setattr(memmod.MemoryMiddleware, "_load_prior_sessions", _fake_load)
+    mw = memmod.MemoryMiddleware(knowledge_store=None)
+
+    state = {"messages": [HumanMessage(content="hello")]}
+    result = await mw.abefore_model(state, runtime=None)
+
+    assert result is not None  # prior sessions injected
+    assert seen_threads and seen_threads[0] is not threading.main_thread()

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -441,7 +441,12 @@ def _build_memory_tools(knowledge_store) -> list:
 
         Returns ``"Stored chunk N in 'domain'."`` on success.
         """
-        chunk_id = knowledge_store.add_chunk(content, domain=domain, heading=heading)
+        # add_chunk embeds over HTTP on hybrid stores — keep it off the loop.
+        import asyncio
+
+        chunk_id = await asyncio.to_thread(
+            knowledge_store.add_chunk, content, domain=domain, heading=heading
+        )
         if chunk_id is None:
             return "Error: failed to store chunk (knowledge store unavailable)."
         return f"Stored chunk {chunk_id} in {domain!r}."
@@ -459,7 +464,10 @@ def _build_memory_tools(knowledge_store) -> list:
         scores above the keyword threshold.
         """
         clamped_k = max(1, min(int(k), _MEMORY_RECALL_MAX_K))
-        results = knowledge_store.search(query, k=clamped_k)
+        # search embeds the query over HTTP on hybrid stores — keep it off the loop.
+        import asyncio
+
+        results = await asyncio.to_thread(knowledge_store.search, query, k=clamped_k)
         if not results:
             return "No matches."
         lines = [f"[{r.get('domain', '?')}] {r['preview']}" for r in results]


### PR DESCRIPTION
Two performance fixes from a fresh audit — one per side of the stack, same theme: hot paths doing blocking work per event.

## A — backend: sync embedding HTTP call blocked the event loop on every model call

**Failure scenario:** with a hybrid knowledge store configured, every LLM invocation (and every `memory_recall`/`memory_ingest` tool call) embeds text over HTTP **on the event loop**. While that request is in flight the whole server stalls: SSE streams to other sessions freeze, health checks queue, A2A peers time out. A slow/unreachable embedding endpoint turns one agent's turn into a server-wide pause (until the circuit breaker opens).

**Evidence:**
- `graph/llm.py:110` — `create_embed_fn` returns the **sync** `OpenAIEmbeddings.embed_query`
- `knowledge/hybrid_store.py:82-91` — `_embed` calls it inline inside `search()`/`add_chunk()`
- `graph/middleware/knowledge.py` — `abefore_model` was `return self.before_model(...)`, so the store search (embed + sqlite) + hot-memory + prior-sessions disk reads ran on the loop before **every** model call; LangChain's factory wraps `(before_model, abefore_model)` in a `RunnableCallable`, so the async hook is what async invocations actually run
- `tools/lg_tools.py` — `async def memory_recall`/`memory_ingest` called the sync `search`/`add_chunk` inline; same for the `async` `/api/knowledge/search` route

**Fix:** dispatch the sync hooks/calls through `await asyncio.to_thread(...)` — the exact pattern the repo already uses for sync sqlite in `graph/checkpointer.py` and sync zeroconf in `graph/fleet/discovery.py`. Sync callers keep `before_model` unchanged. Thread-safety checked: `KnowledgeStore._get_db()` opens a fresh sqlite connection per call (closed in `finally`), and the circuit-breaker state is plain scalar assignment — benign under a worker-thread hop.

## B — frontend: chat store persisted the ENTIRE store to localStorage on every streamed SSE frame

**Failure scenario:** the server flushes SSE roughly every ~24 chars; each frame hits `updateMessages` → `setState` → `persist()`, which `JSON.stringify`s **all** sessions (up to 50, each with full transcripts) and `setItem`s the blob — hundreds of full-store serializations per response, on the main thread, while the UI is also rendering the stream. Each write additionally fires a cross-window `storage` event that `FleetTurnWatch` re-parses in every other open agent window — so one streaming turn taxes the whole fleet console.

**Evidence:** `apps/web/src/chat/chat-store.ts:84-95` (persist serializes all sessions) + `:121-125` (every `setState` persisted).

**Fix:** only the localStorage **write** debounces (trailing ~300 ms); the in-memory update + `useSyncExternalStore` notify stay synchronous, so the UI streams live. Immediate flushes on session create/delete/rename/switch, stream start/done (`setSessionStatus`, which ChatSurface calls right after the final `updateMessages`), and `pagehide`/`beforeunload`. The unload flush is **dirty-gated** so a tenant-clear (`lib/tenant.ts`) is never undone by an unload that had nothing pending; the session LRU (`ensureActiveSessions`) is untouched.

## Tests

- **Backend** — `tests/test_memory_load.py`: `abefore_model` returns the same context as the sync path but the (monkeypatched) `store.search` records its thread, asserted ≠ main thread; same for `MemoryMiddleware`'s disk path. `pytest tests/ -q -x` → **1538 passed**; targeted `-k "knowledge or memory or middleware"` → 172 passed; `ruff check` clean on touched files.
- **Frontend** — `chat-store.test.ts` fake-timer suite: 50 rapid `updateMessages` → **one** `setItem` (with the latest content); snapshot stays synchronous pre-flush; structural ops + `setSessionStatus` + `pagehide` flush immediately; clean-store unload is a no-op. `vitest run` → **36 passed** (4 files); `npm run -w @protoagent/web build` (tsc + vite) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)