### PR TITLE
chore(console): bump @protolabsai/ui 0.26.2 → 0.29.0 + adopt segmented Tabs (protoContent#218)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Design system bumped `@protolabsai/ui` 0.26.2 → 0.29.0 (+ `@protolabsai/design` 0.5.1).**
+  Brings the OS-adaptive light theme + 10 builtin theme presets (Theme panel picks them
+  up automatically), two token fixes splash.css silently depended on (`--pl-space-5`,
+  `--pl-font-weight-semibold`), and the new `@protolabsai/ui/ai` chat module (not yet
+  adopted). The settings **Host / App | Workspace** home toggle and the MCP add-server
+  **Form | Paste JSON** toggle now use the DS `Tabs variant="segmented"` pill control
+  (our protoContent#218 request, shipped in 0.28) — retiring the stacked-tabs interim
+  and the last hand-rolled `.segmented` CSS.
+
 ### Added
 - **ADR 0049 — bundle pin lifecycle**: a bundle pin means *"last verified working"* —
   pin release **tags** (not raw SHAs), record `verified_against:` (core version), and

--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -7,7 +7,7 @@ import { expect, test } from "@playwright/test";
 async function openIntegrations(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Plugins", exact: true }).click();
 }
 

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -6,7 +6,7 @@ import { expect, test } from "@playwright/test";
 test("MCP tab lists servers and adds one inline", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.getByRole("tab", { name: "MCP", exact: true }).click();
 
   await expect(page.getByRole("heading", { name: "MCP servers" })).toBeVisible();
@@ -23,7 +23,7 @@ test("MCP tab lists servers and adds one inline", async ({ page }) => {
 test("MCP tab imports servers from pasted JSON", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.getByRole("tab", { name: "MCP", exact: true }).click();
 
   await page.getByRole("button", { name: /Add server/ }).click();

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -49,7 +49,7 @@ test("beads tab in the right sidebar lists issues (query-backed)", async ({ page
 test("workspace settings: identity lands, then tools and MCP sections", async ({ page }) => {
   // The agent makeup folded into Settings ▸ Workspace (ADR 0048 S-C).
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible(); // landing section
   await expect(page.getByTestId("identity-name")).toBeVisible();
 

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -6,7 +6,7 @@ import { expect, test } from "@playwright/test";
 test("Agent → Skills lists pinned + learned skills and supports search", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
 
   const surface = page.getByTestId("playbooks-surface");
@@ -27,7 +27,7 @@ test("Agent → Skills lists pinned + learned skills and supports search", async
 test("layered skills show tier badges and promote a private skill to the commons", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
@@ -48,7 +48,7 @@ test("layered skills show tier badges and promote a private skill to the commons
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -9,9 +9,9 @@ test("the topbar gear opens the Settings overlay (the two-home one-stop-shop)", 
   await page.getByTestId("topbar-settings").click();
   const dialog = page.getByRole("dialog", { name: "Settings" });
   await expect(dialog).toBeVisible();
-  // The same two scope homes render inside the overlay.
-  await expect(dialog.getByRole("tab", { name: "Host / App", exact: true })).toBeVisible();
-  await expect(dialog.getByRole("tab", { name: "Workspace", exact: true })).toBeVisible();
+  // The same two scope homes render inside the overlay (the segmented toggle).
+  await expect(dialog.getByRole("button", { name: "Host / App", exact: true })).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Workspace", exact: true })).toBeVisible();
 });
 
 test("the chat composer model chip edits a field in a dialog and saves", async ({ page }) => {

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -11,8 +11,14 @@ async function openSettings(page) {
   await page.getByRole("button", { name: "Settings", exact: true }).click();
 }
 
-// Click a home (row 1) or a section (row 2) — names are unique across both strips.
+// Click a home (row 1 — the segmented scope toggle, role=button) or a section
+// (row 2 — a real tablist) — names are unique across both strips.
 async function tab(page, name) {
+  const home = page.locator(".pl-tabs--segmented").getByRole("button", { name, exact: true });
+  if (await home.count()) {
+    await home.click();
+    return;
+  }
   await page.locator(".pl-tabs").getByRole("tab", { name, exact: true }).click();
 }
 
@@ -55,7 +61,7 @@ test("Settings is a two-home shell (Host / App · Workspace)", async ({ page }) 
 test("Workspace ▸ Settings shows the agent's Model + Routing fields", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
   // Model + Routing render here (the agent makeup folded into Workspace, ADR 0048).
   await expect(page.locator(".settings-group-title").first()).toBeVisible(); // wait for the suspense load
@@ -69,7 +75,7 @@ test("Workspace ▸ Settings shows the agent's Model + Routing fields", async ({
 test("editing an Agent setting enables save and round-trips", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
   const save = page.getByRole("button", { name: /Save & apply/ });
   await expect(save).toBeDisabled();
@@ -93,7 +99,7 @@ test("a restart-flagged System field shows the restart banner", async ({ page })
 test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-tabs").getByRole("tab", { name: "Settings", exact: true }).click();
   await expect(page.locator(".settings-group-title").first()).toBeVisible();
   // model.name inherits from the host layer.

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -15,8 +15,8 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "@protolabsai/design": "^0.5.0",
-    "@protolabsai/ui": "^0.26.2",
+    "@protolabsai/design": "^0.5.1",
+    "@protolabsai/ui": "^0.29.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/McpPanel.tsx
+++ b/apps/web/src/app/McpPanel.tsx
@@ -4,7 +4,7 @@ import { QueryErrorResetBoundary, useMutation, useQueryClient, useSuspenseQuery 
 import { Suspense, useState } from "react";
 import { Loader2, Plus, Trash2 } from "lucide-react";
 
-import { PanelHeader } from "@protolabsai/ui/navigation";
+import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
 import { runtimeStatusQuery } from "../lib/queries";
 import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
 import { StatusPill } from "./StatusPill";
@@ -67,9 +67,17 @@ function AddServerForm({ onDone }: { onDone: (msg: string) => void }) {
         else if (formValid) add.mutate();
       }}
     >
-      <div className="segmented mcp-add-modes">
-        <button type="button" className={mode === "form" ? "active" : ""} onClick={() => setMode("form")}>Form</button>
-        <button type="button" className={mode === "json" ? "active" : ""} onClick={() => setMode("json")}>Paste JSON</button>
+      <div className="mcp-add-modes">
+        <Tabs
+          variant="segmented"
+          ariaLabel="Add-server input mode"
+          active={mode}
+          onSelect={(t) => setMode(t as "form" | "json")}
+          items={[
+            { id: "form", label: "Form" },
+            { id: "json", label: "Paste JSON" },
+          ]}
+        />
       </div>
 
       {mode === "json" ? (

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -841,52 +841,6 @@ textarea {
   font-size: 13px;
 }
 
-/* The right-panel tab control (Notes / Beads / Goals — the agent's working
-   memory). The per-project selector + manual refresh were removed: notes/beads
-   are agent-global, and the project/allowed-dirs list is purely the filesystem
-   fence. */
-.segmented {
-  height: 34px;
-  display: grid;
-  /* Equal-width columns for any number of tabs (2, 3, …) — avoids overflow
-     when a tab is added. (Pattern shared with pwnDeck's right panel.) */
-  grid-auto-flow: column;
-  grid-auto-columns: 1fr;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  overflow: hidden;
-}
-
-.segmented button {
-  position: relative; /* anchor for an absolutely-positioned tab badge */
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  gap: 6px;
-  min-width: 0;
-  padding: 0 4px;
-  font-size: 12px;
-  white-space: nowrap;
-  border: 0;
-  border-right: 1px solid var(--border);
-  background: transparent;
-  color: var(--fg-muted);
-  cursor: pointer;
-}
-
-.segmented button svg {
-  flex: 0 0 auto;
-}
-
-.segmented button:last-child {
-  border-right: 0;
-}
-
-.segmented button.active {
-  background: var(--bg-hover);
-  color: var(--fg);
-}
-
 .notes-editor {
   height: 100%;
   border: 0;

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -104,11 +104,9 @@ export function SettingsSurface() {
 
   return (
     <>
-      {/* The scope home toggle. INTERIM: stacked over the section Tabs because the DS
-          has no segmented control yet — adopt `Tabs variant="segmented"` / SegmentedControl
-          when protoContent#218 ships. */}
       <Tabs
-        responsive
+        variant="segmented"
+        ariaLabel="Settings scope"
         active={scope}
         onSelect={(t) => selectHome(t as SettingsScope)}
         items={tabItems(SETTINGS_HOMES)}

--- a/docs/design/ui-component-audit.md
+++ b/docs/design/ui-component-audit.md
@@ -148,7 +148,7 @@ Stack decision (UI team, on #137): **Radix for hard interactive primitives (Menu
 
 | # | Request | Priority | Status |
 |---|---|---|---|
-| [#218](https://github.com/protoLabsAI/protoContent/issues/218) | `Tabs` `segmented` variant / `SegmentedControl` (two-level nav scope toggle) | P2 | Filed 2026-06-11 — was only spec'd on the closed #137; now an actionable child. **Interim:** the settings **Host / App \| Workspace** home toggle stacks a second `<Tabs>` row (`SettingsSurface.tsx`) — retire on adoption. |
+| [#218](https://github.com/protoLabsAI/protoContent/issues/218) | `Tabs` `segmented` variant / `SegmentedControl` (two-level nav scope toggle) | P2 | **Shipped in ui 0.28.0, adopted 2026-06-12** — the settings **Host / App \| Workspace** home toggle (`SettingsSurface.tsx`) and the MCP add-server **Form \| Paste JSON** toggle (`McpPanel.tsx`, the last `.segmented` hand-roll) both use `<Tabs variant="segmented">`; the local `.segmented` CSS block is deleted. |
 
 ## Console adoption status (branch `ds-adoption-sweep`, 2026-06-09)
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,8 +28,8 @@
       "name": "@protoagent/web",
       "version": "0.1.0",
       "dependencies": {
-        "@protolabsai/design": "^0.5.0",
-        "@protolabsai/ui": "^0.26.2",
+        "@protolabsai/design": "^0.5.1",
+        "@protolabsai/ui": "^0.29.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -59,24 +59,24 @@
       }
     },
     "apps/web/node_modules/@protolabsai/design": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.5.0.tgz",
-      "integrity": "sha512-2ZgOlfcdvDaibvase8Vb+B2/L+cKaeTfCeT72vQepZB/e35dwHy2v9u8dofyI2nVDPDrCkL1e+Uy+vRBcHRnuQ==",
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.5.1.tgz",
+      "integrity": "sha512-vffDv6H527tZXyfie41OM1nxIr3AoyCuvL8r+YxTIWczPjaI0EVHbJTE63IASoTsstAyBIETZeMQsTnhvYM9Qg==",
       "license": "MIT",
       "bin": {
         "protolabs-sync-assets": "bin/sync-assets.mjs"
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.26.2",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.26.2.tgz",
-      "integrity": "sha512-+dWUUTOHqfiDliAlMloEWFhUnhSOs0hNuNAVPYr/Xs3EZES6usY6wCRnTjhA7OrOu16sd7ZKp7o6xKZqvqOmdw==",
+      "version": "0.29.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.29.0.tgz",
+      "integrity": "sha512-XRofcLMCQXB+FVGQcrLKH1frqUs/kgQJpOdFFV8UWiZA9V/Yt5//Wb59/zRg0pJvMNgV/c7qMhrPJE2CrZicFg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",
         "@dnd-kit/sortable": "^10.0.0",
         "@dnd-kit/utilities": "^3.2.2",
-        "@protolabsai/design": "0.5.0",
+        "@protolabsai/design": "0.5.1",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@radix-ui/react-popover": "^1.1.16",
         "@types/react": "^19.0.0",


### PR DESCRIPTION
## What

DS catch-up — all three minors landed on protoContent 2026-06-11, the day after our last bump:

- **0.27** — OS-adaptive light theme + 10 `BUILTIN_PRESETS` (the Theme panel uses the DS `ThemePanel`, so the new presets surface automatically). `@protolabsai/design` 0.5.1 defines `--pl-space-5` and `--pl-font-weight-semibold`, which `splash.css` referenced **undefined** until now.
- **0.28** — `Tabs variant="segmented"`: **our protoContent#218 request, shipped.** Adopted in both consumers:
  - the Settings **Host / App | Workspace** home toggle (`SettingsSurface.tsx`) — retires the stacked-two-tab-rows interim from the ADR 0048 fold; the scope toggle is now a visually distinct pill control above the section tablist (overlay gets it free — it reuses the surface);
  - the MCP add-server **Form | Paste JSON** toggle (`McpPanel.tsx`) — retires the last hand-rolled `.segmented` control + its CSS block in `theme.css` (−45 lines).
- **0.29** — new `@protolabsai/ui/ai` chat module (`Conversation`/`Message`/`StreamingCursor`/`Reasoning`/`CodeBlock`/`ToolCall`/`PromptInput`/`Suggestion`). **Available, not adopted here** — it's the foundation for the deferred generative-UI/chat-surface work.

## e2e locator updates

The segmented control is deliberately `role=group` + `aria-pressed` buttons, not `tablist`/`tab` (it's a mode toggle, not section nav). Home-toggle locators move from `getByRole("tab")` to `.pl-tabs--segmented >> getByRole("button")`; `settings.spec.ts`'s `tab()` helper handles both strips.

## Verification

- `tsc` ×2 + vite build green; 45/45 unit; **92/92 e2e** (11s).
- Local visual check: screenshots of both the full Settings surface and the topbar-gear overlay confirm the pill toggle renders distinctly above the section tabs.

`docs/design/ui-component-audit.md` § Filed upstream updated (#218 → shipped + adopted) per the DS contribute-back loop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)