### PR TITLE
feat(chat): surface wait/scheduled resumes live in the chat tab (bd-k02, ADR 0053 Slice 2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   results (on a hybrid store) now carry a `score` — the RRF fused relevance used
   to rank them — so consumers can show or threshold relevance instead of getting
   bare ordered rows. Null on the plain-FTS store / `list_chunks` (unranked). (#1043)
+- **`wait` resumes now appear live in the chat tab (ADR 0053 Slice 2).** When a
+  `wait` (or scheduled task) resumes server-side, the scheduler fires a fresh turn
+  into the originating chat thread — but the browser only renders turns it
+  streamed, so the resumed turn was invisible until the next message. The terminal
+  hook now pushes a `chat.resumed` event for a scheduler-fired turn that lands in a
+  chat session, and a `ChatResumeWatch` appends the resumed answer to that tab live
+  (display-only; the backend still owns history). Closes bd-k02.
 
 ### Fixed
 - **Inbox: a fired `now` item is now marked delivered.** A now-priority inbox

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -64,6 +64,7 @@ import { lazy, Suspense, useEffect, useRef, useState, useSyncExternalStore } fro
 import type { ComponentType, LazyExoticComponent, ReactNode } from "react";
 import { FleetTurnWatch } from "./FleetTurnWatch";
 import { BackgroundWatch } from "./BackgroundWatch";
+import { ChatResumeWatch } from "./ChatResumeWatch";
 import { BackgroundJobs } from "./BackgroundJobs";
 import { ProtoLabsIcon } from "./ProtoLabsIcon";
 import { AuthGate } from "./AuthGate";
@@ -661,6 +662,9 @@ export function App() {
           live into the spawning chat (a system message + toast) if it's still open —
           instead of waiting for the next message to surface it. */}
       <BackgroundWatch />
+      {/* wait/scheduled resumes (ADR 0053, bd-k02): a server-fired resume turn lands in
+          the chat thread; surface it live in the open tab instead of on next interaction. */}
+      <ChatResumeWatch />
       {/* Tenant guard: if a DIFFERENT backend now owns this origin (the HUB re-keyed —
           a fork booted on the old port), drop the previous tenant's persisted chat view.
           Keyed on the HUB's uid, NOT the focused agent's — switching fleet agents keeps

--- a/apps/web/src/app/ChatResumeWatch.tsx
+++ b/apps/web/src/app/ChatResumeWatch.tsx
@@ -1,0 +1,49 @@
+import { useToast } from "@protolabsai/ui/overlays";
+import { useEffect } from "react";
+
+import { chatStore } from "../chat/chat-store";
+import { onTopic } from "../lib/events";
+import { notifyIfHidden } from "../lib/notify";
+import type { ChatMessage } from "../lib/types";
+
+// Live surfacing of a `wait` / scheduled RESUME (ADR 0053, bd-k02) into the chat tab.
+// A `wait` yields and is re-triggered server-side by the scheduler, which fires a fresh
+// A2A turn into the SAME chat session — but the browser only renders turns it streamed,
+// so the resumed turn is invisible until the user next interacts. The server pushes
+// `chat.resumed` {session_id, text, task_id}; we append the resumed answer to that
+// session as a normal assistant message (DISPLAY-ONLY — the backend owns conversation
+// history, so this never double-feeds the model) and toast. Dedup by task_id so an
+// EventSource replay (ADR 0039 ring buffer) on reconnect is idempotent.
+
+const seen = new Set<string>();
+
+export function ChatResumeWatch() {
+  const toast = useToast();
+
+  useEffect(() => {
+    return onTopic("chat.resumed", (data) => {
+      const session = String(data.session_id ?? "");
+      const text = String(data.text ?? "");
+      const taskId = String(data.task_id ?? "");
+      const key = taskId || `${session}:${text.slice(0, 32)}`;
+      if (!session || !text || seen.has(key)) return;
+      seen.add(key);
+
+      const target = chatStore.getSnapshot().sessions.find((s) => s.id === session);
+      if (!target) return; // chat not open in this window — nothing to surface here
+
+      const msg: ChatMessage = {
+        id: `resume-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
+        role: "assistant",
+        content: text,
+        createdAt: Date.now(),
+        status: "done",
+      };
+      chatStore.updateMessages(session, [...target.messages, msg]);
+      toast({ tone: "info", title: "Task resumed", message: "A waited task picked back up in this chat." });
+      notifyIfHidden("Task resumed", text.slice(0, 80));
+    });
+  }, [toast]);
+
+  return null;
+}

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -440,6 +440,29 @@ def _handle_background_terminal(outcome) -> None:
         _spawn_background_wake(job)
 
 
+def _surface_resumed_chat_turn(outcome) -> None:
+    """Surface a scheduler-fired turn (a ``wait`` resume / scheduled task, ADR 0053)
+    that landed in a CHAT session — not the Activity thread — on the event bus so an
+    open chat tab shows the resumed turn LIVE (bd-k02). The browser only renders
+    turns it streamed, so a server-fired resume is otherwise invisible until the
+    next interaction. Mirrors the ADR 0050 background path. Only scheduler-origin
+    turns qualify; an operator/A2A chat turn the browser already streamed does not."""
+    if getattr(outcome, "origin", "") != "scheduler":
+        return
+    text = extract_output(outcome.text) or outcome.text
+    if not text.strip():
+        return
+    _event_bus.publish(
+        "chat.resumed",
+        {
+            "session_id": str(getattr(outcome, "context_id", "") or ""),
+            "text": text,
+            "task_id": getattr(outcome, "task_id", "") or "",
+            "trigger": getattr(outcome, "trigger", "") or "",
+        },
+    )
+
+
 def _a2a_terminal(outcome) -> None:
     """A2A terminal hook (ADR 0003 / 0006). Fired by ``ProtoAgentExecutor`` with
     a ``TurnOutcome`` when a turn reaches a terminal state. Records the per-turn
@@ -454,6 +477,7 @@ def _a2a_terminal(outcome) -> None:
         _handle_background_terminal(outcome)
         return
     if outcome.context_id != ACTIVITY_CONTEXT:
+        _surface_resumed_chat_turn(outcome)
         return
     text = extract_output(outcome.text) or outcome.text
     if not text.strip():

--- a/tests/test_activity_feed.py
+++ b/tests/test_activity_feed.py
@@ -56,3 +56,37 @@ def test_terminal_hook_ignores_non_activity_context(tmp_path, monkeypatch):
     monkeypatch.setattr(server.STATE, "activity_log", log)
     server._a2a_terminal(TurnOutcome(task_id="t", context_id="a-chat", state="completed", text="hi"))
     assert log.recent() == []
+
+
+def test_terminal_hook_surfaces_scheduler_resume_into_chat(tmp_path, monkeypatch):
+    # bd-k02: a wait/scheduled resume that lands in a CHAT session (not Activity)
+    # is pushed as chat.resumed so an open chat tab can show it live.
+    log = ActivityLog(str(tmp_path / "a.db"))
+    monkeypatch.setattr(server.STATE, "activity_log", log)
+    published: list = []
+    monkeypatch.setattr(server._event_bus, "publish", lambda ev, data: published.append((ev, data)))
+
+    server._a2a_terminal(TurnOutcome(
+        task_id="t9", context_id="chat-xyz", state="completed",
+        text="<output>Ship arrived; sold the ore.</output>",
+        origin="scheduler", trigger="wait-resume",
+    ))
+    resumed = next((d for ev, d in published if ev == "chat.resumed"), None)
+    assert resumed is not None
+    assert resumed["session_id"] == "chat-xyz"
+    assert resumed["text"] == "Ship arrived; sold the ore."  # extract_output applied
+    assert resumed["task_id"] == "t9"
+    assert log.recent() == []  # a chat-session turn, not logged to the Activity feed
+
+
+def test_terminal_hook_skips_non_scheduler_chat_turn(tmp_path, monkeypatch):
+    # An operator/A2A chat turn the browser already streamed must NOT be re-pushed.
+    log = ActivityLog(str(tmp_path / "a.db"))
+    monkeypatch.setattr(server.STATE, "activity_log", log)
+    published: list = []
+    monkeypatch.setattr(server._event_bus, "publish", lambda ev, data: published.append((ev, data)))
+    server._a2a_terminal(TurnOutcome(
+        task_id="t", context_id="chat-xyz", state="completed",
+        text="<output>hi</output>", origin="operator",
+    ))
+    assert not any(ev == "chat.resumed" for ev, _ in published)


### PR DESCRIPTION
Closes **bd-k02** — the deferred Slice 2 of ADR 0053 (the `wait` work).

### Problem
A `wait` yields and is re-triggered server-side by the scheduler, which fires a fresh A2A turn into the **same chat thread** (since #1023 stamps `context_id`). But the browser only renders turns **it** streamed, so the resumed turn was invisible in the chat tab until the user next interacted.

### Fix (mirrors the ADR 0050 background path)
- **Backend:** `_a2a_terminal` pushes a `chat.resumed` event `{session_id, text, task_id}` for a **scheduler-origin** turn that lands in a **chat** session (not Activity, not `background:`). An operator/A2A turn the browser already streamed does **not** qualify.
- **Frontend:** `ChatResumeWatch` subscribes to `chat.resumed` and appends the resumed answer to that session as a normal assistant message — **display-only** (the backend owns history; no double-feed) — with a toast. Dedup by `task_id` so an EventSource replay (ADR 0039 ring buffer) is idempotent. Mounted next to `BackgroundWatch`.

### Tests
- Terminal hook emits `chat.resumed` for a scheduler chat turn; skips operator turns; existing non-Activity test still green.
- **2086 backend, 105 web e2e, tsc** all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)