### PR TITLE
docs: managed-MCP example + first-skill tutorial + fix skills-chip emoji

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -56,6 +56,11 @@ export default defineConfig({
           items: [{ text: "Spin up your first agent", link: "/tutorials/first-agent" }],
         },
         {
+          text: "Skills, subagents & workflows",
+          collapsed: false,
+          items: [{ text: "Write your first skill", link: "/tutorials/first-skill" }],
+        },
+        {
           text: "Tools, MCP & plugins",
           collapsed: false,
           items: [{ text: "Write your first tool", link: "/tutorials/first-tool" }],

--- a/docs/dev/docs-gaps.md
+++ b/docs/dev/docs-gaps.md
@@ -16,18 +16,15 @@ target Diátaxis section, and target domain (from the 9-domain taxonomy).
 | Skills loaded chip / `skills.announce` | already in `docs/guides/skills.md` |
 | Operator-console rewrite (was the Gradio→React migration plan) | `docs/guides/react-tauri-ui.md` |
 | Skills reference (frontmatter/schema lookup) | `docs/reference/skills.md` |
+| "Write your first skill" tutorial | `docs/tutorials/first-skill.md` |
+| Managed-MCP-server worked example | `docs/guides/mcp.md` (§ Plugin-managed servers) |
 
 ## Remaining
 
-| # | Gap | Section | Domain | Notes |
-|---|---|---|---|---|
-| 1 | **Author a managed MCP server** | Guide | Tools, MCP & plugins | Already covered at a basic level in `guides/mcp.md` (§ Plugin-managed servers, `register_mcp_server`). Only needs a fuller worked example if demand appears — low priority. |
-| 2 | **First-skill / Langfuse tutorials** | Tutorial | Skills / Operate | Tutorials are thin (2). Candidates: "Write your first skill", "Set up Langfuse tracing". |
+_All audit gaps are filled._
 
-_(No outstanding stale-doc rewrites — `react-tauri-ui.md` was rewritten into a current
-operator-console guide.)_
-
-> Note: the console IA is mid-evolution (utility bar + bottom panel landed in #1176/#1178;
-> ADR 0056 "unified dockable view model" is Proposed). The console guide describes surfaces
-> by behavior, not fixed geometry, to stay durable — re-check the Layout section if the
-> dockable-view work lands.
+- Langfuse-tracing tutorial: **intentionally not written** — `guides/observability.md`
+  already covers it step-by-step; a tutorial would duplicate it.
+- The console guide's Layout section describes surfaces by behavior, not geometry (the IA is
+  mid-evolution — utility bar + bottom panel landed in #1176/#1178; ADR 0056 "dockable
+  views" is Proposed). Fine today; re-check that section if the dockable-view work lands.

--- a/docs/guides/mcp.md
+++ b/docs/guides/mcp.md
@@ -57,14 +57,50 @@ other servers.
 
 ## Plugin-managed servers
 
-A **plugin** can contribute a managed MCP server (you never hand-edit
-`mcp.servers`) via `register_mcp_server(factory)` — `factory(config)` returns an
-`mcp.servers[]` entry, or `None` when the server shouldn't run (off / not yet
-connected), so the server comes and goes with config. A plugin entry whose `name`
-matches a configured server **replaces** it, and a plugin contributing a server
-**activates MCP even when `mcp.enabled` is off**. An OAuth-gated Gmail/Calendar
-integration (e.g. a Google external plugin, launched frozen via the `--mcp-plugin`
-shim) is the canonical worked example. See [Plugins](./plugins.md).
+A **plugin** can contribute a managed MCP server (you never hand-edit `mcp.servers`)
+via `register_mcp_server(factory)` — `factory(config)` returns an `mcp.servers[]` entry,
+or `None` when the server shouldn't run (off / not yet connected). The factory runs at
+**every graph build** with the live `LangGraphConfig`, so the server comes and goes with
+config. A plugin entry whose `name` matches a configured server **replaces** it, and a
+plugin contributing a server **activates MCP even when `mcp.enabled` is off**.
+
+### Worked example — wrap an external server, gated on config
+
+In the plugin's `__init__.py` (`register(registry)` is the contribution hook — see
+[Plugins](./plugins.md)):
+
+```python
+def register(registry):
+    def mcp_factory(config):
+        # registry.config is this plugin's resolved config section (ADR 0019).
+        token = registry.config.get("api_token")
+        if not token:
+            return None                       # not configured → server doesn't start
+        return {
+            "name": "acme",                   # same name as a user mcp.servers entry → replaces it
+            "transport": "stdio",             # or "streamable_http" / "sse"
+            "command": "npx",
+            "args": ["-y", "@acme/mcp-server"],
+            "env": {"ACME_TOKEN": token},
+        }
+
+    registry.register_mcp_server(mcp_factory)
+```
+
+Enable the plugin and set its `api_token` (Settings ▸ Plugins, or its config section +
+`secrets.yaml`); the `acme` tools appear (namespaced, allowlist-gated like any MCP server)
+on the next graph build and vanish when the token is cleared. The returned dict is the same
+`mcp.servers[]` entry shape as a hand-configured server (`command`/`args` + `env` for
+stdio; `url`/`headers` for http/sse).
+
+### A Python server inside the plugin (frozen apps)
+
+If the plugin *implements* the server itself in Python (rather than wrapping an external
+binary), it exposes an `mcp_main()` that runs the server, and the factory launches it as a
+subprocess. In a **frozen desktop build** there's no `python` on PATH, so the agent
+re-invokes its own binary with the generic **`--mcp-plugin <id>`** shim, which imports the
+plugin and calls its `mcp_main()`. The first-party OAuth-gated Google (Gmail/Calendar)
+plugin is the canonical example.
 
 ## Keeping tools out of context (allowlist + lazy connect)
 

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -63,7 +63,7 @@ slash-command autocomplete (from `GET /api/chat/commands`) and renders assistant
 - **Live tool-call cards** — each tool the agent invokes streams in as a collapsible card
   (name, running→done/error, input/result), via the `tool-call-v1` DataPart (see
   [Extensions § tool-call-v1](/reference/extensions)).
-- **Skills chip** — a "📚 Skills" chip shows which skills were auto-retrieved for the turn
+- **Skills chip** — a "Skills" chip shows which skills were auto-retrieved for the turn
   ([Skills](/guides/skills)).
 - **Mid-turn steering** — send a message while a turn runs and it folds in at the next
   model call ([Mid-turn steering](/explanation/steering)).

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -70,7 +70,7 @@ The curator (`python -m graph.skills.curator`) decays + prunes non-`disk` skills
 | `enabled` | `true` | Load + retrieve skills at all |
 | `db_path` | `/sandbox/skills.db` | Index location (→ `~/.protoagent/skills.db` fallback) |
 | `top_k` | `5` | Max skills injected into the prompt per turn |
-| `announce` | `true` | Show the "📚 Skills loaded" chip in chat |
+| `announce` | `true` | Show the "Skills" chip (auto-retrieved skills) in chat |
 | `dir` | `""` | Override the writable skills root |
 | `scope` | `""` (→ `scoped`) | Tier: `scoped` (private) · `shared` (one commons) · `layered` (read commons ∪ private, write private) ([ADR 0041](/adr/0041-workspaces-and-tiered-stores)) |
 | `shared` | `false` | Back-compat boolean — `true` → `scope: shared` when `scope` is blank |

--- a/docs/tutorials/first-skill.md
+++ b/docs/tutorials/first-skill.md
@@ -1,0 +1,88 @@
+# Write your first skill
+
+A **skill** teaches the agent how and when to handle a recurring task. You drop in a
+`SKILL.md` folder; the agent retrieves it by relevance and follows it — no code, no
+re-explaining each turn. By the end of this tutorial you'll have a skill the agent uses
+automatically *and* can run on demand as a `/slash` command.
+
+> Prerequisite: a running agent — see [Spin up your first agent](/tutorials/first-agent).
+> For the full format, see the [Skills reference](/reference/skills); for the concepts, the
+> [Skills guide](/guides/skills).
+
+## 1. Create the skill
+
+Make a folder under your skills root with a `SKILL.md` inside. On the default instance:
+
+```
+config/skills/tldr/SKILL.md
+```
+
+```markdown
+---
+name: tldr
+description: >-
+  Use whenever the user asks for a TL;DR, a summary, or "the short version" of a
+  document, thread, or block of text.
+tools: []
+---
+
+# TL;DR
+
+1. Read the provided text closely.
+2. Reply with exactly three bullet points — the most important takeaways, in plain language.
+3. End with a one-line bottom line prefixed **Bottom line:**.
+```
+
+The **`description` is the trigger** — it's what relevance retrieval matches against, so
+say plainly *when* to reach for the skill. The **body** is the procedure the agent follows.
+
+## 2. Load it
+
+The agent indexes `SKILL.md` files at boot, so restart the server (or trigger a config
+reload). Confirm it loaded:
+
+```bash
+curl -s localhost:7870/api/runtime/status | grep -o '"skills":[^}]*'
+```
+
+> Shortcut: the console's **Agent → Skills → New** authors a skill **live** — no restart.
+> The file path above is the portable, fork-friendly way and shows the raw format.
+
+## 3. Watch it fire
+
+In chat, ask something that matches the description:
+
+> *"Give me a TL;DR of this: \<paste a few paragraphs\>"*
+
+Above the answer you'll see a **Skills: tldr** chip (a small book-icon row) — that's the
+agent telling you it pulled your skill into the turn. The reply should come back as three
+bullets + a bottom line, because that's the procedure you wrote. (No match in the message →
+no chip; that's relevance retrieval working as intended.)
+
+## 4. Make it runnable on demand
+
+Add two frontmatter keys so the skill becomes a `/slash` command too:
+
+```markdown
+---
+name: tldr
+description: >-
+  Use whenever the user asks for a TL;DR or summary of some text.
+user_facing: true
+slash: tldr
+---
+```
+
+Restart, then type `/tldr` in the composer — it appears in the slash menu. `/tldr <text>`
+runs the procedure on the spot (it rewrites the turn with your skill's body as the
+directive; [ADR 0052](/adr/0052-user-facing-skills-slash-commands)).
+
+## What you learned
+
+- A skill is just a `SKILL.md` (frontmatter + body) — the `description` triggers it, the
+  body is the procedure.
+- Retrieved skills surface as the **Skills** chip; `user_facing` skills also run as
+  `/slash` commands.
+
+Next: the [Skills guide](/guides/skills) (tiers, the curator, `/distill` self-authoring)
+and the [Skills reference](/reference/skills) (every field + the `skills:` config block).

--- a/docs/tutorials/index.md
+++ b/docs/tutorials/index.md
@@ -8,10 +8,16 @@ Learning-oriented walkthroughs. Start here if you're new to protoAgent. Grouped 
 |---|---|
 | [Spin up your first agent](/tutorials/first-agent) | A forked, renamed container you can chat with locally |
 
+## Skills, subagents & workflows
+
+| Tutorial | What you'll end up with |
+|---|---|
+| [Write your first skill](/tutorials/first-skill) | A `SKILL.md` the agent auto-uses (and runs via `/slash`) |
+
 ## Tools, MCP & plugins
 
 | Tutorial | What you'll end up with |
 |---|---|
 | [Write your first tool](/tutorials/first-tool) | A custom LangChain tool wired into the agent's loop |
 
-Once you've worked through both, the [How-To Guides](/guides/) are where to head next — they assume you already have an agent running.
+Once you've worked through these, the [How-To Guides](/guides/) are where to head next — they assume you already have an agent running.


### PR DESCRIPTION
Closes the last open item in `docs/dev/docs-gaps.md` and corrects a chip inaccuracy. Also re-lands the first-skill tutorial that got stuck (#1182 went `DIRTY` after #1181 merged — both touched `config.mts` + `docs-gaps.md`).

## Managed MCP server example (the gap)
`guides/mcp.md` § Plugin-managed servers gains a **worked `register_mcp_server` example** — a config-gated wrapper of an external server (`factory(config)` → `mcp.servers[]` entry or `None`) — plus the in-plugin Python-server case and the frozen `--mcp-plugin <id>` shim.

## First-skill tutorial (re-landed)
`tutorials/first-skill.md` + its tutorials sidebar/index entries (superseding the stuck #1182).

## Fix: the skills chip is not an emoji
You flagged it — the chip renders a **lucide `BookOpen` icon + "Skills:" text** (`ChatSurface.tsx:1006-1007`), **not** a 📚 emoji. Dropped the wrong emoji from `reference/skills.md`, `react-tauri-ui.md`, and the first-skill tutorial; described it as the "Skills" chip.

## Result
`docs-gaps.md` **Remaining is now empty** — every audit gap is shipped or deliberately deferred (Langfuse tutorial skipped as duplicative of `observability.md`).

Docs-only. `npm run docs:build` passes clean; `grep` confirms zero 📚 left in `docs/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)