### PR TITLE
feat(delegates): ship the delegate registry enabled by default

### DIFF
--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -30,9 +30,6 @@ Settings — each grants local authority and deserves a deliberate edit):
 
 ```yaml
 # config/langgraph-config.yaml
-plugins:
-  enabled: [delegates]
-
 delegates:
   - name: proto                 # the name you pass to delegate_to(target=…)
     type: acp
@@ -47,8 +44,9 @@ delegates:
     # deny_kinds: [execute, delete]   # override: kinds to deny
 ```
 
-Enabling a plugin needs a **restart** (plugin routes/tools wire once at process
-init); editing the `delegates` list itself hot-reloads on Save & Reload.
+The delegates registry is **enabled by default** — there's no plugin to turn on.
+Declaring (or editing) the `delegates` list hot-reloads on **Save & Reload**: the
+first delegate you add registers `delegate_to` for the next turn, no restart.
 
 ### Other coding agents
 

--- a/docs/guides/delegates.md
+++ b/docs/guides/delegates.md
@@ -20,7 +20,7 @@ the next turn, no restart). See [ADR 0025](/adr/0025-unified-delegate-registry-a
 
 ## Manage in the console (panel)
 
-With the plugin enabled, open **Settings → Plugins → Delegates**. The panel:
+Open **Settings → Plugins → Delegates** (the registry is on by default). The panel:
 
 - **lists** your delegates with a type badge, a `secret set` / `⚠ unconfigured`
   marker, a **live health dot** (a background prober probes each delegate
@@ -34,13 +34,13 @@ With the plugin enabled, open **Settings → Plugins → Delegates**. The panel:
 Saving writes the config + secret and hot-reloads, so the new roster is live on
 the next turn.
 
-## Enable it
+## Declare delegates
+
+The registry is **enabled by default** — it does nothing until you declare a
+delegate, so just add entries (no plugin to turn on):
 
 ```yaml
 # config/langgraph-config.yaml
-plugins:
-  enabled: [delegates]
-
 delegates:
   - name: helm                      # the name the LLM passes to delegate_to(target=…)
     type: a2a

--- a/plugins/delegates/__init__.py
+++ b/plugins/delegates/__init__.py
@@ -7,8 +7,9 @@ gateway-only model) with one hot-swappable roster.
 
 PR1 (this slice): the registry + `delegate_to` + the three adapters, configured
 via the ``delegates`` config section and hot-reloaded by Save & Reload. The CRUD
-REST API (PR2) and the React panel (PR3) build on this. Ships disabled — enable
-with ``plugins: { enabled: [delegates] }`` and declare delegates in config.
+REST API (PR2) and the React panel (PR3) build on this. Enabled by default — it
+contributes ``delegate_to`` only once you declare a delegate in config (a no-op
+until then), so the gate is the delegate, not a plugin toggle.
 """
 
 from __future__ import annotations
@@ -98,10 +99,11 @@ def register(registry) -> None:
             delegates = nested
     reg = DelegateRegistry(delegates)
     if not reg.names():
-        log.warning(
-            "[delegates] enabled but no delegates configured — add entries under "
-            "`delegates` (see docs/guides/delegates.md), or use the Delegates panel. "
-            "No delegate_to tool registered yet."
+        # The default state for a fresh install (the plugin is always-on): no
+        # delegates declared ⇒ no `delegate_to` tool. Not an anomaly — debug, not warn.
+        log.debug(
+            "[delegates] no delegates declared — `delegate_to` not registered. Add "
+            "entries under `delegates` (docs/guides/delegates.md) or use the Delegates panel."
         )
         return
     registry.register_tool(_build_delegate_to(reg))

--- a/plugins/delegates/protoagent.plugin.yaml
+++ b/plugins/delegates/protoagent.plugin.yaml
@@ -9,8 +9,9 @@ description: >-
   docs/guides/delegates.md.
 
   Declare delegates in a top-level `delegates:` list (a list, ORBIS-style — not a
-  plugin config section). Ships DISABLED; enable with
-  `plugins: { enabled: [delegates] }`.
+  plugin config section). Enabled by default — it contributes the `delegate_to`
+  tool ONLY once you declare at least one delegate, so it's a no-op until then.
+  (Turn it off explicitly with `plugins: { disabled: [delegates] }`.)
 
   Example (langgraph-config.yaml):
     delegates:
@@ -31,7 +32,10 @@ description: >-
         args: ["--acp"]
         workdir: ~/dev/my-repo
         permissions: allowlist
-enabled: false
+# Always-on (ADR 0025): the registry ships enabled, but stays a no-op until a
+# delegate is declared (register() adds `delegate_to` only when the roster is
+# non-empty). So the gate is "did you declare a delegate", not "did you enable a plugin".
+enabled: true
 
 # Declarative only (not yet enforced) — surfaced in the console for transparency.
 capabilities:


### PR DESCRIPTION
Reaching a delegate took **two** steps — `plugins: { enabled: [delegates] }` *and* declaring the delegate. But the plugin is already a clean no-op until a delegate exists (`register()` only contributes `delegate_to` when the roster is non-empty), so the enable toggle was pure friction.

**Always-on now, gated solely by declaring a delegate:**
- manifest `enabled: true` (disable explicitly via `plugins: { disabled: [delegates] }`)
- empty-roster log drops **warn → debug** (enabled-but-empty is the normal default for a fresh install)
- docs (coding-agents, delegates) drop the "enable the plugin" step — declare a delegate, Save & Reload registers `delegate_to`, no restart

29 delegates tests green; no behavior change beyond the shipped default + log level. Validated alongside a live end-to-end test of a `claude-code` ACP delegate (`npx @zed-industries/claude-code-acp`) running on Opus.

🤖 Generated with [Claude Code](https://claude.com/claude-code)