### PR TITLE
feat(console): 401 → operator-token prompt (#873)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the slot. Persisted chat sessions are now shape-validated on load — invalid
   members are dropped (the rest survive) instead of throwing later in render.
 
+### Added
+- **The console prompts for the operator token on 401** (#873): any unauthorized
+  response — panel query, boot probe, or chat turn — opens an "Authentication
+  required" dialog that saves the bearer to `protoagent.authToken` and refetches
+  in place (no reload, no devtools). 401s no longer burn retries, and a token-gated
+  first run shows the prompt instead of the BootGate's misleading "isn't responding".
+
 ### Changed
 - **Design system bumped `@protolabsai/ui` 0.26.2 → 0.29.0 (+ `@protolabsai/design` 0.5.1).**
   Brings the OS-adaptive light theme + 10 builtin theme presets (Theme panel picks them

--- a/apps/web/e2e/auth-gate.spec.ts
+++ b/apps/web/e2e/auth-gate.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+// Auth UX (#873): a token-gated deployment answers 401 until the operator
+// supplies the bearer. The console must surface a token prompt (not just
+// per-panel 401 cards), persist the token, and recover in place. The mock
+// server isn't token-gated, so the gate is simulated by intercepting /api/*
+// and rejecting requests that don't carry the expected Authorization header.
+
+const TOKEN = "e2e-operator-token";
+
+test("a 401 opens the token prompt; saving recovers in place and persists", async ({ page }) => {
+  await page.route("**/api/**", async (route) => {
+    const auth = route.request().headers()["authorization"] || "";
+    if (auth === `Bearer ${TOKEN}`) return route.fallback(); // through to the mock
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Unauthorized" }),
+    });
+  });
+
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // The boot probe 401s → the prompt opens (and the BootGate yields to it).
+  const dialog = page.getByRole("dialog", { name: "Authentication required" });
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+
+  await dialog.getByLabel("Operator token").fill(TOKEN);
+  await dialog.getByRole("button", { name: "Connect", exact: true }).click();
+
+  // Recovery in place: the prompt closes and the app reaches the chat surface
+  // without a reload (queries refetch with the bearer attached).
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible({ timeout: 15_000 });
+
+  // The token persisted where authToken() reads it.
+  const stored = await page.evaluate(() => window.localStorage.getItem("protoagent.authToken"));
+  expect(stored).toBe(TOKEN);
+});
+
+test("'Not now' dismisses; the next 401 re-prompts", async ({ page }) => {
+  await page.route("**/api/**", async (route) => {
+    await route.fulfill({
+      status: 401,
+      contentType: "application/json",
+      body: JSON.stringify({ detail: "Unauthorized" }),
+    });
+  });
+
+  await page.goto("/app/", { waitUntil: "load" });
+  const dialog = page.getByRole("dialog", { name: "Authentication required" });
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+  await dialog.getByRole("button", { name: "Not now", exact: true }).click();
+  await expect(dialog).not.toBeVisible();
+
+  // Dismissing doesn't loop the prompt: the 401-aware boot probe stops retrying,
+  // and the BootGate reappears in its failed state. Its Retry fires a fresh
+  // request → 401 → the prompt returns.
+  await page.locator(".pl-bootgate").getByRole("button", { name: "Retry", exact: true }).click();
+  await expect(dialog).toBeVisible({ timeout: 10_000 });
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -60,10 +60,12 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { lazy, Suspense, useEffect, useRef, useState } from "react";
+import { lazy, Suspense, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import type { ComponentType, LazyExoticComponent, ReactNode } from "react";
 import { FleetTurnWatch } from "./FleetTurnWatch";
 import { ProtoLabsIcon } from "./ProtoLabsIcon";
+import { AuthGate } from "./AuthGate";
+import { authRequired, subscribeAuth } from "../lib/auth";
 import { TenantGuard } from "./TenantGuard";
 import { Splash, BootGate } from "@protolabsai/ui/splash";
 import { Button } from "@protolabsai/ui/primitives";
@@ -85,7 +87,7 @@ import {
   type RightPanel,
   type Surface,
 } from "../state/uiStore";
-import { api } from "../lib/api";
+import { api, is401 } from "../lib/api";
 import { PluginView } from "./PluginView";
 import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
 import { Alert } from "@protolabsai/ui/data";
@@ -260,7 +262,11 @@ export function App() {
   // briefly freezes it, so we want to notice the moment it's live again.
   const runtimeQ = useQuery({
     ...runtimeStatusQuery(),
-    retry: 30,
+    // 30 boot-probe retries, but a 401 stops immediately: retrying can't fix a
+    // missing bearer, and a retrying probe would reopen the AuthGate the moment
+    // the operator dismissed it (#873). The gate's invalidateQueries restarts
+    // the probe once a token is saved.
+    retry: (failureCount, error) => !is401(error) && failureCount < 30,
     retryDelay: 1000,
     refetchInterval: (q) => (q.state.data?.graph_loaded ? false : 2500),
   });
@@ -268,7 +274,11 @@ export function App() {
 
   // Tenant uid is the HUB's, never the focused agent's (which changes on every fleet
   // swap and would wrongly wipe the chat view). Host-pinned, stable, low-churn.
-  const hostUidQ = useQuery({ ...hostRuntimeStatusQuery(), retry: 30, retryDelay: 1000 });
+  const hostUidQ = useQuery({
+    ...hostRuntimeStatusQuery(),
+    retry: (failureCount, error) => !is401(error) && failureCount < 30,
+    retryDelay: 1000,
+  });
 
   // Plugin-contributed rail surfaces (ADR 0026): each enabled plugin's declared
   // views become a dynamic rail icon (keyed plugin:<id>:<viewId>) whose panel is
@@ -349,6 +359,11 @@ export function App() {
   // copy/escape-hatch swap. STUCK_AFTER_MS=45s — past it, offer "Continue anyway"
   // so a graph that never compiles can't trap the operator on the loading screen.
   const bootFailed = !runtime && runtimeQ.isError;
+  // Token-gated first run (#873): the boot probe itself 401s. The BootGate's
+  // "Starting… / isn't responding" copy is wrong for that — and its overlay
+  // (z-1900) would cover the AuthGate dialog (z-1000) — so the gate yields to
+  // the token prompt while auth is needed.
+  const authNeeded = useSyncExternalStore(subscribeAuth, authRequired);
   // White-labelled gate copy: identity.name → display name (forks read their own).
   const bootName = brandName(runtime?.identity?.name);
   const [bootStuck, setBootStuck] = useState(false);
@@ -645,7 +660,7 @@ export function App() {
           is a slot-only shell with no `ready` — the host owns the gate by
           conditionally rendering it, and computes the failed/loading copy +
           escape-hatch action. Name flows from identity so forks white-label. */}
-      {!bootReady && (
+      {!bootReady && !authNeeded && (
         // role=status live region restores the screen-reader announcement the old
         // gate carried ("Starting…" / "isn't responding") during the ~30s cold start
         // — the DS BootGate shell doesn't own one. Host wrapper, no CSS (interim
@@ -679,6 +694,10 @@ export function App() {
           />
         </div>
       )}
+      {/* Token prompt (#873): any 401 — panel query, boot probe, chat turn — opens
+          this. Rendered AFTER the BootGate so a token-gated deployment's first run
+          (where the boot probe itself 401s) shows the prompt on top of the gate. */}
+      <AuthGate />
       {/* macOS desktop: the topbar IS the window's drag region (its brand insets
           right of the native traffic lights — see `.is-tauri-mac .topbar`).
           Interactive children (the status dot) stay clickable; harmless on web. */}

--- a/apps/web/src/app/AuthGate.tsx
+++ b/apps/web/src/app/AuthGate.tsx
@@ -1,0 +1,69 @@
+import { Button } from "@protolabsai/ui/primitives";
+import { Input } from "@protolabsai/ui/forms";
+import { Dialog } from "@protolabsai/ui/overlays";
+import { useQueryClient } from "@tanstack/react-query";
+import { useState, useSyncExternalStore } from "react";
+
+import { authRequired, clearAuthRequired, saveAuthToken, subscribeAuth } from "../lib/auth";
+
+// Token prompt for token-gated deployments (#873): any 401 (panel query, boot
+// probe, chat turn) trips the auth store and this dialog appears — previously the
+// only signal was per-panel "401 Unauthorized" cards, and writing
+// `protoagent.authToken` required devtools. Saving invalidates every query so the
+// app recovers in place, no reload. "Not now" dismisses; the next 401 re-prompts.
+// (localStorage as the token home is the standing posture — the httpOnly-cookie
+// move is #869's call, not this gate's.)
+
+export function AuthGate() {
+  const needed = useSyncExternalStore(subscribeAuth, authRequired);
+  const [token, setToken] = useState("");
+  const queryClient = useQueryClient();
+
+  if (!needed) return null;
+
+  const connect = () => {
+    saveAuthToken(token);
+    setToken("");
+    // Refetch everything (including the boot probe) with the new bearer.
+    void queryClient.invalidateQueries();
+  };
+
+  return (
+    <Dialog
+      open
+      title="Authentication required"
+      onClose={clearAuthRequired}
+      width={420}
+      footer={
+        <>
+          <Button type="button" variant="ghost" onClick={clearAuthRequired}>
+            Not now
+          </Button>
+          <Button type="button" disabled={!token.trim()} onClick={connect}>
+            Connect
+          </Button>
+        </>
+      }
+    >
+      <form
+        onSubmit={(e) => {
+          e.preventDefault();
+          if (token.trim()) connect();
+        }}
+      >
+        <p>
+          This instance is token-gated. Paste the operator token (the server's{" "}
+          <code>A2A_AUTH_TOKEN</code>) to connect — it's kept in this browser only.
+        </p>
+        <Input
+          type="password"
+          autoFocus
+          placeholder="operator token"
+          aria-label="Operator token"
+          value={token}
+          onChange={(e) => setToken(e.target.value)}
+        />
+      </form>
+    </Dialog>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -34,6 +34,8 @@ import type {
   WorkflowSummary,
 } from "./types";
 
+import { notifyAuthRequired } from "./auth";
+
 type RequestOptions = Omit<RequestInit, "body"> & {
   body?: unknown;
   /** Pin to the HUB (never slug-route) — for origin-level reads like the tenant uid
@@ -258,6 +260,12 @@ export function isColdStart(error: unknown): boolean {
   return true; // no HTTP response at all ⇒ not reachable yet (desktop sidecar booting)
 }
 
+/** True for a 401 from request() — retrying can't help until the operator supplies
+ *  a token (#873); the AuthGate owns recovery. */
+export function is401(error: unknown): boolean {
+  return error instanceof ApiError && error.status === 401;
+}
+
 async function request<T>(path: string, options: RequestOptions = {}): Promise<T> {
   const { host, ...init } = options;  // `host` is ours (routing), not a fetch RequestInit field
   const headers = applyAuth(new Headers(init.headers));
@@ -281,6 +289,9 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
     } catch {
       detail = await response.text();
     }
+    // Wrong/expired/missing bearer on a token-gated deployment — surface the
+    // token prompt (#873) instead of leaving per-panel 401 cards as the only signal.
+    if (response.status === 401) notifyAuthRequired();
     throw new ApiError(response.status, detail || "request failed");
   }
 
@@ -897,6 +908,7 @@ export const api = {
     });
 
     if (!response.ok) {
+      if (response.status === 401) notifyAuthRequired(); // token-gated chat turn (#873)
       throw new Error(`${response.status} ${response.statusText}`);
     }
 

--- a/apps/web/src/lib/auth.test.ts
+++ b/apps/web/src/lib/auth.test.ts
@@ -1,0 +1,53 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  authRequired,
+  clearAuthRequired,
+  notifyAuthRequired,
+  saveAuthToken,
+  subscribeAuth,
+} from "./auth";
+
+// The 401-driven auth store (#873): request() trips it, the AuthGate dialog
+// subscribes, saveAuthToken persists the bearer api.ts's authToken() reads.
+
+describe("auth store", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+    clearAuthRequired();
+  });
+
+  it("starts clear, flips on notify, clears on demand", () => {
+    expect(authRequired()).toBe(false);
+    notifyAuthRequired();
+    expect(authRequired()).toBe(true);
+    clearAuthRequired();
+    expect(authRequired()).toBe(false);
+  });
+
+  it("notifies subscribers once per transition (bursts of 401s are idempotent)", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeAuth(listener);
+    notifyAuthRequired();
+    notifyAuthRequired();
+    notifyAuthRequired();
+    expect(listener).toHaveBeenCalledTimes(1);
+    clearAuthRequired();
+    expect(listener).toHaveBeenCalledTimes(2);
+    unsubscribe();
+    notifyAuthRequired();
+    expect(listener).toHaveBeenCalledTimes(2);
+  });
+
+  it("saveAuthToken writes the key authToken() reads and clears the prompt", () => {
+    notifyAuthRequired();
+    saveAuthToken("  secret-token  ");
+    expect(window.localStorage.getItem("protoagent.authToken")).toBe("secret-token");
+    expect(authRequired()).toBe(false);
+  });
+
+  it("saveAuthToken with a blank value removes the stored token", () => {
+    window.localStorage.setItem("protoagent.authToken", "old");
+    saveAuthToken("   ");
+    expect(window.localStorage.getItem("protoagent.authToken")).toBeNull();
+  });
+});

--- a/apps/web/src/lib/auth.ts
+++ b/apps/web/src/lib/auth.ts
@@ -1,0 +1,51 @@
+// 401-driven auth state (#873) — a tiny subscribable store (the chat-store
+// pattern; no zustand needed for one boolean). `request()` and the A2A stream
+// fetch call notifyAuthRequired() on a 401; the AuthGate dialog subscribes and
+// prompts for the operator bearer. Pure module so it's unit-testable and usable
+// from non-React code (api.ts).
+
+const TOKEN_KEY = "protoagent.authToken";
+
+let needed = false;
+const listeners = new Set<() => void>();
+
+function emit() {
+  listeners.forEach((l) => l());
+}
+
+export function subscribeAuth(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function authRequired(): boolean {
+  return needed;
+}
+
+/** Flip the "needs auth" state (idempotent — panels can 401 in bursts). */
+export function notifyAuthRequired() {
+  if (needed) return;
+  needed = true;
+  emit();
+}
+
+/** Dismiss without saving (the operator chose "Not now"); the next 401 re-prompts. */
+export function clearAuthRequired() {
+  if (!needed) return;
+  needed = false;
+  emit();
+}
+
+/** Persist the operator bearer (the key api.ts's authToken() reads) and clear the
+ *  prompt. Storage can be unavailable in hardened contexts — the token still won't
+ *  survive a reload there, but in-flight retries pick it up via the gate's refetch. */
+export function saveAuthToken(token: string) {
+  try {
+    const t = token.trim();
+    if (t) window.localStorage.setItem(TOKEN_KEY, t);
+    else window.localStorage.removeItem(TOKEN_KEY);
+  } catch {
+    // best-effort
+  }
+  clearAuthRequired();
+}

--- a/apps/web/src/lib/queryClient.ts
+++ b/apps/web/src/lib/queryClient.ts
@@ -1,6 +1,6 @@
 import { QueryClient } from "@tanstack/react-query";
 
-import { isColdStart } from "./api";
+import { is401, isColdStart } from "./api";
 
 // One QueryClient for the whole console (ADR 0013). Surfaces fetch with
 // `useSuspenseQuery` so loading is a <Suspense> fallback and errors are caught
@@ -23,8 +23,13 @@ export const queryClient = new QueryClient({
       // so a panel stays in its loading state until the agent is up. Everything else
       // keeps the single retry. (Queries that opt out via `retry: false` are unaffected;
       // a genuinely-down agent still surfaces via the shell's boot-gate "isn't responding".)
-      retry: (failureCount, error) =>
-        isColdStart(error) ? failureCount < 25 : failureCount < 1,
+      // 401 never retries: the answer can't change until the operator enters a
+      // token — the AuthGate prompt (#873) owns recovery (it invalidates every
+      // query after the token is saved).
+      retry: (failureCount, error) => {
+        if (is401(error)) return false;
+        return isColdStart(error) ? failureCount < 25 : failureCount < 1;
+      },
       retryDelay: (attempt) => Math.min(1000 * 2 ** attempt, 3000),
       refetchOnWindowFocus: false,
     },

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -56,7 +56,7 @@ When unset, startup logs a WARNING (`"A2A auth token not configured — endpoint
 
 **Scope.** The guard covers everything that can drive the agent: `/a2a`, the operator API (`/api/*` — run subagents, rewrite config/SOUL, schedule jobs), `/api/chat`, and `/v1/*`. **Public (never guarded):** `/healthz`, `/.well-known/agent-card.json`, `/metrics`, the static console at `/app`, and the read-only `/api/events` SSE stream (browsers' `EventSource` can't send an `Authorization` header; it exposes only activity/inbox events, no action).
 
-**Console.** When a token is set, the React console reads it from `localStorage["protoagent.authToken"]` and sends it as a bearer on every API + A2A call. Set it once in the browser (`localStorage.setItem("protoagent.authToken", "<token>")`) for a token-protected deployment; local/desktop runs (no token) need nothing.
+**Console.** When a token is set, the React console sends it as a bearer on every API + A2A call. On the first 401 the console prompts for the token ("Authentication required") and stores it in `localStorage["protoagent.authToken"]` — no devtools needed; local/desktop runs (no token) need nothing.
 
 ## A2A agent-card endpoint
 


### PR DESCRIPTION
## What

Closes #873 (prod-readiness audit, frontend P2 — high-leverage since the boot gate made token-gated the recommended exposed posture).

Previously a wrong/expired/missing bearer surfaced only as per-panel "401 Unauthorized" cards, and **no UI anywhere could write `protoagent.authToken`** — operators had to use devtools.

- **`lib/auth.ts`** — a tiny subscribable 401 store (the chat-store `useSyncExternalStore` pattern; no new deps). `request()` and the A2A stream fetch trip it on 401.
- **`AuthGate`** (DS `Dialog`) — password input → `saveAuthToken` → `queryClient.invalidateQueries()`: recovery **in place**, no reload. "Not now" dismisses; the next 401 re-prompts.
- **401 never retries** — new `is401()` short-circuits the default retry policy *and* the two boot probes' custom `retry: 30` overrides (otherwise a retrying probe reopens the prompt ~1s after dismissal).
- **BootGate yields to the prompt** while auth is needed: its "isn't responding" copy is wrong for a 401, and its overlay (z-1900) would cover the dialog (z-1000).
- Docs: `environment-variables.md` console note now points at the prompt instead of the devtools localStorage incantation.

The httpOnly-cookie + CSRF question stays #869's call, per the issue.

## Verification

- 49/49 unit (4 new auth-store cases) + **94/94 e2e** (2 new `auth-gate.spec.ts` specs, run over a 401-stubbed API via `page.route`): the full recover-in-place flow (prompt → token → dialog closes → chat surface reachable → token persisted + `Authorization` carried on retry), and dismiss → BootGate Retry → re-prompt.
- Dialog screenshot-verified: modal over the shell, panel 401 card contained behind it, health dot red.

🤖 Generated with [Claude Code](https://claude.com/claude-code)