### PR TITLE
docs: make CLAUDE.md a useful pointer + cross-file architecture orientation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,7 +1,68 @@
 # CLAUDE.md
 
-Agent instructions for this repo live in **[PROTO.md](./PROTO.md)** — the
-canonical instruction file for every agent (human or AI) working in protoAgent.
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-Read PROTO.md before editing: it has the run commands, the must-pass-before-PR
-gates (mirroring CI), and the house rules / gotchas that actually recur.
+## Canonical instructions live in PROTO.md
+
+**[PROTO.md](./PROTO.md) is the single source of truth** for working in this repo — and
+it asks you to *edit PROTO.md, not this file*, so the agent guidance has one home and
+doesn't drift. Read it before editing. It owns:
+
+- **Run commands** — `python -m server` (never `python server.py`; retired in ADR 0023);
+  `scripts/dev.sh` for the isolated dev instance; `uv sync` (Python) / `npm ci` (console).
+- **The must-pass-before-PR gates** — the table mirroring `.github/workflows/checks.yml`
+  (`ruff check .`, `lint-imports`, `python -m pytest tests/ -q`, `python scripts/live_smoke.py`,
+  `npm run test:unit`/`test:e2e --workspace @protoagent/web`). Run them locally before the PR.
+- **The gotchas that actually recur** — `F841` fails CI and isn't auto-fixed; the
+  `graph/config.py` ↔ `tests/test_config_roundtrip.py` golden field map; the import-layering
+  contract; `a2a_impl/` (not `a2a/`); empty `current_session_id()` inside tool bodies; the
+  `*/`-in-CSS-comment minifier trap; controlled DS AppShell widths.
+
+[README.md](./README.md) is the feature/capability map (what ships, where it lives, which
+ADR governs it). Subsystem contracts are MADR ADRs in `docs/adr/NNNN-*.md` — check the
+relevant ADR before changing a subsystem's behavior.
+
+## Big picture (the cross-file model)
+
+protoAgent is a **LangGraph agent runtime**: a Python core plus a TypeScript operator
+console, extended by drop-in plugins rather than by forking.
+
+**Request flow.** A consumer (A2A JSON-RPC over `/a2a`, the OpenAI-compatible `/v1` API,
+or the React console over `/api`) hits the **FastAPI server** (`server/`, with the
+operator REST surface in `operator_api/`). The server **never calls the model directly** —
+it submits the message to **`graph/agent.py`** (a LangGraph `create_agent`), which owns the
+tool loop, subagent `task()` delegation (`graph/subagents/`), and the `<scratch_pad>`/
+`<output>` structured-output protocol. The graph talks to an **OpenAI-compatible LiteLLM
+gateway** (`graph/llm.py`) — *model selection is gateway config, not code*.
+
+**Two languages, one repo.** Python is the core (`server/ graph/ a2a_impl/ tools/
+knowledge/ scheduler/ observability/ security/ infra/ runtime/ events/ operator_api/`);
+TypeScript is the console (`apps/web`, the `@protoagent/web` npm workspace, served prebuilt
+from `apps/web/dist`).
+
+**Import layering is an architectural invariant, not a style choice** (enforced by
+`lint-imports`): `graph/` and the infra packages must **never** import `server/` or
+`operator_api/`, and `operator_api/` must never import `server/`. The `ignore_imports`
+lists in `pyproject.toml` are a burndown list — remove from them, never add. (Details and
+the full rule set: PROTO.md.)
+
+**Extensibility without forking.** `plugins/` holds drop-in packages (each a repo with a
+`protoagent.plugin.yaml` manifest) that add tools, `SKILL.md` skills, subagents, workflows,
+FastAPI routes, background surfaces, managed MCP servers, **console rail views**, and their
+own config/secrets/Settings. They're git-URL-installable and pinned in `plugins.lock`.
+First-party examples live in `plugins/` (off by default). Installed/working-tree plugin
+state under `config/plugins/*` and `plugins.lock` churn is expected dev-local state — don't
+re-commit it.
+
+**Instance scoping (ADR 0004).** The default/prod instance is `config/` + `~/.protoagent`
+on `:7870`; the sandbox dev instance (`scripts/dev.sh`, `PROTOAGENT_INSTANCE=dev`) is
+`config/dev/` + `~/.protoagent/{dev,*/dev}` on `:7871`, seeded from your default config but
+with separate chat/beads/knowledge. Use the dev instance for feature testing.
+`scripts/dev-reset.sh` wipes only the sandbox.
+
+## Forking note
+
+This is a template repo: shared-runtime fixes (`server/`, `graph/agent.py`, extension
+support, release pipeline) land here; domain-specific agent behavior belongs in a fork,
+where a fork is close to rewriting `config/SOUL.md`, `graph/prompts.py`, and
+`tools/lg_tools.py` and little else.


### PR DESCRIPTION
## Summary

`CLAUDE.md` was a two-line pointer to `PROTO.md`. This keeps it a pointer (PROTO.md stays the single source of truth — editing happens there, not here) but makes it actually useful for a fresh agent landing in the repo, without duplicating PROTO.md's content (so the two files can't drift).

What the updated `CLAUDE.md` adds:

- **Names what PROTO.md owns** — run commands, the must-pass-before-PR gate table, and the recurring gotchas — with one-line teasers, so an agent knows what's there and where, without restating the lists.
- **A compact "big picture"** of the cross-file mental model that today requires reading README + PROTO + several ADRs to assemble:
  - request flow (A2A `/a2a` · OpenAI `/v1` · console `/api` → FastAPI `server/`+`operator_api/` → `graph/agent.py` LangGraph → LiteLLM gateway; model choice is config, not code),
  - the Python-core / TypeScript-console split,
  - the import-layering invariant (`graph/`+infra never import `server/`/`operator_api/`, enforced by `lint-imports`),
  - the plugin extensibility model + the "don't re-commit `config/plugins/*` / `plugins.lock`" dev-local rule,
  - instance scoping (prod `:7870` vs dev `:7871`, ADR 0004).
- A short forking note (shared runtime here; domain logic in a fork).

No changes to the gate/gotcha lists themselves — those remain solely in PROTO.md.

## Notes

- Docs-only change; no code, so no test impact (per PROTO.md's test-free-change exception).
- Generated via `/init`, then trimmed to respect this repo's "PROTO.md is canonical, CLAUDE.md is a thin pointer" convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)