### PR TITLE
fix(web): tokenize raw colors so they flip in light mode (#842)

### DIFF
--- a/apps/web/src/activity/activity.css
+++ b/apps/web/src/activity/activity.css
@@ -93,9 +93,9 @@
   color: var(--fg-secondary);
 }
 .activity-origin svg { flex: 0 0 auto; }
-.activity-origin-scheduler { color: #818cf8; border-color: color-mix(in srgb, #818cf8 45%, var(--border)); }
-.activity-origin-inbox     { color: #34d399; border-color: color-mix(in srgb, #34d399 45%, var(--border)); }
-.activity-origin-webhook   { color: #fbbf24; border-color: color-mix(in srgb, #fbbf24 45%, var(--border)); }
+.activity-origin-scheduler { color: var(--brand-indigo-bright); border-color: color-mix(in srgb, var(--brand-indigo-bright) 45%, var(--border)); }
+.activity-origin-inbox     { color: var(--success); border-color: color-mix(in srgb, var(--success) 45%, var(--border)); }
+.activity-origin-webhook   { color: var(--warning); border-color: color-mix(in srgb, var(--warning) 45%, var(--border)); }
 .activity-origin-a2a       { color: #f472b6; border-color: color-mix(in srgb, #f472b6 45%, var(--border)); }
 .activity-origin-operator  { color: var(--accent, #7c8cff); border-color: color-mix(in srgb, var(--accent, #7c8cff) 45%, var(--border)); }
 .activity-trigger { font-family: var(--font-mono, ui-monospace, monospace); color: var(--fg-secondary); }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -396,10 +396,10 @@ select:disabled {
   align-items: center;
   gap: 8px;
   margin-bottom: 10px;
-  border: 1px solid rgba(240, 116, 88, 0.3);
+  border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
   border-radius: var(--radius);
-  background: rgba(240, 116, 88, 0.14);
-  color: #f4b09f;
+  background: color-mix(in srgb, var(--error) 14%, transparent);
+  color: var(--error);
   padding: 8px 10px;
 }
 
@@ -705,7 +705,7 @@ textarea {
   margin: 0 12px 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: #08080a;
+  background: var(--pl-color-bg-inset);
   padding: 10px;
   color: var(--fg-secondary);
   font-family: var(--font-mono);
@@ -739,7 +739,7 @@ textarea {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: #46c46a;
+  background: var(--success);
   animation: rail-dot-pulse 1.4s ease-in-out infinite;
 }
 @keyframes rail-dot-pulse {
@@ -989,11 +989,11 @@ textarea {
   padding: 12px;
   border: 1px solid var(--border);
   border-radius: var(--radius);
-  background: rgba(220, 60, 60, 0.06);
+  background: color-mix(in srgb, var(--error) 6%, transparent);
 }
 
 .panel-error svg:first-child {
-  color: #e0564f;
+  color: var(--error);
 }
 
 .panel-error > div {
@@ -1040,7 +1040,7 @@ textarea {
   justify-content: space-between;
   gap: 8px;
   border-bottom: 1px solid var(--border);
-  background: #0c0c0f;
+  background: var(--pl-color-bg-inset);
   padding: 6px 10px;
   color: var(--fg-muted);
   font-family: var(--font-mono);
@@ -1182,7 +1182,7 @@ textarea {
   display: grid;
   place-items: center;
   overflow: auto;
-  background: rgba(10, 10, 12, 0.98);
+  background: color-mix(in srgb, var(--pl-color-bg) 98%, transparent);
   padding: 24px;
 }
 
@@ -1193,7 +1193,7 @@ textarea {
   z-index: 200;
   display: grid;
   place-items: center;
-  background: rgba(10, 10, 12, 0.6);
+  background: var(--pl-color-overlay);
   padding: 24px;
 }
 
@@ -1203,7 +1203,7 @@ textarea {
   border-radius: 12px;
   background: var(--bg-elevated, #16161a);
   padding: 18px 18px 14px;
-  box-shadow: 0 12px 40px rgba(0, 0, 0, 0.5);
+  box-shadow: var(--pl-shadow-popover);
 }
 
 .confirm-head {
@@ -1294,7 +1294,7 @@ textarea {
   height: 34px;
   display: grid;
   place-items: center;
-  border: 1px solid rgba(124, 58, 237, 0.36);
+  border: 1px solid color-mix(in srgb, var(--brand-violet) 36%, transparent);
   border-radius: var(--radius);
   color: var(--brand-violet-light);
 }
@@ -1377,15 +1377,15 @@ textarea {
 }
 
 .setup-error {
-  border: 1px solid rgba(240, 116, 88, 0.3);
-  background: rgba(240, 116, 88, 0.14);
-  color: #f4b09f;
+  border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
+  background: color-mix(in srgb, var(--error) 14%, transparent);
+  color: var(--error);
 }
 
 .setup-message {
-  border: 1px solid rgba(65, 196, 141, 0.28);
-  background: rgba(65, 196, 141, 0.16);
-  color: #a9e8c9;
+  border: 1px solid color-mix(in srgb, var(--success) 28%, transparent);
+  background: color-mix(in srgb, var(--success) 16%, transparent);
+  color: var(--success);
 }
 
 /* "Test connection" result line in the model step. */
@@ -1401,15 +1401,15 @@ textarea {
 }
 
 .setup-test.ok {
-  border: 1px solid rgba(65, 196, 141, 0.28);
-  background: rgba(65, 196, 141, 0.12);
-  color: #a9e8c9;
+  border: 1px solid color-mix(in srgb, var(--success) 28%, transparent);
+  background: color-mix(in srgb, var(--success) 12%, transparent);
+  color: var(--success);
 }
 
 .setup-test.err {
-  border: 1px solid rgba(240, 116, 88, 0.3);
-  background: rgba(240, 116, 88, 0.12);
-  color: #f4b09f;
+  border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
+  background: color-mix(in srgb, var(--error) 12%, transparent);
+  color: var(--error);
 }
 
 .setup-test svg {
@@ -1559,7 +1559,7 @@ textarea {
   align-items: center;
   gap: 4px;
   font-size: 0.8rem;
-  color: #818cf8;
+  color: var(--brand-indigo-bright);
   text-decoration: none;
 }
 .settings-help-link:hover,
@@ -1644,7 +1644,7 @@ textarea {
   color: var(--fg-muted);
 }
 .federated-loading { align-items: center; }
-.federated-error { color: #eadf9a; }
+.federated-error { color: var(--warning); }
 .federated-error strong { color: var(--fg); }
 .federated-error-detail {
   margin: 4px 0 8px;
@@ -1769,8 +1769,8 @@ textarea {
   background: var(--fg-muted);
 }
 .fleet-dot.running {
-  background: #34d399;
-  box-shadow: 0 0 6px rgba(52, 211, 153, 0.5);
+  background: var(--success);
+  box-shadow: 0 0 6px color-mix(in srgb, var(--success) 50%, transparent);
 }
 .fleet-dot.stopped {
   opacity: 0.45;
@@ -1860,7 +1860,7 @@ textarea {
   border: 1px solid var(--border);
   border-radius: var(--radius);
   background: var(--bg-panel);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.3);
+  box-shadow: var(--pl-shadow-popover);
   display: flex;
   flex-direction: column;
   gap: 1px;

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -212,7 +212,7 @@
   background: var(--bg-raised);
   border: 1px solid var(--border-strong);
   border-radius: var(--radius);
-  box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+  box-shadow: var(--pl-shadow-popover);
 }
 .slash-item {
   display: flex;

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -250,9 +250,9 @@
   gap: 6px;
   padding: 6px 8px;
   border-radius: 6px;
-  background: rgba(240, 116, 88, 0.12);
-  border: 1px solid rgba(240, 116, 88, 0.28);
-  color: #f4b09f;
+  background: color-mix(in srgb, var(--error) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--error) 28%, transparent);
+  color: var(--error);
   font-size: 0.8rem;
   line-height: 1.45;
 }
@@ -313,9 +313,9 @@
   flex: none;
   padding: 1px 6px;
   border-radius: 5px;
-  background: rgba(65, 196, 141, 0.16);
-  border: 1px solid rgba(65, 196, 141, 0.28);
-  color: #a9e8c9;
+  background: color-mix(in srgb, var(--success) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--success) 28%, transparent);
+  color: var(--success);
   font-family: var(--font-mono);
   font-size: 0.72rem;
 }

--- a/apps/web/src/fleet/fleet.css
+++ b/apps/web/src/fleet/fleet.css
@@ -66,7 +66,7 @@
   margin: 4px 0 8px;
 }
 .fleet-error {
-  color: #f87171;
+  color: var(--error);
   margin-bottom: 10px;
 }
 .fleet-purge {

--- a/apps/web/src/schedule/schedule.css
+++ b/apps/web/src/schedule/schedule.css
@@ -30,7 +30,7 @@
 }
 .schedule-modes button.active {
   background: var(--accent, #9b87f2);
-  color: #0a0a0c;
+  color: var(--pl-color-fg-on-accent);
 }
 .schedule-repeat {
   display: grid;

--- a/apps/web/src/settings/delegates.css
+++ b/apps/web/src/settings/delegates.css
@@ -10,7 +10,7 @@
   border: 1px solid var(--border);
   color: var(--brand-violet-light);
 }
-.delegate-badge-warn { font-size: 10px; color: #e0a23a; }
+.delegate-badge-warn { font-size: 10px; color: var(--warning); }
 .delegate-badge-ok { font-size: 10px; color: var(--fg-muted); }
 .delegate-form {
   margin-top: 14px;
@@ -40,6 +40,6 @@
 .delegate-type-tile-blurb { font-size: 11px; color: var(--fg-muted); }
 .delegate-field-help { font-size: 11px; color: var(--fg-muted); }
 .delegate-health { font-size: 10px; line-height: 1; }
-.delegate-health.ok { color: #46c46a; }
-.delegate-health.down { color: #e0533a; }
+.delegate-health.ok { color: var(--success); }
+.delegate-health.down { color: var(--error); }
 .delegate-health.unknown { color: var(--fg-muted); }

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -43,12 +43,12 @@
 .plugin-row-title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .plugin-ver { font-size: 11px; color: var(--fg-muted); }
 .plugin-state { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; padding: 1px 6px; border-radius: 999px; }
-.plugin-state.on { background: rgba(70,196,106,.15); color: #46c46a; }
+.plugin-state.on { background: color-mix(in srgb, var(--success) 15%, transparent); color: var(--success); }
 .plugin-state.off { background: var(--bg-hover); color: var(--fg-muted); }
-.plugin-state.warn { background: rgba(245,180,80,.15); color: #f5b450; display: inline-flex; align-items: center; gap: 3px; }
+.plugin-state.warn { background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning); display: inline-flex; align-items: center; gap: 3px; }
 .plugin-desc { font-size: 12px; color: var(--fg-secondary); margin: 4px 0; }
 .plugin-meta { font-size: 11px; color: var(--fg-muted); margin: 2px 0; overflow: hidden; text-overflow: ellipsis; }
 .plugin-review { font-size: 11px; color: var(--fg-muted); margin: 4px 0 0; display: flex; flex-wrap: wrap; gap: 4px 12px; }
-.plugin-review .warn { color: #f5b450; display: inline-flex; align-items: center; gap: 3px; }
+.plugin-review .warn { color: var(--warning); display: inline-flex; align-items: center; gap: 3px; }
 .plugin-enable-hint { font-size: 11px; color: var(--fg-secondary); margin: 6px 0 0; }
-.btn-icon.danger:hover { color: #ef6b6b; }
+.btn-icon.danger:hover { color: var(--danger); }

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -54,9 +54,9 @@
 .setting-restart {
   padding: 1px 6px;
   border-radius: 999px;
-  background: rgba(212, 189, 79, 0.16);
-  border: 1px solid rgba(212, 189, 79, 0.3);
-  color: #eadf9a;
+  background: color-mix(in srgb, var(--warning) 16%, transparent);
+  border: 1px solid color-mix(in srgb, var(--warning) 30%, transparent);
+  color: var(--warning);
   font-size: 0.62rem;
   letter-spacing: 0.05em;
   text-transform: uppercase;


### PR DESCRIPTION
**Draft for your local light-mode pass** — closes the #842 long tail. CI can't judge rendering, so this is up for your eye before merge.

The #854 aliases already fixed the big offenders (`--bg-elevated`/`--danger`/`--fg-tertiary`). This tokenizes the remaining **~40 raw colors** across `theme.css` + the carved modules so they flip too. Each raw color → the `@protolabsai/design` token whose **dark value matches** (dark stays ~the same; light now flips). **+51/−51, color values only.** build + e2e **89/89** green (e2e runs dark → confirms dark didn't structurally break).

## ✅ The #842 repro is fixed
The Scheduler "New schedule" modal now flips end-to-end: overlay scrim → `var(--pl-color-overlay)`, card shadow/bg, and the active-mode button text (`#0a0a0c` → `--pl-color-fg-on-accent`, which was invisible in light mode).

## What to eyeball (judgment calls — veto any)
1. **Status *text* is more saturated in dark.** Originals were pale tints (`#f4b09f` salmon, `#a9e8c9` mint, `#eadf9a` pale-yellow) chosen as light text on dark washes; they now use the saturated semantic tokens (`var(--error)`/`--success`/`--warning`). Consistent with how DS Alert colors text, and no contrast loss — but it's a visible dark-mode shift. If you prefer the pastel look I can `color-mix` toward `--fg` to keep it pale while still flipping.
2. **3 brand-literal spots don't flip** (intentional): `--brand-indigo-bright` (#818cf8) on the help-link + scheduler-origin dot, `--brand-violet` (#7c3aed) on the setup-icon border. Brand accents are theme-fixed (like a logo) — flagging since strictly they have no light variant.
3. **Shadow geometry shifts slightly** on `.confirm-card`/`.slash-menu`/fleet switcher (adopted the composite `--pl-shadow-popover` token: `0 8px 28px` vs the old `0 12px 40px`, same alpha).

## Left raw on purpose (no suitable token)
- The **hljs syntax palette** (decorative Material-Palenight code theme — not chrome).
- **a2a-origin pink** `#f472b6` (no DS magenta/pink token — candidate to file upstream).
- **white-on-accent badge text** (`#fff` on `.rail-badge`/`.inbox-pri`) — the on-accent token resolves near-black in dark, which would invert the deliberate white-on-fill contrast.

With this, **#842 is substantively complete** (aliases + tokenization). Remaining for #832: the Axis-B DS-component shrink (`ToolCard`/`TabBar`/pills/`Empty`/`Grid`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)