### PR TITLE
feat(settings): a "set" badge for configured secrets (did-it-save feedback)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Changed
+- **A configured plugin/model secret now shows a clear "set" badge in Settings.** Secrets
+  never echo their value, so a saved key looked identical to an empty one ("did it save?").
+  The generic Settings surface now renders a "set" badge next to a configured secret field
+  (matching the Delegates panel) — a saved token is glanceable, not just a faint placeholder.
+  (First slice of the plugin/bundle lifecycle tightening — single-agent.)
+
+### Changed
 - **Adopt `@protolabsai/ui@0.26.2`** — picks up the AppShell iframe-drag fix
   (protoContent #212 + #214): resizing a panel that hosts a plugin iframe now tracks
   smoothly and collapses on release, via `.pl-appshell-frame--dragging iframe { pointer-events:

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -374,6 +374,10 @@ function SettingRow({
       <div className="setting-meta">
         <label className="setting-label" htmlFor={`set-${field.key}`}>
           {field.label}
+          {/* A configured secret never echoes its value, so without a glanceable
+              indicator a saved key looks identical to an empty one ("did it save?").
+              Mirror the Delegates panel's "secret set" pill. */}
+          {field.type === "secret" && field.is_set ? <Badge status="success">set</Badge> : null}
           {field.restart ? <span className="setting-restart">restart</span> : null}
         </label>
         {field.description ? <p className="setting-desc">{field.description}</p> : null}


### PR DESCRIPTION
First slice of the plugin/bundle lifecycle tightening — the **secret-config feedback** that bit us with the SpaceTraders token.

## Why
A secret never echoes its value, so in the generic Settings surface a *saved* key looked identical to an *empty* one — the only difference was a faint placeholder (`•••••••• (set…)` vs `unset`). That reads as "did it actually save?" The Delegates panel already does this right (a "secret set" pill); generic Settings didn't.

## Change
Render a glanceable **`set`** Badge next to a configured secret field (`field.type === "secret" && field.is_set`). The save mutation already `invalidateQueries(settings)`, so the badge flips to **set** the instant a token persists — immediate, persistent confirmation.

tsc + build clean.

> Next in this slice (single-agent, fleet untouched): a plugin **lifecycle live-smoke** (install → enable → configure → use → update → uninstall, asserted end-to-end — the "lock it in"), then the **fleet flag (default off)** so the single-agent core is the shippable default.

🤖 Generated with [Claude Code](https://claude.com/claude-code)