### PR TITLE
feat(skills): author/edit/delete skills from the console

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Skills CRUD in the console.** Settings ▸ Workspace ▸ Skills now lets you
+  **author, edit, and delete** skills — not just browse, delete, and promote.
+  Operator-authored skills are persisted as portable `SKILL.md` files under a
+  writable data-home root (`~/.protoagent/skills`, instance-scoped, via
+  `infra.paths.user_skills_dir`) and seeded into the index on boot like any
+  skill root, so they survive restarts, stay out of the repo working tree, and
+  are exportable. Editing an agent-**learned** skill materializes it as a
+  durable `SKILL.md` (curation = persistence); **bundled** examples and shared
+  **commons** skills are read-only. New routes: `POST /api/playbooks` (create),
+  `GET /api/playbooks/{id}` (full body), `PUT /api/playbooks/{id}` (edit); the
+  list payload now tags each skill with `origin`/`editable`.
+
 ## [0.49.1] - 2026-06-18
 
 ## [0.49.0] - 2026-06-18

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -81,6 +81,13 @@ let INSTALLED_PLUGINS = [];
 // `POST /{id}/update` the entry is cleared so the row flips to "up to date".
 let PLUGIN_UPDATES = {};
 
+// Playbooks are MUTATED by the promote spec (a skill flips private→commons), so
+// serve a working copy that each playbooks test resets via
+// POST /api/__test__/playbooks/reset — otherwise the promote leaks into the
+// delete test (a commons skill is read-only, so its delete button is gone).
+const clonePlaybooks = () => JSON.parse(JSON.stringify(PLAYBOOKS));
+let playbooks = clonePlaybooks();
+
 // Fleet state is the one slice of the mock backend the specs MUTATE (create /
 // stop / rename / add-remote). Isolate it PER SPEC so parallel files and serial-
 // group retries can't observe each other's writes: every `x-e2e-fleet` request
@@ -211,7 +218,7 @@ function handleApiGet(pathname, fleet = FLEET) {
     case "/api/telemetry/insights":
       return { enabled: true, insights: TELEMETRY_INSIGHTS };
     case "/api/playbooks":
-      return { enabled: true, playbooks: PLAYBOOKS };
+      return { enabled: true, playbooks };
     case "/api/knowledge/search":
       return {
         enabled: true, query: "", results: KNOWLEDGE_CHUNKS,
@@ -374,6 +381,11 @@ const server = createServer(async (req, res) => {
       fleetScopes.set(req.headers["x-e2e-fleet"] || "default", cloneFleet(FLEET));
       return sendJson(res, { ok: true });
     }
+    if (pathname === "/api/__test__/playbooks/reset" && req.method === "POST") {
+      // Per-test hermeticity: undo any promote (private→commons) from a prior test.
+      playbooks = clonePlaybooks();
+      return sendJson(res, { ok: true });
+    }
     if (pathname === "/api/settings") {
       // ADR 0047: a layer-aware save — "agent" (per-agent leaf, default) or "host"
       // (box-shared host-config.yaml). The mock just echoes which layer it wrote.
@@ -453,7 +465,7 @@ const server = createServer(async (req, res) => {
     }
     if (req.method === "POST" && /^\/api\/playbooks\/\d+\/promote$/.test(pathname)) {
       const id = Number(pathname.split("/").at(-2));
-      const p = PLAYBOOKS.find((x) => x.id === id);
+      const p = playbooks.find((x) => x.id === id);
       if (p) p.tier = "commons"; // promoted: now reads from the commons tier
       return sendJson(res, { enabled: true, promoted: true, name: p?.name });
     }

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -3,9 +3,13 @@ import { expect, test } from "@playwright/test";
 // The Knowledge ▸ Playbooks surface (ADR 0009) browses the skill index:
 // pinned (SKILL.md) vs learned (agent-emitted), with search + delete-with-confirm.
 
-// The promote test mutates the mock (a skill flips private→commons); reset it
-// before each test so that change can't leak into the delete test (a commons
-// skill is read-only, so its delete affordance is gone).
+// The promote test MUTATES the shared mock (a skill flips private→commons) and a
+// commons skill is read-only under the CRUD editability gating, so its delete
+// affordance is gone. With fullyParallel the file's tests would otherwise run on
+// separate workers against the one mock process and stomp each other (the promote
+// leaks into the delete test). Run serially + reset the mock before every test —
+// same guard the fleet spec uses for its shared mutable state.
+test.describe.configure({ mode: "serial" });
 test.beforeEach(async ({ page }) => {
   await page.request.post("/api/__test__/playbooks/reset");
 });

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -3,6 +3,13 @@ import { expect, test } from "@playwright/test";
 // The Knowledge ▸ Playbooks surface (ADR 0009) browses the skill index:
 // pinned (SKILL.md) vs learned (agent-emitted), with search + delete-with-confirm.
 
+// The promote test mutates the mock (a skill flips private→commons); reset it
+// before each test so that change can't leak into the delete test (a commons
+// skill is read-only, so its delete affordance is gone).
+test.beforeEach(async ({ page }) => {
+  await page.request.post("/api/__test__/playbooks/reset");
+});
+
 test("Agent → Skills lists pinned + learned skills and supports search", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -647,6 +647,43 @@ export const api = {
     }>("/api/knowledge/attach", form);
   },
 
+  // Skills CRUD — author/edit operator skills. A create/edit writes a real
+  // SKILL.md under the user-skills root (durable + exportable) and re-indexes it
+  // live; editing a learned skill materializes it as a durable SKILL.md.
+  createPlaybook(body: {
+    name: string;
+    description: string;
+    prompt_template: string;
+    tools_used?: string[];
+    user_facing?: boolean;
+    slash?: string;
+  }) {
+    return request<{ enabled: boolean; id: number | null; skill: Playbook | null }>(
+      "/api/playbooks",
+      { method: "POST", body },
+    );
+  },
+  // Fetch one skill WITH its full prompt_template (the list omits it) to pre-fill the editor.
+  getPlaybook(id: number) {
+    return request<{ enabled: boolean; skill: Playbook | null }>(`/api/playbooks/${id}`);
+  },
+  updatePlaybook(
+    id: number,
+    body: {
+      name: string;
+      description: string;
+      prompt_template: string;
+      tools_used?: string[];
+      user_facing?: boolean;
+      slash?: string;
+    },
+  ) {
+    return request<{ enabled: boolean; id: number | null; skill: Playbook | null }>(
+      `/api/playbooks/${id}`,
+      { method: "PUT", body },
+    );
+  },
+
   deletePlaybook(id: number) {
     return request<{ enabled: boolean; deleted: boolean; error?: string }>(
       `/api/playbooks/${id}`,

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -540,6 +540,16 @@ export type Playbook = {
   // index is layered (the agent reads a shared commons ∪ its private library);
   // absent in scoped/shared mode, where there's a single library and no promote.
   tier?: "private" | "commons";
+  // Skills CRUD — the list route tags each row so the UI shows edit/delete only on
+  // skills the operator owns: "user" (authored SKILL.md) and "learned" (agent-
+  // emitted) are editable; "bundled" (shipped example) and "commons" are read-only.
+  origin?: "user" | "learned" | "bundled" | "commons";
+  editable?: boolean;
+  user_facing?: boolean;
+  slash?: string;
+  // Full procedure body — present only on the single-skill detail (GET
+  // /api/playbooks/:id); the list payload omits it to stay light.
+  prompt_template?: string;
 };
 
 // One row from the knowledge store (knowledge/store.py chunks table), as the

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -1,6 +1,6 @@
-import { Input } from "@protolabsai/ui/forms";
+import { Input, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { ArrowUpToLine, BookMarked, Library, Pin, Share2, Sparkles, Trash2 } from "lucide-react";
+import { ArrowUpToLine, BookMarked, Library, Pencil, Pin, Plus, Share2, Sparkles, Trash2 } from "lucide-react";
 
 import { useEffect, useMemo, useState } from "react";
 
@@ -14,9 +14,138 @@ import type { Playbook } from "../lib/types";
 
 // Playbooks surface (ADR 0009) — browse + manage the procedural-memory skill
 // index (skills.db) the operator was otherwise blind to. "Playbooks" is the
-// operator-facing name for skill-v1 artifacts: disk = pinned SKILL.md,
-// emitted = agent-learned (curated/decaying). Functional-first: list + search +
-// delete-with-confirm. Confidence tuning / curator audit are follow-ups.
+// operator-facing name for skill-v1 artifacts: user = operator-authored SKILL.md,
+// bundled = shipped example, learned = agent-emitted (curated/decaying).
+// Full CRUD: author a new skill, edit one (editing a learned skill materializes
+// it as a durable user SKILL.md), delete, promote to the shared commons. Bundled
+// examples + commons skills are read-only.
+
+type Draft = {
+  name: string;
+  description: string;
+  body: string;
+  tools: string;
+  userFacing: boolean;
+  slash: string;
+};
+const EMPTY_DRAFT: Draft = { name: "", description: "", body: "", tools: "", userFacing: false, slash: "" };
+
+function SkillForm({
+  draft,
+  setDraft,
+  onSave,
+  onCancel,
+  saving,
+  saveLabel,
+}: {
+  draft: Draft;
+  setDraft: (d: Draft) => void;
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+  saveLabel: string;
+}) {
+  const incomplete = !draft.name.trim() || !draft.description.trim() || !draft.body.trim();
+  return (
+    <div className="knowledge-chunk-form">
+      <Input
+        type="text"
+        placeholder="name — e.g. “Release notes”"
+        value={draft.name}
+        onChange={(e) => setDraft({ ...draft, name: e.target.value })}
+        aria-label="skill name"
+      />
+      <Input
+        type="text"
+        placeholder="description — when should the agent reach for this? (the trigger signal)"
+        value={draft.description}
+        onChange={(e) => setDraft({ ...draft, description: e.target.value })}
+        aria-label="skill description"
+      />
+      <Textarea
+        rows={8}
+        placeholder="The procedure — markdown instructions the agent retrieves into context."
+        value={draft.body}
+        onChange={(e) => setDraft({ ...draft, body: e.target.value })}
+        aria-label="skill body"
+      />
+      <Input
+        type="text"
+        placeholder="tools (comma-separated, optional)"
+        value={draft.tools}
+        onChange={(e) => setDraft({ ...draft, tools: e.target.value })}
+        aria-label="skill tools"
+      />
+      <div className="knowledge-chunk-form-row">
+        <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+          <input
+            type="checkbox"
+            checked={draft.userFacing}
+            onChange={(e) => setDraft({ ...draft, userFacing: e.target.checked })}
+            aria-label="invokable as a slash command"
+          />
+          Invokable as a <code>/slash</code> command
+        </label>
+        {draft.userFacing ? (
+          <Input
+            type="text"
+            placeholder="slash token (optional — defaults to the name)"
+            value={draft.slash}
+            onChange={(e) => setDraft({ ...draft, slash: e.target.value })}
+            aria-label="slash token"
+            style={{ maxWidth: 260 }}
+          />
+        ) : null}
+      </div>
+      <div className="knowledge-chunk-form-row">
+        <Button type="button" variant="primary" size="sm" disabled={saving || incomplete} onClick={onSave}>
+          {saveLabel}
+        </Button>
+        <Button type="button" variant="ghost" size="sm" onClick={onCancel}>
+          Cancel
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// An operator can edit user-authored + agent-learned skills; bundled examples and
+// shared commons skills are read-only. Tolerate older payloads (no `origin`) by
+// falling back to the source: a flat "disk" skill we can't classify is treated as
+// editable so the affordance never silently disappears for non-layered stores.
+function isEditable(p: Playbook): boolean {
+  if (typeof p.editable === "boolean") return p.editable;
+  if (p.tier === "commons") return false;
+  return p.source !== "disk";
+}
+
+// Source badge — what KIND of skill this is, independent of its tier: "yours"
+// (operator-authored SKILL.md), "pinned" (bundled example, read-only), or
+// "learned" (agent-emitted). The shared/private TIER is a separate badge.
+function SourceBadge({ p }: { p: Playbook }) {
+  if (p.source === "disk") {
+    return p.origin === "user" ? (
+      <span title="You authored this skill (SKILL.md under your data home)">
+        <Badge status="success">
+          <Pencil size={12} /> yours
+        </Badge>
+      </span>
+    ) : (
+      <span title="Bundled example (re-seeded from SKILL.md on boot) — read-only">
+        <Badge status="info">
+          <Pin size={12} /> pinned
+        </Badge>
+      </span>
+    );
+  }
+  return (
+    <span title="Agent-emitted (curated/decaying)">
+      <Badge status="neutral">
+        <Sparkles size={12} /> learned
+      </Badge>
+    </span>
+  );
+}
 
 export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: string) => void }) {
   const [playbooks, setPlaybooks] = useState<Playbook[]>([]);
@@ -25,6 +154,11 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
   const [query, setQuery] = useState("");
   const [pending, setPending] = useState<Playbook | null>(null);
   const [promoting, setPromoting] = useState<number | null>(null);
+
+  const [adding, setAdding] = useState(false);
+  const [editingId, setEditingId] = useState<number | null>(null);
+  const [draft, setDraft] = useState<Draft>(EMPTY_DRAFT);
+  const [saving, setSaving] = useState(false);
 
   async function load() {
     setLoading(true);
@@ -60,6 +194,71 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
   // is, surface a commons count so the operator sees the shared library at a glance.
   const layered = playbooks.some((p) => p.tier);
   const fromCommons = filtered.filter((p) => p.tier === "commons").length;
+
+  function openCreate() {
+    setEditingId(null);
+    setDraft(EMPTY_DRAFT);
+    setAdding((v) => !v);
+  }
+
+  async function startEdit(p: Playbook) {
+    setAdding(false);
+    try {
+      const r = await api.getPlaybook(p.id);
+      const s = r.skill;
+      if (!s) {
+        onError("could not load that skill");
+        return;
+      }
+      setDraft({
+        name: s.name,
+        description: s.description,
+        body: s.prompt_template || "",
+        tools: (s.tools_used || []).join(", "),
+        userFacing: !!s.user_facing,
+        slash: s.slash || "",
+      });
+      setEditingId(p.id);
+      onError("");
+    } catch (e) {
+      onError(errMsg(e));
+    }
+  }
+
+  function cancelForm() {
+    setAdding(false);
+    setEditingId(null);
+    setDraft(EMPTY_DRAFT);
+  }
+
+  async function save() {
+    setSaving(true);
+    try {
+      const payload = {
+        name: draft.name.trim(),
+        description: draft.description.trim(),
+        prompt_template: draft.body,
+        tools_used: draft.tools
+          .split(",")
+          .map((t) => t.trim())
+          .filter(Boolean),
+        user_facing: draft.userFacing,
+        slash: draft.slash.trim(),
+      };
+      const r = editingId !== null ? await api.updatePlaybook(editingId, payload) : await api.createPlaybook(payload);
+      if (!r.skill) {
+        onError("save failed");
+        return;
+      }
+      cancelForm();
+      onError("");
+      await load();
+    } catch (e) {
+      onError(errMsg(e));
+    } finally {
+      setSaving(false);
+    }
+  }
 
   async function promote(p: Playbook) {
     setPromoting(p.id);
@@ -104,6 +303,18 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
             {/* Quick-set the skill-sharing mode (scoped/shared/layered) right where you
                 manage skills — same field as Workspace ▸ Skills, ADR 0048. */}
             <QuickSetting keys={["skills.scope"]} title="Skill sharing" label="Skill sharing mode" icon={<Share2 size={16} />} />
+            {enabled ? (
+              <Button
+                icon
+                variant="ghost"
+                type="button"
+                onClick={openCreate}
+                title="Author a new skill"
+                data-testid="playbook-new"
+              >
+                <Plus size={16} />
+              </Button>
+            ) : null}
             <RefreshButton onClick={() => void load()} busy={loading} />
           </>
         }
@@ -118,83 +329,120 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
           onChange={(e) => setQuery(e.target.value)}
         />
 
+        {adding ? (
+          <SkillForm
+            draft={draft}
+            setDraft={setDraft}
+            onSave={() => void save()}
+            onCancel={cancelForm}
+            saving={saving}
+            saveLabel="Create skill"
+          />
+        ) : null}
+
         {!enabled ? (
           <Empty>The skills index is disabled (set <code>skills.enabled: true</code>).</Empty>
         ) : filtered.length === 0 ? (
           playbooks.length === 0 ? (
             <Empty
-              title="No playbooks yet"
-              description="author a SKILL.md, or let the agent emit one from a run."
+              title="No skills yet"
+              description="author one with +, drop a SKILL.md, or let the agent emit one from a run."
             />
           ) : (
-            <Empty>No playbooks match your search.</Empty>
+            <Empty>No skills match your search.</Empty>
           )
         ) : (
           <ul className="playbook-list">
             {filtered.map((p) => (
               <li key={p.id} className="playbook-card">
-                <div className="playbook-main">
-                  <div className="playbook-title">
-                    {p.source === "disk" ? (
-                      <span title="Pinned SKILL.md (re-seeded on boot)">
-                        <Badge status="info">
-                          <Pin size={12} /> pinned
-                        </Badge>
-                      </span>
-                    ) : (
-                      <span title="Agent-emitted (curated/decaying)">
-                        <Badge status="success">
-                          <Sparkles size={12} /> learned
-                        </Badge>
-                      </span>
-                    )}
-                    {p.tier === "commons" ? (
-                      <span title="Shared commons — readable by every agent on this box">
-                        <Badge status="neutral">
-                          <Library size={12} /> commons
-                        </Badge>
-                      </span>
-                    ) : p.tier === "private" ? (
-                      <span title="Private to this agent — promote to share it with the fleet">
-                        <Badge status="neutral">private</Badge>
-                      </span>
-                    ) : null}
-                    <strong>{p.name}</strong>
-                  </div>
-                  <p className="playbook-desc">{p.description}</p>
-                  {p.tools_used.length ? (
-                    <div className="playbook-tools">
-                      {p.tools_used.map((t) => (
-                        <code key={t}>{t}</code>
-                      ))}
+                {editingId === p.id ? (
+                  <SkillForm
+                    draft={draft}
+                    setDraft={setDraft}
+                    onSave={() => void save()}
+                    onCancel={cancelForm}
+                    saving={saving}
+                    saveLabel="Save changes"
+                  />
+                ) : (
+                  <>
+                    <div className="playbook-main">
+                      <div className="playbook-title">
+                        <SourceBadge p={p} />
+                        {p.tier === "commons" ? (
+                          <span title="Shared commons — readable by every agent on this box">
+                            <Badge status="neutral">
+                              <Library size={12} /> commons
+                            </Badge>
+                          </span>
+                        ) : p.tier === "private" ? (
+                          <span title="Private to this agent — promote to share it with the fleet">
+                            <Badge status="neutral">private</Badge>
+                          </span>
+                        ) : null}
+                        {p.user_facing ? (
+                          <span title={`Invokable as /${p.slash || p.name}`}>
+                            <Badge status="neutral">/{p.slash || p.name}</Badge>
+                          </span>
+                        ) : null}
+                        <strong>{p.name}</strong>
+                      </div>
+                      <p className="playbook-desc">{p.description}</p>
+                      {p.tools_used.length ? (
+                        <div className="playbook-tools">
+                          {p.tools_used.map((t) => (
+                            <code key={t}>{t}</code>
+                          ))}
+                        </div>
+                      ) : null}
                     </div>
-                  ) : null}
-                </div>
-                <div className="playbook-meta">
-                  <span title="confidence">conf {Math.round((p.confidence ?? 1) * 100)}%</span>
-                  <span title="last used">used {ago(p.last_used)}</span>
-                  {p.tier === "private" ? (
-                    <Button
-                      type="button"
-                      icon variant="ghost"
-                      title="Promote to the shared commons (every agent on this box can then reuse it)"
-                      onClick={() => void promote(p)}
-                      disabled={promoting === p.id}
-                      data-testid={`playbook-promote-${p.id}`}
-                    >
-                      <ArrowUpToLine size={14} className={promoting === p.id ? "spin" : ""} />
-                    </Button>
-                  ) : null}
-                  <Button
-                    type="button"
-                    icon variant="danger"
-                    title={p.source === "disk" ? "Delete (re-seeds from SKILL.md on restart)" : "Delete skill"}
-                    onClick={() => setPending(p)}
-                    data-testid={`playbook-delete-${p.id}`}
-                  >
-                    <Trash2 size={14} />
-                  </Button>
-                </div>
+                    <div className="playbook-meta">
+                      <span title="confidence">conf {Math.round((p.confidence ?? 1) * 100)}%</span>
+                      <span title="last used">used {ago(p.last_used)}</span>
+                      {p.tier === "private" ? (
+                        <Button
+                          type="button"
+                          icon
+                          variant="ghost"
+                          title="Promote to the shared commons (every agent on this box can then reuse it)"
+                          onClick={() => void promote(p)}
+                          disabled={promoting === p.id}
+                          data-testid={`playbook-promote-${p.id}`}
+                        >
+                          <ArrowUpToLine size={14} className={promoting === p.id ? "spin" : ""} />
+                        </Button>
+                      ) : null}
+                      {isEditable(p) ? (
+                        <>
+                          <Button
+                            type="button"
+                            icon
+                            variant="ghost"
+                            title="Edit skill"
+                            onClick={() => void startEdit(p)}
+                            data-testid={`playbook-edit-${p.id}`}
+                          >
+                            <Pencil size={14} />
+                          </Button>
+                          <Button
+                            type="button"
+                            icon
+                            variant="danger"
+                            title="Delete skill"
+                            onClick={() => setPending(p)}
+                            data-testid={`playbook-delete-${p.id}`}
+                          >
+                            <Trash2 size={14} />
+                          </Button>
+                        </>
+                      ) : (
+                        <span className="playbook-readonly" title="Bundled/shared skill — read-only here">
+                          read-only
+                        </span>
+                      )}
+                    </div>
+                  </>
+                )}
               </li>
             ))}
           </ul>
@@ -210,7 +458,7 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
         onClose={() => setPending(null)}
       >
         {pending
-          ? `Remove "${pending.name}"${pending.source === "disk" ? " — note: a pinned SKILL.md re-seeds on the next restart." : "."}`
+          ? `Remove "${pending.name}"${pending.origin === "user" ? " — its SKILL.md is deleted too." : "."}`
           : undefined}
       </ConfirmDialog>
 

--- a/graph/skills/authoring.py
+++ b/graph/skills/authoring.py
@@ -1,0 +1,124 @@
+"""Operator-authored skill CRUD — write/edit/remove ``SKILL.md`` files.
+
+The console's Skills surface lets the operator create and edit skills directly.
+Those skills are persisted as real ``SKILL.md`` files (the portable AgentSkills
+format, same as bundled examples) under the writable user-skills root
+(``infra.paths.user_skills_dir`` → ``~/.protoagent/skills``), NOT as bare DB rows
+— so they survive reboots (re-seeded each boot), are exportable/git-trackable on
+their own, and round-trip through the same loader the agent already uses.
+
+This module is the file layer; the HTTP routes (``operator_api/knowledge_routes``)
+compose it with the live ``SkillsIndex`` so an edit shows up without a restart.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from pathlib import Path
+
+import yaml
+
+from graph.skills.loader import parse_skill_md
+
+log = logging.getLogger("protoagent.skills.authoring")
+
+
+def slugify(name: str) -> str:
+    """Folder-safe slug for a skill name (lowercased, non-alphanumerics → hyphens).
+
+    Mirrors ``SkillV1Artifact.slash_token`` so a skill's folder, slash token, and
+    ``source_session_id`` stay aligned."""
+    return re.sub(r"[^a-z0-9]+", "-", (name or "").strip().lower()).strip("-")
+
+
+def skill_md_text(
+    name: str,
+    description: str,
+    body: str,
+    *,
+    tools: list[str] | None = None,
+    user_facing: bool = False,
+    slash: str = "",
+) -> str:
+    """Render a ``SKILL.md`` document: YAML frontmatter + markdown body."""
+    meta: dict[str, object] = {"name": name.strip(), "description": description.strip()}
+    if tools:
+        meta["tools"] = [str(t).strip() for t in tools if str(t).strip()]
+    if user_facing:
+        meta["user_facing"] = True
+        if slash.strip():
+            meta["slash"] = slash.strip()
+    frontmatter = yaml.safe_dump(meta, sort_keys=False, allow_unicode=True).strip()
+    return f"---\n{frontmatter}\n---\n\n{body.strip()}\n"
+
+
+def skill_path(root: Path, name: str) -> Path:
+    """The ``SKILL.md`` path for *name* under *root* (``<root>/<slug>/SKILL.md``)."""
+    return root / slugify(name) / "SKILL.md"
+
+
+def user_skill_exists(root: Path, name: str) -> bool:
+    """True when *name* resolves to an operator-authored ``SKILL.md`` under *root*."""
+    return skill_path(root, name).is_file()
+
+
+def write_skill(
+    root: Path,
+    name: str,
+    description: str,
+    body: str,
+    *,
+    tools: list[str] | None = None,
+    user_facing: bool = False,
+    slash: str = "",
+):
+    """Write ``<root>/<slug>/SKILL.md`` for *name* and return its parsed artifact.
+
+    Atomic at the file level (write to a temp sibling, then replace). Returns the
+    ``SkillV1Artifact`` so the caller can index it immediately."""
+    from infra.paths import atomic_write
+
+    path = skill_path(root, name)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    atomic_write(path, skill_md_text(name, description, body, tools=tools, user_facing=user_facing, slash=slash))
+    artifact = parse_skill_md(path)
+    if artifact is None:
+        # Shouldn't happen — we just wrote valid frontmatter — but never hand back None.
+        raise ValueError("authored SKILL.md failed to parse back")
+    return artifact
+
+
+def remove_skill(root: Path, name: str) -> bool:
+    """Remove the operator-authored skill folder for *name*. Returns True if removed."""
+    folder = (root / slugify(name)).resolve()
+    root_resolved = root.resolve()
+    # Defensive: never delete outside the user-skills root.
+    if root_resolved not in folder.parents and folder != root_resolved:
+        log.warning("[skills] refusing to remove %s — outside user root %s", folder, root_resolved)
+        return False
+    if folder.is_dir():
+        shutil.rmtree(folder, ignore_errors=True)
+        return True
+    return False
+
+
+def classify(skill: dict, root: Path) -> tuple[str, bool]:
+    """Return ``(origin, editable)`` for a skill dict from ``index.all_skills()``.
+
+    - ``commons``  — shared (layered tier); read-only here (promote is one-way).
+    - ``user``     — operator-authored ``SKILL.md`` under the user root; editable.
+    - ``learned``  — agent-emitted/distilled DB skill; editable (an edit materializes
+                     it as a durable user ``SKILL.md``).
+    - ``bundled``  — a shipped/plugin example (``disk`` source, no user file); read-only.
+    """
+    if skill.get("tier") == "commons":
+        return "commons", False
+    source = skill.get("source") or "emitted"
+    if source == "disk":
+        if user_skill_exists(root, skill.get("name", "")):
+            return "user", True
+        return "bundled", False
+    # emitted / distilled / promoted-in-a-flat-library → operator-curatable
+    return "learned", True

--- a/infra/paths.py
+++ b/infra/paths.py
@@ -272,6 +272,20 @@ def instance_root() -> Path:
     return home / _safe_segment(iid) if iid else home
 
 
+def user_skills_dir(*, create: bool = False) -> Path:
+    """Writable root for operator-authored ``SKILL.md`` skills (``instance_root()/skills``).
+
+    Distinct from the bundled ``config/skills`` (git-tracked, shipped examples) and
+    the live ``<config_dir>/skills`` drop-in: this lives under the data home, so
+    UI-managed skills survive a reboot (it's a skill seed root, re-seeded each boot)
+    and stay OUT of the repo working tree. Instance-scoped, same as ``skills.db``.
+    ``create=True`` mkdirs it."""
+    d = instance_root() / "skills"
+    if create:
+        d.mkdir(parents=True, exist_ok=True)
+    return d
+
+
 def _instances_dir() -> Path:
     """`.instances/` under THIS instance's data root (scoped or shared)."""
     return instance_root() / ".instances"

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import re
 
 from fastapi import File, Form, UploadFile
 from fastapi.responses import JSONResponse
@@ -21,6 +22,59 @@ from fastapi.responses import JSONResponse
 from runtime.state import STATE
 
 log = logging.getLogger("protoagent.server")
+
+
+# ── Playbooks (skills) helpers ────────────────────────────────────────────────
+# Operator-authored skills are persisted as real SKILL.md files under the writable
+# user-skills root (so they survive reboots + are exportable); the route layer
+# composes that file layer (graph.skills.authoring) with the live SkillsIndex so a
+# create/edit shows up without a restart.
+
+
+def _user_skills_root():
+    """The writable root for operator-authored ``SKILL.md`` skills. Not created
+    here — only a write (``write_skill``) mkdirs it, so the read/list path is a
+    pure lookup with no filesystem side effects."""
+    from infra.paths import user_skills_dir
+
+    return user_skills_dir()
+
+
+def _as_str_list(value) -> list[str]:
+    """Coerce a tools field (list, or comma/newline string) to a clean string list."""
+    if isinstance(value, (list, tuple)):
+        return [str(v).strip() for v in value if str(v).strip()]
+    if isinstance(value, str):
+        return [t.strip() for t in re.split(r"[,\n]", value) if t.strip()]
+    return []
+
+
+def _find_skill(idx, skill_id: int, *, writable_only: bool = False):
+    """Return the skill dict with rowid *skill_id*, or None. With ``writable_only``
+    skip commons-tier rows — their rowids live in a separate DB and are read-only
+    here, so an id never resolves to a shared skill for a write/delete."""
+    for s in idx.all_skills():
+        if s.get("id") != skill_id:
+            continue
+        if writable_only and s.get("tier") == "commons":
+            continue
+        return s
+    return None
+
+
+def _skill_response(idx, name: str, root):
+    """The metadata row (no prompt_template) for the just-written skill *name*,
+    tagged with origin/editable — the shape the list route returns."""
+    from graph.skills.authoring import classify, slugify
+
+    target = slugify(name)
+    for s in idx.all_skills():
+        if slugify(s.get("name", "")) == target and s.get("tier") != "commons":
+            origin, editable = classify(s, root)
+            row = {k: v for k, v in s.items() if k != "prompt_template"}
+            row["origin"], row["editable"] = origin, editable
+            return row
+    return None
 
 
 def _knowledge_row(d: dict) -> dict:
@@ -60,18 +114,140 @@ def register_knowledge_routes(app) -> None:
         except Exception:  # noqa: BLE001 — never 500 the console
             log.exception("[playbooks] all_skills failed")
             return {"enabled": True, "playbooks": []}
-        # Drop the (potentially large) prompt_template from the list payload;
-        # the table only needs metadata. Sort pinned-first, then by confidence.
-        out = [{k: v for k, v in s.items() if k != "prompt_template"} for s in skills]
+        # Drop the (potentially large) prompt_template from the list payload; the
+        # table only needs metadata. Tag each row with origin/editable so the UI
+        # knows which skills it can edit (user-authored + learned) vs which are
+        # read-only (bundled examples, shared commons). Sort pinned-first, then by
+        # confidence.
+        from graph.skills.authoring import classify
+
+        root = _user_skills_root()
+        out = []
+        for s in skills:
+            origin, editable = classify(s, root)
+            row = {k: v for k, v in s.items() if k != "prompt_template"}
+            row["origin"], row["editable"] = origin, editable
+            out.append(row)
         out.sort(key=lambda s: (s.get("source") != "disk", -(s.get("confidence") or 0)))
         return {"enabled": True, "playbooks": out}
 
+    # Create an operator-authored skill: write a real SKILL.md under the user-skills
+    # root (durable + exportable) and index it live so it works without a restart.
+    @app.post("/api/playbooks")
+    async def _api_playbook_create(body: dict | None = None):
+        idx = STATE.skills_index
+        if idx is None:
+            return {"enabled": False, "id": None}
+        body = body or {}
+        name = str(body.get("name", "")).strip()
+        description = str(body.get("description", "")).strip()
+        prompt = str(body.get("prompt_template", body.get("body", ""))).strip()
+        if not name or not description or not prompt:
+            return JSONResponse({"detail": "name, description, and body are required"}, status_code=400)
+        from graph.skills.authoring import slugify, write_skill
+
+        slug = slugify(name)
+        if not slug:
+            return JSONResponse({"detail": "name must contain letters or digits"}, status_code=400)
+        if any(slugify(s.get("name", "")) == slug for s in idx.all_skills()):
+            return JSONResponse({"detail": f"a skill named “{name}” already exists"}, status_code=409)
+        root = _user_skills_root()
+        try:
+            artifact = write_skill(
+                root, name, description, prompt,
+                tools=_as_str_list(body.get("tools") or body.get("tools_used")),
+                user_facing=bool(body.get("user_facing", False)),
+                slash=str(body.get("slash", "")).strip(),
+            )
+            idx.add_skill(artifact, source="disk")
+        except Exception as exc:  # noqa: BLE001
+            log.exception("[playbooks] create failed")
+            return JSONResponse({"detail": f"create failed: {exc}"}, status_code=400)
+        created = _skill_response(idx, name, root)
+        return {"enabled": True, "id": (created or {}).get("id"), "skill": created}
+
+    # Fetch one skill WITH its full prompt_template (the list omits it) so the editor
+    # can pre-fill. Read-only — returns commons/bundled skills too (for viewing).
+    @app.get("/api/playbooks/{skill_id}")
+    async def _api_playbook_get(skill_id: int):
+        idx = STATE.skills_index
+        if idx is None:
+            return JSONResponse({"detail": "skills index disabled"}, status_code=404)
+        s = _find_skill(idx, skill_id)
+        if s is None:
+            return JSONResponse({"detail": "no skill with that id"}, status_code=404)
+        from graph.skills.authoring import classify
+
+        origin, editable = classify(s, _user_skills_root())
+        return {"enabled": True, "skill": {**s, "origin": origin, "editable": editable}}
+
+    # Edit a skill: rewrite its SKILL.md and re-index. Editing a learned (DB-only)
+    # skill MATERIALIZES it as a durable user SKILL.md (curation = persistence).
+    # Bundled examples + shared commons skills are read-only.
+    @app.put("/api/playbooks/{skill_id}")
+    async def _api_playbook_update(skill_id: int, body: dict | None = None):
+        idx = STATE.skills_index
+        if idx is None:
+            return {"enabled": False, "id": None}
+        root = _user_skills_root()
+        from graph.skills.authoring import classify, remove_skill, slugify, write_skill
+
+        cur = _find_skill(idx, skill_id, writable_only=True)
+        if cur is None:
+            return JSONResponse({"detail": "no editable skill with that id"}, status_code=404)
+        origin, editable = classify(cur, root)
+        if not editable:
+            return JSONResponse({"detail": f"{origin} skills are read-only"}, status_code=403)
+        body = body or {}
+        name = str(body.get("name", cur.get("name", ""))).strip()
+        description = str(body.get("description", "")).strip()
+        prompt = str(body.get("prompt_template", body.get("body", ""))).strip()
+        if not name or not description or not prompt:
+            return JSONResponse({"detail": "name, description, and body are required"}, status_code=400)
+        new_slug, old_slug = slugify(name), slugify(cur.get("name", ""))
+        if new_slug != old_slug and any(
+            slugify(s.get("name", "")) == new_slug and s.get("id") != skill_id for s in idx.all_skills()
+        ):
+            return JSONResponse({"detail": f"a skill named “{name}” already exists"}, status_code=409)
+        try:
+            artifact = write_skill(
+                root, name, description, prompt,
+                tools=_as_str_list(body.get("tools") or body.get("tools_used")),
+                user_facing=bool(body.get("user_facing", cur.get("user_facing", False))),
+                slash=str(body.get("slash", cur.get("slash", "") or "")).strip(),
+            )
+            idx.delete_skill(skill_id)
+            if new_slug != old_slug:
+                remove_skill(root, cur.get("name", ""))  # renamed → drop the old folder
+            idx.add_skill(artifact, source="disk")
+        except Exception as exc:  # noqa: BLE001
+            log.exception("[playbooks] update failed")
+            return JSONResponse({"detail": f"update failed: {exc}"}, status_code=400)
+        updated = _skill_response(idx, name, root)
+        return {"enabled": True, "id": (updated or {}).get("id"), "skill": updated}
+
     @app.delete("/api/playbooks/{skill_id}")
     async def _api_playbook_delete(skill_id: int):
-        if STATE.skills_index is None:
+        idx = STATE.skills_index
+        if idx is None:
             return {"enabled": False, "deleted": False}
+        root = _user_skills_root()
+        from graph.skills.authoring import classify, remove_skill
+
+        cur = _find_skill(idx, skill_id, writable_only=True)
+        if cur is None:
+            return {"enabled": True, "deleted": False, "error": "no deletable skill with that id"}
+        origin, _editable = classify(cur, root)
+        if origin == "bundled":
+            return {
+                "enabled": True,
+                "deleted": False,
+                "error": "bundled example skills are read-only (edit their SKILL.md in config/skills)",
+            }
         try:
-            STATE.skills_index.delete_skill(skill_id)
+            if origin == "user":
+                remove_skill(root, cur.get("name", ""))  # drop the file too, not just the row
+            idx.delete_skill(skill_id)
             return {"enabled": True, "deleted": True}
         except Exception as exc:  # noqa: BLE001
             log.exception("[playbooks] delete failed")

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -455,6 +455,11 @@ def _build_skills_index(config, extra_skill_dirs=None):
         live_root = Path(config.skills_dir).expanduser() if config.skills_dir else (_live_config_dir() / "skills")
         roots = [_BUNDLE_CONFIG_DIR / "skills", live_root]  # bundle first, live overrides
         roots.extend(Path(d) for d in (extra_skill_dirs or []))  # plugin-bundled skills
+        # Operator-authored skills (UI/console CRUD) live under the data home and
+        # win last — an explicit edit always overrides a bundled/plugin example.
+        from infra.paths import user_skills_dir
+
+        roots.append(user_skills_dir())
         count = seed_skills_index(index, roots)
         log.info("[skills] indexed %d SKILL.md skill(s) into %s", count, db_path)
         return index

--- a/tests/test_skills_crud_routes.py
+++ b/tests/test_skills_crud_routes.py
@@ -1,0 +1,137 @@
+"""Skills CRUD routes (``/api/playbooks`` POST/GET-one/PUT, file-aware DELETE).
+
+Operator-authored skills are persisted as real ``SKILL.md`` files under the
+user-skills root and indexed live, so these run end-to-end against a real
+``SkillsIndex`` on a tmp DB with the user root redirected into ``tmp_path`` — the
+write path (file + index) and the editable/read-only classification are what we
+care about, and a real index is cheaper than faking both halves.
+"""
+
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+import operator_api.knowledge_routes as kr
+from graph.skills.index import SkillsIndex
+from operator_api.knowledge_routes import register_knowledge_routes
+
+
+def _client(monkeypatch, tmp_path):
+    idx = SkillsIndex(db_path=str(tmp_path / "skills.db"))
+    root = tmp_path / "userskills"
+    monkeypatch.setattr(kr, "_user_skills_root", lambda: root)
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "skills_index", idx, raising=False)
+    monkeypatch.setattr(rs.STATE, "knowledge_store", None, raising=False)
+    app = FastAPI()
+    register_knowledge_routes(app)
+    return TestClient(app), idx, root
+
+
+def _seed_emitted(idx, name="Learned thing", desc="learned desc", body="learned body"):
+    idx.add_skill(
+        SimpleNamespace(name=name, description=desc, prompt_template=body, tools_used=[], source_session_id=""),
+        source="emitted",
+    )
+
+
+def test_create_writes_skill_md_and_indexes(monkeypatch, tmp_path):
+    c, idx, root = _client(monkeypatch, tmp_path)
+    r = c.post(
+        "/api/playbooks",
+        json={
+            "name": "Release Notes",
+            "description": "Draft release notes from merged PRs",
+            "prompt_template": "1. gather PRs\n2. group by area",
+            "tools_used": ["github", "git"],
+            "user_facing": True,
+            "slash": "relnotes",
+        },
+    )
+    assert r.status_code == 200
+    skill = r.json()["skill"]
+    assert skill["origin"] == "user" and skill["editable"] is True
+    # The file landed under the user root in the portable SKILL.md format.
+    md = (root / "release-notes" / "SKILL.md").read_text()
+    assert "name: Release Notes" in md and "1. gather PRs" in md
+    # …and it's live in the index (source=disk, no restart needed).
+    rows = idx.all_skills()
+    assert [s["name"] for s in rows] == ["Release Notes"] and rows[0]["source"] == "disk"
+    # GET one carries the full body the list omits.
+    detail = c.get(f"/api/playbooks/{skill['id']}").json()["skill"]
+    assert detail["prompt_template"].startswith("1. gather PRs")
+
+
+def test_create_requires_fields(monkeypatch, tmp_path):
+    c, _idx, _root = _client(monkeypatch, tmp_path)
+    assert c.post("/api/playbooks", json={"name": "x", "description": "y"}).status_code == 400
+
+
+def test_create_rejects_duplicate_name(monkeypatch, tmp_path):
+    c, _idx, _root = _client(monkeypatch, tmp_path)
+    base = {"name": "Dupe", "description": "d", "prompt_template": "b"}
+    assert c.post("/api/playbooks", json=base).status_code == 200
+    assert c.post("/api/playbooks", json={**base, "description": "d2"}).status_code == 409
+
+
+def test_edit_rewrites_file_and_reindexes(monkeypatch, tmp_path):
+    c, idx, root = _client(monkeypatch, tmp_path)
+    created = c.post("/api/playbooks", json={"name": "Edit Me", "description": "old", "prompt_template": "old body"}).json()
+    sid = created["id"]
+    r = c.put(f"/api/playbooks/{sid}", json={"name": "Edit Me", "description": "new desc", "prompt_template": "new body"})
+    assert r.status_code == 200
+    md = (root / "edit-me" / "SKILL.md").read_text()
+    assert "new desc" in md and "new body" in md and "old body" not in md
+    names = [s["name"] for s in idx.all_skills()]
+    assert names == ["Edit Me"]  # no duplicate row left behind
+
+
+def test_edit_learned_materializes_durable_file(monkeypatch, tmp_path):
+    c, idx, root = _client(monkeypatch, tmp_path)
+    _seed_emitted(idx)
+    sid = idx.all_skills()[0]["id"]
+    # Before edit: a learned (DB-only) skill, no file.
+    assert not (root / "learned-thing").exists()
+    r = c.put(
+        f"/api/playbooks/{sid}",
+        json={"name": "Learned thing", "description": "curated", "prompt_template": "curated body"},
+    )
+    assert r.status_code == 200 and r.json()["skill"]["origin"] == "user"
+    assert (root / "learned-thing" / "SKILL.md").is_file()  # now durable
+
+
+def test_delete_user_skill_removes_file(monkeypatch, tmp_path):
+    c, idx, root = _client(monkeypatch, tmp_path)
+    sid = c.post("/api/playbooks", json={"name": "Trash Me", "description": "d", "prompt_template": "b"}).json()["id"]
+    assert (root / "trash-me" / "SKILL.md").is_file()
+    assert c.delete(f"/api/playbooks/{sid}").json() == {"enabled": True, "deleted": True}
+    assert not (root / "trash-me").exists() and idx.all_skills() == []
+
+
+def test_delete_bundled_is_blocked(monkeypatch, tmp_path):
+    c, idx, root = _client(monkeypatch, tmp_path)
+    # A disk skill with NO file under the user root == a bundled/plugin example.
+    idx.add_skill(
+        SimpleNamespace(name="Bundled", description="d", prompt_template="b", tools_used=[], source_session_id=""),
+        source="disk",
+    )
+    sid = idx.all_skills()[0]["id"]
+    body = c.delete(f"/api/playbooks/{sid}").json()
+    assert body["deleted"] is False and "read-only" in body["error"]
+    assert idx.all_skills()  # row survived
+
+
+def test_list_tags_origin_and_editable(monkeypatch, tmp_path):
+    c, idx, _root = _client(monkeypatch, tmp_path)
+    c.post("/api/playbooks", json={"name": "Mine", "description": "d", "prompt_template": "b"})
+    _seed_emitted(idx, name="Emitted one")
+    idx.add_skill(
+        SimpleNamespace(name="Shipped", description="d", prompt_template="b", tools_used=[], source_session_id=""),
+        source="disk",
+    )
+    by_name = {p["name"]: p for p in c.get("/api/playbooks").json()["playbooks"]}
+    assert by_name["Mine"]["origin"] == "user" and by_name["Mine"]["editable"] is True
+    assert by_name["Emitted one"]["origin"] == "learned" and by_name["Emitted one"]["editable"] is True
+    assert by_name["Shipped"]["origin"] == "bundled" and by_name["Shipped"]["editable"] is False


### PR DESCRIPTION
## What

Full CRUD for skills in the console — **Settings ▸ Workspace ▸ Skills** previously only let you browse, delete, and promote. Now you can **author a new skill, edit one, and delete it** end to end.

## Design

Operator-authored skills are persisted as portable **`SKILL.md` files** under a writable data-home root — `infra.paths.user_skills_dir()` → `~/.protoagent/skills` (instance-scoped) — seeded into the skill index as a **4th seed root** so they:
- survive restarts (re-seeded each boot like any skill root),
- stay **out of the git working tree** (unlike the bundled `config/skills` examples),
- are exportable / round-trip through the same loader the agent already uses.

Editing an agent-**learned** (DB-only) skill **materializes it as a durable `SKILL.md`** (curation = persistence). **Bundled** examples and shared **commons** skills are **read-only** (edit-scope = user-created + learned).

## Changes

| Layer | File | Change |
|---|---|---|
| Paths | `infra/paths.py` | `user_skills_dir()` helper (instance-scoped) |
| Index seed | `server/agent_init.py` | append the user root to the skill seed roots (user wins on name collision) |
| File layer | `graph/skills/authoring.py` *(new)* | slug, `SKILL.md` write/remove, `classify()` → user/learned/bundled/commons |
| API | `operator_api/knowledge_routes.py` | `POST /api/playbooks`, `GET /api/playbooks/{id}` (full body), `PUT /api/playbooks/{id}`, file-aware `DELETE`; list tags each skill `origin`/`editable` |
| UI | `apps/web` | author/edit form, inline edit, edit/delete gated on editability (`PlaybooksSurface.tsx`, `api.ts`, `types.ts`) |
| Tests | `tests/test_skills_crud_routes.py` *(new)* | 8 end-to-end CRUD tests (real `SkillsIndex` + tmp skills root) |

## Verification (all local gates green)

- `ruff check` ✓ · `lint-imports` (3 kept, 0 broken) ✓
- `pytest tests/ -q` → **2254 passed** ✓ · `scripts/live_smoke.py` ✓
- web typecheck ✓ · web unit **94 passed** ✓ · **playbooks e2e 3/3** ✓ · production build ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)