### PR TITLE
refactor(web): adopt DS Empty / Grid / Badge, delete bespoke CSS (#832 Axis-B)

### DIFF
--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -16,7 +16,7 @@ test("lists configured delegates with type + secret badges", async ({ page }) =>
   await expect(panel.getByText("Delegates", { exact: true })).toBeVisible();
   const row = panel.locator(".subagent-row", { hasText: "opus" });
   await expect(row).toBeVisible();
-  await expect(row.locator(".delegate-type-badge")).toHaveText("openai");
+  await expect(row.getByText("openai", { exact: true })).toBeVisible(); // DS Badge (#832)
   await expect(row.getByText("secret set")).toBeVisible();
   // Health prober (PR4): the cached status surfaces as a dot.
   await expect(row.locator(".delegate-health.ok")).toBeVisible();

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -17,7 +17,7 @@ test("Agents tab lists the host (this instance) + peers, host active by default"
   await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible();
   // The host self-registers — it's always present + marked "this instance", and focused
   // (active) when no peer is — so the panel is never "0 agents".
-  await expect(page.locator(".fleet-host-tag").first()).toBeVisible();
+  await expect(page.getByText("this instance").first()).toBeVisible(); // DS Badge (#832)
   await expect(page.locator(".fleet-row.active .fleet-name")).toContainText("main");
   await expect(page.locator(".fleet-row", { hasText: "ava" })).toBeVisible();
   await expect(page.locator(".fleet-row", { hasText: "roxy" })).toBeVisible();

--- a/apps/web/e2e/tool-renderers.spec.ts
+++ b/apps/web/e2e/tool-renderers.spec.ts
@@ -51,7 +51,7 @@ test("current_time renders the timestamp and human line", async ({ page }) => {
 test("fetch_url renders a status badge, link, and body", async ({ page }) => {
   const body = await run(page, "FETCH the page");
   const fetch = body.locator(".tool-fetch");
-  await expect(fetch.locator(".tool-badge")).toHaveText("200");
+  await expect(fetch.getByText("200", { exact: true })).toBeVisible(); // DS Badge (#832)
   await expect(fetch.locator("a.tool-link")).toHaveAttribute("href", "https://example.com");
   await expect(fetch.locator(".tool-fetch-body")).toContainText("Example Domain");
 });

--- a/apps/web/src/activity/ActivitySurface.tsx
+++ b/apps/web/src/activity/ActivitySurface.tsx
@@ -1,7 +1,7 @@
 import "./activity.css";
 
 import { Textarea } from "@protolabsai/ui/forms";
-import { Button } from "@protolabsai/ui/primitives";
+import { Button, Empty } from "@protolabsai/ui/primitives";
 import { Clock, Inbox, Loader2, MessageSquare, RefreshCw, Send, Users, Webhook, Zap } from "lucide-react";
 
 import { useEffect, useRef, useState } from "react";
@@ -136,9 +136,11 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
       <div className="stage-body activity-body">
         <div className="activity-feed" ref={scrollRef}>
           {chronological.length === 0 && !loading ? (
-            <div className="activity-empty">
-              Nothing yet. Scheduled fires, inbox items, and sister-agent pushes land here — each tagged with what triggered it.
-            </div>
+            <Empty
+              className="activity-empty"
+              title="Nothing yet"
+              description="Scheduled fires, inbox items, and sister-agent pushes land here — each tagged with what triggered it."
+            />
           ) : null}
           {chronological.map((e) => (
             <div className="activity-entry" key={e.id} data-origin={e.origin}>

--- a/apps/web/src/activity/activity.css
+++ b/apps/web/src/activity/activity.css
@@ -1,6 +1,6 @@
-/* Activity surface (ADR 0003) — moved from app/theme.css (#832). The rail badge
-   (.rail-badge) + the background-stream rail dot (.rail-dot) stay in theme.css:
-   they style the always-mounted shell rail buttons, not the Activity surface. */
+/* Activity surface (ADR 0003) — moved from app/theme.css (#832). The
+   background-stream rail dot (.rail-dot) stays in theme.css: it styles the
+   always-mounted shell rail buttons, not the Activity surface. */
 .activity-body {
   display: flex;
   flex-direction: column;
@@ -16,12 +16,10 @@
   gap: 12px;
 }
 
+/* Layout-only: the chrome is the DS Empty (.pl-empty--slotted, which centers its
+   own contents + caps width); this just centers the block within the scroll feed. */
 .activity-empty {
-  color: var(--fg-secondary);
-  font-size: 13px;
   margin: auto;
-  text-align: center;
-  max-width: 36ch;
 }
 
 .activity-msg {

--- a/apps/web/src/app/BeadsPanel.tsx
+++ b/apps/web/src/app/BeadsPanel.tsx
@@ -1,5 +1,5 @@
 import { Input, Select } from "@protolabsai/ui/forms";
-import { Button } from "@protolabsai/ui/primitives";
+import { Button, Empty } from "@protolabsai/ui/primitives";
 import {
   QueryErrorResetBoundary,
   useMutation,
@@ -149,10 +149,7 @@ function BeadsBody({ confirm }: { confirm: (req: ConfirmRequest) => void }) {
 
       <ScrollArea className="issue-list" role="region" aria-label="Beads tasks" tabIndex={0}>
         {issues.length === 0 ? (
-          <div className="empty-state stacked">
-            <Boxes size={18} />
-            <span>No issues yet — add one above, or the agent will.</span>
-          </div>
+          <Empty icon={<Boxes />} description="No issues yet — add one above, or the agent will." />
         ) : (
           groupIssues(issues).map((group) => {
             const isGroupCollapsed = collapsed.has(group.status);

--- a/apps/web/src/app/FleetSwitcher.tsx
+++ b/apps/web/src/app/FleetSwitcher.tsx
@@ -2,6 +2,8 @@ import { useQuery } from "@tanstack/react-query";
 import { Check, ChevronDown, ExternalLink, Plus } from "lucide-react";
 import { useEffect, useRef, useState, type ReactNode } from "react";
 
+import { Badge } from "@protolabsai/ui/primitives";
+
 import { agentHref, api, currentSlug } from "../lib/api";
 import { queryKeys } from "../lib/queries";
 
@@ -65,7 +67,7 @@ export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: Reac
                 <span className={`fleet-dot ${a.running ? "running" : "stopped"}`} aria-hidden />
                 <span className="fleet-switcher-name">
                   {a.name}
-                  {a.host ? <span className="fleet-host-tag">this instance</span> : null}
+                  {a.host ? <Badge status="neutral">this instance</Badge> : null}
                 </span>
                 {isCurrent ? (
                   <Check size={14} />

--- a/apps/web/src/app/GoalsPanel.tsx
+++ b/apps/web/src/app/GoalsPanel.tsx
@@ -1,6 +1,6 @@
 import "../goals/goals.css";
 
-import { Button } from "@protolabsai/ui/primitives";
+import { Button, Empty } from "@protolabsai/ui/primitives";
 import {
 
   QueryErrorResetBoundary,
@@ -52,12 +52,14 @@ function GoalsList() {
 
   if (!goals.length) {
     return (
-      <div className="goal-row empty">
-        <strong>No goals</strong>
-        <span className="goal-row-meta">
-          set one in chat with <code>/goal …</code>
-        </span>
-      </div>
+      <Empty
+        title="No goals"
+        description={
+          <>
+            set one in chat with <code>/goal …</code>
+          </>
+        }
+      />
     );
   }
 

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -713,22 +713,9 @@ textarea {
   white-space: pre-wrap;
 }
 
-/* Activity surface + rail badge (ADR 0003) ---------------------------------- */
-.rail-badge {
-  position: absolute;
-  top: 4px;
-  right: 6px;
-  min-width: 16px;
-  height: 16px;
-  padding: 0 4px;
-  border-radius: 8px;
-  background: var(--accent, #7c8cff);
-  color: #fff;
-  font-size: 10px;
-  line-height: 16px;
-  text-align: center;
-  font-weight: 600;
-}
+/* Activity surface + rail dot (ADR 0003) ------------------------------------ */
+/* .rail-badge retired (#832) — dead class; the rail unread count is the DS
+   SurfaceRail .pl-count--rail (app-shell.tsx), fed by App.tsx's count. */
 
 /* Background chat-streaming indicator on the Chat rail button — a small pulsing
    dot (no count), shown while a turn streams on another tab. */
@@ -1018,7 +1005,7 @@ textarea {
 }
 
 /* Goals side-panel — .goals-list + .goal-row* moved to src/goals/goals.css (#832).
-   The .issue-* / .empty-state / .setup-overlay rules below belong to other surfaces
+   The .issue-* / .setup-overlay rules below belong to other surfaces
    (BeadsPanel, ChatSurface, SetupWizard) and stay shared here. */
 
 .issue-group {
@@ -1160,20 +1147,8 @@ textarea {
   gap: 6px;
 }
 
-.empty-state {
-  min-height: 96px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
-  gap: 8px;
-  color: var(--fg-muted);
-}
-
-.empty-state.stacked {
-  flex-direction: column;
-  gap: 10px;
-  text-align: center;
-}
+/* .empty-state / .empty-state.stacked retired (#832) — BeadsPanel + ChatSurface
+   now render the DS <Empty> (.pl-empty--slotted). */
 
 .setup-overlay {
   position: fixed;
@@ -1543,7 +1518,7 @@ textarea {
 }
 
 /* ── Settings surface ─────────────────────────────────────────────────────── */
-/* The settings-form chrome (.settings-banner/.settings-group*/.setting-*, ADR 0047
+/* The settings-form chrome (.settings-banner / .settings-group / .setting-..., ADR 0047
    .setting-inheritance) moved to src/settings/settings.css (#832). Left here, shared:
    .settings-status (SchedulePanel renders it too) + the .settings-help-link / .setup-link
    rule (it pairs the setup wizard's link styling). */
@@ -1568,13 +1543,8 @@ textarea {
 }
 
 /* Telemetry dashboard + insights (ADR 0006 Slices 3–4) — the .telemetry-* / .turn-state* /
-   .insight-* / .flag-* rules moved to src/settings/telemetry.css (#832). .empty-note stays:
-   it's shared (PlaybooksSurface + KnowledgeStore render it too). */
-.empty-note {
-  color: var(--fg-muted);
-  font-size: 13px;
-  padding: 16px 2px;
-}
+   .insight-* / .flag-* rules moved to src/settings/telemetry.css (#832). .empty-note retired
+   (#832): Knowledge/Playbooks/Telemetry now render the DS <Empty> (.pl-empty). */
 
 /* Playbooks surface (ADR 0009) */
 .playbook-search {
@@ -1602,13 +1572,8 @@ textarea {
 .playbook-main { min-width: 0; }
 .playbook-title { display: flex; align-items: center; gap: 8px; }
 .playbook-title strong { font-size: 13.5px; }
-.playbook-badge {
-  display: inline-flex; align-items: center; gap: 4px;
-  font-size: 10.5px; padding: 1px 7px; border-radius: 999px;
-  border: 1px solid var(--border); color: var(--fg-muted); white-space: nowrap;
-}
-.playbook-badge.pinned { color: var(--info); border-color: color-mix(in srgb, var(--info) 40%, transparent); }
-.playbook-badge.learned { color: var(--success); border-color: color-mix(in srgb, var(--success) 40%, transparent); }
+/* .playbook-badge / .pinned / .learned retired (#832) — pinned/learned/domain/
+   finding-type tags are now DS <Badge> (info / success / neutral). */
 .playbook-desc { margin: 6px 0 0; font-size: 12.5px; color: var(--fg-secondary); }
 .playbook-tools { margin-top: 7px; display: flex; flex-wrap: wrap; gap: 5px; }
 .playbook-tools code { font-size: 11px; padding: 1px 6px; border-radius: 4px; background: var(--bg-hover); color: var(--fg-muted); }
@@ -1752,11 +1717,12 @@ textarea {
 }
 
 /* Fleet manager (Settings → Agents, ADR 0042) — the .fleet-list / .fleet-row* /
-   .fleet-rename-input / .fleet-active-tag / .fleet-meta / .fleet-error / .fleet-purge /
-   .fleet-delegate-tag / .fleet-discover rules moved to src/fleet/fleet.css (#832).
+   .fleet-rename-input / .fleet-meta / .fleet-error / .fleet-purge / .fleet-discover
+   rules moved to src/fleet/fleet.css (#832). The .fleet-active-tag / .fleet-delegate-tag /
+   .fleet-host-tag text tags are now DS <Badge> (#832).
    Left here (shared / other surfaces): the .archetype-* picker (NewAgentPanel), .field-hint
-   (NewAgentPanel + SetupWizard), the topbar .fleet-switcher* (FleetSwitcher), and .fleet-host-tag
-   + .fleet-dot* — both rendered by the always-mounted topbar FleetSwitcher AND the FleetManager
+   (NewAgentPanel + SetupWizard), the topbar .fleet-switcher* (FleetSwitcher), and .fleet-dot*
+   — both rendered by the always-mounted topbar FleetSwitcher AND the FleetManager
    panel, so they stay in this always-loaded layer (not a Settings-only module that loads lazily),
    plus the global ::view-transition root crossfade. */
 
@@ -1776,10 +1742,9 @@ textarea {
   opacity: 0.45;
 }
 
+/* The grid track + gap are now the DS <Grid min="160px" gap="sm"> (#832); this
+   keeps only the spacing below the picker, merged onto Grid via className. */
 .archetype-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
-  gap: 10px;
   margin-bottom: 18px;
 }
 .archetype-card {
@@ -1895,17 +1860,8 @@ textarea {
   background: var(--border);
 }
 
-/* The host (this instance) tag in the fleet manager + switcher (ADR 0042) */
-.fleet-host-tag {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--fg-muted);
-  border: 1px solid var(--border);
-  border-radius: 4px;
-  padding: 0 5px;
-  margin-left: 8px;
-}
+/* .fleet-host-tag retired (#832) — the "this instance" / "remote" tags in the
+   fleet manager + switcher are now DS <Badge status="neutral">. */
 
 /* Theme crossfade (ADR 0042) — applyAgentTheme() applies the focused agent's look inside a
    View Transition (when supported), so switching agents snapshots before/after and crossfades

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1,6 +1,6 @@
 import "./chat.css";
 import { EditableText } from "@protolabsai/ui/forms";
-import { Button } from "@protolabsai/ui/primitives";
+import { Button, Empty } from "@protolabsai/ui/primitives";
 import {
   Loader2,
   Plus,
@@ -543,10 +543,7 @@ function ChatSessionSlot({
     <div className="chat-session-slot" hidden={!visible}>
       <div className="message-list" ref={listRef}>
         {messages.length === 0 ? (
-          <div className="empty-state">
-            <TerminalSquare size={18} />
-            <span>No messages in this session.</span>
-          </div>
+          <Empty icon={<TerminalSquare />} description="No messages in this session." />
         ) : (
           messages.map((message) => (
             <article className={`message message-${message.role}`} key={message.id || `${message.role}-${message.createdAt}`}>

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -309,16 +309,8 @@
   gap: 7px;
   min-width: 0;
 }
-.tool-badge {
-  flex: none;
-  padding: 1px 6px;
-  border-radius: 5px;
-  background: color-mix(in srgb, var(--success) 16%, transparent);
-  border: 1px solid color-mix(in srgb, var(--success) 28%, transparent);
-  color: var(--success);
-  font-family: var(--font-mono);
-  font-size: 0.72rem;
-}
+/* .tool-badge retired (#832) — the fetch status code is now the DS <Badge
+   status="success"> (success-toned outline pill). */
 
 /* web_search: result cards */
 .tool-results {

--- a/apps/web/src/chat/tool-renderers.tsx
+++ b/apps/web/src/chat/tool-renderers.tsx
@@ -1,6 +1,8 @@
 import { AlertTriangle, ExternalLink } from "lucide-react";
 import type { ReactNode } from "react";
 
+import { Badge } from "@protolabsai/ui/primitives";
+
 // Renders a tool's input/output as real components instead of a raw JSON blob.
 //
 // Two layers:
@@ -179,7 +181,7 @@ function renderFetchUrl(raw: string): ReactNode | null {
   return (
     <div className="tool-fetch">
       <div className="tool-fetch-head">
-        <span className="tool-badge">{status}</span>
+        <Badge status="success">{status}</Badge>
         <Link href={url} />
       </div>
       <div className="tool-text tool-fetch-body">{body}</div>

--- a/apps/web/src/fleet/fleet.css
+++ b/apps/web/src/fleet/fleet.css
@@ -36,15 +36,7 @@
   font-weight: 600;
   width: 12ch;
 }
-.fleet-active-tag {
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--accent);
-  border: 1px solid var(--accent);
-  border-radius: 4px;
-  padding: 0 5px;
-}
+/* .fleet-active-tag retired (#832) — now DS <Badge status="info">. */
 .fleet-meta {
   font-size: 12px;
   color: var(--fg-muted);
@@ -55,7 +47,8 @@
   display: flex;
   gap: 4px;
 }
-.fleet-empty,
+/* .fleet-empty retired (#832) — the manager + discover empty states now render
+   the DS <Empty> (.pl-empty). .fleet-section-label keeps its muted color. */
 .fleet-section-label {
   color: var(--fg-muted);
 }
@@ -80,22 +73,8 @@
   width: auto;
 }
 
-/* "delegate" marker on a fleet row — this agent is a delegate_to target of the focused agent. */
-.fleet-delegate-tag {
-  /* It lives in .fleet-row-actions (a flex row), so center it + don't stretch to the action
-     buttons' height (that left a tall box with the text top-aligned). */
-  align-self: center;
-  display: inline-flex;
-  align-items: center;
-  font-size: 10px;
-  line-height: 1.6;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  color: var(--brand-violet, #9b87f2);
-  border: 1px solid color-mix(in srgb, var(--brand-violet, #9b87f2) 40%, transparent);
-  border-radius: 4px;
-  padding: 1px 6px;
-}
+/* .fleet-delegate-tag retired (#832) — now DS <Badge status="info"> (wrapped in a
+   titled span to keep the "A delegate of this agent" tooltip). */
 
 /* Network-discovery sub-section in the fleet manager (ADR 0042 §I). */
 .fleet-discover {

--- a/apps/web/src/goals/goals.css
+++ b/apps/web/src/goals/goals.css
@@ -18,10 +18,6 @@
   border-bottom: 0;
 }
 
-.goal-row.empty {
-  gap: 2px;
-}
-
 .goal-row-head {
   display: flex;
   align-items: center;

--- a/apps/web/src/inbox/InboxPanel.tsx
+++ b/apps/web/src/inbox/InboxPanel.tsx
@@ -1,6 +1,6 @@
 import "./inbox.css";
 
-import { Button } from "@protolabsai/ui/primitives";
+import { Button, Empty } from "@protolabsai/ui/primitives";
 import {
 
   QueryErrorResetBoundary,
@@ -68,10 +68,14 @@ function InboxBody({
 
       <div className="inbox-list">
         {items.length === 0 ? (
-          <div className="inbox-empty">
-            Nothing pending. Inbound stimuli (webhooks, scripts, sister agents) posted to
-            <code>/api/inbox</code> show up here.
-          </div>
+          <Empty
+            title="Nothing pending"
+            description={
+              <>
+                Inbound stimuli (webhooks, scripts, sister agents) posted to <code>/api/inbox</code> show up here.
+              </>
+            }
+          />
         ) : null}
         {items.map((item) => (
           <div className="inbox-item" key={item.id}>

--- a/apps/web/src/inbox/inbox.css
+++ b/apps/web/src/inbox/inbox.css
@@ -8,20 +8,6 @@
   padding: 10px;
 }
 
-.inbox-empty {
-  color: var(--fg-secondary);
-  font-size: 12px;
-  padding: 8px;
-  line-height: 1.5;
-}
-
-.inbox-empty code {
-  font-size: 11px;
-  background: var(--bg-elevated, #111114);
-  padding: 1px 4px;
-  border-radius: 4px;
-}
-
 .inbox-item {
   border: 1px solid var(--border);
   border-radius: var(--radius);

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -1,5 +1,5 @@
 import { Input } from "@protolabsai/ui/forms";
-import { Button } from "@protolabsai/ui/primitives";
+import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { Brain, Database, RefreshCw } from "lucide-react";
 
 import { useEffect, useState } from "react";
@@ -77,26 +77,33 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
         />
 
         {!enabled ? (
-          <p className="empty-note">
+          <Empty>
             The knowledge store is off (enable <code>middleware.knowledge</code>).
-          </p>
+          </Empty>
         ) : results.length === 0 ? (
-          <p className="empty-note">
-            {query.trim()
-              ? "No entries match your search."
-              : "The knowledge base is empty — findings, daily-log entries, and harvested sessions will appear here as the agent works."}
-          </p>
+          query.trim() ? (
+            <Empty>No entries match your search.</Empty>
+          ) : (
+            <Empty
+              title="The knowledge base is empty"
+              description="findings, daily-log entries, and harvested sessions will appear here as the agent works."
+            />
+          )
         ) : (
           <ul className="playbook-list">
             {results.map((c) => (
               <li key={c.id} className="playbook-card">
                 <div className="playbook-main">
                   <div className="playbook-title">
-                    <span className="playbook-badge learned" title={`domain: ${c.domain}`}>
-                      <Database size={12} /> {c.domain}
+                    <span title={`domain: ${c.domain}`}>
+                      <Badge status="success">
+                        <Database size={12} /> {c.domain}
+                      </Badge>
                     </span>
                     {c.finding_type ? (
-                      <span className="playbook-badge" title="finding type">{c.finding_type}</span>
+                      <span title="finding type">
+                        <Badge status="neutral">{c.finding_type}</Badge>
+                      </span>
                     ) : null}
                     {c.heading ? <strong>{c.heading}</strong> : null}
                   </div>

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -1,5 +1,5 @@
 import { Input } from "@protolabsai/ui/forms";
-import { Button } from "@protolabsai/ui/primitives";
+import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { BookMarked, Pin, RefreshCw, Sparkles, Trash2 } from "lucide-react";
 
 import { useEffect, useMemo, useState } from "react";
@@ -102,13 +102,16 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
         />
 
         {!enabled ? (
-          <p className="empty-note">The skills index is disabled (set <code>skills.enabled: true</code>).</p>
+          <Empty>The skills index is disabled (set <code>skills.enabled: true</code>).</Empty>
         ) : filtered.length === 0 ? (
-          <p className="empty-note">
-            {playbooks.length === 0
-              ? "No playbooks yet — author a SKILL.md, or let the agent emit one from a run."
-              : "No playbooks match your search."}
-          </p>
+          playbooks.length === 0 ? (
+            <Empty
+              title="No playbooks yet"
+              description="author a SKILL.md, or let the agent emit one from a run."
+            />
+          ) : (
+            <Empty>No playbooks match your search.</Empty>
+          )
         ) : (
           <ul className="playbook-list">
             {filtered.map((p) => (
@@ -116,12 +119,16 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
                 <div className="playbook-main">
                   <div className="playbook-title">
                     {p.source === "disk" ? (
-                      <span className="playbook-badge pinned" title="Pinned SKILL.md (re-seeded on boot)">
-                        <Pin size={12} /> pinned
+                      <span title="Pinned SKILL.md (re-seeded on boot)">
+                        <Badge status="info">
+                          <Pin size={12} /> pinned
+                        </Badge>
                       </span>
                     ) : (
-                      <span className="playbook-badge learned" title="Agent-emitted (curated/decaying)">
-                        <Sparkles size={12} /> learned
+                      <span title="Agent-emitted (curated/decaying)">
+                        <Badge status="success">
+                          <Sparkles size={12} /> learned
+                        </Badge>
                       </span>
                     )}
                     <strong>{p.name}</strong>

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -2,7 +2,9 @@ import "./settings.css";
 import "./delegates.css";
 
 import { Input, Select, Textarea } from "@protolabsai/ui/forms";
-import { Button } from "@protolabsai/ui/primitives";
+import { Badge, Button } from "@protolabsai/ui/primitives";
+
+import { StatusPill } from "../app/StatusPill";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, Pencil, Plug, Plus, ShieldCheck, Trash2, X } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -121,9 +123,9 @@ export function DelegatesSection() {
                       ●
                     </span>
                   ) : null}
-                  {d.name} <span className="delegate-type-badge">{d.type}</span>
-                  {!d.configured ? <span className="delegate-badge-warn">⚠ unconfigured</span> : null}
-                  {d.has_secret ? <span className="delegate-badge-ok">secret set</span> : null}
+                  {d.name} <Badge status="neutral">{d.type}</Badge>
+                  {!d.configured ? <StatusPill label="⚠ unconfigured" tone="warning" /> : null}
+                  {d.has_secret ? <StatusPill label="secret set" tone="muted" /> : null}
                 </strong>
                 <span>{p ? probeLine(p) : d.description || d.error || ""}</span>
               </div>

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link2, Pencil, Play, Plus, Radar, Square, Trash2 } from "lucide-react";
 import { useState } from "react";
 
-import { Badge, Button } from "@protolabsai/ui/primitives";
+import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { EditableText } from "@protolabsai/ui/forms";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
@@ -169,9 +169,17 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
           </p>
         ) : null}
         {fleet.isLoading ? (
-          <p className="fleet-empty">Loading the fleet…</p>
+          <Empty>Loading the fleet…</Empty>
         ) : agents.length === 0 ? (
-          <p className="fleet-empty">No agents yet — create one to get started.</p>
+          <Empty
+            title="No agents yet"
+            description="create one to get started"
+            action={
+              <Button variant="primary" onClick={onNew}>
+                <Plus size={15} /> New agent
+              </Button>
+            }
+          />
         ) : (
           <ul className="fleet-list">
             {agents.map((a) => {
@@ -199,8 +207,12 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                       ) : (
                         a.name
                       )}
-                      {a.host ? <span className="fleet-host-tag">this instance</span> : null}
-                      {a.remote ? <span className="fleet-host-tag" title="A remote fleet member — proxied by URL">remote</span> : null}
+                      {a.host ? <Badge status="neutral">this instance</Badge> : null}
+                      {a.remote ? (
+                        <span title="A remote fleet member — proxied by URL">
+                          <Badge status="neutral">remote</Badge>
+                        </span>
+                      ) : null}
                       {/* Version skew (hub↔remote handshake): the hub console drives this
                           remote's /api/* by proxy, so a different release can misbehave. */}
                       {a.remote && a.version && hubVersion && a.version !== hubVersion ? (
@@ -211,7 +223,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                           <Badge status="warning">v{a.version}</Badge>
                         </span>
                       ) : null}
-                      {isActive ? <span className="fleet-active-tag">active</span> : null}
+                      {isActive ? <Badge status="info">active</Badge> : null}
                     </span>
                     <span className="fleet-meta">
                       {a.remote ? a.url : `:${a.port}`}
@@ -224,7 +236,9 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                         agent but the one you're on (it can't delegate to itself). */}
                     {!isActive ? (
                       delegateNames.has(a.name) ? (
-                        <span className="fleet-delegate-tag" title="A delegate of this agent">delegate</span>
+                        <span title="A delegate of this agent">
+                          <Badge status="info">delegate</Badge>
+                        </span>
                       ) : (
                         <Button icon variant="ghost" title="Add as a delegate of this agent (delegate_to)"
                           disabled={addDelegate.isPending || !a.a2a}
@@ -283,7 +297,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
           </Button>
           {discovered ? (
             discovered.length === 0 ? (
-              <p className="fleet-empty">No other protoAgents found on the network.</p>
+              <Empty>No other protoAgents found on the network.</Empty>
             ) : (
               <ul className="fleet-list">
                 {discovered.map((d) => (
@@ -302,7 +316,9 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                         <Plus size={14} />
                       </Button>
                       {delegateNames.has(d.name) ? (
-                        <span className="fleet-delegate-tag" title="A delegate of this agent">delegate</span>
+                        <span title="A delegate of this agent">
+                          <Badge status="info">delegate</Badge>
+                        </span>
                       ) : (
                         <Button icon variant="ghost" title="Add as a remote delegate (delegate_to)"
                           disabled={addDelegate.isPending}

--- a/apps/web/src/settings/NewAgentPanel.tsx
+++ b/apps/web/src/settings/NewAgentPanel.tsx
@@ -3,6 +3,7 @@ import { ArrowLeft } from "lucide-react";
 import { useState } from "react";
 
 import { Button } from "@protolabsai/ui/primitives";
+import { Grid } from "@protolabsai/ui/layout";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 
 import { api } from "../lib/api";
@@ -57,7 +58,7 @@ export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) =>
         ) : null}
 
         <p className="fleet-section-label">Archetype</p>
-        <div className="archetype-grid">
+        <Grid className="archetype-grid" min="160px" gap="sm">
           {list.map((a: Archetype) => (
             <button
               key={a.id}
@@ -71,7 +72,7 @@ export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) =>
               <span className="archetype-blurb">{a.blurb}</span>
             </button>
           ))}
-        </div>
+        </Grid>
 
         <label className="field archetype-name-field">
           <span>Name</span>

--- a/apps/web/src/settings/delegates.css
+++ b/apps/web/src/settings/delegates.css
@@ -1,17 +1,7 @@
 /* ── Delegates panel (ADR 0025) — Settings → Integrations ──────────────────── */
 .delegates-section .subagent-row strong { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
-.delegate-type-badge {
-  font-family: var(--font-mono);
-  font-size: 10px;
-  text-transform: uppercase;
-  letter-spacing: 0.04em;
-  padding: 1px 6px;
-  border-radius: 4px;
-  border: 1px solid var(--border);
-  color: var(--brand-violet-light);
-}
-.delegate-badge-warn { font-size: 10px; color: var(--warning); }
-.delegate-badge-ok { font-size: 10px; color: var(--fg-muted); }
+/* .delegate-type-badge / .delegate-badge-warn / .delegate-badge-ok retired (#832) —
+   now DS Badge (type) + StatusPill (unconfigured/secret-set). */
 .delegate-form {
   margin-top: 14px;
   padding: 14px;

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -1,7 +1,7 @@
 import "../settings/telemetry.css";
 
 import { Table, THead, TBody, Tr, Th, Td } from "@protolabsai/ui/data";
-import { Button } from "@protolabsai/ui/primitives";
+import { Button, Empty } from "@protolabsai/ui/primitives";
 import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
 
 import {
@@ -84,9 +84,9 @@ function TelemetryBody() {
 
       <div className="stage-body">
         {!enabled ? (
-          <p className="empty-note">Telemetry store is disabled (set <code>telemetry.enabled: true</code>).</p>
+          <Empty>Telemetry store is disabled (set <code>telemetry.enabled: true</code>).</Empty>
         ) : !summary || summary.turns === 0 ? (
-          <p className="empty-note">No turns recorded yet — run a turn and refresh.</p>
+          <Empty>No turns recorded yet — run a turn and refresh.</Empty>
         ) : (
           <>
             {insights ? (


### PR DESCRIPTION
**Draft for your local visual pass** — #832 Axis-B, the low-risk DS-component shrink. Swaps hand-rolled families for the DS components that now ship them and **deletes the bespoke CSS** (net **−103 CSS lines**). Content/behavior parity verified; build + e2e **89/89**.

## Adopted
- **`Empty`** (9 empty-states): inbox, activity, goals, beads, chat "no messages", fleet (loading / no-agents / no-discover), knowledge, playbooks, telemetry. Deletes `.inbox-empty`/`.activity-empty`/`.goal-row.empty`/`.empty-state`/`.empty-note`.
- **`Grid`**: `.archetype-grid` → `<Grid min="160px" gap="sm">`. Left `.subagent-grid` (mixed tracks) + `.metric-grid` (hairline-divider gap) bespoke.
- **`Badge`**: tool fetch-status, delegate type, fleet active/delegate/this-instance/remote, playbook pinned/learned, knowledge domain/finding-type. Deletes `.tool-badge`/`.delegate-type-badge*`/`.fleet-*-tag`/`.playbook-badge*`/`.rail-badge`(dead).

## 👀 Visual deltas to eyeball (deliberate DS choices)
- **Badge text renders lowercase + mono** (the DS `.pl-badge` aesthetic), so the previously UPPERCASE letter-spaced tags (fleet `active`/`this instance`/`delegate`, delegate `type`) now read lowercase. Biggest visible shift — veto if you want the caps back.
- **`Empty` icons render at 28px** (vs the bespoke 18px) — Beads/Chat/Knowledge/Playbooks empty-state glyphs are larger.
- Bare `Empty` is **monospace** (vs the old sans `.empty-note`); inline `<code>` loses the bespoke chip bg.
- The fleet **"No agents" empty gains a "New agent" CTA** (additive — was a plain line).
- Archetype grid gap 10px → 8px (`sm` token).

## Left bespoke on purpose (would regress / DS gap)
- **`.inbox-pri` priority pills** — solid-fill colored pills; DS `Badge` is outline-only (a **DS gap** — no filled variant; candidate to file upstream).
- **Beads issue-id badges** — DS `Badge` forces lowercase, which would mangle IDs like `PA-123`.
- The generic-typography settings placeholders (reuse `setting-desc`/`muted`, delete no dedicated rule).

## Also
Fixed a **pre-existing latent CSS comment bug**: a glob `*/` inside the `".settings-group*/"` comment text prematurely closed the comment (parsed by luck on the clean tree; broke once deletions shifted lines). And updated 3 e2e specs that asserted the now-retired badge classes → assert the rendered `Badge` text.

**Remaining for #832:** the two structural swaps — `ToolCard` (chat tool-call frame) and `TabBar` (chat session tabs) — as their own focused draft PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)