### PR TITLE
feat(skills): make the shared-skill commons legible — tier badge + Promote + scope/commons config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent was told a no-op worked; they now read the real per-plugin load status and surface
   "FAILED to load: <error>" so you fix-and-reload instead of testing nothing.
 ### Added
+- **The shared-skill commons is now legible in the console (ADR 0041 / 0048).** The
+  layered skill tier ("shared brain, private hands" — read commons ∪ private, write
+  private) shipped at the data layer but was invisible: the Skills surface couldn't tell
+  a private skill from a commons one, the one curated action (`promote` a private skill
+  into the box-shared commons) had no API route or button, and the skill-sharing mode was
+  YAML-only. Now: a **tier badge** (commons / private) on each skill, a **Promote** action
+  on private skills (`POST /api/playbooks/{id}/promote` over `LayeredSkillsIndex.promote`),
+  and two new settings fields — `skills.scope` (`scoped` · `shared` · `layered`, per-agent)
+  and `commons.path` (the box-shared commons location, host-scoped). Surfacing the second
+  of protoAgent's two inheritance systems (the skill **union**, alongside the ADR 0047
+  settings **override** cascade). Part of the settings-IA reorg (#916).
 - **macOS desktop releases are now verified pristine — and the DMG itself is notarized.**
   Tauri notarizes the `.app` inside the bundle, but the DMG *container* shipped without its
   own ticket; the workflow now runs `notarytool submit` + `stapler staple` on the DMG, then

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -464,11 +464,13 @@ export const PLAYBOOKS = [
     id: 1, name: "web-research", description: "Plan → search → read → synthesize → cite.",
     tools_used: ["web_search", "fetch_url"], source: "disk", confidence: 1.0,
     last_used: "2026-06-01T18:00:00+00:00", created_at: "2026-05-29T00:00:00+00:00",
+    tier: "commons",   // layered index (ADR 0041): already in the shared commons
   },
   {
     id: 2, name: "pr-triage-flow", description: "Learned: how to triage a PR review backlog.",
     tools_used: ["github_get_pr", "github_list_issues"], source: "emitted", confidence: 0.62,
     last_used: "2026-05-31T12:00:00+00:00", created_at: "2026-05-30T00:00:00+00:00",
+    tier: "private",   // private to this agent → eligible for Promote
   },
 ];
 

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -388,6 +388,12 @@ const server = createServer(async (req, res) => {
       FLEET.agents = FLEET.agents.filter((a) => a.name !== name && a.id !== name);
       return sendJson(res, { ok: true, name, removed: [name] });
     }
+    if (req.method === "POST" && /^\/api\/playbooks\/\d+\/promote$/.test(pathname)) {
+      const id = Number(pathname.split("/").at(-2));
+      const p = PLAYBOOKS.find((x) => x.id === id);
+      if (p) p.tier = "commons"; // promoted: now reads from the commons tier
+      return sendJson(res, { enabled: true, promoted: true, name: p?.name });
+    }
     if (req.method === "DELETE" && /^\/api\/playbooks\/\d+$/.test(pathname)) {
       return sendJson(res, { enabled: true, deleted: true });
     }

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -24,6 +24,26 @@ test("Agent → Skills lists pinned + learned skills and supports search", async
   await expect(surface.getByText("web-research")).toBeHidden();
 });
 
+test("layered skills show tier badges and promote a private skill to the commons", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
+  const surface = page.getByTestId("playbooks-surface");
+  await expect(surface).toBeVisible();
+
+  // Tier badges from the layered index (ADR 0041): one commons, one private.
+  await expect(surface.getByText("commons", { exact: true })).toBeVisible();
+  await expect(surface.getByText("private", { exact: true })).toBeVisible();
+
+  // Promote is offered only on the private skill (id 2), not the commons one (id 1).
+  await expect(surface.getByTestId("playbook-promote-2")).toBeVisible();
+  await expect(surface.getByTestId("playbook-promote-1")).toHaveCount(0);
+
+  // Promoting lifts it into the commons → the button is gone afterward.
+  await surface.getByTestId("playbook-promote-2").click();
+  await expect(surface.getByTestId("playbook-promote-2")).toHaveCount(0);
+});
+
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -491,6 +491,15 @@ export const api = {
     );
   },
 
+  // Promote a private skill into the shared commons (ADR 0041) — only meaningful
+  // when the index is layered; the route reports promoted:false with a hint otherwise.
+  promotePlaybook(id: number) {
+    return request<{ enabled: boolean; promoted: boolean; name?: string; error?: string }>(
+      `/api/playbooks/${id}/promote`,
+      { method: "POST" },
+    );
+  },
+
   setupStatus() {
     return request<SetupStatus>("/api/config/setup-status");
   },

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -478,6 +478,10 @@ export type Playbook = {
   confidence: number;
   last_used: string | null;
   created_at: string | null;
+  // Tier (ADR 0041 layered skills): "private" | "commons". Present only when the
+  // index is layered (the agent reads a shared commons ∪ its private library);
+  // absent in scoped/shared mode, where there's a single library and no promote.
+  tier?: "private" | "commons";
 };
 
 // One row from the knowledge store (knowledge/store.py chunks table), as the

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -1,6 +1,6 @@
 import { Input } from "@protolabsai/ui/forms";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { BookMarked, Pin, RefreshCw, Sparkles, Trash2 } from "lucide-react";
+import { ArrowUpToLine, BookMarked, Library, Pin, RefreshCw, Sparkles, Trash2 } from "lucide-react";
 
 import { useEffect, useMemo, useState } from "react";
 
@@ -32,6 +32,7 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
   const [pending, setPending] = useState<Playbook | null>(null);
+  const [promoting, setPromoting] = useState<number | null>(null);
 
   async function load() {
     setLoading(true);
@@ -63,6 +64,27 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
 
   const pinned = filtered.filter((p) => p.source === "disk").length;
   const learned = filtered.length - pinned;
+  // Tier is present only when the index is layered (commons ∪ private). When it
+  // is, surface a commons count so the operator sees the shared library at a glance.
+  const layered = playbooks.some((p) => p.tier);
+  const fromCommons = filtered.filter((p) => p.tier === "commons").length;
+
+  async function promote(p: Playbook) {
+    setPromoting(p.id);
+    try {
+      const r = await api.promotePlaybook(p.id);
+      if (!r.promoted) {
+        onError(r.error || "promote failed");
+        return;
+      }
+      onError("");
+      await load(); // the skill now also reads from the commons tier
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoting(null);
+    }
+  }
 
   async function confirmDelete() {
     if (!pending) return;
@@ -84,7 +106,7 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
     <section className="panel stage-panel" data-testid="playbooks-surface">
       <PanelHeader
         title="Skills"
-        kicker={`methodology the agent retrieves into context · ${pinned} pinned · ${learned} learned`}
+        kicker={`methodology the agent retrieves into context · ${pinned} pinned · ${learned} learned${layered ? ` · ${fromCommons} from commons` : ""}`}
         actions={
           <Button icon variant="ghost" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
             <RefreshCw size={16} className={loading ? "spin" : ""} />
@@ -131,6 +153,17 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
                         </Badge>
                       </span>
                     )}
+                    {p.tier === "commons" ? (
+                      <span title="Shared commons — readable by every agent on this box">
+                        <Badge status="neutral">
+                          <Library size={12} /> commons
+                        </Badge>
+                      </span>
+                    ) : p.tier === "private" ? (
+                      <span title="Private to this agent — promote to share it with the fleet">
+                        <Badge status="neutral">private</Badge>
+                      </span>
+                    ) : null}
                     <strong>{p.name}</strong>
                   </div>
                   <p className="playbook-desc">{p.description}</p>
@@ -145,6 +178,18 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
                 <div className="playbook-meta">
                   <span title="confidence">conf {Math.round((p.confidence ?? 1) * 100)}%</span>
                   <span title="last used">used {ago(p.last_used)}</span>
+                  {p.tier === "private" ? (
+                    <Button
+                      type="button"
+                      icon variant="ghost"
+                      title="Promote to the shared commons (every agent on this box can then reuse it)"
+                      onClick={() => void promote(p)}
+                      disabled={promoting === p.id}
+                      data-testid={`playbook-promote-${p.id}`}
+                    >
+                      <ArrowUpToLine size={14} className={promoting === p.id ? "spin" : ""} />
+                    </Button>
+                  ) : null}
                   <Button
                     type="button"
                     icon variant="danger"

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -131,6 +131,19 @@ FIELDS: list[Field] = [
           "On session retirement, also distil durable facts (aux model) and "
           "consolidate them into the store. Rides the harvest pass."),
 
+    # ── Skills (ADR 0041 tiered stores) ──────────────────────────────────────
+    # `skills.scope` is the agent's own choice of how it participates in the
+    # fleet's skill library; `commons.path` is the box-shared location of that
+    # library (host-scoped — every agent on the box reads the same commons).
+    Field("skills.scope", "skills_scope", "Skill sharing", "select", "Skills",
+          "How this agent uses the skill library: scoped (private only) · shared "
+          "(the one box commons) · layered (read the commons ∪ private, write "
+          "private, promote proven skills up). Blank = derived (scoped).",
+          options=["scoped", "shared", "layered"]),
+    Field("commons.path", "commons_path", "Commons location", "string", "Skills",
+          "Box-shared skill commons read by every agent on this machine. "
+          "Blank = ~/.protoagent/commons.", scope="host"),
+
     # ── Middleware toggles ───────────────────────────────────────────────────
     Field("middleware.knowledge", "knowledge_middleware", "Knowledge middleware", "bool", "Middleware"),
     Field("middleware.memory", "memory_middleware", "Memory middleware", "bool", "Middleware"),
@@ -234,6 +247,10 @@ _SECTION_CATEGORY = {
     "Tools": "Agent",
     # Memory — knowledge/recall config (rendered in the Knowledge view's Settings tab).
     "Knowledge": "Memory",
+    # Skills — the agent's skill-sharing tier + the box commons (ADR 0041). Agent
+    # category today (Agent ▸ Settings); folds into Workspace ▸ Skills, with
+    # commons.path (host-scoped) surfacing in Host/App (ADR 0048).
+    "Skills": "Agent",
     # System — runtime + performance knobs (central Settings → System).
     "Compaction": "System",
     "Caching": "System",

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -72,6 +72,42 @@ def register_knowledge_routes(app) -> None:
             log.exception("[playbooks] delete failed")
             return {"enabled": True, "deleted": False, "error": str(exc)}
 
+    # Promote a private skill into the shared commons (ADR 0041 "shared brain,
+    # private hands") — the one curated lift that makes the layered tier useful.
+    # Only available when the index is layered (it has a ``promote`` method); in
+    # scoped/shared mode there's a single library and nothing to promote into.
+    # The id is the private-DB rowid, so resolve the name within the ``private``
+    # tier (commons rows carry their own rowids — never promote those).
+    @app.post("/api/playbooks/{skill_id}/promote")
+    async def _api_playbook_promote(skill_id: int):
+        idx = STATE.skills_index
+        if idx is None:
+            return {"enabled": False, "promoted": False}
+        promote = getattr(idx, "promote", None)
+        if promote is None:
+            return {
+                "enabled": True,
+                "promoted": False,
+                "error": "skills aren't in layered mode — set skills.scope: layered to share a commons.",
+            }
+        try:
+            match = next(
+                (
+                    s
+                    for s in idx.all_skills()
+                    if s.get("id") == skill_id and s.get("tier", "private") == "private"
+                ),
+                None,
+            )
+            if match is None:
+                return {"enabled": True, "promoted": False, "error": "no private skill with that id"}
+            name = match.get("name", "")
+            ok = bool(promote(name))
+            return {"enabled": True, "promoted": ok, "name": name}
+        except Exception as exc:  # noqa: BLE001
+            log.exception("[playbooks] promote failed")
+            return {"enabled": True, "promoted": False, "error": str(exc)}
+
     # --- Knowledge store (ADR 0020) ----------------------------------------
     # Searchable view of the agent's knowledge base (knowledge/store.py, FTS5):
     # findings, daily-log entries, harvested sessions, operator notes — the same

--- a/tests/test_config_drift_guard.py
+++ b/tests/test_config_drift_guard.py
@@ -238,8 +238,9 @@ def test_fields_types_match_dataclass(field):
 # --------------------------------------------------------------------------- #
 
 # The fields whose shared default lives at the HOST layer (gateway/model/routing/
-# cache/telemetry infra + org branding). Everything else is "agent". Locked here so
-# a new Field can't silently land in the wrong cascade layer.
+# cache/telemetry infra + org branding + the box-shared skill commons location).
+# Everything else is "agent". Locked here so a new Field can't silently land in the
+# wrong cascade layer.
 HOST_SCOPED_KEYS = {
     "model.api_base", "model.provider", "model.name",
     "routing.aux_model", "routing.fallback_models",
@@ -247,6 +248,9 @@ HOST_SCOPED_KEYS = {
     "prompt_cache.warm.enabled", "prompt_cache.warm.interval_seconds",
     "telemetry.enabled", "telemetry.retention_days",
     "identity.org",
+    # commons.path is box-level (ADR 0041 commons read by every agent on the box);
+    # skills.scope stays "agent" (each agent picks its own sharing mode).
+    "commons.path",
 }
 
 

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -135,10 +135,10 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # when their plugin is enabled (surfaced via plugin_config), and a default
     # LangGraphConfig() carries no plugin_config.
     assert set(d.keys()) == {
-        "model", "subagents", "middleware", "knowledge", "skills", "mcp", "plugins",
-        "identity", "auth", "runtime", "operator", "agent_runtime", "checkpoint",
-        "compaction", "execute_code", "goal", "operator_mcp", "prompt_cache",
-        "routing", "telemetry",
+        "model", "subagents", "middleware", "knowledge", "skills", "commons", "mcp",
+        "plugins", "identity", "auth", "runtime", "operator", "agent_runtime",
+        "checkpoint", "compaction", "execute_code", "goal", "operator_mcp",
+        "prompt_cache", "routing", "telemetry",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -159,6 +159,9 @@ CONFIG_TO_DICT_GOLDEN = {
         "max_age_days": 30,
         "prune_interval_hours": 6,
     },
+    "commons": {
+        "path": "",
+    },
     "compaction": {
         "enabled": True,
         "keep_messages": 20,
@@ -252,6 +255,7 @@ CONFIG_TO_DICT_GOLDEN = {
         "db_path": "/sandbox/skills.db",
         "dir": "",
         "enabled": True,
+        "scope": "",
         "top_k": 5,
     },
     "subagents": {

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -62,3 +62,57 @@ def test_playbooks_sorted_pinned_first(monkeypatch):
 def test_knowledge_row_preview_fallback():
     row = _knowledge_row({"heading": "Title", "content": "Body text"})
     assert row["preview"] == "Title: Body text" and row["domain"] == "general"
+
+
+def test_playbooks_tier_passthrough(monkeypatch):
+    """A layered index tags each skill with its tier (private|commons); the list
+    payload must carry it so the surface can badge + gate Promote."""
+    class _Layered:
+        def all_skills(self):
+            return [
+                {"id": 1, "name": "a", "source": "emitted", "confidence": 0.5, "tier": "private", "prompt_template": "x"},
+                {"id": 1, "name": "b", "source": "promoted", "confidence": 0.9, "tier": "commons", "prompt_template": "x"},
+            ]
+
+    c = _client(monkeypatch, skills=_Layered())
+    pb = c.get("/api/playbooks").json()["playbooks"]
+    assert {p["name"]: p["tier"] for p in pb} == {"a": "private", "b": "commons"}
+
+
+def test_promote_route_layered(monkeypatch):
+    """POST .../promote resolves the private skill by id and lifts it to the commons.
+    The id is the private-DB rowid, so a commons row sharing that id is never picked."""
+    promoted: list[str] = []
+
+    class _Layered:
+        def all_skills(self):
+            return [
+                {"id": 7, "name": "private-skill", "tier": "private"},
+                {"id": 7, "name": "commons-skill", "tier": "commons"},
+            ]
+
+        def promote(self, name):
+            promoted.append(name)
+            return True
+
+    c = _client(monkeypatch, skills=_Layered())
+    r = c.post("/api/playbooks/7/promote").json()
+    assert r == {"enabled": True, "promoted": True, "name": "private-skill"}
+    assert promoted == ["private-skill"]  # the commons row with the same id was not promoted
+
+
+def test_promote_route_unsupported_in_scoped_mode(monkeypatch):
+    """A plain (non-layered) index has no commons to promote into — the route
+    explains rather than 500s."""
+    class _Plain:
+        def all_skills(self):
+            return [{"id": 1, "name": "a"}]
+
+    c = _client(monkeypatch, skills=_Plain())
+    r = c.post("/api/playbooks/1/promote").json()
+    assert r["enabled"] is True and r["promoted"] is False and "layered" in r["error"]
+
+
+def test_promote_route_disabled(monkeypatch):
+    c = _client(monkeypatch)  # no skills index
+    assert c.post("/api/playbooks/1/promote").json() == {"enabled": False, "promoted": False}


### PR DESCRIPTION
## What

Makes protoAgent's **shared-skill commons legible in the console**. The layered skill tier ([ADR 0041](docs/adr/0041-workspaces-and-tiered-stores.md) — "shared brain, private hands": read `commons ∪ private`, write private, explicit `promote`) shipped at the data layer but was invisible: the Skills surface couldn't distinguish a private skill from a commons one, `LayeredSkillsIndex.promote` had no route/button, and the skill-sharing mode was YAML-only.

This is the **skills track** of the settings-IA reorg (#916) — surfacing the second of protoAgent's two inheritance systems (the skill **union**, alongside the ADR 0047 settings **override** cascade). S-Skills.1–.3. (S-Skills.4, the Host/App ▸ Commons browser, lands with the Host home in a later slice.)

## Changes

**Backend**
- `POST /api/playbooks/{id}/promote` over `LayeredSkillsIndex.promote` — resolves the private skill by id *within the private tier* (a commons row sharing the rowid is never promoted). Never 500s: returns `promoted:false` + a "set `skills.scope: layered`" hint in scoped/shared mode, `enabled:false` when there's no index.
- `/api/playbooks` already passes `tier` through (the list copies all keys) — now covered by a passthrough test.
- `graph/settings_schema.py`: new **Skills** section — `skills.scope` (`scoped` · `shared` · `layered`, agent-scoped) + `commons.path` (the box-shared commons location, **host-scoped** → joins `_HOST_KEYS`). Drift guard + golden serialization updated.

**Frontend**
- `PlaybooksSurface`: **tier badge** (commons / private), **Promote** button on private skills, "N from commons" in the kicker — all only when the index is layered (absent in scoped/shared mode, so no behavior change there).
- `api.promotePlaybook` + `Playbook.tier` type.

## Tests
- `tests/test_knowledge_routes.py`: tier passthrough + promote (layered / unsupported-scoped / disabled).
- Config golden + drift-guard + mirror-shape updated for the two new fields.
- e2e `playbooks.spec.ts`: layered fixtures + promote mock + a tier/promote spec.
- `336 passed` on the targeted py suite; `tsc --noEmit` clean.

## Note
Small additive surface change (the badge/button only appear in layered mode) — not a layout reorg, so outside the UI local-test gate, but a visual eyeball on the Skills surface is welcome before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
