### PR TITLE
feat(web): separate panel vs palette plugin views + Esc-back (ADR 0057)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.44.1",
+    "@protolabsai/ui": "^0.44.2",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -537,15 +537,17 @@ export function App() {
       .filter((s) => !s.requiresPlugin || enabledPluginIds.has(s.requiresPlugin))
       .map((s) => ({ id: s.id, label: s.label, icon: s.icon })),
   });
-  // Plugin views opted into inline palette morphing (manifest `views[].palette:
-  // "inline"`): ⌘K → the view's command expands its iframe in the palette body,
-  // themed + authed via the same handshake PluginView uses.
+  // Plugin views opted into inline palette morphing (manifest `views[].palette`):
+  // ⌘K → the view's command expands its iframe in the palette body, themed + authed
+  // via the same handshake PluginView uses. `"inline"` reuses the rail page; an object
+  // `{ path }` ships a DISTINCT page for the palette (e.g. a tighter quick editor) vs
+  // the full rail panel — so a plugin can serve separate panel and palette views.
   const inlinePaletteViews = allPluginViews
-    .filter((v) => v.palette === "inline")
+    .filter((v) => v.palette === "inline" || (typeof v.palette === "object" && v.palette !== null))
     .map((v) => ({
       id: v.key,
       title: v.label,
-      url: apiUrl(v.path),
+      url: apiUrl(typeof v.palette === "object" && v.palette?.path ? v.palette.path : v.path),
       icon: pluginViewIcon(v.icon),
       theme: consoleTheme(),
       token: authToken(),

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -101,9 +101,11 @@ export type PluginView = {
   slot?: "chat";
   // ADR 0057 — opt this view into the command palette as an INLINE morph target: its
   // ⌘K command expands the plugin's iframe in the palette body (themed/authed via the
-  // same handshake) instead of navigating to its rail. Passes through `_parse_views`
-  // verbatim (it keeps the whole view dict), so it's a manifest-only opt-in.
-  palette?: "inline";
+  // same handshake) instead of navigating to its rail. `"inline"` reuses this view's
+  // `path`; `{ path }` ships a DISTINCT page for the palette (e.g. a tighter quick
+  // editor) vs the full rail panel — so a plugin can ship separate panel/palette views.
+  // Passes through `_parse_views` verbatim (it keeps the whole view dict) — manifest-only.
+  palette?: "inline" | { path?: string };
   // Owning plugin's load state, stamped on by App so the view host can surface a real,
   // actionable error (loaded=false ⇒ the view route isn't serving — missing env / bad
   // deps / mount race; `pluginError` is the loader's exact diagnostic) instead of a

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.44.1",
+        "@protolabsai/ui": "^0.44.2",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.44.1",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.44.1.tgz",
-      "integrity": "sha512-4EQL3JbUws/YVzDVHzdJjr2hlzfyCl9YcNU+jR359FMcHaCSStDg4+jrbBA9WbvE5FMI5e42Lsor2TmwJclL2g==",
+      "version": "0.44.2",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.44.2.tgz",
+      "integrity": "sha512-pXbTYy++eUaaMPUCAFGqtpvBt2G+zh6+iqTe7pGPHfRwWrLZ4vyAdI+yfxXo/Ucy4NXKU+TSa/Eb5NuwwXE/6A==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",

--- a/plugins/notes/__init__.py
+++ b/plugins/notes/__init__.py
@@ -110,6 +110,14 @@ def _build_view_router():
     async def _view():
         return HTMLResponse(_EDITOR_HTML)
 
+    # The compact "quick note" PAGE (ADR 0057) — the plugin's PALETTE view: the same
+    # shared note + autosave, trimmed chrome (no preview toggle) to fit the ⌘K palette
+    # body. Demonstrates a DISTINCT palette page vs the full rail editor — the manifest
+    # points the palette morph here via `palette: { path: /plugins/notes/quick }`.
+    @router.get("/quick")
+    async def _quick():
+        return HTMLResponse(_QUICK_HTML)
+
     return router
 
 
@@ -224,6 +232,53 @@ _EDITOR_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
     }catch(e){} }
   load();
   // Be a good desktop citizen: don't poll while the window is hidden/minimized; refresh on return.
+  setInterval(function(){ if(!document.hidden && !dirty) load(); }, 4000);
+  document.addEventListener("visibilitychange", function(){ if(!document.hidden && !dirty) load(); });
+</script></body></html>"""
+
+
+# The compact PALETTE page (ADR 0057) — same shared note + autosave + adopt-the-agent's
+# writes, but trimmed to a single textarea (no preview toggle / marked) so it fits the
+# ⌘K palette body. Four-rules compliant like the full editor (slug-aware base, the DS
+# kit owns theme + authed fetch).
+_QUICK_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
+<script>
+  "use strict";
+  window.__base = location.pathname.split("/plugins/")[0];
+  document.write('<link rel="stylesheet" href="' + window.__base + '/_ds/plugin-kit.css">');
+</script>
+<style>
+  html,body{margin:0;height:100%;background:var(--pl-color-bg);color:var(--pl-color-fg);
+    font-family:var(--pl-font-sans,ui-sans-serif,system-ui,sans-serif)}
+  #wrap{display:flex;flex-direction:column;height:100%}
+  #bar{padding:6px 10px;border-bottom:var(--pl-border-width,1px) solid var(--pl-color-border);
+    font-size:11px;color:var(--pl-color-fg-muted)}
+  #ed{flex:1;min-height:0;resize:none;border:0;outline:none;padding:10px 12px;background:transparent;
+    color:var(--pl-color-fg);font-family:var(--pl-font-mono,ui-monospace,Menlo,monospace);
+    font-size:13px;line-height:1.55}
+</style></head><body>
+<div id="wrap">
+  <div id="bar"><span id="status">Quick note</span></div>
+  <textarea id="ed" placeholder="Jot — saves to the shared note." spellcheck="false"></textarea>
+</div>
+<script type="module">
+  "use strict";
+  let kit;
+  try { kit = await import(window.__base + "/_ds/plugin-kit.js"); }
+  catch (e) { kit = { initPluginView(){}, apiFetch:(p,i)=>fetch(window.__base+p,i) }; }
+  var lastSynced="", dirty=false, t=null;
+  var ed=document.getElementById("ed"), st=document.getElementById("status");
+  kit.initPluginView(function(){ if(!dirty) load(); });
+  ed.addEventListener("input", function(){ dirty=true; st.textContent="Saving…"; clearTimeout(t); t=setTimeout(save,600); });
+  async function save(){ try{
+      var r=await kit.apiFetch("/api/plugins/notes/note",{method:"PUT",headers:{"Content-Type":"application/json"},body:JSON.stringify({content:ed.value})});
+      if(!r.ok)throw 0; lastSynced=ed.value; dirty=false; st.textContent="Saved ✓";
+    }catch(e){ st.textContent="Save failed"; } }
+  async function load(){ try{
+      var a=await kit.apiFetch("/api/plugins/notes/note").then(function(r){return r.json();});
+      if(typeof a.content==="string" && a.content!==lastSynced && !dirty){ ed.value=a.content; lastSynced=a.content; }
+    }catch(e){} }
+  load();
   setInterval(function(){ if(!document.hidden && !dirty) load(); }, 4000);
   document.addEventListener("visibilitychange", function(){ if(!document.hidden && !dirty) load(); });
 </script></body></html>"""

--- a/plugins/notes/protoagent.plugin.yaml
+++ b/plugins/notes/protoagent.plugin.yaml
@@ -13,6 +13,8 @@ capabilities:
 # The plugin self-serves its editor page (ADR 0038) — a sandboxed iframe, no host build, so it's
 # git-installable like any plugin. (Was a federated `ui: react` remote; federation retired.)
 views:
-  # `palette: inline` (ADR 0057) — ⌘K → "Notes" morphs the editor into the command
-  # palette body (themed/authed via the same handshake) instead of jumping to the rail.
-  - { id: notes, label: "Notes", icon: "FileText", placement: right, path: "/plugins/notes/view", palette: inline }
+  # Separate panel vs palette views (ADR 0057): the RAIL panel keeps the full editor
+  # (`path: /view`), while ⌘K → "Notes" morphs a DISTINCT compact quick-note page
+  # (`palette: { path: /quick }`) into the palette body. (`palette: inline` would reuse
+  # the same /view page for both.)
+  - { id: notes, label: "Notes", icon: "FileText", placement: right, path: "/plugins/notes/view", palette: { path: "/plugins/notes/quick" } }

--- a/tests/test_notes_plugin.py
+++ b/tests/test_notes_plugin.py
@@ -62,3 +62,18 @@ def test_editor_view_follows_the_four_rules() -> None:
     # antipattern the kit replaces.
     assert "#0a0a0c" not in html
     assert 'addEventListener("message"' not in html
+
+
+def test_quick_palette_view_follows_the_four_rules() -> None:
+    """The compact palette page (ADR 0057 — `palette: { path: /quick }`) must stay
+    four-rules compliant too: it's the same sandboxed-iframe contract as the editor."""
+    html = _load_notes()._QUICK_HTML
+    assert "/_ds/plugin-kit.css" in html
+    assert "/_ds/plugin-kit.js" in html
+    assert 'location.pathname.split("/plugins/")[0]' in html  # slug-aware base
+    assert 'apiFetch("/api/plugins/notes/note"' in html  # gated data via the kit
+    assert "initPluginView" in html
+    assert 'type="module"' in html
+    assert 'import(window.__base + "/_ds/plugin-kit.js")' in html  # ESM dynamic import
+    assert "#0a0a0c" not in html
+    assert 'addEventListener("message"' not in html


### PR DESCRIPTION
**"As a user I want to ship separate views for my panel vs the ⌘K palette."** Now you can.

## What
Manifest `views[].palette` accepts an object `{ path }` — a **distinct page** for the palette morph — alongside the existing `"inline"` (reuse the panel page):
```yaml
- { id: notes, path: /plugins/notes/view,            # rail panel = full editor
    palette: { path: /plugins/notes/quick } }        # ⌘K morph = compact quick-note
```
The adapter resolves the morph URL from `palette.path ?? path`. Manifest-only opt-in (`_parse_views` keeps the whole dict), no rail pollution.

**Showcase — the notes plugin:** the rail keeps the full markdown editor (`/view`, preview toggle, marked); ⌘K → "Notes" morphs a **compact quick-note** page (`/quick`, single textarea, same shared note) into the palette body. Both four-rules compliant.

## Also: Esc-back
Bumps `@protolabsai/ui ^0.44.1 → ^0.44.2`, which carries the DS fix so **Escape pops back out of inline iframe views** (keystrokes inside a cross-document iframe don't bubble to the host — protoContent #271).

## Files
- `lib/types` — `palette?: "inline" | { path?: string }`
- `App.tsx` — inline morph URL = `apiUrl(palette.path ?? path)`
- `plugins/notes` — `/quick` route + `_QUICK_HTML` + manifest `palette: { path }`
- `tests/test_notes_plugin.py` — quick-page four-rules test

## Verification
`npm run build` + **94 web tests** + **4 notes tests** green. (The `/quick` route is new, so a running backend needs a restart to mount it.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)