### PR TITLE
chore(web): rename the "Commons" settings section to "Shared Skills"

### DIFF
--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -59,7 +59,7 @@ test("Workspace settings live in the rail (no scope toggle)", async ({ page }) =
   expect(await page.locator(".pl-accordion__title").allTextContents()).toEqual(["Compaction", "Runtime"]);
 });
 
-test("Global settings open from the header drawer → overlay (Overview · Configuration · Fleet · Telemetry · Commons)", async ({ page }) => {
+test("Global settings open from the header drawer → overlay (Overview · Configuration · Fleet · Telemetry · Shared Skills)", async ({ page }) => {
   await openGlobal(page);
   const sidenav = page.locator(".settings-overlay .pl-sidenav");
   expect(await sidenav.locator("button").allTextContents()).toEqual([
@@ -67,7 +67,7 @@ test("Global settings open from the header drawer → overlay (Overview · Confi
     "Configuration",
     "Fleet",
     "Telemetry",
-    "Commons",
+    "Shared Skills",
   ]);
   // Fleet section shows the agents panel; Telemetry renders the dashboard.
   await sidenav.getByRole("tab", { name: "Fleet", exact: true }).click();

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -102,7 +102,7 @@ function deepLinkCommands(): Command[] {
     link("box:telemetry", "Settings: Telemetry", ["telemetry", "metrics", "box", "global"], () => {
       ui().openGlobalSettings("telemetry");
     }),
-    link("box:commons", "Settings: Commons", ["commons", "shared", "skills", "box", "global"], () => {
+    link("box:commons", "Settings: Shared Skills", ["commons", "shared", "skills", "box", "global"], () => {
       ui().openGlobalSettings("commons");
     }),
   ];

--- a/apps/web/src/settings/CommonsPanel.tsx
+++ b/apps/web/src/settings/CommonsPanel.tsx
@@ -6,10 +6,10 @@ import { Library } from "lucide-react";
 import { RefreshButton } from "../app/ui-kit";
 import { api } from "../lib/api";
 
-// Global ▸ Commons (ADR 0041 + 0048) — the box-shared skill library every agent
-// on this machine reads (commons ∪ private, in layered mode). Read-only here: a
-// skill enters the commons by being PROMOTED from a workspace (Workspace ▸ Skills),
-// which is the curated, explicit "shared brain, private hands" lift. The commons
+// Global ▸ Shared Skills (ADR 0041 + 0048) — the box-shared skill library every agent
+// on this machine reads (shared ∪ private, in layered mode). Read-only here: a skill
+// enters the shared library by being PROMOTED from a workspace (Workspace ▸ Skills),
+// which is the curated, explicit "shared brain, private hands" lift. The library
 // LOCATION (`commons.path`) is a host-scoped field edited in Host ▸ Host config.
 
 export function CommonsPanel() {
@@ -21,19 +21,19 @@ export function CommonsPanel() {
   return (
     <section className="panel stage-panel" data-testid="commons-panel">
       <PanelHeader
-        title="Commons"
+        title="Shared Skills"
         kicker={`the box-shared skill library · ${commons.length} skill${commons.length === 1 ? "" : "s"}`}
         actions={<RefreshButton onClick={() => void q.refetch()} busy={q.isFetching} />}
       />
       <div className="stage-body">
         {!layered ? (
           <Empty
-            title="No commons in use"
-            description="No agent on this box is in layered mode. Set an agent's Skill sharing to “layered” (Workspace ▸ Skills) to read + contribute to a shared commons, and choose its location in Host config (commons.path)."
+            title="No shared skills in use"
+            description="No agent on this box is in layered mode. Set an agent's Skill sharing to “layered” (Workspace ▸ Skills) to read + contribute to the shared skills library, and set its location in Host config (Shared skills location)."
           />
         ) : commons.length === 0 ? (
           <Empty
-            title="The commons is empty"
+            title="No shared skills yet"
             description="Promote a proven skill from a workspace (Workspace ▸ Skills ▸ Promote) to share it with every agent on this box."
           />
         ) : (

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -45,7 +45,7 @@ const HOST_SECTIONS: Section[] = [
   // Box-level operations (formerly the standalone Box rail surface).
   { id: "fleet", label: "Fleet", icon: Server, render: () => <FleetSurface /> },
   { id: "telemetry", label: "Telemetry", icon: BarChart3, render: () => <TelemetrySurface /> },
-  { id: "commons", label: "Commons", icon: Library, render: () => <CommonsPanel /> },
+  { id: "commons", label: "Shared Skills", icon: Library, render: () => <CommonsPanel /> },
 ];
 
 // The Workspace home (ADR 0048 §3.2) — the focused agent, everything that defines it:

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -457,10 +457,10 @@ FIELDS: list[Field] = [
     Field(
         "commons.path",
         "commons_path",
-        "Commons location",
+        "Shared skills location",
         "string",
         "Skills",
-        "Box-shared skill commons read by every agent on this machine. Blank = ~/.protoagent/commons.",
+        "Box-shared skill library read by every agent on this machine. Blank = ~/.protoagent/commons.",
         scope="host",
     ),
     # ── Middleware toggles ───────────────────────────────────────────────────


### PR DESCRIPTION
"Commons" wasn't self-explanatory. This renames the box-shared skill library **section** to **"Shared Skills"**.

**Renamed (user-facing):**
- Settings → Global section label + the panel title/empty-state copy
- Palette deep-link: "Settings: Commons" → "Settings: Shared Skills"
- Host-config field label: "Commons location" → "Shared skills location"
- `settings.spec` assertions

**Kept deliberately:**
- Section id `commons`, config key `commons.path`, form id `commons_path` — renaming these is breaking (persisted state / existing configs).
- The per-skill **tier** value `commons` (its badges + "from commons" on the Playbooks surface). Renaming the tier to "shared" would **collide with the existing "shared" sharing mode** (scoped/shared/layered), so it's left for a separate call.

**Verification:** build + 94 web + 105 E2E + 22 schema tests green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)