### PR TITLE
ci(docs): run the vitepress docs build on PRs, not just on main (#976)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -3,7 +3,12 @@ name: Deploy docs to GitHub Pages
 on:
   push:
     branches: [main]
-    paths: ['docs/**', 'package.json', 'package-lock.json']
+    paths: ['docs/**', 'package.json', 'package-lock.json', '.github/workflows/docs.yml']
+  # PR-level gate (#976): vitepress fails the build on parse errors AND dead links,
+  # so running docs:build here catches doc breakage at review time instead of letting
+  # it merge green and only go red on the main-only deploy. Build-only — no deploy.
+  pull_request:
+    paths: ['docs/**', 'package.json', 'package-lock.json', '.github/workflows/docs.yml']
   workflow_dispatch:
 
 permissions:
@@ -12,7 +17,9 @@ permissions:
   id-token: write
 
 concurrency:
-  group: pages
+  # Ref-scoped so a PR build never serializes behind (or cancels) the main pages
+  # deploy — each ref gets its own group; main keeps a stable group of its own.
+  group: pages-${{ github.ref }}
   cancel-in-progress: false
 
 jobs:
@@ -27,11 +34,15 @@ jobs:
       - run: npm install
       - run: npm run docs:build
       - uses: actions/upload-pages-artifact@v3
+        # Only needed to feed the deploy job — skip on PRs (build-only gate).
+        if: github.event_name != 'pull_request'
         with:
           path: docs/.vitepress/dist
 
   deploy:
     needs: build
+    # Never deploy from a PR — PRs only validate the build above.
+    if: github.event_name != 'pull_request'
     runs-on: namespace-profile-protolabs-linux
     environment:
       name: github-pages


### PR DESCRIPTION
Closes #976 (bd-14p).

The docs site build (`docs.yml` → GitHub Pages, and `marketing-deploy.yml`) ran `npm run docs:build` **only on push to `main`** — so a doc-breaking change merged green and only went red on the main-only deploy. ADR 0048/0049 did exactly that: the build was broken for a full release cycle (v0.36.0 → v0.38.0), found only while cutting v0.38.0 and fixed in #975.

### Change
- **`pull_request` trigger** on `docs.yml` (paths: `docs/**`, `package.json`, `package-lock.json`, `.github/workflows/docs.yml`). vitepress already fails the build on **parse errors** *and* **dead links**, so the gate needs no extra config — it just has to run on PRs.
- **Build-only on PRs:** the `upload-pages-artifact` step and the `deploy` job are gated to `github.event_name != 'pull_request'`, so PRs validate the build without deploying (no `github-pages` environment / pages-write needed on PRs).
- **Ref-scoped concurrency** (`pages-${{ github.ref }}`) so a PR build never serializes behind or cancels the main pages deploy.
- Added the workflow file to the path filters so **this PR self-tests the gate** (you should see the docs `build` job run on it) and future workflow edits re-validate.

Runs on `namespace-profile-protolabs-linux` like the other jobs — no GH-hosted cost. Verified `npm run docs:build` green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)