### PR TITLE
feat: Goal mode fresh-context continuation (Ralph-style carved context)

### DIFF
--- a/graph/goals/controller.py
+++ b/graph/goals/controller.py
@@ -79,7 +79,7 @@ class GoalController:
             return "Goal cleared." if existed else "No active goal to clear."
 
         # /goal {json}  or  /goal <free text>  → set
-        spec, condition, max_iters, no_progress, mode = self._parse_set(rest)
+        spec, condition, max_iters, no_progress, mode, fresh_context = self._parse_set(rest)
         if condition is None:
             return ("Could not parse goal. Use `/goal <text>` or "
                     '`/goal {"condition": "...", "verifier": {"type": "command", '
@@ -89,6 +89,7 @@ class GoalController:
             condition=condition,
             verifier=spec,
             mode=mode,  # "drive" (default) | "monitor" (ADR 0030)
+            fresh_context=fresh_context,
             max_iterations=max_iters or getattr(self._config, "goal_max_iterations", 8),
             no_progress_limit=no_progress,  # per-goal patience (ADR 0030 D4); None → config
         )
@@ -126,22 +127,23 @@ class GoalController:
         return (True, f"Goal set. {state.status_line()}")
 
     def _parse_set(self, rest: str):
-        """Return (verifier_spec, condition, max_iterations|None, no_progress_limit|None, mode)."""
+        """Return (verifier_spec, condition, max_iterations|None, no_progress_limit|None, mode, fresh_context)."""
         if rest.lstrip().startswith("{"):
             try:
                 data = json.loads(rest)
             except json.JSONDecodeError:
-                return ({}, None, None, None, "drive")
+                return ({}, None, None, None, "drive", False)
             condition = data.get("condition")
             if not condition:
-                return ({}, None, None, None, "drive")
+                return ({}, None, None, None, "drive", False)
             verifier = data.get("verifier") or {"type": "llm"}
             if "type" not in verifier:
                 verifier["type"] = "llm"
             mode = "monitor" if data.get("mode") == "monitor" else "drive"
-            return (verifier, condition, data.get("max_iterations"), data.get("no_progress_limit"), mode)
+            fresh_context = bool(data.get("fresh_context", False))
+            return (verifier, condition, data.get("max_iterations"), data.get("no_progress_limit"), mode, fresh_context)
         # plain text → fuzzy goal judged by the llm verifier
-        return ({"type": "llm"}, rest, None, None, "drive")
+        return ({"type": "llm"}, rest, None, None, "drive", False)
 
     # --- evaluation --------------------------------------------------------
 
@@ -188,7 +190,11 @@ class GoalController:
         # 3. Not met — refresh checklist, track progress, decide continue vs stop.
         plan = _GOAL_PLAN_RE.search(last_text or "")
         if plan:
-            state.checklist = plan.group(1).strip()
+            plan_text = plan.group(1).strip()
+            if state.fresh_context:
+                self._store.write_plan(state.session_id, plan_text)
+            else:
+                state.checklist = plan_text
 
         signature_unchanged = (
             result.reason == state.last_reason and result.evidence == state.last_evidence
@@ -304,6 +310,23 @@ class GoalController:
         return Decision(action="done", state=state, note=f"{glyph} goal {status}: {reason}")
 
     def _continuation(self, state: GoalState, result) -> str:
+        if state.fresh_context:
+            plan = self._store.read_plan(state.session_id) or "(no plan yet — create one)"
+            evidence = (result.evidence or "").strip()
+            evidence_block = f"Evidence:\n{evidence}\n" if evidence else ""
+            vtype = state.verifier.get("type", "llm")
+            return (
+                f"[goal continuation {state.iteration}/{state.max_iterations} — fresh context]\n"
+                f"Goal: {state.condition}\n"
+                f"Verifier ({vtype}) last result: {result.reason}\n"
+                + (evidence_block + "\n" if evidence_block else "\n") +
+                f"Plan from last iteration:\n{plan}\n\n"
+                f"Take ONE concrete step toward the goal. Read the plan — it records what's "
+                f"been tried, what's next, and what failed. Update your running checklist "
+                f"inside <goal_plan>...</goal_plan> at the end of your turn (it will be "
+                f"persisted for the next iteration). If you determine the goal is impossible "
+                f'or out of scope, emit <goal_unachievable reason="..."/> and stop.'
+            )
         evidence = (result.evidence or "").strip()
         evidence_block = f"\nEvidence:\n{evidence}\n" if evidence else "\n"
         plan_block = state.checklist.strip() or "(no plan yet — create one)"

--- a/graph/goals/store.py
+++ b/graph/goals/store.py
@@ -63,6 +63,40 @@ class GoalStore:
     def _path(self, session_id: str) -> Path:
         return self._base / f"{_safe_name(session_id)}.json"
 
+    def _plan_path(self, session_id: str) -> Path:
+        return self._base / f"{_safe_name(session_id)}.plan.md"
+
+    def read_plan(self, session_id: str) -> str:
+        """Read the durable plan artifact for a session (Ralph's fix_plan.md equivalent).
+        Returns "" when absent — a fresh goal starts with no plan."""
+        path = self._plan_path(session_id)
+        try:
+            return path.read_text(encoding="utf-8")
+        except FileNotFoundError:
+            return ""
+        except OSError as exc:
+            log.warning("[goal] failed to read plan %s: %s", path, exc)
+            return ""
+
+    def write_plan(self, session_id: str, content: str) -> None:
+        """Write (create/overwrite) the durable plan artifact."""
+        path = self._plan_path(session_id)
+        path.parent.mkdir(parents=True, exist_ok=True)
+        # Atomic write mirroring GoalStore.set()
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+        try:
+            with os.fdopen(tmp_fd, "w", encoding="utf-8") as fh:
+                fh.write(content)
+            os.rename(tmp_path, path)
+        except OSError as exc:
+            log.warning("[goal] failed to write plan %s: %s", path, exc)
+        finally:
+            if tmp_path and os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+
     def get(self, session_id: str) -> GoalState | None:
         path = self._path(session_id)
         if not path.exists():

--- a/graph/goals/types.py
+++ b/graph/goals/types.py
@@ -51,6 +51,11 @@ class GoalState:
     # continuation loop); "monitor" = an external process drives the metric, the
     # agent only supervises (verifier-only, out-of-band, no exhaustion).
     mode: str = "drive"
+    # Fresh-context mode (Ralph loop): each continuation turn starts a NEW
+    # LangGraph thread so the model sees a clean slate — no accumulated
+    # transcript from prior iterations. Durable state (plan artifact) lives
+    # on disk. Opt-in only; short goals benefit from transcript continuity.
+    fresh_context: bool = False
     last_checked: float | None = None  # last out-of-band verifier check (monitor)
     checklist: str = ""
     iteration: int = 0
@@ -81,7 +86,12 @@ class GoalState:
         vt = self.verifier.get("type", "llm")
         # Monitor goals have no iteration budget — show the disposition instead.
         progress = "monitor" if self.mode == "monitor" else f"iteration {self.iteration}/{self.max_iterations}"
-        base = f"goal [{self.status}] via {vt}: {self.condition!r} ({progress})"
+        # mode_tag: only shown when it adds info beyond the progress field.
+        # "fresh-context" is always worth noting; "drive" is the default for
+        # non-monitor goals (shown for clarity); monitor mode is redundant with
+        # the progress label so it's omitted.
+        mode_tag = "fresh-context" if self.fresh_context else ("drive" if self.mode == "drive" else "")
+        base = f"goal [{self.status}] via {vt}: {self.condition!r} ({progress}{', ' + mode_tag if mode_tag else ''})"
         if self.last_reason:
             base += f" — {self.last_reason}"
         return base

--- a/server/chat.py
+++ b/server/chat.py
@@ -850,9 +850,23 @@ async def _chat_langgraph_stream(
                     yield ("tool_start", f"🎯 {decision.note}")
                     if decision.action == "done":
                         break
+                    # For fresh-context goals, create a scoped thread so the checkpointer
+                    # starts clean — no accumulated transcript from prior iterations.
+                    goal_state = decision.state
+                    if goal_state and goal_state.fresh_context:
+                        base_tid = _resolve_thread_id(request_metadata, session_id)
+                        cont_config = {
+                            "configurable": {
+                                "thread_id": f"{base_tid}:goal-iter-{goal_state.iteration}"
+                            },
+                            "recursion_limit": 200,
+                        }
+                    else:
+                        cont_config = config  # same-session (existing behavior)
+
                     cont_raw = ""
                     with goal_turn():
-                        async for kind, payload in _run_turn_stream(decision.message, session_id, config, model=_model):
+                        async for kind, payload in _run_turn_stream(decision.message, session_id, cont_config, model=_model):
                             if kind == "__raw__":
                                 cont_raw = payload
                             else:
@@ -1000,10 +1014,22 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
                     note = decision.note
                     if decision.action == "done":
                         break
+                    # For fresh-context goals, create a scoped thread so the checkpointer
+                    # starts clean — no accumulated transcript from prior iterations.
+                    goal_state = decision.state
+                    if goal_state and goal_state.fresh_context:
+                        cont_config = {
+                            "configurable": {
+                                "thread_id": f"chat:{session_id}:goal-iter-{goal_state.iteration}"
+                            },
+                        }
+                    else:
+                        cont_config = config
+
                     with goal_turn():
                         result = await STATE.graph.ainvoke(
                             {"messages": [HumanMessage(content=decision.message)], "session_id": session_id, **_model_extra},
-                            config=config,
+                            config=cont_config,
                         )
                     nxt = extract_output(_last_ai(result))
                     if nxt:


### PR DESCRIPTION
I'll start by reading all the files that need to be modified to understand the current code structure.



Let me read the rest of `chat.py` to find the goal continuation loops.



Now let me check for existing tests to understand the testing conventions.



Now I have a clear picture of all the files. Let me implement the changes.





**Step 1: `types.py`** — Add `fresh_context` field to `GoalState`.



Now update `status_line()` to reflect `fresh_context` in the output:





**Step 2: `store.py`** — Add plan artifact read/write methods.





**Step 3: `controller.py`** — Multiple changes: parse `fresh_context`, persist plan, fresh continuation prompt.

**3a. Update `_parse_set()` to extract `fresh_context` as 6th return value:**



**3b. Update `parse_control()` to unpack 6th element and pass to `GoalState`:**



**3c. Update `evaluate()` — persist plan artifact when `fresh_context=True`:**



**3d. Update `_continuation()` — fresh-context bootstrap prompt:**







**Step 4: `chat.py`** — Fresh thread per continuation. Let me find the exact goal loop code in both streaming and non-streaming paths.







**4a. Streaming path — scoped thread_id for fresh-context goals:**



**4b. Non-streaming path — same change:**







All edits are done. Let me verify the changes are correct by reviewing the key sections.







Let me verify there are no syntax errors in the modified Python files:



All files compile cleanly. Let me run the existing goal-related tests to verify nothing is broken:



One test failed — the `status_line()` format change broke a monitor goal test. The `"(monitor, monitor)"` duplication is wrong. Let me fix the `status_line()` logic:



Let me check what the failing test asserts:



Now let me re-run the tests:



All 89 existing tests pass. Let me also check the memory load tests mentioned in the acceptance criteria:



All tests pass. Let me do a final verification — quick check that the `from_dict` backward compatibility works for older goal files without `fresh_context`:



Let me verify the plan artifact methods work:



Let me verify the controller's continuation prompt generation:



Let me verify the `_parse_set` parsing of `fresh_context`:



Let me verify the `evaluate()` plan persistence:



All acceptance criteria verified. Let me run the full test suite one final time:



All **104 tests pass**. Implementation complete.

## Summary of changes

**4 files modified:**

1. **`graph/goals/types.py`** — Added `fresh_context: bool = False` field to `GoalState` (after `mode`). Updated `status_line()` to show "fresh-context" tag when set.

2. **`graph/goals/store.py`** — Added `_plan_path()`, `read_plan()`, `write_plan()` methods to `GoalStore`. Plan artifacts are stored as `{session_id}.plan.md` alongside `{session_id}.json`, written atomically (tempfile + rename).

3. **`graph/goals/controller.py`** — Three changes:
   - `_parse_set()`: extracts `fresh_context` from JSON, returns as 6th tuple element
   - `parse_control()`: passes `fresh_context` to `GoalState` constructor
   - `evaluate()`: when `fresh_context=True`, persists `<goal_plan>` to plan artifact (not `checklist`)
   - `_continuation()`: fresh-context bootstrap prompt includes goal condition, plan artifact, verifier result, and "pick ONE step" instruction

4. **`server/chat.py`** — Both streaming and non-streaming goal loops: when `goal_state.fresh_context` is True, each continuation uses a scoped `thread_id` (`{base_tid}:goal-iter-{N}`) so the checkpointer starts clean. Default behavior (same thread) is unchanged.