### PR TITLE
chore(web): @protolabsai/ui 0.39.0 — bottom-dock full-screen

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.38.0",
+    "@protolabsai/ui": "^0.39.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.38.0",
+        "@protolabsai/ui": "^0.39.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.38.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.38.0.tgz",
-      "integrity": "sha512-z+JCs7Gqi8oc0Gi5BiSsD4Z8iSDsq8tEcrkOYlA/AB0IYMeLTKANOqnWkT5Jtjl6Ud9XKzwMDDEzjHMJThlPMA==",
+      "version": "0.39.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.39.0.tgz",
+      "integrity": "sha512-DKr+lM7w+z56R3090xkC+KaDss1O0rRCaWptIgxYY7wR3Tm2ZBGgo/nr7F/fsBxS9qD4P18YuGL+FXN1q+0LAw==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Bumps `@protolabsai/ui` `0.38.0 → 0.39.0` to adopt the full-screen bottom dock ([protoContent #248](https://github.com/protoLabsAI/protoContent/pull/248)).

Drag the bottom-dock handle up past the content-collapse point and the panel **maximizes**: the content row and the util bar both hide and the panel fills the frame. Drag the handle back down to restore. It's a pure AppShell behavior (internal state, no new props), so this adoption is just the version bump — no app wiring.

Verified: `prebuild` copies the new DS bundle (the `--bfull` rules land in `public/_ds/plugin-kit.css`), both `tsc` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)