### PR TITLE
fix(ui): AppShell resize feel — drag either panel fully closed + smooth over iframes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Resizing panels felt sloppy and "wouldn't close right" over plugin views.** The DS
+  AppShell's divider drag tracks the pointer on `window` listeners, so a plugin-view
+  **iframe** captured `pointermove`/`pointerup` the instant the pointer crossed it — the
+  resize stuttered and the pointer-up that commits a collapse was lost. Interim app-CSS
+  guard (`.pl-appshell-frame--dragging iframe { pointer-events: none }`) restores smooth
+  tracking + collapse now; the proper DS fix (a drag overlay that also carries the resize
+  cursor over iframes) is protoContent#212 and lands when we bump `@protolabsai/ui`. The
+  DS stories felt smooth only because they used plain `<div>`s, never iframes.
 - **Swapping between fleet agents wiped the chat view.** The tenant guard (which
   clears persisted chat when the backend behind an origin re-keys) was reading the
   *focused agent's* `instance_uid` (slug-routed runtime status). Every fleet swap

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1592,6 +1592,14 @@ textarea {
 .plugin-view-frame { width: 100%; height: 100%; border: 0; background: var(--bg); display: block; }
 .plugin-view-state { display: flex; align-items: center; gap: 8px; padding: 24px; color: var(--fg-muted); font-size: 13px; }
 
+/* INTERIM (until we bump @protolabsai/ui past protoContent#212): the DS AppShell's
+   divider drag tracks the pointer on window listeners, so a plugin-view iframe captures
+   the pointer mid-drag — the resize stutters and the pointer-up that commits a collapse
+   is swallowed (the panel "doesn't close right"). Make iframes pointer-transparent while
+   dragging so the window keeps the gesture. The DS fix adds a drag overlay (also fixes
+   the cursor over iframes); drop this rule once we're on the release that carries it. */
+.pl-appshell-frame--dragging iframe { pointer-events: none; }
+
 /* Plugins panel (ADR 0027, .plugin-install-* / .plugin-list / .plugin-row-main / -title /
    .plugin-ver/.plugin-state/.plugin-desc/.plugin-meta/.plugin-review/.plugin-enable-hint
    + .btn-icon.danger:hover) — moved to src/settings/plugins.css (#832). The bare


### PR DESCRIPTION
Two fixes to how the dual-panel AppShell *feels* to resize. Both audited against the DS source in `~/dev/protoContent` — the DS component is correct; these are app-side issues plus one upstream gap.

## 1. Either panel can now be dragged fully closed (permanent, app fix)
`uiStore.clampWidth` floored the **live** resize value to `[280, 720]`. So mid-drag:
- the **right** column couldn't shrink below 280 → *"needs to get smaller before it closes"*, and
- pinned at 720, the divider stopped before the **left** column could reach its collapse zone → *"we stop the left one too far."*

The DS AppShell already bounds the live value to `[0, span]` and, on pointer-up, either **collapses** the side (dragged past half its min) or **settles** it to a valid open width (`clampOpen`). So the app must *not* floor the live value — it only needs to guard against negatives:
```ts
const clampWidth = (w) => Math.max(0, Math.round(w));
```
Now both sides track the pointer to the edge and snap closed. Bonus: reopen-from-edge no longer jumps straight to 280px (the old floor was eating the "grow from the edge under the pointer" reveal).

## 2. Smooth resize over plugin iframes (interim for protoContent#212)
The divider gesture runs on `window` pointer listeners, so a plugin-view **iframe** captured `pointermove`/`pointerup` the instant the pointer crossed it — stuttery drag + the pointer-up that commits a collapse was lost. Interim app-CSS guard (`.pl-appshell-frame--dragging iframe { pointer-events: none }`) keeps the window in control now; the proper DS fix (a drag overlay that also carries the resize cursor over iframes) is **protoContent#212** and the marker comment says to drop this rule when we bump `@protolabsai/ui` past it.

Felt smooth in Storybook because the DS stories used plain `<div>`s and never the full `[0, span]` range — both gaps are addressed (the iframe story is added in #212).

Verified: `check-css-comments` guard (#888) green; `uiStore.ts` typechecks clean (the tsc noise is pre-existing implicit-`any` in unrelated workflow files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)