### PR TITLE
fix(knowledge): default embeddings to qwen3-embedding + model dropdown in Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Knowledge embeddings default to `qwen3-embedding`.** The setup wizard hard-coded
+  `nomic-embed-text`, which the protoLabs gateway doesn't serve — so semantic recall
+  401'd on every embed and silently degraded to keyword-only. The wizard now writes
+  `qwen3-embedding` (matching the code default), and the **Embedding model** field in
+  Settings▸Knowledge is now a gateway-model **dropdown** (pick from what your gateway
+  serves) instead of free text, so it can't be typo'd into a 401.
+
 ## [0.39.0] - 2026-06-13
 
 ### Added

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -335,7 +335,10 @@ export function SetupWizard({
           },
           knowledge: {
             db_path: state.knowledgePath.trim(),
-            embed_model: "nomic-embed-text",
+            // Match the code default + what the protoLabs gateway serves. A model the
+            // gateway can't access 401s every embed and silently degrades recall to
+            // keyword-only — the Settings▸Knowledge field is a gateway-model dropdown.
+            embed_model: "qwen3-embedding",
             top_k: Number(state.knowledgeTopK),
           },
           operator: {

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -121,8 +121,11 @@ FIELDS: list[Field] = [
           "Hybrid FTS5 + vector search via the embedding model (RRF-fused). Off = "
           "keyword-only. Needs the gateway to serve the embedding model; falls back "
           "to keyword search on outage.", restart=True),
-    Field("knowledge.embed_model", "embed_model", "Embedding model", "string", "Knowledge",
-          "Gateway alias used when semantic recall is on."),
+    Field("knowledge.embed_model", "embed_model", "Embedding model", "select", "Knowledge",
+          "Gateway model used to embed for semantic recall (NOT the chat model). Picked from "
+          "the models your gateway serves — a wrong alias silently degrades recall to "
+          "keyword-only. Falls back to a free-text field if the gateway can't be listed.",
+          options_source="models"),
     Field("skills.top_k", "skills_top_k", "Skill recall top-k", "number", "Knowledge", minimum=1),
     Field("checkpoint.db_path", "checkpoint_db_path", "Conversation history DB", "string", "Knowledge",
           "SQLite path for per-session chat history (survives restarts). Blank = in-memory.",


### PR DESCRIPTION
## What

The setup wizard hard-coded `knowledge.embed_model: nomic-embed-text` — a model the protoLabs gateway **doesn't serve**. Every embed 401'd (`key_model_access_denied`) and semantic recall silently degraded to keyword-only (the hybrid store's circuit breaker masked it). The code default was *already* `qwen3-embedding`; only the wizard wrote the bad value into each fresh config.

## Changes
- **`SetupWizard.tsx`** — write `embed_model: "qwen3-embedding"` (matches the `LangGraphConfig` default + what the gateway serves).
- **`settings_schema.py`** — the **Embedding model** field in Settings▸Knowledge is now a `select` fed by the gateway's `/v1/models` (`options_source="models"`) instead of free text, so it can't be typo'd into a 401. Falls back to a text input when the gateway can't be listed.

The field was already rendered in the UI (the schema auto-renders by category) — this makes it **safe to set** rather than guessable.

## Verification
- `pytest` config/settings/embeddings suites: **69 passed**.
- `build_schema` smoke: `embed_model` → `type=select`, options fed from the model list, default `qwen3-embedding`.
- **Live**: re-pointed the running instance to `qwen3-embedding`, ingested + searched a chunk — **no 401**, semantic hit returned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)