### PR TITLE
docs: group each Diátaxis section by domain + stale-fix pass

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -43,61 +43,71 @@ export default defineConfig({
       { text: "Explanation", link: "/explanation/" },
     ],
 
+    // Each Diátaxis section's sidebar is grouped by the SAME domain taxonomy
+    // (Getting started → Agent core → Skills → Knowledge → A2A/fleet → Tools/plugins
+    // → Console → Operate → Forks), so "where does X live" reads the same everywhere.
+    // A section only lists the domains it actually has pages for.
     sidebar: {
       "/tutorials/": [
+        { text: "Tutorials", items: [{ text: "Overview", link: "/tutorials/" }] },
         {
-          text: "Tutorials",
-          items: [
-            { text: "Overview", link: "/tutorials/" },
-            { text: "Spin up your first agent", link: "/tutorials/first-agent" },
-            { text: "Write your first tool", link: "/tutorials/first-tool" },
-          ],
+          text: "Getting started",
+          collapsed: false,
+          items: [{ text: "Spin up your first agent", link: "/tutorials/first-agent" }],
+        },
+        {
+          text: "Tools, MCP & plugins",
+          collapsed: false,
+          items: [{ text: "Write your first tool", link: "/tutorials/first-tool" }],
         },
       ],
 
       "/guides/": [
+        { text: "How-To Guides", items: [{ text: "Overview", link: "/guides/" }] },
         {
-          text: "How-To Guides",
-          items: [{ text: "Overview", link: "/guides/" }],
-        },
-        {
-          text: "Set up & deploy",
+          text: "Getting started",
           collapsed: false,
           items: [
+            { text: "Fork the template (fast path)", link: "/guides/fork-the-template" },
             { text: "Customize & deploy", link: "/guides/customize-and-deploy" },
-            { text: "Fork checklist (fast path)", link: "/guides/fork-the-template" },
-            { text: "Deploy via GHCR", link: "/guides/deploy" },
-            { text: "Releasing", link: "/guides/releasing" },
           ],
         },
         {
-          text: "Agent capabilities",
+          text: "Agent core & runtime",
           collapsed: false,
           items: [
-            { text: "Add a custom skill (A2A card)", link: "/guides/add-a-skill" },
-            { text: "Skills (SKILL.md)", link: "/guides/skills" },
-            { text: "Configure subagents", link: "/guides/subagents" },
-            { text: "Reusable workflows", link: "/guides/workflows" },
             { text: "Goal mode", link: "/guides/goal-mode" },
             { text: "Schedule future work", link: "/guides/scheduler" },
+            { text: "Middleware", link: "/guides/middleware" },
+            { text: "Run on a coding agent (ACP runtime)", link: "/guides/acp-runtime" },
           ],
         },
         {
-          text: "Tools & coding agents",
+          text: "Skills, subagents & workflows",
+          collapsed: false,
+          items: [
+            { text: "Skills (SKILL.md)", link: "/guides/skills" },
+            { text: "Add a custom skill (A2A card)", link: "/guides/add-a-skill" },
+            { text: "Configure subagents", link: "/guides/subagents" },
+            { text: "Reusable workflows", link: "/guides/workflows" },
+          ],
+        },
+        {
+          text: "A2A, fleet & delegates",
+          collapsed: false,
+          items: [
+            { text: "Delegates (agents & endpoints)", link: "/guides/delegates" },
+            { text: "Spawn CLI coding agents (ACP)", link: "/guides/coding-agents" },
+            { text: "Fleet (many agents on one host)", link: "/guides/fleet" },
+            { text: "Portfolio (one PM across boards)", link: "/guides/portfolio" },
+          ],
+        },
+        {
+          text: "Tools, MCP & plugins",
           collapsed: false,
           items: [
             { text: "Connect MCP servers", link: "/guides/mcp" },
-            { text: "Spawn CLI coding agents (ACP)", link: "/guides/coding-agents" },
-            { text: "Run on a coding agent (ACP runtime)", link: "/guides/acp-runtime" },
-            { text: "Delegates (agents & endpoints)", link: "/guides/delegates" },
-          ],
-        },
-        {
-          text: "Plugins & channels",
-          collapsed: false,
-          items: [
             { text: "Plugins", link: "/guides/plugins" },
-            { text: "Middleware", link: "/guides/middleware" },
             { text: "Building a plugin view", link: "/guides/building-react-plugin-views" },
             { text: "Build a communication plugin", link: "/guides/communication-plugins" },
             { text: "Install & publish plugins (git URLs)", link: "/guides/plugin-registry" },
@@ -105,11 +115,19 @@ export default defineConfig({
           ],
         },
         {
-          text: "Run & operate",
+          text: "Console & UI",
+          collapsed: false,
+          items: [
+            { text: "Operator console (React/Tauri)", link: "/guides/react-tauri-ui" },
+            { text: "Run headless (API + A2A)", link: "/guides/headless" },
+          ],
+        },
+        {
+          text: "Operate & deploy",
           collapsed: true,
           items: [
-            { text: "Run headless (API + A2A)", link: "/guides/headless" },
-            { text: "Operator console (React/Tauri)", link: "/guides/react-tauri-ui" },
+            { text: "Deploy via GHCR", link: "/guides/deploy" },
+            { text: "Releasing", link: "/guides/releasing" },
             { text: "Run multiple instances", link: "/guides/multi-instance" },
             { text: "Sandboxing & egress", link: "/guides/sandboxing" },
             { text: "Wire Langfuse + Prometheus", link: "/guides/observability" },
@@ -126,45 +144,68 @@ export default defineConfig({
         },
       ],
 
-      "/how-to/": [
+      "/reference/": [
+        { text: "Reference", items: [{ text: "Overview", link: "/reference/" }] },
         {
-          text: "How-To",
+          text: "Agent core & runtime",
+          collapsed: false,
           items: [
-            { text: "Build a plugin view", link: "/how-to/build-a-plugin-view" },
+            { text: "Configuration", link: "/reference/configuration" },
+            { text: "Environment variables", link: "/reference/environment-variables" },
           ],
         },
-      ],
-
-      "/reference/": [
         {
-          text: "Reference",
+          text: "A2A, fleet & delegates",
+          collapsed: false,
           items: [
-            { text: "Overview", link: "/reference/" },
             { text: "A2A endpoints", link: "/reference/a2a-endpoints" },
             { text: "Agent card", link: "/reference/agent-card" },
-            { text: "Starter tools", link: "/reference/starter-tools" },
-            { text: "Environment variables", link: "/reference/environment-variables" },
-            { text: "Configuration", link: "/reference/configuration" },
             { text: "Extensions", link: "/reference/extensions" },
           ],
+        },
+        {
+          text: "Tools, MCP & plugins",
+          collapsed: false,
+          items: [{ text: "Starter tools", link: "/reference/starter-tools" }],
         },
       ],
 
       "/explanation/": [
+        { text: "Explanation", items: [{ text: "Overview", link: "/explanation/" }] },
         {
-          text: "Explanation",
+          text: "Agent core & runtime",
+          collapsed: false,
           items: [
-            { text: "Overview", link: "/explanation/" },
             { text: "Architecture", link: "/explanation/architecture" },
-            { text: "Security & trust model", link: "/explanation/security-and-trust" },
-            { text: "Memory & knowledge store", link: "/explanation/memory-and-knowledge" },
-            { text: "A2A protocol", link: "/explanation/a2a-protocol" },
-            { text: "Cost & trace propagation", link: "/explanation/cost-and-trace" },
-            { text: "Tuning & cost", link: "/explanation/tuning-and-cost" },
             { text: "Output protocol", link: "/explanation/output-protocol" },
             { text: "LiteLLM gateway", link: "/explanation/litellm-gateway" },
-            { text: "Architecture decisions (ADRs)", link: "/adr/" },
           ],
+        },
+        {
+          text: "Knowledge & memory",
+          collapsed: false,
+          items: [{ text: "Memory & knowledge store", link: "/explanation/memory-and-knowledge" }],
+        },
+        {
+          text: "A2A, fleet & delegates",
+          collapsed: false,
+          items: [
+            { text: "A2A protocol", link: "/explanation/a2a-protocol" },
+            { text: "Cost & trace propagation", link: "/explanation/cost-and-trace" },
+          ],
+        },
+        {
+          text: "Operate & deploy",
+          collapsed: false,
+          items: [
+            { text: "Security & trust model", link: "/explanation/security-and-trust" },
+            { text: "Tuning & cost", link: "/explanation/tuning-and-cost" },
+          ],
+        },
+        {
+          text: "Architecture decisions",
+          collapsed: false,
+          items: [{ text: "ADRs", link: "/adr/" }],
         },
       ],
     },

--- a/docs/adr/0001-extensibility-and-plugin-architecture.md
+++ b/docs/adr/0001-extensibility-and-plugin-architecture.md
@@ -64,9 +64,9 @@ backend; redesigning the LangGraph core. The marketplace is explicitly the
 | Capability | Today | Shape |
 |---|---|---|
 | **Tools** | `tools/lg_tools.py::get_all_tools(knowledge_store, scheduler)` | Static list; backend-bound subsets (`MEMORY_TOOL_NAMES`, `SCHEDULER_TOOL_NAMES`). No dynamic registration. |
-| **Subagents** | `graph/subagents/config.py::SUBAGENT_REGISTRY` | Static `SubagentConfig` dataclasses (name, prompt, tool allowlist, `disallowed_tools`, `max_turns`, `allow_skill_emission`). |
+| **Subagents** | `graph/subagents/config.py::SUBAGENT_REGISTRY` | Static `SubagentConfig` dataclasses (name, prompt, tool allowlist, `disallowed_tools`, `max_turns`). |
 | **Hooks / lifecycle** | `graph/agent.py::_build_middleware()` | Config-gated list of langchain `AgentMiddleware` (PromptCache, Knowledge, Audit, Memory, Ingest, Enforcement, Summarization, ModelFallback, MessageCapture). |
-| **Skills (auto)** | `graph/extensions/skills.py` + `graph/skills/` (FTS5 index + curator) | **Agent self-authors** skill-v1 "recipes" via `task(emit_skill=True)`, indexed for retrieval. The hard half of procedural memory already exists. |
+| **Skills** | `graph/skills/` (FTS5 index + curator) + `graph/extensions/skills.py` | Human-authored `SKILL.md` skills, plus agent self-authoring via `/distill`; retrieved into each turn and curated. |
 | **Personas** | `config/soul-presets/*.md` | Markdown SOUL presets; no frontmatter / discovery metadata. |
 | **Tool gating** | `EnforcementMiddleware` (`enforcement_disallowed_tools`, rate limits) | Deny-list + per-tool rate limit. Allowlist is per-subagent. |
 | **Extension convention** | A2A `DataPart` + `mimeType` (`cost-v1`, `worldstate-delta-v1`, `skill-v1`) | Established pattern for typed, routed payloads. |

--- a/docs/adr/0010-headless-setup-and-ui-tiers.md
+++ b/docs/adr/0010-headless-setup-and-ui-tiers.md
@@ -51,7 +51,7 @@ without a UI, or (b) run a lean stack without the console + gradio.
 
 | Tier | Gradio (`/`) | React console (`/app`, `/static`) | API + A2A + `/metrics` | For |
 |---|---|---|---|---|
-| `full` | ✅ | ✅ | ✅ | local dev / `python server.py` (default) |
+| `full` | ✅ | ✅ | ✅ | local dev / `python -m server` (default) |
 | `console` | ✕ | ✅ | ✅ | desktop sidecar (React is the UI) — today's `--headless` |
 | `none` | ✕ | ✕ | ✅ | **headless servers / Roxy — the lighter stack** |
 
@@ -59,13 +59,13 @@ without a UI, or (b) run a lean stack without the console + gradio.
   mounts — pure API + A2A + `/metrics`.
 - `--headless` / `PROTOAGENT_HEADLESS` is kept as a **deprecated alias for
   `--ui console`** (back-compatible; logs a deprecation note).
-- Default stays `full` for `python server.py` so local dev is unchanged.
+- Default stays `full` for `python -m server` so local dev is unchanged.
 
 ### 2.2 Headless setup (no wizard)
 
 Two ways to satisfy the `.setup-complete` gate without a UI:
 
-1. **`python server.py --setup`** — one-shot: `ensure_live_config()`, validate
+1. **`python -m server --setup`** — one-shot: `ensure_live_config()`, validate
    the live config, then `mark_setup_complete()` and exit. Idempotent; the
    explicit operator/CI path.
 2. **Boot-time auto-complete** — when setup isn't complete but the config

--- a/docs/dev/docs-gaps.md
+++ b/docs/dev/docs-gaps.md
@@ -1,0 +1,32 @@
+# Docs gaps — tracked follow-ups
+
+Internal (not published; `docs/dev/**` is `srcExclude`d). Captured during the
+Diátaxis→domain reorg pass. Each item: what's missing, target Diátaxis section, and
+target domain (from the 9-domain taxonomy used across the sidebars).
+
+## Missing pages (shipped code, no user doc)
+
+| # | Gap | Section | Domain | Notes |
+|---|---|---|---|---|
+| 1 | **Ingestion pipeline** — `POST /api/knowledge/ingest`, "Add source" UI, txt/md/html/pdf/web/YouTube + audio/video STT | Guide | Knowledge & memory | `ingestion/` pkg + `KnowledgeIngestMiddleware`; only mentioned in passing |
+| 2 | **Command palette (⌘K)** | Guide | Console & UI | ADR 0057; only a passing mention in `react-tauri-ui.md` |
+| 3 | **Mid-turn steering** — submit a message while a turn runs; folds in at next model call | Explanation | Agent core & runtime | shipped (steering middleware); undocumented for users |
+| 4 | **Operator REST API** (`/api/*`) reference | Reference | Console & UI | `operator_api/` has no endpoint reference; only A2A/metrics documented |
+| 5 | **Knowledge & memory how-to** | Guide | Knowledge & memory | domain has explanation but **no guide** — e.g. "wire a knowledge store / RAG tuning" |
+| 6 | **Author a managed MCP server** | Guide | Tools, MCP & plugins | `mcp_servers/` (e.g. Google) — no authoring guide |
+| 7 | **Skills loaded chip / `skills.announce`** | (done) | Skills | documented in `guides/skills.md` already — no action |
+
+## Stale doc needing a rewrite (not just a banner)
+
+| # | Doc | Issue |
+|---|---|---|
+| A | `docs/guides/react-tauri-ui.md` | Titled "Migration"; it's the original Gradio→React plan. Banner added this pass; needs a rewrite into a current **operator-console how-to** (REST map + console usage), dropping the "keep Gradio for now" slices. |
+
+## Coverage gaps by domain (which Diátaxis cells are empty)
+
+- **Knowledge & memory** — has Explanation, but **no Tutorial / Guide / Reference**.
+- **Console & UI** — has Guides, but **no Reference** (operator REST API) and no Tutorial.
+- **Skills, subagents & workflows** — no Reference page (frontmatter/schema lookup could be one).
+
+Tutorials are thin (2). Candidate additions: "Write your first skill" (Skills), "Set up
+Langfuse tracing" (Operate & deploy).

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -1,12 +1,35 @@
 # Explanation
 
-Understanding-oriented. Read these when you want to know *why* the template is shaped the way it is.
+Understanding-oriented. Read these when you want to know *why* the template is shaped the way it is — grouped by **domain** (same order as the other sections).
+
+## Agent core & runtime
 
 | Page | Question it answers |
 |---|---|
 | [Architecture](/explanation/architecture) | How do the A2A handler, LangGraph runtime, and LiteLLM gateway fit together? |
-| [A2A protocol](/explanation/a2a-protocol) | What does A2A actually require, and where do naive implementations go wrong? |
-| [Cost & trace propagation](/explanation/cost-and-trace) | Why do we emit cost-v1 and parse `a2a.trace`, and why that specific shape? |
 | [Output protocol](/explanation/output-protocol) | Why `<scratch_pad>` / `<output>` instead of whatever the model emits? |
 | [LiteLLM gateway](/explanation/litellm-gateway) | Why route every call through a gateway instead of the provider SDK? |
+
+## Knowledge & memory
+
+| Page | Question it answers |
+|---|---|
+| [Memory & knowledge store](/explanation/memory-and-knowledge) | How does the agent remember across sessions — and why extract, not dump? |
+
+## A2A, fleet & delegates
+
+| Page | Question it answers |
+|---|---|
+| [A2A protocol](/explanation/a2a-protocol) | What does A2A actually require, and where do naive implementations go wrong? |
+| [Cost & trace propagation](/explanation/cost-and-trace) | Why do we emit cost-v1 and parse `a2a.trace`, and why that specific shape? |
+
+## Operate & deploy
+
+| Page | Question it answers |
+|---|---|
+| [Security & trust model](/explanation/security-and-trust) | What's the trust posture — auth, redaction, origin checks, sandboxing? |
 | [Tuning & cost](/explanation/tuning-and-cost) | Which cost/perf levers (compaction, aux-model routing, execute_code, prefix caching, failover) exist, and when to flip them? |
+
+## Architecture decisions
+
+The [ADRs](/adr/) record every significant design decision in MADR format (numbered, never deleted — superseded instead).

--- a/docs/guides/fleet.md
+++ b/docs/guides/fleet.md
@@ -1,8 +1,9 @@
 # Fleet — many agents on one host
 
 Run several named agents on one machine, each fully **isolated**, each runnable in the
-**background**, each built from a reusable **archetype** — and (soon) switchable in place
-from **one console**. The fleet is a handful of composable primitives:
+**background**, each built from a reusable **archetype** — and switchable in place from
+**one console** (slug-routed, per-agent layout/theme). The fleet is a handful of composable
+primitives:
 
 | Primitive | What it is | ADR |
 |---|---|---|
@@ -11,7 +12,7 @@ from **one console**. The fleet is a handful of composable primitives:
 | **Archetype** | a bundle presented as a starter *agent type* (or the built-in **Basic**) | [0042](../adr/0042-fleet-supervisor-unified-console.md) |
 | **Tiered stores** | per-agent private data + an opt-in shared **commons** | [0041](../adr/0041-workspaces-and-tiered-stores.md) |
 | **Supervisor** | run agents as persistent background processes (start/stop/status) | [0042](../adr/0042-fleet-supervisor-unified-console.md) |
-| **Unified console** *(coming)* | one console that hot-swaps between running agents | [0042](../adr/0042-fleet-supervisor-unified-console.md) |
+| **Unified console** | one slug-routed console that hot-swaps between running agents (per-agent layout/theme) | [0042](../adr/0042-fleet-supervisor-unified-console.md) |
 
 ## Quick start
 

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -1,65 +1,80 @@
 # How-To Guides
 
-Task-oriented procedures, grouped by what you're trying to do. Assumes you already have a running agent (see [Tutorials](/tutorials/) if not — the wizard runs with zero setup).
+Task-oriented procedures, grouped by **domain** (the same order used across Tutorials, Reference, and Explanation). Assumes you already have a running agent — see [Tutorials](/tutorials/) if not (the wizard runs with zero setup).
 
-## Set up & deploy
+## Getting started
 
-Fork the template, make it yours, and ship it.
+Fork the template and make it yours.
 
 | Guide | When to read |
 |---|---|
+| [Fork the template (fast path)](/guides/fork-the-template) | Terse checklist for experienced forkers |
 | [Customize & deploy](/guides/customize-and-deploy) | You've evaluated via the wizard and now want to fork, rename, and ship your own image |
-| [Fork checklist (fast path)](/guides/fork-the-template) | Terser version of the above for experienced forkers |
-| [Deploy via GHCR](/guides/deploy) | You're ready to ship and want auto-deploy wired up |
-| [Releasing](/guides/releasing) | You're cutting a versioned release (semver bump → image → GitHub release) |
 
-## Agent capabilities
+## Agent core & runtime
 
-Give the agent things it can do — skills, delegates, recipes, goals, timers.
+Shape how the agent's loop behaves — standing goals, timers, middleware hooks, the runtime brain.
 
 | Guide | When to read |
 |---|---|
-| [Add a custom skill (A2A card)](/guides/add-a-skill) | You want A2A callers to dispatch a named capability — a *card* skill, distinct from the `SKILL.md` skills below |
-| [Skills (`SKILL.md`)](/guides/skills) | You want to drop in reusable, auto-retrieved skill instructions in the AgentSkills `SKILL.md` format |
-| [Configure subagents](/guides/subagents) | You want specialized delegates beyond the shipped `researcher` |
-| [Reusable workflows](/guides/workflows) | You want declarative multi-step recipes (`*.yaml`) the agent can run on demand |
 | [Goal mode](/guides/goal-mode) | You want the agent to pursue a standing goal across turns, not just answer one-shot |
 | [Schedule future work](/guides/scheduler) | You want the agent to defer tasks to itself ("remind me tomorrow", recurring sweeps) — local sqlite or Workstacean-backed |
+| [Middleware](/guides/middleware) | You want pre/post hooks on the agent turn (plugin-contributed) |
+| [Run on a coding agent (ACP runtime)](/guides/acp-runtime) | You want an external coding agent (proto/Codex/Claude/Copilot/OpenCode) to *be* the runtime brain, with protoAgent as the shell |
 
-## Tools & coding agents
+## Skills, subagents & workflows
 
-Plug in external tools, and run the agent on (or delegate to) a coding agent.
+Give the agent reusable, named capabilities and delegates.
+
+| Guide | When to read |
+|---|---|
+| [Skills (`SKILL.md`)](/guides/skills) | You want to drop in reusable, auto-retrieved skill instructions in the AgentSkills `SKILL.md` format |
+| [Add a custom skill (A2A card)](/guides/add-a-skill) | You want A2A callers to dispatch a named capability — a *card* skill, distinct from the `SKILL.md` skills above |
+| [Configure subagents](/guides/subagents) | You want specialized delegates beyond the shipped `researcher` |
+| [Reusable workflows](/guides/workflows) | You want declarative multi-step recipes (`*.yaml`) the agent can run on demand |
+
+## A2A, fleet & delegates
+
+Connect your agent to other agents and endpoints, and run many of them.
+
+| Guide | When to read |
+|---|---|
+| [Delegates (agents & endpoints)](/guides/delegates) | You want to manage the agents + endpoints your agent talks to via `delegate_to` (a2a / openai / acp), hot-swappable from the console |
+| [Spawn CLI coding agents (ACP)](/guides/coding-agents) | You want the agent to drive a CLI coding agent (e.g. protoCLI) over the Agent Client Protocol |
+| [Run a fleet (workspaces, archetypes, supervisor)](/guides/fleet) | You want many named agents on one host — created from archetypes, run in the background, sharing a skills commons |
+| [Portfolio (one PM, many team boards)](/guides/portfolio) | You want one PM agent to dispatch work to, and track, several team-agents' project boards across repos — over A2A |
+
+## Tools, MCP & plugins
+
+Add capability without forking — external tools, drop-in packages, channels.
 
 | Guide | When to read |
 |---|---|
 | [Connect MCP servers](/guides/mcp) | You want to plug external tools into the agent via the Model Context Protocol (stdio / HTTP) |
-| [Spawn CLI coding agents (ACP)](/guides/coding-agents) | You want the agent to drive a CLI coding agent (e.g. protoCLI) over the Agent Client Protocol |
-| [Run on a coding agent (ACP runtime)](/guides/acp-runtime) | You want an external coding agent (proto/Codex/Claude/Copilot/OpenCode) to *be* the runtime brain, with protoAgent as the shell |
-| [Delegates (agents & endpoints)](/guides/delegates) | You want to manage the agents + endpoints your agent talks to via `delegate_to` (a2a / openai / acp), hot-swappable from the console |
-
-## Plugins & channels
-
-Drop-in packages that add capability without forking — and reach the agent over channels like Discord.
-
-| Guide | When to read |
-|---|---|
 | [Plugins](/guides/plugins) | You want drop-in packages that add tools, skills, routes, background surfaces, subagents and managed MCP servers without forking (Discord ships this way; Google/Slack install as external plugins) |
 | [Building a plugin view](/guides/building-react-plugin-views) | You want a plugin to add its own console surface — a left-rail view (dashboard/chart/editor) or a panel that replaces the built-in chat |
 | [Build a communication plugin](/guides/communication-plugins) | You want a new inbound/outbound channel (like Discord) as a plugin surface |
 | [Install & publish plugins (git URLs)](/guides/plugin-registry) | You want to install a plugin from a git URL, or publish one as a shareable repo (tools + skills + subagents + workflows + views) |
 | [Discord surface](/guides/discord) | You want the agent reachable from Discord (the first-party `discord` plugin) |
 
-## Run & operate
+## Console & UI
 
-Run the agent as a service, give it a console, isolate instances, fence it in, and watch it.
+Surface the agent to people — the operator console, or no UI at all.
 
 | Guide | When to read |
 |---|---|
-| [Run headless (API + A2A)](/guides/headless) | You want the agent as a service — REST + A2A — with no UI |
 | [Operator console (React/Tauri)](/guides/react-tauri-ui) | You want the multi-chat React console and to package it for desktop |
+| [Run headless (API + A2A)](/guides/headless) | You want the agent as a service — REST + A2A — with no UI |
+
+## Operate & deploy
+
+Ship it, isolate it, fence it in, and watch it.
+
+| Guide | When to read |
+|---|---|
+| [Deploy via GHCR](/guides/deploy) | You're ready to ship and want auto-deploy wired up |
+| [Releasing](/guides/releasing) | You're cutting a versioned release (semver bump → image → GitHub release) |
 | [Run multiple instances](/guides/multi-instance) | You want several scoped agents (data isolation) on one host |
-| [Run a fleet (workspaces, archetypes, supervisor)](/guides/fleet) | You want many named agents on one host — created from archetypes, run in the background, sharing a skills commons |
-| [Portfolio (one PM, many team boards)](/guides/portfolio) | You want one PM agent to dispatch work to, and track, several team-agents' project boards across repos — over A2A |
 | [Sandboxing & egress](/guides/sandboxing) | You want to fence the filesystem + outbound network |
 | [Wire Langfuse + Prometheus](/guides/observability) | You need traces and metrics in production |
 

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -1,8 +1,13 @@
 # React + Tauri UI Migration
 
-This is the implementation plan for replacing the Gradio UI with a React
-operator console, then wrapping it in a Tauri desktop app once the web surface
-is stable.
+::: warning Historical migration plan
+This page is the original plan for replacing the Gradio UI with the React console
++ Tauri desktop app. **That migration has shipped** — Gradio is removed, the
+console is the only/default UI (`/` → `/app`), and the desktop app is released.
+Sections below that say "keep Gradio for now" / "Gradio retirement" are historical.
+A current operator-console how-to is a tracked follow-up (see `docs/dev/docs-gaps.md`);
+the still-useful parts here are the REST endpoint map and the source patterns.
+:::
 
 ## Source Patterns To Adopt
 

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -45,9 +45,22 @@ tools: [web_search, fetch_url]   # optional, advisory
 | `name` | ✅ | Unique, lowercase-with-hyphens. |
 | `description` | ✅ | ≤ 1024 chars. This is the **trigger signal** — write it "pushy": say plainly *when* the agent should reach for this skill, or it under-triggers. |
 | `tools` (or `metadata.tools`) | — | Advisory list of tool names the skill uses. When the skill is retrieved for a turn, these are surfaced to the agent as `<relevant_tools>` so it knows which of its (already-bound) tools this skill relies on — a relevance hint, not a gate. See [ADR 0005](/adr/0005-tool-pollution-and-progressive-disclosure). |
+| `user_facing` | — | `true` makes the skill directly invokable as a `/<slash>` command in the chat composer (ADR 0052). Off by default. |
+| `slash` | — | The trigger token for a `user_facing` skill (whitespace-free); blank → slug of `name`. e.g. `slash: web-research` → `/web-research`. |
 
 The markdown **body** is the skill's instructions — freeform; write whatever
 helps the agent perform the task.
+
+## Run a skill on demand (`/slash`)
+
+By default a skill fires only when retrieval matches it. Mark a skill
+`user_facing: true` (ADR 0052) and it *also* shows up as a `/<slash>` command in
+the composer's slash menu. Invoking `/<slash> [input]` **rewrites the turn** to
+inject the skill's procedure as a directive and runs it on the normal lead-agent
+turn (full toolset, history intact) — it doesn't spawn a detached worker.
+Precedence on a shared token: `goal` > workflow > subagent > skill. The shipped
+`web-research` skill is user-facing as `/web-research`, and `release-notes` as
+`/release-notes`.
 
 ## Where skills live
 
@@ -85,8 +98,9 @@ loaded.
 
 - Skills are *retrieved by relevance* (BM25 over name/description/body), so a
   precise, trigger-oriented `description` matters most.
-- The agent can also **author its own** skills: the `/distill` subagent turns a
-  proven workflow into a new `SKILL.md` (same `disk` source, indexed and retrieved
-  exactly like the ones you write). The skill curator (`graph/skills/curator.py`)
-  decays and prunes non-pinned skills; disk skills are pinned.
+- The agent can also **author its own** skills: the `/distill` subagent looks back
+  over recent work and turns a proven, repeated workflow into a new skill (its
+  companion `/dream` consolidates memory). Both are schedulable (ADR 0054). The
+  skill curator (`graph/skills/curator.py`) decays and prunes non-pinned skills;
+  disk skills (your `SKILL.md` files) are pinned.
 - OS/binary gating fields are parsed but not yet enforced.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -1,12 +1,24 @@
 # Reference
 
-Information-oriented. Look up exact shapes and values here.
+Information-oriented. Look up exact shapes and values here, grouped by **domain** (same order as the other sections).
+
+## Agent core & runtime
+
+| Page | Contents |
+|---|---|
+| [Configuration](/reference/configuration) | `config/langgraph-config.yaml` schema |
+| [Environment variables](/reference/environment-variables) | Every env knob |
+
+## A2A, fleet & delegates
 
 | Page | Contents |
 |---|---|
 | [A2A endpoints](/reference/a2a-endpoints) | JSON-RPC methods, SSE stream, well-known paths |
 | [Agent card](/reference/agent-card) | Card shape with every supported field |
+| [Extensions](/reference/extensions) | A2A DataPart extensions (`cost-v1`, `confidence-v1`, `tool-call-v1`, …) + `a2a.trace` |
+
+## Tools, MCP & plugins
+
+| Page | Contents |
+|---|---|
 | [Starter tools](/reference/starter-tools) | Shipped LangChain tools and their signatures |
-| [Environment variables](/reference/environment-variables) | Every env knob |
-| [Configuration](/reference/configuration) | `config/langgraph-config.yaml` schema |
-| [Extensions](/reference/extensions) | A2A DataPart extensions (`cost-v1`, `confidence-v1`, `effect-domain-v1`, `tool-call-v1`, …) + `a2a.trace` |

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -1,10 +1,17 @@
 # Tutorials
 
-Learning-oriented walkthroughs. Start here if you're new to protoAgent.
+Learning-oriented walkthroughs. Start here if you're new to protoAgent. Grouped by **domain** (same order as the other sections).
+
+## Getting started
 
 | Tutorial | What you'll end up with |
 |---|---|
 | [Spin up your first agent](/tutorials/first-agent) | A forked, renamed container you can chat with locally |
+
+## Tools, MCP & plugins
+
+| Tutorial | What you'll end up with |
+|---|---|
 | [Write your first tool](/tutorials/first-tool) | A custom LangChain tool wired into the agent's loop |
 
 Once you've worked through both, the [How-To Guides](/guides/) are where to head next — they assume you already have an agent running.


### PR DESCRIPTION
Makes the docs navigable by one mental model: **every Diátaxis section groups its pages by the same 9-domain taxonomy** in both the sidebar and the section index. Previously Guides used ad-hoc capability buckets while Tutorials/Reference/Explanation were flat.

## Domain order (reused everywhere; a section shows only the domains it has)
Getting started · Agent core & runtime · Skills, subagents & workflows · Knowledge & memory · A2A, fleet & delegates · Tools, MCP & plugins · Console & UI · Operate & deploy · Forks & evals

## Reorg
- **`docs/.vitepress/config.mts`** — all four sidebars regrouped into domain groups (the nested-group shape Guides already used). Dropped the orphaned `/how-to/` block + the `plugin-views` redirect stub from nav. Every existing page stays reachable.
- **Index pages** — `guides`/`reference`/`explanation`/`tutorials` indexes regrouped to mirror the sidebar. The explanation index also regains two pages it had silently dropped (`security-and-trust`, `memory-and-knowledge`).

## Stale fixes
- **ADR 0010** — `python server.py` → `python -m server` (run-command; ADR 0023). Historical code-location pointers left as-is.
- **ADR 0001** — extensibility table: dropped removed `allow_skill_emission`; reworded the Skills row off `task(emit_skill=True)` → self-authoring via `/distill`.
- **`fleet.md`** — unified console is shipped (ADR 0042), not "(coming)".
- **`skills.md`** — documented user-facing `/slash` skills (ADR 0052) + `/dream`/`/distill`.
- **`react-tauri-ui.md`** — banner flagging it as the original Gradio→React migration plan (now shipped); full rewrite tracked.

## Gaps tracked, not written (next pass)
`docs/dev/docs-gaps.md` (dev-only, unpublished) lists: ingestion pipeline guide, command palette (⌘K), mid-turn steering explanation, operator REST API reference, knowledge/memory how-to, MCP-server authoring guide — each tagged with target section + domain.

## Verification
Docs-only. `npm run docs:build` (VitePress) passes clean — dead internal links are fatal there, so the green build confirms nothing dangling. Grep sweep confirms no remaining `python server.py` / dead `skill-loop` links; the residual `gradio` mentions are all in the amended ADR 0010 + the deprecated-`full`-alias docs (correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)