### PR TITLE
docs: add a Skills (SKILL.md) reference page

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -164,6 +164,11 @@ export default defineConfig({
           ],
         },
         {
+          text: "Skills, subagents & workflows",
+          collapsed: false,
+          items: [{ text: "Skills (SKILL.md)", link: "/reference/skills" }],
+        },
+        {
           text: "A2A, fleet & delegates",
           collapsed: false,
           items: [

--- a/docs/dev/docs-gaps.md
+++ b/docs/dev/docs-gaps.md
@@ -15,14 +15,14 @@ target Diátaxis section, and target domain (from the 9-domain taxonomy).
 | Operator REST API reference | `docs/reference/operator-api.md` |
 | Skills loaded chip / `skills.announce` | already in `docs/guides/skills.md` |
 | Operator-console rewrite (was the Gradio→React migration plan) | `docs/guides/react-tauri-ui.md` |
+| Skills reference (frontmatter/schema lookup) | `docs/reference/skills.md` |
 
 ## Remaining
 
 | # | Gap | Section | Domain | Notes |
 |---|---|---|---|---|
 | 1 | **Author a managed MCP server** | Guide | Tools, MCP & plugins | Already covered at a basic level in `guides/mcp.md` (§ Plugin-managed servers, `register_mcp_server`). Only needs a fuller worked example if demand appears — low priority. |
-| 2 | **Skills reference** (frontmatter/schema lookup) | Reference | Skills, subagents & workflows | Skills domain has guides + explanation but no Reference page. |
-| 3 | **First-skill / Langfuse tutorials** | Tutorial | Skills / Operate | Tutorials are thin (2). Candidates: "Write your first skill", "Set up Langfuse tracing". |
+| 2 | **First-skill / Langfuse tutorials** | Tutorial | Skills / Operate | Tutorials are thin (2). Candidates: "Write your first skill", "Set up Langfuse tracing". |
 
 _(No outstanding stale-doc rewrites — `react-tauri-ui.md` was rewritten into a current
 operator-console guide.)_

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -103,4 +103,6 @@ loaded.
   companion `/dream` consolidates memory). Both are schedulable (ADR 0054). The
   skill curator (`graph/skills/curator.py`) decays and prunes non-pinned skills;
   disk skills (your `SKILL.md` files) are pinned.
-- OS/binary gating fields are parsed but not yet enforced.
+- Only `name` / `description` / `tools` / `user_facing` / `slash` are read; any other
+  frontmatter keys are ignored. See the [Skills reference](/reference/skills) for the exact
+  field + config schema.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,6 +9,12 @@ Information-oriented. Look up exact shapes and values here, grouped by **domain*
 | [Configuration](/reference/configuration) | `config/langgraph-config.yaml` schema |
 | [Environment variables](/reference/environment-variables) | Every env knob |
 
+## Skills, subagents & workflows
+
+| Page | Contents |
+|---|---|
+| [Skills (SKILL.md)](/reference/skills) | Frontmatter fields, source tags, the `skills:` config block |
+
 ## A2A, fleet & delegates
 
 | Page | Contents |

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,0 +1,79 @@
+# Skills (`SKILL.md`) reference
+
+Exact shapes for the skill format and store. For *how and when* to use skills, see the
+[Skills guide](/guides/skills); for the design, [Memory & the knowledge store](/explanation/memory-and-knowledge).
+
+A skill is a folder containing a `SKILL.md` — YAML frontmatter, then a markdown body.
+
+## Frontmatter fields
+
+These are the only keys the loader (`graph/skills/loader.py`) reads. Any other frontmatter
+key is **ignored** (no OS/binary/license gating is parsed or enforced).
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | ✅ | Unique. Lowercase-with-hyphens by convention. A live skill with the same `name` overrides a bundled one. |
+| `description` | string | ✅ | The retrieval **trigger signal** (BM25 over name/description/body). Truncated at **1024 chars**. Write it "pushy" — say plainly *when* to use the skill. |
+| `tools` (or `metadata.tools`) | list[string] | — | Advisory tool names the skill relies on. Surfaced to the model as `<relevant_tools>` when retrieved — a hint, not a gate ([ADR 0005](/adr/0005-tool-pollution-and-progressive-disclosure)). |
+| `user_facing` | bool | — | `true` → the skill is invokable as a `/<slash>` chat command ([ADR 0052](/adr/0052-user-facing-skills-slash-commands)). Default `false`. Truthy spellings: `true` / `1` / `yes` / `on`. |
+| `slash` | string | — | The `/<token>` trigger for a `user_facing` skill (whitespace-free). Blank → slugified `name` (lowercased, non-alphanumerics → hyphens). |
+
+The markdown **body** is the skill's procedure — freeform instructions, used verbatim as
+the injected guidance (and as the directive when invoked via `/slash`).
+
+```markdown
+---
+name: web-research
+description: >-
+  Use whenever the user asks you to research a topic, compare options, or gather
+  background from the web.
+tools: [web_search, fetch_url]
+user_facing: true
+slash: web-research
+---
+
+# Web Research
+1. Plan briefly.
+2. Search with web_search …
+```
+
+## Where skills load from
+
+Roots, later wins on duplicate `name`:
+
+| Root | Source tag | Writable |
+|---|---|---|
+| `<repo>/config/skills/<slug>/SKILL.md` (bundled examples) | `disk` | read-only |
+| `<config-dir>/skills/<slug>/SKILL.md` (`skills.dir` override) | `disk` | ✅ |
+| plugin-bundled skill dirs | `disk` | via the plugin |
+| operator/console-authored (`user_skills_dir()`) | `disk` | ✅ (live CRUD) |
+
+Sub-folders are organizational only — a skill is named by its frontmatter, not its path.
+
+## The index & source tags
+
+Skills live in a SQLite/FTS5 index (`skills.db`). Each row carries a `source`:
+
+| `source` | Produced by | Curated? |
+|---|---|---|
+| `disk` | `SKILL.md` files + console CRUD (re-seeded each boot) | **pinned** — never decayed/pruned |
+| `distilled` | the `/distill` subagent (`save_skill`) | yes (curator) |
+| `promoted` | `python -m server skills promote <name>` → the commons (layered tier) | yes (curator) |
+
+The curator (`python -m graph.skills.curator`) decays + prunes non-`disk` skills; see the
+[Skills guide](/guides/skills).
+
+## Configuration (`skills:` block)
+
+| Key | Default | Meaning |
+|---|---|---|
+| `enabled` | `true` | Load + retrieve skills at all |
+| `db_path` | `/sandbox/skills.db` | Index location (→ `~/.protoagent/skills.db` fallback) |
+| `top_k` | `5` | Max skills injected into the prompt per turn |
+| `announce` | `true` | Show the "📚 Skills loaded" chip in chat |
+| `dir` | `""` | Override the writable skills root |
+| `scope` | `""` (→ `scoped`) | Tier: `scoped` (private) · `shared` (one commons) · `layered` (read commons ∪ private, write private) ([ADR 0041](/adr/0041-workspaces-and-tiered-stores)) |
+| `shared` | `false` | Back-compat boolean — `true` → `scope: shared` when `scope` is blank |
+
+The shared-tier commons base dir is `commons.path` (blank → `~/.protoagent/commons`).
+`GET /api/runtime/status` reports `skills.count`.


### PR DESCRIPTION
Fills the Skills-domain Reference gap from `docs/dev/docs-gaps.md`. New `docs/reference/skills.md` — an information-oriented lookup that complements the [Skills guide](/guides/skills):

- **Frontmatter field table** — `name`, `description`, `tools`/`metadata.tools`, `user_facing`, `slash`: exactly what `graph/skills/loader.py` reads, with types/required/truncation. Notes that **any other key is ignored** (no OS/binary/license gating is parsed).
- **Load roots + precedence**, the index **`source` tags** (`disk` pinned vs `distilled`/`promoted` curated), and the full **`skills:` config block** with defaults + the tier (`scope`) options.

Wired into the Reference sidebar + index under a new **Skills, subagents & workflows** group (in domain order).

**Stale fix found en route:** the skills guide claimed "OS/binary gating fields are parsed but not yet enforced" — the loader parses no such fields, so that's corrected to "only these 5 keys are read; others ignored."

Docs-only. `npm run docs:build` passes clean (dead links fatal). Field list verified against `graph/skills/loader.py`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)