### PR TITLE
fix(web): scope launcher CSS + drop plugin "open here" hint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The in-app ⌘K palette no longer inherits the desktop launcher's frosted styling.** The
+  launcher window's CSS (transparent scrim, translucent backdrop-blur card, large shadow) is
+  bundled globally, so it leaked onto the main console's command palette; it's now scoped to
+  the launcher window.
+- **Plugin entries in the palette dropped their "open here" hint.** It collided with the new
+  `Open…` command (and the shared "open" keyword surfaced every plugin when you typed "open").
+
 ## [0.56.0] - 2026-06-19
 
 ### Changed

--- a/apps/web/src/app/launcher.css
+++ b/apps/web/src/app/launcher.css
@@ -1,23 +1,27 @@
 /* The frameless desktop quick-launcher window (ADR 0057). The window is transparent +
- * shadowless (see lib.rs), so this stylesheet — loaded ONLY in the launcher window — paints
- * nothing on the frame and instead floats the DS palette as a rounded, frosted card with
- * see-through margins, Raycast-style. The palette renders in its `overlay` presentation. */
-html,
-body,
-#root {
+ * shadowless (see lib.rs), so this stylesheet floats the DS palette as a rounded, frosted
+ * card with see-through margins, Raycast-style. The palette renders in its `overlay`
+ * presentation.
+ *
+ * EVERYTHING here is scoped under `.is-launcher` (set on <html> only in the launcher
+ * window, see main.tsx). Vite bundles imported CSS GLOBALLY — without this scope these
+ * `.pl-cmdk-*` overrides would leak onto the in-app ⌘K palette in the main console window. */
+html.is-launcher,
+.is-launcher body,
+.is-launcher #root {
   height: 100%;
   margin: 0;
   overflow: hidden;
   background: transparent; /* let the transparent window show the desktop behind */
 }
 
-.launcher-root {
+.is-launcher .launcher-root {
   height: 100%;
 }
 
 /* The portaled scrim fills the window. Drop its dim (so the margins are truly see-through)
  * and center the card vertically instead of the DS top-anchor. */
-.pl-cmdk-overlay {
+.is-launcher .pl-cmdk-overlay {
   background: transparent !important;
   align-items: center !important;
   padding: var(--pl-space-4) !important;
@@ -26,7 +30,7 @@ body,
 /* The floating card: the DS panel already carries the radius + border; layer on a
  * translucent surface + backdrop blur so the desktop shows through slightly. The opaque
  * `background` is a fallback for WebKit without color-mix (degrades to solid, still rounded). */
-.pl-cmdk__panel {
+.is-launcher .pl-cmdk__panel {
   background: var(--pl-color-bg-raised);
   background: color-mix(in srgb, var(--pl-color-bg-raised) 82%, transparent);
   -webkit-backdrop-filter: blur(24px) saturate(1.4);

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -223,10 +223,12 @@ export function usePaletteRegistry(
       return {
         id: `nav:${v.id}`,
         label: v.title,
-        hint: inline ? "open here" : "go to",
+        // No "open" verb/keyword here — `Open…` is its own command now and would collide.
+        // An inline plugin morphs in place (no hint); a rail view navigates ("go to").
+        hint: inline ? undefined : "go to",
         icon: v.icon,
         group: "Plugins",
-        keywords: ["plugin", "open", v.kind],
+        keywords: ["plugin", v.kind],
         run: inline
           ? (c) => c.enter(v.id)
           : (c) => {

--- a/apps/web/src/main.tsx
+++ b/apps/web/src/main.tsx
@@ -23,7 +23,10 @@ watchThemeChanges(); // fire `protoagent:theme` on any theme change → plugin i
 
 // The desktop quick-launcher window (ADR 0057) boots the same bundle but renders ONLY the
 // command palette — no shell, no slug activation. Everything else is the full console.
+// The `is-launcher` class scopes launcher.css (its `.pl-cmdk-*` overrides are global in the
+// bundle, so without this they'd leak onto the in-app ⌘K palette in the main window).
 const launcher = isLauncherWindow();
+if (launcher) document.documentElement.classList.add("is-launcher");
 if (!launcher) void activateSlugAgent(); // cold-agent resume + keep-warm touch on slug navigation (#806)
 
 ReactDOM.createRoot(document.getElementById("root")!).render(


### PR DESCRIPTION
Two post-0.56.0 palette fixes.

### 1. Launcher CSS leaked onto the in-app palette
`launcher.css` (transparent scrim, translucent backdrop-blur card, large shadow) is imported by `Launcher.tsx`, but Vite bundles plain CSS **globally** — so those `.pl-cmdk-*` overrides were applying to the **main console's ⌘K palette** too (the big `0 24px 60px` shadow read as "a background around the palette"). Now every launcher rule is scoped under `.is-launcher`, set on `<html>` only in the launcher window (`main.tsx`). The in-app palette reverts to the DS default; the launcher keeps its frosted look. Verified in the built bundle: the panel override is now `.is-launcher .pl-cmdk__panel{…}`, no bare version.

### 2. Plugin "open here" hint collided with `Open…`
With the new command-driven palette, `Open…` is its own command. Plugin rows carried an "open here" hint + an "open" keyword, so typing "open" surfaced every plugin and the hint stomped on the command. Dropped both — inline plugins now show no hint (they morph in place), rail views keep "go to".

## Verified
- ✅ `tsc` + `vite build`; bundle grep confirms the scope; `vitest` 99/99.

🤖 Generated with [Claude Code](https://claude.com/claude-code)