### PR TITLE
fix(chat): denied/failed tool card shows the red X, not green

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A declined or failed tool now shows the red X on its card, not a green "done".**
+  A denied `run_command` returned a normal string, so the card closed *green* with the
+  decline text — the opposite of how a denial should read. `run_command` now raises on
+  deny (and on execution error), so the ToolNode stamps the result `status="error"`; that
+  flows through as a `phase="failed"` tool-call DataPart and the card renders the X (the
+  protocol already supported the failed phase — nothing new on the wire). Enforcement-
+  blocked tools get the same treatment. With the card already sitting yellow/running
+  during the approval pause and turning green on approve, a gated action now reads exactly
+  as intended: **yellow while you decide → green on approve, red X on deny** — no extra
+  "approved" bubble (#904).
 - **Approving a gated action no longer dumps an "approved" bubble into the chat.** When
   the agent gated a command behind an Approve/Deny prompt, the resume posted the literal
   word `approved`/`denied` as a *user message* — noise that cluttered the transcript and

--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -436,12 +436,17 @@ def _tool_call_part(event_type: str, payload: Any) -> Part | None:
     plain text status part so text-only consumers still see progress.
     """
     if isinstance(payload, dict):
-        phase = "started" if event_type == "tool_start" else "completed"
+        errored = event_type == "tool_end" and bool(payload.get("error"))
+        # A failed tool end carries phase="failed" (+ the error text) so the card
+        # renders the X glyph instead of the green "done".
+        phase = "started" if event_type == "tool_start" else ("failed" if errored else "completed")
         kwargs: dict[str, Any] = {}
         if event_type == "tool_start" and payload.get("input") is not None:
             kwargs["args"] = payload.get("input")
         if event_type == "tool_end" and payload.get("output") is not None:
             kwargs["result"] = payload.get("output")
+        if errored:
+            kwargs["error"] = str(payload.get("output") or "tool failed")
         emit = pa.emit_tool_call(
             str(payload.get("id", "")),
             str(payload.get("name", "")),

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -397,14 +397,16 @@ function ChatSessionSlot({
                 if (idx >= 0) calls[idx] = { ...calls[idx], ...card };
                 else calls.push(card);
               } else {
-                // end — flip the matching card to done (or create one if the
-                // start frame was missed). Stamp elapsed when we saw the start.
+                // end — flip the matching card to done/error (or create one if the
+                // start frame was missed). A failed end (e.g. a declined run_command)
+                // closes the card as an error (X). Stamp elapsed when we saw the start.
                 const startedAt = idx >= 0 ? calls[idx].startedAt : undefined;
                 const durationMs = startedAt !== undefined ? now - startedAt : undefined;
+                const endStatus = evt.error ? "error" : "done";
                 if (idx >= 0) {
-                  calls[idx] = { ...calls[idx], output: evt.output, status: "done", durationMs };
+                  calls[idx] = { ...calls[idx], output: evt.output, status: endStatus, durationMs };
                 } else {
-                  calls.push({ id: evt.id, name: evt.name, output: evt.output, status: "done" });
+                  calls.push({ id: evt.id, name: evt.name, output: evt.output, status: endStatus });
                 }
               }
               return { ...message, toolCalls: calls };

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -306,7 +306,7 @@ function dataByMime(parts: RawPart[] | undefined, mime: string): unknown {
  * single ever-overwriting card — the "only one tool at a time" symptom. */
 function toolEventFromParts(parts?: RawPart[]): ToolEvent | null {
   const d = dataByMime(parts, TOOL_CALL_MIME) as
-    | { toolCallId?: string; name?: string; phase?: string; args?: string; result?: string }
+    | { toolCallId?: string; name?: string; phase?: string; args?: string; result?: string; error?: string }
     | null;
   if (!d) return null;
   return {
@@ -314,7 +314,9 @@ function toolEventFromParts(parts?: RawPart[]): ToolEvent | null {
     name: d.name || "",
     phase: d.phase === "started" ? "start" : "end",
     input: d.args,
-    output: d.result,
+    // A "failed" end carries the error text in `error`; fall back to it for the body.
+    output: d.result ?? d.error,
+    error: d.phase === "failed" || Boolean(d.error),
   };
 }
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -299,6 +299,7 @@ export type ToolEvent = {
   phase: "start" | "end";
   input?: string;
   output?: string;
+  error?: boolean; // an "end" that failed (phase "failed" on the wire) → card shows the X
 };
 
 export type ChatMessage = {

--- a/graph/middleware/enforcement.py
+++ b/graph/middleware/enforcement.py
@@ -73,6 +73,7 @@ class EnforcementMiddleware(AgentMiddleware):
         return ToolMessage(
             content=f"Blocked by policy: {reason}",
             tool_call_id=request.tool_call.get("id", ""),
+            status="error",  # the chat card renders a policy block as a failure (X), not green
         )
 
     def wrap_tool_call(self, request, handler):

--- a/server/chat.py
+++ b/server/chat.py
@@ -201,11 +201,15 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
         elif kind == "on_tool_end":
             output = event.get("data", {}).get("output", "")
             # Close the card keyed by the tool_call id (the ToolMessage carries it);
-            # fall back to run_id/name for non-tool-message producers.
+            # fall back to run_id/name for non-tool-message producers. A ToolMessage
+            # the ToolNode stamped status="error" (a raised tool — a declined
+            # run_command, an execution error, an enforcement block) closes the card
+            # as a failure (X) instead of a green "done".
             yield ("tool_end", {
                 "id": getattr(output, "tool_call_id", None) or event.get("run_id") or name,
                 "name": name,
                 "output": _coerce_tool_output(output),
+                "error": getattr(output, "status", None) == "error",
             })
         elif kind == "on_chat_model_stream":
             chunk = event.get("data", {}).get("chunk")

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -354,6 +354,44 @@ async def test_tool_events_surface_as_tool_call_dataparts():
 
 
 @pytest.mark.asyncio
+async def test_errored_tool_end_surfaces_phase_failed():
+    """A tool_end flagged error → a phase=\"failed\" tool-call DataPart (the card
+    renders the X), carrying the error text. A declined run_command takes this path."""
+    import json
+
+    async def stream(text, ctx, *, resume=False, caller_trace=None, **kwargs):
+        yield ("tool_start", {"id": "t1", "name": "run_command", "input": {"command": "rm -rf /"}})
+        yield ("tool_end", {"id": "t1", "name": "run_command",
+                            "output": "Command declined by the operator — not run", "error": True})
+        yield ("done", "ok")
+
+    app = _build_app(stream)
+    payloads = []
+    async with httpx.AsyncClient(transport=httpx.ASGITransport(app=app), base_url="http://test", timeout=10) as c:
+        async with c.stream("POST", "/a2a", headers=A2A_HEADERS, json={
+            "jsonrpc": "2.0", "id": "s", "method": "SendStreamingMessage",
+            "params": {"message": {"messageId": "m", "role": "ROLE_USER", "parts": [{"text": "hi"}]}},
+        }) as resp:
+            async for line in resp.aiter_lines():
+                if not line.startswith("data:"):
+                    continue
+                frame = json.loads(line[5:].strip())
+                status = frame.get("result", {}).get("statusUpdate", {}).get("status", {})
+                msg = status.get("message")
+                if not msg:
+                    continue
+                for part in msg.get("parts", []):
+                    p = pa.parse_tool_call(part)
+                    if p is not None:
+                        payloads.append(p)
+
+    failed = next((p for p in payloads if p["phase"] == "failed"), None)
+    assert failed is not None, [p["phase"] for p in payloads]
+    assert failed["name"] == "run_command"
+    assert "declined" in (failed.get("error") or "")
+
+
+@pytest.mark.asyncio
 async def test_text_deltas_stream_as_incremental_artifact_frames():
     """Token-by-token: each `text` delta is forwarded as its own artifact-update
     (append) frame, so the console fills the bubble live instead of the whole

--- a/tests/test_fs_tools.py
+++ b/tests/test_fs_tools.py
@@ -133,6 +133,24 @@ def test_run_command_executes_in_project_cwd(workspace):
     assert "README.md" in out
 
 
+def test_run_command_declined_raises(workspace, monkeypatch):
+    """A declined approval RAISES (ToolException) rather than returning a string —
+    so the ToolNode stamps status="error" and the chat card shows the X, not a green
+    'done'. interrupt() is stubbed to the deny decision (no graph runtime needed)."""
+    import langgraph.types
+    from langchain_core.tools import ToolException
+
+    _, a, _ = workspace
+    monkeypatch.setattr(langgraph.types, "interrupt", lambda payload: "denied")
+    t = _tools(_Cfg(
+        filesystem_projects=[{"name": "a", "path": str(a)}],
+        filesystem_allow_run=True,
+        filesystem_run_requires_approval=True,
+    ))
+    with pytest.raises(ToolException):
+        asyncio.run(t["run_command"].ainvoke({"project": "a", "command": "ls"}))
+
+
 # ── config round-trip ──────────────────────────────────────────────────────────
 
 

--- a/tools/fs_tools.py
+++ b/tools/fs_tools.py
@@ -25,7 +25,7 @@ import shlex
 from dataclasses import dataclass
 from pathlib import Path
 
-from langchain_core.tools import tool
+from langchain_core.tools import ToolException, tool
 
 from tools.shell import run_command as _shell_run
 
@@ -277,10 +277,13 @@ def build_fs_tools(config) -> list:
                     "project": project,
                 })
                 if not _approved(decision):
-                    return f"Command not run — the operator declined: {command!r}"
+                    # Raise (not return) so the ToolNode stamps the ToolMessage
+                    # status="error": the chat card then renders the declined action
+                    # as a failure (red X) instead of a green "done" with decline text.
+                    raise ToolException(f"Command declined by the operator — not run: {command!r}")
             res = await _shell_run(argv, cwd=str(root), timeout=timeout)
             if res.error:
-                return f"Error: {res.error}"
+                raise ToolException(res.error)
             body = res.stdout or "(no output)"
             if res.stderr:
                 body += f"\n[stderr]\n{res.stderr}"


### PR DESCRIPTION
Finishes the approval/permissions tool-card behavior (the simple version — inline generative components parked for later).

## The target
A gated action should read: **yellow while you decide → green on approve, red X on deny** — no "approved" bubble.

Two of those already worked, and I verified why:
- **Yellow while pending** — the tool-call *start* frame comes from the model's streamed tool call (`server/chat.py`, `on_chat_model_stream`), which fires *before* the tool node runs the `interrupt()`. So the card is already `running`/yellow through the whole approval pause.
- **Green on approve** — the tool runs and closes `done`.
- **No bubble** — shipped in #904.

The one broken case was **deny**: `run_command` *returned a string* (`"Command not run — the operator declined"`), so the card closed **green/done** with the decline text — exactly backwards.

## The fix (no new wire protocol — `emit_tool_call` already supports `phase="failed"` + `error`)
- **`tools/fs_tools.py`** — `run_command` now **raises `ToolException`** on deny (and on execution error) instead of returning a string. The `create_agent`/`create_react_agent` ToolNode catches it (`handle_tool_errors` defaults on) and stamps the `ToolMessage` `status="error"`.
- **`server/chat.py`** — `on_tool_end` forwards `error = (ToolMessage.status == "error")` on the `tool_end` frame.
- **`a2a_impl/executor.py`** — `_tool_call_part` emits `phase="failed"` + `error=<text>` for a failed end.
- **`apps/web` (`api.ts` / `types.ts` / `ChatSurface.tsx`)** — a `failed`/`error` end maps to `ToolCall.status = "error"`, which the DS `ToolCard` already renders as the **X** glyph.
- **Bonus, consistent:** enforcement-middleware-**blocked** tools now also carry `status="error"` → same X (they were green before too).

## Tests
- `test_run_command_declined_raises` — a declined approval raises `ToolException` (stubs `interrupt` → "denied", no graph runtime needed).
- `test_errored_tool_end_surfaces_phase_failed` — an errored `tool_end` surfaces as a `phase="failed"` tool-call DataPart carrying the error text, observed over the real streaming endpoint.
- 59 backend tests in the touched files pass; `tsc` clean; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)