### PR TITLE
ci: run on GitHub-hosted runners (ubuntu-latest)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   workspace-config:
     name: Verify workspace config
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -61,7 +61,7 @@ jobs:
 
   lint:
     name: Lint (ruff + import contracts)
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4
@@ -86,7 +86,7 @@ jobs:
 
   tests:
     name: Python tests
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
 
   live-smoke:
     name: A2A live smoke (lean tier)
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4
@@ -136,7 +136,7 @@ jobs:
 
   web-e2e:
     name: Web E2E smoke
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -357,7 +357,7 @@ jobs:
     if: >-
       github.event_name == 'push' && github.repository == 'protoLabsAI/protoAgent'
       && endsWith(github.ref_name, '.0')
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 10
     steps:
       - name: Setup Node

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -29,7 +29,7 @@ env:
 
 jobs:
   build-and-push:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 30
 
     steps:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,7 +24,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4
@@ -43,7 +43,7 @@ jobs:
     needs: build
     # Never deploy from a PR — PRs only validate the build above.
     if: github.event_name != 'pull_request'
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}

--- a/.github/workflows/marketing-deploy.yml
+++ b/.github/workflows/marketing-deploy.yml
@@ -26,7 +26,7 @@ concurrency:
 jobs:
   deploy:
     name: Build & deploy to Cloudflare Pages
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -33,7 +33,7 @@ concurrency:
 jobs:
   prepare:
     name: Prepare Release
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     # Opt-in guard (fork-friendly): set the `RELEASE_ENABLED` repo variable to
     # `true` to enable the release pipeline. Forks enable it without editing this
     # workflow — so upstream changes to the file don't conflict on re-sync.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -23,7 +23,7 @@ env:
 jobs:
   release:
     name: Release
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     # Opt-in guard (fork-friendly): set the `RELEASE_ENABLED` repo variable to
     # `true` to enable releases. Forks enable without editing this workflow.
     if: vars.RELEASE_ENABLED == 'true'

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -16,7 +16,7 @@ permissions:
 jobs:
   gitleaks:
     name: gitleaks (tree)
-    runs-on: namespace-profile-protolabs-linux
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 5
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
protoAgent is **public** → GitHub-hosted standard runners are **free**, so there's no cost reason to route its CI through the paid Namespace profile. Switches every `namespace-profile-protolabs-linux` job to `ubuntu-latest` (the desktop matrix legs were already GH-hosted).

**Also unblocks the pipeline:** Namespace dispatch stalled (~115m of queued jobs never picked up by idle runners), wedging all CI + the v0.43.0 release. GH-hosted dispatches normally. **Self-applying** — a same-repo PR runs from the head's workflow defs, so this PR's own checks run on `ubuntu-latest` and it merges without waiting on Namespace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)