### PR TITLE
fix(web): show the full background-job result in the dialog (not the ~2k live preview)

### DIFF
--- a/apps/web/src/app/BackgroundJobs.tsx
+++ b/apps/web/src/app/BackgroundJobs.tsx
@@ -1,6 +1,6 @@
 import { Dialog } from "@protolabsai/ui/overlays";
 import { Bot, CheckCircle2, Loader2, Square, XCircle } from "lucide-react";
-import { useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Markdown } from "../chat/LazyMarkdown";
 import { api } from "../lib/api";
@@ -23,13 +23,14 @@ export function BackgroundJobs() {
   const [unread, setUnread] = useState(0);
   const [, setTick] = useState(0); // re-render for live elapsed while open
 
-  // Hydrate from the durable registry.
-  useEffect(() => {
-    let alive = true;
+  // Pull the durable registry — every job's FULL result. The live bus only carries a
+  // trimmed ~2k preview (so a still-open chat can render the outcome without a refetch),
+  // so the API is the source of truth for the dialog. We re-hydrate when the dialog opens
+  // and when a job completes, so "show result" always renders the entire report.
+  const hydrate = useCallback(() => {
     api
       .background()
       .then((d) => {
-        if (!alive) return;
         setEnabled(!!d.enabled);
         const m: Record<string, BackgroundJobDTO> = {};
         for (const j of d.jobs || []) m[j.id] = j;
@@ -38,10 +39,12 @@ export function BackgroundJobs() {
       .catch(() => {
         /* feature off / unreachable — the pill stays hidden */
       });
-    return () => {
-      alive = false;
-    };
   }, []);
+
+  // Hydrate on mount.
+  useEffect(() => {
+    hydrate();
+  }, [hydrate]);
 
   // Live updates off the event bus.
   useEffect(() => {
@@ -101,6 +104,9 @@ export function BackgroundJobs() {
         completed_at: nowIso(),
       });
       setUnread((u) => u + 1);
+      // The event's `result` is the trimmed preview — pull the durable full result so
+      // "show result" renders the entire report, not the …[truncated] copy.
+      hydrate();
     });
 
     return () => {
@@ -108,7 +114,7 @@ export function BackgroundJobs() {
       offProgress();
       offDone();
     };
-  }, []);
+  }, [hydrate]);
 
   const list = useMemo(() => Object.values(jobs).sort(byRecency), [jobs]);
   const running = list.filter((j) => j.status === "running").length;
@@ -140,6 +146,7 @@ export function BackgroundJobs() {
         onClick={() => {
           setOpen(true);
           setUnread(0);
+          hydrate(); // fetch the FULL results when the panel opens (replaces any live previews)
         }}
         title="Background agents"
         aria-label={`Background agents${running ? ` — ${running} running` : ""}`}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -225,6 +225,11 @@
   padding: 4px 12px 12px 33px;
   font-size: 13px;
   border-top: 1px solid var(--border, #2a2a31);
+  /* A long report (research agents emit thousands of words) scrolls within the row
+     so the whole thing is readable without the dialog growing unbounded. */
+  max-height: 50vh;
+  overflow-y: auto;
+  overscroll-behavior: contain;
 }
 
 .topbar {

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -434,7 +434,11 @@ def _handle_background_terminal(outcome) -> None:
         pass
     # Carry a trimmed result so a still-open spawning chat can render the outcome
     # live without a refetch (the model learns separately, via the next-turn drain).
-    result_preview = text if len(text) <= 2000 else text[:2000] + "\n\n…[truncated]"
+    result_preview = (
+        text
+        if len(text) <= 2000
+        else text[:2000] + "\n\n…[truncated — open the **Background agents** panel for the full report]"
+    )
     _event_bus.publish(
         "background.completed",
         {


### PR DESCRIPTION
**Symptom:** a background agent's report (e.g. a research agent's multi-thousand-word summary) showed as `…[truncated]` in the UI — even though the full result is persisted and `GET /api/background` returns it whole.

**Cause:** the `background.completed` bus event carries a **trimmed ~2k preview** (intentional — so a still-open chat can render the outcome live without a refetch). The Background agents dialog overwrote its hydrated *full* result with that preview, so "show result" rendered the truncated copy.

**Fix:**
- Re-hydrate the durable full results from `/api/background` when the panel **opens** and when a job **completes** — "show result" now always renders the entire report.
- The result area scrolls (`max-height: 50vh; overflow-y: auto`) so a long report is fully readable without an unbounded dialog.
- The preview's truncation marker now points at the full-report home: `…[truncated — open the Background agents panel for the full report]`.

**Verification:** web build + 94 web tests + 62 backend (a2a/background) tests green. (No background-jobs E2E spec exists to update.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)