### PR TITLE
fix(chat): non-streaming empty-200 robustness + unreachable web-research skill (bd-2qy, bd-2zh)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Non-streaming chat no longer returns a silent empty `200`.** A turn that ends
+  at an `ask_human` interrupt, after a `wait` yield, or scratch-only used to give
+  `/api/chat` and the OpenAI-compatible `/v1/chat/completions` a blank assistant
+  message — the streaming/A2A path handled all three but `_chat_langgraph` never
+  got the same hardening. It now surfaces the `ask_human` question, runs the
+  dropped-scratch kicker retry, and falls back to the last tool result (e.g. a
+  `wait` "Yielding…" confirmation) so callers always get a signal. The two
+  interrupt-detection sites are now one shared helper so they can't drift again.
+- **First-party `web-research` skill is reachable again.** Its slash token was
+  `research`, which collides with the deep-research *workflow* — workflows win
+  dispatch and hide the skill from the command palette, so a shipped user-facing
+  skill could never be invoked. Renamed to `/web-research`; the command builder
+  now logs a one-time warning when any user-facing skill's slash token is shadowed
+  by a workflow/subagent, so this can't happen silently again.
 - **`set_goal` is now actually bound to the agent.** The tool (ADR 0028 — the
   agent owns a plugin-verified goal) was advertised in the Tools tab / `/api/tools`
   but never reached the model: `create_agent_graph` called `get_all_tools` without

--- a/config/skills/web-research/SKILL.md
+++ b/config/skills/web-research/SKILL.md
@@ -7,7 +7,9 @@ description: >-
   these three tools". Drives a scope → gather → gap-check → synthesize loop.
 tools: [web_search, fetch_url, memory_recall, memory_ingest, current_time]
 user_facing: true
-slash: research
+# `web-research`, not `research`: the deep-research workflow already owns
+# /research and wins dispatch, which would shadow this skill (bd-2zh).
+slash: web-research
 ---
 
 # Web Research

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -33,6 +33,10 @@ from server import AGENT_NAME_ENV, _event_bus, _resolve_operator_project_root
 
 log = logging.getLogger("protoagent.server")
 
+# Slash tokens we've already warned are shadowed (bd-2zh) — warn once per token,
+# not on every /api/chat/commands request.
+_warned_shadowed_skills: set[str] = set()
+
 
 def _operator_allowed_dirs() -> list[str]:
     # The repo root is always operable (it's the default project);
@@ -444,7 +448,22 @@ def _operator_chat_commands() -> dict:
             if not token:
                 import re
                 token = re.sub(r"[^a-z0-9]+", "-", (skill.get("name") or "").lower()).strip("-")
-            if not token or token == "goal" or token in taken:
+            if not token or token == "goal":
+                continue
+            if token in taken:
+                # A workflow/subagent of the same token wins dispatch, so this
+                # user-facing skill is unreachable (bd-2zh — web-research's
+                # `slash: research` was shadowed by the deep-research workflow).
+                # Warn once per token so a shipped-but-shadowed skill is visible
+                # instead of silently dropped; the fix is to rename its `slash:`.
+                if token not in _warned_shadowed_skills:
+                    _warned_shadowed_skills.add(token)
+                    log.warning(
+                        "[skills] user-facing skill %r is unreachable: its slash token /%s "
+                        "is already claimed by a workflow/subagent (which wins dispatch). "
+                        "Rename the skill's `slash:` to expose it.",
+                        skill.get("name") or token, token,
+                    )
                 continue
             taken.add(token)
             commands.append({

--- a/server/chat.py
+++ b/server/chat.py
@@ -196,6 +196,35 @@ def _interrupt_payload(val) -> dict:
     return {"question": (str(val) if val is not None else "Input required.")}
 
 
+async def _pending_interrupt_value(config: dict):
+    """Return the value of a pending LangGraph interrupt (ask_human / HITL) for
+    this thread, or ``None``. Both chat paths read the same snapshot to detect a
+    turn that paused for human input instead of producing a final answer."""
+    try:
+        snapshot = await STATE.graph.aget_state(config)
+    except Exception:
+        return None
+    pending = list(getattr(snapshot, "interrupts", None) or [])
+    if not pending:
+        for t in getattr(snapshot, "tasks", ()) or ():
+            pending.extend(getattr(t, "interrupts", ()) or ())
+    if not pending:
+        return None
+    return getattr(pending[0], "value", pending[0])
+
+
+def _last_tool_text(result) -> str:
+    """The last tool result's text in a turn — the fallback when a turn produced
+    no assistant text (e.g. a ``wait`` yield, whose 'Yielding…' confirmation is a
+    ToolMessage, not an AIMessage)."""
+    from langchain_core.messages import ToolMessage
+
+    for msg in reversed((result or {}).get("messages", [])):
+        if isinstance(msg, ToolMessage) and msg.content:
+            return msg.content if isinstance(msg.content, str) else str(msg.content)
+    return ""
+
+
 async def _run_turn_stream(message: str, session_id: str, config: dict, *, resume_value=None, images=None):
     """Run one graph turn over ``astream_events``.
 
@@ -374,17 +403,9 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
     # HITL pause (ADR 0003): the agent called ask_human → LangGraph interrupt().
     # The graph is checkpointed at the interrupt; surface the question so the A2A
     # layer parks the task as input-required. Resume later with resume_value.
-    try:
-        snapshot = await STATE.graph.aget_state(config)
-        pending = list(getattr(snapshot, "interrupts", None) or [])
-        if not pending:
-            for t in getattr(snapshot, "tasks", ()) or ():
-                pending.extend(getattr(t, "interrupts", ()) or ())
-    except Exception:
-        pending = []
-    if pending:
-        val = getattr(pending[0], "value", pending[0])
-        yield ("input_required", _interrupt_payload(val))
+    interrupt_val = await _pending_interrupt_value(config)
+    if interrupt_val is not None:
+        yield ("input_required", _interrupt_payload(interrupt_val))
         return
 
     yield ("__raw__", accumulated_raw)
@@ -940,7 +961,42 @@ async def _chat_langgraph(message: str, session_id: str) -> list[dict[str, Any]]
                     {"messages": [HumanMessage(content=message)], "session_id": session_id},
                     config=config,
                 )
-            response = extract_output(_last_ai(result))
+            raw = _last_ai(result)
+            response = extract_output(raw)
+
+            # Robustness parity with the streaming path (bd-2qy): a turn can end
+            # with no assistant text — at an ask_human interrupt, after a `wait`
+            # yield, or on a scratch-only turn. Returning "" gives /api/chat +
+            # OpenAI-compat callers a silent empty 200; surface something useful.
+            if not response:
+                interrupt_val = await _pending_interrupt_value(config)
+                if interrupt_val is not None:
+                    # ask_human / HITL — the graph paused for input. There's no
+                    # task to park on this non-streaming surface, so echo the
+                    # prompt; the caller answers with a follow-up message, which
+                    # continues the thread (the checkpointer kept the history).
+                    payload = _interrupt_payload(interrupt_val)
+                    question = (
+                        payload.get("question") or payload.get("title")
+                        or "The agent needs input to continue."
+                    )
+                    return [{"role": "assistant", "content": f"🙋 **Input needed:** {question}"}]
+
+                # Dropped scratch-only turn (no <output>, no tool call): re-prompt
+                # once with the kicker, matching _chat_langgraph_stream.
+                if is_dropped_scratch_turn(raw):
+                    log.warning("[chat] dropped scratch-only turn (session=%s) — kicker retry", session_id)
+                    with goal_turn(goal_active):
+                        result = await STATE.graph.ainvoke(
+                            {"messages": [HumanMessage(content=DROPPED_SCRATCH_KICKER)], "session_id": session_id},
+                            config=config,
+                        )
+                    response = extract_output(_last_ai(result))
+
+            # Still nothing (e.g. a `wait` yield, or a tool-only turn): fall back
+            # to the last tool result so the caller gets a signal, not a blank.
+            if not response:
+                response = _last_tool_text(result) or "_(The agent ended the turn without a textual reply.)_"
 
             # Goal mode: verify after the agent stops; re-invoke with a
             # continuation prompt until met / exhausted / unachievable.

--- a/tests/test_chat_nonstreaming_robustness.py
+++ b/tests/test_chat_nonstreaming_robustness.py
@@ -1,0 +1,102 @@
+"""Non-streaming chat (/api/chat + OpenAI-compat) robustness — bd-2qy.
+
+A turn can end with no assistant text: at an ask_human interrupt, after a `wait`
+yield, or on a scratch-only turn. The non-streaming path used to return a silent
+empty 200 in all three cases (the streaming/A2A path handled them). These drive
+the REAL graph (a fake model emitting the relevant tool call / output) through
+``server.chat.chat`` and assert it never returns a blank reply.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+
+
+class _ToolFake(GenericFakeChatModel):
+    """Fake chat model that supports bind_tools (returns itself) so it can drop
+    into create_agent and replay preset AIMessages, including tool calls."""
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+class _FakeJob:
+    def __init__(self, next_fire: str):
+        self.id = "job-1"
+        self.next_fire = next_fire
+
+
+class _FakeScheduler:
+    def add_job(self, prompt, schedule, *, job_id=None, timezone=None, context_id=None):
+        return _FakeJob(schedule)
+
+    def list_jobs(self):
+        return []
+
+    def cancel_job(self, job_id):
+        return True
+
+
+def _install_graph(monkeypatch, messages, scheduler=None):
+    import runtime.state as rs
+    from graph.config import LangGraphConfig
+    from langgraph.checkpoint.memory import MemorySaver
+
+    fake = _ToolFake(messages=iter(messages))
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+
+        g = create_agent_graph(
+            LangGraphConfig(), scheduler=scheduler,
+            include_subagents=False, checkpointer=MemorySaver(),
+        )
+    monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "goal_controller", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", LangGraphConfig(), raising=False)
+    return g
+
+
+@pytest.mark.asyncio
+async def test_ask_human_interrupt_surfaces_the_question(monkeypatch):
+    from server.chat import chat
+
+    _install_graph(monkeypatch, [
+        AIMessage(content="", tool_calls=[
+            {"name": "ask_human", "args": {"question": "What timezone are you in?"},
+             "id": "c1", "type": "tool_call"}]),
+    ])
+    out = await chat("ask me my timezone", "sessA")
+    content = out[0]["content"]
+    assert content, "interrupt must not return an empty reply"
+    assert "Input needed" in content and "timezone" in content.lower()
+
+
+@pytest.mark.asyncio
+async def test_scratch_only_turn_kicks_and_recovers(monkeypatch):
+    from server.chat import chat
+
+    _install_graph(monkeypatch, [
+        AIMessage(content="<scratch_pad>thinking, never committed</scratch_pad>"),
+        AIMessage(content="<output>recovered answer</output>"),
+    ])
+    out = await chat("do something", "sessB")
+    assert out[0]["content"] == "recovered answer"
+
+
+@pytest.mark.asyncio
+async def test_wait_yield_turn_falls_back_to_tool_text(monkeypatch):
+    from server.chat import chat
+
+    _install_graph(monkeypatch, [
+        AIMessage(content="", tool_calls=[
+            {"name": "wait", "args": {"seconds": 30, "then": "resume"},
+             "id": "c1", "type": "tool_call"}]),
+        AIMessage(content="unused"),
+    ], scheduler=_FakeScheduler())
+    out = await chat("wait a bit then resume", "sessC")
+    content = out[0]["content"]
+    assert content and "Yielding" in content  # not a blank reply

--- a/tests/test_slash_command_shadowing.py
+++ b/tests/test_slash_command_shadowing.py
@@ -1,0 +1,50 @@
+"""User-facing skill slash-token shadowing (bd-2zh).
+
+A user-facing skill whose slash token collides with a workflow/subagent is
+unreachable — the workflow/subagent wins dispatch and the skill is dropped from
+the command palette. The shipped web-research skill hit this (`slash: research`
+vs the deep-research workflow). These guard the rename + the warn-once net.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import operator_api.console_handlers as ch
+import runtime.state as rs
+
+
+def test_web_research_skill_slash_does_not_collide_with_research_workflow():
+    text = Path("config/skills/web-research/SKILL.md").read_text()
+    slash = next(
+        (ln.split(":", 1)[1].strip() for ln in text.splitlines()
+         if ln.strip().startswith("slash:")),
+        None,
+    )
+    assert slash and slash != "research", f"web-research slash={slash!r} collides with /research"
+
+
+def test_shadowed_user_facing_skill_is_skipped_and_warned(monkeypatch, caplog):
+    class _WFReg:
+        def list(self):
+            return [{"name": "research", "description": "deep research", "inputs": []}]
+
+    class _SkillsIdx:
+        def user_facing_skills(self):
+            return [
+                {"name": "web-research", "slash": "research", "description": "shadowed"},
+                {"name": "gather", "slash": "gather", "description": "reachable"},
+            ]
+
+    monkeypatch.setattr(rs.STATE, "goal_controller", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "workflow_registry", _WFReg(), raising=False)
+    monkeypatch.setattr(rs.STATE, "skills_index", _SkillsIdx(), raising=False)
+    ch._warned_shadowed_skills.clear()
+
+    with caplog.at_level("WARNING"):
+        cmds = ch._operator_chat_commands()["commands"]
+
+    names = [c["name"] for c in cmds]
+    assert names.count("research") == 1          # only the workflow; skill skipped
+    assert "gather" in names                      # non-colliding skill stays reachable
+    assert any("unreachable" in r.getMessage() for r in caplog.records)


### PR DESCRIPTION
The two remaining issues found while driving a running agent over its API (companions to #1023).

## bd-2qy — non-streaming chat returned a silent empty `200`
A turn that ends with **no assistant text** — at an `ask_human` interrupt, after a `wait` yield, or scratch-only — gave `/api/chat` and the OpenAI-compatible `/v1/chat/completions` a blank assistant message. The streaming/A2A path handled all three; `_chat_langgraph` never got the same hardening (so OpenAI-compat consumers saw an "empty completion" whenever the agent asked for input or yielded).

Now it:
- **surfaces the `ask_human` question** (the caller answers with a follow-up message, which resumes the thread the checkpointer kept),
- **runs the dropped-scratch kicker retry** (parity with the streaming path),
- **falls back to the last tool result** (e.g. `wait`'s "Yielding…" confirmation), else a clear placeholder — never a blank reply.

The two interrupt-detection sites are unified into one `_pending_interrupt_value` helper so they can't drift apart again.

## bd-2zh — first-party `web-research` skill was unreachable
Its slash token was `research`, which collides with the deep-research **workflow** — workflows win dispatch and hide the skill from the command palette, so a shipped user-facing skill could never be invoked. Renamed to `/web-research`; the command builder now **logs a one-time warning** when any user-facing skill's slash token is shadowed, so this can't happen silently again.

## Tests
- `test_chat_nonstreaming_robustness.py` drives the **real graph** (fake model emitting the relevant tool call / output) through `server.chat.chat` for all three empty-turn cases.
- `test_slash_command_shadowing.py` guards the rename + the warn-once dedup net.
- Full suite green: **2000 passed** (3 pre-existing `test_config_roundtrip` golden failures unrelated — they fail on `main` too, from local config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)