### PR TITLE
feat(settings): model fields use the gateway list + cache the schema query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Settings model fields offer the gateway's model list.** The auxiliary model
+  (`routing.aux_model`) and transcription model (`knowledge.transcribe_model`)
+  were free-text boxes; they now render as comboboxes backed by the gateway's
+  live model list (a datalist of suggestions), matching the primary-model picker —
+  while staying free-text so a blank value or an alias the gateway doesn't list
+  still works. (`model.name` and `knowledge.embed_model` already used the list.)
+
+### Changed
+- **The settings schema is cached client-side.** `GET /api/settings/schema` does a
+  gateway round-trip server-side (it embeds the live model list for the pickers)
+  and is read by both the Settings surface and every chat tab's composer model
+  picker — so it now has a 5-minute React Query `staleTime` instead of refetching
+  (and re-hitting the gateway) on every mount/focus. A settings save still
+  invalidates it, so values stay fresh on change.
 - **Per-tab model selection.** Each chat tab can now talk to its own model,
   overriding the globally configured one. The composer's model dropdown is now a
   per-tab control (sourced from the gateway's live model list) — "Default" uses

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -105,6 +105,12 @@ export const settingsSchemaQuery = () =>
   queryOptions({
     queryKey: queryKeys.settings,
     queryFn: () => api.settingsSchema(),
+    // The schema GET does a gateway round-trip server-side (it embeds the live
+    // model list for the model pickers) and is read by the Settings surface AND
+    // every chat tab's composer picker — so without a staleTime React Query would
+    // refire it on every mount/focus. A save still invalidates it (freshness on
+    // change); between saves it's served from cache.
+    staleTime: 5 * 60_000,
   });
 
 // The inbound inbox (ADR 0003) — all pending tiers. Live: the panel invalidates

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -506,6 +506,32 @@ export function SettingInput({ field, value, onChange }: { field: SettingsField;
       />
     );
   }
+  // A free-text string field that carries gateway-sourced options (e.g.
+  // routing.aux_model, knowledge.transcribe_model) renders as a combobox: type
+  // any alias OR pick from the gateway's models. Unlike `select`, blank/arbitrary
+  // values stay valid (these fields aren't membership-checked), so a datalist of
+  // suggestions is the right control.
+  if (field.options.length) {
+    const listId = `${id}-models`;
+    return (
+      <>
+        <input
+          id={id}
+          className="setting-input"
+          type="text"
+          list={listId}
+          placeholder="type or pick a model"
+          value={typeof value === "string" ? value : value === undefined || value === null ? "" : String(value)}
+          onChange={(e) => onChange(e.target.value)}
+        />
+        <datalist id={listId}>
+          {field.options.map((opt) => (
+            <option key={opt} value={opt} />
+          ))}
+        </datalist>
+      </>
+    );
+  }
   return (
     <Input
       id={id}

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -76,7 +76,7 @@ FIELDS: list[Field] = [
     # ── Routing ──────────────────────────────────────────────────────────────
     Field("routing.aux_model", "aux_model", "Auxiliary (fast) model", "string", "Routing",
           "Cheap/fast alias for summarization, goal-verification, and subagents. "
-          "Blank = use the main model.", scope="host"),
+          "Blank = use the main model.", options_source="models", scope="host"),
     Field("routing.fallback_models", "routing_fallback_models", "Fallback models", "string_list",
           "Routing", "Retried in order when the primary model errors.", scope="host"),
 
@@ -134,7 +134,8 @@ FIELDS: list[Field] = [
           "Knowledge",
           "Gateway speech-to-text model for audio/video ingestion (e.g. whisper-1), via the "
           "OpenAI-compatible /audio/transcriptions endpoint. Blank disables audio/video import. "
-          "Video needs ffmpeg on the host to extract the audio track.", restart=True),
+          "Video needs ffmpeg on the host to extract the audio track.",
+          options_source="models", restart=True),
     Field("knowledge.recall_preview_chars", "knowledge_recall_preview_chars", "Recall preview length",
           "number", "Knowledge",
           "How many characters of each recalled chunk the model sees. Bigger carries more "

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -28,6 +28,11 @@ def test_schema_groups_and_values():
     # The model select is populated from the probed options.
     model = next(f for f in fields if f["key"] == "model.name")
     assert model["type"] == "select" and model["options"] == ["a", "b"]
+    # The free-text model fields ALSO carry the gateway list (as datalist
+    # suggestions) — they stay `string` (blank/any alias allowed), not `select`.
+    for key in ("routing.aux_model", "knowledge.transcribe_model"):
+        f = next(f for f in fields if f["key"] == key)
+        assert f["type"] == "string" and f["options"] == ["a", "b"]
 
 
 def test_groups_carry_category_in_taxonomy_order():


### PR DESCRIPTION
Follow-up to the per-tab model work: an audit of the **settings** model pickers, ensuring they all use the gateway model endpoint.

### Audit
| Field | Before | After |
|---|---|---|
| `model.name` (Primary) | gateway `select` ✅ | unchanged |
| `knowledge.embed_model` | gateway `select` ✅ | unchanged |
| `routing.aux_model` (Auxiliary) | free-text ❌ | **gateway combobox** |
| `knowledge.transcribe_model` | free-text ❌ | **gateway combobox** |
| `routing.fallback_models` | free-text list | unchanged (it's a multi-value `string_list`; a datalist doesn't fit a textarea — left as a follow-up) |

### Changes
- `routing.aux_model` + `knowledge.transcribe_model` get `options_source="models"`, so `build_schema` fills their options from `list_gateway_models`. They render as **datalist comboboxes** — pick from the gateway's models OR type any alias — and stay `string`, so a blank value ("use the main model") or an unlisted alias remain valid (string fields aren't membership-checked, unlike `select`).
- `SettingsCategory` renders any string field carrying options as that combobox.

### Caching
`GET /api/settings/schema` does a **gateway round-trip server-side** (it embeds the live model list for the pickers) and is read by the Settings surface *and* every chat tab's composer picker — but `settingsSchemaQuery` had no `staleTime`, so it refired (and re-hit the gateway) on every mount/focus. Added a **5-minute `staleTime`**; a settings save still invalidates it, so values stay fresh on change.

### Tests
- Schema test asserts `aux_model` + `transcribe_model` carry the gateway options and stay `string`.
- **2079 backend, 84 web unit, 105 e2e green**; tsc + ruff + import-linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)