### PR TITLE
fix(chat): system (background-agent) messages render as a readable card, not a centered pill

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Background-agent notifications render legibly again.** After the DS
+  message-thread adoption, `role:"system"` chat messages — which in practice are
+  background-agent completion reports (ADR 0050): a lede plus a full markdown body
+  with tables/lists — were picking up the design-system's *terse one-line system*
+  styling (centered text in a 100px-rounded pill), turning a report into an
+  unreadable rounded blob. They now render as a left-aligned, readable inset card
+  with a subtle left accent (still visually distinct as system/automation output).
+
 ### Added
 - **Paste images + large text as attachments** — pasting an image (a screenshot, even when
   the browser exposes it only via clipboard `items`) now adds it as an attachment, and

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -45,6 +45,30 @@
   word-break: break-word;
 }
 
+/* Our only `role:"system"` chat messages are background-agent completion
+   notifications (ADR 0050) — full markdown reports (a lede + tables/lists), not
+   a one-line notice. The DS styles system messages as a terse CENTERED 100px
+   pill, which turns a report into an unreadable rounded blob. Override to a
+   left-aligned, readable inset card (a left accent marks it as system/automation)
+   so the report renders like assistant content but stays visually distinct. */
+/* Anchored under .chat-session-slot so it outranks the DS rule (same class
+   specificity) regardless of stylesheet import order. */
+.chat-session-slot .pl-message--system .pl-message__content {
+  display: block;
+  text-align: left;
+  font-size: 0.9rem;
+  color: var(--pl-color-fg);
+  background: var(--pl-color-bg-inset);
+  border: var(--pl-border-width) solid var(--pl-color-border);
+  border-left: 3px solid var(--pl-color-border-strong);
+  border-radius: var(--pl-radius);
+  padding: 12px 16px;
+}
+/* The lede ("✅ Background agent finished — …") is the first markdown line; keep
+   the report's own margins tidy inside the card. */
+.chat-session-slot .pl-message--system .pl-message__content .markdown > :first-child { margin-top: 0; }
+.chat-session-slot .pl-message--system .pl-message__content .markdown > :last-child { margin-bottom: 0; }
+
 /* Subtle live status above the composer while streaming (was a header pill). */
 .composer-status {
   display: flex;


### PR DESCRIPTION
## Problem

After the DS message-thread adoption (#1011), background-agent completion notifications (ADR 0050) render as a **centered, 100px-rounded pill with tiny dim text** — see the audit report in the report below turning into an unreadable rounded blob.

Cause: those notifications are `role:"system"` chat messages (`BackgroundWatch.tsx`), and the design system styles *system* messages as a terse one-line notice (`text-align:center; border-radius:100px; font-size:0.78rem; display:inline-block`). That's right for "model changed" but wrong for a full markdown report (lede + tables + lists), which is the *only* kind of system message we produce in chat.

## Fix

Override `.pl-message--system .pl-message__content` in `chat.css` to a left-aligned, readable inset card with a subtle left accent — so the report reads like assistant content but stays visually distinct as system/automation output. Anchored under `.chat-session-slot` so it outranks the equal-specificity DS rule regardless of stylesheet import order; markdown keeps tidy first/last margins.

CSS-only. Build + CSS-comment guard + chat e2e green.