### PR TITLE
fix(plugins): route a disabled plugin's secret to secrets.yaml, not plaintext config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **A secret saved for an installed-but-DISABLED plugin now routes to `secrets.yaml`,
+  not the plaintext config.** Secret routing (`secret_paths`) and the config-redaction
+  path keyed off *enabled* plugins only — so a secret for a plugin that's currently off
+  (or being configured before enable) wasn't recognized as a secret: it would be written
+  to the live `langgraph-config.yaml` in plaintext (gitignored, so never committed — but
+  the wrong file: configs get exported / backed up / tracked in a fork) and echoed back
+  unredacted to the Settings API. Both paths now cover ALL INSTALLED plugins
+  (`installed_plugin_config_schemas`); the settings UI stays enabled-only. Found by a
+  plugin-lifecycle audit.
+
+### Fixed
 - **The devkit's "edit then `reload_plugins`" loop now picks up edits to EVERY file, and
   reports when a plugin failed to load.** Two reliability gaps in the agent's make-it-live-
   and-test loop (found by a lifecycle audit): (1) the hot-reload re-exec'd only a plugin's

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -119,14 +119,18 @@ SECRET_PATHS: tuple[tuple[str, str], ...] = (
 
 
 def secret_paths() -> tuple[tuple[str, str], ...]:
-    """Base ``SECRET_PATHS`` plus the (section, key) pairs each enabled plugin
+    """Base ``SECRET_PATHS`` plus the (section, key) pairs each INSTALLED plugin
     declares as secrets (ADR 0019). Used by the split/strip logic so a plugin
-    secret is routed to ``secrets.yaml`` exactly like the model API key."""
+    secret is routed to ``secrets.yaml`` exactly like the model API key.
+
+    Covers installed-but-DISABLED plugins too: otherwise a secret saved for a plugin
+    that's off wouldn't be recognized as a secret and would be written to the live
+    config YAML in plaintext (the wrong file — configs get exported/backed-up/forked)."""
     try:
-        from graph.plugins.pconfig import live_plugin_config_schemas
+        from graph.plugins.pconfig import installed_plugin_config_schemas
 
         extra = tuple(
-            (sch.section, key) for sch in live_plugin_config_schemas() for key in sch.secrets
+            (sch.section, key) for sch in installed_plugin_config_schemas() for key in sch.secrets
         )
     except Exception:  # noqa: BLE001 — plugin discovery is best-effort
         extra = ()
@@ -352,9 +356,11 @@ def config_to_dict(config: LangGraphConfig) -> dict[str, Any]:
     plugin_cfg = getattr(config, "plugin_config", {}) or {}
     if plugin_cfg:
         try:
-            from graph.plugins.pconfig import live_plugin_config_schemas
+            # ALL installed plugins (not just enabled) — so a disabled plugin's stored
+            # secret is redacted from the API response too, never echoed back in the clear.
+            from graph.plugins.pconfig import installed_plugin_config_schemas
 
-            secrets_by_section = {s.section: set(s.secrets) for s in live_plugin_config_schemas()}
+            secrets_by_section = {s.section: set(s.secrets) for s in installed_plugin_config_schemas()}
         except Exception:  # noqa: BLE001
             secrets_by_section = {}
         for section, vals in plugin_cfg.items():

--- a/graph/plugins/pconfig.py
+++ b/graph/plugins/pconfig.py
@@ -106,3 +106,22 @@ def live_plugin_config_schemas() -> list[PluginConfigSchema]:
     except Exception:  # noqa: BLE001
         log.exception("[plugins] live config-schema discovery failed")
         return []
+
+
+def installed_plugin_config_schemas() -> list[PluginConfigSchema]:
+    """Like ``live_plugin_config_schemas`` but for EVERY installed plugin — enabled or
+    not. The SECRET-ROUTING + config-redaction paths use this so a secret saved for a
+    currently-DISABLED plugin is still pulled into ``secrets.yaml`` (never left in
+    plaintext in the live config) and never echoed back to the API. The settings UI
+    keeps the enabled-only view (you don't configure a plugin that's off)."""
+    try:
+        from graph.config_io import _live_config_dir, load_yaml_doc
+        from graph.plugins.loader import discover_plugins
+
+        data = load_yaml_doc() or {}
+        roots = plugin_roots_from(_live_config_dir(), str((data.get("plugins") or {}).get("dir") or ""))
+        all_ids = {m.id for m in discover_plugins(roots)}
+        return discover_plugin_config(roots, all_ids, set())  # every installed plugin, on or off
+    except Exception:  # noqa: BLE001
+        log.exception("[plugins] installed config-schema discovery failed")
+        return []

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -225,6 +225,9 @@ def test_ensure_live_config_seeds_from_example(monkeypatch, tmp_path: Path) -> N
     example.write_text("model:\n  name: from-template\n")
     monkeypatch.setattr(config_io, "CONFIG_EXAMPLE_PATH", example)
     monkeypatch.setattr(config_io, "CONFIG_YAML_PATH", live)
+    # Unscoped path (live == base): seeds from the EXAMPLE template, not a scoped-from-base
+    # copy. Pin _BASE too so `scoped` is False regardless of a local config/langgraph-config.yaml.
+    monkeypatch.setattr(config_io, "_BASE_CONFIG_YAML", live)
 
     assert config_io.ensure_live_config() is True
     assert live.exists()
@@ -250,6 +253,9 @@ def test_ensure_live_config_noop_without_example(monkeypatch, tmp_path: Path) ->
 
     monkeypatch.setattr(config_io, "CONFIG_EXAMPLE_PATH", tmp_path / "absent.example.yaml")
     monkeypatch.setattr(config_io, "CONFIG_YAML_PATH", tmp_path / "langgraph-config.yaml")
+    # Unscoped (live == base) so `scoped` is False and the seed source is the (absent)
+    # example — not a local config/langgraph-config.yaml that would otherwise be the base.
+    monkeypatch.setattr(config_io, "_BASE_CONFIG_YAML", tmp_path / "langgraph-config.yaml")
 
     assert config_io.ensure_live_config() is False
     assert not (tmp_path / "langgraph-config.yaml").exists()

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -113,3 +113,25 @@ def test_from_yaml_without_secrets_leaves_blank_for_env_fallback(tmp_path: Path)
     (tmp_path / "langgraph-config.yaml").write_text("model:\n  name: m\n  api_key: \"\"\n")
     cfg = LangGraphConfig.from_yaml(tmp_path / "langgraph-config.yaml")
     assert cfg.api_key == ""
+
+
+def test_disabled_plugin_secret_routes_to_secrets_not_plaintext(tmp_path, monkeypatch) -> None:
+    """A secret saved for an installed-but-DISABLED plugin must still be pulled into the
+    secret half (→ secrets.yaml), never left in the plaintext live config. The routing
+    (`secret_paths`) covers ALL installed plugins, not just enabled ones — otherwise a
+    plugin that's off (or being configured before enable) leaks its key to the config."""
+    from graph.config_io import split_secret_updates
+
+    cfg = tmp_path / "cfg"
+    pdir = cfg / "plugins" / "offp"
+    pdir.mkdir(parents=True)
+    (pdir / "protoagent.plugin.yaml").write_text(
+        "id: offp\nname: Off Plugin\nversion: 0.1.0\nconfig_section: offp\nsecrets: [api_key]\n"
+    )
+    (pdir / "__init__.py").write_text("def register(registry):\n    pass\n")
+    (cfg / "langgraph-config.yaml").write_text("plugins:\n  enabled: []\n")  # offp NOT enabled
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(cfg))
+
+    main, secrets = split_secret_updates({"offp": {"api_key": "sek-ret"}})
+    assert secrets == {"offp": {"api_key": "sek-ret"}}  # routed to the secret half
+    assert "offp" not in main  # NOT left in the plaintext config YAML


### PR DESCRIPTION
The secret-leak fix from the lifecycle audit — and first, the reassurance: **nothing was committed.** The live config + `secrets.yaml` are gitignored, the only tracked config is the `.example` template, and your actual tokens live in `~/.protoagent/.../secrets.yaml` (0600), outside the repo.

## The gap (hygiene, not an incident)
`secret_paths()` (the split/strip routing) and `config_to_dict`'s redaction discovered secret keys from **enabled** plugins only (`live_plugin_config_schemas`). So a secret saved for an installed-but-**disabled** plugin — or one configured *before* you enable it — wasn't recognized as a secret:
- `split_secret_updates` left it in the live `langgraph-config.yaml` in **plaintext**, and
- `config_to_dict` echoed it back to the Settings API **unredacted**.

The live config is gitignored + in the data dir, so it never reaches git — but it's the wrong file (configs get exported, backed up, or tracked in a fork), so secrets belong in `secrets.yaml` regardless of enable state.

## Fix
- New `pconfig.installed_plugin_config_schemas()` — every **installed** plugin, enabled or not.
- `secret_paths()` and the redaction now use it, so a plugin secret always routes to `secrets.yaml` and is always redacted from the API. The settings UI keeps the enabled-only view (you don't configure a plugin that's off).

## Tests
- `test_disabled_plugin_secret_routes_to_secrets_not_plaintext` — a disabled plugin's secret lands in the secret half + is absent from `main` (would've failed under the old enabled-only routing).
- Robustified two `ensure_live_config` tests (a #908 follow-up — the `scoped` flag is now `CONFIG_YAML_PATH != _BASE`, so they must pin `_BASE`; passed in CI but failed locally where a `config/langgraph-config.yaml` exists).

548 config/plugin/secret tests green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)