### PR TITLE
fix(config): plugin secret-path discovery fails SAFE, not empty (#877)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **A plugin's declared secret can no longer slip into the tracked config YAML when
+  plugin discovery fails** (#877). `secret_paths()` swallowed any discovery error to an
+  empty set, so a transient failure stopped recognizing a plugin's secret keys and
+  `strip_secrets_from_doc` would write them into the main (exportable/forkable)
+  `langgraph-config.yaml` in plaintext. It now logs the failure and **falls back to the
+  last successfully-discovered set** (fail-safe, never empty). `_resolve_plugin_config`
+  likewise logs instead of silently returning `{}`.
+
 ## [0.37.0] - 2026-06-13
 
 ### Added

--- a/graph/config.py
+++ b/graph/config.py
@@ -60,7 +60,12 @@ def _resolve_plugin_config(data: dict, secrets: dict, config_dir: Path) -> dict:
         schemas = discover_plugin_config(
             roots, set(plugins.get("enabled") or []), set(plugins.get("disabled") or []),
         )
-    except Exception:  # noqa: BLE001 — plugin config is best-effort
+    except Exception as e:  # noqa: BLE001 — plugin config is best-effort, but say so
+        log.warning(
+            "[plugins] config resolution failed — plugin config unavailable this load "
+            "(plugins behave as if unconfigured): %s",
+            e,
+        )
         return {}
 
     out: dict = {}

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -118,6 +118,14 @@ SECRET_PATHS: tuple[tuple[str, str], ...] = (
 )
 
 
+# Last successfully-discovered plugin secret paths. On a discovery FAILURE we fall back
+# to this cache rather than an empty set — otherwise a transient error would stop
+# recognizing a plugin's declared secret keys, and strip_secrets_from_doc (which uses
+# secret_paths) would let that secret be written into the main, exportable/forkable YAML
+# in plaintext (#877). The cache only fails safe (more keys treated as secret).
+_PLUGIN_SECRET_PATHS_CACHE: tuple[tuple[str, str], ...] = ()
+
+
 def secret_paths() -> tuple[tuple[str, str], ...]:
     """Base ``SECRET_PATHS`` plus the (section, key) pairs each INSTALLED plugin
     declares as secrets (ADR 0019). Used by the split/strip logic so a plugin
@@ -125,15 +133,26 @@ def secret_paths() -> tuple[tuple[str, str], ...]:
 
     Covers installed-but-DISABLED plugins too: otherwise a secret saved for a plugin
     that's off wouldn't be recognized as a secret and would be written to the live
-    config YAML in plaintext (the wrong file — configs get exported/backed-up/forked)."""
+    config YAML in plaintext (the wrong file — configs get exported/backed-up/forked).
+
+    On a discovery failure, falls back to the last successful set (never an empty one),
+    so a transient error can't silently downgrade a plugin secret to plaintext (#877)."""
+    global _PLUGIN_SECRET_PATHS_CACHE
     try:
         from graph.plugins.pconfig import installed_plugin_config_schemas
 
         extra = tuple(
             (sch.section, key) for sch in installed_plugin_config_schemas() for key in sch.secrets
         )
-    except Exception:  # noqa: BLE001 — plugin discovery is best-effort
-        extra = ()
+        _PLUGIN_SECRET_PATHS_CACHE = extra  # remember the good set for next time
+    except Exception as e:  # noqa: BLE001 — discovery is best-effort; fail SAFE, not empty
+        extra = _PLUGIN_SECRET_PATHS_CACHE
+        log.warning(
+            "[plugins] secret-path discovery failed — keeping %d cached plugin secret "
+            "path(s) so a declared secret isn't written to the main YAML in plaintext: %s",
+            len(extra),
+            e,
+        )
     return SECRET_PATHS + extra
 
 # Setup wizard state.

--- a/tests/test_config_secrets.py
+++ b/tests/test_config_secrets.py
@@ -135,3 +135,66 @@ def test_disabled_plugin_secret_routes_to_secrets_not_plaintext(tmp_path, monkey
     main, secrets = split_secret_updates({"offp": {"api_key": "sek-ret"}})
     assert secrets == {"offp": {"api_key": "sek-ret"}}  # routed to the secret half
     assert "offp" not in main  # NOT left in the plaintext config YAML
+
+
+# ── #877: a plugin secret-path discovery failure must fail SAFE, not empty ──────
+
+
+def test_secret_paths_falls_back_to_cache_on_discovery_failure(monkeypatch, caplog):
+    """If plugin secret-path discovery raises, secret_paths() keeps the last
+    successfully-discovered plugin secrets (cached) rather than dropping to the base
+    set — otherwise strip_secrets_from_doc would let that key reach the main YAML."""
+    import logging
+
+    from graph import config_io
+
+    pair = ("myplugin", "api_key")
+
+    class _Schema:
+        section = "myplugin"
+        secrets = ["api_key"]
+
+    # 1) a good discovery populates the cache (the plugin secret is recognized).
+    monkeypatch.setattr(config_io, "_PLUGIN_SECRET_PATHS_CACHE", ())
+    monkeypatch.setattr(
+        "graph.plugins.pconfig.installed_plugin_config_schemas", lambda: [_Schema()]
+    )
+    assert pair in config_io.secret_paths()
+
+    # 2) discovery now FAILS — the plugin secret must still be recognized (cached),
+    #    and the failure is logged (no silent downgrade).
+    def _boom():
+        raise RuntimeError("manifest parse blew up")
+
+    monkeypatch.setattr(
+        "graph.plugins.pconfig.installed_plugin_config_schemas", _boom
+    )
+    with caplog.at_level(logging.WARNING, logger="protoagent.config_io"):
+        paths = config_io.secret_paths()
+    assert pair in paths  # fail-safe: NOT dropped to the base set
+    assert any("secret-path discovery failed" in r.message for r in caplog.records)
+
+
+def test_a_plugin_secret_is_stripped_from_the_doc_even_if_rediscovery_fails(monkeypatch):
+    """End-to-end of the #877 guarantee: once a plugin secret is known, a later
+    discovery failure doesn't let strip_secrets_from_doc leave it in the main YAML."""
+    from graph import config_io
+
+    class _Schema:
+        section = "myplugin"
+        secrets = ["api_key"]
+
+    monkeypatch.setattr(config_io, "_PLUGIN_SECRET_PATHS_CACHE", ())
+    monkeypatch.setattr(
+        "graph.plugins.pconfig.installed_plugin_config_schemas", lambda: [_Schema()]
+    )
+    config_io.secret_paths()  # prime the cache
+
+    monkeypatch.setattr(
+        "graph.plugins.pconfig.installed_plugin_config_schemas",
+        lambda: (_ for _ in ()).throw(RuntimeError("boom")),
+    )
+    doc = {"myplugin": {"api_key": "sk-should-be-stripped", "host": "ok-to-keep"}}
+    config_io.strip_secrets_from_doc(doc)
+    assert "api_key" not in doc["myplugin"]  # the secret never reaches the main YAML
+    assert doc["myplugin"]["host"] == "ok-to-keep"  # non-secret kept


### PR DESCRIPTION
Closes #877 (prod-readiness audit, security-adjacent). First of the security-cluster push.

## Problem

Two swallowed-exception sites:
- `config_io.secret_paths()` caught any plugin-discovery error → returned **base secret paths only** (`extra = ()`). A transient failure stopped recognizing a plugin's declared secret keys, and `strip_secrets_from_doc` (which keys off `secret_paths`) would then write that secret into the main — **exportable/forkable** — `langgraph-config.yaml` **in plaintext**.
- `config._resolve_plugin_config` silently returned `{}` on a discovery error (operator sees "plugin misbehaves" with no log line).

## Fix

- `secret_paths()` caches the last successfully-discovered plugin secret-path set and **falls back to it** on a discovery failure (fail-safe — only ever over-protects, never downgrades a secret to plaintext), plus a `log.warning`.
- `_resolve_plugin_config` logs the exception instead of silently returning `{}`.

## Verification

- New tests: `secret_paths` keeps the cached plugin secret + logs when rediscovery raises; **end-to-end**, `strip_secrets_from_doc` still strips a known plugin secret even when rediscovery fails. Full config suite green (88).

🤖 Generated with [Claude Code](https://claude.com/claude-code)