### PR TITLE
fix(console): settings overlay panel fills full dialog height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,8 +18,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   toggle pinned on top, sections listed down the side), and each section's field
   **groups are collapsible** (DS `Accordion`, 0.29) with a "N unsaved" badge on a
   collapsed group that has edits. Field rows stack to a single column when the
-  in-rail settings column is narrow, and stay two-column in the wide topbar overlay.
-  The vertical nav is an app-local interim pending the DS `SideNav`
+  in-rail settings column is narrow, and stay two-column in the wide topbar overlay
+  (whose body is a flex column so the rail + panel fill its full height). The vertical
+  nav is an app-local interim pending the DS `SideNav`
   ([protoContent#225](https://github.com/protoLabsAI/protoContent/issues/225)); the
   collapsible groups use the shipped `Accordion`.
 

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -146,6 +146,11 @@
   padding: 0;
   height: 80vh;
   overflow: hidden;
+  /* Flex column so the shell (.settings-shell { flex: 1 }) fills the 80vh — without
+     a flex parent the shell collapses to content height and the panel/rail don't
+     reach the dialog's full height. (In the stage, .pl-appshell__col supplies this.) */
+  display: flex;
+  flex-direction: column;
 }
 .theme-quick-dialog .pl-dialog__body {
   padding: 0;


### PR DESCRIPTION
Follow-up to #958. The overlay dialog body was set to `height: 80vh` but stayed `display: block`, so `.settings-shell { flex: 1 1 0 }` had no flex parent and collapsed to content height — the vertical rail and content panel didn't reach the dialog's full height. (In the stage context `.pl-appshell__col` is already a flex column, so only the overlay was affected.)

Fix: make `.settings-overlay .pl-dialog__body` a flex column. Verified by screenshot (rail floor-to-ceiling, content fills, accordions + two-column rows intact); `quick-settings` + `settings` e2e green (8 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)