### PR TITLE
feat: Dedup the operator allowed-dirs list

### DIFF
--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -41,7 +41,10 @@ def _operator_allowed_dirs() -> list[str]:
     roots = [_resolve_operator_project_root()]
     if STATE.graph_config is not None:
         roots.extend(getattr(STATE.graph_config, "operator_allowed_dirs", []) or [])
-    return roots
+    # Dedup (first-seen wins) — the project root is now commonly folded
+    # into operator_allowed_dirs by the setup wizard, so duplicates are
+    # frequent (bd-a7f).
+    return list(dict.fromkeys(roots))
 
 
 def _operator_runtime_status():

--- a/tests/test_operator_project_dir.py
+++ b/tests/test_operator_project_dir.py
@@ -9,6 +9,7 @@ from types import SimpleNamespace
 
 import server
 from graph.config import LangGraphConfig
+from operator_api.console_handlers import _operator_allowed_dirs
 
 
 def test_operator_project_dir_loads_from_dict():
@@ -49,3 +50,48 @@ def test_resolver_blank_config_uses_default(monkeypatch):
     import os
 
     assert os.path.isdir(server._resolve_operator_project_root())
+
+
+def test_allowed_dirs_deduplicates_project_root(tmp_path, monkeypatch):
+    """bd-a7f: project root in operator_allowed_dirs should appear only once."""
+    monkeypatch.delenv("PROTOAGENT_PROJECT_DIR", raising=False)
+    project = str(tmp_path.resolve())
+    monkeypatch.setattr(
+        server.STATE, "graph_config",
+        SimpleNamespace(
+            operator_project_dir=project,
+            operator_allowed_dirs=[project, "/other/dir"],
+        ),
+    )
+    dirs = _operator_allowed_dirs()
+    assert dirs == [project, "/other/dir"]
+
+
+def test_allowed_dirs_preserves_order_on_dedup(tmp_path, monkeypatch):
+    """bd-a7f: first-seen order is preserved when deduping."""
+    monkeypatch.delenv("PROTOAGENT_PROJECT_DIR", raising=False)
+    project = str(tmp_path.resolve())
+    monkeypatch.setattr(
+        server.STATE, "graph_config",
+        SimpleNamespace(
+            operator_project_dir=project,
+            operator_allowed_dirs=["/alpha", project, "/beta", project],
+        ),
+    )
+    dirs = _operator_allowed_dirs()
+    assert dirs == [project, "/alpha", "/beta"]
+
+
+def test_allowed_dirs_unchanged_without_duplicates(tmp_path, monkeypatch):
+    """bd-a7f: no-duplicate lists pass through unchanged."""
+    monkeypatch.delenv("PROTOAGENT_PROJECT_DIR", raising=False)
+    project = str(tmp_path.resolve())
+    monkeypatch.setattr(
+        server.STATE, "graph_config",
+        SimpleNamespace(
+            operator_project_dir=project,
+            operator_allowed_dirs=["/alpha", "/beta"],
+        ),
+    )
+    dirs = _operator_allowed_dirs()
+    assert dirs == [project, "/alpha", "/beta"]


### PR DESCRIPTION
The function `_operator_allowed_dirs()` lives in `operator_api/console_handlers.py`. I'll dedup there and add tests.



Now add the tests:







Both files are done.

**`operator_api/console_handlers.py`** — `_operator_allowed_dirs()` now returns `list(dict.fromkeys(roots))` instead of `roots`, deduplicating while preserving first-seen order.

**`tests/test_operator_project_dir.py`** — three new tests:
- `test_allowed_dirs_deduplicates_project_root` — project root in allowlist appears once
- `test_allowed_dirs_preserves_order_on_dedup` — first-seen order preserved with multiple duplicates
- `test_allowed_dirs_unchanged_without_duplicates` — no-op when there are no duplicates