### PR TITLE
feat(desktop): Raycast-style global quick launcher for the command palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Raycast-style global quick launcher (desktop).** A new system-wide hotkey (⌥Space)
+  summons a frameless, always-on-top window from anywhere — even while protoAgent is hidden
+  in the menu bar — that hosts just the ⌘K command palette: jump to any surface or plugin
+  view, run the deep-link actions, quick-chat with the agent, or open an inline plugin view.
+  Navigation commands hand off to the main console window, and the launcher dismisses on blur
+  or Escape (ADR 0057). `⌘⇧P` still toggles the full console window.
+
 ### Fixed
 - **Background agents widget no longer needs a page reload to appear.** The utility-bar pill
   mounts while a cold backend is still warming up (the desktop sidecar can take ~a minute),

--- a/apps/desktop/src-tauri/capabilities/default.json
+++ b/apps/desktop/src-tauri/capabilities/default.json
@@ -3,7 +3,8 @@
   "identifier": "default",
   "description": "enables the default permissions",
   "windows": [
-    "main"
+    "main",
+    "launcher"
   ],
   "permissions": [
     "core:default",

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -4,7 +4,7 @@ use std::sync::Mutex;
 use tauri::{
     menu::{Menu, MenuItem, PredefinedMenuItem},
     tray::{MouseButton, MouseButtonState, TrayIconBuilder, TrayIconEvent},
-    AppHandle, Manager, RunEvent, Runtime, WebviewUrl, WebviewWindowBuilder, WindowEvent,
+    AppHandle, Emitter, Manager, RunEvent, Runtime, WebviewUrl, WebviewWindowBuilder, WindowEvent,
 };
 use tauri_plugin_dialog::{DialogExt, MessageDialogButtons};
 use tauri_plugin_global_shortcut::{Code, Modifiers, Shortcut, ShortcutState};
@@ -132,6 +132,55 @@ fn toggle_main_window<R: Runtime>(app: &AppHandle<R>) {
             _ => show_main_window(app),
         }
     }
+}
+
+// ── Raycast-style quick launcher ────────────────────────────────────────────
+// A second, frameless, always-on-top window that hosts ONLY the command palette
+// (the web boots into launcher mode off the injected `__PROTOAGENT_LAUNCHER__`).
+// Summoned by a global hotkey from anywhere, dismissed on blur / Escape; the
+// palette's navigation commands hand off to the main window (a `palette:navigate`
+// event the main webview listens for) and then hide the launcher.
+
+/// Re-center, reveal + focus the launcher, and tell its webview to reset the palette
+/// to root + refocus the search field (it stays mounted between summons).
+fn show_launcher<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("launcher") {
+        let _ = window.center();
+        let _ = window.show();
+        let _ = window.set_focus();
+        // Global emit — the launcher webview listens; the main one ignores it.
+        let _ = app.emit("launcher:shown", ());
+    }
+}
+
+fn hide_launcher_window<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("launcher") {
+        let _ = window.hide();
+    }
+}
+
+fn toggle_launcher<R: Runtime>(app: &AppHandle<R>) {
+    if let Some(window) = app.get_webview_window("launcher") {
+        match window.is_visible() {
+            Ok(true) => {
+                let _ = window.hide();
+            }
+            _ => show_launcher(app),
+        }
+    }
+}
+
+/// Hide the launcher — invoked by its webview on Escape / after a navigation handoff.
+#[tauri::command]
+fn hide_launcher<R: Runtime>(app: AppHandle<R>) {
+    hide_launcher_window(&app);
+}
+
+/// Bring the main console window to the front — invoked by the launcher webview when a
+/// navigation command hands a surface off to the main window.
+#[tauri::command]
+fn focus_main<R: Runtime>(app: AppHandle<R>) {
+    show_main_window(&app);
 }
 
 /// Check the GitHub Release updater manifest (latest.json) for a newer build;
@@ -366,7 +415,13 @@ async fn updater_install<R: Runtime>(
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
-        .invoke_handler(tauri::generate_handler![chat_stream, updater_check, updater_install])
+        .invoke_handler(tauri::generate_handler![
+            chat_stream,
+            updater_check,
+            updater_install,
+            hide_launcher,
+            focus_main
+        ])
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         // In-app updates: checks the latest.json manifest on GitHub Releases,
@@ -377,14 +432,27 @@ pub fn run() {
         // menu-bar window is hidden.
         .plugin(tauri_plugin_notification::init())
         .plugin(
+            // Two global, system-wide hotkeys (fire even when the app is unfocused or
+            // hidden in the menu bar):
+            //   ⌘⇧P    — toggle the full console window.
+            //   ⌥Space — summon the Raycast-style quick launcher (just the palette).
+            // ⌥Space is Raycast's familiar alt-default; to rebind, change `launcher_hotkey`
+            // here AND the comparison in the handler (e.g. SUPER|SHIFT + Space if you'd
+            // rather keep Option+Space free for the non-breaking space it normally types).
             tauri_plugin_global_shortcut::Builder::new()
-                .with_shortcut(Shortcut::new(
-                    Some(Modifiers::SUPER | Modifiers::SHIFT),
-                    Code::KeyP,
-                ))
-                .expect("valid global shortcut")
-                .with_handler(|app, _shortcut, event| {
-                    if event.state == ShortcutState::Pressed {
+                .with_shortcuts([
+                    Shortcut::new(Some(Modifiers::SUPER | Modifiers::SHIFT), Code::KeyP),
+                    Shortcut::new(Some(Modifiers::ALT), Code::Space),
+                ])
+                .expect("valid global shortcuts")
+                .with_handler(|app, shortcut, event| {
+                    if event.state != ShortcutState::Pressed {
+                        return;
+                    }
+                    let launcher_hotkey = Shortcut::new(Some(Modifiers::ALT), Code::Space);
+                    if shortcut == &launcher_hotkey {
+                        toggle_launcher(app);
+                    } else {
                         toggle_main_window(app);
                     }
                 })
@@ -435,6 +503,27 @@ pub fn run() {
             }
             win.build()?;
 
+            // The Raycast-style quick launcher: a second, frameless, always-on-top
+            // window hosting ONLY the command palette (the web boots into launcher mode
+            // off `__PROTOAGENT_LAUNCHER__`). Created HIDDEN and reused — the ⌥Space
+            // global shortcut reveals/centers it; it hides on blur (see on_window_event)
+            // or Escape. Same fixed-port API base as the main window.
+            let launcher_init = format!(
+                "window.__PROTOAGENT_API_BASE__ = \"http://127.0.0.1:{port}\"; \
+                 window.__PROTOAGENT_LAUNCHER__ = true;"
+            );
+            WebviewWindowBuilder::new(app, "launcher", WebviewUrl::default())
+                .title("protoAgent — Quick Command")
+                .inner_size(720.0, 480.0)
+                .decorations(false)
+                .always_on_top(true)
+                .skip_taskbar(true)
+                .resizable(false)
+                .center()
+                .visible(false)
+                .initialization_script(&launcher_init)
+                .build()?;
+
             // Menu-bar-only: build the tray, and only drop the dock icon
             // (Accessory) if it succeeds — so a tray failure leaves us reachable
             // in the dock rather than with no way to surface the window. Closing
@@ -455,11 +544,19 @@ pub fn run() {
             // native check (see the tray handler) as a manual fallback.
             Ok(())
         })
-        .on_window_event(|window, event| {
-            if let WindowEvent::CloseRequested { api, .. } = event {
+        .on_window_event(|window, event| match event {
+            // Closing the main window hides the UI (the app + sidecar live on in the menu
+            // bar); the tray's Quit is the real exit.
+            WindowEvent::CloseRequested { api, .. } => {
                 api.prevent_close();
                 let _ = window.hide();
             }
+            // Raycast behavior: the launcher dismisses the moment it loses focus (click
+            // away, or a navigation command focusing the main window).
+            WindowEvent::Focused(false) if window.label() == "launcher" => {
+                let _ = window.hide();
+            }
+            _ => {}
         })
         .build(tauri::generate_context!())
         .expect("error while building tauri application")

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -115,8 +115,11 @@ import { PluginsSurface } from "../plugins/PluginsSurface";
 import { SetupWizard } from "../setup/SetupWizard";
 import { hostRuntimeStatusQuery, runtimeStatusQuery } from "../lib/queries";
 import { buildViews } from "../lib/viewRegistry";
-import { usePaletteRegistry } from "./usePaletteRegistry";
+import { applyNavIntent, usePaletteRegistry } from "./usePaletteRegistry";
+import type { NavIntent } from "./usePaletteRegistry";
 import { PaletteChat } from "./PaletteChat";
+import { CORE_SURFACES } from "./coreSurfaces";
+import { listen } from "../lib/desktop";
 
 // Consolidated nav (heavy grouping): four rail surfaces, each grouped one
 // fanning out to sub-views via an in-surface segmented control.
@@ -454,22 +457,10 @@ export function App() {
     /Mac/i.test(navigator.userAgent);
 
   // ADR 0035 S3 — surface metadata + one renderer, so any surface mounts in either rail.
-  // Chat is excluded here: it mounts unconditionally in its rail's area (streaming continuity)
-  // and is pinned left (railOf.chat is never moved).
-  const CORE_SURFACES: { id: string; label: string; icon: ReactNode }[] = [
-    { id: "chat", label: "Chat", icon: <MessageSquare size={18} /> },
-    // Activity left the rail in the 2026-06 IA pass — it's a read-only utility-bar widget
-    // now (ActivityWidget, bottom-left widgets cluster).
-    { id: "schedule", label: "Schedule", icon: <CalendarClock size={18} /> },
-    // "studio" (Workflows) is contributed via src/ext/workflows.tsx, gated on the
-    // workflows plugin (lean core) — no longer a hardcoded core surface.
-    { id: "knowledge", label: "Knowledge", icon: <BookMarked size={18} /> },
-    // "agent" folded into Settings ▸ Workspace (ADR 0048 S-C) — no longer a rail surface.
-    { id: "plugins", label: "Plugins", icon: <Puzzle size={18} /> },
-    { id: "settings", label: "Settings", icon: <Settings2 size={18} /> },
-    { id: "beads", label: "Beads", icon: <Boxes size={18} /> },
-    { id: "goals", label: "Goals", icon: <Target size={18} /> },
-  ];
+  // The core surface list lives in coreSurfaces.tsx, shared with the desktop launcher so
+  // both build their command lists from one source. Chat is excluded from rail placement
+  // here: it mounts unconditionally in its rail's area (streaming continuity) and is
+  // pinned left (railOf.chat is never moved).
   // Surfaces for a rail side, in the user's order (railOrder, ADR 0036). Core AND plugin views are
   // first-class railOrder members — reconciled below — so all are reorderable/movable, including
   // Chat. Metadata resolves from core or the live plugin-view set; a freshly-appeared plugin not
@@ -547,6 +538,17 @@ export function App() {
   const paletteRegistry = usePaletteRegistry(paletteViews, inlinePaletteViews, paletteChat);
   const [paletteOpen, setPaletteOpen] = useState(false);
   usePaletteHotkey(() => setPaletteOpen((o) => !o));
+  // Desktop launcher handoff (ADR 0057): the frameless ⌥Space launcher window can't
+  // mutate this window's store, so its navigation commands forward a serializable
+  // NavIntent over a Tauri event; the main window replays it here (the Rust shell has
+  // already brought this window to the front via `focus_main`).
+  useEffect(() => {
+    let off = () => {};
+    void listen<NavIntent>("palette:navigate", (intent) => applyNavIntent(intent)).then((fn) => {
+      off = fn;
+    });
+    return () => off();
+  }, []);
 
   function renderSurface(id: string): ReactNode {
     switch (id) {

--- a/apps/web/src/app/Launcher.tsx
+++ b/apps/web/src/app/Launcher.tsx
@@ -1,0 +1,130 @@
+// ADR 0057 — the Raycast-style desktop quick launcher. A SEPARATE, frameless, always-
+// on-top Tauri window (label "launcher") whose webview boots straight into this
+// component instead of the full console. It hosts ONLY the command palette, summoned by
+// the ⌥Space global shortcut from anywhere and dismissed on blur / Escape.
+//
+// It reuses the EXACT registry the in-app ⌘K palette uses (usePaletteRegistry), so the
+// command list stays in lock-step. The difference is navigation: this window has no
+// shell, so its nav commands forward a serializable NavIntent to the main console
+// window (setPaletteNavigator) and then hide the launcher; quick-chat and inline plugin
+// views run right here in the launcher.
+import { useEffect, useMemo, useState } from "react";
+import { MessageSquare, Puzzle } from "lucide-react";
+import { useQuery } from "@tanstack/react-query";
+import type { ReactNode } from "react";
+import { CommandPalette } from "@protolabsai/ui/command-palette";
+import type { PaletteView } from "@protolabsai/ui/command-palette";
+import { setPaletteNavigator, usePaletteRegistry } from "./usePaletteRegistry";
+import type { InlinePluginView } from "./usePaletteRegistry";
+import { PaletteChat } from "./PaletteChat";
+import { CORE_SURFACES } from "./coreSurfaces";
+import { buildViews } from "../lib/viewRegistry";
+import { runtimeStatusQuery } from "../lib/queries";
+import { apiUrl, authToken } from "../lib/api";
+import { consoleTheme } from "./PluginView";
+import { brandName } from "../lib/brand";
+import { emit, invoke, listen } from "../lib/desktop";
+import "./launcher.css";
+
+// The launcher keeps its glyphs lightweight: core surfaces carry their own icons; plugin
+// views fall back to the generic plugin mark (the rail/⌘K palette resolve the full lucide
+// set — not worth pulling that chunk into the launcher window for a secondary surface).
+function pluginIcon(): ReactNode {
+  return <Puzzle size={18} />;
+}
+
+export function Launcher() {
+  // Lightweight: one status fetch for the plugin-view + agent-name inputs (no SSE, no
+  // shell). The palette's quick-chat + inline plugin views talk to the same sidecar.
+  const runtimeQ = useQuery({ ...runtimeStatusQuery() });
+  const runtime = runtimeQ.data ?? null;
+
+  // Mirror App's plugin-view derivation: each enabled plugin's declared views become a
+  // `plugin:<id>:<view>` surface (chat-slot + utility widgets excluded — same as the rail).
+  const allPluginViews = (runtime?.plugins ?? [])
+    .filter((p) => p.enabled && p.views?.length)
+    .flatMap((p) => (p.views ?? []).map((v) => ({ ...v, key: `plugin:${p.id}:${v.id}` })))
+    .filter((v) => v.slot !== "chat" && !v.utility);
+
+  // The same three command sources the in-app palette feeds usePaletteRegistry.
+  const { views: paletteViews } = buildViews({
+    core: CORE_SURFACES,
+    plugins: allPluginViews.map((v) => ({ key: v.key, label: v.label, icon: pluginIcon() })),
+    ext: [], // fork/ext surfaces are build-time host concerns — not surfaced from the launcher
+  });
+
+  // Plugin views that opted into inline palette morphing render their iframe IN the
+  // launcher (themed/authed via the same handshake the in-app palette uses).
+  const inlinePaletteViews: InlinePluginView[] = allPluginViews
+    .filter((v) => v.palette === "inline" || (typeof v.palette === "object" && v.palette !== null))
+    .map((v) => ({
+      id: v.key,
+      title: v.label,
+      url: apiUrl(typeof v.palette === "object" && v.palette?.path ? v.palette.path : v.path),
+      icon: pluginIcon(),
+      theme: consoleTheme(),
+      token: authToken(),
+      sandbox: "allow-scripts allow-forms allow-same-origin allow-popups allow-popups-to-escape-sandbox",
+    }));
+
+  // Inline quick-chat with the focused agent (host, since the launcher loads /app/).
+  const chatAgentName = brandName(runtime?.identity?.name);
+  const paletteChat = useMemo(
+    () => ({
+      name: chatAgentName,
+      icon: <MessageSquare size={16} />,
+      view: {
+        id: "chat",
+        title: chatAgentName,
+        width: 620,
+        render: () => <PaletteChat agentName={chatAgentName} />,
+      } as PaletteView,
+    }),
+    [chatAgentName],
+  );
+
+  const registry = usePaletteRegistry(paletteViews, inlinePaletteViews, paletteChat);
+
+  // Swap the palette's navigation sink: forward the intent to the main console window,
+  // bring it to the front, and dismiss the launcher. Restore the default on unmount.
+  useEffect(() => {
+    setPaletteNavigator((intent) => {
+      void emit("palette:navigate", intent);
+      void invoke("focus_main");
+      void invoke("hide_launcher");
+    });
+    return () => setPaletteNavigator(null);
+  }, []);
+
+  // Open by default; re-summoning (the Rust shell emits "launcher:shown" on show) resets
+  // the palette to its root view + refocuses the search by toggling open off→on.
+  const [open, setOpen] = useState(true);
+  useEffect(() => {
+    let raf = 0;
+    let off = () => {};
+    void listen("launcher:shown", () => {
+      setOpen(false);
+      raf = requestAnimationFrame(() => setOpen(true));
+    }).then((fn) => {
+      off = fn;
+    });
+    return () => {
+      off();
+      if (raf) cancelAnimationFrame(raf);
+    };
+  }, []);
+
+  return (
+    <div className="launcher-root">
+      <CommandPalette
+        open={open}
+        onOpenChange={(next) => {
+          setOpen(next);
+          if (!next) void invoke("hide_launcher"); // Escape / click-away → hide the window
+        }}
+        registry={registry}
+        presentation="fullscreen"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/coreSurfaces.tsx
+++ b/apps/web/src/app/coreSurfaces.tsx
@@ -1,0 +1,24 @@
+// The fixed core console surfaces (ADR 0035 S3). Shared so the main shell AND the
+// desktop quick-launcher (ADR 0057) build their command lists from the SAME source —
+// add a core surface here and it shows up in both the rail and ⌘K / the launcher.
+import type { ReactNode } from "react";
+import { BookMarked, Boxes, CalendarClock, MessageSquare, Puzzle, Settings2, Target } from "lucide-react";
+
+export type CoreSurface = { id: string; label: string; icon: ReactNode };
+
+// Keep in lock-step with App's rail: Chat is excluded from rail placement there (it's
+// pinned + always mounted), but is a valid palette/launcher "go to" target.
+export const CORE_SURFACES: CoreSurface[] = [
+  { id: "chat", label: "Chat", icon: <MessageSquare size={18} /> },
+  // Activity left the rail in the 2026-06 IA pass — it's a read-only utility-bar widget
+  // now (ActivityWidget, bottom-left widgets cluster).
+  { id: "schedule", label: "Schedule", icon: <CalendarClock size={18} /> },
+  // "studio" (Workflows) is contributed via src/ext/workflows.tsx, gated on the
+  // workflows plugin (lean core) — no longer a hardcoded core surface.
+  { id: "knowledge", label: "Knowledge", icon: <BookMarked size={18} /> },
+  // "agent" folded into Settings ▸ Workspace (ADR 0048 S-C) — no longer a rail surface.
+  { id: "plugins", label: "Plugins", icon: <Puzzle size={18} /> },
+  { id: "settings", label: "Settings", icon: <Settings2 size={18} /> },
+  { id: "beads", label: "Beads", icon: <Boxes size={18} /> },
+  { id: "goals", label: "Goals", icon: <Target size={18} /> },
+];

--- a/apps/web/src/app/launcher.css
+++ b/apps/web/src/app/launcher.css
@@ -1,0 +1,24 @@
+/* The frameless desktop quick-launcher window (ADR 0057). The DS palette renders in its
+ * `fullscreen` presentation — the panel fills the window edge-to-edge (no border/radius/
+ * shadow) — so this window IS the palette. We just make the document fill the frame and
+ * paint the raised surface underneath so the open animation never flashes white. */
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+  background: var(--pl-color-bg-raised);
+}
+
+.launcher-root {
+  height: 100%;
+}
+
+/* The fullscreen palette portals its scrim to <body>; pin it to the frame so the panel
+ * stretches the full window height. */
+.launcher-root ~ .pl-cmdk-overlay,
+body > .pl-cmdk-overlay {
+  position: fixed;
+  inset: 0;
+}

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -64,42 +64,89 @@ export function openView(id: string) {
   }
 }
 
+// ── Navigation handoff (desktop launcher, ADR 0057) ────────────────────────────────
+// Every palette navigation funnels through `navigate(intent)` so it has ONE chokepoint.
+// In the normal console window the intent applies to THIS window's store (the default).
+// In the frameless desktop launcher window the store is a separate JS context with no
+// shell — so the launcher swaps the sink (`setPaletteNavigator`) to forward the intent
+// to the main window over a Tauri event, which replays it there via `applyNavIntent`.
+
+/** A serializable description of "where the palette wants to go" — so it can cross the
+ *  window boundary as a plain event payload. */
+export type NavIntent =
+  | { kind: "view"; id: string }
+  | { kind: "plugins"; tab: "local" | "market" }
+  | { kind: "global"; section: "fleet" | "telemetry" | "commons" };
+
+/** Apply an intent to THIS window's UI store. The default navigator, and what the main
+ *  window calls when it receives a forwarded intent from the launcher. */
+export function applyNavIntent(intent: NavIntent) {
+  const ui = useUI.getState();
+  switch (intent.kind) {
+    case "view":
+      openView(intent.id);
+      break;
+    case "plugins":
+      ui.setSurface("plugins");
+      ui.setPluginsTab(intent.tab);
+      break;
+    case "global":
+      ui.openGlobalSettings(intent.section);
+      break;
+  }
+}
+
+let navigator: (intent: NavIntent) => void = applyNavIntent;
+
+/** Override where palette navigation goes (the launcher forwards to the main window).
+ *  Pass `null` to restore the default local apply. */
+export function setPaletteNavigator(fn: ((intent: NavIntent) => void) | null) {
+  navigator = fn ?? applyNavIntent;
+}
+
+/** The single entry point every nav command + deep-link runs through. */
+function navigate(intent: NavIntent) {
+  navigator(intent);
+}
+
 /** Deep-links into sub-tabbed surfaces. The sub-tab ids are the uiStore union types
  *  (the source of truth), so these can't drift into a 404 section. */
 function deepLinkCommands(): Command[] {
-  const ui = () => useUI.getState();
-  const link = (id: string, label: string, keywords: string[], go: () => void): Command => ({
+  // Each deep-link is expressed as a serializable NavIntent routed through `navigate()`,
+  // so it works identically in the console window (apply locally) and the desktop
+  // launcher (forward to the main window).
+  const link = (id: string, label: string, keywords: string[], intent: NavIntent): Command => ({
     id,
     label,
     group: "Jump to",
     keywords,
     run: (c) => {
-      go();
+      navigate(intent);
       c.close();
     },
   });
   return [
     // (Inbox moved to a utility-bar widget; Schedule is a top-level rail surface that
     // auto-registers as a "go to" nav command — so no Activity deep-links here.)
-    link("plug:market", "Plugins: Discover", ["plugins", "discover", "market", "directory", "browse"], () => {
-      ui().setSurface("plugins");
-      ui().setPluginsTab("market");
+    link("plug:market", "Plugins: Discover", ["plugins", "discover", "market", "directory", "browse"], {
+      kind: "plugins",
+      tab: "market",
     }),
     // Install-from-URL is the advanced action under Installed now (ADR 0059 D4) — land there.
-    link("plug:download", "Plugins: Install from URL", ["plugins", "install", "url", "git"], () => {
-      ui().setSurface("plugins");
-      ui().setPluginsTab("local");
+    link("plug:download", "Plugins: Install from URL", ["plugins", "install", "url", "git"], {
+      kind: "plugins",
+      tab: "local",
     }),
     // Global settings (Fleet/Telemetry/Commons) is the header-drawer overlay now
     // (2026-06-18 IA pass) — open it deep-linked to the section.
-    link("box:fleet", "Settings: Fleet", ["fleet", "agents", "box", "global"], () => {
-      ui().openGlobalSettings("fleet");
+    link("box:fleet", "Settings: Fleet", ["fleet", "agents", "box", "global"], { kind: "global", section: "fleet" }),
+    link("box:telemetry", "Settings: Telemetry", ["telemetry", "metrics", "box", "global"], {
+      kind: "global",
+      section: "telemetry",
     }),
-    link("box:telemetry", "Settings: Telemetry", ["telemetry", "metrics", "box", "global"], () => {
-      ui().openGlobalSettings("telemetry");
-    }),
-    link("box:commons", "Settings: Shared Skills", ["commons", "shared", "skills", "box", "global"], () => {
-      ui().openGlobalSettings("commons");
+    link("box:commons", "Settings: Shared Skills", ["commons", "shared", "skills", "box", "global"], {
+      kind: "global",
+      section: "commons",
     }),
   ];
 }
@@ -154,10 +201,13 @@ export function usePaletteRegistry(
         icon: v.icon,
         group: GROUP[v.kind],
         keywords: ["go", "open", v.kind],
+        // Inline plugin views morph IN PLACE (also in the launcher window); a plain
+        // surface navigates — routed through `navigate()` so the launcher can hand it
+        // off to the main window instead of mutating its own (shell-less) store.
         run: inline
           ? (c) => c.enter(v.id)
           : (c) => {
-              openView(v.id);
+              navigate({ kind: "view", id: v.id });
               c.close();
             },
       };

--- a/apps/web/src/lib/desktop.ts
+++ b/apps/web/src/lib/desktop.ts
@@ -1,0 +1,63 @@
+// Thin, dependency-free accessors for the Tauri desktop shell's global API
+// (`withGlobalTauri: true` in tauri.conf.json exposes `window.__TAURI__`), so the
+// shared web bundle needs no `@tauri-apps/api` dependency. Everything degrades to a
+// no-op in the browser, so callers can use these unconditionally.
+
+type TauriCore = {
+  invoke: <T = unknown>(cmd: string, args?: Record<string, unknown>) => Promise<T>;
+};
+type UnlistenFn = () => void;
+type TauriEvent = {
+  emit: (event: string, payload?: unknown) => Promise<void>;
+  listen: <T = unknown>(event: string, handler: (e: { payload: T }) => void) => Promise<UnlistenFn>;
+};
+type TauriGlobal = { core?: TauriCore; event?: TauriEvent };
+
+function tauri(): TauriGlobal | null {
+  try {
+    return (window as unknown as { __TAURI__?: TauriGlobal }).__TAURI__ ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/** True when THIS webview is the frameless quick-launcher window (the Rust shell injects
+ *  `window.__PROTOAGENT_LAUNCHER__` only on that window). */
+export function isLauncherWindow(): boolean {
+  try {
+    return Boolean((window as unknown as { __PROTOAGENT_LAUNCHER__?: boolean }).__PROTOAGENT_LAUNCHER__);
+  } catch {
+    return false;
+  }
+}
+
+/** Invoke a Tauri command; resolves to undefined (no-op) outside the desktop shell. */
+export async function invoke<T = unknown>(cmd: string, args?: Record<string, unknown>): Promise<T | undefined> {
+  const core = tauri()?.core;
+  if (!core) return undefined;
+  try {
+    return await core.invoke<T>(cmd, args);
+  } catch {
+    return undefined;
+  }
+}
+
+/** Emit a Tauri event to every window; no-op outside the desktop shell. */
+export async function emit(event: string, payload?: unknown): Promise<void> {
+  await tauri()?.event?.emit(event, payload).catch(() => {});
+}
+
+/** Listen for a Tauri event. Returns an unlisten fn (a no-op outside the shell), so
+ *  callers can `void listen(...).then(off => ...)` and clean up uniformly. */
+export async function listen<T = unknown>(
+  event: string,
+  handler: (payload: T) => void,
+): Promise<UnlistenFn> {
+  const ev = tauri()?.event;
+  if (!ev) return () => {};
+  try {
+    return await ev.listen<T>(event, (e) => handler(e.payload));
+  } catch {
+    return () => {};
+  }
+}

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -4,8 +4,10 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 
 import { App } from "./app/App";
+import { Launcher } from "./app/Launcher";
 import { AppCrash } from "./app/AppCrash";
 import { ErrorBoundary } from "./app/ErrorBoundary";
+import { isLauncherWindow } from "./lib/desktop";
 // ADR 0037 — design-system foundation. Order matters: brand tokens (--pl-*) first, then
 // Tailwind + the shadcn→token bridge, then the legacy theme.css (which may reference --pl-*).
 import "@protolabsai/design/css/tokens";
@@ -18,7 +20,11 @@ import { queryClient } from "./lib/queryClient";
 import { watchThemeChanges } from "./lib/agentTheme";
 
 watchThemeChanges(); // fire `protoagent:theme` on any theme change → plugin iframes repaint live
-void activateSlugAgent(); // cold-agent resume + keep-warm touch on slug navigation (#806)
+
+// The desktop quick-launcher window (ADR 0057) boots the same bundle but renders ONLY the
+// command palette — no shell, no slug activation. Everything else is the full console.
+const launcher = isLauncherWindow();
+if (!launcher) void activateSlugAgent(); // cold-agent resume + keep-warm touch on slug navigation (#806)
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>
@@ -27,9 +33,7 @@ ReactDOM.createRoot(document.getElementById("root")!).render(
         the providers themselves is caught too. */}
     <ErrorBoundary fallback={({ error }) => <AppCrash error={error} />}>
       <QueryClientProvider client={queryClient}>
-        <ToastProvider>
-          <App />
-        </ToastProvider>
+        <ToastProvider>{launcher ? <Launcher /> : <App />}</ToastProvider>
       </QueryClientProvider>
     </ErrorBoundary>
   </React.StrictMode>,


### PR DESCRIPTION
## What

A **Raycast/ScriptKit-style global quick launcher** for the desktop app (ADR 0057, step 4). A new system-wide hotkey **⌥Space** summons a frameless, always-on-top window — from anywhere, even while protoAgent is hidden in the menu bar — that hosts *just* the ⌘K command palette. `⌘⇧P` still toggles the full console window.

- **Quick-chat & inline plugin views run in the launcher** (it talks to the same sidecar).
- **Surface / deep-link navigation hands off to the main window**: picking e.g. *Knowledge*, *Plugins: Discover*, *Settings: Fleet* brings the console to the front on that surface, then the launcher dismisses (blur or Escape).
- Reuses the **exact registry** the in-app ⌘K palette uses, so the two stay in lock-step.

## How

**Rust (`apps/desktop/src-tauri`)**
- A hidden `launcher` webview (borderless / always-on-top / centered / skip-taskbar), created at startup and reused.
- A second global shortcut (⌥Space) routed in the handler; `show/hide/toggle_launcher`, `hide_launcher` + `focus_main` commands; blur-to-hide in `on_window_event`; a `launcher:shown` emit that re-centers + resets the palette.
- `capabilities/default.json` grants the `launcher` window perms.

**Web (`apps/web`)**
- `Launcher.tsx` — fullscreen palette, forwards a serializable `NavIntent`, resets on `launcher:shown`.
- `usePaletteRegistry.ts` — a `navigate()` handoff chokepoint (`setPaletteNavigator`/`applyNavIntent`) shared by both windows; App behavior unchanged (default = local apply).
- `coreSurfaces.tsx` — shared `CORE_SURFACES` so App and the launcher build one list.
- `lib/desktop.ts` — dependency-free `invoke/emit/listen/isLauncherWindow` over `window.__TAURI__` (no-ops in the browser).
- `main.tsx` — branches into launcher mode off `__PROTOAGENT_LAUNCHER__`; `App.tsx` listens for the `palette:navigate` handoff.

## Notes
- Hotkey is **⌥Space** (Raycast's alt-default). It captures Option+Space system-wide; rebind in `lib.rs` (commented) if you'd rather keep that key for the non-breaking space.
- Launcher window is **opaque borderless** (square corners) — chosen over transparent/rounded to avoid the macOS private-API path. Rounded/transparent is an easy follow-up.
- `show_launcher` reuses the same `show + set_focus` path as the existing (working) `⌘⇧P` toggle, so macOS focus-stealing rides a proven path.

## Test plan
- ✅ `cargo check` (desktop crate) — clean (only pre-existing unused-fn warnings).
- ✅ Web `tsc` typecheck + `vite build`.
- ✅ `vitest` unit — 99/99.
- ⏳ Manual on a real desktop run (the one thing not verifiable in CI): `python -m server` then `npm --workspace @protoagent/desktop run dev`, hit **⌥Space**, confirm summon → type → Enter navigates the main window and quick-chat streams.

🤖 Generated with [Claude Code](https://claude.com/claude-code)