### PR TITLE
feat(evals): retrieval-quality harness (recall@k / MRR / nDCG on a gold set)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Retrieval-quality eval harness** (`evals/retrieval.py` + `evals/retrieval_gold.yaml`).
+  Measures the knowledge store's retrieval in isolation — recall@k / hit-rate@k / MRR /
+  nDCG@k over a labelled gold set, split by query mode (keyword vs paraphrase) — which
+  the A2A side-effect suite never did. Reports the hybrid-vs-keyword recall lift and can
+  sweep the `vector_k` / `rrf_k` knobs. Runs against the real gateway embedder or a
+  deterministic offline bag-of-words embedder; metric math is pure + unit-tested. This is
+  the regression guard + measurement tool for the next RAG steps (chunking, contextual
+  enrichment, reranking).
+
 ### Changed
 - **Semantic recall tuned + made tunable** (RAG bake-off findings from internal research).
   `knowledge.top_k` raised 5 → 10 and the recall preview 240 → 1000 chars (more

--- a/evals/README.md
+++ b/evals/README.md
@@ -147,8 +147,36 @@ never appears.** If the agent has to infer the tool from intent, that
 *is* the test — leaking the tool name into the prompt is testing
 instruction-following, not tool selection.
 
+## Retrieval quality (`evals/retrieval.py`)
+
+The suite above tests end-to-end behaviour over A2A. It does **not** measure
+retrieval quality in isolation — so an embedding/RRF/chunking change could regress
+recall and nothing would notice. `evals/retrieval.py` is that missing layer: it
+seeds a `HybridKnowledgeStore` from a labelled gold set (`retrieval_gold.yaml`),
+runs each query, and scores the ranked ids with **recall@k / hit-rate@k / MRR /
+nDCG@k** — overall and split by query mode (`keyword` vs `paraphrase`).
+
+```bash
+# Real gateway embedder (reads your config + secrets, same as boot):
+python -m evals.retrieval                  # hybrid vs keyword-only @k=10
+python -m evals.retrieval --sweep          # + a vector_k × rrf_k grid
+python -m evals.retrieval --k 5 --json evals/results/retrieval.json
+
+# Deterministic, offline (no gateway) — what the unit test uses:
+python -m evals.retrieval --embedder bow
+```
+
+It prints the **hybrid-vs-keyword recall lift** (the RAG bake-off's headline — the
+vector half should help most on paraphrase queries) and, with `--sweep`, ranks the
+two retrieval knobs surfaced in #985 (`knowledge.vector_k`, `knowledge.rrf_k`) by
+recall@k. The metric functions are pure and unit-tested (`tests/test_retrieval_eval.py`),
+including a constructed case that proves the harness captures the vector lift. This
+is the regression guard + measurement tool for the next RAG steps (chunking,
+contextual enrichment, reranking).
+
 ## References
 
 - Anthropic — [Demystifying evals for AI agents](https://www.anthropic.com/engineering/demystifying-evals-for-ai-agents)
+- Anthropic — [Contextual Retrieval](https://www.anthropic.com/news/contextual-retrieval)
 - BFCL V3 — [Multi-Turn](https://gorilla.cs.berkeley.edu/blogs/13_bfcl_v3_multi_turn.html)
 - [ToolSandbox](https://arxiv.org/html/2408.04682v1)

--- a/evals/retrieval.py
+++ b/evals/retrieval.py
@@ -1,0 +1,262 @@
+"""Retrieval-quality eval for the knowledge store (the missing measurement layer).
+
+protoAgent's main eval suite (ADR 0012, ``evals/runner.py``) drives a live agent
+over A2A and checks side effects — great for end-to-end behaviour, but it never
+measures **retrieval quality** in isolation: there was no recall@k / MRR / nDCG, no
+labelled query→chunk gold set, no regression guard. So an embedding/RRF/chunking
+change could silently regress and nothing would catch it.
+
+This module fills that gap. It seeds a ``HybridKnowledgeStore`` from a labelled
+gold set (``evals/retrieval_gold.yaml``), runs each query, and scores the ranked
+ids against the relevant ones. It can:
+
+  * report recall@k / hit-rate@k / MRR / nDCG@k, overall and split by query mode
+    (keyword vs paraphrase),
+  * **compare hybrid vs keyword-only** on the same corpus (the RAG bake-off's
+    headline: hybrid should beat lexical-alone, especially on paraphrase queries),
+  * **sweep** the retrieval knobs (vector_k, rrf_k) to find a better operating point.
+
+Run it live (real gateway embedder, reads your config + secrets)::
+
+    python -m evals.retrieval                 # compare hybrid vs keyword @k=10
+    python -m evals.retrieval --sweep         # + a vector_k × rrf_k grid
+    python -m evals.retrieval --k 5 --json out.json
+
+Or deterministically with the built-in bag-of-words embedder (no gateway, used by
+the unit test)::
+
+    python -m evals.retrieval --embedder bow
+
+The metrics functions are pure and independently unit-tested.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import math
+import tempfile
+from pathlib import Path
+from typing import Callable, Iterable
+
+import yaml
+
+GOLD_PATH = Path(__file__).resolve().parent / "retrieval_gold.yaml"
+RESULTS_DIR = Path(__file__).resolve().parent / "results"
+
+EmbedFn = Callable[[str], list[float]]
+
+
+# ── metrics (pure) ───────────────────────────────────────────────────────────
+
+
+def recall_at_k(retrieved: list, relevant: Iterable, k: int) -> float:
+    """Fraction of the relevant ids found in the top-k."""
+    rel = set(relevant)
+    if not rel:
+        return 0.0
+    return len(set(retrieved[:k]) & rel) / len(rel)
+
+
+def hit_rate_at_k(retrieved: list, relevant: Iterable, k: int) -> float:
+    """1.0 if ANY relevant id is in the top-k (a.k.a. success@k), else 0.0."""
+    return 1.0 if set(retrieved[:k]) & set(relevant) else 0.0
+
+
+def mrr(retrieved: list, relevant: Iterable) -> float:
+    """Reciprocal rank of the first relevant hit (0 if none)."""
+    rel = set(relevant)
+    for i, cid in enumerate(retrieved):
+        if cid in rel:
+            return 1.0 / (i + 1)
+    return 0.0
+
+
+def ndcg_at_k(retrieved: list, relevant: Iterable, k: int) -> float:
+    """Binary-relevance nDCG@k."""
+    rel = set(relevant)
+    dcg = sum(1.0 / math.log2(i + 2) for i, cid in enumerate(retrieved[:k]) if cid in rel)
+    ideal = sum(1.0 / math.log2(i + 2) for i in range(min(len(rel), k)))
+    return dcg / ideal if ideal else 0.0
+
+
+# ── gold set ─────────────────────────────────────────────────────────────────
+
+
+def load_gold(path: str | Path = GOLD_PATH) -> tuple[list[dict], list[dict]]:
+    """Return ``(corpus, queries)`` from the gold YAML."""
+    doc = yaml.safe_load(Path(path).read_text())
+    return doc.get("corpus", []), doc.get("queries", [])
+
+
+# ── harness ──────────────────────────────────────────────────────────────────
+
+
+def _bow_embed_factory(corpus: list[dict], queries: list[dict]) -> EmbedFn:
+    """A deterministic bag-of-words embedder over the gold set's own vocabulary —
+    no gateway needed. Good enough to exercise the vector path + metric math in a
+    unit test; NOT a stand-in for real embedding quality."""
+    import re
+
+    def toks(s: str) -> list[str]:
+        return re.findall(r"[a-z0-9]+", s.lower())
+
+    vocab: list[str] = []
+    seen: set[str] = set()
+    for item in list(corpus) + list(queries):
+        for w in toks(item.get("content") or item.get("q") or ""):
+            if w not in seen and len(w) > 2:
+                seen.add(w)
+                vocab.append(w)
+    index = {w: i for i, w in enumerate(vocab)}
+
+    def embed(text: str) -> list[float]:
+        v = [0.0] * len(vocab)
+        for w in toks(text):
+            j = index.get(w)
+            if j is not None:
+                v[j] = 1.0
+        return v
+
+    return embed
+
+
+def _seed(corpus: list[dict], embed_fn: EmbedFn | None, *, db_path: str, **store_kwargs):
+    """Build a HybridKnowledgeStore, add the corpus, return ``(store, key->id)``."""
+    from knowledge.hybrid_store import HybridKnowledgeStore
+
+    store = HybridKnowledgeStore(db_path, embed_fn=embed_fn, **store_kwargs)
+    key_to_id: dict[str, int] = {}
+    for item in corpus:
+        cid = store.add_chunk(item["content"], domain=item.get("domain", "general"))
+        key_to_id[item["key"]] = cid
+    return store, key_to_id
+
+
+def evaluate(
+    embed_fn: EmbedFn | None,
+    corpus: list[dict],
+    queries: list[dict],
+    *,
+    k: int = 10,
+    **store_kwargs,
+) -> dict:
+    """Seed a store, run every query, and aggregate metrics overall + by mode."""
+    with tempfile.TemporaryDirectory() as tmp:
+        store, key_to_id = _seed(corpus, embed_fn, db_path=str(Path(tmp) / "kb.db"), **store_kwargs)
+        per_query: list[dict] = []
+        for item in queries:
+            relevant = [key_to_id[key] for key in item["relevant"] if key in key_to_id]
+            rows = store.search(item["q"], k=max(k, 1))
+            retrieved = [r.get("id") for r in rows]
+            per_query.append({
+                "q": item["q"],
+                "mode": item.get("mode", "?"),
+                "recall": recall_at_k(retrieved, relevant, k),
+                "hit": hit_rate_at_k(retrieved, relevant, k),
+                "mrr": mrr(retrieved, relevant),
+                "ndcg": ndcg_at_k(retrieved, relevant, k),
+            })
+
+    def _agg(rows: list[dict]) -> dict:
+        n = len(rows) or 1
+        return {
+            "n": len(rows),
+            "recall@k": round(sum(r["recall"] for r in rows) / n, 4),
+            "hit@k": round(sum(r["hit"] for r in rows) / n, 4),
+            "mrr": round(sum(r["mrr"] for r in rows) / n, 4),
+            "ndcg@k": round(sum(r["ndcg"] for r in rows) / n, 4),
+        }
+
+    modes = sorted({r["mode"] for r in per_query})
+    return {
+        "k": k,
+        "overall": _agg(per_query),
+        "by_mode": {m: _agg([r for r in per_query if r["mode"] == m]) for m in modes},
+        "per_query": per_query,
+    }
+
+
+def compare_hybrid_vs_keyword(embed_fn: EmbedFn, corpus, queries, *, k: int = 10, **store_kwargs) -> dict:
+    """The RAG bake-off's headline question, on our stack: how much does the vector
+    half lift recall over keyword-only (same store, ``embed_fn=None`` ⇒ pure FTS5)?"""
+    hybrid = evaluate(embed_fn, corpus, queries, k=k, **store_kwargs)
+    keyword = evaluate(None, corpus, queries, k=k)
+    lift = round(hybrid["overall"]["recall@k"] - keyword["overall"]["recall@k"], 4)
+    return {"hybrid": hybrid, "keyword": keyword, "recall_lift": lift}
+
+
+def sweep(embed_fn: EmbedFn, corpus, queries, *, k: int = 10,
+          vector_ks=(10, 20, 40), rrf_ks=(20, 60, 120)) -> list[dict]:
+    """Grid over the two retrieval knobs surfaced in #985, ranked by recall@k."""
+    out = []
+    for vk in vector_ks:
+        for rk in rrf_ks:
+            rep = evaluate(embed_fn, corpus, queries, k=k, vector_k=vk, rrf_k=rk)
+            out.append({"vector_k": vk, "rrf_k": rk, **rep["overall"]})
+    out.sort(key=lambda r: (r["recall@k"], r["mrr"]), reverse=True)
+    return out
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def _gateway_embed_fn() -> EmbedFn:
+    """The real embedder, built from the live config + secrets (same path as boot)."""
+    from graph.config import LangGraphConfig
+    from graph.config_io import CONFIG_YAML_PATH
+    from graph.llm import create_embed_fn
+
+    cfg = LangGraphConfig.from_yaml(CONFIG_YAML_PATH)
+    fn = create_embed_fn(cfg)
+    if fn is None:
+        raise SystemExit(
+            "no embedder: set knowledge.embed_model + a gateway api_key, or run with --embedder bow"
+        )
+    return fn
+
+
+def _fmt(agg: dict) -> str:
+    return f"recall@k={agg['recall@k']:.3f}  hit@k={agg['hit@k']:.3f}  mrr={agg['mrr']:.3f}  ndcg@k={agg['ndcg@k']:.3f}  (n={agg['n']})"
+
+
+def main(argv: list[str] | None = None) -> int:
+    p = argparse.ArgumentParser(description="Retrieval-quality eval for the knowledge store.")
+    p.add_argument("--k", type=int, default=10, help="top-k cut for the metrics (default 10).")
+    p.add_argument("--gold", default=str(GOLD_PATH), help="gold YAML path.")
+    p.add_argument("--embedder", choices=["gateway", "bow"], default="gateway",
+                   help="gateway = real qwen3-embedding (default); bow = deterministic, offline.")
+    p.add_argument("--sweep", action="store_true", help="also sweep vector_k × rrf_k.")
+    p.add_argument("--json", dest="json_out", default="", help="write the full report to this path.")
+    args = p.parse_args(argv)
+
+    corpus, queries = load_gold(args.gold)
+    embed_fn = _bow_embed_factory(corpus, queries) if args.embedder == "bow" else _gateway_embed_fn()
+
+    cmp = compare_hybrid_vs_keyword(embed_fn, corpus, queries, k=args.k)
+    print(f"\nRetrieval eval — {len(corpus)} chunks, {len(queries)} queries, k={args.k}, embedder={args.embedder}\n")
+    print(f"  hybrid   {_fmt(cmp['hybrid']['overall'])}")
+    print(f"  keyword  {_fmt(cmp['keyword']['overall'])}")
+    print(f"  recall lift (hybrid − keyword): {cmp['recall_lift']:+.3f}\n")
+    print("  hybrid by mode:")
+    for mode, agg in cmp["hybrid"]["by_mode"].items():
+        print(f"    {mode:12s} {_fmt(agg)}")
+
+    report = {"compare": cmp}
+    if args.sweep:
+        grid = sweep(embed_fn, corpus, queries, k=args.k)
+        report["sweep"] = grid
+        print("\n  knob sweep (top 5 by recall@k):")
+        for row in grid[:5]:
+            print(f"    vector_k={row['vector_k']:<3} rrf_k={row['rrf_k']:<4} "
+                  f"recall@k={row['recall@k']:.3f} mrr={row['mrr']:.3f} ndcg@k={row['ndcg@k']:.3f}")
+
+    if args.json_out:
+        Path(args.json_out).write_text(json.dumps(report, indent=2))
+        print(f"\n  wrote {args.json_out}")
+    print()
+    return 0
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/evals/retrieval_gold.yaml
+++ b/evals/retrieval_gold.yaml
@@ -1,0 +1,130 @@
+# Retrieval-quality gold set for the knowledge store (see evals/retrieval.py).
+#
+# A small, labelled corpus + queries with the chunk(s) that SHOULD be retrieved.
+# Each query is tagged `mode`: "keyword" (lexical overlap — FTS5 should find it)
+# or "paraphrase" (semantically related but few/no shared content words — this is
+# where the vector half of the hybrid earns its keep). Chunks are referenced by a
+# stable `key`; the harness resolves keys → assigned chunk ids at seed time, so the
+# numeric ids never have to be hard-coded.
+#
+# This is deliberately operator-notes-scale (matching the store's design point).
+# It's a regression guard + a way to measure the impact of retrieval changes
+# (knob sweeps today; chunking / contextual enrichment / reranking next).
+
+corpus:
+  - key: scheduler
+    domain: fact
+    content: "The scheduler runs jobs on a cron-like cadence and survives restarts via a SQLite job store."
+  - key: embeddings
+    domain: fact
+    content: "Semantic recall embeds each chunk with qwen3-embedding and fuses keyword and vector hits with reciprocal rank fusion."
+  - key: a2a
+    domain: fact
+    content: "Agents talk to each other over the A2A protocol version 1.0 using JSON-RPC methods like message/send."
+  - key: restart
+    domain: fact
+    content: "The server can be restarted from the console; it drains in-flight work then re-execs the process."
+  - key: discord
+    domain: fact
+    content: "The Discord surface lets an operator direct-message the agent through a gated bot token."
+  - key: knowledge_store
+    domain: fact
+    content: "The knowledge base is a per-agent SQLite store with FTS5 keyword search and an optional vector layer."
+  - key: circuit_breaker
+    domain: fact
+    content: "When the embedding gateway returns errors repeatedly, a circuit breaker falls back to keyword-only search."
+  - key: harvest
+    domain: conversation
+    content: "When a chat session is retired, an auxiliary model summarizes it into the knowledge base before the raw history is pruned."
+  - key: facts_extract
+    domain: fact
+    content: "Durable facts are distilled from conversations and de-duplicated before being stored."
+  - key: skills
+    domain: fact
+    content: "Learned skills are indexed in a separate FTS5 store and injected into the prompt as a learned-skills block."
+  - key: delegates
+    domain: fact
+    content: "Delegate agents are registered with an endpoint and credentials so the agent can hand off subtasks."
+  - key: telemetry
+    domain: fact
+    content: "Each turn writes a cost and latency row to a local telemetry store, queryable through the API."
+  - key: plugins
+    domain: fact
+    content: "Plugins are installed, then enabled, then trusted; enabling hot-mounts the routes without a restart."
+  - key: acp_runtime
+    domain: fact
+    content: "An external coding agent can drive a turn over ACP instead of the native loop, selected by the agent_runtime setting."
+  - key: goals
+    domain: fact
+    content: "Goals have a drive or monitor disposition, with verifiers that check progress on a cadence."
+  - key: backup_note
+    domain: note
+    content: "Note: the production database backups run nightly at 2am and are kept for thirty days."
+  - key: oncall_note
+    domain: note
+    content: "Note: the on-call rotation hands off every Monday morning; page the secondary if there is no acknowledgement within ten minutes."
+  - key: workflows
+    domain: fact
+    content: "Workflows are declarative static DAGs over subagents, useful for adversarial deep-research recipes."
+  - key: caching
+    domain: fact
+    content: "Prompt caching reuses a cacheable prefix with a five-minute TTL to cut latency and cost on repeat traffic."
+  - key: tailnet
+    domain: fact
+    content: "Agents discover each other over mDNS on a LAN and over a Tailscale tailnet by probing online peers."
+
+queries:
+  - q: "scheduler cron cadence"
+    relevant: [scheduler]
+    mode: keyword
+  - q: "how does the agent run tasks on a timer"
+    relevant: [scheduler]
+    mode: paraphrase
+  - q: "reciprocal rank fusion"
+    relevant: [embeddings]
+    mode: keyword
+  - q: "which model turns text into vectors for search"
+    relevant: [embeddings]
+    mode: paraphrase
+  - q: "A2A message/send"
+    relevant: [a2a]
+    mode: keyword
+  - q: "how do agents communicate with one another"
+    relevant: [a2a]
+    mode: paraphrase
+  - q: "can I reboot the backend without using the terminal"
+    relevant: [restart]
+    mode: paraphrase
+  - q: "message the assistant from a chat app"
+    relevant: [discord]
+    mode: paraphrase
+  - q: "what happens to retrieval when the embedding service is down"
+    relevant: [circuit_breaker]
+    mode: paraphrase
+  - q: "summarize a conversation once it ends"
+    relevant: [harvest]
+    mode: paraphrase
+  - q: "hand a subtask off to another agent"
+    relevant: [delegates]
+    mode: paraphrase
+  - q: "installed and enabled plugins"
+    relevant: [plugins]
+    mode: keyword
+  - q: "run a turn with an external coding agent"
+    relevant: [acp_runtime]
+    mode: keyword
+  - q: "how long are nightly database backups kept"
+    relevant: [backup_note]
+    mode: paraphrase
+  - q: "who do I page when on-call doesn't respond"
+    relevant: [oncall_note]
+    mode: paraphrase
+  - q: "discover other agents on the network"
+    relevant: [tailnet]
+    mode: paraphrase
+  - q: "cut latency on repeated prompts"
+    relevant: [caching]
+    mode: paraphrase
+  - q: "where are extracted facts stored"
+    relevant: [facts_extract, knowledge_store]
+    mode: paraphrase

--- a/tests/test_retrieval_eval.py
+++ b/tests/test_retrieval_eval.py
@@ -1,0 +1,87 @@
+"""Tests for the retrieval-quality eval harness (evals/retrieval.py).
+
+Deterministic — no gateway. Covers the pure metric math, an end-to-end run over the
+shipped gold set with the built-in bag-of-words embedder, and a constructed case
+proving the harness actually captures the hybrid (vector) lift over keyword-only.
+"""
+
+from __future__ import annotations
+
+import math
+
+from evals import retrieval as R
+
+
+# ── pure metrics ─────────────────────────────────────────────────────────────
+
+
+def test_recall_at_k():
+    assert R.recall_at_k([1, 2, 3], [2], 10) == 1.0
+    assert R.recall_at_k([1, 2, 3], [9], 10) == 0.0
+    assert R.recall_at_k([1, 2, 3, 4], [2, 4], 10) == 1.0
+    assert R.recall_at_k([1, 2, 3, 4], [2, 4], 2) == 0.5  # only id 2 is in the top-2
+    assert R.recall_at_k([1, 2, 3], [], 10) == 0.0        # no relevant → 0, not a crash
+
+
+def test_hit_rate_at_k():
+    assert R.hit_rate_at_k([1, 2, 3], [3], 3) == 1.0
+    assert R.hit_rate_at_k([1, 2, 3], [3], 2) == 0.0      # id 3 falls outside top-2
+    assert R.hit_rate_at_k([1, 2, 3], [9], 3) == 0.0
+
+
+def test_mrr():
+    assert R.mrr([5, 2, 9], [2]) == 0.5                   # first relevant at rank 2
+    assert R.mrr([2, 5, 9], [2]) == 1.0
+    assert R.mrr([1, 2, 3], [9]) == 0.0
+
+
+def test_ndcg_at_k():
+    assert R.ndcg_at_k([7, 1, 2], [7], 10) == 1.0         # relevant first → ideal
+    # single relevant at rank 3: dcg = 1/log2(4), ideal = 1/log2(2) = 1
+    assert math.isclose(R.ndcg_at_k([1, 2, 7], [7], 10), 1.0 / math.log2(4), rel_tol=1e-9)
+    assert R.ndcg_at_k([1, 2, 3], [9], 10) == 0.0
+
+
+# ── end-to-end over the shipped gold set (bow embedder) ──────────────────────
+
+
+def test_evaluate_gold_set_with_bow_embedder():
+    corpus, queries = R.load_gold()
+    assert corpus and queries
+    embed = R._bow_embed_factory(corpus, queries)
+    rep = R.evaluate(embed, corpus, queries, k=10)
+
+    # well-formed aggregate
+    assert rep["k"] == 10
+    assert rep["overall"]["n"] == len(queries)
+    for key in ("recall@k", "hit@k", "mrr", "ndcg@k"):
+        assert 0.0 <= rep["overall"][key] <= 1.0
+    assert "per_query" in rep and len(rep["per_query"]) == len(queries)
+
+    # keyword-mode queries share tokens with their target, so even lexical/bow
+    # retrieval must find them — a strong, deterministic floor.
+    kw = rep["by_mode"].get("keyword")
+    assert kw and kw["recall@k"] == 1.0
+
+
+# ── the harness captures the vector lift ─────────────────────────────────────
+
+
+def test_hybrid_beats_keyword_on_a_non_lexical_match():
+    """A query with NO lexical overlap with its relevant chunk: keyword-only (FTS5)
+    can't find it (recall 0), but an embedder that maps them together makes the
+    hybrid surface it (recall 1). Proves the harness measures the vector lift."""
+    corpus = [
+        {"key": "target", "domain": "general", "content": "alpha beta gamma"},
+        {"key": "other", "domain": "general", "content": "delta epsilon zeta"},
+    ]
+    queries = [{"q": "zzzzz", "relevant": ["target"], "mode": "paraphrase"}]
+
+    def embed(text: str) -> list[float]:
+        # query "zzzzz" and the target chunk both map to the same vector.
+        return [1.0, 0.0] if ("alpha" in text or "zzzzz" in text) else [0.0, 1.0]
+
+    cmp = R.compare_hybrid_vs_keyword(embed, corpus, queries, k=5)
+    assert cmp["keyword"]["overall"]["recall@k"] == 0.0
+    assert cmp["hybrid"]["overall"]["recall@k"] == 1.0
+    assert cmp["recall_lift"] == 1.0


### PR DESCRIPTION
Second of the two RAG PRs you picked (quick wins + eval harness). The A2A eval suite (ADR 0012) tests end-to-end behaviour but **never measured retrieval in isolation** — gap #11 from the audit: no recall@k / MRR / nDCG, no labelled query→chunk gold set, no regression guard. So an embedding / RRF / chunking change could silently regress recall and nothing would catch it.

## What
- **`evals/retrieval.py`** — seeds a `HybridKnowledgeStore` from a labelled gold set, runs each query, scores the ranked ids:
  - **recall@k / hit-rate@k / MRR / nDCG@k**, overall and split by query `mode` (keyword vs paraphrase)
  - **hybrid vs keyword-only recall lift** — the bake-off's headline, measured on *our* stack (the vector half should help most on paraphrase)
  - a **`vector_k` × `rrf_k` knob sweep** (the knobs #985 surfaced), ranked by recall@k
  - runs against the **real gateway embedder** (reads config+secrets, same path as boot) or a **deterministic offline bag-of-words** embedder
- **`evals/retrieval_gold.yaml`** — 20 chunks, 18 queries (keyword + paraphrase), chunks referenced by stable key so ids never get hard-coded.
- **`tests/test_retrieval_eval.py`** — pure metric math + an end-to-end bow run + a constructed non-lexical case that **proves the harness captures the vector lift** (keyword recall 0 → hybrid recall 1).
- README section + Anthropic Contextual-Retrieval reference.

## Why
This is the **measurement layer** for the rest of the RAG roadmap — chunking, contextual enrichment, reranking can now be *proven*, not guessed. It's also a CI regression guard against silent recall drops.

## Verification
- `pytest tests/test_retrieval_eval.py` → **6 passed**; `ruff` clean.
- Bow CLI smoke: 20 chunks / 18 queries, keyword-mode recall@k = 1.000 (deterministic floor). Real-embedder numbers to follow on main.

Follow-up (not in this PR): wire a `retrieval` lane into the sweep/leaderboard, and port the 4-dim answer-quality rubric (groundedness / context-relevance / answer-relevance / faithfulness) for end-to-end RAG scoring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)