### PR TITLE
fix(web): align settings surfaces to the design system

### DIFF
--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -19,8 +19,8 @@ test("lists configured delegates with type + secret badges", async ({ page }) =>
   await expect(row).toBeVisible();
   await expect(row.getByText("openai", { exact: true })).toBeVisible(); // DS Badge (#832)
   await expect(row.getByText("secret set")).toBeVisible();
-  // Health prober (PR4): the cached status surfaces as a dot.
-  await expect(row.locator(".delegate-health.ok")).toBeVisible();
+  // Health prober (PR4): the cached status surfaces as a DS StatusDot.
+  await expect(row.locator(".pl-dot--success")).toBeVisible();
 });
 
 test("Add opens a type picker and a schema-driven form", async ({ page }) => {
@@ -28,13 +28,13 @@ test("Add opens a type picker and a schema-driven form", async ({ page }) => {
   const panel = page.locator(".delegates-section");
   await panel.getByRole("button", { name: /Add delegate/ }).click();
 
-  // Three type tiles from /api/delegate-types.
-  const tiles = panel.locator(".delegate-type-tile");
+  // Three type cards from /api/delegate-types (DS RadioCard).
+  const tiles = panel.locator(".pl-radiocard");
   await expect(tiles).toHaveCount(3);
 
   // Default type (a2a) renders its URL field; switching to acp renders Command.
   await expect(panel.getByText("URL", { exact: false })).toBeVisible();
-  await panel.locator(".delegate-type-tile", { hasText: "Coding agent" }).click();
+  await panel.locator(".pl-radiocard", { hasText: "Coding agent" }).click();
   await expect(panel.getByText("Command", { exact: false })).toBeVisible();
   await expect(panel.getByText("Workdir", { exact: false })).toBeVisible();
 

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -61,7 +61,9 @@ test("stop a running agent flips its status dot", async ({ page }) => {
   const stop = ava.getByRole("button", { name: "Stop" });
   if (await stop.count()) {
     await stop.click();
-    await expect(ava.locator(".fleet-dot.stopped")).toBeVisible();
+    // Stopped agents drop the success dot and surface a Start button.
+    await expect(ava.getByRole("button", { name: "Start" })).toBeVisible();
+    await expect(ava.locator(".pl-dot--success")).toHaveCount(0);
   }
 });
 
@@ -111,7 +113,7 @@ test("host without delegates: add → 404 → Enable delegates → retried add s
     .getByRole("button", { name: "Add as a delegate of this agent (delegate_to)" })
     .click();
 
-  const error = page.locator(".fleet-error");
+  const error = page.locator(".pl-alert--error");
   await expect(error).toContainText("can't hold delegates");
   await page.getByTestId("enable-delegates").click();
 

--- a/apps/web/src/app/FleetSwitcher.tsx
+++ b/apps/web/src/app/FleetSwitcher.tsx
@@ -4,6 +4,7 @@ import type { ReactNode } from "react";
 
 import { Menu, MenuItem, MenuSeparator } from "@protolabsai/ui/menu";
 import { Badge } from "@protolabsai/ui/primitives";
+import { StatusDot } from "@protolabsai/ui/data";
 
 import { agentHref, api, currentSlug } from "../lib/api";
 import { queryKeys } from "../lib/queries";
@@ -42,7 +43,7 @@ export function FleetSwitcher({ fallbackName, onNewAgent }: { fallbackName: Reac
         return (
           <MenuItem
             key={a.name}
-            icon={<span className={`fleet-dot ${a.running ? "running" : "stopped"}`} aria-hidden />}
+            icon={<StatusDot status={a.running ? "success" : "neutral"} pulse={a.running} />}
             onSelect={() => {
               if (!isCurrent) window.location.href = agentHref(slugOf(a)); // navigate → this agent
             }}

--- a/apps/web/src/app/ToolsPanel.tsx
+++ b/apps/web/src/app/ToolsPanel.tsx
@@ -1,17 +1,18 @@
+import "./tools.css";
+
 import { Input } from "@protolabsai/ui/forms";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
 
-import { PanelHeader } from "@protolabsai/ui/navigation";
+import { Accordion, AccordionItem, PanelHeader } from "@protolabsai/ui/navigation";
+import { Badge } from "@protolabsai/ui/primitives";
 import { toolsQuery } from "../lib/queries";
 import { StagePanel } from "./ErrorBoundary";
-import { StatusPill } from "./StatusPill";
 
 // Runtime → Tools: the live tool inventory the lead agent + subagents can call,
 // grouped by source (core / plugin / mcp). Searchable — the list grows as you
-// add plugins and MCP servers.
-
-const SOURCE_TONE = { core: "success", plugin: "muted", mcp: "muted" } as const;
+// add plugins and MCP servers. Each subsystem is a collapsible DS Accordion
+// section so a long inventory stays scannable; a search expands every match.
 
 // Subsystem ordering — General leads; integrations next; plugin/MCP last.
 const CATEGORY_ORDER = [
@@ -51,22 +52,39 @@ function ToolsBody() {
           value={q}
           onChange={(e) => setQ(e.target.value)}
         />
-        {ordered.map((cat) => (
-          <div key={cat}>
-            <p className="panel-kicker">{cat} <span className="muted">· {groups.get(cat)!.length}</span></p>
-            <div className="table-list">
-              {groups.get(cat)!.map((t) => (
-                <div className="table-row" key={t.name}>
-                  <span>
-                    <strong>{t.name}</strong>
-                    {t.description ? <span className="muted"> — {t.description}</span> : null}
-                  </span>
-                  <StatusPill label={t.source} tone={SOURCE_TONE[t.source] ?? "muted"} />
-                </div>
-              ))}
-            </div>
-          </div>
-        ))}
+        {ordered.length ? (
+          <Accordion className="tools-groups">
+            {ordered.map((cat, i) => {
+              const items = groups.get(cat)!;
+              return (
+                <AccordionItem
+                  // Re-key on the query so a search remounts the sections with the
+                  // "expand every match" defaultOpen (defaultOpen only applies on mount).
+                  key={`${cat}::${query}`}
+                  defaultOpen={Boolean(query) || i === 0}
+                  title={
+                    <span className="tools-group-head">
+                      {cat}
+                      <Badge status="neutral">{items.length}</Badge>
+                    </span>
+                  }
+                >
+                  <div className="tools-list">
+                    {items.map((t) => (
+                      <div className="tools-row" key={t.name}>
+                        <div className="tools-row-main">
+                          <code className="tools-name">{t.name}</code>
+                          {t.description ? <span className="tools-desc">{t.description}</span> : null}
+                        </div>
+                        <Badge status={t.source === "core" ? "success" : "neutral"}>{t.source}</Badge>
+                      </div>
+                    ))}
+                  </div>
+                </AccordionItem>
+              );
+            })}
+          </Accordion>
+        ) : null}
         {tools.length === 0 ? <p className="muted">No tools match.</p> : null}
       </div>
     </>

--- a/apps/web/src/app/theme-base.css
+++ b/apps/web/src/app/theme-base.css
@@ -6,8 +6,12 @@
    in theme.css until it's carved (#832). */
 
 :root {
-  --brand-violet: #7c3aed;
-  --brand-violet-light: #a78bfa;
+  /* Track the themed DS accent (--pl-color-accent) so accent chrome — settings focus
+     rings, the dirty-edit marker, selected cards, group titles — moves with the active
+     theme (incl. per-agent ThemePanel themes) instead of a frozen purple. The old hex
+     stays as the pre-token fallback. */
+  --brand-violet: var(--pl-color-accent, #7c3aed);
+  --brand-violet-light: var(--pl-color-accent, #a78bfa);
   --brand-indigo: #6366f1;
   --brand-indigo-bright: #818cf8;
   /* sister-agent (a2a) accent — the only non-semantic origin tint in the activity feed */

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1816,26 +1816,9 @@ textarea {
    rules moved to src/fleet/fleet.css (#832). The .fleet-active-tag / .fleet-delegate-tag /
    .fleet-host-tag text tags are now DS <Badge> (#832).
    Left here (shared / other surfaces): the .archetype-* picker (NewAgentPanel), .field-hint
-   (NewAgentPanel + SetupWizard), the topbar .fleet-switcher* (FleetSwitcher), and .fleet-dot*
-   — both rendered by the always-mounted topbar FleetSwitcher AND the FleetManager
-   panel, so they stay in this always-loaded layer (not a Settings-only module that loads lazily),
-   plus the global ::view-transition root crossfade. */
-
-/* Status dot — shared by the topbar FleetSwitcher and the FleetManager panel. */
-.fleet-dot {
-  flex: 0 0 auto;
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--fg-muted);
-}
-.fleet-dot.running {
-  background: var(--success);
-  box-shadow: 0 0 6px color-mix(in srgb, var(--success) 50%, transparent);
-}
-.fleet-dot.stopped {
-  opacity: 0.45;
-}
+   (NewAgentPanel + SetupWizard), the topbar .fleet-switcher* (FleetSwitcher), plus the global
+   ::view-transition root crossfade. The status dots (FleetSwitcher + FleetManager) are the DS
+   <StatusDot> now, so the hand-rolled .fleet-dot* is retired. */
 
 /* Archetype picker is now the DS <RadioCardGroup> (protoContent #254). */
 .archetype-name-field {

--- a/apps/web/src/app/tools.css
+++ b/apps/web/src/app/tools.css
@@ -1,0 +1,43 @@
+/* Tools panel (Workspace ▸ Tools) — the live tool inventory grouped into collapsible
+   DS Accordion sections by subsystem. Chrome (the accordion + source/count badges)
+   comes from @protolabsai/ui; only the row layout lives here. */
+.tools-groups {
+  margin-top: 12px;
+}
+.tools-group-head {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.tools-list {
+  display: flex;
+  flex-direction: column;
+}
+.tools-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 7px 2px;
+  border-bottom: 1px solid var(--border);
+}
+.tools-row:last-child {
+  border-bottom: 0;
+}
+.tools-row-main {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  min-width: 0;
+  flex-wrap: wrap;
+}
+.tools-name {
+  font-family: var(--font-mono);
+  font-size: 12.5px;
+  color: var(--fg);
+}
+.tools-desc {
+  font-size: 12px;
+  color: var(--fg-muted);
+  min-width: 0;
+}

--- a/apps/web/src/fleet/fleet.css
+++ b/apps/web/src/fleet/fleet.css
@@ -14,9 +14,8 @@
 .fleet-row.active {
   background: var(--bg-hover);
 }
-/* NB: .fleet-dot* is NOT here — it's shared with the always-mounted topbar
-   FleetSwitcher, so it lives in the always-loaded layer (theme.css), not this
-   Settings-only module (which would only load once Settings → Agents opens). */
+/* The row status dot is the DS <StatusDot> now (FleetSwitcher + FleetManager both use it);
+   the hand-rolled .fleet-dot* is retired. */
 .fleet-row-main {
   flex: 1 1 auto;
   min-width: 0;
@@ -58,10 +57,7 @@
   letter-spacing: 0.05em;
   margin: 4px 0 8px;
 }
-.fleet-error {
-  color: var(--error);
-  margin-bottom: 10px;
-}
+/* .fleet-error retired — the fleet manager + new-agent errors are DS <Alert status="error"> now. */
 .fleet-purge {
   display: flex;
   align-items: center;

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -1,8 +1,10 @@
 import "./settings.css";
 import "./delegates.css";
 
-import { Input, Select, Textarea } from "@protolabsai/ui/forms";
+import { Input, RadioCard, RadioCardGroup, Select, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
+
+import { StatusDot } from "@protolabsai/ui/data";
 
 import { StatusPill } from "../app/StatusPill";
 import { HelpLink } from "../app/ui-kit";
@@ -115,12 +117,11 @@ export function DelegatesSection() {
                 <strong>
                   {d.health ? (
                     <span
-                      className={`delegate-health ${d.health.ok ? "ok" : d.health.ok === false ? "down" : "unknown"}`}
                       title={d.health.ok
                         ? `${d.health.detail || "reachable"}${d.health.latency_ms != null ? ` (${d.health.latency_ms} ms)` : ""}`
                         : d.health.error || "unreachable"}
                     >
-                      ●
+                      <StatusDot status={d.health.ok ? "success" : d.health.ok === false ? "error" : "neutral"} />
                     </span>
                   ) : null}
                   {d.name} <Badge status="neutral">{d.type}</Badge>
@@ -230,19 +231,16 @@ function DelegateForm({
       </div>
 
       {!editing ? (
-        <div className="delegate-type-picker">
+        <RadioCardGroup
+          name="delegate-type"
+          min="160px"
+          value={type}
+          onValueChange={(v) => { setType(v); setProbe(null); setPreset(""); }}
+        >
           {spec.map((s) => (
-            <button
-              key={s.type}
-              type="button"
-              className={`delegate-type-tile${type === s.type ? " active" : ""}`}
-              onClick={() => { setType(s.type); setProbe(null); setPreset(""); }}
-            >
-              <span className="delegate-type-tile-label">{s.label}</span>
-              <span className="delegate-type-tile-blurb">{s.blurb}</span>
-            </button>
+            <RadioCard key={s.type} value={s.type} title={s.label} blurb={s.blurb} />
           ))}
-        </div>
+        </RadioCardGroup>
       ) : null}
 
       <label className="field">

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -5,6 +5,7 @@ import { Link2, Pencil, Play, Plus, Radar, Square, Trash2 } from "lucide-react";
 import { useState } from "react";
 
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
+import { Alert, StatusDot } from "@protolabsai/ui/data";
 import { EditableText, Switch } from "@protolabsai/ui/forms";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
@@ -155,9 +156,9 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
       />
       <div className="stage-body">
         {error ? (
-          <p className="fleet-error" role="alert">
-            {error}
-            {needsEnable ? (
+          <Alert
+            status="error"
+            action={needsEnable ? (
               <Button
                 variant="default"
                 disabled={enableDelegates.isPending || addDelegate.isPending}
@@ -165,8 +166,10 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                 data-testid="enable-delegates">
                 {enableDelegates.isPending ? "Enabling…" : "Enable delegates on this agent"}
               </Button>
-            ) : null}
-          </p>
+            ) : undefined}
+          >
+            {error}
+          </Alert>
         ) : null}
         {fleet.isLoading ? (
           <Empty>Loading the fleet…</Empty>
@@ -186,11 +189,9 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
               const isActive = (a.host ? "host" : a.id) === slug; // slug = stable id, not name
               return (
                 <li key={a.id} className={`fleet-row${isActive ? " active" : ""}`}>
-                  <span
-                    className={`fleet-dot ${a.running ? "running" : "stopped"}`}
-                    title={a.running ? "running" : "stopped"}
-                    aria-label={a.running ? "running" : "stopped"}
-                  />
+                  <span role="img" title={a.running ? "running" : "stopped"} aria-label={a.running ? "running" : "stopped"}>
+                    <StatusDot status={a.running ? "success" : "neutral"} pulse={a.running} />
+                  </span>
                   <div className="fleet-row-main">
                     <span className="fleet-name">
                       {renaming === a.id ? (
@@ -304,7 +305,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
               <ul className="fleet-list">
                 {discovered.map((d) => (
                   <li key={d.url} className="fleet-row">
-                    <span className="fleet-dot running" aria-hidden />
+                    <StatusDot status="success" />
                     <div className="fleet-row-main">
                       <span className="fleet-name">{d.name}</span>
                       <span className="fleet-meta">{d.url}</span>

--- a/apps/web/src/settings/NewAgentPanel.tsx
+++ b/apps/web/src/settings/NewAgentPanel.tsx
@@ -2,8 +2,9 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ArrowLeft } from "lucide-react";
 import { useState } from "react";
 
-import { RadioCard, RadioCardGroup } from "@protolabsai/ui/forms";
+import { Input, RadioCard, RadioCardGroup } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
+import { Alert } from "@protolabsai/ui/data";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 
 import { api } from "../lib/api";
@@ -53,11 +54,7 @@ export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) =>
         }
       />
       <div className="stage-body">
-        {error ? (
-          <p className="fleet-error" role="alert">
-            {error}
-          </p>
-        ) : null}
+        {error ? <Alert status="error">{error}</Alert> : null}
 
         <p className="fleet-section-label">Archetype</p>
         <RadioCardGroup name="archetype" min="160px" value={picked} onValueChange={setPicked}>
@@ -68,7 +65,7 @@ export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) =>
 
         <label className="field archetype-name-field">
           <span>Name</span>
-          <input
+          <Input
             value={name}
             autoFocus
             placeholder="e.g. ava, roxy, research-bot"

--- a/apps/web/src/settings/PluginsSection.tsx
+++ b/apps/web/src/settings/PluginsSection.tsx
@@ -1,7 +1,8 @@
 import "./plugins.css";
 
-import { Button } from "@protolabsai/ui/primitives";
+import { Badge, Button } from "@protolabsai/ui/primitives";
 import { Input } from "@protolabsai/ui/forms";
+import { Alert } from "@protolabsai/ui/data";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { AlertTriangle, DownloadCloud, Loader2, Package, Plus, RefreshCw, ShieldAlert, Trash2 } from "lucide-react";
 import { useState } from "react";
@@ -146,23 +147,24 @@ export function PluginsSection() {
 
       {/* Locked-but-missing plugins (fresh clone / restored data dir) → one-click sync */}
       {missing.length ? (
-        <div className="plugin-sync-banner" role="status">
-          <AlertTriangle size={14} />
-          <span>
-            {missing.length === 1 ? <><code>{missing[0].id}</code> is</> : <>{missing.length} plugins are</>}{" "}
-            in <code>plugins.lock</code> but missing on disk.
-          </span>
-          <Button
-            type="button"
-            variant="default"
-            size="sm"
-            disabled={sync.isPending}
-            onClick={() => { setStatus(""); sync.mutate(); }}
-            title="Re-clone every locked plugin at its pinned commit"
-          >
-            {sync.isPending ? <Loader2 size={13} className="spin" /> : <DownloadCloud size={13} />} Sync plugins
-          </Button>
-        </div>
+        <Alert
+          status="warning"
+          action={
+            <Button
+              type="button"
+              variant="default"
+              size="sm"
+              disabled={sync.isPending}
+              onClick={() => { setStatus(""); sync.mutate(); }}
+              title="Re-clone every locked plugin at its pinned commit"
+            >
+              {sync.isPending ? <Loader2 size={13} className="spin" /> : <DownloadCloud size={13} />} Sync plugins
+            </Button>
+          }
+        >
+          {missing.length === 1 ? <><code>{missing[0].id}</code> is</> : <>{missing.length} plugins are</>}{" "}
+          in <code>plugins.lock</code> but missing on disk.
+        </Alert>
       ) : null}
 
       {/* Installed list */}
@@ -245,7 +247,7 @@ function PluginRow({
           <strong>{m?.name || p.id}</strong>
           {m?.version ? <span className="plugin-ver">v{m.version}</span> : null}
           {local ? (
-            <span className="plugin-state" title="On disk but not in plugins.lock — a local copy. Not update-tracked.">local</span>
+            <span title="On disk but not in plugins.lock — a local copy. Not update-tracked."><Badge status="neutral">local</Badge></span>
           ) : (
             <PluginFreshness update={update} />
           )}
@@ -261,8 +263,8 @@ function PluginRow({
               {updating ? <Loader2 size={13} className="spin" /> : <RefreshCw size={13} />} Update
             </Button>
           ) : null}
-          <span className={`plugin-state ${p.enabled ? "on" : "off"}`}>{p.enabled ? "enabled" : "not enabled"}</span>
-          {!p.present ? <span className="plugin-state warn"><AlertTriangle size={12} /> missing — sync above</span> : null}
+          <Badge status={p.enabled ? "success" : "neutral"}>{p.enabled ? "enabled" : "not enabled"}</Badge>
+          {!p.present ? <Badge status="warning"><AlertTriangle size={12} /> missing — sync above</Badge> : null}
         </div>
         {m?.description ? <p className="plugin-desc">{m.description}</p> : null}
         <p className="plugin-meta">

--- a/apps/web/src/settings/QuickSetting.tsx
+++ b/apps/web/src/settings/QuickSetting.tsx
@@ -1,6 +1,6 @@
 import "./settings.css";
 
-import { Button } from "@protolabsai/ui/primitives";
+import { Badge, Button } from "@protolabsai/ui/primitives";
 import { Dialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
@@ -145,8 +145,8 @@ function QuickSettingDialog({
               <div className="setting-meta">
                 <label className="setting-label" htmlFor={`set-${field.key}`}>
                   {field.label}
-                  {field.restart ? <span className="setting-restart">restart</span> : null}
-                  {field.scope === "host" ? <span className="setting-restart">box-shared</span> : null}
+                  {field.restart ? <Badge status="warning">restart</Badge> : null}
+                  {field.scope === "host" ? <Badge status="info">box-shared</Badge> : null}
                 </label>
                 {field.description ? <p className="setting-desc">{field.description}</p> : null}
               </div>

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -375,7 +375,7 @@ function SettingRow({
               indicator a saved key looks identical to an empty one ("did it save?").
               Mirror the Delegates panel's "secret set" pill. */}
           {field.type === "secret" && field.is_set ? <Badge status="success">set</Badge> : null}
-          {field.restart ? <span className="setting-restart">restart</span> : null}
+          {field.restart ? <Badge status="warning">restart</Badge> : null}
         </label>
         {field.description ? <p className="setting-desc">{field.description}</p> : null}
         {inherit ? (

--- a/apps/web/src/settings/delegates.css
+++ b/apps/web/src/settings/delegates.css
@@ -12,24 +12,8 @@
   gap: 12px;
 }
 .delegate-form-head { display: flex; align-items: center; justify-content: space-between; }
-.delegate-type-picker { display: grid; grid-template-columns: repeat(auto-fit, minmax(160px, 1fr)); gap: 8px; }
-.delegate-type-tile {
-  display: grid;
-  gap: 3px;
-  text-align: left;
-  padding: 10px 12px;
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  background: var(--bg);
-  color: var(--fg);
-  cursor: pointer;
-}
-.delegate-type-tile:hover { border-color: var(--brand-violet); }
-.delegate-type-tile.active { border-color: var(--brand-violet); background: color-mix(in srgb, var(--brand-violet) 12%, var(--bg)); }
-.delegate-type-tile-label { font-size: 13px; font-weight: 600; }
-.delegate-type-tile-blurb { font-size: 11px; color: var(--fg-muted); }
+/* The delegate-type picker is the DS RadioCardGroup/RadioCard now (matches the
+   archetype picker in NewAgentPanel) — the hand-rolled .delegate-type-tile* tiles
+   are retired. */
 .delegate-field-help { font-size: 11px; color: var(--fg-muted); }
-.delegate-health { font-size: 10px; line-height: 1; }
-.delegate-health.ok { color: var(--success); }
-.delegate-health.down { color: var(--error); }
-.delegate-health.unknown { color: var(--fg-muted); }
+/* .delegate-health* retired — the row health indicator is a DS <StatusDot> now. */

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -36,18 +36,15 @@
 
 /* Plugins panel (ADR 0027) — install from a git URL, under Settings → Integrations. */
 .plugin-install-form { display: flex; gap: 8px; margin: 10px 0; flex-wrap: wrap; }
-.plugin-install-form input { flex: 1; min-width: 220px; padding: 7px 10px; background: var(--bg-raised); border: 1px solid var(--border); border-radius: 7px; color: var(--fg); font-size: 13px; }
+/* DS Input owns its chrome; only the flex sizing is ours (don't re-skin .pl-input). */
+.plugin-install-form input { flex: 1; min-width: 220px; }
 .plugin-install-status { font-size: 12px; color: var(--fg-secondary); margin: 4px 0 10px; }
-.plugin-sync-banner { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; margin: 0 0 10px; padding: 8px 10px; font-size: 12px; border-radius: 7px; background: color-mix(in srgb, var(--warning) 10%, transparent); border: 1px solid color-mix(in srgb, var(--warning) 35%, transparent); color: var(--fg-secondary); }
-.plugin-sync-banner > svg { color: var(--warning); flex-shrink: 0; }
+/* .plugin-sync-banner retired — the locked-but-missing notice is a DS <Alert status="warning"> now. */
 .plugin-list { list-style: none; margin: 0; padding: 0; display: flex; flex-direction: column; gap: 8px; }
 .plugin-row-main { flex: 1; min-width: 0; }
 .plugin-row-title { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 .plugin-ver { font-size: 11px; color: var(--fg-muted); }
-.plugin-state { font-size: 10px; text-transform: uppercase; letter-spacing: .04em; padding: 1px 6px; border-radius: 999px; }
-.plugin-state.on { background: color-mix(in srgb, var(--success) 15%, transparent); color: var(--success); }
-.plugin-state.off { background: var(--bg-hover); color: var(--fg-muted); }
-.plugin-state.warn { background: color-mix(in srgb, var(--warning) 15%, transparent); color: var(--warning); display: inline-flex; align-items: center; gap: 3px; }
+/* .plugin-state* retired — enabled / not-enabled / missing / local are DS <Badge>s now. */
 .plugin-desc { font-size: 12px; color: var(--fg-secondary); margin: 4px 0; }
 .plugin-meta { font-size: 11px; color: var(--fg-muted); margin: 2px 0; overflow: hidden; text-overflow: ellipsis; }
 .plugin-review { font-size: 11px; color: var(--fg-muted); margin: 4px 0 0; display: flex; flex-wrap: wrap; gap: 4px 12px; }

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -157,16 +157,7 @@
   font-size: 0.86rem;
   color: var(--fg);
 }
-.setting-restart {
-  padding: 1px 6px;
-  border-radius: 999px;
-  background: color-mix(in srgb, var(--warning) 16%, transparent);
-  border: 1px solid color-mix(in srgb, var(--warning) 30%, transparent);
-  color: var(--warning);
-  font-size: 0.62rem;
-  letter-spacing: 0.05em;
-  text-transform: uppercase;
-}
+/* .setting-restart retired — the "restart" / "box-shared" markers are DS <Badge>s now. */
 .setting-desc {
   margin: 3px 0 0;
   font-size: 0.76rem;
@@ -189,25 +180,11 @@
   color: var(--warning);
 }
 .setting-control { min-width: 0; }
-.setting-input {
-  width: 100%;
-  box-sizing: border-box;
-  padding: 11px 12px;
-  background: var(--bg);
-  border: 1px solid var(--border);
-  border-radius: 6px;
-  color: var(--fg);
-  font-family: var(--font-mono);
-  font-size: 0.8rem;
-}
-.setting-input:focus {
-  outline: none;
-  border-color: var(--brand-violet);
-}
-.setting-textarea {
-  resize: vertical;
-  line-height: 1.45;
-}
+/* The DS control (Input/Select/Combobox/Textarea → .pl-input) owns its chrome,
+   sizing, and accent focus ring. The only deviation we keep is mono for the
+   technical settings values (model names, API bases, paths), which read better
+   monospaced — we no longer re-border, re-background, or override the focus. */
+.setting-input { font-family: var(--font-mono); }
 .setting-toggle {
   display: inline-flex;
   align-items: center;

--- a/apps/web/src/settings/telemetry.css
+++ b/apps/web/src/settings/telemetry.css
@@ -31,21 +31,7 @@
 .telemetry-table tr.turn-failed td {
   color: var(--error);
 }
-.turn-state {
-  font-size: 11px;
-  padding: 1px 7px;
-  border-radius: 999px;
-  border: 1px solid var(--border);
-  color: var(--fg-muted);
-}
-.turn-state-completed {
-  color: var(--success);
-  border-color: color-mix(in srgb, var(--success) 40%, transparent);
-}
-.turn-state-failed {
-  color: var(--error);
-  border-color: color-mix(in srgb, var(--error) 40%, transparent);
-}
+/* .turn-state* retired — the State cell is a DS <Badge> (success/error/neutral) now. */
 
 /* Telemetry insights (ADR 0006 Slice 4 — advise-only) */
 .telemetry-insights {

--- a/apps/web/src/telemetry/TelemetrySurface.tsx
+++ b/apps/web/src/telemetry/TelemetrySurface.tsx
@@ -1,7 +1,7 @@
 import "../settings/telemetry.css";
 
 import { Table, THead, TBody, Tr, Th, Td } from "@protolabsai/ui/data";
-import { Button, Empty } from "@protolabsai/ui/primitives";
+import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { useSuspenseQuery } from "@tanstack/react-query";
 
 import {
@@ -158,7 +158,7 @@ function TelemetryBody() {
                       <Td>{usd(t.cost_usd)}</Td>
                       <Td>{ms(t.duration_ms)}</Td>
                       <Td>{t.llm_calls}/{t.tool_calls}</Td>
-                      <Td><span className={`turn-state turn-state-${t.state}`}>{t.state}</span></Td>
+                      <Td><Badge status={t.state === "completed" ? "success" : t.state === "failed" ? "error" : "neutral"}>{t.state}</Badge></Td>
                     </Tr>
                   ))}
                 </TBody>


### PR DESCRIPTION
## What

Settings, fleet, and tools surfaces had drifted off `@protolabsai/ui` — hand-rolled re-skins where a DS primitive already existed, plus a frozen accent that didn't track the theme. This brings them back onto the DS.

## Changes

**🔴 Accent tracks the theme** — `--brand-violet`/`-light` were hardcoded `#7c3aed`/`#a78bfa`; now aliased to `var(--pl-color-accent)`. Settings focus rings, the dirty-edit marker, selected cards, and group titles move with the active theme (incl. per-agent ThemePanel themes) and match the DS accent everywhere else.

**🟠 Stop fighting the DS form controls** — `.setting-input` reduced from a full re-skin (border/bg/radius/padding + hardcoded violet focus) to *just* mono for technical values; the DS `Input/Select/Combobox/Textarea` own their chrome + accent focus. Same for the `.plugin-install-form input` override.

**🟠 Delegates type picker** → DS `RadioCardGroup`/`RadioCard` (matches the sibling `NewAgentPanel`), deleting the hand-rolled `.delegate-type-tile` CSS.

**🟡 Retired the stragglers** (the `#832`-migration leftovers):
- status dots → `StatusDot` (delegate health, fleet rows + discovery, topbar `FleetSwitcher`)
- pills → `Badge` (`restart`/`box-shared`, plugin `enabled`/`local`/`missing`, telemetry turn state)
- error/warning banners → `Alert` (fleet + new-agent errors, plugins sync banner)
- the hand-rolled `.fleet-dot` is now fully retired

**🛠️ ToolsPanel** — flat category list → collapsible DS `Accordion` sections with count + source `Badge`s; a search auto-expands matches.

**Bonus** — `NewAgentPanel`'s lone raw `<input>` → DS `Input`.

Net **−164 / +127** lines, ~70 lines of bespoke CSS deleted.

## Verification

`tsc` (app + node configs) · 94 unit tests · `vite build` · CSS-comment lint · e2e across delegates / fleet / settings / quick-settings / plugin-install / telemetry / navigation / layout — all green. The 3 e2e selectors coupled to retired classes were updated.

## Deferred (follow-ups)

- `@protolabsai/design` 0.5.1→0.6.0 dedupe (dep bump; deserves its own visual-verification pass)
- P3: `.field`→DS `Field`, `.metric`→DS `Stat`/`Stats` (`Stat` lacks an icon slot — wants a small DS enhancement first)

🤖 Generated with [Claude Code](https://claude.com/claude-code)