### PR TITLE
feat(ops): JSON logging option + backup/restore & shutdown docs + dead-comment cleanup (#876)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Opt-in JSON logging (`LOG_FORMAT=json`)** — set it to emit one JSON object
+  per log line (`ts`/`level`/`logger`/`message`, plus the exception traceback and
+  any `extra=` fields) so aggregators (Loki, CloudWatch, Datadog) can index logs
+  without a grok pattern. Default keeps the human-readable stdlib format; level
+  (`LOG_LEVEL`) and the stderr stream are unchanged either way. (#876)
+- **Deploy guide: backup/restore + shutdown semantics.** `docs/guides/deploy.md`
+  gains an Operations section — how to back up the data dir without corrupting the
+  WAL-mode SQLite stores (cold stop-and-tar or hot `.backup`), how to restore, and
+  what `SIGTERM` does to an in-flight turn (cancelled-but-reconciled; 5s graceful
+  drain). (#876)
+
 ### Fixed
 - **Background-agent notifications render legibly again.** After the DS
   message-thread adoption, `role:"system"` chat messages — which in practice are

--- a/docs/adr/0042-fleet-supervisor-unified-console.md
+++ b/docs/adr/0042-fleet-supervisor-unified-console.md
@@ -74,6 +74,13 @@ plugin views) to the active agent's loopback backend, streaming SSE through unbu
 **Auth**: agents bind loopback and trust a shared hub token (the hub injects it); the
 browser only ever talks to the hub (same-origin), so no per-agent CORS/token sprawl.
 
+> **Amendment (v0.35.0, #883/#900):** the slug proxy also forwards **WebSocket upgrades**,
+> not just HTTP/SSE. The original proxy stripped `Upgrade`/`Connection`, so a member's
+> plugin view that opened a live WS (e.g. `agent_browser`'s viewport) loaded over HTTP but
+> its socket showed "Disconnected" behind the hub. `proxy.forward_ws` resolves the slug →
+> member, opens a client WS (carrying the bearer + subprotocols), and pumps frames both
+> ways — so WS plugin views traverse the hub like HTTP does.
+
 ### D. Session continuity (≈ free)
 Each agent's checkpoints/goals/memory are already `instance.id`-scoped (ADR 0004/0041) —
 so switching back loads that agent's thread, and it survives stop→restart (resume from

--- a/docs/guides/deploy.md
+++ b/docs/guides/deploy.md
@@ -108,6 +108,66 @@ From the Actions tab, run `prepare-release.yml` manually and pick `patch` / `min
 
 Releases are **manual / on-demand** — merging a PR does **not** cut a release. See the [Releasing runbook](/guides/releasing) for the changelog protocol + the branch ruleset.
 
+## Operations
+
+### Backup & restore
+
+All durable state lives under one **data dir** — `/sandbox` in a container,
+`~/.protoagent` otherwise. It holds the SQLite conversation checkpoints
+(`checkpoints.db`), the knowledge store (`knowledge/`), the audit log
+(`audit/audit.jsonl`), scheduler jobs (`scheduler/<agent>/jobs.db`), and the
+inbox / activity / telemetry / background stores.
+
+> The sample compose above persists only `audit` and `knowledge`. Because
+> Watchtower **recreates** the container on every image update, anything not on a
+> mounted volume is lost — conversation history, scheduled jobs, the inbox. For a
+> durable deployment, mount the whole data dir (e.g. `data:/sandbox`) so every
+> store survives a recreate; the backup below then snapshots all of it.
+
+The SQLite stores run in **WAL mode**, so a naive `tar` of a live file can copy a
+torn page (a write in flight) or miss the `-wal` / `-shm` sidecars — producing a
+backup that won't open. Two safe options:
+
+**Cold (simplest, always consistent)** — stop the agent, archive, restart:
+
+```bash
+docker compose stop my-agent          # or Ctrl-C / systemctl stop
+tar czf protoagent-$(date +%F).tgz -C /sandbox .   # ~/.protoagent for a non-container run
+docker compose start my-agent
+```
+
+**Hot (no downtime)** — take a consistent snapshot of each live DB with SQLite's
+online backup, then archive the snapshots:
+
+```bash
+sqlite3 /sandbox/checkpoints.db ".backup '/tmp/backup/checkpoints.db'"
+# repeat for knowledge/*.db and scheduler/<agent>/jobs.db, then tar /tmp/backup + audit/
+```
+
+**Restore** — stop the agent, replace the data dir from the archive, restart:
+
+```bash
+docker compose stop my-agent
+tar xzf protoagent-2026-06-14.tgz -C /sandbox
+docker compose start my-agent
+```
+
+### Shutdown semantics
+
+On `SIGTERM` (`docker stop`, `systemctl stop`) or `SIGINT` (Ctrl-C) the server
+runs its FastAPI shutdown hooks — spinning down fleet members, stopping the
+scheduler, and withdrawing mDNS — then uvicorn drains in-flight connections.
+The graceful drain is **bounded to 5s** (`timeout_graceful_shutdown=5`) so the
+long-lived SSE streams the console holds (chat, runtime status) don't block
+shutdown forever; past that they're force-closed.
+
+A turn **in progress** when the signal arrives is cancelled and its work is lost.
+This is acceptable by design: the A2A task store is durable, so a client that
+reconnects reconciles the interrupted task via `tasks/get` and can resubmit. If
+your turns routinely run longer than the drain window and you want them to finish,
+raise the container's stop grace period (Compose `stop_grace_period`, or
+`docker stop -t <seconds>`) — it defaults to 10s before `SIGKILL`.
+
 ## Related
 
 - [Fork the template](/guides/fork-the-template) — the earlier steps that set up the rest

--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -124,11 +124,13 @@ one keeps its background work (schedules, an in-flight loop) going while you're 
 ## The unified console — every agent in one UI
 
 *(Shipped — ADR 0042 slices 2–5.)* The **hub** (any running agent) serves one console and
-reverse-proxies each agent window's chat / A2A / SSE to that agent's backend, keyed by the
-**URL slug** (`/app/agent/<id>/`) — so every window targets its own agent: switch in place
-from the topbar, or open two agents in two windows at once. Per-agent chat, theme and
-layout follow the slug; a stopped agent **resumes from its checkpoint** when you navigate
-to it; "+ New agent" runs the archetype picker. Settings → Agents is the fleet manager
+reverse-proxies each agent window's chat / A2A / SSE / WebSockets to that agent's backend,
+keyed by the **URL slug** (`/app/agent/<id>/`) — so every window targets its own agent:
+switch in place from the topbar, or open two agents in two windows at once. Per-agent chat,
+theme and layout follow the slug; a stopped agent **resumes from its checkpoint** when you
+navigate to it; "+ New agent" runs the archetype picker. A plugin view served by a member
+that opens a **WebSocket** (e.g. `agent_browser`'s live viewport) works through the hub too:
+the slug proxy forwards WS upgrades, not just HTTP/SSE ([#883](https://github.com/protoLabsAI/protoAgent/issues/883), shipped v0.35.0). Settings → Agents is the fleet manager
 (create / start / stop / rename / remove), and **Discover** finds other protoAgents on the
 box, the LAN (mDNS) and your **tailnet** (via the Tailscale CLI).
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -141,8 +141,9 @@ If both keys are unset, tracing is disabled and every helper in `tracing.py` bec
 | Variable | Default | What |
 |---|---|---|
 | `LOG_LEVEL` | `INFO` | Python logging level. Valid: `DEBUG`, `INFO`, `WARNING`, `ERROR`. |
+| `LOG_FORMAT` | `text` | Set to `json` to emit one JSON object per log line (keys: `ts`, `level`, `logger`, `message`, plus `exc`/`exc_type` on errors and any `extra=` fields) — parse-stable for aggregators (Loki, CloudWatch, Datadog). Anything else keeps the human-readable format. Same level + stderr stream either way. |
 
-The template explicitly calls `logging.basicConfig(level=INFO)` — without this, Python's default WARNING would hide `logger.info(...)` lines like "webhook delivered", making A2A issues invisible in container logs.
+The template configures logging at startup (`observability/logging_config.py`) — without an explicit level, Python's default WARNING would hide `logger.info(...)` lines like "webhook delivered", making A2A issues invisible in container logs.
 
 ## Streaming / origin verification
 

--- a/observability/logging_config.py
+++ b/observability/logging_config.py
@@ -1,0 +1,85 @@
+"""Log formatting — human-readable (default) or JSON lines for aggregators.
+
+``server/__init__.py`` calls :func:`configure_logging` once at import. The
+default keeps the historic stdlib format
+(``%(asctime)s %(levelname)s %(name)s %(message)s``) — fine for a human tailing
+``docker logs``. Set ``LOG_FORMAT=json`` to emit one JSON object per line
+instead, which parse-stable aggregators (Loki, CloudWatch, Datadog, …) can index
+without a grok pattern. Level (``LOG_LEVEL``, default ``INFO``) and the stream
+(standard error, via ``StreamHandler``) are unchanged from the previous
+``basicConfig`` call regardless of format.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+
+_HUMAN_FORMAT = "%(asctime)s %(levelname)s %(name)s %(message)s"
+
+# Attributes a bare LogRecord already carries. Anything outside this set that a
+# caller attached via ``extra=`` is emitted as a top-level JSON field so
+# structured context survives the JSON formatter (the human format drops it).
+_RESERVED = frozenset(vars(logging.makeLogRecord({}))) | {"message", "asctime"}
+
+
+class JsonFormatter(logging.Formatter):
+    """Render each record as a single-line JSON object.
+
+    Stable keys (``ts``, ``level``, ``logger``, ``message``) plus the exception
+    type + rendered traceback when the record carries ``exc_info``, plus any
+    ``extra=`` fields the caller attached.
+    """
+
+    def format(self, record: logging.LogRecord) -> str:
+        payload: dict[str, object] = {
+            "ts": self.formatTime(record, self.datefmt),
+            "level": record.levelname,
+            "logger": record.name,
+            "message": record.getMessage(),
+        }
+        if record.exc_info:
+            payload["exc_type"] = getattr(
+                record.exc_info[0], "__name__", str(record.exc_info[0])
+            )
+            payload["exc"] = self.formatException(record.exc_info)
+        elif record.exc_text:
+            payload["exc"] = record.exc_text
+        if record.stack_info:
+            payload["stack"] = self.formatStack(record.stack_info)
+        for key, value in record.__dict__.items():
+            if key not in _RESERVED and not key.startswith("_"):
+                payload[key] = value
+        return json.dumps(payload, default=str, ensure_ascii=False)
+
+
+# The single handler this module owns on the root logger. Tracked so a re-call
+# swaps the formatter (human ⇄ JSON) by replacing *our* handler only — NOT every
+# root handler (a blunt basicConfig(force=True) would also evict handlers added by
+# pytest's caplog or a host application, breaking log capture / their routing).
+_handler: logging.Handler | None = None
+
+
+def configure_logging() -> None:
+    """Install/refresh the root log handler from ``LOG_LEVEL`` + ``LOG_FORMAT``.
+
+    ``LOG_FORMAT=json`` → :class:`JsonFormatter`; anything else (default) keeps
+    the historic human format. Re-entrant: a second call replaces the handler
+    this module previously installed (so the formatter can switch) and leaves any
+    other root handlers untouched.
+    """
+    global _handler
+    handler = logging.StreamHandler()  # defaults to sys.stderr, as basicConfig did
+    if os.environ.get("LOG_FORMAT", "").strip().lower() == "json":
+        handler.setFormatter(JsonFormatter())
+    else:
+        handler.setFormatter(logging.Formatter(_HUMAN_FORMAT))
+
+    root = logging.getLogger()
+    if _handler is not None and _handler in root.handlers:
+        root.removeHandler(_handler)
+        _handler.close()
+    root.addHandler(handler)
+    root.setLevel(os.environ.get("LOG_LEVEL", "INFO").upper())
+    _handler = handler

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -58,33 +58,18 @@ if TYPE_CHECKING:
 # Root-level log config. Python's default is WARNING, which silently filters
 # every `logger.info(...)` call — including "webhook delivered" lines from
 # the A2A push sender, making the A2A/webhook path invisible in docker logs.
-# LOG_LEVEL env var lets operators tune without a code change.
-logging.basicConfig(
-    level=os.environ.get("LOG_LEVEL", "INFO").upper(),
-    format="%(asctime)s %(levelname)s %(name)s %(message)s",
-)
+# LOG_LEVEL tunes verbosity; LOG_FORMAT=json swaps the human format for JSON
+# lines an aggregator can parse without a grok pattern (both keep the historic
+# stderr stream). See observability/logging_config.py.
+from observability.logging_config import configure_logging
+
+configure_logging()
 log = logging.getLogger("protoagent.server")
 
 
 # ---------------------------------------------------------------------------
 # Agent setup
 # ---------------------------------------------------------------------------
-
-                         # mounted ONCE at init; not hot-reloaded.
-                         # — started in the startup hook, stopped on shutdown.
-                       # Read by the autostart installer so the LaunchAgent reboots
-                       # on the same port the operator launched with, not the default.
-                       # Constructed at init, started on FastAPI startup, stopped
-                       # on shutdown. Lifecycle is hooked in _main() so the
-                       # polling coroutine doesn't leak on server reload.
-                       # lifecycle as STATE.scheduler; keeps the prompt cache warm.
-                         # control messages and runs the goal-completion loop.
-                         # A config reload's heavy graph compile is offloaded to a
-                         # worker thread so it no longer freezes the loop; the
-                         # scheduler/Discord restart that follows still has to run
-                         # ON the loop, so the worker thread schedules it here via
-                         # run_coroutine_threadsafe instead of get_running_loop()
-                         # (which would silently no-op in the thread — the trap).
 
 _event_bus = EventBus()  # Server→client SSE push channel (ADR 0003). Process-
                          # lifetime singleton; producers publish, /api/events

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,84 @@
+"""Tests for the opt-in JSON log formatter (LOG_FORMAT=json) — #876.
+
+Locks in that the JSON formatter emits one parse-stable object per record with
+the stable keys aggregators index, carries exception tracebacks, passes through
+``extra=`` fields, and that configure_logging() only switches to JSON when the
+env opts in.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+from observability.logging_config import JsonFormatter, configure_logging
+
+
+def _record(**kw) -> logging.LogRecord:
+    defaults = dict(
+        name="protoagent.server",
+        level=logging.INFO,
+        pathname=__file__,
+        lineno=1,
+        msg="hello %s",
+        args=("world",),
+        exc_info=None,
+    )
+    defaults.update(kw)
+    return logging.LogRecord(func="t", **defaults)
+
+
+def test_json_formatter_emits_stable_keys():
+    out = JsonFormatter().format(_record())
+    obj = json.loads(out)  # raises if not valid single-line JSON
+    assert obj["level"] == "INFO"
+    assert obj["logger"] == "protoagent.server"
+    assert obj["message"] == "hello world"  # %-args interpolated
+    assert "ts" in obj
+    assert "\n" not in out
+
+
+def test_json_formatter_includes_exception():
+    try:
+        raise ValueError("boom")
+    except ValueError:
+        import sys
+
+        rec = _record(level=logging.ERROR, msg="failed", args=(), exc_info=sys.exc_info())
+    obj = json.loads(JsonFormatter().format(rec))
+    assert obj["exc_type"] == "ValueError"
+    assert "ValueError: boom" in obj["exc"]
+    assert "Traceback" in obj["exc"]
+
+
+def test_json_formatter_passes_through_extra_fields():
+    rec = _record()
+    rec.thread_id = "s-123"  # what logging's extra= attaches
+    obj = json.loads(JsonFormatter().format(rec))
+    assert obj["thread_id"] == "s-123"
+
+
+def _has_json_handler() -> bool:
+    # Scan all root handlers (pytest's caplog handler also lives here) rather than
+    # assume ours is first — configure_logging appends ours.
+    return any(
+        isinstance(h.formatter, JsonFormatter) for h in logging.getLogger().handlers
+    )
+
+
+def test_configure_logging_human_by_default(monkeypatch):
+    monkeypatch.delenv("LOG_FORMAT", raising=False)
+    configure_logging()
+    assert not _has_json_handler()
+
+
+def test_configure_logging_json_when_opted_in(monkeypatch):
+    monkeypatch.setenv("LOG_FORMAT", "json")
+    configure_logging()
+    try:
+        assert _has_json_handler()
+    finally:
+        # Restore the human default so this test doesn't leak JSON logging into
+        # the rest of the session.
+        monkeypatch.delenv("LOG_FORMAT", raising=False)
+        configure_logging()


### PR DESCRIPTION
Knocks out the actionable items from the 2026-06-10 prod-readiness audit tracked in #876.

## What & why

### 1. Opt-in JSON logging — `LOG_FORMAT=json` (item 1)
Logs were plain stdlib format only (`%(asctime)s %(levelname)s %(name)s %(message)s`) — fine for humans, not parse-stable for aggregators. New `observability/logging_config.py`:
- `LOG_FORMAT=json` emits one JSON object per line (`ts`/`level`/`logger`/`message`, plus the exception traceback and any `extra=` fields); anything else keeps the human format.
- `LOG_LEVEL` and the stderr stream are unchanged either way.
- `configure_logging()` is **re-entrant** and manages only the one handler it owns on the root logger — it doesn't blunt-`force` away handlers added by pytest's `caplog` or a host application (that would break log capture / their routing).

### 2. Deploy guide: backup/restore + shutdown (items 2 + 4)
`docs/guides/deploy.md` gains an **Operations** section:
- **Backup/restore** — the data dir holds WAL-mode SQLite (checkpoints, knowledge, scheduler, …), so a naive `tar` of a live file can copy a torn page or miss the `-wal`/`-shm` sidecars. Documents cold (stop-and-tar) and hot (`.backup`) snapshots + restore. Also flags that the sample compose only persists `audit`+`knowledge`, so a Watchtower recreate drops everything else.
- **Shutdown semantics** — `SIGTERM` cancels an in-flight turn (work lost) but the durable A2A task store lets a reconnecting client reconcile via `tasks/get`; graceful drain is bounded to 5s (already shipped in #979). Note on raising the container stop grace period for long turns.

### 3. Dead-comment cleanup (item 5)
Deleted the orphaned floating-comment block at `server/__init__.py:73-87` — annotations whose globals were removed during the ADR 0023 decomposition.

## Not in this PR
- **Item 3 (data-dir version marker)** → split out to #1018 as cheap-insurance follow-up (no current pain).
- **Item 4 code** was already done — `timeout_graceful_shutdown=5` shipped in #979; only the doc remained (above).

## Test plan
- New `tests/test_logging_config.py` (5 tests): JSON keys stable + single-line, exception traceback captured, `extra=` pass-through, default stays human, `LOG_FORMAT=json` switches.
- `tests/test_exception_logging.py` still green (verified the re-entrant handler doesn't break `caplog`).
- `ruff check` clean; pytest collection clean (1987 tests); import contracts unaffected (`server → observability` already exists).

Closes #876

🤖 Generated with [Claude Code](https://claude.com/claude-code)