### PR TITLE
chore: release v0.56.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.56.0] - 2026-06-19
+
 ### Changed
 - **The command palette (⌘K) is now command-driven.** The root list leads with **Agents**,
   then **Plugins** (each plugin's views), then **Commands** — the built-in surfaces no longer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.55.1"
+version = "0.56.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "v0.56.0",
+    "date": "2026-06-19",
+    "changes": [
+      "The command palette (⌘K) is now command-driven."
+    ]
+  },
+  {
     "version": "v0.55.1",
     "date": "2026-06-19",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.56.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.56.0 -m 'Release v0.56.0' && git push origin v0.56.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).