### PR TITLE
fix(desktop): bundle pyproject so the frozen app reports its real version, not 0.0.0 (version-coherence P0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The desktop app reported its version as `0.0.0` (version-coherence Cross-cutting
+  B).** A frozen PyInstaller binary has no installed-package metadata, and
+  `pyproject.toml` wasn't bundled — so `paths.package_version()` fell through to its
+  `0.0.0` last resort, which blinds the A2A card, the fleet version handshake, runtime
+  status, and the plugin `min_protoagent_version` compat gate (every plugin that sets
+  one was wrongly refused on desktop). `pyproject.toml` is now bundled into the
+  sidecar (`build_sidecar.py`), so the existing `_MEIPASS` read resolves the real
+  version. (Docker already worked via `COPY .`.)
+
 ## [0.34.0] - 2026-06-10
 
 ### Fixed

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -32,6 +32,13 @@ NAME = "protoagent-server"
 # .yaml, secrets.yaml, .setup-complete) is NOT bundled — it's written at
 # runtime to PROTOAGENT_CONFIG_DIR. Never bundle secrets.yaml or the live YAML.
 BUNDLED_DATA: list[tuple[str, str]] = [
+    # Version truth (version-coherence Cross-cutting B, docs/dev/version-coherence.md):
+    # `paths.package_version()` has no installed-package metadata in a frozen binary,
+    # so it falls back to reading `pyproject.toml` at _MEIPASS. Bundle it (top level)
+    # so the desktop app reports its REAL version instead of "0.0.0" — which otherwise
+    # blinds the A2A card, the fleet version handshake, runtime status, and the plugin
+    # `min_protoagent_version` compat gate (every plugin with one is wrongly refused).
+    ("pyproject.toml", "."),
     ("config/langgraph-config.example.yaml", "config"),
     ("config/SOUL.md", "config"),
     ("config/soul-presets", "config/soul-presets"),

--- a/tests/test_package_version.py
+++ b/tests/test_package_version.py
@@ -1,0 +1,55 @@
+"""`paths.package_version()` resolution — especially the frozen-binary `_MEIPASS`
+fallback that keeps the desktop app from reporting `0.0.0` (version-coherence
+Cross-cutting B). A `0.0.0` blinds the A2A card, the fleet version handshake, runtime
+status, and the plugin `min_protoagent_version` compat gate, so this must resolve a
+real version on every artifact.
+"""
+
+from __future__ import annotations
+
+import importlib.metadata
+import sys
+
+import paths
+
+
+def _force_no_installed_metadata(monkeypatch):
+    """Make ``importlib.metadata.version("protoagent")`` raise, so resolution falls
+    through to the pyproject read — the frozen-binary + Docker reality (the package
+    is never pip-installed there)."""
+    def _raise(name):
+        raise importlib.metadata.PackageNotFoundError(name)
+
+    monkeypatch.setattr(importlib.metadata, "version", _raise)
+
+
+def test_reads_meipass_pyproject_when_frozen(monkeypatch, tmp_path):
+    _force_no_installed_metadata(monkeypatch)
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "protoagent"\nversion = "9.9.9"\n', encoding="utf-8"
+    )
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    assert paths.package_version() == "9.9.9"
+
+
+def test_source_checkout_reads_repo_pyproject(monkeypatch):
+    # Not frozen, no installed metadata → reads pyproject.toml next to paths.py (the
+    # repo root / `COPY .` image). Must be a real version, not the 0.0.0 fallback.
+    _force_no_installed_metadata(monkeypatch)
+    monkeypatch.setattr(sys, "frozen", False, raising=False)
+
+    v = paths.package_version()
+    assert v != "0.0.0" and v[0].isdigit()
+
+
+def test_zero_fallback_only_when_nothing_resolves(monkeypatch, tmp_path):
+    # Frozen, no metadata, and an empty _MEIPASS with no pyproject.toml → the explicit
+    # last-resort fallback (a regression guard: if this ever fires on a real build,
+    # the bundle step in build_sidecar.py dropped pyproject.toml).
+    _force_no_installed_metadata(monkeypatch)
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    monkeypatch.setattr(sys, "_MEIPASS", str(tmp_path), raising=False)
+
+    assert paths.package_version() == "0.0.0"


### PR DESCRIPTION
The third version-coherence P0 (after #893) — **version truth** on the desktop build.

## The bug

`paths.package_version()` resolves the app version from installed-package metadata, else by reading `pyproject.toml` (next to the module, or at `_MEIPASS` when frozen), else `"0.0.0"`. A frozen PyInstaller binary has **no dist-info metadata** *and* `build_sidecar.py` **never bundled `pyproject.toml`** — so the desktop app always hit the `0.0.0` last resort.

That `0.0.0` is load-bearing in the wrong direction — it's what the **A2A agent card**, the **hub↔member version handshake**, **runtime status**, and the plugin **`min_protoagent_version` gate** all read. So on desktop:
- no version-skew check can ever fire (both sides report `0.0.0`), and
- every plugin that declares a `min_protoagent_version` is **wrongly refused** (`needed > 0.0.0` is always true).

## The fix (one line)

Add `("pyproject.toml", ".")` to `BUNDLED_DATA` so it lands at `_MEIPASS` top level — exactly where `paths.py` already looks when `sys.frozen`. No `paths.py` change needed. (Docker already reported correctly via `COPY . /opt/protoagent/`, so it's untouched.)

## Tests

`tests/test_package_version.py` (3): the frozen `_MEIPASS` read returns the bundled version; a source checkout reads the repo `pyproject` (a real version, not `0.0.0`); the `0.0.0` fallback fires *only* when nothing resolves (a regression guard — if it ever fires on a real build, the bundle step dropped `pyproject.toml`).

**Note:** full end-to-end verification needs an actual desktop build (`desktop-build.yml`, tag-triggered) — the unit tests prove the resolution logic; the bundle landing is verified by the PyInstaller `--add-data` mechanics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)