### PR TITLE
fix(persistence): atomic registry writes + config write lock + 0600 remotes.json

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   is its boundary). **Upgrade note:** an existing deployment binding
   `0.0.0.0` without a token must set `A2A_AUTH_TOKEN` (recommended) or
   `PROTOAGENT_ALLOW_OPEN=1` to boot.
+- **Persistence hardening — atomic writes, a config write lock, and 0600 on the
+  remote-token registry** (prod-readiness audit). `langgraph-config.yaml`,
+  `fleet.json`, `remotes.json`, and `workspace.yaml` were written with a bare
+  `open(path, "w")` — a crash mid-dump left a truncated file, and the fleet
+  registries silently loaded `{}` afterwards (every running agent forgotten,
+  every remote member + stored bearer dropped, zero log lines). All four now
+  land via a shared `paths.atomic_write` (same-dir temp + `os.replace`);
+  corrupt registries still load tolerantly but WARN loudly. `remotes.json`
+  is now written 0600 (it carries remote bearer tokens — the "same posture as
+  secrets.yaml" its comment claimed but didn't have). Concurrent settings
+  saves (two console windows, a save racing a plugin toggle) were a classic
+  lost-update on the YAML plus interleaved graph reloads — `_apply_settings_changes`,
+  `_reset_settings_keys`, and `_reload_langgraph_agent` now serialize on one
+  RLock.
 
 ## [0.32.0] - 2026-06-10
 

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -195,21 +195,28 @@ def load_yaml_doc(path: Path = CONFIG_YAML_PATH) -> Any:
 
 
 def save_yaml_doc(doc: Any, path: Path = CONFIG_YAML_PATH) -> None:
-    """Persist the document. Creates parent dirs if needed."""
-    path.parent.mkdir(parents=True, exist_ok=True)
-    if _HAS_RUAMEL:
-        with open(path, "w") as f:
-            _ruamel.dump(doc, f)
-        return
+    """Persist the document atomically (temp + rename). Creates parent dirs.
 
-    log.warning(
-        "ruamel.yaml not installed — YAML comments in %s will not be "
-        "preserved on save. Add `ruamel.yaml>=0.18` to requirements.txt "
-        "to fix.", path,
-    )
-    import yaml
-    with open(path, "w") as f:
-        yaml.safe_dump(doc, f, sort_keys=False, default_flow_style=False)
+    This file is the single most important one the agent owns — a crash
+    mid-dump must never leave a truncated YAML behind, so the dump goes to a
+    buffer and lands via ``paths.atomic_write``.
+    """
+    import io
+
+    from paths import atomic_write
+
+    buf = io.StringIO()
+    if _HAS_RUAMEL:
+        _ruamel.dump(doc, buf)
+    else:
+        log.warning(
+            "ruamel.yaml not installed — YAML comments in %s will not be "
+            "preserved on save. Add `ruamel.yaml>=0.18` to requirements.txt "
+            "to fix.", path,
+        )
+        import yaml
+        yaml.safe_dump(doc, buf, sort_keys=False, default_flow_style=False)
+    atomic_write(path, buf.getvalue())
 
 
 # ---------------------------------------------------------------------------

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -66,14 +66,18 @@ def _load_state() -> dict:
     try:
         d = json.loads(f.read_text())
         return d if isinstance(d, dict) else {}
-    except (json.JSONDecodeError, OSError):
+    except (json.JSONDecodeError, OSError) as e:
+        # Tolerant load keeps the fleet usable, but say so LOUDLY: a corrupt
+        # registry means every running agent is forgotten (orphaned processes
+        # still holding their ports) until they're re-created.
+        log.warning("[fleet] %s unreadable (%s) — treating as empty; running agents may be orphaned", f, e)
         return {}
 
 
 def _save_state(state: dict) -> None:
-    f = _state_path()
-    f.parent.mkdir(parents=True, exist_ok=True)
-    f.write_text(json.dumps(state, indent=2) + "\n")
+    from paths import atomic_write
+
+    atomic_write(_state_path(), json.dumps(state, indent=2) + "\n")
 
 
 def _alive(pid: int | None) -> bool:
@@ -199,8 +203,8 @@ def _host_entry() -> dict:
 # joins this fleet as a SWITCHABLE agent: it gets a slug window like a local peer, with the
 # hub reverse-proxying its console + A2A. We can't start/stop it — `running` is a cached
 # reachability probe. Registry: `<workspaces_root>/remotes.json` (hub-scoped, #813);
-# an optional bearer token is stored alongside (plaintext, same posture as secrets.yaml)
-# and attached by the proxy — `status()` never returns it.
+# an optional bearer token is stored alongside (0600 + atomic write, same posture as
+# secrets.yaml) and attached by the proxy — `status()` never returns it.
 
 
 def _remotes_path() -> Path:
@@ -208,16 +212,24 @@ def _remotes_path() -> Path:
 
 
 def _load_remotes() -> dict:
+    p = _remotes_path()
+    if not p.exists():
+        return {}
     try:
-        return json.loads(_remotes_path().read_text())
-    except (OSError, json.JSONDecodeError):
+        return json.loads(p.read_text())
+    except (OSError, json.JSONDecodeError) as e:
+        # Loud: a corrupt registry silently dropping every remote member —
+        # including their stored bearer tokens — is undebuggable otherwise.
+        log.warning("[fleet] %s unreadable (%s) — treating as empty; remote members dropped", p, e)
         return {}
 
 
 def _save_remotes(remotes: dict) -> None:
-    p = _remotes_path()
-    p.parent.mkdir(parents=True, exist_ok=True)
-    p.write_text(json.dumps(remotes, indent=2))
+    from paths import atomic_write
+
+    # 0600: this file carries the remotes' bearer tokens (matching the
+    # secrets.yaml posture — written atomically, never group/world readable).
+    atomic_write(_remotes_path(), json.dumps(remotes, indent=2), mode=0o600)
 
 
 def list_remotes() -> list[dict]:

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -19,6 +19,8 @@ import sys
 from datetime import datetime, timezone
 from pathlib import Path
 
+from paths import atomic_write
+
 PORT_BASE = 7870  # workspaces get PORT_BASE+1, +2, … unless an explicit port is given
 
 
@@ -213,7 +215,7 @@ def create(name: str, *, from_config: str | None = None, inherit_model: str | No
     # install, so a concurrent create can't _pick_port the same port (#11). Then clean up the
     # whole dir on any failure, so a retry doesn't 400 with "already exists" on a poisoned
     # workspace that's invisible in the list (no workspace.yaml).
-    (ws / "workspace.yaml").write_text(yaml.safe_dump(rec, sort_keys=False))
+    atomic_write(ws / "workspace.yaml", yaml.safe_dump(rec, sort_keys=False))
     installed: list[str] = []
     try:
         if bundle:
@@ -335,7 +337,7 @@ def rename(ident: str, new_name: str) -> dict:
     ws = Path(found["path"])
     rec = _read_record(ws) or {}
     rec["name"] = new_name
-    (ws / "workspace.yaml").write_text(yaml.safe_dump(rec, sort_keys=False))
+    atomic_write(ws / "workspace.yaml", yaml.safe_dump(rec, sort_keys=False))
     cfg = ws / "langgraph-config.yaml"
     if cfg.exists():  # keep the agent's self-identity in step with the display name
         _stamp_identity(cfg, new_name, False, instance_id=rec.get("id", found["id"]))

--- a/paths.py
+++ b/paths.py
@@ -15,12 +15,41 @@ so the segment survives a ``/sandbox`` → ``~/.protoagent`` fallback.
 
 from __future__ import annotations
 
+import contextlib
 import hashlib
 import os
 import re
+import tempfile
 from pathlib import Path
 
 _TRUTHY = {"1", "true", "yes", "on"}
+
+
+def atomic_write(path: Path | str, text: str, *, mode: int | None = None) -> None:
+    """Crash-safe text write: temp file in the same directory + ``os.replace``.
+
+    A bare ``open(path, "w")`` leaves a truncated file if the process dies
+    mid-write — for the JSON/YAML registries that tolerantly load ``{}`` on a
+    parse error, that silently forgets every record. The same-dir temp file
+    keeps the swap on one filesystem so ``os.replace`` stays atomic.
+
+    ``mode`` (e.g. ``0o600`` for files carrying credentials) is applied to the
+    temp file *before* the swap, so the final path never exists with looser
+    permissions.
+    """
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    fd, tmp = tempfile.mkstemp(dir=str(path.parent), prefix=f".{path.name}.")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(text)
+        if mode is not None:
+            os.chmod(tmp, mode)
+        os.replace(tmp, path)
+    except BaseException:
+        with contextlib.suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
 def _auto_scope_enabled() -> bool:

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -16,9 +16,11 @@ keeps resolving for ``_main``'s wiring and for the test suite.
 """
 
 import asyncio
+import functools
 import logging
 import os
 import re
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -31,6 +33,28 @@ if TYPE_CHECKING:
     from scheduler.interface import SchedulerBackend
 
 log = logging.getLogger("protoagent.server")
+
+# Serializes every config read-modify-write + graph reload. The callers all
+# run on worker threads (asyncio.to_thread from the routes), and a fleet hub
+# makes concurrent saves routine (two console windows, a settings save racing
+# a plugin toggle). Without this: classic lost-update on the YAML, and two
+# interleaved reloads can commit graph A with STATE.graph_config B — the exact
+# de-sync the reload path's build-then-commit choreography assumes can't
+# happen. RLock because _apply_settings_changes/_reset_settings_keys call
+# _reload_langgraph_agent, which is also lockable on its own (plugin routes
+# call it directly).
+_CONFIG_WRITE_LOCK = threading.RLock()
+
+
+def _serialized_config_write(fn):
+    """Run ``fn`` under ``_CONFIG_WRITE_LOCK`` (config RMW + reload guard)."""
+
+    @functools.wraps(fn)
+    def wrapper(*args, **kwargs):
+        with _CONFIG_WRITE_LOCK:
+            return fn(*args, **kwargs)
+
+    return wrapper
 
 
 def _init_langgraph_agent(headless_setup: bool = False):
@@ -930,6 +954,7 @@ def _mount_plugin_routers(routers: list[dict]) -> None:
             log.exception("[plugins] failed to mount router from %s", r.get("plugin_id"))
 
 
+@_serialized_config_write
 def _reload_langgraph_agent() -> tuple[bool, str]:
     """Rebuild the compiled graph from the latest config YAML.
 
@@ -1220,6 +1245,7 @@ def _filter_nested_to_host_keys(config: dict) -> tuple[dict, list[str]]:
     return host_only, dropped
 
 
+@_serialized_config_write
 def _apply_settings_changes(
     config: dict | None = None,
     soul: str | None = None,
@@ -1310,6 +1336,7 @@ def _apply_settings_changes(
     return ok, messages
 
 
+@_serialized_config_write
 def _reset_settings_keys(keys: list[str]) -> tuple[bool, list[str]]:
     """Reset-to-inherited (ADR 0047 slice 3): pop ``keys`` from the AGENT leaf
     YAML, then reload so each field falls back to the Host/App layer.

--- a/tests/test_atomic_writes.py
+++ b/tests/test_atomic_writes.py
@@ -1,0 +1,145 @@
+"""Persistence hardening (2026-06-10 prod-readiness audit).
+
+Three guarantees pinned here:
+
+1. ``paths.atomic_write`` — temp-in-same-dir + ``os.replace`` so a crash
+   mid-write can never leave a truncated registry; optional ``mode`` lands
+   BEFORE the swap (a credentials file never exists world-readable).
+2. The fleet registries (``fleet.json`` / ``remotes.json``) write atomically,
+   ``remotes.json`` is 0600 (it carries remote bearer tokens), and a corrupt
+   registry loads as empty WITH a warning instead of silently forgetting
+   every record.
+3. ``_apply_settings_changes`` / ``_reload_langgraph_agent`` are serialized by
+   ``_CONFIG_WRITE_LOCK`` — concurrent saves can't interleave the YAML
+   read-modify-write or the graph build-then-commit choreography.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import stat
+import threading
+import time
+
+
+from paths import atomic_write
+
+# ── 1. atomic_write ──────────────────────────────────────────────────────────
+
+
+def test_atomic_write_creates_parents_and_content(tmp_path):
+    p = tmp_path / "a" / "b" / "f.json"
+    atomic_write(p, '{"x": 1}')
+    assert json.loads(p.read_text()) == {"x": 1}
+
+
+def test_atomic_write_replaces_existing(tmp_path):
+    p = tmp_path / "f.txt"
+    p.write_text("old")
+    atomic_write(p, "new")
+    assert p.read_text() == "new"
+
+
+def test_atomic_write_mode_0600(tmp_path):
+    p = tmp_path / "secret.json"
+    atomic_write(p, "{}", mode=0o600)
+    assert stat.S_IMODE(p.stat().st_mode) == 0o600
+
+
+def test_atomic_write_leaves_no_temp_droppings(tmp_path):
+    p = tmp_path / "f.txt"
+    atomic_write(p, "data")
+    assert [f.name for f in tmp_path.iterdir()] == ["f.txt"]
+
+
+# ── 2. fleet registries ──────────────────────────────────────────────────────
+
+
+def test_corrupt_fleet_state_warns_and_loads_empty(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    from graph.fleet import supervisor
+
+    f = supervisor._state_path()
+    f.parent.mkdir(parents=True, exist_ok=True)
+    f.write_text('{"truncated": ')  # crash-mid-write artifact
+    with caplog.at_level(logging.WARNING):
+        assert supervisor._load_state() == {}
+    assert any("unreadable" in r.message for r in caplog.records)
+
+
+def test_corrupt_remotes_warns_and_loads_empty(tmp_path, monkeypatch, caplog):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    from graph.fleet import supervisor
+
+    p = supervisor._remotes_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text("not json")
+    with caplog.at_level(logging.WARNING):
+        assert supervisor._load_remotes() == {}
+    assert any("unreadable" in r.message for r in caplog.records)
+
+
+def test_remotes_written_0600(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    from graph.fleet import supervisor
+
+    supervisor._save_remotes({"r1": {"url": "http://h:7870", "token": "tok"}})
+    p = supervisor._remotes_path()
+    assert stat.S_IMODE(p.stat().st_mode) == 0o600
+    assert supervisor._load_remotes()["r1"]["token"] == "tok"
+
+
+def test_save_yaml_doc_is_atomic_no_droppings(tmp_path):
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+
+    p = tmp_path / "cfg.yaml"
+    save_yaml_doc({"model": {"name": "x"}}, p)
+    assert load_yaml_doc(p)["model"]["name"] == "x"
+    assert [f.name for f in tmp_path.iterdir()] == ["cfg.yaml"]
+
+
+# ── 3. config write serialization ────────────────────────────────────────────
+
+
+def test_apply_settings_changes_serialized(monkeypatch):
+    """Two threads in _apply_settings_changes never overlap (lost-update guard)."""
+    from server import agent_init
+
+    in_flight = []
+    overlaps = []
+
+    def fake_reload():
+        in_flight.append(1)
+        if len(in_flight) - len(overlaps) > 1:  # someone else is inside too
+            overlaps.append(1)
+        time.sleep(0.05)
+        in_flight.pop()
+        return True, "reloaded (fake)"
+
+    # Patch the reload + autostart sync; with config/soul None this makes
+    # _apply_settings_changes a pure (locked) reload.
+    monkeypatch.setattr(agent_init, "_reload_langgraph_agent", fake_reload)
+    monkeypatch.setattr(agent_init, "_sync_autostart_with_config", lambda c: "")
+
+    threads = [
+        threading.Thread(target=agent_init._apply_settings_changes) for _ in range(4)
+    ]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not overlaps, "concurrent _apply_settings_changes bodies interleaved"
+
+
+def test_reload_is_directly_lockable():
+    """Plugin routes call _reload_langgraph_agent directly — it must hold the
+    same lock (RLock: nested acquisition from _apply_settings_changes is fine)."""
+    from server import agent_init
+
+    assert agent_init._reload_langgraph_agent.__wrapped__ is not None
+    # The decorator wraps with _CONFIG_WRITE_LOCK; prove re-entrancy works.
+    with agent_init._CONFIG_WRITE_LOCK:
+        acquired = agent_init._CONFIG_WRITE_LOCK.acquire(blocking=False)
+        assert acquired
+        agent_init._CONFIG_WRITE_LOCK.release()


### PR DESCRIPTION
## Three HIGH findings from the 2026-06-10 prod-readiness audit, one shared fix

**N2 — non-atomic writes.** `langgraph-config.yaml` (the single most important file the agent owns), `fleet.json`, `remotes.json`, and `workspace.yaml` were written with a bare `open(path, "w")` — a crash/power-loss mid-dump left a truncated file. Worse, the fleet registries silently swallowed the resulting `JSONDecodeError` into `{}`: every running agent forgotten (orphaned processes holding ports), every remote member **including its stored bearer token** dropped, zero log lines. The codebase already knew the right pattern (`save_secrets` does tmp+`os.replace`) — it just never propagated.
→ New `paths.atomic_write(path, text, mode=None)` (same-dir temp + `os.replace`, mode applied **before** the swap), adopted at all four sites. Corrupt registries still load tolerantly but now WARN loudly.

**N3 — `remotes.json` world-readable.** It carries remote members' bearer tokens; its comment claimed "same posture as secrets.yaml" but secrets.yaml is 0600 and remotes.json was 0644. Now written 0600 atomically; comment corrected to true.

**N1 — no lock on config RMW + graph reload.** All settings-write callers run on worker threads, and the fleet hub makes concurrent saves routine (two console windows; a settings save racing a plugin-enable). Each did `load_yaml → apply → save` on the same file (classic lost-update) and could interleave `_reload_langgraph_agent`'s build-then-commit choreography (graph A committed with `STATE.graph_config` B).
→ `_CONFIG_WRITE_LOCK` (RLock — `_apply_settings_changes` nests into `_reload_langgraph_agent`, which plugin routes also call directly) via a `@_serialized_config_write` decorator on all three.

## Tests
`tests/test_atomic_writes.py` — 10 new: atomic_write semantics (content, replace, mode-before-swap, no temp droppings), corrupt-registry warn+empty for both fleet files, remotes 0600 round-trip, save_yaml_doc atomicity, and a 4-thread overlap test proving `_apply_settings_changes` serializes. Config/settings suites (317) + fleet/workspace suites (76) green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)