### PR TITLE
chore(ci): make the desktop matrix runners overridable → Namespace-ready

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -45,7 +45,20 @@ jobs:
   build:
     name: ${{ matrix.target }}
     if: github.repository == 'protoLabsAI/protoAgent'
-    runs-on: ${{ matrix.os }}
+    # Per-leg runner, overridable by repo variable so the expensive macOS/Windows
+    # legs can move off GitHub-hosted runners (10×/2× billing multipliers) onto
+    # Namespace profiles WITHOUT editing this file — the moment the org provisions
+    # `namespace-profile-protolabs-{macos,windows}`, set DESKTOP_{MACOS,WINDOWS}_RUNNER
+    # and the next release builds there. Defaults preserve today's hosted runners
+    # exactly (no behaviour change until a var is set). Same fork-friendly pattern as
+    # RELEASE_ENABLED / NSC_CONTAINER_REGISTRY. NB the Linux leg's default stays
+    # ubuntu-22.04 ON PURPOSE — it links the PyInstaller sidecar against the oldest
+    # glibc for broadest AppImage reach; only point DESKTOP_LINUX_RUNNER at a
+    # Namespace profile whose base image is glibc ≤ 2.35 (Ubuntu 22.04).
+    runs-on: >-
+      ${{ matrix.target == 'aarch64-apple-darwin' && (vars.DESKTOP_MACOS_RUNNER || 'macos-14')
+      || matrix.target == 'x86_64-pc-windows-msvc' && (vars.DESKTOP_WINDOWS_RUNNER || 'windows-latest')
+      || (vars.DESKTOP_LINUX_RUNNER || 'ubuntu-22.04') }}
     timeout-minutes: 60
     strategy:
       fail-fast: false

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -31,6 +31,14 @@ When the org updater signing key is present, the legs also attach signed updater
 bundles and a fan-in job uploads `latest.json` — the manifest the desktop app's
 in-app updater polls. See `apps/desktop/README.md` § Updates.
 
+> **Runner cost.** Every other workflow runs on Namespace; the desktop matrix is
+> the only GitHub-hosted usage (macOS bills at 10×, Windows 2×). To move a leg onto
+> a Namespace profile once the org provisions one, set the repo variable
+> `DESKTOP_MACOS_RUNNER` / `DESKTOP_WINDOWS_RUNNER` / `DESKTOP_LINUX_RUNNER` to the
+> profile name — no workflow edit. Leave `DESKTOP_LINUX_RUNNER` unset unless the
+> profile's base image is glibc ≤ 2.35 (Ubuntu 22.04), or the AppImage's portability
+> floor rises. Defaults keep the current hosted runners.
+
 ## Cutting a release
 
 1. **Actions → Prepare Release → Run workflow.** Choose the **bump**: `patch`


### PR DESCRIPTION
## Why

Runner-cost audit: **every workflow already runs on Namespace** (`namespace-profile-protolabs-linux`) — checks, secret-scan, docker-publish, docs, marketing, prepare/release, and pm-stack's verify-bundle. The **only** GitHub-hosted runner usage in the whole org is the `desktop-build.yml` matrix, which fires per release tag with three hosted runners — and macOS bills at **10×**, Windows at **2×**.

## What

The macOS/Windows legs can't move today (the org has no Namespace macOS/Windows profile). So this parameterizes the per-leg runner via repo variables with the current hosted runners as defaults:

```yaml
runs-on: >-
  ${{ matrix.target == 'aarch64-apple-darwin' && (vars.DESKTOP_MACOS_RUNNER || 'macos-14')
  || matrix.target == 'x86_64-pc-windows-msvc' && (vars.DESKTOP_WINDOWS_RUNNER || 'windows-latest')
  || (vars.DESKTOP_LINUX_RUNNER || 'ubuntu-22.04') }}
```

- **Zero behaviour change** until a var is set — the live release path is untouched.
- The moment the org provisions `namespace-profile-protolabs-{macos,windows}`, set the matching repo variable and the **next release builds there, no workflow edit** (same fork-friendly pattern as `RELEASE_ENABLED` / `NSC_CONTAINER_REGISTRY`).
- Linux default stays `ubuntu-22.04` deliberately (the PyInstaller sidecar links the oldest glibc for broadest AppImage reach) — only repoint `DESKTOP_LINUX_RUNNER` at a glibc ≤ 2.35 profile.

Validated: YAML parses and the expression folds to a single line (per-leg resolution checked). Documented in `docs/guides/releasing.md`.

## Follow-up (org-gated, the actual saving)

Provisioning the Namespace macOS + Windows profiles and re-validating Apple signing/notarization on a Namespace mac is the real cost cut — tracked separately. Build steps key on `runner.os`, not the literal runner, so they're portable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)