### PR TITLE
docs(readme): correct the release-pipeline trigger — manual, not on-merge

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,9 +218,11 @@ The included GitHub Actions pipeline is optional but opinionated.
 - **On every merge to `main`** → `docker-publish.yml` builds and
   pushes `ghcr.io/protolabsai/<image>:latest` + `sha-<short>`.
   Watchtower (or similar) can poll `latest` for auto-deploy.
-- **When a non-release PR merges** → `prepare-release.yml` opens a
-  "chore: release vX.Y.Z" bump PR, auto-merges it, and pushes a
-  semver tag.
+- **To cut a release** → run `prepare-release.yml` manually
+  (`workflow_dispatch`, gated on the `RELEASE_ENABLED` repo var, with a
+  patch/minor/major bump input). It opens a "chore: release vX.Y.Z" bump
+  PR, auto-merges it, and pushes a semver tag. Releases are on-demand, not
+  per-merge.
 - **When a semver tag lands** → `release.yml` builds and pushes
   the stable semver Docker tags, creates a GitHub release with
   filtered notes, and posts a Discord embed via the shared


### PR DESCRIPTION
The README's "Release pipeline" section claimed `prepare-release.yml` opens a bump PR *"when a non-release PR merges."* It's actually **`workflow_dispatch` only** (gated on the `RELEASE_ENABLED` repo var) with a patch/minor/major bump input — releases are cut **on-demand, not per-merge**. Only `docker-publish.yml` runs on every merge.

Slipped through the #1210 audit (the correct on-merge docker bullet next to it read as fine). One-line factual fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)