### PR TITLE
feat(web): fold Schedule into the Activity surface as a 3rd tab (#1075)

### DIFF
--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -24,8 +24,9 @@ test("Studio lands directly on Workflows (Run tab removed — run is a chat gest
   await expect(page.locator(".pl-tabs").getByRole("tab", { name: "Run", exact: true })).toHaveCount(0);
 });
 
-test("schedule is a right-rail panel that lists scheduled jobs", async ({ page }) => {
-  await page.getByRole("button", { name: "Schedule", exact: true }).click();
+test("schedule is a tab of the Activity surface that lists scheduled jobs (#1075)", async ({ page }) => {
+  await page.locator(".pl-rail").getByRole("button", { name: "Activity", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Schedule", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Schedule" })).toBeVisible();
   await expect(page.getByText("Summarize overnight activity")).toBeVisible();
 });

--- a/apps/web/e2e/schedule.spec.ts
+++ b/apps/web/e2e/schedule.spec.ts
@@ -6,8 +6,9 @@ import { expect, test } from "@playwright/test";
 
 async function openScheduleModal(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  // Schedule is a first-class right-rail panel (notes/beads/goals/schedule).
-  await page.getByRole("button", { name: "Schedule", exact: true }).click();
+  // Schedule is now a tab inside the Activity surface (#1075).
+  await page.locator(".pl-rail").getByRole("button", { name: "Activity", exact: true }).click();
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Schedule", exact: true }).click();
   await page.getByTestId("schedule-new").click();
   await expect(page.getByTestId("schedule-modal")).toBeVisible();
 }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -496,7 +496,7 @@ export function App() {
     { id: "settings", label: "Settings", icon: <Settings2 size={18} /> },
     { id: "beads", label: "Beads", icon: <Boxes size={18} /> },
     { id: "goals", label: "Goals", icon: <Target size={18} /> },
-    { id: "schedule", label: "Schedule", icon: <CalendarClock size={18} /> },
+    // "schedule" is now a tab inside the Activity surface (#1075), not a rail surface.
   ];
   // Surfaces for a rail side, in the user's order (railOrder, ADR 0036). Core AND plugin views are
   // first-class railOrder members — reconciled below — so all are reorderable/movable, including
@@ -532,11 +532,14 @@ export function App() {
       case "activity":
         return (
           <>
+            {/* Schedule is a third Activity tab (#1075): cron is a TRIGGER, so timed
+                turns belong alongside the thread + inbox triggers, not in their own rail. */}
             <Tabs responsive active={activityTab} onSelect={(t) => setActivityTab(t as ActivityTab)} items={[
               { id: "thread", label: "Thread", icon: Activity },
               { id: "inbox", label: "Inbox", icon: Inbox, badge: inboxUnread ? (<span data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span>) : null },
+              { id: "schedule", label: "Schedule", icon: CalendarClock },
             ].map(toTab)} />
-            {activityTab === "thread" ? <ActivitySurface onError={setError} /> : <InboxPanel />}
+            {activityTab === "thread" ? <ActivitySurface onError={setError} /> : activityTab === "inbox" ? <InboxPanel /> : <SchedulePanel />}
           </>
         );
       // The Agent surface folded into Settings ▸ Workspace (ADR 0048 S-C). Its tabs
@@ -569,8 +572,7 @@ export function App() {
         return <BeadsPanel confirm={setConfirmState} />;
       case "goals":
         return <GoalsPanel />;
-      case "schedule":
-        return <SchedulePanel />;
+      // "schedule" folded into the Activity surface as a 3rd tab (#1075) — no rail surface.
       default: {
         // Fork-contributed surface (src/ext seam, ADR 0038 D3) — rendered in-process.
         // Skip a requiresPlugin surface when its plugin is off (e.g. a stale saved order).

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -42,6 +42,16 @@ describe("migrateUiState", () => {
     expect(out.railOrder.left).toEqual(["chat", "box", "settings"]);
   });
 
+  // v4→v5 (#1075): "schedule" folded into the Activity surface (a tab), so it's pruned
+  // from a persisted railOrder rather than lingering as a dead rail id.
+  it("prunes the obsolete 'schedule' rail surface", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "settings"], right: ["beads", "goals", "schedule"] },
+    }) as { railOrder: { left: string[]; right: string[] } };
+    expect(out.railOrder.right).toEqual(["beads", "goals"]);
+    expect(out.railOrder.left).not.toContain("schedule");
+  });
+
   it("does not mutate the input object", () => {
     const input = { railOf: { chat: "left" }, leftActive: "chat" };
     migrateUiState(input);

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -42,9 +42,11 @@ export type Surface =
   | "chat" | "activity" | "studio" | "knowledge" | "plugins" | "box" | "settings" | (string & {});
 // `notes` is no longer a built-in right panel — it's the first-party `notes` plugin
 // (keyed `plugin:notes:<view>`), so it falls under the open `(string & {})` arm.
-export type RightPanel = "beads" | "goals" | "schedule" | (string & {}); // + plugin:<id>:<viewId>
+export type RightPanel = "beads" | "goals" | (string & {}); // + plugin:<id>:<viewId>
 export type PluginsTab = "local" | "market" | "download";
-export type ActivityTab = "thread" | "inbox";
+// "schedule" joins thread/inbox here (#1075): cron is a trigger, so timed turns are a
+// tab of the Activity surface rather than a standalone rail surface.
+export type ActivityTab = "thread" | "inbox" | "schedule";
 // The Box surface (PR4 / ADR 0048 §5) — box-level operations that aren't per-agent
 // cascade settings, moved out of the Settings ▸ Global home into their own rail surface.
 export type BoxTab = "fleet" | "telemetry" | "commons";
@@ -126,6 +128,15 @@ export function migrateUiState(persisted: unknown): unknown {
       left.splice(at >= 0 ? at : left.length, 0, "box");
       rest.railOrder = { ...ro, left };
     }
+    // v5 (#1075): "schedule" folded into the Activity surface (a tab), so prune it from a
+    // persisted railOrder — otherwise it lingers as a dead rail id with no surface metadata.
+    const ro2 = rest.railOrder as { left?: string[]; right?: string[] } | undefined;
+    if (ro2 && (Array.isArray(ro2.left) || Array.isArray(ro2.right))) {
+      rest.railOrder = {
+        left: (ro2.left ?? []).filter((x) => x !== "schedule"),
+        right: (ro2.right ?? []).filter((x) => x !== "schedule"),
+      };
+    }
     return rest;
   }
   return persisted;
@@ -147,7 +158,7 @@ export const useUI = create<UIState>()(
       rightWidth: 360,
       railOrder: {
         left: ["chat", "activity", "studio", "knowledge", "plugins", "box", "settings"],
-        right: ["beads", "goals", "schedule"],
+        right: ["beads", "goals"],
       },
       moveSurface: (id, side) =>
         set((s) => {
@@ -222,7 +233,7 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 4, // v2: railOf→railOrder. v3: settingsTab→scope+section. v4: +Box rail surface (PR4)
+      version: 5, // v2 railOf→railOrder · v3 settingsTab→scope+section · v4 +Box surface · v5 Schedule→Activity tab (#1075)
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
     },
   ),


### PR DESCRIPTION
Closes #1075.

Cron is a **trigger** (ADR 0009), so timed turns belong alongside the thread + inbox triggers — but Schedule shipped as a standalone right-rail surface, navigationally divorced from Activity. This folds it in.

## Change
- **Activity surface gains a third tab**: Thread · Inbox · **Schedule** (`ActivityTab` gains `"schedule"`; `SchedulePanel` renders under it).
- **`schedule` removed as a rail surface** — out of `CORE_SURFACES` + the `railOrder.right` default; dropped from the `RightPanel` union. `uiStore` bumps to **v5**, pruning a persisted `"schedule"` rail id so existing layouts don't strand a dead entry.
- **e2e**: `navigation.spec` + `schedule.spec` now navigate via Activity ▸ Schedule tab; a `uiStore.test` covers the v5 prune.

## Test
`tsc --noEmit` clean · `npm run test:unit` 87/87 · full Playwright **106/106**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)