### PR TITLE
fix(goals): set_goal rejects an unknown verifier (no more unsatisfiable goals)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **`set_goal` rejects an unknown verifier instead of creating an unsatisfiable
+  goal.** The tool only checked the verifier *type*, so a non-existent `check`
+  (e.g. `"manual"`) created a goal that could never pass — it spun toward the
+  iteration cap and ended `unachievable`. It now validates `check` against the
+  registered plugin verifiers up front and lists the available ones, so the agent
+  picks a real verifier. (Found driving the live agent.)
+
 ### Added
 - **Settings model fields offer the gateway's model list.** The auxiliary model
   (`routing.aux_model`) and transcription model (`knowledge.transcribe_model`)

--- a/graph/goals/verifiers.py
+++ b/graph/goals/verifiers.py
@@ -228,6 +228,12 @@ def set_plugin_verifiers(mapping: dict | None) -> None:
     _PLUGIN_VERIFIERS = dict(mapping or {})
 
 
+def plugin_verifier_names() -> list[str]:
+    """Registered plugin-verifier names (``<plugin-id>:<name>``), sorted. Lets the
+    set_goal tool reject an unknown verifier before creating an unsatisfiable goal."""
+    return sorted(_PLUGIN_VERIFIERS)
+
+
 async def _verify_plugin(spec: dict, ctx: VerifyContext) -> VerifyResult:
     """Dispatch a ``{"type":"plugin","check":"<id>:<name>","args":{…}}`` goal to a
     plugin-registered verifier. ``args`` are declarative data the verifier validates."""

--- a/tests/test_set_goal_tool.py
+++ b/tests/test_set_goal_tool.py
@@ -9,6 +9,12 @@ from runtime.state import STATE
 from tools.lg_tools import _build_set_goal_tool, get_all_tools
 
 
+def _register_verifiers(monkeypatch, *names):
+    """Register plugin verifiers so set_goal_safe's name check accepts them (the
+    registry is empty in unit tests). Only the keys matter for validation."""
+    monkeypatch.setattr("graph.goals.verifiers._PLUGIN_VERIFIERS", {n: object() for n in names})
+
+
 def test_get_all_tools_gates_set_goal_on_goal_enabled():
     on = {t.name for t in get_all_tools(goal_enabled=True)}
     off = {t.name for t in get_all_tools(goal_enabled=False)}
@@ -59,6 +65,7 @@ def test_set_goal_reads_session_from_injected_state(monkeypatch, tmp_path):
     ctrl = GoalController(None, GoalStore(base_dir=str(tmp_path)))
     monkeypatch.setattr(STATE, "goal_controller", ctrl)
     monkeypatch.setattr(tracing, "current_session_id", lambda: "")  # contextvar empty
+    _register_verifiers(monkeypatch, "spacetraders:credits")
     out = _build_set_goal_tool().invoke(
         {"condition": "reach 1M", "check": "spacetraders:credits",
          "check_args": {"min": 1_000_000}, "state": {"session_id": "s-injected"}}
@@ -84,6 +91,7 @@ def test_set_goal_sets_a_plugin_verified_goal(monkeypatch, tmp_path):
     ctrl = GoalController(None, GoalStore(base_dir=str(tmp_path)))
     monkeypatch.setattr(STATE, "goal_controller", ctrl)
     monkeypatch.setattr(tracing, "current_session_id", lambda: "s1")
+    _register_verifiers(monkeypatch, "spacetraders:credits")
     out = _build_set_goal_tool().invoke(
         {"condition": "reach 1M", "check": "spacetraders:credits", "check_args": {"min": 1_000_000}}
     )
@@ -91,3 +99,17 @@ def test_set_goal_sets_a_plugin_verified_goal(monkeypatch, tmp_path):
     g = ctrl.active_goal("s1")
     assert g is not None
     assert g.verifier == {"type": "plugin", "check": "spacetraders:credits", "args": {"min": 1_000_000}}
+
+
+def test_set_goal_rejects_an_unknown_verifier(monkeypatch, tmp_path):
+    # An unregistered verifier must be rejected up front — otherwise set_goal
+    # creates a goal that can never pass and spins to the iteration cap (the
+    # 'unknown plugin verifier' / unachievable loop found on the live agent).
+    ctrl = GoalController(None, GoalStore(base_dir=str(tmp_path)))
+    monkeypatch.setattr(STATE, "goal_controller", ctrl)
+    monkeypatch.setattr(tracing, "current_session_id", lambda: "s1")
+    _register_verifiers(monkeypatch, "spacetraders:credits")  # 'manual' is NOT registered
+    out = _build_set_goal_tool().invoke({"condition": "reply DONE", "check": "manual"})
+    assert "unknown plugin verifier" in out.lower()
+    assert "spacetraders:credits" in out  # lists what IS available
+    assert ctrl.active_goal("s1") is None  # no unsatisfiable goal created

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -821,6 +821,14 @@ def _build_set_goal_tool():
         session_id = _session_id_from(state)  # injected graph state, not the contextvar
         if not session_id:
             return "No active session — set_goal can only run during a turn."
+        # Reject an unknown verifier up front. Otherwise the goal is created but can
+        # never pass — it just spins to the iteration cap, flagged 'unachievable'
+        # (the live failure mode). List the registered ones so the agent can choose.
+        from graph.goals.verifiers import plugin_verifier_names
+        known = plugin_verifier_names()
+        if check not in known:
+            avail = ", ".join(known) if known else "(none registered — enable a plugin that contributes a verifier)"
+            return f"Error: unknown plugin verifier {check!r}. Available verifiers: {avail}."
         verifier = {"type": "plugin", "check": check, "args": check_args or {}}
         _ok, msg = STATE.goal_controller.set_goal_safe(
             session_id, condition, verifier, max_iterations,


### PR DESCRIPTION
Found while driving the live agent (during broader subsystem testing): the `set_goal` tool accepted `check="manual"` — not a registered plugin verifier — and **created the goal anyway**. It could never pass (`run_verifier` returns "unknown plugin verifier" each tick), so it spun toward the iteration cap and ended `unachievable`, burning turns.

`set_goal_safe` only validated the verifier **type** (`plugin`) and that `check` was non-empty — never that the name resolves to a registered verifier.

### Fix
- New `graph.goals.verifiers.plugin_verifier_names()` exposes the registered verifier set.
- The **`set_goal` tool** validates `check` against it before creating the goal, returning `unknown plugin verifier <x>. Available verifiers: …` so the agent can pick a real one.

Validation lives in the **tool** (the agent-facing path), not `set_goal_safe` — so the operator `/goal` and REST/plugin callers keep their existing graceful runtime fallback (a bad verifier still fails safe), and the controller test suite is untouched.

### Tests
- `test_set_goal_rejects_an_unknown_verifier` (rejects + lists available + creates no goal); the goal-setting tool tests now register their verifier.
- **2080 backend green**; ruff + import-linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)