### PR TITLE
fix(changelog): _titles folds a bold lead that wraps across lines

### DIFF
--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -56,15 +56,36 @@ def _section(text: str, version: str) -> tuple[str | None, str]:
 
 
 def _titles(body: str) -> list[str]:
-    """Concise draft summaries: each top-level bullet's **bold lead** (or first clause)."""
+    """Concise draft summaries: each top-level bullet's **bold lead** (or first clause).
+
+    A bullet's continuation lines are folded in before extraction, so a bold lead that
+    wraps across lines (``- **A long lead\\n  that wraps.** rest``) is captured whole
+    instead of leaving a stray ``**`` (the v0.47/v0.53 marketing-changelog glitch).
+    """
     out: list[str] = []
-    for line in body.splitlines():
-        m = re.match(r"^- +(.*)$", line)  # top-level bullets only (skip nested/continuations)
-        if not m:
-            continue
-        bold = re.match(r"\*\*(.+?)\*\*", m.group(1))
-        title = bold.group(1) if bold else re.split(r"\s+[—-]\s+|\. ", m.group(1), 1)[0]
+    chunk: list[str] | None = None  # the current top-level bullet's lines
+
+    def flush() -> None:
+        if not chunk:
+            return
+        text = re.sub(r"\s+", " ", " ".join(chunk)).strip()
+        bold = re.match(r"\*\*(.+?)\*\*", text)
+        title = bold.group(1) if bold else re.split(r"\s+[—-]\s+|\. ", text, 1)[0]
         out.append(_strip_md(title))
+
+    for line in body.splitlines():
+        m = re.match(r"^- +(.*)$", line)  # a new TOP-LEVEL bullet (no leading indent)
+        if m:
+            flush()
+            chunk = [m.group(1)]
+        elif chunk is not None:
+            s = line.strip()
+            if not s or s.startswith("- ") or line.startswith("#"):
+                flush()  # blank / nested bullet / heading → the bullet (and its lead) ends
+                chunk = None
+            else:
+                chunk.append(s)  # an indented continuation line of the current bullet
+    flush()
     return out
 
 

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -103,6 +103,19 @@ def test_scaffold_prepends_when_absent_and_is_idempotent(tmp_path, monkeypatch):
     assert json.loads(mj.read_text(encoding="utf-8")) == entries
 
 
+def test_titles_fold_a_bold_lead_that_wraps_lines():
+    """A `**bold**` lead spanning two lines is captured whole (the v0.47/v0.53 glitch),
+    and a same-line lead still works."""
+    body = (
+        "### Added\n"
+        "- **A long bold lead that wraps\n"
+        "  onto a second line.** then the rest of the bullet.\n"
+        "- **Single line.** detail here\n"
+        "  with a continuation that's ignored.\n"
+    )
+    assert changelog._titles(body) == ["A long bold lead that wraps onto a second line.", "Single line."]
+
+
 def test_scaffold_omits_empty_release(tmp_path, monkeypatch):
     """A release whose section has no bullets is omitted from the marketing changelog
     (no bare version+date entry) rather than scaffolded empty."""


### PR DESCRIPTION
Durable fix for the recurring marketing-changelog glitch (hand-fixed on v0.47.0 and v0.53.0): the scaffolder's `_titles` extracted each bullet's `**bold**` lead **per line**, so a lead wrapping onto a second line produced a stray `**` + a truncated title.

`_titles` now groups a top-level bullet with its continuation lines (folding to one string) before matching the bold lead, so a multi-line lead is captured whole. Same-line leads + the first-clause fallback are unchanged; nested bullets/headings/blank lines still end a bullet.

Regression test added (`test_titles_fold_a_bold_lead_that_wraps_lines`); existing `_titles` test still green. ruff + `changelog.py check` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)