### PR TITLE
feat(plugins): fold per-plugin config into the Installed rows (ADR 0059, bd-23a.3)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -222,6 +222,16 @@ export const SETTINGS_SCHEMA = [
       { key: "runtime.autostart_on_boot", label: "Autostart on boot", type: "bool", section: "Runtime", restart: true, description: "Install/remove the boot LaunchAgent.", options: [], value: false, default: false, scope: "agent", source: "agent" },
     ],
   },
+  // A plugin-contributed group (ADR 0019/0059) — tagged with plugin_id so the
+  // Plugins surface folds it into the "Demo Plugin" Installed row (Configure).
+  {
+    section: "Demo Plugin",
+    category: "Plugins",
+    plugin_id: "demo",
+    fields: [
+      { key: "demo.greeting", label: "Greeting", type: "string", section: "Demo Plugin", restart: false, description: "Shown by the demo tool.", options: [], value: "hello", default: "hello", scope: "agent", source: "agent" },
+    ],
+  },
 ];
 
 /** restart_required for a flat updates payload, per the schema. */

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -71,6 +71,13 @@ test("plugins section: Installed / Discover / Install URL tabs", async ({ page }
     .getByRole("button", { name: "Enable" }).click();
   await expect(page.locator(".plugin-hint")).toContainText("Zzz Disabled enabled");
 
+  // Config folded in (ADR 0059, bd-23a.3) — Demo Plugin has a settings group, so its
+  // row exposes Configure → its fields render inline.
+  const demoRow = page.locator(".plugin-row-wrap", { hasText: "Demo Plugin" });
+  await demoRow.getByRole("button", { name: "Configure" }).click();
+  // Fields render flat (no nested accordion) — reachable immediately.
+  await expect(demoRow.locator('.plugin-row-config .setting-row[data-key="demo.greeting"]')).toBeVisible();
+
   // Discover tab — the in-app official-plugin directory (ADR 0059): cards + search.
   await page.locator(".pl-tabs").getByRole("tab", { name: "Discover", exact: true }).click();
   await expect(page.getByLabel("Search plugins")).toBeVisible();

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -223,6 +223,9 @@ export type SettingsGroup = {
   category?: string;
   fields: SettingsField[];
   test?: { endpoint: string };  // ADR 0029 — generic "Test connection" button
+  // The owning plugin id for a plugin-contributed group (ADR 0059) — lets the
+  // Plugins surface fold this group into that plugin's Installed row.
+  plugin_id?: string;
 };
 
 export type WorkflowSummary = {

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -3,15 +3,16 @@ import "../settings/plugins.css";
 import { Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 
-import { useState } from "react";
-import { Download, ExternalLink, Github, Loader2, RefreshCw, Search, Store } from "lucide-react";
+import { Suspense, useState } from "react";
+import { Download, ExternalLink, Github, Loader2, RefreshCw, Search, Settings2, Store } from "lucide-react";
 
 import { PanelHeader } from "@protolabsai/ui/navigation";
-import { pluginUpdatesQuery, queryKeys, runtimeStatusQuery } from "../lib/queries";
+import { pluginUpdatesQuery, queryKeys, runtimeStatusQuery, settingsSchemaQuery } from "../lib/queries";
 import { StagePanel } from "../app/ErrorBoundary";
 import { errMsg } from "../lib/format";
 import { StatusPill } from "../app/StatusPill";
 import { PluginsSection } from "../settings/PluginsSection";
+import { SettingsCategory } from "../settings/SettingsCategory";
 import { PluginFreshness } from "./PluginFreshness";
 import { catalogCategories, filterCatalog } from "./catalog";
 import { api } from "../lib/api";
@@ -40,6 +41,7 @@ function PluginRow({
   onToggle,
   onUpdate,
   updating,
+  configurable,
 }: {
   p: Plugin;
   update?: PluginUpdate;
@@ -47,44 +49,67 @@ function PluginRow({
   onToggle: (p: Plugin) => void;
   onUpdate: (p: Plugin) => void;
   updating: boolean;
+  configurable: boolean;
 }) {
   const on = p.enabled;
+  const [open, setOpen] = useState(false);
   return (
-    <div className="subagent-row" key={p.id}>
-      <div>
-        <strong>
-          {p.name}
-          {p.version ? <span className="muted"> v{p.version}</span> : null}
-          <PluginFreshness update={update} />
-        </strong>
-        <span>{contributionsLabel(p)}</span>
-      </div>
-      <div className="plugin-row-actions">
-        <StatusPill
-          label={p.loaded ? "loaded" : p.error ? "error" : p.enabled ? "enabled" : "disabled"}
-          tone={p.loaded ? "success" : p.error ? "error" : "muted"}
-        />
-        {update?.behind ? (
+    <div className="plugin-row-wrap">
+      <div className="subagent-row">
+        <div>
+          <strong>
+            {p.name}
+            {p.version ? <span className="muted"> v{p.version}</span> : null}
+            <PluginFreshness update={update} />
+          </strong>
+          <span>{contributionsLabel(p)}</span>
+        </div>
+        <div className="plugin-row-actions">
+          <StatusPill
+            label={p.loaded ? "loaded" : p.error ? "error" : p.enabled ? "enabled" : "disabled"}
+            tone={p.loaded ? "success" : p.error ? "error" : "muted"}
+          />
+          {update?.behind ? (
+            <Button
+              type="button"
+              variant="ghost"
+              disabled={updating}
+              onClick={() => onUpdate(p)}
+              title={`Update ${p.name} to the latest commit`}
+            >
+              {updating ? <Loader2 size={14} className="spin" /> : <RefreshCw size={14} />} Update
+            </Button>
+          ) : null}
+          {/* Config folded in (ADR 0059, bd-23a.3) — expand to edit this plugin's settings inline. */}
+          {configurable ? (
+            <Button
+              type="button"
+              variant="ghost"
+              aria-expanded={open}
+              onClick={() => setOpen((o) => !o)}
+              title={`Configure ${p.name}`}
+            >
+              <Settings2 size={14} /> Configure
+            </Button>
+          ) : null}
           <Button
             type="button"
             variant="ghost"
-            disabled={updating}
-            onClick={() => onUpdate(p)}
-            title={`Update ${p.name} to the latest commit`}
+            disabled={busy}
+            onClick={() => onToggle(p)}
+            title={on ? `Disable ${p.name}` : `Enable ${p.name}`}
           >
-            {updating ? <Loader2 size={14} className="spin" /> : <RefreshCw size={14} />} Update
+            {busy ? <Loader2 size={14} className="spin" /> : on ? "Disable" : "Enable"}
           </Button>
-        ) : null}
-        <Button
-          type="button"
-          variant="ghost"
-          disabled={busy}
-          onClick={() => onToggle(p)}
-          title={on ? `Disable ${p.name}` : `Enable ${p.name}`}
-        >
-          {busy ? <Loader2 size={14} className="spin" /> : on ? "Disable" : "Enable"}
-        </Button>
+        </div>
       </div>
+      {configurable && open ? (
+        <div className="plugin-row-config">
+          <Suspense fallback={<p className="muted">Loading settings…</p>}>
+            <SettingsCategory category="Plugins" pluginId={p.id} title={`${p.name} settings`} />
+          </Suspense>
+        </div>
+      ) : null}
     </div>
   );
 }
@@ -138,6 +163,14 @@ function LocalTab() {
   const updatingId = update.isPending ? update.variables?.id : undefined;
   const updateById = new Map((updates.data?.plugins ?? []).map((u) => [u.id, u]));
 
+  // Which plugins have settings to fold in (ADR 0059) — the schema's plugin-tagged
+  // groups. Non-suspense + cached, so it never blocks the list and dedupes with the
+  // SettingsCategory the Configure expander renders.
+  const schema = useQuery(settingsSchemaQuery());
+  const configurableIds = new Set(
+    (schema.data?.groups ?? []).filter((g) => g.plugin_id).map((g) => g.plugin_id as string),
+  );
+
   const plugins = runtime.plugins ?? [];
   const byName = (a: Plugin, b: Plugin) => a.name.localeCompare(b.name);
   const loaded = plugins.filter((p) => p.loaded).sort(byName);
@@ -153,13 +186,13 @@ function LocalTab() {
             {loaded.length ? (
               <>
                 <p className="panel-kicker">Loaded <span className="muted">· {loaded.length}</span></p>
-                <div className="subagent-list">{loaded.map((p) => <PluginRow key={p.id} p={p} update={updateById.get(p.id)} busy={pendingId === p.id} onToggle={onToggle} onUpdate={onUpdate} updating={updatingId === p.id} />)}</div>
+                <div className="subagent-list">{loaded.map((p) => <PluginRow key={p.id} p={p} update={updateById.get(p.id)} busy={pendingId === p.id} onToggle={onToggle} onUpdate={onUpdate} updating={updatingId === p.id} configurable={configurableIds.has(p.id)} />)}</div>
               </>
             ) : null}
             {disabled.length ? (
               <>
                 <p className="panel-kicker">Disabled <span className="muted">· {disabled.length}</span></p>
-                <div className="subagent-list">{disabled.map((p) => <PluginRow key={p.id} p={p} update={updateById.get(p.id)} busy={pendingId === p.id} onToggle={onToggle} onUpdate={onUpdate} updating={updatingId === p.id} />)}</div>
+                <div className="subagent-list">{disabled.map((p) => <PluginRow key={p.id} p={p} update={updateById.get(p.id)} busy={pendingId === p.id} onToggle={onToggle} onUpdate={onUpdate} updating={updatingId === p.id} configurable={configurableIds.has(p.id)} />)}</div>
               </>
             ) : null}
           </>

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -99,6 +99,9 @@ export function SettingsCategory({
   // leaf. The default (false) is the per-agent Settings — every field, with the
   // inherited-vs-overridden badge + reset-to-inherited affordance.
   hostLayer = false,
+  // ADR 0059 — when set, render ONLY this plugin's group (its config folded into the
+  // plugin's row in the Plugins surface). Pairs with category="Plugins".
+  pluginId,
 }: {
   category: string;
   categories?: string[];
@@ -106,6 +109,7 @@ export function SettingsCategory({
   emptyHint?: string;
   footer?: ReactNode;
   hostLayer?: boolean;
+  pluginId?: string;
 }) {
   const queryClient = useQueryClient();
   const { data } = useSuspenseQuery(settingsSchemaQuery());
@@ -113,13 +117,14 @@ export function SettingsCategory({
     // One category, or (host-defaults view) several aggregated into one panel.
     const inScope = (g: SettingsGroup) =>
       categories ? categories.includes(g.category || "Plugins") : (g.category || "Plugins") === category;
-    const selected = data.groups.filter(inScope);
+    let selected = data.groups.filter(inScope);
+    if (pluginId) selected = selected.filter((g) => g.plugin_id === pluginId);  // one plugin's group (ADR 0059)
     if (!hostLayer) return selected;
     // Host-defaults view: keep only the host-scoped fields, dropping now-empty groups.
     return selected
       .map((g) => ({ ...g, fields: g.fields.filter((f) => f.scope === "host") }))
       .filter((g) => g.fields.length);
-  }, [data.groups, category, categories, hostLayer]);
+  }, [data.groups, category, categories, hostLayer, pluginId]);
   const [dirty, setDirty] = useState<Record<string, unknown>>({});
   const [status, setStatus] = useState("");
   const dirtyKeys = Object.keys(dirty);
@@ -216,6 +221,40 @@ export function SettingsCategory({
 
   const discard = () => { setDirty({}); setStatus(""); };
 
+  // The fields + Test/Connect for one group — rendered inside an AccordionItem in the
+  // full Settings view, or flat (no accordion) when folded into a plugin's row (ADR 0059).
+  const renderGroupBody = (group: SettingsGroup) => (
+    <>
+      {group.fields.filter(isVisible).map((field) => (
+        <SettingRow
+          key={field.key}
+          field={field}
+          dirty={field.key in dirty}
+          value={field.key in dirty ? dirty[field.key] : field.value}
+          showInheritance={!hostLayer}
+          onChange={(v) => setDirty((d) => ({ ...d, [field.key]: v }))}
+          onReset={() => reset.mutate([field.key])}
+          resetting={reset.isPending}
+        />
+      ))}
+      {hasDiscord && group.section === "Discord" ? (
+        <div className="settings-group-actions">
+          <TestConnectionButton onClick={() => testDiscord.mutate()} pending={testDiscord.isPending} disabled={save.isPending} />
+          <HelpLink href={DISCORD_GUIDE_URL}>How to create a bot</HelpLink>
+        </div>
+      ) : null}
+      {group.test ? (
+        <div className="settings-group-actions">
+          <TestConnectionButton
+            onClick={() => { setTestingSection(group.section); testGroup.mutate({ endpoint: group.test!.endpoint, fields: groupFields(group) }); }}
+            pending={testGroup.isPending && testingSection === group.section}
+            disabled={save.isPending}
+          />
+        </div>
+      ) : null}
+    </>
+  );
+
   return (
     <>
       <PanelHeader
@@ -273,54 +312,35 @@ export function SettingsCategory({
             you're editing. Collapsed by default — the operator expands groups as
             needed. A dirty-count badge rides the title so a collapsed group still
             announces it has unsaved edits. */}
-        <Accordion className="settings-groups">
-        {groups.map((group) => {
-          const visibleFields = group.fields.filter(isVisible);   // #963
-          const groupDirty = visibleFields.reduce((n, f) => n + (f.key in dirty ? 1 : 0), 0);
-          return (
-          <AccordionItem
-            key={group.section}
-            title={
-              <span className="settings-group-head">
-                {group.section}
-                {groupDirty ? <Badge status="warning">{groupDirty} unsaved</Badge> : null}
-              </span>
-            }
-          >
-            {visibleFields.map((field) => (
-              <SettingRow
-                key={field.key}
-                field={field}
-                dirty={field.key in dirty}
-                value={field.key in dirty ? dirty[field.key] : field.value}
-                onChange={(v) => setDirty((d) => ({ ...d, [field.key]: v }))}
-                // The host-defaults view edits the host layer directly — every field IS the
-                // shared default there, so the per-agent inheritance badge would be noise. The
-                // per-agent view shows the badge + reset affordance.
-                showInheritance={!hostLayer}
-                onReset={() => reset.mutate([field.key])}
-                resetting={reset.isPending}
-              />
+        {/* Folded into a plugin's row (ADR 0059): render the single group's fields
+            FLAT — the row's Configure toggle is the disclosure, so a nested accordion
+            would be a second click. The full Settings view keeps the collapsible groups. */}
+        {pluginId ? (
+          <div className="settings-groups">
+            {groups.map((group) => (
+              <div className="settings-flat-group" key={group.section}>{renderGroupBody(group)}</div>
             ))}
-            {hasDiscord && group.section === "Discord" ? (
-              <div className="settings-group-actions">
-                <TestConnectionButton onClick={() => testDiscord.mutate()} pending={testDiscord.isPending} disabled={save.isPending} />
-                <HelpLink href={DISCORD_GUIDE_URL}>How to create a bot</HelpLink>
-              </div>
-            ) : null}
-            {group.test ? (
-              <div className="settings-group-actions">
-                <TestConnectionButton
-                  onClick={() => { setTestingSection(group.section); testGroup.mutate({ endpoint: group.test!.endpoint, fields: groupFields(group) }); }}
-                  pending={testGroup.isPending && testingSection === group.section}
-                  disabled={save.isPending}
-                />
-              </div>
-            ) : null}
-          </AccordionItem>
-          );
-        })}
-        </Accordion>
+          </div>
+        ) : (
+          <Accordion className="settings-groups">
+            {groups.map((group) => {
+              const groupDirty = group.fields.filter(isVisible).reduce((n, f) => n + (f.key in dirty ? 1 : 0), 0);
+              return (
+                <AccordionItem
+                  key={group.section}
+                  title={
+                    <span className="settings-group-head">
+                      {group.section}
+                      {groupDirty ? <Badge status="warning">{groupDirty} unsaved</Badge> : null}
+                    </span>
+                  }
+                >
+                  {renderGroupBody(group)}
+                </AccordionItem>
+              );
+            })}
+          </Accordion>
+        )}
         {footer}
       </div>
     </>

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -2,7 +2,8 @@ import { Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Palette, Pl
 import type { LucideIcon } from "lucide-react";
 import type { ReactNode } from "react";
 
-import { SideNav, Tabs } from "@protolabsai/ui/navigation";
+import { PanelHeader, SideNav, Tabs } from "@protolabsai/ui/navigation";
+import { Button } from "@protolabsai/ui/primitives";
 
 import { IdentityPanel } from "../agent/IdentityPanel";
 import { McpPanel } from "../app/McpPanel";
@@ -64,16 +65,33 @@ const WORKSPACE_SECTIONS: Section[] = [
     id: "plugins",
     label: "Plugins",
     icon: Puzzle,
-    render: () => (
-      <SettingsCategoryPanel
-        category="Plugins"
-        title="Plugin settings"
-        emptyHint="Plugins with their own view manage settings there. Anything view-less shows up here."
-        footer={<DelegatesSection />}
-      />
-    ),
+    render: () => <PluginSettingsHome />,
   },
 ];
+
+// ADR 0059 — per-plugin config now lives with each plugin in the Plugins panel
+// (Installed → Configure). This section points there + keeps the delegate registry
+// (which has its own richer UI, not generic settings fields).
+function PluginSettingsHome() {
+  const setSurface = useUI((s) => s.setSurface);
+  const setPluginsTab = useUI((s) => s.setPluginsTab);
+  const openPlugins = () => { setPluginsTab("local"); setSurface("plugins"); };
+  return (
+    <>
+      <PanelHeader title="Plugins" kicker="manage + configure in the Plugins panel" />
+      <div className="stage-body">
+        <p className="muted" style={{ marginTop: 0 }}>
+          Browse, install, enable, and <strong>configure</strong> plugins in the dedicated Plugins panel —
+          each installed plugin's settings now live with it (Installed → <strong>Configure</strong>).
+        </p>
+        <Button variant="primary" type="button" onClick={openPlugins}>
+          <Puzzle size={15} /> Open Plugins
+        </Button>
+        <DelegatesSection />
+      </div>
+    </>
+  );
+}
 
 export const SETTINGS_HOMES: Home[] = [
   { id: "host", label: "Global", icon: HardDrive, sections: HOST_SECTIONS },

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -76,3 +76,8 @@
 .plugin-card-foot { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-top: 2px; }
 .plugin-card-repo { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: var(--fg-muted); text-decoration: none; }
 .plugin-card-repo:hover { color: var(--fg-secondary); }
+
+/* Config folded into the Installed plugin rows (ADR 0059) — the Configure expander. */
+.plugin-row-wrap { display: flex; flex-direction: column; }
+.plugin-row-config { margin: 0 0 10px; padding: 4px 12px 10px; border: 1px solid var(--border); border-radius: 9px; background: color-mix(in srgb, var(--bg-raised) 55%, transparent); }
+.settings-flat-group { display: flex; flex-direction: column; }

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -843,7 +843,9 @@ def build_schema(
             if not dk.startswith(f"{sch.section}."):
                 dk = f"{sch.section}.{dk}"
             entry["depends_on"] = {**dep, "key": dk}
-        groups.setdefault(group, {"section": group, "fields": []})["fields"].append(entry)
+        # `plugin_id` tags the group with its owning plugin so the console can fold
+        # the config into that plugin's row in the Plugins surface (ADR 0059, bd-23a.3).
+        groups.setdefault(group, {"section": group, "fields": [], "plugin_id": getattr(sch, "plugin_id", None)})["fields"].append(entry)
         # A plugin that declares `test: true` (ADR 0029) gets a generic console
         # "Test connection" button posting the group's fields to its test route.
         if getattr(sch, "test", False):

--- a/tests/test_settings_test_action.py
+++ b/tests/test_settings_test_action.py
@@ -39,6 +39,7 @@ def test_comms_manifests_declare_test():
 
 def test_build_schema_adds_test_endpoint(monkeypatch):
     class FakeSch:
+        plugin_id = "telegram"
         section = "telegram"
         defaults = {"bot_token": ""}
         test = True
@@ -48,3 +49,19 @@ def test_build_schema_adds_test_endpoint(monkeypatch):
     groups = ss.build_schema(LangGraphConfig())
     g = next(g for g in groups if g["section"] == "Telegram")
     assert g.get("test") == {"endpoint": "/api/config/test-telegram"}
+
+
+def test_build_schema_tags_plugin_group_with_plugin_id(monkeypatch):
+    # ADR 0059 — plugin groups carry plugin_id so the Plugins surface can fold the
+    # config into that plugin's Installed row.
+    class FakeSch:
+        plugin_id = "discord"
+        section = "discord"
+        defaults = {"admin_ids": []}
+        test = False
+
+    spec = {"key": "admin_ids", "type": "string_list", "label": "Admins"}
+    monkeypatch.setattr(ss, "_plugin_field_specs", lambda: [(FakeSch(), "discord.admin_ids", "admin_ids", spec)])
+    groups = ss.build_schema(LangGraphConfig())
+    g = next(g for g in groups if g["section"] == "Discord")
+    assert g.get("plugin_id") == "discord"


### PR DESCRIPTION
## What

The other half of "one place per plugin" (epic **bd-23a**, [ADR 0059](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0059-unified-plugin-manager.md)): a plugin's **config now lives with the plugin**. Each Installed row gets a **Configure** expander that renders that plugin's settings fields + Test/Connect inline, and **Settings ▸ Workspace ▸ Plugins** becomes a pointer to the Plugins panel.

## Changes
- **Backend** — settings groups carry `plugin_id` (`graph/settings_schema.py`, via `getattr` so it's robust), so the console matches a group to its plugin's row.
- **SettingsCategory** — new `pluginId` prop renders **only** that plugin's group, and **flat** (no nested accordion — the row's Configure toggle is the disclosure). The full Settings view keeps its collapsible groups (group body extracted to a shared `renderGroupBody`).
- **PluginsSurface** — Installed rows show **Configure** for plugins that have a settings group (the schema's plugin-tagged groups); the expander reuses `SettingsCategory` (same save/dirty/Test logic) under a `Suspense` boundary.
- **SettingsSurface** — the Plugins section points to the Plugins panel + keeps the delegate registry (its own richer UI).

## Tests
- Backend: `build_schema` tags plugin groups with `plugin_id`.
- e2e: drives **Configure → fields render flat**; `settings`/`plugin-install` specs updated; fixture gains a Demo Plugin settings group.
- **Gates green:** ruff · import-contracts (3/0) · pytest **2279** · web build/typecheck · unit **94** · e2e (fleet.spec is a known timing flake — passes in isolation).

## Epic bd-23a
`.1` catalog ✅ · `.2` Discover ✅ · **`.3` config fold (this)** · `.4` collapse the 3 tabs → Discover/Installed (next) · `.5` generalize bespoke affordances.

🤖 Generated with [Claude Code](https://claude.com/claude-code)