### PR TITLE
feat(web): inbox as a utility-bar widget + reusable UtilityWidget primitive

### DIFF
--- a/apps/web/e2e/inbox.spec.ts
+++ b/apps/web/e2e/inbox.spec.ts
@@ -1,29 +1,29 @@
 import { expect, test } from "@playwright/test";
 
-// The Inbox lives under Activity (ADR 0003): inbound items, a sub-tab unread
-// badge, live updates on `inbox.item`, and dismiss.
+// The Inbox is a utility-bar WIDGET (2026-06 IA pass) — a bottom-left pill with an
+// unread badge that opens the inbox in a dialog; live updates on `inbox.item`, dismiss.
 
-test("inbox badge appears, panel lists items, and dismiss removes one", async ({ page }) => {
+test("inbox widget: badge appears, dialog lists items, dismiss removes one", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Inbound events bump the Activity rail's combined unread badge.
-  await expect(page.locator(".pl-count--rail")).toBeVisible();
+  // A live inbox.item event bumps the widget's unread badge.
+  await expect(page.getByTestId("inbox-badge")).toBeVisible();
 
-  // Open Activity → its Inbox sub-tab.
-  await page.getByRole("button", { name: "Activity", exact: true }).click();
-  await page.getByRole("tab", { name: /Inbox/ }).click();
-  await expect(page.getByRole("heading", { name: "Inbox" })).toBeVisible();
+  // Click the widget → the inbox opens in a dialog (not the Activity surface).
+  await page.getByTestId("inbox-widget").click();
+  const dialog = page.getByRole("dialog", { name: "Inbox" });
+  await expect(dialog).toBeVisible();
 
   // Items from GET /api/inbox render with priority + source.
-  await expect(page.getByText("build failed on main")).toBeVisible();
-  await expect(page.getByText("new signup: acme.co")).toBeVisible();
-  await expect(page.locator(".inbox-pri-now")).toBeVisible();
+  await expect(dialog.getByText("build failed on main")).toBeVisible();
+  await expect(dialog.getByText("new signup: acme.co")).toBeVisible();
+  await expect(dialog.locator(".inbox-pri-now")).toBeVisible();
 
-  // Viewing the Inbox sub-tab clears its unread badge.
+  // Opening the dialog marks the inbox read — the badge clears and stays clear while open.
   await expect(page.getByTestId("inbox-badge")).toHaveCount(0);
 
   // Dismiss the first item → it leaves the list.
-  const firstItem = page.locator(".inbox-item", { hasText: "build failed on main" });
+  const firstItem = dialog.locator(".inbox-item", { hasText: "build failed on main" });
   await firstItem.locator(".inbox-dismiss").click();
-  await expect(page.getByText("build failed on main")).toHaveCount(0);
+  await expect(dialog.getByText("build failed on main")).toHaveCount(0);
 });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -75,7 +75,7 @@ import { Button } from "@protolabsai/ui/primitives";
 
 import { ActivitySurface } from "../activity/ActivitySurface";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
-import { InboxPanel } from "../inbox/InboxPanel";
+import { InboxWidget } from "../inbox/InboxWidget";
 import { ChatSlot } from "./ChatSlot";
 import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
@@ -263,7 +263,6 @@ export function App() {
     null | { title: string; message?: string; confirmLabel?: string; onConfirm: () => void }
   >(null);
   const [activityUnread, setActivityUnread] = useState(0);
-  const [inboxUnread, setInboxUnread] = useState(0);
   // Global settings overlay (the Global home) — store-driven so BOTH the header drawer
   // and command-palette deep-links (Fleet/Telemetry/Commons) can open it. The header
   // hamburger's app drawer itself is local (only App triggers it).
@@ -425,7 +424,6 @@ export function App() {
   const activityTabRef = useRef(activityTab);
   activityTabRef.current = activityTab;
   const viewingThread = () => surfaceRef.current === "activity" && activityTabRef.current === "thread";
-  const viewingInbox = () => surfaceRef.current === "activity" && activityTabRef.current === "inbox";
 
   useEffect(
     () =>
@@ -437,14 +435,6 @@ export function App() {
   useEffect(() => {
     if (viewingThread()) setActivityUnread(0);
   }, [surface, activityTab]);
-
-  useEffect(
-    () =>
-      onServerEvent("inbox.item", () => {
-        if (!viewingInbox()) setInboxUnread((n) => n + 1);
-      }),
-    [],
-  );
 
   // Goal completions surface as a toast (goal.achieved / goal.failed on the bus, ADR 0039) so a
   // plain operator notices a terminal goal without writing a plugin hook.
@@ -460,9 +450,6 @@ export function App() {
       }));
     return () => { offDone(); offFail(); };
   }, [toast]);
-  useEffect(() => {
-    if (viewingInbox()) setInboxUnread(0);
-  }, [surface, activityTab]);
 
   // Resize + collapse are now the DS AppShell's (controlled via rightWidth/onRightWidthChange +
   // rightCollapsed/onCollapse) — the hand-rolled mouse/keyboard handlers are gone.
@@ -580,15 +567,8 @@ export function App() {
   function renderSurface(id: string): ReactNode {
     switch (id) {
       case "activity":
-        return (
-          <>
-            <Tabs responsive active={activityTab} onSelect={(t) => setActivityTab(t as ActivityTab)} items={[
-              { id: "thread", label: "Thread", icon: Activity },
-              { id: "inbox", label: "Inbox", icon: Inbox, badge: inboxUnread ? (<span data-testid="inbox-badge">{inboxUnread > 9 ? "9+" : inboxUnread}</span>) : null },
-            ].map(toTab)} />
-            {activityTab === "thread" ? <ActivitySurface onError={setError} /> : <InboxPanel />}
-          </>
-        );
+        // Inbox moved to a utility-bar widget (2026-06 IA pass); Activity is the thread.
+        return <ActivitySurface onError={setError} />;
       // Schedule is its own rail surface again (un-fold from #1075): cron triggers, but
       // timed work earns a top-level rail rather than a tab buried in Activity.
       case "schedule":
@@ -829,7 +809,7 @@ export function App() {
         className="app-shell-main"
         leftItems={railSurfaces("left").map((s) => ({
           ...s,
-          badge: s.id === "activity" ? activityUnread + inboxUnread : undefined,
+          badge: s.id === "activity" ? activityUnread : undefined,
           dot: s.id === "chat" ? chatStreaming && surface !== "chat" : pluginDots[s.id] || undefined,
         }))}
         rightItems={railSurfaces("right").map((s) => ({ ...s, dot: pluginDots[s.id] || undefined }))}
@@ -927,9 +907,10 @@ export function App() {
             // GitHub moved into the header drawer.
             start={
               <>
-                {/* Widgets — background subagents (ADR 0050 Phase 3): live pill + jobs
-                    dialog. The inbox widget lands here next. */}
+                {/* Widgets (bottom-left): background subagents (ADR 0050 Phase 3) +
+                    the inbox — each a pill with a hover info popover + a click dialog. */}
                 <BackgroundJobs />
+                <InboxWidget />
               </>
             }
             end={

--- a/apps/web/src/app/UtilityWidget.tsx
+++ b/apps/web/src/app/UtilityWidget.tsx
@@ -1,0 +1,74 @@
+import { useState } from "react";
+import type { ReactNode } from "react";
+import { Dialog, Tooltip } from "@protolabsai/ui/overlays";
+
+/**
+ * A utility-bar WIDGET (2026-06 IA pass) — a pill in the bottom-left "widgets" cluster
+ * that shows a hover info popover and opens its content in a dialog on click. The shared
+ * shape behind the inbox and plugin-contributed utility views. Presentation only — the
+ * host owns the badge, the hover info, and the dialog body.
+ *
+ * The dialog body mounts only while open (so the inbox / a plugin iframe loads on demand,
+ * not on every render).
+ */
+export function UtilityWidget({
+  icon,
+  badge,
+  label,
+  info,
+  dialogTitle,
+  dialogWidth = "min(680px, 94vw)",
+  testId,
+  onOpen,
+  onClose,
+  children,
+}: {
+  icon: ReactNode;
+  badge?: ReactNode;
+  /** aria-label for the pill (and its fallback hover title when `info` is absent). */
+  label: string;
+  /** Hover popover content — a quick preview/info; omit for a plain pill. */
+  info?: ReactNode;
+  dialogTitle: string;
+  dialogWidth?: string;
+  testId?: string;
+  onOpen?: () => void;
+  onClose?: () => void;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const pill = (
+    <button
+      type="button"
+      className="util-btn"
+      aria-label={label}
+      title={info ? undefined : label}
+      data-testid={testId}
+      onClick={() => {
+        onOpen?.();
+        setOpen(true);
+      }}
+    >
+      {icon}
+      {badge}
+    </button>
+  );
+  return (
+    <>
+      {info ? <Tooltip label={info}>{pill}</Tooltip> : pill}
+      {open ? (
+        <Dialog
+          open
+          onClose={() => {
+            setOpen(false);
+            onClose?.();
+          }}
+          title={dialogTitle}
+          width={dialogWidth}
+        >
+          {children}
+        </Dialog>
+      ) : null}
+    </>
+  );
+}

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -79,12 +79,8 @@ function deepLinkCommands(): Command[] {
     },
   });
   return [
-    link("act:inbox", "Activity: Inbox", ["activity", "inbox"], () => {
-      ui().setSurface("activity");
-      ui().setActivityTab("inbox");
-    }),
-    // (Schedule is a top-level rail surface again — it auto-registers as a "go to"
-    // nav command, so no Activity deep-link here.)
+    // (Inbox moved to a utility-bar widget; Schedule is a top-level rail surface that
+    // auto-registers as a "go to" nav command — so no Activity deep-links here.)
     link("plug:market", "Plugins: Discover", ["plugins", "discover", "market", "directory", "browse"], () => {
       ui().setSurface("plugins");
       ui().setPluginsTab("market");

--- a/apps/web/src/inbox/InboxWidget.tsx
+++ b/apps/web/src/inbox/InboxWidget.tsx
@@ -1,0 +1,35 @@
+import { useEffect, useRef, useState } from "react";
+import { Inbox } from "lucide-react";
+
+import { onServerEvent } from "../lib/events";
+import { UtilityWidget } from "../app/UtilityWidget";
+import { InboxPanel } from "./InboxPanel";
+
+/**
+ * The inbox as a utility-bar widget (2026-06 IA pass) — moved out of the Activity surface
+ * into the bottom-left widgets cluster. A pill with an unread badge; hover shows the count,
+ * click opens the inbox in a dialog (which marks it read). Tracks its own unread off the
+ * `inbox.item` bus event — incrementing only while the dialog is closed.
+ */
+export function InboxWidget() {
+  const [unread, setUnread] = useState(0);
+  const openRef = useRef(false);
+  useEffect(
+    () => onServerEvent("inbox.item", () => { if (!openRef.current) setUnread((n) => n + 1); }),
+    [],
+  );
+  return (
+    <UtilityWidget
+      testId="inbox-widget"
+      icon={<Inbox size={14} />}
+      badge={unread ? <span data-testid="inbox-badge">{unread > 9 ? "9+" : unread}</span> : null}
+      label={unread ? `Inbox — ${unread} unread` : "Inbox"}
+      info={unread ? `${unread} unread inbound item${unread === 1 ? "" : "s"}` : "Inbox — nothing new"}
+      dialogTitle="Inbox"
+      onOpen={() => { openRef.current = true; setUnread(0); }}
+      onClose={() => { openRef.current = false; }}
+    >
+      <InboxPanel />
+    </UtilityWidget>
+  );
+}


### PR DESCRIPTION
Moves the **inbox** out of the Activity surface into the **bottom-left widgets cluster**, and lands the shared widget shape that the upcoming plugin widgets will reuse.

- **`UtilityWidget`** — a pill that shows a **hover info popover** (DS `Tooltip`) and opens its content in a **dialog** on click. The dialog body mounts only while open.
- **`InboxWidget`** — the inbox as a `UtilityWidget`: unread badge, hover count, click opens the inbox in a dialog (which marks it read). It tracks its own unread off `inbox.item` (incrementing only while closed), so that logic leaves `App`.
- **Activity** is now just the thread (no Thread/Inbox sub-tabs); dropped the `act:inbox` palette deep-link; the Activity rail badge is activity-only.

**Verification:** `inbox.spec` rewritten for the widget (badge → click → dialog → dismiss). Build + 98 web + **109 E2E** green.

**Next (PR 2):** plugin-contributed utility widgets — a `utility` manifest flag renders a plugin view as a `UtilityWidget` opening the plugin's iframe in a dialog, with hover info.

🤖 Generated with [Claude Code](https://claude.com/claude-code)