### PR TITLE
fix(console): left panel resizes below ~50% (DS AppShell maxRightWidth floor)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Left panel no longer springs back to ~50% when resized smaller.** The DS
+  AppShell's single divider made `maxRightWidth` (720) double as a floor on the
+  left column, so on a wide window the left couldn't drag below ~50% and snapped
+  back. Fixed at source in the design system (`@protolabsai/ui` 0.34→0.35: a user
+  drag/keyboard resize now respects only the column mins, so the left shrinks to
+  `minLeftWidth` while `maxRightWidth` still caps default/reopen widths). Console
+  bumped to 0.35; a `layout` e2e guards the left shrinking past the old floor.
+
 ### Added
 - **Opt-in JSON logging (`LOG_FORMAT=json`)** — set it to emit one JSON object
   per log line (`ts`/`level`/`logger`/`message`, plus the exception traceback and

--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -55,3 +55,26 @@ test("right panel is keyboard-resizable (ADR 0035 S3)", async ({ page }) => {
   // only (protoContent #223); panel collapse/restore is covered by the
   // utility-bar-toggle test above. The handle's job here is resize.
 });
+
+test("left panel shrinks to minLeftWidth, past the old maxRightWidth floor (protoContent #236)", async ({ page }) => {
+  // Regression: the DS divider is zero-sum and the right column was capped at
+  // maxRightWidth (720), which double-acted as a FLOOR on the left — on a wide
+  // span the left couldn't go below span−720 (~50%) and sprang back when dragged
+  // smaller. The DS now lets a user resize shrink the left all the way to
+  // minLeftWidth (host sets 200). Drive it via the keyboard (deterministic; the
+  // handle's ArrowLeft grows the right / shrinks the left, and never collapses).
+  await page.goto("/app/", { waitUntil: "load" });
+  const left = page.locator(".pl-appshell__col--left");
+  await expect(left).toBeVisible();
+  const before = (await left.boundingBox())!.width;
+
+  const handle = page.getByRole("separator", { name: "Resize panels" });
+  await handle.focus();
+  for (let i = 0; i < 60; i++) await page.keyboard.press("ArrowLeft");
+
+  const after = (await left.boundingBox())!.width;
+  await expect(left).toBeVisible();        // shrank, did NOT collapse
+  expect(after).toBeLessThan(before);
+  // Reached ~minLeftWidth(200) — well under the old span−720 floor (~50%).
+  expect(after).toBeLessThan(280);
+});

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.34.0",
+    "@protolabsai/ui": "^0.35.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.34.0",
+        "@protolabsai/ui": "^0.35.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.34.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.34.0.tgz",
-      "integrity": "sha512-TnPYAY0LN+F0+yOb3oJ3k1yjHFxHpS6bM0aW99hG5AKfs5itKAcfXOfbD3wgnOXtqTsiA7jpJ1mRmvwlwOmdWA==",
+      "version": "0.35.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.35.0.tgz",
+      "integrity": "sha512-bgHLKHHnVIkzcSnxFe3xDfDDQhmocjE1vqwK8aOEzrl8F+8IHfTExyLZN5bJ/ed02TudtWITl1WBHZXzVI+iDQ==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
## What

The left panel **springs back to ~50%** when you drag it smaller. Root cause was a **DS bug**, fixed at source.

The DS `AppShell` uses one zero-sum divider: the right column is width-controlled (capped at `maxRightWidth`, default 720) and the left flexes (`span − rightWidth`). So `maxRightWidth` double-acted as a **floor on the left** — on a wide window the left couldn't go below `span − 720` (≈ 50%) and snapped back.

## Fix (at source)

[protoContent #236](https://github.com/protoLabsAI/protoContent/pull/236) → `@protolabsai/ui` **0.35.0**: a user drag / keyboard resize now respects only the two column mins (`minRightWidth` / `minLeftWidth`), so the left shrinks to `minLeftWidth` (the console sets 200); `maxRightWidth` still caps default/reopen widths.

This PR just **bumps the console to 0.35** — no host workaround.

## Note

This is distinct from the earlier `minLeftWidth 280→200` tweak (the "I thought we fixed it") — that removed a narrow snap *dead zone* but left the `maxRightWidth` floor untouched.

## Test

New `layout.spec` case: the left column shrinks to ~`minLeftWidth` (200) via the divider — past the old ~50% floor (it'd stick at ~448 on the 1280 test viewport before). Full `layout` suite + web build green; the bump is otherwise behavior-neutral (existing resize/collapse e2e pass).

Needs a console rebuild to go live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)