### PR TITLE
chore(web): drop the verbose skills-surface footer

### DIFF
--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1678,7 +1678,6 @@ textarea {
   font-size: 11.5px; color: var(--fg-muted); white-space: nowrap;
   font-variant-numeric: tabular-nums;
 }
-.playbook-foot { margin-top: 16px; font-size: 11.5px; color: var(--fg-muted); display: flex; align-items: center; gap: 6px; }
 
 /* Knowledge store curation (add / edit / delete a chunk from the console). */
 .knowledge-chunk-form { display: flex; flex-direction: column; gap: 8px; flex: 1; min-width: 0; margin: 8px 0; }

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -1,6 +1,6 @@
 import { Input, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { ArrowUpToLine, BookMarked, Library, Pencil, Pin, Plus, Share2, Sparkles, Trash2 } from "lucide-react";
+import { ArrowUpToLine, Library, Pencil, Pin, Plus, Share2, Sparkles, Trash2 } from "lucide-react";
 
 import { useEffect, useMemo, useState } from "react";
 
@@ -461,12 +461,6 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
           ? `Remove "${pending.name}"${pending.origin === "user" ? " — its SKILL.md is deleted too." : "."}`
           : undefined}
       </ConfirmDialog>
-
-      <p className="playbook-foot">
-        <BookMarked size={13} /> Skills (`SKILL.md`) are methodology the agent <strong>retrieves</strong> into
-        context — they advise, they don't run. For deterministic step-by-step runs
-        across subagents, see <strong>Studio → Workflows</strong>.
-      </p>
     </section>
   );
 }


### PR DESCRIPTION
The skills surface carried a footer paragraph:

> Skills (`SKILL.md`) are methodology the agent **retrieves** into context — they advise, they don't run. For deterministic step-by-step runs across subagents, see **Studio → Workflows**.

It duplicated the surface kicker ("methodology the agent retrieves into context") and just cluttered the view. Removed it, plus the now-unused `BookMarked` import and the orphaned `.playbook-foot` CSS rule.

**Verification:** build + 94 web + playbooks/navigation E2E green (no test asserted the footer).

🤖 Generated with [Claude Code](https://claude.com/claude-code)