### PR TITLE
fix: periodic a2a task sweep, off-loop webhook DNS, enforce min_protoagent_version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   FIELDS key with a non-default sentinel (a missing parse line used to mean
   the YAML held the value, the UI showed it saved, and the runtime silently
   read the default — audited: zero such drops today). (#865)
+- **A2A task records no longer accumulate forever on an always-on agent** — the
+  24h task-TTL sweep ran only inside `initialize_a2a_stores` at boot, so a
+  long-running process grew `a2a-tasks.db` unbounded between restarts. The
+  sweep now also runs from the existing hourly prune loop (alongside the
+  checkpoint + telemetry pruning), best-effort with a log line.
+- **Webhook DNS resolution no longer blocks the event loop** — the push-callback
+  SSRF guard (`is_safe_webhook_url`) calls `socket.getaddrinfo` synchronously,
+  and it ran *on* the loop at push-config set-time and before **every** push
+  POST (the send-time re-validation backstop) — one slow resolver stalled every
+  stream, health check and A2A peer for the OS timeout. Both async call sites
+  now dispatch the check via `asyncio.to_thread`; the guard itself stays sync
+  and its policy is unchanged.
+- **`min_protoagent_version` is actually enforced** — the plugin manifest field
+  was parsed and documented as a compat guard ("warn/refuse on an older host")
+  but never compared against anything. The loader now refuses to load an
+  enabled plugin that declares a newer minimum than the running host (clear
+  `log.error` naming both versions, surfaced in the plugin's status meta,
+  before any plugin code imports); a malformed version string on either side
+  only warns and loads, so a typo can't brick a plugin. Adds `packaging` to
+  `[project.dependencies]` (it was only a transitive dep; the loader now
+  imports it directly).
 - **Autostart launches the server again** — the macOS LaunchAgent installer still
   pointed at the single-file `server.py` that ADR 0023 promoted into the `server/`
   package: the install-time existence check always failed (the login-launch toggle

--- a/a2a_stores.py
+++ b/a2a_stores.py
@@ -25,6 +25,7 @@ restart. This module restores the two capabilities the bespoke
 
 from __future__ import annotations
 
+import asyncio
 import ipaddress
 import logging
 import os
@@ -187,7 +188,9 @@ class ValidatingPushNotificationConfigStore(DatabasePushNotificationConfigStore)
         context: ServerCallContext,
     ) -> None:
         url = notification_config.url
-        if url and not is_safe_webhook_url(url):
+        # is_safe_webhook_url resolves hostnames synchronously (getaddrinfo);
+        # run it off the loop so a slow resolver can't stall the whole process.
+        if url and not await asyncio.to_thread(is_safe_webhook_url, url):
             log.warning("[a2a] rejected unsafe webhook url at set-time: %s", url)
             raise ValueError(
                 f"push-notification callback url is not allowed: {url!r} "
@@ -212,7 +215,10 @@ class ValidatingPushNotificationSender(BasePushNotificationSender):
         task_id: str,
     ) -> bool:
         url = push_info.url
-        if url and not is_safe_webhook_url(url):
+        # Re-validate at send-time (DNS may have changed since set-time) — but
+        # off the loop: this runs before EVERY push POST, and a synchronous
+        # getaddrinfo here would block the event loop for the OS timeout.
+        if url and not await asyncio.to_thread(is_safe_webhook_url, url):
             log.warning(
                 "[a2a] refusing push delivery to unsafe webhook url for "
                 "task_id=%s: %s",

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -137,6 +137,64 @@ def run_plugin_mcp_main(plugin_id: str) -> None:
     raise RuntimeError(f"plugin {plugin_id!r} not found for --mcp-plugin")
 
 
+def _host_version() -> str:
+    """The running protoAgent version, for the manifest compat gate.
+
+    Same resolution order as the A2A card (``server.a2a._package_version`` —
+    not imported here, ``graph`` must not depend on ``server``): installed
+    package metadata first, then the repo ``pyproject.toml`` ``[project].version``.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("protoagent")
+        except PackageNotFoundError:
+            pass
+    except ImportError:  # pragma: no cover - importlib.metadata always present on 3.11+
+        pass
+
+    from graph.config_io import _BUNDLE_CONFIG_DIR
+
+    pyproject = _BUNDLE_CONFIG_DIR.parent / "pyproject.toml"
+    try:
+        m = re.search(r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.MULTILINE)
+        if m:
+            return m.group(1)
+    except OSError:
+        pass
+    return "0.0.0"
+
+
+def _min_version_gate(manifest: PluginManifest) -> str | None:
+    """Enforce the manifest's ``min_protoagent_version`` compat guard.
+
+    Returns ``None`` when the plugin may load, or a refusal reason when the
+    plugin declares it needs a *newer* host than this one — a plugin written
+    against a newer plugin SDK can break the host, so refusing matches the
+    manifest's documented "warn/refuse on an older host" promise. A malformed
+    version string (either side) only warns and loads — a typo in a manifest
+    must not brick the plugin.
+    """
+    declared = (manifest.min_protoagent_version or "").strip()
+    if not declared:
+        return None
+    from packaging.version import InvalidVersion, Version
+
+    host_raw = _host_version()
+    try:
+        needed, host = Version(declared), Version(host_raw)
+    except InvalidVersion:
+        log.warning(
+            "[plugins] %s: unparseable min_protoagent_version %r (host %r) — loading anyway",
+            manifest.id, declared, host_raw,
+        )
+        return None
+    if needed > host:
+        return f"requires protoAgent >= {declared} but this host is {host_raw}"
+    return None
+
+
 def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLoadResult:
     """Load enabled plugins and collect their contributions.
 
@@ -178,6 +236,16 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         if missing:
             entry["error"] = f"missing env: {', '.join(missing)}"
             log.warning("[plugins] %s enabled but %s — skipping", manifest.id, entry["error"])
+            result.meta.append(entry)
+            continue
+
+        # min_protoagent_version compat gate (ADR 0027) — refuse before the
+        # plugin's code ever imports (a plugin built for a newer SDK can break
+        # the host); malformed versions warn inside the gate and load anyway.
+        incompat = _min_version_gate(manifest)
+        if incompat:
+            entry["error"] = incompat
+            log.error("[plugins] %s enabled but %s — refusing to load", manifest.id, incompat)
             result.meta.append(entry)
             continue
 

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -61,7 +61,9 @@ class PluginManifest:
     #   requires_pip: declared pip deps. NOT auto-installed (install ≠ code exec);
     #     the operator installs them explicitly. Missing → clear error on enable.
     #   repository/homepage: provenance, shown in the install review.
-    #   min_protoagent_version: compat guard (warn/refuse on an older host).
+    #   min_protoagent_version: compat guard — the loader refuses to load the
+    #     plugin when the host is older than declared (malformed strings only
+    #     warn and load).
     requires_pip: list[str] = field(default_factory=list)
     repository: str = ""
     homepage: str = ""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,9 @@ dependencies = [
   "langfuse>=3.0",
   "prometheus-client>=0.20",
   "pyyaml>=6.0",
+  # imported directly by graph/plugins/loader.py (min_protoagent_version gate);
+  # was previously only a transitive dep (a2a-sdk, langchain-core, langfuse).
+  "packaging>=23.2",
   "ruamel.yaml>=0.18",
   "websockets>=12.0",
   "langchain>=1.2.3",

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -28,6 +28,9 @@ uvicorn>=0.30
 langfuse>=3.0
 prometheus-client>=0.20
 pyyaml>=6.0
+# imported directly by graph/plugins/loader.py (min_protoagent_version gate);
+# was previously only a transitive dep (a2a-sdk, langchain-core, langfuse).
+packaging>=23.2
 ruamel.yaml>=0.18  # round-trip YAML that preserves comments in config/langgraph-config.yaml when the drawer writes back edits
 websockets>=12.0
 

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -29,6 +29,10 @@ class AppState:
     workflow_registry: Any = None  # set by the workflows plugin (None = plugin disabled)
     workflow_run: Any = None  # async (name, inputs, on_step) -> result; set by the workflows plugin
     telemetry_store: Any = None
+    # Async engine behind the durable A2A task store — held so the periodic
+    # prune loop can re-run the 24h TTL sweep (it used to run only at boot, so
+    # an always-on agent accumulated task rows forever between restarts).
+    a2a_task_engine: Any = None
     inbox_store: Any = None
     beads_store: Any = None
     storm_guard: Any = None

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -716,6 +716,10 @@ def _main():
     # set-time; the matching push sender re-validates at send-time.
     task_store, push_config_store, task_db, push_db = build_a2a_stores()
     asyncio.run(initialize_a2a_stores(task_store, push_config_store))
+    # Hand the engine to the periodic prune loop so the 24h TTL sweep keeps
+    # running on an always-on agent (boot-only before — rows grew unbounded
+    # between restarts).
+    STATE.a2a_task_engine = task_store.engine
     log.info("[a2a] durable stores ready (tasks=%s, push=%s)", task_db, push_db)
 
     async def _structured_finalizer(skill_id: str, final_text: str):

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -633,6 +633,19 @@ async def _checkpoint_prune_loop() -> None:
                     log.info("[telemetry-prune] removed %d turn(s) older than %dd", removed, keep_days)
             except Exception:
                 log.exception("[telemetry-prune] sweep failed")
+        # A2A task TTL sweep (24h) — used to run only at boot, so an always-on
+        # agent accumulated task rows forever between restarts. The store is
+        # async (aiosqlite engine on this same loop), so it's awaited directly
+        # rather than dispatched to a thread like the sync sqlite neighbors.
+        if STATE.a2a_task_engine is not None:
+            try:
+                from a2a_stores import sweep_expired_tasks
+
+                swept = await sweep_expired_tasks(STATE.a2a_task_engine)
+                if swept:
+                    log.info("[a2a-task-prune] removed %d expired task record(s) (24h TTL)", swept)
+            except Exception:
+                log.exception("[a2a-task-prune] sweep failed")
         # Tick at the checkpoint interval if set, else hourly (so telemetry pruning
         # still runs when checkpoint pruning is off).
         await asyncio.sleep(max(1, interval_h or 1) * 3600)

--- a/tests/test_a2a_stores.py
+++ b/tests/test_a2a_stores.py
@@ -290,3 +290,54 @@ async def test_send_time_guard_blocks_private_without_network(tmp_path):
         )
         assert ok is False
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_async_paths_resolve_dns_off_the_event_loop(tmp_path, monkeypatch):
+    """Both async guard call sites run ``is_safe_webhook_url`` via
+    ``asyncio.to_thread``, so a slow resolver can't stall the whole process:
+    ``getaddrinfo`` must execute on a worker thread, not the loop's thread."""
+    import threading
+
+    loop_thread = threading.get_ident()
+    resolver_threads: list[int] = []
+
+    def _recording_getaddrinfo(host, port, *args, **kwargs):
+        resolver_threads.append(threading.get_ident())
+        # (family, type, proto, canonname, sockaddr) for a public address.
+        return [(2, 1, 6, "", ("8.8.8.8", 0))]
+
+    monkeypatch.setattr(a2a_stores.socket, "getaddrinfo", _recording_getaddrinfo)
+
+    db = str(tmp_path / "a2a-push.db")
+    store, engine = await _fresh_push_store(db)
+    # Set-time path (hostname URL so the guard actually resolves).
+    await store.set_info(
+        "task-dns",
+        TaskPushNotificationConfig(task_id="task-dns", url="https://hooks.example.test/x"),
+        _ctx(),
+    )
+    assert resolver_threads, "set_info never hit the resolver"
+    assert all(t != loop_thread for t in resolver_threads)
+
+    # Send-time path: the guard re-resolves before the POST; refuse via a
+    # resolver that "now" returns a private address — still off the loop.
+    resolver_threads.clear()
+    monkeypatch.setattr(
+        a2a_stores.socket,
+        "getaddrinfo",
+        lambda host, port, *a, **kw: (
+            resolver_threads.append(threading.get_ident()),
+            [(2, 1, 6, "", ("10.0.0.1", 0))],
+        )[1],
+    )
+    async with httpx.AsyncClient() as client:
+        sender = a2a_stores.build_push_sender(store, client)
+        ok = await sender._dispatch_notification(
+            None,
+            TaskPushNotificationConfig(task_id="task-dns", url="https://hooks.example.test/x"),
+            "task-dns",
+        )
+    assert ok is False
+    assert resolver_threads and all(t != loop_thread for t in resolver_threads)
+    await engine.dispose()

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -395,3 +395,47 @@ def test_plugin_embedder_is_collected(monkeypatch, tmp_path) -> None:
     monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
     res = load_plugins(_cfg(plugins_enabled=["embplugin"]))
     assert "local" in res.embedders  # ADR 0031 follow-up
+
+
+# ── min_protoagent_version compat gate (ADR 0027) ────────────────────────────────
+
+
+def test_min_version_newer_than_host_refuses_load(tmp_path, monkeypatch) -> None:
+    """A plugin declaring it needs a newer host is refused, with both versions
+    in the surfaced error (the manifest's documented "warn/refuse" promise)."""
+    root = tmp_path / "plugins"
+    _make_plugin(root, "toonew", enabled=True, tool="toonew_tool",
+                 manifest_extra="min_protoagent_version: 99.0.0\n")
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    monkeypatch.setattr(plugin_loader, "_host_version", lambda: "0.32.0")
+    res = load_plugins(_cfg())
+    assert res.tools == []
+    meta = res.meta[0]
+    assert meta["loaded"] is False
+    assert "99.0.0" in meta["error"] and "0.32.0" in meta["error"]
+
+
+def test_min_version_equal_or_older_loads(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "plugins"
+    _make_plugin(root, "okequal", enabled=True, tool="okequal_tool",
+                 manifest_extra="min_protoagent_version: 0.32.0\n")
+    _make_plugin(root, "okolder", enabled=True, tool="okolder_tool",
+                 manifest_extra="min_protoagent_version: 0.1.0\n")
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    monkeypatch.setattr(plugin_loader, "_host_version", lambda: "0.32.0")
+    res = load_plugins(_cfg())
+    assert sorted(t.name for t in res.tools) == ["okequal_tool", "okolder_tool"]
+
+
+def test_min_version_garbage_warns_and_loads(tmp_path, monkeypatch, caplog) -> None:
+    """A typo'd version string must not brick the plugin — warn and load."""
+    root = tmp_path / "plugins"
+    _make_plugin(root, "typoed", enabled=True, tool="typoed_tool",
+                 manifest_extra="min_protoagent_version: not-a-version\n")
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    monkeypatch.setattr(plugin_loader, "_host_version", lambda: "0.32.0")
+    with caplog.at_level("WARNING", logger="protoagent.plugins"):
+        res = load_plugins(_cfg())
+    assert [t.name for t in res.tools] == ["typoed_tool"]
+    assert res.meta[0]["loaded"] is True
+    assert any("min_protoagent_version" in r.message for r in caplog.records)

--- a/uv.lock
+++ b/uv.lock
@@ -52,9 +52,9 @@ name = "aiologic"
 version = "0.16.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "sniffio" },
+    { name = "sniffio", marker = "python_full_version < '3.13'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
-    { name = "wrapt" },
+    { name = "wrapt", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/a8/13/50b91a3ea6b030d280d2654be97c48b6ed81753a50286ee43c646ba36d3c/aiologic-0.16.0.tar.gz", hash = "sha256:c267ccbd3ff417ec93e78d28d4d577ccca115d5797cdbd16785a551d9658858f", size = 225952, upload-time = "2025-11-27T23:48:41.195Z" }
 wheels = [
@@ -526,7 +526,7 @@ name = "culsans"
 version = "0.11.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "aiologic" },
+    { name = "aiologic", marker = "python_full_version < '3.13'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/d9/e3/49afa1bc180e0d28008ec6bcdf82a4072d1c7a41032b5b759b60814ca4b0/culsans-0.11.0.tar.gz", hash = "sha256:0b43d0d05dce6106293d114c86e3fb4bfc63088cfe8ff08ed3fe36891447fe33", size = 107546, upload-time = "2025-12-31T23:15:38.196Z" }
@@ -2100,7 +2100,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.31.0"
+version = "0.32.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },
@@ -2118,6 +2118,7 @@ dependencies = [
     { name = "langgraph" },
     { name = "langgraph-checkpoint-sqlite" },
     { name = "mcp" },
+    { name = "packaging" },
     { name = "prometheus-client" },
     { name = "protolabs-a2a" },
     { name = "python-multipart" },
@@ -2165,6 +2166,7 @@ requires-dist = [
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "mcp", marker = "extra == 'google'", specifier = ">=1.2" },
+    { name = "packaging", specifier = ">=23.2" },
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "protoagent", extras = ["ui", "google"], marker = "extra == 'all'" },
     { name = "protolabs-a2a", git = "https://github.com/protoLabsAI/protolabs-a2a.git?rev=v0.2.0" },


### PR DESCRIPTION
Three XS/S backend hardenings from the 2026-06-10 prod-readiness audit, bundled into one PR.

## 1. A2A task TTL sweep ran only at boot

**Failure scenario:** an always-on agent never restarts, so `sweep_expired_tasks` (invoked solely from `initialize_a2a_stores`) never runs again — `a2a-tasks.db` accumulates task rows forever. The 24h TTL was effectively "24h or until the heat death of the process, whichever is longer."

**Fix:** the sweep now also runs from the existing hourly prune loop (`server/agent_init.py::_checkpoint_prune_loop`, alongside the checkpoint + telemetry pruning), best-effort with a log line, matching its neighbors. The store is async (aiosqlite engine on the same loop the request handlers use), so it's awaited directly rather than dispatched via `asyncio.to_thread` like the sync sqlite neighbors. The engine is handed over via `STATE.a2a_task_engine`.

## 2. Blocking DNS on the event loop in the push-notification paths

**Failure scenario:** `is_safe_webhook_url` calls `socket.getaddrinfo` synchronously, and it ran *on* the loop in `async def set_info` (webhook registration) and `async def _dispatch_notification` (before **every** push POST — the send-time re-validation backstop). One slow/unresponsive resolver stalls every stream, health check, and A2A peer on the server for the OS resolver timeout.

**Fix:** both async call sites now run the guard via `await asyncio.to_thread(is_safe_webhook_url, ...)`. The guard itself stays sync (it's also the documented sync policy surface referenced by `security.py`) and its SSRF policy — including send-time re-validation against DNS changes — is unchanged. New test asserts the resolver executes off the loop's thread on both paths.

## 3. `min_protoagent_version` was parsed but never enforced

**Failure scenario:** a plugin manifest declares `min_protoagent_version: 0.40.0` (documented as "compat guard — warn/refuse on an older host"), an operator installs it on a 0.32.0 host, and… it loads anyway, then breaks at runtime against an older plugin SDK with an opaque error (or worse, half-works).

**Fix:** the loader's enable path now compares the declared minimum against the running host version (resolved the same way the A2A card does: installed package metadata, then `pyproject.toml`) using `packaging.version`, **before any plugin code imports**:
- min > host → **refused**, with a clear `log.error` naming both versions, surfaced in the plugin's status meta (console "error" field).
- equal/older → loads normally.
- malformed version string (either side) → `log.warning` and load anyway — a typo can't brick a plugin.

`packaging` was only a transitive dep (a2a-sdk, langchain-core, langfuse); since the loader now imports it directly it's promoted to `[project.dependencies]` (+ `uv lock`, `requirements-core.txt` reference kept in step).

## Tests

- `tests/test_a2a_stores.py::test_async_paths_resolve_dns_off_the_event_loop` (new) — monkeypatched resolver records its thread on both the set-time and send-time paths.
- `tests/test_plugins.py` (new ×3) — newer-min refused with both versions in the error; equal/older load; garbage version warns + loads.
- Full suite: **1610 passed** (post-rebase on main); ruff clean; `uv lock --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)