### PR TITLE
fix(fleet): member plugin-view styling + spin members down on host exit (version-coherence P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Fleet members render plugin views with no design system (version-coherence
+  Axis 3).** The DS plugin-kit (`/_ds/plugin-kit.{css,js}`) was served only by the
+  console tier (`mount_react_app`), so a `--ui none` fleet member served its plugins'
+  view *pages* but 404'd the kit they `<link>` — proxied plugin views rendered
+  unstyled. The kit now mounts in **every** tier via a dedicated `mount_ds_plugin_kit`,
+  independent of the console SPA.
+
+### Added
+- **Spin local fleet members down when the host exits (version-coherence Axis 1).**
+  Members are spawned detached (so they survive the launching CLI) — but that also
+  let a member outlive a hub rebuild+restart and keep running *old* code. The hub now
+  stops its local members on shutdown by default ("host down → fleet down"); sessions
+  resume from their `instance.id`-scoped checkpoints on the next switch, so it stops
+  processes, not work. Opt out with `PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT=1` for
+  long-running detached agents. Hub-only (a member's scoped registry is empty),
+  bounded teardown (concurrent SIGTERM → one shared wait → SIGKILL stragglers). See
+  `docs/dev/version-coherence.md`.
+
 ## [0.34.0] - 2026-06-10
 
 ### Fixed

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -36,6 +36,16 @@ Every env var the template reads at runtime.
 
 Setup without the wizard: `python -m server --setup` validates the live config (`model.api_base` set + key resolvable via `secrets.yaml`/`OPENAI_API_KEY`) and writes `.setup-complete`, then exits. In the `none` tier the server auto-completes the same way on boot, or **fails fast** if the config is invalid. Readiness is exposed at `GET /healthz` (503 until the graph compiles).
 
+## Fleet (ADR 0042)
+
+The hub spawns local fleet members as detached `--ui none` processes on their own ports.
+
+| Variable | Default | Purpose |
+|---|---|---|
+| `PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT` | (unset) | By default the hub **spins its local members down when it shuts down** ("host down → fleet down" — keeps a rebuilt hub from leaving members running stale code; sessions resume from their `instance.id`-scoped checkpoints on the next switch, so it stops processes, not work). Set `1`/`true` to keep members running across a hub restart — for genuinely long-running detached agents. |
+| `PROTOAGENT_FLEET_MAX_WARM` | `0` | Keep-N-warm cap: at most this many members stay running; switching to another resumes it and evicts the least-recently-active beyond the cap (`0`/unset = unlimited). |
+| `PROTOAGENT_FLEET_WARM_GRACE` | `0` | Seconds a just-active member is spared from keep-warm eviction (may be mid background turn); `0` = pure LRU. |
+
 ## Authentication — A2A bearer token
 
 | Variable | Default | What |

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -397,6 +397,67 @@ def down(names: list[str] | None = None) -> list[dict]:
     return out
 
 
+def keep_members_on_exit() -> bool:
+    """Opt out of spin-down-on-host-exit (``PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT``).
+    Default False — the host owns its fleet, so "host down → fleet down" is the
+    expected lifecycle. Set it for genuinely long-running detached agents that must
+    survive a hub restart."""
+    return os.environ.get("PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT", "").strip().lower() in ("1", "true", "yes")
+
+
+def shutdown_all(*, timeout: float = 3.0) -> list[str]:
+    """Stop every running LOCAL member — called from the hub's shutdown hook so a
+    member can't outlive the host that spawned it.
+
+    Members are spawned detached (``start_new_session=True`` in ``start``) so they
+    survive the CLI/hub that launched them — durable by design, but it also means a
+    hub rebuild+restart strands a member running the OLD code (it's in its own
+    session, gets no signal, and is never re-execed — see
+    ``docs/dev/version-coherence.md`` Axis 1). "Host down → fleet down" is the
+    expected default; opt out via ``PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT=1``.
+    Sessions are ``instance.id``-scoped checkpoints, so a stopped member resumes on
+    its next ``activate`` — this stops PROCESSES, not work.
+
+    **Hub-only by construction:** a member runs ``PROTOAGENT_INSTANCE``-scoped (#813),
+    so inside a member ``_load_state`` reads its own (empty) ``fleet.json`` and this
+    no-ops. Only the hub's registry holds members.
+
+    SIGTERMs all members **at once** (not sequentially), then waits one shared
+    ``timeout`` before SIGKILLing stragglers — so teardown stays bounded regardless of
+    member count and fits the hub's graceful-shutdown window. Best-effort throughout.
+    """
+    if keep_members_on_exit():
+        return []
+    with _state_lock():
+        state = _load_state()
+        # PID-reuse guard (#10): only ours; reserve all stops under the lock.
+        live = [(k, int(r["pid"])) for k, r in state.items()
+                if _alive(r.get("pid")) and _is_our_agent(int(r["pid"]))]
+        if not live:
+            return []
+        for k, _ in live:
+            state.pop(k, None)
+        _save_state(state)
+    for _, pid in live:  # SIGTERM everyone first — concurrent, not 8s-each
+        try:
+            os.kill(pid, signal.SIGTERM)
+        except OSError:
+            pass
+    deadline = time.monotonic() + timeout
+    pending = [pid for _, pid in live]
+    while pending and time.monotonic() < deadline:
+        time.sleep(0.1)
+        pending = [pid for pid in pending if _alive(pid)]
+    for pid in pending:  # SIGKILL stragglers past the shared deadline
+        try:
+            os.kill(pid, signal.SIGKILL)
+        except OSError:
+            pass
+    names = [k for k, _ in live]
+    log.info("[fleet] host exiting — spun down %d member(s): %s", len(names), ", ".join(names))
+    return names
+
+
 # ── Keep-N-warm policy (ADR 0042 §G) ──────────────────────────────────────────
 # Bound how many agents stay hot (a laptop won't run a big fleet). On a switch the
 # target is resumed and the least-recently-active agents beyond the cap are stopped —

--- a/operator_api/web.py
+++ b/operator_api/web.py
@@ -8,11 +8,51 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 
 
+def mount_ds_plugin_kit(app, dist_dir: str | Path) -> bool:
+    """Serve the design-system plugin-kit at ``/_ds/plugin-kit.{css,js}`` — in EVERY
+    UI tier, including ``--ui none`` fleet members.
+
+    Plugin iframe views ``<link>``/``<script>`` these same-origin paths (alongside
+    their ``/plugins/<id>/…`` routes) so a view always matches the console's installed
+    DS version instead of pinning a CDN copy. This is mounted **independently of the
+    full console SPA** precisely because a fleet MEMBER (``--ui none``) serves its
+    plugins' view pages but never mounts the console — without the kit those proxied
+    views render with no design system (the "borked styling" desync; see
+    ``docs/dev/version-coherence.md`` Axis 3). Emitted to ``dist/_ds/`` by the web
+    build (``apps/web/scripts/copy-plugin-kit.mjs``). Returns True when at least one
+    kit asset was served; False when the build output is absent (no ``npm run build``
+    yet) — the ``/_ds`` route then 404s and views fall back to their own defaults.
+    """
+    dist = Path(dist_dir).resolve()
+    mounted = False
+
+    ds_kit_css = dist / "_ds" / "plugin-kit.css"
+    if ds_kit_css.is_file():
+
+        @app.get("/_ds/plugin-kit.css", include_in_schema=False)
+        async def _ds_plugin_kit_css() -> FileResponse:
+            return FileResponse(str(ds_kit_css), media_type="text/css")
+
+        mounted = True
+
+    ds_kit_js = dist / "_ds" / "plugin-kit.js"
+    if ds_kit_js.is_file():
+
+        @app.get("/_ds/plugin-kit.js", include_in_schema=False)
+        async def _ds_plugin_kit_js() -> FileResponse:
+            return FileResponse(str(ds_kit_js), media_type="application/javascript")
+
+        mounted = True
+
+    return mounted
+
+
 def mount_react_app(app, dist_dir: str | Path, *, app_path: str = "/app") -> bool:
     """Mount a built Vite app under ``app_path`` when dist assets exist.
 
-    Returns False when the build output is absent so local Gradio-only dev
-    remains unchanged until ``npm run web:build`` has produced the React app.
+    The console SPA (``/app`` + its assets) — console/full tiers only. The DS
+    plugin-kit (``/_ds/…``) is mounted separately by ``mount_ds_plugin_kit`` so it
+    rides every tier. Returns False when the build output is absent.
     """
     dist = Path(dist_dir).resolve()
     index_path = dist / "index.html"
@@ -27,24 +67,6 @@ def mount_react_app(app, dist_dir: str | Path, *, app_path: str = "/app") -> boo
             StaticFiles(directory=str(assets_dir)),
             name="operator_assets",
         )
-
-    # The design-system plugin-kit, served same-origin at /_ds/plugin-kit.{css,js}
-    # (root, alongside /plugins/<id>/…). Plugin iframe views `<link>`/`<script>` these
-    # paths instead of pinning a CDN copy, so every view matches the console's installed
-    # DS version. Emitted to dist/_ds/ by the web build (apps/web/scripts/copy-plugin-kit.mjs).
-    ds_kit_css = dist / "_ds" / "plugin-kit.css"
-    if ds_kit_css.is_file():
-
-        @app.get("/_ds/plugin-kit.css", include_in_schema=False)
-        async def _ds_plugin_kit_css() -> FileResponse:
-            return FileResponse(str(ds_kit_css), media_type="text/css")
-
-    ds_kit_js = dist / "_ds" / "plugin-kit.js"
-    if ds_kit_js.is_file():
-
-        @app.get("/_ds/plugin-kit.js", include_in_schema=False)
-        async def _ds_plugin_kit_js() -> FileResponse:
-            return FileResponse(str(ds_kit_js), media_type="application/javascript")
 
     @app.get(app_path, include_in_schema=False)
     async def _operator_index() -> FileResponse:

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -586,6 +586,18 @@ def _main():
             _paths.unregister_instance()
         except Exception:  # noqa: BLE001 — shutdown teardown is best-effort
             pass
+        # Spin down LOCAL fleet members so they don't outlive the host running OLD
+        # code (the stale-member desync — docs/dev/version-coherence.md Axis 1).
+        # Default on; opt out with PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT=1. Hub-only
+        # (a member's scoped fleet.json is empty), bounded + off the loop, best-effort.
+        # Done early so members start exiting while the hub tears down the rest.
+        try:
+            from graph.fleet import supervisor as _sup
+            stopped = await asyncio.to_thread(_sup.shutdown_all)
+            if stopped:
+                log.info("[fleet] spun down %d member(s) on host exit", len(stopped))
+        except Exception:  # noqa: BLE001 — member teardown is best-effort on shutdown
+            log.exception("[fleet] spin-down on host exit failed")
         # Withdraw the mDNS advertisement (ADR 0042 §I). Off the loop — same deadlock as
         # advertise (zc.close() posts to and waits on the loop it's called from).
         try:
@@ -763,12 +775,18 @@ def _main():
 
     # --- React operator console (tiers full/console; skipped in 'none') ------
     static_dir = _bundle_root() / "static"
-    if ui != "none":
-        from operator_api.web import mount_react_app
+    web_dist_dir = _bundle_root() / "apps" / "web" / "dist"
+    from operator_api.web import mount_ds_plugin_kit, mount_react_app
 
-        web_dist_dir = _bundle_root() / "apps" / "web" / "dist"
-        if mount_react_app(fastapi_app, web_dist_dir):
-            log.info("React operator console mounted at /app")
+    # The DS plugin-kit (/_ds/plugin-kit.{css,js}) rides EVERY tier — including
+    # `--ui none` fleet members, which serve their plugins' view pages but never
+    # mount the console SPA. Without it, a proxied plugin view renders with no design
+    # system (Axis 3 of docs/dev/version-coherence.md). Independent of the SPA mount.
+    mount_ds_plugin_kit(fastapi_app, web_dist_dir)
+
+    # The console SPA (/app) — console/full tiers only; 'none' (members/headless) skip it.
+    if ui != "none" and mount_react_app(fastapi_app, web_dist_dir):
+        log.info("React operator console mounted at /app")
 
     # --- Static + PWA assets (skipped in 'none') ---------------------------
     if ui != "none" and static_dir.exists():

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -232,3 +232,92 @@ def test_remotes_lock_serializes_concurrent_adds(tmp_path, monkeypatch):
         t.join()
     assert not errs
     assert {r["name"] for r in supervisor.list_remotes()} == {"r-one", "r-two"}
+
+
+# ── spin-down on host exit (version-coherence Axis 1) ─────────────────────────
+def _multi_fleet(tmp_path, monkeypatch):
+    """Fleet with INCREMENTING fake pids (distinct members) + a recording kill.
+    Returns (alive set, killed list of (pid, signal))."""
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    alive: set[int] = set()
+    seq = {"n": 6000}
+    killed: list[tuple[int, int]] = []
+    monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
+
+    class FakeProc:
+        def __init__(self, *a, **k):
+            seq["n"] += 1
+            self.pid = seq["n"]
+            alive.add(self.pid)
+
+    monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
+    monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
+
+    def fake_kill(pid, sig):
+        killed.append((int(pid), int(sig)))
+        alive.discard(int(pid))  # the fake dies on its first signal (SIGTERM)
+
+    monkeypatch.setattr(supervisor.os, "kill", fake_kill)
+    return alive, killed
+
+
+def test_shutdown_all_stops_every_member(tmp_path, monkeypatch):
+    alive, _ = _multi_fleet(tmp_path, monkeypatch)
+    for nm in ("a", "b", "c"):
+        manager.create(nm)
+        supervisor.start(nm)
+    assert len(alive) == 3
+
+    stopped = supervisor.shutdown_all(timeout=1.0)
+
+    assert len(stopped) == 3
+    assert not alive  # every member signalled dead
+    # registry reaped — nothing running but the always-present host entry
+    assert not any(s["running"] for s in supervisor.status() if not s.get("host"))
+
+
+def test_shutdown_all_opt_out_keeps_members(tmp_path, monkeypatch):
+    alive, killed = _multi_fleet(tmp_path, monkeypatch)
+    monkeypatch.setenv("PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT", "1")
+    manager.create("a")
+    supervisor.start("a")
+
+    assert supervisor.shutdown_all(timeout=1.0) == []  # opt-out → no-op
+    assert len(alive) == 1 and not killed              # member untouched
+    assert supervisor.is_running("a")
+
+
+def test_shutdown_all_no_members_is_noop(tmp_path, monkeypatch):
+    _multi_fleet(tmp_path, monkeypatch)  # mocks wired, nothing started
+    # Empty registry — also the member-scope case (a member's own fleet.json is empty).
+    assert supervisor.shutdown_all(timeout=1.0) == []
+
+
+def test_shutdown_all_sigkills_straggler(tmp_path, monkeypatch):
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    alive: set[int] = set()
+    seq = {"n": 7000}
+    sigs: list[int] = []
+    monkeypatch.setattr(supervisor, "_alive", lambda pid: int(pid) in alive if pid else False)
+
+    class FakeProc:
+        def __init__(self, *a, **k):
+            seq["n"] += 1
+            self.pid = seq["n"]
+            alive.add(self.pid)
+
+    monkeypatch.setattr(supervisor.subprocess, "Popen", FakeProc)
+    monkeypatch.setattr(supervisor, "_is_our_agent", lambda pid: True)
+
+    def stubborn_kill(pid, sig):  # ignores SIGTERM; dies only on SIGKILL
+        sigs.append(int(sig))
+        if int(sig) == int(supervisor.signal.SIGKILL):
+            alive.discard(int(pid))
+
+    monkeypatch.setattr(supervisor.os, "kill", stubborn_kill)
+    manager.create("a")
+    supervisor.start("a")
+
+    assert supervisor.shutdown_all(timeout=0.2)  # returns the stopped member
+    assert not alive  # SIGKILL'd after the bounded wait
+    assert int(supervisor.signal.SIGTERM) in sigs and int(supervisor.signal.SIGKILL) in sigs

--- a/tests/test_operator_web_mount.py
+++ b/tests/test_operator_web_mount.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
-from operator_api.web import mount_react_app
+from operator_api.web import mount_ds_plugin_kit, mount_react_app
 
 
 def test_mount_react_app_serves_index_assets_and_fallback(tmp_path) -> None:
@@ -31,27 +31,43 @@ def test_mount_react_app_noops_when_dist_is_missing(tmp_path) -> None:
     assert TestClient(app).get("/app").status_code == 404
 
 
-def test_serves_plugin_kit_same_origin_when_present(tmp_path) -> None:
+def test_mount_ds_plugin_kit_serves_css_js_independent_of_the_spa(tmp_path) -> None:
+    # No index.html / SPA — proves the kit is served independently of the console,
+    # which is exactly the `--ui none` fleet-member case: a member serves plugin
+    # view pages that need the kit but never mounts the SPA (version-coherence Axis 3).
+    dist = tmp_path / "dist"
+    (dist / "_ds").mkdir(parents=True)
+    (dist / "_ds" / "plugin-kit.css").write_text(":root{--pl-color-bg:#0a0a0c}", encoding="utf-8")
+    (dist / "_ds" / "plugin-kit.js").write_text("export const x=1", encoding="utf-8")
+
+    app = FastAPI()
+    assert mount_ds_plugin_kit(app, dist)
+    client = TestClient(app)
+
+    css = client.get("/_ds/plugin-kit.css")
+    assert css.status_code == 200 and "text/css" in css.headers["content-type"] and "--pl-color-bg" in css.text
+    js = client.get("/_ds/plugin-kit.js")
+    assert js.status_code == 200 and "javascript" in js.headers["content-type"]
+    assert client.get("/app").status_code == 404  # the kit function never mounts the console SPA
+
+
+def test_mount_ds_plugin_kit_noops_without_the_build_artifact(tmp_path) -> None:
+    app = FastAPI()
+    assert mount_ds_plugin_kit(app, tmp_path / "missing") is False
+    assert TestClient(app).get("/_ds/plugin-kit.css").status_code == 404
+
+
+def test_mount_react_app_no_longer_serves_the_kit(tmp_path) -> None:
+    # The kit moved OUT of mount_react_app (it's now tier-independent — see
+    # mount_ds_plugin_kit). mount_react_app mounts only the SPA; this guards against
+    # silently re-coupling them (which would re-break members).
     dist = tmp_path / "dist"
     (dist / "_ds").mkdir(parents=True)
     (dist / "index.html").write_text("<div id='root'></div>", encoding="utf-8")
-    (dist / "_ds" / "plugin-kit.css").write_text(":root{--pl-color-bg:#0a0a0c}", encoding="utf-8")
+    (dist / "_ds" / "plugin-kit.css").write_text(":root{}", encoding="utf-8")
 
     app = FastAPI()
     assert mount_react_app(app, dist)
-    res = TestClient(app).get("/_ds/plugin-kit.css")
-
-    assert res.status_code == 200
-    assert "text/css" in res.headers["content-type"]
-    assert "--pl-color-bg" in res.text
-
-
-def test_plugin_kit_route_absent_without_the_build_artifact(tmp_path) -> None:
-    dist = tmp_path / "dist"
-    dist.mkdir(parents=True)
-    (dist / "index.html").write_text("<div id='root'></div>", encoding="utf-8")
-
-    app = FastAPI()
-    assert mount_react_app(app, dist)
-    # No dist/_ds/plugin-kit.css → the root route is never registered.
-    assert TestClient(app).get("/_ds/plugin-kit.css").status_code == 404
+    client = TestClient(app)
+    assert client.get("/app").status_code == 200
+    assert client.get("/_ds/plugin-kit.css").status_code == 404  # NOT served by the SPA mount


### PR DESCRIPTION
Two P0 fixes from [`docs/dev/version-coherence.md`](../blob/main/docs/dev/version-coherence.md) (#892) — both fleet-member coherence. These are the two cheapest/highest-value items and each fixes a live bug from this session.

## Axis 3 — serve the DS kit in every tier (fixes "borked styling")

The DS plugin-kit (`/_ds/plugin-kit.{css,js}`) was registered *inside* `mount_react_app`, which is gated `if ui != "none"` — so a `--ui none` **fleet member** served its plugins' view *pages* (router mounted) but **404'd the kit those pages `<link>`**, and the proxied view rendered with no design system. Confirmed live: member `:7871` served `/plugins/project_board/board` (200) but `/_ds/plugin-kit.css` (404).

Fix: extracted the kit-serving into **`mount_ds_plugin_kit`** and call it **unconditionally** (every tier); `mount_react_app` now mounts only the SPA.

## Axis 1 — spin members down on host exit (kills the stale-member class)

Members are spawned detached (`start_new_session=True`) so they survive the launching CLI — durable by design, but it also let a member **outlive a hub rebuild+restart and keep running old code** (never re-execed). That's the "still the old shit after a rebuild" bug.

`supervisor.shutdown_all()` now stops local members from the hub's shutdown hook:
- **Default ON** ("host down → fleet down" — the owner's call). Opt out with `PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT=1` for long-running detached agents.
- **Non-destructive:** sessions are `instance.id`-scoped checkpoints → a stopped member resumes on its next `activate`. Stops *processes*, not *work*.
- **Hub-only by construction:** a member's scoped `fleet.json` is empty (#813), so it no-ops inside a member.
- **Bounded teardown:** concurrent SIGTERM → one shared 3s wait → SIGKILL stragglers (fits the graceful-shutdown window regardless of member count).

## Tests
`shutdown_all`: stops-all / opt-out-noop / empty-noop / sigkill-straggler. `mount_ds_plugin_kit`: serves `/_ds` independent of the SPA (the member case) + a guard that `mount_react_app` no longer serves the kit. `ruff` clean; `server` imports clean; `test_fleet_routes` green.

## Docs
New "Fleet (ADR 0042)" section in `environment-variables.md` (the opt-out + the previously-undocumented warm-cap vars) + CHANGELOG.

Remaining version-coherence P0: **version truth** (`package_version()` → `0.0.0` in the frozen binary / Docker) — separate PR. P1/P2 tracked in the doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)