### PR TITLE
fix(fleet): member plugin secret double-scoped → read back "unset"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   dropped it. Removes the app-side interim guard from #903; the design system now owns it.
 
 ### Fixed
+- **A fleet member's plugin secret (e.g. a SpaceTraders token) now actually saves +
+  reads back, instead of showing "unset" after you enter it.** A member is launched with
+  both `PROTOAGENT_CONFIG_DIR=<workspace>` and `PROTOAGENT_INSTANCE=<id>`, and config_io
+  applied `scope_leaf()` on top of the already-per-member config dir — double-nesting the
+  config/secrets to `<ws>/<id>/secrets.yaml`. The secret persisted there (securely — in
+  `secrets.yaml`, mode 0600, never the tracked config), but the member's plugin-config
+  resolver looks for the plugin at `<ws>/plugins`, so it never found the section to merge
+  the secret into → the Settings field reported `is_set: false`. The config-dir-relative
+  paths (config / secrets / setup-marker) now skip `scope_leaf` when `PROTOAGENT_CONFIG_DIR`
+  is explicit (the dir is already the isolated leaf), and a one-time self-heal drops the
+  orphaned `<ws>/<id>/` dir on the next member restart (re-enter the token once). Regression
+  tests cover the scope helper, the plugin-secret round-trip, and the self-heal.
 - **A declined or failed tool now shows the red X on its card, not a green "done".**
   A denied `run_command` returned a normal string, so the card closed *green* with the
   decline text — the opposite of how a denial should read. `run_command` now raises on

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -77,8 +77,27 @@ PRESETS_DIR = _BUNDLE_CONFIG_DIR / "soul-presets"
 # (the base path) for the unscoped default. The unscoped base is kept for graceful seeding.
 from infra.paths import scope_leaf as _scope_leaf
 
+
+def _config_scope(path: Path) -> Path:
+    """Instance-scoping for the config-dir-relative files (config / secrets /
+    setup-marker).
+
+    ``scope_leaf`` isolates co-located instances that SHARE a config dir (the
+    bundle dir, or the data home) by ``PROTOAGENT_INSTANCE``. But when
+    ``PROTOAGENT_CONFIG_DIR`` is set explicitly — the desktop app's per-user dir,
+    or a FLEET MEMBER's per-workspace dir — that dir is ALREADY the isolated leaf.
+    Scoping it again double-nests (``<ws>/<id>/secrets.yaml``), so the member
+    writes a path its own plugin-config resolver (rooted at ``<ws>/plugins``)
+    never reads — a saved plugin secret then reads back ``unset``. So scope the
+    leaf only when the config dir is the implicit default.
+    """
+    if os.environ.get("PROTOAGENT_CONFIG_DIR", "").strip():
+        return path
+    return _scope_leaf(path)
+
+
 _BASE_CONFIG_YAML = _LIVE_CONFIG_DIR / "langgraph-config.yaml"
-CONFIG_YAML_PATH = _scope_leaf(_BASE_CONFIG_YAML)
+CONFIG_YAML_PATH = _config_scope(_BASE_CONFIG_YAML)
 SOUL_RUNTIME_PATH = Path("/sandbox/SOUL.md")
 
 # Secrets overlay. The setup wizard / drawer collect a model API key and an
@@ -87,7 +106,7 @@ SOUL_RUNTIME_PATH = Path("/sandbox/SOUL.md")
 # untracked sibling file (gitignored + dockerignored), read back by
 # ``LangGraphConfig.from_yaml`` and stripped from the main YAML on every save.
 _BASE_SECRETS_YAML = _LIVE_CONFIG_DIR / "secrets.yaml"
-SECRETS_YAML_PATH = _scope_leaf(_BASE_SECRETS_YAML)
+SECRETS_YAML_PATH = _config_scope(_BASE_SECRETS_YAML)
 
 # (section, key) pairs that must never be written to the tracked YAML.
 SECRET_PATHS: tuple[tuple[str, str], ...] = (
@@ -119,7 +138,7 @@ def secret_paths() -> tuple[tuple[str, str], ...]:
 # wizard on first page load. Lives in the live config dir so a Docker volume
 # mount (or the desktop app-data dir) persists setup across runs.
 _BASE_SETUP_MARKER = _LIVE_CONFIG_DIR / ".setup-complete"
-SETUP_MARKER_PATH = _scope_leaf(_BASE_SETUP_MARKER)
+SETUP_MARKER_PATH = _config_scope(_BASE_SETUP_MARKER)
 
 
 # ---------------------------------------------------------------------------
@@ -137,6 +156,31 @@ except ImportError:
     _HAS_RUAMEL = False
 
 
+def _reset_double_scoped_config() -> None:
+    """Self-heal the double-scope bug (ADR 0042): earlier builds nested a fleet
+    member's config under ``<config-dir>/<instance>/`` — ``scope_leaf`` ran on top of
+    an already-per-member ``PROTOAGENT_CONFIG_DIR`` — so a saved plugin secret landed
+    in a dir the member's own plugin-config resolver (rooted at ``<dir>/plugins``)
+    never reads. Config now lives directly under the explicit dir; remove the orphaned
+    nested copy (its secrets are re-entered — by design we don't migrate it). No-op
+    unless an explicit config dir is set AND the old nested config exists."""
+    if not os.environ.get("PROTOAGENT_CONFIG_DIR", "").strip():
+        return
+    old = _scope_leaf(_BASE_CONFIG_YAML)  # the OLD <dir>/<id>/langgraph-config.yaml
+    if old == CONFIG_YAML_PATH or not old.exists():
+        return  # not double-scoped on disk (already healed, or never happened)
+    for name in ("langgraph-config.yaml", "secrets.yaml", ".setup-complete"):
+        try:
+            (old.parent / name).unlink()
+        except OSError:
+            pass
+    try:
+        old.parent.rmdir()  # only succeeds if now empty — never blow away other state
+        log.info("[config] removed orphaned double-scoped config dir %s", old.parent)
+    except OSError:
+        pass
+
+
 def ensure_live_config() -> bool:
     """Seed the live config on first run. Returns True only when it created the file.
 
@@ -150,13 +194,16 @@ def ensure_live_config() -> bool:
 
     Idempotent — does nothing once the live file exists, so edits are never clobbered.
     """
+    _reset_double_scoped_config()  # self-heal: drop the old <dir>/<id>/ nesting
     if CONFIG_YAML_PATH.exists():
         return False
     import shutil
 
-    from infra.paths import instance_id
-
-    scoped = bool(instance_id())  # PROTOAGENT_INSTANCE set ⇒ this path is instance-scoped
+    # Scoped iff the live path actually sits in an instance subdir of the base
+    # (PROTOAGENT_INSTANCE set AND no explicit config dir — see `_config_scope`); a
+    # fleet member's explicit dir is its own base, so it seeds from the template, not
+    # a self-copy.
+    scoped = CONFIG_YAML_PATH != _BASE_CONFIG_YAML
     source = _BASE_CONFIG_YAML if (scoped and _BASE_CONFIG_YAML.exists()) else CONFIG_EXAMPLE_PATH
     if not source.exists():
         return False

--- a/tests/test_member_config_scope.py
+++ b/tests/test_member_config_scope.py
@@ -1,0 +1,90 @@
+"""Fleet-member config scoping — the double-scope regression (ADR 0042 / 0004).
+
+A member is launched with BOTH ``PROTOAGENT_CONFIG_DIR=<ws>`` AND
+``PROTOAGENT_INSTANCE=<id>``. ``config_io`` must NOT ``scope_leaf`` the config /
+secrets under the already-per-member dir — doing so double-nests
+``<ws>/<id>/secrets.yaml``, so a saved plugin secret reads back ``unset`` because
+the plugin actually lives at ``<ws>/plugins`` (``PROTOAGENT_PLUGINS_DIR``), not
+``<ws>/<id>/plugins``. See ``graph/config_io._config_scope``.
+"""
+
+from __future__ import annotations
+
+
+def test_config_scope_skips_scope_leaf_when_config_dir_is_explicit(monkeypatch, tmp_path):
+    """An explicit PROTOAGENT_CONFIG_DIR is already the isolated leaf — config /
+    secrets sit directly under it, NOT under a second <instance>/ level."""
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "member-7")
+    from graph.config_io import _config_scope
+
+    p = tmp_path / "secrets.yaml"
+    assert _config_scope(p) == p  # unchanged — no <member-7>/ nesting
+
+
+def test_config_scope_still_isolates_a_shared_default_dir(monkeypatch, tmp_path):
+    """Without an explicit dir, co-located instances DO isolate by instance id
+    under the shared default dir (the legacy scope_leaf path stays intact)."""
+    monkeypatch.delenv("PROTOAGENT_CONFIG_DIR", raising=False)
+    monkeypatch.setenv("PROTOAGENT_INSTANCE", "member-7")
+    from graph.config_io import _config_scope
+
+    p = tmp_path / "secrets.yaml"
+    assert _config_scope(p) == tmp_path / "member-7" / "secrets.yaml"
+
+
+def test_plugin_secret_resolves_when_config_dir_holds_the_plugins(tmp_path):
+    """The regression itself: a plugin secret in ``<dir>/secrets.yaml`` merges into
+    ``plugin_config`` when the plugin lives at ``<dir>/plugins`` (config_dir ==
+    plugins dir). The double-scope bug pointed config_dir at a nested dir with no
+    plugins, so ``_resolve_plugin_config`` found nothing and silently produced
+    ``is_set=False`` even though the secret was on disk."""
+    pdir = tmp_path / "plugins" / "demo"
+    pdir.mkdir(parents=True)
+    (pdir / "protoagent.plugin.yaml").write_text(
+        "id: demo\nname: Demo\nversion: 0.1.0\nconfig_section: demo\n"
+        "secrets: [api_key]\n"
+        "settings:\n  - { key: api_key, label: Key, type: secret }\n"
+    )
+    (pdir / "__init__.py").write_text("def register(registry):\n    pass\n")
+    (tmp_path / "langgraph-config.yaml").write_text("plugins:\n  enabled: [demo]\n")
+    (tmp_path / "secrets.yaml").write_text("demo:\n  api_key: super-secret-token\n")
+
+    from graph.config import LangGraphConfig
+
+    cfg = LangGraphConfig.from_yaml(tmp_path / "langgraph-config.yaml")
+    assert cfg.plugin_config.get("demo", {}).get("api_key") == "super-secret-token"
+
+
+def test_self_heal_removes_orphaned_double_scoped_dir(monkeypatch, tmp_path):
+    """On startup a member with an explicit config dir + an OLD nested config drops
+    the orphaned ``<dir>/<id>/`` dir (reset — by design we don't migrate it)."""
+    from pathlib import Path
+
+    import graph.config_io as cio
+
+    nested = tmp_path / "member-7"
+    nested.mkdir()
+    (nested / "langgraph-config.yaml").write_text("plugins: {enabled: []}\n")
+    (nested / "secrets.yaml").write_text("model: {api_key: x}\n")
+
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path))
+    monkeypatch.setattr(cio, "_BASE_CONFIG_YAML", tmp_path / "langgraph-config.yaml")
+    monkeypatch.setattr(cio, "CONFIG_YAML_PATH", tmp_path / "langgraph-config.yaml")
+    monkeypatch.setattr(cio, "_scope_leaf", lambda p: nested / Path(p).name)
+
+    cio._reset_double_scoped_config()
+    assert not nested.exists()  # orphan removed
+
+
+def test_self_heal_is_a_noop_without_an_explicit_config_dir(monkeypatch, tmp_path):
+    """The default (shared-dir) case is legitimately scoped — never reset it."""
+    import graph.config_io as cio
+
+    monkeypatch.delenv("PROTOAGENT_CONFIG_DIR", raising=False)
+    nested = tmp_path / "member-7"
+    nested.mkdir()
+    (nested / "langgraph-config.yaml").write_text("x\n")
+    monkeypatch.setattr(cio, "_scope_leaf", lambda p: nested / "langgraph-config.yaml")
+    cio._reset_double_scoped_config()
+    assert nested.exists()  # untouched


### PR DESCRIPTION
**The "I add my SpaceTraders token and it says unset" bug.**

## Diagnosis (confirmed against the live member)
A fleet member is launched with **both** `PROTOAGENT_CONFIG_DIR=<workspace>` and `PROTOAGENT_INSTANCE=<id>` (`manager.run_exec`). `config_io` then did `SECRETS_YAML_PATH = scope_leaf(<ws>/secrets.yaml)` — and `scope_leaf` inserts the instance id **again** → `<ws>/<id>/secrets.yaml`. So:
- The token **did** save, **securely** — `secrets.yaml`, mode `-rw-------`, never the tracked config. (Security: fine.)
- But it landed in the doubly-nested dir, while the member's plugin-config resolver (`_resolve_plugin_config` → `plugin_roots_from(config_dir)`) looks for the plugin at `<ws>/plugins`. It never found the `spacetraders` section to merge the secret into → the schema reported `is_set: false` → the field showed **"unset."**

Verified on the running member: `secrets.yaml` had `spacetraders.account_token`, but `:7872/api/settings/schema` returned `is_set:false / source:default`.

## Fix
- **`_config_scope()`** — config-dir-relative paths (config / secrets / setup-marker) **skip `scope_leaf` when `PROTOAGENT_CONFIG_DIR` is explicit**, because that dir is already the isolated per-member leaf. The shared-default-dir case (no explicit dir — e.g. `PROTOAGENT_INSTANCE=roxy` on the bundle dir) still scopes by instance, unchanged.
- **`_reset_double_scoped_config()`** — one-time self-heal: drops the orphaned `<ws>/<id>/` dir on the member's next restart (a **reset**, not a migration — you re-enter the token once, as agreed).

## Tests
`tests/test_member_config_scope.py`: the scope helper (explicit-dir → no nest; shared-default → still nests), the **plugin-secret round-trip** through `from_yaml`/`_resolve_plugin_config` when `config_dir` holds the plugins (the exact failure — would have caught this), and the self-heal (+ no-op without an explicit dir). 451 config/scope/fleet tests green; ruff clean.

## Adoption
Pull + rebuild + restart the hub/members → members read `<ws>/...` (un-nested), the self-heal clears the old `<ws>/<id>/` dir, re-enter the token once → it sticks.

> Follow-up: a coverage true-up PR is coming (per a full audit) — the double-scope class, `_resolve_plugin_config` end-to-end, the create-vs-run plugin-dir alignment, and the shared-skills commons were all untested. This is why it shipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)