### PR TITLE
fix(chat): render markdown for system messages (background notifications)

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -557,9 +557,12 @@ function ChatSessionSlot({
                   <ToolCalls calls={message.toolCalls} />
                 ) : null}
                 {message.content
-                  ? message.role === "assistant"
-                    ? <Markdown>{message.content}</Markdown>
-                    : message.content
+                  ? message.role === "user"
+                    ? message.content
+                    : // assistant + system (e.g. background-completion notifications,
+                      // ADR 0050) carry markdown — render it; only the user's own input
+                      // stays literal.
+                      <Markdown>{message.content}</Markdown>
                   : message.status === "streaming" && !(message.toolCalls && message.toolCalls.length)
                     ? <Loader2 className="spin" size={15} />
                     : null}


### PR DESCRIPTION
## What

ChatSurface only ran **assistant** messages through `<Markdown>`; `system` and `user` messages rendered as raw text. The background-completion notification (ADR 0050, `BackgroundWatch`) is injected as a `system` message carrying the subagent's markdown result (tables/headers), so it displayed as unrendered markdown source.

Now `assistant` **and** `system` render as markdown; only the user's own input stays literal.

## Why a separate PR

This fix was committed onto the Phase-2 branch, but #998 auto-merged at its first commit (the idle-wake feature) before this commit was included — so it never reached main. Re-landing it cleanly here (cherry-pick of the original commit).

## Testing

`tsc --noEmit` clean; the only `system`-message producer in the chat is `BackgroundWatch`, so this is scoped to background-completion notifications. Live-verified on the running console (rebuilt bundle).

🤖 Generated with [Claude Code](https://claude.com/claude-code)