### PR TITLE
fix(settings): host-config banner — accurate per-hub scope (#1077, copy)

### DIFF
--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -262,9 +262,10 @@ export function SettingsCategory({
       <div className="stage-body">
         {hostLayer ? (
           <Alert status="info" className="settings-banner">
-            <strong>Global · box-shared defaults</strong> (ADR 0047) — edits here write to the
-            box's <code>host-config.yaml</code> and become the inherited default for every agent
-            on this box that hasn't set its own value. Per-agent overrides win.
+            <strong>Global · box-shared defaults</strong> (ADR 0047) — edits here write to this
+            hub's <code>host-config.yaml</code> and become the inherited default for every agent the
+            hub manages that hasn't set its own value. Per-agent overrides win. (Usually one hub per
+            machine; a machine running several hubs keeps a host-config per hub.)
           </Alert>
         ) : null}
         {acpAgent ? (


### PR DESCRIPTION
Addresses the **user-facing copy half** of #1077 (the issue stays open for the architecture decision).

## Problem
The Global ▸ Configuration banner overstated the sharing scope — "edits here write to **the box's** `host-config.yaml` … the inherited default for **every agent on this box**" — but `host_config_path()` is `scope_leaf`'d **per hub** (`infra/paths.py`). A box running multiple hubs keeps a host-config per hub, so "box" overstates it.

## Change
Reworded the editable host-layer banner to "**this hub's** `host-config.yaml` … every agent **the hub manages**", with a one-hub-per-machine clarifier. Kept "box-shared" as the casual header label (`HostConfigLocked` was already accurate — "this workspace inherits them").

## Out of scope (stays open in #1077)
The formal decision — **ratify** the shipped per-hub behavior in ADR 0047 §D2, or **revert** the code to per-box (un-`scope_leaf` `host_config_path`) — is yours. This PR only stops the copy from lying about current behavior.

## Test
`tsc` clean · settings + quick-settings e2e 9/9 (the banner's `box-shared` assertion still holds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)