### PR TITLE
docs: backfill v0.39.0 changelog entries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.39.0] - 2026-06-13
 
+### Added
+- **Restart the server from the console** (#979). A gated `POST /api/restart` plus a
+  "Restart server" button in Settings▸Plugins gracefully restart the process (clean
+  shutdown, then re-exec) and the console reconnects on its own — no terminal `Ctrl-C`
+  needed after a change that can't hot-load.
+
+### Fixed
+- **The left console panel can narrow to 200px** (#980) — dragging it narrower no
+  longer snaps it back up to 280 (the AppShell `minLeftWidth` floor was the default).
+- **OpenShell deploy path validated end-to-end** against OpenShell v0.0.59 (#891).
+
 ## [0.38.0] - 2026-06-13
 
 ### Added

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -2,7 +2,11 @@
   {
     "version": "v0.39.0",
     "date": "2026-06-13",
-    "changes": []
+    "changes": [
+      "Restart the server from the console — a gated POST /api/restart plus a Settings▸Plugins button (no terminal needed for a change that can't hot-load)",
+      "The left console panel can be dragged down to 200px without snapping back to 280",
+      "OpenShell deploy path validated end-to-end against OpenShell v0.0.59"
+    ]
   },
   {
     "version": "v0.38.0",


### PR DESCRIPTION
`prepare-release.yml` (#981) rolled an **empty** `[0.39.0]` section into `CHANGELOG.md` because #979/#980 didn't carry `[Unreleased]` entries, and the marketing `changelog.json` v0.39.0 entry was likewise empty.

This backfills both **before the `v0.39.0` tag is pushed**:

### Added
- Restart the server from the console (#979)

### Fixed
- Left console panel narrows to 200px (#980)
- OpenShell deploy path validated end-to-end vs v0.0.59 (#891)

The GitHub Release notes auto-generate from PR titles regardless; this is the committed-record + marketing-site fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)