### PR TITLE
fix(memory): default session-memory path via data_home(), not a /sandbox literal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Session memory now persists on non-container hosts (and stops writing to the drive
+  root on Windows).** `MemoryMiddleware`'s default path was a literal `/sandbox/memory/` —
+  on any machine without a `/sandbox` mount (local dev, the desktop sidecar) the create
+  failed on read-only `/` and persistence was *silently skipped*, so agents had no
+  cross-session continuity by default; on Windows the path resolved drive-relative and
+  happily wrote to `\sandbox` at the drive root (caught by the desktop sidecar smoke).
+  The default now routes through `data_home()` — `/sandbox/memory` in a container, else
+  `~/.protoagent/memory`, instance-scoped as before — the same writable fallback every
+  other store already used. `KnowledgeMiddleware.load_memory` drops its duplicate path
+  literal and defers to the writer's resolved `MEMORY_PATH`, so reader and writer can't
+  drift. `MEMORY_PATH` env override unchanged.
+
+### Fixed
 - **A secret saved for an installed-but-DISABLED plugin now routes to `secrets.yaml`,
   not the plaintext config.** Secret routing (`secret_paths`) and the config-redaction
   path keyed off *enabled* plugins only — so a secret for a plugin that's currently off

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -51,9 +51,10 @@ def _in_goal_turn() -> bool:
 class KnowledgeMiddleware(AgentMiddleware):
     """Inject knowledge store context before each LLM call.
 
-    Also loads prior session summaries from /sandbox/memory/ and injects
-    them as a <prior_sessions> block so the agent has continuity across
-    sessions without requiring an active knowledge store.
+    Also loads prior session summaries from the session-memory dir (see
+    ``graph.middleware.memory.MEMORY_PATH``) and injects them as a
+    <prior_sessions> block so the agent has continuity across sessions
+    without requiring an active knowledge store.
     """
 
     def __init__(
@@ -80,7 +81,7 @@ class KnowledgeMiddleware(AgentMiddleware):
 
     def load_memory(
         self,
-        memory_path: str = "/sandbox/memory/",
+        memory_path: str | None = None,
         max_sessions: int = 10,
         max_tokens: int = 2000,
     ) -> str:
@@ -89,11 +90,13 @@ class KnowledgeMiddleware(AgentMiddleware):
 
         Delegates to the shared :func:`graph.middleware.memory.load_prior_sessions`
         (ADR 0021) — one source of truth, with read-time reasoning stripping —
-        so this and ``MemoryMiddleware`` can't drift. Never raises.
+        so this and ``MemoryMiddleware`` can't drift. ``memory_path`` defaults
+        to the writer's resolved ``MEMORY_PATH`` (no duplicate path literal,
+        same can't-drift reasoning). Never raises.
         """
-        from graph.middleware.memory import load_prior_sessions
+        from graph.middleware.memory import MEMORY_PATH, load_prior_sessions
 
-        return load_prior_sessions(memory_path, max_sessions, max_tokens)
+        return load_prior_sessions(memory_path or MEMORY_PATH, max_sessions, max_tokens)
 
     # ---------------------------------------------------------------------------
     # Skill retrieval

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -25,11 +25,18 @@ log = logging.getLogger(__name__)
 # Configuration — read once at module init
 # ---------------------------------------------------------------------------
 
-from infra.paths import scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
+from infra.paths import data_home, scope_leaf  # ADR 0004 — per-instance scoping (no-op when unset)
 
 # ``PROTOAGENT_INSTANCE`` is seeded by server init before the graph (and this
 # middleware) is built, so the instance segment applies here too.
-MEMORY_PATH = str(scope_leaf(os.environ.get("MEMORY_PATH", "/sandbox/memory/")))
+#
+# Default via data_home(): ``/sandbox/memory`` in a container, else
+# ``~/.protoagent/memory`` — the writable fallback every other store already
+# uses. The old literal ``/sandbox/memory/`` silently skipped persistence on
+# any non-container host (read-only ``/``), and on Windows resolved
+# drive-relative and wrote to ``\sandbox`` at the drive root (caught by the
+# desktop sidecar smoke).
+MEMORY_PATH = str(scope_leaf(os.environ.get("MEMORY_PATH") or data_home() / "memory"))
 _DISABLE_ENV = os.environ.get("PROTOAGENT_DISABLE_MEMORY", "")
 _PERSISTENCE_DISABLED = _DISABLE_ENV.lower() in ("1", "true", "yes")
 

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -528,3 +528,26 @@ def test_after_agent_does_not_persist_when_last_msg_not_ai(tmp_path):
         mw.after_agent(state, runtime)
 
     mock_persist.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Default path resolution (no MEMORY_PATH override)
+# ---------------------------------------------------------------------------
+
+def test_default_memory_path_uses_data_home(monkeypatch):
+    """Without MEMORY_PATH, the default resolves under data_home() — the
+    /sandbox-in-a-container, else ~/.protoagent writable fallback every other
+    store uses. The old literal /sandbox/memory/ silently skipped persistence
+    on non-container hosts and, on Windows, wrote to \\sandbox at the drive
+    root (caught by the desktop sidecar smoke)."""
+    from pathlib import Path
+
+    from infra.paths import data_home
+
+    monkeypatch.delenv("MEMORY_PATH", raising=False)
+    monkeypatch.delenv("PROTOAGENT_INSTANCE", raising=False)
+    monkeypatch.delenv("PROTOAGENT_AUTO_SCOPE", raising=False)
+    sys.modules.pop("graph.middleware.memory", None)
+    import graph.middleware.memory as mod
+
+    assert Path(mod.MEMORY_PATH) == data_home() / "memory"


### PR DESCRIPTION
## What

Found live by the desktop sidecar smoke on the new three-platform matrix (#911): the **Windows** frozen server wrote session memory to `\sandbox\<instance>\memory` — the **drive root** — while the **macOS** leg logged `cannot create directory /sandbox/...: Read-only file system — skipping persistence`.

Root cause: `MemoryMiddleware` defaulted to the literal `/sandbox/memory/` with no writable fallback — the only store that didn't route through `data_home()` (`/sandbox` when it exists, i.e. containers, else `~/.protoagent`). Two consequences:

1. **Local/desktop runs silently had no session memory at all** — the mkdir failed and persistence was skipped with only a log line. Cross-session continuity worked in containers but not for the desktop app or local dev (unless `MEMORY_PATH` was set).
2. **Windows created `\sandbox` at the drive root** — the path is drive-relative there and the create *succeeds*, in the wrong place.

## Fix

- `MEMORY_PATH` default → `data_home() / "memory"` (instance-scoped via `scope_leaf` as before; env override unchanged). Container behavior identical (`/sandbox/memory`); everywhere else lands in `~/.protoagent/memory`.
- `KnowledgeMiddleware.load_memory` had its own duplicate `/sandbox/memory/` literal (the prior-sessions *reader*) — it now defers to the writer's resolved `MEMORY_PATH`, per its own "one source of truth, can't drift" docstring.
- Regression test: default resolves under `data_home()` when `MEMORY_PATH` is unset.

## Validation

`tests/test_memory_persistence.py` + knowledge tests: 51 passed. Ruff clean. Existing tests all override `MEMORY_PATH` explicitly and are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)