### PR TITLE
fix(plugins): notes adopts the DS kit + repair the broken kit-loading pattern (protoContent#224)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   chat surfaces (`src/ext`) are boundary-wrapped too, so a throw stays contained in
   the slot. Persisted chat sessions are now shape-validated on load — invalid
   members are dropped (the rest survive) instead of throwing later in render.
+- **The documented kit-loading pattern for plugin views was broken** — `plugin-kit.js`
+  is an ES module, so the classic `<script src>` the docs and `chat_example` taught
+  threw `Unexpected token 'export'` and the page's kit logic never ran. The notes
+  editor, `chat_example`, and both plugin-view guides now load the kit via dynamic
+  `import(base + "/_ds/plugin-kit.js")` (filed upstream as protoContent#224).
 
 ### Changed
+- **The Notes plugin editor adopts the DS plugin kit (rule 4)** — `plugin-kit.css`
+  `--pl-*` tokens + `initPluginView` + slug-aware authed `apiFetch` replace its
+  hand-rolled hex theme map, bespoke `protoagent:init` listener, and manual bearer
+  headers; the editor now follows the operator's live theme (including the new
+  OS-adaptive light presets). Notes plugin → 0.2.0.
 - **Design system bumped `@protolabsai/ui` 0.26.2 → 0.29.0 (+ `@protolabsai/design` 0.5.1).**
   Brings the OS-adaptive light theme + 10 builtin theme presets (Theme panel picks them
   up automatically), two token fixes splash.css silently depended on (`--pl-space-5`,

--- a/docs/design/ui-component-audit.md
+++ b/docs/design/ui-component-audit.md
@@ -149,6 +149,7 @@ Stack decision (UI team, on #137): **Radix for hard interactive primitives (Menu
 | # | Request | Priority | Status |
 |---|---|---|---|
 | [#218](https://github.com/protoLabsAI/protoContent/issues/218) | `Tabs` `segmented` variant / `SegmentedControl` (two-level nav scope toggle) | P2 | **Shipped in ui 0.28.0, adopted 2026-06-12** — the settings **Host / App \| Workspace** home toggle (`SettingsSurface.tsx`) and the MCP add-server **Form \| Paste JSON** toggle (`McpPanel.tsx`, the last `.segmented` hand-roll) both use `<Tabs variant="segmented">`; the local `.segmented` CSS block is deleted. |
+| [#224](https://github.com/protoLabsAI/protoContent/issues/224) | `plugin-kit.js` classic-`<script>` contract is impossible (the file is ESM — `Unexpected token 'export'`, the `window.protoPluginView` global never sets) | P2 | Filed 2026-06-12. **App-side fixed** (notes-adopts-kit PR): the notes editor + `chat_example` + both plugin-view docs now load the kit via dynamic `import(base + "/_ds/plugin-kit.js")` from a module script. |
 
 ## Console adoption status (branch `ds-adoption-sweep`, 2026-06-09)
 

--- a/docs/guides/building-react-plugin-views.md
+++ b/docs/guides/building-react-plugin-views.md
@@ -165,7 +165,10 @@ The console serves the design-system kit same-origin at **`<base>/_ds/plugin-kit
 no-hardcode escape hatch. `plugin-kit.css` gives `--pl-*` tokens + `.pl-*` components;
 `plugin-kit.js` does the handshake and exposes a tiny API.
 
-Link both slug-aware (RULE 3 + 4):
+Link both slug-aware (RULE 3 + 4). **`plugin-kit.js` is an ES module** (`export` statements) — a
+classic `<script src>` throws `Unexpected token 'export'` and never runs it, so the JS half loads
+with a **dynamic `import()`** (a static import specifier can't carry the slug-aware base; only the
+CSS `<link>` is base-prefixed by hand, because it loads before any script can help):
 
 ```html
 <script>
@@ -174,12 +177,13 @@ Link both slug-aware (RULE 3 + 4):
   document.write('<link rel="stylesheet" href="' + window.__base + '/_ds/plugin-kit.css">');
 </script>
 ...
-<script src="" id="kit"></script>
-<script>document.getElementById("kit").src = window.__base + "/_ds/plugin-kit.js";</script>
+<script type="module">
+  const kit = await import(window.__base + "/_ds/plugin-kit.js");
+  // …the view's logic, using kit.initPluginView() / kit.apiFetch() …
+</script>
 ```
 
-The classic script-tag form exposes a **`window.protoPluginView`** global; the kit is also an ES
-module (`import { initPluginView } from ".../plugin-kit.js"`). The API:
+The API:
 
 | Helper | What it does |
 |---|---|
@@ -187,15 +191,18 @@ module (`import { initPluginView } from ".../plugin-kit.js"`). The API:
 | `getToken()` | The captured operator bearer (null until the handshake delivers one). |
 | `apiUrl(path)` | Resolves a root-relative `path` to its **slug-aware** URL — prepends `/agents/<slug>` under the fleet proxy, leaves it untouched on the host window (plugin-kit 0.26+). Idempotent: a path already under the base is returned as-is. |
 | `apiFetch(input, init?)` | A same-origin `fetch` that resolves `input` through `apiUrl` (**slug-aware** — pass a bare `/api/...`, no manual base) **and** attaches `Authorization: Bearer <token>` when present. Use it for every gated `/api/...` call. |
-| `window.protoPluginView` | The same helpers as a global, for no-build classic script-tag pages. |
 
 So a whole view's handshake + authed fetch is:
 
 ```js
-const kit = window.protoPluginView;
+const kit = await import(window.__base + "/_ds/plugin-kit.js");
 kit.initPluginView();                         // handshake + live re-theme, hands-free
 const res = await kit.apiFetch("/api/chat", { method: "POST", body: ... });  // slug-aware, no manual base
 ```
+
+> The kit also assigns a `window.protoPluginView` global when it runs, but that only happens after
+> the module is evaluated — don't rely on it from a separate classic `<script>`; import the module
+> and use what it returns.
 
 Prefer the kit over hardcoding hex values, a theme map, or a CDN — colors and the handshake both come
 from the console's own DS, so your view always matches the operator's live theme.

--- a/docs/how-to/build-a-plugin-view.md
+++ b/docs/how-to/build-a-plugin-view.md
@@ -36,22 +36,24 @@ Reload. (`chat_example` claims the chat slot; a normal view adds a rail icon ins
 
 ## The kit helper API (`plugin-kit.js`)
 
-The console serves the design-system kit same-origin at `<base>/_ds/plugin-kit.{css,js}`. Load it as
-an ES module (`import { initPluginView } from ".../plugin-kit.js"`) or use the
-`window.protoPluginView` global from a classic script tag:
+The console serves the design-system kit same-origin at `<base>/_ds/plugin-kit.{css,js}`.
+**`plugin-kit.js` is an ES module** — a classic `<script src>` throws
+`Unexpected token 'export'` and never runs it, so load it with a **dynamic `import()`**
+(the slug-aware URL can't be a static import specifier):
 
 | Helper | What it does |
 |---|---|
 | `initPluginView(onInit?)` | Listens for the `protoagent:init` handshake (bearer + theme) **and** live `protoagent:theme` re-themes, mapping the console theme onto the DS `--pl-*` tokens. Call once on load. |
 | `getToken()` | The captured operator bearer (null until the handshake delivers one). |
-| `apiFetch(input, init?)` | Same-origin `fetch` with `Authorization: Bearer <token>` attached when present — for every gated `/api/...` call. |
-| `window.protoPluginView` | The same three helpers as a global, for no-build pages. |
+| `apiFetch(input, init?)` | Same-origin `fetch` with `Authorization: Bearer <token>` attached when present, resolved slug-aware — pass a bare `/api/...`, no manual base. For every gated `/api/...` call. |
 
-```js
-const kit = window.protoPluginView;
-kit.initPluginView();                                   // handshake + live re-theme, hands-free
-const base = location.pathname.split("/plugins/")[0];   // "" or "/agents/<slug>"
-const res = await kit.apiFetch(base + "/api/plugins/mychart/data");
+```html
+<script type="module">
+  const base = location.pathname.split("/plugins/")[0];   // "" or "/agents/<slug>"
+  const kit = await import(base + "/_ds/plugin-kit.js");
+  kit.initPluginView();                                   // handshake + live re-theme, hands-free
+  const res = await kit.apiFetch("/api/plugins/mychart/data"); // slug-aware, no manual base
+</script>
 ```
 
 ## Next

--- a/examples/plugins/chat_example/panel.html
+++ b/examples/plugins/chat_example/panel.html
@@ -91,19 +91,18 @@
     <button id="send" class="pl-btn pl-btn--primary" type="submit">Send</button>
   </form>
 </div>
-<!-- RULE 4: the kit's JS, same-origin + slug-aware. Gives window.protoPluginView
-     ({ initPluginView, apiFetch, getToken }) — the no-build handshake + authed fetch. -->
-<script src="" id="kit"></script>
-<script>
-  document.getElementById("kit").src = window.__base + "/_ds/plugin-kit.js";
-</script>
-<script>
+<!-- RULE 4: the kit's JS, same-origin + slug-aware. plugin-kit.js is an ES MODULE
+     (export statements) — a classic <script src> throws "Unexpected token 'export'"
+     and never sets the window.protoPluginView global. Dynamic import() is the
+     no-build way to load it with a slug-aware URL (a static import specifier can't
+     carry the base). -->
+<script type="module">
   "use strict";
   const base = window.__base;
 
   // ── RULE 4: the kit handles the protoagent:init handshake (bearer + theme) and
   // re-skins its --pl-* tokens to the operator's live theme. We just listen. ──
-  const kit = window.protoPluginView;
+  const kit = await import(window.__base + "/_ds/plugin-kit.js");
   kit.initPluginView();
 
   // ── RULE 3: one session per agent, keyed by slug-aware base; New session rotates it. ──

--- a/plugins/notes/__init__.py
+++ b/plugins/notes/__init__.py
@@ -148,58 +148,78 @@ def register(registry) -> None:
     registry.register_router(_build_data_router(), prefix="/api/plugins/notes")
 
 
-# The editor page the console iframes (ADR 0026 bridge → bearer + theme). A self-contained markdown
-# editor: debounced autosave (PUT /note), an edit↔preview toggle (marked from CDN), and a poll that
-# adopts the agent's writes. Dark by default, following the console theme. No host build — the
-# plugin serves its own UI, so it works installed from a git URL (ADR 0038).
+# The editor page the console iframes. A self-contained markdown editor: debounced
+# autosave (PUT /note), an edit↔preview toggle (marked from CDN, degrades to raw text
+# offline), and a poll that adopts the agent's writes. No host build — the plugin
+# serves its own UI, so it works installed from a git URL (ADR 0038).
 #
-# FLEET-PROXY-SAFE FETCH (ADR 0042): the iframe (the PUBLIC page) loads at /plugins/notes/view on the
-# host window, but at /agents/<slug>/plugins/notes/view when this agent is viewed through the fleet
-# proxy. So it derives `base` from its own path (= "" on host, "/agents/<slug>" when proxied) and
-# prefixes EVERY data fetch — never hardcode an absolute "/api/..." or the proxied window would hit
-# the host agent. The data path stays the GATED /api/plugins/notes/note, fetched with the token.
-_EDITOR_HTML = r"""<!doctype html><html><head><meta charset="utf-8"><style>
-  :root{ --bg:#0a0a0c; --bg-raised:#161616; --fg:#ededed; --fg-muted:#9aa0aa; --border:#2a2a30; --brand:#a78bfa; }
-  html,body{margin:0;height:100%;background:var(--bg);color:var(--fg);
-    font-family:ui-sans-serif,system-ui,-apple-system,sans-serif}
+# FOUR-RULES COMPLIANT (docs/how-to/build-a-plugin-view.md, the chat_example pattern):
+#   3. SLUG-AWARE — the kit's apiFetch derives the base (host vs /agents/<slug> proxy)
+#      for every data call; only the kit's own <link>/<script> are base-prefixed by
+#      hand (they load before the kit exists).
+#   4. LINK THE KIT — <base>/_ds/plugin-kit.{css,js} replaces the hand-rolled hex
+#      token map + bespoke protoagent:init listener + manual bearer headers this page
+#      carried before: plugin-kit.js maps the operator's live theme onto --pl-*
+#      (initial handshake AND protoagent:theme re-themes), and apiFetch attaches the
+#      token. Local <style> is layout-only.
+_EDITOR_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
+<script>
+  "use strict";
+  // Slug-aware base (ADR 0042), computed FIRST: the kit's own assets load before the
+  // kit exists, so they're the one thing prefixed by hand (rule 4).
+  window.__base = location.pathname.split("/plugins/")[0];
+  document.write('<link rel="stylesheet" href="' + window.__base + '/_ds/plugin-kit.css">');
+</script>
+<style>
+  /* Layout only — colors/typography come from plugin-kit.css's --pl-* tokens, which
+     plugin-kit.js re-skins to the operator's live theme on the handshake. */
+  html,body{margin:0;height:100%;background:var(--pl-color-bg);color:var(--pl-color-fg);
+    font-family:var(--pl-font-sans,ui-sans-serif,system-ui,sans-serif)}
   #wrap{display:flex;flex-direction:column;height:100%}
-  #bar{display:flex;align-items:center;justify-content:space-between;padding:6px 10px;border-bottom:1px solid var(--border);font-size:12px;color:var(--fg-muted)}
-  #bar button{background:transparent;border:1px solid var(--border);color:var(--fg-muted);border-radius:6px;padding:3px 10px;cursor:pointer;font-size:12px}
-  #ed{flex:1;min-height:0;resize:none;border:0;outline:none;padding:12px;background:transparent;color:var(--fg);
-    font-family:ui-monospace,SFMono-Regular,Menlo,monospace;font-size:13px;line-height:1.6}
+  #bar{display:flex;align-items:center;justify-content:space-between;padding:6px 10px;
+    border-bottom:var(--pl-border-width,1px) solid var(--pl-color-border);
+    font-size:12px;color:var(--pl-color-fg-muted)}
+  #ed{flex:1;min-height:0;resize:none;border:0;outline:none;padding:12px;background:transparent;
+    color:var(--pl-color-fg);font-family:var(--pl-font-mono,ui-monospace,Menlo,monospace);
+    font-size:13px;line-height:1.6}
   #pv{flex:1;min-height:0;overflow:auto;padding:12px;display:none}
-  #pv :is(h1,h2,h3){color:var(--fg)} #pv code{background:var(--bg-raised);padding:2px 5px;border-radius:5px}
+  #pv :is(h1,h2,h3){color:var(--pl-color-fg)}
+  #pv code{background:var(--pl-color-bg-raised);padding:2px 5px;border-radius:var(--pl-radius)}
 </style></head><body>
 <div id="wrap">
-  <div id="bar"><span id="status">Notes</span><button id="toggle" type="button">Preview</button></div>
+  <div id="bar"><span id="status">Notes</span>
+    <button id="toggle" class="pl-btn pl-btn--sm" type="button">Preview</button></div>
   <textarea id="ed" placeholder="A shared note — you and the agent both write here." spellcheck="false"></textarea>
   <div id="pv"></div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.2/marked.min.js"></script>
-<script>
-  var token=null, lastSynced="", dirty=false, preview=false, t=null;
+<script type="module">
+  "use strict";
+  // plugin-kit.js is an ES MODULE (it has export statements) — a classic
+  // <script src> throws "Unexpected token 'export'" and never sets the
+  // window.protoPluginView global. Dynamic import is the no-build way to load it
+  // with a slug-aware URL (a static import specifier can't carry the base).
+  // Older host with no /_ds route: fall back to a tokenless same-origin shim
+  // (fine locally; gated instances always serve the kit).
+  let kit;
+  try { kit = await import(window.__base + "/_ds/plugin-kit.js"); }
+  catch (e) { kit = { initPluginView(){}, apiFetch: (p, i) => fetch(window.__base + p, i) }; }
+  var lastSynced="", dirty=false, preview=false, t=null;
   var ed=document.getElementById("ed"), pv=document.getElementById("pv"), st=document.getElementById("status"), tg=document.getElementById("toggle");
-  // Slug-aware base (ADR 0042): the iframe (PUBLIC page) lives at /plugins/notes/view on the host
-  // window or /agents/<slug>/plugins/notes/view when proxied. base = "" (host) or "/agents/<slug>"
-  // (proxied); prefix EVERY data fetch so the proxied window talks to ITS agent, never the host's.
-  var base = location.pathname.split("/plugins/")[0];
-  window.addEventListener("message", function(e){
-    var m=e.data||{}; if(m.type!=="protoagent:init") return; token=m.token||null;
-    if(m.theme){ var r=document.documentElement.style;
-      if(m.theme.bg)r.setProperty("--bg",m.theme.bg); if(m.theme.fg)r.setProperty("--fg",m.theme.fg);
-      if(m.theme.fgMuted)r.setProperty("--fg-muted",m.theme.fgMuted); if(m.theme.border)r.setProperty("--border",m.theme.border); }
-  });
-  function hdr(extra){ var h=extra||{}; if(token)h["Authorization"]="Bearer "+token; return h; }
+  // The kit owns the protoagent:init handshake (bearer + theme, incl. live re-themes)
+  // and authed slug-aware fetches; on a token-gated instance the first token arrives
+  // with the handshake, so re-load then (the immediate load() covers tokenless local).
+  kit.initPluginView(function(){ if(!dirty) load(); });
   function renderPreview(){ pv.innerHTML = window.marked ? marked.parse(ed.value||"") : ed.value; }
   tg.onclick=function(){ preview=!preview; if(preview){renderPreview();pv.style.display="block";ed.style.display="none";tg.textContent="Edit";}
     else{pv.style.display="none";ed.style.display="block";tg.textContent="Preview";} };
   ed.addEventListener("input", function(){ dirty=true; st.textContent="Saving…"; clearTimeout(t); t=setTimeout(save,700); });
   async function save(){ try{
-      var r=await fetch(base+"/api/plugins/notes/note",{method:"PUT",headers:hdr({"Content-Type":"application/json"}),body:JSON.stringify({content:ed.value})});
+      var r=await kit.apiFetch("/api/plugins/notes/note",{method:"PUT",headers:{"Content-Type":"application/json"},body:JSON.stringify({content:ed.value})});
       if(!r.ok)throw 0; lastSynced=ed.value; dirty=false; st.textContent="Saved ✓";
     }catch(e){ st.textContent="Save failed"; } }
   async function load(){ try{
-      var a=await fetch(base+"/api/plugins/notes/note",{headers:hdr()}).then(function(r){return r.json();});
+      var a=await kit.apiFetch("/api/plugins/notes/note").then(function(r){return r.json();});
       if(typeof a.content==="string" && a.content!==lastSynced && !dirty){ ed.value=a.content; lastSynced=a.content; if(preview)renderPreview(); }
     }catch(e){} }
   load();

--- a/plugins/notes/protoagent.plugin.yaml
+++ b/plugins/notes/protoagent.plugin.yaml
@@ -1,6 +1,6 @@
 id: notes
 name: Notes
-version: 0.1.0
+version: 0.2.0
 description: >-
   A single shared markdown note the agent and the operator both read and write.
   The flagship reference plugin (ADR 0034 S4) — it owns its storage, its agent

--- a/tests/test_notes_plugin.py
+++ b/tests/test_notes_plugin.py
@@ -39,3 +39,27 @@ def test_notes_storage_is_instance_scoped(tmp_path, monkeypatch) -> None:
     notes = _load_notes()
     notes.write_note.invoke({"content": "alpha-note"})
     assert (tmp_path / "alpha" / "note.md").read_text(encoding="utf-8") == "alpha-note"
+
+
+def test_editor_view_follows_the_four_rules() -> None:
+    """The served editor page must stay four-rules compliant
+    (docs/how-to/build-a-plugin-view.md): kit css+js linked slug-aware (rule 4),
+    data fetched via the kit's authed apiFetch (rules 2+3), and no hand-rolled
+    theme map (the pre-kit page carried a hex :root token block that ignored
+    the operator's theme)."""
+    html = _load_notes()._EDITOR_HTML
+    # Rule 4 — the same-origin DS kit, base-prefixed by hand (loads before the kit exists).
+    assert "/_ds/plugin-kit.css" in html
+    assert "/_ds/plugin-kit.js" in html
+    assert 'location.pathname.split("/plugins/")[0]' in html  # slug-aware base
+    # Rules 2+3 — gated data path via the kit's slug-aware authed fetch.
+    assert 'apiFetch("/api/plugins/notes/note"' in html
+    assert "initPluginView" in html
+    # The kit is an ES MODULE — it must load via dynamic import from a module
+    # script, never a classic <script src> (SyntaxError: Unexpected token 'export').
+    assert 'type="module"' in html
+    assert 'import(window.__base + "/_ds/plugin-kit.js")' in html
+    # No hand-rolled theme: hex colors and a bespoke handshake listener are the
+    # antipattern the kit replaces.
+    assert "#0a0a0c" not in html
+    assert 'addEventListener("message"' not in html


### PR DESCRIPTION
## What

Two halves, found together while doing the notes-adopts-kit follow-up (rule 4 of the plugin-view contract):

### Notes adopts the kit
The editor page's hand-rolled hex `:root` token map, bespoke `protoagent:init` listener, and manual bearer headers are replaced by **`plugin-kit.css` `--pl-*` tokens + `initPluginView` (handshake + live re-themes) + slug-aware authed `apiFetch`**. Local `<style>` is layout-only; the toggle is a `.pl-btn`; the editor now follows the operator's live theme (including the 0.27 OS-adaptive light presets). `marked` stays CDN-loaded with its existing raw-text degradation. Notes plugin 0.1.0 → 0.2.0.

### The documented kit-loading pattern was broken everywhere it was taught
`plugin-kit.js` is an **ES module** — the classic `<script src>` + `window.protoPluginView` pattern that `chat_example` and both plugin-view guides taught throws `Unexpected token 'export'` and the global never sets (live-reproduced: chat_example's panel was dead on arrival). Not a 0.29 regression — 0.26.2 ships the same ESM. The no-build fix is **dynamic `import(base + "/_ds/plugin-kit.js")`** from a module script (a static specifier can't carry the slug-aware base). Fixed in:
- `examples/plugins/chat_example/panel.html` (the gold-standard copy-me)
- `docs/how-to/build-a-plugin-view.md` + `docs/guides/building-react-plugin-views.md`
- filed upstream as [protoContent#224](https://github.com/protoLabsAI/protoContent/issues/224); recorded in the component audit § Filed upstream

## Verification

- Notes editor **and** chat_example driven end-to-end against the real served kit (playwright route-intercept over vite preview's `/_ds/`): zero page errors, themed render (edit + preview), authed data round-trip (chat_example: send → `apiFetch("/api/chat")` → reply bubble).
- `test_notes_plugin.py` gains a four-rules contract test (kit css+js linked slug-aware, module `import()`, `apiFetch` data path, no hex tokens / bespoke handshake listener); 197 plugin/notes python tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)