### PR TITLE
chore: release v0.53.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,17 +11,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.53.0] - 2026-06-19
+
 ### Added
 - **Docs plugin — read and ask about protoAgent's own docs** (first-party, on by default).
   A keyword FTS index over the bundled docs + `docs_search` / `docs_read` tools + a skill
   (search → read → cite) so the agent answers from the docs; plus a console **Docs** reader
   view (a Diátaxis→domain tree mirroring the docs site + server-rendered markdown) and a ⌘K
   **Docs** search. Self-contained and offline — no embeddings, no knowledge-store coupling.
+- **`user_only` skills** — mark a skill so it's *only* a `/<slash>` command and is never
+  auto-retrieved into context, for deliberate run-on-demand procedures.
 
 ### Changed
-- **The desktop in-app update notice is now a full modal with a markdown-rendered
-  changelog.** The release notes render as readable markdown (headings, bullets, links) in
-  a centered dialog instead of a cramped plain-text corner panel.
+- **Desktop update notice is now a full modal with a markdown changelog.** The release
+  notes render as readable markdown (headings, bullets, links) in a centered dialog instead
+  of a cramped plain-text corner panel.
+
+### Fixed
+- **Plugin views are themed in the desktop app** — the frozen sidecar now serves
+  `/_ds/plugin-kit.{css,js}`, so plugin iframes (Notes, Docs) pick up the design system
+  instead of rendering unstyled.
 
 ## [0.52.0] - 2026-06-19
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.52.0"
+version = "0.53.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "v0.53.0",
+    "date": "2026-06-19",
+    "changes": [
+      "Docs plugin — read and ask about protoAgent's own docs",
+      "user_only skills",
+      "Desktop update notice is now a full modal with a markdown changelog.",
+      "Plugin views are themed in the desktop app"
+    ]
+  },
+  {
     "version": "v0.52.0",
     "date": "2026-06-19",
     "changes": [


### PR DESCRIPTION
Minor release. Ships the recent feature work and — as a `.0` tag — triggers the **desktop build** (free now; public repo) so the new plugin + UI reach the desktop binaries + in-app updater.

Standard prep (`version.py minor` + `changelog.py roll`/`scaffold`): pyproject → `0.53.0`, CHANGELOG rolled, marketing `changelog.json` entry derived.

Headlines:
- **Docs plugin** — the agent answers from protoAgent's own docs (`docs_search`/`docs_read` + skill), a console **Docs** reader (Diátaxis→domain tree + server-rendered markdown), and ⌘K docs search (#1191/#1192/#1193).
- **`user_only` skills** — `/slash`-only, never auto-loaded (#1189).
- **Desktop update notice** → full modal with a markdown changelog (#1188).
- **Fix** — frozen sidecar serves `/_ds/plugin-kit` so plugin iframes are themed (#1190).

After merge: `git tag -a v0.53.0 -m 'Release v0.53.0' && git push origin v0.53.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)