### PR TITLE
test(e2e): isolate the mock fleet per spec — kill the fleet.spec flake

### DIFF
--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -6,6 +6,18 @@ import { expect, test } from "@playwright/test";
 
 test.describe.configure({ mode: "serial" });
 
+// This spec MUTATES the mock fleet (create / stop / rename / add-remote). Claim a
+// private fleet scope (the mock keys state on x-e2e-fleet) and reset it to baseline
+// before every test — including serial-group retries — so a write can never leak
+// into the next test, a retry, or another spec. The scope is keyed on the parallel
+// worker so even concurrent runners (repeat-each, if mode:serial is ever lifted)
+// stay isolated from each other.
+test.beforeEach(async ({ page }, testInfo) => {
+  const scope = `fleet-spec-${testInfo.parallelIndex}`;
+  await page.setExtraHTTPHeaders({ "x-e2e-fleet": scope }); // app fetches carry it
+  await page.request.post("/api/__test__/fleet/reset", { headers: { "x-e2e-fleet": scope } });
+});
+
 async function openAgents(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -81,7 +81,21 @@ let INSTALLED_PLUGINS = [];
 // `POST /{id}/update` the entry is cleared so the row flips to "up to date".
 let PLUGIN_UPDATES = {};
 
-function handleApiGet(pathname) {
+// Fleet state is the one slice of the mock backend the specs MUTATE (create /
+// stop / rename / add-remote). Isolate it PER SPEC so parallel files and serial-
+// group retries can't observe each other's writes: every `x-e2e-fleet` request
+// header gets its own lazy deep-clone of the FLEET baseline, and a spec resets
+// its own scope between tests via POST /api/__test__/fleet/reset. Requests with
+// no header share the "default" scope.
+const fleetScopes = new Map();
+const cloneFleet = (f) => JSON.parse(JSON.stringify(f));
+function fleetFor(req) {
+  const scope = req.headers["x-e2e-fleet"] || "default";
+  if (!fleetScopes.has(scope)) fleetScopes.set(scope, cloneFleet(FLEET));
+  return fleetScopes.get(scope);
+}
+
+function handleApiGet(pathname, fleet = FLEET) {
   switch (pathname) {
     case "/api/runtime/status":
       return RUNTIME_STATUS;
@@ -152,11 +166,11 @@ function handleApiGet(pathname) {
     case "/api/theme":
       return { theme: null }; // per-agent theme (ADR 0042); null → DS defaults
     case "/api/fleet":
-      return { agents: FLEET.agents };
+      return { agents: fleet.agents };
     case "/api/fleet/discover":
       // One discoverable sibling on the LAN (not in the fleet) — candidates for
       // add-as-delegate or add-to-fleet (remote member).
-      return { discovered: FLEET.agents.some((a) => a.name === "remy") ? [] : [
+      return { discovered: fleet.agents.some((a) => a.name === "remy") ? [] : [
         { name: "remy", url: "http://192.168.5.50:7871", host: "192.168.5.50", port: 7871 },
       ] };
     case "/api/archetypes":
@@ -305,12 +319,18 @@ const server = createServer(async (req, res) => {
   }
   if (pathname.startsWith("/api/")) {
     if (req.method === "GET") {
-      const payload = handleApiGet(pathname);
+      const payload = handleApiGet(pathname, fleetFor(req));
       if (payload !== null) return sendJson(res, payload);
       return sendJson(res, { detail: "not mocked" }, 404);
     }
     // POST/PATCH/DELETE writes → generic ok so the UI doesn't error.
     const body = await readBody(req);
+    const fleet = fleetFor(req);
+    if (pathname === "/api/__test__/fleet/reset" && req.method === "POST") {
+      // Per-spec hermeticity: restore this scope's fleet to the baseline.
+      fleetScopes.set(req.headers["x-e2e-fleet"] || "default", cloneFleet(FLEET));
+      return sendJson(res, { ok: true });
+    }
     if (pathname === "/api/settings") {
       // ADR 0047: a layer-aware save — "agent" (per-agent leaf, default) or "host"
       // (box-shared host-config.yaml). The mock just echoes which layer it wrote.
@@ -335,46 +355,46 @@ const server = createServer(async (req, res) => {
     if (req.method === "DELETE" && /^\/api\/plugins\/workflows\/[^/]+$/.test(pathname)) {
       return sendJson(res, { deleted: true });
     }
-    // Fleet (ADR 0042) — mutate the in-memory FLEET so create/start/stop/activate/remove round-trip.
+    // Fleet (ADR 0042) — mutate this scope's fleet so create/start/stop/activate/remove round-trip.
     if (pathname === "/api/fleet" && req.method === "POST") {
       const name = String(body.name || "").trim();
       if (!/^[A-Za-z0-9-_]+$/.test(name)) return sendJson(res, { detail: "invalid name" }, 400);
       // Ids are opaque + immutable (name-<4hex>); the name is the editable display label.
       const agent = { name, id: `${name}-ab12`, port: 7899, pid: 5000, running: true, bundle: body.bundle || "" };
-      FLEET.agents.push(agent);
+      fleet.agents.push(agent);
       return sendJson(res, { ok: true, agent, installed: [] });
     }
     if (pathname === "/api/fleet/remotes" && req.method === "POST") {
       const name = String(body.name || "").trim();
-      if (FLEET.agents.some((a) => a.name === name)) return sendJson(res, { detail: "an agent named " + name + " already exists" }, 400);
+      if (fleet.agents.some((a) => a.name === name)) return sendJson(res, { detail: "an agent named " + name + " already exists" }, 400);
       const agent = { name, id: `${name}-re01`, port: null, pid: null, running: true, bundle: "", remote: true, url: body.url, a2a: `${body.url}/a2a` };
-      FLEET.agents.push(agent);
+      fleet.agents.push(agent);
       return sendJson(res, { ok: true, agent });
     }
     if (req.method === "DELETE" && /^\/api\/fleet\/remotes\/[^/]+$/.test(pathname)) {
       const ident = decodeURIComponent(pathname.split("/").pop());
-      const a = FLEET.agents.find((x) => x.remote && (x.id === ident || x.name === ident));
+      const a = fleet.agents.find((x) => x.remote && (x.id === ident || x.name === ident));
       if (!a) return sendJson(res, { detail: "no remote member" }, 400);
-      FLEET.agents = FLEET.agents.filter((x) => x !== a);
+      fleet.agents = fleet.agents.filter((x) => x !== a);
       return sendJson(res, { ok: true, id: a.id, name: a.name });
     }
     if (req.method === "PATCH" && /^\/api\/fleet\/[^/]+$/.test(pathname)) {
       const ident = decodeURIComponent(pathname.split("/").pop());
-      const a = FLEET.agents.find((x) => x.id === ident || x.name === ident);
+      const a = fleet.agents.find((x) => x.id === ident || x.name === ident);
       if (!a) return sendJson(res, { detail: "no such agent" }, 400);
-      if (FLEET.agents.some((x) => x.name === body.name && x.id !== a.id))
+      if (fleet.agents.some((x) => x.name === body.name && x.id !== a.id))
         return sendJson(res, { detail: "an agent with that name already exists" }, 400);
       a.name = String(body.name || "").trim();
       return sendJson(res, { ok: true, id: a.id, name: a.name });
     }
     if (pathname === "/api/fleet/down" && req.method === "POST") {
-      FLEET.agents.forEach((a) => { a.running = false; a.pid = null; });
-      return sendJson(res, { ok: true, stopped: FLEET.agents.map((a) => a.name) });
+      fleet.agents.forEach((a) => { a.running = false; a.pid = null; });
+      return sendJson(res, { ok: true, stopped: fleet.agents.map((a) => a.name) });
     }
     {
       const m = pathname.match(/^\/api\/fleet\/([^/]+)\/(start|stop|activate)$/);
       if (m && req.method === "POST") {
-        const a = FLEET.agents.find((x) => x.name === m[1] || x.id === m[1]);
+        const a = fleet.agents.find((x) => x.name === m[1] || x.id === m[1]);
         if (!a) return sendJson(res, { detail: "no such agent" }, 400);
         if (m[2] === "start") { a.running = true; a.pid = 5001; return sendJson(res, { ok: true, agent: a }); }
         if (m[2] === "stop") { a.running = false; a.pid = null; return sendJson(res, { ok: true, name: a.name, stopped: true }); }
@@ -385,7 +405,7 @@ const server = createServer(async (req, res) => {
     }
     if (req.method === "DELETE" && /^\/api\/fleet\/[^/]+$/.test(pathname)) {
       const name = decodeURIComponent(pathname.split("/").pop());
-      FLEET.agents = FLEET.agents.filter((a) => a.name !== name && a.id !== name);
+      fleet.agents = fleet.agents.filter((a) => a.name !== name && a.id !== name);
       return sendJson(res, { ok: true, name, removed: [name] });
     }
     if (req.method === "POST" && /^\/api\/playbooks\/\d+\/promote$/.test(pathname)) {


### PR DESCRIPTION
## What

The Web E2E smoke job has been intermittently failing on `fleet.spec.ts` (`lists the host + peers` and `discover → add to fleet`). Root cause is a **test-isolation bug in the mock harness, not a product bug**.

`e2e/mock-server.mjs` held `FLEET` as a single module-level mutable global, but `playwright.config.ts` runs `fullyParallel: true`. `fleet.spec.ts` (`mode: serial`) **creates / stops / renames** agents and **adds/removes** a remote member in that shared global and never resets it. So when its serial group is retried, the retry observes contaminated state:
- `ava` was already renamed → `roxy`… → "lists the host + peers" can't find the `ava` row.
- `remy` was already registered → `/api/fleet/discover` returns `[]` → "discover → add to fleet" can't re-add it.

## Fix

Per-spec fleet isolation in the mock:
- State is keyed on an `x-e2e-fleet` request header; each scope **lazily deep-clones** the `FLEET` baseline.
- New `POST /api/__test__/fleet/reset` restores the caller's scope to baseline.
- `fleet.spec.ts` claims a **per-parallel-worker** scope and resets it in `beforeEach` (runs on every retry), so writes can't leak across tests, retries, or parallel specs.
- Headerless requests share the `"default"` scope → all other specs behave exactly as before, now also fenced off from fleet's writes.

No product/frontend code changes — `mock-server.mjs` + `fleet.spec.ts` only.

## Verification

- Full e2e suite: **92 passed**, 0 flaky.
- `fleet + activate + turn-watch` under `--repeat-each=5 --workers=4` (forced parallelism that the real serial config never produces): **55 passed, 0 flaky** (was 2 flaky before the per-worker scope).

This pre-existing flake is what's red on the box-runtime-fields PR (#929) and on main generally; landing it here unblocks both.

🤖 Generated with [Claude Code](https://claude.com/claude-code)