### PR TITLE
fix(fleet): don't wipe chat when swapping agents — tenant guard keys on the HUB uid

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Swapping between fleet agents wiped the chat view.** The tenant guard (which
+  clears persisted chat when the backend behind an origin re-keys) was reading the
+  *focused agent's* `instance_uid` (slug-routed runtime status). Every fleet swap
+  changes the focused agent → its uid changes → the guard fired and cleared **all**
+  slugs' chat. It now keys on the **hub's** uid (a host-pinned runtime read, never
+  slug-routed) — the hub is the actual tenant of the origin and is stable across
+  swaps, so switching agents keeps each agent's chat. The guard still fires on a real
+  re-key (a fork booting on the hub's old port).
 - **The fleet proxy now forwards WebSocket upgrades (#883).** The hub's
   `/agents/<slug>/*` reverse proxy was HTTP-only (it even stripped `Upgrade`/
   `Connection`), so a fleet member's plugin that opens a live WS — `agent_browser`'s

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -112,7 +112,7 @@ import { SubagentsPanel } from "./SubagentsPanel";
 import { MiddlewarePanel } from "./MiddlewarePanel";
 import { PluginsSurface } from "../plugins/PluginsSurface";
 import { SetupWizard } from "../setup/SetupWizard";
-import { runtimeStatusQuery } from "../lib/queries";
+import { hostRuntimeStatusQuery, runtimeStatusQuery } from "../lib/queries";
 
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
 // fanning out to sub-views via an in-surface segmented control.
@@ -273,6 +273,10 @@ export function App() {
     refetchInterval: (q) => (q.state.data?.graph_loaded ? false : 2500),
   });
   const runtime = runtimeQ.data ?? null;
+
+  // Tenant uid is the HUB's, never the focused agent's (which changes on every fleet
+  // swap and would wrongly wipe the chat view). Host-pinned, stable, low-churn.
+  const hostUidQ = useQuery({ ...hostRuntimeStatusQuery(), retry: 30, retryDelay: 1000 });
 
   // Plugin-contributed rail surfaces (ADR 0026): each enabled plugin's declared
   // views become a dynamic rail icon (keyed plugin:<id>:<viewId>) whose panel is
@@ -666,9 +670,11 @@ export function App() {
           finishes (per-window SSE can't see it — this watches the other slugs'
           persisted in-flight turns and polls their durable tasks via the hub). */}
       <FleetTurnWatch />
-      {/* Tenant guard: if a DIFFERENT backend now owns this origin (port handed
-          between agents), drop the previous tenant's persisted chat view. */}
-      <TenantGuard uid={runtime?.instance_uid} />
+      {/* Tenant guard: if a DIFFERENT backend now owns this origin (the HUB re-keyed —
+          a fork booted on the old port), drop the previous tenant's persisted chat view.
+          Keyed on the HUB's uid, NOT the focused agent's — switching fleet agents keeps
+          the same hub, so it must not clear chat on a normal swap. */}
+      <TenantGuard uid={hostUidQ.data?.instance_uid} />
       {/* Cold-start gate: holds over the app until the runtime probe first
           resolves (engine up), so the ~30s frozen-sidecar boot shows
           "Starting <agent>…" rather than a "Load failed" flash. The DS BootGate

--- a/apps/web/src/app/TenantGuard.tsx
+++ b/apps/web/src/app/TenantGuard.tsx
@@ -4,14 +4,15 @@ import { useEffect } from "react";
 import { SWITCHED_FLAG, tenantCheck } from "../lib/tenant";
 
 // Tenant guard: localStorage is keyed by ORIGIN, but the backend behind an origin can
-// change (a port handed from one agent to another — e.g. a fork booted on the old
-// port). The chat store persists full transcripts client-side, so without a check the
-// new tenant's window renders the PREVIOUS agent's conversations. The server exposes a
-// stable per-data-root uid (runtime-status `instance_uid`); on mismatch we drop the
-// previous tenant's chat view (all slugs) + the turn-watcher state, then reload so the
+// change (a fork booted on the old port — a different data root now answers here). The
+// chat store persists full transcripts client-side, so without a check the new tenant's
+// window renders the PREVIOUS one's conversations. The `uid` here is the HUB's stable
+// per-data-root uid (host-pinned runtime status, NOT the focused agent's — switching
+// fleet agents keeps the same hub, so a normal swap must NOT trip this). On mismatch we
+// drop the persisted chat view (all slugs) + the turn-watcher state, then reload so the
 // already-hydrated stores restart clean. Layout/theme/authToken stay — layout is
 // cosmetic, theme is server-side per agent, and clearing a bearer token could lock the
-// operator out. Same data root ⇒ same uid, so restarts/upgrades of the SAME agent
+// operator out. Same hub data root ⇒ same uid, so restarts/upgrades + agent swaps
 // never trip this.
 
 export function TenantGuard({ uid }: { uid: string | undefined }) {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -36,6 +36,9 @@ import type {
 
 type RequestOptions = Omit<RequestInit, "body"> & {
   body?: unknown;
+  /** Pin to the HUB (never slug-route) — for origin-level reads like the tenant uid
+   * that must NOT follow the focused agent. */
+  host?: boolean;
 };
 
 type A2APart = {
@@ -182,12 +185,14 @@ function isAgentPath(path: string) {
   );
 }
 
-export function apiUrl(path: string) {
+export function apiUrl(path: string, opts?: { host?: boolean }) {
   if (/^https?:\/\//.test(path)) return path;
   // Agent-level paths route through the focused agent's proxy, keyed by the URL slug.
+  // `opts.host` forces the HUB (no slug routing) — for origin-level reads (the tenant
+  // uid) that must stay on the hub regardless of which agent is focused.
   let p = path;
   const slug = currentSlug();
-  if (slug !== "host" && isAgentPath(path)) {
+  if (!opts?.host && slug !== "host" && isAgentPath(path)) {
     p = `/agents/${encodeURIComponent(slug)}${path}`;
   }
   const base = defaultApiBase();
@@ -230,15 +235,16 @@ function applyAuth(headers: Headers): Headers {
 }
 
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
-  const headers = applyAuth(new Headers(options.headers));
+  const { host, ...init } = options;  // `host` is ours (routing), not a fetch RequestInit field
+  const headers = applyAuth(new Headers(init.headers));
   let body: BodyInit | undefined;
-  if (options.body !== undefined) {
+  if (init.body !== undefined) {
     headers.set("Content-Type", "application/json");
-    body = JSON.stringify(options.body);
+    body = JSON.stringify(init.body);
   }
 
-  const response = await fetch(apiUrl(path), {
-    ...options,
+  const response = await fetch(apiUrl(path, { host }), {
+    ...init,
     headers,
     body,
   });
@@ -417,6 +423,14 @@ async function consumeSse(
 export const api = {
   runtimeStatus() {
     return request<RuntimeStatus>("/api/runtime/status");
+  },
+
+  // The HUB's runtime status — NEVER slug-routed. The TenantGuard keys on the hub's
+  // `instance_uid` (the real tenant of this origin), which is STABLE across agent
+  // swaps. The slug-routed runtimeStatus() returns the FOCUSED agent's uid, which
+  // changes on every switch and would wrongly wipe the chat view each time.
+  hostRuntimeStatus() {
+    return request<RuntimeStatus>("/api/runtime/status", { host: true });
   },
 
   telemetrySummary(since?: string) {

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -132,6 +132,17 @@ export const runtimeStatusQuery = () =>
     queryFn: () => api.runtimeStatus(),
   });
 
+// The HUB's runtime status (never slug-routed) — used ONLY for the tenant uid, which
+// must track the origin's backend, not the focused agent. A separate key from the
+// slug-routed `runtime` so switching agents never confuses it; the uid is stable, so
+// it doesn't poll.
+export const hostRuntimeStatusQuery = () =>
+  queryOptions({
+    queryKey: ["runtime", "host"] as const,
+    queryFn: () => api.hostRuntimeStatus(),
+    staleTime: Infinity,
+  });
+
 // Delegate registry (ADR 0025) — read non-suspense in the Settings → Integrations
 // panel so a 404 (delegates plugin disabled) degrades gracefully instead of
 // blanking Settings. Invalidated after create/update/delete.


### PR DESCRIPTION
**The "I'm losing chat history when I swap agents" bug.** The tenant guard (#831) clears persisted chat when a *different backend* takes over an origin (a fork booted on the old port). It read `runtime.instance_uid` — but that runtime read is **slug-routed** (`apiUrl`), so it returns the **focused agent's** uid. Every fleet swap changes the focused agent → uid mismatch → `tenantCheck` cleared **every slug's** chat and reloaded. So you lost the chat view on every switch (the "Different agent on this address" toast).

## Fix
Key the guard on the **hub's** uid, never the focused agent's — the hub is the actual tenant of the origin and its uid is stable across swaps.
- **`api.ts`**: `apiUrl` gains `{ host: true }` (skip slug routing); `request` threads it (and keeps `host` out of the fetch `RequestInit`). New `api.hostRuntimeStatus()` = `/api/runtime/status` pinned to the hub.
- **`queries.ts`**: `hostRuntimeStatusQuery` — separate `["runtime","host"]` key, `staleTime: Infinity` (the uid is stable, no poll).
- **`App.tsx`**: `TenantGuard` uid now comes from the host-pinned query, not the slug-routed shell runtime.

The guard **still fires** on a real re-key (a different data root answering the hub's origin); switching / restarting / upgrading agents no longer trips it.

## Note
The chat transcript is client-side, so the clear genuinely blanked the view (the *agent's* server-side memory was always intact — it just wasn't re-rendered). After this, each agent's chat view persists across swaps.

## Verified
`tsc` clean; the `tenant.ts` vitest (4) still green — `tenantCheck` logic is unchanged, only the uid **source** moved from focused-agent to hub.

🤖 Generated with [Claude Code](https://claude.com/claude-code)