### PR TITLE
refactor(web): small-UI kit — RefreshButton, TestConnectionButton, HelpLink

### DIFF
--- a/apps/web/src/activity/ActivitySurface.tsx
+++ b/apps/web/src/activity/ActivitySurface.tsx
@@ -2,11 +2,12 @@ import "./activity.css";
 
 import { Textarea } from "@protolabsai/ui/forms";
 import { Button, Empty } from "@protolabsai/ui/primitives";
-import { Clock, Inbox, Loader2, MessageSquare, RefreshCw, Send, Users, Webhook, Zap } from "lucide-react";
+import { Clock, Inbox, Loader2, MessageSquare, Send, Users, Webhook, Zap } from "lucide-react";
 
 import { useEffect, useRef, useState } from "react";
 
 import { Markdown } from "../chat/LazyMarkdown";
+import { RefreshButton } from "../app/ui-kit";
 import { api } from "../lib/api";
 import { ago, errMsg } from "../lib/format";
 import { PanelHeader } from "@protolabsai/ui/navigation";
@@ -117,11 +118,7 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
       <PanelHeader
         title="Activity"
         kicker="what the agent did on its own — and why"
-        actions={
-          <Button icon variant="ghost" type="button" onClick={() => void load()} title="Refresh">
-            {loading ? <Loader2 className="spin" size={16} /> : <RefreshCw size={16} />}
-          </Button>
-        }
+        actions={<RefreshButton onClick={() => void load()} busy={loading} />}
       />
 
       <div className="stage-body activity-body">

--- a/apps/web/src/app/ui-kit.tsx
+++ b/apps/web/src/app/ui-kit.tsx
@@ -1,0 +1,60 @@
+// Small shared UI leaves — the button/link idioms repeated verbatim across the
+// surface panels. Pure presentation, no state.
+
+import { Button } from "@protolabsai/ui/primitives";
+import { ExternalLink, Loader2, RefreshCw, ShieldCheck } from "lucide-react";
+import type { ReactNode } from "react";
+
+/**
+ * Ghost icon-button whose glyph spins while `busy`. The header "Refresh" in
+ * Activity / Inbox / Schedule / Telemetry / Knowledge / Playbooks / Commons.
+ */
+export function RefreshButton({
+  onClick,
+  busy = false,
+  title = "Refresh",
+  size = 16,
+}: {
+  onClick: () => void;
+  busy?: boolean;
+  title?: string;
+  size?: number;
+}) {
+  return (
+    <Button icon variant="ghost" type="button" onClick={onClick} disabled={busy} title={title} aria-label={title}>
+      <RefreshCw size={size} className={busy ? "spin" : undefined} />
+    </Button>
+  );
+}
+
+/**
+ * "Test connection" button — a ShieldCheck that swaps to a spinner while
+ * `pending`. `disabled` is OR-ed with `pending` (a pending test is also disabled).
+ */
+export function TestConnectionButton({
+  onClick,
+  pending = false,
+  disabled = false,
+  children = "Test connection",
+}: {
+  onClick: () => void;
+  pending?: boolean;
+  disabled?: boolean;
+  children?: ReactNode;
+}) {
+  return (
+    <Button type="button" onClick={onClick} disabled={disabled || pending}>
+      {pending ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
+      {children}
+    </Button>
+  );
+}
+
+/** External help link with a trailing ExternalLink glyph (and safe `rel`). */
+export function HelpLink({ href, children }: { href: string; children: ReactNode }) {
+  return (
+    <a className="settings-help-link" href={href} target="_blank" rel="noreferrer">
+      {children} <ExternalLink size={13} />
+    </a>
+  );
+}

--- a/apps/web/src/inbox/InboxPanel.tsx
+++ b/apps/web/src/inbox/InboxPanel.tsx
@@ -6,10 +6,11 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { Check, RefreshCw } from "lucide-react";
+import { Check } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { StagePanel } from "../app/ErrorBoundary";
+import { RefreshButton } from "../app/ui-kit";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { api } from "../lib/api";
 import { onServerEvent } from "../lib/events";
@@ -57,11 +58,7 @@ function InboxBody({
         compact
         title="Inbox"
         kicker={`${items.length} pending`}
-        actions={
-          <Button icon variant="ghost" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
-            <RefreshCw size={16} className={isFetching ? "spin" : ""} />
-          </Button>
-        }
+        actions={<RefreshButton onClick={() => void refetch()} busy={isFetching} />}
       />
 
       <div className="inbox-list">

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -1,10 +1,11 @@
 import { Input, Textarea } from "@protolabsai/ui/forms";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { Brain, Database, FileUp, Pencil, Plus, RefreshCw, Trash2 } from "lucide-react";
+import { Brain, Database, FileUp, Pencil, Plus, Trash2 } from "lucide-react";
 
 import { useEffect, useState } from "react";
 
+import { RefreshButton } from "../app/ui-kit";
 import { api } from "../lib/api";
 import { ago, errMsg } from "../lib/format";
 import { PanelHeader } from "@protolabsai/ui/navigation";
@@ -297,9 +298,7 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
                 </Button>
               </>
             ) : null}
-            <Button icon variant="ghost" type="button" onClick={() => void run(query)} disabled={loading} title="Refresh">
-              <RefreshCw size={16} className={loading ? "spin" : ""} />
-            </Button>
+            <RefreshButton onClick={() => void run(query)} busy={loading} />
           </>
         }
       />

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -1,11 +1,12 @@
 import { Input } from "@protolabsai/ui/forms";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { ArrowUpToLine, BookMarked, Library, Pin, RefreshCw, Share2, Sparkles, Trash2 } from "lucide-react";
+import { ArrowUpToLine, BookMarked, Library, Pin, Share2, Sparkles, Trash2 } from "lucide-react";
 
 import { useEffect, useMemo, useState } from "react";
 
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
+import { RefreshButton } from "../app/ui-kit";
 import { api } from "../lib/api";
 import { ago, errMsg } from "../lib/format";
 import { QuickSetting } from "../settings/QuickSetting";
@@ -103,9 +104,7 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
             {/* Quick-set the skill-sharing mode (scoped/shared/layered) right where you
                 manage skills — same field as Workspace ▸ Skills, ADR 0048. */}
             <QuickSetting keys={["skills.scope"]} title="Skill sharing" label="Skill sharing mode" icon={<Share2 size={16} />} />
-            <Button icon variant="ghost" type="button" onClick={() => void load()} disabled={loading} title="Refresh">
-              <RefreshCw size={16} className={loading ? "spin" : ""} />
-            </Button>
+            <RefreshButton onClick={() => void load()} busy={loading} />
           </>
         }
       />

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -7,10 +7,11 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { CalendarClock, Plus, RefreshCw, Trash2, X } from "lucide-react";
+import { CalendarClock, Plus, Trash2, X } from "lucide-react";
 import { useEffect, useMemo, useState } from "react";
 
 import { StagePanel } from "../app/ErrorBoundary";
+import { RefreshButton } from "../app/ui-kit";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
@@ -200,9 +201,7 @@ function ScheduleBody() {
         kicker={`${jobs.length} job${jobs.length === 1 ? "" : "s"} · ${backend}`}
         actions={
           <>
-            <Button icon variant="ghost" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
-              <RefreshCw size={16} className={isFetching ? "spin" : ""} />
-            </Button>
+            <RefreshButton onClick={() => void refetch()} busy={isFetching} />
             <Button variant="primary" type="button" onClick={() => setModalOpen(true)}
                     disabled={backend === "disabled"} data-testid="schedule-new">
               <Plus size={16} /> New schedule

--- a/apps/web/src/settings/CommonsPanel.tsx
+++ b/apps/web/src/settings/CommonsPanel.tsx
@@ -1,8 +1,9 @@
-import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
+import { Badge, Empty } from "@protolabsai/ui/primitives";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { useQuery } from "@tanstack/react-query";
-import { Library, RefreshCw } from "lucide-react";
+import { Library } from "lucide-react";
 
+import { RefreshButton } from "../app/ui-kit";
 import { api } from "../lib/api";
 
 // Global ▸ Commons (ADR 0041 + 0048) — the box-shared skill library every agent
@@ -22,11 +23,7 @@ export function CommonsPanel() {
       <PanelHeader
         title="Commons"
         kicker={`the box-shared skill library · ${commons.length} skill${commons.length === 1 ? "" : "s"}`}
-        actions={
-          <Button icon variant="ghost" type="button" onClick={() => void q.refetch()} disabled={q.isFetching} title="Refresh">
-            <RefreshCw size={16} className={q.isFetching ? "spin" : ""} />
-          </Button>
-        }
+        actions={<RefreshButton onClick={() => void q.refetch()} busy={q.isFetching} />}
       />
       <div className="stage-body">
         {!layered ? (

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -5,6 +5,7 @@ import { Input, Select, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 
 import { StatusPill } from "../app/StatusPill";
+import { HelpLink } from "../app/ui-kit";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { Loader2, Pencil, Plug, Plus, ShieldCheck, Trash2, X } from "lucide-react";
 import { useMemo, useState } from "react";
@@ -89,9 +90,7 @@ export function DelegatesSection() {
         <p className="setting-desc">
           Enable the <code>delegates</code> plugin (<code>plugins: {"{ enabled: [delegates] }"}</code>) to
           manage the agents and endpoints this agent can talk to.{" "}
-          <a className="settings-help-link" href={DELEGATES_GUIDE_URL} target="_blank" rel="noreferrer">
-            Guide
-          </a>
+          <HelpLink href={DELEGATES_GUIDE_URL}>Guide</HelpLink>
         </p>
       </section>
     );

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -4,13 +4,14 @@ import { Alert } from "@protolabsai/ui/data";
 import { Input, Select, Switch, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { ExternalLink, Link2, Loader2, RotateCcw, Save, ShieldCheck } from "lucide-react";
+import { Link2, Loader2, RotateCcw, Save } from "lucide-react";
 
 import { useMemo, useState } from "react";
 import type { ReactNode } from "react";
 
 import { Accordion, AccordionItem, PanelHeader } from "@protolabsai/ui/navigation";
 import { StagePanel } from "../app/ErrorBoundary";
+import { HelpLink, TestConnectionButton } from "../app/ui-kit";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
@@ -226,10 +227,7 @@ export function SettingsCategory({
         actions={
           <>
             {hasModel ? (
-              <Button type="button" onClick={() => testConn.mutate()} disabled={testConn.isPending || save.isPending}>
-                {testConn.isPending ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
-                Test connection
-              </Button>
+              <TestConnectionButton onClick={() => testConn.mutate()} pending={testConn.isPending} disabled={save.isPending} />
             ) : null}
             {/* Pilot of the protoLabs design system (ADR 0037 D7) — the real @protolabsai/ui Button. */}
             <Button type="button" onClick={discard} disabled={save.isPending || !dirtyKeys.length}>
@@ -303,13 +301,8 @@ export function SettingsCategory({
             ))}
             {hasDiscord && group.section === "Discord" ? (
               <div className="settings-group-actions">
-                <Button type="button" onClick={() => testDiscord.mutate()} disabled={testDiscord.isPending || save.isPending}>
-                  {testDiscord.isPending ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
-                  Test connection
-                </Button>
-                <a className="settings-help-link" href={DISCORD_GUIDE_URL} target="_blank" rel="noreferrer">
-                  How to create a bot <ExternalLink size={13} />
-                </a>
+                <TestConnectionButton onClick={() => testDiscord.mutate()} pending={testDiscord.isPending} disabled={save.isPending} />
+                <HelpLink href={DISCORD_GUIDE_URL}>How to create a bot</HelpLink>
               </div>
             ) : null}
             {hasGoogle && group.section === "Google" ? (
@@ -331,22 +324,16 @@ export function SettingsCategory({
                       ? "Save the client ID + secret, then connect"
                       : "Not connected"}
                 </span>
-                <a className="settings-help-link" href={GOOGLE_GUIDE_URL} target="_blank" rel="noreferrer">
-                  Get an OAuth client <ExternalLink size={13} />
-                </a>
+                <HelpLink href={GOOGLE_GUIDE_URL}>Get an OAuth client</HelpLink>
               </div>
             ) : null}
             {group.test ? (
               <div className="settings-group-actions">
-                <Button
-
-                  type="button"
+                <TestConnectionButton
                   onClick={() => { setTestingSection(group.section); testGroup.mutate({ endpoint: group.test!.endpoint, fields: groupFields(group) }); }}
-                  disabled={(testGroup.isPending && testingSection === group.section) || save.isPending}
-                >
-                  {testGroup.isPending && testingSection === group.section ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
-                  Test connection
-                </Button>
+                  pending={testGroup.isPending && testingSection === group.section}
+                  disabled={save.isPending}
+                />
               </div>
             ) : null}
           </AccordionItem>

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -18,6 +18,7 @@ import {
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
+import { TestConnectionButton } from "../app/ui-kit";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import type { AgentConfig, ConfigPayload, SetupStatus } from "../lib/types";
@@ -467,15 +468,11 @@ export function SetupWizard({
                   {busy ? <Loader2 className="spin" size={15} /> : <Search size={15} />}
                   Probe
                 </Button>
-                <Button
-                 
-                  type="button"
+                <TestConnectionButton
                   onClick={() => void testConnection()}
-                  disabled={busy || !state.apiBase.trim() || !state.modelName.trim()}
-                >
-                  {busy ? <Loader2 className="spin" size={15} /> : <ShieldCheck size={15} />}
-                  Test connection
-                </Button>
+                  pending={busy}
+                  disabled={!state.apiBase.trim() || !state.modelName.trim()}
+                />
               </div>
               {tested ? (
                 <div className={`setup-test ${tested.ok ? "ok" : "err"}`} role="status">

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -14,11 +14,11 @@ import {
   Download,
   Hash,
   Layers,
-  RefreshCw,
   Wrench,
 } from "lucide-react";
 
 import { StagePanel } from "../app/ErrorBoundary";
+import { RefreshButton } from "../app/ui-kit";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { QuickSetting } from "../settings/QuickSetting";
 import { api } from "../lib/api";
@@ -58,9 +58,7 @@ function TelemetryBody() {
                     disabled={!enabled || !summary?.turns} title="Export CSV" data-testid="telemetry-export">
               <Download size={16} />
             </Button>
-            <Button icon variant="ghost" type="button" onClick={() => void refetch()} disabled={isFetching} title="Refresh">
-              <RefreshCw size={16} className={isFetching ? "spin" : ""} />
-            </Button>
+            <RefreshButton onClick={() => void refetch()} busy={isFetching} />
           </>
         }
       />


### PR DESCRIPTION
**Stacked on #1067 → #1065.** Auto-retargets up the stack as each merges.

New `app/ui-kit.tsx` holds three repeated leaf components; migrates 14 call sites.

- **`RefreshButton`** (7) — the ghost icon-refresh in Activity / Inbox / Schedule / Telemetry / Knowledge / Playbooks / Commons. (Activity also picks up the disabled-while-loading the other six had.)
- **`TestConnectionButton`** (4) — the ShieldCheck/spinner "Test connection" in `SettingsCategory` (model / Discord / per-group) + `SetupWizard`.
- **`HelpLink`** (3) — the external `settings-help-link` + `ExternalLink` glyph (Discord/Google guides + the Delegates "Guide", now icon-unified).

Prunes the now-unused lucide icon imports per file (and a dead `Button` import in `CommonsPanel`). `DelegatesSection`'s icon-only "Test" button is intentionally left (different shape).

## Scope note
`SaveBar`/`useDirtyForm` were **not** extracted: the save bars diverge enough (single-Save vs Discard+Save, e2e-coupled testids like `identity-save` and labels like `"Save & apply"`) that a shared component would be props-heavy and obscure more than it saves. `PluginRow` unification (two impls over different types) is deferred — medium-risk, separate PR.

## Test
`tsc --noEmit` clean · `npm run test:unit` 84/84 · full Playwright **105/105**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)