### PR TITLE
feat(knowledge): "Add source" UI — ingest files / URLs / YouTube from the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,8 +21,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `POST /api/knowledge/ingest` accepts a file upload, a URL, or pasted text (extraction +
   embedding run off the event loop) and returns the created chunk ids. Each extractor
   degrades cleanly — an optional dep that's missing raises a friendly error, a bad source
-  never 500s. Audio/video (local ASR) is a deliberate Phase 2 (the gateway serves no
-  transcription model).
+  never 500s. The Knowledge console gets an **"Add source"** affordance — drop a file or
+  paste a web/YouTube URL — alongside the existing typed-fact entry. Audio/video (local
+  ASR) is a deliberate Phase 2 (the gateway serves no transcription model).
 - **Contextual enrichment on knowledge ingest** (ADR 0021 — Anthropic's Contextual
   Retrieval). When a document splits into chunks, an aux-LLM one-line context that
   situates each chunk in the *whole* document is prepended before it's embedded and

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1546,6 +1546,31 @@ textarea {
 .knowledge-chunk-form-row > :first-child { flex: 1; min-width: 180px; }
 .knowledge-chunk-actions { display: flex; gap: 2px; }
 
+/* Document ingestion drop-zone (ADR 0021) — file/URL "Add source". */
+.knowledge-ingest-drop {
+  display: flex; align-items: center; gap: 8px;
+  padding: 14px 12px;
+  border: 1px dashed var(--pl-color-border);
+  border-radius: 8px;
+  background: var(--pl-color-bg-inset);
+  color: var(--fg-muted);
+  font-size: 13px;
+  transition: border-color 0.12s ease, background 0.12s ease;
+}
+.knowledge-ingest-drop.is-drag {
+  border-color: var(--accent, #7c8cff);
+  border-style: solid;
+  background: var(--pl-color-bg-raised);
+}
+.knowledge-ingest-drop.is-busy { opacity: 0.6; pointer-events: none; }
+.knowledge-ingest-pick {
+  color: var(--accent, #7c8cff);
+  cursor: pointer;
+  text-decoration: underline;
+  font-weight: 500;
+}
+.knowledge-ingest-note { color: var(--fg-muted); font-size: 12px; align-self: center; }
+
 /* ── Delegates panel (ADR 0025) — moved to src/settings/delegates.css (#832). ── */
 
 /* Plugin-contributed console views (ADR 0026) — optional subnav above, iframe fills. */

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -1,7 +1,7 @@
 import { Input, Textarea } from "@protolabsai/ui/forms";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { Brain, Database, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Brain, Database, FileUp, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
 
 import { useEffect, useState } from "react";
 
@@ -86,6 +86,122 @@ function ChunkForm({
   );
 }
 
+// Document ingestion (ADR 0021) — extract a file / web URL / YouTube link into
+// the KB, chunked + enriched + embedded server-side. Distinct from ChunkForm
+// (typed facts): this is "bring a whole document in".
+const INGEST_ACCEPT = ".txt,.text,.log,.csv,.md,.markdown,.html,.htm,.pdf";
+
+function IngestForm({
+  onDone,
+  onError,
+  onClose,
+}: {
+  onDone: () => void | Promise<void>;
+  onError: (message: string) => void;
+  onClose: () => void;
+}) {
+  const [url, setUrl] = useState("");
+  const [domain, setDomain] = useState("general");
+  const [busy, setBusy] = useState(false);
+  const [drag, setDrag] = useState(false);
+  const [note, setNote] = useState("");
+
+  async function ingest(form: FormData) {
+    setBusy(true);
+    setNote("");
+    onError("");
+    try {
+      form.set("domain", domain.trim() || "general");
+      const r = await api.ingestKnowledge(form);
+      setNote(`Added ${r.chunks} chunk${r.chunks === 1 ? "" : "s"}${r.title ? ` from “${r.title}”` : ""}.`);
+      setUrl("");
+      await onDone();
+    } catch (e) {
+      onError(e instanceof Error ? e.message : String(e));
+    } finally {
+      setBusy(false);
+    }
+  }
+
+  function ingestFile(file: File) {
+    const f = new FormData();
+    f.append("file", file);
+    void ingest(f);
+  }
+
+  function ingestUrl() {
+    if (!url.trim()) return;
+    const f = new FormData();
+    f.append("url", url.trim());
+    void ingest(f);
+  }
+
+  return (
+    <div className="knowledge-chunk-form">
+      <div
+        className={`knowledge-ingest-drop${drag ? " is-drag" : ""}${busy ? " is-busy" : ""}`}
+        onDragOver={(e) => { e.preventDefault(); setDrag(true); }}
+        onDragLeave={() => setDrag(false)}
+        onDrop={(e) => {
+          e.preventDefault();
+          setDrag(false);
+          const file = e.dataTransfer.files?.[0];
+          if (file) ingestFile(file);
+        }}
+      >
+        <FileUp size={18} />
+        <span>
+          Drop a file here, or{" "}
+          <label className="knowledge-ingest-pick">
+            browse
+            <input
+              type="file"
+              hidden
+              accept={INGEST_ACCEPT}
+              disabled={busy}
+              onChange={(e) => {
+                const file = e.target.files?.[0];
+                if (file) ingestFile(file);
+                e.target.value = "";
+              }}
+            />
+          </label>{" "}
+          — txt, md, html, pdf
+        </span>
+      </div>
+      <div className="knowledge-chunk-form-row">
+        <Input
+          type="url"
+          placeholder="…or paste a web / YouTube URL"
+          value={url}
+          onChange={(e) => setUrl(e.target.value)}
+          onKeyDown={(e) => { if (e.key === "Enter") ingestUrl(); }}
+          aria-label="source url"
+          disabled={busy}
+        />
+        <Input
+          type="text"
+          placeholder="domain"
+          value={domain}
+          onChange={(e) => setDomain(e.target.value)}
+          aria-label="ingest domain"
+          style={{ maxWidth: 160 }}
+          disabled={busy}
+        />
+      </div>
+      <div className="knowledge-chunk-form-row">
+        <Button type="button" variant="primary" size="sm" disabled={busy || !url.trim()} onClick={ingestUrl}>
+          {busy ? "Importing…" : "Import URL"}
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onClose} disabled={busy}>
+          Close
+        </Button>
+        {note ? <span className="knowledge-ingest-note">{note}</span> : null}
+      </div>
+    </div>
+  );
+}
+
 export function KnowledgeStore({ onError }: { onError: (message: string) => void }) {
   const [results, setResults] = useState<KnowledgeChunk[]>([]);
   const [stats, setStats] = useState<Record<string, number>>({});
@@ -94,6 +210,7 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
   const [query, setQuery] = useState("");
 
   const [adding, setAdding] = useState(false);
+  const [ingesting, setIngesting] = useState(false);
   const [editingId, setEditingId] = useState<number | null>(null);
   const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
   const [saving, setSaving] = useState(false);
@@ -166,15 +283,26 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
             {/* Quick-set recall behaviour right where you inspect what the agent knows (ADR 0048). */}
             <QuickSetting keys={["knowledge.top_k", "knowledge.embeddings"]} title="Recall" label="Knowledge recall settings" />
             {enabled ? (
-              <Button
-                icon
-                variant="ghost"
-                type="button"
-                onClick={() => { setEditingId(null); setDraft(EMPTY_DRAFT); setAdding((v) => !v); }}
-                title="Add a knowledge entry"
-              >
-                <Plus size={16} />
-              </Button>
+              <>
+                <Button
+                  icon
+                  variant="ghost"
+                  type="button"
+                  onClick={() => { setEditingId(null); setAdding(false); setIngesting((v) => !v); }}
+                  title="Add a source — file, web URL, or YouTube link"
+                >
+                  <FileUp size={16} />
+                </Button>
+                <Button
+                  icon
+                  variant="ghost"
+                  type="button"
+                  onClick={() => { setEditingId(null); setDraft(EMPTY_DRAFT); setIngesting(false); setAdding((v) => !v); }}
+                  title="Add a knowledge entry"
+                >
+                  <Plus size={16} />
+                </Button>
+              </>
             ) : null}
             <Button icon variant="ghost" type="button" onClick={() => void run(query)} disabled={loading} title="Refresh">
               <RefreshCw size={16} className={loading ? "spin" : ""} />
@@ -191,6 +319,14 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
           value={query}
           onChange={(e) => setQuery(e.target.value)}
         />
+
+        {ingesting ? (
+          <IngestForm
+            onDone={() => run(query)}
+            onError={onError}
+            onClose={() => setIngesting(false)}
+          />
+        ) : null}
 
         {adding ? (
           <ChunkForm

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -298,6 +298,30 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   return (await response.json()) as T;
 }
 
+// Multipart sibling of `request` for file uploads (the ingestion engine). Never
+// sets Content-Type — the browser adds the multipart boundary itself — but reuses
+// the same auth + slug routing + 401 handling.
+async function requestForm<T>(path: string, form: FormData, opts: { host?: boolean } = {}): Promise<T> {
+  const headers = applyAuth(new Headers());
+  const response = await fetch(apiUrl(path, { host: opts.host }), {
+    method: "POST",
+    headers,
+    body: form,
+  });
+  if (!response.ok) {
+    let detail = `${response.status} ${response.statusText}`;
+    try {
+      const payload = (await response.json()) as { detail?: string };
+      detail = payload.detail || detail;
+    } catch {
+      detail = await response.text();
+    }
+    if (response.status === 401) notifyAuthRequired();
+    throw new ApiError(response.status, detail || "request failed");
+  }
+  return (await response.json()) as T;
+}
+
 export function textFromParts(parts?: Array<{ kind?: string; text?: string }>) {
   return (parts || [])
     .filter((part) => (part.kind === undefined || part.kind === "text") && part.text)
@@ -530,6 +554,18 @@ export const api = {
       `/api/knowledge/chunks/${id}`,
       { method: "DELETE" },
     );
+  },
+  // Document ingestion engine — extract a file/URL/YouTube into the KB (chunked,
+  // enriched, embedded). FormData carries `file` OR `url` OR `text`, plus `domain`.
+  ingestKnowledge(form: FormData) {
+    return requestForm<{
+      enabled: boolean;
+      ids: number[];
+      chunks: number;
+      title: string | null;
+      source_type: string;
+      chars: number;
+    }>("/api/knowledge/ingest", form);
   },
 
   deletePlaybook(id: number) {


### PR DESCRIPTION
## What

The **frontend half** of the ingestion engine (#990) — so a user can actually add documents from the console, not just via the API.

The Knowledge console gains an **"Add source"** button (📤) next to the existing "Add entry" (➕):
- a **drag-drop file zone** (txt / md / html / pdf) with a *browse* picker,
- a **web / YouTube URL** field,
- a domain field,

…posting multipart to `POST /api/knowledge/ingest`. On success it refreshes the list and shows *"Added N chunks from "<title>""*. Distinct from the typed-fact `ChunkForm` — this is "bring a whole document in".

## How

- **`apps/web/src/lib/api.ts`** — `requestForm()` multipart helper (never sets `Content-Type`, so the browser adds the boundary; reuses the same auth + slug routing + 401 handling as `request()`) + `api.ingestKnowledge(form)`.
- **`apps/web/src/knowledge/KnowledgeStore.tsx`** — `IngestForm` (drop-zone + URL + domain, busy/result states), a `FileUp` toolbar toggle.
- **`theme.css`** — `.knowledge-ingest-drop` / `.is-drag` / `.knowledge-ingest-pick` (DS tokens; CSS-comment guard green).

## Verification

Backend was already verified live in #990 (markdown file + `example.com` URL → chunked → searchable). CSS-comment guard passes; the Web E2E smoke build (`tsc --noEmit` + vite) is the typecheck gate. The `Input`/`Button` DS primitives already spread `style`/`aria-label` in this file, so they forward `disabled`/`onKeyDown` too.

This completes **Phase 1** of the ingestion engine. Phase 2 (audio/video via local ASR) remains deferred pending your go-ahead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)