### PR TITLE
feat(desktop): frosted, rounded floating launcher panel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The desktop quick launcher (⌥Space) is now a frosted, rounded floating panel.** The
+  launcher window is transparent + shadowless and the palette renders as a translucent,
+  blurred, rounded card with see-through margins — a Raycast-style glass look — instead of
+  filling the window edge-to-edge.
+
 ## [0.55.0] - 2026-06-19
 
 ### Added

--- a/apps/desktop/src-tauri/Cargo.toml
+++ b/apps/desktop/src-tauri/Cargo.toml
@@ -21,7 +21,9 @@ tauri-build = { version = "2.6.2", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.11.2", features = ["tray-icon", "image-png", "devtools"] }
+# `macos-private-api` enables the transparent launcher window (paired with
+# app.macOSPrivateApi in tauri.conf.json) — used for the frosted/rounded launcher.
+tauri = { version = "2.11.2", features = ["tray-icon", "image-png", "devtools", "macos-private-api"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-global-shortcut = "2.3.2"
 tauri-plugin-log = "2"

--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -516,6 +516,12 @@ pub fn run() {
                 .title("protoAgent — Quick Command")
                 .inner_size(720.0, 480.0)
                 .decorations(false)
+                // Transparent + shadowless so the web shell can float a rounded, frosted
+                // palette card with see-through margins (the window itself paints nothing;
+                // the panel's CSS owns the radius + shadow). macOS needs the paired
+                // `macOSPrivateApi` config flag + the `macos-private-api` cargo feature.
+                .transparent(true)
+                .shadow(false)
                 .always_on_top(true)
                 .skip_taskbar(true)
                 .resizable(false)

--- a/apps/desktop/src-tauri/tauri.conf.json
+++ b/apps/desktop/src-tauri/tauri.conf.json
@@ -12,6 +12,7 @@
   "app": {
     "windows": [],
     "withGlobalTauri": true,
+    "macOSPrivateApi": true,
     "security": {
       "csp": null
     }

--- a/apps/web/src/app/Launcher.tsx
+++ b/apps/web/src/app/Launcher.tsx
@@ -123,7 +123,10 @@ export function Launcher() {
           if (!next) void invoke("hide_launcher"); // Escape / click-away → hide the window
         }}
         registry={registry}
-        presentation="fullscreen"
+        // `overlay` floats the palette as a rounded card (vs `fullscreen`'s edge-to-edge
+        // fill); launcher.css makes the surrounding scrim transparent so the window's
+        // see-through margins + the frosted card read as a Raycast-style panel.
+        presentation="overlay"
       />
     </div>
   );

--- a/apps/web/src/app/launcher.css
+++ b/apps/web/src/app/launcher.css
@@ -1,24 +1,37 @@
-/* The frameless desktop quick-launcher window (ADR 0057). The DS palette renders in its
- * `fullscreen` presentation — the panel fills the window edge-to-edge (no border/radius/
- * shadow) — so this window IS the palette. We just make the document fill the frame and
- * paint the raised surface underneath so the open animation never flashes white. */
+/* The frameless desktop quick-launcher window (ADR 0057). The window is transparent +
+ * shadowless (see lib.rs), so this stylesheet — loaded ONLY in the launcher window — paints
+ * nothing on the frame and instead floats the DS palette as a rounded, frosted card with
+ * see-through margins, Raycast-style. The palette renders in its `overlay` presentation. */
 html,
 body,
 #root {
   height: 100%;
   margin: 0;
   overflow: hidden;
-  background: var(--pl-color-bg-raised);
+  background: transparent; /* let the transparent window show the desktop behind */
 }
 
 .launcher-root {
   height: 100%;
 }
 
-/* The fullscreen palette portals its scrim to <body>; pin it to the frame so the panel
- * stretches the full window height. */
-.launcher-root ~ .pl-cmdk-overlay,
-body > .pl-cmdk-overlay {
-  position: fixed;
-  inset: 0;
+/* The portaled scrim fills the window. Drop its dim (so the margins are truly see-through)
+ * and center the card vertically instead of the DS top-anchor. */
+.pl-cmdk-overlay {
+  background: transparent !important;
+  align-items: center !important;
+  padding: var(--pl-space-4) !important;
+}
+
+/* The floating card: the DS panel already carries the radius + border; layer on a
+ * translucent surface + backdrop blur so the desktop shows through slightly. The opaque
+ * `background` is a fallback for WebKit without color-mix (degrades to solid, still rounded). */
+.pl-cmdk__panel {
+  background: var(--pl-color-bg-raised);
+  background: color-mix(in srgb, var(--pl-color-bg-raised) 82%, transparent);
+  -webkit-backdrop-filter: blur(24px) saturate(1.4);
+  backdrop-filter: blur(24px) saturate(1.4);
+  box-shadow:
+    var(--pl-shadow-popover),
+    0 24px 60px -20px rgb(0 0 0 / 0.55);
 }


### PR DESCRIPTION
Follow-up polish to the ⌥Space quick launcher (shipped in v0.54.0): give it **rounded corners + slight transparency** — a Raycast-style frosted-glass floating card instead of an edge-to-edge fill.

## Changes
- **`tauri.conf.json`** — `app.macOSPrivateApi: true` (required for transparent windows on macOS).
- **`Cargo.toml`** — adds the `macos-private-api` tauri feature (paired with the config flag).
- **`lib.rs`** — the launcher window is now `transparent(true)` + `shadow(false)`; the panel's CSS owns the radius + shadow so only the card is visible (no rectangular window shadow around the transparent frame).
- **`Launcher.tsx`** — palette renders in `overlay` presentation (a floating card) instead of `fullscreen` (edge-to-edge).
- **`launcher.css`** — transparent window + scrim, a vertically-centered **frosted card**: `color-mix` translucent surface + `backdrop-filter: blur()`, with an **opaque fallback** for WebKit without `color-mix` (degrades to solid, still rounded).

## Verified
- ✅ `cargo check` — clean with the new feature (tauri-runtime/wry recompiled; only pre-existing unused-fn warnings).
- ✅ Web `tsc` + `vite build`; `vitest` 99/99; CSS-comment prebuild gate.
- ⏳ On-device look needs a real desktop run (can't render a GUI from CI).

## Note
This changes desktop binaries, so the release that ships it must build the desktop matrix (a patch release skips it by default — will dispatch Desktop Build for the tag, or cut as a minor).

🤖 Generated with [Claude Code](https://claude.com/claude-code)