### PR TITLE
fix(fleet): forward WebSocket upgrades through the slug proxy (#883)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The fleet proxy now forwards WebSocket upgrades (#883).** The hub's
+  `/agents/<slug>/*` reverse proxy was HTTP-only (it even stripped `Upgrade`/
+  `Connection`), so a fleet member's plugin that opens a live WS — `agent_browser`'s
+  viewport/feed, say — loaded its panel over HTTP but its socket showed
+  "Disconnected" behind the hub. Added a WS route (`proxy.forward_ws`) that resolves
+  the slug → member, opens a client WS (carrying the bearer + subprotocols), and
+  pumps frames both ways until either side closes. Live plugin sockets now traverse
+  the hub like HTTP does.
+
 ### Changed
 - **Installing a plugin from the console now auto-enables + runs it** (ADR 0027,
   trust-by-default). Previously install ≠ enable: you installed, then had to find the

--- a/graph/fleet/proxy.py
+++ b/graph/fleet/proxy.py
@@ -111,3 +111,84 @@ async def forward_to(slug: str, request, path: str):
         return JSONResponse({"detail": f"agent {slug!r} is not running"}, status_code=409)
     base, extra = target
     return await _forward_to_base(base, request, path, extra)
+
+
+async def _pump_ws(client_ws, upstream) -> None:
+    """Relay frames between the browser-side Starlette ``WebSocket`` and the upstream
+    ``websockets`` client until either side closes. First-to-finish wins; the other
+    direction is cancelled and both ends are closed."""
+    import asyncio
+
+    async def client_to_upstream():
+        try:
+            while True:
+                msg = await client_ws.receive()
+                if msg.get("type") == "websocket.disconnect":
+                    return
+                if (t := msg.get("text")) is not None:
+                    await upstream.send(t)
+                elif (b := msg.get("bytes")) is not None:
+                    await upstream.send(b)
+        except Exception:  # noqa: BLE001 — a closed/erroring side just ends the relay
+            return
+
+    async def upstream_to_client():
+        try:
+            async for msg in upstream:
+                if isinstance(msg, (bytes, bytearray)):
+                    await client_ws.send_bytes(bytes(msg))
+                else:
+                    await client_ws.send_text(msg)
+        except Exception:  # noqa: BLE001
+            return
+
+    tasks = [asyncio.create_task(client_to_upstream()), asyncio.create_task(upstream_to_client())]
+    try:
+        await asyncio.wait(tasks, return_when=asyncio.FIRST_COMPLETED)
+    finally:
+        for t in tasks:
+            t.cancel()
+
+
+async def forward_ws(slug: str, ws, path: str) -> None:
+    """Reverse-proxy a **WebSocket** to the agent named by ``slug`` (#883). The HTTP proxy
+    above can't carry a WS upgrade (it strips ``Upgrade``/``Connection``), so a plugin's
+    live WS — agent_browser's viewport/feed, say — couldn't traverse the hub: HTTP loaded
+    the panel but the socket showed "Disconnected". This resolves the slug → member, opens
+    a client WS to it (carrying the bearer + subprotocols), and pumps frames both ways.
+    """
+    import websockets
+
+    target = _target_for_slug(slug)
+    if target is None:
+        await ws.close(code=1011, reason=f"agent {slug!r} is not running")
+        return
+    base, extra = target
+    ws_base = "ws" + base[len("http"):]  # http(s):// → ws(s)://
+    query = ws.url.query
+    upstream_url = f"{ws_base}/{path}" + (f"?{query}" if query else "")
+
+    headers = dict(extra)  # a remote member's bearer; else carry the browser's
+    auth = ws.headers.get("authorization")
+    if auth and not any(k.lower() == "authorization" for k in headers):
+        headers["authorization"] = auth
+    sub = ws.headers.get("sec-websocket-protocol")
+    subprotocols = [s.strip() for s in sub.split(",") if s.strip()] if sub else None
+
+    try:
+        upstream = await websockets.connect(
+            upstream_url, additional_headers=headers or None, subprotocols=subprotocols,
+            open_timeout=5, ping_interval=None, max_size=None,
+        )
+    except Exception as exc:  # noqa: BLE001 — connect refused / handshake failed / not a WS route
+        log.info("[fleet] ws proxy to %s (%s) failed: %s", slug, path, exc)
+        await ws.close(code=1011, reason="upstream websocket unreachable")
+        return
+    try:
+        await ws.accept(subprotocol=upstream.subprotocol)
+        await _pump_ws(ws, upstream)
+    finally:
+        try:
+            await upstream.close()
+        except Exception:  # noqa: BLE001
+            pass

--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -14,9 +14,9 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from fastapi import Request  # module-level so the stringized `request: Request` annotation
-                             # on the proxy route resolves (function-local imports don't,
-                             # under `from __future__ import annotations`).
+from fastapi import Request, WebSocket  # module-level so the stringized `request: Request` /
+                             # `ws: WebSocket` annotations on the proxy routes resolve
+                             # (function-local imports don't, under `from __future__ import annotations`).
 
 log = logging.getLogger("protoagent.server")
 
@@ -115,6 +115,13 @@ def register_fleet_routes(app) -> None:
         its workspace port via the supervisor.
         """
         return await proxy.forward_to(slug, request, path)
+
+    @app.websocket("/agents/{slug}/{path:path}")
+    async def _agent_ws_proxy(ws: WebSocket, slug: str, path: str):
+        """Reverse-proxy a WebSocket to the agent by slug (#883). Same slug routing as the
+        HTTP proxy above, but for WS upgrades — so a plugin's live socket (agent_browser's
+        viewport/feed) traverses the hub instead of showing "Disconnected" behind it."""
+        await proxy.forward_ws(slug, ws, path)
 
     @app.post("/api/fleet")
     async def _create_agent(body: dict = Body(...)):

--- a/tests/test_fleet_proxy_ws.py
+++ b/tests/test_fleet_proxy_ws.py
@@ -1,0 +1,78 @@
+"""Fleet-proxy WebSocket relay (#883) — `proxy.forward_ws` proxies a WS upgrade through
+the hub to the focused member, so a plugin's live socket (agent_browser's viewport/feed)
+traverses the hub instead of showing "Disconnected" behind the HTTP-only proxy."""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+
+import pytest
+from fastapi import FastAPI, WebSocket
+from fastapi.testclient import TestClient
+from starlette.websockets import WebSocketDisconnect
+
+from graph.fleet import proxy
+
+
+def _echo_ws_server():
+    """A real echo WebSocket server on a free port, in a background thread.
+    Returns (port, stop) — proves forward_ws relays frames BOTH ways over real sockets."""
+    import websockets
+
+    holder: dict = {}
+    ready = threading.Event()
+    loop = asyncio.new_event_loop()
+
+    async def _echo(conn):
+        async for msg in conn:
+            await conn.send(msg)  # echo text or binary
+
+    async def _main():
+        server = await websockets.serve(_echo, "127.0.0.1", 0)
+        holder["port"] = server.sockets[0].getsockname()[1]
+        ready.set()
+        await asyncio.Future()  # serve forever
+
+    def _run():
+        asyncio.set_event_loop(loop)
+        try:
+            loop.run_until_complete(_main())
+        except (asyncio.CancelledError, RuntimeError):
+            pass
+
+    threading.Thread(target=_run, daemon=True).start()
+    assert ready.wait(5), "echo ws server didn't start"
+    return holder["port"], (lambda: loop.call_soon_threadsafe(loop.stop))
+
+
+def _ws_app() -> FastAPI:
+    app = FastAPI()
+
+    @app.websocket("/agents/{slug}/{path:path}")
+    async def _p(ws: WebSocket, slug: str, path: str):
+        await proxy.forward_ws(slug, ws, path)
+
+    return app
+
+
+def test_ws_proxy_relays_text_and_binary(monkeypatch):
+    port, stop = _echo_ws_server()
+    try:
+        monkeypatch.setattr(proxy, "_target_for_slug",
+                            lambda slug: (f"http://127.0.0.1:{port}", {}))
+        with TestClient(_ws_app()).websocket_connect("/agents/peer/live") as ws:
+            ws.send_text("ping")
+            assert ws.receive_text() == "ping"             # text round-trips through the hub
+            ws.send_bytes(b"\x00\x01\x02")
+            assert ws.receive_bytes() == b"\x00\x01\x02"   # binary round-trips too
+    finally:
+        stop()
+
+
+def test_ws_proxy_rejects_when_agent_not_running(monkeypatch):
+    # No live target → the proxy closes the handshake (the WS analog of the HTTP 409).
+    monkeypatch.setattr(proxy, "_target_for_slug", lambda slug: None)
+    with pytest.raises(WebSocketDisconnect):
+        with TestClient(_ws_app()).websocket_connect("/agents/ghost/live"):
+            pass


### PR DESCRIPTION
**Your "No browser connected" — root-caused live.** The `agent_browser` dashboard was running fine (`manage_dashboard` surface had it up on `:4848` with a real Chrome), and its panel loaded over HTTP through the hub — but the **viewport showed "Disconnected"** because the hub's `/agents/<slug>/*` reverse proxy is **HTTP-only** (httpx + `StreamingResponse`, and `_HOP` even strips `Upgrade`/`Connection`). The live viewport is a WebSocket, and the WS handshake died at the proxy. That's the long-standing #883.

## Fix
- **`proxy.forward_ws(slug, ws, path)`** — resolve the slug → member (same `_target_for_slug` as the HTTP proxy: host / local peer / remote-with-bearer), open a `websockets` client to `ws(s)://<member>/<path>` carrying the bearer + subprotocols, accept the browser side with the negotiated subprotocol, and **pump frames both ways** (`_pump_ws`: text + binary; first side to close ends the relay, both ends closed).
- **`@app.websocket("/agents/{slug}/{path:path}")`** in `fleet_routes.py`, alongside the HTTP `api_route`. No live target → `close(1011)` (the WS analog of the HTTP 409).
- `websockets>=12.0` is already a declared core dep — **no new dependency**.

## Tests
`test_fleet_proxy_ws.py`: a **real echo WS upstream** relayed through `forward_ws` — text + binary frames round-trip; not-running closes the handshake. 15 fleet-proxy tests pass; ruff + `import server` clean.

## Verify (live, after merge)
Restart the hub, open a fleet member's `agent_browser` panel **through the hub** — the viewport connects now (was "Disconnected"). The dashboard process itself already auto-starts via the plugin's `manage_dashboard` surface; this was purely the hub not carrying its socket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)