### PR TITLE
refactor(web): decompose theme.css — carve activity/schedule/settings/plugins (#832 Axis-A, final)

### DIFF
--- a/apps/web/src/activity/ActivitySurface.tsx
+++ b/apps/web/src/activity/ActivitySurface.tsx
@@ -1,3 +1,5 @@
+import "./activity.css";
+
 import { Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
 import { Clock, Inbox, Loader2, MessageSquare, RefreshCw, Send, Users, Webhook, Zap } from "lucide-react";

--- a/apps/web/src/activity/activity.css
+++ b/apps/web/src/activity/activity.css
@@ -1,0 +1,102 @@
+/* Activity surface (ADR 0003) — moved from app/theme.css (#832). The rail badge
+   (.rail-badge) + the background-stream rail dot (.rail-dot) stay in theme.css:
+   they style the always-mounted shell rail buttons, not the Activity surface. */
+.activity-body {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
+
+.activity-log {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.activity-empty {
+  color: var(--fg-secondary);
+  font-size: 13px;
+  margin: auto;
+  text-align: center;
+  max-width: 36ch;
+}
+
+.activity-msg {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.activity-role {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-tertiary, var(--fg-secondary));
+}
+
+.activity-content {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 8px 12px;
+  background: var(--bg-elevated, #111114);
+  font-size: 14px;
+}
+
+.activity-user .activity-content {
+  background: color-mix(in srgb, var(--accent, #7c8cff) 12%, transparent);
+}
+
+.activity-composer {
+  display: flex;
+  gap: 8px;
+  padding: 12px;
+  border-top: 1px solid var(--border);
+}
+
+.activity-composer textarea {
+  flex: 1;
+  resize: none;
+}
+
+/* Activity provenance feed (ADR 0022) ------------------------------------- */
+.activity-feed {
+  flex: 1;
+  overflow-y: auto;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.activity-entry {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+}
+.activity-prov {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  font-size: 11px;
+}
+.activity-origin {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 2px 7px;
+  border-radius: 999px;
+  font-weight: 600;
+  border: 1px solid var(--border);
+  color: var(--fg-secondary);
+}
+.activity-origin svg { flex: 0 0 auto; }
+.activity-origin-scheduler { color: #818cf8; border-color: color-mix(in srgb, #818cf8 45%, var(--border)); }
+.activity-origin-inbox     { color: #34d399; border-color: color-mix(in srgb, #34d399 45%, var(--border)); }
+.activity-origin-webhook   { color: #fbbf24; border-color: color-mix(in srgb, #fbbf24 45%, var(--border)); }
+.activity-origin-a2a       { color: #f472b6; border-color: color-mix(in srgb, #f472b6 45%, var(--border)); }
+.activity-origin-operator  { color: var(--accent, #7c8cff); border-color: color-mix(in srgb, var(--accent, #7c8cff) 45%, var(--border)); }
+.activity-trigger { font-family: var(--font-mono, ui-monospace, monospace); color: var(--fg-secondary); }
+.activity-time { margin-left: auto; color: var(--fg-tertiary, var(--fg-secondary)); }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -411,38 +411,10 @@ select:disabled {
   overflow: auto;
 }
 
-/* Plugins → Marketplace: discovery links (directory + GitHub topic). */
-.plugin-market {
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.plugin-market-link {
-  display: flex;
-  align-items: center;
-  gap: 12px;
-  padding: 10px 12px;
-  border-radius: 8px;
-  border: 1px solid var(--pl-color-border);
-  background: var(--pl-color-bg-raised);
-  color: inherit;
-  text-decoration: none;
-  transition: border-color 0.15s;
-}
-.plugin-market-link:hover {
-  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 45%, transparent);
-}
-.plugin-market-link > span {
-  display: flex;
-  flex-direction: column;
-  flex: 1;
-  gap: 1px;
-}
-.plugin-market-link .muted {
-  font-size: 12px;
-}
+/* Plugins → Marketplace (.plugin-market*) — moved to src/settings/plugins.css (#832). */
 
-/* Plugins → Installed: per-row enable/disable + the result hint. */
+/* Plugins → Installed: per-row enable/disable + the result hint. Shared with the
+   MCP panel (McpPanel renders .plugin-row-actions + .plugin-hint), so they stay here. */
 .plugin-row-actions {
   display: flex;
   align-items: center;
@@ -779,105 +751,7 @@ textarea {
   position: relative;
 }
 
-.activity-body {
-  display: flex;
-  flex-direction: column;
-  min-height: 0;
-}
-
-.activity-log {
-  flex: 1;
-  overflow-y: auto;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-
-.activity-empty {
-  color: var(--fg-secondary);
-  font-size: 13px;
-  margin: auto;
-  text-align: center;
-  max-width: 36ch;
-}
-
-.activity-msg {
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-}
-
-.activity-role {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.05em;
-  color: var(--fg-tertiary, var(--fg-secondary));
-}
-
-.activity-content {
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  padding: 8px 12px;
-  background: var(--bg-elevated, #111114);
-  font-size: 14px;
-}
-
-.activity-user .activity-content {
-  background: color-mix(in srgb, var(--accent, #7c8cff) 12%, transparent);
-}
-
-.activity-composer {
-  display: flex;
-  gap: 8px;
-  padding: 12px;
-  border-top: 1px solid var(--border);
-}
-
-.activity-composer textarea {
-  flex: 1;
-  resize: none;
-}
-
-/* Activity provenance feed (ADR 0022) ------------------------------------- */
-.activity-feed {
-  flex: 1;
-  overflow-y: auto;
-  padding: 12px;
-  display: flex;
-  flex-direction: column;
-  gap: 14px;
-}
-.activity-entry {
-  display: flex;
-  flex-direction: column;
-  gap: 5px;
-}
-.activity-prov {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  flex-wrap: wrap;
-  font-size: 11px;
-}
-.activity-origin {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  padding: 2px 7px;
-  border-radius: 999px;
-  font-weight: 600;
-  border: 1px solid var(--border);
-  color: var(--fg-secondary);
-}
-.activity-origin svg { flex: 0 0 auto; }
-.activity-origin-scheduler { color: #818cf8; border-color: color-mix(in srgb, #818cf8 45%, var(--border)); }
-.activity-origin-inbox     { color: #34d399; border-color: color-mix(in srgb, #34d399 45%, var(--border)); }
-.activity-origin-webhook   { color: #fbbf24; border-color: color-mix(in srgb, #fbbf24 45%, var(--border)); }
-.activity-origin-a2a       { color: #f472b6; border-color: color-mix(in srgb, #f472b6 45%, var(--border)); }
-.activity-origin-operator  { color: var(--accent, #7c8cff); border-color: color-mix(in srgb, var(--accent, #7c8cff) 45%, var(--border)); }
-.activity-trigger { font-family: var(--font-mono, ui-monospace, monospace); color: var(--fg-secondary); }
-.activity-time { margin-left: auto; color: var(--fg-tertiary, var(--fg-secondary)); }
+/* Activity surface + provenance feed (.activity-*) — moved to src/activity/activity.css (#832). */
 
 /* In-surface sub-nav (grouped rail surfaces) ------------------------------- */
 /* The sub-tab strip is now @protolabsai/ui <Tabs> (.pl-tabs/.pl-tab); the inbox
@@ -1362,57 +1236,7 @@ textarea {
   margin-top: 18px;
 }
 
-/* New-schedule modal (friendly builder) */
-.schedule-card {
-  width: min(560px, 100%);
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.schedule-card .confirm-head { position: relative; }
-.schedule-close {
-  margin-left: auto;
-}
-.schedule-modes {
-  display: inline-flex;
-  gap: 4px;
-  padding: 3px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  align-self: flex-start;
-}
-.schedule-modes button {
-  border: none;
-  background: transparent;
-  color: var(--fg-secondary);
-  padding: 5px 14px;
-  border-radius: 6px;
-  font-size: 13px;
-  cursor: pointer;
-}
-.schedule-modes button.active {
-  background: var(--accent, #9b87f2);
-  color: #0a0a0c;
-}
-.schedule-repeat {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 12px;
-}
-.schedule-preview {
-  margin: 0;
-  font-size: 13px;
-  color: var(--fg-secondary);
-}
-.schedule-preview code {
-  margin-left: 8px;
-  padding: 1px 6px;
-  border-radius: 4px;
-  background: var(--bg-raised, #131316);
-  border: 1px solid var(--border);
-  font-size: 12px;
-}
-.schedule-preview .muted { color: var(--fg-muted, #71717a); }
+/* New-schedule modal (friendly builder, .schedule-*) — moved to src/schedule/schedule.css (#832). */
 
 .setup-frame {
   width: min(720px, 100%);
@@ -1719,29 +1543,15 @@ textarea {
 }
 
 /* ── Settings surface ─────────────────────────────────────────────────────── */
-/* Banners are DS Alert (pl-alert) now — only the stage spacing lives here. */
-.settings-banner {
-  margin-bottom: 10px;
-}
+/* The settings-form chrome (.settings-banner/.settings-group*/.setting-*, ADR 0047
+   .setting-inheritance) moved to src/settings/settings.css (#832). Left here, shared:
+   .settings-status (SchedulePanel renders it too) + the .settings-help-link / .setup-link
+   rule (it pairs the setup wizard's link styling). */
 .settings-status {
   margin: 0 0 10px;
   font-size: 0.8rem;
   color: var(--fg-muted);
   font-family: var(--font-mono);
-}
-.settings-group {
-  margin-bottom: 40px;
-}
-/* Per-group action row (e.g. the Discord "Test connection" + help link). */
-.settings-group-actions {
-  display: flex;
-  align-items: center;
-  gap: 14px;
-  margin-top: 10px;
-}
-.settings-inline-status {
-  font-size: 0.8rem;
-  color: var(--fg-muted);
 }
 .settings-help-link,
 .setup-link {
@@ -1755,88 +1565,6 @@ textarea {
 .settings-help-link:hover,
 .setup-link:hover {
   text-decoration: underline;
-}
-.settings-group-title {
-  margin: 0 0 4px;
-  font-size: 0.72rem;
-  letter-spacing: 0.06em;
-  text-transform: uppercase;
-  color: var(--brand-violet-light);
-  border-bottom: 1px solid var(--border);
-  padding-bottom: 8px;
-}
-.setting-row {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
-  gap: 28px;
-  align-items: center;
-  padding: 26px 6px;
-  border-bottom: 1px solid var(--border);
-}
-.setting-row.dirty {
-  /* subtle marker that this field has unsaved edits */
-  box-shadow: inset 2px 0 0 var(--brand-violet);
-  padding-left: 10px;
-}
-.setting-meta { min-width: 0; }
-.setting-label {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  font-size: 0.86rem;
-  color: var(--fg);
-}
-.setting-restart {
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: rgba(212, 189, 79, 0.16);
-  border: 1px solid rgba(212, 189, 79, 0.3);
-  color: #eadf9a;
-  font-size: 0.62rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
-.setting-desc {
-  margin: 3px 0 0;
-  font-size: 0.76rem;
-  line-height: 1.45;
-  color: var(--fg-muted);
-}
-/* ADR 0047 inheritance row — the source Badge + reset-to-inherited link aligned. */
-.setting-inheritance {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  margin: 5px 0 0;
-}
-.setting-control { min-width: 0; }
-.setting-input {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 11px 12px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--fg);
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-}
-.setting-input:focus {
-  outline: none;
-  border-color: var(--brand-violet);
-}
-.setting-textarea {
-  resize: vertical;
-  line-height: 1.45;
-}
-.setting-toggle {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-  color: var(--fg-secondary);
-  cursor: pointer;
 }
 
 /* Telemetry dashboard + insights (ADR 0006 Slices 3–4) — the .telemetry-* / .turn-state* /
@@ -1899,25 +1627,11 @@ textarea {
 .plugin-view-frame { width: 100%; height: 100%; border: 0; background: var(--bg); display: block; }
 .plugin-view-state { display: flex; align-items: center; gap: 8px; padding: 24px; color: var(--fg-muted); font-size: 13px; }
 
-/* Plugins panel (ADR 0027) — install from a git URL, under Settings → Integrations. */
-.plugin-install-form { display: flex; gap: 8px; margin: 10px 0; flex-wrap: wrap; }
-.plugin-install-form input { flex: 1; min-width: 220px; padding: 7px 10px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 7px; color: var(--fg); font-size: 13px; }
-.plugin-install-status { font-size: 12px; color: var(--fg-secondary); margin: 4px 0 10px; }
-.plugin-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+/* Plugins panel (ADR 0027, .plugin-install-*/.plugin-list/.plugin-row-main/-title/
+   .plugin-ver/.plugin-state/.plugin-desc/.plugin-meta/.plugin-review/.plugin-enable-hint
+   + .btn-icon.danger:hover) — moved to src/settings/plugins.css (#832). The bare
+   .plugin-row stays here: it's shared with the MCP panel + the Plugins surface. */
 .plugin-row { display: flex; align-items: flex-start; gap: 10px; padding: 12px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 9px; }
-.plugin-row-main { flex: 1; min-width: 0; }
-.plugin-row-title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.plugin-ver { font-size: 11px; color: var(--fg-muted); }
-.plugin-state { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; padding: 1px 6px; border-radius: 999px; }
-.plugin-state.on { background: rgba(70,196,106,.15); color: #46c46a; }
-.plugin-state.off { background: var(--bg-hover); color: var(--fg-muted); }
-.plugin-state.warn { background: rgba(245,180,80,.15); color: #f5b450; display: inline-flex; align-items: center; gap: 3px; }
-.plugin-desc { font-size: 12px; color: var(--fg-secondary); margin: 4px 0; }
-.plugin-meta { font-size: 11px; color: var(--fg-muted); margin: 2px 0; overflow: hidden; text-overflow: ellipsis; }
-.plugin-review { font-size: 11px; color: var(--fg-muted); margin: 4px 0 0; display: flex; flex-wrap: wrap; gap: 4px 12px; }
-.plugin-review .warn { color: #f5b450; display: inline-flex; align-items: center; gap: 3px; }
-.plugin-enable-hint { font-size: 11px; color: var(--fg-secondary); margin: 6px 0 0; }
-.btn-icon.danger:hover { color: #ef6b6b; }
 
 /* Federated plugin view (ADR 0034) — loading + bounded error card (D6). */
 .federated-loading,

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -1,3 +1,5 @@
+import "../settings/plugins.css";
+
 import { Button } from "@protolabsai/ui/primitives";
 import { QueryErrorResetBoundary, useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -1,3 +1,5 @@
+import "./schedule.css";
+
 import { Input, Select, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
 import {

--- a/apps/web/src/schedule/schedule.css
+++ b/apps/web/src/schedule/schedule.css
@@ -1,0 +1,53 @@
+/* New-schedule modal (friendly builder) — moved from app/theme.css (#832). The
+   generic .confirm-* destructive-action modal chrome stays in theme.css (shared);
+   .schedule-card composes onto .confirm-card. */
+.schedule-card {
+  width: min(560px, 100%);
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.schedule-card .confirm-head { position: relative; }
+.schedule-close {
+  margin-left: auto;
+}
+.schedule-modes {
+  display: inline-flex;
+  gap: 4px;
+  padding: 3px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  align-self: flex-start;
+}
+.schedule-modes button {
+  border: none;
+  background: transparent;
+  color: var(--fg-secondary);
+  padding: 5px 14px;
+  border-radius: 6px;
+  font-size: 13px;
+  cursor: pointer;
+}
+.schedule-modes button.active {
+  background: var(--accent, #9b87f2);
+  color: #0a0a0c;
+}
+.schedule-repeat {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: 12px;
+}
+.schedule-preview {
+  margin: 0;
+  font-size: 13px;
+  color: var(--fg-secondary);
+}
+.schedule-preview code {
+  margin-left: 8px;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--bg-raised, #131316);
+  border: 1px solid var(--border);
+  font-size: 12px;
+}
+.schedule-preview .muted { color: var(--fg-muted, #71717a); }

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -1,3 +1,4 @@
+import "./settings.css";
 import "./delegates.css";
 
 import { Input, Select, Textarea } from "@protolabsai/ui/forms";

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -1,3 +1,5 @@
+import "./plugins.css";
+
 import { Input } from "@protolabsai/ui/forms";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, Loader2, Package, Plus, ShieldAlert, Trash2 } from "lucide-react";

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -1,3 +1,5 @@
+import "./settings.css";
+
 import { Alert } from "@protolabsai/ui/data";
 import { Input, Select, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -1,0 +1,54 @@
+/* Plugins panel — moved from app/theme.css (#832). The settings-panel-exclusive
+   install/list/marketplace UI (PluginsSection + PluginsSurface). Left in theme.css:
+   .plugin-row / .plugin-row-actions / .plugin-hint (shared with the MCP panel), the
+   .plugin-view* host (ADR 0026), and the .federated-* federated view card (ADR 0034). */
+
+/* Plugins → Marketplace: discovery links (directory + GitHub topic). */
+.plugin-market {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.plugin-market-link {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid var(--pl-color-border);
+  background: var(--pl-color-bg-raised);
+  color: inherit;
+  text-decoration: none;
+  transition: border-color 0.15s;
+}
+.plugin-market-link:hover {
+  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 45%, transparent);
+}
+.plugin-market-link > span {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  gap: 1px;
+}
+.plugin-market-link .muted {
+  font-size: 12px;
+}
+
+/* Plugins panel (ADR 0027) — install from a git URL, under Settings → Integrations. */
+.plugin-install-form { display: flex; gap: 8px; margin: 10px 0; flex-wrap: wrap; }
+.plugin-install-form input { flex: 1; min-width: 220px; padding: 7px 10px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 7px; color: var(--fg); font-size: 13px; }
+.plugin-install-status { font-size: 12px; color: var(--fg-secondary); margin: 4px 0 10px; }
+.plugin-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
+.plugin-row-main { flex: 1; min-width: 0; }
+.plugin-row-title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.plugin-ver { font-size: 11px; color: var(--fg-muted); }
+.plugin-state { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; padding: 1px 6px; border-radius: 999px; }
+.plugin-state.on { background: rgba(70,196,106,.15); color: #46c46a; }
+.plugin-state.off { background: var(--bg-hover); color: var(--fg-muted); }
+.plugin-state.warn { background: rgba(245,180,80,.15); color: #f5b450; display: inline-flex; align-items: center; gap: 3px; }
+.plugin-desc { font-size: 12px; color: var(--fg-secondary); margin: 4px 0; }
+.plugin-meta { font-size: 11px; color: var(--fg-muted); margin: 2px 0; overflow: hidden; text-overflow: ellipsis; }
+.plugin-review { font-size: 11px; color: var(--fg-muted); margin: 4px 0 0; display: flex; flex-wrap: wrap; gap: 4px 12px; }
+.plugin-review .warn { color: #f5b450; display: inline-flex; align-items: center; gap: 3px; }
+.plugin-enable-hint { font-size: 11px; color: var(--fg-secondary); margin: 6px 0 0; }
+.btn-icon.danger:hover { color: #ef6b6b; }

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -1,0 +1,105 @@
+/* ── Settings surface ─────────────────────────────────────────────────────── */
+/* Moved from app/theme.css (#832) — settings-form chrome rendered by
+   SettingsCategory + the DelegatesSection footer. Banners are DS Alert (pl-alert)
+   now; only the stage spacing lives here. Left in theme.css: .settings-status
+   (also rendered by SchedulePanel) and the .settings-help-link / .setup-link rule
+   (it pairs the setup wizard's link styling). */
+.settings-banner {
+  margin-bottom: 10px;
+}
+.settings-group {
+  margin-bottom: 40px;
+}
+/* Per-group action row (e.g. the Discord "Test connection" + help link). */
+.settings-group-actions {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  margin-top: 10px;
+}
+.settings-inline-status {
+  font-size: 0.8rem;
+  color: var(--fg-muted);
+}
+.settings-group-title {
+  margin: 0 0 4px;
+  font-size: 0.72rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--brand-violet-light);
+  border-bottom: 1px solid var(--border);
+  padding-bottom: 8px;
+}
+.setting-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(220px, 320px);
+  gap: 28px;
+  align-items: center;
+  padding: 26px 6px;
+  border-bottom: 1px solid var(--border);
+}
+.setting-row.dirty {
+  /* subtle marker that this field has unsaved edits */
+  box-shadow: inset 2px 0 0 var(--brand-violet);
+  padding-left: 10px;
+}
+.setting-meta { min-width: 0; }
+.setting-label {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  font-size: 0.86rem;
+  color: var(--fg);
+}
+.setting-restart {
+  padding: 1px 6px;
+  border-radius: 999px;
+  background: rgba(212, 189, 79, 0.16);
+  border: 1px solid rgba(212, 189, 79, 0.3);
+  color: #eadf9a;
+  font-size: 0.62rem;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.setting-desc {
+  margin: 3px 0 0;
+  font-size: 0.76rem;
+  line-height: 1.45;
+  color: var(--fg-muted);
+}
+/* ADR 0047 inheritance row — the source Badge + reset-to-inherited link aligned. */
+.setting-inheritance {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin: 5px 0 0;
+}
+.setting-control { min-width: 0; }
+.setting-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 11px 12px;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  color: var(--fg);
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+}
+.setting-input:focus {
+  outline: none;
+  border-color: var(--brand-violet);
+}
+.setting-textarea {
+  resize: vertical;
+  line-height: 1.45;
+}
+.setting-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  font-family: var(--font-mono);
+  font-size: 0.8rem;
+  color: var(--fg-secondary);
+  cursor: pointer;
+}


### PR DESCRIPTION
#832 Axis-A, final step: extract the last surface-exclusive sections. After this the residual `theme.css` is genuinely-shared shell/base — which #832 says stays. **Pure reorg — zero visual change.**

## What moved
| Module | Imported by | Contents |
|---|---|---|
| `activity/activity.css` (102) | ActivitySurface | `.activity-*` + ADR 0022 provenance feed |
| `schedule/schedule.css` (53) | SchedulePanel | the new-schedule friendly builder |
| `settings/settings.css` (105) | SettingsCategory + Delegates | settings-form chrome + ADR 0047 inheritance row |
| `settings/plugins.css` (54) | PluginsSection + PluginsSurface | Marketplace + install/list panel |

`theme.css` **2204 → 1918** (−286). **Axis-A complete: 3387 → 1918** across the four carve PRs.

## Why it's safe
- Rule multiset **byte-identical** (brace-count + sorted-diff: 281 CSS lines each side, nothing lost/duplicated/reordered).
- Every moved selector grep-verified exclusive to its surface.
- `npm run build` clean + **e2e 89/89**.

## Deliberately left shared (verified cross-surface)
- The **rail badge/dot + `.rail button`** (always-mounted shell, not activity).
- The generic **`.confirm-*`** destructive modal (shared primitive).
- **`.settings-status`** (also SchedulePanel), the **`.setup-link`** half of the help-link rule (SetupWizard), **`.plugin-row*`** (McpPanel).
- **`.plugin-view*`/`.federated-*`** — the plugin *view host* (ADR 0026/0034), not the settings panel.
- All shell/panel/markdown/scroll/suspense/mobile/topbar chrome.

`settings.css` is imported in `SettingsCategory` (the actual renderer — the Agent + Knowledge tabs mount it directly, bypassing `SettingsSurface`), so all three call sites are covered.

This finishes **Axis-A**. Remaining for #832/#842: the Axis-B DS shrink (`ToolCard`/`TabBar`/pills/`Empty`/`Grid`) + per-surface light-mode hex tokenization — **draft PRs for your local visual pass** (CI can't judge rendering).

🤖 Generated with [Claude Code](https://claude.com/claude-code)