### PR TITLE
chore(ds): bump @protolabsai/ui 0.26 — slug-aware plugin-kit apiFetch/apiUrl (protoContent#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   any `*/` glued to identifier characters inside a `src` CSS file — so this class
   of corruption can never reach `dist` silently again.
 ### Added
+- **Design-system 0.26 + slug-aware plugin-kit `apiFetch`/`apiUrl` (protoContent#208).**
+  Bumped `@protolabsai/ui` to 0.26, whose served plugin-kit now derives the
+  `/agents/<slug>/` fleet-proxy base itself — a plugin view's data call is just
+  `kit.apiFetch("/api/plugins/<id>/x")`, no manual
+  `location.pathname.split("/plugins/")[0]` prefixing, and it stays correct on the
+  host window **and** through the fleet proxy (ADR 0042). View-authoring rule 3 is
+  now automatic for data. Updated the `chat_example` gold-standard + the
+  building-a-view guide (rule 3 + the kit-helper table, now documenting the new
+  `apiUrl`) to model the simpler pattern; the only thing a view still base-prefixes
+  by hand is the kit's own `<link>`/`<script>` (they load before the kit exists).
+  0.26 is a **kit-only** DS release — no console component changed (verified by
+  diffing the package), so the bump carries no console visual risk.
 - **Plugin update / version-awareness (ADR 0027 follow-on).** Git-installed
   plugins now show whether they're current and can be updated in place. A new
   `GET /api/plugins/updates` reports per-plugin freshness — `git ls-remote` the

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.0",
-    "@protolabsai/ui": "^0.25.0",
+    "@protolabsai/ui": "^0.26.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/docs/guides/building-react-plugin-views.md
+++ b/docs/guides/building-react-plugin-views.md
@@ -27,7 +27,7 @@ Every plugin view should follow these. Each links a section below.
 |---|---|
 | **1. Serve the path you declare** — the manifest's `views[].path` MUST equal a path your `register_router` actually serves. | The console iframes exactly that path. Default router prefix is `/plugins/<id>`; a custom prefix (as the artifact plugin uses) is fine — just keep `path` in sync with it. A mismatch is a blank iframe. |
 | **2. Gate by default** — mount the router under `prefix="/api/plugins/<id>"`. | Routes under `/api/*` inherit the operator **bearer gate** (ADR 0026 D5). Use the ungated `/plugins/<id>` prefix **only** for genuinely public assets (e.g. the page itself — see [why the page is public](#why-the-page-is-public-but-its-data-is-gated)). |
-| **3. Same-origin, slug-aware, never hardcode** — derive `base = location.pathname.split("/plugins/")[0]` and prefix every fetch/asset with it. | Never hardcode an absolute `/api/.../`, `/plugins/.../`, or `http://localhost:PORT`. On the host window `base=""`; through the ADR 0042 `/agents/<slug>/` fleet proxy `base="/agents/<slug>"`. Hardcoding talks to the wrong agent and breaks the same-origin token handshake. |
+| **3. Same-origin, slug-aware, never hardcode** — for DATA calls just use the kit's slug-aware `apiFetch`/`apiUrl` (plugin-kit 0.26+): `kit.apiFetch("/api/plugins/<id>/x")` resolves itself. Only the kit's OWN `<link>`/`<script>` need a hand-derived `base = location.pathname.split("/plugins/")[0]` — they load *before* the kit exists. | Never hardcode an absolute `/api/.../`, `/plugins/.../`, or `http://localhost:PORT`. On the host window `base=""`; through the ADR 0042 `/agents/<slug>/` fleet proxy `base="/agents/<slug>"`. `apiFetch` reaches the right agent on both; hardcoding talks to the wrong agent and breaks the same-origin token handshake. |
 | **4. Link the DS kit** — load `<base>/_ds/plugin-kit.css` + `<base>/_ds/plugin-kit.js`. | Pull colors/components/handshake from the console's own design system instead of hand-rolling a hex map or pinning a CDN. The kit's `--pl-*` tokens re-skin to the operator's live theme for free. See [the kit helpers](#the-kit-helpers-plugin-kitjs). |
 
 ## The shape
@@ -185,15 +185,16 @@ module (`import { initPluginView } from ".../plugin-kit.js"`). The API:
 |---|---|
 | `initPluginView(onInit?)` | Starts listening for the handshake. Maps the console `theme` onto the DS `--pl-*` tokens on the initial `protoagent:init` **and** on every live `protoagent:theme` re-theme. `onInit({ token, theme })` (optional) fires on both. Call once on load. |
 | `getToken()` | The captured operator bearer (null until the handshake delivers one). |
-| `apiFetch(input, init?)` | A same-origin `fetch` with `Authorization: Bearer <token>` attached when a token is present. Use it for every gated `/api/...` call. |
-| `window.protoPluginView` | The same three helpers as a global, for no-build classic script-tag pages. |
+| `apiUrl(path)` | Resolves a root-relative `path` to its **slug-aware** URL — prepends `/agents/<slug>` under the fleet proxy, leaves it untouched on the host window (plugin-kit 0.26+). Idempotent: a path already under the base is returned as-is. |
+| `apiFetch(input, init?)` | A same-origin `fetch` that resolves `input` through `apiUrl` (**slug-aware** — pass a bare `/api/...`, no manual base) **and** attaches `Authorization: Bearer <token>` when present. Use it for every gated `/api/...` call. |
+| `window.protoPluginView` | The same helpers as a global, for no-build classic script-tag pages. |
 
 So a whole view's handshake + authed fetch is:
 
 ```js
 const kit = window.protoPluginView;
 kit.initPluginView();                         // handshake + live re-theme, hands-free
-const res = await kit.apiFetch(base + "/api/chat", { method: "POST", body: ... });
+const res = await kit.apiFetch("/api/chat", { method: "POST", body: ... });  // slug-aware, no manual base
 ```
 
 Prefer the kit over hardcoding hex values, a theme map, or a CDN — colors and the handshake both come

--- a/examples/plugins/chat_example/panel.html
+++ b/examples/plugins/chat_example/panel.html
@@ -18,11 +18,14 @@
        public chrome on purpose: a browser iframe page-load can't carry an
        Authorization header — so only the page is public; all its data is gated.)
 
-    3. SAME-ORIGIN, SLUG-AWARE, NEVER HARDCODE — derive `base` from the iframe's
-       OWN path and prefix EVERY fetch/asset with it. On the host window base=""
-       (so /api/chat); through the fleet proxy base="/agents/<slug>" (so
-       /agents/<slug>/api/chat) — the panel always talks to ITS agent, never the
-       host's (ADR 0042). Hardcoding "/api/chat" is the fleet-UNSAFE antipattern.
+    3. SAME-ORIGIN, SLUG-AWARE, NEVER HARDCODE — the kit's apiFetch/apiUrl derive
+       the slug-aware base FOR you (plugin-kit 0.26+), so a DATA call is just
+       `kit.apiFetch("/api/chat")`. On the host window that resolves to /api/chat;
+       through the fleet proxy to /agents/<slug>/api/chat — the panel always talks
+       to ITS agent, never the host's (ADR 0042). The ONLY thing you base-prefix by
+       hand is the kit's OWN <link>/<script> (rule 4): those load before the kit
+       exists, so there's nothing yet to resolve them. Hardcoding "/api/chat" with
+       no kit, or "http://localhost:PORT", is the fleet-UNSAFE antipattern.
 
     4. LINK THE KIT — pull the design system from the console's own, same-origin
        <base>/_ds/plugin-kit.{css,js} instead of hand-rolling a hex/theme map or
@@ -130,8 +133,10 @@
   async function sendTurn(message) {
     const pending = bubble("assistant pending", "thinking…");
     try {
-      // RULE 2 + 3: kit.apiFetch attaches the bearer; base keeps it on OUR agent.
-      const res = await kit.apiFetch(base + "/api/chat", {
+      // RULE 2 + 3: kit.apiFetch attaches the bearer AND derives the slug-aware
+      // base (plugin-kit 0.26+) — a bare "/api/chat" reaches OUR agent on the host
+      // window and through the fleet proxy alike. No manual base for data calls.
+      const res = await kit.apiFetch("/api/chat", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ message, session_id: sessionId }),

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.0",
-        "@protolabsai/ui": "^0.25.0",
+        "@protolabsai/ui": "^0.26.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.25.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.25.0.tgz",
-      "integrity": "sha512-YTHFXGp2ZMBruMJa/4D3vQJTRgtuB7bYIsxwB0Megm7nU2J2sDRJEyW1LNT4Kyrbin/NU5tUu3POaz0KslSz2g==",
+      "version": "0.26.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.26.0.tgz",
+      "integrity": "sha512-HbwpyEpCy5ZOSEhY2Kz9/lugaq428GC19a41mqV3MyeH3v3364hWeyTpxgyXkvjzjVQ2fjZ6+F+uKNAbExFuMg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## What

protoContent shipped **#208** — the thing we filed during the plugin-view hardening pass. The served **plugin-kit's `apiFetch` now derives the ADR 0042 `/agents/<slug>/` fleet-proxy base itself**, plus a new **`apiUrl`** helper. So a plugin view's data call is just:

```js
const res = await kit.apiFetch("/api/plugins/<id>/x");   // slug-aware, no manual base
```

— correct on the host window **and** through the fleet proxy, with no `location.pathname.split("/plugins/")[0]` bookkeeping. **View-authoring rule 3 is now automatic for data calls.**

## Changes

- **Bump** `apps/web` `@protolabsai/ui` `^0.25.0` → `^0.26.0` (+ lockfile). `prebuild` copies 0.26's slug-aware `plugin-kit.js` into `public/_ds/`, served same-origin to every view.
- **`examples/plugins/chat_example/panel.html`** (the gold-standard authors copy): the data fetch drops the manual base → `kit.apiFetch("/api/chat")`; rule-3 header reframed — the only hand-derived base left is the kit's own `<link>`/`<script>` (they load *before* the kit exists, so nothing can resolve them yet).
- **`docs/guides/building-react-plugin-views.md`**: rule 3 + the kit-helper table (`apiFetch` documented as slug-aware; new `apiUrl` row) + the snippet.

## Why it's safe to merge (no visual gate)

**0.26 is a kit-only DS release.** Diffing the published package, the *sole* changed file 0.25→0.26 is `src/plugin-kit.js` (the `apiFetch`/`apiUrl` change) — **no console component touched** and the `exports` map is identical. So the bump can't drift the console chrome; the [local-test gate](https://github.com/protoLabsAI/protoAgent) for visual DS work doesn't apply here.

## Verification

- Build clean — **zero `css-syntax-error` warnings** (#888's guard + fix are present off main).
- The copied `public/_ds/plugin-kit.js` is the slug-aware 0.26 one.
- `vitest` 40 passed; plugin e2e (`plugin-install` + `plugin-views`) 10 passed.

## Follow-up (separate, not this PR)

The `notes` example still hand-rolls its handshake/theme/`fetch` and doesn't link the kit at all — that's a **rule-4** cleanup (adopt the kit + drop the hex theme map), orthogonal to this apiFetch/rule-3 adoption. Filing it as its own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)