### PR TITLE
feat(skills): user-only skills — a /slash the agent never auto-loads

### DIFF
--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -50,6 +50,12 @@ test("the + button opens the New skill DIALOG, not an inline panel form", async 
   await expect(dialog).toBeVisible();
   await expect(dialog.getByLabel("skill name")).toBeVisible();
   await expect(dialog.getByRole("button", { name: "Create skill" })).toBeVisible();
+
+  // The "user only" (hide from the agent) toggle appears only once it's a /slash command.
+  const userOnly = dialog.getByLabel(/hide from the agent/i);
+  await expect(userOnly).toHaveCount(0);
+  await dialog.getByLabel("invokable as a slash command").check();
+  await expect(userOnly).toBeVisible();
 });
 
 test("layered skills show tier badges and promote a private skill to the commons", async ({ page }) => {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -559,6 +559,8 @@ export type Playbook = {
   origin?: "user" | "learned" | "bundled" | "commons";
   editable?: boolean;
   user_facing?: boolean;
+  // User-only (2026-06): a `/<slash>` command withheld from the agent's retrieval.
+  user_only?: boolean;
   slash?: string;
   // Full procedure body — present only on the single-skill detail (GET
   // /api/playbooks/:id); the list payload omits it to stay light.

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -26,9 +26,10 @@ type Draft = {
   body: string;
   tools: string;
   userFacing: boolean;
+  userOnly: boolean;
   slash: string;
 };
-const EMPTY_DRAFT: Draft = { name: "", description: "", body: "", tools: "", userFacing: false, slash: "" };
+const EMPTY_DRAFT: Draft = { name: "", description: "", body: "", tools: "", userFacing: false, userOnly: false, slash: "" };
 
 function SkillForm({
   draft,
@@ -81,7 +82,8 @@ function SkillForm({
           <input
             type="checkbox"
             checked={draft.userFacing}
-            onChange={(e) => setDraft({ ...draft, userFacing: e.target.checked })}
+            // Unchecking the slash trigger also clears "user only" (it requires a slash).
+            onChange={(e) => setDraft({ ...draft, userFacing: e.target.checked, userOnly: e.target.checked && draft.userOnly })}
             aria-label="invokable as a slash command"
           />
           Invokable as a <code>/slash</code> command
@@ -97,6 +99,19 @@ function SkillForm({
           />
         ) : null}
       </div>
+      {draft.userFacing ? (
+        <div className="knowledge-chunk-form-row">
+          <label style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <input
+              type="checkbox"
+              checked={draft.userOnly}
+              onChange={(e) => setDraft({ ...draft, userOnly: e.target.checked })}
+              aria-label="hide from the agent — operator slash command only"
+            />
+            Hide from the agent — operator <code>/slash</code> command only
+          </label>
+        </div>
+      ) : null}
       <div className="knowledge-chunk-form-row">
         <Button type="button" variant="primary" size="sm" disabled={saving || incomplete} onClick={onSave}>
           {saveLabel}
@@ -216,6 +231,7 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
         body: s.prompt_template || "",
         tools: (s.tools_used || []).join(", "),
         userFacing: !!s.user_facing,
+        userOnly: !!s.user_only,
         slash: s.slash || "",
       });
       setEditingId(p.id);
@@ -242,7 +258,8 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
           .split(",")
           .map((t) => t.trim())
           .filter(Boolean),
-        user_facing: draft.userFacing,
+        user_facing: draft.userFacing || draft.userOnly,
+        user_only: draft.userOnly,
         slash: draft.slash.trim(),
       };
       const r = editingId !== null ? await api.updatePlaybook(editingId, payload) : await api.createPlaybook(payload);
@@ -362,6 +379,11 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
                         {p.user_facing ? (
                           <span title={`Invokable as /${p.slash || p.name}`}>
                             <Badge status="neutral">/{p.slash || p.name}</Badge>
+                          </span>
+                        ) : null}
+                        {p.user_only ? (
+                          <span title="Hidden from the agent — an operator /slash command only">
+                            <Badge status="warning">user-only</Badge>
                           </span>
                         ) : null}
                         <strong>{p.name}</strong>

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -46,6 +46,7 @@ tools: [web_search, fetch_url]   # optional, advisory
 | `description` | ✅ | ≤ 1024 chars. This is the **trigger signal** — write it "pushy": say plainly *when* the agent should reach for this skill, or it under-triggers. |
 | `tools` (or `metadata.tools`) | — | Advisory list of tool names the skill uses. When the skill is retrieved for a turn, these are surfaced to the agent as `<relevant_tools>` so it knows which of its (already-bound) tools this skill relies on — a relevance hint, not a gate. See [ADR 0005](/adr/0005-tool-pollution-and-progressive-disclosure). |
 | `user_facing` | — | `true` makes the skill directly invokable as a `/<slash>` command in the chat composer (ADR 0052). Off by default. |
+| `user_only` | — | `true` makes it an **operator-only** skill: a `/<slash>` command the agent **never auto-loads** into context. Implies `user_facing`. Off by default. |
 | `slash` | — | The trigger token for a `user_facing` skill (whitespace-free); blank → slug of `name`. e.g. `slash: web-research` → `/web-research`. |
 
 The markdown **body** is the skill's instructions — freeform; write whatever
@@ -61,6 +62,30 @@ turn (full toolset, history intact) — it doesn't spawn a detached worker.
 Precedence on a shared token: `goal` > workflow > subagent > skill. The shipped
 `web-research` skill is user-facing as `/web-research`, and `release-notes` as
 `/release-notes`.
+
+### Operator-only skills (`user_only`)
+
+Some procedures should be **yours to invoke, not something the agent reaches for
+on its own** — a deploy/rollback runbook, a destructive cleanup, a manual override,
+a "do exactly this" command you'd rather the model not improvise around.
+
+Set `user_only: true` (it implies `user_facing: true`):
+
+```yaml
+---
+name: Deploy
+description: Deploy + verify the service, then roll back on failure
+user_only: true        # → /deploy works, but the agent never auto-loads it
+slash: deploy
+---
+1. …procedure…
+```
+
+The skill is **excluded from the agent's retrieval** (`load_skills`) — it never
+lands in the `<learned_skills>` context block, so the agent won't pull it in on a
+hunch — but it stays a `/<slash>` command you can run on demand. In the Skills
+panel a **`user-only`** badge marks which skills the agent can't auto-load. Toggle
+it in the editor with **"Hide from the agent — operator `/slash` command only."**
 
 ## Where skills live
 

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -16,6 +16,7 @@ key is **ignored** (no OS/binary/license gating is parsed or enforced).
 | `description` | string | ✅ | The retrieval **trigger signal** (BM25 over name/description/body). Truncated at **1024 chars**. Write it "pushy" — say plainly *when* to use the skill. |
 | `tools` (or `metadata.tools`) | list[string] | — | Advisory tool names the skill relies on. Surfaced to the model as `<relevant_tools>` when retrieved — a hint, not a gate ([ADR 0005](/adr/0005-tool-pollution-and-progressive-disclosure)). |
 | `user_facing` | bool | — | `true` → the skill is invokable as a `/<slash>` chat command ([ADR 0052](/adr/0052-user-facing-skills-slash-commands)). Default `false`. Truthy spellings: `true` / `1` / `yes` / `on`. |
+| `user_only` | bool | — | `true` → an **operator-only** skill: it's a `/<slash>` command, but it is **withheld from the agent's retrieval** (`load_skills`) — the agent never auto-loads it into `<learned_skills>`. **Implies `user_facing`.** Default `false`. Use it for procedures you want to run on demand without the agent reaching for them on its own. |
 | `slash` | string | — | The `/<token>` trigger for a `user_facing` skill (whitespace-free). Blank → slugified `name` (lowercased, non-alphanumerics → hyphens). |
 
 The markdown **body** is the skill's procedure — freeform instructions, used verbatim as

--- a/graph/extensions/skills.py
+++ b/graph/extensions/skills.py
@@ -43,6 +43,10 @@ class SkillV1Artifact:
     # deliberately-authored skills become directly invokable.
     user_facing: bool = False
     slash: str = ""
+    # User-ONLY skills (2026-06): user_facing AND withheld from the agent's retrieval
+    # (`load_skills`) — a `/<slash>` command the operator can run, but the agent never
+    # pulls into context. Implies user_facing.
+    user_only: bool = False
 
     def __post_init__(self) -> None:
         if not self.name:

--- a/graph/skills/authoring.py
+++ b/graph/skills/authoring.py
@@ -41,15 +41,19 @@ def skill_md_text(
     tools: list[str] | None = None,
     user_facing: bool = False,
     slash: str = "",
+    user_only: bool = False,
 ) -> str:
     """Render a ``SKILL.md`` document: YAML frontmatter + markdown body."""
     meta: dict[str, object] = {"name": name.strip(), "description": description.strip()}
     if tools:
         meta["tools"] = [str(t).strip() for t in tools if str(t).strip()]
-    if user_facing:
+    # user_only implies user_facing — the /slash is the only way to use it.
+    if user_facing or user_only:
         meta["user_facing"] = True
         if slash.strip():
             meta["slash"] = slash.strip()
+    if user_only:
+        meta["user_only"] = True
     frontmatter = yaml.safe_dump(meta, sort_keys=False, allow_unicode=True).strip()
     return f"---\n{frontmatter}\n---\n\n{body.strip()}\n"
 
@@ -73,6 +77,7 @@ def write_skill(
     tools: list[str] | None = None,
     user_facing: bool = False,
     slash: str = "",
+    user_only: bool = False,
 ):
     """Write ``<root>/<slug>/SKILL.md`` for *name* and return its parsed artifact.
 
@@ -82,7 +87,10 @@ def write_skill(
 
     path = skill_path(root, name)
     path.parent.mkdir(parents=True, exist_ok=True)
-    atomic_write(path, skill_md_text(name, description, body, tools=tools, user_facing=user_facing, slash=slash))
+    atomic_write(
+        path,
+        skill_md_text(name, description, body, tools=tools, user_facing=user_facing, slash=slash, user_only=user_only),
+    )
     artifact = parse_skill_md(path)
     if artifact is None:
         # Shouldn't happen — we just wrote valid frontmatter — but never hand back None.

--- a/graph/skills/index.py
+++ b/graph/skills/index.py
@@ -38,7 +38,8 @@ def _build_match_query(query: str) -> str:
 # v3: added `source` ('disk' = human-authored SKILL.md, re-seeded each boot;
 #     'emitted' = agent-authored via task(), persisted + curator-managed).
 # v4: added user_facing + slash (ADR 0052 — `/<slash>` chat commands).
-_SCHEMA_VERSION = 4
+# v5: added user_only (2026-06) — a user_facing skill withheld from agent retrieval.
+_SCHEMA_VERSION = 5
 
 # Columns indexed by FTS5 (order matters for sqlite_master check)
 _FTS_CONTENT_COLUMNS = (
@@ -151,7 +152,8 @@ class SkillsIndex:
                 last_used UNINDEXED,
                 source UNINDEXED,
                 user_facing UNINDEXED,
-                slash UNINDEXED
+                slash UNINDEXED,
+                user_only UNINDEXED
             );
 
             CREATE TABLE _skills_meta (
@@ -160,7 +162,7 @@ class SkillsIndex:
             );
 
             INSERT INTO _skills_meta (key, version)
-            VALUES ('schema_version', 4);
+            VALUES ('schema_version', 5);
         """)
         conn.commit()
         log.info("[skills] schema created at %s", self._db_path)
@@ -214,6 +216,8 @@ class SkillsIndex:
         slash = getattr(artifact, "slash", "") or ""
         if user_facing == "1" and not slash and hasattr(artifact, "slash_token"):
             slash = artifact.slash_token()
+        # User-only (v5): withheld from load_skills (agent retrieval) but still a /slash.
+        user_only = "1" if getattr(artifact, "user_only", False) else "0"
 
         conn = self._open_conn()
         try:
@@ -222,8 +226,8 @@ class SkillsIndex:
                 INSERT INTO skills_fts
                     (name, description, prompt_template, tools_used,
                      source_session_id, created_at, confidence, last_used, source,
-                     user_facing, slash)
-                VALUES (?, ?, ?, ?, ?, ?, 1.0, ?, ?, ?, ?)
+                     user_facing, slash, user_only)
+                VALUES (?, ?, ?, ?, ?, ?, 1.0, ?, ?, ?, ?, ?)
                 """,
                 (
                     name,
@@ -236,6 +240,7 @@ class SkillsIndex:
                     source,
                     user_facing,
                     slash,
+                    user_only,
                 ),
             )
             conn.commit()
@@ -291,6 +296,7 @@ class SkillsIndex:
                        bm25(skills_fts) AS score
                 FROM skills_fts
                 WHERE skills_fts MATCH ?
+                  AND user_only = '0'
                 ORDER BY score
                 LIMIT ?
                 """,
@@ -322,7 +328,7 @@ class SkillsIndex:
             cur = conn.execute(
                 """
                 SELECT rowid AS id, name, description, prompt_template, tools_used,
-                       created_at, confidence, last_used, source, user_facing, slash
+                       created_at, confidence, last_used, source, user_facing, slash, user_only
                 FROM skills_fts
                 """
             )
@@ -348,6 +354,7 @@ class SkillsIndex:
             "source": (row["source"] if "source" in keys else "emitted") or "emitted",
             "user_facing": (row["user_facing"] if "user_facing" in keys else "0") == "1",
             "slash": (row["slash"] if "slash" in keys else "") or "",
+            "user_only": (row["user_only"] if "user_only" in keys else "0") == "1",
         }
 
     def user_facing_skills(self) -> list[dict]:
@@ -359,7 +366,7 @@ class SkillsIndex:
             cur = conn.execute(
                 """
                 SELECT rowid AS id, name, description, prompt_template, tools_used,
-                       created_at, confidence, last_used, source, user_facing, slash
+                       created_at, confidence, last_used, source, user_facing, slash, user_only
                 FROM skills_fts
                 WHERE user_facing = '1'
                 """

--- a/graph/skills/loader.py
+++ b/graph/skills/loader.py
@@ -77,6 +77,11 @@ def parse_skill_md(path: Path) -> SkillV1Artifact | None:
     # token make the skill invokable as `/<slash>` in chat. Accept a few truthy spellings.
     user_facing = str(meta.get("user_facing", "")).strip().lower() in ("true", "1", "yes", "on")
     slash = str(meta.get("slash", "")).strip()
+    # User-ONLY (2026-06): a `/<slash>` command withheld from the agent's retrieval. It
+    # implies user_facing (the slash is the only way to use it).
+    user_only = str(meta.get("user_only", "")).strip().lower() in ("true", "1", "yes", "on")
+    if user_only:
+        user_facing = True
 
     return SkillV1Artifact(
         name=name,
@@ -86,6 +91,7 @@ def parse_skill_md(path: Path) -> SkillV1Artifact | None:
         source_session_id=f"skill-md:{path.parent.name}",
         user_facing=user_facing,
         slash=slash,
+        user_only=user_only,
     )
 
 

--- a/operator_api/knowledge_routes.py
+++ b/operator_api/knowledge_routes.py
@@ -158,6 +158,7 @@ def register_knowledge_routes(app) -> None:
                 tools=_as_str_list(body.get("tools") or body.get("tools_used")),
                 user_facing=bool(body.get("user_facing", False)),
                 slash=str(body.get("slash", "")).strip(),
+                user_only=bool(body.get("user_only", False)),
             )
             idx.add_skill(artifact, source="disk")
         except Exception as exc:  # noqa: BLE001
@@ -215,6 +216,7 @@ def register_knowledge_routes(app) -> None:
                 tools=_as_str_list(body.get("tools") or body.get("tools_used")),
                 user_facing=bool(body.get("user_facing", cur.get("user_facing", False))),
                 slash=str(body.get("slash", cur.get("slash", "") or "")).strip(),
+                user_only=bool(body.get("user_only", cur.get("user_only", False))),
             )
             idx.delete_skill(skill_id)
             if new_slug != old_slug:

--- a/tests/test_skill_index.py
+++ b/tests/test_skill_index.py
@@ -40,6 +40,9 @@ class _FakeArtifact:
     tools_used: list[str] = field(default_factory=list)
     created_at: datetime = field(default_factory=lambda: datetime.now(timezone.utc))
     source_session_id: str = ""
+    user_facing: bool = False
+    slash: str = ""
+    user_only: bool = False
 
 
 def _make_artifact(
@@ -663,3 +666,29 @@ def test_user_facing_slash_falls_back_to_slug(index):
     index.add_skill(uf, source="disk")
     ufs = index.user_facing_skills()
     assert ufs and ufs[0]["slash"] == "big-task"
+
+
+def test_user_only_skill_is_withheld_from_agent_retrieval_but_still_a_slash(index):
+    """A user_only skill (v5): the agent never retrieves it (load_skills), but it's a
+    user_facing /slash command."""
+    # A normal retrievable skill + a user-only one, both matching "deploy".
+    index.add_skill(
+        _FakeArtifact(name="Deploy guide", description="how to deploy the app",
+                      prompt_template="deploy steps", source_session_id="s1"),
+        source="disk",
+    )
+    index.add_skill(
+        _FakeArtifact(name="Deploy now", description="deploy the app immediately",
+                      prompt_template="run deploy", user_facing=True, user_only=True,
+                      slash="deploy", source_session_id="s2"),
+        source="disk",
+    )
+    # Agent retrieval (load_skills) sees the normal skill, NOT the user-only one.
+    names = [r.name for r in index.load_skills("deploy", k=10)]
+    assert "Deploy guide" in names
+    assert "Deploy now" not in names
+    # But the user-only skill IS exposed as a /slash command + carries the flag.
+    ufs = {s["name"]: s for s in index.user_facing_skills()}
+    assert "Deploy now" in ufs
+    assert ufs["Deploy now"]["slash"] == "deploy"
+    assert ufs["Deploy now"]["user_only"] is True

--- a/tests/test_skills_crud_routes.py
+++ b/tests/test_skills_crud_routes.py
@@ -64,6 +64,33 @@ def test_create_writes_skill_md_and_indexes(monkeypatch, tmp_path):
     assert detail["prompt_template"].startswith("1. gather PRs")
 
 
+def test_create_user_only_skill_is_slash_but_not_agent_retrievable(monkeypatch, tmp_path):
+    c, idx, root = _client(monkeypatch, tmp_path)
+    r = c.post(
+        "/api/playbooks",
+        json={
+            "name": "Ops Runbook",
+            "description": "deploy and rollback the service",
+            "prompt_template": "1. deploy\n2. verify\n3. rollback",
+            "user_only": True,
+            "slash": "ops",
+        },
+    )
+    assert r.status_code == 200
+    skill = r.json()["skill"]
+    assert skill["user_only"] is True
+    assert skill["user_facing"] is True  # user_only implies user_facing
+    # SKILL.md persisted the flag.
+    md = (root / "ops-runbook" / "SKILL.md").read_text()
+    assert "user_only: true" in md and "user_facing: true" in md
+    # The agent never retrieves it; the /slash list does expose it.
+    assert "Ops Runbook" not in [s.name for s in idx.load_skills("deploy rollback service", k=10)]
+    assert "Ops Runbook" in [s["name"] for s in idx.user_facing_skills()]
+    # The editor round-trips the flag.
+    detail = c.get(f"/api/playbooks/{skill['id']}").json()["skill"]
+    assert detail["user_only"] is True
+
+
 def test_create_requires_fields(monkeypatch, tmp_path):
     c, _idx, _root = _client(monkeypatch, tmp_path)
     assert c.post("/api/playbooks", json={"name": "x", "description": "y"}).status_code == 400


### PR DESCRIPTION
**Answer to "do we have a user-facing-only option?"** — we didn't; now we do.

A **user-only** skill is `user_facing` (invocable as `/<slash>`) **AND withheld from the agent's retrieval** — it never lands in the `<learned_skills>` context block, so the agent won't pull it in on a hunch. For operator-run procedures you want on demand but not improvised around: deploy/rollback runbooks, destructive cleanups, manual overrides.

- **Model + loader:** `user_only` frontmatter; implies `user_facing`.
- **Index (schema → v5):** new `user_only` column; `load_skills` (agent retrieval) filters it out; `user_facing_skills` (the `/slash` source) still includes it. Old DBs rebuild from disk on boot.
- **CRUD:** create/update accept + round-trip `user_only`.
- **UI:** a *"Hide from the agent — operator `/slash` command only"* toggle in the skill editor (shown once it's a slash command); a **`user-only`** badge in the list.
- **Docs:** reference + guide blurbs (the flag + the use case).

**Verification:** index test (retrieval excludes it / slash lists it), CRUD-route test, form-toggle E2E. **148 skill backend + 94 web + playbooks E2E** green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)