### PR TITLE
fix(server): bounded graceful shutdown so a single Ctrl-C exits cleanly

### DIFF
--- a/server/__init__.py
+++ b/server/__init__.py
@@ -836,7 +836,14 @@ def _main():
     # server orphaned (holding its port). Poll the launcher and exit if it dies.
     _install_parent_death_watchdog()
 
-    uvicorn.run(app, host=args.host, port=args.port)
+    # Bound the graceful drain. The console holds long-lived connections that
+    # never close on their own — SSE streams (chat, runtime status) and the
+    # fleet proxy's stream-to-member. With uvicorn's default (no timeout), the
+    # first Ctrl-C waits forever ("Waiting for connections to close"), forcing a
+    # second Ctrl-C whose KeyboardInterrupt fires mid-request and dumps noisy
+    # CancelledError tracebacks. A bounded timeout lets in-flight work finish,
+    # then force-closes the streams cleanly on a single Ctrl-C.
+    uvicorn.run(app, host=args.host, port=args.port, timeout_graceful_shutdown=5)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
**Symptom:** stopping the server with Ctrl-C hangs on *"Waiting for connections to close"*, and a second Ctrl-C dumps `CancelledError` / "Exception in ASGI application" tracebacks.

**Cause:** `uvicorn.run(...)` had no `timeout_graceful_shutdown`, so uvicorn waits **indefinitely** for open connections. The console holds long-lived connections that never close on their own — SSE streams (chat, runtime status, `operator_api/chat_routes.py`) and the **fleet proxy** stream-to-member (`graph/fleet/proxy.py`). So the first Ctrl-C hangs; the second (force quit) raises `KeyboardInterrupt` mid-request → the in-flight task through Starlette's `BaseHTTPMiddleware` is cancelled → the noisy tracebacks. Harmless (the process *does* exit), but ugly and requires a double Ctrl-C.

**Fix:** `timeout_graceful_shutdown=5` — a single Ctrl-C drains in-flight work for up to 5s, then force-closes the streams cleanly and exits.

ruff clean; `uvicorn` 0.49 supports the param.

🤖 Generated with [Claude Code](https://claude.com/claude-code)