### PR TITLE
fix(lint): restore graph/slash_commands.py so main's import contract passes

### DIFF
--- a/graph/slash_commands.py
+++ b/graph/slash_commands.py
@@ -1,0 +1,135 @@
+"""Single source of truth for slash-command resolution (precedence + palette).
+
+The chat dispatcher (``server.chat``) and the console command palette
+(``operator_api.console_handlers``) both need to agree on what a ``/<token>``
+does. They used to encode the ``workflow > subagent > skill`` precedence (and the
+shadowed-skill rule) separately, which is how a shipped skill could be silently
+unreachable. This module holds that logic ONCE.
+
+It lives in ``graph/`` deliberately: ``operator_api`` must not import ``server``
+(import-linter contract), so the shared code can't live in ``server.chat``. Both
+layers may import ``graph``. It depends only on ``runtime.state`` (for the live
+registries) and ``graph.subagents`` — never on ``server`` / ``operator_api``.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+
+from runtime.state import STATE
+
+log = logging.getLogger("protoagent.server")
+
+# Slash tokens already warned as shadowed (a skill whose token a workflow/subagent
+# claims) — warn once, not on every resolve.
+_warned_shadowed_skills: set[str] = set()
+
+
+def slugify_slash(raw: str) -> str:
+    """Lowercase + non-alphanumerics→hyphens slug for a slash token."""
+    return re.sub(r"[^a-z0-9]+", "-", (raw or "").strip().lower()).strip("-")
+
+
+def find_user_facing_skill(name: str):
+    """The user-facing skill whose slash token matches ``/<name>``, or ``None``.
+    Token = explicit ``slash:`` (lowercased) else a slug of the skill name."""
+    token = slugify_slash(name)
+    if not token:
+        return None
+    reader = getattr(STATE.skills_index, "user_facing_skills", None) if STATE.skills_index else None
+    if reader is None:
+        return None
+    try:
+        skills = reader()
+    except Exception:
+        return None
+    for skill in skills:
+        sk_token = (skill.get("slash") or "").strip().lower() or slugify_slash(skill.get("name", ""))
+        if sk_token == token:
+            return skill
+    return None
+
+
+def slash_kind(name: str) -> str | None:
+    """The kind a ``/<name>`` slash command resolves to — the SINGLE source of
+    precedence shared by the chat dispatcher and the console palette, so they can
+    never disagree about what a token does. Reserved: ``goal``. Precedence:
+    workflow > subagent > user-facing skill. Returns ``None`` for an unknown token.
+    (Workflows/subagents match the bare name; skills match a slug.)"""
+    if not name:
+        return None
+    if name == "goal" or slugify_slash(name) == "goal":
+        return "goal"
+    if STATE.workflow_registry is not None and STATE.workflow_registry.get(name) is not None:
+        return "workflow"
+    try:
+        from graph.subagents.config import SUBAGENT_REGISTRY
+        if name in SUBAGENT_REGISTRY:
+            return "subagent"
+    except Exception:
+        pass
+    if find_user_facing_skill(name) is not None:
+        return "skill"
+    return None
+
+
+def resolve_slash_commands() -> list[dict]:
+    """Single source of truth for the slash-command inventory — every registered
+    ``/<token>`` with its ``kind`` + display metadata, precedence applied via
+    ``slash_kind`` (so the palette can't drift from the dispatcher). A skill
+    shadowed by a workflow/subagent is excluded and warned once. ``goal`` is a
+    control command surfaced separately by the caller."""
+    cmds: list[dict] = []
+    seen: set[str] = set()
+
+    def _add(name, kind, description, usage):
+        if not name or name in seen:
+            return
+        seen.add(name)
+        cmds.append({"name": name, "kind": kind, "description": description, "usage": usage})
+
+    if STATE.workflow_registry is not None:
+        for wf in STATE.workflow_registry.list():
+            declared = wf.get("inputs", []) or []
+            req = "".join(f" <{i['name']}>" for i in declared if i.get("required"))
+            opt = "".join(f" [{i['name']}]" for i in declared if not i.get("required"))
+            _add(wf["name"], "workflow",
+                 wf.get("description") or f"Run the {wf['name']} workflow.",
+                 f"/{wf['name']}{req}{opt}")
+
+    try:
+        from graph.subagents.config import SUBAGENT_REGISTRY
+    except Exception:
+        SUBAGENT_REGISTRY = {}
+    for sname, cfg in SUBAGENT_REGISTRY.items():
+        if slash_kind(sname) != "subagent":  # a workflow of the same name wins
+            continue
+        _add(sname, "subagent",
+             getattr(cfg, "description", "") or f"Run the {sname} subagent.",
+             f"/{sname} <prompt>")
+
+    reader = getattr(STATE.skills_index, "user_facing_skills", None) if STATE.skills_index else None
+    if reader is not None:
+        try:
+            ufs = reader()
+        except Exception:
+            ufs = []
+        for skill in ufs:
+            token = (skill.get("slash") or "").strip().lower() or slugify_slash(skill.get("name") or "")
+            if not token or token == "goal":
+                continue
+            kind = slash_kind(token)
+            if kind != "skill":
+                if kind is not None and token not in _warned_shadowed_skills:
+                    _warned_shadowed_skills.add(token)
+                    log.warning(
+                        "[skills] user-facing skill %r is unreachable: /%s is already "
+                        "claimed by a %s (which wins dispatch). Rename the skill's `slash:`.",
+                        skill.get("name") or token, token, kind,
+                    )
+                continue
+            _add(token, "skill",
+                 skill.get("description") or f"Run the {token} skill.",
+                 f"/{token} [input]")
+    return cmds

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -412,7 +412,7 @@ def _operator_chat_commands() -> dict:
     resolver the chat dispatcher uses (``server.chat.resolve_slash_commands``), so
     the palette can't drift from what actually runs. ``/goal`` (a server-handled
     control command) is surfaced here when goal mode is loaded."""
-    from server.chat import resolve_slash_commands
+    from graph.slash_commands import resolve_slash_commands
 
     commands = []
     if STATE.goal_controller is not None:

--- a/server/chat.py
+++ b/server/chat.py
@@ -16,7 +16,6 @@ import cycle. ``server/__init__.py`` re-exports every public name so
 import asyncio
 import json
 import logging
-import re
 import time
 from typing import Any
 
@@ -537,118 +536,13 @@ async def _run_parsed_subagent(subagent_type: str, prompt: str) -> str:
 # token win (dispatch checks them first).
 
 
-def _slugify_slash(raw: str) -> str:
-    """Lowercase + non-alphanumerics→hyphens slug for a slash token."""
-    return re.sub(r"[^a-z0-9]+", "-", (raw or "").strip().lower()).strip("-")
-
-
-# Slash tokens already warned as shadowed (a skill whose token a workflow/subagent
-# claims) — warn once, not on every resolve. Shared by dispatch + the palette.
-_warned_shadowed_skills: set[str] = set()
-
-
-def _find_user_facing_skill(name: str):
-    """The user-facing skill whose slash token matches ``/<name>``, or ``None``.
-    Token = explicit ``slash:`` (lowercased) else a slug of the skill name."""
-    token = _slugify_slash(name)
-    if not token:
-        return None
-    reader = getattr(STATE.skills_index, "user_facing_skills", None) if STATE.skills_index else None
-    if reader is None:
-        return None
-    try:
-        skills = reader()
-    except Exception:
-        return None
-    for skill in skills:
-        sk_token = (skill.get("slash") or "").strip().lower() or _slugify_slash(skill.get("name", ""))
-        if sk_token == token:
-            return skill
-    return None
-
-
-def _slash_kind(name: str) -> str | None:
-    """The kind a ``/<name>`` slash command resolves to — the SINGLE source of
-    precedence shared by the chat dispatcher and the console palette, so they can
-    never disagree about what a token does. Reserved: ``goal``. Precedence:
-    workflow > subagent > user-facing skill. Returns ``None`` for an unknown token.
-    (Workflows/subagents match the bare name; skills match a slug.)"""
-    if not name:
-        return None
-    if name == "goal" or _slugify_slash(name) == "goal":
-        return "goal"
-    if STATE.workflow_registry is not None and STATE.workflow_registry.get(name) is not None:
-        return "workflow"
-    try:
-        from graph.subagents.config import SUBAGENT_REGISTRY
-        if name in SUBAGENT_REGISTRY:
-            return "subagent"
-    except Exception:
-        pass
-    if _find_user_facing_skill(name) is not None:
-        return "skill"
-    return None
-
-
-def resolve_slash_commands() -> list[dict]:
-    """Single source of truth for the slash-command inventory — every registered
-    ``/<token>`` with its ``kind`` + display metadata, precedence applied via
-    ``_slash_kind`` (so the palette can't drift from the dispatcher). A skill
-    shadowed by a workflow/subagent is excluded and warned once. ``goal`` is a
-    control command surfaced separately by the caller."""
-    cmds: list[dict] = []
-    seen: set[str] = set()
-
-    def _add(name, kind, description, usage):
-        if not name or name in seen:
-            return
-        seen.add(name)
-        cmds.append({"name": name, "kind": kind, "description": description, "usage": usage})
-
-    if STATE.workflow_registry is not None:
-        for wf in STATE.workflow_registry.list():
-            declared = wf.get("inputs", []) or []
-            req = "".join(f" <{i['name']}>" for i in declared if i.get("required"))
-            opt = "".join(f" [{i['name']}]" for i in declared if not i.get("required"))
-            _add(wf["name"], "workflow",
-                 wf.get("description") or f"Run the {wf['name']} workflow.",
-                 f"/{wf['name']}{req}{opt}")
-
-    try:
-        from graph.subagents.config import SUBAGENT_REGISTRY
-    except Exception:
-        SUBAGENT_REGISTRY = {}
-    for sname, cfg in SUBAGENT_REGISTRY.items():
-        if _slash_kind(sname) != "subagent":  # a workflow of the same name wins
-            continue
-        _add(sname, "subagent",
-             getattr(cfg, "description", "") or f"Run the {sname} subagent.",
-             f"/{sname} <prompt>")
-
-    reader = getattr(STATE.skills_index, "user_facing_skills", None) if STATE.skills_index else None
-    if reader is not None:
-        try:
-            ufs = reader()
-        except Exception:
-            ufs = []
-        for skill in ufs:
-            token = (skill.get("slash") or "").strip().lower() or _slugify_slash(skill.get("name") or "")
-            if not token or token == "goal":
-                continue
-            kind = _slash_kind(token)
-            if kind != "skill":
-                if kind is not None and token not in _warned_shadowed_skills:
-                    _warned_shadowed_skills.add(token)
-                    log.warning(
-                        "[skills] user-facing skill %r is unreachable: /%s is already "
-                        "claimed by a %s (which wins dispatch). Rename the skill's `slash:`.",
-                        skill.get("name") or token, token, kind,
-                    )
-                continue
-            _add(token, "skill",
-                 skill.get("description") or f"Run the {token} skill.",
-                 f"/{token} [input]")
-    return cmds
+# Slash-command precedence + the palette resolver live in graph/slash_commands.py
+# — a neutral module both the dispatcher (here) and the console palette import, so
+# the two can't drift (operator_api may not import server, so it can't live here).
+from graph.slash_commands import (  # noqa: E402
+    find_user_facing_skill as _find_user_facing_skill,
+    slash_kind as _slash_kind,
+)
 
 
 def _parse_skill_command(message: str):

--- a/tests/test_slash_command_shadowing.py
+++ b/tests/test_slash_command_shadowing.py
@@ -39,9 +39,7 @@ def test_shadowed_user_facing_skill_is_skipped_and_warned(monkeypatch, caplog):
                 {"name": "gather", "slash": "gather", "description": "reachable"},
             ]
 
-    import importlib
-
-    sc = importlib.import_module("server.chat")  # the module (server.chat re-exports the chat fn)
+    import graph.slash_commands as sc
 
     monkeypatch.setattr(rs.STATE, "goal_controller", None, raising=False)
     monkeypatch.setattr(rs.STATE, "workflow_registry", _WFReg(), raising=False)


### PR DESCRIPTION
**Hotfix for `main`.** PR #1031 squash-merged with `head=337f25a` — only its first commit. The lint-fix follow-up (which moved the shared slash resolver out of `server.chat` into a neutral `graph/slash_commands.py`) didn't make it in, because the **Lint (ruff + import contracts) check is not a *required* status check** — auto-merge fired the moment the required checks (tests) went green, before the lint fix landed.

Result: `main` currently fails the import-linter contract `operator_api does not import server` (`operator_api.console_handlers -> server.chat`) and is missing `graph/slash_commands.py`.

This re-applies that fix commit:
- adds `graph/slash_commands.py` (the shared `slash_kind` / `find_user_facing_skill` / `resolve_slash_commands`, in a layer both `server` and `operator_api` may import),
- points `console_handlers` at it instead of `server.chat`,
- drops the now-unused `import re` from `server.chat`.

Verified locally: `lint-imports` → 3 contracts kept / 0 broken; `ruff==0.15.10` clean; slash/console/tools tests green.

Recommend making the Lint check **required** in branch protection so a red contract can't auto-merge again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)