### PR TITLE
feat: Settings accordions start collapsed by default

### DIFF
--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -22,6 +22,18 @@ async function tab(page, name) {
   await page.locator(".pl-sidenav").getByRole("tab", { name, exact: true }).click();
 }
 
+// Field groups are collapsed by default (the operator expands as needed) — open
+// every group so the fields under them are visible/interactable in a test. Waits
+// for the suspense load, then toggles only the still-collapsed triggers.
+async function expandAllGroups(page) {
+  await expect(page.locator(".pl-accordion__trigger").first()).toBeVisible();
+  const triggers = page.locator(".pl-accordion__trigger");
+  for (let i = 0; i < (await triggers.count()); i++) {
+    const t = triggers.nth(i);
+    if ((await t.getAttribute("aria-expanded")) !== "true") await t.click();
+  }
+}
+
 test("Settings is a two-home shell (Host / App · Workspace)", async ({ page }) => {
   await openSettings(page);
   // The two scope homes (ADR 0048) — the segmented toggle pinned atop the SideNav.
@@ -67,6 +79,7 @@ test("Workspace ▸ Settings shows the agent's Model + Routing fields", async ({
   // Model + Routing render here (the agent makeup folded into Workspace, ADR 0048).
   await expect(page.locator(".pl-accordion__title").first()).toBeVisible(); // wait for the suspense load
   expect(await page.locator(".pl-accordion__title").allTextContents()).toEqual(["Model", "Routing"]);
+  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
   const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
   await expect(aux).toHaveValue("protolabs/fast");
   const key = page.locator('.setting-row[data-key="model.api_key"] input');
@@ -78,6 +91,7 @@ test("editing an Agent setting enables save and round-trips", async ({ page }) =
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
   await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Settings", exact: true }).click();
+  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
   const save = page.getByRole("button", { name: /Save & apply/ });
   await expect(save).toBeDisabled();
   await page.locator('.setting-row[data-key="routing.aux_model"] input').fill("protolabs/turbo");
@@ -91,6 +105,7 @@ test("a restart-flagged System field shows the restart banner", async ({ page })
   await tab(page, "Workspace");
   await tab(page, "System");
   await expect(page.locator(".settings-banner")).toHaveCount(0);
+  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
   await page.locator('.setting-row[data-key="runtime.autostart_on_boot"] input[type="checkbox"]').check();
   await expect(page.locator(".settings-banner")).toContainText("restart");
 });
@@ -102,7 +117,7 @@ test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ pag
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
   await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Settings", exact: true }).click();
-  await expect(page.locator(".pl-accordion__title").first()).toBeVisible();
+  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
   // model.name inherits from the host layer.
   await expect(
     page.locator('.setting-row[data-key="model.name"] .setting-inheritance'),
@@ -126,6 +141,7 @@ test("Host config edits the host-scoped subset and saves to the host layer", asy
   await openSettings(page);
   await tab(page, "Host config"); // Host / App is the default home
   await expect(page.locator(".settings-banner").first()).toContainText("box-shared");
+  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
   // Only host-scoped fields appear — model.name (host) is here; the agent-scoped
   // model.api_key + routing.fallback_models are NOT.
   await expect(page.locator('.setting-row[data-key="model.name"]')).toBeVisible();

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -284,9 +284,9 @@ export function SettingsCategory({
 
         {/* Each field group is a collapsible accordion (DS 0.29) so a dense category
             (the Workspace home's panels run long) can be tidied to the few sections
-            you're editing. Open by default — collapsing is the operator's tool, not a
-            hidden-by-default trap. A dirty-count badge rides the title so a collapsed
-            group still announces it has unsaved edits. */}
+            you're editing. Collapsed by default — the operator expands groups as
+            needed. A dirty-count badge rides the title so a collapsed group still
+            announces it has unsaved edits. */}
         <Accordion className="settings-groups">
         {groups.map((group) => {
           const visibleFields = group.fields.filter(isVisible);   // #963
@@ -294,7 +294,6 @@ export function SettingsCategory({
           return (
           <AccordionItem
             key={group.section}
-            defaultOpen
             title={
               <span className="settings-group-head">
                 {group.section}


### PR DESCRIPTION
Now I'll make both edits: remove `defaultOpen` and update the comment.





Both edits applied. Let me verify the changes look correct:



Done. Two changes in `SettingsCategory.tsx`:

1. **Removed `defaultOpen`** from `<AccordionItem>` — groups now start collapsed.
2. **Updated the comment** above `<Accordion>` from "Open by default" to "Collapsed by default — the operator expands groups as needed."

The dirty-count `<Badge>` on each group header remains untouched, so unsaved edits are still visible on collapsed headers.