### PR TITLE
feat(settings): scalar multiline `text` field + conditional `depends_on` visibility (#964, #963)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `thought_callback` (falling back to the progress narration) instead of being dropped.
   All in `plugins/coding_agent/acp_client.py`; the delegates plugin and project_board
   inherit it with no changes.
+- **Settings: a scalar multiline `text` field + conditional `depends_on` visibility**
+  (#964, #963). Long string settings (a system prompt, a template, a blurb) get a new
+  `text` field type that renders a textarea but saves exactly like `string` — no more
+  editing a paragraph in a one-line input. And any settings field (core `Field` or a
+  plugin's `settings:` spec) can declare `depends_on: {key, equals}` (or `{key, in: […]}`,
+  or a bare `{key}` for "is truthy") so it only shows once a prerequisite is set — the
+  "enable X → show X's options" pattern (e.g. the artifact plugin's *Ask system
+  instruction* appears only when *Interactive artifacts* is on). Reactive to the in-form
+  value; a plugin's short `depends_on.key` is resolved to its full dotted path at build.
 
 ### Fixed
 - **SSRF: the model-probe and fleet-remote registration now run egress checks** (#871).

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -165,7 +165,8 @@ export type SlashCommand = {
 export type SettingsField = {
   key: string;
   label: string;
-  type: "string" | "number" | "bool" | "select" | "string_list" | "secret";
+  // "text" = a scalar multiline string (#964), rendered as a textarea but saved like "string".
+  type: "string" | "text" | "number" | "bool" | "select" | "string_list" | "secret";
   section: string;
   description?: string;
   restart: boolean;
@@ -175,6 +176,10 @@ export type SettingsField = {
   is_set?: boolean; // secrets only
   minimum?: number;
   maximum?: number;
+  // #963 — conditional visibility: hide this field until a sibling field's current
+  // form value satisfies the predicate. `key` is the sibling's full dotted key.
+  // {equals}: strict equality · {in}: membership · neither: sibling is truthy.
+  depends_on?: { key: string; equals?: unknown; in?: unknown[] };
   // Cascade layer this field's shared default lives at (ADR 0047): "agent" (the
   // per-agent leaf) or "host" (the box-shared host-config.yaml). Where the
   // Settings UI writes a "save to default" edit.

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -14,6 +14,7 @@ import { ErrorBoundary, PanelError, PanelSkeleton } from "../app/ErrorBoundary";
 import { api } from "../lib/api";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
 import type { SettingsField, SettingsGroup } from "../lib/types";
+import { fieldVisible } from "./visibility";
 
 // Drop-in full-panel wrapper (section + Suspense + ErrorBoundary) so any surface can
 // embed a category's settings as a standalone panel — Agent, Knowledge, central Settings.
@@ -117,6 +118,16 @@ export function SettingsCategory({
   const [dirty, setDirty] = useState<Record<string, unknown>>({});
   const [status, setStatus] = useState("");
   const dirtyKeys = Object.keys(dirty);
+
+  // #963 — conditional field visibility. The live value of every in-scope field
+  // (the dirty edit if any, else the saved value), so a `depends_on` predicate is
+  // reactive to what's on the form right now, not just what was last saved.
+  const currentValues = useMemo(() => {
+    const m = new Map<string, unknown>();
+    for (const g of groups) for (const f of g.fields) m.set(f.key, f.key in dirty ? dirty[f.key] : f.value);
+    return m;
+  }, [groups, dirty]);
+  const isVisible = (field: SettingsField): boolean => fieldVisible(field, (k) => currentValues.get(k));
 
   const hasModel = groups.some((g) => g.fields.some((f) => f.key === "model.name"));
   const hasDiscord = groups.some((g) => g.section === "Discord");
@@ -278,7 +289,8 @@ export function SettingsCategory({
             group still announces it has unsaved edits. */}
         <Accordion className="settings-groups">
         {groups.map((group) => {
-          const groupDirty = group.fields.reduce((n, f) => n + (f.key in dirty ? 1 : 0), 0);
+          const visibleFields = group.fields.filter(isVisible);   // #963
+          const groupDirty = visibleFields.reduce((n, f) => n + (f.key in dirty ? 1 : 0), 0);
           return (
           <AccordionItem
             key={group.section}
@@ -290,7 +302,7 @@ export function SettingsCategory({
               </span>
             }
           >
-            {group.fields.map((field) => (
+            {visibleFields.map((field) => (
               <SettingRow
                 key={field.key}
                 field={field}
@@ -465,6 +477,19 @@ export function SettingInput({ field, value, onChange }: { field: SettingsField;
         value={text}
         placeholder="one per line"
         onChange={(e) => onChange(e.target.value.split("\n").map((s) => s.trim()).filter(Boolean))}
+      />
+    );
+  }
+  if (field.type === "text") {
+    // A scalar multiline string (#964) — a system prompt, template, or blurb. Renders
+    // a textarea but casts/saves exactly like `string` (one value, no list semantics).
+    return (
+      <Textarea
+        id={id}
+        className="setting-input setting-textarea"
+        rows={4}
+        value={typeof value === "string" ? value : value === undefined || value === null ? "" : String(value)}
+        onChange={(e) => onChange(e.target.value)}
       />
     );
   }

--- a/apps/web/src/settings/visibility.test.ts
+++ b/apps/web/src/settings/visibility.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from "vitest";
+
+import type { SettingsField } from "../lib/types";
+import { fieldVisible } from "./visibility";
+
+// A minimal field factory — only the bits fieldVisible reads.
+const field = (depends_on?: SettingsField["depends_on"]): SettingsField =>
+  ({ key: "child", label: "Child", type: "text", section: "S", restart: false, options: [], scope: "agent", source: "agent", depends_on }) as SettingsField;
+
+describe("fieldVisible (#963 depends_on)", () => {
+  it("shows a field with no depends_on", () => {
+    expect(fieldVisible(field(), () => undefined)).toBe(true);
+  });
+
+  it("{equals}: shows only on strict equality", () => {
+    const f = field({ key: "ask_enabled", equals: true });
+    expect(fieldVisible(f, () => true)).toBe(true);
+    expect(fieldVisible(f, () => false)).toBe(false);
+    expect(fieldVisible(f, () => undefined)).toBe(false); // unset prerequisite → hidden
+  });
+
+  it("{equals} a string value", () => {
+    const f = field({ key: "mode", equals: "advanced" });
+    expect(fieldVisible(f, () => "advanced")).toBe(true);
+    expect(fieldVisible(f, () => "basic")).toBe(false);
+  });
+
+  it("{in}: shows on membership", () => {
+    const f = field({ key: "mode", in: ["a", "b"] });
+    expect(fieldVisible(f, () => "b")).toBe(true);
+    expect(fieldVisible(f, () => "c")).toBe(false);
+  });
+
+  it("bare {key}: shows once the prerequisite is truthy", () => {
+    const f = field({ key: "ask_enabled" });
+    expect(fieldVisible(f, () => true)).toBe(true);
+    expect(fieldVisible(f, () => "non-empty")).toBe(true);
+    expect(fieldVisible(f, () => false)).toBe(false);
+    expect(fieldVisible(f, () => "")).toBe(false);
+  });
+
+  it("reads the value of the named sibling key, not its own", () => {
+    const f = field({ key: "ask_enabled", equals: true });
+    const values: Record<string, unknown> = { ask_enabled: true, child: false };
+    expect(fieldVisible(f, (k) => values[k])).toBe(true);
+  });
+});

--- a/apps/web/src/settings/visibility.ts
+++ b/apps/web/src/settings/visibility.ts
@@ -1,0 +1,18 @@
+import type { SettingsField } from "../lib/types";
+
+// #963 — is a settings field visible given the current form values? A field with no
+// `depends_on` always shows; otherwise the named sibling's current value must satisfy
+// the predicate: {equals} = strict equality · {in} = membership · neither = the sibling
+// is truthy (the "enable X → show X's options" pattern). `valueOf` returns the live
+// form value for a key (the dirty edit if any, else the saved value), so visibility is
+// reactive to what's on the form right now, not just what was last saved.
+//
+// Pure + standalone (no React / no @protolabsai/ui) so the predicate is unit-testable.
+export function fieldVisible(field: SettingsField, valueOf: (key: string) => unknown): boolean {
+  const dep = field.depends_on;
+  if (!dep?.key) return true;
+  const cur = valueOf(dep.key);
+  if ("equals" in dep) return cur === dep.equals;
+  if (Array.isArray(dep.in)) return dep.in.includes(cur);
+  return Boolean(cur);
+}

--- a/docs/guides/plugins.md
+++ b/docs/guides/plugins.md
@@ -238,6 +238,19 @@ settings:                      # System → Settings group (named after the sect
   - { key: api_key,  label: "API key",       type: secret }
 ```
 
+**Field types:** `string` · `text` (multiline string — a system prompt / template) ·
+`number` · `bool` · `select` (with `options: [...]`) · `string_list` · `secret`.
+
+**Conditional fields** — add `depends_on` to show a field only once a sibling is set
+(e.g. an "enable X" toggle gates X's options); reactive to the in-form value:
+
+```yaml
+settings:
+  - { key: ask_enabled, label: "Interactive", type: bool }
+  - { key: ask_system,  label: "Ask system instruction", type: text,
+      depends_on: { key: ask_enabled, equals: true } }   # also: { key, in: [...] } | bare { key } = truthy
+```
+
 Read the resolved config (manifest defaults ⊕ YAML ⊕ secrets) in `register()`:
 
 ```python

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -23,7 +23,7 @@ class Field:
     key: str                      # dotted YAML path, e.g. "model.temperature"
     attr: str                     # LangGraphConfig attribute holding the value
     label: str
-    type: str                     # string|number|bool|select|string_list|secret
+    type: str                     # string|text|number|bool|select|string_list|secret
     section: str
     description: str = ""
     restart: bool = False         # True = needs a full process restart (not hot-reload)
@@ -31,6 +31,12 @@ class Field:
     options_source: str = ""      # "models" → filled dynamically by the endpoint
     minimum: float | None = None
     maximum: float | None = None
+    # Conditional visibility (#963): {"key": "<sibling field key>", "equals": <value>}
+    # — or {"key", "in": [...]}, or just {"key"} for "is truthy". The console hides
+    # this field until the named sibling's *current form value* satisfies it (reactive
+    # to the in-form value, not just the saved one). The sibling key is the full dotted
+    # path for core fields; plugin specs may use the short key (resolved at build time).
+    depends_on: dict | None = None
     # Cascade layer this field's shared default lives at (ADR 0047). "agent" (the
     # leaf) by default; "host" = box-shared default in host-config.yaml. Git-style
     # advisory — a field is always overridable at a lower layer, so this only sets
@@ -376,6 +382,8 @@ def build_schema(
             entry["minimum"] = f.minimum
         if f.maximum is not None:
             entry["maximum"] = f.maximum
+        if f.depends_on:
+            entry["depends_on"] = f.depends_on   # #963 — full dotted sibling key
         groups.setdefault(f.section, {"section": f.section, "fields": []})["fields"].append(entry)
 
     # Plugin-declared settings fields (ADR 0019) — value from config.plugin_config,
@@ -408,6 +416,15 @@ def build_schema(
             entry["minimum"] = spec["minimum"]
         if spec.get("maximum") is not None:
             entry["maximum"] = spec["maximum"]
+        # #963 — a plugin spec uses the SHORT sibling key (e.g. depends_on.key
+        # "ask_enabled"); resolve it to the full dotted path the UI sees so the
+        # console can match it against the rendered sibling field.
+        dep = spec.get("depends_on")
+        if isinstance(dep, dict) and dep.get("key"):
+            dk = str(dep["key"])
+            if not dk.startswith(f"{sch.section}."):
+                dk = f"{sch.section}.{dk}"
+            entry["depends_on"] = {**dep, "key": dk}
         groups.setdefault(group, {"section": group, "fields": []})["fields"].append(entry)
         # A plugin that declares `test: true` (ADR 0029) gets a generic console
         # "Test connection" button posting the group's fields to its test route.

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -95,3 +95,63 @@ def test_nest_updates_builds_yaml_shape_and_drops_blank_secrets():
 def test_restart_keys_flags_only_restart_fields():
     keys = restart_keys({"runtime.autostart_on_boot": True, "model.temperature": 0.5})
     assert keys == ["runtime.autostart_on_boot"]
+
+
+# ── #964 text type + #963 depends_on ──────────────────────────────────────────
+
+
+def _fake_plugin_specs(monkeypatch, specs: list[dict]):
+    """Install fake plugin-declared settings specs (ADR 0019) so build_schema /
+    validate_flat see them as a plugin's `settings:`. Returns nothing — the schema
+    is read through the monkeypatched `_plugin_field_specs`."""
+    from types import SimpleNamespace
+
+    sch = SimpleNamespace(
+        section="artifact",
+        defaults={s["key"]: s.get("default") for s in specs},
+        test=False,
+    )
+    tuples = [(sch, f"artifact.{s['key']}", s["key"], s) for s in specs]
+    monkeypatch.setattr("graph.settings_schema._plugin_field_specs", lambda: tuples)
+
+
+def test_text_field_renders_as_text_and_validates_like_string(monkeypatch):
+    """#964 — a scalar `text` field surfaces its type verbatim and validates like a
+    plain string (a multiline value is fine; no list/number coercion)."""
+    _fake_plugin_specs(monkeypatch, [
+        {"key": "ask_system", "label": "Ask system", "type": "text", "default": ""},
+    ])
+    fields = {f["key"]: f for g in build_schema(LangGraphConfig()) for f in g["fields"]}
+    assert fields["artifact.ask_system"]["type"] == "text"
+    assert validate_flat({"artifact.ask_system": "line 1\nline 2"})[0] is True
+
+
+def test_depends_on_resolves_plugin_short_key_to_full_key(monkeypatch):
+    """#963 — a plugin spec's `depends_on.key` is a SHORT sibling key; build_schema
+    resolves it to the full dotted path the console matches against."""
+    _fake_plugin_specs(monkeypatch, [
+        {"key": "ask_enabled", "label": "Interactive", "type": "bool", "default": False},
+        {"key": "ask_system", "label": "Ask system", "type": "text",
+         "depends_on": {"key": "ask_enabled", "equals": True}},
+    ])
+    fields = {f["key"]: f for g in build_schema(LangGraphConfig()) for f in g["fields"]}
+    assert fields["artifact.ask_system"]["depends_on"] == {"key": "artifact.ask_enabled", "equals": True}
+    # An already-qualified key is left as-is (no double prefix).
+    _fake_plugin_specs(monkeypatch, [
+        {"key": "x", "label": "X", "type": "text",
+         "depends_on": {"key": "artifact.ask_enabled", "equals": True}},
+    ])
+    fields = {f["key"]: f for g in build_schema(LangGraphConfig()) for f in g["fields"]}
+    assert fields["artifact.x"]["depends_on"]["key"] == "artifact.ask_enabled"
+
+
+def test_core_field_depends_on_passed_through(monkeypatch):
+    """#963 — a core Field's `depends_on` (full dotted key) flows through unchanged."""
+    from graph.settings_schema import Field
+
+    demo = Field("demo.child", "compaction_keep_messages", "Child", "number", "Demo",
+                 depends_on={"key": "compaction.enabled", "equals": True})
+    monkeypatch.setattr("graph.settings_schema.FIELDS", [demo])
+    groups = build_schema(LangGraphConfig())
+    entry = next(e for g in groups for e in g["fields"] if e["key"] == "demo.child")
+    assert entry["depends_on"] == {"key": "compaction.enabled", "equals": True}


### PR DESCRIPTION
Closes #964. Closes #963.

Two small settings-UX additions — both land in the generic Settings **schema + renderer**, so core `Field`s *and* plugin `settings:` specs (ADR 0019) inherit them.

### #964 — a scalar multiline `text` field
A long string setting (a system prompt, a template, a blurb) rendered in a one-line `<input>` is painful to edit. `string_list` already rendered a `<textarea>`; this adds the missing **scalar multiline**: `type: text` renders a textarea but casts/validates **exactly like `string`** (one value, no list semantics).

### #963 — conditional field visibility via `depends_on`
Any field can declare `depends_on` and the console hides it until a sibling's **current form value** satisfies the predicate (reactive to the in-form value, not just the saved one):
- `{ key, equals: <value> }` — strict equality
- `{ key, in: [...] }` — membership
- bare `{ key }` — the sibling is truthy (the "enable X → show X's options" pattern)

Cleans up cases like the artifact plugin's *Ask system instruction* (only meaningful when *Interactive artifacts* is on), Discord's token/admin fields, etc.

### Changes
- **`graph/settings_schema.py`** — `Field` gains `depends_on`; `build_schema` threads it for core fields (full dotted key) and **resolves a plugin spec's SHORT sibling key to the full dotted path** the UI matches against (no double-prefix if already qualified). `text` flows through and validates like `string`.
- **`apps/web`** — `SettingInput` renders `text` as a `<Textarea>`; `SettingsCategory` filters rows through a pure, standalone `fieldVisible` predicate (`settings/visibility.ts`) keyed on the live form values; `SettingsField` type gains `"text"` + `depends_on`.

### Tests
- Backend (`tests/test_settings_schema.py`): `text` validates like string + renders; plugin short-key → full-key resolution (incl. no-double-prefix); core `depends_on` pass-through.
- Frontend (`apps/web/src/settings/visibility.test.ts`): `fieldVisible` — equals / in / truthy / reads the *sibling* key. 66 web tests green; `tsc --noEmit` + lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)