### PR TITLE
fix(plugin-devkit): serve views by the four rules + ship-ready scaffolds

### DIFF
--- a/graph/plugins/cli.py
+++ b/graph/plugins/cli.py
@@ -29,6 +29,7 @@ def _build_parser() -> argparse.ArgumentParser:
     pn.add_argument("--skill", action="store_true", help="include a SKILL.md skill stub")
     pn.add_argument("--workflow", action="store_true", help="include a workflow YAML stub")
     pn.add_argument("--comms", action="store_true", help="a communication plugin (ChatAdapter, ADR 0029) instead of a tool plugin")
+    pn.add_argument("--tests", action="store_true", help="include a host-free test suite + CI + requirements-dev (for a standalone-repo plugin)")
     pn.add_argument("--dir", default=None, help="target dir (default: the live plugins dir the loader discovers)")
 
     pnb = sub.add_parser("new-bundle", help="scaffold a plugin BUNDLE (protoagent.bundle.yaml, ADR 0040)")
@@ -62,7 +63,8 @@ def run_plugin_cli(argv: list[str]) -> int:
             try:
                 res = scaffold.scaffold_plugin(
                     args.name, summary=args.summary, with_view=args.view, with_skill=args.skill,
-                    with_workflow=args.workflow, with_comms=args.comms, target_dir=args.dir,
+                    with_workflow=args.workflow, with_comms=args.comms, with_tests=args.tests,
+                    target_dir=args.dir,
                 )
             except FileExistsError as e:
                 print(f"✗ {scaffold.slug(args.name)!r} already exists at {e}", file=sys.stderr)

--- a/graph/plugins/scaffold.py
+++ b/graph/plugins/scaffold.py
@@ -47,14 +47,23 @@ _VIEW_STUB = '''
 
     @router.get("/view")
     async def _view():
-        # The console iframes this page (ADR 0038) and postMessages it the operator
-        # bearer + theme (ADR 0026). Serve a sandboxed page; for untrusted/generated
-        # content keep the inner frame sandbox="allow-scripts" with no same-origin.
-        return HTMLResponse("<!doctype html><body style='background:#0a0a0c;color:#ededed;"
-                            "font-family:system-ui;padding:32px'><h1>{name}</h1>"
-                            "<p>Your plugin view — replace this page.</p></body>")
-    # Mounted under /api/plugins/{id} so it inherits the operator bearer gate (ADR 0026).
-    registry.register_router(router, prefix="/api/plugins/{id}")
+        # Four rules (ADR 0026/0038): serve the declared path · gate DATA (not the page)
+        # · slug-aware base · link the DS kit. Untrusted/generated HTML → nest it in an
+        # <iframe sandbox="allow-scripts"> with NO same-origin.
+        return HTMLResponse(
+            "<!doctype html><html><head><meta charset='utf-8'>"
+            "<script>var B=location.pathname.split('/plugins/')[0];"  # "" on host, /agents/<slug> via proxy
+            "var l=document.createElement('link');l.rel='stylesheet';"
+            "l.href=B+'/_ds/plugin-kit.css';document.head.appendChild(l);</script>"
+            "<style>body{{margin:0;padding:32px;background:var(--pl-color-bg);"
+            "color:var(--pl-color-fg);font-family:var(--pl-font-sans,system-ui)}}</style>"
+            "</head><body><h1>{name}</h1>"
+            "<p>Your plugin view — replace this page. Load the kit JS and fetch gated data "
+            "with kit.apiFetch('/api/plugins/{id}/...').</p></body></html>"
+        )
+    # The PAGE is PUBLIC: an iframe page-load can't carry a bearer, so it must NOT be
+    # gated. Mount any DATA routes under /api/plugins/{id} for the operator bearer gate.
+    registry.register_router(router, prefix="/plugins/{id}")
 '''
 
 _MANIFEST_STUB = """id: {id}
@@ -95,6 +104,145 @@ steps:
       {{{{inputs.request}}}}
 output: "{{{{steps.do.output}}}}"
 """
+
+# Shippable-repo stubs (with_tests) — a host-free test suite + CI + dev deps, so a
+# standalone-repo plugin is green from birth. Written verbatim unless noted.
+_CONFTEST_STUB = '''"""Test bootstrap — load the plugin host-free (no protoAgent running).
+
+Executing __init__.py is safe: the host-only imports (fastapi, graph.*) are lazy
+(inside register()), so the suite needs only requirements-dev.txt.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+@pytest.fixture
+def plugin():
+    spec = importlib.util.spec_from_file_location("plugin_under_test", ROOT / "__init__.py")
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+class _Registry:
+    """A fake registry — records what register() contributes, with no host."""
+
+    def __init__(self):
+        self.config = {}
+        self.tools, self.routers, self.surfaces, self.subagents, self.skill_dirs = [], [], [], [], []
+
+    def register_tool(self, t):
+        self.tools.append(t)
+
+    def register_tools(self, ts):
+        self.tools.extend(ts)
+
+    def register_router(self, router, prefix=""):
+        self.routers.append(prefix)
+
+    def register_surface(self, start, stop=None, name=None):
+        self.surfaces.append(name)
+
+    def register_subagent(self, cfg):
+        self.subagents.append(cfg)
+
+    def register_skill_dir(self, path):
+        self.skill_dirs.append(path)
+
+    def emit(self, *a, **k):
+        pass
+
+    def on(self, *a, **k):
+        pass
+
+
+@pytest.fixture
+def registry():
+    return _Registry()
+'''
+
+# .format(id=, name=) — no other literal braces.
+_TEST_STUB = '''"""Smoke tests for {name} — host-free (no protoAgent running)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+ROOT = Path(__file__).resolve().parent.parent
+
+
+def test_register_runs_host_free(plugin, registry):
+    plugin.register(registry)  # must not raise with no host present
+    # The scaffold wires its contributions here — replace with your real assertions.
+    assert registry.tools or registry.routers or registry.surfaces or registry.subagents
+
+
+def test_manifest_is_valid():
+    m = yaml.safe_load((ROOT / "protoagent.plugin.yaml").read_text())
+    assert m["id"] == "{id}" and m["version"]
+'''
+
+# Verbatim (the ${{ }} is GitHub Actions syntax — do NOT .format this).
+_CI_STUB = """name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    # The org's Namespace Linux profile; override NSC_RUNNER on a fork that lacks it.
+    runs-on: ${{ vars.NSC_RUNNER || 'namespace-profile-protolabs-linux' }}
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+      - run: pip install -r requirements-dev.txt ruff
+      # Lint the whole plugin; format-check only tests/ (the generated starter
+      # __init__ is yours to shape). Broaden to `ruff format --check .` once you've
+      # run `ruff format .` on your code.
+      - run: ruff check . && ruff format --check tests/
+      - run: pytest -q
+"""
+
+_REQS_DEV_STUB = """# Test-only deps — the host (protoAgent) provides langchain-core + fastapi at
+# runtime; these let the suite run standalone in CI with no host.
+fastapi>=0.110
+langchain-core>=0.2
+pyyaml>=6
+httpx>=0.27
+pytest>=8
+# pytest-asyncio>=0.23   # uncomment if you add async tests (asyncio_mode below)
+"""
+
+# .format(id=) — no literal braces in this TOML.
+_PYPROJECT_STUB = """[project]
+name = "{id}"
+version = "0.1.0"            # keep in lockstep with protoagent.plugin.yaml
+requires-python = ">=3.11"
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+pythonpath = ["."]
+# asyncio_mode = "auto"     # uncomment with pytest-asyncio for async tests
+
+[tool.ruff]
+line-length = 120
+target-version = "py311"
+"""
+
 
 # Communication plugin (ADR 0029) — a ChatAdapter on the shared wirer.
 _COMMS_MANIFEST_STUB = """id: {id}
@@ -224,6 +372,7 @@ def scaffold_plugin(
     with_skill: bool = False,
     with_workflow: bool = False,
     with_comms: bool = False,
+    with_tests: bool = False,
     target_dir: str | None = None,
 ) -> Scaffolded:
     """Write a new plugin SKELETON (manifest + ``register()`` + optional
@@ -231,7 +380,11 @@ def scaffold_plugin(
 
     ``with_comms=True`` writes a **communication plugin** (ADR 0029) — a
     ``ChatAdapter`` skeleton on the shared wirer instead of the default tool
-    plugin. Raises ``FileExistsError`` if the id already exists.
+    plugin. ``with_tests=True`` also writes a **host-free test suite + CI +
+    requirements-dev + pyproject** so a standalone-repo plugin is green from birth
+    (skip it for a plugin bundled inside protoAgent, which uses the host's tests/CI;
+    not written for ``with_comms`` plugins, which import the host at module top).
+    Raises ``FileExistsError`` if the id already exists.
     """
     pid = slug(name)
     id_us = pid.replace("-", "_")
@@ -258,7 +411,7 @@ def scaffold_plugin(
         return Scaffolded(id=pid, path=target, made=made, kind="comms")
 
     views_block = (
-        f"views:\n  - {{ id: main, label: \"{name}\", icon: Boxes, path: /api/plugins/{pid}/view }}\n"
+        f"views:\n  - {{ id: main, label: \"{name}\", icon: Boxes, path: /plugins/{pid}/view }}\n"
         if with_view else ""
     )
     (target / "protoagent.plugin.yaml").write_text(
@@ -286,8 +439,24 @@ def scaffold_plugin(
         (target / "workflows").mkdir()
         (target / "workflows" / f"{pid}.yaml").write_text(_WORKFLOW_STUB.format(id=pid))
         made.append("workflows/")
+    if with_tests:
+        _write_test_harness(target, pid=pid, id_us=id_us, name=name)
+        made += ["tests/", ".github/workflows/ci.yml", "requirements-dev.txt", "pyproject.toml"]
 
     return Scaffolded(id=pid, path=target, made=made, kind="plugin")
+
+
+def _write_test_harness(target: Path, *, pid: str, id_us: str, name: str) -> None:
+    """Write the host-free test suite + CI + dev deps + pyproject (with_tests)."""
+    tdir = target / "tests"
+    tdir.mkdir()
+    (tdir / "conftest.py").write_text(_CONFTEST_STUB)
+    (tdir / f"test_{id_us}.py").write_text(_TEST_STUB.format(id=pid, name=name))
+    gh = target / ".github" / "workflows"
+    gh.mkdir(parents=True)
+    (gh / "ci.yml").write_text(_CI_STUB)
+    (target / "requirements-dev.txt").write_text(_REQS_DEV_STUB)
+    (target / "pyproject.toml").write_text(_PYPROJECT_STUB.format(id=pid))
 
 
 def _render_members(members: list[dict] | None) -> tuple[str, list[str]]:

--- a/plugins/plugin-devkit/__init__.py
+++ b/plugins/plugin-devkit/__init__.py
@@ -90,6 +90,7 @@ def _build_scaffold_tool(config: dict | None):
         with_skill: bool = False,
         with_workflow: bool = False,
         with_comms: bool = False,
+        with_tests: bool = False,
         enable: bool = True,
     ) -> str:
         """Scaffold a new protoAgent plugin SKELETON on disk AND enable it live —
@@ -105,6 +106,11 @@ def _build_scaffold_tool(config: dict | None):
         connect/receive/send, then enable it from Settings (it needs a token), so
         comms plugins are NOT auto-enabled here.
 
+        Set ``with_tests=True`` to also write a host-free test suite + CI +
+        requirements-dev + pyproject — use it when scaffolding a STANDALONE-repo
+        plugin (its own git repo) so it's shippable + green from birth; skip it for a
+        plugin bundled inside protoAgent (which rides the host's tests/CI).
+
         Use this when asked to create/build/scaffold a plugin; see the building-plugins
         skill for the contract.
         """
@@ -112,7 +118,7 @@ def _build_scaffold_tool(config: dict | None):
             res = scaffold.scaffold_plugin(
                 name, summary=summary, with_tool=with_tool, with_view=with_view,
                 with_skill=with_skill, with_workflow=with_workflow, with_comms=with_comms,
-                target_dir=target_dir,
+                with_tests=with_tests, target_dir=target_dir,
             )
         except FileExistsError as e:
             return f"✗ {scaffold.slug(name)!r} already exists at {e} — pick another name or remove it first."
@@ -240,8 +246,10 @@ def _plugin_architect() -> SubagentConfig:
             "`register(registry)` sketch. Follow the plugin contract: the manifest is "
             "data; code runs only on enable; config_section is a string; skills/ and "
             "workflows/ subdirs auto-load; declare requires_pip, don't assume it's "
-            "installed; console views are sandboxed iframes served under /api/plugins/<id> "
-            "(ADR 0038); plugins coordinate via the event bus (registry.emit/on), never "
+            "installed; console views are sandboxed iframes — serve the PAGE on the public "
+            "/plugins/<id> prefix (an iframe load can't carry a bearer) and its DATA on the "
+            "gated /api/plugins/<id> (ADR 0026/0038); plugins coordinate via the event bus "
+            "(registry.emit/on), never "
             "by importing each other (ADR 0039). Keep it to the smallest plugin that "
             "satisfies the request."
         ),
@@ -255,14 +263,30 @@ def _build_guide_router():
 
     router = APIRouter()
 
+    # This page is itself a four-rules-compliant view (the reference plugin should
+    # model the contract): it derives a slug-aware BASE, links the DS plugin-kit off
+    # it (so it themes live via --pl-* tokens), and serves NO bearer-gated data —
+    # it's a static card, so it lives on the PUBLIC /plugins/<id> prefix.
     @router.get("/guide")
     async def _guide():
-        html = """<!doctype html><html><head><meta charset="utf-8"><style>
-          html,body{margin:0;background:#0a0a0c;color:#ededed;font-family:ui-sans-serif,system-ui,sans-serif}
-          .wrap{max-width:52ch;margin:0 auto;padding:40px 28px;line-height:1.6}
-          h1{color:#a78bfa;font-size:22px;margin:0 0 4px} h2{color:#a78bfa;font-size:15px;margin:22px 0 6px}
-          code{background:#19191d;color:#a78bfa;padding:2px 6px;border-radius:5px;font-size:13px}
-          p,li{color:#a3a3ad;font-size:14px} ul{padding-left:18px}
+        html = """<!doctype html><html lang="en"><head><meta charset="utf-8">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+        <script>
+          // RULE 3 — slug-aware base ("" on host, "/agents/<slug>" through the fleet proxy).
+          var BASE = location.pathname.split("/plugins/")[0];
+          // RULE 4 — link the DS kit CSS off BASE so the card themes live (no hardcoded hex).
+          (function(){ var l=document.createElement("link"); l.rel="stylesheet";
+            l.href=BASE+"/_ds/plugin-kit.css"; document.head.appendChild(l); })();
+        </script>
+        <style>
+          html,body{margin:0;background:var(--pl-color-bg);color:var(--pl-color-fg);
+            font-family:var(--pl-font-sans, ui-sans-serif,system-ui,sans-serif)}
+          .wrap{max-width:54ch;margin:0 auto;padding:40px 28px;line-height:1.6}
+          h1{color:var(--pl-color-accent);font-size:22px;margin:0 0 4px}
+          h2{color:var(--pl-color-accent);font-size:15px;margin:22px 0 6px}
+          code{background:var(--pl-color-bg-raised);color:var(--pl-color-accent);
+            padding:2px 6px;border-radius:var(--pl-radius,5px);font-size:13px}
+          p,li{color:var(--pl-color-fg-muted);font-size:14px} ul{padding-left:18px}
         </style></head><body><div class="wrap">
           <h1>Plugin Devkit</h1>
           <p>This plugin gives the agent what it needs to build plugins — and is itself
@@ -270,7 +294,7 @@ def _build_guide_router():
           <h2>Build it live (no restart)</h2>
           <ul>
             <li><code>scaffold_plugin</code> — writes a skeleton <strong>and enables it</strong>; its
-                tools/view are live on the next turn</li>
+                tools/view are live on the next turn (pass <code>with_tests</code> for a shippable repo)</li>
             <li>edit the plugin's <code>__init__.py</code>, then <code>reload_plugins</code> — your change goes live</li>
             <li><code>enable_plugin</code> — turn on a plugin that's on disk but off</li>
             <li><code>scaffold_bundle</code> — a <code>protoagent.bundle.yaml</code> stack (ADR 0040)</li>
@@ -292,8 +316,9 @@ def _build_guide_router():
             <li><code>__init__.py</code> — <code>register(registry)</code> (tools, subagents, routes, MCP)</li>
             <li><code>skills/</code> + <code>workflows/</code> — auto-discovered data</li>
             <li><code>views:</code> — a rail icon → a <strong>sandboxed iframe</strong> of a page your plugin
-                serves (ADR 0038). Mount its router under <code>/api/plugins/&lt;id&gt;</code> so it's
-                bearer-gated; the console hands it the token + theme (ADR 0026).</li>
+                serves (ADR 0038). Serve the <strong>page</strong> on the public <code>/plugins/&lt;id&gt;</code>
+                prefix (an iframe load can't carry a bearer); its <strong>data</strong> calls ride the
+                gated <code>/api/plugins/&lt;id&gt;</code> via the DS kit's <code>apiFetch</code> (ADR 0026).</li>
           </ul>
           <h2>Events (ADR 0039)</h2>
           <ul>
@@ -317,6 +342,7 @@ def register(registry) -> None:
     registry.register_tool(enable_plugin)                            # turn on an on-disk plugin live
     registry.register_tool(reload_plugins)                           # pick up edits live
     registry.register_subagent(_plugin_architect())                  # a subagent
-    # Gated under /api/plugins/plugin-devkit (ADR 0026) — the console iframes /guide.
-    registry.register_router(_build_guide_router(), prefix="/api/plugins/plugin-devkit")
+    # PUBLIC /plugins/plugin-devkit (ADR 0026) — the console iframes /guide, and an
+    # iframe page-load can't carry a bearer, so the page route must NOT be gated.
+    registry.register_router(_build_guide_router(), prefix="/plugins/plugin-devkit")
     # skills/ + workflows/ auto-discover — no call needed (ADR 0027).

--- a/plugins/plugin-devkit/protoagent.plugin.yaml
+++ b/plugins/plugin-devkit/protoagent.plugin.yaml
@@ -27,7 +27,8 @@ settings:
 emits:
   - plugin-devkit.scaffolded
 
-# Console view (ADR 0026/0038) — a quick-reference card, served under /api/plugins/* so it
-# inherits the operator bearer gate; the console iframes it.
+# Console view (ADR 0026/0038) — a quick-reference card. The PAGE is served on the
+# PUBLIC /plugins/<id> prefix: an iframe page-load can't carry a bearer, so the page
+# must NOT be bearer-gated (data routes, if any, ride /api/plugins/<id>).
 views:
-  - { id: guide, label: "Plugin Devkit", icon: Boxes, path: /api/plugins/plugin-devkit/guide }
+  - { id: guide, label: "Plugin Devkit", icon: Boxes, path: /plugins/plugin-devkit/guide }

--- a/plugins/plugin-devkit/skills/building-plugins/SKILL.md
+++ b/plugins/plugin-devkit/skills/building-plugins/SKILL.md
@@ -113,7 +113,14 @@ You don't need to restart to try a plugin you built. With **plugin-devkit** enab
 - If it declares `requires_pip`, `python -m server plugin install-deps my-plugin`
   first (a missing dep gives a clear error on enable).
 
-From the shell (no agent): `python -m server plugin new "My Plugin" --view --skill`
+For a **standalone-repo** plugin (its own git repo, not bundled in protoAgent), pass
+`with_tests=True` (`scaffold_plugin`) / `--tests` (the CLI) to also get a **host-free
+test suite + CI + requirements-dev + pyproject** so the repo is green from birth: the
+suite imports the plugin with no host (lazy host imports + a fake registry) and `ruff`
++ `pytest` run in GitHub Actions. Keep host-only imports (`fastapi`, `graph.*`) inside
+`register()` so the suite needs only `requirements-dev.txt`.
+
+From the shell (no agent): `python -m server plugin new "My Plugin" --view --skill --tests`
 scaffolds the skeleton; `plugin new-bundle "My Stack" --member id=url@ref --builtin delegates`
 scaffolds an ADR-0040 bundle.
 

--- a/tests/test_plugin_scaffold.py
+++ b/tests/test_plugin_scaffold.py
@@ -46,6 +46,44 @@ def test_scaffold_plugin_refuses_overwrite(tmp_path):
         scaffold.scaffold_plugin("dup", target_dir=str(tmp_path))
 
 
+def test_scaffold_view_is_served_on_the_public_prefix(tmp_path):
+    """The view PAGE must be on the PUBLIC /plugins/<id> prefix (an iframe page-load
+    can't carry a bearer) — not the gated /api/plugins/<id> — and follow the four
+    rules (slug-aware base + DS kit)."""
+    scaffold.scaffold_plugin("Viewy", with_view=True, target_dir=str(tmp_path))
+    pdir = tmp_path / "viewy"
+    init = (pdir / "__init__.py").read_text()
+    manifest = (pdir / "protoagent.plugin.yaml").read_text()
+    assert 'prefix="/plugins/viewy"' in init  # public page route, not /api/plugins/viewy
+    assert "path: /plugins/viewy/view" in manifest
+    assert "/_ds/plugin-kit.css" in init and "split('/plugins/')" in init  # rules 3 + 4
+
+
+def test_scaffold_with_tests_is_shippable(tmp_path):
+    """with_tests writes a host-free suite + CI + dev deps + pyproject, version-coherent."""
+    import yaml
+
+    res = scaffold.scaffold_plugin("Shippable One", with_tests=True, target_dir=str(tmp_path))
+    pdir = tmp_path / "shippable-one"
+    for rel in (
+        "tests/conftest.py",
+        "tests/test_shippable_one.py",
+        ".github/workflows/ci.yml",
+        "requirements-dev.txt",
+        "pyproject.toml",
+    ):
+        assert (pdir / rel).exists(), rel
+    assert "tests/" in res.made
+    # the generated test file is valid Python
+    compile((pdir / "tests" / "test_shippable_one.py").read_text(), "t.py", "exec")
+    # manifest ↔ pyproject versions agree (the coherence a release should hold)
+    mv = yaml.safe_load((pdir / "protoagent.plugin.yaml").read_text())["version"]
+    assert f'version = "{mv}"' in (pdir / "pyproject.toml").read_text()
+    # ci.yml is valid YAML with a test job
+    ci = yaml.safe_load((pdir / ".github" / "workflows" / "ci.yml").read_text())
+    assert "test" in ci["jobs"]
+
+
 def test_scaffold_comms_plugin(tmp_path):
     res = scaffold.scaffold_plugin("My Chat", with_comms=True, target_dir=str(tmp_path))
     assert res.kind == "comms"


### PR DESCRIPTION
Two related improvements to **plugin-devkit**, surfaced while comparing it to a Claude Code plugin-building skill.

## 1. View correctness (a latent bug)

The devkit's **own** guide view violated the four rules it teaches — the exact **artifact-plugin P0 class**:
- mounted on the **gated** `/api/plugins/plugin-devkit` prefix → an iframe page-load can't carry a bearer, so on a token-gated deploy the guide panel comes back **blank/401**;
- hardcoded hex + **no DS kit** + no slug-aware base → no live theming, breaks through the fleet proxy.

And the **scaffold's `_VIEW_STUB`** generated the same wrong pattern, so **every `with_view` scaffold was born broken**.

Fixed:
- the **guide page** now serves on the **public** `/plugins/plugin-devkit` prefix, derives a slug-aware base, links the DS plugin-kit, and uses `--pl-*` tokens (the reference plugin now actually models the contract);
- the **scaffold** `_VIEW_STUB` + manifest `views.path` emit the public `/plugins/<id>` pattern with the slug-base + kit;
- corrected the two prose statements that told you to mount the **view** under `/api` (the `plugin-architect` prompt + the guide card). The **page** is public; only its **data** is gated. *(The `building-plugins` SKILL.md was already correct.)*

## 2. Ship-ready scaffolds

`scaffold_plugin(..., with_tests=True)` / `plugin new --tests` now also writes:
- a **host-free test suite** (`tests/conftest.py` with a fake registry + a smoke test),
- `.github/workflows/ci.yml` (Namespace runner),
- `requirements-dev.txt`, and a version-coherent `pyproject.toml`

— so a **standalone-repo** plugin is **green from birth**. Opt-in (off for in-host/bundled scaffolds); **not** written for comms plugins (they import the host at module top, so they aren't host-free). The generated CI lints the whole plugin and format-checks `tests/` (the starter `__init__` is the author's to shape).

## Verification

- `ruff check .` clean; **72 plugin tests** pass (incl. 2 new: public-prefix view + shippable `--tests`).
- **End-to-end:** a generated `--tests` plugin passes its own `ruff check . && ruff format --check tests/ && pytest` **host-free**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)