### PR TITLE
feat(web): chat can dock at the bottom (streaming-continuity intact)

### DIFF
--- a/apps/web/e2e/chat-bottom-dock.spec.ts
+++ b/apps/web/e2e/chat-bottom-dock.spec.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "@playwright/test";
+
+// Chat can dock at the bottom now (not just the side rails). Its slot mounts unconditionally
+// on whichever dock holds it, so an in-flight conversation survives switching the bottom dock
+// to another surface and back — the #613 streaming-continuity contract, on the bottom dock.
+
+test("chat docks at the bottom and survives a bottom-dock surface switch", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+
+  const rightRail = page.locator(".pl-rail--right");
+  const leftRail = page.locator(".pl-rail:not(.pl-rail--right):not(.pl-rail--bottom)");
+  const bottomRail = page.locator(".pl-rail--bottom");
+
+  // Put a second surface AND chat on the bottom dock, so the dock can switch between them.
+  await rightRail.getByRole("button", { name: "Beads", exact: true }).click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Move to bottom dock").click();
+  await leftRail.getByRole("button", { name: "Chat", exact: true }).click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Move to bottom dock").click();
+
+  await expect(bottomRail.getByRole("button", { name: "Chat", exact: true })).toBeVisible();
+  // Chat no longer lives on a side rail — single mount, on the bottom dock.
+  await expect(leftRail.getByRole("button", { name: "Chat", exact: true })).toHaveCount(0);
+
+  // The Chat move opens the dock on chat, so the composer is already showing — send a message.
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+  await composer.fill("remember this message");
+  await composer.press("Enter");
+  await expect(page.locator(".pl-message--user")).toHaveText(/remember this message/);
+
+  // Switch the bottom dock to Beads → chat hides but stays mounted (slot, not torn down).
+  await bottomRail.getByRole("button", { name: "Beads", exact: true }).click();
+  await expect(page.locator(".chat-stage")).toHaveCount(1); // still in the DOM
+  await expect(page.locator(".chat-stage")).not.toBeVisible(); // just hidden
+
+  // Back to chat → the conversation is exactly as we left it (stream never torn down).
+  await bottomRail.getByRole("button", { name: "Chat", exact: true }).click();
+  await expect(page.locator(".chat-stage")).toBeVisible();
+  await expect(page.locator(".pl-message--user")).toHaveText(/remember this message/);
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -459,8 +459,8 @@ export function App() {
   // ADR 0035 S3 — surface metadata + one renderer, so any surface mounts in either rail.
   // The core surface list lives in coreSurfaces.tsx, shared with the desktop launcher so
   // both build their command lists from one source. Chat is excluded from rail placement
-  // here: it mounts unconditionally in its rail's area (streaming continuity) and is
-  // pinned left (railOf.chat is never moved).
+  // here: it mounts unconditionally in its dock's area (streaming continuity) and is
+  // movable across all three docks (left/right/bottom) like any other surface.
   // Surfaces for a rail side, in the user's order (railOrder, ADR 0036). Core AND plugin views are
   // first-class railOrder members — reconciled below — so all are reorderable/movable, including
   // Chat. Metadata resolves from core or the live plugin-view set; a freshly-appeared plugin not
@@ -622,8 +622,25 @@ export function App() {
   // Bottom dock active surface (mirror left/right) — clamp to a member of the bottom dock.
   const bottomMembers = railSurfaces("bottom").map((s) => s.id);
   const bottomActive = bottomMembers.includes(bottomPanel) ? bottomPanel : (bottomMembers[0] ?? "");
-  // Chat mounts unconditionally on whichever side it's on (streaming continuity, #613).
-  const chatRail: "left" | "right" = railOrder.right.includes("chat") ? "right" : "left";
+  // Chat mounts unconditionally on whichever dock holds it (streaming continuity, #613) —
+  // left, right, OR the bottom dock. Its slot stays mounted while another surface swaps in
+  // on the same dock, so an in-flight stream survives a surface switch on any rail.
+  const chatRail: "left" | "right" | "bottom" =
+    railOrder.right.includes("chat")
+      ? "right"
+      : railOrder.bottom.includes("chat")
+        ? "bottom"
+        : "left";
+  // Background-stream pulse on the chat rail icon (#613 dot, ADR 0039): show it while a turn
+  // streams and chat ISN'T the visible surface on its dock — collapse-aware, any rail. (The
+  // old check keyed off the left-only `surface`, so it never pulsed for chat on right/bottom.)
+  const chatVisible =
+    chatRail === "left"
+      ? leftActive === "chat" && !leftCollapsed
+      : chatRail === "right"
+        ? rightActive === "chat" && !rightCollapsed
+        : bottomActive === "chat" && !bottomCollapsed;
+  const chatDot = chatStreaming && !chatVisible;
 
   // Notification dots (ADR 0039): a bus event under `<pluginId>.*` lights that plugin's rail
   // icon until its surface is opened. Subscribe once; refs avoid resubscribing each render.
@@ -792,10 +809,16 @@ export function App() {
         className="app-shell-main"
         leftItems={railSurfaces("left").map((s) => ({
           ...s,
-          dot: s.id === "chat" ? chatStreaming && surface !== "chat" : pluginDots[s.id] || undefined,
+          dot: s.id === "chat" ? chatDot : pluginDots[s.id] || undefined,
         }))}
-        rightItems={railSurfaces("right").map((s) => ({ ...s, dot: pluginDots[s.id] || undefined }))}
-        bottomItems={railSurfaces("bottom").map((s) => ({ ...s, dot: pluginDots[s.id] || undefined }))}
+        rightItems={railSurfaces("right").map((s) => ({
+          ...s,
+          dot: s.id === "chat" ? chatDot : pluginDots[s.id] || undefined,
+        }))}
+        bottomItems={railSurfaces("bottom").map((s) => ({
+          ...s,
+          dot: s.id === "chat" ? chatDot : pluginDots[s.id] || undefined,
+        }))}
         activeLeft={leftCollapsed ? "" : leftActive}
         activeRight={rightCollapsed ? "" : rightActive}
         activeBottom={bottomCollapsed ? "" : bottomActive}
@@ -815,14 +838,9 @@ export function App() {
         }}
         onRailContextMenu={(side, e, id) => openContextMenu("rail-surface", e, { id, side })}
         onRailReorder={(next) => {
-          // Chat is the streaming slot (#613), never the bottom dock — if a drag landed it
-          // there, bounce it back to the SIDE rail it came from (its pre-drag side), not
-          // always the left.
-          if (next.bottom.includes("chat")) {
-            const back = railOrder.right.includes("chat") ? "right" : "left";
-            next = { ...next, bottom: next.bottom.filter((x) => x !== "chat") };
-            if (!next[back].includes("chat")) next = { ...next, [back]: [...next[back], "chat"] };
-          }
+          // Chat can dock anywhere now — left, right, or the bottom dock. Its slot mounts
+          // unconditionally on whichever dock holds it (bottomContent mirrors the side rails),
+          // so streaming survives a surface switch on any rail. No bounce-back guard needed.
           setRailOrder(next);
         }}
         rightWidth={rightWidth}
@@ -882,7 +900,22 @@ export function App() {
             {rightActive !== "chat" ? renderSurface(rightActive) : null}
           </>
         }
-        bottomContent={bottomActive ? renderSurface(bottomActive) : null}
+        bottomContent={
+          <>
+            {/* Chat on the bottom dock mounts the same way it does on a side rail: the slot
+                is always present (hidden when not active) so a switch to another bottom
+                surface — or back — never tears down an in-flight stream (#613). */}
+            {chatRail === "bottom" ? (
+              <ChatSlot
+                onError={setError}
+                active={bottomActive === "chat"}
+                pluginView={chatSlotView}
+                enabledPluginIds={enabledPluginIds}
+              />
+            ) : null}
+            {bottomActive && bottomActive !== "chat" ? renderSurface(bottomActive) : null}
+          </>
+        }
         utilityBar={
           <UtilityBar
             // Bottom-left = widgets, bottom-right = layout (2026-06 IA pass). Docs +

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -5,8 +5,8 @@ import { registerContextMenu } from "./registry";
 import type { MenuEntry } from "./types";
 
 // First customer (ADR 0036 D6 / ADR 0035 D2): right-click a rail icon → reorder it within its
-// rail (Move up/down) and move it to the other rail (append to the bottom). Chat is pinned to the
-// left rail (no move-across); plugin views follow their manifest placement (no items yet).
+// rail (Move up/down) and move it to another dock (append to the end). Chat is movable across all
+// three docks like any other surface; plugin views follow their manifest placement (no items yet).
 registerContextMenu({
   type: "rail-surface",
   items: (ctx: { id: string; side: "left" | "right" | "bottom" }): MenuEntry[] => {
@@ -29,9 +29,9 @@ registerContextMenu({
       { side: "right", label: "Move to right rail" },
       { side: "bottom", label: "Move to bottom dock" },
     ];
-    // Any surface — core, plugin, or chat — reorders within its rail and moves across. (Moving
-    // chat across rails remounts it: a brief blip on an in-flight stream; a deliberate action.)
-    // Chat is excluded from the bottom dock — it's the streaming slot, not a bottom-panel surface.
+    // Any surface — core, plugin, or chat — reorders within its dock and moves across, including
+    // chat to the bottom dock (its slot mounts unconditionally there too). Moving chat across docks
+    // remounts it: a brief blip on an in-flight stream; a deliberate action.
     return [
       {
         id: "move-up",
@@ -49,7 +49,6 @@ registerContextMenu({
       },
       { id: "rail-div", divider: true },
       ...DOCKS.filter((d) => d.side !== ctx.side)
-        .filter((d) => !(d.side === "bottom" && ctx.id === "chat"))
         .map((d): MenuEntry => ({
           id: `move-${d.side}`,
           label: d.label,


### PR DESCRIPTION
Chat was pinned to the side rails — **two guards** bounced it off the bottom dock. But the key finding: the DS AppShell unmounts the bottom dock's content on collapse **exactly like it does the side rails** (`bottomOpen ? <section>{bottomContent}</section> : …` vs `showLeft && <main>{leftContent}</main>`). So the bottom dock is no different for streaming continuity — it just needed the same dual-mount structure the sides have.

## What changed (`App.tsx`)
- **`chatRail` is now 3-way** (`left` / `right` / `bottom`).
- **`bottomContent` mirrors the side rails**: the `ChatSlot` mounts *unconditionally* when chat is on the bottom dock (hidden when another bottom surface is active), so an in-flight stream survives a bottom-dock surface switch — the #613 contract, on the bottom dock.
- **Dropped both chat guards**: the DnD bounce-back in `onRailReorder`, and the `Move to bottom dock` filter in the rail context menu (`registrations.tsx`).
- **`chatDot` fix (bonus)**: the background-stream pulse was keyed off the left-only `surface`, so it never lit for chat on the **right** or **bottom**. Now computed collapse-aware on whichever dock holds chat — fixes the right rail too.

## Tests
- New `chat-bottom-dock.spec.ts`: docks Beads + Chat at the bottom, sends a message, switches the dock to Beads and back — asserts `.chat-stage` stays mounted + the conversation holds.
- Full suite green: typecheck ✓ · web unit (99) ✓ · **e2e (110)** ✓ (incl. unchanged navigation / chat-continuity / chat-slot).

## Caveat (parity with the sides — not a regression)
Collapsing the dock unmounts chat and drops the live SSE attachment, same as collapsing a side rail today. History is `chatStore`-backed so it restores on remount; only a stream started elsewhere wouldn't re-attach. The bottom dock also **defaults collapsed**, so chat moved *solely* there boots unmounted until opened.

🤖 Generated with [Claude Code](https://claude.com/claude-code)