### PR TITLE
fix(fleet): ride out cold-start (409/502) so a cold agent doesn't flash panel errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dropped it. Removes the app-side interim guard from #903; the design system now owns it.
 
 ### Fixed
+- **Switching to a not-yet-running fleet agent no longer flashes errors in its panels.**
+  A cold agent answers 409 (the member is still spawning) then 502 (booting, not bound yet)
+  for a few seconds until it's up — but only the boot probe retried through that window, so
+  the other panels (beads/theme/…) gave up after one retry and surfaced a "failed" flash
+  mid-boot. `request()` now throws a typed `ApiError` (carrying the status), and the
+  QueryClient default rides out cold-start codes (409/502) — panels stay in their loading
+  state until the agent answers, then fill in. A genuinely-down agent still surfaces via the
+  shell's boot-gate "isn't responding". (ADR 0042 cold-start polish.)
 - **A declined or failed tool now shows the red X on its card, not a green "done".**
   A denied `run_command` returned a normal string, so the card closed *green* with the
   decline text — the opposite of how a denial should read. `run_command` now raises on

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -1,5 +1,25 @@
 import { describe, it, expect } from "vitest";
-import { apiUrl, drainSseBuffer, textFromParts, hitlFromParts } from "./api";
+import { ApiError, apiUrl, drainSseBuffer, isColdStart, textFromParts, hitlFromParts } from "./api";
+
+describe("cold-start detection (ApiError / isColdStart)", () => {
+  it("ApiError carries the HTTP status", () => {
+    const e = new ApiError(409, "agent 'x' is not running");
+    expect(e.status).toBe(409);
+    expect(e).toBeInstanceOf(Error);
+  });
+
+  it("treats 409 (member spawning) and 502 (booting) as cold-start", () => {
+    expect(isColdStart(new ApiError(409, "not running"))).toBe(true);
+    expect(isColdStart(new ApiError(502, "not reachable"))).toBe(true);
+  });
+
+  it("does NOT treat other failures (404/500) or plain errors as cold-start", () => {
+    expect(isColdStart(new ApiError(404, "nope"))).toBe(false);
+    expect(isColdStart(new ApiError(500, "boom"))).toBe(false);
+    expect(isColdStart(new Error("network"))).toBe(false);
+    expect(isColdStart(undefined)).toBe(false);
+  });
+});
 
 const HITL_MIME = "application/vnd.protolabs.hitl-v1+json";
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -234,6 +234,23 @@ function applyAuth(headers: Headers): Headers {
   return headers;
 }
 
+/** An HTTP error from `request()` that carries the status code, so callers (and the
+ *  QueryClient's retry policy) can react to it without parsing the message. */
+export class ApiError extends Error {
+  constructor(readonly status: number, message: string) {
+    super(message);
+    this.name = "ApiError";
+  }
+}
+
+/** Cold start: a just-switched-to fleet agent answers 409 (the member isn't running
+ *  yet — `activate` is still spawning it) or 502 (it's booting but not bound) for a few
+ *  seconds until it's up. These are transient, not failures — retry through them. */
+export function isColdStart(error: unknown): boolean {
+  const s = error instanceof ApiError ? error.status : 0;
+  return s === 409 || s === 502;
+}
+
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const { host, ...init } = options;  // `host` is ours (routing), not a fetch RequestInit field
   const headers = applyAuth(new Headers(init.headers));
@@ -257,7 +274,7 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
     } catch {
       detail = await response.text();
     }
-    throw new Error(detail || "request failed");
+    throw new ApiError(response.status, detail || "request failed");
   }
 
   return (await response.json()) as T;

--- a/apps/web/src/lib/queryClient.ts
+++ b/apps/web/src/lib/queryClient.ts
@@ -1,5 +1,7 @@
 import { QueryClient } from "@tanstack/react-query";
 
+import { isColdStart } from "./api";
+
 // One QueryClient for the whole console (ADR 0013). Surfaces fetch with
 // `useSuspenseQuery` so loading is a <Suspense> fallback and errors are caught
 // by an <ErrorBoundary> — replacing the per-surface useEffect + busy-flag +
@@ -13,7 +15,17 @@ export const queryClient = new QueryClient({
   defaultOptions: {
     queries: {
       staleTime: 5_000,
-      retry: 1,
+      // Cold start (ADR 0042): switching to a not-yet-running fleet agent makes its
+      // panels answer 409 (member spawning) / 502 (booting, not bound) for a few
+      // seconds. Without this they gave up after one retry and flashed an error
+      // mid-boot; ride out cold-start codes — up to ~25 retries with capped backoff
+      // (~70s, covering a slow first launch and outlasting the boot probe's window) —
+      // so a panel stays in its loading state until the agent is up. Everything else
+      // keeps the single retry. (Queries that opt out via `retry: false` are unaffected;
+      // a genuinely-down agent still surfaces via the shell's boot-gate "isn't responding".)
+      retry: (failureCount, error) =>
+        isColdStart(error) ? failureCount < 25 : failureCount < 1,
+      retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 3000),
       refetchOnWindowFocus: false,
     },
   },


### PR DESCRIPTION
**The "switched to another agent and it flashed errors" report.** The pasted trace is the cold-start sequence — and it *does* recover (ends with the SpaceTraders dashboard loading `200`), but it flashes errors on the way up.

## What's happening
Switching to a not-yet-running fleet agent:
1. its panels fire → **409 Conflict** (`proxy.py`: the member isn't running yet)
2. frontend `POST …/activate` → `[fleet] started … (:7871)`
3. member is booting but not bound → **502 Bad Gateway** (`proxy.py`: not reachable) for ~4s
4. `:7871/api/runtime/status 200` → it's up → panels recover

The boot **gate** waits correctly because `runtimeQ` overrides with `retry: 30`. But the QueryClient default is **`retry: 1`**, so every *other* panel query (beads/theme/…) gives up after one retry — *before* the agent finishes booting — and surfaces a "failed" flash (the error strip / panel error state). That's the noise.

## Fix (central, one place)
- **`request()`** now throws a typed **`ApiError`** carrying the HTTP `status` (it was a plain `Error` with the code buried in the message).
- **`isColdStart(err)`** = `status === 409 || 502`.
- **`queryClient`** default `retry` now rides out cold-start codes — up to ~25 retries with capped backoff (~70s, past the boot probe and a slow first launch) — so a panel **stays in its loading state** until the agent answers, then fills in. Everything else keeps the single retry; `retry: false` queries are untouched; a genuinely-down agent still surfaces via the boot-gate **"isn't responding"**.

Chat's `chatCommands()` already swallowed its error (`.catch(()=>{})`) and the `/api/events` EventSource auto-reconnects, so this targets the panel queries that were the actual flashers.

## Tests
`ApiError` carries the status; `isColdStart` true for 409/502, false for 404/500/plain `Error`/undefined. 21 web tests pass; `tsc` + `build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)