### PR TITLE
feat(chat): native vision — send attached images straight to the model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   exists are now swept (at boot + on the periodic task-prune tick) — the SDK store has no
   TTL, so stale webhook configs previously persisted forever; their lifetime is now tied to
   the task.
+- **Native vision in chat** — when the active model accepts images (`model.vision`; true for
+  e.g. `protolabs/fast`, `protolabs/smart`, and `protolabs/reasoning`/deepseek-v4), an attached
+  image is sent **straight to the model as a multimodal part** instead of through the extraction
+  pipeline. The composer base64s the image into an A2A image part (proto `raw` + `mediaType`);
+  the executor turns inbound image parts into an `image_url` content block on the `HumanMessage`
+  so the model sees the picture directly. Off by default (`model.vision` Settings toggle);
+  non-vision models keep routing images through the pipeline. Verified end-to-end against the
+  live gateway (deepseek-v4 correctly read a test image).
 - **A2A alignment polish + realtime cost/goal events** (ADR 0051 Slice 3) — fixed a real
   bug: the **delegate A2A client now sends `A2A-Version: 1.0`** (a missing header made a
   strict 1.0 peer reject the call with `-32009`). The agent card now advertises a

--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -240,6 +240,7 @@ class ProtoAgentExecutor(AgentExecutor):
         _notify_progress(context.context_id, context.task_id, {"phase": "turn_started"})
 
         text = context.get_user_input()
+        images = _extract_image_parts(context)
         caller_trace = _extract_caller_trace(context)
 
         # Provenance for the Activity feed (ADR 0022): what triggered this turn.
@@ -330,7 +331,7 @@ class ProtoAgentExecutor(AgentExecutor):
         try:
             async for event_type, payload in self._stream_factory(
                 text, context.context_id, resume=resume, caller_trace=caller_trace,
-                request_metadata=_md,
+                request_metadata=_md, images=images,
             ):
                 if event_type == "text":
                     accumulated += payload
@@ -492,6 +493,30 @@ def _extract_caller_trace(context: RequestContext) -> dict:
     """The ``a2a.trace`` metadata (Langfuse cross-trace propagation), or {}."""
     trace = _request_metadata(context).get("a2a.trace")
     return trace if isinstance(trace, dict) else {}
+
+
+def _extract_image_parts(context: RequestContext) -> list[tuple[str, str]]:
+    """Vision image parts off the inbound message → ``[(media_type, data_uri)]``.
+
+    A part with an ``image/*`` media_type carries either inline bytes (proto
+    ``raw``, base64-encoded into a ``data:`` URI) or a ``url`` (already a
+    ``data:``/``http`` URL). Empty when there are none — so non-vision turns and
+    text-only consumers pay nothing. The turn handler only forwards these to the
+    model when the active model is vision-capable."""
+    import base64
+
+    out: list[tuple[str, str]] = []
+    msg = getattr(context, "message", None)
+    for p in (getattr(msg, "parts", None) or []):
+        mt = (getattr(p, "media_type", "") or "").lower()
+        if not mt.startswith("image/"):
+            continue
+        raw = getattr(p, "raw", b"") or b""
+        if raw:
+            out.append((mt, f"data:{mt};base64,{base64.b64encode(bytes(raw)).decode()}"))
+        elif getattr(p, "url", ""):
+            out.append((mt, p.url))
+    return out
 
 
 def _extract_skill_hint(context: RequestContext) -> str:

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -8,8 +8,10 @@ import {
   TerminalSquare,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useQuery } from "@tanstack/react-query";
 
 import { api } from "../lib/api";
+import { runtimeStatusQuery } from "../lib/queries";
 import { QuickSetting } from "../settings/QuickSetting";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import type { ChatMessage, HitlPayload, SlashCommand, ToolCall } from "../lib/types";
@@ -24,6 +26,21 @@ function messageId() {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
 }
 
+// Read a File to bare base64 (no `data:…;base64,` prefix) — the proto Part `raw`
+// (bytes) field for a native-vision image.
+function fileToBase64(file: File): Promise<string> {
+  return new Promise((resolve, reject) => {
+    const reader = new FileReader();
+    reader.onload = () => {
+      const s = String(reader.result || "");
+      const comma = s.indexOf(",");
+      resolve(comma >= 0 ? s.slice(comma + 1) : s);
+    };
+    reader.onerror = () => reject(reader.error || new Error("file read failed"));
+    reader.readAsDataURL(file);
+  });
+}
+
 // A file being attached to the next message. Uploaded to /api/knowledge/attach on
 // pick; `context` is the backend's ready-to-prepend block (full text or lede).
 type PendingAttachment = {
@@ -34,6 +51,11 @@ type PendingAttachment = {
   context?: string;
   mode?: "inline" | "indexed";
   error?: string;
+  // Native-vision images skip the pipeline: their base64 + mime ride the turn as
+  // a multimodal A2A part straight to the model (no `context`).
+  native?: boolean;
+  b64?: string;
+  mime?: string;
 };
 
 // Append an actionable pointer when a turn fails on something the operator can
@@ -191,11 +213,36 @@ function ChatSessionSlot({
   // block we prepend to the SENT message (not the visible bubble) on send.
   const [attachments, setAttachments] = useState<PendingAttachment[]>([]);
   const fileInputRef = useRef<HTMLInputElement | null>(null);
+  // Native vision: when the active model accepts images, attached images go
+  // straight to the model as multimodal parts; otherwise they take the pipeline.
+  const { data: runtime } = useQuery(runtimeStatusQuery());
+  const visionModel = Boolean(runtime?.model?.vision);
 
   async function uploadAttachment(file: File) {
     const id = messageId();
     const kind: "file" | "image" = file.type.startsWith("image/") ? "image" : "file";
     setAttachments((a) => [...a, { id, name: file.name, kind, status: "uploading" }]);
+
+    // Native vision: a vision model sees the image directly — base64 it and send
+    // it as a multimodal part, no pipeline round-trip.
+    if (kind === "image" && visionModel) {
+      try {
+        const b64 = await fileToBase64(file);
+        setAttachments((a) =>
+          a.map((x) =>
+            x.id === id
+              ? { ...x, status: "ready", native: true, b64, mime: file.type || "image/png", mode: "inline" }
+              : x,
+          ),
+        );
+      } catch (e) {
+        const msg = e instanceof Error ? e.message : String(e);
+        setAttachments((a) => a.map((x) => (x.id === id ? { ...x, status: "error", error: msg } : x)));
+        onError(`Couldn't read ${file.name}: ${msg}`);
+      }
+      return;
+    }
+
     try {
       const form = new FormData();
       form.append("file", file);
@@ -365,18 +412,22 @@ function ChatSessionSlot({
     if (!session || !canSend) return;
     const text = draft.trim();
     setDraft("");
-    const ready = attachments.filter((a) => a.status === "ready" && a.context);
-    if (ready.length === 0) {
+    // Native-vision images ride the turn as multimodal parts; pipeline attachments
+    // contribute a prepended context block.
+    const nativeImgs = attachments.filter((a) => a.status === "ready" && a.native && a.b64);
+    const piped = attachments.filter((a) => a.status === "ready" && a.context);
+    if (nativeImgs.length === 0 && piped.length === 0) {
       void runTurn(text);
       return;
     }
-    // The model gets the attachment context blocks prepended; the user bubble
-    // shows only the typed text + a 📎 list (never the raw doc dump).
-    const sent = [...ready.map((a) => a.context as string), text].join("\n\n").trim();
-    const names = ready.map((a) => a.name).join(", ");
+    const images = nativeImgs.map((a) => ({ b64: a.b64 as string, mime: a.mime || "image/png", name: a.name }));
+    // The model gets the pipeline context prepended + the images natively; the
+    // user bubble shows only the typed text + a 📎 list (never a raw doc/data dump).
+    const sent = [...piped.map((a) => a.context as string), text].join("\n\n").trim();
+    const names = [...piped, ...nativeImgs].map((a) => a.name).join(", ");
     const display = text ? `${text}\n\n📎 ${names}` : `📎 ${names}`;
     setAttachments([]);
-    void runTurn(display, { sendAs: sent });
+    void runTurn(display, { sendAs: sent, images });
   }
 
   // Resume a paused (input-required) turn: submitting the HITL form/question
@@ -392,7 +443,10 @@ function ChatSessionSlot({
     void runTurn(typeof response === "string" ? response : JSON.stringify(response), { hidden: silent });
   }
 
-  async function runTurn(content: string, opts: { hidden?: boolean; sendAs?: string } = {}) {
+  async function runTurn(
+    content: string,
+    opts: { hidden?: boolean; sendAs?: string; images?: { b64: string; mime: string; name: string }[] } = {},
+  ) {
     if (!session || !content) return;
     // `sendAs` (attachment context prepended) is what the MODEL receives; `content`
     // is what the user bubble shows.
@@ -584,7 +638,7 @@ function ChatSessionSlot({
             }),
           );
         },
-      });
+      }, { images: opts.images });
       chatStore.setSessionStatus(session.id, "idle");
       setStatusMessage("idle");
     } catch (exc) {
@@ -768,6 +822,7 @@ function ChatSessionSlot({
           hidden
           accept={
             ".txt,.text,.log,.csv,.md,.markdown,.html,.htm,.pdf," +
+            ".png,.jpg,.jpeg,.gif,.webp,.bmp," +
             ".mp3,.wav,.m4a,.flac,.ogg,.opus,.aac,.mp4,.mov,.mkv,.webm,.avi,.m4v"
           }
           onChange={(e) => {

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -965,6 +965,7 @@ export const api = {
       onFailed?: (message: string) => void;
       onDone?: () => void;
     } = {},
+    opts: { images?: { b64: string; mime: string; name: string }[] } = {},
   ) {
     // Desktop (WKWebView) can't read a streaming SSE body via fetch (see
     // isDesktopWebview) — the turn would render as a blank assistant bubble. Take
@@ -1018,7 +1019,16 @@ export const api = {
         params: {
           message: {
             role: "ROLE_USER",
-            parts: [{ text: message }],
+            // Native vision: image parts ride as proto-JSON Parts (raw=base64
+            // bytes + mediaType) the executor turns into multimodal content.
+            parts: [
+              { text: message },
+              ...(opts.images || []).map((img) => ({
+                raw: img.b64,
+                mediaType: img.mime,
+                filename: img.name,
+              })),
+            ],
             messageId: rpcId,
             contextId: sessionId,
           },

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -16,6 +16,9 @@ export type RuntimeStatus = {
     temperature: number | null;
     max_tokens: number | null;
     max_iterations: number | null;
+    /** Model accepts native image input (model.vision) — chat sends attached
+     *  images straight to the model instead of through the extraction pipeline. */
+    vision?: boolean;
   };
   identity: null | {
     name: string;

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -18,6 +18,10 @@ model:
   temperature: 0.2
   max_tokens: 32768  # 32k — required headroom for the Qwen models we run
   max_iterations: 50
+  # Native image input — set true when `name` is a vision model (protolabs/fast,
+  # protolabs/smart, protolabs/reasoning/deepseek-v4). Chat then sends attached
+  # images straight to the model instead of through the extraction pipeline.
+  vision: false
   request_timeout: 120   # per-call timeout (s) on the model client — bounds a hung/slow gateway
   max_retries: 2         # transient-error retries inside the client
   # Advanced sampling — all optional; omit to use the gateway / model-card

--- a/graph/config.py
+++ b/graph/config.py
@@ -194,6 +194,11 @@ class LangGraphConfig:
     temperature: float = 0.2
     max_tokens: int = 32768  # 32k — required headroom for the Qwen models we run
     max_iterations: int = 50
+    # Native vision (ADR 0021): set true when `model_name` is image-capable (e.g.
+    # protolabs/fast, protolabs/smart). The chat composer then sends attached
+    # images as native multimodal parts straight to the model instead of routing
+    # them through the extraction pipeline. Off → images go through the pipeline.
+    model_vision: bool = False
 
     # Per-call timeout (seconds) on the model client + transient-retry cap. Bounds
     # a hung/slow gateway so a turn surfaces a clean error instead of blocking the
@@ -730,6 +735,7 @@ class LangGraphConfig:
             api_key=secret_api_key or model.get("api_key", cls.api_key),
             temperature=model.get("temperature", cls.temperature),
             max_tokens=model.get("max_tokens", cls.max_tokens),
+            model_vision=model.get("vision", cls.model_vision),
             max_iterations=model.get("max_iterations", cls.max_iterations),
             request_timeout=model.get("request_timeout", cls.request_timeout),
             llm_max_retries=model.get("max_retries", cls.llm_max_retries),

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -66,6 +66,10 @@ FIELDS: list[Field] = [
     Field("model.temperature", "temperature", "Temperature", "number", "Model",
           minimum=0, maximum=2),
     Field("model.max_tokens", "max_tokens", "Max output tokens", "number", "Model", minimum=1),
+    Field("model.vision", "model_vision", "Vision (native images)", "bool", "Model",
+          "Turn on when the primary model accepts images (e.g. protolabs/fast, protolabs/smart). "
+          "Chat then sends attached images straight to the model as native multimodal parts "
+          "instead of through the extraction pipeline.", restart=True),
     Field("model.max_iterations", "max_iterations", "Max tool iterations", "number", "Model",
           "Hard cap on the agent loop per turn.", minimum=1),
 

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -86,6 +86,7 @@ def build_runtime_status(
             "temperature": getattr(config, "temperature", None),
             "max_tokens": getattr(config, "max_tokens", None),
             "max_iterations": getattr(config, "max_iterations", None),
+            "vision": bool(getattr(config, "model_vision", False)),
         },
         "identity": {
             "name": getattr(config, "identity_name", ""),

--- a/server/chat.py
+++ b/server/chat.py
@@ -195,7 +195,7 @@ def _interrupt_payload(val) -> dict:
     return {"question": (str(val) if val is not None else "Input required.")}
 
 
-async def _run_turn_stream(message: str, session_id: str, config: dict, *, resume_value=None):
+async def _run_turn_stream(message: str, session_id: str, config: dict, *, resume_value=None, images=None):
     """Run one graph turn over ``astream_events``.
 
     Yields the same ``(kind, payload)`` status/usage frames the A2A handler
@@ -213,13 +213,23 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
     from langchain_core.messages import HumanMessage
     from langgraph.types import Command
 
+    # Native vision (ADR 0021): when the model is vision-capable and the turn
+    # carried image parts, the user message is a multimodal content list (text +
+    # image_url blocks) the model sees directly — not piped through extraction.
+    if images and getattr(STATE.graph_config, "model_vision", False):
+        blocks: list[dict] = [{"type": "text", "text": message}] if message else []
+        blocks += [{"type": "image_url", "image_url": {"url": uri}} for _mt, uri in images]
+        human = HumanMessage(content=blocks)
+    else:
+        human = HumanMessage(content=message)
+
     graph_input = (
         Command(resume=resume_value)
         if resume_value is not None
         # Prepend any completed background-job notifications (ADR 0050) so the model
         # learns of detached work that finished since this session last ran a turn.
         else {
-            "messages": _drain_background_messages(session_id) + [HumanMessage(content=message)],
+            "messages": _drain_background_messages(session_id) + [human],
             "session_id": session_id,
         }
     )
@@ -511,6 +521,7 @@ async def _chat_langgraph_stream(
     caller_trace: dict | None = None,
     resume: bool = False,
     request_metadata: dict | None = None,
+    images: list[tuple[str, str]] | None = None,
 ):
     """Async generator — yields (event_type, payload) tuples from the
     LangGraph run. Consumed by ``executor.ProtoAgentExecutor`` to
@@ -702,6 +713,7 @@ async def _chat_langgraph_stream(
                 async for kind, payload in _run_turn_stream(
                     message, session_id, config,
                     resume_value=(message if resume else None),
+                    images=images,
                 ):
                     if kind == "__raw__":
                         accumulated_raw = payload

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -576,3 +576,31 @@ async def test_allowed_origin_passes():
             "jsonrpc": "2.0", "id": 1, "method": "SendMessage",
             "params": {"message": {"messageId": "m", "role": "ROLE_USER", "parts": [{"text": "hi"}]}}})
     assert r.status_code == 200
+
+
+# ── native vision: inbound image part extraction ──────────────────────────────
+def test_extract_image_parts_inline_and_url():
+    import base64
+    import types as _t
+
+    from a2a_impl.executor import _extract_image_parts
+
+    img = b"\x89PNG-fake-bytes"
+    parts = [
+        _t.SimpleNamespace(media_type="", raw=b"", url=""),                     # text → skip
+        _t.SimpleNamespace(media_type="image/png", raw=img, url=""),            # inline image
+        _t.SimpleNamespace(media_type="image/jpeg", raw=b"", url="https://x/y.jpg"),  # url image
+        _t.SimpleNamespace(media_type="application/pdf", raw=b"x", url=""),     # non-image → skip
+    ]
+    ctx = _t.SimpleNamespace(message=_t.SimpleNamespace(parts=parts))
+    out = _extract_image_parts(ctx)
+    assert len(out) == 2
+    assert out[0] == ("image/png", f"data:image/png;base64,{base64.b64encode(img).decode()}")
+    assert out[1] == ("image/jpeg", "https://x/y.jpg")
+
+
+def test_extract_image_parts_empty_when_no_message():
+    import types as _t
+
+    from a2a_impl.executor import _extract_image_parts
+    assert _extract_image_parts(_t.SimpleNamespace(message=None)) == []

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -116,6 +116,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "memory_middleware": True,
     "model_name": "protolabs/reasoning",
     "model_provider": "openai",
+    "model_vision": False,
     "operator_allowed_dirs": [],
     "operator_mcp_enabled": False,
     "operator_mcp_tools": [],
@@ -266,6 +267,7 @@ CONFIG_TO_DICT_GOLDEN = {
         "name": "protolabs/reasoning",
         "provider": "openai",
         "temperature": 0.2,
+        "vision": False,
     },
     "network": {
         "bind": "127.0.0.1",
@@ -341,6 +343,7 @@ EMITTED_ATTRS = {
     "api_key",  # redacted -> resolves to ""
     "temperature",
     "max_tokens",
+    "model_vision",
     "max_iterations",
     # subagents.researcher
     "researcher",


### PR DESCRIPTION
## What

Closes **bd-16n**. When the active model accepts images (`model.vision` — true for `protolabs/fast`, `protolabs/smart`, and `protolabs/reasoning`/deepseek-v4), an attached image is sent **straight to the model as a native multimodal part** instead of through the extraction pipeline.

**Verified live:** `protolabs/reasoning` (deepseek-v4) correctly read a generated test image via the standard `image_url` content block — confirming both the model's vision and this PR's content format.

## How (full-stack, off by default)

- **config** — `model.vision` flag (loader, Settings toggle, exposed on runtime-status `model.vision`, round-trip goldens, example yaml).
- **executor** — `_extract_image_parts` pulls `image/*` parts off the inbound A2A message (proto `raw` bytes → data URI, or a `url`) and threads them to the stream factory.
- **server/chat.py** — when images are present *and* `model.vision`, the user `HumanMessage` becomes a multimodal content list (text + `image_url` blocks); otherwise plain text (unchanged).
- **frontend** — the composer base64s an image and sends it as an A2A part (`raw` + `mediaType`) when the model is vision-capable; otherwise it uses the pipeline path (#1002). `api.streamChat` gains an `images` opt; the file picker now accepts image types; paste/drag images work too.

## Tests

`_extract_image_parts` (inline + url + skip non-image / no-message); config round-trip goldens. **Full suite 1954 passed**, web e2e 97 green, ruff + import contracts clean.

Two of the three remaining chat-UX items left after this: **bd-1n7** (file-only send) and **bd-1rn** (DS message-thread).

🤖 Generated with [Claude Code](https://claude.com/claude-code)