### PR TITLE
feat(chat): drag-to-reorder session tabs (DS TabBar onReorder)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.42.0",
+    "@protolabsai/ui": "^0.43.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -149,6 +149,7 @@ export function ChatSurface({
         onSelect={(id) => chatStore.switchSession(id)}
         onClose={(id) => setPendingClose(id)}
         onRename={(id, label) => chatStore.renameSession(id, label)}
+        onReorder={(next) => chatStore.reorderSessions(next.map((t) => t.id))}
         onAdd={() => chatStore.createSession()}
         addLabel="New chat"
       />

--- a/apps/web/src/chat/chat-store.test.ts
+++ b/apps/web/src/chat/chat-store.test.ts
@@ -156,6 +156,29 @@ describe("persist debouncing", () => {
     expect(setItem).toHaveBeenCalledTimes(4);
   });
 
+  it("reorderSessions reorders the tabs, preserves the active session, and flushes immediately", async () => {
+    const { chatStore } = await freshStore();
+    const first = chatStore.getSnapshot().currentSessionId!;
+    const b = chatStore.createSession();
+    const c = chatStore.createSession();
+    chatStore.switchSession(first); // active = first; order is [first, b, c]
+    setItem.mockClear();
+
+    chatStore.reorderSessions([c.id, first, b.id]); // drag c to the front
+    expect(chatStore.getSnapshot().sessions.map((s) => s.id)).toEqual([c.id, first, b.id]);
+    expect(chatStore.getSnapshot().currentSessionId).toBe(first); // active untouched
+    expect(setItem).toHaveBeenCalledTimes(1); // structural → immediate flush
+  });
+
+  it("reorderSessions keeps a session the caller omitted (defensive)", async () => {
+    const { chatStore } = await freshStore();
+    const first = chatStore.getSnapshot().currentSessionId!;
+    const b = chatStore.createSession();
+
+    chatStore.reorderSessions([b.id]); // omit `first`
+    expect(chatStore.getSnapshot().sessions.map((s) => s.id)).toEqual([b.id, first]);
+  });
+
   it("flushes on stream done (setSessionStatus) so the final answer persists", async () => {
     const { chatStore } = await freshStore();
     const sessionId = chatStore.getSnapshot().currentSessionId!;

--- a/apps/web/src/chat/chat-store.ts
+++ b/apps/web/src/chat/chat-store.ts
@@ -285,6 +285,25 @@ export const chatStore = {
     }));
   },
 
+  /** Reorder the session tabs to match `orderedIds` (from the DS TabBar's
+   *  `onReorder`, ui@0.43.0). Pure reordering — active session + status untouched;
+   *  persists immediately so the order survives reload. */
+  reorderSessions(orderedIds: string[]) {
+    setState((current) => {
+      const byId = new Map(current.sessions.map((s) => [s.id, s]));
+      const next = orderedIds
+        .map((id) => byId.get(id))
+        .filter((s): s is ChatSession => s != null);
+      // Defensive: keep any session the caller omitted, in its original order.
+      if (next.length !== current.sessions.length) {
+        for (const s of current.sessions) {
+          if (!orderedIds.includes(s.id)) next.push(s);
+        }
+      }
+      return { ...current, sessions: next };
+    });
+  },
+
   updateMessages(sessionId: string, messages: ChatMessage[]) {
     // Fires per streamed SSE frame (~24 chars) — debounce the localStorage
     // write. The stream-done path flushes via setSessionStatus right after the

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.42.0",
+        "@protolabsai/ui": "^0.43.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.42.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.42.0.tgz",
-      "integrity": "sha512-EAGxlKjauKy9hXH4Y0vbrsW/VePYgu3lv/A8IN4mGt6yyoor1JqorUbxMw/vVqymp+aB8Rs1WyVTO64DiSchAA==",
+      "version": "0.43.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.43.0.tgz",
+      "integrity": "sha512-exa+jR5QJLmG4er0a5aG+6ymAiqTxymyHsj/CaOYCPY7vNRZT3BWzJxSMnI9PAYcb/bsCiaKP5H2Ig7u4+e8IA==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Adopts the DS `TabBar` `onReorder` shipped in **`@protolabsai/ui@0.43.0`** (protoContent #264) into the chat session tabs — the quick win from the dock-DnD direction Josh validated, using what just shipped.

## What
- **`chatStore.reorderSessions(orderedIds)`** — reorders the `sessions` array to match the dragged order; active session + per-session status untouched; persists immediately (structural change → flush), so order survives reload.
- **`ChatSurface`** — passes `onReorder` to the chat `TabBar`. Drag a session tab to reorder; the ✕/rename/＋ still work (the DS handles drag-vs-click and disables drag mid-rename).
- DS bump 0.42.0 → **0.43.0**.

## Forward-compatible
Session order is part of the unified-dock end state ([ADR 0056](./docs/adr/0056-unified-dockable-view-model.md)) — this isn't throwaway; reordering sessions is a real increment toward it.

## Validation
- `tsc` clean · **90 web unit** (2 new chat-store tests: reorder + the defensive omitted-id path) · chat / chat-slot / chat-reconcile / commands / message-actions / file-only-send **e2e green** against the published DS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)