### PR TITLE
feat(delegates): make the delegate registry a built-in; config moves to Workspace settings

### DIFF
--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -1,13 +1,14 @@
 import { expect, test } from "@playwright/test";
 
-// The Delegates panel (ADR 0025) lives under Settings ▸ Workspace ▸ Plugins (ADR 0048):
-// it lists the configured delegates (GET /api/delegates), and an Add form with a type
-// picker driven by GET /api/delegate-types. Mocked endpoints in e2e/mock-server.mjs.
+// The Delegates panel (ADR 0025) is a built-in core surface with its own top-level
+// Settings ▸ Workspace ▸ Delegates section (ADR 0048): it lists the configured delegates
+// (GET /api/delegates), and an Add form with a type picker driven by GET
+// /api/delegate-types. Mocked endpoints in e2e/mock-server.mjs.
 
 async function openIntegrations(page) {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await page.locator(".pl-sidenav").getByRole("tab", { name: "Plugins", exact: true }).click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "Delegates", exact: true }).click();
 }
 
 test("lists configured delegates with type + secret badges", async ({ page }) => {

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -47,6 +47,7 @@ test("Workspace settings live in the rail (no scope toggle)", async ({ page }) =
     "Tools",
     "MCP",
     "Subagents",
+    "Delegates",
     "Skills",
     "Middleware",
     "Memory",

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -78,6 +78,10 @@ export type RuntimeStatus = {
     version?: string;
     enabled: boolean;
     loaded: boolean;
+    // Core runtime infrastructure (e.g. the delegate registry): always loaded, can't
+    // be disabled, and hidden from the Plugins management list (its config lives in the
+    // core Workspace settings, not the Plugins panel).
+    builtin?: boolean;
     tools: string[];
     skills: number;
     error?: string;

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -172,7 +172,10 @@ function LocalTab() {
     (schema.data?.groups ?? []).filter((g) => g.plugin_id).map((g) => g.plugin_id as string),
   );
 
-  const plugins = runtime.plugins ?? [];
+  // Built-ins (core runtime infrastructure like the delegate registry) aren't optional
+  // add-ons — they always load, can't be toggled, and are configured in Workspace
+  // settings — so they don't belong in the install/enable list.
+  const plugins = (runtime.plugins ?? []).filter((p) => !p.builtin);
   const byName = (a: Plugin, b: Plugin) => a.name.localeCompare(b.name);
   const loaded = plugins.filter((p) => p.loaded).sort(byName);
   const disabled = plugins.filter((p) => !p.loaded).sort(byName);

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -84,14 +84,16 @@ export function DelegatesSection() {
     onError: (e, d) => setProbes((m) => ({ ...m, [d.name]: { ok: false, error: errMsg(e) } })),
   });
 
-  // The delegates plugin isn't enabled (routes 404) — show a hint, not an error.
+  // The delegate registry is built-in, so this normally resolves. A 404 here means the
+  // registry route is unreachable (e.g. an older remote fleet agent) — show a hint, not
+  // an error.
   if (list.isError) {
     return (
       <section className="settings-group">
         <p className="settings-group-title">Delegates</p>
         <p className="setting-desc">
-          Enable the <code>delegates</code> plugin (<code>plugins: {"{ enabled: [delegates] }"}</code>) to
-          manage the agents and endpoints this agent can talk to.{" "}
+          Couldn't reach the delegate registry for this agent — manage the agents and
+          endpoints it can talk to once it's available.{" "}
           <HelpLink href={DELEGATES_GUIDE_URL}>Guide</HelpLink>
         </p>
       </section>

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Library, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Wrench } from "lucide-react";
+import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Library, Network, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
@@ -61,6 +61,10 @@ const WORKSPACE_SECTIONS: Section[] = [
   { id: "tools", label: "Tools", icon: Wrench, render: () => <ToolsPanel /> },
   { id: "mcp", label: "MCP", icon: Plug, render: () => <McpPanel /> },
   { id: "subagents", label: "Subagents", icon: Bot, render: () => <SubagentsPanel /> },
+  // The delegate registry (ADR 0025) is built-in core infrastructure — its config
+  // lives here alongside the agent's other call-out surfaces (Tools/MCP/Subagents),
+  // not under Plugins.
+  { id: "delegates", label: "Delegates", icon: Network, render: () => <DelegatesSection /> },
   { id: "skills", label: "Skills", icon: BookMarked, render: () => <PlaybooksSurface /> },
   { id: "middleware", label: "Middleware", icon: Layers, render: () => <MiddlewarePanel /> },
   { id: "memory", label: "Memory", icon: Database, render: () => <SettingsCategoryPanel category="Memory" title="Memory" /> },
@@ -75,8 +79,9 @@ const WORKSPACE_SECTIONS: Section[] = [
 ];
 
 // ADR 0059 — per-plugin config now lives with each plugin in the Plugins panel
-// (Installed → Configure). This section points there + keeps the delegate registry
-// (which has its own richer UI, not generic settings fields).
+// (Installed → Configure). This section just points there. (The delegate registry is
+// built-in core infrastructure, so it has its own top-level Workspace ▸ Delegates
+// section rather than living under Plugins.)
 function PluginSettingsHome() {
   const setSurface = useUI((s) => s.setSurface);
   const setPluginsTab = useUI((s) => s.setPluginsTab);
@@ -92,7 +97,6 @@ function PluginSettingsHome() {
         <Button variant="primary" type="button" onClick={openPlugins}>
           <Puzzle size={15} /> Open Plugins
         </Button>
-        <DelegatesSection />
       </div>
     </>
   );

--- a/docs/guides/delegates.md
+++ b/docs/guides/delegates.md
@@ -1,8 +1,8 @@
 # Delegates — the agents & endpoints your agent can talk to
 
-An **opt-in plugin** ([ADR 0025](/adr/0025-unified-delegate-registry-and-panel))
+A **built-in registry** ([ADR 0025](/adr/0025-unified-delegate-registry-and-panel))
 that gives the lead agent **one tool — `delegate_to(target, query)`** — over a
-unified registry of delegates it can hand work to:
+unified roster of delegates it can hand work to:
 
 | `type` | What it is | Dispatch |
 |---|---|---|
@@ -14,13 +14,14 @@ This unifies what used to be three separate things — `peer_consult` (a2a),
 `code_with` (acp), and "no way to ask another model" — into one hot-swappable
 roster.
 
-Manage delegates three ways: the **console panel** (Settings → Plugins →
+Manage delegates three ways: the **console panel** (Workspace settings ▸
 Delegates), a **REST API**, or **config** — all hot-swappable (changes apply on
 the next turn, no restart). See [ADR 0025](/adr/0025-unified-delegate-registry-and-panel).
 
 ## Manage in the console (panel)
 
-Open **Settings → Plugins → Delegates** (the registry is on by default). The panel:
+Open **Workspace settings ▸ Delegates** (a built-in — always on, alongside Tools,
+MCP, and Subagents). The panel:
 
 - **lists** your delegates with a type badge, a `secret set` / `⚠ unconfigured`
   marker, a **live health dot** (a background prober probes each delegate
@@ -36,8 +37,9 @@ the next turn.
 
 ## Declare delegates
 
-The registry is **enabled by default** — it does nothing until you declare a
-delegate, so just add entries (no plugin to turn on):
+The registry is a **built-in** — always on, can't be disabled, and managed in
+**Workspace settings ▸ Delegates** (no plugin to install or turn on). It does
+nothing until you declare a delegate, so just add entries:
 
 ```yaml
 # config/langgraph-config.yaml

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -259,14 +259,21 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
     seen_tool_names = set(core_tool_names or set())
 
     for manifest in discover_plugins(roots):
-        # plugins.disabled wins — turn off a bundled plugin (e.g. a first-party
-        # surface) without deleting it or editing core.
-        enabled = (manifest.enabled or manifest.id in enabled_ids) and manifest.id not in disabled_ids
+        # A builtin (core runtime infrastructure, e.g. the delegate registry) always
+        # loads — it ignores the enable gate AND the disabled list, so it can't be
+        # turned off. Otherwise plugins.disabled wins: turn off a bundled plugin (e.g.
+        # a first-party surface) without deleting it or editing core.
+        enabled = manifest.builtin or (
+            (manifest.enabled or manifest.id in enabled_ids) and manifest.id not in disabled_ids
+        )
         entry = {
             "id": manifest.id,
             "name": manifest.name,
             "version": manifest.version,
             "enabled": enabled,
+            # Built-in plugins are filtered out of the Plugins management list (they
+            # aren't optional add-ons) — the flag rides along in /api/runtime/status.
+            "builtin": manifest.builtin,
             "loaded": False,
             "tools": [],
             "skills": 0,

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -27,6 +27,12 @@ class PluginManifest:
     # wrote/dropped in yourself). An operator can also enable by id via
     # ``plugins.enabled`` in config. Either path counts as consent.
     enabled: bool = False
+    # ``builtin: true`` marks a plugin as core runtime infrastructure (e.g. the
+    # delegate registry): it ALWAYS loads — ignoring both the enable gate and the
+    # ``plugins.disabled`` list — and is hidden from the Plugins management list,
+    # since it isn't an optional add-on the operator toggles. Its config lives in
+    # the core Workspace settings, not the Plugins panel.
+    builtin: bool = False
     requires_env: list[str] = field(default_factory=list)
     # Declarative, for transparency in the console — not yet enforced.
     capabilities: dict = field(default_factory=dict)
@@ -160,6 +166,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
         version=str(data.get("version", "0.0.0")),
         description=str(data.get("description", "")),
         enabled=bool(data.get("enabled", False)),
+        builtin=bool(data.get("builtin", False)),
         requires_env=requires_env,
         capabilities=caps if isinstance(caps, dict) else {},
         entrypoint=str(data.get("entrypoint", "")).strip(),

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -274,6 +274,14 @@ def register_plugin_routes(app) -> None:
         # Snapshot the plugin's pre-reload meta — on DISABLE the reload clears its views
         # from STATE.plugin_meta, so we must read "did it contribute a surface?" first.
         prev_meta = next((p for p in (STATE.plugin_meta or []) if p.get("id") == plugin_id), None)
+        # A builtin (core runtime infrastructure, e.g. the delegate registry) always
+        # loads regardless of plugins.disabled — refuse to disable it rather than write a
+        # config entry the loader silently ignores.
+        if not want and prev_meta and prev_meta.get("builtin"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"{plugin_id!r} is a built-in plugin and can't be disabled",
+            )
         if want:
             enabled.append(plugin_id)
         else:

--- a/plugins/delegates/protoagent.plugin.yaml
+++ b/plugins/delegates/protoagent.plugin.yaml
@@ -9,9 +9,9 @@ description: >-
   docs/guides/delegates.md.
 
   Declare delegates in a top-level `delegates:` list (a list, ORBIS-style — not a
-  plugin config section). Enabled by default — it contributes the `delegate_to`
-  tool ONLY once you declare at least one delegate, so it's a no-op until then.
-  (Turn it off explicitly with `plugins: { disabled: [delegates] }`.)
+  plugin config section). A built-in (always-on, can't be disabled) — it
+  contributes the `delegate_to` tool ONLY once you declare at least one delegate,
+  so it's a no-op until then. Manage the roster in Workspace settings ▸ Delegates.
 
   Example (langgraph-config.yaml):
     delegates:
@@ -32,10 +32,12 @@ description: >-
         args: ["--acp"]
         workdir: ~/dev/my-repo
         permissions: allowlist
-# Always-on (ADR 0025): the registry ships enabled, but stays a no-op until a
-# delegate is declared (register() adds `delegate_to` only when the roster is
-# non-empty). So the gate is "did you declare a delegate", not "did you enable a plugin".
-enabled: true
+# Always-on (ADR 0025): the registry is core runtime infrastructure, not an
+# optional add-on — `builtin: true` makes it load unconditionally (it can't be
+# disabled and is hidden from the Plugins management list). It still stays a no-op
+# until a delegate is declared (register() adds `delegate_to` only when the roster
+# is non-empty). So the gate is "did you declare a delegate", never a plugin toggle.
+builtin: true
 
 # Declarative only (not yet enforced) — surfaced in the console for transparency.
 capabilities:

--- a/tests/test_plugin_routes.py
+++ b/tests/test_plugin_routes.py
@@ -76,11 +76,21 @@ def test_disabling_a_view_plugin_recommends_restart(monkeypatch):
 
 
 def test_disabling_a_route_only_plugin_recommends_restart(monkeypatch):
-    # A plugin with no views but a contributed router (e.g. delegates) still leaves a
-    # stale route on disable → restart recommended.
-    _wire(monkeypatch, enabled=["delegates"], disabled=[], meta=[{"id": "delegates", "views": [], "routers": 1}])
-    body = _client().post("/api/plugins/delegates/enabled", json={"enabled": False}).json()
+    # A plugin with no views but a contributed router still leaves a stale route on
+    # disable → restart recommended.
+    _wire(monkeypatch, enabled=["routeplug"], disabled=[], meta=[{"id": "routeplug", "views": [], "routers": 1}])
+    body = _client().post("/api/plugins/routeplug/enabled", json={"enabled": False}).json()
     assert body["restart_recommended"] is True
+
+
+def test_disabling_a_builtin_plugin_is_rejected(monkeypatch):
+    # A builtin (core infrastructure, e.g. the delegate registry) always loads and can't
+    # be turned off — disabling it via the API is a 400, not a no-op config write.
+    _wire(monkeypatch, enabled=[], disabled=[], meta=[{"id": "delegates", "views": [], "builtin": True}])
+    res = _client().post("/api/plugins/delegates/enabled", json={"enabled": False})
+    assert res.status_code == 400
+    # Enabling a builtin is harmless (it's already on) and not blocked.
+    assert _client().post("/api/plugins/delegates/enabled", json={"enabled": True}).status_code == 200
 
 
 def test_disabling_a_plain_plugin_does_not_recommend_restart(monkeypatch):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -75,6 +75,28 @@ def test_disabled_plugin_not_loaded(tmp_path, monkeypatch) -> None:
     assert res.meta[0]["id"] == "offplug" and res.meta[0]["enabled"] is False
 
 
+def test_builtin_plugin_always_loads_and_ignores_disabled(tmp_path, monkeypatch) -> None:
+    """A ``builtin: true`` plugin loads even without an enable flag AND even when it's
+    listed in plugins.disabled — it's core infrastructure, not a toggleable add-on.
+    The meta carries ``builtin: true`` so the console can hide it from the Plugins list."""
+    root = tmp_path / "plugins"
+    _make_plugin(root, "core", enabled=False, tool="core_tool", manifest_extra="builtin: true\n")
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+    # No enable flag, AND explicitly disabled — a builtin still loads.
+    res = load_plugins(_cfg(plugins_disabled=["core"]))
+    assert [t.name for t in res.tools] == ["core_tool"]
+    assert res.meta[0]["enabled"] is True
+    assert res.meta[0]["builtin"] is True
+
+
+def test_delegates_manifest_is_builtin() -> None:
+    """The bundled delegate registry ships as a non-disableable built-in."""
+    from pathlib import Path as _Path
+
+    m = load_manifest(_Path(__file__).resolve().parent.parent / "plugins" / "delegates")
+    assert m is not None and m.builtin is True
+
+
 def test_enabled_via_config(tmp_path, monkeypatch) -> None:
     root = tmp_path / "plugins"
     _make_plugin(root, "p", enabled=False, tool="p_tool")


### PR DESCRIPTION
## What & why

The delegate registry (ADR 0025) is core runtime infrastructure — not an optional add-on you toggle. This makes it a **built-in** and moves its config to a first-class **Workspace ▸ Delegates** settings section alongside Tools / MCP / Subagents.

## Changes

**Built-in mechanism (new `builtin` manifest field)**
- `graph/plugins/manifest.py` — new `builtin` field.
- `graph/plugins/loader.py` — `builtin` ⇒ always loads, ignoring both the enable gate *and* `plugins.disabled`; stamps `builtin` into `/api/runtime/status` plugin meta.
- `plugins/delegates/protoagent.plugin.yaml` — `enabled: true` → `builtin: true` (+ refreshed comments).
- `operator_api/plugin_routes.py` — `/api/plugins/{id}/enabled` rejects disabling a built-in (400) rather than writing a config entry the loader silently ignores.
- `apps/web/src/plugins/PluginsSurface.tsx` + `lib/types.ts` — built-ins are filtered out of the Plugins management list.

**Delegates → top-level Workspace settings**
- `apps/web/src/settings/SettingsSurface.tsx` — new top-level **Delegates** section (Network icon), placed after Subagents; removed from inside the Plugins home.
- `apps/web/src/settings/DelegatesSection.tsx` — dropped the stale "enable the delegates plugin" 404 hint (it's always-on now).
- `docs/guides/delegates.md` — built-in language + new settings home.

## Tests
- `tests/test_plugins.py` — built-in loads even when explicitly disabled; bundled delegates manifest is `builtin`.
- `tests/test_plugin_routes.py` — disabling a built-in is a 400 (and moved the route-only-plugin example off `delegates`).
- `apps/web/e2e/delegates.spec.ts` — navigates to the new Delegates tab.

## Verification (local)
- `ruff check .` clean · targeted pytest **97 passed** · web `tsc` build clean · vitest **99 passed** · delegates e2e **2 passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)