### PR TITLE
feat(desktop): in-app update notice with changelog (orbis-style)

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -381,11 +381,18 @@ jobs:
             echo "::notice::No signed updater bundles on the release — skipping latest.json (in-app updates disabled for ${TAG})."
             exit 0
           fi
+          # Use the real GitHub Release body as the updater notes, so the in-app
+          # UpdateNotice shows the actual changelog (not a generic placeholder). By the
+          # time this fan-in runs (after the long desktop matrix), release.yml has long
+          # since created + populated the release. Fall back to the placeholder if the
+          # body is somehow empty.
+          NOTES="$(gh release view "$TAG" --repo "${{ github.repository }}" --json body -q .body 2>/dev/null || true)"
+          [ -z "$NOTES" ] && NOTES="protoAgent ${TAG} — see the GitHub Release for details."
           npx --yes -p '@protolabsai/release-tools@latest' build-updater-manifest \
             --version "$VERSION" \
             --dist updater-dist \
             --base-url "https://github.com/${{ github.repository }}/releases/download/${TAG}" \
-            --notes "protoAgent ${TAG} — see the GitHub Release for details." \
+            --notes "$NOTES" \
             --out latest.json
           cat latest.json
           # --repo is required: this job never checks out the repo (it only

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -303,10 +303,70 @@ async fn chat_stream(
     Ok(())
 }
 
+#[derive(serde::Serialize, Clone)]
+struct UpdateInfo {
+    version: String,
+    current: String,
+    /// The release notes / changelog (latest.json `notes`) — shown in the in-app pill.
+    notes: String,
+}
+
+#[derive(serde::Serialize, Clone)]
+#[serde(rename_all = "camelCase")]
+struct DownloadProgress {
+    chunk_length: u64,
+    content_length: Option<u64>,
+}
+
+/// Check the updater manifest for a newer build, returning its version + notes for the
+/// in-app UpdateNotice (the web pill renders the changelog) — the typed counterpart to
+/// the tray's native-dialog `check_for_updates`. None when up to date; Err on failure.
+#[tauri::command]
+async fn updater_check<R: Runtime>(app: AppHandle<R>) -> Result<Option<UpdateInfo>, String> {
+    let updater = app.updater().map_err(|e| e.to_string())?;
+    let current = app.package_info().version.to_string();
+    match updater.check().await.map_err(|e| e.to_string())? {
+        Some(u) => Ok(Some(UpdateInfo {
+            version: u.version.clone(),
+            current,
+            notes: u.body.clone().unwrap_or_default(),
+        })),
+        None => Ok(None),
+    }
+}
+
+/// Download + install the available update (signature-verified by the plugin against the
+/// embedded pubkey), streaming progress to the webview over an IPC Channel, then relaunch.
+#[tauri::command]
+async fn updater_install<R: Runtime>(
+    app: AppHandle<R>,
+    on_progress: tauri::ipc::Channel<DownloadProgress>,
+) -> Result<(), String> {
+    let updater = app.updater().map_err(|e| e.to_string())?;
+    let update = updater
+        .check()
+        .await
+        .map_err(|e| e.to_string())?
+        .ok_or_else(|| "no update available".to_string())?;
+    update
+        .download_and_install(
+            move |chunk, total| {
+                let _ = on_progress.send(DownloadProgress {
+                    chunk_length: chunk as u64,
+                    content_length: total,
+                });
+            },
+            || {},
+        )
+        .await
+        .map_err(|e| e.to_string())?;
+    app.restart();
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![chat_stream])
+        .invoke_handler(tauri::generate_handler![chat_stream, updater_check, updater_install])
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         // In-app updates: checks the latest.json manifest on GitHub Releases,
@@ -388,11 +448,11 @@ pub fn run() {
                 Err(e) => log::error!("tray setup failed; staying in the dock: {e}"),
             }
 
-            // Silent launch check (release builds only — `tauri dev` runs at the
-            // in-tree placeholder version and would always see an "update").
-            if !cfg!(debug_assertions) {
-                check_for_updates(app.handle().clone(), false);
-            }
+            // Ambient update checks are now owned by the web UpdateNotice (an in-app
+            // pill + changelog, polling `updater_check` ~10s after boot then every 6h) —
+            // so the old silent launch check is gone, to avoid double-prompting (a native
+            // dialog AND the pill). The tray "Check for updates" still does an interactive
+            // native check (see the tray handler) as a manual fallback.
             Ok(())
         })
         .on_window_event(|window, event| {

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -64,6 +64,7 @@ import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useEffect, useRef, useState, useSyncExternalStore } from "react";
 import type { ComponentType, LazyExoticComponent, ReactNode } from "react";
 import { FleetTurnWatch } from "./FleetTurnWatch";
+import { UpdateNotice } from "./UpdateNotice";
 import { BackgroundWatch } from "./BackgroundWatch";
 import { ChatResumeWatch } from "./ChatResumeWatch";
 import { BackgroundJobs } from "./BackgroundJobs";
@@ -678,6 +679,8 @@ export function App() {
           finishes (per-window SSE can't see it — this watches the other slugs'
           persisted in-flight turns and polls their durable tasks via the hub). */}
       <FleetTurnWatch />
+      {/* In-app update notice (desktop/Tauri): ambient pill → changelog + Update & Restart. */}
+      <UpdateNotice />
       {/* Background subagents (ADR 0050): when a detached job finishes, push its result
           live into the spawning chat (a system message + toast) if it's still open —
           instead of waiting for the next message to surface it. */}

--- a/apps/web/src/app/UpdateNotice.tsx
+++ b/apps/web/src/app/UpdateNotice.tsx
@@ -1,0 +1,124 @@
+import { useEffect, useState } from "react";
+import { Button } from "@protolabsai/ui/primitives";
+import { api, isDesktopWebview } from "../lib/api";
+
+/**
+ * In-app update notice for the desktop shell (Tauri). Periodically checks the signed
+ * `latest.json`; when a newer build is published it surfaces an ambient pill — click it
+ * for the **changelog** + a one-click "Update & Restart". User-driven (we notify; you
+ * choose when to apply — no silent background install). Silent in dev / browser /
+ * offline / when up to date. The updater work runs in the Rust shell (`updater_check`/
+ * `updater_install`); this is the UX. Mirrors the orbis `UpdateNotice` pattern.
+ */
+
+const FIRST_CHECK_MS = 10_000; // let the boot settle
+const CHECK_INTERVAL_MS = 6 * 60 * 60 * 1000; // re-check every 6h
+
+type UpdateInfo = { version: string; current: string; notes: string };
+type Phase = "available" | "downloading" | "error";
+
+export function UpdateNotice() {
+  const [update, setUpdate] = useState<UpdateInfo | null>(null);
+  const [open, setOpen] = useState(false);
+  const [phase, setPhase] = useState<Phase>("available");
+  const [pct, setPct] = useState(0);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!isDesktopWebview()) return;
+    let cancelled = false;
+    const run = async () => {
+      if (cancelled || update) return;
+      const u = await api.checkUpdate();
+      if (!cancelled && u) setUpdate(u);
+    };
+    const first = window.setTimeout(run, FIRST_CHECK_MS);
+    const timer = window.setInterval(run, CHECK_INTERVAL_MS);
+    return () => {
+      cancelled = true;
+      window.clearTimeout(first);
+      window.clearInterval(timer);
+    };
+  }, [update]);
+
+  if (!update) return null;
+
+  const install = async () => {
+    setPhase("downloading");
+    setError(null);
+    setPct(0);
+    try {
+      let got = 0;
+      let total = 0;
+      await api.installUpdate((e) => {
+        if (e.contentLength) total = e.contentLength;
+        got += e.chunkLength;
+        if (total > 0) setPct(Math.min(100, Math.round((got / total) * 100)));
+      });
+      // On success the Rust command relaunches the app — we won't reach here.
+    } catch (e) {
+      setPhase("error");
+      setError(e instanceof Error ? e.message : String(e));
+    }
+  };
+
+  if (!open) {
+    return (
+      <button
+        type="button"
+        className="update-notice-pill"
+        onClick={() => setOpen(true)}
+        aria-label={`Update available: ${update.version}`}
+      >
+        <span className="update-notice-dot" />
+        Update · {update.version}
+      </button>
+    );
+  }
+
+  return (
+    <div className="update-notice-panel" role="dialog" aria-label="Update available">
+      <div className="update-notice-head">
+        <span>
+          Update available <span className="update-notice-ver">{update.version}</span>
+        </span>
+        <button
+          type="button"
+          className="update-notice-x"
+          onClick={() => setOpen(false)}
+          aria-label="Dismiss"
+        >
+          ✕
+        </button>
+      </div>
+
+      {update.notes ? (
+        <div className="update-notice-notes">{update.notes}</div>
+      ) : (
+        <p className="update-notice-empty">A newer version is ready (you have {update.current}).</p>
+      )}
+
+      {phase === "downloading" && (
+        <div className="update-notice-progress">
+          <div className="update-notice-bar">
+            <div className="update-notice-fill" style={{ width: `${pct}%` }} />
+          </div>
+          <div className="update-notice-pct">Downloading… {pct}%</div>
+        </div>
+      )}
+
+      {phase === "error" && error && <p className="update-notice-err">Update failed: {error}</p>}
+
+      <div className="update-notice-actions">
+        {phase !== "downloading" && (
+          <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+            Later
+          </Button>
+        )}
+        <Button variant="primary" size="sm" onClick={install} disabled={phase === "downloading"}>
+          {phase === "downloading" ? "Updating…" : phase === "error" ? "Retry" : "Update & Restart"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1885,3 +1885,122 @@ textarea {
   animation-duration: 0.35s;
   animation-timing-function: ease;
 }
+
+/* In-app update notice (desktop/Tauri) — ambient pill + changelog panel (UpdateNotice.tsx).
+   Top-right under the topbar; uses only DS --pl-* tokens + currentColor so it themes with
+   whatever palette is active. */
+.update-notice-pill {
+  position: fixed;
+  top: 44px;
+  right: 12px;
+  z-index: 40;
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  border: 1px solid var(--pl-color-border);
+  background: var(--pl-color-bg-raised);
+  color: inherit;
+  font-size: 12px;
+  cursor: pointer;
+  box-shadow: var(--pl-shadow-popover);
+}
+.update-notice-pill:hover {
+  background: var(--pl-color-bg-inset);
+}
+.update-notice-dot {
+  width: 6px;
+  height: 6px;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.7;
+}
+.update-notice-panel {
+  position: fixed;
+  top: 44px;
+  right: 12px;
+  z-index: 40;
+  width: 320px;
+  max-width: calc(100vw - 24px);
+  padding: var(--pl-space-4, 16px);
+  border-radius: 10px;
+  border: 1px solid var(--pl-color-border);
+  background: var(--pl-color-bg-raised);
+  box-shadow: var(--pl-shadow-popover);
+  font-size: 13px;
+}
+.update-notice-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.update-notice-ver {
+  font-family: ui-monospace, monospace;
+  font-size: 12px;
+  opacity: 0.75;
+}
+.update-notice-x {
+  border: none;
+  background: none;
+  cursor: pointer;
+  color: inherit;
+  opacity: 0.6;
+  font-size: 12px;
+  line-height: 1;
+}
+.update-notice-x:hover {
+  opacity: 1;
+}
+.update-notice-notes {
+  margin-top: 8px;
+  max-height: 160px;
+  overflow-y: auto;
+  white-space: pre-wrap;
+  font-size: 12px;
+  opacity: 0.85;
+  line-height: 1.45;
+}
+.update-notice-empty {
+  margin-top: 8px;
+  font-size: 12px;
+  opacity: 0.7;
+}
+.update-notice-progress {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.update-notice-bar {
+  height: 4px;
+  border-radius: 999px;
+  background: var(--pl-color-bg-inset);
+  overflow: hidden;
+}
+.update-notice-fill {
+  height: 100%;
+  border-radius: 999px;
+  background: currentColor;
+  opacity: 0.8;
+  transition: width 0.2s ease;
+}
+.update-notice-pct {
+  text-align: center;
+  font-size: 11px;
+  opacity: 0.7;
+  font-variant-numeric: tabular-nums;
+}
+.update-notice-err {
+  margin-top: 8px;
+  font-size: 12px;
+  color: #e5484d;
+}
+.update-notice-actions {
+  margin-top: 12px;
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+}

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1144,6 +1144,31 @@ export const api = {
     });
   },
 
+  /** Desktop in-app updater (Tauri). `checkUpdate` returns the available build's
+   * version + notes (the changelog from latest.json) or null (up to date / not
+   * desktop / offline). `installUpdate` downloads + installs + relaunches, streaming
+   * download progress. Both go through the Rust `updater_*` commands via the Tauri
+   * global (withGlobalTauri); they no-op outside the desktop shell. */
+  async checkUpdate(): Promise<{ version: string; current: string; notes: string } | null> {
+    const core = tauriCore();
+    if (!core) return null;
+    try {
+      return (await core.invoke<{ version: string; current: string; notes: string } | null>("updater_check")) ?? null;
+    } catch {
+      return null; // not in Tauri / no manifest / offline — stay quiet
+    }
+  },
+  async installUpdate(
+    onProgress: (e: { chunkLength: number; contentLength: number | null }) => void,
+  ): Promise<void> {
+    const core = tauriCore();
+    if (!core) throw new Error("Tauri core API unavailable");
+    const channel = new core.Channel<{ chunkLength: number; contentLength: number | null }>();
+    channel.onmessage = onProgress;
+    // Resolves only if install fails — on success the Rust command relaunches the app.
+    await core.invoke("updater_install", { onProgress: channel });
+  },
+
   // Mid-turn steering: queue a user message into a RUNNING turn (folded in at the
   // next model call by SteeringMiddleware) without stopping the stream. The client
   // `id` lets the turn-end reconcile tell consumed from arrived-too-late.


### PR DESCRIPTION
Replaces the bare native update dialog with an ambient, user-driven **in-app notice that shows the changelog** — the orbis `UpdateNotice` pattern. A pill surfaces top-right when a newer build is published; click it for the **release notes** + one-click **"Update & Restart"** with a download progress bar.

- **Rust** `updater_check` (→ `{version, current, notes}`) + `updater_install` (download+install+relaunch, streaming progress over an IPC Channel), reusing `tauri_plugin_updater`.
- **api.ts** `checkUpdate`/`installUpdate` reach them via the Tauri global (`withGlobalTauri`) — no `@tauri-apps/api` dep. **`UpdateNotice.tsx`** is the UX (pill + changelog panel + progress), mounted in the shell, DS `Button`, themed with `--pl-*` tokens; no-op in browser/dev.
- Removed the **silent launch check** (the web notice owns ambient polling now — ~10s after boot, then every 6h) so there's no double-prompt; the tray "Check for updates" stays as a manual native fallback.
- **desktop-build fan-in:** `latest.json` notes are now the **real GitHub Release body** (the changelog the pill shows), not a placeholder.

`cargo check` clean; web typechecks clean (the only tsc errors are the pre-existing ChatSurface `onReorder` — a stale-deps artifact CI's fresh install resolves). Ships/validates on the next `.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)