### PR TITLE
feat(chat): wire ✕-cancel for queued steers via a backend dequeue

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -476,6 +476,28 @@ function ChatSessionSlot({
     }
   }
 
+  // Cancel a queued steer via the ✕ on its pending bubble. Drop the bubble
+  // optimistically so the click feels instant, then DELETE it server-side. If the
+  // agent had already drained it (`removed: false`), it's too late to cancel — it
+  // shaped the reply, so settle it into the thread instead of lying it never ran.
+  async function cancelSteer(id: string) {
+    if (!session) return;
+    const item = steerQueueRef.current.find((q) => q.id === id);
+    if (!item) return;
+    setSteerQueue(steerQueueRef.current.filter((q) => q.id !== id));
+    try {
+      const { removed } = await api.cancelSteer(session.id, id);
+      if (!removed) settleConsumed([item]);
+    } catch (e) {
+      // Couldn't reach the backend — restore the bubble rather than drop a steer
+      // that may still be queued (avoid concurrent-add clobber by re-checking).
+      if (!steerQueueRef.current.some((q) => q.id === id)) {
+        setSteerQueue([...steerQueueRef.current, item]);
+      }
+      onError(`Couldn't cancel message: ${errMsg(e)}`);
+    }
+  }
+
   // Settle steered messages the agent has folded in: drop them from the queue and
   // place them into the thread just before the turn's current assistant message —
   // they shaped it. Shared by the mid-turn poll and the turn-end reconcile.
@@ -916,10 +938,17 @@ function ChatSessionSlot({
           ))
         )}
         {steerQueue.map((q) => (
-          // DS queued state (0.42.0): dimmed pending bubble + spinner. No ✕ yet —
-          // the steer is already POSTed and there's no dequeue endpoint, so an
-          // optimistic cancel would mislead (the agent would still fold it in).
-          <Message key={q.id} role="user" queued queuedLabel="queued — folds into the agent's work at its next step">
+          // DS queued state (0.42.0): dimmed pending bubble + spinner + ✕. The ✕
+          // hits DELETE /steer/{id}: if still queued it's dropped before the agent
+          // sees it; if already folded in, cancelSteer settles it into the thread
+          // (no lie that it never ran).
+          <Message
+            key={q.id}
+            role="user"
+            queued
+            queuedLabel="queued — folds into the agent's work at its next step"
+            onCancel={() => void cancelSteer(q.id)}
+          >
             <span className="chat-user-text">{q.text}</span>
           </Message>
         ))}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1138,6 +1138,15 @@ export const api = {
       `/api/chat/sessions/${encodeURIComponent(sessionId)}/steer`,
     );
   },
+  // Cancel a still-queued steer (the ✕ on a pending bubble) before it folds into
+  // the turn. `removed: false` means it was already drained — the agent will act
+  // on it, so the caller settles it into the thread rather than dropping it.
+  cancelSteer(sessionId: string, id: string) {
+    return request<{ removed: boolean; pending: number }>(
+      `/api/chat/sessions/${encodeURIComponent(sessionId)}/steer/${encodeURIComponent(id)}`,
+      { method: "DELETE" },
+    );
+  },
 
   // Reconcile a turn against the server's durable task (A2A GetTask). Used to
   // self-heal a chat message stuck in `streaming` after the stream was

--- a/graph/steering.py
+++ b/graph/steering.py
@@ -44,6 +44,26 @@ def drain(session_id: str) -> list[dict]:
     return _QUEUES.pop(session_id, [])
 
 
+def dequeue(session_id: str, msg_id: str) -> bool:
+    """Remove a still-queued steering message by id BEFORE it's folded in (the
+    console's ✕-cancel on a pending bubble). Returns True if it was found and
+    dropped; False if absent — already drained into the running turn (too late;
+    the agent will still act on it) or never queued. The console settles a
+    not-removed steer into the thread rather than lie that it never happened."""
+    if not session_id or not msg_id:
+        return False
+    q = _QUEUES.get(session_id)
+    if not q:
+        return False
+    for i, item in enumerate(q):
+        if item.get("id") == msg_id:
+            del q[i]
+            if not q:
+                _QUEUES.pop(session_id, None)  # match drain(): no empty lists linger
+            return True
+    return False
+
+
 def pending_items(session_id: str) -> list[dict]:
     """Peek the still-queued items for ``session_id`` (not drained) — the
     turn-end reconcile reads this to find input that arrived too late."""

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -105,6 +105,19 @@ def register_chat_routes(app, ui: str) -> None:
 
         return {"pending": steering.pending_items(session_id)}
 
+    @app.delete("/api/chat/sessions/{session_id}/steer/{msg_id}")
+    async def _api_steer_cancel(session_id: str, msg_id: str):
+        """Cancel a still-queued steer before it folds into the turn (the ✕ on a
+        pending bubble). ``removed: true`` means it was dropped from the queue and
+        the agent never sees it; ``removed: false`` means it had already been
+        drained into the running turn (too late — the agent will still act on it)
+        or was never queued. The console settles a not-removed steer into the
+        thread instead of pretending it never happened."""
+        from graph import steering
+
+        removed = steering.dequeue(session_id, msg_id)
+        return {"removed": removed, "pending": steering.pending(session_id)}
+
     # --- Goal mode API ------------------------------------------------------
     # Programmatic status/clear for a session's goal (setting is done via the
     # `/goal ...` control message through chat/A2A). Returns 404-style payloads

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -120,6 +120,24 @@ def test_goal_disabled_when_no_controller(monkeypatch):
     assert c.delete("/api/goal/s1").json() == {"enabled": False, "cleared": False}
 
 
+def test_steer_enqueue_then_cancel_roundtrip(monkeypatch):
+    # Full HTTP lifecycle of the steer endpoints: POST queues, GET peeks, DELETE
+    # cancels a still-queued message, and a second DELETE reports too-late.
+    from graph import steering
+
+    steering._QUEUES.clear()
+    c = _client(monkeypatch)
+    posted = c.post("/api/chat/sessions/s1/steer", json={"id": "m1", "text": "do X instead"}).json()
+    assert posted == {"ok": True, "id": "m1", "pending": 1}
+    assert c.get("/api/chat/sessions/s1/steer").json() == {"pending": [{"id": "m1", "text": "do X instead"}]}
+
+    # ✕ before the turn folds it in → removed, queue empties.
+    assert c.delete("/api/chat/sessions/s1/steer/m1").json() == {"removed": True, "pending": 0}
+    # ✕ again (or after it's drained) → too late, nothing removed.
+    assert c.delete("/api/chat/sessions/s1/steer/m1").json() == {"removed": False, "pending": 0}
+    steering._QUEUES.clear()
+
+
 def test_openai_models_and_completion(monkeypatch):
     c = _client(monkeypatch)
     models = c.get("/v1/models").json()

--- a/tests/test_steering.py
+++ b/tests/test_steering.py
@@ -56,6 +56,37 @@ def test_queues_are_per_session():
     assert steering.drain("b") == [{"id": "2", "text": "for-b"}]
 
 
+# ── dequeue (the ✕ cancel) ──────────────────────────────────────────────────────
+
+
+def test_dequeue_removes_the_targeted_item_and_keeps_order():
+    steering.enqueue("s1", "first", msg_id="a")
+    steering.enqueue("s1", "second", msg_id="b")
+    steering.enqueue("s1", "third", msg_id="c")
+    assert steering.dequeue("s1", "b") is True  # cancel the middle one
+    assert steering.pending_items("s1") == [{"id": "a", "text": "first"}, {"id": "c", "text": "third"}]
+
+
+def test_dequeue_returns_false_when_already_drained_or_absent():
+    steering.enqueue("s1", "x", msg_id="a")
+    assert steering.dequeue("s1", "missing") is False  # never queued
+    steering.drain("s1")  # turn folded it in
+    assert steering.dequeue("s1", "a") is False  # too late — already drained
+    assert steering.dequeue("s1", "a") is False  # session has no queue at all
+
+
+def test_dequeue_ignores_blanks():
+    assert steering.dequeue("", "a") is False
+    assert steering.dequeue("s1", "") is False
+
+
+def test_dequeue_drops_the_empty_queue_like_drain():
+    steering.enqueue("s1", "only", msg_id="a")
+    assert steering.dequeue("s1", "a") is True
+    assert "s1" not in steering._QUEUES  # no empty list lingers (matches drain)
+    assert steering.pending("s1") == 0
+
+
 # ── the middleware (unit) ──────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
## What

Closes the consumer-side follow-up flagged in **protoContent#261** (and its #262 comment): mid-turn steering's queued bubble couldn't be cancelled. A steer was already POSTed to `/steer` with no dequeue, so the DS `Message onCancel` ✕ (shipped in `@protolabsai/ui@0.42.0`) was deliberately left unwired — an optimistic cancel would have lied, since the agent still folds a *drained* steer in.

This adds the backend dequeue and wires the ✕.

## Changes

- **`graph/steering.py`** — `dequeue(session_id, msg_id) -> bool`: removes a still-queued steer *before* it's folded in. Returns `False` if it was already drained into the running turn (too late) or never queued. Pops the empty queue like `drain()`.
- **`operator_api/chat_routes.py`** — `DELETE /api/chat/sessions/{id}/steer/{msg_id}` → `{removed, pending}`.
- **`apps/web` (`api.ts` + `ChatSurface.tsx`)** — `api.cancelSteer` + a `cancelSteer` handler:
  - drops the pending bubble **optimistically** (the ✕ feels instant);
  - on `removed: false` (already folded in) it **settles the steer into the thread** — it shaped the reply, so we don't pretend it never ran;
  - **restores** the bubble if the DELETE can't reach the backend.
  - wired onto `<Message queued onCancel=…>`.

## Context

- DS half: `@protolabsai/ui@0.42.0` (protoContent#262). Adoption: protoAgent#1102. Backend + MVP: protoAgent#1101.
- The `Message` primitive (`queued` + `queuedLabel` + `onCancel`) was already waiting for this.

## Tests / gates (all green locally)

| Gate | Result |
|---|---|
| `ruff check` | pass |
| `lint-imports` | 3 kept, 0 broken |
| `pytest` (steering + chat_routes) | 22 passed |
| `tsc --noEmit` | clean |
| web unit (vitest) | 88 passed |

New tests: `dequeue` unit cases (remove-by-id keeps order; too-late/absent → False; empty-queue cleanup) + the **first HTTP-level steer lifecycle test** (POST → GET → DELETE removed → DELETE too-late). Playwright e2e not run locally — CI covers it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)