### PR TITLE
feat(web): restore Settings rail surface + surface-color/theming polish pass

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -97,7 +97,6 @@ import { AppShell, Header, UtilityBar } from "@protolabsai/ui/app-shell";
 import { CommandPalette, usePaletteHotkey } from "@protolabsai/ui/command-palette";
 import type { PaletteView } from "@protolabsai/ui/command-palette";
 import { Alert } from "@protolabsai/ui/data";
-import { Logo } from "@protolabsai/ui/primitives";
 import { useIsMobile } from "../lib/useIsMobile";
 import { useActiveTheme } from "../lib/useActiveTheme";
 import { registeredSurfaces } from "../ext"; // build-time fork seam (ADR 0038 D3); also self-loads fork surfaces
@@ -692,7 +691,7 @@ export function App() {
           gradient-filled to match the wordmark via stroke="url(#pl-brand-gradient)"
           (the def Splash auto-renders with `gradient`). */}
       <Splash
-        logo={<ProtoLabsIcon variant="outline" size={88} decorative gradientStroke />}
+        logo={<ProtoLabsIcon variant="outline" size={88} decorative gradientStroke tone="accent" />}
         word="protoLabs.studio"
         holdMs={2500}
         once="protoagent.introSeen"
@@ -729,7 +728,7 @@ export function App() {
         // for protoContent#203: DS BootGate should own role=status aria-live).
         <div role="status" aria-live="polite">
           <BootGate
-            logo={<ProtoLabsIcon variant="outline" size={56} decorative />}
+            logo={<ProtoLabsIcon variant="outline" size={56} decorative gradientStroke tone="accent" />}
             title={
               bootFailed
                 ? `${bootName} isn’t responding`
@@ -771,7 +770,7 @@ export function App() {
       <div className="app-topbar">
       <Header
         dragRegion
-        logo={<Logo src={`${import.meta.env.BASE_URL}protolabs-icon-outline.svg`} alt="" size={22} />}
+        logo={<ProtoLabsIcon variant="outline" tone="accent" size={22} decorative />}
         name={
           <FleetSwitcher
             fallbackName={brandName(runtime?.identity?.name)}

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -159,6 +159,27 @@ export function PluginView({ view }: { view: PluginViewType }) {
     };
   }, [src, pluginId]);
 
+  // Live re-theme (ADR 0026/0042). The console fires a `protoagent:theme` window event on
+  // any theme/accent change (watchThemeChanges in agentTheme.ts observes the root's
+  // style/data-theme). Re-post the FRESH curated theme to the mounted iframe so an embedded
+  // plugin view repaints WITHOUT a reload — its plugin-kit listens for `protoagent:theme`
+  // and re-skins the --pl-* tokens. `handleLoad` only covers the first paint; this covers
+  // every subsequent switch. (consoleTheme() reads the now-updated :root vars at fire time.)
+  useEffect(() => {
+    const onThemeChange = () => {
+      const win = frameRef.current?.contentWindow;
+      if (!win) return;
+      try {
+        const origin = new URL(apiUrl(src), window.location.href).origin;
+        win.postMessage({ type: "protoagent:theme", theme: consoleTheme() }, origin);
+      } catch {
+        /* cross-origin / detached — best effort */
+      }
+    };
+    window.addEventListener("protoagent:theme", onThemeChange);
+    return () => window.removeEventListener("protoagent:theme", onThemeChange);
+  }, [src]);
+
   function handleLoad(e: React.SyntheticEvent<HTMLIFrameElement>) {
     setLoaded(true);
     const win = e.currentTarget.contentWindow;

--- a/apps/web/src/app/ProtoLabsIcon.tsx
+++ b/apps/web/src/app/ProtoLabsIcon.tsx
@@ -23,6 +23,7 @@ export function ProtoLabsIcon({
   className,
   decorative = false,
   gradientStroke = false,
+  tone = "lavender",
 }: {
   size?: number;
   variant?: "flat" | "outline" | "white";
@@ -38,14 +39,23 @@ export function ProtoLabsIcon({
    *  entirely. (We used to reference `#pl-brand-gradient`, which is exactly why the
    *  Splash logo lost its eyes + ears.) */
   gradientStroke?: boolean;
+  /** "lavender" (default) = the fixed brand-chrome lavender. "accent" = follow the
+   *  live theme accent (`--pl-color-accent`) so the mark recolors with the operator's
+   *  chosen accent — the `flat` background square or the `outline` strokes. Routed
+   *  through `currentColor` because an SVG presentation attribute can't hold `var()`. */
+  tone?: "lavender" | "accent";
 }) {
   // Unique, selector-safe id per instance (useId yields ":r0:"-style ids; strip
   // the colons so the funciri url(#…) and any tooling stay happy).
   const gradId = `pl-grad-${useId().replace(/:/g, "")}`;
+  // The recolorable lavender chrome. "accent" paints it with the live theme accent via
+  // currentColor (set on the <svg> below); brand rules still hold — the robot in `flat`
+  // stays white, only the background square / outline strokes take the accent.
+  const lavender = tone === "accent" ? "currentColor" : "#9b87f2";
   const robotStroke = gradientStroke
     ? `url(#${gradId})`
     : variant === "outline"
-      ? "#9b87f2"
+      ? lavender
       : "#ffffff";
   const a11y = decorative
     ? { "aria-hidden": true as const }
@@ -56,22 +66,36 @@ export function ProtoLabsIcon({
       height={size}
       viewBox="0 0 256 256"
       className={className}
+      style={tone === "accent" ? { color: "var(--pl-color-accent, #9b87f2)" } : undefined}
       {...a11y}
     >
       {gradientStroke && (
         <defs>
           {/* userSpaceOnUse + coords in the mark's LOCAL space (the paths' own
               coordinate system, inside the translate/scale group) — paints every
-              subpath including the zero-area eye/ear strokes. lavender → brand
-              violet, matching the gradient wordmark. */}
+              subpath including the zero-area eye/ear strokes. "lavender" tone is the
+              fixed brand gradient (lavender → violet); "accent" tone derives a light→dark
+              gradient from the live theme accent so it white-labels and coheres with the
+              DS splash/bootgate neon glow (already keyed to --pl-color-accent). The accent
+              stops use `style` (CSS context) because var()/color-mix() can't resolve in an
+              SVG stop-color presentation attribute. */}
           <linearGradient id={gradId} gradientUnits="userSpaceOnUse" x1="2" y1="4" x2="22" y2="20">
-            <stop offset="0" stopColor="#9b87f2" />
-            <stop offset="1" stopColor="#7c3aed" />
+            {tone === "accent" ? (
+              <>
+                <stop offset="0" style={{ stopColor: "color-mix(in srgb, var(--pl-color-accent, #9b87f2), #fff 22%)" }} />
+                <stop offset="1" style={{ stopColor: "color-mix(in srgb, var(--pl-color-accent, #7c3aed), #000 25%)" }} />
+              </>
+            ) : (
+              <>
+                <stop offset="0" stopColor="#9b87f2" />
+                <stop offset="1" stopColor="#7c3aed" />
+              </>
+            )}
           </linearGradient>
         </defs>
       )}
       {variant === "flat" && (
-        <rect x="16" y="16" width="224" height="224" rx="56" fill="#9b87f2" />
+        <rect x="16" y="16" width="224" height="224" rx="56" fill={lavender} />
       )}
       <g
         transform="translate(224, 32) scale(-8, 8)"

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -465,12 +465,17 @@
 }
 
 /* A tabbed surface renders the DS Tabs + the .panel card as siblings in the AppShell
-   column. Style the tab strip as the card's TOP edge and drop the panel's top
-   border/radius, so the two read as ONE full-height card — its top aligns with the
-   non-tabbed panels. (Responsive Tabs wrap the strip in .pl-tabs-wrap and collapse to
-   a dropdown on narrow containers — match both as the column's direct child.) */
+   column (or the bottom dock). Style the tab strip as the card's TOP edge and drop the
+   panel's top border/radius, so the two read as ONE full-height card — its top aligns
+   with the non-tabbed panels. (Responsive Tabs wrap the strip in .pl-tabs-wrap and
+   collapse to a dropdown on narrow containers — match both as the direct child.) The
+   bottom dock (`.pl-appshell__bottom`) is a different wrapper than the side columns, so
+   it must be matched explicitly or its tab strip falls through to the shell's dark
+   ground instead of the panel surface. */
 .pl-appshell__col > .pl-tabs,
-.pl-appshell__col > .pl-tabs-wrap {
+.pl-appshell__col > .pl-tabs-wrap,
+.pl-appshell__bottom > .pl-tabs,
+.pl-appshell__bottom > .pl-tabs-wrap {
   flex: 0 0 auto;
   padding: 8px 12px 0;
   border: 1px solid var(--border);
@@ -479,10 +484,30 @@
   background: var(--bg-panel);
 }
 .pl-appshell__col > .pl-tabs + .panel,
-.pl-appshell__col > .pl-tabs-wrap + .panel {
+.pl-appshell__col > .pl-tabs-wrap + .panel,
+.pl-appshell__bottom > .pl-tabs + .panel,
+.pl-appshell__bottom > .pl-tabs-wrap + .panel {
   border-top: none;
   border-top-left-radius: 0;
   border-top-right-radius: 0;
+}
+
+/* ── Interim DS-component surface overrides ──────────────────────────────────────
+   Two DS surfaces read too dark in our console. These are LOCAL interim overrides
+   (theme.css loads after @protolabsai/ui/styles.css, so same-specificity rules win)
+   pending DS-side fixes — drop them once those land.
+
+   Reasoning (chat): the DS uses --pl-color-bg-inset (#060608, BELOW the page), so the
+   block reads as a dark hole on the chat panel. Lift it to the subtle raised surface so
+   it reads as a distinct "thinking" block. See protoContent#273. */
+.pl-reasoning {
+  background: var(--pl-color-bg-subtle);
+}
+/* Select: the DS closed control uses --pl-color-bg-raised — the SAME color as the panel
+   it sits on, so it disappears. Lift to the subtle surface for contrast. (The OPEN native
+   <select> menu is OS-rendered and can't be themed from CSS — that's protoContent#274.) */
+.pl-select {
+  background: var(--pl-color-bg-subtle);
 }
 
 /* Settings panel: header · category sub-nav · scrolling body (ADR 0020). The

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -58,7 +58,8 @@ describe("migrateUiState", () => {
   // "activity" from every dock + the mobile quick-bar so it doesn't linger as a dead id.
   it("prunes 'activity' from the rails and quick-bar", () => {
     const out = migrateUiState({
-      railOrder: { left: ["chat", "activity", "schedule"], right: ["activity", "beads"], bottom: ["activity"] },
+      // "settings" present so the v9 re-add below is a no-op — this test is about activity.
+      railOrder: { left: ["chat", "activity", "schedule"], right: ["activity", "beads", "settings"], bottom: ["activity"] },
       quickBar: ["chat", "activity", "knowledge"],
     }) as { railOrder: { left: string[]; right: string[]; bottom: string[] }; quickBar: string[] };
     expect(out.railOrder.left).not.toContain("activity");
@@ -66,6 +67,31 @@ describe("migrateUiState", () => {
     expect(out.railOrder.bottom).not.toContain("activity");
     expect(out.railOrder.left).toEqual(["chat", "schedule"]);
     expect(out.quickBar).toEqual(["chat", "knowledge"]);
+  });
+
+  // v9 (2026-06-18 IA pass): Workspace settings became a rail surface; re-add "settings"
+  // to a persisted layout that lacks it so existing users don't lose the Settings icon.
+  it("restores the 'settings' rail surface to a layout that lacks it", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "schedule"], right: ["beads", "goals", "plugins"], bottom: [] },
+    }) as { railOrder: { left: string[] } };
+    // No "plugins" on the left rail → appended to the end of it.
+    expect(out.railOrder.left).toEqual(["chat", "schedule", "settings"]);
+  });
+
+  it("re-adds 'settings' right after 'plugins' on the left when present", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "schedule", "plugins", "knowledge"], right: ["beads"], bottom: [] },
+    }) as { railOrder: { left: string[] } };
+    expect(out.railOrder.left).toEqual(["chat", "schedule", "plugins", "settings", "knowledge"]);
+  });
+
+  it("keeps a user-placed 'settings' where it is", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "schedule"], right: ["settings", "beads"], bottom: [] },
+    }) as { railOrder: { left: string[]; right: string[] } };
+    expect(out.railOrder.right).toContain("settings");
+    expect(out.railOrder.left).not.toContain("settings");
   });
 
   // v5→v6 (bottom dock): railOrder gains a `bottom` dock; add the empty array to a

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -167,6 +167,24 @@ export function migrateUiState(persisted: unknown): unknown {
       const noAct = (arr?: string[]) => (Array.isArray(arr) ? arr.filter((x) => x !== "activity") : []);
       rest.railOrder = { left: noAct(ro5.left), right: noAct(ro5.right), bottom: noAct(ro5.bottom) };
     }
+    // v9 (2026-06-18 IA pass): Workspace settings became a rail surface (id "settings").
+    // The default railOrder gained it, but `railSurfaces()` only renders ids already in a
+    // user's persisted railOrder and nothing re-adds a missing CORE surface — so anyone
+    // with a layout saved before the pass lost the Settings icon entirely (only the Global
+    // overlay in the header drawer remained). Re-add "settings" to the left rail (after
+    // "plugins" if present, else at the end) unless the user already keeps it on some dock.
+    // Mirrors the v7 schedule re-add.
+    const ro6 = rest.railOrder as { left?: string[]; right?: string[]; bottom?: string[] } | undefined;
+    if (ro6) {
+      const has = (arr?: string[]) => Array.isArray(arr) && arr.includes("settings");
+      if (!has(ro6.left) && !has(ro6.right) && !has(ro6.bottom)) {
+        const left = Array.isArray(ro6.left) ? ro6.left.slice() : [];
+        const at = left.indexOf("plugins");
+        if (at >= 0) left.splice(at + 1, 0, "settings");
+        else left.push("settings");
+        rest.railOrder = { ...ro6, left };
+      }
+    }
     if (Array.isArray(rest.quickBar)) {
       rest.quickBar = (rest.quickBar as string[]).filter((x) => x !== "activity");
     }
@@ -275,7 +293,7 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 8, // …v6 +bottom dock · v7 Schedule→rail surface again · v8 Activity→utility widget
+      version: 9, // …v6 +bottom dock · v7 Schedule→rail surface again · v8 Activity→utility widget · v9 re-add Settings rail surface
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
       // The Global settings overlay is ephemeral UI state — drop it from persistence so a
       // refresh never reopens it (everything else persists as before).

--- a/plugins/docs/__init__.py
+++ b/plugins/docs/__init__.py
@@ -139,7 +139,7 @@ _VIEW_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
 <script>window.__base = location.pathname.split("/plugins/")[0];
 document.write('<link rel="stylesheet" href="'+window.__base+'/_ds/plugin-kit.css">');</script>
 <style>
-  *{box-sizing:border-box} html,body{margin:0;height:100%;color:var(--pl-color-fg);background:var(--pl-color-bg);font:14px/1.55 system-ui,-apple-system,sans-serif}
+  *{box-sizing:border-box} html,body{margin:0;height:100%;color:var(--pl-color-fg);background:var(--pl-color-bg-raised);font:14px/1.55 system-ui,-apple-system,sans-serif}
   #app{display:flex;height:100vh}
   #nav{width:280px;flex:none;border-right:1px solid var(--pl-color-border);overflow:auto;padding:8px}
   #reader{flex:1;overflow:auto;padding:16px 26px}

--- a/plugins/notes/__init__.py
+++ b/plugins/notes/__init__.py
@@ -181,7 +181,7 @@ _EDITOR_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
 <style>
   /* Layout only — colors/typography come from plugin-kit.css's --pl-* tokens, which
      plugin-kit.js re-skins to the operator's live theme on the handshake. */
-  html,body{margin:0;height:100%;background:var(--pl-color-bg);color:var(--pl-color-fg);
+  html,body{margin:0;height:100%;background:var(--pl-color-bg-raised);color:var(--pl-color-fg);
     font-family:var(--pl-font-sans,ui-sans-serif,system-ui,sans-serif)}
   #wrap{display:flex;flex-direction:column;height:100%}
   #bar{display:flex;align-items:center;justify-content:space-between;padding:6px 10px;
@@ -248,7 +248,7 @@ _QUICK_HTML = r"""<!doctype html><html><head><meta charset="utf-8">
   document.write('<link rel="stylesheet" href="' + window.__base + '/_ds/plugin-kit.css">');
 </script>
 <style>
-  html,body{margin:0;height:100%;background:var(--pl-color-bg);color:var(--pl-color-fg);
+  html,body{margin:0;height:100%;background:var(--pl-color-bg-raised);color:var(--pl-color-fg);
     font-family:var(--pl-font-sans,ui-sans-serif,system-ui,sans-serif)}
   #wrap{display:flex;flex-direction:column;height:100%}
   #bar{padding:6px 10px;border-bottom:var(--pl-border-width,1px) solid var(--pl-color-border);


### PR DESCRIPTION
A console UI pass — one regression fix plus surface-color + theming fixes. Live-verified on the isolated dev instance (`scripts/dev.sh`).

## Settings rail (regression)
The 2026-06-18 IA pass made Workspace settings a rail surface (`id: "settings"`) and added it to the **default** `railOrder`, but never migrated **existing** persisted layouts — and `railSurfaces()` only renders ids already in `railOrder` (no re-add for a missing core surface). So anyone with a layout saved before the pass lost the Settings icon (only the Global overlay remained). Adds a **v9 persist migration** that re-adds `settings` (after `plugins`) to any layout lacking it — mirrors the existing `schedule` re-add — + version bump + 3 tests.

## Surface colors
- **Notes/Docs views**: page bg was `--pl-color-bg` (deepest ground) → `--pl-color-bg-raised` so they match the chat/panel surface.
- **Bottom-dock tab strip**: the rule only targeted `.pl-appshell__col`; the bottom dock (`.pl-appshell__bottom`) fell through to the dark ground — now matched too.
- **Reasoning + Select** read too dark: interim local overrides to `--pl-color-bg-subtle`, pending DS fixes — **protoContent#273** (Reasoning variant) and **protoContent#274** (token-driven Select popover).

## Accent-themed brand marks
`ProtoLabsIcon` gains a `tone` prop. `tone="accent"` follows the live theme accent (`--pl-color-accent`): the header mark recolors with it (solid), and the splash + boot-gate marks get an accent-derived light→dark gradient. The DS neon glow already keys to `--pl-color-accent`, so mark + glow now cohere. Default `tone="lavender"` leaves other usages untouched. Header swapped off the flat `<img>` Logo to the inline mark (dropped the unused `Logo` import).

## Live plugin-iframe re-theme
`PluginView` only handed the iframe its theme on load, so a theme/accent change never reached an open plugin panel until a reload — even though `watchThemeChanges()` fires a `protoagent:theme` window event and the iframe's plugin-kit handles it. Adds the missing listener: re-post the fresh `consoleTheme()` to the mounted iframe on every theme change, so Notes/Docs repaint live.

## Verification
ruff clean · pytest 44 (notes/docs/plugins) · vitest 102 (incl. 3 new migration tests) · web build/typecheck clean · eyeballed on `:7871` (settings back, surfaces, accent marks + glow, live re-theme).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Plugins now support live theme updates after loading
  * Settings rail is automatically restored to users' layouts that were missing it

* **Bug Fixes**
  * Improved visual contrast for reasoning and select dropdown elements
  * Enhanced tabbed panel visual integration with card surfaces

* **Chores**
  * Updated branding icon styling and background colors across plugins for consistency

<!-- end of auto-generated comment: release notes by coderabbit.ai -->