### PR TITLE
docs: add "Write your first skill" tutorial

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,11 @@ export default defineConfig({
           items: [{ text: "Spin up your first agent", link: "/tutorials/first-agent" }],
         },
         {
+          text: "Skills, subagents & workflows",
+          collapsed: false,
+          items: [{ text: "Write your first skill", link: "/tutorials/first-skill" }],
+        },
+        {
           text: "Tools, MCP & plugins",
           collapsed: false,
           items: [{ text: "Write your first tool", link: "/tutorials/first-tool" }],

--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -164,6 +164,11 @@ export default defineConfig({
           ],
         },
         {
+          text: "Skills, subagents & workflows",
+          collapsed: false,
+          items: [{ text: "Skills (SKILL.md)", link: "/reference/skills" }],
+        },
+        {
           text: "A2A, fleet & delegates",
           collapsed: false,
           items: [

--- a/docs/dev/docs-gaps.md
+++ b/docs/dev/docs-gaps.md
@@ -15,14 +15,14 @@ target Diátaxis section, and target domain (from the 9-domain taxonomy).
 | Operator REST API reference | `docs/reference/operator-api.md` |
 | Skills loaded chip / `skills.announce` | already in `docs/guides/skills.md` |
 | Operator-console rewrite (was the Gradio→React migration plan) | `docs/guides/react-tauri-ui.md` |
+| Skills reference (frontmatter/schema lookup) | `docs/reference/skills.md` |
 
 ## Remaining
 
 | # | Gap | Section | Domain | Notes |
 |---|---|---|---|---|
 | 1 | **Author a managed MCP server** | Guide | Tools, MCP & plugins | Already covered at a basic level in `guides/mcp.md` (§ Plugin-managed servers, `register_mcp_server`). Only needs a fuller worked example if demand appears — low priority. |
-| 2 | **Skills reference** (frontmatter/schema lookup) | Reference | Skills, subagents & workflows | Skills domain has guides + explanation but no Reference page. |
-| 3 | **First-skill / Langfuse tutorials** | Tutorial | Skills / Operate | Tutorials are thin (2). Candidates: "Write your first skill", "Set up Langfuse tracing". |
+| 2 | **First-skill / Langfuse tutorials** | Tutorial | Skills / Operate | Tutorials are thin (2). Candidates: "Write your first skill", "Set up Langfuse tracing". |
 
 _(No outstanding stale-doc rewrites — `react-tauri-ui.md` was rewritten into a current
 operator-console guide.)_

--- a/docs/dev/docs-gaps.md
+++ b/docs/dev/docs-gaps.md
@@ -16,13 +16,16 @@ target Diátaxis section, and target domain (from the 9-domain taxonomy).
 | Skills loaded chip / `skills.announce` | already in `docs/guides/skills.md` |
 | Operator-console rewrite (was the Gradio→React migration plan) | `docs/guides/react-tauri-ui.md` |
 | Skills reference (frontmatter/schema lookup) | `docs/reference/skills.md` |
+| "Write your first skill" tutorial | `docs/tutorials/first-skill.md` |
 
 ## Remaining
 
 | # | Gap | Section | Domain | Notes |
 |---|---|---|---|---|
 | 1 | **Author a managed MCP server** | Guide | Tools, MCP & plugins | Already covered at a basic level in `guides/mcp.md` (§ Plugin-managed servers, `register_mcp_server`). Only needs a fuller worked example if demand appears — low priority. |
-| 2 | **First-skill / Langfuse tutorials** | Tutorial | Skills / Operate | Tutorials are thin (2). Candidates: "Write your first skill", "Set up Langfuse tracing". |
+
+_Langfuse-tracing tutorial: **intentionally not written** — `guides/observability.md` already
+covers it step-by-step; a tutorial would duplicate it._
 
 _(No outstanding stale-doc rewrites — `react-tauri-ui.md` was rewritten into a current
 operator-console guide.)_

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -103,4 +103,6 @@ loaded.
   companion `/dream` consolidates memory). Both are schedulable (ADR 0054). The
   skill curator (`graph/skills/curator.py`) decays and prunes non-pinned skills;
   disk skills (your `SKILL.md` files) are pinned.
-- OS/binary gating fields are parsed but not yet enforced.
+- Only `name` / `description` / `tools` / `user_facing` / `slash` are read; any other
+  frontmatter keys are ignored. See the [Skills reference](/reference/skills) for the exact
+  field + config schema.

--- a/docs/reference/index.md
+++ b/docs/reference/index.md
@@ -9,6 +9,12 @@ Information-oriented. Look up exact shapes and values here, grouped by **domain*
 | [Configuration](/reference/configuration) | `config/langgraph-config.yaml` schema |
 | [Environment variables](/reference/environment-variables) | Every env knob |
 
+## Skills, subagents & workflows
+
+| Page | Contents |
+|---|---|
+| [Skills (SKILL.md)](/reference/skills) | Frontmatter fields, source tags, the `skills:` config block |
+
 ## A2A, fleet & delegates
 
 | Page | Contents |

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -1,0 +1,79 @@
+# Skills (`SKILL.md`) reference
+
+Exact shapes for the skill format and store. For *how and when* to use skills, see the
+[Skills guide](/guides/skills); for the design, [Memory & the knowledge store](/explanation/memory-and-knowledge).
+
+A skill is a folder containing a `SKILL.md` — YAML frontmatter, then a markdown body.
+
+## Frontmatter fields
+
+These are the only keys the loader (`graph/skills/loader.py`) reads. Any other frontmatter
+key is **ignored** (no OS/binary/license gating is parsed or enforced).
+
+| Field | Type | Required | Notes |
+|---|---|---|---|
+| `name` | string | ✅ | Unique. Lowercase-with-hyphens by convention. A live skill with the same `name` overrides a bundled one. |
+| `description` | string | ✅ | The retrieval **trigger signal** (BM25 over name/description/body). Truncated at **1024 chars**. Write it "pushy" — say plainly *when* to use the skill. |
+| `tools` (or `metadata.tools`) | list[string] | — | Advisory tool names the skill relies on. Surfaced to the model as `<relevant_tools>` when retrieved — a hint, not a gate ([ADR 0005](/adr/0005-tool-pollution-and-progressive-disclosure)). |
+| `user_facing` | bool | — | `true` → the skill is invokable as a `/<slash>` chat command ([ADR 0052](/adr/0052-user-facing-skills-slash-commands)). Default `false`. Truthy spellings: `true` / `1` / `yes` / `on`. |
+| `slash` | string | — | The `/<token>` trigger for a `user_facing` skill (whitespace-free). Blank → slugified `name` (lowercased, non-alphanumerics → hyphens). |
+
+The markdown **body** is the skill's procedure — freeform instructions, used verbatim as
+the injected guidance (and as the directive when invoked via `/slash`).
+
+```markdown
+---
+name: web-research
+description: >-
+  Use whenever the user asks you to research a topic, compare options, or gather
+  background from the web.
+tools: [web_search, fetch_url]
+user_facing: true
+slash: web-research
+---
+
+# Web Research
+1. Plan briefly.
+2. Search with web_search …
+```
+
+## Where skills load from
+
+Roots, later wins on duplicate `name`:
+
+| Root | Source tag | Writable |
+|---|---|---|
+| `<repo>/config/skills/<slug>/SKILL.md` (bundled examples) | `disk` | read-only |
+| `<config-dir>/skills/<slug>/SKILL.md` (`skills.dir` override) | `disk` | ✅ |
+| plugin-bundled skill dirs | `disk` | via the plugin |
+| operator/console-authored (`user_skills_dir()`) | `disk` | ✅ (live CRUD) |
+
+Sub-folders are organizational only — a skill is named by its frontmatter, not its path.
+
+## The index & source tags
+
+Skills live in a SQLite/FTS5 index (`skills.db`). Each row carries a `source`:
+
+| `source` | Produced by | Curated? |
+|---|---|---|
+| `disk` | `SKILL.md` files + console CRUD (re-seeded each boot) | **pinned** — never decayed/pruned |
+| `distilled` | the `/distill` subagent (`save_skill`) | yes (curator) |
+| `promoted` | `python -m server skills promote <name>` → the commons (layered tier) | yes (curator) |
+
+The curator (`python -m graph.skills.curator`) decays + prunes non-`disk` skills; see the
+[Skills guide](/guides/skills).
+
+## Configuration (`skills:` block)
+
+| Key | Default | Meaning |
+|---|---|---|
+| `enabled` | `true` | Load + retrieve skills at all |
+| `db_path` | `/sandbox/skills.db` | Index location (→ `~/.protoagent/skills.db` fallback) |
+| `top_k` | `5` | Max skills injected into the prompt per turn |
+| `announce` | `true` | Show the "📚 Skills loaded" chip in chat |
+| `dir` | `""` | Override the writable skills root |
+| `scope` | `""` (→ `scoped`) | Tier: `scoped` (private) · `shared` (one commons) · `layered` (read commons ∪ private, write private) ([ADR 0041](/adr/0041-workspaces-and-tiered-stores)) |
+| `shared` | `false` | Back-compat boolean — `true` → `scope: shared` when `scope` is blank |
+
+The shared-tier commons base dir is `commons.path` (blank → `~/.protoagent/commons`).
+`GET /api/runtime/status` reports `skills.count`.

--- a/docs/tutorials/first-skill.md
+++ b/docs/tutorials/first-skill.md
@@ -1,0 +1,88 @@
+# Write your first skill
+
+A **skill** teaches the agent how and when to handle a recurring task. You drop in a
+`SKILL.md` folder; the agent retrieves it by relevance and follows it — no code, no
+re-explaining each turn. By the end of this tutorial you'll have a skill the agent uses
+automatically *and* can run on demand as a `/slash` command.
+
+> Prerequisite: a running agent — see [Spin up your first agent](/tutorials/first-agent).
+> For the full format, see the [Skills reference](/reference/skills); for the concepts, the
+> [Skills guide](/guides/skills).
+
+## 1. Create the skill
+
+Make a folder under your skills root with a `SKILL.md` inside. On the default instance:
+
+```
+config/skills/tldr/SKILL.md
+```
+
+```markdown
+---
+name: tldr
+description: >-
+  Use whenever the user asks for a TL;DR, a summary, or "the short version" of a
+  document, thread, or block of text.
+tools: []
+---
+
+# TL;DR
+
+1. Read the provided text closely.
+2. Reply with exactly three bullet points — the most important takeaways, in plain language.
+3. End with a one-line bottom line prefixed **Bottom line:**.
+```
+
+The **`description` is the trigger** — it's what relevance retrieval matches against, so
+say plainly *when* to reach for the skill. The **body** is the procedure the agent follows.
+
+## 2. Load it
+
+The agent indexes `SKILL.md` files at boot, so restart the server (or trigger a config
+reload). Confirm it loaded:
+
+```bash
+curl -s localhost:7870/api/runtime/status | grep -o '"skills":[^}]*'
+```
+
+> Shortcut: the console's **Agent → Skills → New** authors a skill **live** — no restart.
+> The file path above is the portable, fork-friendly way and shows the raw format.
+
+## 3. Watch it fire
+
+In chat, ask something that matches the description:
+
+> *"Give me a TL;DR of this: \<paste a few paragraphs\>"*
+
+Above the answer you'll see a **📚 Skills: tldr** chip — that's the agent telling you it
+pulled your skill into the turn. The reply should come back as three bullets + a bottom
+line, because that's the procedure you wrote. (No match in the message → no chip; that's
+relevance retrieval working as intended.)
+
+## 4. Make it runnable on demand
+
+Add two frontmatter keys so the skill becomes a `/slash` command too:
+
+```markdown
+---
+name: tldr
+description: >-
+  Use whenever the user asks for a TL;DR or summary of some text.
+user_facing: true
+slash: tldr
+---
+```
+
+Restart, then type `/tldr` in the composer — it appears in the slash menu. `/tldr <text>`
+runs the procedure on the spot (it rewrites the turn with your skill's body as the
+directive; [ADR 0052](/adr/0052-user-facing-skills-slash-commands)).
+
+## What you learned
+
+- A skill is just a `SKILL.md` (frontmatter + body) — the `description` triggers it, the
+  body is the procedure.
+- Retrieved skills surface as the **📚 Skills** chip; `user_facing` skills also run as
+  `/slash` commands.
+
+Next: the [Skills guide](/guides/skills) (tiers, the curator, `/distill` self-authoring)
+and the [Skills reference](/reference/skills) (every field + the `skills:` config block).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -8,10 +8,16 @@ Learning-oriented walkthroughs. Start here if you're new to protoAgent. Grouped 
 |---|---|
 | [Spin up your first agent](/tutorials/first-agent) | A forked, renamed container you can chat with locally |
 
+## Skills, subagents & workflows
+
+| Tutorial | What you'll end up with |
+|---|---|
+| [Write your first skill](/tutorials/first-skill) | A `SKILL.md` the agent auto-uses (and runs via `/slash`) |
+
 ## Tools, MCP & plugins
 
 | Tutorial | What you'll end up with |
 |---|---|
 | [Write your first tool](/tutorials/first-tool) | A custom LangChain tool wired into the agent's loop |
 
-Once you've worked through both, the [How-To Guides](/guides/) are where to head next — they assume you already have an agent running.
+Once you've worked through these, the [How-To Guides](/guides/) are where to head next — they assume you already have an agent running.


### PR DESCRIPTION
Fills the thin Tutorials section — Skills had a guide + reference + explanation but **no tutorial**. New `docs/tutorials/first-skill.md`, a hands-on walkthrough:

1. Author a `tldr` `SKILL.md` (frontmatter + body)
2. Load it (restart, or the live console path)
3. Watch the **📚 Skills** chip fire when a matching message arrives
4. Make it user-facing → run it as `/tldr`

Wired into the Tutorials sidebar + index under a new **Skills, subagents & workflows** group (domain order), so the section now reads Getting started → Skills → Tools.

**Scope call:** the candidate "Set up Langfuse tracing" tutorial is **intentionally not written** — `guides/observability.md` already covers it step-by-step, so a tutorial would just duplicate it (noted in `docs-gaps.md`). Remaining backlog is one optional item (a fuller MCP-authoring example; basic coverage already exists).

Docs-only. `npm run docs:build` passes clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)