### PR TITLE
feat(plugins): install auto-enables + runs the plugin (trust-by-default)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **Installing a plugin from the console now auto-enables + runs it** (ADR 0027,
+  trust-by-default). Previously install ≠ enable: you installed, then had to find the
+  Enable toggle (a buried, easy-to-miss step — and a bundle had no single toggle at
+  all). Now `POST /api/plugins/install` adds the plugin (or every bundle member) to
+  `plugins.enabled` and hot-reloads, so its tools, console views and background
+  surfaces come up live with no separate step and no restart (the router hot-mounts,
+  #822). A failed enable-reload is surfaced (`enable_error`) without failing the
+  install. The CLI `plugin install` stays fetch-only (reproducible/scripted setups);
+  set `PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE=1` to make the console match it. (A
+  one-time "this runs code" confirm for unofficial sources, with "don't show again,"
+  lands next.)
 - **Grouped the loose root-level modules into packages** (pure restructure — no
   behavior change). The 13 modules that sat at the repo root are now cohesive
   packages: **`a2a_impl/`** (`auth`/`executor`/`stores` — named to avoid shadowing

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -424,7 +424,7 @@ const server = createServer(async (req, res) => {
       const sha = "abc1234567def8900000000000000000000abcd";
       INSTALLED_PLUGINS = INSTALLED_PLUGINS.filter((p) => p.id !== id).concat({
         id, source_url: body.url, requested_ref: body.ref || "", resolved_sha: sha,
-        present: true, enabled: false,
+        present: true, enabled: true,   // install AUTO-ENABLES + runs it (trust-by-default)
         manifest: { name: id, version: "0.1.0", description: "installed via console", requires_pip: [], views: [] },
       });
       return sendJson(res, {
@@ -433,7 +433,10 @@ const server = createServer(async (req, res) => {
           resolved_sha: sha, source_url: body.url, requires_pip: [], capabilities: {},
           contributes: { views: [], secrets: [] },
         },
-        restart_required: true,
+        enabled: [id],
+        reloaded: true,
+        restart_recommended: false,
+        enable_error: null,
       });
     }
     {

--- a/apps/web/e2e/plugin-install.spec.ts
+++ b/apps/web/e2e/plugin-install.spec.ts
@@ -20,12 +20,11 @@ test("install a plugin from a git URL, then uninstall it", async ({ page }) => {
   await page.getByLabel("plugin git URL").fill("https://github.com/acme/protoagent-plugin-widgets");
   await page.getByRole("button", { name: "Install", exact: true }).click();
 
-  // Row appears, marked NOT enabled (install ≠ enable).
+  // Row appears, AUTO-ENABLED — installing enables + runs the plugin (trust-by-default).
   const row = page.locator(".plugin-row");
   await expect(row).toHaveCount(1);
   await expect(row.locator(".plugin-row-title")).toContainText("protoagent-plugin-widgets");
-  await expect(row.getByText("not enabled", { exact: true })).toBeVisible();
-  await expect(row.getByText(/add .*to.*plugins\.enabled/i)).toBeVisible();
+  await expect(row.getByText("enabled", { exact: true })).toBeVisible();
 
   // Uninstall
   await row.getByRole("button", { name: /uninstall/i }).click();

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1010,8 +1010,17 @@ export const api = {
   installedPlugins() {
     return request<{ plugins: InstalledPlugin[] }>("/api/plugins/installed");
   },
+  // Install AUTO-ENABLES + runs the plugin (trust-by-default): `enabled` lists the
+  // ids now live; `reloaded` whether the hot-reload landed; `enable_error` is set if
+  // the install succeeded but the enable-reload failed (enable it manually then).
   installPlugin(url: string, ref?: string, force?: boolean) {
-    return request<{ installed: PluginInstallSummary; restart_required: boolean }>(
+    return request<{
+      installed: PluginInstallSummary;
+      enabled: string[];
+      reloaded: boolean;
+      restart_recommended: boolean;
+      enable_error: string | null;
+    }>(
       "/api/plugins/install",
       { method: "POST", body: { url, ref: ref || undefined, force: force || undefined } },
     );

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -13,8 +13,9 @@ import type { InstalledPlugin, PluginUpdate } from "../lib/types";
 
 // Plugins panel (ADR 0027) — install plugins from a git URL, under Settings →
 // Integrations. Mirrors the delegates panel. Read non-suspense so a 404 shows a
-// hint rather than blanking Settings. Install fetches code only (install ≠
-// enable): enabling stays a config + restart decision, surfaced here.
+// hint rather than blanking Settings. Installing AUTO-ENABLES + runs the plugin
+// (trust-by-default) — the console flashes a one-time "runs code" confirm for
+// unofficial sources first.
 const REGISTRY_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/plugin-registry";
 
 export function PluginsSection() {
@@ -53,8 +54,15 @@ export function PluginsSection() {
     mutationFn: () => api.installPlugin(url.trim(), ref.trim() || undefined),
     onSuccess: (res) => {
       const s = res.installed;
-      const deps = s.requires_pip.length ? ` — declares deps (install manually): ${s.requires_pip.join(", ")}` : "";
-      setStatus(`✓ installed ${s.id} v${s.version} @ ${s.resolved_sha.slice(0, 10)} — NOT enabled yet${deps}`);
+      const who = res.enabled.length ? res.enabled.join(", ") : (s.id ?? "plugin");
+      const deps = s.requires_pip?.length ? ` — declares deps (install manually): ${s.requires_pip.join(", ")}` : "";
+      setStatus(
+        res.enable_error
+          ? `✓ installed ${who} — auto-enable failed (${res.enable_error}); enable it on the Local tab${deps}`
+          : res.reloaded
+            ? `✓ installed + enabled ${who} — it's live${deps}`
+            : `✓ installed ${who}${deps}`,
+      );
       setUrl("");
       setRef("");
       invalidate();
@@ -75,10 +83,10 @@ export function PluginsSection() {
       <header className="settings-section-head">
         <h3><Package size={16} /> Install from a git URL</h3>
         <p className="settings-section-sub">
-          Install a plugin from a git URL. Fetching code never runs it — review, then{" "}
-          <strong>enable</strong> it from the <strong>Local</strong> tab (tools, console
-          views and background surfaces all come up live — no restart). Untrusted code?
-          Use an <a href="https://protolabsai.github.io/protoAgent/guides/mcp" target="_blank" rel="noreferrer">MCP server</a> instead.{" "}
+          Install a plugin from a git URL. Installing <strong>enables and runs it</strong>{" "}
+          immediately — its tools, console views and background surfaces come up live, no
+          separate enable step and no restart. Only install code you trust; for untrusted
+          code use an <a href="https://protolabsai.github.io/protoAgent/guides/mcp" target="_blank" rel="noreferrer">MCP server</a> instead.{" "}
           <a href={REGISTRY_GUIDE_URL} target="_blank" rel="noreferrer">Guide</a>.
         </p>
       </header>

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -27,12 +27,20 @@ they're reported so you can `pip uninstall` them if unused.
 **Console:** the **Plugins** section → **Download** — paste the URL, review the
 manifest + capabilities, install, uninstall.
 
-Either way, **install fetches code only — it does not enable or run it.** To
-enable: add the plugin's id to `plugins.enabled` in your config and restart.
+**Installing from the console AUTO-ENABLES + runs the plugin** (trust-by-default):
+it's added to `plugins.enabled` and hot-reloaded, so its tools, console views and
+background surfaces come up live — no separate enable step and no restart. The
+console flashes a one-time "this runs code on your machine" confirm for unofficial
+sources first (official `protoLabsAI/*` installs skip it; "don't show again" flips to
+full trust). Only install code you trust — for untrusted code, use an MCP server.
+
+> The **CLI** `plugin install` stays fetch-only by design (install ≠ enable) for
+> reproducible/scripted setups — enable explicitly via `plugins.enabled`. Set
+> `PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE=1` to make the console behave the same way.
 
 ```yaml
 plugins:
-  enabled: [protoagent-plugin-x]
+  enabled: [protoagent-plugin-x]   # the console auto-adds this for you on install
 ```
 
 Install pins the **resolved commit SHA** and records it in a committed

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -2,8 +2,10 @@
 
 Backs the console Plugins panel: list installed plugins (with their manifest +
 declared capabilities for review), install from a git URL, uninstall, and
-enable/disable. Install fetches code only (install ≠ enable). Enable/disable edits
-``plugins.enabled`` and hot-reloads.
+enable/disable. **Installing AUTO-ENABLES + runs the plugin** (trust-by-default — the
+console flashes a one-time "this runs code" confirm for unofficial sources first; opt
+out with ``PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE=1`` for strict install ≠ enable).
+Enable/disable edits ``plugins.enabled`` and hot-reloads.
 
 ENABLE is fully live: tools/middleware/MCP rebuild with the graph, and a plugin's
 router — which is what serves a console view (the view iframe just points at a
@@ -36,6 +38,26 @@ def _sources_allowlist() -> list[str] | None:
     cfg = STATE.graph_config
     allow = getattr(cfg, "plugins_sources_allow", None) if cfg else None
     return list(allow) if allow else None
+
+
+def _install_no_enable() -> bool:
+    """Opt out of auto-enable-on-install — back to ADR 0027's strict install ≠ enable.
+    Default off: installing a plugin enables + runs it (trust-by-default; the console
+    flashes a one-time "this runs code" confirm for unofficial sources first)."""
+    import os
+
+    return os.environ.get("PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE", "").strip().lower() in ("1", "true", "yes")
+
+
+def _enabled_ids_from_summary(summary: dict) -> list[str]:
+    """The plugin id(s) to enable for an install summary: a single plugin → its id; a
+    bundle → its declared ``enabled`` set (else every installed member)."""
+    if "bundle" in summary:
+        suggested = [str(x) for x in (summary.get("enabled") or [])]
+        members = [str(s["id"]) for s in (summary.get("installed") or []) if s.get("id")]
+        return suggested or members
+    pid = summary.get("id")
+    return [str(pid)] if pid else []
 
 
 def register_plugin_routes(app) -> None:
@@ -77,9 +99,44 @@ def register_plugin_routes(app) -> None:
             )
         except installer.InstallError as exc:
             raise HTTPException(status_code=400, detail=str(exc)) from exc
-        # install ≠ enable: the new plugin's routes/surfaces mount at init, so it
-        # needs a restart + plugins.enabled to take effect.
-        return {"installed": summary, "restart_required": True}
+
+        # Install AUTO-ENABLES + runs the code (ADR 0027, trust-by-default posture):
+        # installing IS the consent — the console flashes a one-time "this runs code"
+        # confirm for unofficial sources first. Add the plugin (or every bundle member)
+        # to plugins.enabled and hot-reload, so its tools / views / surfaces go live with
+        # NO separate enable step and NO restart (the router hot-mounts, #822). Opt out
+        # with PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE=1 (back to strict install ≠ enable).
+        ids = _enabled_ids_from_summary(summary)
+        enabled_now: list[str] = []
+        reloaded = False
+        enable_error: str | None = None
+        if ids and not _install_no_enable():
+            cfg = STATE.graph_config
+            enabled = list(getattr(cfg, "plugins_enabled", []) or [])
+            disabled = [p for p in (getattr(cfg, "plugins_disabled", []) or []) if p not in ids]
+            for pid in ids:
+                if pid not in enabled:
+                    enabled.append(pid)
+            from server.agent_init import _apply_settings_changes
+
+            ok, messages = _apply_settings_changes(
+                config={"plugins": {"enabled": enabled, "disabled": disabled}},
+            )
+            if ok:
+                reloaded, enabled_now = True, ids
+            else:
+                # The install itself succeeded (code is on disk + locked); surface the
+                # enable-reload failure without 500ing — it can be enabled manually.
+                enable_error = "; ".join(messages) or "reload failed"
+                log.warning("[plugins] installed %s but auto-enable reload failed: %s", ids, enable_error)
+
+        return {
+            "installed": summary,
+            "enabled": enabled_now,        # the ids now live
+            "reloaded": reloaded,
+            "restart_recommended": False,  # enable hot-mounts the router/view (#822)
+            "enable_error": enable_error,
+        }
 
     @app.post("/api/plugins/{plugin_id}/enabled")
     async def _set_enabled(plugin_id: str, body: dict | None = None):

--- a/tests/test_plugin_routes.py
+++ b/tests/test_plugin_routes.py
@@ -88,3 +88,56 @@ def test_disabling_a_plain_plugin_does_not_recommend_restart(monkeypatch):
           meta=[{"id": "github", "views": []}])
     body = _client().post("/api/plugins/github/enabled", json={"enabled": False}).json()
     assert body["restart_recommended"] is False
+
+
+# ── auto-enable on install (trust-by-default; install = enabled + running) ────────
+def test_install_auto_enables_and_runs(monkeypatch):
+    from graph.plugins import installer
+    captured = _wire(monkeypatch, enabled=["delegates"], disabled=[], meta=[])
+    monkeypatch.setattr(installer, "install",
+                        lambda url, ref=None, **k: {"id": "spacetraders", "name": "SpaceTraders", "version": "1.0.0"})
+    body = _client().post("/api/plugins/install",
+                          json={"url": "https://github.com/protoLabsAI/spacetraders-plugin"}).json()
+    assert body["enabled"] == ["spacetraders"] and body["reloaded"] is True and body["enable_error"] is None
+    # added to plugins.enabled + persisted via the same _apply_settings_changes path the enable toggle uses
+    assert set(captured["config"]["plugins"]["enabled"]) == {"delegates", "spacetraders"}
+
+
+def test_install_bundle_enables_declared_members(monkeypatch):
+    from graph.plugins import installer
+    captured = _wire(monkeypatch, enabled=[], disabled=[], meta=[])
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {
+        "bundle": "pm-stack", "installed": [{"id": "board"}, {"id": "browser"}], "enabled": ["board"]})
+    body = _client().post("/api/plugins/install", json={"url": "https://x/pm-stack"}).json()
+    assert body["enabled"] == ["board"]                       # the bundle's declared enable set
+    assert captured["config"]["plugins"]["enabled"] == ["board"]
+
+
+def test_install_bundle_without_declared_enable_enables_every_member(monkeypatch):
+    from graph.plugins import installer
+    _wire(monkeypatch, enabled=[], disabled=[], meta=[])
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {
+        "bundle": "x", "installed": [{"id": "a"}, {"id": "b"}], "enabled": []})
+    body = _client().post("/api/plugins/install", json={"url": "https://x/y"}).json()
+    assert body["enabled"] == ["a", "b"]
+
+
+def test_install_opt_out_stays_install_not_enable(monkeypatch):
+    from graph.plugins import installer
+    monkeypatch.setenv("PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE", "1")
+    captured = _wire(monkeypatch, enabled=["delegates"], disabled=[], meta=[])
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "demo"})
+    body = _client().post("/api/plugins/install", json={"url": "https://x"}).json()
+    assert body["enabled"] == [] and body["reloaded"] is False
+    assert "config" not in captured                          # _apply_settings_changes never called
+
+
+def test_install_succeeds_even_if_enable_reload_fails(monkeypatch):
+    from graph.plugins import installer
+    _wire(monkeypatch, enabled=[], disabled=[], meta=[])
+    sys.modules["server.agent_init"]._apply_settings_changes = lambda config=None, soul=None: (False, ["graph compile failed"])
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "demo"})
+    resp = _client().post("/api/plugins/install", json={"url": "https://x"})
+    assert resp.status_code == 200                            # the install itself didn't 500
+    body = resp.json()
+    assert body["installed"]["id"] == "demo" and body["enabled"] == [] and "graph compile failed" in body["enable_error"]


### PR DESCRIPTION
**The bug you hit:** installing a plugin meant install → then hunt for the Enable toggle on the Local tab — buried and easy to miss, and a **bundle has no single toggle**, so there was literally no UI path to enable a full-bundle plugin like SpaceTraders. Confirmed live: a freshly installed SpaceTraders with zero way to enable from the console.

**Your call (ComfyUI trust posture — "it's our code, it's safe; people who install third-party figure it out"):** installing from the console now **auto-enables and runs the plugin.**

## What changed
- **`POST /api/plugins/install`**: after install, add the plugin — or **every bundle member** (the bundle's declared `enabled` set, else all members) — to `plugins.enabled` and **hot-reload** via the same `_apply_settings_changes` path the enable toggle uses. Tools / console views / background surfaces come up live (router hot-mounts, #822) — no separate enable, no restart. A failed enable-reload is surfaced (`enable_error`) **without** 500ing the install (the code is on disk + locked; enable manually). Response: `{installed, enabled, reloaded, restart_recommended, enable_error}`.
- **Opt out** with `PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE=1` (strict install ≠ enable). The **CLI** `plugin install` stays fetch-only (reproducible/scripted setups).
- **Frontend**: the install result now says "installed + enabled — it's live" (or surfaces `enable_error`); the Install panel copy + the `installPlugin` api type updated.

## Persistence (the deeper reason enabling felt broken)
Verified end-to-end: the reload only **loads** config (no re-save over the write), and `apply_updates_to_yaml({plugins:{enabled}})` persists the enabled list **and** preserves `sources.*` — so auto-enable sticks across restarts.

## Tests
5 new (`test_plugin_routes.py`): single auto-enable + the persisted list, bundle declared-members, bundle all-members, opt-out stays fetch-only, install survives a failed enable-reload. `ruff` clean; frontend type-checks; 31 plugin-route/update tests pass.

## Next (slice 2)
The one-time **"this runs code on your machine" confirm** before an *unofficial* git install + a **"don't show again"** full-trust toggle; **official `protoLabsAI/*` auto-trust** (skips the confirm). Tracked in the plugin-hardening plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)