### PR TITLE
feat(plugins): docs plugin — agent answers questions from protoAgent's own docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Docs plugin — the agent can answer questions about protoAgent's own docs** (first-party,
+  on by default). A keyword FTS index over the bundled docs + `docs_search` / `docs_read`
+  tools + a skill (search → read → cite). Self-contained and offline — no embeddings, no
+  knowledge-store coupling. A console Docs reader view + ⌘K doc search follow.
+
 ### Changed
 - **The desktop in-app update notice is now a full modal with a markdown-rendered
   changelog.** The release notes render as readable markdown (headings, bullets, links) in

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -54,6 +54,14 @@ BUNDLED_DATA: list[tuple[str, str]] = [
     # the frozen app finds them under _MEIPASS/plugins (the loader's bundle root).
     # Externals (Discord, Google, …) install at runtime into the live dir (ADR 0058).
     ("plugins", "plugins"),
+    # The published docs corpus — the `docs` plugin reads it (`docs/` beside the bundled
+    # `plugins/` under _MEIPASS) to power docs_search/docs_read + the Docs view. Only the
+    # Diátaxis sections + ADRs; `docs/dev` (internal) and `.vitepress` (build) are excluded.
+    ("docs/tutorials", "docs/tutorials"),
+    ("docs/guides", "docs/guides"),
+    ("docs/reference", "docs/reference"),
+    ("docs/explanation", "docs/explanation"),
+    ("docs/adr", "docs/adr"),
 ]
 
 # Packages PyInstaller's static analysis under-collects (dynamic imports +

--- a/plugins/docs/__init__.py
+++ b/plugins/docs/__init__.py
@@ -1,0 +1,74 @@
+"""Docs plugin — let the agent answer questions about protoAgent from its own docs.
+
+Ships a keyword FTS index over the bundled `docs/` tree (built in memory at load) plus two
+tools — `docs_search` (find the right page) and `docs_read` (read its markdown) — and a
+SKILL.md (`skills/answering-docs.md`, auto-discovered) that teaches search → read → cite.
+First-party, `enabled: true`. A console Docs reader view + ⌘K search come in a follow-up.
+
+No knowledge-store coupling and no embeddings: the index is self-contained and offline, so
+docs Q&A works in the frozen desktop app and never pollutes the operator's knowledge store.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from langchain_core.tools import tool
+
+from .corpus import read_doc
+from .docs_index import DocsIndex
+
+log = logging.getLogger("protoagent.plugins.docs")
+
+_INDEX: DocsIndex | None = None
+
+
+def _index() -> DocsIndex:
+    """The process-wide docs index, built lazily on first use."""
+    global _INDEX
+    if _INDEX is None:
+        idx = DocsIndex()
+        try:
+            n = idx.seed()
+            log.info("[docs] indexed %d doc(s)", n)
+        except Exception as exc:  # noqa: BLE001 — never let a bad corpus break the tools
+            log.warning("[docs] index seed failed: %s", exc)
+        _INDEX = idx
+    return _INDEX
+
+
+@tool
+async def docs_search(query: str, k: int = 5) -> str:
+    """Search the protoAgent project documentation for pages matching ``query``.
+
+    Use this FIRST whenever the user asks how protoAgent works, or about a specific
+    feature, configuration option, tool, plugin, API, or design decision (ADR) — anything
+    answerable from the docs. Returns the top matches as ``[section] Title — path`` lines;
+    then call ``docs_read(path)`` on the best one or two.
+    """
+    k = max(1, min(int(k), 10))
+    results = await asyncio.to_thread(_index().search, query, k)
+    if not results:
+        return "No matching docs."
+    return "\n".join(f"[{r.section}] {r.title} — {r.path}" for r in results)
+
+
+@tool
+async def docs_read(path: str) -> str:
+    """Read the full markdown of a protoAgent doc by its ``path`` (e.g. ``guides/skills.md``,
+    as returned by ``docs_search``). Answer from what you read and **cite the path**."""
+    if not _index().has(path):
+        return f"No such doc: {path!r}. Use docs_search to find the right path."
+    text = await asyncio.to_thread(read_doc, path)
+    return text or f"Could not read {path!r}."
+
+
+def register(registry) -> None:
+    """Entry point — build the index (so the first turn is fast) + expose the tools.
+    The ``skills/`` dir is auto-discovered by the loader; no explicit registration."""
+    try:
+        _index()
+    except Exception as exc:  # noqa: BLE001 — plugin load must never fail on this
+        log.warning("[docs] index build at load failed: %s", exc)
+    registry.register_tools([docs_search, docs_read])

--- a/plugins/docs/corpus.py
+++ b/plugins/docs/corpus.py
@@ -1,0 +1,80 @@
+"""The docs corpus — resolve the `docs/` tree and enumerate the indexed markdown.
+
+The agent indexes + reads the SAME `docs/` the VitePress site publishes. We index the
+four Diátaxis sections plus the ADRs, and deliberately EXCLUDE `docs/dev/**` (internal
+handoffs — mirrors the site's `srcExclude: ["dev/**"]`) and `.vitepress/` (build config).
+
+Resolution works in every deployment: in dev/Docker the tree is the repo's `docs/`; in the
+frozen desktop sidecar the PyInstaller build bundles the doc dirs, so `docs/` sits beside
+the bundled `plugins/` under `_MEIPASS` — `plugins/docs/__init__.py`'s grandparent is the
+repo root (dev) or `_MEIPASS` (frozen) either way.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+# Indexed/served sections. docs/dev (internal) + .vitepress (build) are intentionally out.
+SECTIONS: tuple[str, ...] = ("tutorials", "guides", "reference", "explanation", "adr")
+
+
+def docs_root() -> Path:
+    """The `docs/` directory — repo root in dev/Docker, the bundle root when frozen."""
+    return Path(__file__).resolve().parent.parent.parent / "docs"
+
+
+def iter_docs(root: Path | None = None):
+    """Yield ``(rel_path, abs_path)`` for every indexed markdown file. ``rel_path`` is a
+    posix path rooted at `docs/` (e.g. ``guides/skills.md``) — it's the public handle the
+    tools + view use, and the membership set is the read-access gate."""
+    root = root or docs_root()
+    for section in SECTIONS:
+        base = root / section
+        if not base.is_dir():
+            continue
+        for p in sorted(base.rglob("*.md")):
+            yield p.relative_to(root).as_posix(), p
+
+
+def valid_paths(root: Path | None = None) -> set[str]:
+    """The set of readable doc rel-paths — exact membership is the security gate."""
+    return {rel for rel, _ in iter_docs(root)}
+
+
+def read_doc(rel_path: str, root: Path | None = None) -> str | None:
+    """Read a doc by its rel-path, validated to be a real indexed doc. Returns ``None``
+    for anything outside the corpus (rejects traversal / absolute / unknown paths)."""
+    root = root or docs_root()
+    rel = (rel_path or "").strip().lstrip("/")
+    if rel not in valid_paths(root):
+        return None
+    try:
+        return (root / rel).read_text(encoding="utf-8")
+    except OSError:
+        return None
+
+
+def doc_title(abs_path: Path) -> str:
+    """The doc's first markdown H1, else its filename stem."""
+    try:
+        for line in abs_path.read_text(encoding="utf-8").splitlines():
+            s = line.strip()
+            if s.startswith("# "):
+                return s[2:].strip()
+    except OSError:
+        pass
+    return abs_path.stem
+
+
+def doc_preview(content: str, limit: int = 240) -> str:
+    """A short plain-text lede: the first non-heading, non-frontmatter line, trimmed."""
+    in_fm = False
+    for raw in content.splitlines():
+        line = raw.strip()
+        if line == "---":  # YAML frontmatter fence
+            in_fm = not in_fm
+            continue
+        if in_fm or not line or line.startswith("#") or line.startswith(">"):
+            continue
+        return line[:limit]
+    return ""

--- a/plugins/docs/docs_index.py
+++ b/plugins/docs/docs_index.py
@@ -1,0 +1,93 @@
+"""In-memory SQLite FTS5 index over the bundled docs — the keyword search the agent's
+`docs_search` tool (and, later, the console view) query.
+
+Mirrors `graph/skills/index.py` (the SkillsIndex pattern: FTS5 + a prefix-OR MATCH query +
+BM25 ranking), trimmed to a **read-only, rebuild-on-boot** corpus: the docs ship bundled
+and never change at runtime, so the index lives in memory (`:memory:`) and is seeded once
+at plugin load — no db file, no path resolution, no staleness. No embeddings (keyword BM25
+is plenty for well-titled docs; a hybrid upgrade can hide behind `search()` later).
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import sqlite3
+from pathlib import Path
+from typing import NamedTuple
+
+from .corpus import doc_preview, doc_title, iter_docs
+
+log = logging.getLogger("protoagent.plugins.docs")
+
+
+def _match_query(query: str) -> str:
+    """Free text → a safe FTS5 prefix-OR MATCH expr (each term as ``term*``), so variants
+    match and arbitrary user text can't raise a query error. Mirrors SkillsIndex."""
+    terms = re.findall(r"\w+", (query or "").lower())
+    return " OR ".join(f"{t}*" for t in terms)
+
+
+class DocRecord(NamedTuple):
+    path: str
+    title: str
+    section: str
+    preview: str
+    score: float
+
+
+class DocsIndex:
+    """FTS5 keyword index over the doc corpus. Build once, query many."""
+
+    def __init__(self, root: Path | None = None) -> None:
+        self._root = root
+        self._paths: set[str] = set()
+        self._conn = sqlite3.connect(":memory:", check_same_thread=False)
+        self._conn.row_factory = sqlite3.Row
+        try:
+            self._conn.execute(
+                "CREATE VIRTUAL TABLE docs_fts USING fts5(path, title, section, content, preview UNINDEXED)"
+            )
+        except sqlite3.OperationalError as exc:
+            raise RuntimeError("SQLite FTS5 not available — rebuild SQLite with FTS5.") from exc
+
+    def seed(self) -> int:
+        """Index every corpus doc. Returns the count."""
+        rows: list[tuple[str, str, str, str, str]] = []
+        for rel, abs_path in iter_docs(self._root):
+            try:
+                content = abs_path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+            rows.append((rel, doc_title(abs_path), rel.split("/", 1)[0], content, doc_preview(content)))
+            self._paths.add(rel)
+        if rows:
+            self._conn.executemany(
+                "INSERT INTO docs_fts (path, title, section, content, preview) VALUES (?, ?, ?, ?, ?)",
+                rows,
+            )
+            self._conn.commit()
+        return len(rows)
+
+    def search(self, query: str, k: int = 5) -> list[DocRecord]:
+        """Top-k docs for *query*, BM25-ranked best-first (lower score = better)."""
+        mq = _match_query(query)
+        if not mq:
+            return []
+        try:
+            cur = self._conn.execute(
+                "SELECT path, title, section, preview, bm25(docs_fts) AS score "
+                "FROM docs_fts WHERE docs_fts MATCH ? ORDER BY score LIMIT ?",
+                (mq, max(1, int(k))),
+            )
+            return [
+                DocRecord(r["path"], r["title"], r["section"], r["preview"] or "", float(r["score"]))
+                for r in cur.fetchall()
+            ]
+        except sqlite3.OperationalError as exc:  # empty table / odd query
+            log.debug("[docs] search error (returning empty): %s", exc)
+            return []
+
+    def has(self, path: str) -> bool:
+        """Whether *path* is an indexed doc (the read-access gate)."""
+        return (path or "").strip().lstrip("/") in self._paths

--- a/plugins/docs/protoagent.plugin.yaml
+++ b/plugins/docs/protoagent.plugin.yaml
@@ -1,0 +1,12 @@
+id: docs
+name: Docs
+version: 0.1.0
+description: >-
+  Answer questions about protoAgent from its own documentation. Ships a keyword
+  index over the bundled docs + `docs_search` / `docs_read` agent tools + a skill
+  that teaches search → read → cite. A console Docs reader view and ⌘K search
+  come next. First-party, on by default; disable via `plugins.disabled: [docs]`.
+enabled: true
+capabilities:
+  network: []
+  filesystem: scoped   # read-only over the bundled docs/ tree

--- a/plugins/docs/skills/answering-docs.md
+++ b/plugins/docs/skills/answering-docs.md
@@ -1,0 +1,20 @@
+---
+name: answering-protoagent-docs
+description: >-
+  Use whenever the user asks how protoAgent works, or about a specific feature,
+  configuration option, tool, plugin, API endpoint, or design decision (ADR) — anything
+  answerable from the project's own documentation. Reach for this before guessing.
+tools: [docs_search, docs_read]
+---
+
+# Answering questions from the protoAgent docs
+
+protoAgent ships its full documentation, searchable via the `docs` plugin. When a question
+is about how protoAgent itself works, don't answer from memory — look it up:
+
+1. Call **`docs_search`** with the user's question (or its key terms). It returns the best
+   pages as `[section] Title — path` lines.
+2. Read the **1–3 most relevant** hits with **`docs_read(path)`**.
+3. Answer from what you actually read — concrete and specific. **Cite the doc path(s)** you
+   used (e.g. "see `guides/skills.md`") so the operator can follow up.
+4. If `docs_search` returns nothing useful, say so plainly rather than inventing an answer.

--- a/tests/test_docs_plugin.py
+++ b/tests/test_docs_plugin.py
@@ -1,0 +1,97 @@
+"""Docs plugin — the FTS index, corpus path-validation, and the search/read tools."""
+
+from __future__ import annotations
+
+import importlib.util
+import sys
+from pathlib import Path
+
+
+def _load_docs():
+    """Load the multi-file docs plugin as a package (so its relative imports resolve) —
+    mirrors graph.plugins.loader._load_plugin_module."""
+    name = "docs_plugin_under_test"
+    for n in [m for m in list(sys.modules) if m == name or m.startswith(name + ".")]:
+        sys.modules.pop(n, None)
+    spec = importlib.util.spec_from_file_location(
+        name,
+        Path("plugins/docs/__init__.py"),
+        submodule_search_locations=["plugins/docs"],
+    )
+    assert spec and spec.loader
+    mod = importlib.util.module_from_spec(spec)
+    sys.modules[name] = mod
+    spec.loader.exec_module(mod)
+    return mod
+
+
+def _corpus(root: Path) -> None:
+    """Write a tiny doc tree: two indexed sections + an excluded dev/ dir."""
+    (root / "guides").mkdir()
+    (root / "guides" / "skills.md").write_text(
+        "# Skills (SKILL.md)\n\nSkills teach the agent how and when to use its tools.\n",
+        encoding="utf-8",
+    )
+    (root / "reference").mkdir()
+    (root / "reference" / "configuration.md").write_text(
+        "# Configuration\n\nThe langgraph-config.yaml schema and every option.\n",
+        encoding="utf-8",
+    )
+    (root / "dev").mkdir()  # internal — must NOT be indexed
+    (root / "dev" / "secret.md").write_text("# Secret\n\ninternal handoff\n", encoding="utf-8")
+
+
+def test_index_seeds_and_ranks(tmp_path) -> None:
+    docs = _load_docs()
+    _corpus(tmp_path)
+    idx = docs.DocsIndex(root=tmp_path)
+    assert idx.seed() == 2  # only the two section docs; dev/ excluded
+
+    hits = idx.search("skills tools")
+    assert hits and hits[0].path == "guides/skills.md"
+    assert hits[0].section == "guides"
+    assert hits[0].title == "Skills (SKILL.md)"
+
+    # Title/body match the right doc.
+    cfg = idx.search("configuration schema")
+    assert cfg and cfg[0].path == "reference/configuration.md"
+
+    # No match → empty, never an error.
+    assert idx.search("zzz_no_such_term_xyz") == []
+    assert idx.search("") == []
+
+
+def test_dev_dir_is_excluded(tmp_path) -> None:
+    docs = _load_docs()
+    _corpus(tmp_path)
+    idx = docs.DocsIndex(root=tmp_path)
+    idx.seed()
+    assert idx.search("internal handoff secret") == []  # dev/ never indexed
+    assert idx.has("dev/secret.md") is False
+
+
+def test_read_doc_gated_to_corpus(tmp_path) -> None:
+    _load_docs()  # loads the package so its .corpus submodule is importable below
+    _corpus(tmp_path)
+    corpus = sys.modules["docs_plugin_under_test.corpus"]
+
+    # In-corpus read works.
+    assert "Skills teach the agent" in corpus.read_doc("guides/skills.md", root=tmp_path)
+    # Out-of-corpus is refused (traversal / absolute / unknown / excluded dev).
+    assert corpus.read_doc("../secret.md", root=tmp_path) is None
+    assert corpus.read_doc("/etc/passwd", root=tmp_path) is None
+    assert corpus.read_doc("guides/missing.md", root=tmp_path) is None
+    assert corpus.read_doc("dev/secret.md", root=tmp_path) is None
+
+
+async def test_tools_over_the_real_docs() -> None:
+    """End-to-end against the repo's real docs/ tree (present in the test env)."""
+    docs = _load_docs()
+    out = await docs.docs_search.ainvoke({"query": "how do skills work"})
+    assert "guides/skills.md" in out
+
+    body = await docs.docs_read.ainvoke({"path": "guides/skills.md"})
+    assert "SKILL.md" in body
+
+    refused = await docs.docs_read.ainvoke({"path": "../../etc/passwd"})
+    assert "No such doc" in refused


### PR DESCRIPTION
**PR 1 of 2** for the first-party, default-on **`docs` plugin**. This is the agent foundation — the running agent can now answer questions about protoAgent's *own* documentation. (PR 2 adds the console Docs reader view + ⌘K doc search.)

## What's here
- **`plugins/docs/`** (`enabled: true`, on by default; opt out via `plugins.disabled: [docs]`):
  - **`DocsIndex`** — in-memory SQLite **FTS5** keyword index (mirrors `graph/skills/index.py`; BM25, **no embeddings**), seeded at load from the bundled `docs/` tree. Indexes the four Diátaxis sections + ADRs; **excludes `docs/dev/**` + `.vitepress/`** (matches the site's `srcExclude`).
  - **`corpus.py`** — resolves `docs/` in dev/Docker *and* the frozen bundle, and **gates reads to the indexed set** (rejects traversal / absolute / out-of-corpus paths).
  - **Tools** `docs_search(query)` + `docs_read(path)`, and a **SKILL.md** (auto-discovered) teaching *search → read → cite*. Self-contained + offline — **no knowledge-store coupling**, so it never pollutes the operator's knowledge and works in the frozen desktop app.
- **`apps/desktop/sidecar/build_sidecar.py`** — bundle the doc md dirs so the frozen sidecar can read the corpus (single source of truth; no committed duplicate).

## Deviation from the plan
The index is **in-memory** (rebuilt at load) rather than a `/sandbox/docs.db` file — the corpus is read-only + bundled, so a db file/path/staleness buys nothing. Same `DocsIndex.search()` seam if a hybrid/embeddings upgrade is ever wanted.

## Verification
`ruff` · `lint-imports` (3 kept / 0 broken) · `pytest` (**2246**, incl. 4 new docs tests — index ranking, `dev/` exclusion, read path-validation, tools over the real corpus) · `live_smoke` (real server boots clean with the plugin enabled). Verified the loader discovers it, marks it enabled, and registers both tools + the skill dir.

🤖 Generated with [Claude Code](https://claude.com/claude-code)