### PR TITLE
fix(openshell): validate deploy path end-to-end against OpenShell v0.0.59

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -95,3 +95,7 @@ config/*/.setup-complete
 
 # Playwright run artifacts
 test-results/
+
+# OpenShell local deployment artifacts (deploy/openshell/)
+deploy/openshell/jwt/
+deploy/openshell/openshell-policy.yaml

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,10 @@
 FROM python:3.12-slim
 
-# System deps
+# System deps. iproute2 is required when running under NVIDIA OpenShell —
+# the sandbox supervisor shells out to `ip` to build the network namespace
+# that enforces deny-by-default egress (sandbox creation fails without it).
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    git curl ca-certificates build-essential gettext-base gnupg \
+    git curl ca-certificates build-essential gettext-base gnupg iproute2 \
     && rm -rf /var/lib/apt/lists/*
 
 # GitHub CLI — optional for forks that call `gh` from tools. Kept in the

--- a/deploy/openshell/README.md
+++ b/deploy/openshell/README.md
@@ -1,8 +1,9 @@
 # protoAgent under NVIDIA OpenShell
 
 Run protoAgent (or a fork like Roxy) as an **OpenShell-managed sandbox** —
-kernel-enforced filesystem (Landlock), syscall filtering (seccomp), and
-deny-by-default network egress — instead of the app-level isolation alone. See
+kernel-enforced filesystem (Landlock), per-binary deny-by-default network
+egress (netns + proxy), and an unprivileged process identity — instead of the
+app-level isolation alone. See
 [ADR 0008](../../docs/adr/0008-sandboxing-and-openshell.md) and the
 [Sandboxing & egress guide](../../docs/guides/sandboxing.md).
 
@@ -11,28 +12,100 @@ The model: a long-running **gateway** (control plane) provisions the agent as a
 **generated from protoAgent's own config** — `filesystem.projects` → Landlock
 paths, `egress.allowed_hosts` + `model.api_base` → the egress allowlist.
 
-> Verbatim gateway/Helm bits are from OpenShell's docs; the sandbox/CRD wiring is
-> a starting template — OpenShell + the Agent Sandbox CRD are pre-1.0, so verify
-> fields against the versions you install.
+> **Validated:** the Docker path below was run end-to-end against OpenShell
+> **v0.0.59** (gateway image + CLI) on 2026-06-10 — sandbox `Ready`, agent
+> serving A2A from inside, off-policy egress blocked with `403`, off-policy
+> writes denied by Landlock. OpenShell is pre-1.0; re-verify on upgrade.
+> The Kubernetes section is still a starting template (not yet validated).
 
-## Local / single host (Docker)
+## Local / single host (Docker) — validated walkthrough
+
+### 0. Prereqs
+
+- Docker, and an agent image built from this repo: `docker build -t protoagent:local .`
+  The Dockerfile ships **iproute2** — the OpenShell supervisor shells out to
+  `ip` to build the egress network namespace and sandbox creation fails
+  without it. Images built before this was added need a rebuild.
+- The `openshell` CLI ([releases](https://github.com/NVIDIA/OpenShell/releases)
+  ship static tarballs, deb/rpm, and an `install.sh`). Verify the checksum.
+
+### 1. Gateway setup (one-time)
 
 ```bash
-# 1) gateway (control plane)
-docker compose -f deploy/openshell/compose.yml up -d
+cd deploy/openshell
+
+# Sandbox-JWT keypair — the docker driver refuses to start sandboxes without
+# it ("docker sandboxes require gateway JWT auth"):
+mkdir -p jwt && openssl genpkey -algorithm ed25519 -out jwt/signing.pem \
+  && openssl pkey -in jwt/signing.pem -pubout -out jwt/public.pem \
+  && echo "local-dev-key-1" > jwt/kid
+
+# Gateway state dir — must be an ABSOLUTE path that exists on the host; it is
+# mounted into the gateway container at the same path (the supervisor binary
+# is extracted here and bind-mounted into sandboxes by the host docker daemon):
+export OPENSHELL_STATE_DIR=/srv/openshell-state   # pick yours
+sudo mkdir -p "$OPENSHELL_STATE_DIR" && sudo chown 1000:1000 "$OPENSHELL_STATE_DIR"
+
+export DOCKER_GID=$(stat -c '%g' /var/run/docker.sock)
+export DOCKER_BRIDGE_IP=$(ip -4 addr show docker0 | awk '/inet /{sub(/\/.*/,"",$2); print $2}')
+
+docker compose up -d
 openshell gateway add http://127.0.0.1:8080 --local --name local
-
-# 2) generate the policy + create the protoAgent sandbox
-bash deploy/openshell/create-protoagent-sandbox.sh
-#   PROTOAGENT_IMAGE / PROTOAGENT_PORT / PROTOAGENT_CONFIG override the defaults
-
-openshell sandbox list
 ```
 
-The generated `openshell-policy.yaml` is the fence: the sandbox can only read/
-write the project paths in the policy and only reach the allowlisted hosts.
+**Firewall:** sandboxes reach the gateway at
+`http://host.openshell.internal:<port>` (the bridge IP). On hosts with a
+default-DROP INPUT policy (ufw etc.), allow the OpenShell bridge in, e.g.:
 
-## Kubernetes
+```bash
+BR="br-$(docker network inspect openshell-docker --format '{{.Id}}' | cut -c1-12)"
+sudo iptables -I INPUT -i "$BR" -p tcp --dport 8080 -j ACCEPT
+```
+
+(Symptom otherwise: the sandbox crash-loops with `Policy fetch failed`.)
+
+If host port 8080 is taken, set `OPENSHELL_GATEWAY_PORT` — the gateway
+advertises its **bind** port to sandboxes, so compose keeps the container and
+host ports identical.
+
+### 2. Create the protoAgent sandbox
+
+```bash
+# PROTOAGENT_IMAGE / PROTOAGENT_PORT / PROTOAGENT_CONFIG override the defaults
+PROTOAGENT_IMAGE=protoagent:local bash deploy/openshell/create-protoagent-sandbox.sh
+```
+
+The generated `openshell-policy.yaml` is the fence: the sandbox can only
+read/write the project paths in the policy, and only the policy's binaries can
+reach the policy's hosts. The agent's port is forwarded to
+`127.0.0.1:<PROTOAGENT_PORT>` while the script runs (Ctrl-C stops the agent;
+wrap in tmux/systemd for long-running use).
+
+### 3. Verify
+
+```bash
+openshell sandbox list                       # PHASE should be Ready
+curl http://127.0.0.1:7870/healthz           # via the forward
+
+# the fence is real:
+openshell sandbox exec --no-tty -- curl -s -m 8 https://example.com   # blocked (proxy 403)
+openshell sandbox exec --no-tty -- touch /opt/protoagent/x            # blocked (Landlock)
+```
+
+### Gotchas (each cost us a debug loop)
+
+| Symptom | Cause / fix |
+|---|---|
+| gateway crash-loop: `unable to open database file` | sqlx needs `?mode=rwc` to create the sqlite file **and** a writable state dir (gateway runs as uid 1000). compose.yml handles both; chown the state dir. |
+| gateway crash-loop: `failed to create docker supervisor cache dir '/.local/share/...'` | distroless image has no `HOME`; compose.yml points `HOME`/`XDG_DATA_HOME` at the state dir. |
+| `exec: "/opt/openshell/bin/openshell-sandbox": is a directory` | gateway-in-container extracted the supervisor to a path that doesn't exist on the host. The state dir must be an identical-path bind mount (compose.yml enforces this). |
+| `docker sandboxes require gateway JWT auth` | generate the `jwt/` keypair (step 1). |
+| CLI: `missing authorization header` | enabling gateway JWTs turns on auth for CLI calls too; `gateway.toml` sets `allow_unauthenticated_users = true` (local single-player only). |
+| sandbox crash-loop: `Policy fetch failed` / `h2 protocol error` | supervisor can't reach the gateway: published port ≠ bind port, wrong bridge IP (`DOCKER_BRIDGE_IP` — custom `bip` daemons aren't 172.17.0.1), or firewall DROP (see above). An `h2 protocol error` usually means it connected to some *other* service squatting the port. |
+| `Network namespace creation failed ... ip helper not found` | sandbox **image** must ship iproute2 (this repo's Dockerfile does). |
+| `No module named server` | the supervisor does not inherit image ENV; pass `--env PYTHONPATH=/opt/protoagent` (the script does). |
+
+## Kubernetes (starting template — not yet validated)
 
 ```bash
 # 1) Agent Sandbox controller + CRDs (OpenShell builds on the SIG project)
@@ -56,14 +129,23 @@ kubectl apply -f deploy/openshell/k8s/protoagent-sandbox.yaml
 
 | File | What |
 |---|---|
-| `compose.yml` | OpenShell gateway as a container (docker driver) — verbatim from OpenShell docs |
+| `compose.yml` | OpenShell gateway as a container (docker driver) — validated v0.0.59 |
+| `gateway.toml` | Gateway config: docker driver, sandbox JWTs, local-dev auth |
 | `create-protoagent-sandbox.sh` | Generate the policy + create the protoAgent sandbox under the gateway |
 | `k8s/values.yaml` | Helm values for the gateway (kubernetes driver) |
 | `k8s/protoagent-sandbox.yaml` | Templated Agent-Sandbox CRD for protoAgent + policy ConfigMap wiring |
+
+## GPUs
+
+The protoAgent image itself is CPU-only, but OpenShell can grant a sandbox GPU
+access at create time: `openshell sandbox create --gpu` (optionally
+`--gpu-device nvidia.com/gpu=0`, CDI id) with the nvidia-container-toolkit on
+the host. Pair with a CUDA-based agent image if the agent itself needs CUDA.
 
 ## Roxy
 
 A read-only monitor (every project `write:false`) is the ideal tenant: the
 policy makes her read-only authority **kernel-enforced** and pins egress to the
-gateway + `gh`/git hosts. Generate her policy the same way (`gen_openshell_policy.py`
-against Roxy's config) and run her sandbox with `PROTOAGENT_INSTANCE=roxy`.
+gateway + `gh`/git hosts. Generate her policy the same way
+(`gen_openshell_policy.py` against Roxy's config) and run her sandbox with
+`--env PROTOAGENT_INSTANCE=roxy`.

--- a/deploy/openshell/compose.yml
+++ b/deploy/openshell/compose.yml
@@ -5,24 +5,51 @@
 # create-protoagent-sandbox.sh (the agent is NOT a plain compose service; the
 # gateway spins its container with the Landlock/seccomp/egress policy applied).
 #
-# Gateway config below is verbatim from OpenShell's "Running the Gateway as a
-# Container" docs (TLS disabled = local/dev; enable mTLS for anything shared).
-# Verify image tag + env names against your installed OpenShell release.
+# Validated against OpenShell v0.0.59 (gateway image + CLI). Required env:
+#
+#   OPENSHELL_STATE_DIR  absolute host dir for gateway state. Mounted at the
+#                        SAME path inside the container — the gateway extracts
+#                        the sandbox supervisor binary here and bind-mounts it
+#                        into sandboxes via the host docker daemon, so the path
+#                        must be valid on both sides. mkdir it before first up.
+#   DOCKER_GID           gid of /var/run/docker.sock, so the gateway (uid 1000,
+#                        distroless) can drive the docker API:
+#                          DOCKER_GID=$(stat -c '%g' /var/run/docker.sock)
+#
+# One-time: generate the sandbox-JWT keypair the docker driver requires
+# (see README.md § Gateway setup) into ./jwt/ before first up.
+#
+# Port notes: the gateway ADVERTISES its bind port to sandbox supervisors
+# (http://host.openshell.internal:<port>), so the published host port must
+# equal the container bind port — keep the two OPENSHELL_GATEWAY_PORT uses in
+# sync (the command below overrides the image CMD, which hardcodes 8080).
+# DOCKER_BRIDGE_IP is your docker bridge gateway IP (`ip addr show docker0`,
+# commonly 172.17.0.1; custom `bip` daemons differ) so sandboxes can reach the
+# gateway without exposing it beyond loopback + the bridge. Hosts with a
+# default-DROP INPUT policy (ufw) also need an accept rule — see README.md.
 
 services:
   openshell-gateway:
     image: ghcr.io/nvidia/openshell/gateway:latest
     container_name: openshell-gateway
     restart: unless-stopped
+    command: ["--bind-address", "0.0.0.0", "--port", "${OPENSHELL_GATEWAY_PORT:-8080}"]
     ports:
-      - "127.0.0.1:8080:8080"      # localhost only
+      - "127.0.0.1:${OPENSHELL_GATEWAY_PORT:-8080}:${OPENSHELL_GATEWAY_PORT:-8080}"
+      - "${DOCKER_BRIDGE_IP:-172.17.0.1}:${OPENSHELL_GATEWAY_PORT:-8080}:${OPENSHELL_GATEWAY_PORT:-8080}"
+    group_add:
+      - "${DOCKER_GID:?run with DOCKER_GID=$(stat -c '%g' /var/run/docker.sock)}"
     volumes:
-      - openshell-state:/var/openshell
-      - /var/run/docker.sock:/var/run/docker.sock   # docker driver provisions sandboxes
+      - "${OPENSHELL_STATE_DIR:?set OPENSHELL_STATE_DIR to an absolute host dir (identical-path mount)}:${OPENSHELL_STATE_DIR}"
+      - ./jwt:/etc/openshell/jwt:ro                  # sandbox-JWT keypair (README § Gateway setup)
+      - ./gateway.toml:/etc/openshell/gateway.toml:ro
+      - /var/run/docker.sock:/var/run/docker.sock    # docker driver provisions sandboxes
     environment:
-      OPENSHELL_DRIVERS: docker
-      OPENSHELL_DB_URL: sqlite:/var/openshell/openshell.db
-      OPENSHELL_DISABLE_TLS: "true"   # DEV ONLY — set OPENSHELL_ENABLE_MTLS_AUTH=true + certs for shared hosts
-
-volumes:
-  openshell-state:
+      OPENSHELL_GATEWAY_CONFIG: /etc/openshell/gateway.toml
+      # sqlx refuses to CREATE a missing sqlite file without mode=rwc.
+      OPENSHELL_DB_URL: "sqlite://${OPENSHELL_STATE_DIR}/openshell.db?mode=rwc"
+      OPENSHELL_DISABLE_TLS: "true"   # DEV ONLY — enable mTLS for shared hosts
+      # The image is distroless with no HOME; point the XDG fallbacks at the
+      # state dir or the supervisor cache lands at unwritable /.local/share.
+      HOME: "${OPENSHELL_STATE_DIR}"
+      XDG_DATA_HOME: "${OPENSHELL_STATE_DIR}/data"

--- a/deploy/openshell/create-protoagent-sandbox.sh
+++ b/deploy/openshell/create-protoagent-sandbox.sh
@@ -1,9 +1,11 @@
 #!/usr/bin/env bash
 # Create a protoAgent sandbox under a running OpenShell gateway (ADR 0008).
 #
-# Prereqs: `docker compose -f compose.yml up -d` (gateway running) and the
-# `openshell` CLI installed + registered against the gateway:
-#   openshell gateway add http://127.0.0.1:8080 --local --name local
+# Prereqs (see README.md for the full validated walkthrough):
+#   - gateway up:  docker compose -f compose.yml up -d   (with its env set)
+#   - CLI registered:  openshell gateway add http://127.0.0.1:8080 --local --name local
+#   - an agent image built from this repo (the Dockerfile ships iproute2,
+#     which the OpenShell supervisor needs for its egress network namespace)
 #
 # This (1) generates a least-privilege policy from your protoAgent config and
 # (2) creates the sandbox. The policy's filesystem paths come from
@@ -11,8 +13,11 @@
 # + `model.api_base` — so the sandbox can only touch what the agent is actually
 # configured to use.
 #
-# NOTE: `openshell sandbox create` flags (image/mounts/ports) vary by release —
-# the call below is a template; adapt mount/port flags to your OpenShell CLI.
+# Flags below are OpenShell v0.0.59: the image is `--from`, file mounts are
+# `--upload` (one-shot copy, not a live bind), and env is `--env` — the
+# supervisor does NOT inherit the image's ENV, so PYTHONPATH must be passed
+# explicitly. The command after `--` runs in the foreground of this terminal
+# (Ctrl-C stops the agent); wrap in tmux/systemd for long-running use.
 set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -25,15 +30,19 @@ echo "→ generating OpenShell policy from $CONFIG"
 python "$REPO_ROOT/scripts/gen_openshell_policy.py" --config "$CONFIG" --out "$POLICY"
 
 echo "→ creating protoAgent sandbox (image=$IMAGE, port=$PORT)"
-# The gateway applies the policy (Landlock fs + seccomp + deny-by-default egress)
-# to the container it spins for this command. Mount the live config + the data
-# volume; the project dirs are mounted per the policy's filesystem paths.
+# The gateway applies the policy (Landlock fs + deny-by-default egress proxy +
+# unprivileged process identity) to the container it spins for this command.
 openshell sandbox create \
   --name protoagent \
   --policy "$POLICY" \
-  --image "$IMAGE" \
-  --publish "127.0.0.1:${PORT}:7870" \
-  --mount "$CONFIG:/sandbox/config/langgraph-config.yaml:ro" \
-  -- python -m server --host 0.0.0.0 --port 7870 --ui none   # server/ package (ADR 0023); --host 0.0.0.0 since this override bypasses entrypoint.sh (server defaults to loopback)
-
-echo "✓ protoAgent sandbox created. Inspect: openshell sandbox list"
+  --from "$IMAGE" \
+  --upload "$CONFIG:/sandbox/config/langgraph-config.yaml" \
+  --env PYTHONPATH=/opt/protoagent \
+  --env "PROTOAGENT_INSTANCE=${PROTOAGENT_INSTANCE:-openshell}" \
+  --forward "127.0.0.1:${PORT}" \
+  --no-auto-providers \
+  -- python -m server --host 127.0.0.1 --port "$PORT" --ui none
+  # server/ package (ADR 0023). Loopback bind is correct here: the --forward
+  # relay runs inside the sandbox netns, and the server refuses 0.0.0.0
+  # without an A2A auth token. Model credentials: pass --env OPENAI_API_KEY
+  # (or attach an OpenShell provider) — headless setup fails without one.

--- a/deploy/openshell/gateway.toml
+++ b/deploy/openshell/gateway.toml
@@ -1,0 +1,26 @@
+# OpenShell gateway config for the local docker-driver deployment (ADR 0008).
+# Mounted by compose.yml; validated against OpenShell v0.0.59.
+# Precedence: CLI flags > OPENSHELL_* env > this file.
+
+[openshell]
+version = 1
+
+[openshell.gateway]
+compute_drivers = ["docker"]
+
+# Docker sandboxes REQUIRE gateway-minted sandbox JWTs (the supervisor inside
+# each sandbox authenticates back to the gateway with one). Generate the
+# keypair into deploy/openshell/jwt/ — see README.md § Gateway setup.
+# ttl omitted = non-expiring sandbox JWTs: acceptable for local single-player
+# gateways only; set a positive ttl_secs on anything shared.
+[openshell.gateway.gateway_jwt]
+signing_key_path = "/etc/openshell/jwt/signing.pem"
+public_key_path  = "/etc/openshell/jwt/public.pem"
+kid_path         = "/etc/openshell/jwt/kid"
+gateway_id       = "local"
+
+# Local single-player escape hatch: CLI/API calls skip OIDC/mTLS while sandbox
+# supervisors still authenticate with JWTs. NEVER set true on a shared host —
+# wire up [openshell.gateway.oidc] or mtls_auth instead.
+[openshell.gateway.auth]
+allow_unauthenticated_users = true

--- a/docs/guides/sandboxing.md
+++ b/docs/guides/sandboxing.md
@@ -62,25 +62,29 @@ model gateway become the network allowlist:
 python scripts/gen_openshell_policy.py --config config/langgraph-config.yaml --out openshell-policy.yaml
 ```
 
-The output maps directly:
+The output maps directly (OpenShell **v1 policy schema**, validated against
+v0.0.59):
 
-- `filesystem.projects` → `filesystem.read_only` / `read_write` (a `write:false`
-  project becomes a **kernel-enforced** read-only mount — so a monitor like Roxy
-  *cannot* write even if something tried);
-- `egress.allowed_hosts` + `model.api_base` → `network.allow` (everything else
-  denied);
-- `process.seccomp: default` → real syscall filtering for `execute_code`;
-- `inference.route_to` → the gateway.
+- `filesystem.projects` → `filesystem_policy.read_only` / `read_write` (a
+  `write:false` project becomes a **kernel-enforced** read-only path — so a
+  monitor like Roxy *cannot* write even if something tried), plus an OS
+  baseline under `landlock.compatibility: best_effort`;
+- `egress.allowed_hosts` + `model.api_base` → `network_policies` endpoints,
+  scoped to the agent's binaries (everything else denied by the per-sandbox
+  proxy);
+- `process.run_as_user: sandbox` → the unprivileged image user (root is
+  rejected by OpenShell).
 
-> The generated policy targets OpenShell's **documented** four-domain model —
-> verify field names against your installed OpenShell release before applying.
+> OpenShell is pre-1.0 — re-verify against your installed release when
+> upgrading (`openshell policy prove` can check properties of the output).
 > It's a generated starting point, derived from real config, not a guess.
 
 ### Run it
 
 ```bash
-# install OpenShell (see its docs), then wrap the agent's container/command:
-openshell sandbox create --policy openshell-policy.yaml -- python -m server
+# install OpenShell (see its docs), then wrap the agent's image/command:
+openshell sandbox create --policy openshell-policy.yaml --from protoagent:local \
+  --env PYTHONPATH=/opt/protoagent -- python -m server
 ```
 
 Credentials are injected as env at runtime (never on disk); egress is
@@ -96,9 +100,10 @@ deny-by-default through the proxy; the filesystem is locked to the policy paths.
   `k8s/protoagent-sandbox.yaml` (Agent-Sandbox CRD + policy ConfigMap) — after
   installing the Agent Sandbox CRDs.
 
-See [`deploy/openshell/README.md`](https://github.com/protoLabsAI/protoAgent/blob/main/deploy/openshell/README.md). The gateway/Helm
-commands are verbatim from OpenShell's docs; the sandbox/CRD wiring is a
-starting template (OpenShell is pre-1.0 — verify fields against your release).
+See [`deploy/openshell/README.md`](https://github.com/protoLabsAI/protoAgent/blob/main/deploy/openshell/README.md). The Docker path is
+**validated end-to-end against OpenShell v0.0.59** (including a gotcha table
+from the validation run); the k8s CRD wiring is still a starting template
+(OpenShell is pre-1.0 — verify fields against your release).
 
 ## Recommended posture
 

--- a/scripts/gen_openshell_policy.py
+++ b/scripts/gen_openshell_policy.py
@@ -2,21 +2,29 @@
 """Generate an NVIDIA OpenShell sandbox policy from protoAgent config (ADR 0008).
 
 Reads ``langgraph-config.yaml`` and emits a least-privilege starter policy in
-OpenShell's documented four-domain model — derived from what the agent is
-actually configured to use, not hand-rolled guesses:
+OpenShell's **v1 policy schema** (validated against OpenShell v0.0.59) —
+derived from what the agent is actually configured to use, not hand-rolled
+guesses:
 
-- **filesystem** (Landlock) ← the ``filesystem.projects`` registry (read-only vs
-  read-write per project) + the agent data root.
-- **network** (OPA proxy, deny-by-default) ← ``egress.allowed_hosts`` +
-  ``model.api_base`` + common fleet endpoints.
-- **process** ← default seccomp.
-- **inference** ← pinned to the model gateway.
+- ``filesystem_policy`` (Landlock) ← the ``filesystem.projects`` registry
+  (read-only vs read-write per project) + the agent data root + a read-only
+  OS baseline.
+- ``network_policies`` (per-binary, deny-by-default egress proxy) ←
+  ``egress.allowed_hosts`` + ``model.api_base``.
+- ``process`` ← runs as the unprivileged ``sandbox`` user from the image.
+- ``landlock.compatibility: best_effort`` ← missing baseline paths are
+  skipped instead of aborting startup.
+
+Schema reference: https://github.com/NVIDIA/OpenShell — docs/reference/policy-schema.
+Top-level fields are ``version`` / ``filesystem_policy`` / ``landlock`` /
+``process`` / ``network_policies``. There is no ``inference`` domain in v1;
+model-credential injection is handled by OpenShell *providers* instead.
 
 Usage:
     python scripts/gen_openshell_policy.py [--config config/langgraph-config.yaml] [--out policy.yaml]
 
-NOTE: targets OpenShell's *documented* schema — verify field names against your
-installed OpenShell release before applying. It's a generated starting point.
+NOTE: OpenShell is pre-1.0 — re-verify against your installed release when
+upgrading. ``openshell policy prove`` can check properties of the output.
 """
 
 from __future__ import annotations
@@ -31,69 +39,108 @@ sys.path.insert(0, str(_REPO))
 
 from graph.config import LangGraphConfig  # noqa: E402
 
+# Read-only OS baseline for the python:3.12-slim image. Missing paths are
+# skipped under landlock best_effort, so this is safe across image variants.
+_RO_BASELINE = ["/usr", "/lib", "/lib64", "/etc", "/proc", "/opt/protoagent", "/dev/urandom"]
+# Writable surfaces matching the Dockerfile (USER sandbox, /sandbox data root).
+# /opt/protoagent/config is the live-config dir ensure_live_config() copies
+# into at boot (a named volume under docker-compose; just a writable dir here).
+_RW_BASELINE = ["/sandbox", "/tmp", "/dev/null", "/home/sandbox", "/opt/protoagent/config"]
+# Executables allowed to use the egress allowlist: the agent process itself
+# plus the CLI tools the image ships for model-driven shell use.
+_EGRESS_BINARIES = ["/usr/local/bin/python*", "/usr/bin/git", "/usr/bin/curl", "/usr/bin/gh"]
 
-def _host(url: str) -> str:
-    if not url:
-        return ""
-    u = url if "://" in url else f"//{url}"
-    return (urlparse(u).hostname or "").strip()
+
+def _host_port(url_or_host: str) -> tuple[str, int]:
+    """Split a config value into (host, port). Bare hosts default to 443."""
+    raw = str(url_or_host or "").strip()
+    if not raw:
+        return "", 0
+    u = urlparse(raw if "://" in raw else f"https://{raw}")
+    host = (u.hostname or "").strip()
+    port = u.port or (80 if u.scheme == "http" else 443)
+    return host, port
 
 
 def build_policy(cfg: LangGraphConfig) -> str:
-    rw_paths: list[str] = ["/sandbox  # agent data root (stores, checkpoints, telemetry, memory)"]
-    ro_paths: list[str] = []
+    rw_paths: list[tuple[str, str]] = [(p, "") for p in _RW_BASELINE]
+    ro_paths: list[tuple[str, str]] = [(p, "") for p in _RO_BASELINE]
     for entry in cfg.filesystem_projects or []:
         if not isinstance(entry, dict):
             continue
         path = str(entry.get("path") or "").strip()
         if not path:
             continue
-        (rw_paths if entry.get("write") else ro_paths).append(f"{path}  # project: {entry.get('name', '?')}")
+        target = rw_paths if entry.get("write") else ro_paths
+        target.append((path, f"project: {entry.get('name', '?')}"))
 
     # Egress allowlist: configured hosts + the inference gateway. Deny everything else.
-    hosts: list[str] = []
-    api_host = _host(getattr(cfg, "api_base", ""))
+    endpoints: list[tuple[str, int, str]] = []
+    api_host, api_port = _host_port(getattr(cfg, "api_base", ""))
     if api_host:
-        hosts.append(f"{api_host}  # model / inference gateway")
+        endpoints.append((api_host, api_port, "model / inference gateway"))
     for h in cfg.egress_allowed_hosts or []:
-        hosts.append(str(h))
-    if not hosts:
-        hosts.append("# (none configured — set egress.allowed_hosts; default-deny blocks all egress)")
+        host, port = _host_port(h)
+        if host and (host, port) != (api_host, api_port):
+            endpoints.append((host, port, ""))
 
-    def _block(items: list[str], indent: str = "    ") -> str:
-        return "\n".join(f"{indent}- {i}" for i in items) if items else f"{indent}[]"
+    def _paths(items: list[tuple[str, str]]) -> str:
+        return "\n".join(
+            f"    - {p}" + (f"  # {note}" if note else "") for p, note in items
+        )
+
+    def _endpoints() -> str:
+        if not endpoints:
+            return (
+                "      []  # none configured — set egress.allowed_hosts and/or"
+                " model.api_base; default-deny blocks all egress"
+            )
+        out = []
+        for host, port, note in endpoints:
+            out.append(f"      - host: {host}" + (f"  # {note}" if note else ""))
+            out.append(f"        port: {port}")
+        return "\n".join(out)
 
     return f"""\
 # OpenShell sandbox policy for protoAgent — GENERATED (ADR 0008). Do not hand-edit;
 # regenerate:  python scripts/gen_openshell_policy.py --config <config.yaml>
 #
-# Targets OpenShell's documented four-domain model (filesystem/network/process/
-# inference). VERIFY field names against your installed OpenShell release.
-# Single source of truth: filesystem ← filesystem.projects; network ←
+# v1 policy schema, validated against OpenShell v0.0.59. Re-verify on upgrade
+# (`openshell policy prove` can check properties of this file). Single source
+# of truth: filesystem_policy ← filesystem.projects; network_policies ←
 # egress.allowed_hosts + model.api_base.
 
-filesystem:
-  # Landlock allowed paths, locked at sandbox creation. Nothing else is readable
-  # or writable — the kernel-enforced version of protoAgent's in-process fence.
-  read_write:
-{_block(rw_paths)}
-  read_only:
-{_block(ro_paths) if ro_paths else "    []  # (no read-only projects registered)"}
+version: 1
 
-network:
-  # Deny-by-default egress via the OPA proxy. Only these hosts are reachable.
-  default: deny
-  allow:
-{_block(hosts)}
+filesystem_policy:
+  # Landlock allowed paths, locked at sandbox creation. Anything not listed is
+  # inaccessible — the kernel-enforced version of protoAgent's in-process fence.
+  include_workdir: true
+  read_write:
+{_paths(rw_paths)}
+  read_only:
+{_paths(ro_paths)}
+
+landlock:
+  # best_effort skips baseline paths missing from the image instead of
+  # aborting; switch to hard_requirement where any isolation gap must abort.
+  compatibility: best_effort
 
 process:
-  # Default seccomp — blocks ptrace / mount / pivot_root / clone+unshare / raw
-  # sockets. Gives execute_code/run_command real syscall filtering.
-  seccomp: default
+  # The unprivileged user baked into the protoAgent image (UID 1001).
+  run_as_user: sandbox
+  run_as_group: sandbox
 
-inference:
-  # Pin model calls to the gateway; strip caller credentials on the way out.
-  route_to: {getattr(cfg, 'api_base', '') or '# set model.api_base'}
+network_policies:
+  # Deny-by-default egress. Only the binaries below may reach the endpoints
+  # below; everything else is blocked by the per-sandbox proxy (the in-process
+  # egress allowlist still applies inside as defense-in-depth).
+  agent_egress:
+    name: protoagent-egress
+    endpoints:
+{_endpoints()}
+    binaries:
+{chr(10).join(f"      - path: {b}" for b in _EGRESS_BINARIES)}
 """
 
 

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -113,23 +113,31 @@ def test_policy_reflects_projects_and_egress(tmp_path):
     )
     cfg = LangGraphConfig.from_yaml(p)
     policy = _gen().build_policy(cfg)
-    # filesystem: rw project under read_write, ro project under read_only
-    assert "/work/pixelgen" in policy and "/work/ORBIS" in policy
-    assert "/sandbox" in policy
-    # network: deny-by-default + gateway host + configured host
-    assert "default: deny" in policy
+    # v1 policy schema (validated against OpenShell v0.0.59).
+    assert "version: 1" in policy and "filesystem_policy:" in policy
+    # filesystem_policy: the write:true project lands under read_write, write:false
+    # under read_only — verify by section ORDER, not just presence.
+    rw_idx, ro_idx = policy.index("read_write:"), policy.index("read_only:")
+    assert rw_idx < policy.index("/work/pixelgen") < ro_idx   # write:true → read_write
+    assert ro_idx < policy.index("/work/ORBIS")               # write:false → read_only
+    assert "project: pixelgen" in policy and "project: orbis" in policy
+    assert "/sandbox" in policy  # data root, read-write
+    # network_policies: deny-by-default egress allowlist (only listed endpoints
+    # reachable) carrying the gateway host + the configured host.
+    assert "network_policies:" in policy and "agent_egress:" in policy
     assert "api.proto-labs.ai" in policy
     assert "*.github.com" in policy
-    # process + inference domains present
-    assert "seccomp: default" in policy
-    assert "route_to: https://api.proto-labs.ai/v1" in policy
+    # process domain: the unprivileged image user (no seccomp / inference domain in v1).
+    assert "run_as_user: sandbox" in policy
 
 
 def test_policy_empty_config_is_default_deny(tmp_path):
     from graph.config import LangGraphConfig
 
     policy = _gen().build_policy(LangGraphConfig())
-    assert "default: deny" in policy
+    # Deny-by-default egress = a network_policies allowlist: nothing is reachable
+    # except the endpoints explicitly listed under agent_egress.
+    assert "network_policies:" in policy and "agent_egress:" in policy
     assert "/sandbox" in policy  # data root always read-write
 
 


### PR DESCRIPTION
## Summary

The `deploy/openshell/` example was a starting template that had never been run against a real OpenShell release. This PR validates the **Docker path end-to-end against OpenShell v0.0.59** on real hardware and fixes everything that broke along the way.

**Proof of life** (all verified live):
- `openshell sandbox list` → `protoagent … Ready`
- `curl http://127.0.0.1:17870/healthz` through the OpenShell forward → `{"ok":true,"graph_compiled":true,"setup_complete":true,…}`
- off-policy egress (`https://example.com`) → blocked by the per-sandbox proxy (CONNECT 403)
- off-policy write (`/opt/protoagent/x`) → denied by Landlock; live-config dir (`/opt/protoagent/config`) writable per policy

## Changes

| File | Fix |
|---|---|
| `scripts/gen_openshell_policy.py` | Rewritten for the real **v1 policy schema** (`version`/`filesystem_policy`/`landlock`/`process`/`network_policies`). The "four-domain model" it targeted doesn't exist in v0.0.59. Adds RO OS baseline, RW live-config dir, per-binary egress scoping. Output accepted by a live gateway. |
| `deploy/openshell/compose.yml` | Docker sandboxes **require gateway-minted JWTs**; sqlite URL needs `?mode=rwc`; distroless image has no `HOME` (XDG fallback → unwritable `/.local/share`); state dir must be an **identical-path bind mount** (the gateway extracts the supervisor binary and the *host* daemon bind-mounts it); published port must equal bind port (it's advertised to supervisors); `group_add` for docker.sock. |
| `deploy/openshell/gateway.toml` | New — driver + `gateway_jwt` + local-dev auth config the gateway needs. |
| `deploy/openshell/create-protoagent-sandbox.sh` | v0.0.59 CLI flags (`--from`/`--upload`/`--env`/`--forward`); `PYTHONPATH` + `PROTOAGENT_INSTANCE` env (supervisor does **not** inherit image ENV); loopback bind (forward relays inside the sandbox netns; `0.0.0.0` without an A2A token is refused by our own guard). |
| `Dockerfile` | Ship **iproute2** — the OpenShell supervisor shells out to `ip` to build the egress netns; sandbox creation fails without it. |
| `deploy/openshell/README.md` | Validated walkthrough + gotcha table (each row cost a debug loop: JWT requirement, ufw/custom-`bip` firewall, h2-error-means-wrong-service, etc.). k8s section explicitly marked not-yet-validated. |
| `docs/guides/sandboxing.md` | Updated to v1 schema reality. |
| `.gitignore` | `deploy/openshell/jwt/` (private key) + generated policy. |

## Not covered

- Kubernetes path (still a template, now labeled as such)
- GPU passthrough (`--gpu` exists in v0.0.59; noted in README)

🤖 Generated with [Claude Code](https://claude.com/claude-code)