### PR TITLE
feat: Add age/cap retention pruning to InboxStore + ActivityLog in hourly prune loop

### DIFF
--- a/activity/store.py
+++ b/activity/store.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import logging
 import sqlite3
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 log = logging.getLogger(__name__)
@@ -88,6 +88,26 @@ class ActivityLog:
         except sqlite3.DatabaseError:
             log.exception("[activity] add failed")
             return None
+        finally:
+            try:
+                db.close()
+            except Exception:  # noqa: BLE001
+                pass
+
+    def prune(self, keep_days: int = 90, *, now: datetime | None = None) -> int:
+        """Delete entries older than ``keep_days``. 0 = keep forever. Returns rows removed."""
+        if keep_days == 0:
+            return 0
+        now = now or datetime.now(UTC)
+        cutoff = (now - timedelta(days=keep_days)).isoformat()
+        try:
+            db = self._connect()
+            cur = db.execute("DELETE FROM activity WHERE created_at < ?", (cutoff,))
+            db.commit()
+            return cur.rowcount
+        except sqlite3.DatabaseError:
+            log.exception("[activity] prune failed")
+            return 0
         finally:
             try:
                 db.close()

--- a/graph/config.py
+++ b/graph/config.py
@@ -444,6 +444,10 @@ class LangGraphConfig:
     # Retention guardrail (ADR 0006) — turns older than this are pruned by the
     # periodic maintenance loop so the store can't grow unbounded. 0 = keep forever.
     telemetry_retention_days: int = 90
+    # Inbox/Activity retention — delivered inbox items and activity log entries
+    # are pruned by the same maintenance loop. 0 = keep forever.
+    inbox_retention_days: int = 90
+    activity_retention_days: int = 90
     # Checkpoint pruning — keeps the SQLite DB from growing unbounded. Keep the
     # latest N checkpoints per session, and TTL whole sessions idle past
     # max_age_days. Runs every prune_interval_hours (0 disables the sweep).
@@ -796,6 +800,8 @@ class LangGraphConfig:
             telemetry_enabled=data.get("telemetry", {}).get("enabled", cls.telemetry_enabled),
             telemetry_db_path=data.get("telemetry", {}).get("db_path", cls.telemetry_db_path),
             telemetry_retention_days=data.get("telemetry", {}).get("retention_days", cls.telemetry_retention_days),
+            inbox_retention_days=data.get("inbox", {}).get("retention_days", cls.inbox_retention_days),
+            activity_retention_days=data.get("activity", {}).get("retention_days", cls.activity_retention_days),
             checkpoint_keep_per_thread=data.get("checkpoint", {}).get("keep_per_thread", cls.checkpoint_keep_per_thread),
             checkpoint_max_age_days=data.get("checkpoint", {}).get("max_age_days", cls.checkpoint_max_age_days),
             checkpoint_prune_interval_hours=data.get("checkpoint", {}).get("prune_interval_hours", cls.checkpoint_prune_interval_hours),

--- a/inbox/store.py
+++ b/inbox/store.py
@@ -149,6 +149,24 @@ class InboxStore:
     def pending_count(self, *, priority_floor: str = "next") -> int:
         return len(self.list(priority_floor=priority_floor, limit=1000))
 
+    def prune(self, keep_days: int = 90, *, now: datetime | None = None) -> int:
+        """Delete delivered items older than ``keep_days``. Pending items
+        (undelivered) are never pruned. Returns rows removed. 0 = keep forever."""
+        if keep_days == 0:
+            return 0
+        now = now or datetime.now(UTC)
+        cutoff = (now - timedelta(days=keep_days)).isoformat()
+        db = self._connect()
+        try:
+            cur = db.execute(
+                "DELETE FROM inbox WHERE delivered_at IS NOT NULL AND created_at < ?",
+                (cutoff,),
+            )
+            db.commit()
+            return cur.rowcount
+        finally:
+            db.close()
+
 
 class StormGuard:
     """Anti-storm rate limiter for the now→fire path.

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -678,6 +678,27 @@ async def _checkpoint_prune_loop() -> None:
                     log.info("[telemetry-prune] removed %d turn(s) older than %dd", removed, keep_days)
             except Exception:
                 log.exception("[telemetry-prune] sweep failed")
+        # Inbox retention — delete delivered items older than the configured window
+        # so the inbox DB can't grow unbounded. Pending (undelivered) items are never
+        # pruned. 0 = keep all.
+        inbox_keep = getattr(cfg, "inbox_retention_days", 0) if cfg else 0
+        if STATE.inbox_store is not None and inbox_keep > 0:
+            try:
+                removed = await asyncio.to_thread(STATE.inbox_store.prune, inbox_keep)
+                if removed:
+                    log.info("[inbox-prune] removed %d delivered item(s) older than %dd", removed, inbox_keep)
+            except Exception:
+                log.exception("[inbox-prune] sweep failed")
+        # Activity retention — delete feed entries older than the configured window
+        # so the activity DB can't grow unbounded. 0 = keep all.
+        activity_keep = getattr(cfg, "activity_retention_days", 0) if cfg else 0
+        if STATE.activity_log is not None and activity_keep > 0:
+            try:
+                removed = await asyncio.to_thread(STATE.activity_log.prune, activity_keep)
+                if removed:
+                    log.info("[activity-prune] removed %d entry(ies) older than %dd", removed, activity_keep)
+            except Exception:
+                log.exception("[activity-prune] sweep failed")
         # A2A task TTL sweep (24h) — used to run only at boot, so an always-on
         # agent accumulated task rows forever between restarts. The store is
         # async (aiosqlite engine on this same loop), so it's awaited directly

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -12,7 +12,10 @@ from operator_api.routes import register_operator_routes
 
 def test_notify_terminal_invokes_hook_and_is_exception_safe():
     outcome = TurnOutcome(
-        task_id="t1", context_id="system:activity", state="completed", text="hi",
+        task_id="t1",
+        context_id="system:activity",
+        state="completed",
+        text="hi",
     )
     seen = []
     prior = executor._ON_TERMINAL[0]
@@ -82,7 +85,7 @@ async def _unused(*_a, **_k):  # pragma: no cover - placeholder callable
 
 # ── ActivityLog.prune ────────────────────────────────────────────────────────
 
-from datetime import UTC, datetime, timedelta
+from datetime import UTC, datetime
 
 from activity.store import ActivityLog
 
@@ -100,6 +103,7 @@ def test_prune_activity_removes_old(tmp_path):
     # Directly insert rows with controlled timestamps via raw SQL so we
     # can set created_at to an old date (ActivityLog.add always uses _now_iso).
     import sqlite3
+
     db = sqlite3.connect(str(tmp_path / "activity.db"))
     db.execute(
         "INSERT INTO activity (created_at, context_id, origin, text) VALUES (?, ?, ?, ?)",
@@ -124,6 +128,7 @@ def test_prune_activity_keep_all_zero(tmp_path):
     al = _activity_log(tmp_path)
 
     import sqlite3
+
     db = sqlite3.connect(str(tmp_path / "activity.db"))
     db.execute(
         "INSERT INTO activity (created_at, context_id, origin, text) VALUES (?, ?, ?, ?)",

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -78,3 +78,60 @@ def test_activity_route_absent_without_callback():
 
 async def _unused(*_a, **_k):  # pragma: no cover - placeholder callable
     return ""
+
+
+# ── ActivityLog.prune ────────────────────────────────────────────────────────
+
+from datetime import UTC, datetime, timedelta
+
+from activity.store import ActivityLog
+
+
+def _activity_log(tmp_path):
+    return ActivityLog(str(tmp_path / "activity.db"))
+
+
+def test_prune_activity_removes_old(tmp_path):
+    """Entries older than keep_days are deleted; recent ones survive."""
+    al = _activity_log(tmp_path)
+    now = datetime(2024, 3, 1, tzinfo=UTC)
+    old = datetime(2024, 1, 1, tzinfo=UTC)
+
+    # Directly insert rows with controlled timestamps via raw SQL so we
+    # can set created_at to an old date (ActivityLog.add always uses _now_iso).
+    import sqlite3
+    db = sqlite3.connect(str(tmp_path / "activity.db"))
+    db.execute(
+        "INSERT INTO activity (created_at, context_id, origin, text) VALUES (?, ?, ?, ?)",
+        (old.isoformat(), "ctx-old", "test", "old entry"),
+    )
+    db.execute(
+        "INSERT INTO activity (created_at, context_id, origin, text) VALUES (?, ?, ?, ?)",
+        (now.isoformat(), "ctx-new", "test", "recent entry"),
+    )
+    db.commit()
+    db.close()
+
+    removed = al.prune(keep_days=30, now=now)
+    assert removed == 1
+    remaining = al.recent(limit=10)
+    assert len(remaining) == 1
+    assert remaining[0]["text"] == "recent entry"
+
+
+def test_prune_activity_keep_all_zero(tmp_path):
+    """keep_days=0 removes nothing (keep forever)."""
+    al = _activity_log(tmp_path)
+
+    import sqlite3
+    db = sqlite3.connect(str(tmp_path / "activity.db"))
+    db.execute(
+        "INSERT INTO activity (created_at, context_id, origin, text) VALUES (?, ?, ?, ?)",
+        (datetime(2020, 1, 1, tzinfo=UTC).isoformat(), "ctx", "test", "ancient"),
+    )
+    db.commit()
+    db.close()
+
+    removed = al.prune(keep_days=0, now=datetime(2026, 1, 1, tzinfo=UTC))
+    assert removed == 0
+    assert len(al.recent(limit=10)) == 1

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -151,6 +151,8 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "telemetry_db_path": "/sandbox/telemetry.db",
     "telemetry_enabled": True,
     "telemetry_retention_days": 90,
+    "inbox_retention_days": 90,
+    "activity_retention_days": 90,
     "temperature": 0.2,
     "tools_deferred_enabled": False,
     "tools_deferred_keep": [],

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -81,6 +81,51 @@ def test_add_rejects_empty_and_bad_priority(tmp_path):
         s.add("hi", priority="urgent")
 
 
+# ── InboxStore.prune ─────────────────────────────────────────────────────────
+
+
+def test_prune_inbox_removes_old_delivered_only(tmp_path):
+    """Only delivered items older than keep_days are removed; pending items
+    (undelivered) survive regardless of age."""
+    s = _store(tmp_path)
+    old = datetime(2024, 1, 1, tzinfo=UTC)
+    now = datetime(2024, 3, 1, tzinfo=UTC)
+    # Old delivered item — should be pruned.
+    item_old = s.add("old delivered", priority="next", now=old)
+    s.mark_delivered([item_old["id"]], now=old)
+    # Old pending item — should survive (never prune pending).
+    s.add("old pending", priority="next", now=old)
+    removed = s.prune(keep_days=30, now=now)
+    assert removed == 1
+    remaining = s.list(priority_floor="later", include_delivered=True)
+    assert len(remaining) == 1
+    assert remaining[0]["text"] == "old pending"
+
+
+def test_prune_inbox_keeps_recent_delivered(tmp_path):
+    """A recently delivered item within keep_days survives pruning."""
+    s = _store(tmp_path)
+    now = datetime(2024, 3, 1, tzinfo=UTC)
+    recent = now - timedelta(days=10)
+    item = s.add("recent delivered", priority="next", now=recent)
+    s.mark_delivered([item["id"]], now=recent)
+    removed = s.prune(keep_days=30, now=now)
+    assert removed == 0
+    remaining = s.list(priority_floor="later", include_delivered=True)
+    assert len(remaining) == 1
+
+
+def test_prune_inbox_keep_all_zero(tmp_path):
+    """keep_days=0 means keep forever — no rows are removed."""
+    s = _store(tmp_path)
+    old = datetime(2020, 1, 1, tzinfo=UTC)
+    item = s.add("ancient", priority="next", now=old)
+    s.mark_delivered([item["id"]], now=old)
+    removed = s.prune(keep_days=0, now=datetime(2026, 1, 1, tzinfo=UTC))
+    assert removed == 0
+    assert len(s.list(priority_floor="later", include_delivered=True)) == 1
+
+
 # ── StormGuard ───────────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Now let me look at the `from_dict` method in config.py and the `_build_inbox_store` / `_build_activity_log` functions.Now I have all the patterns. Let me create tasks and implement.Now implementing all changes.Need to add `timedelta` import to activity/store.py:Now add config fields and wire them in `from_dict`:Now wire them in `from_dict`, right after the `telemetry_retention_days` line:Now add inbox and activity prune stanzas after the telemetry stanza in the prune loop:Now let me add the tests. First, let me check the test_activity_feed.py for any ActivityLog patterns:Now add the tests. First, inbox tests:Now add activity prune tests:Let me verify the final state of all modified files:All changes verified. Here's a summary of what was done across 6 files:

**`inbox/store.py`** — Added `InboxStore.prune(keep_days=90, *, now=None) -> int`. Deletes rows where `delivered_at IS NOT NULL AND created_at < cutoff`. Pending items survive. Mirrors `TelemetryStore.prune` pattern: `_connect` / try / execute / commit / return rowcount / finally close.

**`activity/store.py`** — Added `ActivityLog.prune(keep_days=90, *, now=None) -> int`. Deletes rows where `created_at < cutoff`. Wraps in the existing try/except/finally pattern used by the rest of `ActivityLog` (sqlite error → log + return 0).

**`graph/config.py`** — Added `inbox_retention_days: int = 90` and `activity_retention_days: int = 90` fields to `LangGraphConfig`. Wired in `from_dict` via `data.get("inbox", {}).get("retention_days")` and `data.get("activity", {}).get("retention_days")`. 0 = keep forever.

**`server/agent_init.py`** — Added inbox then activity prune stanzas in `_checkpoint_prune_loop`, right after the telemetry stanza. Each is gated on `STATE.inbox_store`/`STATE.activity_log is not None` and `cfg.*_retention_days > 0`. Prune calls are dispatched via `asyncio.to_thread`. Log info on success, exception on failure — never crashes the loop.

**`tests/test_inbox.py`** — Added `test_prune_inbox_removes_old_delivered_only` (old delivered+old pending → only delivered removed) and `test_prune_inbox_keeps_recent_delivered` (recent delivered survives).

**`tests/test_activity.py`** — Added `test_prune_activity_removes_old` (old+recent → old removed, recent kept) and `test_prune_activity_keep_all_zero` (keep_days=0 removes nothing).