### PR TITLE
fix(web): proxy /_ds in dev so plugin-kit loads in plugin iframes

### DIFF
--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -25,6 +25,12 @@ export default defineConfig(({ mode }) => {
         // (ADR 0026). In prod the backend serves /app + /plugins together; the dev
         // server must proxy them too, else a plugin view 404s on Vite's /app/ base.
         "/plugins": apiBase,
+        // The DS plugin-kit (CSS + JS) the backend serves same-origin at /_ds/… A plugin
+        // iframe base-splits to "" and requests root-absolute /_ds/plugin-kit.{css,js}; it
+        // bypasses Vite's /app/ base, so without this proxy it 404s on the dev server and
+        // EVERY plugin view loses its theme handshake (prod is fine — the backend serves
+        // /_ds from the built dist). Mirrors /plugins above.
+        "/_ds": apiBase,
         "/healthz": apiBase,
       },
     },


### PR DESCRIPTION
Plugin views render **unthemed in the dev server** (`npm run web:dev`): their iframe pages load `/_ds/plugin-kit.{css,js}` to run the `protoagent:init` theme handshake, but the page base-splits `location.pathname` to `""` and requests **root-absolute** `/_ds/plugin-kit.*`. That bypasses Vite's `/app/` base and **isn't proxied** → 404 → no plugin-kit → every plugin iframe loads unstyled.

Fix: add `/_ds` to the Vite proxy (→ backend, which serves it 200), mirroring the `/plugins` entry directly above.

Prod/desktop unaffected — the backend serves `/_ds` from the built dist; this is dev-server only. Verified locally: `/_ds/plugin-kit.{css,js}` go 404 → 200 and plugin views theme correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)