### PR TITLE
chore: release v0.36.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.36.0] - 2026-06-13
+
 ### Changed
 - **The committed `plugins.lock` now ships empty.** A fresh clone previously
   inherited the upstream developer's local installs (artifact, doom) as

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.35.3"
+version = "0.36.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,24 @@
 [
   {
+    "version": "v0.36.0",
+    "date": "2026-06-13",
+    "changes": [
+      "The committed plugins.lock now ships empty.",
+      "One-click plugin sync from the console.",
+      "Knowledge base CRUD from the console.",
+      "Harvest-on-delete is now opt-in.",
+      "Drag-and-drop rail positions for plugin views now survive a reload.",
+      "A render error no longer white-screens the console",
+      "The documented kit-loading pattern for plugin views was broken",
+      "The console prompts for the operator token on 401",
+      "The Notes plugin editor adopts the DS plugin kit (rule 4)",
+      "Design system bumped @protolabsai/ui 0.26.2 → 0.29.0 (+ @protolabsai/design 0.5.1).",
+      "ADR 0049 — bundle pin lifecycle",
+      "Force re-install no longer claims a live hot-mount it can't deliver (#942).",
+      "Annotated-tag pins no longer report a permanent false \"Update available\"."
+    ]
+  },
+  {
     "version": "v0.35.3",
     "date": "2026-06-12",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.36.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.36.0 -m 'Release v0.36.0' && git push origin v0.36.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).