### PR TITLE
feat(sdk): runtime knobs + presets control surface — closes #1028

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so it drops into any plugin console view without a specific stylesheet). All values escaped.
   Generalizes the spacetraders `_DECISIONS` ring buffer + `st_report` envelope + dashboard
   decision-log panel. Pure stdlib, host-free (#1027).
+- **Runtime knobs + presets control surface (`graph/knobs.py`, `from graph.sdk import Knobs,
+  make_knob_tools`).** A reusable, bounded, reversible control surface an LLM strategist can
+  steer a deterministic plugin engine with: declare typed knobs once (`define`, with `lo`/`hi`
+  clamps + `choices`), read them live in the engine (`get`), and `set` them coerced + clamped
+  + validated + logged; named **presets** apply a curated knob bundle as one move
+  (`apply_preset`, non-cumulative); a change log records every tune/preset. `make_knob_tools`
+  auto-generates the agent-facing `<prefix>_knobs` / `_tune` / `_preset` tools. Pure stdlib
+  (host-free, directly unit-tested). Generalizes the spacetraders `_TUNABLE`/`set_knob`/
+  strategy-preset surface (#1028).
 - **Host-free plugin test harness (`graph/plugins/testkit.py`).** A self-contained
   (stdlib-only) testkit that loads a plugin as a **package** — so a plugin's real engine
   modules (relative imports, module-level `@tool`, lazy `graph.*` host imports) can be

--- a/graph/knobs.py
+++ b/graph/knobs.py
@@ -1,0 +1,226 @@
+"""Runtime knobs + presets — a bounded, reversible control surface an LLM strategist can
+steer a deterministic plugin engine with.
+
+The pattern the SpaceTraders two-loop fleet hand-rolled: a set of tunable engine knobs read
+live at call time (so a change takes effect on the running engine immediately), typed
+coercion + clamping on set, named *presets* (curated knob bundles = a whole doctrine in one
+move), and a decision log of every change. This generalizes it: declare your knobs once, get
+``get``/``set``/``reset``/presets + a change log, and (optionally) auto-generated agent tools.
+
+Pure stdlib — no protoAgent host deps, so it unit-tests directly. The tool factory imports
+langchain lazily, so importing this module never requires it.
+
+    KNOBS = (Knobs()
+             .define("min_margin", 30, lo=0, help="cr/unit floor for a trade route")
+             .define("buy_buffer", 600_000, lo=0, help="reinvest a hauler above this")
+             .define("sink_cutoff", "ABUNDANT", choices=["LIMITED", "HIGH", "ABUNDANT"]))
+    KNOBS.preset("trade-max", {"buy_buffer": 300_000, "min_margin": 20},
+                 blurb="pure arbitrage")
+
+    KNOBS.get("min_margin")            # read live in the engine
+    KNOBS.set("min_margin", "15")      # the strategist tunes (typed-coerced + clamped + logged)
+    KNOBS.apply_preset("trade-max")    # a whole doctrine in one move
+    registry.register_tools(make_knob_tools(KNOBS, prefix="fleet"))  # st_tune/st_knobs/st_preset
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+__all__ = ["Knob", "Knobs", "make_knob_tools"]
+
+_TRUE = {"1", "true", "on", "yes", "y"}
+
+
+class Knob:
+    """One declared knob: its default, current value, type, optional bounds/choices, help."""
+
+    __slots__ = ("name", "default", "value", "kind", "lo", "hi", "choices", "help")
+
+    def __init__(self, name, default, *, kind, lo=None, hi=None, choices=None, help=""):
+        self.name = name
+        self.default = default
+        self.value = default
+        self.kind = kind
+        self.lo = lo
+        self.hi = hi
+        self.choices = choices
+        self.help = help
+
+    def coerce(self, raw: Any) -> Any:
+        """Coerce ``raw`` to this knob's type (accepts numbers-as-strings, bare strings),
+        validate against ``choices``, and clamp to ``[lo, hi]``."""
+        if self.choices is not None:
+            s = str(raw).strip()
+            for c in self.choices:
+                if str(c).lower() == s.lower():
+                    return c
+            raise ValueError(f"{self.name} must be one of {list(self.choices)}")
+        if self.kind is bool:
+            return str(raw).strip().lower() in _TRUE
+        if self.kind is int:
+            v: Any = int(float(raw))
+        elif self.kind is float:
+            v = float(raw)
+        else:
+            return str(raw)
+        if self.lo is not None:
+            v = max(self.lo, v)
+        if self.hi is not None:
+            v = min(self.hi, v)
+        return v
+
+
+class Knobs:
+    """A registry of runtime knobs + presets, with a change log. Holds the values itself
+    (read ``get`` live in your engine) — no module globals."""
+
+    def __init__(self, *, log_cap: int = 50):
+        self._knobs: dict[str, Knob] = {}
+        self._presets: dict[str, dict] = {}
+        self._log: list[dict] = []
+        self._log_cap = log_cap
+
+    # ── declaration ────────────────────────────────────────────────────────────────────
+    def define(self, name: str, default: Any, *, kind: type | None = None,
+               lo: Any = None, hi: Any = None, choices: list | None = None,
+               help: str = "") -> "Knobs":
+        """Declare a knob (chainable). ``kind`` is inferred from ``default`` if omitted
+        (bool/int/float/str). ``lo``/``hi`` clamp numbers; ``choices`` constrains values."""
+        if name in self._knobs:
+            raise ValueError(f"knob {name!r} already defined")
+        k = kind or (bool if isinstance(default, bool) else
+                     int if isinstance(default, int) else
+                     float if isinstance(default, float) else str)
+        self._knobs[name] = Knob(name, default, kind=k, lo=lo, hi=hi, choices=choices, help=help)
+        return self
+
+    def preset(self, name: str, overrides: dict, *, blurb: str = "") -> "Knobs":
+        """Declare a named preset — a bundle of knob overrides applied as one doctrine
+        (chainable). Every key must be a defined knob."""
+        unknown = set(overrides) - set(self._knobs)
+        if unknown:
+            raise ValueError(f"preset {name!r} references unknown knobs: {sorted(unknown)}")
+        self._presets[name] = {"overrides": dict(overrides), "blurb": blurb}
+        return self
+
+    # ── read ───────────────────────────────────────────────────────────────────────────
+    def get(self, name: str) -> Any:
+        return self._knobs[name].value
+
+    def values(self) -> dict:
+        """Current ``name -> value`` for all knobs (audit/telemetry)."""
+        return {n: k.value for n, k in self._knobs.items()}
+
+    def schema(self) -> list[dict]:
+        """Per-knob ``{name, value, default, choices?, range?, help}`` (for a show tool/UI)."""
+        out = []
+        for k in self._knobs.values():
+            row = {"name": k.name, "value": k.value, "default": k.default, "help": k.help}
+            if k.choices is not None:
+                row["choices"] = list(k.choices)
+            if k.lo is not None or k.hi is not None:
+                row["range"] = [k.lo, k.hi]
+            out.append(row)
+        return out
+
+    def presets(self) -> dict:
+        return {n: dict(p) for n, p in self._presets.items()}
+
+    def changes(self) -> list[dict]:
+        """The decision log — every set/preset change, newest last."""
+        return list(self._log)
+
+    # ── mutate ─────────────────────────────────────────────────────────────────────────
+    def set(self, name: str, value: Any) -> str:
+        """Set a knob (typed-coerced, validated, clamped) and log the change. Returns a
+        human message; raises nothing the agent can't read — unknown/invalid come back as text."""
+        key = (name or "").strip()
+        if key not in self._knobs:
+            return f"unknown knob {name!r}; knobs: {', '.join(self._knobs)}"
+        k = self._knobs[key]
+        try:
+            new = k.coerce(value)
+        except (TypeError, ValueError) as e:
+            return f"bad value for {key}: {e}"
+        old = k.value
+        k.value = new
+        if new != old:
+            self._record("tune", f"{key}: {old} → {new}")
+        return f"{key}: {old} → {new}"
+
+    def reset(self) -> None:
+        """Restore every knob to its declared default (no log entry per knob)."""
+        for k in self._knobs.values():
+            k.value = k.default
+
+    def apply_preset(self, name: str) -> str:
+        """Reset to defaults, then apply the preset's overrides (so switching presets is not
+        cumulative). Logs one decision. Returns a message."""
+        key = (name or "").strip()
+        if key not in self._presets:
+            return f"unknown preset {name!r}; presets: {', '.join(self._presets) or '—'}"
+        self.reset()
+        for n, v in self._presets[key]["overrides"].items():
+            self._knobs[n].value = self._knobs[n].coerce(v)
+        blurb = self._presets[key]["blurb"]
+        self._record("preset", f"→ {key}" + (f" ({blurb})" if blurb else ""))
+        return f"preset → {key}" + (f" ({blurb})" if blurb else "") + f" · knobs now {self.values()}"
+
+    def _record(self, action: str, detail: str) -> None:
+        self._log.append({"action": action, "detail": detail})
+        del self._log[: -self._log_cap]
+
+
+def make_knob_tools(knobs: Knobs, *, prefix: str,
+                    show: bool = True, tune: bool = True, presets: bool = True) -> list:
+    """Auto-generate the agent-facing control-surface tools for ``knobs`` — ``<prefix>_knobs``
+    (show), ``<prefix>_tune`` (set one knob), ``<prefix>_preset`` (show/apply a preset). Returns
+    a list of LangChain tools to ``registry.register_tools(...)``. langchain is imported lazily,
+    so importing this module never requires it.
+    """
+    from langchain_core.tools import tool  # lazy — keeps the module host-free to import
+
+    made: list = []
+    knob_help = "; ".join(f"{r['name']} ({r['help']})" if r["help"] else r["name"]
+                          for r in knobs.schema())
+
+    if show:
+        async def _show() -> str:
+            lines = [f"{prefix} knobs:"]
+            for r in knobs.schema():
+                extra = (f" choices={r['choices']}" if "choices" in r
+                         else f" range={r['range']}" if "range" in r else "")
+                lines.append(f"  {r['name']} = {r['value']} (default {r['default']}){extra}"
+                             + (f" — {r['help']}" if r["help"] else ""))
+            if knobs.presets():
+                lines.append("presets: " + ", ".join(knobs.presets()))
+            return "\n".join(lines)
+        _show.__name__ = f"{prefix}_knobs"
+        _show.__doc__ = f"Show the current {prefix} engine knobs, their ranges, and presets."
+        made.append(tool(_show))
+
+    if tune:
+        async def _tune(knob: str, value: str) -> str:
+            return knobs.set(knob, value)
+        _tune.__name__ = f"{prefix}_tune"
+        _tune.__doc__ = (
+            f"Tune ONE {prefix} engine knob at runtime (reversible; takes effect immediately). "
+            f"Knobs: {knob_help}.\n\nArgs:\n    knob: the knob name.\n    value: the new value "
+            f"(a number, or one of the knob's choices).")
+        made.append(tool(_tune))
+
+    if presets and knobs.presets():
+        async def _preset(name: str = "") -> str:
+            if not name:
+                return f"{prefix} presets: " + " · ".join(
+                    f"{n} ({p['blurb']})" if p["blurb"] else n for n, p in knobs.presets().items())
+            return knobs.apply_preset(name)
+        _preset.__name__ = f"{prefix}_preset"
+        _preset.__doc__ = (
+            f"Set or show the {prefix} engine PRESET — a named knob bundle (a whole doctrine in "
+            f"one move) vs {prefix}_tune's single knob. Call with no name to list presets.\n\n"
+            f"Args:\n    name: the preset to apply, or \"\" to list them.")
+        made.append(tool(_preset))
+
+    return made

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -31,6 +31,11 @@ from graph.supervisor import Supervisor, supervise  # noqa: F401
 # surface (audit trail + envelope + themed panel). graph/telemetry.py is host-free.
 from graph.telemetry import DecisionLog, render_html, telemetry  # noqa: F401
 
+# Re-export the runtime-knobs + presets control surface, so a plugin writes
+# `from graph.sdk import Knobs, make_knob_tools` for a bounded, reversible set of tunable
+# engine knobs + presets + auto-generated agent tools (graph/knobs.py is host-free).
+from graph.knobs import Knobs, make_knob_tools  # noqa: F401
+
 
 def config() -> Any:
     """The live runtime ``LangGraphConfig``."""

--- a/tests/test_knobs.py
+++ b/tests/test_knobs.py
@@ -1,0 +1,136 @@
+"""Runtime knobs + presets control surface (graph.knobs).
+
+Generalizes the SpaceTraders engine's tunable-knobs + strategy-presets surface: typed knobs
+read live, coerced/clamped/validated on set, named presets, a change log, and auto-generated
+agent tools. Pure stdlib — tested directly; the tool factory needs langchain (a core dep).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graph.knobs import Knobs, make_knob_tools
+from graph.sdk import Knobs as SdkKnobs  # re-exported on the plugin SDK surface
+
+
+def _knobs() -> Knobs:
+    return (Knobs()
+            .define("min_margin", 30, lo=0, help="cr/unit floor")
+            .define("buy_buffer", 600_000, lo=0)
+            .define("mining", True)
+            .define("sink_cutoff", "ABUNDANT", choices=["LIMITED", "HIGH", "ABUNDANT"]))
+
+
+def test_exported_on_the_sdk():
+    assert SdkKnobs is Knobs
+
+
+def test_define_infers_type_and_defaults():
+    k = _knobs()
+    assert k.get("min_margin") == 30
+    assert k.get("mining") is True
+    assert k.values() == {"min_margin": 30, "buy_buffer": 600_000,
+                          "mining": True, "sink_cutoff": "ABUNDANT"}
+
+
+def test_set_coerces_number_from_string():
+    k = _knobs()
+    assert "15" in k.set("min_margin", "15")
+    assert k.get("min_margin") == 15 and isinstance(k.get("min_margin"), int)
+
+
+def test_set_clamps_to_bounds():
+    k = _knobs()
+    k.set("min_margin", "-5")
+    assert k.get("min_margin") == 0  # clamped to lo
+
+
+def test_set_bool_from_truthy_strings():
+    k = _knobs()
+    k.set("mining", "off")
+    assert k.get("mining") is False
+    k.set("mining", "yes")
+    assert k.get("mining") is True
+
+
+def test_choices_are_validated_case_insensitively():
+    k = _knobs()
+    assert "high" in k.set("sink_cutoff", "high").lower()
+    assert k.get("sink_cutoff") == "HIGH"  # normalized to the declared choice
+    msg = k.set("sink_cutoff", "GALAXY")
+    assert "must be one of" in msg
+    assert k.get("sink_cutoff") == "HIGH"  # unchanged on bad value
+
+
+def test_unknown_knob_is_a_readable_message_not_a_raise():
+    k = _knobs()
+    assert "unknown knob" in k.set("warp_speed", "9")
+
+
+def test_changes_log_records_only_real_changes():
+    k = _knobs()
+    k.set("min_margin", "30")     # same value → no log entry
+    k.set("min_margin", "20")     # changed → logged
+    log = k.changes()
+    assert len(log) == 1 and log[0]["action"] == "tune" and "30 → 20" in log[0]["detail"]
+
+
+def test_presets_apply_as_a_bundle_and_are_not_cumulative():
+    k = _knobs()
+    k.preset("trade-max", {"buy_buffer": 300_000, "min_margin": 20}, blurb="pure arbitrage")
+    k.set("min_margin", "99")
+    k.apply_preset("trade-max")
+    assert k.get("buy_buffer") == 300_000 and k.get("min_margin") == 20
+    # a knob not in the preset resets to its default (not the cumulative 99)
+    k.set("min_margin", "99")
+    k.apply_preset("trade-max")
+    assert k.get("min_margin") == 20
+    assert any(c["action"] == "preset" for c in k.changes())
+
+
+def test_preset_with_unknown_knob_is_rejected_at_declaration():
+    with pytest.raises(ValueError):
+        Knobs().define("a", 1).preset("p", {"b": 2})
+
+
+def test_reset_restores_defaults():
+    k = _knobs()
+    k.set("min_margin", "5")
+    k.set("sink_cutoff", "LIMITED")
+    k.reset()
+    assert k.get("min_margin") == 30 and k.get("sink_cutoff") == "ABUNDANT"
+
+
+def test_schema_describes_choices_and_ranges():
+    rows = {r["name"]: r for r in _knobs().schema()}
+    assert rows["sink_cutoff"]["choices"] == ["LIMITED", "HIGH", "ABUNDANT"]
+    assert rows["min_margin"]["range"] == [0, None]
+
+
+# ── tool factory ───────────────────────────────────────────────────────────────────────
+def test_make_knob_tools_generates_named_tools():
+    k = _knobs().preset("trade-max", {"min_margin": 20})
+    tools = make_knob_tools(k, prefix="fleet")
+    names = {t.name for t in tools}
+    assert names == {"fleet_knobs", "fleet_tune", "fleet_preset"}
+
+
+def test_no_preset_tool_when_no_presets_declared():
+    tools = make_knob_tools(_knobs(), prefix="fleet")
+    assert {t.name for t in tools} == {"fleet_knobs", "fleet_tune"}
+
+
+async def test_generated_tune_tool_sets_the_knob():
+    k = _knobs()
+    tune = {t.name: t for t in make_knob_tools(k, prefix="fleet")}["fleet_tune"]
+    out = await tune.ainvoke({"knob": "min_margin", "value": "12"})
+    assert "12" in out and k.get("min_margin") == 12
+
+
+async def test_generated_preset_tool_lists_and_applies():
+    k = _knobs().preset("trade-max", {"min_margin": 20}, blurb="pure arbitrage")
+    preset = {t.name: t for t in make_knob_tools(k, prefix="fleet")}["fleet_preset"]
+    listed = await preset.ainvoke({"name": ""})
+    assert "trade-max" in listed
+    await preset.ainvoke({"name": "trade-max"})
+    assert k.get("min_margin") == 20


### PR DESCRIPTION
Closes #1028.

## Problem
Plugins that pair a deterministic engine with an LLM strategist reinvent the same control surface: tunable knobs read live at call time, typed coercion + clamping on `set`, named presets (a whole doctrine in one move), and a change log. The spacetraders two-loop fleet hand-rolled it via `globals()` + a name→var map + `set_knob` + a `strategy.py` preset module.

## What this adds
**`graph/knobs.py`** — `Knobs` + `make_knob_tools`, re-exported from `graph.sdk`:

```python
from graph.sdk import Knobs, make_knob_tools

KNOBS = (Knobs()
         .define("min_margin", 30, lo=0, help="cr/unit floor for a route")
         .define("buy_buffer", 600_000, lo=0)
         .define("sink_cutoff", "ABUNDANT", choices=["LIMITED", "HIGH", "ABUNDANT"]))
KNOBS.preset("trade-max", {"buy_buffer": 300_000, "min_margin": 20}, blurb="pure arbitrage")

KNOBS.get("min_margin")            # read live in the engine
KNOBS.set("min_margin", "15")      # coerced + clamped + validated + logged
KNOBS.apply_preset("trade-max")    # a doctrine in one move (non-cumulative)
registry.register_tools(make_knob_tools(KNOBS, prefix="fleet"))  # fleet_knobs / _tune / _preset
```

- **Declare typed knobs once** (`define` — kind inferred from the default; `lo`/`hi` clamps; `choices`).
- **`set`** coerces (numbers-as-strings, bools, case-insensitive choices), clamps, validates (a bad/unknown value comes back as **readable text, not a raise**), and logs the change.
- **Presets** apply a curated knob bundle, **non-cumulative** (reset → overrides), declared with a blurb.
- A **change log** records every tune/preset — the decision trail.
- **`make_knob_tools`** auto-generates the agent-facing `<prefix>_knobs` / `_tune` / `_preset` tools (langchain imported lazily, so the module is host-free to import).

The registry **owns the values** (no module globals) — cleaner and more reusable than the pattern it generalizes.

## Tests
Pure stdlib → tested directly: type coercion, bounds clamping, choices validation, the readable-not-raise error path, the change log (only real changes), non-cumulative preset application, reset, schema, and the generated tools (named correctly; `_tune`/`_preset` actually mutate). **16 tests green; ruff clean.**

> Note: independent of #1034 (supervisor), but both add an import to `graph/sdk.py` + a CHANGELOG `### Added` entry — I'll rebase whichever lands second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
