### PR TITLE
feat(web): header → always-on hamburger (remove status light + theme + settings gear)

### DIFF
--- a/apps/web/e2e/events.spec.ts
+++ b/apps/web/e2e/events.spec.ts
@@ -1,15 +1,9 @@
 import { expect, test } from "@playwright/test";
 
-// The console opens a server→client SSE channel (GET /api/events, ADR 0003) for
-// the app's lifetime. The topbar "live" indicator reflects the connection.
-
-test("live indicator turns connected when the event stream opens", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "load" });
-  const dot = page.getByTestId("live-indicator");
-  await expect(dot).toBeVisible();
-  // EventSource onopen flips it live shortly after the response headers arrive.
-  await expect(dot).toHaveAttribute("data-live", "true");
-});
+// The console opens a server→client SSE channel (GET /api/events, ADR 0003) for the
+// app's lifetime. The dedicated topbar "live" indicator was removed with the status
+// light; the goal.achieved toast below still exercises the channel end-to-end — the
+// event only arrives if the SSE connected.
 
 test("a goal.achieved bus event surfaces a toast", async ({ page }) => {
   // ADR 0039 — the mock pushes a one-shot goal.achieved; the console toasts it so a plain

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -4,9 +4,10 @@ import { expect, test } from "@playwright/test";
 // opens a dialog editing fields via the same /api/settings path, and the central
 // two-home one-stop-shop is also openable as an overlay from the topbar.
 
-test("the topbar gear opens the Settings overlay (the two-home one-stop-shop)", async ({ page }) => {
+test("the header menu opens the Settings overlay (the two-home one-stop-shop)", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.getByTestId("topbar-settings").click();
+  await page.getByTestId("header-menu").click();
+  await page.getByRole("menuitem", { name: "Settings" }).click();
   const dialog = page.getByRole("dialog", { name: "Settings" });
   await expect(dialog).toBeVisible();
   // The same two scope homes render inside the overlay (the segmented toggle).

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -83,7 +83,7 @@ import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { SettingsOverlay } from "../settings/SettingsOverlay";
-import { ThemeQuickButton } from "../settings/ThemeQuickButton";
+import { HamburgerMenu } from "./HamburgerMenu";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
@@ -459,22 +459,9 @@ export function App() {
   // Resize + collapse are now the DS AppShell's (controlled via rightWidth/onRightWidthChange +
   // rightCollapsed/onCollapse) — the hand-rolled mouse/keyboard handlers are gone.
 
-  // One glanceable health light for the topbar (detail on hover; full status in
-  // System → Runtime). Worst-state wins. Derived from the runtime query — while
-  // it's still loading (no data, e.g. the sidecar booting) we show "starting".
-  const statusLabel = runtimeQ.isError
-    ? "error"
-    : !runtime
-      ? "starting server…"
-      : runtimeQ.isFetching
-        ? "refreshing"
-        : "ready";
-  const health: { tone: "ok" | "warning" | "error"; label: string } =
-    !runtime && runtimeQ.isError ? { tone: "error", label: "error" }
-    : !runtime ? { tone: "warning", label: "starting…" }
-    : !runtime.setup_complete ? { tone: "warning", label: "setup pending" }
-    : !runtime.graph_loaded ? { tone: "error", label: "graph offline" }
-    : { tone: "ok", label: "ready" };
+  // (The topbar health light was removed — its status/health derivation went with it.
+  // Runtime health still surfaces via the warnings strip + the boot gate; full detail
+  // lives in Settings ▸ Runtime. SSE connection state is still tracked via `setLive`.)
 
   // Desktop (macOS) runs with an overlay/invisible title bar — no chrome, the
   // native traffic lights float over the content. Detect that build so the
@@ -763,42 +750,10 @@ export function App() {
         }
         org={runtime?.identity?.org || "protoLabs.studio"}
         actions={
-          <>
-            {/* Quick-settings (ADR 0048). Model tuning lives on the chat composer (by the
-                input); the topbar keeps appearance + the gear to the full one-stop-shop. */}
-            <ThemeQuickButton />
-            <Button
-              icon
-              variant="ghost"
-              type="button"
-              title="Open settings"
-              aria-label="Open settings"
-              data-testid="topbar-settings"
-              onClick={() => setSettingsOverlayOpen(true)}
-            >
-              <Settings2 size={16} />
-            </Button>
-          </>
-        }
-        status={
-          <button
-            type="button"
-            className={`status-dot tone-${health.tone}`}
-            onClick={() => {
-              void runtimeQ.refetch();
-            }}
-            title={
-              `Setup: ${runtime?.setup_complete ? "complete" : "pending"}\n` +
-              `Graph: ${runtime?.graph_loaded ? "loaded" : "offline"}\n` +
-              `Event stream: ${live ? "connected" : "offline"}\n` +
-              `Status: ${statusLabel}` +
-              (error ? `\nError: ${error}` : "") +
-              `\n\nClick to refresh.`
-            }
-            aria-label={`Status: ${health.label}. Click to refresh.`}
-            data-testid="live-indicator"
-            data-live={live ? "true" : "false"}
-          />
+          // Always-on hamburger — the new home for global actions as Settings get
+          // rearranged app-wide. Replaces the old theme toggle + settings gear + status
+          // light (theme lives in Settings ▸ Appearance; Settings is also a rail surface).
+          <HamburgerMenu onOpenSettings={() => setSettingsOverlayOpen(true)} />
         }
       />
       </div>

--- a/apps/web/src/app/HamburgerMenu.tsx
+++ b/apps/web/src/app/HamburgerMenu.tsx
@@ -1,0 +1,37 @@
+import { useRef } from "react";
+import { Menu as MenuIcon, Settings2 } from "lucide-react";
+import { Menu, MenuItem, type MenuHandle } from "@protolabsai/ui/menu";
+import { Button } from "@protolabsai/ui/primitives";
+
+/**
+ * Always-on header menu (the hamburger). A ghost button that drops the DS Menu anchored
+ * under it. This is the new home for global actions as Settings get rearranged app-wide
+ * (ADR 0048 follow-up) — for now it carries the one-stop-shop Settings overlay (the job
+ * the topbar gear used to do); more items land here as the IA settles.
+ */
+export function HamburgerMenu({ onOpenSettings }: { onOpenSettings: () => void }) {
+  const menuRef = useRef<MenuHandle>(null);
+  return (
+    <>
+      <Button
+        icon
+        variant="ghost"
+        type="button"
+        title="Menu"
+        aria-label="Menu"
+        data-testid="header-menu"
+        onClick={(e) => {
+          const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
+          menuRef.current?.open({ x: r.right, y: r.bottom + 4 });
+        }}
+      >
+        <MenuIcon size={18} />
+      </Button>
+      <Menu ref={menuRef} align="end">
+        <MenuItem icon={<Settings2 size={14} />} onSelect={onOpenSettings}>
+          Settings
+        </MenuItem>
+      </Menu>
+    </>
+  );
+}


### PR DESCRIPTION
First step of the app-wide settings rearrangement.

- **Removed** the status light, theme quick-toggle, and settings gear from the topbar (`Header` `actions` + `status`). Nothing's orphaned — theme is in **Settings ▸ Appearance**, **Settings is also a rail surface**, and runtime health still shows via the warnings strip + boot gate. Dropped the now-dead status/health derivation (the dot was its only reader); SSE tracking (`setLive`) untouched.
- **Added `HamburgerMenu`** — an always-on ghost button that drops the DS Menu under it. For now it carries the one-stop-shop **Settings** overlay (the gear's old job); **content will grow** as the settings IA settles.
- **e2e:** `quick-settings` opens Settings via the header menu; the `events` live-indicator test is dropped (its dot is gone — the `goal.achieved` toast still exercises the SSE end-to-end).

Typechecks clean; the Web E2E covers the new header-menu → Settings path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)