### PR TITLE
feat(web): Activity → read-only utility-bar widget (off the rail)

### DIFF
--- a/apps/web/e2e/activity.spec.ts
+++ b/apps/web/e2e/activity.spec.ts
@@ -1,19 +1,21 @@
 import { expect, test } from "@playwright/test";
 
-// The Activity provenance feed (ADR 0022): a timeline of agent-initiated turns,
-// each tagged with what triggered it. Loads entries from GET /api/activity,
-// shows an unread badge while off-surface, and appends pushed events live.
+// Activity is a read-only utility-bar widget (2026-06 IA pass): a bottom-left pill with an
+// unread badge that opens the provenance feed (ADR 0022) in a dialog. The feed loads from
+// GET /api/activity and appends pushed `activity.message` events live while the dialog is open.
 
-test("feed shows entries with provenance + live append", async ({ page }) => {
+test("widget badge → dialog feed with provenance + live append", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Pushed activity messages arrive while we're on Chat → the rail badge shows.
-  await expect(page.locator(".pl-count--rail")).toBeVisible();
+  // Pushed activity messages arrive while the dialog is closed → the widget's unread badge shows.
+  await expect(page.getByTestId("activity-badge")).toBeVisible();
 
-  await page.getByRole("button", { name: "Activity", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Activity" })).toBeVisible();
-
+  // Click the widget pill → the read-only feed opens in a dialog (and the badge clears).
+  await page.getByTestId("activity-widget").click();
   const feed = page.getByTestId("activity-surface");
+  await expect(feed).toBeVisible();
+  await expect(page.getByTestId("activity-badge")).toHaveCount(0);
+
   // Entry text + its provenance badges (origin + trigger) render.
   await expect(feed.getByText("3 PRs merged overnight, CI green.")).toBeVisible();
   await expect(feed.getByText("scheduled").first()).toBeVisible(); // origin badge
@@ -21,17 +23,9 @@ test("feed shows entries with provenance + live append", async ({ page }) => {
   await expect(feed.getByText("Build failed on main — investigating.")).toBeVisible();
   await expect(feed.getByText("inbox").first()).toBeVisible(); // inbox origin badge
 
-  // A pushed event appends live while the surface is open.
+  // A pushed event appends live while the dialog is open.
   await expect(feed.getByText("live activity ping").first()).toBeVisible();
-});
 
-test("replying clears the composer (the answer returns as a feed entry)", async ({ page }) => {
-  await page.goto("/app/", { waitUntil: "load" });
-  await page.getByRole("button", { name: "Activity", exact: true }).click();
-
-  const composer = page.locator(".activity-composer textarea");
-  await composer.fill("ping from operator");
-  await page.getByRole("button", { name: "Send", exact: true }).click();
-  // The feed shows agent outputs (not an echo of your reply); send clears the box.
-  await expect(composer).toHaveValue("");
+  // Read-only since the IA pass — there is no reply composer.
+  await expect(page.locator(".activity-composer")).toHaveCount(0);
 });

--- a/apps/web/e2e/chat-continuity.spec.ts
+++ b/apps/web/e2e/chat-continuity.spec.ts
@@ -19,7 +19,7 @@ test("conversation survives navigating away and back (surface stays mounted)", a
 
   // Leave the Chat tab → the chat surface is hidden but still mounted in the DOM
   // (not unmounted), so its state + any in-flight stream are preserved.
-  await rail(page, "Activity");
+  await rail(page, "Schedule");
   await expect(page.locator(".chat-stage")).toHaveCount(1); // still in the DOM
   await expect(page.locator(".chat-stage")).not.toBeVisible(); // just hidden
   await expect(page.locator(".pl-message--user")).toHaveCount(1); // message not lost
@@ -44,7 +44,7 @@ test("tool-call cards survive navigating away and back", async ({ page }) => {
   await expect(card.locator(".pl-toolcard__name")).toHaveText("web_search");
 
   // Leave and return — the tool card must still be there (not torn down).
-  await rail(page, "Activity");
+  await rail(page, "Schedule");
   await expect(page.locator(".pl-toolcard")).toHaveCount(1); // still in the DOM while away
   await rail(page, "Chat");
   await expect(page.locator(".pl-toolcard").first().locator(".pl-toolcard__name")).toHaveText("web_search");

--- a/apps/web/e2e/chat-slot.spec.ts
+++ b/apps/web/e2e/chat-slot.spec.ts
@@ -54,7 +54,7 @@ test("a slot claimant stays mounted across surface switches (#613 contract)", as
 
   // Switch away — a NORMAL plugin view would unmount (plugin-views.spec asserts
   // count 0); the slot claimant must stay in the DOM, merely hidden.
-  await page.locator(".pl-rail").getByRole("button", { name: "Activity", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Schedule", exact: true }).click();
   await expect(slotFrame).toHaveCount(1);
   await expect(slotFrame).toBeHidden();
 

--- a/apps/web/src/activity/ActivitySurface.tsx
+++ b/apps/web/src/activity/ActivitySurface.tsx
@@ -1,8 +1,7 @@
 import "./activity.css";
 
-import { Textarea } from "@protolabsai/ui/forms";
-import { Button, Empty } from "@protolabsai/ui/primitives";
-import { Clock, Inbox, Loader2, MessageSquare, Send, Users, Webhook, Zap } from "lucide-react";
+import { Empty } from "@protolabsai/ui/primitives";
+import { Clock, Inbox, MessageSquare, Users, Webhook, Zap } from "lucide-react";
 
 import { useEffect, useRef, useState } from "react";
 
@@ -14,13 +13,11 @@ import { PanelHeader } from "@protolabsai/ui/navigation";
 import { onServerEvent } from "../lib/events";
 import type { ActivityEntry } from "../lib/types";
 
-// The Activity provenance feed (ADR 0022): a timeline of agent-initiated turns,
-// each tagged with what triggered it (scheduled job / webhook / inbox / sister
-// agent / your reply). Loads from GET /api/activity, appends live via the
-// `activity.message` push event, and lets the operator reply into the
-// `system:activity` thread — the reply's answer arrives as a new feed entry.
-
-const ACTIVITY = "system:activity";
+// The Activity provenance feed (ADR 0022): a READ-ONLY timeline of agent-initiated
+// turns, each tagged with what triggered it (scheduled job / webhook / inbox /
+// sister agent). Loads from GET /api/activity and appends live via the
+// `activity.message` push event. Read-only since the 2026-06 IA pass — Activity is a
+// utility-bar widget now (ActivityWidget), not a rail surface you reply into.
 
 // origin → badge (icon + label). "" / unknown falls back to a generic agent turn.
 const ORIGIN: Record<string, { icon: typeof Clock; label: string }> = {
@@ -46,12 +43,11 @@ function Badge({ entry }: { entry: ActivityEntry }) {
   );
 }
 
-export function ActivitySurface({ onError }: { onError: (message: string) => void }) {
+export function ActivitySurface() {
   // Held newest-first (as the API returns), rendered oldest-first.
   const [entries, setEntries] = useState<ActivityEntry[]>([]);
-  const [draft, setDraft] = useState("");
-  const [sending, setSending] = useState(false);
   const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
   async function load() {
@@ -59,8 +55,9 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
     try {
       const r = await api.activity();
       setEntries(r.entries || []);
+      setError(null);
     } catch (e) {
-      onError(errMsg(e));
+      setError(errMsg(e));
     } finally {
       setLoading(false);
     }
@@ -96,21 +93,6 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
     scrollRef.current?.scrollTo({ top: scrollRef.current.scrollHeight });
   }, [entries]);
 
-  async function send() {
-    const text = draft.trim();
-    if (!text || sending) return;
-    setSending(true);
-    setDraft("");
-    try {
-      // Reply into the Activity thread; the answer returns as a feed entry.
-      await api.streamChat(text, ACTIVITY, {});
-    } catch (e) {
-      onError(errMsg(e));
-    } finally {
-      setSending(false);
-    }
-  }
-
   const chronological = [...entries].reverse();
 
   return (
@@ -122,6 +104,11 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
       />
 
       <div className="stage-body activity-body">
+        {error ? (
+          <div className="activity-error" role="alert">
+            {error}
+          </div>
+        ) : null}
         <div className="activity-feed" ref={scrollRef}>
           {chronological.length === 0 && !loading ? (
             <Empty
@@ -139,31 +126,6 @@ export function ActivitySurface({ onError }: { onError: (message: string) => voi
             </div>
           ))}
         </div>
-
-        <form
-          className="activity-composer"
-          onSubmit={(ev) => {
-            ev.preventDefault();
-            void send();
-          }}
-        >
-          <Textarea
-            value={draft}
-            onChange={(ev) => setDraft(ev.target.value)}
-            placeholder="Reply in the activity thread…"
-            rows={2}
-            onKeyDown={(ev) => {
-              if (ev.key === "Enter" && !ev.shiftKey && !ev.ctrlKey) {
-                ev.preventDefault();
-                void send();
-              }
-            }}
-          />
-          <Button variant="primary" type="submit" disabled={sending || !draft.trim()}>
-            {sending ? <Loader2 className="spin" size={16} /> : <Send size={16} />}
-            Send
-          </Button>
-        </form>
       </div>
     </section>
   );

--- a/apps/web/src/activity/ActivityWidget.tsx
+++ b/apps/web/src/activity/ActivityWidget.tsx
@@ -1,0 +1,41 @@
+import { useEffect, useRef, useState } from "react";
+import { Activity } from "lucide-react";
+
+import { onServerEvent } from "../lib/events";
+import { UtilityWidget } from "../app/UtilityWidget";
+import { ActivitySurface } from "./ActivitySurface";
+
+/**
+ * Activity as a utility-bar widget (2026-06 IA pass) — moved off the left rail into the
+ * bottom-left widgets cluster, alongside the inbox + background jobs. A pill with an unread
+ * badge; hover shows the count, click opens the read-only provenance feed in a dialog (which
+ * clears the badge). Tracks its own unread off the `activity.message` bus event —
+ * incrementing only while the dialog is closed.
+ */
+export function ActivityWidget() {
+  const [unread, setUnread] = useState(0);
+  const openRef = useRef(false);
+  useEffect(
+    () => onServerEvent("activity.message", () => { if (!openRef.current) setUnread((n) => n + 1); }),
+    [],
+  );
+  return (
+    <UtilityWidget
+      testId="activity-widget"
+      icon={<Activity size={14} />}
+      badge={unread ? <span data-testid="activity-badge">{unread > 9 ? "9+" : unread}</span> : null}
+      label={unread ? `Activity — ${unread} new` : "Activity"}
+      info={
+        unread
+          ? `${unread} new agent turn${unread === 1 ? "" : "s"} since you last looked`
+          : "Activity — what the agent did on its own"
+      }
+      dialogTitle="Activity"
+      dialogWidth="min(720px, 94vw)"
+      onOpen={() => { openRef.current = true; setUnread(0); }}
+      onClose={() => { openRef.current = false; }}
+    >
+      <ActivitySurface />
+    </UtilityWidget>
+  );
+}

--- a/apps/web/src/activity/activity.css
+++ b/apps/web/src/activity/activity.css
@@ -47,16 +47,15 @@
   background: color-mix(in srgb, var(--accent, #7c8cff) 12%, transparent);
 }
 
-.activity-composer {
-  display: flex;
-  gap: 8px;
-  padding: 12px;
-  border-top: 1px solid var(--border);
-}
-
-.activity-composer textarea {
-  flex: 1;
-  resize: none;
+/* Read-only since the 2026-06 IA pass — the reply composer is gone (Activity is a
+   utility-bar widget now). A load failure surfaces as a strip above the feed. */
+.activity-error {
+  margin: 8px 12px 0;
+  padding: 8px 12px;
+  border: 1px solid var(--danger, #e5484d);
+  border-radius: var(--radius);
+  color: var(--danger, #e5484d);
+  font-size: 13px;
 }
 
 /* Activity provenance feed (ADR 0022) ------------------------------------- */

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -73,7 +73,7 @@ import { TenantGuard } from "./TenantGuard";
 import { Splash, BootGate } from "@protolabsai/ui/splash";
 import { Button } from "@protolabsai/ui/primitives";
 
-import { ActivitySurface } from "../activity/ActivitySurface";
+import { ActivityWidget } from "../activity/ActivityWidget";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { InboxWidget } from "../inbox/InboxWidget";
 import { ChatSlot } from "./ChatSlot";
@@ -86,7 +86,6 @@ import { HamburgerMenu } from "./HamburgerMenu";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
-  type ActivityTab,
   type PluginsTab,
   type RightPanel,
   type Surface,
@@ -234,8 +233,6 @@ export function App() {
   const pluginsTab = useUI((s) => s.pluginsTab);
   const setPluginsTab = useUI((s) => s.setPluginsTab);
   const setFleetStartNew = useUI((s) => s.setFleetStartNew);
-  const activityTab = useUI((s) => s.activityTab);
-  const setActivityTab = useUI((s) => s.setActivityTab);
   const rightPanel = useUI((s) => s.rightPanel);
   const setRightPanel = useUI((s) => s.setRightPanel);
   const rightCollapsed = useUI((s) => s.rightCollapsed);
@@ -263,7 +260,6 @@ export function App() {
   const [confirmState, setConfirmState] = useState<
     null | { title: string; message?: string; confirmLabel?: string; onConfirm: () => void }
   >(null);
-  const [activityUnread, setActivityUnread] = useState(0);
   // Global settings overlay (the Global home) — store-driven so BOTH the header drawer
   // and command-palette deep-links (Fleet/Telemetry/Commons) can open it. The header
   // hamburger's app drawer itself is local (only App triggers it).
@@ -420,25 +416,8 @@ export function App() {
   // state for the "live" indicator. Surfaces subscribe to named events.
   useEffect(() => onConnectionChange(setLive), []);
 
-  // Unread badges (Activity rail + its Inbox sub-tab): count agent-initiated
-  // messages / inbound items that arrive while the operator isn't looking at
-  // the matching view. Refs so the event handlers read the live view.
-  const surfaceRef = useRef(surface);
-  surfaceRef.current = surface;
-  const activityTabRef = useRef(activityTab);
-  activityTabRef.current = activityTab;
-  const viewingThread = () => surfaceRef.current === "activity" && activityTabRef.current === "thread";
-
-  useEffect(
-    () =>
-      onServerEvent("activity.message", () => {
-        if (!viewingThread()) setActivityUnread((n) => n + 1);
-      }),
-    [],
-  );
-  useEffect(() => {
-    if (viewingThread()) setActivityUnread(0);
-  }, [surface, activityTab]);
+  // Activity unread now lives on the ActivityWidget (the utility-bar widget tracks its own
+  // `activity.message` count, clearing it when its dialog opens) — no rail badge to drive.
 
   // Goal completions surface as a toast (goal.achieved / goal.failed on the bus, ADR 0039) so a
   // plain operator notices a terminal goal without writing a plugin hook.
@@ -479,7 +458,8 @@ export function App() {
   // and is pinned left (railOf.chat is never moved).
   const CORE_SURFACES: { id: string; label: string; icon: ReactNode }[] = [
     { id: "chat", label: "Chat", icon: <MessageSquare size={18} /> },
-    { id: "activity", label: "Activity", icon: <Activity size={18} /> },
+    // Activity left the rail in the 2026-06 IA pass — it's a read-only utility-bar widget
+    // now (ActivityWidget, bottom-left widgets cluster).
     { id: "schedule", label: "Schedule", icon: <CalendarClock size={18} /> },
     // "studio" (Workflows) is contributed via src/ext/workflows.tsx, gated on the
     // workflows plugin (lean core) — no longer a hardcoded core surface.
@@ -570,9 +550,6 @@ export function App() {
 
   function renderSurface(id: string): ReactNode {
     switch (id) {
-      case "activity":
-        // Inbox moved to a utility-bar widget (2026-06 IA pass); Activity is the thread.
-        return <ActivitySurface onError={setError} />;
       // Schedule is its own rail surface again (un-fold from #1075): cron triggers, but
       // timed work earns a top-level rail rather than a tab buried in Activity.
       case "schedule":
@@ -813,7 +790,6 @@ export function App() {
         className="app-shell-main"
         leftItems={railSurfaces("left").map((s) => ({
           ...s,
-          badge: s.id === "activity" ? activityUnread : undefined,
           dot: s.id === "chat" ? chatStreaming && surface !== "chat" : pluginDots[s.id] || undefined,
         }))}
         rightItems={railSurfaces("right").map((s) => ({ ...s, dot: pluginDots[s.id] || undefined }))}
@@ -911,10 +887,12 @@ export function App() {
             // GitHub moved into the header drawer.
             start={
               <>
-                {/* Widgets (bottom-left): background subagents (ADR 0050 Phase 3) +
-                    the inbox — each a pill with a hover info popover + a click dialog. */}
+                {/* Widgets (bottom-left): background subagents (ADR 0050 Phase 3), the
+                    inbox, and the read-only Activity feed — each a pill with a hover info
+                    popover + a click dialog. */}
                 <BackgroundJobs />
                 <InboxWidget />
+                <ActivityWidget />
                 {/* Plugin-contributed utility widgets (`views[].utility`): a pill that opens
                     the plugin's iframe in a dialog, with hover info. Reuses PluginView. */}
                 {utilityWidgetViews.map((v) => (

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -36,12 +36,13 @@ describe("migrateUiState", () => {
   });
 
   // v7: "schedule" is a top-level rail surface again (un-fold from #1075). A persisted
-  // layout that lost it (it was pruned/folded) gets it re-injected after "activity".
+  // layout that lost it (it was pruned/folded) gets it re-injected where "activity" was —
+  // then v8 prunes "activity" itself, leaving "schedule" in its place.
   it("restores the 'schedule' rail surface to a layout that lacks it", () => {
     const out = migrateUiState({
       railOrder: { left: ["chat", "activity", "settings"], right: ["beads", "goals"] },
     }) as { railOrder: { left: string[]; right: string[] } };
-    expect(out.railOrder.left).toEqual(["chat", "activity", "schedule", "settings"]);
+    expect(out.railOrder.left).toEqual(["chat", "schedule", "settings"]);
   });
 
   // …but if the user keeps "schedule" on some dock already, don't duplicate it.
@@ -51,6 +52,20 @@ describe("migrateUiState", () => {
     }) as { railOrder: { left: string[]; right: string[] } };
     expect(out.railOrder.right).toContain("schedule");
     expect(out.railOrder.left).not.toContain("schedule");
+  });
+
+  // v8 (2026-06 IA pass): Activity moved off the rail to a utility-bar widget. Prune
+  // "activity" from every dock + the mobile quick-bar so it doesn't linger as a dead id.
+  it("prunes 'activity' from the rails and quick-bar", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "activity", "schedule"], right: ["activity", "beads"], bottom: ["activity"] },
+      quickBar: ["chat", "activity", "knowledge"],
+    }) as { railOrder: { left: string[]; right: string[]; bottom: string[] }; quickBar: string[] };
+    expect(out.railOrder.left).not.toContain("activity");
+    expect(out.railOrder.right).not.toContain("activity");
+    expect(out.railOrder.bottom).not.toContain("activity");
+    expect(out.railOrder.left).toEqual(["chat", "schedule"]);
+    expect(out.quickBar).toEqual(["chat", "knowledge"]);
   });
 
   // v5→v6 (bottom dock): railOrder gains a `bottom` dock; add the empty array to a

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -47,10 +47,6 @@ export type RightPanel = "beads" | "goals" | (string & {}); // + plugin:<id>:<vi
 // "market" = Discover. (Keys kept for persisted-state compat; the old "download"
 // tab is gone — a stale persisted value falls back to Installed.)
 export type PluginsTab = "local" | "market";
-// Activity = the trigger/event surface: what happened (thread) + inbound (inbox).
-// "schedule" was briefly folded in here (#1075) but is its own top-level rail surface
-// again — cron is a trigger, but timed work earns its own rail.
-export type ActivityTab = "thread" | "inbox";
 // Settings IA (ADR 0048): scope is the primary axis — two homes, each with its own
 // section sub-nav. `settingsScope` picks the home; `settingsSection` the active
 // section within it (a free string so each home owns its own section ids).
@@ -72,7 +68,6 @@ type UIState = {
   globalSettingsSection?: string;
   openGlobalSettings: (section?: string) => void;
   closeGlobalSettings: () => void;
-  activityTab: ActivityTab;
   rightCollapsed: boolean;
   leftCollapsed: boolean;
   rightWidth: number;
@@ -104,7 +99,6 @@ type UIState = {
   setSettingsScope: (s: SettingsScope) => void;
   setSettingsSection: (s: string) => void;
   setFleetStartNew: (b: boolean) => void;
-  setActivityTab: (t: ActivityTab) => void;
   setRightCollapsed: (b: boolean) => void;
   setLeftCollapsed: (b: boolean) => void;
   setRightWidth: (w: number) => void;
@@ -164,6 +158,18 @@ export function migrateUiState(persisted: unknown): unknown {
         rest.railOrder = { ...ro4, left };
       }
     }
+    // v8 (2026-06 IA pass): Activity is no longer a rail surface — it moved to a
+    // read-only utility-bar widget (the bottom-left widgets cluster). Prune "activity"
+    // from every dock + the mobile quick-bar so it doesn't linger as a dead rail id.
+    // (Runs AFTER the v7 schedule re-add, which anchors on "activity" before it's gone.)
+    const ro5 = rest.railOrder as { left?: string[]; right?: string[]; bottom?: string[] } | undefined;
+    if (ro5) {
+      const noAct = (arr?: string[]) => (Array.isArray(arr) ? arr.filter((x) => x !== "activity") : []);
+      rest.railOrder = { left: noAct(ro5.left), right: noAct(ro5.right), bottom: noAct(ro5.bottom) };
+    }
+    if (Array.isArray(rest.quickBar)) {
+      rest.quickBar = (rest.quickBar as string[]).filter((x) => x !== "activity");
+    }
     return rest;
   }
   return persisted;
@@ -182,7 +188,6 @@ export const useUI = create<UIState>()(
       globalSettingsSection: undefined,
       openGlobalSettings: (section) => set({ globalSettingsOpen: true, globalSettingsSection: section }),
       closeGlobalSettings: () => set({ globalSettingsOpen: false }),
-      activityTab: "thread",
       rightCollapsed: false,
       leftCollapsed: false,
       rightWidth: 360,
@@ -190,7 +195,7 @@ export const useUI = create<UIState>()(
       bottomHeight: 240,
       bottomCollapsed: false,
       railOrder: {
-        left: ["chat", "activity", "schedule", "studio", "knowledge", "plugins", "settings"],
+        left: ["chat", "schedule", "studio", "knowledge", "plugins", "settings"],
         right: ["beads", "goals"],
         bottom: [],
       },
@@ -219,7 +224,7 @@ export const useUI = create<UIState>()(
       setRailOrder: (railOrder) => set({ railOrder }),
       mobileActive: "chat",
       setMobileActive: (mobileActive) => set({ mobileActive }),
-      quickBar: ["chat", "activity", "knowledge", "plugins"],
+      quickBar: ["chat", "knowledge", "plugins"],
       toggleQuickBar: (id) =>
         set((s) => {
           if (s.quickBar.includes(id)) return { quickBar: s.quickBar.filter((x) => x !== id) };
@@ -244,7 +249,6 @@ export const useUI = create<UIState>()(
       setSettingsScope: (settingsScope) => set({ settingsScope }),
       setSettingsSection: (settingsSection) => set({ settingsSection }),
       setFleetStartNew: (fleetStartNew) => set({ fleetStartNew }),
-      setActivityTab: (activityTab) => set({ activityTab }),
       setRightCollapsed: (rightCollapsed) => set({ rightCollapsed }),
       setLeftCollapsed: (leftCollapsed) => set({ leftCollapsed }),
       // The DS AppShell is a CONTROLLED width: during a divider drag it streams transient
@@ -271,7 +275,7 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 7, // …v5 Schedule→Activity tab (#1075) · v6 +bottom dock · v7 Schedule→rail surface again
+      version: 8, // …v6 +bottom dock · v7 Schedule→rail surface again · v8 Activity→utility widget
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
       // The Global settings overlay is ephemeral UI state — drop it from persistence so a
       // refresh never reopens it (everything else persists as before).


### PR DESCRIPTION
Continues the 2026-06 IA pass (background jobs + inbox already moved). **Activity leaves the left rail and becomes a read-only utility-bar widget** in the bottom-left widgets cluster.

## What changed
- **Read-only feed.** `ActivitySurface` drops the reply composer (Textarea / Send / `send()`). It's the provenance timeline (ADR 0022) only now — loads `GET /api/activity`, appends `activity.message` live. Self-contained error strip instead of an `onError` prop.
- **New `ActivityWidget`** mirrors `InboxWidget`: a pill with an unread badge (off `activity.message`, incrementing only while closed), opens the feed in a dialog, clears the badge on open.
- **App.tsx**: removed the Activity `CORE_SURFACE`, the rail unread badge, and the App-level unread tracking (`viewingThread`/effects) — all now the widget's job. Renders `<ActivityWidget/>` in the util-bar start cluster after `<InboxWidget/>`.
- **uiStore**: dropped `"activity"` from the `railOrder`/`quickBar` defaults and removed the now-dead `ActivityTab` type + `activityTab` state/setter. **v8 migration** prunes `"activity"` from every dock + the quick-bar so persisted layouts don't linger with a dead rail id (runs after the v7 schedule re-add, which anchors on `"activity"` before it's gone).

## Tests
- `uiStore.test.ts`: new prune test; updated the v7 schedule-restore expectation (activity is now removed).
- `activity.spec.ts`: rewritten to the widget flow (badge → dialog → feed + live append + no composer).
- `chat-continuity` / `chat-slot`: navigate via **Schedule** instead of Activity (no longer a rail surface).

Green locally: typecheck ✓ · web unit (99) ✓ · uiStore migration (15) ✓ · full e2e (109) ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)