### PR TITLE
chore(ci): skip the desktop build on patch releases (cut the 10× macOS spend)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -19,10 +19,13 @@ name: Desktop Build
 # updater bundles, and the updater-manifest fan-in job composes latest.json
 # (the manifest the in-app updater polls) onto the release — uploaded last.
 #
-# Fires on semver tags (alongside release.yml's Docker build) and on manual
-# dispatch (dispatch macOS builds are unsigned unless the full signing secret
-# set is present; Linux/Windows are always unsigned). See ADR 0010 (UI tiers /
-# desktop).
+# Fires on MINOR/MAJOR semver tags (a `.0` patch component) alongside release.yml's
+# Docker build, and on manual dispatch. PATCH tags (vX.Y.Z, Z>0) are skipped — a
+# patch is a server/Docker fix and rebuilding the 10×-billed macOS leg per patch is
+# the bulk of CI cost; dispatch this workflow manually with the tag for a patch that
+# genuinely needs a desktop rebuild. Dispatch macOS builds are unsigned unless the
+# full signing secret set is present; Linux/Windows are always unsigned. See
+# ADR 0010 (UI tiers / desktop).
 
 on:
   push:
@@ -44,7 +47,16 @@ permissions:
 jobs:
   build:
     name: ${{ matrix.target }}
-    if: github.repository == 'protoLabsAI/protoAgent'
+    # Skip PATCH releases: desktop legs (esp. GitHub-hosted macOS at 10× billing)
+    # rebuild on every tag, but a patch is almost always a server/Docker fix — the
+    # in-app updater can wait for the next minor. Build only on a `.0` tag
+    # (minor/major), or any manual dispatch (the escape hatch for a patch that DOES
+    # need a desktop rebuild — dispatch this workflow with the tag). Patch releases
+    # still ship Docker + the GitHub release via release.yml; they just carry no new
+    # desktop binaries, and latest.json keeps pointing at the last minor's build.
+    if: >-
+      github.repository == 'protoLabsAI/protoAgent'
+      && (github.event_name == 'workflow_dispatch' || endsWith(github.ref_name, '.0'))
     # Per-leg runner, overridable by repo variable so the expensive macOS/Windows
     # legs can move off GitHub-hosted runners (10×/2× billing multipliers) onto
     # Namespace profiles WITHOUT editing this file — the moment the org provisions
@@ -339,7 +351,12 @@ jobs:
   updater-manifest:
     name: updater manifest (latest.json)
     needs: build
-    if: github.event_name == 'push' && github.repository == 'protoLabsAI/protoAgent'
+    # `needs: build` already skips this when the matrix is skipped (patch tag), but
+    # mirror the `.0` guard so the intent is explicit and a dispatch run (no release
+    # to attach to) doesn't try to compose a manifest.
+    if: >-
+      github.event_name == 'push' && github.repository == 'protoLabsAI/protoAgent'
+      && endsWith(github.ref_name, '.0')
     runs-on: namespace-profile-protolabs-linux
     timeout-minutes: 10
     steps:

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -22,11 +22,18 @@ you merge the PR (CI green)  ──▶  you push tag vX.Y.Z  ──▶  Release 
 `latest` Docker tag is pushed on every `main` merge by `docker-publish.yml` —
 independent of releases.
 
-The tag push also triggers `desktop-build.yml`, which builds the desktop app on
-a three-platform matrix and attaches the artifacts to the same GitHub Release:
-the macOS `.dmg` (signed + notarized — requires the full Apple secret set, the
-leg fails otherwise), the Linux `.AppImage` + `.deb`, and the Windows NSIS
-`-setup.exe` (both unsigned). See `apps/desktop/README.md` § Platforms & CI.
+A **minor/major** tag push (a `.0` patch component) also triggers
+`desktop-build.yml`, which builds the desktop app on a three-platform matrix and
+attaches the artifacts to the same GitHub Release: the macOS `.dmg` (signed +
+notarized — requires the full Apple secret set, the leg fails otherwise), the
+Linux `.AppImage` + `.deb`, and the Windows NSIS `-setup.exe` (both unsigned). See
+`apps/desktop/README.md` § Platforms & CI.
+
+> **Patch releases skip the desktop build.** `vX.Y.Z` with `Z>0` ships Docker + the
+> GitHub release but no new desktop binaries (a patch is a server fix; rebuilding the
+> 10×-billed macOS leg per patch is the bulk of CI cost). The in-app updater keeps
+> pointing at the last minor's build until the next minor. If a patch genuinely needs
+> a desktop rebuild, **Actions → Desktop Build → Run workflow** with the tag.
 When the org updater signing key is present, the legs also attach signed updater
 bundles and a fan-in job uploads `latest.json` — the manifest the desktop app's
 in-app updater polls. See `apps/desktop/README.md` § Updates.


### PR DESCRIPTION
## Why

The desktop-build matrix is the org's **only** GitHub-hosted runner usage, and it rebuilds on **every** release tag — the macOS leg bills at **10×**. A patch release is almost always a server/Docker fix, but it still rebuilds all three desktop binaries including the expensive signed+notarized macOS dmg. We cut 5 releases in 48h, each a full desktop rebuild — that's the bulk of the spend.

## What

Gate both jobs — the `build` matrix and the `updater-manifest` (latest.json) fan-in — on a **`.0` patch component** (minor/major releases):

```yaml
if: github.repository == 'protoLabsAI/protoAgent'
    && (github.event_name == 'workflow_dispatch' || endsWith(github.ref_name, '.0'))
```

- **Patch tags (`vX.Y.Z`, Z>0) skip the desktop build entirely.** They still ship Docker + the GitHub release via `release.yml`; they just carry no new desktop binaries, and `latest.json` keeps pointing at the last minor's build (the in-app updater won't offer a patch).
- **`workflow_dispatch` stays an escape hatch** — a patch that genuinely needs a desktop rebuild is dispatched manually with the tag.
- The `manifest` job already cascades off `needs: build` (skipped build → skipped manifest), but the guard is mirrored for explicitness.

`endsWith(ref_name, '.0')` is exact for semver: the patch component is the segment after the last dot, so `.0` ⟺ patch 0 (`v0.36.0` ✓, `v1.0.0` ✓, `v0.36.1`/`v0.36.10` skip).

Validated: YAML parses, both guards confirmed. Documented in the workflow header + `docs/guides/releasing.md`.

Pairs with #957 (Namespace-ready overridable runners); both tracked in bd-qv5.

🤖 Generated with [Claude Code](https://claude.com/claude-code)