### PR TITLE
perf(knowledge): run per-chunk contextual enrichment concurrently

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,7 +73,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the embed, so a batch failure still leaves FTS5-searchable chunks (and trips the same
   circuit breaker); single-chunk docs, embeddings-off, or an open breaker fall back to the
   per-chunk path. New `create_embed_batch_fn` + `HybridKnowledgeStore(embed_batch_fn=…)`.
-  (Contextual enrichment's per-chunk aux call is still serial — a separate follow-up.)
+- **Parallel contextual enrichment on ingest** (ADR 0021). The per-chunk enrichment aux-LLM
+  calls — the dominant ingest cost for a large enriched doc — now run **concurrently** (bounded
+  pool) instead of serially. The first chunk is probed serially so a gateway outage still
+  disables enrichment after one call (no N concurrent failing requests); a per-chunk failure in
+  the parallel batch degrades just that chunk to raw. Order is preserved. Together with batched
+  embedding, a multi-chunk document's ingest is now a single embed request + a concurrent burst
+  of enrich calls rather than 2N serial round-trips.
 - **Semantic recall tuned + made tunable** (RAG bake-off findings from internal research).
   `knowledge.top_k` raised 5 → 10 and the recall preview 240 → 1000 chars (more
   answer-bearing context in-prompt at no retrieval cost). The hybrid-store knobs are now

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -44,6 +44,11 @@ log = logging.getLogger(__name__)
 
 DEFAULT_DB_PATH = "/sandbox/knowledge/agent.db"
 
+# Bounded concurrency for per-chunk contextual enrichment on ingest — the calls
+# are independent aux-LLM requests, so we fan them out, but cap the burst on the
+# gateway. Tune up for a faster gateway / down to be gentler.
+_ENRICH_MAX_WORKERS = 8
+
 # Fallback reasoning-stripper used if graph.output_format isn't importable (the
 # store must never hard-depend on the graph package). Mirrors its scratch_pad /
 # think / orphan-open rules.
@@ -456,21 +461,42 @@ class KnowledgeStore:
             and (enrich if enrich is not None else True)
             and len(pieces) >= 2
         )
-        out: list[str] = []
-        for piece in pieces:
-            stored = piece
-            if enriching:
-                try:
-                    context = (self._context_fn(content, piece) or "").strip()
-                    if context:
-                        stored = f"{context}\n\n{piece}"
-                except Exception as exc:  # noqa: BLE001 — degrade to raw chunk
-                    # One failure (gateway hiccup) disables enrichment for the
-                    # rest of THIS doc, so an outage doesn't fire N failing calls.
-                    log.warning("[knowledge] context enrichment failed: %s; raw chunks", exc)
-                    enriching = False
-            out.append(stored)
-        return out
+        if not enriching:
+            return list(pieces)
+        contexts = self._enrich_contexts(content, pieces)
+        return [f"{ctx}\n\n{piece}" if ctx else piece for piece, ctx in zip(pieces, contexts)]
+
+    def _enrich_contexts(self, content: str, pieces: list[str]) -> list[str]:
+        """Generate the per-chunk Contextual Retrieval context strings.
+
+        Probe with the FIRST chunk serially: a failure there means the gateway
+        is down, so disable enrichment for the whole doc (raw chunks) rather than
+        firing N concurrent failing calls. If the probe succeeds, the remaining
+        chunks are enriched CONCURRENTLY (independent calls; bounded pool) — these
+        aux-LLM calls dominate ingest latency when run serially. A per-chunk
+        failure in the parallel batch degrades just that chunk to raw."""
+        try:
+            first = (self._context_fn(content, pieces[0]) or "").strip()
+        except Exception as exc:  # noqa: BLE001 — gateway down → no enrichment for the doc
+            log.warning("[knowledge] context enrichment failed: %s; raw chunks", exc)
+            return [""] * len(pieces)
+
+        rest = pieces[1:]
+        if not rest:
+            return [first]
+
+        def _one(piece: str) -> str:
+            try:
+                return (self._context_fn(content, piece) or "").strip()
+            except Exception as exc:  # noqa: BLE001 — degrade just this chunk to raw
+                log.warning("[knowledge] context enrichment failed for a chunk: %s", exc)
+                return ""
+
+        from concurrent.futures import ThreadPoolExecutor
+
+        with ThreadPoolExecutor(max_workers=min(_ENRICH_MAX_WORKERS, len(rest))) as pool:
+            rest_contexts = list(pool.map(_one, rest))  # order preserved
+        return [first, *rest_contexts]
 
     # ── reads ───────────────────────────────────────────────────────────────
 

--- a/tests/test_chunking.py
+++ b/tests/test_chunking.py
@@ -279,6 +279,33 @@ def test_enrichment_prepends_context_to_each_chunk(tmp_path):
     assert all(c[0] == doc for c in calls)
     hits = store.search("CTX", k=10)
     assert hits and all(h["content"].startswith("CTX[") for h in hits)
+    # Order-correctness across the parallel fan-out: each chunk gets ITS OWN
+    # context, not a thread-shuffled mismatch.
+    alpha = next(h for h in hits if "alpha" in h["content"])
+    assert alpha["content"].startswith("CTX[alpha]")
+
+
+def test_enrichment_parallel_partial_failure_degrades_only_that_chunk(tmp_path):
+    """A per-chunk failure in the parallel batch degrades just that chunk to raw;
+    the rest still get context (the probe chunk succeeded, so enrichment is on)."""
+    def ctx(doc, chunk):
+        if "bravo" in chunk:
+            raise RuntimeError("one flaky chunk")
+        return f"CTX[{chunk.split()[0]}]"
+
+    store = KnowledgeStore(
+        db_path=str(tmp_path / "agent.db"),
+        chunk_max_chars=120, chunk_overlap_chars=0, chunk_min_chars=0,
+        context_fn=ctx,
+    )
+    doc = "\n\n".join(["alpha " + "w " * 40, "bravo " + "w " * 40, "charlie " + "w " * 40])
+    store.add_document(doc)
+    hits = store.search("alpha bravo charlie w", k=10)
+    by = {h["id"]: h["content"] for h in hits}
+    bravo = next(c for c in by.values() if "bravo" in c)
+    others = [c for c in by.values() if "alpha" in c or "charlie" in c]
+    assert not bravo.startswith("CTX[")           # the flaky chunk is raw
+    assert others and all(c.startswith("CTX[") for c in others)  # the rest enriched
 
 
 def test_single_chunk_doc_is_not_enriched(tmp_path):


### PR DESCRIPTION
## What

Closes **bd-nfb**. Follow-up to #993. The pipeline test showed a 26-chunk article still took ~2min even after batching embeds — because **contextual enrichment** (#988) made N **serial** aux-LLM calls (one doc+chunk prompt per chunk). That's now the dominant ingest cost; this parallelizes it.

## How

- Fan the per-chunk enrichment calls out across a bounded thread pool (`_ENRICH_MAX_WORKERS=8`).
- **Probe the first chunk serially** — a failure there means the gateway is down, so disable enrichment for the whole doc (raw chunks) rather than firing N concurrent failing requests. This preserves the existing "first failure disables the rest" degrade.
- A per-chunk failure in the parallel batch degrades **just that chunk** to raw.
- Order preserved (`pool.map`). Logic lives in `_enrich_contexts`, called by `_chunk_and_enrich`, so both the base and hybrid-batched paths benefit.

Net: a multi-chunk document's ingest is now **one batched embed request + a concurrent burst of enrich calls**, instead of 2N serial round-trips.

## Tests

- Order-correctness across the fan-out — each chunk gets **its own** context (catches thread-shuffle mismatches).
- Parallel partial failure degrades only the flaky chunk; the rest stay enriched.
- Probe-failure still caps at exactly one call (degrade preserved).

**Full suite: 1891 passed**; ruff + import contracts clean. `_ENRICH_MAX_WORKERS` is a module constant — easy to surface as config later if needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)