### PR TITLE
fix(acp): coding turn died on its own large output + silent read loop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   so the picker is ready without a manual "Probe" (bd-hbf).
 
 ### Fixed
+- **ACP coding-agent client: a real coding turn died on its own output.** The
+  client read the agent's stdout with asyncio's default **64 KB line limit**, but a
+  single ACP JSON-RPC message routinely exceeds that (a tool result with a file's
+  contents, a large diff, a resumed session's history) — past the limit
+  `readline()` raises `LimitOverrunError`, which tore down the read loop and
+  aborted the turn mid-build. Raised the per-line ceiling to 32 MB. Also made the
+  read loop **resilient + diagnosable**: a single malformed `session/update` (or a
+  callback raising) is now logged and skipped instead of killing the whole session,
+  the loop logs *why* it ends (it was silent before — failures surfaced only as an
+  opaque "agent exited"), and `content` extraction handles list-shaped blocks (not
+  just a single dict), which also raised `AttributeError` and killed the turn.
+  Found by dogfooding the project-board coding loop end-to-end.
 - **Setup wizard "Project path" was cosmetic.** It was only folded into
   `operator.allowed_dirs` and never persisted, so the real beads/notes root
   (`_resolve_operator_project_root`) ignored it — typing a path didn't relocate

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -51,6 +51,21 @@ def _tool_output_preview(update: dict, limit: int = 300) -> str:
             out.append(block["text"])
     return " ".join(o for o in out if o).strip()[:limit]
 
+
+def _content_text(content) -> str:
+    """Text out of a session/update ``content`` field. The ACP spec types it as a
+    single ContentBlock (a dict), but agents legitimately send a LIST of blocks —
+    and the old ``(content or {}).get("text")`` raised ``AttributeError`` on a list,
+    which killed the whole read loop and aborted the turn. Handle dict, list, and
+    bare-string shapes."""
+    if isinstance(content, dict):
+        return content.get("text", "") or ""
+    if isinstance(content, list):
+        return "".join(b.get("text", "") for b in content if isinstance(b, dict))
+    if isinstance(content, str):
+        return content
+    return ""
+
 # ACP protocol version protoAgent speaks. Negotiated in `initialize`: the client
 # proposes ``PROTOCOL_VERSION`` and the agent echoes it (supported) or counters with
 # its latest. We only speak the versions in ``SUPPORTED_PROTOCOL_VERSIONS``; if the
@@ -58,6 +73,13 @@ def _tool_output_preview(update: dict, limit: int = 300) -> str:
 # not proceed on an unsupported version) rather than warn-and-continue.
 PROTOCOL_VERSION = 1
 SUPPORTED_PROTOCOL_VERSIONS = (1,)
+
+# asyncio's StreamReader defaults to a 64 KB line limit; a single newline-delimited
+# ACP JSON-RPC message routinely exceeds that (a tool result with a file's contents,
+# a large diff, or a resumed session's history). Past the limit, `readline()` raises
+# LimitOverrunError, which killed the read loop and aborted the turn mid-build. Give
+# the reader generous headroom (per-line buffer ceiling).
+_STDOUT_LINE_LIMIT = 32 * 1024 * 1024  # 32 MB
 
 # JSON-RPC error code the agent returns from `session/new` when it has no
 # resolved auth (ACP `AUTH_REQUIRED`). The client surfaces an actionable message.
@@ -157,6 +179,9 @@ class AcpClient:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env={**os.environ, **(self.env or {})},
+                # Raise the per-line buffer ceiling — ACP messages exceed the 64 KB
+                # default and would otherwise raise LimitOverrunError (kills the turn).
+                limit=_STDOUT_LINE_LIMIT,
             )
         except FileNotFoundError as exc:
             raise AcpError(
@@ -229,9 +254,22 @@ class AcpClient:
                 except json.JSONDecodeError:
                     logger.warning("[acp/%s] non-JSON line: %.200s", self.name, line)
                     continue
-                await self._handle(msg)
+                # One bad message (an update shape we mishandle, a callback raising)
+                # must NOT tear down the session — that aborts the turn mid-build with
+                # NO diagnostic (the old behavior: the loop died here, the finally
+                # failed the prompt future with "agent exited", and why was lost). Log
+                # it and keep reading so the turn survives a single hiccup.
+                try:
+                    await self._handle(msg)
+                except Exception:  # noqa: BLE001
+                    logger.exception(
+                        "[acp/%s] error handling message (skipping, turn continues): %.300s",
+                        self.name, line,
+                    )
         except asyncio.CancelledError:
             raise
+        except Exception:  # noqa: BLE001 — surface WHY the loop ended (was silent → undiagnosable)
+            logger.exception("[acp/%s] read loop ended on error", self.name)
         finally:
             # Fail any in-flight requests if the process dies mid-turn.
             for fut in self._pending.values():
@@ -272,14 +310,14 @@ class AcpClient:
         update = params.get("update") or {}
         kind = update.get("sessionUpdate")
         if kind == "agent_message_chunk":
-            text = (update.get("content") or {}).get("text", "")
+            text = _content_text(update.get("content"))
             if text:
                 self._answer += text
                 await self._emit_text(text)   # stream the delta (token-ish) to the UI
         elif kind == "agent_thought_chunk":
             # The coder's reasoning trace — surface it (never folded into the answer)
             # for parity with the native runtime's thinking stream.
-            text = (update.get("content") or {}).get("text", "")
+            text = _content_text(update.get("content"))
             if text:
                 await self._emit_thought(text)
         elif kind == "tool_call":

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -222,6 +222,34 @@ async def test_acp_client_streams_answer_text_deltas():
     assert client._answer == "Hello world"   # still accumulated for the final return
 
 
+async def test_acp_client_handles_list_shaped_content_without_crashing():
+    """A coding agent (e.g. proto) can send agent_message_chunk `content` as a LIST
+    of blocks, not a single dict. The old `(content or {}).get("text")` raised
+    AttributeError on a list, killing the read loop and silently aborting the whole
+    turn mid-build. Content must extract from dict, list, and string shapes."""
+    from plugins.coding_agent.acp_client import AcpClient, _content_text
+
+    assert _content_text({"text": "a"}) == "a"
+    assert _content_text([{"type": "text", "text": "a"}, {"type": "text", "text": "b"}]) == "ab"
+    assert _content_text("bare") == "bare"
+    assert _content_text(None) == ""
+
+    client = AcpClient("noop", cwd="/tmp", name="t")
+    deltas = []
+
+    async def on_text(d):
+        deltas.append(d)
+
+    client._on_text = on_text
+    # The shape that used to crash the loop:
+    await client._handle_update({"update": {
+        "sessionUpdate": "agent_message_chunk",
+        "content": [{"type": "text", "text": "from "}, {"type": "text", "text": "a list"}],
+    }})
+    assert deltas == ["from a list"]
+    assert client._answer == "from a list"
+
+
 async def test_persona_written_to_copilot_instructions(tmp_path, monkeypatch):
     import runtime.acp_runtime as rt_mod
     monkeypatch.setattr(rt_mod, "persona_doc", lambda config: "# id\nYou are Aria.")


### PR DESCRIPTION
## Found by dogfooding the project-board coding loop end-to-end
Driving a feature through the loop (protoAgent boards it → `proto` ACP coder builds it in a worktree → PR), the coder kept dying mid-build. The ACP client had three faults, all of which aborted a real build with **no usable diagnostic**:

1. **64 KB stdout line limit (the actual blocker).** The read loop read the agent's stdout via asyncio's default `StreamReader` limit. A single ACP JSON-RPC message routinely exceeds 64 KB (a tool result carrying a file's contents, a large diff, a resumed session's history) — past the limit `readline()` raises `LimitOverrunError`, which tears down the read loop and aborts the turn. Raised the per-line ceiling to **32 MB**. proto now completes cleanly (`turn complete, stopReason=end_turn` → PR).
2. **Brittle read loop.** One malformed `session/update` (or a callback raising) killed the entire session/turn. Now the offending message is logged and skipped; the turn survives a hiccup.
3. **Silent failure.** The loop failed in-flight requests with an opaque `"agent exited"` and never logged the cause — so the first two bugs surfaced as nothing at all. It now logs *why* the loop ends.

Plus: `content` extraction handles **list-shaped** blocks — an agent can send `content` as a list of blocks, not a single dict; the old `(content or {}).get("text")` raised `AttributeError` and killed the turn.

## Why it mattered
Before: the loop spawned proto, proto authed + ingested the task + started writing tool-calls, then protoAgent closed its stdin with zero logging → `proto agent exited` → feature `blocked`. After: a feature builds end-to-end → [PR #1051](https://github.com/protoLabsAI/protoAgent/pull/1051) (proto's own dedup fix + tests).

## Test plan
- New regression `test_acp_client_handles_list_shaped_content_without_crashing` (dict/list/string/None content shapes + a list-content `agent_message_chunk` that previously crashed the loop).
- `tests/test_acp_runtime.py` + `tests/test_coding_agent_plugin.py` green (38). ruff clean; import-linter 3/3.
- Live-validated: with the fix, `proto` completes a real build through the loop.

Companion fix (separate repo): [projectBoard-plugin PR #23](https://github.com/protoLabsAI/projectBoard-plugin/pull/23) (the loop's `ready_queue` self-rejected every feature against beads-rust 0.1.23).

🤖 Generated with [Claude Code](https://claude.com/claude-code)