### PR TITLE
feat(acp): session/load reattach, session/close, version guard, thought streaming (#970)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **ACP client: restart-surviving sessions + thought streaming** (#970). The shared
+  `coding_agent` ACP client (which the `delegates` plugin and `project_board` loop both
+  drive) gained the rest of the session lifecycle, so a coding thread no longer dies with
+  its subprocess. On start it now persists the `sessionId` per launch signature and, when
+  the agent advertises the `loadSession` capability, **`session/load`s the saved thread**
+  (replay suppressed — a silent reattach) instead of always `session/new`-ing; a stale id
+  falls back to a fresh session. `close()` sends a best-effort **`session/close`** before
+  the SIGTERM (graceful, spec-aligned teardown). `initialize` now **honors the negotiated
+  `protocolVersion`** — it closes the connection on an unsupported counter rather than
+  warn-and-continue. And **`agent_thought_chunk`** reasoning is surfaced via a new
+  `thought_callback` (falling back to the progress narration) instead of being dropped.
+  All in `plugins/coding_agent/acp_client.py`; the delegates plugin and project_board
+  inherit it with no changes.
+
 ### Fixed
 - **SSRF: the model-probe and fleet-remote registration now run egress checks** (#871).
   `list_gateway_models` / `validate_model_connection` (reached via `/api/config/models`

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -124,11 +124,13 @@ delegate_to(target="proto", query=…)
   → AcpAdapter.dispatch (plugins/delegates/adapters.py)
       → AcpClient (plugins/coding_agent/acp_client.py)
           → spawn `command args` in workdir, JSON-RPC 2.0 over its stdio:
-            initialize → session/new(cwd) → session/prompt(query)
+            initialize → session/load(saved id) or session/new(cwd) → session/prompt(query)
           ← session/update {agent_message_chunk}  → accumulated into the answer
+          ← session/update {agent_thought_chunk}  → surfaced as the reasoning trace
           ← session/update {tool_call, title}       → narrated (logged)
           ← session/request_permission              → answered by the policy
   → returns the agent's final message text
+            … session/cancel on abort · session/close on teardown
 ```
 
 One `AcpClient` (subprocess + session) is **cached per launch+policy signature**
@@ -137,6 +139,16 @@ dispatches into a **transient, per-call `workdir`** — e.g. `dataclasses.replac
 a delegate onto a disposable git worktree — should call `AcpAdapter.teardown(d)` in
 a `finally` to reap that worktree's subprocess (a plain cache drop forgets the handle
 but leaves the process alive).
+
+### Sessions survive a restart
+
+The `sessionId` is persisted per launch signature (under `~/.protoagent/acp_sessions/`).
+On the next start, if the agent advertises the ACP `loadSession` capability the client
+**`session/load`s the saved thread** (replaying its history silently to reattach)
+instead of starting fresh — so a crash, a CI bounce, or a re-dispatch continues the
+same coding thread rather than losing its context. A stale or unknown id falls back to
+a fresh `session/new`. The ACP `protocolVersion` is negotiated at `initialize`; the
+client closes the connection if the agent counters with a version it doesn't speak.
 
 ## Eval it
 

--- a/plugins/coding_agent/__init__.py
+++ b/plugins/coding_agent/__init__.py
@@ -24,7 +24,9 @@ the client applies to the coding agent's ``session/request_permission`` requests
 
 from __future__ import annotations
 
+import hashlib
 import logging
+from pathlib import Path
 from typing import Callable
 
 from .acp_client import AcpClient
@@ -84,6 +86,18 @@ def _cache_key(spec: dict) -> tuple:
     )
 
 
+def _session_id_path(spec: dict) -> Path:
+    """Where this agent's ACP session id is persisted, so a restart can
+    ``session/load`` the same thread instead of starting fresh (#970). Keyed by a
+    digest of the full launch+policy signature (the same tuple as the client cache),
+    and ``scope_leaf``'d per instance like every other store so co-located hubs stay
+    isolated. Imported lazily to keep this library host-free for its unit tests."""
+    from infra.paths import data_home, scope_leaf
+
+    digest = hashlib.sha256(repr(_cache_key(spec)).encode()).hexdigest()[:16]
+    return scope_leaf(data_home() / "acp_sessions" / f"{digest}.json")
+
+
 def _client_for(spec: dict) -> AcpClient:
     """Get-or-create the cached client for an agent spec."""
     key = _cache_key(spec)
@@ -96,6 +110,7 @@ def _client_for(spec: dict) -> AcpClient:
             env=spec["env"],
             name=spec["name"],
             permission=_make_permission(spec),
+            session_id_path=_session_id_path(spec),
         )
         _CLIENTS[key] = client
     return client

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -9,13 +9,16 @@ server side is e.g. ``proto --acp``. Spec: https://agentclientprotocol.com.
 Ported from ORBIS's ``acp/client.py`` (the canonical protoLabs ACP client).
 ADR 0024.
 
-PR1 scope (the thin vertical):
-  * handshake: ``initialize`` → ``session/new`` (cwd = the agent's config workdir)
+Surface:
+  * handshake: ``initialize`` (honors the negotiated ``protocolVersion`` — closes on
+    an unsupported counter) → ``session/load`` the persisted thread when the agent
+    advertises ``loadSession`` and we have a saved id, else ``session/new``
   * one turn: ``session/prompt`` → accumulate ``agent_message_chunk`` text as the
-    answer; narrate ``tool_call`` titles via ``progress_callback`` ("Editing
-    app.py", "Running pytest")
+    answer; narrate ``tool_call`` titles via ``progress_callback``; surface
+    ``agent_thought_chunk`` reasoning via ``thought_callback``
+  * lifecycle: ``session/cancel`` on prompt abort, ``session/close`` on teardown
   * auto-allow ``session/request_permission`` (the coding agent self-governs,
-    scoped to the session cwd — see ADR 0024). Policy + HITL gating land next.
+    scoped to the session cwd — see ADR 0024); the plugin injects a by-kind policy.
   * ``fs/*`` and ``terminal/*`` are NOT advertised — the coding agent uses its own
     file access, confined to the session ``cwd``.
 """
@@ -48,8 +51,13 @@ def _tool_output_preview(update: dict, limit: int = 300) -> str:
             out.append(block["text"])
     return " ".join(o for o in out if o).strip()[:limit]
 
-# ACP protocol version protoAgent speaks. Negotiated in `initialize`.
+# ACP protocol version protoAgent speaks. Negotiated in `initialize`: the client
+# proposes ``PROTOCOL_VERSION`` and the agent echoes it (supported) or counters with
+# its latest. We only speak the versions in ``SUPPORTED_PROTOCOL_VERSIONS``; if the
+# agent counters with anything else we close the connection (spec: the client SHOULD
+# not proceed on an unsupported version) rather than warn-and-continue.
 PROTOCOL_VERSION = 1
+SUPPORTED_PROTOCOL_VERSIONS = (1,)
 
 # JSON-RPC error code the agent returns from `session/new` when it has no
 # resolved auth (ACP `AUTH_REQUIRED`). The client surfaces an actionable message.
@@ -87,12 +95,18 @@ class AcpClient:
         name: str = "acp",
         permission: Callable[[dict], str | None] | None = None,
         mcp_servers: list[dict] | None = None,
+        session_id_path: Path | None = None,
     ) -> None:
         self.command = command
         self.args = list(args or [])
         self.cwd = str(Path(cwd).expanduser())
         self.env = env
         self.name = name
+        # Where the session id is persisted so a restart can ``session/load`` the
+        # same thread instead of starting fresh (ADR 0024 / #970). ``None`` ⇒ the
+        # session lives only as long as this subprocess. The factory derives the
+        # path from the client cache key so reattach is keyed to launch+policy+cwd.
+        self.session_id_path = session_id_path
         # MCP servers mounted into the ACP session (ADR 0033) — how the coding agent
         # gets protoAgent's operator tools (notes/beads/goals/…) over `session/new`.
         self.mcp_servers = list(mcp_servers or [])
@@ -106,6 +120,10 @@ class AcpClient:
         # Captured from the `initialize` response (was previously discarded).
         self._auth_methods: list[dict] = []
         self._agent_capabilities: dict = {}
+        self._protocol_version = PROTOCOL_VERSION   # the negotiated version
+        # True only while replaying history during ``session/load`` — suppresses the
+        # replayed updates so a silent reattach doesn't re-stream the thread.
+        self._loading = False
         self._next_id = 0
         self._pending: dict[int, asyncio.Future] = {}
         self._reader_task: asyncio.Task | None = None
@@ -117,6 +135,7 @@ class AcpClient:
         self._progress: ProgressCallback | None = None
         self._on_tool: ToolCallback | None = None
         self._on_text: ProgressCallback | None = None
+        self._on_thought: ProgressCallback | None = None
 
     # -- lifecycle -----------------------------------------------------------
 
@@ -147,7 +166,7 @@ class AcpClient:
         self._reader_task = asyncio.create_task(self._read_loop())
         self._stderr_task = asyncio.create_task(self._drain_stderr())
         await self._initialize()
-        await self._new_session()
+        await self._open_session()
         logger.info(
             "[acp/%s] up (pid=%s, session=%s, cwd=%s)",
             self.name,
@@ -160,7 +179,12 @@ class AcpClient:
         """Cancel the I/O tasks and reap the subprocess. Crucially this ``await``s
         ``proc.wait()`` so the child is reaped *while the loop is alive* — without
         it the subprocess transport lingers and its ``__del__`` fires after the loop
-        closes ("Event loop is closed"), and the stderr-drain task leaks."""
+        closes ("Event loop is closed"), and the stderr-drain task leaks.
+
+        Sends a best-effort ``session/close`` first — the graceful, spec-aligned
+        shutdown (and what matters if an agent ever serves multiple sessions per
+        process) before the SIGTERM that actually frees this one-process-per-session."""
+        await self._close_session()
         for task in (self._reader_task, self._stderr_task):
             if task and not task.done():
                 task.cancel()
@@ -243,6 +267,8 @@ class AcpClient:
     # -- inbound updates + requests -----------------------------------------
 
     async def _handle_update(self, params: dict) -> None:
+        if self._loading:
+            return  # replaying history during session/load — reattaching silently
         update = params.get("update") or {}
         kind = update.get("sessionUpdate")
         if kind == "agent_message_chunk":
@@ -250,6 +276,12 @@ class AcpClient:
             if text:
                 self._answer += text
                 await self._emit_text(text)   # stream the delta (token-ish) to the UI
+        elif kind == "agent_thought_chunk":
+            # The coder's reasoning trace — surface it (never folded into the answer)
+            # for parity with the native runtime's thinking stream.
+            text = (update.get("content") or {}).get("text", "")
+            if text:
+                await self._emit_thought(text)
         elif kind == "tool_call":
             # A tool call STARTED — narrate its title + emit a structured start event so the
             # UI can render a card (parity with the native runtime's tool_start).
@@ -272,6 +304,10 @@ class AcpClient:
                     "output": _tool_output_preview(update),
                     "status": status,
                 })
+        elif kind:
+            # plan / current_mode_update / available_commands_update / usage_update —
+            # not surfaced yet, but logged so they're visibly dropped, not silent.
+            logger.debug("[acp/%s] unhandled session update %r", self.name, kind)
 
     async def _handle_request(self, msg: dict) -> None:
         method = msg.get("method")
@@ -321,6 +357,17 @@ class AcpClient:
             except Exception as exc:  # best-effort — streaming never breaks a turn
                 logger.warning("[acp/%s] text_callback raised: %s", self.name, exc)
 
+    async def _emit_thought(self, delta: str) -> None:
+        """Surface a reasoning delta. Routes to ``thought_callback`` when wired, else
+        falls back to ``progress_callback`` so thoughts are surfaced (not dropped)
+        even for callers that only wire narration — the issue's intent."""
+        cb = self._on_thought or self._progress
+        if cb and delta:
+            try:
+                await cb(delta)
+            except Exception as exc:  # best-effort — thoughts never break a turn
+                logger.warning("[acp/%s] thought_callback raised: %s", self.name, exc)
+
     # -- JSON-RPC primitives -------------------------------------------------
 
     async def _send(self, obj: dict) -> None:
@@ -347,14 +394,14 @@ class AcpClient:
     async def _respond_error(self, rid, code: int, message: str) -> None:
         await self._send({"jsonrpc": "2.0", "id": rid, "error": {"code": code, "message": message}})
 
-    async def _cancel_session(self) -> None:
-        """Best-effort ``session/cancel`` notification: tell the agent to abandon
-        the in-flight turn so a reused session isn't left mid-generation.
+    async def _notify_session(self, method: str) -> None:
+        """Fire-and-forget a session lifecycle notification (``session/cancel`` on
+        abort, ``session/close`` on teardown). Notifications have no id and no
+        response, so this writes straight to stdin without a pending future.
 
-        Runs on the prompt abort path (timeout / external cancel / transport
-        failure), so it must never raise: no-op when the process is gone or no
-        session is open, and swallows any send error. ``session/cancel`` is a
-        notification (no id, no response)."""
+        Best-effort by contract — it runs on abort/teardown paths and must never
+        raise: no-op when the process is gone or no session is open, and any send
+        error is swallowed."""
         proc = self._proc
         if not (proc and proc.returncode is None and proc.stdin and self._session_id):
             return
@@ -362,18 +409,26 @@ class AcpClient:
             proc.stdin.write(
                 (
                     json.dumps(
-                        {
-                            "jsonrpc": "2.0",
-                            "method": "session/cancel",
-                            "params": {"sessionId": self._session_id},
-                        }
+                        {"jsonrpc": "2.0", "method": method,
+                         "params": {"sessionId": self._session_id}}
                     )
                     + "\n"
                 ).encode()
             )
             await proc.stdin.drain()
-        except Exception as exc:  # noqa: BLE001 — abort path is best-effort
-            logger.debug("[acp/%s] session/cancel failed (best-effort): %s", self.name, exc)
+        except Exception as exc:  # noqa: BLE001 — abort/teardown path is best-effort
+            logger.debug("[acp/%s] %s failed (best-effort): %s", self.name, method, exc)
+
+    async def _cancel_session(self) -> None:
+        """Tell the agent to abandon the in-flight turn so a reused session isn't
+        left mid-generation. Runs on the prompt abort path (timeout / external
+        cancel / transport failure)."""
+        await self._notify_session("session/cancel")
+
+    async def _close_session(self) -> None:
+        """Tell the agent to release the session before the subprocess is reaped —
+        the graceful, spec-aligned counterpart to the SIGTERM in ``close()``."""
+        await self._notify_session("session/close")
 
     # -- handshake -----------------------------------------------------------
 
@@ -395,15 +450,87 @@ class AcpClient:
         # (for an actionable auth-required message) and capabilities.
         self._auth_methods = result.get("authMethods") or []
         self._agent_capabilities = result.get("agentCapabilities") or {}
+        # Honor the negotiated protocol version (spec): the agent echoes our version
+        # if it supports it, else counters with its latest. If that counter is one we
+        # don't speak, the client SHOULD close rather than proceed on an incompatible
+        # wire. A missing version field is treated leniently as our own (older agents).
         negotiated = result.get("protocolVersion")
-        if isinstance(negotiated, int) and negotiated != PROTOCOL_VERSION:
-            logger.warning(
-                "[acp/%s] agent negotiated ACP protocol v%s but client speaks v%s — "
-                "proceeding, but behaviour may differ",
-                self.name,
-                negotiated,
-                PROTOCOL_VERSION,
+        if isinstance(negotiated, int):
+            if negotiated not in SUPPORTED_PROTOCOL_VERSIONS:
+                supported = "/".join(str(v) for v in SUPPORTED_PROTOCOL_VERSIONS)
+                raise AcpError(
+                    f"{self.name} agent negotiated ACP protocol v{negotiated}, but this "
+                    f"client only supports v{supported}. Update the coding agent or the "
+                    f"client so their ACP versions match."
+                )
+            self._protocol_version = negotiated
+
+    async def _open_session(self) -> None:
+        """Reattach the persisted session when possible, else start a fresh one.
+
+        If a session id was persisted for this launch signature AND the agent
+        advertises the ``loadSession`` capability, ``session/load`` reattaches the
+        thread (surviving a subprocess crash/restart) instead of losing it to a new
+        session. A failed load (expired/unknown id, agent refusal) falls back to a
+        fresh ``session/new`` so a stale id never wedges startup."""
+        persisted = self._read_persisted_session_id()
+        if persisted and self._agent_capabilities.get("loadSession"):
+            try:
+                await self._load_session(persisted)
+                logger.info("[acp/%s] reattached session %s (session/load)", self.name, persisted)
+                return
+            except AcpError as exc:
+                logger.info(
+                    "[acp/%s] session/load %s failed (%s) — starting fresh",
+                    self.name, persisted, exc,
+                )
+        await self._new_session()
+
+    async def _load_session(self, session_id: str) -> None:
+        """Reattach a persisted session (ACP ``session/load``). The agent replays its
+        history via ``session/update`` notifications — suppressed here (``_loading``)
+        since we're silently reattaching, not re-streaming the thread — then responds
+        ``null``. Caller gates this on the agent's ``loadSession`` capability."""
+        self._loading = True
+        try:
+            await self._request(
+                "session/load",
+                {"sessionId": session_id, "cwd": self.cwd, "mcpServers": self.mcp_servers},
+                timeout=60.0,
             )
+        finally:
+            self._loading = False
+        self._session_id = session_id
+
+    def _read_persisted_session_id(self) -> str | None:
+        """The session id saved for this launch signature, or None. Guards on a
+        matching ``cwd`` so a stale/copied file can't reattach a foreign workdir."""
+        path = self.session_id_path
+        if not path:
+            return None
+        try:
+            data = json.loads(path.read_text(encoding="utf-8"))
+        except (OSError, json.JSONDecodeError):
+            return None
+        if not isinstance(data, dict) or data.get("cwd") != self.cwd:
+            return None
+        sid = data.get("sessionId")
+        return sid if isinstance(sid, str) and sid else None
+
+    def _persist_session_id(self, session_id: str) -> None:
+        """Save the session id (with its ``cwd``) so a later client for the same
+        launch signature can ``session/load`` it. Best-effort — never fatal."""
+        path = self.session_id_path
+        if not (path and session_id):
+            return
+        try:
+            path.parent.mkdir(parents=True, exist_ok=True)
+            path.write_text(
+                json.dumps({"sessionId": session_id, "cwd": self.cwd, "command": self.command}),
+                encoding="utf-8",
+            )
+        except OSError as exc:
+            logger.debug("[acp/%s] could not persist sessionId: %s", self.name, exc)
 
     async def _new_session(self) -> None:
         try:
@@ -431,6 +558,7 @@ class AcpClient:
         self._session_id = (result or {}).get("sessionId")
         if not self._session_id:
             raise AcpError("session/new returned no sessionId")
+        self._persist_session_id(self._session_id)
 
     # -- public: one turn ----------------------------------------------------
 
@@ -441,20 +569,23 @@ class AcpClient:
         progress_callback: ProgressCallback | None = None,
         tool_callback: ToolCallback | None = None,
         text_callback: ProgressCallback | None = None,
+        thought_callback: ProgressCallback | None = None,
         timeout: float = 600.0,
     ) -> str:
         """Send one user turn; return the agent's accumulated message text.
 
         Streams ``tool_call`` titles to ``progress_callback`` (text narration), structured
-        start/end events to ``tool_callback`` (UI tool cards), and answer-text deltas to
-        ``text_callback`` (token-ish streaming) as the agent works. Raises ``AcpError`` on
-        transport/protocol failure.
+        start/end events to ``tool_callback`` (UI tool cards), answer-text deltas to
+        ``text_callback`` (token-ish streaming), and the coder's reasoning deltas to
+        ``thought_callback`` (``agent_thought_chunk``; falls back to ``progress_callback``)
+        as the agent works. Raises ``AcpError`` on transport/protocol failure.
         """
         await self._ensure_started()
         self._answer = ""
         self._progress = progress_callback
         self._on_tool = tool_callback
         self._on_text = text_callback
+        self._on_thought = thought_callback
         try:
             result = await self._request(
                 "session/prompt",
@@ -474,6 +605,7 @@ class AcpClient:
             self._progress = None
             self._on_tool = None
             self._on_text = None
+            self._on_thought = None
         stop = (result or {}).get("stopReason")
         logger.info("[acp/%s] turn complete (stopReason=%s)", self.name, stop)
         return self._answer.strip()

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -11,6 +11,7 @@ and client-cache eviction/teardown.
 from __future__ import annotations
 
 import asyncio
+import json
 import sys
 
 import pytest
@@ -226,6 +227,210 @@ async def test_session_new_auth_required_raises_actionable(tmp_path):
     assert ei.value.code == -32000             # AUTH_REQUIRED preserved
 
 
+# ── session lifecycle: load / close / version / thought (#970) ────────────────
+
+# Advertises the `loadSession` capability, records whether session/new vs
+# session/load fired (to a marker), and on load replays one history chunk BEFORE
+# responding null — so the test can prove the replay is suppressed on reattach.
+_LOADER_AGENT = r'''
+import sys, json, os
+MARKER = os.environ.get("MARKER", "")
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n"); sys.stdout.flush()
+def mark(s):
+    if MARKER:
+        with open(MARKER, "w") as fh: fh.write(s)
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method, mid = msg.get("method"), msg.get("id")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": mid, "result": {
+            "protocolVersion": 1, "agentCapabilities": {"loadSession": True}}})
+    elif method == "session/new":
+        mark("new")
+        send({"jsonrpc": "2.0", "id": mid, "result": {"sessionId": "s1"}})
+    elif method == "session/load":
+        # Replay one history entry, then respond null (per spec).
+        send({"jsonrpc": "2.0", "method": "session/update", "params": {
+            "sessionId": "s1", "update": {"sessionUpdate": "agent_message_chunk",
+                                          "content": {"type": "text", "text": "OLD HISTORY"}}}})
+        mark("load:" + str(msg.get("params", {}).get("sessionId")))
+        send({"jsonrpc": "2.0", "id": mid, "result": None})
+    elif method == "session/prompt":
+        send({"jsonrpc": "2.0", "method": "session/update", "params": {
+            "sessionId": "s1", "update": {"sessionUpdate": "agent_message_chunk",
+                                          "content": {"type": "text", "text": "fresh"}}}})
+        send({"jsonrpc": "2.0", "id": mid, "result": {"stopReason": "end_turn"}})
+'''
+
+# Emits an agent_thought_chunk (reasoning) then an agent_message_chunk (answer),
+# so the test can prove thoughts are surfaced separately and never folded in.
+_THOUGHT_AGENT = r'''
+import sys, json
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n"); sys.stdout.flush()
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    method, mid = msg.get("method"), msg.get("id")
+    if method == "initialize":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"protocolVersion": 1}})
+    elif method == "session/new":
+        send({"jsonrpc": "2.0", "id": mid, "result": {"sessionId": "s1"}})
+    elif method == "session/prompt":
+        send({"jsonrpc": "2.0", "method": "session/update", "params": {
+            "sessionId": "s1", "update": {"sessionUpdate": "agent_thought_chunk",
+                                          "content": {"type": "text", "text": "thinking hard"}}}})
+        send({"jsonrpc": "2.0", "method": "session/update", "params": {
+            "sessionId": "s1", "update": {"sessionUpdate": "agent_message_chunk",
+                                          "content": {"type": "text", "text": "the answer"}}}})
+        send({"jsonrpc": "2.0", "id": mid, "result": {"stopReason": "end_turn"}})
+'''
+
+# Counters with protocolVersion 2 (which this client does not speak) — the client
+# must close rather than proceed.
+_V2_AGENT = r'''
+import sys, json
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n"); sys.stdout.flush()
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    if msg.get("method") == "initialize":
+        send({"jsonrpc": "2.0", "id": msg.get("id"), "result": {"protocolVersion": 2}})
+'''
+
+
+async def test_session_load_reattaches_persisted_session(tmp_path):
+    """A persisted session id + an agent that advertises loadSession ⇒ the client
+    session/loads (reattaches) rather than session/news, and the replayed history is
+    suppressed (the reattach is silent — only the new turn's text is the answer)."""
+    script = tmp_path / "loader_agent.py"
+    script.write_text(_LOADER_AGENT, encoding="utf-8")
+    marker = tmp_path / "which.marker"
+    sess_file = tmp_path / "sess.json"
+    sess_file.write_text(
+        json.dumps({"sessionId": "s1", "cwd": str(tmp_path), "command": sys.executable}),
+        encoding="utf-8",
+    )
+    client = AcpClient(
+        sys.executable, [str(script)], cwd=str(tmp_path), name="loader",
+        env={"MARKER": str(marker)}, session_id_path=sess_file,
+    )
+    try:
+        answer = await client.prompt("continue the thread", timeout=30.0)
+    finally:
+        await client.close()
+    assert answer == "fresh"                 # replayed "OLD HISTORY" suppressed
+    assert marker.read_text() == "load:s1"   # reattached via session/load, not new
+    assert client._session_id == "s1"
+
+
+async def test_session_new_persists_id_for_reattach(fake_agent, tmp_path):
+    """A fresh session/new writes its id (with cwd) to the session-id path so a
+    later client for the same launch signature can reattach it."""
+    sess_file = tmp_path / "sess.json"
+    client = AcpClient(
+        sys.executable, [str(fake_agent)], cwd=str(tmp_path), name="persist",
+        session_id_path=sess_file,
+    )
+    try:
+        await client.prompt("go", timeout=30.0)
+    finally:
+        await client.close()
+    data = json.loads(sess_file.read_text(encoding="utf-8"))
+    assert data["sessionId"] == "s1"
+    assert data["cwd"] == str(tmp_path)
+
+
+async def test_persisted_id_ignored_when_agent_lacks_loadsession(fake_agent, tmp_path):
+    """A persisted id must NOT trigger session/load if the agent doesn't advertise
+    loadSession — the client falls back to a fresh session/new and overwrites it."""
+    sess_file = tmp_path / "sess.json"
+    sess_file.write_text(
+        json.dumps({"sessionId": "OLD", "cwd": str(tmp_path), "command": sys.executable}),
+        encoding="utf-8",
+    )
+    client = AcpClient(
+        sys.executable, [str(fake_agent)], cwd=str(tmp_path), name="nolc",
+        session_id_path=sess_file,
+    )
+    try:
+        answer = await client.prompt("add a healthz route", timeout=30.0)
+    finally:
+        await client.close()
+    assert answer == "Hello world [ok]"   # ran a normal new-session turn
+    assert client._session_id == "s1"      # the new id, not the stale "OLD"
+    assert json.loads(sess_file.read_text(encoding="utf-8"))["sessionId"] == "s1"
+
+
+async def test_close_emits_session_close_before_reaping(fake_agent, tmp_path):
+    """close() sends a best-effort session/close while the child is still alive
+    (returncode None) — the graceful, spec-aligned shutdown before the SIGTERM."""
+    client = AcpClient(sys.executable, [str(fake_agent)], cwd=str(tmp_path), name="close")
+    await client.prompt("go", timeout=30.0)
+    calls: list[tuple] = []
+    orig = client._notify_session
+
+    async def spy(method: str) -> None:
+        calls.append((method, client._proc.returncode))
+        await orig(method)
+
+    client._notify_session = spy
+    await client.close()
+    assert ("session/close", None) in calls  # emitted before the process was reaped
+
+
+async def test_initialize_rejects_unsupported_protocol_version(tmp_path):
+    """The agent counters with protocolVersion 2 (unsupported) — the client must
+    raise (close the connection) instead of warn-and-continue."""
+    script = tmp_path / "v2_agent.py"
+    script.write_text(_V2_AGENT, encoding="utf-8")
+    client = AcpClient(sys.executable, [str(script)], cwd=str(tmp_path), name="v2")
+    try:
+        with pytest.raises(AcpError) as ei:
+            await client.prompt("hi", timeout=10.0)
+    finally:
+        await client.close()
+    msg = str(ei.value).lower()
+    assert "protocol" in msg and "v2" in msg
+
+
+async def test_agent_thought_chunk_surfaced_not_in_answer(tmp_path):
+    """agent_thought_chunk reasoning is routed to thought_callback and never folded
+    into the answer text."""
+    script = tmp_path / "thought_agent.py"
+    script.write_text(_THOUGHT_AGENT, encoding="utf-8")
+    thoughts: list[str] = []
+
+    async def on_thought(t: str) -> None:
+        thoughts.append(t)
+
+    client = AcpClient(sys.executable, [str(script)], cwd=str(tmp_path), name="thought")
+    try:
+        answer = await client.prompt("go", thought_callback=on_thought, timeout=30.0)
+    finally:
+        await client.close()
+    assert answer == "the answer"        # thought NOT folded into the answer
+    assert thoughts == ["thinking hard"]  # surfaced to the thought callback
+
+
 # ── permission policy ─────────────────────────────────────────────────────────
 
 _OPTS = [{"optionId": "a", "kind": "allow_once"}, {"optionId": "r", "kind": "reject_once"}]
@@ -296,6 +501,20 @@ async def test_evict_client_pops_and_closes():
     assert P._cache_key(spec) not in P._CLIENTS
     # idempotent: nothing cached for this spec now
     assert await P.evict_client(spec) is False
+
+
+def test_session_id_path_is_stable_and_keyed_per_signature():
+    """The factory derives a session-id path from the cache key — stable for the same
+    spec, distinct when the launch signature (e.g. workdir) changes."""
+    spec_a = {
+        "name": "proto", "command": "proto", "args": ["--acp"], "workdir": "/tmp/wt-a",
+        "permissions": "auto", "allow_kinds": [], "deny_kinds": [],
+    }
+    spec_b = {**spec_a, "workdir": "/tmp/wt-b"}
+    p_a, p_a2, p_b = P._session_id_path(spec_a), P._session_id_path(spec_a), P._session_id_path(spec_b)
+    assert p_a == p_a2                       # stable for the same signature
+    assert p_a != p_b                        # workdir is part of the key
+    assert p_a.name.endswith(".json") and p_a.parent.name == "acp_sessions"
 
 
 async def test_evict_client_swallows_close_errors():


### PR DESCRIPTION
Closes #970. Follow-on to #969.

The shared `coding_agent` ACP client (`AcpClient`) spoke only the minimal `initialize → session/new → session/prompt` surface. This adopts the rest of the session lifecycle so a coding thread no longer dies with its subprocess. Everything lands in `plugins/coding_agent/acp_client.py`, so the `delegates` plugin and the `project_board` loop **inherit it with no changes**.

### What changed

1. **`session/load` reattach — restart-surviving threads (highest value).** The `sessionId` is now persisted per launch+policy signature (`~/.protoagent/acp_sessions/<digest>.json`, `scope_leaf`'d per instance). On start, when the agent advertises the `loadSession` capability and a saved id exists, the client **`session/load`s the thread** — replay suppressed via a `_loading` flag (a *silent* reattach, not a re-stream) — instead of always `session/new`-ing. A stale/unknown id, or an agent without `loadSession`, falls back to `session/new` and overwrites the saved id.
2. **`session/close` on teardown.** `close()` now sends a best-effort `session/close` *before* the SIGTERM (graceful, spec-aligned). Refactored #969's `session/cancel` send into a shared `_notify_session` helper used by both cancel and close.
3. **Protocol-version negotiation honored.** `_initialize` now **closes the connection** (raises `AcpError`) if the agent counters with a `protocolVersion` the client doesn't speak (`SUPPORTED_PROTOCOL_VERSIONS`), rather than warn-and-continue. A missing version field stays lenient.
4. **`agent_thought_chunk` surfaced.** The coder's reasoning is routed to a new `thought_callback` (falling back to progress narration) instead of being dropped; other unhandled update kinds (`plan`/`current_mode_update`/…) are now debug-logged, not silently swallowed. Thoughts are never folded into the answer text.

### Acceptance (from #970)
- [x] `session/resume`/`session/load` reattaches a persisted session across a client restart (wire-exchange test)
- [x] `close()` emits `session/close` before reaping (best-effort)
- [x] `_initialize` honors/guards the negotiated `protocolVersion`
- [x] `agent_thought_chunk` updates are surfaced, not dropped
- [x] all in `plugins/coding_agent/acp_client.py`; `delegates` + `project_board` inherit with no changes

### Design note — client vs. SDK
There **is** a Python ACP SDK (`agent-client-protocol` 0.10.1), but it's a young community port (Zed ships official Rust + TS). For this incremental, security-sensitive subprocess path I kept the hand-rolled, tested client and added the four methods directly. A full SDK migration deserves its own evaluation issue rather than a fold-in here.

### Tests
Fake ACP agents driven over real stdio: reattach-via-load (proves replay suppression + load-not-new), new-session persistence, capability gating, `close()` emits `session/close` before reaping, version-mismatch close, and thought-chunk surfacing. `tests/test_coding_agent_plugin.py` — 21 passing; `test_acp_runtime.py` + `test_delegates_*` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)