### PR TITLE
fix(web): route default-prefix plugin VIEW paths to the focused fleet member

### DIFF
--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { drainSseBuffer, textFromParts, hitlFromParts } from "./api";
+import { apiUrl, drainSseBuffer, textFromParts, hitlFromParts } from "./api";
 
 const HITL_MIME = "application/vnd.protolabs.hitl-v1+json";
 
@@ -89,5 +89,38 @@ describe("hitlFromParts", () => {
 
   it("returns null for undefined parts", () => {
     expect(hitlFromParts(undefined)).toBeNull();
+  });
+});
+
+describe("apiUrl — fleet slug routing (ADR 0042)", () => {
+  // currentSlug() reads /app/agent/<slug>/ from the URL; drive it via history.
+  const focus = (slug: string | null) =>
+    window.history.replaceState({}, "", slug ? `/app/agent/${slug}/` : "/app/");
+
+  it("does not slug-prefix on the host window", () => {
+    focus(null);
+    expect(apiUrl("/plugins/agent_browser/panel")).not.toContain("/agents/");
+    expect(apiUrl("/api/runtime/status")).not.toContain("/agents/");
+  });
+
+  it("routes a DEFAULT-prefix plugin view (/plugins/<id>/…) to the focused member", () => {
+    // The 404 regression: agent_browser/project_board views use the registry's default
+    // /plugins/ prefix; without that in isAgentPath, a member's view iframe hit the hub.
+    focus("protoPlugins-abf8");
+    expect(apiUrl("/plugins/agent_browser/panel")).toContain(
+      "/agents/protoPlugins-abf8/plugins/agent_browser/panel",
+    );
+  });
+
+  it("routes custom-prefix plugin views (/api/plugins/<id>/…) and the agent API", () => {
+    focus("m");
+    expect(apiUrl("/api/plugins/notes/view")).toContain("/agents/m/api/plugins/notes/view");
+    expect(apiUrl("/api/runtime/status")).toContain("/agents/m/api/runtime/status");
+  });
+
+  it("keeps hub control-plane paths on the hub even in a member window", () => {
+    focus("m");
+    expect(apiUrl("/api/fleet")).not.toContain("/agents/");
+    expect(apiUrl("/api/archetypes")).not.toContain("/agents/");
   });
 });

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -166,8 +166,19 @@ function isHubPath(path: string) {
 }
 function isAgentPath(path: string) {
   // Everything that drives the focused AGENT: its console API, its A2A brain (streaming chat),
-  // and its OpenAI-compat endpoint. /api/fleet stays on the hub.
-  return (path.startsWith("/api/") && !isHubPath(path)) || path.startsWith("/a2a") || path.startsWith("/v1");
+  // its OpenAI-compat endpoint, and its plugin VIEW content. /api/fleet stays on the hub.
+  //
+  // `/plugins/` is the registry's DEFAULT router prefix — plugin views served there (e.g.
+  // agent_browser → /plugins/agent_browser/panel) are the focused agent's, so a fleet member's
+  // view must proxy to it. Custom-prefix plugins serve their view at /api/plugins/<id>/… (already
+  // covered by the /api/ clause). Without /plugins/ here, a member's default-prefix view iframe
+  // hits the hub origin instead of the member → 404 (the agent_browser/project_board panels).
+  return (
+    (path.startsWith("/api/") && !isHubPath(path)) ||
+    path.startsWith("/plugins/") ||
+    path.startsWith("/a2a") ||
+    path.startsWith("/v1")
+  );
 }
 
 export function apiUrl(path: string) {


### PR DESCRIPTION
**Live bug:** on a fleet member (`http://…:7874/app/agent/protoPlugins-abf8/`), the `agent_browser` and `project_board` panels render a failing/404 iframe — while `notes` + `plugin-devkit` work, and everything works on the primary.

## Root cause
`apiUrl()` routes a request to the focused agent (`/agents/<slug>/…`) only when `isAgentPath()` matches — and it matched `/api/*`, `/a2a`, `/v1` but **not `/plugins/*`**, the registry's **default** router prefix. So:

| plugin | view path | on a member |
|---|---|---|
| notes | `/api/plugins/notes/view` | ✅ routed → member |
| plugin-devkit | `/api/plugins/plugin-devkit/guide` | ✅ routed → member |
| **agent_browser** | `/plugins/agent_browser/panel` | ❌ hit the **hub** → 404 |
| **project_board** | `/plugins/project_board/board` | ❌ hit the **hub** → 404 |

The default-prefix view iframe (and the #853 status probe) resolved against the hub origin, which doesn't have the member's fork plugin → 404. It works on the primary because there the plugin *is* on that origin.

Confirmed live against `protoPlugins-abf8`'s runtime status (paths above are verbatim from it).

## Fix
One clause: `isAgentPath()` also matches `/plugins/`. Now a focused member's plugin-view content proxies to that member (`/agents/<slug>/plugins/<id>/<view>` → the member's `/plugins/<id>/<view>`). Same-origin is preserved (still served via the hub proxy), so the ADR-0039 event-bus postMessage relay is unaffected.

## Tests
4 vitest cases on `apiUrl`: host window = no prefix; default-prefix view → member; custom-prefix view + agent API → member; hub control-plane (`/api/fleet`, `/api/archetypes`) stays on the hub. build + **e2e 89/89**.

> To see it on your running instance: rebuild `apps/web` (the fix is frontend) and reload — the panels will resolve against the member.

🤖 Generated with [Claude Code](https://claude.com/claude-code)