### PR TITLE
feat: fleet: offload supervisor.status() from event loop (#875 perf tail)

### DIFF
--- a/operator_api/fleet_routes.py
+++ b/operator_api/fleet_routes.py
@@ -33,7 +33,7 @@ def register_fleet_routes(app) -> None:
         slug now (ADR 0042 slug routing) — no server-side 'active' pointer. Remote probes are
         TTL-cached + refreshed off the loop, so the 3s console poll stays cheap."""
         await asyncio.to_thread(supervisor.refresh_remote_probes)
-        return {"agents": supervisor.status()}
+        return {"agents": await asyncio.to_thread(supervisor.status)}
 
     @app.post("/api/fleet/remotes")
     async def _add_remote(req: dict):

--- a/tests/test_fleet_routes.py
+++ b/tests/test_fleet_routes.py
@@ -2,6 +2,9 @@
 
 from __future__ import annotations
 
+import asyncio
+import threading
+
 import pytest
 
 
@@ -126,3 +129,37 @@ def test_discover_endpoint(client, monkeypatch):
     monkeypatch.setattr(discovery, "discover", fake_discover)
     body = client.get("/api/fleet/discover").json()
     assert body["discovered"][0]["name"] == "remote"
+
+
+def test_fleet_list_offloads_status_to_thread(client, monkeypatch):
+    """supervisor.status() must run off the event loop via asyncio.to_thread (#875)."""
+    from graph.fleet import supervisor
+
+    recorded = []
+    orig_to_thread = asyncio.to_thread
+
+    async def wrapped_to_thread(func, /, *args, **kwargs):
+        recorded.append(func)
+        return await orig_to_thread(func, *args, **kwargs)
+
+    monkeypatch.setattr(asyncio, "to_thread", wrapped_to_thread)
+    client.get("/api/fleet")
+    assert supervisor.status in recorded, "supervisor.status was not passed to asyncio.to_thread"
+
+
+def test_fleet_list_status_not_on_event_loop_thread(client, monkeypatch):
+    """supervisor.status must not run on the main thread — confirming to_thread off-loads it."""
+    from graph.fleet import supervisor
+
+    original_status = supervisor.status
+
+    def checked_status():
+        if threading.current_thread() is threading.main_thread():
+            raise RuntimeError("supervisor.status called on main thread — not offloaded")
+        return original_status()
+
+    monkeypatch.setattr(supervisor, "status", checked_status)
+    # If status() ran on the main thread, RuntimeError propagates.
+    # Offloaded via to_thread → runs on a thread-pool worker → no error.
+    r = client.get("/api/fleet")
+    assert r.status_code == 200


### PR DESCRIPTION
Clear picture. One-line change in the route, one new test.



Now writing the tests. I'll add two tests covering acceptance criteria 3 and 4:







The second test is overcomplicated. Let me simplify it to match the acceptance criterion more directly:



Let me verify the final state of both files:





Both files look correct. Here's a summary of the changes:

**`operator_api/fleet_routes.py`** (line 36):
- `return {"agents": supervisor.status()}` → `return {"agents": await asyncio.to_thread(supervisor.status)}`

**`tests/test_fleet_routes.py`** — two new tests:
1. **`test_fleet_list_offloads_status_to_thread`** — wraps `asyncio.to_thread` to record every function passed to it, asserts `supervisor.status` is among them.
2. **`test_fleet_list_status_not_on_event_loop_thread`** — patches `supervisor.status` to raise `RuntimeError` if called on the main thread; the request must succeed (200), confirming `to_thread` off-loads it to a thread-pool worker.