### PR TITLE
feat(scheduler): wait resumes in the originating chat thread (ADR 0053)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   WAL-mode SQLite stores (cold stop-and-tar or hot `.backup`), how to restore, and
   what `SIGTERM` does to an in-flight turn (cancelled-but-reconciled; 5s graceful
   drain). (#876)
+- **`wait` resumes in the same conversation** (ADR 0053). When the agent calls
+  `wait` inside a chat, the scheduled resume now fires back into **that chat's
+  thread** instead of the Activity thread — so it wakes up with the conversation
+  history intact and continues where it left off. The originating session is read
+  from the same per-turn contextvar the background-subagent path uses; the
+  scheduler `Job` gained a lazily-migrated `context_id` column (existing schedules
+  keep working). Plain scheduled jobs still land in the Activity thread. (Live UI
+  surfacing of the resumed turn in the chat tab is a tracked follow-up.)
 
 ### Fixed
 - **Background-agent notifications render legibly again.** After the DS

--- a/docs/adr/0053-wait-yield-and-resume.md
+++ b/docs/adr/0053-wait-yield-and-resume.md
@@ -63,21 +63,33 @@ independent of what the model would do next.
 
 ### Where the resume lands
 
-The scheduler fires resumes in the **Activity thread** (`system:activity`), the
-established home for autonomous/long-horizon work — durable and visible in the
-Activity feed. The agent's `then` instruction plus the Activity history carry the
-context forward; a long task becomes a chain of short turns, each ended by `wait`.
+**Same-session resume (added):** `wait` stamps the originating chat session onto
+the job (`Job.context_id`), read from the same `tracing.current_session_id()`
+contextvar the background-subagent path uses — no extra plumbing. The scheduler
+fires into `job.context_id or ACTIVITY_CONTEXT`, so a yield *from a chat* resumes
+in **that chat's thread** (the agent wakes with the conversation history intact),
+while a plain scheduled/Activity-origin job still lands in the durable Activity
+thread. `context_id` is a new, lazily-migrated `jobs` column (existing DBs keep
+working); the workstacean (remote) backend accepts the arg for parity but can't
+target a context, so it stays Activity-routed there.
 
-Resuming in the *originating* chat session instead (carrying the contextId
-through the job) is a deliberate follow-up, not part of this ADR.
+This is **agent-side continuity** (Problem A): the resumed turn runs in the chat's
+checkpointer thread. **UI surfacing** (Problem B) — making that server-fired turn
+*appear live* in the browser chat tab — is separate: the browser only renders
+turns it streamed, so it needs a per-session push (reusing the ADR 0050
+`background.completed` → `BackgroundWatch` pattern). That remains a follow-up
+(tracked in beads); until then the work happens in-thread and surfaces on the
+chat's next interaction.
 
 ## Consequences
 
 - Long-horizon "do X, wait, do Y" tasks no longer burn a turn's recursion budget
   polling; the budget covers actual work.
+- A `wait` issued inside a chat resumes in that same conversation thread — the
+  agent keeps full context across the yield.
 - `wait` is lead-agent-only (gated on the scheduler; subagents run bounded by
   `max_turns` and don't get it).
 - The yield is durable across restart (the resume is a persisted scheduler job).
-- Follow-up: optional same-session resume (thread the originating contextId into
-  the job so the continuation lands in the chat the user is watching, not only
-  the Activity feed).
+- Follow-up: live UI surfacing of the resumed turn in the originating chat tab
+  (per-session push à la ADR 0050), so a watching user sees the continuation
+  arrive rather than only the agent picking it up server-side.

--- a/scheduler/interface.py
+++ b/scheduler/interface.py
@@ -36,6 +36,11 @@ class Job:
     # IANA timezone the cron expression is evaluated in (e.g. "America/Chicago").
     # None = UTC. Ignored for one-shot ISO schedules (those carry their own offset).
     timezone: str | None = None
+    # A2A contextId to fire the job INTO (None → the durable Activity thread, the
+    # default for scheduled work). The `wait` tool sets this to the originating
+    # chat session so a yield-and-resume continues that conversation's thread
+    # rather than landing in Activity (ADR 0053 same-session resume).
+    context_id: str | None = None
     enabled: bool = True
 
     def as_dict(self) -> dict[str, Any]:
@@ -54,13 +59,17 @@ class SchedulerBackend(Protocol):
 
     def add_job(
         self, prompt: str, schedule: str, *, job_id: str | None = None,
-        timezone: str | None = None,
+        timezone: str | None = None, context_id: str | None = None,
     ) -> Job:
         """Persist a new job. Returns the stored ``Job`` (with
         backend-assigned id and next_fire if the caller didn't set them).
 
         ``timezone`` is an IANA name the cron expression is evaluated in
-        (None = UTC). Raises ``ValueError`` for malformed schedule/timezone."""
+        (None = UTC). Raises ``ValueError`` for malformed schedule/timezone.
+
+        ``context_id`` is the A2A contextId to fire into (None → the durable
+        Activity thread). Used for same-session resume (ADR 0053); backends that
+        can't target a context (remote schedulers) may ignore it."""
         ...
 
     def cancel_job(self, job_id: str) -> bool:

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -180,7 +180,8 @@ CREATE TABLE IF NOT EXISTS jobs (
     last_fire   TEXT,
     enabled     INTEGER NOT NULL DEFAULT 1,
     created_at  TEXT NOT NULL,
-    timezone    TEXT
+    timezone    TEXT,
+    context_id  TEXT
 );
 
 CREATE INDEX IF NOT EXISTS idx_jobs_next_fire   ON jobs(next_fire);
@@ -254,6 +255,11 @@ class LocalScheduler:
                 db.execute("ALTER TABLE jobs ADD COLUMN timezone TEXT")
             except sqlite3.OperationalError:
                 pass  # column already present
+            # …and before per-job context_id (ADR 0053 same-session resume).
+            try:
+                db.execute("ALTER TABLE jobs ADD COLUMN context_id TEXT")
+            except sqlite3.OperationalError:
+                pass  # column already present
             db.commit()
             db.close()
         except sqlite3.DatabaseError:
@@ -263,7 +269,7 @@ class LocalScheduler:
 
     def add_job(
         self, prompt: str, schedule: str, *, job_id: str | None = None,
-        timezone: str | None = None,
+        timezone: str | None = None, context_id: str | None = None,
     ) -> Job:
         if not prompt or not prompt.strip():
             raise ValueError("scheduler: prompt is required")
@@ -277,14 +283,17 @@ class LocalScheduler:
             agent_name=self.agent_name,
             next_fire=next_fire,
             timezone=timezone,
+            context_id=context_id,
         )
         db = self._connect()
         try:
             db.execute(
                 "INSERT INTO jobs (id, prompt, schedule, agent_name, next_fire, "
-                "last_fire, enabled, created_at, timezone) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                "last_fire, enabled, created_at, timezone, context_id) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
                 (job.id, job.prompt, job.schedule, job.agent_name,
-                 job.next_fire, job.last_fire, int(job.enabled), job.created_at, job.timezone),
+                 job.next_fire, job.last_fire, int(job.enabled), job.created_at,
+                 job.timezone, job.context_id),
             )
             db.commit()
         except sqlite3.IntegrityError as exc:
@@ -558,11 +567,12 @@ class LocalScheduler:
                     "role": "ROLE_USER",
                     "parts": [{"text": job.prompt}],
                     "messageId": message_id,
-                    # Route into the durable Activity thread (ADR 0003) so the
-                    # fired turn lands somewhere visible/continuable instead of a
-                    # throwaway context. Without this, the agent mints a fresh
-                    # context per fire and the response surfaces nowhere.
-                    "contextId": ACTIVITY_CONTEXT,
+                    # Fire into the job's own context when set (ADR 0053 — the
+                    # `wait` tool stamps the originating chat session so a resume
+                    # continues that conversation's thread), else the durable
+                    # Activity thread (ADR 0003) so a normal scheduled fire lands
+                    # somewhere visible/continuable instead of a throwaway context.
+                    "contextId": job.context_id or ACTIVITY_CONTEXT,
                     # Scheduler bookkeeping for this fire (origin + job id) —
                     # informational; the handler doesn't require these keys.
                     "metadata": {
@@ -607,4 +617,5 @@ def _row_to_job(row: Any) -> Job:
         enabled=bool(row["enabled"]),
         created_at=row["created_at"],
         timezone=row["timezone"] if "timezone" in keys else None,
+        context_id=row["context_id"] if "context_id" in keys else None,
     )

--- a/scheduler/workstacean.py
+++ b/scheduler/workstacean.py
@@ -70,10 +70,14 @@ class WorkstaceanScheduler:
 
     def add_job(
         self, prompt: str, schedule: str, *, job_id: str | None = None,
-        timezone: str | None = None,
+        timezone: str | None = None, context_id: str | None = None,
     ) -> Job:
         if not prompt or not prompt.strip():
             raise ValueError("scheduler: prompt is required")
+        # NOTE: same-session resume (ADR 0053 / `context_id`) is a local-backend
+        # feature — Workstacean fires through its own A2A bridge, which targets
+        # the bridge's default context, so we accept the arg for protocol parity
+        # but can't route into the originating chat thread here.
         # Validate the schedule eagerly so a malformed expr fails at
         # tool-call time, not silently inside Workstacean.
         _validate_schedule(schedule)
@@ -115,6 +119,7 @@ class WorkstaceanScheduler:
             agent_name=self.agent_name,
             next_fire=None,  # Workstacean owns the schedule state
             timezone=timezone,
+            context_id=context_id,
         )
 
     def cancel_job(self, job_id: str) -> bool:

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -600,3 +600,89 @@ def test_no_timezone_defaults_to_utc(tmp_path):
     assert job.timezone is None
     nf_utc = datetime.fromisoformat(job.next_fire).astimezone(ZoneInfo("UTC"))
     assert nf_utc.hour == 12
+
+
+# ── context_id / same-session resume (ADR 0053) ──────────────────────────────
+
+
+class _CapClient:
+    """Captures the JSON body of the single POST the scheduler fires."""
+
+    posted: dict = {}
+
+    def __init__(self, **_kw):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_a):
+        return False
+
+    async def post(self, _url, headers=None, json=None):  # noqa: A002
+        _CapClient.posted = json or {}
+
+        class _R:
+            status_code = 200
+            text = "ok"
+
+        return _R()
+
+
+class TestContextId:
+    def test_add_job_round_trips_context_id(self, tmp_path):
+        s = _make_scheduler(tmp_path)
+        s.add_job("resume", "2099-01-01T00:00:00+00:00", job_id="j", context_id="chat-abc")
+        assert s.list_jobs()[0].context_id == "chat-abc"
+
+    def test_context_id_defaults_to_none(self, tmp_path):
+        s = _make_scheduler(tmp_path)
+        s.add_job("plain", "2099-01-01T00:00:00+00:00", job_id="j")
+        assert s.list_jobs()[0].context_id is None
+
+    def test_migrates_pre_context_id_db(self, tmp_path):
+        # Simulate a store created before the context_id column existed: rebuild
+        # the table with the old shape, then a fresh instance runs the lazy
+        # ALTER-TABLE migration on init.
+        s = _make_scheduler(tmp_path)
+        old_schema = (
+            "DROP TABLE jobs;"
+            "CREATE TABLE jobs (id TEXT PRIMARY KEY, prompt TEXT NOT NULL, "
+            "schedule TEXT NOT NULL, agent_name TEXT NOT NULL, next_fire TEXT NOT NULL, "
+            "last_fire TEXT, enabled INTEGER NOT NULL DEFAULT 1, created_at TEXT NOT NULL, "
+            "timezone TEXT);"
+        )
+        db = sqlite3.connect(str(s.path))
+        db.executescript(old_schema)
+        db.execute(
+            "INSERT INTO jobs (id, prompt, schedule, agent_name, next_fire, enabled, created_at) "
+            "VALUES ('old', 'p', '0 9 * * *', 'gina-test', '2099-01-01T00:00:00+00:00', 1, "
+            "'2026-01-01T00:00:00+00:00')"
+        )
+        db.commit()
+        db.close()
+
+        s2 = _make_scheduler(tmp_path)
+        jobs = s2.list_jobs()
+        assert len(jobs) == 1 and jobs[0].context_id is None  # old row → no context
+        s2.add_job("new", "2099-01-02T00:00:00+00:00", job_id="new", context_id="chat-x")
+        got = {j.id: j for j in s2.list_jobs()}
+        assert got["new"].context_id == "chat-x"
+
+    @pytest.mark.asyncio
+    async def test_fire_routes_to_job_context_id(self, tmp_path, monkeypatch):
+        import httpx
+
+        from events import ACTIVITY_CONTEXT
+
+        s = _make_scheduler(tmp_path)
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _CapClient())
+
+        soon = (datetime.now(UTC) + timedelta(seconds=1)).isoformat()
+        scoped = s.add_job("resume me", soon, job_id="scoped", context_id="chat-abc")
+        assert await s._fire(scoped) is True
+        assert _CapClient.posted["params"]["message"]["contextId"] == "chat-abc"
+
+        plain = s.add_job("plain", soon, job_id="plain")
+        await s._fire(plain)
+        assert _CapClient.posted["params"]["message"]["contextId"] == ACTIVITY_CONTEXT

--- a/tests/test_wait_yield.py
+++ b/tests/test_wait_yield.py
@@ -72,9 +72,11 @@ class _FakeJob:
 class _FakeScheduler:
     def __init__(self):
         self.added: list[tuple[str, str]] = []
+        self.last_context_id: str | None = "__unset__"
 
-    def add_job(self, prompt, schedule, *, job_id=None, timezone=None):
+    def add_job(self, prompt, schedule, *, job_id=None, timezone=None, context_id=None):
         self.added.append((prompt, schedule))
+        self.last_context_id = context_id
         return _FakeJob(schedule)
 
     def list_jobs(self):
@@ -113,3 +115,23 @@ async def test_wait_requires_a_then_instruction():
     out = await _wait_tool(sched).ainvoke({"seconds": 10, "then": "  "})
     assert out.startswith("Error:")
     assert sched.added == []  # nothing scheduled
+
+
+@pytest.mark.asyncio
+async def test_wait_carries_the_origin_session_as_context_id(monkeypatch):
+    # Same-session resume (ADR 0053): the resume is stamped with the current
+    # turn's session so the scheduler fires it back into that chat thread.
+    import observability.tracing as tracing
+    monkeypatch.setattr(tracing, "current_session_id", lambda: "chat-abc")
+    sched = _FakeScheduler()
+    await _wait_tool(sched).ainvoke({"seconds": 5, "then": "continue"})
+    assert sched.last_context_id == "chat-abc"
+
+
+@pytest.mark.asyncio
+async def test_wait_without_a_session_leaves_context_id_none(monkeypatch):
+    import observability.tracing as tracing
+    monkeypatch.setattr(tracing, "current_session_id", lambda: "")
+    sched = _FakeScheduler()
+    await _wait_tool(sched).ainvoke({"seconds": 5, "then": "continue"})
+    assert sched.last_context_id is None  # → scheduler falls back to Activity

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -687,8 +687,16 @@ def _build_scheduler_tools(scheduler) -> list:
             return "Error: `then` is required — describe what to do on resume."
         secs = max(1, int(seconds))
         when = (datetime.now(UTC) + timedelta(seconds=secs)).isoformat()
+        # Resume in the SAME conversation: stamp the originating chat session
+        # (== the turn's A2A contextId) onto the job so the scheduler fires the
+        # resume into this thread, not the Activity thread — the agent wakes up
+        # with the conversation history intact (ADR 0053). Same contextvar the
+        # background-subagent path reads. Empty (e.g. an Activity-origin turn) →
+        # the scheduler falls back to the Activity thread.
+        from observability import tracing
+        ctx = tracing.current_session_id() or None
         try:
-            job = await asyncio.to_thread(scheduler.add_job, then, when)
+            job = await asyncio.to_thread(scheduler.add_job, then, when, context_id=ctx)
         except Exception as exc:  # noqa: BLE001
             return f"Error: couldn't schedule the wake-up: {exc}"
         return (


### PR DESCRIPTION
## What

Same-session resume — **Problem A (agent context continuity)** from the ADR 0053 follow-up. When the agent calls `wait` inside a chat, the scheduled resume now fires back into **that chat's thread** instead of the Activity thread, so it wakes up with the conversation history intact and continues where it left off.

Modeled on the background-subagent path, as suggested: the originating session is read from the **same `tracing.current_session_id()` contextvar** background uses — no `RunnableConfig` plumbing.

## How

- `scheduler.Job` gains an optional **`context_id`** (`interface.py`) + a SQLite column in `local.py` with a **lazy `ALTER TABLE` migration** (existing schedule DBs keep working). The `workstacean` remote backend accepts the arg for protocol parity but can't target a context, so it stays Activity-routed there.
- `LocalScheduler._fire` POSTs `contextId = job.context_id or ACTIVITY_CONTEXT`.
- The `wait` tool stamps the originating session onto the job; empty (an Activity-origin turn) falls back to Activity.

Net: a `wait` from a chat → resume runs in `a2a:<session>` (same checkpointer thread) → agent has full history. A plain scheduled/cron job → unchanged (Activity).

## Tests

`context_id` round-trip + default-None + **pre-`context_id` DB migration** (old store keeps working) + `_fire` routes to `job.context_id` vs the `ACTIVITY_CONTEXT` fallback; the `wait` tool stamps/omits the session. **1988 backend pass**; ruff + import contracts clean.

## Not in scope (tracked: bd-k02)

**Problem B — live UI surfacing.** The browser chat only renders turns it streamed, so a server-fired resume won't *appear live* in the tab without a per-session push (reusing the ADR 0050 `background.completed` → `BackgroundWatch` pattern). Until then the work happens in-thread and surfaces on the chat's next interaction. This PR delivers the agent-side continuity; the UI push is the next slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)