### PR TITLE
refactor(web): nav cleanup — dead notes refs + Schedule Dialog/Tabs

### DIFF
--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -43,7 +43,7 @@ registerContextMenu({
           u.moveSurface(ctx.id, to);
           if (to === "left") {
             u.setSurface(ctx.id);
-            if (u.rightPanel === ctx.id) u.setRightPanel(u.railOrder.right[0] ?? "notes");
+            if (u.rightPanel === ctx.id) u.setRightPanel(u.railOrder.right[0] ?? "beads");
           } else {
             u.setRightPanel(ctx.id);
             u.setRightCollapsed(false);

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -2,17 +2,18 @@ import "./schedule.css";
 
 import { Input, Select, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
+import { Dialog } from "@protolabsai/ui/overlays";
 import {
   useMutation,
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { CalendarClock, Plus, Trash2, X } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { CalendarClock, Plus, Trash2 } from "lucide-react";
+import { useMemo, useState } from "react";
 
 import { StagePanel } from "../app/ErrorBoundary";
 import { RefreshButton } from "../app/ui-kit";
-import { PanelHeader } from "@protolabsai/ui/navigation";
+import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { queryKeys, schedulesQuery } from "../lib/queries";
@@ -67,37 +68,36 @@ function ScheduleModal({
 
   const preview = describeSchedule(schedule);
 
-  useEffect(() => {
-    if (!open) return;
-    const onKey = (e: KeyboardEvent) => e.key === "Escape" && onClose();
-    window.addEventListener("keydown", onKey);
-    return () => window.removeEventListener("keydown", onKey);
-  }, [open, onClose]);
-
-  if (!open) return null;
-
   const canSubmit = !!prompt.trim() && !!schedule && !busy;
 
   return (
-    <div className="confirm-overlay" role="dialog" aria-modal="true" aria-label="New schedule"
-         onClick={onClose} data-testid="schedule-modal">
-      <div className="confirm-card schedule-card" onClick={(e) => e.stopPropagation()}>
-        <div className="confirm-head">
-          <CalendarClock size={16} />
-          <h2>New schedule</h2>
-          <Button icon variant="ghost" className="schedule-close" type="button" onClick={onClose} title="Close">
-            <X size={16} />
+    <Dialog
+      open={open}
+      onClose={onClose}
+      title={<><CalendarClock size={16} /> New schedule</>}
+      width="min(560px, 94vw)"
+      className="schedule-dialog"
+      footer={
+        <>
+          <Button type="button" onClick={onClose}>Cancel</Button>
+          <Button type="button" variant="primary" disabled={!canSubmit} data-testid="schedule-submit"
+                  onClick={() => onAdd({ prompt: prompt.trim(), schedule, job_id: jobId.trim() || undefined, timezone: mode !== "once" && tz ? tz : undefined })}>
+            <Plus size={16} /> Schedule
           </Button>
-        </div>
-
-        <div className="schedule-modes" role="tablist">
-          <button type="button" role="tab" aria-selected={mode === "once"}
-                  className={mode === "once" ? "active" : ""} onClick={() => setMode("once")}>Once</button>
-          <button type="button" role="tab" aria-selected={mode === "repeat"}
-                  className={mode === "repeat" ? "active" : ""} onClick={() => setMode("repeat")}>Repeat</button>
-          <button type="button" role="tab" aria-selected={mode === "cron"}
-                  className={mode === "cron" ? "active" : ""} onClick={() => setMode("cron")}>Cron</button>
-        </div>
+        </>
+      }
+    >
+      <div className="schedule-form" data-testid="schedule-modal">
+        <Tabs
+          ariaLabel="Schedule mode"
+          active={mode}
+          onSelect={(m) => setMode(m as Mode)}
+          items={[
+            { id: "once", label: "Once" },
+            { id: "repeat", label: "Repeat" },
+            { id: "cron", label: "Cron" },
+          ]}
+        />
 
         {mode === "once" && (
           <label className="field">
@@ -165,15 +165,8 @@ function ScheduleModal({
           <Input value={jobId} onChange={(e) => setJobId(e.target.value)} placeholder="auto" />
         </label>
 
-        <div className="confirm-actions">
-          <Button type="button"  onClick={onClose}>Cancel</Button>
-          <Button type="button" variant="primary" disabled={!canSubmit} data-testid="schedule-submit"
-                  onClick={() => onAdd({ prompt: prompt.trim(), schedule, job_id: jobId.trim() || undefined, timezone: mode !== "once" && tz ? tz : undefined })}>
-            <Plus size={16} /> Schedule
-          </Button>
-        </div>
       </div>
-    </div>
+    </Dialog>
   );
 }
 

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -40,7 +40,9 @@ const _layoutStorage = createJSONStorage(() => ({
 // now store-only (its Memory settings live in Settings ▸ Workspace ▸ Memory).
 export type Surface =
   | "chat" | "activity" | "studio" | "knowledge" | "plugins" | "box" | "settings" | (string & {});
-export type RightPanel = "notes" | "beads" | "goals" | "schedule" | (string & {}); // + plugin:<id>:<viewId>
+// `notes` is no longer a built-in right panel — it's the first-party `notes` plugin
+// (keyed `plugin:notes:<view>`), so it falls under the open `(string & {})` arm.
+export type RightPanel = "beads" | "goals" | "schedule" | (string & {}); // + plugin:<id>:<viewId>
 export type PluginsTab = "local" | "market" | "download";
 export type ActivityTab = "thread" | "inbox";
 // The Box surface (PR4 / ADR 0048 §5) — box-level operations that aren't per-agent


### PR DESCRIPTION
**Final PR of the sweep. Stacked on #1071 → #1069 → #1067 → #1065.**

## Dead-code cleanup
`notes` is the first-party `notes` *plugin* now (keyed `plugin:notes:*`), not a built-in panel. Dropped it from the `RightPanel` union and switched the move-rail context-menu fallback from `"notes"` → `"beads"`.

## Schedule → DS (the deferred structural swaps)
- **"New schedule" modal → DS `Dialog`** — Esc/backdrop dismiss, focus trap, and the titled head/footer now come from the DS; the hand-rolled `.confirm-overlay`, the Escape `useEffect`, and the manual close button are gone. `data-testid="schedule-modal"` + every field testid preserved.
- **Mode switch (Once/Repeat/Cron) → DS `Tabs`** — default variant, so it keeps `role="tab"` and the e2e + a11y semantics are unchanged (segmented would have dropped `role="tab"`).

## Justified exceptions (not guessed)
- **FleetSwitcher stays hand-rolled.** Each row carries a *secondary* per-row action (open-in-new-window) alongside the primary navigate — DS `MenuItem` is a single-action Radix item and can't model that without regressing the feature. Real DS gap: "MenuItem with a trailing action."
- **Plugin-management home** and **Schedule's rail placement** are genuine IA forks ADR 0048 explicitly left open (Settings▸Plugins is plugin *settings*; the Download tab is *install* — not a literal duplicate to dedupe). Not decided unilaterally.

## Test
`tsc --noEmit` clean · `npm run test:unit` 86/86 · full Playwright **106/106**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)