### PR TITLE
feat(plugins): collapse the 3 tabs into Installed + Discover (ADR 0059, bd-23a.4)

### DIFF
--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -61,8 +61,11 @@ test("workspace settings: identity lands, then tools and MCP sections", async ({
   await expect(page.getByText("echo · stdio")).toBeVisible(); // MCP server
 });
 
-test("plugins section: Installed / Discover / Install URL tabs", async ({ page }) => {
+test("plugins section: Installed / Discover (config + advanced install folded in)", async ({ page }) => {
   await page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true }).click();
+
+  // Two sections only now (ADR 0059 D4) — no separate "Install URL" tab.
+  await expect(page.locator(".pl-tabs").getByRole("tab", { name: "Install URL", exact: true })).toHaveCount(0);
 
   // Installed (default tab) — both status groups + the enable toggle.
   await expect(page.getByText("Demo Plugin", { exact: false })).toBeVisible();
@@ -71,12 +74,14 @@ test("plugins section: Installed / Discover / Install URL tabs", async ({ page }
     .getByRole("button", { name: "Enable" }).click();
   await expect(page.locator(".plugin-hint")).toContainText("Zzz Disabled enabled");
 
-  // Config folded in (ADR 0059, bd-23a.3) — Demo Plugin has a settings group, so its
-  // row exposes Configure → its fields render inline.
+  // Config folded in (ADR 0059, bd-23a.3) — Demo Plugin's row exposes Configure → fields inline.
   const demoRow = page.locator(".plugin-row-wrap", { hasText: "Demo Plugin" });
   await demoRow.getByRole("button", { name: "Configure" }).click();
-  // Fields render flat (no nested accordion) — reachable immediately.
   await expect(demoRow.locator('.plugin-row-config .setting-row[data-key="demo.greeting"]')).toBeVisible();
+
+  // Install-from-URL is now the advanced action under Installed (ADR 0059 D4), not a tab.
+  await page.getByRole("button", { name: "Install from a git URL" }).click();
+  await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
 
   // Discover tab — the in-app official-plugin directory (ADR 0059): cards + search.
   await page.locator(".pl-tabs").getByRole("tab", { name: "Discover", exact: true }).click();
@@ -84,10 +89,6 @@ test("plugins section: Installed / Discover / Install URL tabs", async ({ page }
   const artifact = page.locator(".plugin-card", { hasText: "Artifact" });
   await expect(artifact.getByRole("button", { name: /Install/ })).toBeVisible();   // not installed → installable
   await expect(page.locator(".plugin-card", { hasText: "Discord" })).toContainText(/installed/);
-
-  // Install URL tab — install from a git URL (advanced).
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Install URL", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
 });
 
 test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async ({ page }) => {

--- a/apps/web/e2e/plugin-install.spec.ts
+++ b/apps/web/e2e/plugin-install.spec.ts
@@ -6,8 +6,8 @@ import { expect, test } from "@playwright/test";
 async function openPluginsPanel(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true }).click();
-  // Install-from-URL lives on the "Install URL" tab (advanced).
-  await page.locator(".pl-tabs").getByRole("tab", { name: "Install URL", exact: true }).click();
+  // Install-from-URL is the advanced action under Installed (ADR 0059 D4) — expand it.
+  await page.getByRole("button", { name: "Install from a git URL" }).click();
   await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();
 }
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -19,7 +19,6 @@ import {
   PanelRight,
   Plus,
   Puzzle,
-  Download,
   Store,
   Save,
   Settings2,
@@ -595,7 +594,6 @@ export function App() {
             <Tabs responsive active={pluginsTab} onSelect={(t) => setPluginsTab(t as PluginsTab)} items={[
               { id: "local", label: "Installed", icon: Boxes },
               { id: "market", label: "Discover", icon: Store },
-              { id: "download", label: "Install URL", icon: Download },
             ].map(toTab)} />
             <PluginsSurface tab={pluginsTab} />
           </>

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -87,13 +87,14 @@ function deepLinkCommands(): Command[] {
       ui().setSurface("activity");
       ui().setActivityTab("schedule");
     }),
-    link("plug:market", "Plugins: Market", ["plugins", "market", "directory"], () => {
+    link("plug:market", "Plugins: Discover", ["plugins", "discover", "market", "directory", "browse"], () => {
       ui().setSurface("plugins");
       ui().setPluginsTab("market");
     }),
-    link("plug:download", "Plugins: Install from URL", ["plugins", "install", "download", "url"], () => {
+    // Install-from-URL is the advanced action under Installed now (ADR 0059 D4) — land there.
+    link("plug:download", "Plugins: Install from URL", ["plugins", "install", "url", "git"], () => {
       ui().setSurface("plugins");
-      ui().setPluginsTab("download");
+      ui().setPluginsTab("local");
     }),
     link("box:telemetry", "Box: Telemetry", ["box", "telemetry", "metrics"], () => {
       ui().setSurface("box");

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -114,7 +114,7 @@ function PluginRow({
   );
 }
 
-type PluginsTab = "local" | "market" | "download";
+type PluginsTab = "local" | "market";
 
 // Local — installed plugins, grouped Loaded → Disabled (alpha), with enable/disable.
 function LocalTab() {
@@ -124,6 +124,7 @@ function LocalTab() {
   const updates = useQuery(pluginUpdatesQuery());
   const qc = useQueryClient();
   const [hint, setHint] = useState<string | null>(null);
+  const [urlOpen, setUrlOpen] = useState(false); // advanced: install-from-URL (ADR 0059 D4)
   const toggle = useMutation({
     mutationFn: (p: Plugin) => api.setPluginEnabled(p.id, !p.enabled),
     onSuccess: (res, p) => {
@@ -199,11 +200,19 @@ function LocalTab() {
         ) : (
           <div className="table-list">
             <div className="table-row">
-              <span>no plugins installed — see the Discover or Download tabs</span>
+              <span>no plugins installed — browse the Discover tab, or install from a git URL below</span>
               <StatusPill label="none" tone="muted" />
             </div>
           </div>
         )}
+        {/* Install-from-URL is the advanced path (ADR 0059 D4) — the curated Discover
+            directory is the primary way to add a plugin. */}
+        <div className="plugin-install-advanced">
+          <Button type="button" variant="ghost" aria-expanded={urlOpen} onClick={() => setUrlOpen((o) => !o)}>
+            <Download size={14} /> Install from a git URL
+          </Button>
+          {urlOpen ? <PluginsSection /> : null}
+        </div>
       </div>
     </>
   );
@@ -295,22 +304,9 @@ function DiscoverTab() {
   );
 }
 
-// Download — install from a git URL (PluginsSection ships its own header + form).
-function DownloadTab() {
-  return (
-    <>
-      <PanelHeader title="Download" kicker="install from a git URL" />
-      <div className="stage-body">
-        <PluginsSection />
-      </div>
-    </>
-  );
-}
-
 const TABS: Record<PluginsTab, () => JSX.Element> = {
   local: LocalTab,
   market: DiscoverTab,
-  download: DownloadTab,
 };
 
 export function PluginsSurface({ tab = "local" }: { tab?: PluginsTab }) {

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -81,3 +81,4 @@
 .plugin-row-wrap { display: flex; flex-direction: column; }
 .plugin-row-config { margin: 0 0 10px; padding: 4px 12px 10px; border: 1px solid var(--border); border-radius: 9px; background: color-mix(in srgb, var(--bg-raised) 55%, transparent); }
 .settings-flat-group { display: flex; flex-direction: column; }
+.plugin-install-advanced { margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border); }

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -43,7 +43,10 @@ export type Surface =
 // `notes` is no longer a built-in right panel — it's the first-party `notes` plugin
 // (keyed `plugin:notes:<view>`), so it falls under the open `(string & {})` arm.
 export type RightPanel = "beads" | "goals" | (string & {}); // + plugin:<id>:<viewId>
-export type PluginsTab = "local" | "market" | "download";
+// Two sections (ADR 0059 D4): "local" = Installed (+ advanced install-from-URL),
+// "market" = Discover. (Keys kept for persisted-state compat; the old "download"
+// tab is gone — a stale persisted value falls back to Installed.)
+export type PluginsTab = "local" | "market";
 // "schedule" joins thread/inbox here (#1075): cron is a trigger, so timed turns are a
 // tab of the Activity surface rather than a standalone rail surface.
 export type ActivityTab = "thread" | "inbox" | "schedule";


### PR DESCRIPTION
## What

The finale of the unified plugin manager (epic **bd-23a**, [ADR 0059](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0059-unified-plugin-manager.md) D4): the Plugins surface is now **two sections — Installed + Discover** — instead of three tabs. **Install-from-URL** is no longer a top-level tab; it's an advanced *"Install from a git URL"* disclosure at the bottom of **Installed** (the curated Discover directory is the primary way to add a plugin).

## Changes
- Removed `DownloadTab`; `PluginsSection` (the install form) is reused inline as the advanced action.
- `uiStore.PluginsTab` drops `"download"` → `"local" | "market"` (keys kept for persisted-state compat; a stale `"download"` falls back to Installed).
- `App.tsx` tab strip → two tabs (Installed · Discover).
- Command palette: *"Plugins: Market"* → *"Plugins: Discover"*; *"Install from URL"* now lands on Installed (where the advanced action lives) — fixes the type error from the removed tab.

## Tests
- `navigation` e2e: asserts there's **no Install-URL tab** and the advanced install disclosure reveals the form; keeps the Configure + Discover assertions.
- `plugin-install` e2e: opens the install form via the advanced action.
- **Gates green:** web build/typecheck · unit **94** · e2e **106**. Frontend-only (no backend changes).

## Epic bd-23a — complete bar one
`.1` catalog ✅ · `.2` Discover ✅ · `.3` config fold ✅ · **`.4` collapse (this)** · `.5` generalize bespoke affordances (optional polish — the last open slice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)