### PR TITLE
feat(knowledge): document ingestion engine — add files/URLs/YouTube to the KB (Phase 1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Document ingestion engine** (ADR 0021) — add real documents to the knowledge base,
+  not just typed facts. A new core `ingestion/` package turns a source into text and
+  feeds it through `add_document` (chunk → contextual-enrich → embed), so a whole PDF or
+  article becomes per-passage recall. Phase 1 formats (light, pure-Python): plain text,
+  Markdown, HTML, PDF (`pypdf`), web URLs (fetched + readability-stripped via
+  BeautifulSoup), and **YouTube** links (transcript via `youtube-transcript-api`). New
+  `POST /api/knowledge/ingest` accepts a file upload, a URL, or pasted text (extraction +
+  embedding run off the event loop) and returns the created chunk ids. Each extractor
+  degrades cleanly — an optional dep that's missing raises a friendly error, a bad source
+  never 500s. Audio/video (local ASR) is a deliberate Phase 2 (the gateway serves no
+  transcription model).
 - **Contextual enrichment on knowledge ingest** (ADR 0021 — Anthropic's Contextual
   Retrieval). When a document splits into chunks, an aux-LLM one-line context that
   situates each chunk in the *whole* document is prepended before it's embedded and

--- a/ingestion/__init__.py
+++ b/ingestion/__init__.py
@@ -1,0 +1,44 @@
+"""Document ingestion engine — turn a source into plain text for the knowledge base.
+
+The knowledge store ingests text (``add_document`` chunks + contextually enriches
++ embeds it, ADR 0021). This package is the *front* of that pipeline: it turns a
+file or URL into that text. Each format is a small extractor; the heavy ones
+(PDF parsing, YouTube transcripts) lazy-import their dependency and raise a
+friendly ``MissingDependency`` if it isn't installed, so the base import is light.
+
+Phase 1 (this module) covers the light, pure-Python formats: plain text,
+Markdown, HTML / web URLs, PDF, and YouTube transcripts. Audio/video (local ASR)
+is a deliberate Phase 2 — the gateway serves no transcription model.
+
+Public API:
+    extract_bytes(filename, data, content_type=None) -> ExtractResult
+    extract_url(url) -> ExtractResult
+    SUPPORTED_EXTENSIONS, SUPPORTED_DESCRIPTION
+    IngestionError / UnsupportedSource / ExtractionError / MissingDependency
+"""
+
+from ingestion.engine import (
+    SUPPORTED_DESCRIPTION,
+    SUPPORTED_EXTENSIONS,
+    ExtractionError,
+    ExtractResult,
+    IngestionError,
+    MissingDependency,
+    UnsupportedSource,
+    extract_bytes,
+    extract_url,
+    youtube_id,
+)
+
+__all__ = [
+    "ExtractResult",
+    "IngestionError",
+    "UnsupportedSource",
+    "ExtractionError",
+    "MissingDependency",
+    "extract_bytes",
+    "extract_url",
+    "youtube_id",
+    "SUPPORTED_EXTENSIONS",
+    "SUPPORTED_DESCRIPTION",
+]

--- a/ingestion/engine.py
+++ b/ingestion/engine.py
@@ -1,0 +1,285 @@
+"""Source → text extractors for the ingestion engine (ADR 0021).
+
+Pure-Python, dependency-light. Network (URL fetch) and optional deps (pypdf,
+youtube-transcript-api) are isolated to their own extractors so the parsing
+helpers (HTML→text, YouTube-id parsing, decode) stay unit-testable offline.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from dataclasses import dataclass, field
+from pathlib import Path
+from urllib.parse import parse_qs, urlparse
+
+log = logging.getLogger(__name__)
+
+# A page fetched from the web shouldn't be allowed to be unbounded.
+_MAX_FETCH_BYTES = 25 * 1024 * 1024  # 25 MB
+_FETCH_TIMEOUT_S = 30.0
+_FETCH_UA = "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)"
+
+
+class IngestionError(Exception):
+    """Base for ingestion failures (kept distinct so routes can map to HTTP codes)."""
+
+
+class UnsupportedSource(IngestionError):
+    """The file type / URL isn't something we know how to extract."""
+
+
+class ExtractionError(IngestionError):
+    """The source is a known type but yielded no usable text."""
+
+
+class MissingDependency(IngestionError):
+    """A format needs an optional package that isn't installed."""
+
+
+@dataclass
+class ExtractResult:
+    """Extracted text plus light provenance for the knowledge chunk."""
+
+    text: str
+    title: str | None = None
+    source_type: str = "text"
+    meta: dict = field(default_factory=dict)
+
+
+# Extension → kind. content_type sniffing supplements this for URL/upload paths.
+_TEXT_EXTS = {".txt", ".text", ".log", ".rst", ".csv", ".tsv"}
+_MD_EXTS = {".md", ".markdown", ".mdown", ".mkd", ".mdx"}
+_HTML_EXTS = {".html", ".htm", ".xhtml"}
+_PDF_EXTS = {".pdf"}
+
+SUPPORTED_EXTENSIONS = sorted(_TEXT_EXTS | _MD_EXTS | _HTML_EXTS | _PDF_EXTS)
+SUPPORTED_DESCRIPTION = "text, Markdown, HTML, PDF files, and web/YouTube URLs"
+
+
+# ── decoding / parsing helpers (pure) ────────────────────────────────────────
+
+
+def _decode(data: bytes) -> str:
+    """Best-effort text decode: UTF-8 (BOM-aware) then latin-1 as a last resort
+    (latin-1 maps every byte, so it never raises — keeps ingest resilient)."""
+    if isinstance(data, str):
+        return data
+    for enc in ("utf-8-sig", "utf-8"):
+        try:
+            return data.decode(enc)
+        except UnicodeDecodeError:
+            continue
+    return data.decode("latin-1", errors="replace")
+
+
+def _looks_textual(data: bytes) -> bool:
+    """Heuristic for an unknown-extension upload: decodes as UTF-8 and has no NULs
+    → treat as plain text; otherwise it's binary we don't handle."""
+    if b"\x00" in data[:8192]:
+        return False
+    try:
+        data[:8192].decode("utf-8")
+        return True
+    except UnicodeDecodeError:
+        return False
+
+
+def html_to_text(data: bytes | str) -> str:
+    """Strip an HTML document to readable text (BeautifulSoup — a core dep).
+
+    Drops script/style/nav/footer/aside chrome and collapses whitespace. Not a
+    full readability model (that's a later upgrade), but enough that an article's
+    body dominates the chunked text."""
+    from bs4 import BeautifulSoup
+
+    html = _decode(data) if isinstance(data, bytes) else data
+    soup = BeautifulSoup(html, "html.parser")
+    for tag in soup(["script", "style", "noscript", "template", "svg",
+                     "nav", "footer", "aside", "form"]):
+        tag.decompose()
+    text = soup.get_text(separator="\n")
+    # Collapse runs of blank lines / trailing spaces the tag soup leaves behind.
+    lines = [ln.strip() for ln in text.splitlines()]
+    out: list[str] = []
+    blank = False
+    for ln in lines:
+        if ln:
+            out.append(ln)
+            blank = False
+        elif not blank:
+            out.append("")
+            blank = True
+    return "\n".join(out).strip()
+
+
+def html_title(data: bytes | str) -> str | None:
+    from bs4 import BeautifulSoup
+
+    html = _decode(data) if isinstance(data, bytes) else data
+    soup = BeautifulSoup(html, "html.parser")
+    if soup.title and soup.title.string:
+        return soup.title.string.strip() or None
+    h1 = soup.find("h1")
+    if h1:
+        t = h1.get_text(strip=True)
+        return t or None
+    return None
+
+
+_YT_HOSTS = {"youtube.com", "www.youtube.com", "m.youtube.com", "music.youtube.com",
+             "youtu.be", "www.youtu.be"}
+
+
+def youtube_id(url: str) -> str | None:
+    """Extract an 11-char YouTube video id from any of its URL shapes
+    (watch?v=, youtu.be/, /shorts/, /embed/, /live/), else None."""
+    try:
+        u = urlparse(url.strip())
+    except (ValueError, AttributeError):
+        return None
+    if (u.hostname or "").lower() not in _YT_HOSTS:
+        return None
+    if u.hostname and u.hostname.lower().endswith("youtu.be"):
+        cand = u.path.lstrip("/").split("/")[0]
+        return cand if _valid_yt_id(cand) else None
+    if u.path == "/watch":
+        cand = (parse_qs(u.query).get("v") or [""])[0]
+        return cand if _valid_yt_id(cand) else None
+    for prefix in ("/shorts/", "/embed/", "/live/", "/v/"):
+        if u.path.startswith(prefix):
+            cand = u.path[len(prefix):].split("/")[0]
+            return cand if _valid_yt_id(cand) else None
+    return None
+
+
+def _valid_yt_id(cand: str) -> bool:
+    return bool(re.fullmatch(r"[A-Za-z0-9_-]{11}", cand or ""))
+
+
+# ── format extractors ────────────────────────────────────────────────────────
+
+
+def _extract_pdf(data: bytes) -> str:
+    try:
+        from pypdf import PdfReader
+    except ImportError as exc:
+        raise MissingDependency(
+            "PDF ingestion needs the 'pypdf' package (pip install pypdf).") from exc
+    import io
+
+    try:
+        reader = PdfReader(io.BytesIO(data))
+        pages = [(p.extract_text() or "").strip() for p in reader.pages]
+    except Exception as exc:  # noqa: BLE001 — pypdf raises a zoo of errors on bad PDFs
+        raise ExtractionError(f"could not parse PDF: {exc}") from exc
+    return "\n\n".join(p for p in pages if p)
+
+
+def _snippet_text(snippet) -> str:
+    """Read a transcript snippet's text across api versions: 1.x yields snippet
+    objects with a ``.text`` attribute; the legacy 0.6 API yielded ``{"text": …}``."""
+    if hasattr(snippet, "text"):
+        return (snippet.text or "").strip()
+    if isinstance(snippet, dict):
+        return (snippet.get("text") or "").strip()
+    return ""
+
+
+def _youtube_transcript(video_id: str) -> str:
+    try:
+        from youtube_transcript_api import YouTubeTranscriptApi
+    except ImportError as exc:
+        raise MissingDependency(
+            "YouTube ingestion needs the 'youtube-transcript-api' package "
+            "(pip install youtube-transcript-api).") from exc
+    try:
+        # 1.x instance API (`fetch`); FetchedTranscript is iterable of snippets.
+        fetched = YouTubeTranscriptApi().fetch(video_id)
+    except Exception as exc:  # noqa: BLE001 — no captions / disabled / unavailable
+        raise ExtractionError(
+            f"no transcript available for video {video_id}: {exc}") from exc
+    parts = [_snippet_text(s) for s in fetched]
+    return " ".join(p for p in parts if p)
+
+
+# ── public entry points ──────────────────────────────────────────────────────
+
+
+def extract_bytes(filename: str, data: bytes, content_type: str | None = None) -> ExtractResult:
+    """Extract text from an uploaded file's bytes, dispatched by extension then
+    content-type. ``filename`` provides the extension + a default title."""
+    ext = Path(filename or "").suffix.lower()
+    ct = (content_type or "").split(";")[0].strip().lower()
+    title = (Path(filename).stem if filename else None) or None
+
+    if ext in _PDF_EXTS or ct == "application/pdf":
+        text, source_type = _extract_pdf(data), "pdf"
+    elif ext in _HTML_EXTS or "html" in ct:
+        text, source_type = html_to_text(data), "html"
+    elif ext in _MD_EXTS:
+        text, source_type = _decode(data), "markdown"
+    elif ext in _TEXT_EXTS or ct.startswith("text/"):
+        text, source_type = _decode(data), "text"
+    elif not ext and not ct and _looks_textual(data):
+        text, source_type = _decode(data), "text"
+    else:
+        raise UnsupportedSource(
+            f"unsupported file type {ext or ct or 'unknown'!r}; supported: {SUPPORTED_DESCRIPTION}")
+
+    if not text.strip():
+        raise ExtractionError("no extractable text in the file")
+    return ExtractResult(text=text, title=title, source_type=source_type,
+                         meta={"filename": filename})
+
+
+def extract_url(url: str, *, fetch=None) -> ExtractResult:
+    """Extract text from a web URL. YouTube links resolve to their transcript;
+    everything else is fetched and dispatched by content-type (HTML/PDF/text).
+
+    ``fetch`` is an injection seam for tests: a callable ``(url) -> (bytes,
+    content_type)``. Defaults to an httpx GET (bounded size + timeout)."""
+    url = (url or "").strip()
+    if not url:
+        raise UnsupportedSource("empty URL")
+
+    vid = youtube_id(url)
+    if vid:
+        text = _youtube_transcript(vid)
+        if not text.strip():
+            raise ExtractionError(f"empty transcript for video {vid}")
+        return ExtractResult(text=text, title=f"YouTube transcript ({vid})",
+                             source_type="youtube", meta={"url": url, "video_id": vid})
+
+    data, ct = (fetch or _http_fetch)(url)
+    ct = (ct or "").split(";")[0].strip().lower()
+
+    if "pdf" in ct or url.lower().endswith(".pdf"):
+        text, source_type, title = _extract_pdf(data), "pdf", url
+    elif "html" in ct or not ct:
+        text = html_to_text(data)
+        title = html_title(data) or url
+        source_type = "html"
+    elif ct.startswith("text/"):
+        text, source_type, title = _decode(data), "text", url
+    else:
+        raise UnsupportedSource(f"unsupported content-type {ct!r} at {url}")
+
+    if not text.strip():
+        raise ExtractionError(f"no extractable text at {url}")
+    return ExtractResult(text=text, title=title, source_type=source_type,
+                         meta={"url": url, "content_type": ct})
+
+
+def _http_fetch(url: str) -> tuple[bytes, str]:
+    import httpx
+
+    with httpx.Client(follow_redirects=True, timeout=_FETCH_TIMEOUT_S,
+                      headers={"User-Agent": _FETCH_UA}) as client:
+        resp = client.get(url)
+        resp.raise_for_status()
+        content = resp.content
+        if len(content) > _MAX_FETCH_BYTES:
+            raise ExtractionError(
+                f"document too large ({len(content)} bytes > {_MAX_FETCH_BYTES})")
+        return content, resp.headers.get("content-type", "")

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 import asyncio
 import logging
 
+from fastapi import File, Form, UploadFile
 from fastapi.responses import JSONResponse
 
 from runtime.state import STATE
@@ -175,6 +176,80 @@ def register_knowledge_routes(app) -> None:
         if not ids:
             return JSONResponse({"detail": "the store rejected the chunk"}, status_code=400)
         return {"enabled": True, "id": ids[0], "ids": ids}
+
+    @app.post("/api/knowledge/ingest")
+    async def _api_knowledge_ingest(
+        file: UploadFile | None = File(default=None),
+        url: str = Form(default=""),
+        text: str = Form(default=""),
+        title: str = Form(default=""),
+        domain: str = Form(default="general"),
+    ):
+        """Ingest a document (file / URL / pasted text) into the knowledge base.
+
+        The ingestion engine turns the source into text (txt/md/html/pdf, web +
+        YouTube URLs), then ``add_document`` chunks + contextually enriches +
+        embeds it (ADR 0021) — so a whole PDF or article becomes per-passage
+        recall, not one diluted chunk. Multipart so a file upload and the
+        URL/text fields share one endpoint. Extraction + embedding run off the
+        event loop. Returns the created chunk ids."""
+        if STATE.knowledge_store is None:
+            return {"enabled": False, "ids": []}
+        from ingestion import (
+            ExtractResult,
+            MissingDependency,
+            UnsupportedSource,
+            extract_bytes,
+            extract_url,
+        )
+        from knowledge import add_document
+
+        url, text, title = url.strip(), text.strip(), title.strip()
+        source = "console"
+        try:
+            if file is not None:
+                data = await file.read()
+                result = await asyncio.to_thread(
+                    extract_bytes, file.filename or "upload", data, file.content_type)
+                source = file.filename or "upload"
+            elif url:
+                result = await asyncio.to_thread(extract_url, url)
+                source = url
+            elif text:
+                result = ExtractResult(text=text, title=title or None, source_type="text")
+            else:
+                return JSONResponse(
+                    {"detail": "provide a file, url, or text"}, status_code=400)
+        except MissingDependency as exc:
+            return JSONResponse({"detail": str(exc)}, status_code=501)
+        except UnsupportedSource as exc:
+            return JSONResponse({"detail": str(exc)}, status_code=415)
+        except Exception as exc:  # noqa: BLE001 — surface extraction failure, never 500
+            log.warning("[knowledge] ingest extraction failed: %s", exc)
+            return JSONResponse({"detail": f"extraction failed: {exc}"}, status_code=400)
+
+        heading = title or result.title or None
+        ids = await asyncio.to_thread(
+            lambda: add_document(
+                STATE.knowledge_store,
+                result.text,
+                domain=(domain.strip() or "general"),
+                heading=heading,
+                source=source,
+                source_type=result.source_type,
+            )
+        )
+        if not ids:
+            return JSONResponse(
+                {"detail": "nothing ingested (no text after extraction)"}, status_code=400)
+        return {
+            "enabled": True,
+            "ids": ids,
+            "chunks": len(ids),
+            "title": heading,
+            "source_type": result.source_type,
+            "chars": len(result.text),
+        }
 
     @app.put("/api/knowledge/chunks/{chunk_id}")
     async def _api_knowledge_update(chunk_id: int, body: dict | None = None):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,9 @@ dependencies = [
   "croniter>=2.0",
   "filelock>=3.12",
   "zeroconf>=0.131",
+  # Document ingestion engine (ADR 0021) — light pure-Python extractors:
+  "pypdf>=4.0",                  # PDF → text
+  "youtube-transcript-api>=1.0", # YouTube captions → text (1.x instance API)
 ]
 
 [project.optional-dependencies]
@@ -79,6 +82,7 @@ packages = [
   "graph",
   "inbox",
   "infra",
+  "ingestion",
   "knowledge",
   "observability",
   "operator_api",
@@ -114,6 +118,7 @@ root_packages = [
   "events",
   "graph",
   "infra",
+  "ingestion",
   "knowledge",
   "observability",
   "operator_api",
@@ -156,7 +161,7 @@ ignore_imports = [
 name = "infra packages do not import server or operator_api"
 type = "forbidden"
 source_modules = [
-  "a2a_impl", "events", "infra", "knowledge", "observability",
+  "a2a_impl", "events", "infra", "ingestion", "knowledge", "observability",
   "runtime", "scheduler", "security", "tools",
 ]
 forbidden_modules = ["server", "operator_api"]

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -1,0 +1,165 @@
+"""Ingestion engine — source → text extractors (ADR 0021).
+
+Pure helpers (YouTube-id parsing, HTML→text, decode) are tested directly; the
+dependency/network extractors (PDF, YouTube, URL fetch) are tested with injected
+fetchers / monkeypatched libs so the suite stays offline and deterministic.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from ingestion import (
+    ExtractionError,
+    UnsupportedSource,
+    extract_bytes,
+    extract_url,
+    youtube_id,
+)
+from ingestion import engine
+
+
+# ── youtube_id (pure) ─────────────────────────────────────────────────────────
+
+
+@pytest.mark.parametrize("url,expected", [
+    ("https://www.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://www.youtube.com/watch?v=dQw4w9WgXcQ&t=30s", "dQw4w9WgXcQ"),
+    ("https://youtu.be/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://www.youtube.com/shorts/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://youtube.com/embed/dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://m.youtube.com/watch?v=dQw4w9WgXcQ", "dQw4w9WgXcQ"),
+    ("https://example.com/watch?v=dQw4w9WgXcQ", None),   # not youtube
+    ("https://www.youtube.com/watch?v=short", None),     # not 11 chars
+    ("https://www.youtube.com/", None),
+    ("not a url", None),
+])
+def test_youtube_id(url, expected):
+    assert youtube_id(url) == expected
+
+
+# ── html helpers (pure) ───────────────────────────────────────────────────────
+
+
+def test_html_to_text_strips_chrome():
+    html = (b"<html><head><title>T</title><style>x{}</style></head><body>"
+            b"<nav>menu home</nav><script>evil()</script>"
+            b"<h1>Heading</h1><p>Hello world.</p><footer>copyright</footer></body></html>")
+    text = engine.html_to_text(html)
+    assert "Heading" in text and "Hello world." in text
+    assert "evil()" not in text and "menu home" not in text and "copyright" not in text
+
+
+def test_html_title_prefers_title_then_h1():
+    assert engine.html_title(b"<title>  My Doc </title><h1>H</h1>") == "My Doc"
+    assert engine.html_title(b"<body><h1>Fallback</h1></body>") == "Fallback"
+    assert engine.html_title(b"<p>nothing</p>") is None
+
+
+def test_decode_handles_utf8_and_falls_back():
+    assert engine._decode("café".encode("utf-8")) == "café"
+    # Invalid UTF-8 never raises (latin-1 last resort).
+    assert engine._decode(b"\xff\xfeabc")  # no exception
+
+
+# ── extract_bytes ─────────────────────────────────────────────────────────────
+
+
+def test_extract_bytes_text_and_markdown():
+    r = extract_bytes("notes.txt", b"plain content here")
+    assert r.text == "plain content here" and r.source_type == "text" and r.title == "notes"
+    r2 = extract_bytes("doc.md", b"# Title\n\nbody")
+    assert r2.source_type == "markdown" and "# Title" in r2.text
+
+
+def test_extract_bytes_html():
+    r = extract_bytes("page.html", b"<title>T</title><p>Hi there</p>")
+    assert r.source_type == "html" and "Hi there" in r.text
+
+
+def test_extract_bytes_unknown_but_textual():
+    r = extract_bytes("README", b"just some text, no extension")
+    assert r.source_type == "text" and "just some text" in r.text
+
+
+def test_extract_bytes_rejects_binary():
+    with pytest.raises(UnsupportedSource):
+        extract_bytes("blob.bin", b"\x00\x01\x02\x03garbage")
+
+
+def test_extract_bytes_empty_raises():
+    with pytest.raises(ExtractionError):
+        extract_bytes("empty.txt", b"   \n  ")
+
+
+def test_extract_bytes_content_type_sniff():
+    # No extension, but content_type says HTML.
+    r = extract_bytes("download", b"<p>From header</p>", content_type="text/html; charset=utf-8")
+    assert r.source_type == "html" and "From header" in r.text
+
+
+# ── PDF (pypdf logic, reader monkeypatched) ───────────────────────────────────
+
+
+def test_extract_pdf_joins_pages(monkeypatch):
+    class _Page:
+        def __init__(self, t): self._t = t
+        def extract_text(self): return self._t
+
+    class _Reader:
+        def __init__(self, _stream): self.pages = [_Page("page one"), _Page(""), _Page("page two")]
+
+    import pypdf
+    monkeypatch.setattr(pypdf, "PdfReader", _Reader)
+    r = extract_bytes("doc.pdf", b"%PDF-1.4 ...")
+    assert r.source_type == "pdf" and r.text == "page one\n\npage two"
+
+
+def test_extract_pdf_parse_error_raises_extraction_error(monkeypatch):
+    import pypdf
+
+    def _boom(_stream): raise ValueError("corrupt")
+    monkeypatch.setattr(pypdf, "PdfReader", _boom)
+    with pytest.raises(ExtractionError):
+        extract_bytes("doc.pdf", b"not really a pdf")
+
+
+# ── extract_url (injected fetch / monkeypatched transcript) ───────────────────
+
+
+def test_extract_url_html_with_injected_fetch():
+    def fake_fetch(url):
+        return b"<title>Article</title><p>Body text here.</p>", "text/html; charset=utf-8"
+    r = extract_url("https://example.com/post", fetch=fake_fetch)
+    assert r.source_type == "html" and r.title == "Article" and "Body text here." in r.text
+
+
+def test_extract_url_plaintext_with_injected_fetch():
+    r = extract_url("https://example.com/raw.txt", fetch=lambda u: (b"raw body", "text/plain"))
+    assert r.source_type == "text" and r.text == "raw body"
+
+
+def test_extract_url_rejects_unknown_content_type():
+    with pytest.raises(UnsupportedSource):
+        extract_url("https://example.com/x.zip", fetch=lambda u: (b"PK\x03\x04", "application/zip"))
+
+
+def test_extract_url_youtube(monkeypatch):
+    class _Snippet:
+        def __init__(self, t): self.text = t
+
+    class _FakeApi:
+        def fetch(self, video_id, *a, **k):
+            assert video_id == "dQw4w9WgXcQ"
+            return [_Snippet("never gonna"), _Snippet("give you up")]
+
+    import youtube_transcript_api
+    monkeypatch.setattr(youtube_transcript_api, "YouTubeTranscriptApi", _FakeApi)
+    r = extract_url("https://youtu.be/dQw4w9WgXcQ")
+    assert r.source_type == "youtube" and r.text == "never gonna give you up"
+    assert r.meta["video_id"] == "dQw4w9WgXcQ"
+
+
+def test_extract_url_empty_raises():
+    with pytest.raises(UnsupportedSource):
+        extract_url("   ")

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -182,3 +182,67 @@ def test_promote_route_unsupported_in_scoped_mode(monkeypatch):
 def test_promote_route_disabled(monkeypatch):
     c = _client(monkeypatch)  # no skills index
     assert c.post("/api/playbooks/1/promote").json() == {"enabled": False, "promoted": False}
+
+
+# ── document ingestion (/api/knowledge/ingest) ────────────────────────────────
+class _IngestKS:
+    """Store double exposing add_document (returns N ids to mimic chunking)."""
+
+    def __init__(self):
+        self.docs = []
+
+    def add_document(self, content, **kw):
+        self.docs.append((content, kw))
+        return [101, 102]  # pretend it split into 2 chunks
+
+
+def test_ingest_text(monkeypatch):
+    ks = _IngestKS()
+    c = _client(monkeypatch, knowledge=ks)
+    body = c.post("/api/knowledge/ingest",
+                  data={"text": "a pasted note body", "title": "My Note"}).json()
+    assert body["enabled"] is True
+    assert body["ids"] == [101, 102] and body["chunks"] == 2
+    assert body["source_type"] == "text" and body["title"] == "My Note"
+    content, kw = ks.docs[0]
+    assert content == "a pasted note body" and kw["heading"] == "My Note"
+
+
+def test_ingest_file_upload(monkeypatch):
+    ks = _IngestKS()
+    c = _client(monkeypatch, knowledge=ks)
+    files = {"file": ("notes.md", b"# Heading\n\nsome body text", "text/markdown")}
+    body = c.post("/api/knowledge/ingest", files=files).json()
+    assert body["enabled"] is True and body["source_type"] == "markdown"
+    assert ks.docs[0][1]["source"] == "notes.md"
+
+
+def test_ingest_url(monkeypatch):
+    ks = _IngestKS()
+    # Patch the engine so no network: the route imports extract_url from `ingestion`.
+    import ingestion
+    from ingestion import ExtractResult
+    monkeypatch.setattr(
+        ingestion, "extract_url",
+        lambda u: ExtractResult(text="fetched article body", title="Article", source_type="html"),
+    )
+    c = _client(monkeypatch, knowledge=ks)
+    body = c.post("/api/knowledge/ingest", data={"url": "https://example.com/post"}).json()
+    assert body["enabled"] is True and body["source_type"] == "html"
+    assert ks.docs[0][1]["source"] == "https://example.com/post"
+
+
+def test_ingest_requires_a_source(monkeypatch):
+    c = _client(monkeypatch, knowledge=_IngestKS())
+    assert c.post("/api/knowledge/ingest", data={}).status_code == 400
+
+
+def test_ingest_unsupported_type_returns_415(monkeypatch):
+    c = _client(monkeypatch, knowledge=_IngestKS())
+    files = {"file": ("blob.bin", b"\x00\x01\x02\x03", "application/octet-stream")}
+    assert c.post("/api/knowledge/ingest", files=files).status_code == 415
+
+
+def test_ingest_disabled_when_store_off(monkeypatch):
+    c = _client(monkeypatch)  # no knowledge store
+    assert c.post("/api/knowledge/ingest", data={"text": "x"}).json() == {"enabled": False, "ids": []}

--- a/uv.lock
+++ b/uv.lock
@@ -495,6 +495,15 @@ wheels = [
 ]
 
 [[package]]
+name = "defusedxml"
+version = "0.7.1"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/0f/d5/c66da9b79e5bdb124974bfe172b4daf3c984ebd9c2a06e2b8a4dc7331c72/defusedxml-0.7.1.tar.gz", hash = "sha256:1bb3032db185915b62d7c6209c5a8792be6a32ab2fedacc84e01b52c51aa3e69", size = 75520, upload-time = "2021-03-08T10:59:26.269Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/07/6c/aa3f2f849e01cb6a001cd8554a88d4c77c5c1a31c95bdf1cf9301e6d9ef4/defusedxml-0.7.1-py2.py3-none-any.whl", hash = "sha256:a352e7e428770286cc899e2542b6cdaedb2b4953ff269a210103ec58f6198a61", size = 25604, upload-time = "2021-03-08T10:59:24.45Z" },
+]
+
+[[package]]
 name = "distro"
 version = "1.9.0"
 source = { registry = "https://pypi.org/simple" }
@@ -1572,7 +1581,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.35.3"
+version = "0.39.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },
@@ -1593,11 +1602,13 @@ dependencies = [
     { name = "packaging" },
     { name = "prometheus-client" },
     { name = "protolabs-a2a" },
+    { name = "pypdf" },
     { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "ruamel-yaml" },
     { name = "uvicorn" },
     { name = "websockets" },
+    { name = "youtube-transcript-api" },
     { name = "zeroconf" },
 ]
 
@@ -1637,11 +1648,13 @@ requires-dist = [
     { name = "prometheus-client", specifier = ">=0.20" },
     { name = "protoagent", extras = ["google"], marker = "extra == 'all'" },
     { name = "protolabs-a2a", git = "https://github.com/protoLabsAI/protolabs-a2a.git?rev=v0.2.0" },
+    { name = "pypdf", specifier = ">=4.0" },
     { name = "python-multipart", specifier = ">=0.0.9" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "ruamel-yaml", specifier = ">=0.18" },
     { name = "uvicorn", specifier = ">=0.30" },
     { name = "websockets", specifier = ">=12.0" },
+    { name = "youtube-transcript-api", specifier = ">=1.0" },
     { name = "zeroconf", specifier = ">=0.131" },
 ]
 provides-extras = ["google", "all"]
@@ -1852,6 +1865,15 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/f3/91/9c6ee907786a473bf81c5f53cf703ba0957b23ab84c264080fb5a450416f/pyparsing-3.3.2.tar.gz", hash = "sha256:c777f4d763f140633dcb6d8a3eda953bf7a214dc4eff598413c070bcdc117cbc", size = 6851574, upload-time = "2026-01-21T03:57:59.36Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/10/bd/c038d7cc38edc1aa5bf91ab8068b63d4308c66c4c8bb3cbba7dfbc049f9c/pyparsing-3.3.2-py3-none-any.whl", hash = "sha256:850ba148bd908d7e2411587e247a1e4f0327839c40e2e5e6d05a007ecc69911d", size = 122781, upload-time = "2026-01-21T03:57:55.912Z" },
+]
+
+[[package]]
+name = "pypdf"
+version = "6.13.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/0a/48fe05c6bb3aa4bb4d2a4079a383d33c0dfec1edf613a642f07d8b8b5c2e/pypdf-6.13.2.tar.gz", hash = "sha256:5a96a17dbdfbf9c2ab24c0a13fa0aba182be22ba6f283098712c16fc242f509f", size = 6479250, upload-time = "2026-06-10T16:42:34.5Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/17/378943705992f74e451a06de3401ce68e3213763c81e44d0614559c45599/pypdf-6.13.2-py3-none-any.whl", hash = "sha256:6eeb9e57693f29d41bd01255d02660cbbb41fd7fc818a982677389a35e4f2083", size = 346555, upload-time = "2026-06-10T16:42:32.37Z" },
 ]
 
 [[package]]
@@ -2861,6 +2883,19 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/bd/b1/dfe2629f7c77eb2fa234c72ff537cdd64939763df704e256446ed364a16d/xxhash-3.7.0-pp311-pypy311_pp73-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:48b542c347c2089f43dc5a6db31d2a6f3cdb04ee33505ec6e9f653834dbb0bde", size = 36307, upload-time = "2026-04-25T11:10:26.949Z" },
     { url = "https://files.pythonhosted.org/packages/e7/f7/5a484afce0f48dd8083208b42e4911f290a82c7b52458ef2927e4d421a45/xxhash-3.7.0-pp311-pypy311_pp73-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a169a036bed0995e090d1493b283cc2cc8a6f5046821086b843abefff80643bc", size = 32534, upload-time = "2026-04-25T11:10:29.01Z" },
     { url = "https://files.pythonhosted.org/packages/0f/5f/4acfcd490db9780cf36c58534d828003c564cde5350220a1c783c4d10776/xxhash-3.7.0-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:ec101643395d7f21405b640f728f6f627e6986557027d740f2f9b220955edafe", size = 31552, upload-time = "2026-04-25T11:10:30.727Z" },
+]
+
+[[package]]
+name = "youtube-transcript-api"
+version = "1.2.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "defusedxml" },
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/60/43/4104185a2eaa839daa693b30e15c37e7e58795e8e09ec414f22b3db54bec/youtube_transcript_api-1.2.4.tar.gz", hash = "sha256:b72d0e96a335df599d67cee51d49e143cff4f45b84bcafc202ff51291603ddcd", size = 469839, upload-time = "2026-01-29T09:09:17.088Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/be/95/129ea37efd6cd6ed00f62baae6543345c677810b8a3bf0026756e1d3cf3c/youtube_transcript_api-1.2.4-py3-none-any.whl", hash = "sha256:03878759356da5caf5edac77431780b91448fb3d8c21d4496015bdc8a7bc43ff", size = 485227, upload-time = "2026-01-29T09:09:15.427Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## What

The first half of the **ingestion engine** you asked for — add real documents to the knowledge base, not just typed facts. The hard half (chunking + contextual enrichment + embedding) already shipped in #987/#988; this is the **front of the pipeline**: turn a source into text, then feed it through `add_document`.

```
source ──▶ ingestion (source → text) ──▶ add_document ──▶ chunk → enrich → embed → KB
            (this PR)                      (✅ #987/#988)
```

So a whole PDF or article becomes **per-passage recall**, not one diluted chunk.

## Phase 1 formats (light, pure-Python, inline)

- **txt / Markdown** — decode
- **HTML** — BeautifulSoup, script/style/nav/footer chrome stripped
- **PDF** — `pypdf`
- **web URLs** — `httpx` fetch (bounded size + timeout), content-type dispatch (html/pdf/text)
- **YouTube** — `youtube-transcript-api` (1.x instance API) → captions, no download

Audio/video (local ASR via faster-whisper + ffmpeg) is a deliberate **Phase 2** — the gateway serves no transcription model, so it needs a heavier dependency + async-job commitment.

## How

- **`ingestion/` core package.** `extract_bytes(filename, data, content_type)` + `extract_url(url, fetch=…)` → `ExtractResult(text, title, source_type, meta)`. Pure helpers (`youtube_id`, `html_to_text`, `_decode`) stay unit-testable offline; optional deps lazy-import with a friendly `MissingDependency`; a bad source raises a typed error and never 500s. Enforced as an import-linter **leaf** (never reaches up into server/operator_api).
- **`POST /api/knowledge/ingest`** (multipart) — file upload **or** URL **or** pasted text → extract → `add_document`. Extraction + embedding run off the event loop. Returns created chunk ids + counts. Typed errors map to **415** (unsupported) / **501** (missing dep) / **400** (extraction failed).
- **Deps**: `pypdf`, `youtube-transcript-api>=1.0`; added to the wheel `packages` list so frozen/desktop builds bundle it.

## Tests

- **Engine**: YouTube-id across URL shapes, HTML strip/title, decode fallbacks, `extract_bytes` (text/md/html/unknown-textual/binary-reject/empty/content-type sniff), PDF page-join + parse-error (reader monkeypatched), `extract_url` (html/text/youtube/unsupported via injected fetch — no network).
- **Route**: text / file-upload / url / empty→400 / unsupported→415 / store-off→disabled.

**Full suite: 1871 passed**; ruff + import contracts clean.

## Next (Phase 1 PR2)
Console **"Add source"** UI — drag-drop file + URL paste in `KnowledgeStore.tsx`, wired to this route with progress + result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)