### PR TITLE
feat(web): utility bar — widgets left, layout right + bottom-panel toggle

### DIFF
--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -78,3 +78,14 @@ test("left panel shrinks to minLeftWidth, past the old maxRightWidth floor (prot
   // Reached ~minLeftWidth(200) — well under the old span−720 floor (~50%).
   expect(after).toBeLessThan(280);
 });
+
+test("the bottom-panel toggle sits with the layout buttons, gated until a surface is docked", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const toggleBottom = page.getByTestId("toggle-bottom");
+  // Present alongside the left/right layout toggles (the bottom-right cluster).
+  await expect(toggleBottom).toBeVisible();
+  await expect(page.getByTestId("toggle-left")).toBeVisible();
+  await expect(page.getByTestId("toggle-right")).toBeVisible();
+  // Disabled by default — nothing is docked at the bottom (railOrder.bottom is empty).
+  await expect(toggleBottom).toBeDisabled();
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -13,6 +13,7 @@ import {
   LayoutDashboard,
   Loader2,
   MessageSquare,
+  PanelBottom,
   PanelLeft,
   PanelRight,
   Plus,
@@ -922,11 +923,34 @@ export function App() {
         bottomContent={bottomActive ? renderSurface(bottomActive) : null}
         utilityBar={
           <UtilityBar
-            // Docs + GitHub moved into the header drawer (2026-06-18 IA pass).
+            // Bottom-left = widgets, bottom-right = layout (2026-06 IA pass). Docs +
+            // GitHub moved into the header drawer.
+            start={
+              <>
+                {/* Widgets — background subagents (ADR 0050 Phase 3): live pill + jobs
+                    dialog. The inbox widget lands here next. */}
+                <BackgroundJobs />
+              </>
+            }
             end={
               <>
-                {/* Background subagents (ADR 0050 Phase 3) — live pill + jobs dialog. */}
-                <BackgroundJobs />
+                <button
+                  type="button"
+                  className={`util-btn ${bottomCollapsed ? "is-off" : ""}`}
+                  onClick={() => setBottomCollapsed(!bottomCollapsed)}
+                  disabled={!bottomActive}
+                  title={
+                    bottomActive
+                      ? bottomCollapsed
+                        ? "Show bottom panel"
+                        : "Hide bottom panel"
+                      : "No bottom panel — move a surface to the bottom dock"
+                  }
+                  aria-label="Toggle bottom panel"
+                  data-testid="toggle-bottom"
+                >
+                  <PanelBottom size={14} />
+                </button>
                 <button
                   type="button"
                   className={`util-btn ${leftCollapsed ? "is-off" : ""}`}


### PR DESCRIPTION
First step of the utility-bar IA pass: **bottom-left = widgets, bottom-right = layout** (the DS `UtilityBar`'s `start` / `end` clusters).

- **start (widgets):** the background-subagents pill moves to the left. *(The inbox widget lands here next, as a dialog popover.)*
- **end (layout):** a new **bottom-panel toggle** (`PanelBottom`) to the **left** of the existing left/right toggles. Mirrors the left/right toggle pattern (`setBottomCollapsed`); **disabled until a surface is docked** at the bottom (default `railOrder.bottom` is empty), with a tooltip explaining how to dock one.

**Verification:** new E2E asserts the bottom toggle sits with the layout buttons and is gated by default; existing `toggle-right` collapse/resize tests still pass. Build + 94 web + **109 E2E** green.

Next: move the inbox view into the widgets cluster as a dialog popover.

🤖 Generated with [Claude Code](https://claude.com/claude-code)