### PR TITLE
feat(web): separate Global vs Workspace settings — header drawer + Global overlay

### DIFF
--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -6,8 +6,7 @@ import { expect, test } from "@playwright/test";
 
 async function openIntegrations(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Plugins", exact: true }).click();
 }
 

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -19,15 +19,23 @@ test.beforeEach(async ({ page }, testInfo) => {
 });
 
 async function openFleet(page) {
-  // Fleet lives under Settings ▸ Global now (folded in from the old Box rail surface).
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Global", exact: true }).click();
-  await page.locator(".pl-sidenav").getByRole("tab", { name: "Fleet", exact: true }).click();
+  // Fleet lives under the Global settings overlay now, opened from the header
+  // hamburger → app drawer → Global settings (folded in from the old Box rail surface).
+  await page.getByTestId("header-menu").click();
+  await page.getByTestId("app-drawer").getByRole("button", { name: "Global settings", exact: true }).click();
+  await page.locator(".settings-overlay .pl-sidenav").getByRole("tab", { name: "Fleet", exact: true }).click();
 }
 
 async function openAgents(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await openFleet(page);
+}
+
+// Fleet lives in the Global settings overlay (a modal) now, so its backdrop intercepts
+// the topbar switcher — close it before interacting with the top bar.
+async function closeOverlay(page) {
+  await page.locator(".settings-overlay .pl-dialog__close").click();
+  await expect(page.locator(".settings-overlay")).toHaveCount(0);
 }
 
 test("Agents tab lists the host (this instance) + peers, host active by default", async ({ page }) => {
@@ -132,6 +140,7 @@ test("rename edits the display name; the id/slug stays", async ({ page }) => {
   await expect(renamed).toBeVisible();
   // The slug (stable id) is untouched: switching to the renamed agent still
   // navigates to its original id URL.
+  await closeOverlay(page);
   await page.getByTestId("fleet-switcher").click();
   await page.getByRole("menuitem", { name: /nova/ }).click();
   await expect(page).toHaveURL(/\/app\/agent\/ava\//);
@@ -153,6 +162,7 @@ test("discover → add to fleet → switch into the remote member (ADR 0042 §I)
 
   // And switchable: the topbar switcher navigates to its slug window, where the hub
   // proxies the console (the mock strips /agents/<slug>/ — the app boots normally).
+  await closeOverlay(page);
   await page.getByTestId("fleet-switcher").click();
   await page.getByRole("menuitem", { name: /remy/ }).click();
   await expect(page).toHaveURL(/\/app\/agent\/remy-re01\//);

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -6,7 +6,6 @@ import { expect, test } from "@playwright/test";
 test("MCP tab lists servers and adds one inline", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "MCP", exact: true }).click();
 
   await expect(page.getByRole("heading", { name: "MCP servers" })).toBeVisible();
@@ -23,7 +22,6 @@ test("MCP tab lists servers and adds one inline", async ({ page }) => {
 test("MCP tab imports servers from pasted JSON", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "MCP", exact: true }).click();
 
   await page.getByRole("button", { name: /Add server/ }).click();

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -47,9 +47,9 @@ test("beads tab in the right sidebar lists issues (query-backed)", async ({ page
 });
 
 test("workspace settings: identity lands, then tools and MCP sections", async ({ page }) => {
-  // The agent makeup folded into Settings ▸ Workspace (ADR 0048 S-C).
+  // The agent makeup folded into Settings ▸ Workspace (ADR 0048 S-C); the rail
+  // Settings surface is Workspace-direct now (Global moved to the header drawer).
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible(); // landing section
   await expect(page.getByTestId("identity-name")).toBeVisible();
 
@@ -155,7 +155,7 @@ test("right-click → Move to bottom dock docks the surface at the bottom", asyn
   await expect(page.locator(".pl-appshell__bottom").getByRole("heading", { name: "Beads" })).toBeVisible();
 });
 
-test("mobile shell: bottom quick-bar + hamburger drawer (ADR 0035 S4)", async ({ page }) => {
+test("mobile shell: bottom quick-bar + unified header drawer (ADR 0035 S4)", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 800 });
   await page.goto("/app/", { waitUntil: "load" });
 
@@ -167,10 +167,12 @@ test("mobile shell: bottom quick-bar + hamburger drawer (ADR 0035 S4)", async ({
   // A default quick-bar surface switches the single active surface.
   await bar.getByRole("button", { name: "Knowledge", exact: true }).click();
 
-  // The hamburger opens a drawer with the full surface list.
-  await bar.getByRole("button", { name: "All surfaces" }).click();
-  const drawer = page.getByRole("dialog", { name: "Surfaces" });
+  // The DS bottom-bar "More" is hidden (2026-06-18 IA pass) — the unified mobile
+  // "more" is the header hamburger's app drawer, which on mobile also lists surfaces.
+  await expect(bar.getByRole("button", { name: "All surfaces" })).toBeHidden();
+  await page.getByTestId("header-menu").click();
+  const drawer = page.getByTestId("app-drawer");
   await expect(drawer).toBeVisible();
   await drawer.getByRole("button", { name: "Beads", exact: true }).click();
-  await expect(drawer).toHaveCount(0); // picking closes it
+  await expect(drawer).toHaveCount(0); // picking a surface closes the drawer
 });

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -6,7 +6,6 @@ import { expect, test } from "@playwright/test";
 test("Agent → Skills lists pinned + learned skills and supports search", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Skills", exact: true }).click();
 
   const surface = page.getByTestId("playbooks-surface");
@@ -27,7 +26,6 @@ test("Agent → Skills lists pinned + learned skills and supports search", async
 test("layered skills show tier badges and promote a private skill to the commons", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
@@ -48,7 +46,6 @@ test("layered skills show tier badges and promote a private skill to the commons
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -4,17 +4,24 @@ import { expect, test } from "@playwright/test";
 // opens a dialog editing fields via the same /api/settings path, and the central
 // two-home one-stop-shop is also openable as an overlay from the topbar.
 
-// The header hamburger was removed (to be re-homed later); the Settings overlay it
-// opened has no trigger for now. Skipped until the global-actions entry point lands.
-test.skip("the header menu opens the Settings overlay (the two-home one-stop-shop)", async ({ page }) => {
+// The header hamburger opens the app drawer (2026-06-18 IA pass): global actions
+// (Global settings, Telemetry) + the Docs/GitHub links. "Global settings" opens the
+// Global-only overlay — Workspace settings live in the rail surface, not here.
+test("the header hamburger opens the app drawer → Global settings overlay", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByTestId("header-menu").click();
-  await page.getByRole("menuitem", { name: "Settings" }).click();
-  const dialog = page.getByRole("dialog", { name: "Settings" });
+  const drawer = page.getByTestId("app-drawer");
+  await expect(drawer).toBeVisible();
+  await expect(drawer.getByRole("button", { name: "Global settings", exact: true })).toBeVisible();
+  await expect(drawer.getByRole("button", { name: "Telemetry", exact: true })).toBeVisible();
+  await expect(drawer.getByRole("link", { name: "Docs" })).toBeVisible();
+  await expect(drawer.getByRole("link", { name: "GitHub" })).toBeVisible();
+
+  await drawer.getByRole("button", { name: "Global settings", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "Global settings" });
   await expect(dialog).toBeVisible();
-  // The same two scope homes render inside the overlay (the segmented toggle).
-  await expect(dialog.getByRole("button", { name: "Global", exact: true })).toBeVisible();
-  await expect(dialog.getByRole("button", { name: "Workspace", exact: true })).toBeVisible();
+  // Global-only — no scope toggle inside (the two-home toggle is gone).
+  await expect(dialog.locator(".pl-tabs--segmented")).toHaveCount(0);
 });
 
 test("the chat composer model picker overrides the model per-tab (no global save)", async ({ page }) => {

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,30 +1,33 @@
 import { expect, test } from "@playwright/test";
 
-// Settings IA (ADR 0048): scope is the primary axis — TWO homes, each with its own
-// section sub-nav. 🖥 Global (box-shared) and 🧩 Workspace (the focused agent).
-// Each section renders GET /api/settings/schema groups for its category and saves via
-// POST /api/settings (auto-reload). The Agent rail surface still hosts the agent
-// makeup until the S-C collapse.
+// Settings IA (2026-06-18 pass): WORKSPACE settings live in the rail "Settings"
+// surface (no scope toggle); GLOBAL settings open from the header hamburger → app
+// drawer → an overlay dialog. Each section renders GET /api/settings/schema groups
+// and saves via POST /api/settings (auto-reload).
 
+// The rail Settings surface — Workspace-only now.
 async function openSettings(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
 }
 
-// Click a home (the segmented scope toggle in the SideNav header, role=button) or a
-// section (the DS SideNav rail, role=tab). Names are unique across both.
-async function tab(page, name) {
-  const home = page.locator(".pl-tabs--segmented").getByRole("button", { name, exact: true });
-  if (await home.count()) {
-    await home.click();
-    return;
-  }
-  await page.locator(".pl-sidenav").getByRole("tab", { name, exact: true }).click();
+// Global settings open from the header drawer; `item` picks the drawer entry
+// ("Global settings" lands on Overview, "Telemetry" deep-links that section).
+async function openGlobal(page, item = "Global settings") {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("header-menu").click();
+  const drawer = page.getByTestId("app-drawer");
+  await expect(drawer).toBeVisible();
+  await drawer.getByRole("button", { name: item, exact: true }).click();
+  await expect(page.locator(".settings-overlay")).toBeVisible();
 }
 
-// Field groups are collapsed by default (the operator expands as needed) — open
-// every group so the fields under them are visible/interactable in a test. Waits
-// for the suspense load, then toggles only the still-collapsed triggers.
+// Click a section in a sidenav (the rail's, or — scoped — the overlay's).
+async function section(page, name, scope = ".pl-sidenav") {
+  await page.locator(scope).getByRole("tab", { name, exact: true }).click();
+}
+
+// Field groups are collapsed by default — open every group so the fields are visible.
 async function expandAllGroups(page) {
   await expect(page.locator(".pl-accordion__trigger").first()).toBeVisible();
   const triggers = page.locator(".pl-accordion__trigger");
@@ -34,25 +37,10 @@ async function expandAllGroups(page) {
   }
 }
 
-test("Settings is a two-home shell (Global · Workspace)", async ({ page }) => {
+test("Workspace settings live in the rail (no scope toggle)", async ({ page }) => {
   await openSettings(page);
-  // The two scope homes (ADR 0048) — the segmented toggle pinned atop the SideNav.
-  expect(await page.locator(".pl-tabs--segmented").locator("button").allTextContents()).toEqual([
-    "Global",
-    "Workspace",
-  ]);
-  // The Global home = the box-shared cascade + the box-level ops (Fleet/Telemetry/
-  // Commons folded back in from the old Box rail surface).
-  expect(await page.locator(".pl-sidenav").locator("button").allTextContents()).toEqual([
-    "Overview",
-    "Configuration",
-    "Fleet",
-    "Telemetry",
-    "Commons",
-  ]);
-  await expect(page.getByRole("heading", { name: "Overview" })).toBeVisible(); // default section
-  // The Workspace home → the focused agent's makeup + settings (ADR 0048 fold).
-  await tab(page, "Workspace");
+  // No Global/Workspace segmented toggle anymore — the rail is Workspace directly.
+  await expect(page.locator(".pl-tabs--segmented")).toHaveCount(0);
   expect(await page.locator(".pl-sidenav").locator("button").allTextContents()).toEqual([
     "Identity",
     "Model & Routing",
@@ -66,49 +54,47 @@ test("Settings is a two-home shell (Global · Workspace)", async ({ page }) => {
     "Theme",
     "Plugins",
   ]);
-  await tab(page, "System");
-  // Field groups are collapsible accordions (DS 0.29); titles render in the trigger.
-  await expect(page.locator(".pl-accordion__title").first()).toBeVisible(); // wait for the suspense load
+  await section(page, "System");
+  await expect(page.locator(".pl-accordion__title").first()).toBeVisible();
   expect(await page.locator(".pl-accordion__title").allTextContents()).toEqual(["Compaction", "Runtime"]);
 });
 
-test("Global home hosts Fleet · Telemetry · Commons (folded in from the Box surface)", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Global", exact: true }).click();
-  const sidenav = page.locator(".pl-sidenav");
-  for (const s of ["Overview", "Configuration", "Fleet", "Telemetry", "Commons"]) {
-    await expect(sidenav.getByRole("tab", { name: s, exact: true })).toBeVisible();
-  }
-  // Fleet section shows the agents panel.
+test("Global settings open from the header drawer → overlay (Overview · Configuration · Fleet · Telemetry · Commons)", async ({ page }) => {
+  await openGlobal(page);
+  const sidenav = page.locator(".settings-overlay .pl-sidenav");
+  expect(await sidenav.locator("button").allTextContents()).toEqual([
+    "Overview",
+    "Configuration",
+    "Fleet",
+    "Telemetry",
+    "Commons",
+  ]);
+  // Fleet section shows the agents panel; Telemetry renders the dashboard.
   await sidenav.getByRole("tab", { name: "Fleet", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible();
-  // …and Telemetry renders the dashboard.
   await sidenav.getByRole("tab", { name: "Telemetry", exact: true }).click();
   await expect(page.getByTestId("telemetry-surface")).toBeVisible();
 });
 
+test("the drawer's Telemetry item deep-links the Global Telemetry section", async ({ page }) => {
+  await openGlobal(page, "Telemetry");
+  await expect(page.getByTestId("telemetry-surface")).toBeVisible();
+});
+
 test("Workspace ▸ Model & Routing shows the agent's Model + Routing fields", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
-  await page.locator(".pl-sidenav").getByRole("tab", { name: "Model & Routing", exact: true }).click();
-  // Model + Routing render here (the agent makeup folded into Workspace, ADR 0048).
-  await expect(page.locator(".pl-accordion__title").first()).toBeVisible(); // wait for the suspense load
+  await openSettings(page);
+  await section(page, "Model & Routing");
+  await expect(page.locator(".pl-accordion__title").first()).toBeVisible();
   expect(await page.locator(".pl-accordion__title").allTextContents()).toEqual(["Model", "Routing"]);
-  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
-  const aux = page.locator('.setting-row[data-key="routing.aux_model"] input');
-  await expect(aux).toHaveValue("protolabs/fast");
-  const key = page.locator('.setting-row[data-key="model.api_key"] input');
-  await expect(key).toHaveAttribute("placeholder", /set/);
+  await expandAllGroups(page);
+  await expect(page.locator('.setting-row[data-key="routing.aux_model"] input')).toHaveValue("protolabs/fast");
+  await expect(page.locator('.setting-row[data-key="model.api_key"] input')).toHaveAttribute("placeholder", /set/);
 });
 
 test("editing an Agent setting enables save and round-trips", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
-  await page.locator(".pl-sidenav").getByRole("tab", { name: "Model & Routing", exact: true }).click();
-  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
+  await openSettings(page);
+  await section(page, "Model & Routing");
+  await expandAllGroups(page);
   const save = page.getByRole("button", { name: /Save & apply/ });
   await expect(save).toBeDisabled();
   await page.locator('.setting-row[data-key="routing.aux_model"] input').fill("protolabs/turbo");
@@ -119,54 +105,40 @@ test("editing an Agent setting enables save and round-trips", async ({ page }) =
 
 test("a restart-flagged System field shows the restart banner", async ({ page }) => {
   await openSettings(page);
-  await tab(page, "Workspace");
-  await tab(page, "System");
+  await section(page, "System");
   await expect(page.locator(".settings-banner")).toHaveCount(0);
-  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
-  // The bool setting renders as a DS Switch (its native checkbox is 0×0/opacity:0,
-  // so click the switch label to toggle it on rather than .check() the input).
+  await expandAllGroups(page);
   await page.locator('.setting-row[data-key="runtime.autostart_on_boot"] .pl-switch').click();
   await expect(page.locator(".settings-banner")).toContainText("restart");
 });
 
-// ADR 0047 hybrid layered settings — per-agent Settings shows every field with an
+// ADR 0047 hybrid layered settings — per-agent settings show every field with an
 // inheritance badge; an overridden host-scoped field offers reset-to-inherited.
 test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Workspace", exact: true }).click();
-  await page.locator(".pl-sidenav").getByRole("tab", { name: "Model & Routing", exact: true }).click();
-  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
-  // model.name inherits from the host layer.
-  await expect(
-    page.locator('.setting-row[data-key="model.name"] .setting-inheritance'),
-  ).toContainText("inherited from Global");
-  // routing.aux_model inherits the App default.
-  await expect(
-    page.locator('.setting-row[data-key="routing.aux_model"] .setting-inheritance'),
-  ).toContainText("inherited from default");
-  // model.temperature is host-scoped but overridden here → reset affordance.
+  await openSettings(page);
+  await section(page, "Model & Routing");
+  await expandAllGroups(page);
+  await expect(page.locator('.setting-row[data-key="model.name"] .setting-inheritance')).toContainText(
+    "inherited from Global",
+  );
+  await expect(page.locator('.setting-row[data-key="routing.aux_model"] .setting-inheritance')).toContainText(
+    "inherited from default",
+  );
   const temp = page.locator('.setting-row[data-key="model.temperature"]');
   await expect(temp.locator(".setting-inheritance")).toContainText("overridden here");
   await temp.getByRole("button", { name: /Reset to inherited/ }).click();
   await expect(page.locator(".settings-status")).toContainText("inherited");
-  // routing.fallback_models is a plain agent setting — no badge.
-  await expect(
-    page.locator('.setting-row[data-key="routing.fallback_models"] .setting-inheritance'),
-  ).toHaveCount(0);
+  await expect(page.locator('.setting-row[data-key="routing.fallback_models"] .setting-inheritance')).toHaveCount(0);
 });
 
-test("Configuration edits the host-scoped subset and saves to the host layer", async ({ page }) => {
-  await openSettings(page);
-  await tab(page, "Configuration"); // Global is the default home; host console → editable
+test("Configuration (Global) edits the host-scoped subset and saves to the host layer", async ({ page }) => {
+  await openGlobal(page);
+  await section(page, "Configuration", ".settings-overlay .pl-sidenav");
   await expect(page.locator(".settings-banner").first()).toContainText("box-shared");
-  await expandAllGroups(page); // groups are collapsed by default — open to reach the fields
-  // Only host-scoped fields appear — model.name (host) is here; the agent-scoped
-  // model.api_key + routing.fallback_models are NOT.
+  await expandAllGroups(page);
   await expect(page.locator('.setting-row[data-key="model.name"]')).toBeVisible();
   await expect(page.locator('.setting-row[data-key="model.api_key"]')).toHaveCount(0);
   await expect(page.locator('.setting-row[data-key="routing.fallback_models"]')).toHaveCount(0);
-  // A save writes to the host layer (the mock echoes the layer).
   await page.locator('.setting-row[data-key="routing.aux_model"] input').fill("protolabs/host-fast");
   const save = page.getByRole("button", { name: /Save & apply/ }).first();
   await save.click();

--- a/apps/web/e2e/telemetry.spec.ts
+++ b/apps/web/e2e/telemetry.spec.ts
@@ -1,15 +1,15 @@
 import { expect, test } from "@playwright/test";
 
-// The Box ▸ Telemetry tab renders the per-turn rollups from
+// The Telemetry section renders the per-turn rollups from
 // /api/telemetry/* (ADR 0006 Slice 3): summary cards + a recent-turns table.
 
-test("Settings ▸ Global ▸ Telemetry shows the summary cards and recent turns", async ({ page }) => {
+test("Global ▸ Telemetry shows the summary cards and recent turns", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Telemetry lives under Settings ▸ Global now (folded in from the old Box rail).
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-tabs--segmented").getByRole("button", { name: "Global", exact: true }).click();
-  await page.locator(".pl-sidenav").getByRole("tab", { name: "Telemetry", exact: true }).click();
+  // Telemetry lives under the Global settings overlay now, deep-linked from the
+  // header hamburger → app drawer → Telemetry (folded in from the old Box rail).
+  await page.getByTestId("header-menu").click();
+  await page.getByTestId("app-drawer").getByRole("button", { name: "Telemetry", exact: true }).click();
 
   const surface = page.getByTestId("telemetry-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -9,7 +9,6 @@ import {
   CircleAlert,
   FileText,
   Gauge,
-  Github,
   Inbox,
   LayoutDashboard,
   Loader2,
@@ -81,6 +80,8 @@ import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { SettingsSurface } from "../settings/SettingsSurface";
 import { SettingsOverlay } from "../settings/SettingsOverlay";
+import { AppDrawer } from "./AppDrawer";
+import { HamburgerMenu } from "./HamburgerMenu";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
@@ -230,8 +231,6 @@ export function App() {
   const chatStreaming = useAnyChatStreaming();
   const pluginsTab = useUI((s) => s.pluginsTab);
   const setPluginsTab = useUI((s) => s.setPluginsTab);
-  const setSettingsScope = useUI((s) => s.setSettingsScope);
-  const setSettingsSection = useUI((s) => s.setSettingsSection);
   const setFleetStartNew = useUI((s) => s.setFleetStartNew);
   const activityTab = useUI((s) => s.activityTab);
   const setActivityTab = useUI((s) => s.setActivityTab);
@@ -264,8 +263,14 @@ export function App() {
   >(null);
   const [activityUnread, setActivityUnread] = useState(0);
   const [inboxUnread, setInboxUnread] = useState(0);
-  // The one-stop-shop Settings overlay (ADR 0048) — opened by the topbar gear.
-  const [settingsOverlayOpen, setSettingsOverlayOpen] = useState(false);
+  // Global settings overlay (the Global home) — store-driven so BOTH the header drawer
+  // and command-palette deep-links (Fleet/Telemetry/Commons) can open it. The header
+  // hamburger's app drawer itself is local (only App triggers it).
+  const globalSettingsOpen = useUI((s) => s.globalSettingsOpen);
+  const globalSettingsSection = useUI((s) => s.globalSettingsSection);
+  const openGlobalSettings = useUI((s) => s.openGlobalSettings);
+  const closeGlobalSettings = useUI((s) => s.closeGlobalSettings);
+  const [drawerOpen, setDrawerOpen] = useState(false);
   const [projectPath, setProjectPath] = useLocalStorageState("protoagent.projectPath", "");
   // Shell-level runtime read (ADR 0013): non-suspense useQuery so the topbar
   // always renders; the retry doubles as the desktop sidecar boot-probe. The
@@ -605,9 +610,9 @@ export function App() {
       case "knowledge":
         return <KnowledgeStore onError={setError} />;
       case "settings":
-        // SettingsSurface owns its own two-level nav (home + section, ADR 0048).
-        // Box (Fleet/Telemetry/Commons) is folded into its Global home now.
-        return <SettingsSurface />;
+        // The rail Settings surface is Workspace-only now (2026-06-18 IA pass) — no
+        // scope toggle. Global settings live in the header drawer's overlay instead.
+        return <SettingsSurface only="workspace" />;
       // Notes is now the first-party `notes` plugin (ADR 0034 S4) — rendered via the default
       // plugin-view case below, not a native surface.
       case "beads":
@@ -790,17 +795,19 @@ export function App() {
           <FleetSwitcher
             fallbackName={brandName(runtime?.identity?.name)}
             onNewAgent={() => {
-              // Fleet lives under Settings ▸ Global ▸ Fleet now; open it + ask the
-              // panel to pop the new-agent picker on mount.
-              setSurface("settings");
-              setSettingsScope("host");
-              setSettingsSection("fleet");
+              // Fleet lives in the Global settings overlay now (header drawer). Open it on
+              // the Fleet section + ask the panel to pop the new-agent picker on mount.
               setFleetStartNew(true);
+              openGlobalSettings("fleet");
             }}
           />
         }
         org={runtime?.identity?.org || "protoLabs.studio"}
       />
+      {/* Top-right hamburger → the app drawer (Global settings, Telemetry, links; mobile nav). */}
+      <div className="app-topbar-menu">
+        <HamburgerMenu onOpen={() => setDrawerOpen(true)} />
+      </div>
       </div>
 
       {/* Operational warnings from the runtime status (#706 co-located instances etc.) —
@@ -868,10 +875,13 @@ export function App() {
         // Let the left column narrow to 200 before it snaps/collapses (the DS default is
         // 280, which left a 140–280 dead zone where a narrowed left snapped back up).
         minLeftWidth={200}
-        mobileItems={[...railSurfaces("left"), ...railSurfaces("right"), ...railSurfaces("bottom")].map((s) => ({
-          ...s,
-          dot: pluginDots[s.id] || undefined,
-        }))}
+        // Mobile bottom bar = the quick-bar (first 5 of quickBarIds). The DS shell's own
+        // "More" button is hidden (app-drawer.css) — the unified mobile "more" is the
+        // header hamburger's AppDrawer (surfaces + global settings + links). We still pass
+        // the full surface set so the bar resolves its quick icons (and the DS sheet would
+        // degrade gracefully if ever shown).
+        mobileItems={[...railSurfaces("left"), ...railSurfaces("right"), ...railSurfaces("bottom")]
+          .map((s) => ({ ...s, dot: pluginDots[s.id] || undefined }))}
         mobileActiveId={mobileActive}
         onMobileSelect={setMobileActive}
         quickBarIds={quickBar}
@@ -912,16 +922,7 @@ export function App() {
         bottomContent={bottomActive ? renderSurface(bottomActive) : null}
         utilityBar={
           <UtilityBar
-            start={
-              <>
-                <a className="util-btn" href="https://protolabsai.github.io/protoAgent/" target="_blank" rel="noreferrer" title="Documentation" aria-label="Documentation">
-                  <BookOpen size={14} />
-                </a>
-                <a className="util-btn" href="https://github.com/protoLabsAI/protoAgent" target="_blank" rel="noreferrer" title="GitHub repository" aria-label="GitHub repository">
-                  <Github size={14} />
-                </a>
-              </>
-            }
+            // Docs + GitHub moved into the header drawer (2026-06-18 IA pass).
             end={
               <>
                 {/* Background subagents (ADR 0050 Phase 3) — live pill + jobs dialog. */}
@@ -979,8 +980,26 @@ export function App() {
         Rendered OUTSIDE the .app-shell grid: the DS Menu stays mounted to hold its ref, so
         its (closed) anchor would otherwise be a stray 4th grid row and break the layout. */}
     <ContextMenuRenderer />
-    {/* The one-stop-shop Settings overlay (ADR 0048) — the topbar gear opens it. */}
-    <SettingsOverlay open={settingsOverlayOpen} onClose={() => setSettingsOverlayOpen(false)} />
+    {/* The header drawer (hamburger) — global actions + (on mobile) surface nav. */}
+    <AppDrawer
+      open={drawerOpen}
+      onClose={() => setDrawerOpen(false)}
+      mobile={isMobile}
+      surfaces={[...railSurfaces("left"), ...railSurfaces("right"), ...railSurfaces("bottom")].map((s) => ({
+        id: s.id,
+        label: s.label,
+        icon: s.icon,
+      }))}
+      activeSurface={isMobile ? mobileActive : leftActive}
+      onSelectSurface={setMobileActive}
+      onOpenGlobal={openGlobalSettings}
+    />
+    {/* Global settings overlay — opened from the drawer or a palette deep-link (store-driven). */}
+    <SettingsOverlay
+      open={globalSettingsOpen}
+      section={globalSettingsSection}
+      onClose={closeGlobalSettings}
+    />
     </>
   );
 }

--- a/apps/web/src/app/AppDrawer.tsx
+++ b/apps/web/src/app/AppDrawer.tsx
@@ -1,0 +1,117 @@
+import { useEffect } from "react";
+import type { ReactNode } from "react";
+import { BarChart3, BookOpen, Github, Settings2, X } from "lucide-react";
+
+import { Button } from "@protolabsai/ui/primitives";
+
+import "./app-drawer.css";
+
+type SurfaceItem = { id: string; label: string; icon: ReactNode };
+
+/**
+ * The app menu drawer — a right-side sheet opened by the header hamburger (2026-06-18
+ * IA pass). One drawer for both modes: on desktop it holds the box-level/global actions
+ * (Global settings, Telemetry) + the GitHub/Docs links; on mobile it ALSO lists the
+ * surfaces (it's the mobile "more"). Workspace settings stay in the rail surface, not here.
+ */
+export function AppDrawer({
+  open,
+  onClose,
+  mobile,
+  surfaces,
+  activeSurface,
+  onSelectSurface,
+  onOpenGlobal,
+}: {
+  open: boolean;
+  onClose: () => void;
+  mobile: boolean;
+  surfaces: SurfaceItem[];
+  activeSurface: string;
+  onSelectSurface: (id: string) => void;
+  onOpenGlobal: (section?: string) => void;
+}) {
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") onClose();
+    };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  if (!open) return null;
+  // Each action closes the drawer after running.
+  const act = (fn: () => void) => () => {
+    fn();
+    onClose();
+  };
+
+  return (
+    <div className="app-drawer-root" role="dialog" aria-modal="true" aria-label="Menu">
+      <div className="app-drawer-backdrop" onClick={onClose} />
+      <aside className="app-drawer" data-testid="app-drawer">
+        <header className="app-drawer-head">
+          <strong>Menu</strong>
+          <Button icon variant="ghost" type="button" aria-label="Close menu" onClick={onClose}>
+            <X size={16} />
+          </Button>
+        </header>
+        <div className="app-drawer-body">
+          {mobile && surfaces.length ? (
+            <section className="app-drawer-group">
+              <p className="app-drawer-label">Go to</p>
+              {surfaces.map((s) => (
+                <button
+                  key={s.id}
+                  type="button"
+                  className={`app-drawer-item${s.id === activeSurface ? " on" : ""}`}
+                  onClick={act(() => onSelectSurface(s.id))}
+                >
+                  <span className="app-drawer-ico">{s.icon}</span>
+                  {s.label}
+                </button>
+              ))}
+            </section>
+          ) : null}
+
+          <section className="app-drawer-group">
+            <p className="app-drawer-label">Settings</p>
+            <button type="button" className="app-drawer-item" onClick={act(() => onOpenGlobal())}>
+              <span className="app-drawer-ico"><Settings2 size={16} /></span>
+              Global settings
+            </button>
+            <button type="button" className="app-drawer-item" onClick={act(() => onOpenGlobal("telemetry"))}>
+              <span className="app-drawer-ico"><BarChart3 size={16} /></span>
+              Telemetry
+            </button>
+          </section>
+
+          <section className="app-drawer-group">
+            <p className="app-drawer-label">Links</p>
+            <a
+              className="app-drawer-item"
+              href="https://protolabsai.github.io/protoAgent/"
+              target="_blank"
+              rel="noreferrer"
+              onClick={onClose}
+            >
+              <span className="app-drawer-ico"><BookOpen size={16} /></span>
+              Docs
+            </a>
+            <a
+              className="app-drawer-item"
+              href="https://github.com/protoLabsAI/protoAgent"
+              target="_blank"
+              rel="noreferrer"
+              onClick={onClose}
+            >
+              <span className="app-drawer-ico"><Github size={16} /></span>
+              GitHub
+            </a>
+          </section>
+        </div>
+      </aside>
+    </div>
+  );
+}

--- a/apps/web/src/app/HamburgerMenu.tsx
+++ b/apps/web/src/app/HamburgerMenu.tsx
@@ -1,37 +1,24 @@
-import { useRef } from "react";
-import { Menu as MenuIcon, Settings2 } from "lucide-react";
-import { Menu, MenuItem, type MenuHandle } from "@protolabsai/ui/menu";
+import { Menu as MenuIcon } from "lucide-react";
 import { Button } from "@protolabsai/ui/primitives";
 
 /**
- * Always-on header menu (the hamburger). A ghost button that drops the DS Menu anchored
- * under it. This is the new home for global actions as Settings get rearranged app-wide
- * (ADR 0048 follow-up) — for now it carries the one-stop-shop Settings overlay (the job
- * the topbar gear used to do); more items land here as the IA settles.
+ * The header hamburger (top-right) — opens the app drawer (AppDrawer): Global settings,
+ * Telemetry, GitHub/Docs links, and on mobile the surface nav. Replaces the earlier
+ * dropdown-Menu version (#1137/#1155), which was pulled — same trigger, a side drawer
+ * now instead of a dropdown.
  */
-export function HamburgerMenu({ onOpenSettings }: { onOpenSettings: () => void }) {
-  const menuRef = useRef<MenuHandle>(null);
+export function HamburgerMenu({ onOpen }: { onOpen: () => void }) {
   return (
-    <>
-      <Button
-        icon
-        variant="ghost"
-        type="button"
-        title="Menu"
-        aria-label="Menu"
-        data-testid="header-menu"
-        onClick={(e) => {
-          const r = (e.currentTarget as HTMLElement).getBoundingClientRect();
-          menuRef.current?.open({ x: r.right, y: r.bottom + 4 });
-        }}
-      >
-        <MenuIcon size={18} />
-      </Button>
-      <Menu ref={menuRef} align="end">
-        <MenuItem icon={<Settings2 size={14} />} onSelect={onOpenSettings}>
-          Settings
-        </MenuItem>
-      </Menu>
-    </>
+    <Button
+      icon
+      variant="ghost"
+      type="button"
+      title="Menu"
+      aria-label="Menu"
+      data-testid="header-menu"
+      onClick={onOpen}
+    >
+      <MenuIcon size={18} />
+    </Button>
   );
 }

--- a/apps/web/src/app/app-drawer.css
+++ b/apps/web/src/app/app-drawer.css
@@ -1,0 +1,91 @@
+/* The app menu drawer (header hamburger). A right-side sheet over a dim backdrop;
+   doubles as the mobile "more" view. Themed from the design-system tokens. */
+.app-drawer-root {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+}
+.app-drawer-backdrop {
+  position: absolute;
+  inset: 0;
+  background: color-mix(in srgb, #000 38%, transparent);
+}
+.app-drawer {
+  position: absolute;
+  top: 0;
+  right: 0;
+  height: 100%;
+  width: min(320px, 88vw);
+  display: flex;
+  flex-direction: column;
+  background: var(--bg-raised);
+  border-left: 1px solid var(--border);
+  box-shadow: -8px 0 24px color-mix(in srgb, #000 25%, transparent);
+  animation: app-drawer-in 0.16s ease;
+}
+@keyframes app-drawer-in {
+  from { transform: translateX(12px); opacity: 0; }
+  to { transform: translateX(0); opacity: 1; }
+}
+.app-drawer-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+  font-size: 14px;
+}
+.app-drawer-body {
+  flex: 1;
+  overflow-y: auto;
+  padding: 8px;
+}
+.app-drawer-group {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 0;
+}
+.app-drawer-group + .app-drawer-group {
+  border-top: 1px solid var(--border);
+  margin-top: 4px;
+  padding-top: 8px;
+}
+.app-drawer-label {
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--fg-muted);
+  margin: 0 6px 4px;
+}
+.app-drawer-item {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 9px 10px;
+  border-radius: 8px;
+  border: 0;
+  background: transparent;
+  color: var(--fg);
+  font-size: 14px;
+  text-align: left;
+  text-decoration: none;
+  cursor: pointer;
+}
+.app-drawer-item:hover {
+  background: var(--bg-hover);
+}
+.app-drawer-item.on {
+  background: color-mix(in srgb, var(--pl-color-brand-lavender) 16%, transparent);
+}
+.app-drawer-ico {
+  display: inline-flex;
+  color: var(--fg-muted);
+}
+
+/* The mobile "more" is unified into THIS drawer (the header hamburger), so hide the
+   DS bottom-bar's own "More" button — the bottom bar stays the quick-bar only. The
+   .pl-mobilenav only mounts under the mobile breakpoint, so no media query is needed. */
+.pl-mobilenav__tab[aria-label="All surfaces"] {
+  display: none;
+}

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -21,6 +21,17 @@
 .app-topbar {
   flex: 0 0 48px;
   min-height: 48px;
+  position: relative;
+}
+/* The header hamburger, pinned top-right over the DS Header. */
+.app-topbar-menu {
+  position: absolute;
+  top: 0;
+  right: 8px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  z-index: 5;
 }
 
 /* Operational warning strip under the topbar (#706 co-located instances etc.) —

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -94,21 +94,16 @@ function deepLinkCommands(): Command[] {
       ui().setSurface("plugins");
       ui().setPluginsTab("local");
     }),
-    // Box folded into Settings ▸ Global (ADR 0048 follow-up) — land on the section.
-    link("box:fleet", "Settings: Fleet", ["fleet", "agents", "box"], () => {
-      ui().setSurface("settings");
-      ui().setSettingsScope("host");
-      ui().setSettingsSection("fleet");
+    // Global settings (Fleet/Telemetry/Commons) is the header-drawer overlay now
+    // (2026-06-18 IA pass) — open it deep-linked to the section.
+    link("box:fleet", "Settings: Fleet", ["fleet", "agents", "box", "global"], () => {
+      ui().openGlobalSettings("fleet");
     }),
-    link("box:telemetry", "Settings: Telemetry", ["telemetry", "metrics", "box"], () => {
-      ui().setSurface("settings");
-      ui().setSettingsScope("host");
-      ui().setSettingsSection("telemetry");
+    link("box:telemetry", "Settings: Telemetry", ["telemetry", "metrics", "box", "global"], () => {
+      ui().openGlobalSettings("telemetry");
     }),
-    link("box:commons", "Settings: Commons", ["commons", "shared", "skills", "box"], () => {
-      ui().setSurface("settings");
-      ui().setSettingsScope("host");
-      ui().setSettingsSection("commons");
+    link("box:commons", "Settings: Commons", ["commons", "shared", "skills", "box", "global"], () => {
+      ui().openGlobalSettings("commons");
     }),
   ];
 }

--- a/apps/web/src/settings/SettingsOverlay.tsx
+++ b/apps/web/src/settings/SettingsOverlay.tsx
@@ -4,16 +4,24 @@ import { Dialog } from "@protolabsai/ui/overlays";
 
 import { SettingsSurface } from "./SettingsSurface";
 
-// The one-stop-shop as an overlay (ADR 0048, operator direction 2026-06-11): the
-// same two-home SettingsSurface, openable as a dialog from the topbar gear so
-// settings are reachable from anywhere without leaving the current surface. It
-// shares the persisted settingsScope/settingsSection, so it opens wherever you
-// last were (and quick-settings' "Open full settings" can deep-link a section).
-export function SettingsOverlay({ open, onClose }: { open: boolean; onClose: () => void }) {
+// Global (box-shared) settings as an overlay, opened from the header drawer
+// (2026-06-18 IA pass): the Global home — Overview · Configuration · Fleet ·
+// Telemetry · Commons — without the scope toggle. Workspace settings live in the
+// rail surface, not here. `section` deep-links a Global section (e.g. the drawer's
+// "Telemetry" item opens straight to it); the `key` re-seeds the surface per open.
+export function SettingsOverlay({
+  open,
+  onClose,
+  section,
+}: {
+  open: boolean;
+  onClose: () => void;
+  section?: string;
+}) {
   if (!open) return null;
   return (
-    <Dialog open onClose={onClose} title="Settings" width="min(960px, 94vw)" className="settings-overlay">
-      <SettingsSurface />
+    <Dialog open onClose={onClose} title="Global settings" width="min(960px, 94vw)" className="settings-overlay">
+      <SettingsSurface only="host" initialSection={section} key={section || "_"} />
     </Dialog>
   );
 }

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,6 +1,6 @@
 import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Library, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import type { ReactNode } from "react";
+import { useState, type ReactNode } from "react";
 
 import { PanelHeader, SideNav, Tabs } from "@protolabsai/ui/navigation";
 import { Button } from "@protolabsai/ui/primitives";
@@ -103,13 +103,26 @@ export const SETTINGS_HOMES: Home[] = [
   { id: "workspace", label: "Workspace", icon: Boxes, sections: WORKSPACE_SECTIONS },
 ];
 
-export function SettingsSurface() {
-  const scope = useUI((s) => s.settingsScope);
-  const section = useUI((s) => s.settingsSection);
+// `only` renders a single scope's sections WITHOUT the Global/Workspace toggle —
+// Workspace lives in the rail surface, Global in the header-drawer's overlay
+// (separated per the 2026-06-18 IA pass). The Global overlay keeps its own section
+// in local state (seeded by `initialSection`) so it never fights the rail's persisted
+// workspace section. Bare `<SettingsSurface />` keeps the legacy two-home toggle.
+export function SettingsSurface({ only, initialSection }: { only?: SettingsScope; initialSection?: string } = {}) {
+  const persistedScope = useUI((s) => s.settingsScope);
+  const persistedSection = useUI((s) => s.settingsSection);
   const setScope = useUI((s) => s.setSettingsScope);
-  const setSection = useUI((s) => s.setSettingsSection);
+  const setPersistedSection = useUI((s) => s.setSettingsSection);
 
+  const scope: SettingsScope = only ?? persistedScope;
   const home = SETTINGS_HOMES.find((h) => h.id === scope) ?? SETTINGS_HOMES[0];
+
+  // The Global overlay (only="host") tracks its section locally; the rail (workspace
+  // or the legacy toggle) uses the persisted store.
+  const overlay = only === "host";
+  const [localSection, setLocalSection] = useState(initialSection ?? home.sections[0].id);
+  const section = overlay ? localSection : persistedSection;
+  const setSection = overlay ? setLocalSection : setPersistedSection;
   const active = home.sections.find((s) => s.id === section) ?? home.sections[0];
 
   // Switching home lands on its first section unless the current section id also
@@ -135,15 +148,18 @@ export function SettingsSurface() {
         active={active.id}
         onSelect={(t) => setSection(t)}
         items={home.sections.map((s) => ({ id: s.id, label: s.label, icon: <s.icon size={15} /> }))}
-        // Scope toggle pinned atop the rail; text-only so both home labels fit.
+        // Scope toggle pinned atop the rail — only for the legacy two-home surface.
+        // A scoped surface (`only`) shows just its own sections, no toggle.
         header={
-          <Tabs
-            variant="segmented"
-            ariaLabel="Settings scope"
-            active={scope}
-            onSelect={(t) => selectHome(t as SettingsScope)}
-            items={SETTINGS_HOMES.map((h) => ({ id: h.id, label: h.label }))}
-          />
+          only ? undefined : (
+            <Tabs
+              variant="segmented"
+              ariaLabel="Settings scope"
+              active={scope}
+              onSelect={(t) => selectHome(t as SettingsScope)}
+              items={SETTINGS_HOMES.map((h) => ({ id: h.id, label: h.label }))}
+            />
+          )
         }
       />
       <div className="settings-content">{active.render()}</div>

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -65,6 +65,13 @@ type UIState = {
   // One-shot: the FleetSwitcher's "+ New agent" deep-link routes to Host/App ▸ Fleet
   // and asks the fleet panel to open the new-agent picker on mount, then clears it.
   fleetStartNew: boolean;
+  // Global settings overlay (the Global home; opened from the header drawer or a
+  // command-palette deep-link). EPHEMERAL — partialized out of persistence so a refresh
+  // never reopens it. The section deep-links a Global section (e.g. "telemetry").
+  globalSettingsOpen: boolean;
+  globalSettingsSection?: string;
+  openGlobalSettings: (section?: string) => void;
+  closeGlobalSettings: () => void;
   activityTab: ActivityTab;
   rightCollapsed: boolean;
   leftCollapsed: boolean;
@@ -171,6 +178,10 @@ export const useUI = create<UIState>()(
       settingsScope: "host" as SettingsScope,
       settingsSection: "overview",
       fleetStartNew: false,
+      globalSettingsOpen: false,
+      globalSettingsSection: undefined,
+      openGlobalSettings: (section) => set({ globalSettingsOpen: true, globalSettingsSection: section }),
+      closeGlobalSettings: () => set({ globalSettingsOpen: false }),
       activityTab: "thread",
       rightCollapsed: false,
       leftCollapsed: false,
@@ -262,6 +273,9 @@ export const useUI = create<UIState>()(
       storage: _layoutStorage,
       version: 7, // …v5 Schedule→Activity tab (#1075) · v6 +bottom dock · v7 Schedule→rail surface again
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
+      // The Global settings overlay is ephemeral UI state — drop it from persistence so a
+      // refresh never reopens it (everything else persists as before).
+      partialize: ({ globalSettingsOpen: _o, globalSettingsSection: _s, ...rest }) => rest,
     },
   ),
 );


### PR DESCRIPTION
## What

Splits the two settings homes by **entry point** instead of an in-panel toggle (the segmented Global/Workspace toggle is gone):

- **Workspace settings** stay in the rail **Settings** surface — now Workspace-direct, no scope toggle.
- **Global settings** (Overview · Configuration · Fleet · Telemetry · Commons) open as an **overlay** from a new **top-right header hamburger → side drawer**.

The new **AppDrawer** is a right-side sheet that *also serves as the unified mobile "more" view*: on mobile it lists the surfaces too, so the DS shell's own bottom-bar **"More"** is hidden — one drawer for global actions + nav + the **Docs/GitHub** links (moved out of the utility bar).

> Replaces the earlier dropdown-style hamburger (#1137/#1155, pulled) — same trigger, a **side drawer** now instead of a dropdown.

## How

- `SettingsSurface` gains `only` + `initialSection`: render a single scope with no toggle. The Global overlay tracks its section in **local** state so it never fights the rail's persisted Workspace section.
- Global-overlay open state lives in the **UI store** (ephemeral — `partialize`d out of persistence so a refresh never reopens it) so **command-palette** deep-links (Fleet/Telemetry/Commons) and the **FleetSwitcher "+ New agent"** flow can open it.
- `AppDrawer` + `app-drawer.css` (new); `HamburgerMenu` rewritten to a ghost icon button that opens the drawer.

## Why draft

This is a **visual/UX** change — the hamburger placement (vs the header `org` text), the drawer slide-in feel, and the mobile "more" unification need your eye. CI can't judge that. The last hamburger "wasn't quite right"; this is the side-drawer take.

## Gates (all green locally)

- ✅ web build + `tsc --noEmit` (×2)
- ✅ CSS comment guard
- ✅ `npm run test:unit` — 94 passed
- ✅ `npm run test:e2e` — 107 passed (rewrote settings/fleet/telemetry/quick-settings/navigation/mcp/delegates/playbooks nav; unskipped the header-drawer test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)