### PR TITLE
feat(chat): file-only send — attachment with no caption

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **File-only chat send** — you can now send a message with an attachment and no typed
+  text (attach an image or doc and hit send with an empty field — e.g. "describe this").
+  The composer's send gate enables on text **or** a ready attachment, matching the DS
+  PromptInput (`@protolabsai/ui` bumped to 0.34 for the attachment-aware submit). The user
+  bubble still shows just the 📎 attachment line, never a raw dump.
 - **Chat message toolbar — copy, fork, regenerate** (DS message-thread adoption) — the
   chat transcript now uses the design-system `Conversation`/`Message`/`MessageActions`
   components. Each settled assistant reply gets a hover toolbar: **Copy** the answer,

--- a/apps/web/e2e/file-only-send.spec.ts
+++ b/apps/web/e2e/file-only-send.spec.ts
@@ -1,0 +1,35 @@
+import { expect, test } from "@playwright/test";
+
+// bd-1n7: a message can be sent with an attachment and NO typed text (e.g.
+// attach a doc/image and hit send with an empty field). The DS PromptInput
+// (@protolabsai/ui ≥ 0.34) enables submit when attachments are present, and the
+// composer's send gate matches.
+test("attach a file with no caption and send it", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+  const slot = page.locator(".chat-session-slot:not([hidden])");
+
+  // Attach a small text file via the hidden picker — no text typed.
+  await slot.locator('input[type="file"]').setInputFiles({
+    name: "notes.txt",
+    mimeType: "text/plain",
+    buffer: Buffer.from("hello from the attached file"),
+  });
+
+  // The attachment chip appears and settles (no longer uploading).
+  const chips = slot.locator(".pl-prompt__attachments");
+  await expect(chips).toContainText("notes.txt");
+  await expect(chips).not.toContainText("uploading");
+
+  // Send is enabled with an empty field — click it.
+  const send = slot.getByRole("button", { name: "Send" });
+  await expect(send).toBeEnabled();
+  await send.click();
+
+  // The turn sends: the user bubble shows the 📎 attachment line (not a raw dump),
+  // and the assistant answers.
+  await expect(slot.locator(".pl-message--user")).toContainText("notes.txt");
+  await expect(slot.locator(".pl-message--assistant .markdown")).toContainText(
+    "Done — found 8 results.",
+  );
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -323,6 +323,17 @@ const server = createServer(async (req, res) => {
       if (payload !== null) return sendJson(res, payload);
       return sendJson(res, { detail: "not mocked" }, 404);
     }
+    if (pathname === "/api/knowledge/attach" && req.method === "POST") {
+      // Chat attachment upload (#1002) — multipart, so DON'T JSON-parse the body.
+      // Drain it, then return the small-file "inline" tier with a context block.
+      req.resume();
+      await new Promise((r) => req.on("end", r));
+      return sendJson(res, {
+        enabled: true,
+        mode: "inline",
+        context: "[attachment notes.txt]\nhello from the attached file",
+      });
+    }
     // POST/PATCH/DELETE writes → generic ok so the UI doesn't error.
     const body = await readBody(req);
     const fleet = fleetFor(req);

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.33.0",
+    "@protolabsai/ui": "^0.34.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -417,7 +417,15 @@ function ChatSessionSlot({
     [messages],
   );
 
-  const canSend = useMemo(() => Boolean(draft.trim()) && status !== "streaming", [draft, status]);
+  // Sendable with text OR at least one ready attachment (file-only send, e.g.
+  // "describe this image" with no caption). Matches the DS PromptInput gate,
+  // which also enables submit when attachments are present (@protolabsai/ui ≥ 0.34).
+  const canSend = useMemo(
+    () =>
+      (Boolean(draft.trim()) || attachments.some((a) => a.status === "ready")) &&
+      status !== "streaming",
+    [draft, attachments, status],
+  );
 
   async function send() {
     if (!session || !canSend) return;

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.33.0",
+        "@protolabsai/ui": "^0.34.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.33.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.33.0.tgz",
-      "integrity": "sha512-VdrGNpTpOhbBey6OZbSkL2t1shkrrEOPYN8RlndILZz74CPeBd4YIh0cQK6k4jOtZqSyr3FBvJTKvsT0rZBjtA==",
+      "version": "0.34.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.34.0.tgz",
+      "integrity": "sha512-TnPYAY0LN+F0+yOb3oJ3k1yjHFxHpS6bM0aW99hG5AKfs5itKAcfXOfbD3wgnOXtqTsiA7jpJ1mRmvwlwOmdWA==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## What

Closes **bd-1n7**. You can now send a chat message with an **attachment and no typed text** — attach an image or doc and hit send with an empty field (e.g. "describe this image" without a caption).

## How

- `canSend` enables on text **or** a ready attachment (was text-only). This matches the DS `PromptInput`, which now enables submit when attachments are present.
- Bumps `@protolabsai/ui` 0.33 → **0.34** — the [attachment-aware submit gate](https://github.com/protoLabsAI/protoContent/pull/234) I just landed upstream (`canSubmit`/Enter fire with text **or** attachments).
- The composer's `send()` already handled the no-text case (the user bubble shows just the 📎 attachment line, while the model gets the attachment context / native image) — this PR only unblocks the gate.

## Test

- The mock e2e server now answers `POST /api/knowledge/attach` (multipart, inline tier), so the upload path is finally exercisable in e2e.
- New `file-only-send.spec.ts`: attach a file with an empty field → send is enabled → the turn sends (📎 bubble + assistant answer).
- Full web build + typecheck clean. **101 e2e green.**

This completes the chat-UX refresh trio after native vision (#1009) and the DS message-thread (#1011).

🤖 Generated with [Claude Code](https://claude.com/claude-code)