### PR TITLE
feat(sdk): plugin telemetry + agent decision-log kit — closes #1027

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   a duration shorthand (`"15m"` / `"2h"` / `"1d"`); rolls the goal back if scheduling fails;
   `stop_goal_loop` clears the goal + cancels the tick (e.g. from an `on_achieved` hook).
   Generalizes the wiring the spacetraders `manage-the-fleet` skill described in prose (#1026).
+- **Plugin telemetry + agent decision-log kit (`graph/telemetry.py`, `from graph.sdk import
+  DecisionLog, telemetry, render_html`).** The observability surface an unattended/agentic
+  plugin needs: `DecisionLog` (a capped audit trail of what the agent changed, and why),
+  `telemetry(...)` (the standard envelope — status / metrics / hints / decisions / sections),
+  and `render_html(...)` (a self-contained, `--pl-*`-token-themed HTML panel — with fallbacks,
+  so it drops into any plugin console view without a specific stylesheet). All values escaped.
+  Generalizes the spacetraders `_DECISIONS` ring buffer + `st_report` envelope + dashboard
+  decision-log panel. Pure stdlib, host-free (#1027).
 - **Host-free plugin test harness (`graph/plugins/testkit.py`).** A self-contained
   (stdlib-only) testkit that loads a plugin as a **package** — so a plugin's real engine
   modules (relative imports, module-level `@tool`, lazy `graph.*` host imports) can be

--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -26,6 +26,11 @@ from runtime.state import STATE
 # engine instead of hand-rolling task/restart machinery (graph/supervisor.py is host-free).
 from graph.supervisor import Supervisor, supervise  # noqa: F401
 
+# Re-export the telemetry + decision-log kit, so a plugin writes
+# `from graph.sdk import DecisionLog, telemetry, render_html` for a standard observability
+# surface (audit trail + envelope + themed panel). graph/telemetry.py is host-free.
+from graph.telemetry import DecisionLog, render_html, telemetry  # noqa: F401
+
 
 def config() -> Any:
     """The live runtime ``LangGraphConfig``."""

--- a/graph/telemetry.py
+++ b/graph/telemetry.py
@@ -1,0 +1,167 @@
+"""Plugin telemetry + agent decision log — the observability surface an unattended or
+agentic plugin needs: a capped audit trail of what the agent DID (and why), a standard
+telemetry envelope, and a themed HTML panel any plugin view can drop in.
+
+The lesson from the SpaceTraders two-loop fleet: an autonomous agent steering a deterministic
+engine is only trustworthy if you can SEE what it changed and how it's doing. That plugin
+hand-rolled a decision-log ring buffer (`_DECISIONS` / `_log_decision`), a structured
+``st_report`` (status + metrics + hints + decisions), and a dashboard panel. This generalizes
+all three:
+
+  * :class:`DecisionLog` — record every agent decision (the audit trail).
+  * :func:`telemetry`    — assemble the standard envelope (status / metrics / hints /
+    decisions / sections) a report tool returns and a panel renders.
+  * :func:`render_html`  — render that envelope as a self-contained, ``--pl-*``-token-themed
+    HTML fragment to drop into a plugin's console view (carries its own styles + fallbacks,
+    so it needs no specific stylesheet loaded).
+
+Pure stdlib (+ ``html.escape``) — host-free, directly unit-tested.
+"""
+
+from __future__ import annotations
+
+import html
+from typing import Any
+
+__all__ = ["DecisionLog", "telemetry", "render_html"]
+
+
+class DecisionLog:
+    """A capped, newest-last log of agent decisions — the audit trail for an autonomous
+    plugin (what the agent changed, and optionally why). Surface ``entries()`` in a report
+    tool and a console panel.
+
+        log = DecisionLog()
+        log.record("tune", "min_margin: 30 → 15")
+        log.record("strategy", "→ trade-max", reason="cr/hr falling")
+        log.entries(5)   # [{'action': 'strategy', 'detail': '→ trade-max', 'reason': …}, …]
+    """
+
+    def __init__(self, cap: int = 50):
+        self._cap = max(1, cap)
+        self._entries: list[dict] = []
+
+    def record(self, action: str, detail: str = "", **fields: Any) -> dict:
+        """Append a decision ``{action, detail, **fields}`` (e.g. a ``reason``/``ts``) and
+        return it. Oldest entries fall off past the cap."""
+        entry = {"action": str(action), "detail": str(detail), **fields}
+        self._entries.append(entry)
+        del self._entries[: -self._cap]
+        return entry
+
+    def entries(self, n: int | None = None) -> list[dict]:
+        """The last ``n`` entries (newest last), or all of them."""
+        return list(self._entries[-n:]) if n else list(self._entries)
+
+    def clear(self) -> None:
+        self._entries.clear()
+
+    def __len__(self) -> int:
+        return len(self._entries)
+
+
+def _as_decisions(decisions: Any) -> list[dict]:
+    if decisions is None:
+        return []
+    if isinstance(decisions, DecisionLog):
+        return decisions.entries()
+    return list(decisions)
+
+
+def telemetry(*, status: str | None = None, metrics: dict | None = None,
+              hints: list | None = None, decisions: Any = None,
+              sections: list | None = None, **extra: Any) -> dict:
+    """Assemble the standard telemetry envelope — the shape a plugin's report tool returns
+    and :func:`render_html` (or a future console panel) renders uniformly:
+
+        {
+          "status":   "running · 1,240,000 cr · 18,400 cr/hr",   # one-line headline
+          "metrics":  {"credits": 1_240_000, "cr/hr": 18_400},   # name -> value (stat cards)
+          "hints":    ["idle capital — reinvest", …],            # deterministic nudges
+          "decisions": [{"action": "tune", "detail": "min_margin 30→15"}, …],  # or a DecisionLog
+          "sections": [{"title": "Fleet", "columns": ["ship","role"], "rows": [[...], ...]}],
+          ...extra                                               # plugin-specific keys pass through
+        }
+    """
+    return {
+        "status": status or "",
+        "metrics": dict(metrics or {}),
+        "hints": list(hints or []),
+        "decisions": _as_decisions(decisions),
+        "sections": list(sections or []),
+        **extra,
+    }
+
+
+# ── HTML panel ─────────────────────────────────────────────────────────────────────────
+_STYLE = """
+.pl-tele{font-family:var(--pl-font-sans,system-ui,sans-serif);color:var(--pl-color-fg,#e8e8e8);
+  background:var(--pl-color-bg,#111);padding:var(--pl-space-4,16px);border-radius:var(--pl-radius,10px)}
+.pl-tele h3{margin:0 0 4px;font-size:15px}
+.pl-tele .pl-tele-status{color:var(--pl-color-fg-muted,#9a9a9a);font-size:13px;margin-bottom:12px}
+.pl-tele-metrics{display:flex;flex-wrap:wrap;gap:10px;margin-bottom:12px}
+.pl-tele-metric{background:var(--pl-color-bg-raised,#1b1b1b);border:1px solid var(--pl-color-border,#2a2a2a);
+  border-radius:var(--pl-radius,8px);padding:8px 12px;min-width:90px}
+.pl-tele-metric .v{font-size:18px;font-weight:600}
+.pl-tele-metric .k{font-size:11px;color:var(--pl-color-fg-muted,#9a9a9a);text-transform:uppercase;letter-spacing:.04em}
+.pl-tele table{width:100%;border-collapse:collapse;font-size:13px;margin:6px 0 12px}
+.pl-tele th,.pl-tele td{text-align:left;padding:5px 8px;border-bottom:1px solid var(--pl-color-border,#2a2a2a)}
+.pl-tele th{color:var(--pl-color-fg-muted,#9a9a9a);font-weight:500}
+.pl-tele .pl-tele-badge{display:inline-block;padding:1px 7px;border-radius:999px;font-size:11px;
+  background:var(--pl-color-accent,#9b87f2);color:#fff}
+.pl-tele ul{margin:0 0 12px;padding-left:18px}
+.pl-tele li{font-size:13px;margin:2px 0}
+.pl-tele h4{margin:10px 0 2px;font-size:12px;color:var(--pl-color-fg-muted,#9a9a9a);
+  text-transform:uppercase;letter-spacing:.04em}
+"""
+
+
+def _esc(v: Any) -> str:
+    if isinstance(v, bool):
+        return "yes" if v else "no"
+    if isinstance(v, int):
+        return f"{v:,}"
+    return html.escape("" if v is None else str(v))
+
+
+def render_html(envelope: dict, *, title: str = "Telemetry") -> str:
+    """Render a telemetry envelope as a self-contained, ``--pl-*``-token-themed HTML fragment
+    (a ``<section class="pl-tele">`` carrying its own ``<style>`` with fallbacks), ready to
+    drop into a plugin's console iframe view. All values are HTML-escaped.
+    """
+    env = envelope or {}
+    parts = [f"<style>{_STYLE}</style>", '<section class="pl-tele">',
+             f"<h3>{_esc(title)}</h3>"]
+    if env.get("status"):
+        parts.append(f'<div class="pl-tele-status">{_esc(env["status"])}</div>')
+
+    metrics = env.get("metrics") or {}
+    if metrics:
+        cards = "".join(
+            f'<div class="pl-tele-metric"><div class="v">{_esc(v)}</div>'
+            f'<div class="k">{_esc(k)}</div></div>' for k, v in metrics.items())
+        parts.append(f'<div class="pl-tele-metrics">{cards}</div>')
+
+    decisions = env.get("decisions") or []
+    if decisions:
+        rows = "".join(
+            f'<tr><td><span class="pl-tele-badge">{_esc(d.get("action", ""))}</span></td>'
+            f'<td>{_esc(d.get("detail", ""))}</td></tr>' for d in reversed(decisions))
+        parts.append('<h4>Decisions</h4><table><tr><th>Move</th><th>Detail</th></tr>'
+                     f'{rows}</table>')
+
+    for sec in (env.get("sections") or []):
+        cols = sec.get("columns") or []
+        head = "".join(f"<th>{_esc(c)}</th>" for c in cols)
+        body = "".join("<tr>" + "".join(f"<td>{_esc(c)}</td>" for c in row) + "</tr>"
+                       for row in (sec.get("rows") or []))
+        parts.append(f'<h4>{_esc(sec.get("title", ""))}</h4>'
+                     f"<table><tr>{head}</tr>{body}</table>")
+
+    hints = env.get("hints") or []
+    if hints:
+        items = "".join(f"<li>{_esc(h)}</li>" for h in hints)
+        parts.append(f"<h4>Hints</h4><ul>{items}</ul>")
+
+    parts.append("</section>")
+    return "".join(parts)

--- a/plugins/plugin-devkit/skills/building-plugins/SKILL.md
+++ b/plugins/plugin-devkit/skills/building-plugins/SKILL.md
@@ -100,7 +100,54 @@ public chrome — its data calls are the gated part). The console iframes the pa
 `building-react-plugin-views`. An event under `<id>.*` lights your plugin's rail icon (a notification
 dot) until the user opens it.
 
-## 5. Test it — live, no restart
+## 5. Consume core capabilities (`graph.sdk`)
+A plugin doesn't only *contribute* — it can call **back into the host** through the stable
+`graph.sdk` surface (so core can refactor underneath you). Keep these imports **lazy** (inside
+functions/tools) so your plugin still loads + tests host-free. The surface:
+
+- **Run the model / a subagent** — `run_subagent(...)` (a full tool-using subagent),
+  `complete(prompt)` (a bare LLM completion).
+- **A supervised background engine** — `supervise(work, …)`: run a unit of work back-to-back
+  with a watchdog that re-kicks a crash, restarts a stall, and recovers via `on_crash`
+  (`.start()` / `.stop()` / `.request_stop()` / `.status()`). The deterministic heartbeat for a
+  long-running engine — don't hand-roll task/restart machinery.
+  ```python
+  from graph.sdk import supervise
+  engine = supervise(run_one_window, name="fleet", interval=90,
+                     stall_check=lambda: not busy(), on_crash=recover)
+  engine.start()
+  ```
+- **A tunable control surface** — `Knobs()` + `make_knob_tools(knobs, prefix=…)`: declare typed
+  knobs (clamped, `choices`) + named presets, read live in your engine; auto-generate the
+  `<prefix>_knobs` / `_tune` / `_preset` agent tools.
+  ```python
+  from graph.sdk import Knobs, make_knob_tools
+  KNOBS = Knobs().define("min_margin", 30, lo=0).preset("trade-max", {"min_margin": 20})
+  registry.register_tools(make_knob_tools(KNOBS, prefix="fleet"))
+  ```
+- **A self-driving goal loop (OODA)** — `start_goal_loop(…)`: set a monitor goal verified by
+  your plugin verifier **and** schedule a recurring tick that drives it until the verifier
+  passes — in one call (`stop_goal_loop` to tear down, e.g. from an `on_achieved` hook). Register
+  the verifier + hook in `register()` first; pass `session_id` from your tool's `InjectedState`.
+  ```python
+  from graph.sdk import start_goal_loop
+  start_goal_loop(session_id=sid, goal="reach 1M credits",
+                  verifier="fleet:credits", verifier_args={"min": 1_000_000},
+                  every="30m", prompt="Run the OODA tick and report.")
+  ```
+- **Observability** — `DecisionLog` (an audit trail of what the agent changed, and why),
+  `telemetry(…)` (the standard status/metrics/hints/decisions envelope), `render_html(env)` (a
+  themed panel for your console view).
+  ```python
+  from graph.sdk import DecisionLog, telemetry, render_html
+  LOG = DecisionLog(); LOG.record("tune", "min_margin 30→15", reason="cr/hr falling")
+  return render_html(telemetry(status="running", metrics={"credits": cr}, decisions=LOG))
+  ```
+
+These generalize the patterns the SpaceTraders two-loop fleet proved (its `manage-the-fleet`
+skill is the worked example: a deterministic engine steered by an agentic OODA loop).
+
+## 6. Test it — live, no restart
 You don't need to restart to try a plugin you built. With **plugin-devkit** enabled:
 - `scaffold_plugin(...)` already **enabled** it (the default) — its tools/view are
   live on your **next turn**. Call its `<id>_hello` to confirm.
@@ -141,7 +188,7 @@ From the shell (no agent): `python -m server plugin new "My Plugin" --view --ski
 scaffolds the skeleton; `plugin new-bundle "My Stack" --member id=url@ref --builtin delegates`
 scaffolds an ADR-0040 bundle.
 
-## 6. Distribute (optional)
+## 7. Distribute (optional)
 Publish as a git repo; others install by URL:
 `python -m server plugin install <git-url> --ref <tag>` (or the console Plugins
 panel). Install pins a commit SHA in `plugins.lock`; `plugin sync` reproduces it.

--- a/tests/test_telemetry.py
+++ b/tests/test_telemetry.py
@@ -1,0 +1,102 @@
+"""Plugin telemetry + decision-log kit (graph.telemetry).
+
+Generalizes the SpaceTraders observability surface: a decision-log ring buffer, the standard
+telemetry envelope, and a themed HTML panel. Pure stdlib — tested directly.
+"""
+
+from __future__ import annotations
+
+from graph.sdk import DecisionLog as SdkDecisionLog  # re-exported on the plugin SDK surface
+from graph.telemetry import DecisionLog, render_html, telemetry
+
+
+def test_exported_on_the_sdk():
+    assert SdkDecisionLog is DecisionLog
+
+
+# ── DecisionLog ──────────────────────────────────────────────────────────────────────
+def test_decision_log_records_action_detail_and_extra_fields():
+    log = DecisionLog()
+    e = log.record("tune", "min_margin: 30 → 15", reason="cr/hr falling")
+    assert e == {"action": "tune", "detail": "min_margin: 30 → 15", "reason": "cr/hr falling"}
+    assert log.entries() == [e] and len(log) == 1
+
+
+def test_decision_log_is_capped_newest_kept():
+    log = DecisionLog(cap=3)
+    for i in range(5):
+        log.record("tune", f"k{i}")
+    details = [e["detail"] for e in log.entries()]
+    assert details == ["k2", "k3", "k4"]  # oldest two fell off, newest last
+
+
+def test_decision_log_entries_n_and_clear():
+    log = DecisionLog()
+    for i in range(4):
+        log.record("a", str(i))
+    assert [e["detail"] for e in log.entries(2)] == ["2", "3"]
+    log.clear()
+    assert log.entries() == [] and len(log) == 0
+
+
+# ── telemetry envelope ───────────────────────────────────────────────────────────────
+def test_telemetry_envelope_has_the_standard_shape():
+    env = telemetry(status="running", metrics={"credits": 1000}, hints=["reinvest"])
+    assert env["status"] == "running"
+    assert env["metrics"] == {"credits": 1000}
+    assert env["hints"] == ["reinvest"]
+    assert env["decisions"] == [] and env["sections"] == []
+
+
+def test_telemetry_accepts_a_decisionlog_or_a_list():
+    log = DecisionLog()
+    log.record("strategy", "→ trade-max")
+    assert telemetry(decisions=log)["decisions"] == [{"action": "strategy", "detail": "→ trade-max"}]
+    raw = [{"action": "tune", "detail": "x"}]
+    assert telemetry(decisions=raw)["decisions"] == raw
+
+
+def test_telemetry_passes_extra_keys_through():
+    env = telemetry(status="ok", credits=1234, per_hour=42)
+    assert env["credits"] == 1234 and env["per_hour"] == 42
+
+
+# ── render_html ──────────────────────────────────────────────────────────────────────
+def test_render_html_includes_metrics_decisions_and_hints():
+    log = DecisionLog()
+    log.record("tune", "min_margin 30→15")
+    env = telemetry(status="running · 1,000,000 cr", metrics={"credits": 1_000_000},
+                    hints=["idle capital — reinvest"], decisions=log)
+    out = render_html(env, title="Fleet")
+    assert "<section" in out and "pl-tele" in out
+    assert "Fleet" in out and "running · 1,000,000 cr" in out
+    assert "1,000,000" in out          # int metric comma-formatted
+    assert "min_margin 30→15" in out and "idle capital — reinvest" in out
+    assert "--pl-color-fg" in out      # themed via DS tokens (with fallbacks)
+
+
+def test_render_html_renders_section_tables():
+    env = telemetry(sections=[{"title": "Fleet", "columns": ["ship", "role"],
+                               "rows": [["DRONE-1", "miner"], ["HAULER-1", "trader"]]}])
+    out = render_html(env)
+    assert "<th>ship</th>" in out and "<td>DRONE-1</td>" in out and "<td>miner</td>" in out
+
+
+def test_render_html_escapes_values():
+    env = telemetry(status="<script>alert(1)</script>", hints=["a & b <c>"])
+    out = render_html(env)
+    assert "<script>alert(1)</script>" not in out
+    assert "&lt;script&gt;" in out and "a &amp; b &lt;c&gt;" in out
+
+
+def test_render_html_handles_empty_envelope():
+    out = render_html(telemetry())
+    assert "<section" in out and "</section>" in out  # no metrics/decisions/hints → still valid
+
+
+def test_decisions_render_newest_first():
+    log = DecisionLog()
+    log.record("a", "first")
+    log.record("b", "second")
+    out = render_html(telemetry(decisions=log))
+    assert out.index("second") < out.index("first")  # newest at the top of the table


### PR DESCRIPTION
Closes #1027.

## Problem
An autonomous agent steering a deterministic engine is only trustworthy if you can **see what it changed and how it's doing**. Unattended/agentic plugins broadly need "structured status + an audit trail of the agent's decisions, surfaced in the console" — but there's no shared convention or kit, so each plugin reinvents the shape and the rendering. The spacetraders fleet hand-rolled a `_DECISIONS` ring buffer, a structured `st_report` (status + metrics + hints + decisions), and a dashboard panel.

## What this adds
**`graph/telemetry.py`** — re-exported from `graph.sdk`:

```python
from graph.sdk import DecisionLog, telemetry, render_html

log = DecisionLog()
log.record("tune", "min_margin: 30 → 15", reason="cr/hr falling")
log.record("strategy", "→ trade-max")

env = telemetry(
    status="running · 1,240,000 cr · 18,400 cr/hr",
    metrics={"credits": 1_240_000, "cr/hr": 18_400},
    hints=["idle capital — reinvest"],
    decisions=log,                                   # or a raw list
    sections=[{"title": "Fleet", "columns": ["ship", "role"], "rows": [["DRONE-1", "miner"]]}],
)
return render_html(env, title="Fleet")               # drop into the plugin's console iframe view
```

- **`DecisionLog`** — a capped, newest-last audit trail: `record(action, detail, **fields)` / `entries(n)` / `clear`. The "what did the agent change, and why" log.
- **`telemetry(...)`** — the standard envelope (status / metrics / hints / decisions / sections + passthrough extras) a report tool returns and a panel renders uniformly.
- **`render_html(...)`** — a **self-contained**, `--pl-*`-token-themed HTML fragment (carries its own `<style>` with fallbacks, **all values escaped**), so it drops into any plugin console view without a specific stylesheet loaded: metrics as stat cards, decisions newest-first, section tables, hints.

## Scope note
I deliberately delivered the **self-contained core** (the convention + a host-free HTML renderer) rather than a cross-repo `@protolabsai/ui` (protoContent) DS panel — it works today in any plugin's iframe view with zero cross-repo coupling. A first-class DS console panel can render the *same envelope* later; the envelope is the contract.

## Tests
Pure stdlib → 12 tests direct: capped log + entries/clear, envelope shape, `DecisionLog`-or-list, extras passthrough, render of metrics/decisions/sections/hints, HTML escaping, newest-first ordering. **ruff clean.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
