### PR TITLE
feat(chat): per-tab model selection — each chat tab talks to its own model

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Per-tab model selection.** Each chat tab can now talk to its own model,
+  overriding the globally configured one. The composer's model dropdown is now a
+  per-tab control (sourced from the gateway's live model list) — "Default" uses
+  the configured model; any other choice is stored on that chat session and sent
+  with every turn. Backend: the chosen model rides the turn as `state["model"]`
+  and a new `ModelOverrideMiddleware` swaps the lead model for that turn (clients
+  built via `create_llm` and cached per model), so sibling tabs stay on their own
+  models. Wired through `/a2a` (message metadata), `/api/chat` (a `model` field),
+  and the OpenAI-compatible `/v1/chat/completions` (honors the request's `model`
+  unless it's the agent's own advertised id). The cost-v1 DataPart already reports
+  the model that actually ran, so per-tab routing is visible per turn.
 - **One-call goal-driven recurring loop (`graph.sdk.start_goal_loop` / `stop_goal_loop`).**
   Wires the OODA / self-improving pattern — *run a tick every N toward a goal until its
   verifier passes* — in a single call, instead of a plugin hand-stitching the goal controller

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -14,18 +14,22 @@ test("the topbar gear opens the Settings overlay (the two-home one-stop-shop)", 
   await expect(dialog.getByRole("button", { name: "Workspace", exact: true })).toBeVisible();
 });
 
-test("the chat composer model picker selects a model and saves", async ({ page }) => {
+test("the chat composer model picker overrides the model per-tab (no global save)", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  // The model picker lives inline in the DS composer's actions slot (a <select>),
-  // wired to the `model.name` settings field (host-scoped). Selecting saves immediately.
-  const model = page.getByRole("combobox", { name: "Model" });
+  // The composer's inline model picker is a PER-TAB override (not a global settings
+  // write). It defaults to "Default" (the configured model) and offers the gateway's
+  // models; picking one stores it on the chat session and is sent with each turn.
+  const model = page.getByRole("combobox", { name: "Model for this chat" });
   await expect(model).toBeVisible();
-  await expect(model).toHaveValue("protolabs/reasoning"); // current model from the schema
-  const saved = page.waitForRequest(
-    (r) => r.url().endsWith("/api/settings") && r.method() === "POST",
-  );
-  await model.selectOption("protolabs/fast");
-  const body = (await saved).postDataJSON();
-  expect(body.updates["model.name"]).toBe("protolabs/fast");
-  expect(body.layer).toBe("host"); // model.name is host-scoped → saved to the host layer
+  await expect(model).toHaveValue(""); // "" → Default (the configured global model)
+
+  // Picking a model must NOT POST /api/settings (that would change it globally).
+  let settingsWrite = false;
+  page.on("request", (r) => {
+    if (r.url().endsWith("/api/settings") && r.method() === "POST") settingsWrite = true;
+  });
+  await model.selectOption("protolabs/fast"); // throws if the gateway option is absent
+  await expect(model).toHaveValue("protolabs/fast");
+  await page.waitForTimeout(300);
+  expect(settingsWrite).toBe(false);
 });

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -703,7 +703,7 @@ function ChatSessionSlot({
             }),
           );
         },
-      }, { images: opts.images });
+      }, { images: opts.images, model: session.model });
       chatStore.setSessionStatus(session.id, "idle");
       setStatusMessage("idle");
     } catch (exc) {

--- a/apps/web/src/chat/ComposerModelSelect.tsx
+++ b/apps/web/src/chat/ComposerModelSelect.tsx
@@ -1,38 +1,35 @@
-import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { useQuery } from "@tanstack/react-query";
 
-import { api } from "../lib/api";
-import { queryKeys, settingsSchemaQuery } from "../lib/queries";
+import { settingsSchemaQuery } from "../lib/queries";
+import { chatStore, useChatState } from "./chat-store";
 
-// The composer's inline model picker — rendered in the DS PromptInput `actions` slot
-// (the design-system composer pattern), replacing the separate QuickSetting model chip.
-// Reads the `model.name` field straight from the settings schema (its `options` are the
-// available models, `value` the active one, `scope` the cascade layer) and saves on change
-// via the same /api/settings write path the central Settings home uses. Temperature /
-// max-tokens live in full Settings now — the composer just picks the model.
+// The composer's inline model picker — rendered in the DS PromptInput `actions` slot.
+// This is a PER-TAB override: it does NOT change the saved global model (that lives in
+// Settings). The choice is stored on the chat session and sent with each turn, so each
+// tab can talk to its own model. "Default" clears the override → the configured global
+// model. Available models come from the settings schema's `model.name` options (the
+// gateway's live model list), the same source the wizard's picker uses.
 export function ComposerModelSelect() {
-  const qc = useQueryClient();
   const schema = useQuery(settingsSchemaQuery());
+  const { sessions, currentSessionId } = useChatState();
   const field = schema.data?.groups.flatMap((g) => g.fields).find((f) => f.key === "model.name");
 
-  const save = useMutation({
-    mutationFn: (v: string) =>
-      api.saveSettings({ "model.name": v }, field?.scope === "host" ? "host" : "agent"),
-    onSuccess: () => void qc.invalidateQueries({ queryKey: queryKeys.settings }),
-  });
+  const globalModel = String(field?.value ?? "");
+  const options = field?.options?.length ? field.options : globalModel ? [globalModel] : [];
+  const session = sessions.find((s) => s.id === currentSessionId);
+  const selected = session?.model ?? "";
 
-  if (!field) return null;
-  const value = String(field.value ?? "");
-  const options = field.options?.length ? field.options : value ? [value] : [];
+  if (!options.length || !currentSessionId) return null;
 
   return (
     <select
-      aria-label="Model"
-      title="Model"
+      aria-label="Model for this chat"
+      title={selected ? `This tab uses ${selected}` : `Default${globalModel ? ` (${globalModel})` : ""}`}
       className="composer-model-select"
-      value={value}
-      onChange={(e) => save.mutate(e.target.value)}
-      disabled={save.isPending}
+      value={selected}
+      onChange={(e) => chatStore.setSessionModel(currentSessionId, e.target.value)}
     >
+      <option value="">{globalModel ? `Default · ${globalModel}` : "Default"}</option>
       {options.map((m) => (
         <option key={m} value={m}>
           {m}

--- a/apps/web/src/chat/chat-store.test.ts
+++ b/apps/web/src/chat/chat-store.test.ts
@@ -172,6 +172,17 @@ describe("persist debouncing", () => {
     expect(setItem).toHaveBeenCalledTimes(1);
   });
 
+  it("setSessionModel sets a per-tab model and clears it on empty", async () => {
+    const { chatStore } = await freshStore();
+    const sessionId = chatStore.getSnapshot().currentSessionId!;
+    const modelOf = () => chatStore.getSnapshot().sessions.find((s) => s.id === sessionId)!.model;
+
+    chatStore.setSessionModel(sessionId, "protolabs/fast");
+    expect(modelOf()).toBe("protolabs/fast");
+    chatStore.setSessionModel(sessionId, ""); // clear → back to the configured default
+    expect(modelOf()).toBeUndefined();
+  });
+
   it("flushes pending state on pagehide/beforeunload, and only when dirty", async () => {
     const { chatStore } = await freshStore();
     const sessionId = chatStore.getSnapshot().currentSessionId!;

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -11,6 +11,9 @@ export type ChatSession = {
   messages: ChatMessage[];
   createdAt: number;
   updatedAt: number;
+  // Per-tab model override (gateway model id). Undefined → the configured
+  // default. Sent with each turn so this tab talks to its own model.
+  model?: string;
 };
 
 export type SessionStatus = "idle" | "streaming" | "error";
@@ -317,6 +320,16 @@ export const chatStore = {
     setState((current) => ({
       ...current,
       sessionStatusMap: { ...current.sessionStatusMap, [sessionId]: status },
+    }));
+  },
+
+  // Per-tab model override. Empty string clears it (→ configured default).
+  setSessionModel(sessionId: string, model: string) {
+    setState((current) => ({
+      ...current,
+      sessions: current.sessions.map((session) =>
+        session.id === sessionId ? { ...session, model: model || undefined } : session,
+      ),
     }));
   },
 };

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -929,10 +929,10 @@ export const api = {
     return request<{ ok: boolean }>("/api/theme", { method: "DELETE" });
   },
 
-  chat(message: string, sessionId: string) {
+  chat(message: string, sessionId: string, model?: string) {
     return request<{ response: string; messages: ChatMessage[] }>("/api/chat", {
       method: "POST",
-      body: { message, session_id: sessionId },
+      body: { message, session_id: sessionId, ...(model ? { model } : {}) },
     });
   },
 
@@ -965,7 +965,7 @@ export const api = {
       onFailed?: (message: string) => void;
       onDone?: () => void;
     } = {},
-    opts: { images?: { b64: string; mime: string; name: string }[] } = {},
+    opts: { images?: { b64: string; mime: string; name: string }[]; model?: string } = {},
   ) {
     // Desktop (WKWebView) can't read a streaming SSE body via fetch (see
     // isDesktopWebview) — the turn would render as a blank assistant bubble. Take
@@ -978,7 +978,7 @@ export const api = {
           method: "POST",
           headers: applyAuth(new Headers({ "Content-Type": "application/json" })),
           signal: handlers.signal,
-          body: JSON.stringify({ message, session_id: sessionId }),
+          body: JSON.stringify({ message, session_id: sessionId, ...(opts.model ? { model: opts.model } : {}) }),
         });
         if (!res.ok) {
           let detail = `${res.status} ${res.statusText}`;
@@ -1031,6 +1031,9 @@ export const api = {
             ],
             messageId: rpcId,
             contextId: sessionId,
+            // Per-tab model override — the executor merges message metadata into
+            // request_metadata, which the chat layer reads as the turn's model.
+            ...(opts.model ? { metadata: { model: opts.model } } : {}),
           },
         },
       }),

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -38,6 +38,12 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
     from graph.middleware.wait_yield import WaitYieldMiddleware
     middleware.append(WaitYieldMiddleware())
 
+    # Per-turn model override (per chat tab). Outermost wrap_model_call so the
+    # PromptCache below sees the ACTUAL model when deciding caching. No-op unless
+    # the turn carries state["model"].
+    from graph.middleware.model_override import ModelOverrideMiddleware
+    middleware.append(ModelOverrideMiddleware(config))
+
     # Prompt caching + knowledge-context delivery (wrap_model_call). Added
     # first/outermost so the cache breakpoint lands on the stable system
     # prefix; KnowledgeMiddleware's context is delivered just after it.

--- a/graph/middleware/model_override.py
+++ b/graph/middleware/model_override.py
@@ -1,0 +1,57 @@
+"""ModelOverrideMiddleware — per-turn model selection (per chat tab).
+
+The graph is compiled once with a single lead model, but the console lets each
+chat tab pick its own model. The chosen model rides on the turn as
+``state["model"]`` (stamped by the chat layer from the request); this middleware
+reads it at the ``wrap_model_call`` boundary and swaps ``request.model`` to a
+client for that model, built via ``create_llm(config, model_name=…)`` and cached
+per model. Unset / unknown → the configured default, unchanged.
+
+Added OUTERMOST among the wrap_model_call middleware so the actual (overridden)
+model is what PromptCacheMiddleware sees when it decides caching.
+"""
+
+from __future__ import annotations
+
+import logging
+
+from langchain.agents.middleware import AgentMiddleware
+
+log = logging.getLogger(__name__)
+
+
+def _model_name_of(model) -> str:
+    return getattr(model, "model_name", None) or getattr(model, "model", "") or ""
+
+
+class ModelOverrideMiddleware(AgentMiddleware):
+    """Swap the turn's model to the tab-selected one (``state["model"]``)."""
+
+    def __init__(self, config):
+        super().__init__()
+        self._config = config
+        self._cache: dict[str, object] = {}  # model_name → ChatOpenAI
+
+    def _llm_for(self, want: str):
+        llm = self._cache.get(want)
+        if llm is None:
+            from graph.llm import create_llm
+            llm = create_llm(self._config, model_name=want)
+            self._cache[want] = llm
+        return llm
+
+    def _override(self, request):
+        want = ((getattr(request, "state", None) or {}).get("model") or "").strip()
+        if not want or want == _model_name_of(getattr(request, "model", None)):
+            return request  # unset or already on it — no-op
+        try:
+            return request.override(model=self._llm_for(want))
+        except Exception:  # noqa: BLE001 — never break a turn over model selection
+            log.exception("[model-override] could not switch to %r; using default", want)
+            return request
+
+    def wrap_model_call(self, request, handler):
+        return handler(self._override(request))
+
+    async def awrap_model_call(self, request, handler):
+        return await handler(self._override(request))

--- a/graph/state.py
+++ b/graph/state.py
@@ -26,6 +26,10 @@ class ProtoAgentState(AgentState):
     # Session tracking (A2A / chat session ID)
     session_id: NotRequired[str]
 
+    # Per-turn model override (per chat tab) — read by ModelOverrideMiddleware to
+    # swap the lead model for this turn; unset → the configured default.
+    model: NotRequired[str]
+
     # Knowledge context injected by KnowledgeMiddleware before LLM call
     context: NotRequired[str]
 

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -33,6 +33,7 @@ from server.chat import chat
 class ChatRequest(BaseModel):
     message: str
     session_id: str = "api-default"
+    model: str | None = None  # per-tab model override; None → configured default
 
 
 def register_chat_routes(app, ui: str) -> None:
@@ -45,7 +46,7 @@ def register_chat_routes(app, ui: str) -> None:
     # --- Chat API -----------------------------------------------------------
     @app.post("/api/chat")
     async def _api_chat(req: ChatRequest):
-        result = await chat(req.message, req.session_id)
+        result = await chat(req.message, req.session_id, model=req.model)
         parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
         return {"response": "\n\n".join(parts), "messages": result}
 
@@ -120,7 +121,14 @@ def register_chat_routes(app, ui: str) -> None:
         session_id = f"openai-compat-{int(time.time())}"
         stream = req.get("stream", False)
 
-        result = await chat(prompt, session_id)
+        # Honor the OpenAI `model` field as a per-request override — unless it's
+        # this agent's own advertised id (the default model from /v1/models), in
+        # which case use the configured default. Lets an OpenAI client target a
+        # specific gateway model.
+        req_model = (req.get("model") or "").strip()
+        model = req_model if req_model and req_model != agent_name() else None
+
+        result = await chat(prompt, session_id, model=model)
         parts = [m["content"] for m in result if m.get("role") == "assistant" and m.get("content")]
         content = "\n\n".join(parts)
         created = int(time.time())

--- a/server/chat.py
+++ b/server/chat.py
@@ -135,18 +135,19 @@ def _setup_required_message() -> list[dict[str, Any]]:
 # Chat backend — called by the A2A handler + OpenAI-compat endpoint
 # ---------------------------------------------------------------------------
 
-async def chat(message: str, session_id: str) -> list[dict[str, Any]]:
+async def chat(message: str, session_id: str, *, model: str | None = None) -> list[dict[str, Any]]:
     """Route a user message through LangGraph and return the final assistant
     response as a list of ``{"role": "assistant", "content": ...}`` dicts.
 
     This is the non-streaming entry point used by the console + the OpenAI-compat
     endpoint. The A2A handler uses ``_chat_langgraph_stream`` instead to
     capture tool events and emit the cost-v1 DataPart on the terminal
-    artifact.
+    artifact. ``model`` overrides the lead model for this turn (per-tab / per
+    OpenAI request); unset → the configured default.
     """
     if STATE.graph is None:
         return _setup_required_message()
-    return await _chat_langgraph(message, session_id)
+    return await _chat_langgraph(message, session_id, model=model)
 
 
 # Cap tool input/output previews so a single frame stays small on the wire.
@@ -224,7 +225,7 @@ def _last_tool_text(result) -> str:
     return ""
 
 
-async def _run_turn_stream(message: str, session_id: str, config: dict, *, resume_value=None, images=None):
+async def _run_turn_stream(message: str, session_id: str, config: dict, *, resume_value=None, images=None, model=None):
     """Run one graph turn over ``astream_events``.
 
     Yields the same ``(kind, payload)`` status/usage frames the A2A handler
@@ -260,6 +261,9 @@ async def _run_turn_stream(message: str, session_id: str, config: dict, *, resum
         else {
             "messages": _drain_background_messages(session_id) + [human],
             "session_id": session_id,
+            # Per-tab model override (ModelOverrideMiddleware reads it); omit the
+            # key when unset so the configured default applies.
+            **({"model": model} if model else {}),
         }
     )
     from observability import metrics
@@ -759,6 +763,12 @@ async def _chat_langgraph_stream(
                 "recursion_limit": 200,
             }
 
+            # Per-tab model override (the console puts the tab's chosen model in
+            # the A2A request metadata). Threaded into every turn this stream runs
+            # — initial, kicker, goal continuation — so the whole conversation
+            # stays on the tab's model. Unset → the configured default.
+            _model = ((request_metadata or {}).get("model") or "").strip() or None
+
             # When a goal is already active, the whole turn is goal-driven —
             # suppress cross-session prior_sessions on the initial turn (and the
             # kicker retry below), matching the continuation turns.
@@ -776,7 +786,7 @@ async def _chat_langgraph_stream(
                 async for kind, payload in _run_turn_stream(
                     message, session_id, config,
                     resume_value=(message if resume else None),
-                    images=images,
+                    images=images, model=_model,
                 ):
                     if kind == "__raw__":
                         accumulated_raw = payload
@@ -809,7 +819,7 @@ async def _chat_langgraph_stream(
                 yield ("tool_start", "↻ retry: prior turn dropped scratch-only")
                 retry_raw = ""
                 with goal_turn(goal_active):
-                    async for kind, payload in _run_turn_stream(DROPPED_SCRATCH_KICKER, session_id, config):
+                    async for kind, payload in _run_turn_stream(DROPPED_SCRATCH_KICKER, session_id, config, model=_model):
                         if kind == "__raw__":
                             retry_raw = payload
                         else:
@@ -842,7 +852,7 @@ async def _chat_langgraph_stream(
                         break
                     cont_raw = ""
                     with goal_turn():
-                        async for kind, payload in _run_turn_stream(decision.message, session_id, config):
+                        async for kind, payload in _run_turn_stream(decision.message, session_id, config, model=_model):
                             if kind == "__raw__":
                                 cont_raw = payload
                             else:
@@ -883,12 +893,15 @@ async def _chat_langgraph_stream(
             tracing.flush()
 
 
-async def _chat_langgraph(message: str, session_id: str) -> list[dict[str, Any]]:
+async def _chat_langgraph(message: str, session_id: str, *, model: str | None = None) -> list[dict[str, Any]]:
     """Non-streaming LangGraph entry — used by the console + OpenAI-compat."""
     from observability import tracing
     from langchain_core.messages import HumanMessage, AIMessage
 
     from graph.goals.goal_turn import goal_turn
+
+    # Per-turn model override (ModelOverrideMiddleware reads state["model"]).
+    _model_extra = {"model": model} if (model or "").strip() else {}
 
     async with tracing.trace_session(
         session_id=session_id,
@@ -934,7 +947,7 @@ async def _chat_langgraph(message: str, session_id: str) -> list[dict[str, Any]]
             )
             with goal_turn(goal_active):
                 result = await STATE.graph.ainvoke(
-                    {"messages": [HumanMessage(content=message)], "session_id": session_id},
+                    {"messages": [HumanMessage(content=message)], "session_id": session_id, **_model_extra},
                     config=config,
                 )
             raw = _last_ai(result)
@@ -964,7 +977,7 @@ async def _chat_langgraph(message: str, session_id: str) -> list[dict[str, Any]]
                     log.warning("[chat] dropped scratch-only turn (session=%s) — kicker retry", session_id)
                     with goal_turn(goal_active):
                         result = await STATE.graph.ainvoke(
-                            {"messages": [HumanMessage(content=DROPPED_SCRATCH_KICKER)], "session_id": session_id},
+                            {"messages": [HumanMessage(content=DROPPED_SCRATCH_KICKER)], "session_id": session_id, **_model_extra},
                             config=config,
                         )
                     response = extract_output(_last_ai(result))
@@ -989,7 +1002,7 @@ async def _chat_langgraph(message: str, session_id: str) -> list[dict[str, Any]]
                         break
                     with goal_turn():
                         result = await STATE.graph.ainvoke(
-                            {"messages": [HumanMessage(content=decision.message)], "session_id": session_id},
+                            {"messages": [HumanMessage(content=decision.message)], "session_id": session_id, **_model_extra},
                             config=config,
                         )
                     nxt = extract_output(_last_ai(result))

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -10,8 +10,9 @@ def _client(monkeypatch, *, graph=object(), goal=None, chat_reply=None):
     import operator_api.chat_routes as cr
     import runtime.state as rs
 
-    async def _fake_chat(message, session_id):
-        return chat_reply or [{"role": "assistant", "content": f"echo:{message}"}]
+    async def _fake_chat(message, session_id, *, model=None):
+        suffix = f"@{model}" if model else ""
+        return chat_reply or [{"role": "assistant", "content": f"echo:{message}{suffix}"}]
 
     monkeypatch.setattr(cr, "chat", _fake_chat)
     monkeypatch.setattr(cr, "agent_name", lambda: "protoagent")
@@ -27,6 +28,28 @@ def test_api_chat_joins_assistant_parts(monkeypatch):
     c = _client(monkeypatch)
     body = c.post("/api/chat", json={"message": "hi"}).json()
     assert body["response"] == "echo:hi"
+
+
+def test_api_chat_threads_per_tab_model(monkeypatch):
+    c = _client(monkeypatch)
+    body = c.post("/api/chat", json={"message": "hi", "model": "protolabs/fast"}).json()
+    assert body["response"] == "echo:hi@protolabs/fast"  # model reached chat()
+
+
+def test_openai_completion_honors_model_override(monkeypatch):
+    c = _client(monkeypatch)
+    # A real (non-agent) model id is forwarded as a per-request override.
+    comp = c.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "yo"}], "model": "protolabs/fast"},
+    ).json()
+    assert comp["choices"][0]["message"]["content"] == "echo:yo@protolabs/fast"
+    # The agent's own advertised id means "use the configured default" (no override).
+    comp2 = c.post(
+        "/v1/chat/completions",
+        json={"messages": [{"role": "user", "content": "yo"}], "model": "protoagent"},
+    ).json()
+    assert comp2["choices"][0]["message"]["content"] == "echo:yo"
 
 
 def test_delete_session_harvest_is_opt_in(monkeypatch):

--- a/tests/test_model_override.py
+++ b/tests/test_model_override.py
@@ -1,0 +1,122 @@
+"""Per-tab model override — ModelOverrideMiddleware + the per-turn wiring.
+
+A chat tab can pick its own model; it rides on the turn as ``state["model"]`` and
+this middleware swaps the bound model for that turn (building/caching a client via
+create_llm). Unset → the configured default, untouched.
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage
+
+from graph.middleware import model_override as mo
+
+
+# ── unit: the middleware ──────────────────────────────────────────────────────
+
+class _FakeModel:
+    def __init__(self, name):
+        self.model_name = name
+
+
+class _FakeReq:
+    def __init__(self, state, model):
+        self.state = state
+        self.model = model
+
+    def override(self, **kw):
+        return _FakeReq(self.state, kw.get("model", self.model))
+
+
+def _patch_create_llm(monkeypatch, recorder):
+    def _fake(config, *, model_name=None):
+        recorder.append(model_name)
+        return _FakeModel(model_name)
+    monkeypatch.setattr("graph.llm.create_llm", _fake)
+
+
+def test_swaps_model_when_state_selects_one(monkeypatch):
+    built: list = []
+    _patch_create_llm(monkeypatch, built)
+    mw = mo.ModelOverrideMiddleware(config=object())
+    seen = {}
+    req = _FakeReq(state={"model": "protolabs/fast"}, model=_FakeModel("protolabs/reasoning"))
+    mw.wrap_model_call(req, lambda r: seen.setdefault("model", r.model))
+    assert built == ["protolabs/fast"]
+    assert seen["model"].model_name == "protolabs/fast"
+
+
+def test_noop_when_no_model_selected(monkeypatch):
+    built: list = []
+    _patch_create_llm(monkeypatch, built)
+    mw = mo.ModelOverrideMiddleware(config=object())
+    seen = {}
+    req = _FakeReq(state={}, model=_FakeModel("protolabs/reasoning"))
+    mw.wrap_model_call(req, lambda r: seen.setdefault("model", r.model))
+    assert built == []  # create_llm never called
+    assert seen["model"].model_name == "protolabs/reasoning"  # unchanged
+
+
+def test_noop_when_already_on_selected_model(monkeypatch):
+    built: list = []
+    _patch_create_llm(monkeypatch, built)
+    mw = mo.ModelOverrideMiddleware(config=object())
+    req = _FakeReq(state={"model": "protolabs/fast"}, model=_FakeModel("protolabs/fast"))
+    mw.wrap_model_call(req, lambda r: None)
+    assert built == []  # no rebuild — already on it
+
+
+def test_caches_built_clients(monkeypatch):
+    built: list = []
+    _patch_create_llm(monkeypatch, built)
+    mw = mo.ModelOverrideMiddleware(config=object())
+    for _ in range(3):
+        mw.wrap_model_call(_FakeReq({"model": "m1"}, _FakeModel("d")), lambda r: None)
+    assert built == ["m1"]  # built once, cached thereafter
+
+
+@pytest.mark.asyncio
+async def test_async_swaps_model(monkeypatch):
+    built: list = []
+    _patch_create_llm(monkeypatch, built)
+    mw = mo.ModelOverrideMiddleware(config=object())
+    seen = {}
+
+    async def handler(r):
+        seen["model"] = r.model
+    await mw.awrap_model_call(_FakeReq({"model": "m2"}, _FakeModel("d")), handler)
+    assert built == ["m2"] and seen["model"].model_name == "m2"
+
+
+# ── integration: the override fires inside a real graph turn ───────────────────
+
+class _ToolFake(GenericFakeChatModel):
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+@pytest.mark.asyncio
+async def test_state_model_drives_the_turn(monkeypatch):
+    from unittest.mock import patch
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from graph.config import LangGraphConfig
+
+    calls: list = []
+
+    def _fake_create_llm(config, *, model_name=None):
+        calls.append(model_name)
+        return _ToolFake(messages=iter([AIMessage(content="ok")]))
+
+    with patch("graph.agent.create_llm", _fake_create_llm), \
+         patch("graph.llm.create_llm", _fake_create_llm):
+        from graph.agent import create_agent_graph
+        g = create_agent_graph(LangGraphConfig(), include_subagents=False, checkpointer=MemorySaver())
+        await g.ainvoke(
+            {"messages": [HumanMessage("hi")], "session_id": "s1", "model": "protolabs/fast"},
+            config={"configurable": {"thread_id": "t1"}},
+        )
+    # The middleware built a client for the tab's model during the turn.
+    assert "protolabs/fast" in calls

--- a/tests/test_prompt_cache.py
+++ b/tests/test_prompt_cache.py
@@ -104,15 +104,16 @@ def test_config_wires_middleware():
     # before_model-only gates that never wrap the model call).
     assert names[0] == "ToolCallRepairMiddleware"
     assert "WaitYieldMiddleware" in names
-    # PromptCacheMiddleware stays the outermost *model* wrapper — the first
-    # middleware that actually wraps the model call — so the cache breakpoint lands
-    # on the stable system prefix. (before_model-only gates ahead of it don't wrap.)
+    # ModelOverrideMiddleware is the outermost *model* wrapper — it swaps the
+    # per-tab model FIRST, so PromptCacheMiddleware (the next wrapper) sees the
+    # ACTUAL model when deciding whether to cache. ModelOverride doesn't touch the
+    # system message, so the cache breakpoint still lands on the stable prefix.
     wrappers = [
         m.__class__.__name__
         for m in mw
         if type(m).wrap_model_call is not AgentMiddleware.wrap_model_call
     ]
-    assert wrappers and wrappers[0] == "PromptCacheMiddleware"
+    assert wrappers[:2] == ["ModelOverrideMiddleware", "PromptCacheMiddleware"]
 
 
 @pytest.mark.asyncio


### PR DESCRIPTION
Each chat tab can now **override the globally configured model** and talk to its own. The composer's model dropdown becomes a **per-tab** control (sourced from the gateway's live model list): **Default** uses the configured model; any other choice is stored on that chat session and sent with every turn, so sibling tabs stay on their own models.

### Why
A single global model (set in Settings / host-config) meant every tab shared one model. This lets you run, say, a fast model in one tab and a reasoning model in another, simultaneously.

### Backend
- `ProtoAgentState` gains `model`; the chat layer stamps the turn's chosen model into the graph input on **every** turn (initial, dropped-scratch kicker, goal continuation).
- New **`ModelOverrideMiddleware`** (outermost `wrap_model_call`) swaps the lead model to `create_llm(config, model_name=…)` for that turn, **cached per model**. Unset → configured default. Outermost so `PromptCacheMiddleware` sees the *actual* model when deciding caching; it doesn't touch the system prompt, so the cache breakpoint is unchanged.
- Wired through **`/a2a`** (message `metadata.model`), **`/api/chat`** (a `model` field), and **`/v1/chat/completions`** (honors the request's `model` unless it's the agent's own advertised id).

### Frontend
- `ChatSession` gains a persisted `model`; `chatStore.setSessionModel` sets/clears it.
- `ComposerModelSelect` is now a per-tab picker (was a global settings writer); `streamChat` + `chat` send the session's model.

### Tests
- Middleware unit tests + a **real-graph integration** (the override fires mid-turn, proven via `create_llm` recording).
- Route threading for `/api/chat` + OpenAI-compat (incl. agent-id = default).
- Store setter + persistence; middleware-ordering test updated for the new outermost wrapper.
- **2079 backend + 84 web unit tests green**; `tsc` + `vite build` clean.

The cost-v1 DataPart already reports the model that actually ran, so per-tab routing is verifiable per turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)