### PR TITLE
feat(subagents): autonomous idle-wake on background completion (ADR 0050 Phase 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Background subagents wake the agent on completion** (ADR 0050, Phase 2) — when a
+  background job finishes, the agent now **reacts to the result autonomously** instead of
+  only learning on the spawning chat's next message: the completion fires a turn into the
+  Activity thread (via a `now`-priority inbox item, storm-guarded), where the response
+  surfaces live in the console's Activity feed. So a backgrounded strategist audit can
+  finish and the agent acts on it on its own. On by default; `BACKGROUND_WAKE=0` opts out.
 - **Background subagents** (ADR 0050, Phase 1) — the `task` tool now takes
   `run_in_background: true`. A long, independent delegation (deep research, multi-step
   gathering) runs **detached** instead of blocking the chat turn: the tool returns

--- a/docs/adr/0050-background-subagents-reactive-notifications.md
+++ b/docs/adr/0050-background-subagents-reactive-notifications.md
@@ -142,11 +142,20 @@ nudges close that:
    loop); the `task` tool always accepts the arg and degrades to synchronous if the manager
    is disabled.
 
-### Phases 2–4 (planned, not in this ADR's PR)
+### Phase 2 — reactivity / idle-wake (shipped)
 
-- **Phase 2 — reactivity / idle-wake.** Route a completion into an inbox `now` item so the
-  existing inbox→Activity-turn fire wakes the agent autonomously even when the user isn't
-  typing. Publish `background.{started,progress}` on the bus.
+A finished background job now **wakes the agent autonomously**, so it acts on the result
+without waiting for the spawning session's next turn. On completion, `_handle_background_terminal`
+adds a `now`-priority **inbox item** (the existing reactive path, ADR 0003) whose fire runs a
+turn into the **Activity thread** — storm-guarded by the inbox's `StormGuard`. Activity is the
+right home (not the originating chat): the console's chat view is localStorage-driven and won't
+render a backend-initiated turn, but the **Activity feed is server-driven** (it renders the
+`activity.message` bus event), so the autonomous response shows up there live. The wake stimulus
+names the originating session so the agent can reference it. Gated by `BACKGROUND_WAKE` (on by
+default; `=0` opts out, parity with `BACKGROUND_DISABLED`). `background.started` is published on
+spawn (Phase 1); `background.progress` remains a follow-up.
+
+### Phases 3–4 (planned, not in this ADR's PR)
 - **Phase 3 — chat UX.** A live status pill (`⟳ 2 agents running`), a background-jobs panel
   (status / elapsed / stop), a completion toast + unread badge, and a rich live subagent card
   in-transcript. Check `@protolabsai/ui/ai` (Conversation/Message/ToolCall) before hand-rolling.
@@ -164,11 +173,14 @@ nudges close that:
   toolset and a fresh, isolated context (good: no parent-context pollution; capable). Per-job
   tool-allowlist scoping (running the actual `researcher` allowlist) is deferred — the
   `subagent_type` currently contributes a role preamble to the fired prompt, not a tool fence.
-- **The human sees it live; the model learns on the next turn.** If the spawning chat is open,
-  `BackgroundWatch` surfaces the result immediately (step 6). The *model* still only ingests the
-  completion on that session's next turn (step 5) — so if the user never sends another message,
-  the agent itself won't act on the result. Autonomous wake (firing a turn so the agent responds
-  unprompted) is Phase 2.
+- **Three ways a completion surfaces.** (a) The human sees it live in the open spawning chat
+  (`BackgroundWatch`, step 6); (b) the model ingests it on that session's next turn (the drain,
+  step 5); and (c) the agent **wakes and acts on it autonomously** in the Activity thread
+  (Phase 2). (a)+(b) are chat-scoped and human-paced; (c) is the self-driving path that fires
+  even if the user never returns to the chat.
+- **Autonomous wake costs a turn per completion.** Each finished background job fires one
+  Activity turn (storm-guarded). Proportionate — background jobs are deliberate and low-volume —
+  but `BACKGROUND_WAKE=0` disables it for cost-sensitive or non-reactive deployments.
 - **A background turn could itself spawn background turns.** Bounded in practice by focused
   prompts + the prompt contract; a hard depth fence is a later refinement.
 - **Long jobs vs. the self-POST timeout.** `_fire` holds the connection open for the whole turn

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -14,6 +14,7 @@ imports from ``server`` (``agent_name``, ``_event_bus``) are all defined in
 ``__init__`` before its re-export line, so the import is not a cycle.
 """
 
+import asyncio
 import logging
 import os
 
@@ -23,6 +24,69 @@ from runtime.state import STATE
 from server import _event_bus, agent_name
 
 log = logging.getLogger("protoagent.server")
+
+# Holds the fire-and-forget background-wake tasks (ADR 0050 Phase 2) so they aren't
+# GC'd mid-flight; the done callback discards each on completion.
+_BG_WAKE_TASKS: set = set()
+
+
+def _background_wake_enabled() -> bool:
+    """Whether a finished background job should autonomously wake the agent (ADR 0050
+    Phase 2). On by default; ``BACKGROUND_WAKE=0`` opts out (parity with
+    ``BACKGROUND_DISABLED``)."""
+    return os.environ.get("BACKGROUND_WAKE", "1").strip().lower() not in ("0", "false", "no")
+
+
+def _background_wake_text(job) -> str:
+    """The stimulus the agent wakes to when a background job finishes."""
+    result = job.result or ""
+    if len(result) > 4000:
+        result = result[:4000] + "\n\n…[truncated]"
+    where = f" (you spawned it from session {job.origin_session})" if job.origin_session else ""
+    verb = "failed" if job.status == "failed" else "finished"
+    return (
+        f"A background task you delegated has {verb}{where} — decide whether to act on it.\n\n"
+        f"Job: {job.description} [{job.subagent_type}]\n"
+        f"Status: {job.status}\n"
+        f"Result:\n{result}\n\n"
+        "If this calls for follow-up action, take it now. Otherwise acknowledge it briefly "
+        "and stop — don't re-run the task."
+    )
+
+
+async def _background_wake(job) -> bool:
+    """Wake the agent on a completion by adding a now-priority inbox item (ADR 0050
+    Phase 2) — which fires a turn into the Activity thread via the existing inbox→
+    Activity path (storm-guarded). Returns whether the fire was dispatched. The Activity
+    response surfaces live in the console's Activity feed (server-driven, unlike the
+    localStorage chat view)."""
+    if STATE.inbox_store is None:
+        return False
+    from operator_api.console_handlers import _operator_inbox_add
+
+    res = await _operator_inbox_add({
+        "text": _background_wake_text(job),
+        "priority": "now",
+        "source": "background",
+        "dedup_key": f"background-wake:{job.id}",
+    })
+    return bool(res.get("fired"))
+
+
+def _spawn_background_wake(job) -> None:
+    """Schedule the (async) wake fire-and-forget on the running loop. No-op off-loop."""
+    try:
+        loop = asyncio.get_running_loop()
+    except RuntimeError:
+        return
+    async def _go() -> None:
+        try:
+            await _background_wake(job)
+        except Exception:  # noqa: BLE001 — best-effort; never breaks the terminal hook
+            log.exception("[background] wake fire failed for %s", getattr(job, "id", "?"))
+    t = loop.create_task(_go())
+    _BG_WAKE_TASKS.add(t)
+    t.add_done_callback(_BG_WAKE_TASKS.discard)
 
 
 def _bearer_configured() -> bool:
@@ -301,6 +365,11 @@ def _handle_background_terminal(outcome) -> None:
             "result": result_preview,
         },
     )
+    # Autonomous idle-wake (ADR 0050 Phase 2): fire an Activity turn so the agent reacts
+    # to the result on its own, instead of only learning on the spawning session's next
+    # turn. Gated + storm-guarded; needs the full job row for the stimulus.
+    if job is not None and _background_wake_enabled():
+        _spawn_background_wake(job)
 
 
 def _a2a_terminal(outcome) -> None:

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -237,6 +237,71 @@ class TestManager:
         assert mgr.store.get(jid).status == "failed"
 
 
+# ── Phase 2: autonomous idle-wake (server/a2a.py) ────────────────────────────
+
+
+class TestPhase2Wake:
+    def _job(self, status="completed"):
+        from background.store import BackgroundJob
+
+        return BackgroundJob(
+            id="bg-abc", agent_name="a", origin_session="sess-X",
+            subagent_type="strategist", description="audit fleet", prompt="p",
+            status=status, result="Tuned buy_buffer to 30k.", notified=False,
+            created_at="t1", completed_at="t2",
+        )
+
+    def test_wake_enabled_default_and_optout(self, monkeypatch):
+        from server.a2a import _background_wake_enabled
+
+        monkeypatch.delenv("BACKGROUND_WAKE", raising=False)
+        assert _background_wake_enabled() is True
+        monkeypatch.setenv("BACKGROUND_WAKE", "0")
+        assert _background_wake_enabled() is False
+        monkeypatch.setenv("BACKGROUND_WAKE", "1")
+        assert _background_wake_enabled() is True
+
+    def test_wake_text_includes_job_and_result(self):
+        from server.a2a import _background_wake_text
+
+        t = _background_wake_text(self._job("completed"))
+        assert "audit fleet" in t and "strategist" in t
+        assert "finished" in t and "sess-X" in t
+        assert "Tuned buy_buffer" in t
+
+    def test_wake_text_failed_verb(self):
+        from server.a2a import _background_wake_text
+
+        assert "failed" in _background_wake_text(self._job("failed"))
+
+    async def test_wake_adds_now_inbox_item(self, monkeypatch):
+        import operator_api.console_handlers as ch
+        import server.a2a as a2a
+        from runtime.state import STATE
+
+        monkeypatch.setattr(STATE, "inbox_store", object(), raising=False)
+        captured: dict = {}
+
+        async def fake_add(payload):
+            captured.update(payload)
+            return {"ok": True, "fired": True}
+
+        monkeypatch.setattr(ch, "_operator_inbox_add", fake_add)
+        fired = await a2a._background_wake(self._job())
+        assert fired is True
+        assert captured["priority"] == "now"
+        assert captured["source"] == "background"
+        assert captured["dedup_key"] == "background-wake:bg-abc"
+        assert "audit fleet" in captured["text"]
+
+    async def test_wake_noop_without_inbox(self, monkeypatch):
+        import server.a2a as a2a
+        from runtime.state import STATE
+
+        monkeypatch.setattr(STATE, "inbox_store", None, raising=False)
+        assert await a2a._background_wake(self._job()) is False
+
+
 def test_task_tool_constrains_subagent_type_to_enum():
     """The `task` tool's subagent_type must render as a JSON-schema enum of the live
     registry (ADR 0050 follow-up) so the model can't pass a name that doesn't exist."""


### PR DESCRIPTION
## What & why

**Phase 2 of [ADR 0050](docs/adr/0050-background-subagents-reactive-notifications.md).** Phase 1 (#996) made a background job's result come back to the spawning chat (next-turn drain + live in-chat push). But the *agent* only learned of it when the user sent another message — if nobody returned to the chat, the agent never acted. This closes that: a finished background job now **wakes the agent autonomously**.

So you can background a strategist audit, walk away, and the agent acts on the result on its own.

## How

On completion, `_handle_background_terminal` adds a **`now`-priority inbox item**, whose fire runs a turn into the **Activity thread** — the existing reactive path (ADR 0003), **storm-guarded** by the inbox `StormGuard`.

**Why Activity, not the originating chat:** the console chat view is localStorage-driven and won't render a backend-initiated turn, but the **Activity feed is server-driven** (renders the `activity.message` bus event), so the autonomous response surfaces there **live**. The wake stimulus names the originating session so the agent can reference where it came from.

A completion now surfaces three ways: human sees it live in the open chat (Phase 1 `BackgroundWatch`), the model ingests it on that chat's next turn (Phase 1 drain), and the agent acts on it autonomously in Activity (this PR).

## Config

- `BACKGROUND_WAKE` — on by default; `=0` opts out (parity with `BACKGROUND_DISABLED`). One Activity turn per completion (storm-guarded) — proportionate since background jobs are deliberate + low-volume.

## Testing

- `tests/test_background.py` +5 Phase 2 cases (enable/opt-out, wake-text content incl. failed verb, `now`-inbox dispatch with dedup key, no-inbox no-op). Background suite: **23 passed**; with a2a/inbox/stores adjacents: **85 passed**. `ruff` clean.

Closes `bd-g9c`. Follow-ups (Phases 3–4 in the ADR): chat-UX jobs panel/pill, `task_output`/`stop_task` + auto-background, `background.progress` events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)