### PR TITLE
feat(setup): drop Discord/Google steps + add GitHub Copilot to the ACP list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Setup wizard slimmed to the essentials.** The Discord and Google steps are gone —
+  both are managed in System → Settings (with their own Test/Connect actions), so the
+  wizard no longer collects bot tokens or OAuth clients. Finishing setup now leaves any
+  existing Discord/Google config untouched (the YAML write merges, never replaces).
+- **GitHub Copilot is now selectable as the ACP runtime** in the setup wizard's coding-agent
+  list (`acp:copilot` → `copilot --acp`), matching the Settings runtime options.
+
 ### Fixed
 - **Knowledge embeddings default to `qwen3-embedding`.** The setup wizard hard-coded
   `nomic-embed-text`, which the protoLabs gateway doesn't serve — so semantic recall

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -4,15 +4,12 @@ import {
 
   AlertTriangle,
   Bot,
-  CalendarDays,
   Check,
   ChevronLeft,
   ChevronRight,
   Database,
-  ExternalLink,
   KeyRound,
   Loader2,
-  MessageCircle,
   Network,
   Search,
   ShieldCheck,
@@ -24,22 +21,18 @@ import type { ReactNode } from "react";
 import { api } from "../lib/api";
 import type { AgentConfig, ConfigPayload, SetupStatus } from "../lib/types";
 
-type Step = "welcome" | "identity" | "model" | "persona" | "tools" | "workspace" | "discord" | "google" | "finish";
+type Step = "welcome" | "identity" | "model" | "persona" | "tools" | "workspace" | "finish";
 
-const steps: Step[] = ["welcome", "identity", "model", "persona", "tools", "workspace", "discord", "google", "finish"];
+const steps: Step[] = ["welcome", "identity", "model", "persona", "tools", "workspace", "finish"];
 
 // CLI coding agents that can be the runtime over ACP (ADR 0033) — agent_runtime: acp:<id>.
 const ACP_AGENTS: { id: string; label: string; hint: string }[] = [
   { id: "proto", label: "proto", hint: "protoLabs CLI — proto --acp" },
   { id: "codex", label: "Codex", hint: "OpenAI Codex — npx @zed-industries/codex-acp" },
   { id: "claude", label: "Claude", hint: "Claude agent — npx @agentclientprotocol/claude-agent-acp" },
+  { id: "copilot", label: "Copilot", hint: "GitHub Copilot CLI — copilot --acp" },
   { id: "opencode", label: "OpenCode", hint: "OpenCode — opencode acp" },
 ];
-
-// Setup walkthroughs live in the template's (protoAgent) canonical docs — forks
-// don't ship their own docs site, so the in-app help links point there.
-const DISCORD_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/discord#bot-setup";
-const GOOGLE_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/google#oauth-client";
 
 type WizardState = {
   agentName: string;
@@ -62,16 +55,6 @@ type WizardState = {
   knowledgeTopK: number;
   allowedDirs: string;
   initBeads: boolean;
-  // Discord surface (optional, skippable). `discordAdminId` accepts one or more
-  // IDs (comma/newline) — the operator's own user ID(s) allowed to DM the bot.
-  discordEnabled: boolean;
-  discordToken: string;
-  discordAdminId: string;
-  // Google surface (optional). Collect the OAuth client here; authorizing
-  // ("Connect Google") happens in Settings after setup (it opens the browser).
-  googleClientId: string;
-  googleClientSecret: string;
-  googleTz: string;
 };
 
 function defaultState(): WizardState {
@@ -99,12 +82,6 @@ function defaultState(): WizardState {
     knowledgeTopK: 5,
     allowedDirs: "",
     initBeads: false,
-    discordEnabled: false,
-    discordToken: "",
-    discordAdminId: "",
-    googleClientId: "",
-    googleClientSecret: "",
-    googleTz: "",
   };
 }
 
@@ -135,12 +112,6 @@ function hydrateState(payload: ConfigPayload, status: SetupStatus | null): Wizar
     knowledgeTopK: Number(config.knowledge.top_k ?? 5),
     allowedDirs: (config.operator?.allowed_dirs || []).join("\n"),
     initBeads: false,
-    discordEnabled: Boolean(config.discord?.enabled),
-    discordToken: "",
-    discordAdminId: (config.discord?.admin_ids || []).join(", "),
-    googleClientId: config.google?.client_id || "",
-    googleClientSecret: "",
-    googleTz: config.google?.tz || "",
   };
 }
 
@@ -165,8 +136,6 @@ export function SetupWizard({
   // Result of the last "Test connection" probe (a real completion). null = not
   // yet tested; invalidated whenever the key/base/model changes.
   const [tested, setTested] = useState<null | { ok: boolean; error: string }>(null);
-  // Discord "Test connection" result (null = not tested; carries the bot name).
-  const [discordTested, setDiscordTested] = useState<null | { ok: boolean; error: string; bot: string | null }>(null);
 
   const index = steps.indexOf(step);
 
@@ -197,11 +166,6 @@ export function SetupWizard({
   useEffect(() => {
     setTested(null);
   }, [state.apiBase, state.apiKey, state.modelName]);
-
-  // A changed token invalidates a prior Discord test.
-  useEffect(() => {
-    setDiscordTested(null);
-  }, [state.discordToken]);
 
   const canGoNext = useMemo(() => {
     // ACP runtime needs no gateway, so don't gate the step on the model fields.
@@ -254,22 +218,6 @@ export function SetupWizard({
       setTested({ ok: r.ok, error: r.error || "" });
     } catch (exc) {
       setTested({ ok: false, error: exc instanceof Error ? exc.message : String(exc) });
-    } finally {
-      setBusy(false);
-    }
-  }
-
-  // Verify the Discord bot token before finishing — fetches the bot identity so
-  // a bad token is caught in the UI (and the operator sees the bot's name).
-  async function testDiscord() {
-    setBusy(true);
-    setError("");
-    setDiscordTested(null);
-    try {
-      const r = await api.testDiscord(state.discordToken.trim());
-      setDiscordTested({ ok: r.ok, error: r.error || "", bot: r.bot_user });
-    } catch (exc) {
-      setDiscordTested({ ok: false, error: exc instanceof Error ? exc.message : String(exc), bot: null });
     } finally {
       setBusy(false);
     }
@@ -344,26 +292,9 @@ export function SetupWizard({
           operator: {
             allowed_dirs: allowedDirs,
           },
-          // Discord is enabled when a token is present (this run or already
-          // stored). bot_token is only sent when entered — blank preserves the
-          // existing secret, same as the model api_key.
-          discord: {
-            enabled: Boolean(state.discordToken.trim()) || state.discordEnabled,
-            ...(state.discordToken.trim() ? { bot_token: state.discordToken.trim() } : {}),
-            admin_ids: state.discordAdminId
-              .split(/[\n,]/)
-              .map((id) => id.trim())
-              .filter(Boolean),
-          },
-          // Google: store the OAuth client; enabling happens, but the managed MCP
-          // server only starts once "Connect Google" (Settings) mints a token.
-          // client_secret only sent when entered (blank preserves the stored one).
-          google: {
-            enabled: Boolean(state.googleClientId.trim()),
-            client_id: state.googleClientId.trim(),
-            ...(state.googleClientSecret.trim() ? { client_secret: state.googleClientSecret.trim() } : {}),
-            tz: state.googleTz.trim(),
-          },
+          // Discord + Google are managed in System → Settings, not the setup
+          // wizard. They're omitted here so finishing setup leaves any existing
+          // integration config untouched (the YAML write merges, never replaces).
         },
         state.soul,
       );
@@ -637,99 +568,6 @@ export function SetupWizard({
                 onCheckedChange={(c) => update({ initBeads: c })}
                 label="Initialize beads"
               />
-            </StepBody>
-          ) : null}
-
-          {step === "discord" ? (
-            <StepBody icon={<MessageCircle size={20} />} title="Discord" kicker="Optional">
-              <p className="field-hint" style={{ marginTop: 0 }}>
-                Connect a Discord bot so you can DM {state.agentName || "your agent"} from
-                Discord. Optional — skip it and set it up later in System → Settings.{" "}
-                <a href={DISCORD_GUIDE_URL} target="_blank" rel="noreferrer" className="setup-link">
-                  How to create a bot <ExternalLink size={12} />
-                </a>
-              </p>
-              <label className="field">
-                <span>Bot token</span>
-                <Input
-                  type="password"
-                  value={state.discordToken}
-                  onChange={(event) => update({ discordToken: event.target.value })}
-                  autoComplete="off"
-                  placeholder="Leave blank to skip Discord"
-                />
-              </label>
-              <div className="setup-grid model-row">
-                <label className="field">
-                  <span>Your Discord user ID(s)</span>
-                  <Input
-                    value={state.discordAdminId}
-                    onChange={(event) => update({ discordAdminId: event.target.value })}
-                    placeholder="e.g. 249386616806834177 — comma-separated; empty = anyone"
-                  />
-                </label>
-                <Button
-                 
-                  type="button"
-                  onClick={() => void testDiscord()}
-                  disabled={busy || !state.discordToken.trim()}
-                >
-                  {busy ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
-                  Test connection
-                </Button>
-              </div>
-              {discordTested ? (
-                <div className={`setup-test ${discordTested.ok ? "ok" : "err"}`} role="status">
-                  {discordTested.ok ? <Check size={15} /> : <AlertTriangle size={15} />}
-                  <span>
-                    {discordTested.ok
-                      ? `Connected as ${discordTested.bot || "your bot"}.`
-                      : `Connection failed — ${discordTested.error || "check the token."}`}
-                  </span>
-                </div>
-              ) : null}
-            </StepBody>
-          ) : null}
-
-          {step === "google" ? (
-            <StepBody icon={<CalendarDays size={20} />} title="Google" kicker="Optional">
-              <p className="field-hint" style={{ marginTop: 0 }}>
-                Give {state.agentName || "your agent"} read access to Gmail + Calendar. Paste your
-                Google Cloud <strong>Desktop app</strong> OAuth client below — after setup, click
-                <strong> Connect Google</strong> in System → Settings to authorize (it opens your
-                browser). Optional — skip to do it later.{" "}
-                <a href={GOOGLE_GUIDE_URL} target="_blank" rel="noreferrer" className="setup-link">
-                  Get an OAuth client <ExternalLink size={12} />
-                </a>
-              </p>
-              <div className="setup-grid two">
-                <label className="field">
-                  <span>OAuth client ID</span>
-                  <Input
-                    value={state.googleClientId}
-                    onChange={(event) => update({ googleClientId: event.target.value })}
-                    placeholder="…apps.googleusercontent.com"
-                  />
-                </label>
-                <label className="field">
-                  <span>OAuth client secret</span>
-                  <Input
-                    type="password"
-                    value={state.googleClientSecret}
-                    onChange={(event) => update({ googleClientSecret: event.target.value })}
-                    autoComplete="off"
-                    placeholder="Leave blank to skip Google"
-                  />
-                </label>
-              </div>
-              <label className="field">
-                <span>Timezone (IANA, optional)</span>
-                <Input
-                  value={state.googleTz}
-                  onChange={(event) => update({ googleTz: event.target.value })}
-                  placeholder="e.g. America/Los_Angeles — sets the day bounds for “today”"
-                />
-              </label>
             </StepBody>
           ) : null}
 


### PR DESCRIPTION
## What
- **Removed the Discord and Google steps** from the setup wizard. Both integrations are fully managed in **System → Settings** (each has its own Test/Connect action), so the wizard no longer collects bot tokens or OAuth clients. Finishing setup **omits** the `discord`/`google` keys, so existing config is preserved — the YAML write *merges*, never replaces (verified in `_apply_settings_changes` → `apply_updates_to_yaml`).
- **Added GitHub Copilot** to the wizard's ACP coding-agent picker (`acp:copilot` → `copilot --acp`), matching `runtime/acp_runtime.py` and the Settings runtime options. It was the one `acp:*` runtime the wizard was missing.

## Cleanup
Removed the now-unused state, hydrate/default fields, the `testDiscord` probe + its result state/effect, the two guide-URL constants, and the `MessageCircle`/`CalendarDays`/`ExternalLink` icon imports.

## Verification
- `tsc` (both projects) clean — no unused locals/imports.
- No `discord`/`google`/`testDiscord` references remain in the wizard (only an explanatory comment).

🤖 Generated with [Claude Code](https://claude.com/claude-code)