### PR TITLE
chore: ship an empty committed plugins.lock (fresh clones start with no plugins)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The committed `plugins.lock` now ships empty.** A fresh clone previously
+  inherited the upstream developer's local installs (artifact, doom) as
+  "missing / not enabled" rows in the Plugins panel. Upstream starts with no
+  third-party plugins; your installs append to the lock, and forks/deployments
+  commit theirs for reproducible checkouts (ADR 0027 unchanged).
+
 ### Added
 - **One-click plugin sync from the console.** On a fresh checkout (or restored data
   dir) `plugins.lock` lists plugins whose gitignored code isn't on disk; the Plugins

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -50,6 +50,12 @@ dir) the console flags each locked-but-missing plugin and offers a one-click
 **Sync plugins** button (`POST /api/plugins/sync`) — the same re-clone the CLI
 does; plugins that are already in `plugins.enabled` come up live on the spot.
 
+Upstream protoAgent ships the lock **empty** — a fresh clone starts with no
+third-party plugins, by design. Your installs append to it; **forks and
+deployments commit their lock** so their plugin set reproduces on every
+checkout. (That means the upstream developer's own installs show as a local
+diff on `plugins.lock` — expected; commit or discard as you see fit.)
+
 ## Keep one up to date
 
 Because the lock pins a commit SHA, an installed plugin doesn't move until you

--- a/plugins.lock
+++ b/plugins.lock
@@ -1,20 +1,3 @@
 {
-  "plugins": [
-    {
-      "id": "artifact",
-      "source_url": "https://github.com/protoLabsAI/artifact-plugin",
-      "requested_ref": "v0.2.1",
-      "resolved_sha": "e49f185f8366bb371114ef3eb35f1cec3842f321",
-      "installed_at": "2026-06-12T22:33:42.127934+00:00",
-      "by": "console"
-    },
-    {
-      "id": "doom",
-      "source_url": "https://github.com/protoLabsAI/doom-plugin",
-      "requested_ref": "",
-      "resolved_sha": "0d6f91b668d78573be83b1ba1b645c48ad0083de",
-      "installed_at": "2026-06-10T21:26:13.407111+00:00",
-      "by": "console"
-    }
-  ]
+  "plugins": []
 }


### PR DESCRIPTION
Per the new-user test decision: **the committed `plugins.lock` ships empty.**

A fresh clone previously inherited the upstream developer's local installs (artifact, doom) as "missing / not enabled" rows in the Plugins panel — noise for every new user. Upstream now ships `{"plugins": []}` (the installer's canonical empty shape). The ADR 0027 model is unchanged: installs append to the lock, and forks/deployments commit *their* lock for reproducible checkouts — only upstream's default contents change. Guide note added (including that upstream-dev local installs showing as a `plugins.lock` diff is expected).

🤖 Generated with [Claude Code](https://claude.com/claude-code)