### PR TITLE
feat(desktop): real chat streaming in the desktop shell (Tauri-relayed SSE)

### DIFF
--- a/apps/desktop/src-tauri/Cargo.lock
+++ b/apps/desktop/src-tauri/Cargo.lock
@@ -2991,7 +2991,9 @@ dependencies = [
 name = "protoagent_desktop"
 version = "0.1.0"
 dependencies = [
+ "futures-util",
  "log",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
@@ -3220,6 +3222,41 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-util",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "wasm-streams 0.4.2",
+ "web-sys",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "219c5811de6525e5416c7d5d53bb656d3afdbc6c5af816e0802bcfa42dbdc1c3"
@@ -3253,7 +3290,7 @@ dependencies = [
  "url",
  "wasm-bindgen",
  "wasm-bindgen-futures",
- "wasm-streams",
+ "wasm-streams 0.5.0",
  "web-sys",
 ]
 
@@ -3447,6 +3484,12 @@ name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3674,6 +3717,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -4109,7 +4164,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.4",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4343,7 +4398,7 @@ dependencies = [
  "minisign-verify",
  "osakit",
  "percent-encoding",
- "reqwest",
+ "reqwest 0.13.4",
  "rustls",
  "semver",
  "serde",
@@ -5153,6 +5208,19 @@ dependencies = [
  "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
+]
+
+[[package]]
+name = "wasm-streams"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
+dependencies = [
+ "futures-util",
+ "js-sys",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
 ]
 
 [[package]]

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -28,3 +28,8 @@ tauri-plugin-log = "2"
 tauri-plugin-notification = "2"
 tauri-plugin-shell = "2"
 tauri-plugin-updater = "2"
+# Desktop chat streaming: WKWebView can't read a streaming fetch body, so the
+# `chat_stream` command runs the /a2a SSE POST here and relays chunks to the
+# webview. Local sidecar is http://127.0.0.1, so no TLS backend needed.
+reqwest = { version = "0.12", default-features = false, features = ["json", "stream"] }
+futures-util = "0.3"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -260,9 +260,53 @@ fn build_tray(app: &tauri::App) -> tauri::Result<()> {
     Ok(())
 }
 
+/// Stream a chat turn for the desktop shell. WKWebView won't deliver a streaming
+/// SSE `fetch` body chunk-by-chunk, so the webview hands us the A2A request body and
+/// we run the `/a2a` `SendStreamingMessage` POST here (reqwest streams fine), relaying
+/// each raw response chunk to the frontend over an IPC `Channel`. The webview parses
+/// the SSE + dispatches frames exactly like the browser path (`drainSseBuffer`), so
+/// desktop gets real token-by-token + tool-call streaming. On any error the caller
+/// falls back to the non-streaming `/api/chat` path — so this never regresses below
+/// today's behavior.
+#[tauri::command]
+async fn chat_stream(
+    url: String,
+    body: serde_json::Value,
+    auth: Option<String>,
+    on_event: tauri::ipc::Channel<String>,
+) -> Result<(), String> {
+    use futures_util::StreamExt;
+
+    let client = reqwest::Client::new();
+    let mut req = client
+        .post(&url)
+        .header("Content-Type", "application/json")
+        .header("A2A-Version", "1.0")
+        .json(&body);
+    if let Some(token) = auth.filter(|t| !t.is_empty()) {
+        req = req.header("Authorization", token);
+    }
+    let resp = req.send().await.map_err(|e| e.to_string())?;
+    if !resp.status().is_success() {
+        return Err(format!("HTTP {}", resp.status().as_u16()));
+    }
+    let mut stream = resp.bytes_stream();
+    while let Some(chunk) = stream.next().await {
+        let bytes = chunk.map_err(|e| e.to_string())?;
+        // Relay raw bytes; the webview accumulates + parses SSE (handles frames split
+        // across chunks). Stop if the frontend dropped the channel (window closed /
+        // turn cancelled via the server-side CancelTask, which ends the stream).
+        if on_event.send(String::from_utf8_lossy(&bytes).into_owned()).is_err() {
+            break;
+        }
+    }
+    Ok(())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
+        .invoke_handler(tauri::generate_handler![chat_stream])
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         // In-app updates: checks the latest.json manifest on GitHub Releases,

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -11,6 +11,7 @@
   },
   "app": {
     "windows": [],
+    "withGlobalTauri": true,
     "security": {
       "csp": null
     }

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -227,6 +227,22 @@ export function isDesktopWebview(): boolean {
   }
 }
 
+/** A typed view of the bits of the Tauri `core` API the desktop streaming path uses,
+ * read off the `window.__TAURI__` global (the shell sets `withGlobalTauri: true`), so
+ * the shared web bundle needs no `@tauri-apps/api` dependency. Null outside the shell. */
+type TauriChannel<T> = { onmessage: (msg: T) => void };
+type TauriCore = {
+  invoke: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+  Channel: new <T>() => TauriChannel<T>;
+};
+function tauriCore(): TauriCore | null {
+  try {
+    return (window as unknown as { __TAURI__?: { core?: TauriCore } }).__TAURI__?.core ?? null;
+  } catch {
+    return null;
+  }
+}
+
 /** Operator bearer token, set in localStorage (`protoagent.authToken`). Sent on
  * every fetch-based API + A2A call so a token-configured deployment's console
  * authenticates against the server guard. Blank ⇒ no header — the default
@@ -978,12 +994,89 @@ export const api = {
     } = {},
     opts: { images?: { b64: string; mime: string; name: string }[]; model?: string } = {},
   ) {
-    // Desktop (WKWebView) can't read a streaming SSE body via fetch (see
-    // isDesktopWebview) — the turn would render as a blank assistant bubble. Take
-    // the non-streaming `/api/chat` path: one request, full reply, render once.
-    // No token-by-token streaming or tool-call cards here, but the turn always
-    // shows. Browsers fall through to the streaming `/a2a` path below.
+    // One A2A SendStreamingMessage body + one frame dispatcher, shared by the desktop
+    // (Tauri-relayed) and browser (fetch SSE) paths so both decode turns identically.
+    const rpcId = `web-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const buildBody = () => ({
+      jsonrpc: "2.0",
+      id: rpcId,
+      method: "SendStreamingMessage",
+      params: {
+        message: {
+          role: "ROLE_USER",
+          parts: [
+            { text: message },
+            ...(opts.images || []).map((img) => ({ raw: img.b64, mediaType: img.mime, filename: img.name })),
+          ],
+          messageId: rpcId,
+          contextId: sessionId,
+          ...(opts.model ? { metadata: { model: opts.model } } : {}),
+        },
+      },
+    });
+    const dispatchFrame = (frame: A2AFrame) => {
+      if (frame.error?.message) throw new Error(frame.error.message);
+      const result = frame.result;
+      if (!result) return;
+      const task = result.task ?? (result.kind === "task" ? result : undefined);
+      const statusUpdate = result.statusUpdate ?? (result.kind === "status-update" ? result : undefined);
+      const artifactUpdate = result.artifactUpdate ?? (result.kind === "artifact-update" ? result : undefined);
+      if (task?.id) {
+        handlers.onTaskId?.(task.id);
+        const terminalText = textFromTerminalTask(task);
+        if (terminalText) handlers.onText?.(terminalText, false);
+      }
+      if (statusUpdate) {
+        const state = statusUpdate.status?.state || "";
+        const parts = statusUpdate.status?.message?.parts;
+        const messageText = textFromParts(parts);
+        const reasoning = reasoningFromParts(parts);
+        if (reasoning) handlers.onReasoning?.(reasoning);
+        if (!reasoning) handlers.onStatus?.(messageText || state);
+        const toolEvent = toolEventFromParts(parts);
+        if (toolEvent) handlers.onToolCall?.(toolEvent);
+        const component = componentFromParts(parts);
+        if (component) handlers.onComponent?.(component);
+        if (state === "input-required" || state === "TASK_STATE_INPUT_REQUIRED") {
+          handlers.onInputRequired?.(hitlFromParts(parts) || { question: messageText });
+        }
+        if (state === "failed" || state === "TASK_STATE_FAILED") {
+          handlers.onFailed?.(messageText || "the turn failed");
+        }
+      }
+      if (artifactUpdate) {
+        const text = textFromParts(artifactUpdate.artifact?.parts);
+        if (text) handlers.onText?.(text, artifactUpdate.append !== false);
+      }
+    };
+
+    // Desktop: WKWebView can't read a streaming SSE body via fetch, so relay the /a2a
+    // SSE through the Tauri shell (Rust reqwest → IPC Channel) and parse frames with the
+    // SAME drainSseBuffer + dispatchFrame as the browser — real token-by-token + tool-card
+    // streaming. Falls back to the non-streaming `/api/chat` path if the native command
+    // is unavailable or fails, so it never regresses below the old render-once behavior.
     if (isDesktopWebview()) {
+      try {
+        const core = tauriCore();
+        if (!core) throw new Error("Tauri core API unavailable (withGlobalTauri off?)");
+        const channel = new core.Channel<string>();
+        let buf = "";
+        channel.onmessage = (chunk) => {
+          buf += chunk;
+          buf = drainSseBuffer(buf, dispatchFrame);
+        };
+        const tok = authToken();
+        await core.invoke("chat_stream", {
+          url: apiUrl("/a2a"),
+          body: buildBody(),
+          auth: tok ? `Bearer ${tok}` : null,
+          onEvent: channel,
+        });
+        handlers.onDone?.();
+        return;
+      } catch (err) {
+        console.warn("[desktop] native chat stream failed; falling back to /api/chat:", err);
+      }
       try {
         const res = await fetch(apiUrl("/api/chat"), {
           method: "POST",
@@ -1014,40 +1107,14 @@ export const api = {
       return;
     }
 
-    const rpcId = `web-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
     const response = await fetch(apiUrl("/a2a"), {
       method: "POST",
       headers: applyAuth(new Headers({ "Content-Type": "application/json", "A2A-Version": "1.0" })),
       signal: handlers.signal,
-      // A2A 1.0 (a2a-sdk): the streaming RPC is `SendStreamingMessage` (0.3's
-      // `message/stream` is gone → -32601 Method not found, the cause of a
-      // never-resolving spinner). Message uses ROLE_USER, member-discriminated
-      // parts (`{text}`, not `{kind,text}`), and carries messageId + contextId.
-      body: JSON.stringify({
-        jsonrpc: "2.0",
-        id: rpcId,
-        method: "SendStreamingMessage",
-        params: {
-          message: {
-            role: "ROLE_USER",
-            // Native vision: image parts ride as proto-JSON Parts (raw=base64
-            // bytes + mediaType) the executor turns into multimodal content.
-            parts: [
-              { text: message },
-              ...(opts.images || []).map((img) => ({
-                raw: img.b64,
-                mediaType: img.mime,
-                filename: img.name,
-              })),
-            ],
-            messageId: rpcId,
-            contextId: sessionId,
-            // Per-tab model override — the executor merges message metadata into
-            // request_metadata, which the chat layer reads as the turn's model.
-            ...(opts.model ? { metadata: { model: opts.model } } : {}),
-          },
-        },
-      }),
+      // A2A 1.0 streaming RPC `SendStreamingMessage`; body built by buildBody()
+      // (shared with the desktop path) — ROLE_USER, member-discriminated parts,
+      // messageId + contextId, optional image parts + per-tab model metadata.
+      body: JSON.stringify(buildBody()),
     });
 
     if (!response.ok) {
@@ -1055,52 +1122,7 @@ export const api = {
       throw new Error(`${response.status} ${response.statusText}`);
     }
 
-    await consumeSse(response, (frame) => {
-      if (frame.error?.message) throw new Error(frame.error.message);
-      const result = frame.result;
-      if (!result) return;
-
-      // A2A 1.0 nests the event (task / statusUpdate / artifactUpdate); fall
-      // back to the flat 0.3 `kind`-tagged shape.
-      const task = result.task ?? (result.kind === "task" ? result : undefined);
-      const statusUpdate =
-        result.statusUpdate ?? (result.kind === "status-update" ? result : undefined);
-      const artifactUpdate =
-        result.artifactUpdate ?? (result.kind === "artifact-update" ? result : undefined);
-
-      if (task?.id) {
-        handlers.onTaskId?.(task.id);
-        const terminalText = textFromTerminalTask(task);
-        if (terminalText) handlers.onText?.(terminalText, false);
-      }
-
-      if (statusUpdate) {
-        const state = statusUpdate.status?.state || "";
-        const parts = statusUpdate.status?.message?.parts;
-        const messageText = textFromParts(parts);
-        const reasoning = reasoningFromParts(parts);
-        if (reasoning) handlers.onReasoning?.(reasoning);
-        // A reasoning-only frame shouldn't blank the status line to bare "working".
-        if (!reasoning) handlers.onStatus?.(messageText || state);
-        const toolEvent = toolEventFromParts(parts);
-        if (toolEvent) handlers.onToolCall?.(toolEvent);
-        const component = componentFromParts(parts);
-        if (component) handlers.onComponent?.(component);
-        // HITL pause: the turn parked awaiting the operator (0.3 `input-required`
-        // / 1.0 `TASK_STATE_INPUT_REQUIRED`). Surface the form/question payload.
-        if (state === "input-required" || state === "TASK_STATE_INPUT_REQUIRED") {
-          handlers.onInputRequired?.(hitlFromParts(parts) || { question: messageText });
-        }
-        if (state === "failed" || state === "TASK_STATE_FAILED") {
-          handlers.onFailed?.(messageText || "the turn failed");
-        }
-      }
-
-      if (artifactUpdate) {
-        const text = textFromParts(artifactUpdate.artifact?.parts);
-        if (text) handlers.onText?.(text, artifactUpdate.append !== false);
-      }
-    });
+    await consumeSse(response, dispatchFrame);
     // The SSE stream closing is the canonical "turn complete" signal in A2A 1.0
     // (terminal-by-state, no `final` flag) — resolve the spinner here.
     handlers.onDone?.();


### PR DESCRIPTION
WKWebView won't deliver a streaming SSE `fetch` body chunk-by-chunk, so desktop chat fell back to a single non-streaming `/api/chat` request — **no live tokens, no tool-call cards** (the reported issue). This makes it stream for real by relaying the `/a2a` SSE through the **Rust shell**.

- **Rust `chat_stream` command** (reqwest + futures-util): runs the `/a2a` `SendStreamingMessage` POST and relays each raw chunk to the webview over an IPC `Channel`. Local sidecar is `http://127.0.0.1`, so reqwest needs no TLS backend.
- **`withGlobalTauri: true`** so the shared web bundle reaches `invoke`/`Channel` via `window.__TAURI__.core` — **no `@tauri-apps/api` dep** added to `apps/web` (typed via a small `tauriCore()` accessor).
- **`api.ts`**: extracted `buildBody` + `dispatchFrame` (shared by both paths). The desktop branch feeds the relayed chunks through the **same `drainSseBuffer` + `dispatchFrame`** as the browser → token-by-token text + tool cards. **Falls back** to the old `/api/chat` path on any error — never worse than today.

Validation: `cargo check` clean, `api.ts` typechecks clean. End-to-end is the next `.0` desktop build (the fallback guarantees no regression if the native path misbehaves). Custom app commands are allowed by default under Tauri v2's ACL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)