### PR TITLE
fix(chat): single focus ring + click-anywhere-to-focus on the DS composer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -122,6 +122,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   list (`acp:copilot` → `copilot --acp`), matching the Settings runtime options.
 
 ### Fixed
+- **Chat composer focus polish.** The migrated DS composer showed a double focus ring (the
+  app's global `textarea:focus-visible` outline leaked through the DS field's own reset by
+  specificity) — now suppressed so only the container's single focus ring shows. Clicking
+  anywhere in the prompt box (its padding or button bar, not just the textarea) now focuses
+  the input.
 - **Embedding circuit breaker clears on a passing connection test.** After repeated embed
   auth failures (e.g. an expired gateway key) the breaker latches open for
   `embed_breaker_cooldown_s` and serves keyword-only FTS5. Fixing the key via Settings

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -578,7 +578,19 @@ function ChatSessionSlot({
         />
       )}
 
-      <div className="composer-wrap">
+      <div
+        className="composer-wrap"
+        onMouseDown={(e) => {
+          // Click anywhere in the prompt box (its padding / button bar) focuses the
+          // field — not just the textarea. Skip when the click is outside the box or
+          // on an interactive child (send/stop button, slash item, the field itself).
+          const target = e.target as HTMLElement;
+          if (!target.closest(".pl-prompt")) return;
+          if (target.closest("button, a, textarea, input, select, label, [role='option']")) return;
+          e.preventDefault(); // keep focus from leaving the field
+          textareaRef.current?.focus();
+        }}
+      >
         {status === "streaming" && statusMessage ? (
           <div className="composer-status">
             <Loader2 className="spin" size={12} />

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -61,6 +61,15 @@
 .composer-wrap {
   position: relative;
 }
+
+/* The DS PromptInput shows focus on the CONTAINER (.pl-prompt:focus-within). Our
+   global textarea:focus-visible outline (theme-base.css) has higher specificity than
+   the DS field's own `outline: none`, so it leaks an inner ring — suppress it here so
+   there's a single (external) focus ring, not two. */
+.pl-prompt__field:focus,
+.pl-prompt__field:focus-visible {
+  outline: none;
+}
 .slash-menu {
   position: absolute;
   left: 12px;


### PR DESCRIPTION
## What

Two polish bugs you spotted on the migrated DS composer (#995):

1. **Double focus ring** — the app's global `textarea:focus-visible { outline: 1px solid }` (theme-base.css) has higher specificity (`0,1,1`) than the DS field's own `.pl-prompt__field { outline: none }` (`0,1,0`), so on focus it leaked an *inner* ring on top of the DS container's `.pl-prompt:focus-within` ring. Fixed by re-asserting `outline: none` on the field (so only the single external ring shows).
2. **Click-to-focus** — only the textarea focused the input. A `composer-wrap` `onMouseDown` now focuses the field when the click lands anywhere inside the `.pl-prompt` box (its padding / button bar), skipping interactive children (send/stop button, slash item, the field itself); `preventDefault` keeps focus from leaving.

## Verification

Full web e2e suite (97) green, including the streaming/send + slash paths — the new mousedown handler doesn't interfere with sends, button clicks, or slash selection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)