### PR TITLE
feat(a2a): renderable components over the A2A envelope — show_component (ADR 0051 Slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Renderable chat components over A2A** (ADR 0051 Slice 2) — the agent can render
+  structured data as a real inline widget instead of a markdown blob, via a new
+  `show_component(component, props)` tool. It rides a typed `component-v1` DataPart on the A2A
+  envelope (same contract as tool-call/HITL parts) and renders through a curated, data-only
+  registry — **table**, **key-value/status**, and **timeline** — safe without a sandbox
+  (free-form generated UI still uses the artifact iframe path). New widgets are a registry
+  entry, not new transport.
 - **Background jobs: realtime progress + stop/inspect controls** (ADR 0051) — a detached
   background subagent's tool-by-tool progress now streams to the console: the jobs dialog
   shows a live `⊷ web_search ✓ fetch_url …` feed per running job (a new executor progress

--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -53,6 +53,11 @@ logger = logging.getLogger(__name__)
 # rides the 1.0 envelope identically — it's just not on the shared card.
 HITL_MIME = "application/vnd.protolabs.hitl-v1+json"
 
+# A renderable UI component (ADR 0051 Slice 2) — a typed, data-only widget the console
+# renders inline ({component, props}). Same DataPart contract as the HITL/tool-call parts.
+from graph.components import COMPONENT_MIME  # noqa: E402
+
+
 @dataclass
 class TurnOutcome:
     """Everything a host needs at the end of an A2A turn (ADR 0003 / 0006).
@@ -339,6 +344,18 @@ class ProtoAgentExecutor(AgentExecutor):
                     if isinstance(payload, dict):
                         _notify_progress(
                             context.context_id, context.task_id, {"phase": event_type, **payload}
+                        )
+
+                elif event_type == "component":
+                    # A renderable UI component (ADR 0051 Slice 2) — emit it as a
+                    # component-v1 DataPart on a working frame so the console renders it
+                    # inline immediately.
+                    if isinstance(payload, dict):
+                        await updater.update_status(
+                            TaskState.TASK_STATE_WORKING,
+                            message=updater.new_agent_message(
+                                [_data_part_proto(payload, COMPONENT_MIME)]
+                            ),
                         )
 
                 elif event_type == "delta":

--- a/apps/web/src/chat/ChatComponent.tsx
+++ b/apps/web/src/chat/ChatComponent.tsx
@@ -1,0 +1,120 @@
+import "./chat-component.css";
+
+import type { ComponentSpec } from "../lib/types";
+
+// Curated, data-only chat component registry (ADR 0051 Slice 2). Renders typed
+// component-v1 DataParts inline in the transcript. No code execution — props are pure
+// data, so this is safe without a sandbox (free-form generated UI uses the ADR 0038
+// iframe/artifact path instead). Unknown component types degrade to a labeled note.
+
+type Row = unknown[];
+
+function asString(v: unknown): string {
+  if (v === null || v === undefined) return "";
+  if (typeof v === "object") {
+    try {
+      return JSON.stringify(v);
+    } catch {
+      return String(v);
+    }
+  }
+  return String(v);
+}
+
+function Title({ props }: { props: Record<string, unknown> }) {
+  const t = typeof props.title === "string" ? props.title : "";
+  return t ? <div className="chat-comp-title">{t}</div> : null;
+}
+
+function TableComponent({ props }: { props: Record<string, unknown> }) {
+  const columns = Array.isArray(props.columns) ? (props.columns as unknown[]).map(asString) : [];
+  const rows = Array.isArray(props.rows) ? (props.rows as Row[]) : [];
+  return (
+    <div className="chat-comp chat-comp-table">
+      <Title props={props} />
+      <table>
+        {columns.length > 0 ? (
+          <thead>
+            <tr>
+              {columns.map((c, i) => (
+                <th key={i}>{c}</th>
+              ))}
+            </tr>
+          </thead>
+        ) : null}
+        <tbody>
+          {rows.map((r, ri) => (
+            <tr key={ri}>
+              {(Array.isArray(r) ? r : [r]).map((cell, ci) => (
+                <td key={ci}>{asString(cell)}</td>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function KeyValueComponent({ props }: { props: Record<string, unknown> }) {
+  const items = Array.isArray(props.items)
+    ? (props.items as Array<Record<string, unknown>>)
+    : Object.entries((props.pairs as Record<string, unknown>) || {}).map(([label, value]) => ({
+        label,
+        value,
+      }));
+  return (
+    <div className="chat-comp chat-comp-kv">
+      <Title props={props} />
+      <dl>
+        {items.map((it, i) => (
+          <div className="chat-comp-kv-row" key={i}>
+            <dt>{asString(it.label)}</dt>
+            <dd>{asString(it.value)}</dd>
+          </div>
+        ))}
+      </dl>
+    </div>
+  );
+}
+
+function TimelineComponent({ props }: { props: Record<string, unknown> }) {
+  const steps = Array.isArray(props.steps) ? (props.steps as Array<Record<string, unknown>>) : [];
+  return (
+    <div className="chat-comp chat-comp-timeline">
+      <Title props={props} />
+      <ol>
+        {steps.map((s, i) => {
+          const state = asString(s.state) || "todo";
+          return (
+            <li key={i} className={`chat-comp-step is-${state}`}>
+              <span className="chat-comp-step-dot" aria-hidden />
+              <span className="chat-comp-step-body">
+                <span className="chat-comp-step-label">{asString(s.label)}</span>
+                {s.detail ? <span className="chat-comp-step-detail">{asString(s.detail)}</span> : null}
+              </span>
+            </li>
+          );
+        })}
+      </ol>
+    </div>
+  );
+}
+
+const REGISTRY: Record<string, (p: { props: Record<string, unknown> }) => JSX.Element> = {
+  table: TableComponent,
+  keyvalue: KeyValueComponent,
+  timeline: TimelineComponent,
+};
+
+export function ChatComponent({ spec }: { spec: ComponentSpec }) {
+  const Renderer = REGISTRY[spec.component];
+  if (!Renderer) {
+    return <div className="chat-comp chat-comp-unknown">[unsupported component: {spec.component}]</div>;
+  }
+  try {
+    return <Renderer props={spec.props || {}} />;
+  } catch {
+    return <div className="chat-comp chat-comp-unknown">[failed to render {spec.component}]</div>;
+  }
+}

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -16,6 +16,7 @@ import type { ChatMessage, HitlPayload, SlashCommand, ToolCall } from "../lib/ty
 import { HitlForm } from "./HitlForm";
 import { notifyIfHidden } from "../lib/notify";
 import { chatStore, useChatState } from "./chat-store";
+import { ChatComponent } from "./ChatComponent";
 import { Markdown } from "./LazyMarkdown";
 import { ToolCalls } from "./ToolCalls";
 
@@ -530,6 +531,20 @@ function ChatSessionSlot({
             }),
           );
         },
+        onComponent: (spec) => {
+          // A renderable component (ADR 0051) — append to the assistant message; the
+          // registry renders it inline after the text.
+          const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
+          if (!latest) return;
+          chatStore.updateMessages(
+            session.id,
+            latest.messages.map((message) =>
+              message.id === assistantId
+                ? { ...message, components: [...(message.components || []), spec] }
+                : message,
+            ),
+          );
+        },
         onDone: () => {
           const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
           if (!latest) return;
@@ -619,9 +634,12 @@ function ChatSessionSlot({
                       // ADR 0050) carry markdown — render it; only the user's own input
                       // stays literal.
                       <Markdown>{message.content}</Markdown>
-                  : message.status === "streaming" && !(message.toolCalls && message.toolCalls.length)
+                  : message.status === "streaming" && !(message.toolCalls && message.toolCalls.length) && !(message.components && message.components.length)
                     ? <Loader2 className="spin" size={15} />
                     : null}
+                {message.components && message.components.length > 0
+                  ? message.components.map((spec, i) => <ChatComponent key={i} spec={spec} />)
+                  : null}
               </div>
             </article>
           ))

--- a/apps/web/src/chat/chat-component.css
+++ b/apps/web/src/chat/chat-component.css
@@ -1,0 +1,100 @@
+/* Inline chat components (ADR 0051 Slice 2) — table / key-value / timeline. */
+.chat-comp {
+  margin: 8px 0;
+  border: 1px solid var(--border, #2a2a31);
+  border-radius: 8px;
+  background: var(--bg-elevated, #16161b);
+  padding: 10px 12px;
+  font-size: 13px;
+  overflow-x: auto;
+}
+.chat-comp-title {
+  font-weight: 600;
+  margin-bottom: 8px;
+}
+
+/* table */
+.chat-comp-table table {
+  border-collapse: collapse;
+  width: 100%;
+}
+.chat-comp-table th,
+.chat-comp-table td {
+  text-align: left;
+  padding: 6px 10px;
+  border-bottom: 1px solid var(--border, #2a2a31);
+  vertical-align: top;
+}
+.chat-comp-table th {
+  font-weight: 600;
+  color: var(--fg-secondary);
+  font-size: 12px;
+}
+.chat-comp-table tr:last-child td {
+  border-bottom: 0;
+}
+
+/* key-value */
+.chat-comp-kv dl {
+  margin: 0;
+  display: grid;
+  grid-template-columns: minmax(0, max-content) 1fr;
+  gap: 4px 16px;
+}
+.chat-comp-kv-row {
+  display: contents;
+}
+.chat-comp-kv dt {
+  color: var(--fg-secondary);
+}
+.chat-comp-kv dd {
+  margin: 0;
+}
+
+/* timeline */
+.chat-comp-timeline ol {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+.chat-comp-step {
+  display: flex;
+  align-items: flex-start;
+  gap: 9px;
+}
+.chat-comp-step-dot {
+  flex: none;
+  width: 9px;
+  height: 9px;
+  margin-top: 4px;
+  border-radius: 999px;
+  border: 1.5px solid var(--fg-tertiary, #555);
+}
+.chat-comp-step.is-done .chat-comp-step-dot {
+  background: var(--accent, #7c8cff);
+  border-color: var(--accent, #7c8cff);
+}
+.chat-comp-step.is-active .chat-comp-step-dot {
+  border-color: var(--accent, #7c8cff);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--accent, #7c8cff) 25%, transparent);
+}
+.chat-comp-step-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1px;
+  min-width: 0;
+}
+.chat-comp-step-detail {
+  color: var(--fg-secondary);
+  font-size: 12px;
+}
+.chat-comp-step.is-done .chat-comp-step-label {
+  color: var(--fg-secondary);
+}
+.chat-comp-unknown {
+  color: var(--fg-secondary);
+  font-size: 12px;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -5,6 +5,7 @@ import type {
   BackgroundJobDTO,
   BeadsIssue,
   ChatMessage,
+  ComponentSpec,
   ConfigPayload,
   DelegateProbe,
   DelegateTypeSpec,
@@ -332,6 +333,7 @@ export function textFromParts(parts?: Array<{ kind?: string; text?: string }>) {
 
 const TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json";
 const HITL_MIME = "application/vnd.protolabs.hitl-v1+json";
+const COMPONENT_MIME = "application/vnd.protolabs.component-v1+json";
 
 type RawPart = {
   kind?: string;
@@ -381,6 +383,15 @@ function toolEventFromParts(parts?: RawPart[]): ToolEvent | null {
 }
 
 /** Pull the HITL form/question payload off an input-required frame's parts. */
+/** Decode a component-v1 DataPart (ADR 0051) → a {component, props} spec, or null. */
+export function componentFromParts(parts?: RawPart[]): ComponentSpec | null {
+  const d = dataByMime(parts, COMPONENT_MIME) as
+    | { component?: string; props?: Record<string, unknown> }
+    | undefined;
+  if (!d || typeof d.component !== "string") return null;
+  return { component: d.component, props: (d.props as Record<string, unknown>) || {} };
+}
+
 export function hitlFromParts(parts?: RawPart[]): HitlPayload | null {
   return (dataByMime(parts, HITL_MIME) as HitlPayload) || null;
 }
@@ -937,6 +948,7 @@ export const api = {
       onStatus?: (status: string) => void;
       onText?: (text: string, append: boolean) => void;
       onToolCall?: (evt: ToolEvent) => void;
+      onComponent?: (spec: ComponentSpec) => void;
       onInputRequired?: (payload: HitlPayload) => void;
       // Terminal failure (A2A `TASK_STATE_FAILED`) — e.g. the model rejected the
       // turn (bad API key → 401). Carries the gateway's error text. Without this
@@ -1037,6 +1049,8 @@ export const api = {
         handlers.onStatus?.(messageText || state);
         const toolEvent = toolEventFromParts(parts);
         if (toolEvent) handlers.onToolCall?.(toolEvent);
+        const component = componentFromParts(parts);
+        if (component) handlers.onComponent?.(component);
         // HITL pause: the turn parked awaiting the operator (0.3 `input-required`
         // / 1.0 `TASK_STATE_INPUT_REQUIRED`). Surface the form/question payload.
         if (state === "input-required" || state === "TASK_STATE_INPUT_REQUIRED") {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -323,11 +323,16 @@ export type BackgroundJobDTO = {
   completed_at?: string;
 };
 
+// A renderable UI component (ADR 0051 Slice 2) carried on a component-v1 DataPart and
+// rendered inline by the curated chat component registry.
+export type ComponentSpec = { component: string; props: Record<string, unknown> };
+
 export type ChatMessage = {
   id?: string;
   role: "user" | "assistant" | "system";
   content: string;
   toolCalls?: ToolCall[];
+  components?: ComponentSpec[];
   createdAt?: number;
   status?: "streaming" | "done" | "error";
   /** A2A task id for this turn — persisted so a stuck `streaming` message can be

--- a/docs/adr/0051-a2a-realtime-streaming-and-component-rendering.md
+++ b/docs/adr/0051-a2a-realtime-streaming-and-component-rendering.md
@@ -67,11 +67,20 @@ Expose the realtime stream of any turn through a small **executor progress/lifec
 
 ### Slice 2 — component rendering (generative-UI path A)
 
-A typed **`application/vnd.protolabs.component-v1+json`** DataPart `{component, props}` (e.g.
-`table`/`chart`/`timeline`/`status`), emitted over the A2A envelope like any other DataPart,
-decoded by a new `componentFromParts`, and rendered inline in chat by a **curated registry**
-of data-only widgets (no code execution → safe without a sandbox). Free-form generated UI
-stays on the ADR 0038 sandboxed-iframe path (the `artifact` plugin).
+Shipped. A typed **`application/vnd.protolabs.component-v1+json`** DataPart `{component, props}`,
+emitted over the A2A envelope like any other DataPart, decoded by `componentFromParts`, and
+rendered inline in chat by a **curated registry** of data-only widgets (no code execution →
+safe without a sandbox). Free-form generated UI stays on the ADR 0038 sandboxed-iframe path
+(the `artifact` plugin).
+
+The agent calls a **`show_component(component, props, title?)`** tool; its return carries the
+payload past the LangGraph stream behind a sentinel (`graph/components.py`), which
+`server/chat.py` lifts into a `("component", …)` frame on `on_tool_end` (stripping the
+sentinel from the tool card), and the executor emits as the DataPart — the same relay as the
+realtime hooks, reusing the `tool-call-v1`/`hitl-v1` decode+render pipeline. Widgets in the
+first registry: **`table`** (columns/rows), **`keyvalue`** (label/value items), **`timeline`**
+(steps with done/active/todo state). Chart was deliberately skipped (would add a charting
+dep); a new widget is a registry entry + a render fn, no new transport.
 
 ### Slice 3 — alignment polish
 

--- a/graph/components.py
+++ b/graph/components.py
@@ -1,0 +1,55 @@
+"""Renderable UI components over the A2A envelope (ADR 0051 Slice 2).
+
+The agent calls the ``show_component`` tool to render a typed, data-only widget inline
+in the chat. The tool's return value carries the payload past the LangGraph stream via a
+sentinel; ``server/chat.py`` extracts it into a ``("component", payload)`` frame, and the
+A2A executor emits it as a ``component-v1`` DataPart — the same typed-DataPart contract as
+``tool-call-v1``/``hitl-v1``. The console decodes the MIME and renders a curated widget
+(no code execution → safe without a sandbox; free-form generated UI stays on the ADR 0038
+iframe/artifact path).
+"""
+
+from __future__ import annotations
+
+import json
+
+# MIME the executor stamps on the DataPart and the console matches on.
+COMPONENT_MIME = "application/vnd.protolabs.component-v1+json"
+
+# The curated widgets the console knows how to render (ADR 0051 Slice 2).
+COMPONENT_TYPES = ("table", "keyvalue", "timeline")
+
+# A marker (record-separator char) prepended to the tool's return so the chat stream can
+# recover the structured payload without the model needing to emit raw wire JSON.
+_SENTINEL = "\x1e[component-v1]"
+
+
+def encode_component(component: str, props: dict) -> str:
+    """Serialize a component payload behind the sentinel, for a tool return value."""
+    return _SENTINEL + json.dumps({"component": component, "props": props}, ensure_ascii=False)
+
+
+def extract_component(text: str) -> dict | None:
+    """Parse a ``{component, props}`` payload out of a sentinel-bearing string, or None.
+    Validates the component type so a malformed/unknown payload is ignored."""
+    if not isinstance(text, str):
+        return None
+    i = text.find(_SENTINEL)
+    if i < 0:
+        return None
+    try:
+        payload = json.loads(text[i + len(_SENTINEL):])
+    except (ValueError, TypeError):
+        return None
+    if not isinstance(payload, dict) or payload.get("component") not in COMPONENT_TYPES:
+        return None
+    props = payload.get("props")
+    return {"component": payload["component"], "props": props if isinstance(props, dict) else {}}
+
+
+def strip_component(text: str) -> str:
+    """Drop the sentinel + payload tail from a tool result, leaving the human prefix."""
+    if not isinstance(text, str):
+        return text
+    i = text.find(_SENTINEL)
+    return text[:i].rstrip() if i >= 0 else text

--- a/server/chat.py
+++ b/server/chat.py
@@ -255,10 +255,20 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
             # the ToolNode stamped status="error" (a raised tool — a declined
             # run_command, an execution error, an enforcement block) closes the card
             # as a failure (X) instead of a green "done".
+            coerced = _coerce_tool_output(output)
+            # A show_component result (ADR 0051) carries a sentinel-wrapped payload — lift
+            # it into a `component` frame (→ a component-v1 DataPart) and strip it from the
+            # card so the user sees the rendered widget, not raw wire JSON.
+            if isinstance(coerced, str):
+                from graph.components import extract_component, strip_component
+                comp = extract_component(coerced)
+                if comp is not None:
+                    yield ("component", comp)
+                    coerced = strip_component(coerced)
             yield ("tool_end", {
                 "id": getattr(output, "tool_call_id", None) or event.get("run_id") or name,
                 "name": name,
-                "output": _coerce_tool_output(output),
+                "output": coerced,
                 "error": getattr(output, "status", None) == "error",
             })
         elif kind == "on_chat_model_stream":

--- a/tests/test_components.py
+++ b/tests/test_components.py
@@ -1,0 +1,69 @@
+"""Tests for renderable chat components over A2A (ADR 0051 Slice 2) — the codec
+(graph/components.py) and the show_component tool."""
+
+from __future__ import annotations
+
+from graph.components import (
+    COMPONENT_MIME,
+    COMPONENT_TYPES,
+    encode_component,
+    extract_component,
+    strip_component,
+)
+
+
+class TestCodec:
+    def test_roundtrip(self):
+        s = "Rendered a table component. " + encode_component(
+            "table", {"columns": ["A", "B"], "rows": [["1", "2"]]}
+        )
+        got = extract_component(s)
+        assert got == {"component": "table", "props": {"columns": ["A", "B"], "rows": [["1", "2"]]}}
+        assert strip_component(s) == "Rendered a table component."
+
+    def test_unknown_component_type_rejected(self):
+        s = encode_component("table", {})  # encode is dumb; tamper the type
+        s = s.replace('"table"', '"nope"')
+        assert extract_component(s) is None
+
+    def test_no_sentinel_returns_none(self):
+        assert extract_component("just a normal tool result") is None
+        assert strip_component("just a normal tool result") == "just a normal tool result"
+
+    def test_malformed_json_returns_none(self):
+        from graph.components import _SENTINEL
+
+        assert extract_component(_SENTINEL + "{not json") is None
+
+    def test_props_defaults_to_empty_dict(self):
+        s = encode_component("keyvalue", {"items": []})
+        s = s.replace('{"items": []}', "null")  # props=null on the wire
+        got = extract_component(s)
+        assert got is not None and got["props"] == {}
+
+    def test_mime_and_types(self):
+        assert COMPONENT_MIME.endswith("component-v1+json")
+        assert set(COMPONENT_TYPES) == {"table", "keyvalue", "timeline"}
+
+
+class TestShowComponentTool:
+    def _tool(self):
+        from tools.lg_tools import get_all_tools
+
+        tools = {t.name: t for t in get_all_tools()}
+        return tools["show_component"]
+
+    async def test_valid_emits_sentinel_payload(self):
+        out = await self._tool().ainvoke(
+            {"component": "keyvalue", "props": {"items": [{"label": "Credits", "value": "183k"}]}, "title": "Wallet"}
+        )
+        comp = extract_component(out)
+        assert comp is not None
+        assert comp["component"] == "keyvalue"
+        assert comp["props"]["title"] == "Wallet"  # title folded into props
+        assert comp["props"]["items"] == [{"label": "Credits", "value": "183k"}]
+
+    async def test_unknown_component_errors_without_sentinel(self):
+        out = await self._tool().ainvoke({"component": "barchart", "props": {}})
+        assert out.startswith("Error:")
+        assert extract_component(out) is None

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -102,6 +102,36 @@ def request_user_input(title: str, steps: list[dict], description: str = "") -> 
 
 
 @tool
+def show_component(component: str, props: dict, title: str = "") -> str:
+    """Render a structured UI component inline in the chat (ADR 0051).
+
+    Use this to present structured data as a real widget instead of a markdown blob —
+    a comparison table, a status/metrics block, a plan/timeline. Data-only and safe;
+    for free-form generated HTML use an artifact instead.
+
+    Args:
+        component: one of ``"table"``, ``"keyvalue"``, ``"timeline"``.
+        props: the component's data:
+            - table:    ``{"columns": ["A","B"], "rows": [["a1","b1"], ...]}``
+            - keyvalue: ``{"items": [{"label": "Credits", "value": "183k"}, ...]}``
+            - timeline: ``{"steps": [{"label": "Buy hauler", "state": "done|active|todo",
+                          "detail": "…"}, ...]}``
+        title: optional heading shown above the component.
+
+    Renders immediately for the user; also briefly summarize the data in your text reply
+    (the component is a visual aid, not a substitute for your answer).
+    """
+    from graph.components import COMPONENT_TYPES, encode_component
+
+    if component not in COMPONENT_TYPES:
+        return f"Error: unknown component '{component}'. Use one of: {', '.join(COMPONENT_TYPES)}."
+    payload = dict(props or {})
+    if title and "title" not in payload:
+        payload["title"] = title
+    return f"Rendered a {component} component for the user. " + encode_component(component, payload)
+
+
+@tool
 @with_fallback()
 async def current_time(timezone: str = "UTC") -> str:
     """Return the current wall-clock time in the given IANA timezone.
@@ -747,7 +777,8 @@ def get_all_tools(knowledge_store=None, scheduler=None, inbox_store=None,
     # LangGraph interrupt that only the lead turn's runner resumes. Subagents
     # (run outside that runner) must not get it, so it's gated by allowlist:
     # present in the full set for the lead agent, absent from subagent allowlists.
-    tools = [current_time, calculator, web_search, fetch_url, ask_human, request_user_input]
+    tools = [current_time, calculator, web_search, fetch_url, ask_human, request_user_input,
+             show_component]
     # GitHub read tools (PRs/issues/commits) moved to the first-party `github`
     # plugin (opt-in) — not everyone needs them. Enable with plugins.enabled: [github].
     # Notes tools now ship with the first-party `notes` plugin (ADR 0034 S4):


### PR DESCRIPTION
## What

**ADR 0051 Slice 2 — component rendering.** The agent can now render structured data as a real inline widget instead of a markdown blob, via a **`show_component(component, props, title?)`** tool, carried over the **A2A envelope** as a typed `component-v1` DataPart and rendered by a **curated, data-only registry**:

- **table** — `{columns, rows}`
- **keyvalue** — `{items: [{label, value}]}` (or `{pairs}`) — status/metrics blocks
- **timeline** — `{steps: [{label, state: done|active|todo, detail}]}`

No code execution (props are pure data) → safe without a sandbox. Free-form generated UI stays on the ADR 0038 artifact/iframe path. Chart was intentionally skipped (would add a charting dep); a new widget is a registry entry + render fn, **not** new transport.

## How (reuses the proven DataPart pipeline)

`show_component`'s return carries the payload past the LangGraph stream behind a sentinel (`graph/components.py`); `server/chat.py` lifts it into a `("component", …)` frame on `on_tool_end` (stripping the sentinel from the tool card); the executor emits it as a `component-v1` DataPart on a working frame — the same relay as the Slice 1 hooks. The console decodes via `componentFromParts` (mirrors `toolEventFromParts`/`hitlFromParts`) → `onComponent` → `<ChatComponent>` renders inline.

## Reconciled with #1004

This branch merges `origin/main` (#1004 reasoning display) and resolves the 4 chat-streaming conflicts — both features coexist (the executor has both `component` and `reasoning` event branches; the message renders reasoning + components + tools; both MIMEs/decoders present). Verified post-merge.

## Testing

`tests/test_components.py` (codec roundtrip / unknown-type / malformed / null-props; `show_component` valid + error). Full backend suite + `ruff check .` clean; web `tsc`+`vite build`+CSS-guard clean; web vitest green. (Backend changes need a server restart to go live.)

Slice 3 (alignment polish) is the remaining follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)