### PR TITLE
feat(chat): mid-turn steering — redirect a running turn without stopping the stream

### DIFF
--- a/PROTO.md
+++ b/PROTO.md
@@ -14,6 +14,13 @@ TypeScript is the console.
 - **Server:** `python -m server` (never `python server.py` — single-file launch
   was retired in ADR 0023 and CI fails on it). Console is served from
   `apps/web/dist`; `/healthz` is the readiness probe.
+- **Isolated dev instance (don't stomp prod data):** `scripts/dev.sh` runs a
+  sandboxed instance via `PROTOAGENT_INSTANCE=dev` (ADR 0004 scoping) on `:7871` —
+  its own `config/dev/` + `~/.protoagent/{dev,*/dev}` data, **seeded from your
+  default config** (boots with your gateway, no re-setup) but with fresh, separate
+  chat/beads/knowledge. The default instance (`config/` + `~/.protoagent`, `:7870`)
+  is untouched. `scripts/dev-reset.sh` wipes just the sandbox. Use this for feature
+  testing instead of the default instance.
 - **Python deps:** managed with `uv` (`pyproject.toml [project.dependencies]` is
   the source of truth; `uv.lock` is tracked). `uv sync` to install.
 - **Console deps:** `npm ci` at the repo root (npm workspaces; the web app is

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -319,9 +319,16 @@ const server = createServer(async (req, res) => {
   }
   if (pathname.startsWith("/api/")) {
     if (req.method === "GET") {
+      // Mid-turn steering: turn-end reconcile reads the still-queued items.
+      if (/^\/api\/chat\/sessions\/[^/]+\/steer$/.test(pathname)) return sendJson(res, { pending: [] });
       const payload = handleApiGet(pathname, fleetFor(req));
       if (payload !== null) return sendJson(res, payload);
       return sendJson(res, { detail: "not mocked" }, 404);
+    }
+    // Mid-turn steering enqueue — accept + echo (the console ignores the body).
+    if (/^\/api\/chat\/sessions\/[^/]+\/steer$/.test(pathname) && req.method === "POST") {
+      const body = await readBody(req);
+      return sendJson(res, { ok: true, id: body.id ?? null, pending: 0 });
     }
     if (pathname === "/api/knowledge/attach" && req.method === "POST") {
       // Chat attachment upload (#1002) — multipart, so DON'T JSON-parse the body.

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -16,6 +16,7 @@ import {
   GitBranch,
   Loader2,
   RotateCcw,
+  Square,
   TerminalSquare,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -215,6 +216,15 @@ function ChatSessionSlot({
   const abortRef = useRef<AbortController | null>(null);
   // Transient "copied ✓" feedback on a message's copy action.
   const [copiedId, setCopiedId] = useState<string | null>(null);
+  // Mid-turn steering: user messages queued WHILE a turn streams (optimistic),
+  // reconciled at turn-end. The ref mirrors the state so the post-stream reconcile
+  // (a stale render closure) reads the live queue.
+  const [steerQueue, setSteerQueueState] = useState<{ id: string; text: string }[]>([]);
+  const steerQueueRef = useRef<{ id: string; text: string }[]>([]);
+  const setSteerQueue = (next: { id: string; text: string }[]) => {
+    steerQueueRef.current = next;
+    setSteerQueueState(next);
+  };
   // Forwarded into the DS PromptInput (inputRef) — for slash-completion focus and
   // the Ctrl/⌘+Enter caret insert. The DS component owns the auto-grow.
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
@@ -449,6 +459,98 @@ function ChatSessionSlot({
     setAttachments([]);
     void runTurn(display, { sendAs: sent, images });
   }
+
+  // Steer a RUNNING turn: queue the typed message (folds in at the agent's next
+  // model call via SteeringMiddleware) without stopping the stream. Shows an
+  // optimistic "queued" bubble; turn-end reconcile settles or re-sends it.
+  async function queueSteer() {
+    const text = draft.trim();
+    if (!session || !text) return;
+    const id = messageId();
+    setDraft("");
+    setSteerQueue([...steerQueueRef.current, { id, text }]);
+    try {
+      await api.steerChat(session.id, id, text);
+    } catch (e) {
+      setSteerQueue(steerQueueRef.current.filter((x) => x.id !== id));
+      onError(`Couldn't queue message: ${errMsg(e)}`);
+    }
+  }
+
+  // Settle steered messages the agent has folded in: drop them from the queue and
+  // place them into the thread just before the turn's current assistant message —
+  // they shaped it. Shared by the mid-turn poll and the turn-end reconcile.
+  function settleConsumed(consumed: { id: string; text: string }[]) {
+    if (!session || !consumed.length) return;
+    const consumedIds = new Set(consumed.map((c) => c.id));
+    setSteerQueue(steerQueueRef.current.filter((q) => !consumedIds.has(q.id)));
+    const snap = chatStore.getSnapshot().sessions.find((s) => s.id === session.id);
+    if (!snap) return;
+    const settled: ChatMessage[] = consumed.map((c) => ({
+      id: c.id,
+      role: "user",
+      content: c.text,
+      createdAt: Date.now(),
+      status: "done",
+    }));
+    const msgs = [...snap.messages];
+    let at = msgs.length;
+    for (let i = msgs.length - 1; i >= 0; i--) {
+      if (msgs[i].role === "assistant") {
+        at = i;
+        break;
+      }
+    }
+    msgs.splice(at, 0, ...settled);
+    chatStore.updateMessages(session.id, msgs);
+  }
+
+  // After a turn ends, reconcile any still-queued steers: those the agent folded
+  // in settle into the thread; those still queued arrived after the last model
+  // call (never seen) → re-send as a fresh turn so they aren't lost.
+  async function reconcileSteer() {
+    const queued = steerQueueRef.current;
+    if (!session || !queued.length) return;
+    let remaining: { id: string; text: string }[];
+    try {
+      remaining = (await api.pendingSteer(session.id)).pending;
+    } catch {
+      return; // can't tell consumed from not — leave the queue rather than guess
+    }
+    const remainingIds = new Set(remaining.map((r) => r.id));
+    const consumed = queued.filter((q) => !remainingIds.has(q.id));
+    const unconsumed = queued.filter((q) => remainingIds.has(q.id));
+    if (consumed.length) settleConsumed(consumed);
+    setSteerQueue([]);
+    if (unconsumed.length) {
+      void runTurn(unconsumed.map((u) => u.text).join("\n\n"));
+    }
+  }
+
+  // Mid-turn ack: while a turn streams with queued steers, poll the backend so a
+  // steer the agent has already folded in settles into the thread immediately —
+  // otherwise a long turn shows "queued" long after the agent received it.
+  useEffect(() => {
+    if (status !== "streaming" || steerQueue.length === 0 || !session) return;
+    let alive = true;
+    const tick = async () => {
+      try {
+        const remaining = (await api.pendingSteer(session.id)).pending;
+        if (!alive) return;
+        const remainingIds = new Set(remaining.map((r) => r.id));
+        const consumed = steerQueueRef.current.filter((q) => !remainingIds.has(q.id));
+        if (consumed.length) settleConsumed(consumed);
+      } catch {
+        /* transient — retry next tick */
+      }
+    };
+    const handle = window.setInterval(tick, 1500);
+    return () => {
+      alive = false;
+      window.clearInterval(handle);
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [status, steerQueue.length, session?.id]);
 
   function copyMessage(message: ChatMessage) {
     void navigator.clipboard?.writeText(message.content || "");
@@ -706,6 +808,7 @@ function ChatSessionSlot({
       }, { images: opts.images, model: session.model });
       chatStore.setSessionStatus(session.id, "idle");
       setStatusMessage("idle");
+      void reconcileSteer();
     } catch (exc) {
       if (controller.signal.aborted) {
         setStatusMessage("stopped");
@@ -743,6 +846,8 @@ function ChatSessionSlot({
     abortRef.current?.abort();
     chatStore.setSessionStatus(sessionId, "idle");
     setStatusMessage("stopped");
+    // Drop any optimistic queued-steer bubbles; the user chose to stop.
+    setSteerQueue([]);
   }
 
   if (!session) return null;
@@ -811,6 +916,14 @@ function ChatSessionSlot({
             </Message>
           ))
         )}
+        {steerQueue.map((q) => (
+          <Message key={q.id} role="user">
+            <span className="chat-user-text">{q.text}</span>
+            <span className="steer-queued">
+              <Loader2 className="spin" size={11} /> queued — folds into the agent&apos;s work at its next step
+            </span>
+          </Message>
+        ))}
       </Conversation>
 
       {hitl && (
@@ -843,10 +956,13 @@ function ChatSessionSlot({
           }
         }}
       >
-        {status === "streaming" && statusMessage ? (
+        {status === "streaming" ? (
           <div className="composer-status">
             <Loader2 className="spin" size={12} />
-            <span>{statusMessage}</span>
+            <span>{statusMessage || "working"}</span>
+            <button type="button" className="composer-stop" onClick={() => void stop()}>
+              <Square size={10} /> Stop
+            </button>
           </div>
         ) : null}
         <PromptInput
@@ -855,13 +971,19 @@ function ChatSessionSlot({
             setDraft(v);
             setSlashDismissed(false); // re-open the menu when the input changes
           }}
-          // The DS button is Send when idle, Stop (square) while streaming.
+          // Idle → send. While a turn streams, the field stays live so the user can
+          // type and Enter to STEER (queue into the running turn) without stopping
+          // it; Stop is the dedicated control above. So `loading` stays false.
           onSubmit={() => {
-            if (status === "streaming") void stop();
+            if (status === "streaming") void queueSteer();
             else void send();
           }}
-          loading={status === "streaming"}
-          placeholder="Message protoAgent  (/ for commands · Enter to send · ⌘/Ctrl+Enter for newline)"
+          loading={false}
+          placeholder={
+            status === "streaming"
+              ? "Steer the agent — your message folds into its work at the next step (Enter to queue)"
+              : "Message protoAgent  (/ for commands · Enter to send · ⌘/Ctrl+Enter for newline)"
+          }
           inputRef={textareaRef}
           onKeyDown={onComposerKeyDown}
           onPaste={(e) => {

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -79,6 +79,40 @@
   color: var(--fg-secondary);
 }
 
+/* Dedicated Stop control while a turn streams (the composer's send button stays
+   live for mid-turn steering, so Stop is its own affordance here). */
+.composer-stop {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font: inherit;
+  font-size: 11px;
+  color: var(--fg-secondary);
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 6px;
+  padding: 1px 7px;
+  cursor: pointer;
+}
+.composer-stop:hover,
+.composer-stop:focus-visible {
+  color: var(--fg);
+  border-color: var(--fg-muted);
+}
+
+/* A queued mid-turn steering message — an optimistic user bubble shown until the
+   running turn folds it in (then it settles into the thread) or it's re-sent. */
+.steer-queued {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  margin-top: 4px;
+  font-size: 11px;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+
 /* Composer model picker — rendered in the DS PromptInput `actions` slot (ADR 0051,
    the ComposerWithAttachments DS pattern). A quiet inline button that reads as text
    until hover/focus. Drives a DS Menu dropdown. */

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1122,6 +1122,23 @@ export const api = {
     });
   },
 
+  // Mid-turn steering: queue a user message into a RUNNING turn (folded in at the
+  // next model call by SteeringMiddleware) without stopping the stream. The client
+  // `id` lets the turn-end reconcile tell consumed from arrived-too-late.
+  steerChat(sessionId: string, id: string, text: string) {
+    return request<{ ok: boolean; id: string | null; pending: number }>(
+      `/api/chat/sessions/${encodeURIComponent(sessionId)}/steer`,
+      { method: "POST", body: { id, text } },
+    );
+  },
+  // Items still queued for the session — read at turn-end: anything here arrived
+  // after the turn's last model call and wasn't folded in (re-send as a new turn).
+  pendingSteer(sessionId: string) {
+    return request<{ pending: { id: string; text: string }[] }>(
+      `/api/chat/sessions/${encodeURIComponent(sessionId)}/steer`,
+    );
+  },
+
   // Reconcile a turn against the server's durable task (A2A GetTask). Used to
   // self-heal a chat message stuck in `streaming` after the stream was
   // interrupted (reload, network blip, a stale tab) — the server task is the

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -40,6 +40,13 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
 
     middleware.append(WaitYieldMiddleware())
 
+    # Mid-turn user steering (spike) — fold queued user input into the running
+    # turn at the next model call, so a user can redirect ongoing work without
+    # stopping the stream. No-op when nothing was injected this turn.
+    from graph.middleware.steering import SteeringMiddleware
+
+    middleware.append(SteeringMiddleware())
+
     # Per-turn model override (per chat tab). Outermost wrap_model_call so the
     # PromptCache below sees the ACTUAL model when deciding caching. No-op unless
     # the turn carries state["model"].

--- a/graph/middleware/steering.py
+++ b/graph/middleware/steering.py
@@ -1,0 +1,54 @@
+"""SteeringMiddleware (spike) — fold queued mid-turn user input into a running turn.
+
+``before_model`` runs before every model call. Here it drains the per-session
+steering queue (graph/steering.py) and, if the user injected anything while the
+turn was working, appends it as HumanMessage(s) to the thread — so the model sees
+the redirection on its very next step. Because it runs before the *next* model
+call (i.e. right after a tool result comes back), the new input lands exactly at
+the "next tool-call boundary" the user expects, without the stream being stopped.
+
+No-op on a turn with an empty queue, so it never affects a normal turn. The queue
+is keyed by the turn's ``session_id`` state channel (state_schema=ProtoAgentState).
+"""
+
+from __future__ import annotations
+
+from langchain.agents.middleware import AgentMiddleware
+from langchain_core.messages import HumanMessage
+
+from graph import steering
+
+# Frame the injected text so the model reads it as a mid-task interjection (it may
+# redirect, or continue if it doesn't change the task) rather than a fresh request.
+# The wording mirrors the convergent comp pattern — Claude Code's h2A queue and
+# protoCLI's handleCompletedTools both wrap mid-turn input this way — validated in
+# the steering due-diligence.
+_INTERJECTION = (
+    "[User message received while you were working — address it now if it changes the "
+    "task, otherwise acknowledge briefly and keep going with your current work]\n\n"
+)
+
+
+class SteeringMiddleware(AgentMiddleware):
+    """Inject queued mid-turn user messages before the next model call."""
+
+    def before_model(self, state, runtime):  # type: ignore[override]
+        return self._inject(state)
+
+    async def abefore_model(self, state, runtime):  # type: ignore[override]
+        return self._inject(state)
+
+    @staticmethod
+    def _inject(state) -> dict | None:
+        session_id = state.get("session_id") if isinstance(state, dict) else getattr(state, "session_id", None)
+        if not session_id:
+            return None
+        queued = steering.drain(session_id)
+        if not queued:
+            return None
+        # One framed HumanMessage carrying all queued text. The add_messages reducer
+        # appends it to the thread before the model node runs, so the very next model
+        # call sees it. The console settles the user's ORIGINAL text into the thread
+        # (per-id); only the model sees the framed interjection.
+        combined = "\n\n".join(item["text"] for item in queued)
+        return {"messages": [HumanMessage(content=_INTERJECTION + combined)]}

--- a/graph/steering.py
+++ b/graph/steering.py
@@ -1,0 +1,55 @@
+"""Mid-turn user steering — a per-session queue of user messages that get folded
+into a RUNNING turn at the next model call.
+
+The console enqueues via ``POST /api/chat/sessions/{id}/steer`` while a turn is
+streaming; ``SteeringMiddleware`` (graph/middleware/steering.py) drains the queue
+in ``before_model`` and appends the messages, so the model sees the new input on
+its next step — letting a user redirect or reset ongoing work without stopping the
+stream.
+
+Each item carries a client-supplied ``id`` so the console can reconcile at
+turn-end: anything still queued when the turn finishes arrived after the last
+model call (not consumed) and is re-sent as a fresh turn; the rest were folded in.
+
+A process-wide singleton dict is fine: the graph turn and the API endpoint run in
+the same process + event loop, so enqueue (API) and drain (graph) never race on
+the dict. host-free (lives under graph/), so both the middleware and operator_api
+can import it without crossing an import layer.
+"""
+
+from __future__ import annotations
+
+import uuid
+
+# session_id -> [{"id": str, "text": str}], FIFO.
+_QUEUES: dict[str, list[dict]] = {}
+
+
+def enqueue(session_id: str, text: str, msg_id: str | None = None) -> str | None:
+    """Queue a user message for ``session_id``'s running turn. Returns its id (the
+    client's if supplied, else a fresh one), or None on a blank message."""
+    text = (text or "").strip()
+    if not session_id or not text:
+        return None
+    mid = msg_id or uuid.uuid4().hex
+    _QUEUES.setdefault(session_id, []).append({"id": mid, "text": text})
+    return mid
+
+
+def drain(session_id: str) -> list[dict]:
+    """Return and clear all queued items for ``session_id`` (FIFO). Used by the
+    middleware to fold the messages into the running turn."""
+    if not session_id:
+        return []
+    return _QUEUES.pop(session_id, [])
+
+
+def pending_items(session_id: str) -> list[dict]:
+    """Peek the still-queued items for ``session_id`` (not drained) — the
+    turn-end reconcile reads this to find input that arrived too late."""
+    return list(_QUEUES.get(session_id, []))
+
+
+def pending(session_id: str) -> int:
+    """How many messages are queued for ``session_id`` (not yet drained)."""
+    return len(_QUEUES.get(session_id, []))

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -75,6 +75,36 @@ def register_chat_routes(app, ui: str) -> None:
                 log.warning("[chat] attachment cleanup failed for %s: %s", session_id, exc)
         return {"deleted": True, "harvested": chunk_id is not None}
 
+    @app.post("/api/chat/sessions/{session_id}/steer")
+    async def _api_steer(session_id: str, body: dict | None = None):
+        """Queue a user message into a RUNNING turn (mid-turn steering).
+
+        The next model call folds it in via ``SteeringMiddleware``, so the user
+        can redirect or reset ongoing work without stopping the live stream. This
+        does NOT start a turn — it only enqueues; the in-flight turn picks it up at
+        its next model call (i.e. after the current tool finishes). The client may
+        pass its own ``id`` so it can reconcile at turn-end."""
+        from fastapi import HTTPException
+
+        from graph import steering
+
+        text = str((body or {}).get("text", "")).strip()
+        if not text:
+            raise HTTPException(status_code=400, detail="text is required")
+        msg_id = str((body or {}).get("id", "")).strip() or None
+        mid = steering.enqueue(session_id, text, msg_id=msg_id)
+        return {"ok": True, "id": mid, "pending": steering.pending(session_id)}
+
+    @app.get("/api/chat/sessions/{session_id}/steer")
+    async def _api_steer_pending(session_id: str):
+        """Items still queued for ``session_id`` — i.e. steering messages that
+        arrived after the turn's last model call and weren't folded in. The
+        console reads this at turn-end: it settles the consumed ones into the
+        thread and re-sends these un-consumed ones as a fresh turn."""
+        from graph import steering
+
+        return {"pending": steering.pending_items(session_id)}
+
     # --- Goal mode API ------------------------------------------------------
     # Programmatic status/clear for a session's goal (setting is done via the
     # `/goal ...` control message through chat/A2A). Returns 404-style payloads

--- a/scripts/dev-reset.sh
+++ b/scripts/dev-reset.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+#
+# Wipe the ISOLATED dev instance's state — its config + ALL its data — leaving your
+# default ("prod") agent under ~/.protoagent and config/ completely untouched.
+#
+# Stop the dev server first (Ctrl-C the `scripts/dev.sh` process).
+#
+#   scripts/dev-reset.sh                       # resets instance 'dev'
+#   PROTOAGENT_INSTANCE=scratch scripts/dev-reset.sh   # resets a differently-named sandbox
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+IID="${PROTOAGENT_INSTANCE:-dev}"
+DATA="${HOME}/.protoagent"
+
+echo "Resetting dev instance '${IID}' — your prod data under ${DATA} stays untouched."
+# Scoped config (seeded from the default on first run): config/<iid>/{langgraph-config,secrets,.setup-complete}
+rm -rf "config/${IID}"
+# Per-instance data root: ~/.protoagent/<iid>
+rm -rf "${DATA:?}/${IID}"
+# Per-store scoped leaves: ~/.protoagent/<store>/<iid>  (beads, knowledge, inbox, activity, scheduler, background, …)
+find "${DATA}" -mindepth 2 -maxdepth 2 -type d -name "${IID}" -exec rm -rf {} + 2>/dev/null || true
+
+echo "✓ dev instance '${IID}' wiped. Re-launch a fresh one with scripts/dev.sh."

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+#
+# Launch an ISOLATED dev instance of protoAgent so testing never touches your real
+# ("prod") agent data.
+#
+# Uses PROTOAGENT_INSTANCE scoping (ADR 0004): the dev instance gets its own config
+# + data leaves under the same homes, SEEDED from the default's config on first run
+# (so it boots with your gateway already configured — no re-setup wizard) but with
+# FRESH, separate chat / beads / knowledge / checkpoint data. Your default instance
+# (config/ + ~/.protoagent, port 7870) is left completely untouched.
+#
+#   scripts/dev.sh                 # → PROTOAGENT_INSTANCE=dev on http://127.0.0.1:7871
+#   PORT=7882 scripts/dev.sh       # pick a different port
+#   PROTOAGENT_INSTANCE=scratch scripts/dev.sh   # a differently-named sandbox
+#   scripts/dev.sh --ui none       # extra args pass straight through to `python -m server`
+#
+# Reset just this sandbox (prod untouched):  scripts/dev-reset.sh
+set -euo pipefail
+cd "$(dirname "$0")/.."
+
+export PROTOAGENT_INSTANCE="${PROTOAGENT_INSTANCE:-dev}"
+PORT="${PORT:-7871}"
+
+# Prefer the uv-managed project venv; fall back to whatever `python` is on PATH.
+PY="${PYTHON:-.venv/bin/python}"
+[ -x "$PY" ] || PY="python"
+
+echo "▶ protoAgent dev instance '${PROTOAGENT_INSTANCE}' on http://127.0.0.1:${PORT}"
+echo "  isolated config+data (seeded from your default config; prod data untouched)"
+exec "$PY" -m server --port "$PORT" "$@"

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -1,0 +1,152 @@
+"""Mid-turn steering (spike) — fold queued user input into a RUNNING turn at the
+next model call, so a user can redirect ongoing work without stopping the stream.
+
+graph/steering.py (the per-session queue) + graph/middleware/steering.py
+(SteeringMiddleware.before_model, which drains it).
+"""
+
+from __future__ import annotations
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, HumanMessage, ToolMessage
+from langchain_core.tools import tool
+
+from graph import steering
+from graph.middleware.steering import SteeringMiddleware
+
+
+@pytest.fixture(autouse=True)
+def _clear_queue():
+    steering._QUEUES.clear()
+    yield
+    steering._QUEUES.clear()
+
+
+# ── the queue ─────────────────────────────────────────────────────────────────
+
+
+def test_enqueue_drain_roundtrip_fifo():
+    steering.enqueue("s1", "first", msg_id="a")
+    steering.enqueue("s1", "second", msg_id="b")
+    assert steering.pending("s1") == 2
+    assert steering.pending_items("s1") == [{"id": "a", "text": "first"}, {"id": "b", "text": "second"}]
+    assert steering.drain("s1") == [{"id": "a", "text": "first"}, {"id": "b", "text": "second"}]
+    assert steering.pending("s1") == 0
+    assert steering.drain("s1") == []  # draining an empty queue is safe
+
+
+def test_enqueue_returns_id_and_mints_one_when_absent():
+    assert steering.enqueue("s1", "x", msg_id="given") == "given"
+    minted = steering.enqueue("s1", "y")
+    assert minted and minted != "given"
+
+
+def test_enqueue_ignores_blanks_and_missing_session():
+    assert steering.enqueue("s1", "   ") is None
+    assert steering.enqueue("", "x") is None
+    assert steering.pending("s1") == 0
+    assert steering.drain("") == []
+
+
+def test_queues_are_per_session():
+    steering.enqueue("a", "for-a", msg_id="1")
+    steering.enqueue("b", "for-b", msg_id="2")
+    assert steering.drain("a") == [{"id": "1", "text": "for-a"}]
+    assert steering.drain("b") == [{"id": "2", "text": "for-b"}]
+
+
+# ── the middleware (unit) ──────────────────────────────────────────────────────
+
+
+def test_middleware_injects_queued_then_clears():
+    steering.enqueue("sess", "actually, focus on X")
+    steering.enqueue("sess", "and skip the tests")
+    out = SteeringMiddleware._inject({"session_id": "sess", "messages": []})
+    assert out is not None
+    msgs = out["messages"]
+    # All queued text is combined into ONE framed interjection HumanMessage.
+    assert len(msgs) == 1 and isinstance(msgs[0], HumanMessage)
+    assert msgs[0].content.startswith("[User message received")  # advisory framing
+    assert "actually, focus on X" in msgs[0].content
+    assert "and skip the tests" in msgs[0].content
+    # drained — a second pass on the same turn is a no-op
+    assert SteeringMiddleware._inject({"session_id": "sess", "messages": []}) is None
+
+
+def test_middleware_noop_without_session_or_queue():
+    assert SteeringMiddleware._inject({"messages": []}) is None  # no session_id
+    assert SteeringMiddleware._inject({"session_id": "sess", "messages": []}) is None  # empty queue
+
+
+# ── end-to-end in a REAL graph ─────────────────────────────────────────────────
+# Drive a real create_agent graph: model call 1 invokes a tool; while the tool
+# "runs" the user steers (enqueue); SteeringMiddleware.before_model must fold that
+# message into the thread before model call 2, so it lands AFTER the tool result
+# and BEFORE the final answer — exactly the next-tool-call boundary.
+
+
+class _ToolFake(GenericFakeChatModel):
+    """Fake chat model that supports bind_tools (returns itself) so it drops into
+    create_agent and replays preset AIMessages, including tool calls."""
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+
+@pytest.mark.asyncio
+async def test_steering_message_injected_mid_turn():
+    from unittest.mock import patch
+
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from graph.config import LangGraphConfig
+
+    # The tool simulates the user steering WHILE it runs (mid-turn injection).
+    @tool
+    def long_task() -> str:
+        """A long step; the user redirects the agent while it runs."""
+        steering.enqueue("sess-1", "actually, do X instead")
+        return "long_task step done"
+
+    fake = _ToolFake(
+        messages=iter(
+            [
+                AIMessage(
+                    content="",
+                    tool_calls=[{"name": "long_task", "args": {}, "id": "c1", "type": "tool_call"}],
+                ),
+                AIMessage(content="Understood — switching to X."),
+            ]
+        )
+    )
+
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+
+        graph = create_agent_graph(
+            LangGraphConfig(),
+            include_subagents=False,
+            checkpointer=MemorySaver(),
+            extra_tools=[long_task],
+        )
+
+    result = await graph.ainvoke(
+        {"messages": [HumanMessage("start the long task")], "session_id": "sess-1"},
+        config={"configurable": {"thread_id": "t1"}},
+    )
+    msgs = result["messages"]
+
+    # The steering message was injected into the live thread (not the queue) — framed
+    # as a mid-task interjection that carries the user's text.
+    steer = [m for m in msgs if isinstance(m, HumanMessage) and "actually, do X instead" in m.content]
+    assert len(steer) == 1, "steering message should be folded into the running turn exactly once"
+
+    # …and at the right point: after the tool result, before the final answer.
+    idx_steer = msgs.index(steer[0])
+    idx_tool = max(i for i, m in enumerate(msgs) if isinstance(m, ToolMessage))
+    idx_final = max(i for i, m in enumerate(msgs) if isinstance(m, AIMessage) and m.content)
+    assert idx_tool < idx_steer < idx_final, "steering must land between the tool result and the final answer"
+
+    # The queue is drained — nothing left to leak into a later turn.
+    assert steering.pending("sess-1") == 0


### PR DESCRIPTION
Let a user submit messages **while a turn is working**; they fold into the running turn at its **next model call** so the agent can adjust or reset course — without killing the stream. This is the **lead-level MVP**; UX is intentionally minimal — **handing off to the UI team to dial in**.

Validated against the convergent comp pattern in a steering due-diligence: Claude Code's `h2A` queue and protoCLI's between-tool-call drain both do exactly this (cooperative, next-step injection with advisory framing). Notably, **no comparable system steers into subagents** (it's an open Claude Code feature request), so the lead-level scope is the industry norm, not a gap.

## Backend
- **`graph/steering.py`** — per-session queue (`enqueue`/`drain`/`pending`) keyed by the turn's `session_id`; client-supplied ids for turn-end reconcile.
- **`graph/middleware/steering.py`** — `SteeringMiddleware.before_model` drains the queue and injects **one framed `HumanMessage`** (`[User message received while you were working — address it now if it changes the task, otherwise … keep going]`) so the model treats it as an interjection, not a fresh request. Wired after `wait_yield`; no-op on an empty queue.
- **`POST`/`GET /api/chat/sessions/{id}/steer`** — enqueue while a turn streams (does **not** start a turn) + read still-queued items for reconcile.

## Frontend (`ChatSurface`)
- Composer stays live while streaming: **Enter queues** (optimistic "queued" bubble) with a dedicated **Stop** button.
- **Mid-turn ack** poll: a steer the agent folded in settles into the thread immediately (so a long turn doesn't look stuck).
- **Turn-end reconcile**: consumed steers settle into the thread (before the answer); any that arrived after the last model call re-send as a fresh turn. Console shows the user's plain text; only the model sees the framing.

## Dev tooling (so testing never stomps prod data)
- **`scripts/dev.sh`** — isolated instance via `PROTOAGENT_INSTANCE=dev` (ADR 0004) on `:7871`: config+data scoped + seeded from the default (boots configured, fresh data). **`scripts/dev-reset.sh`** wipes just the sandbox. PROTO.md documents it.

## Tests / gates
`tests/test_steering.py` — queue + middleware unit + a **real `create_agent` graph** proving a mid-turn-enqueued message folds in at the next model call, framed. Green locally: ruff · import-linter · pytest (2214 passed; the only fails are a pre-existing **local** spacetraders-plugin config-roundtrip artifact, green on clean CI) · tsc · web unit (88) · web e2e (107) · live smoke. Verified end-to-end against the real model (mid-flight "switch octopus→jellyfish" redirect).

## Known limitation (deferred — see due-diligence)
Steering reaches the **lead** only; a subagent `task` delegation runs without the middleware. Follow-ups: a Cancel-the-delegation affordance, then maybe mid-subagent injection (an industry-first if pursued).

🤖 Generated with [Claude Code](https://claude.com/claude-code)