### PR TITLE
chore: release v0.47.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.47.0] - 2026-06-18
+
 ### Removed
 - **Google (Gmail + Calendar) and Slack are no longer bundled — they move to
   standalone external plugins.** The `google` plugin (`plugins/google/` +

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.46.0"
+version = "0.47.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "v0.47.0",
+    "date": "2026-06-18",
+    "changes": [
+      "**Google (Gmail + Calendar) and Slack are no longer bundled"
+    ]
+  },
+  {
     "version": "v0.46.0",
     "date": "2026-06-17",
     "changes": []


### PR DESCRIPTION
Automated version bump to `v0.47.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.47.0 -m 'Release v0.47.0' && git push origin v0.47.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).