### PR TITLE
feat(web): author/edit skills in a modal dialog instead of an in-panel form

### DIFF
--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -34,6 +34,24 @@ test("Agent → Skills lists pinned + learned skills and supports search", async
   await expect(surface.getByText("web-research")).toBeHidden();
 });
 
+test("the + button opens the New skill DIALOG, not an inline panel form", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "Skills", exact: true }).click();
+  const surface = page.getByTestId("playbooks-surface");
+  await expect(surface).toBeVisible();
+
+  // Closed: the form isn't anywhere yet.
+  await expect(surface.getByLabel("skill name")).toHaveCount(0);
+
+  await page.getByTestId("playbook-new").click();
+  // It opens as a MODAL dialog (role=dialog) — an inline panel form wouldn't be one.
+  const dialog = page.getByRole("dialog", { name: "New skill" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.getByLabel("skill name")).toBeVisible();
+  await expect(dialog.getByRole("button", { name: "Create skill" })).toBeVisible();
+});
+
 test("layered skills show tier badges and promote a private skill to the commons", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -4,7 +4,7 @@ import { ArrowUpToLine, Library, Pencil, Pin, Plus, Share2, Sparkles, Trash2 } f
 
 import { useEffect, useMemo, useState } from "react";
 
-import { ConfirmDialog } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, Dialog } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { RefreshButton } from "../app/ui-kit";
 import { api } from "../lib/api";
@@ -198,7 +198,7 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
   function openCreate() {
     setEditingId(null);
     setDraft(EMPTY_DRAFT);
-    setAdding((v) => !v);
+    setAdding(true);
   }
 
   async function startEdit(p: Playbook) {
@@ -329,17 +329,6 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
           onChange={(e) => setQuery(e.target.value)}
         />
 
-        {adding ? (
-          <SkillForm
-            draft={draft}
-            setDraft={setDraft}
-            onSave={() => void save()}
-            onCancel={cancelForm}
-            saving={saving}
-            saveLabel="Create skill"
-          />
-        ) : null}
-
         {!enabled ? (
           <Empty>The skills index is disabled (set <code>skills.enabled: true</code>).</Empty>
         ) : filtered.length === 0 ? (
@@ -355,17 +344,7 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
           <ul className="playbook-list">
             {filtered.map((p) => (
               <li key={p.id} className="playbook-card">
-                {editingId === p.id ? (
-                  <SkillForm
-                    draft={draft}
-                    setDraft={setDraft}
-                    onSave={() => void save()}
-                    onCancel={cancelForm}
-                    saving={saving}
-                    saveLabel="Save changes"
-                  />
-                ) : (
-                  <>
+                <>
                     <div className="playbook-main">
                       <div className="playbook-title">
                         <SourceBadge p={p} />
@@ -441,8 +420,7 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
                         </span>
                       )}
                     </div>
-                  </>
-                )}
+                </>
               </li>
             ))}
           </ul>
@@ -461,6 +439,24 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
           ? `Remove "${pending.name}"${pending.origin === "user" ? " — its SKILL.md is deleted too." : "."}`
           : undefined}
       </ConfirmDialog>
+
+      {/* Author / edit a skill in a modal — keeps the list intact instead of taking
+          over the panel. One form for both; the title + save label adapt. */}
+      <Dialog
+        open={adding || editingId !== null}
+        onClose={cancelForm}
+        title={editingId !== null ? "Edit skill" : "New skill"}
+        width="min(640px, 94vw)"
+      >
+        <SkillForm
+          draft={draft}
+          setDraft={setDraft}
+          onSave={() => void save()}
+          onCancel={cancelForm}
+          saving={saving}
+          saveLabel={editingId !== null ? "Save changes" : "Create skill"}
+        />
+      </Dialog>
     </section>
   );
 }


### PR DESCRIPTION
The "add new skill" flow (and editing) used to take over the panel — `+` expanded an inline form at the top of the list, and editing a row swapped the row for the form. Move both into **one shared modal `Dialog`**, so the list stays put while you author or edit.

- A single `<Dialog>` opens when `adding || editingId !== null`; the title + save label adapt (**New skill / Create skill** vs **Edit skill / Save changes**).
- `+` now just opens it (no toggle); dropped the two inline `<SkillForm>` render sites.

**Verification:** new E2E asserts `+` opens a `role="dialog"` titled "New skill" with the form + Create button. Build + 94 web + **108 E2E** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)