### PR TITLE
feat(knowledge): console CRUD for the store + opt-in harvest on chat delete

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `POST /api/plugins/sync`) that re-clones every locked plugin at its pinned commit;
   anything already in `plugins.enabled` hot-reloads live. Fetch ≠ enable still
   holds — syncing never turns plugins on.
+- **Knowledge base CRUD from the console.** The Knowledge → Store view was
+  read-only; now the operator can curate it: **add** an entry (+ button — heading,
+  domain, content), **edit** a chunk in place, and **delete** one (with confirm).
+  Backed by `POST/PUT/DELETE /api/knowledge/chunks[/{id}]` on the ADR 0031 backend
+  protocol — edit adds the new revision *before* deleting the old row (a failed
+  save can't lose the original), and a hybrid store re-embeds the new content.
+  Operator-added entries carry `source: console / source_type: operator`.
+
+### Changed
+- **Harvest-on-delete is now opt-in.** Deleting a chat tab silently summarized the
+  conversation into the knowledge base first; the delete dialog now has a
+  **"Harvest into the knowledge base first"** checkbox (off by default — deleting a
+  chat shouldn't copy it into searchable memory unless you ask). The API gained
+  `DELETE /api/chat/sessions/{id}?harvest=true|false` (default false); the TTL
+  prune sweep keeps its config-driven `checkpoint_harvest_enabled` default.
 
 ### Fixed
 - **A render error no longer white-screens the console** (#872): a root error

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1540,6 +1540,12 @@ textarea {
 }
 .playbook-foot { margin-top: 16px; font-size: 11.5px; color: var(--fg-muted); display: flex; align-items: center; gap: 6px; }
 
+/* Knowledge store curation (add / edit / delete a chunk from the console). */
+.knowledge-chunk-form { display: flex; flex-direction: column; gap: 8px; flex: 1; min-width: 0; margin: 8px 0; }
+.knowledge-chunk-form-row { display: flex; gap: 8px; align-items: center; flex-wrap: wrap; }
+.knowledge-chunk-form-row > :first-child { flex: 1; min-width: 180px; }
+.knowledge-chunk-actions { display: flex; gap: 2px; }
+
 /* ── Delegates panel (ADR 0025) — moved to src/settings/delegates.css (#832). ── */
 
 /* Plugin-contributed console views (ADR 0026) — optional subnav above, iframe fills. */

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -64,6 +64,7 @@ export function ChatSurface({
   const chat = useChatState();
   const currentSession = chat.sessions.find((session) => session.id === chat.currentSessionId) || null;
   const [pendingClose, setPendingClose] = useState<string | null>(null);
+  const [harvestOnDelete, setHarvestOnDelete] = useState(false);
   const pendingCloseSession = chat.sessions.find((s) => s.id === pendingClose) || null;
 
   useEffect(() => {
@@ -72,10 +73,10 @@ export function ChatSurface({
     }
   }, [chat.currentSessionId, chat.sessions.length]);
 
-  function closeSession(id: string) {
-    // Retire server-side (harvest history → knowledge, purge checkpoints),
-    // best-effort, then drop the tab locally.
-    void api.deleteChatSession(id).catch(() => {});
+  function closeSession(id: string, harvest: boolean) {
+    // Retire server-side (purge checkpoints; harvest into knowledge ONLY when
+    // the dialog's checkbox opted in), best-effort, then drop the tab locally.
+    void api.deleteChatSession(id, harvest).catch(() => {});
     chatStore.deleteSession(id);
   }
 
@@ -122,14 +123,30 @@ export function ChatSurface({
         confirmLabel="Delete chat"
         destructive
         onConfirm={() => {
-          if (pendingClose) closeSession(pendingClose);
+          if (pendingClose) closeSession(pendingClose, harvestOnDelete);
           setPendingClose(null);
+          setHarvestOnDelete(false);
         }}
-        onClose={() => setPendingClose(null)}
+        onClose={() => { setPendingClose(null); setHarvestOnDelete(false); }}
       >
-        {pendingCloseSession
-          ? `"${pendingCloseSession.title}" and its history will be removed. The conversation is first harvested into the knowledge base, then its checkpoints are purged — this can't be undone from here.`
-          : undefined}
+        {pendingCloseSession ? (
+          <>
+            <p style={{ margin: 0 }}>
+              {`"${pendingCloseSession.title}" and its history will be removed — this can't be undone from here.`}
+            </p>
+            {/* Harvest is OPT-IN: deleting a chat must not silently copy it into
+                searchable memory — the operator may be deleting it precisely to
+                get rid of it. */}
+            <label className="chat-delete-harvest">
+              <input
+                type="checkbox"
+                checked={harvestOnDelete}
+                onChange={(e) => setHarvestOnDelete(e.target.checked)}
+              />
+              Harvest into the knowledge base first (keeps a searchable summary)
+            </label>
+          </>
+        ) : undefined}
       </ConfirmDialog>
     </section>
   );

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -123,3 +123,15 @@
   resize: none;
   overflow-y: auto;
 }
+
+/* Delete-chat dialog: the opt-in harvest checkbox (harvest is never automatic). */
+.chat-delete-harvest {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+  font-size: 12.5px;
+  color: var(--fg-secondary);
+  cursor: pointer;
+}
+.chat-delete-harvest input { accent-color: var(--accent); }

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -1,6 +1,7 @@
-import { Input } from "@protolabsai/ui/forms";
+import { Input, Textarea } from "@protolabsai/ui/forms";
+import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { Brain, Database, RefreshCw } from "lucide-react";
+import { Brain, Database, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
 
 import { useEffect, useState } from "react";
 
@@ -14,6 +15,9 @@ import type { KnowledgeChunk } from "../lib/types";
 // sessions, operator notes. The same store KnowledgeMiddleware queries before
 // every turn, so this is also where you debug "why did it recall that?". Empty
 // query → most-recent chunks; typing runs server-side FTS5 search (debounced).
+// The operator can also CURATE the store here: add a fact, fix a stale chunk,
+// delete a wrong one. Edit replaces the chunk server-side (new id — the new
+// revision is added before the old row is dropped, and a hybrid store re-embeds).
 
 function ago(iso: string | null): string {
   if (!iso) return "—";
@@ -26,12 +30,74 @@ function ago(iso: string | null): string {
   return `${Math.round(s / 86400)}d ago`;
 }
 
+type Draft = { heading: string; domain: string; content: string };
+const EMPTY_DRAFT: Draft = { heading: "", domain: "general", content: "" };
+
+function ChunkForm({
+  draft,
+  setDraft,
+  onSave,
+  onCancel,
+  saving,
+  saveLabel,
+}: {
+  draft: Draft;
+  setDraft: (d: Draft) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  saveLabel: string;
+}) {
+  return (
+    <div className="knowledge-chunk-form">
+      <div className="knowledge-chunk-form-row">
+        <Input
+          type="text"
+          placeholder="heading (optional)"
+          value={draft.heading}
+          onChange={(e) => setDraft({ ...draft, heading: e.target.value })}
+          aria-label="heading"
+        />
+        <Input
+          type="text"
+          placeholder="domain"
+          value={draft.domain}
+          onChange={(e) => setDraft({ ...draft, domain: e.target.value })}
+          aria-label="domain"
+          style={{ maxWidth: 160 }}
+        />
+      </div>
+      <Textarea
+        rows={4}
+        placeholder="What should the agent know? This becomes retrievable context."
+        value={draft.content}
+        onChange={(e) => setDraft({ ...draft, content: e.target.value })}
+        aria-label="content"
+      />
+      <div className="knowledge-chunk-form-row">
+        <Button type="button" variant="primary" size="sm" disabled={saving || !draft.content.trim()} onClick={onSave}>
+          {saveLabel}
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
 export function KnowledgeStore({ onError }: { onError: (message: string) => void }) {
   const [results, setResults] = useState<KnowledgeChunk[]>([]);
   const [stats, setStats] = useState<Record<string, number>>({});
   const [enabled, setEnabled] = useState(true);
   const [loading, setLoading] = useState(false);
   const [query, setQuery] = useState("");
+
+  const [adding, setAdding] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
+  const [saving, setSaving] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<KnowledgeChunk | null>(null);
 
   async function run(q: string) {
     setLoading(true);
@@ -54,6 +120,40 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
     return () => window.clearTimeout(t);
   }, [query]);
 
+  async function save() {
+    setSaving(true);
+    try {
+      if (editingId !== null) {
+        await api.updateKnowledgeChunk(editingId, draft);
+      } else {
+        await api.addKnowledgeChunk(draft);
+      }
+      setAdding(false);
+      setEditingId(null);
+      setDraft(EMPTY_DRAFT);
+      await run(query);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  async function remove(id: number) {
+    try {
+      await api.deleteKnowledgeChunk(id);
+      await run(query);
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    }
+  }
+
+  function startEdit(c: KnowledgeChunk) {
+    setAdding(false);
+    setEditingId(c.id);
+    setDraft({ heading: c.heading || "", domain: c.domain || "general", content: c.content || "" });
+  }
+
   const total = stats.chunks ?? stats.total ?? 0;
 
   return (
@@ -65,6 +165,17 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
           <>
             {/* Quick-set recall behaviour right where you inspect what the agent knows (ADR 0048). */}
             <QuickSetting keys={["knowledge.top_k", "knowledge.embeddings"]} title="Recall" label="Knowledge recall settings" />
+            {enabled ? (
+              <Button
+                icon
+                variant="ghost"
+                type="button"
+                onClick={() => { setEditingId(null); setDraft(EMPTY_DRAFT); setAdding((v) => !v); }}
+                title="Add a knowledge entry"
+              >
+                <Plus size={16} />
+              </Button>
+            ) : null}
             <Button icon variant="ghost" type="button" onClick={() => void run(query)} disabled={loading} title="Refresh">
               <RefreshCw size={16} className={loading ? "spin" : ""} />
             </Button>
@@ -81,6 +192,17 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
           onChange={(e) => setQuery(e.target.value)}
         />
 
+        {adding ? (
+          <ChunkForm
+            draft={draft}
+            setDraft={setDraft}
+            onSave={() => void save()}
+            onCancel={() => { setAdding(false); setDraft(EMPTY_DRAFT); }}
+            saving={saving}
+            saveLabel="Add entry"
+          />
+        ) : null}
+
         {!enabled ? (
           <Empty>
             The knowledge store is off (enable <code>middleware.knowledge</code>).
@@ -91,42 +213,79 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
           ) : (
             <Empty
               title="The knowledge base is empty"
-              description="findings, daily-log entries, and harvested sessions will appear here as the agent works."
+              description="findings, daily-log entries, and harvested sessions will appear here as the agent works — or add one with +."
             />
           )
         ) : (
           <ul className="playbook-list">
             {results.map((c) => (
               <li key={c.id} className="playbook-card">
-                <div className="playbook-main">
-                  <div className="playbook-title">
-                    <span title={`domain: ${c.domain}`}>
-                      <Badge status="success">
-                        <Database size={12} /> {c.domain}
-                      </Badge>
-                    </span>
-                    {c.finding_type ? (
-                      <span title="finding type">
-                        <Badge status="neutral">{c.finding_type}</Badge>
-                      </span>
-                    ) : null}
-                    {c.heading ? <strong>{c.heading}</strong> : null}
-                  </div>
-                  <p className="playbook-desc">{c.content || c.preview}</p>
-                  {c.source ? (
-                    <div className="playbook-tools">
-                      <code>{c.source}</code>
+                {editingId === c.id ? (
+                  <ChunkForm
+                    draft={draft}
+                    setDraft={setDraft}
+                    onSave={() => void save()}
+                    onCancel={() => { setEditingId(null); setDraft(EMPTY_DRAFT); }}
+                    saving={saving}
+                    saveLabel="Save changes"
+                  />
+                ) : (
+                  <>
+                    <div className="playbook-main">
+                      <div className="playbook-title">
+                        <span title={`domain: ${c.domain}`}>
+                          <Badge status="success">
+                            <Database size={12} /> {c.domain}
+                          </Badge>
+                        </span>
+                        {c.finding_type ? (
+                          <span title="finding type">
+                            <Badge status="neutral">{c.finding_type}</Badge>
+                          </span>
+                        ) : null}
+                        {c.heading ? <strong>{c.heading}</strong> : null}
+                      </div>
+                      <p className="playbook-desc">{c.content || c.preview}</p>
+                      {c.source ? (
+                        <div className="playbook-tools">
+                          <code>{c.source}</code>
+                        </div>
+                      ) : null}
                     </div>
-                  ) : null}
-                </div>
-                <div className="playbook-meta">
-                  <span title="added">{ago(c.created_at)}</span>
-                </div>
+                    <div className="playbook-meta">
+                      <span title="added">{ago(c.created_at)}</span>
+                      <span className="knowledge-chunk-actions">
+                        <Button icon variant="ghost" type="button" title="Edit entry" onClick={() => startEdit(c)} aria-label={`edit entry ${c.id}`}>
+                          <Pencil size={14} />
+                        </Button>
+                        <Button icon variant="ghost" type="button" title="Delete entry" onClick={() => setPendingDelete(c)} aria-label={`delete entry ${c.id}`}>
+                          <Trash2 size={14} />
+                        </Button>
+                      </span>
+                    </div>
+                  </>
+                )}
               </li>
             ))}
           </ul>
         )}
       </div>
+
+      <ConfirmDialog
+        open={pendingDelete !== null}
+        title="Delete this knowledge entry?"
+        confirmLabel="Delete entry"
+        destructive
+        onConfirm={() => {
+          if (pendingDelete) void remove(pendingDelete.id);
+          setPendingDelete(null);
+        }}
+        onClose={() => setPendingDelete(null)}
+      >
+        {pendingDelete
+          ? `"${pendingDelete.heading || pendingDelete.preview.slice(0, 80)}" will be removed from the knowledge base — the agent will no longer recall it. This can't be undone.`
+          : undefined}
+      </ConfirmDialog>
 
       <p className="playbook-foot">
         <Brain size={13} /> This is the memory the agent retrieves into context before each turn — search it to see what it knows.

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -502,6 +502,29 @@ export const api = {
     }>(`/api/knowledge/search?q=${encodeURIComponent(q)}`);
   },
 
+  // Knowledge chunk CRUD — operator curation of the store (add a fact, fix a
+  // stale one, drop a wrong one). Edit replaces the chunk (new id): the server
+  // adds the revision first, then deletes the old row, so it works on every
+  // ADR 0031 backend and a hybrid store re-embeds on the way in.
+  addKnowledgeChunk(body: { content: string; domain?: string; heading?: string }) {
+    return request<{ enabled: boolean; id: number | null }>(
+      "/api/knowledge/chunks",
+      { method: "POST", body },
+    );
+  },
+  updateKnowledgeChunk(id: number, body: { content: string; domain?: string; heading?: string; source?: string | null }) {
+    return request<{ enabled: boolean; id: number | null; replaced: boolean }>(
+      `/api/knowledge/chunks/${id}`,
+      { method: "PUT", body },
+    );
+  },
+  deleteKnowledgeChunk(id: number) {
+    return request<{ enabled: boolean; deleted: boolean }>(
+      `/api/knowledge/chunks/${id}`,
+      { method: "DELETE" },
+    );
+  },
+
   deletePlaybook(id: number) {
     return request<{ enabled: boolean; deleted: boolean; error?: string }>(
       `/api/playbooks/${id}`,
@@ -820,11 +843,12 @@ export const api = {
     });
   },
 
-  // Retire a chat session server-side: harvest its history into knowledge (if
-  // enabled) then purge its checkpoints. Fire-and-forget on tab delete.
-  deleteChatSession(sessionId: string) {
+  // Retire a chat session server-side: purge its checkpoints, optionally
+  // harvesting the conversation into knowledge first (the delete dialog's
+  // opt-in checkbox). Fire-and-forget on tab delete.
+  deleteChatSession(sessionId: string, harvest = false) {
     return request<{ deleted: boolean; harvested: boolean }>(
-      `/api/chat/sessions/${encodeURIComponent(sessionId)}`,
+      `/api/chat/sessions/${encodeURIComponent(sessionId)}?harvest=${harvest}`,
       { method: "DELETE" },
     );
   },

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -46,12 +46,16 @@ def register_chat_routes(app, ui: str) -> None:
         return {"response": "\n\n".join(parts), "messages": result}
 
     @app.delete("/api/chat/sessions/{session_id}")
-    async def _api_delete_session(session_id: str):
-        """Retire a chat session: harvest its conversation into the knowledge
-        base (if enabled), then purge its checkpoints. Called when the operator
-        deletes a chat tab, so deleted conversations don't linger to the TTL —
-        their substance lives on as searchable memory instead."""
-        chunk_id = await _retire_thread(f"a2a:{session_id}")
+    async def _api_delete_session(session_id: str, harvest: bool = False):
+        """Retire a chat session: purge its checkpoints, optionally harvesting
+        the conversation into the knowledge base first. Called when the
+        operator deletes a chat tab.
+
+        Harvest is OPT-IN (``?harvest=true`` — the delete dialog's checkbox):
+        deleting a chat must not silently copy it into searchable memory; the
+        operator may be deleting it precisely to get rid of it. The TTL prune
+        sweep keeps its own config-driven default (``checkpoint_harvest_enabled``)."""
+        chunk_id = await _retire_thread(f"a2a:{session_id}", harvest=harvest)
         return {"deleted": True, "harvested": chunk_id is not None}
 
     # --- Goal mode API ------------------------------------------------------

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -3,15 +3,19 @@
 The console's "Knowledge" surface is a searchable Store + Playbooks (ADR 0020):
 the FTS5 knowledge base (findings, daily-log, harvested sessions, operator notes)
 and the procedural-memory skill index. Extracted from ``server._main`` (ADR 0023
-phase 3) into a ``register_knowledge_routes(app)`` registrar. Every route is
-read-only / best-effort and degrades to ``{"enabled": False}`` when its store is
-off; none ever 500s the console.
+phase 3) into a ``register_knowledge_routes(app)`` registrar. Browse/search is
+best-effort and degrades to ``{"enabled": False}`` when its store is off; none of
+the routes ever 500s the console. The chunk CRUD routes let the operator curate
+the store directly (add a fact, fix a stale one, drop a wrong one) — the same
+``KnowledgeBackend`` protocol surface every backend implements (ADR 0031).
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+
+from fastapi.responses import JSONResponse
 
 from runtime.state import STATE
 
@@ -136,3 +140,65 @@ def register_knowledge_routes(app) -> None:
         except Exception:  # noqa: BLE001
             stats = {}
         return {"enabled": True, "query": q, "results": results, "stats": stats}
+
+    # --- Knowledge chunk CRUD (operator curation) ---------------------------
+    # The store fills up with harvested sessions / findings the operator could
+    # only read; these let them curate it: add a fact, fix a stale one, drop a
+    # wrong one. add/delete are the KnowledgeBackend protocol (ADR 0031); edit
+    # composes them (add the new revision FIRST, then delete the old — a failed
+    # add must never lose the original) so it works on every backend, and a
+    # hybrid store re-embeds the new content on the way in.
+
+    @app.post("/api/knowledge/chunks")
+    async def _api_knowledge_add(body: dict | None = None):
+        if STATE.knowledge_store is None:
+            return {"enabled": False, "id": None}
+        body = body or {}
+        content = str(body.get("content", "")).strip()
+        if not content:
+            return JSONResponse({"detail": "content is required"}, status_code=400)
+        chunk_id = await asyncio.to_thread(
+            lambda: STATE.knowledge_store.add_chunk(
+                content,
+                str(body.get("domain", "") or "general"),
+                # kwargs only beyond (content, domain) — the ADR 0031 protocol
+                # guarantees nothing else positionally.
+                heading=(str(body.get("heading", "")).strip() or None),
+                source="console",
+                source_type="operator",
+            )
+        )
+        if chunk_id is None:
+            return JSONResponse({"detail": "the store rejected the chunk"}, status_code=400)
+        return {"enabled": True, "id": chunk_id}
+
+    @app.put("/api/knowledge/chunks/{chunk_id}")
+    async def _api_knowledge_update(chunk_id: int, body: dict | None = None):
+        if STATE.knowledge_store is None:
+            return {"enabled": False, "id": None}
+        body = body or {}
+        content = str(body.get("content", "")).strip()
+        if not content:
+            return JSONResponse({"detail": "content is required"}, status_code=400)
+        new_id = await asyncio.to_thread(
+            lambda: STATE.knowledge_store.add_chunk(
+                content,
+                str(body.get("domain", "") or "general"),
+                heading=(str(body.get("heading", "")).strip() or None),
+                source=(body.get("source") or "console"),
+                source_type="operator",
+            )
+        )
+        if new_id is None:
+            return JSONResponse({"detail": "the store rejected the new revision"}, status_code=400)
+        deleted = await asyncio.to_thread(STATE.knowledge_store.delete_by_id, chunk_id)
+        if not deleted:
+            log.warning("[knowledge] edit of chunk %s left the old row (delete failed)", chunk_id)
+        return {"enabled": True, "id": new_id, "replaced": deleted}
+
+    @app.delete("/api/knowledge/chunks/{chunk_id}")
+    async def _api_knowledge_delete(chunk_id: int):
+        if STATE.knowledge_store is None:
+            return {"enabled": False, "deleted": False}
+        deleted = await asyncio.to_thread(STATE.knowledge_store.delete_by_id, chunk_id)
+        return {"enabled": True, "deleted": bool(deleted)}

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -671,16 +671,27 @@ async def _monitor_goals_loop() -> None:
         await asyncio.sleep(max(5, interval))
 
 
-async def _retire_thread(thread_id: str) -> str | None:
+async def _retire_thread(thread_id: str, *, harvest: bool | None = None) -> str | None:
     """Harvest a thread to the knowledge base (best-effort) then delete its
     checkpoints. Shared by the prune sweep and explicit tab deletion. Returns
-    the harvested knowledge chunk id, if any."""
+    the harvested knowledge chunk id, if any.
+
+    ``harvest`` — ``None`` defers to ``checkpoint_harvest_enabled`` (the TTL
+    sweep's config-driven default); an explicit bool overrides it (the
+    delete-chat dialog's opt-in checkbox: an unchecked box must not harvest
+    just because the sweep is configured to, and a checked box is an explicit
+    operator request)."""
     import asyncio
 
     from graph.checkpoint_prune import delete_thread
 
     chunk_id = None
-    if STATE.graph_config is not None and getattr(STATE.graph_config, "checkpoint_harvest_enabled", False):
+    do_harvest = (
+        getattr(STATE.graph_config, "checkpoint_harvest_enabled", False)
+        if harvest is None
+        else harvest
+    )
+    if STATE.graph_config is not None and do_harvest:
         from graph.conversation_harvest import harvest_thread
         chunk_id = await harvest_thread(
             thread_id,

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -29,6 +29,27 @@ def test_api_chat_joins_assistant_parts(monkeypatch):
     assert body["response"] == "echo:hi"
 
 
+def test_delete_session_harvest_is_opt_in(monkeypatch):
+    # Deleting a chat must NOT silently copy it into the knowledge base: the
+    # route defaults harvest=False and forwards the dialog checkbox explicitly.
+    import operator_api.chat_routes as cr
+
+    calls: list[tuple] = []
+
+    async def _fake_retire(thread_id, *, harvest=None):
+        calls.append((thread_id, harvest))
+        return "chunk-1" if harvest else None
+
+    monkeypatch.setattr(cr, "_retire_thread", _fake_retire)
+    c = _client(monkeypatch)
+
+    body = c.delete("/api/chat/sessions/s1").json()
+    assert body == {"deleted": True, "harvested": False}
+    body = c.delete("/api/chat/sessions/s2?harvest=true").json()
+    assert body == {"deleted": True, "harvested": True}
+    assert calls == [("a2a:s1", False), ("a2a:s2", True)]
+
+
 def test_healthz_ready_and_echoes_ui(monkeypatch):
     c = _client(monkeypatch, graph=object())
     r = c.get("/healthz")

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -45,6 +45,70 @@ def test_knowledge_search_and_browse(monkeypatch):
     assert browse["results"][0]["id"] == 2
 
 
+# ── chunk CRUD (operator curation) ────────────────────────────────────────────
+class _CrudKS:
+    """Backend double tracking add/delete calls (the ADR 0031 protocol surface)."""
+
+    def __init__(self, *, next_id=7, delete_ok=True):
+        self.next_id = next_id
+        self.delete_ok = delete_ok
+        self.added: list[tuple] = []
+        self.deleted: list[int] = []
+
+    def add_chunk(self, content, domain="general", **kwargs):
+        self.added.append((content, domain, kwargs))
+        return self.next_id
+
+    def delete_by_id(self, chunk_id):
+        self.deleted.append(chunk_id)
+        return self.delete_ok
+
+
+def test_chunk_add(monkeypatch):
+    ks = _CrudKS()
+    c = _client(monkeypatch, knowledge=ks)
+    body = c.post("/api/knowledge/chunks", json={"content": "fact", "domain": "ops", "heading": "H"}).json()
+    assert body == {"enabled": True, "id": 7}
+    content, domain, kwargs = ks.added[0]
+    assert (content, domain) == ("fact", "ops")
+    # heading/source ride kwargs ONLY — the protocol guarantees nothing else positionally
+    assert kwargs["heading"] == "H" and kwargs["source_type"] == "operator"
+
+
+def test_chunk_add_requires_content(monkeypatch):
+    c = _client(monkeypatch, knowledge=_CrudKS())
+    assert c.post("/api/knowledge/chunks", json={"content": "  "}).status_code == 400
+
+
+def test_chunk_update_adds_revision_before_deleting_old(monkeypatch):
+    ks = _CrudKS(next_id=9)
+    c = _client(monkeypatch, knowledge=ks)
+    body = c.put("/api/knowledge/chunks/3", json={"content": "fixed fact"}).json()
+    assert body == {"enabled": True, "id": 9, "replaced": True}
+    assert ks.added and ks.deleted == [3]
+
+
+def test_chunk_update_keeps_old_row_when_add_fails(monkeypatch):
+    ks = _CrudKS()
+    ks.add_chunk = lambda *a, **k: None  # store rejects the revision
+    c = _client(monkeypatch, knowledge=ks)
+    assert c.put("/api/knowledge/chunks/3", json={"content": "x"}).status_code == 400
+    assert ks.deleted == []                                   # the original survives
+
+
+def test_chunk_delete(monkeypatch):
+    ks = _CrudKS()
+    c = _client(monkeypatch, knowledge=ks)
+    assert c.delete("/api/knowledge/chunks/4").json() == {"enabled": True, "deleted": True}
+    assert ks.deleted == [4]
+
+
+def test_chunk_crud_disabled_without_store(monkeypatch):
+    c = _client(monkeypatch)
+    assert c.post("/api/knowledge/chunks", json={"content": "x"}).json()["enabled"] is False
+    assert c.delete("/api/knowledge/chunks/1").json() == {"enabled": False, "deleted": False}
+
+
 def test_playbooks_sorted_pinned_first(monkeypatch):
     class _SK:
         def all_skills(self):


### PR DESCRIPTION
## What

Two operator-curation gaps from the new-user test pass:

**1. Harvest-on-delete is now opt-in.** Deleting a chat tab silently summarized the conversation into the knowledge base before purging — but deleting a chat shouldn't copy it into searchable memory unless asked (the operator may be deleting it precisely to get rid of it). The delete dialog gains a **"Harvest into the knowledge base first"** checkbox (off by default); `DELETE /api/chat/sessions/{id}` takes `?harvest=` (default **false**); `_retire_thread` takes `harvest: bool | None` where `None` defers to `checkpoint_harvest_enabled` — so the TTL prune sweep's config-driven behavior is unchanged.

**2. Knowledge base CRUD from the console.** Knowledge → Store was read-only. Now: **add** an entry (+ button — heading/domain/content), **edit** a chunk in place, **delete** with confirm. `POST/PUT/DELETE /api/knowledge/chunks[/{id}]` use only the ADR 0031 `KnowledgeBackend` protocol surface (`add_chunk`/`delete_by_id`; heading/source passed as kwargs since the protocol guarantees nothing beyond `(content, domain)` positionally) — works on any backend, and a hybrid store re-embeds edited content. **Edit adds the new revision before deleting the old row**, so a rejected save can never lose the original. Operator entries carry `source: console / source_type: operator` provenance.

## Test

- 7 new route tests (CRUD happy paths, content-required 400s, add-before-delete ordering on edit, old-row-preserved-when-add-fails, disabled-store degradation, harvest flag passthrough + opt-in default) — 21 pass across the two files.
- **Live on the running host**: add → search finds it (operator provenance) → update (`replaced: true`, new id) → delete → search empty; chat delete returns clean for both `harvest=false` (default) and `harvest=true`. Console rebuilt + served (typecheck + CSS gate green).

🤖 Generated with [Claude Code](https://claude.com/claude-code)