### PR TITLE
refactor: single source of truth for tool + slash-command inventories (bd-67j, bd-1wt)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The Tools tab shows exactly what the agent can call.** `/api/tools` re-derived
+  its inventory from `get_all_tools` (the shared lead+subagent base) + plugins +
+  mcp, a *separate* assembly from what `create_agent_graph` actually binds — so it
+  drifted both ways: it advertised `set_goal` while the model couldn't call it
+  (bd-2aa) and it hid `task`/`task_batch`, the filesystem tools, `execute_code`,
+  and the deferred search tool that the model *can* call (bd-67j). Now
+  `create_agent_graph` stamps its final tool set on the compiled graph and the
+  Tools tab reads that — one source of truth, no drift in either direction.
+- **Slash-command palette can't drift from the dispatcher.** The chat dispatcher
+  and the `/api/chat/commands` palette each encoded the `workflow > subagent >
+  skill` precedence (and the shadowed-skill rule) separately. Both now resolve
+  through one shared `_slash_kind` / `resolve_slash_commands` in `server.chat`, so
+  what the palette lists always matches what actually runs.
 - **Background subagent results are delivered back to the chat that started them.**
   A `task(run_in_background=True)` (ADR 0050) captured its `origin_session` from
   the tracing contextvar, which reads empty inside a tool body — so the job ran

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -741,6 +741,12 @@ def create_agent_graph(
         state_schema=ProtoAgentState,
     )
 
+    # Single source of truth for "what tools the model has". Stamp the final
+    # assembled set on the compiled graph so the Tools tab (/api/tools) and any
+    # other consumer read exactly what's BOUND, instead of re-deriving the list
+    # and drifting from it (set_goal advertised-but-unbound bd-2aa; task /
+    # filesystem / execute_code under-reported bd-67j).
+    agent.bound_tools = list(all_tools)
     return agent
 
 

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -33,10 +33,6 @@ from server import AGENT_NAME_ENV, _event_bus, _resolve_operator_project_root
 
 log = logging.getLogger("protoagent.server")
 
-# Slash tokens we've already warned are shadowed (bd-2zh) — warn once per token,
-# not on every /api/chat/commands request.
-_warned_shadowed_skills: set[str] = set()
-
 
 def _operator_allowed_dirs() -> list[str]:
     # The repo root is always operable (it's the default project);
@@ -134,23 +130,41 @@ def _tool_category(name: str, source: str) -> str:
 
 def _operator_tools_list():
     """Live tool inventory for the Tools tab — name, one-line description, source
-    (core/plugin/mcp), and a subsystem category for grouping. Best-effort; degrades
-    to an empty list pre-setup."""
-    cfg = STATE.graph_config
+    (core/plugin/mcp), and a subsystem category for grouping.
+
+    Reads the tools ACTUALLY BOUND to the compiled graph (``graph.bound_tools``,
+    stamped by ``create_agent_graph``) so the Tools tab can't drift from what the
+    model can really call — it covers task/task_batch, filesystem, execute_code,
+    and the deferred search tool, not just the shared ``get_all_tools`` base
+    (bd-2aa / bd-67j). Falls back to re-deriving the base pre-setup, before the
+    graph exists."""
     out: list[dict] = []
     seen: set[str] = set()
+    # Source is derived by cross-referencing the plugin/mcp tool name sets;
+    # everything else bound to the graph is core.
+    plugin_names = {getattr(t, "name", None) for t in (getattr(STATE, "plugin_tools", None) or [])}
+    mcp_names = {getattr(t, "name", None) for t in (getattr(STATE, "mcp_tools", None) or [])}
 
-    def add(tool, source):
+    def add(tool, source=None):
         name = getattr(tool, "name", None)
         if not name or name in seen:
             return
         seen.add(name)
+        src = source or ("plugin" if name in plugin_names else "mcp" if name in mcp_names else "core")
         desc = (getattr(tool, "description", "") or "").strip().split("\n")[0]
         out.append({
-            "name": name, "description": desc, "source": source,
-            "category": _tool_category(name, source),
+            "name": name, "description": desc, "source": src,
+            "category": _tool_category(name, src),
         })
 
+    bound = getattr(STATE.graph, "bound_tools", None)
+    if bound is not None:
+        for t in bound:
+            add(t)
+        return {"tools": out, "count": len(out)}
+
+    # Pre-setup fallback (no compiled graph yet): re-derive the shared base.
+    cfg = STATE.graph_config
     try:
         from tools.lg_tools import get_all_tools
 
@@ -394,81 +408,19 @@ async def _operator_inbox_deliver(item_id: int) -> dict:
 def _operator_chat_commands() -> dict:
     """Slash commands the chat understands — drives the composer autocomplete.
 
-    Currently just `/goal` (when goal mode is loaded). Register a new
-    server-handled control command here and the console picks it up.
-    """
+    The workflow/subagent/skill inventory + precedence comes from the SAME
+    resolver the chat dispatcher uses (``server.chat.resolve_slash_commands``), so
+    the palette can't drift from what actually runs. ``/goal`` (a server-handled
+    control command) is surfaced here when goal mode is loaded."""
+    from server.chat import resolve_slash_commands
+
     commands = []
     if STATE.goal_controller is not None:
         commands.append({
             "name": "goal",
+            "kind": "control",
             "description": "Set, check, or clear a self-driving goal for this chat session.",
             "usage": "/goal <condition>   ·   /goal  (status)   ·   /goal clear",
         })
-    # Each registered workflow is runnable as /<name> (ADR 0002).
-    wf_names: set[str] = set()
-    if STATE.workflow_registry is not None:
-        for wf in STATE.workflow_registry.list():
-            wf_names.add(wf["name"])
-            declared = wf.get("inputs", []) or []
-            req = "".join(f" <{i['name']}>" for i in declared if i.get("required"))
-            opt = "".join(f" [{i['name']}]" for i in declared if not i.get("required"))
-            commands.append({
-                "name": wf["name"],
-                "description": wf.get("description") or f"Run the {wf['name']} workflow.",
-                "usage": f"/{wf['name']}{req}{opt}",
-            })
-    # Each registered subagent is runnable as /<name> <prompt> (ADR 0020),
-    # unless a workflow already claims the name (workflow wins in dispatch).
-    taken: set[str] = set(wf_names)
-    try:
-        from graph.subagents.config import SUBAGENT_REGISTRY
-    except Exception:
-        SUBAGENT_REGISTRY = {}
-    for name, cfg in SUBAGENT_REGISTRY.items():
-        if name in wf_names:
-            continue
-        taken.add(name)
-        commands.append({
-            "name": name,
-            "description": getattr(cfg, "description", "") or f"Run the {name} subagent.",
-            "usage": f"/{name} <prompt>",
-        })
-    # User-facing skills are runnable as /<slash> [args] (ADR 0052). A skill
-    # whose token collides with a workflow/subagent name is skipped (those win
-    # in dispatch); the slash token is the explicit `slash:` or a slug of the name.
-    skills_index = STATE.skills_index
-    reader = getattr(skills_index, "user_facing_skills", None) if skills_index else None
-    if reader is not None:
-        try:
-            ufs = reader()
-        except Exception:
-            ufs = []
-        for skill in ufs:
-            token = (skill.get("slash") or "").strip().lower()
-            if not token:
-                import re
-                token = re.sub(r"[^a-z0-9]+", "-", (skill.get("name") or "").lower()).strip("-")
-            if not token or token == "goal":
-                continue
-            if token in taken:
-                # A workflow/subagent of the same token wins dispatch, so this
-                # user-facing skill is unreachable (bd-2zh — web-research's
-                # `slash: research` was shadowed by the deep-research workflow).
-                # Warn once per token so a shipped-but-shadowed skill is visible
-                # instead of silently dropped; the fix is to rename its `slash:`.
-                if token not in _warned_shadowed_skills:
-                    _warned_shadowed_skills.add(token)
-                    log.warning(
-                        "[skills] user-facing skill %r is unreachable: its slash token /%s "
-                        "is already claimed by a workflow/subagent (which wins dispatch). "
-                        "Rename the skill's `slash:` to expose it.",
-                        skill.get("name") or token, token,
-                    )
-                continue
-            taken.add(token)
-            commands.append({
-                "name": token,
-                "description": skill.get("description") or f"Run the {token} skill.",
-                "usage": f"/{token} [input]",
-            })
+    commands.extend(resolve_slash_commands())
     return {"commands": commands}

--- a/server/chat.py
+++ b/server/chat.py
@@ -461,10 +461,10 @@ def _parse_workflow_inputs(recipe: dict, rest: str) -> dict:
 def _parse_workflow_command(message: str):
     """Return (name, inputs) if ``message`` is ``/<known-workflow> …``, else None."""
     name, rest = _parse_slash_command(message)
-    if not name or STATE.workflow_registry is None:
+    if not name or _slash_kind(name) != "workflow":
         return None
     recipe = STATE.workflow_registry.get(name)
-    if recipe is None:
+    if recipe is None:  # defensive — _slash_kind already confirmed it
         return None
     return name, _parse_workflow_inputs(recipe, rest)
 
@@ -501,18 +501,10 @@ async def _run_parsed_workflow(name: str, inputs: dict, *, on_step=None) -> str:
 
 def _parse_subagent_command(message: str):
     """Return ``(subagent_type, prompt)`` if ``message`` is ``/<known-subagent>
-    …`` (and not a workflow of the same name), else ``None``."""
+    …`` (and not a workflow of the same name), else ``None``. Precedence is
+    decided once by ``_slash_kind`` (a workflow of the same name wins)."""
     name, rest = _parse_slash_command(message)
-    if not name:
-        return None
-    # Workflow wins on a name collision (dispatch checks workflows first).
-    if STATE.workflow_registry is not None and STATE.workflow_registry.get(name) is not None:
-        return None
-    try:
-        from graph.subagents.config import SUBAGENT_REGISTRY
-    except Exception:
-        return None
-    if name not in SUBAGENT_REGISTRY:
+    if not name or _slash_kind(name) != "subagent":
         return None
     return name, rest.strip()
 
@@ -550,24 +542,17 @@ def _slugify_slash(raw: str) -> str:
     return re.sub(r"[^a-z0-9]+", "-", (raw or "").strip().lower()).strip("-")
 
 
-def _parse_skill_command(message: str):
-    """Return ``(skill_dict, args)`` if ``message`` is ``/<user-facing-skill> …``
-    (and not ``/goal`` or a workflow/subagent of the same token), else ``None``."""
-    name, rest = _parse_slash_command(message)
-    if not name:
-        return None
+# Slash tokens already warned as shadowed (a skill whose token a workflow/subagent
+# claims) — warn once, not on every resolve. Shared by dispatch + the palette.
+_warned_shadowed_skills: set[str] = set()
+
+
+def _find_user_facing_skill(name: str):
+    """The user-facing skill whose slash token matches ``/<name>``, or ``None``.
+    Token = explicit ``slash:`` (lowercased) else a slug of the skill name."""
     token = _slugify_slash(name)
-    if not token or token == "goal":
+    if not token:
         return None
-    # Workflow / subagent of the same token win (they're dispatched first).
-    if STATE.workflow_registry is not None and STATE.workflow_registry.get(token) is not None:
-        return None
-    try:
-        from graph.subagents.config import SUBAGENT_REGISTRY
-        if token in SUBAGENT_REGISTRY:
-            return None
-    except Exception:
-        pass
     reader = getattr(STATE.skills_index, "user_facing_skills", None) if STATE.skills_index else None
     if reader is None:
         return None
@@ -578,8 +563,105 @@ def _parse_skill_command(message: str):
     for skill in skills:
         sk_token = (skill.get("slash") or "").strip().lower() or _slugify_slash(skill.get("name", ""))
         if sk_token == token:
-            return skill, rest.strip()
+            return skill
     return None
+
+
+def _slash_kind(name: str) -> str | None:
+    """The kind a ``/<name>`` slash command resolves to — the SINGLE source of
+    precedence shared by the chat dispatcher and the console palette, so they can
+    never disagree about what a token does. Reserved: ``goal``. Precedence:
+    workflow > subagent > user-facing skill. Returns ``None`` for an unknown token.
+    (Workflows/subagents match the bare name; skills match a slug.)"""
+    if not name:
+        return None
+    if name == "goal" or _slugify_slash(name) == "goal":
+        return "goal"
+    if STATE.workflow_registry is not None and STATE.workflow_registry.get(name) is not None:
+        return "workflow"
+    try:
+        from graph.subagents.config import SUBAGENT_REGISTRY
+        if name in SUBAGENT_REGISTRY:
+            return "subagent"
+    except Exception:
+        pass
+    if _find_user_facing_skill(name) is not None:
+        return "skill"
+    return None
+
+
+def resolve_slash_commands() -> list[dict]:
+    """Single source of truth for the slash-command inventory — every registered
+    ``/<token>`` with its ``kind`` + display metadata, precedence applied via
+    ``_slash_kind`` (so the palette can't drift from the dispatcher). A skill
+    shadowed by a workflow/subagent is excluded and warned once. ``goal`` is a
+    control command surfaced separately by the caller."""
+    cmds: list[dict] = []
+    seen: set[str] = set()
+
+    def _add(name, kind, description, usage):
+        if not name or name in seen:
+            return
+        seen.add(name)
+        cmds.append({"name": name, "kind": kind, "description": description, "usage": usage})
+
+    if STATE.workflow_registry is not None:
+        for wf in STATE.workflow_registry.list():
+            declared = wf.get("inputs", []) or []
+            req = "".join(f" <{i['name']}>" for i in declared if i.get("required"))
+            opt = "".join(f" [{i['name']}]" for i in declared if not i.get("required"))
+            _add(wf["name"], "workflow",
+                 wf.get("description") or f"Run the {wf['name']} workflow.",
+                 f"/{wf['name']}{req}{opt}")
+
+    try:
+        from graph.subagents.config import SUBAGENT_REGISTRY
+    except Exception:
+        SUBAGENT_REGISTRY = {}
+    for sname, cfg in SUBAGENT_REGISTRY.items():
+        if _slash_kind(sname) != "subagent":  # a workflow of the same name wins
+            continue
+        _add(sname, "subagent",
+             getattr(cfg, "description", "") or f"Run the {sname} subagent.",
+             f"/{sname} <prompt>")
+
+    reader = getattr(STATE.skills_index, "user_facing_skills", None) if STATE.skills_index else None
+    if reader is not None:
+        try:
+            ufs = reader()
+        except Exception:
+            ufs = []
+        for skill in ufs:
+            token = (skill.get("slash") or "").strip().lower() or _slugify_slash(skill.get("name") or "")
+            if not token or token == "goal":
+                continue
+            kind = _slash_kind(token)
+            if kind != "skill":
+                if kind is not None and token not in _warned_shadowed_skills:
+                    _warned_shadowed_skills.add(token)
+                    log.warning(
+                        "[skills] user-facing skill %r is unreachable: /%s is already "
+                        "claimed by a %s (which wins dispatch). Rename the skill's `slash:`.",
+                        skill.get("name") or token, token, kind,
+                    )
+                continue
+            _add(token, "skill",
+                 skill.get("description") or f"Run the {token} skill.",
+                 f"/{token} [input]")
+    return cmds
+
+
+def _parse_skill_command(message: str):
+    """Return ``(skill_dict, args)`` if ``message`` is ``/<user-facing-skill> …``
+    (and not ``/goal`` or a workflow/subagent of the same token), else ``None``.
+    Precedence is decided once by ``_slash_kind``."""
+    name, rest = _parse_slash_command(message)
+    if not name or _slash_kind(name) != "skill":
+        return None
+    skill = _find_user_facing_skill(name)
+    if skill is None:  # defensive — _slash_kind already confirmed it
+        return None
+    return skill, rest.strip()
 
 
 def _skill_directive(skill: dict, args: str) -> str:

--- a/tests/test_console_handlers.py
+++ b/tests/test_console_handlers.py
@@ -52,6 +52,9 @@ def test_chat_commands_lists_workflows_and_subagents(monkeypatch):
     class _Reg:
         def list(self):
             return [{"name": "deep-research", "description": "d", "inputs": [{"name": "topic", "required": True}]}]
+
+        def get(self, name):
+            return next((w for w in self.list() if w["name"] == name), None)
     monkeypatch.setattr(rs.STATE, "workflow_registry", _Reg(), raising=False)
     out = ch._operator_chat_commands()
     names = [c["name"] for c in out["commands"]]

--- a/tests/test_slash_command_shadowing.py
+++ b/tests/test_slash_command_shadowing.py
@@ -29,6 +29,9 @@ def test_shadowed_user_facing_skill_is_skipped_and_warned(monkeypatch, caplog):
         def list(self):
             return [{"name": "research", "description": "deep research", "inputs": []}]
 
+        def get(self, name):
+            return next((w for w in self.list() if w["name"] == name), None)
+
     class _SkillsIdx:
         def user_facing_skills(self):
             return [
@@ -36,10 +39,14 @@ def test_shadowed_user_facing_skill_is_skipped_and_warned(monkeypatch, caplog):
                 {"name": "gather", "slash": "gather", "description": "reachable"},
             ]
 
+    import importlib
+
+    sc = importlib.import_module("server.chat")  # the module (server.chat re-exports the chat fn)
+
     monkeypatch.setattr(rs.STATE, "goal_controller", None, raising=False)
     monkeypatch.setattr(rs.STATE, "workflow_registry", _WFReg(), raising=False)
     monkeypatch.setattr(rs.STATE, "skills_index", _SkillsIdx(), raising=False)
-    ch._warned_shadowed_skills.clear()
+    sc._warned_shadowed_skills.clear()
 
     with caplog.at_level("WARNING"):
         cmds = ch._operator_chat_commands()["commands"]

--- a/tests/test_tools_inventory_single_source.py
+++ b/tests/test_tools_inventory_single_source.py
@@ -1,0 +1,77 @@
+"""The Tools tab is fed by the bound graph, not a re-derivation (bd-2aa, bd-67j).
+
+`_operator_tools_list` reads `graph.bound_tools` (stamped by create_agent_graph),
+so the operator's Tools inventory is exactly what the model can call — it can't
+over-report (set_goal advertised-but-unbound) or under-report (task / filesystem
+omitted). One source of truth.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage
+
+
+class _ToolFake(GenericFakeChatModel):
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+def _graph(goal_enabled=True):
+    from graph.agent import create_agent_graph
+    from graph.config import LangGraphConfig
+
+    fake = _ToolFake(messages=iter([AIMessage(content="x")]))
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        return create_agent_graph(LangGraphConfig(goal_enabled=goal_enabled))
+
+
+def test_tools_tab_exactly_matches_the_bound_graph(monkeypatch):
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    g = _graph(goal_enabled=True)
+    monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "plugin_tools", [], raising=False)
+    monkeypatch.setattr(rs.STATE, "mcp_tools", [], raising=False)
+
+    listed = {t["name"] for t in ch._operator_tools_list()["tools"]}
+    bound = {getattr(t, "name", None) for t in g.bound_tools}
+
+    assert listed == bound                      # no drift, either direction
+    assert "task" in listed                     # subagent delegation now visible
+    assert "read_file" in listed                # filesystem now visible (was omitted)
+    assert "set_goal" in listed                 # bound when goal_enabled (bd-2aa)
+
+
+def test_tools_tab_omits_set_goal_when_goal_disabled(monkeypatch):
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    g = _graph(goal_enabled=False)
+    monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "plugin_tools", [], raising=False)
+    monkeypatch.setattr(rs.STATE, "mcp_tools", [], raising=False)
+
+    listed = {t["name"] for t in ch._operator_tools_list()["tools"]}
+    assert "set_goal" not in listed
+
+
+def test_pre_setup_fallback_without_a_graph(monkeypatch):
+    # Before the graph is compiled, degrade to the shared base instead of erroring.
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "graph", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "knowledge_store", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "scheduler", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "inbox_store", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "beads_store", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "plugin_tools", [], raising=False)
+    monkeypatch.setattr(rs.STATE, "mcp_tools", [], raising=False)
+
+    names = {t["name"] for t in ch._operator_tools_list()["tools"]}
+    assert "current_time" in names              # the keyless base is always present


### PR DESCRIPTION
Prompted by the observation that several of this session's bugs share one root cause: **the same "truth" assembled independently in two places, which then drift.** This collapses the two worst offenders onto a single source each.

## Tool inventory (bd-67j; retroactively bd-2aa)
`/api/tools` (`_operator_tools_list`) re-derived the inventory from `get_all_tools` (the shared lead+subagent base) + plugins + mcp — a **different assembly** from what `create_agent_graph` actually binds. So it drifted both ways:
- **over-reported:** `set_goal` was advertised while the model couldn't call it (bd-2aa);
- **under-reported:** `task`/`task_batch`, the **filesystem tools**, `execute_code`, and the deferred `search_tools` were hidden even though the model can call them (bd-67j) — a real transparency gap (the operator couldn't see the agent had filesystem access).

Now `create_agent_graph` stamps its final assembled set on the compiled graph (`graph.bound_tools`) and the Tools tab reads **that**, deriving source by cross-referencing the plugin/mcp name sets. The `get_all_tools` re-derivation stays only as a pre-setup fallback. The tab now equals exactly what the model can call — no drift in either direction.

## Slash commands (bd-1wt; retroactively bd-2zh)
The chat dispatcher (`_parse_workflow/subagent/skill_command`) and the palette (`_operator_chat_commands`) each encoded the `workflow > subagent > skill` precedence and the shadowed-skill rule **separately**. Collapsed into one authority in `server.chat`:
- `_slash_kind(name)` — the precedence decision, used by all three `_parse_*` functions;
- `resolve_slash_commands()` — the palette's list, built from `_slash_kind`, with the warn-once shadow logic.

The palette now lists exactly what the dispatcher will run.

## Tests
- New `test_tools_inventory_single_source.py`: the Tools tab **equals** the graph's bound tools (incl. `task` + `read_file`; `set_goal` gated on `goal_enabled`); pre-setup fallback covered.
- Slash dispatch/palette behavior unchanged — existing `test_workflow_slash` / `test_subagent_slash` / `test_skill_slash` / `test_console_handlers` / `test_slash_command_shadowing` all green (test fakes made faithful to the real registry's `.get()` contract).
- Full suite: **2004 passed** (3 pre-existing `test_config_roundtrip` golden failures unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)