### PR TITLE
feat(plugins): in-app official-plugin directory — Discover + host catalog (ADR 0059, bd-23a.1/.2)

### DIFF
--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -153,6 +153,24 @@ function handleApiGet(pathname, fleet = FLEET) {
       return DELEGATES;
     case "/api/plugins/installed":
       return { plugins: INSTALLED_PLUGINS };
+    case "/api/plugins/catalog":
+      // Discover directory (ADR 0059) — official entries with mixed install state.
+      return {
+        plugins: [
+          {
+            id: "artifact", name: "Artifact", category: "Generative UI", official: true,
+            repo: "https://github.com/protoLabsAI/artifact-plugin",
+            tagline: "Render HTML/SVG/Mermaid/React into a sandboxed iframe.",
+            bundled: false, installed: false, enabled: false,
+          },
+          {
+            id: "discord", name: "Discord", category: "Communication", official: true,
+            repo: "https://github.com/protoLabsAI/discord-plugin",
+            tagline: "Run your agent as a Discord bot.",
+            bundled: false, installed: true, enabled: true,
+          },
+        ],
+      };
     case "/api/plugins/updates":
       // Per-plugin freshness (ADR 0027). Console-installed plugins are up to date
       // (their resolved_sha is the latest); the seeded fixtures exercise the other

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -61,22 +61,25 @@ test("workspace settings: identity lands, then tools and MCP sections", async ({
   await expect(page.getByText("echo · stdio")).toBeVisible(); // MCP server
 });
 
-test("plugins section: Local / Market / Download tabs", async ({ page }) => {
+test("plugins section: Installed / Discover / Install URL tabs", async ({ page }) => {
   await page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true }).click();
 
-  // Local (default tab) — both status groups + the enable toggle.
+  // Installed (default tab) — both status groups + the enable toggle.
   await expect(page.getByText("Demo Plugin", { exact: false })).toBeVisible();
   await expect(page.getByText("Zzz Disabled", { exact: false })).toBeVisible();
   await page.locator(".subagent-row", { hasText: "Zzz Disabled" })
     .getByRole("button", { name: "Enable" }).click();
   await expect(page.locator(".plugin-hint")).toContainText("Zzz Disabled enabled");
 
-  // Market tab — discovery links.
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Market", exact: true }).click();
-  await expect(page.getByRole("link", { name: /Browse the directory/ })).toBeVisible();
+  // Discover tab — the in-app official-plugin directory (ADR 0059): cards + search.
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Discover", exact: true }).click();
+  await expect(page.getByLabel("Search plugins")).toBeVisible();
+  const artifact = page.locator(".plugin-card", { hasText: "Artifact" });
+  await expect(artifact.getByRole("button", { name: /Install/ })).toBeVisible();   // not installed → installable
+  await expect(page.locator(".plugin-card", { hasText: "Discord" })).toContainText(/installed/);
 
-  // Download tab — install from a git URL.
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Download", exact: true }).click();
+  // Install URL tab — install from a git URL (advanced).
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Install URL", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
 });
 

--- a/apps/web/e2e/plugin-install.spec.ts
+++ b/apps/web/e2e/plugin-install.spec.ts
@@ -6,8 +6,8 @@ import { expect, test } from "@playwright/test";
 async function openPluginsPanel(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true }).click();
-  // Install lives on the Download tab.
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Download", exact: true }).click();
+  // Install-from-URL lives on the "Install URL" tab (advanced).
+  await page.locator(".pl-tabs").getByRole("tab", { name: "Install URL", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
 }
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -577,9 +577,9 @@ export function App() {
         return (
           <>
             <Tabs responsive active={pluginsTab} onSelect={(t) => setPluginsTab(t as PluginsTab)} items={[
-              { id: "local", label: "Local", icon: Boxes },
-              { id: "market", label: "Market", icon: Store },
-              { id: "download", label: "Download", icon: Download },
+              { id: "local", label: "Installed", icon: Boxes },
+              { id: "market", label: "Discover", icon: Store },
+              { id: "download", label: "Install URL", icon: Download },
             ].map(toTab)} />
             <PluginsSurface tab={pluginsTab} />
           </>

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -17,6 +17,7 @@ import type {
   GoalState,
   HitlPayload,
   InboxItem,
+  CatalogPlugin,
   InstalledPlugin,
   PluginInstallSummary,
   PluginUpdate,
@@ -1291,6 +1292,11 @@ export const api = {
   // Git-installed plugins (ADR 0027). install fetches code only (does NOT enable).
   installedPlugins() {
     return request<{ plugins: InstalledPlugin[] }>("/api/plugins/installed");
+  },
+  // The curated official-plugin directory (Discover, ADR 0059), merged with install
+  // state. One-click install posts each entry's `repo` to installPlugin().
+  pluginCatalog() {
+    return request<{ plugins: CatalogPlugin[] }>("/api/plugins/catalog");
   },
   // Install AUTO-ENABLES + runs the plugin (trust-by-default): `enabled` lists the
   // ids now live; `reloaded` whether the hot-reload landed; `enable_error` is set if

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -141,6 +141,22 @@ export type InstalledPlugin = {
   };
 };
 
+// An entry in the official-plugin directory (GET /api/plugins/catalog, ADR 0059),
+// merged with install state. `repo` is the install URL — one-click install runs
+// `plugin install <repo>`. `bundled` = a built-in still shipped with the host (not
+// separately installable); `installed` = present in the live plugins dir.
+export type CatalogPlugin = {
+  id: string;
+  name: string;
+  tagline?: string;
+  category?: string;
+  official?: boolean;
+  repo: string;
+  bundled: boolean;
+  installed: boolean;
+  enabled: boolean;
+};
+
 // Per-plugin update status (GET /api/plugins/updates, ADR 0027). The backend
 // TTL-caches these — a *pinned* plugin (its requested_ref is a full SHA) skips
 // the network; the rest ls-remote their ref. `behind` ⇒ the recorded

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -4,7 +4,7 @@ import { Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 
 import { useState } from "react";
-import { ExternalLink, Github, Loader2, RefreshCw, Store } from "lucide-react";
+import { Download, ExternalLink, Github, Loader2, RefreshCw, Search, Store } from "lucide-react";
 
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { pluginUpdatesQuery, queryKeys, runtimeStatusQuery } from "../lib/queries";
@@ -13,8 +13,9 @@ import { errMsg } from "../lib/format";
 import { StatusPill } from "../app/StatusPill";
 import { PluginsSection } from "../settings/PluginsSection";
 import { PluginFreshness } from "./PluginFreshness";
+import { catalogCategories, filterCatalog } from "./catalog";
 import { api } from "../lib/api";
-import type { PluginUpdate, RuntimeStatus } from "../lib/types";
+import type { CatalogPlugin, PluginUpdate, RuntimeStatus } from "../lib/types";
 
 type Plugin = NonNullable<RuntimeStatus["plugins"]>[number];
 
@@ -165,7 +166,7 @@ function LocalTab() {
         ) : (
           <div className="table-list">
             <div className="table-row">
-              <span>no plugins installed — see the Market or Download tabs</span>
+              <span>no plugins installed — see the Discover or Download tabs</span>
               <StatusPill label="none" tone="muted" />
             </div>
           </div>
@@ -175,16 +176,79 @@ function LocalTab() {
   );
 }
 
-// Market — discover plugins (directory + GitHub topic).
-function MarketTab() {
+// Discover — the in-app official-plugin directory (ADR 0059): browse the curated
+// catalog + one-click install (runtime install, works on every surface incl. the
+// frozen desktop app via ADR 0058).
+function DiscoverTab() {
+  const qc = useQueryClient();
+  const catalog = useQuery({ queryKey: ["plugin-catalog"], queryFn: () => api.pluginCatalog(), retry: false });
+  const [q, setQ] = useState("");
+  const [cat, setCat] = useState("All");
+  const [hint, setHint] = useState<string | null>(null);
+
+  const install = useMutation({
+    mutationFn: (p: CatalogPlugin) => api.installPlugin(p.repo),
+    onSuccess: (res, p) => {
+      qc.invalidateQueries({ queryKey: ["plugin-catalog"] });
+      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      setHint(`${p.name} installed${res.reloaded ? " + enabled" : ""}.`);
+    },
+    onError: (err: unknown, p) => setHint(`Couldn't install ${p.name}: ${errMsg(err)}`),
+  });
+  const installingRepo = install.isPending ? install.variables?.repo : undefined;
+
+  const plugins = catalog.data?.plugins ?? [];
+  const categories = catalogCategories(plugins);
+  const shown = filterCatalog(plugins, q, cat);
+
   return (
     <>
-      <PanelHeader title="Market" kicker="discover plugins" />
+      <PanelHeader title="Discover" kicker={`${plugins.length} official plugins`} />
       <div className="stage-body">
-        <div className="plugin-market">
+        {hint ? <p className="plugin-hint">{hint}</p> : null}
+        <div className="plugin-discover-controls">
+          <div className="plugin-search">
+            <Search size={14} />
+            <input placeholder="Search plugins…" value={q} onChange={(e) => setQ(e.target.value)} aria-label="Search plugins" />
+          </div>
+          <div className="plugin-cats">
+            {categories.map((c) => (
+              <button key={c} type="button" className={c === cat ? "plugin-cat on" : "plugin-cat"} onClick={() => setCat(c)}>{c}</button>
+            ))}
+          </div>
+        </div>
+        {catalog.isLoading ? <p className="muted">Loading directory…</p> : null}
+        {catalog.isError ? <p className="plugin-hint">Couldn't load the catalog: {errMsg(catalog.error)}</p> : null}
+        <div className="plugin-card-grid">
+          {shown.map((p) => (
+            <div className="plugin-card" key={p.id}>
+              <div className="plugin-card-head">
+                <strong>{p.name}</strong>
+                {p.category ? <span className="plugin-chip">{p.category}</span> : null}
+              </div>
+              <p className="plugin-card-tagline">{p.tagline}</p>
+              <div className="plugin-card-foot">
+                <a className="plugin-card-repo" href={p.repo} target="_blank" rel="noopener noreferrer">
+                  <Github size={13} /> repo <ExternalLink size={11} />
+                </a>
+                {p.bundled ? (
+                  <StatusPill label="bundled" tone="muted" />
+                ) : p.installed ? (
+                  <StatusPill label={p.enabled ? "installed · on" : "installed"} tone="success" />
+                ) : (
+                  <Button type="button" disabled={install.isPending} onClick={() => { setHint(null); install.mutate(p); }}>
+                    {installingRepo === p.repo ? <Loader2 size={14} className="spin" /> : <Download size={14} />} Install
+                  </Button>
+                )}
+              </div>
+            </div>
+          ))}
+          {!shown.length && !catalog.isLoading ? <p className="muted">No plugins match.</p> : null}
+        </div>
+        <div className="plugin-market" style={{ marginTop: 14 }}>
           <a className="plugin-market-link" href={DIRECTORY_URL} target="_blank" rel="noopener noreferrer">
             <Store size={16} />
-            <span><strong>Browse the directory</strong><span className="muted">Curated + community plugins, with install URLs</span></span>
+            <span><strong>Full directory</strong><span className="muted">Curated + community plugins online</span></span>
             <ExternalLink size={14} />
           </a>
           <a className="plugin-market-link" href={TOPIC_URL} target="_blank" rel="noopener noreferrer">
@@ -193,9 +257,6 @@ function MarketTab() {
             <ExternalLink size={14} />
           </a>
         </div>
-        <p className="muted" style={{ marginTop: 10 }}>
-          Found one? Copy its git URL and install it from the <strong>Download</strong> tab.
-        </p>
       </div>
     </>
   );
@@ -215,7 +276,7 @@ function DownloadTab() {
 
 const TABS: Record<PluginsTab, () => JSX.Element> = {
   local: LocalTab,
-  market: MarketTab,
+  market: DiscoverTab,
   download: DownloadTab,
 };
 

--- a/apps/web/src/plugins/catalog.test.ts
+++ b/apps/web/src/plugins/catalog.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+
+import { catalogCategories, filterCatalog } from "./catalog";
+import type { CatalogPlugin } from "../lib/types";
+
+const mk = (over: Partial<CatalogPlugin>): CatalogPlugin => ({
+  id: "x",
+  name: "X",
+  repo: "https://github.com/o/x",
+  bundled: false,
+  installed: false,
+  enabled: false,
+  ...over,
+});
+
+const CAT: CatalogPlugin[] = [
+  mk({ id: "discord", name: "Discord", category: "Communication", tagline: "chat bot" }),
+  mk({ id: "artifact", name: "Artifact", category: "Generative UI", tagline: "sandboxed iframe" }),
+  mk({ id: "pm", name: "Product Manager", category: "Product", tagline: "PM skills + brain" }),
+];
+
+describe("filterCatalog", () => {
+  it("returns everything for empty query + All", () => {
+    expect(filterCatalog(CAT, "", "All")).toHaveLength(3);
+  });
+
+  it("matches name, tagline, and id (case-insensitive)", () => {
+    expect(filterCatalog(CAT, "DISCORD", "All").map((p) => p.id)).toEqual(["discord"]);
+    expect(filterCatalog(CAT, "iframe", "All").map((p) => p.id)).toEqual(["artifact"]);
+    expect(filterCatalog(CAT, "pm", "All").map((p) => p.id)).toEqual(["pm"]);
+  });
+
+  it("filters by category and combines with query", () => {
+    expect(filterCatalog(CAT, "", "Product").map((p) => p.id)).toEqual(["pm"]);
+    expect(filterCatalog(CAT, "chat", "Communication").map((p) => p.id)).toEqual(["discord"]);
+    expect(filterCatalog(CAT, "chat", "Product")).toEqual([]);
+  });
+});
+
+describe("catalogCategories", () => {
+  it("is All + the distinct categories, sorted", () => {
+    expect(catalogCategories(CAT)).toEqual(["All", "Communication", "Generative UI", "Product"]);
+  });
+});

--- a/apps/web/src/plugins/catalog.ts
+++ b/apps/web/src/plugins/catalog.ts
@@ -1,0 +1,17 @@
+import type { CatalogPlugin } from "../lib/types";
+
+// Filter the official-plugin catalog by free-text query + category (ADR 0059).
+// Pure — unit-tested and shared by the Discover section.
+export function filterCatalog(plugins: CatalogPlugin[], q: string, category: string): CatalogPlugin[] {
+  const needle = q.trim().toLowerCase();
+  return plugins.filter((p) => {
+    if (category !== "All" && (p.category || "Other") !== category) return false;
+    if (!needle) return true;
+    return `${p.name} ${p.tagline ?? ""} ${p.id}`.toLowerCase().includes(needle);
+  });
+}
+
+// The category chips for a catalog: "All" + the distinct categories, sorted.
+export function catalogCategories(plugins: CatalogPlugin[]): string[] {
+  return ["All", ...Array.from(new Set(plugins.map((p) => p.category || "Other"))).sort()];
+}

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -56,3 +56,23 @@
 .btn-icon.danger:hover { color: var(--danger); }
 .plugin-restart-row { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-top: 16px; padding-top: 12px; border-top: 1px solid var(--border); }
 .plugin-restart-row > span { margin: 0; }
+
+/* Discover (ADR 0059) — the in-app official-plugin directory: search + category
+   filter over a grid of installable cards. */
+.plugin-discover-controls { display: flex; align-items: center; gap: 10px; flex-wrap: wrap; margin: 6px 0 12px; }
+.plugin-search { display: flex; align-items: center; gap: 6px; flex: 1; min-width: 200px; padding: 6px 10px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 7px; }
+.plugin-search > svg { color: var(--fg-muted); flex-shrink: 0; }
+.plugin-search input { flex: 1; min-width: 0; border: 0; background: transparent; color: var(--fg); font-size: 13px; outline: none; }
+.plugin-cats { display: flex; gap: 6px; flex-wrap: wrap; }
+.plugin-cat { padding: 4px 10px; font-size: 12px; border-radius: 999px; border: 1px solid var(--border); background: transparent; color: var(--fg-secondary); cursor: pointer; transition: border-color 0.15s, color 0.15s; }
+.plugin-cat:hover { border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 45%, transparent); }
+.plugin-cat.on { background: color-mix(in srgb, var(--pl-color-brand-lavender) 18%, transparent); border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 55%, transparent); color: var(--fg); }
+.plugin-card-grid { display: grid; grid-template-columns: repeat(auto-fill, minmax(260px, 1fr)); gap: 10px; }
+.plugin-card { display: flex; flex-direction: column; gap: 6px; padding: 12px; border: 1px solid var(--border); border-radius: 9px; background: var(--bg-raised); }
+.plugin-card-head { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
+.plugin-card-head strong { font-size: 14px; }
+.plugin-chip { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; padding: 1px 7px; border-radius: 999px; background: var(--bg-hover); color: var(--fg-muted); white-space: nowrap; }
+.plugin-card-tagline { font-size: 12px; color: var(--fg-secondary); margin: 0; flex: 1; }
+.plugin-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 2px; }
+.plugin-card-repo { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: var(--fg-muted); text-decoration: none; }
+.plugin-card-repo:hover { color: var(--fg-secondary); }

--- a/config/plugin-catalog.json
+++ b/config/plugin-catalog.json
@@ -1,0 +1,93 @@
+{
+  "_comment": "Curated official-plugin directory served by GET /api/plugins/catalog and rendered in the Plugins ▸ Discover section (ADR 0059). The official source; keep in sync with sites/marketing/data/plugins.json. A fork can override it by placing its own plugin-catalog.json in the live config dir. `repo` is the install URL (one-click install runs `plugin install <repo>`, ADR 0058 — works on every surface incl. the frozen desktop app).",
+  "plugins": [
+    {
+      "id": "discord",
+      "name": "Discord",
+      "category": "Communication",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/discord-plugin",
+      "tagline": "Run your agent as a Discord bot — inbound DMs + @-mentions, outbound send/read/react tools."
+    },
+    {
+      "id": "artifact",
+      "name": "Artifact (Generative UI)",
+      "category": "Generative UI",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/artifact-plugin",
+      "tagline": "Render HTML/SVG/Mermaid/React into a sandboxed iframe (show_artifact). The reference external plugin."
+    },
+    {
+      "id": "terminal",
+      "name": "Terminal",
+      "category": "Tools",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/terminal-plugin",
+      "tagline": "A full terminal (xterm.js + a real PTY over WebSocket) as a console view, themed from the design system."
+    },
+    {
+      "id": "agent_browser",
+      "name": "Agent Browser",
+      "category": "Automation",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/agent-browser-plugin",
+      "tagline": "Browser automation backed by vercel-labs/agent-browser: tools + skill + workflows + a live browser panel."
+    },
+    {
+      "id": "project_board",
+      "name": "Project Board",
+      "category": "Orchestration",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/projectBoard-plugin",
+      "tagline": "Board-driven coding orchestration — a beads board + ACP spawn loop + planning layer + console view."
+    },
+    {
+      "id": "portfolio",
+      "name": "Portfolio",
+      "category": "Orchestration",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/portfolio-plugin",
+      "tagline": "Multi-team orchestration — one PM across many project boards over A2A (ADR 0055)."
+    },
+    {
+      "id": "pm",
+      "name": "Product Manager",
+      "category": "Product",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/pm-plugin",
+      "tagline": "PM toolkit — 65 PM skills, a provenance-enforced PM Brain, specialist subagents, and a brain dashboard."
+    },
+    {
+      "id": "spacetraders",
+      "name": "SpaceTraders",
+      "category": "Examples",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/spacetraders-plugin",
+      "tagline": "Autonomous SpaceTraders fleet commander — tools, crew, workflows, skills, and a console dashboard."
+    },
+    {
+      "id": "prototrader-finance",
+      "name": "protoTrader Finance",
+      "category": "Finance",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/prototrader-finance",
+      "tagline": "Market data, backtesting, factor IC, a gated paper broker, the research desk, and a Quant Desk view."
+    },
+    {
+      "id": "monarch_money",
+      "name": "Monarch Money",
+      "category": "Finance",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/monarch-money-plugin",
+      "tagline": "Give your agent access to Monarch Money via its MCP server."
+    },
+    {
+      "id": "doom",
+      "name": "DOOM",
+      "category": "Examples",
+      "official": true,
+      "repo": "https://github.com/protoLabsAI/doom-plugin",
+      "tagline": "But can it run DOOM? Play shareware DOOM in a console view via WebAssembly (prboom)."
+    }
+  ]
+}

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -27,6 +27,7 @@ routes don't serve until a process restart, so both routes flag it.
 from __future__ import annotations
 
 import logging
+import re
 
 from fastapi import HTTPException
 
@@ -131,6 +132,52 @@ def register_plugin_routes(app) -> None:
                     "secrets": m.secrets,
                 }
             out.append(item)
+        return {"plugins": out}
+
+    @app.get("/api/plugins/catalog")
+    async def _catalog():
+        """The curated official-plugin directory (ADR 0059) — `config/plugin-catalog.json`
+        (live dir overrides the bundle), merged with install state so the Discover UI can
+        show **Available / Installed / Bundled**. State is matched by `repo` URL (robust)
+        or id; one-click install runs `plugin install <repo>` (ADR 0058)."""
+        import json
+
+        from graph.config_io import _BUNDLE_CONFIG_DIR, _live_config_dir
+
+        entries: list[dict] = []
+        for base in (_live_config_dir(), _BUNDLE_CONFIG_DIR):
+            f = base / "plugin-catalog.json"
+            if f.exists():
+                try:
+                    entries = (json.loads(f.read_text()) or {}).get("plugins") or []
+                except (json.JSONDecodeError, OSError):
+                    log.warning("[plugins] plugin-catalog.json unreadable at %s", f)
+                break
+
+        def _norm(u: str | None) -> str:
+            return re.sub(r"\.git$", "", (u or "").strip().rstrip("/")).lower()
+
+        installed = installer.list_installed()
+        by_url = {_norm(e.get("source_url")): e["id"] for e in installed if e.get("source_url")}
+        by_id = {e["id"] for e in installed}
+        enabled = {p["id"]: bool(p.get("enabled")) for p in (STATE.plugin_meta or [])}
+
+        out = []
+        for entry in entries:
+            eid = entry.get("id") or ""
+            repo = entry.get("repo") or entry.get("install_url") or ""
+            # Bundled built-in (still in the repo's plugins/ tree) — already present, can't
+            # be git-installed over (the installer's built-in guard); show as "Bundled".
+            bundled = bool(eid) and (installer.REPO_ROOT / "plugins" / eid).exists()
+            inst_id = by_url.get(_norm(repo)) or (eid if eid in by_id else None)
+            out.append(
+                {
+                    **entry,
+                    "bundled": bundled,
+                    "installed": inst_id is not None,
+                    "enabled": enabled.get(inst_id, False) if inst_id else False,
+                }
+            )
         return {"plugins": out}
 
     @app.post("/api/plugins/install")

--- a/tests/test_plugin_catalog_route.py
+++ b/tests/test_plugin_catalog_route.py
@@ -1,0 +1,79 @@
+"""GET /api/plugins/catalog — the Discover directory (ADR 0059), merged with state."""
+
+from __future__ import annotations
+
+import json
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import graph.config_io as cio
+import runtime.state as rs
+from graph.plugins import installer
+from operator_api.plugin_routes import register_plugin_routes
+
+
+def _client(catalog_dir):
+    app = FastAPI()
+    register_plugin_routes(app)
+    return TestClient(app)
+
+
+def test_catalog_served_with_install_state(monkeypatch, tmp_path):
+    (tmp_path / "plugin-catalog.json").write_text(
+        json.dumps(
+            {
+                "plugins": [
+                    {"id": "discord", "name": "Discord", "repo": "https://github.com/protoLabsAI/discord-plugin"},
+                    {"id": "artifact", "name": "Artifact", "repo": "https://github.com/protoLabsAI/artifact-plugin"},
+                    {"id": "terminal", "name": "Terminal", "repo": "https://github.com/protoLabsAI/terminal-plugin"},
+                ]
+            }
+        )
+    )
+    # Catalog resolves from the bundle dir; live dir empty; no built-ins present.
+    monkeypatch.setattr(cio, "_BUNDLE_CONFIG_DIR", tmp_path)
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path / "nolive"))
+    monkeypatch.setattr(installer, "REPO_ROOT", tmp_path)  # tmp_path/plugins doesn't exist → nothing bundled
+    # artifact installed (matched by repo URL, even with a trailing .git) + enabled; terminal installed, disabled.
+    monkeypatch.setattr(
+        installer,
+        "list_installed",
+        lambda: [
+            {"id": "artifact", "source_url": "https://github.com/protoLabsAI/artifact-plugin.git", "present": True},
+            {"id": "terminal", "source_url": "https://github.com/protoLabsAI/terminal-plugin", "present": True},
+        ],
+    )
+    monkeypatch.setattr(rs.STATE, "plugin_meta", [{"id": "artifact", "enabled": True}], raising=False)
+
+    r = _client(tmp_path).get("/api/plugins/catalog")
+    assert r.status_code == 200
+    plugs = {p["id"]: p for p in r.json()["plugins"]}
+    assert len(plugs) == 3
+    assert plugs["artifact"]["installed"] and plugs["artifact"]["enabled"]
+    assert plugs["terminal"]["installed"] and plugs["terminal"]["enabled"] is False
+    assert plugs["discord"]["installed"] is False and plugs["discord"]["bundled"] is False
+
+
+def test_catalog_marks_bundled_builtin(monkeypatch, tmp_path):
+    (tmp_path / "plugin-catalog.json").write_text(
+        json.dumps({"plugins": [{"id": "discord", "name": "Discord", "repo": "https://github.com/x/discord-plugin"}]})
+    )
+    monkeypatch.setattr(cio, "_BUNDLE_CONFIG_DIR", tmp_path)
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path / "nolive"))
+    monkeypatch.setattr(installer, "list_installed", lambda: [])
+    monkeypatch.setattr(rs.STATE, "plugin_meta", [], raising=False)
+    # A repo root whose plugins/discord exists → that catalog entry is "bundled".
+    (tmp_path / "plugins" / "discord").mkdir(parents=True)
+    monkeypatch.setattr(installer, "REPO_ROOT", tmp_path)
+
+    plugs = {p["id"]: p for p in _client(tmp_path).get("/api/plugins/catalog").json()["plugins"]}
+    assert plugs["discord"]["bundled"] is True and plugs["discord"]["installed"] is False
+
+
+def test_catalog_empty_when_no_file(monkeypatch, tmp_path):
+    monkeypatch.setattr(cio, "_BUNDLE_CONFIG_DIR", tmp_path)
+    monkeypatch.setenv("PROTOAGENT_CONFIG_DIR", str(tmp_path / "nolive"))
+    monkeypatch.setattr(installer, "list_installed", lambda: [])
+    monkeypatch.setattr(rs.STATE, "plugin_meta", [], raising=False)
+    assert _client(tmp_path).get("/api/plugins/catalog").json() == {"plugins": []}


### PR DESCRIPTION
## What

First slice of the unified plugin manager (epic **bd-23a**, [ADR 0059](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0059-unified-plugin-manager.md)): **browse + one-click download official plugins from inside the app** — on every surface including the frozen desktop, because runtime install just landed ([ADR 0058](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0058-runtime-plugin-install-frozen-app.md)).

## bd-23a.1 — host-served catalog
- `config/plugin-catalog.json` — the curated official directory (11 plugins: discord, artifact, terminal, agent-browser, project-board, portfolio, pm, spacetraders, prototrader-finance, monarch-money, doom). The index ADR 0027 D9 gestured at; offline/desktop-safe; a fork can override it in the live config dir.
- `GET /api/plugins/catalog` — serves it merged with install state (matched by **repo URL**, robust to id/`.git` differences) + a `bundled` flag for built-ins still in the tree.

## bd-23a.2 — Discover
- The link-only **Market** tab becomes a real in-app directory: cards (name · tagline · category), **search + category filter**, and a per-card **Install** that posts the repo to the existing install API. States: *Available / Installed · on / Bundled*.
- Tabs relabeled **Installed / Discover / Install URL** (the full collapse to two sections is bd-23a.4). `filterCatalog`/`catalogCategories` are pure + unit-tested.

## Tests
- Backend: 3 route tests (catalog served, state merge, bundled detection, empty).
- Web unit: 4 (filter/categories). e2e: updated `navigation`/`plugin-install` for the new tabs + asserts Discover cards (catalog mock added to the harness).
- **All gates green:** ruff · import-contracts (3/0) · pytest **2278** · web build/typecheck · unit **94** · e2e **106**.

## Follow-ups (epic bd-23a)
`.3` fold per-plugin config into Installed rows · `.4` collapse to Discover/Installed · `.5` generalize bespoke affordances. Catalog completeness (sync with `sites/marketing/data/plugins.json`) tracked under `.1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)