### PR TITLE
fix(desktop): agent-switch asset 404 (absolute Vite base) + show app version in Overview

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Switching agents in the desktop app no longer breaks the window.** The desktop
+  build pinned Vite's `--base ./` (relative), so the bundled `index.html`
+  referenced its JS/CSS relatively. At the root URL that's fine, but the fleet
+  switcher navigates to a real path (`tauri://localhost/agent/<slug>/`), where
+  `./assets/…` resolved to `/agent/<slug>/assets/…` — which doesn't exist, so
+  Tauri's asset resolver fell back to `index.html` and the browser rejected it
+  (`'text/html' is not a valid JavaScript MIME type`, `Did not parse stylesheet`).
+  Switched the desktop build to an absolute `--base /` so assets always resolve
+  from the protocol root regardless of route. (`apiBase()` already hard-targets
+  `127.0.0.1:7870` in the Tauri context, and `agentHref` reads `BASE_URL`, so
+  navigation + API are unaffected.)
+
+### Added
+- **The app version is shown in Settings ▸ Host / App ▸ Overview** (the runtime
+  status already carries it — `0.35.1` etc.; the frozen desktop sidecar reports
+  its bundled version per #894). Surfaced as a "Version" tile and in the panel
+  subtitle, so there's an at-a-glance "about" for which build you're running.
+
 ## [0.35.1] - 2026-06-12
 
 ### Fixed

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "frontendDist": "../../web/dist",
     "devUrl": "http://127.0.0.1:5173/app/",
     "beforeDevCommand": "npm --workspace @protoagent/web run dev",
-    "beforeBuildCommand": "npm --workspace @protoagent/web run build -- --base ./"
+    "beforeBuildCommand": "npm --workspace @protoagent/web run build -- --base /"
   },
   "app": {
     "windows": [],

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -1,6 +1,9 @@
 export type RuntimeStatus = {
   setup_complete: boolean;
   graph_loaded: boolean;
+  /** App version (pyproject [project].version; the frozen desktop sidecar reports
+   *  its bundled version — #894). Surfaced in Settings ▸ Host / App ▸ Overview. */
+  version?: string;
   project: {
     path: string;
     allowed_dirs?: string[];

--- a/apps/web/src/settings/OverviewPanel.tsx
+++ b/apps/web/src/settings/OverviewPanel.tsx
@@ -1,5 +1,5 @@
 import { QueryErrorResetBoundary, useSuspenseQuery } from "@tanstack/react-query";
-import { Bot, Database, HardDrive, Settings2, Sparkles } from "lucide-react";
+import { Bot, Database, HardDrive, Settings2, Sparkles, Tag } from "lucide-react";
 import { Suspense, type ReactNode } from "react";
 
 import { brandName } from "../lib/brand";
@@ -38,10 +38,14 @@ function StatusBody() {
   const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
   return (
     <>
-      <PanelHeader title="Overview" kicker={runtime.model?.name || "model not configured"} />
+      <PanelHeader
+        title="Overview"
+        kicker={`${runtime.model?.name || "model not configured"}${runtime.version ? ` · v${runtime.version}` : ""}`}
+      />
       <div className="stage-body">
         <div className="metric-grid">
           <Metric icon={<Bot size={16} />} label="Agent" value={brandName(runtime.identity?.name)} />
+          <Metric icon={<Tag size={16} />} label="Version" value={runtime.version ? `v${runtime.version}` : "—"} />
           <Metric icon={<Settings2 size={16} />} label="Provider" value={runtime.model?.provider || "none"} />
           <Metric icon={<Database size={16} />} label="Knowledge" value={runtime.knowledge.resolved_path || runtime.knowledge.configured_path || "disabled"} />
           <Metric icon={<Sparkles size={16} />} label="Goal mode" value={runtime.goal.enabled ? "on" : "off"} />


### PR DESCRIPTION
Two issues surfaced while running the freshly-shipped v0.35.1 desktop app.

## 1. Switching agents broke the window (the serious one)

Reported console errors after toggling to another agent:
```
'text/html' is not a valid JavaScript MIME type
Did not parse stylesheet at 'tauri://localhost/agent/roxy-2a88/assets/index-…css'
```

**Cause:** the desktop build pinned Vite `--base ./` (relative). FleetSwitcher navigates to a real path (`tauri://localhost/agent/<slug>/`, full navigation — ADR 0042), where the bundled `index.html`'s relative `./assets/…` resolved to `/agent/<slug>/assets/…`. That path doesn't exist, so Tauri's asset resolver fell back to `index.html` → the browser got `text/html` for `.js`/`.css` → rejected.

**Fix:** absolute `--base /`. Tauri serves `frontendDist` at the protocol root, so `/assets/…` resolves correctly at any route. Safe because `apiBase()` already hard-targets `127.0.0.1:7870` in the Tauri context and `agentHref` reads `BASE_URL`.

**Verified locally** (replicating Tauri's resolver — root-served `dist/` + index.html SPA fallback): at `/agent/<slug>/`, assets serve as `text/css` + `text/javascript` (200), **zero MIME/stylesheet console errors**, styles applied. The `--base ./` build reproduces the failure at the same route.

## 2. App version now shown (your request)

`/api/runtime/status` already carries the version (`0.35.1`; the frozen sidecar reports its bundled version per #894) but nothing surfaced it. Added a top-level `version` to the `RuntimeStatus` type and a **"Version" tile + subtitle** in **Settings ▸ Host / App ▸ Overview** — an at-a-glance "about".

## Notes
- The slug fix is desktop-only (`tauri.conf.json` beforeBuildCommand); the web build keeps its `/app/` base.
- Full end-to-end proof for #1 is a desktop build + live agent-switch (not buildable on a PR); the local SPA-fallback test covers the asset resolution that actually broke.
- Targeting a follow-up patch (v0.35.2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)