### PR TITLE
feat(fleet): hub↔remote version handshake + remotes registry write lock

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,7 +34,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `remotes.json` mutations now serialize on their own sibling FileLock
   (`remotes.json.lock`) instead of sharing `fleet.json`'s, so remote add/remove
   and probe-version persists can't contend with — or be lost under — fleet-state
-  writes. (#862)
+  writes. (#868)
 
 ### Fixed
 - **`config_to_dict` now emits the complete plugins section** — the serialized

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `operator_api` route modules reaching into `server.agent_init`/`server.chat`)
   are grandfathered as an explicit burndown list in `ignore_imports` — new
   violations fail CI, including function-level (lazy) imports. (#866)
+- **Hub↔remote version handshake — fleet version skew is visible now** (audit N5).
+  The console↔server `/api/*` surface has no versioning, and a remote fleet member
+  (ADR 0042 §I) makes skew real: the hub console drives a *different release* by
+  proxy. The remote-reachability probe now also lifts the remote's app version off
+  its A2A agent card (same unauthenticated request, no extra round-trip) and
+  persists it on the registry record; `/api/fleet` carries `version` on every
+  member (the hub's own on the `host` entry, never any token), and
+  `/api/runtime/status` reports the serving instance's `version`. Settings →
+  Agents shows a warning badge on a remote whose version differs from the hub's
+  ("remote runs vX.Y.Z, hub vA.B.C — features may misbehave"). Also:
+  `remotes.json` mutations now serialize on their own sibling FileLock
+  (`remotes.json.lock`) instead of sharing `fleet.json`'s, so remote add/remove
+  and probe-version persists can't contend with — or be lost under — fleet-state
+  writes. (#862)
 
 ### Fixed
 - **`config_to_dict` now emits the complete plugins section** — the serialized

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -515,6 +515,10 @@ export type FleetAgent = {
   host?: boolean; // the instance serving this console — can't be stopped/removed from itself
   remote?: boolean; // a REMOTE member (ADR 0042 §I) — proxied by URL, no start/stop from here
   url?: string; // the remote member's base URL
+  // App version (pyproject [project].version). Always set on the host (hub) entry;
+  // for a remote member it's the last-probed value ("" until the first probe lands).
+  // The console flags hub↔remote skew — the proxied /api/* surface has no other versioning.
+  version?: string;
 };
 
 // The focused agent is the URL slug now (ADR 0042 slug routing) — no server-side 'active'.

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -4,7 +4,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Link2, Pencil, Play, Plus, Radar, Square, Trash2 } from "lucide-react";
 import { useState } from "react";
 
-import { Button } from "@protolabsai/ui/primitives";
+import { Badge, Button } from "@protolabsai/ui/primitives";
 import { EditableText } from "@protolabsai/ui/forms";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
@@ -38,6 +38,9 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
 
   const agents = fleet.data?.agents ?? [];
   const slug = currentSlug(); // the agent this window is focused on (the URL slug)
+  // Hub↔remote version handshake (ADR 0042 §I): the proxied /api/* surface has no
+  // other versioning, so a remote member on a different release gets a warning badge.
+  const hubVersion = agents.find((a) => a.host)?.version ?? "";
 
   const run = useMutation({
     mutationFn: async (fn: () => Promise<unknown>) => fn(),
@@ -198,6 +201,16 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                       )}
                       {a.host ? <span className="fleet-host-tag">this instance</span> : null}
                       {a.remote ? <span className="fleet-host-tag" title="A remote fleet member — proxied by URL">remote</span> : null}
+                      {/* Version skew (hub↔remote handshake): the hub console drives this
+                          remote's /api/* by proxy, so a different release can misbehave. */}
+                      {a.remote && a.version && hubVersion && a.version !== hubVersion ? (
+                        <span
+                          data-testid="fleet-version-skew"
+                          title={`This remote runs v${a.version}, the hub runs v${hubVersion} — features may misbehave across the version gap.`}
+                        >
+                          <Badge status="warning">v{a.version}</Badge>
+                        </span>
+                      ) : null}
                       {isActive ? <span className="fleet-active-tag">active</span> : null}
                     </span>
                     <span className="fleet-meta">

--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -159,6 +159,12 @@ their lifecycle; **Remove** only unregisters (the remote agent is untouched). Re
 as a member and adding as a [`delegate_to` target](delegates.md) compose: the same agent
 can be both a window you operate and a delegate your agents call.
 
+**Version skew is flagged.** The hub console drives a remote's full `/api/*` by proxy, so a
+remote on a *different protoAgent release* is a real compat surface. The reachability probe
+also reads the remote's app version off its A2A agent card; when it differs from the hub's,
+the fleet manager shows a warning badge on that member ("remote runs vX.Y.Z, the hub
+vA.B.C — features may misbehave"). Upgrade the lagging side to clear it.
+
 ## See also
 
 - ADRs: [0040 bundles](../adr/0040-plugin-bundles.md) ·

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -183,6 +183,8 @@ def _host_entry() -> dict:
 
     from runtime.state import STATE
 
+    from paths import package_version
+
     cfg = getattr(STATE, "graph_config", None)
     name = getattr(cfg, "identity_name", "") or "main"
     port = getattr(STATE, "active_port", None)
@@ -195,6 +197,10 @@ def _host_entry() -> dict:
         "bundle": "",
         "host": True,
         "a2a": f"http://127.0.0.1:{port}/a2a" if port else None,
+        # The hub's own version — the console compares remote members against it
+        # (hub↔remote version handshake, ADR 0042 §I): a remote on a different
+        # release is a real, otherwise-invisible /api/* compat surface.
+        "version": package_version(),
     }
 
 
@@ -209,6 +215,14 @@ def _host_entry() -> dict:
 
 def _remotes_path() -> Path:
     return manager.workspaces_root() / "remotes.json"
+
+
+def _remotes_lock() -> FileLock:
+    """Cross-process lock around remotes.json read-modify-write — same pattern as
+    ``_state_lock`` but a SIBLING lock file, so remote-registry mutations (two route
+    handlers adding members concurrently, a probe persisting a version) serialize
+    against each other without contending on fleet.json's lock."""
+    return FileLock(str(_remotes_path()) + ".lock", timeout=5)
 
 
 def _load_remotes() -> dict:
@@ -251,7 +265,7 @@ def add_remote(name: str, url: str, token: str = "") -> dict:
     url = (url or "").strip().rstrip("/")
     if not url.startswith(("http://", "https://")):
         raise FleetError(f"remote url must be http(s), got {url!r}")
-    with _state_lock():
+    with _remotes_lock():
         remotes = _load_remotes()
         taken = ({r["name"] for r in remotes.values()}
                  | {w["name"] for w in manager.list_workspaces()})
@@ -270,7 +284,7 @@ def add_remote(name: str, url: str, token: str = "") -> dict:
 
 def remove_remote(ident: str) -> dict:
     """Unregister a remote member (by id or name) — the remote agent itself is untouched."""
-    with _state_lock():
+    with _remotes_lock():
         remotes = _load_remotes()
         rid = ident if ident in remotes else next(
             (k for k, r in remotes.items() if r["name"] == ident), None)
@@ -297,12 +311,36 @@ def refresh_remote_probes(timeout: float = 1.0) -> None:
         hit = _probe_cache.get(rec["id"])
         if hit and now - hit[1] < _PROBE_TTL:
             continue
+        version = ""
         try:
             r = httpx.get(f"{rec['url']}/.well-known/agent-card.json", timeout=timeout)
             alive = r.status_code == 200
+            if alive:
+                try:
+                    # The A2A card carries the remote's app version (pyproject
+                    # [project].version) — same unauthenticated endpoint the
+                    # reachability probe already hits, no extra round-trip.
+                    version = str(r.json().get("version", "") or "")
+                except ValueError:
+                    version = ""
         except httpx.HTTPError:
             alive = False
         _probe_cache[rec["id"]] = (alive, now)
+        if version and version != rec.get("version"):
+            _record_remote_version(rec["id"], version)
+
+
+def _record_remote_version(rid: str, version: str) -> None:
+    """Persist a probed remote's version on its registry record (hub↔remote version
+    handshake) so ``status()`` can surface skew — last-known survives a hub restart.
+    Write-on-change only; under the remotes lock so it can't lose a concurrent
+    add/remove."""
+    with _remotes_lock():
+        remotes = _load_remotes()
+        rec = remotes.get(rid)
+        if rec is not None and rec.get("version") != version:
+            rec["version"] = version
+            _save_remotes(remotes)
 
 
 def status() -> list[dict]:
@@ -334,6 +372,8 @@ def status() -> list[dict]:
         alive = _probe_cache.get(rec["id"], (False, 0.0))[0]
         out.append({"name": rec["name"], "id": rec["id"], "port": None, "pid": None,
                     "running": alive, "bundle": "", "remote": True, "url": rec["url"],
+                    # Last-probed remote version (from its A2A card) — NEVER the token.
+                    "version": rec.get("version", ""),
                     "a2a": f"{rec['url']}/a2a"})
     return out
 

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -48,7 +48,7 @@ def _operator_runtime_status():
     # Live co-location check (#706) — re-evaluated per poll so the shell banner
     # appears/clears as siblings come and go. Quiet (empty `.instances/`) costs one
     # is_dir(); the `ps` guard only runs when sibling heartbeats actually exist.
-    from paths import colocation_warning, instance_uid
+    from paths import colocation_warning, instance_uid, package_version
     try:
         warnings = [w for w in (colocation_warning(),) if w]
     except Exception:  # noqa: BLE001 — status must never raise
@@ -74,6 +74,9 @@ def _operator_runtime_status():
         checkpoint_path=STATE.checkpoint_path,
         warnings=warnings,
         instance_uid=instance_uid(),
+        # App version (pyproject [project].version) — the hub↔remote version
+        # handshake (ADR 0042 §I) needs skew between consoles + agents visible.
+        version=package_version(),
     )
 
 

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -23,6 +23,7 @@ def build_runtime_status(
     checkpoint_path: str = "",
     warnings: list[str] | None = None,
     instance_uid: str = "",
+    version: str = "",
 ) -> dict[str, Any]:
     """Return UI-safe runtime status.
 
@@ -34,6 +35,11 @@ def build_runtime_status(
 
     ``warnings`` are user-facing operational alerts (e.g. a live co-located
     instance sharing this data root, #706) — the shell banners them.
+
+    ``version`` is this instance's app version (pyproject ``[project].version``) —
+    the console↔server ``/api/*`` surface has no other versioning, and with remote
+    fleet members (ADR 0042 §I) a hub console can drive a DIFFERENT release by
+    proxy, so skew must at least be visible.
     """
     warnings_block = [w for w in (warnings or []) if w]
     project = {"path": project_path, "allowed_dirs": list(allowed_dirs or [])}
@@ -65,6 +71,7 @@ def build_runtime_status(
             "cache_warmer": {"enabled": False, "loaded": False},
             "warnings": warnings_block,
             "instance_uid": instance_uid,
+            "version": version,
         }
 
     return {
@@ -137,6 +144,7 @@ def build_runtime_status(
         # Stable per-data-root uid — the console keys per-origin client state on it
         # (a different backend on the same address must not render this one's chats).
         "instance_uid": instance_uid,
+        "version": version,
     }
 
 

--- a/paths.py
+++ b/paths.py
@@ -52,6 +52,43 @@ def atomic_write(path: Path | str, text: str, *, mode: int | None = None) -> Non
         raise
 
 
+def package_version() -> str:
+    """This instance's app version — ``pyproject.toml`` ``[project].version`` is the
+    one source of truth (the release pipeline bumps it).
+
+    Prefer installed-package metadata; fall back to reading pyproject.toml next to
+    this module (source checkout / ``COPY .`` image) or the PyInstaller bundle root;
+    final fallback keeps callers valid if neither is available. Lives here (a leaf
+    module) so the A2A card (``server/a2a.py``), the runtime status, and the fleet
+    supervisor all report it without import cycles — the hub↔remote version
+    handshake compares it.
+    """
+    try:
+        from importlib.metadata import PackageNotFoundError, version
+
+        try:
+            return version("protoagent")
+        except PackageNotFoundError:
+            pass
+    except ImportError:  # pragma: no cover - importlib.metadata always present on 3.11+
+        pass
+
+    import sys
+
+    root = Path(__file__).resolve().parent
+    if getattr(sys, "frozen", False):  # PyInstaller onefile — assets land at _MEIPASS
+        root = Path(getattr(sys, "_MEIPASS", root))
+    try:
+        m = re.search(
+            r'^version\s*=\s*"([^"]+)"', (root / "pyproject.toml").read_text(), re.MULTILINE
+        )
+        if m:
+            return m.group(1)
+    except OSError:
+        pass
+    return "0.0.0"
+
+
 def _auto_scope_enabled() -> bool:
     """``PROTOAGENT_AUTO_SCOPE`` — derive a per-instance scope from the working dir when
     no explicit ``PROTOAGENT_INSTANCE`` is set, so co-located instances never silently

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -9,20 +9,18 @@ wiring itself still lives in ``server.__init__._main`` (it calls these); only th
 logic moved here.
 
 ``server/__init__.py`` re-exports every public name below so ``server.<symbol>``
-keeps resolving for ``_main`` and the test suite. The three symbols this module
-imports from ``server`` (``agent_name``, ``_bundle_root``, ``_event_bus``) are
-all defined in ``__init__`` before its re-export line, so the import is not a
-cycle.
+keeps resolving for ``_main`` and the test suite. The symbols this module
+imports from ``server`` (``agent_name``, ``_event_bus``) are all defined in
+``__init__`` before its re-export line, so the import is not a cycle.
 """
 
 import logging
 import os
-import re
 
 from events import ACTIVITY_CONTEXT
 from graph.output_format import extract_output
 from runtime.state import STATE
-from server import _bundle_root, _event_bus, agent_name
+from server import _event_bus, agent_name
 
 log = logging.getLogger("protoagent.server")
 
@@ -110,31 +108,14 @@ def structured_skill_schema(skill_id: str) -> dict | None:
 def _package_version() -> str:
     """Single-source the agent-card version from the package metadata.
 
-    ``pyproject.toml`` ``[project].version`` is the one source of truth (the
-    release pipeline bumps it). Prefer installed-package metadata; fall back
-    to reading pyproject.toml (it's shipped in the image via ``COPY .``);
-    final fallback keeps the card valid if neither is available.
+    Delegates to ``paths.package_version()`` (one source of truth — the
+    pyproject ``[project].version`` the release pipeline bumps) so the card,
+    the runtime status, and the fleet version handshake can never disagree.
+    Kept as a name here for its existing importers (``server.__init__`` re-exports it).
     """
-    try:
-        from importlib.metadata import PackageNotFoundError, version
+    from paths import package_version
 
-        try:
-            return version("protoagent")
-        except PackageNotFoundError:
-            pass
-    except ImportError:  # pragma: no cover - importlib.metadata always present on 3.11+
-        pass
-
-    pyproject = _bundle_root() / "pyproject.toml"
-    try:
-        m = re.search(
-            r'^version\s*=\s*"([^"]+)"', pyproject.read_text(), re.MULTILINE
-        )
-        if m:
-            return m.group(1)
-    except OSError:
-        pass
-    return "0.0.0"
+    return package_version()
 
 
 def _a2a_card_url() -> str:

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -90,6 +90,31 @@ def test_reserved_host_name_is_400(client):
     assert client.post("/api/fleet", json={"name": "host"}).status_code == 400
 
 
+def test_fleet_list_carries_versions(client, monkeypatch):
+    """Hub↔remote version handshake over /api/fleet: the host entry carries the hub's
+    own version, a remote member carries its last-probed one (never its token) —
+    that's what the console compares to flag skew."""
+    import httpx
+    from graph.fleet import supervisor
+
+    supervisor._probe_cache.clear()
+    supervisor.add_remote("ava", "http://1.2.3.4:7871", token="sek")
+
+    class FakeCard:
+        status_code = 200
+
+        def json(self):
+            return {"name": "ava", "version": "0.30.0"}
+
+    monkeypatch.setattr(httpx, "get", lambda url, timeout: FakeCard())
+    agents = client.get("/api/fleet").json()["agents"]
+    host = next(a for a in agents if a.get("host"))
+    assert host["version"]  # the hub always knows its own version
+    remote = next(a for a in agents if a.get("remote"))
+    assert remote["version"] == "0.30.0"
+    assert "token" not in remote and "sek" not in str(agents)
+
+
 def test_discover_endpoint(client, monkeypatch):
     # /api/fleet/discover returns OTHER protoAgents (mock the scan); the route's host self-exclusion
     # + supervisor scan run, discover() internals are unit-tested elsewhere.

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -110,6 +110,8 @@ def test_remote_member_lifecycle(tmp_path, monkeypatch):
     entry = next(a for a in supervisor.status() if a.get("remote"))
     assert entry["name"] == "ava" and entry["running"] is False
     assert entry["a2a"] == "http://100.101.189.45:7871/a2a" and entry["pid"] is None
+    assert entry["version"] == ""      # no probe yet — version unknown
+    assert "token" not in entry        # the bearer NEVER leaves the registry via status()
 
     supervisor._probe_cache[rec["id"]] = (True, supervisor.time.monotonic())
     assert next(a for a in supervisor.status() if a.get("remote"))["running"] is True
@@ -134,6 +136,9 @@ def test_refresh_remote_probes_ttl(tmp_path, monkeypatch):
     class FakeResp:
         status_code = 200
 
+        def json(self):
+            return {"name": "ava", "version": "0.9.9"}
+
     def fake_get(url, timeout):
         calls["n"] += 1
         return FakeResp()
@@ -144,3 +149,86 @@ def test_refresh_remote_probes_ttl(tmp_path, monkeypatch):
     supervisor.refresh_remote_probes()  # within TTL — no second call
     assert calls["n"] == 1
     assert supervisor._probe_cache[rec["id"]][0] is True
+
+
+def test_probe_captures_remote_version(tmp_path, monkeypatch):
+    """Hub↔remote version handshake: the probe lifts ``version`` off the remote's A2A
+    card, persists it on the registry record (survives a hub restart), and status()
+    surfaces it — while the stored bearer token still never leaves via status()."""
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    supervisor._probe_cache.clear()
+    rec = supervisor.add_remote("ava", "http://h:9", token="sek")
+
+    class FakeResp:
+        status_code = 200
+
+        def json(self):
+            return {"name": "ava", "version": "0.30.0"}
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", lambda url, timeout: FakeResp())
+    supervisor.refresh_remote_probes()
+
+    entry = next(a for a in supervisor.status() if a.get("remote"))
+    assert entry["version"] == "0.30.0" and entry["running"] is True
+    assert "token" not in entry
+    # persisted on the record (token intact for the proxy)
+    stored = supervisor.remote_for_slug(rec["id"])
+    assert stored["version"] == "0.30.0" and stored["token"] == "sek"
+    # …and the hub's own version rides on the host entry, so the console can compare.
+    host = next(a for a in supervisor.status() if a.get("host"))
+    assert host["version"]
+
+
+def test_probe_card_without_version_keeps_last_known(tmp_path, monkeypatch):
+    """A card with no/blank version (or unparseable JSON) must not clobber the
+    last-known value — last-good wins until the remote reports something new."""
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    supervisor._probe_cache.clear()
+    rec = supervisor.add_remote("ava", "http://h:9")
+    supervisor._record_remote_version(rec["id"], "0.28.0")
+
+    class NoVersionResp:
+        status_code = 200
+
+        def json(self):
+            raise ValueError("not json")
+
+    import httpx
+    monkeypatch.setattr(httpx, "get", lambda url, timeout: NoVersionResp())
+    supervisor.refresh_remote_probes()
+    assert supervisor.remote_for_slug(rec["id"])["version"] == "0.28.0"
+    assert next(a for a in supervisor.status() if a.get("remote"))["version"] == "0.28.0"
+
+
+def test_remotes_lock_serializes_concurrent_adds(tmp_path, monkeypatch):
+    """remotes.json RMW is FileLock-guarded (sibling of the fleet.json lock): two
+    concurrent add_remote calls — e.g. two route handlers — must both land. The
+    widened load→save window (sleep) loses one of them if the lock is ever dropped."""
+    import threading
+
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    orig_load = supervisor._load_remotes
+
+    def slow_load():
+        d = orig_load()
+        supervisor.time.sleep(0.05)  # widen the read→write window
+        return d
+
+    monkeypatch.setattr(supervisor, "_load_remotes", slow_load)
+    errs: list[Exception] = []
+
+    def add(name, port):
+        try:
+            supervisor.add_remote(name, f"http://h:{port}")
+        except Exception as e:  # noqa: BLE001 — surfaced below
+            errs.append(e)
+
+    threads = [threading.Thread(target=add, args=(n, p))
+               for n, p in (("r-one", 1), ("r-two", 2))]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    assert not errs
+    assert {r["name"] for r in supervisor.list_remotes()} == {"r-one", "r-two"}

--- a/tests/test_operator_api_runtime.py
+++ b/tests/test_operator_api_runtime.py
@@ -56,6 +56,18 @@ def test_runtime_status_handles_missing_config() -> None:
     assert status["model"] is None
     assert status["knowledge"]["enabled"] is False
     assert status["project"]["allowed_dirs"] == []
+    assert status["version"] == ""  # not passed — defaults empty, key still present
+
+
+def test_runtime_status_carries_version() -> None:
+    # The console↔server /api/* surface has no other versioning (hub↔remote skew,
+    # ADR 0042 §I) — runtime status carries the app version in both shapes.
+    s = build_runtime_status(config=None, setup_complete=False, graph_loaded=False,
+                             version="0.32.0")
+    assert s["version"] == "0.32.0"
+    s2 = build_runtime_status(config=LangGraphConfig(), setup_complete=True,
+                              graph_loaded=True, version="0.32.0")
+    assert s2["version"] == "0.32.0"
 
 
 def test_list_subagents_uses_registry_and_config_override() -> None:


### PR DESCRIPTION
## The N5 skew scenario (2026-06-10 audit)

The console↔server `/api/*` surface has **no versioning**. That was tolerable while the console and its server always shipped from the same checkout — but remote fleet members (#839) broke that invariant: a hub console now drives a *different machine's* protoAgent — potentially a **different release** — by reverse proxy, full `/api/*` and all. A hub on v0.32 rendering settings/chat/plugins against a remote on v0.28 fails in quiet, confusing ways (missing endpoints, shape drift), and nothing anywhere said why. Before tier-b (remote start/stop) lands, skew must at least be **visible**.

## What's surfaced where

- **One version accessor** — `paths.package_version()` (importlib.metadata → pyproject fallback, PyInstaller-aware). `server/a2a._package_version` (the agent-card version) now delegates to it, so the card, the runtime status, and the fleet handshake can never disagree.
- **`/api/runtime/status`** now reports the serving instance's `version` (the console↔server surface itself).
- **Probe → registry**: the existing remote reachability probe already GETs the remote's `/.well-known/agent-card.json` (unauthenticated by design) — it now also lifts the card's `version` and persists it **write-on-change** on the `remotes.json` record, so last-known survives a hub restart. A blank/unparseable card keeps the last-known value.
- **`/api/fleet`**: every member carries `version` — the hub's own on the `host` entry, the last-probed one on each `remote` entry. The bearer token still never leaves the registry via `status()` (tested).
- **Console** (Settings → Agents): a DS `Badge status="warning"` on any remote whose version differs from the hub's, with a plain-title tooltip — *"This remote runs vX.Y.Z, the hub runs vA.B.C — features may misbehave across the version gap."* Native `title` per the ui-component-audit's accepted pattern; no hand-rolled chrome.

## The lock fix

`remotes.json` add/remove (and now the probe's version persist) serialized on **`fleet.json`'s** FileLock — correct, but cross-registry: remote mutations contended with fleet-state writes (start/stop/touch/prune) for no reason. They now use the same FileLock pattern on a dedicated sibling (`remotes.json.lock`); `_save_remotes` keeps the #858 `atomic_write(..., mode=0o600)` posture. A new two-thread test widens the load→save window and proves both concurrent `add_remote` records land.

## Tests

- `tests/test_fleet_supervisor.py`: probe captures + persists version; `status()` exposes it and never the token; no-version card keeps last-known; concurrent `add_remote` serialization.
- `tests/test_fleet_routes.py`: `/api/fleet` carries host + remote versions, token absent from the payload.
- `tests/test_operator_api_runtime.py`: `version` in both runtime-status shapes.
- Full suite **1615 passed**; ruff clean; import-linter contracts 3/3 kept; web `tsc` + vite build green, 36 vitest green (vitest covers pure logic only — the badge rides on tsc/e2e).
- Docs: `docs/guides/fleet.md` remote-members section + CHANGELOG `[Unreleased]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)