### PR TITLE
fix(console): plugin iframes block links + clipboard (add allow-popups + clipboard)

### DIFF
--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -205,12 +205,17 @@ export function PluginView({ view }: { view: PluginViewType }) {
                 a 404 fires onLoad (not onError), so an unprobed iframe would render the
                 server's raw 404 body as a blank "view". */}
             {reachable ? (
+              // sandbox: allow-popups (+ -to-escape-sandbox) so links / window.open inside
+              // a plugin open as normal un-sandboxed pages instead of being blocked.
+              // allow: clipboard via Permissions-Policy (no sandbox token exists for it) so
+              // copy/paste works in plugin UIs.
               <iframe
                 ref={frameRef}
                 className="plugin-view-frame"
                 src={apiUrl(src)}
                 title={view.label}
-                sandbox="allow-scripts allow-forms allow-same-origin"
+                sandbox="allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox"
+                allow="clipboard-read; clipboard-write"
                 onLoad={handleLoad}
                 onError={() => setError(`The plugin page at ${src} didn’t respond.`)}
                 style={{ visibility: loaded ? "visible" : "hidden" }}


### PR DESCRIPTION
Plugin views set the iframe `sandbox` without `allow-popups`, so links / `window.open` inside a plugin were blocked and clipboard copy/paste failed.

- `sandbox` += `allow-popups allow-popups-to-escape-sandbox` (links open as normal pages)
- `allow="clipboard-read; clipboard-write"` (clipboard is Permissions-Policy, not a sandbox token)

`PluginView` is the single iframe renderer, so this covers all plugin views. `allow-same-origin` left as-is (plugins need same-origin fetch; tightening it is the separate #869 trust call).

🤖 Generated with [Claude Code](https://claude.com/claude-code)