### PR TITLE
fix(scheduler): retry the jobs.db owner-lock instead of giving up at boot (bd-1o9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **The scheduler retries the jobs.db owner-lock instead of giving up.** If the
+  owner-lock was briefly held when the scheduler started — common on a
+  restart/redeploy where the previous process freed the port but is still
+  draining an in-flight turn — it logged "owned by another live instance" and
+  **never started**, so `wait` resumes (ADR 0053) and every scheduled task
+  silently didn't fire until an unrelated config reload happened to re-init it. It
+  now retries in the background (~15s) and starts polling the moment the lock
+  frees, so a contended boot self-heals in seconds. (Found driving the live agent
+  — a `wait` sat 16 min overdue after a restart.)
 - **`set_goal` rejects an unknown verifier instead of creating an unsatisfiable
   goal.** The tool only checked the verifier *type*, so a non-existent `check`
   (e.g. `"manual"`) created a goal that could never pass — it spun toward the

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -200,6 +200,10 @@ class LocalScheduler:
 
     name = "local"
 
+    # How often start() retries the jobs.db owner-lock when it's held at boot (a
+    # transient restart/redeploy overlap) before it can begin polling.
+    _LOCK_RETRY_SECONDS = 15.0
+
     def __init__(
         self,
         agent_name: str,
@@ -339,12 +343,21 @@ class LocalScheduler:
         # scheduler (the rest of the agent still serves normally).
         self._lock_fd = _acquire_jobs_lock(self.path)
         if self._lock_fd is None:
-            log.error(
-                "[scheduler] jobs.db at %s is already owned by another live instance — "
-                "not starting the scheduler. Run each instance with a distinct "
-                "PROTOAGENT_INSTANCE (or agent name) so they don't share a jobs.db.",
-                self.path,
+            # The jobs.db is owned by another live instance RIGHT NOW. Don't give
+            # up permanently — a brief overlap is common (a restart/redeploy where
+            # the old process freed the port but is still draining an in-flight
+            # turn keeps holding the flock). Retry in the background until it's
+            # free, then start polling, so a contended boot self-heals in seconds
+            # instead of staying scheduler-less until the next config reload. A
+            # genuinely co-located instance just keeps waiting harmlessly.
+            log.warning(
+                "[scheduler] jobs.db at %s is owned by another instance — retrying "
+                "every %.0fs in the background until it's free (if this persists, run "
+                "each instance with a distinct PROTOAGENT_INSTANCE).",
+                self.path, self._LOCK_RETRY_SECONDS,
             )
+            self._stopping = False
+            self._task = asyncio.create_task(self._await_lock_then_poll(), name="scheduler.local.lockwait")
             return
         self._stopping = False
         self._recover_missed_fires()
@@ -353,6 +366,24 @@ class LocalScheduler:
             "[scheduler] local backend started: agent=%s db=%s",
             self.agent_name, self.path,
         )
+
+    async def _await_lock_then_poll(self) -> None:
+        """Retry the owner-lock until acquired (or stopped), then poll. Lets a
+        scheduler that booted into a momentary lock contention recover on its own."""
+        while not self._stopping:
+            await asyncio.sleep(self._LOCK_RETRY_SECONDS)
+            if self._stopping:
+                return
+            fd = _acquire_jobs_lock(self.path)
+            if fd is not None:
+                self._lock_fd = fd
+                log.info(
+                    "[scheduler] acquired jobs.db owner-lock after waiting — starting poll loop "
+                    "(agent=%s db=%s)", self.agent_name, self.path,
+                )
+                self._recover_missed_fires()
+                await self._poll_loop()
+                return
 
     async def stop(self) -> None:
         self._stopping = True

--- a/tests/test_instance_scoping.py
+++ b/tests/test_instance_scoping.py
@@ -73,24 +73,28 @@ def test_jobs_lock_excludes_a_second_holder(tmp_path):
     _release_jobs_lock(db, again)
 
 
-def test_second_scheduler_on_same_db_does_not_start_polling(tmp_path):
+def test_second_scheduler_on_same_db_does_not_poll(tmp_path):
     async def run():
         a = LocalScheduler("agentA", invoke_url="http://127.0.0.1:7870", db_dir=str(tmp_path))
         b = LocalScheduler("agentA", invoke_url="http://127.0.0.1:7871", db_dir=str(tmp_path))
         assert a.path == b.path  # same jobs.db (same agent + dir)
         await a.start()
-        await b.start()  # interlock: b must NOT start a poll task
-        started = (a._task is not None, b._task is not None)
+        await b.start()  # interlock: b must NOT acquire the lock / poll A's db
+        # A owns the lock and polls. B does NOT acquire it (so it never races A),
+        # but it doesn't give up either — it schedules a background retry (so a
+        # transient boot-time overlap self-heals rather than killing the scheduler).
+        a_owns = a._lock_fd is not None
+        b_waits = b._lock_fd is None and b._task is not None
         await a.stop()
         await b.stop()
         # After A releases, a fresh scheduler can claim it.
         c = LocalScheduler("agentA", invoke_url="http://127.0.0.1:7872", db_dir=str(tmp_path))
         await c.start()
-        c_started = c._task is not None
+        c_owns = c._lock_fd is not None
         await c.stop()
-        return started, c_started
+        return a_owns, b_waits, c_owns
 
-    (a_started, b_started), c_started = asyncio.run(run())
-    assert a_started is True
-    assert b_started is False
-    assert c_started is True
+    a_owns, b_waits, c_owns = asyncio.run(run())
+    assert a_owns is True
+    assert b_waits is True  # B waits for the lock (retry), never polls A's db
+    assert c_owns is True

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -251,6 +251,32 @@ async def test_start_stop_idempotent(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_start_retries_owner_lock_then_polls(tmp_path):
+    """A jobs.db lock held at boot (a restart/redeploy overlap) must NOT
+    permanently skip the scheduler. start() schedules a background retry and
+    begins polling once the lock frees — instead of staying off until a reload."""
+    import scheduler.local as sl
+
+    s = _make_scheduler(tmp_path)
+    s._LOCK_RETRY_SECONDS = 0.05  # don't wait the real 15s
+    key = str(s.path)
+    sl._LOCKED_PATHS.add(key)  # simulate another live instance owning the jobs.db
+    try:
+        await s.start()
+        assert s._task is not None  # scheduled a retry — did NOT give up
+        assert s._lock_fd is None   # not acquired yet (still held)
+
+        sl._LOCKED_PATHS.discard(key)  # the other instance exits → lock frees
+        for _ in range(60):            # let the background retry acquire it
+            if s._lock_fd is not None:
+                break
+            await asyncio.sleep(0.05)
+        assert s._lock_fd is not None  # acquired after waiting → now polling
+    finally:
+        await s.stop()
+
+
+@pytest.mark.asyncio
 async def test_due_job_fires(tmp_path, monkeypatch):
     """End-to-end: an ISO job in the past gets picked up and POSTs to /a2a."""
     s = _make_scheduler(tmp_path)


### PR DESCRIPTION
Found driving the live agent during broader subsystem testing: after a restart the scheduler logged **"jobs.db … already owned by another live instance — not starting the scheduler"** and stayed **off for ~16 minutes** — a `wait` job sat overdue with an empty `last_fire` — until an unrelated config hot-reload re-ran `start()` and finally acquired the lock.

### Root cause
`LocalScheduler.start()` took the non-blocking `fcntl.flock` exactly once and, on failure, **logged + returned (no retry)**. A brief overlap is common: a restart/redeploy where the **old** process freed the port (so a port-wait restart proceeds) but is still draining an in-flight turn keeps holding the flock. The new server's scheduler then never started — `wait` resumes (ADR 0053) and **all scheduled tasks silently didn't fire** — until something happened to re-init it. That's a real production risk (a Docker redeploy / watchtower with momentary container overlap).

### Fix
When the lock is held at `start()`, schedule a background retry (`_await_lock_then_poll`, every `_LOCK_RETRY_SECONDS = 15s`) instead of giving up. It acquires → recovers missed fires → polls the moment the lock frees, so a contended boot self-heals in seconds. A genuinely co-located instance just keeps waiting harmlessly (throttled warning). The two-instance interlock invariant is preserved — the waiter has no lock, so it never polls the shared db.

### Tests
- New `test_start_retries_owner_lock_then_polls` (locked at boot → schedules a retry, acquires + polls once freed).
- `test_instance_scoping` interlock test updated: the second scheduler **waits** (retry) rather than giving up, and still never polls the shared db.
- **2081 backend green**; ruff + import-linter clean.

Also filed bd-3vp (P3, separate): the startup catch-up can fire overdue jobs before Uvicorn is accepting connections → a noisy (self-healing) connection-refused. Not fixed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)