### PR TITLE
feat(setup): install the chosen archetype's bundle on finish (Plan C)

### DIFF
--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -300,8 +300,12 @@ export function SetupWizard({
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [loaded, archetypeList, state.soul, state.archetype]);
 
-  // Labels for the finish-step summary.
-  const personaLabel = archetypeList.find((a) => a.id === state.archetype)?.label ?? state.archetype;
+  // The picked archetype drives the finish summary AND (Plan C) the bundle install:
+  // an archetype with a bundle (e.g. Project Manager → pm-stack) installs its plugins
+  // into this host on finish, so the persona arrives WITH its tools.
+  const pickedArchetype = archetypeList.find((a) => a.id === state.archetype);
+  const personaLabel = pickedArchetype?.label ?? state.archetype;
+  const pickedBundle = pickedArchetype?.bundle ?? null;
   const acpAgentLabel = ACP_AGENTS.find((a) => a.id === state.acpAgent)?.label ?? state.acpAgent;
 
   async function finishSetup() {
@@ -379,7 +383,29 @@ export function SetupWizard({
       if (state.initBeads) {
         await api.initBeads();
       }
-      setMessage(response.message);
+      // Plan C: if the chosen archetype carries a plugin bundle (e.g. Project
+      // Manager → pm-stack), install it into THIS host on finish — so the new user
+      // gets the persona AND its tools/board in one shot, not just the prose.
+      // installPlugin auto-enables + hot-reloads the bundle's plugins (no restart).
+      // A failure is non-fatal: setup is already written, so we finish anyway and
+      // point the user at Settings ▸ Plugins.
+      if (pickedBundle) {
+        setMessage(`Setting up the ${personaLabel} tools — this can take a few seconds…`);
+        try {
+          const r = await api.installPlugin(pickedBundle);
+          setMessage(
+            r.enable_error
+              ? `Setup complete. The ${personaLabel} tools installed but couldn't auto-enable (${r.enable_error}) — turn them on in Settings ▸ Plugins.`
+              : `Setup complete — ${personaLabel} tools are ready.`,
+          );
+        } catch (exc) {
+          setMessage(
+            `Setup complete, but installing the ${personaLabel} tools failed (${errMsg(exc)}). You can add them later in Settings ▸ Plugins.`,
+          );
+        }
+      } else {
+        setMessage(response.message);
+      }
       onFinished();
     } catch (exc) {
       setError(errMsg(exc));


### PR DESCRIPTION
Follow-up to #1095. The wizard's persona step seeds the SOUL from the picked archetype — but a **bundle** archetype (e.g. Project Manager → pm-stack) carries *tools*, not just prose. This closes the loop: **finishing setup now installs that bundle into the host**, so picking "Project Manager" gives the persona **and** the board / browser / delegate tools in one shot.

## How
After the config write in `finishSetup()`, if the picked archetype has a `bundle`, call `api.installPlugin(url)`:
- Clones + pip-installs the bundle, **auto-enables** its members, and **hot-reloads** them — no restart (first install hot-mounts, #822).
- The finish step shows *"Setting up the &lt;Persona&gt; tools…"* while it runs (`request()` has no timeout, so it waits out the clone+pip).
- **Non-fatal by design**: setup is already written, so an install failure (offline / git missing / enable-reload hiccup) still completes setup and points the user at Settings ▸ Plugins.

Basic / Custom carry no bundle → finish persona-only, unchanged.

## Notes
- Reuses the existing, tested `POST /api/plugins/install` route (bundle install + auto-enable + config write are covered by `test_plugin_routes.py`); this PR is the wizard glue. Frontend-only.
- Gates green locally: `tsc`, web unit (88), web e2e (107). The wizard isn't e2e-covered (the mock harness skips the setup overlay), so the integrated flow is best verified by walking the wizard and picking Project Manager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)