### PR TITLE
feat(portfolio): portfolio_rollup — bounded cross-board view (ADR 0055 P2)

### DIFF
--- a/plugins/portfolio/__init__.py
+++ b/plugins/portfolio/__init__.py
@@ -43,6 +43,56 @@ def _remote_by_name(name: str) -> dict | None:
     return None
 
 
+class _BoardUnavailable(Exception):
+    """A team board couldn't be read (policy block, 404, HTTP error, network)."""
+
+
+async def _fetch_board_features(rec: dict, state: str = "") -> list:
+    """GET a remote team board's features (structured) — the shared read used by both
+    the raw read and the rollup. Raises ``_BoardUnavailable`` so callers format their
+    own message. The stored remote bearer authenticates both ``/a2a`` and the board
+    API; the remote was egress-vetted at add_remote, re-checked here for parity with
+    the A2A dispatch path."""
+    url = rec["url"].rstrip("/") + "/api/plugins/project_board/features"
+    from security import policy
+
+    blocked = policy.check_url(url)
+    if blocked:
+        raise _BoardUnavailable(blocked)
+
+    import httpx
+
+    headers = {"Authorization": f"Bearer {rec['token']}"} if rec.get("token") else {}
+    params = {"state": state} if state else None
+    try:
+        async with httpx.AsyncClient(timeout=30) as client:
+            r = await client.get(url, headers=headers, params=params)
+    except Exception as exc:  # noqa: BLE001
+        raise _BoardUnavailable(str(exc)) from exc
+    if r.status_code == 404:
+        raise _BoardUnavailable("no project board exposed (project_board not enabled there)")
+    if r.status_code >= 400:
+        raise _BoardUnavailable(f"HTTP {r.status_code} {r.text[:200]}")
+    return r.json().get("features", [])
+
+
+def _rollup_one(name: str, features: list) -> dict:
+    """Project a board's features into a BOUNDED rollup — lane counts + only the
+    blocked / foundation (critical-path) items, never the full feature list. This is
+    what keeps a PM's context small when reasoning over many boards."""
+    counts: dict[str, int] = {}
+    blocked: list[dict] = []
+    critical: list[dict] = []
+    for f in features:
+        st = f.get("board_state", "backlog")
+        counts[st] = counts.get(st, 0) + 1
+        if f.get("blocked") or f.get("dag_blocked"):
+            blocked.append({"id": f.get("id"), "title": f.get("title", "")})
+        if f.get("foundation") and st != "done":
+            critical.append({"id": f.get("id"), "title": f.get("title", ""), "state": st})
+    return {"board": name, "total": len(features), "counts": counts, "blocked": blocked, "critical_path": critical}
+
+
 def _dispatch_instruction(title: str, spec: str, acceptance_criteria: str, files_to_modify: str) -> str:
     lines = [
         "You manage a project board (the project_board plugin). Create a new feature on it "
@@ -122,29 +172,44 @@ def _tools() -> list:
         rec = _remote_by_name(board)
         if rec is None:
             return f"Error: no team board named {board!r}. Call portfolio_boards to list them."
-
-        url = rec["url"].rstrip("/") + "/api/plugins/project_board/features"
-        # The remote was egress-vetted at add_remote; re-check the read URL too (parity
-        # with the A2A dispatch path, which guards every call).
-        from security import policy
-
-        blocked = policy.check_url(url)
-        if blocked:
-            return f"Error reading {board!r} board: {blocked}"
-
-        import httpx
-
-        headers = {"Authorization": f"Bearer {rec['token']}"} if rec.get("token") else {}
-        params = {"state": state} if state else None
         try:
-            async with httpx.AsyncClient(timeout=30) as client:
-                r = await client.get(url, headers=headers, params=params)
-        except Exception as exc:  # noqa: BLE001
+            feats = await _fetch_board_features(rec, state)
+        except _BoardUnavailable as exc:
             return f"Error reading {board!r} board: {exc}"
-        if r.status_code == 404:
-            return f"{board!r} doesn't expose a project board (project_board not enabled there)."
-        if r.status_code >= 400:
-            return f"Error reading {board!r} board: HTTP {r.status_code} {r.text[:200]}"
-        return json.dumps(r.json().get("features", []), indent=2)
+        return json.dumps(feats, indent=2)
 
-    return [portfolio_boards, portfolio_dispatch, portfolio_board_read]
+    @tool
+    async def portfolio_rollup(boards: str = "") -> str:
+        """A BOUNDED portfolio view across team boards: per-board lane counts + only the
+        blocked / critical-path (foundation) items — NOT every feature — so you can
+        reason over MANY boards at once without pulling each one raw. Optional comma-
+        separated ``boards`` filters to specific team-agent names (default = all). An
+        unreachable board is reported with an ``error`` instead of failing the rollup."""
+        from graph.fleet import supervisor
+
+        wanted = {b.strip() for b in boards.split(",") if b.strip()} if boards else None
+        recs = [
+            r
+            for r in supervisor.list_remotes()
+            if wanted is None or r.get("name") in wanted or r.get("id") in wanted
+        ]
+        if not recs:
+            return (
+                "No matching team boards. Call portfolio_boards to list them."
+                if wanted
+                else "No team boards yet — register a team-agent as a fleet member first (see portfolio_boards)."
+            )
+
+        async def _one(rec: dict) -> dict:
+            try:
+                feats = await _fetch_board_features(rec)
+            except _BoardUnavailable as exc:
+                return {"board": rec.get("name"), "error": str(exc)}
+            return _rollup_one(rec.get("name"), feats)
+
+        import asyncio
+
+        rollups = await asyncio.gather(*[_one(r) for r in recs])
+        return json.dumps(rollups, indent=2)
+
+    return [portfolio_boards, portfolio_dispatch, portfolio_board_read, portfolio_rollup]

--- a/plugins/portfolio/protoagent.plugin.yaml
+++ b/plugins/portfolio/protoagent.plugin.yaml
@@ -1,6 +1,6 @@
 id: portfolio
 name: Portfolio (multi-team orchestration)
-version: 0.1.0
+version: 0.2.0
 description: >-
   The PM / program orchestration layer (ADR 0055 P1). One agent orchestrates work
   across MANY team-agents, each running its own project board for its own repo
@@ -10,7 +10,9 @@ description: >-
   addressed by name: list them, dispatch a feature to one, read one back — over A2A.
 
   Tools: portfolio_boards (enumerate), portfolio_dispatch (send a feature to a
-  team board over A2A), portfolio_board_read (structured read of a team board).
+  team board over A2A), portfolio_board_read (structured read of one team board),
+  portfolio_rollup (bounded cross-board view — per-board lane counts + only the
+  blocked/critical-path items, so a PM reasons over MANY boards without raw reads).
   Ships DISABLED; enable with `plugins: { enabled: [portfolio] }`. Pairs with the
   `delegates` plugin and remote fleet members (ADR 0042). See ADR 0055.
 

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -167,7 +167,7 @@ def test_manifest_discovers_and_ships_disabled():
     assert m.version and m.enabled is False  # enable is the operator's trust decision
 
 
-def test_register_exposes_the_three_tools():
+def test_register_exposes_the_tools():
     seen = []
 
     class _Reg:
@@ -175,4 +175,102 @@ def test_register_exposes_the_three_tools():
             seen.append(t.name)
 
     portfolio.register(_Reg())
-    assert set(seen) == {"portfolio_boards", "portfolio_dispatch", "portfolio_board_read"}
+    assert set(seen) == {"portfolio_boards", "portfolio_dispatch", "portfolio_board_read", "portfolio_rollup"}
+
+
+# ── portfolio_rollup (P2) ────────────────────────────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_rollup_projects_bounded_counts_and_only_blocked_critical(monkeypatch):
+    from graph.fleet import supervisor
+    from plugins import portfolio as pf
+
+    monkeypatch.setattr(
+        supervisor,
+        "list_remotes",
+        lambda: [
+            {"id": "r1", "name": "team-web", "url": "https://web.example", "token": "t"},
+            {"id": "r2", "name": "team-api", "url": "https://api.example", "token": "t"},
+        ],
+    )
+
+    boards = {
+        "team-web": [
+            {"id": "w1", "title": "ready feat", "board_state": "ready"},
+            {"id": "w2", "title": "blocked feat", "board_state": "in_progress", "blocked": True},
+            {"id": "w3", "title": "foundation", "board_state": "in_progress", "foundation": True},
+            {"id": "w4", "title": "done foundation", "board_state": "done", "foundation": True},
+        ],
+        "team-api": [{"id": "a1", "title": "x", "board_state": "backlog"}],
+    }
+
+    async def fake_fetch(rec, state=""):
+        return boards[rec["name"]]
+
+    monkeypatch.setattr(pf, "_fetch_board_features", fake_fetch)
+
+    out = {r["board"]: r for r in json.loads(await _tool("portfolio_rollup").ainvoke({}))}
+    web = out["team-web"]
+    assert web["total"] == 4
+    assert web["counts"] == {"ready": 1, "in_progress": 2, "done": 1}
+    assert web["blocked"] == [{"id": "w2", "title": "blocked feat"}]  # only the blocked one
+    assert web["critical_path"] == [{"id": "w3", "title": "foundation", "state": "in_progress"}]  # done foundation excluded
+    # the rollup is BOUNDED — it carries counts + blocked/critical only, never the full feature list
+    assert "spec" not in json.dumps(web) and "files_to_modify" not in json.dumps(web)
+    assert out["team-api"]["counts"] == {"backlog": 1}
+
+
+@pytest.mark.asyncio
+async def test_rollup_filters_by_boards_arg(monkeypatch):
+    from graph.fleet import supervisor
+    from plugins import portfolio as pf
+
+    monkeypatch.setattr(
+        supervisor,
+        "list_remotes",
+        lambda: [
+            {"id": "r1", "name": "team-web", "url": "https://web.example", "token": "t"},
+            {"id": "r2", "name": "team-api", "url": "https://api.example", "token": "t"},
+        ],
+    )
+
+    async def fake_fetch(rec, state=""):
+        return []
+
+    monkeypatch.setattr(pf, "_fetch_board_features", fake_fetch)
+    out = json.loads(await _tool("portfolio_rollup").ainvoke({"boards": "team-api"}))
+    assert [r["board"] for r in out] == ["team-api"]
+
+
+@pytest.mark.asyncio
+async def test_rollup_tolerates_an_unreachable_board(monkeypatch):
+    from graph.fleet import supervisor
+    from plugins import portfolio as pf
+
+    monkeypatch.setattr(
+        supervisor,
+        "list_remotes",
+        lambda: [
+            {"id": "r1", "name": "up", "url": "https://up.example", "token": "t"},
+            {"id": "r2", "name": "down", "url": "https://down.example", "token": "t"},
+        ],
+    )
+
+    async def fake_fetch(rec, state=""):
+        if rec["name"] == "down":
+            raise pf._BoardUnavailable("no project board exposed (project_board not enabled there)")
+        return [{"id": "x", "board_state": "ready"}]
+
+    monkeypatch.setattr(pf, "_fetch_board_features", fake_fetch)
+    out = {r["board"]: r for r in json.loads(await _tool("portfolio_rollup").ainvoke({}))}
+    assert out["up"]["counts"] == {"ready": 1}
+    assert "error" in out["down"] and "no project board" in out["down"]["error"]  # one bad board doesn't sink the rollup
+
+
+@pytest.mark.asyncio
+async def test_rollup_no_boards_message(monkeypatch):
+    from graph.fleet import supervisor
+
+    monkeypatch.setattr(supervisor, "list_remotes", lambda: [])
+    assert "No team boards yet" in await _tool("portfolio_rollup").ainvoke({})


### PR DESCRIPTION
**ADR 0055 P2, slice 1** — the context layer that makes multi-team orchestration scale.

A PM today reads one board at a time (`portfolio_board_read`). **`portfolio_rollup`** gives a **bounded** view across MANY boards at once: per-board lane counts + only the **blocked / critical-path (foundation)** items — never the full feature list — so the PM's context stays small while it reasons over a whole portfolio.

- `portfolio_rollup(boards="")` fans out across team boards concurrently (`asyncio.gather`) → `{board, total, counts, blocked[], critical_path[]}` per board. Optional comma-separated `boards` filter. An unreachable board returns `{board, error}` instead of sinking the whole rollup.
- Extracted the remote board read into a shared `_fetch_board_features` helper (raising `_BoardUnavailable`), reused by both `portfolio_board_read` and the rollup — the **same read path live-verified in P1** (#1107). Plugin → **v0.2.0**.

### Tests
12 (the original 8 + rollup: counts/blocked/critical projection, **bounded-output assertion** — no `spec`/`files_to_modify` leak into the rollup, board filter, per-board error tolerance, empty-fleet message).

### Next (P2 slice 2)
Push **deltas** — team-agents emit state changes (PR merged / blocked / coder failed) to the PM over the event bus + A2A, so the PM learns of changes without polling. Built on the same fleet/A2A spine.

🤖 Generated with [Claude Code](https://claude.com/claude-code)