### PR TITLE
feat(plugins): host-free plugin test harness (testkit) — closes #1024

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Host-free plugin test harness (`graph/plugins/testkit.py`).** A self-contained
+  (stdlib-only) testkit that loads a plugin as a **package** — so a plugin's real engine
+  modules (relative imports, module-level `@tool`, lazy `graph.*` host imports) can be
+  unit-tested with no protoAgent running, not just `register()`. `load_plugin()` mirrors
+  the runtime loader's `protoagent_plugin_<id>` convention; `install_host_stubs()` registers
+  stand-ins for absent host modules (`graph.*` / `knowledge.*`) that are monkeypatchable and
+  raise-loud-if-unpatched; `FakeRegistry` captures contributions. `scaffold_plugin(with_tests=True)`
+  now **vendors** the testkit (`tests/_plugin_testkit.py`, verbatim) + a conftest that uses
+  it, so new and standalone plugins get deep-module testing out of the box. Closes the gap
+  hit building the spacetraders plugin, where `fleet.py`/`tools.py` couldn't be tested
+  without extracting all logic into dependency-free modules (#1024).
+
 ### Fixed
 - **The Tools tab shows exactly what the agent can call.** `/api/tools` re-derived
   its inventory from `get_all_tools` (the shared lead+subagent base) + plugins +

--- a/graph/plugins/scaffold.py
+++ b/graph/plugins/scaffold.py
@@ -109,63 +109,50 @@ output: "{{{{steps.do.output}}}}"
 # standalone-repo plugin is green from birth. Written verbatim unless noted.
 _CONFTEST_STUB = '''"""Test bootstrap — load the plugin host-free (no protoAgent running).
 
-Executing __init__.py is safe: the host-only imports (fastapi, graph.*) are lazy
-(inside register()), so the suite needs only requirements-dev.txt.
+Uses the vendored testkit (``_plugin_testkit.py`` — a verbatim copy of protoAgent's
+``graph/plugins/testkit.py``, dropped here so the suite has zero protoAgent dependency).
+It loads the plugin as a PACKAGE, so your tests can import and exercise the REAL sibling
+modules — relative imports and all — not just ``register()``:
+
+    def test_engine(plugin):
+        import importlib
+        engine = importlib.import_module(plugin.__name__ + ".engine")  # a deep module
+        assert engine.classify([...]) == ...
+
+``install_host_stubs()`` (run at import below) registers stand-ins for the host-only
+modules (``graph.*`` / ``knowledge.*``) so a plugin module that imports them loads with no
+host; monkeypatch a seam to assert its behaviour. To refresh the vendored copy after a
+protoAgent upgrade, re-run ``scaffold_plugin`` or recopy ``graph/plugins/testkit.py``.
 """
 
 from __future__ import annotations
 
-import importlib.util
+import sys
 from pathlib import Path
 
 import pytest
 
+sys.path.insert(0, str(Path(__file__).resolve().parent))  # so `import _plugin_testkit` resolves
+
+from _plugin_testkit import FakeRegistry, install_host_stubs, load_plugin  # noqa: E402
+
 ROOT = Path(__file__).resolve().parent.parent
+PLUGIN_ID = "{id}"
+
+install_host_stubs()  # before any plugin module imports the host
 
 
 @pytest.fixture
 def plugin():
-    spec = importlib.util.spec_from_file_location("plugin_under_test", ROOT / "__init__.py")
-    mod = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(mod)
-    return mod
-
-
-class _Registry:
-    """A fake registry — records what register() contributes, with no host."""
-
-    def __init__(self):
-        self.config = {}
-        self.tools, self.routers, self.surfaces, self.subagents, self.skill_dirs = [], [], [], [], []
-
-    def register_tool(self, t):
-        self.tools.append(t)
-
-    def register_tools(self, ts):
-        self.tools.extend(ts)
-
-    def register_router(self, router, prefix=""):
-        self.routers.append(prefix)
-
-    def register_surface(self, start, stop=None, name=None):
-        self.surfaces.append(name)
-
-    def register_subagent(self, cfg):
-        self.subagents.append(cfg)
-
-    def register_skill_dir(self, path):
-        self.skill_dirs.append(path)
-
-    def emit(self, *a, **k):
-        pass
-
-    def on(self, *a, **k):
-        pass
+    """The plugin loaded as a package — ``register()`` runs and ``from <pkg> import x``
+    works, so you can unit-test deep engine modules, not just registration."""
+    return load_plugin(ROOT, PLUGIN_ID)
 
 
 @pytest.fixture
 def registry():
-    return _Registry()
+    """A fake registry that records what ``register()`` contributes (assert against it)."""
+    return FakeRegistry()
 '''
 
 # .format(id=, name=) — no other literal braces.
@@ -447,10 +434,16 @@ def scaffold_plugin(
 
 
 def _write_test_harness(target: Path, *, pid: str, id_us: str, name: str) -> None:
-    """Write the host-free test suite + CI + dev deps + pyproject (with_tests)."""
+    """Write the host-free test suite + CI + dev deps + pyproject (with_tests).
+
+    Vendors ``graph/plugins/testkit.py`` verbatim as ``tests/_plugin_testkit.py`` (single
+    source of truth — stdlib-only, so the standalone repo needs no protoAgent dependency),
+    and a conftest that uses it to load the plugin as a package."""
     tdir = target / "tests"
     tdir.mkdir()
-    (tdir / "conftest.py").write_text(_CONFTEST_STUB)
+    testkit_src = (Path(__file__).with_name("testkit.py")).read_text()
+    (tdir / "_plugin_testkit.py").write_text(testkit_src)
+    (tdir / "conftest.py").write_text(_CONFTEST_STUB.format(id=pid))
     (tdir / f"test_{id_us}.py").write_text(_TEST_STUB.format(id=pid, name=name))
     gh = target / ".github" / "workflows"
     gh.mkdir(parents=True)

--- a/graph/plugins/testkit.py
+++ b/graph/plugins/testkit.py
@@ -1,0 +1,241 @@
+"""Host-free plugin test harness — load a plugin and exercise its REAL modules
+(relative imports + host APIs) without a running protoAgent.
+
+Why this exists: a plugin is a package whose modules use relative imports
+(``from . import client``) and may touch host-only modules (``graph.*``,
+``knowledge.store``) that protoAgent provides at runtime but aren't pip deps. So a
+plain ``import client`` from the repo root fails, and a plugin's engine logic
+(``fleet.autopilot`` role assignment, a trade-route ranker, …) goes untested unless
+every bit is hand-extracted into dependency-free modules. This harness removes that
+tax: it loads the plugin the way the host does, so its sibling modules are importable
+and its host imports resolve to stubs.
+
+Two capabilities:
+  * ``load_plugin(root)``     — import the plugin dir as a package so ``from . import x``
+    resolves and ``import <pkg>.fleet`` works → unit-test deep engine modules directly.
+  * ``install_host_stubs()``  — register stub ``graph.*`` / ``knowledge.*`` modules in
+    ``sys.modules`` so the plugin's host imports load (and are monkeypatchable) with no
+    host. Plus ``FakeRegistry`` to capture what ``register()`` contributes.
+
+Self-contained on purpose: **stdlib only, zero protoAgent-internal imports**, so it works
+both in-repo (``from graph.plugins.testkit import load_plugin``) AND vendored verbatim into
+a standalone plugin's CI (the scaffolder copies this file to ``tests/_plugin_testkit.py``).
+The package naming mirrors ``graph/plugins/loader.py`` so tests exercise the SAME import
+paths the runtime uses — keep the two in sync.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import re
+import sys
+import types
+from pathlib import Path
+
+__all__ = ["plugin_module_name", "load_plugin", "install_host_stubs", "FakeRegistry"]
+
+
+def plugin_module_name(plugin_id: str) -> str:
+    """The synthetic package name a plugin loads under — mirrors
+    ``graph.plugins.loader._plugin_module_name`` (a hyphen in the module name breaks the
+    relative-import machinery, so non-identifier chars become ``_``)."""
+    return "protoagent_plugin_" + re.sub(r"\W", "_", plugin_id)
+
+
+def load_plugin(root, plugin_id: str | None = None, *, entry: str = "__init__.py"):
+    """Import a plugin directory as a PACKAGE and return the package module.
+
+    After this, the plugin's own relative imports resolve and you can reach its sibling
+    modules — ``import <pkg>.fleet`` / ``getattr(pkg, "fleet")`` — to unit-test engine
+    logic directly, exactly as the host loads it (under ``protoagent_plugin_<id>`` with the
+    plugin dir on the package search path). Idempotent + reload-safe: re-loading purges the
+    package AND its cached submodules so an edited sibling re-execs (mirrors the loader).
+
+    Args:
+        root: the plugin directory (where ``__init__.py`` lives).
+        plugin_id: the plugin id; defaults to the directory name.
+        entry: the entry module filename (``__init__.py`` or ``plugin.py``).
+    """
+    root = Path(root).resolve()
+    name = plugin_module_name(plugin_id or root.name)
+    for cached in [m for m in list(sys.modules) if m == name or m.startswith(name + ".")]:
+        sys.modules.pop(cached, None)
+    spec = importlib.util.spec_from_file_location(
+        name, str(root / entry), submodule_search_locations=[str(root)])
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"could not create an import spec for {root / entry}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module  # register BEFORE exec so `from .x import y` finds the parent
+    try:
+        spec.loader.exec_module(module)
+    except BaseException:
+        sys.modules.pop(name, None)
+        raise
+    return module
+
+
+# ── host stubs ───────────────────────────────────────────────────────────────────────
+# protoAgent provides these modules at runtime but they aren't pip deps, so a plugin's
+# `from graph.sdk import complete` / `from knowledge.store import KnowledgeStore` raise
+# ModuleNotFoundError under bare pytest. We register lightweight stand-ins. Each undefined
+# attribute resolves to a stub that's safe to IMPORT and to monkeypatch, but RAISES if
+# actually called unpatched — so a test that exercises a host seam without patching it
+# fails loudly rather than silently passing against a fake.
+
+
+def _raise_unpatched(dotted: str):
+    def _stub(*_a, **_k):
+        raise RuntimeError(
+            f"{dotted} is a stubbed host seam — monkeypatch it in your test "
+            f"(install_host_stubs registered a placeholder so the import resolves).")
+    return _stub
+
+
+class _StubModule(types.ModuleType):
+    """A stub host module: declared attributes are returned as-is; any other attribute
+    resolves to a raise-when-called placeholder (so imports succeed and seams are
+    patchable). Marked as a package (``__path__``) so submodules resolve."""
+
+    def __init__(self, name: str, attrs: dict | None = None):
+        super().__init__(name)
+        self.__path__ = []  # type: ignore[attr-defined]
+        for k, v in (attrs or {}).items():
+            setattr(self, k, v)
+
+    def __getattr__(self, item: str):
+        if item.startswith("__"):
+            raise AttributeError(item)
+        return _raise_unpatched(f"{self.__name__}.{item}")
+
+
+# Default host surface, derived from what real plugins import (spacetraders, project_board,
+# notes, …). `extra` lets a plugin add its own; anything already importable is left alone.
+def _default_stubs() -> dict:
+    return {
+        "graph": {},
+        "graph.sdk": {},                       # run_subagent / subagent_types / config / complete
+        "graph.config": {"LangGraphConfig": type("LangGraphConfig", (), {})},
+        "graph.config_io": {"SECRETS_YAML_PATH": Path("config/secrets.yaml")},
+        "graph.goals": {},
+        "graph.goals.types": {"VerifyResult": type("VerifyResult", (), {
+            "__init__": lambda self, **kw: self.__dict__.update(kw)})},
+        "knowledge": {},
+        "knowledge.store": {"KnowledgeStore": type("KnowledgeStore", (), {})},
+    }
+
+
+def install_host_stubs(extra: dict | None = None) -> list[str]:
+    """Register stub host modules in ``sys.modules`` so a plugin's ``graph.*`` /
+    ``knowledge.*`` imports resolve with no protoAgent present. Call BEFORE ``load_plugin``
+    (or before importing any plugin module that imports the host).
+
+    Idempotent and non-clobbering: a module that's already importable (a real one, or a
+    stub from a previous call) is left untouched. ``extra`` is ``{module_name: {attr: val}}``
+    to add or override host modules your plugin needs. Returns the names newly installed.
+    """
+    specs = _default_stubs()
+    for name, attrs in (extra or {}).items():
+        specs.setdefault(name, {}).update(attrs)
+    installed: list[str] = []
+    for name in sorted(specs, key=lambda n: n.count(".")):  # parents before children
+        if name in sys.modules:
+            continue                                        # already present (real or stubbed) — leave it
+        try:
+            __import__(name)                                # a real host module is installed → use it
+            continue
+        except Exception:
+            pass
+        module = _StubModule(name, specs[name])             # attrs set only when we CREATE the stub,
+        sys.modules[name] = module                          # so a real host module is never clobbered
+        installed.append(name)
+        if "." in name:                                     # attach to the parent package
+            parent, _, child = name.rpartition(".")
+            if parent in sys.modules:
+                setattr(sys.modules[parent], child, module)
+    return installed
+
+
+# ── fake registry ────────────────────────────────────────────────────────────────────
+class FakeRegistry:
+    """Records what ``register(registry)`` contributes, with no host — mirrors the real
+    ``graph.plugins.registry.PluginRegistry`` surface so a plugin's ``register()`` runs
+    unchanged. Assert against the captured lists/dicts.
+
+    e.g. ``reg = FakeRegistry(); plugin.register(reg); assert reg.tools and reg.verifiers``.
+    """
+
+    def __init__(self, config: dict | None = None):
+        self.config = config or {}
+        self.tools: list = []
+        self.routers: list = []
+        self.surfaces: list = []
+        self.subagents: list = []
+        self.middlewares: list = []
+        self.mcp_servers: list = []
+        self.a2a_skills: list = []
+        self.skill_dirs: list = []
+        self.workflow_dirs: list = []
+        self.verifiers: dict = {}
+        self.goal_hooks: list = []
+        self.knowledge_stores: dict = {}
+        self.embedders: dict = {}
+        self.handlers: dict = {}          # topic -> [handlers]
+        self.emitted: list = []           # (topic, data)
+        self.navigations: list = []
+        self.thread_id_resolver = None
+
+    # contributions
+    def register_tool(self, tool) -> None:
+        self.tools.append(tool)
+
+    def register_tools(self, tools) -> None:
+        self.tools.extend(tools)
+
+    def register_router(self, router, prefix: str | None = None) -> None:
+        self.routers.append((prefix, router))
+
+    def register_surface(self, start, stop=None, name: str | None = None, reload=None) -> None:
+        self.surfaces.append(name)
+
+    def register_subagent(self, config) -> None:
+        self.subagents.append(config)
+
+    def register_middleware(self, factory) -> None:
+        self.middlewares.append(factory)
+
+    def register_mcp_server(self, factory) -> None:
+        self.mcp_servers.append(factory)
+
+    def register_a2a_skill(self, spec: dict) -> None:
+        self.a2a_skills.append(spec)
+
+    def register_skill_dir(self, path) -> None:
+        self.skill_dirs.append(str(path))
+
+    def register_workflow_dir(self, path) -> None:
+        self.workflow_dirs.append(str(path))
+
+    def register_goal_verifier(self, name: str, fn) -> None:
+        self.verifiers[name] = fn
+
+    def register_goal_hook(self, *, on_achieved=None, on_failed=None) -> None:
+        self.goal_hooks.append((on_achieved, on_failed))
+
+    def register_knowledge_store(self, name: str, factory) -> None:
+        self.knowledge_stores[name] = factory
+
+    def register_embedder(self, name: str, factory) -> None:
+        self.embedders[name] = factory
+
+    def register_thread_id_resolver(self, fn) -> None:
+        self.thread_id_resolver = fn
+
+    # bus / nav (no-op capture)
+    def emit(self, topic: str, data: dict | None = None) -> None:
+        self.emitted.append((topic, data))
+
+    def on(self, topic: str, handler) -> None:
+        self.handlers.setdefault(topic, []).append(handler)
+
+    def navigate(self, view: str = "") -> None:
+        self.navigations.append(view)

--- a/plugins/plugin-devkit/skills/building-plugins/SKILL.md
+++ b/plugins/plugin-devkit/skills/building-plugins/SKILL.md
@@ -115,10 +115,27 @@ You don't need to restart to try a plugin you built. With **plugin-devkit** enab
 
 For a **standalone-repo** plugin (its own git repo, not bundled in protoAgent), pass
 `with_tests=True` (`scaffold_plugin`) / `--tests` (the CLI) to also get a **host-free
-test suite + CI + requirements-dev + pyproject** so the repo is green from birth: the
-suite imports the plugin with no host (lazy host imports + a fake registry) and `ruff`
-+ `pytest` run in GitHub Actions. Keep host-only imports (`fastapi`, `graph.*`) inside
-`register()` so the suite needs only `requirements-dev.txt`.
+test suite + CI + requirements-dev + pyproject** so the repo is green from birth, and
+`ruff` + `pytest` run in GitHub Actions.
+
+The suite ships a **vendored testkit** (`tests/_plugin_testkit.py`, a verbatim copy of
+`graph/plugins/testkit.py`) so it depends on no running host. The testkit loads the plugin
+as a **package**, so you can unit-test the REAL engine modules — relative imports and all —
+not just `register()`:
+
+```python
+def test_engine(plugin):            # `plugin` = the loaded package (conftest fixture)
+    import importlib
+    engine = importlib.import_module(plugin.__name__ + ".engine")
+    assert engine.classify([...]) == ...
+```
+
+`install_host_stubs()` (run in the conftest) registers stand-ins for `graph.*` / `knowledge.*`
+so a module that imports the host loads with no host present — monkeypatch a seam to assert
+its behaviour. So you no longer have to extract logic into dependency-free modules just to
+test it; keeping host-only imports lazy is still good practice but no longer a hard
+requirement. In-repo (bundled) plugins import the same testkit directly:
+`from graph.plugins.testkit import load_plugin, install_host_stubs, FakeRegistry`.
 
 From the shell (no agent): `python -m server plugin new "My Plugin" --view --skill --tests`
 scaffolds the skeleton; `plugin new-bundle "My Stack" --member id=url@ref --builtin delegates`

--- a/tests/fixtures/sample_plugin/__init__.py
+++ b/tests/fixtures/sample_plugin/__init__.py
@@ -1,0 +1,21 @@
+"""A fixture plugin for the testkit suite — exercises the hard cases: a sibling engine
+module, a tool module with a module-level relative import + ``@tool``, and a lazy host
+import (``graph.goals.types``) inside ``register()``. Host imports stay lazy so loading
+the package is host-free."""
+
+from __future__ import annotations
+
+
+def register(registry):
+    """Contribute a tool + a goal verifier + a skill dir (host imports lazy)."""
+    from graph.goals.types import VerifyResult  # lazy host import — resolved by host_stubs
+
+    from . import tools
+
+    registry.register_tool(tools.summarize)
+
+    def _verify(_cfg):
+        return VerifyResult(ok=True, detail="fixture")
+
+    registry.register_goal_verifier("sample:done", _verify)
+    registry.register_skill_dir("skills")

--- a/tests/fixtures/sample_plugin/engine.py
+++ b/tests/fixtures/sample_plugin/engine.py
@@ -1,0 +1,13 @@
+"""A plugin's deep engine logic — the kind of module that, today, can only be tested
+if it's hand-extracted to be dependency-free. Here it's a sibling module the harness
+can reach via the loaded package."""
+
+from __future__ import annotations
+
+
+def classify(items: list[dict]) -> dict:
+    """Split items into 'big' (size >= 10) and 'small' — stand-in for real engine logic."""
+    return {
+        "big": [i["name"] for i in items if i.get("size", 0) >= 10],
+        "small": [i["name"] for i in items if i.get("size", 0) < 10],
+    }

--- a/tests/fixtures/sample_plugin/tools.py
+++ b/tests/fixtures/sample_plugin/tools.py
@@ -1,0 +1,18 @@
+"""A plugin tool module — the case that breaks bare ``import tools``: a MODULE-LEVEL
+relative import (``from . import engine``) plus the ``@tool`` decorator. Only loadable
+once the plugin is imported as a package (what the harness does)."""
+
+from __future__ import annotations
+
+from langchain_core.tools import tool
+
+from . import engine
+
+
+@tool
+def summarize(items_json: str) -> str:
+    """Classify items and report the counts (a stand-in plugin tool)."""
+    import json
+
+    out = engine.classify(json.loads(items_json))
+    return f"{len(out['big'])} big, {len(out['small'])} small"

--- a/tests/test_plugin_scaffold.py
+++ b/tests/test_plugin_scaffold.py
@@ -67,6 +67,7 @@ def test_scaffold_with_tests_is_shippable(tmp_path):
     pdir = tmp_path / "shippable-one"
     for rel in (
         "tests/conftest.py",
+        "tests/_plugin_testkit.py",
         "tests/test_shippable_one.py",
         ".github/workflows/ci.yml",
         "requirements-dev.txt",
@@ -74,6 +75,11 @@ def test_scaffold_with_tests_is_shippable(tmp_path):
     ):
         assert (pdir / rel).exists(), rel
     assert "tests/" in res.made
+    # the vendored testkit is a VERBATIM copy of the canonical source (single source of truth)
+    from pathlib import Path as _P
+
+    canonical = (_P(scaffold.__file__).with_name("testkit.py")).read_text()
+    assert (pdir / "tests" / "_plugin_testkit.py").read_text() == canonical
     # the generated test file is valid Python
     compile((pdir / "tests" / "test_shippable_one.py").read_text(), "t.py", "exec")
     # manifest ↔ pyproject versions agree (the coherence a release should hold)
@@ -82,6 +88,20 @@ def test_scaffold_with_tests_is_shippable(tmp_path):
     # ci.yml is valid YAML with a test job
     ci = yaml.safe_load((pdir / ".github" / "workflows" / "ci.yml").read_text())
     assert "test" in ci["jobs"]
+
+
+def test_scaffolded_suite_passes_end_to_end(tmp_path):
+    """The generated suite is GREEN out of the box — run pytest on the scaffolded plugin in
+    a subprocess (cwd = the plugin, where ``graph`` is absent, so the vendored testkit's
+    host stubs are exercised for real, the standalone-plugin path)."""
+    import subprocess
+    import sys
+
+    scaffold.scaffold_plugin("Green Birth", with_tests=True, target_dir=str(tmp_path))
+    pdir = tmp_path / "green-birth"
+    proc = subprocess.run([sys.executable, "-m", "pytest", "-q"],
+                          cwd=str(pdir), capture_output=True, text=True)
+    assert proc.returncode == 0, f"scaffolded suite failed:\n{proc.stdout}\n{proc.stderr}"
 
 
 def test_scaffold_comms_plugin(tmp_path):

--- a/tests/test_plugin_testkit.py
+++ b/tests/test_plugin_testkit.py
@@ -1,0 +1,105 @@
+"""The host-free plugin test harness (graph.plugins.testkit).
+
+Proves a plugin's REAL modules — sibling modules with relative imports, a tool module
+with a module-level ``@tool``, a ``register()`` with lazy host imports — load and run with
+no protoAgent host, which is exactly what the standalone plugins (spacetraders, …) couldn't
+do before. The fixture plugin lives in ``tests/fixtures/sample_plugin``.
+
+Note: this suite runs INSIDE protoAgent, where the real ``graph.*`` host IS importable — so
+``install_host_stubs`` correctly no-ops for those (it only stubs absent modules). The
+stub MACHINERY is exercised against a ``phantom_host.*`` namespace that's guaranteed absent,
+so the test never clobbers the real host.
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+from graph.plugins import testkit
+from graph.plugins.loader import _plugin_module_name  # the harness must match the runtime
+
+FIXTURE = Path(__file__).parent / "fixtures" / "sample_plugin"
+PID = "sample-plugin"
+
+
+@pytest.fixture(autouse=True)
+def _clean_modules():
+    """Drop the fixture's synthetic package + any phantom stubs between tests."""
+    yield
+    pkg = testkit.plugin_module_name(PID)
+    for m in [n for n in list(sys.modules)
+              if n == pkg or n.startswith(pkg + ".") or n.split(".")[0] == "phantom_host"]:
+        sys.modules.pop(m, None)
+
+
+def test_package_name_matches_the_runtime_loader():
+    # The whole point: tests must exercise the SAME import paths the host uses.
+    assert testkit.plugin_module_name(PID) == _plugin_module_name(PID)
+    assert testkit.plugin_module_name("sample-plugin") == "protoagent_plugin_sample_plugin"
+
+
+def test_load_plugin_makes_sibling_modules_importable():
+    pkg = testkit.load_plugin(FIXTURE, PID)
+    # The deep engine module is reachable through the loaded package — the capability the
+    # old "test register() only" scaffold lacked.
+    engine = importlib.import_module(f"{testkit.plugin_module_name(PID)}.engine")
+    out = engine.classify([{"name": "a", "size": 12}, {"name": "b", "size": 3}])
+    assert out == {"big": ["a"], "small": ["b"]}
+    assert hasattr(pkg, "register")
+
+
+def test_tool_module_with_relative_import_and_decorator_loads():
+    # tools.py has a MODULE-LEVEL `from . import engine` + `@tool` — unloadable bare.
+    testkit.load_plugin(FIXTURE, PID)
+    tools = importlib.import_module(f"{testkit.plugin_module_name(PID)}.tools")
+    # The @tool-wrapped callable is invokable and routes through the engine.
+    assert tools.summarize.invoke({"items_json": '[{"name":"x","size":50}]'}) == "1 big, 0 small"
+
+
+def test_reload_is_clean_no_stale_submodules():
+    testkit.load_plugin(FIXTURE, PID)
+    name = testkit.plugin_module_name(PID)
+    importlib.import_module(f"{name}.engine")
+    testkit.load_plugin(FIXTURE, PID)  # re-load must purge cached submodules
+    assert f"{name}.engine" not in sys.modules  # stale submodule dropped on reload
+
+
+def test_register_runs_host_free_and_fake_registry_captures():
+    testkit.install_host_stubs()  # no-op for real graph in-repo; stubs it standalone
+    pkg = testkit.load_plugin(FIXTURE, PID)
+    reg = testkit.FakeRegistry()
+    pkg.register(reg)  # must not raise: the lazy `from graph.goals.types import VerifyResult` resolves
+    assert len(reg.tools) == 1
+    assert "sample:done" in reg.verifiers
+    assert reg.skill_dirs == ["skills"]
+
+
+def test_install_host_stubs_creates_patchable_seam_for_absent_host():
+    # phantom_host.* is guaranteed absent, so the stub machinery (not the real graph) is tested.
+    installed = testkit.install_host_stubs(extra={"phantom_host": {}, "phantom_host.sdk": {}})
+    assert "phantom_host.sdk" in installed
+    sdk = importlib.import_module("phantom_host.sdk")
+    # An undeclared seam imports fine but raises if called unpatched (no silent fake-pass)…
+    with pytest.raises(RuntimeError):
+        sdk.complete("hi")
+    # …and is monkeypatchable like the real seam.
+    sdk.complete = lambda *_a, **_k: "patched"
+    assert sdk.complete("hi") == "patched"
+
+
+def test_install_host_stubs_leaves_the_real_host_untouched():
+    before = sys.modules.get("graph")
+    testkit.install_host_stubs()
+    # The real graph package is still the same object — never stubbed or mutated.
+    assert sys.modules.get("graph") is before
+    assert importlib.import_module("graph.plugins.loader")  # real host still importable
+
+
+def test_install_host_stubs_is_idempotent():
+    first = testkit.install_host_stubs(extra={"phantom_host": {}, "phantom_host.sdk": {}})
+    second = testkit.install_host_stubs(extra={"phantom_host": {}, "phantom_host.sdk": {}})
+    assert "phantom_host.sdk" in first and second == []  # nothing re-installed the 2nd time


### PR DESCRIPTION
Closes #1024.

## Problem
A plugin is a package whose modules use relative imports (`from . import client`) and lazy host APIs (`graph.*`, `knowledge.store`). So a plugin's **engine logic** — `fleet.autopilot` role assignment, a trade-route ranker, etc. — can't be unit-tested without booting protoAgent, *unless* every bit is hand-extracted into dependency-free modules. We hit this building the spacetraders plugin: `fleet.py`/`tools.py` went untested and logic had to be carved out into pure modules just to be importable. The existing scaffold test template only covered `register()` (lazy imports + a fake registry), not deep modules. Mature siblings (projectBoard, terminal) each hand-rolled their own conftest; there was no shared, canonical version.

## What this adds
**`graph/plugins/testkit.py`** — a self-contained (stdlib-only, **zero protoAgent imports**, so it vendors into a standalone plugin's CI):
- **`load_plugin(root, id)`** — imports the plugin as a **package** under the runtime's `protoagent_plugin_<id>` name (mirrors `loader.py`), so relative imports resolve and `import <pkg>.fleet` works → test deep modules directly. Reload-safe (purges stale submodules).
- **`install_host_stubs()`** — registers stand-ins for absent host modules (`graph.*` / `knowledge.*`) so a module that imports the host loads with no host; each seam is monkeypatchable and **raises-loud-if-unpatched** (no silent fake-pass). No-ops for real host modules in-repo; only stubs the genuinely-absent ones standalone — never clobbers the real host.
- **`FakeRegistry`** — captures what `register()` contributes (the full `PluginRegistry` surface).

**Scaffolder** (`scaffold_plugin(with_tests=True)`) now **vendors `testkit.py` verbatim** as `tests/_plugin_testkit.py` (single source of truth) + a conftest that loads the plugin as a package — so new and standalone plugins get deep-module testing out of the box, replacing the old `register()`-only template.

## Tests
- `tests/test_plugin_testkit.py` + a fixture plugin (`tests/fixtures/sample_plugin`) with the hard cases — a sibling engine module, a tool module with a **module-level** `from . import engine` + `@tool`, and a lazy `from graph.goals.types import VerifyResult` in `register()` — all loaded + exercised host-free.
- An **end-to-end** test scaffolds a plugin and runs its generated suite in a subprocess where `graph` is absent — exercising the real standalone stub path.
- **57 plugin tests green**, ruff clean.

## Follow-up
Retrofitting the spacetraders plugin to use this (so `fleet.py`'s `autopilot` role assignment / saturation cap become testable) is a separate PR in that repo — this lands the protoAgent-side capability that unblocks it, and the other four `plugin-dev` issues (#1025–#1028).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
