### PR TITLE
feat(portfolio): cross-board dependency graph — portfolio_link + portfolio_plan (ADR 0055 P3 slice 1)

### DIFF
--- a/docs/adr/0055-multi-team-orchestration-federated-boards.md
+++ b/docs/adr/0055-multi-team-orchestration-federated-boards.md
@@ -143,4 +143,20 @@ registry:
     team side. *Deferred push upgrade (P2.5+):* a team-side bus→`/api/inbox` bridge once a
     team↔PM handshake exists — the inbox (`POST /api/inbox`, `priority:"now"` fires a turn)
     is the right inbound sink, but it's a larger lift for marginal latency gain.
-- **P3** — cross-repo dependency graph + program-level sequencing.
+- **P3** ✅ *(slice 1 shipped)* — cross-repo dependency graph + program-level
+  sequencing: `portfolio_link` + `portfolio_plan` (plugin v0.4.0). Cross-board edges
+  are **PM-side state** (`portfolio_links.json`, scoped) — `{from_board, from_feature,
+  to_board, to_feature}` meaning *from is blocked until to is done*. Features are keyed
+  by `(board, feature_id)` (ids are board-local). `portfolio_plan` fetches every board
+  and marks each edge **satisfied** (the depended-on feature merged→`done`, the board's
+  one Done signal), **blocking**, **unknown** (board unreachable — fail-closed, never
+  assumed satisfied), or **dangling** (feature/board gone), then returns
+  `ready_to_dispatch` (a `from` whose every blocker is satisfied and that hasn't started)
+  + `blocked`. Cycles are rejected at link time (DFS). *Why PM-side:* beads' `blocks`
+  edges are single-DB (no foreign ids), a team-agent doesn't know its dependents, and
+  sequencing is the PM's concern — same rationale as P2. *Deferred (later P3 slices):*
+  auto-dispatch of unblocked work (pair `portfolio_plan` → `portfolio_dispatch` with an
+  idempotency guard; ideally delta-triggered, not polled), bead-side annotation so an
+  edge travels with the work, full cycle-aware multi-hop topological sequencing, and a
+  console graph view. Improves on the Studio comp (project-level edges, manual
+  `resolve`) with feature-level edges + automatic merge detection.

--- a/docs/guides/portfolio.md
+++ b/docs/guides/portfolio.md
@@ -42,6 +42,8 @@ registry), [delegates](/guides/delegates) (the A2A dispatch primitive), and
 | `portfolio_rollup([boards])` | **Bounded** cross-board view — per-board lane counts + only the blocked / critical-path items, never the full feature list. Reason over many boards without raw reads |
 | `portfolio_diff([boards])` | What **changed** since the last check — features merged / newly-blocked / unblocked / new — then advances the baseline |
 | `portfolio_watch([interval_min, boards])` | Records a baseline, then hands you the `schedule_task` call to run `portfolio_diff` on a schedule |
+| `portfolio_link(from_board, from_feature, to_board, to_feature[, note, remove])` | Record (or remove) a cross-board dependency: A's feature waits for B's |
+| `portfolio_plan()` | The cross-board dependency graph + what's ready to dispatch next |
 
 ## Deltas without polling
 
@@ -63,6 +65,32 @@ Each scheduled fire arrives as a turn carrying only the deltas — *the system p
 the PM*. (Why pull-diff and not push: A2A push notifications are task-scoped, the event
 bus is in-process, and a team-agent doesn't know its PM — so a PM-side snapshot+diff is
 the thin correct shape. See [ADR 0055 P2](../adr/0055-multi-team-orchestration-federated-boards.md#phasing).)
+
+## Cross-board dependencies
+
+When one team's feature can't start until another team's ships, record the edge and
+let the PM sequence:
+
+```
+portfolio_link(from_board="team-web", from_feature="bd-aaa",
+               to_board="team-api",  to_feature="bd-bbb",
+               note="web's probe wiring needs the /v2 endpoint")
+# team-web:bd-aaa is now blocked until team-api:bd-bbb is done (merged)
+
+portfolio_plan()
+# → every link tagged satisfied / blocking / unknown / dangling, plus:
+#   ready_to_dispatch — from-features whose every blocker has merged (dispatch these next)
+#   blocked           — the rest, with their open blockers
+```
+
+Edges are **PM-side** (`portfolio_links.json`, scoped to the PM) — features are
+addressed by `(board, feature_id)` since ids are board-local. A link is **satisfied**
+the moment its depended-on feature reaches `done` (the board's only merge signal); an
+unreachable blocker is **unknown** and fail-closed (never dispatched on a guess); a
+vanished one is **dangling** (prune with `portfolio_link(remove="lnk-…")`). Cycles are
+rejected when you add the link. Pair `portfolio_plan` with `portfolio_dispatch` to send
+the unblocked work — the PM (or you) stays in the loop; auto-dispatch is a later slice
+(see [ADR 0055 P3](../adr/0055-multi-team-orchestration-federated-boards.md#phasing)).
 
 ## Notes
 

--- a/plugins/portfolio/__init__.py
+++ b/plugins/portfolio/__init__.py
@@ -11,8 +11,9 @@ subsystems — no new dispatch or registry machinery:
 The PM treats each remote fleet member as a *board* addressed by its name: list
 them (`portfolio_boards`), dispatch a feature to one over A2A (`portfolio_dispatch`),
 read one back structured (`portfolio_board_read`), see a bounded cross-board rollup
-(`portfolio_rollup`), and watch for changes without polling (`portfolio_watch` +
-`portfolio_diff`). See ADR 0055.
+(`portfolio_rollup`), watch for changes without polling (`portfolio_watch` +
+`portfolio_diff`), and sequence cross-board dependencies (`portfolio_link` +
+`portfolio_plan`). See ADR 0055.
 
 P2 deltas are PULL-DIFF, not push: the PM snapshots each board (state per feature)
 and reports what changed since the last check. A2A push notifications are task-scoped
@@ -206,6 +207,85 @@ async def _compute_portfolio_diff(wanted: set | None) -> dict:
     return {"recs": len(recs), "first_run": first_run, "changes": changes}
 
 
+# ── P3 cross-board dependency graph (PM-side links + sequencing) ──────────────────
+
+
+async def _fetch_all(recs: list) -> tuple[dict, dict]:
+    """Fetch every board's features concurrently → (features_by_board, unreachable{name:error})."""
+
+    async def _one(rec: dict):
+        name = rec.get("name")
+        try:
+            return name, await _fetch_board_features(rec), None
+        except _BoardUnavailable as exc:
+            return name, None, str(exc)
+
+    results = await asyncio.gather(*[_one(r) for r in recs]) if recs else []
+    by_board, unreachable = {}, {}
+    for name, feats, err in results:
+        if err is None:
+            by_board[name] = feats
+        else:
+            unreachable[name] = err
+    return by_board, unreachable
+
+
+def _links_path():
+    """Cross-board dependency edges, scoped under the PM's data root (ADR 0004) —
+    mirrors the P2 snapshot + fleet remotes.json. Edges are PM state: a team-agent
+    doesn't know its dependents, and the sequencing is the PM's concern."""
+    from infra.paths import data_home, scope_leaf
+
+    return scope_leaf(data_home() / "portfolio_links.json")
+
+
+def _load_links() -> list:
+    p = _links_path()
+    try:
+        return json.loads(p.read_text()) if p.exists() else []
+    except Exception:  # noqa: BLE001 — a corrupt links file shouldn't break the tools
+        return []
+
+
+def _save_links(links: list) -> None:
+    from infra.paths import atomic_write
+
+    p = _links_path()
+    p.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(p, json.dumps(links, indent=2))
+
+
+def _edge_id(from_board: str, from_feature: str, to_board: str, to_feature: str) -> str:
+    """Stable id from the edge tuple → natural dedup (the same edge always gets the same id)."""
+    import hashlib
+
+    key = f"{from_board}:{from_feature}>{to_board}:{to_feature}"
+    return "lnk-" + hashlib.sha1(key.encode()).hexdigest()[:8]
+
+
+def _has_cycle(links: list) -> bool:
+    """DFS over (board, feature) nodes — True if the edge set contains a cycle (a feature
+    transitively depends on itself). Used to REJECT a cycle at link time; without this a
+    cycle would silently deadlock (nothing ever becomes ready)."""
+    from collections import defaultdict
+
+    adj: dict = defaultdict(list)
+    for ln in links:
+        adj[(ln["from_board"], ln["from_feature"])].append((ln["to_board"], ln["to_feature"]))
+    color: dict = {}  # absent/0 = unvisited, 1 = on the current path, 2 = done
+
+    def visit(node) -> bool:
+        color[node] = 1
+        for nxt in adj.get(node, []):
+            c = color.get(nxt, 0)
+            if c == 1 or (c == 0 and visit(nxt)):
+                return True
+        color[node] = 2
+        return False
+
+    return any(color.get(n, 0) == 0 and visit(n) for n in list(adj))
+
+
 def _dispatch_instruction(title: str, spec: str, acceptance_criteria: str, files_to_modify: str) -> str:
     lines = [
         "You manage a project board (the project_board plugin). Create a new feature on it "
@@ -372,6 +452,119 @@ def _tools() -> list:
             "Each fire arrives as a turn carrying only the changes since the prior sweep."
         )
 
+    @tool
+    def portfolio_link(
+        from_board: str = "",
+        from_feature: str = "",
+        to_board: str = "",
+        to_feature: str = "",
+        note: str = "",
+        remove: str = "",
+    ) -> str:
+        """Record (or remove) a CROSS-BOARD dependency: ``from_board``'s ``from_feature``
+        is blocked until ``to_board``'s ``to_feature`` is done (merged on that team's
+        board). Features are addressed by (board name, feature id) — ids are board-local,
+        so the board is always required. Run portfolio_plan to see the graph + what's
+        unblocked. To delete an edge, pass ``remove="lnk-..."`` (the id from
+        portfolio_plan)."""
+        links = _load_links()
+        if remove:
+            kept = [ln for ln in links if ln.get("id") != remove]
+            if len(kept) == len(links):
+                return f"No cross-board link {remove!r} to remove."
+            _save_links(kept)
+            return f"Removed link {remove}."
+        if not (from_board and from_feature and to_board and to_feature):
+            return "Error: from_board, from_feature, to_board and to_feature are all required."
+        if (from_board, from_feature) == (to_board, to_feature):
+            return "Error: a feature can't depend on itself."
+        for b in (from_board, to_board):
+            if _remote_by_name(b) is None:
+                return f"Error: no team board named {b!r}. Call portfolio_boards to list them."
+        eid = _edge_id(from_board, from_feature, to_board, to_feature)
+        if any(ln.get("id") == eid for ln in links):
+            return f"Already linked ({eid})."
+        edge = {
+            "id": eid,
+            "from_board": from_board,
+            "from_feature": from_feature,
+            "to_board": to_board,
+            "to_feature": to_feature,
+            "note": note,
+        }
+        if _has_cycle(links + [edge]):
+            return "Error: that link would create a cross-board dependency cycle — not recorded."
+        _save_links(links + [edge])
+        return json.dumps(
+            {k: edge[k] for k in ("id", "from_board", "from_feature", "to_board", "to_feature")}, indent=2
+        )
+
+    @tool
+    async def portfolio_plan() -> str:
+        """The cross-board dependency graph + what's ready to dispatch next. For each link
+        (see portfolio_link): ``satisfied`` (the depended-on feature is done), ``blocking``
+        (not yet), ``unknown`` (its board is unreachable — never assumed satisfied), or
+        ``dangling`` (the board/feature no longer exists — prune it). ``ready_to_dispatch``
+        = ``from`` features whose every blocker is satisfied and that haven't started yet;
+        ``blocked`` lists the rest with their open blockers."""
+        links = _load_links()
+        if not links:
+            return "No cross-board links yet. Use portfolio_link to record a dependency, then portfolio_plan to sequence."
+        from graph.fleet import supervisor
+
+        by_board, unreachable = await _fetch_all(supervisor.list_remotes())
+        state = {}
+        for name, feats in by_board.items():
+            for f in feats:
+                if f.get("id"):
+                    state[(name, f["id"])] = f.get("board_state")
+
+        def status_of(ln) -> str:
+            if ln["to_board"] in unreachable:
+                return "unknown"  # fail-closed: an unreadable blocker is NOT satisfied
+            key = (ln["to_board"], ln["to_feature"])
+            if key not in state:
+                return "dangling"
+            return "satisfied" if state[key] == "done" else "blocking"
+
+        enriched = [
+            {
+                "id": ln["id"],
+                "from_board": ln["from_board"],
+                "from_feature": ln["from_feature"],
+                "to_board": ln["to_board"],
+                "to_feature": ln["to_feature"],
+                "status": status_of(ln),
+                "to_state": state.get((ln["to_board"], ln["to_feature"])),
+            }
+            for ln in links
+        ]
+
+        from collections import defaultdict
+
+        by_from: dict = defaultdict(list)
+        for e in enriched:
+            by_from[(e["from_board"], e["from_feature"])].append(e)
+        ready, blocked = [], []
+        for (fb, ff), edges in by_from.items():
+            if all(e["status"] == "satisfied" for e in edges):
+                from_state = state.get((fb, ff))
+                if from_state in (None, "backlog", "ready"):  # not yet underway → dispatchable
+                    ready.append({"board": fb, "feature": ff, "state": from_state})
+            else:
+                blocked.append(
+                    {
+                        "board": fb,
+                        "feature": ff,
+                        "blockers": [
+                            {"board": e["to_board"], "feature": e["to_feature"], "status": e["status"], "to_state": e["to_state"]}
+                            for e in edges
+                            if e["status"] != "satisfied"
+                        ],
+                    }
+                )
+        return json.dumps({"links": enriched, "ready_to_dispatch": ready, "blocked": blocked}, indent=2)
+
     return [
         portfolio_boards,
         portfolio_dispatch,
@@ -379,4 +572,6 @@ def _tools() -> list:
         portfolio_rollup,
         portfolio_diff,
         portfolio_watch,
+        portfolio_link,
+        portfolio_plan,
     ]

--- a/plugins/portfolio/protoagent.plugin.yaml
+++ b/plugins/portfolio/protoagent.plugin.yaml
@@ -1,6 +1,6 @@
 id: portfolio
 name: Portfolio (multi-team orchestration)
-version: 0.3.0
+version: 0.4.0
 description: >-
   The PM / program orchestration layer (ADR 0055 P1). One agent orchestrates work
   across MANY team-agents, each running its own project board for its own repo
@@ -15,8 +15,11 @@ description: >-
   blocked/critical-path items, so a PM reasons over MANY boards without raw reads),
   portfolio_diff (what changed since last check — merged/blocked/unblocked/new) +
   portfolio_watch (baseline now, then schedule a recurring diff — deltas without
-  polling). Ships DISABLED; enable with `plugins: { enabled: [portfolio] }`. Pairs
-  with the `delegates` plugin and remote fleet members (ADR 0042). See ADR 0055.
+  polling), portfolio_link (record a cross-board dependency: A's feature waits for
+  B's) + portfolio_plan (the cross-board graph + what's ready to dispatch next; a
+  link is satisfied when the depended-on feature merges→done). Ships DISABLED; enable
+  with `plugins: { enabled: [portfolio] }`. Pairs with the `delegates` plugin and
+  remote fleet members (ADR 0042). See ADR 0055.
 
 enabled: false
 min_protoagent_version: "0.42.0"

--- a/tests/test_portfolio.py
+++ b/tests/test_portfolio.py
@@ -182,6 +182,8 @@ def test_register_exposes_the_tools():
         "portfolio_rollup",
         "portfolio_diff",
         "portfolio_watch",
+        "portfolio_link",
+        "portfolio_plan",
     }
 
 
@@ -369,3 +371,122 @@ async def test_diff_no_boards_message(monkeypatch, tmp_path):
     monkeypatch.setattr(supervisor, "list_remotes", lambda: [])
     monkeypatch.setattr(pf, "_snapshot_path", lambda: tmp_path / "snap.json")
     assert "No team boards yet" in await _tool("portfolio_diff").ainvoke({})
+
+
+# ── portfolio_link / portfolio_plan (P3 — cross-board dependency graph) ───────
+
+
+def test_has_cycle_unit():
+    from plugins import portfolio as pf
+
+    edges = [
+        {"from_board": "a", "from_feature": "1", "to_board": "b", "to_feature": "2"},
+        {"from_board": "b", "from_feature": "2", "to_board": "a", "to_feature": "1"},
+    ]
+    assert pf._has_cycle(edges) is True
+    assert pf._has_cycle(edges[:1]) is False  # a single edge is acyclic
+
+
+def _patch_links(monkeypatch, tmp_path, boards=("team-web", "team-api")):
+    from graph.fleet import supervisor
+    from plugins import portfolio as pf
+
+    monkeypatch.setattr(
+        supervisor,
+        "list_remotes",
+        lambda: [{"id": f"r-{n}", "name": n, "url": f"https://{n}.example", "token": "t"} for n in boards],
+    )
+    monkeypatch.setattr(pf, "_links_path", lambda: tmp_path / "links.json")
+
+
+def test_link_add_dedup_self_unknown(monkeypatch, tmp_path):
+    _patch_links(monkeypatch, tmp_path)
+    link = _tool("portfolio_link")
+    edge = {"from_board": "team-web", "from_feature": "w1", "to_board": "team-api", "to_feature": "a1"}
+
+    out = json.loads(link.invoke(edge))
+    assert out["from_board"] == "team-web" and out["to_feature"] == "a1" and out["id"].startswith("lnk-")
+    assert "Already linked" in link.invoke(edge)  # dedup on the 4-tuple
+    assert "can't depend on itself" in link.invoke(
+        {"from_board": "team-web", "from_feature": "w1", "to_board": "team-web", "to_feature": "w1"}
+    )
+    assert "no team board named 'ghost'" in link.invoke(
+        {"from_board": "team-web", "from_feature": "w1", "to_board": "ghost", "to_feature": "x"}
+    )
+
+
+def test_link_rejects_a_cycle(monkeypatch, tmp_path):
+    _patch_links(monkeypatch, tmp_path)
+    link = _tool("portfolio_link")
+    link.invoke({"from_board": "team-web", "from_feature": "w1", "to_board": "team-api", "to_feature": "a1"})
+    # the reverse edge would close a cycle (web:w1 → api:a1 → web:w1)
+    out = link.invoke({"from_board": "team-api", "from_feature": "a1", "to_board": "team-web", "to_feature": "w1"})
+    assert "cycle" in out
+
+
+def test_link_remove(monkeypatch, tmp_path):
+    _patch_links(monkeypatch, tmp_path)
+    link = _tool("portfolio_link")
+    eid = json.loads(
+        link.invoke({"from_board": "team-web", "from_feature": "w1", "to_board": "team-api", "to_feature": "a1"})
+    )["id"]
+    assert "Removed" in link.invoke({"remove": eid})  # remove short-circuits before validation
+    assert "No cross-board link" in link.invoke({"remove": "lnk-zzzzzzzz"})
+
+
+@pytest.mark.asyncio
+async def test_plan_satisfied_blocking_and_ready(monkeypatch, tmp_path):
+    from plugins import portfolio as pf
+
+    _patch_links(monkeypatch, tmp_path)
+    pf._save_links(
+        [
+            {"id": "l1", "from_board": "team-web", "from_feature": "w1", "to_board": "team-api", "to_feature": "a1", "note": ""},
+            {"id": "l2", "from_board": "team-web", "from_feature": "w2", "to_board": "team-api", "to_feature": "a2", "note": ""},
+        ]
+    )
+    boards = {
+        "team-web": [{"id": "w1", "board_state": "backlog"}, {"id": "w2", "board_state": "backlog"}],
+        "team-api": [{"id": "a1", "board_state": "done"}, {"id": "a2", "board_state": "in_progress"}],
+    }
+
+    async def fake_fetch(rec, state=""):
+        return boards[rec["name"]]
+
+    monkeypatch.setattr(pf, "_fetch_board_features", fake_fetch)
+    plan = json.loads(await _tool("portfolio_plan").ainvoke({}))
+    assert {ln["id"]: ln["status"] for ln in plan["links"]} == {"l1": "satisfied", "l2": "blocking"}
+    assert plan["ready_to_dispatch"] == [{"board": "team-web", "feature": "w1", "state": "backlog"}]  # blocker done
+    assert plan["blocked"][0]["feature"] == "w2"
+    assert plan["blocked"][0]["blockers"][0]["feature"] == "a2"
+
+
+@pytest.mark.asyncio
+async def test_plan_unknown_and_dangling_fail_closed(monkeypatch, tmp_path):
+    from plugins import portfolio as pf
+
+    _patch_links(monkeypatch, tmp_path)
+    pf._save_links(
+        [
+            {"id": "l1", "from_board": "team-web", "from_feature": "w1", "to_board": "team-api", "to_feature": "a1", "note": ""},
+            {"id": "l2", "from_board": "team-web", "from_feature": "w2", "to_board": "team-web", "to_feature": "ghost", "note": ""},
+        ]
+    )
+
+    async def fake_fetch(rec, state=""):
+        if rec["name"] == "team-api":
+            raise pf._BoardUnavailable("down")
+        return [{"id": "w1", "board_state": "backlog"}, {"id": "w2", "board_state": "backlog"}]
+
+    monkeypatch.setattr(pf, "_fetch_board_features", fake_fetch)
+    plan = json.loads(await _tool("portfolio_plan").ainvoke({}))
+    assert {ln["id"]: ln["status"] for ln in plan["links"]} == {"l1": "unknown", "l2": "dangling"}
+    assert plan["ready_to_dispatch"] == []  # fail-closed: never dispatch on an unknown/dangling blocker
+
+
+@pytest.mark.asyncio
+async def test_plan_empty(monkeypatch, tmp_path):
+    from plugins import portfolio as pf
+
+    monkeypatch.setattr(pf, "_links_path", lambda: tmp_path / "links.json")
+    assert "No cross-board links yet" in await _tool("portfolio_plan").ainvoke({})


### PR DESCRIPTION
**ADR 0055 P3, slice 1** — the last phase. Sequence work that spans team boards: when team-A's feature can't start until team-B's ships, record the edge and let the PM sequence + see what's unblocked.

### Tools (plugin → v0.4.0, 8 tools)
- **`portfolio_link(from_board, from_feature, to_board, to_feature, note="", remove="")`** — records a cross-board edge (*from is blocked until to is done*). **PM-side state** at `scope_leaf(data_home()/portfolio_links.json)`; features keyed by `(board, feature_id)` (beads ids are board-local). Rejects self-edges, dupes (stable hashed id), and **cycles** (DFS at link time). `remove="lnk-…"` deletes.
- **`portfolio_plan()`** — fetches every board (reusing the rollup/diff fetch path) and tags each edge **satisfied** (depended-on feature merged→`done`) / **blocking** / **unknown** (board unreachable — *fail-closed*) / **dangling** (gone); returns **`ready_to_dispatch`** (from-features whose every blocker is satisfied and haven't started) + **`blocked`** with open blockers.

### Why PM-side, not beads edges
beads `blocks` edges are single-DB (no foreign ids), a team-agent doesn't know its dependents, and sequencing is the PM's concern — same rationale as P1/P2. Improves on the Studio comp (project-level edges, manual `resolve`) with **feature-level edges + automatic merge detection**.

### Docs (upserted)
ADR 0055 P3 phasing (edge model, statuses, fail-closed, deferred slices) + a **Cross-board dependencies** section in `docs/guides/portfolio.md`.

### Tests
23 (prior 16 + cycle-detector unit, link add/dedup/self/unknown/cycle/remove, plan satisfied/blocking/ready + unknown/dangling fail-closed + empty).

### Deferred (later P3 slices)
Auto-dispatch of unblocked work (delta-triggered, idempotency-guarded), bead-side annotation, full multi-hop topological sequencing, a console graph view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)