### PR TITLE
ci: import-linter architecture contract + pin release-tools clone

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -26,13 +26,18 @@ jobs:
           node-version: "20"
       - name: Verify workspace config (.beads / .automaker / owned runners)
         # The npm package is still 1.0.0 (predates verify-workspace-config),
-        # so run the v1.1.0 script directly. It's zero-dependency (node
-        # builtins only), so no `npm install` is needed. Switch to
+        # so run the script directly. It's zero-dependency (node builtins
+        # only), so no `npm install` is needed. Switch to
         # `npx -p @protolabsai/release-tools verify-workspace-config` once
         # 1.1.0+ is published to npm (protoLabsAI/release-tools#27).
+        # Pinned by commit SHA (same supply-chain posture as the
+        # release-tools action pin in release.yml) so a push to that repo's
+        # main can't change what executes in this PR gate. To bump: pick the
+        # new release-tools SHA/tag and update both the SHA and the version
+        # comment below.
         run: |
-          git clone --depth 1 \
-            https://github.com/protoLabsAI/release-tools /tmp/release-tools
+          git clone https://github.com/protoLabsAI/release-tools /tmp/release-tools
+          git -C /tmp/release-tools checkout 96159f8f3adf3cce60278cc689b67521ff5a547c # v2.3.0
           node /tmp/release-tools/bin/verify-workspace-config.mjs --root "$GITHUB_WORKSPACE"
       - name: Guard against the deleted server.py entrypoint
         # ADR 0023 promoted the monolith to the server/ package (launch:
@@ -55,7 +60,7 @@ jobs:
           echo "ok: no stale single-file launches in deploy artifacts or launchers"
 
   lint:
-    name: Lint (ruff)
+    name: Lint (ruff + import contracts)
     runs-on: namespace-profile-protolabs-linux
     timeout-minutes: 5
     steps:
@@ -69,6 +74,15 @@ jobs:
         run: |
           pip install ruff==0.15.10
           ruff check .
+      - name: Import contracts (import-linter)
+        # Architectural layering gate: graph/ and the infra packages must not
+        # import server/ or operator_api/ (contracts + the grandfathered
+        # burndown list live in pyproject.toml [tool.importlinter]). Static
+        # AST analysis only — catches function-level (lazy) imports too and
+        # needs no project deps installed. Pinned like ruff above.
+        run: |
+          pip install import-linter==2.11
+          lint-imports
 
   tests:
     name: Python tests

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Architectural import contracts in CI** — `lint-imports` (import-linter,
+  pinned) now gates three layering contracts declared in `pyproject.toml
+  [tool.importlinter]`: `graph/` and the infra packages
+  (`events`/`knowledge`/`runtime`/`scheduler`/`tools`) must not import
+  `server/` or `operator_api/`, and `operator_api/` must not import `server/`.
+  The 8 existing violations (e.g. `graph.skills.cli -> server.agent_init`, the
+  `operator_api` route modules reaching into `server.agent_init`/`server.chat`)
+  are grandfathered as an explicit burndown list in `ignore_imports` — new
+  violations fail CI, including function-level (lazy) imports. (#858)
+
 ### Fixed
 - **Autostart launches the server again** — the macOS LaunchAgent installer still
   pointed at the single-file `server.py` that ADR 0023 promoted into the `server/`
@@ -60,6 +71,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   lost-update on the YAML plus interleaved graph reloads — `_apply_settings_changes`,
   `_reset_settings_keys`, and `_reload_langgraph_agent` now serialize on one
   RLock.
+- **Pinned the release-tools clone in the PR gate** — `checks.yml` cloned
+  `protoLabsAI/release-tools` at HEAD and executed its script on every PR, so
+  a push to that repo's `main` could change what runs in this repo's CI. The
+  clone is now pinned to a commit SHA (v2.3.0), matching the action pin
+  `release.yml` already uses. (#858)
 
 ## [0.32.0] - 2026-06-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The 8 existing violations (e.g. `graph.skills.cli -> server.agent_init`, the
   `operator_api` route modules reaching into `server.agent_init`/`server.chat`)
   are grandfathered as an explicit burndown list in `ignore_imports` — new
-  violations fail CI, including function-level (lazy) imports. (#858)
+  violations fail CI, including function-level (lazy) imports. (#866)
 
 ### Fixed
 - **Autostart launches the server again** — the macOS LaunchAgent installer still
@@ -75,7 +75,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `protoLabsAI/release-tools` at HEAD and executed its script on every PR, so
   a push to that repo's `main` could change what runs in this repo's CI. The
   clone is now pinned to a commit SHA (v2.3.0), matching the action pin
-  `release.yml` already uses. (#858)
+  `release.yml` already uses. (#866)
 
 ## [0.32.0] - 2026-06-10
 

--- a/docs/dev/prod-readiness-tasklist.md
+++ b/docs/dev/prod-readiness-tasklist.md
@@ -49,6 +49,28 @@ Suggested order (dependency-aware):
 
 ## C. Backend structure
 
+> **Import contracts now CI-enforced (2026-06-10).** `lint-imports`
+> (import-linter, pinned in the checks.yml lint job) gates three layering
+> contracts declared in `pyproject.toml [tool.importlinter]`:
+> 1. **graph → server/operator_api forbidden** — grandfathered:
+>    `graph.skills.cli -> server.agent_init` (lazy import of seed paths).
+> 2. **operator_api → server forbidden** — grandfathered (7): `chat_routes ->
+>    server / server.agent_init / server.chat`, `config_routes ->
+>    server.agent_init`, `console_handlers -> server`, `mcp_routes ->
+>    server.agent_init`, `plugin_routes -> server.agent_init`. These are the
+>    other half of the server↔operator_api ring (server/__init__ imports
+>    operator_api.* lazily inside `_main`).
+> 3. **events/knowledge/runtime/scheduler/tools → server/operator_api
+>    forbidden** — clean today, locked in (no ignores).
+>
+> The `ignore_imports` lists are a **burndown list, not an allowance** —
+> import-linter sees function-level (lazy) imports too, so new violations fail
+> CI even if hidden inside a function. Don't add entries; delete them as C1/C2
+> untangle `_main()`/`agent_init.py`. The graph-internal config ring
+> (`config`/`config_io`/`settings_schema`/`plugins.loader`/`plugins.pconfig`)
+> is B1's territory — same-package cycles, not expressible as a forbidden
+> contract; collapse the triplet instead.
+
 | ID | Task | Evidence | Effort | Disp. |
 |----|------|----------|:------:|:-----:|
 | C1 | Break up `_main()` (534 L); extract host-binding **security gate** into a testable fn | `server/__init__.py:274,794` | M | 🟡 Next |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,6 +109,61 @@ include = [
 # via the [build-system] above.
 package = false
 
+[tool.importlinter]
+# Architectural import contracts (enforced by `lint-imports` in CI — see
+# .github/workflows/checks.yml and docs/dev/prod-readiness-tasklist.md § C2).
+# Layering: graph/ (agent brain) and the infra packages (tools/knowledge/
+# events/scheduler/runtime) must never reach up into the server bootstrap or
+# the operator HTTP surface. import-linter analyzes function-level (lazy)
+# imports too, so the `ignore_imports` lists below are explicit grandfathered
+# violations — a BURNDOWN LIST, not an allowance. Don't add to them; remove
+# entries as the cycles are untangled (the server.agent_init decomposition,
+# tasklist C2, owns most of the burndown).
+root_packages = [
+  "events",
+  "graph",
+  "knowledge",
+  "operator_api",
+  "runtime",
+  "scheduler",
+  "server",
+  "tools",
+]
+
+[[tool.importlinter.contracts]]
+name = "graph does not import server or operator_api"
+type = "forbidden"
+source_modules = ["graph"]
+forbidden_modules = ["server", "operator_api"]
+# Burndown: skills CLI reaches into server bootstrap for seed paths (lazy import).
+ignore_imports = [
+  "graph.skills.cli -> server.agent_init",
+]
+
+[[tool.importlinter.contracts]]
+name = "operator_api does not import server"
+type = "forbidden"
+source_modules = ["operator_api"]
+forbidden_modules = ["server"]
+# Burndown: the route modules still pull settings-apply + chat internals out of
+# the server package (server/__init__ imports operator_api.* lazily inside
+# _main, so these are the other half of the server↔operator_api ring).
+ignore_imports = [
+  "operator_api.chat_routes -> server",
+  "operator_api.chat_routes -> server.agent_init",
+  "operator_api.chat_routes -> server.chat",
+  "operator_api.config_routes -> server.agent_init",
+  "operator_api.console_handlers -> server",
+  "operator_api.mcp_routes -> server.agent_init",
+  "operator_api.plugin_routes -> server.agent_init",
+]
+
+[[tool.importlinter.contracts]]
+name = "infra packages do not import server or operator_api"
+type = "forbidden"
+source_modules = ["events", "knowledge", "runtime", "scheduler", "tools"]
+forbidden_modules = ["server", "operator_api"]
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 testpaths = ["tests"]


### PR DESCRIPTION
## Part 1 — architectural import contracts (import-linter)

The 2026-06-10 audit found two real import cycles held together by lazy in-function imports (the graph config ring, and the server ↔ operator_api ring). This PR doesn't untangle them — it **stops new violations** while grandfathering the existing ones explicitly.

`pyproject.toml [tool.importlinter]` declares three `forbidden` contracts over the flat top-level packages, gated by a new `lint-imports` step in the checks.yml **lint** job (`pip install import-linter==2.11`, pinned like ruff; static AST analysis — needs no project deps, and it **does** see function-level/lazy imports):

1. **`graph` does not import `server` or `operator_api`** — grandfathered (1):
   - `graph.skills.cli -> server.agent_init` (lazy; seed/commons paths)
2. **`operator_api` does not import `server`** — grandfathered (7), the other half of the ring (`server/__init__` imports `operator_api.*` lazily inside `_main`):
   - `operator_api.chat_routes -> server` / `-> server.agent_init` / `-> server.chat` (module-top)
   - `operator_api.config_routes -> server.agent_init` (module-top)
   - `operator_api.console_handlers -> server` (module-top)
   - `operator_api.mcp_routes -> server.agent_init` (lazy ×3)
   - `operator_api.plugin_routes -> server.agent_init` (lazy)
3. **`events`/`knowledge`/`runtime`/`scheduler`/`tools` do not import `server` or `operator_api`** — verified clean today, locked in with zero ignores.

The `ignore_imports` lists are a **burndown list, not an allowance** — import-linter errors on unmatched ignores, so the list is exactly the current violation set and shrinks monotonically as C1/C2 (the `_main()`/`agent_init.py` decompositions) land. Documented in `docs/dev/prod-readiness-tasklist.md` § C. The graph-internal config ring (`config`/`config_io`/`settings_schema`/`plugins.loader`/`plugins.pconfig`) is same-package cycles — not expressible as a forbidden contract; that's B1 (collapse the config triplet).

## Part 2 — pin the release-tools clone (supply chain)

The workspace-config job did `git clone --depth 1` of `protoLabsAI/release-tools` at **HEAD** and executed its script on every PR — a push to that repo's `main` could change what runs in this repo's CI, unlike `release.yml`, which pins the same repo by commit SHA. The clone is now checked out at `96159f8f3adf3cce60278cc689b67521ff5a547c` (v2.3.0, current main) with a comment explaining why + how to bump.

## Validation

- `lint-imports`: **3 kept, 0 broken** (also verified in an isolated env with no project deps — the CI scenario)
- `pytest tests/ -q`: **1559 passed**
- `ruff check .`: clean; workflow YAML parses
- No dependency changes (import-linter is CI-pinned like ruff — no dev group exists in this repo; `uv.lock` untouched). Note: `uv lock --check` fails on a clean main checkout too — pre-existing drift, not from this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)