### PR TITLE
feat(subagents): background-jobs console widget — pill + jobs dialog (ADR 0050 Phase 3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Background-jobs console widget** (ADR 0050, Phase 3) — a pill in the utility bar shows a
+  spinner + count while background subagents run and an unread dot when they finish; clicking
+  it opens a dialog listing each job's status, live elapsed time, and (for finished jobs) its
+  result rendered as markdown. Hydrates from `GET /api/background` and tracks live off the
+  `background.{started,completed}` events. (A live per-tool progress card in the transcript is
+  a follow-up — it needs a `background.progress` channel.)
 - **Background subagents wake the agent on completion** (ADR 0050, Phase 2) — when a
   background job finishes, the agent now **reacts to the result autonomously** instead of
   only learning on the spawning chat's next message: the completion fires a turn into the

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -64,6 +64,7 @@ import { lazy, Suspense, useEffect, useRef, useState, useSyncExternalStore } fro
 import type { ComponentType, LazyExoticComponent, ReactNode } from "react";
 import { FleetTurnWatch } from "./FleetTurnWatch";
 import { BackgroundWatch } from "./BackgroundWatch";
+import { BackgroundJobs } from "./BackgroundJobs";
 import { ProtoLabsIcon } from "./ProtoLabsIcon";
 import { AuthGate } from "./AuthGate";
 import { authRequired, subscribeAuth } from "../lib/auth";
@@ -877,6 +878,8 @@ export function App() {
             }
             end={
               <>
+                {/* Background subagents (ADR 0050 Phase 3) — live pill + jobs dialog. */}
+                <BackgroundJobs />
                 <button
                   type="button"
                   className={`util-btn ${leftCollapsed ? "is-off" : ""}`}

--- a/apps/web/src/app/BackgroundJobs.test.ts
+++ b/apps/web/src/app/BackgroundJobs.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from "vitest";
+
+import { byRecency, fmtElapsed } from "./background-jobs";
+import type { BackgroundJobDTO } from "../lib/types";
+
+function job(p: Partial<BackgroundJobDTO>): BackgroundJobDTO {
+  return { id: "x", status: "completed", subagent_type: "researcher", description: "d", ...p };
+}
+
+describe("fmtElapsed", () => {
+  it("formats sub-minute / minute / hour spans", () => {
+    const t0 = "2026-06-14T00:00:00.000Z";
+    expect(fmtElapsed(t0, "2026-06-14T00:00:12.000Z")).toBe("12s");
+    expect(fmtElapsed(t0, "2026-06-14T00:03:04.000Z")).toBe("3m 4s");
+    expect(fmtElapsed(t0, "2026-06-14T02:05:00.000Z")).toBe("2h 5m");
+  });
+
+  it("returns empty for missing/invalid start", () => {
+    expect(fmtElapsed(undefined)).toBe("");
+    expect(fmtElapsed("not-a-date", "2026-06-14T00:00:01.000Z")).toBe("");
+  });
+});
+
+describe("byRecency", () => {
+  it("sorts running jobs ahead of finished ones", () => {
+    const running = job({ id: "r", status: "running", created_at: "2026-06-14T00:00:00Z" });
+    const done = job({ id: "d", status: "completed", completed_at: "2026-06-14T01:00:00Z" });
+    expect([done, running].sort(byRecency).map((j) => j.id)).toEqual(["r", "d"]);
+  });
+
+  it("orders finished jobs newest-first", () => {
+    const older = job({ id: "o", completed_at: "2026-06-14T00:00:00Z" });
+    const newer = job({ id: "n", completed_at: "2026-06-14T02:00:00Z" });
+    expect([older, newer].sort(byRecency).map((j) => j.id)).toEqual(["n", "o"]);
+  });
+});

--- a/apps/web/src/app/BackgroundJobs.tsx
+++ b/apps/web/src/app/BackgroundJobs.tsx
@@ -1,0 +1,183 @@
+import { Dialog } from "@protolabsai/ui/overlays";
+import { Bot, CheckCircle2, Loader2, XCircle } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
+
+import { Markdown } from "../chat/LazyMarkdown";
+import { api } from "../lib/api";
+import { onTopic } from "../lib/events";
+import type { BackgroundJobDTO } from "../lib/types";
+import { byRecency, fmtElapsed, nowIso } from "./background-jobs";
+
+// Background-jobs UtilityBar pill + dialog (ADR 0050 Phase 3). Hydrates from
+// GET /api/background, then tracks live via the `background.{started,completed}`
+// bus events (scoped to this window's agent). The pill shows a spinner + count
+// while jobs run and an unread dot when jobs finish; clicking opens a dialog
+// listing each job's status, elapsed time, and (for finished jobs) its result.
+// Read-only — stop/kill controls are Phase 4. (Pure helpers live in
+// ./background-jobs so they're unit-testable without a react-dom import.)
+
+export function BackgroundJobs() {
+  const [enabled, setEnabled] = useState(false);
+  const [jobs, setJobs] = useState<Record<string, BackgroundJobDTO>>({});
+  const [open, setOpen] = useState(false);
+  const [unread, setUnread] = useState(0);
+  const [, setTick] = useState(0); // re-render for live elapsed while open
+
+  // Hydrate from the durable registry.
+  useEffect(() => {
+    let alive = true;
+    api
+      .background()
+      .then((d) => {
+        if (!alive) return;
+        setEnabled(!!d.enabled);
+        const m: Record<string, BackgroundJobDTO> = {};
+        for (const j of d.jobs || []) m[j.id] = j;
+        setJobs(m);
+      })
+      .catch(() => {
+        /* feature off / unreachable — the pill stays hidden */
+      });
+    return () => {
+      alive = false;
+    };
+  }, []);
+
+  // Live updates off the event bus.
+  useEffect(() => {
+    const upsert = (id: string, patch: Partial<BackgroundJobDTO>) =>
+      setJobs((m) => {
+        const prev = m[id];
+        const next: BackgroundJobDTO = {
+          id,
+          status: patch.status ?? prev?.status ?? "running",
+          subagent_type: patch.subagent_type ?? prev?.subagent_type ?? "",
+          description: patch.description ?? prev?.description ?? "",
+          origin_session: patch.origin_session ?? prev?.origin_session,
+          result: patch.result ?? prev?.result,
+          created_at: patch.created_at ?? prev?.created_at,
+          completed_at: patch.completed_at ?? prev?.completed_at,
+        };
+        return { ...m, [id]: next };
+      });
+
+    const offStart = onTopic("background.started", (d) => {
+      const id = String(d.job_id || "");
+      if (!id) return;
+      setEnabled(true);
+      upsert(id, {
+        status: "running",
+        subagent_type: String(d.subagent_type || ""),
+        description: String(d.description || ""),
+        origin_session: String(d.origin_session || ""),
+        created_at: nowIso(),
+      });
+    });
+
+    const offDone = onTopic("background.completed", (d) => {
+      const id = String(d.job_id || "");
+      if (!id) return;
+      upsert(id, {
+        status: String(d.status) === "failed" ? "failed" : "completed",
+        subagent_type: String(d.subagent_type || ""),
+        description: String(d.description || ""),
+        origin_session: String(d.origin_session || ""),
+        result: String(d.result || ""),
+        completed_at: nowIso(),
+      });
+      setUnread((u) => u + 1);
+    });
+
+    return () => {
+      offStart();
+      offDone();
+    };
+  }, []);
+
+  const list = useMemo(() => Object.values(jobs).sort(byRecency), [jobs]);
+  const running = list.filter((j) => j.status === "running").length;
+
+  // Tick the elapsed clock once a second while the dialog is open and work runs.
+  useEffect(() => {
+    if (!open || running === 0) return;
+    const t = setInterval(() => setTick((n) => n + 1), 1000);
+    return () => clearInterval(t);
+  }, [open, running]);
+
+  if (!enabled && list.length === 0) return null;
+
+  return (
+    <>
+      <button
+        type="button"
+        className="util-btn bg-jobs-pill"
+        onClick={() => {
+          setOpen(true);
+          setUnread(0);
+        }}
+        title="Background agents"
+        aria-label={`Background agents${running ? ` — ${running} running` : ""}`}
+        data-testid="background-jobs-pill"
+      >
+        {running > 0 ? <Loader2 size={13} className="spin" /> : <Bot size={13} />}
+        {running > 0 ? <span>{running}</span> : null}
+        {unread > 0 ? <span className="bg-jobs-unread" aria-label={`${unread} finished`} /> : null}
+      </button>
+      {open ? (
+        <Dialog open onClose={() => setOpen(false)} title="Background agents" width="min(640px, 94vw)">
+          {list.length === 0 ? (
+            <p className="bg-jobs-empty">No background agents have run yet.</p>
+          ) : (
+            <ul className="bg-jobs-list">
+              {list.map((j) => (
+                <BgJobRow key={j.id} job={j} />
+              ))}
+            </ul>
+          )}
+        </Dialog>
+      ) : null}
+    </>
+  );
+}
+
+function BgJobRow({ job }: { job: BackgroundJobDTO }) {
+  const [expanded, setExpanded] = useState(false);
+  const icon =
+    job.status === "running" ? (
+      <Loader2 size={14} className="spin" />
+    ) : job.status === "failed" ? (
+      <XCircle size={14} className="bg-jobs-fail" />
+    ) : (
+      <CheckCircle2 size={14} className="bg-jobs-ok" />
+    );
+  const elapsed = fmtElapsed(job.created_at, job.status === "running" ? undefined : job.completed_at);
+  const hasResult = job.status !== "running" && !!job.result;
+  return (
+    <li className="bg-jobs-row">
+      <button
+        type="button"
+        className="bg-jobs-rowhead"
+        onClick={() => hasResult && setExpanded((v) => !v)}
+        aria-expanded={hasResult ? expanded : undefined}
+        disabled={!hasResult}
+      >
+        <span className="bg-jobs-icon">{icon}</span>
+        <span className="bg-jobs-meta">
+          <span className="bg-jobs-title">
+            <strong>{job.subagent_type || "agent"}</strong> — {job.description || "(no description)"}
+          </span>
+          <span className="bg-jobs-sub">
+            {job.status}
+            {elapsed ? ` · ${elapsed}` : ""}
+            {hasResult ? (expanded ? " · hide result" : " · show result") : ""}
+          </span>
+        </span>
+      </button>
+      {hasResult && expanded ? (
+        <div className="bg-jobs-result">
+          <Markdown>{job.result || ""}</Markdown>
+        </div>
+      ) : null}
+    </li>
+  );
+}

--- a/apps/web/src/app/background-jobs.ts
+++ b/apps/web/src/app/background-jobs.ts
@@ -1,0 +1,31 @@
+// Pure helpers for the background-jobs UtilityBar widget (ADR 0050 Phase 3).
+// Kept React-free so they're unit-testable without a DOM/react-dom import.
+
+import type { BackgroundJobDTO } from "../lib/types";
+
+export function nowIso(): string {
+  return new Date().toISOString();
+}
+
+export function fmtElapsed(startIso?: string, endIso?: string): string {
+  if (!startIso) return "";
+  const start = Date.parse(startIso);
+  const end = endIso ? Date.parse(endIso) : Date.now();
+  if (Number.isNaN(start) || Number.isNaN(end)) return "";
+  let s = Math.max(0, Math.round((end - start) / 1000));
+  if (s < 60) return `${s}s`;
+  const m = Math.floor(s / 60);
+  s = s % 60;
+  if (m < 60) return `${m}m ${s}s`;
+  const h = Math.floor(m / 60);
+  return `${h}h ${m % 60}m`;
+}
+
+/** Sort order for the jobs list: running first, then most-recently-touched. */
+export function byRecency(a: BackgroundJobDTO, b: BackgroundJobDTO): number {
+  if (a.status === "running" && b.status !== "running") return -1;
+  if (b.status === "running" && a.status !== "running") return 1;
+  const at = Date.parse(a.completed_at || a.created_at || "") || 0;
+  const bt = Date.parse(b.completed_at || b.created_at || "") || 0;
+  return bt - at;
+}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -108,6 +108,87 @@
   color: var(--accent, #7c8cff);
 }
 
+/* Background subagents (ADR 0050 Phase 3) — UtilityBar pill + jobs dialog. */
+.bg-jobs-pill {
+  position: relative;
+}
+.bg-jobs-unread {
+  position: absolute;
+  top: 1px;
+  right: 1px;
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: var(--accent, #7c8cff);
+}
+.bg-jobs-empty {
+  color: var(--fg-secondary);
+  font-size: 13px;
+}
+.bg-jobs-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  max-height: min(60vh, 520px);
+  overflow-y: auto;
+}
+.bg-jobs-row {
+  border: 1px solid var(--border, #2a2a31);
+  border-radius: 8px;
+  background: var(--bg-elevated, #16161b);
+}
+.bg-jobs-rowhead {
+  display: flex;
+  align-items: flex-start;
+  gap: 10px;
+  width: 100%;
+  padding: 9px 11px;
+  border: 0;
+  background: transparent;
+  color: var(--fg);
+  text-align: left;
+  cursor: pointer;
+}
+.bg-jobs-rowhead:disabled {
+  cursor: default;
+}
+.bg-jobs-rowhead:not(:disabled):hover {
+  background: var(--bg-elevated-hover, rgba(255, 255, 255, 0.03));
+}
+.bg-jobs-icon {
+  flex: none;
+  margin-top: 1px;
+}
+.bg-jobs-meta {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  min-width: 0;
+}
+.bg-jobs-title {
+  font-size: 13px;
+  line-height: 1.35;
+}
+.bg-jobs-sub {
+  font-size: 11px;
+  color: var(--fg-secondary);
+  text-transform: capitalize;
+}
+.bg-jobs-ok {
+  color: var(--accent, #7c8cff);
+}
+.bg-jobs-fail {
+  color: var(--pl-color-status-error, #e5484d);
+}
+.bg-jobs-result {
+  padding: 4px 12px 12px 33px;
+  font-size: 13px;
+  border-top: 1px solid var(--border, #2a2a31);
+}
+
 .topbar {
   display: flex;
   align-items: center;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -2,6 +2,7 @@ import type {
   ActivityHistory,
   AgentConfig,
   Archetype,
+  BackgroundJobDTO,
   BeadsIssue,
   ChatMessage,
   ConfigPayload,
@@ -499,6 +500,13 @@ export const api = {
   // changes on every switch and would wrongly wipe the chat view each time.
   hostRuntimeStatus() {
     return request<RuntimeStatus>("/api/runtime/status", { host: true });
+  },
+
+  // Background subagent jobs (ADR 0050) — the focused agent's registry. Read-only;
+  // the UtilityBar pill + jobs dialog hydrate from this, then track live via the
+  // `background.{started,completed}` bus events.
+  background() {
+    return request<{ enabled: boolean; jobs: BackgroundJobDTO[] }>("/api/background");
   },
 
   telemetrySummary(since?: string) {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -310,6 +310,19 @@ export type ToolEvent = {
   error?: boolean; // an "end" that failed (phase "failed" on the wire) → card shows the X
 };
 
+// A background subagent job (ADR 0050) as returned by GET /api/background and
+// carried (partially) on the background.{started,completed} bus events.
+export type BackgroundJobDTO = {
+  id: string;
+  status: "running" | "completed" | "failed";
+  subagent_type: string;
+  description: string;
+  origin_session?: string;
+  result?: string;
+  created_at?: string;
+  completed_at?: string;
+};
+
 export type ChatMessage = {
   id?: string;
   role: "user" | "assistant" | "system";

--- a/docs/adr/0050-background-subagents-reactive-notifications.md
+++ b/docs/adr/0050-background-subagents-reactive-notifications.md
@@ -155,10 +155,23 @@ names the originating session so the agent can reference it. Gated by `BACKGROUN
 default; `=0` opts out, parity with `BACKGROUND_DISABLED`). `background.started` is published on
 spawn (Phase 1); `background.progress` remains a follow-up.
 
-### Phases 3–4 (planned, not in this ADR's PR)
-- **Phase 3 — chat UX.** A live status pill (`⟳ 2 agents running`), a background-jobs panel
-  (status / elapsed / stop), a completion toast + unread badge, and a rich live subagent card
-  in-transcript. Check `@protolabsai/ui/ai` (Conversation/Message/ToolCall) before hand-rolling.
+### Phase 3 — chat UX (shipped, except the live progress card)
+
+A `BackgroundJobs` widget in the console's `UtilityBar`: a **pill** that shows a spinner +
+running count while jobs are in flight and an **unread dot** when jobs finish, and a
+**dialog** listing each job (status icon, subagent + description, live elapsed, and the
+result rendered as markdown for finished jobs — expandable). It hydrates from
+`GET /api/background`, then tracks live off the `background.{started,completed}` bus events;
+opening the dialog clears the unread count. Completion toasts already shipped in Phase 1
+(`BackgroundWatch`). Read-only — stop/kill is Phase 4.
+
+**Deferred:** the *rich live subagent card in-transcript* (a per-tool progress feed like
+protocli's `AgentExecutionDisplay`). It needs a `background.progress` channel — background
+jobs run as detached A2A turns whose tool-by-tool frames aren't surfaced to the bus today.
+That progress channel + card is a follow-up. (`@protolabsai/ui/ai`'s ToolCall component is
+the thing to check first when it lands.)
+
+### Phase 4 (planned, not in this ADR's PR)
 - **Phase 4 — control + the runaway fix.** `task_output(id, block, timeout)` and `stop_task(id)`
   tools (cc-2.18's TaskOutput/TaskStop), and foreground→auto-background on a time budget so a
   long synchronous delegation transparently detaches and becomes killable — the direct cure for


### PR DESCRIPTION
## What

**Phase 3 of [ADR 0050](docs/adr/0050-background-subagents-reactive-notifications.md)** — a `BackgroundJobs` widget in the console `UtilityBar`:

- a **pill** that shows a spinner + running count while background subagents are in flight, and an **unread dot** when jobs finish;
- a **dialog** (click the pill) listing each job — status icon, subagent + description, **live elapsed**, and the **result rendered as markdown** for finished jobs (expandable).

It hydrates from `GET /api/background`, then tracks live off the `background.{started,completed}` bus events (scoped to this window's agent); opening the dialog clears the unread count. Completion toasts already shipped in Phase 1. **Read-only** — stop/kill is Phase 4.

## Notes

- Pure helpers (`fmtElapsed`/`byRecency`) live in `background-jobs.ts` so they're unit-testable without a react-dom import (the `.tsx` pulls in DS components that error in the node test env).
- `GET /api/background` already existed (Phase 1); this adds `api.background()` + a `BackgroundJobDTO` type.

## Deferred (filed as `bd-1sr`)

The **rich live per-tool progress card in the transcript** (à la protocli's `AgentExecutionDisplay`). It needs a `background.progress` channel — detached A2A background turns don't surface tool-by-tool frames to the bus today. That channel + card is a follow-up.

## Testing

`src/app/BackgroundJobs.test.ts` (4 cases: elapsed formatting, running-first + newest-first sort). `tsc --noEmit` + `vite build` clean; CSS-comment guard passes. Live-verified on the running console (rebuilt bundle served).

Closes `bd-1iw`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)