### PR TITLE
feat(settings): two-home Settings shell (Host/App · Workspace) + QuickSetting [draft, needs local UX pass]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent was told a no-op worked; they now read the real per-plugin load status and surface
   "FAILED to load: <error>" so you fix-and-reload instead of testing nothing.
 ### Added
+- **Settings are reorganizing around *scope* — a two-home shell + contextual quick-settings (ADR 0048, in progress).**
+  The central Settings surface now leads with the two scope homes from ADR 0048 — **🖥 Host / App**
+  (box-shared: Overview · Host config · Fleet · Telemetry · Commons) and **🧩 Workspace** (the focused
+  agent: Theme · Plugins · System for now; the agent makeup folds in next). Scope is the primary axis,
+  replacing the flat category tabs (`settingsTab` → `settingsScope` + `settingsSection`, persist v3).
+  Alongside the one-stop-shop, a reusable **`QuickSetting`** primitive puts a gear-icon → dialog
+  *contextual* shortcut wherever a setting is relevant (it edits the same fields via the same
+  cascade-aware `/api/settings` write path) — first one lands on the Skills surface (skill-sharing mode).
+  Part of #916; the Agent rail surface stays until the collapse slice.
 - **The shared-skill commons is now legible in the console (ADR 0041 / 0048).** The
   layered skill tier ("shared brain, private hands" — read commons ∪ private, write
   private) shipped at the data layer but was invisible: the Skills surface couldn't tell

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -9,7 +9,7 @@ test.describe.configure({ mode: "serial" });
 async function openAgents(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Agents", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Fleet", exact: true }).click();
 }
 
 test("Agents tab lists the host (this instance) + peers, host active by default", async ({ page }) => {
@@ -142,7 +142,7 @@ test("discover → add to fleet → switch into the remote member (ADR 0042 §I)
 
   // Unregister from the fleet manager (the remote agent itself is untouched).
   await page.getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Agents", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Fleet", exact: true }).click();
   await page.locator(".fleet-row", { hasText: "remy" })
     .getByRole("button", { name: /Remove from this fleet/ }).click();
   await expect(page.locator(".fleet-row", { hasText: "remy" })).toHaveCount(0);

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,32 +1,44 @@
 import { expect, test } from "@playwright/test";
 
-// Settings are decentralized: Agent settings live in the Agent view, Memory in the
-// Knowledge view, and the central Settings surface keeps only the cross-cutting tabs
-// (Overview · Telemetry · Plugins · System). Each renders GET /api/settings/schema
-// groups for its category and saves via POST /api/settings (auto-reload).
+// Settings IA (ADR 0048): scope is the primary axis — TWO homes, each with its own
+// section sub-nav. 🖥 Host / App (box-shared) and 🧩 Workspace (the focused agent).
+// Each section renders GET /api/settings/schema groups for its category and saves via
+// POST /api/settings (auto-reload). The Agent rail surface still hosts the agent
+// makeup until the S-C collapse.
 
 async function openSettings(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();
 }
 
+// Click a home (row 1) or a section (row 2) — names are unique across both strips.
 async function tab(page, name) {
   await page.locator(".pl-tabs").getByRole("tab", { name, exact: true }).click();
 }
 
-test("central Settings is just the cross-cutting tabs", async ({ page }) => {
+test("Settings is a two-home shell (Host / App · Workspace)", async ({ page }) => {
   await openSettings(page);
-  expect(await page.locator(".pl-tabs button").allTextContents()).toEqual([
+  // Row 1 — the two scope homes (ADR 0048).
+  expect(await page.locator(".pl-tabs").first().locator("button").allTextContents()).toEqual([
+    "Host / App",
+    "Workspace",
+  ]);
+  // Row 2 — the Host / App home's sections (the default home).
+  expect(await page.locator(".pl-tabs").nth(1).locator("button").allTextContents()).toEqual([
     "Overview",
-    "Agents",
-    "Theme",
+    "Host config",
+    "Fleet",
     "Telemetry",
+    "Commons",
+  ]);
+  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible(); // default section
+  // The Workspace home → its sections; System holds the runtime/perf knobs.
+  await tab(page, "Workspace");
+  expect(await page.locator(".pl-tabs").nth(1).locator("button").allTextContents()).toEqual([
+    "Theme",
     "Plugins",
     "System",
-    "Host defaults", // ADR 0047 — the host-scoped subset, edited at the host layer
   ]);
-  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible(); // default
-  // System holds the runtime/perf knobs (Compaction + Runtime here).
   await tab(page, "System");
   await expect(page.locator(".settings-group-title").first()).toBeVisible(); // wait for the suspense load
   expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Compaction", "Runtime"]);
@@ -59,6 +71,7 @@ test("editing an Agent setting enables save and round-trips", async ({ page }) =
 
 test("a restart-flagged System field shows the restart banner", async ({ page }) => {
   await openSettings(page);
+  await tab(page, "Workspace");
   await tab(page, "System");
   await expect(page.locator(".settings-banner")).toHaveCount(0);
   await page.locator('.setting-row[data-key="runtime.autostart_on_boot"] input[type="checkbox"]').check();
@@ -91,9 +104,9 @@ test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ pag
   ).toHaveCount(0);
 });
 
-test("Host defaults view edits the host-scoped subset and saves to the host layer", async ({ page }) => {
+test("Host config edits the host-scoped subset and saves to the host layer", async ({ page }) => {
   await openSettings(page);
-  await tab(page, "Host defaults");
+  await tab(page, "Host config"); // Host / App is the default home
   await expect(page.locator(".settings-banner").first()).toContainText("box-shared");
   // Only host-scoped fields appear — model.name (host) is here; the agent-scoped
   // model.api_key + routing.fallback_models are NOT.

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -75,7 +75,7 @@ import { ChatSlot } from "./ChatSlot";
 import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
-import { SettingsSurface, SETTINGS_TABS, type SettingsTab } from "../settings/SettingsSurface";
+import { SettingsSurface } from "../settings/SettingsSurface";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
@@ -232,8 +232,9 @@ export function App() {
   const setPluginsTab = useUI((s) => s.setPluginsTab);
   const knowledgeTab = useUI((s) => s.knowledgeTab);
   const setKnowledgeTab = useUI((s) => s.setKnowledgeTab);
-  const settingsTab = useUI((s) => s.settingsTab);
-  const setSettingsTab = useUI((s) => s.setSettingsTab);
+  const setSettingsScope = useUI((s) => s.setSettingsScope);
+  const setSettingsSection = useUI((s) => s.setSettingsSection);
+  const setFleetStartNew = useUI((s) => s.setFleetStartNew);
   const activityTab = useUI((s) => s.activityTab);
   const setActivityTab = useUI((s) => s.setActivityTab);
   const rightPanel = useUI((s) => s.rightPanel);
@@ -569,12 +570,8 @@ export function App() {
           </>
         );
       case "settings":
-        return (
-          <>
-            <Tabs responsive active={settingsTab} onSelect={(t) => setSettingsTab(t as SettingsTab)} items={SETTINGS_TABS.map(toTab)} />
-            <SettingsSurface tab={settingsTab} />
-          </>
-        );
+        // SettingsSurface owns its own two-level nav (home + section, ADR 0048).
+        return <SettingsSurface />;
       // Notes is now the first-party `notes` plugin (ADR 0034 S4) — rendered via the default
       // plugin-view case below, not a native surface.
       case "beads":
@@ -731,8 +728,12 @@ export function App() {
           <FleetSwitcher
             fallbackName={brandName(runtime?.identity?.name)}
             onNewAgent={() => {
+              // Fleet now lives under Host / App ▸ Fleet (ADR 0048); ask the panel to
+              // open the new-agent picker on mount.
               setSurface("settings");
-              setSettingsTab("agents");
+              setSettingsScope("host");
+              setSettingsSection("fleet");
+              setFleetStartNew(true);
             }}
           />
         }

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -1,12 +1,13 @@
 import { Input } from "@protolabsai/ui/forms";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { ArrowUpToLine, BookMarked, Library, Pin, RefreshCw, Sparkles, Trash2 } from "lucide-react";
+import { ArrowUpToLine, BookMarked, Library, Pin, RefreshCw, Share2, Sparkles, Trash2 } from "lucide-react";
 
 import { useEffect, useMemo, useState } from "react";
 
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { api } from "../lib/api";
+import { QuickSetting } from "../settings/QuickSetting";
 import type { Playbook } from "../lib/types";
 
 // Playbooks surface (ADR 0009) — browse + manage the procedural-memory skill
@@ -108,9 +109,14 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
         title="Skills"
         kicker={`methodology the agent retrieves into context · ${pinned} pinned · ${learned} learned${layered ? ` · ${fromCommons} from commons` : ""}`}
         actions={
-          <Button icon variant="ghost" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
-            <RefreshCw size={16} className={loading ? "spin" : ""} />
-          </Button>
+          <>
+            {/* Quick-set the skill-sharing mode (scoped/shared/layered) right where you
+                manage skills — same field as Workspace ▸ Skills, ADR 0048. */}
+            <QuickSetting keys={["skills.scope"]} title="Skill sharing" label="Skill sharing mode" icon={<Share2 size={16} />} />
+            <Button icon variant="ghost" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
+              <RefreshCw size={16} className={loading ? "spin" : ""} />
+            </Button>
+          </>
         }
       />
 

--- a/apps/web/src/settings/CommonsPanel.tsx
+++ b/apps/web/src/settings/CommonsPanel.tsx
@@ -1,0 +1,71 @@
+import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
+import { PanelHeader } from "@protolabsai/ui/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { Library, RefreshCw } from "lucide-react";
+
+import { api } from "../lib/api";
+
+// Host / App ▸ Commons (ADR 0041 + 0048) — the box-shared skill library every agent
+// on this machine reads (commons ∪ private, in layered mode). Read-only here: a
+// skill enters the commons by being PROMOTED from a workspace (Workspace ▸ Skills),
+// which is the curated, explicit "shared brain, private hands" lift. The commons
+// LOCATION (`commons.path`) is a host-scoped field edited in Host ▸ Host config.
+
+export function CommonsPanel() {
+  const q = useQuery({ queryKey: ["playbooks"], queryFn: () => api.playbooks(), retry: false });
+  const all = q.data?.playbooks ?? [];
+  const commons = all.filter((p) => p.tier === "commons");
+  const layered = all.some((p) => p.tier);
+
+  return (
+    <section className="panel stage-panel" data-testid="commons-panel">
+      <PanelHeader
+        title="Commons"
+        kicker={`the box-shared skill library · ${commons.length} skill${commons.length === 1 ? "" : "s"}`}
+        actions={
+          <Button icon variant="ghost" type="button" onClick={() => void q.refetch()} disabled={q.isFetching} title="Refresh">
+            <RefreshCw size={16} className={q.isFetching ? "spin" : ""} />
+          </Button>
+        }
+      />
+      <div className="stage-body">
+        {!layered ? (
+          <Empty
+            title="No commons in use"
+            description="No agent on this box is in layered mode. Set an agent's Skill sharing to “layered” (Workspace ▸ Skills) to read + contribute to a shared commons, and choose its location in Host config (commons.path)."
+          />
+        ) : commons.length === 0 ? (
+          <Empty
+            title="The commons is empty"
+            description="Promote a proven skill from a workspace (Workspace ▸ Skills ▸ Promote) to share it with every agent on this box."
+          />
+        ) : (
+          <ul className="playbook-list">
+            {commons.map((p) => (
+              <li key={p.id} className="playbook-card">
+                <div className="playbook-main">
+                  <div className="playbook-title">
+                    <span title="Shared commons — readable by every agent on this box">
+                      <Badge status="neutral">
+                        <Library size={12} /> commons
+                      </Badge>
+                    </span>
+                    <strong>{p.name}</strong>
+                  </div>
+                  <p className="playbook-desc">{p.description}</p>
+                  {p.tools_used.length ? (
+                    <div className="playbook-tools">
+                      {p.tools_used.map((t) => (
+                        <code key={t}>{t}</code>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/settings/FleetSurface.tsx
+++ b/apps/web/src/settings/FleetSurface.tsx
@@ -1,12 +1,25 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { useUI } from "../state/uiStore";
 import { FleetManagerPanel } from "./FleetManagerPanel";
 import { NewAgentPanel } from "./NewAgentPanel";
 
-// Settings → Agents (ADR 0042). The fleet manager + the new-agent picker, toggled in
-// place — "+ New agent" opens the picker, which returns to the list on create/cancel.
+// Host / App ▸ Fleet (ADR 0042 / 0048). The fleet manager + the new-agent picker,
+// toggled in place — "+ New agent" opens the picker, which returns to the list on
+// create/cancel. The FleetSwitcher's "+ New agent" deep-link sets a one-shot
+// `fleetStartNew` flag (ADR 0048) so landing here opens the picker straight away.
 export function FleetSurface() {
-  const [view, setView] = useState<"list" | "new">("list");
+  const startNew = useUI((s) => s.fleetStartNew);
+  const setStartNew = useUI((s) => s.setFleetStartNew);
+  const [view, setView] = useState<"list" | "new">(startNew ? "new" : "list");
+
+  useEffect(() => {
+    if (startNew) {
+      setView("new");
+      setStartNew(false); // consume the one-shot so a manual back-to-list sticks
+    }
+  }, [startNew, setStartNew]);
+
   if (view === "new") {
     return <NewAgentPanel onDone={() => setView("list")} onCancel={() => setView("list")} />;
   }

--- a/apps/web/src/settings/QuickSetting.tsx
+++ b/apps/web/src/settings/QuickSetting.tsx
@@ -1,0 +1,148 @@
+import "./settings.css";
+
+import { Button } from "@protolabsai/ui/primitives";
+import { Dialog } from "@protolabsai/ui/overlays";
+import { PanelHeader } from "@protolabsai/ui/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ExternalLink, Loader2, Save, Settings2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+import { api } from "../lib/api";
+import { queryKeys, settingsSchemaQuery } from "../lib/queries";
+import type { SettingsField } from "../lib/types";
+import { SettingInput } from "./SettingsCategory";
+
+// QuickSetting (ADR 0048) — a contextual settings shortcut: a small icon button that
+// opens a dialog editing one (or a few) named fields right where they're relevant,
+// instead of making the operator navigate to the central Settings home. It edits the
+// SAME fields via the SAME /api/settings write path + cascade (so a host-scoped field
+// saves to the host layer); the central Settings surface stays the canonical
+// one-stop-shop. Drop one in anywhere:
+//
+//   <QuickSetting keys={["skills.scope"]} title="Skill sharing" />
+//   <QuickSetting keys={["model.temperature", "model.max_tokens"]} title="Model tuning" />
+
+export function QuickSetting({
+  keys,
+  title = "Quick settings",
+  label,
+  icon,
+  deepLink,
+}: {
+  keys: string[];
+  title?: string;
+  /** Accessible label / tooltip for the trigger button (defaults to title). */
+  label?: string;
+  /** Trigger glyph (defaults to a gear). */
+  icon?: ReactNode;
+  /** Optional "Open full settings →" callback (e.g. route to the central home). */
+  deepLink?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button icon variant="ghost" type="button" title={label ?? title} aria-label={label ?? title} onClick={() => setOpen(true)}>
+        {icon ?? <Settings2 size={15} />}
+      </Button>
+      {open ? (
+        <QuickSettingDialog keys={keys} title={title} deepLink={deepLink} onClose={() => setOpen(false)} />
+      ) : null}
+    </>
+  );
+}
+
+function QuickSettingDialog({
+  keys,
+  title,
+  deepLink,
+  onClose,
+}: {
+  keys: string[];
+  title: string;
+  deepLink?: () => void;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const schema = useQuery(settingsSchemaQuery());
+  const [dirty, setDirty] = useState<Record<string, unknown>>({});
+  const [status, setStatus] = useState("");
+
+  const fields = useMemo<SettingsField[]>(() => {
+    const byKey = new globalThis.Map<string, SettingsField>();
+    for (const g of schema.data?.groups ?? []) for (const f of g.fields) byKey.set(f.key, f);
+    return keys.map((k) => byKey.get(k)).filter((f): f is SettingsField => Boolean(f));
+  }, [schema.data, keys]);
+
+  // Save to the host layer iff every edited field is host-scoped (a mixed set is
+  // unusual for a quick-set; default to the agent leaf then).
+  const layer = fields.length && fields.every((f) => f.scope === "host") ? "host" : "agent";
+
+  const save = useMutation({
+    mutationFn: () => api.saveSettings(dirty, layer),
+    onMutate: () => setStatus("saving…"),
+    onSuccess: (r) => {
+      if (!r.ok) {
+        setStatus(`save failed: ${r.messages.join(" · ")}`);
+        return;
+      }
+      void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
+      onClose();
+    },
+    onError: (e) => setStatus(`save failed: ${e instanceof Error ? e.message : String(e)}`),
+  });
+
+  const dirtyKeys = Object.keys(dirty);
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      title={title}
+      width={460}
+      className="quick-setting-dialog"
+      footer={
+        <>
+          {deepLink ? (
+            <Button type="button" variant="ghost" onClick={() => { onClose(); deepLink(); }}>
+              <ExternalLink size={14} /> Open full settings
+            </Button>
+          ) : null}
+          <Button type="button" onClick={onClose} disabled={save.isPending}>Cancel</Button>
+          <Button variant="primary" type="button" onClick={() => save.mutate()} disabled={save.isPending || !dirtyKeys.length}>
+            {save.isPending ? <Loader2 className="spin" size={15} /> : <Save size={15} />} Save
+          </Button>
+        </>
+      }
+    >
+      {schema.isLoading ? (
+        <p className="muted">Loading…</p>
+      ) : !fields.length ? (
+        <p className="muted">Nothing to configure here.</p>
+      ) : (
+        <div className="quick-setting-body">
+          {fields.map((field) => (
+            <div className="setting-row" key={field.key} data-key={field.key}>
+              <div className="setting-meta">
+                <label className="setting-label" htmlFor={`set-${field.key}`}>
+                  {field.label}
+                  {field.restart ? <span className="setting-restart">restart</span> : null}
+                  {field.scope === "host" ? <span className="setting-restart">box-shared</span> : null}
+                </label>
+                {field.description ? <p className="setting-desc">{field.description}</p> : null}
+              </div>
+              <div className="setting-control">
+                <SettingInput
+                  field={field}
+                  value={field.key in dirty ? dirty[field.key] : field.value}
+                  onChange={(v) => setDirty((d) => ({ ...d, [field.key]: v }))}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {status ? <p className="settings-status">{status}</p> : null}
+    </Dialog>
+  );
+}

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -37,7 +37,13 @@ export function SettingsCategoryPanel(props: { category: string; title?: string;
 // categories, editable, saving to the host layer. Surfaced as its own Settings tab.
 // TODO(ADR 0047 §7): gate to the host console (slug=host); for now it renders for any
 // focused agent, clearly labeled "box-shared", so the slice isn't blocked on gating.
-export function HostDefaultsPanel({ categories = ["Agent", "System"] }: { categories?: string[] }) {
+export function HostDefaultsPanel({
+  categories = ["Agent", "System"],
+  title = "Host defaults",
+}: {
+  categories?: string[];
+  title?: string;
+}) {
   // ONE panel — the host-scoped fields across all the given categories render
   // together under a single header + Save bar + explainer (grouped by their
   // section). Previously this mapped one full SettingsCategory PER category, which
@@ -51,7 +57,7 @@ export function HostDefaultsPanel({ categories = ["Agent", "System"] }: { catego
               <SettingsCategory
                 category={categories[0]}
                 categories={categories}
-                title="Host defaults"
+                title={title}
                 emptyHint="No box-shared defaults on this box yet."
                 hostLayer
               />
@@ -400,7 +406,7 @@ function SettingRow({
   );
 }
 
-function SettingInput({ field, value, onChange }: { field: SettingsField; value: unknown; onChange: (value: unknown) => void }) {
+export function SettingInput({ field, value, onChange }: { field: SettingsField; value: unknown; onChange: (value: unknown) => void }) {
   const id = `set-${field.key}`;
 
   if (field.type === "bool") {

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,45 +1,97 @@
-import { BarChart3, Gauge, HardDrive, Palette, Puzzle, Server, Settings2 } from "lucide-react";
+import { BarChart3, Boxes, Gauge, HardDrive, Library, Palette, Puzzle, Server, Settings2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
 
+import { Tabs } from "@protolabsai/ui/navigation";
+
+import { useUI, type SettingsScope } from "../state/uiStore";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
+import { CommonsPanel } from "./CommonsPanel";
 import { DelegatesSection } from "./DelegatesSection";
 import { FleetSurface } from "./FleetSurface";
 import { OverviewPanel } from "./OverviewPanel";
 import { HostDefaultsPanel, SettingsCategoryPanel } from "./SettingsCategory";
 import { ThemeSurface } from "./ThemeSurface";
 
-// Central Settings — only cross-cutting stuff now (the settings decentralization):
-// Overview (status), Telemetry, Plugins (delegates + the settings for any view-less
-// plugin), and System (runtime/middleware). Agent + Memory settings moved to their
-// home views (Agent → Settings, Knowledge → Settings).
+// Settings IA (ADR 0048) — scope is the primary axis. TWO homes, each with its own
+// section sub-nav, replacing the old flat category tabs:
+//
+//   🖥 Host / App   — box-shared, reachable from any workspace (set once, every agent
+//                     inherits; per-agent overrides win, ADR 0047).
+//   🧩 Workspace    — the focused agent: everything that defines it.
+//
+// S-A builds the Host/App home in full and a transitional Workspace home (today's
+// agent-scoped central settings). S-B folds the agent makeup (Identity/Tools/MCP/
+// Subagents/Skills/Middleware + Model/Behavior) into Workspace; S-C removes the
+// standalone Agent rail surface + the old category tabs.
 
-export type SettingsTab = "overview" | "agents" | "theme" | "telemetry" | "plugins" | "system" | "host";
+type Section = { id: string; label: string; icon: LucideIcon; render: () => ReactNode };
+type Home = { id: SettingsScope; label: string; icon: LucideIcon; sections: Section[] };
 
-export const SETTINGS_TABS = [
-  { id: "overview", label: "Overview", icon: Gauge },
-  { id: "agents", label: "Agents", icon: Server },
-  { id: "theme", label: "Theme", icon: Palette },
-  { id: "telemetry", label: "Telemetry", icon: BarChart3 },
-  { id: "plugins", label: "Plugins", icon: Puzzle },
-  { id: "system", label: "System", icon: Settings2 },
-  // Host / box-shared defaults (ADR 0047) — the host-scoped subset, edited at the host layer.
-  { id: "host", label: "Host defaults", icon: HardDrive },
-] as const;
+const HOST_SECTIONS: Section[] = [
+  { id: "overview", label: "Overview", icon: Gauge, render: () => <OverviewPanel /> },
+  // The host-scoped FIELDS (model gateway · routing · caching · org + the commons
+  // location) in ONE panel, saving to the box's host-config.yaml (ADR 0047).
+  { id: "config", label: "Host config", icon: HardDrive, render: () => <HostDefaultsPanel title="Host configuration" /> },
+  { id: "fleet", label: "Fleet", icon: Server, render: () => <FleetSurface /> },
+  { id: "telemetry", label: "Telemetry", icon: BarChart3, render: () => <TelemetrySurface /> },
+  // The box-shared skill commons (ADR 0041): browse it, promote from a workspace.
+  { id: "commons", label: "Commons", icon: Library, render: () => <CommonsPanel /> },
+];
 
-export function SettingsSurface({ tab = "overview" }: { tab?: SettingsTab }) {
-  if (tab === "agents") return <FleetSurface />;              // the fleet (ADR 0042)
-  if (tab === "theme") return <ThemeSurface />;               // per-agent look (ADR 0042)
-  if (tab === "telemetry") return <TelemetrySurface />;       // self-contained (own section + boundary)
-  if (tab === "plugins") {
-    return (
+const WORKSPACE_SECTIONS: Section[] = [
+  { id: "theme", label: "Theme", icon: Palette, render: () => <ThemeSurface /> },
+  {
+    id: "plugins",
+    label: "Plugins",
+    icon: Puzzle,
+    render: () => (
       <SettingsCategoryPanel
         category="Plugins"
         title="Plugin settings"
         emptyHint="Plugins with their own view manage settings there. Anything view-less shows up here."
         footer={<DelegatesSection />}
       />
-    );
+    ),
+  },
+  { id: "system", label: "System", icon: Settings2, render: () => <SettingsCategoryPanel category="System" title="System" /> },
+];
+
+export const SETTINGS_HOMES: Home[] = [
+  { id: "host", label: "Host / App", icon: HardDrive, sections: HOST_SECTIONS },
+  { id: "workspace", label: "Workspace", icon: Boxes, sections: WORKSPACE_SECTIONS },
+];
+
+const tabItems = (xs: { id: string; label: string; icon: LucideIcon }[]) =>
+  xs.map((x) => ({ id: x.id, label: x.label, icon: <x.icon size={15} /> }));
+
+export function SettingsSurface() {
+  const scope = useUI((s) => s.settingsScope);
+  const section = useUI((s) => s.settingsSection);
+  const setScope = useUI((s) => s.setSettingsScope);
+  const setSection = useUI((s) => s.setSettingsSection);
+
+  const home = SETTINGS_HOMES.find((h) => h.id === scope) ?? SETTINGS_HOMES[0];
+  const active = home.sections.find((s) => s.id === section) ?? home.sections[0];
+
+  // Switching home lands on its first section unless the current section id also
+  // exists in the new home (it usually won't — the homes don't share section ids).
+  function selectHome(next: SettingsScope) {
+    const h = SETTINGS_HOMES.find((x) => x.id === next) ?? SETTINGS_HOMES[0];
+    setScope(next);
+    if (!h.sections.some((s) => s.id === section)) setSection(h.sections[0].id);
   }
-  if (tab === "system") return <SettingsCategoryPanel category="System" title="System" />;
-  if (tab === "host") return <HostDefaultsPanel />;            // box-shared defaults (ADR 0047)
-  return <OverviewPanel />;                                    // overview (default; own section)
+
+  return (
+    <>
+      <Tabs
+        responsive
+        active={scope}
+        onSelect={(t) => selectHome(t as SettingsScope)}
+        items={tabItems(SETTINGS_HOMES)}
+      />
+      <Tabs responsive active={active.id} onSelect={(t) => setSection(t)} items={tabItems(home.sections)} />
+      {active.render()}
+    </>
+  );
 }

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -7,6 +7,18 @@
 .settings-banner {
   margin-bottom: 10px;
 }
+/* QuickSetting dialog (ADR 0048) — contextual settings shortcut. Reuses the
+   .setting-row chrome; the dialog just stacks the rows with breathing room. */
+.quick-setting-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.quick-setting-body .setting-row {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+}
 .settings-group {
   margin-bottom: 40px;
 }

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -16,6 +16,14 @@ describe("migrateUiState", () => {
     expect(migrateUiState({ leftActive: "chat" })).toEqual({ leftActive: "chat" });
   });
 
+  // v2→v3 (ADR 0048): the flat `settingsTab` is replaced by `settingsScope` +
+  // `settingsSection`; a stale `settingsTab` must be dropped so the new defaults apply.
+  it("drops the obsolete settingsTab", () => {
+    const out = migrateUiState({ settingsTab: "host", rightWidth: 320 }) as Record<string, unknown>;
+    expect(out).not.toHaveProperty("settingsTab");
+    expect(out).toEqual({ rightWidth: 320 });
+  });
+
   it("does not mutate the input object", () => {
     const input = { railOf: { chat: "left" }, leftActive: "chat" };
     migrateUiState(input);

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -12,8 +12,6 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
-import type { SettingsTab } from "../settings/SettingsSurface";
-
 // Per-agent layout (ADR 0042). Each fleet agent keeps its OWN layout — rail order, widths,
 // active surface, plugins out. In the single-agent product that fell out for free (each agent
 // is its own origin → its own localStorage); the unified console collapses that, so we namespace
@@ -45,6 +43,10 @@ export type AgentTab = "identity" | "settings" | "tools" | "mcp" | "subagents" |
 export type PluginsTab = "local" | "market" | "download";
 export type KnowledgeTab = "store" | "settings";
 export type ActivityTab = "thread" | "inbox";
+// Settings IA (ADR 0048): scope is the primary axis — two homes, each with its own
+// section sub-nav. `settingsScope` picks the home; `settingsSection` the active
+// section within it (a free string so each home owns its own section ids).
+export type SettingsScope = "host" | "workspace";
 
 const RIGHT_MIN = 280;
 const RIGHT_MAX = 720;
@@ -56,7 +58,11 @@ type UIState = {
   agentTab: AgentTab;
   pluginsTab: PluginsTab;
   knowledgeTab: KnowledgeTab;
-  settingsTab: SettingsTab;
+  settingsScope: SettingsScope;
+  settingsSection: string;
+  // One-shot: the FleetSwitcher's "+ New agent" deep-link routes to Host/App ▸ Fleet
+  // and asks the fleet panel to open the new-agent picker on mount, then clears it.
+  fleetStartNew: boolean;
   activityTab: ActivityTab;
   rightCollapsed: boolean;
   leftCollapsed: boolean;
@@ -81,7 +87,9 @@ type UIState = {
   setAgentTab: (t: AgentTab) => void;
   setPluginsTab: (t: PluginsTab) => void;
   setKnowledgeTab: (t: KnowledgeTab) => void;
-  setSettingsTab: (t: SettingsTab) => void;
+  setSettingsScope: (s: SettingsScope) => void;
+  setSettingsSection: (s: string) => void;
+  setFleetStartNew: (b: boolean) => void;
   setActivityTab: (t: ActivityTab) => void;
   setRightCollapsed: (b: boolean) => void;
   setLeftCollapsed: (b: boolean) => void;
@@ -96,7 +104,10 @@ type UIState = {
  * falls back to the default via the store's merge. Exported for unit testing. */
 export function migrateUiState(persisted: unknown): unknown {
   if (persisted && typeof persisted === "object") {
-    const { railOf: _drop, ...rest } = persisted as Record<string, unknown>;
+    // v2: drop the obsolete `railOf` (side map). v3 (ADR 0048): drop the flat
+    // `settingsTab` — replaced by `settingsScope` + `settingsSection`, which fall
+    // back to the store defaults via the persist merge.
+    const { railOf: _drop, settingsTab: _drop2, ...rest } = persisted as Record<string, unknown>;
     return rest;
   }
   return persisted;
@@ -110,7 +121,9 @@ export const useUI = create<UIState>()(
       agentTab: "identity",
       pluginsTab: "local",
       knowledgeTab: "store",
-      settingsTab: "overview" as SettingsTab,
+      settingsScope: "host" as SettingsScope,
+      settingsSection: "overview",
+      fleetStartNew: false,
       activityTab: "thread",
       rightCollapsed: false,
       leftCollapsed: false,
@@ -164,7 +177,11 @@ export const useUI = create<UIState>()(
       setAgentTab: (agentTab) => set({ agentTab }),
       setPluginsTab: (pluginsTab) => set({ pluginsTab }),
       setKnowledgeTab: (knowledgeTab) => set({ knowledgeTab }),
-      setSettingsTab: (settingsTab) => set({ settingsTab }),
+      // Switching home resets to that home's first section (its own default lives in
+      // SettingsSurface); callers that want a specific section call setSettingsSection too.
+      setSettingsScope: (settingsScope) => set({ settingsScope }),
+      setSettingsSection: (settingsSection) => set({ settingsSection }),
+      setFleetStartNew: (fleetStartNew) => set({ fleetStartNew }),
       setActivityTab: (activityTab) => set({ activityTab }),
       setRightCollapsed: (rightCollapsed) => set({ rightCollapsed }),
       setLeftCollapsed: (leftCollapsed) => set({ leftCollapsed }),
@@ -182,7 +199,7 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 2, // v2: railOf (side map) → railOrder (ordered lists per rail)
+      version: 3, // v2: railOf→railOrder. v3: settingsTab→settingsScope+settingsSection (ADR 0048)
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
     },
   ),


### PR DESCRIPTION
> **Draft — needs the operator's local UX pass** (UI local-test gate). Stacked on #917 (base = `feat/skills-inheritance-ui`); retarget to `main` once #917 merges.

## What

The first visible step of the settings-IA reorg around **scope** ([ADR 0048](docs/adr/0048-settings-ia-two-scope-homes.md), #916). The central Settings surface now leads with the **two scope homes**, replacing the flat category tabs — plus a reusable **`QuickSetting`** primitive for contextual "quick-set" shortcuts.

```
Settings
├── 🖥 Host / App     Overview · Host config · Fleet · Telemetry · Commons   (box-shared)
└── 🧩 Workspace      Theme · Plugins · System                              (the focused agent)
```

Scope is the primary axis; sections are the second level. **Additive** — the Agent rail surface + its settings stay until the S-C collapse, so nothing is lost yet.

## Changes

- **uiStore**: `settingsTab` → `settingsScope` (`host` | `workspace`) + `settingsSection`; persist **v3** strips the obsolete key. One-shot `fleetStartNew` preserves the FleetSwitcher "+ New agent" deep-link (→ Host/App ▸ Fleet with the picker open).
- **SettingsSurface** owns its own two-level nav (home row + section row); `App.tsx` just renders it. `HostDefaultsPanel` gains a `title` prop.
- **Commons** section (S-Skills.4): browse the box-shared commons skill library; explains promote-from-workspace + the host-scoped `commons.path`.
- **`QuickSetting`** (your "icon-button → dialog, quick-set where it makes sense"): a gear icon opens a DS `Dialog` editing one or more named fields, saving via the **same** cascade-aware `/api/settings` path (host-scoped fields → host layer). The central home stays the canonical one-stop-shop. First placement: **skill-sharing mode** on the Skills surface header.

## Placement decisions (locked with the operator)
Fleet → Host/App · Theme → Workspace · Telemetry → Host/App. `plugins.sources` → Host/App is deferred (ADR 0048 says follow-up; no sources UI exists yet).

## Tests / gates
`tsc -p` + `tsc -p node` + `vite build` clean · vitest **44 passed** (added the v3 migration drop) · CSS comment guard green · e2e updated for the new nav (two-home shell, Agents→Fleet). **Playwright not run here** — deferred to the local pass per the gate.

## Try it
Settings ▸ (defaults to Host / App ▸ Overview) — toggle to Workspace; open the gear on the Skills surface to quick-set sharing mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
