### PR TITLE
feat(chat): stream reasoning to a collapsible "thinking" view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   A foreground `task` delegation can also **auto-background** when it overruns a time budget
   (`BACKGROUND_AUTO_S`, off by default), so a long inline subagent stops freezing the turn.
   Canceled turns now record telemetry instead of vanishing.
+- **Reasoning display in chat** — the model's `<scratch_pad>` / provider `<think>` deliberation,
+  previously stripped server-side and never shown, now streams to the console as a **collapsible
+  "thinking" block** above the answer (DS `@protolabsai/ui/ai` `Reasoning`). It rides its own
+  channel — a `reasoning-v1` DataPart on WORKING status frames (`stream_visible_reasoning`
+  incrementally extracts scratch_pad/think; the executor emits it; the frontend accumulates it
+  into `message.reasoning`) — so the **answer artifact is untouched** and plain A2A consumers
+  ignore it. The block is open while the model is thinking and auto-collapses when the answer
+  begins.
 - **Background-jobs console widget** (ADR 0050, Phase 3) — a pill in the utility bar shows a
   spinner + count while background subagents run and an unread dot when they finish; clicking
   it opens a dialog listing each job's status, live elapsed time, and (for finished jobs) its

--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -52,6 +52,10 @@ logger = logging.getLogger(__name__)
 # with the same ``data_part`` wire primitive as the fleet extensions, so it
 # rides the 1.0 envelope identically — it's just not on the shared card.
 HITL_MIME = "application/vnd.protolabs.hitl-v1+json"
+# Streamed scratch_pad reasoning ("thinking") — carried on WORKING status frames as
+# a DataPart, distinct from the answer artifact, so the console can show a
+# collapsible reasoning view. Plain consumers ignore it.
+REASONING_MIME = "application/vnd.protolabs.reasoning-v1+json"
 
 @dataclass
 class TurnOutcome:
@@ -339,6 +343,16 @@ class ProtoAgentExecutor(AgentExecutor):
                     if isinstance(payload, dict):
                         _notify_progress(
                             context.context_id, context.task_id, {"phase": event_type, **payload}
+                        )
+
+                elif event_type == "reasoning":
+                    # Live "thinking" — a reasoning DataPart on a WORKING frame,
+                    # separate from the answer artifact (plain consumers ignore it).
+                    if payload:
+                        await updater.update_status(
+                            TaskState.TASK_STATE_WORKING,
+                            message=updater.new_agent_message(
+                                [_data_part_proto({"text": str(payload)}, REASONING_MIME)]),
                         )
 
                 elif event_type == "delta":

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1,6 +1,6 @@
 import "./chat.css";
 import { Empty } from "@protolabsai/ui/primitives";
-import { PromptInput } from "@protolabsai/ui/ai";
+import { PromptInput, Reasoning } from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
 import {
   Loader2,
@@ -486,6 +486,20 @@ function ChatSessionSlot({
             ),
           );
         },
+        onReasoning: (delta) => {
+          // Accumulate the streamed scratch_pad into the assistant message's
+          // collapsible reasoning block (separate from the answer text).
+          const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
+          if (!latest) return;
+          chatStore.updateMessages(
+            session.id,
+            latest.messages.map((message) =>
+              message.id === assistantId
+                ? { ...message, reasoning: `${message.reasoning ?? ""}${delta}` }
+                : message,
+            ),
+          );
+        },
         onToolCall: (evt) => {
           const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
           if (!latest) return;
@@ -609,6 +623,13 @@ function ChatSessionSlot({
             <article className={`message message-${message.role}`} key={message.id || `${message.role}-${message.createdAt}`}>
               <div className="message-role">{message.role}</div>
               <div className="message-body">
+                {message.reasoning ? (
+                  // Collapsible "thinking" — open while the model is still reasoning
+                  // (no answer text yet), auto-collapses once the answer starts.
+                  <Reasoning streaming={message.status === "streaming" && !message.content}>
+                    {message.reasoning}
+                  </Reasoning>
+                ) : null}
                 {message.toolCalls && message.toolCalls.length > 0 ? (
                   <ToolCalls calls={message.toolCalls} />
                 ) : null}
@@ -619,7 +640,9 @@ function ChatSessionSlot({
                       // ADR 0050) carry markdown — render it; only the user's own input
                       // stays literal.
                       <Markdown>{message.content}</Markdown>
-                  : message.status === "streaming" && !(message.toolCalls && message.toolCalls.length)
+                  : message.status === "streaming"
+                      && !(message.toolCalls && message.toolCalls.length)
+                      && !message.reasoning
                     ? <Loader2 className="spin" size={15} />
                     : null}
               </div>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -332,6 +332,7 @@ export function textFromParts(parts?: Array<{ kind?: string; text?: string }>) {
 
 const TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json";
 const HITL_MIME = "application/vnd.protolabs.hitl-v1+json";
+const REASONING_MIME = "application/vnd.protolabs.reasoning-v1+json";
 
 type RawPart = {
   kind?: string;
@@ -383,6 +384,12 @@ function toolEventFromParts(parts?: RawPart[]): ToolEvent | null {
 /** Pull the HITL form/question payload off an input-required frame's parts. */
 export function hitlFromParts(parts?: RawPart[]): HitlPayload | null {
   return (dataByMime(parts, HITL_MIME) as HitlPayload) || null;
+}
+
+/** Pull a streamed reasoning ("thinking") delta off a working frame's parts. */
+function reasoningFromParts(parts?: RawPart[]): string | null {
+  const d = dataByMime(parts, REASONING_MIME) as { text?: string } | null;
+  return d?.text || null;
 }
 
 function textFromTerminalTask(result: NonNullable<A2AFrame["result"]>) {
@@ -936,6 +943,7 @@ export const api = {
       onTaskId?: (taskId: string) => void;
       onStatus?: (status: string) => void;
       onText?: (text: string, append: boolean) => void;
+      onReasoning?: (delta: string) => void;
       onToolCall?: (evt: ToolEvent) => void;
       onInputRequired?: (payload: HitlPayload) => void;
       // Terminal failure (A2A `TASK_STATE_FAILED`) — e.g. the model rejected the
@@ -1034,7 +1042,10 @@ export const api = {
         const state = statusUpdate.status?.state || "";
         const parts = statusUpdate.status?.message?.parts;
         const messageText = textFromParts(parts);
-        handlers.onStatus?.(messageText || state);
+        const reasoning = reasoningFromParts(parts);
+        if (reasoning) handlers.onReasoning?.(reasoning);
+        // A reasoning-only frame shouldn't blank the status line to bare "working".
+        if (!reasoning) handlers.onStatus?.(messageText || state);
         const toolEvent = toolEventFromParts(parts);
         if (toolEvent) handlers.onToolCall?.(toolEvent);
         // HITL pause: the turn parked awaiting the operator (0.3 `input-required`

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -328,6 +328,9 @@ export type ChatMessage = {
   role: "user" | "assistant" | "system";
   content: string;
   toolCalls?: ToolCall[];
+  /** Streamed scratch_pad reasoning ("thinking") — rendered as a collapsible block
+   *  above the answer; never part of `content`. */
+  reasoning?: string;
   createdAt?: number;
   status?: "streaming" | "done" | "error";
   /** A2A task id for this turn — persisted so a stuck `streaming` message can be

--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -210,6 +210,43 @@ def stream_visible_output(raw: str) -> str:
     return after
 
 
+# Reasoning regions for live "thinking" display — the protocol scratch_pad and any
+# provider <think> block. Match open→content (with no nested reasoning tag) → close.
+_REASONING_BLOCK_RE = re.compile(
+    r"(?<!`)<(scratch_pad|think)>([\s\S]*?)</\1>", re.IGNORECASE)
+# A still-open trailing reasoning block (content runs to the end, no close yet).
+_REASONING_OPEN_TAIL_RE = re.compile(
+    r"(?<!`)<(scratch_pad|think)>((?:(?!</?(?:scratch_pad|think)>)[\s\S])*)$", re.IGNORECASE)
+
+
+def stream_visible_reasoning(raw: str) -> str:
+    """The model's reasoning so far — for a live, collapsible "thinking" view.
+
+    The counterpart to :func:`stream_visible_output`, but for the *hidden* side:
+    concatenates every ``<scratch_pad>`` / ``<think>`` block seen so far (so
+    multi-step turns show all their deliberation), plus any still-open trailing
+    block with a partial tag held back. Monotonic as ``raw`` grows, so a caller
+    can stream ``result[already_emitted:]`` each step. Empty until the first
+    reasoning tag opens.
+    """
+    chunks: list[str] = []
+    for m in _REASONING_BLOCK_RE.finditer(raw):
+        body = m.group(2).strip()
+        if body:
+            chunks.append(body)
+    tail = _REASONING_OPEN_TAIL_RE.search(raw)
+    if tail:
+        body = tail.group(2)
+        # Hold back a partial trailing tag ("</scr", a lone "<") so it never flashes.
+        lt = body.rfind("<")
+        if lt != -1 and ">" not in body[lt:]:
+            body = body[:lt]
+        body = body.strip()
+        if body:
+            chunks.append(body)
+    return "\n\n".join(chunks)
+
+
 def extract_confidence(text: str) -> tuple[float | None, str | None]:
     """Parse an optional self-reported ``<confidence>`` (and explanation).
 

--- a/server/chat.py
+++ b/server/chat.py
@@ -25,6 +25,7 @@ from graph.output_format import (
     extract_output,
     is_dropped_scratch_turn,
     stream_visible_output,
+    stream_visible_reasoning,
 )
 from runtime.state import STATE
 
@@ -227,6 +228,7 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
 
     accumulated_raw = ""
     streamed_len = 0  # chars of visible <output> already emitted as text frames
+    reasoned_len = 0  # chars of scratch_pad reasoning already emitted (live thinking)
     _llm_started: dict[str, float] = {}  # run_id → monotonic start (per-call latency)
     announced_tools: set[str] = set()  # tool_call ids already surfaced as a start frame
     async for event in STATE.graph.astream_events(
@@ -283,6 +285,12 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
                 if len(visible) > streamed_len:
                     yield ("text", visible[streamed_len:])
                     streamed_len = len(visible)
+                # Stream the scratch_pad reasoning on its own channel — a collapsible
+                # "thinking" view in the console (never folded into the answer text).
+                reasoning = stream_visible_reasoning(accumulated_raw)
+                if len(reasoning) > reasoned_len:
+                    yield ("reasoning", reasoning[reasoned_len:])
+                    reasoned_len = len(reasoning)
         elif kind == "on_chat_model_end":
             output = event.get("data", {}).get("output")
             # Finalize each tool card with its full args, keyed by the tool_call id.

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -20,6 +20,7 @@ from graph.output_format import (
     _strip_reasoning,
     extract_output,
     stream_visible_output,
+    stream_visible_reasoning,
 )
 
 
@@ -236,6 +237,45 @@ def test_stream_visible_orphan_open_streams_content():
 
 def test_stream_visible_closed_output():
     assert stream_visible_output("<output>the answer</output>") == "the answer"
+
+
+# ── stream_visible_reasoning (live "thinking" channel) ───────────────────────
+
+
+def test_stream_reasoning_empty_before_any_tag():
+    assert stream_visible_reasoning("") == ""
+    assert stream_visible_reasoning("no tags yet") == ""
+
+
+def test_stream_reasoning_open_block_streams_content():
+    assert stream_visible_reasoning("<scratch_pad>deciding which tool") == "deciding which tool"
+
+
+def test_stream_reasoning_holds_back_partial_close_tag():
+    # A half-written </scratch_pad> must not flash into the reasoning view.
+    assert stream_visible_reasoning("<scratch_pad>thinking</scratc") == "thinking"
+
+
+def test_stream_reasoning_is_monotonic_prefix():
+    # As raw grows, the result only ever extends — required for delta streaming.
+    steps = [
+        "<scratch_pad>step one",
+        "<scratch_pad>step one and two</scratch_pad><output>ans",
+    ]
+    a = stream_visible_reasoning(steps[0])
+    b = stream_visible_reasoning(steps[1])
+    assert b.startswith(a)
+    assert "step one and two" in b
+
+
+def test_stream_reasoning_concatenates_multiple_blocks():
+    raw = "<scratch_pad>plan A</scratch_pad><output>x</output><scratch_pad>plan B</scratch_pad>"
+    out = stream_visible_reasoning(raw)
+    assert "plan A" in out and "plan B" in out
+
+
+def test_stream_reasoning_includes_provider_think():
+    assert stream_visible_reasoning("<think>provider chain of thought</think>") == "provider chain of thought"
 
 
 def test_stream_visible_holds_back_partial_closing_tag():


### PR DESCRIPTION
## What

The model's `<scratch_pad>` / provider `<think>` deliberation was stripped server-side and never shown. This surfaces it as a **collapsible "thinking" block** above the answer (DS `@protolabsai/ui/ai` `Reasoning`) — your top ask for the chat-UX refresh.

It rides **its own channel** so the answer stream is untouched and plain A2A consumers ignore it.

## How (additive, low-risk)

- **`output_format.stream_visible_reasoning(raw)`** — incremental, monotonic extractor of all `<scratch_pad>`/`<think>` content (closed blocks + the still-open tail, with a partial trailing tag held back). The hidden-side counterpart to `stream_visible_output`.
- **`server/chat.py`** — emits `("reasoning", delta)` alongside the visible-output stream.
- **`a2a_impl/executor.py`** — a `"reasoning"` event becomes a `reasoning-v1` DataPart on a WORKING status frame (`REASONING_MIME`), distinct from the answer artifact.
- **frontend** — `api.ts` parses the reasoning DataPart → `onReasoning`; `ChatMessage.reasoning` accumulates the deltas; `ChatSurface` renders `<Reasoning streaming=…>` — open while thinking, auto-collapses when the answer starts (and suppresses the now-redundant spinner).

## Tests

`stream_visible_reasoning` (open block / held-back partial tag / monotonic prefix / multi-block / provider `<think>`). **Full suite 1931 passed**; e2e streaming green; ruff + import contracts clean; the DS `pl-reasoning*` styles bundle via `@protolabsai/ui/styles.css`.

Part of the chat-UX refresh (bd-39m). Next: DS message-thread adoption (copy/regenerate), native multimodal, file-only send.

🤖 Generated with [Claude Code](https://claude.com/claude-code)