### PR TITLE
feat(web): FleetSwitcher → DS Menu with trailing per-row action (#1078)

### DIFF
--- a/apps/web/src/app/FleetSwitcher.tsx
+++ b/apps/web/src/app/FleetSwitcher.tsx
@@ -1,7 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { Check, ChevronDown, ExternalLink, Plus } from "lucide-react";
-import { useEffect, useRef, useState, type ReactNode } from "react";
+import type { ReactNode } from "react";
 
+import { Menu, MenuItem, MenuSeparator } from "@protolabsai/ui/menu";
 import { Badge } from "@protolabsai/ui/primitives";
 
 import { agentHref, api, currentSlug } from "../lib/api";
@@ -14,21 +15,11 @@ const slugOf = (a: { id: string; host?: boolean }) => (a.host ? "host" : a.id);
 // Topbar agent switcher (ADR 0042 slug routing). The focused agent lives in the URL
 // (/app/agent/<slug>/), so picking one NAVIGATES there — each window is its own agent, a reload
 // can't desync, and you can open a second agent in a new window. Single-agent (just the host) →
-// plain name, no dropdown.
+// plain name, no dropdown. The dropdown is the DS Menu (#1078): open/close, outside-click, focus
+// trap, and the trailing per-row "open in a new window" action all come from @protolabsai/ui.
 export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: ReactNode; onNewAgent?: () => void }) {
   // Poll so the topbar reflects the fleet live (a newly-added agent makes the switcher appear).
   const fleet = useQuery({ queryKey: queryKeys.fleet, queryFn: () => api.fleet(), retry: false, refetchInterval: 3_000 });
-  const [open, setOpen] = useState(false);
-  const ref = useRef<HTMLDivElement>(null);
-
-  useEffect(() => {
-    if (!open) return;
-    const onDoc = (e: MouseEvent) => {
-      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false);
-    };
-    document.addEventListener("mousedown", onDoc);
-    return () => document.removeEventListener("mousedown", onDoc);
-  }, [open]);
 
   const agents = fleet.data?.agents ?? [];
   const slug = currentSlug(); // the agent THIS window is on
@@ -38,72 +29,47 @@ export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: Reac
   if (fleet.isError || agents.length <= 1) return <>{fallbackName}</>;
 
   return (
-    <div className="fleet-switcher" ref={ref}>
-      <button
-        type="button"
-        className="fleet-switcher-trigger"
-        onClick={() => setOpen((o) => !o)}
-        aria-haspopup="menu"
-        aria-expanded={open}
-        data-testid="fleet-switcher"
-      >
-        <span>{current?.name ?? fallbackName}</span>
-        <ChevronDown size={14} />
-      </button>
-      {open ? (
-        <div className="fleet-switcher-menu" role="menu">
-          {agents.map((a) => {
-            const isCurrent = slugOf(a) === slug;
-            return (
-              <button
-                key={a.name}
-                type="button"
-                role="menuitem"
-                className={`fleet-switcher-item${isCurrent ? " active" : ""}`}
-                onClick={() => {
-                  if (!isCurrent) window.location.href = agentHref(slugOf(a)); // navigate → this agent
-                }}
-              >
-                <span className={`fleet-dot ${a.running ? "running" : "stopped"}`} aria-hidden />
-                <span className="fleet-switcher-name">
-                  {a.name}
-                  {a.host ? <Badge status="neutral">this instance</Badge> : null}
-                </span>
-                {isCurrent ? (
-                  <Check size={14} />
-                ) : (
-                  // Open this agent in a second window (two agents at once — the whole point of
-                  // slug routing). A span, not a nested button, to keep the markup valid.
-                  <span
-                    className="fleet-switcher-newwin"
-                    role="button"
-                    tabIndex={0}
-                    title="Open in a new window"
-                    onClick={(e) => {
-                      e.stopPropagation();
-                      window.open(agentHref(slugOf(a)), "_blank", "noopener");
-                    }}
-                  >
-                    <ExternalLink size={13} />
-                  </span>
-                )}
-              </button>
-            );
-          })}
-          <div className="fleet-switcher-sep" />
-          <button
-            type="button"
-            role="menuitem"
-            className="fleet-switcher-item"
-            onClick={() => {
-              setOpen(false);
-              onNewAgent?.();
+    <Menu
+      trigger={
+        <button type="button" className="fleet-switcher-trigger" data-testid="fleet-switcher" aria-label="Switch agent">
+          <span>{current?.name ?? fallbackName}</span>
+          <ChevronDown size={14} />
+        </button>
+      }
+    >
+      {agents.map((a) => {
+        const isCurrent = slugOf(a) === slug;
+        return (
+          <MenuItem
+            key={a.name}
+            icon={<span className={`fleet-dot ${a.running ? "running" : "stopped"}`} aria-hidden />}
+            onSelect={() => {
+              if (!isCurrent) window.location.href = agentHref(slugOf(a)); // navigate → this agent
             }}
+            // Non-current rows get a trailing "open in a new window" action (two agents at once —
+            // the point of slug routing); it doesn't trigger the row's navigate or close the menu.
+            action={
+              isCurrent
+                ? undefined
+                : {
+                    icon: <ExternalLink size={13} />,
+                    label: "Open in a new window",
+                    onClick: () => window.open(agentHref(slugOf(a)), "_blank", "noopener"),
+                  }
+            }
           >
-            <Plus size={14} /> New agent
-          </button>
-        </div>
-      ) : null}
-    </div>
+            <span className="fleet-switcher-name">
+              {a.name}
+              {a.host ? <Badge status="neutral">this instance</Badge> : null}
+              {isCurrent ? <Check size={14} className="fleet-switcher-check" /> : null}
+            </span>
+          </MenuItem>
+        );
+      })}
+      <MenuSeparator />
+      <MenuItem icon={<Plus size={14} />} onSelect={() => onNewAgent?.()}>
+        New agent
+      </MenuItem>
+    </Menu>
   );
 }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1878,19 +1878,10 @@ textarea {
   color: var(--fg-muted);
 }
 
-/* Topbar fleet switcher (ADR 0042) — the agent name as a dropdown */
-/* The DS Header name slot (.pl-header__name) sets `overflow: hidden` for text ellipsis — but
-   it now hosts the FleetSwitcher, whose dropdown menu is positioned BELOW the trigger and so
-   gets clipped invisible. Let the slot (and the lockup above it) overflow when the switcher
-   lives there, so the menu actually shows. */
-.pl-header__lockup:has(.fleet-switcher),
-.pl-header__name:has(.fleet-switcher) {
-  overflow: visible;
-}
-.fleet-switcher {
-  position: relative;
-  display: inline-flex;
-}
+/* Topbar fleet switcher (ADR 0042) — the agent name as a DS Menu trigger (#1078).
+   The dropdown itself is the DS Menu (.pl-menu, portaled to <body>), so the old
+   overflow-visible hack + the hand-rolled .fleet-switcher-menu/item/sep rules are
+   gone; only the trigger button + the per-row name layout remain. */
 .fleet-switcher-trigger {
   display: inline-flex;
   align-items: center;
@@ -1908,49 +1899,15 @@ textarea {
 .fleet-switcher-trigger:hover {
   background: var(--bg-hover);
 }
-.fleet-switcher-menu {
-  position: absolute;
-  top: calc(100% + 6px);
-  left: 0;
-  z-index: 60;
-  min-width: 200px;
-  padding: 4px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-panel);
-  box-shadow: var(--pl-shadow-popover);
-  display: flex;
-  flex-direction: column;
-  gap: 1px;
-}
-.fleet-switcher-item {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  width: 100%;
-  padding: 7px 9px;
-  background: none;
-  border: none;
-  border-radius: 5px;
-  color: var(--fg);
-  font: inherit;
-  text-align: left;
-  cursor: pointer;
-}
-.fleet-switcher-item:hover {
-  background: var(--bg-hover);
-}
-.fleet-switcher-item.active {
-  color: var(--accent);
-}
 .fleet-switcher-name {
-  flex: 1 1 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
   min-width: 0;
 }
-.fleet-switcher-sep {
-  height: 1px;
-  margin: 4px 2px;
-  background: var(--border);
+.fleet-switcher-check {
+  flex: 0 0 auto;
+  color: var(--accent);
 }
 
 /* .fleet-host-tag retired (#832) — the "this instance" / "remote" tags in the


### PR DESCRIPTION
Closes #1078. Completes the DS adoption sweep — the **last hand-rolled dropdown** in the console now uses DS `Menu` (shipped in `@protolabsai/ui@0.37.0`).

## Change
- **FleetSwitcher** — drop the `open`/`ref`/outside-click `useEffect` and the hand-rolled `role="menu"` markup → `<Menu trigger={…}>` with `<MenuItem onSelect action=…>`. Open/close, outside-click, focus, and the portaled popover come from the DS. Each non-current row's **"open in a new window"** is the new `MenuItem` **`action`** slot (#241) — it doesn't trigger the row's navigate or close the menu, the exact behavior this hand-rolled before.
- **`theme.css`** — remove the now-dead `.fleet-switcher` / `-menu` / `-item` / `-sep` rules and the `overflow:visible` `:has()` hack (the DS popover portals to `<body>`, so the clipping workaround is moot); keep the trigger + name layout, add `.fleet-switcher-check`.

## Test
`tsc` clean · `npm run build` (CSS-comment check) clean · full Playwright **106/106**, including **fleet.spec's 7** switcher tests (navigate-by-slug, rename, discover→switch — all drive the DS Menu).

🤖 Generated with [Claude Code](https://claude.com/claude-code)