### PR TITLE
fix(plugins): force re-install over a live router flags the restart it needs (#942)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   agent spawned from the archetype.
 
 ### Fixed
+- **Force re-install no longer claims a live hot-mount it can't deliver (#942).**
+  Re-installing a plugin whose router is already mounted re-registers the router on
+  reload, but FastAPI can't swap a mounted router in place — the fresh routes keep
+  serving the OLD code until a restart, while `POST /api/plugins/install` answered
+  `restart_recommended: false` (hardcoded). The install route now reads the live
+  mount registry (which survives a disable, unlike plugin meta) and flags the
+  restart honestly, and it purges the re-installed plugin's module subtree before
+  the reload (parity with the update route) so a multi-file plugin's tools run the
+  fresh checkout. The update route's restart heuristic also gained the
+  mount-registry check for the disabled-but-still-mounted case.
 - **Annotated-tag pins no longer report a permanent false "Update available".**
   `git ls-remote <url> <tag>` returns the *tag object* SHA for an annotated tag —
   never equal to the lock's commit SHA — so tag-pinned plugins (e.g. `artifact@v0.2.1`)

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -17,6 +17,11 @@ DISABLE is the residual restart case: FastAPI has no route-removal API, so a
 disabled plugin's view/route lingers on the live app until a process restart
 (documented in ``_mount_plugin_routers``). We flag ``restart_recommended`` only
 when disabling a plugin that contributed a view/route/surface.
+
+FORCE RE-INSTALL (and UPDATE, which is a force re-install at the recorded ref) is
+the other residual case (#942): the reload re-registers the plugin's router, but the
+mount keeps the FIRST one (FastAPI can't swap in place) — the freshly installed
+routes don't serve until a process restart, so both routes flag it.
 """
 
 from __future__ import annotations
@@ -58,6 +63,45 @@ def _enabled_ids_from_summary(summary: dict) -> list[str]:
         return suggested or members
     pid = summary.get("id")
     return [str(pid)] if pid else []
+
+
+def _installed_ids_from_summary(summary: dict) -> list[str]:
+    """The plugin id(s) whose CODE this install just placed on disk — for a bundle,
+    its fetched members only (``builtin`` members aren't fetched, so they can't have
+    been replaced under a live mount)."""
+    if "bundle" in summary:
+        return [str(s["id"]) for s in (summary.get("installed") or []) if s.get("id")]
+    pid = summary.get("id")
+    return [str(pid)] if pid else []
+
+
+def _has_surface(meta: dict | None) -> bool:
+    """True when the plugin contributed a view / router / background surface — the
+    contributions FastAPI can't unmount or swap in place (restart territory)."""
+    return bool(meta and (meta.get("views") or meta.get("routers") or meta.get("surfaces")))
+
+
+def _mounted_router_ids() -> set[str]:
+    """Plugin ids with a router currently mounted on the live app. This is the mount
+    ground truth (``_mount_plugin_routers``'s registry) — unlike ``plugin_meta`` it
+    survives a disable, whose router lingers mounted with no meta entry."""
+    keys = getattr(STATE, "plugin_router_keys", None) or set()
+    return {pid for (pid, _prefix) in keys}
+
+
+def _purge_plugin_modules(plugin_id: str) -> None:
+    """Drop a plugin's module subtree from ``sys.modules`` so the next reload
+    re-execs every file from disk. The loader re-execs the entry ``__init__`` each
+    reload, but a multi-file plugin's ``from .tools import …`` resolves the SUBMODULE
+    through ``sys.modules`` — which still holds the OLD code after a force
+    re-install. Scoped to the plugin's own prefix; the reload rebuilds it."""
+    import sys
+
+    from graph.plugins.loader import _plugin_module_name
+
+    prefix = _plugin_module_name(plugin_id)
+    for name in [n for n in list(sys.modules) if n == prefix or n.startswith(prefix + ".")]:
+        sys.modules.pop(name, None)
 
 
 def register_plugin_routes(app) -> None:
@@ -107,6 +151,23 @@ def register_plugin_routes(app) -> None:
         # NO separate enable step and NO restart (the router hot-mounts, #822). Opt out
         # with PROTOAGENT_PLUGIN_INSTALL_NO_ENABLE=1 (back to strict install ≠ enable).
         ids = _enabled_ids_from_summary(summary)
+        # Snapshot BEFORE the reload: which just-(re)installed plugins were already
+        # LIVE — a mounted router (mount registry; survives disable) or a loaded
+        # view/router/surface (meta). For those, the reload can't deliver the fresh
+        # routes: the re-registered router is dropped in favour of the mounted one
+        # (FastAPI can't swap in place), so the OLD code keeps serving (#942).
+        fresh = _installed_ids_from_summary(summary)
+        mounted = _mounted_router_ids()
+        prev_meta = {p.get("id"): p for p in (STATE.plugin_meta or [])}
+        stale_after_reload = [
+            pid for pid in fresh if pid in mounted or _has_surface(prev_meta.get(pid))
+        ]
+        # Same parity for code the reload CAN swap: drop each re-installed plugin's
+        # module subtree so tools/middleware re-exec from the fresh checkout (the
+        # update route's multi-file fix; a first install is a no-op here).
+        for pid in fresh:
+            _purge_plugin_modules(pid)
+
         enabled_now: list[str] = []
         reloaded = False
         enable_error: str | None = None
@@ -134,7 +195,9 @@ def register_plugin_routes(app) -> None:
             "installed": summary,
             "enabled": enabled_now,        # the ids now live
             "reloaded": reloaded,
-            "restart_recommended": False,  # enable hot-mounts the router/view (#822)
+            # A FIRST install hot-mounts fully live (#822); a force re-install over a
+            # live router serves stale routes until restart (#942).
+            "restart_recommended": bool(stale_after_reload),
             "enable_error": enable_error,
         }
 
@@ -174,9 +237,6 @@ def register_plugin_routes(app) -> None:
         # Enabling hot-mounts the router that serves the view (#822) — fully live, no
         # restart. Only DISABLE leaves a stale route behind (no FastAPI unmount), so we
         # recommend a restart when turning OFF a plugin that contributed a view/route/surface.
-        def _has_surface(m: dict | None) -> bool:
-            return bool(m and (m.get("views") or m.get("routers") or m.get("surfaces")))
-
         restart = bool(not want and _has_surface(prev_meta))
         return {"ok": True, "enabled": want, "reloaded": True, "restart_recommended": restart}
 
@@ -226,23 +286,9 @@ def register_plugin_routes(app) -> None:
         reloaded = False
         if is_enabled:
             # Force a genuinely fresh import of the just-pulled code before the
-            # reload. The loader re-execs a plugin's entry __init__ from disk every
-            # reload, but a multi-file plugin's `from .tools import …` resolves the
-            # SUBMODULE through sys.modules — which still holds the OLD code after a
-            # force re-install. Drop this plugin's whole module subtree so the reload
-            # re-execs every file from disk (scoped to its own prefix; the reload
-            # rebuilds it). This is what makes UPDATE deliver fresh code where the
-            # enable path's hot-mount alone wouldn't for a multi-file plugin.
-            import sys
-
-            from graph.plugins.loader import _plugin_module_name
-
-            _mod_prefix = _plugin_module_name(plugin_id)
-            for _name in [
-                n for n in list(sys.modules)
-                if n == _mod_prefix or n.startswith(_mod_prefix + ".")
-            ]:
-                sys.modules.pop(_name, None)
+            # reload — what makes UPDATE deliver fresh code for a multi-file plugin
+            # where the enable path's hot-mount alone wouldn't.
+            _purge_plugin_modules(plugin_id)
 
             # Reload through the enable route's path so the freshly pulled code
             # hot-mounts (router re-mount, tools/middleware/MCP rebuild — #822).
@@ -258,18 +304,17 @@ def register_plugin_routes(app) -> None:
             reloaded = True
 
         # FastAPI can't swap an already-mounted router in place, so a view/route-
-        # contributing plugin's OLD route lingers until a process restart — flag it
-        # (mirrors the enable route's surface heuristic).
-        def _has_surface(m: dict | None) -> bool:
-            return bool(m and (m.get("views") or m.get("routers") or m.get("surfaces")))
-
+        # contributing plugin's OLD route lingers until a process restart — flag it.
+        # The mount registry catches the disabled-but-still-mounted case meta misses.
         return {
             "ok": True,
             "id": plugin_id,
             "version": summary.get("version"),
             "resolved_sha": summary.get("resolved_sha"),
             "reloaded": reloaded,
-            "restart_recommended": bool(_has_surface(meta)),
+            "restart_recommended": bool(
+                _has_surface(meta) or plugin_id in _mounted_router_ids()
+            ),
         }
 
     @app.delete("/api/plugins/{plugin_id}")

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1089,6 +1089,11 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     else:
         new_graph = None
         new_inbox_store = None
+        # Setup pending → no graph build, so no middleware was resolved. Without
+        # this, the commit below raises UnboundLocalError and EVERY pre-setup
+        # reload 500s (e.g. installing a plugin during the wizard, whose
+        # auto-enable reloads through here).
+        new_middleware = []
 
     # Commit: config → A2A bearer → graph. All three reference the
     # same ``new_config`` so they stay consistent.

--- a/tests/test_plugin_routes.py
+++ b/tests/test_plugin_routes.py
@@ -15,8 +15,12 @@ def _client():
     return TestClient(app)
 
 
-def _wire(monkeypatch, *, enabled, disabled, meta):
-    """Fake the hot-reload apply + STATE; return a dict that captures the config patch."""
+def _wire(monkeypatch, *, enabled, disabled, meta, router_keys=()):
+    """Fake the hot-reload apply + STATE; return a dict that captures the config patch.
+
+    ``router_keys`` seeds the live-mount registry (``STATE.plugin_router_keys``,
+    ``{(plugin_id, prefix), …}``) — the ground truth for "this plugin's router is
+    already mounted" that the force re-install restart check reads (#942)."""
     captured: dict = {}
     fake = types.ModuleType("server.agent_init")
 
@@ -31,6 +35,7 @@ def _wire(monkeypatch, *, enabled, disabled, meta):
     cfg = types.SimpleNamespace(plugins_enabled=list(enabled), plugins_disabled=list(disabled))
     monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
     monkeypatch.setattr(rs.STATE, "plugin_meta", meta, raising=False)
+    monkeypatch.setattr(rs.STATE, "plugin_router_keys", set(router_keys), raising=False)
     return captured
 
 
@@ -141,3 +146,83 @@ def test_install_succeeds_even_if_enable_reload_fails(monkeypatch):
     assert resp.status_code == 200                            # the install itself didn't 500
     body = resp.json()
     assert body["installed"]["id"] == "demo" and body["enabled"] == [] and "graph compile failed" in body["enable_error"]
+
+
+# ── force re-install over a LIVE plugin can't hot-swap its router (#942) ──────────
+def test_fresh_install_hot_mounts_no_restart(monkeypatch):
+    # First install: nothing mounted yet, the reload hot-mounts the router (#822) —
+    # fully live, no restart. The pre-#942 posture, preserved.
+    from graph.plugins import installer
+    _wire(monkeypatch, enabled=[], disabled=[], meta=[])
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "boardy"})
+    body = _client().post("/api/plugins/install", json={"url": "https://x/boardy"}).json()
+    assert body["reloaded"] is True
+    assert body["restart_recommended"] is False
+
+
+def test_force_reinstall_over_mounted_router_recommends_restart(monkeypatch):
+    # The plugin's router is already mounted → the reload re-registers it and the
+    # mount DROPS the new one (FastAPI can't swap in place) — the fresh routes don't
+    # serve until a process restart. The response must say so, not claim hot-mount.
+    from graph.plugins import installer
+    _wire(monkeypatch, enabled=["boardy"], disabled=[], meta=[],
+          router_keys={("boardy", "/plugins/boardy")})
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "boardy"})
+    body = _client().post("/api/plugins/install", json={"url": "https://x/boardy", "force": True}).json()
+    assert body["reloaded"] is True
+    assert body["restart_recommended"] is True
+
+
+def test_force_reinstall_over_disabled_lingering_router_recommends_restart(monkeypatch):
+    # Disable doesn't unmount, so the router lingers with NO plugin_meta entry —
+    # the mount registry is the signal that survives (the meta check alone misses it).
+    from graph.plugins import installer
+    _wire(monkeypatch, enabled=[], disabled=["boardy"], meta=[],
+          router_keys={("boardy", "/plugins/boardy")})
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "boardy"})
+    body = _client().post("/api/plugins/install", json={"url": "https://x/boardy", "force": True}).json()
+    assert body["restart_recommended"] is True
+
+
+def test_bundle_reinstall_flags_restart_only_for_mounted_members(monkeypatch):
+    # A bundle re-install over one live member + one fresh member → restart (the
+    # live member's routes are stale); builtin members are never fetched → ignored.
+    from graph.plugins import installer
+    _wire(monkeypatch, enabled=["board"], disabled=[], meta=[],
+          router_keys={("board", "/plugins/board")})
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {
+        "bundle": "pm-stack", "installed": [{"id": "board"}, {"id": "browser"}],
+        "enabled": ["board", "browser"]})
+    body = _client().post("/api/plugins/install", json={"url": "https://x/pm-stack", "force": True}).json()
+    assert body["restart_recommended"] is True
+
+
+def test_force_reinstall_purges_module_subtree(monkeypatch):
+    # Parity with the update route: the reload re-execs the entry __init__, but a
+    # multi-file plugin's submodules resolve through sys.modules — purge them so the
+    # fresh checkout is what actually runs.
+    from graph.plugins import installer
+    from graph.plugins.loader import _plugin_module_name
+    _wire(monkeypatch, enabled=["boardy"], disabled=[], meta=[],
+          router_keys={("boardy", "/plugins/boardy")})
+    monkeypatch.setattr(installer, "install", lambda url, ref=None, **k: {"id": "boardy"})
+    mod = _plugin_module_name("boardy")
+    monkeypatch.setitem(sys.modules, mod, types.ModuleType(mod))
+    monkeypatch.setitem(sys.modules, mod + ".tools", types.ModuleType(mod + ".tools"))
+    _client().post("/api/plugins/install", json={"url": "https://x/boardy", "force": True})
+    assert mod not in sys.modules and (mod + ".tools") not in sys.modules
+
+
+def test_update_route_flags_restart_for_disabled_lingering_router(monkeypatch):
+    # The update route's restart heuristic also reads the mount registry now — a
+    # disabled-but-still-mounted plugin (no meta) updating at its ref needs a restart.
+    from graph.plugins import installer
+    _wire(monkeypatch, enabled=[], disabled=["boardy"], meta=[],
+          router_keys={("boardy", "/plugins/boardy")})
+    monkeypatch.setattr(installer, "list_installed", lambda: [
+        {"id": "boardy", "source_url": "https://x/boardy", "requested_ref": "v1"}])
+    monkeypatch.setattr(installer, "install",
+                        lambda url, ref=None, **k: {"id": "boardy", "version": "2", "resolved_sha": "b" * 40})
+    body = _client().post("/api/plugins/boardy/update").json()
+    assert body["reloaded"] is False                          # disabled → nothing to reload
+    assert body["restart_recommended"] is True


### PR DESCRIPTION
## What

Closes #942 — two halves, both found live during the pm-stack incident remediation:

**1. `POST /api/plugins/install` hardcoded `restart_recommended: false`.** Right for a FIRST install (the reload hot-mounts the router, #822) — wrong for a **force re-install over a mounted router**: the reload re-registers the router, `_mount_plugin_routers` drops the new one at the occupied prefix (FastAPI can't swap in place), and the OLD code keeps serving while the response claims everything is live. The route now snapshots the **mount registry** (`STATE.plugin_router_keys` — the ground truth that *survives a disable*, unlike `plugin_meta`) + previous meta before the reload, and flags the restart honestly. It also **purges the re-installed plugin's module subtree** pre-reload (parity with the update route's multi-file fix) so re-installed tools actually run the fresh checkout. The update route's restart heuristic gains the mount-registry check too (disabled-but-still-mounted case). The triplicated `_has_surface` closure is hoisted to one module-level helper alongside `_mounted_router_ids` / `_purge_plugin_modules`.

**2. Pre-setup reloads 500'd** (found because the smoke ran against a wizard-state host): `_reload_langgraph_agent` only assigns `new_middleware` when setup is complete, but the commit block reads it unconditionally → `UnboundLocalError` on every reload before setup — including the plugin install auto-enable during the wizard. The else branch now resolves it to `[]`.

## Test

- 6 new unit tests (fresh-install stays hot-mount/no-restart; force over mounted router → restart; **disabled-but-still-mounted** → restart, the case meta alone misses; bundle member variant; module-subtree purge; update route over a lingering router). Plugin suites: 57 pass; agent_init-adjacent suites: 49 pass.
- **Live wire smoke** on the running host: force re-install of `artifact` (router mounted) → `{reloaded: true, restart_recommended: true}`; `doom` (mounted via a prior enable) → `true` and its panel serves 200; pre-setup install returns 200 instead of the `UnboundLocalError` 500.

🤖 Generated with [Claude Code](https://claude.com/claude-code)