### PR TITLE
feat(settings): fold the Agent surface into Settings ▸ Workspace (S-B + S-C) [draft, needs local UX pass]

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ sites/marketing/.astro/
 config/*/secrets.yaml
 config/*/langgraph-config.yaml
 config/*/.setup-complete
+
+# Playwright run artifacts
+test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,15 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent was told a no-op worked; they now read the real per-plugin load status and surface
   "FAILED to load: <error>" so you fix-and-reload instead of testing nothing.
 ### Added
-- **Settings are reorganizing around *scope* — a two-home shell + contextual quick-settings (ADR 0048, in progress).**
-  The central Settings surface now leads with the two scope homes from ADR 0048 — **🖥 Host / App**
-  (box-shared: Overview · Host config · Fleet · Telemetry · Commons) and **🧩 Workspace** (the focused
-  agent: Theme · Plugins · System for now; the agent makeup folds in next). Scope is the primary axis,
-  replacing the flat category tabs (`settingsTab` → `settingsScope` + `settingsSection`, persist v3).
-  Alongside the one-stop-shop, a reusable **`QuickSetting`** primitive puts a gear-icon → dialog
-  *contextual* shortcut wherever a setting is relevant (it edits the same fields via the same
-  cascade-aware `/api/settings` write path) — first one lands on the Skills surface (skill-sharing mode).
-  Part of #916; the Agent rail surface stays until the collapse slice.
+- **Settings are reorganized around *scope* — a two-home shell + contextual quick-settings (ADR 0048).**
+  The Settings surface is now **two scope homes**, replacing the flat category tabs and the separate
+  Agent rail surface: **🖥 Host / App** (box-shared: Overview · Host config · Fleet · Telemetry ·
+  Commons) and **🧩 Workspace** (the focused agent's full makeup — Identity · Settings · Tools · MCP ·
+  Subagents · Skills · Middleware · Memory · System · Theme · Plugins). Scope is the primary axis
+  (`settingsTab` → `settingsScope` + `settingsSection`, persist v3). The standalone **Agent** rail
+  surface is gone (folded into Workspace) and Knowledge is now store-only (its Memory settings moved to
+  Workspace ▸ Memory). Alongside this one-stop-shop, a reusable **`QuickSetting`** primitive puts a
+  gear-icon → dialog *contextual* shortcut wherever a setting is relevant — editing the same fields via
+  the same cascade-aware `/api/settings` write path (host-scoped fields route to the host layer); first
+  one lands on the Skills surface (skill-sharing mode). Part of #916.
 - **The shared-skill commons is now legible in the console (ADR 0041 / 0048).** The
   layered skill tier ("shared brain, private hands" — read commons ∪ private, write
   private) shipped at the data layer but was invisible: the Skills surface couldn't tell

--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "@playwright/test";
 
-// The Delegates panel (ADR 0025) lives under Settings → Plugins: it lists the
-// configured delegates (GET /api/delegates), and an Add form with a type picker
-// driven by GET /api/delegate-types. Mocked endpoints in e2e/mock-server.mjs.
+// The Delegates panel (ADR 0025) lives under Settings ▸ Workspace ▸ Plugins (ADR 0048):
+// it lists the configured delegates (GET /api/delegates), and an Add form with a type
+// picker driven by GET /api/delegate-types. Mocked endpoints in e2e/mock-server.mjs.
 
 async function openIntegrations(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Plugins", exact: true }).click();
 }
 

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -1,11 +1,12 @@
 import { expect, test } from "@playwright/test";
 
-// Agent → MCP tab: add/remove MCP servers inline (hot reload). The mock runtime
-// status ships one server (echo); add/remove hit the mocked /api/mcp/servers.
+// Settings ▸ Workspace ▸ MCP: add/remove MCP servers inline (hot reload). The mock
+// runtime status ships one server (echo); add/remove hit the mocked /api/mcp/servers.
 
 test("MCP tab lists servers and adds one inline", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.getByRole("tab", { name: "MCP", exact: true }).click();
 
   await expect(page.getByRole("heading", { name: "MCP servers" })).toBeVisible();
@@ -21,7 +22,8 @@ test("MCP tab lists servers and adds one inline", async ({ page }) => {
 
 test("MCP tab imports servers from pasted JSON", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.getByRole("tab", { name: "MCP", exact: true }).click();
 
   await page.getByRole("button", { name: /Add server/ }).click();

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -46,9 +46,11 @@ test("beads tab in the right sidebar lists issues (query-backed)", async ({ page
   await expect(page.getByText("Wire the telemetry rollup")).toBeVisible();
 });
 
-test("agent surface: identity lands, then tools and MCP tabs", async ({ page }) => {
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible(); // landing tab
+test("workspace settings: identity lands, then tools and MCP sections", async ({ page }) => {
+  // The agent makeup folded into Settings ▸ Workspace (ADR 0048 S-C).
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible(); // landing section
   await expect(page.getByTestId("identity-name")).toBeVisible();
 
   await page.locator(".pl-tabs").getByRole("tab", { name: "Tools", exact: true }).click();
@@ -80,14 +82,14 @@ test("plugins section: Local / Market / Download tabs", async ({ page }) => {
 test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Move off the defaults: a left surface (Agent) + a non-default right-panel tab (Goals — Beads
+  // Move off the defaults: a left surface (Plugins) + a non-default right-panel tab (Goals — Beads
   // is the default, and clicking the default-active one would toggle it closed).
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true }).click();
   await page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true }).click();
 
   // Reload — the persisted store restores both, instead of snapping back to Chat/Notes.
   await page.reload({ waitUntil: "load" });
-  await expect(page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true })).toHaveClass(/active/);
+  await expect(page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true })).toHaveClass(/active/);
   await expect(page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true })).toHaveClass(/active/);
 });
 

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -5,8 +5,8 @@ import { expect, test } from "@playwright/test";
 
 test("Agent → Skills lists pinned + learned skills and supports search", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
-  // Skills moved under the Agent section — switch to the Skills tab.
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
 
   const surface = page.getByTestId("playbooks-surface");
@@ -26,7 +26,8 @@ test("Agent → Skills lists pinned + learned skills and supports search", async
 
 test("layered skills show tier badges and promote a private skill to the commons", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
@@ -46,7 +47,8 @@ test("layered skills show tier badges and promote a private skill to the commons
 
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -32,23 +32,32 @@ test("Settings is a two-home shell (Host / App · Workspace)", async ({ page }) 
     "Commons",
   ]);
   await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible(); // default section
-  // The Workspace home → its sections; System holds the runtime/perf knobs.
+  // The Workspace home → the focused agent's makeup + settings (ADR 0048 fold).
   await tab(page, "Workspace");
   expect(await page.locator(".pl-tabs").nth(1).locator("button").allTextContents()).toEqual([
+    "Identity",
+    "Settings",
+    "Tools",
+    "MCP",
+    "Subagents",
+    "Skills",
+    "Middleware",
+    "Memory",
+    "System",
     "Theme",
     "Plugins",
-    "System",
   ]);
   await tab(page, "System");
   await expect(page.locator(".settings-group-title").first()).toBeVisible(); // wait for the suspense load
   expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Compaction", "Runtime"]);
 });
 
-test("Agent settings live in the Agent view's Settings tab", async ({ page }) => {
+test("Workspace ▸ Settings shows the agent's Model + Routing fields", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
-  // Model + Routing render here, not in the central Settings surface.
+  // Model + Routing render here (the agent makeup folded into Workspace, ADR 0048).
   await expect(page.locator(".settings-group-title").first()).toBeVisible(); // wait for the suspense load
   expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Model", "Routing"]);
   const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
@@ -59,7 +68,8 @@ test("Agent settings live in the Agent view's Settings tab", async ({ page }) =>
 
 test("editing an Agent setting enables save and round-trips", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
   const save = page.getByRole("button", { name: /Save & apply/ });
   await expect(save).toBeDisabled();
@@ -82,7 +92,8 @@ test("a restart-flagged System field shows the restart banner", async ({ page })
 // inheritance badge; an overridden host-scoped field offers reset-to-inherited.
 test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
   await expect(page.locator(".settings-group-title").first()).toBeVisible();
   // model.name inherits from the host layer.

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -74,19 +74,15 @@ import { InboxPanel } from "../inbox/InboxPanel";
 import { ChatSlot } from "./ChatSlot";
 import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
-import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
   type ActivityTab,
-  type AgentTab,
-  type KnowledgeTab,
   type PluginsTab,
   type RightPanel,
   type Surface,
 } from "../state/uiStore";
-import { SettingsCategoryPanel } from "../settings/SettingsCategory";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
 import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
@@ -105,11 +101,6 @@ import { StatusPill } from "./StatusPill";
 import { GoalsPanel } from "./GoalsPanel";
 import { BeadsPanel } from "./BeadsPanel";
 import { SchedulePanel } from "../schedule/SchedulePanel";
-import { IdentityPanel } from "../agent/IdentityPanel";
-import { ToolsPanel } from "./ToolsPanel";
-import { McpPanel } from "./McpPanel";
-import { SubagentsPanel } from "./SubagentsPanel";
-import { MiddlewarePanel } from "./MiddlewarePanel";
 import { PluginsSurface } from "../plugins/PluginsSurface";
 import { SetupWizard } from "../setup/SetupWizard";
 import { hostRuntimeStatusQuery, runtimeStatusQuery } from "../lib/queries";
@@ -226,12 +217,8 @@ export function App() {
   // Background-streaming indicator for the Chat rail (narrow selector → only
   // re-renders when the boolean flips, not per token).
   const chatStreaming = useAnyChatStreaming();
-  const agentTab = useUI((s) => s.agentTab);
-  const setAgentTab = useUI((s) => s.setAgentTab);
   const pluginsTab = useUI((s) => s.pluginsTab);
   const setPluginsTab = useUI((s) => s.setPluginsTab);
-  const knowledgeTab = useUI((s) => s.knowledgeTab);
-  const setKnowledgeTab = useUI((s) => s.setKnowledgeTab);
   const setSettingsScope = useUI((s) => s.setSettingsScope);
   const setSettingsSection = useUI((s) => s.setSettingsSection);
   const setFleetStartNew = useUI((s) => s.setFleetStartNew);
@@ -479,7 +466,7 @@ export function App() {
     // "studio" (Workflows) is contributed via src/ext/workflows.tsx, gated on the
     // workflows plugin (lean core) — no longer a hardcoded core surface.
     { id: "knowledge", label: "Knowledge", icon: <BookMarked size={18} /> },
-    { id: "agent", label: "Agent", icon: <Bot size={18} /> },
+    // "agent" folded into Settings ▸ Workspace (ADR 0048 S-C) — no longer a rail surface.
     { id: "plugins", label: "Plugins", icon: <Puzzle size={18} /> },
     { id: "settings", label: "Settings", icon: <Settings2 size={18} /> },
     { id: "beads", label: "Beads", icon: <Boxes size={18} /> },
@@ -527,27 +514,9 @@ export function App() {
             {activityTab === "thread" ? <ActivitySurface onError={setError} /> : <InboxPanel />}
           </>
         );
-      case "agent":
-        return (
-          <>
-            <Tabs responsive active={agentTab} onSelect={(t) => setAgentTab(t as AgentTab)} items={[
-              { id: "identity", label: "Identity", icon: Sparkles },
-              { id: "settings", label: "Settings", icon: Settings2 },
-              { id: "tools", label: "Tools", icon: Wrench },
-              { id: "mcp", label: "MCP", icon: Plug },
-              { id: "subagents", label: "Subagents", icon: Bot },
-              { id: "skills", label: "Skills", icon: BookMarked },
-              { id: "middleware", label: "Middleware", icon: Layers },
-            ].map(toTab)} />
-            {agentTab === "identity" ? <IdentityPanel /> : null}
-            {agentTab === "settings" ? <SettingsCategoryPanel category="Agent" title="Settings" /> : null}
-            {agentTab === "tools" ? <ToolsPanel /> : null}
-            {agentTab === "mcp" ? <McpPanel /> : null}
-            {agentTab === "subagents" ? <SubagentsPanel /> : null}
-            {agentTab === "skills" ? <PlaybooksSurface onError={setError} /> : null}
-            {agentTab === "middleware" ? <MiddlewarePanel /> : null}
-          </>
-        );
+      // The Agent surface folded into Settings ▸ Workspace (ADR 0048 S-C). Its tabs
+      // (Identity/Settings/Tools/MCP/Subagents/Skills/Middleware) are now Workspace
+      // sections in SettingsSurface.
       case "plugins":
         return (
           <>
@@ -559,16 +528,10 @@ export function App() {
             <PluginsSurface tab={pluginsTab} />
           </>
         );
+      // Knowledge is the searchable Store; its Memory settings folded into
+      // Settings ▸ Workspace ▸ Memory (ADR 0048 S-C).
       case "knowledge":
-        return (
-          <>
-            <Tabs responsive active={knowledgeTab} onSelect={(t) => setKnowledgeTab(t as KnowledgeTab)} items={[
-              { id: "store", label: "Store", icon: Database },
-              { id: "settings", label: "Settings", icon: Settings2 },
-            ].map(toTab)} />
-            {knowledgeTab === "store" ? <KnowledgeStore onError={setError} /> : <SettingsCategoryPanel category="Memory" title="Settings" />}
-          </>
-        );
+        return <KnowledgeStore onError={setError} />;
       case "settings":
         // SettingsSurface owns its own two-level nav (home + section, ADR 0048).
         return <SettingsSurface />;

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -27,7 +27,7 @@ function ago(iso: string | null): string {
   return `${Math.round(s / 86400)}d ago`;
 }
 
-export function PlaybooksSurface({ onError }: { onError: (message: string) => void }) {
+export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: string) => void }) {
   const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(false);

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,9 +1,15 @@
-import { BarChart3, Boxes, Gauge, HardDrive, Library, Palette, Puzzle, Server, Settings2 } from "lucide-react";
+import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Library, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Tabs } from "@protolabsai/ui/navigation";
 
+import { IdentityPanel } from "../agent/IdentityPanel";
+import { McpPanel } from "../app/McpPanel";
+import { MiddlewarePanel } from "../app/MiddlewarePanel";
+import { SubagentsPanel } from "../app/SubagentsPanel";
+import { ToolsPanel } from "../app/ToolsPanel";
+import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { useUI, type SettingsScope } from "../state/uiStore";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { CommonsPanel } from "./CommonsPanel";
@@ -39,7 +45,22 @@ const HOST_SECTIONS: Section[] = [
   { id: "commons", label: "Commons", icon: Library, render: () => <CommonsPanel /> },
 ];
 
+// The Workspace home (ADR 0048 §3.2) — the focused agent, everything that defines it:
+// the makeup panels (Identity/Tools/MCP/Subagents/Skills/Middleware) folded in from the
+// old Agent rail surface + Theme, plus the agent-scoped field settings (Agent/Memory/
+// System/Plugins categories). Host-scoped fields that appear here (e.g. model.name)
+// keep their ADR 0047 "inherited from Host" badge + override. (A later refinement can
+// regroup the field sections into the ADR's idealized Model/Behavior cut.)
 const WORKSPACE_SECTIONS: Section[] = [
+  { id: "identity", label: "Identity", icon: Sparkles, render: () => <IdentityPanel /> },
+  { id: "settings", label: "Settings", icon: Settings2, render: () => <SettingsCategoryPanel category="Agent" title="Agent settings" /> },
+  { id: "tools", label: "Tools", icon: Wrench, render: () => <ToolsPanel /> },
+  { id: "mcp", label: "MCP", icon: Plug, render: () => <McpPanel /> },
+  { id: "subagents", label: "Subagents", icon: Bot, render: () => <SubagentsPanel /> },
+  { id: "skills", label: "Skills", icon: BookMarked, render: () => <PlaybooksSurface /> },
+  { id: "middleware", label: "Middleware", icon: Layers, render: () => <MiddlewarePanel /> },
+  { id: "memory", label: "Memory", icon: Database, render: () => <SettingsCategoryPanel category="Memory" title="Memory" /> },
+  { id: "system", label: "System", icon: Settings2, render: () => <SettingsCategoryPanel category="System" title="System" /> },
   { id: "theme", label: "Theme", icon: Palette, render: () => <ThemeSurface /> },
   {
     id: "plugins",
@@ -54,7 +75,6 @@ const WORKSPACE_SECTIONS: Section[] = [
       />
     ),
   },
-  { id: "system", label: "System", icon: Settings2, render: () => <SettingsCategoryPanel category="System" title="System" /> },
 ];
 
 export const SETTINGS_HOMES: Home[] = [

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -36,12 +36,12 @@ const _layoutStorage = createJSONStorage(() => ({
 // Core surfaces are fixed literals; plugin views (ADR 0026) add dynamic surfaces keyed
 // `plugin:<pluginId>:<viewId>`. The `(string & {})` keeps literal autocomplete while allowing
 // those runtime keys.
+// The "agent" surface folded into Settings ▸ Workspace (ADR 0048 S-C); Knowledge is
+// now store-only (its Memory settings live in Settings ▸ Workspace ▸ Memory).
 export type Surface =
-  | "chat" | "activity" | "studio" | "knowledge" | "agent" | "plugins" | "settings" | (string & {});
+  | "chat" | "activity" | "studio" | "knowledge" | "plugins" | "settings" | (string & {});
 export type RightPanel = "notes" | "beads" | "goals" | "schedule" | (string & {}); // + plugin:<id>:<viewId>
-export type AgentTab = "identity" | "settings" | "tools" | "mcp" | "subagents" | "skills" | "middleware";
 export type PluginsTab = "local" | "market" | "download";
-export type KnowledgeTab = "store" | "settings";
 export type ActivityTab = "thread" | "inbox";
 // Settings IA (ADR 0048): scope is the primary axis — two homes, each with its own
 // section sub-nav. `settingsScope` picks the home; `settingsSection` the active
@@ -55,9 +55,7 @@ const clampWidth = (w: number) => Math.min(RIGHT_MAX, Math.max(RIGHT_MIN, Math.r
 type UIState = {
   surface: Surface;
   rightPanel: RightPanel;
-  agentTab: AgentTab;
   pluginsTab: PluginsTab;
-  knowledgeTab: KnowledgeTab;
   settingsScope: SettingsScope;
   settingsSection: string;
   // One-shot: the FleetSwitcher's "+ New agent" deep-link routes to Host/App ▸ Fleet
@@ -84,9 +82,7 @@ type UIState = {
   toggleQuickBar: (id: string) => void;
   setSurface: (s: Surface) => void;
   setRightPanel: (p: RightPanel) => void;
-  setAgentTab: (t: AgentTab) => void;
   setPluginsTab: (t: PluginsTab) => void;
-  setKnowledgeTab: (t: KnowledgeTab) => void;
   setSettingsScope: (s: SettingsScope) => void;
   setSettingsSection: (s: string) => void;
   setFleetStartNew: (b: boolean) => void;
@@ -104,10 +100,18 @@ type UIState = {
  * falls back to the default via the store's merge. Exported for unit testing. */
 export function migrateUiState(persisted: unknown): unknown {
   if (persisted && typeof persisted === "object") {
-    // v2: drop the obsolete `railOf` (side map). v3 (ADR 0048): drop the flat
-    // `settingsTab` — replaced by `settingsScope` + `settingsSection`, which fall
-    // back to the store defaults via the persist merge.
-    const { railOf: _drop, settingsTab: _drop2, ...rest } = persisted as Record<string, unknown>;
+    // v2: drop the obsolete `railOf` (side map). v3 (ADR 0048): drop `settingsTab`
+    // (→ `settingsScope` + `settingsSection`) and the `agentTab` / `knowledgeTab`
+    // keys whose surfaces folded into Settings ▸ Workspace. All fall back to the
+    // store defaults via the persist merge. (A stale "agent" left in `railOrder` is
+    // harmless — railSurfaces() filters ids with no surface metadata.)
+    const {
+      railOf: _drop,
+      settingsTab: _drop2,
+      agentTab: _drop3,
+      knowledgeTab: _drop4,
+      ...rest
+    } = persisted as Record<string, unknown>;
     return rest;
   }
   return persisted;
@@ -118,9 +122,7 @@ export const useUI = create<UIState>()(
     (set) => ({
       surface: "chat",
       rightPanel: "beads",
-      agentTab: "identity",
       pluginsTab: "local",
-      knowledgeTab: "store",
       settingsScope: "host" as SettingsScope,
       settingsSection: "overview",
       fleetStartNew: false,
@@ -129,7 +131,7 @@ export const useUI = create<UIState>()(
       leftCollapsed: false,
       rightWidth: 360,
       railOrder: {
-        left: ["chat", "activity", "studio", "knowledge", "agent", "plugins", "settings"],
+        left: ["chat", "activity", "studio", "knowledge", "plugins", "settings"],
         right: ["beads", "goals", "schedule"],
       },
       moveSurface: (id, side) =>
@@ -174,9 +176,7 @@ export const useUI = create<UIState>()(
         }),
       setSurface: (surface) => set({ surface }),
       setRightPanel: (rightPanel) => set({ rightPanel }),
-      setAgentTab: (agentTab) => set({ agentTab }),
       setPluginsTab: (pluginsTab) => set({ pluginsTab }),
-      setKnowledgeTab: (knowledgeTab) => set({ knowledgeTab }),
       // Switching home resets to that home's first section (its own default lives in
       // SettingsSurface); callers that want a specific section call setSettingsSection too.
       setSettingsScope: (settingsScope) => set({ settingsScope }),


### PR DESCRIPTION
> **Draft — needs the operator's local UX pass** (UI local-test gate). Stacked on #920 (base = `feat/settings-ia-host-home`); retarget down the chain as #917 → #920 merge.

## What

Completes the settings-IA fold ([ADR 0048](docs/adr/0048-settings-ia-two-scope-homes.md), #916). The standalone **Agent** rail surface dissolves into **Settings ▸ Workspace** — so everything that defines an agent lives in one place.

```
Rail after the fold:  Chat · Activity · Knowledge · Plugins · Settings · Beads · Goals · Schedule
                                                                  └─ 🖥 Host / App  |  🧩 Workspace

🧩 Workspace:  Identity · Settings · Tools · MCP · Subagents · Skills · Middleware · Memory · System · Theme · Plugins
```

## S-B — Workspace home
The Workspace home renders the focused agent's full makeup as sections, reusing the existing panels (Identity SOUL editor, Tools, MCP, Subagents, Skills/Playbooks, Middleware) plus the agent-scoped field settings (Agent/Memory/System/Plugins categories) + Theme. Host-scoped fields surfacing here keep their ADR 0047 "inherited from Host" badge + override. `PlaybooksSurface.onError` is now optional.

## S-C — Collapse
- `App.tsx`: drop the `agent` render case + rail entry; **Knowledge is store-only** now (its Memory settings → Workspace ▸ Memory); removed the now-unused panel imports.
- `uiStore`: drop the `agent` Surface + `agentTab`/`knowledgeTab` state/types/setters; `agent` out of the default railOrder; the v3 migration strips the stale `agentTab`/`knowledgeTab` persisted keys.
- **e2e**: every Agent-rail navigation rewired to `Settings ▸ Workspace ▸ <section>` (settings/navigation/playbooks/mcp/delegates); the persist test moves via Plugins.

## Gates
**Full Playwright suite: 90 passed** (`--workers=2`; the default-concurrency run had 7 flaky `page.goto` timeouts under load — all green serially/at reduced concurrency). `tsc -p` + `tsc -p node` + `vite build` clean · vitest **44 passed** · CSS guard green.

## Try it
Settings ▸ Workspace — the old Agent tabs are now sections here; the Agent rail item is gone.

## Note / follow-ups
- The field sections (Settings/Memory/System) are a faithful relocation; a later refinement can regroup them into ADR 0048's idealized **Model / Behavior** cut.
- Next (separate PR, per the operator's direction): a **topbar gear → Settings overlay** + `QuickSetting` gears on chat (model+temp), telemetry (retention), theme, knowledge (top-k+embeddings).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
