### PR TITLE
feat(model): thinking-mode toggle + reasoning effort for OpenAI-compatible models

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -33,6 +33,13 @@ model:
   #   presence_penalty: 0.0
   #   repetition_penalty: 1.05
   #   chat_template_kwargs: { preserve_thinking: true }
+  # Reasoning controls for OpenAI-compatible reasoning models (DeepSeek, the
+  # OpenAI o-series). Both opt-in; omit to inherit the provider default.
+  # `thinking` rides extra_body (enabled|disabled); `reasoning_effort` is sent
+  # top-level (low|medium|high|max). NOTE: with thinking on, DeepSeek ignores
+  # temperature / top_p / penalties.
+  #   thinking: enabled
+  #   reasoning_effort: high
 
 subagents:
   researcher:

--- a/graph/config.py
+++ b/graph/config.py
@@ -234,6 +234,17 @@ class LangGraphConfig:
     repetition_penalty: float | None = None
     chat_template_kwargs: dict | None = None
 
+    # Reasoning controls for OpenAI-compatible reasoning models (DeepSeek, the
+    # OpenAI o-series, etc. behind the gateway). Both opt-in — unset means "let the
+    # provider/model card decide", so an un-tuned config is a true no-op (#1113).
+    #   ``thinking`` — "" (inherit) | "enabled" | "disabled". When set, rides
+    #     ``extra_body`` as ``{"thinking": {"type": ...}}`` (DeepSeek's spelling).
+    #   ``reasoning_effort`` — None (inherit) | "low" | "medium" | "high" | "max".
+    #     A native ChatOpenAI param, sent top-level. DeepSeek maps low/medium→high
+    #     and xhigh→max server-side; we just pass the string through.
+    thinking: str = ""
+    reasoning_effort: str | None = None
+
     # Subagents — template ships one example, `researcher` (see
     # graph/subagents/config.py). Add fields here as you add entries to
     # SUBAGENT_REGISTRY. Tool/max_turns here mirror the registry default and
@@ -782,6 +793,8 @@ class LangGraphConfig:
             presence_penalty=model.get("presence_penalty", cls.presence_penalty),
             repetition_penalty=model.get("repetition_penalty", cls.repetition_penalty),
             chat_template_kwargs=model.get("chat_template_kwargs", cls.chat_template_kwargs),
+            thinking=model.get("thinking", cls.thinking),
+            reasoning_effort=model.get("reasoning_effort", cls.reasoning_effort),
             knowledge_middleware=middleware.get("knowledge", cls.knowledge_middleware),
             audit_middleware=middleware.get("audit", cls.audit_middleware),
             memory_middleware=middleware.get("memory", cls.memory_middleware),

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -66,6 +66,10 @@ def _build_llm_kwargs(config: LangGraphConfig) -> dict:
         kwargs["top_p"] = config.top_p
     if config.presence_penalty is not None:
         kwargs["presence_penalty"] = config.presence_penalty
+    # Reasoning effort (#1113) — a native ChatOpenAI param, so it goes top-level
+    # (not extra_body). Only sent when set, so the model card default wins otherwise.
+    if config.reasoning_effort:
+        kwargs["reasoning_effort"] = config.reasoning_effort
 
     extra_body: dict = {}
     if config.top_k is not None and config.top_k >= 0:
@@ -74,6 +78,10 @@ def _build_llm_kwargs(config: LangGraphConfig) -> dict:
         extra_body["repetition_penalty"] = config.repetition_penalty
     if config.chat_template_kwargs:
         extra_body["chat_template_kwargs"] = dict(config.chat_template_kwargs)
+    # Thinking mode (#1113) — DeepSeek's spelling rides extra_body like
+    # chat_template_kwargs; "" means inherit (omit it entirely).
+    if config.thinking in ("enabled", "disabled"):
+        extra_body["thinking"] = {"type": config.thinking}
     if extra_body:
         kwargs["extra_body"] = extra_body
 

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -88,6 +88,27 @@ FIELDS: list[Field] = [
     Field("model.temperature", "temperature", "Temperature", "number", "Model", minimum=0, maximum=2),
     Field("model.max_tokens", "max_tokens", "Max output tokens", "number", "Model", minimum=1),
     Field(
+        "model.thinking",
+        "thinking",
+        "Thinking mode",
+        "select",
+        "Model",
+        "Reasoning models on an OpenAI-compatible gateway (e.g. DeepSeek) can toggle their "
+        "thinking/reasoning step. Blank = inherit the provider default. Note: with thinking on, "
+        "DeepSeek ignores temperature / top-p / penalties.",
+        options=["", "enabled", "disabled"],
+    ),
+    Field(
+        "model.reasoning_effort",
+        "reasoning_effort",
+        "Reasoning effort",
+        "select",
+        "Model",
+        "How hard a reasoning model thinks. Blank = inherit the provider default. DeepSeek maps "
+        "low/medium to high and treats max as the ceiling; the OpenAI o-series uses these directly.",
+        options=["", "low", "medium", "high", "max"],
+    ),
+    Field(
         "model.vision",
         "model_vision",
         "Vision (native images)",

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -131,6 +131,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "prompt_cache_enabled": True,
     "prompt_cache_force": False,
     "prompt_cache_ttl": "5m",
+    "reasoning_effort": None,
     "repetition_penalty": None,
     "request_timeout": 120,
     "researcher": SubagentDef(
@@ -156,6 +157,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "inbox_retention_days": 90,
     "activity_retention_days": 90,
     "temperature": 0.2,
+    "thinking": "",
     "tools_deferred_enabled": False,
     "tools_deferred_keep": [],
     "tools_disabled": [],
@@ -273,7 +275,9 @@ CONFIG_TO_DICT_GOLDEN = {
         "max_tokens": 32768,
         "name": "protolabs/reasoning",
         "provider": "openai",
+        "reasoning_effort": None,
         "temperature": 0.2,
+        "thinking": "",
         "vision": False,
     },
     "network": {
@@ -353,6 +357,8 @@ EMITTED_ATTRS = {
     "max_tokens",
     "model_vision",
     "max_iterations",
+    "thinking",
+    "reasoning_effort",
     # subagents.researcher
     "researcher",
     # middleware.*

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -54,6 +54,45 @@ def test_negative_top_k_means_default_and_is_omitted():
     assert "extra_body" not in kwargs
 
 
+def test_reasoning_controls_omitted_by_default():
+    # #1113 — thinking/reasoning_effort are opt-in: unset → nothing emitted,
+    # so the provider/model-card default wins and existing configs are unchanged.
+    kwargs = _build_llm_kwargs(LangGraphConfig())
+    assert "reasoning_effort" not in kwargs
+    assert "extra_body" not in kwargs
+
+
+def test_reasoning_effort_is_top_level():
+    # #1113 — reasoning_effort is a native ChatOpenAI param, sent top-level
+    # (NOT extra_body).
+    kwargs = _build_llm_kwargs(LangGraphConfig(reasoning_effort="high"))
+    assert kwargs["reasoning_effort"] == "high"
+    assert "extra_body" not in kwargs
+
+
+def test_thinking_rides_extra_body():
+    # #1113 — DeepSeek's thinking toggle rides extra_body as {"thinking": {"type": ...}}.
+    for state in ("enabled", "disabled"):
+        kwargs = _build_llm_kwargs(LangGraphConfig(thinking=state))
+        assert kwargs["extra_body"]["thinking"] == {"type": state}
+
+
+def test_blank_thinking_is_omitted():
+    # "" is the inherit sentinel — no thinking key emitted.
+    kwargs = _build_llm_kwargs(LangGraphConfig(thinking=""))
+    assert "extra_body" not in kwargs
+
+
+def test_from_yaml_reads_reasoning_controls(tmp_path):
+    import yaml
+
+    p = tmp_path / "c.yaml"
+    p.write_text(yaml.safe_dump({"model": {"thinking": "disabled", "reasoning_effort": "max"}}))
+    cfg = LangGraphConfig.from_yaml(p)
+    assert cfg.thinking == "disabled"
+    assert cfg.reasoning_effort == "max"
+
+
 def test_from_yaml_reads_sampling_block(tmp_path):
     import yaml
 


### PR DESCRIPTION
## Summary

Adds a first-class config + settings-UI surface for the two reasoning controls DeepSeek (and the OpenAI o-series) expose on the OpenAI-compatible API, so users running such a provider as their default model can toggle thinking and tune effort **without** hand-editing `model.chat_template_kwargs`.

Closes #1113.

## What changed (94 insertions, 6 files — additive, backend + schema only)

- **`graph/config.py`** — two opt-in dataclass fields:
  - `thinking: str = ""` → `"" (inherit) | "enabled" | "disabled"`
  - `reasoning_effort: str | None = None` → `low | medium | high | max`
  - parsed in `from_dict` alongside the existing sampling params.
- **`graph/llm.py`** (`_build_llm_kwargs`):
  - `reasoning_effort` is a **native `ChatOpenAI` field** (verified against the pinned `langchain-openai`), so it's sent **top-level** — not `extra_body`.
  - `thinking` rides `extra_body` as `{"thinking": {"type": ...}}` (DeepSeek's spelling), mirroring the existing `chat_template_kwargs` precedent.
  - **Both emitted only when set** → unset is a true no-op; the gateway/model-card default wins and existing configs are unaffected.
- **`graph/settings_schema.py`** — two `select` `Field`s in the **Model** section, each with a blank "inherit" option. The console **auto-renders** them via the existing DS `Select`, so there are **no `apps/web` changes and nothing new needed from `@protolabsai/ui`**.
- **`config/langgraph-config.example.yaml`** — commented usage hints next to the existing sampling examples.
- **Tests** — `tests/test_llm.py` (top-level effort, `extra_body` thinking, opt-in omission, `from_yaml`) and `tests/test_config_roundtrip.py` (both goldens + `EMITTED_ATTRS`).

## Resolved open questions (from the issue)

- **Provider gating?** → **No allowlist** — pass-through when set, mirroring how `top_p`/`top_k` already work. Default-unset = no behavior change.
- **Hide `temperature`/`top_p`/penalties when thinking is on?** → **Intentionally not wired.** That rule is DeepSeek-specific; protoAgent routes many providers through one OpenAI-compatible gateway, so hiding fields globally would mislead non-DeepSeek users. (The `depends_on` infra from #963 is available if we ever want it per-provider.)

## Design system

No component-library work required — the settings surface is 100% schema-driven and both new fields render through the existing DS `Select`. Live schema output:

```
model.thinking         -> select ['', 'enabled', 'disabled']        default=''
model.reasoning_effort -> select ['', 'low','medium','high','max']  default=None
```

## Test plan / gates (CI-mirroring set from PROTO.md)

- `ruff check` ✅
- `lint-imports` ✅ (3 contracts kept)
- `pytest tests/test_llm.py tests/test_config_roundtrip.py` ✅ (36) + all settings/schema/config tests ✅ (127)
- No web changes → web gates N/A.

> Note: `test_config_roundtrip.py`'s `api_key==""` goldens fail locally **only** when a populated `config/secrets.yaml` overlays a real key onto `from_yaml(example)`; they pass in clean CI (verified with the file moved aside). Unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)