### PR TITLE
feat(web): plugin-contributed utility-bar widgets (utility flag → iframe dialog)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -54,6 +54,8 @@ export const RUNTIME_STATUS = {
         { id: "stats", label: "Stats", icon: "BarChart3", path: "/plugins/boardy/stats" },
         // A right-rail panel (ADR 0026 placement:"right") — sits with Notes/Beads/Goals.
         { id: "scratch", label: "Scratch", icon: "FileText", path: "/plugins/boardy/scratch", placement: "right" },
+        // A utility-bar widget (2026-06 IA pass): a bottom-left pill → dialog, with hover info.
+        { id: "snap", label: "Boardy Snapshot", icon: "Gauge", path: "/plugins/boardy/snap", utility: { info: "A quick board snapshot" } },
       ],
     },
   ],

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -114,3 +114,21 @@ test("a plugin view with placement:right becomes a right-sidebar panel", async (
   await expect(frame).toBeVisible();
   await expect(frame).toHaveAttribute("src", /\/plugins\/boardy\/scratch/);
 });
+
+test("a plugin view with utility:{...} is a bottom-left widget (hover info + click dialog)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  // It's a pill in the bottom-left widgets cluster — NOT a left-rail surface.
+  const pill = page.getByTestId("util-widget-snap");
+  await expect(pill).toBeVisible();
+  await expect(page.locator(".pl-rail").getByRole("button", { name: "Boardy Snapshot" })).toHaveCount(0);
+
+  // The hover info popover carries the manifest's `utility.info`.
+  await expect(page.locator(".pl-tip-wrap", { has: pill }).getByRole("tooltip")).toContainText("A quick board snapshot");
+
+  // Click → the plugin opens in a dialog hosting its iframe at the declared path.
+  await pill.click();
+  const dialog = page.getByRole("dialog", { name: "Boardy Snapshot" });
+  await expect(dialog).toBeVisible();
+  await expect(dialog.locator(".plugin-view-frame")).toHaveAttribute("src", /\/plugins\/boardy\/snap/);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -93,6 +93,7 @@ import {
 } from "../state/uiStore";
 import { api, apiUrl, authToken, is401 } from "../lib/api";
 import { PluginView, consoleTheme } from "./PluginView";
+import { UtilityWidget } from "./UtilityWidget";
 import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
 import { CommandPalette, usePaletteHotkey } from "@protolabsai/ui/command-palette";
 import type { PaletteView } from "@protolabsai/ui/command-palette";
@@ -170,14 +171,14 @@ function lazyLucideIcon(key: string): IconComp {
   }
   return comp;
 }
-function pluginViewIcon(name?: string): ReactNode {
-  if (!name) return <Puzzle size={18} />;
+function pluginViewIcon(name?: string, size = 18): ReactNode {
+  if (!name) return <Puzzle size={size} />;
   const Curated = PLUGIN_VIEW_ICONS[name];
-  if (Curated) return <Curated size={18} />;
+  if (Curated) return <Curated size={size} />;
   const Lazy = lazyLucideIcon(toPascalCase(name));
   return (
-    <Suspense fallback={<Puzzle size={18} />}>
-      <Lazy size={18} />
+    <Suspense fallback={<Puzzle size={size} />}>
+      <Lazy size={size} />
     </Suspense>
   );
 }
@@ -321,7 +322,10 @@ export function App() {
   // renders under the core "chat" rail id, so it's excluded from the dynamic rail
   // list below. First enabled claimant wins (deterministic: plugin load order).
   const chatSlotView = allDeclaredViews.find((v) => v.slot === "chat");
-  const allPluginViews = allDeclaredViews.filter((v) => v.slot !== "chat");
+  // A view with `utility` is a bottom-left utility-bar widget (a pill → dialog), NOT a rail
+  // surface — so it's excluded from the rail list, like the chat-slot claimant.
+  const utilityWidgetViews = allDeclaredViews.filter((v) => v.utility);
+  const allPluginViews = allDeclaredViews.filter((v) => v.slot !== "chat" && !v.utility);
   // Enabled plugin ids — gates ext surfaces that declare requiresPlugin (e.g. Studio → workflows).
   const enabledPluginIds = new Set((runtime?.plugins ?? []).filter((p) => p.enabled).map((p) => p.id));
 
@@ -911,6 +915,23 @@ export function App() {
                     the inbox — each a pill with a hover info popover + a click dialog. */}
                 <BackgroundJobs />
                 <InboxWidget />
+                {/* Plugin-contributed utility widgets (`views[].utility`): a pill that opens
+                    the plugin's iframe in a dialog, with hover info. Reuses PluginView. */}
+                {utilityWidgetViews.map((v) => (
+                  <UtilityWidget
+                    key={v.key}
+                    testId={`util-widget-${v.id}`}
+                    icon={pluginViewIcon(v.icon, 14)}
+                    label={v.label}
+                    info={typeof v.utility === "object" && v.utility?.info ? v.utility.info : `Open ${v.label}`}
+                    dialogTitle={v.label}
+                    dialogWidth="min(900px, 96vw)"
+                  >
+                    <div className="plugin-widget-dialog">
+                      <PluginView view={v} />
+                    </div>
+                  </UtilityWidget>
+                ))}
               </>
             }
             end={

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1717,6 +1717,10 @@ textarea {
 .plugin-view-body { position: relative; flex: 1; min-height: 0; }
 .plugin-view-frame { width: 100%; height: 100%; border: 0; background: var(--bg); display: block; }
 .plugin-view-state { display: flex; align-items: center; gap: 8px; padding: 24px; color: var(--fg-muted); font-size: 13px; }
+/* A plugin view hosted in a utility-widget DIALOG (vs the stage): give it a fixed height
+   so the iframe has room to fill (the stage normally supplies that via its flex column). */
+.plugin-widget-dialog { display: flex; flex-direction: column; height: 70vh; min-height: 0; }
+.plugin-widget-dialog > .plugin-view { flex: 1; min-height: 0; }
 
 /* Plugins panel (ADR 0027, .plugin-install-* / .plugin-list / .plugin-row-main / -title /
    .plugin-ver/.plugin-state/.plugin-desc/.plugin-meta/.plugin-review/.plugin-enable-hint

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -109,6 +109,11 @@ export type PluginView = {
   // editor) vs the full rail panel — so a plugin can ship separate panel/palette views.
   // Passes through `_parse_views` verbatim (it keeps the whole view dict) — manifest-only.
   palette?: "inline" | { path?: string };
+  // Render this view as a UTILITY-BAR WIDGET (2026-06 IA pass): a bottom-left pill that
+  // shows a hover info popover and opens the view's iframe in a DIALOG on click, instead of
+  // adding a rail surface. `true` uses the label as the hover info; `{ info }` sets custom
+  // hover text. Like `palette`, it rides through `_parse_views` verbatim — manifest-only.
+  utility?: boolean | { info?: string };
   // Owning plugin's load state, stamped on by App so the view host can surface a real,
   // actionable error (loaded=false ⇒ the view route isn't serving — missing env / bad
   // deps / mount race; `pluginError` is the loader's exact diagnostic) instead of a


### PR DESCRIPTION
PR 2 of the utility-bar IA pass (builds on the `UtilityWidget` primitive from #1178): **plugins can add their own widgets** to the bottom-left cluster.

A plugin view opts in with a manifest flag:
```yaml
views:
  - id: snap
    label: Boardy Snapshot
    icon: Gauge
    path: /plugins/boardy/snap
    utility: { info: "A quick board snapshot" }   # or just `utility: true`
```
→ a **pill** that shows a **hover info popover** (`utility.info`) and opens the plugin's **iframe in a dialog** on click — instead of a rail surface. "Whatever the plugin author wants" renders in their own page.

- `utility?: boolean | { info?: string }` on `PluginView` — rides through `_parse_views` verbatim, so **no backend change**.
- Utility-flagged views are excluded from the rail and rendered as `UtilityWidget`s hosting `PluginView` in a sized dialog. `pluginViewIcon` gained a size param for the 14px pill.

**Verification:** new E2E — a mock plugin's utility view renders as a pill (not a rail icon), exposes the hover info, and click opens a dialog with the iframe at the declared path. Build + 98 web + **110 E2E** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)