### PR TITLE
feat(desktop): update notice as a full modal with markdown changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The desktop in-app update notice is now a full modal with a markdown-rendered
+  changelog.** The release notes render as readable markdown (headings, bullets, links) in
+  a centered dialog instead of a cramped plain-text corner panel.
+
 ## [0.52.0] - 2026-06-19
 
 ### Changed

--- a/apps/web/src/app/UpdateNotice.tsx
+++ b/apps/web/src/app/UpdateNotice.tsx
@@ -1,14 +1,17 @@
 import { useEffect, useState } from "react";
 import { Button } from "@protolabsai/ui/primitives";
+import { Dialog } from "@protolabsai/ui/overlays";
 import { api, isDesktopWebview } from "../lib/api";
+import { Markdown } from "../chat/LazyMarkdown";
 
 /**
  * In-app update notice for the desktop shell (Tauri). Periodically checks the signed
  * `latest.json`; when a newer build is published it surfaces an ambient pill — click it
- * for the **changelog** + a one-click "Update & Restart". User-driven (we notify; you
- * choose when to apply — no silent background install). Silent in dev / browser /
- * offline / when up to date. The updater work runs in the Rust shell (`updater_check`/
- * `updater_install`); this is the UX. Mirrors the orbis `UpdateNotice` pattern.
+ * for a **full modal** with the release **changelog rendered as markdown** + a one-click
+ * "Update & Restart". User-driven (we notify; you choose when to apply — no silent
+ * background install). Silent in dev / browser / offline / when up to date. The updater
+ * work runs in the Rust shell (`updater_check` / `updater_install`); this is the UX.
+ * Mirrors the orbis `UpdateNotice` pattern.
  */
 
 const FIRST_CHECK_MS = 10_000; // let the boot settle
@@ -62,8 +65,21 @@ export function UpdateNotice() {
     }
   };
 
-  if (!open) {
-    return (
+  const footer = (
+    <>
+      {phase !== "downloading" && (
+        <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
+          Later
+        </Button>
+      )}
+      <Button variant="primary" size="sm" onClick={install} disabled={phase === "downloading"}>
+        {phase === "downloading" ? "Updating…" : phase === "error" ? "Retry" : "Update & Restart"}
+      </Button>
+    </>
+  );
+
+  return (
+    <>
       <button
         type="button"
         className="update-notice-pill"
@@ -73,52 +89,38 @@ export function UpdateNotice() {
         <span className="update-notice-dot" />
         Update · {update.version}
       </button>
-    );
-  }
 
-  return (
-    <div className="update-notice-panel" role="dialog" aria-label="Update available">
-      <div className="update-notice-head">
-        <span>
-          Update available <span className="update-notice-ver">{update.version}</span>
-        </span>
-        <button
-          type="button"
-          className="update-notice-x"
-          onClick={() => setOpen(false)}
-          aria-label="Dismiss"
-        >
-          ✕
-        </button>
-      </div>
-
-      {update.notes ? (
-        <div className="update-notice-notes">{update.notes}</div>
-      ) : (
-        <p className="update-notice-empty">A newer version is ready (you have {update.current}).</p>
-      )}
-
-      {phase === "downloading" && (
-        <div className="update-notice-progress">
-          <div className="update-notice-bar">
-            <div className="update-notice-fill" style={{ width: `${pct}%` }} />
+      <Dialog
+        open={open}
+        onClose={() => setOpen(false)}
+        width={680}
+        title={
+          <>
+            Update available <span className="update-notice-ver">{update.version}</span>
+            <span className="update-notice-cur"> · you have {update.current}</span>
+          </>
+        }
+        footer={footer}
+      >
+        {update.notes ? (
+          <div className="update-notice-notes markdown">
+            <Markdown>{update.notes}</Markdown>
           </div>
-          <div className="update-notice-pct">Downloading… {pct}%</div>
-        </div>
-      )}
-
-      {phase === "error" && error && <p className="update-notice-err">Update failed: {error}</p>}
-
-      <div className="update-notice-actions">
-        {phase !== "downloading" && (
-          <Button variant="ghost" size="sm" onClick={() => setOpen(false)}>
-            Later
-          </Button>
+        ) : (
+          <p className="update-notice-empty">A newer version is ready (you have {update.current}).</p>
         )}
-        <Button variant="primary" size="sm" onClick={install} disabled={phase === "downloading"}>
-          {phase === "downloading" ? "Updating…" : phase === "error" ? "Retry" : "Update & Restart"}
-        </Button>
-      </div>
-    </div>
+
+        {phase === "downloading" && (
+          <div className="update-notice-progress">
+            <div className="update-notice-bar">
+              <div className="update-notice-fill" style={{ width: `${pct}%` }} />
+            </div>
+            <div className="update-notice-pct">Downloading… {pct}%</div>
+          </div>
+        )}
+
+        {phase === "error" && error && <p className="update-notice-err">Update failed: {error}</p>}
+      </Dialog>
+    </>
   );
 }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1939,51 +1939,21 @@ textarea {
   background: currentColor;
   opacity: 0.7;
 }
-.update-notice-panel {
-  position: fixed;
-  top: 44px;
-  right: 12px;
-  z-index: 40;
-  width: 320px;
-  max-width: calc(100vw - 24px);
-  padding: var(--pl-space-4, 16px);
-  border-radius: 10px;
-  border: 1px solid var(--pl-color-border);
-  background: var(--pl-color-bg-raised);
-  box-shadow: var(--pl-shadow-popover);
-  font-size: 13px;
-}
-.update-notice-head {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  gap: 8px;
-}
+/* The update notice now renders in the DS Dialog (full modal) — the version in the
+   title, and the release changelog as scrollable markdown in the body. */
 .update-notice-ver {
   font-family: ui-monospace, monospace;
-  font-size: 12px;
-  opacity: 0.75;
+  font-size: 0.85em;
+  opacity: 0.85;
 }
-.update-notice-x {
-  border: none;
-  background: none;
-  cursor: pointer;
-  color: inherit;
+.update-notice-cur {
+  font-size: 0.8em;
   opacity: 0.6;
-  font-size: 12px;
-  line-height: 1;
-}
-.update-notice-x:hover {
-  opacity: 1;
 }
 .update-notice-notes {
-  margin-top: 8px;
-  max-height: 160px;
+  max-height: min(55vh, 480px);
   overflow-y: auto;
-  white-space: pre-wrap;
-  font-size: 12px;
-  opacity: 0.85;
-  line-height: 1.45;
+  overscroll-behavior: contain;
 }
 .update-notice-empty {
   margin-top: 8px;
@@ -2019,11 +1989,4 @@ textarea {
   margin-top: 8px;
   font-size: 12px;
   color: #e5484d;
-}
-.update-notice-actions {
-  margin-top: 12px;
-  display: flex;
-  align-items: center;
-  justify-content: flex-end;
-  gap: 8px;
 }


### PR DESCRIPTION
The desktop in-app update notice showed the release changelog as **plain text** in a cramped 320px corner panel — unreadable for a real changelog (the notes are GitHub-release markdown: headings, bullets, PR links).

This makes it a **full modal** with the changelog **rendered as markdown**:
- Swapped the hand-rolled corner panel for the DS **`Dialog`** (`@protolabsai/ui/overlays`) — centered, backdrop, focus trap, ×, scrollable body, footer action row, 680px.
- Renders `update.notes` via the lazy `Markdown` renderer (`chat/LazyMarkdown`) → readable headings/bullets/links; falls back to raw text until the markdown chunk loads.
- Ambient pill still triggers it; download progress + error + **Update & Restart** live in the dialog body/footer; the empty-notes fallback stays.
- Dropped the now-unused `.update-notice-{panel,head,x,actions}` CSS; notes area is a scrollable markdown region (`max-height: min(55vh, 480px)`).

Reaches the desktop app on the next minor (`.0`) release's desktop build; the web console picks it up on the next build.

## Verification
`tsc` + `vite build` clean; `npm run test:unit` 98 green. (CHANGELOG `[Unreleased]` updated — practicing the guardrail from #1184.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)