### PR TITLE
feat(chat): mid-turn steering Tier 2 — cancel a running subagent delegation

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -498,6 +498,19 @@ function ChatSessionSlot({
     }
   }
 
+  // Tier 2: abort a running subagent delegation (the Stop on a running `task` tool
+  // card). Cancels just that delegation server-side — the lead continues; the card
+  // settles to done with a "cancelled" result via the normal tool_end stream, so we
+  // don't mutate it here. Distinct from the composer Stop, which kills the whole turn.
+  async function cancelDelegation(delegationId: string) {
+    if (!session) return;
+    try {
+      await api.cancelDelegation(session.id, delegationId);
+    } catch (e) {
+      onError(`Couldn't cancel delegation: ${errMsg(e)}`);
+    }
+  }
+
   // Settle steered messages the agent has folded in: drop them from the queue and
   // place them into the thread just before the turn's current assistant message —
   // they shaped it. Shared by the mid-turn poll and the turn-end reconcile.
@@ -893,7 +906,7 @@ function ChatSessionSlot({
                 </Reasoning>
               ) : null}
               {message.toolCalls && message.toolCalls.length > 0 ? (
-                <ToolCalls calls={message.toolCalls} />
+                <ToolCalls calls={message.toolCalls} onCancelDelegation={cancelDelegation} />
               ) : null}
               {message.content
                 ? message.role === "user"

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -6,6 +6,7 @@ import {
   Globe,
   Network,
   Search,
+  Square,
   Wrench,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
@@ -34,7 +35,15 @@ function iconFor(name: string): LucideIcon {
  * status glyph, duration, nesting) is the DS `ToolCard` family; the body is our
  * per-tool value renderers (`ToolValue` via `tool-renderers.tsx`).
  */
-export function ToolCalls({ calls }: { calls: ToolCall[] }) {
+export function ToolCalls({
+  calls,
+  onCancelDelegation,
+}: {
+  calls: ToolCall[];
+  /** Abort a running top-level `task` delegation by its tool-call id (Tier 2). When
+   *  omitted, no Stop affordance renders (e.g. historical/finished messages). */
+  onCancelDelegation?: (id: string) => void;
+}) {
   // Group children (tools that ran inside a `task` subagent) under their parent.
   const childrenByParent = new Map<string, ToolCall[]>();
   const top: ToolCall[] = [];
@@ -50,7 +59,15 @@ export function ToolCalls({ calls }: { calls: ToolCall[] }) {
   return (
     <ToolCardList className="tool-calls">
       {top.map((call) => (
-        <ToolGroup key={call.id} call={call} childrenByParent={childrenByParent} />
+        // Only TOP-LEVEL groups get the cancel callback — a delegation is always a
+        // top-level `task`; its nested children (the subagent's own tools) aren't
+        // independently cancellable, so recursion drops `onCancelDelegation`.
+        <ToolGroup
+          key={call.id}
+          call={call}
+          childrenByParent={childrenByParent}
+          onCancelDelegation={onCancelDelegation}
+        />
       ))}
     </ToolCardList>
   );
@@ -61,13 +78,16 @@ export function ToolCalls({ calls }: { calls: ToolCall[] }) {
 function ToolGroup({
   call,
   childrenByParent,
+  onCancelDelegation,
 }: {
   call: ToolCall;
   childrenByParent: Map<string, ToolCall[]>;
+  onCancelDelegation?: (id: string) => void;
 }) {
   const kids = childrenByParent.get(call.id);
   const nested = kids?.length
     ? kids.map((kid) => (
+        // Children inherit no cancel callback — they aren't independent delegations.
         <ToolGroup key={kid.id} call={kid} childrenByParent={childrenByParent} />
       ))
     : undefined;
@@ -94,6 +114,26 @@ function ToolGroup({
       </>
     ) : undefined;
 
+  // A running subagent delegation can be aborted (Tier 2): Stop cancels just this
+  // `task`, the lead keeps working. Lives in the DS ToolCard header `actions` slot
+  // (a sibling of the disclosure toggle, so it doesn't expand the card).
+  const actions =
+    onCancelDelegation && call.name === "task" && call.status === "running" ? (
+      <button
+        type="button"
+        className="pl-iconbtn tool-cancel-btn"
+        title="Stop this delegation — the agent keeps working without its result"
+        aria-label="Stop this delegation"
+        onClick={(e) => {
+          e.stopPropagation();
+          onCancelDelegation(call.id);
+        }}
+      >
+        <Square size={11} />
+        <span>Stop</span>
+      </button>
+    ) : undefined;
+
   return (
     <ToolCard
       name={call.name}
@@ -101,6 +141,7 @@ function ToolGroup({
       icon={<Icon size={13} />}
       duration={call.durationMs}
       nested={nested}
+      actions={actions}
     >
       {body}
     </ToolCard>

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -17,6 +17,31 @@
   white-space: normal;
 }
 
+/* Tier 2: Stop a running subagent delegation. Rides the DS header `actions` slot
+   (.pl-toolcard__actions) as a compact, error-toned text button — quiet until
+   hover so a long delegation reads as "running" first, "abortable" on intent. */
+.tool-cancel-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 1px 7px;
+  width: auto;
+  border-radius: 6px;
+  font-size: 0.72rem;
+  font-weight: 500;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  border: 1px solid transparent;
+}
+.tool-cancel-btn:hover {
+  color: var(--error);
+  background: color-mix(in srgb, var(--error) 12%, transparent);
+  border-color: color-mix(in srgb, var(--error) 28%, transparent);
+}
+.tool-cancel-btn svg {
+  flex: none;
+}
+
 /* Generic JSON-blob fallback box, scoped to the DS body slot. */
 .pl-toolcard__body pre {
   margin: 0;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1147,6 +1147,16 @@ export const api = {
       { method: "DELETE" },
     );
   },
+  // Abort ONE running foreground subagent delegation (the Stop on a running `task`
+  // tool card, Tier 2) — cancels just that subagent, NOT the whole turn: the lead
+  // continues with a 'cancelled' result. `delegationId` is the `task` tool-call id.
+  // `cancelled: false` means it already finished / wasn't running (too late).
+  cancelDelegation(sessionId: string, delegationId: string) {
+    return request<{ cancelled: boolean; running: number }>(
+      `/api/chat/sessions/${encodeURIComponent(sessionId)}/delegations/${encodeURIComponent(delegationId)}/cancel`,
+      { method: "POST" },
+    );
+  },
 
   // Reconcile a turn against the server's durable task (A2A GetTask). Used to
   // self-heal a chat message stuck in `streaming` after the stream was

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -464,7 +464,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
     import asyncio
     from typing import Literal
 
-    from langchain_core.tools import tool
+    from langchain_core.tools import InjectedToolCallId, tool
 
     tool_map = {t.name: t for t in all_tools}
     subagent_names = list(SUBAGENT_REGISTRY.keys())
@@ -487,6 +487,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
         emit_skill: bool = False,
         run_in_background: bool = False,
         state: Annotated[Any, InjectedState] = None,
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
     ) -> str:
         """Delegate a single task to a specialized subagent.
 
@@ -567,17 +568,42 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], skills
                 "finishes — continue with other work; do NOT re-spawn it."
             )
 
-        return await _run_subagent(
-            config=config,
-            tool_map=tool_map,
-            available_subagents=available_subagents,
-            description=description,
-            prompt=prompt,
-            subagent_type=subagent_type,
-            emit_skill=emit_skill,
-            truncate=None,
-            skills_index=skills_index,
+        # Foreground delegation: a blocking `await` that would freeze the turn until
+        # the subagent finishes. Wrap it in a cancellable task registered under THIS
+        # tool call's id (the one the console sees on the running `task` card) so the
+        # user can ABORT just this delegation (Tier 2). On a user cancel the lead
+        # CONTINUES with a "cancelled" result; a parent turn-level cancel (the Stop
+        # button → A2A CancelTask) still propagates and kills the whole turn.
+        from graph import delegations
+
+        session_id = _session_id_from(state)
+        deleg = asyncio.ensure_future(
+            _run_subagent(
+                config=config,
+                tool_map=tool_map,
+                available_subagents=available_subagents,
+                description=description,
+                prompt=prompt,
+                subagent_type=subagent_type,
+                emit_skill=emit_skill,
+                truncate=None,
+                skills_index=skills_index,
+            )
         )
+        delegations.register(session_id, tool_call_id, deleg, label=description)
+        try:
+            return await deleg
+        except asyncio.CancelledError:
+            # User-initiated delegation cancel → swallow and let the lead keep going;
+            # a turn-level cancel (flag unset) → re-raise so the whole turn unwinds.
+            if delegations.was_cancelled(session_id, tool_call_id):
+                return (
+                    f"[delegation cancelled by the user before it finished: "
+                    f"{subagent_type} — {description}. Continue without its result.]"
+                )
+            raise
+        finally:
+            delegations.unregister(session_id, tool_call_id)
 
     @tool
     async def task_batch(tasks: list[dict]) -> str:

--- a/graph/delegations.py
+++ b/graph/delegations.py
@@ -1,0 +1,88 @@
+"""Cancellable subagent delegations — a per-session registry of in-flight
+foreground ``task`` delegations so the console can ABORT one without killing the
+whole turn (mid-turn steering, Tier 2).
+
+The lead's ``task`` tool normally ``await``s a subagent to completion
+(graph/agent.py), blocking the turn with no cancel handle. We wrap that await in
+an ``asyncio.Task``, register it here keyed by the **tool-call id** the console
+already sees on the running ``task`` tool card, and expose ``cancel()`` so
+``POST …/delegations/{id}/cancel`` can ``.cancel()`` it. The tool then returns a
+graceful "cancelled" string and the LEAD CONTINUES — unlike an A2A ``CancelTask``,
+which kills the entire turn (that's what the composer Stop button does).
+
+``cancel()`` sets a per-entry ``cancelled`` flag BEFORE cancelling the task so the
+tool can tell a *user-initiated delegation cancel* (swallow ``CancelledError`` →
+graceful return, lead continues) from a *parent turn-level cancel* (flag unset →
+re-raise so the whole turn dies as intended).
+
+A process-wide singleton dict is fine: the graph turn and the API endpoint run in
+the same process + event loop, so register (graph) and cancel (API) never race on
+the dict. host-free (lives under graph/) so both agent.py and operator_api can
+import it without crossing an import layer — mirrors graph/steering.py.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# session_id -> { delegation_id: {"task": <asyncio task/future>, "label": str, "cancelled": bool} }
+_RUNNING: dict[str, dict[str, dict]] = {}
+
+
+def register(session_id: str, delegation_id: str, task: Any, *, label: str = "") -> None:
+    """Track an in-flight foreground delegation so it can be cancelled by id. A
+    blank ``session_id``/``delegation_id`` (e.g. the tool ran without an injected
+    tool-call id) is a no-op — the delegation simply isn't cancellable."""
+    if not session_id or not delegation_id:
+        return
+    _RUNNING.setdefault(session_id, {})[delegation_id] = {
+        "task": task,
+        "label": label,
+        "cancelled": False,
+    }
+
+
+def unregister(session_id: str, delegation_id: str) -> None:
+    """Drop a delegation from the registry once it has settled (call in a finally).
+    Pops the empty session dict so nothing lingers, like ``steering.drain``."""
+    sess = _RUNNING.get(session_id)
+    if not sess:
+        return
+    sess.pop(delegation_id, None)
+    if not sess:
+        _RUNNING.pop(session_id, None)
+
+
+def cancel(session_id: str, delegation_id: str) -> bool:
+    """Abort a running delegation by id. Marks it ``cancelled`` (so the tool returns
+    a graceful 'cancelled' message instead of failing the turn) and cancels its
+    task. Returns True if a live, not-already-cancelled delegation was found; False
+    if absent, already finished, or already cancelling (too late / nothing to do)."""
+    entry = (_RUNNING.get(session_id) or {}).get(delegation_id)
+    if not entry or entry["cancelled"]:
+        return False
+    task = entry["task"]
+    if task.done():
+        return False
+    entry["cancelled"] = True
+    task.cancel()
+    return True
+
+
+def was_cancelled(session_id: str, delegation_id: str) -> bool:
+    """True if this delegation was explicitly cancelled via ``cancel()`` (vs a
+    parent turn-level ``CancelledError`` that merely passed through). The tool reads
+    this to decide swallow-and-continue vs re-raise."""
+    entry = (_RUNNING.get(session_id) or {}).get(delegation_id)
+    return bool(entry and entry["cancelled"])
+
+
+def running_items(session_id: str) -> list[dict]:
+    """The in-flight delegations for a session — ``[{"id", "label"}]`` — the
+    authoritative list the console's Cancel affordance can act on / verify."""
+    return [{"id": did, "label": e["label"]} for did, e in (_RUNNING.get(session_id) or {}).items()]
+
+
+def running(session_id: str) -> int:
+    """How many foreground delegations are in flight for ``session_id``."""
+    return len(_RUNNING.get(session_id) or {})

--- a/operator_api/chat_routes.py
+++ b/operator_api/chat_routes.py
@@ -118,6 +118,28 @@ def register_chat_routes(app, ui: str) -> None:
         removed = steering.dequeue(session_id, msg_id)
         return {"removed": removed, "pending": steering.pending(session_id)}
 
+    @app.get("/api/chat/sessions/{session_id}/delegations")
+    async def _api_delegations(session_id: str):
+        """In-flight foreground subagent delegations for ``session_id`` —
+        ``[{"id", "label"}]``. ``id`` is the running ``task`` tool-call id; the
+        console surfaces a Cancel affordance on each running ``task`` card and this
+        is the authoritative list that affordance acts on."""
+        from graph import delegations
+
+        return {"running": delegations.running_items(session_id)}
+
+    @app.post("/api/chat/sessions/{session_id}/delegations/{delegation_id}/cancel")
+    async def _api_delegation_cancel(session_id: str, delegation_id: str):
+        """Abort ONE running foreground delegation (the Stop on a running ``task``
+        card) — cancels just that subagent, NOT the whole turn: the lead continues
+        with a 'cancelled' result. Contrast the composer Stop, which A2A-CancelTasks
+        the entire turn. ``cancelled: false`` means the delegation already finished,
+        was already cancelling, or was never running (too late / nothing to do)."""
+        from graph import delegations
+
+        cancelled = delegations.cancel(session_id, delegation_id)
+        return {"cancelled": cancelled, "running": delegations.running(session_id)}
+
     # --- Goal mode API ------------------------------------------------------
     # Programmatic status/clear for a session's goal (setting is done via the
     # `/goal ...` control message through chat/A2A). Returns 404-style payloads

--- a/tests/test_chat_routes.py
+++ b/tests/test_chat_routes.py
@@ -138,6 +138,40 @@ def test_steer_enqueue_then_cancel_roundtrip(monkeypatch):
     steering._QUEUES.clear()
 
 
+def test_delegation_list_and_cancel_roundtrip(monkeypatch):
+    # HTTP lifecycle of the Tier 2 delegation routes: GET lists in-flight `task`
+    # delegations; POST cancels one (the route hits graph.delegations directly).
+    from graph import delegations
+
+    class _Fake:
+        def __init__(self):
+            self.cancelled = False
+
+        def done(self):
+            return self.cancelled
+
+        def cancel(self):
+            self.cancelled = True
+
+    delegations._RUNNING.clear()
+    c = _client(monkeypatch)
+    assert c.get("/api/chat/sessions/s1/delegations").json() == {"running": []}
+
+    f = _Fake()
+    delegations.register("s1", "d1", f, label="research X")
+    assert c.get("/api/chat/sessions/s1/delegations").json() == {
+        "running": [{"id": "d1", "label": "research X"}]
+    }
+    # Cancel the live delegation → cancelled; still counted (the tool's finally
+    # unregisters once the task actually unwinds, not the route).
+    assert c.post("/api/chat/sessions/s1/delegations/d1/cancel").json() == {"cancelled": True, "running": 1}
+    assert f.cancelled is True
+    # Cancel again (already cancelling) and an unknown id → both too-late/false.
+    assert c.post("/api/chat/sessions/s1/delegations/d1/cancel").json() == {"cancelled": False, "running": 1}
+    assert c.post("/api/chat/sessions/s1/delegations/nope/cancel").json() == {"cancelled": False, "running": 1}
+    delegations._RUNNING.clear()
+
+
 def test_openai_models_and_completion(monkeypatch):
     c = _client(monkeypatch)
     models = c.get("/v1/models").json()

--- a/tests/test_delegations.py
+++ b/tests/test_delegations.py
@@ -1,0 +1,103 @@
+"""Cancellable subagent delegations (Tier 2) — graph/delegations.py: a per-session
+registry of in-flight foreground `task` delegations so the console can abort ONE
+delegation without killing the whole turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from graph import delegations
+
+
+@pytest.fixture(autouse=True)
+def _clear():
+    delegations._RUNNING.clear()
+    yield
+    delegations._RUNNING.clear()
+
+
+class _FakeTask:
+    """Minimal asyncio.Task stand-in for registry tests that don't need a loop."""
+
+    def __init__(self, done: bool = False):
+        self._done = done
+        self.cancel_called = False
+
+    def done(self) -> bool:
+        return self._done
+
+    def cancel(self) -> None:
+        self.cancel_called = True
+
+
+# ── the registry ───────────────────────────────────────────────────────────────
+
+
+def test_register_lists_and_counts_in_order():
+    delegations.register("s1", "d1", _FakeTask(), label="research X")
+    delegations.register("s1", "d2", _FakeTask(), label="research Y")
+    assert delegations.running("s1") == 2
+    assert delegations.running_items("s1") == [
+        {"id": "d1", "label": "research X"},
+        {"id": "d2", "label": "research Y"},
+    ]
+    assert delegations.running_items("other") == []  # per-session
+
+
+def test_register_ignores_blank_session_or_id():
+    delegations.register("", "d1", _FakeTask())
+    delegations.register("s1", "", _FakeTask())
+    assert delegations.running("s1") == 0
+
+
+def test_unregister_drops_entry_and_empty_session():
+    delegations.register("s1", "d1", _FakeTask())
+    delegations.unregister("s1", "d1")
+    assert "s1" not in delegations._RUNNING  # no empty session dict lingers
+    delegations.unregister("s1", "gone")  # safe no-op on a missing entry/session
+
+
+# ── cancel semantics ───────────────────────────────────────────────────────────
+
+
+def test_cancel_marks_flag_and_cancels_the_task():
+    f = _FakeTask()
+    delegations.register("s1", "d1", f, label="long one")
+    assert delegations.cancel("s1", "d1") is True
+    assert f.cancel_called is True
+    assert delegations.was_cancelled("s1", "d1") is True
+    # second cancel is a no-op — already cancelling (too late to "find" it live)
+    assert delegations.cancel("s1", "d1") is False
+
+
+def test_cancel_false_when_absent_or_already_done():
+    assert delegations.cancel("s1", "missing") is False  # never registered
+    done = _FakeTask(done=True)
+    delegations.register("s1", "d1", done)
+    assert delegations.cancel("s1", "d1") is False  # already finished → nothing to abort
+    assert done.cancel_called is False  # we don't cancel a done task
+    assert delegations.was_cancelled("s1", "d1") is False
+
+
+def test_was_cancelled_false_for_unflagged_or_absent():
+    delegations.register("s1", "d1", _FakeTask())
+    assert delegations.was_cancelled("s1", "d1") is False  # registered but not cancelled
+    assert delegations.was_cancelled("s1", "nope") is False
+    assert delegations.was_cancelled("other", "d1") is False
+
+
+# ── the real cancel mechanism the tool relies on ───────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_cancel_aborts_a_real_asyncio_task():
+    t = asyncio.ensure_future(asyncio.sleep(3600))
+    await asyncio.sleep(0)  # let it start running
+    delegations.register("s1", "d1", t, label="real")
+    assert delegations.cancel("s1", "d1") is True
+    with pytest.raises(asyncio.CancelledError):
+        await t
+    assert t.cancelled()

--- a/tests/test_task_batch.py
+++ b/tests/test_task_batch.py
@@ -43,8 +43,18 @@ def test_build_returns_task_and_batch(monkeypatch):
 async def test_single_task_is_unbounded(monkeypatch):
     rec = []
     tools = _build(monkeypatch, recorder=rec)
-    out = await tools["task"].ainvoke({"description": "d", "prompt": "p", "subagent_type": "researcher"})
-    assert out == "OUT:d"
+    # `task` carries an InjectedToolCallId (the cancellable-delegation key, Tier 2),
+    # so it must be invoked with a full model ToolCall — exactly how the graph's
+    # ToolNode calls it in production. Result comes back as a ToolMessage.
+    out = await tools["task"].ainvoke(
+        {
+            "name": "task",
+            "args": {"description": "d", "prompt": "p", "subagent_type": "researcher"},
+            "id": "tc-test",
+            "type": "tool_call",
+        }
+    )
+    assert out.content == "OUT:d"
     # single task must not truncate
     assert rec[0]["truncate"] is None
 


### PR DESCRIPTION
## What

Follow-up to **#1104** (the steer ✕-cancel dequeue). The lead can be steered mid-turn, but a foreground `task` delegation runs as a blocking `await subagent.ainvoke(...)` with **no cancel handle** — the turn is frozen until it returns, and the only escape was the composer Stop (A2A `CancelTask`), which kills the **whole turn**.

**Tier 2** lets the user abort just *that one delegation* — like Esc in Claude Code / Gemini-CLI. The lead keeps working, without the cancelled subagent's result.

## How

- **`graph/delegations.py`** — per-session registry of in-flight foreground delegations, keyed by the `task` **tool-call id the console already sees** on the running card. `cancel()` sets a `cancelled` flag *before* `.cancel()`ing the task so the tool can distinguish a **user delegation-cancel** (swallow `CancelledError` → graceful return, lead continues) from a **parent turn-level cancel** (flag unset → re-raise so the whole turn unwinds). host-free under `graph/`, mirrors `graph/steering.py`.
- **`graph/agent.py`** — the `task` foreground path wraps `_run_subagent` in an `asyncio` task, registers it (`InjectedToolCallId` → the card id, **hidden from the model schema**), awaits with cancel-aware handling + `finally`-unregister.
- **`operator_api/chat_routes.py`** — `GET …/delegations` (list) + `POST …/delegations/{id}/cancel` → `{cancelled, running}`.
- **web** — `api.cancelDelegation`; a **Stop** button on a running top-level `task` card (DS `ToolCard` `actions` slot) cancels just that delegation; the card settles to *done* with the "cancelled" result via the normal `tool_end` stream.

## Out of scope (deferred)

- The auto-background inline path (`BACKGROUND_AUTO_S>0`, off by default) keeps its own timeout-cancel — not wired to user-cancel.
- **Tier 3** (steering *into* a running subagent) remains unbuilt — no industry precedent.

## Tests / gates (all green locally)

| Gate | Result |
|---|---|
| `ruff check` | pass |
| `lint-imports` | 3 kept, 0 broken |
| `pytest` (delegations + chat_routes + steering + subagent subset) | pass |
| graph-build smoke | injected `tool_call_id`/`state` stay **out** of the model-facing tool schema |
| `tsc --noEmit` | clean |
| web unit (vitest) | 88 passed |
| css-comment prebuild gate | OK |

New tests: registry semantics incl. a **real `asyncio.Task` cancel** (proves the abort mechanism) + HTTP route lifecycle (GET list, POST cancel → cancelled / too-late / unknown).

**Verification note:** I live-smoked the routes against a running server (`GET …/delegations` → `{running:[]}`, `POST …/cancel` unknown → `{cancelled:false}`, steer routes no-regression). The full *cancel-a-live-delegation* loop needs a real model (a subagent run), which the dummy-key sandbox can't drive — that path is covered by the registry's real-task cancel test + the route test.

Built in an isolated git worktree off `main`; protoContent#261 lineage.

🤖 Generated with [Claude Code](https://claude.com/claude-code)