### PR TITLE
feat(portfolio): board deltas — portfolio_diff + portfolio_watch (ADR 0055 P2 slice 2)

### DIFF
--- a/docs/adr/0055-multi-team-orchestration-federated-boards.md
+++ b/docs/adr/0055-multi-team-orchestration-federated-boards.md
@@ -112,10 +112,35 @@ registry:
 
 ## Phasing
 
-- **P0** — deterministic per-instance board pinning in `project_board` (explicit
-  beads location; honor `operator.project_dir`/instance; `db_path` wires through;
-  singleton reload). *Also fixes the dev-env isolation gap.*
-- **P1** — PM portfolio capability: address team-agents as boards over A2A
-  (discover, dispatch a feature, read a board's state) on the ADR 0042 spine.
-- **P2** — rollup + event/A2A delta streaming (the bounded-context layer).
+- **P0** ✅ *(shipped)* — deterministic per-instance board pinning in `project_board`
+  (explicit beads location; `db_path` wires through; per-(db,repo) store; `br` runs in
+  the configured repo). *Also fixed the dev-env isolation gap.* projectBoard-plugin
+  v0.19.0 (#46) + pm-stack pin (#6) + the host fix protoAgent #1105 (scoped instances
+  now resolve installed-plugin config from the unscoped plugins dir).
+- **P1** ✅ *(shipped + live-verified)* — PM portfolio capability: the `portfolio`
+  plugin (#1107) — `portfolio_boards` / `portfolio_dispatch` (A2A) / `portfolio_board_read`.
+  Pure composition of fleet × delegates × project_board. Live-verified end-to-end
+  against a real team-agent over A2A (a dispatched feature was created on the team's
+  own isolated board and read back structured).
+- **P2** — rollup + delta streaming (the bounded-context layer).
+  - *Slice 1* ✅ *(shipped)* — `portfolio_rollup` (#1110): bounded cross-board view —
+    per-board lane counts + only the blocked/critical-path items, never raw boards.
+  - *Slice 2* ✅ *(shipped)* — board **deltas** via `portfolio_diff` + `portfolio_watch`:
+    a PM-side **pull-diff**. The PM snapshots each board (feature→state/blocked) under
+    its instance data root and reports only the transitions (merged / newly-blocked /
+    unblocked / new); `portfolio_watch` seeds a baseline and hands back a `schedule_task`
+    cron so the diff runs on a schedule and arrives as a turn — *the system polls for the
+    PM, not the PM's reasoning loop*.
+
+    **Why pull-diff, not push** (decided after a substrate scout): A2A push notifications
+    (`pushNotificationConfig`) are **task-scoped** — they express "my dispatched task
+    finished," not "this board changed," which is the wrong granularity. The event bus
+    (ADR 0039) is **in-process per instance** with no cross-instance bridge. And remote
+    registration is **one-directional** (PM→team via `remotes.json`) — a team-agent has
+    no back-reference to its PM, so a push would need new credential distribution + a
+    team-side emit hook in the standalone `project_board` repo. Pull-diff reuses the
+    slice-1 read path verbatim, auth already flows PM→team, and nothing changes on the
+    team side. *Deferred push upgrade (P2.5+):* a team-side bus→`/api/inbox` bridge once a
+    team↔PM handshake exists — the inbox (`POST /api/inbox`, `priority:"now"` fires a turn)
+    is the right inbound sink, but it's a larger lift for marginal latency gain.
 - **P3** — cross-repo dependency graph + program-level sequencing.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -60,6 +60,7 @@ Run the agent as a service, give it a console, isolate instances, fence it in, a
 | [Operator console (React/Tauri)](/guides/react-tauri-ui) | You want the multi-chat React console and to package it for desktop |
 | [Run multiple instances](/guides/multi-instance) | You want several scoped agents (data isolation) on one host |
 | [Run a fleet (workspaces, archetypes, supervisor)](/guides/fleet) | You want many named agents on one host — created from archetypes, run in the background, sharing a skills commons |
+| [Portfolio (one PM, many team boards)](/guides/portfolio) | You want one PM agent to dispatch work to, and track, several team-agents' project boards across repos — over A2A |
 | [Sandboxing & egress](/guides/sandboxing) | You want to fence the filesystem + outbound network |
 | [Wire Langfuse + Prometheus](/guides/observability) | You need traces and metrics in production |
 

--- a/docs/guides/portfolio.md
+++ b/docs/guides/portfolio.md
@@ -1,0 +1,73 @@
+# Portfolio — one PM across many team boards
+
+Run **one PM (program-manager) agent** that orchestrates work across **many
+team-agents**, each running its own [project board](/guides/coding-agents) for its
+own repo. The PM dispatches features to a team's board, reads a team's state, sees a
+bounded cross-board rollup, and watches for changes — all over A2A, on the
+[fleet](/guides/fleet) spine. This is the **scale-out** model: multiplicity lives in
+the fleet, not inside one board (see [ADR 0055](../adr/0055-multi-team-orchestration-federated-boards.md)).
+
+The `portfolio` plugin is **pure composition** — it adds no new dispatch or registry
+machinery, just tools over three things you already have: the fleet (the team-agent
+registry), [delegates](/guides/delegates) (the A2A dispatch primitive), and
+`project_board` (the board read).
+
+## Setup
+
+1. **Each team is its own agent.** Stand up a protoAgent instance per repo/team with
+   the `project_board` plugin enabled, pinned to that repo (its `.beads`). On its own
+   host it's just `plugins: { enabled: [project_board, delegates] }`; for an isolated
+   co-located instance, scope it (`PROTOAGENT_INSTANCE`, see
+   [multi-instance](/guides/multi-instance)) and set `project_board.db_path`/`repo`.
+2. **Enable `portfolio` on the PM:** `plugins: { enabled: [portfolio] }` (it ships
+   disabled — enabling is the trust decision). The PM also needs `delegates` for the
+   A2A dispatch path.
+3. **Register each team-agent as a remote fleet member** — Discover → *Add to this
+   fleet* in the console, or `POST /api/fleet/remotes {name, url, token}`. The board is
+   addressed by that **name**. The stored bearer authenticates both the team's `/a2a`
+   (dispatch) and its `/api/plugins/project_board` (read) — one credential, the right
+   direction (PM→team).
+
+> On loopback with no `auth.token` set, a team-agent runs in open mode (the
+> default-deny A2A auth is a no-op) — handy for local testing. Across a LAN/tailnet,
+> give each team-agent an `A2A_AUTH_TOKEN` and register it with that token.
+
+## Tools
+
+| Tool | What it does |
+|---|---|
+| `portfolio_boards()` | List the team boards (remote members) — name, url, reachability |
+| `portfolio_dispatch(board, title, spec, …)` | Send a feature to a team board over A2A. The team's lead creates + readies it on **its own** board; the team's loop ships the PR in **its** repo |
+| `portfolio_board_read(board[, state])` | Structured read of one team board |
+| `portfolio_rollup([boards])` | **Bounded** cross-board view — per-board lane counts + only the blocked / critical-path items, never the full feature list. Reason over many boards without raw reads |
+| `portfolio_diff([boards])` | What **changed** since the last check — features merged / newly-blocked / unblocked / new — then advances the baseline |
+| `portfolio_watch([interval_min, boards])` | Records a baseline, then hands you the `schedule_task` call to run `portfolio_diff` on a schedule |
+
+## Deltas without polling
+
+`portfolio_diff` is a **pull-diff**: the PM keeps a per-board snapshot (feature →
+state/blocked) under its instance data root and reports only the transitions. The
+first call records a baseline and reports nothing; every call after surfaces just the
+changes.
+
+To stay current without burning the PM's reasoning loop on polling, schedule it:
+
+```
+portfolio_watch(interval_min=15)
+# → records a baseline + returns:
+#   schedule_task(prompt="Run portfolio_diff and report any board changes; if none, do nothing.",
+#                 when="*/15 * * * *")
+```
+
+Each scheduled fire arrives as a turn carrying only the deltas — *the system polls for
+the PM*. (Why pull-diff and not push: A2A push notifications are task-scoped, the event
+bus is in-process, and a team-agent doesn't know its PM — so a PM-side snapshot+diff is
+the thin correct shape. See [ADR 0055 P2](../adr/0055-multi-team-orchestration-federated-boards.md#phasing).)
+
+## Notes
+
+- A board id **is** the team-agent's fleet name — no separate registry.
+- An unreachable board never sinks a rollup/diff: it's reported with an `error` and the
+  others still return.
+- Board isolation (ADR 0055 P0) means each team's board writes to **its own** repo's
+  `.beads` — the PM only ever touches a team's board over A2A.

--- a/plugins/portfolio/__init__.py
+++ b/plugins/portfolio/__init__.py
@@ -10,11 +10,20 @@ subsystems — no new dispatch or registry machinery:
 
 The PM treats each remote fleet member as a *board* addressed by its name: list
 them (`portfolio_boards`), dispatch a feature to one over A2A (`portfolio_dispatch`),
-and read one back structured (`portfolio_board_read`). See ADR 0055.
+read one back structured (`portfolio_board_read`), see a bounded cross-board rollup
+(`portfolio_rollup`), and watch for changes without polling (`portfolio_watch` +
+`portfolio_diff`). See ADR 0055.
+
+P2 deltas are PULL-DIFF, not push: the PM snapshots each board (state per feature)
+and reports what changed since the last check. A2A push notifications are task-scoped
+(wrong granularity), the event bus is in-process, and a team-agent doesn't know its
+PM — so a PM-side snapshot+diff, run on a schedule, is the thin correct shape (ADR
+0055 P2; the optional inbox-push upgrade is deferred).
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 
 from langchain_core.tools import tool
@@ -91,6 +100,110 @@ def _rollup_one(name: str, features: list) -> dict:
         if f.get("foundation") and st != "done":
             critical.append({"id": f.get("id"), "title": f.get("title", ""), "state": st})
     return {"board": name, "total": len(features), "counts": counts, "blocked": blocked, "critical_path": critical}
+
+
+def _parse_boards(boards: str) -> set | None:
+    """Comma-separated board filter → a set of names, or None for all."""
+    return {b.strip() for b in boards.split(",") if b.strip()} if boards else None
+
+
+# ── P2 deltas: snapshot + diff (pull-diff, PM-side) ──────────────────────────────
+
+
+def _snapshot_path():
+    """Per-instance baseline for delta detection — scoped under the PM's data root so
+    co-located instances don't collide (ADR 0004), mirroring remotes.json."""
+    from infra.paths import data_home, scope_leaf
+
+    return scope_leaf(data_home() / "portfolio_snapshot.json")
+
+
+def _load_snapshot() -> dict:
+    p = _snapshot_path()
+    try:
+        return json.loads(p.read_text()) if p.exists() else {}
+    except Exception:  # noqa: BLE001 — a corrupt snapshot just re-baselines, never breaks the tool
+        return {}
+
+
+def _save_snapshot(snap: dict) -> None:
+    p = _snapshot_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    p.write_text(json.dumps(snap))
+
+
+def _index_features(features: list) -> dict:
+    """feature_id → the fields a diff cares about (state + blocked + title)."""
+    return {
+        f["id"]: {
+            "state": f.get("board_state"),
+            "blocked": bool(f.get("blocked") or f.get("dag_blocked")),
+            "title": f.get("title", ""),
+        }
+        for f in features
+        if f.get("id")
+    }
+
+
+def _diff_boards(prev: dict, curr: dict) -> dict:
+    """Compare two feature-index snapshots → only the meaningful transitions: a feature
+    reaching ``done`` (PR merged), newly blocked, unblocked, or newly appearing."""
+    merged, newly_blocked, unblocked, new = [], [], [], []
+    for fid, c in curr.items():
+        p = prev.get(fid)
+        if p is None:
+            new.append({"id": fid, "title": c["title"], "state": c["state"]})
+            continue
+        if c["state"] == "done" and p.get("state") != "done":
+            merged.append({"id": fid, "title": c["title"]})
+        if c["blocked"] and not p.get("blocked"):
+            newly_blocked.append({"id": fid, "title": c["title"]})
+        elif p.get("blocked") and not c["blocked"]:
+            unblocked.append({"id": fid, "title": c["title"]})
+    out = {}
+    if merged:
+        out["merged"] = merged
+    if newly_blocked:
+        out["newly_blocked"] = newly_blocked
+    if unblocked:
+        out["unblocked"] = unblocked
+    if new:
+        out["new"] = new
+    return out
+
+
+async def _compute_portfolio_diff(wanted: set | None) -> dict:
+    """Fan out across the (filtered) team boards, diff each against the saved baseline,
+    and rewrite the baseline. Returns ``{recs, first_run, changes}``. On the first run
+    (no baseline) it records the baseline and reports nothing — there's no 'before'."""
+    from graph.fleet import supervisor
+
+    recs = [
+        r
+        for r in supervisor.list_remotes()
+        if wanted is None or r.get("name") in wanted or r.get("id") in wanted
+    ]
+    snap = _load_snapshot()
+    first_run = not snap
+
+    async def _one(rec: dict):
+        name = rec.get("name")
+        try:
+            feats = await _fetch_board_features(rec)
+        except _BoardUnavailable as exc:
+            return name, {"error": str(exc)}, None
+        idx = _index_features(feats)
+        return name, _diff_boards(snap.get(name, {}), idx), idx
+
+    results = await asyncio.gather(*[_one(r) for r in recs]) if recs else []
+    changes = {}
+    for name, deltas, idx in results:
+        if idx is not None:  # only advance the baseline for boards we actually read
+            snap[name] = idx
+        if deltas and not first_run:  # first run = pure baseline, suppress the all-new noise
+            changes[name] = deltas
+    _save_snapshot(snap)
+    return {"recs": len(recs), "first_run": first_run, "changes": changes}
 
 
 def _dispatch_instruction(title: str, spec: str, acceptance_criteria: str, files_to_modify: str) -> str:
@@ -207,9 +320,63 @@ def _tools() -> list:
                 return {"board": rec.get("name"), "error": str(exc)}
             return _rollup_one(rec.get("name"), feats)
 
-        import asyncio
-
         rollups = await asyncio.gather(*[_one(r) for r in recs])
         return json.dumps(rollups, indent=2)
 
-    return [portfolio_boards, portfolio_dispatch, portfolio_board_read, portfolio_rollup]
+    @tool
+    async def portfolio_diff(boards: str = "") -> str:
+        """Report what CHANGED on the team boards since the last check — features that
+        merged (reached done), newly blocked, unblocked, or newly added — then update
+        the baseline. The bounded, push-free way to stay current: schedule this (see
+        portfolio_watch) and each run surfaces only the deltas. The FIRST run records a
+        baseline and reports nothing (there's no 'before'). Optional comma-separated
+        ``boards`` filter."""
+        res = await _compute_portfolio_diff(_parse_boards(boards))
+        if res["recs"] == 0:
+            return (
+                "No matching team boards. Call portfolio_boards to list them."
+                if boards
+                else "No team boards yet — register a team-agent as a fleet member first (see portfolio_boards)."
+            )
+        if res["first_run"]:
+            return (
+                f"Baseline recorded for {res['recs']} board(s). Future portfolio_diff calls "
+                "report only what changed since now."
+            )
+        if not res["changes"]:
+            return "No board changes since the last check."
+        return json.dumps(res["changes"], indent=2)
+
+    @tool
+    async def portfolio_watch(interval_min: int = 15, boards: str = "") -> str:
+        """Start watching the team boards for changes WITHOUT polling: record a baseline
+        now, then hand you the exact schedule_task call to run a recurring portfolio_diff.
+        Each scheduled fire arrives as a turn carrying only the changes since the prior
+        sweep — so the system polls for you, not your reasoning loop. Optional
+        ``interval_min`` (default 15) and comma-separated ``boards`` filter."""
+        res = await _compute_portfolio_diff(_parse_boards(boards))
+        if res["recs"] == 0:
+            return (
+                "No matching team boards to watch."
+                if boards
+                else "No team boards yet — register a team-agent as a fleet member first (see portfolio_boards)."
+            )
+        interval = max(1, int(interval_min))
+        cron = f"*/{interval} * * * *" if interval < 60 else "0 * * * *"
+        filt = f' boards="{boards}"' if boards else ""
+        return (
+            f"Baseline captured for {res['recs']} board(s). To receive deltas without polling, "
+            "schedule a recurring sweep with your schedule_task tool:\n\n"
+            f'  schedule_task(prompt="Run portfolio_diff{filt} and report any board changes; '
+            f'if there are none, do nothing.", when="{cron}")\n\n'
+            "Each fire arrives as a turn carrying only the changes since the prior sweep."
+        )
+
+    return [
+        portfolio_boards,
+        portfolio_dispatch,
+        portfolio_board_read,
+        portfolio_rollup,
+        portfolio_diff,
+        portfolio_watch,
+    ]

--- a/plugins/portfolio/protoagent.plugin.yaml
+++ b/plugins/portfolio/protoagent.plugin.yaml
@@ -1,6 +1,6 @@
 id: portfolio
 name: Portfolio (multi-team orchestration)
-version: 0.2.0
+version: 0.3.0
 description: >-
   The PM / program orchestration layer (ADR 0055 P1). One agent orchestrates work
   across MANY team-agents, each running its own project board for its own repo
@@ -12,9 +12,11 @@ description: >-
   Tools: portfolio_boards (enumerate), portfolio_dispatch (send a feature to a
   team board over A2A), portfolio_board_read (structured read of one team board),
   portfolio_rollup (bounded cross-board view — per-board lane counts + only the
-  blocked/critical-path items, so a PM reasons over MANY boards without raw reads).
-  Ships DISABLED; enable with `plugins: { enabled: [portfolio] }`. Pairs with the
-  `delegates` plugin and remote fleet members (ADR 0042). See ADR 0055.
+  blocked/critical-path items, so a PM reasons over MANY boards without raw reads),
+  portfolio_diff (what changed since last check — merged/blocked/unblocked/new) +
+  portfolio_watch (baseline now, then schedule a recurring diff — deltas without
+  polling). Ships DISABLED; enable with `plugins: { enabled: [portfolio] }`. Pairs
+  with the `delegates` plugin and remote fleet members (ADR 0042). See ADR 0055.
 
 enabled: false
 min_protoagent_version: "0.42.0"

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -175,7 +175,14 @@ def test_register_exposes_the_tools():
             seen.append(t.name)
 
     portfolio.register(_Reg())
-    assert set(seen) == {"portfolio_boards", "portfolio_dispatch", "portfolio_board_read", "portfolio_rollup"}
+    assert set(seen) == {
+        "portfolio_boards",
+        "portfolio_dispatch",
+        "portfolio_board_read",
+        "portfolio_rollup",
+        "portfolio_diff",
+        "portfolio_watch",
+    }
 
 
 # ── portfolio_rollup (P2) ────────────────────────────────────────────────────
@@ -274,3 +281,91 @@ async def test_rollup_no_boards_message(monkeypatch):
 
     monkeypatch.setattr(supervisor, "list_remotes", lambda: [])
     assert "No team boards yet" in await _tool("portfolio_rollup").ainvoke({})
+
+
+# ── portfolio_diff / portfolio_watch (P2 slice 2 — deltas) ───────────────────
+
+
+def test_diff_boards_pure_projection():
+    from plugins import portfolio as pf
+
+    prev = {
+        "f1": {"state": "in_progress", "blocked": False, "title": "merge me"},
+        "f2": {"state": "in_progress", "blocked": True, "title": "stuck"},
+        "f3": {"state": "ready", "blocked": False, "title": "steady"},
+    }
+    curr = {
+        "f1": {"state": "done", "blocked": False, "title": "merge me"},  # → merged
+        "f2": {"state": "in_progress", "blocked": False, "title": "stuck"},  # → unblocked
+        "f3": {"state": "ready", "blocked": False, "title": "steady"},  # unchanged → no delta
+        "f4": {"state": "in_progress", "blocked": True, "title": "fresh+blocked"},  # → new (not double-counted as blocked)
+    }
+    d = pf._diff_boards(prev, curr)
+    assert d["merged"] == [{"id": "f1", "title": "merge me"}]
+    assert d["unblocked"] == [{"id": "f2", "title": "stuck"}]
+    assert d["new"] == [{"id": "f4", "title": "fresh+blocked", "state": "in_progress"}]
+    assert "newly_blocked" not in d  # f4 is reported as new, not also as blocked
+    assert pf._diff_boards(curr, curr) == {}  # no changes → empty
+
+
+def _patch_board(monkeypatch, tmp_path, board_features: dict):
+    from graph.fleet import supervisor
+    from plugins import portfolio as pf
+
+    monkeypatch.setattr(
+        supervisor,
+        "list_remotes",
+        lambda: [{"id": "r1", "name": n, "url": f"https://{n}.example", "token": "t"} for n in board_features],
+    )
+    state = {"features": board_features}
+
+    async def fake_fetch(rec, fstate=""):
+        return state["features"][rec["name"]]
+
+    monkeypatch.setattr(pf, "_fetch_board_features", fake_fetch)
+    monkeypatch.setattr(pf, "_snapshot_path", lambda: tmp_path / "snap.json")
+    return state
+
+
+@pytest.mark.asyncio
+async def test_diff_first_run_baselines_then_reports_changes(monkeypatch, tmp_path):
+    state = _patch_board(
+        monkeypatch,
+        tmp_path,
+        {"team-web": [{"id": "w1", "title": "feat", "board_state": "in_progress"}]},
+    )
+
+    # first run: records baseline, reports nothing
+    out1 = await _tool("portfolio_diff").ainvoke({})
+    assert "Baseline recorded" in out1
+    assert (tmp_path / "snap.json").exists()
+
+    # nothing changed → no-change message
+    assert "No board changes" in await _tool("portfolio_diff").ainvoke({})
+
+    # the feature merges → next diff reports it
+    state["features"]["team-web"] = [{"id": "w1", "title": "feat", "board_state": "done"}]
+    out3 = json.loads(await _tool("portfolio_diff").ainvoke({}))
+    assert out3 == {"team-web": {"merged": [{"id": "w1", "title": "feat"}]}}
+
+    # and it's consumed — a re-run sees no further change
+    assert "No board changes" in await _tool("portfolio_diff").ainvoke({})
+
+
+@pytest.mark.asyncio
+async def test_watch_baselines_and_returns_schedule_guidance(monkeypatch, tmp_path):
+    _patch_board(monkeypatch, tmp_path, {"team-web": [{"id": "w1", "title": "f", "board_state": "ready"}]})
+    out = await _tool("portfolio_watch").ainvoke({"interval_min": 30})
+    assert "Baseline captured for 1 board" in out
+    assert 'when="*/30 * * * *"' in out and "schedule_task" in out
+    assert (tmp_path / "snap.json").exists()  # baseline seeded
+
+
+@pytest.mark.asyncio
+async def test_diff_no_boards_message(monkeypatch, tmp_path):
+    from graph.fleet import supervisor
+    from plugins import portfolio as pf
+
+    monkeypatch.setattr(supervisor, "list_remotes", lambda: [])
+    monkeypatch.setattr(pf, "_snapshot_path", lambda: tmp_path / "snap.json")
+    assert "No team boards yet" in await _tool("portfolio_diff").ainvoke({})


### PR DESCRIPTION
**ADR 0055 P2, slice 2** — the PM learns what **changed** on its team boards without polling. Completes the bounded-context layer (slice 1 = `portfolio_rollup` #1110).

### Pull-diff, not push (decided via a substrate scout)
- A2A push notifications (`pushNotificationConfig`) are **task-scoped** — "my dispatched task finished," not "this board changed." Wrong granularity.
- The event bus (ADR 0039) is **in-process per instance** — no cross-instance bridge.
- Remote registration is **one-directional** (PM→team) — a team-agent doesn't know its PM, so push would need credential distribution + a team-side hook in the standalone `project_board` repo.
- **Pull-diff** reuses the slice-1 read path verbatim, auth already flows PM→team, nothing changes on the team side.

### Tools (plugin → v0.3.0)
- **`portfolio_diff(boards="")`** — snapshots each board (feature → state/blocked) under the PM's instance data root and reports only transitions: `merged` (→done) / `newly_blocked` / `unblocked` / `new`. First run baselines silently; tolerant of an unreachable board.
- **`portfolio_watch(interval_min=15, boards="")`** — records a baseline, returns the exact `schedule_task` cron to run `portfolio_diff` recurringly. Each fire arrives as a turn carrying only the deltas — *the system polls for the PM, not its reasoning loop*.

### Docs (upserted)
- **ADR 0055** phasing updated — P0/P1/P2 status + the pull-diff-vs-push decision recorded + the deferred inbox-push upgrade path.
- New **`docs/guides/portfolio.md`** (setup, the 6 tools, the watch pattern) + guides index link.

### Tests
16 (prior 12 + `_diff_boards` projection, first-run baseline→reports-changes→consumed, watch baseline+schedule guidance, empty-fleet).

Deferred push upgrade (P2.5+): a team-side bus→`/api/inbox` bridge once a team↔PM handshake exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)