### PR TITLE
chore(followups): quiet scheduler startup catch-up (bd-3vp) + fallback_models gateway picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **The fallback-models setting picks from the gateway list.**
+  `routing.fallback_models` was a plain newline textarea; it now renders as a list
+  of model comboboxes (one row per model + a blank row to add), each backed by the
+  gateway's live model list — so you order fallbacks by picking real aliases (or
+  typing any). Completes the settings-model-picker pass (`model.name`,
+  `aux_model`, `transcribe_model`, and now `fallback_models` all use the gateway).
+
 ### Fixed
+- **Scheduler startup catch-up no longer logs scary tracebacks.** When the
+  scheduler's catch-up fires an overdue job before Uvicorn is accepting
+  connections, the POST to the agent's own `/a2a` is refused — an expected,
+  self-healing condition (the poll loop retries next tick). It now logs a concise
+  "agent not reachable yet; will retry" at INFO instead of an ERROR
+  `fire exception` traceback.
 - **The scheduler retries the jobs.db owner-lock instead of giving up.** If the
   owner-lock was briefly held when the scheduler started — common on a
   restart/redeploy where the previous process freed the port but is still

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -467,6 +467,38 @@ export function SettingInput({ field, value, onChange }: { field: SettingsField;
       </Select>
     );
   }
+  // A string_list backed by gateway options (e.g. routing.fallback_models)
+  // renders as a list of datalist comboboxes — one per value plus a trailing
+  // blank row to add — so you pick models from the gateway (or type any alias),
+  // ordered. Clearing a row removes it.
+  if (field.type === "string_list" && field.options.length) {
+    const items = Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+    const listId = `${id}-models`;
+    const update = (i: number, v: string) => {
+      const next = items.slice();
+      if (v) next[i] = v;
+      else next.splice(i, 1);
+      onChange(next);
+    };
+    return (
+      <div id={id} className="setting-list" style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
+        {[...items, ""].map((item, i) => (
+          <input
+            key={i}
+            className="setting-input"
+            type="text"
+            list={listId}
+            value={item}
+            placeholder={i === items.length ? "add a model…" : ""}
+            onChange={(e) => update(i, e.target.value)}
+          />
+        ))}
+        <datalist id={listId}>
+          {field.options.map((opt) => <option key={opt} value={opt} />)}
+        </datalist>
+      </div>
+    );
+  }
   if (field.type === "string_list") {
     const text = Array.isArray(value) ? value.join("\n") : "";
     return (

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -78,7 +78,8 @@ FIELDS: list[Field] = [
           "Cheap/fast alias for summarization, goal-verification, and subagents. "
           "Blank = use the main model.", options_source="models", scope="host"),
     Field("routing.fallback_models", "routing_fallback_models", "Fallback models", "string_list",
-          "Routing", "Retried in order when the primary model errors.", scope="host"),
+          "Routing", "Retried in order when the primary model errors.",
+          options_source="models", scope="host"),
 
     # ── Context compaction ───────────────────────────────────────────────────
     Field("compaction.enabled", "compaction_enabled", "Enable compaction", "bool", "Compaction",

--- a/scheduler/local.py
+++ b/scheduler/local.py
@@ -625,6 +625,16 @@ class LocalScheduler:
                 return False
             log.info("[scheduler] fired job %s", job.id)
             return True
+        except (httpx.ConnectError, httpx.ConnectTimeout) as exc:
+            # The agent's own HTTP server isn't accepting connections yet — common
+            # when the scheduler's startup catch-up runs before Uvicorn finishes
+            # binding. Expected and self-healing (the poll loop retries next tick),
+            # so log concisely instead of a scary ERROR traceback (bd-3vp).
+            log.info(
+                "[scheduler] deferring fire for job %s — agent not reachable yet (%s); will retry",
+                job.id, type(exc).__name__,
+            )
+            return False
         except Exception:  # noqa: BLE001
             log.exception("[scheduler] fire exception for job %s", job.id)
             return False

--- a/tests/test_scheduler_local.py
+++ b/tests/test_scheduler_local.py
@@ -277,6 +277,39 @@ async def test_start_retries_owner_lock_then_polls(tmp_path):
 
 
 @pytest.mark.asyncio
+async def test_fire_defers_quietly_when_agent_not_reachable(tmp_path, monkeypatch, caplog):
+    """bd-3vp: a connection error to our own /a2a (Uvicorn not accepting yet during
+    startup catch-up) is an expected, self-healing condition — _fire returns False
+    and logs concisely, not a scary 'fire exception' traceback."""
+    import httpx
+
+    s = _make_scheduler(tmp_path)
+    job = s.add_job("X", (datetime.now(UTC) - timedelta(seconds=1)).isoformat(), job_id="jx")
+
+    class _Refused:
+        def __init__(self, *_a, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def post(self, *_a, **_kw):
+            raise httpx.ConnectError("connection refused")
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Refused)
+
+    with caplog.at_level("INFO"):
+        ok = await s._fire(job)
+    assert ok is False
+    msgs = " ".join(r.getMessage() for r in caplog.records)
+    assert "deferring fire" in msgs
+    assert "fire exception" not in msgs  # no error-level traceback for a not-ready server
+
+
+@pytest.mark.asyncio
 async def test_due_job_fires(tmp_path, monkeypatch):
     """End-to-end: an ISO job in the past gets picked up and POSTs to /a2a."""
     s = _make_scheduler(tmp_path)

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -33,6 +33,9 @@ def test_schema_groups_and_values():
     for key in ("routing.aux_model", "knowledge.transcribe_model"):
         f = next(f for f in fields if f["key"] == key)
         assert f["type"] == "string" and f["options"] == ["a", "b"]
+    # The fallback list carries the gateway options too (rendered as combobox rows).
+    fallback = next(f for f in fields if f["key"] == "routing.fallback_models")
+    assert fallback["type"] == "string_list" and fallback["options"] == ["a", "b"]
 
 
 def test_groups_carry_category_in_taxonomy_order():


### PR DESCRIPTION
The two deferred follow-ups from the broader subsystem-testing pass.

### bd-3vp — scheduler startup catch-up noise
When the scheduler's catch-up fires an overdue job before Uvicorn is accepting connections, the POST to the agent's own `/a2a` is refused. It's **expected and self-healing** (the poll loop retries next tick and the job fires), but `_fire` logged a full ERROR `fire exception` traceback each time. Now `httpx.ConnectError`/`ConnectTimeout` is caught separately and logged concisely at INFO ("agent not reachable yet; will retry"); other exceptions still `log.exception`. Test added.

### fallback_models gateway picker
`routing.fallback_models` was a plain newline textarea. It now carries `options_source="models"`, and the settings UI renders an **options-backed `string_list`** as a list of **datalist comboboxes** (one row per model + a blank row to add) — so you order fallbacks by picking real gateway aliases (or typing any). This completes the settings-model-picker pass: `model.name`, `aux_model`, `transcribe_model`, and now `fallback_models` all use the gateway list.

### Tests
- New `test_fire_defers_quietly_when_agent_not_reachable` (ConnectError → returns False, concise INFO, no traceback).
- Schema test asserts `fallback_models` carries gateway options + stays `string_list`.
- **2082 backend + web e2e green**; tsc + ruff + import-linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)