### PR TITLE
docs(changelog): add the utility bar to the v0.51.1 notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.51.1] - 2026-06-19
 
+### Added
+- **Utility bar in the console.** A compact bar with quick widgets on the left and layout
+  controls on the right, plus a toggleable bottom panel. The **inbox** is now a utility-bar
+  widget (on a reusable `UtilityWidget` primitive), and **plugins can contribute their own
+  widgets** (a `utility:` manifest flag → an iframe dialog).
+
 ### Docs
 - **Documentation overhaul.** Every Diátaxis section (Tutorials / Guides / Reference /
   Explanation) is now grouped by one consistent domain taxonomy in the sidebar and

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -3,6 +3,7 @@
     "version": "v0.51.1",
     "date": "2026-06-19",
     "changes": [
+      "Utility bar in the console.",
       "Documentation overhaul.",
       "The marketing changelog no longer shows empty releases."
     ]


### PR DESCRIPTION
v0.51.1 also shipped the **console utility bar** (#1176/#1178/#1179) — those PRs merged after v0.51.0 without `[Unreleased]` entries, so the cut release notes (and my "docs-only" framing) omitted it. This adds the `### Added` entry and re-derives `changelog.json` so the marketing /changelog reflects what actually shipped in v0.51.1. The tag is already cut; this corrects the canonical changelog + marketing data on main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)