### PR TITLE
feat(plugins): one-click sync for locked-but-missing plugins from the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **One-click plugin sync from the console.** On a fresh checkout (or restored data
+  dir) `plugins.lock` lists plugins whose gitignored code isn't on disk; the Plugins
+  panel said "missing — run sync" but sync was CLI-only — a dead end for a new user.
+  The panel now shows a banner with a **Sync plugins** button (new
+  `POST /api/plugins/sync`) that re-clones every locked plugin at its pinned commit;
+  anything already in `plugins.enabled` hot-reloads live. Fetch ≠ enable still
+  holds — syncing never turns plugins on.
+
 ### Fixed
 - **A render error no longer white-screens the console** (#872): a root error
   boundary around the app shows a full-page recovery card — Reload, plus "Reset

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1094,6 +1094,16 @@ export const api = {
   pluginUpdates() {
     return request<{ plugins: PluginUpdate[] }>("/api/plugins/updates");
   },
+  // Re-clone every locked plugin that's missing on disk (fresh clone / restored
+  // data dir). Fetches at the lock's resolved_sha; already-enabled plugins come
+  // up live via the same hot-reload the enable toggle uses.
+  syncPlugins() {
+    return request<{
+      plugins: { id: string; status: "present" | "installed" | "failed"; error?: string }[];
+      reloaded: boolean;
+      reload_error: string | null;
+    }>("/api/plugins/sync", { method: "POST" });
+  },
   // Pull the latest code at the plugin's recorded ref + hot-reload (same path as
   // enable). Returns whether the live reload landed and if a restart is still
   // recommended (a view/route plugin can't swap its mounted router in place).

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -3,7 +3,7 @@ import "./plugins.css";
 import { Button } from "@protolabsai/ui/primitives";
 import { Input } from "@protolabsai/ui/forms";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { AlertTriangle, Loader2, Package, Plus, RefreshCw, ShieldAlert, Trash2 } from "lucide-react";
+import { AlertTriangle, DownloadCloud, Loader2, Package, Plus, RefreshCw, ShieldAlert, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { api } from "../lib/api";
@@ -76,7 +76,25 @@ export function PluginsSection() {
     onError: (e: unknown) => setStatus(`✗ ${e instanceof Error ? e.message : "uninstall failed"}`),
   });
 
+  const sync = useMutation({
+    mutationFn: () => api.syncPlugins(),
+    onSuccess: (res) => {
+      const fetched = res.plugins.filter((r) => r.status === "installed").map((r) => r.id);
+      const failed = res.plugins.filter((r) => r.status === "failed");
+      setStatus(
+        failed.length
+          ? `✗ sync: ${failed.map((f) => `${f.id} (${f.error ?? "failed"})`).join(", ")}${fetched.length ? ` — fetched ${fetched.join(", ")}` : ""}`
+          : fetched.length
+            ? `✓ fetched ${fetched.join(", ")}${res.reloaded ? " — enabled plugins are live" : ""}${res.reload_error ? ` — reload failed (${res.reload_error})` : ""}`
+            : "✓ nothing to sync — all locked plugins present",
+      );
+      invalidateAll();
+    },
+    onError: (e: unknown) => setStatus(`✗ ${e instanceof Error ? e.message : "sync failed"}`),
+  });
+
   const plugins = list.data?.plugins ?? [];
+  const missing = plugins.filter((p) => !p.present);
 
   return (
     <section className="settings-section">
@@ -117,6 +135,27 @@ export function PluginsSection() {
         </button>
       </div>
       {status ? <p className="plugin-install-status" role="status">{status}</p> : null}
+
+      {/* Locked-but-missing plugins (fresh clone / restored data dir) → one-click sync */}
+      {missing.length ? (
+        <div className="plugin-sync-banner" role="status">
+          <AlertTriangle size={14} />
+          <span>
+            {missing.length === 1 ? <><code>{missing[0].id}</code> is</> : <>{missing.length} plugins are</>}{" "}
+            in <code>plugins.lock</code> but missing on disk.
+          </span>
+          <Button
+            type="button"
+            variant="default"
+            size="sm"
+            disabled={sync.isPending}
+            onClick={() => { setStatus(""); sync.mutate(); }}
+            title="Re-clone every locked plugin at its pinned commit"
+          >
+            {sync.isPending ? <Loader2 size={13} className="spin" /> : <DownloadCloud size={13} />} Sync plugins
+          </Button>
+        </div>
+      ) : null}
 
       {/* Installed list */}
       {list.isError ? (
@@ -179,7 +218,7 @@ function PluginRow({
             </Button>
           ) : null}
           <span className={`plugin-state ${p.enabled ? "on" : "off"}`}>{p.enabled ? "enabled" : "not enabled"}</span>
-          {!p.present ? <span className="plugin-state warn"><AlertTriangle size={12} /> missing — run sync</span> : null}
+          {!p.present ? <span className="plugin-state warn"><AlertTriangle size={12} /> missing — sync above</span> : null}
         </div>
         {m?.description ? <p className="plugin-desc">{m.description}</p> : null}
         <p className="plugin-meta">

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -38,6 +38,8 @@
 .plugin-install-form { display: flex; gap: 8px; margin: 10px 0; flex-wrap: wrap; }
 .plugin-install-form input { flex: 1; min-width: 220px; padding: 7px 10px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 7px; color: var(--fg); font-size: 13px; }
 .plugin-install-status { font-size: 12px; color: var(--fg-secondary); margin: 4px 0 10px; }
+.plugin-sync-banner { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 0 0 10px; padding: 8px 10px; font-size: 12px; border-radius: 7px; background: color-mix(in srgb, var(--warning) 10%, transparent); border: 1px solid color-mix(in srgb, var(--warning) 35%, transparent); color: var(--fg-secondary); }
+.plugin-sync-banner > svg { color: var(--warning); flex-shrink: 0; }
 .plugin-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
 .plugin-row-main { flex: 1; min-width: 0; }
 .plugin-row-title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -45,7 +45,10 @@ plugins:
 
 Install pins the **resolved commit SHA** and records it in a committed
 `plugins.lock`, so `plugin sync` reproduces the exact set. The code itself is
-gitignored (re-cloned from the lock).
+gitignored (re-cloned from the lock). On a fresh checkout (or a restored data
+dir) the console flags each locked-but-missing plugin and offers a one-click
+**Sync plugins** button (`POST /api/plugins/sync`) — the same re-clone the CLI
+does; plugins that are already in `plugins.enabled` come up live on the spot.
 
 ## Keep one up to date
 

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -250,6 +250,38 @@ def register_plugin_routes(app) -> None:
         non-fatal per entry — surfaced in each row's ``error``."""
         return {"plugins": installer.check_updates()}
 
+    @app.post("/api/plugins/sync")
+    async def _sync():
+        """Re-clone every locked plugin that's missing on disk (the console's
+        "missing" state; previously CLI-only as `python -m server plugin sync`).
+
+        The lock is the source of truth: each missing plugin re-installs at its
+        recorded ``resolved_sha`` — fetch, not update, and fetch ≠ enable (ADR
+        0027). If anything was fetched and is already in ``plugins.enabled``
+        (e.g. a restored data dir whose config still enables it), hot-reload so
+        it comes up live — a previously-missing plugin has no mounted router, so
+        the hot-mount path applies and no restart is needed."""
+        results = installer.sync(allow=_sources_allowlist())
+        fetched = {r["id"] for r in results if r.get("status") == "installed"}
+
+        reloaded = False
+        cfg = STATE.graph_config
+        enabled_now = set(getattr(cfg, "plugins_enabled", []) or [])
+        if fetched & enabled_now:
+            from server.agent_init import _apply_settings_changes
+
+            ok, messages = _apply_settings_changes(
+                config={"plugins": {"enabled": sorted(enabled_now),
+                                    "disabled": list(getattr(cfg, "plugins_disabled", []) or [])}},
+            )
+            if not ok:
+                # The fetch itself succeeded — surface the reload failure per row
+                # semantics rather than 500ing (mirrors the install route).
+                return {"plugins": results, "reloaded": False,
+                        "reload_error": "; ".join(messages) or "reload failed"}
+            reloaded = True
+        return {"plugins": results, "reloaded": reloaded, "reload_error": None}
+
     @app.post("/api/plugins/{plugin_id}/update")
     async def _update(plugin_id: str):
         """Pull the latest code for an installed plugin at its recorded ref, then

--- a/tests/test_plugin_routes.py
+++ b/tests/test_plugin_routes.py
@@ -213,6 +213,49 @@ def test_force_reinstall_purges_module_subtree(monkeypatch):
     assert mod not in sys.modules and (mod + ".tools") not in sys.modules
 
 
+# ── sync: re-clone locked-but-missing plugins from the console (#947) ─────────────
+def test_sync_fetches_missing_and_reloads_enabled(monkeypatch):
+    # A locked plugin that's missing AND enabled (restored data dir): sync fetches it
+    # and hot-reloads so it comes up live — fresh code, no mounted router, no restart.
+    from graph.plugins import installer
+    captured = _wire(monkeypatch, enabled=["artifact"], disabled=[], meta=[])
+    monkeypatch.setattr(installer, "sync", lambda allow=None: [
+        {"id": "artifact", "status": "installed"},
+        {"id": "doom", "status": "present"},
+    ])
+    body = _client().post("/api/plugins/sync").json()
+    assert body["reloaded"] is True and body["reload_error"] is None
+    assert captured["config"]["plugins"]["enabled"] == ["artifact"]
+    assert [p["status"] for p in body["plugins"]] == ["installed", "present"]
+
+
+def test_sync_skips_reload_when_nothing_fetched_is_enabled(monkeypatch):
+    # Fresh clone: locked plugins fetched but none enabled → no reload (fetch ≠ enable,
+    # ADR 0027 — turning them on stays the operator's explicit step).
+    from graph.plugins import installer
+    captured = _wire(monkeypatch, enabled=["discord"], disabled=[], meta=[])
+    monkeypatch.setattr(installer, "sync", lambda allow=None: [
+        {"id": "artifact", "status": "installed"},
+    ])
+    body = _client().post("/api/plugins/sync").json()
+    assert body["reloaded"] is False and body["reload_error"] is None
+    assert "config" not in captured                           # no reload triggered
+
+
+def test_sync_surfaces_reload_failure_without_500(monkeypatch):
+    from graph.plugins import installer
+    _wire(monkeypatch, enabled=["artifact"], disabled=[], meta=[])
+    sys.modules["server.agent_init"]._apply_settings_changes = (
+        lambda config=None, soul=None: (False, ["graph compile failed"]))
+    monkeypatch.setattr(installer, "sync", lambda allow=None: [
+        {"id": "artifact", "status": "installed"},
+    ])
+    resp = _client().post("/api/plugins/sync")
+    assert resp.status_code == 200                            # the fetch itself landed
+    body = resp.json()
+    assert body["reloaded"] is False and "graph compile failed" in body["reload_error"]
+
+
 def test_update_route_flags_restart_for_disabled_lingering_router(monkeypatch):
     # The update route's restart heuristic also reads the mount registry now — a
     # disabled-but-still-mounted plugin (no meta) updating at its ref needs a restart.


### PR DESCRIPTION
## What

New-user dead end found during the fresh-user wipe test: a fresh checkout has `plugins.lock` entries whose gitignored code isn't on disk, and the Plugins panel says **"missing — run sync"** — but sync existed only as a CLI (`python -m server plugin sync`). The console named an action it didn't offer.

- **`POST /api/plugins/sync`** — wraps `installer.sync()`: re-clones every locked-but-missing plugin at its recorded `resolved_sha` (sources allowlist honored). **Fetch ≠ enable** (ADR 0027) — syncing never turns anything on — but plugins *already* in `plugins.enabled` (restored data dir) hot-reload live: a previously-missing plugin has no mounted router, so #822's hot-mount path applies, no restart. Reload failure → surfaced in the response, not a 500 (install-route contract).
- **Console**: warning banner above the installed list when any lock entry is missing, with a **Sync plugins** button; per-row hint now points at the banner instead of the CLI.

## Test

- 3 new route tests (fetch+reload when enabled; no reload when nothing fetched is enabled; reload failure surfaced without 500) — 20 pass in `test_plugin_routes.py`.
- Live on the running host: route answers 200 with the correct no-op shape; rebuilt console serves the banner bundle (typecheck + CSS gate green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)