### PR TITLE
fix(web): show Knowledge "initializing" during boot instead of "disabled"

### DIFF
--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -28,6 +28,9 @@ export type RuntimeStatus = {
   middleware: Record<string, boolean>;
   knowledge: {
     enabled: boolean;
+    // "ready" (store built) · "initializing" (flag on, store still warming up during
+    // boot/recompile) · "disabled" (flag off). Optional for older backends.
+    status?: "ready" | "initializing" | "disabled";
     configured_path: string | null;
     resolved_path: string | null;
     top_k?: number | null;

--- a/apps/web/src/settings/OverviewPanel.tsx
+++ b/apps/web/src/settings/OverviewPanel.tsx
@@ -47,7 +47,17 @@ function StatusBody() {
           <Metric icon={<Bot size={16} />} label="Agent" value={brandName(runtime.identity?.name)} />
           <Metric icon={<Tag size={16} />} label="Version" value={runtime.version ? `v${runtime.version}` : "—"} />
           <Metric icon={<Settings2 size={16} />} label="Provider" value={runtime.model?.provider || "none"} />
-          <Metric icon={<Database size={16} />} label="Knowledge" value={runtime.knowledge.resolved_path || runtime.knowledge.configured_path || "disabled"} />
+          <Metric
+            icon={<Database size={16} />}
+            label="Knowledge"
+            value={
+              runtime.knowledge.status === "initializing"
+                ? "initializing…"
+                : runtime.knowledge.resolved_path ||
+                  runtime.knowledge.configured_path ||
+                  (runtime.knowledge.enabled ? "enabled" : "disabled")
+            }
+          />
           <Metric icon={<Sparkles size={16} />} label="Goal mode" value={runtime.goal.enabled ? "on" : "off"} />
         </div>
         {runtime.storage ? (

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -62,7 +62,7 @@ def build_runtime_status(
             "model": None,
             "identity": None,
             "middleware": {},
-            "knowledge": {"enabled": False, "configured_path": None, "resolved_path": None},
+            "knowledge": {"enabled": False, "status": "initializing", "configured_path": None, "resolved_path": None},
             "skills": {"enabled": False, "count": skill_count, "configured_path": None},
             "mcp": mcp_block,
             "plugins": plugins_block,
@@ -73,6 +73,13 @@ def build_runtime_status(
             "instance_uid": instance_uid,
             "version": version,
         }
+
+    # Knowledge can be ON (the config flag) but still building its store during the
+    # boot/recompile window — surface that as "initializing" so the UI doesn't read a
+    # warming store as "disabled" (the flag is the source of truth for on/off).
+    _kn_on = bool(getattr(config, "knowledge_middleware", False))
+    _kn_resolved = str(getattr(knowledge_store, "path", "") or "") or None
+    _kn_status = "disabled" if not _kn_on else ("ready" if _kn_resolved else "initializing")
 
     return {
         "setup_complete": bool(setup_complete),
@@ -105,9 +112,10 @@ def build_runtime_status(
             "execute_code": bool(getattr(config, "execute_code_enabled", False)),
         },
         "knowledge": {
-            "enabled": bool(getattr(config, "knowledge_middleware", False)),
+            "enabled": _kn_on,
+            "status": _kn_status,
             "configured_path": getattr(config, "knowledge_db_path", None),
-            "resolved_path": str(getattr(knowledge_store, "path", "") or "") or None,
+            "resolved_path": _kn_resolved,
             "top_k": getattr(config, "knowledge_top_k", None),
         },
         "skills": {

--- a/tests/test_operator_api_runtime.py
+++ b/tests/test_operator_api_runtime.py
@@ -40,6 +40,8 @@ def test_runtime_status_redacts_secret_values() -> None:
     assert status["project"]["path"] == "/tmp/protoagent"
     assert status["project"]["allowed_dirs"] == ["/tmp/protoagent", "/home/kj/projects/foo"]
     assert status["knowledge"]["resolved_path"] == "/tmp/protoagent/knowledge.db"
+    # Flag on (default) + store built → ready.
+    assert status["knowledge"]["status"] == "ready"
     assert status["scheduler"]["backend"] == "local"
     assert "sk-secret" not in repr(status)
 
@@ -55,6 +57,8 @@ def test_runtime_status_handles_missing_config() -> None:
     assert status["graph_loaded"] is False
     assert status["model"] is None
     assert status["knowledge"]["enabled"] is False
+    # No config yet (booting) → initializing, not "disabled".
+    assert status["knowledge"]["status"] == "initializing"
     assert status["project"]["allowed_dirs"] == []
     assert status["version"] == ""  # not passed — defaults empty, key still present
 


### PR DESCRIPTION
**Symptom:** caught mid-startup, Settings → Overview showed **Knowledge: disabled** — even though the knowledge middleware is on by default.

**Cause:** the metric rendered `resolved_path || configured_path || "disabled"` and ignored the `enabled` flag. During the boot/recompile window the store isn't built yet (no `resolved_path`), so it fell through to "disabled". The flag was on the whole time — the store was just still warming up.

**Fix:**
- `runtime_status` now reports a knowledge **`status`**: `ready` (store built) · `initializing` (flag on, store warming up / config not loaded yet) · `disabled` (flag off).
- `OverviewPanel` renders **"initializing…"** for that state; otherwise the path, falling back to the `enabled` flag rather than always "disabled".

**Verification:** web build + 94 web + 105 E2E + 4 runtime-status tests (added `ready` + `initializing` assertions) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)