### PR TITLE
chore(ui): adopt @protolabsai/ui@0.26.2 + drop the AppShell iframe-drag interim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,11 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
-- **Adopt `@protolabsai/ui@0.26.1`** — picks up the AppShell drag fix (protoContent#212:
-  a transparent drag overlay during a divider/reopen gesture so the resize tracks smoothly
-  over plugin iframes and the `col-resize` cursor stays correct, plus the `WithIframePanels`
-  story). Removes the app-side interim guard from #903 (`.pl-appshell-frame--dragging iframe
-  { pointer-events: none }`) — the design system now owns that behavior.
+- **Adopt `@protolabsai/ui@0.26.2`** — picks up the AppShell iframe-drag fix
+  (protoContent #212 + #214): resizing a panel that hosts a plugin iframe now tracks
+  smoothly and collapses on release, via `.pl-appshell-frame--dragging iframe { pointer-events:
+  none }` (the window keeps the gesture over the iframe; the col-resize cursor is inherited by
+  the column behind it). 0.26.1 also tried a full-window drag overlay, but it covered the
+  divider handle and broke double-click-to-collapse — caught by our layout e2e — so 0.26.2
+  dropped it. Removes the app-side interim guard from #903; the design system now owns it.
 
 ### Fixed
 - **A declined or failed tool now shows the red X on its card, not a green "done".**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Adopt `@protolabsai/ui@0.26.1`** — picks up the AppShell drag fix (protoContent#212:
+  a transparent drag overlay during a divider/reopen gesture so the resize tracks smoothly
+  over plugin iframes and the `col-resize` cursor stays correct, plus the `WithIframePanels`
+  story). Removes the app-side interim guard from #903 (`.pl-appshell-frame--dragging iframe
+  { pointer-events: none }`) — the design system now owns that behavior.
+
 ### Fixed
 - **A declined or failed tool now shows the red X on its card, not a green "done".**
   A denied `run_command` returned a normal string, so the card closed *green* with the

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.0",
-    "@protolabsai/ui": "^0.26.1",
+    "@protolabsai/ui": "^0.26.2",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.0",
-    "@protolabsai/ui": "^0.26.0",
+    "@protolabsai/ui": "^0.26.1",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1592,14 +1592,6 @@ textarea {
 .plugin-view-frame { width: 100%; height: 100%; border: 0; background: var(--bg); display: block; }
 .plugin-view-state { display: flex; align-items: center; gap: 8px; padding: 24px; color: var(--fg-muted); font-size: 13px; }
 
-/* INTERIM (until we bump @protolabsai/ui past protoContent#212): the DS AppShell's
-   divider drag tracks the pointer on window listeners, so a plugin-view iframe captures
-   the pointer mid-drag — the resize stutters and the pointer-up that commits a collapse
-   is swallowed (the panel "doesn't close right"). Make iframes pointer-transparent while
-   dragging so the window keeps the gesture. The DS fix adds a drag overlay (also fixes
-   the cursor over iframes); drop this rule once we're on the release that carries it. */
-.pl-appshell-frame--dragging iframe { pointer-events: none; }
-
 /* Plugins panel (ADR 0027, .plugin-install-* / .plugin-list / .plugin-row-main / -title /
    .plugin-ver/.plugin-state/.plugin-desc/.plugin-meta/.plugin-review/.plugin-enable-hint
    + .btn-icon.danger:hover) — moved to src/settings/plugins.css (#832). The bare

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.0",
-        "@protolabsai/ui": "^0.26.0",
+        "@protolabsai/ui": "^0.26.1",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.26.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.26.0.tgz",
-      "integrity": "sha512-HbwpyEpCy5ZOSEhY2Kz9/lugaq428GC19a41mqV3MyeH3v3364hWeyTpxgyXkvjzjVQ2fjZ6+F+uKNAbExFuMg==",
+      "version": "0.26.1",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.26.1.tgz",
+      "integrity": "sha512-VGdO8Hpd7chkr+Z2FAXKCQu9kp4cnr3qiDXAgS+XcDe2hmMa2Z/Hb+ijgI6FKv8oyLyfLfGrh9lufuUeMnnw/g==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.0",
-        "@protolabsai/ui": "^0.26.1",
+        "@protolabsai/ui": "^0.26.2",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.26.1",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.26.1.tgz",
-      "integrity": "sha512-VGdO8Hpd7chkr+Z2FAXKCQu9kp4cnr3qiDXAgS+XcDe2hmMa2Z/Hb+ijgI6FKv8oyLyfLfGrh9lufuUeMnnw/g==",
+      "version": "0.26.2",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.26.2.tgz",
+      "integrity": "sha512-+dWUUTOHqfiDliAlMloEWFhUnhSOs0hNuNAVPYr/Xs3EZES6usY6wCRnTjhA7OrOu16sd7ZKp7o6xKZqvqOmdw==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Closes the loop on the AppShell drag fix.

- **Bumps `@protolabsai/ui` → 0.26.1** (pin `^0.26.1`, lockfile + node_modules). 0.26.1 ships the proper fix from **protoContent#212**: a transparent **drag overlay** during a divider/reopen gesture so the resize tracks smoothly over plugin iframes and the `col-resize` cursor stays correct, plus the `WithIframePanels` regression story.
- **Removes the app-side interim** from #903 (`.pl-appshell-frame--dragging iframe { pointer-events: none }` in `theme.css`) — the DS now owns that behavior, so the marker-commented stopgap is no longer needed.

Build is clean on 0.26.1.

Context: protoContent #212 merged → changesets cut 0.26.1 (#213) → published. This adopts it. Separately, the local dev `node_modules` was also synced from a stale 0.25.0 → 0.26.0 → now 0.26.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)