### PR TITLE
fix(docs): unbreak the vitepress build (inline-code parse + 2 dead links)

### DIFF
--- a/docs/adr/0048-settings-ia-two-scope-homes.md
+++ b/docs/adr/0048-settings-ia-two-scope-homes.md
@@ -6,7 +6,7 @@
 - **Tags:** settings, ux, information-architecture, fleet, host, console
 - **Related:** consumes [ADR 0047](./0047-layered-settings-cascade.md) (the
   per-field `Field.scope` host/agent cascade — this ADR is its UI surface);
-  reorganizes surfaces from [ADR 0020](./0020-run-from-chat-manage-from-surfaces.md)
+  reorganizes surfaces from [ADR 0020](./0020-console-ia-run-from-chat.md)
   (settings live in their home view), [ADR 0009](./0009-studio-control-stack.md)
   (the agent's makeup), and [ADR 0042](./0042-fleet-supervisor-unified-console.md)
   (fleet, slug routing, host = the first agent).

--- a/docs/adr/0049-bundle-pin-lifecycle.md
+++ b/docs/adr/0049-bundle-pin-lifecycle.md
@@ -22,8 +22,8 @@ Three structural gaps made that possible, and would make it recur:
 2. **Staleness is invisible at runtime.** `check_updates` deliberately skips the network
    for SHA-pinned entries (`pinned-skips-net`, ADR/PR #887) — correct as an auto-update
    guard, but it means a SHA-pinned bundle member *never even reports* `behind`.
-   Worse, tag-pinned entries reported a **permanent false positive**: `git ls-remote <url>
-   <tag>` returns the *tag object* SHA for an annotated tag (not the peeled commit), which
+   Worse, tag-pinned entries reported a **permanent false positive**: `git ls-remote <url> <tag>`
+   returns the *tag object* SHA for an annotated tag (not the peeled commit), which
    never equals the lock's `resolved_sha`.
 3. **Fixing the bundle repo fixes nothing deployed.** Pins are copied into each agent's
    `plugins.lock` at install; a bumped bundle repo does not propagate to already-spawned
@@ -57,7 +57,7 @@ which is strictly worse than a stale-but-functional pin. Instead:
    PR, which must pass the same verify to merge. After this, the pin only ever moves
    through a passing verification: "pin where it last worked" stops being an intention
    and becomes the mechanism. A reference implementation ships in-repo under
-   [`examples/bundles/template/`](../../examples/bundles/template/).
+   [`examples/bundles/template/`](https://github.com/protoLabsAI/protoAgent/tree/main/examples/bundles/template).
 4. **Runtime surfacing (kept, and now honest).** Tag-pinned members keep reporting
    `behind` via the (fixed) ls-remote compare. SHA-pinned members keep `pinned-skips-net`;
    the `update_available_but_pinned` advisory and the bundle-level re-pin endpoint that


### PR DESCRIPTION
The docs site build — `docs.yml` (GitHub Pages) and `marketing-deploy.yml` — has been **red on `main`** since ADR 0048/0049 landed in v0.36.0. Both workflows are **main-push only** (they don't run on PRs), so the breakage was invisible at PR time; I hit it cutting the v0.38.0 release (the release-PR merge re-ran the marketing deploy → failure).

Three fixes, all in untouched ADR prose:

1. **ADR 0049 — parse error (the hard failure).** An inline code span `` `git ls-remote <url> <tag>` `` was split across a soft line break, so VitePress's Vue compiler read `<url>`/`<tag>` as HTML elements → *"Element is missing end tag"* and the whole build aborted. Reflowed onto one line.
2. **ADR 0048 — dead link.** Link to ADR 0020 used a stale filename (`0020-run-from-chat-manage-from-surfaces.md` → `0020-console-ia-run-from-chat.md`).
3. **ADR 0049 — dead link.** A relative link to `examples/bundles/template/` resolves *outside* the docs tree (not a docs page). Switched to the GitHub repo URL, matching how other docs link to repo paths.

The parse error (1) failed the build *first*, masking the two dead links (2,3) behind it — so all three had to be fixed to get a clean build.

**Verified locally:** `npm run docs:build` now completes clean (`build complete`). Note neither docs workflow runs on PRs, so this can't be gated by PR CI — it'll go green on the `main` merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)