### PR TITLE
chore: release v0.55.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.55.0] - 2026-06-19
+
 ## [0.54.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.55.0] - 2026-06-19
 
+### Added
+- **Chat can dock at the bottom panel.** Drag it there, or right-click the Chat rail icon →
+  *Move to bottom dock* — previously chat was confined to the left/right rails. Its slot mounts
+  unconditionally on the bottom dock the same way it does on a side rail, so an in-flight turn
+  keeps streaming when you switch the bottom dock to another surface and back (#613). (Collapsing
+  the dock still tears the stream down — same as collapsing a side rail; the conversation itself
+  is restored from the session store.)
+
+### Fixed
+- **The chat "still streaming" pulse now shows on the right rail and bottom dock.** The rail
+  icon's background-stream dot was computed off the left rail only, so it never lit when chat
+  lived on the right rail (or the new bottom dock). It's now derived on whichever dock holds chat.
+
 ## [0.54.0] - 2026-06-19
 
 ### Added
@@ -22,6 +35,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   view, run the deep-link actions, quick-chat with the agent, or open an inline plugin view.
   Navigation commands hand off to the main console window, and the launcher dismisses on blur
   or Escape (ADR 0057). `⌘⇧P` still toggles the full console window.
+
+### Changed
+- **Activity is a read-only utility-bar widget, off the left rail.** The provenance feed —
+  what the agent did on its own, and why — moved from a rail surface into the bottom-left
+  widgets cluster, alongside the inbox and background jobs: a pill with an unread badge that
+  opens the feed in a dialog. The reply composer is gone; Activity is a read-only event log now.
 
 ### Fixed
 - **Background agents widget no longer needs a page reload to appear.** The utility-bar pill

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.54.0"
+version = "0.55.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.55.0",
+    "date": "2026-06-19",
+    "changes": [
+      "Chat can dock at the bottom panel.",
+      "The chat \"still streaming\" pulse now shows on the right rail and bottom dock."
+    ]
+  },
+  {
     "version": "v0.54.0",
     "date": "2026-06-19",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.55.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.55.0 -m 'Release v0.55.0' && git push origin v0.55.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).