### PR TITLE
fix(console): honor the DS AppShell controlled width — drop the store clamp

### DIFF
--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -48,10 +48,6 @@ export type ActivityTab = "thread" | "inbox";
 // section within it (a free string so each home owns its own section ids).
 export type SettingsScope = "host" | "workspace";
 
-const RIGHT_MIN = 280;
-const RIGHT_MAX = 720;
-const clampWidth = (w: number) => Math.min(RIGHT_MAX, Math.max(RIGHT_MIN, Math.round(w)));
-
 type UIState = {
   surface: Surface;
   rightPanel: RightPanel;
@@ -185,7 +181,14 @@ export const useUI = create<UIState>()(
       setActivityTab: (activityTab) => set({ activityTab }),
       setRightCollapsed: (rightCollapsed) => set({ rightCollapsed }),
       setLeftCollapsed: (leftCollapsed) => set({ leftCollapsed }),
-      setRightWidth: (w) => set({ rightWidth: clampWidth(w) }),
+      // The DS AppShell is a CONTROLLED width: during a divider drag it streams transient
+      // widths from 0 up to the full left+right span (that's how a drag collapses a side —
+      // the column has to track the pointer past its min/max), and it commits its OWN
+      // clamped value (`clampOpen`) on pointer-up. So store the value verbatim. The old
+      // [280,720] clamp here re-clamped those transients and broke the gesture: the right
+      // column could never grow past 720, so the LEFT column never reached its collapse
+      // threshold (left wouldn't close), and the column stopped tracking the pointer mid-drag.
+      setRightWidth: (w) => set({ rightWidth: Math.max(0, Math.round(w)) }),
       pluginDots: {},
       setPluginDot: (key, on) =>
         set((s) => {


### PR DESCRIPTION
## What

`uiStore.setRightWidth` no longer re-clamps the panel width to `[280, 720]`. It stores the controlled value verbatim (floored at 0).

## Why

The DS `AppShell` is a **controlled** width. During a divider drag it streams transient widths from `0` up to the full left+right span — that's the mechanism by which a drag collapses a side (the column has to track the pointer past its own min/max) — and it commits its own clamped value (`clampOpen`) on pointer-up.

The store's `[280, 720]` clamp re-clamped those transients, which broke the gesture two ways:

- **Left panel wouldn't close** — the right column could never grow past 720px, so on any reasonably wide window the left column never reached its `<140px` collapse threshold. Structurally impossible.
- **"Didn't transition all the way"** — mid-drag the column pinned at 280/720 and stopped tracking the pointer, then jank-snapped on release.

The DS already commits a sane clamped value on every gesture end, so the store clamp added nothing for committed state and only mangled the transient drag values the DS needs honored.

## Notes

- Rebased onto the ADR 0048 settings-IA fold (#925), which re-carried the original `clampWidth` from before this fix — without this, that bug ships on `main`.
- The companion DS interaction change (handles are grab-and-drag only) is protoContent#223.

🤖 Generated with [Claude Code](https://claude.com/claude-code)