### PR TITLE
chore: release v0.35.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.35.3] - 2026-06-12
+
 ### Changed
 - **Identity panel: the "Saving writes SOUL.md…" helper + save status now sit
   ABOVE the SOUL.md editor** (next to the Save button), instead of trailing under

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.35.2"
+version = "0.35.3"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.35.3",
+    "date": "2026-06-12",
+    "changes": [
+      "**Identity panel: the \"Saving writes SOUL.md…\" helper + save status now sit",
+      "Desktop first-run: panels no longer flash \"Load failed\" and need a reload.",
+      "macOS desktop: the brand again clears the native traffic lights."
+    ]
+  },
+  {
     "version": "v0.35.2",
     "date": "2026-06-12",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.35.3`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.35.3 -m 'Release v0.35.3' && git push origin v0.35.3`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).