### PR TITLE
feat(web): chat in the command palette + autofocus composer/notes inputs (ADR 0057)

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -61,7 +61,7 @@ import {
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
-import { lazy, Suspense, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { lazy, Suspense, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import type { ComponentType, LazyExoticComponent, ReactNode } from "react";
 import { FleetTurnWatch } from "./FleetTurnWatch";
 import { UpdateNotice } from "./UpdateNotice";
@@ -117,6 +117,7 @@ import { SetupWizard } from "../setup/SetupWizard";
 import { hostRuntimeStatusQuery, runtimeStatusQuery } from "../lib/queries";
 import { buildViews } from "../lib/viewRegistry";
 import { usePaletteRegistry } from "./usePaletteRegistry";
+import { makeChatTransport } from "./paletteChat";
 
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
 // fanning out to sub-views via an in-surface segmented control.
@@ -553,7 +554,20 @@ export function App() {
       token: authToken(),
       sandbox: "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox",
     }));
-  const paletteRegistry = usePaletteRegistry(paletteViews, inlinePaletteViews);
+  // Inline chat with the focused agent (ADR 0057) — ⌘K → a quick chat that streams via
+  // api.streamChat (ephemeral context per open). Memoized so the transport (+ its
+  // session) is stable across renders; re-created only when the agent name changes.
+  const chatAgentName = brandName(runtime?.identity?.name);
+  const paletteChat = useMemo(
+    () => ({
+      name: chatAgentName,
+      transport: makeChatTransport(chatAgentName),
+      icon: <MessageSquare size={16} />,
+      greeting: `Ask ${chatAgentName} anything — a quick scratch chat (its own context).`,
+    }),
+    [chatAgentName],
+  );
+  const paletteRegistry = usePaletteRegistry(paletteViews, inlinePaletteViews, paletteChat);
   const [paletteOpen, setPaletteOpen] = useState(false);
   usePaletteHotkey(() => setPaletteOpen((o) => !o));
 

--- a/apps/web/src/app/paletteChat.ts
+++ b/apps/web/src/app/paletteChat.ts
@@ -1,0 +1,104 @@
+// ADR 0057 — the command-palette chat transport. Bridges the DS chat view's
+// `AgentTransport` (a `send(history) => AsyncIterable<string>`) onto the console's
+// existing `api.streamChat` — which already POSTs A2A 1.0 `SendStreamingMessage` to
+// the slug-routed, bearer-authed `/a2a` of the FOCUSED agent and decodes reply text
+// from `artifactUpdate` parts. So the palette chat talks to the real agent with zero
+// new transport code.
+//
+// Session model: an EPHEMERAL context per palette-chat open (a fresh contextId on the
+// first turn). The palette chat is a self-contained "quick ask the agent" — it doesn't
+// entangle the main chat tabs (which would diverge, since the DS view owns its own
+// transcript). It inherits the active tab's MODEL so it talks to the same model.
+// (Continuing the active session is a future option if context-continuity is wanted.)
+import type { AgentTransport } from "@protolabsai/ui/command-palette";
+import { api } from "../lib/api";
+import { chatStore } from "../chat/chat-store";
+
+/** Build an `AgentTransport` that streams turns to the focused agent via
+ *  `api.streamChat`. `name` is shown in the chat view header + composer placeholder. */
+export function makeChatTransport(name: string): AgentTransport {
+  // Persists across turns within one open chat; reset on a fresh chat (first user turn).
+  let sessionId = "";
+  return {
+    name,
+    async *send(history, { signal }) {
+      const userTurns = history.filter((m) => m.role === "user").length;
+      if (userTurns <= 1 || !sessionId) {
+        sessionId = `palette-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+      }
+      const text = [...history].reverse().find((m) => m.role === "user")?.content ?? "";
+      // Inherit the active tab's per-tab model override so the palette uses the same model.
+      const snap = chatStore.getSnapshot();
+      const model = snap.sessions.find((s) => s.id === snap.currentSessionId)?.model;
+
+      // Bridge api.streamChat's callbacks → an async iterator of appendable text deltas.
+      const queue: string[] = [];
+      let done = false;
+      let error: Error | null = null;
+      let wake: (() => void) | null = null;
+      const wakeUp = () => {
+        const w = wake;
+        wake = null;
+        w?.();
+      };
+      // The DS chat view appends each yielded chunk, but streamChat can emit a REPLACE
+      // (append=false, e.g. terminal task text). Track what we've yielded and only push
+      // the new tail so the transcript never duplicates.
+      let acc = "";
+      const push = (s: string) => {
+        if (s) {
+          queue.push(s);
+          wakeUp();
+        }
+      };
+
+      void api
+        .streamChat(
+          text,
+          sessionId,
+          {
+            signal,
+            onText: (t, append) => {
+              if (append) {
+                acc += t;
+                push(t);
+              } else if (t.startsWith(acc)) {
+                const delta = t.slice(acc.length);
+                acc = t;
+                push(delta);
+              } else {
+                acc = t;
+                push(t);
+              }
+            },
+            onFailed: (m) => {
+              error = new Error(m || "The agent turn failed.");
+              done = true;
+              wakeUp();
+            },
+            onDone: () => {
+              done = true;
+              wakeUp();
+            },
+          },
+          { model },
+        )
+        .catch((e: unknown) => {
+          error = e instanceof Error ? e : new Error(String(e));
+          done = true;
+          wakeUp();
+        });
+
+      while (!done || queue.length) {
+        if (!queue.length) {
+          await new Promise<void>((resolve) => {
+            wake = resolve;
+          });
+          continue;
+        }
+        yield queue.shift() as string;
+      }
+      if (error) throw error;
+    },
+  };
+}

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -8,13 +8,23 @@
 // of navigating to its rail. (Plugin-declared `commands:` + dispatch are step 3b.)
 import type { ReactNode } from "react";
 import { useEffect, useMemo } from "react";
-import { createPaletteRegistry, pluginView } from "@protolabsai/ui/command-palette";
-import type { Command, PaletteRegistry, PaletteSource } from "@protolabsai/ui/command-palette";
+import { chatView, createPaletteRegistry, pluginView } from "@protolabsai/ui/command-palette";
+import type { AgentTransport, Command, PaletteRegistry, PaletteSource } from "@protolabsai/ui/command-palette";
 import { useUI } from "../state/uiStore";
 import type { View, ViewKind } from "../lib/viewRegistry";
 
 const SURFACES: PaletteSource = { id: "surfaces", label: "Surfaces" };
 const ACTIONS: PaletteSource = { id: "actions", label: "Actions" };
+const AGENTS: PaletteSource = { id: "agents", label: "Agents" };
+
+/** Optional inline chat with the focused agent (ADR 0057). App builds the transport
+ *  (it owns the agent name + the icon node); the adapter registers the view + command. */
+export type PaletteChat = {
+  name: string;
+  transport: AgentTransport;
+  icon?: ReactNode;
+  greeting?: ReactNode;
+};
 
 const GROUP: Record<ViewKind, string> = {
   surface: "Surfaces",
@@ -99,7 +109,11 @@ function deepLinkCommands(): Command[] {
 /** Build the palette registry from the resolved view list + the inline plugin views.
  *  Stable across renders; nav commands + inline views re-register only when their set
  *  changes (plugins enable/disable) — matching the DS registry's add/withdraw model. */
-export function usePaletteRegistry(views: View[], inlineViews: InlinePluginView[] = []): PaletteRegistry {
+export function usePaletteRegistry(
+  views: View[],
+  inlineViews: InlinePluginView[] = [],
+  chat?: PaletteChat,
+): PaletteRegistry {
   const registry = useMemo(() => createPaletteRegistry(), []);
   const inlineIds = useMemo(() => new Set(inlineViews.map((v) => v.id)), [inlineViews]);
 
@@ -152,6 +166,32 @@ export function usePaletteRegistry(views: View[], inlineViews: InlinePluginView[
   }, [navSig, inlineSig, registry]);
 
   useEffect(() => registry.registerCommands(deepLinkCommands(), { source: ACTIONS }), [registry]);
+
+  // Inline chat with the focused agent — ⌘K → morph the palette into a chat that
+  // streams turns via api.streamChat (an ephemeral context per open; see paletteChat).
+  // The DS chat view focuses its composer on open, so it's type-ready immediately.
+  useEffect(() => {
+    if (!chat) return;
+    const offView = registry.registerViews([chatView({ title: chat.name })]);
+    const offCmd = registry.registerCommands(
+      [
+        {
+          id: "chat",
+          label: `Chat with ${chat.name}`,
+          hint: "ask the agent",
+          icon: chat.icon,
+          group: "Agents",
+          keywords: ["chat", "ask", "talk", "agent"],
+          run: (c) => c.enter("chat", { transport: chat.transport, greeting: chat.greeting }),
+        },
+      ],
+      { source: AGENTS },
+    );
+    return () => {
+      offView();
+      offCmd();
+    };
+  }, [registry, chat]);
 
   return registry;
 }

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -228,6 +228,11 @@ function ChatSessionSlot({
   // Forwarded into the DS PromptInput (inputRef) — for slash-completion focus and
   // the Ctrl/⌘+Enter caret insert. The DS component owns the auto-grow.
   const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+  // Autofocus the composer when this session becomes the visible one, so you can type
+  // immediately on open / tab-switch — the field doesn't grab focus on its own.
+  useEffect(() => {
+    if (visible) textareaRef.current?.focus();
+  }, [visible]);
   const status = chat.sessionStatusMap[sessionId] || "idle";
 
   // Pending file attachments. Each is uploaded to /api/knowledge/attach on pick;

--- a/plugins/notes/__init__.py
+++ b/plugins/notes/__init__.py
@@ -197,7 +197,7 @@ _EDITOR_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
 <div id="wrap">
   <div id="bar"><span id="status">Notes</span>
     <button id="toggle" class="pl-btn pl-btn--sm" type="button">Preview</button></div>
-  <textarea id="ed" placeholder="A shared note — you and the agent both write here." spellcheck="false"></textarea>
+  <textarea id="ed" placeholder="A shared note — you and the agent both write here." spellcheck="false" autofocus></textarea>
   <div id="pv"></div>
 </div>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/marked/12.0.2/marked.min.js"></script>
@@ -259,7 +259,7 @@ _QUICK_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
 </style></head><body>
 <div id="wrap">
   <div id="bar"><span id="status">Quick note</span></div>
-  <textarea id="ed" placeholder="Jot — saves to the shared note." spellcheck="false"></textarea>
+  <textarea id="ed" placeholder="Jot — saves to the shared note." spellcheck="false" autofocus></textarea>
 </div>
 <script type="module">
   "use strict";


### PR DESCRIPTION
**⌘K → "Chat with <agent>"** morphs the palette into a chat that streams turns to the **real focused agent** — not a mock.

## Chat
- **`app/paletteChat.ts`** — `makeChatTransport()` bridges the console's existing **`api.streamChat`** (A2A 1.0 `SendStreamingMessage`, slug-routed + bearer-authed, decodes reply text from `artifactUpdate` parts) onto the DS chat view's `AgentTransport` (`send(history) => AsyncIterable<string>`, handling append-vs-replace so the transcript never duplicates).
- **`usePaletteRegistry`** — optional `chat` param registers `chatView()` + a "Chat with <agent>" command (Agents group).
- **`App.tsx`** — builds the memoized transport from the focused agent's name.

**Session model:** an **ephemeral context per open** — a quick "ask the agent" scratch chat that doesn't entangle the main chat tabs (which would diverge, since the DS view owns its own transcript). Inherits the active tab's **model**. (Continuing the active session is an easy future option if you want context continuity.)

## Autofocus (so you can type immediately)
- **Main chat composer** — focus the textarea when its session becomes visible (`ChatSessionSlot`; it didn't grab focus before).
- **Notes editor + quick-note pages** — `autofocus` on the textarea.
- **Palette chat composer** — already focuses on open (DS chat view).

## Verification
`npm run build` + **94 web tests** + notes tests green. (The notes HTML changed, so a running backend needs a restart to re-serve it; the chat is web-only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)