### PR TITLE
feat(web): adopt DS Combobox in SettingsCategory; bump @protolabsai/ui 0.37.0 (#1079)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.35.0",
+    "@protolabsai/ui": "^0.37.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -1,7 +1,7 @@
 import "./settings.css";
 
 import { Alert } from "@protolabsai/ui/data";
-import { Input, Select, Switch, Textarea } from "@protolabsai/ui/forms";
+import { Combobox, Input, Select, Switch, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Link2, Loader2, RotateCcw, Save } from "lucide-react";
@@ -469,29 +469,27 @@ export function SettingInput({ field, value, onChange }: { field: SettingsField;
   // ordered. Clearing a row removes it.
   if (field.type === "string_list" && field.options.length) {
     const items = Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
-    const listId = `${id}-models`;
     const update = (i: number, v: string) => {
       const next = items.slice();
       if (v) next[i] = v;
       else next.splice(i, 1);
       onChange(next);
     };
+    // A column of DS Comboboxes — one per value plus a trailing blank-to-add row;
+    // each carries its own suggestion list (the gateway models), and clearing a row
+    // removes it. Type any alias OR pick a suggestion.
     return (
       <div id={id} className="setting-list" style={{ display: "flex", flexDirection: "column", gap: "0.35rem" }}>
         {[...items, ""].map((item, i) => (
-          <input
+          <Combobox
             key={i}
             className="setting-input"
-            type="text"
-            list={listId}
+            options={field.options}
             value={item}
             placeholder={i === items.length ? "add a model…" : ""}
-            onChange={(e) => update(i, e.target.value)}
+            onValueChange={(v) => update(i, v)}
           />
         ))}
-        <datalist id={listId}>
-          {field.options.map((opt) => <option key={opt} value={opt} />)}
-        </datalist>
       </div>
     );
   }
@@ -540,24 +538,15 @@ export function SettingInput({ field, value, onChange }: { field: SettingsField;
   // values stay valid (these fields aren't membership-checked), so a datalist of
   // suggestions is the right control.
   if (field.options.length) {
-    const listId = `${id}-models`;
     return (
-      <>
-        <input
-          id={id}
-          className="setting-input"
-          type="text"
-          list={listId}
-          placeholder="type or pick a model"
-          value={typeof value === "string" ? value : value === undefined || value === null ? "" : String(value)}
-          onChange={(e) => onChange(e.target.value)}
-        />
-        <datalist id={listId}>
-          {field.options.map((opt) => (
-            <option key={opt} value={opt} />
-          ))}
-        </datalist>
-      </>
+      <Combobox
+        id={id}
+        className="setting-input"
+        options={field.options}
+        placeholder="type or pick a model"
+        value={typeof value === "string" ? value : value === undefined || value === null ? "" : String(value)}
+        onValueChange={onChange}
+      />
     );
   }
   return (

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.35.0",
+        "@protolabsai/ui": "^0.37.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.35.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.35.0.tgz",
-      "integrity": "sha512-bgHLKHHnVIkzcSnxFe3xDfDDQhmocjE1vqwK8aOEzrl8F+8IHfTExyLZN5bJ/ed02TudtWITl1WBHZXzVI+iDQ==",
+      "version": "0.37.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.37.0.tgz",
+      "integrity": "sha512-GGOk6rcu5qLlYdFPpbz7KZ35jXePQETz471pPlucFWyPoPVKGirDMoWUkwoU+SdmMHoAGMx38AB9VGYDRT2RJw==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Closes #1079.

The model-pickers in `SettingInput` were the last raw form controls left after the DS sweep — a raw `<input list>` + `<datalist>` for the free-text-with-options field (`routing.aux_model`, `knowledge.transcribe_model`) and a column of them for the `string_list`-with-options field (`routing.fallback_models`). Both now use the DS **`Combobox`** (shipped in `@protolabsai/ui@0.36.0`).

## Change
- **Bump** `@protolabsai/ui` `^0.35.0` → `^0.37.0` (brings `Combobox` + the new `MenuItem` `action` slot used by the FleetSwitcher adoption next).
- **`SettingInput`** — both datalist sites → `<Combobox options value onValueChange>`; each control carries its own generated datalist (drops the hand-managed `listId` + `<datalist>`).

## Test
`tsc` clean · `npm run test:unit` · full Playwright **106/106** (the settings specs exercise `routing.aux_model` / `fallback_models` — the Combobox still renders an `<input>`, so the selectors hold).

Follow-up (separate PR): FleetSwitcher → DS `Menu` + the `MenuItem action` slot (#1078).

🤖 Generated with [Claude Code](https://claude.com/claude-code)