### PR TITLE
feat(acp): forget_session — start a coder fresh when its workdir was recreated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **ACP `forget_session` — start a coder fresh when its workdir was recreated.** A
+  persisted ACP session (#970) lets a dispatch *reattach* a prior thread — right when
+  the workdir keeps its contents across calls, wrong when the caller **recreates the
+  workdir fresh per attempt** (the project-board loop's disposable git worktree): a
+  resumed thread carries memory of a diff the wiped tree no longer has, so the coder
+  thinks it's already done (→ no diff) or edits against stale assumptions.
+  `coding_agent.forget_session(spec)` (+ `AcpAdapter.forget_session(delegate)`) evicts
+  the client and deletes the persisted session id so the next dispatch is a clean
+  `session/new` — keeping the coder's memory in step with the (empty) tree.
 - **`dream` & `distill` — scheduled self-curation subagents (ADR 0054).** Two new
   subagents the agent can run on demand (`/dream`, `/distill`) or on a cadence via
   the existing scheduler (`schedule_task "/dream"` — no new scheduling code).

--- a/plugins/coding_agent/__init__.py
+++ b/plugins/coding_agent/__init__.py
@@ -135,3 +135,29 @@ async def evict_client(spec: dict) -> bool:
     except Exception:  # noqa: BLE001 — teardown is best-effort
         log.warning("[coding_agent/%s] close during evict failed", spec.get("name"), exc_info=True)
     return True
+
+
+async def forget_session(spec: dict) -> bool:
+    """Forget the persisted ACP session for ``spec`` — evict the live client AND
+    delete its saved session id — so the NEXT dispatch starts a fresh ``session/new``
+    instead of ``session/load``-resuming the old thread.
+
+    The persisted session (``#970``) lets a dispatch *reattach* a prior thread,
+    which is right when the same ``workdir`` keeps its contents across calls. But a
+    caller that **recreates the workdir fresh per attempt** (the project_board loop's
+    disposable git worktree) wants the opposite: a resumed thread would carry memory
+    of a diff the wiped tree no longer has, so the coder thinks it's already done
+    (→ no diff) or edits against stale assumptions. Calling this first keeps the
+    coder's memory in step with the (empty) tree. Returns True if anything was
+    cleared; idempotent.
+    """
+    evicted = await evict_client(spec)
+    removed = False
+    try:
+        _session_id_path(spec).unlink()
+        removed = True
+    except FileNotFoundError:
+        pass
+    except OSError:
+        log.warning("[coding_agent/%s] could not delete persisted session", spec.get("name"), exc_info=True)
+    return evicted or removed

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -393,6 +393,15 @@ class AcpAdapter(Adapter):
         from plugins.coding_agent import evict_client
         return await evict_client(self._spec(d))
 
+    async def forget_session(self, d: Delegate) -> bool:
+        """Forget this delegate's persisted ACP session so the next ``dispatch``
+        starts a fresh ``session/new`` (vs reattaching the prior thread). For a
+        caller that recreates ``workdir`` fresh per call (a disposable worktree), a
+        resumed session's memory would reference a diff the wiped tree no longer has.
+        See ``coding_agent.forget_session``. Idempotent."""
+        from plugins.coding_agent import forget_session
+        return await forget_session(self._spec(d))
+
     async def probe(self, d: Delegate) -> dict:
         import os
         import shutil

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -359,6 +359,25 @@ async def test_session_new_persists_id_for_reattach(fake_agent, tmp_path):
     assert data["cwd"] == str(tmp_path)
 
 
+async def test_forget_session_deletes_persisted_id(tmp_path, monkeypatch):
+    """forget_session deletes the persisted session-id file (and evicts the client)
+    so the next dispatch starts a fresh session/new instead of session/load-resuming
+    the old thread — fresh-both for callers that recreate the workdir per attempt."""
+    import plugins.coding_agent as ca
+
+    sess = tmp_path / "sess.json"
+    sess.write_text('{"sessionId": "s1"}', encoding="utf-8")
+    monkeypatch.setattr(ca, "_session_id_path", lambda spec: sess)
+    spec = {
+        "name": "proto", "command": "proto", "args": ["--acp"], "workdir": str(tmp_path),
+        "env": None, "permissions": "auto", "allow_kinds": [], "deny_kinds": [],
+    }
+    assert await ca.forget_session(spec) is True
+    assert not sess.exists()
+    # idempotent: nothing left to clear → False
+    assert await ca.forget_session(spec) is False
+
+
 async def test_persisted_id_ignored_when_agent_lacks_loadsession(fake_agent, tmp_path):
     """A persisted id must NOT trigger session/load if the agent doesn't advertise
     loadSession — the client falls back to a fresh session/new and overwrites it."""


### PR DESCRIPTION
## Why
Came out of a question about how ACP state/history works in the coding loop. The persisted ACP session (#970) reattaches a prior thread on the next dispatch (`session/load`). That's right when the workdir **keeps its contents** across calls — but **wrong when the caller recreates the workdir fresh per attempt** (the project-board loop's disposable git worktree, recreated off `origin/<base>` every drive). A resumed thread carries the coder's memory of a diff the wiped tree no longer has, so it thinks it's already done (→ no diff) or edits against stale assumptions. "Fresh-both" means: fresh worktree ⇒ fresh session.

## What
- **`coding_agent.forget_session(spec)`** — evicts the live client (kills the subprocess) **and** deletes the persisted session-id file, so the next dispatch is a clean `session/new` instead of `session/load`.
- **`AcpAdapter.forget_session(delegate)`** — the delegate-registry seam over it (mirrors `teardown`/`evict_client`).

General capability. The **project-board loop** calls it before each dispatch (companion PR: projectBoard-plugin) so every attempt — CI-fail bounce, tier escalation, crash recovery — starts with the coder's memory in step with the freshly-recreated (empty) tree. (#970's reattach stays available for callers that *do* reuse a workdir.)

## Test plan
`test_forget_session_deletes_persisted_id` (deletes the persisted id + idempotent). `tests/test_coding_agent_plugin.py` + `test_acp_runtime.py` + delegates tests green (67). ruff clean; import-linter 3/3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)