### PR TITLE
feat(settings): scope-based IA reorg (ADR 0048) — two homes, agent-fold, quick-settings, skills commons

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,6 @@ sites/marketing/.astro/
 config/*/secrets.yaml
 config/*/langgraph-config.yaml
 config/*/.setup-complete
+
+# Playwright run artifacts
+test-results/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,15 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent was told a no-op worked; they now read the real per-plugin load status and surface
   "FAILED to load: <error>" so you fix-and-reload instead of testing nothing.
 ### Added
-- **Settings are reorganizing around *scope* — a two-home shell + contextual quick-settings (ADR 0048, in progress).**
-  The central Settings surface now leads with the two scope homes from ADR 0048 — **🖥 Host / App**
-  (box-shared: Overview · Host config · Fleet · Telemetry · Commons) and **🧩 Workspace** (the focused
-  agent: Theme · Plugins · System for now; the agent makeup folds in next). Scope is the primary axis,
-  replacing the flat category tabs (`settingsTab` → `settingsScope` + `settingsSection`, persist v3).
-  Alongside the one-stop-shop, a reusable **`QuickSetting`** primitive puts a gear-icon → dialog
-  *contextual* shortcut wherever a setting is relevant (it edits the same fields via the same
-  cascade-aware `/api/settings` write path) — first one lands on the Skills surface (skill-sharing mode).
-  Part of #916; the Agent rail surface stays until the collapse slice.
+- **Settings are reorganized around *scope* — a two-home shell + contextual quick-settings (ADR 0048).**
+  The Settings surface is now **two scope homes**, replacing the flat category tabs and the separate
+  Agent rail surface: **🖥 Host / App** (box-shared: Overview · Host config · Fleet · Telemetry ·
+  Commons) and **🧩 Workspace** (the focused agent's full makeup — Identity · Settings · Tools · MCP ·
+  Subagents · Skills · Middleware · Memory · System · Theme · Plugins). Scope is the primary axis
+  (`settingsTab` → `settingsScope` + `settingsSection`, persist v3). The standalone **Agent** rail
+  surface is gone (folded into Workspace) and Knowledge is now store-only (its Memory settings moved to
+  Workspace ▸ Memory). Alongside this one-stop-shop, a reusable **`QuickSetting`** primitive puts a
+  gear-icon → dialog *contextual* shortcut wherever a setting is relevant — editing the same fields via
+  the same cascade-aware `/api/settings` write path (host-scoped fields route to the host layer); first
+  one lands on the Skills surface (skill-sharing mode). Part of #916.
 - **The shared-skill commons is now legible in the console (ADR 0041 / 0048).** The
   layered skill tier ("shared brain, private hands" — read commons ∪ private, write
   private) shipped at the data layer but was invisible: the Skills surface couldn't tell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent was told a no-op worked; they now read the real per-plugin load status and surface
   "FAILED to load: <error>" so you fix-and-reload instead of testing nothing.
 ### Added
+- **The shared-skill commons is now legible in the console (ADR 0041 / 0048).** The
+  layered skill tier ("shared brain, private hands" — read commons ∪ private, write
+  private) shipped at the data layer but was invisible: the Skills surface couldn't tell
+  a private skill from a commons one, the one curated action (`promote` a private skill
+  into the box-shared commons) had no API route or button, and the skill-sharing mode was
+  YAML-only. Now: a **tier badge** (commons / private) on each skill, a **Promote** action
+  on private skills (`POST /api/playbooks/{id}/promote` over `LayeredSkillsIndex.promote`),
+  and two new settings fields — `skills.scope` (`scoped` · `shared` · `layered`, per-agent)
+  and `commons.path` (the box-shared commons location, host-scoped). Surfacing the second
+  of protoAgent's two inheritance systems (the skill **union**, alongside the ADR 0047
+  settings **override** cascade). Part of the settings-IA reorg (#916).
 - **macOS desktop releases are now verified pristine — and the DMG itself is notarized.**
   Tauri notarizes the `.app` inside the bundle, but the DMG *container* shipped without its
   own ticket; the workflow now runs `notarytool submit` + `stapler staple` on the DMG, then

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,8 +43,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   surface is gone (folded into Workspace) and Knowledge is now store-only (its Memory settings moved to
   Workspace ▸ Memory). Alongside this one-stop-shop, a reusable **`QuickSetting`** primitive puts a
   gear-icon → dialog *contextual* shortcut wherever a setting is relevant — editing the same fields via
-  the same cascade-aware `/api/settings` write path (host-scoped fields route to the host layer); first
-  one lands on the Skills surface (skill-sharing mode). Part of #916.
+  the same cascade-aware `/api/settings` write path (host-scoped fields route to the host layer). The
+  **topbar gear** opens the whole one-stop-shop as an overlay from anywhere, and contextual quick-set
+  gears sit where they're relevant: **model tuning** by the agent name, **appearance**, **telemetry**
+  policy (on the Telemetry view), **recall** (on Knowledge), and **skill-sharing mode** (on Skills).
+  Part of #916.
 - **The shared-skill commons is now legible in the console (ADR 0041 / 0048).** The
   layered skill tier ("shared brain, private hands" — read commons ∪ private, write
   private) shipped at the data layer but was invisible: the Skills surface couldn't tell

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -34,6 +34,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent was told a no-op worked; they now read the real per-plugin load status and surface
   "FAILED to load: <error>" so you fix-and-reload instead of testing nothing.
 ### Added
+- **Settings are reorganizing around *scope* — a two-home shell + contextual quick-settings (ADR 0048, in progress).**
+  The central Settings surface now leads with the two scope homes from ADR 0048 — **🖥 Host / App**
+  (box-shared: Overview · Host config · Fleet · Telemetry · Commons) and **🧩 Workspace** (the focused
+  agent: Theme · Plugins · System for now; the agent makeup folds in next). Scope is the primary axis,
+  replacing the flat category tabs (`settingsTab` → `settingsScope` + `settingsSection`, persist v3).
+  Alongside the one-stop-shop, a reusable **`QuickSetting`** primitive puts a gear-icon → dialog
+  *contextual* shortcut wherever a setting is relevant (it edits the same fields via the same
+  cascade-aware `/api/settings` write path) — first one lands on the Skills surface (skill-sharing mode).
+  Part of #916; the Agent rail surface stays until the collapse slice.
 - **The shared-skill commons is now legible in the console (ADR 0041 / 0048).** The
   layered skill tier ("shared brain, private hands" — read commons ∪ private, write
   private) shipped at the data layer but was invisible: the Skills surface couldn't tell

--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -1,12 +1,13 @@
 import { expect, test } from "@playwright/test";
 
-// The Delegates panel (ADR 0025) lives under Settings → Plugins: it lists the
-// configured delegates (GET /api/delegates), and an Add form with a type picker
-// driven by GET /api/delegate-types. Mocked endpoints in e2e/mock-server.mjs.
+// The Delegates panel (ADR 0025) lives under Settings ▸ Workspace ▸ Plugins (ADR 0048):
+// it lists the configured delegates (GET /api/delegates), and an Add form with a type
+// picker driven by GET /api/delegate-types. Mocked endpoints in e2e/mock-server.mjs.
 
 async function openIntegrations(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Plugins", exact: true }).click();
 }
 

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -464,11 +464,13 @@ export const PLAYBOOKS = [
     id: 1, name: "web-research", description: "Plan → search → read → synthesize → cite.",
     tools_used: ["web_search", "fetch_url"], source: "disk", confidence: 1.0,
     last_used: "2026-06-01T18:00:00+00:00", created_at: "2026-05-29T00:00:00+00:00",
+    tier: "commons",   // layered index (ADR 0041): already in the shared commons
   },
   {
     id: 2, name: "pr-triage-flow", description: "Learned: how to triage a PR review backlog.",
     tools_used: ["github_get_pr", "github_list_issues"], source: "emitted", confidence: 0.62,
     last_used: "2026-05-31T12:00:00+00:00", created_at: "2026-05-30T00:00:00+00:00",
+    tier: "private",   // private to this agent → eligible for Promote
   },
 ];
 

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -9,7 +9,7 @@ test.describe.configure({ mode: "serial" });
 async function openAgents(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Agents", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Fleet", exact: true }).click();
 }
 
 test("Agents tab lists the host (this instance) + peers, host active by default", async ({ page }) => {
@@ -142,7 +142,7 @@ test("discover → add to fleet → switch into the remote member (ADR 0042 §I)
 
   // Unregister from the fleet manager (the remote agent itself is untouched).
   await page.getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Agents", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Fleet", exact: true }).click();
   await page.locator(".fleet-row", { hasText: "remy" })
     .getByRole("button", { name: /Remove from this fleet/ }).click();
   await expect(page.locator(".fleet-row", { hasText: "remy" })).toHaveCount(0);

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -1,11 +1,12 @@
 import { expect, test } from "@playwright/test";
 
-// Agent → MCP tab: add/remove MCP servers inline (hot reload). The mock runtime
-// status ships one server (echo); add/remove hit the mocked /api/mcp/servers.
+// Settings ▸ Workspace ▸ MCP: add/remove MCP servers inline (hot reload). The mock
+// runtime status ships one server (echo); add/remove hit the mocked /api/mcp/servers.
 
 test("MCP tab lists servers and adds one inline", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.getByRole("tab", { name: "MCP", exact: true }).click();
 
   await expect(page.getByRole("heading", { name: "MCP servers" })).toBeVisible();
@@ -21,7 +22,8 @@ test("MCP tab lists servers and adds one inline", async ({ page }) => {
 
 test("MCP tab imports servers from pasted JSON", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.getByRole("tab", { name: "MCP", exact: true }).click();
 
   await page.getByRole("button", { name: /Add server/ }).click();

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -388,6 +388,12 @@ const server = createServer(async (req, res) => {
       FLEET.agents = FLEET.agents.filter((a) => a.name !== name && a.id !== name);
       return sendJson(res, { ok: true, name, removed: [name] });
     }
+    if (req.method === "POST" && /^\/api\/playbooks\/\d+\/promote$/.test(pathname)) {
+      const id = Number(pathname.split("/").at(-2));
+      const p = PLAYBOOKS.find((x) => x.id === id);
+      if (p) p.tier = "commons"; // promoted: now reads from the commons tier
+      return sendJson(res, { enabled: true, promoted: true, name: p?.name });
+    }
     if (req.method === "DELETE" && /^\/api\/playbooks\/\d+$/.test(pathname)) {
       return sendJson(res, { enabled: true, deleted: true });
     }

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -46,9 +46,11 @@ test("beads tab in the right sidebar lists issues (query-backed)", async ({ page
   await expect(page.getByText("Wire the telemetry rollup")).toBeVisible();
 });
 
-test("agent surface: identity lands, then tools and MCP tabs", async ({ page }) => {
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible(); // landing tab
+test("workspace settings: identity lands, then tools and MCP sections", async ({ page }) => {
+  // The agent makeup folded into Settings ▸ Workspace (ADR 0048 S-C).
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible(); // landing section
   await expect(page.getByTestId("identity-name")).toBeVisible();
 
   await page.locator(".pl-tabs").getByRole("tab", { name: "Tools", exact: true }).click();
@@ -80,14 +82,14 @@ test("plugins section: Local / Market / Download tabs", async ({ page }) => {
 test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Move off the defaults: a left surface (Agent) + a non-default right-panel tab (Goals — Beads
+  // Move off the defaults: a left surface (Plugins) + a non-default right-panel tab (Goals — Beads
   // is the default, and clicking the default-active one would toggle it closed).
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true }).click();
   await page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true }).click();
 
   // Reload — the persisted store restores both, instead of snapping back to Chat/Notes.
   await page.reload({ waitUntil: "load" });
-  await expect(page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true })).toHaveClass(/active/);
+  await expect(page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true })).toHaveClass(/active/);
   await expect(page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true })).toHaveClass(/active/);
 });
 

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -24,6 +24,26 @@ test("Agent → Skills lists pinned + learned skills and supports search", async
   await expect(surface.getByText("web-research")).toBeHidden();
 });
 
+test("layered skills show tier badges and promote a private skill to the commons", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
+  const surface = page.getByTestId("playbooks-surface");
+  await expect(surface).toBeVisible();
+
+  // Tier badges from the layered index (ADR 0041): one commons, one private.
+  await expect(surface.getByText("commons", { exact: true })).toBeVisible();
+  await expect(surface.getByText("private", { exact: true })).toBeVisible();
+
+  // Promote is offered only on the private skill (id 2), not the commons one (id 1).
+  await expect(surface.getByTestId("playbook-promote-2")).toBeVisible();
+  await expect(surface.getByTestId("playbook-promote-1")).toHaveCount(0);
+
+  // Promoting lifts it into the commons → the button is gone afterward.
+  await surface.getByTestId("playbook-promote-2").click();
+  await expect(surface.getByTestId("playbook-promote-2")).toHaveCount(0);
+});
+
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -5,8 +5,8 @@ import { expect, test } from "@playwright/test";
 
 test("Agent → Skills lists pinned + learned skills and supports search", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
-  // Skills moved under the Agent section — switch to the Skills tab.
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
 
   const surface = page.getByTestId("playbooks-surface");
@@ -26,7 +26,8 @@ test("Agent → Skills lists pinned + learned skills and supports search", async
 
 test("layered skills show tier badges and promote a private skill to the commons", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
@@ -46,7 +47,8 @@ test("layered skills show tier badges and promote a private skill to the commons
 
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -14,8 +14,9 @@ test("the topbar gear opens the Settings overlay (the two-home one-stop-shop)", 
   await expect(dialog.getByRole("tab", { name: "Workspace", exact: true })).toBeVisible();
 });
 
-test("the topbar model quick-set edits a field in a dialog and saves", async ({ page }) => {
+test("the chat composer model chip edits a field in a dialog and saves", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
+  // The model control lives on the chat composer (the default surface), by the input.
   await page.getByRole("button", { name: "Model settings" }).click();
   const dialog = page.getByRole("dialog", { name: "Model" });
   await expect(dialog).toBeVisible();

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -1,0 +1,26 @@
+import { expect, test } from "@playwright/test";
+
+// Contextual quick-settings + the topbar Settings overlay (ADR 0048): a gear icon
+// opens a dialog editing fields via the same /api/settings path, and the central
+// two-home one-stop-shop is also openable as an overlay from the topbar.
+
+test("the topbar gear opens the Settings overlay (the two-home one-stop-shop)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("topbar-settings").click();
+  const dialog = page.getByRole("dialog", { name: "Settings" });
+  await expect(dialog).toBeVisible();
+  // The same two scope homes render inside the overlay.
+  await expect(dialog.getByRole("tab", { name: "Host / App", exact: true })).toBeVisible();
+  await expect(dialog.getByRole("tab", { name: "Workspace", exact: true })).toBeVisible();
+});
+
+test("the topbar model quick-set edits a field in a dialog and saves", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByRole("button", { name: "Model settings" }).click();
+  const dialog = page.getByRole("dialog", { name: "Model" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByText("Primary model")).toBeVisible(); // model.name field
+  await dialog.locator('.setting-row[data-key="model.temperature"] input').fill("0.5");
+  await dialog.getByRole("button", { name: "Save", exact: true }).click();
+  await expect(dialog).toBeHidden(); // saved → closes
+});

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -32,23 +32,32 @@ test("Settings is a two-home shell (Host / App · Workspace)", async ({ page }) 
     "Commons",
   ]);
   await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible(); // default section
-  // The Workspace home → its sections; System holds the runtime/perf knobs.
+  // The Workspace home → the focused agent's makeup + settings (ADR 0048 fold).
   await tab(page, "Workspace");
   expect(await page.locator(".pl-tabs").nth(1).locator("button").allTextContents()).toEqual([
+    "Identity",
+    "Settings",
+    "Tools",
+    "MCP",
+    "Subagents",
+    "Skills",
+    "Middleware",
+    "Memory",
+    "System",
     "Theme",
     "Plugins",
-    "System",
   ]);
   await tab(page, "System");
   await expect(page.locator(".settings-group-title").first()).toBeVisible(); // wait for the suspense load
   expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Compaction", "Runtime"]);
 });
 
-test("Agent settings live in the Agent view's Settings tab", async ({ page }) => {
+test("Workspace ▸ Settings shows the agent's Model + Routing fields", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
-  // Model + Routing render here, not in the central Settings surface.
+  // Model + Routing render here (the agent makeup folded into Workspace, ADR 0048).
   await expect(page.locator(".settings-group-title").first()).toBeVisible(); // wait for the suspense load
   expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Model", "Routing"]);
   const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
@@ -59,7 +68,8 @@ test("Agent settings live in the Agent view's Settings tab", async ({ page }) =>
 
 test("editing an Agent setting enables save and round-trips", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
   const save = page.getByRole("button", { name: /Save & apply/ });
   await expect(save).toBeDisabled();
@@ -82,7 +92,8 @@ test("a restart-flagged System field shows the restart banner", async ({ page })
 // inheritance badge; an overridden host-scoped field offers reset-to-inherited.
 test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Agent", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
   await expect(page.locator(".settings-group-title").first()).toBeVisible();
   // model.name inherits from the host layer.

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,32 +1,44 @@
 import { expect, test } from "@playwright/test";
 
-// Settings are decentralized: Agent settings live in the Agent view, Memory in the
-// Knowledge view, and the central Settings surface keeps only the cross-cutting tabs
-// (Overview · Telemetry · Plugins · System). Each renders GET /api/settings/schema
-// groups for its category and saves via POST /api/settings (auto-reload).
+// Settings IA (ADR 0048): scope is the primary axis — TWO homes, each with its own
+// section sub-nav. 🖥 Host / App (box-shared) and 🧩 Workspace (the focused agent).
+// Each section renders GET /api/settings/schema groups for its category and saves via
+// POST /api/settings (auto-reload). The Agent rail surface still hosts the agent
+// makeup until the S-C collapse.
 
 async function openSettings(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();
 }
 
+// Click a home (row 1) or a section (row 2) — names are unique across both strips.
 async function tab(page, name) {
   await page.locator(".pl-tabs").getByRole("tab", { name, exact: true }).click();
 }
 
-test("central Settings is just the cross-cutting tabs", async ({ page }) => {
+test("Settings is a two-home shell (Host / App · Workspace)", async ({ page }) => {
   await openSettings(page);
-  expect(await page.locator(".pl-tabs button").allTextContents()).toEqual([
+  // Row 1 — the two scope homes (ADR 0048).
+  expect(await page.locator(".pl-tabs").first().locator("button").allTextContents()).toEqual([
+    "Host / App",
+    "Workspace",
+  ]);
+  // Row 2 — the Host / App home's sections (the default home).
+  expect(await page.locator(".pl-tabs").nth(1).locator("button").allTextContents()).toEqual([
     "Overview",
-    "Agents",
-    "Theme",
+    "Host config",
+    "Fleet",
     "Telemetry",
+    "Commons",
+  ]);
+  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible(); // default section
+  // The Workspace home → its sections; System holds the runtime/perf knobs.
+  await tab(page, "Workspace");
+  expect(await page.locator(".pl-tabs").nth(1).locator("button").allTextContents()).toEqual([
+    "Theme",
     "Plugins",
     "System",
-    "Host defaults", // ADR 0047 — the host-scoped subset, edited at the host layer
   ]);
-  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible(); // default
-  // System holds the runtime/perf knobs (Compaction + Runtime here).
   await tab(page, "System");
   await expect(page.locator(".settings-group-title").first()).toBeVisible(); // wait for the suspense load
   expect(await page.locator(".settings-group-title").allTextContents()).toEqual(["Compaction", "Runtime"]);
@@ -59,6 +71,7 @@ test("editing an Agent setting enables save and round-trips", async ({ page }) =
 
 test("a restart-flagged System field shows the restart banner", async ({ page }) => {
   await openSettings(page);
+  await tab(page, "Workspace");
   await tab(page, "System");
   await expect(page.locator(".settings-banner")).toHaveCount(0);
   await page.locator('.setting-row[data-key="runtime.autostart_on_boot"] input[type="checkbox"]').check();
@@ -91,9 +104,9 @@ test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ pag
   ).toHaveCount(0);
 });
 
-test("Host defaults view edits the host-scoped subset and saves to the host layer", async ({ page }) => {
+test("Host config edits the host-scoped subset and saves to the host layer", async ({ page }) => {
   await openSettings(page);
-  await tab(page, "Host defaults");
+  await tab(page, "Host config"); // Host / App is the default home
   await expect(page.locator(".settings-banner").first()).toContainText("box-shared");
   // Only host-scoped fields appear — model.name (host) is here; the agent-scoped
   // model.api_key + routing.fallback_models are NOT.

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -75,7 +75,7 @@ import { ChatSlot } from "./ChatSlot";
 import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
-import { SettingsSurface, SETTINGS_TABS, type SettingsTab } from "../settings/SettingsSurface";
+import { SettingsSurface } from "../settings/SettingsSurface";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
@@ -232,8 +232,9 @@ export function App() {
   const setPluginsTab = useUI((s) => s.setPluginsTab);
   const knowledgeTab = useUI((s) => s.knowledgeTab);
   const setKnowledgeTab = useUI((s) => s.setKnowledgeTab);
-  const settingsTab = useUI((s) => s.settingsTab);
-  const setSettingsTab = useUI((s) => s.setSettingsTab);
+  const setSettingsScope = useUI((s) => s.setSettingsScope);
+  const setSettingsSection = useUI((s) => s.setSettingsSection);
+  const setFleetStartNew = useUI((s) => s.setFleetStartNew);
   const activityTab = useUI((s) => s.activityTab);
   const setActivityTab = useUI((s) => s.setActivityTab);
   const rightPanel = useUI((s) => s.rightPanel);
@@ -569,12 +570,8 @@ export function App() {
           </>
         );
       case "settings":
-        return (
-          <>
-            <Tabs responsive active={settingsTab} onSelect={(t) => setSettingsTab(t as SettingsTab)} items={SETTINGS_TABS.map(toTab)} />
-            <SettingsSurface tab={settingsTab} />
-          </>
-        );
+        // SettingsSurface owns its own two-level nav (home + section, ADR 0048).
+        return <SettingsSurface />;
       // Notes is now the first-party `notes` plugin (ADR 0034 S4) — rendered via the default
       // plugin-view case below, not a native surface.
       case "beads":
@@ -731,8 +728,12 @@ export function App() {
           <FleetSwitcher
             fallbackName={brandName(runtime?.identity?.name)}
             onNewAgent={() => {
+              // Fleet now lives under Host / App ▸ Fleet (ADR 0048); ask the panel to
+              // open the new-agent picker on mount.
               setSurface("settings");
-              setSettingsTab("agents");
+              setSettingsScope("host");
+              setSettingsSection("fleet");
+              setFleetStartNew(true);
             }}
           />
         }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -22,7 +22,6 @@ import {
   Store,
   Save,
   Settings2,
-  SlidersHorizontal,
   Sparkles,
   Target,
   Undo2,
@@ -77,7 +76,6 @@ import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { SettingsOverlay } from "../settings/SettingsOverlay";
-import { QuickSetting } from "../settings/QuickSetting";
 import { ThemeQuickButton } from "../settings/ThemeQuickButton";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
@@ -709,20 +707,8 @@ export function App() {
         org={runtime?.identity?.org || "protoLabs.studio"}
         actions={
           <>
-            {/* Contextual quick-settings (ADR 0048) — gear-icon → dialog, by the agent
-                name. Model tuning here; the topbar gear opens the full one-stop-shop. */}
-            <QuickSetting
-              keys={["model.name", "model.temperature", "model.max_tokens"]}
-              title="Model"
-              label="Model settings"
-              icon={<SlidersHorizontal size={16} />}
-              deepLink={() => {
-                setSurface("settings");
-                setSettingsScope("workspace");
-                setSettingsSection("settings");
-                setSettingsOverlayOpen(true);
-              }}
-            />
+            {/* Quick-settings (ADR 0048). Model tuning lives on the chat composer (by the
+                input); the topbar keeps appearance + the gear to the full one-stop-shop. */}
             <ThemeQuickButton />
             <Button
               icon

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -22,6 +22,7 @@ import {
   Store,
   Save,
   Settings2,
+  SlidersHorizontal,
   Sparkles,
   Target,
   Undo2,
@@ -75,6 +76,9 @@ import { ChatSlot } from "./ChatSlot";
 import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { SettingsSurface } from "../settings/SettingsSurface";
+import { SettingsOverlay } from "../settings/SettingsOverlay";
+import { QuickSetting } from "../settings/QuickSetting";
+import { ThemeQuickButton } from "../settings/ThemeQuickButton";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
@@ -247,6 +251,8 @@ export function App() {
   >(null);
   const [activityUnread, setActivityUnread] = useState(0);
   const [inboxUnread, setInboxUnread] = useState(0);
+  // The one-stop-shop Settings overlay (ADR 0048) — opened by the topbar gear.
+  const [settingsOverlayOpen, setSettingsOverlayOpen] = useState(false);
   const [projectPath, setProjectPath] = useLocalStorageState("protoagent.projectPath", "");
   // Shell-level runtime read (ADR 0013): non-suspense useQuery so the topbar
   // always renders; the retry doubles as the desktop sidecar boot-probe. The
@@ -701,6 +707,36 @@ export function App() {
           />
         }
         org={runtime?.identity?.org || "protoLabs.studio"}
+        actions={
+          <>
+            {/* Contextual quick-settings (ADR 0048) — gear-icon → dialog, by the agent
+                name. Model tuning here; the topbar gear opens the full one-stop-shop. */}
+            <QuickSetting
+              keys={["model.name", "model.temperature", "model.max_tokens"]}
+              title="Model"
+              label="Model settings"
+              icon={<SlidersHorizontal size={16} />}
+              deepLink={() => {
+                setSurface("settings");
+                setSettingsScope("workspace");
+                setSettingsSection("settings");
+                setSettingsOverlayOpen(true);
+              }}
+            />
+            <ThemeQuickButton />
+            <Button
+              icon
+              variant="ghost"
+              type="button"
+              title="Open settings"
+              aria-label="Open settings"
+              data-testid="topbar-settings"
+              onClick={() => setSettingsOverlayOpen(true)}
+            >
+              <Settings2 size={16} />
+            </Button>
+          </>
+        }
         status={
           <button
             type="button"
@@ -875,6 +911,8 @@ export function App() {
         Rendered OUTSIDE the .app-shell grid: the DS Menu stays mounted to hold its ref, so
         its (closed) anchor would otherwise be a stray 4th grid row and break the layout. */}
     <ContextMenuRenderer />
+    {/* The one-stop-shop Settings overlay (ADR 0048) — the topbar gear opens it. */}
+    <SettingsOverlay open={settingsOverlayOpen} onClose={() => setSettingsOverlayOpen(false)} />
     </>
   );
 }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -74,19 +74,15 @@ import { InboxPanel } from "../inbox/InboxPanel";
 import { ChatSlot } from "./ChatSlot";
 import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
-import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
   type ActivityTab,
-  type AgentTab,
-  type KnowledgeTab,
   type PluginsTab,
   type RightPanel,
   type Surface,
 } from "../state/uiStore";
-import { SettingsCategoryPanel } from "../settings/SettingsCategory";
 import { api } from "../lib/api";
 import { PluginView } from "./PluginView";
 import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
@@ -105,11 +101,6 @@ import { StatusPill } from "./StatusPill";
 import { GoalsPanel } from "./GoalsPanel";
 import { BeadsPanel } from "./BeadsPanel";
 import { SchedulePanel } from "../schedule/SchedulePanel";
-import { IdentityPanel } from "../agent/IdentityPanel";
-import { ToolsPanel } from "./ToolsPanel";
-import { McpPanel } from "./McpPanel";
-import { SubagentsPanel } from "./SubagentsPanel";
-import { MiddlewarePanel } from "./MiddlewarePanel";
 import { PluginsSurface } from "../plugins/PluginsSurface";
 import { SetupWizard } from "../setup/SetupWizard";
 import { hostRuntimeStatusQuery, runtimeStatusQuery } from "../lib/queries";
@@ -226,12 +217,8 @@ export function App() {
   // Background-streaming indicator for the Chat rail (narrow selector → only
   // re-renders when the boolean flips, not per token).
   const chatStreaming = useAnyChatStreaming();
-  const agentTab = useUI((s) => s.agentTab);
-  const setAgentTab = useUI((s) => s.setAgentTab);
   const pluginsTab = useUI((s) => s.pluginsTab);
   const setPluginsTab = useUI((s) => s.setPluginsTab);
-  const knowledgeTab = useUI((s) => s.knowledgeTab);
-  const setKnowledgeTab = useUI((s) => s.setKnowledgeTab);
   const setSettingsScope = useUI((s) => s.setSettingsScope);
   const setSettingsSection = useUI((s) => s.setSettingsSection);
   const setFleetStartNew = useUI((s) => s.setFleetStartNew);
@@ -479,7 +466,7 @@ export function App() {
     // "studio" (Workflows) is contributed via src/ext/workflows.tsx, gated on the
     // workflows plugin (lean core) — no longer a hardcoded core surface.
     { id: "knowledge", label: "Knowledge", icon: <BookMarked size={18} /> },
-    { id: "agent", label: "Agent", icon: <Bot size={18} /> },
+    // "agent" folded into Settings ▸ Workspace (ADR 0048 S-C) — no longer a rail surface.
     { id: "plugins", label: "Plugins", icon: <Puzzle size={18} /> },
     { id: "settings", label: "Settings", icon: <Settings2 size={18} /> },
     { id: "beads", label: "Beads", icon: <Boxes size={18} /> },
@@ -527,27 +514,9 @@ export function App() {
             {activityTab === "thread" ? <ActivitySurface onError={setError} /> : <InboxPanel />}
           </>
         );
-      case "agent":
-        return (
-          <>
-            <Tabs responsive active={agentTab} onSelect={(t) => setAgentTab(t as AgentTab)} items={[
-              { id: "identity", label: "Identity", icon: Sparkles },
-              { id: "settings", label: "Settings", icon: Settings2 },
-              { id: "tools", label: "Tools", icon: Wrench },
-              { id: "mcp", label: "MCP", icon: Plug },
-              { id: "subagents", label: "Subagents", icon: Bot },
-              { id: "skills", label: "Skills", icon: BookMarked },
-              { id: "middleware", label: "Middleware", icon: Layers },
-            ].map(toTab)} />
-            {agentTab === "identity" ? <IdentityPanel /> : null}
-            {agentTab === "settings" ? <SettingsCategoryPanel category="Agent" title="Settings" /> : null}
-            {agentTab === "tools" ? <ToolsPanel /> : null}
-            {agentTab === "mcp" ? <McpPanel /> : null}
-            {agentTab === "subagents" ? <SubagentsPanel /> : null}
-            {agentTab === "skills" ? <PlaybooksSurface onError={setError} /> : null}
-            {agentTab === "middleware" ? <MiddlewarePanel /> : null}
-          </>
-        );
+      // The Agent surface folded into Settings ▸ Workspace (ADR 0048 S-C). Its tabs
+      // (Identity/Settings/Tools/MCP/Subagents/Skills/Middleware) are now Workspace
+      // sections in SettingsSurface.
       case "plugins":
         return (
           <>
@@ -559,16 +528,10 @@ export function App() {
             <PluginsSurface tab={pluginsTab} />
           </>
         );
+      // Knowledge is the searchable Store; its Memory settings folded into
+      // Settings ▸ Workspace ▸ Memory (ADR 0048 S-C).
       case "knowledge":
-        return (
-          <>
-            <Tabs responsive active={knowledgeTab} onSelect={(t) => setKnowledgeTab(t as KnowledgeTab)} items={[
-              { id: "store", label: "Store", icon: Database },
-              { id: "settings", label: "Settings", icon: Settings2 },
-            ].map(toTab)} />
-            {knowledgeTab === "store" ? <KnowledgeStore onError={setError} /> : <SettingsCategoryPanel category="Memory" title="Settings" />}
-          </>
-        );
+        return <KnowledgeStore onError={setError} />;
       case "settings":
         // SettingsSurface owns its own two-level nav (home + section, ADR 0048).
         return <SettingsSurface />;

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -153,6 +153,15 @@ function ChatSessionSlot({
   const abortRef = useRef<AbortController | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  // Auto-grow the single-row composer to fit its content (capped by max-height in
+  // CSS, then it scrolls). Runs on every draft change incl. programmatic ones
+  // (slash completion, send-clears-the-draft).
+  useEffect(() => {
+    const ta = textareaRef.current;
+    if (!ta) return;
+    ta.style.height = "auto";
+    ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
+  }, [draft]);
   const status = chat.sessionStatusMap[sessionId] || "idle";
 
   // Slash-command autocomplete. Commands the server handles (e.g. /goal) are
@@ -520,18 +529,6 @@ function ChatSessionSlot({
       )}
 
       <div className="composer-wrap">
-        {/* Model control, where you actually chat (ADR 0048) — a chip showing the active
-            model alias; click to tune model / temperature / max tokens. Same field +
-            cascade as Settings ▸ Workspace ▸ Settings. */}
-        <div className="composer-toolbar">
-          <QuickSetting
-            keys={["model.name", "model.temperature", "model.max_tokens"]}
-            summaryKey="model.name"
-            title="Model"
-            label="Model settings"
-            icon={<SlidersHorizontal size={14} />}
-          />
-        </div>
         {status === "streaming" && statusMessage ? (
           <div className="composer-status">
             <Loader2 className="spin" size={12} />
@@ -620,7 +617,7 @@ function ChatSessionSlot({
             }
           }}
           placeholder="Message protoAgent  (/ for commands · Enter to send · ⌘/Ctrl+Enter for newline)"
-          rows={3}
+          rows={1}
         />
         {status === "streaming" ? (
           <Button type="button" onClick={() => void stop()}>
@@ -634,6 +631,18 @@ function ChatSessionSlot({
           </Button>
         )}
         </form>
+        {/* Model control, under the input (ADR 0048) — a chip showing the active model
+            alias; click to tune model / temperature / max tokens. Same field + cascade
+            as Settings ▸ Workspace ▸ Settings. */}
+        <div className="composer-toolbar">
+          <QuickSetting
+            keys={["model.name", "model.temperature", "model.max_tokens"]}
+            summaryKey="model.name"
+            title="Model"
+            label="Model settings"
+            icon={<SlidersHorizontal size={14} />}
+          />
+        </div>
       </div>
     </div>
   );

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -4,12 +4,14 @@ import { TabBar } from "@protolabsai/ui/navigation";
 import {
   Loader2,
   Send,
+  SlidersHorizontal,
   Square,
   TerminalSquare,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "../lib/api";
+import { QuickSetting } from "../settings/QuickSetting";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import type { ChatMessage, HitlPayload, SlashCommand, ToolCall } from "../lib/types";
 import { HitlForm } from "./HitlForm";
@@ -518,6 +520,18 @@ function ChatSessionSlot({
       )}
 
       <div className="composer-wrap">
+        {/* Model control, where you actually chat (ADR 0048) — a chip showing the active
+            model alias; click to tune model / temperature / max tokens. Same field +
+            cascade as Settings ▸ Workspace ▸ Settings. */}
+        <div className="composer-toolbar">
+          <QuickSetting
+            keys={["model.name", "model.temperature", "model.max_tokens"]}
+            summaryKey="model.name"
+            title="Model"
+            label="Model settings"
+            icon={<SlidersHorizontal size={14} />}
+          />
+        </div>
         {status === "streaming" && statusMessage ? (
           <div className="composer-status">
             <Loader2 className="spin" size={12} />

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -48,28 +48,22 @@
   color: var(--fg-secondary);
 }
 
-/* A thin control row above the input (ADR 0048) — holds the model chip (and is the
-   home for future per-turn controls). Sits on the composer's top border. */
-.composer-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px 0;
-  border-top: 1px solid var(--border);
-}
-
 .composer {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
   gap: 10px;
   padding: 12px;
   border-top: 1px solid var(--border);
-  align-items: start; /* don't let the textarea + Send button stretch each other tall */
+  align-items: center; /* a single-row input sits centered against the Send button */
 }
-/* With the toolbar above, the composer's own top border would double up — drop it. */
-.composer-toolbar + .composer,
-.composer-status + .composer {
-  border-top: 0;
+
+/* A thin control row UNDER the input (ADR 0048) — holds the model chip (and is the
+   home for future per-turn controls). */
+.composer-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 0 12px 8px;
 }
 
 /* Slash-command autocomplete (floats above the composer). */
@@ -120,8 +114,12 @@
 /* The chat input is a compact fixed height (it doesn't auto-grow) — without this it has no cap
    and rendered far too tall. .notes-editor keeps its own sizing above. */
 .composer textarea {
-  height: 60px;
-  min-height: 44px;
+  /* Single-row by default (like a text input); auto-grows with content up to
+     max-height (JS sets the inline height), then scrolls. */
+  height: auto;
+  min-height: 40px;
   max-height: 200px;
   line-height: 1.45;
+  resize: none;
+  overflow-y: auto;
 }

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -48,6 +48,16 @@
   color: var(--fg-secondary);
 }
 
+/* A thin control row above the input (ADR 0048) — holds the model chip (and is the
+   home for future per-turn controls). Sits on the composer's top border. */
+.composer-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 12px 0;
+  border-top: 1px solid var(--border);
+}
+
 .composer {
   display: grid;
   grid-template-columns: minmax(0, 1fr) auto;
@@ -55,6 +65,11 @@
   padding: 12px;
   border-top: 1px solid var(--border);
   align-items: start; /* don't let the textarea + Send button stretch each other tall */
+}
+/* With the toolbar above, the composer's own top border would double up — drop it. */
+.composer-toolbar + .composer,
+.composer-status + .composer {
+  border-top: 0;
 }
 
 /* Slash-command autocomplete (floats above the composer). */

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -6,6 +6,7 @@ import { useEffect, useState } from "react";
 
 import { api } from "../lib/api";
 import { PanelHeader } from "@protolabsai/ui/navigation";
+import { QuickSetting } from "../settings/QuickSetting";
 import type { KnowledgeChunk } from "../lib/types";
 
 // Knowledge → Store (ADR 0020) — a searchable window onto the agent's knowledge
@@ -61,9 +62,13 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
         title="Knowledge"
         kicker={`searchable knowledge base${total ? ` · ${total} entr${total === 1 ? "y" : "ies"}` : ""}`}
         actions={
-          <Button icon variant="ghost" type="button" onClick={() => void run(query)} disabled={loading} title="Refresh">
-            <RefreshCw size={16} className={loading ? "spin" : ""} />
-          </Button>
+          <>
+            {/* Quick-set recall behaviour right where you inspect what the agent knows (ADR 0048). */}
+            <QuickSetting keys={["knowledge.top_k", "knowledge.embeddings"]} title="Recall" label="Knowledge recall settings" />
+            <Button icon variant="ghost" type="button" onClick={() => void run(query)} disabled={loading} title="Refresh">
+              <RefreshCw size={16} className={loading ? "spin" : ""} />
+            </Button>
+          </>
         }
       />
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -491,6 +491,15 @@ export const api = {
     );
   },
 
+  // Promote a private skill into the shared commons (ADR 0041) — only meaningful
+  // when the index is layered; the route reports promoted:false with a hint otherwise.
+  promotePlaybook(id: number) {
+    return request<{ enabled: boolean; promoted: boolean; name?: string; error?: string }>(
+      `/api/playbooks/${id}/promote`,
+      { method: "POST" },
+    );
+  },
+
   setupStatus() {
     return request<SetupStatus>("/api/config/setup-status");
   },

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -478,6 +478,10 @@ export type Playbook = {
   confidence: number;
   last_used: string | null;
   created_at: string | null;
+  // Tier (ADR 0041 layered skills): "private" | "commons". Present only when the
+  // index is layered (the agent reads a shared commons ∪ its private library);
+  // absent in scoped/shared mode, where there's a single library and no promote.
+  tier?: "private" | "commons";
 };
 
 // One row from the knowledge store (knowledge/store.py chunks table), as the

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -1,6 +1,6 @@
 import { Input } from "@protolabsai/ui/forms";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { BookMarked, Pin, RefreshCw, Sparkles, Trash2 } from "lucide-react";
+import { ArrowUpToLine, BookMarked, Library, Pin, RefreshCw, Sparkles, Trash2 } from "lucide-react";
 
 import { useEffect, useMemo, useState } from "react";
 
@@ -32,6 +32,7 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
   const [pending, setPending] = useState<Playbook | null>(null);
+  const [promoting, setPromoting] = useState<number | null>(null);
 
   async function load() {
     setLoading(true);
@@ -63,6 +64,27 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
 
   const pinned = filtered.filter((p) => p.source === "disk").length;
   const learned = filtered.length - pinned;
+  // Tier is present only when the index is layered (commons ∪ private). When it
+  // is, surface a commons count so the operator sees the shared library at a glance.
+  const layered = playbooks.some((p) => p.tier);
+  const fromCommons = filtered.filter((p) => p.tier === "commons").length;
+
+  async function promote(p: Playbook) {
+    setPromoting(p.id);
+    try {
+      const r = await api.promotePlaybook(p.id);
+      if (!r.promoted) {
+        onError(r.error || "promote failed");
+        return;
+      }
+      onError("");
+      await load(); // the skill now also reads from the commons tier
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setPromoting(null);
+    }
+  }
 
   async function confirmDelete() {
     if (!pending) return;
@@ -84,7 +106,7 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
     <section className="panel stage-panel" data-testid="playbooks-surface">
       <PanelHeader
         title="Skills"
-        kicker={`methodology the agent retrieves into context · ${pinned} pinned · ${learned} learned`}
+        kicker={`methodology the agent retrieves into context · ${pinned} pinned · ${learned} learned${layered ? ` · ${fromCommons} from commons` : ""}`}
         actions={
           <Button icon variant="ghost" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
             <RefreshCw size={16} className={loading ? "spin" : ""} />
@@ -131,6 +153,17 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
                         </Badge>
                       </span>
                     )}
+                    {p.tier === "commons" ? (
+                      <span title="Shared commons — readable by every agent on this box">
+                        <Badge status="neutral">
+                          <Library size={12} /> commons
+                        </Badge>
+                      </span>
+                    ) : p.tier === "private" ? (
+                      <span title="Private to this agent — promote to share it with the fleet">
+                        <Badge status="neutral">private</Badge>
+                      </span>
+                    ) : null}
                     <strong>{p.name}</strong>
                   </div>
                   <p className="playbook-desc">{p.description}</p>
@@ -145,6 +178,18 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
                 <div className="playbook-meta">
                   <span title="confidence">conf {Math.round((p.confidence ?? 1) * 100)}%</span>
                   <span title="last used">used {ago(p.last_used)}</span>
+                  {p.tier === "private" ? (
+                    <Button
+                      type="button"
+                      icon variant="ghost"
+                      title="Promote to the shared commons (every agent on this box can then reuse it)"
+                      onClick={() => void promote(p)}
+                      disabled={promoting === p.id}
+                      data-testid={`playbook-promote-${p.id}`}
+                    >
+                      <ArrowUpToLine size={14} className={promoting === p.id ? "spin" : ""} />
+                    </Button>
+                  ) : null}
                   <Button
                     type="button"
                     icon variant="danger"

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -27,7 +27,7 @@ function ago(iso: string | null): string {
   return `${Math.round(s / 86400)}d ago`;
 }
 
-export function PlaybooksSurface({ onError }: { onError: (message: string) => void }) {
+export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: string) => void }) {
   const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(false);

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -1,12 +1,13 @@
 import { Input } from "@protolabsai/ui/forms";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { ArrowUpToLine, BookMarked, Library, Pin, RefreshCw, Sparkles, Trash2 } from "lucide-react";
+import { ArrowUpToLine, BookMarked, Library, Pin, RefreshCw, Share2, Sparkles, Trash2 } from "lucide-react";
 
 import { useEffect, useMemo, useState } from "react";
 
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { api } from "../lib/api";
+import { QuickSetting } from "../settings/QuickSetting";
 import type { Playbook } from "../lib/types";
 
 // Playbooks surface (ADR 0009) — browse + manage the procedural-memory skill
@@ -108,9 +109,14 @@ export function PlaybooksSurface({ onError }: { onError: (message: string) => vo
         title="Skills"
         kicker={`methodology the agent retrieves into context · ${pinned} pinned · ${learned} learned${layered ? ` · ${fromCommons} from commons` : ""}`}
         actions={
-          <Button icon variant="ghost" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
-            <RefreshCw size={16} className={loading ? "spin" : ""} />
-          </Button>
+          <>
+            {/* Quick-set the skill-sharing mode (scoped/shared/layered) right where you
+                manage skills — same field as Workspace ▸ Skills, ADR 0048. */}
+            <QuickSetting keys={["skills.scope"]} title="Skill sharing" label="Skill sharing mode" icon={<Share2 size={16} />} />
+            <Button icon variant="ghost" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
+              <RefreshCw size={16} className={loading ? "spin" : ""} />
+            </Button>
+          </>
         }
       />
 

--- a/apps/web/src/settings/CommonsPanel.tsx
+++ b/apps/web/src/settings/CommonsPanel.tsx
@@ -1,0 +1,71 @@
+import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
+import { PanelHeader } from "@protolabsai/ui/navigation";
+import { useQuery } from "@tanstack/react-query";
+import { Library, RefreshCw } from "lucide-react";
+
+import { api } from "../lib/api";
+
+// Host / App ▸ Commons (ADR 0041 + 0048) — the box-shared skill library every agent
+// on this machine reads (commons ∪ private, in layered mode). Read-only here: a
+// skill enters the commons by being PROMOTED from a workspace (Workspace ▸ Skills),
+// which is the curated, explicit "shared brain, private hands" lift. The commons
+// LOCATION (`commons.path`) is a host-scoped field edited in Host ▸ Host config.
+
+export function CommonsPanel() {
+  const q = useQuery({ queryKey: ["playbooks"], queryFn: () => api.playbooks(), retry: false });
+  const all = q.data?.playbooks ?? [];
+  const commons = all.filter((p) => p.tier === "commons");
+  const layered = all.some((p) => p.tier);
+
+  return (
+    <section className="panel stage-panel" data-testid="commons-panel">
+      <PanelHeader
+        title="Commons"
+        kicker={`the box-shared skill library · ${commons.length} skill${commons.length === 1 ? "" : "s"}`}
+        actions={
+          <Button icon variant="ghost" type="button" onClick={() => void q.refetch()} disabled={q.isFetching} title="Refresh">
+            <RefreshCw size={16} className={q.isFetching ? "spin" : ""} />
+          </Button>
+        }
+      />
+      <div className="stage-body">
+        {!layered ? (
+          <Empty
+            title="No commons in use"
+            description="No agent on this box is in layered mode. Set an agent's Skill sharing to “layered” (Workspace ▸ Skills) to read + contribute to a shared commons, and choose its location in Host config (commons.path)."
+          />
+        ) : commons.length === 0 ? (
+          <Empty
+            title="The commons is empty"
+            description="Promote a proven skill from a workspace (Workspace ▸ Skills ▸ Promote) to share it with every agent on this box."
+          />
+        ) : (
+          <ul className="playbook-list">
+            {commons.map((p) => (
+              <li key={p.id} className="playbook-card">
+                <div className="playbook-main">
+                  <div className="playbook-title">
+                    <span title="Shared commons — readable by every agent on this box">
+                      <Badge status="neutral">
+                        <Library size={12} /> commons
+                      </Badge>
+                    </span>
+                    <strong>{p.name}</strong>
+                  </div>
+                  <p className="playbook-desc">{p.description}</p>
+                  {p.tools_used.length ? (
+                    <div className="playbook-tools">
+                      {p.tools_used.map((t) => (
+                        <code key={t}>{t}</code>
+                      ))}
+                    </div>
+                  ) : null}
+                </div>
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/settings/FleetSurface.tsx
+++ b/apps/web/src/settings/FleetSurface.tsx
@@ -1,12 +1,25 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
+import { useUI } from "../state/uiStore";
 import { FleetManagerPanel } from "./FleetManagerPanel";
 import { NewAgentPanel } from "./NewAgentPanel";
 
-// Settings → Agents (ADR 0042). The fleet manager + the new-agent picker, toggled in
-// place — "+ New agent" opens the picker, which returns to the list on create/cancel.
+// Host / App ▸ Fleet (ADR 0042 / 0048). The fleet manager + the new-agent picker,
+// toggled in place — "+ New agent" opens the picker, which returns to the list on
+// create/cancel. The FleetSwitcher's "+ New agent" deep-link sets a one-shot
+// `fleetStartNew` flag (ADR 0048) so landing here opens the picker straight away.
 export function FleetSurface() {
-  const [view, setView] = useState<"list" | "new">("list");
+  const startNew = useUI((s) => s.fleetStartNew);
+  const setStartNew = useUI((s) => s.setFleetStartNew);
+  const [view, setView] = useState<"list" | "new">(startNew ? "new" : "list");
+
+  useEffect(() => {
+    if (startNew) {
+      setView("new");
+      setStartNew(false); // consume the one-shot so a manual back-to-list sticks
+    }
+  }, [startNew, setStartNew]);
+
   if (view === "new") {
     return <NewAgentPanel onDone={() => setView("list")} onCancel={() => setView("list")} />;
   }

--- a/apps/web/src/settings/QuickSetting.tsx
+++ b/apps/web/src/settings/QuickSetting.tsx
@@ -1,0 +1,148 @@
+import "./settings.css";
+
+import { Button } from "@protolabsai/ui/primitives";
+import { Dialog } from "@protolabsai/ui/overlays";
+import { PanelHeader } from "@protolabsai/ui/navigation";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ExternalLink, Loader2, Save, Settings2 } from "lucide-react";
+import { useMemo, useState } from "react";
+import type { ReactNode } from "react";
+
+import { api } from "../lib/api";
+import { queryKeys, settingsSchemaQuery } from "../lib/queries";
+import type { SettingsField } from "../lib/types";
+import { SettingInput } from "./SettingsCategory";
+
+// QuickSetting (ADR 0048) — a contextual settings shortcut: a small icon button that
+// opens a dialog editing one (or a few) named fields right where they're relevant,
+// instead of making the operator navigate to the central Settings home. It edits the
+// SAME fields via the SAME /api/settings write path + cascade (so a host-scoped field
+// saves to the host layer); the central Settings surface stays the canonical
+// one-stop-shop. Drop one in anywhere:
+//
+//   <QuickSetting keys={["skills.scope"]} title="Skill sharing" />
+//   <QuickSetting keys={["model.temperature", "model.max_tokens"]} title="Model tuning" />
+
+export function QuickSetting({
+  keys,
+  title = "Quick settings",
+  label,
+  icon,
+  deepLink,
+}: {
+  keys: string[];
+  title?: string;
+  /** Accessible label / tooltip for the trigger button (defaults to title). */
+  label?: string;
+  /** Trigger glyph (defaults to a gear). */
+  icon?: ReactNode;
+  /** Optional "Open full settings →" callback (e.g. route to the central home). */
+  deepLink?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button icon variant="ghost" type="button" title={label ?? title} aria-label={label ?? title} onClick={() => setOpen(true)}>
+        {icon ?? <Settings2 size={15} />}
+      </Button>
+      {open ? (
+        <QuickSettingDialog keys={keys} title={title} deepLink={deepLink} onClose={() => setOpen(false)} />
+      ) : null}
+    </>
+  );
+}
+
+function QuickSettingDialog({
+  keys,
+  title,
+  deepLink,
+  onClose,
+}: {
+  keys: string[];
+  title: string;
+  deepLink?: () => void;
+  onClose: () => void;
+}) {
+  const queryClient = useQueryClient();
+  const schema = useQuery(settingsSchemaQuery());
+  const [dirty, setDirty] = useState<Record<string, unknown>>({});
+  const [status, setStatus] = useState("");
+
+  const fields = useMemo<SettingsField[]>(() => {
+    const byKey = new globalThis.Map<string, SettingsField>();
+    for (const g of schema.data?.groups ?? []) for (const f of g.fields) byKey.set(f.key, f);
+    return keys.map((k) => byKey.get(k)).filter((f): f is SettingsField => Boolean(f));
+  }, [schema.data, keys]);
+
+  // Save to the host layer iff every edited field is host-scoped (a mixed set is
+  // unusual for a quick-set; default to the agent leaf then).
+  const layer = fields.length && fields.every((f) => f.scope === "host") ? "host" : "agent";
+
+  const save = useMutation({
+    mutationFn: () => api.saveSettings(dirty, layer),
+    onMutate: () => setStatus("saving…"),
+    onSuccess: (r) => {
+      if (!r.ok) {
+        setStatus(`save failed: ${r.messages.join(" · ")}`);
+        return;
+      }
+      void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
+      onClose();
+    },
+    onError: (e) => setStatus(`save failed: ${e instanceof Error ? e.message : String(e)}`),
+  });
+
+  const dirtyKeys = Object.keys(dirty);
+
+  return (
+    <Dialog
+      open
+      onClose={onClose}
+      title={title}
+      width={460}
+      className="quick-setting-dialog"
+      footer={
+        <>
+          {deepLink ? (
+            <Button type="button" variant="ghost" onClick={() => { onClose(); deepLink(); }}>
+              <ExternalLink size={14} /> Open full settings
+            </Button>
+          ) : null}
+          <Button type="button" onClick={onClose} disabled={save.isPending}>Cancel</Button>
+          <Button variant="primary" type="button" onClick={() => save.mutate()} disabled={save.isPending || !dirtyKeys.length}>
+            {save.isPending ? <Loader2 className="spin" size={15} /> : <Save size={15} />} Save
+          </Button>
+        </>
+      }
+    >
+      {schema.isLoading ? (
+        <p className="muted">Loading…</p>
+      ) : !fields.length ? (
+        <p className="muted">Nothing to configure here.</p>
+      ) : (
+        <div className="quick-setting-body">
+          {fields.map((field) => (
+            <div className="setting-row" key={field.key} data-key={field.key}>
+              <div className="setting-meta">
+                <label className="setting-label" htmlFor={`set-${field.key}`}>
+                  {field.label}
+                  {field.restart ? <span className="setting-restart">restart</span> : null}
+                  {field.scope === "host" ? <span className="setting-restart">box-shared</span> : null}
+                </label>
+                {field.description ? <p className="setting-desc">{field.description}</p> : null}
+              </div>
+              <div className="setting-control">
+                <SettingInput
+                  field={field}
+                  value={field.key in dirty ? dirty[field.key] : field.value}
+                  onChange={(v) => setDirty((d) => ({ ...d, [field.key]: v }))}
+                />
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {status ? <p className="settings-status">{status}</p> : null}
+    </Dialog>
+  );
+}

--- a/apps/web/src/settings/QuickSetting.tsx
+++ b/apps/web/src/settings/QuickSetting.tsx
@@ -29,6 +29,7 @@ export function QuickSetting({
   label,
   icon,
   deepLink,
+  summaryKey,
 }: {
   keys: string[];
   title?: string;
@@ -38,13 +39,30 @@ export function QuickSetting({
   icon?: ReactNode;
   /** Optional "Open full settings →" callback (e.g. route to the central home). */
   deepLink?: () => void;
+  /** When set, the trigger renders as a CHIP showing this field's current value
+   * (e.g. the model alias on the chat composer) instead of an icon-only button. */
+  summaryKey?: string;
 }) {
   const [open, setOpen] = useState(false);
+  // Only fetch the (cached) schema when a chip summary is requested.
+  const schema = useQuery({ ...settingsSchemaQuery(), enabled: Boolean(summaryKey) });
+  const summary = summaryKey
+    ? schema.data?.groups.flatMap((g) => g.fields).find((f) => f.key === summaryKey)?.value
+    : undefined;
+  const tip = label ?? title;
+
   return (
     <>
-      <Button icon variant="ghost" type="button" title={label ?? title} aria-label={label ?? title} onClick={() => setOpen(true)}>
-        {icon ?? <Settings2 size={15} />}
-      </Button>
+      {summaryKey ? (
+        <Button variant="ghost" size="sm" type="button" title={tip} aria-label={tip} onClick={() => setOpen(true)}>
+          {icon ?? <Settings2 size={14} />}
+          <span className="quick-setting-summary">{summary != null && summary !== "" ? String(summary) : title}</span>
+        </Button>
+      ) : (
+        <Button icon variant="ghost" type="button" title={tip} aria-label={tip} onClick={() => setOpen(true)}>
+          {icon ?? <Settings2 size={15} />}
+        </Button>
+      )}
       {open ? (
         <QuickSettingDialog keys={keys} title={title} deepLink={deepLink} onClose={() => setOpen(false)} />
       ) : null}

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -37,7 +37,13 @@ export function SettingsCategoryPanel(props: { category: string; title?: string;
 // categories, editable, saving to the host layer. Surfaced as its own Settings tab.
 // TODO(ADR 0047 §7): gate to the host console (slug=host); for now it renders for any
 // focused agent, clearly labeled "box-shared", so the slice isn't blocked on gating.
-export function HostDefaultsPanel({ categories = ["Agent", "System"] }: { categories?: string[] }) {
+export function HostDefaultsPanel({
+  categories = ["Agent", "System"],
+  title = "Host defaults",
+}: {
+  categories?: string[];
+  title?: string;
+}) {
   // ONE panel — the host-scoped fields across all the given categories render
   // together under a single header + Save bar + explainer (grouped by their
   // section). Previously this mapped one full SettingsCategory PER category, which
@@ -51,7 +57,7 @@ export function HostDefaultsPanel({ categories = ["Agent", "System"] }: { catego
               <SettingsCategory
                 category={categories[0]}
                 categories={categories}
-                title="Host defaults"
+                title={title}
                 emptyHint="No box-shared defaults on this box yet."
                 hostLayer
               />
@@ -400,7 +406,7 @@ function SettingRow({
   );
 }
 
-function SettingInput({ field, value, onChange }: { field: SettingsField; value: unknown; onChange: (value: unknown) => void }) {
+export function SettingInput({ field, value, onChange }: { field: SettingsField; value: unknown; onChange: (value: unknown) => void }) {
   const id = `set-${field.key}`;
 
   if (field.type === "bool") {

--- a/apps/web/src/settings/SettingsOverlay.tsx
+++ b/apps/web/src/settings/SettingsOverlay.tsx
@@ -1,0 +1,19 @@
+import "./settings.css";
+
+import { Dialog } from "@protolabsai/ui/overlays";
+
+import { SettingsSurface } from "./SettingsSurface";
+
+// The one-stop-shop as an overlay (ADR 0048, operator direction 2026-06-11): the
+// same two-home SettingsSurface, openable as a dialog from the topbar gear so
+// settings are reachable from anywhere without leaving the current surface. It
+// shares the persisted settingsScope/settingsSection, so it opens wherever you
+// last were (and quick-settings' "Open full settings" can deep-link a section).
+export function SettingsOverlay({ open, onClose }: { open: boolean; onClose: () => void }) {
+  if (!open) return null;
+  return (
+    <Dialog open onClose={onClose} title="Settings" width="min(960px, 94vw)" className="settings-overlay">
+      <SettingsSurface />
+    </Dialog>
+  );
+}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,9 +1,15 @@
-import { BarChart3, Boxes, Gauge, HardDrive, Library, Palette, Puzzle, Server, Settings2 } from "lucide-react";
+import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Library, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
 import { Tabs } from "@protolabsai/ui/navigation";
 
+import { IdentityPanel } from "../agent/IdentityPanel";
+import { McpPanel } from "../app/McpPanel";
+import { MiddlewarePanel } from "../app/MiddlewarePanel";
+import { SubagentsPanel } from "../app/SubagentsPanel";
+import { ToolsPanel } from "../app/ToolsPanel";
+import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { useUI, type SettingsScope } from "../state/uiStore";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { CommonsPanel } from "./CommonsPanel";
@@ -39,7 +45,22 @@ const HOST_SECTIONS: Section[] = [
   { id: "commons", label: "Commons", icon: Library, render: () => <CommonsPanel /> },
 ];
 
+// The Workspace home (ADR 0048 §3.2) — the focused agent, everything that defines it:
+// the makeup panels (Identity/Tools/MCP/Subagents/Skills/Middleware) folded in from the
+// old Agent rail surface + Theme, plus the agent-scoped field settings (Agent/Memory/
+// System/Plugins categories). Host-scoped fields that appear here (e.g. model.name)
+// keep their ADR 0047 "inherited from Host" badge + override. (A later refinement can
+// regroup the field sections into the ADR's idealized Model/Behavior cut.)
 const WORKSPACE_SECTIONS: Section[] = [
+  { id: "identity", label: "Identity", icon: Sparkles, render: () => <IdentityPanel /> },
+  { id: "settings", label: "Settings", icon: Settings2, render: () => <SettingsCategoryPanel category="Agent" title="Agent settings" /> },
+  { id: "tools", label: "Tools", icon: Wrench, render: () => <ToolsPanel /> },
+  { id: "mcp", label: "MCP", icon: Plug, render: () => <McpPanel /> },
+  { id: "subagents", label: "Subagents", icon: Bot, render: () => <SubagentsPanel /> },
+  { id: "skills", label: "Skills", icon: BookMarked, render: () => <PlaybooksSurface /> },
+  { id: "middleware", label: "Middleware", icon: Layers, render: () => <MiddlewarePanel /> },
+  { id: "memory", label: "Memory", icon: Database, render: () => <SettingsCategoryPanel category="Memory" title="Memory" /> },
+  { id: "system", label: "System", icon: Settings2, render: () => <SettingsCategoryPanel category="System" title="System" /> },
   { id: "theme", label: "Theme", icon: Palette, render: () => <ThemeSurface /> },
   {
     id: "plugins",
@@ -54,7 +75,6 @@ const WORKSPACE_SECTIONS: Section[] = [
       />
     ),
   },
-  { id: "system", label: "System", icon: Settings2, render: () => <SettingsCategoryPanel category="System" title="System" /> },
 ];
 
 export const SETTINGS_HOMES: Home[] = [

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -104,6 +104,9 @@ export function SettingsSurface() {
 
   return (
     <>
+      {/* The scope home toggle. INTERIM: stacked over the section Tabs because the DS
+          has no segmented control yet — adopt `Tabs variant="segmented"` / SegmentedControl
+          when protoContent#218 ships. */}
       <Tabs
         responsive
         active={scope}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,45 +1,97 @@
-import { BarChart3, Gauge, HardDrive, Palette, Puzzle, Server, Settings2 } from "lucide-react";
+import { BarChart3, Boxes, Gauge, HardDrive, Library, Palette, Puzzle, Server, Settings2 } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
 
+import { Tabs } from "@protolabsai/ui/navigation";
+
+import { useUI, type SettingsScope } from "../state/uiStore";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
+import { CommonsPanel } from "./CommonsPanel";
 import { DelegatesSection } from "./DelegatesSection";
 import { FleetSurface } from "./FleetSurface";
 import { OverviewPanel } from "./OverviewPanel";
 import { HostDefaultsPanel, SettingsCategoryPanel } from "./SettingsCategory";
 import { ThemeSurface } from "./ThemeSurface";
 
-// Central Settings — only cross-cutting stuff now (the settings decentralization):
-// Overview (status), Telemetry, Plugins (delegates + the settings for any view-less
-// plugin), and System (runtime/middleware). Agent + Memory settings moved to their
-// home views (Agent → Settings, Knowledge → Settings).
+// Settings IA (ADR 0048) — scope is the primary axis. TWO homes, each with its own
+// section sub-nav, replacing the old flat category tabs:
+//
+//   🖥 Host / App   — box-shared, reachable from any workspace (set once, every agent
+//                     inherits; per-agent overrides win, ADR 0047).
+//   🧩 Workspace    — the focused agent: everything that defines it.
+//
+// S-A builds the Host/App home in full and a transitional Workspace home (today's
+// agent-scoped central settings). S-B folds the agent makeup (Identity/Tools/MCP/
+// Subagents/Skills/Middleware + Model/Behavior) into Workspace; S-C removes the
+// standalone Agent rail surface + the old category tabs.
 
-export type SettingsTab = "overview" | "agents" | "theme" | "telemetry" | "plugins" | "system" | "host";
+type Section = { id: string; label: string; icon: LucideIcon; render: () => ReactNode };
+type Home = { id: SettingsScope; label: string; icon: LucideIcon; sections: Section[] };
 
-export const SETTINGS_TABS = [
-  { id: "overview", label: "Overview", icon: Gauge },
-  { id: "agents", label: "Agents", icon: Server },
-  { id: "theme", label: "Theme", icon: Palette },
-  { id: "telemetry", label: "Telemetry", icon: BarChart3 },
-  { id: "plugins", label: "Plugins", icon: Puzzle },
-  { id: "system", label: "System", icon: Settings2 },
-  // Host / box-shared defaults (ADR 0047) — the host-scoped subset, edited at the host layer.
-  { id: "host", label: "Host defaults", icon: HardDrive },
-] as const;
+const HOST_SECTIONS: Section[] = [
+  { id: "overview", label: "Overview", icon: Gauge, render: () => <OverviewPanel /> },
+  // The host-scoped FIELDS (model gateway · routing · caching · org + the commons
+  // location) in ONE panel, saving to the box's host-config.yaml (ADR 0047).
+  { id: "config", label: "Host config", icon: HardDrive, render: () => <HostDefaultsPanel title="Host configuration" /> },
+  { id: "fleet", label: "Fleet", icon: Server, render: () => <FleetSurface /> },
+  { id: "telemetry", label: "Telemetry", icon: BarChart3, render: () => <TelemetrySurface /> },
+  // The box-shared skill commons (ADR 0041): browse it, promote from a workspace.
+  { id: "commons", label: "Commons", icon: Library, render: () => <CommonsPanel /> },
+];
 
-export function SettingsSurface({ tab = "overview" }: { tab?: SettingsTab }) {
-  if (tab === "agents") return <FleetSurface />;              // the fleet (ADR 0042)
-  if (tab === "theme") return <ThemeSurface />;               // per-agent look (ADR 0042)
-  if (tab === "telemetry") return <TelemetrySurface />;       // self-contained (own section + boundary)
-  if (tab === "plugins") {
-    return (
+const WORKSPACE_SECTIONS: Section[] = [
+  { id: "theme", label: "Theme", icon: Palette, render: () => <ThemeSurface /> },
+  {
+    id: "plugins",
+    label: "Plugins",
+    icon: Puzzle,
+    render: () => (
       <SettingsCategoryPanel
         category="Plugins"
         title="Plugin settings"
         emptyHint="Plugins with their own view manage settings there. Anything view-less shows up here."
         footer={<DelegatesSection />}
       />
-    );
+    ),
+  },
+  { id: "system", label: "System", icon: Settings2, render: () => <SettingsCategoryPanel category="System" title="System" /> },
+];
+
+export const SETTINGS_HOMES: Home[] = [
+  { id: "host", label: "Host / App", icon: HardDrive, sections: HOST_SECTIONS },
+  { id: "workspace", label: "Workspace", icon: Boxes, sections: WORKSPACE_SECTIONS },
+];
+
+const tabItems = (xs: { id: string; label: string; icon: LucideIcon }[]) =>
+  xs.map((x) => ({ id: x.id, label: x.label, icon: <x.icon size={15} /> }));
+
+export function SettingsSurface() {
+  const scope = useUI((s) => s.settingsScope);
+  const section = useUI((s) => s.settingsSection);
+  const setScope = useUI((s) => s.setSettingsScope);
+  const setSection = useUI((s) => s.setSettingsSection);
+
+  const home = SETTINGS_HOMES.find((h) => h.id === scope) ?? SETTINGS_HOMES[0];
+  const active = home.sections.find((s) => s.id === section) ?? home.sections[0];
+
+  // Switching home lands on its first section unless the current section id also
+  // exists in the new home (it usually won't — the homes don't share section ids).
+  function selectHome(next: SettingsScope) {
+    const h = SETTINGS_HOMES.find((x) => x.id === next) ?? SETTINGS_HOMES[0];
+    setScope(next);
+    if (!h.sections.some((s) => s.id === section)) setSection(h.sections[0].id);
   }
-  if (tab === "system") return <SettingsCategoryPanel category="System" title="System" />;
-  if (tab === "host") return <HostDefaultsPanel />;            // box-shared defaults (ADR 0047)
-  return <OverviewPanel />;                                    // overview (default; own section)
+
+  return (
+    <>
+      <Tabs
+        responsive
+        active={scope}
+        onSelect={(t) => selectHome(t as SettingsScope)}
+        items={tabItems(SETTINGS_HOMES)}
+      />
+      <Tabs responsive active={active.id} onSelect={(t) => setSection(t)} items={tabItems(home.sections)} />
+      {active.render()}
+    </>
+  );
 }

--- a/apps/web/src/settings/ThemeQuickButton.tsx
+++ b/apps/web/src/settings/ThemeQuickButton.tsx
@@ -1,0 +1,26 @@
+import { Button } from "@protolabsai/ui/primitives";
+import { Dialog } from "@protolabsai/ui/overlays";
+import { Palette } from "lucide-react";
+import { useState } from "react";
+
+import { ThemeSurface } from "./ThemeSurface";
+
+// Theme quick-set (ADR 0048, operator direction) — a palette icon → dialog with the
+// per-agent appearance controls (the same ThemeSurface that lives under Settings ▸
+// Workspace ▸ Theme). Theme isn't a FIELDS-backed setting (it persists its own blob
+// via /api/theme), so it gets a dedicated quick dialog rather than a QuickSetting.
+export function ThemeQuickButton() {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Button icon variant="ghost" type="button" title="Appearance" aria-label="Appearance" onClick={() => setOpen(true)}>
+        <Palette size={16} />
+      </Button>
+      {open ? (
+        <Dialog open onClose={() => setOpen(false)} title="Appearance" width="min(720px, 94vw)" className="theme-quick-dialog">
+          <ThemeSurface />
+        </Dialog>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -14,6 +14,14 @@
   flex-direction: column;
   gap: 14px;
 }
+/* Chip trigger (summaryKey) — e.g. the model alias on the chat composer. Truncate
+   so a long alias can't blow out its host row. */
+.quick-setting-summary {
+  max-width: 16ch;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
 .quick-setting-body .setting-row {
   flex-direction: column;
   align-items: stretch;

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -19,6 +19,23 @@
   align-items: stretch;
   gap: 6px;
 }
+
+/* The one-stop-shop Settings overlay + the theme quick dialog (ADR 0048) embed a
+   full surface inside a dialog — give the panels a tall, scrollable viewport and
+   drop the dialog's own body padding (the panels carry their own chrome). */
+.settings-overlay .pl-dialog__body,
+.theme-quick-dialog .pl-dialog__body {
+  padding: 0;
+  max-height: 80vh;
+  min-height: 50vh;
+  overflow-y: auto;
+}
+.settings-overlay .stage-panel,
+.theme-quick-dialog .stage-panel {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+}
 .settings-group {
   margin-bottom: 40px;
 }

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -7,6 +7,18 @@
 .settings-banner {
   margin-bottom: 10px;
 }
+/* QuickSetting dialog (ADR 0048) — contextual settings shortcut. Reuses the
+   .setting-row chrome; the dialog just stacks the rows with breathing room. */
+.quick-setting-body {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+.quick-setting-body .setting-row {
+  flex-direction: column;
+  align-items: stretch;
+  gap: 6px;
+}
 .settings-group {
   margin-bottom: 40px;
 }

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -16,6 +16,14 @@ describe("migrateUiState", () => {
     expect(migrateUiState({ leftActive: "chat" })).toEqual({ leftActive: "chat" });
   });
 
+  // v2→v3 (ADR 0048): the flat `settingsTab` is replaced by `settingsScope` +
+  // `settingsSection`; a stale `settingsTab` must be dropped so the new defaults apply.
+  it("drops the obsolete settingsTab", () => {
+    const out = migrateUiState({ settingsTab: "host", rightWidth: 320 }) as Record<string, unknown>;
+    expect(out).not.toHaveProperty("settingsTab");
+    expect(out).toEqual({ rightWidth: 320 });
+  });
+
   it("does not mutate the input object", () => {
     const input = { railOf: { chat: "left" }, leftActive: "chat" };
     migrateUiState(input);

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -36,12 +36,12 @@ const _layoutStorage = createJSONStorage(() => ({
 // Core surfaces are fixed literals; plugin views (ADR 0026) add dynamic surfaces keyed
 // `plugin:<pluginId>:<viewId>`. The `(string & {})` keeps literal autocomplete while allowing
 // those runtime keys.
+// The "agent" surface folded into Settings ▸ Workspace (ADR 0048 S-C); Knowledge is
+// now store-only (its Memory settings live in Settings ▸ Workspace ▸ Memory).
 export type Surface =
-  | "chat" | "activity" | "studio" | "knowledge" | "agent" | "plugins" | "settings" | (string & {});
+  | "chat" | "activity" | "studio" | "knowledge" | "plugins" | "settings" | (string & {});
 export type RightPanel = "notes" | "beads" | "goals" | "schedule" | (string & {}); // + plugin:<id>:<viewId>
-export type AgentTab = "identity" | "settings" | "tools" | "mcp" | "subagents" | "skills" | "middleware";
 export type PluginsTab = "local" | "market" | "download";
-export type KnowledgeTab = "store" | "settings";
 export type ActivityTab = "thread" | "inbox";
 // Settings IA (ADR 0048): scope is the primary axis — two homes, each with its own
 // section sub-nav. `settingsScope` picks the home; `settingsSection` the active
@@ -55,9 +55,7 @@ const clampWidth = (w: number) => Math.min(RIGHT_MAX, Math.max(RIGHT_MIN, Math.r
 type UIState = {
   surface: Surface;
   rightPanel: RightPanel;
-  agentTab: AgentTab;
   pluginsTab: PluginsTab;
-  knowledgeTab: KnowledgeTab;
   settingsScope: SettingsScope;
   settingsSection: string;
   // One-shot: the FleetSwitcher's "+ New agent" deep-link routes to Host/App ▸ Fleet
@@ -84,9 +82,7 @@ type UIState = {
   toggleQuickBar: (id: string) => void;
   setSurface: (s: Surface) => void;
   setRightPanel: (p: RightPanel) => void;
-  setAgentTab: (t: AgentTab) => void;
   setPluginsTab: (t: PluginsTab) => void;
-  setKnowledgeTab: (t: KnowledgeTab) => void;
   setSettingsScope: (s: SettingsScope) => void;
   setSettingsSection: (s: string) => void;
   setFleetStartNew: (b: boolean) => void;
@@ -104,10 +100,18 @@ type UIState = {
  * falls back to the default via the store's merge. Exported for unit testing. */
 export function migrateUiState(persisted: unknown): unknown {
   if (persisted && typeof persisted === "object") {
-    // v2: drop the obsolete `railOf` (side map). v3 (ADR 0048): drop the flat
-    // `settingsTab` — replaced by `settingsScope` + `settingsSection`, which fall
-    // back to the store defaults via the persist merge.
-    const { railOf: _drop, settingsTab: _drop2, ...rest } = persisted as Record<string, unknown>;
+    // v2: drop the obsolete `railOf` (side map). v3 (ADR 0048): drop `settingsTab`
+    // (→ `settingsScope` + `settingsSection`) and the `agentTab` / `knowledgeTab`
+    // keys whose surfaces folded into Settings ▸ Workspace. All fall back to the
+    // store defaults via the persist merge. (A stale "agent" left in `railOrder` is
+    // harmless — railSurfaces() filters ids with no surface metadata.)
+    const {
+      railOf: _drop,
+      settingsTab: _drop2,
+      agentTab: _drop3,
+      knowledgeTab: _drop4,
+      ...rest
+    } = persisted as Record<string, unknown>;
     return rest;
   }
   return persisted;
@@ -118,9 +122,7 @@ export const useUI = create<UIState>()(
     (set) => ({
       surface: "chat",
       rightPanel: "beads",
-      agentTab: "identity",
       pluginsTab: "local",
-      knowledgeTab: "store",
       settingsScope: "host" as SettingsScope,
       settingsSection: "overview",
       fleetStartNew: false,
@@ -129,7 +131,7 @@ export const useUI = create<UIState>()(
       leftCollapsed: false,
       rightWidth: 360,
       railOrder: {
-        left: ["chat", "activity", "studio", "knowledge", "agent", "plugins", "settings"],
+        left: ["chat", "activity", "studio", "knowledge", "plugins", "settings"],
         right: ["beads", "goals", "schedule"],
       },
       moveSurface: (id, side) =>
@@ -174,9 +176,7 @@ export const useUI = create<UIState>()(
         }),
       setSurface: (surface) => set({ surface }),
       setRightPanel: (rightPanel) => set({ rightPanel }),
-      setAgentTab: (agentTab) => set({ agentTab }),
       setPluginsTab: (pluginsTab) => set({ pluginsTab }),
-      setKnowledgeTab: (knowledgeTab) => set({ knowledgeTab }),
       // Switching home resets to that home's first section (its own default lives in
       // SettingsSurface); callers that want a specific section call setSettingsSection too.
       setSettingsScope: (settingsScope) => set({ settingsScope }),

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -12,8 +12,6 @@
 import { create } from "zustand";
 import { createJSONStorage, persist } from "zustand/middleware";
 
-import type { SettingsTab } from "../settings/SettingsSurface";
-
 // Per-agent layout (ADR 0042). Each fleet agent keeps its OWN layout — rail order, widths,
 // active surface, plugins out. In the single-agent product that fell out for free (each agent
 // is its own origin → its own localStorage); the unified console collapses that, so we namespace
@@ -45,6 +43,10 @@ export type AgentTab = "identity" | "settings" | "tools" | "mcp" | "subagents" |
 export type PluginsTab = "local" | "market" | "download";
 export type KnowledgeTab = "store" | "settings";
 export type ActivityTab = "thread" | "inbox";
+// Settings IA (ADR 0048): scope is the primary axis — two homes, each with its own
+// section sub-nav. `settingsScope` picks the home; `settingsSection` the active
+// section within it (a free string so each home owns its own section ids).
+export type SettingsScope = "host" | "workspace";
 
 const RIGHT_MIN = 280;
 const RIGHT_MAX = 720;
@@ -56,7 +58,11 @@ type UIState = {
   agentTab: AgentTab;
   pluginsTab: PluginsTab;
   knowledgeTab: KnowledgeTab;
-  settingsTab: SettingsTab;
+  settingsScope: SettingsScope;
+  settingsSection: string;
+  // One-shot: the FleetSwitcher's "+ New agent" deep-link routes to Host/App ▸ Fleet
+  // and asks the fleet panel to open the new-agent picker on mount, then clears it.
+  fleetStartNew: boolean;
   activityTab: ActivityTab;
   rightCollapsed: boolean;
   leftCollapsed: boolean;
@@ -81,7 +87,9 @@ type UIState = {
   setAgentTab: (t: AgentTab) => void;
   setPluginsTab: (t: PluginsTab) => void;
   setKnowledgeTab: (t: KnowledgeTab) => void;
-  setSettingsTab: (t: SettingsTab) => void;
+  setSettingsScope: (s: SettingsScope) => void;
+  setSettingsSection: (s: string) => void;
+  setFleetStartNew: (b: boolean) => void;
   setActivityTab: (t: ActivityTab) => void;
   setRightCollapsed: (b: boolean) => void;
   setLeftCollapsed: (b: boolean) => void;
@@ -96,7 +104,10 @@ type UIState = {
  * falls back to the default via the store's merge. Exported for unit testing. */
 export function migrateUiState(persisted: unknown): unknown {
   if (persisted && typeof persisted === "object") {
-    const { railOf: _drop, ...rest } = persisted as Record<string, unknown>;
+    // v2: drop the obsolete `railOf` (side map). v3 (ADR 0048): drop the flat
+    // `settingsTab` — replaced by `settingsScope` + `settingsSection`, which fall
+    // back to the store defaults via the persist merge.
+    const { railOf: _drop, settingsTab: _drop2, ...rest } = persisted as Record<string, unknown>;
     return rest;
   }
   return persisted;
@@ -110,7 +121,9 @@ export const useUI = create<UIState>()(
       agentTab: "identity",
       pluginsTab: "local",
       knowledgeTab: "store",
-      settingsTab: "overview" as SettingsTab,
+      settingsScope: "host" as SettingsScope,
+      settingsSection: "overview",
+      fleetStartNew: false,
       activityTab: "thread",
       rightCollapsed: false,
       leftCollapsed: false,
@@ -164,7 +177,11 @@ export const useUI = create<UIState>()(
       setAgentTab: (agentTab) => set({ agentTab }),
       setPluginsTab: (pluginsTab) => set({ pluginsTab }),
       setKnowledgeTab: (knowledgeTab) => set({ knowledgeTab }),
-      setSettingsTab: (settingsTab) => set({ settingsTab }),
+      // Switching home resets to that home's first section (its own default lives in
+      // SettingsSurface); callers that want a specific section call setSettingsSection too.
+      setSettingsScope: (settingsScope) => set({ settingsScope }),
+      setSettingsSection: (settingsSection) => set({ settingsSection }),
+      setFleetStartNew: (fleetStartNew) => set({ fleetStartNew }),
       setActivityTab: (activityTab) => set({ activityTab }),
       setRightCollapsed: (rightCollapsed) => set({ rightCollapsed }),
       setLeftCollapsed: (leftCollapsed) => set({ leftCollapsed }),
@@ -182,7 +199,7 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 2, // v2: railOf (side map) → railOrder (ordered lists per rail)
+      version: 3, // v2: railOf→railOrder. v3: settingsTab→settingsScope+settingsSection (ADR 0048)
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
     },
   ),

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -21,6 +21,7 @@ import { Suspense } from "react";
 
 import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { PanelHeader } from "@protolabsai/ui/navigation";
+import { QuickSetting } from "../settings/QuickSetting";
 import { api } from "../lib/api";
 import { telemetryQuery } from "../lib/queries";
 
@@ -71,6 +72,9 @@ function TelemetryBody() {
         kicker={`per-turn cost & latency · ${summary?.turns ?? 0} turns recorded`}
         actions={
           <>
+            {/* Quick-set the box-shared telemetry policy (ADR 0048) — both host-scoped,
+                so this saves to the host layer. */}
+            <QuickSetting keys={["telemetry.enabled", "telemetry.retention_days"]} title="Telemetry" label="Telemetry settings" />
             <Button icon variant="ghost" type="button" onClick={() => void downloadTelemetryCsv()}
                     disabled={!enabled || !summary?.turns} title="Export CSV" data-testid="telemetry-export">
               <Download size={16} />

--- a/docs/design/ui-component-audit.md
+++ b/docs/design/ui-component-audit.md
@@ -103,6 +103,12 @@ What the console needs that **`@protolabsai/ui@0.4.0` does not provide.** Ordere
 
 Context-menu **registry/store** (`ContextType` keying is app domain logic — only the *renderer* needs the DS Menu), chat tool-renderers, the workflow builder canvas, plugin-iframe host, setup-wizard flow logic.
 
+Settings IA (ADR 0048, #916) — all compose DS primitives (`Dialog`, `Button`, `Badge`, `Tabs`, `PanelHeader`, `Input/Select/Textarea`, `ThemePanel`); the logic is app-coupled, so they stay local:
+- **`QuickSetting`** — a gear→dialog that edits named fields via *our* settings schema + the `/api/settings` cascade (host-scoped → host layer). The *pattern* is reusable, but the binding is app domain.
+- **`SettingsOverlay`** — wraps our two-home `SettingsSurface` in a DS `Dialog`.
+- **`ThemeQuickButton`** — wraps our per-agent `ThemeSurface` (which calls `/api/theme`) in a DS `Dialog`.
+- **`CommonsPanel`** — the box-shared skills commons (ADR 0041).
+
 ---
 
 ## Filed upstream (protoContent)
@@ -138,7 +144,11 @@ Context-menu **registry/store** (`ContextType` keying is app domain logic — on
 | [#143](https://github.com/protoLabsAI/protoContent/issues/143) | `MobileNav` (bottom quick-bar + drawer) | Filed — source handed over; offered to PR |
 | [#144](https://github.com/protoLabsAI/protoContent/issues/144) | `AppShell` composite (controlled; app keeps persistence) | Filed |
 
-Stack decision (UI team, on #137): **Radix for hard interactive primitives (Menu now; Popover/Combobox/Select later) styled with `--pl-*`; everything else className-only; no Tailwind.** Segmented Tabs variant spec'd on #137 (UI team to add).
+Stack decision (UI team, on #137): **Radix for hard interactive primitives (Menu now; Popover/Combobox/Select later) styled with `--pl-*`; everything else className-only; no Tailwind.**
+
+| # | Request | Priority | Status |
+|---|---|---|---|
+| [#218](https://github.com/protoLabsAI/protoContent/issues/218) | `Tabs` `segmented` variant / `SegmentedControl` (two-level nav scope toggle) | P2 | Filed 2026-06-11 — was only spec'd on the closed #137; now an actionable child. **Interim:** the settings **Host / App \| Workspace** home toggle stacks a second `<Tabs>` row (`SettingsSurface.tsx`) — retire on adoption. |
 
 ## Console adoption status (branch `ds-adoption-sweep`, 2026-06-09)
 

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -131,6 +131,19 @@ FIELDS: list[Field] = [
           "On session retirement, also distil durable facts (aux model) and "
           "consolidate them into the store. Rides the harvest pass."),
 
+    # ── Skills (ADR 0041 tiered stores) ──────────────────────────────────────
+    # `skills.scope` is the agent's own choice of how it participates in the
+    # fleet's skill library; `commons.path` is the box-shared location of that
+    # library (host-scoped — every agent on the box reads the same commons).
+    Field("skills.scope", "skills_scope", "Skill sharing", "select", "Skills",
+          "How this agent uses the skill library: scoped (private only) · shared "
+          "(the one box commons) · layered (read the commons ∪ private, write "
+          "private, promote proven skills up). Blank = derived (scoped).",
+          options=["scoped", "shared", "layered"]),
+    Field("commons.path", "commons_path", "Commons location", "string", "Skills",
+          "Box-shared skill commons read by every agent on this machine. "
+          "Blank = ~/.protoagent/commons.", scope="host"),
+
     # ── Middleware toggles ───────────────────────────────────────────────────
     Field("middleware.knowledge", "knowledge_middleware", "Knowledge middleware", "bool", "Middleware"),
     Field("middleware.memory", "memory_middleware", "Memory middleware", "bool", "Middleware"),
@@ -234,6 +247,10 @@ _SECTION_CATEGORY = {
     "Tools": "Agent",
     # Memory — knowledge/recall config (rendered in the Knowledge view's Settings tab).
     "Knowledge": "Memory",
+    # Skills — the agent's skill-sharing tier + the box commons (ADR 0041). Agent
+    # category today (Agent ▸ Settings); folds into Workspace ▸ Skills, with
+    # commons.path (host-scoped) surfacing in Host/App (ADR 0048).
+    "Skills": "Agent",
     # System — runtime + performance knobs (central Settings → System).
     "Compaction": "System",
     "Caching": "System",

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -72,6 +72,42 @@ def register_knowledge_routes(app) -> None:
             log.exception("[playbooks] delete failed")
             return {"enabled": True, "deleted": False, "error": str(exc)}
 
+    # Promote a private skill into the shared commons (ADR 0041 "shared brain,
+    # private hands") — the one curated lift that makes the layered tier useful.
+    # Only available when the index is layered (it has a ``promote`` method); in
+    # scoped/shared mode there's a single library and nothing to promote into.
+    # The id is the private-DB rowid, so resolve the name within the ``private``
+    # tier (commons rows carry their own rowids — never promote those).
+    @app.post("/api/playbooks/{skill_id}/promote")
+    async def _api_playbook_promote(skill_id: int):
+        idx = STATE.skills_index
+        if idx is None:
+            return {"enabled": False, "promoted": False}
+        promote = getattr(idx, "promote", None)
+        if promote is None:
+            return {
+                "enabled": True,
+                "promoted": False,
+                "error": "skills aren't in layered mode — set skills.scope: layered to share a commons.",
+            }
+        try:
+            match = next(
+                (
+                    s
+                    for s in idx.all_skills()
+                    if s.get("id") == skill_id and s.get("tier", "private") == "private"
+                ),
+                None,
+            )
+            if match is None:
+                return {"enabled": True, "promoted": False, "error": "no private skill with that id"}
+            name = match.get("name", "")
+            ok = bool(promote(name))
+            return {"enabled": True, "promoted": ok, "name": name}
+        except Exception as exc:  # noqa: BLE001
+            log.exception("[playbooks] promote failed")
+            return {"enabled": True, "promoted": False, "error": str(exc)}
+
     # --- Knowledge store (ADR 0020) ----------------------------------------
     # Searchable view of the agent's knowledge base (knowledge/store.py, FTS5):
     # findings, daily-log entries, harvested sessions, operator notes — the same

--- a/tests/test_config_drift_guard.py
+++ b/tests/test_config_drift_guard.py
@@ -238,8 +238,9 @@ def test_fields_types_match_dataclass(field):
 # --------------------------------------------------------------------------- #
 
 # The fields whose shared default lives at the HOST layer (gateway/model/routing/
-# cache/telemetry infra + org branding). Everything else is "agent". Locked here so
-# a new Field can't silently land in the wrong cascade layer.
+# cache/telemetry infra + org branding + the box-shared skill commons location).
+# Everything else is "agent". Locked here so a new Field can't silently land in the
+# wrong cascade layer.
 HOST_SCOPED_KEYS = {
     "model.api_base", "model.provider", "model.name",
     "routing.aux_model", "routing.fallback_models",
@@ -247,6 +248,9 @@ HOST_SCOPED_KEYS = {
     "prompt_cache.warm.enabled", "prompt_cache.warm.interval_seconds",
     "telemetry.enabled", "telemetry.retention_days",
     "identity.org",
+    # commons.path is box-level (ADR 0041 commons read by every agent on the box);
+    # skills.scope stays "agent" (each agent picks its own sharing mode).
+    "commons.path",
 }
 
 

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -135,10 +135,10 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
     # when their plugin is enabled (surfaced via plugin_config), and a default
     # LangGraphConfig() carries no plugin_config.
     assert set(d.keys()) == {
-        "model", "subagents", "middleware", "knowledge", "skills", "mcp", "plugins",
-        "identity", "auth", "runtime", "operator", "agent_runtime", "checkpoint",
-        "compaction", "execute_code", "goal", "operator_mcp", "prompt_cache",
-        "routing", "telemetry",
+        "model", "subagents", "middleware", "knowledge", "skills", "commons", "mcp",
+        "plugins", "identity", "auth", "runtime", "operator", "agent_runtime",
+        "checkpoint", "compaction", "execute_code", "goal", "operator_mcp",
+        "prompt_cache", "routing", "telemetry",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -159,6 +159,9 @@ CONFIG_TO_DICT_GOLDEN = {
         "max_age_days": 30,
         "prune_interval_hours": 6,
     },
+    "commons": {
+        "path": "",
+    },
     "compaction": {
         "enabled": True,
         "keep_messages": 20,
@@ -252,6 +255,7 @@ CONFIG_TO_DICT_GOLDEN = {
         "db_path": "/sandbox/skills.db",
         "dir": "",
         "enabled": True,
+        "scope": "",
         "top_k": 5,
     },
     "subagents": {

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -62,3 +62,57 @@ def test_playbooks_sorted_pinned_first(monkeypatch):
 def test_knowledge_row_preview_fallback():
     row = _knowledge_row({"heading": "Title", "content": "Body text"})
     assert row["preview"] == "Title: Body text" and row["domain"] == "general"
+
+
+def test_playbooks_tier_passthrough(monkeypatch):
+    """A layered index tags each skill with its tier (private|commons); the list
+    payload must carry it so the surface can badge + gate Promote."""
+    class _Layered:
+        def all_skills(self):
+            return [
+                {"id": 1, "name": "a", "source": "emitted", "confidence": 0.5, "tier": "private", "prompt_template": "x"},
+                {"id": 1, "name": "b", "source": "promoted", "confidence": 0.9, "tier": "commons", "prompt_template": "x"},
+            ]
+
+    c = _client(monkeypatch, skills=_Layered())
+    pb = c.get("/api/playbooks").json()["playbooks"]
+    assert {p["name"]: p["tier"] for p in pb} == {"a": "private", "b": "commons"}
+
+
+def test_promote_route_layered(monkeypatch):
+    """POST .../promote resolves the private skill by id and lifts it to the commons.
+    The id is the private-DB rowid, so a commons row sharing that id is never picked."""
+    promoted: list[str] = []
+
+    class _Layered:
+        def all_skills(self):
+            return [
+                {"id": 7, "name": "private-skill", "tier": "private"},
+                {"id": 7, "name": "commons-skill", "tier": "commons"},
+            ]
+
+        def promote(self, name):
+            promoted.append(name)
+            return True
+
+    c = _client(monkeypatch, skills=_Layered())
+    r = c.post("/api/playbooks/7/promote").json()
+    assert r == {"enabled": True, "promoted": True, "name": "private-skill"}
+    assert promoted == ["private-skill"]  # the commons row with the same id was not promoted
+
+
+def test_promote_route_unsupported_in_scoped_mode(monkeypatch):
+    """A plain (non-layered) index has no commons to promote into — the route
+    explains rather than 500s."""
+    class _Plain:
+        def all_skills(self):
+            return [{"id": 1, "name": "a"}]
+
+    c = _client(monkeypatch, skills=_Plain())
+    r = c.post("/api/playbooks/1/promote").json()
+    assert r["enabled"] is True and r["promoted"] is False and "layered" in r["error"]
+
+
+def test_promote_route_disabled(monkeypatch):
+    c = _client(monkeypatch)  # no skills index
+    assert c.post("/api/playbooks/1/promote").json() == {"enabled": False, "promoted": False}


### PR DESCRIPTION
Ships the full **settings IA reorg around scope** (ADR 0048) + the two-inheritance-systems legibility + contextual quick-settings — the whole stack from #916, collapsed here (supersedes #917/#920/#923, whose commits are all included).

## What lands
- **Skills commons legible** (ADR 0041) — `promote` route + tier badges (commons/private) + new `skills.scope` / `commons.path` fields.
- **Two scope homes** — Settings is now **🖥 Host / App** (Overview · Host config · Fleet · Telemetry · Commons) and **🧩 Workspace** (Identity · Settings · Tools · MCP · Subagents · Skills · Middleware · Memory · System · Theme · Plugins). `settingsTab` → `settingsScope` + `settingsSection` (persist v3).
- **The fold** — the standalone **Agent** rail surface is gone (into Workspace); Knowledge is store-only.
- **Quick-settings** — a reusable `QuickSetting` (gear → dialog editing fields via the same cascade-aware `/api/settings`): the **topbar gear** opens the whole one-stop-shop as an overlay; **appearance**, **telemetry**, and **recall** gears where they're relevant; the **model** control is a live chip **under the chat input** (which is now a single-row auto-growing composer).
- DS contribute-back: filed protoContent#218 (segmented control); the rest logged not-for-DS.

## Gates
Per-slice: tsc + vite build + vitest (44) + CSS guard + the Python config/skills/knowledge suites green; **full Playwright e2e 92 green** locally. CI (`retries:1`) green on the skills slice already (#917).

Closes the build-out tracked in #916. Reviewed locally by the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
