### PR TITLE
fix(config): config_to_dict emits plugins.disabled/sources.allow + from_dict drift guard

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **`config_to_dict` now emits the complete plugins section** — the serialized
+  config dict (the `/api/config` payload and anything else treating it as the
+  full config) carried only `plugins.{enabled, dir}`, silently dropping
+  `plugins.disabled` and `plugins.sources.allow` (2026-06-10 prod-readiness
+  audit, N6). The YAML file itself was never at risk — saves merge in place and
+  never delete absent keys — but dict consumers lost the values and the
+  Settings UI could never surface them; this unblocks the plugin-hardening
+  work that writes `sources.*`. A new drift-guard test also pins the third
+  triplet direction: `LangGraphConfig.from_dict` must consume every settings
+  FIELDS key with a non-default sentinel (a missing parse line used to mean
+  the YAML held the value, the UI showed it saved, and the runtime silently
+  read the default — audited: zero such drops today). (#865)
 - **Autostart launches the server again** — the macOS LaunchAgent installer still
   pointed at the single-file `server.py` that ADR 0023 promoted into the `server/`
   package: the install-time existence check always failed (the login-launch toggle

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -277,9 +277,17 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
             "db_path": config.skills_db_path,
             "dir": config.skills_dir,
         },
+        # Every plugins.* key from_dict consumes must be emitted here, or any
+        # consumer treating this dict as the COMPLETE config silently loses it
+        # (the YAML file itself was never at risk — apply_updates_to_yaml merges
+        # in place). `disabled` + `sources.allow` were omitted until the
+        # 2026-06-10 prod-readiness audit (N6); plugin-hardening P1 writes
+        # `sources.*`, so the dict has to carry them.
         "plugins": {
             "enabled": list(config.plugins_enabled),
+            "disabled": list(config.plugins_disabled),
             "dir": config.plugins_dir,
+            "sources": {"allow": list(config.plugins_sources_allow)},
         },
         "subagents": {
             "researcher": {

--- a/tests/test_config_drift_guard.py
+++ b/tests/test_config_drift_guard.py
@@ -14,6 +14,11 @@ shows a field that never persists (missing dataclass attr), or a save round-trip
 through a serializer that drops the section on the floor. These tests turn any
 such drift into a CI failure.
 
+Test #5 (2026-06-10) guards the third direction: ``LangGraphConfig.from_dict``
+must CONSUME every FIELDS key — a missing parse line means the YAML holds the
+value, config_to_dict shows it "saved", but the runtime silently reads the
+default.
+
 NOTE on the import path: ``config_to_dict`` lives in ``graph.config_io`` (not
 ``graph.config``) — it is imported from there below.
 
@@ -257,3 +262,103 @@ def test_field_scope_assignment_matches_adr_0047():
     # Only "agent" / "host" are valid today (App layer = dataclass defaults, no field scope).
     bad = {f.scope for f in FIELDS} - {"agent", "host"}
     assert not bad, f"unexpected Field.scope value(s): {bad}"
+
+
+# --------------------------------------------------------------------------- #
+# 5) Every non-secret FIELDS key is CONSUMED by from_dict (third direction).
+# --------------------------------------------------------------------------- #
+
+# The third drift direction tests #1-#2 don't cover: a FIELDS key whose parse
+# line is missing from ``LangGraphConfig.from_dict``. That failure is the
+# nastiest of the three — the YAML holds the value, config_to_dict echoes it
+# back (so the Settings UI shows it "saved"), but the live config silently
+# reads the default. Audited 2026-06-10: EMPTY — every FIELDS key has its
+# parse line today. If a field legitimately can't round-trip (computed /
+# env-only), add its key here WITH a comment saying why; a bare addition to
+# silence a red test is exactly the drift this set exists to make explicit.
+FROM_DICT_UNCONSUMED_KEYS: set[str] = set()
+
+_FROM_DICT_REASON = (
+    "from_dict has no parse line for this FIELDS key — the YAML value is "
+    "silently ignored and the dataclass default wins. Add the kwarg line in "
+    "LangGraphConfig.from_dict."
+)
+
+
+def _sentinel_for(field) -> object:
+    """A guaranteed NON-default value of the right shape for ``field``.
+
+    Derived from the dataclass default's Python type (bool checked before int —
+    it's an int subclass), falling back to the Field's declared UI type when the
+    default is ``None``. Using the default as the base means the sentinel can
+    never accidentally equal it.
+    """
+    default = getattr(LangGraphConfig(), field.attr)
+    if isinstance(default, bool):
+        return not default
+    if isinstance(default, int):
+        return default + 1
+    if isinstance(default, float):
+        return default + 0.5
+    if isinstance(default, str):
+        return "__drift__"
+    if isinstance(default, list):
+        return ["__drift__"]
+    if isinstance(default, dict):
+        return {"__drift__": 1}
+    # default is None (e.g. nullable sampler knobs) — pick by declared UI type.
+    return 1 if field.type == "number" else "__drift__"
+
+
+def _nest(dotted: str, value: object) -> dict:
+    """Build the minimal nested config dict setting ``dotted`` to ``value``."""
+    d: dict = {}
+    cursor = d
+    parts = dotted.split(".")
+    for part in parts[:-1]:
+        cursor = cursor.setdefault(part, {})
+    cursor[parts[-1]] = value
+    return d
+
+
+def _from_dict_consumes(field) -> tuple[object, object]:
+    """Run from_dict over a sentinel-bearing dict; return (sentinel, parsed)."""
+    sentinel = _sentinel_for(field)
+    cfg = LangGraphConfig.from_dict(_nest(field.key, sentinel))
+    return sentinel, getattr(cfg, field.attr)
+
+
+@pytest.mark.parametrize(
+    "field",
+    [_param(f, FROM_DICT_UNCONSUMED_KEYS, _FROM_DICT_REASON) for f in _NON_SECRET_FIELDS],
+)
+def test_from_dict_consumes_every_fields_key(field):
+    """A non-default sentinel placed at the dotted YAML key must land on the
+    mapped dataclass attr after ``from_dict``.
+
+    Secrets are excluded: their YAML value competes with the secrets-overlay
+    path and config_to_dict redacts them anyway, so the sentinel contract
+    doesn't hold (and #2 already excludes them for the same reason).
+    """
+    sentinel, parsed = _from_dict_consumes(field)
+    assert parsed == sentinel, (
+        f"FIELDS key {field.key!r}: from_dict left LangGraphConfig.{field.attr} "
+        f"at {parsed!r} instead of the sentinel {sentinel!r} — the parse line "
+        "is missing or reads a different key."
+    )
+
+
+def test_from_dict_unconsumed_set_is_exactly_as_expected():
+    """Belt-and-suspenders (same pattern as tests #1/#2): the live set of
+    FIELDS keys from_dict drops equals the documented exception set, so a new
+    field can't silently join it and a stale exception can't linger."""
+    live_unconsumed = set()
+    for f in _NON_SECRET_FIELDS:
+        sentinel, parsed = _from_dict_consumes(f)
+        if parsed != sentinel:
+            live_unconsumed.add(f.key)
+    assert live_unconsumed == FROM_DICT_UNCONSUMED_KEYS, (
+        f"from_dict consumption drift: {live_unconsumed} "
+        f"(expected {FROM_DICT_UNCONSUMED_KEYS}). Add the missing parse line in "
+        "LangGraphConfig.from_dict, or document the exception here with a reason."
+    )

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -227,7 +227,11 @@ CONFIG_TO_DICT_GOLDEN = {
     },
     "plugins": {
         "dir": "",
+        "disabled": [],
         "enabled": [],
+        "sources": {
+            "allow": [],
+        },
     },
     "prompt_cache": {
         "enabled": True,
@@ -307,9 +311,13 @@ EMITTED_ATTRS = {
     "mcp_servers",
     "mcp_timeout_seconds",
     "mcp_denylist",
-    # plugins.*
+    # plugins.* (disabled + sources.allow added by the 2026-06-10 N6 fix —
+    # config_to_dict used to emit only enabled/dir, so any complete-dict
+    # consumer lost them)
     "plugins_enabled",
+    "plugins_disabled",
     "plugins_dir",
+    "plugins_sources_allow",
     # identity.*
     "identity_name",
     "identity_operator",
@@ -743,3 +751,28 @@ def test_plugins_sources_empty_section_is_empty_list(tmp_path):
     path = _write_yaml(tmp_path, "plugins:\n  sources:\n")
     cfg = LangGraphConfig.from_yaml(path)
     assert cfg.plugins_sources_allow == []
+
+
+def test_plugins_disabled_and_sources_allow_survive_config_to_dict():
+    """N6 (2026-06-10 prod-readiness audit): config_to_dict emitted only
+    plugins.{enabled, dir}, dropping `disabled` + `sources.allow`. The YAML file
+    round-trip was never lossy (apply_updates_to_yaml merges in place and never
+    deletes absent keys) — the DICT was: any consumer treating it as the complete
+    config lost them, and the Settings UI could never display/edit them. This
+    pins the full plugins.* section round-tripping through from_dict ->
+    config_to_dict with NON-default values."""
+    cfg = LangGraphConfig.from_dict({
+        "plugins": {
+            "enabled": ["alpha"],
+            "disabled": ["beta"],
+            "dir": "/custom/plugins",
+            "sources": {"allow": ["github.com/protolabsai/*"]},
+        },
+    })
+    d = config_to_dict(cfg)
+    assert d["plugins"] == {
+        "enabled": ["alpha"],
+        "disabled": ["beta"],
+        "dir": "/custom/plugins",
+        "sources": {"allow": ["github.com/protolabsai/*"]},
+    }

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -154,9 +154,21 @@ def test_requires_env_gating(tmp_path, monkeypatch) -> None:
 def test_config_round_trip() -> None:
     from graph.config_io import config_to_dict
 
-    cfg = LangGraphConfig(plugins_enabled=["a", "b"], plugins_dir="/x")
+    cfg = LangGraphConfig(
+        plugins_enabled=["a", "b"],
+        plugins_disabled=["c"],
+        plugins_dir="/x",
+        plugins_sources_allow=["github.com/protolabsai/*"],
+    )
     d = config_to_dict(cfg)
-    assert d["plugins"] == {"enabled": ["a", "b"], "dir": "/x"}
+    # The dict must carry EVERY plugins.* key from_dict consumes (N6,
+    # 2026-06-10 audit) — it used to emit only enabled/dir.
+    assert d["plugins"] == {
+        "enabled": ["a", "b"],
+        "disabled": ["c"],
+        "dir": "/x",
+        "sources": {"allow": ["github.com/protolabsai/*"]},
+    }
 
 
 def test_from_yaml_parses_plugins(tmp_path) -> None:


### PR DESCRIPTION
Closes two config-system gaps found in the 2026-06-10 prod-readiness audit.

## Gap 1 — `config_to_dict` dropped `plugins.disabled` + `plugins.sources.allow` (N6, verified live)

The FIELDS-driven serializer's hand-written plugins section emitted only `{enabled, dir}`. Important precision: **the YAML file round-trip was never lossy** — `apply_updates_to_yaml` merges in place and never deletes absent keys — the **dict** was the lossy layer. Any consumer treating `config_to_dict()` output as the complete config (the `/api/config` payload, the Gradio drawer's `get_config`) silently lost the two keys, and the Settings UI could never display or edit them. (An earlier note that "`to_yaml` drops `sources.*`" was imprecise — persistence was safe; completeness wasn't.)

`from_dict` consumes exactly four `plugins.*` keys (`enabled`, `disabled`, `dir`, `sources.allow`); `config_to_dict` now emits all four. **This unblocks plugin-hardening P1 S1**, which needs `plugins.sources.*` to survive the dict layer.

Consumers checked: the settings UI schema is built from `FIELDS` and ignores non-FIELDS dict keys, so the new keys are inert there; goldens in `tests/test_config_roundtrip.py` and the plugins round-trip in `tests/test_plugins.py` updated to pin the full section (with non-default values).

## Gap 2 — nothing guarded the third drift direction: `from_dict` consuming every FIELDS key

`tests/test_config_drift_guard.py` pinned FIELDS→dataclass-attr and FIELDS→`config_to_dict`, but not FIELDS→`from_dict`. Forget the parse line when adding a field and the failure is the nastiest of the three: the YAML holds the value, `config_to_dict` echoes it back (UI shows it "saved"), and the runtime silently reads the default.

New test #5 (same style as #1/#2): for each non-secret FIELD, plant a type-appropriate **non-default sentinel** at the dotted key (bool→flipped, int→+1, float→+0.5, str→`"__drift__"`, list/dict→drift literals; None-default falls back to the declared UI type), run `from_dict`, and assert the mapped attr equals the sentinel — plus the belt-and-suspenders set-equality test so the documented exception set (`FROM_DICT_UNCONSUMED_KEYS`) can't silently grow or go stale.

**Audit result: zero real drops** — all 45 non-secret FIELDS keys already have their parse lines, so the exception set ships empty and no `from_dict` fixes were needed.

## Tests

- Full suite: `pytest tests/ -q -x` → **1606 passed**
- `ruff check` clean on all touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)