### PR TITLE
chore(web): @protolabsai/ui 0.39.1 — bottom-dock maximize fix

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.39.0",
+    "@protolabsai/ui": "^0.39.1",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.39.0",
+        "@protolabsai/ui": "^0.39.1",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.39.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.39.0.tgz",
-      "integrity": "sha512-DKr+lM7w+z56R3090xkC+KaDss1O0rRCaWptIgxYY7wR3Tm2ZBGgo/nr7F/fsBxS9qD4P18YuGL+FXN1q+0LAw==",
+      "version": "0.39.1",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.39.1.tgz",
+      "integrity": "sha512-rEW75DysCFPHciDelyVfCyYYlyZWFi4YAEPSNa6UCCGFxUa5TpDTtV0oGSVMKcbKcUL5UY2bN3ao11pMNJ5MKw==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Bumps `@protolabsai/ui` `0.39.0 → 0.39.1` to pick up the bottom-dock maximize fix ([protoContent #250](https://github.com/protoLabsAI/protoContent/pull/250)).

The full-screen maximize relied on an overshoot that only header-hosting shells can produce; protoAgent renders its topbar outside the shell, so the panel capped short of full-screen. 0.39.1 also triggers maximize when the handle is dragged to the top of the frame.

**Verified live in this app** via a local source override before release. Pure version bump — no app wiring. Both `tsc` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)