### PR TITLE
fix(web): background-agents pill appears without a reload on cold boot

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Background agents widget no longer needs a page reload to appear.** The utility-bar pill
+  mounts while a cold backend is still warming up (the desktop sidecar can take ~a minute),
+  so its one-shot startup fetch could fail before the engine was up and the pill stayed
+  hidden until a manual reload. It now re-checks whenever the event bus (re)connects — the
+  pill appears as soon as the engine is reachable, and also refreshes after a server restart.
+
 ## [0.53.0] - 2026-06-19
 
 ### Added

--- a/apps/web/src/app/BackgroundJobs.tsx
+++ b/apps/web/src/app/BackgroundJobs.tsx
@@ -4,7 +4,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 
 import { Markdown } from "../chat/LazyMarkdown";
 import { api } from "../lib/api";
-import { onTopic } from "../lib/events";
+import { onConnectionChange, onTopic } from "../lib/events";
 import type { BackgroundJobDTO } from "../lib/types";
 import { applyProgress, byRecency, fmtElapsed, nowIso, type ProgressTool } from "./background-jobs";
 
@@ -41,9 +41,20 @@ export function BackgroundJobs() {
       });
   }, []);
 
-  // Hydrate on mount.
+  // Hydrate on mount, then again whenever the event bus (re)connects. The reconnect
+  // refetch is what makes the pill appear WITHOUT a manual reload when the backend wasn't
+  // reachable at first paint: the shell (and this widget) mounts immediately while a cold
+  // sidecar is still warming up — the BootGate splash only overlays it — so the one-shot
+  // mount fetch can fail (connection refused) before the engine is up, and nothing else
+  // re-fetches the *existence* of the feature. `onConnectionChange` fires the current state
+  // immediately and on every transition; we refetch on each connect (also refreshing after
+  // a server restart). The plain mount call covers token-gated setups where the SSE bus
+  // can't authenticate but plain HTTP can.
   useEffect(() => {
     hydrate();
+    return onConnectionChange((c) => {
+      if (c) hydrate();
+    });
   }, [hydrate]);
 
   // Live updates off the event bus.


### PR DESCRIPTION
## What

The **Background agents** utility-bar pill didn't show on first page load — only after a manual reload.

## Why

The pill's *presence* is gated on a single `GET /api/background` fetch run **once on mount**:

```ts
if (!enabled && list.length === 0) return null;  // hidden until enabled is known
```

But the `AppShell` (and this widget) mounts **unconditionally** — the `BootGate` splash only *overlays* it while the engine warms up. On a cold start (the frozen desktop sidecar can take ~a minute), that one-shot fetch is rejected before the backend is reachable, the `.catch()` swallows it, and nothing re-fetches. So `enabled` stays `false` and the pill stays hidden until the user reloads (by which point the backend is up).

## Fix

Re-hydrate whenever the event bus `(re)connects` via `onConnectionChange` — the SSE `/api/events` connection opening is a reliable "engine is reachable now" signal. The pill appears as soon as the backend comes up (no reload), and it also refreshes after a server restart. The original mount fetch is kept so token-gated deployments (where the SSE bus can't carry a bearer, but plain HTTP can) still work.

## Test

- `tsc --noEmit` clean, eslint clean
- `test:unit` — 33 passed (background helpers + api)
- Live: pill now self-surfaces on a cold desktop boot instead of requiring ⌘R.

🤖 Generated with [Claude Code](https://claude.com/claude-code)