### PR TITLE
feat(portfolio): PM portfolio plugin — dispatch to + read remote team boards over A2A (ADR 0055 P1)

### DIFF
--- a/plugins/portfolio/__init__.py
+++ b/plugins/portfolio/__init__.py
@@ -1,0 +1,150 @@
+"""portfolio — the PM / program orchestration layer (ADR 0055 P1).
+
+One agent orchestrates work across MANY team-agents, each running its own project
+board for its own repo (scale-out). This is **pure composition** of three existing
+subsystems — no new dispatch or registry machinery:
+
+  - fleet (`graph.fleet.supervisor`) — the team-agent registry (remote members)
+  - delegates (`plugins.delegates`) — the A2A dispatch primitive (`A2aAdapter`)
+  - project_board (its data router) — the structured remote board read
+
+The PM treats each remote fleet member as a *board* addressed by its name: list
+them (`portfolio_boards`), dispatch a feature to one over A2A (`portfolio_dispatch`),
+and read one back structured (`portfolio_board_read`). See ADR 0055.
+"""
+
+from __future__ import annotations
+
+import json
+
+from langchain_core.tools import tool
+
+
+def register(registry) -> None:
+    for t in _tools():
+        registry.register_tool(t)
+
+
+def _remote_by_name(name: str) -> dict | None:
+    """The remote-member record (token INCLUDED) for a board name/id, or None.
+
+    A board is addressed by the remote fleet member's name (ADR 0055 §2). Uses
+    ``list_remotes()`` (not ``status()``) because dispatch + read need the stored
+    bearer, which ``status()`` strips.
+    """
+    from graph.fleet import supervisor
+
+    name = (name or "").strip()
+    if not name:
+        return None
+    for rec in supervisor.list_remotes():
+        if rec.get("name") == name or rec.get("id") == name:
+            return rec
+    return None
+
+
+def _dispatch_instruction(title: str, spec: str, acceptance_criteria: str, files_to_modify: str) -> str:
+    lines = [
+        "You manage a project board (the project_board plugin). Create a new feature on it "
+        "and mark it ready so your spawn loop picks it up — use board_create_feature then "
+        "board_mark_ready.",
+        f"Title: {title}",
+        f"Spec: {spec}",
+    ]
+    if acceptance_criteria:
+        lines.append(f"Acceptance criteria: {acceptance_criteria}")
+    if files_to_modify:
+        lines.append(f"Files to modify: {files_to_modify}")
+    lines.append("Report the created feature id and its board state.")
+    return "\n".join(lines)
+
+
+def _tools() -> list:
+    @tool
+    def portfolio_boards() -> str:
+        """List the team boards you can orchestrate. Each is a remote team-agent — its
+        own protoAgent instance running a project board for its repo. Returns each
+        board's name, url, and whether it's reachable. Use the name as the ``board``
+        argument to portfolio_dispatch / portfolio_board_read."""
+        from graph.fleet import supervisor
+
+        boards = [
+            {"board": a["name"], "url": a.get("url"), "reachable": bool(a.get("running"))}
+            for a in supervisor.status()
+            if a.get("remote") and a.get("url")
+        ]
+        if not boards:
+            return (
+                "No team boards yet. A team board is a remote protoAgent (running the "
+                "project_board plugin for its repo) registered as a fleet member — add one "
+                "via the console (Discover → Add to this fleet) or POST /api/fleet/remotes."
+            )
+        return json.dumps(boards, indent=2)
+
+    @tool
+    async def portfolio_dispatch(
+        board: str,
+        title: str,
+        spec: str,
+        acceptance_criteria: str = "",
+        files_to_modify: str = "",
+    ) -> str:
+        """Dispatch a feature to a team board over A2A. ``board`` is a team-agent name
+        (see portfolio_boards). The team's lead agent creates the feature on its OWN
+        board and marks it ready; its loop then ships the PR in ITS repo. Give a
+        self-sufficient spec + acceptance criteria + the files to touch — a vague task
+        makes a coder produce nothing. Returns the team agent's reply."""
+        rec = _remote_by_name(board)
+        if rec is None:
+            return f"Error: no team board named {board!r}. Call portfolio_boards to list them."
+        from plugins.delegates.adapters import ADAPTERS, Delegate
+
+        d = Delegate(
+            name=board,
+            type="a2a",
+            url=rec["url"].rstrip("/") + "/a2a",
+            auth_scheme="bearer",
+            auth_token=rec.get("token", ""),
+        )
+        try:
+            return await ADAPTERS["a2a"].dispatch(
+                d, _dispatch_instruction(title, spec, acceptance_criteria, files_to_modify), timeout=120
+            )
+        except Exception as exc:  # noqa: BLE001 — surface the dispatch failure to the model
+            return f"Error dispatching to {board!r}: {exc}"
+
+    @tool
+    async def portfolio_board_read(board: str, state: str = "") -> str:
+        """Read a team board's current state (structured) — the bounded view a PM
+        reasons over. ``board`` is a team-agent name (see portfolio_boards); optional
+        ``state`` filters to one lane (backlog/ready/in_progress/in_review/done/
+        blocked). Returns the features as JSON."""
+        rec = _remote_by_name(board)
+        if rec is None:
+            return f"Error: no team board named {board!r}. Call portfolio_boards to list them."
+
+        url = rec["url"].rstrip("/") + "/api/plugins/project_board/features"
+        # The remote was egress-vetted at add_remote; re-check the read URL too (parity
+        # with the A2A dispatch path, which guards every call).
+        from security import policy
+
+        blocked = policy.check_url(url)
+        if blocked:
+            return f"Error reading {board!r} board: {blocked}"
+
+        import httpx
+
+        headers = {"Authorization": f"Bearer {rec['token']}"} if rec.get("token") else {}
+        params = {"state": state} if state else None
+        try:
+            async with httpx.AsyncClient(timeout=30) as client:
+                r = await client.get(url, headers=headers, params=params)
+        except Exception as exc:  # noqa: BLE001
+            return f"Error reading {board!r} board: {exc}"
+        if r.status_code == 404:
+            return f"{board!r} doesn't expose a project board (project_board not enabled there)."
+        if r.status_code >= 400:
+            return f"Error reading {board!r} board: HTTP {r.status_code} {r.text[:200]}"
+        return json.dumps(r.json().get("features", []), indent=2)
+
+    return [portfolio_boards, portfolio_dispatch, portfolio_board_read]

--- a/plugins/portfolio/protoagent.plugin.yaml
+++ b/plugins/portfolio/protoagent.plugin.yaml
@@ -1,0 +1,22 @@
+id: portfolio
+name: Portfolio (multi-team orchestration)
+version: 0.1.0
+description: >-
+  The PM / program orchestration layer (ADR 0055 P1). One agent orchestrates work
+  across MANY team-agents, each running its own project board for its own repo
+  (scale-out). Pure composition of three existing subsystems — the fleet
+  (team-agent registry), delegates (the A2A dispatch primitive), and project_board
+  (the remote board read). The PM treats each remote fleet member as a *board*
+  addressed by name: list them, dispatch a feature to one, read one back — over A2A.
+
+  Tools: portfolio_boards (enumerate), portfolio_dispatch (send a feature to a
+  team board over A2A), portfolio_board_read (structured read of a team board).
+  Ships DISABLED; enable with `plugins: { enabled: [portfolio] }`. Pairs with the
+  `delegates` plugin and remote fleet members (ADR 0042). See ADR 0055.
+
+enabled: false
+min_protoagent_version: "0.42.0"
+
+# Declarative only (console transparency).
+capabilities:
+  network: ["*"]   # A2A dispatch + project_board reads to remote team-agents

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -1,0 +1,178 @@
+"""portfolio plugin tests (ADR 0055 P1).
+
+The PM orchestration tools are pure composition over fleet × delegates ×
+project_board — so the tests stub all three: no fleet, no A2A, no HTTP. They
+assert the tools address the right remote board, dispatch over A2A with the
+stored bearer, and read the structured board back.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from plugins import portfolio
+
+
+def _tool(name: str):
+    return next(t for t in portfolio._tools() if t.name == name)
+
+
+# ── portfolio_boards ─────────────────────────────────────────────────────────
+
+
+def test_boards_lists_only_remote_members(monkeypatch):
+    from graph.fleet import supervisor
+
+    monkeypatch.setattr(
+        supervisor,
+        "status",
+        lambda: [
+            {"name": "host", "host": True},
+            {"name": "team-web", "remote": True, "url": "https://web.example", "running": True},
+            {"name": "team-api", "remote": True, "url": "https://api.example", "running": False},
+            {"name": "local-x", "port": 7890},  # a local member, not a remote → excluded
+        ],
+    )
+    out = json.loads(_tool("portfolio_boards").invoke({}))
+    assert {b["board"] for b in out} == {"team-web", "team-api"}
+    assert next(b for b in out if b["board"] == "team-web")["reachable"] is True
+    assert next(b for b in out if b["board"] == "team-api")["reachable"] is False
+
+
+def test_boards_empty_message(monkeypatch):
+    from graph.fleet import supervisor
+
+    monkeypatch.setattr(supervisor, "status", lambda: [{"name": "host", "host": True}])
+    assert "No team boards yet" in _tool("portfolio_boards").invoke({})
+
+
+# ── portfolio_dispatch ───────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_dispatch_sends_over_a2a_with_the_stored_bearer(monkeypatch):
+    from graph.fleet import supervisor
+    from plugins.delegates import adapters
+
+    monkeypatch.setattr(
+        supervisor,
+        "list_remotes",
+        lambda: [{"id": "r1", "name": "team-web", "url": "https://web.example/", "token": "tok-web"}],
+    )
+    captured = {}
+
+    async def fake_dispatch(d, query, *, timeout=None):
+        captured.update(url=d.url, token=d.auth_token, scheme=d.auth_scheme, query=query, timeout=timeout)
+        return "Created bd-7; state ready."
+
+    monkeypatch.setattr(adapters.ADAPTERS["a2a"], "dispatch", fake_dispatch)
+
+    out = await _tool("portfolio_dispatch").ainvoke(
+        {
+            "board": "team-web",
+            "title": "Add /healthz",
+            "spec": "expose a readiness probe",
+            "acceptance_criteria": "returns 200 when ready",
+            "files_to_modify": "server.py",
+        }
+    )
+    assert out == "Created bd-7; state ready."
+    assert captured["url"] == "https://web.example/a2a"  # /a2a appended, trailing slash normalized
+    assert captured["token"] == "tok-web" and captured["scheme"] == "bearer"
+    # the instruction carries the spec + tells the team lead to use its board tools
+    assert "Add /healthz" in captured["query"] and "board_create_feature" in captured["query"]
+    assert "returns 200 when ready" in captured["query"] and "server.py" in captured["query"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unknown_board(monkeypatch):
+    from graph.fleet import supervisor
+
+    monkeypatch.setattr(supervisor, "list_remotes", lambda: [])
+    out = await _tool("portfolio_dispatch").ainvoke({"board": "nope", "title": "t", "spec": "s"})
+    assert "no team board named 'nope'" in out
+
+
+# ── portfolio_board_read ─────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_board_read_fetches_structured_features_with_bearer(monkeypatch):
+    import httpx
+
+    from graph.fleet import supervisor
+    from security import policy
+
+    monkeypatch.setattr(
+        supervisor,
+        "list_remotes",
+        lambda: [{"id": "r1", "name": "team-web", "url": "https://web.example", "token": "tok-web"}],
+    )
+    monkeypatch.setattr(policy, "check_url", lambda _url: "")  # allow the read URL
+
+    seen = {}
+
+    class _Resp:
+        status_code = 200
+
+        def json(self):
+            return {"features": [{"id": "bd-1", "title": "T", "state": "ready"}]}
+
+    class _Client:
+        def __init__(self, **_kw):
+            pass
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def get(self, url, headers=None, params=None):
+            seen.update(url=url, headers=headers, params=params)
+            return _Resp()
+
+    monkeypatch.setattr(httpx, "AsyncClient", _Client)
+
+    out = json.loads(await _tool("portfolio_board_read").ainvoke({"board": "team-web", "state": "ready"}))
+    assert out == [{"id": "bd-1", "title": "T", "state": "ready"}]
+    assert seen["url"] == "https://web.example/api/plugins/project_board/features"
+    assert seen["headers"]["Authorization"] == "Bearer tok-web"
+    assert seen["params"] == {"state": "ready"}
+
+
+@pytest.mark.asyncio
+async def test_board_read_unknown_board(monkeypatch):
+    from graph.fleet import supervisor
+
+    monkeypatch.setattr(supervisor, "list_remotes", lambda: [])
+    out = await _tool("portfolio_board_read").ainvoke({"board": "nope"})
+    assert "no team board named 'nope'" in out
+
+
+# ── manifest / loader ────────────────────────────────────────────────────────
+
+
+def test_manifest_discovers_and_ships_disabled():
+    from pathlib import Path
+
+    from graph.plugins.loader import discover_plugins
+
+    plugins_root = Path(__file__).resolve().parent.parent / "plugins"
+    by_id = {m.id: m for m in discover_plugins([plugins_root])}
+    m = by_id.get("portfolio")
+    assert m is not None, "portfolio plugin not discovered"
+    assert m.version and m.enabled is False  # enable is the operator's trust decision
+
+
+def test_register_exposes_the_three_tools():
+    seen = []
+
+    class _Reg:
+        def register_tool(self, t):
+            seen.append(t.name)
+
+    portfolio.register(_Reg())
+    assert set(seen) == {"portfolio_boards", "portfolio_dispatch", "portfolio_board_read"}


### PR DESCRIPTION
**ADR 0055 P1** (multi-team orchestration, scale-out) — the first slice of the PM/program layer. One agent orchestrates work across **many team-agents**, each running its own `project_board` for its own repo.

**Pure composition** of three existing subsystems — no new dispatch/registry machinery:
- **fleet** (`graph.fleet.supervisor`) — the team-agent registry (remote members, ADR 0042)
- **delegates** (`plugins.delegates` `A2aAdapter`) — the A2A dispatch primitive
- **project_board** (its `/features` data router) — the structured remote board read

The PM treats each remote fleet member as a **board addressed by name**. Three tools (ships **disabled**; enable on the PM agent):
- `portfolio_boards()` — enumerate the team boards
- `portfolio_dispatch(board, title, spec, …)` — send a feature to a team board over A2A; the team's lead creates+readies it on its **own** board and its loop ships the PR in **its** repo
- `portfolio_board_read(board[, state])` — authenticated structured read of a team board (the stored remote bearer covers both `/a2a` and `/api/plugins/project_board`) — the bounded view a PM reasons over

Builds on **P0 board pinning** (#1105 / projectBoard-plugin v0.19.0): which repo each team board points at.

### Tests
`tests/test_portfolio.py` — 8 cases: tool logic with fleet/A2A/HTTP **stubbed** (no fleet, no network), addressing + bearer assertions, manifest discovery, register wiring.

### Not in this slice (next)
Full multi-instance **live** verification (a PM + ≥1 team-agent), board→{agent,repo} richer addressing, and **P2** (rollup + event/A2A delta streaming). The dispatch/read primitives are all verified to exist; this wires them into agent tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)