### PR TITLE
fix(console): trim the macOS traffic-light inset (84px → 60px)

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -125,7 +125,7 @@
    NB: the brand bar is `.app-topbar` (App.tsx) — a rename left this rule on the
    old `.topbar`, so the inset silently stopped clearing the lights. */
 .app-shell.is-tauri-mac .app-topbar {
-  padding-left: 84px;
+  padding-left: 60px;
 }
 
 /* The splash → app hand-off cross-fade (default root view transition); a touch


### PR DESCRIPTION
84px cleared the native traffic lights but left too wide a gap before the brand; 60px sits the logo right after them (dialed in live on the desktop app). One-line CSS change — rides the next release, not worth its own publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)