### PR TITLE
docs(fleet): note the slug proxy forwards WebSocket upgrades (#883)

### DIFF
--- a/docs/adr/0042-fleet-supervisor-unified-console.md
+++ b/docs/adr/0042-fleet-supervisor-unified-console.md
@@ -74,6 +74,13 @@ plugin views) to the active agent's loopback backend, streaming SSE through unbu
 **Auth**: agents bind loopback and trust a shared hub token (the hub injects it); the
 browser only ever talks to the hub (same-origin), so no per-agent CORS/token sprawl.
 
+> **Amendment (v0.35.0, #883/#900):** the slug proxy also forwards **WebSocket upgrades**,
+> not just HTTP/SSE. The original proxy stripped `Upgrade`/`Connection`, so a member's
+> plugin view that opened a live WS (e.g. `agent_browser`'s viewport) loaded over HTTP but
+> its socket showed "Disconnected" behind the hub. `proxy.forward_ws` resolves the slug →
+> member, opens a client WS (carrying the bearer + subprotocols), and pumps frames both
+> ways — so WS plugin views traverse the hub like HTTP does.
+
 ### D. Session continuity (≈ free)
 Each agent's checkpoints/goals/memory are already `instance.id`-scoped (ADR 0004/0041) —
 so switching back loads that agent's thread, and it survives stop→restart (resume from

--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -124,11 +124,13 @@ one keeps its background work (schedules, an in-flight loop) going while you're 
 ## The unified console — every agent in one UI
 
 *(Shipped — ADR 0042 slices 2–5.)* The **hub** (any running agent) serves one console and
-reverse-proxies each agent window's chat / A2A / SSE to that agent's backend, keyed by the
-**URL slug** (`/app/agent/<id>/`) — so every window targets its own agent: switch in place
-from the topbar, or open two agents in two windows at once. Per-agent chat, theme and
-layout follow the slug; a stopped agent **resumes from its checkpoint** when you navigate
-to it; "+ New agent" runs the archetype picker. Settings → Agents is the fleet manager
+reverse-proxies each agent window's chat / A2A / SSE / WebSockets to that agent's backend,
+keyed by the **URL slug** (`/app/agent/<id>/`) — so every window targets its own agent:
+switch in place from the topbar, or open two agents in two windows at once. Per-agent chat,
+theme and layout follow the slug; a stopped agent **resumes from its checkpoint** when you
+navigate to it; "+ New agent" runs the archetype picker. A plugin view served by a member
+that opens a **WebSocket** (e.g. `agent_browser`'s live viewport) works through the hub too:
+the slug proxy forwards WS upgrades, not just HTTP/SSE ([#883](https://github.com/protoLabsAI/protoAgent/issues/883), shipped v0.35.0). Settings → Agents is the fleet manager
 (create / start / stop / rename / remove), and **Discover** finds other protoAgents on the
 box, the LAN (mDNS) and your **tailnet** (via the Tailscale CLI).
 


### PR DESCRIPTION
## What
Documents the fleet WS-proxy capability that shipped in **v0.35.0** (#900, fixing #883). The fix was changelogged at the time, but the **fleet guide** and **ADR 0042** still described the slug proxy as HTTP/SSE-only.

## Changes
- **`docs/guides/fleet.md`** — the unified-console proxy now lists `chat / A2A / SSE / WebSockets`, plus a sentence noting a member's WS plugin view (e.g. `agent_browser`'s live viewport) traverses the hub.
- **`docs/adr/0042` §C** — amendment noting `proxy.forward_ws` / WS-upgrade forwarding added in v0.35.0.

Docs-only; no code change. The implementation already exists on `main` (`graph/fleet/proxy.py:forward_ws`, route in `operator_api/fleet_routes.py`, test `tests/test_fleet_proxy_ws.py`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)