### PR TITLE
refactor(web): adopt DS FormField + RadioCard (0.41.0)

### DIFF
--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -42,8 +42,8 @@ test("New agent → archetype picker → create returns to the list", async ({ p
   await openAgents(page);
   await page.getByRole("button", { name: "New agent" }).click();
   await expect(page.getByRole("heading", { name: "New agent" })).toBeVisible();
-  await expect(page.locator(".archetype-card")).toHaveCount(2); // from GET /api/archetypes
-  await page.locator(".archetype-card", { hasText: "Project Manager" }).click();
+  await expect(page.locator(".pl-radiocard")).toHaveCount(2); // DS RadioCard, from GET /api/archetypes
+  await page.locator(".pl-radiocard", { hasText: "Project Manager" }).click();
   await page.getByLabel("Agent name").fill("newbot");
   await page.getByRole("button", { name: /Create/ }).click();
   await expect(page.locator(".fleet-row", { hasText: "newbot" })).toBeVisible();

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.40.0",
+    "@protolabsai/ui": "^0.41.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1447,43 +1447,8 @@ textarea {
   line-height: 1.4;
 }
 
-/* Runtime-kind picker — selectable cards. Mirrors .archetype-card's token usage so it
-   tracks the theme accent (was inline styles on the off-theme --brand-violet-light).
-   DS gap: a RadioCard/SegmentedControl primitive (see protoContent issues). */
-.setup-choices {
-  display: flex;
-  gap: 8px;
-}
-.setup-choice {
-  flex: 1;
-  display: flex;
-  flex-direction: column;
-  gap: 2px;
-  text-align: left;
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-panel);
-  color: inherit;
-  cursor: pointer;
-}
-.setup-choice:hover {
-  border-color: var(--fg-muted);
-}
-.setup-choice.selected {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
-  background: color-mix(in srgb, var(--accent) 12%, var(--bg-panel));
-}
-.setup-choice strong {
-  font-size: 13px;
-  font-weight: 600;
-}
-.setup-choice small {
-  color: var(--fg-muted);
-  font-size: 12px;
-  line-height: 1.4;
-}
+/* Runtime-kind + archetype pickers are now the DS <RadioCardGroup> (protoContent #254);
+   the old .setup-choice / .archetype-card classes are retired. */
 
 .setup-actions {
   display: flex;
@@ -1867,41 +1832,7 @@ textarea {
   opacity: 0.45;
 }
 
-/* The grid track + gap are now the DS <Grid min="160px" gap="sm"> (#832); this
-   keeps only the spacing below the picker, merged onto Grid via className. */
-.archetype-grid {
-  margin-bottom: 18px;
-}
-.archetype-card {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  text-align: left;
-  padding: 12px;
-  border: 1px solid var(--border);
-  border-radius: var(--radius);
-  background: var(--bg-panel);
-  cursor: pointer;
-}
-.archetype-card:hover {
-  border-color: var(--fg-muted);
-}
-.archetype-card.selected {
-  border-color: var(--accent);
-  box-shadow: 0 0 0 1px var(--accent);
-}
-.archetype-icon {
-  color: var(--accent);
-  display: inline-flex;
-}
-.archetype-label {
-  font-weight: 600;
-}
-.archetype-blurb {
-  font-size: 12px;
-  color: var(--fg-muted);
-  line-height: 1.4;
-}
+/* Archetype picker is now the DS <RadioCardGroup> (protoContent #254). */
 .archetype-name-field {
   max-width: 380px;
 }

--- a/apps/web/src/settings/NewAgentPanel.tsx
+++ b/apps/web/src/settings/NewAgentPanel.tsx
@@ -2,8 +2,8 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { useState } from "react";
 
+import { RadioCard, RadioCardGroup } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
-import { Grid } from "@protolabsai/ui/layout";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 
 import { api } from "../lib/api";
@@ -60,21 +60,11 @@ export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) =>
         ) : null}
 
         <p className="fleet-section-label">Archetype</p>
-        <Grid className="archetype-grid" min="160px" gap="sm">
+        <RadioCardGroup name="archetype" min="160px" value={picked} onValueChange={setPicked}>
           {list.map((a: Archetype) => (
-            <button
-              key={a.id}
-              type="button"
-              className={`archetype-card${a.id === picked ? " selected" : ""}`}
-              aria-pressed={a.id === picked}
-              onClick={() => setPicked(a.id)}
-            >
-              <span className="archetype-icon">{lucideIcon(a.icon, 22)}</span>
-              <span className="archetype-label">{a.label}</span>
-              <span className="archetype-blurb">{a.blurb}</span>
-            </button>
+            <RadioCard key={a.id} value={a.id} icon={lucideIcon(a.icon, 22)} title={a.label} blurb={a.blurb} />
           ))}
-        </Grid>
+        </RadioCardGroup>
 
         <label className="field archetype-name-field">
           <span>Name</span>

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -1,6 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Field, Input, Select, Textarea } from "@protolabsai/ui/forms";
-import { Grid } from "@protolabsai/ui/layout";
+import { Field, FormField, Input, RadioCard, RadioCardGroup, Select, Textarea } from "@protolabsai/ui/forms";
 import { Button, Callout } from "@protolabsai/ui/primitives";
 import { Alert, Spinner } from "@protolabsai/ui/data";
 import {
@@ -455,24 +454,22 @@ export function SetupWizard({
               <p className="setup-hint">
                 Pick an archetype to seed the persona below — the agent&apos;s base SOUL. You can edit it freely.
               </p>
-              <Grid className="archetype-grid" min="160px" gap="sm">
+              <RadioCardGroup
+                name="archetype"
+                min="160px"
+                value={state.archetype}
+                onValueChange={(id) => {
+                  const a = archetypeList.find((x) => x.id === id);
+                  if (a) pickArchetype(a);
+                }}
+              >
                 {archetypeList.map((a) => (
-                  <button
-                    key={a.id}
-                    type="button"
-                    className={`archetype-card${a.id === state.archetype ? " selected" : ""}`}
-                    aria-pressed={a.id === state.archetype}
-                    onClick={() => pickArchetype(a)}
-                  >
-                    <span className="archetype-icon">{lucideIcon(a.icon, 22)}</span>
-                    <span className="archetype-label">{a.label}</span>
-                    <span className="archetype-blurb">{a.blurb}</span>
-                  </button>
+                  <RadioCard key={a.id} value={a.id} icon={lucideIcon(a.icon, 22)} title={a.label} blurb={a.blurb} />
                 ))}
-              </Grid>
-              <WizardField label="SOUL.md">
+              </RadioCardGroup>
+              <FormField label="SOUL.md">
                 <Textarea className="setup-editor" value={state.soul} onChange={(event) => update({ soul: event.target.value })} />
-              </WizardField>
+              </FormField>
             </StepBody>
           ) : null}
 
@@ -483,28 +480,29 @@ export function SetupWizard({
               kicker={state.runtimeKind === "acp" ? "coding agent over ACP" : "OpenAI-compatible gateway"}
             >
               {/* How this agent thinks: native LangGraph loop on a gateway, or hand each
-                  turn to a CLI coding agent over ACP (ADR 0033). */}
-              <WizardField label="How this agent thinks">
-                <div className="setup-choices">
-                  {([
-                    ["native", "Native model", "Run turns on an OpenAI-compatible gateway."],
-                    ["acp", "Coding agent (ACP)", "Hand each turn to a CLI coding agent — it's the brain, no gateway key needed."],
-                  ] as const).map(([kind, label, blurb]) => (
-                    <button
-                      key={kind}
-                      type="button"
-                      className={`setup-choice${state.runtimeKind === kind ? " selected" : ""}`}
-                      aria-pressed={state.runtimeKind === kind}
-                      onClick={() => update({ runtimeKind: kind })}
-                    >
-                      <strong>{label}</strong>
-                      <small>{blurb}</small>
-                    </button>
-                  ))}
-                </div>
-              </WizardField>
+                  turn to a CLI coding agent over ACP (ADR 0033). A radiogroup, so it gets a
+                  plain label (not a FormField <label>, which should point at one control). */}
+              <div className="pl-field">
+                <span className="pl-field__label">How this agent thinks</span>
+                <RadioCardGroup
+                  name="runtime"
+                  value={state.runtimeKind}
+                  onValueChange={(kind) => update({ runtimeKind: kind as WizardState["runtimeKind"] })}
+                >
+                  <RadioCard value="native" title="Native model" blurb="Run turns on an OpenAI-compatible gateway." />
+                  <RadioCard value="acp" title="Coding agent (ACP)" blurb="Hand each turn to a CLI coding agent — it's the brain, no gateway key needed." />
+                </RadioCardGroup>
+              </div>
               {state.runtimeKind === "acp" ? (
-                <WizardField label="Coding agent">
+                <FormField
+                  label="Coding agent"
+                  hint={
+                    <>
+                      {ACP_AGENTS.find((a) => a.id === state.acpAgent)?.hint} — runtime set to{" "}
+                      <code>acp:{state.acpAgent}</code>. No gateway key needed; a fallback model for native delegates can be set later in Settings.
+                    </>
+                  }
+                >
                   <Select
                     value={state.acpAgent}
                     onChange={(event) => update({ acpAgent: event.target.value })}
@@ -513,11 +511,7 @@ export function SetupWizard({
                       <option key={a.id} value={a.id}>{a.label}</option>
                     ))}
                   </Select>
-                  <small className="field-hint">
-                    {ACP_AGENTS.find((a) => a.id === state.acpAgent)?.hint} — runtime set to{" "}
-                    <code>acp:{state.acpAgent}</code>. No gateway key needed; a fallback model for native delegates can be set later in Settings.
-                  </small>
-                </WizardField>
+                </FormField>
               ) : (
                 <>
                   {/* Native gateway config — only when the runtime is the native model.
@@ -527,7 +521,7 @@ export function SetupWizard({
                       Settings. */}
                   <div className="setup-grid two">
                     <Field label="API base" value={state.apiBase} onValueChange={(value) => update({ apiBase: value })} />
-                    <WizardField label="API key">
+                    <FormField label="API key">
                       <Input
                         type="password"
                         value={state.apiKey}
@@ -535,17 +529,17 @@ export function SetupWizard({
                         autoComplete="off"
                         placeholder="Leave blank to preserve current key"
                       />
-                    </WizardField>
+                    </FormField>
                   </div>
                   <div className="setup-grid model-row">
-                    <WizardField label="Model">
+                    <FormField label="Model">
                       <Input list="model-options" value={state.modelName} onChange={(event) => update({ modelName: event.target.value })} />
                       <datalist id="model-options">
                         {models.map((model) => (
                           <option key={model} value={model} />
                         ))}
                       </datalist>
-                    </WizardField>
+                    </FormField>
                     <Button type="button" onClick={() => void probeModels()} disabled={busy || !state.apiBase.trim()}>
                       {busy ? <Spinner size={15} /> : <Search size={15} />}
                       Probe
@@ -635,18 +629,6 @@ function StepBody({
       </div>
       {children}
     </div>
-  );
-}
-
-// Label + an arbitrary DS control. The DS `Field` renders its OWN input, so it can't wrap
-// a Select / password Input / datalist — this reuses the DS `pl-field` classes so these
-// composite fields match `<Field>` exactly. Interim for a DS FormField primitive (gap filed).
-function WizardField({ label, children }: { label: ReactNode; children: ReactNode }) {
-  return (
-    <label className="pl-field">
-      <span className="pl-field__label">{label}</span>
-      {children}
-    </label>
   );
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.40.0",
+        "@protolabsai/ui": "^0.41.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.40.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.40.0.tgz",
-      "integrity": "sha512-89jPqAesnw89jWJO5FQ8A7dbjmt5lZVWIdtNjROA6QzJTMRQnMyZLIMv4XdnVIMvZ37sZM1CpaRwaJWqYGUaeg==",
+      "version": "0.41.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.41.0.tgz",
+      "integrity": "sha512-kOx2Qc2sY91wbbiW19YMjDg7aSKRoya8CEIygdWkUizY7Le0wSe6IQvyWWDUK2OPMDuhjP3WSFuvmW1gZ6xR9g==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Bumps `@protolabsai/ui` `0.40.0 → 0.41.0` and retires the interim from the [setup-wizard audit](https://github.com/protoLabsAI/protoAgent/pull/1099), now that the DS ships the two components ([protoContent #256](https://github.com/protoLabsAI/protoContent/pull/256), closing #254/#255).

- **`WizardField` → DS `<FormField>`** — the local label wrapper is gone; the ACP hint moves into `FormField`'s `hint` prop.
- **Runtime-kind + archetype pickers → DS `<RadioCardGroup>`/`<RadioCard>`** — native radio semantics (arrow-key nav, form grouping) for free.
- **Fleet new-agent picker (`NewAgentPanel`)** shared the `.archetype-card` pattern — converted too, so `.setup-choice` + `.archetype-card*` CSS is **fully removed** from `theme.css` (no half-dead interim).

Net negative on hand-rolled markup + CSS. `tsc` (both projects) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)