### PR TITLE
fix(tools): bind set_goal + restore wait same-session resume (bd-2aa, bd-3b6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`set_goal` is now actually bound to the agent.** The tool (ADR 0028 — the
+  agent owns a plugin-verified goal) was advertised in the Tools tab / `/api/tools`
+  but never reached the model: `create_agent_graph` called `get_all_tools` without
+  threading `goal_enabled`, so it defaulted off and `set_goal` was silently
+  dropped from the bound toolset (calling it errored `"set_goal is not a valid
+  tool"`). The `/goal` chat control message kept working — it's parsed before the
+  graph — which masked the gap. The agent can now self-set a goal during
+  autonomous/fleet/autopilot runs, not just when a human types `/goal`.
+- **`wait`'s same-session resume now works (ADR 0053).** A `wait` issued in a chat
+  was supposed to resume in *that* chat's thread with history intact, but the
+  resume fired into the Activity thread instead: the tool read the originating
+  session from `tracing.current_session_id()`, which is reliably set for
+  middleware but reads **empty inside a tool body** under LangGraph — so the
+  job's `context_id` was never stamped. Root cause: `create_agent` ran on the
+  default messages-only state, so the declared `ProtoAgentState` (with
+  `session_id`) was never wired in and the per-turn `session_id` was dropped.
+  Fixed by passing `state_schema=ProtoAgentState` to `create_agent` and reading
+  the session from injected graph state (`InjectedState`) in `wait` and `set_goal`,
+  with the contextvar kept only as an off-graph fallback. (Both found by driving a
+  running agent over the API; regression tests now drive a real graph turn rather
+  than monkeypatching the broken function.)
+
 ## [0.40.0] - 2026-06-14
 
 ### Fixed

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -14,6 +14,7 @@ from graph.middleware.audit import AuditMiddleware
 from graph.middleware.knowledge import KnowledgeMiddleware
 from graph.middleware.memory import MemoryMiddleware
 from graph.middleware.message_capture import MessageCaptureMiddleware
+from graph.state import ProtoAgentState
 from graph.subagents.config import SUBAGENT_REGISTRY
 from tools.lg_tools import get_all_tools
 
@@ -660,6 +661,13 @@ def create_agent_graph(
 
     all_tools = get_all_tools(
         knowledge_store, scheduler=scheduler, inbox_store=inbox_store, beads_store=beads_store,
+        # Thread the goal flag so the agent-facing set_goal tool (ADR 0028) is
+        # actually BOUND, not just advertised. Without this it defaults False and
+        # set_goal silently never reaches the model (it stayed in /api/tools,
+        # which passes goal_enabled explicitly — a registry-vs-binding split).
+        # Subagent builds deliberately omit it: subagents are bounded by
+        # max_turns and must not self-set goals.
+        goal_enabled=config.goal_enabled,
     )
 
     if extra_tools:
@@ -718,6 +726,13 @@ def create_agent_graph(
         middleware=middleware,
         system_prompt=system_prompt,
         checkpointer=checkpointer,
+        # Wire the declared state schema so session_id (stamped into every turn's
+        # graph input by the chat/A2A layer) is a real channel the tools can read
+        # via InjectedState. Without this, create_agent runs on the default
+        # messages-only state, session_id is silently dropped, and tool bodies
+        # can't recover it (the tracing contextvar is invisible in a tool body) —
+        # which broke wait's same-session resume (ADR 0053) and set_goal.
+        state_schema=ProtoAgentState,
     )
 
     return agent

--- a/graph/state.py
+++ b/graph/state.py
@@ -8,14 +8,19 @@ for captured message() tool content. Fork-specific state fields
 import operator
 from typing import Annotated, NotRequired
 
-from langgraph.prebuilt.chat_agent_executor import AgentState
+# langchain's create_agent state base (messages + jump_to + structured_response).
+# NOT langgraph's chat_agent_executor.AgentState — that carries a managed
+# `remaining_steps` channel which create_agent rejects in the input schema.
+from langchain.agents import AgentState
 
 
 class ProtoAgentState(AgentState):
     """Base state schema for the protoAgent LangGraph agent.
 
-    Extends AgentState (which provides `messages` with add_messages reducer).
-    Extend this class in your fork to add domain-specific state.
+    Extends create_agent's AgentState (which provides `messages` with the
+    add_messages reducer). Passed as ``state_schema`` to create_agent so these
+    fields are real channels readable by tools via InjectedState. Extend this
+    class in your fork to add domain-specific state.
     """
 
     # Session tracking (A2A / chat session ID)

--- a/tests/test_set_goal_tool.py
+++ b/tests/test_set_goal_tool.py
@@ -15,6 +15,58 @@ def test_get_all_tools_gates_set_goal_on_goal_enabled():
     assert "set_goal" in on and "set_goal" not in off
 
 
+def _lead_graph_tool_names(goal_enabled: bool) -> set[str]:
+    """Bound tool names on a compiled lead-agent graph (what the MODEL can call).
+
+    Stubs the LLM so no gateway is needed; reads the ToolNode's tool map.
+    """
+    from unittest.mock import patch
+
+    from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+    from langchain_core.messages import AIMessage
+
+    class _Fake(GenericFakeChatModel):
+        def bind_tools(self, tools, **k):
+            return self
+
+    fake = _Fake(messages=iter([AIMessage(content="x")]))
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+        from graph.config import LangGraphConfig
+
+        g = create_agent_graph(LangGraphConfig(goal_enabled=goal_enabled))
+    node = g.nodes["tools"]
+    for obj in (node, getattr(node, "runnable", None), getattr(node, "bound", None)):
+        tbn = getattr(obj, "tools_by_name", None)
+        if tbn:
+            return set(tbn.keys())
+    raise AssertionError("could not locate the ToolNode tool map")
+
+
+def test_set_goal_is_actually_bound_to_the_lead_agent_when_enabled():
+    # bd-2aa regression: get_all_tools(goal_enabled=True) including set_goal is
+    # NOT enough — create_agent_graph must thread goal_enabled into that call, or
+    # set_goal is advertised (/api/tools) but never bound to the model. This
+    # asserts the binding on the COMPILED graph, which is what was broken.
+    assert "set_goal" in _lead_graph_tool_names(goal_enabled=True)
+    assert "set_goal" not in _lead_graph_tool_names(goal_enabled=False)
+
+
+def test_set_goal_reads_session_from_injected_state(monkeypatch, tmp_path):
+    # Companion to bd-3b6: once bound, set_goal must resolve the session from the
+    # injected graph state, not the contextvar (empty in a tool body) — else it
+    # would always refuse with "No active session" mid-turn.
+    ctrl = GoalController(None, GoalStore(base_dir=str(tmp_path)))
+    monkeypatch.setattr(STATE, "goal_controller", ctrl)
+    monkeypatch.setattr(tracing, "current_session_id", lambda: "")  # contextvar empty
+    out = _build_set_goal_tool().invoke(
+        {"condition": "reach 1M", "check": "spacetraders:credits",
+         "check_args": {"min": 1_000_000}, "state": {"session_id": "s-injected"}}
+    )
+    assert "Goal set" in out
+    assert ctrl.active_goal("s-injected") is not None
+
+
 def test_set_goal_reports_when_goal_mode_off(monkeypatch):
     monkeypatch.setattr(STATE, "goal_controller", None)
     out = _build_set_goal_tool().invoke({"condition": "c", "check": "x:y"})

--- a/tests/test_wait_yield.py
+++ b/tests/test_wait_yield.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 from datetime import UTC, datetime
 
 import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
 from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
 
 from graph.middleware.wait_yield import WaitYieldMiddleware, _just_waited
@@ -118,9 +119,34 @@ async def test_wait_requires_a_then_instruction():
 
 
 @pytest.mark.asyncio
-async def test_wait_carries_the_origin_session_as_context_id(monkeypatch):
-    # Same-session resume (ADR 0053): the resume is stamped with the current
-    # turn's session so the scheduler fires it back into that chat thread.
+async def test_wait_reads_session_from_injected_state():
+    # The fix (bd-3b6): wait reads the originating session from the injected graph
+    # state — reliable in a tool body — not the tracing contextvar, which reads
+    # empty there and silently dropped the resume to the Activity thread. Passing
+    # `state` directly mirrors what the ToolNode injects at runtime.
+    sched = _FakeScheduler()
+    await _wait_tool(sched).ainvoke(
+        {"seconds": 5, "then": "continue", "state": {"session_id": "chat-xyz"}}
+    )
+    assert sched.last_context_id == "chat-xyz"
+
+
+@pytest.mark.asyncio
+async def test_wait_injected_state_wins_over_contextvar(monkeypatch):
+    # State is authoritative; the contextvar is only an off-graph fallback.
+    import observability.tracing as tracing
+    monkeypatch.setattr(tracing, "current_session_id", lambda: "stale-ctxvar")
+    sched = _FakeScheduler()
+    await _wait_tool(sched).ainvoke(
+        {"seconds": 5, "then": "x", "state": {"session_id": "live-state"}}
+    )
+    assert sched.last_context_id == "live-state"
+
+
+@pytest.mark.asyncio
+async def test_wait_falls_back_to_contextvar_off_graph(monkeypatch):
+    # No injected state (tool used outside a graph turn): fall back to the
+    # contextvar so existing off-graph callers keep working.
     import observability.tracing as tracing
     monkeypatch.setattr(tracing, "current_session_id", lambda: "chat-abc")
     sched = _FakeScheduler()
@@ -135,3 +161,48 @@ async def test_wait_without_a_session_leaves_context_id_none(monkeypatch):
     sched = _FakeScheduler()
     await _wait_tool(sched).ainvoke({"seconds": 5, "then": "continue"})
     assert sched.last_context_id is None  # → scheduler falls back to Activity
+
+
+# ── end-to-end: a wait in a REAL graph turn resumes in-thread (bd-3b6) ─────────
+# The integration the old monkeypatch unit test could NOT catch: it patched
+# current_session_id (the broken function) and so masked that the contextvar
+# reads empty in a tool body. This drives a real create_agent graph whose model
+# emits a wait tool call and asserts the scheduled resume carries the turn's
+# session_id — proving session_id is a real state channel (state_schema=
+# ProtoAgentState) and InjectedState delivers it to the tool.
+
+class _ToolFake(GenericFakeChatModel):
+    """Fake chat model that supports bind_tools (returns itself) so it can drop
+    into create_agent and replay preset AIMessages, including tool calls."""
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+@pytest.mark.asyncio
+async def test_wait_in_a_real_graph_stamps_the_turn_session(monkeypatch):
+    from unittest.mock import patch
+
+    from langchain_core.messages import HumanMessage
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from graph.config import LangGraphConfig
+
+    wait_call = AIMessage(
+        content="",
+        tool_calls=[{"name": "wait", "args": {"seconds": 30, "then": "resume"},
+                     "id": "c1", "type": "tool_call"}],
+    )
+    fake = _ToolFake(messages=iter([wait_call, AIMessage(content="done")]))
+    sched = _FakeScheduler()
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+        graph = create_agent_graph(
+            LangGraphConfig(), scheduler=sched, include_subagents=False,
+            checkpointer=MemorySaver(),
+        )
+    await graph.ainvoke(
+        {"messages": [HumanMessage("wait then resume")], "session_id": "sess-XYZ"},
+        config={"configurable": {"thread_id": "t1"}},
+    )
+    assert sched.last_context_id == "sess-XYZ"

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -42,9 +42,11 @@ import ast
 import asyncio
 import operator as _op
 from datetime import UTC, datetime, timedelta
+from typing import Annotated, Any
 from zoneinfo import ZoneInfo, ZoneInfoNotFoundError
 
 from langchain_core.tools import tool
+from langgraph.prebuilt import InjectedState
 
 from tools.fallbacks import with_fallback
 
@@ -658,7 +660,8 @@ def _build_scheduler_tools(scheduler) -> list:
         return f"Canceled {job_id}." if ok else f"Error: cancel failed or no such job {job_id}."
 
     @tool
-    async def wait(seconds: int, then: str) -> str:
+    async def wait(seconds: int, then: str,
+                   state: Annotated[Any, InjectedState] = None) -> str:
         """Pause and resume LATER instead of polling. Use this whenever you are
         waiting for something to finish — a ship to arrive, a build/deploy, a
         cooldown, a countdown a status tool reported ("arriving in 37s"). Do NOT
@@ -667,9 +670,10 @@ def _build_scheduler_tools(scheduler) -> list:
 
         Calling ``wait`` ENDS your turn immediately and schedules a one-shot
         wake-up ``seconds`` from now. When it fires you are re-invoked with
-        ``then`` as your instruction (in your Activity thread), so you act
-        exactly once — when the thing is actually ready. This is the right way to
-        run long-horizon work without spinning.
+        ``then`` as your instruction — back in THIS same conversation, with its
+        history intact (ADR 0053) — so you act exactly once, when the thing is
+        actually ready. This is the right way to run long-horizon work without
+        spinning.
 
         Args:
             seconds: how long to wait, in seconds (e.g. 40). Use the ETA a status
@@ -693,8 +697,10 @@ def _build_scheduler_tools(scheduler) -> list:
         # with the conversation history intact (ADR 0053). Same contextvar the
         # background-subagent path reads. Empty (e.g. an Activity-origin turn) →
         # the scheduler falls back to the Activity thread.
-        from observability import tracing
-        ctx = tracing.current_session_id() or None
+        # Read the originating session from the injected graph state, NOT the
+        # tracing contextvar — the contextvar reads empty in a tool body under
+        # LangGraph, which silently dropped this resume to the Activity thread.
+        ctx = _session_id_from(state) or None
         try:
             job = await asyncio.to_thread(scheduler.add_job, then, when, context_id=ctx)
         except Exception as exc:  # noqa: BLE001
@@ -773,6 +779,25 @@ def _build_beads_tools(beads_store) -> list:
     return [beads_create, beads_list, beads_update, beads_close]
 
 
+def _session_id_from(state: Any) -> str:
+    """Resolve the originating session id from inside a TOOL BODY.
+
+    The graph state (``graph/state.py``) reliably carries ``session_id`` at
+    tool-execution time — every turn's graph input stamps it. The
+    ``tracing.current_session_id()`` contextvar is visible to MIDDLEWARE but NOT
+    to a tool body under LangGraph (the tool runs in a different execution
+    context), so it silently reads empty there — which is why ``wait`` dropped
+    its same-session resume to the Activity thread (ADR 0053) and why ``set_goal``
+    would refuse with "No active session". Prefer the injected state; keep the
+    contextvar only as a fallback for tools invoked outside a graph turn."""
+    from observability import tracing
+
+    sid = ""
+    if isinstance(state, dict):
+        sid = (state.get("session_id") or "").strip()
+    return sid or (tracing.current_session_id() or "")
+
+
 def _build_set_goal_tool():
     """The lead agent sets its OWN standing goal — verified by a plugin verifier
     only (ADR 0028). The agent literally can't open a shell/eval goal here: the
@@ -780,7 +805,8 @@ def _build_set_goal_tool():
 
     @tool
     def set_goal(condition: str, check: str, check_args: dict | None = None,
-                 max_iterations: int | None = None) -> str:
+                 max_iterations: int | None = None,
+                 state: Annotated[Any, InjectedState] = None) -> str:
         """Set a standing goal for THIS session, ground-truthed by a plugin verifier.
 
         You'll be re-invoked toward `condition` until the plugin verifier named by
@@ -789,11 +815,10 @@ def _build_set_goal_tool():
         verifiers are allowed — shell/test/data goals are operator-only via /goal.
         Returns the goal status, or an error if goal mode is off / `check` is unknown.
         """
-        from observability import tracing
         from runtime.state import STATE
         if STATE.goal_controller is None:
             return "Goal mode is not enabled."
-        session_id = tracing.current_session_id()
+        session_id = _session_id_from(state)  # injected graph state, not the contextvar
         if not session_id:
             return "No active session — set_goal can only run during a turn."
         verifier = {"type": "plugin", "check": check, "args": check_args or {}}


### PR DESCRIPTION
Two tool-wiring bugs found while driving a running agent over its API, both rooted in **`session_id` never reaching tool bodies**. They're coupled — fixing one exposes the other — so they ship together.

## `set_goal` advertised but not bound (bd-2aa)
The agent-facing `set_goal` tool (ADR 0028) showed up in `/api/tools` but was **never bound to the model** — invoking it errored `set_goal is not a valid tool`. `create_agent_graph` called `get_all_tools(...)` without threading `goal_enabled`, so it defaulted `False` and `set_goal` was dropped. The `/goal` chat control message kept working (parsed before the graph), which masked the gap. So the agent could never self-set a goal during autonomous/fleet/autopilot runs.

**Fix:** pass `goal_enabled=config.goal_enabled` into the lead-agent build.

## `wait` same-session resume broken (bd-3b6, ADR 0053)
A `wait` issued in a chat is supposed to resume in *that* chat's thread with history intact, but it fired into the **Activity thread** instead. The tool read the session from `tracing.current_session_id()`, which is set for **middleware** but reads **empty inside a tool body** under LangGraph — so the scheduler job's `context_id` was never stamped. Verified live: the resume ran in `system:activity`, not the originating session.

**Root cause:** `create_agent` ran on the default messages-only state, so the declared `ProtoAgentState` (which has `session_id`) was **never wired in** and the per-turn `session_id` was silently dropped.

**Fix:** pass `state_schema=ProtoAgentState` to `create_agent` and read the session via `InjectedState` in `wait` + `set_goal` (contextvar kept only as an off-graph fallback). `ProtoAgentState` is rebased on langchain's `create_agent` `AgentState` — the langgraph base carried a managed `remaining_steps` channel that `create_agent` rejects in the input schema.

## Tests
- New regression tests drive a **real `create_agent` graph turn** (fake model emitting the tool call) and assert the scheduled resume carries the turn's `session_id` + that `set_goal` is bound on the compiled graph. The prior `test_wait_yield` test monkeypatched `current_session_id` — the very function that's broken in-context — which is why it gave false confidence.
- Full suite green: **1995 passed** (3 pre-existing `test_config_roundtrip` golden failures, unrelated — they fail on `main` too, from local config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)