### PR TITLE
feat(fleet): first-boot-after-update reconcile — stamp versions, live skew warning

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **An app update can no longer silently strand fleet members on the old binary**
+  (version-coherence P2). Members are detached processes — one that survives a hub
+  update (crashed hub, or the `PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT` opt-out) keeps
+  running OLD code indefinitely, invisibly. Now: `start()` stamps the spawner's app
+  version on the member record, the hub stamps each boot's version beside `fleet.json`
+  and logs the transition (`reconcile_on_boot` — an in-app update, DMG swap, or
+  `git pull` all land here), and a **live, self-clearing warning** rides the runtime
+  status whenever a running local member's spawn version differs from the hub's —
+  same posture as the co-location banner, clearing the moment the member is
+  restarted. The Fleet panel's version-skew badge now covers local members too
+  (it was remote-only), with a restart hint.
+
+### Added
 - **The desktop app updates itself in place.** tauri-plugin-updater wired into the shell:
   a silent check at launch (release builds) plus a tray "Check for Updates…" item; it polls
   `latest.json` on the GitHub Release, verifies the bundle's minisign signature against the

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -213,12 +213,14 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                           <Badge status="neutral">remote</Badge>
                         </span>
                       ) : null}
-                      {/* Version skew (hub↔remote handshake): the hub console drives this
-                          remote's /api/* by proxy, so a different release can misbehave. */}
-                      {a.remote && a.version && hubVersion && a.version !== hubVersion ? (
+                      {/* Version skew — remotes (hub↔remote handshake) AND local members:
+                          a local member spawned before an app update keeps running the OLD
+                          binary until restarted (version-coherence P2), so it gets the same
+                          warning badge a drifted remote does. */}
+                      {a.version && hubVersion && a.version !== hubVersion ? (
                         <span
                           data-testid="fleet-version-skew"
-                          title={`This remote runs v${a.version}, the hub runs v${hubVersion} — features may misbehave across the version gap.`}
+                          title={`This ${a.remote ? "remote" : "member"} runs v${a.version}, the hub runs v${hubVersion} — ${a.remote ? "features may misbehave across the version gap." : "restart it (Stop → Start) to pick up the hub's binary."}`}
                         >
                           <Badge status="warning">v{a.version}</Badge>
                         </span>

--- a/docs/dev/version-coherence.md
+++ b/docs/dev/version-coherence.md
@@ -221,8 +221,12 @@ and the `min_protoagent_version` gate wrongly refuses every plugin that sets one
    path) so local fleet works on desktop and members run the current binary.
 10. **Bundle `git`** into the sidecar (as Docker bundles `br`/`gh`) **or** gate plugin
     install behind a PATH-`git` probe with a clear error.
-11. **On app update, reconcile detached members** from `fleet.json` — offer to restart
-    the ones still running the old binary.
+11. ~~**On app update, reconcile detached members** from `fleet.json` — offer to restart
+    the ones still running the old binary.~~ **SHIPPED**: `start()` stamps the spawner's
+    version on the member record; `reconcile_on_boot()` stamps each boot's version beside
+    `fleet.json` and logs the update transition; `version_skew_warning()` rides the runtime
+    status per poll (self-clearing) and the Fleet panel's skew badge now covers LOCAL
+    members, not just remotes.
 
 ## The framing to keep
 

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -128,9 +128,15 @@ def start(ident: str) -> dict:
         logf = open(log_path, "a")  # noqa: SIM115 — handed to the child; closed on its exit
         # start_new_session detaches it from this CLI's process group so it survives exit.
         proc = subprocess.Popen(argv, env=full_env, stdout=logf, stderr=logf, start_new_session=True)
+        from infra.paths import package_version
+
         now = datetime.now(timezone.utc).isoformat()
         rec = {"pid": proc.pid, "port": ws.get("port"), "id": wid,
-               "started_at": now, "last_active": now, "log": str(log_path)}
+               "started_at": now, "last_active": now, "log": str(log_path),
+               # The spawner's app version (version-coherence P1/P2): a member is
+               # this binary until restarted, so status()/version_skew_warning()
+               # can surface a live member left behind by an app update.
+               "version": package_version()}
         state[wid] = rec
         _save_state(state)
     log.info("[fleet] started %s (pid %d, :%s)", name, proc.pid, rec["port"])
@@ -363,6 +369,12 @@ def status() -> list[dict]:
         out.append({"name": ws["name"], "id": ws.get("id", ws["name"]),
                     "port": port, "pid": rec.get("pid") if running else None,
                     "running": running, "bundle": ws.get("bundle", ""),
+                    # The version the member was SPAWNED at (stamped in start()) —
+                    # the console compares it against the host entry's version so a
+                    # local member left behind by an app update shows the same skew
+                    # badge a drifted remote does. Empty while stopped (a stopped
+                    # member runs whatever binary the next start() spawns).
+                    "version": rec.get("version", "") if running else "",
                     # Direct A2A endpoint — every agent is an independent endpoint on its
                     # own port (ADR 0042), reachable regardless of console focus, so a
                     # focused agent can `delegate_to` an unfocused sibling here. Live only
@@ -456,6 +468,89 @@ def shutdown_all(*, timeout: float = 3.0) -> list[str]:
     names = [k for k, _ in live]
     log.info("[fleet] host exiting — spun down %d member(s): %s", len(names), ", ".join(names))
     return names
+
+
+# ── First-boot-after-update reconcile (version-coherence P2) ──────────────────
+# Members are detached processes: a hub update + restart leaves any survivor (a
+# crashed hub, or the KEEP_MEMBERS_ON_EXIT opt-out) running the OLD binary
+# indefinitely. The boot hook stamps each boot's version beside fleet.json and logs
+# the transition; the live warning is recomputed per runtime-status poll (like
+# colocation_warning) so it shows while skewed members run and clears the moment
+# they're restarted.
+
+
+def _version_stamp_path() -> Path:
+    return manager.workspaces_root() / ".last-version"
+
+
+def reconcile_on_boot() -> str:
+    """Stamp this boot's app version and log the transition when it changed since
+    the previous boot (the first-boot-after-update signal — an in-app update, a
+    DMG swap, or a `git pull` all land here).
+
+    Returns the previously-stamped version ("" on first boot). Hub-scoped like
+    fleet.json (#813); inside a member the scoped root is its own, so stamps don't
+    cross. Best-effort — never raises.
+    """
+    from infra.paths import atomic_write, package_version
+
+    previous = ""
+    try:
+        current = package_version()
+        stamp = _version_stamp_path()
+        try:
+            previous = stamp.read_text().strip()
+        except OSError:
+            previous = ""
+        if previous != current:
+            stamp.parent.mkdir(parents=True, exist_ok=True)
+            atomic_write(stamp, current + "\n")
+        if previous and previous != current:
+            log.info("[fleet] app version changed since last boot: %s -> %s", previous, current)
+            skew = version_skew_warning()
+            if skew:
+                log.warning("[fleet] %s", skew)
+    except Exception:  # noqa: BLE001 — boot reconcile must never block startup
+        log.exception("[fleet] boot version reconcile failed")
+    return previous
+
+
+def version_skew_warning() -> str | None:
+    """A live warning when running LOCAL members were spawned by a different app
+    version than this process runs.
+
+    Recomputed on every runtime-status poll (same posture as
+    ``infra.paths.colocation_warning``) so it appears while skewed members run and
+    self-clears once they're restarted — no hub restart needed. A member spawned
+    before version stamping existed reads as "unknown" and is flagged too: it
+    cannot be told apart from a stale one. Best-effort: None on any failure.
+    """
+    try:
+        from infra.paths import package_version
+
+        current = package_version()
+        state = _load_state()
+        if not state:
+            return None
+        names = {ws["id"]: ws["name"] for ws in manager.list_workspaces()}
+        stale: list[str] = []
+        for wid, rec in state.items():
+            if not _alive(rec.get("pid")):
+                continue
+            v = str(rec.get("version", "") or "")
+            if v != current:
+                label = names.get(wid, wid)
+                stale.append(f"{label} (v{v})" if v else f"{label} (version unknown)")
+        if not stale:
+            return None
+        return (
+            f"{len(stale)} fleet member(s) run a different protoAgent version than this hub "
+            f"(v{current}): {', '.join(sorted(stale))}. They keep the OLD code until restarted "
+            "— restart them from the Fleet panel to close the gap "
+            "(docs/dev/version-coherence.md, Axis 1)."
+        )
+    except Exception:  # noqa: BLE001 — a status-poll warning must never raise
+        return None
 
 
 # ── Keep-N-warm policy (ADR 0042 §G) ──────────────────────────────────────────

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -53,6 +53,17 @@ def _operator_runtime_status():
         warnings = [w for w in (colocation_warning(),) if w]
     except Exception:  # noqa: BLE001 — status must never raise
         warnings = []
+    # Fleet version skew (version-coherence P2) — also live + self-clearing: a
+    # member that survived an app update keeps running the OLD binary until
+    # restarted; banner it the same way as a co-located sibling. Inside a member
+    # the scoped fleet.json is empty, so this no-ops.
+    try:
+        from graph.fleet import supervisor as _sup
+        skew = _sup.version_skew_warning()
+        if skew:
+            warnings.append(skew)
+    except Exception:  # noqa: BLE001 — status must never raise
+        pass
     return _build_operator_status(
         config=STATE.graph_config,
         setup_complete=_operator_setup_complete(),

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -559,6 +559,17 @@ def _main():
         except Exception:
             log.exception("[instance] co-location check failed")
 
+        # First-boot-after-update reconcile (version-coherence P2): stamp this
+        # boot's app version beside fleet.json and log the transition when it
+        # changed (in-app update, DMG swap, git pull — all land here). The live
+        # member-skew warning rides runtime status per poll; this records the
+        # moment. Hub-scoped, off the loop (file IO + liveness probes), best-effort.
+        try:
+            from graph.fleet import supervisor as _sup
+            await asyncio.to_thread(_sup.reconcile_on_boot)
+        except Exception:
+            log.exception("[fleet] boot version reconcile failed")
+
     @fastapi_app.on_event("shutdown")
     async def _scheduler_shutdown() -> None:
         # Drop the co-location heartbeat (#706). Best-effort.

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -321,3 +321,64 @@ def test_shutdown_all_sigkills_straggler(tmp_path, monkeypatch):
     assert supervisor.shutdown_all(timeout=0.2)  # returns the stopped member
     assert not alive  # SIGKILL'd after the bounded wait
     assert int(supervisor.signal.SIGTERM) in sigs and int(supervisor.signal.SIGKILL) in sigs
+
+
+# ── first-boot-after-update reconcile (version-coherence P2) ──────────────────
+def test_start_stamps_spawner_version(fleet):
+    from infra.paths import package_version
+
+    manager.create("alpha", port=7890)
+    supervisor.start("alpha")
+    rec = next(iter(supervisor._load_state().values()))
+    assert rec["version"] == package_version()
+    entry = next(a for a in supervisor.status() if a["name"] == "alpha")
+    assert entry["version"] == package_version()
+
+
+def test_version_skew_warning_flags_and_clears(tmp_path, monkeypatch):
+    """A live member spawned by an older binary is flagged; restarting it (so the
+    current binary respawns it) clears the warning — no hub restart needed."""
+    import infra.paths as paths_mod
+
+    _multi_fleet(tmp_path, monkeypatch)
+    monkeypatch.setattr(paths_mod, "package_version", lambda: "0.1.0")
+    manager.create("a")
+    supervisor.start("a")  # spawned at 0.1.0
+    assert supervisor.version_skew_warning() is None  # versions match
+
+    # "App update": this process now runs 0.2.0; the member still runs 0.1.0.
+    monkeypatch.setattr(paths_mod, "package_version", lambda: "0.2.0")
+    warn = supervisor.version_skew_warning()
+    assert warn and "a (v0.1.0)" in warn and "0.2.0" in warn
+
+    supervisor.stop("a")
+    supervisor.start("a")  # respawned by the "new" binary
+    assert supervisor.version_skew_warning() is None
+
+
+def test_version_skew_flags_prestamp_records_as_unknown(tmp_path, monkeypatch):
+    """A record written before version stamping existed can't be told apart from a
+    stale one — flag it as unknown rather than assuming it's current."""
+    _multi_fleet(tmp_path, monkeypatch)
+    manager.create("a")
+    supervisor.start("a")
+    with supervisor._state_lock():
+        state = supervisor._load_state()
+        next(iter(state.values())).pop("version", None)
+        supervisor._save_state(state)
+    warn = supervisor.version_skew_warning()
+    assert warn and "version unknown" in warn
+
+
+def test_reconcile_on_boot_stamps_and_returns_previous(tmp_path, monkeypatch):
+    import infra.paths as paths_mod
+
+    monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    monkeypatch.setattr(paths_mod, "package_version", lambda: "0.1.0")
+    assert supervisor.reconcile_on_boot() == ""  # first boot — no stamp yet
+    assert supervisor._version_stamp_path().read_text().strip() == "0.1.0"
+    assert supervisor.reconcile_on_boot() == "0.1.0"  # same version, stamp stable
+
+    monkeypatch.setattr(paths_mod, "package_version", lambda: "0.2.0")
+    assert supervisor.reconcile_on_boot() == "0.1.0"  # the update is visible once…
+    assert supervisor._version_stamp_path().read_text().strip() == "0.2.0"  # …then re-stamped


### PR DESCRIPTION
## What

Closes version-coherence **P2 item 11** ("on app update, reconcile detached members from `fleet.json`") — bead `bd-2wa`, the follow-up the in-app updater (#918) made urgent: self-updating hubs mean version transitions happen more often, and a detached member that survives one keeps running the **old binary** indefinitely with zero visibility.

Three pieces:

1. **Spawn-version stamping** — `supervisor.start()` records `package_version()` on the member's `fleet.json` record; `status()` surfaces it for running local members. (Also the groundwork for P1 item 4.)
2. **Boot stamp + transition log** — `reconcile_on_boot()` (called from the startup hook, off-loop, best-effort) writes each boot's version to `<workspaces_root>/.last-version` and logs `version changed since last boot: X → Y`. In-app update, manual DMG swap, and `git pull` all land here. Hub-scoped like `fleet.json` (#813); a member's scoped root keeps stamps separate.
3. **Live, self-clearing skew warning** — `version_skew_warning()` is recomputed on every runtime-status poll (the exact `colocation_warning()` posture): if any *running* local member's spawn version ≠ the hub's, the console banners it with member names and a restart hint, and the warning clears the moment they're restarted — no hub restart needed. Records that predate stamping read as `version unknown` and are flagged too (indistinguishable from stale). Cost per poll: one `fleet.json` read + `kill -0` per record; inside a member it no-ops (empty scoped registry).

**Console:** the Fleet panel's version-skew badge — previously gated `a.remote` — now covers local members too (a stale local member shows the same warning badge a drifted remote does, with a restart hint).

## Why live rather than boot-only

A boot-time-only warning goes stale both ways: it misses members started by an *older* hub two restarts back, and it keeps shouting after the member's been restarted. Recomputing per poll (like the co-location banner) is self-truing in both directions; the boot hook just records the transition moment for forensics.

## Validation

- `tests/test_fleet_supervisor.py` +4 tests: spawn stamping, skew flags-then-clears across a simulated update + restart, pre-stamp records flagged as unknown, boot stamp roundtrip. 28 pass with the existing fleet suites; ruff clean.
- `docs/dev/version-coherence.md` P2 item 11 marked shipped with the mechanism.

🤖 Generated with [Claude Code](https://claude.com/claude-code)