### PR TITLE
fix(console): plugin-view rail DnD survives reload — never reconcile an unresolved plugin list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The committed `plugins.lock` now ships empty.** A fresh clone previously
+  inherited the upstream developer's local installs (artifact, doom) as
+  "missing / not enabled" rows in the Plugins panel. Upstream starts with no
+  third-party plugins; your installs append to the lock, and forks/deployments
+  commit theirs for reproducible checkouts (ADR 0027 unchanged).
+
 ### Added
 - **One-click plugin sync from the console.** On a fresh checkout (or restored data
   dir) `plugins.lock` lists plugins whose gitignored code isn't on disk; the Plugins

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   prune sweep keeps its config-driven `checkpoint_harvest_enabled` default.
 
 ### Fixed
+- **Drag-and-drop rail positions for plugin views now survive a reload.** On boot
+  the rail reconciler ran once against the not-yet-loaded plugin list, pruned every
+  persisted `plugin:` entry as "uninstalled", then re-appended the loaded views at
+  their manifest `placement` — silently wiping the operator's arrangement on every
+  reload and making the declared rail look like it always overrode the saved one.
+  The reconciler now waits for the runtime status to resolve (unknown ≠ empty); a
+  view's `placement` is only the default for its first appearance.
 - **A render error no longer white-screens the console** (#872): a root error
   boundary around the app shows a full-page recovery card — Reload, plus "Reset
   chat data & reload" which clears `protoagent.chat.sessions*` (the known way a

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -575,14 +575,20 @@ export function App() {
 
   // Keep plugin views as first-class railOrder members (ADR 0036) — append new ones, prune gone.
   // Keyed on a stable signature so the effect only fires when the view set actually changes.
+  // GATED on the runtime status having RESOLVED: on boot `runtime` is null → zero views →
+  // reconcile would prune every persisted `plugin:` entry as "uninstalled", and the loaded set
+  // would then re-append them at their MANIFEST placement — wiping the operator's drag-and-drop
+  // rail layout on every reload. Unknown ≠ empty: never reconcile against an unresolved list.
+  const pluginViewsLoaded = runtime !== null;
   const pluginViewSig = allPluginViews.map((v) => `${v.key}:${v.placement ?? "rail"}`).join(",");
   useEffect(() => {
+    if (!pluginViewsLoaded) return;
     reconcilePluginViews([
       ...pluginRail.map((v) => ({ id: v.key, side: "left" as const })),
       ...pluginRightPanels.map((v) => ({ id: v.key, side: "right" as const })),
     ]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [pluginViewSig, reconcilePluginViews]);
+  }, [pluginViewSig, pluginViewsLoaded, reconcilePluginViews]);
 
   // Active surface per rail, clamped to a member of that side (a moved surface never leaves a
   // stale active). Chat is no longer pinned — it lives on whichever rail holds it.

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect } from "vitest";
-import { migrateUiState } from "./uiStore";
+import { beforeEach, describe, it, expect } from "vitest";
+import { migrateUiState, useUI } from "./uiStore";
 
 // v1→v2 migration: the obsolete `railOf` (per-surface side map) must be dropped
 // so `railOrder` falls back to the default via the store's merge. A stale
@@ -34,5 +34,57 @@ describe("migrateUiState", () => {
     expect(migrateUiState(null)).toBeNull();
     expect(migrateUiState("nope")).toBe("nope");
     expect(migrateUiState(undefined)).toBeUndefined();
+  });
+});
+
+// reconcilePluginViews keeps plugin views as railOrder members: append new ones at
+// their manifest side, prune uninstalled ones — and NEVER move an id the operator
+// already placed. The manifest `placement` is a default for first appearance, not
+// an override of a persisted drag-and-drop layout. (The App-side caller must also
+// gate on the plugin list having LOADED: reconciling against the boot-time empty
+// set would prune every persisted entry and the reload would re-seed by manifest —
+// the layout-wipe bug this contract pins down.)
+describe("reconcilePluginViews", () => {
+  const seed = (left: string[], right: string[]) =>
+    useUI.setState({ railOrder: { left, right } });
+
+  beforeEach(() => seed(["chat", "plugin:doom:panel"], ["beads", "plugin:board:board", "notes"]));
+
+  it("keeps a moved view at its persisted side and position despite its declared side", () => {
+    // board's manifest says right→ but suppose the operator dragged doom to the left
+    // already; both views re-declare their manifest sides on every reconcile.
+    useUI.getState().reconcilePluginViews([
+      { id: "plugin:doom:panel", side: "right" }, // manifest says right; operator put it LEFT
+      { id: "plugin:board:board", side: "right" },
+    ]);
+    expect(useUI.getState().railOrder.left).toEqual(["chat", "plugin:doom:panel"]);
+    expect(useUI.getState().railOrder.right).toEqual(["beads", "plugin:board:board", "notes"]);
+  });
+
+  it("keeps mid-rail positions (no prune/re-append shuffle)", () => {
+    useUI.getState().reconcilePluginViews([{ id: "plugin:board:board", side: "right" }, { id: "plugin:doom:panel", side: "left" }]);
+    // board stays BETWEEN beads and notes — not re-appended to the bottom.
+    expect(useUI.getState().railOrder.right).toEqual(["beads", "plugin:board:board", "notes"]);
+  });
+
+  it("appends a NEW view at its declared side", () => {
+    useUI.getState().reconcilePluginViews([
+      { id: "plugin:doom:panel", side: "left" },
+      { id: "plugin:board:board", side: "right" },
+      { id: "plugin:browser:panel", side: "right" },
+    ]);
+    expect(useUI.getState().railOrder.right).toEqual(["beads", "plugin:board:board", "notes", "plugin:browser:panel"]);
+  });
+
+  it("prunes a view absent from a non-empty set, leaving core surfaces alone", () => {
+    useUI.getState().reconcilePluginViews([{ id: "plugin:doom:panel", side: "left" }]);
+    expect(useUI.getState().railOrder.left).toEqual(["chat", "plugin:doom:panel"]);
+    expect(useUI.getState().railOrder.right).toEqual(["beads", "notes"]);
+  });
+
+  it("prunes everything on an empty set — why the caller must gate on loaded", () => {
+    useUI.getState().reconcilePluginViews([]);
+    expect(useUI.getState().railOrder.left).toEqual(["chat"]);
+    expect(useUI.getState().railOrder.right).toEqual(["beads", "notes"]);
   });
 });

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -50,6 +50,12 @@ dir) the console flags each locked-but-missing plugin and offers a one-click
 **Sync plugins** button (`POST /api/plugins/sync`) — the same re-clone the CLI
 does; plugins that are already in `plugins.enabled` come up live on the spot.
 
+Upstream protoAgent ships the lock **empty** — a fresh clone starts with no
+third-party plugins, by design. Your installs append to it; **forks and
+deployments commit their lock** so their plugin set reproduces on every
+checkout. (That means the upstream developer's own installs show as a local
+diff on `plugins.lock` — expected; commit or discard as you see fit.)
+
 ## Keep one up to date
 
 Because the lock pins a commit SHA, an installed plugin doesn't move until you

--- a/plugins.lock
+++ b/plugins.lock
@@ -1,20 +1,3 @@
 {
-  "plugins": [
-    {
-      "id": "artifact",
-      "source_url": "https://github.com/protoLabsAI/artifact-plugin",
-      "requested_ref": "v0.2.1",
-      "resolved_sha": "e49f185f8366bb371114ef3eb35f1cec3842f321",
-      "installed_at": "2026-06-12T22:33:42.127934+00:00",
-      "by": "console"
-    },
-    {
-      "id": "doom",
-      "source_url": "https://github.com/protoLabsAI/doom-plugin",
-      "requested_ref": "",
-      "resolved_sha": "0d6f91b668d78573be83b1ba1b645c48ad0083de",
-      "installed_at": "2026-06-10T21:26:13.407111+00:00",
-      "by": "console"
-    }
-  ]
+  "plugins": []
 }


### PR DESCRIPTION
## What

Plugin views can be dragged to another position or the other rail, but the arrangement never survived a reload — the view always snapped back to its manifest `placement`.

**Root cause:** the railOrder reconciler (`reconcilePluginViews`, ADR 0036) is keyed on the view-set signature — which fires once on boot while `runtime` is still `null` (plugin list not loaded → zero views). That empty pass **prunes every persisted `plugin:` entry as "uninstalled"**, and when the list resolves a moment later, the second pass re-appends each view at its **manifest placement**, bottom of the rail. The store function and persistence were both correct; the caller fed it `unknown` as if it were `empty`.

**Fix:** gate the effect on `runtime !== null`. A moved view now keeps its persisted side and mid-rail position; `placement` is what it was designed to be — the default for a view's *first* appearance; real uninstalls (a *resolved* list without the view) still prune.

## Test

- 5 new store-contract vitests for `reconcilePluginViews` (kept side/position despite a different declared side, mid-rail position preserved, new-view append, non-empty prune, and the empty-set wipe that makes the caller gate mandatory) — 10 pass in `uiStore.test.ts`.
- Console build green (typecheck + CSS gate); served from dist immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)