### PR TITLE
feat(settings): box-runtime knobs → Host FIELDS (ADR 0047 D8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Box-runtime knobs (bind interface, fleet ports, discovery, warm policy) are now
+  Host-layer settings, not just scattered env vars** (ADR 0047 D8 — the cascade's
+  final slice). `network.bind`, `fleet.port_base`, `fleet.discovery.port_min/port_max/mdns`,
+  and `fleet.warm.max/grace_seconds` join `FIELDS` as `scope="host"`, so they cascade
+  App → `host-config.yaml` → agent-leaf like every other host default and get a home in
+  **Settings ▸ Host / App ▸ Host config** (with the inherited-from-Host / override / reset
+  badges for free). Each pairs with an **env-var fallback** so existing `PROTOAGENT_HOST` /
+  `PROTOAGENT_FLEET_MAX_WARM` / `PROTOAGENT_FLEET_WARM_GRACE` boxes keep working unchanged —
+  precedence is **file > env > default** (a value set in the file/UI can't be silently
+  shadowed by a leftover env var), and an explicit `--host` flag still wins over all of
+  them. The host process's bind, the workspace port picker, fleet discovery (scan range +
+  mDNS gate), and the warm-agent supervisor now read the resolved config instead of reading
+  env at the call site; a CLI/no-config context falls back to env exactly as before.
 - **An app update can no longer silently strand fleet members on the old binary**
   (version-coherence P2). Members are detached processes — one that survives a hub
   update (crashed hub, or the `PROTOAGENT_FLEET_KEEP_MEMBERS_ON_EXIT` opt-out) keeps

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -223,6 +223,24 @@ operator:
   allowed_dirs: []
   # - /home/kj/projects/my-other-repo
 
+# Box runtime (Host layer, ADR 0047 D8) — box-wide knobs every agent this machine
+# owns inherits. These are HOST defaults: best set once in host-config.yaml or the
+# Settings ▸ Host / App home (a per-agent value here is a silent no-op — the host
+# process reads its own config). Resolution is file > env > default, so the
+# PROTOAGENT_HOST / PROTOAGENT_FLEET_MAX_WARM / PROTOAGENT_FLEET_WARM_GRACE env vars
+# stay the fallback for env-configured boxes.
+network:
+  bind: 127.0.0.1           # 0.0.0.0 = all interfaces (token-gate A2A first); --host still wins
+fleet:
+  port_base: 7870           # fleet workspace agents get port_base+1, +2, …
+  discovery:
+    port_min: 7860          # LAN/tailnet discovery scan window (inclusive)
+    port_max: 7910
+    mdns: true              # advertise + browse the _protoagent._tcp mDNS channel
+  warm:
+    max: 0                  # warm-agent cap (0 = unlimited)
+    grace_seconds: 0        # spare agents touched within N seconds from LRU eviction
+
 # Discord surface (ADR 0015/0016) — inbound DM gateway. Configure this in-app
 # (setup wizard step / System → Settings → Discord) rather than by hand: the
 # bot_token is stored in the gitignored secrets.yaml overlay, never here.

--- a/docs/adr/0047-layered-settings-cascade.md
+++ b/docs/adr/0047-layered-settings-cascade.md
@@ -425,6 +425,21 @@ throughout:
 3. Promote env/CLI host knobs into `FIELDS` as `scope="host"` (with env fallback)
    + add the Host/Machine settings view.
 
+**Status — all three slices SHIPPED.** Slices 1–2 landed with the settings-IA fold
+(PR #925). Slice 3 (this) promotes the box-runtime knobs `network.bind`,
+`fleet.port_base`, `fleet.discovery.port_min/port_max/mdns`, and
+`fleet.warm.max/grace_seconds` into `FIELDS` (`scope="host"`, section "Fleet" →
+category System, so they surface in Settings ▸ Host / App ▸ Host config). The
+env-fallback bridge lives in `from_dict` as `section.get(key, _env_default(ENV, default))`,
+fixing **Open decision #2 to file > env > default** (operator, 2026-06-11): the file/UI
+value wins, the `PROTOAGENT_*` env var is the zero-migration fallback consulted only when
+the merged dict omits the key, and an explicit `--host` flag wins over both. The four call
+sites (`server.__init__` uvicorn bind, `manager._pick_port`, `fleet.discovery`, and
+`fleet.supervisor.max_warm`/`_warm_grace_seconds`) read the resolved config via the lazy
+`runtime.state.STATE` accessor, falling back to env in a CLI/no-config context. Data-root /
+`PROTOAGENT_AUTO_SCOPE` is intentionally NOT promoted (it resolves where `host-config.yaml`
+itself lives — chicken-and-egg; stays env/CLI).
+
 ## 4. Migration / back-compat
 
 **ZERO migration. Zero new bytes on disk for any existing deployment.**

--- a/graph/config.py
+++ b/graph/config.py
@@ -110,6 +110,21 @@ def _set_dotted(out: dict, dotted: str, value) -> None:
     cur[parts[-1]] = value
 
 
+def _env_default(name: str, default, cast=str):
+    """Env-fallback for a promoted host knob (ADR 0047 D8). Returns the env var's
+    value (cast) when set+non-empty, else ``default``. Used as the ``.get(key, …)``
+    fallback in ``from_dict`` so resolution is **file > env > app-default**: env is
+    consulted only when the merged (host⊕leaf) dict omits the key, keeping
+    promotion of an env-configured box zero-migration."""
+    raw = os.environ.get(name)
+    if raw is None or raw == "":
+        return default
+    try:
+        return cast(raw)
+    except (TypeError, ValueError):
+        return default
+
+
 def _filter_to_host_keys(raw: dict) -> dict:
     """Keep only the host-scoped FIELDS keys present in a raw host-config doc.
 
@@ -508,6 +523,21 @@ class LangGraphConfig:
     # whether the plist should exist.
     autostart_on_boot: bool = False
 
+    # Box runtime (Host layer, ADR 0047 D8) — box-wide knobs promoted out of
+    # scattered env/CLI reads into the Host cascade layer (scope="host" in FIELDS).
+    # Each pairs with an env-var fallback in ``from_dict`` (file > env > default), so
+    # existing PROTOAGENT_* boxes keep working with zero migration. Consumed by the
+    # host process (uvicorn bind / workspace port picker / fleet discovery + warm
+    # supervisor) — a workspace leaf override is a silent no-op (the host process
+    # reads its own config), see ADR §5.
+    bind_host: str = "127.0.0.1"          # uvicorn bind interface; env: PROTOAGENT_HOST
+    fleet_port_base: int = 7870           # workspace agents get port_base+1, +2, …
+    discovery_port_min: int = 7860        # fleet discovery scan window (inclusive)
+    discovery_port_max: int = 7910
+    discovery_mdns: bool = True           # advertise + browse the _protoagent._tcp mDNS channel
+    fleet_max_warm: int = 0               # warm-agent cap (0 = unlimited); env: PROTOAGENT_FLEET_MAX_WARM
+    fleet_warm_grace_seconds: int = 0     # spare agents touched within N s from LRU eviction; env: PROTOAGENT_FLEET_WARM_GRACE
+
     # Operator-console directory allowlist — the extra directories the
     # React console's beads/notes APIs may read and write. The protoAgent
     # repo root is always allowed implicitly (it's the default project);
@@ -629,6 +659,12 @@ class LangGraphConfig:
         auth = data.get("auth", {})
         runtime = data.get("runtime", {})
         operator = data.get("operator", {})
+        # Box runtime (Host layer, ADR 0047 D8) — `or {}` because a present-but-empty
+        # section parses to None.
+        network = data.get("network", {}) or {}
+        fleet = data.get("fleet", {}) or {}
+        discovery = fleet.get("discovery", {}) or {}
+        warm = fleet.get("warm", {}) or {}
 
         # Secret overlay wins when present; otherwise the (now secret-free)
         # main YAML value, otherwise the dataclass default — and a blank
@@ -733,6 +769,17 @@ class LangGraphConfig:
             instance_id=data.get("instance", {}).get("id", "") or data.get("instance_id", cls.instance_id),
             auth_token=secret_auth_token or auth.get("token", cls.auth_token),
             autostart_on_boot=runtime.get("autostart_on_boot", cls.autostart_on_boot),
+            # Box runtime (Host layer, ADR 0047 D8) — file > env > default. The env
+            # fallback only fires when the merged dict omits the key (zero-migration).
+            bind_host=network.get("bind", _env_default("PROTOAGENT_HOST", cls.bind_host)),
+            fleet_port_base=fleet.get("port_base", cls.fleet_port_base),
+            discovery_port_min=discovery.get("port_min", cls.discovery_port_min),
+            discovery_port_max=discovery.get("port_max", cls.discovery_port_max),
+            discovery_mdns=discovery.get("mdns", cls.discovery_mdns),
+            fleet_max_warm=warm.get("max", _env_default("PROTOAGENT_FLEET_MAX_WARM", cls.fleet_max_warm, int)),
+            fleet_warm_grace_seconds=warm.get(
+                "grace_seconds", _env_default("PROTOAGENT_FLEET_WARM_GRACE", cls.fleet_warm_grace_seconds, int)
+            ),
             operator_allowed_dirs=list(operator.get("allowed_dirs", []) or []),
             filesystem_enabled=data.get("filesystem", {}).get("enabled", cls.filesystem_enabled),
             filesystem_allow_run=data.get("filesystem", {}).get("allow_run", cls.filesystem_allow_run),

--- a/graph/fleet/discovery.py
+++ b/graph/fleet/discovery.py
@@ -33,6 +33,38 @@ _SERVICE_TYPE = "_protoagent._tcp.local."
 _zc = None  # the advertised Zeroconf instance (None until advertise())
 _info = None
 
+# App-layer defaults for the discovery knobs (Host layer, ADR 0047 D8) — used when no
+# live config is loaded (CLI/test context). Mirror the LangGraphConfig dataclass defaults.
+_DEFAULT_PORT_RANGE = (7860, 7910)
+
+
+def _cfg():
+    """The live ``LangGraphConfig`` (or ``None`` in a CLI/no-STATE context). Lazy import
+    to avoid an import-time cycle. Lets the discovery knobs (port range + mDNS toggle,
+    ADR 0047 D8 ``fleet.discovery.*``) be resolved from the Host cascade while keeping
+    ``discover``/``advertise`` parametric for tests."""
+    try:
+        from runtime.state import STATE
+
+        return getattr(STATE, "graph_config", None)
+    except Exception:  # noqa: BLE001 — no live config ⇒ the app defaults
+        return None
+
+
+def _mdns_enabled() -> bool:
+    cfg = _cfg()
+    return bool(getattr(cfg, "discovery_mdns", True)) if cfg is not None else True
+
+
+def _config_port_range() -> tuple[int, int]:
+    cfg = _cfg()
+    if cfg is None:
+        return _DEFAULT_PORT_RANGE
+    return (
+        int(getattr(cfg, "discovery_port_min", _DEFAULT_PORT_RANGE[0])),
+        int(getattr(cfg, "discovery_port_max", _DEFAULT_PORT_RANGE[1])),
+    )
+
 
 def _local_ip() -> str:
     """Best-effort LAN IP (the address other machines reach us on); 127.0.0.1 if offline."""
@@ -58,6 +90,9 @@ def advertise(name: str, port: int) -> None:
     """
     global _zc, _info
     if _zc is not None or not port:
+        return
+    if not _mdns_enabled():  # Host layer (ADR 0047 D8): fleet.discovery.mdns=false ⇒ no advert
+        log.info("[discovery] mDNS disabled (fleet.discovery.mdns=false) — not advertising %s", name)
         return
     if _on_event_loop():
         log.warning("[discovery] advertise() called on an event loop thread — refusing "
@@ -209,19 +244,32 @@ def _browse_mdns(timeout: float) -> list[dict]:
     return found
 
 
+async def _no_results() -> list[dict]:
+    """A do-nothing channel — substituted for the mDNS browse when it's disabled."""
+    return []
+
+
 async def discover(*, known: set | None = None,
-                   port_range: tuple[int, int] = (7860, 7910), timeout: float = 1.5) -> list[dict]:
+                   port_range: tuple[int, int] | None = None, timeout: float = 1.5,
+                   mdns: bool | None = None) -> list[dict]:
     """Other protoAgents (local + LAN + tailnet) minus the ones already in the fleet.
 
     ``known`` is a set of ``(host, port)`` already known (the host itself + existing members);
     those are filtered out. Returns ``[{name, url, host, port}]`` — duplicates by
     ``(host, port)`` are collapsed; a dual-homed machine (LAN IP via mDNS + ``100.x``
-    via tailnet) intentionally keeps both addresses."""
+    via tailnet) intentionally keeps both addresses.
+
+    ``port_range`` and ``mdns`` default to the resolved Host-layer config (ADR 0047 D8
+    ``fleet.discovery.*``) when left ``None`` — pass them explicitly in tests."""
     known = known or set()
+    if port_range is None:
+        port_range = _config_port_range()
+    if mdns is None:
+        mdns = _mdns_enabled()
     skip_local = {p for (h, p) in known if h in ("127.0.0.1", "localhost")}
     local, network, tailnet = await asyncio.gather(  # independent channels — scan concurrently
         _scan_local(port_range, skip_local),
-        asyncio.to_thread(_browse_mdns, timeout),
+        asyncio.to_thread(_browse_mdns, timeout) if mdns else _no_results(),
         _scan_tailnet(port_range, known),
     )
     # An mDNS advert carrying THIS machine's own IP is a co-located agent — the same

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -558,10 +558,47 @@ def version_skew_warning() -> str | None:
 # target is resumed and the least-recently-active agents beyond the cap are stopped —
 # their sessions persist (instance.id-scoped checkpoints) and resume on the next switch.
 
+def _live_config():
+    """The live ``LangGraphConfig`` (or ``None`` in a CLI/no-STATE context). Lazy
+    import to avoid an import-time cycle — same idiom as ``_pick_port`` /
+    ``runtime_status``."""
+    try:
+        from runtime.state import STATE
+
+        return getattr(STATE, "graph_config", None)
+    except Exception:  # noqa: BLE001 — no live config ⇒ caller's env fallback
+        return None
+
+
 def max_warm() -> int:
-    """Warm-agent cap from ``PROTOAGENT_FLEET_MAX_WARM`` (0/unset = unlimited)."""
+    """Warm-agent cap (Host layer, ADR 0047 D8) — the resolved ``fleet.warm.max``
+    (0/unset = unlimited). Reads the live config (which already folds in the
+    PROTOAGENT_FLEET_MAX_WARM env fallback, file > env > default); falls back to the
+    env var directly when no config is loaded."""
+    cfg = _live_config()
+    if cfg is not None:
+        try:
+            return max(0, int(getattr(cfg, "fleet_max_warm", 0) or 0))
+        except (TypeError, ValueError):
+            return 0
     try:
         return max(0, int(os.environ.get("PROTOAGENT_FLEET_MAX_WARM", "0")))
+    except ValueError:
+        return 0
+
+
+def _warm_grace_seconds() -> int:
+    """LRU-eviction grace (Host layer, ADR 0047 D8) — the resolved
+    ``fleet.warm.grace_seconds`` (0 = pure LRU). Live config first (env fallback
+    folded in), else the PROTOAGENT_FLEET_WARM_GRACE env var directly."""
+    cfg = _live_config()
+    if cfg is not None:
+        try:
+            return max(0, int(getattr(cfg, "fleet_warm_grace_seconds", 0) or 0))
+        except (TypeError, ValueError):
+            return 0
+    try:
+        return int(os.environ.get("PROTOAGENT_FLEET_WARM_GRACE", "0") or "0")
     except ValueError:
         return 0
 
@@ -595,7 +632,8 @@ def enforce_warm_cap(keep: int | None = None, *, protect: str | None = None) -> 
     # Opt-in grace (default 0 = pure LRU, unchanged): a positive value spares agents touched
     # within that window, trading a temporarily-over-cap fleet for not killing a recently-active
     # (possibly mid-turn) agent. Off by default so rapid switching still bounds the warm set.
-    grace = int(os.environ.get("PROTOAGENT_FLEET_WARM_GRACE", "0") or "0")
+    # Host layer (ADR 0047 D8): resolved fleet.warm.grace_seconds, env fallback when no config.
+    grace = _warm_grace_seconds()
     cutoff = (datetime.now(timezone.utc) - timedelta(seconds=grace)).isoformat()
     candidates = [n for n, r in running if n != protect and r.get("last_active", "") < cutoff]
     evicted: list[str] = []

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -179,6 +179,39 @@ FIELDS: list[Field] = [
     # ── Runtime (restart) ────────────────────────────────────────────────────
     Field("runtime.autostart_on_boot", "autostart_on_boot", "Autostart on boot", "bool", "Runtime",
           "Install/remove the boot LaunchAgent.", restart=True),
+
+    # ── Fleet (Host layer, ADR 0047 D8) ──────────────────────────────────────
+    # Box-wide runtime knobs promoted out of env/CLI into the Host cascade layer.
+    # All scope="host": the box default every co-located agent inherits (file > env
+    # > default; the matching PROTOAGENT_* env var stays the fallback). Consumed by
+    # the host process — a workspace leaf override is a silent no-op (ADR §5).
+    Field("network.bind", "bind_host", "Bind interface", "string", "Fleet",
+          "Network interface the server listens on. 127.0.0.1 = loopback only (safe "
+          "default); 0.0.0.0 = all interfaces (token-gate the A2A endpoint first). An "
+          "explicit --host flag still wins. Env fallback: PROTOAGENT_HOST.",
+          restart=True, scope="host"),
+    Field("fleet.port_base", "fleet_port_base", "Workspace port base", "number", "Fleet",
+          "Base TCP port for fleet workspace agents — each gets port_base+1, +2, … "
+          "unless given an explicit port.", minimum=1, maximum=65535, restart=True, scope="host"),
+    Field("fleet.discovery.port_min", "discovery_port_min", "Discovery scan: min port", "number",
+          "Fleet", "Low end (inclusive) of the port window fleet discovery probes on the "
+          "LAN / tailnet.", minimum=1, maximum=65535, scope="host"),
+    Field("fleet.discovery.port_max", "discovery_port_max", "Discovery scan: max port", "number",
+          "Fleet", "High end (inclusive) of the discovery port window.",
+          minimum=1, maximum=65535, scope="host"),
+    Field("fleet.discovery.mdns", "discovery_mdns", "mDNS discovery", "bool", "Fleet",
+          "Advertise + browse the _protoagent._tcp mDNS/Bonjour channel so LAN siblings "
+          "find each other automatically. Off = no mDNS (tailnet + manual register still "
+          "work); useful where multicast is noisy or blocked.", scope="host"),
+    Field("fleet.warm.max", "fleet_max_warm", "Warm-agent cap", "number", "Fleet",
+          "Max fleet agents kept running at once; the least-recently-active beyond this "
+          "are spun down (LRU). 0 = unlimited. Env fallback: PROTOAGENT_FLEET_MAX_WARM.",
+          minimum=0, scope="host"),
+    Field("fleet.warm.grace_seconds", "fleet_warm_grace_seconds", "Warm eviction grace (s)",
+          "number", "Fleet",
+          "Spare an agent touched within this many seconds from LRU eviction (it may be "
+          "mid-turn). 0 = pure LRU. Env fallback: PROTOAGENT_FLEET_WARM_GRACE.",
+          minimum=0, scope="host"),
 ]
 
 _BY_KEY = {f.key: f for f in FIELDS}
@@ -257,6 +290,10 @@ _SECTION_CATEGORY = {
     "Middleware": "System",
     "Runtime": "System",
     "Telemetry": "System",
+    # Fleet — box-runtime host knobs (ADR 0047 D8). System category so the host-scoped
+    # fields surface in Settings ▸ Host / App ▸ Host config (which renders the host
+    # fields of the Agent+System categories).
+    "Fleet": "System",
     # Discord / Google / other plugin sections → "Plugins" (the default).
 }
 

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -112,6 +112,22 @@ def list_workspaces() -> list[dict]:
     return out
 
 
+def _port_base() -> int:
+    """Base port for fleet workspace agents (Host layer, ADR 0047 D8). Reads the
+    resolved ``fleet.port_base`` from the live config (which already folds in the
+    PROTOAGENT_* env fallback); falls back to the module default in a CLI/no-STATE
+    context."""
+    try:
+        from runtime.state import STATE
+
+        cfg = getattr(STATE, "graph_config", None)
+        if cfg is not None:
+            return int(getattr(cfg, "fleet_port_base", PORT_BASE) or PORT_BASE)
+    except Exception:  # noqa: BLE001 — best-effort; no live config ⇒ the constant
+        pass
+    return PORT_BASE
+
+
 def _pick_port(explicit: int | None) -> int:
     if explicit:
         return int(explicit)
@@ -124,7 +140,7 @@ def _pick_port(explicit: int | None) -> int:
             used.add(int(STATE.active_port))
     except Exception:  # noqa: BLE001 — best-effort; CLI/no-STATE context just skips it
         pass
-    p = PORT_BASE + 1
+    p = _port_base() + 1
     while p in used:
         p += 1
     return p

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -328,7 +328,10 @@ def _main():
     # reachable by anything that can reach the port). Containers set
     # PROTOAGENT_HOST=0.0.0.0 (entrypoint / deploy manifests) because their
     # boundary is the network policy + published port, not the in-container bind.
-    parser.add_argument("--host", type=str, default=os.environ.get("PROTOAGENT_HOST", "127.0.0.1"))
+    # Default None ⇒ resolve from the Host-layer cascade after config load (ADR 0047
+    # D8 network.bind, which folds in the PROTOAGENT_HOST env fallback); an explicit
+    # --host always wins.
+    parser.add_argument("--host", type=str, default=None)
     parser.add_argument("--config", type=str, default=None)
     parser.add_argument(
         "--ui",
@@ -821,6 +824,17 @@ def _main():
             return RedirectResponse(url="/app/")
 
     app = fastapi_app
+
+    # Resolve the bind interface (Host layer, ADR 0047 D8). An explicit --host wins;
+    # otherwise take the cascade-resolved network.bind (leaf > host-config.yaml > env
+    # PROTOAGENT_HOST > 127.0.0.1). STATE.graph_config is loaded by now (agent_init);
+    # the env read is a defensive fallback for the degenerate no-config path.
+    if not args.host:
+        args.host = (
+            STATE.graph_config.bind_host if STATE.graph_config
+            else os.environ.get("PROTOAGENT_HOST", "127.0.0.1")
+        ) or "127.0.0.1"
+
     log.info("Starting %s (ui=%s) on http://%s:%d", agent_name(), ui, args.host, args.port)
 
     # Boot gate: a non-loopback bind with no A2A auth token exposes the full

--- a/tests/test_config_drift_guard.py
+++ b/tests/test_config_drift_guard.py
@@ -251,6 +251,10 @@ HOST_SCOPED_KEYS = {
     # commons.path is box-level (ADR 0041 commons read by every agent on the box);
     # skills.scope stays "agent" (each agent picks its own sharing mode).
     "commons.path",
+    # Box runtime (ADR 0047 D8) — env/CLI knobs promoted into the Host layer.
+    "network.bind", "fleet.port_base",
+    "fleet.discovery.port_min", "fleet.discovery.port_max", "fleet.discovery.mdns",
+    "fleet.warm.max", "fleet.warm.grace_seconds",
 }
 
 

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -139,6 +139,8 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
         "plugins", "identity", "auth", "runtime", "operator", "agent_runtime",
         "checkpoint", "compaction", "execute_code", "goal", "operator_mcp",
         "prompt_cache", "routing", "telemetry",
+        # Box runtime (Host layer, ADR 0047 D8).
+        "network", "fleet",
     }
     assert d["model"]["name"] == cfg.model_name
     assert d["model"]["temperature"] == cfg.temperature

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -41,6 +41,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "audit_middleware": True,
     "autostart_on_boot": False,
     "aux_model": "",
+    "bind_host": "127.0.0.1",
     "cache_warming_enabled": False,
     "cache_warming_interval_seconds": 3300,
     "chat_template_kwargs": None,
@@ -54,6 +55,9 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "compaction_keep_messages": 20,
     "compaction_model": "",
     "compaction_trigger": "fraction:0.8",
+    "discovery_mdns": True,
+    "discovery_port_max": 7910,
+    "discovery_port_min": 7860,
     "egress_allowed_hosts": [],
     "embed_model": "qwen3-embedding",
     "enforcement_disallowed_tools": [],
@@ -67,6 +71,9 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "filesystem_enabled": True,
     "filesystem_projects": [],
     "filesystem_run_requires_approval": True,
+    "fleet_max_warm": 0,
+    "fleet_port_base": 7870,
+    "fleet_warm_grace_seconds": 0,
     "goal_enabled": True,
     "goal_eval_model": "",
     "goal_max_iterations": 8,
@@ -177,6 +184,18 @@ CONFIG_TO_DICT_GOLDEN = {
         "enabled": False,
         "timeout": 30,
     },
+    "fleet": {
+        "port_base": 7870,
+        "discovery": {
+            "port_min": 7860,
+            "port_max": 7910,
+            "mdns": True,
+        },
+        "warm": {
+            "max": 0,
+            "grace_seconds": 0,
+        },
+    },
     "goal": {
         "enabled": True,
         "eval_model": "",
@@ -221,6 +240,9 @@ CONFIG_TO_DICT_GOLDEN = {
         "name": "protolabs/reasoning",
         "provider": "openai",
         "temperature": 0.2,
+    },
+    "network": {
+        "bind": "127.0.0.1",
     },
     "operator": {
         "allowed_dirs": [],
@@ -371,6 +393,14 @@ EMITTED_ATTRS = {
     # telemetry.*
     "telemetry_enabled",
     "telemetry_retention_days",
+    # network.bind / fleet.* (box runtime, ADR 0047 D8)
+    "bind_host",
+    "fleet_port_base",
+    "discovery_port_min",
+    "discovery_port_max",
+    "discovery_mdns",
+    "fleet_max_warm",
+    "fleet_warm_grace_seconds",
 }
 
 

--- a/tests/test_settings_cascade.py
+++ b/tests/test_settings_cascade.py
@@ -336,3 +336,125 @@ def test_pop_keys_from_yaml_prunes_and_is_idempotent():
     # Idempotent — popping again is a no-op, never raises.
     pop_keys_from_yaml(doc, ["prompt_cache.warm.enabled"])
     assert "prompt_cache" not in doc
+
+
+# ── D8: box-runtime knobs promoted into the Host layer (ADR 0047 D8) ───────────
+# bind interface / fleet port base / discovery range+mDNS / supervisor warm policy
+# are now host-scoped FIELDS. Each resolves file > env > app-default (the env var is
+# the zero-migration fallback), and the host process call sites read the live config.
+
+
+def _fleet_env_clear(monkeypatch):
+    """Start each env-precedence test from a clean slate — a dev's shell may already
+    export these (conftest only defaults PROTOAGENT_HOST_CONFIG)."""
+    for name in ("PROTOAGENT_HOST", "PROTOAGENT_FLEET_MAX_WARM", "PROTOAGENT_FLEET_WARM_GRACE"):
+        monkeypatch.delenv(name, raising=False)
+
+
+def test_d8_app_defaults_when_nothing_set(monkeypatch):
+    """No file, no leaf, no env → the dataclass (App) defaults."""
+    _fleet_env_clear(monkeypatch)
+    cfg = LangGraphConfig.from_dict({})
+    assert cfg.bind_host == "127.0.0.1"
+    assert cfg.fleet_port_base == 7870
+    assert (cfg.discovery_port_min, cfg.discovery_port_max) == (7860, 7910)
+    assert cfg.discovery_mdns is True
+    assert cfg.fleet_max_warm == 0
+    assert cfg.fleet_warm_grace_seconds == 0
+
+
+def test_d8_env_fallback_when_key_absent(monkeypatch):
+    """A promoted knob falls back to its PROTOAGENT_* env var when the merged dict
+    omits the key — the bridge that makes promotion zero-migration."""
+    _fleet_env_clear(monkeypatch)
+    monkeypatch.setenv("PROTOAGENT_HOST", "0.0.0.0")
+    monkeypatch.setenv("PROTOAGENT_FLEET_MAX_WARM", "3")
+    monkeypatch.setenv("PROTOAGENT_FLEET_WARM_GRACE", "15")
+    cfg = LangGraphConfig.from_dict({})
+    assert cfg.bind_host == "0.0.0.0"
+    assert cfg.fleet_max_warm == 3
+    assert cfg.fleet_warm_grace_seconds == 15
+
+
+def test_d8_file_wins_over_env(monkeypatch):
+    """File > env: a key present in the (host/leaf) dict beats the env var."""
+    _fleet_env_clear(monkeypatch)
+    monkeypatch.setenv("PROTOAGENT_HOST", "0.0.0.0")
+    monkeypatch.setenv("PROTOAGENT_FLEET_MAX_WARM", "3")
+    cfg = LangGraphConfig.from_dict({"network": {"bind": "127.0.0.1"}, "fleet": {"warm": {"max": 9}}})
+    assert cfg.bind_host == "127.0.0.1"
+    assert cfg.fleet_max_warm == 9
+
+
+def test_d8_bad_env_value_degrades_to_default(monkeypatch):
+    """A non-integer env var for an int knob degrades to the app default, not a crash."""
+    _fleet_env_clear(monkeypatch)
+    monkeypatch.setenv("PROTOAGENT_FLEET_MAX_WARM", "not-a-number")
+    assert LangGraphConfig.from_dict({}).fleet_max_warm == 0
+
+
+def test_d8_host_file_sets_box_runtime_leaf_overrides(tmp_path, monkeypatch):
+    """End-to-end cascade for fleet knobs: host-config.yaml sets the box default,
+    a leaf value overrides it (git-style), env is the lowest fallback."""
+    _fleet_env_clear(monkeypatch)
+    monkeypatch.setenv("PROTOAGENT_FLEET_MAX_WARM", "1")  # lowest precedence
+    _host_yaml(tmp_path, "fleet:\n  port_base: 8000\n  warm:\n    max: 5\n", monkeypatch)
+    path = _agent_yaml(tmp_path, "fleet:\n  warm:\n    max: 7\n")  # leaf overrides warm, silent on port_base
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.fleet_max_warm == 7       # leaf wins over host + env
+    assert cfg.fleet_port_base == 8000   # inherited from host
+
+
+def test_d8_host_cannot_inject_via_unscoped_key(tmp_path, monkeypatch):
+    """The fleet knobs are host-scoped, so a host file CAN set them (unlike an
+    agent-scoped key) — confirms the scope tagging took effect."""
+    _fleet_env_clear(monkeypatch)
+    _host_yaml(tmp_path, "network:\n  bind: 0.0.0.0\n", monkeypatch)
+    cfg = LangGraphConfig.from_yaml(str(tmp_path / "absent.yaml"))
+    assert cfg.bind_host == "0.0.0.0"  # host-scoped key applied from the host file
+
+
+def test_d8_supervisor_warm_policy_reads_live_config(monkeypatch):
+    """supervisor.max_warm()/grace prefer the resolved config; fall back to env with
+    no live config (the CLI/no-STATE path keeps today's behavior)."""
+    import runtime.state as rs
+    from graph.fleet import supervisor
+
+    class _Cfg:
+        fleet_max_warm = 4
+        fleet_warm_grace_seconds = 12
+
+    monkeypatch.setattr(rs.STATE, "graph_config", _Cfg(), raising=False)
+    assert supervisor.max_warm() == 4
+    assert supervisor._warm_grace_seconds() == 12
+
+    monkeypatch.setattr(rs.STATE, "graph_config", None, raising=False)
+    monkeypatch.setenv("PROTOAGENT_FLEET_MAX_WARM", "6")
+    assert supervisor.max_warm() == 6
+
+
+def test_d8_discovery_helpers_read_live_config(monkeypatch):
+    """discovery resolves its port range + mDNS gate from the Host-layer config."""
+    import runtime.state as rs
+    from graph.fleet import discovery
+
+    class _Cfg:
+        discovery_port_min = 9000
+        discovery_port_max = 9100
+        discovery_mdns = False
+
+    monkeypatch.setattr(rs.STATE, "graph_config", _Cfg(), raising=False)
+    assert discovery._config_port_range() == (9000, 9100)
+    assert discovery._mdns_enabled() is False
+
+
+def test_d8_manager_port_base_reads_live_config(monkeypatch):
+    """_pick_port bases its scan on the resolved fleet.port_base."""
+    import runtime.state as rs
+    from graph.workspaces import manager
+
+    class _Cfg:
+        fleet_port_base = 8200
+
+    monkeypatch.setattr(rs.STATE, "graph_config", _Cfg(), raising=False)
+    assert manager._port_base() == 8200


### PR DESCRIPTION
## What

The third and final slice of the ADR 0047 settings cascade (**D8**). Slices 1–2 (the cascade, the `host-config.yaml` layer, and the inherited/override/reset UI) already shipped in #925. The Host layer only pays off once the box-wide runtime knobs actually live in `FIELDS` — this promotes them out of scattered env/CLI reads:

| YAML key | scope | env fallback | consumed at |
|---|---|---|---|
| `network.bind` | host | `PROTOAGENT_HOST` | uvicorn bind |
| `fleet.port_base` | host | — | `manager._pick_port` |
| `fleet.discovery.port_min/port_max` | host | — | discovery scans |
| `fleet.discovery.mdns` | host | — | mDNS advertise/browse gate |
| `fleet.warm.max` | host | `PROTOAGENT_FLEET_MAX_WARM` | `supervisor.max_warm` |
| `fleet.warm.grace_seconds` | host | `PROTOAGENT_FLEET_WARM_GRACE` | warm-eviction grace |

They cascade App → `host-config.yaml` → agent-leaf and surface in **Settings ▸ Host / App ▸ Host config** (new "Fleet" section → System category) with the inherited-from-Host / override / reset badges for free — **zero frontend changes**, the schema endpoint drives it.

## Decisions

- **Precedence = file > env > default** (operator, ADR Open decision #2). The `_env_default` bridge in `from_dict` consults the env var only when the merged (host⊕leaf) dict omits the key, so a value set in the file/UI can't be silently shadowed by a leftover env var — and existing `PROTOAGENT_*` boxes keep working with **zero migration**. An explicit `--host` flag still wins over everything.
- Call sites read the resolved config via the lazy `runtime.state.STATE` accessor (the established idiom), falling back to env in a CLI/no-config context — today's behavior byte-identical when no config is loaded.
- Data-root / `PROTOAGENT_AUTO_SCOPE` deliberately **not** promoted (it resolves where `host-config.yaml` itself lives — chicken-and-egg).

## Tests

- `test_config_drift_guard` `HOST_SCOPED_KEYS` + `test_config_roundtrip` goldens (`FROM_YAML_EXAMPLE_FIELDS` / `CONFIG_TO_DICT_GOLDEN` / `EMITTED_ATTRS`) + `test_config_io` top-level key set extended for the 7 new fields.
- New D8 block in `test_settings_cascade`: env-fallback, file-wins-over-env, leaf-overrides-host, bad-env-degrades, and call-sites-read-live-config (supervisor / discovery / manager).
- **Full Python suite green (1732 passed).** No frontend edits → tsc/vitest/build unchanged from main.

## Draft — operator local-test gate

Surfaces new fields in the settings UI, so it follows the settings-IA UI gate (operator eyeballs locally; CI can't judge UX). Quick smoke to confirm before marking ready:
- Settings ▸ Host / App ▸ Host config shows the **Fleet** group; editing a knob saves to `host-config.yaml`.
- `--host 0.0.0.0` still overrides; with `--host` omitted, a `host-config.yaml` `network.bind` takes effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)