### PR TITLE
refactor(acp): unify the ACP coding-agent list into one canonical catalog

### DIFF
--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -37,4 +37,10 @@ test("Add opens a type picker and a schema-driven form", async ({ page }) => {
   await panel.locator(".delegate-type-tile", { hasText: "Coding agent" }).click();
   await expect(panel.getByText("Command", { exact: false })).toBeVisible();
   await expect(panel.getByText("Workdir", { exact: false })).toBeVisible();
+
+  // The coding-agent preset picker (from the canonical /api/acp-agents catalog) fills
+  // Command + Args when an agent is chosen.
+  await expect(panel.locator("#acp-preset")).toBeVisible();
+  await panel.locator("#acp-preset").selectOption("claude");
+  await expect(panel.locator("#del-command")).toHaveValue("npx");
 });

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -142,6 +142,13 @@ function handleApiGet(pathname, fleet = FLEET) {
       return { groups: SETTINGS_SCHEMA };
     case "/api/delegate-types":
       return DELEGATE_TYPES;
+    case "/api/acp-agents":
+      return {
+        agents: [
+          { id: "proto", label: "proto (protoCLI)", command: "proto", args: ["--acp"] },
+          { id: "claude", label: "Claude Code", command: "npx", args: ["-y", "@agentclientprotocol/claude-agent-acp"] },
+        ],
+      };
     case "/api/delegates":
       return DELEGATES;
     case "/api/plugins/installed":

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type {
+  AcpAgent,
   ActivityHistory,
   AgentConfig,
   Archetype,
@@ -1294,6 +1295,10 @@ export const api = {
   // Delegate registry (ADR 0025) — the agents & endpoints the agent can talk to.
   delegateTypes() {
     return request<{ types: DelegateTypeSpec[] }>("/api/delegate-types");
+  },
+  // The canonical ACP coding-agent catalog (single source — runtime/acp_agents.py).
+  acpAgents() {
+    return request<{ agents: AcpAgent[] }>("/api/acp-agents");
   },
   delegates() {
     return request<{ delegates: DelegateView[] }>("/api/delegates");

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -18,6 +18,7 @@ export const queryKeys = {
   runtime: ["runtime"] as const,
   delegates: ["delegates"] as const,
   delegateTypes: ["delegates", "types"] as const,
+  acpAgents: ["acp", "agents"] as const,
   installedPlugins: ["plugins", "installed"] as const,
   pluginUpdates: ["plugins", "updates"] as const,
   fleet: ["fleet"] as const,
@@ -182,5 +183,13 @@ export const delegateTypesQuery = () =>
   queryOptions({
     queryKey: queryKeys.delegateTypes,
     queryFn: () => api.delegateTypes(),
+    retry: false,
+  });
+
+export const acpAgentsQuery = () =>
+  queryOptions({
+    queryKey: queryKeys.acpAgents,
+    queryFn: () => api.acpAgents(),
+    staleTime: Infinity, // a static catalog — fetch once
     retry: false,
   });

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -547,6 +547,9 @@ export type DelegateFieldSpec = {
   default?: unknown;
 };
 export type DelegateTypeSpec = { type: string; label: string; blurb: string; fields: DelegateFieldSpec[] };
+// A known ACP coding agent from the canonical backend catalog (/api/acp-agents) — the
+// single source for the Delegates picker + the setup wizard's runtime choices.
+export type AcpAgent = { id: string; label: string; command: string; args: string[] };
 export type DelegateProbe = { ok: boolean | null; latency_ms?: number; error?: string; detail?: string; checked_at?: number };
 export type DelegateView = {
   name: string;

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -12,7 +12,7 @@ import { useMemo, useState } from "react";
 
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
-import { delegatesQuery, delegateTypesQuery, queryKeys } from "../lib/queries";
+import { acpAgentsQuery, delegatesQuery, delegateTypesQuery, queryKeys } from "../lib/queries";
 import type { DelegateFieldSpec, DelegateProbe, DelegateTypeSpec, DelegateView } from "../lib/types";
 
 // Delegates panel (ADR 0025, PR3) — manage the agents & endpoints the agent can
@@ -190,10 +190,13 @@ function DelegateForm({
   const [name, setName] = useState(initial?.name || "");
   const [description, setDescription] = useState(initial?.description || "");
   const [vals, setVals] = useState<Record<string, string>>(() => seed(initial, spec));
+  const [preset, setPreset] = useState(""); // ACP coding-agent preset (fills command/args)
   const [probe, setProbe] = useState<DelegateProbe | null>(null);
   const [err, setErr] = useState("");
 
   const current = useMemo(() => spec.find((s) => s.type === type), [spec, type]);
+  // The canonical ACP coding-agent catalog (single source — /api/acp-agents).
+  const acpAgents = useQuery({ ...acpAgentsQuery(), enabled: type === "acp" });
 
   function buildEntry(): Record<string, unknown> {
     const entry: Record<string, unknown> = { name, type, description };
@@ -233,7 +236,7 @@ function DelegateForm({
               key={s.type}
               type="button"
               className={`delegate-type-tile${type === s.type ? " active" : ""}`}
-              onClick={() => { setType(s.type); setProbe(null); }}
+              onClick={() => { setType(s.type); setProbe(null); setPreset(""); }}
             >
               <span className="delegate-type-tile-label">{s.label}</span>
               <span className="delegate-type-tile-blurb">{s.blurb}</span>
@@ -250,6 +253,31 @@ function DelegateForm({
         <span>Description</span>
         <Input value={description} onChange={(e) => setDescription(e.target.value)} placeholder="What it's for (the model reads this to pick it)." />
       </label>
+
+      {type === "acp" && (acpAgents.data?.agents?.length ?? 0) > 0 ? (
+        <label className="field">
+          <span>Coding agent</span>
+          <Select
+            id="acp-preset"
+            value={preset}
+            onChange={(e) => {
+              const id = e.target.value;
+              setPreset(id);
+              const a = acpAgents.data?.agents.find((x) => x.id === id);
+              if (a) setVals((m) => ({ ...m, command: a.command, args: a.args.join(" ") }));
+            }}
+          >
+            <option value="">Custom / pick a preset…</option>
+            {acpAgents.data?.agents.map((a) => (
+              <option key={a.id} value={a.id}>{a.label}</option>
+            ))}
+          </Select>
+          <small className="delegate-field-help">
+            Pre-fills the launch fields below for a known coding agent. Claude Code needs the
+            adapter (<code>npm i -g @agentclientprotocol/claude-agent-acp</code>).
+          </small>
+        </label>
+      ) : null}
 
       {(current?.fields ?? []).map((f) => (
         <DelegateField

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -21,7 +21,7 @@ import { TestConnectionButton } from "../app/ui-kit";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { lucideIcon } from "../lib/lucideIcon";
-import { archetypesQuery } from "../lib/queries";
+import { acpAgentsQuery, archetypesQuery } from "../lib/queries";
 import type { AgentConfig, Archetype, ConfigPayload } from "../lib/types";
 
 // Four steps: intro, then "who the agent is" (name + persona), then "how it thinks"
@@ -37,14 +37,6 @@ type Step = "welcome" | "agent" | "brain" | "finish";
 //     tune later in Settings.
 const steps: Step[] = ["welcome", "agent", "brain", "finish"];
 
-// CLI coding agents that can be the runtime over ACP (ADR 0033) — agent_runtime: acp:<id>.
-const ACP_AGENTS: { id: string; label: string; hint: string }[] = [
-  { id: "proto", label: "proto", hint: "protoLabs CLI — proto --acp" },
-  { id: "codex", label: "Codex", hint: "OpenAI Codex — npx @zed-industries/codex-acp" },
-  { id: "claude", label: "Claude", hint: "Claude agent — npx @agentclientprotocol/claude-agent-acp" },
-  { id: "copilot", label: "Copilot", hint: "GitHub Copilot CLI — copilot --acp" },
-  { id: "opencode", label: "OpenCode", hint: "OpenCode — opencode acp" },
-];
 
 type WizardState = {
   agentName: string;
@@ -165,6 +157,7 @@ export function SetupWizard({
   // source the fleet new-agent picker uses. Each carries a base SOUL the persona
   // step seeds when picked (ADR 0042).
   const archetypes = useQuery(archetypesQuery());
+  const acpAgentList = useQuery(acpAgentsQuery()).data?.agents ?? [];
   const [models, setModels] = useState<string[]>([]);
   // Flips true once the initial config load finishes. The persona seed waits on it
   // so the async load() (which replaces the whole state) can't clobber the seed.
@@ -304,7 +297,9 @@ export function SetupWizard({
   const pickedArchetype = archetypeList.find((a) => a.id === state.archetype);
   const personaLabel = pickedArchetype?.label ?? state.archetype;
   const pickedBundle = pickedArchetype?.bundle ?? null;
-  const acpAgentLabel = ACP_AGENTS.find((a) => a.id === state.acpAgent)?.label ?? state.acpAgent;
+  const acpAgent = acpAgentList.find((a) => a.id === state.acpAgent);
+  const acpAgentLabel = acpAgent?.label ?? state.acpAgent;
+  const acpLaunchHint = acpAgent ? `${acpAgent.command} ${acpAgent.args.join(" ")}`.trim() : state.acpAgent;
 
   async function finishSetup() {
     setBusy(true);
@@ -498,7 +493,7 @@ export function SetupWizard({
                   label="Coding agent"
                   hint={
                     <>
-                      {ACP_AGENTS.find((a) => a.id === state.acpAgent)?.hint} — runtime set to{" "}
+                      Launches <code>{acpLaunchHint}</code> — runtime set to{" "}
                       <code>acp:{state.acpAgent}</code>. No gateway key needed; a fallback model for native delegates can be set later in Settings.
                     </>
                   }
@@ -507,7 +502,7 @@ export function SetupWizard({
                     value={state.acpAgent}
                     onChange={(event) => update({ acpAgent: event.target.value })}
                   >
-                    {ACP_AGENTS.map((a) => (
+                    {acpAgentList.map((a) => (
                       <option key={a.id} value={a.id}>{a.label}</option>
                     ))}
                   </Select>

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from typing import Any
 
+from runtime.acp_agents import acp_runtime_options
+
 
 @dataclass
 class Field:
@@ -49,9 +51,10 @@ class Field:
     ui_hidden: bool = False
 
 
-# ACP coding-agent choices, offered as the main-brain runtime AND as model overrides for
-# the auxiliary slots (aux / goal-eval / compaction). Mirrors runtime/acp_runtime._ACP_ADAPTERS.
-ACP_MODEL_OPTIONS = ["acp:proto", "acp:codex", "acp:claude", "acp:gemini", "acp:copilot", "acp:opencode"]
+# ACP coding-agent choices, offered as the main-brain runtime AND as model overrides for the
+# auxiliary slots (aux / goal-eval / compaction). Derived from the canonical catalog
+# (runtime/acp_agents.py) so the list lives in exactly one place.
+ACP_MODEL_OPTIONS = acp_runtime_options()
 
 
 # Ordered registry. Section order here is the order the UI renders groups in.

--- a/operator_api/config_routes.py
+++ b/operator_api/config_routes.py
@@ -178,6 +178,14 @@ def register_config_routes(app) -> None:
 
         return {"name": name, "content": read_soul_preset(name)}
 
+    @app.get("/api/acp-agents")
+    async def _api_acp_agents():
+        """The canonical ACP coding-agent catalog (id, label, command, args) — one source
+        for the Delegates picker, the setup wizard, and the agent_runtime options."""
+        from runtime.acp_agents import acp_agent_catalog
+
+        return {"agents": acp_agent_catalog()}
+
     # --- Generic settings (schema-driven UI) --------------------------------
     @app.get("/api/settings/schema")
     async def _api_settings_schema():

--- a/runtime/acp_agents.py
+++ b/runtime/acp_agents.py
@@ -1,0 +1,33 @@
+"""Canonical ACP coding-agent catalog — the SINGLE source of truth for which CLI coding
+agents protoAgent can drive over the Agent Client Protocol, and how to launch each.
+
+A pure-data leaf (no imports) so every consumer can derive from it without import cycles:
+  * ``runtime.acp_runtime`` — ``_ACP_ADAPTERS`` (launch specs for the ACP runtime + aux models)
+  * ``graph.settings_schema`` — the ``agent_runtime`` choices + the ``acp:<agent>`` model overrides
+  * ``GET /api/acp-agents`` — serves the catalog to the web Delegates picker + the setup wizard
+
+Add/adjust an agent HERE and it propagates everywhere. Each entry's ``command``/``args`` is
+the launch incantation; ``id`` is the short key (``agent_runtime: acp:<id>``); ``label`` is
+the human name shown in pickers.
+"""
+
+from __future__ import annotations
+
+ACP_AGENT_CATALOG: list[dict] = [
+    {"id": "proto", "label": "proto (protoCLI)", "command": "proto", "args": ["--acp"]},
+    {"id": "codex", "label": "Codex", "command": "npx", "args": ["-y", "@zed-industries/codex-acp"]},
+    {"id": "claude", "label": "Claude Code", "command": "npx", "args": ["-y", "@agentclientprotocol/claude-agent-acp"]},
+    {"id": "gemini", "label": "Gemini CLI", "command": "gemini", "args": ["--experimental-acp"]},
+    {"id": "opencode", "label": "OpenCode", "command": "opencode", "args": ["acp"]},
+    {"id": "copilot", "label": "Copilot CLI", "command": "copilot", "args": ["--acp"]},
+]
+
+
+def acp_agent_catalog() -> list[dict]:
+    """The catalog as fresh dicts (args copied) so callers can't mutate the source."""
+    return [{**a, "args": list(a["args"])} for a in ACP_AGENT_CATALOG]
+
+
+def acp_runtime_options() -> list[str]:
+    """The ``acp:<id>`` strings — for the agent_runtime select + the aux-model overrides."""
+    return [f"acp:{a['id']}" for a in ACP_AGENT_CATALOG]

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -21,21 +21,18 @@ import os
 import sys
 from pathlib import Path
 
+from runtime.acp_agents import ACP_AGENT_CATALOG
 from runtime.context import ContextAssembler
 
 log = logging.getLogger(__name__)
 
 _REPO_ROOT = Path(__file__).resolve().parents[1]  # repo root (where the `server` pkg lives)
 
-# Best-effort launch commands per agent — ACP servers drift, so these are *defaults*
-# the operator can override in config (``acp.agents.<name>: {command, args}``).
+# Best-effort launch commands per agent, derived from the canonical catalog
+# (runtime/acp_agents.py) — ACP servers drift, so these are *defaults* the operator can
+# override in config (``acp.agents.<name>: {command, args}``).
 _ACP_ADAPTERS: dict[str, dict] = {
-    "proto": {"command": "proto", "args": ["--acp"]},
-    "codex": {"command": "npx", "args": ["-y", "@zed-industries/codex-acp"]},
-    "claude": {"command": "npx", "args": ["-y", "@agentclientprotocol/claude-agent-acp"]},
-    "gemini": {"command": "gemini", "args": ["--experimental-acp"]},
-    "opencode": {"command": "opencode", "args": ["acp"]},
-    "copilot": {"command": "copilot", "args": ["--acp"]},
+    a["id"]: {"command": a["command"], "args": list(a["args"])} for a in ACP_AGENT_CATALOG
 }
 
 

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -447,3 +447,16 @@ async def test_eviction_during_get_acp_runtime(monkeypatch):
     # The requested runtime was created and returned.
     assert rt is chat._ACP_RUNTIMES["new-thread"]
     assert "new-thread" in chat._ACP_RUNTIME_ACCESS
+
+
+def test_adapters_derived_from_canonical_catalog():
+    # Single source: the launch specs + the settings options all come from acp_agents.
+    from graph.settings_schema import ACP_MODEL_OPTIONS
+    from runtime.acp_agents import acp_agent_catalog, acp_runtime_options
+    from runtime.acp_runtime import _ACP_ADAPTERS
+
+    catalog_ids = {a["id"] for a in acp_agent_catalog()}
+    assert set(_ACP_ADAPTERS) == catalog_ids
+    assert ACP_MODEL_OPTIONS == acp_runtime_options() == [f"acp:{a['id']}" for a in acp_agent_catalog()]
+    # claude maps to the current adapter (the deprecated @zed-industries one is gone).
+    assert "@agentclientprotocol/claude-agent-acp" in _ACP_ADAPTERS["claude"]["args"]

--- a/tests/test_config_routes.py
+++ b/tests/test_config_routes.py
@@ -37,6 +37,16 @@ def test_get_config_delegates(monkeypatch):
     assert body == {"config": {"model": "x"}, "soul": "SOUL"}
 
 
+def test_acp_agents_route_serves_the_catalog():
+    # The canonical ACP catalog is served for the web pickers (single source).
+    body = _client().get("/api/acp-agents").json()
+    agents = body["agents"]
+    ids = {a["id"] for a in agents}
+    assert {"proto", "claude", "gemini"} <= ids
+    claude = next(a for a in agents if a["id"] == "claude")
+    assert claude["label"] and claude["command"] and isinstance(claude["args"], list)
+
+
 def test_setup_status_and_reset(monkeypatch):
     seen = {}
     monkeypatch.setitem(


### PR DESCRIPTION
The known ACP agents (id + label + launch command/args) were duplicated across ~4 places that had **already drifted** — the setup wizard was missing `gemini`; the delegate picker used a different `claude` form: `runtime/acp_runtime._ACP_ADAPTERS`, `settings_schema.ACP_MODEL_OPTIONS`, the Delegates panel preset, and the setup wizard.

**Collapsed to one source — `runtime/acp_agents.py`** (a pure-data leaf, no imports):
- `_ACP_ADAPTERS` (the ACP runtime + aux-model launch specs) derives from it.
- `ACP_MODEL_OPTIONS` (the `agent_runtime` select + the `acp:<agent>` aux/eval/compaction overrides) derives from it.
- new **`GET /api/acp-agents`** serves the catalog.
- the **web Delegates picker** + the **setup-wizard runtime picker** fetch that endpoint instead of hardcoding their own lists.

This also **delivers the guided coding-agent picker** that #1129 prototyped (closed in favour of this catalog-fed version, which fixes the e2e selector collision the old help text caused). Add/adjust an agent in `acp_agents.py` → it propagates everywhere.

**Tests:** catalog ↔ `_ACP_ADAPTERS` ↔ `ACP_MODEL_OPTIONS` consistency, the `/api/acp-agents` route, and an e2e that the preset fills Command from the catalog. Python 109 + web typecheck + ruff + import-contracts all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)