### PR TITLE
refactor(web): DS true-up — Switch / Select / Button swaps

### DIFF
--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -106,7 +106,9 @@ test("a restart-flagged System field shows the restart banner", async ({ page })
   await tab(page, "System");
   await expect(page.locator(".settings-banner")).toHaveCount(0);
   await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
-  await page.locator('.setting-row[data-key="runtime.autostart_on_boot"] input[type="checkbox"]').check();
+  // The bool setting renders as a DS Switch (its native checkbox is 0×0/opacity:0,
+  // so click the switch label to toggle it on rather than .check() the input).
+  await page.locator('.setting-row[data-key="runtime.autostart_on_boot"] .pl-switch').click();
   await expect(page.locator(".settings-banner")).toContainText("restart");
 });
 

--- a/apps/web/src/activity/activity.css
+++ b/apps/web/src/activity/activity.css
@@ -94,7 +94,7 @@
 .activity-origin-scheduler { color: var(--brand-indigo-bright); border-color: color-mix(in srgb, var(--brand-indigo-bright) 45%, var(--border)); }
 .activity-origin-inbox     { color: var(--success); border-color: color-mix(in srgb, var(--success) 45%, var(--border)); }
 .activity-origin-webhook   { color: var(--warning); border-color: color-mix(in srgb, var(--warning) 45%, var(--border)); }
-.activity-origin-a2a       { color: #f472b6; border-color: color-mix(in srgb, #f472b6 45%, var(--border)); }
+.activity-origin-a2a       { color: var(--brand-pink); border-color: color-mix(in srgb, var(--brand-pink) 45%, var(--border)); }
 .activity-origin-operator  { color: var(--accent, #7c8cff); border-color: color-mix(in srgb, var(--accent, #7c8cff) 45%, var(--border)); }
 .activity-trigger { font-family: var(--font-mono, ui-monospace, monospace); color: var(--fg-secondary); }
 .activity-time { margin-left: auto; color: var(--fg-tertiary, var(--fg-secondary)); }

--- a/apps/web/src/app/theme-base.css
+++ b/apps/web/src/app/theme-base.css
@@ -10,6 +10,8 @@
   --brand-violet-light: #a78bfa;
   --brand-indigo: #6366f1;
   --brand-indigo-bright: #818cf8;
+  /* sister-agent (a2a) accent — the only non-semantic origin tint in the activity feed */
+  --brand-pink: #f472b6;
 
   /* Light-mode ready: the legacy app vars are now ALIASES of the @protolabsai/design
      `--pl-*` tokens (imported in main.tsx), so the whole console — DS components AND

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1,5 +1,6 @@
 import "./chat.css";
 import { Empty } from "@protolabsai/ui/primitives";
+import { Switch } from "@protolabsai/ui/forms";
 import {
   Conversation,
   Message,
@@ -183,14 +184,12 @@ export function ChatSurface({
             {/* Harvest is OPT-IN: deleting a chat must not silently copy it into
                 searchable memory — the operator may be deleting it precisely to
                 get rid of it. */}
-            <label className="chat-delete-harvest">
-              <input
-                type="checkbox"
-                checked={harvestOnDelete}
-                onChange={(e) => setHarvestOnDelete(e.target.checked)}
-              />
-              Harvest into the knowledge base first (keeps a searchable summary)
-            </label>
+            <Switch
+              className="chat-delete-harvest"
+              checked={harvestOnDelete}
+              onCheckedChange={setHarvestOnDelete}
+              label="Harvest into the knowledge base first (keeps a searchable summary)"
+            />
           </>
         ) : undefined}
       </ConfirmDialog>

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -5,7 +5,7 @@ import { Link2, Pencil, Play, Plus, Radar, Square, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { EditableText } from "@protolabsai/ui/forms";
+import { EditableText, Switch } from "@protolabsai/ui/forms";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 
@@ -351,10 +351,12 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
         onClose={() => setConfirmRemove(null)}
       >
         <p>Stops the agent and removes it from the fleet.</p>
-        <label className="fleet-purge">
-          <input type="checkbox" checked={purge} onChange={(e) => setPurge(e.target.checked)} />
-          Also purge its workspace data (irreversible)
-        </label>
+        <Switch
+          className="fleet-purge"
+          checked={purge}
+          onCheckedChange={setPurge}
+          label="Also purge its workspace data (irreversible)"
+        />
       </ConfirmDialog>
     </section>
   );

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -292,7 +292,7 @@ function PluginRow({
           </p>
         ) : null}
       </div>
-      <Button icon variant="ghost" title="Uninstall" disabled={removing} onClick={onRemove} aria-label={`uninstall ${p.id}`}>
+      <Button icon variant="danger" title="Uninstall" disabled={removing} onClick={onRemove} aria-label={`uninstall ${p.id}`}>
         <Trash2 size={15} />
       </Button>
     </li>

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -134,13 +134,13 @@ export function PluginsSection() {
           aria-label="git ref"
           style={{ maxWidth: 200 }}
         />
-        <button
-          className="btn"
+        <Button
+          variant="primary"
           disabled={!url.trim() || install.isPending}
           onClick={() => { setStatus(""); install.mutate(); }}
         >
           {install.isPending ? <Loader2 className="spin" size={15} /> : <Plus size={15} />} Install
-        </button>
+        </Button>
       </div>
       {status ? <p className="plugin-install-status" role="status">{status}</p> : null}
 
@@ -292,9 +292,9 @@ function PluginRow({
           </p>
         ) : null}
       </div>
-      <button className="btn-icon danger" title="Uninstall" disabled={removing} onClick={onRemove} aria-label={`uninstall ${p.id}`}>
+      <Button icon variant="ghost" title="Uninstall" disabled={removing} onClick={onRemove} aria-label={`uninstall ${p.id}`}>
         <Trash2 size={15} />
-      </button>
+      </Button>
     </li>
   );
 }

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -1,7 +1,7 @@
 import "./settings.css";
 
 import { Alert } from "@protolabsai/ui/data";
-import { Input, Select, Textarea } from "@protolabsai/ui/forms";
+import { Input, Select, Switch, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { ExternalLink, Link2, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
@@ -425,10 +425,12 @@ export function SettingInput({ field, value, onChange }: { field: SettingsField;
 
   if (field.type === "bool") {
     return (
-      <label className="setting-toggle">
-        <input id={id} type="checkbox" checked={Boolean(value)} onChange={(e) => onChange(e.target.checked)} />
-        <span>{value ? "on" : "off"}</span>
-      </label>
+      <Switch
+        id={id}
+        checked={Boolean(value)}
+        onCheckedChange={onChange}
+        label={value ? "on" : "off"}
+      />
     );
   }
   if (field.type === "number") {

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Input, Select, Textarea } from "@protolabsai/ui/forms";
+import { Checkbox, Input, Select, Switch, Textarea } from "@protolabsai/ui/forms";
 import { Button, Callout } from "@protolabsai/ui/primitives";
 import {
 
@@ -423,21 +423,14 @@ export function SetupWizard({
               {state.runtimeKind === "acp" ? (
                 <label className="field">
                   <span>Coding agent</span>
-                  <select
+                  <Select
                     value={state.acpAgent}
                     onChange={(event) => update({ acpAgent: event.target.value })}
-                    style={{
-                      padding: "0.5rem",
-                      borderRadius: 8,
-                      color: "inherit",
-                      background: "var(--bg-panel, #1a1a1a)",
-                      border: "1px solid var(--border, #333)",
-                    }}
                   >
                     {ACP_AGENTS.map((a) => (
                       <option key={a.id} value={a.id}>{a.label}</option>
                     ))}
-                  </select>
+                  </Select>
                   <small style={{ opacity: 0.7 }}>
                     {ACP_AGENTS.find((a) => a.id === state.acpAgent)?.hint} — runtime set to{" "}
                     <code>acp:{state.acpAgent}</code>. The gateway below is <strong>optional</strong> (only for native delegates / fallback).
@@ -540,14 +533,13 @@ export function SetupWizard({
             <StepBody icon={<ShieldCheck size={20} />} title="Tools" kicker="Middleware">
               <div className="toggle-grid">
                 {Object.entries(state.middleware).map(([key, value]) => (
-                  <label className="toggle-row" key={key}>
+                  <div className="toggle-row" key={key}>
                     <span>{key}</span>
-                    <input
-                      type="checkbox"
+                    <Switch
                       checked={value}
-                      onChange={(event) => setMiddleware(key as keyof WizardState["middleware"], event.target.checked)}
+                      onCheckedChange={(checked) => setMiddleware(key as keyof WizardState["middleware"], checked)}
                     />
-                  </label>
+                  </div>
                 ))}
               </div>
               <label className="field">


### PR DESCRIPTION
**Stacked on #1065** (foundations). Review/merge that first; this PR auto-retargets to `main` when it lands.

Swaps raw HTML controls for the DS components `@protolabsai/ui` already ships — no upstream change needed.

## Swaps
- **`Switch`** — `SettingInput` bool toggle (every bool setting), the fleet purge confirm, the chat-delete "harvest" opt-in, and the setup middleware toggle-grid (`label`→`div` since `Switch` carries its own `<label>`).
- **`Select`** — the setup ACP coding-agent picker (drops its inline `style`).
- **`Button`** — the plugin **Install** (`variant="primary"`) and **Uninstall** (`icon variant="ghost"`, matching the app's other icon-delete buttons) raw `<button className="btn">`s.
- **Token** — the stray `#f472b6` in `activity.css` → `--brand-pink` (the a2a/sister-agent origin tint), defined once with the other brand colors.

## e2e
The DS switch's native `<input>` is `0×0; opacity:0`, so `.check()` can't act on it — `settings.spec.ts`'s restart-banner test now clicks the `.pl-switch` label.

## Deferred (separate, e2e-heavy PR)
Structural swaps that restructure DOM/portals and have `schedule.spec`/`fleet.spec` coverage: **Schedule** modal→`Dialog` + tab-strip→`Tabs variant="segmented"`, **FleetSwitcher** dropdown→`Menu`. The only genuine upstream DS gap remains a **Combobox/Autocomplete** for the `SettingInput` datalist model-pickers.

## Test
`tsc --noEmit` clean · `npm run test:unit` 84/84 · full Playwright suite **105/105**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)