### PR TITLE
fix(desktop): correct the updater pubkey to match the signing key

### DIFF
--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -41,7 +41,7 @@
   },
   "plugins": {
     "updater": {
-      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEZBQTg4QTBCRERFN0E4MDkKUldRSnFPZmRDNHFvK3FMMGdubXlkWGp6bkVmYXFRS29GR1RBVnlpenlUNHh2TUxYWENQdkREUjIK",
+      "pubkey": "dW50cnVzdGVkIGNvbW1lbnQ6IG1pbmlzaWduIHB1YmxpYyBrZXk6IEIxMkFDRUQ0MjdCM0IyOTAKUldTUXNyTW4xTTRxc1lBeWlnZDRzRFFrTTdWcTJMdVdCVk1BdWtIVUM0M2x0WWVXdklhNExaczMK",
       "endpoints": [
         "https://github.com/protoLabsAI/protoAgent/releases/latest/download/latest.json"
       ]


### PR DESCRIPTION
The embedded updater pubkey (`FAA88A0BDDE7A809`, committed in #918) never matched the keypair CI signs with → every in-app update fails minisign verification (the "signature created with a different key" error). Broken since #918; `.dmg` installs unaffected (Apple-signed).

Sets `pubkey` → the **regenerated** keypair's public key (`B12ACED427B3B290`). **Requires** `TAURI_SIGNING_PRIVATE_KEY`(+password) set to the matching private key before the next desktop build.

⚠️ Existing installs have the old pubkey baked in and can't auto-update to this fix — **one-time manual reinstall of v0.44.0** required; auto-update works after. Must ship as a **minor** (patch skips the desktop build). Fixes the updater-keypair-mismatch bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)