### PR TITLE
feat(knowledge): surface the RRF relevance score in search results (#1043)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Knowledge search returns the RRF relevance score.** `/api/knowledge/search`
+  results (on a hybrid store) now carry a `score` — the RRF fused relevance used
+  to rank them — so consumers can show or threshold relevance instead of getting
+  bare ordered rows. Null on the plain-FTS store / `list_chunks` (unranked). (#1043)
+
 ### Fixed
 - **Inbox: a fired `now` item is now marked delivered.** A now-priority inbox
   item (e.g. an ADR 0050 background-completion notification) fires an Activity

--- a/knowledge/hybrid_store.py
+++ b/knowledge/hybrid_store.py
@@ -331,12 +331,10 @@ class HybridKnowledgeStore(KnowledgeStore):
         ordered = ordered[:k]
         results: list[dict] = []
         for cid in ordered:
-            if cid in by_id:
-                results.append(by_id[cid])
-            else:
-                hydrated = self._hydrate_chunk(cid)
-                if hydrated is not None:
-                    results.append(hydrated)
+            item = by_id.get(cid) or self._hydrate_chunk(cid)
+            if item is not None:
+                item["score"] = round(scores[cid], 6)  # RRF fused relevance (#1043)
+                results.append(item)
         return results
 
     def _hydrate_chunk(self, chunk_id: int) -> dict | None:

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -38,6 +38,9 @@ def _knowledge_row(d: dict) -> dict:
         "source_type": d.get("source_type"),
         "finding_type": d.get("finding_type"),
         "created_at": d.get("created_at"),
+        # RRF relevance score on a hybrid store (#1043); null for unranked rows
+        # (plain FTS store / list_chunks).
+        "score": d.get("score"),
     }
 
 

--- a/tests/test_hybrid_store.py
+++ b/tests/test_hybrid_store.py
@@ -48,6 +48,17 @@ def test_hybrid_returns_relevant_chunk(tmp_path):
     assert any("calculator" in r["content"] for r in results)
 
 
+def test_hybrid_results_carry_an_rrf_score(tmp_path):
+    # #1043: a hybrid result exposes its RRF fused score, descending by rank.
+    store = HybridKnowledgeStore(_db(tmp_path), embed_fn=_bow_embed)
+    store.add_chunk("use the calculator for math", domain="general")
+    store.add_chunk("tomorrow's weather forecast", domain="general")
+    results = store.search("math calculator", k=2)
+    scores = [r.get("score") for r in results]
+    assert all(isinstance(s, float) for s in scores)  # every hit scored
+    assert scores == sorted(scores, reverse=True)      # ranked high→low
+
+
 def test_vector_only_hit_is_hydrated(tmp_path):
     """A chunk FTS5 can't match (no shared tokens) still surfaces via the
     vector ranking, and is hydrated into a full result dict."""


### PR DESCRIPTION
Closes #1043.

The hybrid store computes RRF fused scores to rank `/api/knowledge/search` results but **dropped them** — the API returned bare ordered rows with no relevance signal.

- `HybridKnowledgeStore.search` now attaches each hit's RRF fused `score`.
- `_knowledge_row` surfaces it as `score` (null on the plain-FTS store / `list_chunks`, which are unranked).

Lets the console show/threshold relevance and makes retrieval quality eyeballable without re-running the eval harness.

**Test:** hybrid results carry a float `score`, ranked high→low. 2085 backend green; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)