### PR TITLE
fix(inbox): mark a fired now-item delivered so check_inbox doesn't re-surface it (bd-jus)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Inbox: a fired `now` item is now marked delivered.** A now-priority inbox
+  item (e.g. an ADR 0050 background-completion notification) fires an Activity
+  turn on arrival, but it was never marked delivered — so it lingered as pending
+  forever and the next `check_inbox` re-surfaced (and could re-act on) a backlog
+  of already-handled notifications. A successful fire now marks the item
+  delivered; a failed fire stays pending so `check_inbox` remains its fallback.
+
 ### Added
 - **The fallback-models setting picks from the gateway list.**
   `routing.fallback_models` was a plain newline textarea; it now renders as a list

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -387,6 +387,15 @@ async def _operator_inbox_add(payload: dict) -> dict:
         "source": item.get("source") or "", "text": item["text"],
     })
     fired = await _fire_activity_from_inbox(item) if item["priority"] == "now" else False
+    if fired:
+        # A now-item that fired has been delivered to the agent (its Activity turn
+        # ran) — mark it delivered so it doesn't linger as pending and get
+        # re-surfaced by the next check_inbox (bd-jus). A FAILED fire stays pending
+        # so check_inbox remains the fallback delivery path for it.
+        try:
+            STATE.inbox_store.mark_delivered([item["id"]])
+        except Exception:  # noqa: BLE001 — best-effort; a missed mark just re-surfaces
+            log.warning("[inbox] could not mark fired now-item %s delivered", item.get("id"))
     return {"ok": True, "item": item, "fired": fired}
 
 

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -110,6 +110,46 @@ def test_check_inbox_tool_returns_and_marks_delivered(tmp_path):
     assert asyncio.run(check_inbox.ainvoke({"priority_floor": "next"})) == "Inbox empty."
 
 
+# ── now-item fire marks delivered (bd-jus) ───────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_fired_now_item_is_marked_delivered(tmp_path, monkeypatch):
+    """A now-item whose Activity turn fired must be marked delivered, not left
+    pending to be re-surfaced (and re-acted-on) by the next check_inbox."""
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    store = _store(tmp_path)
+    monkeypatch.setattr(rs.STATE, "inbox_store", store, raising=False)
+
+    async def _fire_ok(_item):
+        return True
+    monkeypatch.setattr(ch, "_fire_activity_from_inbox", _fire_ok)
+
+    res = await ch._operator_inbox_add({"text": "bg done", "priority": "now", "source": "background"})
+    assert res["fired"] is True
+    assert store.list(priority_floor="later") == []  # delivered → nothing pending
+
+
+@pytest.mark.asyncio
+async def test_failed_now_fire_stays_pending(tmp_path, monkeypatch):
+    """A now-item whose fire FAILED stays pending so check_inbox is the fallback."""
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    store = _store(tmp_path)
+    monkeypatch.setattr(rs.STATE, "inbox_store", store, raising=False)
+
+    async def _fire_fail(_item):
+        return False
+    monkeypatch.setattr(ch, "_fire_activity_from_inbox", _fire_fail)
+
+    res = await ch._operator_inbox_add({"text": "bg done", "priority": "now"})
+    assert res["fired"] is False
+    assert len(store.list(priority_floor="later")) == 1  # still pending for check_inbox
+
+
 # ── POST /api/inbox route ────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Found probing the inbox subsystem on the live agent: **5 `now`-priority items** (all `source=background` — ADR 0050 background-completion notifications) sat **pending** with `delivered_at=None` for ~20h.

A `now` item fires an Activity turn on arrival (`check_inbox`'s own docstring says *"`now` items already fired a turn"*), but `_operator_inbox_add` **never marked it delivered**. So every fired `now` item lingers as pending, and the next `check_inbox` (default floor `next` = now+next) lists + `mark_delivered`s the whole backlog — re-surfacing, and potentially re-acting on, already-handled notifications. The pending count also grows unbounded with handled items.

### Fix
A **successful** fire now marks the item delivered (it *was* delivered to the agent via the turn). A **failed** fire leaves it pending, so `check_inbox` remains the fallback delivery path for an unfired `now` item. The existing backlog self-clears on the next `check_inbox`; delivered items stay viewable via `include_delivered`, so nothing is lost.

### Tests
- `test_fired_now_item_is_marked_delivered` (fired → not pending).
- `test_failed_now_fire_stays_pending` (failed fire → still pending for check_inbox).
- **2084 backend green**; ruff + import-linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)