### PR TITLE
fix(plugins): make disk the single source of truth for the installed inventory

### DIFF
--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -117,6 +117,10 @@ export type InstalledPlugin = {
   installed_at?: string;
   by?: string;
   present: boolean;
+  // false = on disk but not in plugins.lock (a local/dev copy) — no source_url/SHA,
+  // so it can't be update-checked or re-synced. Disk is the source of truth, so it's
+  // still listed (and enabled/loaded normally); it just isn't update-tracked.
+  tracked?: boolean;
   enabled: boolean;
   manifest?: {
     name: string;

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -234,14 +234,22 @@ function PluginRow({
 }) {
   const m = p.manifest;
   const caps = m?.capabilities && Object.keys(m.capabilities).length ? m.capabilities : null;
+  // Disk is the source of truth, so a plugin can be on disk (loaded fine) without a
+  // plugins.lock entry — a hand-placed local/dev copy. It has no source_url/SHA and
+  // can't be update-checked or synced; show it plainly rather than a broken row.
+  const local = p.tracked === false;
   return (
     <li className="plugin-row">
       <div className="plugin-row-main">
         <div className="plugin-row-title">
           <strong>{m?.name || p.id}</strong>
           {m?.version ? <span className="plugin-ver">v{m.version}</span> : null}
-          <PluginFreshness update={update} />
-          {update?.behind ? (
+          {local ? (
+            <span className="plugin-state" title="On disk but not in plugins.lock — a local copy. Not update-tracked.">local</span>
+          ) : (
+            <PluginFreshness update={update} />
+          )}
+          {!local && update?.behind ? (
             <Button
               type="button"
               variant="ghost"
@@ -258,8 +266,14 @@ function PluginRow({
         </div>
         {m?.description ? <p className="plugin-desc">{m.description}</p> : null}
         <p className="plugin-meta">
-          <span title={p.source_url}>{p.source_url}</span> · <code>{p.resolved_sha.slice(0, 10)}</code>
-          {p.requested_ref ? ` · ${p.requested_ref}` : ""}
+          {local ? (
+            <span title="installed by copying into config/plugins — not from a git URL">local install · not in plugins.lock</span>
+          ) : (
+            <>
+              <span title={p.source_url}>{p.source_url}</span> · <code>{p.resolved_sha.slice(0, 10)}</code>
+              {p.requested_ref ? ` · ${p.requested_ref}` : ""}
+            </>
+          )}
         </p>
         {/* review surface: what this plugin can do (ADR 0027 D5) */}
         {(m?.views?.length || m?.requires_pip?.length || m?.requires_env?.length || m?.secrets?.length || caps) ? (

--- a/graph/plugins/cli.py
+++ b/graph/plugins/cli.py
@@ -141,8 +141,12 @@ def run_plugin_cli(argv: list[str]) -> int:
                 print("(no git-installed plugins)")
                 return 0
             for e in rows:
-                mark = "" if e.get("present") else "  [MISSING — run `plugin sync`]"
-                print(f"  {e['id']:20} {e['resolved_sha'][:10]}  {e['source_url']}{mark}")
+                if not e.get("present"):
+                    print(f"  {e['id']:20} {e['resolved_sha'][:10]}  {e['source_url']}  [MISSING — run `plugin sync`]")
+                elif not e.get("tracked", True):
+                    print(f"  {e['id']:20} {'local':10}  (on disk, not in plugins.lock — not update-tracked)")
+                else:
+                    print(f"  {e['id']:20} {e['resolved_sha'][:10]}  {e['source_url']}")
             return 0
         if args.cmd == "uninstall":
             rep = installer.uninstall(args.id, purge=args.purge)

--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -384,11 +384,51 @@ def install_deps(plugin_id: str) -> list[str]:
 
 
 def list_installed() -> list[dict]:
-    """Lock entries, annotated with whether the code is present on disk."""
-    out = []
+    """Inventory of installed plugins — **disk is the source of truth**.
+
+    Enumerates every plugin actually present in the live plugins dir (the SAME dir
+    the loader discovers, so "installed" == "loadable") and overlays its
+    ``plugins.lock`` provenance:
+
+    * on disk **and** in the lock → ``tracked: True`` — source + SHA known, so it can
+      be update-checked (``check_updates``) and re-synced.
+    * on disk, **no** lock entry → ``tracked: False`` — a hand-placed local/dev copy
+      (gitignored ``config/plugins/<id>``). Surfaced, not hidden: an enabled plugin
+      that was never `install()`-ed used to be invisible here while running fine,
+      because this only ever read the lock.
+    * in the lock but **missing** from disk → ``present: False`` — fresh checkout or
+      deleted code; ``sync`` refetches it at its pinned SHA.
+    """
     root = live_plugins_dir()
-    for e in _read_lock()["plugins"]:
-        out.append({**e, "present": (root / e["id"]).exists()})
+    lock_by_id = {e["id"]: e for e in _read_lock()["plugins"] if e.get("id")}
+    out: list[dict] = []
+    on_disk: set[str] = set()
+
+    if root.exists():
+        for child in sorted(root.iterdir()):
+            if not child.is_dir():
+                continue
+            manifest = load_manifest(child)
+            if manifest is None:
+                continue  # a dir without a manifest isn't a plugin (mirror the loader)
+            pid = manifest.id
+            on_disk.add(pid)
+            locked = lock_by_id.get(pid)
+            if locked is not None:
+                out.append({**locked, "present": True, "tracked": True})
+            else:
+                out.append({
+                    "id": pid, "source_url": "", "requested_ref": "",
+                    "resolved_sha": "", "installed_at": "", "by": "local",
+                    "present": True, "tracked": False,
+                })
+
+    # Locked but gone from disk — keep visible so the UI can offer `sync`.
+    for pid, locked in lock_by_id.items():
+        if pid not in on_disk:
+            out.append({**locked, "present": False, "tracked": True})
+
+    out.sort(key=lambda e: e.get("id", ""))
     return out
 
 

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -116,6 +116,34 @@ def test_sync_recolones_missing_from_lock(env):
     assert (installer.live_plugins_dir() / "demo_ext").exists()
 
 
+def test_list_installed_surfaces_untracked_local_copy(env):
+    # Disk is the source of truth: a plugin dir hand-placed into the live plugins
+    # dir (a gitignored local/dev copy) is NOT in plugins.lock, but it loads — so it
+    # must still be listed, marked tracked:False, not hidden.
+    installed = _make_plugin_repo(env)
+    installer.install(str(installed))  # tracked: on disk + in the lock
+
+    local = installer.live_plugins_dir() / "local_ext"
+    local.mkdir(parents=True)
+    (local / "protoagent.plugin.yaml").write_text(
+        "id: local_ext\nname: Local Ext\nversion: 0.1.0\ndescription: a local copy\n"
+    )
+
+    rows = {r["id"]: r for r in installer.list_installed()}
+    assert set(rows) == {"demo_ext", "local_ext"}
+    assert rows["demo_ext"]["tracked"] is True and rows["demo_ext"]["present"] is True
+    assert rows["local_ext"]["tracked"] is False and rows["local_ext"]["present"] is True
+    assert rows["local_ext"]["source_url"] == "" and rows["local_ext"]["resolved_sha"] == ""
+
+
+def test_list_installed_ignores_non_plugin_dirs(env):
+    # A stray dir without a manifest isn't a plugin (mirror the loader) — not listed.
+    stray = installer.live_plugins_dir() / "not_a_plugin"
+    stray.mkdir(parents=True)
+    (stray / "README.md").write_text("nope")
+    assert installer.list_installed() == []
+
+
 def test_source_allowlist_blocks_offlist(env):
     repo = _make_plugin_repo(env)
     with pytest.raises(installer.InstallError, match="not on plugins.sources.allow"):


### PR DESCRIPTION
## Why

We had **stale / invisible plugins**: `project_board` and `spacetraders` were enabled and running, yet absent from the Plugins management UI and freshness checks. Root cause — two competing inventories:

- the **loader** reads `config/plugins/` (disk) to decide what actually runs;
- `installer.list_installed()` / `check_updates()` read **`plugins.lock`**.

A plugin placed on disk without a lock entry (a gitignored local/dev copy) ran fine but was invisible to everything lock-driven. This PR demotes the lock to a **provenance overlay** and makes **disk the single source of truth** for the inventory.

## What

- **`installer.list_installed()`** — now enumerates the live plugins dir (mirroring the loader's "dir + valid manifest" rule) and overlays lock provenance:
  - on disk **+** in lock → `tracked: True` (has source/SHA → update-checkable, syncable)
  - on disk, **no** lock entry → `tracked: False` (local/dev copy — *surfaced, not hidden*)
  - in lock but **gone** from disk → `present: False` (so `sync` can refetch)
- **`check_updates()`** stays lock-scoped on purpose — only plugins with a recorded `source_url` have an upstream to compare against, which is now exactly the `tracked` subset of the one inventory.
- **CLI** `plugin list` — shows local (untracked) copies plainly instead of a blank SHA.
- **Web** — `InstalledPlugin.tracked`; `PluginsSection` renders local copies with a `local` tag (no empty SHA/source line, no misleading update control).
- **Tests** — untracked local copy is surfaced `tracked:false`; manifest-less dirs are ignored.

## Verification

```
list_installed():   all 3 → present=True  tracked=True
check_updates():    all 3 → behind=False  err=None
```

- `uv run pytest -k "plugin or loader or fleet_path"` → **246 passed**
- `tsc --noEmit` → clean · `ruff check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)