### PR TITLE
chore: release v0.50.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.50.0] - 2026-06-18
+
 ### Added
 - **Skills CRUD in the console.** Settings ▸ Workspace ▸ Skills now lets you
   **author, edit, and delete** skills — not just browse, delete, and promote.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.49.1"
+version = "0.50.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "v0.50.0",
+    "date": "2026-06-18",
+    "changes": [
+      "Skills CRUD in the console."
+    ]
+  },
+  {
     "version": "v0.49.1",
     "date": "2026-06-18",
     "changes": []


### PR DESCRIPTION
Automated version bump to `v0.50.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.50.0 -m 'Release v0.50.0' && git push origin v0.50.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).