### PR TITLE
feat(plugins): manifest-driven Test + guide link — no per-plugin frontend (ADR 0059, bd-23a.5)

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -710,14 +710,6 @@ export const api = {
     });
   },
 
-  // Verify a Discord bot token by fetching its identity. Blank falls back to the
-  // saved token. Returns the bot username on success ("Connected as <bot>").
-  testDiscord(botToken: string) {
-    return request<{ ok: boolean; error: string; bot_user: string | null }>("/api/config/test-discord", {
-      method: "POST",
-      body: { bot_token: botToken },
-    });
-  },
 
   finishSetup(config: Partial<AgentConfig>, soul: string) {
     return request<{ ok: boolean; message: string }>("/api/config/setup", {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -228,6 +228,7 @@ export type SettingsGroup = {
   // The owning plugin id for a plugin-contributed group (ADR 0059) — lets the
   // Plugins surface fold this group into that plugin's Installed row.
   plugin_id?: string;
+  guide_url?: string;  // ADR 0059 — optional setup-guide link rendered next to the group
 };
 
 export type WorkflowSummary = {

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -76,9 +76,6 @@ export function HostConfigLocked() {
   );
 }
 
-// Setup walkthroughs live in the template's docs (forks don't ship their own site).
-const DISCORD_GUIDE_URL = "https://protolabsai.github.io/protoAgent/guides/discord#bot-setup";
-
 // One category's settings — the field groups tagged with `category`, rendered with
 // their own dirty-tracking, Save-&-apply, and per-group Test buttons. Extracted from
 // the old monolithic SettingsSurface so settings can live in their home view (Agent,
@@ -140,7 +137,6 @@ export function SettingsCategory({
   const isVisible = (field: SettingsField): boolean => fieldVisible(field, (k) => currentValues.get(k));
 
   const hasModel = groups.some((g) => g.fields.some((f) => f.key === "model.name"));
-  const hasDiscord = groups.some((g) => g.section === "Discord");
 
   // Active agent runtime (ADR 0033) — for the banner + header badge when this category
   // carries the selector (the Agent settings). Reflects the pending (dirty) choice live.
@@ -212,13 +208,6 @@ export function SettingsCategory({
     onSettled: () => setTestingSection(null),
   });
 
-  const testDiscord = useMutation({
-    mutationFn: () => api.testDiscord(asStr(dirty["discord.bot_token"])),
-    onMutate: () => setStatus("testing Discord…"),
-    onSuccess: (r) => setStatus(r.ok ? `Discord OK — connected as ${r.bot_user || "your bot"}.` : `Discord connection failed — ${r.error || "check the token"}`),
-    onError: (e) => setStatus(`Discord test failed: ${errMsg(e)}`),
-  });
-
   const discard = () => { setDirty({}); setStatus(""); };
 
   // The fields + Test/Connect for one group — rendered inside an AccordionItem in the
@@ -237,19 +226,19 @@ export function SettingsCategory({
           resetting={reset.isPending}
         />
       ))}
-      {hasDiscord && group.section === "Discord" ? (
+      {/* Generic, data-driven group actions (ADR 0059) — a Test button from the
+          manifest's `test: true` and a setup-guide link from `guide_url`. No
+          per-plugin frontend. */}
+      {group.test || group.guide_url ? (
         <div className="settings-group-actions">
-          <TestConnectionButton onClick={() => testDiscord.mutate()} pending={testDiscord.isPending} disabled={save.isPending} />
-          <HelpLink href={DISCORD_GUIDE_URL}>How to create a bot</HelpLink>
-        </div>
-      ) : null}
-      {group.test ? (
-        <div className="settings-group-actions">
-          <TestConnectionButton
-            onClick={() => { setTestingSection(group.section); testGroup.mutate({ endpoint: group.test!.endpoint, fields: groupFields(group) }); }}
-            pending={testGroup.isPending && testingSection === group.section}
-            disabled={save.isPending}
-          />
+          {group.test ? (
+            <TestConnectionButton
+              onClick={() => { setTestingSection(group.section); testGroup.mutate({ endpoint: group.test!.endpoint, fields: groupFields(group) }); }}
+              pending={testGroup.isPending && testingSection === group.section}
+              disabled={save.isPending}
+            />
+          ) : null}
+          {group.guide_url ? <HelpLink href={group.guide_url}>Setup guide</HelpLink> : null}
         </div>
       ) : null}
     </>

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -46,6 +46,9 @@ class PluginManifest:
     # one), and the console renders a generic "Test connection" button for the
     # group. No console edit needed per plugin.
     test: bool = False
+    # Optional setup-guide URL (ADR 0059) — the console renders a generic "Setup
+    # guide" link next to the plugin's settings, so no per-plugin frontend is needed.
+    guide_url: str = ""
     # Console surfaces (ADR 0026) — each entry adds a left-rail icon opening a
     # full view (an iframe of a page the plugin serves at `path`). Declared as
     # data so it's known without importing the plugin, and surfaced to the
@@ -165,6 +168,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
         secrets=[str(s) for s in secrets] if isinstance(secrets, (list, tuple)) else [],
         settings=[s for s in settings if isinstance(s, dict)] if isinstance(settings, (list, tuple)) else [],
         test=bool(data.get("test", False)),
+        guide_url=str(data.get("guide_url", "") or "").strip(),
         views=views,
         emits=[str(x) for x in emits] if isinstance(emits, (list, tuple)) else [],
         subscribes=[str(x) for x in subscribes] if isinstance(subscribes, (list, tuple)) else [],

--- a/graph/plugins/pconfig.py
+++ b/graph/plugins/pconfig.py
@@ -60,6 +60,7 @@ class PluginConfigSchema:
     secrets: list = field(default_factory=list)
     settings: list = field(default_factory=list)
     test: bool = False  # has a /api/config/test-<section> check (ADR 0029)
+    guide_url: str = ""  # optional setup-guide link rendered next to the group (ADR 0059)
 
 
 def discover_plugin_config(roots, enabled_ids, disabled_ids=None) -> list[PluginConfigSchema]:
@@ -101,6 +102,7 @@ def discover_plugin_config(roots, enabled_ids, disabled_ids=None) -> list[Plugin
                     list(m.secrets or []),
                     list(m.settings or []),
                     test=bool(getattr(m, "test", False)),
+                    guide_url=str(getattr(m, "guide_url", "") or ""),
                 )
             )
         return out

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -850,6 +850,10 @@ def build_schema(
         # "Test connection" button posting the group's fields to its test route.
         if getattr(sch, "test", False):
             groups[group]["test"] = {"endpoint": f"/api/config/test-{sch.section}"}
+        # Optional setup-guide link (ADR 0059) — rendered generically next to the
+        # group, so a plugin needs no bespoke console frontend.
+        if getattr(sch, "guide_url", ""):
+            groups[group]["guide_url"] = sch.guide_url
 
     out = list(groups.values())
     # Insertion order = first appearance in FIELDS (core), then plugins.

--- a/plugins/discord/__init__.py
+++ b/plugins/discord/__init__.py
@@ -89,7 +89,9 @@ def _build_router(registry):
         body = req or DiscordProbe()
         token = body.bot_token or (registry.config.get("bot_token") or "")
         ok, bot_user, error = await validate_token(token)
-        return {"ok": ok, "error": error, "bot_user": (bot_user or {}).get("username") if ok else None}
+        # `identity` is the generic test-route field the console renders (ADR 0029) —
+        # the bot's username on success.
+        return {"ok": ok, "error": error, "identity": (bot_user or {}).get("username") if ok else None}
 
     return router
 

--- a/plugins/discord/protoagent.plugin.yaml
+++ b/plugins/discord/protoagent.plugin.yaml
@@ -11,6 +11,11 @@ requires_env: []
 # Config section (ADR 0019) — claims the top-level `discord` section, so the
 # existing Settings group + wizard step keep working unchanged.
 config_section: discord
+# Generic console Test button (ADR 0029) → POST /api/config/test-discord (served by
+# this plugin's router below); `guide_url` adds a generic "Setup guide" link next to
+# it — so the console needs NO Discord-specific frontend (ADR 0059 bd-23a.5).
+test: true
+guide_url: "https://protolabsai.github.io/protoAgent/guides/discord#bot-setup"
 config:
   enabled: false
   admin_ids: []

--- a/tests/test_settings_test_action.py
+++ b/tests/test_settings_test_action.py
@@ -21,20 +21,30 @@ def test_manifest_parses_test_flag(tmp_path):
                 "name": "Demo",
                 "config_section": "demo",
                 "test": True,
+                "guide_url": "https://example.com/setup",
                 "settings": [{"key": "bot_token", "type": "secret", "label": "Token"}],
             }
         )
     )
     m = load_manifest(d)
     assert m.test is True
+    assert m.guide_url == "https://example.com/setup"
 
 
 def test_comms_manifests_declare_test():
-    # telegram uses the generic Test button via the chat_surface wirer; Discord
-    # keeps its bespoke button (with a guide link), so it doesn't set test.
-    for p in ("telegram",):
+    # The generic Test button (ADR 0029): telegram via the chat_surface wirer,
+    # Discord via its own route — both data-driven, no bespoke console frontend (ADR 0059).
+    for p in ("telegram", "discord"):
         m = yaml.safe_load(Path(f"plugins/{p}/protoagent.plugin.yaml").read_text())
         assert m.get("test") is True, p
+
+
+def test_discord_manifest_declares_generic_affordances():
+    # ADR 0059 — Discord's Test button + setup-guide link are now manifest-declared
+    # (test + guide_url), so the console renders them generically (no Discord frontend).
+    m = yaml.safe_load(Path("plugins/discord/protoagent.plugin.yaml").read_text())
+    assert m.get("test") is True
+    assert str(m.get("guide_url", "")).startswith("http")
 
 
 def test_build_schema_adds_test_endpoint(monkeypatch):
@@ -65,3 +75,20 @@ def test_build_schema_tags_plugin_group_with_plugin_id(monkeypatch):
     groups = ss.build_schema(LangGraphConfig())
     g = next(g for g in groups if g["section"] == "Discord")
     assert g.get("plugin_id") == "discord"
+
+
+def test_build_schema_surfaces_guide_url(monkeypatch):
+    # ADR 0059 — a manifest guide_url flows to the group so the console renders a
+    # generic "Setup guide" link (no per-plugin frontend).
+    class FakeSch:
+        plugin_id = "discord"
+        section = "discord"
+        defaults = {"admin_ids": []}
+        test = True
+        guide_url = "https://example.com/guide"
+
+    spec = {"key": "admin_ids", "type": "string_list", "label": "Admins"}
+    monkeypatch.setattr(ss, "_plugin_field_specs", lambda: [(FakeSch(), "discord.admin_ids", "admin_ids", spec)])
+    g = next(g for g in ss.build_schema(LangGraphConfig()) if g["section"] == "Discord")
+    assert g.get("guide_url") == "https://example.com/guide"
+    assert g.get("test") == {"endpoint": "/api/config/test-discord"}


### PR DESCRIPTION
## What

**Closes the unified plugin manager epic (bd-23a).** The consolidated Plugins surface now has **zero plugin-specific frontend**. The last bespoke affordance — Discord's hardcoded Test button + "how to create a bot" guide link in `SettingsCategory` — is replaced by data-driven manifest fields.

## Changes
- Manifest gains **`guide_url`** (`PluginManifest` → `PluginConfigSchema` → the settings group), rendered as a generic **"Setup guide"** link next to the group's Test button.
- The bundled **discord** plugin declares `test: true` + `guide_url`; its `/api/config/test-discord` route now returns **`identity`** so the generic Test button shows the bot name. So Discord uses the generic affordances like any plugin.
- Removed `hasDiscord` / `testDiscord` / `DISCORD_GUIDE_URL` from `SettingsCategory` and `api.testDiscord`. The generic group-actions block (Test from `test:true` + the `guide_url` link) now covers every plugin.

## Tests
- Manifest parses `guide_url`; `build_schema` surfaces `guide_url` + the test endpoint; the discord manifest declares `test` + `guide_url`.
- **Gates green:** ruff · import-contracts (3/0) · pytest **2282** · web build/typecheck · unit **94** · e2e **106**.

## Follow-up
The external `protoLabsAI/discord-plugin` repo gets the same manifest + route change (v0.1.1) so it matches when installed — small separate PR.

## Epic bd-23a — DONE 🎉
`.1` catalog · `.2` Discover · `.3` config fold · `.4` collapse · **`.5` generalize affordances (this)**. The whole consolidation: in-app official-plugin directory (browse + 1-click install on every surface incl. frozen desktop), one place per plugin (install → enable → configure inline), 3 tabs → Installed + Discover, and no per-plugin console frontend.

🤖 Generated with [Claude Code](https://claude.com/claude-code)