### PR TITLE
fix(setup): probe can't 500 or hang the new-user wizard's runtime step

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -292,12 +292,15 @@ async function request<T>(path: string, options: RequestOptions = {}): Promise<T
   });
 
   if (!response.ok) {
+    // Read the body ONCE — calling response.json() then response.text() on the same
+    // response throws "body stream already read" (a second error that masks the real
+    // one). Read text, then best-effort parse a JSON {detail}.
+    const raw = await response.text().catch(() => "");
     let detail = `${response.status} ${response.statusText}`;
     try {
-      const payload = (await response.json()) as { detail?: string };
-      detail = payload.detail || detail;
+      detail = (JSON.parse(raw) as { detail?: string }).detail || raw || detail;
     } catch {
-      detail = await response.text();
+      detail = raw || detail;
     }
     // Wrong/expired/missing bearer on a token-gated deployment — surface the
     // token prompt (#873) instead of leaving per-panel 401 cards as the only signal.

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -117,6 +117,21 @@ function hydrateState(payload: ConfigPayload, status: SetupStatus | null): Wizar
   };
 }
 
+// A probe/test against a possibly-wrong or slow gateway must never hang the wizard —
+// race it against a timeout so `busy` always clears and the step never locks (which
+// would disable Next, trapping the user on the runtime step).
+function withTimeout<T>(p: Promise<T>, ms: number, label: string): Promise<T> {
+  return Promise.race([
+    p,
+    new Promise<T>((_resolve, reject) =>
+      setTimeout(
+        () => reject(new Error(`${label} timed out after ${Math.round(ms / 1000)}s — check the API base and key`)),
+        ms,
+      ),
+    ),
+  ]);
+}
+
 export function SetupWizard({
   open,
   projectPath,
@@ -195,7 +210,7 @@ export function SetupWizard({
     setError("");
     if (!silent) setModels([]);
     try {
-      const response = await api.models(state.apiBase, state.apiKey);
+      const response = await withTimeout(api.models(state.apiBase, state.apiKey), 15000, "Probe");
       if (response.error) {
         if (!silent) setError(response.error); // auto-probe stays quiet — the user may still be typing creds
         return;
@@ -234,7 +249,11 @@ export function SetupWizard({
     setError("");
     setTested(null);
     try {
-      const r = await api.testModel(state.apiBase.trim(), state.apiKey.trim(), state.modelName.trim());
+      const r = await withTimeout(
+        api.testModel(state.apiBase.trim(), state.apiKey.trim(), state.modelName.trim()),
+        25000,
+        "Test connection",
+      );
       setTested({ ok: r.ok, error: r.error || "" });
     } catch (exc) {
       setTested({ ok: false, error: errMsg(exc) });

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -693,6 +693,11 @@ def list_gateway_models(
             resp = client.get(url, headers=headers)
     except httpx.HTTPError as e:
         return [], f"connection failed: {e}"
+    except Exception as e:  # noqa: BLE001 — a malformed api_base (httpx.InvalidURL, e.g.
+        # "Invalid port", a bad scheme/host) is NOT an httpx.HTTPError, so it would
+        # otherwise propagate as a 500 and lock the setup wizard. A probe must always
+        # return a fixable error, never raise.
+        return [], f"invalid api_base ({type(e).__name__}): {e}"
 
     if resp.status_code >= 400:
         # Don't echo the raw upstream body (#871) — just the status.

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -389,6 +389,27 @@ def test_list_gateway_models_empty_base_returns_error():
     assert "api_base" in err
 
 
+def test_list_gateway_models_malformed_url_returns_error_not_raise(monkeypatch):
+    """A malformed api_base makes httpx raise InvalidURL — which is NOT an
+    httpx.HTTPError subclass, so it would propagate as a 500 and lock the setup
+    wizard's runtime step. The probe must catch it and return a clean, fixable error.
+    Regression for the new-user setup-wizard hang."""
+    import httpx
+
+    from graph import config_io
+
+    fake_client = MagicMock()
+    fake_client.__enter__ = lambda self: fake_client
+    fake_client.__exit__ = lambda *args: None
+    fake_client.get.side_effect = httpx.InvalidURL("Invalid port: '4000\\'")
+    monkeypatch.setattr("httpx.Client", lambda **kw: fake_client)
+
+    # 8.8.8.8 passes the egress guard, so we reach the (mocked) get → InvalidURL path.
+    models, err = config_io.list_gateway_models("http://8.8.8.8:4000/v1", "key")
+    assert models == []
+    assert "invalid api_base" in err and "InvalidURL" in err
+
+
 def test_list_gateway_models_http_error(monkeypatch):
     from graph import config_io
 


### PR DESCRIPTION
**New-user repro** (found right after a factory reset): hitting **Probe** on the Runtime step spun forever and the step wouldn't let you continue. Three causes:

1. **500 on a bad api_base** — `list_gateway_models` caught `httpx.HTTPError` but **not** `httpx.InvalidURL` (a separate exception, e.g. `Invalid port: '4000\\'`), so a malformed base propagated as a **500** instead of a clean `(models, error)`. Broadened the `except` → always returns a fixable message. **Regression test added.**
2. **Masked error in `request()`** — the error path read the body twice (`response.json()` then `response.text()` in the `catch`) → "body stream already read" threw a *second* error over the real one. Read the body once as text, then best-effort JSON-parse.
3. **No client-side timeout** — Probe + Test-connection could keep `busy` true on a slow/hanging gateway → **Next stayed disabled → trapped on the step**. Race them against a timeout (15s probe / 25s test) so they always settle and the step unlocks.

Net: a probe/test against a wrong-or-slow gateway now shows a **clean error, never 500s, and never locks the wizard** — Next works (the model fields are the only gate). Verified live: every malformed base now returns a clean error; the real base returns a clean `HTTP 401` (bad key) instead of hanging. 46 config tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)