### PR TITLE
feat(model): ACP coding agent as the aux/eval/compaction model override

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -208,6 +208,9 @@ checkpoint:
 #   aux_model: ONE cheap/fast alias for the non-reasoning calls — context
 #     summarization, goal verification, and subagent delegation all fall back
 #     to it unless they set a specific override. Blank = main model everywhere.
+#     Can also be an `acp:<agent>` (e.g. acp:claude) to route those aux calls
+#     through a coding agent instead of a gateway model — same for goal.eval_model
+#     and compaction.model. (The main brain itself is selected via agent_runtime.)
 #   fallback_models: on a primary error, retry on each in order. Empty = none.
 routing:
   # aux_model: protolabs/fast

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -97,6 +97,20 @@ def create_llm(config: LangGraphConfig, *, model_name: str | None = None) -> Cha
     for a different model on the same gateway (used for compaction /
     fallback models).
     """
+    # Explicit per-slot ACP override: an `acp:<agent>` model name (e.g. `aux_model: acp:claude`,
+    # `goal.eval_model: acp:claude`, `compaction.model: acp:claude`, or a subagent's model) routes
+    # THIS call through that ACP agent — regardless of the main runtime or whether a gateway is
+    # configured. Lets a strong coding agent (Claude Code/Opus) back the auxiliary slots while the
+    # main brain stays on the gateway. Falls back to the gateway model if the ACP path can't build.
+    if model_name and model_name.strip().startswith("acp:"):
+        try:
+            from runtime.acp_runtime import make_acp_aux_model
+
+            return make_acp_aux_model(config, agent=model_name.split(":", 1)[1].strip() or None)
+        except Exception:  # noqa: BLE001 — degrade to the gateway model rather than break the call
+            log.warning("[llm] ACP override %r unavailable; using the main model", model_name, exc_info=True)
+            model_name = None
+
     # ACP-only fallback (ADR 0033): when the runtime is an ACP coding agent AND no gateway
     # key is configured, back protoAgent's auxiliary LLM calls (compaction, goal-eval, fact
     # extraction) with that same ACP agent — so an ACP-only setup needs no OpenAI-compatible

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -49,6 +49,11 @@ class Field:
     ui_hidden: bool = False
 
 
+# ACP coding-agent choices, offered as the main-brain runtime AND as model overrides for
+# the auxiliary slots (aux / goal-eval / compaction). Mirrors runtime/acp_runtime._ACP_ADAPTERS.
+ACP_MODEL_OPTIONS = ["acp:proto", "acp:codex", "acp:claude", "acp:gemini", "acp:copilot", "acp:opencode"]
+
+
 # Ordered registry. Section order here is the order the UI renders groups in.
 FIELDS: list[Field] = [
     # ── Agent runtime (ADR 0033) — leads the Agent settings: "who runs the turn?" ──
@@ -60,7 +65,7 @@ FIELDS: list[Field] = [
         "Agent runtime",
         "Which brain drives a turn: the built-in LangGraph loop (native), or an external "
         "coding agent over ACP (needs its CLI installed + authenticated on the host).",
-        options=["native", "acp:proto", "acp:codex", "acp:claude", "acp:copilot", "acp:opencode"],
+        options=["native", *ACP_MODEL_OPTIONS],
     ),
     Field(
         "operator_mcp.tools",
@@ -135,8 +140,10 @@ FIELDS: list[Field] = [
         "Auxiliary (fast) model",
         "string",
         "Routing",
-        "Cheap/fast alias for summarization, goal-verification, and subagents. Blank = use the main model.",
-        options_source="models",
+        "Cheap/fast alias for summarization, goal-verification, and subagents. Blank = use the "
+        "main model. Or pick an `acp:<agent>` to route these aux calls through a coding agent "
+        "(e.g. Opus via acp:claude) — needs that agent's CLI on the host.",
+        options_source="models+acp",
         scope="host",
     ),
     Field(
@@ -180,7 +187,9 @@ FIELDS: list[Field] = [
         "Summarizer model",
         "string",
         "Compaction",
-        "Blank = routing.aux_model, then the main model.",
+        "Blank = routing.aux_model, then the main model. Accepts an `acp:<agent>` to summarize "
+        "with a coding agent.",
+        options_source="models+acp",
     ),
     # ── Goal mode ────────────────────────────────────────────────────────────
     Field("goal.enabled", "goal_enabled", "Enable goal mode", "bool", "Goal mode"),
@@ -191,7 +200,9 @@ FIELDS: list[Field] = [
         "Verifier model",
         "string",
         "Goal mode",
-        "Blank = routing.aux_model, then the main model.",
+        "Blank = routing.aux_model, then the main model. Accepts an `acp:<agent>` to verify goals "
+        "with a coding agent.",
+        options_source="models+acp",
     ),
     # ── Programmatic tool calling ────────────────────────────────────────────
     Field(
@@ -767,7 +778,13 @@ def build_schema(
             "section": f.section,
             "description": f.description,
             "restart": f.restart,
-            "options": (model_options or []) if f.options_source == "models" else list(f.options),
+            "options": (
+                (model_options or [])
+                if f.options_source == "models"
+                else (model_options or []) + ACP_MODEL_OPTIONS
+                if f.options_source == "models+acp"
+                else list(f.options)
+            ),
             "default": _jsonable(getattr(defaults, f.attr, None)),
             "scope": f.scope,  # ADR 0047: "agent" | "host"
             "source": _source_for(f.key, agent_doc, host_doc),  # which layer set the live value

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -266,14 +266,17 @@ def _messages_to_text(messages) -> str:
     return "\n\n".join(p for p in parts if p)
 
 
-def make_acp_aux_model(config):
-    """A `BaseChatModel` backed by the configured ACP agent — for aux LLM calls under an
-    ACP-only setup. Lazy + import-guarded so langchain stays optional at import time."""
+def make_acp_aux_model(config, agent: str | None = None):
+    """A `BaseChatModel` backed by an ACP agent — for aux LLM calls (compaction, goal-eval,
+    fact extraction, …). `agent` names which coding agent (e.g. "claude"); blank falls back
+    to the main runtime's agent, then "proto". Used both by the ACP-only fallback (no
+    gateway) and by an explicit per-slot override like `aux_model: acp:claude`. Lazy +
+    import-guarded so langchain stays optional at import time."""
     from langchain_core.language_models import BaseChatModel
     from langchain_core.messages import AIMessage
     from langchain_core.outputs import ChatGeneration, ChatResult
 
-    agent = resolve_runtime(config)[1] or "proto"
+    agent = (agent or "").strip() or resolve_runtime(config)[1] or "proto"
 
     class AcpChatModel(BaseChatModel):
         """Text-only chat model over the ACP coding agent (no tools)."""

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -7,7 +7,13 @@ import types
 
 import pytest
 
-from runtime.acp_runtime import AcpRuntime, adapter_for, operator_mcp_server_spec, resolve_runtime
+from runtime.acp_runtime import (
+    AcpRuntime,
+    adapter_for,
+    make_acp_aux_model,
+    operator_mcp_server_spec,
+    resolve_runtime,
+)
 from runtime.context import AssembledContext
 
 
@@ -22,6 +28,16 @@ def test_resolve_runtime_variants():
     assert resolve_runtime(types.SimpleNamespace(agent_runtime="acp:codex")) == ("acp", "codex")
     assert resolve_runtime(types.SimpleNamespace(agent_runtime="acp")) == ("native", "")  # needs an agent
     assert resolve_runtime(types.SimpleNamespace(agent_runtime="bogus")) == ("native", "")
+
+
+def test_make_acp_aux_model_honors_explicit_agent():
+    # An explicit agent (from `aux_model: acp:claude`) wins over the main runtime's agent,
+    # so a coding agent can back the aux slots independent of the brain. (No spawn — the
+    # ACP client is created lazily on first prompt.)
+    m = make_acp_aux_model(_cfg(agent_runtime="acp:codex"), agent="claude")
+    assert m._llm_type == "acp:claude"
+    # Blank agent falls back to the main runtime's agent.
+    assert make_acp_aux_model(_cfg(agent_runtime="acp:codex"))._llm_type == "acp:codex"
 
 
 def test_adapter_default_and_override():

--- a/tests/test_llm.py
+++ b/tests/test_llm.py
@@ -116,3 +116,22 @@ def test_from_yaml_reads_sampling_block(tmp_path):
     assert cfg.presence_penalty == 0.3
     assert cfg.repetition_penalty == 1.05
     assert cfg.chat_template_kwargs == {"preserve_thinking": True}
+
+
+def test_create_llm_routes_acp_model_name_to_acp_aux(monkeypatch):
+    # An `acp:<agent>` override (aux_model / eval_model / compaction.model / a subagent's
+    # model) routes THAT call through the named ACP agent, not the gateway — regardless of
+    # the main runtime. Parses the agent off the prefix and hands it to make_acp_aux_model.
+    import runtime.acp_runtime as AR
+    from graph.llm import create_llm
+
+    captured = {}
+    sentinel = object()
+
+    def _fake(config, agent=None):
+        captured["agent"] = agent
+        return sentinel
+
+    monkeypatch.setattr(AR, "make_acp_aux_model", _fake)
+    out = create_llm(LangGraphConfig(), model_name="acp:claude")
+    assert out is sentinel and captured["agent"] == "claude"

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from graph.config import LangGraphConfig
 from graph.settings_schema import (
+    ACP_MODEL_OPTIONS,
     FIELDS,
     build_schema,
     nest_updates,
@@ -34,12 +35,19 @@ def test_schema_groups_and_values():
     assert model["type"] == "select" and model["options"] == ["a", "b"]
     # The free-text model fields ALSO carry the gateway list (as datalist
     # suggestions) — they stay `string` (blank/any alias allowed), not `select`.
-    for key in ("routing.aux_model", "knowledge.transcribe_model"):
+    transcribe = next(f for f in fields if f["key"] == "knowledge.transcribe_model")
+    assert transcribe["type"] == "string" and transcribe["options"] == ["a", "b"]
+    # The auxiliary-slot models additionally offer the ACP coding agents (acp:<agent>) so a
+    # coding agent can back aux/eval/compaction — still `string`, so any value validates.
+    for key in ("routing.aux_model", "compaction.model", "goal.eval_model"):
         f = next(f for f in fields if f["key"] == key)
-        assert f["type"] == "string" and f["options"] == ["a", "b"]
+        assert f["type"] == "string" and f["options"] == ["a", "b"] + ACP_MODEL_OPTIONS
     # The fallback list carries the gateway options too (rendered as combobox rows).
     fallback = next(f for f in fields if f["key"] == "routing.fallback_models")
     assert fallback["type"] == "string_list" and fallback["options"] == ["a", "b"]
+    # The main-brain runtime select offers native + every ACP agent (incl. gemini).
+    runtime = next(f for f in fields if f["key"] == "agent_runtime")
+    assert runtime["type"] == "select" and runtime["options"] == ["native", *ACP_MODEL_OPTIONS]
 
 
 def test_groups_carry_category_in_taxonomy_order():


### PR DESCRIPTION
ACP could only be the **main brain** (`agent_runtime: acp:<agent>`, already selectable in Settings) — the auxiliary model slots were gateway-only. Now `routing.aux_model`, `goal.eval_model`, `compaction.model` (and per-subagent models) can name an **`acp:<agent>`** to route that specific one-shot call through a coding agent (e.g. **Opus via `acp:claude`**) while the main brain stays on the gateway.

Per the design discussion, the **per-tab chat dropdown → ACP is intentionally excluded** — it's a stateless per-turn model swap, a poor fit for a stateful ACP subprocess session.

- **`graph/llm.py`** — `create_llm` honors a `model_name` of `acp:<agent>` → `make_acp_aux_model(agent)`; degrades to the gateway model if the ACP path can't build.
- **`runtime/acp_runtime.py`** — `make_acp_aux_model(config, agent=None)`; explicit agent wins over the main runtime's (the per-agent `_aux_prompt` plumbing already existed).
- **`settings_schema.py`** — shared `ACP_MODEL_OPTIONS`; a `models+acp` options source surfaces `acp:<agent>` in the aux/eval/compaction dropdowns (stays `string`, so any value validates); `agent_runtime` gains the missing `acp:gemini`.
- Example config + field help document the override.

**Tests:** `create_llm` acp routing, `make_acp_aux_model` explicit-agent, schema offers acp options for the three slots + `agent_runtime`. Full config/settings/subagent suite green (352).

🤖 Generated with [Claude Code](https://claude.com/claude-code)