### PR TITLE
fix(background): capture spawning session so completions drain back (bd-3v0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Background subagent results are delivered back to the chat that started them.**
+  A `task(run_in_background=True)` (ADR 0050) captured its `origin_session` from
+  the tracing contextvar, which reads empty inside a tool body — so the job ran
+  detached with no originating session and its result could never drain back to
+  the spawning chat (the agent was told "you'll be notified" and never was). It
+  now reads the session from injected graph state, so the completion notification
+  lands on the originating conversation's next turn as designed. (Same root cause
+  as the `wait`/`set_goal` fixes; third caller, now closed.)
 - **Non-streaming chat no longer returns a silent empty `200`.** A turn that ends
   at an `ask_human` interrupt, after a `wait` yield, or scratch-only used to give
   `/api/chat` and the OpenAI-compatible `/v1/chat/completions` a blank assistant

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -4,8 +4,11 @@ Builds the agent graph with middleware, tools, and subagent support.
 Uses langchain's create_agent() with AgentMiddleware for the DeerFlow pattern.
 """
 
+from typing import Annotated, Any
+
 from langchain.agents import create_agent
 from langchain_core.tools import BaseTool
+from langgraph.prebuilt import InjectedState
 
 from graph.config import LangGraphConfig
 from graph.llm import create_llm
@@ -16,7 +19,7 @@ from graph.middleware.memory import MemoryMiddleware
 from graph.middleware.message_capture import MessageCaptureMiddleware
 from graph.state import ProtoAgentState
 from graph.subagents.config import SUBAGENT_REGISTRY
-from tools.lg_tools import get_all_tools
+from tools.lg_tools import _session_id_from, get_all_tools
 
 
 def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_index=None, extra_middleware=None):
@@ -435,6 +438,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
         subagent_type: _SubagentType = "researcher",
         emit_skill: bool = False,
         run_in_background: bool = False,
+        state: Annotated[Any, InjectedState] = None,
     ) -> str:
         """Delegate a single task to a specialized subagent.
 
@@ -460,9 +464,11 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
                 default) when you need the result to finish the current turn.
         """
         async def _spawn_bg() -> str:
-            from observability import tracing
+            # Resolve the originating session from injected graph state, not the
+            # tracing contextvar — the contextvar reads empty in a tool body, so
+            # the completion could never drain back to the spawning chat (ADR 0050).
             job_id = await background_mgr.spawn(
-                origin_session=tracing.current_session_id(),
+                origin_session=_session_id_from(state),
                 subagent_type=subagent_type,
                 description=description,
                 prompt=prompt,

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -12,6 +12,10 @@ from __future__ import annotations
 import asyncio
 from pathlib import Path
 
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+
 from background.manager import BackgroundManager, _build_fired_prompt
 from background.store import BackgroundStore
 
@@ -467,3 +471,57 @@ class TestDrainIntoChat:
         body = _drain_background_messages("sess-Y")[0].content
         assert "truncated to" in body
         assert len(body) < _BG_RESULT_CAP + 2000
+
+
+# ── the `task` tool captures the spawning session (bd-3v0) ────────────────────
+# A chat-originated `task(run_in_background=True)` must stamp the turn's
+# session_id as origin_session, or the completion can never drain back to the
+# spawning chat (server.chat._drain_background_messages matches origin_session).
+# Regression for the contextvar-empty-in-tool-body class — origin_session was
+# read from tracing.current_session_id(), which is empty in a tool body; it now
+# comes from injected graph state. Drives a REAL graph so a monkeypatch can't
+# mask it.
+
+class _ToolFake(GenericFakeChatModel):
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+class _RecordingBG:
+    def __init__(self):
+        self.seen_origin = "__unset__"
+
+    async def spawn(self, *, origin_session, subagent_type, description, prompt):
+        self.seen_origin = origin_session
+        return "bg-test-1"
+
+
+@pytest.mark.asyncio
+async def test_background_task_stamps_the_turn_session_as_origin(monkeypatch):
+    from unittest.mock import patch
+
+    from langchain_core.messages import HumanMessage
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from graph.config import LangGraphConfig
+
+    task_call = AIMessage(
+        content="",
+        tool_calls=[{"name": "task", "args": {
+            "description": "deep dive", "prompt": "go research",
+            "subagent_type": "researcher", "run_in_background": True},
+            "id": "c1", "type": "tool_call"}],
+    )
+    fake = _ToolFake(messages=iter([task_call, AIMessage(content="started, carrying on")]))
+    bg = _RecordingBG()
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+        graph = create_agent_graph(
+            LangGraphConfig(), include_subagents=True, background_mgr=bg,
+            checkpointer=MemorySaver(),
+        )
+    await graph.ainvoke(
+        {"messages": [HumanMessage("kick off background research")], "session_id": "sess-BG"},
+        config={"configurable": {"thread_id": "t1"}},
+    )
+    assert bg.seen_origin == "sess-BG"


### PR DESCRIPTION
Found by probing the background-subagent subsystem (ADR 0050) after #1023/#1029. Same root-cause class as the `wait`/`set_goal` fixes — a **third** caller reading the session from the contextvar inside a tool body, where it's empty.

## The bug
`task(run_in_background=True)` captured `origin_session = tracing.current_session_id()` in the `task` tool body. That contextvar is visible to middleware but **empty inside a tool body** under LangGraph, so the job was created with `origin_session=""`. Since `server.chat._drain_background_messages(session_id)` delivers completions by matching `origin_session == session_id`, the result was **orphaned** — the spawning chat never received the `<task-notification>`, despite the tool telling the agent "you will be notified of the result automatically on a later turn." The job still ran and stored its result; it just never got delivered.

Verified empirically: drove a real `create_agent` graph whose model calls `task(run_in_background=True)`; a recording manager saw `origin_session=''` (expected the turn's `sess-BG`).

## The fix
Read the session from injected graph state (`InjectedState` — `state_schema=ProtoAgentState` is wired since #1023) via `tools.lg_tools._session_id_from`, contextvar kept as an off-graph fallback. `task_batch` is foreground-only and unaffected.

## Tests
- New regression test drives a **real graph turn** (fake model emitting the `task` call) and asserts the spawn's `origin_session` == the turn's `session_id`.
- Full suite green: **2001 passed** (3 pre-existing `test_config_roundtrip` golden failures unrelated — fail on `main` too).

Cosmetic follow-up noted in bd-3v0: the emitted `SkillV1Artifact.source_session_id` (`graph/agent.py`) reads empty for the same reason — left as-is (attribution only; would need threading state through `_run_subagent`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)