### PR TITLE
chore: release v0.42.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.42.0] - 2026-06-17
+
 ### Added
 - **ACP `forget_session` — start a coder fresh when its workdir was recreated.** A
   persisted ACP session (#970) lets a dispatch *reattach* a prior thread — right when

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.41.0"
+version = "0.42.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,18 @@
 [
   {
+    "version": "v0.42.0",
+    "date": "2026-06-17",
+    "changes": [
+      "ACP forget_session — start a coder fresh when its workdir was recreated.",
+      "dream & distill — scheduled self-curation subagents.",
+      "New-user setup wizard, rebuilt around archetypes.",
+      "ACP coding-agent client: a real coding turn died on its own output.",
+      "operator.project_dir actually drives the workspace root.",
+      "Setup probe could 500 or hang the runtime step.",
+      "Out-of-graph subagent runs now see the lead's full tool set."
+    ]
+  },
+  {
     "version": "v0.41.0",
     "date": "2026-06-15",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.42.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.42.0 -m 'Release v0.42.0' && git push origin v0.42.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).