### PR TITLE
fix(settings): identity.name single edit path — ui_hidden field (#1076)

### DIFF
--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -43,6 +43,10 @@ class Field:
     # the home/default layer + where the settings UI writes it. No "app" value: the
     # App layer is the dataclass defaults (no writable file).
     scope: str = "agent"
+    # Keep the field in FIELDS (so it round-trips through config_to_dict / the YAML
+    # writer) but DON'T render it in the generic Settings UI — for a key a dedicated
+    # panel already owns. `build_schema` skips it; `config_to_dict` keeps it. (#1076)
+    ui_hidden: bool = False
 
 
 # Ordered registry. Section order here is the order the UI renders groups in.
@@ -455,7 +459,11 @@ FIELDS: list[Field] = [
         scope="host",
     ),
     # ── Identity / operator ──────────────────────────────────────────────────
-    Field("identity.name", "identity_name", "Agent name", "string", "Identity"),
+    # `identity.name` stays in FIELDS so it round-trips through the YAML writer, but
+    # it's ui_hidden: the dedicated Identity panel (Workspace ▸ Identity, POST
+    # /api/config) owns the agent name alongside its persona (SOUL.md). Surfacing it
+    # here too made the same field editable from two places with two write paths (#1076).
+    Field("identity.name", "identity_name", "Agent name", "string", "Identity", ui_hidden=True),
     Field("identity.operator", "identity_operator", "Operator", "string", "Identity"),
     Field("identity.org", "identity_org", "Organization", "string", "Identity", scope="host"),
     Field(
@@ -726,6 +734,8 @@ def build_schema(
     defaults = type(config)()
     groups: dict[str, dict[str, Any]] = {}
     for f in FIELDS:
+        if f.ui_hidden:
+            continue  # in FIELDS for config round-trip, but a dedicated panel owns the UI (#1076)
         if _frozen and f.key.startswith("execute_code"):
             continue
         current = getattr(config, f.attr, None)

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -18,11 +18,15 @@ def test_schema_groups_and_values():
     # Grouped + ordered by category: the Agent category leads, runtime first.
     assert [g["section"] for g in groups][:3] == ["Agent runtime", "Model", "Routing"]
     fields = [f for g in groups for f in g["fields"]]
-    # Every core FIELD is present. (build_schema also appends plugin-declared
-    # settings — e.g. the discord plugin — so count only the core-keyed fields,
+    # Every core FIELD is present — EXCEPT ui_hidden ones, which stay in FIELDS for
+    # config round-trip but aren't rendered in the settings UI (e.g. identity.name,
+    # owned by the dedicated Identity panel — #1076). (build_schema also appends
+    # plugin-declared settings — e.g. discord — so count only the core-keyed fields,
     # which keeps this robust to whichever plugins are installed.)
     core_keys = {f.key for f in FIELDS}
-    assert len([f for f in fields if f["key"] in core_keys]) == len(FIELDS)
+    visible_core = [f for f in FIELDS if not f.ui_hidden]
+    assert len([f for f in fields if f["key"] in core_keys]) == len(visible_core)
+    assert "identity.name" not in {f["key"] for f in fields}  # ui_hidden → not in the UI
     for f in fields:
         assert {"key", "label", "type", "value", "default", "restart", "description"} <= set(f)
     # The model select is populated from the probed options.


### PR DESCRIPTION
Closes #1076.

`identity.name` was editable from **two places with two write paths** — the dedicated Identity panel (Workspace ▸ Identity → `POST /api/config`, name + SOUL.md) **and** the generic Settings ▸ Identity accordion (`POST /api/settings`). Same config key, two doors.

## Why not just remove the schema field
`config_to_dict` is **FIELDS-complete** and drives the YAML round-trip (`apply_updates_to_yaml`), so dropping `identity.name` from `FIELDS` would strand it from persistence — a test (`test_config_io::test_config_to_dict_mirrors_yaml_shape`) catches exactly this.

## Fix — a `ui_hidden` flag
Mirrors the existing frozen/`execute_code` skip in `build_schema`:
- `build_schema` **omits** `ui_hidden` fields from the settings UI.
- `config_to_dict` **keeps** them (round-trip intact — it iterates `FIELDS` directly).
- `identity.name` is marked `ui_hidden=True`; the Identity panel is now its single editor; it still persists normally.

Reusable for any future "a dedicated panel owns this key" case.

## Tests
- `test_settings_schema` now asserts the visible-field count excludes `ui_hidden` fields, and that `identity.name` is no longer rendered in the UI.
- `tsc`-side / frontend: no change needed — `build_schema` drives the UI, so the field just stops appearing.
- `.venv-test` run: settings/config/cascade suites pass. (3 `test_config_roundtrip` failures are a **pre-existing local-env secret-redaction artifact** — they fail identically on clean `main`; green in CI's clean env.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)