### PR TITLE
fix(acp): cancel in-flight turn on prompt abort + handle auth_required

### DIFF
--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -51,9 +51,22 @@ def _tool_output_preview(update: dict, limit: int = 300) -> str:
 # ACP protocol version protoAgent speaks. Negotiated in `initialize`.
 PROTOCOL_VERSION = 1
 
+# JSON-RPC error code the agent returns from `session/new` when it has no
+# resolved auth (ACP `AUTH_REQUIRED`). The client surfaces an actionable message.
+AUTH_REQUIRED = -32000
+
 
 class AcpError(Exception):
-    """Any ACP transport / protocol failure. The caller speaks the message."""
+    """Any ACP transport / protocol failure. The caller speaks the message.
+
+    Carries the JSON-RPC error ``code`` when the failure came from an agent
+    error response (else ``None``), so callers can special-case e.g.
+    ``AUTH_REQUIRED``.
+    """
+
+    def __init__(self, message: str, *, code: int | None = None) -> None:
+        super().__init__(message)
+        self.code = code
 
 
 class AcpClient:
@@ -90,6 +103,9 @@ class AcpClient:
 
         self._proc: asyncio.subprocess.Process | None = None
         self._session_id: str | None = None
+        # Captured from the `initialize` response (was previously discarded).
+        self._auth_methods: list[dict] = []
+        self._agent_capabilities: dict = {}
         self._next_id = 0
         self._pending: dict[int, asyncio.Future] = {}
         self._reader_task: asyncio.Task | None = None
@@ -205,7 +221,13 @@ class AcpClient:
             fut = self._pending.pop(msg["id"], None)
             if fut and not fut.done():
                 if "error" in msg:
-                    fut.set_exception(AcpError(str(msg["error"])))
+                    err = msg.get("error") or {}
+                    if isinstance(err, dict):
+                        fut.set_exception(
+                            AcpError(str(err.get("message") or err), code=err.get("code"))
+                        )
+                    else:
+                        fut.set_exception(AcpError(str(err)))
                 else:
                     fut.set_result(msg.get("result"))
             return
@@ -325,10 +347,38 @@ class AcpClient:
     async def _respond_error(self, rid, code: int, message: str) -> None:
         await self._send({"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": message}})
 
+    async def _cancel_session(self) -> None:
+        """Best-effort ``session/cancel`` notification: tell the agent to abandon
+        the in-flight turn so a reused session isn't left mid-generation.
+
+        Runs on the prompt abort path (timeout / external cancel / transport
+        failure), so it must never raise: no-op when the process is gone or no
+        session is open, and swallows any send error. ``session/cancel`` is a
+        notification (no id, no response)."""
+        proc = self._proc
+        if not (proc and proc.returncode is None and proc.stdin and self._session_id):
+            return
+        try:
+            proc.stdin.write(
+                (
+                    json.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "method": "session/cancel",
+                            "params": {"sessionId": self._session_id},
+                        }
+                    )
+                    + "\n"
+                ).encode()
+            )
+            await proc.stdin.drain()
+        except Exception as exc:  # noqa: BLE001 — abort path is best-effort
+            logger.debug("[acp/%s] session/cancel failed (best-effort): %s", self.name, exc)
+
     # -- handshake -----------------------------------------------------------
 
     async def _initialize(self) -> None:
-        await self._request(
+        result = await self._request(
             "initialize",
             {
                 "protocolVersion": PROTOCOL_VERSION,
@@ -340,12 +390,44 @@ class AcpClient:
                 },
             },
             timeout=30.0,
-        )
+        ) or {}
+        # Keep what the agent told us instead of discarding it: its auth methods
+        # (for an actionable auth-required message) and capabilities.
+        self._auth_methods = result.get("authMethods") or []
+        self._agent_capabilities = result.get("agentCapabilities") or {}
+        negotiated = result.get("protocolVersion")
+        if isinstance(negotiated, int) and negotiated != PROTOCOL_VERSION:
+            logger.warning(
+                "[acp/%s] agent negotiated ACP protocol v%s but client speaks v%s — "
+                "proceeding, but behaviour may differ",
+                self.name,
+                negotiated,
+                PROTOCOL_VERSION,
+            )
 
     async def _new_session(self) -> None:
-        result = await self._request(
-            "session/new", {"cwd": self.cwd, "mcpServers": self.mcp_servers}, timeout=30.0
-        )
+        try:
+            result = await self._request(
+                "session/new", {"cwd": self.cwd, "mcpServers": self.mcp_servers}, timeout=30.0
+            )
+        except AcpError as exc:
+            if exc.code == AUTH_REQUIRED:
+                methods = (
+                    ", ".join(
+                        str(m.get("id") or m.get("name"))
+                        for m in self._auth_methods
+                        if isinstance(m, dict)
+                    )
+                    or "(none advertised)"
+                )
+                raise AcpError(
+                    f"{self.name} agent requires authentication before a session can "
+                    f"start. Configure its credentials in the delegate env (e.g. "
+                    f"OPENAI_API_KEY, OPENAI_MODEL, OPENAI_BASE_URL). Advertised auth "
+                    f"methods: {methods}.",
+                    code=AUTH_REQUIRED,
+                ) from exc
+            raise
         self._session_id = (result or {}).get("sessionId")
         if not self._session_id:
             raise AcpError("session/new returned no sessionId")
@@ -382,6 +464,12 @@ class AcpClient:
                 },
                 timeout=timeout,
             )
+        except (AcpError, asyncio.CancelledError):
+            # Turn abandoned — internal timeout, external cancel (e.g. an
+            # orchestrator's wait_for watchdog), or transport failure. Tell the
+            # agent to drain it so the reused session isn't left mid-generation.
+            await self._cancel_session()
+            raise
         finally:
             self._progress = None
             self._on_tool = None

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -10,6 +10,7 @@ and client-cache eviction/teardown.
 
 from __future__ import annotations
 
+import asyncio
 import sys
 
 import pytest
@@ -130,6 +131,99 @@ async def test_acp_client_bad_workdir_raises_acp_error():
     client = AcpClient(sys.executable, [], cwd="/no/such/dir/anywhere")
     with pytest.raises(AcpError):
         await client.prompt("hi", timeout=10.0)
+
+
+# ── abort + auth lifecycle ────────────────────────────────────────────────────
+
+# Handshakes, then on session/prompt HANGS (never replies) — keeps reading stdin
+# so it can receive a session/cancel notification, which it records to a marker
+# file. Proves the client cancels the in-flight turn on the abort path instead of
+# leaving the session mid-generation.
+_CANCEL_AGENT = r'''
+import sys, json, os
+MARKER = os.environ.get("CANCEL_MARKER", "")
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n"); sys.stdout.flush()
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method, mid = msg.get("method"), msg.get("id")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"protocolVersion": 1}})
+    elif method == "session/new":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"sessionId": "s1"}})
+    elif method == "session/prompt":
+        pass  # hang — wait for the client to cancel
+    elif method == "session/cancel":
+        if MARKER:
+            with open(MARKER, "w") as fh:
+                fh.write("cancelled")
+        break
+'''
+
+# Advertises an auth method, then rejects session/new with AUTH_REQUIRED (-32000).
+_AUTH_AGENT = r'''
+import sys, json
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n"); sys.stdout.flush()
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method, mid = msg.get("method"), msg.get("id")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": mid, "result": {
+            "protocolVersion": 1,
+            "authMethods": [{"id": "openai", "name": "Use OpenAI API key"}]}})
+    elif method == "session/new":
+        send({"jsonrpc": "2.0", "id": mid,
+              "error": {"code": -32000, "message": "auth required"}})
+'''
+
+
+async def test_prompt_timeout_sends_session_cancel(tmp_path):
+    script = tmp_path / "cancel_agent.py"
+    script.write_text(_CANCEL_AGENT, encoding="utf-8")
+    marker = tmp_path / "cancelled.marker"
+    client = AcpClient(
+        sys.executable, [str(script)], cwd=str(tmp_path), name="cancel",
+        env={"CANCEL_MARKER": str(marker)},
+    )
+    try:
+        with pytest.raises(AcpError):
+            await client.prompt("hang please", timeout=1.0)
+        # The timeout path must have sent session/cancel; the fake records it.
+        for _ in range(60):
+            if marker.exists():
+                break
+            await asyncio.sleep(0.05)
+        assert marker.exists(), "client did not send session/cancel on prompt timeout"
+    finally:
+        await client.close()
+
+
+async def test_session_new_auth_required_raises_actionable(tmp_path):
+    script = tmp_path / "auth_agent.py"
+    script.write_text(_AUTH_AGENT, encoding="utf-8")
+    client = AcpClient(sys.executable, [str(script)], cwd=str(tmp_path), name="auth")
+    try:
+        with pytest.raises(AcpError) as ei:
+            await client.prompt("do work", timeout=10.0)
+    finally:
+        await client.close()
+    msg = str(ei.value)
+    assert "requires authentication" in msg   # actionable, not opaque
+    assert "openai" in msg                     # advertised auth method surfaced
+    assert ei.value.code == -32000             # AUTH_REQUIRED preserved
 
 
 # ── permission policy ─────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
Two robustness fixes to the shared ACP client (`plugins/coding_agent/acp_client.py`) — the library the `delegates` plugin and the `project_board` loop drive coding agents over. Found while auditing the proto ⇄ protoAgent ACP integration end-to-end.

### 1. `session/cancel` on prompt abort
`prompt()` raised on timeout/cancel but **left the agent generating**. With a cached, reused session (the normal case — `_client_for` keeps one subprocess+session per spec) that orphans the turn and the next prompt can collide. Now, when a turn is abandoned — internal timeout, external `CancelledError` (e.g. `project_board`'s `wait_for` watchdog in `worktree.dispatch_coder`), or transport failure — the client sends a best-effort `session/cancel` notification so the agent drains the turn before the subprocess is reaped. **project_board's timeout path inherits this: hard-kill → graceful drain.**

### 2. Actionable `auth_required`
`initialize`'s response was discarded. It's now captured (`authMethods`, `agentCapabilities`, negotiated `protocolVersion`) with a version-mismatch warning. When `session/new` returns `AUTH_REQUIRED` (-32000), the client raises a clear error — "configure credentials (OPENAI_API_KEY/MODEL/BASE_URL), advertised methods: …" — instead of an opaque stringified JSON-RPC error. `AcpError` now carries `.code`.

## Test plan
- [x] Two new wire-exchange tests against fake ACP agents: one hangs on `session/prompt` and records the `session/cancel` it receives; one rejects `session/new` with -32000 and asserts the actionable message + preserved code.
- [x] `test_coding_agent_plugin.py` 14 passing; adjacent `test_acp_runtime` / `test_delegates_*` 44 passing
- [x] ruff clean
- [ ] CI

## Context
The projectBoard-plugin (Automaker's replacement) and the `delegates` plugin both ride this client and don't reimplement ACP — so this is the right single place to harden. The proto (protoCLI) agent side already supports `session/cancel` and emits `auth_required`, so both halves now line up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)