### PR TITLE
ci(desktop): publish desktop binaries on patch tags too

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -19,12 +19,12 @@ name: Desktop Build
 # updater bundles, and the updater-manifest fan-in job composes latest.json
 # (the manifest the in-app updater polls) onto the release — uploaded last.
 #
-# Fires on MINOR/MAJOR semver tags (a `.0` patch component) alongside release.yml's
-# Docker build, and on manual dispatch. PATCH tags (vX.Y.Z, Z>0) are skipped — a
-# patch is a server/Docker fix and rebuilding the 10×-billed macOS leg per patch is
-# the bulk of CI cost; dispatch this workflow manually with the tag for a patch that
-# genuinely needs a desktop rebuild. Dispatch macOS builds are unsigned unless the
-# full signing secret set is present; Linux/Windows are always unsigned. See
+# Fires on EVERY semver tag push (patch included) alongside release.yml's Docker build,
+# and on manual dispatch. Patches used to be skipped to save CI minutes, but this repo is
+# public so GitHub-hosted runners (incl. the 10×/2× macOS/Windows legs) are free +
+# unlimited — so every release, patch or minor, ships fresh desktop binaries and an
+# updated latest.json (no more hand-attaching a patch's binaries). macOS builds are signed
+# only when the full Apple secret set is present; Linux/Windows are always unsigned. See
 # ADR 0010 (UI tiers / desktop).
 
 on:
@@ -47,16 +47,12 @@ permissions:
 jobs:
   build:
     name: ${{ matrix.target }}
-    # Skip PATCH releases: desktop legs (esp. GitHub-hosted macOS at 10× billing)
-    # rebuild on every tag, but a patch is almost always a server/Docker fix — the
-    # in-app updater can wait for the next minor. Build only on a `.0` tag
-    # (minor/major), or any manual dispatch (the escape hatch for a patch that DOES
-    # need a desktop rebuild — dispatch this workflow with the tag). Patch releases
-    # still ship Docker + the GitHub release via release.yml; they just carry no new
-    # desktop binaries, and latest.json keeps pointing at the last minor's build.
-    if: >-
-      github.repository == 'protoLabsAI/protoAgent'
-      && (github.event_name == 'workflow_dispatch' || endsWith(github.ref_name, '.0'))
+    # Build on every semver tag push (patch included) + any manual dispatch. The old
+    # patch-skip was a CI-cost guard; it's unnecessary on a public repo where GH-hosted
+    # runners are free, and it meant patch desktop fixes never reached users (their
+    # binaries weren't attached and latest.json kept pointing at the last minor). The
+    # repo guard keeps forks from running the matrix.
+    if: github.repository == 'protoLabsAI/protoAgent'
     # Per-leg runner, overridable by repo variable so the expensive macOS/Windows
     # legs can move off GitHub-hosted runners (10×/2× billing multipliers) onto
     # Namespace profiles WITHOUT editing this file — the moment the org provisions
@@ -362,12 +358,12 @@ jobs:
   updater-manifest:
     name: updater manifest (latest.json)
     needs: build
-    # `needs: build` already skips this when the matrix is skipped (patch tag), but
-    # mirror the `.0` guard so the intent is explicit and a dispatch run (no release
-    # to attach to) doesn't try to compose a manifest.
+    # Runs on every tag push (patch included) so the in-app updater's latest.json is
+    # refreshed for every release. Gated to `push` so a manual dispatch (which builds
+    # artifacts, with no release to attach to) doesn't try to compose a manifest;
+    # `needs: build` ties it to a successful matrix.
     if: >-
       github.event_name == 'push' && github.repository == 'protoLabsAI/protoAgent'
-      && endsWith(github.ref_name, '.0')
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 10
     steps:

--- a/docs/guides/releasing.md
+++ b/docs/guides/releasing.md
@@ -22,18 +22,18 @@ you merge the PR (CI green)  ──▶  you push tag vX.Y.Z  ──▶  Release 
 `latest` Docker tag is pushed on every `main` merge by `docker-publish.yml` —
 independent of releases.
 
-A **minor/major** tag push (a `.0` patch component) also triggers
-`desktop-build.yml`, which builds the desktop app on a three-platform matrix and
-attaches the artifacts to the same GitHub Release: the macOS `.dmg` (signed +
-notarized — requires the full Apple secret set, the leg fails otherwise), the
-Linux `.AppImage` + `.deb`, and the Windows NSIS `-setup.exe` (both unsigned). See
-`apps/desktop/README.md` § Platforms & CI.
+**Every** semver tag push (patch included) also triggers `desktop-build.yml`, which
+builds the desktop app on a three-platform matrix and attaches the artifacts to the
+same GitHub Release: the macOS `.dmg` (signed + notarized — requires the full Apple
+secret set, the leg fails otherwise), the Linux `.AppImage` + `.deb`, and the Windows
+NSIS `-setup.exe` (both unsigned). See `apps/desktop/README.md` § Platforms & CI.
 
-> **Patch releases skip the desktop build.** `vX.Y.Z` with `Z>0` ships Docker + the
-> GitHub release but no new desktop binaries (a patch is a server fix; rebuilding the
-> 10×-billed macOS leg per patch is the bulk of CI cost). The in-app updater keeps
-> pointing at the last minor's build until the next minor. If a patch genuinely needs
-> a desktop rebuild, **Actions → Desktop Build → Run workflow** with the tag.
+> **Patches ship desktop binaries too** (changed 2026-06-19). They used to skip the
+> desktop build to save CI minutes, but this repo is public so GitHub-hosted runners
+> (incl. the 10×/2× macOS/Windows legs) are free + unlimited — so every release, patch
+> or minor, publishes fresh desktop binaries and refreshes `latest.json`. (The old
+> skip also meant a patch's desktop fix never reached users — binaries weren't attached
+> and the in-app updater stayed on the last minor.)
 When the org updater signing key is present, the legs also attach signed updater
 bundles and a fan-in job uploads `latest.json` — the manifest the desktop app's
 in-app updater polls. See `apps/desktop/README.md` § Updates.


### PR DESCRIPTION
Brings back desktop publishing for **patch** releases.

The desktop-build matrix + the `latest.json` fan-in were gated to `.0` (minor/major) tags as a CI-cost guard. But this repo is **public**, so GitHub-hosted runners (incl. the 10×/2× macOS/Windows legs) are **free + unlimited** — and the skip meant a patch's desktop fix never reached users: its binaries weren't attached to the release, and the in-app updater stayed pointed at the last minor (we just had to hand-attach v0.55.1's binaries from the dispatched run's artifacts).

## Change
- `build` job `if`: drop `&& endsWith(github.ref_name, '.0')` → builds on **every** semver tag push (+ manual dispatch). Repo guard retained (forks skip).
- `updater-manifest` job `if`: drop the `.0` gate → `latest.json` refreshes on every tag push (still `push`-only, so a manual dispatch doesn't try to compose a manifest with no release to attach to).
- Updated `docs/guides/releasing.md` + the workflow header comments.

YAML validated. No behavior change for minors; patches now ship binaries + updater manifest like minors do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)