### PR TITLE
feat(web): delete + clear-finished for stacked-up background-agent entries

### DIFF
--- a/apps/web/src/app/BackgroundJobs.tsx
+++ b/apps/web/src/app/BackgroundJobs.tsx
@@ -1,5 +1,5 @@
 import { Dialog } from "@protolabsai/ui/overlays";
-import { Bot, CheckCircle2, Loader2, Square, XCircle } from "lucide-react";
+import { Bot, CheckCircle2, Loader2, Square, Trash2, XCircle } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Markdown } from "../chat/LazyMarkdown";
@@ -118,6 +118,7 @@ export function BackgroundJobs() {
 
   const list = useMemo(() => Object.values(jobs).sort(byRecency), [jobs]);
   const running = list.filter((j) => j.status === "running").length;
+  const finished = list.length - running;
 
   // Tick the elapsed clock once a second while the dialog is open and work runs.
   useEffect(() => {
@@ -133,6 +134,30 @@ export function BackgroundJobs() {
       await api.stopBackground(jobId);
     } catch {
       /* best-effort; the registry stays source of truth */
+    }
+  }
+
+  // Delete a single finished entry — optimistic remove; the registry is source of truth.
+  async function del(jobId: string) {
+    setJobs((m) => {
+      const next = { ...m };
+      delete next[jobId];
+      return next;
+    });
+    try {
+      await api.deleteBackground(jobId);
+    } catch {
+      /* best-effort */
+    }
+  }
+
+  // Clear all finished entries at once (running jobs stay).
+  async function clearFinished() {
+    setJobs((m) => Object.fromEntries(Object.entries(m).filter(([, j]) => j.status === "running")));
+    try {
+      await api.clearFinishedBackground();
+    } catch {
+      /* best-effort */
     }
   }
 
@@ -161,11 +186,20 @@ export function BackgroundJobs() {
           {list.length === 0 ? (
             <p className="bg-jobs-empty">No background agents have run yet.</p>
           ) : (
-            <ul className="bg-jobs-list">
-              {list.map((j) => (
-                <BgJobRow key={j.id} job={j} tools={progress[j.id] || []} onStop={stop} />
-              ))}
-            </ul>
+            <>
+              {finished > 0 ? (
+                <div className="bg-jobs-toolbar">
+                  <button type="button" className="bg-jobs-clear" onClick={clearFinished}>
+                    <Trash2 size={12} /> Clear finished ({finished})
+                  </button>
+                </div>
+              ) : null}
+              <ul className="bg-jobs-list">
+                {list.map((j) => (
+                  <BgJobRow key={j.id} job={j} tools={progress[j.id] || []} onStop={stop} onDelete={del} />
+                ))}
+              </ul>
+            </>
           )}
         </Dialog>
       ) : null}
@@ -177,10 +211,12 @@ function BgJobRow({
   job,
   tools,
   onStop,
+  onDelete,
 }: {
   job: BackgroundJobDTO;
   tools: ProgressTool[];
   onStop: (jobId: string) => void;
+  onDelete: (jobId: string) => void;
 }) {
   const [expanded, setExpanded] = useState(false);
   const running = job.status === "running";
@@ -235,7 +271,17 @@ function BgJobRow({
           >
             <Square size={12} />
           </button>
-        ) : null}
+        ) : (
+          <button
+            type="button"
+            className="bg-jobs-stop"
+            onClick={() => onDelete(job.id)}
+            title="Delete this entry"
+            aria-label="Delete"
+          >
+            <Trash2 size={12} />
+          </button>
+        )}
       </div>
       {hasResult && expanded ? (
         <div className="bg-jobs-result">

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -179,6 +179,27 @@
   color: var(--pl-color-status-error, #e5484d);
   background: var(--bg-elevated-hover, rgba(255, 255, 255, 0.03));
 }
+.bg-jobs-toolbar {
+  display: flex;
+  justify-content: flex-end;
+  padding: 0 4px 8px;
+}
+.bg-jobs-clear {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 9px;
+  font-size: 12px;
+  border: 1px solid var(--border, #2a2a31);
+  border-radius: 6px;
+  background: transparent;
+  color: var(--fg-secondary);
+  cursor: pointer;
+}
+.bg-jobs-clear:hover {
+  color: var(--pl-color-status-error, #e5484d);
+  border-color: var(--pl-color-status-error, #e5484d);
+}
 .bg-jobs-icon {
   flex: none;
   margin-top: 1px;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -564,6 +564,19 @@ export const api = {
     );
   },
 
+  // Delete a FINISHED background job's entry (housekeeping). Running jobs are kept.
+  deleteBackground(jobId: string) {
+    return request<{ ok: boolean; deleted?: boolean }>(
+      `/api/background/${encodeURIComponent(jobId)}`,
+      { method: "DELETE" },
+    );
+  },
+
+  // Delete all FINISHED background jobs (clears the stacked-up history).
+  clearFinishedBackground() {
+    return request<{ ok: boolean; cleared?: number }>("/api/background/clear", { method: "POST" });
+  },
+
   telemetrySummary(since?: string) {
     const q = since ? `?since=${encodeURIComponent(since)}` : "";
     return request<{ enabled: boolean; summary: TelemetrySummary | null }>(

--- a/background/store.py
+++ b/background/store.py
@@ -266,3 +266,29 @@ class BackgroundStore:
             return [_row_to_job(r) for r in rows]
         finally:
             db.close()
+
+    def delete(self, job_id: str) -> bool:
+        """Delete a finished job's row (housekeeping). A running job is left alone —
+        cancel it first. Returns ``True`` if a row was removed."""
+        db = self._connect()
+        try:
+            cur = db.execute("DELETE FROM background_jobs WHERE id = ? AND status != 'running'", (job_id,))
+            db.commit()
+            return cur.rowcount > 0
+        finally:
+            db.close()
+
+    def clear_finished(self, origin_session: str | None = None) -> int:
+        """Delete all finished (non-running) jobs, optionally scoped to one originating
+        session. Running jobs are kept. Returns the number removed."""
+        clauses, params = ["status != 'running'"], []
+        if origin_session is not None:
+            clauses.append("origin_session = ?")
+            params.append(origin_session)
+        db = self._connect()
+        try:
+            cur = db.execute(f"DELETE FROM background_jobs WHERE {' AND '.join(clauses)}", params)
+            db.commit()
+            return cur.rowcount
+        finally:
+            db.close()

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -255,6 +255,36 @@ def register_operator_routes(
         except Exception as exc:
             raise _http_error(exc) from exc
 
+    @app.delete("/api/background/{job_id}")
+    async def _background_delete(job_id: str):
+        """Delete a FINISHED background job's entry (housekeeping). Running jobs are kept —
+        cancel them first. Returns ``{ok, deleted}``."""
+        from runtime.state import STATE
+
+        mgr = getattr(STATE, "background_mgr", None)
+        if mgr is None:
+            return {"ok": False, "detail": "Background jobs are not available."}
+        try:
+            deleted = await asyncio.to_thread(mgr.store.delete, job_id)
+            return {"ok": True, "deleted": bool(deleted)}
+        except Exception as exc:
+            raise _http_error(exc) from exc
+
+    @app.post("/api/background/clear")
+    async def _background_clear(session: str = ""):
+        """Delete all FINISHED background jobs (optionally scoped to an originating
+        ``session``). Running jobs are kept. Returns ``{ok, cleared}``."""
+        from runtime.state import STATE
+
+        mgr = getattr(STATE, "background_mgr", None)
+        if mgr is None:
+            return {"ok": False, "detail": "Background jobs are not available."}
+        try:
+            cleared = await asyncio.to_thread(mgr.store.clear_finished, session or None)
+            return {"ok": True, "cleared": int(cleared)}
+        except Exception as exc:
+            raise _http_error(exc) from exc
+
     @app.post("/api/subagents/run")
     async def _subagent_run(req: SubagentRunRequest):
         try:

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -102,6 +102,39 @@ class TestStore:
         assert {j.status for j in s.list(status="completed")} == {"completed"}
         assert len(s.list()) == 2
 
+    def test_delete_removes_a_finished_job(self, tmp_path):
+        s = _store(tmp_path)
+        jid = s.create(agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p")
+        s.mark_complete(jid, "completed", "done")
+        assert s.delete(jid) is True
+        assert s.get(jid) is None
+        assert s.delete(jid) is False  # already gone — idempotent
+
+    def test_delete_keeps_a_running_job(self, tmp_path):
+        s = _store(tmp_path)
+        jid = s.create(agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p")
+        assert s.delete(jid) is False  # running jobs are kept — cancel first
+        assert s.get(jid) is not None
+
+    def test_clear_finished_removes_only_finished(self, tmp_path):
+        s = _store(tmp_path)
+        done = s.create(agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p")
+        s.mark_complete(done, "completed", "r")
+        run = s.create(agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p")
+        assert s.clear_finished() == 1
+        assert s.get(done) is None
+        assert s.get(run) is not None  # running kept
+
+    def test_clear_finished_is_session_scoped(self, tmp_path):
+        s = _store(tmp_path)
+        a = s.create(agent_name="a", origin_session="s1", subagent_type="researcher", description="d", prompt="p")
+        b = s.create(agent_name="a", origin_session="s2", subagent_type="researcher", description="d", prompt="p")
+        s.mark_complete(a, "completed", "ra")
+        s.mark_complete(b, "completed", "rb")
+        assert s.clear_finished("s1") == 1
+        assert s.get(a) is None
+        assert s.get(b) is not None
+
 
 # ── manager ──────────────────────────────────────────────────────────────────
 


### PR DESCRIPTION
The Background agents dialog only grew — finished jobs piled up with no way to remove them. This adds housekeeping.

**Backend**
- `BackgroundStore.delete(job_id)` — finished jobs only (running jobs are kept; cancel them first). Idempotent.
- `BackgroundStore.clear_finished(origin_session=None)` — bulk-remove finished jobs, optionally session-scoped.
- `DELETE /api/background/{job_id}` and `POST /api/background/clear`.

**UI**
- A **trash** button on every finished row (optimistic remove).
- A **"Clear finished (N)"** toolbar button at the top of the dialog when finished entries exist.
- Running jobs keep their **Stop** control and can't be deleted.

**Verification:** store delete/clear tests (finished-only + session-scoped) — 36 backend · 94 web · 105 E2E, all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)