### PR TITLE
fix(desktop): v0.35.3 first-run + execute_code batch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Desktop first-run: panels no longer flash "Load failed" and need a reload.**
+  The cold-start retry policy only rode out HTTP 409/502 (a fleet member spawning),
+  but the desktop sidecar's ~12s first-launch boot is a *connection-refused* network
+  error (WKWebView reports it as `TypeError: Load failed`) with no HTTP status — so
+  beads/notes/etc. fell through to the single-retry default, gave up before the
+  sidecar bound its port, and stuck in the error fallback until manually reloaded.
+  `isColdStart` now also treats a response-less fetch failure as "not up yet", so
+  those panels stay in their loading state and resolve once the sidecar is ready.
+- **macOS desktop: the brand again clears the native traffic lights.** A rename of
+  the topbar element (`.topbar` → `.app-topbar`) left the title-bar inset rule on the
+  old selector, so the 84px inset silently stopped applying and the window's
+  traffic-light buttons crowded the logo. Pointed the `.is-tauri-mac` inset at
+  `.app-topbar`.
+
 ## [0.35.2] - 2026-06-12
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Identity panel: the "Saving writes SOUL.md…" helper + save status now sit
+  ABOVE the SOUL.md editor** (next to the Save button), instead of trailing under
+  it — so the editor runs to the panel bottom without a footer of helper text.
+
 ### Fixed
 - **Desktop first-run: panels no longer flash "Load failed" and need a reload.**
   The cold-start retry policy only rode out HTTP 409/502 (a fleet member spawning),

--- a/apps/web/src/agent/IdentityPanel.tsx
+++ b/apps/web/src/agent/IdentityPanel.tsx
@@ -75,6 +75,13 @@ export function IdentityPanel() {
               <span>Agent name</span>
               <Input value={name} onChange={(e) => setName(e.target.value)} placeholder="my-agent" data-testid="identity-name" />
             </label>
+            {/* Save feedback + what saving does — ABOVE the editor (near the Save button), so the
+                SOUL.md editor runs to the panel bottom instead of being trailed by helper text. */}
+            {save.isError ? <p className="error-strip" role="alert">Save failed — check the server log.</p> : null}
+            {save.isSuccess && !dirty ? <p className="muted">Saved — agent reloaded.</p> : null}
+            <p className="muted soul-hint">
+              Saving writes SOUL.md + config and hot-reloads the agent. The name updates the A2A card and console.
+            </p>
             <div className="field soul-field">
               <div className="soul-head">
                 <span>SOUL.md — the agent's persona &amp; system identity</span>
@@ -98,11 +105,6 @@ export function IdentityPanel() {
                 </div>
               )}
             </div>
-            {save.isError ? <p className="error-strip" role="alert">Save failed — check the server log.</p> : null}
-            {save.isSuccess && !dirty ? <p className="muted">Saved — agent reloaded.</p> : null}
-            <p className="muted" style={{ fontSize: "12px" }}>
-              Saving writes SOUL.md + config and hot-reloads the agent. The name updates the A2A card and console.
-            </p>
           </>
         )}
       </div>

--- a/apps/web/src/agent/identity.css
+++ b/apps/web/src/agent/identity.css
@@ -39,3 +39,9 @@
 }
 .soul-preview > :first-child { margin-top: 0; }
 .soul-preview > :last-child { margin-bottom: 0; }
+/* Helper line above the SOUL.md editor (what "Save & reload" does). Small + tight —
+   the .identity-body gap owns the vertical rhythm, so no extra margin here. */
+.soul-hint {
+  font-size: 12px;
+  margin: 0;
+}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -121,8 +121,10 @@
 /* macOS desktop (invisible title bar): inset the brand so it clears the native
    traffic lights that float top-left over the content. The topbar carries
    `data-tauri-drag-region`, so this area drags the window. Mac build ONLY — the
-   browser has no traffic lights, so no inset there. */
-.app-shell.is-tauri-mac .topbar {
+   browser has no traffic lights, so no inset there.
+   NB: the brand bar is `.app-topbar` (App.tsx) — a rename left this rule on the
+   old `.topbar`, so the inset silently stopped clearing the lights. */
+.app-shell.is-tauri-mac .app-topbar {
   padding-left: 84px;
 }
 

--- a/apps/web/src/lib/api.test.ts
+++ b/apps/web/src/lib/api.test.ts
@@ -13,11 +13,17 @@ describe("cold-start detection (ApiError / isColdStart)", () => {
     expect(isColdStart(new ApiError(502, "not reachable"))).toBe(true);
   });
 
-  it("does NOT treat other failures (404/500) or plain errors as cold-start", () => {
+  it("does NOT treat real HTTP failures (404/500) as cold-start", () => {
     expect(isColdStart(new ApiError(404, "nope"))).toBe(false);
     expect(isColdStart(new ApiError(500, "boom"))).toBe(false);
-    expect(isColdStart(new Error("network"))).toBe(false);
-    expect(isColdStart(undefined)).toBe(false);
+  });
+
+  it("treats a fetch with no HTTP response as cold-start (desktop sidecar booting)", () => {
+    // WKWebView throws `TypeError: Load failed` (Chrome: "Failed to fetch") when the
+    // local sidecar isn't bound to its port yet on first launch — ride it out rather
+    // than flashing "Load failed" in the beads/notes panels.
+    expect(isColdStart(new TypeError("Load failed"))).toBe(true);
+    expect(isColdStart(new Error("Failed to fetch"))).toBe(true);
   });
 });
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -243,12 +243,19 @@ export class ApiError extends Error {
   }
 }
 
-/** Cold start: a just-switched-to fleet agent answers 409 (the member isn't running
- *  yet — `activate` is still spawning it) or 502 (it's booting but not bound) for a few
- *  seconds until it's up. These are transient, not failures — retry through them. */
+/** Cold start: the backend isn't answering *yet*, but will be shortly — retry through
+ *  it instead of flashing an error. Two shapes:
+ *   - HTTP 409 / 502: a just-switched-to fleet agent (the member isn't running yet —
+ *     `activate` is still spawning it) or its hub proxy (booting, not bound).
+ *   - A fetch that threw before any response (no ApiError status): the LOCAL desktop
+ *     sidecar isn't bound to its port yet during the ~12s first-launch boot. WKWebView
+ *     surfaces this as `TypeError: Load failed` — which is exactly why the beads/notes
+ *     panels showed "Load failed" and had to be reloaded on a fresh desktop start.
+ *  A genuinely-down backend just keeps the panels in their loading state until the
+ *  shell's boot-gate ("isn't responding") takes over — same as before. */
 export function isColdStart(error: unknown): boolean {
-  const s = error instanceof ApiError ? error.status : 0;
-  return s === 409 || s === 502;
+  if (error instanceof ApiError) return error.status === 409 || error.status === 502;
+  return true; // no HTTP response at all ⇒ not reachable yet (desktop sidecar booting)
 }
 
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {


### PR DESCRIPTION
Fixes found dogfooding the freshly-shipped v0.35.2 desktop app as a brand-new user. Targeting **v0.35.3**.

## Console / first-run
1. **Panel "Load failed" boot race** — `isColdStart` now rides out the desktop sidecar's connection-refused boot (was fleet-409/502-only), so beads/notes don't flash an error + need a reload. Test added.
2. **macOS traffic-light inset** — the brand bar was renamed `.topbar`→`.app-topbar` but the inset rule wasn't; pointed it at `.app-topbar` (verified padding-left = 84px).
3. **Identity save-note** moved above the SOUL.md editor (so the editor reaches the panel bottom).

## execute_code (it was enabled + broke a chat thread on desktop)
4. **Helper text** rewritten — was jargon + oversold the "sandbox" (the impl calls it "isolation, not a true sandbox").
5. **Frozen guard** — `run_code` returns a clean error in a frozen build instead of the broken `sys.executable -u` spawn.
6. **Hidden + disabled in desktop** — the frozen build no longer builds the tool *or* shows its Settings toggle (it can't spawn Python there). From source/Docker: unchanged, still off by default.

## Robustness (the deeper gap behind the 400)
7. **`ToolCallRepairMiddleware`** — self-heals a thread left with a dangling tool_call (a hung tool + a follow-up message, an interrupted turn, a dropped stream) that otherwise 400s every later turn. Drops the unanswered call from history before the model call. **No-op on a healthy history**, so it never touches a normal turn. 4 unit tests + graph-build smoke.

## Verification
- New/updated unit tests green (isColdStart, tool_call_repair, execute_code); config goldens green; tsc/build green; inset measured in a render.
- The desktop-specific behaviors (boot race, traffic-light inset, frozen execute_code) are best-effort locally — fully exercised only in a built dmg / live boot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)