### PR TITLE
fix(desktop): sidecar can't start under hardened runtime — DOA in v0.35.0

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -214,6 +214,24 @@ jobs:
             npm run build -- --bundles "$BUNDLES"
           fi
 
+      - name: Smoke-test the SIGNED sidecar (macOS)
+        if: runner.os == 'macOS' && steps.build.outputs.signed == 'true'
+        shell: bash
+        # The pre-bundle smoke (above) boots the UNSIGNED PyInstaller binary, so it
+        # CANNOT see a signing-induced failure. Hardened-runtime signing turns on
+        # library validation, which refuses to dlopen the frozen Python.framework
+        # (a different Team ID) unless `disable-library-validation` is entitled —
+        # exactly the regression that shipped a dead backend in v0.35.0 (sidecar
+        # never started → console up, every API call failing). Boot the SIGNED
+        # sidecar from the freshly-bundled .app so that class of bug fails the
+        # build here, not in a user's hands.
+        run: |
+          set -euo pipefail
+          APP="$(ls -d apps/desktop/src-tauri/target/release/bundle/macos/*.app | head -1)"
+          BIN="${APP}/Contents/MacOS/protoagent-server"
+          echo "Smoking signed sidecar: ${BIN}"
+          python scripts/live_smoke.py --bin "${BIN}" --timeout 180
+
       - name: Collect artifacts
         shell: bash
         # Normalize every bundle into dist-desktop/ as

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,28 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The desktop app's backend now actually starts (it was dead on arrival in
+  v0.35.0).** The signed/notarized macOS build runs the PyInstaller server
+  sidecar under the hardened runtime, which enables **library validation** — and
+  the frozen onefile extracts and `dlopen()`s a bundled `Python.framework` signed
+  with a different Team ID than our Developer ID. Library validation refused to
+  map it (`code signature ... not valid for use in process: ... different Team
+  IDs`), so the sidecar never started: the console loaded but every API call
+  failed (no beads, no settings, the boot gate stuck on "…attention in
+  Settings"). Added the sanctioned, notarization-permitted
+  `com.apple.security.cs.disable-library-validation` entitlement so the embedded
+  interpreter loads. CI missed it because the frozen-sidecar smoke runs on the
+  **unsigned** binary (before bundling) — added a **post-sign smoke** that boots
+  the signed sidecar from the bundled `.app`, so a signing-induced backend
+  failure fails the build instead of shipping. `verify-macos-desktop.sh` now
+  *requires* the entitlement (it previously forbade it).
+- **Desktop release builds now write logs.** `tauri-plugin-log` was initialised
+  only under `cfg!(debug_assertions)`, so release builds produced no log file —
+  which is why the sidecar boot failure above left no trace on disk. Logging is
+  now always on; `[sidecar]` stdout/stderr (including a boot crash) is captured
+  to `~/Library/Logs/studio.protolabs.protoagent/`.
+
 ## [0.35.0] - 2026-06-12
 
 ### Added

--- a/apps/desktop/src-tauri/entitlements.plist
+++ b/apps/desktop/src-tauri/entitlements.plist
@@ -13,5 +13,18 @@
          or broader code-signing exceptions unless a shipped feature requires it. -->
     <key>com.apple.security.cs.allow-jit</key>
     <true/>
+    <!-- REQUIRED for the PyInstaller server sidecar. The frozen onefile extracts
+         and dlopen()s a bundled Python.framework signed with a different Team ID
+         than our Developer ID. Under the hardened runtime, library validation
+         refuses to map a library whose Team ID differs from the process's —
+         "code signature ... not valid for use in process: ... different Team IDs"
+         — so the sidecar cannot start at all in the signed/notarized build (the
+         backend never comes up; the console loads but every API call fails).
+         Disabling library validation is the sanctioned, notarization-permitted
+         exception for embedded interpreters. Tauri signs the sidecar with this
+         same plist, so the entitlement reaches the process doing the dlopen.
+         (Shipped in v0.35.0 WITHOUT this → the desktop app was dead on arrival.) -->
+    <key>com.apple.security.cs.disable-library-validation</key>
+    <true/>
 </dict>
 </plist>

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -287,13 +287,16 @@ pub fn run() {
                 .build(),
         )
         .setup(|app| {
-            if cfg!(debug_assertions) {
-                app.handle().plugin(
-                    tauri_plugin_log::Builder::default()
-                        .level(log::LevelFilter::Info)
-                        .build(),
-                )?;
-            }
+            // Init logging in RELEASE too (was debug-only): a release build that
+            // wrote no logs is exactly why the v0.35.0 sidecar failure was opaque
+            // — "no logs?". tauri-plugin-log's default targets include the OS log
+            // dir (~/Library/Logs/studio.protolabs.protoagent/), so the captured
+            // `[sidecar]` stdout/stderr (incl. a boot crash) lands on disk.
+            app.handle().plugin(
+                tauri_plugin_log::Builder::default()
+                    .level(log::LevelFilter::Info)
+                    .build(),
+            )?;
             app.manage(SidecarProcess::default());
 
             // Pin the sidecar to the fixed port the web client falls back to in

--- a/scripts/verify-macos-desktop.sh
+++ b/scripts/verify-macos-desktop.sh
@@ -64,16 +64,22 @@ codesign -dvv "$APP" 2>&1 | grep -q "TeamIdentifier=" || { echo "FAIL: no TeamId
 echo "ok: Developer ID authority + team identifier"
 
 ENTITLEMENTS="$(codesign -d --entitlements :- "$APP" 2>/dev/null)"
-for key in com.apple.security.network.client com.apple.security.network.server com.apple.security.cs.allow-jit; do
+# disable-library-validation is REQUIRED: the PyInstaller sidecar dlopen()s a
+# Python.framework with a different Team ID, which the hardened runtime blocks
+# without it (the sidecar — hence the whole backend — was DOA in v0.35.0).
+for key in com.apple.security.network.client com.apple.security.network.server \
+           com.apple.security.cs.allow-jit com.apple.security.cs.disable-library-validation; do
   echo "$ENTITLEMENTS" | grep -q "$key" || { echo "FAIL: missing entitlement: $key"; exit 1; }
 done
-for key in com.apple.security.cs.allow-unsigned-executable-memory com.apple.security.cs.disable-library-validation; do
+# Still keep the blast radius tight — nothing broader than the declared set.
+for key in com.apple.security.cs.allow-unsigned-executable-memory \
+           com.apple.security.cs.allow-dyld-environment-variables; do
   if echo "$ENTITLEMENTS" | grep -q "$key"; then
     echo "FAIL: forbidden entitlement present: $key"
     exit 1
   fi
 done
-echo "ok: entitlements exactly as declared (network client/server + JIT; nothing broader)"
+echo "ok: entitlements exactly as declared (network client/server + JIT + library-validation exception for the frozen sidecar; nothing broader)"
 
 spctl --assess --type execute --verbose=4 "$APP"
 echo "ok: Gatekeeper accepts the app"


### PR DESCRIPTION
## Severity: the v0.35.0 desktop app's backend never starts

The signed/notarized macOS app shipped a **dead backend**. Reproduced by running the installed sidecar directly:

```
[PYI-…:ERROR] Failed to load Python shared library '…/Python':
  code signature '…/Python.framework/…/Python' not valid for use in process:
  mapping process and mapped file (non-platform) have different Team IDs
```

The PyInstaller onefile sidecar runs under the **hardened runtime** (`flags=0x10000(runtime)`, `TeamIdentifier=29A6U8MPB5`). It extracts + `dlopen()`s a bundled `Python.framework` signed with a **different Team ID**, and library validation refuses to map it → the sidecar exits immediately. The console (served as a Tauri asset) still renders, but every API call fails:

> **no beads, no settings, nothing loads; boot gate stuck on "…attention in Settings"** — the exact reported symptom.

## Fix

Add `com.apple.security.cs.disable-library-validation` to `entitlements.plist` — the sanctioned, notarization-permitted exception for an embedded interpreter. Tauri signs the sidecar with this same plist (the shipped sidecar already carried its other entitlements), so it reaches the process doing the `dlopen`.

## Why CI missed it + guards so it can't reship

1. **Pre-sign smoke is blind to it.** The frozen-sidecar smoke runs on the *unsigned* binary (library validation off → passes); signing then breaks the artifact. → **Added a post-sign smoke** that boots the *signed* sidecar from the bundled `.app`.
2. **The verifier asserted the broken posture.** `verify-macos-desktop.sh` *forbade* this entitlement ("keep it minimal") and passed. → It now **requires** it.
3. **No logs in release.** `tauri-plugin-log` initialised only under `cfg!(debug_assertions)`, so the release wrote nothing to disk — why the failure was opaque ("don't we have logs?"). → Logging is **always on** now (`~/Library/Logs/studio.protolabs.protoagent/`).

## Verification

- Root cause reproduced + confirmed against the shipped binary (`codesign -dvv`, `-d --entitlements`).
- plist lints, verify script + workflow YAML + changelog validated.
- **Final proof is the next signed build**: the new post-sign smoke must boot the signed sidecar green. This is *not* locally verifiable (needs hardened-runtime signing on a runner).

## Release

v0.35.0 is **pulled** (drafted — 404 for anonymous download). After this + the splash-logo fix (#933) land, re-cut **v0.35.1**; keep the desktop release as a draft until the post-sign smoke is green and the dmg is hand-checked, then publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)