### PR TITLE
fix: land execute_code + tool_call-repair fixes stranded off #938 (for v0.35.3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Identity panel: the "Saving writes SOUL.md…" helper + save status now sit
   ABOVE the SOUL.md editor** (next to the Save button), instead of trailing under
   it — so the editor runs to the panel bottom without a footer of helper text.
+- **`execute_code` is hidden and disabled in the desktop app**, and its Settings
+  helper text was rewritten. It can't run in the packaged build (no standalone
+  Python interpreter to spawn), so the frozen sidecar no longer offers the tool to
+  the model *or* shows its toggle. The helper text also now states plainly that the
+  subprocess is "isolation, not a true sandbox" (the old text oversold it). From
+  source / Docker: unchanged, still off by default.
 
 ### Fixed
 - **Desktop first-run: panels no longer flash "Load failed" and need a reload.**
@@ -32,6 +38,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   old selector, so the 84px inset silently stopped applying and the window's
   traffic-light buttons crowded the logo. Pointed the `.is-tauri-mac` inset at
   `.app-topbar`.
+- **`execute_code` no longer poisons a chat thread in the desktop app.** It spawns
+  `sys.executable -u <script>`, but in the frozen build that's the server binary,
+  not Python — so the spawn hung and the model's tool call never got a result,
+  leaving a dangling `tool_calls` message that 400'd every later turn
+  (`insufficient tool messages following tool_calls`). `run_code` now returns a
+  clean error in a frozen build instead of the broken spawn.
+- **The agent self-heals a chat thread left with a dangling tool_call.** Any turn
+  that persists an assistant `tool_calls` message whose result never landed (a
+  hung tool + a follow-up message, an interrupted/crashed turn, a dropped stream)
+  used to 400 *every* later turn until the chat was deleted. A new
+  `ToolCallRepairMiddleware` drops the unanswered tool_call from the history before
+  each model call so the request is valid again — a no-op on a healthy history, so
+  it never touches a normal turn.
 
 ## [0.35.2] - 2026-06-12
 

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -21,6 +21,14 @@ from tools.lg_tools import get_all_tools
 def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_index=None, extra_middleware=None):
     middleware = []
 
+    # Self-heal a thread left with a dangling tool_call (a tool that hung while
+    # the user sent the next message, an interrupted turn, …) before anything
+    # else touches the history — otherwise the provider 400s every later turn
+    # ("insufficient tool messages following tool_calls"). No-op on a healthy
+    # history, so it never affects a normal turn.
+    from graph.middleware.tool_call_repair import ToolCallRepairMiddleware
+    middleware.append(ToolCallRepairMiddleware())
+
     # Prompt caching + knowledge-context delivery (wrap_model_call). Added
     # first/outermost so the cache breakpoint lands on the stable system
     # prefix; KnowledgeMiddleware's context is delivered just after it.
@@ -541,9 +549,21 @@ def create_agent_graph(
 
     # Programmatic tool calling — opt-in. Built last so it can wrap every
     # other tool (including task/task_batch) but never itself.
+    # Not in the frozen desktop build: it spawns a Python subprocess, but the
+    # PyInstaller binary has no standalone interpreter (sys.executable is the
+    # server itself). Don't even offer it to the model there — the Settings
+    # toggle is hidden too (graph.settings_schema.build_schema). From source /
+    # Docker it works normally.
     if config.execute_code_enabled:
-        from tools.execute_code import build_execute_code_tool
-        all_tools.append(build_execute_code_tool(all_tools, config=config))
+        import sys as _sys
+        if getattr(_sys, "frozen", False):
+            logging.getLogger(__name__).warning(
+                "execute_code is enabled but unavailable in the packaged desktop build "
+                "(no standalone Python interpreter) — not loading the tool."
+            )
+        else:
+            from tools.execute_code import build_execute_code_tool
+            all_tools.append(build_execute_code_tool(all_tools, config=config))
 
     # Deferred tools (ADR 0005 #3) — opt-in progressive disclosure. The
     # search_tools meta-tool is built over the full set (so it can surface any

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -555,6 +555,7 @@ def create_agent_graph(
     # toggle is hidden too (graph.settings_schema.build_schema). From source /
     # Docker it works normally.
     if config.execute_code_enabled:
+        import logging
         import sys as _sys
         if getattr(_sys, "frozen", False):
             logging.getLogger(__name__).warning(

--- a/graph/middleware/tool_call_repair.py
+++ b/graph/middleware/tool_call_repair.py
@@ -1,0 +1,69 @@
+"""Repair a chat thread left with a dangling tool_call, before the model runs.
+
+A turn can persist an assistant message whose ``tool_calls`` were never answered:
+a tool that hung while the user sent the next message, an interrupted/crashed
+turn, a stream that dropped the tool result. The provider then rejects EVERY
+later turn in that thread:
+
+    An assistant message with 'tool_calls' must be followed by tool messages
+    responding to each 'tool_call_id'. (insufficient tool messages …)  -> HTTP 400
+
+so the chat is permanently bricked until it's deleted. This middleware makes the
+agent self-heal: before each model call it scans the history and, for any
+tool_call that has no matching ``ToolMessage``, drops that dangling call from its
+assistant message (replacing the message in place by id) so the request is valid
+again. Already-answered calls and message text are preserved.
+
+It is a **no-op on a healthy history** — ``before_model`` returns ``None`` unless
+there is an actual orphan — so it can never alter a normal turn; it only ever
+touches a thread that would otherwise 400.
+"""
+
+from __future__ import annotations
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import AIMessage, ToolMessage
+
+
+def _tc_id(tc) -> str | None:
+    return tc.get("id") if isinstance(tc, dict) else getattr(tc, "id", None)
+
+
+def repair_messages(messages: list) -> list:
+    """Return replacement messages (same ids) for any assistant message that
+    carries an unanswered tool_call. Empty list ⇒ nothing to repair."""
+    answered = {
+        m.tool_call_id
+        for m in messages
+        if isinstance(m, ToolMessage) and getattr(m, "tool_call_id", None)
+    }
+    repairs: list = []
+    for m in messages:
+        tool_calls = getattr(m, "tool_calls", None) or []
+        if not tool_calls:
+            continue
+        kept = [tc for tc in tool_calls if _tc_id(tc) in answered]
+        if len(kept) == len(tool_calls):
+            continue  # every call answered — fine
+        # Drop the dangling call(s); keep the answered ones + the message text.
+        content = m.content if isinstance(m.content, str) else ""
+        if not kept and not content:
+            content = "[tool call abandoned — no result was produced]"
+        repairs.append(m.model_copy(update={"tool_calls": kept, "content": content}))
+    return repairs
+
+
+class ToolCallRepairMiddleware(AgentMiddleware):
+    """Drop unanswered tool_calls from history before the model call (self-heal a
+    thread that would otherwise 400 forever). No-op on a healthy history."""
+
+    def _repair(self, state):
+        messages = state.get("messages") or []
+        repairs = repair_messages(messages)
+        return {"messages": repairs} if repairs else None
+
+    def before_model(self, state, runtime):  # type: ignore[override]
+        return self._repair(state)
+
+    async def abefore_model(self, state, runtime):  # type: ignore[override]
+        return self._repair(state)

--- a/graph/middleware/tool_call_repair.py
+++ b/graph/middleware/tool_call_repair.py
@@ -22,7 +22,7 @@ touches a thread that would otherwise 400.
 from __future__ import annotations
 
 from langchain.agents.middleware import AgentMiddleware
-from langchain_core.messages import AIMessage, ToolMessage
+from langchain_core.messages import ToolMessage
 
 
 def _tc_id(tc) -> str | None:

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -89,9 +89,12 @@ FIELDS: list[Field] = [
 
     # ── Programmatic tool calling ────────────────────────────────────────────
     Field("execute_code.enabled", "execute_code_enabled", "Enable execute_code", "bool", "Tools",
-          "Lets the model run one Python script composing many tools. SECURITY: runs "
-          "model-authored code in a sandboxed subprocess — only enable for trusted "
-          "models or in a hardened container."),
+          "The model writes ONE Python script that calls several of its tools and returns "
+          "just the result — collapsing a long think→call→read tool chain into a single "
+          "turn. SECURITY: runs model-written code in a subprocess (its env scrubbed of "
+          "secrets + a hard timeout). That's isolation, NOT a true sandbox — the script "
+          "can still reach the disk/network as the server user, so enable it only for a "
+          "trusted model or inside a hardened container."),
     Field("execute_code.timeout", "execute_code_timeout", "Script timeout (s)", "number", "Tools",
           minimum=1),
 
@@ -340,9 +343,17 @@ def build_schema(
 
     Secrets report ``value: ""`` plus ``is_set`` rather than echoing the secret.
     """
+    import sys as _sys
+    # In the frozen desktop build execute_code can't run (no standalone Python to
+    # spawn — see graph.agent), so hide its toggle entirely rather than offer a
+    # setting that does nothing. From source / Docker it shows as normal.
+    _frozen = getattr(_sys, "frozen", False)
+
     defaults = type(config)()
     groups: dict[str, dict[str, Any]] = {}
     for f in FIELDS:
+        if _frozen and f.key.startswith("execute_code"):
+            continue
         current = getattr(config, f.attr, None)
         entry: dict[str, Any] = {
             "key": f.key,

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -96,7 +96,12 @@ def test_config_wires_middleware():
     from graph.config import LangGraphConfig
     from graph.agent import _build_middleware
     mw = _build_middleware(LangGraphConfig(), knowledge_store=None)
-    assert mw[0].__class__.__name__ == "PromptCacheMiddleware"
+    names = [m.__class__.__name__ for m in mw]
+    # ToolCallRepairMiddleware runs first — heal a dangling-tool_call history before
+    # anything else touches it; PromptCacheMiddleware stays the outermost *model*
+    # wrapper (repair only has before_model hooks, so the cache breakpoint is intact).
+    assert names[0] == "ToolCallRepairMiddleware"
+    assert names[1] == "PromptCacheMiddleware"
 
 
 @pytest.mark.asyncio

--- a/tests/test_tool_call_repair.py
+++ b/tests/test_tool_call_repair.py
@@ -1,0 +1,88 @@
+"""Dangling-tool_call repair (graph.middleware.tool_call_repair).
+
+A thread with an assistant tool_call that never got a ToolMessage 400s at the
+provider on every later turn; repair_messages drops the orphan so it's valid.
+"""
+
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+
+from graph.middleware.tool_call_repair import ToolCallRepairMiddleware, repair_messages
+
+
+def _ai(tool_calls, content=""):
+    return AIMessage(content=content, tool_calls=tool_calls)
+
+
+def _call(cid, name="web_search"):
+    return {"name": name, "args": {"q": "x"}, "id": cid, "type": "tool_call"}
+
+
+def test_healthy_history_is_untouched():
+    msgs = [
+        HumanMessage(content="hi"),
+        _ai([_call("c1")]),
+        ToolMessage(content="result", tool_call_id="c1"),
+        AIMessage(content="done"),
+    ]
+    assert repair_messages(msgs) == []  # nothing to repair
+    assert ToolCallRepairMiddleware()._repair({"messages": msgs}) is None
+
+
+def test_no_tool_calls_at_all_is_noop():
+    msgs = [HumanMessage(content="hi"), AIMessage(content="hello")]
+    assert repair_messages(msgs) == []
+
+
+def test_dangling_tool_call_is_dropped():
+    orphan = _ai([_call("c1")])  # no ToolMessage answers c1
+    msgs = [HumanMessage(content="smoke test execute_code"), orphan, HumanMessage(content="huh?")]
+    repairs = repair_messages(msgs)
+    assert len(repairs) == 1
+    fixed = repairs[0]
+    assert fixed.id == orphan.id          # replaces the orphan in place (same id)
+    assert fixed.tool_calls == []         # the dangling call is gone
+    assert fixed.content                  # pure-tool_call message gets placeholder text
+
+
+def test_keeps_answered_drops_only_dangling():
+    msgs = [
+        _ai([_call("c1"), _call("c2")], content="calling two"),
+        ToolMessage(content="r1", tool_call_id="c1"),  # c1 answered, c2 dangling
+        HumanMessage(content="next"),
+    ]
+    repairs = repair_messages(msgs)
+    assert len(repairs) == 1
+    kept_ids = [tc["id"] for tc in repairs[0].tool_calls]
+    assert kept_ids == ["c1"]             # answered call kept, dangling c2 dropped
+    assert repairs[0].content == "calling two"
+
+
+def test_repair_applied_through_the_langgraph_reducer():
+    """The integration that actually matters: the middleware returns replacement
+    messages, and LangGraph's `add_messages` reducer (what create_agent uses for
+    the messages key) must REPLACE the orphaned assistant message in place by id —
+    so the merged history the model sees has no dangling tool_call."""
+    from langgraph.graph.message import add_messages
+
+    # Build the history the way the graph does — add_messages assigns ids, which is
+    # what makes the in-place replace work (a message returned with an existing id
+    # REPLACES rather than appends).
+    history = add_messages(
+        [],
+        [HumanMessage(content="smoke test execute_code"), _ai([_call("c1")]), HumanMessage(content="huh?")],
+    )
+    assert all(m.id for m in history)  # state messages always carry ids
+
+    update = ToolCallRepairMiddleware()._repair({"messages": history})
+    assert update is not None
+
+    merged = add_messages(history, update["messages"])
+    # Same count + order — the orphan was REPLACED in place, not appended.
+    assert len(merged) == len(history)
+    ai = [m for m in merged if isinstance(m, AIMessage)]
+    assert len(ai) == 1 and ai[0].tool_calls == []  # the dangling call is gone
+    # Nothing in the merged history is left with an unanswered tool_call.
+    answered = {m.tool_call_id for m in merged if isinstance(m, ToolMessage)}
+    for m in merged:
+        for tc in (getattr(m, "tool_calls", None) or []):
+            assert tc["id"] in answered

--- a/tools/execute_code.py
+++ b/tools/execute_code.py
@@ -139,6 +139,19 @@ async def _connect_write(fd: int):
 
 async def run_code(code: str, tool_map: dict, *, timeout: float = 30.0, truncate: int = 6000) -> str:
     """Run ``code`` in a child process with a tool-RPC bridge; return its stdout."""
+    if getattr(sys, "frozen", False):
+        # In a PyInstaller build (the desktop app) ``sys.executable`` is the frozen
+        # server binary, NOT a Python interpreter — ``<binary> -u <script>`` would
+        # relaunch the server, not run the script. There's no standalone Python to
+        # spawn. Refuse cleanly with a tool RESULT (so the tool_call is answered and
+        # the thread can't be left with a dangling tool_call that 400s every later
+        # turn) rather than attempting the broken spawn.
+        return (
+            "Error: execute_code is unavailable in the packaged desktop app — it needs a "
+            "standalone Python interpreter to spawn, which the frozen build doesn't ship. "
+            "Run protoAgent from source or in Docker to use it, or turn it off under "
+            "Settings ▸ Tools ▸ Enable execute_code."
+        )
     path = _build_runner_file(code)
     # Pipes: child writes requests on req_w; parent writes responses on resp_w.
     req_r, req_w = os.pipe()


### PR DESCRIPTION
#938 auto-merged with only the first 3 first-run fixes; the execute_code guard / hide+disable / helper-text and the `ToolCallRepairMiddleware` were pushed to the branch **after** it had merged, so they never reached main — the v0.35.3 build (built from main) shipped without them. Caught by verifying the actual v0.35.3 dmg (execute_code still in its settings schema). This lands them before v0.35.3 publishes. Tests green (repair incl. the add_messages reducer integration; execute_code; config; changelog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)