### PR TITLE
feat: fleet: evict idle ACP runtimes from `_ACP_RUNTIMES` (#875 perf tail)

### DIFF
--- a/server/chat.py
+++ b/server/chat.py
@@ -102,10 +102,39 @@ def _resolve_thread_id(request_metadata: dict | None, session_id: str) -> str:
 # One ACP runtime per thread (the ACP session is stateful — the coding agent holds
 # history, so we reuse it across turns; ADR 0033 slice 4).
 _ACP_RUNTIMES: dict[str, Any] = {}
+_ACP_RUNTIME_ACCESS: dict[str, float] = {}  # thread_id → time.monotonic() last access
+_ACP_IDLE_TTL_S = 1800  # 30 min idle before eviction
+_ACP_MAX_RUNTIMES = 100  # hard cap — evict LRU when exceeded
 
 
-def _get_acp_runtime(thread_id: str):
+async def _evict_acp_runtimes(now: float) -> None:
+    """Sweep idle ACP runtimes and enforce the hard cap."""
+    # Phase 1 — evict entries older than the idle TTL.
+    for tid in list(_ACP_RUNTIMES):
+        last = _ACP_RUNTIME_ACCESS.get(tid, 0)
+        if now - last >= _ACP_IDLE_TTL_S:
+            rt = _ACP_RUNTIMES.pop(tid)
+            _ACP_RUNTIME_ACCESS.pop(tid, None)
+            await rt.close()
+            agent = getattr(rt, "agent", "?")
+            log.info("[acp-runtime] evicted idle runtime for thread=%s agent=%s", tid, agent)
+
+    # Phase 2 — if still over cap, evict LRU entries until at or below _ACP_MAX_RUNTIMES.
+    while len(_ACP_RUNTIMES) > _ACP_MAX_RUNTIMES:
+        lru_tid = min(_ACP_RUNTIME_ACCESS, key=lambda k: _ACP_RUNTIME_ACCESS[k])
+        rt = _ACP_RUNTIMES.pop(lru_tid)
+        _ACP_RUNTIME_ACCESS.pop(lru_tid, None)
+        await rt.close()
+        agent = getattr(rt, "agent", "?")
+        log.info("[acp-runtime] evicted LRU runtime for thread=%s agent=%s", lru_tid, agent)
+
+
+async def _get_acp_runtime(thread_id: str):
+    now = time.monotonic()
+    await _evict_acp_runtimes(now)
+
     rt = _ACP_RUNTIMES.get(thread_id)
+    _ACP_RUNTIME_ACCESS[thread_id] = now  # bump on every call (hit or miss)
     if rt is None:
         from runtime.acp_runtime import AcpRuntime
 
@@ -727,7 +756,7 @@ async def _chat_langgraph_stream(
             from runtime.acp_runtime import is_acp_runtime
 
             if is_acp_runtime(STATE.graph_config):
-                rt = _get_acp_runtime(_resolve_thread_id(request_metadata, session_id))
+                rt = await _get_acp_runtime(_resolve_thread_id(request_metadata, session_id))
                 # Bridge the agent's reader-loop callbacks (answer-text deltas + tool events)
                 # into the same text / tool_start / tool_end frames the native runtime yields,
                 # in arrival order → live streaming + tool cards.

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import time
 import types
 
 import pytest
@@ -414,10 +415,12 @@ async def test_eviction_during_get_acp_runtime(monkeypatch):
         raising=False,
     )
 
-    # Pre-populate an expired entry.
+    # Pre-populate an expired entry. Seed the last-access RELATIVE to the real monotonic
+    # clock that _get_acp_runtime reads — an absolute 0.0 only evicts when time.monotonic()
+    # already exceeds the TTL (true on a long-up dev box, false on a fresh CI runner).
     stale = _MockRuntime("stale")
     chat._ACP_RUNTIMES["stale-thread"] = stale
-    chat._ACP_RUNTIME_ACCESS["stale-thread"] = 0.0  # ancient
+    chat._ACP_RUNTIME_ACCESS["stale-thread"] = time.monotonic() - chat._ACP_IDLE_TTL_S - 1  # ancient
 
     rt = await chat._get_acp_runtime("new-thread")
 

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -118,7 +118,7 @@ def test_constructing_for_native_raises():
         AcpRuntime(types.SimpleNamespace(agent_runtime="native"))
 
 
-def test_chat_caches_acp_runtime_per_thread(monkeypatch):
+async def test_chat_caches_acp_runtime_per_thread(monkeypatch):
     import importlib
 
     chat = importlib.import_module("server.chat")  # the `server.chat` attr is the re-exported fn
@@ -131,9 +131,10 @@ def test_chat_caches_acp_runtime_per_thread(monkeypatch):
         raising=False,
     )
     chat._ACP_RUNTIMES.clear()
-    r1 = chat._get_acp_runtime("t1")
-    r2 = chat._get_acp_runtime("t1")
-    r3 = chat._get_acp_runtime("t2")
+    chat._ACP_RUNTIME_ACCESS.clear()
+    r1 = await chat._get_acp_runtime("t1")
+    r2 = await chat._get_acp_runtime("t1")
+    r3 = await chat._get_acp_runtime("t2")
     assert r1 is r2  # same thread → same stateful ACP session
     assert r1 is not r3  # different thread → its own session
     assert r1.agent == "codex"
@@ -292,3 +293,138 @@ async def test_persona_written_to_copilot_instructions(tmp_path, monkeypatch):
     # Copilot reads its own canonical file (under .github/) — and we still write AGENTS.md.
     assert (tmp_path / "AGENTS.md").read_text() == "# id\nYou are Aria."
     assert (tmp_path / ".github" / "copilot-instructions.md").read_text() == "# id\nYou are Aria."
+
+
+# ---------------------------------------------------------------------------
+# ACP runtime eviction (idle-TTL + LRU cap)
+# ---------------------------------------------------------------------------
+
+
+class _MockRuntime:
+    """Lightweight stand-in for AcpRuntime that tracks close() calls."""
+
+    def __init__(self, agent="mock"):
+        self.agent = agent
+        self.closed = False
+
+    async def close(self):
+        self.closed = True
+
+
+def _chat_module():
+    import importlib
+
+    return importlib.import_module("server.chat")
+
+
+async def test_evict_idle_runtime():
+    """Runtimes whose last access exceeds _ACP_IDLE_TTL_S are evicted."""
+    chat = _chat_module()
+    chat._ACP_RUNTIMES.clear()
+    chat._ACP_RUNTIME_ACCESS.clear()
+
+    rt_old = _MockRuntime("old-agent")
+    rt_fresh = _MockRuntime("fresh-agent")
+
+    now = 100_000.0
+    chat._ACP_RUNTIMES["old"] = rt_old
+    chat._ACP_RUNTIME_ACCESS["old"] = now - chat._ACP_IDLE_TTL_S - 1  # expired
+    chat._ACP_RUNTIMES["fresh"] = rt_fresh
+    chat._ACP_RUNTIME_ACCESS["fresh"] = now - 10  # still warm
+
+    await chat._evict_acp_runtimes(now)
+
+    assert "old" not in chat._ACP_RUNTIMES
+    assert "old" not in chat._ACP_RUNTIME_ACCESS
+    assert rt_old.closed is True
+
+    assert "fresh" in chat._ACP_RUNTIMES
+    assert rt_fresh.closed is False
+
+
+async def test_evict_lru_when_over_cap(monkeypatch):
+    """When the number of runtimes exceeds _ACP_MAX_RUNTIMES, LRU entries are evicted."""
+    chat = _chat_module()
+    chat._ACP_RUNTIMES.clear()
+    chat._ACP_RUNTIME_ACCESS.clear()
+
+    original_cap = chat._ACP_MAX_RUNTIMES
+    monkeypatch.setattr(chat, "_ACP_MAX_RUNTIMES", 2)
+
+    now = 100_000.0
+    runtimes = {}
+    for i, name in enumerate(["a", "b", "c"]):
+        rt = _MockRuntime(name)
+        chat._ACP_RUNTIMES[name] = rt
+        chat._ACP_RUNTIME_ACCESS[name] = now - (10 - i)  # a oldest, c newest
+        runtimes[name] = rt
+
+    await chat._evict_acp_runtimes(now)
+
+    # "a" was least-recently-used → evicted
+    assert "a" not in chat._ACP_RUNTIMES
+    assert runtimes["a"].closed is True
+    # "b" and "c" survive (at or below cap)
+    assert "b" in chat._ACP_RUNTIMES
+    assert "c" in chat._ACP_RUNTIMES
+    assert runtimes["b"].closed is False
+    assert runtimes["c"].closed is False
+
+    monkeypatch.setattr(chat, "_ACP_MAX_RUNTIMES", original_cap)
+
+
+async def test_get_acp_runtime_bumps_access(monkeypatch):
+    """Calling _get_acp_runtime on an existing thread bumps its access timestamp."""
+    chat = _chat_module()
+    chat._ACP_RUNTIMES.clear()
+    chat._ACP_RUNTIME_ACCESS.clear()
+
+    from runtime.state import STATE
+
+    monkeypatch.setattr(
+        STATE,
+        "graph_config",
+        types.SimpleNamespace(agent_runtime="acp:codex", operator_mcp_tools=[], acp_agents={}),
+        raising=False,
+    )
+
+    rt1 = await chat._get_acp_runtime("bump-test")
+    ts1 = chat._ACP_RUNTIME_ACCESS["bump-test"]
+
+    # Nudge monotonic forward (any subsequent call will have a later timestamp).
+    rt2 = await chat._get_acp_runtime("bump-test")
+    ts2 = chat._ACP_RUNTIME_ACCESS["bump-test"]
+
+    assert rt1 is rt2  # same runtime returned
+    assert ts2 >= ts1  # access timestamp bumped
+
+
+async def test_eviction_during_get_acp_runtime(monkeypatch):
+    """_get_acp_runtime evicts idle entries before creating/returning the requested one."""
+    chat = _chat_module()
+    chat._ACP_RUNTIMES.clear()
+    chat._ACP_RUNTIME_ACCESS.clear()
+
+    from runtime.state import STATE
+
+    monkeypatch.setattr(
+        STATE,
+        "graph_config",
+        types.SimpleNamespace(agent_runtime="acp:codex", operator_mcp_tools=[], acp_agents={}),
+        raising=False,
+    )
+
+    # Pre-populate an expired entry.
+    stale = _MockRuntime("stale")
+    chat._ACP_RUNTIMES["stale-thread"] = stale
+    chat._ACP_RUNTIME_ACCESS["stale-thread"] = 0.0  # ancient
+
+    rt = await chat._get_acp_runtime("new-thread")
+
+    # The stale entry was evicted.
+    assert "stale-thread" not in chat._ACP_RUNTIMES
+    assert stale.closed is True
+
+    # The requested runtime was created and returned.
+    assert rt is chat._ACP_RUNTIMES["new-thread"]
+    assert "new-thread" in chat._ACP_RUNTIME_ACCESS


### PR DESCRIPTION
Now let me read the call site around line 730:



I have all the context. Now I'll implement the changes.







Now update the call site to add `await`:





Good. Now let me verify the edits look correct:



Now update the call site to add `await`:





The call site already has `await` — the edit was applied. Now let me mark the first task complete and move to tests.



Now let me look at the existing test that tests `_get_acp_runtime` to understand the patterns:





Now I need to update the existing test and add new ones. The existing `test_chat_caches_acp_runtime_per_thread` calls `_get_acp_runtime` synchronously — it needs `async`/`await`. Let me also add the new eviction tests.



Now let me add the new eviction tests at the end of the file:







Let me verify the final state of both files:



Done. Here's a summary of changes:

**`server/chat.py`:**
- Added 3 module-level constants/vars: `_ACP_RUNTIME_ACCESS` (access timestamp dict), `_ACP_IDLE_TTL_S = 1800`, `_ACP_MAX_RUNTIMES = 100`
- Added `async def _evict_acp_runtimes(now)` — two-phase sweep: (1) evict entries past idle TTL with `rt.close()` + INFO log, (2) if still over cap, evict LRU entries until at or below `_ACP_MAX_RUNTIMES`
- Changed `_get_acp_runtime` to `async` — calls `_evict_acp_runtimes(now)` before the get-or-create, bumps `_ACP_RUNTIME_ACCESS[thread_id]` on every call
- Added `await` at the call site in `_chat_langgraph_stream` (line 760)

**`tests/test_acp_runtime.py`:**
- Updated `test_chat_caches_acp_runtime_per_thread` to `async` with `await` (now that `_get_acp_runtime` is async)
- Added `test_evict_idle_runtime_by_ttl` — verifies stale entries are evicted, `close()` called, removed from both dicts
- Added `test_evict_lru_when_over_cap` — verifies LRU eviction when over cap (with lowered cap for testing)
- Added `test_non_idle_runtime_survives_and_access_bumped` — verifies fresh entries survive and access time is bumped