### PR TITLE
feat(knowledge): audio & video ingestion via gateway STT (ingestion Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Audio & video ingestion** (ADR 0021, ingestion engine Phase 2) — drop an audio file
+  (mp3/wav/m4a/flac/ogg/…) or a video (mp4/mov/mkv/webm/…) into the knowledge base and it's
+  transcribed, then chunked + enriched + embedded like any other document. Transcription
+  rides the gateway's OpenAI-compatible `/audio/transcriptions` endpoint
+  (`knowledge.transcribe_model`, e.g. `whisper-1`) — same gateway + key as chat/embeddings,
+  no local ASR model. Video has its audio track pulled by `ffmpeg` (a host binary) first;
+  a missing `ffmpeg`, or a blank `transcribe_model`, returns a clear error rather than
+  failing silently. Direct audio/video URLs work too. The console "Add source" drop-zone
+  now accepts these formats.
 - **Document ingestion engine** (ADR 0021) — add real documents to the knowledge base,
   not just typed facts. A new core `ingestion/` package turns a source into text and
   feeds it through `add_document` (chunk → contextual-enrich → embed), so a whole PDF or

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -89,7 +89,10 @@ function ChunkForm({
 // Document ingestion (ADR 0021) — extract a file / web URL / YouTube link into
 // the KB, chunked + enriched + embedded server-side. Distinct from ChunkForm
 // (typed facts): this is "bring a whole document in".
-const INGEST_ACCEPT = ".txt,.text,.log,.csv,.md,.markdown,.html,.htm,.pdf";
+const INGEST_ACCEPT =
+  ".txt,.text,.log,.csv,.md,.markdown,.html,.htm,.pdf," +
+  ".mp3,.wav,.m4a,.flac,.ogg,.opus,.aac," +
+  ".mp4,.mov,.mkv,.webm,.avi,.m4v";
 
 function IngestForm({
   onDone,
@@ -166,7 +169,7 @@ function IngestForm({
               }}
             />
           </label>{" "}
-          — txt, md, html, pdf
+          — txt, md, html, pdf, audio &amp; video
         </span>
       </div>
       <div className="knowledge-chunk-form-row">
@@ -289,7 +292,7 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
                   variant="ghost"
                   type="button"
                   onClick={() => { setEditingId(null); setAdding(false); setIngesting((v) => !v); }}
-                  title="Add a source — file, web URL, or YouTube link"
+                  title="Add a source — file (text/pdf/audio/video), web URL, or YouTube link"
                 >
                   <FileUp size={16} />
                 </Button>

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -68,6 +68,10 @@ knowledge:
   # The embedding model your gateway serves (NOT the chat model). Default is the
   # protoLabs gateway's; forks on another gateway set theirs (check GET /v1/models).
   embed_model: qwen3-embedding
+  # Speech-to-text model for audio/video ingestion — the gateway's OpenAI-compatible
+  # /audio/transcriptions alias (e.g. whisper-1). Blank disables audio/video import.
+  # Video needs ffmpeg on the host to extract the audio track.
+  transcribe_model: whisper-1
   # Extract durable facts from a conversation on retirement (aux model) and
   # consolidate them into the store. Rides the harvest pass (ADR 0021).
   facts: true

--- a/graph/config.py
+++ b/graph/config.py
@@ -371,6 +371,11 @@ class LangGraphConfig:
     # their gateway has (check GET /v1/models). A wrong/absent model degrades to
     # keyword search via the store's circuit breaker — never KB-less.
     embed_model: str = "qwen3-embedding"
+    # Speech-to-text model for audio/video ingestion (ADR 0021) — the gateway's
+    # OpenAI-compatible /audio/transcriptions alias (e.g. whisper-1). Audio is sent
+    # as-is; video has its audio track pulled by ffmpeg first. Blank disables
+    # audio/video ingestion (they error with a clear message).
+    transcribe_model: str = "whisper-1"
     # Semantic recall (ADR 0021): when True, the knowledge store is the
     # HybridKnowledgeStore (FTS5 + vector embeddings via `embed_model`, fused
     # with RRF). On by default — semantic recall finds paraphrases keyword search
@@ -781,6 +786,7 @@ class LangGraphConfig:
             knowledge_facts=data.get("knowledge", {}).get("facts", cls.knowledge_facts),
             workflow_dir=data.get("workflows", {}).get("dir", cls.workflow_dir),
             embed_model=knowledge.get("embed_model", cls.embed_model),
+            transcribe_model=knowledge.get("transcribe_model", cls.transcribe_model),
             knowledge_embeddings=knowledge.get("embeddings", cls.knowledge_embeddings),
             knowledge_top_k=knowledge.get("top_k", cls.knowledge_top_k),
             knowledge_vector_k=knowledge.get("vector_k", cls.knowledge_vector_k),

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -134,6 +134,48 @@ def create_embed_fn(config: LangGraphConfig) -> Callable[[str], list[float]] | N
     return embeddings.embed_query
 
 
+# Transcription timeout — STT of a long clip is slow (cold model load + minutes
+# of audio); generous but bounded so a hung gateway can't wedge an ingest thread.
+_TRANSCRIBE_TIMEOUT_S = 600.0
+
+
+def create_transcribe_fn(
+    config: LangGraphConfig,
+) -> Callable[[bytes, str], str] | None:
+    """Build a sync ``(audio_bytes, filename) -> transcript`` function, or None.
+
+    Posts to the gateway's OpenAI-compatible ``/audio/transcriptions`` endpoint
+    (ADR 0021) using ``knowledge.transcribe_model`` (e.g. ``whisper-1``) — so
+    audio/video ingestion reuses the same gateway + key as chat/embeddings, no
+    local ASR model. Raw httpx (not the OpenAI SDK) to send the allowlisted
+    User-Agent the gateway's WAF requires. Returns ``None`` when no transcribe
+    model is configured; transport/parse errors propagate to the ingestion
+    engine, which maps them to a clean extraction failure."""
+    model = (getattr(config, "transcribe_model", "") or "").strip()
+    if not model:
+        return None
+    api_base = (config.api_base or "").rstrip("/")
+    api_key = config.api_key or os.environ.get("OPENAI_API_KEY", "")
+
+    def _transcribe(data: bytes, filename: str) -> str:
+        import httpx
+
+        headers = {"User-Agent": _GATEWAY_UA}
+        if api_key:
+            headers["Authorization"] = f"Bearer {api_key}"
+        with httpx.Client(timeout=_TRANSCRIBE_TIMEOUT_S) as client:
+            resp = client.post(
+                f"{api_base}/audio/transcriptions",
+                headers=headers,
+                data={"model": model},
+                files={"file": (filename or "audio.mp3", data)},
+            )
+            resp.raise_for_status()
+            return (resp.json().get("text") or "").strip()
+
+    return _transcribe
+
+
 # Contextual Retrieval (Anthropic) — situate each chunk in its source document
 # before embedding/indexing, so a chunk's vector + FTS terms carry doc-level
 # context they'd otherwise lack. Improves both semantic and keyword recall.

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -126,6 +126,11 @@ FIELDS: list[Field] = [
           "the models your gateway serves — a wrong alias silently degrades recall to "
           "keyword-only. Falls back to a free-text field if the gateway can't be listed.",
           options_source="models"),
+    Field("knowledge.transcribe_model", "transcribe_model", "Transcription model", "string",
+          "Knowledge",
+          "Gateway speech-to-text model for audio/video ingestion (e.g. whisper-1), via the "
+          "OpenAI-compatible /audio/transcriptions endpoint. Blank disables audio/video import. "
+          "Video needs ffmpeg on the host to extract the audio track.", restart=True),
     Field("knowledge.recall_preview_chars", "knowledge_recall_preview_chars", "Recall preview length",
           "number", "Knowledge",
           "How many characters of each recalled chunk the model sees. Bigger carries more "

--- a/ingestion/engine.py
+++ b/ingestion/engine.py
@@ -15,10 +15,14 @@ from urllib.parse import parse_qs, urlparse
 
 log = logging.getLogger(__name__)
 
-# A page fetched from the web shouldn't be allowed to be unbounded.
-_MAX_FETCH_BYTES = 25 * 1024 * 1024  # 25 MB
-_FETCH_TIMEOUT_S = 30.0
+# A page fetched from the web shouldn't be allowed to be unbounded. Generous —
+# media (audio/video) URLs are larger than HTML; the operator route is trusted.
+_MAX_FETCH_BYTES = 100 * 1024 * 1024  # 100 MB
+_FETCH_TIMEOUT_S = 60.0
 _FETCH_UA = "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)"
+# ffmpeg audio-extraction (video → audio) is bounded so a pathological file can't
+# wedge an ingest thread.
+_FFMPEG_TIMEOUT_S = 600.0
 
 
 class IngestionError(Exception):
@@ -52,9 +56,16 @@ _TEXT_EXTS = {".txt", ".text", ".log", ".rst", ".csv", ".tsv"}
 _MD_EXTS = {".md", ".markdown", ".mdown", ".mkd", ".mdx"}
 _HTML_EXTS = {".html", ".htm", ".xhtml"}
 _PDF_EXTS = {".pdf"}
+# Audio → transcribed directly via the gateway STT endpoint.
+_AUDIO_EXTS = {".mp3", ".wav", ".m4a", ".flac", ".ogg", ".oga", ".opus", ".aac",
+               ".wma", ".aiff", ".aif"}
+# Video → audio track extracted with ffmpeg, then transcribed.
+_VIDEO_EXTS = {".mp4", ".mov", ".mkv", ".webm", ".avi", ".m4v", ".mpeg", ".mpg", ".wmv"}
 
-SUPPORTED_EXTENSIONS = sorted(_TEXT_EXTS | _MD_EXTS | _HTML_EXTS | _PDF_EXTS)
-SUPPORTED_DESCRIPTION = "text, Markdown, HTML, PDF files, and web/YouTube URLs"
+SUPPORTED_EXTENSIONS = sorted(
+    _TEXT_EXTS | _MD_EXTS | _HTML_EXTS | _PDF_EXTS | _AUDIO_EXTS | _VIDEO_EXTS)
+SUPPORTED_DESCRIPTION = (
+    "text, Markdown, HTML, PDF, audio + video files, and web/YouTube URLs")
 
 
 # ── decoding / parsing helpers (pure) ────────────────────────────────────────
@@ -203,12 +214,77 @@ def _youtube_transcript(video_id: str) -> str:
     return " ".join(p for p in parts if p)
 
 
+def _audio_from_video(data: bytes, suffix: str) -> bytes:
+    """Extract a video's audio track to MP3 with ffmpeg, for transcription.
+
+    ffmpeg is a system binary (not a pip dep); a missing one is a friendly
+    MissingDependency, not a crash."""
+    import os
+    import shutil
+    import subprocess
+    import tempfile
+
+    if not shutil.which("ffmpeg"):
+        raise MissingDependency(
+            "video ingestion needs ffmpeg on PATH (brew install ffmpeg / apt install ffmpeg)")
+    src = tempfile.NamedTemporaryFile(suffix=suffix or ".mp4", delete=False)
+    out_path = src.name + ".mp3"
+    try:
+        src.write(data)
+        src.flush()
+        src.close()
+        subprocess.run(
+            ["ffmpeg", "-y", "-i", src.name, "-vn", "-acodec", "libmp3lame", "-q:a", "4", out_path],
+            check=True, capture_output=True, timeout=_FFMPEG_TIMEOUT_S,
+        )
+        with open(out_path, "rb") as f:
+            return f.read()
+    except subprocess.CalledProcessError as exc:
+        tail = (exc.stderr or b"").decode("utf-8", "replace")[-400:]
+        raise ExtractionError(f"ffmpeg could not extract audio: {tail}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise ExtractionError("ffmpeg timed out extracting audio") from exc
+    finally:
+        for p in (src.name, out_path):
+            try:
+                os.unlink(p)
+            except OSError:
+                pass
+
+
+def _transcribe_media(data: bytes, filename: str, transcribe, *, video: bool) -> str:
+    """Turn audio/video bytes into text via the injected transcribe fn (gateway
+    STT). Video is run through ffmpeg first to pull the audio track."""
+    if transcribe is None:
+        raise MissingDependency(
+            "audio/video ingestion needs a transcription model — set "
+            "knowledge.transcribe_model and a gateway that serves it (e.g. whisper-1)")
+    audio, name = data, filename
+    if video:
+        audio = _audio_from_video(data, Path(filename or "").suffix or ".mp4")
+        name = (Path(filename or "audio").stem or "audio") + ".mp3"
+    try:
+        text = transcribe(audio, name)
+    except IngestionError:
+        raise
+    except Exception as exc:  # noqa: BLE001 — gateway/transport error → clean failure
+        raise ExtractionError(f"transcription failed: {exc}") from exc
+    return text or ""
+
+
 # ── public entry points ──────────────────────────────────────────────────────
 
 
-def extract_bytes(filename: str, data: bytes, content_type: str | None = None) -> ExtractResult:
+def extract_bytes(
+    filename: str,
+    data: bytes,
+    content_type: str | None = None,
+    *,
+    transcribe=None,
+) -> ExtractResult:
     """Extract text from an uploaded file's bytes, dispatched by extension then
-    content-type. ``filename`` provides the extension + a default title."""
+    content-type. ``filename`` provides the extension + a default title.
+    ``transcribe`` (bytes, filename) -> text powers audio/video (gateway STT)."""
     ext = Path(filename or "").suffix.lower()
     ct = (content_type or "").split(";")[0].strip().lower()
     title = (Path(filename).stem if filename else None) or None
@@ -219,6 +295,10 @@ def extract_bytes(filename: str, data: bytes, content_type: str | None = None) -
         text, source_type = html_to_text(data), "html"
     elif ext in _MD_EXTS:
         text, source_type = _decode(data), "markdown"
+    elif ext in _AUDIO_EXTS or ct.startswith("audio/"):
+        text, source_type = _transcribe_media(data, filename, transcribe, video=False), "audio"
+    elif ext in _VIDEO_EXTS or ct.startswith("video/"):
+        text, source_type = _transcribe_media(data, filename, transcribe, video=True), "video"
     elif ext in _TEXT_EXTS or ct.startswith("text/"):
         text, source_type = _decode(data), "text"
     elif not ext and not ct and _looks_textual(data):
@@ -233,9 +313,10 @@ def extract_bytes(filename: str, data: bytes, content_type: str | None = None) -
                          meta={"filename": filename})
 
 
-def extract_url(url: str, *, fetch=None) -> ExtractResult:
+def extract_url(url: str, *, fetch=None, transcribe=None) -> ExtractResult:
     """Extract text from a web URL. YouTube links resolve to their transcript;
-    everything else is fetched and dispatched by content-type (HTML/PDF/text).
+    everything else is fetched and dispatched by content-type (HTML/PDF/text/
+    audio/video). Audio/video URLs are transcribed via the gateway STT fn.
 
     ``fetch`` is an injection seam for tests: a callable ``(url) -> (bytes,
     content_type)``. Defaults to an httpx GET (bounded size + timeout)."""
@@ -253,9 +334,16 @@ def extract_url(url: str, *, fetch=None) -> ExtractResult:
 
     data, ct = (fetch or _http_fetch)(url)
     ct = (ct or "").split(";")[0].strip().lower()
+    url_ext = Path(urlparse(url).path).suffix.lower()
 
-    if "pdf" in ct or url.lower().endswith(".pdf"):
+    if "pdf" in ct or url_ext in _PDF_EXTS:
         text, source_type, title = _extract_pdf(data), "pdf", url
+    elif ct.startswith("audio/") or url_ext in _AUDIO_EXTS:
+        name = _media_filename(url, url_ext, ".mp3")
+        text, source_type, title = _transcribe_media(data, name, transcribe, video=False), "audio", url
+    elif ct.startswith("video/") or url_ext in _VIDEO_EXTS:
+        name = _media_filename(url, url_ext, ".mp4")
+        text, source_type, title = _transcribe_media(data, name, transcribe, video=True), "video", url
     elif "html" in ct or not ct:
         text = html_to_text(data)
         title = html_title(data) or url
@@ -269,6 +357,15 @@ def extract_url(url: str, *, fetch=None) -> ExtractResult:
         raise ExtractionError(f"no extractable text at {url}")
     return ExtractResult(text=text, title=title, source_type=source_type,
                          meta={"url": url, "content_type": ct})
+
+
+def _media_filename(url: str, url_ext: str, default_ext: str) -> str:
+    """A filename WITH an extension for a media URL — so ffmpeg/STT see the
+    format. Uses the URL's basename when it has one, else ``media<ext>``."""
+    name = Path(urlparse(url).path).name
+    if name and Path(name).suffix:
+        return name
+    return f"media{url_ext or default_ext}"
 
 
 def _http_fetch(url: str) -> tuple[bytes, str]:

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -187,12 +187,12 @@ def register_knowledge_routes(app) -> None:
     ):
         """Ingest a document (file / URL / pasted text) into the knowledge base.
 
-        The ingestion engine turns the source into text (txt/md/html/pdf, web +
-        YouTube URLs), then ``add_document`` chunks + contextually enriches +
-        embeds it (ADR 0021) — so a whole PDF or article becomes per-passage
-        recall, not one diluted chunk. Multipart so a file upload and the
-        URL/text fields share one endpoint. Extraction + embedding run off the
-        event loop. Returns the created chunk ids."""
+        The ingestion engine turns the source into text (txt/md/html/pdf, audio +
+        video via gateway STT, web + YouTube URLs), then ``add_document`` chunks +
+        contextually enriches + embeds it (ADR 0021) — so a whole PDF, article, or
+        recording becomes per-passage recall, not one diluted chunk. Multipart so
+        a file upload and the URL/text fields share one endpoint. Extraction +
+        embedding run off the event loop. Returns the created chunk ids."""
         if STATE.knowledge_store is None:
             return {"enabled": False, "ids": []}
         from ingestion import (
@@ -204,16 +204,27 @@ def register_knowledge_routes(app) -> None:
         )
         from knowledge import add_document
 
+        # Gateway STT for audio/video (None if no transcribe_model configured →
+        # audio/video raise a clean "not configured" error, text/pdf unaffected).
+        transcribe = None
+        try:
+            from graph.llm import create_transcribe_fn
+
+            transcribe = create_transcribe_fn(STATE.graph_config) if STATE.graph_config else None
+        except Exception as exc:  # noqa: BLE001 — transcription stays optional
+            log.warning("[knowledge] transcribe fn unavailable: %s", exc)
+
         url, text, title = url.strip(), text.strip(), title.strip()
         source = "console"
         try:
             if file is not None:
                 data = await file.read()
                 result = await asyncio.to_thread(
-                    extract_bytes, file.filename or "upload", data, file.content_type)
+                    extract_bytes, file.filename or "upload", data, file.content_type,
+                    transcribe=transcribe)
                 source = file.filename or "upload"
             elif url:
-                result = await asyncio.to_thread(extract_url, url)
+                result = await asyncio.to_thread(extract_url, url, transcribe=transcribe)
                 source = url
             elif text:
                 result = ExtractResult(text=text, title=title or None, source_type="text")

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -60,6 +60,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "discovery_port_min": 7860,
     "egress_allowed_hosts": [],
     "embed_model": "qwen3-embedding",
+    "transcribe_model": "whisper-1",
     "enforcement_disallowed_tools": [],
     "enforcement_enabled": False,
     "enforcement_rate_limits": {},
@@ -239,6 +240,7 @@ CONFIG_TO_DICT_GOLDEN = {
         "recall_preview_chars": 1000,
         "rrf_k": 60,
         "top_k": 5,
+        "transcribe_model": "whisper-1",
         "vector_k": 20,
     },
     "mcp": {
@@ -348,6 +350,7 @@ EMITTED_ATTRS = {
     # knowledge.*
     "knowledge_db_path",
     "embed_model",
+    "transcribe_model",
     "knowledge_top_k",
     "knowledge_vector_k",
     "knowledge_rrf_k",

--- a/tests/test_embeddings_wiring.py
+++ b/tests/test_embeddings_wiring.py
@@ -13,7 +13,7 @@ import graph.agent  # noqa: F401 — bind graph.agent.create_llm to the REAL fn 
 #   capture the fake create_llm permanently and leak into later middleware-wiring tests.
 import server
 from graph.config import LangGraphConfig
-from graph.llm import create_context_fn, create_embed_fn
+from graph.llm import create_context_fn, create_embed_fn, create_transcribe_fn
 
 
 def _cfg(tmp_path, *, embeddings: bool, model: str = "nomic-embed-text") -> LangGraphConfig:
@@ -129,3 +129,50 @@ def test_store_wires_context_fn_when_enrichment_on(tmp_path, monkeypatch):
 def test_store_no_context_fn_when_enrichment_off(tmp_path):
     store = server._build_knowledge_store(_cfg(tmp_path, embeddings=False))
     assert store._context_fn is None
+
+
+# ── transcription (gateway STT for audio/video ingestion) ─────────────────────
+
+
+def test_create_transcribe_fn_none_without_model():
+    cfg = LangGraphConfig()
+    cfg.transcribe_model = ""
+    assert create_transcribe_fn(cfg) is None
+
+
+def test_create_transcribe_fn_posts_audio_to_gateway(monkeypatch):
+    import httpx
+
+    captured = {}
+
+    class _Resp:
+        def raise_for_status(self):
+            pass
+
+        def json(self):
+            return {"text": "  hello from whisper  "}
+
+    class _Client:
+        def __init__(self, **kw):
+            pass
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *a):
+            return False
+
+        def post(self, url, headers=None, data=None, files=None):
+            captured.update(url=url, headers=headers, data=data, files=files)
+            return _Resp()
+
+    monkeypatch.setattr(httpx, "Client", _Client)
+    cfg = LangGraphConfig()
+    cfg.api_base, cfg.api_key, cfg.transcribe_model = "http://gw.test/v1", "k", "whisper-1"
+    fn = create_transcribe_fn(cfg)
+    out = fn(b"audio-bytes", "clip.mp3")
+    assert out == "hello from whisper"                     # stripped
+    assert captured["url"] == "http://gw.test/v1/audio/transcriptions"
+    assert captured["data"] == {"model": "whisper-1"}
+    assert captured["files"]["file"][0] == "clip.mp3"
+    assert captured["headers"]["Authorization"] == "Bearer k"

--- a/tests/test_ingestion.py
+++ b/tests/test_ingestion.py
@@ -11,6 +11,7 @@ import pytest
 
 from ingestion import (
     ExtractionError,
+    MissingDependency,
     UnsupportedSource,
     extract_bytes,
     extract_url,
@@ -163,3 +164,75 @@ def test_extract_url_youtube(monkeypatch):
 def test_extract_url_empty_raises():
     with pytest.raises(UnsupportedSource):
         extract_url("   ")
+
+
+# ── audio / video (gateway STT, injected transcribe + ffmpeg) ─────────────────
+
+
+def test_extract_bytes_audio_transcribes():
+    seen = {}
+
+    def transcribe(data, name):
+        seen["name"] = name
+        return "spoken words from the clip"
+
+    r = extract_bytes("talk.mp3", b"\x00fake-audio", transcribe=transcribe)
+    assert r.source_type == "audio" and r.text == "spoken words from the clip"
+    assert seen["name"] == "talk.mp3"
+
+
+def test_extract_bytes_audio_by_content_type():
+    r = extract_bytes("blob", b"\x00", content_type="audio/mpeg",
+                      transcribe=lambda d, n: "heard it")
+    assert r.source_type == "audio" and r.text == "heard it"
+
+
+def test_extract_bytes_audio_without_transcribe_raises():
+    with pytest.raises(MissingDependency):
+        extract_bytes("a.mp3", b"\x00audio")
+
+
+def test_extract_bytes_video_extracts_audio_then_transcribes(monkeypatch):
+    monkeypatch.setattr(engine, "_audio_from_video", lambda data, suffix: b"AUDIO-TRACK")
+    seen = {}
+
+    def transcribe(data, name):
+        seen["data"], seen["name"] = data, name
+        return "the talk narration"
+
+    r = extract_bytes("keynote.mp4", b"\x00video-bytes", transcribe=transcribe)
+    assert r.source_type == "video" and r.text == "the talk narration"
+    assert seen["data"] == b"AUDIO-TRACK" and seen["name"].endswith(".mp3")
+
+
+def test_extract_url_audio(monkeypatch):
+    r = extract_url(
+        "https://example.com/podcast/ep1.mp3",
+        fetch=lambda u: (b"\x00audio", "audio/mpeg"),
+        transcribe=lambda data, name: "episode transcript",
+    )
+    assert r.source_type == "audio" and r.text == "episode transcript"
+
+
+def test_audio_from_video_invokes_ffmpeg(monkeypatch):
+    import shutil
+    import subprocess
+
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/bin/ffmpeg")
+
+    def fake_run(cmd, **kw):
+        with open(cmd[-1], "wb") as f:  # ffmpeg's output path is the last arg
+            f.write(b"MP3-BYTES")
+        class _R:
+            returncode = 0
+        return _R()
+
+    monkeypatch.setattr(subprocess, "run", fake_run)
+    assert engine._audio_from_video(b"video-bytes", ".mp4") == b"MP3-BYTES"
+
+
+def test_audio_from_video_missing_ffmpeg(monkeypatch):
+    import shutil
+    monkeypatch.setattr(shutil, "which", lambda name: None)
+    with pytest.raises(MissingDependency):
+        engine._audio_from_video(b"x", ".mp4")

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -224,7 +224,7 @@ def test_ingest_url(monkeypatch):
     from ingestion import ExtractResult
     monkeypatch.setattr(
         ingestion, "extract_url",
-        lambda u: ExtractResult(text="fetched article body", title="Article", source_type="html"),
+        lambda u, **kw: ExtractResult(text="fetched article body", title="Article", source_type="html"),
     )
     c = _client(monkeypatch, knowledge=ks)
     body = c.post("/api/knowledge/ingest", data={"url": "https://example.com/post"}).json()
@@ -246,3 +246,13 @@ def test_ingest_unsupported_type_returns_415(monkeypatch):
 def test_ingest_disabled_when_store_off(monkeypatch):
     c = _client(monkeypatch)  # no knowledge store
     assert c.post("/api/knowledge/ingest", data={"text": "x"}).json() == {"enabled": False, "ids": []}
+
+
+def test_ingest_audio_without_transcribe_model_returns_501(monkeypatch):
+    """Audio upload with no transcribe model configured (graph_config=None →
+    transcribe fn None) → the engine's MissingDependency maps to 501."""
+    import runtime.state as rs
+    monkeypatch.setattr(rs.STATE, "graph_config", None, raising=False)
+    c = _client(monkeypatch, knowledge=_IngestKS())
+    files = {"file": ("clip.mp3", b"\x00\x01audio", "audio/mpeg")}
+    assert c.post("/api/knowledge/ingest", files=files).status_code == 501


### PR DESCRIPTION
## What

**Phase 2 of the ingestion engine** — now that the gateway serves an OpenAI-compatible `/audio/transcriptions` endpoint (`whisper-1`), audio/video ingestion rides the gateway exactly like chat/embeddings. **No local ASR model.** Drop an **audio** file (mp3/wav/m4a/flac/ogg/opus/aac…) or a **video** (mp4/mov/mkv/webm/avi/m4v…) and it's transcribed → chunked → contextually enriched → embedded like any other document.

This completes the format matrix you asked for: *txt, md, pdf, youtube, mp4, audio*.

## How

- **`graph/llm.py` — `create_transcribe_fn(config)`**: sync `(bytes, filename) -> transcript`; raw **httpx** POST to `{api_base}/audio/transcriptions` with the WAF-allowlisted User-Agent (the OpenAI SDK default UA is blocked), model from `knowledge.transcribe_model`. Returns `None` when unset.
- **`ingestion/engine.py`**: audio extensions transcribe directly; video extensions get their audio track pulled by **ffmpeg** (`_audio_from_video`) first. A `transcribe=` injection seam on `extract_bytes`/`extract_url` (mirrors the existing `fetch=` seam). Missing `ffmpeg` or a blank `transcribe_model` → `MissingDependency` (→ **501**), never a silent failure. Direct audio/video URLs work (fetch cap raised 25→100 MB for media).
- **config**: `knowledge.transcribe_model` (default `whisper-1`) + Settings field + loader + round-trip goldens.
- **route**: builds the transcribe fn from config, passes it through.
- **UI**: the "Add source" drop-zone now accepts audio/video extensions.

`ffmpeg` is a **host binary** (`brew install ffmpeg` / `apt install ffmpeg`), not a pip dep — only needed for video; audio goes straight to the gateway.

## Tests

- Engine: audio transcribes (injected fn), content-type sniff, audio-without-transcribe → `MissingDependency`, video → ffmpeg-extract-then-transcribe (monkeypatched), audio URL, `_audio_from_video` invokes ffmpeg / errors when absent.
- `create_transcribe_fn`: posts the right URL/model/file/auth (httpx monkeypatched); `None` without a model.
- Route: audio upload with no model → 501.

**Full suite: 1885 passed**; ruff + import contracts + CSS guard clean.

Live gateway STT was confirmed working by hand (whisper-1 → faster-whisper-large-v3-turbo); I'll verify the wired path on the running instance after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)