### PR TITLE
perf(knowledge): batch a document's chunk embeddings into one request

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enrichment, reranking).
 
 ### Changed
+- **Batched embedding on document ingest** (ADR 0021). `add_document` now embeds all of a
+  document's chunks in a **single** gateway request instead of one serial `_embed` call per
+  chunk — a 26-chunk web article went from 26 embed round-trips to 1. Rows are written before
+  the embed, so a batch failure still leaves FTS5-searchable chunks (and trips the same
+  circuit breaker); single-chunk docs, embeddings-off, or an open breaker fall back to the
+  per-chunk path. New `create_embed_batch_fn` + `HybridKnowledgeStore(embed_batch_fn=…)`.
+  (Contextual enrichment's per-chunk aux call is still serial — a separate follow-up.)
 - **Semantic recall tuned + made tunable** (RAG bake-off findings from internal research).
   `knowledge.top_k` raised 5 → 10 and the recall preview 240 → 1000 chars (more
   answer-bearing context in-prompt at no retrieval cost). The hybrid-store knobs are now

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -107,20 +107,14 @@ def create_llm(config: LangGraphConfig, *, model_name: str | None = None) -> Cha
     return ChatOpenAI(**kwargs)
 
 
-def create_embed_fn(config: LangGraphConfig) -> Callable[[str], list[float]] | None:
-    """Build a sync ``text -> vector`` function against the same gateway, or None.
-
-    Routes ``knowledge.embed_model`` through the OpenAI-compatible LiteLLM
-    gateway (ADR 0021), so semantic search reuses the model infra we already
-    have. Returns ``None`` when no embed model is configured — callers fall back
-    to FTS5. Runtime embedding outages are handled by the
-    ``HybridKnowledgeStore`` circuit breaker, not here.
-    """
+def _build_embeddings(config: LangGraphConfig) -> "OpenAIEmbeddings | None":
+    """The shared OpenAIEmbeddings client for ``knowledge.embed_model`` against
+    the gateway (ADR 0021), or None when no embed model is configured."""
     model = (getattr(config, "embed_model", "") or "").strip()
     if not model:
         return None
     api_key = config.api_key or os.environ.get("OPENAI_API_KEY", "")
-    embeddings = OpenAIEmbeddings(
+    return OpenAIEmbeddings(
         base_url=config.api_base,
         api_key=api_key,
         model=model,
@@ -131,7 +125,27 @@ def create_embed_fn(config: LangGraphConfig) -> Callable[[str], list[float]] | N
         # be a valid string"). Off = the gateway tokenizes — the portable choice.
         check_embedding_ctx_length=False,
     )
-    return embeddings.embed_query
+
+
+def create_embed_fn(config: LangGraphConfig) -> Callable[[str], list[float]] | None:
+    """Build a sync ``text -> vector`` function against the same gateway, or None.
+
+    Used for query embedding and per-chunk fallback. Returns ``None`` when no
+    embed model is configured — callers fall back to FTS5. Runtime embedding
+    outages are handled by the ``HybridKnowledgeStore`` circuit breaker.
+    """
+    emb = _build_embeddings(config)
+    return emb.embed_query if emb is not None else None
+
+
+def create_embed_batch_fn(
+    config: LangGraphConfig,
+) -> Callable[[list[str]], list[list[float]]] | None:
+    """Build a sync ``texts -> vectors`` function (one gateway request for the
+    whole list), or None. Used by ``add_document`` to embed all of a document's
+    chunks in a single round-trip instead of N serial calls (ADR 0021)."""
+    emb = _build_embeddings(config)
+    return emb.embed_documents if emb is not None else None
 
 
 # Transcription timeout — STT of a long clip is slow (cold model load + minutes

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -45,6 +45,7 @@ class HybridKnowledgeStore(KnowledgeStore):
         db_path=None,
         *,
         embed_fn: EmbedFn | None = None,
+        embed_batch_fn: Callable[[list[str]], list[list[float]]] | None = None,
         vector_k: int = 20,
         rrf_k: int = 60,
         min_score: float = 0.0,
@@ -65,6 +66,10 @@ class HybridKnowledgeStore(KnowledgeStore):
             context_fn=context_fn,
         )
         self._embed_fn = embed_fn
+        # Optional batched embedder (texts -> vectors in one request). When set,
+        # add_document embeds a whole document's chunks in a single round-trip
+        # instead of N serial _embed calls.
+        self._embed_batch_fn = embed_batch_fn
         self._vector_k = vector_k
         self._rrf_k = rrf_k
         # Relevance floor: drop fused hits whose RRF score is below this. 0 keeps
@@ -121,6 +126,21 @@ class HybridKnowledgeStore(KnowledgeStore):
             self._record_embed_failure()
             return None
 
+    def _embed_batch(self, texts: list[str]) -> list[list[float]] | None:
+        """Embed a list of texts in one call (shares the circuit breaker with
+        ``_embed``). Returns None — caller degrades to FTS5 — when batching is
+        unavailable, the breaker is open, or the request fails."""
+        if self._embed_batch_fn is None or self._breaker_open():
+            return None
+        try:
+            vecs = self._embed_batch_fn(texts)
+            self._record_embed_success()
+            return [[float(x) for x in v] for v in vecs]
+        except Exception as exc:  # noqa: BLE001 - breaker by design
+            log.warning("[knowledge] embed_batch_fn failed: %s", exc)
+            self._record_embed_failure()
+            return None
+
     # ── vector storage ──────────────────────────────────────────────────────────
 
     def _ensure_vectors_table(self) -> None:
@@ -159,6 +179,65 @@ class HybridKnowledgeStore(KnowledgeStore):
                 finally:
                     db.close()
         return chunk_id
+
+    def add_document(self, content: str, domain: str = "general", heading=None, **kw) -> list[int]:
+        """Chunk + enrich, then embed ALL of the document's chunks in ONE batched
+        request instead of N serial ``_embed`` calls (ADR 0021).
+
+        Falls back to the base per-chunk path (each piece embedded via
+        ``add_chunk``) when there's nothing to batch — a single chunk, no batched
+        embedder, embeddings off, or the breaker open. Rows are always written
+        first, so an embed failure still leaves FTS5-searchable chunks."""
+        # Pull the chunk-knob + enrich kwargs out for _chunk_and_enrich; the rest
+        # (domain/heading/source/…) are chunk-write kwargs.
+        prep_kw = {k: kw.pop(k) for k in ("max_chars", "overlap_chars", "min_chars", "enrich")
+                   if k in kw}
+        texts = self._chunk_and_enrich(content, **prep_kw)
+        batchable = (
+            len(texts) > 1
+            and self._embed_fn is not None
+            and self._embed_batch_fn is not None
+            and not self._breaker_open()
+        )
+        if not batchable:
+            # Base path: per-chunk add_chunk (single embed each, or FTS-only).
+            ids: list[int] = []
+            for text in texts:
+                cid = self.add_chunk(text, domain, heading, **kw)
+                if cid is not None:
+                    ids.append(cid)
+            return ids
+
+        # Batched path: write rows WITHOUT per-chunk embed (the BASE add_chunk),
+        # then one embed call for the whole document, then bulk-store the vectors.
+        rows: list[tuple[int, str]] = []
+        for text in texts:
+            cid = KnowledgeStore.add_chunk(self, text, domain, heading, **kw)
+            if cid is not None:
+                # Embed heading+content so vector search sees what FTS5 sees.
+                rows.append((cid, (heading + "\n" if heading else "") + text))
+        if not rows:
+            return []
+        vecs = self._embed_batch([t for _, t in rows])
+        if vecs is not None and len(vecs) == len(rows):
+            self._store_vectors([(cid, v) for (cid, _), v in zip(rows, vecs)])
+        return [cid for cid, _ in rows]
+
+    def _store_vectors(self, pairs: list[tuple[int, list[float]]]) -> None:
+        """Bulk-insert chunk vectors in one transaction."""
+        db = self._get_db()
+        if db is None:
+            return
+        try:
+            db.executemany(
+                "INSERT OR REPLACE INTO chunk_vectors (chunk_id, vec) VALUES (?, ?)",
+                [(cid, json.dumps(v)) for cid, v in pairs],
+            )
+            db.commit()
+        except sqlite3.DatabaseError as exc:
+            log.warning("[knowledge] batch store vectors failed: %s", exc)
+        finally:
+            db.close()
 
     def _vector_search(self, query_vec: list[float], k: int, domain: str | None) -> list[int]:
         """Return chunk ids ranked by cosine similarity (brute force)."""

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -408,6 +408,38 @@ class KnowledgeStore:
         safe drop-in for ``add_chunk`` on any path that might receive a large
         body. Returns the created row ids (a failed piece is skipped, never
         aborts the rest)."""
+        texts = self._chunk_and_enrich(
+            content, max_chars=max_chars, overlap_chars=overlap_chars,
+            min_chars=min_chars, enrich=enrich,
+        )
+        ids: list[int] = []
+        for text in texts:
+            cid = self.add_chunk(
+                text,
+                domain=domain,
+                heading=heading,
+                source=source,
+                source_type=source_type,
+                finding_type=finding_type,
+                namespace=namespace,
+            )
+            if cid is not None:
+                ids.append(cid)
+        return ids
+
+    def _chunk_and_enrich(
+        self,
+        content: str,
+        *,
+        max_chars: int | None = None,
+        overlap_chars: int | None = None,
+        min_chars: int | None = None,
+        enrich: bool | None = None,
+    ) -> list[str]:
+        """Split a document into chunks and prepend per-chunk Contextual
+        Retrieval context (when a ``context_fn`` is set and the doc actually
+        splits). Returns the final texts to store/embed — shared by the base
+        ``add_document`` and the hybrid store's batched-embedding override."""
         from knowledge.chunking import chunk_text
 
         pieces = chunk_text(
@@ -424,7 +456,7 @@ class KnowledgeStore:
             and (enrich if enrich is not None else True)
             and len(pieces) >= 2
         )
-        ids: list[int] = []
+        out: list[str] = []
         for piece in pieces:
             stored = piece
             if enriching:
@@ -437,18 +469,8 @@ class KnowledgeStore:
                     # rest of THIS doc, so an outage doesn't fire N failing calls.
                     log.warning("[knowledge] context enrichment failed: %s; raw chunks", exc)
                     enriching = False
-            cid = self.add_chunk(
-                stored,
-                domain=domain,
-                heading=heading,
-                source=source,
-                source_type=source_type,
-                finding_type=finding_type,
-                namespace=namespace,
-            )
-            if cid is not None:
-                ids.append(cid)
-        return ids
+            out.append(stored)
+        return out
 
     # ── reads ───────────────────────────────────────────────────────────────
 

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -285,7 +285,7 @@ def _build_knowledge_store(config):
         # KB-less — and the store's circuit breaker handles runtime outages.
         if getattr(config, "knowledge_embeddings", False):
             try:
-                from graph.llm import create_embed_fn
+                from graph.llm import create_embed_batch_fn, create_embed_fn
                 from knowledge.hybrid_store import HybridKnowledgeStore
 
                 embed_fn = create_embed_fn(config)
@@ -294,6 +294,7 @@ def _build_knowledge_store(config):
                     return HybridKnowledgeStore(
                         db_path=config.knowledge_db_path,
                         embed_fn=embed_fn,
+                        embed_batch_fn=create_embed_batch_fn(config),
                         vector_k=config.knowledge_vector_k,
                         rrf_k=config.knowledge_rrf_k,
                         min_score=config.knowledge_min_score,

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -163,6 +163,99 @@ def test_hybrid_add_document_embeds_each_chunk(tmp_path):
     assert n_vecs == len(ids)            # one embedding per chunk, not one for the doc
 
 
+def _bow_factory():
+    vocab = ["alpha", "bravo", "charlie", "delta", "echo", "foxtrot"]
+
+    def bow(text: str) -> list[float]:
+        t = text.lower()
+        return [1.0 if w in t else 0.0 for w in vocab]
+
+    return bow
+
+
+def _multi_chunk_doc() -> str:
+    return "\n\n".join([
+        "alpha section. " + "padding word " * 12,
+        "bravo section. " + "padding word " * 12,
+        "charlie section. " + "padding word " * 12,
+    ])
+
+
+def test_add_document_batches_embeddings_into_one_call(tmp_path):
+    """The batched path: N chunks → ONE embed_batch call, zero per-chunk embeds,
+    and every chunk still gets its vector."""
+    import sqlite3
+
+    from knowledge.hybrid_store import HybridKnowledgeStore
+
+    bow = _bow_factory()
+    calls = {"batch": 0, "single": 0}
+
+    def single(text):
+        calls["single"] += 1
+        return bow(text)
+
+    def batch(texts):
+        calls["batch"] += 1
+        return [bow(t) for t in texts]
+
+    db = str(tmp_path / "kb.db")
+    store = HybridKnowledgeStore(db, embed_fn=single, embed_batch_fn=batch,
+                                 chunk_max_chars=120, chunk_overlap_chars=0, chunk_min_chars=0)
+    ids = store.add_document(_multi_chunk_doc(), domain="conversation", heading="Doc")
+    assert len(ids) >= 3
+    assert calls["batch"] == 1 and calls["single"] == 0   # one batched call, no per-chunk
+    conn = sqlite3.connect(db)
+    assert conn.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0] == len(ids)
+    conn.close()
+    # And the batched vectors are actually usable for retrieval.
+    assert store.search("bravo", k=3)
+
+
+def test_add_document_single_chunk_skips_batch(tmp_path):
+    from knowledge.hybrid_store import HybridKnowledgeStore
+
+    bow = _bow_factory()
+    calls = {"batch": 0, "single": 0}
+
+    def single(text):
+        calls["single"] += 1
+        return bow(text)
+
+    def batch(texts):
+        calls["batch"] += 1
+        return [bow(t) for t in texts]
+
+    store = HybridKnowledgeStore(str(tmp_path / "kb.db"), embed_fn=single,
+                                 embed_batch_fn=batch, chunk_max_chars=5000)
+    ids = store.add_document("a short single-chunk note", domain="general")
+    assert len(ids) == 1
+    assert calls["batch"] == 0 and calls["single"] == 1   # single chunk → per-chunk embed
+
+
+def test_add_document_batch_failure_keeps_fts_rows(tmp_path):
+    """A batched-embed failure still stores the chunks (FTS5-searchable) and trips
+    the breaker — never loses the document."""
+    import sqlite3
+
+    from knowledge.hybrid_store import HybridKnowledgeStore
+
+    bow = _bow_factory()
+    db = str(tmp_path / "kb.db")
+    store = HybridKnowledgeStore(
+        db, embed_fn=bow,
+        embed_batch_fn=lambda ts: (_ for _ in ()).throw(RuntimeError("gateway down")),
+        breaker_threshold=1, chunk_max_chars=120, chunk_overlap_chars=0, chunk_min_chars=0,
+    )
+    ids = store.add_document(_multi_chunk_doc(), domain="conversation", heading="Doc")
+    assert len(ids) >= 3                       # rows written despite the embed failure
+    conn = sqlite3.connect(db)
+    assert conn.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0] == 0  # no vectors
+    conn.close()
+    assert store._breaker_open()               # breaker tripped
+    assert store.search("bravo")               # still searchable via FTS5
+
+
 # ── contextual enrichment ────────────────────────────────────────────────────
 
 

--- a/tests/test_embeddings_wiring.py
+++ b/tests/test_embeddings_wiring.py
@@ -13,7 +13,12 @@ import graph.agent  # noqa: F401 — bind graph.agent.create_llm to the REAL fn 
 #   capture the fake create_llm permanently and leak into later middleware-wiring tests.
 import server
 from graph.config import LangGraphConfig
-from graph.llm import create_context_fn, create_embed_fn, create_transcribe_fn
+from graph.llm import (
+    create_context_fn,
+    create_embed_batch_fn,
+    create_embed_fn,
+    create_transcribe_fn,
+)
 
 
 def _cfg(tmp_path, *, embeddings: bool, model: str = "nomic-embed-text") -> LangGraphConfig:
@@ -38,6 +43,20 @@ def test_create_embed_fn_callable_with_model():
     cfg.api_base, cfg.api_key = "http://gateway.test/v1", "k"
     fn = create_embed_fn(cfg)
     assert callable(fn)
+
+
+def test_create_embed_batch_fn():
+    cfg = LangGraphConfig()
+    cfg.api_base, cfg.api_key = "http://gateway.test/v1", "k"
+    assert callable(create_embed_batch_fn(cfg))   # OpenAIEmbeddings.embed_documents
+    cfg.embed_model = ""
+    assert create_embed_batch_fn(cfg) is None
+
+
+def test_hybrid_store_gets_a_batch_embedder(tmp_path):
+    store = server._build_knowledge_store(_cfg(tmp_path, embeddings=True))
+    assert type(store).__name__ == "HybridKnowledgeStore"
+    assert store._embed_batch_fn is not None       # batched ingest wired in
 
 
 def test_create_embed_fn_sends_raw_strings(monkeypatch):


### PR DESCRIPTION
## What

Closes **bd-3dz**. The pipeline test surfaced this: a 26-chunk Wikipedia article took **2m16s** to ingest because `add_document` embedded each chunk with its own serial `_embed` call (26 embed round-trips). This batches all of a document's chunk embeddings into a **single** gateway request.

## How

- **`graph/llm.py`** — extract `_build_embeddings(config)`; add `create_embed_batch_fn` → `embeddings.embed_documents` (`texts -> vectors` in one call).
- **`knowledge/store.py`** — factor the chunk + contextual-enrich step into `_chunk_and_enrich()` so the base and hybrid paths share it.
- **`knowledge/hybrid_store.py`** — `embed_batch_fn` ctor param + `_embed_batch` (shares the circuit breaker) + a batched `add_document` override: **write rows first** (base `add_chunk`, no per-row embed), then **one** batched embed, then bulk-store vectors. Falls back to the per-chunk path for a single chunk / no batch fn / open breaker. A batch failure keeps the FTS5 rows and trips the breaker — never loses the document.
- **`server/agent_init.py`** — wire `embed_batch_fn=create_embed_batch_fn(config)`.

**Scope note:** contextual enrichment's per-chunk aux call is still serial — batching/parallelizing that is a separate follow-up (it can't collapse to one request the way embeddings can, since each chunk needs its own doc+chunk prompt).

## Tests

- One batched call for N chunks + **zero** per-chunk embeds + all vectors stored + retrievable.
- Single-chunk doc skips the batch (per-chunk embed).
- Batch-embed failure → FTS5 rows kept, no vectors, breaker trips, still searchable.
- `create_embed_batch_fn` (callable / None without model); hybrid store gets a batch embedder.

**Full suite: 1890 passed**; ruff + import contracts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)