### PR TITLE
chore(changelog): backfill empty releases + omit-empty guardrail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.51.0] - 2026-06-18
 
+### Added
+- **"Skills loaded" chip in chat.** The console shows which skills the agent auto-retrieved for a turn (hover a name for its description); toggle with `skills.announce`.
+- **Author/edit skills in a modal dialog** in the console (instead of the in-panel form), plus a version badge + "built by protoLabs.studio" footer in the app drawer.
+
+### Removed
+- **Dropped the never-used `emit_skill` capture path.** The agent self-authors skills via `/distill`; the dead skill-v1 emission machinery is gone.
+
+### Fixed
+- **Desktop sidecar bundles `config/plugin-catalog.json`** so the plugin Discover directory works in the frozen app.
+
 ## [0.50.0] - 2026-06-18
 
 ### Added
@@ -30,9 +40,29 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.49.1] - 2026-06-18
 
+### Fixed
+- **Background-job dialog shows the full result**, not the truncated live preview.
+
 ## [0.49.0] - 2026-06-18
 
+### Added
+- **Native command-palette chat** recovered, a **`/effort` reasoning control** for chat turns, and a **Schedule rail** in the console.
+
 ## [0.48.0] - 2026-06-18
+
+### Added
+- **Command palette (⌘K).** Jump to any surface plus core actions, with chat and inline plugin views living inside the palette (ADR 0057).
+- **Unified plugin manager.** Collapsed to **Discover** (an in-app official-plugin directory served from the host catalog) + **Installed** (per-plugin config folded into the rows, manifest-driven Test + guide link) — ADR 0059.
+- **Always-on hamburger menu** replaces the header status-light / theme / settings cluster.
+
+### Changed
+- **Discord is no longer bundled** — it installs as a runtime external plugin in the frozen desktop app (ADR 0058).
+
+### Fixed
+- **Plugin git refs are validated before fetch**, and the dev server proxies `/_ds` so plugin-kit loads in plugin iframes.
+
+### Docs
+- **ADRs 0057 / 0058 / 0059** — command palette, runtime plugin install in the frozen app, and the unified plugin manager.
 
 ## [0.47.0] - 2026-06-18
 
@@ -55,11 +85,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.46.0] - 2026-06-17
 
+### Added
+- **In-app update notice with the changelog** in the desktop app — shows what changed instead of a generic prompt.
+
 ## [0.45.0] - 2026-06-17
+
+### Added
+- **Real chat streaming in the desktop app** — token-by-token output + tool cards over Tauri-relayed SSE.
+
+### Fixed
+- **Desktop in-app updater no longer 404s** — a release is marked "Latest" only once `latest.json` is published.
 
 ## [0.44.0] - 2026-06-17
 
+### Fixed
+- **Desktop updater public key now matches the signing key**, so in-app updates verify and install.
+
 ## [0.43.0] - 2026-06-17
+
+### Added
+- **Portfolio plugin (ADR 0055).** One PM agent dispatches work to, and tracks, several team-agents' project boards across repos over A2A — `portfolio_rollup` (bounded cross-board view), `portfolio_diff`/`portfolio_watch` (board deltas), and `portfolio_link`/`portfolio_plan` (cross-board dependency graph). Shipped as a standalone plugin.
+- **Mid-turn steering.** Send a message while a turn is running and the agent folds it in at the next model call instead of stopping — with a ✕ to cancel a queued steer, and a Tier-2 control to cancel a single running subagent delegation.
+- **Drag-to-reorder chat session tabs.**
+
+### Changed
+- **Setup wizard + forms rebuilt on the design system** (FormField / RadioCard, token cleanup).
+- **Instance-scoped agents resolve their installed-plugin config correctly**, and idle ACP coding-agent runtimes are evicted from the runtime pool.
+
+### Docs
+- **ADR 0056** — unified dockable-view model (tabs ↔ rails).
 
 ## [0.42.0] - 2026-06-17
 

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -86,6 +86,11 @@ We keep a [Keep a Changelog](https://keepachangelog.com/en/1.1.0/)-style
 - The rolled changelog is committed **inside the release PR**, so it goes
   through the same `main` ruleset (PR + checks) as any change — nothing is
   pushed to `main` directly.
+- **The marketing `/changelog`** (`sites/marketing/data/changelog.json`) is
+  scaffolded from each release's section by `changelog.py scaffold`. A release
+  whose PRs added **no** `[Unreleased]` bullets has an empty section, so it's
+  **omitted** from the marketing changelog rather than shown as a bare
+  version+date line — add a bullet in your PR for the release to appear.
 
 ## Branch protection
 

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -78,21 +78,23 @@ def _vtuple(v: str) -> tuple[int, ...]:
 
 
 def missing_versions() -> list[str]:
-    """Released versions inside the curated range with no changelog.json entry.
+    """Released versions inside the curated range with content but no changelog.json entry.
 
     The marketing changelog only goes back to a curated floor (~v0.16), so we don't
     demand ancient history — we catch a *forgotten new release* (the original
     'stuck at 0.21' bug): any version at or above the oldest curated entry that's
-    missing.
+    missing. An **empty** release (no ``[Unreleased]`` bullets → an empty section) is
+    intentionally omitted from /changelog, so it's not flagged as missing.
     """
     have = {e["version"] for e in json.loads(MARKETING_JSON.read_text(encoding="utf-8"))}
     if not have:
         return []
     floor = min(_vtuple(v) for v in have)
+    text = CHANGELOG.read_text(encoding="utf-8")
     return [
         f"v{v}"
-        for v in dated_versions(CHANGELOG.read_text(encoding="utf-8"))
-        if _vtuple(v) >= floor and f"v{v}" not in have
+        for v in dated_versions(text)
+        if _vtuple(v) >= floor and f"v{v}" not in have and _titles(_section(text, v)[1])
     ]
 
 
@@ -107,7 +109,13 @@ def scaffold(version: str) -> bool:
     date, body = _section(CHANGELOG.read_text(encoding="utf-8"), version)
     if date is None:
         raise ValueError(f"no '## [{version}]' section in CHANGELOG.md")
-    entries.insert(0, {"version": vtag, "date": date, "changes": _titles(body)})
+    changes = _titles(body)
+    if not changes:
+        # Empty release (the PRs added no `[Unreleased]` bullets) → omit it from the
+        # marketing changelog rather than emit a bare version+date line. Add a bullet
+        # under `[Unreleased]` in your PR for the release to appear on /changelog.
+        return False
+    entries.insert(0, {"version": vtag, "date": date, "changes": changes})
     MARKETING_JSON.write_text(json.dumps(entries, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
     return True
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -2,7 +2,12 @@
   {
     "version": "v0.51.0",
     "date": "2026-06-18",
-    "changes": []
+    "changes": [
+      "\"Skills loaded\" chip in chat.",
+      "Author/edit skills in a modal dialog",
+      "Dropped the never-used emit_skill capture path.",
+      "Desktop sidecar bundles config/plugin-catalog.json"
+    ]
   },
   {
     "version": "v0.50.0",
@@ -14,44 +19,69 @@
   {
     "version": "v0.49.1",
     "date": "2026-06-18",
-    "changes": []
+    "changes": [
+      "Background-job dialog shows the full result"
+    ]
   },
   {
     "version": "v0.49.0",
     "date": "2026-06-18",
-    "changes": []
+    "changes": [
+      "Native command-palette chat"
+    ]
   },
   {
     "version": "v0.48.0",
     "date": "2026-06-18",
-    "changes": []
+    "changes": [
+      "Command palette (⌘K).",
+      "Unified plugin manager.",
+      "Always-on hamburger menu",
+      "Discord is no longer bundled",
+      "Plugin git refs are validated before fetch",
+      "ADRs 0057 / 0058 / 0059"
+    ]
   },
   {
     "version": "v0.47.0",
     "date": "2026-06-18",
     "changes": [
-      "**Google (Gmail + Calendar) and Slack are no longer bundled"
+      "Google (Gmail + Calendar) and Slack are no longer bundled — they move to standalone external plugins."
     ]
   },
   {
     "version": "v0.46.0",
     "date": "2026-06-17",
-    "changes": []
+    "changes": [
+      "In-app update notice with the changelog"
+    ]
   },
   {
     "version": "v0.45.0",
     "date": "2026-06-17",
-    "changes": []
+    "changes": [
+      "Real chat streaming in the desktop app",
+      "Desktop in-app updater no longer 404s"
+    ]
   },
   {
     "version": "v0.44.0",
     "date": "2026-06-17",
-    "changes": []
+    "changes": [
+      "Desktop updater public key now matches the signing key"
+    ]
   },
   {
     "version": "v0.43.0",
     "date": "2026-06-17",
-    "changes": []
+    "changes": [
+      "Portfolio plugin.",
+      "Mid-turn steering.",
+      "Drag-to-reorder chat session tabs.",
+      "Setup wizard + forms rebuilt on the design system",
+      "Instance-scoped agents resolve their installed-plugin config correctly",
+      "ADR 0056"
+    ]
   },
   {
     "version": "v0.42.0",

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -103,6 +103,24 @@ def test_scaffold_prepends_when_absent_and_is_idempotent(tmp_path, monkeypatch):
     assert json.loads(mj.read_text(encoding="utf-8")) == entries
 
 
+def test_scaffold_omits_empty_release(tmp_path, monkeypatch):
+    """A release whose section has no bullets is omitted from the marketing changelog
+    (no bare version+date entry) rather than scaffolded empty."""
+    import json
+
+    cl = tmp_path / "CHANGELOG.md"
+    cl.write_text("# Changelog\n\n## [Unreleased]\n\n## [0.3.0] - 2026-03-03\n\n", encoding="utf-8")
+    mj = tmp_path / "changelog.json"
+    mj.write_text(json.dumps([{"version": "v0.1.0", "date": "2026-01-01", "changes": ["x"]}]), encoding="utf-8")
+    monkeypatch.setattr(changelog, "CHANGELOG", cl)
+    monkeypatch.setattr(changelog, "MARKETING_JSON", mj)
+
+    assert changelog.scaffold("0.3.0") is False  # empty section → skipped
+    assert [e["version"] for e in json.loads(mj.read_text(encoding="utf-8"))] == ["v0.1.0"]
+    # …and an empty release absent from the json is NOT flagged as missing.
+    assert changelog.missing_versions() == []
+
+
 def test_no_released_version_is_missing_from_marketing_changelog():
     """Staleness guard (the original 'stuck at 0.21' bug): every dated CHANGELOG.md
     version must have a marketing changelog.json entry."""


### PR DESCRIPTION
**Why the marketing `/changelog` had empty entries:** it renders `sites/marketing/data/changelog.json`, which `changelog.py scaffold` derives from each release's `CHANGELOG.md` section. Releases **v0.43–v0.51** (minus 0.47/0.50) had **empty sections** — the PRs in them never added an `## [Unreleased]` bullet — so the site showed bare version+date lines. Not a site bug; empty source data.

## Backfill (the visible fix)
Wrote curated, user-facing entries (reconstructed from the merged PR titles in each tag range) into the 8 empty `CHANGELOG.md` sections, and regenerated their `changes[]` in `changelog.json`:

| Version | Now shows |
|---|---|
| v0.51.0 | skills-loaded chip, modal skill editor, **emit_skill removal**, sidecar catalog fix |
| v0.49.1 / v0.49.0 | bg-job dialog fix · palette chat + `/effort` + Schedule rail |
| v0.48.0 | command palette (⌘K), unified plugin manager, Discord unbundled |
| v0.46.0 / v0.45.0 / v0.44.0 | desktop update notice · desktop SSE streaming · updater pubkey fix |
| v0.43.0 | portfolio plugin (ADR 0055), mid-turn steering, DS setup wizard |

Also cleaned a stray `**` in the already-shipped v0.47.0 entry.

## Guardrail (omit empty going forward)
- `scaffold` now **skips** a release whose section has no bullets — no more bare entries.
- `missing_versions`/`check` only require versions that actually have content, so a genuinely empty release is intentionally absent (not flagged as missing).
- Documented in `docs/guides/releasing.md`; new test `test_scaffold_omits_empty_release`.

So: empty releases vanish from the marketing changelog rather than rendering blank, and the existing burst is now fully populated.

## Verification
`changelog.py check` passes; `tests/test_changelog.py` 9 green; ruff clean; `changelog.json` valid with zero empty-change entries (was 8). The marketing site picks this up on its next build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)