### PR TITLE
fix(console): let the left panel narrow to 200px (was a 280 snap-back)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -814,6 +814,9 @@ export function App() {
         onCollapse={setRightCollapsed}
         leftCollapsed={leftCollapsed}
         onLeftCollapse={setLeftCollapsed}
+        // Let the left column narrow to 200 before it snaps/collapses (the DS default is
+        // 280, which left a 140–280 dead zone where a narrowed left snapped back up).
+        minLeftWidth={200}
         mobileItems={[...railSurfaces("left"), ...railSurfaces("right")].map((s) => ({
           ...s,
           dot: pluginDots[s.id] || undefined,


### PR DESCRIPTION
**Symptom:** narrowing the left panel and releasing snaps it back up to a set width.

**Cause:** the DS AppShell is a single zero-sum divider — the right column is width-controlled, the left flexes with a `minLeftWidth` floor (DS default **280**). App.tsx passed no `minLeftWidth`, so a left width between the collapse threshold (140) and 280 had **no resting place** → `clampOpen` snapped it back up to 280 on pointer-up. Not a drag glitch; the resting-position math has a gap there.

**Fix:** pass `minLeftWidth={200}` — the left can now rest as narrow as 200 (snap zone 100–200, collapses below 100). One prop; right panel unchanged.

(Easy to tune — say the word for 160/120.)