### PR TITLE
feat(plugins): docs plugin views — console reader + ⌘K search (PR2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,10 +12,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- **Docs plugin — the agent can answer questions about protoAgent's own docs** (first-party,
-  on by default). A keyword FTS index over the bundled docs + `docs_search` / `docs_read`
-  tools + a skill (search → read → cite). Self-contained and offline — no embeddings, no
-  knowledge-store coupling. A console Docs reader view + ⌘K doc search follow.
+- **Docs plugin — read and ask about protoAgent's own docs** (first-party, on by default).
+  A keyword FTS index over the bundled docs + `docs_search` / `docs_read` tools + a skill
+  (search → read → cite) so the agent answers from the docs; plus a console **Docs** reader
+  view (section tree + server-rendered markdown) and a ⌘K **Docs** search. Self-contained
+  and offline — no embeddings, no knowledge-store coupling.
 
 ### Changed
 - **The desktop in-app update notice is now a full modal with a markdown-rendered

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -102,6 +102,9 @@ COLLECT_ALL = [
     # imported, so collect it explicitly. (An external Google Gmail/Calendar MCP
     # plugin re-invokes the frozen binary via the generic ``--mcp-plugin <id>`` shim.)
     "mcp",
+    # Markdown renderer for the bundled `docs` plugin's reader view — imported only by
+    # the path-loaded plugin, so the import-scan misses it; collect explicitly.
+    "markdown_it",
 ]
 
 # Google client libraries (ADR 0017) — bundled only when installed in the build

--- a/plugins/docs/__init__.py
+++ b/plugins/docs/__init__.py
@@ -16,8 +16,9 @@ import logging
 
 from langchain_core.tools import tool
 
-from .corpus import read_doc
+from .corpus import doc_tree, read_doc
 from .docs_index import DocsIndex
+from .render import render_markdown
 
 log = logging.getLogger("protoagent.plugins.docs")
 
@@ -64,11 +65,129 @@ async def docs_read(path: str) -> str:
     return text or f"Could not read {path!r}."
 
 
+def _title_from_md(md: str, fallback: str) -> str:
+    for line in md.splitlines():
+        s = line.strip()
+        if s.startswith("# "):
+            return s[2:].strip()
+    return fallback
+
+
+def _build_view_router():
+    """The reader PAGE — served UNGATED under ``/plugins/docs`` (an iframe page-load can't
+    carry a bearer). One mode-adaptive page: full tree+reader on the rail, search-first in
+    the ⌘K palette (``?mode=search``). It fetches its data from the gated router below."""
+    from fastapi import APIRouter
+    from fastapi.responses import HTMLResponse
+
+    router = APIRouter()
+
+    @router.get("/view")
+    async def _view():
+        return HTMLResponse(_VIEW_HTML)
+
+    return router
+
+
+def _build_data_router():
+    """The Docs DATA routes — GATED under ``/api/plugins/docs`` (fetched with the handshake
+    token). ``/doc`` renders markdown → HTML server-side (offline; no JS markdown bundle)."""
+    from fastapi import APIRouter
+    from fastapi.responses import JSONResponse
+
+    router = APIRouter()
+
+    @router.get("/tree")
+    async def _tree() -> dict:
+        return {"sections": doc_tree()}
+
+    @router.get("/search")
+    async def _search(q: str = "") -> dict:
+        rows = _index().search(q, k=20)
+        return {"results": [{"path": r.path, "title": r.title, "section": r.section, "preview": r.preview} for r in rows]}
+
+    @router.get("/doc")
+    async def _doc(path: str = ""):
+        if not _index().has(path):
+            return JSONResponse({"error": "not found"}, status_code=404)
+        md = read_doc(path)
+        if md is None:
+            return JSONResponse({"error": "not found"}, status_code=404)
+        return {"path": path, "title": _title_from_md(md, path), "html": render_markdown(md)}
+
+    return router
+
+
 def register(registry) -> None:
-    """Entry point — build the index (so the first turn is fast) + expose the tools.
-    The ``skills/`` dir is auto-discovered by the loader; no explicit registration."""
+    """Entry point — build the index (so the first turn is fast), expose the tools, and
+    serve the reader view (page ungated, data gated). ``skills/`` is auto-discovered."""
     try:
         _index()
     except Exception as exc:  # noqa: BLE001 — plugin load must never fail on this
         log.warning("[docs] index build at load failed: %s", exc)
     registry.register_tools([docs_search, docs_read])
+    registry.register_router(_build_view_router(), prefix="/plugins/docs")
+    registry.register_router(_build_data_router(), prefix="/api/plugins/docs")
+
+
+# The reader page the console iframes (rail "Docs" + the ⌘K "Docs" palette morph). One
+# mode-adaptive page (full tree+reader; `?mode=search` = search-first for the palette).
+# FOUR-RULES COMPLIANT (docs/guides/building-react-plugin-views.md): base-prefixed kit
+# css+js loaded slug-aware (rule 4), gated data via the kit's authed apiFetch (rules 2+3).
+# Markdown is rendered SERVER-SIDE (/doc returns HTML) — no CDN, offline/frozen-safe.
+_VIEW_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
+<script>window.__base = location.pathname.split("/plugins/")[0];
+document.write('<link rel="stylesheet" href="'+window.__base+'/_ds/plugin-kit.css">');</script>
+<style>
+  *{box-sizing:border-box} html,body{margin:0;height:100%;color:var(--pl-color-fg);background:var(--pl-color-bg);font:14px/1.55 system-ui,-apple-system,sans-serif}
+  #app{display:flex;height:100vh}
+  #nav{width:280px;flex:none;border-right:1px solid var(--pl-color-border);overflow:auto;padding:8px}
+  #reader{flex:1;overflow:auto;padding:16px 26px}
+  .q{width:100%;padding:6px 8px;border:1px solid var(--pl-color-border);border-radius:6px;background:var(--pl-color-bg-inset);color:inherit;margin-bottom:8px;font:inherit}
+  .sec{font-weight:600;font-size:11px;letter-spacing:.04em;text-transform:uppercase;opacity:.6;margin:12px 4px 4px}
+  .item{display:block;padding:3px 8px;border-radius:4px;cursor:pointer;color:inherit;text-decoration:none;font-size:13px;white-space:nowrap;overflow:hidden;text-overflow:ellipsis}
+  .item:hover,.item.active{background:var(--pl-color-bg-inset)}
+  .res{padding:6px 8px;border-radius:6px;cursor:pointer} .res:hover{background:var(--pl-color-bg-inset)}
+  .res .t{font-weight:600} .res .p{font-size:12px;opacity:.65}
+  .empty{opacity:.6;padding:24px}
+  .md{max-width:760px} .md h1{font-size:1.6em} .md h2{font-size:1.3em;border-bottom:1px solid var(--pl-color-border);padding-bottom:.2em} .md h3{font-size:1.1em}
+  .md code{background:var(--pl-color-bg-inset);padding:1px 5px;border-radius:4px;font-size:.9em}
+  .md pre{background:var(--pl-color-bg-inset);padding:12px;border-radius:8px;overflow:auto} .md pre code{background:none;padding:0}
+  .md table{border-collapse:collapse;margin:8px 0} .md th,.md td{border:1px solid var(--pl-color-border);padding:5px 9px;text-align:left}
+  .md a{color:var(--pl-color-accent,#818cf8)} .md blockquote{border-left:3px solid var(--pl-color-border);margin:8px 0;padding:2px 12px;opacity:.85}
+  body.mode-search #app{flex-direction:column} body.mode-search #nav{width:auto;border-right:none;border-bottom:1px solid var(--pl-color-border);max-height:48%}
+</style></head>
+<body>
+<div id="app">
+  <aside id="nav"><input id="q" class="q" placeholder="Search docs…" autofocus><div id="list"></div></aside>
+  <main id="reader"><div class="empty">Select a doc from the list.</div></main>
+</div>
+<script type="module">
+const base = window.__base;
+let kit; try { kit = await import(base+"/_ds/plugin-kit.js"); } catch(e){ kit = { initPluginView(){}, apiFetch:(p,i)=>fetch(base+p,i) }; }
+kit.initPluginView(()=>{});
+if (new URLSearchParams(location.search).get("mode")==="search") document.body.classList.add("mode-search");
+const $list=document.getElementById("list"), $reader=document.getElementById("reader"), $q=document.getElementById("q");
+const esc=s=>String(s).replace(/[&<>"]/g,c=>({"&":"&amp;","<":"&lt;",">":"&gt;",'"':"&quot;"}[c]));
+async function api(p){ try{ const r=await kit.apiFetch("/api/plugins/docs"+p); return r.ok?await r.json():null; }catch(e){ return null; } }
+async function openDoc(path){
+  const d=await api("/doc?path="+encodeURIComponent(path));
+  $reader.innerHTML = d ? '<article class="md">'+d.html+'</article>' : '<div class="empty">Could not load.</div>';
+  $reader.scrollTop=0;
+  [...document.querySelectorAll(".item")].forEach(a=>a.classList.toggle("active", a.dataset.path===path));
+}
+function renderTree(sections){
+  $list.innerHTML = sections.map(s=>'<div class="sec">'+esc(s.label)+'</div>'+s.items.map(it=>'<a class="item" data-path="'+esc(it.path)+'" title="'+esc(it.path)+'">'+esc(it.title)+'</a>').join("")).join("") || '<div class="empty">No docs.</div>';
+  [...$list.querySelectorAll(".item")].forEach(a=>a.onclick=()=>openDoc(a.dataset.path));
+}
+function renderResults(rows){
+  $list.innerHTML = rows.length ? rows.map(r=>'<div class="res" data-path="'+esc(r.path)+'"><div class="t">'+esc(r.title)+'</div><div class="p">'+esc(r.section)+' · '+esc(r.path)+'</div></div>').join("") : '<div class="empty">No matches.</div>';
+  [...$list.querySelectorAll(".res")].forEach(d=>d.onclick=()=>openDoc(d.dataset.path));
+}
+let tree=null;
+async function showTree(){ if(!tree){ const t=await api("/tree"); tree=(t&&t.sections)||[]; } renderTree(tree); }
+let timer;
+$q.oninput=()=>{ clearTimeout(timer); timer=setTimeout(async()=>{ const q=$q.value.trim(); if(!q){ showTree(); return; } const r=await api("/search?q="+encodeURIComponent(q)); renderResults((r&&r.results)||[]); }, 180); };
+showTree();
+</script></body></html>
+"""

--- a/plugins/docs/corpus.py
+++ b/plugins/docs/corpus.py
@@ -17,6 +17,14 @@ from pathlib import Path
 # Indexed/served sections. docs/dev (internal) + .vitepress (build) are intentionally out.
 SECTIONS: tuple[str, ...] = ("tutorials", "guides", "reference", "explanation", "adr")
 
+_SECTION_LABELS = {
+    "tutorials": "Tutorials",
+    "guides": "Guides",
+    "reference": "Reference",
+    "explanation": "Explanation",
+    "adr": "Architecture Decisions",
+}
+
 
 def docs_root() -> Path:
     """The `docs/` directory — repo root in dev/Docker, the bundle root when frozen."""
@@ -64,6 +72,23 @@ def doc_title(abs_path: Path) -> str:
     except OSError:
         pass
     return abs_path.stem
+
+
+def doc_tree(root: Path | None = None) -> list[dict]:
+    """Ordered sections → items (`{path, title}`) for the reader's nav. Section order
+    follows `SECTIONS` (the Diátaxis arc, then ADRs); items sorted by title."""
+    root = root or docs_root()
+    by_section: dict[str, list[dict]] = {s: [] for s in SECTIONS}
+    for rel, abs_path in iter_docs(root):
+        section = rel.split("/", 1)[0]
+        if section in by_section:
+            by_section[section].append({"path": rel, "title": doc_title(abs_path)})
+    out: list[dict] = []
+    for section in SECTIONS:
+        items = sorted(by_section[section], key=lambda x: x["title"].lower())
+        if items:
+            out.append({"id": section, "label": _SECTION_LABELS.get(section, section.title()), "items": items})
+    return out
 
 
 def doc_preview(content: str, limit: int = 240) -> str:

--- a/plugins/docs/protoagent.plugin.yaml
+++ b/plugins/docs/protoagent.plugin.yaml
@@ -10,3 +10,7 @@ enabled: true
 capabilities:
   network: []
   filesystem: scoped   # read-only over the bundled docs/ tree
+views:
+  # A rail "Docs" reader (domain/section tree + markdown), and a ⌘K "Docs" palette morph
+  # into the same page in search-first mode (ADR 0026 / 0057).
+  - { id: docs, label: "Docs", icon: "BookOpen", placement: rail, path: "/plugins/docs/view", palette: { path: "/plugins/docs/view?mode=search" } }

--- a/plugins/docs/render.py
+++ b/plugins/docs/render.py
@@ -1,0 +1,18 @@
+"""Server-side markdown → HTML for the Docs reader view.
+
+Rendered in the plugin (not the iframe) so the view ships no JS markdown bundle and works
+offline / in the frozen desktop app — the `docs_read` tool still returns raw markdown for
+the agent; only the view needs HTML. CommonMark + GFM tables (the docs are table-heavy);
+no linkify (avoids an extra dep — the docs use explicit `[text](url)` links).
+"""
+
+from __future__ import annotations
+
+from markdown_it import MarkdownIt
+
+_MD = MarkdownIt("commonmark").enable(["table", "strikethrough"])
+
+
+def render_markdown(md: str) -> str:
+    """Render markdown to an HTML fragment (the view injects it into a `.markdown` block)."""
+    return _MD.render(md or "")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,6 +41,8 @@ dependencies = [
   # Document ingestion engine (ADR 0021) — light pure-Python extractors:
   "pypdf>=4.0",                  # PDF → text
   "youtube-transcript-api>=1.0", # YouTube captions → text (1.x instance API)
+  # Markdown → HTML for the `docs` plugin's reader view (server-side render, offline).
+  "markdown-it-py>=3.0",
 ]
 
 [build-system]

--- a/tests/test_docs_plugin.py
+++ b/tests/test_docs_plugin.py
@@ -95,3 +95,40 @@ async def test_tools_over_the_real_docs() -> None:
 
     refused = await docs.docs_read.ainvoke({"path": "../../etc/passwd"})
     assert "No such doc" in refused
+
+
+def test_render_handles_tables() -> None:
+    docs = _load_docs()
+    html = docs.render_markdown("# T\n\n| a | b |\n|---|---|\n| 1 | 2 |\n")
+    assert "<h1>" in html and "<table>" in html and "<td>1</td>" in html
+
+
+def test_data_routes(tmp_path) -> None:
+    from fastapi import FastAPI
+    from fastapi.testclient import TestClient
+
+    docs = _load_docs()
+    app = FastAPI()
+    app.include_router(docs._build_data_router(), prefix="/api/plugins/docs")
+    c = TestClient(app)
+
+    tree = c.get("/api/plugins/docs/tree").json()["sections"]
+    assert {s["id"] for s in tree} >= {"guides", "reference"}  # real corpus
+
+    res = c.get("/api/plugins/docs/search", params={"q": "skills"}).json()["results"]
+    assert any(r["path"] == "guides/skills.md" for r in res)
+
+    doc = c.get("/api/plugins/docs/doc", params={"path": "guides/skills.md"}).json()
+    assert doc["path"] == "guides/skills.md" and "<h1>" in doc["html"]
+
+    # Out-of-corpus path → 404 (the read gate).
+    assert c.get("/api/plugins/docs/doc", params={"path": "../../etc/passwd"}).status_code == 404
+    assert c.get("/api/plugins/docs/doc", params={"path": "dev/secret.md"}).status_code == 404
+
+
+def test_view_is_four_rules_compliant() -> None:
+    html = _load_docs()._VIEW_HTML
+    assert "/_ds/plugin-kit.css" in html and "/_ds/plugin-kit.js" in html  # rule 4
+    assert 'location.pathname.split("/plugins/")[0]' in html  # rule 3 (slug-aware base)
+    assert 'apiFetch("/api/plugins/docs' in html  # rules 2+3 (gated data via authed fetch)
+    assert "https://" not in html.split("<style>")[0]  # no CDN in the head

--- a/uv.lock
+++ b/uv.lock
@@ -1208,6 +1208,18 @@ wheels = [
 ]
 
 [[package]]
+name = "markdown-it-py"
+version = "4.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mdurl" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/ff/7841249c247aa650a76b9ee4bbaeae59370dc8bfd2f6c01f3630c35eb134/markdown_it_py-4.2.0.tar.gz", hash = "sha256:04a21681d6fbb623de53f6f364d352309d4094dd4194040a10fd51833e418d49", size = 82454, upload-time = "2026-05-07T12:08:28.36Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/81/4da04ced5a082363ecfa159c010d200ecbd959ae410c10c0264a38cac0f5/markdown_it_py-4.2.0-py3-none-any.whl", hash = "sha256:9f7ebbcd14fe59494226453aed97c1070d83f8d24b6fc3a3bcf9a38092641c4a", size = 91687, upload-time = "2026-05-07T12:08:27.182Z" },
+]
+
+[[package]]
 name = "mcp"
 version = "1.27.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1230,6 +1242,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/27/3c/347cf965d313f5d41764e7d46bea6ffe7d9ef13b983cc429b0340962a082/mcp-1.27.2.tar.gz", hash = "sha256:8e02db104096d1c25b28e64bde29a5c32b31bc241710213e12fd4d84985bdfef", size = 621116, upload-time = "2026-05-29T17:16:04.039Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c9/11/252c6f971dc4f16af1d98a1c469d8ba523aab00d1bb76b4d3bc1ff32eacc/mcp-1.27.2-py3-none-any.whl", hash = "sha256:d6ff5160c6ca65d93013626efb3fc249de683c30b2d8570755ceddd490344de5", size = 220498, upload-time = "2026-05-29T17:16:02.442Z" },
+]
+
+[[package]]
+name = "mdurl"
+version = "0.1.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d6/54/cfe61301667036ec958cb99bd3efefba235e65cdeb9c84d24a8293ba1d90/mdurl-0.1.2.tar.gz", hash = "sha256:bb413d29f5eea38f31dd4754dd7377d4465116fb207585f97bf925588687c1ba", size = 8729, upload-time = "2022-08-14T12:40:10.846Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/b3/38/89ba8ad64ae25be8de66a6d463314cf1eb366222074cfda9ee839c56a4b4/mdurl-0.1.2-py3-none-any.whl", hash = "sha256:84008a41e51615a49fc9966191ff91509e3c40b939176e643fd50a5c2196b8f8", size = 9979, upload-time = "2022-08-14T12:40:09.779Z" },
 ]
 
 [[package]]
@@ -1518,7 +1539,7 @@ wheels = [
 
 [[package]]
 name = "protoagent"
-version = "0.46.0"
+version = "0.52.0"
 source = { virtual = "." }
 dependencies = [
     { name = "a2a-sdk", extra = ["fastapi", "http-server", "sqlite"] },
@@ -1535,6 +1556,7 @@ dependencies = [
     { name = "langfuse" },
     { name = "langgraph" },
     { name = "langgraph-checkpoint-sqlite" },
+    { name = "markdown-it-py" },
     { name = "mcp" },
     { name = "packaging" },
     { name = "prometheus-client" },
@@ -1565,6 +1587,7 @@ requires-dist = [
     { name = "langfuse", specifier = ">=3.0" },
     { name = "langgraph", specifier = ">=1.1.0" },
     { name = "langgraph-checkpoint-sqlite", specifier = ">=2.0" },
+    { name = "markdown-it-py", specifier = ">=3.0" },
     { name = "mcp", specifier = ">=1.2" },
     { name = "packaging", specifier = ">=23.2" },
     { name = "prometheus-client", specifier = ">=0.20" },


### PR DESCRIPTION
**PR 2 of 2** — completes the first-party `docs` plugin with its console surfaces (PR 1, the agent tools + index, merged in #1191).

## What's here
- **Rail "Docs" reader** — a section tree (Tutorials / Guides / Reference / Explanation / ADRs) + a markdown reader pane, served as a themed iframe.
- **⌘K "Docs" search** — the same page in search-first mode (`palette: {path: …?mode=search}`, ADR 0026/0057) — type → results → open inline.
- **Server-side markdown** (`render.py`, `markdown-it-py`, CommonMark + GFM tables) so the view ships **no JS markdown bundle** and works offline / in the frozen app. The `docs_read` *tool* still returns raw markdown for the agent — only the view renders HTML.
- **Routes**: ungated page `/plugins/docs/view`; gated data `/api/plugins/docs/{tree,search,doc}` — `/doc` is gated to the indexed corpus (404s anything outside it).
- **Dep**: `markdown-it-py` (pyproject single-source; `--collect-all markdown_it` so the frozen sidecar has it).
- The page is **four-rules compliant** (slug-aware base, plugin-kit css+js, authed `apiFetch`); no CDN; embedded HTML in docs is escaped (CommonMark `html:false`).

## Scope notes
- **Domain grouping deferred**: the tree groups by Diátaxis **section** + H1 title (robust, no fragile `config.mts` TS-parsing). A generated `nav.json` can add the site's domain grouping later.
- **Palette = inline view** (its own search box) — native ⌘K command/search providers are ADR 0057 **step-3b** (not shipped).

## Verification
`ruff` · `lint-imports` (3/0) · `pytest` (**2249**, +3: data routes incl. traversal-404, table render, view four-rules) · `live_smoke` (boots clean with the plugin, its views, and the new dep). The rail/palette views are runtime (iframe from manifest) — no console rebuild needed; worth an eyeball in the console.

🤖 Generated with [Claude Code](https://claude.com/claude-code)