### PR TITLE
fix(desktop): pass --repo when uploading latest.json — unstrand the updater manifest

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -340,4 +340,10 @@ jobs:
             --notes "protoAgent ${TAG} — see the GitHub Release for details." \
             --out latest.json
           cat latest.json
-          gh release upload "$TAG" latest.json --clobber
+          # --repo is required: this job never checks out the repo (it only
+          # `gh release download`s bundles), so without it `gh release upload`
+          # tries to infer the repo from `git remote` and dies with
+          # "not a git repository" — stranding latest.json off the release
+          # (the in-app updater manifest). The download step above already
+          # passes --repo for the same reason.
+          gh release upload "$TAG" latest.json --repo "${{ github.repository }}" --clobber


### PR DESCRIPTION
## What

The Desktop Build's **`updater manifest (latest.json)`** fan-in job failed on v0.35.0 — the **inaugural desktop release**. All three platform legs built, signed, and attached fine; only the updater manifest was stranded.

## Root cause

The job composes `latest.json` correctly (the log shows a valid 3-platform manifest), then on its last line runs:

```
gh release upload "$TAG" latest.json --clobber
→ failed to run git: fatal: not a git repository
```

The fan-in job **never checks out the repo** — it only `gh release download`s the signed bundles. With no `.git`, `gh release upload` falls back to inferring the repo from `git remote` and dies. The sibling `gh release download` two lines up already passes `--repo` for exactly this reason; the upload didn't.

## Fix

One line: add `--repo "${{ github.repository }}"` to the upload (+ a comment so it doesn't regress). This unblocks `latest.json` on every future release.

## v0.35.0 status

- Server release ✅ (Docker + GitHub Release + Discord)
- All desktop apps ✅ signed + notarized (macOS), Linux (AppImage/deb), Windows (NSIS unsigned)
- `latest.json` ✅ **backfilled manually** onto the v0.35.0 release (composed with the same `@protolabsai/release-tools build-updater-manifest`, uploaded with `--repo`), so in-app updates are live now — this PR just prevents the recurrence.

🤖 Generated with [Claude Code](https://claude.com/claude-code)