### PR TITLE
fix(knowledge): clear the embed circuit breaker on a passing connection test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list (`acp:copilot` → `copilot --acp`), matching the Settings runtime options.
 
 ### Fixed
+- **Embedding circuit breaker clears on a passing connection test.** After repeated embed
+  auth failures (e.g. an expired gateway key) the breaker latches open for
+  `embed_breaker_cooldown_s` and serves keyword-only FTS5. Fixing the key via Settings
+  already recovered instantly (the store is rebuilt with a fresh breaker), but an
+  out-of-band fix — hand-edited `secrets.yaml`, an env var, or a gateway-side recovery —
+  left recall degraded until the cooldown elapsed. A successful **Test connection** of the
+  live key (`/api/config/test-model` with no form-local key) now clears the breaker
+  immediately, so semantic recall resumes at once. New `HybridKnowledgeStore.reset_embed_breaker()`.
 - **Knowledge embeddings default to `qwen3-embedding`.** The setup wizard hard-coded
   `nomic-embed-text`, which the protoLabs gateway doesn't serve — so semantic recall
   401'd on every embed and silently degraded to keyword-only. The wizard now writes

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -97,6 +97,18 @@ class HybridKnowledgeStore(KnowledgeStore):
         self._embed_failures = 0
         self._breaker_open_until = 0.0
 
+    def reset_embed_breaker(self) -> bool:
+        """Force the embedding circuit closed immediately.
+
+        Called when the gateway key is confirmed good out-of-band (a successful
+        "Test connection" of the live key) so semantic recall resumes at once
+        instead of waiting out ``breaker_cooldown_s``. Returns True if the
+        breaker was actually open (something changed) — lets callers log only
+        when it mattered. A no-op when already closed."""
+        was_open = self._breaker_open() or self._embed_failures > 0
+        self._record_embed_success()
+        return was_open
+
     def _embed(self, text: str) -> list[float] | None:
         if self._embed_fn is None or self._breaker_open():
             return None

--- a/operator_api/config_routes.py
+++ b/operator_api/config_routes.py
@@ -50,6 +50,23 @@ class SettingsResetRequest(BaseModel):
     keys: list[str] = []
 
 
+def _reset_live_embed_breaker() -> None:
+    """Clear the live knowledge store's embedding circuit breaker, if it has one.
+
+    Duck-typed: only ``HybridKnowledgeStore`` exposes ``reset_embed_breaker``; a
+    keyword-only base store or a plugin backend simply has no breaker to reset."""
+    store = STATE.knowledge_store
+    reset = getattr(store, "reset_embed_breaker", None)
+    if callable(reset):
+        try:
+            if reset():
+                import logging
+                logging.getLogger("protoagent.server").info(
+                    "[knowledge] embedding breaker cleared (live key tested OK)")
+        except Exception:  # noqa: BLE001 — never let a breaker reset break the test route
+            pass
+
+
 def register_config_routes(app) -> None:
     """Register the ``/api/config*`` + ``/api/settings*`` routes on ``app``."""
 
@@ -110,6 +127,14 @@ def register_config_routes(app) -> None:
         key = body.api_key or (STATE.graph_config.api_key if STATE.graph_config else "")
         model = body.model or (STATE.graph_config.model_name if STATE.graph_config else "")
         ok, error = await asyncio.to_thread(validate_model_connection, base, key, model)
+        # A successful test of the LIVE saved key (no form-local override) proves the
+        # gateway + key are good again — so clear any open embedding circuit breaker
+        # now, instead of waiting out the cooldown. This is the recovery path for an
+        # out-of-band key fix (hand-edited secrets.yaml, env var, gateway-side fix):
+        # the settings-save path already resets it by rebuilding the store. Embeds use
+        # the same api_base/key, so a chat-completion success is a sound signal.
+        if ok and not body.api_key:
+            _reset_live_embed_breaker()
         return {"ok": ok, "error": error}
 
     # `/api/config/test-discord` (discord plugin) and `/api/config/google/status`

--- a/tests/test_config_routes.py
+++ b/tests/test_config_routes.py
@@ -167,3 +167,51 @@ def test_reset_settings_rejects_unknown_key(monkeypatch):
     resp = _client().post("/api/settings/reset", json={"keys": ["bogus.key"]}).json()
     assert resp["ok"] is False
     assert any("unknown setting: bogus.key" in m for m in resp["messages"])
+
+
+class _BreakerStore:
+    def __init__(self):
+        self.reset_calls = 0
+
+    def reset_embed_breaker(self):
+        self.reset_calls += 1
+        return True
+
+
+def _wire_test_model(monkeypatch, *, ok: bool):
+    monkeypatch.setitem(
+        sys.modules,
+        "graph.config_io",
+        _fake_module("graph.config_io", validate_model_connection=lambda b, k, m: (ok, "" if ok else "401")),
+    )
+    import runtime.state as rs
+    cfg = types.SimpleNamespace(api_base="http://g/v1", api_key="live-key", model_name="m")
+    monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
+    store = _BreakerStore()
+    monkeypatch.setattr(rs.STATE, "knowledge_store", store, raising=False)
+    return store
+
+
+def test_test_model_success_clears_embed_breaker(monkeypatch):
+    """A passing Test-connection of the LIVE key (no form override) clears the
+    embedding circuit breaker so semantic recall recovers without the cooldown."""
+    store = _wire_test_model(monkeypatch, ok=True)
+    resp = _client().post("/api/config/test-model", json={}).json()
+    assert resp["ok"] is True
+    assert store.reset_calls == 1
+
+
+def test_test_model_failure_does_not_clear_breaker(monkeypatch):
+    store = _wire_test_model(monkeypatch, ok=False)
+    resp = _client().post("/api/config/test-model", json={}).json()
+    assert resp["ok"] is False
+    assert store.reset_calls == 0
+
+
+def test_test_model_with_form_key_does_not_clear_breaker(monkeypatch):
+    """Testing a CANDIDATE key (form override) must not touch the live store —
+    that key isn't what the running embedder uses yet."""
+    store = _wire_test_model(monkeypatch, ok=True)
+    resp = _client().post("/api/config/test-model", json={"api_key": "candidate"}).json()
+    assert resp["ok"] is True
+    assert store.reset_calls == 0

--- a/tests/test_hybrid_store.py
+++ b/tests/test_hybrid_store.py
@@ -81,3 +81,38 @@ def test_circuit_breaker_falls_back_to_fts(tmp_path):
     store.search("calculator")
     store.search("calculator")
     assert calls["n"] == before  # breaker short-circuits embed_fn
+
+
+def test_reset_embed_breaker_closes_an_open_breaker(tmp_path):
+    fail = {"on": True}
+
+    def embed(text):
+        if fail["on"]:
+            raise RuntimeError("down")
+        return [1.0, 0.0]
+
+    store = HybridKnowledgeStore(
+        _db(tmp_path), embed_fn=embed, breaker_threshold=2, breaker_cooldown_s=999,
+    )
+    store.add_chunk("calculator math", domain="general")
+    store.search("calculator")  # trips the failures
+    store.search("calculator")  # breaker now open
+    assert store._breaker_open()
+
+    # Key fixed out-of-band; reset reports it actually cleared something.
+    fail["on"] = False
+    assert store.reset_embed_breaker() is True
+    assert not store._breaker_open()
+    # A no-op when already closed.
+    assert store.reset_embed_breaker() is False
+    # The embedder is exercised again now the breaker is closed.
+    n = {"c": 0}
+    orig = store._embed_fn
+
+    def counting(t):
+        n["c"] += 1
+        return orig(t)
+
+    store._embed_fn = counting
+    store.search("calculator")
+    assert n["c"] > 0  # embed_fn called again post-reset


### PR DESCRIPTION
## What

Follow-up to the RAG work: close the one window where a fixed gateway key didn't recover semantic recall right away.

After repeated embed auth failures (e.g. an expired gateway key), the `HybridKnowledgeStore` circuit breaker latches **open for `embed_breaker_cooldown_s`** (default 300s) and serves keyword-only FTS5. Fixing the key via **Settings → Model → Save** already recovered instantly — the reload rebuilds the store with a fresh breaker. But an **out-of-band** fix (hand-edited `secrets.yaml`, an env var, or a gateway-side recovery) left recall degraded until the cooldown elapsed.

## How

A successful **Test connection** of the *live* key now clears the breaker immediately — that's the user's natural "is it working now?" action:

- `HybridKnowledgeStore.reset_embed_breaker() -> bool` — forces the circuit closed; returns whether it actually changed anything (so callers log only when it mattered).
- `/api/config/test-model`: on success **with no form-local key override** (i.e. testing the live saved key), clear the live store's breaker. A *candidate*-key test (form override) does **not** touch the live store — that key isn't what the running embedder uses yet. Embeds share the same `api_base`/key, so a chat-completion success is a sound signal.
- `_reset_live_embed_breaker()` is duck-typed: a keyword-only base store or a plugin backend simply has no breaker to reset.

## Tests

- Primitive: closes an open breaker, returns `True`; no-op + `False` when already closed; embedder is exercised again after reset.
- Route: clears on live-key success; does **not** clear on failure; does **not** clear on a form-key candidate.

`59 passed` across the knowledge/route surface; ruff + import contracts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)