### PR TITLE
fix(plugins): plugin-view authoring hardening — kit same-origin, guardrails, fixed examples + canonical guide

### DIFF
--- a/apps/web/scripts/copy-plugin-kit.mjs
+++ b/apps/web/scripts/copy-plugin-kit.mjs
@@ -1,13 +1,14 @@
-// Copies @protolabsai/ui's no-build plugin-kit.css into public/_ds/ so Vite emits
-// it to dist/_ds/plugin-kit.css, which the backend serves same-origin at
-// /_ds/plugin-kit.css (operator_api/web.py). Plugin iframe pages <link> that one
-// path instead of pinning a CDN copy — so every plugin view matches the console's
-// installed design-system version automatically. See protoContent #176.
+// Copies @protolabsai/ui's no-build plugin-kit (CSS + JS) into public/_ds/ so
+// Vite emits them to dist/_ds/, which the backend serves same-origin at
+// /_ds/plugin-kit.css and /_ds/plugin-kit.js (operator_api/web.py). Plugin iframe
+// pages <link>/<script> those two paths instead of pinning a CDN copy — so every
+// plugin view matches the console's installed design-system version automatically.
+// See protoContent #176.
 //
-// Non-fatal: if the package/file isn't resolvable (e.g. @protolabsai/ui not yet
-// bumped/installed to a version that ships the kit), it warns and skips rather than
-// breaking the build — the /_ds route then 404s and plugins fall back to their own
-// dark defaults until the dep is updated.
+// Non-fatal: if a package/file isn't resolvable (e.g. @protolabsai/ui not yet
+// bumped/installed to a version that ships the kit), it warns and skips that file
+// rather than breaking the build — the /_ds route then 404s and plugins fall back
+// to their own dark defaults until the dep is updated.
 
 import { createRequire } from "node:module";
 import { copyFileSync, mkdirSync } from "node:fs";
@@ -15,16 +16,25 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const here = dirname(fileURLToPath(import.meta.url));
-const dest = resolve(here, "..", "public", "_ds", "plugin-kit.css");
+const require = createRequire(import.meta.url);
 
-try {
-  const src = createRequire(import.meta.url).resolve("@protolabsai/ui/plugin-kit.css");
-  mkdirSync(dirname(dest), { recursive: true });
-  copyFileSync(src, dest);
-  console.log(`[copy-plugin-kit] ${src} -> public/_ds/plugin-kit.css`);
-} catch (err) {
-  console.warn(
-    `[copy-plugin-kit] skipped — could not resolve @protolabsai/ui/plugin-kit.css ` +
-      `(bump @protolabsai/ui to >=0.19 and reinstall). ${err?.message ?? err}`,
-  );
+// Each asset: the package export to resolve, and the public/_ds/ filename to write.
+const assets = [
+  { spec: "@protolabsai/ui/plugin-kit.css", out: "plugin-kit.css" },
+  { spec: "@protolabsai/ui/plugin-kit.js", out: "plugin-kit.js" },
+];
+
+for (const { spec, out } of assets) {
+  const dest = resolve(here, "..", "public", "_ds", out);
+  try {
+    const src = require.resolve(spec);
+    mkdirSync(dirname(dest), { recursive: true });
+    copyFileSync(src, dest);
+    console.log(`[copy-plugin-kit] ${src} -> public/_ds/${out}`);
+  } catch (err) {
+    console.warn(
+      `[copy-plugin-kit] skipped — could not resolve ${spec} ` +
+        `(bump @protolabsai/ui to >=0.19 and reinstall). ${err?.message ?? err}`,
+    );
+  }
 }

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -114,7 +114,7 @@ describe("apiUrl — fleet slug routing (ADR 0042)", () => {
 
   it("routes custom-prefix plugin views (/api/plugins/<id>/…) and the agent API", () => {
     focus("m");
-    expect(apiUrl("/api/plugins/notes/view")).toContain("/agents/m/api/plugins/notes/view");
+    expect(apiUrl("/api/plugins/notes/note")).toContain("/agents/m/api/plugins/notes/note");
     expect(apiUrl("/api/runtime/status")).toContain("/agents/m/api/runtime/status");
   });
 

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -98,7 +98,7 @@ export default defineConfig({
           items: [
             { text: "Plugins", link: "/guides/plugins" },
             { text: "Middleware", link: "/guides/middleware" },
-            { text: "Plugin console views", link: "/guides/plugin-views" },
+            { text: "Building a plugin view", link: "/guides/building-react-plugin-views" },
             { text: "Build a communication plugin", link: "/guides/communication-plugins" },
             { text: "Install & publish plugins (git URLs)", link: "/guides/plugin-registry" },
             { text: "Discord surface", link: "/guides/discord" },
@@ -123,6 +123,15 @@ export default defineConfig({
             { text: "Build an operator fork (Roxy)", link: "/guides/operator-fork" },
             { text: "Sync a fork from upstream", link: "/guides/upstream-sync" },
             { text: "Eval your fork", link: "/guides/evals" },
+          ],
+        },
+      ],
+
+      "/how-to/": [
+        {
+          text: "How-To",
+          items: [
+            { text: "Build a plugin view", link: "/how-to/build-a-plugin-view" },
           ],
         },
       ],

--- a/docs/adr/0026-plugin-contributed-console-surfaces.md
+++ b/docs/adr/0026-plugin-contributed-console-surfaces.md
@@ -125,7 +125,7 @@ for the plugin page; core views are unaffected.
 - **PR3 (shipped): view-tabs + auth/theming bridge + sandbox + docs.** Declared
   `tabs` → `stage-subnav`; the post-load `postMessage` token + theme handshake
   (`protoagent:init`); sandbox attrs; the `hello` view is the reference receiver;
-  `docs/guides/plugin-views.md`.
+  `docs/guides/building-react-plugin-views.md` (canonical guide; `chat_example` is the copy-me reference).
 - **Later (optional): schema-driven views** (D1) for forks that want a native-look
   dashboard without serving their own page — a separate ADR if pursued.
 

--- a/docs/guides/building-react-plugin-views.md
+++ b/docs/guides/building-react-plugin-views.md
@@ -1,29 +1,49 @@
 # Building a plugin view
 
 A plugin can add a **console surface** — a rail icon that opens a view (a chart, an editor, a
-dashboard, a generative-UI panel). The model is simple and **sandboxed**: the plugin **serves its
-own page**, and the console renders it in an **iframe**. No host build, no shared bundle — so the
-same plugin works whether it's bundled in the repo or **installed from a git URL** (ADR 0027).
+dashboard, a generative-UI panel), or a view that **replaces** the built-in chat panel
+(`slot: "chat"`, ADR 0045). The model is simple and **sandboxed**: the plugin **serves its own
+page**, and the console renders it in an **iframe**. No host build, no shared bundle — so the same
+plugin works whether it's bundled in the repo or **installed from a git URL** (ADR 0027).
 
 > **Why iframes, not in-process React?** A plugin's UI is third-party code. The whole field
-> sandboxes generated/third-party UI in iframes (Claude Artifacts, Open WebUI, CodePen). It's the
-> right security boundary *and* it keeps plugins trivially distributable. (We tried Module
-> Federation for in-process React; ADR 0038 retired it — heavier than a fork needs, less safe than
-> untrusted code requires.)
+> sandboxes third-party/generated UI in iframes (Claude Artifacts, Open WebUI, CodePen). It's the
+> right boundary *and* it keeps plugins trivially distributable. (We tried Module Federation for
+> in-process React; ADR 0038 retired it — heavier than a fork needs, less safe than untrusted code
+> requires. Forks that want native in-process components use the build-time `src/ext/` seam instead —
+> see [below](#fork-components-no-plugin-no-iframe).)
+
+> [!TIP]
+> **Copy the gold-standard.** [`examples/plugins/chat_example`](https://github.com/protoLabsAI/protoAgent/tree/main/examples/plugins/chat_example)
+> is a single-page vanilla-JS view that follows every rule below — the init/theme handshake, live
+> re-theming, slug-aware routing, the DS kit, and a real turn over a gated `/api/` route. Start by
+> copying it: `cp -r examples/plugins/chat_example plugins/`.
+
+## The four rules
+
+Every plugin view should follow these. Each links a section below.
+
+| Rule | One-line why |
+|---|---|
+| **1. Serve the path you declare** — the manifest's `views[].path` MUST equal a path your `register_router` actually serves. | The console iframes exactly that path. Default router prefix is `/plugins/<id>`; a custom prefix (as the artifact plugin uses) is fine — just keep `path` in sync with it. A mismatch is a blank iframe. |
+| **2. Gate by default** — mount the router under `prefix="/api/plugins/<id>"`. | Routes under `/api/*` inherit the operator **bearer gate** (ADR 0026 D5). Use the ungated `/plugins/<id>` prefix **only** for genuinely public assets (e.g. the page itself — see [why the page is public](#why-the-page-is-public-but-its-data-is-gated)). |
+| **3. Same-origin, slug-aware, never hardcode** — derive `base = location.pathname.split("/plugins/")[0]` and prefix every fetch/asset with it. | Never hardcode an absolute `/api/.../`, `/plugins/.../`, or `http://localhost:PORT`. On the host window `base=""`; through the ADR 0042 `/agents/<slug>/` fleet proxy `base="/agents/<slug>"`. Hardcoding talks to the wrong agent and breaks the same-origin token handshake. |
+| **4. Link the DS kit** — load `<base>/_ds/plugin-kit.css` + `<base>/_ds/plugin-kit.js`. | Pull colors/components/handshake from the console's own design system instead of hand-rolling a hex map or pinning a CDN. The kit's `--pl-*` tokens re-skin to the operator's live theme for free. See [the kit helpers](#the-kit-helpers-plugin-kitjs). |
 
 ## The shape
 
 A plugin is a directory with a `protoagent.plugin.yaml` manifest and an `__init__.py` exposing
-`register(registry)`. To add a view:
+`register(registry)`. To add a view, declare it and serve a page.
 
 ```yaml
 # protoagent.plugin.yaml
 id: mychart
 name: My Chart
 enabled: true
+# A rail icon → an iframe of the page your plugin serves. placement: "right" docks it
+# into the right sidebar; "rail" (default) is a full left-rail surface.
 views:
-  # A rail icon → an iframe of the page your plugin serves. placement: "right" docks it.
-  - { id: mychart, label: "My Chart", icon: "BarChart3", placement: right, path: "/api/plugins/mychart/view" }
+  - { id: mychart, label: "My Chart", icon: "BarChart3", placement: right, path: "/plugins/mychart/view" }
 ```
 
 ```python
@@ -33,46 +53,157 @@ def _build_router():
     from fastapi.responses import HTMLResponse
     router = APIRouter()
 
-    @router.get("/data")          # your data API (gated, because it's under /api/*)
+    @router.get("/data")          # RULE 2: a DATA route — gate it under /api/plugins/<id>
     async def _data() -> dict:
         return {"points": [1, 2, 3]}
 
-    @router.get("/view")          # the page the console iframes
+    @router.get("/view")          # the page the console iframes (public chrome — see below)
     async def _view():
         return HTMLResponse(_PAGE)
 
     return router
 
 def register(registry):
-    registry.register_router(_build_router(), prefix="/api/plugins/mychart")  # under /api → bearer-gated
-
-_PAGE = """<!doctype html><html><body>...your UI...</body></html>"""
+    # RULE 1 + 2: serve the page on the path you declared. Data routes go under /api/.
+    registry.register_router(_data_router(), prefix="/api/plugins/mychart")   # gated data
+    registry.register_router(_build_router(), prefix="/plugins/mychart")      # public page
 ```
 
 That's it. Drop the directory in `plugins/` (or `git`-install it) → the router mounts, the rail icon
 appears, the iframe loads your page. **No host rebuild.**
 
-## The console ↔ page bridge (ADR 0026)
+`icon` is **any** [lucide](https://lucide.dev) icon name — PascalCase (`LineChart`) or kebab-case
+(`line-chart`). A curated common set (`LayoutDashboard`, `BarChart3`, `Database`, `Workflow`, `Bot`,
+`Rocket`, `Coins`, `Shield`, …) renders instantly; anything else lazy-loads on demand. The console
+reads `views` from `/api/runtime/status` and renders a rail icon per view (keyed
+`plugin:<id>:<viewId>`); `tabs` render as a sub-nav that swaps the iframe page.
 
-After the iframe loads, the console `postMessage`s it `{ type: "protoagent:init", token, theme }`:
+### Why the page is public but its data is gated
 
-- **`token`** — the operator bearer. Send it on your fetches so authed `/api/*` calls work:
-  `fetch(url, { headers: { Authorization: "Bearer " + token } })`.
-- **`theme`** — console tokens (`bg`, `fg`, `fgMuted`, `border`, …). Apply them so your page matches
-  the console — and default to dark so you never flash white.
+A browser **iframe page-load can't carry an `Authorization` header** — so the HTML page itself must
+be reachable without the bearer. Serve **only the page** outside `/api/` (the public `/plugins/<id>`
+prefix); everything the page *fetches* (your data) goes through gated `/api/plugins/<id>/...` routes,
+authed with the bearer the console hands you over the [init handshake](#the-init-handshake-bearer--theme).
+The page is public chrome; its data is not.
+
+## Claim the chat slot (`slot: "chat"`)
+
+The chat surface is a **slot** (ADR 0045): your view can *replace* the built-in chat panel instead of
+adding a rail icon.
+
+```yaml
+views:
+  - { id: panel, label: "My chat", icon: MessageSquare, path: "/plugins/mychat/panel", slot: chat }
+```
+
+What changes versus a normal view:
+
+- Your page renders under the core **Chat** rail id — **no separate icon**; the first enabled
+  claimant wins.
+- You inherit chat's mount contract: the iframe stays mounted for the **app's lifetime** (a normal
+  view unmounts when you switch away) — what keeps an in-flight streamed turn alive across surface
+  switches.
+- Without a claimant, the built-in chat renders — the console is never chat-less.
+
+Your page speaks the same protocol the built-in panel does: the
+[init handshake](#the-init-handshake-bearer--theme) hands you the bearer + theme, and the agent is
+driven over **A2A 1.0** (`SendStreamingMessage` for the streaming turn, `tasks/get` for
+reconciliation) plus three REST endpoints (`/api/chat/commands`, `DELETE /api/chat/sessions/{id}`,
+non-streaming `POST /api/chat`). Before shipping a real one, read the **conformance checklist in
+ADR 0045** — it encodes the hard-won invariants (never remount mid-turn, reconcile stuck streams on
+load, render terminal text once, key local state per agent slug).
+
+`examples/plugins/chat_example` is the worked reference: a vanilla-JS panel that does the handshake,
+live re-theming, slug-aware routing, and a turn over the **non-streaming** `/api/chat` fallback. Copy
+it and grow your panel from there:
+
+```bash
+cp -r examples/plugins/chat_example plugins/
+```
+
+```yaml
+plugins:
+  enabled: [chat_example]
+```
+
+Reload — Chat becomes the example panel. Disable (or delete) the copy and the built-in chat is back.
+
+Forks have an in-process alternative: register a `src/ext` surface with `id: "chat"` (ADR 0038 D3) —
+it overrides the slot ahead of plugin claims, with full React context.
+
+## The init handshake (bearer + theme)
+
+After the iframe loads, the console **posts a message** to it — so your page gets the operator bearer
+(for its own API calls) and the console theme tokens (to match the look) **without a token in the
+URL**. There are two messages:
+
+- **`protoagent:init`** — sent once after load, carrying `{ token, theme }`.
+- **`protoagent:theme`** — sent on every live operator theme switch, carrying the new `{ theme }`, so
+  your page re-skins without a reload.
 
 ```js
 window.addEventListener("message", (e) => {
-  if (e.data?.type !== "protoagent:init") return;
-  const { token, theme } = e.data;        // use token for fetches; apply theme to your page
+  const m = e.data || {};
+  if (m.type === "protoagent:init") {
+    // m.token — operator bearer (or null when none is configured). Use it as
+    //           `Authorization: Bearer <token>` on your /api/plugins/<id>/... calls.
+    // m.theme — { bg, bgPanel, fg, fgMuted, brand, border } from the console.
+    if (m.theme?.bg) document.body.style.background = m.theme.bg;
+  } else if (m.type === "protoagent:theme") {
+    // live re-theme — re-apply m.theme
+  }
 });
 ```
+
+The message is sent same-origin and targeted at your page's origin. In practice you don't hand-write
+this — [the DS kit](#the-kit-helpers-plugin-kitjs) wires it for you and maps `theme` onto its `--pl-*`
+tokens.
+
+## The kit helpers (`plugin-kit.js`)
+
+The console serves the design-system kit same-origin at **`<base>/_ds/plugin-kit.{css,js}`** — the
+no-hardcode escape hatch. `plugin-kit.css` gives `--pl-*` tokens + `.pl-*` components;
+`plugin-kit.js` does the handshake and exposes a tiny API.
+
+Link both slug-aware (RULE 3 + 4):
+
+```html
+<script>
+  // RULE 3: compute base FIRST — everything (the kit href included) prefixes it.
+  window.__base = location.pathname.split("/plugins/")[0];  // "" or "/agents/<slug>"
+  document.write('<link rel="stylesheet" href="' + window.__base + '/_ds/plugin-kit.css">');
+</script>
+...
+<script src="" id="kit"></script>
+<script>document.getElementById("kit").src = window.__base + "/_ds/plugin-kit.js";</script>
+```
+
+The classic script-tag form exposes a **`window.protoPluginView`** global; the kit is also an ES
+module (`import { initPluginView } from ".../plugin-kit.js"`). The API:
+
+| Helper | What it does |
+|---|---|
+| `initPluginView(onInit?)` | Starts listening for the handshake. Maps the console `theme` onto the DS `--pl-*` tokens on the initial `protoagent:init` **and** on every live `protoagent:theme` re-theme. `onInit({ token, theme })` (optional) fires on both. Call once on load. |
+| `getToken()` | The captured operator bearer (null until the handshake delivers one). |
+| `apiFetch(input, init?)` | A same-origin `fetch` with `Authorization: Bearer <token>` attached when a token is present. Use it for every gated `/api/...` call. |
+| `window.protoPluginView` | The same three helpers as a global, for no-build classic script-tag pages. |
+
+So a whole view's handshake + authed fetch is:
+
+```js
+const kit = window.protoPluginView;
+kit.initPluginView();                         // handshake + live re-theme, hands-free
+const res = await kit.apiFetch(base + "/api/chat", { method: "POST", body: ... });
+```
+
+Prefer the kit over hardcoding hex values, a theme map, or a CDN — colors and the handshake both come
+from the console's own DS, so your view always matches the operator's live theme.
 
 ## Events — broadcast and subscribe (ADR 0039)
 
 Plugins talk to the rest of the app through the **event bus**, never by importing each other. You
 broadcast and forget; anyone who cares subscribes by topic. Topics are namespaced to your plugin
-(`<plugin_id>.<event>`), and you may only publish under your own namespace.
+(`<plugin_id>.<event>`), and you may only publish under your **own** namespace (the host forces it).
 
 **From Python** (in `register`):
 
@@ -82,47 +213,76 @@ def register(registry):
     registry.on("notes.*", lambda evt: ...)    # subscribe to ANY topic (read-only); * / # wildcards
 ```
 
-**From a sandboxed view** (your served page), over the bridge:
+**From a sandboxed view** (your served page), over the bridge — three message types:
 
 ```js
-// subscribe to topics you care about, then receive them
+// 1. subscribe to topics you care about, then receive them
 parent.postMessage({ type: "protoagent:subscribe", patterns: ["artifact.#"] }, "*");
 window.addEventListener("message", (e) => {
   const m = e.data || {};
-  if (m.type === "protoagent:event") { /* m.topic, m.data */ }
+  if (m.type === "protoagent:event") { /* m.topic, m.data */ }   // 2. delivered events
 });
-// publish (the host forces your namespace + gates it)
+// 3. publish — the host FORCES your plugin's namespace + gates it
 parent.postMessage({ type: "protoagent:publish", topic: "created", data: { id: "a1" } }, "*");
 ```
 
-**Declare your contract** in the manifest so others can discover it (shown in runtime status):
+**Declare your contract** in the manifest so others can discover it (surfaced in runtime status):
 
 ```yaml
-emits: ["artifact.created"]
+emits: ["mychart.created"]
 subscribes: ["notes.changed"]
 ```
 
 **Notification dots come for free:** any event under `<plugin_id>.*` lights your plugin's rail icon
-until the user opens that surface — no badge endpoint, no polling. (See the
-[security & trust model](../explanation/security-and-trust.md): subscribing is safe; publishing is
-the gated direction.)
+until the user opens that surface — no badge endpoint, no polling. Subscribing is always safe;
+publishing is the gated direction (namespace-forced).
+
+## Trust & the sandbox split
+
+There are **two different** iframe-sandbox postures. Do not blur them.
+
+- **Plugin rail/right views are isolation-of-convenience, not a security boundary** (ADR 0026 D6).
+  The console sets `sandbox="allow-scripts allow-forms allow-same-origin"` on your iframe.
+  `allow-same-origin` is required so your page can call its own `/api/` (the bearer handshake works).
+  This scopes your CSS/JS from the console — but it is **not** protection against a malicious enabled
+  plugin: an enabled plugin already runs **in-process as the agent** (same trust model as plugin
+  backends, ADR 0018). Only enable plugins you trust.
+
+- **Untrusted generated content gets `sandbox="allow-scripts"` with NO `allow-same-origin`** — the
+  **artifact** pattern (ADR 0026 D6 / ADR 0038). When the *agent generates* HTML/SVG/React
+  (`show_artifact`), it's rendered in a nested iframe with **no** same-origin and often via `srcdoc`,
+  so it runs but **can't** touch the console, its cookies, or its APIs. This is the one place the
+  sandbox is a genuine security line — "code the model emitted," not "code you installed."
+
+The rule of thumb: a **plugin** you installed → `allow-same-origin` (trusted, can call its API);
+**generated** content → no `allow-same-origin` / `srcdoc` (untrusted, fully fenced). See the
+[security & trust model](../explanation/security-and-trust.md).
 
 ## Want React (or any framework)?
 
-Build your UI however you like and **serve the built files** — inline (a single `_PAGE` string),
-as static assets your plugin serves, or pull libs from a CDN at runtime (the **`artifact`** plugin
-loads React + Babel from a CDN inside its sandbox). The console just iframes your `path`. For
-untrusted code (generated artifacts, third-party views) keep the iframe `sandbox="allow-scripts"`
-with **no** `allow-same-origin`.
+Build your UI however you like and **serve the built files** — inline (a single `_PAGE` string), as
+static assets your plugin serves, or pull libs from a CDN at runtime (the **artifact** plugin loads
+React + Babel from a CDN inside its sandbox). The console just iframes your `path`.
 
-## Reference plugins (in `plugins/`)
+## Reference plugins
 
-- **artifact-plugin** (external — github.com/protoLabsAI/artifact-plugin) — generative UI: the agent calls `show_artifact(kind, code)`; renders in a nested sandboxed iframe. The reference distributable plugin.
-- **`notes`** — a self-contained markdown editor: tools (`read_note`/`write_note`/`append_note`) +
-  a `/note` data route + a `/view` editor page. The template for "a plugin that owns its vertical."
+- **[`examples/plugins/chat_example`](https://github.com/protoLabsAI/protoAgent/tree/main/examples/plugins/chat_example)** —
+  the **gold-standard copy-me view**: a single-page chat panel covering all four rules + the
+  handshake + live re-theme + slug-aware routing + a real turn over a gated route. Start here.
+- **artifact-plugin** (external — github.com/protoLabsAI/artifact-plugin) — generative UI: the agent
+  calls `show_artifact(kind, code)`; renders in a **nested, no-same-origin** sandboxed iframe (the
+  untrusted-content posture above). Uses a **custom router prefix** — a good example of RULE 1 with a
+  non-default prefix.
 
-Both are pure Python + a served page + (optionally) a bundled `SKILL.md`, and both are fully
-distributable from a git URL.
+Both are pure Python + a served page + (optionally) a bundled `SKILL.md`, fully distributable from a
+git URL.
+
+## Lifecycle
+
+- Views appear for **enabled** plugins; disabling one (or a config reload that drops it) removes its
+  rail icon and, if you were on it, falls back to Chat.
+- Adding a view to an existing plugin needs a **restart** (routes mount once at init) — but the rail
+  picks up the declaration from `runtime-status` with **no console rebuild**.
 
 ## Fork components (no plugin, no iframe)
 
@@ -132,7 +292,10 @@ sandboxed.
 
 ## References
 
+- [Build a plugin view (quickstart)](/how-to/build-a-plugin-view) — the short entry the DS kit header
+  points to, plus the kit helper API at a glance.
 - [Security & trust model](../explanation/security-and-trust.md) — why plugin UIs are sandboxed
   iframes, and the "installing a plugin runs its code" trust posture.
-- ADR 0026 (plugin console surfaces + the bridge), ADR 0027 (git-URL install), ADR 0038
-  (the two-mode model + why federation was retired).
+- ADR 0026 (plugin console surfaces + the bridge + the sandbox split), ADR 0027 (git-URL install),
+  ADR 0038 (the two-mode model + why federation was retired), ADR 0039 (the event bus), ADR 0042 (the
+  `/agents/<slug>/` fleet proxy), ADR 0045 (the chat slot).

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -44,7 +44,7 @@ Drop-in packages that add capability without forking — and reach the agent ove
 | Guide | When to read |
 |---|---|
 | [Plugins](/guides/plugins) | You want drop-in packages that add tools, skills, routes, background surfaces, subagents and managed MCP servers without forking (Discord + Google ship this way) |
-| [Plugin console views](/guides/plugin-views) | You want a plugin to add its own left-rail icon + view (dashboard) to the console |
+| [Building a plugin view](/guides/building-react-plugin-views) | You want a plugin to add its own console surface — a left-rail view (dashboard/chart/editor) or a panel that replaces the built-in chat |
 | [Build a communication plugin](/guides/communication-plugins) | You want a new inbound/outbound channel (like Discord) as a plugin surface |
 | [Install & publish plugins (git URLs)](/guides/plugin-registry) | You want to install a plugin from a git URL, or publish one as a shareable repo (tools + skills + subagents + workflows + views) |
 | [Discord surface](/guides/discord) | You want the agent reachable from Discord (the first-party `discord` plugin) |

--- a/docs/guides/middleware.md
+++ b/docs/guides/middleware.md
@@ -169,5 +169,5 @@ For the full path (plugin load → chain membership), see
 ## Related
 
 - [Plugins](/guides/plugins) — the full contribution surface (`register_*` inventory)
-- [Plugin console views](/guides/plugin-views) — surface your middleware's output in the console
+- [Building a plugin view](/guides/building-react-plugin-views) — surface your middleware's output in the console
 - ADR 0032 (plugin middleware) · ADR 0039 (event bus)

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -75,7 +75,7 @@ def register(registry):
 
 `skills/` and `workflows/` are **data**, so they're auto-discovered from those
 conventional subdirs — no boilerplate. **Console views** (a rail icon + page) are
-declared in the manifest — see [Plugin console views](/guides/plugin-views).
+declared in the manifest — see [Building a plugin view](/guides/building-react-plugin-views).
 
 Declare pip dependencies (they are **not** auto-installed — see Safety):
 

--- a/docs/guides/plugin-views.md
+++ b/docs/guides/plugin-views.md
@@ -1,148 +1,23 @@
 # Plugin console views (rail surfaces)
 
-A plugin can add its own **left-rail icon and view** to the operator console — a
-dashboard, board, or whatever UI the fork wants — by declaring it in the manifest
-and serving a page. **No console rebuild.** This is the frontend counterpart to
-[plugin tools/routes](/guides/plugins) and [plugin settings](/guides/plugins);
-see [ADR 0026](/adr/0026-plugin-contributed-console-surfaces).
+> [!IMPORTANT]
+> This page moved. The single canonical guide for plugin views — rail surfaces, the
+> `slot: "chat"` panel, the init/theme handshake, the event-bus bridge, the sandbox split, and the
+> DS kit helpers — is now **[Building a plugin view](/guides/building-react-plugin-views)**.
+>
+> For the short copy-me quickstart, see **[Build a plugin view](/how-to/build-a-plugin-view)**.
 
-## Declare a view
+A plugin can add its own **left-rail icon and view** to the operator console — a dashboard, board,
+chart, editor, or a panel that *replaces* the built-in chat (`slot: "chat"`) — by declaring it in the
+manifest and serving a page. **No console rebuild.** This is the frontend counterpart to
+[plugin tools/routes](/guides/plugins); see [ADR 0026](/adr/0026-plugin-contributed-console-surfaces).
 
-Add a `views:` block to `protoagent.plugin.yaml`:
+The mechanics — and the four rules every view should follow — live in the canonical guide:
 
-```yaml
-views:
-  - id: board                      # unique within the plugin
-    label: "Board"                 # rail + tab label
-    icon: LayoutDashboard          # a lucide-react icon name
-    path: /plugins/myplugin/board  # the page the iframe loads (you serve it)
-    placement: rail                # "rail" (default — left-rail surface) | "right" (right sidebar)
-    tabs:                          # optional sub-nav (view-tabs)
-      - { id: open, label: "Open", path: /plugins/myplugin/board?tab=open }
-      - { id: done, label: "Done", path: /plugins/myplugin/board?tab=done }
-```
+→ **[Building a plugin view](/guides/building-react-plugin-views)**
 
-**`placement`** chooses where the view lives: **`rail`** (default) is a full left-rail
-surface; **`right`** is a panel in the right sidebar alongside Notes / Beads / Goals /
-Schedule. Same iframe host either way.
-
-The console reads this from `/api/runtime/status` and renders a rail icon per
-view (keyed `plugin:<id>:<viewId>`). When selected, it hosts `path` in a
-same-origin **iframe** that fills the stage; `tabs` render as a sub-nav that swaps
-the iframe page. `icon` is **any** [lucide](https://lucide.dev) icon name — either
-PascalCase (`LineChart`) or kebab-case (`line-chart`). A curated common set
-(dashboards, data, comms, dev, AI, finance, space/fleet, security — e.g.
-`LayoutDashboard`, `BarChart3`, `Database`, `Workflow`, `Bot`, `Rocket`, `Coins`,
-`Shield`) renders instantly; anything else is lazy-loaded on demand, so you're not
-limited to an allowlist and the console bundle stays lean. An unknown name falls back
-to a generic plugin glyph.
-
-## Claim the chat slot (`slot: "chat"`)
-
-The chat surface is a **slot** (ADR 0045): your view can *replace* the built-in chat
-panel instead of adding a rail icon.
-
-```yaml
-views:
-  - id: panel
-    label: "My chat"
-    icon: MessageSquare
-    path: /plugins/mychat/panel
-    slot: chat          # replace the built-in chat panel
-```
-
-What changes versus a normal view:
-
-- Your page renders under the core **Chat** rail id — you get **no separate icon**,
-  and the first enabled claimant wins.
-- You inherit chat's mount contract: the iframe is kept mounted for the **app's
-  lifetime** (a normal view unmounts when you switch away); visibility toggles only.
-  That's what keeps an in-flight streamed turn alive across surface switches.
-- Without a claimant, the built-in chat renders — the console is never chat-less.
-
-Your page speaks the same protocol the built-in panel does: the
-[init handshake](#the-init-handshake-bearer--theme) hands you the bearer + theme, and
-the agent itself is driven over **A2A 1.0** (`SendStreamingMessage` for the streaming
-turn, `tasks/get` for reconciliation) plus three REST endpoints (`/api/chat/commands`,
-`DELETE /api/chat/sessions/{id}`, non-streaming `POST /api/chat`). Before shipping,
-read the **conformance checklist in ADR 0045** — it encodes the hard-won invariants
-(never remount mid-turn, reconcile stuck streams on load, render terminal text once,
-key local state per agent slug).
-
-Forks have an in-process alternative: register a `src/ext` surface with `id: "chat"`
-(ADR 0038 D3) — it overrides the slot ahead of plugin claims, with full React context.
-
-A complete reference implementation lives in **`examples/plugins/chat_example`** —
-a single-page vanilla-JS panel covering the handshake, live re-theming, slug-aware
-routing, and a turn over the non-streaming path. It's a copy-me example, not a
-bundled plugin. Try it:
+Copy the gold-standard reference to start:
 
 ```bash
 cp -r examples/plugins/chat_example plugins/
 ```
-
-```yaml
-plugins:
-  enabled: [chat_example]
-```
-
-Reload — Chat becomes the example panel. Disable (or delete) the copy and the
-built-in chat is back.
-
-## Serve the page
-
-The page is yours — any framework, or plain HTML. Serve it from the plugin's
-router (the same `register_router` that backs tools/routes):
-
-```python
-def _build_router():
-    from fastapi import APIRouter
-    from fastapi.responses import HTMLResponse
-    router = APIRouter()
-
-    @router.get("/board")          # mounted at /plugins/myplugin/board
-    async def _board():
-        return HTMLResponse("<!doctype html>… your UI …")
-    return router
-
-def register(registry):
-    registry.register_router(_build_router())
-```
-
-See the shipped [`plugins/hello`](https://github.com/protoLabsAI/protoAgent/tree/main/plugins/hello)
-for a worked example (a `views:` entry + a `/view` page).
-
-## The init handshake (bearer + theme)
-
-After the iframe loads, the console **posts a message** to it — so your page gets
-the operator bearer (for its own API calls) and the console theme tokens (to match
-the look) **without a token in the URL**:
-
-```js
-window.addEventListener("message", (e) => {
-  const m = e.data || {};
-  if (m.type !== "protoagent:init") return;
-  // m.token — operator bearer (or null when none is configured); use it as
-  //           `Authorization: Bearer <token>` for your /plugins/<id>/... calls.
-  // m.theme — { bg, bgPanel, fg, fgMuted, brand, border } from the console.
-  if (m.theme?.bg) document.body.style.background = m.theme.bg;
-});
-```
-
-The message is sent same-origin and targeted at your page's origin.
-
-## Trust & sandbox
-
-The view runs in an iframe with `sandbox="allow-scripts allow-forms allow-same-origin"`.
-This scopes the plugin's CSS/JS from the console — it is **not** a security
-boundary against a malicious enabled plugin: an enabled plugin already runs
-in-process as the agent (same trust model as [plugin backends](/guides/plugins)).
-Only enable plugins you trust.
-
-## Lifecycle
-
-- Views appear for **enabled** plugins; disabling one (or a config reload that
-  drops it) removes its rail icon and, if you were on it, falls back to Chat.
-- Mounting/serving is config-driven — adding a view to an existing plugin needs a
-  restart (routes mount once at init), but the rail picks up the declaration from
-  `runtime-status` with no console rebuild.

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -63,7 +63,7 @@ def register(registry):
 ```
 
 `register` is called once at load. The registry accepts these contribution types
-(plus console **views**, declared in the manifest — see [Plugin console views](/guides/plugin-views)) —
+(plus console **views**, declared in the manifest — see [Building a plugin view](/guides/building-react-plugin-views)) —
 a fork adds any of them as a plugin, never editing the core `server/` package:
 
 | Method | Contributes | Lifecycle |
@@ -193,7 +193,7 @@ def register(registry):
 - **Declare your contract** in the manifest (`emits:` / `subscribes:`) — your events are your public
   API, discoverable in `/api/runtime/status`.
 - A console **view** (sandboxed iframe) talks to the bus over the bridge — see
-  [Plugin console views](/guides/plugin-views). Any event under `<plugin_id>.*` lights your plugin's
+  [Building a plugin view](/guides/building-react-plugin-views). Any event under `<plugin_id>.*` lights your plugin's
   rail icon (a **notification dot**) until the user opens that surface.
 - Fire-and-forget + topic-filtered + exception-isolated: a slow or broken subscriber can't affect the
   publisher or other subscribers. Ephemeral (a ring buffer covers SSE reconnects; no durable log).
@@ -307,8 +307,8 @@ Restart, then check `GET /api/runtime/status` — the `hello` plugin shows
 
 ## Related
 
-- **[Plugin console views](/guides/plugin-views)** — give a plugin its own
-  left-rail icon + view (a dashboard) in the console (ADR 0026).
+- **[Building a plugin view](/guides/building-react-plugin-views)** — give a plugin its own
+  console surface — a left-rail view or a chat-slot panel (ADR 0026 / 0045).
 - **[Install & publish plugins (git URLs)](/guides/plugin-registry)** — install a
   plugin from a git URL (`python -m server plugin install <url>`) or publish one as
   a shareable repo. A repo is a full bundle: besides what `register()` adds, a

--- a/docs/how-to/build-a-plugin-view.md
+++ b/docs/how-to/build-a-plugin-view.md
@@ -1,0 +1,61 @@
+# Build a plugin view
+
+A plugin adds a console surface by **serving its own page** and declaring it in the manifest; the
+console renders it in a sandboxed **iframe**. No host build. This is the short, copy-me entry — the
+full guide is **[Building a plugin view](/guides/building-react-plugin-views)**.
+
+## Copy the gold-standard
+
+[`examples/plugins/chat_example`](https://github.com/protoLabsAI/protoAgent/tree/main/examples/plugins/chat_example)
+is a single-page view that follows every rule below — start by copying it:
+
+```bash
+cp -r examples/plugins/chat_example plugins/
+```
+
+```yaml
+plugins:
+  enabled: [chat_example]
+```
+
+Reload. (`chat_example` claims the chat slot; a normal view adds a rail icon instead.)
+
+## The four rules
+
+1. **Serve the path you declare** — the manifest's `views[].path` MUST equal a path your
+   `register_router` serves (default prefix `/plugins/<id>`; a custom prefix is fine, just keep them
+   in sync). A mismatch is a blank iframe.
+2. **Gate by default** — mount data routes under `prefix="/api/plugins/<id>"` so they inherit the
+   operator bearer gate. Use the ungated `/plugins/<id>` prefix only for genuinely public assets (the
+   page itself — an iframe page-load can't carry an `Authorization` header).
+3. **Same-origin, slug-aware, never hardcode** — derive `base = location.pathname.split("/plugins/")[0]`
+   and prefix every fetch/asset. Never hardcode `/api/.../`, `/plugins/.../`, or `http://localhost:PORT`
+   — it breaks the `/agents/<slug>/` fleet proxy and the same-origin token handshake.
+4. **Link the DS kit** — `<base>/_ds/plugin-kit.css` + `<base>/_ds/plugin-kit.js` instead of
+   hardcoding hex or a CDN. The kit's `--pl-*` tokens re-skin to the operator's live theme.
+
+## The kit helper API (`plugin-kit.js`)
+
+The console serves the design-system kit same-origin at `<base>/_ds/plugin-kit.{css,js}`. Load it as
+an ES module (`import { initPluginView } from ".../plugin-kit.js"`) or use the
+`window.protoPluginView` global from a classic script tag:
+
+| Helper | What it does |
+|---|---|
+| `initPluginView(onInit?)` | Listens for the `protoagent:init` handshake (bearer + theme) **and** live `protoagent:theme` re-themes, mapping the console theme onto the DS `--pl-*` tokens. Call once on load. |
+| `getToken()` | The captured operator bearer (null until the handshake delivers one). |
+| `apiFetch(input, init?)` | Same-origin `fetch` with `Authorization: Bearer <token>` attached when present — for every gated `/api/...` call. |
+| `window.protoPluginView` | The same three helpers as a global, for no-build pages. |
+
+```js
+const kit = window.protoPluginView;
+kit.initPluginView();                                   // handshake + live re-theme, hands-free
+const base = location.pathname.split("/plugins/")[0];   // "" or "/agents/<slug>"
+const res = await kit.apiFetch(base + "/api/plugins/mychart/data");
+```
+
+## Next
+
+- **[Building a plugin view](/guides/building-react-plugin-views)** — the full guide: the `slot: "chat"`
+  panel (ADR 0045), the event-bus bridge (ADR 0039), the sandbox split (ADR 0026 D6), and references.
+- **[Plugins](/guides/plugins)** — the rest of the plugin contract (tools, subagents, config, MCP).

--- a/examples/plugins/chat_example/panel.html
+++ b/examples/plugins/chat_example/panel.html
@@ -1,82 +1,109 @@
 <!doctype html>
+<!--
+  ════════════════════════════════════════════════════════════════════════════
+  chat_example/panel.html — the GOLD-STANDARD copy-me plugin view.
+
+  Copy this when you build your own console view. It models the FOUR RULES every
+  plugin view should follow:
+
+    1. SERVE WHAT YOU DECLARE — the manifest's `views[].path`
+       (/plugins/chat_example/panel) is the ONE route the plugin's router serves
+       (see __init__.py). The console iframes exactly that path; serve it and
+       nothing the manifest doesn't declare.
+
+    2. GATE BY DEFAULT — every DATA call goes to a bearer-gated /api/ route
+       (here the core non-streaming POST /api/chat), authed with the bearer the
+       console hands us via the protoagent:init handshake — never a public route,
+       never a token in the URL. (The PAGE itself is served outside /api/ as
+       public chrome on purpose: a browser iframe page-load can't carry an
+       Authorization header — so only the page is public; all its data is gated.)
+
+    3. SAME-ORIGIN, SLUG-AWARE, NEVER HARDCODE — derive `base` from the iframe's
+       OWN path and prefix EVERY fetch/asset with it. On the host window base=""
+       (so /api/chat); through the fleet proxy base="/agents/<slug>" (so
+       /agents/<slug>/api/chat) — the panel always talks to ITS agent, never the
+       host's (ADR 0042). Hardcoding "/api/chat" is the fleet-UNSAFE antipattern.
+
+    4. LINK THE KIT — pull the design system from the console's own, same-origin
+       <base>/_ds/plugin-kit.{css,js} instead of hand-rolling a hex/theme map or
+       pinning a CDN. plugin-kit.css gives the --pl-* tokens + .pl-* components;
+       plugin-kit.js wires the protoagent:init handshake so the kit's tokens
+       re-skin to the operator's live theme for free (protoContent #176).
+  ════════════════════════════════════════════════════════════════════════════
+-->
 <html>
 <head>
 <meta charset="utf-8" />
 <title>Chat (example plugin)</title>
+<script>
+  "use strict";
+  // ── RULE 3: slug-aware base, computed FIRST (everything below prefixes it). ──
+  // iframe lives at /plugins/... (host) or /agents/<slug>/plugins/... (proxied).
+  window.__base = location.pathname.split("/plugins/")[0]; // "" or "/agents/<slug>"
+  // ── RULE 4: link the kit from the console's own same-origin DS, slug-aware. ──
+  // Injected here (not a static <link>) so the href carries the slug-aware base.
+  document.write(
+    '<link rel="stylesheet" href="' + window.__base + '/_ds/plugin-kit.css">',
+  );
+</script>
 <style>
-  /* Defaults match the console's dark ground; protoagent:init overrides them with
-     the live theme tokens so the panel re-skins with the agent's theme. */
-  :root {
-    --bg: #0a0f14; --bg-panel: #11161d; --fg: #e6e6e6; --fg-muted: #9aa0aa;
-    --brand: #9b87f2; --border: #232a33;
-  }
-  html, body { margin: 0; height: 100%; background: var(--bg); color: var(--fg);
-    font-family: ui-sans-serif, system-ui, -apple-system, sans-serif; }
+  /* Layout only — colors/typography come from plugin-kit.css's --pl-* tokens,
+     which plugin-kit.js re-skins to the operator's live theme on the handshake. */
+  html, body { margin: 0; height: 100%; }
   .wrap { display: flex; flex-direction: column; height: 100%; box-sizing: border-box; }
   header { display: flex; align-items: center; gap: 8px; padding: 10px 14px;
-    border-bottom: 1px solid var(--border); font-size: 13px; color: var(--fg-muted); }
-  header .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--brand); }
-  header button { margin-left: auto; background: none; border: 1px solid var(--border);
-    color: var(--fg-muted); border-radius: 6px; padding: 3px 10px; font-size: 12px; cursor: pointer; }
-  header button:hover { color: var(--fg); border-color: var(--brand); }
+    border-bottom: var(--pl-border-width) solid var(--pl-color-border);
+    font-size: 13px; color: var(--pl-color-fg-muted); }
+  header .dot { width: 8px; height: 8px; border-radius: 50%; background: var(--pl-color-accent); }
+  header button { margin-left: auto; }
   #log { flex: 1; overflow-y: auto; padding: 16px; display: flex; flex-direction: column; gap: 10px; }
-  .msg { max-width: 72ch; padding: 9px 13px; border-radius: 12px; font-size: 14px;
+  .msg { max-width: 72ch; padding: 9px 13px; border-radius: var(--pl-radius); font-size: 14px;
     line-height: 1.55; white-space: pre-wrap; word-break: break-word; }
-  .msg.user { align-self: flex-end; background: var(--brand); color: #0a0f14; border-bottom-right-radius: 4px; }
-  .msg.assistant { align-self: flex-start; background: var(--bg-panel);
-    border: 1px solid var(--border); border-bottom-left-radius: 4px; }
-  .msg.pending { color: var(--fg-muted); font-style: italic; }
-  .msg.error { align-self: stretch; background: none; border: 1px solid #b3404a; color: #e08089; }
-  .empty { margin: auto; text-align: center; color: var(--fg-muted); font-size: 13px; max-width: 44ch; line-height: 1.7; }
-  .empty b { color: var(--brand); }
-  form { display: flex; gap: 8px; padding: 12px 14px; border-top: 1px solid var(--border); }
-  textarea { flex: 1; resize: none; background: var(--bg-panel); color: var(--fg);
-    border: 1px solid var(--border); border-radius: 10px; padding: 9px 12px; font: inherit;
-    font-size: 14px; min-height: 20px; max-height: 140px; }
-  textarea:focus { outline: none; border-color: var(--brand); }
-  form button { background: var(--brand); color: #0a0f14; border: 0; border-radius: 10px;
-    padding: 0 18px; font-weight: 600; font-size: 14px; cursor: pointer; }
-  form button:disabled { opacity: 0.5; cursor: default; }
+  .msg.user { align-self: flex-end; background: var(--pl-color-accent); color: var(--pl-color-fg-on-accent); }
+  .msg.assistant { align-self: flex-start; background: var(--pl-color-bg-raised);
+    border: var(--pl-border-width) solid var(--pl-color-border); }
+  .msg.pending { color: var(--pl-color-fg-muted); font-style: italic; }
+  .msg.error { align-self: stretch; background: none;
+    border: var(--pl-border-width) solid var(--pl-color-status-error); color: var(--pl-color-status-error); }
+  .empty { margin: auto; text-align: center; color: var(--pl-color-fg-muted);
+    font-size: 13px; max-width: 44ch; line-height: 1.7; }
+  .empty b { color: var(--pl-color-fg); }
+  form { display: flex; gap: 8px; padding: 12px 14px; border-top: var(--pl-border-width) solid var(--pl-color-border); }
+  #input { flex: 1; min-height: 20px; max-height: 140px; }
 </style>
 </head>
 <body>
 <div class="wrap">
   <header><span class="dot"></span> chat_example — a slot-claiming chat panel
-    <button id="reset" type="button" title="Start a fresh session">New session</button>
+    <button id="reset" class="pl-btn pl-btn--sm" type="button" title="Start a fresh session">New session</button>
   </header>
   <div id="log">
     <div class="empty">This is the <b>example chat plugin</b> rendering in the chat slot.
-      Send a message — it drives the agent over <b>POST /api/chat</b> with the bearer from
-      the <b>protoagent:init</b> handshake. Disable the plugin to restore the built-in chat.</div>
+      Send a message — it drives the agent over the gated <b>POST /api/chat</b> with the
+      bearer from the <b>protoagent:init</b> handshake. Disable the plugin to restore the
+      built-in chat.</div>
   </div>
   <form id="composer">
-    <textarea id="input" rows="1" placeholder="Message the agent…"></textarea>
-    <button id="send" type="submit">Send</button>
+    <textarea id="input" class="pl-input" rows="1" placeholder="Message the agent…"></textarea>
+    <button id="send" class="pl-btn pl-btn--primary" type="submit">Send</button>
   </form>
 </div>
+<!-- RULE 4: the kit's JS, same-origin + slug-aware. Gives window.protoPluginView
+     ({ initPluginView, apiFetch, getToken }) — the no-build handshake + authed fetch. -->
+<script src="" id="kit"></script>
+<script>
+  document.getElementById("kit").src = window.__base + "/_ds/plugin-kit.js";
+</script>
 <script>
   "use strict";
-  // ── Console handshake (ADR 0038): bearer + theme arrive via postMessage. ─────
-  let token = null;
-  function applyTheme(theme) {
-    if (!theme) return;
-    const map = { bg: "--bg", bgPanel: "--bg-panel", fg: "--fg", fgMuted: "--fg-muted",
-                  brand: "--brand", border: "--border" };
-    for (const [k, v] of Object.entries(map)) {
-      if (theme[k]) document.documentElement.style.setProperty(v, theme[k]);
-    }
-  }
-  window.addEventListener("message", (e) => {
-    const m = e.data || {};
-    if (m.type === "protoagent:init") { token = m.token || null; applyTheme(m.theme); }
-    else if (m.type === "protoagent:theme") applyTheme(m.theme); // live re-theme
-  });
+  const base = window.__base;
 
-  // ── Slug-aware base (ADR 0042): the iframe lives at /plugins/... (host window)
-  // or /agents/<slug>/plugins/... (peer window) — keep API calls on OUR agent. ──
-  const base = location.pathname.split("/plugins/")[0];
+  // ── RULE 4: the kit handles the protoagent:init handshake (bearer + theme) and
+  // re-skins its --pl-* tokens to the operator's live theme. We just listen. ──
+  const kit = window.protoPluginView;
+  kit.initPluginView();
 
-  // ── One session per agent, persisted; New session rotates it. ────────────────
+  // ── RULE 3: one session per agent, keyed by slug-aware base; New session rotates it. ──
   const SKEY = "chat-example.session:" + (base || "host");
   let sessionId = localStorage.getItem(SKEY) ||
     "chx-" + Date.now().toString(36) + "-" + Math.random().toString(36).slice(2, 8);
@@ -103,10 +130,10 @@
   async function sendTurn(message) {
     const pending = bubble("assistant pending", "thinking…");
     try {
-      const res = await fetch(base + "/api/chat", {
+      // RULE 2 + 3: kit.apiFetch attaches the bearer; base keeps it on OUR agent.
+      const res = await kit.apiFetch(base + "/api/chat", {
         method: "POST",
-        headers: { "Content-Type": "application/json",
-                   ...(token ? { Authorization: "Bearer " + token } : {}) },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message, session_id: sessionId }),
       });
       if (!res.ok) {

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -195,6 +195,47 @@ def _min_version_gate(manifest: PluginManifest) -> str | None:
     return None
 
 
+def _served_paths(routers: list[dict]) -> set[str]:
+    """The set of URL paths served by *routers* (``[{"router", "prefix"}, …]``).
+
+    Each path is the router's ``prefix`` + a contained route's ``path``. A route
+    at the prefix root (``route.path`` of ``""`` or ``"/"``) is normalised to the
+    bare prefix so a view declared as the prefix itself counts as served.
+    """
+    served: set[str] = set()
+    for r in routers:
+        prefix = str(r.get("prefix", "")).rstrip("/")
+        router = r.get("router")
+        for route in getattr(router, "routes", []) or []:
+            rp = getattr(route, "path", None)
+            if rp is None:
+                continue
+            full = (prefix + str(rp)).rstrip("/") or "/"
+            served.add(full)
+    return served
+
+
+def _warn_unserved_views(manifest: PluginManifest, routers: list[dict]) -> None:
+    """Warn for each enabled view whose ``path`` no router serves (ADR 0026/0018).
+
+    A declared view is an iframe of a page the plugin must serve at ``path``. If no
+    registered router serves that path the iframe renders blank/404 — usually a
+    missing ``register_router`` or a path typo, which fails silently today.
+    """
+    if not manifest.views:
+        return
+    served = _served_paths(routers)
+    for view in manifest.views:
+        path = str(view.get("path", "")).rstrip("/") or "/"
+        if path not in served:
+            log.warning(
+                "[plugins] %s: view %r declares path %r but no registered router serves it "
+                "— it will render a blank/404 iframe (did you forget register_router, "
+                "or is the path a typo?)",
+                manifest.id, view.get("id"), view.get("path"),
+            )
+
+
 def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLoadResult:
     """Load enabled plugins and collect their contributions.
 
@@ -302,6 +343,10 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         # the server can namespace + report them.
         for r in registry.routers:
             result.routers.append({"plugin_id": manifest.id, **r})
+        # Cross-check: every declared view must be served by one of this plugin's
+        # routers, else the iframe renders blank/404. Catches "declared a view but
+        # forgot register_router" / a path typo that fails silently today.
+        _warn_unserved_views(manifest, registry.routers)
         for s in registry.surfaces:
             result.surfaces.append({"plugin_id": manifest.id, **s})
         result.subagents.extend(registry.subagents)

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
 
@@ -48,7 +49,13 @@ class PluginManifest:
     # Console surfaces (ADR 0026) — each entry adds a left-rail icon opening a
     # full view (an iframe of a page the plugin serves at `path`). Declared as
     # data so it's known without importing the plugin, and surfaced to the
-    # frontend via /api/runtime/status. Each: {id, label, icon, path, tabs?}.
+    # frontend via /api/runtime/status. Each: {id, label, icon, path, tabs?, slot?}.
+    # `path` must (1) be a path a registered router actually serves — the console
+    # iframes it verbatim, so a path no router answers is a blank surface — and
+    # (2) be a same-origin RELATIVE path (no scheme/host/port): an absolute URL
+    # escapes the ADR 0042 fleet proxy origin and breaks the same-origin
+    # postMessage token handshake. See `_parse_views` (warns on non-same-origin)
+    # and docs/guides/building-react-plugin-views.md.
     views: list[dict] = field(default_factory=list)
     # Event contract (ADR 0039) — the topics this plugin broadcasts / listens for.
     # Declarative for discoverability (surfaced in /api/runtime/status): a plugin
@@ -68,6 +75,41 @@ class PluginManifest:
     repository: str = ""
     homepage: str = ""
     min_protoagent_version: str = ""
+
+
+# A view path that carries a scheme/host instead of being a same-origin relative
+# path. Console views are sandboxed iframes served back through the ADR 0042 fleet
+# proxy and rely on a same-origin postMessage token handshake — an absolute URL
+# (http(s)://…, protocol-relative //host, localhost, or an explicit :PORT) escapes
+# the proxy origin and breaks both. We warn (not reject) so a typo is loud but the
+# plugin still loads.
+_NON_SAME_ORIGIN_PATH = re.compile(r"https?://|^//|localhost|:\d", re.IGNORECASE)
+
+
+def _parse_views(views, plugin_id: str) -> list[dict]:
+    """Keep view entries with an ``id`` + ``path``; warn on non-same-origin paths.
+
+    Views must point at a same-origin **relative** path. A path that carries a
+    scheme or host (``http(s)://``, protocol-relative ``//host``, ``localhost``, or
+    a ``:PORT``) breaks the ADR 0042 fleet proxy and the same-origin postMessage
+    token handshake — we log a warning but still keep the view so the author sees
+    the mistake rather than a silently-missing rail icon.
+    """
+    if not isinstance(views, (list, tuple)):
+        return []
+    kept: list[dict] = []
+    for v in views:
+        if not (isinstance(v, dict) and v.get("id") and v.get("path")):
+            continue
+        path = str(v.get("path"))
+        if _NON_SAME_ORIGIN_PATH.search(path):
+            log.warning(
+                "[plugins] %s: view %r path %r is not same-origin relative — a scheme/host "
+                "breaks the fleet proxy + the postMessage token handshake; use a relative path",
+                plugin_id, v.get("id"), path,
+            )
+        kept.append(v)
+    return kept
 
 
 def load_manifest(plugin_dir: Path) -> PluginManifest | None:
@@ -102,7 +144,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     cfg = data.get("config")
     secrets = data.get("secrets")
     settings = data.get("settings")
-    views = data.get("views")
+    views = _parse_views(data.get("views"), pid)
     emits = data.get("emits")
     subscribes = data.get("subscribes")
     requires_pip = data.get("requires_pip")
@@ -121,8 +163,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
         secrets=[str(s) for s in secrets] if isinstance(secrets, (list, tuple)) else [],
         settings=[s for s in settings if isinstance(s, dict)] if isinstance(settings, (list, tuple)) else [],
         test=bool(data.get("test", False)),
-        views=[v for v in views if isinstance(v, dict) and v.get("id") and v.get("path")]
-        if isinstance(views, (list, tuple)) else [],
+        views=views,
         emits=[str(x) for x in emits] if isinstance(emits, (list, tuple)) else [],
         subscribes=[str(x) for x in subscribes] if isinstance(subscribes, (list, tuple)) else [],
         requires_pip=[str(x) for x in requires_pip] if isinstance(requires_pip, (list, tuple)) else [],

--- a/operator_api/web.py
+++ b/operator_api/web.py
@@ -28,16 +28,23 @@ def mount_react_app(app, dist_dir: str | Path, *, app_path: str = "/app") -> boo
             name="operator_assets",
         )
 
-    # The design-system plugin-kit, served same-origin at /_ds/plugin-kit.css (root,
-    # alongside /plugins/<id>/…). Plugin iframe views `<link>` this one path instead
-    # of pinning a CDN copy, so every view matches the console's installed DS version.
-    # Emitted to dist/_ds/ by the web build (apps/web/scripts/copy-plugin-kit.mjs).
-    ds_kit = dist / "_ds" / "plugin-kit.css"
-    if ds_kit.is_file():
+    # The design-system plugin-kit, served same-origin at /_ds/plugin-kit.{css,js}
+    # (root, alongside /plugins/<id>/…). Plugin iframe views `<link>`/`<script>` these
+    # paths instead of pinning a CDN copy, so every view matches the console's installed
+    # DS version. Emitted to dist/_ds/ by the web build (apps/web/scripts/copy-plugin-kit.mjs).
+    ds_kit_css = dist / "_ds" / "plugin-kit.css"
+    if ds_kit_css.is_file():
 
         @app.get("/_ds/plugin-kit.css", include_in_schema=False)
-        async def _ds_plugin_kit() -> FileResponse:
-            return FileResponse(str(ds_kit), media_type="text/css")
+        async def _ds_plugin_kit_css() -> FileResponse:
+            return FileResponse(str(ds_kit_css), media_type="text/css")
+
+    ds_kit_js = dist / "_ds" / "plugin-kit.js"
+    if ds_kit_js.is_file():
+
+        @app.get("/_ds/plugin-kit.js", include_in_schema=False)
+        async def _ds_plugin_kit_js() -> FileResponse:
+            return FileResponse(str(ds_kit_js), media_type="application/javascript")
 
     @app.get(app_path, include_in_schema=False)
     async def _operator_index() -> FileResponse:

--- a/plugins/hello/protoagent.plugin.yaml
+++ b/plugins/hello/protoagent.plugin.yaml
@@ -31,11 +31,3 @@ settings:
 # name; `path` is served by this plugin's router (see __init__.py `/view`).
 views:
   - { id: hello, label: "Hello", icon: "Sparkles", path: "/plugins/hello/view" }
-  # A first-class React plugin view (ADR 0034) — `ui: react` mounts a Module Federation
-  # remote into the console's own React tree (not an iframe), in the right panel. `path` is
-  # kept as an iframe fallback. The remote is built to apps/web/public/remotes/hello-react/.
-  - {
-      id: hello-react, label: "Hello (React)", icon: "Atom", placement: right,
-      ui: react, path: "/plugins/hello/view",
-      remote: { url: "/app/remotes/hello-react/assets/remoteEntry.js", module: "./Panel" },
-    }

--- a/plugins/notes/__init__.py
+++ b/plugins/notes/__init__.py
@@ -1,9 +1,20 @@
-"""Notes plugin (ADR 0034 S4) — the first-class React reference plugin.
+"""Notes plugin (ADR 0034 S4) — the flagship reference plugin.
 
 A single shared markdown note that BOTH the agent (via tools) and the operator
-(via the `ui: react` console panel) read and write. The plugin owns its whole
-vertical: storage, agent tools, and the UI's data route. No tabs, no undo, no
-versioning — deliberately the basic notebook we actually want.
+(via a console panel) read and write. The plugin owns its whole vertical: storage,
+agent tools, and a sandboxed-iframe editor it serves itself (ADR 0038 — no host
+build, git-installable). No tabs, no undo, no versioning — deliberately the basic
+notebook we actually want.
+
+It models the VIEW-vs-DATA gating rule (the plugin-authoring guide): the editor
+PAGE is served under the PUBLIC ``/plugins/notes`` prefix because a browser iframe
+page-load can't carry an Authorization bearer — a gated page would 401-blank under
+the token gate. Its DATA/action routes stay GATED under ``/api/plugins/notes`` and
+are fetched from inside the loaded page with the postMessage handshake token.
+
+It also models the FLEET-PROXY-SAFE fetch (ADR 0042): the editor derives its API
+base from its own iframe path and prefixes every request, so a proxied
+/agents/<slug>/ window talks to ITS agent — never the host's.
 """
 
 from __future__ import annotations
@@ -83,12 +94,31 @@ def append_note(text: str) -> str:
     return f"Appended {len(text)} chars to the note."
 
 
-def _build_router():
-    """The Notes routes — mounted under ``/api/plugins/notes`` so they inherit the operator bearer
-    gate (P0 auth). ``/note`` is the data API; ``/view`` is the editor page the console iframes
-    (ADR 0038 — the plugin self-serves its UI; no host build, git-installable)."""
-    from fastapi import APIRouter, Body
+def _build_view_router():
+    """The editor PAGE — served under the PUBLIC ``/plugins/notes`` prefix (UNGATED).
+    A browser iframe page-load can't carry an Authorization bearer, so a gated page
+    would 401-blank under the token gate; the page itself is public chrome. It's the
+    editor the console iframes (ADR 0038 — the plugin self-serves its UI; no host
+    build, git-installable). The page then fetches its DATA from the gated data
+    router with the postMessage handshake token."""
+    from fastapi import APIRouter
     from fastapi.responses import HTMLResponse
+
+    router = APIRouter()
+
+    @router.get("/view")
+    async def _view():
+        return HTMLResponse(_EDITOR_HTML)
+
+    return router
+
+
+def _build_data_router():
+    """The Notes DATA/action routes — mounted under ``/api/plugins/notes`` so they
+    inherit the operator bearer gate (P0 auth). ``/note`` is fetched from inside the
+    loaded view page with the postMessage handshake token (the view page is public,
+    the data is gated — the rule the plugin-authoring guide teaches)."""
+    from fastapi import APIRouter, Body
 
     router = APIRouter()
 
@@ -101,24 +131,33 @@ def _build_router():
         _write(str(body.get("content", "")))
         return {"ok": True, "updated_at": _updated_at()}
 
-    @router.get("/view")
-    async def _view():
-        return HTMLResponse(_EDITOR_HTML)
-
     return router
 
 
 def register(registry) -> None:
-    """Entry point — called once at load with a PluginRegistry."""
+    """Entry point — called once at load with a PluginRegistry.
+
+    Two routers at DISTINCT prefixes (a same-prefix second router would be silently
+    dropped by the host's de-dupe — see server.agent_init._mount_plugin_routers):
+    the view PAGE under the public ``/plugins/notes`` (ungated, iframe-loadable) and
+    the DATA routes under ``/api/plugins/notes`` (gated, fetched with the token)."""
     registry.register_tools([read_note, write_note, append_note])
-    # Mounted at /api/plugins/notes (gated) — not the default /plugins/notes.
-    registry.register_router(_build_router(), prefix="/api/plugins/notes")
+    # View PAGE: public /plugins/notes (ungated) — iframe nav can't carry a bearer.
+    registry.register_router(_build_view_router(), prefix="/plugins/notes")
+    # DATA routes: gated /api/plugins/notes — fetched with the handshake token.
+    registry.register_router(_build_data_router(), prefix="/api/plugins/notes")
 
 
 # The editor page the console iframes (ADR 0026 bridge → bearer + theme). A self-contained markdown
 # editor: debounced autosave (PUT /note), an edit↔preview toggle (marked from CDN), and a poll that
 # adopts the agent's writes. Dark by default, following the console theme. No host build — the
 # plugin serves its own UI, so it works installed from a git URL (ADR 0038).
+#
+# FLEET-PROXY-SAFE FETCH (ADR 0042): the iframe (the PUBLIC page) loads at /plugins/notes/view on the
+# host window, but at /agents/<slug>/plugins/notes/view when this agent is viewed through the fleet
+# proxy. So it derives `base` from its own path (= "" on host, "/agents/<slug>" when proxied) and
+# prefixes EVERY data fetch — never hardcode an absolute "/api/..." or the proxied window would hit
+# the host agent. The data path stays the GATED /api/plugins/notes/note, fetched with the token.
 _EDITOR_HTML = r"""<!doctype html><html><head><meta charset="utf-8"><style>
   :root{ --bg:#0a0a0c; --bg-raised:#161616; --fg:#ededed; --fg-muted:#9aa0aa; --border:#2a2a30; --brand:#a78bfa; }
   html,body{margin:0;height:100%;background:var(--bg);color:var(--fg);
@@ -140,6 +179,10 @@ _EDITOR_HTML = r"""<!doctype html><html><head><meta charset="utf-8"><style>
 <script>
   var token=null, lastSynced="", dirty=false, preview=false, t=null;
   var ed=document.getElementById("ed"), pv=document.getElementById("pv"), st=document.getElementById("status"), tg=document.getElementById("toggle");
+  // Slug-aware base (ADR 0042): the iframe (PUBLIC page) lives at /plugins/notes/view on the host
+  // window or /agents/<slug>/plugins/notes/view when proxied. base = "" (host) or "/agents/<slug>"
+  // (proxied); prefix EVERY data fetch so the proxied window talks to ITS agent, never the host's.
+  var base = location.pathname.split("/plugins/")[0];
   window.addEventListener("message", function(e){
     var m=e.data||{}; if(m.type!=="protoagent:init") return; token=m.token||null;
     if(m.theme){ var r=document.documentElement.style;
@@ -152,11 +195,11 @@ _EDITOR_HTML = r"""<!doctype html><html><head><meta charset="utf-8"><style>
     else{pv.style.display="none";ed.style.display="block";tg.textContent="Preview";} };
   ed.addEventListener("input", function(){ dirty=true; st.textContent="Saving…"; clearTimeout(t); t=setTimeout(save,700); });
   async function save(){ try{
-      var r=await fetch("/api/plugins/notes/note",{method:"PUT",headers:hdr({"Content-Type":"application/json"}),body:JSON.stringify({content:ed.value})});
+      var r=await fetch(base+"/api/plugins/notes/note",{method:"PUT",headers:hdr({"Content-Type":"application/json"}),body:JSON.stringify({content:ed.value})});
       if(!r.ok)throw 0; lastSynced=ed.value; dirty=false; st.textContent="Saved ✓";
     }catch(e){ st.textContent="Save failed"; } }
   async function load(){ try{
-      var a=await fetch("/api/plugins/notes/note",{headers:hdr()}).then(function(r){return r.json();});
+      var a=await fetch(base+"/api/plugins/notes/note",{headers:hdr()}).then(function(r){return r.json();});
       if(typeof a.content==="string" && a.content!==lastSynced && !dirty){ ed.value=a.content; lastSynced=a.content; if(preview)renderPreview(); }
     }catch(e){} }
   load();

--- a/plugins/notes/protoagent.plugin.yaml
+++ b/plugins/notes/protoagent.plugin.yaml
@@ -3,9 +3,9 @@ name: Notes
 version: 0.1.0
 description: >-
   A single shared markdown note the agent and the operator both read and write.
-  The first-class React reference plugin (ADR 0034 S4) — it owns its storage,
-  its agent tools, and a `ui: react` console panel. Replaces the legacy native
-  Notes surface.
+  The flagship reference plugin (ADR 0034 S4) — it owns its storage, its agent
+  tools, and a sandboxed-iframe editor it serves itself (ADR 0038). Replaces the
+  legacy native Notes surface.
 enabled: true            # first-party — shipped on
 capabilities:
   network: []
@@ -13,4 +13,4 @@ capabilities:
 # The plugin self-serves its editor page (ADR 0038) — a sandboxed iframe, no host build, so it's
 # git-installable like any plugin. (Was a federated `ui: react` remote; federation retired.)
 views:
-  - { id: notes, label: "Notes", icon: "FileText", placement: right, path: "/api/plugins/notes/view" }
+  - { id: notes, label: "Notes", icon: "FileText", placement: right, path: "/plugins/notes/view" }

--- a/plugins/plugin-devkit/skills/building-plugins/SKILL.md
+++ b/plugins/plugin-devkit/skills/building-plugins/SKILL.md
@@ -16,9 +16,11 @@ description: >-
 
 A plugin is a self-contained directory (optionally its own git repo) that extends
 a running agent **without forking** core. Authoritative refs: ADR 0018 (surfaces),
-0019 (config/secrets/settings), 0026 (console views), 0027 (distribution); guides
-`plugins`, `plugin-views`, `plugin-registry`. The shipped `plugins/hello/` is the
-worked example — read it first.
+0019 (config/secrets/settings), 0026 (console views), 0027 (distribution), 0045
+(chat slot); guides `plugins`, `building-react-plugin-views`, `plugin-registry`.
+The shipped `plugins/hello/` is the worked backend example — read it first. For a
+**console view**, copy `examples/plugins/chat_example` — the gold-standard view
+(the four rules + the init/theme handshake + slug-aware routing + the DS kit).
 
 ## Scale to the ask
 A one-tool plugin is ~15 lines (manifest + `register()`). A "full bundle"
@@ -31,8 +33,9 @@ Map the ask to the contribution surface:
 - **tool / subagent / route / MCP server** → code, via `register(registry)`.
 - **SKILL.md skills** / **`*.yaml` workflows** → data, auto-discovered from
   conventional `skills/` and `workflows/` subdirs (no code).
-- **console view** (rail icon + page) → declared in the manifest `views:`; a **sandboxed
-  iframe** of a page your plugin serves (ADR 0038).
+- **console view** (rail icon + page, or a `slot: "chat"` panel) → declared in the manifest
+  `views:`; a **sandboxed iframe** of a page your plugin serves (ADR 0026/0038/0045). Copy
+  `examples/plugins/chat_example`; full guide: `building-react-plugin-views`.
 - **events** (broadcast / react) → `registry.emit("x", data)` / `registry.on("topic.*", fn)`;
   declare `emits:` / `subscribes:` in the manifest (ADR 0039). Plugins coordinate via the bus,
   never by importing each other.
@@ -66,7 +69,9 @@ settings:                   # render in Settings → its group
   - { key: api_base, label: "API base", type: string }
   - { key: api_key, label: "API key", type: secret }
 views:                      # console rail view (ADR 0026/0038) — a sandboxed iframe of a page you serve
-  - { id: board, label: "Board", icon: LayoutDashboard, path: /api/plugins/my-plugin/board }
+  # `path` MUST be a path a registered router serves, same-origin RELATIVE (no scheme/host).
+  # The PAGE is public (an iframe load can't carry a bearer); its DATA calls are gated /api/.
+  - { id: board, label: "Board", icon: LayoutDashboard, path: /plugins/my-plugin/board }
 emits: ["my-plugin.updated"]     # event-bus topics you broadcast (ADR 0039; optional, for discovery)
 subscribes: ["other-plugin.*"]   # topics you listen for
 requires_pip: ["httpx>=0.27"]   # deps — declared, NOT auto-installed (ADR 0027)
@@ -86,10 +91,14 @@ def register(registry):
     registry.on("other-plugin.*", on_event)     # react to another plugin without importing it
     # skills/ and workflows/ subdirs auto-load — no call needed.
 ```
-A `views:` page is served by your router (e.g. `@router.get("/board")` returning HTML). Mount the
-router under **`/api/plugins/<id>`** so it inherits the operator bearer gate; the console iframes the
-page (sandboxed) and `postMessage`s it the bearer + theme — see the `plugin-views` guide. An event
-under `<id>.*` lights your plugin's rail icon (a notification dot) until the user opens it.
+A `views:` page is served by your router (e.g. `@router.get("/board")` returning HTML). Mount **data**
+routes under **`/api/plugins/<id>`** so they inherit the operator bearer gate; serve the **page itself**
+under the public **`/plugins/<id>`** prefix (an iframe page-load can't carry a bearer, so the page is
+public chrome — its data calls are the gated part). The console iframes the page (sandboxed) and
+`postMessage`s it the bearer + theme; the page derives a slug-aware base and uses the DS kit's
+`apiFetch` for authed same-origin calls — copy `examples/plugins/chat_example`, full guide
+`building-react-plugin-views`. An event under `<id>.*` lights your plugin's rail icon (a notification
+dot) until the user opens it.
 
 ## 5. Test it
 - Enable it: `plugins: { enabled: [my-plugin] }`, restart, then

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -958,6 +958,16 @@ def _mount_plugin_routers(routers: list[dict]) -> None:
     for r in routers:
         key = (r.get("plugin_id"), r.get("prefix"))
         if key in STATE.plugin_router_keys:
+            # A plugin registered a SECOND router at the SAME prefix — the first
+            # already won the slot, so this one is silently dropped and its routes
+            # never serve (projectBoard's /board 404'd for exactly this reason).
+            # Mount distinct prefixes for distinct route groups (e.g. a public
+            # /plugins/<id> view router + a gated /api/plugins/<id> data router).
+            log.warning(
+                "[plugins] %s registered a second router at prefix %s — dropped "
+                "(its routes won't be served; mount each router at a distinct prefix)",
+                r.get("plugin_id"), r.get("prefix") or "/",
+            )
             continue
         try:
             app.include_router(r["router"], prefix=r.get("prefix") or "")


### PR DESCRIPTION
The **core-owned** half of the plugin-view audit (the external plugin bugs are fixed in their own repos — `agent-browser#7`, `projectBoard#2`, `doom#2`, all merged). This roots out the antipatterns + the stale/contradictory guidance that *caused* the 404 / "refused to connect" / blank-panel problems you hit.

## Kit — the escape hatch was unreachable
`copy-plugin-kit.mjs` now ships **both** `plugin-kit.css` **and** `plugin-kit.js` to `/_ds/`, and `web.py` serves `/_ds/plugin-kit.js`. So `initPluginView`/`getToken`/`apiFetch` are finally callable same-origin.

## Guardrails — silent failures now warn
- **manifest**: warn on a non-same-origin `views[].path` (`http(s)://`/`//`/`localhost`/`:PORT`).
- **loader**: warn when a declared `views[].path` is served by no router (typo / forgot `register_router`).
- **mount** (`agent_init`): warn when a plugin registers a **second router at the same `(plugin_id, prefix)`** — the host silently drops it. *This was projectBoard's `/board` 404 root cause*, missed by the pre-mount check.

## Examples — now model the rules
- **notes**: slug-aware fetches + **split view (public `/plugins/notes/view`) from data (gated `/api/plugins/notes/note`)** — resolving the contradiction that the iframe page-load can't carry a bearer, so a gated page 401-blanks.
- **hello**: dropped the retired Module Federation entry (ADR 0038).
- **chat_example**: the annotated gold-standard (links the slug-aware kit, public page + gated data, four-rules header).

## Docs — one canonical guide
`building-react-plugin-views.md` is now canonical (in the sidebar + index; `plugin-views.md` → pointer). Adds the **four rules** (serve-what-you-declare · gate the *data* not the page · same-origin slug-aware never-hardcode · link the kit), the handshake + event-bus + sandbox-split contract, and the kit-helper reference. New `docs/how-to/build-a-plugin-view.md`.

ruff clean · 67 plugin/notes + 18 vitest + 89 e2e green · both `/_ds` kit files emitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)