### PR TITLE
refactor(web): adopt DS ToolCard for the chat tool-call frame (#832 Axis-B)

### DIFF
--- a/apps/web/e2e/chat-continuity.spec.ts
+++ b/apps/web/e2e/chat-continuity.spec.ts
@@ -38,13 +38,14 @@ test("tool-call cards survive navigating away and back", async ({ page }) => {
   // This prompt makes the mock stream a web_search tool-call card.
   await composer.fill("search for AI coding agents");
   await composer.press("Enter");
-  const card = page.locator(".tool-card").first();
+  // Frame = DS ToolCard (#832): `.pl-toolcard*`.
+  const card = page.locator(".pl-toolcard").first();
   await expect(card).toBeVisible();
-  await expect(card.locator(".tool-card-name")).toHaveText("web_search");
+  await expect(card.locator(".pl-toolcard__name")).toHaveText("web_search");
 
   // Leave and return — the tool card must still be there (not torn down).
   await rail(page, "Activity");
-  await expect(page.locator(".tool-card")).toHaveCount(1); // still in the DOM while away
+  await expect(page.locator(".pl-toolcard")).toHaveCount(1); // still in the DOM while away
   await rail(page, "Chat");
-  await expect(page.locator(".tool-card").first().locator(".tool-card-name")).toHaveText("web_search");
+  await expect(page.locator(".pl-toolcard").first().locator(".pl-toolcard__name")).toHaveText("web_search");
 });

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -33,21 +33,22 @@ test("Enter sends; Ctrl+Enter inserts a newline", async ({ page }) => {
 test("tool-call card is collapsed by default and renders structured components", async ({ page }) => {
   await send(page, "search for AI coding agents");
 
-  const card = page.locator(".tool-card").first();
+  // Frame = DS ToolCard (#832): `.pl-toolcard*`; body slot is ours.
+  const card = page.locator(".pl-toolcard").first();
   await expect(card).toBeVisible();
-  await expect(card.locator(".tool-card-name")).toHaveText("web_search");
+  await expect(card.locator(".pl-toolcard__name")).toHaveText("web_search");
 
   // Stable default: collapsed — no body rendered until the user opens it.
-  await expect(page.locator(".tool-card-body")).toHaveCount(0);
+  await expect(page.locator(".pl-toolcard__body")).toHaveCount(0);
 
   // The tool finishes → done glyph (not the running spinner).
-  await expect(card.locator(".tool-card-status.done")).toBeVisible();
+  await expect(card.locator(".pl-toolcard__status--done")).toBeVisible();
 
   // A duration pill is stamped on completion (mock gaps frames ~40ms).
-  await expect(card.locator(".tool-card-dur")).toHaveText(/^\d+ms$|^\d+\.\d+s$/);
+  await expect(card.locator(".pl-toolcard__dur")).toHaveText(/^\d+ms$|^\d+\.\d+s$/);
 
-  await card.locator(".tool-card-head").click();
-  const body = card.locator(".tool-card-body");
+  await card.locator(".pl-toolcard__head").click();
+  const body = card.locator(".pl-toolcard__body");
   await expect(body).toBeVisible();
 
   // Input renders as key/value field rows — NOT a raw JSON blob.
@@ -77,10 +78,10 @@ test("expanded state is sticky and the assistant answer renders as markdown", as
 test("long tool values do not overflow the chat horizontally", async ({ page }) => {
   await send(page, "OVERFLOW: trigger a long token");
 
-  const card = page.locator(".tool-card").first();
+  const card = page.locator(".pl-toolcard").first();
   await expect(card).toBeVisible();
-  await card.locator(".tool-card-head").click();
-  await expect(card.locator(".tool-card-body")).toBeVisible();
+  await card.locator(".pl-toolcard__head").click();
+  await expect(card.locator(".pl-toolcard__body")).toBeVisible();
 
   const metrics = await page.evaluate(() => {
     const body = document.querySelector(".message-assistant .message-body");

--- a/apps/web/e2e/copy.spec.ts
+++ b/apps/web/e2e/copy.spec.ts
@@ -11,17 +11,18 @@ test("copy button writes the raw value to the clipboard", async ({ page }) => {
   await composer.fill("CALC compute it");
   await composer.press("Enter");
 
-  const card = page.locator(".tool-card").first();
-  await expect(card.locator(".tool-card-status.done")).toBeVisible();
-  await card.locator(".tool-card-head").click();
+  // Frame + copy button are the DS ToolCard/ToolSection (#832): `.pl-toolcard*`.
+  const card = page.locator(".pl-toolcard").first();
+  await expect(card.locator(".pl-toolcard__status--done")).toBeVisible();
+  await card.locator(".pl-toolcard__head").click();
 
   // Copy the input section's raw value.
-  const inputSection = card.locator(".tool-card-section").first();
-  await expect(inputSection.locator(".tool-copy")).toBeVisible();
-  await inputSection.locator(".tool-copy").click();
+  const inputSection = card.locator(".pl-toolcard__section").first();
+  await expect(inputSection.locator(".pl-toolcard__copy")).toBeVisible();
+  await inputSection.locator(".pl-toolcard__copy").click();
 
   // Button flips to the copied (check) state.
-  await expect(inputSection.locator(".tool-copy")).toHaveAttribute("aria-label", "Copied");
+  await expect(inputSection.locator(".pl-toolcard__copy")).toHaveAttribute("aria-label", "Copied");
 
   // Clipboard holds the raw tool input (JSON for the calculator expression).
   const clip = await page.evaluate(() => navigator.clipboard.readText());

--- a/apps/web/e2e/nesting.spec.ts
+++ b/apps/web/e2e/nesting.spec.ts
@@ -11,17 +11,18 @@ test("subagent child tools nest under the task card", async ({ page }) => {
   await composer.fill("SUBAGENT delegate this");
   await composer.press("Enter");
 
-  // The parent task card is top-level inside a group.
-  const group = page.locator(".tool-calls > .tool-card-group");
+  // The parent task card is top-level inside a group. Frame = DS ToolCard (#832):
+  // `.pl-toolcard-group` / `.pl-toolcard` / `.pl-toolcard__children`.
+  const group = page.locator(".tool-calls > .pl-toolcard-group");
   await expect(group).toHaveCount(1);
-  await expect(group.locator("> .tool-card .tool-card-name")).toHaveText("task");
+  await expect(group.locator("> .pl-toolcard .pl-toolcard__name")).toHaveText("task");
 
   // The web_search child renders inside the nested children container.
-  const children = group.locator("> .tool-children");
+  const children = group.locator("> .pl-toolcard__children");
   await expect(children).toBeVisible();
-  await expect(children.locator(".tool-card-name")).toHaveText("web_search");
+  await expect(children.locator(".pl-toolcard__name")).toHaveText("web_search");
 
   // And it is NOT also rendered as a sibling top-level card.
-  await expect(page.locator(".tool-calls > .tool-card-group")).toHaveCount(1);
-  await expect(page.locator(".tool-calls > .tool-card")).toHaveCount(0);
+  await expect(page.locator(".tool-calls > .pl-toolcard-group")).toHaveCount(1);
+  await expect(page.locator(".tool-calls > .pl-toolcard")).toHaveCount(0);
 });

--- a/apps/web/e2e/tool-renderers.spec.ts
+++ b/apps/web/e2e/tool-renderers.spec.ts
@@ -10,12 +10,13 @@ async function run(page, prompt: string) {
   await composer.waitFor({ state: "visible" });
   await composer.fill(prompt);
   await composer.press("Enter");
-  const card = page.locator(".tool-card").first();
+  // Frame is the DS ToolCard (#832): `.pl-toolcard*`; the body slot is ours.
+  const card = page.locator(".pl-toolcard").first();
   await expect(card).toBeVisible();
-  await expect(card.locator(".tool-card-status.done")).toBeVisible();
-  await card.locator(".tool-card-head").click();
-  await expect(card.locator(".tool-card-body")).toBeVisible();
-  return card.locator(".tool-card-body");
+  await expect(card.locator(".pl-toolcard__status--done")).toBeVisible();
+  await card.locator(".pl-toolcard__head").click();
+  await expect(card.locator(".pl-toolcard__body")).toBeVisible();
+  return card.locator(".pl-toolcard__body");
 }
 
 test("calculator renders expression = result", async ({ page }) => {
@@ -25,8 +26,9 @@ test("calculator renders expression = result", async ({ page }) => {
   await expect(calc.locator("code")).toHaveText("19 * 23");
   await expect(calc.locator("strong")).toHaveText("437");
   await expect(body.locator("pre")).toHaveCount(0);
-  // Header shows the tool-specific icon (not the generic wrench).
-  await expect(page.locator(".tool-card-head .tool-card-icon.lucide-calculator")).toBeVisible();
+  // Header shows the tool-specific icon (not the generic wrench). The DS wraps
+  // the host lucide element in `.pl-toolcard__icon`.
+  await expect(page.locator(".pl-toolcard__head .pl-toolcard__icon .lucide-calculator")).toBeVisible();
 });
 
 test("each tool gets its own header icon", async ({ page }) => {
@@ -36,7 +38,7 @@ test("each tool gets its own header icon", async ({ page }) => {
     ["search for things", "lucide-search"],
   ] as const) {
     await run(page, prompt);
-    await expect(page.locator(`.tool-card-head .tool-card-icon.${icon}`).first()).toBeVisible();
+    await expect(page.locator(`.pl-toolcard__head .pl-toolcard__icon .${icon}`).first()).toBeVisible();
   }
 });
 
@@ -81,11 +83,11 @@ test("a tool whose end frame never arrives still finishes when the turn complete
   await composer.fill("NOEND run the workflow");
   await composer.press("Enter");
 
-  const card = page.locator(".tool-card").first();
+  const card = page.locator(".pl-toolcard").first();
   await expect(card).toBeVisible();
   // The assistant's final text arrives (turn completed).
   await expect(page.getByText("Workflow finished.")).toBeVisible();
   // The card resolved to done — no lingering spinner.
-  await expect(card).toHaveClass(/tool-card-done/);
-  await expect(card.locator(".tool-card-status.running")).toHaveCount(0);
+  await expect(card).toHaveClass(/pl-toolcard--done/);
+  await expect(card.locator(".pl-toolcard__status--running")).toHaveCount(0);
 });

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -1,20 +1,16 @@
 import "./tool-calls.css";
 import {
   Calculator,
-  Check,
-  ChevronRight,
   Clock,
-  Copy,
   Database,
   Globe,
-  Loader2,
   Network,
   Search,
   Wrench,
-  X,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { useState } from "react";
+
+import { ToolCard, ToolCardList, ToolSection } from "@protolabsai/ui/tool-card";
 
 import type { ToolCall } from "../lib/types";
 import { ToolValue } from "./tool-renderers";
@@ -34,7 +30,9 @@ function iconFor(name: string): LucideIcon {
  * Renders the agent's tool activity as collapsible cards inside an assistant
  * message. Each card shows the tool name, a running→done/error state pill, and
  * (when expanded) the input preview + result preview the server streamed over
- * the tool-call DataPart. Mirrors ProtoMaker's chat tool-call cards.
+ * the tool-call DataPart. The disclosure FRAME (card chrome, header, caret,
+ * status glyph, duration, nesting) is the DS `ToolCard` family; the body is our
+ * per-tool value renderers (`ToolValue` via `tool-renderers.tsx`).
  */
 export function ToolCalls({ calls }: { calls: ToolCall[] }) {
   // Group children (tools that ran inside a `task` subagent) under their parent.
@@ -50,15 +48,16 @@ export function ToolCalls({ calls }: { calls: ToolCall[] }) {
     }
   }
   return (
-    <div className="tool-calls">
+    <ToolCardList className="tool-calls">
       {top.map((call) => (
         <ToolGroup key={call.id} call={call} childrenByParent={childrenByParent} />
       ))}
-    </div>
+    </ToolCardList>
   );
 }
 
-/** A tool card plus, when it's a subagent `task`, its nested child tool cards. */
+/** A tool card plus, when it's a subagent `task`, its nested child tool cards.
+ *  Subagent nesting rides the DS `ToolCard` `nested` prop (indented child rail). */
 function ToolGroup({
   call,
   childrenByParent,
@@ -67,117 +66,43 @@ function ToolGroup({
   childrenByParent: Map<string, ToolCall[]>;
 }) {
   const kids = childrenByParent.get(call.id);
-  if (!kids?.length) return <ToolCard call={call} />;
-  return (
-    <div className="tool-card-group">
-      <ToolCard call={call} />
-      <div className="tool-children">
-        {kids.map((kid) => (
-          <ToolGroup key={kid.id} call={kid} childrenByParent={childrenByParent} />
-        ))}
-      </div>
-    </div>
-  );
-}
+  const nested = kids?.length
+    ? kids.map((kid) => (
+        <ToolGroup key={kid.id} call={kid} childrenByParent={childrenByParent} />
+      ))
+    : undefined;
 
-function ToolCard({ call }: { call: ToolCall }) {
-  // Collapsed by default and stays put — the header row (icon, name, status)
-  // is the stable at-a-glance view; expanding is an explicit, sticky choice so
-  // the message doesn't reflow as tools start and finish. The user opens the
-  // cards they care about.
-  const [open, setOpen] = useState(false);
-  const hasDetail = Boolean(call.input || call.output);
+  // Collapsed by default and stays put — the header row (icon, name, status) is
+  // the stable at-a-glance view; expanding is an explicit, sticky choice so the
+  // message doesn't reflow as tools start and finish. Pass `children` only when
+  // there's detail so the DS gives us the disabled-caret behavior for empty cards
+  // (the DS gates `hasBody` on `children != null`, so a no-detail card omits it).
   const Icon = iconFor(call.name);
-
-  return (
-    <div className={`tool-card tool-card-${call.status}`}>
-      <button
-        type="button"
-        className="tool-card-head"
-        aria-expanded={open}
-        disabled={!hasDetail}
-        onClick={() => setOpen((v) => !v)}
-      >
-        {hasDetail ? (
-          <ChevronRight size={13} className={`tool-card-caret${open ? " open" : ""}`} />
-        ) : (
-          <span className="tool-card-caret-spacer" />
-        )}
-        <Icon size={13} className="tool-card-icon" />
-        <span className="tool-card-name">{call.name}</span>
-        {call.durationMs !== undefined ? (
-          <span className="tool-card-dur">{formatDuration(call.durationMs)}</span>
+  const body =
+    call.input || call.output ? (
+      <>
+        {call.input ? (
+          <ToolSection label="input" copyText={call.input}>
+            <ToolValue raw={call.input} role="input" tool={call.name} />
+          </ToolSection>
         ) : null}
-        <StatusGlyph status={call.status} />
-      </button>
-      {open && hasDetail ? (
-        <div className="tool-card-body">
-          {call.input ? (
-            <ToolSection label="input" raw={call.input} role="input" tool={call.name} />
-          ) : null}
-          {call.output ? (
-            <ToolSection label="result" raw={call.output} role="output" tool={call.name} />
-          ) : null}
-        </div>
-      ) : null}
-    </div>
-  );
-}
+        {call.output ? (
+          <ToolSection label="result" copyText={call.output}>
+            <ToolValue raw={call.output} role="output" tool={call.name} />
+          </ToolSection>
+        ) : null}
+      </>
+    ) : undefined;
 
-function ToolSection({
-  label,
-  raw,
-  role,
-  tool,
-}: {
-  label: string;
-  raw: string;
-  role: "input" | "output";
-  tool: string;
-}) {
   return (
-    <div className="tool-card-section">
-      <div className="tool-section-head">
-        <span className="tool-card-label">{label}</span>
-        <CopyButton text={raw} />
-      </div>
-      <ToolValue raw={raw} role={role} tool={tool} />
-    </div>
-  );
-}
-
-/** Copies the raw value to the clipboard, flashing a check on success. */
-function CopyButton({ text }: { text: string }) {
-  const [copied, setCopied] = useState(false);
-  return (
-    <button
-      type="button"
-      className="tool-copy"
-      title="Copy to clipboard"
-      aria-label={copied ? "Copied" : "Copy"}
-      onClick={async () => {
-        try {
-          await navigator.clipboard.writeText(text);
-          setCopied(true);
-          setTimeout(() => setCopied(false), 1200);
-        } catch {
-          // Clipboard unavailable (insecure context / denied) — no-op.
-        }
-      }}
+    <ToolCard
+      name={call.name}
+      status={call.status}
+      icon={<Icon size={13} />}
+      duration={call.durationMs}
+      nested={nested}
     >
-      {copied ? <Check size={12} /> : <Copy size={12} />}
-    </button>
+      {body}
+    </ToolCard>
   );
-}
-
-/** Human-readable elapsed: "820ms" under a second, "1.2s" above. */
-function formatDuration(ms: number): string {
-  if (ms < 1000) return `${Math.round(ms)}ms`;
-  return `${(ms / 1000).toFixed(1)}s`;
-}
-
-function StatusGlyph({ status }: { status: ToolCall["status"] }) {
-  if (status === "running") return <Loader2 size={13} className="spin tool-card-status running" />;
-  if (status === "error") return <X size={13} className="tool-card-status error" />;
-  return <Check size={13} className="tool-card-status done" />;
 }

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -1,150 +1,24 @@
-/* tool-calls.css — the agent's tool-call cards + per-tool renderers.
-   Carved out of app/theme.css (#832, Axis-A step 2). Imported by ToolCalls.tsx;
-   classes are also used by tool-renderers.tsx (rendered only by ToolCalls).
-   Move verbatim — no restyle. */
+/* tool-calls.css — the agent's per-tool VALUE renderers (the card body).
+   Carved out of app/theme.css (#832, Axis-A step 2). The disclosure FRAME
+   (card chrome, header, caret, status glyph, duration, subagent nesting) is now
+   the DS `ToolCard` family (`@protolabsai/ui/tool-card`, `.pl-toolcard*` — styled
+   by the DS styles bundle imported in main.tsx). This file keeps only the
+   value-renderer body styling that lives INSIDE the DS body slot and has no DS
+   equivalent (it's domain logic, owned by tool-renderers.tsx, rendered only by
+   ToolCalls). Body/section-scoped rules are re-scoped onto the DS body/section
+   class names (`.pl-toolcard__body` / `.pl-toolcard__section`). */
 
-/* Tool-call cards — the agent's tool activity streamed into an assistant
-   message (name, running→done/error state, expandable input/result). */
+/* The `.tool-calls` passthrough class rides ToolCardList — it only adds the
+   bottom margin separating the tool column from the message text (the
+   flex-column + gap are the DS `.pl-toolcard-list`). */
 .tool-calls {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
   margin: 0 0 0.6em;
-  min-width: 0;
   max-width: 100%;
   white-space: normal;
 }
-.tool-card {
-  min-width: 0;
-  max-width: 100%;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-raised);
-  overflow: hidden;
-}
-/* Subagent grouping: a `task` card with its children nested beneath it. */
-.tool-card-group {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-.tool-children {
-  margin-left: 14px;
-  padding-left: 10px;
-  border-left: 2px solid var(--border);
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  min-width: 0;
-}
-.tool-card-running {
-  border-color: var(--warning);
-}
-.tool-card-head {
-  display: flex;
-  align-items: center;
-  gap: 7px;
-  width: 100%;
-  padding: 6px 9px;
-  background: none;
-  border: none;
-  color: var(--fg-secondary);
-  font: inherit;
-  font-size: 0.82rem;
-  text-align: left;
-  cursor: pointer;
-}
-.tool-card-head:disabled {
-  cursor: default;
-}
-.tool-card-caret {
-  flex: none;
-  color: var(--fg-muted);
-  transition: transform 0.12s ease;
-}
-.tool-card-caret.open {
-  transform: rotate(90deg);
-}
-.tool-card-caret-spacer {
-  width: 13px;
-  flex: none;
-}
-.tool-card-icon {
-  flex: none;
-  color: var(--brand-violet-light);
-}
-.tool-card-name {
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  font-family: var(--font-mono);
-  color: var(--fg);
-}
-.tool-card-dur {
-  flex: none;
-  font-family: var(--font-mono);
-  font-size: 0.7rem;
-  color: var(--fg-muted);
-  font-variant-numeric: tabular-nums;
-}
-.tool-card-status {
-  flex: none;
-}
-.tool-card-status.done {
-  color: var(--success);
-}
-.tool-card-status.error {
-  color: var(--error);
-}
-.tool-card-status.running {
-  color: var(--warning);
-}
-.tool-card-body {
-  border-top: 1px solid var(--border);
-  padding: 8px 9px;
-  display: flex;
-  flex-direction: column;
-  gap: 8px;
-}
-.tool-card-section {
-  display: flex;
-  flex-direction: column;
-  gap: 3px;
-}
-.tool-card-label {
-  font-size: 0.68rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-  color: var(--fg-muted);
-}
-.tool-section-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
-.tool-copy {
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  padding: 2px;
-  background: none;
-  border: none;
-  border-radius: 4px;
-  color: var(--fg-muted);
-  cursor: pointer;
-  opacity: 0.6;
-  transition: opacity 0.12s ease, color 0.12s ease, background 0.12s ease;
-}
-.tool-copy:hover {
-  opacity: 1;
-  color: var(--fg);
-  background: var(--bg-hover);
-}
-.tool-card-body pre {
+
+/* Generic JSON-blob fallback box, scoped to the DS body slot. */
+.pl-toolcard__body pre {
   margin: 0;
   padding: 6px 8px;
   background: var(--bg);
@@ -161,7 +35,7 @@
 
 /* Rendered tool values — structured components instead of a raw JSON blob.
    The shared surface for a scalar/text value is a padded, monospace-ish box. */
-.tool-card-section .tool-text,
+.pl-toolcard__section .tool-text,
 .tool-fetch-body {
   padding: 6px 8px;
   background: var(--bg);


### PR DESCRIPTION
**Draft, stacked on #863** (the Empty/Grid/Badge shrink) — review/merge #863 first, then this. #832 Axis-B flagship: adopt the DS `ToolCard` family for the chat tool-call frame.

The DS `ToolCard` CSS header says it was *"ported from the protoAgent console's tool-card family"* — so this is **our own component coming home**, a clean 1:1.

## What changed
- `ToolCalls.tsx`: bespoke `ToolCard`/`CopyButton`/`StatusGlyph`/`formatDuration` + local open-state/caret/disabled-toggle → DS `ToolCardList`/`ToolCard`/`ToolSection`. `status`/`name`/`durationMs` map straight off the wire `ToolCall`; `iconFor()` stays app-side feeding the DS `icon` slot; **subagent grouping rides the DS `nested` prop** (pixel-identical indent rail); collapsed-sticky default + disabled-caret-when-empty preserved.
- **Our rich value-renderers (`tool-renderers.tsx`) are untouched** — calculator/current_time/fetch_url/web_search/kv/error all render in the DS body via `<ToolSection><ToolValue/></ToolSection>`.
- `tool-calls.css`: deleted **19 bespoke `.tool-card*` frame rules**; kept every value-renderer body rule, re-scoped the 2 body-anchored ones onto `.pl-toolcard__body/__section`.

**Net −195 lines.** build + e2e **89/89**, vitest 36/36. Updated 5 e2e specs to the DS frame selectors.

## 👀 One visual delta (DS-frame difference)
A **running** card no longer shows a warning-toned **border** — running is now signaled by the DS spinner glyph only (the DS doesn't tint the card border). Minor, no functional loss. Candidate DS gap (a `running` border tone) if you want it back.

Last #832 item after this: `TabBar` (chat session tabs).

🤖 Generated with [Claude Code](https://claude.com/claude-code)