### PR TITLE
feat(chat): paste images + large text as attachments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Paste images + large text as attachments** — pasting an image (a screenshot, even when
+  the browser exposes it only via clipboard `items`) now adds it as an attachment, and
+  pasting text over a threshold (~1500 chars or ~20 lines) becomes a removable attachment
+  pill — routed through the same tiering as a dropped file (inline / RAG-indexed) — instead
+  of flooding the input field. Short pastes still go straight into the field. Drag-drop uses
+  the same image-aware collection.
 - **File-only chat send** — you can now send a message with an attachment and no typed
   text (attach an image or doc and hit send with an empty field — e.g. "describe this").
   The composer's send gate enables on text **or** a ready attachment, matching the DS

--- a/apps/web/e2e/paste-attach.spec.ts
+++ b/apps/web/e2e/paste-attach.spec.ts
@@ -1,0 +1,61 @@
+import { expect, test } from "@playwright/test";
+
+// Composer paste behaviour (bd-873 / bd-2pp): a large text paste becomes a
+// removable attachment pill instead of flooding the field, and a pasted image
+// (delivered via clipboard items[]) becomes an attachment.
+
+const FIELD = ".chat-session-slot:not([hidden]) .pl-prompt__field";
+
+// Dispatch a synthetic paste carrying text on the composer textarea.
+async function pasteText(page, text: string) {
+  await page.evaluate(
+    ({ sel, text }) => {
+      const ta = document.querySelector(sel) as HTMLTextAreaElement;
+      const dt = new DataTransfer();
+      dt.setData("text/plain", text);
+      ta.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }));
+    },
+    { sel: FIELD, text },
+  );
+}
+
+test.beforeEach(async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+});
+
+test("a large text paste becomes a removable attachment, not field text", async ({ page }) => {
+  const slot = page.locator(".chat-session-slot:not([hidden])");
+  await pasteText(page, "X".repeat(2000));
+
+  const chips = slot.locator(".pl-prompt__attachments");
+  await expect(chips).toContainText("Pasted text.txt");
+  await expect(chips).not.toContainText("uploading");
+  await expect(page.locator(FIELD)).toHaveValue(""); // not dumped into the input
+
+  // Removable like any attachment.
+  await chips.getByRole("button", { name: /remove/i }).first().click();
+  await expect(chips).toHaveCount(0);
+});
+
+test("a short text paste falls through to the field (no attachment)", async ({ page }) => {
+  const slot = page.locator(".chat-session-slot:not([hidden])");
+  await pasteText(page, "just a short note");
+  await expect(slot.locator(".pl-prompt__attachments")).toHaveCount(0);
+});
+
+test("a pasted image (clipboard items) becomes an attachment", async ({ page }) => {
+  const slot = page.locator(".chat-session-slot:not([hidden])");
+  await page.evaluate((sel) => {
+    const ta = document.querySelector(sel) as HTMLTextAreaElement;
+    const b64 =
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+    const bytes = Uint8Array.from(atob(b64), (c) => c.charCodeAt(0));
+    const file = new File([bytes], "shot.png", { type: "image/png" });
+    const dt = new DataTransfer();
+    dt.items.add(file);
+    ta.dispatchEvent(new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true }));
+  }, FIELD);
+
+  await expect(slot.locator(".pl-prompt__attachments")).toContainText("shot.png");
+});

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -30,6 +30,7 @@ import { chatStore, useChatState } from "./chat-store";
 import { ChatComponent } from "./ChatComponent";
 import { ComposerModelSelect } from "./ComposerModelSelect";
 import { Markdown } from "./LazyMarkdown";
+import { filesFromTransfer, isLargePaste, pastedTextFile } from "./paste";
 import { ToolCalls } from "./ToolCalls";
 
 function messageId() {
@@ -835,7 +836,7 @@ function ChatSessionSlot({
         }}
         onDragOver={(e) => { if (e.dataTransfer?.types?.includes("Files")) e.preventDefault(); }}
         onDrop={(e) => {
-          const files = Array.from(e.dataTransfer?.files ?? []);
+          const files = filesFromTransfer(e.dataTransfer);
           if (files.length) {
             e.preventDefault();
             files.forEach((f) => void uploadAttachment(f));
@@ -864,12 +865,22 @@ function ChatSessionSlot({
           inputRef={textareaRef}
           onKeyDown={onComposerKeyDown}
           onPaste={(e) => {
-            // Paste-to-attach (the DS onPaste seam): files on the clipboard become
-            // attachments; plain text paste falls through to the field.
-            const files = Array.from(e.clipboardData?.files ?? []);
+            // Paste-to-attach (the DS onPaste seam). Clipboard files — incl.
+            // IMAGES/screenshots that some browsers expose only via items[] —
+            // become attachments.
+            const files = filesFromTransfer(e.clipboardData);
             if (files.length) {
               e.preventDefault();
               files.forEach((f) => void uploadAttachment(f));
+              return;
+            }
+            // A large text paste becomes a removable attachment pill (routed
+            // through the attach pipeline → tiered inline/indexed) instead of
+            // flooding the field; small pastes fall through to the textarea.
+            const text = e.clipboardData?.getData("text/plain") ?? "";
+            if (isLargePaste(text)) {
+              e.preventDefault();
+              void uploadAttachment(pastedTextFile(text));
             }
           }}
           onAttach={() => fileInputRef.current?.click()}

--- a/apps/web/src/chat/paste.test.ts
+++ b/apps/web/src/chat/paste.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  LARGE_PASTE_CHARS,
+  LARGE_PASTE_LINES,
+  filesFromTransfer,
+  isLargePaste,
+  namedFile,
+  pastedTextFile,
+} from "./paste";
+
+describe("isLargePaste", () => {
+  it("is false for empty / short text", () => {
+    expect(isLargePaste("")).toBe(false);
+    expect(isLargePaste("a quick message")).toBe(false);
+  });
+
+  it("is true over the character threshold", () => {
+    expect(isLargePaste("x".repeat(LARGE_PASTE_CHARS + 1))).toBe(true);
+    expect(isLargePaste("x".repeat(LARGE_PASTE_CHARS))).toBe(false);
+  });
+
+  it("is true over the line threshold even when short", () => {
+    expect(isLargePaste("a\n".repeat(LARGE_PASTE_LINES + 1))).toBe(true);
+    expect(isLargePaste("a\n".repeat(2))).toBe(false);
+  });
+});
+
+describe("namedFile", () => {
+  it("keeps an existing name", () => {
+    const f = new File(["x"], "report.pdf", { type: "application/pdf" });
+    expect(namedFile(f)).toBe(f);
+  });
+
+  it("names an unnamed image by its mime subtype", () => {
+    const out = namedFile(new File(["x"], "", { type: "image/png" }));
+    expect(out.name).toBe("pasted-image.png");
+    expect(out.type).toBe("image/png");
+  });
+
+  it("falls back to a generic name for an unnamed typeless blob", () => {
+    expect(namedFile(new File(["x"], "", { type: "" })).name).toBe("pasted-file.bin");
+  });
+});
+
+describe("filesFromTransfer", () => {
+  it("returns [] for a null payload", () => {
+    expect(filesFromTransfer(null)).toEqual([]);
+  });
+
+  it("prefers items[].getAsFile() (clipboard images live there)", () => {
+    const img = new File(["x"], "", { type: "image/png" });
+    const dt = {
+      items: [
+        { kind: "string", getAsFile: () => null },
+        { kind: "file", getAsFile: () => img },
+      ],
+      files: [],
+    } as unknown as DataTransfer;
+    const out = filesFromTransfer(dt);
+    expect(out).toHaveLength(1);
+    expect(out[0].name).toBe("pasted-image.png"); // unnamed → named
+  });
+
+  it("falls back to .files when items has no files", () => {
+    const doc = new File(["x"], "notes.txt", { type: "text/plain" });
+    const dt = { items: [], files: [doc] } as unknown as DataTransfer;
+    expect(filesFromTransfer(dt)).toEqual([doc]);
+  });
+});
+
+describe("pastedTextFile", () => {
+  it("wraps text as a text/plain file", async () => {
+    const f = pastedTextFile("hello world");
+    expect(f.name).toBe("Pasted text.txt");
+    expect(f.type).toBe("text/plain");
+    expect(await f.text()).toBe("hello world");
+  });
+});

--- a/apps/web/src/chat/paste.ts
+++ b/apps/web/src/chat/paste.ts
@@ -1,0 +1,49 @@
+// Clipboard / drag-drop → attachment helpers for the chat composer.
+//
+// Two behaviours sit on top of these:
+//  • pasted IMAGES (screenshots) and files become attachments — see
+//    `filesFromTransfer` (catches images a browser exposes only via `items`);
+//  • pasted TEXT over a threshold becomes a removable attachment pill instead
+//    of flooding the input — see `isLargePaste`.
+
+// Pasted text longer than this (characters OR lines) is attached rather than
+// inserted into the field. Tuned so a normal message stays inline but a pasted
+// log / article / code block becomes an attachment.
+export const LARGE_PASTE_CHARS = 1500;
+export const LARGE_PASTE_LINES = 20;
+
+export function isLargePaste(text: string): boolean {
+  if (!text) return false;
+  return text.length > LARGE_PASTE_CHARS || text.split("\n").length > LARGE_PASTE_LINES;
+}
+
+// Give an unnamed clipboard blob (e.g. a pasted screenshot) a sensible filename
+// so the attachment pill has a label and the backend gets an extension.
+export function namedFile(f: File): File {
+  if (f.name) return f;
+  const isImg = f.type.startsWith("image/");
+  const ext = (f.type.split("/")[1] || "").replace(/[^a-z0-9]/gi, "") || (isImg ? "png" : "bin");
+  return new File([f], `pasted-${isImg ? "image" : "file"}.${ext}`, { type: f.type });
+}
+
+// Collect Files from a clipboard or drag payload. Prefer `items[].getAsFile()`
+// so clipboard IMAGES that a browser surfaces only via `items` (not `.files`)
+// are caught; fall back to `.files`. Unnamed blobs are given a name.
+export function filesFromTransfer(dt: DataTransfer | null | undefined): File[] {
+  if (!dt) return [];
+  const fromItems: File[] = [];
+  for (const item of Array.from(dt.items ?? [])) {
+    if (item.kind === "file") {
+      const f = item.getAsFile();
+      if (f) fromItems.push(namedFile(f));
+    }
+  }
+  if (fromItems.length) return fromItems;
+  return Array.from(dt.files ?? []).map(namedFile);
+}
+
+// The synthetic file a large text paste is wrapped in (routed through the same
+// attach pipeline as a dropped .txt, so it gets tiered inline/indexed).
+export function pastedTextFile(text: string): File {
+  return new File([text], "Pasted text.txt", { type: "text/plain" });
+}


### PR DESCRIPTION
## What

Two composer paste improvements (closes **bd-873** + **bd-2pp**):

- **Paste images** — pasting a screenshot now adds it as an attachment, including images a browser exposes only via clipboard `items[]` (not `.files`) — the previous handler missed those. Unnamed clipboard blobs get a synthesized filename. Drag-drop uses the same image-aware collection.
- **Paste large text as an attachment** — pasting text over a threshold (~1500 chars **or** ~20 lines) becomes a **removable attachment pill** instead of flooding the input. It's wrapped as a `text/plain` file and routed through the same attach pipeline as a dropped doc, so it gets tiered (inline for small, RAG-indexed for big). Short pastes still go straight into the field.

## How

Paste logic extracted to `src/chat/paste.ts` (pure, testable):
- `filesFromTransfer(dt)` — prefer `items[].getAsFile()`, fall back to `.files`; name unnamed blobs.
- `isLargePaste(text)` — char/line threshold (named constants, easy to tune).
- `pastedTextFile(text)` — wraps a big paste as `Pasted text.txt`.

The composer `onPaste`/`onDrop` call these; everything else (tiering, the 📎 pill, removal, send) reuses the existing attachment machinery.

## Threshold

Defaulted to **1500 chars / 20 lines** (`LARGE_PASTE_CHARS` / `LARGE_PASTE_LINES` in `paste.ts`) — a normal message stays inline; a pasted log / article / code block attaches. Easy to change if you'd prefer a different cutoff.

## Test

- `paste.test.ts` — 10 unit cases (thresholds, item-vs-files preference, naming).
- `paste-attach.spec.ts` — live: large text → removable pill + empty field; short text → fallthrough; pasted image item → attachment.
- **83 unit + 104 e2e green**; build + typecheck clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)