### PR TITLE
feat(a2a): scheduler.fired bus event + orphaned push-config sweep (ADR 0051 Slice 3 follow-ups)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **`scheduler.fired` event + orphaned push-config sweep** (ADR 0051 Slice 3 follow-ups) —
+  a scheduled job dispatching now publishes `scheduler.fired` on the event bus (live
+  visibility into cron/one-shot fires). And push-notification configs whose task no longer
+  exists are now swept (at boot + on the periodic task-prune tick) — the SDK store has no
+  TTL, so stale webhook configs previously persisted forever; their lifetime is now tied to
+  the task.
 - **A2A alignment polish + realtime cost/goal events** (ADR 0051 Slice 3) — fixed a real
   bug: the **delegate A2A client now sends `A2A-Version: 1.0`** (a missing header made a
   strict 1.0 peer reject the call with `-32009`). The agent card now advertises a

--- a/a2a_impl/stores.py
+++ b/a2a_impl/stores.py
@@ -35,7 +35,7 @@ from pathlib import Path
 from urllib.parse import urlparse
 
 import httpx
-from sqlalchemy import delete, update
+from sqlalchemy import bindparam, delete, select, text, update
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
 from a2a.server.context import ServerCallContext
@@ -307,6 +307,43 @@ async def sweep_expired_tasks(
         return result.rowcount or 0
 
 
+async def sweep_orphaned_push_configs(
+    task_engine: AsyncEngine, push_engine: AsyncEngine
+) -> int:
+    """Delete push-notification configs whose task no longer exists (ADR 0051 Slice 3).
+
+    The SDK push-config store has no timestamp/TTL knob, so a registered webhook config
+    persists forever — even after its task is TTL-swept (``sweep_expired_tasks``). Tie the
+    config's lifetime to the task: read the live task ids, then drop push rows whose
+    ``task_id`` isn't among them. Task + push live in separate SQLite files, so this is a
+    two-step read-then-delete (no cross-DB join). Best-effort + SDK-table-tolerant: a
+    no-op (returns 0) if the push table is absent or renamed by an SDK upgrade.
+    Returns the rows deleted."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker
+
+    tsm = async_sessionmaker(task_engine, expire_on_commit=False)
+    async with tsm() as s:
+        live = {r[0] for r in (await s.execute(select(TaskModel.id))).all()}
+
+    psm = async_sessionmaker(push_engine, expire_on_commit=False)
+    async with psm() as s:
+        try:
+            rows = (await s.execute(
+                text("SELECT DISTINCT task_id FROM push_notification_configs")
+            )).all()
+        except Exception:  # noqa: BLE001 — table absent/renamed (SDK change): no-op
+            return 0
+        orphans = [r[0] for r in rows if r[0] not in live]
+        if not orphans:
+            return 0
+        stmt = text(
+            "DELETE FROM push_notification_configs WHERE task_id IN :ids"
+        ).bindparams(bindparam("ids", expanding=True))
+        res = await s.execute(stmt, {"ids": orphans})
+        await s.commit()
+        return res.rowcount or len(orphans)
+
+
 # Non-terminal states a restart leaves dead: a queued (``submitted``) or
 # mid-flight (``working``) task can never progress once its LangGraph runner is
 # gone. We deliberately do NOT touch ``input_required`` / ``auth_required`` —
@@ -392,3 +429,9 @@ async def initialize_a2a_stores(
             log.info("[a2a] swept %d expired task record(s) (24h TTL)", n)
     except Exception:
         log.exception("[a2a] task TTL sweep failed; continuing")
+    try:
+        p = await sweep_orphaned_push_configs(task_store.engine, push_store.engine)
+        if p:
+            log.info("[a2a] swept %d orphaned push-config(s) (ADR 0051)", p)
+    except Exception:
+        log.exception("[a2a] push-config sweep failed; continuing")

--- a/docs/adr/0051-a2a-realtime-streaming-and-component-rendering.md
+++ b/docs/adr/0051-a2a-realtime-streaming-and-component-rendering.md
@@ -97,8 +97,13 @@ dep); a new widget is a registry entry + a render fn, no new transport.
   telemetry store → a live cost HUD) and `goal.iteration` (the goal loop's per-continuation
   progress, previously only `goal.achieved`/`failed` were on the bus).
 
-Deferred (noted in `bd-383`): `scheduler.fired` (needs bus injection into the scheduler),
-push-config TTL, and verifying push fires on terminal.
+Slice 3 follow-ups (after the initial PR): **`scheduler.fired`** now fires on the bus (the
+scheduler got the same injected-`publish` treatment as the background manager), and
+**orphaned push-configs are swept** — the SDK push store has no timestamp, so instead of a
+TTL the config's lifetime is tied to its task: `sweep_orphaned_push_configs` drops push rows
+whose `task_id` is no longer a live task, run at boot + on the periodic task-prune tick.
+Still open: verifying push actually fires on a terminal turn (the executor enqueues no
+explicit `PushNotificationEvent`).
 
 ## Consequences
 

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -33,6 +33,7 @@ class AppState:
     # prune loop can re-run the 24h TTL sweep (it used to run only at boot, so
     # an always-on agent accumulated task rows forever between restarts).
     a2a_task_engine: Any = None
+    a2a_push_engine: Any = None  # push-config store engine — for the orphan sweep (ADR 0051)
     inbox_store: Any = None
     beads_store: Any = None
     storm_guard: Any = None

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -207,11 +207,15 @@ class LocalScheduler:
         api_key: str | None = None,
         bearer_token: str | None = None,
         db_dir: str | Path | None = None,
+        event_publish=None,
     ):
         self.agent_name = agent_name
         self._invoke_url = invoke_url.rstrip("/")
         self._api_key = api_key or ""
         self._bearer = bearer_token or ""
+        # (topic, data) -> None — the server's event bus, so a console sees a
+        # ``scheduler.fired`` event when a cron/one-shot job dispatches (ADR 0051). Optional.
+        self._publish = event_publish
         self.path = _resolve_db_path(db_dir, agent_name)
         self._task: asyncio.Task | None = None
         self._stopping = False
@@ -531,6 +535,18 @@ class LocalScheduler:
             headers["Authorization"] = f"Bearer {self._bearer}"
         if self._api_key:
             headers["X-API-Key"] = self._api_key
+
+        # Realtime: announce the dispatch on the bus (ADR 0051) so a console shows the
+        # scheduled job firing — before the POST, which blocks for the whole turn.
+        if self._publish is not None:
+            try:
+                self._publish("scheduler.fired", {
+                    "job_id": job.id,
+                    "schedule": job.schedule,
+                    "prompt": (job.prompt or "")[:200],
+                })
+            except Exception:  # noqa: BLE001 — the event is best-effort
+                log.exception("[scheduler] fired-event publish failed for %s", job.id)
 
         message_id = str(uuid.uuid4())
         body = {

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -736,6 +736,7 @@ def _main():
     # running on an always-on agent (boot-only before — rows grew unbounded
     # between restarts).
     STATE.a2a_task_engine = task_store.engine
+    STATE.a2a_push_engine = push_config_store.engine  # for the orphan push-config sweep (ADR 0051)
     log.info("[a2a] durable stores ready (tasks=%s, push=%s)", task_db, push_db)
 
     async def _structured_finalizer(skill_id: str, final_text: str):

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -683,6 +683,14 @@ async def _checkpoint_prune_loop() -> None:
                 swept = await sweep_expired_tasks(STATE.a2a_task_engine)
                 if swept:
                     log.info("[a2a-task-prune] removed %d expired task record(s) (24h TTL)", swept)
+                # Drop push-notification configs orphaned by the task sweep (ADR 0051).
+                if STATE.a2a_push_engine is not None:
+                    from a2a_impl.stores import sweep_orphaned_push_configs
+                    orphaned = await sweep_orphaned_push_configs(
+                        STATE.a2a_task_engine, STATE.a2a_push_engine
+                    )
+                    if orphaned:
+                        log.info("[a2a-task-prune] removed %d orphaned push-config(s)", orphaned)
             except Exception:
                 log.exception("[a2a-task-prune] sweep failed")
         # Tick at the checkpoint interval if set, else hourly (so telemetry pruning
@@ -1041,11 +1049,17 @@ def _build_scheduler(config) -> "SchedulerBackend | None":
         # break self-invocation auth.
         api_key_env = f"{AGENT_NAME_ENV.upper()}_API_KEY"
         api_key = os.environ.get(api_key_env, "").strip()
+        try:
+            from server import _event_bus
+            publish = _event_bus.publish
+        except Exception:  # noqa: BLE001
+            publish = None
         return LocalScheduler(
             agent_name=name,
             invoke_url=invoke_url,
             api_key=api_key,
             bearer_token=bearer,
+            event_publish=publish,  # scheduler.fired on the bus (ADR 0051)
         )
     except Exception as exc:
         log.warning(

--- a/tests/test_a2a_stores.py
+++ b/tests/test_a2a_stores.py
@@ -26,6 +26,7 @@ from a2a_impl.stores import (
     make_sqlite_engine,
     reconcile_interrupted_tasks,
     sweep_expired_tasks,
+    sweep_orphaned_push_configs,
 )
 from a2a.server.tasks import DatabaseTaskStore
 
@@ -132,6 +133,34 @@ async def test_task_ttl_sweep_evicts_old_rows(tmp_path):
     assert await store.get("stale", ctx) is None
     assert await store.get("fresh", ctx) is not None
     await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_orphaned_push_config_sweep(tmp_path):
+    """sweep_orphaned_push_configs drops push configs whose task is gone (ADR 0051),
+    keeps configs for live tasks."""
+    from a2a.types import a2a_pb2
+
+    ctx = _ctx()
+    task_engine = make_sqlite_engine(str(tmp_path / "a2a-tasks.db"))
+    task_store = DatabaseTaskStore(task_engine)
+    await task_store.initialize()
+    await task_store.save(a2a_pb2.Task(id="live", context_id="c"), ctx)
+
+    push_store, push_engine = await _fresh_push_store(str(tmp_path / "a2a-push.db"))
+    for tid in ("live", "gone"):
+        await push_store.set_info(
+            tid,
+            TaskPushNotificationConfig(task_id=tid, id="cfg", url="https://8.8.8.8/hook", token="t"),
+            ctx,
+        )
+
+    swept = await sweep_orphaned_push_configs(task_engine, push_engine)
+    assert swept == 1
+    assert await push_store.get_info("gone", ctx) == []
+    assert len(await push_store.get_info("live", ctx)) == 1
+    await task_engine.dispose()
+    await push_engine.dispose()
 
 
 # ── (a2) restart reconciliation: interrupted tasks fail, not linger (#486) ───────

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -299,6 +299,45 @@ async def test_due_job_fires(tmp_path, monkeypatch):
     assert msg["metadata"]["origin"] == "scheduler"
 
 
+async def test_fire_publishes_scheduler_fired_event(tmp_path, monkeypatch):
+    """A dispatched job publishes `scheduler.fired` on the bus (ADR 0051)."""
+    events: list = []
+    s = LocalScheduler(
+        agent_name="gina-test", invoke_url="http://127.0.0.1:7870",
+        api_key="k", bearer_token="b", db_dir=tmp_path,
+        event_publish=lambda topic, data: events.append((topic, data)),
+    )
+    past = (datetime.now(UTC) - timedelta(seconds=1)).isoformat()
+    s.add_job("nightly audit", past, job_id="firetest")
+
+    class _FakeResponse:
+        status_code = 200
+        text = "ok"
+
+    class _FakeClient:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def post(self, *_a, **_kw):
+            return _FakeResponse()
+
+    import httpx
+    monkeypatch.setattr(httpx, "AsyncClient", _FakeClient)
+    await s.start()
+    await asyncio.sleep(1.5)
+    await s.stop()
+
+    fired = [d for (t, d) in events if t == "scheduler.fired"]
+    assert fired and fired[0]["job_id"] == "firetest"
+    assert fired[0]["prompt"] == "nightly audit"
+
+
 @pytest.mark.asyncio
 async def test_fire_failure_leaves_job_in_place(tmp_path, monkeypatch):
     """A 5xx HTTP response from /a2a must NOT delete the job.


### PR DESCRIPTION
## What

The two deferred ADR 0051 Slice 3 items — both **entirely outside the chat-streaming files** (zero overlap with the other team's stream).

- **`scheduler.fired` event.** `LocalScheduler` gets an injected `event_publish` (same pattern as the background manager) and publishes `scheduler.fired` `{job_id, schedule, prompt}` when a cron/one-shot job dispatches — live visibility into scheduled fires on the bus.
- **Orphaned push-config sweep.** The SDK push-config store has no timestamp/TTL, so a registered webhook config persisted **forever** (even after its task was 24h-TTL-swept). `sweep_orphaned_push_configs` ties config lifetime to the task: reads the live task ids and drops push rows whose `task_id` is no longer a live task (across the separate task/push SQLite files). Runs at boot (`initialize_a2a_stores`) **and** on the periodic task-prune tick. SDK-table-tolerant — no-op if the table is renamed by an upgrade.

## Testing

- `test_a2a_stores.py::test_orphaned_push_config_sweep` — keeps the live task's config, drops the gone one.
- `test_scheduler_local.py::test_fire_publishes_scheduler_fired_event` — asserts the event fires on dispatch.
- Full backend suite green (the only reds are the 3 pre-existing `test_config_roundtrip` local-env failures that pass in CI); `ruff check .` clean.

Still open (noted on `bd-383`): verify push actually fires on a terminal turn (the executor enqueues no explicit `PushNotificationEvent`) — lower-value, left for later.

This is the **last** of the ADR 0050 + 0051 work.

🤖 Generated with [Claude Code](https://claude.com/claude-code)