### PR TITLE
chore: release v0.37.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.37.0] - 2026-06-13
+
 ### Added
 - **`graph.sdk.complete()` — a bare LLM completion for plugins.** The ADR 0043
   consumption SDK exposed only `run_subagent` (a full tool-using subagent); added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.36.0"
+version = "0.37.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "v0.37.0",
+    "date": "2026-06-13",
+    "changes": [
+      "graph.sdk.complete() — a bare LLM completion for plugins.",
+      "Settings is a vertical-nav + collapsible-groups layout now.",
+      "Design system bumped to @protolabsai/ui 0.30.0",
+      "The topbar Settings overlay panel fills the full dialog height"
+    ]
+  },
+  {
     "version": "v0.36.0",
     "date": "2026-06-13",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.37.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.37.0 -m 'Release v0.37.0' && git push origin v0.37.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).