### PR TITLE
docs: fill priority gaps (ingestion, RAG, palette, steering, operator API)

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -93,6 +93,14 @@ export default defineConfig({
           ],
         },
         {
+          text: "Knowledge & memory",
+          collapsed: false,
+          items: [
+            { text: "Ingest documents & media", link: "/guides/ingestion" },
+            { text: "Tune the knowledge store (RAG)", link: "/guides/knowledge" },
+          ],
+        },
+        {
           text: "A2A, fleet & delegates",
           collapsed: false,
           items: [
@@ -119,6 +127,7 @@ export default defineConfig({
           collapsed: false,
           items: [
             { text: "Operator console (React/Tauri)", link: "/guides/react-tauri-ui" },
+            { text: "Command palette (⌘K)", link: "/guides/command-palette" },
             { text: "Run headless (API + A2A)", link: "/guides/headless" },
           ],
         },
@@ -168,6 +177,11 @@ export default defineConfig({
           collapsed: false,
           items: [{ text: "Starter tools", link: "/reference/starter-tools" }],
         },
+        {
+          text: "Console & UI",
+          collapsed: false,
+          items: [{ text: "Operator REST API", link: "/reference/operator-api" }],
+        },
       ],
 
       "/explanation/": [
@@ -178,6 +192,7 @@ export default defineConfig({
           items: [
             { text: "Architecture", link: "/explanation/architecture" },
             { text: "Output protocol", link: "/explanation/output-protocol" },
+            { text: "Mid-turn steering", link: "/explanation/steering" },
             { text: "LiteLLM gateway", link: "/explanation/litellm-gateway" },
           ],
         },

--- a/docs/dev/docs-gaps.md
+++ b/docs/dev/docs-gaps.md
@@ -1,32 +1,30 @@
 # Docs gaps — tracked follow-ups
 
 Internal (not published; `docs/dev/**` is `srcExclude`d). Captured during the
-Diátaxis→domain reorg pass. Each item: what's missing, target Diátaxis section, and
-target domain (from the 9-domain taxonomy used across the sidebars).
+Diátaxis→domain reorg pass; updated as gaps are filled. Each item: what's missing,
+target Diátaxis section, and target domain (from the 9-domain taxonomy).
 
-## Missing pages (shipped code, no user doc)
+## Done (filled in the gap-fill pass)
+
+| Gap | Page shipped |
+|---|---|
+| Ingestion pipeline | `docs/guides/ingestion.md` |
+| Knowledge & memory how-to (RAG tuning) | `docs/guides/knowledge.md` |
+| Command palette (⌘K) — was shipped, not just proposed | `docs/guides/command-palette.md` |
+| Mid-turn steering | `docs/explanation/steering.md` |
+| Operator REST API reference | `docs/reference/operator-api.md` |
+| Skills loaded chip / `skills.announce` | already in `docs/guides/skills.md` |
+
+## Remaining
 
 | # | Gap | Section | Domain | Notes |
 |---|---|---|---|---|
-| 1 | **Ingestion pipeline** — `POST /api/knowledge/ingest`, "Add source" UI, txt/md/html/pdf/web/YouTube + audio/video STT | Guide | Knowledge & memory | `ingestion/` pkg + `KnowledgeIngestMiddleware`; only mentioned in passing |
-| 2 | **Command palette (⌘K)** | Guide | Console & UI | ADR 0057; only a passing mention in `react-tauri-ui.md` |
-| 3 | **Mid-turn steering** — submit a message while a turn runs; folds in at next model call | Explanation | Agent core & runtime | shipped (steering middleware); undocumented for users |
-| 4 | **Operator REST API** (`/api/*`) reference | Reference | Console & UI | `operator_api/` has no endpoint reference; only A2A/metrics documented |
-| 5 | **Knowledge & memory how-to** | Guide | Knowledge & memory | domain has explanation but **no guide** — e.g. "wire a knowledge store / RAG tuning" |
-| 6 | **Author a managed MCP server** | Guide | Tools, MCP & plugins | `mcp_servers/` (e.g. Google) — no authoring guide |
-| 7 | **Skills loaded chip / `skills.announce`** | (done) | Skills | documented in `guides/skills.md` already — no action |
+| 1 | **Author a managed MCP server** | Guide | Tools, MCP & plugins | Already covered at a basic level in `guides/mcp.md` (§ Plugin-managed servers, `register_mcp_server`). Only needs a fuller worked example if demand appears — low priority. |
+| 2 | **Skills reference** (frontmatter/schema lookup) | Reference | Skills, subagents & workflows | Skills domain has guides + explanation but no Reference page. |
+| 3 | **First-skill / Langfuse tutorials** | Tutorial | Skills / Operate | Tutorials are thin (2). Candidates: "Write your first skill", "Set up Langfuse tracing". |
 
 ## Stale doc needing a rewrite (not just a banner)
 
 | # | Doc | Issue |
 |---|---|---|
-| A | `docs/guides/react-tauri-ui.md` | Titled "Migration"; it's the original Gradio→React plan. Banner added this pass; needs a rewrite into a current **operator-console how-to** (REST map + console usage), dropping the "keep Gradio for now" slices. |
-
-## Coverage gaps by domain (which Diátaxis cells are empty)
-
-- **Knowledge & memory** — has Explanation, but **no Tutorial / Guide / Reference**.
-- **Console & UI** — has Guides, but **no Reference** (operator REST API) and no Tutorial.
-- **Skills, subagents & workflows** — no Reference page (frontmatter/schema lookup could be one).
-
-Tutorials are thin (2). Candidate additions: "Write your first skill" (Skills), "Set up
-Langfuse tracing" (Operate & deploy).
+| A | `docs/guides/react-tauri-ui.md` | Titled "Migration"; it's the original Gradio→React plan. Banner added; still wants a rewrite into a current **operator-console how-to** (the new [Operator REST API](/reference/operator-api) reference now covers the endpoint map, so the rewrite can focus on console usage). |

--- a/docs/explanation/index.md
+++ b/docs/explanation/index.md
@@ -8,6 +8,7 @@ Understanding-oriented. Read these when you want to know *why* the template is s
 |---|---|
 | [Architecture](/explanation/architecture) | How do the A2A handler, LangGraph runtime, and LiteLLM gateway fit together? |
 | [Output protocol](/explanation/output-protocol) | Why `<scratch_pad>` / `<output>` instead of whatever the model emits? |
+| [Mid-turn steering](/explanation/steering) | How can I redirect the agent mid-turn without stopping and losing its work? |
 | [LiteLLM gateway](/explanation/litellm-gateway) | Why route every call through a gateway instead of the provider SDK? |
 
 ## Knowledge & memory

--- a/docs/explanation/steering.md
+++ b/docs/explanation/steering.md
@@ -1,0 +1,48 @@
+# Mid-turn steering
+
+A turn can take a while — tool loops, subagent delegations, long generations. **Mid-turn
+steering** lets you send a message *while the agent is working* and have it folded in at
+the next model call, so you can redirect without stopping (and losing) the stream.
+
+## Why not just stop and re-ask
+
+Stopping a turn discards in-flight work (an open delegation, a half-built answer) and
+restarts cold. Steering instead **queues** your message and lets the running turn pick it
+up on its next reasoning step — the agent course-corrects mid-flight, keeping everything
+it's already done.
+
+## How it works
+
+- **A per-session queue** (`graph/steering.py`) holds messages submitted during a turn.
+  `enqueue` adds, `drain` removes-and-returns all, `dequeue` cancels one before it's used.
+- **`SteeringMiddleware`** (`graph/middleware/steering.py`) runs in the `before_model`
+  hook: it drains the queue and, if anything's there, prepends it as a `HumanMessage` so
+  the reducer appends it before the next model call. It wraps the text in an advisory —
+  *"address it now if it changes the task, otherwise acknowledge briefly and keep going"* —
+  so the agent treats it as guidance, not a hard interrupt. Empty queue → no-op, so normal
+  turns are unaffected.
+
+Because the middleware fires before *every* model call in the turn, a steer lands at the
+next step regardless of how deep the tool loop is.
+
+## What you see in the console
+
+- Type into the composer while a turn streams; the message posts to
+  `POST /api/chat/sessions/{id}/steer` and shows as a **pending bubble** with a ✕.
+- **✕ cancels** it (`DELETE …/steer/{msg_id}`) if it hasn't been folded in yet. If it
+  already shaped the reply, the console settles it into the thread instead of dropping it.
+- At turn end the console reconciles against `GET …/steer`: anything that arrived after
+  the turn's last model call (so it wasn't folded in) is **re-sent as a fresh turn**, so a
+  late steer is never silently lost.
+
+## Steering vs. cancelling a delegation
+
+Two different controls:
+
+- **Steering** redirects the *lead* turn by queuing a message (above).
+- **Delegation cancel** (`POST …/delegations/{id}/cancel`) aborts a single running
+  subagent `task` — the lead continues with a "cancelled" result. Contrast the composer's
+  **Stop**, which A2A-`CancelTask`s the *whole* turn.
+
+See also [ADR 0051](/adr/0051-a2a-realtime-streaming-and-component-rendering) (realtime
+streaming + stop) and the [output protocol](/explanation/output-protocol).

--- a/docs/guides/command-palette.md
+++ b/docs/guides/command-palette.md
@@ -1,0 +1,35 @@
+# Command palette (⌘K)
+
+The console has a command palette — press **⌘K** (macOS) / **Ctrl-K** (Linux/Windows)
+to open it from anywhere. It's the fast path to jump between surfaces and act without
+hunting through rails and menus ([ADR 0057](/adr/0057-command-palette)).
+
+## What's in it
+
+- **Go to any surface** — every resolvable view (Chat, Activity, Inbox, Plugins,
+  Settings, plugin rail views) is a "go to" command, listed first.
+- **Deep links** — jump straight to Activity/Inbox, Plugins → Discover/Install, or a
+  specific Settings tab.
+- **Inline chat** — start typing a question and the palette morphs into a quick chat
+  with the focused agent (its own thread, persisted locally) — handy for a one-off ask
+  without leaving what you're doing.
+- **Plugin views** — a plugin view can opt to render *inside* the palette by declaring
+  `palette: "inline"` on its view (so a lightweight tool can live behind ⌘K instead of
+  taking a rail slot).
+
+Commands are ranked in a fixed order — surfaces, then deep links, then chat — so
+navigation always stays at the top.
+
+## For plugin authors
+
+A plugin's view opts into the palette by setting `palette: "inline"` on its view entry
+in `protoagent.plugin.yaml` (the same view that would otherwise mount in a rail/tab).
+When opened from ⌘K, the palette renders the view's body in place.
+
+> Plugin-declared *commands* (a manifest `commands:` list that contributes arbitrary
+> actions, beyond views) are the next slice of ADR 0057 and not shipped yet — today a
+> plugin reaches the palette via an inline **view**.
+
+The palette is wired in `apps/web/src/app/App.tsx` (the `@protolabsai/ui/command-palette`
+substrate + `usePaletteHotkey`); the registry is built in
+`apps/web/src/app/usePaletteRegistry.ts`.

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -33,6 +33,15 @@ Give the agent reusable, named capabilities and delegates.
 | [Configure subagents](/guides/subagents) | You want specialized delegates beyond the shipped `researcher` |
 | [Reusable workflows](/guides/workflows) | You want declarative multi-step recipes (`*.yaml`) the agent can run on demand |
 
+## Knowledge & memory
+
+Load content the agent can recall, and tune how it's retrieved.
+
+| Guide | When to read |
+|---|---|
+| [Ingest documents & media](/guides/ingestion) | You want to pull files, web pages, PDFs, or audio/video into the knowledge store |
+| [Tune the knowledge store (RAG)](/guides/knowledge) | You want to adjust hybrid retrieval — `top_k`, `vector_k`, `rrf_k`, `min_score`, embeddings |
+
 ## A2A, fleet & delegates
 
 Connect your agent to other agents and endpoints, and run many of them.
@@ -64,6 +73,7 @@ Surface the agent to people — the operator console, or no UI at all.
 | Guide | When to read |
 |---|---|
 | [Operator console (React/Tauri)](/guides/react-tauri-ui) | You want the multi-chat React console and to package it for desktop |
+| [Command palette (⌘K)](/guides/command-palette) | You want the fast keyboard path to jump between surfaces + inline chat |
 | [Run headless (API + A2A)](/guides/headless) | You want the agent as a service — REST + A2A — with no UI |
 
 ## Operate & deploy

--- a/docs/guides/ingestion.md
+++ b/docs/guides/ingestion.md
@@ -1,0 +1,76 @@
+# Ingest documents & media
+
+Pull files, web pages, and media into the knowledge store so the agent can recall
+them. Ingestion **extracts text, chunks it, embeds it, and indexes it** — one call
+handles plain text, Markdown, HTML, PDF, audio, video, and web/YouTube URLs.
+
+> This is the *ingest* (write) side. For how recall works and the tuning knobs, see
+> [Tune the knowledge store (RAG)](/guides/knowledge); for the design, see
+> [Memory & the knowledge store](/explanation/memory-and-knowledge).
+
+## From the console
+
+**Knowledge → Store → Add source.** Drop a file, or paste a web/YouTube URL, pick a
+**domain** (defaults to `general`), and import. The form accepts `txt, md, html, pdf`
+and audio/video (`mp3, wav, m4a, flac, ogg, opus, aac, mp4, mov, mkv, webm, avi, m4v`).
+You'll see `Added N chunks from "<title>"`.
+
+## From the API
+
+```bash
+# a file
+curl -F file=@notes.pdf -F domain=research \
+  http://localhost:7870/api/knowledge/ingest
+
+# a web page or YouTube URL
+curl -F url=https://example.com/post -F title="That post" \
+  http://localhost:7870/api/knowledge/ingest
+
+# raw text
+curl -F text="the thing to remember" -F title=Note \
+  http://localhost:7870/api/knowledge/ingest
+```
+
+`POST /api/knowledge/ingest` (multipart) takes one of `file` / `url` / `text`, plus
+optional `title` and `domain`. It responds with the chunk `ids`, the `chunks` count,
+the detected `source_type`, and `chars`.
+
+## What's supported
+
+| Source | How it's handled | Needs |
+|---|---|---|
+| Text / Markdown | decoded directly | — |
+| HTML | readable text extracted (script/nav/footer stripped) | — |
+| PDF | text extracted per page | `pypdf` |
+| Web URL | fetched, then dispatched by content-type | — |
+| YouTube URL | transcript via the captions API, else gateway STT | `youtube-transcript-api` |
+| Audio | transcribed via the gateway's `/audio/transcriptions` (Whisper) | `knowledge.transcribe_model` set |
+| Video | `ffmpeg` extracts the audio track → gateway STT | `ffmpeg` on PATH + `transcribe_model` |
+
+Format is detected from the file extension, then the content-type, then a UTF-8
+heuristic. The `pypdf` / `youtube-transcript-api` deps are lazy-imported — a missing
+one fails *that* source with a clear message, never the server. Audio/video always
+transcribe **through the gateway** (no local ASR); leave `transcribe_model` blank to
+disable media ingestion.
+
+## Chunking & enrichment (config)
+
+Large documents are split before embedding. Tune under `knowledge:` in
+`langgraph-config.yaml`:
+
+```yaml
+knowledge:
+  transcribe_model: whisper-1     # gateway STT model; blank disables audio/video
+  chunk_max_chars: 1200           # target ceiling per chunk
+  chunk_overlap_chars: 150        # shared tail between adjacent chunks
+  chunk_min_chars: 200            # trailing fragments fold into the prior chunk
+  contextual_enrichment: false    # prepend a 1-sentence doc context per chunk before
+                                  # embedding (Anthropic Contextual Retrieval) — one aux
+                                  # LLM call per chunk at INGEST time; off by default
+  context_max_doc_chars: 12000    # doc cap fed to the enrichment prompt
+```
+
+Chat attachments take the same path above `attach_inline_budget` (default 8000 chars):
+small files are read inline for the turn; larger ones are ingested + indexed and a lede
+is surfaced, so a big paste never dumps into context. See
+[chat file upload](/explanation/memory-and-knowledge).

--- a/docs/guides/knowledge.md
+++ b/docs/guides/knowledge.md
@@ -1,0 +1,64 @@
+# Tune the knowledge store (RAG)
+
+The knowledge store is what the agent recalls from. By default it's **hybrid** —
+keyword (SQLite FTS5) **and** semantic (vector) search, fused with Reciprocal Rank
+Fusion (RRF). `KnowledgeMiddleware` injects the top hits into the system prompt every
+turn. This guide is the tuning surface; for the design and write paths see
+[Memory & the knowledge store](/explanation/memory-and-knowledge), and to load
+content see [Ingest documents & media](/guides/ingestion).
+
+## Which store you get
+
+- **Default:** `HybridKnowledgeStore` (FTS5 + vectors) when `knowledge.embeddings`
+  is on (the default) and `embed_model` resolves on your gateway.
+- **Keyword-only:** set `embeddings: false` → FTS5 only (no embedding calls).
+- **Pluggable:** a plugin can register an alternate backend (`knowledge.backend`) or
+  embedder (`knowledge.embedder`) — see [ADR 0031](/adr/0031-pluggable-knowledge-backend).
+
+If embeddings fail repeatedly the store trips a **circuit breaker** and silently
+degrades to keyword-only — it's never KB-less. Test/refresh the gateway key with
+**Settings → Test connection**, which clears the breaker immediately.
+
+## The knobs
+
+All under `knowledge:` in `langgraph-config.yaml`:
+
+```yaml
+knowledge:
+  embeddings: true            # hybrid (semantic+keyword); false → keyword-only
+  embed_model: qwen3-embedding # gateway EMBEDDING model (not the chat model);
+                              #   must be served by your gateway (check GET /v1/models)
+  top_k: 10                   # hits injected into the prompt per turn
+  vector_k: 20                # vector candidates fetched before RRF fusion (hybrid)
+  rrf_k: 60                   # RRF constant — higher = keyword & semantic weigh more evenly
+  min_score: 0.0              # drop fused hits below this score (0 = keep all)
+  recall_preview_chars: 1000  # chars of each hit the model sees in the injected block
+  embed_breaker_threshold: 2  # consecutive embed failures before the breaker opens
+  embed_breaker_cooldown_s: 300 # seconds the breaker stays open before retrying
+  facts: true                 # harvest semantic facts from retiring conversations
+  db_path: /sandbox/knowledge/agent.db  # → ~/.protoagent/knowledge/agent.db fallback
+```
+
+Rules of thumb:
+- **Recall too thin?** raise `top_k` (more injected) and/or `vector_k` (bigger candidate
+  pool). **Context too noisy / off-topic?** raise `min_score` to set a relevance floor.
+- `rrf_k` rebalances semantic vs keyword — lower lets semantic dominate. Tune it against
+  the retrieval eval harness rather than by feel.
+- Chunking (`chunk_*`) and `contextual_enrichment` are ingest-time knobs — see
+  [Ingest documents & media](/guides/ingestion).
+
+## The agent's memory tools
+
+When a knowledge store is wired, the agent gets these (operator-curatable under
+**Knowledge → Store**):
+
+| Tool | What it does |
+|---|---|
+| `memory_ingest(content, domain, heading?)` | store a self-contained fact/note for later recall |
+| `memory_recall(query, k=5)` | search long-term memory (hybrid, or FTS5 if the breaker is open) |
+| `memory_list(domain?, limit=10)` | browse recent chunks (used by `/dream` consolidation) |
+| `memory_stats()` | per-domain chunk counts |
+| `forget_memory(chunk_id, reason?)` | delete one chunk by id (targeted) |
+
+`GET /api/runtime/status` reports the store status; `GET /api/knowledge/search`
+backs the console browser.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -22,3 +22,9 @@ Information-oriented. Look up exact shapes and values here, grouped by **domain*
 | Page | Contents |
 |---|---|
 | [Starter tools](/reference/starter-tools) | Shipped LangChain tools and their signatures |
+
+## Console & UI
+
+| Page | Contents |
+|---|---|
+| [Operator REST API](/reference/operator-api) | The console's `/api/*` control-plane endpoints, grouped by area |

--- a/docs/reference/operator-api.md
+++ b/docs/reference/operator-api.md
@@ -1,0 +1,122 @@
+# Operator REST API
+
+The console drives the backend over a REST control-plane under `/api/*` (defined in
+`operator_api/`). This is the **operator** surface — managing one agent and its host.
+For talking *to* the agent as a client, use the [A2A endpoints](/reference/a2a-endpoints)
+(`/a2a`) or the OpenAI-compatible `/v1` surface instead.
+
+All `/api/*` routes are gated by the same bearer auth as the rest of the server (set via
+`A2A_AUTH_TOKEN` / the configured token); the console attaches it automatically. This page
+is a map — `operator_api/*.py` is the source of truth for exact request/response shapes.
+
+## Runtime & health
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/healthz` | Liveness probe |
+| GET | `/api/runtime/status` | Setup state, model, enabled middleware, knowledge/scheduler/skills counts |
+
+## Chat & sessions
+
+| Method | Path | Purpose |
+|---|---|---|
+| POST | `/api/chat` | Run a non-streaming chat turn (the streaming path is A2A `/a2a`) |
+| DELETE | `/api/chat/sessions/{id}` | Delete a session (`?harvest=` to extract memory first) |
+| GET | `/api/chat/commands` | Slash-command inventory (workflows / subagents / skills) |
+| POST | `/api/chat/sessions/{id}/steer` | Enqueue a mid-turn [steering](/explanation/steering) message |
+| GET | `/api/chat/sessions/{id}/steer` | Peek pending steers |
+| DELETE | `/api/chat/sessions/{id}/steer/{msg_id}` | Cancel a queued steer |
+| GET | `/api/chat/sessions/{id}/delegations` | List running subagent delegations |
+| POST | `/api/chat/sessions/{id}/delegations/{del_id}/cancel` | Cancel one delegation (lead continues) |
+
+## Goals (goal mode)
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/goals` · `/api/goal/{session_id}` | List goals / get a session's goal |
+| POST | `/api/goals` | Set a goal |
+| DELETE | `/api/goals/{session_id}` · `/api/goal/{session_id}` | Clear a goal |
+
+## Subagents & tools
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/subagents` | Registered subagents (allowlists, max turns) |
+| POST | `/api/subagents/run` | Run one subagent manually |
+| POST | `/api/subagents/batch` | Run several subagents concurrently |
+| GET | `/api/tools` | Wired tools (core / plugin / MCP) |
+| GET | `/api/acp-agents` | Detected ACP coding agents |
+
+## Background jobs & scheduler
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/background` | Background subagent jobs |
+| POST | `/api/background/{job_id}/cancel` · `/api/background/clear` | Cancel one / clear finished |
+| DELETE | `/api/background/{job_id}` | Remove a job row |
+| GET · POST | `/api/scheduler/jobs` | List / create scheduled jobs |
+| DELETE | `/api/scheduler/jobs/{job_id}` | Delete a scheduled job |
+
+## Knowledge & skills
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/knowledge/search` | Browse/search the knowledge store |
+| POST | `/api/knowledge/ingest` | [Ingest](/guides/ingestion) a file / URL / text |
+| POST | `/api/knowledge/attach` | Attach a chat upload (tiered inline-vs-index) |
+| POST · PUT · DELETE | `/api/knowledge/chunks[/{id}]` | Add / edit / delete a chunk |
+| GET | `/api/playbooks` · `/api/playbooks/{id}` | List / fetch skills ("playbooks") |
+| POST · PUT · DELETE | `/api/playbooks[/{id}]` | Create / edit / delete a skill |
+| POST | `/api/playbooks/{id}/promote` | Promote a private skill into the commons |
+
+## Activity, inbox & events
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/activity` | Provenance activity feed |
+| GET · POST | `/api/inbox` | Read / add inbox items |
+| POST | `/api/inbox/{item_id}/deliver` | Deliver an inbox item to the agent |
+| GET | `/api/events` | Server-sent event stream (console live updates) |
+| POST | `/api/events/publish` | Publish an event to the bus |
+| GET · POST · PATCH · DELETE | `/api/beads/...` | Beads issue store (status, init, issues CRUD, close) |
+
+## Config, setup & settings
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET · POST | `/api/config` | Read / write `langgraph-config.yaml` (+ SOUL) |
+| GET | `/api/config/setup-status` | Wizard state |
+| POST | `/api/config/setup` · `/api/config/reset-setup` | Complete / reset the setup wizard |
+| GET | `/api/config/presets/{name}` | A SOUL/archetype preset |
+| POST | `/api/config/models` · `/api/config/test-model` | List gateway models / test the connection |
+| GET | `/api/settings/schema` | Settings UI schema |
+| POST | `/api/settings` · `/api/settings/reset` | Apply / reset settings |
+
+## Fleet & agents
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET · POST | `/api/fleet` | List / create workspace agents |
+| PATCH · DELETE | `/api/fleet/{name}` | Rename / remove an agent |
+| POST | `/api/fleet/{name}/{start,stop,activate}` · `/api/fleet/down` | Lifecycle control |
+| GET | `/api/fleet/discover` | Discover agents (LAN mDNS + tailnet) |
+| POST · DELETE | `/api/fleet/remotes[/{ident}]` | Register / remove a remote member |
+| GET | `/api/archetypes` | Starter agent types (bundles + Basic) |
+
+## Plugins & MCP
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/plugins/installed` · `/api/plugins/catalog` · `/api/plugins/updates` | Installed / host catalog / available updates |
+| POST | `/api/plugins/install` · `/api/plugins/sync` | Install from git URL / re-sync from lock |
+| POST | `/api/plugins/{id}/enabled` · `/api/plugins/{id}/update` | Enable-disable / update one |
+| DELETE | `/api/plugins/{id}` | Uninstall |
+| POST | `/api/mcp/servers` · `/api/mcp/servers/import` | Add / import an MCP server |
+| DELETE | `/api/mcp/servers/{name}` | Remove an MCP server |
+
+## Telemetry & theme
+
+| Method | Path | Purpose |
+|---|---|---|
+| GET | `/api/telemetry/{summary,recent,export,insights}` | Cost/usage telemetry |
+| GET · PUT · DELETE | `/api/theme` | Read / set / clear the saved theme |


### PR DESCRIPTION
First content pass against `docs/dev/docs-gaps.md` (the follow-up list from the Diátaxis→domain reorg). **Five new user docs**, each slotted into the right domain group in the sidebars + section indexes.

## New pages
| Page | Section · Domain | What it covers |
|---|---|---|
| `guides/ingestion.md` | Guide · Knowledge & memory | `POST /api/knowledge/ingest`, supported formats incl. audio/video STT (gateway Whisper + ffmpeg), the "Add source" UI, chunking/enrichment config |
| `guides/knowledge.md` | Guide · Knowledge & memory | hybrid store selection + RAG tuning knobs (`top_k`/`vector_k`/`rrf_k`/`min_score`, embeddings, embed breaker) + the agent's memory tools — fills the previously empty Knowledge guide cell |
| `guides/command-palette.md` | Guide · Console & UI | the ⌘K palette (surfaces / deep-links / inline chat / `palette:"inline"` views) |
| `explanation/steering.md` | Explanation · Agent core & runtime | mid-turn steering — the queue + `SteeringMiddleware` `before_model` fold-in, the console pending-bubble/✕ + turn-end reconcile, vs. delegation-cancel |
| `reference/operator-api.md` | Reference · Console & UI | grouped map of the `/api/*` control plane, built from the live route table |

## Notes from the research
- **Command palette is already shipped** (`App.tsx` + `@protolabsai/ui/command-palette` + `usePaletteHotkey`), not just proposed as ADR 0057's status implied — documented as shipped.
- **MCP-server authoring downgraded** — already covered at a basic level in `guides/mcp.md` (§ Plugin-managed servers); only needs a fuller example if demand appears.
- `react-tauri-ui.md` rewrite still tracked (the new operator-API reference now covers its endpoint map, so the rewrite can focus on console usage).

## Verification
Docs-only. `npm run docs:build` passes clean — VitePress treats dead internal links as fatal, so the green build confirms all five pages + their cross-links + the new sidebar/index entries resolve.

🤖 Generated with [Claude Code](https://claude.com/claude-code)