### PR TITLE
docs(acp): full lifecycle in ADR 0024 + claude-code fixes in guide

### DIFF
--- a/docs/adr/0024-spawn-cli-coding-agents-acp.md
+++ b/docs/adr/0024-spawn-cli-coding-agents-acp.md
@@ -5,6 +5,26 @@ Status: **Superseded by [ADR 0025](./0025-unified-delegate-registry-and-panel.md
 reuses the ACP client mechanics below. `plugins/coding_agent/` remains as the shared ACP
 client library. (Originally: Accepted, PR1 — thin vertical.)
 
+## Update (2026-06) — full session lifecycle adopted
+
+PR1 was a deliberate "thin vertical" (handshake → one turn → auto-allow), so the
+mechanics described below are no longer the whole story. The shared client
+(`plugins/coding_agent/acp_client.py`) has since grown the full ACP session
+lifecycle:
+
+- **#969** — best-effort `session/cancel` on prompt abort (timeout / external
+  cancel) and actionable `AUTH_REQUIRED` handling (the client no longer surfaces an
+  opaque error when the agent isn't authenticated).
+- **#972** — `session/load` reattach for **restart-surviving threads** (gated on the
+  agent advertising the `loadSession` capability; the `sessionId` is persisted per
+  launch signature), `session/close` on teardown, real `protocolVersion`
+  negotiation (closes if the agent counters with an unsupported version), and
+  `agent_thought_chunk` surfaced as the reasoning trace.
+
+Validated end-to-end against both `proto --acp` and Claude Code (via
+`@zed-industries/claude-code-acp`) — the client is agent-agnostic. See the
+[coding-agents guide](/guides/coding-agents) for the current behaviour and config.
+
 ## Context
 
 protoAgent's lead agent already delegates in two ways: to **in-process LLM

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -57,7 +57,7 @@ Any agent that speaks ACP works — just point `command`/`args` at it:
 ```yaml
 delegates:
   - { name: proto,       type: acp, command: proto, args: ["--acp"],                         workdir: ~/dev/my-repo }
-  - { name: claude-code, type: acp, command: npx,   args: ["@zed-industries/claude-code-acp"], workdir: ~/dev/my-repo }
+  - { name: claude-code, type: acp, command: npx,   args: ["--yes", "@zed-industries/claude-code-acp"], workdir: ~/dev/my-repo }
   - { name: codex,       type: acp, command: codex, args: ["acp"],                            workdir: ~/dev/my-repo }
   - { name: gemini,      type: acp, command: gemini, args: ["--experimental-acp"],            workdir: ~/dev/my-repo }
 ```
@@ -65,6 +65,16 @@ delegates:
 The binary must be installed and on the `PATH` of the process running protoAgent.
 A missing binary returns a clear error string to the agent (it doesn't crash) — the
 delegates panel's **Test** button probes this.
+
+The same `AcpClient` drives any of them — proto and Claude Code are both
+validated end-to-end. `--yes` on the `npx` form skips the first-run install
+prompt (which would otherwise hang the non-interactive spawn).
+
+> **Claude Code caveat:** `@zed-industries/claude-code-acp` launches the `claude`
+> binary, which **refuses to start nested inside another Claude Code session**
+> (`Error: Claude Code cannot be launched inside another Claude Code session`). Run
+> protoAgent from a normal shell — not from within a `claude` session — when using
+> the Claude Code agent.
 
 ## Use it
 


### PR DESCRIPTION
## Summary
Doc upserts from validating the proto ⇄ protoAgent ACP integration end-to-end against **both proto and Claude Code**.

- **ADR 0024** still framed the ACP client as the "PR1 thin vertical." Added an *Update (2026-06)* section noting the full session lifecycle has since shipped — #969 (`session/cancel` on abort, actionable `AUTH_REQUIRED`) and #972 (`session/load` reattach for restart-surviving threads, `session/close`, real `protocolVersion` negotiation, `agent_thought_chunk`) — and that it's agent-agnostic (proto + Claude Code).
- **coding-agents guide**: two fixes found while testing —
  - `--yes` on the `npx @zed-industries/claude-code-acp` example. Without it, npx prompts on first run and **hangs the non-interactive ACP spawn**.
  - A caveat that the `claude` binary **refuses to launch nested inside another Claude Code session** (`Error: Claude Code cannot be launched inside another Claude Code session`) — run protoAgent from a normal shell.

## Validation backing these docs
- proto `--acp` 0.59.0: happy path (file written + runs), abort path (`session/cancel` → `session/close` on a forced timeout), and **restart-surviving thread** (client#2 `session/load`-reattached client#1's session and added a docstring to the existing file with full context).
- Claude Code via `claude-code-acp`: same client, clean ACP handshake + `session/new` + `Write` tool-call → correct `palindrome.py`.

Docs-only (`docs:` — no version bump).

🤖 Generated with [Claude Code](https://claude.com/claude-code)