### PR TITLE
fix(plugins): validate git ref before fetch (PR #1140 QA hardening)

### DIFF
--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -36,6 +36,11 @@ REPO_ROOT = _BUNDLE_CONFIG_DIR.parent
 LOCK_PATH = Path(os.environ.get("PROTOAGENT_PLUGINS_LOCK", str(REPO_ROOT / "plugins.lock")))
 
 _SHA_RE = re.compile(r"^[0-9a-f]{7,40}$", re.IGNORECASE)
+# A git ref we'll accept from a caller — branch/tag/sha shapes only. Keeps a ref
+# from being interpolated into the GitHub API URL (path/query injection) or passed
+# to git as an option (a leading `-`). Permissive enough for real refs
+# (`release/1.2`, `v1.0.0`, a 40-char sha) but no `..`, control chars, or schemes.
+_REF_RE = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._/-]*$")
 _ALLOWED_SCHEMES = ("https://", "http://", "git://", "ssh://", "git@", "file://", "/")
 
 # `git ls-remote` network safety (check_updates): a bounded timeout so a slow/dead
@@ -72,6 +77,13 @@ def _git(*args: str, cwd: Path | None = None, timeout: float | None = None) -> s
 def _validate_url(url: str) -> None:
     if not any(url.startswith(s) for s in _ALLOWED_SCHEMES):
         raise InstallError(f"unsupported source {url!r} — use https://, ssh://, git@, or a local path.")
+
+
+def _validate_ref(ref: str) -> None:
+    """Reject a ref that could escape the GitHub API URL path / inject a query, or
+    reach git as an option. Empty = the default branch (resolved separately)."""
+    if ".." in ref or not _REF_RE.match(ref):
+        raise InstallError(f"invalid ref {ref!r} — use a branch, tag, or commit SHA.")
 
 
 def _source_allowed(url: str, allow: list[str] | None) -> bool:
@@ -330,6 +342,8 @@ def install(
     to its resolved SHA, and record it in ``plugins.lock``. Does NOT enable it or
     install its deps. Returns the install summary."""
     _validate_url(url)
+    if ref:
+        _validate_ref(ref)  # before it reaches git or the GitHub API URL (PR #1140 QA)
     if not _source_allowed(url, allow):
         raise InstallError(
             f"source {url!r} is not on plugins.sources.allow — add it or install from an allowed origin."

--- a/tests/test_plugin_installer_archive.py
+++ b/tests/test_plugin_installer_archive.py
@@ -69,6 +69,26 @@ def test_github_owner_repo_rejects_non_github():
         installer._github_owner_repo("https://gitlab.com/x/y")
 
 
+@pytest.mark.parametrize("ref", ["main", "release/1.2", "v1.0.0", "a" * 40, "feature_x"])
+def test_validate_ref_accepts_real_refs(ref):
+    installer._validate_ref(ref)  # no raise
+
+
+@pytest.mark.parametrize("ref", ["../../etc/passwd", "main..evil", "-upload-pack=x", "a b", "x?y=z", "/abs", "a#frag"])
+def test_validate_ref_rejects_unsafe(ref):
+    with pytest.raises(installer.InstallError, match="invalid ref"):
+        installer._validate_ref(ref)
+
+
+def test_install_rejects_unsafe_ref_before_fetch(env, monkeypatch):
+    # Refused at validation — never reaches the GitHub API URL or git.
+    called = {"fetch": False}
+    monkeypatch.setattr(installer, "_fetch", lambda *a, **k: called.__setitem__("fetch", True))
+    with pytest.raises(installer.InstallError, match="invalid ref"):
+        installer.install("https://github.com/acme/demo_ext", "../../evil")
+    assert called["fetch"] is False
+
+
 @pytest.mark.parametrize("spec,name", [("websockets>=12", "websockets"), ("httpx", "httpx"), ("pkg[extra]>=1", "pkg")])
 def test_dep_pkg_name(spec, name):
     assert installer._dep_pkg_name(spec) == name


### PR DESCRIPTION
Addresses the LOW-severity QA note on #1140: `install()`'s `ref` was interpolated into the GitHub API URL (`/commits/{ref}`) and passed to git without validation.

Adds `_validate_ref` (accepts branch/tag/sha shapes only — rejects `..`, control chars, query/fragment chars, and a leading `-` git would read as an option) and calls it in `install()` before the ref reaches either the archive or git backend.

Tests: accepts real refs (`main`, `release/1.2`, `v1.0.0`, a 40-char sha), rejects traversal/option/query shapes, and `install()` refuses a bad ref **before any fetch**.

Gates: ruff ✓ · lint-imports ✓ (3/0) · installer tests 47 ✓.

Follow-up to #1140 (epic bd-3uh).

🤖 Generated with [Claude Code](https://claude.com/claude-code)