### PR TITLE
feat(web): settings IA — Global = cascade only, new Box surface, gated host config

### DIFF
--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -20,8 +20,9 @@ test.beforeEach(async ({ page }, testInfo) => {
 
 async function openAgents(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-sidenav").getByRole("tab", { name: "Fleet", exact: true }).click();
+  // Fleet lives under the Box rail surface now (PR4), not Settings.
+  await page.locator(".pl-rail").getByRole("button", { name: "Box", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Fleet", exact: true }).click();
 }
 
 test("Agents tab lists the host (this instance) + peers, host active by default", async ({ page }) => {
@@ -153,8 +154,8 @@ test("discover → add to fleet → switch into the remote member (ADR 0042 §I)
   await expect(page.getByTestId("fleet-switcher")).toContainText("remy");
 
   // Unregister from the fleet manager (the remote agent itself is untouched).
-  await page.getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-sidenav").getByRole("tab", { name: "Fleet", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Box", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Fleet", exact: true }).click();
   await page.locator(".fleet-row", { hasText: "remy" })
     .getByRole("button", { name: /Remove from this fleet/ }).click();
   await expect(page.locator(".fleet-row", { hasText: "remy" })).toHaveCount(0);

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -41,13 +41,11 @@ test("Settings is a two-home shell (Global · Workspace)", async ({ page }) => {
     "Global",
     "Workspace",
   ]);
-  // The Global home's sections (the default home) — DS SideNav rail.
+  // The Global home is the box-shared cascade ONLY now (PR4) — Fleet/Telemetry/Commons
+  // moved out to the Box rail surface.
   expect(await page.locator(".pl-sidenav").locator("button").allTextContents()).toEqual([
     "Overview",
-    "Host config",
-    "Fleet",
-    "Telemetry",
-    "Commons",
+    "Configuration",
   ]);
   await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible(); // default section
   // The Workspace home → the focused agent's makeup + settings (ADR 0048 fold).
@@ -69,6 +67,19 @@ test("Settings is a two-home shell (Global · Workspace)", async ({ page }) => {
   // Field groups are collapsible accordions (DS 0.29); titles render in the trigger.
   await expect(page.locator(".pl-accordion__title").first()).toBeVisible(); // wait for the suspense load
   expect(await page.locator(".pl-accordion__title").allTextContents()).toEqual(["Compaction", "Runtime"]);
+});
+
+test("Box surface hosts Fleet · Telemetry · Commons (moved out of Settings, PR4)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-rail").getByRole("button", { name: "Box", exact: true }).click();
+  const tabs = page.locator(".pl-tabs").getByRole("tab");
+  await expect(tabs).toHaveCount(3);
+  expect(await tabs.allTextContents()).toEqual(["Fleet", "Telemetry", "Commons"]);
+  // Fleet is the default Box tab.
+  await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible();
+  // …and the moved Telemetry dashboard renders under its tab.
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Telemetry", exact: true }).click();
+  await expect(page.getByTestId("telemetry-surface")).toBeVisible();
 });
 
 test("Workspace ▸ Settings shows the agent's Model + Routing fields", async ({ page }) => {
@@ -123,7 +134,7 @@ test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ pag
   // model.name inherits from the host layer.
   await expect(
     page.locator('.setting-row[data-key="model.name"] .setting-inheritance'),
-  ).toContainText("inherited from Host");
+  ).toContainText("inherited from Global");
   // routing.aux_model inherits the App default.
   await expect(
     page.locator('.setting-row[data-key="routing.aux_model"] .setting-inheritance'),
@@ -139,9 +150,9 @@ test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ pag
   ).toHaveCount(0);
 });
 
-test("Host config edits the host-scoped subset and saves to the host layer", async ({ page }) => {
+test("Configuration edits the host-scoped subset and saves to the host layer", async ({ page }) => {
   await openSettings(page);
-  await tab(page, "Host config"); // Global is the default home
+  await tab(page, "Configuration"); // Global is the default home; host console → editable
   await expect(page.locator(".settings-banner").first()).toContainText("box-shared");
   await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
   // Only host-scoped fields appear — model.name (host) is here; the agent-scoped

--- a/apps/web/e2e/telemetry.spec.ts
+++ b/apps/web/e2e/telemetry.spec.ts
@@ -1,14 +1,14 @@
 import { expect, test } from "@playwright/test";
 
-// The System ▸ Telemetry tab renders the per-turn rollups from
+// The Box ▸ Telemetry tab renders the per-turn rollups from
 // /api/telemetry/* (ADR 0006 Slice 3): summary cards + a recent-turns table.
 
-test("Settings → Telemetry shows the telemetry summary cards and recent turns", async ({ page }) => {
+test("Box → Telemetry shows the telemetry summary cards and recent turns", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Telemetry is its own tab under Settings now (split out of Overview).
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-sidenav").getByRole("tab", { name: "Telemetry", exact: true }).click();
+  // Telemetry moved from Settings ▸ Global to the Box rail surface (PR4).
+  await page.locator(".pl-rail").getByRole("button", { name: "Box", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Telemetry", exact: true }).click();
 
   const surface = page.getByTestId("telemetry-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -4,6 +4,7 @@ import {
   BookMarked,
   Database,
   BookOpen,
+  Box,
   Boxes,
   CalendarClock,
   CircleAlert,
@@ -108,6 +109,7 @@ import { StatusPill } from "./StatusPill";
 import { GoalsPanel } from "./GoalsPanel";
 import { BeadsPanel } from "./BeadsPanel";
 import { SchedulePanel } from "../schedule/SchedulePanel";
+import { BoxSurface } from "./BoxSurface";
 import { PluginsSurface } from "../plugins/PluginsSurface";
 import { SetupWizard } from "../setup/SetupWizard";
 import { hostRuntimeStatusQuery, runtimeStatusQuery } from "../lib/queries";
@@ -226,8 +228,7 @@ export function App() {
   const chatStreaming = useAnyChatStreaming();
   const pluginsTab = useUI((s) => s.pluginsTab);
   const setPluginsTab = useUI((s) => s.setPluginsTab);
-  const setSettingsScope = useUI((s) => s.setSettingsScope);
-  const setSettingsSection = useUI((s) => s.setSettingsSection);
+  const setBoxTab = useUI((s) => s.setBoxTab);
   const setFleetStartNew = useUI((s) => s.setFleetStartNew);
   const activityTab = useUI((s) => s.activityTab);
   const setActivityTab = useUI((s) => s.setActivityTab);
@@ -490,6 +491,8 @@ export function App() {
     { id: "knowledge", label: "Knowledge", icon: <BookMarked size={18} /> },
     // "agent" folded into Settings ▸ Workspace (ADR 0048 S-C) — no longer a rail surface.
     { id: "plugins", label: "Plugins", icon: <Puzzle size={18} /> },
+    // Box (PR4) — box-level ops (Fleet · Telemetry · Commons), moved out of Settings ▸ Global.
+    { id: "box", label: "Box", icon: <Box size={18} /> },
     { id: "settings", label: "Settings", icon: <Settings2 size={18} /> },
     { id: "beads", label: "Beads", icon: <Boxes size={18} /> },
     { id: "goals", label: "Goals", icon: <Target size={18} /> },
@@ -557,6 +560,9 @@ export function App() {
       case "settings":
         // SettingsSurface owns its own two-level nav (home + section, ADR 0048).
         return <SettingsSurface />;
+      // Box (PR4) — owns its own Fleet/Telemetry/Commons sub-tabs.
+      case "box":
+        return <BoxSurface />;
       // Notes is now the first-party `notes` plugin (ADR 0034 S4) — rendered via the default
       // plugin-view case below, not a native surface.
       case "beads":
@@ -730,11 +736,10 @@ export function App() {
           <FleetSwitcher
             fallbackName={brandName(runtime?.identity?.name)}
             onNewAgent={() => {
-              // Fleet now lives under Global ▸ Fleet (ADR 0048); ask the panel to
-              // open the new-agent picker on mount.
-              setSurface("settings");
-              setSettingsScope("host");
-              setSettingsSection("fleet");
+              // Fleet now lives under the Box surface (PR4); ask the panel to open
+              // the new-agent picker on mount.
+              setSurface("box");
+              setBoxTab("fleet");
               setFleetStartNew(true);
             }}
           />

--- a/apps/web/src/app/BoxSurface.tsx
+++ b/apps/web/src/app/BoxSurface.tsx
@@ -1,0 +1,36 @@
+import { BarChart3, Library, Server } from "lucide-react";
+
+import { Tabs } from "@protolabsai/ui/navigation";
+
+import { CommonsPanel } from "../settings/CommonsPanel";
+import { FleetSurface } from "../settings/FleetSurface";
+import { useUI, type BoxTab } from "../state/uiStore";
+import { TelemetrySurface } from "../telemetry/TelemetrySurface";
+
+// The Box surface (PR4 / ADR 0048 §5) — box-level operations that are NOT per-agent
+// cascade settings: the fleet roster, the telemetry dashboard, and the skill commons.
+// They used to live as sections under Settings ▸ Global, which conflated "box-shared
+// settings" (the cascade) with "box-level tools." Now they're their own rail surface
+// and Settings ▸ Global is just the cascade (Overview + Configuration).
+const BOX_TABS: { id: BoxTab; label: string; icon: typeof Server }[] = [
+  { id: "fleet", label: "Fleet", icon: Server },
+  { id: "telemetry", label: "Telemetry", icon: BarChart3 },
+  { id: "commons", label: "Commons", icon: Library },
+];
+
+export function BoxSurface() {
+  const tab = useUI((s) => s.boxTab);
+  const setTab = useUI((s) => s.setBoxTab);
+  return (
+    <>
+      <Tabs
+        responsive
+        ariaLabel="Box sections"
+        active={tab}
+        onSelect={(t) => setTab(t as BoxTab)}
+        items={BOX_TABS.map((t) => ({ id: t.id, label: t.label, icon: <t.icon size={15} /> }))}
+      />
+      {tab === "fleet" ? <FleetSurface /> : tab === "telemetry" ? <TelemetrySurface /> : <CommonsPanel />}
+    </>
+  );
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -143,6 +143,13 @@ export function currentSlug(): string {
   }
 }
 
+/** True when this window is the host console (the un-suffixed root or the reserved
+ *  `host` slug) — the only console allowed to edit the box-shared Global defaults
+ *  (ADR 0047 §7.7). A workspace console sees those fields read-only. */
+export function isHostConsole(): boolean {
+  return currentSlug() === "host";
+}
+
 /** URL of the console focused on `slug` (for navigation / opening a new window). */
 export function agentHref(slug: string): string {
   const base = import.meta.env.BASE_URL || "/"; // "/app/"

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from "react";
 import { Accordion, AccordionItem, PanelHeader } from "@protolabsai/ui/navigation";
 import { StagePanel } from "../app/ErrorBoundary";
 import { HelpLink, TestConnectionButton } from "../app/ui-kit";
-import { api } from "../lib/api";
+import { agentHref, api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
 import type { SettingsField, SettingsGroup } from "../lib/types";
@@ -28,13 +28,12 @@ export function SettingsCategoryPanel(props: { category: string; title?: string;
   );
 }
 
-// Host / box-shared defaults view (ADR 0047) — the host-scoped fields across ALL
-// categories, editable, saving to the host layer. Surfaced as its own Settings tab.
-// TODO(ADR 0047 §7): gate to the host console (slug=host); for now it renders for any
-// focused agent, clearly labeled "box-shared", so the slice isn't blocked on gating.
+// Global / box-shared defaults view (ADR 0047) — the host-scoped fields across ALL
+// categories, editable, saving to the host layer. Gated to the host console at the
+// call site (SettingsSurface): a workspace console renders <HostConfigLocked/> instead.
 export function HostDefaultsPanel({
   categories = ["Agent", "System"],
-  title = "Host defaults",
+  title = "Configuration",
 }: {
   categories?: string[];
   title?: string;
@@ -44,7 +43,7 @@ export function HostDefaultsPanel({
   // section). Previously this mapped one full SettingsCategory PER category, which
   // stacked duplicate panels each with its own scroll/Save/explainer.
   return (
-    <StagePanel label="host defaults" className="settings-panel">
+    <StagePanel label="configuration" className="settings-panel">
       <SettingsCategory
         category={categories[0]}
         categories={categories}
@@ -53,6 +52,27 @@ export function HostDefaultsPanel({
         hostLayer
       />
     </StagePanel>
+  );
+}
+
+// Workspace-console view of Global ▸ Configuration (ADR 0047 §7.7): the box-shared
+// defaults are editable only on the host console, so a workspace console gets a
+// read-only pointer. Per-agent overrides still happen under Workspace ▸ Settings.
+export function HostConfigLocked() {
+  return (
+    <section className="panel stage-panel settings-panel">
+      <PanelHeader title="Configuration" kicker="box-shared Global defaults" />
+      <div className="stage-body">
+        <Alert status="info" className="settings-banner">
+          These are the box-shared <strong>Global</strong> defaults — edited on the
+          <strong> host console</strong>. This workspace inherits them; to change a value
+          just for this agent, override it under <strong>Workspace ▸ Settings</strong>.
+        </Alert>
+        <Button variant="primary" type="button" onClick={() => { window.location.href = agentHref("host"); }}>
+          Open host console
+        </Button>
+      </div>
+    </section>
   );
 }
 
@@ -242,12 +262,9 @@ export function SettingsCategory({
       <div className="stage-body">
         {hostLayer ? (
           <Alert status="info" className="settings-banner">
-            <strong>Host / box-shared defaults</strong> (ADR 0047) — edits here write to the
+            <strong>Global · box-shared defaults</strong> (ADR 0047) — edits here write to the
             box's <code>host-config.yaml</code> and become the inherited default for every agent
             on this box that hasn't set its own value. Per-agent overrides win.
-            {/* TODO(ADR 0047 §7): gate this view to the host console (slug=host). For now it
-                renders for any focused agent — clearly labeled as box-shared — so the slice
-                isn't blocked on host-console gating. */}
           </Alert>
         ) : null}
         {acpAgent ? (
@@ -352,7 +369,7 @@ export function SettingsCategory({
 //   source=="agent" && scope=="host"  → overridden here (offer reset-to-inherited)
 //   source=="agent" && scope=="agent" → a plain agent setting (no badge)
 function inheritance(field: SettingsField): { label: string; status: "neutral" | "info" | "warning"; overridden: boolean } | null {
-  if (field.source === "host") return { label: "inherited from Host", status: "neutral", overridden: false };
+  if (field.source === "host") return { label: "inherited from Global", status: "neutral", overridden: false };
   if (field.source === "default") return { label: "inherited from default", status: "neutral", overridden: false };
   if (field.source === "agent" && field.scope === "host") return { label: "overridden here", status: "warning", overridden: true };
   return null; // source=="agent" && scope=="agent" — just an agent setting.
@@ -398,6 +415,11 @@ function SettingRow({
               </Button>
             ) : null}
           </p>
+        ) : null}
+        {/* Editing a still-inherited box-shared field in the Workspace view writes a
+            per-agent leaf override (not the box default) — make that effect explicit. */}
+        {showInheritance && dirty && field.scope === "host" && field.source !== "agent" ? (
+          <p className="setting-override-note">Saving overrides the Global default for this agent only.</p>
         ) : null}
       </div>
       <div className="setting-control">

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Library, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Wrench } from "lucide-react";
+import { Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Palette, Plug, Puzzle, Settings2, Sparkles, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
@@ -9,40 +9,38 @@ import { McpPanel } from "../app/McpPanel";
 import { MiddlewarePanel } from "../app/MiddlewarePanel";
 import { SubagentsPanel } from "../app/SubagentsPanel";
 import { ToolsPanel } from "../app/ToolsPanel";
+import { isHostConsole } from "../lib/api";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { useUI, type SettingsScope } from "../state/uiStore";
-import { TelemetrySurface } from "../telemetry/TelemetrySurface";
-import { CommonsPanel } from "./CommonsPanel";
 import { DelegatesSection } from "./DelegatesSection";
-import { FleetSurface } from "./FleetSurface";
 import { OverviewPanel } from "./OverviewPanel";
-import { HostDefaultsPanel, SettingsCategoryPanel } from "./SettingsCategory";
+import { HostConfigLocked, HostDefaultsPanel, SettingsCategoryPanel } from "./SettingsCategory";
 import { ThemeSurface } from "./ThemeSurface";
 
-// Settings IA (ADR 0048) — scope is the primary axis. TWO homes, each with its own
-// section sub-nav, replacing the old flat category tabs:
+// Settings IA (ADR 0048 + PR4) — scope is the primary axis. TWO homes, each with its
+// own section sub-nav:
 //
-//   🖥 Global       — box-shared, reachable from any workspace (set once, every agent
-//                     inherits; per-agent overrides win, ADR 0047).
+//   🖥 Global       — the box-shared cascade ONLY (ADR 0047): Overview + Configuration
+//                     (the host-scoped fields). Editable on the host console; a
+//                     workspace console sees them read-only. Set once, every agent
+//                     inherits; per-agent overrides win.
 //   🧩 Workspace    — the focused agent: everything that defines it.
 //
-// S-A builds the Host/App home in full and a transitional Workspace home (today's
-// agent-scoped central settings). S-B folds the agent makeup (Identity/Tools/MCP/
-// Subagents/Skills/Middleware + Model/Behavior) into Workspace; S-C removes the
-// standalone Agent rail surface + the old category tabs.
+// Box-level *tools* that aren't cascade settings — Fleet, Telemetry, Commons — moved
+// OUT of Global to the dedicated Box rail surface (src/app/BoxSurface.tsx, PR4).
 
 type Section = { id: string; label: string; icon: LucideIcon; render: () => ReactNode };
 type Home = { id: SettingsScope; label: string; icon: LucideIcon; sections: Section[] };
 
+// Global = the box-shared cascade ONLY (ADR 0047): Overview + the host-scoped fields.
+// Fleet / Telemetry / Commons were box-level *tools*, not cascade settings — moved out
+// to the Box rail surface (PR4). Host config is gated to the host console; a workspace
+// console sees a read-only pointer instead (ADR 0047 §7.7).
 const HOST_SECTIONS: Section[] = [
   { id: "overview", label: "Overview", icon: Gauge, render: () => <OverviewPanel /> },
   // The host-scoped FIELDS (model gateway · routing · caching · org + the commons
   // location) in ONE panel, saving to the box's host-config.yaml (ADR 0047).
-  { id: "config", label: "Host config", icon: HardDrive, render: () => <HostDefaultsPanel title="Host configuration" /> },
-  { id: "fleet", label: "Fleet", icon: Server, render: () => <FleetSurface /> },
-  { id: "telemetry", label: "Telemetry", icon: BarChart3, render: () => <TelemetrySurface /> },
-  // The box-shared skill commons (ADR 0041): browse it, promote from a workspace.
-  { id: "commons", label: "Commons", icon: Library, render: () => <CommonsPanel /> },
+  { id: "config", label: "Configuration", icon: HardDrive, render: () => (isHostConsole() ? <HostDefaultsPanel title="Configuration" /> : <HostConfigLocked />) },
 ];
 
 // The Workspace home (ADR 0048 §3.2) — the focused agent, everything that defines it:

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -178,6 +178,14 @@
   gap: 8px;
   margin: 5px 0 0;
 }
+/* "Saving overrides the Global default for this agent" — shown when a still-inherited
+   box-shared field is edited in the Workspace view (PR4). */
+.setting-override-note {
+  margin: 4px 0 0;
+  font-size: 0.74rem;
+  line-height: 1.4;
+  color: var(--warning);
+}
 .setting-control { min-width: 0; }
 .setting-input {
   width: 100%;

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -24,6 +24,24 @@ describe("migrateUiState", () => {
     expect(out).toEqual({ rightWidth: 320 });
   });
 
+  // v3→v4 (PR4): the new "box" rail surface is injected into a pre-v4 railOrder
+  // (before "settings") so an existing drag-and-drop layout gains it rather than
+  // hiding it.
+  it("injects the Box surface into a pre-v4 railOrder, before settings", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "plugins", "settings"], right: ["beads"] },
+    }) as { railOrder: { left: string[]; right: string[] } };
+    expect(out.railOrder.left).toEqual(["chat", "plugins", "box", "settings"]);
+    expect(out.railOrder.right).toEqual(["beads"]);
+  });
+
+  it("does not duplicate Box if a layout already has it", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "box", "settings"], right: [] },
+    }) as { railOrder: { left: string[] } };
+    expect(out.railOrder.left).toEqual(["chat", "box", "settings"]);
+  });
+
   it("does not mutate the input object", () => {
     const input = { railOf: { chat: "left" }, leftActive: "chat" };
     migrateUiState(input);

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -39,10 +39,13 @@ const _layoutStorage = createJSONStorage(() => ({
 // The "agent" surface folded into Settings ▸ Workspace (ADR 0048 S-C); Knowledge is
 // now store-only (its Memory settings live in Settings ▸ Workspace ▸ Memory).
 export type Surface =
-  | "chat" | "activity" | "studio" | "knowledge" | "plugins" | "settings" | (string & {});
+  | "chat" | "activity" | "studio" | "knowledge" | "plugins" | "box" | "settings" | (string & {});
 export type RightPanel = "notes" | "beads" | "goals" | "schedule" | (string & {}); // + plugin:<id>:<viewId>
 export type PluginsTab = "local" | "market" | "download";
 export type ActivityTab = "thread" | "inbox";
+// The Box surface (PR4 / ADR 0048 §5) — box-level operations that aren't per-agent
+// cascade settings, moved out of the Settings ▸ Global home into their own rail surface.
+export type BoxTab = "fleet" | "telemetry" | "commons";
 // Settings IA (ADR 0048): scope is the primary axis — two homes, each with its own
 // section sub-nav. `settingsScope` picks the home; `settingsSection` the active
 // section within it (a free string so each home owns its own section ids).
@@ -52,6 +55,7 @@ type UIState = {
   surface: Surface;
   rightPanel: RightPanel;
   pluginsTab: PluginsTab;
+  boxTab: BoxTab;
   settingsScope: SettingsScope;
   settingsSection: string;
   // One-shot: the FleetSwitcher's "+ New agent" deep-link routes to Host/App ▸ Fleet
@@ -79,6 +83,7 @@ type UIState = {
   setSurface: (s: Surface) => void;
   setRightPanel: (p: RightPanel) => void;
   setPluginsTab: (t: PluginsTab) => void;
+  setBoxTab: (t: BoxTab) => void;
   setSettingsScope: (s: SettingsScope) => void;
   setSettingsSection: (s: string) => void;
   setFleetStartNew: (b: boolean) => void;
@@ -108,6 +113,17 @@ export function migrateUiState(persisted: unknown): unknown {
       knowledgeTab: _drop4,
       ...rest
     } = persisted as Record<string, unknown>;
+    // v4 (PR4): the "Box" rail surface (Fleet/Telemetry/Commons moved out of Settings ▸
+    // Global). Inject it into a persisted railOrder that predates it — just before
+    // "settings" — so an existing drag-and-drop layout gains the surface instead of
+    // silently hiding it. (A fresh store seeds it via the default railOrder above.)
+    const ro = rest.railOrder as { left?: string[]; right?: string[] } | undefined;
+    if (ro && Array.isArray(ro.left) && !ro.left.includes("box") && !(ro.right ?? []).includes("box")) {
+      const left = ro.left.slice();
+      const at = left.indexOf("settings");
+      left.splice(at >= 0 ? at : left.length, 0, "box");
+      rest.railOrder = { ...ro, left };
+    }
     return rest;
   }
   return persisted;
@@ -119,6 +135,7 @@ export const useUI = create<UIState>()(
       surface: "chat",
       rightPanel: "beads",
       pluginsTab: "local",
+      boxTab: "fleet",
       settingsScope: "host" as SettingsScope,
       settingsSection: "overview",
       fleetStartNew: false,
@@ -127,7 +144,7 @@ export const useUI = create<UIState>()(
       leftCollapsed: false,
       rightWidth: 360,
       railOrder: {
-        left: ["chat", "activity", "studio", "knowledge", "plugins", "settings"],
+        left: ["chat", "activity", "studio", "knowledge", "plugins", "box", "settings"],
         right: ["beads", "goals", "schedule"],
       },
       moveSurface: (id, side) =>
@@ -173,6 +190,7 @@ export const useUI = create<UIState>()(
       setSurface: (surface) => set({ surface }),
       setRightPanel: (rightPanel) => set({ rightPanel }),
       setPluginsTab: (pluginsTab) => set({ pluginsTab }),
+      setBoxTab: (boxTab) => set({ boxTab }),
       // Switching home resets to that home's first section (its own default lives in
       // SettingsSurface); callers that want a specific section call setSettingsSection too.
       setSettingsScope: (settingsScope) => set({ settingsScope }),
@@ -202,7 +220,7 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 3, // v2: railOf→railOrder. v3: settingsTab→settingsScope+settingsSection (ADR 0048)
+      version: 4, // v2: railOf→railOrder. v3: settingsTab→scope+section. v4: +Box rail surface (PR4)
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
     },
   ),


### PR DESCRIPTION
**The headline PR. Stacked on #1069 → #1067 → #1065.** Resolves the Global-vs-Workspace settings IA per the audit (decision: **gate + relocate**, name everything **Global**, relocate to a **Box** rail surface).

## Relocate
Fleet / Telemetry / Commons were box-level **tools**, not cascade settings, but lived as sections under Settings ▸ Global. Moved out to a new **`Box`** rail surface (`app/BoxSurface.tsx`) with Fleet · Telemetry · Commons sub-tabs. `uiStore` bumps to **v4** and injects `"box"` into a pre-existing `railOrder` (before `settings`) so saved drag-and-drop layouts gain it instead of hiding it.

## Global = the cascade only
Settings ▸ Global is now just **Overview + Configuration** (the host-scoped fields).

## Gate the host config
`Configuration` is editable only on the **host console** (`currentSlug() === "host"`, new `lib/api isHostConsole()`). A workspace console gets a read-only pointer (`HostConfigLocked`) → "edited on the host console; override per-agent under Workspace ▸ Settings." This closes the long-standing `TODO(ADR 0047 §7)` (the panel used to let *any* agent edit box-wide defaults under a "Global" label).

## Override clarity
Editing a still-inherited box-shared field in Workspace now shows **"Saving overrides the Global default for this agent only."**

## Naming → "Global"
Tab label "Global" (kept) · section **"Host config" → "Configuration"** · badge **"inherited from Host" → "inherited from Global"** · banner leads with "Global · box-shared defaults". FleetSwitcher "+ New agent" deep-link now targets **Box ▸ Fleet**.

## Tests
- `settings` / `fleet` / `telemetry` e2e rewired to the new IA, **+ a new Box-surface test**.
- `uiStore.test` covers the **v4 railOrder migration** (inject + no-duplicate).
- `tsc --noEmit` clean · `npm run test:unit` **86/86** · full Playwright **106/106**.

## Follow-ups (not here)
The audit also flagged the `identity.name` two-path edit (IdentityPanel `/api/config` vs Settings▸Identity `/api/settings`) and the host-file scoping doc/code mismatch (`infra/paths.py` is per-hub vs the ADR's per-box) — left for a focused pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)