### PR TITLE
chore: release v0.52.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.52.0] - 2026-06-19
+
+### Changed
+- **Desktop app catches up to v0.51.x.** A minor bump so the desktop build runs: the
+  console **utility bar** (widgets + bottom panel) and the documentation overhaul now ship
+  in the signed macOS / Windows / Linux binaries + in-app updater. No new runtime changes
+  beyond v0.51.1.
+
 ## [0.51.1] - 2026-06-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.51.1"
+version = "0.52.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "v0.52.0",
+    "date": "2026-06-19",
+    "changes": [
+      "Desktop app catches up to v0.51.x."
+    ]
+  },
+  {
     "version": "v0.51.1",
     "date": "2026-06-19",
     "changes": [


### PR DESCRIPTION
Minor bump so the **desktop build** runs (it only fires on a `.0` tag). Ships the v0.51.x work — the console **utility bar** (#1176/#1178/#1179) + the documentation overhaul — into fresh signed desktop binaries (macOS dmg / Windows nsis / Linux AppImage+deb) + the in-app updater. No new runtime changes beyond v0.51.1.

Public repo → GH-hosted runners (incl. macOS/Windows) are free, so the desktop matrix is fine.

After merge: `git tag -a v0.52.0 -m 'Release v0.52.0' && git push origin v0.52.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)