### PR TITLE
fix: reorg stragglers — version resolution + missed `import X as`/`# noqa` rewrites

### DIFF
--- a/infra/paths.py
+++ b/infra/paths.py
@@ -75,17 +75,24 @@ def package_version() -> str:
 
     import sys
 
-    root = Path(__file__).resolve().parent
-    if getattr(sys, "frozen", False):  # PyInstaller onefile — assets land at _MEIPASS
-        root = Path(getattr(sys, "_MEIPASS", root))
-    try:
-        m = re.search(
-            r'^version\s*=\s*"([^"]+)"', (root / "pyproject.toml").read_text(), re.MULTILINE
-        )
-        if m:
-            return m.group(1)
-    except OSError:
-        pass
+    here = Path(__file__).resolve()
+    if getattr(sys, "frozen", False):  # PyInstaller onefile — pyproject bundled at _MEIPASS (#894)
+        candidates = [Path(getattr(sys, "_MEIPASS", here.parent))]
+    else:
+        # Search UPWARD for pyproject.toml: it's at the repo root (or the `COPY .`
+        # image root), NOT next to this module — paths.py lives in infra/, so a
+        # plain `__file__.parent` would look in infra/ and miss it (the regression
+        # the root-module reorg introduced). The nearest one going up is the repo's.
+        candidates = list(here.parents)
+    for base in candidates:
+        try:
+            m = re.search(
+                r'^version\s*=\s*"([^"]+)"', (base / "pyproject.toml").read_text(), re.MULTILINE
+            )
+            if m:
+                return m.group(1)
+        except OSError:
+            continue
     return "0.0.0"
 
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -550,7 +550,7 @@ def _main():
         # every poll, so the console banners it too). Off the loop: the check shells
         # out to `ps` per sibling.
         try:
-            import paths as _paths
+            from infra import paths as _paths
             _paths.register_instance(int(getattr(STATE, "active_port", 0) or 0) or None,
                                      agent_name())
             _w = await asyncio.to_thread(_paths.colocation_warning)
@@ -563,7 +563,7 @@ def _main():
     async def _scheduler_shutdown() -> None:
         # Drop the co-location heartbeat (#706). Best-effort.
         try:
-            import paths as _paths
+            from infra import paths as _paths
             _paths.unregister_instance()
         except Exception:  # noqa: BLE001 — shutdown teardown is best-effort
             pass

--- a/tests/test_exception_logging.py
+++ b/tests/test_exception_logging.py
@@ -53,7 +53,7 @@ def _stub_tracing():
     other tests that patch tracing attributes it omits (e.g. the audit
     redaction suite patches tracing.trace_tool_call). See protoAgent#176."""
     try:
-        import tracing  # noqa: F401
+        from observability import tracing  # noqa: F401
 
         return  # real module present — never stub
     except Exception:

--- a/tests/test_package_version.py
+++ b/tests/test_package_version.py
@@ -10,8 +10,7 @@ from __future__ import annotations
 import importlib.metadata
 import sys
 
-import paths
-
+from infra import paths
 
 def _force_no_installed_metadata(monkeypatch):
     """Make ``importlib.metadata.version("protoagent")`` raise, so resolution falls


### PR DESCRIPTION
The root-module reorg (#896) left a few references the bulk import-rewrite couldn't reach — `import X as Y`, `import X  # noqa`, and a test added *after* the reorg branch forked. **Caught by refreshing a local checkout and booting a fresh agent from scratch** (none were covered by the moved branch's own tests). Main currently boots with a `ModuleNotFoundError` on the co-location check and `test_package_version` is broken — so this is a fix to a live regression.

## Fixes
1. **`infra/paths.py` `package_version()` returned `0.0.0`** for source checkouts + virtual-uv projects (no installed metadata): `paths.py` moved into `infra/`, so `Path(__file__).parent / "pyproject.toml"` looked in `infra/` and missed the repo root. Now searches **upward** for `pyproject.toml` (works at the old root location *and* the new `infra/` one; frozen still reads `_MEIPASS`, #894). This is the **version-truth regression** — the hub/member agent cards + the fleet handshake all read `0.0.0` without it.
2. **`server/__init__.py` (×2):** `import paths as _paths` — the rewrite regex matched bare `import paths` but not the ` as` form → the co-location check raised `ModuleNotFoundError` at boot. → `from infra import paths as _paths`.
3. **`tests/test_exception_logging.py`:** `import tracing  # noqa` (trailing comment dodged the `$`-anchored regex) → `from observability import tracing  # noqa`.
4. **`tests/test_package_version.py`:** `import paths` → `from infra import paths`. Added by #894 *after* the reorg branch forked, so neither branch had both the test and the move — broken on the merged main until now.

## Verification
`ruff` clean; `package_version()` = **`0.34.0`** (source + forced-no-metadata); `server` boot-path imports resolve. **Live-verified** by refreshing the local checkout and booting the hub (`ui=console` default, `/` → `/app`, agent card `0.34.0`, `/_ds` served) plus a fresh `--ui none` member (serves `/_ds` direct *and* through the fleet proxy — the Axis 3 styling fix). CI runs the full pytest suite.

This is the value of the refresh-and-verify pass — three regressions that ruff + the moved branch's tests didn't catch, surfaced the moment a real instance booted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)