### PR TITLE
feat(chat): tiered, session-scoped attachment context (backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Activity thread (via a `now`-priority inbox item, storm-guarded), where the response
   surfaces live in the console's Activity feed. So a backgrounded strategist audit can
   finish and the agent acts on it on its own. On by default; `BACKGROUND_WAKE=0` opts out.
+- **Chat attachments — tiered context (backend)** (ADR 0021). `POST /api/knowledge/attach`
+  extracts a dropped file (the ingestion engine — txt/md/html/pdf, audio/video via STT) and
+  **tiers it so a big document never gets dumped into the turn**: text at or under
+  `knowledge.attach_inline_budget` (default 8000 chars) is inlined whole; a larger doc is
+  ingested (chunked → contextually enriched → embedded) under a per-session namespace
+  (`attach:<session>`) so the user's *question* retrieves only the relevant passages, with
+  just a lede inlined as an anchor. The attachments are **session-scoped + ephemeral** —
+  deleting the chat (`DELETE /api/chat/sessions/{id}`) now drops them via the new
+  `KnowledgeStore.delete_by_namespace` (hybrid clears the side vector table too). The
+  composer UI that drives this is the next PR.
 - **Background subagents** (ADR 0050, Phase 1) — the `task` tool now takes
   `run_in_background: true`. A long, independent delegation (deep research, multi-step
   gathering) runs **detached** instead of blocking the chat turn: the tool returns

--- a/graph/config.py
+++ b/graph/config.py
@@ -418,6 +418,11 @@ class LangGraphConfig:
     # text sent in the context prompt.
     knowledge_contextual_enrichment: bool = False
     knowledge_context_max_doc_chars: int = 12000
+    # Chat attachments (ADR 0021) — a file dropped in chat is extracted, then TIERED
+    # so a big doc never gets dumped into the turn: text at or under this many chars
+    # is inlined whole; a larger doc is ingested (chunked/embedded, session-scoped)
+    # for retrieval and only a lede of this many chars is inlined as an anchor.
+    knowledge_attach_inline_budget: int = 8000
 
     # Conversation checkpointer — persists each chat session's history per
     # thread_id so multi-turn chats survive a server restart. A path → durable
@@ -808,6 +813,8 @@ class LangGraphConfig:
                 "contextual_enrichment", cls.knowledge_contextual_enrichment),
             knowledge_context_max_doc_chars=knowledge.get(
                 "context_max_doc_chars", cls.knowledge_context_max_doc_chars),
+            knowledge_attach_inline_budget=knowledge.get(
+                "attach_inline_budget", cls.knowledge_attach_inline_budget),
             skills_enabled=skills.get("enabled", cls.skills_enabled),
             skills_db_path=skills.get("db_path", cls.skills_db_path),
             skills_top_k=skills.get("top_k", cls.skills_top_k),

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -161,6 +161,11 @@ FIELDS: list[Field] = [
           "whole document before embedding — lifts both semantic and keyword recall (Anthropic's "
           "Contextual Retrieval). Costs one aux call per chunk at ingest (not on the query path). "
           "Off by default.", restart=True),
+    Field("knowledge.attach_inline_budget", "knowledge_attach_inline_budget",
+          "Chat attachment inline budget", "number", "Knowledge",
+          "A file dropped in chat is inlined whole if its text is at or under this many "
+          "characters; a larger doc is indexed for retrieval instead, with only a lede of this "
+          "length inlined — so a big document never gets dumped into the turn.", minimum=1),
     Field("skills.top_k", "skills_top_k", "Skill recall top-k", "number", "Knowledge", minimum=1),
     Field("checkpoint.db_path", "checkpoint_db_path", "Conversation history DB", "string", "Knowledge",
           "SQLite path for per-session chat history (survives restarts). Blank = in-memory.",

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -239,6 +239,26 @@ class HybridKnowledgeStore(KnowledgeStore):
         finally:
             db.close()
 
+    def delete_by_namespace(self, namespace: str) -> int:
+        """Drop the namespace's chunks AND their vectors (no FK cascade on the
+        side table) so ephemeral chunks leave nothing behind."""
+        if not namespace:
+            return 0
+        db = self._get_db()
+        if db is not None:
+            try:
+                db.execute(
+                    "DELETE FROM chunk_vectors WHERE chunk_id IN "
+                    "(SELECT id FROM chunks WHERE namespace = ?)",
+                    (namespace,),
+                )
+                db.commit()
+            except sqlite3.DatabaseError as exc:
+                log.warning("[knowledge] delete_by_namespace vectors failed: %s", exc)
+            finally:
+                db.close()
+        return super().delete_by_namespace(namespace)
+
     def _vector_search(self, query_vec: list[float], k: int, domain: str | None) -> list[int]:
         """Return chunk ids ranked by cosine similarity (brute force)."""
         db = self._get_db()

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -772,3 +772,22 @@ class KnowledgeStore:
             return 0
         finally:
             db.close()
+
+    def delete_by_namespace(self, namespace: str) -> int:
+        """Delete every chunk in ``namespace``. Used to clean up ephemeral,
+        session-scoped chunks (e.g. chat attachments) when the session is
+        retired (ADR 0021). Returns the count removed."""
+        if not namespace:
+            return 0
+        db = self._get_db()
+        if db is None:
+            return 0
+        try:
+            cur = db.execute("DELETE FROM chunks WHERE namespace = ?", (namespace,))
+            db.commit()
+            return int(cur.rowcount)
+        except sqlite3.DatabaseError as exc:
+            log.warning("[knowledge] delete_by_namespace failed: %s", exc)
+            return 0
+        finally:
+            db.close()

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -14,13 +14,17 @@ HTTP layer over it. ``ui`` (the deployment tier) is passed in because
 
 from __future__ import annotations
 
+import asyncio
 import json
+import logging
 import time
 
 from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel
 
 from runtime.state import STATE
+
+log = logging.getLogger("protoagent.server")
 from server import agent_name
 from server.agent_init import _retire_thread
 from server.chat import chat
@@ -56,6 +60,14 @@ def register_chat_routes(app, ui: str) -> None:
         operator may be deleting it precisely to get rid of it. The TTL prune
         sweep keeps its own config-driven default (``checkpoint_harvest_enabled``)."""
         chunk_id = await _retire_thread(f"a2a:{session_id}", harvest=harvest)
+        # Ephemeral chat attachments are session-scoped (ADR 0021) — drop them so a
+        # deleted chat leaves nothing indexed behind.
+        store = STATE.knowledge_store
+        if store is not None and hasattr(store, "delete_by_namespace"):
+            try:
+                await asyncio.to_thread(store.delete_by_namespace, f"attach:{session_id}")
+            except Exception as exc:  # noqa: BLE001 — cleanup is best-effort
+                log.warning("[chat] attachment cleanup failed for %s: %s", session_id, exc)
         return {"deleted": True, "harvested": chunk_id is not None}
 
     # --- Goal mode API ------------------------------------------------------

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -262,6 +262,84 @@ def register_knowledge_routes(app) -> None:
             "chars": len(result.text),
         }
 
+    @app.post("/api/knowledge/attach")
+    async def _api_chat_attach(
+        file: UploadFile = File(...),
+        session_id: str = Form(...),
+    ):
+        """Extract a chat attachment and TIER it so a big doc never gets dumped
+        into the turn (ADR 0021):
+
+        - text at or under ``knowledge.attach_inline_budget`` → inlined whole
+          (``mode=inline``); the caller prepends ``context`` to its message.
+        - a larger doc → ingested (chunked / contextually enriched / embedded)
+          under a per-session namespace so the user's *question* retrieves the
+          relevant passages, and only a ``lede`` is inlined as an anchor
+          (``mode=indexed``). Cleaned up when the chat session is deleted.
+
+        Returns the ready-to-prepend ``context`` block + a descriptor for the
+        composer chip."""
+        if STATE.knowledge_store is None:
+            return {"enabled": False}
+        from ingestion import MissingDependency, UnsupportedSource, extract_bytes
+        from knowledge import add_document
+
+        sid = (session_id or "").strip()
+        if not sid:
+            return JSONResponse({"detail": "session_id is required"}, status_code=400)
+
+        transcribe = None
+        try:
+            from graph.llm import create_transcribe_fn
+
+            transcribe = create_transcribe_fn(STATE.graph_config) if STATE.graph_config else None
+        except Exception as exc:  # noqa: BLE001 — transcription stays optional
+            log.warning("[knowledge] transcribe fn unavailable: %s", exc)
+
+        name = file.filename or "attachment"
+        try:
+            data = await file.read()
+            result = await asyncio.to_thread(
+                extract_bytes, name, data, file.content_type, transcribe=transcribe)
+        except MissingDependency as exc:
+            return JSONResponse({"detail": str(exc)}, status_code=501)
+        except UnsupportedSource as exc:
+            return JSONResponse({"detail": str(exc)}, status_code=415)
+        except Exception as exc:  # noqa: BLE001 — surface extraction failure, never 500
+            log.warning("[knowledge] attach extraction failed: %s", exc)
+            return JSONResponse({"detail": f"extraction failed: {exc}"}, status_code=400)
+
+        text = result.text
+        budget = int(getattr(STATE.graph_config, "knowledge_attach_inline_budget", 8000) or 8000)
+
+        if len(text) <= budget:
+            context = f"[Attached file: {name}]\n{text}\n[end of {name}]"
+            return {
+                "enabled": True, "mode": "inline", "name": name,
+                "source_type": result.source_type, "chars": len(text),
+                "chunks": 0, "context": context,
+            }
+
+        # Large → index for retrieval (session-scoped, ephemeral) + inline a lede.
+        ids = await asyncio.to_thread(
+            lambda: add_document(
+                STATE.knowledge_store, text,
+                domain="attachment", namespace=f"attach:{sid}",
+                source=name, source_type=result.source_type,
+            )
+        )
+        lede = text[:budget]
+        context = (
+            f"[Attached file: {name} — large ({len(text)} chars), indexed for retrieval. "
+            f"Opening excerpt:]\n{lede}\n"
+            f"[Ask about its contents to retrieve more from {name}.]"
+        )
+        return {
+            "enabled": True, "mode": "indexed", "name": name,
+            "source_type": result.source_type, "chars": len(text),
+            "chunks": len(ids), "context": context,
+        }
+
     @app.put("/api/knowledge/chunks/{chunk_id}")
     async def _api_knowledge_update(chunk_id: int, body: dict | None = None):
         if STATE.knowledge_store is None:

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -50,6 +50,28 @@ def test_delete_session_harvest_is_opt_in(monkeypatch):
     assert calls == [("a2a:s1", False), ("a2a:s2", True)]
 
 
+def test_delete_session_cleans_ephemeral_attachments(monkeypatch):
+    """Deleting a chat drops its session-scoped attachment chunks."""
+    import operator_api.chat_routes as cr
+    import runtime.state as rs
+
+    async def _fake_retire(thread_id, *, harvest=None):
+        return None
+
+    ns: list[str] = []
+
+    class _Store:
+        def delete_by_namespace(self, namespace):
+            ns.append(namespace)
+            return 3
+
+    monkeypatch.setattr(cr, "_retire_thread", _fake_retire)
+    c = _client(monkeypatch)
+    monkeypatch.setattr(rs.STATE, "knowledge_store", _Store(), raising=False)
+    assert c.delete("/api/chat/sessions/s1").json()["deleted"] is True
+    assert ns == ["attach:s1"]
+
+
 def test_healthz_ready_and_echoes_ui(monkeypatch):
     c = _client(monkeypatch, graph=object())
     r = c.get("/healthz")

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -105,6 +105,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "knowledge_chunk_min_chars": 200,
     "knowledge_contextual_enrichment": False,
     "knowledge_context_max_doc_chars": 12000,
+    "knowledge_attach_inline_budget": 8000,
     "llm_max_retries": 2,
     "max_iterations": 50,
     "max_tokens": 32768,
@@ -225,6 +226,7 @@ CONFIG_TO_DICT_GOLDEN = {
         "org": "",
     },
     "knowledge": {
+        "attach_inline_budget": 8000,
         "chunk_max_chars": 1200,
         "chunk_min_chars": 200,
         "chunk_overlap_chars": 150,
@@ -363,6 +365,7 @@ EMITTED_ATTRS = {
     "knowledge_chunk_min_chars",
     "knowledge_contextual_enrichment",
     "knowledge_context_max_doc_chars",
+    "knowledge_attach_inline_budget",
     # skills.*
     "skills_enabled",
     "skills_db_path",

--- a/tests/test_knowledge_routes.py
+++ b/tests/test_knowledge_routes.py
@@ -256,3 +256,52 @@ def test_ingest_audio_without_transcribe_model_returns_501(monkeypatch):
     c = _client(monkeypatch, knowledge=_IngestKS())
     files = {"file": ("clip.mp3", b"\x00\x01audio", "audio/mpeg")}
     assert c.post("/api/knowledge/ingest", files=files).status_code == 501
+
+
+# ── chat attachments (/api/knowledge/attach) — tiered, session-scoped ─────────
+import types as _types  # noqa: E402
+
+
+def _attach_client(monkeypatch, ks, *, budget=20):
+    import runtime.state as rs
+    monkeypatch.setattr(
+        rs.STATE, "graph_config",
+        _types.SimpleNamespace(knowledge_attach_inline_budget=budget),
+        raising=False,
+    )
+    return _client(monkeypatch, knowledge=ks)
+
+
+def test_attach_small_doc_inlines(monkeypatch):
+    ks = _IngestKS()
+    c = _attach_client(monkeypatch, ks, budget=200)
+    files = {"file": ("note.txt", b"a short attached note", "text/plain")}
+    body = c.post("/api/knowledge/attach", data={"session_id": "s1"}, files=files).json()
+    assert body["mode"] == "inline" and body["chunks"] == 0
+    assert "a short attached note" in body["context"]
+    assert ks.docs == []                       # nothing indexed for a small doc
+
+
+def test_attach_large_doc_indexes_session_scoped(monkeypatch):
+    ks = _IngestKS()
+    c = _attach_client(monkeypatch, ks, budget=20)
+    big = b"word " * 50  # 250 chars > 20-char budget
+    files = {"file": ("big.txt", big, "text/plain")}
+    body = c.post("/api/knowledge/attach", data={"session_id": "s1"}, files=files).json()
+    assert body["mode"] == "indexed" and body["chunks"] == 2
+    assert "indexed for retrieval" in body["context"]   # lede + retrieval note, not a dump
+    assert len(body["context"]) < 250                    # only the lede inlined, not the whole doc
+    content, kw = ks.docs[0]
+    assert kw["domain"] == "attachment" and kw["namespace"] == "attach:s1"
+
+
+def test_attach_requires_session_id(monkeypatch):
+    c = _attach_client(monkeypatch, _IngestKS())
+    files = {"file": ("note.txt", b"hi", "text/plain")}
+    assert c.post("/api/knowledge/attach", files=files, data={"session_id": "  "}).status_code == 400
+
+
+def test_attach_disabled_when_store_off(monkeypatch):
+    c = _client(monkeypatch)
+    files = {"file": ("note.txt", b"hi", "text/plain")}
+    assert c.post("/api/knowledge/attach", data={"session_id": "s1"}, files=files).json() == {"enabled": False}

--- a/tests/test_store_namespace.py
+++ b/tests/test_store_namespace.py
@@ -59,3 +59,41 @@ def test_namespace_migration_on_preexisting_db(tmp_path):
     rows = {c.content: c.namespace for c in store.list_chunks(limit=10)}
     assert rows["old row"] is None
     assert rows["new row"] == "ns"
+
+
+def test_delete_by_namespace(tmp_path):
+    """delete_by_namespace drops exactly the namespace's chunks (ephemeral chat
+    attachments are cleaned this way), leaving other namespaces + globals."""
+    store = KnowledgeStore(tmp_path / "kb.db")
+    store.add_chunk("attach one", domain="attachment", namespace="attach:s1")
+    store.add_chunk("attach two", domain="attachment", namespace="attach:s1")
+    store.add_chunk("other session", domain="attachment", namespace="attach:s2")
+    store.add_chunk("a global fact", domain="fact")
+
+    removed = store.delete_by_namespace("attach:s1")
+    assert removed == 2
+    remaining = {c.as_dict()["content"] for c in store.list_chunks()}
+    assert "attach one" not in remaining and "attach two" not in remaining
+    assert "other session" in remaining and "a global fact" in remaining
+    assert store.delete_by_namespace("attach:s1") == 0   # idempotent
+    assert store.delete_by_namespace("") == 0            # guard
+
+
+def test_hybrid_delete_by_namespace_drops_vectors(tmp_path):
+    """The hybrid override also clears the side chunk_vectors table (no FK cascade)."""
+    import sqlite3 as _sql
+
+    from knowledge.hybrid_store import HybridKnowledgeStore
+
+    db = str(tmp_path / "kb.db")
+    store = HybridKnowledgeStore(db, embed_fn=lambda t: [1.0, 0.0])
+    store.add_chunk("attach one", domain="attachment", namespace="attach:s1")
+    store.add_chunk("keep me", domain="fact")
+    conn = _sql.connect(db)
+    assert conn.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0] == 2
+    conn.close()
+
+    store.delete_by_namespace("attach:s1")
+    conn = _sql.connect(db)
+    assert conn.execute("SELECT COUNT(*) FROM chunk_vectors").fetchone()[0] == 1  # only the kept one
+    conn.close()


### PR DESCRIPTION
## What

The **backend engine** for chat file upload (bd-3dh / bd-39m), built to your strategy: a big document **never gets dumped into the turn**.

`POST /api/knowledge/attach` (multipart: `file` + `session_id`) extracts a dropped file via the ingestion engine (txt/md/html/pdf, audio/video via gateway STT) and **tiers it by size** against `knowledge.attach_inline_budget` (default 8000 chars):

- **small** → inline the whole text (`mode=inline`); the caller prepends the returned `context`.
- **large** → `add_document(domain="attachment", namespace="attach:<session>")` so the user's *question* retrieves only the relevant passages (RAG over the attachment), with just a **lede** inlined as an anchor so vague asks ("summarize this") still work (`mode=indexed`).

Typed errors → 415 / 501 / 400, never 500.

## Session-scoped + ephemeral

- `KnowledgeStore.delete_by_namespace` (the hybrid override also clears the side `chunk_vectors` table — no FK cascade).
- `DELETE /api/chat/sessions/{id}` now drops the session's `attach:<id>` chunks, so a deleted chat leaves nothing indexed behind.

## Config / tests

- `knowledge.attach_inline_budget` (Settings▸Knowledge field).
- Tiering (inline vs indexed, session namespace, missing-session/store-off), `delete_by_namespace` (base + hybrid vectors), chat-delete cleanup, config round-trip goldens.

**Full suite 1920 passed**; ruff + import contracts clean.

## Next
The composer attachments UI (DS `onAttach`/`attachments` chips → upload to this endpoint → prepend `context` to the message) — the visible half — is the follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)