### PR TITLE
fix(desktop): close the in-app-updater 404 window — mark 'Latest' only after latest.json is up

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -395,3 +395,9 @@ jobs:
           # (the in-app updater manifest). The download step above already
           # passes --repo for the same reason.
           gh release upload "$TAG" latest.json --repo "${{ github.repository }}" --clobber
+          # Promote to 'Latest' ONLY now that latest.json (and every binary) is on the
+          # release — this closes the in-app-updater 404 window. release.yml creates the
+          # release with --latest=false, so it becomes 'Latest' exactly here, after the
+          # manifest exists. (The no-bundles path above exits 0 before this, so an
+          # unsigned build never gets promoted — 'Latest' stays on the last good .0.)
+          gh release edit "$TAG" --repo "${{ github.repository }}" --latest

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -145,9 +145,17 @@ jobs:
           NOTES: ${{ steps.notes.outputs.notes }}
         run: |
           printf '%s' "$NOTES" > "$RUNNER_TEMP/release-notes.md"
+          # --latest=false: do NOT promote to 'Latest' yet. The in-app updater fetches
+          # releases/latest/download/latest.json, so a release must not become 'Latest'
+          # until its latest.json exists — otherwise update checks 404 in the window
+          # before the desktop build's fan-in uploads it. The desktop fan-in flips this
+          # release to 'Latest' once latest.json is up (desktop-build.yml). Patch tags
+          # skip the desktop build entirely, so they stay non-Latest and 'Latest'
+          # correctly remains on the last .0 (the one carrying latest.json).
           gh release create "${{ steps.version.outputs.tag }}" \
             --title "${{ steps.version.outputs.tag }}" \
-            --notes-file "$RUNNER_TEMP/release-notes.md"
+            --notes-file "$RUNNER_TEMP/release-notes.md" \
+            --latest=false
 
       # ── Discord ───────────────────────────────────────────────────────────────
       # Shared fleet tooling: rewrites the commit range into themed notes via


### PR DESCRIPTION
The in-app updater fetches `releases/latest/download/latest.json`. But `release.yml` let GitHub auto-promote the new tag to **"Latest"** immediately, while the desktop build's fan-in uploads `latest.json` ~15–30 min later — so every release had a window where update checks **404** (hit live on v0.43.0). Patch tags were worse: they skip the desktop build, so an auto-"Latest" patch would 404 the updater until the next minor.

**Fix:** `release.yml` creates the release with `--latest=false`; the desktop fan-in flips it to "Latest" (`gh release edit --latest`) **right after** `latest.json` is uploaded. So "Latest" only ever lands on a release that actually carries the manifest:
- **`.0`** → becomes Latest only once `latest.json` is up → no window.
- **patch** → desktop skipped → stays non-Latest → "Latest" correctly stays on the last `.0` (which has `latest.json` + matching binaries).
- **unsigned/failed build** → the no-bundles path exits before the promote → never Latest → "Latest" stays on the last good `.0` (safe failure mode).

Validated on the next `.0` release (the change only affects release-time promotion). Fixes the updater 404-window bug.

🤖 Generated with [Claude Code](https://claude.com/claude-code)