### PR TITLE
chore: release v0.51.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.51.1] - 2026-06-19
+
+### Docs
+- **Documentation overhaul.** Every Diátaxis section (Tutorials / Guides / Reference /
+  Explanation) is now grouped by one consistent domain taxonomy in the sidebar and
+  indexes, and the gaps are filled — guides for **ingestion** and **RAG tuning**, the
+  **command palette (⌘K)**, **mid-turn steering**, an **Operator REST API** reference, a
+  **Skills** reference, a "write your first skill" tutorial, a managed-MCP-server example,
+  and a rewritten **operator-console** guide.
+
+### Changed
+- **The marketing changelog no longer shows empty releases.** Backfilled the recent empty
+  entries, and the release tooling now omits a release that ships no notes instead of
+  rendering a bare version + date.
+
 ## [0.51.0] - 2026-06-18
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.51.0"
+version = "0.51.1"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.51.1",
+    "date": "2026-06-19",
+    "changes": [
+      "Documentation overhaul.",
+      "The marketing changelog no longer shows empty releases."
+    ]
+  },
+  {
     "version": "v0.51.0",
     "date": "2026-06-18",
     "changes": [


### PR DESCRIPTION
Cuts **v0.51.1** — a docs + release-tooling patch (no runtime change since v0.51.0).

Standard release prep (`version.py patch` + `changelog.py roll`/`scaffold`):
- `pyproject.toml` → `0.51.1`
- `CHANGELOG.md` → rolls `[Unreleased]` into the dated section
- `sites/marketing/data/changelog.json` → v0.51.1 entry scaffolded

**Patch on purpose:** everything since v0.51.0 is docs + the changelog tooling, and a patch tag **skips the desktop-build matrix** (the only GH-hosted spend) — this release is Docker image + GitHub release + Discord notes only.

After merge, push the tag to cut it:
```
git checkout main && git pull && git tag -a v0.51.1 -m 'Release v0.51.1' && git push origin v0.51.1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)