### PR TITLE
feat(sdk): one-call goal-driven recurring loop — closes #1026

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **One-call goal-driven recurring loop (`graph.sdk.start_goal_loop` / `stop_goal_loop`).**
+  Wires the OODA / self-improving pattern — *run a tick every N toward a goal until its
+  verifier passes* — in a single call, instead of a plugin hand-stitching the goal controller
+  (set a monitor goal, ADR 0028/0030) + the scheduler (a recurring prompt, ADR 0003/0053).
+  Sets a monitor goal verified by a plugin verifier and schedules the tick **into the goal's
+  own session** (`context_id`), so it drives the right goal; `every` accepts a 5-field cron or
+  a duration shorthand (`"15m"` / `"2h"` / `"1d"`); rolls the goal back if scheduling fails;
+  `stop_goal_loop` clears the goal + cancels the tick (e.g. from an `on_achieved` hook).
+  Generalizes the wiring the spacetraders `manage-the-fleet` skill described in prose (#1026).
 - **Host-free plugin test harness (`graph/plugins/testkit.py`).** A self-contained
   (stdlib-only) testkit that loads a plugin as a **package** — so a plugin's real engine
   modules (relative imports, module-level `@tool`, lazy `graph.*` host imports) can be

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -16,6 +16,7 @@ its engine injects ``run_subagent`` as the per-step runner).
 
 from __future__ import annotations
 
+import re
 from typing import Any
 
 from runtime.state import STATE
@@ -84,3 +85,108 @@ async def complete(
     resp = await llm.ainvoke(messages)
     content = getattr(resp, "content", resp)
     return content if isinstance(content, str) else str(content)
+
+
+# ── goal-driven recurring loop (the OODA pattern) ──────────────────────────────────────
+# Composing a self-driving "run a tick every N toward a goal until its verifier passes" loop
+# means stitching three subsystems by hand: a plugin goal verifier (ADR 0028), the goal
+# controller (set a MONITOR goal, ADR 0030), and the scheduler (a recurring prompt, ADR
+# 0003/0053). These helpers do it in one call so a plugin doesn't have to know the wiring.
+
+_DURATION = re.compile(r"^\s*(\d+)\s*([mhd])\s*$", re.IGNORECASE)
+
+
+def _to_cron(every: str) -> str:
+    """A 5-field cron passes through; a duration shorthand (``"15m"`` / ``"2h"`` / ``"1d"``)
+    is converted to cron. Raises ValueError on anything else."""
+    from scheduler.interface import is_cron
+
+    s = (every or "").strip()
+    if is_cron(s):
+        return s
+    m = _DURATION.match(s)
+    if not m:
+        raise ValueError(f"{every!r} is not a 5-field cron or a duration like '15m'/'2h'/'1d'")
+    n, unit = int(m.group(1)), m.group(2).lower()
+    if n < 1:
+        raise ValueError("duration must be >= 1")
+    if unit == "m":
+        if n > 59:
+            raise ValueError("minutes must be 1–59 (use '1h' for 60)")
+        return f"*/{n} * * * *"
+    if unit == "h":
+        if n > 23:
+            raise ValueError("hours must be 1–23 (use '1d' for 24)")
+        return f"0 */{n} * * *"
+    if n > 31:
+        raise ValueError("days must be 1–31")
+    return f"0 0 */{n} * *"
+
+
+def start_goal_loop(*, session_id: str, goal: str, verifier: str, every: str, prompt: str,
+                    verifier_args: dict | None = None, mode: str = "monitor",
+                    timezone: str | None = None, no_progress_limit: int | None = None,
+                    max_iterations: int | None = None, job_id: str | None = None) -> dict:
+    """Wire a goal-driven recurring loop in ONE call (the OODA / self-improving pattern):
+    set a goal verified by a plugin verifier, and schedule a recurring prompt that drives it
+    until the verifier passes — at which point the goal's ``on_achieved`` hook winds the work
+    down.
+
+    Register the pieces at ``register()`` time first: the verifier
+    (``registry.register_goal_verifier(verifier, fn)``) and usually the hook
+    (``registry.register_goal_hook(on_achieved=…)``). Then call this from a tool, passing
+    ``session_id`` from your tool's ``InjectedState`` — the goal + the tick are scoped to that
+    session (the tick fires back INTO it via ``context_id``, so it drives the right goal).
+
+    Args:
+        session_id: the session to scope the goal + tick to (from InjectedState).
+        goal: the goal condition text (e.g. "reach 1,000,000 credits").
+        verifier: the registered plugin verifier name, ``"<plugin-id>:<name>"``.
+        every: how often the tick fires — a 5-field cron (``"0 */6 * * *"``) or a duration
+            shorthand ``"15m"`` / ``"2h"`` / ``"1d"``.
+        prompt: the recurring tick prompt (e.g. "Run the manage-the-fleet OODA tick …").
+        verifier_args: declarative args for the verifier (e.g. ``{"min": 1000000}``).
+        mode: ``"monitor"`` (default — an external engine drives the metric; the agent isn't
+            re-invoked to *drive* the goal, only the scheduled tick runs) or ``"drive"``.
+        timezone: IANA tz for the schedule (e.g. ``"America/Chicago"``); UTC if omitted.
+        no_progress_limit, max_iterations: passed through to the goal.
+        job_id: a stable id for the tick job (so a re-call replaces it).
+
+    Returns ``{"ok", "goal", "job_id", "schedule", "message"}``; ``ok=False`` with a readable
+    message if the goal/scheduler subsystems are absent or the inputs are bad.
+    """
+    controller = STATE.goal_controller
+    scheduler = STATE.scheduler
+    if controller is None:
+        return {"ok": False, "message": "goal system unavailable (no goal_controller)"}
+    if scheduler is None:
+        return {"ok": False, "message": "scheduler unavailable"}
+    try:
+        schedule = _to_cron(every)
+    except ValueError as e:
+        return {"ok": False, "message": str(e)}
+    spec = {"type": "plugin", "check": verifier, "args": verifier_args or {}}
+    ok, msg = controller.set_goal_safe(session_id, goal, spec, max_iterations=max_iterations,
+                                       no_progress_limit=no_progress_limit, mode=mode)
+    if not ok:
+        return {"ok": False, "message": f"goal not set: {msg}"}
+    try:
+        job = scheduler.add_job(prompt, schedule, job_id=job_id, timezone=timezone,
+                                context_id=session_id)  # tick runs IN the goal's session
+    except ValueError as e:
+        controller.store.clear(session_id)  # roll back the goal if scheduling failed
+        return {"ok": False, "message": f"bad schedule {every!r}: {e}"}
+    return {"ok": True, "goal": goal, "job_id": job.id, "schedule": schedule,
+            "message": f"goal loop started — {goal} · tick {schedule} · {msg}"}
+
+
+def stop_goal_loop(*, session_id: str, job_id: str | None = None) -> dict:
+    """Tear down a goal loop: clear the goal for ``session_id`` and cancel its tick job
+    (call this from an ``on_achieved`` hook, a stop tool, or when winding down)."""
+    cleared = False
+    if STATE.goal_controller is not None:
+        cleared = STATE.goal_controller.store.clear(session_id)
+    cancelled = False
+    if job_id and STATE.scheduler is not None:
+        cancelled = STATE.scheduler.cancel_job(job_id)
+    return {"ok": True, "goal_cleared": cleared, "job_cancelled": cancelled}

--- a/tests/test_goal_loop.py
+++ b/tests/test_goal_loop.py
@@ -1,0 +1,167 @@
+"""One-call goal-driven recurring loop helper (graph.sdk.start_goal_loop / stop_goal_loop).
+
+Composes the goal controller (set a monitor goal, ADR 0028/0030) + the scheduler (a recurring
+tick, ADR 0003/0053) so a plugin declares a self-driving OODA loop in one call. Tested by
+faking the two host singletons on ``STATE`` — no live controller/scheduler needed.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from graph import sdk
+from graph.sdk import _to_cron, start_goal_loop, stop_goal_loop
+from runtime.state import STATE
+
+
+# ── _to_cron ─────────────────────────────────────────────────────────────────────────
+def test_to_cron_passes_through_a_cron_expression():
+    assert _to_cron("0 */6 * * *") == "0 */6 * * *"
+
+
+@pytest.mark.parametrize("every,expected", [
+    ("15m", "*/15 * * * *"),
+    ("30m", "*/30 * * * *"),
+    ("2h", "0 */2 * * *"),
+    ("1d", "0 0 */1 * *"),
+    ("  45m ", "*/45 * * * *"),
+])
+def test_to_cron_converts_duration_shorthand(every, expected):
+    assert _to_cron(every) == expected
+
+
+@pytest.mark.parametrize("bad", ["", "soon", "0m", "60m", "24h", "32d", "2025-01-01T00:00"])
+def test_to_cron_rejects_bad_durations(bad):
+    with pytest.raises(ValueError):
+        _to_cron(bad)
+
+
+# ── fakes for the two host singletons ────────────────────────────────────────────────
+class _Store:
+    def __init__(self):
+        self.cleared: list[str] = []
+
+    def clear(self, sid):
+        self.cleared.append(sid)
+        return True
+
+
+class _Controller:
+    def __init__(self, ok=True, msg="Goal set."):
+        self._ok, self._msg = ok, msg
+        self.calls: list[dict] = []
+        self.store = _Store()
+
+    def set_goal_safe(self, session_id, condition, verifier, max_iterations=None,
+                      no_progress_limit=None, mode="drive"):
+        self.calls.append({"session_id": session_id, "condition": condition,
+                           "verifier": verifier, "mode": mode})
+        return (self._ok, self._msg)
+
+
+class _Job:
+    def __init__(self, jid):
+        self.id = jid
+
+
+class _Scheduler:
+    def __init__(self, raise_on_add=False):
+        self.added: list[dict] = []
+        self.cancelled: list[str] = []
+        self._raise = raise_on_add
+
+    def add_job(self, prompt, schedule, *, job_id=None, timezone=None, context_id=None):
+        if self._raise:
+            raise ValueError("bad timezone")
+        self.added.append({"prompt": prompt, "schedule": schedule, "job_id": job_id,
+                           "timezone": timezone, "context_id": context_id})
+        return _Job(job_id or "job-1")
+
+    def cancel_job(self, job_id):
+        self.cancelled.append(job_id)
+        return True
+
+
+@pytest.fixture
+def wired(monkeypatch):
+    ctrl, sched = _Controller(), _Scheduler()
+    monkeypatch.setattr(STATE, "goal_controller", ctrl)
+    monkeypatch.setattr(STATE, "scheduler", sched)
+    return ctrl, sched
+
+
+# ── start_goal_loop ──────────────────────────────────────────────────────────────────
+def test_start_goal_loop_sets_a_monitor_goal_and_schedules_the_tick(wired):
+    ctrl, sched = wired
+    res = start_goal_loop(session_id="sess-1", goal="reach 1,000,000 credits",
+                          verifier="spacetraders:credits", verifier_args={"min": 1_000_000},
+                          every="30m", prompt="Run the OODA tick and report.")
+    assert res["ok"] and res["job_id"] == "job-1" and res["schedule"] == "*/30 * * * *"
+    # the goal is a MONITOR goal verified by the plugin verifier
+    call = ctrl.calls[0]
+    assert call["mode"] == "monitor"
+    assert call["verifier"] == {"type": "plugin", "check": "spacetraders:credits",
+                                "args": {"min": 1_000_000}}
+    # the tick fires back INTO the goal's session (so it drives the right goal)
+    assert sched.added[0]["context_id"] == "sess-1"
+    assert sched.added[0]["schedule"] == "*/30 * * * *"
+
+
+def test_bad_schedule_does_not_set_a_goal(wired):
+    ctrl, sched = wired
+    res = start_goal_loop(session_id="s", goal="g", verifier="p:v", every="whenever",
+                          prompt="tick")
+    assert not res["ok"]
+    assert ctrl.calls == [] and sched.added == []  # nothing wired on bad input
+
+
+def test_goal_rejected_means_no_job_scheduled(monkeypatch):
+    ctrl = _Controller(ok=False, msg="verifier not found")
+    sched = _Scheduler()
+    monkeypatch.setattr(STATE, "goal_controller", ctrl)
+    monkeypatch.setattr(STATE, "scheduler", sched)
+    res = start_goal_loop(session_id="s", goal="g", verifier="p:missing", every="15m",
+                          prompt="tick")
+    assert not res["ok"] and "goal not set" in res["message"]
+    assert sched.added == []
+
+
+def test_scheduling_failure_rolls_back_the_goal(monkeypatch):
+    ctrl = _Controller()
+    sched = _Scheduler(raise_on_add=True)
+    monkeypatch.setattr(STATE, "goal_controller", ctrl)
+    monkeypatch.setattr(STATE, "scheduler", sched)
+    res = start_goal_loop(session_id="sess-1", goal="g", verifier="p:v", every="15m",
+                          prompt="tick", timezone="Bad/Zone")
+    assert not res["ok"]
+    assert ctrl.store.cleared == ["sess-1"]  # goal rolled back so we don't strand it
+
+
+def test_unavailable_subsystems_are_reported(monkeypatch):
+    monkeypatch.setattr(STATE, "goal_controller", None)
+    monkeypatch.setattr(STATE, "scheduler", _Scheduler())
+    assert not start_goal_loop(session_id="s", goal="g", verifier="p:v",
+                               every="15m", prompt="t")["ok"]
+    monkeypatch.setattr(STATE, "goal_controller", _Controller())
+    monkeypatch.setattr(STATE, "scheduler", None)
+    assert not start_goal_loop(session_id="s", goal="g", verifier="p:v",
+                               every="15m", prompt="t")["ok"]
+
+
+# ── stop_goal_loop ───────────────────────────────────────────────────────────────────
+def test_stop_goal_loop_clears_goal_and_cancels_job(wired):
+    ctrl, sched = wired
+    res = stop_goal_loop(session_id="sess-1", job_id="job-1")
+    assert res["ok"] and res["goal_cleared"] and res["job_cancelled"]
+    assert ctrl.store.cleared == ["sess-1"] and sched.cancelled == ["job-1"]
+
+
+def test_stop_goal_loop_without_job_id_just_clears(wired):
+    ctrl, sched = wired
+    res = stop_goal_loop(session_id="sess-1")
+    assert res["goal_cleared"] and not res["job_cancelled"]
+    assert sched.cancelled == []
+
+
+def test_sdk_module_exposes_the_helpers():
+    assert callable(sdk.start_goal_loop) and callable(sdk.stop_goal_loop)


### PR DESCRIPTION
Closes #1026.

## Problem
The OODA / self-improving loop — *run a tick every N minutes toward a goal until its verifier passes, then wind down* — requires a plugin to hand-stitch three subsystems: the **goal controller** (set a monitor goal, ADR 0028/0030), the **scheduler** (a recurring prompt, ADR 0003/0053), and the session plumbing between them (the tick must drive the *right* goal). The spacetraders `manage-the-fleet` skill described this in prose; there was no programmatic API, so every plugin would re-derive `set_goal_safe`'s verifier-dict shape, the scheduler's cron API, the `context_id` session wiring, and the rollback/teardown.

## What this adds
**`graph.sdk.start_goal_loop` / `stop_goal_loop`** — one call:

```python
from graph.sdk import start_goal_loop

# in a tool (session_id from InjectedState); the verifier + on_achieved hook are
# registered in the plugin's register() as usual.
start_goal_loop(
    session_id=session_id,
    goal="reach 1,000,000 credits",
    verifier="spacetraders:credits", verifier_args={"min": 1_000_000},
    every="30m",                                   # cron or "15m"/"2h"/"1d"
    prompt="Run the manage-the-fleet OODA tick: observe, decide, act, record.",
)
```

- Sets a **monitor** goal (default) verified by the plugin verifier, and schedules the tick.
- The tick fires **back into the goal's session** (`context_id=session_id`) so it drives the right goal, not a fresh session — the subtle bit a hand-rolled version gets wrong.
- `every` accepts a 5-field cron **or** a duration shorthand (`"15m"` / `"2h"` / `"1d"`).
- **Rolls the goal back** if scheduling fails; reports absent subsystems / bad input as readable text, never a raise.
- `stop_goal_loop(session_id, job_id)` clears the goal + cancels the tick — call it from the `on_achieved` hook to wind down.

It composes the verified host APIs (`controller.set_goal_safe`, `scheduler.add_job`, `controller.store.clear`) — no new subsystem, just the ergonomic seam.

## Tests
21 tests via faked `STATE` singletons (no live controller/scheduler): cron passthrough + duration conversion + bounds, the monitor-goal verifier spec, the `context_id` session wiring, goal-rejected → no job, schedule-fails → goal rolled back, absent subsystems, and teardown. **ruff clean.**

## Follow-up
A declarative manifest stanza (the issue's other option) could sit on top of this helper later — this lands the programmatic seam first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
