### PR TITLE
feat(plugins): devkit builds AND runs a plugin live — no restart + a scaffold CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -82,6 +82,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   independent of the console SPA.
 
 ### Added
+- **The plugin devkit can now build a plugin AND run it live — no restart** (ADR
+  0027/0040). `scaffold_plugin` used to write a skeleton and tell you to "add it to
+  `plugins.enabled` and restart"; it now **enables + hot-reloads** what it scaffolded
+  (the same path the console enable toggle uses, #822), so the new plugin's tools/view
+  are live on the agent's next turn. The edit→test loop is closed with two new devkit
+  tools: `reload_plugins` (re-execs enabled plugins so an edit to a plugin's
+  `__init__.py` goes live) and `enable_plugin(id)` (turn on any on-disk plugin live).
+  Communication plugins (ADR 0029) still enable from Settings (they need a token).
+- **`plugin new` / `plugin new-bundle` CLI** — scaffold a plugin or an ADR-0040
+  bundle from the shell: `python -m server plugin new "My Plugin" --view --skill`,
+  `… plugin new-bundle "My Stack" --member board=url@ref --builtin delegates`. The
+  writers moved to core (`graph.plugins.scaffold`) so the CLI works without the devkit
+  plugin enabled; the devkit tool is now a thin wrapper that adds the live-enable.
 - **Spin local fleet members down when the host exits (version-coherence Axis 1).**
   Members are spawned detached (so they survive the launching CLI) — but that also
   let a member outlive a hub rebuild+restart and keep running *old* code. The hub now

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -74,10 +74,14 @@ the network entirely.
 
 > **Start from the devkit.** Enable the bundled **`plugin-devkit`** plugin
 > (`plugins: { enabled: [plugin-devkit] }`) — it's the canonical full-bundle
-> example *and* it gives the agent a `scaffold_plugin` tool, a `plugin-architect`
-> subagent + `design-plugin` workflow, and the `building-plugins` skill. With it
-> on, just ask the agent to *"build a plugin that …"* and it scaffolds a working
-> skeleton for you to fill in.
+> example *and* it gives the agent the authoring tools: `scaffold_plugin` (writes a
+> skeleton **and enables it live**), `reload_plugins` (re-exec after you edit it),
+> `enable_plugin`, `scaffold_bundle`, plus a `plugin-architect` subagent +
+> `design-plugin` workflow + the `building-plugins` skill. With it on, ask the agent
+> to *"build a plugin that …"* and it scaffolds, enables, and tests it **in the same
+> session — no restart**. Prefer the shell? `python -m server plugin new "My Plugin"
+> --view --skill` (and `plugin new-bundle` for an ADR-0040 stack) scaffold without
+> the plugin enabled.
 
 A plugin is a directory (its own repo) with a manifest + a `register()`. The
 **conventional layout** — everything here is picked up when the plugin is enabled:

--- a/graph/plugins/cli.py
+++ b/graph/plugins/cli.py
@@ -1,7 +1,10 @@
-"""`python -m server plugin …` — manage git-installed plugins (ADR 0027).
+"""`python -m server plugin …` — scaffold + manage plugins (ADR 0027).
 
-A thin CLI over ``graph.plugins.installer``. Install fetches code only (it never
-enables the plugin or installs its deps — both are explicit, by design).
+A thin CLI over ``graph.plugins.installer`` (install/list/…) and
+``graph.plugins.scaffold`` (``new`` / ``new-bundle``). Install fetches code only
+(it never enables the plugin or installs its deps — both are explicit, by design);
+``new`` writes a skeleton on disk (enable it from the console or, in a running
+agent, the devkit's ``enable_plugin`` tool — live, no restart).
 """
 
 from __future__ import annotations
@@ -9,15 +12,33 @@ from __future__ import annotations
 import argparse
 import sys
 
-from graph.plugins import installer
+from graph.plugins import installer, scaffold
 
 
 def _build_parser() -> argparse.ArgumentParser:
     p = argparse.ArgumentParser(
         prog="python -m server plugin",
-        description="Install/manage plugins from git URLs (ADR 0027).",
+        description="Scaffold + install/manage plugins (ADR 0027).",
     )
     sub = p.add_subparsers(dest="cmd", required=True)
+
+    pn = sub.add_parser("new", help="scaffold a new plugin skeleton on disk (ready to fill in + enable)")
+    pn.add_argument("name", help="human name (the id is slugified from it, e.g. \"My Plugin\" → my-plugin)")
+    pn.add_argument("--summary", default="A protoAgent plugin.", help="one-line description for the manifest")
+    pn.add_argument("--view", action="store_true", help="include a console view (sandboxed iframe + router)")
+    pn.add_argument("--skill", action="store_true", help="include a SKILL.md skill stub")
+    pn.add_argument("--workflow", action="store_true", help="include a workflow YAML stub")
+    pn.add_argument("--comms", action="store_true", help="a communication plugin (ChatAdapter, ADR 0029) instead of a tool plugin")
+    pn.add_argument("--dir", default=None, help="target dir (default: the live plugins dir the loader discovers)")
+
+    pnb = sub.add_parser("new-bundle", help="scaffold a plugin BUNDLE (protoagent.bundle.yaml, ADR 0040)")
+    pnb.add_argument("name", help="human name for the bundle (slugified to its id)")
+    pnb.add_argument("--summary", default="A protoAgent plugin bundle.", help="one-line description")
+    pnb.add_argument("--member", action="append", metavar="id=url[@ref]", default=[],
+                     help="a git plugin member; repeatable (e.g. --member board=https://github.com/you/board@v0.1.0)")
+    pnb.add_argument("--builtin", action="append", metavar="id", default=[],
+                     help="a built-in member that ships with protoAgent; repeatable (e.g. --builtin delegates)")
+    pnb.add_argument("--dir", default=None, help="target dir (default: the live plugins dir)")
 
     pi = sub.add_parser("install", help="install a plugin — or a bundle of plugins — from a git URL (does NOT enable it)")
     pi.add_argument("url", help="git URL (https://, ssh://, git@, or a local path) of a plugin or a bundle repo")
@@ -37,6 +58,47 @@ def _build_parser() -> argparse.ArgumentParser:
 def run_plugin_cli(argv: list[str]) -> int:
     args = _build_parser().parse_args(argv)
     try:
+        if args.cmd == "new":
+            try:
+                res = scaffold.scaffold_plugin(
+                    args.name, summary=args.summary, with_view=args.view, with_skill=args.skill,
+                    with_workflow=args.workflow, with_comms=args.comms, target_dir=args.dir,
+                )
+            except FileExistsError as e:
+                print(f"✗ {scaffold.slug(args.name)!r} already exists at {e}", file=sys.stderr)
+                return 1
+            print(f"✓ scaffolded {res.kind} {res.id!r} at {res.path}")
+            print(f"  wrote: {', '.join(res.made)}")
+            if res.kind == "comms":
+                print("  next: implement the ChatAdapter (see plugins/telegram), then enable it from Settings.")
+            else:
+                print("  next: fill in __init__.py, then enable it — toggle it on in the console, or in a running")
+                print(f"        agent (with plugin-devkit enabled) ask it to enable_plugin('{res.id}') — live, no restart.")
+            return 0
+        if args.cmd == "new-bundle":
+            members: list[dict] = []
+            for spec in args.member:
+                if "=" not in spec:
+                    print(f"✗ bad --member {spec!r} (expected id=url[@ref])", file=sys.stderr)
+                    return 1
+                mid, rest = spec.split("=", 1)
+                url, _, ref = rest.partition("@")
+                members.append({"id": mid, "url": url, "ref": ref or None})
+            for bid in args.builtin:
+                members.append({"id": bid, "builtin": True})
+            try:
+                res = scaffold.scaffold_bundle(
+                    args.name, summary=args.summary, members=members or None, target_dir=args.dir,
+                )
+            except FileExistsError as e:
+                print(f"✗ {scaffold.slug(args.name)!r} already exists at {e}", file=sys.stderr)
+                return 1
+            print(f"✓ scaffolded bundle {res.id!r} at {res.path}")
+            print(f"  wrote: {', '.join(res.made)}")
+            if not members:
+                print("  fill in the REPLACE_ME member(s), then:")
+            print("  commit/push it, then `plugin install <repo-url>` to install + enable the stack (ADR 0040).")
+            return 0
         if args.cmd == "install":
             s = installer.install(args.url, args.ref, force=args.force,
                                   allow=installer.configured_allowlist())

--- a/graph/plugins/scaffold.py
+++ b/graph/plugins/scaffold.py
@@ -1,0 +1,341 @@
+"""Plugin/bundle scaffolding — the writers behind the `scaffold_plugin` devkit
+tool AND the `plugin new` / `plugin new-bundle` CLI (ADR 0027).
+
+These are pure filesystem writers: no agent, no graph, no enable. They drop a
+ready-to-fill skeleton on disk and return what they wrote. Living in core (not
+the plugin) means the CLI can scaffold even when the devkit plugin is disabled.
+The *live-enable* half — turning the skeleton on and hot-reloading so you can
+test it without a restart — lives in the plugin-devkit tool, because it needs
+the running graph.
+"""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# ── stubs (the worked templates) ────────────────────────────────────────────
+
+_INIT_STUB = '''"""{name} — a protoAgent plugin (scaffolded by plugin-devkit)."""
+
+from __future__ import annotations
+
+from langchain_core.tools import tool
+{view_import}
+
+def register(registry):
+    """Wire this plugin's contributions into the agent (ADR 0018)."""
+{registrations}
+    # Event bus (ADR 0039) — coordinate without importing other plugins:
+    #   registry.emit("did_something", {{"id": 1}})   # → "{id_us}.did_something" on the bus
+    #   registry.on("other-plugin.*", lambda evt: ...) # react to anyone's events
+'''
+
+_TOOL_STUB = '''
+    @tool
+    def {id_us}_hello(name: str = "world") -> str:
+        """Say hello — replace with your tool's real work."""
+        return f"hello, {{name}}, from {id}"
+    registry.register_tool({id_us}_hello)
+'''
+
+_VIEW_STUB = '''
+    from fastapi import APIRouter
+    from fastapi.responses import HTMLResponse
+    router = APIRouter()
+
+    @router.get("/view")
+    async def _view():
+        # The console iframes this page (ADR 0038) and postMessages it the operator
+        # bearer + theme (ADR 0026). Serve a sandboxed page; for untrusted/generated
+        # content keep the inner frame sandbox="allow-scripts" with no same-origin.
+        return HTMLResponse("<!doctype html><body style='background:#0a0a0c;color:#ededed;"
+                            "font-family:system-ui;padding:32px'><h1>{name}</h1>"
+                            "<p>Your plugin view — replace this page.</p></body>")
+    # Mounted under /api/plugins/{id} so it inherits the operator bearer gate (ADR 0026).
+    registry.register_router(router, prefix="/api/plugins/{id}")
+'''
+
+_MANIFEST_STUB = """id: {id}
+name: {name}
+version: 0.1.0
+description: >-
+  {summary}
+enabled: false
+config_section: {id_us}
+# Event bus (ADR 0039) — topics this plugin broadcasts / listens for (optional, for discovery):
+# emits: ["{id_us}.something"]
+# subscribes: ["other-plugin.*"]
+{views_block}"""
+
+_SKILL_STUB = """---
+name: {id}-skill
+description: >-
+  Describe WHEN to use this skill (the trigger). Replace this with the cases that
+  should invoke {name}.
+---
+
+# {name}
+
+Replace this body with the procedure the agent should follow.
+"""
+
+_WORKFLOW_STUB = """name: {id}-workflow
+description: A scaffolded workflow — replace the steps with your recipe.
+version: 1
+inputs:
+  - name: request
+    description: What to do.
+    required: true
+steps:
+  - id: do
+    subagent: researcher
+    prompt: |
+      {{{{inputs.request}}}}
+output: "{{{{steps.do.output}}}}"
+"""
+
+# Communication plugin (ADR 0029) — a ChatAdapter on the shared wirer.
+_COMMS_MANIFEST_STUB = """id: {id}
+name: {name}
+version: 0.1.0
+description: >-
+  {summary}
+enabled: false
+config_section: {id}
+config:
+  enabled: false
+  admin_ids: []
+secrets: [bot_token]
+settings:
+  - {{ key: enabled, label: "Enable {name}", type: bool, description: "Inbound gateway. Needs the token below; reconnects live on save." }}
+  - {{ key: bot_token, label: "Bot token", type: secret, description: "Platform bot token. Use Test connection to verify." }}
+  - {{ key: admin_ids, label: "Admin user IDs", type: string_list, description: "User IDs allowed to message the bot (one per line). Empty = anyone." }}
+"""
+
+_COMMS_INIT_STUB = '''"""{name} — a communication plugin (scaffolded by plugin-devkit, ADR 0029).
+
+Implement the transport (connect / receive / send); the shared wirer handles
+admin-gating, per-conversation threads, agent invoke, reply-chunking, lifecycle,
+and the Test route. Reference: plugins/telegram. Guide:
+docs/guides/communication-plugins.md.
+"""
+
+from __future__ import annotations
+
+from graph.plugins.chat_surface import InboundMessage, register_chat_surface
+
+
+class {cls}Adapter:
+    id = "{id}"
+    chunk_limit = 4000  # your platform's message-length cap (0 = no chunking)
+
+    def configured(self, cfg) -> bool:
+        return bool((cfg.get("bot_token") or "").strip())
+
+    async def validate(self, cfg):
+        """Verify the token (the Test button). Return (ok, identity|None, error|None)."""
+        token = (cfg.get("bot_token") or "").strip()
+        if not token:
+            return (False, None, "No bot token set.")
+        # TODO: call your platform's auth/me endpoint and return its identity.
+        return (True, None, None)
+
+    async def run(self, handle, *, cfg, host):
+        """Connect, then loop. For each inbound message:
+            async def reply(text): ...send it back...
+            await handle(InboundMessage(text=..., user_id=..., channel_id=..., reply=reply))
+        Runs until cancelled."""
+        raise NotImplementedError("Implement {cls}Adapter.run — see plugins/telegram.")
+
+
+def register(registry):
+    register_chat_surface(registry, {cls}Adapter())
+'''
+
+# Bundle (ADR 0040) — a reference manifest naming a set of plugins to install +
+# enable together. No code of its own; each member is a git URL or builtin: true.
+_BUNDLE_STUB = """id: {id}
+name: {name}
+description: >-
+  {summary}
+# A bundle NAMES plugins to install + enable together (ADR 0040). It carries no
+# code — each member is a git {{url, ref}} or `builtin: true` (ships with protoAgent).
+plugins:
+{members}
+enabled: [{enabled}]
+# Per-member config applied on install (optional):
+# config:
+#   some_plugin: {{ setting: value }}
+"""
+
+# Single braces: this is a .format() ARGUMENT (the members block), not the format
+# string, so its braces are NOT un-escaped — they must already be literal YAML.
+_BUNDLE_MEMBER_PLACEHOLDER = (
+    "  # - { id: delegates,  builtin: true }                      # ships with protoAgent\n"
+    "  - { id: REPLACE_ME, url: https://github.com/you/your-plugin, ref: v0.1.0 }"
+)
+
+
+# ── helpers ──────────────────────────────────────────────────────────────────
+
+
+def slug(name: str) -> str:
+    """A plugin/bundle id: lowercase, dash-separated, safe for a dir + module name."""
+    return re.sub(r"[^a-z0-9-]+", "-", (name or "").lower()).strip("-") or "plugin"
+
+
+@dataclass
+class Scaffolded:
+    """What a scaffold wrote — for the CLI to print or the tool to narrate."""
+
+    id: str
+    path: Path
+    made: list[str] = field(default_factory=list)
+    kind: str = "plugin"  # "plugin" | "comms" | "bundle"
+
+
+def live_plugins_dir() -> Path:
+    """The plugins dir the loader discovers — the default scaffold target."""
+    from graph.plugins.installer import live_plugins_dir as _d
+
+    return _d()
+
+
+def _resolve_root(target_dir: str | None) -> Path:
+    return Path(target_dir).expanduser() if target_dir else live_plugins_dir()
+
+
+def _class_name(name: str, fallback: str) -> str:
+    parts = [w for w in re.split(r"[-_ ]+", name) if w]
+    return "".join(w[:1].upper() + w[1:] for w in parts) or fallback.title()
+
+
+# ── writers ──────────────────────────────────────────────────────────────────
+
+
+def scaffold_plugin(
+    name: str,
+    *,
+    summary: str = "A protoAgent plugin.",
+    with_tool: bool = True,
+    with_view: bool = False,
+    with_skill: bool = False,
+    with_workflow: bool = False,
+    with_comms: bool = False,
+    target_dir: str | None = None,
+) -> Scaffolded:
+    """Write a new plugin SKELETON (manifest + ``register()`` + optional
+    view/skill/workflow stubs) under ``target_dir`` (or the live plugins dir).
+
+    ``with_comms=True`` writes a **communication plugin** (ADR 0029) — a
+    ``ChatAdapter`` skeleton on the shared wirer instead of the default tool
+    plugin. Raises ``FileExistsError`` if the id already exists.
+    """
+    pid = slug(name)
+    id_us = pid.replace("-", "_")
+    target = _resolve_root(target_dir) / pid
+    if target.exists():
+        raise FileExistsError(str(target))
+    target.mkdir(parents=True)
+
+    # Communication plugin (ADR 0029) — different shape from the default tool plugin.
+    if with_comms:
+        cls = _class_name(name, id_us)
+        (target / "protoagent.plugin.yaml").write_text(
+            _COMMS_MANIFEST_STUB.format(id=pid, name=name, summary=summary)
+        )
+        (target / "__init__.py").write_text(
+            _COMMS_INIT_STUB.format(id=pid, name=name, cls=cls)
+        )
+        made = ["protoagent.plugin.yaml", "__init__.py (ChatAdapter)"]
+        if with_skill:
+            sk = target / "skills" / f"{pid}-skill"
+            sk.mkdir(parents=True)
+            (sk / "SKILL.md").write_text(_SKILL_STUB.format(id=pid, name=name))
+            made.append("skills/")
+        return Scaffolded(id=pid, path=target, made=made, kind="comms")
+
+    views_block = (
+        f"views:\n  - {{ id: main, label: \"{name}\", icon: Boxes, path: /api/plugins/{pid}/view }}\n"
+        if with_view else ""
+    )
+    (target / "protoagent.plugin.yaml").write_text(
+        _MANIFEST_STUB.format(id=pid, name=name, summary=summary, id_us=id_us, views_block=views_block)
+    )
+
+    registrations = ""
+    if with_tool:
+        registrations += _TOOL_STUB.format(id=pid, id_us=id_us)
+    if with_view:
+        registrations += _VIEW_STUB.format(id=pid, name=name)
+    if not registrations.strip():
+        registrations = "    pass  # add registry.register_* calls here\n"
+    (target / "__init__.py").write_text(
+        _INIT_STUB.format(name=name, view_import="", registrations=registrations, id_us=id_us)
+    )
+
+    made = ["protoagent.plugin.yaml", "__init__.py"]
+    if with_skill:
+        sk = target / "skills" / f"{pid}-skill"
+        sk.mkdir(parents=True)
+        (sk / "SKILL.md").write_text(_SKILL_STUB.format(id=pid, name=name))
+        made.append("skills/")
+    if with_workflow:
+        (target / "workflows").mkdir()
+        (target / "workflows" / f"{pid}.yaml").write_text(_WORKFLOW_STUB.format(id=pid))
+        made.append("workflows/")
+
+    return Scaffolded(id=pid, path=target, made=made, kind="plugin")
+
+
+def _render_members(members: list[dict] | None) -> tuple[str, list[str]]:
+    """Render the bundle's ``plugins:`` block + the list of member ids (for enabled)."""
+    if not members:
+        return _BUNDLE_MEMBER_PLACEHOLDER, ["REPLACE_ME"]
+    lines, ids = [], []
+    for m in members:
+        # Member ids reference EXISTING plugin ids — keep them verbatim (plugin ids
+        # keep underscores, e.g. project_board / agent_browser); don't slugify.
+        mid = str(m.get("id") or "").strip()
+        if not mid:
+            continue
+        ids.append(mid)
+        if m.get("builtin"):
+            lines.append(f"  - {{ id: {mid}, builtin: true }}")
+        else:
+            url = m.get("url") or "https://github.com/you/your-plugin"
+            ref = m.get("ref")
+            ref_part = f", ref: {ref}" if ref else ""
+            lines.append(f"  - {{ id: {mid}, url: {url}{ref_part} }}")
+    return "\n".join(lines), ids
+
+
+def scaffold_bundle(
+    name: str,
+    *,
+    summary: str = "A protoAgent plugin bundle.",
+    members: list[dict] | None = None,
+    enabled: list[str] | None = None,
+    target_dir: str | None = None,
+) -> Scaffolded:
+    """Write a ``protoagent.bundle.yaml`` skeleton (ADR 0040) under a new
+    ``<bundle-id>/`` dir. ``members`` is a list of ``{id, url, ref}`` or
+    ``{id, builtin: true}``; with none, a REPLACE_ME template is written.
+    Raises ``FileExistsError`` if the id already exists.
+    """
+    bid = slug(name)
+    target = _resolve_root(target_dir) / bid
+    if target.exists():
+        raise FileExistsError(str(target))
+    target.mkdir(parents=True)
+    members_block, member_ids = _render_members(members)
+    enabled_ids = enabled if enabled is not None else member_ids
+    (target / "protoagent.bundle.yaml").write_text(
+        _BUNDLE_STUB.format(
+            id=bid, name=name, summary=summary,
+            members=members_block, enabled=", ".join(enabled_ids),
+        )
+    )
+    return Scaffolded(id=bid, path=target, made=["protoagent.bundle.yaml"], kind="bundle")

--- a/plugins/plugin-devkit/__init__.py
+++ b/plugins/plugin-devkit/__init__.py
@@ -1,42 +1,26 @@
 """Plugin Devkit — the plugin-authoring kit + the reference plugin (ADR 0027).
 
-The featured full-bundle example: in ONE plugin it contributes a **tool**
-(`scaffold_plugin`), a **subagent** (`plugin-architect`), a bundled **skill**
-(`skills/building-plugins`), a **workflow** (`workflows/design-plugin`), a
-**console view** (`/guide`), and **config/settings** — every contribution type.
-Enable it to let the agent build its own plugins: it has the *how* (the skill) and
-the *doing* (the scaffold tool).
+The featured full-bundle example: in ONE plugin it contributes **tools**
+(`scaffold_plugin`, `scaffold_bundle`, `enable_plugin`, `reload_plugins`), a
+**subagent** (`plugin-architect`), a bundled **skill** (`skills/building-plugins`),
+a **workflow** (`workflows/design-plugin`), a **console view** (`/guide`), and
+**config/settings** — every contribution type.
 
-Read this file as a template — it's intentionally a worked example of each seam.
+Enable it to let the agent build its own plugins *and test them live*: it has the
+*how* (the skill), the *doing* (scaffold), and — new — the *running it* (enable +
+hot-reload, no restart). The scaffolders themselves live in core
+(`graph.plugins.scaffold`) so the `plugin new` CLI shares them; this file is the
+agent-facing half + the live-enable that needs the running graph.
 """
 
 from __future__ import annotations
 
-import re
-from pathlib import Path
-
 from langchain_core.tools import tool
 
+from graph.plugins import scaffold
 from graph.subagents.config import SubagentConfig
 
-# ── helpers ──────────────────────────────────────────────────────────────────
-
-
-def _slug(name: str) -> str:
-    return re.sub(r"[^a-z0-9-]+", "-", (name or "").lower()).strip("-") or "plugin"
-
-
-def _target_root(config: dict | None) -> Path:
-    """Where scaffolded plugins are written: the configured ``target_dir`` (ADR
-    0019) or, blank, the live plugins dir the loader discovers."""
-    t = (config or {}).get("target_dir") or ""
-    if t:
-        return Path(t).expanduser()
-    from graph.plugins.installer import live_plugins_dir
-    return live_plugins_dir()
-
-
-# Captured at register() so the scaffold tool can broadcast on the event bus (ADR 0039) —
+# Captured at register() so the scaffold tools can broadcast on the event bus (ADR 0039) —
 # the devkit dogfoods its own lesson.
 _REGISTRY = None
 
@@ -49,146 +33,33 @@ def _emit_scaffolded(pid: str, kind: str) -> None:
         pass
 
 
-_INIT_STUB = '''"""{name} — a protoAgent plugin (scaffolded by plugin-devkit)."""
+def _live_enable(pid: str) -> tuple[bool, str]:
+    """Enable a plugin in the RUNNING agent + hot-reload — the same path the console
+    enable toggle uses (#822): tools/subagents/middleware/MCP rebuild with the graph
+    and the plugin's router hot-mounts, so a freshly enabled plugin is live with no
+    restart. No-ops cleanly when there's no live graph (the CLI / tests)."""
+    try:
+        from runtime.state import STATE
 
-from __future__ import annotations
+        if getattr(STATE, "graph", None) is None:
+            return (False, "not running — enable it when the agent is live")
+        cfg = STATE.graph_config
+        enabled = [p for p in (getattr(cfg, "plugins_enabled", []) or []) if p != pid]
+        enabled.append(pid)
+        disabled = [p for p in (getattr(cfg, "plugins_disabled", []) or []) if p != pid]
+        from server.agent_init import _apply_settings_changes
 
-from langchain_core.tools import tool
-{view_import}
-
-def register(registry):
-    """Wire this plugin's contributions into the agent (ADR 0018)."""
-{registrations}
-    # Event bus (ADR 0039) — coordinate without importing other plugins:
-    #   registry.emit("did_something", {{"id": 1}})   # → "{id_us}.did_something" on the bus
-    #   registry.on("other-plugin.*", lambda evt: ...) # react to anyone's events
-'''
-
-_TOOL_STUB = '''
-    @tool
-    def {id_us}_hello(name: str = "world") -> str:
-        """Say hello — replace with your tool's real work."""
-        return f"hello, {{name}}, from {id}"
-    registry.register_tool({id_us}_hello)
-'''
-
-_VIEW_STUB = '''
-    from fastapi import APIRouter
-    from fastapi.responses import HTMLResponse
-    router = APIRouter()
-
-    @router.get("/view")
-    async def _view():
-        # The console iframes this page (ADR 0038) and postMessages it the operator
-        # bearer + theme (ADR 0026). Serve a sandboxed page; for untrusted/generated
-        # content keep the inner frame sandbox="allow-scripts" with no same-origin.
-        return HTMLResponse("<!doctype html><body style='background:#0a0a0c;color:#ededed;"
-                            "font-family:system-ui;padding:32px'><h1>{name}</h1>"
-                            "<p>Your plugin view — replace this page.</p></body>")
-    # Mounted under /api/plugins/{id} so it inherits the operator bearer gate (ADR 0026).
-    registry.register_router(router, prefix="/api/plugins/{id}")
-'''
-
-_MANIFEST_STUB = """id: {id}
-name: {name}
-version: 0.1.0
-description: >-
-  {summary}
-enabled: false
-config_section: {id_us}
-# Event bus (ADR 0039) — topics this plugin broadcasts / listens for (optional, for discovery):
-# emits: ["{id_us}.something"]
-# subscribes: ["other-plugin.*"]
-{views_block}"""
-
-_SKILL_STUB = """---
-name: {id}-skill
-description: >-
-  Describe WHEN to use this skill (the trigger). Replace this with the cases that
-  should invoke {name}.
----
-
-# {name}
-
-Replace this body with the procedure the agent should follow.
-"""
-
-_WORKFLOW_STUB = """name: {id}-workflow
-description: A scaffolded workflow — replace the steps with your recipe.
-version: 1
-inputs:
-  - name: request
-    description: What to do.
-    required: true
-steps:
-  - id: do
-    subagent: researcher
-    prompt: |
-      {{{{inputs.request}}}}
-output: "{{{{steps.do.output}}}}"
-"""
-
-# Communication plugin (ADR 0029) — a ChatAdapter on the shared wirer.
-_COMMS_MANIFEST_STUB = """id: {id}
-name: {name}
-version: 0.1.0
-description: >-
-  {summary}
-enabled: false
-config_section: {id}
-config:
-  enabled: false
-  admin_ids: []
-secrets: [bot_token]
-settings:
-  - {{ key: enabled, label: "Enable {name}", type: bool, description: "Inbound gateway. Needs the token below; reconnects live on save." }}
-  - {{ key: bot_token, label: "Bot token", type: secret, description: "Platform bot token. Use Test connection to verify." }}
-  - {{ key: admin_ids, label: "Admin user IDs", type: string_list, description: "User IDs allowed to message the bot (one per line). Empty = anyone." }}
-"""
-
-_COMMS_INIT_STUB = '''"""{name} — a communication plugin (scaffolded by plugin-devkit, ADR 0029).
-
-Implement the transport (connect / receive / send); the shared wirer handles
-admin-gating, per-conversation threads, agent invoke, reply-chunking, lifecycle,
-and the Test route. Reference: plugins/telegram. Guide:
-docs/guides/communication-plugins.md.
-"""
-
-from __future__ import annotations
-
-from graph.plugins.chat_surface import InboundMessage, register_chat_surface
-
-
-class {cls}Adapter:
-    id = "{id}"
-    chunk_limit = 4000  # your platform's message-length cap (0 = no chunking)
-
-    def configured(self, cfg) -> bool:
-        return bool((cfg.get("bot_token") or "").strip())
-
-    async def validate(self, cfg):
-        """Verify the token (the Test button). Return (ok, identity|None, error|None)."""
-        token = (cfg.get("bot_token") or "").strip()
-        if not token:
-            return (False, None, "No bot token set.")
-        # TODO: call your platform's auth/me endpoint and return its identity.
-        return (True, None, None)
-
-    async def run(self, handle, *, cfg, host):
-        """Connect, then loop. For each inbound message:
-            async def reply(text): ...send it back...
-            await handle(InboundMessage(text=..., user_id=..., channel_id=..., reply=reply))
-        Runs until cancelled."""
-        raise NotImplementedError("Implement {cls}Adapter.run — see plugins/telegram.")
-
-
-def register(registry):
-    register_chat_surface(registry, {cls}Adapter())
-'''
+        ok, msgs = _apply_settings_changes(
+            config={"plugins": {"enabled": enabled, "disabled": disabled}}
+        )
+        return (ok, "enabled + loaded live") if ok else (False, "; ".join(msgs) or "reload failed")
+    except Exception as e:  # noqa: BLE001 — enable is best-effort; the skeleton still landed
+        return (False, f"auto-enable failed: {e}")
 
 
 def _build_scaffold_tool(config: dict | None):
     """Closes over the plugin's config so the tool knows where to write."""
+    target_dir = (config or {}).get("target_dir") or None
 
     @tool
     def scaffold_plugin(
@@ -199,93 +70,126 @@ def _build_scaffold_tool(config: dict | None):
         with_skill: bool = False,
         with_workflow: bool = False,
         with_comms: bool = False,
+        enable: bool = True,
     ) -> str:
-        """Scaffold a new protoAgent plugin SKELETON on disk (manifest + register()
-        + optional view/skill/workflow stubs), ready to fill in and enable.
+        """Scaffold a new protoAgent plugin SKELETON on disk AND enable it live —
+        so you can build a plugin and test it in the SAME session, no restart.
 
-        Set ``with_comms=True`` for a **communication plugin** (a chat integration —
-        Discord/Slack/Telegram-style): it writes a `ChatAdapter` skeleton on the
-        shared wirer (ADR 0029) instead of the default tool plugin, so you only fill
-        in connect/receive/send. See the communication-plugins guide.
+        Writes the manifest + ``register()`` + optional view/skill/workflow stubs,
+        then (``enable=True``, the default) turns it on and hot-reloads the agent:
+        its tools/views are live on your NEXT turn. Iterate by editing the plugin's
+        ``__init__.py`` and calling ``reload_plugins`` to pick up the change live.
 
-        Writes into the live plugins dir (or the configured target_dir). Does NOT
-        enable it or run any code — review, fill in the logic, then add the id to
-        plugins.enabled and restart. Returns the path + next steps. Use this when
-        asked to create/build/scaffold a plugin; see the building-plugins skill for
-        the contract.
+        Set ``with_comms=True`` for a **communication plugin** (Discord/Slack/Telegram-
+        style): it writes a ``ChatAdapter`` skeleton (ADR 0029) — you fill in
+        connect/receive/send, then enable it from Settings (it needs a token), so
+        comms plugins are NOT auto-enabled here.
+
+        Use this when asked to create/build/scaffold a plugin; see the building-plugins
+        skill for the contract.
         """
-        pid = _slug(name)
-        id_us = pid.replace("-", "_")
-        root = _target_root(config)
-        target = root / pid
-        if target.exists():
-            return f"✗ {pid!r} already exists at {target} — pick another name or remove it first."
-        (target).mkdir(parents=True)
-
-        # Communication plugin (ADR 0029) — a ChatAdapter, different shape from the
-        # default tool plugin; the tool/view stubs don't apply.
-        if with_comms:
-            cls = "".join(w[:1].upper() + w[1:] for w in re.split(r"[-_ ]+", name) if w) or id_us.title()
-            (target / "protoagent.plugin.yaml").write_text(
-                _COMMS_MANIFEST_STUB.format(id=pid, name=name, summary=summary)
+        try:
+            res = scaffold.scaffold_plugin(
+                name, summary=summary, with_tool=with_tool, with_view=with_view,
+                with_skill=with_skill, with_workflow=with_workflow, with_comms=with_comms,
+                target_dir=target_dir,
             )
-            (target / "__init__.py").write_text(
-                _COMMS_INIT_STUB.format(id=pid, name=name, cls=cls)
+        except FileExistsError as e:
+            return f"✗ {scaffold.slug(name)!r} already exists at {e} — pick another name or remove it first."
+
+        _emit_scaffolded(res.id, res.kind)
+        kind_label = "communication plugin" if res.kind == "comms" else res.kind
+        lines = [f"✓ scaffolded {kind_label} {res.id!r} at {res.path}", f"  wrote: {', '.join(res.made)}"]
+
+        if res.kind == "comms":
+            cls = scaffold._class_name(name, res.id.replace("-", "_"))
+            lines.append(
+                f"  next: implement {cls}Adapter.run/validate (see plugins/telegram), then enable it\n"
+                f"        from Settings (it needs a bot token). Guide: docs/guides/communication-plugins.md"
             )
-            made = ["protoagent.plugin.yaml", "__init__.py (ChatAdapter)"]
-            if with_skill:
-                sk = target / "skills" / f"{pid}-skill"
-                sk.mkdir(parents=True)
-                (sk / "SKILL.md").write_text(_SKILL_STUB.format(id=pid, name=name))
-                made.append("skills/")
-            _emit_scaffolded(pid, "comms")
-            return (
-                f"✓ scaffolded communication plugin {pid!r} at {target}\n"
-                f"  wrote: {', '.join(made)}\n"
-                f"  next: implement {cls}Adapter.run/validate (see plugins/telegram), then enable —\n"
-                f"        add '{pid}' to plugins.enabled and restart.\n"
-                f"  (see docs/guides/communication-plugins.md)"
-            )
+            return "\n".join(lines)
 
-        views_block = (
-            f"views:\n  - {{ id: main, label: \"{name}\", icon: Boxes, path: /api/plugins/{pid}/view }}\n"
-            if with_view else ""
-        )
-        (target / "protoagent.plugin.yaml").write_text(
-            _MANIFEST_STUB.format(id=pid, name=name, summary=summary, id_us=id_us, views_block=views_block)
-        )
-
-        registrations = ""
-        if with_tool:
-            registrations += _TOOL_STUB.format(id=pid, id_us=id_us)
-        if with_view:
-            registrations += _VIEW_STUB.format(id=pid, name=name)
-        if not registrations.strip():
-            registrations = "    pass  # add registry.register_* calls here\n"
-        (target / "__init__.py").write_text(
-            _INIT_STUB.format(name=name, view_import="", registrations=registrations, id_us=id_us)
-        )
-
-        made = ["protoagent.plugin.yaml", "__init__.py"]
-        if with_skill:
-            sk = target / "skills" / f"{pid}-skill"
-            sk.mkdir(parents=True)
-            (sk / "SKILL.md").write_text(_SKILL_STUB.format(id=pid, name=name))
-            made.append("skills/")
-        if with_workflow:
-            (target / "workflows").mkdir()
-            (target / "workflows" / f"{pid}.yaml").write_text(_WORKFLOW_STUB.format(id=pid))
-            made.append("workflows/")
-
-        _emit_scaffolded(pid, "plugin")
-        return (
-            f"✓ scaffolded plugin {pid!r} at {target}\n"
-            f"  wrote: {', '.join(made)}\n"
-            f"  next: fill in the logic, then enable — add '{pid}' to plugins.enabled and restart.\n"
-            f"  (see the building-plugins skill for the full contract)"
-        )
+        if enable:
+            ok, detail = _live_enable(res.id)
+            if ok:
+                hello = f"{res.id.replace('-', '_')}_hello" if with_tool else "its tools"
+                lines.append(f"  ✓ {detail} — call {hello} on your NEXT turn to test it (no restart).")
+                lines.append(f"  iterate: edit {res.path}/__init__.py, then call reload_plugins to go live.")
+            else:
+                lines.append(f"  ⚠ scaffolded but not auto-enabled ({detail}) — call enable_plugin({res.id!r}).")
+        else:
+            lines.append(f"  next: fill in the logic, then call enable_plugin({res.id!r}) to load it live.")
+        lines.append("  (see the building-plugins skill for the full contract)")
+        return "\n".join(lines)
 
     return scaffold_plugin
+
+
+def _build_scaffold_bundle_tool(config: dict | None):
+    target_dir = (config or {}).get("target_dir") or None
+
+    @tool
+    def scaffold_bundle(
+        name: str,
+        summary: str = "A protoAgent plugin bundle.",
+        members: list[dict] | None = None,
+        enabled: list[str] | None = None,
+    ) -> str:
+        """Scaffold a plugin BUNDLE (ADR 0040) — a ``protoagent.bundle.yaml`` that
+        names a set of plugins to install + enable together (like the PM stack).
+
+        ``members`` is a list of ``{id, url, ref}`` (a git plugin) or
+        ``{id, builtin: true}`` (one that ships with protoAgent); omit it for a
+        REPLACE_ME template. ``enabled`` defaults to every member.
+
+        A bundle is a reference manifest (no code) — it's not enabled live like a
+        plugin. Commit/push it, then install the whole stack with
+        ``plugin install <bundle-repo-url>``.
+        """
+        try:
+            res = scaffold.scaffold_bundle(
+                name, summary=summary, members=members, enabled=enabled, target_dir=target_dir,
+            )
+        except FileExistsError as e:
+            return f"✗ {scaffold.slug(name)!r} already exists at {e} — pick another name or remove it first."
+        _emit_scaffolded(res.id, res.kind)
+        return (
+            f"✓ scaffolded bundle {res.id!r} at {res.path}\n"
+            f"  wrote: {', '.join(res.made)}\n"
+            f"  next: fill in the member plugins (git url + ref, or builtin: true), then commit/push it\n"
+            f"        and install the stack: `plugin install <this-repo-url>` (ADR 0040)."
+        )
+
+    return scaffold_bundle
+
+
+@tool
+def enable_plugin(plugin_id: str) -> str:
+    """Enable an already-present plugin (one you scaffolded or installed) by id and
+    hot-reload it live — no restart. Use when a plugin is on disk but turned off."""
+    ok, detail = _live_enable(plugin_id)
+    return f"✓ {plugin_id}: {detail}" if ok else f"✗ {plugin_id}: {detail}"
+
+
+@tool
+def reload_plugins() -> str:
+    """Hot-reload all enabled plugins — re-exec their code so edits you made to a
+    plugin's ``__init__.py`` take effect WITHOUT a restart. Use after editing a
+    plugin you're iterating on; the new tools/views are live on your NEXT turn."""
+    try:
+        from runtime.state import STATE
+
+        if getattr(STATE, "graph", None) is None:
+            return "✗ no live agent to reload (run inside the server)."
+        from server.agent_init import _apply_settings_changes
+
+        ok, msgs = _apply_settings_changes()  # bare call = pure reload (picks up file edits)
+        return (
+            "✓ reloaded — your plugin edits are live on the next turn."
+            if ok else f"✗ reload failed: {'; '.join(msgs)}"
+        )
+    except Exception as e:  # noqa: BLE001
+        return f"✗ reload failed: {e}"
 
 
 def _plugin_architect() -> SubagentConfig:
@@ -333,13 +237,24 @@ def _build_guide_router():
           <h1>Plugin Devkit</h1>
           <p>This plugin gives the agent what it needs to build plugins — and is itself
           the full-bundle example. Ask the agent: <em>"build a plugin that …"</em>.</p>
-          <h2>It contributes</h2>
+          <h2>Build it live (no restart)</h2>
           <ul>
-            <li><code>scaffold_plugin</code> tool — writes a new plugin skeleton</li>
+            <li><code>scaffold_plugin</code> — writes a skeleton <strong>and enables it</strong>; its
+                tools/view are live on the next turn</li>
+            <li>edit the plugin's <code>__init__.py</code>, then <code>reload_plugins</code> — your change goes live</li>
+            <li><code>enable_plugin</code> — turn on a plugin that's on disk but off</li>
+            <li><code>scaffold_bundle</code> — a <code>protoagent.bundle.yaml</code> stack (ADR 0040)</li>
+          </ul>
+          <h2>Also contributes</h2>
+          <ul>
             <li><code>plugin-architect</code> subagent + <code>design-plugin</code> workflow — request → spec</li>
             <li>the <code>building-plugins</code> skill — the authoring contract</li>
-            <li>this console view + config/settings</li>
-            <li>emits <code>plugin-devkit.scaffolded</code> on the bus when it scaffolds (ADR 0039)</li>
+            <li>this console view + config/settings; emits <code>plugin-devkit.scaffolded</code> (ADR 0039)</li>
+          </ul>
+          <h2>From the CLI</h2>
+          <ul>
+            <li><code>python -m server plugin new "My Plugin" --view --skill</code> — scaffold from the shell</li>
+            <li><code>python -m server plugin new-bundle "My Stack" --member id=url@ref --builtin delegates</code></li>
           </ul>
           <h2>The plugin contract</h2>
           <ul>
@@ -353,8 +268,6 @@ def _build_guide_router():
           <h2>Events (ADR 0039)</h2>
           <ul>
             <li><code>registry.emit("x", data)</code> → <code>&lt;id&gt;.x</code> on the bus · <code>registry.on("other.*", fn)</code> to react</li>
-            <li>declare <code>emits:</code> / <code>subscribes:</code> in the manifest (discovery)</li>
-            <li>an event under <code>&lt;id&gt;.*</code> lights your plugin's rail icon (notification dot)</li>
             <li>plugins coordinate <em>only</em> via the bus — never import each other</li>
           </ul>
           <p>Fork components (compiled in, not sandboxed) use the build-time <code>src/ext</code> seam (ADR 0038).</p>
@@ -368,9 +281,12 @@ def _build_guide_router():
 def register(registry) -> None:
     """Every contribution type, in one plugin (the point of the devkit)."""
     global _REGISTRY
-    _REGISTRY = registry                                            # for the bus emit (ADR 0039)
-    registry.register_tool(_build_scaffold_tool(registry.config))  # a tool
-    registry.register_subagent(_plugin_architect())                # a subagent
+    _REGISTRY = registry                                              # for the bus emit (ADR 0039)
+    registry.register_tool(_build_scaffold_tool(registry.config))    # scaffold a plugin (+ enable live)
+    registry.register_tool(_build_scaffold_bundle_tool(registry.config))  # scaffold a bundle
+    registry.register_tool(enable_plugin)                            # turn on an on-disk plugin live
+    registry.register_tool(reload_plugins)                           # pick up edits live
+    registry.register_subagent(_plugin_architect())                  # a subagent
     # Gated under /api/plugins/plugin-devkit (ADR 0026) — the console iframes /guide.
     registry.register_router(_build_guide_router(), prefix="/api/plugins/plugin-devkit")
     # skills/ + workflows/ auto-discover — no call needed (ADR 0027).

--- a/plugins/plugin-devkit/skills/building-plugins/SKILL.md
+++ b/plugins/plugin-devkit/skills/building-plugins/SKILL.md
@@ -100,12 +100,22 @@ public chrome — its data calls are the gated part). The console iframes the pa
 `building-react-plugin-views`. An event under `<id>.*` lights your plugin's rail icon (a notification
 dot) until the user opens it.
 
-## 5. Test it
-- Enable it: `plugins: { enabled: [my-plugin] }`, restart, then
-  `GET /api/runtime/status` → the plugin shows `loaded: true` with its tools/views.
+## 5. Test it — live, no restart
+You don't need to restart to try a plugin you built. With **plugin-devkit** enabled:
+- `scaffold_plugin(...)` already **enabled** it (the default) — its tools/view are
+  live on your **next turn**. Call its `<id>_hello` to confirm.
+- Iterate: edit the plugin's `__init__.py`, then call **`reload_plugins`** — the
+  loader re-execs the file, so your change is live next turn (no restart).
+- Built a plugin some other way (CLI / by hand)? Call **`enable_plugin("<id>")`** to
+  turn it on + hot-reload, or toggle it in the console Plugins panel (#822).
+- `GET /api/runtime/status` → the plugin shows `loaded: true` with its tools/views.
 - Unit-test the tool/registration like `tests/test_plugins.py` does.
 - If it declares `requires_pip`, `python -m server plugin install-deps my-plugin`
   first (a missing dep gives a clear error on enable).
+
+From the shell (no agent): `python -m server plugin new "My Plugin" --view --skill`
+scaffolds the skeleton; `plugin new-bundle "My Stack" --member id=url@ref --builtin delegates`
+scaffolds an ADR-0040 bundle.
 
 ## 6. Distribute (optional)
 Publish as a git repo; others install by URL:
@@ -121,7 +131,10 @@ Remove cleanly with `plugin uninstall <id>` (`--purge` also drops config + secre
   literal, not an f-string (`__doc__` is None for f-string "docstrings").
 - Discovery reads the manifest as **data**; code runs only on **enable**. Keep the
   manifest importable-free.
-- Adding routes/surfaces/views needs a **restart** (they mount once at init); the
-  rail picks up a new view from `runtime-status` without a console rebuild.
+- **Enabling** a plugin is fully live: tools/subagents/middleware/MCP rebuild with
+  the graph and its router (which serves any view) **hot-mounts** (#822) — no restart.
+  Only **disabling** leaves a stale route behind (FastAPI can't unmount), so that path
+  alone wants a restart. The rail picks up a new view from `runtime-status` without a
+  console rebuild.
 - Don't edit core files to wire a plugin in — if you need to, you're missing a
   seam; file it (see the operator-fork contract) instead of re-porting each sync.

--- a/tests/test_plugin_devkit.py
+++ b/tests/test_plugin_devkit.py
@@ -47,7 +47,7 @@ def test_scaffold_produces_a_loadable_plugin(monkeypatch, tmp_path):
     scaffold = mod._build_scaffold_tool({"target_dir": str(out_root)})
     msg = scaffold.invoke(
         {"name": "My Cool Plugin", "summary": "demo", "with_view": True,
-         "with_skill": True, "with_workflow": True}
+         "with_skill": True, "with_workflow": True, "enable": False}
     )
     assert "scaffolded" in msg
     pdir = out_root / "my-cool-plugin"
@@ -67,8 +67,8 @@ def test_scaffold_refuses_overwrite(tmp_path):
     mod = _load_devkit_module(tmp_path)
     out_root = tmp_path / "out"; out_root.mkdir()
     scaffold = mod._build_scaffold_tool({"target_dir": str(out_root)})
-    scaffold.invoke({"name": "dup"})
-    assert "already exists" in scaffold.invoke({"name": "dup"})
+    scaffold.invoke({"name": "dup", "enable": False})
+    assert "already exists" in scaffold.invoke({"name": "dup", "enable": False})
 
 
 def test_scaffold_communication_plugin(monkeypatch, tmp_path):
@@ -88,3 +88,43 @@ def test_scaffold_communication_plugin(monkeypatch, tmp_path):
     res = load_plugins(_cfg(plugins_enabled=["my-chat"]))
     meta = next(m for m in res.meta if m["id"] == "my-chat")
     assert meta["loaded"], meta.get("error")
+
+
+def test_scaffold_enable_hot_reloads_when_live(monkeypatch, tmp_path):
+    """enable=True (the default) drives the live hot-reload path so a freshly
+    scaffolded plugin loads without a restart — it adds the new id to
+    plugins.enabled (preserving the rest) and reloads via _apply_settings_changes."""
+    mod = _load_devkit_module(tmp_path)
+    out_root = tmp_path / "out"; out_root.mkdir()
+
+    import server.agent_init as agent_init
+    from runtime.state import STATE
+
+    class _Cfg:
+        plugins_enabled = ["existing"]
+        plugins_disabled = []
+
+    captured: dict = {}
+
+    def _fake_apply(config=None, soul=None, layer="agent"):
+        captured["config"] = config
+        return (True, [])
+
+    monkeypatch.setattr(STATE, "graph", object(), raising=False)
+    monkeypatch.setattr(STATE, "graph_config", _Cfg(), raising=False)
+    monkeypatch.setattr(agent_init, "_apply_settings_changes", _fake_apply)
+
+    scaffold = mod._build_scaffold_tool({"target_dir": str(out_root)})
+    msg = scaffold.invoke({"name": "Live One"})  # enable defaults True
+    assert "enabled + loaded live" in msg
+    assert captured["config"]["plugins"]["enabled"] == ["existing", "live-one"]
+
+
+def test_enable_plugin_tool_noop_without_graph(monkeypatch):
+    """enable_plugin / reload_plugins degrade gracefully when there's no live agent."""
+    mod = _load_devkit_module(None)
+    from runtime.state import STATE
+
+    monkeypatch.setattr(STATE, "graph", None, raising=False)
+    assert "not running" in mod.enable_plugin.invoke({"plugin_id": "whatever"})
+    assert "no live agent" in mod.reload_plugins.invoke({})

--- a/tests/test_plugin_scaffold.py
+++ b/tests/test_plugin_scaffold.py
@@ -1,0 +1,105 @@
+"""Core plugin/bundle scaffolding (graph.plugins.scaffold) + the `plugin new`
+CLI — the writers shared by the devkit tool and the shell (ADR 0027 / 0040)."""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.config import LangGraphConfig
+from graph.plugins import installer, scaffold
+from graph.plugins import loader as plugin_loader
+from graph.plugins.cli import run_plugin_cli
+from graph.plugins.loader import load_plugins
+
+
+def _cfg(**kw):
+    return LangGraphConfig(**kw)
+
+
+def test_slug():
+    assert scaffold.slug("My Cool Plugin!") == "my-cool-plugin"
+    assert scaffold.slug("") == "plugin"
+
+
+def test_scaffold_plugin_is_loadable(monkeypatch, tmp_path):
+    res = scaffold.scaffold_plugin(
+        "My Cool Plugin", summary="demo", with_view=True, with_skill=True,
+        with_workflow=True, target_dir=str(tmp_path),
+    )
+    assert res.id == "my-cool-plugin" and res.kind == "plugin"
+    pdir = tmp_path / "my-cool-plugin"
+    assert (pdir / "protoagent.plugin.yaml").exists()
+    assert (pdir / "__init__.py").exists()
+    assert (pdir / "skills").is_dir() and (pdir / "workflows").is_dir()
+
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [tmp_path])
+    out = load_plugins(_cfg(plugins_enabled=["my-cool-plugin"]))
+    meta = next(m for m in out.meta if m["id"] == "my-cool-plugin")
+    assert meta["loaded"], meta.get("error")
+    assert "my_cool_plugin_hello" in meta["tools"]
+    assert meta["routers"] >= 1  # the view router
+
+
+def test_scaffold_plugin_refuses_overwrite(tmp_path):
+    scaffold.scaffold_plugin("dup", target_dir=str(tmp_path))
+    with pytest.raises(FileExistsError):
+        scaffold.scaffold_plugin("dup", target_dir=str(tmp_path))
+
+
+def test_scaffold_comms_plugin(tmp_path):
+    res = scaffold.scaffold_plugin("My Chat", with_comms=True, target_dir=str(tmp_path))
+    assert res.kind == "comms"
+    init = (tmp_path / "my-chat" / "__init__.py").read_text()
+    assert "register_chat_surface" in init and "class MyChatAdapter" in init
+
+
+def test_scaffold_bundle_round_trips_through_loader(tmp_path):
+    res = scaffold.scaffold_bundle(
+        "Project Manager Stack", summary="board + browser",
+        members=[
+            {"id": "delegates", "builtin": True},
+            {"id": "project_board", "url": "https://github.com/you/pb", "ref": "v0.1.0"},
+        ],
+        target_dir=str(tmp_path),
+    )
+    assert res.kind == "bundle" and res.id == "project-manager-stack"
+    bdir = tmp_path / "project-manager-stack"
+    bundle = installer.load_bundle(bdir)
+    assert bundle is not None
+    assert bundle["id"] == "project-manager-stack"
+    ids = {p["id"] for p in bundle["plugins"]}
+    assert ids == {"delegates", "project_board"}
+    assert any(p.get("builtin") for p in bundle["plugins"])
+    assert bundle["enabled"] == ["delegates", "project_board"]
+
+
+def test_scaffold_bundle_placeholder_is_valid_yaml(tmp_path):
+    """A member-less bundle still parses (a REPLACE_ME template, not broken YAML)."""
+    scaffold.scaffold_bundle("Empty Stack", target_dir=str(tmp_path))
+    bundle = installer.load_bundle(tmp_path / "empty-stack")
+    assert bundle is not None and bundle["enabled"] == ["REPLACE_ME"]
+
+
+def test_cli_new_scaffolds(tmp_path, capsys):
+    rc = run_plugin_cli(["new", "My Plugin", "--dir", str(tmp_path), "--view"])
+    assert rc == 0
+    assert (tmp_path / "my-plugin" / "__init__.py").exists()
+    assert "scaffolded plugin 'my-plugin'" in capsys.readouterr().out
+
+
+def test_cli_new_bundle_scaffolds(tmp_path, capsys):
+    rc = run_plugin_cli([
+        "new-bundle", "My Stack", "--dir", str(tmp_path),
+        "--member", "board=https://github.com/you/board@v1.0.0",
+        "--builtin", "delegates",
+    ])
+    assert rc == 0
+    bundle = installer.load_bundle(tmp_path / "my-stack")
+    assert {p["id"] for p in bundle["plugins"]} == {"board", "delegates"}
+    assert "scaffolded bundle 'my-stack'" in capsys.readouterr().out
+
+
+def test_cli_new_rejects_bad_member(tmp_path, capsys):
+    rc = run_plugin_cli(["new-bundle", "Bad", "--dir", str(tmp_path), "--member", "noequals"])
+    assert rc == 1
+    assert "bad --member" in capsys.readouterr().err


### PR DESCRIPTION
**The ask:** let an agent using the devkit *actually set up and enable* a plugin so it can build one and test it **live, without restarting** — and give us a CLI to scaffold a plugin (and a bundle) quickly.

## Audit (what was missing)
The devkit already had `scaffold_plugin`, `plugin-architect`, `design-plugin`, the `building-plugins` skill, and a `/guide` view. Three gaps vs. "scaffold → enable → test live":
1. **No live-enable** — `scaffold_plugin` ended with *"add the id to `plugins.enabled` and **restart**."* The agent couldn't load + test what it just built.
2. **No CLI scaffold** — only the agent tool. No `plugin new`.
3. **No bundle scaffold** — nothing wrote a `protoagent.bundle.yaml` (the PM-stack shape).

## What this does
**Closes the build→test loop (no restart):**
- `scaffold_plugin(...)` now **enables + hot-reloads** what it scaffolded — the same path the console enable toggle uses (#822: tools/subagents/middleware/MCP rebuild with the graph, the plugin's router hot-mounts). The new plugin's tools/view are live on the agent's **next turn**.
- **`reload_plugins`** — re-execs enabled plugins so an edit to a plugin's `__init__.py` goes live (the loader already does `module_from_spec` + `exec_module` from disk on every reload). This is the *iterate* half.
- **`enable_plugin(id)`** — turn on any on-disk plugin (scaffolded or installed) live.
- Communication plugins (ADR 0029) still enable from Settings (they need a token), so they're deliberately **not** auto-enabled.

**A CLI for the shell** (works even with the devkit disabled):
- `python -m server plugin new "My Plugin" --view --skill --workflow --comms`
- `python -m server plugin new-bundle "My Stack" --member board=https://…/board@v1 --builtin delegates`

## Structure
The scaffold writers moved to **core** (`graph/plugins/scaffold.py`) so the CLI doesn't depend on a plugin being enabled. The devkit tool is now a thin wrapper that adds the live-enable + the `plugin-devkit.scaffolded` bus emit. The live-enable gates on `STATE.graph` so it cleanly no-ops in the CLI/tests.

## Tests (`182 passed`, plugin area)
- `tests/test_plugin_scaffold.py` (new): pure writers produce a loadable plugin; bundle **round-trips through `installer.load_bundle`** (incl. the member-less REPLACE_ME template staying valid YAML); the `plugin new` / `new-bundle` CLI; bad-member rejection. Caught two real bugs pre-merge: member ids were being slugified (`project_board`→`project-board`) and the placeholder used `{{ }}` as a `.format()` *argument* (stayed doubled → invalid YAML).
- `tests/test_plugin_devkit.py`: a live-enable test (mocks the running graph, asserts it appends to `plugins.enabled` preserving the rest + calls `_apply_settings_changes`) + graceful-noop-without-a-graph.

## Docs
`building-plugins` skill (the "Test it — live, no restart" loop + the enable-hot-mounts correction + the CLI), the plugin-registry guide callout, the `/guide` view, CHANGELOG.

## Note on live verification
The unit tests mock `_apply_settings_changes`. The mid-turn reload is safe because the devkit tools are **sync** (run off the event loop in a worker thread) and the path is build-then-commit — the running turn keeps the old graph, the next turn gets the new one — the same call `#899`'s install-auto-enable already makes from a route. Worth a quick live confirm on a running instance (scaffold → call the new `*_hello` next turn).

🤖 Generated with [Claude Code](https://claude.com/claude-code)