### PR TITLE
chore: release v0.38.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.38.0] - 2026-06-13
+
 ### Added
 - **ACP client: restart-surviving sessions + thought streaming** (#970). The shared
   `coding_agent` ACP client (which the `delegates` plugin and `project_board` loop both

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.37.0"
+version = "0.38.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "v0.38.0",
+    "date": "2026-06-13",
+    "changes": [
+      "ACP client: restart-surviving sessions + thought streaming",
+      "Settings: a scalar multiline text field + conditional depends_on visibility",
+      "SSRF: the model-probe and fleet-remote registration now run egress checks",
+      "**A plugin's declared secret can no longer slip into the tracked config YAML when"
+    ]
+  },
+  {
     "version": "v0.37.0",
     "date": "2026-06-13",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.38.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.38.0 -m 'Release v0.38.0' && git push origin v0.38.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).