### PR TITLE
feat(chat): DS message-thread — copy, fork, regenerate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Chat message toolbar — copy, fork, regenerate** (DS message-thread adoption) — the
+  chat transcript now uses the design-system `Conversation`/`Message`/`MessageActions`
+  components. Each settled assistant reply gets a hover toolbar: **Copy** the answer,
+  **Fork from here** (opens a new chat tab seeded with the history up to that message —
+  the original is untouched, so you can branch a conversation), and **Regenerate** (re-runs
+  the last turn in place, no duplicate user bubble). `Conversation` brings smart auto-scroll
+  (stays pinned while streaming, but won't yank you down while you read back; a jump-to-latest
+  button appears when scrolled up), replacing the hand-rolled message list. The streaming and
+  self-heal invariants (#613/#615) are unchanged — this is a render-layer swap.
 - **`scheduler.fired` event + orphaned push-config sweep** (ADR 0051 Slice 3 follow-ups) —
   a scheduled job dispatching now publishes `scheduler.fired` on the event bus (live
   visibility into cron/one-shot fires). And push-notification configs whose task no longer

--- a/apps/web/e2e/chat-continuity.spec.ts
+++ b/apps/web/e2e/chat-continuity.spec.ts
@@ -15,19 +15,19 @@ test("conversation survives navigating away and back (surface stays mounted)", a
 
   await composer.fill("remember this message");
   await composer.press("Enter");
-  await expect(page.locator(".message-user")).toHaveText(/remember this message/);
+  await expect(page.locator(".pl-message--user")).toHaveText(/remember this message/);
 
   // Leave the Chat tab → the chat surface is hidden but still mounted in the DOM
   // (not unmounted), so its state + any in-flight stream are preserved.
   await rail(page, "Activity");
   await expect(page.locator(".chat-stage")).toHaveCount(1); // still in the DOM
   await expect(page.locator(".chat-stage")).not.toBeVisible(); // just hidden
-  await expect(page.locator(".message-user")).toHaveCount(1); // message not lost
+  await expect(page.locator(".pl-message--user")).toHaveCount(1); // message not lost
 
   // Return → the conversation is exactly as we left it.
   await rail(page, "Chat");
   await expect(page.locator(".chat-stage")).toBeVisible();
-  await expect(page.locator(".message-user")).toHaveText(/remember this message/);
+  await expect(page.locator(".pl-message--user")).toHaveText(/remember this message/);
 });
 
 test("tool-call cards survive navigating away and back", async ({ page }) => {

--- a/apps/web/e2e/chat-reconcile.spec.ts
+++ b/apps/web/e2e/chat-reconcile.spec.ts
@@ -33,7 +33,7 @@ test("a stuck 'streaming' message reconciles to the server's completed answer on
 
   // On mount the reconcile fires: tasks/get → completed → finalize. The answer
   // from the server's artifact appears, and the message is no longer streaming.
-  await expect(page.locator(".message-assistant")).toContainText("RECONCILED ANSWER");
+  await expect(page.locator(".pl-message--assistant")).toContainText("RECONCILED ANSWER");
   // No longer spinning — the streaming loader is gone once finalized.
-  await expect(page.locator(".message-assistant .spin")).toHaveCount(0);
+  await expect(page.locator(".pl-message--assistant .spin")).toHaveCount(0);
 });

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -23,11 +23,11 @@ test("Enter sends; Ctrl+Enter inserts a newline", async ({ page }) => {
   await composer.fill("line one");
   await composer.press("Control+Enter"); // newline, not send
   await expect(composer).toHaveValue("line one\n");
-  await expect(page.locator(".message-user")).toHaveCount(0);
+  await expect(page.locator(".pl-message--user")).toHaveCount(0);
 
   await composer.fill("hello there"); // plain Enter sends
   await composer.press("Enter");
-  await expect(page.locator(".message-user")).toHaveText(/hello there/);
+  await expect(page.locator(".pl-message--user")).toHaveText(/hello there/);
 });
 
 test("tool-call card is collapsed by default and renders structured components", async ({ page }) => {
@@ -68,7 +68,7 @@ test("expanded state is sticky and the assistant answer renders as markdown", as
   await send(page, "MARKDOWN: summarize");
 
   // Final answer renders through the markdown pipeline.
-  const md = page.locator(".message-assistant .markdown");
+  const md = page.locator(".pl-message--assistant .markdown");
   await expect(md.locator("h2")).toHaveText("Summary");
   await expect(md.locator("strong")).toHaveText("key");
   await expect(md.locator("li")).toHaveCount(2);
@@ -84,7 +84,7 @@ test("long tool values do not overflow the chat horizontally", async ({ page }) 
   await expect(card.locator(".pl-toolcard__body")).toBeVisible();
 
   const metrics = await page.evaluate(() => {
-    const body = document.querySelector(".message-assistant .message-body");
+    const body = document.querySelector(".pl-message--assistant .pl-message__content");
     return {
       docScroll: document.documentElement.scrollWidth,
       win: window.innerWidth,

--- a/apps/web/e2e/message-actions.spec.ts
+++ b/apps/web/e2e/message-actions.spec.ts
@@ -1,0 +1,66 @@
+import { expect, test } from "@playwright/test";
+
+// The DS Message toolbar adopted in bd-1rn: copy, fork-from-here, and
+// regenerate, shown on a settled assistant message (hover-revealed). Drives the
+// canned mock turn (default scenario answers "Done — found 8 results.").
+test.use({ permissions: ["clipboard-read", "clipboard-write"] });
+
+async function send(page, prompt: string) {
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+  await composer.fill(prompt);
+  await composer.press("Enter");
+}
+
+// The active chat slot — fork spawns a second, hidden slot, so scope queries here.
+const visibleSlot = (page) => page.locator(".chat-session-slot:not([hidden])");
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+});
+
+test("copy action writes the assistant answer to the clipboard", async ({ page }) => {
+  await send(page, "hello there");
+  const assistant = visibleSlot(page).locator(".pl-message--assistant").last();
+  await expect(assistant.locator(".markdown")).toContainText("Done — found 8 results.");
+
+  await assistant.getByRole("button", { name: "Copy" }).click();
+  await expect(assistant.getByRole("button", { name: "Copied" })).toBeVisible();
+
+  const clip = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clip).toContain("Done — found 8 results.");
+});
+
+test("fork opens a new tab seeded with the history through that message", async ({ page }) => {
+  await send(page, "remember this");
+  const assistant = visibleSlot(page).locator(".pl-message--assistant").last();
+  await expect(assistant.locator(".markdown")).toContainText("Done — found 8 results.");
+  await expect(page.locator(".pl-tabbar__tab")).toHaveCount(1);
+
+  await assistant.getByRole("button", { name: "Fork from here" }).click();
+
+  // A new tab is added and becomes active, seeded with the same history; the
+  // original is untouched (now two tabs).
+  await expect(page.locator(".pl-tabbar__tab")).toHaveCount(2);
+  await expect(visibleSlot(page).locator(".pl-message--user")).toHaveText(/remember this/);
+  await expect(visibleSlot(page).locator(".pl-message--assistant .markdown")).toContainText(
+    "Done — found 8 results.",
+  );
+});
+
+test("regenerate re-runs the last turn without duplicating the user bubble", async ({ page }) => {
+  await send(page, "hello there");
+  const slot = visibleSlot(page);
+  await expect(slot.locator(".pl-message--assistant .markdown")).toContainText("Done — found 8 results.");
+  await expect(slot.locator(".pl-message--user")).toHaveCount(1);
+
+  await slot.locator(".pl-message--assistant").last().getByRole("button", { name: "Regenerate" }).click();
+
+  // Exactly one user bubble still (the `hidden` re-run path adds no duplicate),
+  // and a fresh assistant answer comes back.
+  await expect(slot.locator(".pl-message--user")).toHaveCount(1);
+  await expect(slot.locator(".pl-message--assistant .markdown").last()).toContainText(
+    "Done — found 8 results.",
+  );
+});

--- a/apps/web/e2e/streaming.spec.ts
+++ b/apps/web/e2e/streaming.spec.ts
@@ -12,7 +12,7 @@ test("assistant answer streams in and reconciles to the final text", async ({ pa
   await composer.fill("STREAM the answer");
   await composer.press("Enter");
 
-  const answer = page.locator(".message-assistant .markdown");
+  const answer = page.locator(".pl-message--assistant .markdown");
   // Partial text appears before the full answer (append:true delta).
   await expect(answer).toContainText("Testing");
   // Final reconciled text — concatenated cleanly, not duplicated.

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -598,27 +598,9 @@ select:disabled {
   outline-offset: -2px;
 }
 
-.message-list {
-  padding: 12px;
-}
-
-.message {
-  display: grid;
-  grid-template-columns: 88px minmax(0, 1fr);
-  gap: 12px;
-  padding: 10px 0;
-  border-bottom: 1px solid var(--border);
-}
-
-.message:first-child {
-  padding-top: 0;
-}
-
-.message-body {
-  min-width: 0;
-  white-space: pre-wrap;
-  word-break: break-word;
-}
+/* The chat thread now uses the DS Conversation/Message components (bd-1rn) —
+   the old hand-rolled `.message*` bubble rules were removed. Generic list scroll
+   (`.message-list, .issue-list, …`) stays above for the other surfaces. */
 
 /* Tool-call cards + per-tool renderers — moved to src/chat/tool-calls.css (#832). */
 

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1,9 +1,20 @@
 import "./chat.css";
 import { Empty } from "@protolabsai/ui/primitives";
-import { PromptInput, Reasoning } from "@protolabsai/ui/ai";
+import {
+  Conversation,
+  Message,
+  MessageAction,
+  MessageActions,
+  PromptInput,
+  Reasoning,
+} from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
 import {
+  Check,
+  Copy,
+  GitBranch,
   Loader2,
+  RotateCcw,
   TerminalSquare,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -201,7 +212,8 @@ function ChatSessionSlot({
   const [taskId, setTaskId] = useState("");
   const [hitl, setHitl] = useState<HitlPayload | null>(null);
   const abortRef = useRef<AbortController | null>(null);
-  const listRef = useRef<HTMLDivElement | null>(null);
+  // Transient "copied ✓" feedback on a message's copy action.
+  const [copiedId, setCopiedId] = useState<string | null>(null);
   // Forwarded into the DS PromptInput (inputRef) — for slash-completion focus and
   // the Ctrl/⌘+Enter caret insert. The DS component owns the auto-grow.
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -338,11 +350,6 @@ function ChatSessionSlot({
   }
 
   useEffect(() => {
-    if (!visible) return;
-    listRef.current?.scrollTo({ top: listRef.current.scrollHeight });
-  }, [session?.messages, visible]);
-
-  useEffect(() => {
     return () => {
       abortRef.current?.abort();
     };
@@ -404,6 +411,11 @@ function ChatSessionSlot({
   }, [sessionId]);
 
   const messages = session?.messages || [];
+  // Regenerate is offered only on the most recent assistant reply.
+  const lastAssistantId = useMemo(
+    () => [...messages].reverse().find((m) => m.role === "assistant")?.id,
+    [messages],
+  );
 
   const canSend = useMemo(() => Boolean(draft.trim()) && status !== "streaming", [draft, status]);
 
@@ -427,6 +439,46 @@ function ChatSessionSlot({
     const display = text ? `${text}\n\n📎 ${names}` : `📎 ${names}`;
     setAttachments([]);
     void runTurn(display, { sendAs: sent, images });
+  }
+
+  function copyMessage(message: ChatMessage) {
+    void navigator.clipboard?.writeText(message.content || "");
+    setCopiedId(message.id ?? null);
+    window.setTimeout(() => setCopiedId((id) => (id === message.id ? null : id)), 1500);
+  }
+
+  // Regenerate an assistant reply: drop it (and anything after) from the thread,
+  // then re-run the user message that prompted it via the `hidden` path — no
+  // duplicate user bubble, just a fresh streaming assistant. Only offered on the
+  // last assistant message when idle.
+  function regenerate(assistantId?: string) {
+    if (!assistantId || !session || status === "streaming") return;
+    const snap = chatStore.getSnapshot().sessions.find((s) => s.id === session.id);
+    if (!snap) return;
+    const i = snap.messages.findIndex((m) => m.id === assistantId);
+    if (i < 0) return;
+    const user = [...snap.messages.slice(0, i)].reverse().find((m) => m.role === "user");
+    if (!user) return;
+    chatStore.updateMessages(session.id, snap.messages.slice(0, i));
+    void runTurn(user.content, { hidden: true });
+  }
+
+  // Fork the conversation at a message: open a NEW tab/session seeded with the
+  // history up to and including that message, leaving the original untouched.
+  // Continue the branch from there.
+  function forkAtMessage(message: ChatMessage) {
+    if (!session) return;
+    const i = session.messages.findIndex((m) => m.id === message.id);
+    if (i < 0) return;
+    const seed = session.messages.slice(0, i + 1).map((m) => ({
+      ...m,
+      // a forked-from message is settled history in the new branch
+      status: m.status === "streaming" ? "done" : m.status,
+    }));
+    const created = chatStore.createSession(); // becomes the current + active tab
+    chatStore.updateMessages(created.id, seed);
+    const baseTitle = session.title && session.title !== "New chat" ? session.title : "Chat";
+    chatStore.renameSession(created.id, `${baseTitle} (fork)`);
   }
 
   // Resume a paused (input-required) turn: submitting the HITL form/question
@@ -468,11 +520,16 @@ function ChatSessionSlot({
 
     setDraft("");
     setStatusMessage("submitted");
-    // `hidden` (an approval resume) sends `content` to the server but omits the user
-    // bubble — the agent still receives the approve/deny, the chat just doesn't show it.
+    // Build off the live store snapshot, not the render-closure `messages` — a
+    // regenerate trims the thread in the store then calls runTurn in the same tick
+    // (before a re-render), so the closure copy would be stale.
+    const base =
+      chatStore.getSnapshot().sessions.find((s) => s.id === session.id)?.messages ?? messages;
+    // `hidden` (an approval resume, or a regenerate) sends `content` to the server but
+    // omits the user bubble — the agent still receives it, the chat just doesn't show it.
     chatStore.updateMessages(
       session.id,
-      opts.hidden ? [...messages, assistant] : [...messages, userMessage, assistant],
+      opts.hidden ? [...base, assistant] : [...base, userMessage, assistant],
     );
     chatStore.setSessionStatus(session.id, "streaming");
     onError("");
@@ -683,45 +740,69 @@ function ChatSessionSlot({
 
   return (
     <div className="chat-session-slot" hidden={!visible}>
-      <div className="message-list" ref={listRef}>
+      <Conversation>
         {messages.length === 0 ? (
           <Empty icon={<TerminalSquare />} description="No messages in this session." />
         ) : (
           messages.map((message) => (
-            <article className={`message message-${message.role}`} key={message.id || `${message.role}-${message.createdAt}`}>
-              <div className="message-role">{message.role}</div>
-              <div className="message-body">
-                {message.reasoning ? (
-                  // Collapsible "thinking" — open while the model is still reasoning
-                  // (no answer text yet), auto-collapses once the answer starts.
-                  <Reasoning streaming={message.status === "streaming" && !message.content}>
-                    {message.reasoning}
-                  </Reasoning>
-                ) : null}
-                {message.toolCalls && message.toolCalls.length > 0 ? (
-                  <ToolCalls calls={message.toolCalls} />
-                ) : null}
-                {message.content
-                  ? message.role === "user"
-                    ? message.content
-                    : // assistant + system (e.g. background-completion notifications,
-                      // ADR 0050) carry markdown — render it; only the user's own input
-                      // stays literal.
-                      <Markdown>{message.content}</Markdown>
-                  : message.status === "streaming"
-                      && !(message.toolCalls && message.toolCalls.length)
-                      && !(message.components && message.components.length)
-                      && !message.reasoning
-                    ? <Loader2 className="spin" size={15} />
-                    : null}
-                {message.components && message.components.length > 0
-                  ? message.components.map((spec, i) => <ChatComponent key={i} spec={spec} />)
+            <Message
+              key={message.id || `${message.role}-${message.createdAt}`}
+              role={message.role}
+              streaming={message.status === "streaming"}
+            >
+              {message.reasoning ? (
+                // Collapsible "thinking" — open while the model is still reasoning
+                // (no answer text yet), auto-collapses once the answer starts.
+                <Reasoning streaming={message.status === "streaming" && !message.content}>
+                  {message.reasoning}
+                </Reasoning>
+              ) : null}
+              {message.toolCalls && message.toolCalls.length > 0 ? (
+                <ToolCalls calls={message.toolCalls} />
+              ) : null}
+              {message.content
+                ? message.role === "user"
+                  ? // Literal user input — preserve newlines (markdown reflows assistant text).
+                    <span className="chat-user-text">{message.content}</span>
+                  : // assistant + system (e.g. background-completion notifications,
+                    // ADR 0050) carry markdown — render it; only the user's own input
+                    // stays literal.
+                    <Markdown>{message.content}</Markdown>
+                : message.status === "streaming"
+                    && !(message.toolCalls && message.toolCalls.length)
+                    && !(message.components && message.components.length)
+                    && !message.reasoning
+                  ? <Loader2 className="spin" size={15} />
                   : null}
-              </div>
-            </article>
+              {message.components && message.components.length > 0
+                ? message.components.map((spec, i) => <ChatComponent key={i} spec={spec} />)
+                : null}
+              {message.role === "assistant" && message.status !== "streaming" && message.content ? (
+                <MessageActions>
+                  <MessageAction
+                    label={copiedId === message.id ? "Copied" : "Copy"}
+                    icon={copiedId === message.id ? <Check size={14} /> : <Copy size={14} />}
+                    onClick={() => copyMessage(message)}
+                  />
+                  <MessageAction
+                    label="Fork from here"
+                    icon={<GitBranch size={14} />}
+                    onClick={() => forkAtMessage(message)}
+                  />
+                  {message.id === lastAssistantId ? (
+                    <MessageAction
+                      label="Regenerate"
+                      icon={<RotateCcw size={14} />}
+                      disabled={status === "streaming"}
+                      onClick={() => regenerate(message.id)}
+                    />
+                  ) : null}
+                </MessageActions>
+              ) : null}
+            </Message>
           ))
         )}
-      </div>
+      </Conversation>
 
       {hitl && (
         <HitlForm

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -38,6 +38,13 @@
   display: none;
 }
 
+/* Literal user input inside the DS Message bubble — preserve newlines/wrapping
+   (assistant markdown reflows on its own). */
+.chat-user-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
 /* Subtle live status above the composer while streaming (was a header pill). */
 .composer-status {
   display: flex;


### PR DESCRIPTION
## What

Closes **bd-1rn**. Adopts the design-system `Conversation` / `Message` / `MessageActions` for the chat transcript, replacing the hand-rolled message list + bubble CSS — and adds a per-message action toolbar.

Includes the **Fork** action requested mid-build: fork a conversation at any assistant reply into a new tab.

## Actions (hover toolbar on settled assistant replies)

- **Copy** — copies the answer; flips to a ✓ *Copied* state briefly.
- **Fork from here** — opens a **new chat tab** seeded with the history up to and including that message. The original session is untouched, so you can branch a conversation and explore a different direction.
- **Regenerate** — re-runs the last user turn *in place* via the existing `hidden` path (no duplicate user bubble); shown only on the most recent reply.

## Why DS Conversation

Smart auto-scroll: stays pinned to the newest content while streaming, but **won't yank you down while you read back** through history (a jump-to-latest button appears when you've scrolled up). This replaces the manual `listRef.scrollTo` effect that always force-scrolled.

## Notes

- **Render-layer only.** The streaming / self-heal invariants are untouched: #613 (slot stays mounted across surface switches) and #615 (`tasks/get` reconcile of a stuck stream) both still pass their e2e.
- `runTurn` now builds its optimistic base off the live store snapshot instead of the render closure, so *regenerate* can trim-then-rerun in the same tick.
- Old `.message*` bubble CSS removed; user input keeps literal newlines via a `.chat-user-text` pre-wrap span.
- e2e selectors moved to the DS classes (`.pl-message--*`, `.pl-message__content`); new `message-actions.spec.ts` covers copy / fork / regenerate.

## Test

Full web build + typecheck clean. **100 e2e green** (97 prior + 3 new).

🤖 Generated with [Claude Code](https://claude.com/claude-code)