### PR TITLE
fix(web): kill the */-in-CSS-comment corruption + guard against its return

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **CSS comment corruption that silently shrank plugin iframes (build guard).**
+  A `*/` written inside a CSS comment — e.g. a class glob like
+  `.plugin-install-*/.plugin-list` in prose — closes the comment early, so
+  esbuild parses the rest as CSS, emits a recoverable `css-syntax-error` *warning*,
+  and drops tokens. A real rule downstream can vanish from the bundle while the
+  build still "succeeds" (this is the root cause behind the tiny-plugin-iframe
+  reports: a dropped `.plugin-view` rule fell back to the stage-panel grid). Fixed
+  the two latent instances in `chat.css` and `theme.css`, and added a
+  `prebuild` guard (`scripts/check-css-comments.mjs`) that **fails the build** on
+  any `*/` glued to identifier characters inside a `src` CSS file — so this class
+  of corruption can never reach `dist` silently again.
+
 ## [0.33.0] - 2026-06-10
 
 ### Added

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -5,7 +5,7 @@
   "type": "module",
   "scripts": {
     "dev": "vite --host 127.0.0.1",
-    "prebuild": "node scripts/copy-plugin-kit.mjs",
+    "prebuild": "node scripts/check-css-comments.mjs && node scripts/copy-plugin-kit.mjs",
     "build": "tsc -p tsconfig.json --noEmit && tsc -p tsconfig.node.json --noEmit && vite build",
     "preview": "vite preview --host 127.0.0.1",
     "test:e2e": "npm run build && playwright test",

--- a/apps/web/scripts/check-css-comments.mjs
+++ b/apps/web/scripts/check-css-comments.mjs
@@ -1,0 +1,61 @@
+// Build guard against a corruption class that has bitten the console CSS three
+// times (#863 + the chat/theme comments fixed alongside this script): a stray
+// `*/` *inside* a CSS comment — almost always a glob written in prose, e.g.
+//
+//     /* the .plugin-install-*/.plugin-list family moved to plugins.css */
+//                            ^^ this closes the comment EARLY
+//
+// Everything after the premature `*/` is then parsed as CSS. esbuild's minifier
+// emits a "css-syntax-error" WARNING (not an error) and recovers by dropping
+// tokens — so a real rule downstream can silently vanish from dist (this is the
+// root cause of the "tiny plugin iframes" bug: a dropped `.plugin-view` rule fell
+// back to the stage-panel grid). The build still "succeeds", so nobody notices.
+//
+// The signature is unmistakable and has no legitimate counterpart: a `*/` glued
+// to identifier-ish characters on BOTH sides. A real comment terminator is always
+// ` */` (whitespace/newline around it), and `*/` cannot appear outside a comment
+// in valid CSS at all. So any match here is a bug — we fail the build loudly.
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { dirname, join, relative, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const here = dirname(fileURLToPath(import.meta.url));
+const SRC = resolve(here, "..", "src");
+
+// `*/` with identifier chars (incl. `.` `-` `_`) immediately on each side.
+const GLUED_COMMENT_CLOSE = /[A-Za-z0-9_.-]\*\/[A-Za-z0-9_.-]/;
+
+function cssFiles(dir) {
+  const out = [];
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) out.push(...cssFiles(p));
+    else if (name.endsWith(".css")) out.push(p);
+  }
+  return out;
+}
+
+const violations = [];
+for (const file of cssFiles(SRC)) {
+  const lines = readFileSync(file, "utf8").split("\n");
+  lines.forEach((line, i) => {
+    const m = GLUED_COMMENT_CLOSE.exec(line);
+    if (m) violations.push({ file: relative(SRC, file), line: i + 1, snippet: line.trim() });
+  });
+}
+
+if (violations.length) {
+  console.error(
+    "\n[check-css-comments] A `*/` is glued inside a CSS comment — it closes the\n" +
+      "comment early and silently corrupts everything after it in the minified bundle.\n" +
+      "Put a space around the slash (`.foo* / .bar`) or reword the prose.\n",
+  );
+  for (const v of violations) {
+    console.error(`  src/${v.file}:${v.line}\n    ${v.snippet}`);
+  }
+  console.error("");
+  process.exit(1);
+}
+
+console.log("[check-css-comments] OK — no glued */ in any src CSS comment.");

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1592,7 +1592,7 @@ textarea {
 .plugin-view-frame { width: 100%; height: 100%; border: 0; background: var(--bg); display: block; }
 .plugin-view-state { display: flex; align-items: center; gap: 8px; padding: 24px; color: var(--fg-muted); font-size: 13px; }
 
-/* Plugins panel (ADR 0027, .plugin-install-*/.plugin-list/.plugin-row-main/-title/
+/* Plugins panel (ADR 0027, .plugin-install-* / .plugin-list / .plugin-row-main / -title /
    .plugin-ver/.plugin-state/.plugin-desc/.plugin-meta/.plugin-review/.plugin-enable-hint
    + .btn-icon.danger:hover) — moved to src/settings/plugins.css (#832). The bare
    .plugin-row stays here: it's shared with the MCP panel + the Plugins surface. */

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -4,7 +4,7 @@
 
 /* Per-session status dot — passed into the DS TabBar `icon` slot (#832), so it
    renders inside .pl-tabbar__icon before the title (the TabBar frame itself is
-   now DS-owned; the bespoke .chat-tab*/.chat-tabbar*/.chat-session-select CSS the
+   now DS-owned; the bespoke .chat-tab* / .chat-tabbar* / .chat-session-select CSS the
    .pl-tabbar replaces was deleted). Plain global class keyed on .session-dot. */
 .session-dot {
   width: 7px;


### PR DESCRIPTION
## The bug (recurring)

A `*/` written **inside** a CSS comment — almost always a class glob in prose, e.g.

```css
/* Plugins panel (ADR 0027, .plugin-install-*/.plugin-list/…) — moved to plugins.css */
                          ^^ this closes the comment HERE
```

closes the comment early. esbuild then parses the trailing text as CSS, emits a **recoverable** `css-syntax-error` *warning*, and recovers by dropping tokens — so a real rule downstream can silently vanish from the minified bundle while `vite build` still exits 0.

This is the root cause behind the recurring **"tiny plugin iframes"**: a dropped `.plugin-view { display:flex }` fell back to the stage-panel's 3-row grid, stuffing the iframe into a 158px row. It has now bitten **three times** (#863 + the two comments fixed here, in `chat.css` and `theme.css`).

## The fix + the durable guard

- Fixed the two latent instances (put a space around the slash so the `*/` adjacency is broken — meaning preserved).
- Added **`apps/web/scripts/check-css-comments.mjs`**, wired ahead of `copy-plugin-kit` in `prebuild`. It scans every `src/**/*.css` for a `*/` glued to identifier chars on **both** sides — the unmistakable signature, since a legitimate terminator is always ` */` and `*/` can't appear outside a comment in valid CSS — and **fails the build** with `file:line`. So this class of corruption can never reach `dist` silently again.

## Verification

- **Build now emits zero `css-syntax-error` warnings** (was 3); `✓ built in 3.43s`, CSS bundle clean.
- Guard **catches** both historical patterns (`.chat-tab*/.chat-tabbar`, `.plugin-install-*/.plugin-list`) and **clears** legit `/`-bearing CSS: `calc(100% / 2)`, `.a / .b`, `url(http://x) */`, plain `/* clean */`.

```
[check-css-comments] OK — no glued */ in any src CSS comment.
```

No behavior change beyond the two comment edits; pure build-hygiene + a guard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)