### PR TITLE
fix(plugins): make the devkit's live make-and-test loop reliable (audit-driven)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The devkit's "edit then `reload_plugins`" loop now picks up edits to EVERY file, and
+  reports when a plugin failed to load.** Two reliability gaps in the agent's make-it-live-
+  and-test loop (found by a lifecycle audit): (1) the hot-reload re-exec'd only a plugin's
+  `__init__.py`, so an edit to a sibling module (`from .impl import …`) silently served STALE
+  code until a process restart — the loader now purges the plugin's whole `sys.modules`
+  subtree before re-exec, on **every** reload path (not just `update`). (2) `enable_plugin` /
+  `reload_plugins` / scaffold's live-enable reported "loaded live" whenever the config reload
+  succeeded — but a plugin whose `register()` raises is *skipped* (best-effort load), so the
+  agent was told a no-op worked; they now read the real per-plugin load status and surface
+  "FAILED to load: <error>" so you fix-and-reload instead of testing nothing.
+
 ### Changed
 - **A configured plugin/model secret now shows a clear "set" badge in Settings.** Secrets
   never echo their value, so a saved key looked identical to an empty one ("did it save?").

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -83,6 +83,14 @@ def _load_plugin_module(manifest: PluginManifest, entry: Path):
     module is registered in ``sys.modules`` BEFORE exec — relative imports resolve
     the parent package there — and the name is sanitized to a valid identifier."""
     mod_name = _plugin_module_name(manifest.id)
+    # Reload-safety: drop any cached modules for this plugin — the entry AND its sibling
+    # submodules (``mod_name.*``) — so a hot-reload re-execs EVERY file, not just
+    # __init__.py. Without this, ``from .tools import x`` resolves a stale cached
+    # ``mod_name.tools`` and an edit to a sibling module silently has no effect until a
+    # process restart (breaking the devkit's "edit then reload_plugins" loop). On a first
+    # load this is a no-op (nothing cached). Previously only the update route purged.
+    for _name in [n for n in list(sys.modules) if n == mod_name or n.startswith(mod_name + ".")]:
+        sys.modules.pop(_name, None)
     spec = importlib.util.spec_from_file_location(
         mod_name, str(entry), submodule_search_locations=[str(manifest.path)]
     )

--- a/plugins/plugin-devkit/__init__.py
+++ b/plugins/plugin-devkit/__init__.py
@@ -33,11 +33,24 @@ def _emit_scaffolded(pid: str, kind: str) -> None:
         pass
 
 
+def _plugin_meta(pid: str) -> dict | None:
+    """The latest load meta for a plugin (``{id, loaded, error, tools, …}``) off the
+    runtime — set by the loader on every (re)load. ``None`` if the loader didn't see it."""
+    from runtime.state import STATE
+
+    return next((m for m in (getattr(STATE, "plugin_meta", []) or []) if m.get("id") == pid), None)
+
+
 def _live_enable(pid: str) -> tuple[bool, str]:
     """Enable a plugin in the RUNNING agent + hot-reload — the same path the console
     enable toggle uses (#822): tools/subagents/middleware/MCP rebuild with the graph
     and the plugin's router hot-mounts, so a freshly enabled plugin is live with no
-    restart. No-ops cleanly when there's no live graph (the CLI / tests)."""
+    restart. No-ops cleanly when there's no live graph (the CLI / tests).
+
+    Crucially it confirms the plugin actually LOADED — ``load_plugins`` is best-effort
+    per-plugin, so a ``register()`` that raises is *skipped*, not fatal: the config
+    reload "succeeds" while the plugin is silently not live. We surface that instead of
+    a false 'loaded live', so the agent can fix-and-reload instead of testing a no-op."""
     try:
         from runtime.state import STATE
 
@@ -52,7 +65,14 @@ def _live_enable(pid: str) -> tuple[bool, str]:
         ok, msgs = _apply_settings_changes(
             config={"plugins": {"enabled": enabled, "disabled": disabled}}
         )
-        return (ok, "enabled + loaded live") if ok else (False, "; ".join(msgs) or "reload failed")
+        if not ok:
+            return (False, "; ".join(msgs) or "reload failed")
+        meta = _plugin_meta(pid)
+        if meta is None:
+            return (False, "enabled in config, but the loader didn't discover it — check the id and that it's in the plugins dir")
+        if not meta.get("loaded"):
+            return (False, f"enabled, but it FAILED to load: {meta.get('error') or 'unknown error'} — fix __init__.py, then call reload_plugins")
+        return (True, "enabled + loaded live")
     except Exception as e:  # noqa: BLE001 — enable is best-effort; the skeleton still landed
         return (False, f"auto-enable failed: {e}")
 
@@ -173,9 +193,12 @@ def enable_plugin(plugin_id: str) -> str:
 
 @tool
 def reload_plugins() -> str:
-    """Hot-reload all enabled plugins — re-exec their code so edits you made to a
-    plugin's ``__init__.py`` take effect WITHOUT a restart. Use after editing a
-    plugin you're iterating on; the new tools/views are live on your NEXT turn."""
+    """Hot-reload all enabled plugins — re-exec their code (every file, not just
+    ``__init__.py``) so edits you made take effect WITHOUT a restart. Use after editing
+    a plugin you're iterating on; the new tools/views are live on your NEXT turn.
+
+    Reports which plugins FAILED to load (a syntax error, a bad import) so you fix-and-
+    reload instead of testing stale/no-op code — a failed plugin is skipped, never fatal."""
     try:
         from runtime.state import STATE
 
@@ -184,10 +207,17 @@ def reload_plugins() -> str:
         from server.agent_init import _apply_settings_changes
 
         ok, msgs = _apply_settings_changes()  # bare call = pure reload (picks up file edits)
-        return (
-            "✓ reloaded — your plugin edits are live on the next turn."
-            if ok else f"✗ reload failed: {'; '.join(msgs)}"
-        )
+        if not ok:
+            return f"✗ reload failed: {'; '.join(msgs)}"
+        failed = [
+            (m["id"], m.get("error") or "unknown error")
+            for m in (getattr(STATE, "plugin_meta", []) or [])
+            if not m.get("loaded")
+        ]
+        if failed:
+            detail = "; ".join(f"{pid}: {err}" for pid, err in failed)
+            return f"⚠ reloaded, but these plugins FAILED to load — fix the code and reload again: {detail}"
+        return "✓ reloaded — your plugin edits are live on the next turn."
     except Exception as e:  # noqa: BLE001
         return f"✗ reload failed: {e}"
 

--- a/tests/test_plugin_devkit.py
+++ b/tests/test_plugin_devkit.py
@@ -113,6 +113,9 @@ def test_scaffold_enable_hot_reloads_when_live(monkeypatch, tmp_path):
     monkeypatch.setattr(STATE, "graph", object(), raising=False)
     monkeypatch.setattr(STATE, "graph_config", _Cfg(), raising=False)
     monkeypatch.setattr(agent_init, "_apply_settings_changes", _fake_apply)
+    # _live_enable now confirms the plugin actually LOADED (not just that the config
+    # reload ran) — the loader publishes that on STATE.plugin_meta.
+    monkeypatch.setattr(STATE, "plugin_meta", [{"id": "live-one", "loaded": True}], raising=False)
 
     scaffold = mod._build_scaffold_tool({"target_dir": str(out_root)})
     msg = scaffold.invoke({"name": "Live One"})  # enable defaults True
@@ -128,3 +131,30 @@ def test_enable_plugin_tool_noop_without_graph(monkeypatch):
     monkeypatch.setattr(STATE, "graph", None, raising=False)
     assert "not running" in mod.enable_plugin.invoke({"plugin_id": "whatever"})
     assert "no live agent" in mod.reload_plugins.invoke({})
+
+
+def test_live_enable_reports_a_plugin_that_failed_to_load(monkeypatch):
+    """The make-test-live reliability fix: a plugin whose register() raises is *skipped*
+    (best-effort load), so the config reload 'succeeds' — but the agent must be told it
+    FAILED to load (with the error) rather than 'live', so it fixes-and-reloads instead
+    of testing a no-op. Previously _live_enable reported the reload result and called it
+    'loaded live' regardless."""
+    mod = _load_devkit_module(None)
+    import server.agent_init as agent_init
+    from runtime.state import STATE
+
+    class _Cfg:
+        plugins_enabled: list = []
+        plugins_disabled: list = []
+
+    monkeypatch.setattr(STATE, "graph", object(), raising=False)
+    monkeypatch.setattr(STATE, "graph_config", _Cfg(), raising=False)
+    monkeypatch.setattr(agent_init, "_apply_settings_changes", lambda **k: (True, []))
+    monkeypatch.setattr(
+        STATE, "plugin_meta",
+        [{"id": "broken", "loaded": False, "error": "boom: bad import"}], raising=False,
+    )
+    out = mod.enable_plugin.invoke({"plugin_id": "broken"})
+    assert "FAILED to load" in out and "boom" in out
+    # reload_plugins surfaces the same failure (so the iterate loop is honest)
+    assert "FAILED to load" in mod.reload_plugins.invoke({})

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -439,3 +439,47 @@ def test_min_version_garbage_warns_and_loads(tmp_path, monkeypatch, caplog) -> N
     assert [t.name for t in res.tools] == ["typoed_tool"]
     assert res.meta[0]["loaded"] is True
     assert any("min_protoagent_version" in r.message for r in caplog.records)
+
+
+_MULTIFILE_INIT = '''
+from langchain_core.tools import tool
+from .impl import greeting
+
+@tool
+def say() -> str:
+    """say the greeting"""
+    return greeting()
+
+def register(registry):
+    registry.register_tool(say)
+'''
+
+
+def test_reload_picks_up_edited_sibling_submodule(tmp_path, monkeypatch) -> None:
+    """The devkit iterate loop: editing a SIBLING module (`impl.py`, not just
+    `__init__.py`) and reloading must serve the new code. The loader purges the
+    plugin's sys.modules subtree before re-exec, so a stale cached submodule can't
+    shadow the edit. (Regression for the plain-reload submodule-staleness gap.)"""
+    d = tmp_path / "multi"
+    d.mkdir()
+    (d / "protoagent.plugin.yaml").write_text("id: multi\nname: Multi\nversion: 0.1.0\n")
+    (d / "__init__.py").write_text(_MULTIFILE_INIT)
+    (d / "impl.py").write_text("def greeting():\n    return 'v1'\n")
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [tmp_path])
+
+    res1 = load_plugins(_cfg(plugins_enabled=["multi"]))
+    say1 = next(t for t in res1.tools if getattr(t, "name", "") == "say")
+    assert say1.invoke({}) == "v1"
+
+    # edit the SIBLING module, then reload — the new greeting must be live, not stale.
+    # (Bump the mtime so the .pyc bytecode cache, granular to 1s, can't serve v1 on a
+    # same-second test edit; in real use edits are seconds apart so this is moot.)
+    import os
+    import time
+
+    (d / "impl.py").write_text("def greeting():\n    return 'v2'\n")
+    _t = time.time() + 10
+    os.utime(d / "impl.py", (_t, _t))
+    res2 = load_plugins(_cfg(plugins_enabled=["multi"]))
+    say2 = next(t for t in res2.tools if getattr(t, "name", "") == "say")
+    assert say2.invoke({}) == "v2"


### PR DESCRIPTION
Driven by your ask to make the devkit's "make plugins live and test them" loop solid (it was shaky) + a full lifecycle audit. The audit's reassuring headline: **the hot-reload is fundamentally safe** — build-then-commit means a mid-turn reload finishes the in-flight turn on the old graph and swaps atomically, and a broken plugin is *skipped* (best-effort), never bricking the agent. It pinpointed two real gaps:

## 1. Stale sibling submodules on reload (the headline)
`_load_plugin_module` re-exec'd only the entry `__init__.py`. A multi-file plugin's `from .impl import x` resolved a **cached** `sys.modules` entry, so editing a sibling module silently served **stale code** until a process restart — through the devkit's own advertised *"edit then `reload_plugins`"* loop. The subtree purge existed only in the `update` route.
**Fix:** the loader now purges the plugin's whole `sys.modules` subtree (`mod_name` + `mod_name.*`) before re-exec, so **every** reload path (devkit, console enable, update) picks up edits to every file.

## 2. False "loaded live"
`_live_enable` / `reload_plugins` / scaffold's live-enable reported success on the **config reload**, never checking whether the plugin actually registered. A `register()` that raises is skipped — so the agent was told a no-op worked.
**Fix:** they now read the real per-plugin status off `STATE.plugin_meta` and surface `FAILED to load: <error>` (or "the loader didn't discover it") so the agent fix-and-reloads instead of testing nothing. This also closes the audit's "enable a bad id reports success" gap on the devkit side.

## Tests
- edit a **sibling submodule** → reload → new code is live (regression for #1; bumps the file mtime so the 1s-granular `.pyc` cache can't mask it on a same-second test edit — in real use edits are seconds apart).
- enable a plugin that failed to load → reported **failed, not live** (#2).
- existing live-enable test updated to publish `plugin_meta`. 202 plugin tests green; ruff clean.

> The audit surfaced more (a secret saved for a *disabled* plugin leaks to the tracked YAML in plaintext — high; bundle partial-failure has no rollback; install→auto-enable doesn't propagate a per-plugin load error). I'll bring those + the "devkit covers the whole lifecycle" tools (install/update/uninstall/disable) as follow-ups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)