### PR TITLE
feat(sdk): supervised background-task helper — closes #1025

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   it, so new and standalone plugins get deep-module testing out of the box. Closes the gap
   hit building the spacetraders plugin, where `fleet.py`/`tools.py` couldn't be tested
   without extracting all logic into dependency-free modules (#1024).
+- **Supervised background-task helper (`graph/supervisor.py`, `from graph.sdk import supervise`).**
+  A reusable, watchdog-backed lifecycle for a plugin's long-running background engine: run a
+  unit of work back-to-back, and a watchdog that **re-kicks** a crash, **restarts** a stall
+  (frozen `progress` + a confirming `stall_check`), and **recovers** a known fault via an
+  `on_crash` hook — so the loop survives unattended. The plugin supplies only the work + the
+  predicates; the Supervisor owns create/cancel/re-kick/restart/heartbeat and a `status()`
+  dict. Pure asyncio (host-free, directly unit-tested). Generalizes the ~150 lines of
+  task/watchdog machinery the spacetraders fleet engine hand-rolled (#1025).
 
 ### Fixed
 - **The Tools tab shows exactly what the agent can call.** `/api/tools` re-derived

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -20,6 +20,11 @@ from typing import Any
 
 from runtime.state import STATE
 
+# Re-export the supervised background-task helper as part of the consumption surface, so a
+# plugin writes `from graph.sdk import supervise` for a self-perpetuating, watchdog-backed
+# engine instead of hand-rolling task/restart machinery (graph/supervisor.py is host-free).
+from graph.supervisor import Supervisor, supervise  # noqa: F401
+
 
 def config() -> Any:
     """The live runtime ``LangGraphConfig``."""

--- a/graph/supervisor.py
+++ b/graph/supervisor.py
@@ -1,0 +1,276 @@
+"""Supervised background task — a self-perpetuating async loop with a watchdog.
+
+The lifecycle pattern protoAgent plugins reinvent for any long-running background engine
+(the SpaceTraders fleet autopilot, a board reconciler, an ingest worker, a poller): run a
+unit of work back-to-back, with a watchdog that **re-kicks** it if it crashes, **restarts**
+it if it stalls, and **recovers** from a known fault — so the loop survives unattended. The
+deterministic watchdog is the heartbeat; an LLM agent (if any) is the exception handler, not
+the reverse.
+
+The plugin supplies only the *work* (one window) and the *predicates* (is it stalled? can a
+crash be recovered?); the Supervisor owns the create / cancel / re-kick / restart / heartbeat
+machinery and exposes a ``status()`` dict.
+
+Pure asyncio + stdlib — no protoAgent host deps, so it unit-tests directly. Plugins reach it
+via ``from graph.sdk import supervise`` (or ``Supervisor``).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any, Awaitable, Callable
+
+log = logging.getLogger("protoagent.supervisor")
+
+WorkFn = Callable[[], Awaitable[Any]]
+
+
+async def _maybe_await(value: Any) -> Any:
+    """Await ``value`` if it's a coroutine, else return it — so predicates/hooks may be
+    sync or async."""
+    if asyncio.iscoroutine(value):
+        return await value
+    return value
+
+
+class Supervisor:
+    """Runs ``work`` (an async no-arg callable) under a watchdog.
+
+    Args:
+        work: ``async () -> Any`` — one unit of work (e.g. one engine window). Its return is
+            stored as ``status()['result']``.
+        name: label for logs/status.
+        loop: run ``work`` back-to-back (default) vs once.
+        breath: seconds to pause between work units when looping.
+        interval: watchdog check period (seconds).
+        on_crash: ``(result) -> bool`` (sync/async) called when the runner crashed or stopped
+            while still wanted-running. Return True if the fault was handled (the watchdog
+            then re-kicks), False to clear want-running and stop the storm (an unrecoverable
+            fault). Called at most once per down-streak. ``result`` is the last
+            ``{"error": …}`` / ``{"stopped": …}``.
+        progress: ``() -> Any`` (sync/async) — a token that CHANGES while the task makes
+            progress (e.g. ``len(log)``). The watchdog flags a stall when it stops changing.
+        stall_check: ``() -> bool`` (sync/async) — confirm a *real* stall (e.g. "no ship in
+            transit"), so a legitimately-long unit of work isn't false-tripped. A stall needs
+            BOTH frozen progress (if ``progress`` is set) AND ``stall_check`` truthy (if set).
+        stall_ticks: consecutive stalled checks before the watchdog restarts the runner.
+        rekicks_warn: emit a "persistently failing" event after this many consecutive re-kicks.
+        event_cap: keep the last N lifecycle events for ``status()``.
+    """
+
+    def __init__(
+        self,
+        work: WorkFn,
+        *,
+        name: str = "task",
+        loop: bool = True,
+        breath: float = 3.0,
+        interval: float = 90.0,
+        on_crash: Callable[[Any], Any] | None = None,
+        progress: Callable[[], Any] | None = None,
+        stall_check: Callable[[], Any] | None = None,
+        stall_ticks: int = 3,
+        rekicks_warn: int = 5,
+        event_cap: int = 30,
+    ):
+        self._work = work
+        self.name = name
+        self._loop = loop
+        self._breath = breath
+        self._interval = interval
+        self._on_crash = on_crash
+        self._progress = progress
+        self._stall_check = stall_check
+        self._stall_ticks = stall_ticks
+        self._rekicks_warn = rekicks_warn
+        self._event_cap = event_cap
+
+        self._task: asyncio.Task | None = None
+        self._watchdog: asyncio.Task | None = None
+        self._want = False        # operator wants it running; the watchdog keeps it there
+        self._stop = False        # graceful wind-down after the current unit
+        self._crashed = False     # last runner exit was an exception (vs clean / cancelled)
+        self._result: Any = None
+        self._restarts = 0
+        self._events: list[str] = []
+
+    # ── public API ────────────────────────────────────────────────────────────────────
+    def start(self) -> str:
+        """Start (or ensure running). Idempotent; also (re)starts the watchdog."""
+        self._want = True
+        self._ensure_watchdog()
+        if self.running():
+            return f"{self.name}: already running"
+        self._spawn_runner()
+        self._event("started")
+        return f"{self.name}: started"
+
+    def stop(self) -> str:
+        """Operator stop — cancel now; the watchdog will NOT re-kick."""
+        self._want = False
+        task = self._task
+        if task is None or task.done():
+            return f"{self.name}: not running"
+        task.cancel()
+        self._event("stopped (operator)")
+        return f"{self.name}: stopping"
+
+    def request_stop(self) -> None:
+        """Graceful wind-down: finish the current unit of work, then stop (no re-kick)."""
+        self._want = False
+        self._stop = True
+
+    def running(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    def status(self) -> dict:
+        return {
+            "name": self.name,
+            "running": self.running(),
+            "want_running": self._want,
+            "watchdog": self._watchdog is not None and not self._watchdog.done(),
+            "restarts": self._restarts,
+            "result": self._result,
+            "events": self._events[-8:],
+        }
+
+    # ── internals ─────────────────────────────────────────────────────────────────────
+    def _event(self, msg: str) -> None:
+        self._events.append(msg)
+        del self._events[: -self._event_cap]
+        log.debug("[supervisor:%s] %s", self.name, msg)
+
+    def _spawn_runner(self) -> None:
+        self._stop = False
+        self._task = asyncio.create_task(self._runner(), name=f"{self.name}-runner")
+
+    async def _runner(self) -> None:
+        me = asyncio.current_task()
+        self._crashed = False
+        try:
+            while not self._stop:
+                self._result = await self._work()
+                if not self._loop:
+                    break
+                await asyncio.sleep(self._breath)
+            if self._loop:
+                self._event("wound down")
+        except asyncio.CancelledError:
+            self._result = {"stopped": True}
+            raise
+        except Exception as e:  # noqa: BLE001 — surface, don't crash the supervisor
+            self._crashed = True
+            self._result = {"error": f"{type(e).__name__}: {e}"}
+            self._event(f"crashed: {type(e).__name__}: {e}")
+        finally:
+            # Only detach if we're still the active runner — a stall-restart may have already
+            # swapped in a new task, and an old cancelled task must not null it out.
+            if self._task is me:
+                self._task = None
+
+    def _ensure_watchdog(self) -> None:
+        if self._watchdog is None or self._watchdog.done():
+            self._watchdog = asyncio.create_task(self._watch(), name=f"{self.name}-watchdog")
+
+    async def _restart_runner(self) -> None:
+        old = self._task
+        self._task = None                 # detach first (the guarded finally won't fight us)
+        if old is not None and not old.done():
+            old.cancel()                  # fire-and-forget; its finally is guarded
+        self._restarts += 1
+        self._spawn_runner()
+
+    async def _watch(self) -> None:
+        frozen = 0
+        rekicks = 0
+        recovered = False
+        last_token: Any = object()        # sentinel so the first compare is never "frozen"
+        while True:
+            try:
+                await asyncio.sleep(self._interval)
+                if not self._want:
+                    frozen = 0
+                    continue
+
+                # (1) not running while wanted. A clean one-shot completion (loop=False, no
+                #     crash) is DONE — clear want, don't re-run. Otherwise recover + re-kick.
+                if not self.running():
+                    if not self._loop and not self._crashed:
+                        self._want = False
+                        self._event("completed")
+                        continue
+                    if self._on_crash is not None and not recovered:
+                        recovered = True
+                        try:
+                            handled = bool(await _maybe_await(self._on_crash(self._result)))
+                        except Exception as e:  # noqa: BLE001
+                            handled = False
+                            self._event(f"on_crash errored: {e}")
+                        if not handled:
+                            self._want = False  # unrecoverable → don't spin
+                            self._event("unrecoverable — want_running cleared")
+                            continue
+                        self._event("recovered via on_crash")
+                    rekicks += 1
+                    if rekicks == self._rekicks_warn:
+                        self._event("persistently failing — may need attention")
+                    self._event(f"re-kick #{rekicks}")
+                    self._spawn_runner()
+                    frozen = 0
+                    continue
+                rekicks = 0
+                recovered = False
+
+                # (2) running but stalled → restart. Needs frozen PROGRESS (if a progress fn
+                #     is set) AND a truthy STALL_CHECK (if set); with neither, no stall detection.
+                if self._progress is None and self._stall_check is None:
+                    continue
+                token = await _maybe_await(self._progress()) if self._progress else None
+                progress_frozen = self._progress is None or token == last_token
+                last_token = token
+                confirmed = True
+                if self._stall_check is not None:
+                    confirmed = bool(await _maybe_await(self._stall_check()))
+                frozen = frozen + 1 if (progress_frozen and confirmed) else 0
+                if frozen >= self._stall_ticks:
+                    self._event("stall detected — restarting")
+                    await self._restart_runner()
+                    frozen = 0
+            except asyncio.CancelledError:
+                raise
+            except Exception:  # noqa: BLE001 — the watchdog must NEVER die
+                await asyncio.sleep(self._interval)
+
+    async def aclose(self) -> None:
+        """Cancel the runner + watchdog and await them — for clean teardown (tests, shutdown)."""
+        self._want = False
+        for task in (self._task, self._watchdog):
+            if task is not None and not task.done():
+                task.cancel()
+        for task in (self._task, self._watchdog):
+            if task is not None:
+                try:
+                    await task
+                except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                    pass
+        self._task = self._watchdog = None
+
+
+def supervise(work: WorkFn, **kwargs: Any) -> Supervisor:
+    """Create a (not-yet-started) :class:`Supervisor` for ``work``; call ``.start()``.
+
+    Example — a plugin's background engine, self-perpetuating + supervised::
+
+        from graph.sdk import supervise
+
+        engine = supervise(run_one_window, name="fleet", interval=90,
+                           progress=lambda: len(LOG),
+                           stall_check=lambda: not any_ship_in_transit(),
+                           on_crash=recover_from_reset)
+        engine.start()           # returns immediately; runs in the background
+        ...
+        engine.status()          # {running, want_running, restarts, result, events, …}
+        engine.request_stop()    # graceful wind-down (e.g. from a goal on_achieved hook)
+    """
+    return Supervisor(work, **kwargs)

--- a/tests/test_supervisor.py
+++ b/tests/test_supervisor.py
@@ -1,0 +1,164 @@
+"""The supervised background-task helper (graph.supervisor).
+
+Generalizes the lifecycle the SpaceTraders fleet engine hand-rolled (run windows
+back-to-back; a watchdog that re-kicks a crash, restarts a stall, recovers a known fault).
+Pure asyncio — tested directly with tiny intervals. ``asyncio_mode = auto`` runs the async
+tests.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from graph.sdk import supervise as sdk_supervise  # re-exported on the plugin SDK surface
+from graph.supervisor import Supervisor, supervise
+
+
+def test_supervise_is_exported_on_the_sdk():
+    assert sdk_supervise is supervise
+
+
+async def test_loops_back_to_back_then_stops():
+    n = 0
+
+    async def work():
+        nonlocal n
+        n += 1
+        return n
+
+    sv = supervise(work, interval=10, breath=0.0)  # watchdog idle; we only test the loop
+    sv.start()
+    assert sv.start().endswith("already running")  # idempotent
+    await asyncio.sleep(0.1)
+    looped = n
+    assert looped >= 3, looped
+    assert sv.running() and sv.status()["result"] == looped
+    await sv.aclose()
+    after = n
+    await asyncio.sleep(0.05)
+    assert n == after and not sv.running()  # stopped — no more work
+
+
+async def test_run_once_completes_and_is_not_rekicked():
+    runs = 0
+
+    async def work():
+        nonlocal runs
+        runs += 1
+        return "done"
+
+    sv = supervise(work, loop=False, interval=0.02)
+    sv.start()
+    await asyncio.sleep(0.15)  # several watchdog ticks — a one-shot must NOT be re-run
+    assert runs == 1
+    assert not sv.running()
+    assert sv.status()["result"] == "done"
+    assert sv.status()["want_running"] is False  # watchdog marked it completed
+    await sv.aclose()
+
+
+async def test_crash_is_rekicked_after_on_crash_recovery():
+    calls = 0
+    recovered = []
+
+    async def work():
+        nonlocal calls
+        calls += 1
+        if calls == 1:
+            raise ValueError("boom")
+        await asyncio.sleep(0.5)  # second run stays alive
+        return "ok"
+
+    def on_crash(result):
+        recovered.append(result)
+        return True  # handled → re-kick
+
+    sv = supervise(work, interval=0.02, breath=0.0, on_crash=on_crash)
+    sv.start()
+    await asyncio.sleep(0.15)
+    assert calls >= 2                       # crashed once, watchdog re-kicked, ran again
+    assert len(recovered) == 1              # on_crash fired exactly once for the down-streak
+    assert "error" in recovered[0]          # got the crash result
+    await sv.aclose()
+
+
+async def test_unrecoverable_crash_clears_want_running():
+    async def work():
+        raise RuntimeError("always")
+
+    def on_crash(_result):
+        return False  # cannot recover → stop the storm
+
+    sv = supervise(work, interval=0.02, on_crash=on_crash)
+    sv.start()
+    await asyncio.sleep(0.12)
+    assert sv.status()["want_running"] is False
+    assert not sv.running()
+    await sv.aclose()
+
+
+async def test_stall_is_detected_and_restarted():
+    async def work():
+        await asyncio.sleep(10)  # hangs — running but making no progress
+
+    sv = supervise(
+        work, interval=0.02, stall_ticks=2,
+        progress=lambda: 0,            # constant token → frozen progress
+        stall_check=lambda: True,      # confirmed stalled
+    )
+    sv.start()
+    await asyncio.sleep(0.2)
+    assert sv.status()["restarts"] >= 1
+    await sv.aclose()
+
+
+async def test_stall_check_prevents_false_trip():
+    async def work():
+        await asyncio.sleep(10)
+
+    sv = supervise(
+        work, interval=0.02, stall_ticks=2,
+        progress=lambda: 0,            # frozen…
+        stall_check=lambda: False,     # …but NOT a real stall (e.g. legit long work)
+    )
+    sv.start()
+    await asyncio.sleep(0.15)
+    assert sv.status()["restarts"] == 0  # never restarted
+    await sv.aclose()
+
+
+async def test_request_stop_is_graceful():
+    windows = 0
+
+    async def work():
+        nonlocal windows
+        windows += 1
+        await asyncio.sleep(0.02)
+        return windows
+
+    sv = supervise(work, interval=10, breath=0.0)
+    sv.start()
+    await asyncio.sleep(0.05)
+    sv.request_stop()                  # finish the current window, then stop — no re-kick
+    await asyncio.sleep(0.1)
+    assert not sv.running()
+    assert sv.status()["want_running"] is False
+    settled = windows
+    await asyncio.sleep(0.05)
+    assert windows == settled
+    await sv.aclose()
+
+
+async def test_status_shape():
+    async def work():
+        await asyncio.sleep(0.01)
+
+    sv = Supervisor(work, name="probe", interval=10)
+    s = sv.status()
+    assert s["name"] == "probe" and s["running"] is False and s["restarts"] == 0
+    sv.start()
+    await asyncio.sleep(0.02)
+    s = sv.status()
+    assert s["running"] and s["want_running"] and s["watchdog"]
+    assert "started" in s["events"]
+    await sv.aclose()


### PR DESCRIPTION
Closes #1025.

## Problem
Any plugin with a long-running background engine reinvents the same ~150 lines of lifecycle machinery: an `_OPS` task dict, back-to-back work windows, `start`/`stop`, and a watchdog that re-kicks a crash, breaks a stall, and recovers from a fault. The spacetraders fleet engine hand-rolled it; the next plugin will too. The crash/stall/restart concerns are identical across them — only the *work* differs.

## What this adds
**`graph/supervisor.py`** — `Supervisor` + `supervise()`, re-exported from `graph.sdk`:

```python
from graph.sdk import supervise

engine = supervise(run_one_window, name="fleet", interval=90,
                   progress=lambda: len(LOG),                  # changes while progressing
                   stall_check=lambda: not any_in_transit(),   # confirms a real stall
                   on_crash=recover_from_reset)                # once per down-streak
engine.start()            # returns immediately; runs supervised in the background
engine.status()           # {running, want_running, restarts, result, events, …}
engine.request_stop()     # graceful wind-down (e.g. from a goal on_achieved hook)
```

The Supervisor owns: running `work` back-to-back (or once, `loop=False`); a watchdog that **re-kicks** a crashed/stopped runner, **restarts** a stall (needs frozen `progress` AND a truthy `stall_check`, so a legitimately-long unit of work isn't false-tripped), and **recovers** a known fault via `on_crash` (return `False` to clear want-running and stop the storm on an unrecoverable error); `start`/`stop`/`request_stop`/`status`/`aclose`; a capped event log; and a watchdog that never dies.

The plugin supplies only the work + the predicates. Design principle (the lesson from the two-loop fleet): **the deterministic watchdog is the heartbeat; the LLM agent is the exception handler, not the reverse.**

## Tests
Pure asyncio (no host deps) → tested directly with tiny intervals: loop back-to-back, one-shot (not re-kicked), crash → `on_crash` → re-kick, unrecoverable → stop, stall → restart, `stall_check` false-trip guard, graceful `request_stop`, status shape, and the `graph.sdk` re-export. **9 tests green; ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
