### PR TITLE
chore: release v0.55.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.55.1] - 2026-06-19
+
 ### Changed
 - **The desktop quick launcher (⌥Space) is now a frosted, rounded floating panel.** The
   launcher window is transparent + shadowless and the palette renders as a translucent,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.55.0"
+version = "0.55.1"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "v0.55.1",
+    "date": "2026-06-19",
+    "changes": [
+      "The desktop quick launcher (⌥Space) is now a frosted, rounded floating panel."
+    ]
+  },
+  {
     "version": "v0.55.0",
     "date": "2026-06-19",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.55.1`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.55.1 -m 'Release v0.55.1' && git push origin v0.55.1`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).