### PR TITLE
refactor(web): adopt DS queue-while-working steering (ui 0.42.0)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.41.0",
+    "@protolabsai/ui": "^0.42.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -16,7 +16,6 @@ import {
   GitBranch,
   Loader2,
   RotateCcw,
-  Square,
   TerminalSquare,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
@@ -917,11 +916,11 @@ function ChatSessionSlot({
           ))
         )}
         {steerQueue.map((q) => (
-          <Message key={q.id} role="user">
+          // DS queued state (0.42.0): dimmed pending bubble + spinner. No ✕ yet —
+          // the steer is already POSTed and there's no dequeue endpoint, so an
+          // optimistic cancel would mislead (the agent would still fold it in).
+          <Message key={q.id} role="user" queued queuedLabel="queued — folds into the agent's work at its next step">
             <span className="chat-user-text">{q.text}</span>
-            <span className="steer-queued">
-              <Loader2 className="spin" size={11} /> queued — folds into the agent&apos;s work at its next step
-            </span>
           </Message>
         ))}
       </Conversation>
@@ -957,12 +956,11 @@ function ChatSessionSlot({
         }}
       >
         {status === "streaming" ? (
+          // Live turn status. Stop now lives inside the composer (the DS busy mode's
+          // self-contained onStop), so this strip is just the "working…" readout.
           <div className="composer-status">
             <Loader2 className="spin" size={12} />
             <span>{statusMessage || "working"}</span>
-            <button type="button" className="composer-stop" onClick={() => void stop()}>
-              <Square size={10} /> Stop
-            </button>
           </div>
         ) : null}
         <PromptInput
@@ -971,14 +969,13 @@ function ChatSessionSlot({
             setDraft(v);
             setSlashDismissed(false); // re-open the menu when the input changes
           }}
-          // Idle → send. While a turn streams, the field stays live so the user can
-          // type and Enter to STEER (queue into the running turn) without stopping
-          // it; Stop is the dedicated control above. So `loading` stays false.
-          onSubmit={() => {
-            if (status === "streaming") void queueSteer();
-            else void send();
-          }}
-          loading={false}
+          // Idle → send. While a turn streams (`busy`), the field stays live: Enter
+          // queues a steer into the running turn (onQueue) without stopping it, and
+          // the kit renders a dedicated Stop (onStop) beside Send.
+          onSubmit={() => void send()}
+          busy={status === "streaming"}
+          onQueue={() => void queueSteer()}
+          onStop={() => void stop()}
           placeholder={
             status === "streaming"
               ? "Steer the agent — your message folds into its work at the next step (Enter to queue)"

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -79,39 +79,8 @@
   color: var(--fg-secondary);
 }
 
-/* Dedicated Stop control while a turn streams (the composer's send button stays
-   live for mid-turn steering, so Stop is its own affordance here). */
-.composer-stop {
-  margin-left: auto;
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  font: inherit;
-  font-size: 11px;
-  color: var(--fg-secondary);
-  background: none;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  padding: 1px 7px;
-  cursor: pointer;
-}
-.composer-stop:hover,
-.composer-stop:focus-visible {
-  color: var(--fg);
-  border-color: var(--fg-muted);
-}
-
-/* A queued mid-turn steering message — an optimistic user bubble shown until the
-   running turn folds it in (then it settles into the thread) or it's re-sent. */
-.steer-queued {
-  display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  margin-top: 4px;
-  font-size: 11px;
-  color: var(--fg-muted);
-  font-style: italic;
-}
+/* Stop (while streaming) and the queued-steer bubble are now the DS busy mode +
+   <Message queued> (0.42.0) — see ChatSurface. No bespoke CSS needed here. */
 
 /* Composer model picker — rendered in the DS PromptInput `actions` slot (ADR 0051,
    the ComposerWithAttachments DS pattern). A quiet inline button that reads as text

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.41.0",
+        "@protolabsai/ui": "^0.42.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.41.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.41.0.tgz",
-      "integrity": "sha512-kOx2Qc2sY91wbbiW19YMjDg7aSKRoya8CEIygdWkUizY7Le0wSe6IQvyWWDUK2OPMDuhjP3WSFuvmW1gZ6xR9g==",
+      "version": "0.42.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.42.0.tgz",
+      "integrity": "sha512-EAGxlKjauKy9hXH4Y0vbrsW/VePYgu3lv/A8IN4mGt6yyoor1JqorUbxMw/vVqymp+aB8Rs1WyVTO64DiSchAA==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Adopts the first-class steering support shipped in `@protolabsai/ui@0.42.0` (protoContent #262, closing the DS half of protoContent #261), replacing the hand-rolled MVP from #1101.

## Changes
- **Composer** — `PromptInput` now uses `busy={status === "streaming"}` + `onQueue` (queue a steer) + `onStop` (halt the turn). The Stop control is **self-contained in the composer bar** (the kit's busy mode), so the external `.composer-stop` button is gone and the status strip is just the "working…" readout. The streaming/queue branch in `onSubmit` collapses to a plain `send()`.
- **Queued bubbles** — render via the DS `<Message queued queuedLabel="…">` (dimmed bubble + spinner), replacing the bespoke `.steer-queued` markup.
- **CSS** — drops `.composer-stop` + `.steer-queued` (now provided by the DS).

## Not changed (deliberately)
- **No ✕ to cancel a queued steer yet.** The steer is already POSTed to `/steer` and there's no dequeue endpoint, so an optimistic cancel would mislead — the agent would still fold it in. The DS supports `onCancel`; wiring it needs a backend dequeue (follow-up).

## Validation
- `tsc --noEmit` clean · 88 web unit pass
- e2e green against the **published** DS: `streaming`, `turn-watch`, `chat`, `chat-reconcile`, `file-only-send`, `paste-attach`, `commands`, `fleet`, `message-actions` (24 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)