### PR TITLE
feat(web): version badge + "built by protoLabs.studio" footer in the app drawer

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -11,6 +11,7 @@ export const RUNTIME_STATUS = {
   setup_complete: true,
   instance_uid: "mock-uid-1", // TenantGuard keys per-origin client state on this
   graph_loaded: true,
+  version: "9.9.9",
   project: { path: "/tmp/e2e-project", allowed_dirs: ["/tmp/e2e-project"] },
   model: {
     provider: "openai",

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -16,6 +16,11 @@ test("the header hamburger opens the app drawer → Global settings overlay", as
   await expect(drawer.getByRole("button", { name: "Telemetry", exact: true })).toBeVisible();
   await expect(drawer.getByRole("link", { name: "Docs" })).toBeVisible();
   await expect(drawer.getByRole("link", { name: "GitHub" })).toBeVisible();
+  // Footer: version badge + protoLabs.studio branding link.
+  await expect(drawer.getByText("v9.9.9", { exact: true })).toBeVisible();
+  const built = drawer.getByRole("link", { name: /built by protoLabs\.studio/i });
+  await expect(built).toBeVisible();
+  await expect(built).toHaveAttribute("href", "https://protolabs.studio");
 
   await drawer.getByRole("button", { name: "Global settings", exact: true }).click();
   const dialog = page.getByRole("dialog", { name: "Global settings" });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -993,6 +993,7 @@ export function App() {
       activeSurface={isMobile ? mobileActive : leftActive}
       onSelectSurface={setMobileActive}
       onOpenGlobal={openGlobalSettings}
+      version={runtime?.version}
     />
     {/* Global settings overlay — opened from the drawer or a palette deep-link (store-driven). */}
     <SettingsOverlay

--- a/apps/web/src/app/AppDrawer.tsx
+++ b/apps/web/src/app/AppDrawer.tsx
@@ -22,6 +22,7 @@ export function AppDrawer({
   activeSurface,
   onSelectSurface,
   onOpenGlobal,
+  version,
 }: {
   open: boolean;
   onClose: () => void;
@@ -30,6 +31,7 @@ export function AppDrawer({
   activeSurface: string;
   onSelectSurface: (id: string) => void;
   onOpenGlobal: (section?: string) => void;
+  version?: string;
 }) {
   useEffect(() => {
     if (!open) return;
@@ -111,6 +113,19 @@ export function AppDrawer({
             </a>
           </section>
         </div>
+        <footer className="app-drawer-foot">
+          {version ? <span className="app-drawer-version">v{version}</span> : null}
+          {/* P4: the wordmark is sacred — protoLabs.studio, exactly. */}
+          <a
+            className="app-drawer-built"
+            href="https://protolabs.studio"
+            target="_blank"
+            rel="noreferrer"
+            onClick={onClose}
+          >
+            built by <strong>protoLabs.studio</strong>
+          </a>
+        </footer>
       </aside>
     </div>
   );

--- a/apps/web/src/app/app-drawer.css
+++ b/apps/web/src/app/app-drawer.css
@@ -83,6 +83,38 @@
   color: var(--fg-muted);
 }
 
+/* Footer: version badge + "built by protoLabs.studio" branding (pinned to the bottom). */
+.app-drawer-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 10px 14px;
+  border-top: 1px solid var(--border);
+  font-size: 12px;
+}
+.app-drawer-version {
+  display: inline-flex;
+  align-items: center;
+  padding: 2px 8px;
+  border: 1px solid var(--border);
+  border-radius: 999px;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+}
+.app-drawer-built {
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+.app-drawer-built strong {
+  color: var(--fg);
+  font-weight: 600;
+}
+.app-drawer-built:hover,
+.app-drawer-built:hover strong {
+  color: var(--pl-color-brand-lavender);
+}
+
 /* The mobile "more" is unified into THIS drawer (the header hamburger), so hide the
    DS bottom-bar's own "More" button — the bottom bar stays the quick-bar only. The
    .pl-mobilenav only mounts under the mobile breakpoint, so no media query is needed. */


### PR DESCRIPTION
Adds a footer to the header-hamburger **app drawer** (the slideout sheet):
- A **version pill** (`v{runtime.version}`) — omitted until the runtime reports a version.
- A **"built by protoLabs.studio"** link → `https://protolabs.studio`, using the sacred wordmark (P4: lowercase `p`, capital `L`, the dot is part of the wordmark).

App threads `runtime.version` into `<AppDrawer>`; styling uses DS tokens (subtle muted footer, brand-lavender on hover).

**Verification:** the drawer E2E now asserts the `v9.9.9` badge + the `protoLabs.studio` link and its `href` (mock runtime status gains a `version`). Build + 94 web + **107 E2E** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)