### PR TITLE
feat: restart the server from the console (graceful POST /api/restart)

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -462,6 +462,13 @@ export const api = {
     return request<RuntimeStatus>("/api/runtime/status");
   },
 
+  // Gracefully restart the server process (POST /api/restart) — the server drains and
+  // re-execs; the console reconnects via the boot gate. Always targets the HOST (the
+  // process you're connected to), never a slug-routed agent.
+  restart() {
+    return request<{ ok: boolean; restarting: boolean }>("/api/restart", { method: "POST", host: true });
+  },
+
   // The HUB's runtime status — NEVER slug-routed. The TenantGuard keys on the hub's
   // `instance_uid` (the real tenant of this origin), which is STABLE across agent
   // swaps. The slug-routed runtimeStatus() returns the FOCUSED agent's uid, which

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -93,6 +93,14 @@ export function PluginsSection() {
     onError: (e: unknown) => setStatus(`✗ ${e instanceof Error ? e.message : "sync failed"}`),
   });
 
+  const restart = useMutation({
+    mutationFn: () => api.restart(),
+    // The connection drops as the server drains; the app's boot gate shows "Starting…"
+    // and reconnects on its own once the fresh process is up.
+    onSuccess: () => setStatus("Restarting server… the console will reconnect when it's back."),
+    onError: (e: unknown) => setStatus(`✗ ${e instanceof Error ? e.message : "restart failed"}`),
+  });
+
   const plugins = list.data?.plugins ?? [];
   const missing = plugins.filter((p) => !p.present);
 
@@ -177,6 +185,34 @@ export function PluginsSection() {
           ))}
         </ul>
       )}
+
+      {/* Server restart — for changes that can't hot-load (a plugin's console view or
+          background surface, and env/launch flags). The console reconnects on its own. */}
+      <div className="plugin-restart-row">
+        <span className="settings-section-sub">
+          A plugin's console view or background surface — and env / launch-flag changes — need a
+          server restart to take effect.
+        </span>
+        <Button
+          type="button"
+          variant="default"
+          size="sm"
+          disabled={restart.isPending}
+          onClick={() => {
+            if (
+              window.confirm(
+                "Restart the server now? In-flight work finishes, then the console reconnects automatically.",
+              )
+            ) {
+              setStatus("Restarting server…");
+              restart.mutate();
+            }
+          }}
+          title="Gracefully restart the server process"
+        >
+          {restart.isPending ? <Loader2 size={13} className="spin" /> : <RefreshCw size={13} />} Restart server
+        </Button>
+      </div>
     </section>
   );
 }

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -54,3 +54,5 @@
 .plugin-review .warn { color: var(--warning); display: inline-flex; align-items: center; gap: 3px; }
 .plugin-enable-hint { font-size: 11px; color: var(--fg-secondary); margin: 6px 0 0; }
 .btn-icon.danger:hover { color: var(--danger); }
+.plugin-restart-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--border); }
+.plugin-restart-row > span { margin: 0; }

--- a/operator_api/runtime_routes.py
+++ b/operator_api/runtime_routes.py
@@ -1,0 +1,63 @@
+"""Operator server controls — ``POST /api/restart`` (graceful self-restart).
+
+Restarting the process is the only reliable way to apply changes that can't be
+hot-mounted (a plugin's view code, a removed route, env/launch-flag changes). This
+endpoint does it the safe way: set a flag, trigger the existing graceful-shutdown
+path (the #882 Ctrl-C handler — spins down fleet members, withdraws mDNS, stops the
+scheduler), and let ``server._main`` re-exec a fresh process AFTER ``uvicorn.run()``
+returns (so the port is released first). A hard ``os.execv`` from inside the request
+would skip that cleanup and could fail to rebind the port.
+
+Gated by the ``/api/*`` bearer middleware (a2a_impl/auth.py) like every operator
+route — only the authenticated operator can restart.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import signal
+
+log = logging.getLogger("protoagent.server.restart")
+
+
+def reexec_command(executable: str, argv: list[str], frozen: bool) -> list[str]:
+    """The argv to re-exec the server with, preserving the launch flags. A PyInstaller
+    frozen build re-runs the binary directly; from source it's ``python -m server``.
+    Pure (no side effects) so it's unit-testable; ``server._main`` feeds it the real
+    ``sys.executable`` / ``sys.argv`` / ``sys.frozen`` and calls ``os.execv``."""
+    rest = list(argv[1:])  # argv[0] is the script/binary; drop it
+    if frozen:
+        return [executable, *rest]
+    return [executable, "-m", "server", *rest]
+
+
+def register_runtime_control_routes(app) -> None:
+    from fastapi import APIRouter
+    from fastapi.responses import JSONResponse
+
+    router = APIRouter()
+
+    @router.post("/api/restart")
+    async def _restart():
+        """Gracefully restart the server. Returns 202 immediately; the process drains
+        and re-execs a moment later, and the console reconnects via the boot gate."""
+        from runtime.state import STATE
+
+        STATE.restart_requested = True
+
+        async def _drain_then_signal():
+            # Let the 202 flush to the client, then trigger the graceful Ctrl-C path;
+            # _main re-execs once uvicorn.run() returns.
+            await asyncio.sleep(0.3)
+            try:
+                os.kill(os.getpid(), signal.SIGINT)
+            except Exception:  # noqa: BLE001 — last resort if signalling fails
+                log.exception("[restart] failed to signal graceful shutdown")
+
+        asyncio.create_task(_drain_then_signal())
+        log.info("[restart] operator requested a restart — draining then re-exec")
+        return JSONResponse({"ok": True, "restarting": True}, status_code=202)
+
+    app.include_router(router)

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -52,6 +52,8 @@ class AppState:
     # lets a config reload hot-mount a newly-enabled plugin's routes (no restart).
     fastapi_app: object = None
     plugin_router_keys: set = field(default_factory=set)
+    # Set by POST /api/restart: after uvicorn drains, _main re-execs a fresh process.
+    restart_requested: bool = False
     plugin_surfaces: list = field(default_factory=list)
     plugin_surface_handles: list = field(default_factory=list)
     plugin_meta: list = field(default_factory=list)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -649,6 +649,12 @@ def _main():
     register_knowledge_routes(fastapi_app)
     register_plugin_routes(fastapi_app)
 
+    # Operator server controls — POST /api/restart (graceful self-restart). Gated by
+    # the /api/* bearer middleware like every operator route; _main re-execs below.
+    from operator_api.runtime_routes import register_runtime_control_routes
+
+    register_runtime_control_routes(fastapi_app)
+
     # Fleet control plane (ADR 0042) — /api/fleet (list/create/start/stop) +
     # /api/archetypes. The CLI + the desktop GUI panels both drive these.
     from operator_api.fleet_routes import register_fleet_routes
@@ -868,6 +874,17 @@ def _main():
     # CancelledError tracebacks. A bounded timeout lets in-flight work finish,
     # then force-closes the streams cleanly on a single Ctrl-C.
     uvicorn.run(app, host=args.host, port=args.port, timeout_graceful_shutdown=5)
+
+    # uvicorn.run() returns once the server has fully drained and released the port —
+    # either a real shutdown (Ctrl-C) or an operator restart (POST /api/restart set the
+    # flag + signalled SIGINT). On a restart, re-exec a fresh process HERE, so the new
+    # server can rebind the now-free port. os.execv never returns.
+    if STATE.restart_requested:
+        from operator_api.runtime_routes import reexec_command
+
+        cmd = reexec_command(sys.executable, sys.argv, bool(getattr(sys, "frozen", False)))
+        log.info("[restart] re-exec: %s", " ".join(cmd))
+        os.execv(cmd[0], cmd)
 
 
 if __name__ == "__main__":

--- a/tests/test_restart_route.py
+++ b/tests/test_restart_route.py
@@ -1,0 +1,35 @@
+"""POST /api/restart — the operator self-restart control (operator_api/runtime_routes)."""
+
+from __future__ import annotations
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from operator_api.runtime_routes import reexec_command, register_runtime_control_routes
+from runtime.state import STATE
+
+
+def test_reexec_command_from_source():
+    # python -m server --port 7870 → re-run the module with the same flags.
+    cmd = reexec_command("/usr/bin/python", ["/x/server/__main__.py", "--port", "7870"], frozen=False)
+    assert cmd == ["/usr/bin/python", "-m", "server", "--port", "7870"]
+
+
+def test_reexec_command_frozen():
+    # A PyInstaller binary re-runs itself directly (no -m server).
+    cmd = reexec_command("/app/protoagent", ["/app/protoagent", "--host", "0.0.0.0"], frozen=True)
+    assert cmd == ["/app/protoagent", "--host", "0.0.0.0"]
+
+
+def test_restart_route_sets_flag_and_returns_202(monkeypatch):
+    # Stub os.kill so the route's graceful-shutdown signal can't kill the test runner.
+    monkeypatch.setattr("operator_api.runtime_routes.os.kill", lambda *a, **k: None)
+    STATE.restart_requested = False
+    app = FastAPI()
+    register_runtime_control_routes(app)
+    try:
+        r = TestClient(app).post("/api/restart")
+        assert r.status_code == 202 and r.json()["restarting"] is True
+        assert STATE.restart_requested is True  # _main re-execs once uvicorn drains
+    finally:
+        STATE.restart_requested = False  # don't leak the flag to other tests


### PR DESCRIPTION
Adds a **"Restart server"** button to the console so you don't have to drop to a terminal for a `Ctrl-C` after a change that can't hot-load (a plugin's view/surface, env/launch flags).

## Backend — `operator_api/runtime_routes.py`
- **`POST /api/restart`** — auto-gated by the existing `/api/*` bearer middleware (`a2a_impl/auth.py`), so only the operator can call it.
- It does a **graceful** restart: set `STATE.restart_requested`, return `202`, then signal `SIGINT` to trigger protoAgent's existing graceful-shutdown path (#882 — spins down fleet members, withdraws mDNS, stops the scheduler). `server._main` then **re-execs a fresh process after `uvicorn.run()` returns**, so the port is released first. (A hard `os.execv` from inside the request would skip cleanup and could fail to rebind the port.)
- **Frozen-app aware**: the PyInstaller binary re-runs itself; from source it's `python -m server` — same launch flags either way (`reexec_command`).

## Frontend
- `api.restart()` (HOST-targeted, never slug-routed) + a **"Restart server"** button in **Settings▸Plugins** (with a confirm), right where the "this needs a restart" hints already appear for view/surface plugins.
- **Reuses the boot gate** — the connection drops, the app shows "Starting…", and the runtime-status poll reconnects when the fresh process is up. No new overlay.

## Tests / gates
- `reexec_command` (source + frozen argv) + the route sets the flag and returns `202` (with `os.kill` stubbed so it can't signal the test runner).
- `ruff` clean · import-linter 3/3 (operator_api doesn't import server; the new module imports only `runtime.state`).

## Gotchas handled
- **Fleet:** a hub restart is a normal member-recovery scenario; members keep running + reconnect.
- **Desktop (Tauri sidecar):** the re-exec happens inside the child, so the parent watchdog stays satisfied (same PID).
- **Docker:** exits → the orchestrator restarts with the same env/port (standard).

🤖 Generated with [Claude Code](https://claude.com/claude-code)