### PR TITLE
fix(delegates): first-class Claude Code ACP support + real-handshake probe (#1116)

### DIFF
--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -56,25 +56,30 @@ Any agent that speaks ACP works — just point `command`/`args` at it:
 
 ```yaml
 delegates:
-  - { name: proto,       type: acp, command: proto, args: ["--acp"],                         workdir: ~/dev/my-repo }
-  - { name: claude-code, type: acp, command: npx,   args: ["--yes", "@zed-industries/claude-code-acp"], workdir: ~/dev/my-repo }
-  - { name: codex,       type: acp, command: codex, args: ["acp"],                            workdir: ~/dev/my-repo }
+  - { name: proto,       type: acp, command: proto,       args: ["--acp"],            workdir: ~/dev/my-repo }
+  - { name: claude-code, type: acp, command: claude-code, args: [],                   workdir: ~/dev/my-repo }   # alias → claude-agent-acp
+  - { name: codex,       type: acp, command: codex,       args: ["acp"],              workdir: ~/dev/my-repo }
   - { name: gemini,      type: acp, command: gemini, args: ["--experimental-acp"],            workdir: ~/dev/my-repo }
 ```
 
 The binary must be installed and on the `PATH` of the process running protoAgent.
-A missing binary returns a clear error string to the agent (it doesn't crash) — the
-delegates panel's **Test** button probes this.
+The delegates panel's **Test** button performs a real ACP `initialize` handshake — so
+a wrong launch command **fails the probe** instead of showing green (it's not just a
+missing-binary check). A misconfigured delegate surfaces at Test, not at first dispatch.
 
-The same `AcpClient` drives any of them — proto and Claude Code are both
-validated end-to-end. `--yes` on the `npx` form skips the first-run install
-prompt (which would otherwise hang the non-interactive spawn).
+**Claude Code has no native ACP mode.** Drive it through the
+[`claude-agent-acp`](https://www.npmjs.com/package/@agentclientprotocol/claude-agent-acp)
+adapter: install it (`npm i -g @agentclientprotocol/claude-agent-acp`) and use the
+`claude-code` alias above — it maps to `command: claude-agent-acp` with no args, so you
+don't have to know the incantation. (The older `@zed-industries/claude-code-acp` is
+**deprecated** — it was renamed to `@agentclientprotocol/claude-agent-acp`.) Setting
+`command: claude` directly does **not** work — `claude` isn't an ACP server, and the
+probe will tell you so.
 
-> **Claude Code caveat:** `@zed-industries/claude-code-acp` launches the `claude`
-> binary, which **refuses to start nested inside another Claude Code session**
-> (`Error: Claude Code cannot be launched inside another Claude Code session`). Run
-> protoAgent from a normal shell — not from within a `claude` session — when using
-> the Claude Code agent.
+> **Caveat:** the adapter launches the `claude` binary, which **refuses to start
+> nested inside another Claude Code session** (`Error: Claude Code cannot be launched
+> inside another Claude Code session`). Run protoAgent from a normal shell / the
+> desktop app — not from within a `claude` session — when using the Claude Code agent.
 
 ## Use it
 

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -355,9 +355,14 @@ class AcpAdapter(Adapter):
     def config_schema(self) -> list[FieldSpec]:
         return [
             FieldSpec(
-                "command", "Command", "text", required=True, placeholder="proto", help="Binary on PATH that speaks ACP."
+                "command",
+                "Command",
+                "text",
+                required=True,
+                placeholder="proto",
+                help="Binary on PATH that speaks ACP (e.g. proto). For Claude Code use `claude-code` — an alias for the claude-agent-acp adapter.",
             ),
-            FieldSpec("args", "Args", "args", placeholder="--acp", help="Launch args, e.g. --acp."),
+            FieldSpec("args", "Args", "args", placeholder="--acp", help="Launch args (e.g. --acp). Leave empty for claude-code."),
             FieldSpec(
                 "workdir",
                 "Workdir",
@@ -393,6 +398,14 @@ class AcpAdapter(Adapter):
             raise DelegateError(f"acp delegate {d.name!r} needs command + workdir")
         args = raw.get("args") or []
         d.args = [str(a) for a in args] if isinstance(args, (list, tuple)) else []
+        # Convenience alias (issue #1116): Claude Code has NO native ACP mode — it needs
+        # the claude-agent-acp adapter (formerly @zed-industries/claude-code-acp, now
+        # deprecated). Let operators write the intuitive `command: claude-code` and map
+        # it to the adapter binary, which takes no launch args — instead of hand-authoring
+        # the incantation and getting an opaque `agent exited` at first dispatch.
+        if d.command in ("claude-code", "claude-acp"):
+            d.command = "claude-agent-acp"
+            d.args = []
         env = raw.get("env") if isinstance(raw.get("env"), dict) else {}
         d.env = {str(k): str(v) for k, v in env.items()}
         try:
@@ -460,15 +473,57 @@ class AcpAdapter(Adapter):
         return await forget_session(self._spec(d))
 
     async def probe(self, d: Delegate) -> dict:
+        """Reachability check for the panel's Test button.
+
+        Does a REAL ACP `initialize` handshake (spawn the command, complete the
+        protocol handshake, close — no session/prompt), so a launch command that's
+        on PATH and workdir-valid but doesn't actually speak ACP FAILS the probe
+        instead of showing green (issue #1116 — the old PATH+workdir check passed
+        `command: claude` while every dispatch failed with an opaque `agent exited`).
+        """
+        import asyncio
         import os
         import shutil
 
+        # Bare `claude` is on PATH but has no native ACP mode — the classic false-green.
+        # Steer to the adapter instead of spawning it only to watch the handshake hang.
+        if os.path.basename(d.command) == "claude":
+            return {
+                "ok": False,
+                "error": (
+                    "`claude` has no native ACP mode. Claude Code needs the claude-agent-acp "
+                    "adapter — `npm i -g @agentclientprotocol/claude-agent-acp`, then set "
+                    "command: claude-code (an alias) or claude-agent-acp."
+                ),
+            }
         if not shutil.which(d.command):
+            if os.path.basename(d.command) == "claude-agent-acp":
+                return {
+                    "ok": False,
+                    "error": "claude-agent-acp not installed — run `npm i -g @agentclientprotocol/claude-agent-acp`.",
+                }
             return {"ok": False, "error": f"binary not on PATH: {d.command!r}"}
         wd = os.path.expanduser(d.workdir)
         if not os.path.isdir(wd):
             return {"ok": False, "error": f"workdir does not exist: {wd}"}
-        return {"ok": True, "detail": f"{d.command} on PATH; workdir OK"}
+
+        # Real handshake. `_ensure_started` spawns the agent and runs ACP `initialize`
+        # (it does NOT open a session), so it's a cheap, side-effect-free liveness check.
+        from plugins.coding_agent.acp_client import AcpClient
+
+        client = AcpClient(command=d.command, args=d.args, cwd=wd, env=(d.env or None), name=d.name)
+        try:
+            await asyncio.wait_for(client._ensure_started(), timeout=45)
+        except asyncio.TimeoutError:
+            return {"ok": False, "error": f"ACP handshake timed out — does {d.command!r} speak ACP?"}
+        except Exception as exc:  # noqa: BLE001 — spawn/handshake failure → tool-visible string
+            return {"ok": False, "error": f"ACP handshake failed: {type(exc).__name__}: {exc}"}
+        finally:
+            try:
+                await client.close()
+            except Exception:  # noqa: BLE001 — best-effort teardown
+                pass
+        return {"ok": True, "detail": f"ACP handshake OK (protocol {client._protocol_version}) — {d.command}"}
 
 
 ADAPTERS: dict[str, Adapter] = {a.type: a for a in (A2aAdapter(), OpenAiAdapter(), AcpAdapter())}

--- a/tests/test_delegates_api.py
+++ b/tests/test_delegates_api.py
@@ -123,10 +123,21 @@ def test_create_invalid_returns_400(client):
     )  # no model
 
 
-def test_test_endpoint_acp_probe(client):
+def test_test_endpoint_acp_probe(client, monkeypatch):
     import sys
 
-    # acp probe is local (binary-on-PATH + workdir exists) — point at the python exe.
+    from plugins.coding_agent.acp_client import AcpClient
+
+    # The acp probe now does a real ACP `initialize` handshake (#1116), so mock it —
+    # the python exe is on PATH + /tmp exists, but it doesn't speak ACP for real.
+    async def _ok(self):
+        self._protocol_version = 1
+
+    async def _noop(self):
+        pass
+
+    monkeypatch.setattr(AcpClient, "_ensure_started", _ok)
+    monkeypatch.setattr(AcpClient, "close", _noop)
     r = client.post(
         "/api/delegates/test", json={"name": "t", "type": "acp", "command": sys.executable, "workdir": "/tmp"}
     )
@@ -146,11 +157,21 @@ def test_list_includes_health_snapshot(client, monkeypatch):
     assert body["health"]["ok"] is True and body["health"]["latency_ms"] == 12
 
 
-def test_test_endpoint_probes_saved_delegate_by_name(client):
+def test_test_endpoint_probes_saved_delegate_by_name(client, monkeypatch):
     # The per-row Test button sends only {name, type}; the endpoint must probe the
     # STORED config (command/workdir), not fail on the missing fields.
     import sys
 
+    from plugins.coding_agent.acp_client import AcpClient
+
+    async def _ok(self):
+        self._protocol_version = 1
+
+    async def _noop(self):
+        pass
+
+    monkeypatch.setattr(AcpClient, "_ensure_started", _ok)
+    monkeypatch.setattr(AcpClient, "close", _noop)
     client.post("/api/delegates", json={"name": "proto", "type": "acp", "command": sys.executable, "workdir": "/tmp"})
     r = client.post("/api/delegates/test", json={"name": "proto", "type": "acp"})
     assert r.status_code == 200 and r.json()["ok"] is True

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -68,6 +68,61 @@ def test_acp_parse_ok_and_requires_command_workdir():
         ADAPTERS["acp"].parse({"name": "x", "type": "acp", "command": "proto"})  # no workdir
 
 
+def test_acp_parse_claude_code_alias():
+    # `claude-code` is a convenience alias for the claude-agent-acp adapter (#1116):
+    # the operator's intuitive name maps to the real binary, with no launch args.
+    d = ADAPTERS["acp"].parse(
+        {"name": "cc", "type": "acp", "command": "claude-code", "args": ["--stray"], "workdir": "/tmp"}
+    )
+    assert d.command == "claude-agent-acp" and d.args == []
+
+
+async def test_acp_probe_bare_claude_hints_the_adapter():
+    # `claude` is on PATH but has no native ACP mode — the probe must steer to the
+    # adapter rather than show green (the false-green the old PATH check gave, #1116).
+    d = ADAPTERS["acp"].parse({"name": "x", "type": "acp", "command": "claude", "workdir": "/tmp"})
+    res = await ADAPTERS["acp"].probe(d)
+    assert res["ok"] is False and "claude-agent-acp" in res["error"]
+
+
+async def test_acp_probe_fails_when_handshake_fails(monkeypatch):
+    # A command on PATH + valid workdir that does NOT speak ACP must FAIL the probe —
+    # the core fix for #1116 (PATH+workdir alone gave false confidence).
+    import sys
+
+    from plugins.coding_agent.acp_client import AcpClient, AcpError
+
+    async def _boom(self):
+        raise AcpError("agent exited")
+
+    async def _noop(self):
+        pass
+
+    monkeypatch.setattr(AcpClient, "_ensure_started", _boom)
+    monkeypatch.setattr(AcpClient, "close", _noop)
+    d = ADAPTERS["acp"].parse({"name": "x", "type": "acp", "command": sys.executable, "workdir": "/tmp"})
+    res = await ADAPTERS["acp"].probe(d)
+    assert res["ok"] is False and "handshake failed" in res["error"]
+
+
+async def test_acp_probe_ok_on_successful_handshake(monkeypatch):
+    import sys
+
+    from plugins.coding_agent.acp_client import AcpClient
+
+    async def _ok(self):
+        self._protocol_version = 1
+
+    async def _noop(self):
+        pass
+
+    monkeypatch.setattr(AcpClient, "_ensure_started", _ok)
+    monkeypatch.setattr(AcpClient, "close", _noop)
+    d = ADAPTERS["acp"].parse({"name": "x", "type": "acp", "command": sys.executable, "workdir": "/tmp"})
+    res = await ADAPTERS["acp"].probe(d)
+    assert res["ok"] is True and "handshake OK" in res["detail"]
+
+
 def test_secret_value_wins_then_env(monkeypatch):
     assert _secret({"token": "explicit"}, "token", "credentialsEnv") == "explicit"
     monkeypatch.setenv("MY_TOK", "fromenv")


### PR DESCRIPTION
Closes #1116.

Adding Claude Code as an `acp` delegate was a sharp edge: no native ACP mode, the natural `command: claude` silently fails at dispatch (`agent exited`), and the Test probe showed **green** (PATH+workdir only — `claude` *is* on PATH) while every dispatch failed.

**What changed**
- **`claude-code` alias** (+ `claude-acp`) → maps to the real adapter **`claude-agent-acp`** (no args). Operators write the intuitive name, not the incantation. (The old `@zed-industries/claude-code-acp` is **deprecated** → renamed to `@agentclientprotocol/claude-agent-acp`.) — issue ask #1
- **Real-handshake probe** — `AcpAdapter.probe` now spawns the command and completes the ACP `initialize` handshake (no session), so a wrong launch command **fails Test** instead of false-green. — issue ask #3
- **Adapter-aware hints** — bare `claude` → "use the claude-agent-acp adapter / `claude-code` alias"; missing `claude-agent-acp` → the `npm i -g …` install hint. — issue ask #2
- **Docs** — `coding-agents.md` migrated to `claude-agent-acp`, the alias, the deprecation, and the handshake probe. — issue ask #4

**Validation:** 33 delegates tests pass (4 new: alias, bare-claude hint, handshake-fails→not-ok, handshake-ok→ok; API probe tests mock the handshake). Live-verified: `claude-code` → real ACP handshake OK on Opus; bare `claude` → hint.

🤖 Generated with [Claude Code](https://claude.com/claude-code)