### PR TITLE
feat(chat): migrate the composer to the DS PromptInput (@protolabsai/ui/ai)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   enrichment, reranking).
 
 ### Changed
+- **Chat composer migrated to the design-system `PromptInput`** (`@protolabsai/ui/ai`, bumped
+  0.30 → 0.33). The hand-rolled `<form>`/`<textarea>` is replaced by the DS composer, driven
+  through the new host-extension seams added upstream (`inputRef`/`onKeyDown`/`overlay`): the
+  slash-command menu renders in the `overlay` slot with the same ↑/↓/Enter/Tab/Esc nav, ⌘/Ctrl
+  +Enter still inserts a newline, and the send button becomes a stop control while streaming.
+  Behavior preserved; the composer now tracks DS chat styling and is ready for file attachments.
 - **Batched embedding on document ingest** (ADR 0021). `add_document` now embeds all of a
   document's chunks in a **single** gateway request instead of one serial `_embed` call per
   chunk — a 26-chunk web article went from 26 embed round-trips to 1. Rows are written before

--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -39,7 +39,7 @@ test("right panel resizes by dragging its handle and the width persists", async 
   expect(Math.abs(reloaded - after)).toBeLessThan(8);
 });
 
-test("right panel is keyboard-resizable + double-click collapses (ADR 0035 S3)", async ({ page }) => {
+test("right panel is keyboard-resizable (ADR 0035 S3)", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   const right = page.locator(".pl-appshell__col--right");
   const handle = page.getByRole("separator", { name: "Resize panels" });
@@ -51,7 +51,7 @@ test("right panel is keyboard-resizable + double-click collapses (ADR 0035 S3)",
   const wider = (await right.boundingBox())!.width;
   expect(wider).toBeGreaterThan(before);
 
-  // Double-click the handle collapses the panel (DS AppShell behavior — unmounts it).
-  await handle.dblclick();
-  await expect(right).toHaveCount(0);
+  // Collapse is no longer a handle double-click — the DS made handles grab-and-drag
+  // only (protoContent #223); panel collapse/restore is covered by the
+  // utility-bar-toggle test above. The handle's job here is resize.
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.30.0",
+    "@protolabsai/ui": "^0.33.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1,11 +1,10 @@
 import "./chat.css";
-import { Button, Empty } from "@protolabsai/ui/primitives";
+import { Empty } from "@protolabsai/ui/primitives";
+import { PromptInput } from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
 import {
   Loader2,
-  Send,
   SlidersHorizontal,
-  Square,
   TerminalSquare,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -169,16 +168,9 @@ function ChatSessionSlot({
   const [hitl, setHitl] = useState<HitlPayload | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const listRef = useRef<HTMLDivElement | null>(null);
+  // Forwarded into the DS PromptInput (inputRef) — for slash-completion focus and
+  // the Ctrl/⌘+Enter caret insert. The DS component owns the auto-grow.
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
-  // Auto-grow the single-row composer to fit its content (capped by max-height in
-  // CSS, then it scrolls). Runs on every draft change incl. programmatic ones
-  // (slash completion, send-clears-the-draft).
-  useEffect(() => {
-    const ta = textareaRef.current;
-    if (!ta) return;
-    ta.style.height = "auto";
-    ta.style.height = `${Math.min(ta.scrollHeight, 200)}px`;
-  }, [draft]);
   const status = chat.sessionStatusMap[sessionId] || "idle";
 
   // Slash-command autocomplete. Commands the server handles (e.g. /goal) are
@@ -213,6 +205,47 @@ function ChatSessionSlot({
     setSlashIndex(0);
     setSlashDismissed(true); // a space follows, so it would close anyway
     textareaRef.current?.focus();
+  }
+
+  // Runs BEFORE the DS PromptInput's Enter-to-submit (via its onKeyDown seam):
+  // preventDefault to take over the key. Slash-menu nav wins while open; ⌘/Ctrl+Enter
+  // inserts a newline. Plain Enter falls through → PromptInput submits (→ send()).
+  function onComposerKeyDown(event: React.KeyboardEvent<HTMLTextAreaElement>) {
+    if (slashActive) {
+      if (event.key === "ArrowDown") {
+        event.preventDefault();
+        setSlashIndex((i) => (i + 1) % slashMatches.length);
+        return;
+      }
+      if (event.key === "ArrowUp") {
+        event.preventDefault();
+        setSlashIndex((i) => (i - 1 + slashMatches.length) % slashMatches.length);
+        return;
+      }
+      if (event.key === "Enter" || event.key === "Tab") {
+        event.preventDefault();
+        completeCommand(slashMatches[slashSel]);
+        return;
+      }
+      if (event.key === "Escape") {
+        event.preventDefault();
+        setSlashDismissed(true);
+        return;
+      }
+    }
+    if (event.key === "Enter" && (event.metaKey || event.ctrlKey)) {
+      // ⌘/Ctrl+Enter → newline at the caret (the textarea wouldn't on its own).
+      event.preventDefault();
+      const ta = textareaRef.current;
+      if (ta) {
+        const start = ta.selectionStart;
+        const end = ta.selectionEnd;
+        setDraft(`${draft.slice(0, start)}\n${draft.slice(end)}`);
+        requestAnimationFrame(() => {
+          ta.selectionStart = ta.selectionEnd = start + 1;
+        });
+      }
+    }
   }
 
   useEffect(() => {
@@ -552,102 +585,40 @@ function ChatSessionSlot({
             <span>{statusMessage}</span>
           </div>
         ) : null}
-        {slashActive ? (
-          <div className="slash-menu" role="listbox">
-            {slashMatches.map((cmd, index) => (
-              <button
-                type="button"
-                key={cmd.name}
-                role="option"
-                aria-selected={index === slashSel}
-                className={`slash-item${index === slashSel ? " active" : ""}`}
-                onMouseEnter={() => setSlashIndex(index)}
-                onClick={() => completeCommand(cmd)}
-              >
-                <span className="slash-name">/{cmd.name}</span>
-                <span className="slash-desc">{cmd.usage || cmd.description}</span>
-              </button>
-            ))}
-          </div>
-        ) : null}
-        <form
-          className="composer"
-          onSubmit={(event) => {
-            event.preventDefault();
-            void send();
-          }}
-        >
-        <textarea
-          ref={textareaRef}
+        <PromptInput
           value={draft}
-          onChange={(event) => {
-            setDraft(event.target.value);
+          onChange={(v) => {
+            setDraft(v);
             setSlashDismissed(false); // re-open the menu when the input changes
           }}
-          onKeyDown={(event) => {
-            // Slash-command navigation takes priority while the menu is open.
-            if (slashActive) {
-              if (event.key === "ArrowDown") {
-                event.preventDefault();
-                setSlashIndex((i) => (i + 1) % slashMatches.length);
-                return;
-              }
-              if (event.key === "ArrowUp") {
-                event.preventDefault();
-                setSlashIndex((i) => (i - 1 + slashMatches.length) % slashMatches.length);
-                return;
-              }
-              if (event.key === "Enter" || event.key === "Tab") {
-                event.preventDefault();
-                completeCommand(slashMatches[slashSel]);
-                return;
-              }
-              if (event.key === "Escape") {
-                event.preventDefault();
-                setSlashDismissed(true);
-                return;
-              }
-            }
-            // Enter sends; Cmd/Ctrl+Enter (and Shift+Enter) insert a newline.
-            if (event.key === "Enter") {
-              if (event.metaKey || event.ctrlKey) {
-                // Ctrl/Cmd+Enter → newline at the caret (the textarea wouldn't
-                // insert one for this combo on its own).
-                event.preventDefault();
-                const ta = textareaRef.current;
-                if (ta) {
-                  const start = ta.selectionStart;
-                  const end = ta.selectionEnd;
-                  const next = `${draft.slice(0, start)}\n${draft.slice(end)}`;
-                  setDraft(next);
-                  requestAnimationFrame(() => {
-                    ta.selectionStart = ta.selectionEnd = start + 1;
-                  });
-                }
-                return;
-              }
-              if (!event.shiftKey) {
-                // Plain Enter → send. (Shift+Enter falls through to a newline.)
-                event.preventDefault();
-                void send();
-              }
-            }
+          // The DS button is Send when idle, Stop (square) while streaming.
+          onSubmit={() => {
+            if (status === "streaming") void stop();
+            else void send();
           }}
+          loading={status === "streaming"}
           placeholder="Message protoAgent  (/ for commands · Enter to send · ⌘/Ctrl+Enter for newline)"
-          rows={1}
+          inputRef={textareaRef}
+          onKeyDown={onComposerKeyDown}
+          overlay={slashActive ? (
+            <div className="slash-menu" role="listbox">
+              {slashMatches.map((cmd, index) => (
+                <button
+                  type="button"
+                  key={cmd.name}
+                  role="option"
+                  aria-selected={index === slashSel}
+                  className={`slash-item${index === slashSel ? " active" : ""}`}
+                  onMouseEnter={() => setSlashIndex(index)}
+                  onClick={() => completeCommand(cmd)}
+                >
+                  <span className="slash-name">/{cmd.name}</span>
+                  <span className="slash-desc">{cmd.usage || cmd.description}</span>
+                </button>
+              ))}
+            </div>
+          ) : null}
         />
-        {status === "streaming" ? (
-          <Button type="button" onClick={() => void stop()}>
-            <Square size={15} />
-            Stop
-          </Button>
-        ) : (
-          <Button variant="primary" type="submit" disabled={!canSend}>
-            <Send size={16} />
-            Send
-          </Button>
-        )}
-        </form>
         {/* Model control, under the input (ADR 0048) — a chip showing the active model
             alias; click to tune model / temperature / max tokens. Same field + cascade
             as Settings ▸ Workspace ▸ Settings. */}

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -48,15 +48,6 @@
   color: var(--fg-secondary);
 }
 
-.composer {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) auto;
-  gap: 10px;
-  padding: 12px;
-  border-top: 1px solid var(--border);
-  align-items: center; /* a single-row input sits centered against the Send button */
-}
-
 /* A thin control row UNDER the input (ADR 0048) — holds the model chip (and is the
    home for future per-turn controls). */
 .composer-toolbar {
@@ -109,19 +100,6 @@
 .slash-desc {
   font-size: 11px;
   color: var(--fg-muted);
-}
-
-/* The chat input is a compact fixed height (it doesn't auto-grow) — without this it has no cap
-   and rendered far too tall. .notes-editor keeps its own sizing above. */
-.composer textarea {
-  /* Single-row by default (like a text input); auto-grows with content up to
-     max-height (JS sets the inline height), then scrolls. */
-  height: auto;
-  min-height: 40px;
-  max-height: 200px;
-  line-height: 1.45;
-  resize: none;
-  overflow-y: auto;
 }
 
 /* Delete-chat dialog: the opt-in harvest checkbox (harvest is never automatic). */

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.30.0",
+        "@protolabsai/ui": "^0.33.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.30.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.30.0.tgz",
-      "integrity": "sha512-Wj6SdtRjlBfWmuW1W9XKc2mOBHZGsNhUDaZASGpLPd+Duybib5zewrSMUP4teUyt6JGtDBnq37/ZY1TtnyIlmg==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.33.0.tgz",
+      "integrity": "sha512-VdrGNpTpOhbBey6OZbSkL2t1shkrrEOPYN8RlndILZz74CPeBd4YIh0cQK6k4jOtZqSyr3FBvJTKvsT0rZBjtA==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## What

PR 1 of the chat-UX refresh (**bd-39m**). Replaces our hand-rolled `<form>`/`<textarea>` composer with the design-system `PromptInput`, using the host-extension seams I just shipped upstream (**protoContent #232 → @protolabsai/ui 0.33**). This is the foundation for file attachments (bd-3dh) and exercises the new DS hooks end-to-end.

Bumps `@protolabsai/ui` **0.30 → 0.33**.

## How the delicate composer behavior is preserved

- **Slash-command menu** → rendered in the DS `overlay` slot; `onKeyDown` carries the same ↑/↓ nav, Enter/Tab complete, Esc dismiss.
- **⌘/Ctrl+Enter newline** → handled in `onKeyDown` (preventDefault), using `inputRef` for the caret insert.
- **Plain Enter sends** → our `onKeyDown` doesn't preventDefault, so it falls through to the DS's Enter-to-submit → `send()`.
- **Stop while streaming** → DS button flips to a stop square when `loading`; `onSubmit` routes to `stop()` vs `send()`.
- **HITL form** + **model QuickSetting** + **streaming status** unchanged (siblings around the composer).

DS owns auto-grow, so the local auto-grow effect and the now-dead `.composer` / `.composer textarea` CSS are removed.

## Verification

- `tsc --noEmit` + `vite build` green; the `.pl-prompt*` styles bundle via `@protolabsai/ui/styles.css` (confirmed in the built CSS).
- ⚠️ The slash-nav / ⌘+Enter / stop-mid-stream paths are interaction-heavy — worth a manual sanity pass in the running console after merge (there's no composer-level e2e test; the Web E2E smoke covers build+load).

## Next in the initiative
PR 2: attachments + file upload (composer collects files → A2A parts → backend pipeline, bd-3dh). PR 3: adopt the DS message thread (Conversation/Message/MessageActions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)