### PR TITLE
fix(security): SSRF egress checks on model probe + fleet remote registration (#871)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **SSRF: the model-probe and fleet-remote registration now run egress checks** (#871).
+  `list_gateway_models` / `validate_model_connection` (reached via `/api/config/models`
+  and `/api/config/test-model`) made a raw request to the operator-supplied `api_base`
+  with no guard — `api_base=http://169.254.169.254/…` was semi-blind SSRF that even
+  echoed the upstream body. They now run `egress.check_url` before the request (blocked
+  hosts need `egress.allowed_hosts`) and no longer echo raw upstream bodies. Registering
+  a fleet remote (`add_remote`) validates the URL too — `allow_private` keeps LAN /
+  tailnet / co-located remotes working while link-local / cloud-metadata / reserved
+  targets are always blocked. `egress.check_url` gains `allow_private` +
+  `block_unresolvable` modes (defaults unchanged for existing callers).
 - **A plugin's declared secret can no longer slip into the tracked config YAML when
   plugin discovery fails** (#877). `secret_paths()` swallowed any discovery error to an
   empty set, so a transient failure stopped recognizing a plugin's secret keys and

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -653,6 +653,13 @@ def list_gateway_models(
 
     key = api_key or os.environ.get("OPENAI_API_KEY", "")
     url = api_base.rstrip("/") + "/models"
+    # SSRF guard (#871): an operator-supplied api_base must not steer this probe at an
+    # internal service or cloud-metadata (169.254.169.254). Blocked unless explicitly
+    # allowlisted via egress.allowed_hosts.
+    from security import egress
+
+    if egress.check_url(url):
+        return [], "api_base host is blocked by the egress guard (set egress.allowed_hosts to permit it)"
     headers = {}
     if key:
         headers["Authorization"] = f"Bearer {key}"
@@ -664,8 +671,8 @@ def list_gateway_models(
         return [], f"connection failed: {e}"
 
     if resp.status_code >= 400:
-        detail = resp.text[:200] if resp.text else ""
-        return [], f"HTTP {resp.status_code} from {url}: {detail}"
+        # Don't echo the raw upstream body (#871) — just the status.
+        return [], f"HTTP {resp.status_code} from the gateway's /models"
 
     try:
         data = resp.json()
@@ -713,6 +720,11 @@ def validate_model_connection(
 
     key = api_key or os.environ.get("OPENAI_API_KEY", "")
     url = api_base.rstrip("/") + "/chat/completions"
+    # SSRF guard (#871) — same as list_gateway_models.
+    from security import egress
+
+    if egress.check_url(url):
+        return False, "api_base host is blocked by the egress guard (set egress.allowed_hosts to permit it)"
     headers = {"Content-Type": "application/json"}
     if key:
         headers["Authorization"] = f"Bearer {key}"

--- a/graph/fleet/supervisor.py
+++ b/graph/fleet/supervisor.py
@@ -271,6 +271,17 @@ def add_remote(name: str, url: str, token: str = "") -> dict:
     url = (url or "").strip().rstrip("/")
     if not url.startswith(("http://", "https://")):
         raise FleetError(f"remote url must be http(s), got {url!r}")
+    # SSRF guard (#871): the hub reverse-proxies /agents/<slug>/* to this URL, so a
+    # registered remote can turn the hub into an internal-network proxy. Fleet remotes
+    # ARE normally private (LAN / tailnet / a co-located instance), so allow_private —
+    # but ALWAYS block link-local/cloud-metadata (169.254.169.254), multicast, reserved.
+    from security import egress
+
+    if egress.check_url(url, allow_private=True, block_unresolvable=False):
+        raise FleetError(
+            f"remote url {url} is blocked by the egress guard (link-local/metadata/"
+            f"reserved address); allowlist it via egress.allowed_hosts if intentional"
+        )
     with _remotes_lock():
         remotes = _load_remotes()
         taken = ({r["name"] for r in remotes.values()}

--- a/security/egress.py
+++ b/security/egress.py
@@ -55,13 +55,18 @@ def _host_allowed(host: str) -> bool:
     return False
 
 
-def _blocked_ip(host: str) -> str | None:
+def _blocked_ip(host: str, *, allow_private: bool = False) -> str | None:
     """Resolve ``host`` and return the first address that is a private/internal
     SSRF target (loopback / link-local / private / multicast / reserved /
     unspecified), or the literal ``"unresolvable"`` when DNS fails (treated as
     unsafe, matching ``a2a_impl.stores``). ``None`` ⇒ the host resolves only to
     globally-routable addresses. One-shot resolution — not a DNS-rebinding
-    defence, but closes the trivial literal/redirect-to-internal vector."""
+    defence, but closes the trivial literal/redirect-to-internal vector.
+
+    ``allow_private=True`` permits private + loopback ranges (LAN / tailnet / a
+    co-located instance — the *normal* case for a fleet remote) while STILL
+    blocking link-local (incl. cloud-metadata ``169.254.169.254``), multicast,
+    reserved and unspecified — the actual SSRF/credential-theft targets."""
     try:
         ipaddress.ip_address(host)
         candidates = [host]
@@ -75,13 +80,15 @@ def _blocked_ip(host: str) -> str | None:
             ip = ipaddress.ip_address(addr)
         except ValueError:
             return addr
-        if (ip.is_loopback or ip.is_link_local or ip.is_private
-                or ip.is_multicast or ip.is_reserved or ip.is_unspecified):
+        # link-local covers the cloud-metadata IP — always blocked.
+        if ip.is_link_local or ip.is_multicast or ip.is_reserved or ip.is_unspecified:
+            return addr
+        if not allow_private and (ip.is_loopback or ip.is_private):
             return addr
     return None
 
 
-def check_url(url: str) -> str | None:
+def check_url(url: str, *, allow_private: bool = False, block_unresolvable: bool = True) -> str | None:
     """Return an error string if the URL's host is not permitted, else ``None``.
 
     Two layers:
@@ -92,6 +99,10 @@ def check_url(url: str) -> str | None:
       private / loopback / link-local / cloud-metadata / reserved address. This
       default-on SSRF guard stops the model `fetch_url`-ing an internal service
       or `169.254.169.254` even when no allowlist is configured.
+
+    ``allow_private=True`` keeps LAN/tailnet/loopback hosts (the normal fleet-remote
+    case) while still blocking link-local/metadata/multicast/reserved — for callers
+    that legitimately reach private peers but must never be steered at metadata.
     """
     try:
         host = (urlparse(url).hostname or "").lower()
@@ -106,13 +117,17 @@ def check_url(url: str) -> str | None:
             f"Error: egress to {host} is blocked — not in the egress allowlist "
             f"({', '.join(_allowed)}). Set egress.allowed_hosts to permit it."
         )
-    bad = _blocked_ip(host)
+    bad = _blocked_ip(host, allow_private=allow_private)
     if bad == "unresolvable":
-        return f"Error: egress to {host} is blocked — host did not resolve."
+        # An unresolvable host is not itself an SSRF target. Callers that register a
+        # URL for later use (a fleet remote that may come online afterwards) pass
+        # block_unresolvable=False; request-time callers keep the strict default.
+        return None if not block_unresolvable else f"Error: egress to {host} is blocked — host did not resolve."
     if bad:
+        kind = "link-local/metadata/reserved" if allow_private else "private/internal"
         return (
             f"Error: egress to {host} ({bad}) is blocked — it resolves to a "
-            f"private/internal address (SSRF guard). Allowlist it via "
+            f"{kind} address (SSRF guard). Allowlist it via "
             f"egress.allowed_hosts if this is intentional."
         )
     return None

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -360,11 +360,12 @@ def test_list_gateway_models_success(monkeypatch):
 
     monkeypatch.setattr("httpx.Client", lambda **kw: fake_client)
 
-    models, err = config_io.list_gateway_models("http://gateway:4000/v1", "test-key")
+    # Public IP literal: passes the egress guard (#871) without needing DNS in CI.
+    models, err = config_io.list_gateway_models("http://8.8.8.8:4000/v1", "test-key")
     assert err == ""
     assert models == ["model-a", "model-b", "model-c"]  # sorted
     called_url = fake_client.get.call_args[0][0]
-    assert called_url == "http://gateway:4000/v1/models"
+    assert called_url == "http://8.8.8.8:4000/v1/models"
 
 
 def test_list_gateway_models_empty_base_returns_error():
@@ -385,7 +386,7 @@ def test_list_gateway_models_http_error(monkeypatch):
 
     monkeypatch.setattr("httpx.Client", lambda **kw: fake_client)
 
-    models, err = config_io.list_gateway_models("http://bad-host/v1")
+    models, err = config_io.list_gateway_models("http://8.8.8.8/v1")
     assert models == []
     assert "connection failed" in err
 
@@ -395,7 +396,7 @@ def test_list_gateway_models_bad_status(monkeypatch):
 
     fake_response = MagicMock()
     fake_response.status_code = 401
-    fake_response.text = "unauthorized"
+    fake_response.text = "unauthorized-secret-leak"
 
     fake_client = MagicMock()
     fake_client.__enter__ = lambda self: fake_client
@@ -404,9 +405,27 @@ def test_list_gateway_models_bad_status(monkeypatch):
 
     monkeypatch.setattr("httpx.Client", lambda **kw: fake_client)
 
-    models, err = config_io.list_gateway_models("http://x/v1", "bad-key")
+    models, err = config_io.list_gateway_models("http://8.8.8.8/v1", "bad-key")
     assert models == []
     assert "401" in err
+    assert "unauthorized-secret-leak" not in err  # raw upstream body not echoed (#871)
+
+
+def test_list_gateway_models_blocks_internal_api_base(monkeypatch):
+    """#871 SSRF: an api_base pointed at cloud-metadata / an internal host is blocked
+    BEFORE any request (no probe, no echoed body)."""
+    from graph import config_io
+
+    called = {"n": 0}
+    fake_client = MagicMock()
+    fake_client.__enter__ = lambda self: fake_client
+    fake_client.__exit__ = lambda *args: None
+    fake_client.get.side_effect = lambda *a, **k: called.__setitem__("n", called["n"] + 1)
+    monkeypatch.setattr("httpx.Client", lambda **kw: fake_client)
+
+    models, err = config_io.list_gateway_models("http://169.254.169.254/latest/v1")
+    assert models == [] and "blocked" in err
+    assert called["n"] == 0  # never hit the network
 
 
 # ── list_available_tools ─────────────────────────────────────────────────────

--- a/tests/test_egress.py
+++ b/tests/test_egress.py
@@ -131,3 +131,24 @@ def test_policy_empty_config_is_default_deny(tmp_path):
     policy = _gen().build_policy(LangGraphConfig())
     assert "default: deny" in policy
     assert "/sandbox" in policy  # data root always read-write
+
+
+# ── #871: allow_private mode (fleet remotes) ────────────────────────────────────
+
+
+def test_allow_private_permits_lan_but_blocks_metadata():
+    # Fleet remotes are normally LAN / tailnet / loopback — allow those, but ALWAYS
+    # block link-local/cloud-metadata, multicast, reserved (the real SSRF targets).
+    for ok in ("http://10.0.0.5:7870/", "http://192.168.1.20/", "http://127.0.0.1:7871/",
+               "http://100.119.239.8/"):  # tailnet
+        assert egress.check_url(ok, allow_private=True) is None, ok
+    for bad in ("http://169.254.169.254/latest/meta-data/",  # cloud metadata
+                "http://224.0.0.1/",                           # multicast
+                "http://0.0.0.0/"):                            # unspecified
+        assert egress.check_url(bad, allow_private=True) is not None, bad
+
+
+def test_default_mode_still_blocks_all_private():
+    # The model-probe path keeps the strict default — private + loopback blocked too.
+    for bad in ("http://10.0.0.5/", "http://127.0.0.1/", "http://169.254.169.254/"):
+        assert egress.check_url(bad) is not None, bad

--- a/tests/test_fleet_supervisor.py
+++ b/tests/test_fleet_supervisor.py
@@ -105,6 +105,10 @@ def test_remote_member_lifecycle(tmp_path, monkeypatch):
         supervisor.add_remote("bad", "ftp://nope")              # not http(s)
     with pytest.raises(supervisor.FleetError):
         supervisor.add_remote("host", "http://h:1")             # reserved slug
+    # SSRF guard (#871): cloud-metadata / link-local is blocked even though private
+    # LAN/tailnet remotes (like ava above) are allowed.
+    with pytest.raises(supervisor.FleetError):
+        supervisor.add_remote("meta", "http://169.254.169.254/latest/meta-data/")
 
     # status(): remote rides along with the cached probe (no probe yet → stopped)
     entry = next(a for a in supervisor.status() if a.get("remote"))

--- a/tests/test_model_validation.py
+++ b/tests/test_model_validation.py
@@ -33,7 +33,7 @@ def test_auth_error_strips_token_hash_and_key(monkeypatch):
     import httpx
     monkeypatch.setattr(httpx, "Client", _client_returning(_FakeResp(401, {"error": {"message": leaky}})))
 
-    ok, err = config_io.validate_model_connection("https://gw.example/v1", "sk-bogus", "m")
+    ok, err = config_io.validate_model_connection("https://8.8.8.8/v1", "sk-bogus", "m")
     assert ok is False
     # The actionable cause survives…
     assert "Authentication Error" in err
@@ -48,7 +48,7 @@ def test_clean_gateway_message_passes_through(monkeypatch):
         httpx, "Client",
         _client_returning(_FakeResp(400, {"error": {"message": "expected to start with 'sk-'"}})),
     )
-    ok, err = config_io.validate_model_connection("https://gw.example/v1", "bad", "m")
+    ok, err = config_io.validate_model_connection("https://8.8.8.8/v1", "bad", "m")
     assert ok is False
     assert "expected to start with 'sk-'" in err
 


### PR DESCRIPTION
Closes #871 (prod-readiness audit). Second of the security-cluster push (after #877).

## Problem

Two operator-supplied-URL surfaces let the server be steered at internal targets / cloud-metadata:
1. **Model probe** — `list_gateway_models` / `validate_model_connection` (via `/api/config/models`, `/api/config/test-model`) made a raw request to `api_base` with **no egress guard** and echoed up to 200 chars of the upstream body. `api_base=http://169.254.169.254/…` → semi-blind SSRF leaking cloud-metadata.
2. **Fleet proxy** — `add_remote` registered any URL the hub then reverse-proxies `/agents/<slug>/*` to, with no validation → register `http://169.254.169.254/` and the hub proxies to internal targets.

## Fix

- Both probes run `egress.check_url()` **before** the request (strict default — private/loopback/link-local blocked; `egress.allowed_hosts` is the escape hatch for a legitimately-private gateway) and **no longer echo the raw upstream body**.
- `add_remote` validates the URL with **`allow_private=True`** (LAN / tailnet / co-located remotes are the normal case) — link-local / cloud-metadata / multicast / reserved are always blocked — and `block_unresolvable=False` (a remote that isn't resolvable yet can still register).
- `security/egress.py` gains `allow_private` + `block_unresolvable` params; **defaults preserve the existing strict behavior** so `fetch_url` and other callers are unchanged.

## Verification

- New tests: egress `allow_private` permits LAN/loopback but blocks metadata/multicast; strict mode still blocks all private; `add_remote` rejects `169.254.169.254`; `list_gateway_models` blocks an internal `api_base` before any request and no longer echoes the body. Existing probe tests use public IP literals so egress passes without DNS. **147 green** across config/fleet/egress/plugins suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)