### PR TITLE
feat(chat): composer file upload — attach button, paste, drag-drop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   result rendered as markdown. Hydrates from `GET /api/background` and tracks live off the
   `background.{started,completed}` events. (A live per-tool progress card in the transcript is
   a follow-up — it needs a `background.progress` channel.)
+- **Chat file upload (composer UI).** The chat composer can now take attachments — an attach
+  button (DS `PromptInput`), **paste-to-attach**, and **drag-and-drop** — across txt/md/html/
+  pdf and audio/video. Each file is uploaded to the tiered attach endpoint on pick; small docs
+  are inlined into the message and large docs are indexed for retrieval (a big document is
+  never dumped into the turn). The attachment context is prepended to what the *model* receives
+  while the chat bubble shows only the typed text + a 📎 file list. Files are session-scoped and
+  cleaned up when the chat is deleted.
 - **Background subagents wake the agent on completion** (ADR 0050, Phase 2) — when a
   background job finishes, the agent now **reacts to the result autonomously** instead of
   only learning on the spawning chat's next message: the completion fires a turn into the

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -23,6 +23,18 @@ function messageId() {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+// A file being attached to the next message. Uploaded to /api/knowledge/attach on
+// pick; `context` is the backend's ready-to-prepend block (full text or lede).
+type PendingAttachment = {
+  id: string;
+  name: string;
+  kind: "file" | "image";
+  status: "uploading" | "ready" | "error";
+  context?: string;
+  mode?: "inline" | "indexed";
+  error?: string;
+};
+
 // Append an actionable pointer when a turn fails on something the operator can
 // fix in the UI — chiefly model auth (a bad/blank API key 401s). Keeps the raw
 // gateway detail (it's specific, e.g. "expected to start with 'sk-'") but tells
@@ -173,6 +185,36 @@ function ChatSessionSlot({
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
   const status = chat.sessionStatusMap[sessionId] || "idle";
 
+  // Pending file attachments. Each is uploaded to /api/knowledge/attach on pick;
+  // the backend tiers it (inline small / index large) and returns a `context`
+  // block we prepend to the SENT message (not the visible bubble) on send.
+  const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
+
+  async function uploadAttachment(file: File) {
+    const id = messageId();
+    const kind: "file" | "image" = file.type.startsWith("image/") ? "image" : "file";
+    setAttachments((a) => [...a, { id, name: file.name, kind, status: "uploading" }]);
+    try {
+      const form = new FormData();
+      form.append("file", file);
+      form.append("session_id", sessionId);
+      const r = await api.attachToChat(form);
+      if (!r.enabled || !r.context) throw new Error("attachment not accepted");
+      setAttachments((a) =>
+        a.map((x) => (x.id === id ? { ...x, status: "ready", context: r.context, mode: r.mode } : x)),
+      );
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      setAttachments((a) => a.map((x) => (x.id === id ? { ...x, status: "error", error: msg } : x)));
+      onError(`Couldn't attach ${file.name}: ${msg}`);
+    }
+  }
+
+  function removeAttachment(id: string) {
+    setAttachments((a) => a.filter((x) => x.id !== id));
+  }
+
   // Slash-command autocomplete. Commands the server handles (e.g. /goal) are
   // fetched once; the dropdown is active while typing "/name" (before a space).
   const [commands, setCommands] = useState<SlashCommand[]>([]);
@@ -320,9 +362,20 @@ function ChatSessionSlot({
 
   async function send() {
     if (!session || !canSend) return;
-    const content = draft.trim();
+    const text = draft.trim();
     setDraft("");
-    void runTurn(content);
+    const ready = attachments.filter((a) => a.status === "ready" && a.context);
+    if (ready.length === 0) {
+      void runTurn(text);
+      return;
+    }
+    // The model gets the attachment context blocks prepended; the user bubble
+    // shows only the typed text + a 📎 list (never the raw doc dump).
+    const sent = [...ready.map((a) => a.context as string), text].join("\n\n").trim();
+    const names = ready.map((a) => a.name).join(", ");
+    const display = text ? `${text}\n\n📎 ${names}` : `📎 ${names}`;
+    setAttachments([]);
+    void runTurn(display, { sendAs: sent });
   }
 
   // Resume a paused (input-required) turn: submitting the HITL form/question
@@ -338,8 +391,11 @@ function ChatSessionSlot({
     void runTurn(typeof response === "string" ? response : JSON.stringify(response), { hidden: silent });
   }
 
-  async function runTurn(content: string, opts: { hidden?: boolean } = {}) {
+  async function runTurn(content: string, opts: { hidden?: boolean; sendAs?: string } = {}) {
     if (!session || !content) return;
+    // `sendAs` (attachment context prepended) is what the MODEL receives; `content`
+    // is what the user bubble shows.
+    const sent = opts.sendAs ?? content;
     const userMessage: ChatMessage = {
       id: messageId(),
       role: "user",
@@ -371,7 +427,7 @@ function ChatSessionSlot({
     abortRef.current = controller;
 
     try {
-      await api.streamChat(userMessage.content, session.id, {
+      await api.streamChat(sent, session.id, {
         signal: controller.signal,
         onTaskId: (id) => {
           setTaskId(id);
@@ -593,6 +649,14 @@ function ChatSessionSlot({
           e.preventDefault(); // keep focus from leaving the field
           textareaRef.current?.focus();
         }}
+        onDragOver={(e) => { if (e.dataTransfer?.types?.includes("Files")) e.preventDefault(); }}
+        onDrop={(e) => {
+          const files = Array.from(e.dataTransfer?.files ?? []);
+          if (files.length) {
+            e.preventDefault();
+            files.forEach((f) => void uploadAttachment(f));
+          }
+        }}
       >
         {status === "streaming" && statusMessage ? (
           <div className="composer-status">
@@ -615,6 +679,27 @@ function ChatSessionSlot({
           placeholder="Message protoAgent  (/ for commands · Enter to send · ⌘/Ctrl+Enter for newline)"
           inputRef={textareaRef}
           onKeyDown={onComposerKeyDown}
+          onPaste={(e) => {
+            // Paste-to-attach (the DS onPaste seam): files on the clipboard become
+            // attachments; plain text paste falls through to the field.
+            const files = Array.from(e.clipboardData?.files ?? []);
+            if (files.length) {
+              e.preventDefault();
+              files.forEach((f) => void uploadAttachment(f));
+            }
+          }}
+          onAttach={() => fileInputRef.current?.click()}
+          attachments={attachments.map((a) => ({
+            id: a.id,
+            name: a.name,
+            kind: a.kind,
+            size:
+              a.status === "uploading" ? "uploading…"
+              : a.status === "error" ? "failed"
+              : a.mode === "indexed" ? "indexed for retrieval"
+              : undefined,
+          }))}
+          onRemoveAttachment={removeAttachment}
           overlay={slashActive ? (
             <div className="slash-menu" role="listbox">
               {slashMatches.map((cmd, index) => (
@@ -633,6 +718,21 @@ function ChatSessionSlot({
               ))}
             </div>
           ) : null}
+        />
+        <input
+          ref={fileInputRef}
+          type="file"
+          multiple
+          hidden
+          accept={
+            ".txt,.text,.log,.csv,.md,.markdown,.html,.htm,.pdf," +
+            ".mp3,.wav,.m4a,.flac,.ogg,.opus,.aac,.mp4,.mov,.mkv,.webm,.avi,.m4v"
+          }
+          onChange={(e) => {
+            const files = Array.from(e.target.files ?? []);
+            files.forEach((f) => void uploadAttachment(f));
+            e.target.value = ""; // allow re-picking the same file
+          }}
         />
         {/* Model control, under the input (ADR 0048) — a chip showing the active model
             alias; click to tune model / temperature / max tokens. Same field + cascade

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -576,6 +576,22 @@ export const api = {
     }>("/api/knowledge/ingest", form);
   },
 
+  // Chat attachment — extract + TIER a dropped file (FormData: `file` + `session_id`).
+  // Returns a ready-to-prepend `context` block (full text for small docs, a lede +
+  // retrieval note for large docs indexed under the session) so a big doc never
+  // gets dumped into the turn.
+  attachToChat(form: FormData) {
+    return requestForm<{
+      enabled: boolean;
+      mode?: "inline" | "indexed";
+      name?: string;
+      source_type?: string;
+      chars?: number;
+      chunks?: number;
+      context?: string;
+    }>("/api/knowledge/attach", form);
+  },
+
   deletePlaybook(id: number) {
     return request<{ enabled: boolean; deleted: boolean; error?: string }>(
       `/api/playbooks/${id}`,


### PR DESCRIPTION
## What

The **visible half** of chat attachments (bd-3dh), riding the tiered backend from #999. Completes the file-upload feature.

The composer now takes attachments three ways:
- **Attach button** (DS `PromptInput` `onAttach` → file picker)
- **Paste-to-attach** (the DS `onPaste` seam I upstreamed in #232)
- **Drag-and-drop** onto the composer

Accepts txt/md/html/pdf + audio/video. Removable chips show name + status (`uploading…` / `indexed for retrieval` / `failed`).

## The "don't dump the doc" flow, end to end

1. On pick/paste/drop, each file uploads to `/api/knowledge/attach` (`file` + `session_id`) immediately. The backend **tiers** it: small → inline, large → indexed under the session namespace (RAG), returning a `context` block.
2. On send, the ready attachments' `context` blocks are prepended to **what the model receives** (`runTurn` gains a `sendAs` opt) — while the **chat bubble shows only the typed text + a 📎 file list**, never the raw doc.
3. Files are session-scoped and cleaned up when the chat is deleted (#999).

## Verification

`tsc` + `vite` build clean; **full web e2e (97) green** (send/slash/streaming unaffected). `api.attachToChat` reuses the multipart `requestForm` helper.

**Note:** a typed message is still required to send (the DS send button enables on text) — file-only send is a small follow-up (needs the DS to count attachments in `canSubmit`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)