### PR TITLE
chore: release v0.54.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.54.0] - 2026-06-19
+
 ### Added
 - **Raycast-style global quick launcher (desktop).** A new system-wide hotkey (⌥Space)
   summons a frameless, always-on-top window from anywhere — even while protoAgent is hidden

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.53.0"
+version = "0.54.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.54.0",
+    "date": "2026-06-19",
+    "changes": [
+      "Raycast-style global quick launcher (desktop).",
+      "Background agents widget no longer needs a page reload to appear."
+    ]
+  },
+  {
     "version": "v0.53.0",
     "date": "2026-06-19",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.54.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.54.0 -m 'Release v0.54.0' && git push origin v0.54.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).