### PR TITLE
feat(web): bottom dock — third surface dock wired to the DS AppShell

### DIFF
--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -128,6 +128,23 @@ test("Chat is movable too — right-click → move to the right rail (ADR 0036)"
   await expect(leftRail.getByRole("button", { name: "Chat", exact: true })).toHaveCount(0);
 });
 
+test("right-click → Move to bottom dock docks the surface at the bottom", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const rightRail = page.locator(".pl-rail--right");
+  const bottomRail = page.locator(".pl-rail--bottom");
+  // The bottom rail exists as an (empty) drop target, but nothing is docked there by default.
+  await expect(bottomRail.getByRole("button")).toHaveCount(0);
+
+  // Move Beads (right rail) → bottom dock.
+  await rightRail.getByRole("button", { name: "Beads", exact: true }).click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Move to bottom dock").click();
+
+  // Beads now lives in the (icon-only) bottom rail, off the right rail, and its panel opens.
+  await expect(bottomRail.getByRole("button", { name: "Beads", exact: true })).toBeVisible();
+  await expect(rightRail.getByRole("button", { name: "Beads", exact: true })).toHaveCount(0);
+  await expect(page.locator(".pl-appshell__bottom").getByRole("heading", { name: "Beads" })).toBeVisible();
+});
+
 test("mobile shell: bottom quick-bar + hamburger drawer (ADR 0035 S4)", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 800 });
   await page.goto("/app/", { waitUntil: "load" });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.37.0",
+    "@protolabsai/ui": "^0.38.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -240,6 +240,12 @@ export function App() {
   const setLeftCollapsed = useUI((s) => s.setLeftCollapsed);
   const rightWidth = useUI((s) => s.rightWidth);
   const setRightWidth = useUI((s) => s.setRightWidth);
+  const bottomPanel = useUI((s) => s.bottomPanel);
+  const setBottomPanel = useUI((s) => s.setBottomPanel);
+  const bottomHeight = useUI((s) => s.bottomHeight);
+  const setBottomHeight = useUI((s) => s.setBottomHeight);
+  const bottomCollapsed = useUI((s) => s.bottomCollapsed);
+  const setBottomCollapsed = useUI((s) => s.setBottomCollapsed);
   const railOrder = useUI((s) => s.railOrder);
   const reconcilePluginViews = useUI((s) => s.reconcilePluginViews);
   const isMobile = useIsMobile();
@@ -330,8 +336,9 @@ export function App() {
     [],
   );
 
-  const pluginRail = allPluginViews.filter((v) => (v.placement ?? "rail") !== "right");
+  const pluginRail = allPluginViews.filter((v) => (v.placement ?? "rail") !== "right" && v.placement !== "bottom");
   const pluginRightPanels = allPluginViews.filter((v) => v.placement === "right");
+  const pluginBottom = allPluginViews.filter((v) => v.placement === "bottom");
   const activePluginView = pluginRail.find((v) => v.key === surface) ?? null;
 
   // Stale-surface fallback: if we're on a plugin view that no longer exists (its
@@ -508,11 +515,11 @@ export function App() {
     allPluginViews.map((v) => [v.key, { id: v.key, label: v.label, icon: pluginViewIcon(v.icon) }] as const),
   );
   const metaFor = (id: string): RailItem | undefined => coreMeta.get(id) ?? pluginMeta.get(id);
-  function railSurfaces(side: "left" | "right"): RailItem[] {
-    const placed = new Set([...railOrder.left, ...railOrder.right]);
+  function railSurfaces(side: "left" | "right" | "bottom"): RailItem[] {
+    const placed = new Set([...railOrder.left, ...railOrder.right, ...railOrder.bottom]);
     const ordered = (railOrder[side] ?? []).map(metaFor).filter((s): s is RailItem => Boolean(s));
     // Safety net: a plugin view that appeared before reconcile ran — append it for this side.
-    const extra = (side === "left" ? pluginRail : pluginRightPanels)
+    const extra = (side === "left" ? pluginRail : side === "right" ? pluginRightPanels : pluginBottom)
       .filter((v) => !placed.has(v.key))
       .map((v): RailItem => ({ id: v.key, label: v.label, icon: pluginViewIcon(v.icon) }));
     // Fork-contributed surfaces (ADR 0038 D3 — the src/ext seam), appended for their rail side.
@@ -597,6 +604,7 @@ export function App() {
     reconcilePluginViews([
       ...pluginRail.map((v) => ({ id: v.key, side: "left" as const })),
       ...pluginRightPanels.map((v) => ({ id: v.key, side: "right" as const })),
+      ...pluginBottom.map((v) => ({ id: v.key, side: "bottom" as const })),
     ]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pluginViewSig, pluginViewsLoaded, reconcilePluginViews]);
@@ -607,6 +615,9 @@ export function App() {
   const rightMembers = railSurfaces("right").map((s) => s.id);
   const leftActive = leftMembers.includes(surface) ? surface : (leftMembers[0] ?? "chat");
   const rightActive = rightMembers.includes(rightPanel) ? rightPanel : (rightMembers[0] ?? "beads");
+  // Bottom dock active surface (mirror left/right) — clamp to a member of the bottom dock.
+  const bottomMembers = railSurfaces("bottom").map((s) => s.id);
+  const bottomActive = bottomMembers.includes(bottomPanel) ? bottomPanel : (bottomMembers[0] ?? "");
   // Chat mounts unconditionally on whichever side it's on (streaming continuity, #613).
   const chatRail: "left" | "right" = railOrder.right.includes("chat") ? "right" : "left";
 
@@ -622,6 +633,7 @@ export function App() {
   // be excluded — otherwise that panel could never light a dot.
   const visibleKeys: string[] = [leftActive, mobileActive];
   if (!rightCollapsed) visibleKeys.push(rightActive);
+  if (!bottomCollapsed && bottomActive) visibleKeys.push(bottomActive);
   const activeKeysRef = useRef<Set<string>>(new Set());
   activeKeysRef.current = new Set(visibleKeys);
   useEffect(
@@ -644,7 +656,7 @@ export function App() {
       if (key && key.startsWith("plugin:")) setPluginDot(key, false);
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [leftActive, rightActive, mobileActive, rightCollapsed, setPluginDot]);
+  }, [leftActive, rightActive, bottomActive, mobileActive, rightCollapsed, bottomCollapsed, setPluginDot]);
 
   return (
     <>
@@ -810,31 +822,51 @@ export function App() {
           dot: s.id === "chat" ? chatStreaming && surface !== "chat" : pluginDots[s.id] || undefined,
         }))}
         rightItems={railSurfaces("right").map((s) => ({ ...s, dot: pluginDots[s.id] || undefined }))}
+        bottomItems={railSurfaces("bottom").map((s) => ({ ...s, dot: pluginDots[s.id] || undefined }))}
         activeLeft={leftCollapsed ? "" : leftActive}
         activeRight={rightCollapsed ? "" : rightActive}
+        activeBottom={bottomCollapsed ? "" : bottomActive}
         onSelect={(side, id) => {
           // Click the already-open view's icon → toggle the panel closed; otherwise open the
           // panel on the clicked view (re-opening it if it was collapsed).
           if (side === "left") {
             if (!leftCollapsed && leftActive === id) setLeftCollapsed(true);
             else { setSurface(id); setLeftCollapsed(false); }
-          } else {
+          } else if (side === "right") {
             if (!rightCollapsed && rightActive === id) setRightCollapsed(true);
             else { setRightPanel(id); setRightCollapsed(false); }
+          } else {
+            if (!bottomCollapsed && bottomActive === id) setBottomCollapsed(true);
+            else { setBottomPanel(id); setBottomCollapsed(false); }
           }
         }}
         onRailContextMenu={(side, e, id) => openContextMenu("rail-surface", e, { id, side })}
-        onRailReorder={setRailOrder}
+        onRailReorder={(next) => {
+          // Chat is the streaming slot (#613), never the bottom dock — bounce it back to the
+          // left rail if a drag landed it there.
+          if (next.bottom.includes("chat")) {
+            next = {
+              ...next,
+              bottom: next.bottom.filter((x) => x !== "chat"),
+              left: next.left.includes("chat") ? next.left : ["chat", ...next.left],
+            };
+          }
+          setRailOrder(next);
+        }}
         rightWidth={rightWidth}
         onRightWidthChange={setRightWidth}
         rightCollapsed={rightCollapsed}
         onCollapse={setRightCollapsed}
         leftCollapsed={leftCollapsed}
         onLeftCollapse={setLeftCollapsed}
+        bottomHeight={bottomHeight}
+        onBottomHeightChange={setBottomHeight}
+        bottomCollapsed={bottomCollapsed}
+        onBottomCollapse={setBottomCollapsed}
         // Let the left column narrow to 200 before it snaps/collapses (the DS default is
         // 280, which left a 140–280 dead zone where a narrowed left snapped back up).
         minLeftWidth={200}
-        mobileItems={[...railSurfaces("left"), ...railSurfaces("right")].map((s) => ({
+        mobileItems={[...railSurfaces("left"), ...railSurfaces("right"), ...railSurfaces("bottom")].map((s) => ({
           ...s,
           dot: pluginDots[s.id] || undefined,
         }))}
@@ -875,6 +907,7 @@ export function App() {
             {rightActive !== "chat" ? renderSurface(rightActive) : null}
           </>
         }
+        bottomContent={bottomActive ? renderSurface(bottomActive) : null}
         utilityBar={
           <UtilityBar
             start={

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -9,15 +9,29 @@ import type { MenuEntry } from "./types";
 // left rail (no move-across); plugin views follow their manifest placement (no items yet).
 registerContextMenu({
   type: "rail-surface",
-  items: (ctx: { id: string; side: "left" | "right" }): MenuEntry[] => {
+  items: (ctx: { id: string; side: "left" | "right" | "bottom" }): MenuEntry[] => {
     if (!ctx) return [];
     const ui = useUI.getState();
     const list = ui.railOrder[ctx.side] ?? [];
     const i = list.indexOf(ctx.id);
     if (i < 0) return []; // not yet tracked (a freshly-appeared plugin, pre-reconcile)
-    const to = ctx.side === "left" ? "right" : "left";
+    // Open the moved surface on its new dock (un-collapsing it). The App clamps each dock's
+    // active to a member, so the source dock self-heals when the surface leaves.
+    const moveTo = (side: "left" | "right" | "bottom") => {
+      const u = useUI.getState();
+      u.moveSurface(ctx.id, side);
+      if (side === "left") { u.setSurface(ctx.id); u.setLeftCollapsed(false); }
+      else if (side === "right") { u.setRightPanel(ctx.id); u.setRightCollapsed(false); }
+      else { u.setBottomPanel(ctx.id); u.setBottomCollapsed(false); }
+    };
+    const DOCKS: { side: "left" | "right" | "bottom"; label: string }[] = [
+      { side: "left", label: "Move to left rail" },
+      { side: "right", label: "Move to right rail" },
+      { side: "bottom", label: "Move to bottom dock" },
+    ];
     // Any surface — core, plugin, or chat — reorders within its rail and moves across. (Moving
     // chat across rails remounts it: a brief blip on an in-flight stream; a deliberate action.)
+    // Chat is excluded from the bottom dock — it's the streaming slot, not a bottom-panel surface.
     return [
       {
         id: "move-up",
@@ -34,23 +48,14 @@ registerContextMenu({
         run: () => useUI.getState().reorderSurface(ctx.id, 1),
       },
       { id: "rail-div", divider: true },
-      {
-        id: "move-rail",
-        label: `Move to ${to} rail`,
-        icon: <ArrowLeftRight size={14} />,
-        run: () => {
-          const u = useUI.getState();
-          u.moveSurface(ctx.id, to);
-          if (to === "left") {
-            u.setSurface(ctx.id);
-            if (u.rightPanel === ctx.id) u.setRightPanel(u.railOrder.right[0] ?? "beads");
-          } else {
-            u.setRightPanel(ctx.id);
-            u.setRightCollapsed(false);
-            if (u.surface === ctx.id) u.setSurface(u.railOrder.left[0] ?? "chat");
-          }
-        },
-      },
+      ...DOCKS.filter((d) => d.side !== ctx.side)
+        .filter((d) => !(d.side === "bottom" && ctx.id === "chat"))
+        .map((d): MenuEntry => ({
+          id: `move-${d.side}`,
+          label: d.label,
+          icon: <ArrowLeftRight size={14} />,
+          run: () => moveTo(d.side),
+        })),
     ];
   },
 });

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -92,8 +92,8 @@ export type PluginView = {
   path: string;
   tabs?: { id: string; label: string; path: string }[];
   // "rail" (default) = a left-rail surface; "right" = a right-sidebar panel
-  // alongside Notes/Beads/Goals/Schedule (ADR 0026).
-  placement?: "rail" | "right";
+  // alongside Notes/Beads/Goals/Schedule (ADR 0026); "bottom" = the bottom dock.
+  placement?: "rail" | "right" | "bottom";
   // Claim a core surface slot instead of adding a rail icon (ADR 0045). A view with
   // slot:"chat" REPLACES the built-in chat panel — it renders under the core "chat"
   // rail id, stays mounted for the app's lifetime (streaming continuity, #613), and

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -52,6 +52,17 @@ describe("migrateUiState", () => {
     expect(out.railOrder.left).not.toContain("schedule");
   });
 
+  // v5→v6 (bottom dock): railOrder gains a `bottom` dock; add the empty array to a
+  // persisted layout that predates it.
+  it("adds the bottom dock to a pre-v6 railOrder", () => {
+    // `box` already present so this isolates the v6 step (the migration is cumulative).
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "box", "settings"], right: ["beads"] },
+    }) as { railOrder: { left: string[]; right: string[]; bottom: string[] } };
+    expect(out.railOrder.bottom).toEqual([]);
+    expect(out.railOrder.left).toEqual(["chat", "box", "settings"]);
+  });
+
   it("does not mutate the input object", () => {
     const input = { railOf: { chat: "left" }, leftActive: "chat" };
     migrateUiState(input);
@@ -73,8 +84,8 @@ describe("migrateUiState", () => {
 // set would prune every persisted entry and the reload would re-seed by manifest —
 // the layout-wipe bug this contract pins down.)
 describe("reconcilePluginViews", () => {
-  const seed = (left: string[], right: string[]) =>
-    useUI.setState({ railOrder: { left, right } });
+  const seed = (left: string[], right: string[], bottom: string[] = []) =>
+    useUI.setState({ railOrder: { left, right, bottom } });
 
   beforeEach(() => seed(["chat", "plugin:doom:panel"], ["beads", "plugin:board:board", "notes"]));
 

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -72,13 +72,20 @@ type UIState = {
   // Ordered surface lists per rail (ADR 0035 D2 + 0036) — a surface is on exactly one side, at a
   // position. Core surfaces seeded below; plugin views append by their manifest `placement`. Chat
   // is pinned left (mounts unconditionally for streaming continuity) — never moved across rails.
-  railOrder: { left: string[]; right: string[] };
-  moveSurface: (id: string, side: "left" | "right") => void; // splice out → append to side's bottom
+  // Three docks now (DS AppShell bottom dock): left/right rails + the bottom dock (a
+  // horizontal icon rail in the util bar + a full-width panel). A surface is on exactly
+  // one dock, at a position.
+  railOrder: { left: string[]; right: string[]; bottom: string[] };
+  moveSurface: (id: string, side: "left" | "right" | "bottom") => void; // splice out → append to the target dock
   reorderSurface: (id: string, dir: -1 | 1) => void; // swap with the neighbour within its rail
-  setRailOrder: (next: { left: string[]; right: string[] }) => void; // DS AppShell DnD — whole new order
+  setRailOrder: (next: { left: string[]; right: string[]; bottom: string[] }) => void; // DS AppShell DnD — whole new order
   // Sync plugin views into railOrder (ADR 0036) — append newly-available ones to their placement
   // side, prune `plugin:` ids no longer present. Core surfaces are left untouched.
-  reconcilePluginViews: (views: { id: string; side: "left" | "right" }[]) => void;
+  reconcilePluginViews: (views: { id: string; side: "left" | "right" | "bottom" }[]) => void;
+  // Bottom dock — active surface + height + collapse (mirror the right panel, on the Y axis).
+  bottomPanel: string;
+  bottomHeight: number;
+  bottomCollapsed: boolean;
   // Mobile shell (ADR 0035 S4): one active surface + a configurable bottom quick-bar.
   mobileActive: string;
   setMobileActive: (id: string) => void;
@@ -95,6 +102,9 @@ type UIState = {
   setRightCollapsed: (b: boolean) => void;
   setLeftCollapsed: (b: boolean) => void;
   setRightWidth: (w: number) => void;
+  setBottomPanel: (p: string) => void;
+  setBottomHeight: (h: number) => void;
+  setBottomCollapsed: (b: boolean) => void;
   // Notification dots (ADR 0039) — a plugin surface key (`plugin:<id>:<view>`) with unseen
   // bus activity shows a rail dot until opened. Persisted so the dot survives a refresh.
   pluginDots: Record<string, boolean>;
@@ -137,6 +147,12 @@ export function migrateUiState(persisted: unknown): unknown {
         right: (ro2.right ?? []).filter((x) => x !== "schedule"),
       };
     }
+    // v6 (bottom dock): railOrder gains a `bottom` dock — add the empty array to a
+    // persisted layout that predates it so the shape is complete.
+    const ro3 = rest.railOrder as { left?: string[]; right?: string[]; bottom?: string[] } | undefined;
+    if (ro3 && !Array.isArray(ro3.bottom)) {
+      rest.railOrder = { ...ro3, bottom: [] };
+    }
     return rest;
   }
   return persisted;
@@ -156,16 +172,23 @@ export const useUI = create<UIState>()(
       rightCollapsed: false,
       leftCollapsed: false,
       rightWidth: 360,
+      bottomPanel: "",
+      bottomHeight: 240,
+      bottomCollapsed: false,
       railOrder: {
         left: ["chat", "activity", "studio", "knowledge", "plugins", "box", "settings"],
         right: ["beads", "goals"],
+        bottom: [],
       },
       moveSurface: (id, side) =>
         set((s) => {
-          const left = s.railOrder.left.filter((x) => x !== id);
-          const right = s.railOrder.right.filter((x) => x !== id);
-          (side === "left" ? left : right).push(id); // append to the target's bottom
-          return { railOrder: { left, right } };
+          const arrs = {
+            left: s.railOrder.left.filter((x) => x !== id),
+            right: s.railOrder.right.filter((x) => x !== id),
+            bottom: s.railOrder.bottom.filter((x) => x !== id),
+          };
+          arrs[side].push(id); // append to the target dock's end
+          return { railOrder: arrs };
         }),
       reorderSurface: (id, dir) =>
         set((s) => {
@@ -177,7 +200,7 @@ export const useUI = create<UIState>()(
             [next[i], next[j]] = [next[j], next[i]];
             return next;
           };
-          return { railOrder: { left: swap(s.railOrder.left), right: swap(s.railOrder.right) } };
+          return { railOrder: { left: swap(s.railOrder.left), right: swap(s.railOrder.right), bottom: swap(s.railOrder.bottom) } };
         }),
       setRailOrder: (railOrder) => set({ railOrder }),
       mobileActive: "chat",
@@ -193,12 +216,11 @@ export const useUI = create<UIState>()(
         set((s) => {
           const ids = new Set(views.map((v) => v.id));
           const keep = (arr: string[]) => arr.filter((x) => !x.startsWith("plugin:") || ids.has(x));
-          const left = keep(s.railOrder.left);
-          const right = keep(s.railOrder.right);
+          const arrs = { left: keep(s.railOrder.left), right: keep(s.railOrder.right), bottom: keep(s.railOrder.bottom) };
           for (const v of views) {
-            if (!left.includes(v.id) && !right.includes(v.id)) (v.side === "left" ? left : right).push(v.id);
+            if (!arrs.left.includes(v.id) && !arrs.right.includes(v.id) && !arrs.bottom.includes(v.id)) arrs[v.side].push(v.id);
           }
-          return { railOrder: { left, right } };
+          return { railOrder: arrs };
         }),
       setSurface: (surface) => set({ surface }),
       setRightPanel: (rightPanel) => set({ rightPanel }),
@@ -220,6 +242,9 @@ export const useUI = create<UIState>()(
       // column could never grow past 720, so the LEFT column never reached its collapse
       // threshold (left wouldn't close), and the column stopped tracking the pointer mid-drag.
       setRightWidth: (w) => set({ rightWidth: Math.max(0, Math.round(w)) }),
+      setBottomPanel: (bottomPanel) => set({ bottomPanel }),
+      setBottomHeight: (h) => set({ bottomHeight: Math.max(0, Math.round(h)) }),
+      setBottomCollapsed: (bottomCollapsed) => set({ bottomCollapsed }),
       pluginDots: {},
       setPluginDot: (key, on) =>
         set((s) => {
@@ -233,7 +258,7 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 5, // v2 railOf→railOrder · v3 settingsTab→scope+section · v4 +Box surface · v5 Schedule→Activity tab (#1075)
+      version: 6, // …v4 +Box · v5 Schedule→Activity tab (#1075) · v6 +bottom dock
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
     },
   ),

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.37.0",
+        "@protolabsai/ui": "^0.38.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.37.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.37.0.tgz",
-      "integrity": "sha512-GGOk6rcu5qLlYdFPpbz7KZ35jXePQETz471pPlucFWyPoPVKGirDMoWUkwoU+SdmMHoAGMx38AB9VGYDRT2RJw==",
+      "version": "0.38.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.38.0.tgz",
+      "integrity": "sha512-z+JCs7Gqi8oc0Gi5BiSsD4Z8iSDsq8tEcrkOYlA/AB0IYMeLTKANOqnWkT5Jtjl6Ud9XKzwMDDEzjHMJThlPMA==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Adopts `@protolabsai/ui@0.38.0`'s **AppShell bottom dock** — a horizontal icon rail in the util bar + a full-width panel below it, a true peer of the L/R rails. Drag a rail icon down to dock it; click to open; resize/collapse the panel via its handle.

## Wiring
- **`uiStore`** — `railOrder` gains `bottom`; `bottomPanel`/`bottomHeight`/`bottomCollapsed` state + setters (mirror the right panel); `moveSurface`/`reorderSurface`/`reconcilePluginViews` go 3-way; **migration v6** adds `bottom: []`.
- **`App.tsx`** — `railSurfaces("bottom")` + `pluginBottom` + a `bottomActive` clamp; the three bottom `<AppShell>` props + `bottomContent={renderSurface(bottomActive)}` (one surface, reuses the existing renderer — no bespoke UI); `onSelect` bottom branch; `pluginDots`/`mobileItems` include bottom.
- **Context menu** — the move-rail menu is now 3-way: *Move to left rail / right rail / bottom dock*.
- **types** — plugin `placement` gains `"bottom"`.

## Decisions (as agreed)
- **Chat stays a left/right slot** — it's the streaming mount, so it's excluded from the bottom dock (the context menu hides "Move to bottom" for chat, and `onRailReorder` bounces it back to the left rail if a drag lands it there).
- **All other surfaces are bottom-eligible** — the rail-peer model means none need special handling; `renderSurface(bottomActive)` covers them.

## Additive / no regression
`railOrder.bottom` defaults `[]`, so the shell is visually unchanged until a surface is docked. All existing layout/nav specs pass untouched.

## Test
`tsc --noEmit` clean · `npm run test:unit` **88/88** (incl. v6-migration test) · full Playwright **107/107** (new: *right-click → Move to bottom dock*).

🤖 Generated with [Claude Code](https://claude.com/claude-code)