### PR TITLE
fix(desktop): bundle plugin-catalog.json — Discover shows "0 official plugins" in the frozen app

### DIFF
--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -43,6 +43,10 @@ BUNDLED_DATA: list[tuple[str, str]] = [
     ("pyproject.toml", "."),
     ("config/langgraph-config.example.yaml", "config"),
     ("config/SOUL.md", "config"),
+    # The curated Discover directory (ADR 0059). The catalog route reads it from
+    # REPO_ROOT/config (→ _MEIPASS/config when frozen); without it the desktop app's
+    # Plugins ▸ Discover shows "0 official plugins" (every entry is unreachable).
+    ("config/plugin-catalog.json", "config"),
     ("config/soul-presets", "config/soul-presets"),
     ("static", "static"),
     # Bundled first-party plugins (ADR 0018/0019). Loaded by file path (importlib)


### PR DESCRIPTION
**Symptom:** in the desktop app, **Plugins ▸ Discover** shows *"0 official plugins / No plugins match"* — the curated directory is empty. (Works fine in the web/server build.)

**Cause:** the catalog route (`/api/plugins/catalog`) reads `config/plugin-catalog.json` from `REPO_ROOT/config` (which resolves to `_MEIPASS/config` in the frozen sidecar). But `build_sidecar.py`'s `BUNDLED_DATA` listed `langgraph-config.example.yaml`, `SOUL.md`, `soul-presets`, and `static` — **not `plugin-catalog.json`**. The build loop silently skips files not in the list, so the catalog never made it into the bundle → the route finds nothing → all **11** curated plugins (discord, terminal, artifact, agent_browser, …) are unreachable.

**Fix:** add `("config/plugin-catalog.json", "config")` to `BUNDLED_DATA`, alongside the other bundled config defaults.

The plugins *tree* (`("plugins", "plugins")`) was already bundled, so first-party plugins still **load** — only the **Discover catalog** display was missing.

**Delivery:** build-only change; reaches users on the next **desktop build** (a `.0` minor tag, or a manual `desktop-build` dispatch). Can't be unit-tested without a full PyInstaller build — verified by the bundle list + that the catalog file exists (3.8 KB, 11 plugins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)