### PR TITLE
feat(chat): model picker in the DS composer actions slot, drop the custom chip

### DIFF
--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -14,14 +14,18 @@ test("the topbar gear opens the Settings overlay (the two-home one-stop-shop)", 
   await expect(dialog.getByRole("button", { name: "Workspace", exact: true })).toBeVisible();
 });
 
-test("the chat composer model chip edits a field in a dialog and saves", async ({ page }) => {
+test("the chat composer model picker selects a model and saves", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  // The model control lives on the chat composer (the default surface), by the input.
-  await page.getByRole("button", { name: "Model settings" }).click();
-  const dialog = page.getByRole("dialog", { name: "Model" });
-  await expect(dialog).toBeVisible();
-  await expect(dialog.getByText("Primary model")).toBeVisible(); // model.name field
-  await dialog.locator('.setting-row[data-key="model.temperature"] input').fill("0.5");
-  await dialog.getByRole("button", { name: "Save", exact: true }).click();
-  await expect(dialog).toBeHidden(); // saved → closes
+  // The model picker lives inline in the DS composer's actions slot (a <select>),
+  // wired to the `model.name` settings field (host-scoped). Selecting saves immediately.
+  const model = page.getByRole("combobox", { name: "Model" });
+  await expect(model).toBeVisible();
+  await expect(model).toHaveValue("protolabs/reasoning"); // current model from the schema
+  const saved = page.waitForRequest(
+    (r) => r.url().endsWith("/api/settings") && r.method() === "POST",
+  );
+  await model.selectOption("protolabs/fast");
+  const body = (await saved).postDataJSON();
+  expect(body.updates["model.name"]).toBe("protolabs/fast");
+  expect(body.layer).toBe("host"); // model.name is host-scoped → saved to the host layer
 });

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -4,19 +4,18 @@ import { PromptInput, Reasoning } from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
 import {
   Loader2,
-  SlidersHorizontal,
   TerminalSquare,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 
 import { api } from "../lib/api";
-import { QuickSetting } from "../settings/QuickSetting";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import type { ChatMessage, HitlPayload, SlashCommand, ToolCall } from "../lib/types";
 import { HitlForm } from "./HitlForm";
 import { notifyIfHidden } from "../lib/notify";
 import { chatStore, useChatState } from "./chat-store";
 import { ChatComponent } from "./ChatComponent";
+import { ComposerModelSelect } from "./ComposerModelSelect";
 import { Markdown } from "./LazyMarkdown";
 import { ToolCalls } from "./ToolCalls";
 
@@ -731,6 +730,9 @@ function ChatSessionSlot({
             }
           }}
           onAttach={() => fileInputRef.current?.click()}
+          // The model picker lives in the DS composer's actions slot (ADR 0048 / the
+          // ComposerWithAttachments DS pattern) — replaces the separate chip below.
+          actions={<ComposerModelSelect />}
           attachments={attachments.map((a) => ({
             id: a.id,
             name: a.name,
@@ -776,18 +778,6 @@ function ChatSessionSlot({
             e.target.value = ""; // allow re-picking the same file
           }}
         />
-        {/* Model control, under the input (ADR 0048) — a chip showing the active model
-            alias; click to tune model / temperature / max tokens. Same field + cascade
-            as Settings ▸ Workspace ▸ Settings. */}
-        <div className="composer-toolbar">
-          <QuickSetting
-            keys={["model.name", "model.temperature", "model.max_tokens"]}
-            summaryKey="model.name"
-            title="Model"
-            label="Model settings"
-            icon={<SlidersHorizontal size={14} />}
-          />
-        </div>
       </div>
     </div>
   );

--- a/apps/web/src/chat/ComposerModelSelect.tsx
+++ b/apps/web/src/chat/ComposerModelSelect.tsx
@@ -1,0 +1,43 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+import { api } from "../lib/api";
+import { queryKeys, settingsSchemaQuery } from "../lib/queries";
+
+// The composer's inline model picker — rendered in the DS PromptInput `actions` slot
+// (the design-system composer pattern), replacing the separate QuickSetting model chip.
+// Reads the `model.name` field straight from the settings schema (its `options` are the
+// available models, `value` the active one, `scope` the cascade layer) and saves on change
+// via the same /api/settings write path the central Settings home uses. Temperature /
+// max-tokens live in full Settings now — the composer just picks the model.
+export function ComposerModelSelect() {
+  const qc = useQueryClient();
+  const schema = useQuery(settingsSchemaQuery());
+  const field = schema.data?.groups.flatMap((g) => g.fields).find((f) => f.key === "model.name");
+
+  const save = useMutation({
+    mutationFn: (v: string) =>
+      api.saveSettings({ "model.name": v }, field?.scope === "host" ? "host" : "agent"),
+    onSuccess: () => void qc.invalidateQueries({ queryKey: queryKeys.settings }),
+  });
+
+  if (!field) return null;
+  const value = String(field.value ?? "");
+  const options = field.options?.length ? field.options : value ? [value] : [];
+
+  return (
+    <select
+      aria-label="Model"
+      title="Model"
+      className="composer-model-select"
+      value={value}
+      onChange={(e) => save.mutate(e.target.value)}
+      disabled={save.isPending}
+    >
+      {options.map((m) => (
+        <option key={m} value={m}>
+          {m}
+        </option>
+      ))}
+    </select>
+  );
+}

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -48,13 +48,29 @@
   color: var(--fg-secondary);
 }
 
-/* A thin control row UNDER the input (ADR 0048) — holds the model chip (and is the
-   home for future per-turn controls). */
-.composer-toolbar {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 0 12px 8px;
+/* Composer model picker — rendered in the DS PromptInput `actions` slot (ADR 0051,
+   the ComposerWithAttachments DS pattern). A quiet inline select that reads as text
+   until hover/focus. */
+.composer-model-select {
+  font: inherit;
+  font-size: 12px;
+  color: var(--fg-secondary);
+  background: none;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  padding: 2px 6px;
+  cursor: pointer;
+  max-width: 180px;
+}
+.composer-model-select:hover,
+.composer-model-select:focus-visible {
+  color: var(--fg);
+  border-color: var(--border);
+  background: var(--bg-elevated, rgba(255, 255, 255, 0.03));
+}
+.composer-model-select:disabled {
+  opacity: 0.6;
+  cursor: default;
 }
 
 /* Slash-command autocomplete (floats above the composer). */


### PR DESCRIPTION
## What

Adopt the design-system composer's **model-input pattern** ([`components-ai--composer-with-attachments`](https://storybook.protolabs.studio/?path=/story/components-ai--composer-with-attachments)): the model picker now renders **inline in `PromptInput`'s `actions` slot**, replacing the separate `QuickSetting` model chip that sat *below* the input.

Our composer already used the DS `PromptInput` + its attachments API; this drops the last custom bit — the model control's bespoke placement.

## How

`ComposerModelSelect` reads the **`model.name` field straight from the settings schema** — its `options` are the 18 available models, `value` is the active one, `scope` is the cascade layer — and saves on change via the same `/api/settings` write path the central Settings home uses (host-scoped for `model.name`, so it behaves exactly as the old chip did). No new endpoint; reuses the cascade.

Temperature / max-tokens move to full Settings (the composer just picks the model, matching the DS composer). `QuickSetting` + `SlidersHorizontal` imports and the `.composer-toolbar` block are removed.

## Notes

- `@protolabsai/ui@0.33` (our latest) has **no dedicated model component** — the DS pattern is a picker in the `actions` slot, which is what this implements.
- **Heads-up to the chat-UX team:** this touches `ChatSurface.tsx` (the composer region only) — relates to **`bd-39m`**. Small + contained; rebase your in-flight work over it or ping me.

## Testing

`tsc` + `vite build` + CSS-comment guard clean; web vitest green (73). (Needs a hard-refresh to see live.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)