### PR TITLE
chore: release v0.35.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.2] - 2026-06-12
+
 ### Fixed
 - **Switching agents in the desktop app no longer breaks the window.** The desktop
   build pinned Vite's `--base ./` (relative), so the bundled `index.html`

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.35.1"
+version = "0.35.2"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.35.2",
+    "date": "2026-06-12",
+    "changes": [
+      "Switching agents in the desktop app no longer breaks the window.",
+      "The app version is shown in Settings ▸ Host / App ▸ Overview"
+    ]
+  },
+  {
     "version": "v0.35.1",
     "date": "2026-06-12",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.35.2`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.35.2 -m 'Release v0.35.2' && git push origin v0.35.2`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).