### PR TITLE
fix(console): root error boundary + chat-session shape validation (#872)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A render error no longer white-screens the console** (#872): a root error
+  boundary around the app shows a full-page recovery card — Reload, plus "Reset
+  chat data & reload" which clears `protoagent.chat.sessions*` (the known way a
+  corrupt blob bricks render) while keeping layout/theme/auth token. Fork-registered
+  chat surfaces (`src/ext`) are boundary-wrapped too, so a throw stays contained in
+  the slot. Persisted chat sessions are now shape-validated on load — invalid
+  members are dropped (the rest survive) instead of throwing later in render.
+
 ### Changed
 - **Design system bumped `@protolabsai/ui` 0.26.2 → 0.29.0 (+ `@protolabsai/design` 0.5.1).**
   Brings the OS-adaptive light theme + 10 builtin theme presets (Theme panel picks them

--- a/apps/web/e2e/resilience.spec.ts
+++ b/apps/web/e2e/resilience.spec.ts
@@ -1,0 +1,67 @@
+import { expect, test } from "@playwright/test";
+
+// Console resilience (#872): corrupt persisted chat state must never white-screen
+// the app. loadPersisted's sanitize pass drops invalid sessions (keeping valid
+// ones) and starts a fresh session when nothing survives; the root error boundary
+// is the backstop for anything else.
+
+test("a corrupt chat-sessions blob boots a fresh chat, not a white screen", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem("protoagent.chat.sessions", "{definitely not json");
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+});
+
+test("invalid session members are dropped while valid sessions survive", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "protoagent.chat.sessions",
+      JSON.stringify({
+        version: 1,
+        currentSessionId: "good",
+        sessions: [
+          {
+            id: "good",
+            title: "Survivor chat",
+            messages: [{ role: "user", content: "hello" }],
+            createdAt: 1,
+            updatedAt: 1,
+          },
+          { id: "shapeless" }, // missing every other field — dropped
+          null, // not even an object — dropped
+        ],
+      }),
+    );
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+  // The valid session survived the sanitize pass…
+  await expect(page.getByRole("tab", { name: "Survivor chat" })).toBeVisible();
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+  // …and the dropped members are gone from storage after the next persist.
+});
+
+test("currentSessionId pointing at a dropped session re-points at a survivor", async ({ page }) => {
+  await page.addInitScript(() => {
+    window.localStorage.setItem(
+      "protoagent.chat.sessions",
+      JSON.stringify({
+        version: 1,
+        currentSessionId: "the-corrupt-one",
+        sessions: [
+          { id: "the-corrupt-one", title: "Broken", messages: [{ role: "user" }], createdAt: 1, updatedAt: 1 },
+          {
+            id: "ok",
+            title: "Still here",
+            messages: [{ role: "user", content: "hi" }],
+            createdAt: 1,
+            updatedAt: 1,
+          },
+        ],
+      }),
+    );
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.getByRole("tab", { name: "Still here" })).toBeVisible();
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+});

--- a/apps/web/src/app/AppCrash.tsx
+++ b/apps/web/src/app/AppCrash.tsx
@@ -1,0 +1,55 @@
+import { Button } from "@protolabsai/ui/primitives";
+import { AlertTriangle, RefreshCw, Trash2 } from "lucide-react";
+
+import "./app-crash.css";
+
+// Full-page fallback for the ROOT error boundary (#872) — a render throw that
+// escapes every panel boundary lands here instead of a white screen. This renders
+// while the app is broken, so it must stay dependency-light: no stores, no
+// queries, no router — any of them may be the thing that threw.
+
+/** Clear the persisted chat sessions (all agents' slug-suffixed keys included) but
+ *  keep layout/theme/authToken — the same selective scope as the tenant guard. A
+ *  corrupt saved session is the known way to brick render (issue #872); everything
+ *  else persisted is cheap to keep. */
+export function resetChatData() {
+  try {
+    const stale: string[] = [];
+    for (let i = 0; i < window.localStorage.length; i++) {
+      const k = window.localStorage.key(i) || "";
+      if (k.startsWith("protoagent.chat.sessions")) stale.push(k);
+    }
+    stale.forEach((k) => window.localStorage.removeItem(k));
+  } catch {
+    // Storage unavailable — reload alone is the best we can do.
+  }
+}
+
+export function AppCrash({ error }: { error: Error }) {
+  return (
+    <div className="app-crash" role="alert">
+      <AlertTriangle size={28} aria-hidden />
+      <h1>The console hit a render error</h1>
+      <p className="app-crash__msg">{error.message}</p>
+      <div className="app-crash__actions">
+        <Button type="button" onClick={() => window.location.reload()}>
+          <RefreshCw size={14} /> Reload
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          onClick={() => {
+            resetChatData();
+            window.location.reload();
+          }}
+        >
+          <Trash2 size={14} /> Reset chat data &amp; reload
+        </Button>
+      </div>
+      <p className="app-crash__hint">
+        Layout, theme and auth token are kept. If reloading loops back here, reset chat
+        data — a corrupt saved session is the usual cause.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/src/app/ChatSlot.tsx
+++ b/apps/web/src/app/ChatSlot.tsx
@@ -2,6 +2,7 @@ import type { PluginView as PluginViewMeta } from "../lib/types";
 
 import { registeredSurfaces } from "../ext";
 import { ChatSurface } from "../chat/ChatSurface";
+import { ErrorBoundary, PanelError } from "./ErrorBoundary";
 import { PluginView } from "./PluginView";
 
 // The chat surface is a SLOT, not a hardcoded panel (ADR 0045). Resolution order:
@@ -30,7 +31,13 @@ export function ChatSlot({
   if (ext) {
     return (
       <div className="chat-slot" style={{ display: active ? "contents" : "none" }}>
-        {ext.render()}
+        {/* Fork-registered surfaces are arbitrary code — a throw must stay contained
+            in the slot, not unmount the app (#872). */}
+        <ErrorBoundary
+          fallback={({ error, reset }) => <PanelError error={error} reset={reset} label="chat surface" />}
+        >
+          {ext.render()}
+        </ErrorBoundary>
       </div>
     );
   }

--- a/apps/web/src/app/app-crash.css
+++ b/apps/web/src/app/app-crash.css
@@ -1,0 +1,47 @@
+/* Full-page fallback for the root error boundary (#872). Token-driven so it follows
+   the operator's theme even while the app proper is broken. */
+
+.app-crash {
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  padding: 24px;
+  text-align: center;
+  background: var(--bg, var(--pl-bg, #0a0a0c));
+  color: var(--fg, var(--pl-fg, #ededed));
+}
+
+.app-crash > svg {
+  color: var(--warning, #d29922);
+}
+
+.app-crash h1 {
+  margin: 0;
+  font-size: 18px;
+  font-weight: 600;
+}
+
+.app-crash__msg {
+  max-width: 560px;
+  margin: 0;
+  color: var(--fg-muted, #9aa0aa);
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 13px;
+  overflow-wrap: anywhere;
+}
+
+.app-crash__actions {
+  display: flex;
+  gap: 10px;
+  margin-top: 6px;
+}
+
+.app-crash__hint {
+  max-width: 480px;
+  margin: 0;
+  color: var(--fg-muted, #9aa0aa);
+  font-size: 12px;
+}

--- a/apps/web/src/chat/chat-store.test.ts
+++ b/apps/web/src/chat/chat-store.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { ensureActiveSessions, MAX_ACTIVE_SESSIONS, type ChatState } from "./chat-store";
+import {
+  ensureActiveSessions,
+  sanitizePersisted,
+  MAX_ACTIVE_SESSIONS,
+  type ChatSession,
+  type ChatState,
+} from "./chat-store";
 
 // ensureActiveSessions is the LRU that decides which chat sessions stay mounted.
 // Its load-bearing invariant: it must NEVER evict a session that is mid-stream
@@ -184,5 +190,72 @@ describe("persist debouncing", () => {
     const { flushChatPersist } = await freshStore();
     flushChatPersist();
     expect(setItem).not.toHaveBeenCalled();
+  });
+});
+
+// sanitizePersisted is the pure half of loadPersisted (#872): a corrupt or
+// hand-edited localStorage blob must never reach render — drop the bad
+// sessions, keep the good ones, and re-point currentSessionId if its target
+// was dropped. null = nothing usable (the caller starts a fresh session).
+
+function mkSession(id: string, overrides: Partial<ChatSession> = {}): ChatSession {
+  return {
+    id,
+    title: `chat ${id}`,
+    messages: [{ role: "user", content: "hi" }],
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides,
+  };
+}
+
+describe("sanitizePersisted", () => {
+  it("returns null for non-objects and shapeless blobs", () => {
+    expect(sanitizePersisted(null)).toBeNull();
+    expect(sanitizePersisted("corrupt")).toBeNull();
+    expect(sanitizePersisted(42)).toBeNull();
+    expect(sanitizePersisted({})).toBeNull();
+    expect(sanitizePersisted({ sessions: "not-an-array" })).toBeNull();
+  });
+
+  it("passes a valid blob through intact", () => {
+    const blob = { version: 1, sessions: [mkSession("a"), mkSession("b")], currentSessionId: "b" };
+    expect(sanitizePersisted(blob)).toEqual(blob);
+  });
+
+  it("drops invalid members and keeps the rest", () => {
+    const good = mkSession("a");
+    const out = sanitizePersisted({
+      sessions: [
+        good,
+        null,
+        "garbage",
+        { id: "no-other-fields" },
+        mkSession("bad-messages", { messages: [{ role: "user" }] as never }),
+        mkSession("bad-role", { messages: [{ role: "alien", content: "x" }] as never }),
+      ],
+      currentSessionId: "a",
+    });
+    expect(out?.sessions).toEqual([good]);
+  });
+
+  it("returns null when no session survives (caller starts fresh)", () => {
+    expect(sanitizePersisted({ sessions: [null, { id: "x" }] })).toBeNull();
+    expect(sanitizePersisted({ sessions: [] })).toBeNull();
+  });
+
+  it("re-points currentSessionId at the first survivor when its target was dropped", () => {
+    const out = sanitizePersisted({
+      sessions: [mkSession("a"), "corrupt"],
+      currentSessionId: "the-dropped-one",
+    });
+    expect(out?.currentSessionId).toBe("a");
+  });
+
+  it("accepts sessions with empty messages and optional message fields", () => {
+    const s = mkSession("a", {
+      messages: [{ role: "assistant", content: "", taskId: "t1", status: "done" }],
+    });
+    expect(sanitizePersisted({ sessions: [s], currentSessionId: "a" })?.sessions).toEqual([s]);
   });
 });

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -15,7 +15,7 @@ export type ChatSession = {
 
 export type SessionStatus = "idle" | "streaming" | "error";
 
-type PersistedChatState = {
+export type PersistedChatState = {
   version: number;
   sessions: ChatSession[];
   currentSessionId: string | null;
@@ -60,25 +60,63 @@ function createSession(): ChatSession {
   };
 }
 
+// A corrupt/hand-edited member must not reach render — it would throw past the
+// panel boundaries and white-screen the app (#872). Only the fields render
+// dereferences unconditionally are required; optional message fields can be
+// anything (they're guarded at use).
+function isValidSession(s: unknown): s is ChatSession {
+  if (!s || typeof s !== "object") return false;
+  const x = s as Record<string, unknown>;
+  return (
+    typeof x.id === "string" &&
+    typeof x.title === "string" &&
+    typeof x.createdAt === "number" &&
+    typeof x.updatedAt === "number" &&
+    Array.isArray(x.messages) &&
+    x.messages.every((m) => {
+      if (!m || typeof m !== "object") return false;
+      const msg = m as Record<string, unknown>;
+      return (
+        (msg.role === "user" || msg.role === "assistant" || msg.role === "system") &&
+        typeof msg.content === "string"
+      );
+    })
+  );
+}
+
+/** Pure half of loadPersisted (unit-tested): drop invalid sessions, keep the rest,
+ *  and re-point currentSessionId if it referenced a dropped one. Returns null when
+ *  nothing usable survives (caller starts fresh). */
+export function sanitizePersisted(parsed: unknown): PersistedChatState | null {
+  if (!parsed || typeof parsed !== "object") return null;
+  const p = parsed as Partial<PersistedChatState>;
+  const sessions = (Array.isArray(p.sessions) ? p.sessions : [])
+    .filter(isValidSession)
+    .slice(0, MAX_SESSIONS);
+  if (!sessions.length) return null;
+  return {
+    version: 1,
+    sessions,
+    currentSessionId: sessions.some((s) => s.id === p.currentSessionId)
+      ? (p.currentSessionId as string)
+      : sessions[0].id,
+  };
+}
+
 function loadPersisted(): PersistedChatState {
   try {
     const raw = window.localStorage.getItem(STORAGE_KEY);
-    if (!raw) throw new Error("empty");
-    const parsed = JSON.parse(raw) as Partial<PersistedChatState>;
-    const sessions = Array.isArray(parsed.sessions) ? parsed.sessions.slice(0, MAX_SESSIONS) : [];
-    return {
-      version: 1,
-      sessions,
-      currentSessionId: parsed.currentSessionId || sessions[0]?.id || null,
-    };
+    const state = raw ? sanitizePersisted(JSON.parse(raw)) : null;
+    if (state) return state;
   } catch {
-    const session = createSession();
-    return {
-      version: 1,
-      sessions: [session],
-      currentSessionId: session.id,
-    };
+    // Corrupt JSON or storage unavailable — fall through to a fresh session.
   }
+  const session = createSession();
+  return {
+    version: 1,
+    sessions: [session],
+    currentSessionId: session.id,
+  };
 }
 
 function persist(state: ChatState) {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,6 +4,8 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./app/App";
+import { AppCrash } from "./app/AppCrash";
+import { ErrorBoundary } from "./app/ErrorBoundary";
 // ADR 0037 — design-system foundation. Order matters: brand tokens (--pl-*) first, then
 // Tailwind + the shadcn→token bridge, then the legacy theme.css (which may reference --pl-*).
 import "@protolabsai/design/css/tokens";
@@ -20,10 +22,15 @@ void activateSlugAgent(); // cold-agent resume + keep-warm touch on slug navigat
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
-    <QueryClientProvider client={queryClient}>
-      <ToastProvider>
-        <App />
-      </ToastProvider>
-    </QueryClientProvider>
+    {/* The ROOT boundary (#872): anything a panel boundary doesn't catch lands on a
+        full-page recovery card instead of a white screen. Outermost so a throw in
+        the providers themselves is caught too. */}
+    <ErrorBoundary fallback={({ error }) => <AppCrash error={error} />}>
+      <QueryClientProvider client={queryClient}>
+        <ToastProvider>
+          <App />
+        </ToastProvider>
+      </QueryClientProvider>
+    </ErrorBoundary>
   </React.StrictMode>,
 );


### PR DESCRIPTION
## What

Closes #872 (prod-readiness audit, frontend P1) — all three parts of the spec'd fix:

1. **Root boundary** (`main.tsx`): one `<ErrorBoundary>` around the providers + `<App />` → a full-page **AppCrash** recovery card instead of a white screen. Two actions: **Reload**, and **Reset chat data & reload** — clears `protoagent.chat.sessions*` (all slug-suffixed keys) with the same selective scope as the tenant guard; layout/theme/authToken kept. The card is dependency-light (no stores/queries/router) since it renders while the app is broken.
2. **ChatSlot**: `ext.render()` (fork-registered chat surfaces — arbitrary code) is boundary-wrapped → a contained `PanelError` with retry, not an app unmount.
3. **`loadPersisted` shape validation**: new pure `sanitizePersisted` (exported + unit-tested) — drops invalid session members, keeps the rest, re-points `currentSessionId` when its target was dropped, starts fresh when nothing survives.

## Verification

- 51/51 unit (6 new `sanitizePersisted` cases) + **95/95 e2e** (3 new `resilience.spec.ts` specs: corrupt blob → fresh boot; partial corruption → survivors kept; dangling `currentSessionId` → re-pointed).
- Root boundary verified end-to-end by injecting a deliberate render throw into `App` and screenshotting the crash card (centered, token-themed, both actions render).

🤖 Generated with [Claude Code](https://claude.com/claude-code)