### PR TITLE
fix(web): chat bounce-back restores its prior side, not always left

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -842,14 +842,13 @@ export function App() {
         }}
         onRailContextMenu={(side, e, id) => openContextMenu("rail-surface", e, { id, side })}
         onRailReorder={(next) => {
-          // Chat is the streaming slot (#613), never the bottom dock — bounce it back to the
-          // left rail if a drag landed it there.
+          // Chat is the streaming slot (#613), never the bottom dock — if a drag landed it
+          // there, bounce it back to the SIDE rail it came from (its pre-drag side), not
+          // always the left.
           if (next.bottom.includes("chat")) {
-            next = {
-              ...next,
-              bottom: next.bottom.filter((x) => x !== "chat"),
-              left: next.left.includes("chat") ? next.left : ["chat", ...next.left],
-            };
+            const back = railOrder.right.includes("chat") ? "right" : "left";
+            next = { ...next, bottom: next.bottom.filter((x) => x !== "chat") };
+            if (!next[back].includes("chat")) next = { ...next, [back]: [...next[back], "chat"] };
           }
           setRailOrder(next);
         }}


### PR DESCRIPTION
Addresses Quinn's MEDIUM finding on #1087: dragging chat into the bottom dock bounced it back to the **left** rail unconditionally, even if the user had chat on the **right**. Now it restores chat to the side it was on pre-drag (`railOrder.right.includes("chat") ? "right" : "left"`).

`tsc` clean; behavior-only edge-case fix (chat is the streaming slot, excluded from the bottom dock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)