### PR TITLE
feat(sdk): expose knowledge_search + knowledge_add to plugins (ADR 0043)

### DIFF
--- a/graph/sdk.py
+++ b/graph/sdk.py
@@ -16,6 +16,7 @@ its engine injects ``run_subagent`` as the per-step runner).
 
 from __future__ import annotations
 
+import asyncio
 import re
 from typing import Any
 
@@ -98,6 +99,36 @@ async def complete(prompt: str, *, system: str | None = None, model_name: str | 
     resp = await llm.ainvoke(messages)
     content = getattr(resp, "content", resp)
     return content if isinstance(content, str) else str(content)
+
+
+# ── knowledge graph (the plugin↔knowledge channel, ADR 0043 — "shared knowledge") ──
+# The consumption SDK exposed run_subagent/complete but not the knowledge store, so a
+# plugin couldn't ground its work in (or contribute to) what the agent knows. These
+# two thin accessors close that: the coding loop reads distilled lessons to inject into
+# a coder's prompt; the loop-retro writes recurring failures back as searchable chunks.
+# Both degrade to a no-op ([] / None) when no store is configured, and run the
+# (HTTP-embedding) store call off the event loop.
+
+
+async def knowledge_search(query: str, *, k: int = 5, domain: str | None = None) -> list[dict]:
+    """Search the agent's knowledge graph (hybrid FTS5 + embeddings); return the top-``k``
+    matching chunks (each a dict with ``preview``/``content``, ``domain``, ``score`` …),
+    or ``[]`` when no store is configured. ``domain`` scopes to one bucket
+    (e.g. ``"loop-lessons"``)."""
+    store = getattr(STATE, "knowledge_store", None)
+    if store is None:
+        return []
+    return await asyncio.to_thread(store.search, query, k=k, domain=domain)
+
+
+async def knowledge_add(content: str, *, domain: str = "general", heading: str | None = None) -> int | None:
+    """Add one chunk to the agent's knowledge graph; return its id, or ``None`` when no
+    store is configured / it was a no-op. ``domain`` is the bucket, ``heading`` an
+    optional title — e.g. ``knowledge_add(lesson, domain="loop-lessons", heading=cls)``."""
+    store = getattr(STATE, "knowledge_store", None)
+    if store is None:
+        return None
+    return await asyncio.to_thread(store.add_chunk, content, domain=domain, heading=heading)
 
 
 # ── goal-driven recurring loop (the OODA pattern) ──────────────────────────────────────

--- a/tests/test_sdk_knowledge.py
+++ b/tests/test_sdk_knowledge.py
@@ -1,0 +1,49 @@
+"""graph.sdk.knowledge_search / knowledge_add — the plugin↔knowledge channel (ADR 0043)."""
+
+from __future__ import annotations
+
+import pytest
+
+
+class _FakeStore:
+    def __init__(self):
+        self.calls = []
+
+    def search(self, query, k=5, *, domain=None):
+        self.calls.append(("search", query, k, domain))
+        return [{"preview": "a lesson", "domain": domain or "general", "score": 0.9}]
+
+    def add_chunk(self, content, domain="general", heading=None):
+        self.calls.append(("add", content, domain, heading))
+        return 42
+
+
+@pytest.mark.asyncio
+async def test_knowledge_search_wraps_the_store(monkeypatch):
+    from graph import sdk
+
+    store = _FakeStore()
+    monkeypatch.setattr(sdk.STATE, "knowledge_store", store, raising=False)
+    out = await sdk.knowledge_search("golden map", k=3, domain="loop-lessons")
+    assert out and out[0]["preview"] == "a lesson"
+    assert store.calls == [("search", "golden map", 3, "loop-lessons")]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_add_wraps_the_store(monkeypatch):
+    from graph import sdk
+
+    store = _FakeStore()
+    monkeypatch.setattr(sdk.STATE, "knowledge_store", store, raising=False)
+    cid = await sdk.knowledge_add("a lesson", domain="loop-lessons", heading="golden-map")
+    assert cid == 42
+    assert store.calls == [("add", "a lesson", "loop-lessons", "golden-map")]
+
+
+@pytest.mark.asyncio
+async def test_knowledge_ops_degrade_to_noop_without_a_store(monkeypatch):
+    from graph import sdk
+
+    monkeypatch.setattr(sdk.STATE, "knowledge_store", None, raising=False)
+    assert await sdk.knowledge_search("x") == []
+    assert await sdk.knowledge_add("x", domain="loop-lessons") is None


### PR DESCRIPTION
The **plugin↔knowledge channel** — foundation (P1) for the flywheel's KG write-back.

`graph/sdk.py` (the ADR 0043 consumption SDK plugins already import) exposed `run_subagent`/`complete` but **not** the knowledge store, so a plugin couldn't ground its work in — or contribute to — what the agent knows ("shared knowledge not implemented; only shared skills"). Two thin async accessors close it:
- `knowledge_search(query, *, k=5, domain=None)` → top-k chunks (or `[]` with no store)
- `knowledge_add(content, *, domain="general", heading=None)` → chunk id (or `None` with no store)

Both run the HTTP-embedding store call off the event loop and degrade to a no-op when no store is configured.

**Enables:** the loop-retro writing distilled lessons as `loop-lessons` chunks (P2), and the coding loop reading them to inject into a coder's prompt at build time (P3).

`3 passed`, ruff + import-contracts clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)