### PR TITLE
chore: release v0.34.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.34.0] - 2026-06-10
+
 ### Fixed
 - **CSS comment corruption that silently shrank plugin iframes (build guard).**
   A `*/` written inside a CSS comment — e.g. a class glob like

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.33.0"
+version = "0.34.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.34.0",
+    "date": "2026-06-10",
+    "changes": [
+      "CSS comment corruption that silently shrank plugin iframes (build guard).",
+      "Design-system 0.26 + slug-aware plugin-kit apiFetch/apiUrl (protoContent#208).",
+      "Plugin update / version-awareness."
+    ]
+  },
+  {
     "version": "v0.33.0",
     "date": "2026-06-10",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.34.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.34.0 -m 'Release v0.34.0' && git push origin v0.34.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).