### PR TITLE
feat(sdk): add complete() — a bare LLM completion to the plugin consumption SDK

### DIFF
--- a/docs/adr/0043-plugin-consumption-sdk-workflows-extraction.md
+++ b/docs/adr/0043-plugin-consumption-sdk-workflows-extraction.md
@@ -33,6 +33,13 @@ v1 is deliberately tiny — only what workflows needs:
 config/stores from runtime state), `subagent_types()`, and `config()`. Grow it
 deliberately as more plugins tap core; this is the seam we lean on going forward.
 
+> **Grown since:** `complete(prompt, *, system=None, model_name=None)` — a **bare** LLM
+> completion (no tools, no agent loop, no persona), distinct from `run_subagent`'s
+> full tool-using subagent. The clean primitive for a plugin that just needs the model
+> to answer a prompt — first consumer: the artifact plugin's interactive
+> `window.protoArtifact.ask()` bridge (artifacts call back to the agent, the
+> `window.claude.complete` analog).
+
 **2. Workflows becomes an opt-in plugin (`plugins/workflows`, `enabled: false`).**
 
 - The engine + registry move into the plugin (standalone — the engine was already

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -59,3 +59,28 @@ async def run_subagent(
         extra_tools=extra_tools,
         truncate=truncate,
     )
+
+
+async def complete(
+    prompt: str, *, system: str | None = None, model_name: str | None = None
+) -> str:
+    """Run a single **bare** LLM completion and return the text — no tools, no agent
+    loop, no persona, no memory. The clean primitive for a plugin that just needs the
+    model to answer a prompt (e.g. an interactive artifact calling back to the agent,
+    a one-shot classifier/summarizer). Distinct from :func:`run_subagent`, which runs a
+    full tool-using subagent. Uses the live config's model through the gateway; pass
+    ``model_name`` to target a different model on the same gateway, ``system`` for a
+    system instruction.
+    """
+    from langchain_core.messages import HumanMessage, SystemMessage
+
+    from graph.llm import create_llm
+
+    llm = create_llm(STATE.graph_config, model_name=model_name)
+    messages: list[Any] = []
+    if system:
+        messages.append(SystemMessage(system))
+    messages.append(HumanMessage(prompt))
+    resp = await llm.ainvoke(messages)
+    content = getattr(resp, "content", resp)
+    return content if isinstance(content, str) else str(content)

--- a/tests/test_sdk_complete.py
+++ b/tests/test_sdk_complete.py
@@ -1,0 +1,45 @@
+"""graph.sdk.complete — a bare LLM completion for plugins (ADR 0043 consumption SDK)."""
+from __future__ import annotations
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_complete_invokes_the_model_with_prompt_and_system(monkeypatch):
+    from graph import sdk
+
+    captured = {}
+
+    class _Resp:
+        content = "the answer"
+
+    class _LLM:
+        async def ainvoke(self, messages):
+            captured["messages"] = messages
+            return _Resp()
+
+    monkeypatch.setattr(sdk.STATE, "graph_config", object(), raising=False)
+    monkeypatch.setattr("graph.llm.create_llm", lambda cfg, model_name=None: _LLM())
+
+    out = await sdk.complete("ping", system="be terse")
+    assert out == "the answer"
+    roles = [type(m).__name__ for m in captured["messages"]]
+    assert roles == ["SystemMessage", "HumanMessage"]
+    assert captured["messages"][-1].content == "ping"
+
+
+@pytest.mark.asyncio
+async def test_complete_without_system_sends_only_the_prompt(monkeypatch):
+    from graph import sdk
+
+    class _Resp:
+        content = "ok"
+
+    class _LLM:
+        async def ainvoke(self, messages):
+            assert len(messages) == 1 and type(messages[0]).__name__ == "HumanMessage"
+            return _Resp()
+
+    monkeypatch.setattr(sdk.STATE, "graph_config", object(), raising=False)
+    monkeypatch.setattr("graph.llm.create_llm", lambda cfg, model_name=None: _LLM())
+    assert await sdk.complete("hi") == "ok"


### PR DESCRIPTION
## Why

`graph.sdk` (the ADR 0043 plugin **consumption** seam) exposed only `run_subagent` — a full, tool-using, persona-bearing subagent. The artifact plugin's interactive **`window.protoArtifact.ask()`** bridge (artifacts calling back to the agent — the `window.claude.complete` analog) needs a **clean, bare completion**, not a tool-loop. Reaching into `graph.llm.create_llm` from a plugin would violate the "plugins use `graph.sdk`, not internals" principle.

## What

Add `async complete(prompt, *, system=None, model_name=None) -> str` to `graph/sdk.py`: a single bare LLM completion (no tools, no agent loop, no persona, no memory) via `create_llm` + `ainvoke`, through the gateway. Distinct from `run_subagent`. Documented in ADR 0043 (the SDK's first deliberate growth since v1).

## Verification

2 unit tests (with/without a system message, mocked `create_llm`); ruff clean. The artifact plugin's `/ask` endpoint is the first consumer (separate PR on that repo).

🤖 Generated with [Claude Code](https://claude.com/claude-code)