### PR TITLE
feat(desktop): build Linux (.AppImage/.deb) + Windows (NSIS) in CI alongside macOS

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -1,11 +1,24 @@
 name: Desktop Build
 
-# Builds the macOS protoAgent desktop app (.dmg) — the Tauri shell + its
-# PyInstaller server sidecar (apps/desktop/sidecar/build_sidecar.py) — signed +
-# notarized with the org Apple Developer ID, and attaches it to the GitHub
-# release. Fires on semver tags (alongside release.yml's Docker build) and on
-# manual dispatch (dispatch builds an unsigned dev artifact unless the full
-# signing secret set is present). See ADR 0010 (UI tiers / desktop).
+# Builds the protoAgent desktop app — the Tauri shell + its PyInstaller server
+# sidecar (apps/desktop/sidecar/build_sidecar.py) — for all three desktop
+# platforms and attaches the artifacts to the GitHub release:
+#
+#   - macOS   .dmg (aarch64)            signed + notarized (org Apple Developer ID)
+#   - Linux   .AppImage + .deb (x86_64) unsigned; built on ubuntu-22.04 so the
+#                                       PyInstaller sidecar reaches the oldest glibc
+#                                       a hosted runner can target (2.35)
+#   - Windows NSIS -setup.exe (x86_64)  unsigned (no Windows signing identity yet —
+#                                       expect a SmartScreen prompt)
+#
+# Every leg smoke-tests the actual frozen sidecar (scripts/live_smoke.py --bin
+# boots it and drives a real A2A turn) BEFORE the slow Tauri bundle step, so
+# per-platform PyInstaller under-collection fails the build, not the first user.
+#
+# Fires on semver tags (alongside release.yml's Docker build) and on manual
+# dispatch (dispatch macOS builds are unsigned unless the full signing secret
+# set is present; Linux/Windows are always unsigned). See ADR 0010 (UI tiers /
+# desktop).
 
 on:
   push:
@@ -29,13 +42,20 @@ jobs:
     name: ${{ matrix.target }}
     if: github.repository == 'protoLabsAI/protoAgent'
     runs-on: ${{ matrix.os }}
-    timeout-minutes: 45
+    timeout-minutes: 60
     strategy:
       fail-fast: false
       matrix:
         include:
           - os: macos-14          # Apple Silicon runner
             target: aarch64-apple-darwin
+            bundles: dmg
+          - os: ubuntu-22.04      # oldest hosted runner = broadest glibc reach
+            target: x86_64-unknown-linux-gnu
+            bundles: appimage,deb
+          - os: windows-latest
+            target: x86_64-pc-windows-msvc
+            bundles: nsis
     steps:
       - uses: actions/checkout@v4
         with:
@@ -54,6 +74,16 @@ jobs:
       - name: Install Rust
         uses: dtolnay/rust-toolchain@stable
 
+      - name: Install Linux system deps
+        if: runner.os == 'Linux'
+        # Tauri v2's webkit/gtk toolchain + ayatana-appindicator for the tray
+        # (the runtime side of this dep is declared in tauri.conf.json's
+        # bundle.linux.deb.depends; AppImage bundles it).
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y libwebkit2gtk-4.1-dev build-essential curl wget file \
+            libxdo-dev libssl-dev libayatana-appindicator3-dev librsvg2-dev
+
       - name: Read version
         id: version
         shell: bash
@@ -66,6 +96,19 @@ jobs:
           echo "tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      - name: Stamp app version
+        shell: bash
+        # tauri.conf.json stays a placeholder in-tree; stamp the real version at
+        # build time so bundle metadata (DMG/installer/add-remove-programs)
+        # reports it instead of the placeholder (version-coherence: the desktop
+        # must not claim a version pyproject doesn't).
+        run: |
+          V="${{ steps.version.outputs.version }}"
+          CONF=apps/desktop/src-tauri/tauri.conf.json
+          jq --arg v "$V" '.version = $v' "$CONF" > "$CONF.tmp"
+          mv "$CONF.tmp" "$CONF"
+          echo "tauri.conf.json version -> $V"
+
       - name: Build server sidecar (PyInstaller)
         shell: bash
         # Freezes `server` into binaries/protoagent-server-<triple> — the
@@ -76,6 +119,18 @@ jobs:
           pip install -r requirements.txt pyinstaller
           python apps/desktop/sidecar/build_sidecar.py
           ls -la apps/desktop/src-tauri/binaries/
+
+      - name: Smoke-test the frozen sidecar
+        shell: bash
+        # Boot the actual frozen binary (not the venv server) against the fake
+        # OpenAI endpoint and drive a real A2A turn — catches per-platform
+        # PyInstaller under-collection before the slow Tauri bundle step.
+        # 180s healthz budget: onefile binaries self-extract on first boot (and
+        # Windows Defender scans them).
+        run: |
+          BIN="apps/desktop/src-tauri/binaries/protoagent-server-${{ matrix.target }}"
+          if [ "${RUNNER_OS}" = "Windows" ]; then BIN="${BIN}.exe"; fi
+          python scripts/live_smoke.py --bin "${BIN}" --timeout 180
 
       - name: Install web + desktop deps
         shell: bash
@@ -103,43 +158,69 @@ jobs:
           set -euo pipefail
           cd apps/desktop
           SIGNED="unsigned (dev)"
-          # tauri-bundler signs as soon as *any* Apple secret is set, then fails
-          # if the set is incomplete. Require the full set; otherwise unset all so
-          # a dispatch build falls back cleanly to unsigned.
-          if [ -n "${APPLE_CERTIFICATE}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD}" ] \
-             && [ -n "${APPLE_SIGNING_IDENTITY}" ] && [ -n "${APPLE_API_ISSUER}" ] \
-             && [ -n "${APPLE_API_KEY}" ] && [ -n "${APPLE_API_KEY_BASE64}" ] \
-             && [ -n "${APPLE_TEAM_ID}" ]; then
-            # tauri expects APPLE_API_KEY_PATH = a .p8 file; the secret is its base64.
-            KEYFILE="$(mktemp -t protoagent-apple-api-XXXXXX).p8"
-            python3 -c 'import base64,os,sys; open(sys.argv[1],"wb").write(base64.b64decode(os.environ["APPLE_API_KEY_BASE64"]))' "$KEYFILE"
-            export APPLE_API_KEY_PATH="${KEYFILE}"
-            SIGNED="Developer ID (signed + notarized)"
-          elif [ "${{ github.event_name }}" = "push" ]; then
-            echo "::error::Semver-tag desktop releases require the full Apple signing secret set."
-            exit 2
+          if [ "${RUNNER_OS}" = "macOS" ]; then
+            # tauri-bundler signs as soon as *any* Apple secret is set, then fails
+            # if the set is incomplete. Require the full set; otherwise unset all so
+            # a dispatch build falls back cleanly to unsigned.
+            if [ -n "${APPLE_CERTIFICATE}" ] && [ -n "${APPLE_CERTIFICATE_PASSWORD}" ] \
+               && [ -n "${APPLE_SIGNING_IDENTITY}" ] && [ -n "${APPLE_API_ISSUER}" ] \
+               && [ -n "${APPLE_API_KEY}" ] && [ -n "${APPLE_API_KEY_BASE64}" ] \
+               && [ -n "${APPLE_TEAM_ID}" ]; then
+              # tauri expects APPLE_API_KEY_PATH = a .p8 file; the secret is its base64.
+              KEYFILE="$(mktemp -t protoagent-apple-api-XXXXXX).p8"
+              python3 -c 'import base64,os,sys; open(sys.argv[1],"wb").write(base64.b64decode(os.environ["APPLE_API_KEY_BASE64"]))' "$KEYFILE"
+              export APPLE_API_KEY_PATH="${KEYFILE}"
+              SIGNED="Developer ID (signed + notarized)"
+            elif [ "${{ github.event_name }}" = "push" ]; then
+              echo "::error::Semver-tag desktop releases require the full Apple signing secret set."
+              exit 2
+            else
+              unset APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY \
+                    APPLE_API_ISSUER APPLE_API_KEY APPLE_API_KEY_BASE64 APPLE_TEAM_ID
+            fi
           else
+            # No Linux/Windows signing identity yet — ship unsigned and make sure
+            # the bundler never sees the Apple env.
             unset APPLE_CERTIFICATE APPLE_CERTIFICATE_PASSWORD APPLE_SIGNING_IDENTITY \
                   APPLE_API_ISSUER APPLE_API_KEY APPLE_API_KEY_BASE64 APPLE_TEAM_ID
+            SIGNED="unsigned (${RUNNER_OS})"
           fi
           [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ] || unset TAURI_SIGNING_PRIVATE_KEY_PASSWORD
           echo "Signing mode: ${SIGNED}"
-          npm run build -- --bundles dmg
-          DMG="$(ls src-tauri/target/release/bundle/dmg/*.dmg | head -1)"
-          OUT="protoAgent-${{ steps.version.outputs.version }}-${{ matrix.target }}.dmg"
-          cp "${DMG}" "${GITHUB_WORKSPACE}/${OUT}"
-          echo "dmg=${OUT}" >> "$GITHUB_OUTPUT"
-          echo "Built ${OUT} (${SIGNED})"
+          npm run build -- --bundles ${{ matrix.bundles }}
+
+      - name: Collect artifacts
+        shell: bash
+        # Normalize every bundle into dist-desktop/ as
+        # protoAgent-<version>-<target>.<ext> so upload/release steps are
+        # platform-agnostic.
+        run: |
+          set -euo pipefail
+          V="${{ steps.version.outputs.version }}"
+          T="${{ matrix.target }}"
+          B="apps/desktop/src-tauri/target/release/bundle"
+          mkdir -p dist-desktop
+          case "${RUNNER_OS}" in
+            macOS)
+              cp "$(ls "${B}"/dmg/*.dmg | head -1)" "dist-desktop/protoAgent-${V}-${T}.dmg" ;;
+            Linux)
+              cp "$(ls "${B}"/appimage/*.AppImage | head -1)" "dist-desktop/protoAgent-${V}-${T}.AppImage"
+              cp "$(ls "${B}"/deb/*.deb | head -1)" "dist-desktop/protoAgent-${V}-${T}.deb" ;;
+            Windows)
+              cp "$(ls "${B}"/nsis/*-setup.exe | head -1)" "dist-desktop/protoAgent-${V}-${T}-setup.exe" ;;
+          esac
+          ls -la dist-desktop/
 
       - name: Upload dispatch artifact
         if: github.event_name == 'workflow_dispatch'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.build.outputs.dmg }}
-          path: ${{ steps.build.outputs.dmg }}
+          name: protoAgent-${{ steps.version.outputs.version }}-${{ matrix.target }}
+          path: dist-desktop/*
 
       - name: Attach to release
         if: github.event_name == 'push'
+        shell: bash
         env:
           GH_TOKEN: ${{ github.token }}
-        run: gh release upload "${{ steps.version.outputs.tag }}" "${{ steps.build.outputs.dmg }}" --clobber
+        run: gh release upload "${{ steps.version.outputs.tag }}" dist-desktop/* --clobber

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -114,9 +114,12 @@ jobs:
         # Freezes `server` into binaries/protoagent-server-<triple> — the
         # externalBin Tauri bundles. The React console is the UI; no server-side
         # UI extras are bundled.
+        # mcp[cli] is a build-env requirement, not a runtime dep: --collect-all
+        # mcp imports every mcp submodule, and mcp.cli hard-errors at import
+        # when typer is missing (broke all legs once an unpinned mcp drifted).
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt pyinstaller
+          pip install -r requirements.txt pyinstaller "mcp[cli]"
           python apps/desktop/sidecar/build_sidecar.py
           ls -la apps/desktop/src-tauri/binaries/
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   succeeded — but a plugin whose `register()` raises is *skipped* (best-effort load), so the
   agent was told a no-op worked; they now read the real per-plugin load status and surface
   "FAILED to load: <error>" so you fix-and-reload instead of testing nothing.
+### Added
+- **Desktop builds for Linux and Windows.** `desktop-build.yml` now fans out a
+  three-leg matrix: the macOS `.dmg` (signed + notarized, as before), Linux
+  `.AppImage` + `.deb` (x86_64, built on ubuntu-22.04 for the broadest glibc reach a
+  hosted runner offers), and a Windows NSIS `-setup.exe` (x86_64, unsigned for now —
+  SmartScreen will prompt until a Windows signing identity is added). Every leg also
+  **smoke-tests the actual frozen sidecar before bundling** (`scripts/live_smoke.py
+  --bin` boots the PyInstaller binary with no repo on `PYTHONPATH` and drives a real
+  A2A turn — per-platform under-collection now fails CI, not the first user), and the
+  real release version is **stamped into `tauri.conf.json` at build time** so the
+  installer/app metadata stops claiming the in-tree placeholder.
 
 ### Changed
 - **A configured plugin/model secret now shows a clear "set" badge in Settings.** Secrets

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -24,7 +24,7 @@ npm run desktop:dev
 The app **bundles and launches the protoAgent server itself** as a Tauri sidecar — no separately-running server required.
 
 - `apps/desktop/sidecar/build_sidecar.py` freezes the server into a single binary via PyInstaller, named `binaries/protoagent-server-<target-triple>` (the `externalBin` Tauri bundles). The React console is the UI, so the binary stays lean (~60 MB) rather than carrying a heavier server-rendered UI stack.
-- On launch the Rust shell (`src-tauri/src/lib.rs`) **picks a free port**, spawns the sidecar with `--ui console --port <port>` (the console UI tier — API + A2A + console; ADR 0010), sets `PROTOAGENT_CONFIG_DIR` to the per-user app-config dir (so the read-only binary still persists setup/secrets), drains its output to the log, and kills it on app exit. A free port (not a fixed 7870) means the desktop coexists with any other agent already running — and is the foundation for several agents at once.
+- On launch the Rust shell (`src-tauri/src/lib.rs`) spawns the sidecar on the **fixed port 7870** with `--ui console --port 7870` (the console UI tier — API + A2A + console; ADR 0010), sets `PROTOAGENT_CONFIG_DIR` to the per-user app-config dir (so the read-only binary still persists setup/secrets), drains its output to the log, and kills it on app exit. (The dynamic-free-port + window-injection handoff proved unreliable across Tauri v2 webview contexts, so the port is pinned to the web client's fallback — see the comment in `lib.rs`.)
 - The shell creates the window itself and injects `window.__PROTOAGENT_API_BASE__` (the chosen `http://127.0.0.1:<port>`) before any page script runs; the webview's React build reads it (`apps/web/src/lib/api.ts`) and calls the sidecar's `/api`, `/a2a`, and `/v1`. The console probes with backoff on startup so the few-second cold start doesn't surface as an error.
 
 The sidecar binary is gitignored — it's a build artifact produced per platform by step 1 (locally or in CI before `tauri build`).
@@ -36,3 +36,28 @@ To point the desktop UI at a *different* server instead of the bundled one, set 
 - Tray menu: show, hide, quit.
 - Close button hides the window instead of quitting.
 - `Cmd+Shift+P` on macOS or `Super+Shift+P` on Linux/Windows toggles the window.
+
+## Platforms & CI
+
+`.github/workflows/desktop-build.yml` builds all three platforms on semver tags
+(and on manual dispatch, which uploads workflow artifacts instead):
+
+| Platform | Artifact | Signing |
+|---|---|---|
+| macOS (aarch64) | `.dmg` | Developer ID, signed + notarized (full Apple secret set) |
+| Linux (x86_64) | `.AppImage` + `.deb` | unsigned |
+| Windows (x86_64) | NSIS `-setup.exe` | unsigned — expect a SmartScreen prompt until a Windows signing identity is added |
+
+Notes per platform:
+
+- **Every leg smoke-tests the frozen sidecar** before bundling: `scripts/live_smoke.py --bin`
+  boots the actual PyInstaller binary (neutral cwd, no `PYTHONPATH`) and drives a real A2A
+  turn, so per-platform under-collection fails CI rather than the first launch on a user's
+  machine.
+- **Linux** builds on `ubuntu-22.04`, so the frozen sidecar needs glibc ≥ 2.35 at runtime
+  (PyInstaller binaries don't run on older glibc than they were built with). The tray icon
+  needs `libayatana-appindicator3-1` — declared as a `.deb` dependency; the AppImage bundles it.
+- **Windows** PyInstaller onefile binaries are occasionally false-flagged by AV — a known
+  PyInstaller issue; code-signing the sidecar/installer is the durable fix.
+- The real release version is stamped into `tauri.conf.json` at build time (in-tree it stays
+  a placeholder), so the installer/app metadata reports the actual `pyproject.toml` version.

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -7,8 +7,11 @@ React console itself, so the binary stays as small as this dependency stack allo
 
 Run from a venv with the runtime deps + PyInstaller installed:
 
-    pip install -r requirements.txt pyinstaller
+    pip install -r requirements.txt pyinstaller "mcp[cli]"
     python apps/desktop/sidecar/build_sidecar.py
+
+(``mcp[cli]`` is a build-env-only need: ``--collect-all mcp`` imports every mcp
+submodule, and ``mcp.cli`` raises at import when typer is missing.)
 
 The target triple matches Tauri's expectation (``rustc`` host), so the binary
 lands at the exact name Tauri looks for during ``tauri build``.

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -25,6 +25,11 @@
       "infoPlist": "./Info.plist",
       "minimumSystemVersion": "13.0"
     },
+    "linux": {
+      "deb": {
+        "depends": ["libayatana-appindicator3-1"]
+      }
+    },
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -22,6 +22,12 @@ you merge the PR (CI green)  ──▶  you push tag vX.Y.Z  ──▶  Release 
 `latest` Docker tag is pushed on every `main` merge by `docker-publish.yml` —
 independent of releases.
 
+The tag push also triggers `desktop-build.yml`, which builds the desktop app on
+a three-platform matrix and attaches the artifacts to the same GitHub Release:
+the macOS `.dmg` (signed + notarized — requires the full Apple secret set, the
+leg fails otherwise), the Linux `.AppImage` + `.deb`, and the Windows NSIS
+`-setup.exe` (both unsigned). See `apps/desktop/README.md` § Platforms & CI.
+
 ## Cutting a release
 
 1. **Actions → Prepare Release → Run workflow.** Choose the **bump**: `patch`

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -8,11 +8,16 @@ import gaps — by exercising the actual transport, not a mock. The fake model
 (scripts/fake_openai_server.py) returns a canned completion so the turn reaches a
 terminal state without a real gateway.
 
+`--bin <path>` smokes a PyInstaller-frozen sidecar (the desktop build) instead of
+`python -m server` — same wire checks, but against the actual frozen binary, so
+per-platform under-collection fails CI instead of the first desktop user.
+
 Exit 0 on success, non-zero (with a diagnostic) on any failure.
 """
 
 from __future__ import annotations
 
+import argparse
 import json
 import os
 import socket
@@ -34,6 +39,23 @@ def _free_port() -> int:
     return port
 
 
+def _parse_args() -> argparse.Namespace:
+    ap = argparse.ArgumentParser(description="protoAgent live-smoke")
+    ap.add_argument(
+        "--bin",
+        dest="bin_path",
+        default=None,
+        help="smoke a frozen server binary (the desktop sidecar) instead of `python -m server`",
+    )
+    ap.add_argument(
+        "--timeout",
+        type=float,
+        default=90.0,
+        help="seconds to wait for /healthz (frozen onefile binaries self-extract on first boot)",
+    )
+    return ap.parse_args()
+
+
 def _wait_healthz(port: int, timeout: float = 90.0) -> bool:
     end = time.time() + timeout
     url = f"http://127.0.0.1:{port}/healthz"
@@ -49,6 +71,7 @@ def _wait_healthz(port: int, timeout: float = 90.0) -> bool:
 
 
 def main() -> int:
+    args = _parse_args()
     fake_port, agent_port = _free_port(), _free_port()
     cfg_dir = Path(tempfile.mkdtemp(prefix="smoke-cfg-"))
     (cfg_dir / "langgraph-config.yaml").write_text(
@@ -66,13 +89,21 @@ def main() -> int:
         "PYTHONPATH": str(ROOT),
     }
 
+    if args.bin_path:
+        # Frozen sidecar: run from a neutral cwd with no PYTHONPATH so the repo
+        # checkout can't paper over PyInstaller under-collection — the desktop
+        # app won't have the repo on disk either.
+        env.pop("PYTHONPATH", None)
+        agent_cmd = [str(Path(args.bin_path).resolve()), "--ui", "none", "--port", str(agent_port)]
+        agent_cwd = str(cfg_dir)
+    else:
+        agent_cmd = [sys.executable, "-m", "server", "--ui", "none", "--port", str(agent_port)]
+        agent_cwd = str(ROOT)
+
     fake = subprocess.Popen([sys.executable, str(ROOT / "scripts" / "fake_openai_server.py"), str(fake_port)])
-    agent = subprocess.Popen(
-        [sys.executable, "-m", "server", "--ui", "none", "--port", str(agent_port)],
-        cwd=str(ROOT), env=env,
-    )
+    agent = subprocess.Popen(agent_cmd, cwd=agent_cwd, env=env)
     try:
-        if not _wait_healthz(agent_port):
+        if not _wait_healthz(agent_port, timeout=args.timeout):
             print("FAIL: /healthz never returned 200 (server did not become ready)")
             return 1
         print("ok: /healthz 200 (lean server booted + graph compiled)")

--- a/scripts/live_smoke.py
+++ b/scripts/live_smoke.py
@@ -30,6 +30,12 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parent.parent
 
+# Windows consoles/pipes default to cp1252, which can't encode "✓" — the smoke
+# then dies at its own success banner. Force UTF-8 (lossy on truly odd terminals).
+for _stream in (sys.stdout, sys.stderr):
+    if hasattr(_stream, "reconfigure"):
+        _stream.reconfigure(encoding="utf-8", errors="replace")
+
 
 def _free_port() -> int:
     s = socket.socket()


### PR DESCRIPTION
## What

Extends `desktop-build.yml` from macOS-only to a three-leg matrix, plus two build-quality patterns ported from the ORBIS desktop pipeline.

| Leg | Runner | Artifacts | Signing |
|---|---|---|---|
| `aarch64-apple-darwin` | macos-14 | `.dmg` | Developer ID, signed + notarized (unchanged) |
| `x86_64-unknown-linux-gnu` | ubuntu-22.04 | `.AppImage` + `.deb` | unsigned |
| `x86_64-pc-windows-msvc` | windows-latest | NSIS `-setup.exe` | unsigned (SmartScreen prompt expected until we add a Windows identity) |

## ORBIS patterns ported

- **Frozen-sidecar smoke before bundling** — `scripts/live_smoke.py` grew `--bin` / `--timeout`: it boots the actual PyInstaller binary (neutral cwd, `PYTHONPATH` scrubbed so the repo checkout can't mask under-collection) and drives a real A2A turn. Per-platform PyInstaller collect gaps now fail CI before the slow Tauri bundle, not the first user launch. Default (venv) mode is untouched — verified locally, `LIVE SMOKE PASSED ✓`.
- **Version stamping** — the real release version is `jq`-stamped into `tauri.conf.json` at build time; in-tree it stays a placeholder. Installer/app metadata stops claiming `0.1.0` (version-coherence).

## Details

- Apple signing gate now runs **only on the macOS leg**; Linux/Windows scrub the Apple env so tauri-bundler never trips on a partial set. The tag-push hard-fail for missing Apple secrets is preserved on macOS.
- `bundle.linux.deb.depends` declares `libayatana-appindicator3-1` (tray runtime dep on Linux; the AppImage bundles it).
- ubuntu-22.04 chosen deliberately: PyInstaller binaries need runtime glibc ≥ build glibc, so the oldest hosted runner gives the broadest reach (≥ 2.35).
- Artifacts normalize into `dist-desktop/` as `protoAgent-<version>-<target>.<ext>`; dispatch uploads workflow artifacts, tag-push attaches to the GitHub Release (now multi-file).
- Job timeout 45 → 60 min (Windows Rust cold builds are slower; no Rust cache yet — possible follow-up).
- Docs: `apps/desktop/README.md` gains a Platforms & CI section (and drops the stale "picks a free port" claim — the port is pinned to 7870 per `lib.rs`); `docs/guides/releasing.md` now mentions the desktop artifacts a tag push produces.

## Deliberately out of scope

- **Tauri updater** (`latest.json` + `TAURI_SIGNING_PRIVATE_KEY` artifacts, ORBIS-style) — protoAgent has no updater plugin wired yet; belongs with the version-coherence P2 "update-in-place" work.
- **Windows code signing** (Azure Trusted Signing / EV cert) and **macOS x86_64 / universal**.

## Validation

- `live_smoke.py` default mode passes locally; ruff clean; workflow YAML + tauri.conf.json parse.
- The real validation is a `workflow_dispatch` of **Desktop Build** on this branch (all three legs) — being kicked off now; results will be posted here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)