### PR TITLE
feat(desktop): in-app updates — updater plugin + signed bundles + latest.json fan-in

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -15,6 +15,10 @@ name: Desktop Build
 # boots it and drives a real A2A turn) BEFORE the slow Tauri bundle step, so
 # per-platform PyInstaller under-collection fails the build, not the first user.
 #
+# When the org updater signing key is present, every leg also emits signed
+# updater bundles, and the updater-manifest fan-in job composes latest.json
+# (the manifest the in-app updater polls) onto the release — uploaded last.
+#
 # Fires on semver tags (alongside release.yml's Docker build) and on manual
 # dispatch (dispatch macOS builds are unsigned unless the full signing secret
 # set is present; Linux/Windows are always unsigned). See ADR 0010 (UI tiers /
@@ -195,7 +199,20 @@ jobs:
           else
             echo "signed=false" >> "$GITHUB_OUTPUT"
           fi
-          npm run build -- --bundles ${{ matrix.bundles }}
+          BUNDLES="${{ matrix.bundles }}"
+          if [ -n "${TAURI_SIGNING_PRIVATE_KEY:-}" ]; then
+            # Signed updater artifacts (.app.tar.gz / -setup.nsis.zip /
+            # .AppImage.tar.gz + .sig). v1Compatible = the shapes release-tools'
+            # build-updater-manifest detects. Injected here, not in-tree, so
+            # keyless local builds don't fail on a missing signing key. The
+            # macOS updater bundle derives from the .app — add that target.
+            if [ "${RUNNER_OS}" = "macOS" ]; then BUNDLES="app,dmg"; fi
+            npm run build -- --bundles "$BUNDLES" \
+              --config '{"bundle":{"createUpdaterArtifacts":"v1Compatible"}}'
+          else
+            echo "No updater signing key — building without updater artifacts."
+            npm run build -- --bundles "$BUNDLES"
+          fi
 
       - name: Collect artifacts
         shell: bash
@@ -208,14 +225,32 @@ jobs:
           T="${{ matrix.target }}"
           B="apps/desktop/src-tauri/target/release/bundle"
           mkdir -p dist-desktop
+          # Updater bundles (+ .sig) exist only when the signing key was present.
+          # The renamed files keep the target triple + the exact suffixes that
+          # release-tools' build-updater-manifest classifies by.
           case "${RUNNER_OS}" in
             macOS)
-              cp "$(ls "${B}"/dmg/*.dmg | head -1)" "dist-desktop/protoAgent-${V}-${T}.dmg" ;;
+              cp "$(ls "${B}"/dmg/*.dmg | head -1)" "dist-desktop/protoAgent-${V}-${T}.dmg"
+              UP="$(ls "${B}"/macos/*.app.tar.gz 2>/dev/null | head -1 || true)"
+              if [ -n "${UP}" ]; then
+                cp "${UP}" "dist-desktop/protoAgent-${V}-${T}.app.tar.gz"
+                cp "${UP}.sig" "dist-desktop/protoAgent-${V}-${T}.app.tar.gz.sig"
+              fi ;;
             Linux)
               cp "$(ls "${B}"/appimage/*.AppImage | head -1)" "dist-desktop/protoAgent-${V}-${T}.AppImage"
-              cp "$(ls "${B}"/deb/*.deb | head -1)" "dist-desktop/protoAgent-${V}-${T}.deb" ;;
+              cp "$(ls "${B}"/deb/*.deb | head -1)" "dist-desktop/protoAgent-${V}-${T}.deb"
+              UP="$(ls "${B}"/appimage/*.AppImage.tar.gz 2>/dev/null | head -1 || true)"
+              if [ -n "${UP}" ]; then
+                cp "${UP}" "dist-desktop/protoAgent-${V}-${T}.AppImage.tar.gz"
+                cp "${UP}.sig" "dist-desktop/protoAgent-${V}-${T}.AppImage.tar.gz.sig"
+              fi ;;
             Windows)
-              cp "$(ls "${B}"/nsis/*-setup.exe | head -1)" "dist-desktop/protoAgent-${V}-${T}-setup.exe" ;;
+              cp "$(ls "${B}"/nsis/*-setup.exe | head -1)" "dist-desktop/protoAgent-${V}-${T}-setup.exe"
+              UP="$(ls "${B}"/nsis/*.nsis.zip 2>/dev/null | head -1 || true)"
+              if [ -n "${UP}" ]; then
+                cp "${UP}" "dist-desktop/protoAgent-${V}-${T}-setup.nsis.zip"
+                cp "${UP}.sig" "dist-desktop/protoAgent-${V}-${T}-setup.nsis.zip.sig"
+              fi ;;
           esac
           ls -la dist-desktop/
 
@@ -263,3 +298,46 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: gh release upload "${{ steps.version.outputs.tag }}" dist-desktop/* --clobber
+
+  # Fan-in: compose latest.json from every leg's signed updater bundle and
+  # upload it LAST, so the manifest never points at assets that don't exist
+  # yet. Runs only on semver tags, and only once ALL legs succeeded (a partial
+  # manifest would skew versions across platforms). If the release carries no
+  # updater bundles (key wasn't present), it skips — in-app updates are simply
+  # disabled for that release.
+  updater-manifest:
+    name: updater manifest (latest.json)
+    needs: build
+    if: github.event_name == 'push' && github.repository == 'protoLabsAI/protoAgent'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Compose + upload latest.json
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+          mkdir -p updater-dist
+          gh release download "$TAG" --repo "${{ github.repository }}" --dir updater-dist \
+            --pattern '*.app.tar.gz*' --pattern '*-setup.nsis.zip*' --pattern '*.AppImage.tar.gz*' \
+            2>/dev/null || true
+          if ! ls updater-dist/* >/dev/null 2>&1; then
+            echo "::notice::No signed updater bundles on the release — skipping latest.json (in-app updates disabled for ${TAG})."
+            exit 0
+          fi
+          npx --yes -p '@protolabsai/release-tools@latest' build-updater-manifest \
+            --version "$VERSION" \
+            --dist updater-dist \
+            --base-url "https://github.com/${{ github.repository }}/releases/download/${TAG}" \
+            --notes "protoAgent ${TAG} — see the GitHub Release for details." \
+            --out latest.json
+          cat latest.json
+          gh release upload "$TAG" latest.json --clobber

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -309,7 +309,7 @@ jobs:
     name: updater manifest (latest.json)
     needs: build
     if: github.event_name == 'push' && github.repository == 'protoLabsAI/protoAgent'
-    runs-on: ubuntu-latest
+    runs-on: namespace-profile-protolabs-linux
     timeout-minutes: 10
     steps:
       - name: Setup Node

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **The desktop app updates itself in place.** tauri-plugin-updater wired into the shell:
+  a silent check at launch (release builds) plus a tray "Check for Updates…" item; it polls
+  `latest.json` on the GitHub Release, verifies the bundle's minisign signature against the
+  org public key baked into `tauri.conf.json`, installs, and relaunches — agent data is
+  untouched. CI: when the org `TAURI_SIGNING_PRIVATE_KEY` is present, every desktop leg
+  emits signed updater bundles (`.app.tar.gz` / `-setup.nsis.zip` / `.AppImage.tar.gz`,
+  v1-compatible shapes) and a fan-in job composes `latest.json` from all three platforms
+  and uploads it *last*, so the manifest never points at missing assets. A release built
+  without the key just ships without in-app update for that cycle. (`.deb` installs stay
+  apt-managed — the updater handles AppImage only on Linux.)
+
 ### Fixed
 - **A secret saved for an installed-but-DISABLED plugin now routes to `secrets.yaml`,
   not the plaintext config.** Secret routing (`secret_paths`) and the config-redaction

--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -33,9 +33,24 @@ To point the desktop UI at a *different* server instead of the bundled one, set 
 
 ## Desktop Behavior
 
-- Tray menu: show, hide, quit.
+- Tray menu: show, hide, check for updates, quit.
 - Close button hides the window instead of quitting.
 - `Cmd+Shift+P` on macOS or `Super+Shift+P` on Linux/Windows toggles the window.
+
+## Updates
+
+The app updates itself in place (tauri-plugin-updater): a silent check at launch
+(release builds only) plus a tray "Check for Updates…" item. It polls
+`latest.json` on the GitHub Release, verifies the bundle's minisign signature
+against the org public key baked into `tauri.conf.json`, installs, and
+relaunches — agent data (`PROTOAGENT_CONFIG_DIR`, workspaces) is untouched.
+
+- Updater bundles are only produced in CI when the org `TAURI_SIGNING_PRIVATE_KEY`
+  is present; a release without them simply has no in-app update (the `latest.json`
+  fan-in job skips with a notice).
+- macOS updates via `.app.tar.gz`, Windows re-runs the NSIS installer, Linux
+  updates the `.AppImage` in place. A `.deb` install is apt's job — the updater
+  reports it can't manage that install, which the tray flow surfaces politely.
 
 ## Platforms & CI
 

--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -76,6 +76,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3d036a3c4ab069c7b410a2ce876bd74808d2d0888a82667669f8e783a898bf1"
+dependencies = [
+ "derive_arbitrary",
+]
+
+[[package]]
 name = "arrayvec"
 version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -788,6 +797,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "derive_arbitrary"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "derive_more"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1117,16 @@ checksum = "38e2275cc4e4fc009b0669731a1e5ab7ebf11f469eaede2bab9309a5b4d6057f"
 dependencies = [
  "memoffset",
  "rustc_version",
+]
+
+[[package]]
+name = "filetime"
+version = "0.2.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c287a33c7f0a620c38e641e7f60827713987b3c0f26e8ddc9462cc69cf75759"
+dependencies = [
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -1698,6 +1728,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "33ca68d021ef39cf6463ab54c1d0f5daf03377b70561305bb89a8f83aab66e0f"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1985,6 +2030,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "jni"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
+dependencies = [
+ "cfg-if",
+ "combine",
+ "jni-macros",
+ "jni-sys 0.4.1",
+ "log",
+ "simd_cesu8",
+ "thiserror 2.0.18",
+ "walkdir",
+ "windows-link 0.2.1",
+]
+
+[[package]]
+name = "jni-macros"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00109accc170f0bdb141fed3e393c565b6f5e072365c3bd58f5b062591560a3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "simd_cesu8",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "jni-sys"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2194,6 +2269,12 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
+
+[[package]]
+name = "minisign-verify"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22f9645cb765ea72b8111f36c522475d2daa0d22c957a9826437e97534bc4e9e"
 
 [[package]]
 name = "miniz_oxide"
@@ -2477,6 +2558,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2-osa-kit"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f112d1746737b0da274ef79a23aac283376f335f4095a083a267a082f21db0c0"
+dependencies = [
+ "bitflags 2.11.1",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-foundation",
+]
+
+[[package]]
 name = "objc2-quartz-core"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2552,6 +2645,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "openssl-probe"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+
+[[package]]
 name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2674,20 @@ checksum = "7d8fae84b431384b68627d0f9b3b1245fcf9f46f6c0e3dc902e9dce64edd1967"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "osakit"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "732c71caeaa72c065bb69d7ea08717bd3f4863a4f451402fc9513e29dbd5261b"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+ "objc2-osa-kit",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2883,10 +2996,12 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+ "tauri-plugin-dialog",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-log",
  "tauri-plugin-notification",
  "tauri-plugin-shell",
+ "tauri-plugin-updater",
 ]
 
 [[package]]
@@ -3117,15 +3232,20 @@ dependencies = [
  "http-body",
  "http-body-util",
  "hyper",
+ "hyper-rustls",
  "hyper-util",
  "js-sys",
  "log",
  "percent-encoding",
  "pin-project-lite",
+ "rustls",
+ "rustls-pki-types",
+ "rustls-platform-verifier",
  "serde",
  "serde_json",
  "sync_wrapper",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
  "tower",
  "tower-http",
@@ -3135,6 +3255,44 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rfd"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a15ad77d9e70a92437d8f74c35d99b4e4691128df018833e99f90bcd36152672"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "glib-sys",
+ "gobject-sys",
+ "gtk-sys",
+ "js-sys",
+ "log",
+ "objc2",
+ "objc2-app-kit",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "raw-window-handle",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3212,6 +3370,79 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dab5152771c58876a2146916e53e35057e1a4dfa2b9df0f0305b07f611fdea4d"
+dependencies = [
+ "openssl-probe",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
+dependencies = [
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-platform-verifier"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
+dependencies = [
+ "core-foundation",
+ "core-foundation-sys",
+ "jni 0.22.4",
+ "log",
+ "once_cell",
+ "rustls",
+ "rustls-native-certs",
+ "rustls-platform-verifier-android",
+ "rustls-webpki",
+ "security-framework",
+ "security-framework-sys",
+ "webpki-root-certs",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "rustls-platform-verifier-android"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f87165f0995f63a9fbeea62b64d10b4d9d8e78ec6d7d51fb2125fda7bb36788f"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3224,6 +3455,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "93fc1dc3aaa9bfed95e02e6eadabb4baf7e3078b0bd1b4d7b6b0b68378900502"
 dependencies = [
  "winapi-util",
+]
+
+[[package]]
+name = "schannel"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91c1b7e4904c873ef0710c1f407dde2e6287de2bebc1bbbf7d430bb7cbffd939"
+dependencies = [
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3288,6 +3528,29 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "security-framework"
+version = "3.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
+dependencies = [
+ "bitflags 2.11.1",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ce2691df843ecc5d231c0b14ece2acc3efb62c0a398c7e1d875f3983ce020e3"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "selectors"
@@ -3542,6 +3805,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "simd_cesu8"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94f90157bb87cddf702797c5dadfa0be7d266cdf49e22da2fcaa32eff75b2c33"
+dependencies = [
+ "rustc_version",
+ "simdutf8",
+]
+
+[[package]]
 name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3660,6 +3933,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3743,7 +4022,7 @@ dependencies = [
  "gdkwayland-sys",
  "gdkx11-sys",
  "gtk",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "ndk",
@@ -3783,6 +4062,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
+name = "tar"
+version = "0.4.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f6221d9a6003c78398e3b239969f352578258df48c8eb051caadae0015bc840"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
+
+[[package]]
 name = "target-lexicon"
 version = "0.12.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3806,7 +4096,7 @@ dependencies = [
  "heck 0.5.0",
  "http",
  "image",
- "jni",
+ "jni 0.21.1",
  "libc",
  "log",
  "mime",
@@ -3919,6 +4209,48 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-dialog"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65981abb771e74e571a38196c3baa11c459379164791eba0e67abc1a5fac9884"
+dependencies = [
+ "log",
+ "raw-window-handle",
+ "rfd",
+ "serde",
+ "serde_json",
+ "tauri",
+ "tauri-plugin",
+ "tauri-plugin-fs",
+ "thiserror 2.0.18",
+ "url",
+]
+
+[[package]]
+name = "tauri-plugin-fs"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7ecc274121aca0c036a2b42d1cbe83d368d348f54e0bb8a735c2b1548e8f371"
+dependencies = [
+ "anyhow",
+ "dunce",
+ "glob",
+ "log",
+ "objc2-foundation",
+ "percent-encoding",
+ "schemars 0.8.22",
+ "serde",
+ "serde_json",
+ "serde_repr",
+ "tauri",
+ "tauri-plugin",
+ "tauri-utils",
+ "thiserror 2.0.18",
+ "toml 1.1.2+spec-1.1.0",
+ "url",
+]
+
+[[package]]
 name = "tauri-plugin-global-shortcut"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3996,6 +4328,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-plugin-updater"
+version = "2.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "806d9dac662c2e4594ff03c647a552f2c9bd544e7d0f683ec58f872f952ce4af"
+dependencies = [
+ "base64 0.22.1",
+ "dirs",
+ "flate2",
+ "futures-util",
+ "http",
+ "infer",
+ "log",
+ "minisign-verify",
+ "osakit",
+ "percent-encoding",
+ "reqwest",
+ "rustls",
+ "semver",
+ "serde",
+ "serde_json",
+ "tar",
+ "tauri",
+ "tauri-plugin",
+ "tempfile",
+ "thiserror 2.0.18",
+ "time",
+ "tokio",
+ "url",
+ "windows-sys 0.60.2",
+ "zip",
+]
+
+[[package]]
 name = "tauri-runtime"
 version = "2.11.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4005,7 +4370,7 @@ dependencies = [
  "dpi",
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "objc2",
  "objc2-ui-kit",
  "objc2-web-kit",
@@ -4028,7 +4393,7 @@ checksum = "b83849ee63ecb27a8e8d0fe51915ca215076914aca43f96db1179f0f415f6cd9"
 dependencies = [
  "gtk",
  "http",
- "jni",
+ "jni 0.21.1",
  "log",
  "objc2",
  "objc2-app-kit",
@@ -4240,6 +4605,16 @@ dependencies = [
  "pin-project-lite",
  "socket2",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4562,6 +4937,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4866,6 +5247,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "webpki-root-certs"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
 name = "webview2-com"
 version = "0.38.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5093,6 +5483,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5478,7 +5877,7 @@ dependencies = [
  "gtk",
  "http",
  "javascriptcore-rs",
- "jni",
+ "jni 0.21.1",
  "libc",
  "ndk",
  "objc2",
@@ -5550,6 +5949,16 @@ name = "x11rb-protocol"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ea6fc2961e4ef194dcbfe56bb845534d0dc8098940c7e5c012a258bfec6701bd"
+
+[[package]]
+name = "xattr"
+version = "1.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
+dependencies = [
+ "libc",
+ "rustix",
+]
 
 [[package]]
 name = "xkeysym"
@@ -5683,6 +6092,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
+
+[[package]]
 name = "zerotrie"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5713,6 +6128,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "zip"
+version = "4.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caa8cd6af31c3b31c6631b8f483848b91589021b28fffe50adada48d4f4d2ed1"
+dependencies = [
+ "arbitrary",
+ "crc32fast",
+ "indexmap 2.14.0",
+ "memchr",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -22,7 +22,9 @@ serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
 tauri = { version = "2.11.2", features = ["tray-icon", "image-png", "devtools"] }
+tauri-plugin-dialog = "2"
 tauri-plugin-global-shortcut = "2.3.2"
 tauri-plugin-log = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-shell = "2"
+tauri-plugin-updater = "2"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -6,11 +6,13 @@ use tauri::{
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
     AppHandle, Manager, RunEvent, Runtime, WebviewUrl, WebviewWindowBuilder, WindowEvent,
 };
+use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
 use tauri_plugin_shell::{
     process::{CommandChild, CommandEvent},
     ShellExt,
 };
+use tauri_plugin_updater::UpdaterExt;
 
 /// Fallback port if probing for a free one fails (matches the historical
 /// hardcoded default + the web client's last-resort base).
@@ -132,12 +134,97 @@ fn toggle_main_window<R: Runtime>(app: &AppHandle<R>) {
     }
 }
 
+/// Check the GitHub Release updater manifest (latest.json) for a newer build;
+/// prompt, download + install, then relaunch. Signatures are verified against
+/// the org minisign pubkey baked into tauri.conf.json.
+///
+/// `interactive` = invoked from the tray item: "up to date" and errors surface
+/// as dialogs. The silent launch check only logs. On Linux the updater manages
+/// AppImage installs only (a .deb belongs to apt) — that limitation comes back
+/// as an error from the plugin and is handled like any other.
+fn check_for_updates<R: Runtime>(app: AppHandle<R>, interactive: bool) {
+    tauri::async_runtime::spawn(async move {
+        let updater = match app.updater() {
+            Ok(u) => u,
+            Err(e) => {
+                log::info!("updater: unavailable for this install: {e}");
+                if interactive {
+                    app.dialog()
+                        .message(format!("Updates aren't managed in-app for this install.\n\n{e}"))
+                        .title("protoAgent updates")
+                        .show(|_| {});
+                }
+                return;
+            }
+        };
+        match updater.check().await {
+            Ok(Some(update)) => {
+                let current = app.package_info().version.to_string();
+                let version = update.version.clone();
+                log::info!("updater: {version} available (running {current})");
+                let app_for_install = app.clone();
+                app.dialog()
+                    .message(format!(
+                        "protoAgent {version} is available (you have {current}).\n\n\
+                         Download and install now? The app relaunches when it finishes \
+                         and your agent data is untouched."
+                    ))
+                    .title("Update available")
+                    .buttons(MessageDialogButtons::OkCancelCustom(
+                        "Install and Relaunch".to_string(),
+                        "Later".to_string(),
+                    ))
+                    .show(move |confirmed| {
+                        if !confirmed {
+                            return;
+                        }
+                        tauri::async_runtime::spawn(async move {
+                            match update.download_and_install(|_, _| {}, || {}).await {
+                                Ok(()) => {
+                                    log::info!("updater: installed, relaunching");
+                                    app_for_install.restart();
+                                }
+                                Err(e) => {
+                                    log::error!("updater: install failed: {e}");
+                                    app_for_install
+                                        .dialog()
+                                        .message(format!("The update failed to install.\n\n{e}"))
+                                        .title("protoAgent updates")
+                                        .show(|_| {});
+                                }
+                            }
+                        });
+                    });
+            }
+            Ok(None) => {
+                log::info!("updater: up to date");
+                if interactive {
+                    app.dialog()
+                        .message("You're on the latest version.")
+                        .title("protoAgent updates")
+                        .show(|_| {});
+                }
+            }
+            Err(e) => {
+                log::warn!("updater: check failed: {e}");
+                if interactive {
+                    app.dialog()
+                        .message(format!("Couldn't check for updates.\n\n{e}"))
+                        .title("protoAgent updates")
+                        .show(|_| {});
+                }
+            }
+        }
+    });
+}
+
 fn build_tray(app: &tauri::App) -> tauri::Result<()> {
     let show = MenuItem::with_id(app, "show", "Show protoAgent", true, None::<&str>)?;
     let hide = MenuItem::with_id(app, "hide", "Hide", true, None::<&str>)?;
+    let updates = MenuItem::with_id(app, "updates", "Check for Updates…", true, None::<&str>)?;
     let quit = MenuItem::with_id(app, "quit", "Quit", true, None::<&str>)?;
     let separator = PredefinedMenuItem::separator(app)?;
-    let menu = Menu::with_items(app, &[&show, &hide, &separator, &quit])?;
+    let menu = Menu::with_items(app, &[&show, &hide, &separator, &updates, &quit])?;
 
     // The protoLabs robot mark, at the menu-bar size + template treatment Orbis
     // used for fleet agents (icons/tray-robot.png, 44×44; system-tinted). Each
@@ -152,6 +239,7 @@ fn build_tray(app: &tauri::App) -> tauri::Result<()> {
         .on_menu_event(|app, event| match event.id().as_ref() {
             "show" => show_main_window(app),
             "hide" => hide_main_window(app),
+            "updates" => check_for_updates(app.clone(), true),
             "quit" => app.exit(0),
             _ => {}
         })
@@ -176,6 +264,10 @@ fn build_tray(app: &tauri::App) -> tauri::Result<()> {
 pub fn run() {
     tauri::Builder::default()
         .plugin(tauri_plugin_shell::init())
+        .plugin(tauri_plugin_dialog::init())
+        // In-app updates: checks the latest.json manifest on GitHub Releases,
+        // verifies the minisign signature, installs, relaunches.
+        .plugin(tauri_plugin_updater::Builder::new().build())
         // Notifications — bridges the web Notification API in the webview so the
         // console can alert (e.g. a HITL form awaiting input) even when the
         // menu-bar window is hidden.
@@ -247,6 +339,12 @@ pub fn run() {
                     let _ = app.set_activation_policy(tauri::ActivationPolicy::Accessory);
                 }
                 Err(e) => log::error!("tray setup failed; staying in the dock: {e}"),
+            }
+
+            // Silent launch check (release builds only — `tauri dev` runs at the
+            // in-tree placeholder version and would always see an "update").
+            if !cfg!(debug_assertions) {
+                check_for_updates(app.handle().clone(), false);
             }
             Ok(())
         })

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -38,5 +38,13 @@
       "icons/icon.icns",
       "icons/icon.ico"
     ]
+  },
+  "plugins": {
+    "updater": {
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEZBQTg4QTBCRERFN0E4MDkKUldRSnFPZmRDNHFvK3FMMGdubXlkWGp6bkVmYXFRS29GR1RBVnlpenlUNHh2TUxYWENQdkREUjIK",
+      "endpoints": [
+        "https://github.com/protoLabsAI/protoAgent/releases/latest/download/latest.json"
+      ]
+    }
   }
 }

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -27,6 +27,9 @@ a three-platform matrix and attaches the artifacts to the same GitHub Release:
 the macOS `.dmg` (signed + notarized — requires the full Apple secret set, the
 leg fails otherwise), the Linux `.AppImage` + `.deb`, and the Windows NSIS
 `-setup.exe` (both unsigned). See `apps/desktop/README.md` § Platforms & CI.
+When the org updater signing key is present, the legs also attach signed updater
+bundles and a fan-in job uploads `latest.json` — the manifest the desktop app's
+in-app updater polls. See `apps/desktop/README.md` § Updates.
 
 ## Cutting a release
 


### PR DESCRIPTION
## What

The desktop app updates itself in place — the third ORBIS port, adapted for the three-platform matrix (#911/#915 groundwork).

**Shell** (`apps/desktop/src-tauri`):
- `tauri-plugin-updater` + `tauri-plugin-dialog`; `plugins.updater` in `tauri.conf.json` with the **org minisign pubkey** (counterpart of the org-level `TAURI_SIGNING_PRIVATE_KEY` orbis already signs with — shared org key by design) and endpoint `releases/latest/download/latest.json`.
- Silent check at launch (release builds only — `tauri dev` runs at the in-tree placeholder version and would always "find" an update) + tray **Check for Updates…**. Prompt → download (signature-verified) → install → relaunch. Errors and "up to date" surface as dialogs only in the interactive path.
- Linux: the plugin manages AppImage installs only; `.deb` is apt's job — that limitation comes back as a plugin error and is surfaced politely.

**CI** (`desktop-build.yml`):
- When `TAURI_SIGNING_PRIVATE_KEY` is present, each leg builds with `--config '{"bundle":{"createUpdaterArtifacts":"v1Compatible"}}'` (injected in CI, not in-tree, so keyless local builds keep working). v1Compatible = the artifact shapes release-tools' `build-updater-manifest` classifies. macOS bundles `app,dmg` since the `.app.tar.gz` derives from the app target.
- Collect keeps the target triple in the updater bundle names (`protoAgent-<v>-aarch64-apple-darwin.app.tar.gz`, `…-setup.nsis.zip`, `….AppImage.tar.gz` + `.sig`) — matching the manifest builder's filename detection exactly.
- New **`updater-manifest` fan-in job** (tag pushes only, `needs: build` so all legs must succeed — a partial manifest would skew versions across platforms): downloads the release's updater bundles, runs `npx @protolabsai/release-tools build-updater-manifest`, uploads `latest.json` **last** so the manifest never points at assets that don't exist yet. No bundles on the release → skips with a notice (that release just has no in-app update).

## Deliberately out of scope

- **First-boot-after-update reconcile** (version-coherence P2: reconcile detached fleet members + plugin re-pin prompts when the sidecar version changes) — server-side work, next PR; valuable for manual `.dmg` swaps too.
- Console-side update UI (DS Badge à la plugin updates #887) — the Rust dialog flow is the v1.

## Validation

- `cargo check` green on the shell changes.
- Will dispatch **Desktop Build** on this branch: with the org key present, all three legs should emit signed updater bundles into the workflow artifacts (validates the per-leg half). The fan-in job is tag-push-only — it gets its first live run on the next release; its skip path (no bundles) is exercised trivially.

🤖 Generated with [Claude Code](https://claude.com/claude-code)