### PR TITLE
chore(web): @protolabsai/ui 0.40.0 — accent form controls

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.39.1",
+    "@protolabsai/ui": "^0.40.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.39.1",
+        "@protolabsai/ui": "^0.40.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.39.1",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.39.1.tgz",
-      "integrity": "sha512-rEW75DysCFPHciDelyVfCyYYlyZWFi4YAEPSNa6UCCGFxUa5TpDTtV0oGSVMKcbKcUL5UY2bN3ao11pMNJ5MKw==",
+      "version": "0.40.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.40.0.tgz",
+      "integrity": "sha512-89jPqAesnw89jWJO5FQ8A7dbjmt5lZVWIdtNjROA6QzJTMRQnMyZLIMv4XdnVIMvZ37sZM1CpaRwaJWqYGUaeg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Bumps `@protolabsai/ui` `0.39.1 → 0.40.0` to pick up accent-colored active form controls ([protoContent #252](https://github.com/protoLabsAI/protoContent/pull/252)).

Switch (on), checkbox (checked), and radio (selected) now fill with `--pl-color-accent` instead of the monochrome foreground — fixes the console's toggles/checkboxes rendering "white" and ignoring the theme accent. **Verified live in this app** via a local source override before release. CSS-only DS change; no app wiring. Both `tsc` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)