### PR TITLE
feat(web): adopt @protolabsai/ui 0.45.0 — Reasoning surface + DropdownSelect

### DIFF
--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -41,6 +41,9 @@ test("Add opens a type picker and a schema-driven form", async ({ page }) => {
   // The coding-agent preset picker (from the canonical /api/acp-agents catalog) fills
   // Command + Args when an agent is chosen.
   await expect(panel.locator("#acp-preset")).toBeVisible();
-  await panel.locator("#acp-preset").selectOption("claude");
+  // DropdownSelect (#274): open the trigger, then pick the portaled menu item (rendered at
+  // document.body, so it's page-scoped, not inside `panel`).
+  await panel.locator("#acp-preset").click();
+  await page.getByRole("menuitemradio", { name: "Claude Code" }).click();
   await expect(panel.locator("#del-command")).toHaveValue("npx");
 });

--- a/apps/web/e2e/schedule.spec.ts
+++ b/apps/web/e2e/schedule.spec.ts
@@ -26,7 +26,9 @@ test("repeat presets build cron with a plain-English preview", async ({ page }) 
   await expect(preview).toContainText("every day at");
   await expect(preview.locator("code")).toContainText("0 9 * * *");
   // switch to weekdays
-  await page.getByTestId("schedule-freq").selectOption("weekdays");
+  // DropdownSelect (#274): open the trigger, then pick the portaled menu item.
+  await page.locator("#schedule-freq").click();
+  await page.getByRole("menuitemradio", { name: "Every weekday" }).click();
   await expect(preview).toContainText("every weekday at");
   await expect(preview.locator("code")).toContainText("* * 1-5");
 });

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.44.2",
+    "@protolabsai/ui": "^0.45.0",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/apps/web/src/app/BeadsPanel.tsx
+++ b/apps/web/src/app/BeadsPanel.tsx
@@ -1,4 +1,4 @@
-import { Input, Select } from "@protolabsai/ui/forms";
+import { DropdownSelect, Input } from "@protolabsai/ui/forms";
 import { Button, Empty } from "@protolabsai/ui/primitives";
 import {
   QueryErrorResetBoundary,
@@ -115,27 +115,29 @@ function BeadsBody({ confirm }: { confirm: (req: ConfirmRequest) => void }) {
           Add
         </Button>
         <div className="issue-create-meta">
-          <Select
+          <DropdownSelect
             value={draft.type}
-            onChange={(event) => setDraft((d) => ({ ...d, type: event.target.value }))}
+            onValueChange={(v) => setDraft((d) => ({ ...d, type: v }))}
             aria-label="Issue type"
-          >
-            <option value="task">task</option>
-            <option value="bug">bug</option>
-            <option value="feature">feature</option>
-            <option value="chore">chore</option>
-          </Select>
-          <Select
-            value={draft.priority}
-            onChange={(event) => setDraft((d) => ({ ...d, priority: Number(event.target.value) }))}
+            options={[
+              { value: "task", label: "task" },
+              { value: "bug", label: "bug" },
+              { value: "feature", label: "feature" },
+              { value: "chore", label: "chore" },
+            ]}
+          />
+          <DropdownSelect
+            value={String(draft.priority)}
+            onValueChange={(v) => setDraft((d) => ({ ...d, priority: Number(v) }))}
             aria-label="Issue priority"
-          >
-            <option value={0}>P0</option>
-            <option value={1}>P1</option>
-            <option value={2}>P2</option>
-            <option value={3}>P3</option>
-            <option value={4}>P4</option>
-          </Select>
+            options={[
+              { value: "0", label: "P0" },
+              { value: "1", label: "P1" },
+              { value: "2", label: "P2" },
+              { value: "3", label: "P3" },
+              { value: "4", label: "P4" },
+            ]}
+          />
           <Input
             value={draft.description}
             onChange={(event) => setDraft((d) => ({ ...d, description: event.target.value }))}

--- a/apps/web/src/app/McpPanel.tsx
+++ b/apps/web/src/app/McpPanel.tsx
@@ -1,4 +1,4 @@
-import { Input, Select, Textarea } from "@protolabsai/ui/forms";
+import { DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
@@ -93,11 +93,16 @@ function AddServerForm({ onDone }: { onDone: (msg: string) => void }) {
         <>
           <div className="mcp-add-row">
             <Input className="playbook-search" placeholder="name (e.g. echo)" value={name} onChange={(e) => setName(e.target.value)} />
-            <Select className="playbook-search" value={transport} onChange={(e) => setTransport(e.target.value as Transport)}>
-              <option value="stdio">stdio</option>
-              <option value="http">http</option>
-              <option value="sse">sse</option>
-            </Select>
+            <DropdownSelect
+              className="playbook-search"
+              value={transport}
+              onValueChange={(v) => setTransport(v as Transport)}
+              options={[
+                { value: "stdio", label: "stdio" },
+                { value: "http", label: "http" },
+                { value: "sse", label: "sse" },
+              ]}
+            />
           </div>
           {transport === "stdio" ? (
             <div className="mcp-add-row">

--- a/apps/web/src/app/PaletteChat.tsx
+++ b/apps/web/src/app/PaletteChat.tsx
@@ -182,7 +182,7 @@ export function PaletteChat({ agentName }: { agentName: string }) {
                   ))}
                 </div>
               ) : null}
-              {m.reasoning ? <Reasoning streaming={isStreaming && !m.content}>{m.reasoning}</Reasoning> : null}
+              {m.reasoning ? <Reasoning surface="subtle" streaming={isStreaming && !m.content}>{m.reasoning}</Reasoning> : null}
               {m.toolCalls && m.toolCalls.length ? <ToolCalls calls={m.toolCalls} /> : null}
               {m.content ? (
                 <Markdown>{m.content}</Markdown>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -492,24 +492,6 @@
   border-top-right-radius: 0;
 }
 
-/* ── Interim DS-component surface overrides ──────────────────────────────────────
-   Two DS surfaces read too dark in our console. These are LOCAL interim overrides
-   (theme.css loads after @protolabsai/ui/styles.css, so same-specificity rules win)
-   pending DS-side fixes — drop them once those land.
-
-   Reasoning (chat): the DS uses --pl-color-bg-inset (#060608, BELOW the page), so the
-   block reads as a dark hole on the chat panel. Lift it to the subtle raised surface so
-   it reads as a distinct "thinking" block. See protoContent#273. */
-.pl-reasoning {
-  background: var(--pl-color-bg-subtle);
-}
-/* Select: the DS closed control uses --pl-color-bg-raised — the SAME color as the panel
-   it sits on, so it disappears. Lift to the subtle surface for contrast. (The OPEN native
-   <select> menu is OS-rendered and can't be themed from CSS — that's protoContent#274.) */
-.pl-select {
-  background: var(--pl-color-bg-subtle);
-}
-
 /* Settings panel: header · category sub-nav · scrolling body (ADR 0020). The
    sub-nav is its own auto row so it doesn't land in the 1fr content row and
    overlap the fields. */

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1016,7 +1016,7 @@ function ChatSessionSlot({
               {message.reasoning ? (
                 // Collapsible "thinking" — open while the model is still reasoning
                 // (no answer text yet), auto-collapses once the answer starts.
-                <Reasoning streaming={message.status === "streaming" && !message.content}>
+                <Reasoning surface="subtle" streaming={message.status === "streaming" && !message.content}>
                   {message.reasoning}
                 </Reasoning>
               ) : null}

--- a/apps/web/src/chat/HitlForm.tsx
+++ b/apps/web/src/chat/HitlForm.tsx
@@ -1,5 +1,5 @@
 import "./hitl.css";
-import { Checkbox, Input, Select, Textarea } from "@protolabsai/ui/forms";
+import { Checkbox, DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
 import { useState } from "react";
 
@@ -59,16 +59,12 @@ function Field({
   let control;
   if (Array.isArray(schema.enum)) {
     control = (
-      <Select value={String(value ?? "")} onChange={(e) => onChange(e.target.value)}>
-        <option value="" disabled>
-          Select…
-        </option>
-        {schema.enum.map((opt) => (
-          <option key={String(opt)} value={String(opt)}>
-            {String(opt)}
-          </option>
-        ))}
-      </Select>
+      <DropdownSelect
+        value={String(value ?? "")}
+        onValueChange={(v) => onChange(v)}
+        placeholder="Select…"
+        options={schema.enum.map((opt) => ({ value: String(opt), label: String(opt) }))}
+      />
     );
   } else if (schema.type === "number" || schema.type === "integer") {
     control = (

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -1,6 +1,6 @@
 import "./schedule.css";
 
-import { Input, Select, Textarea } from "@protolabsai/ui/forms";
+import { DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
 import { Dialog } from "@protolabsai/ui/overlays";
 import {
@@ -111,19 +111,26 @@ function ScheduleModal({
           <div className="schedule-repeat">
             <label className="field">
               <span>Frequency</span>
-              <Select value={freq} onChange={(e) => setFreq(e.target.value as RepeatFreq)} data-testid="schedule-freq">
-                <option value="hourly">Every hour</option>
-                <option value="daily">Every day</option>
-                <option value="weekdays">Every weekday (Mon–Fri)</option>
-                <option value="weekly">Every week</option>
-              </Select>
+              <DropdownSelect
+                id="schedule-freq"
+                value={freq}
+                onValueChange={(v) => setFreq(v as RepeatFreq)}
+                options={[
+                  { value: "hourly", label: "Every hour" },
+                  { value: "daily", label: "Every day" },
+                  { value: "weekdays", label: "Every weekday (Mon–Fri)" },
+                  { value: "weekly", label: "Every week" },
+                ]}
+              />
             </label>
             {freq === "weekly" && (
               <label className="field">
                 <span>Day</span>
-                <Select value={dow} onChange={(e) => setDow(Number(e.target.value))}>
-                  {WEEKDAYS.map((d, i) => <option key={i} value={i}>{d}</option>)}
-                </Select>
+                <DropdownSelect
+                  value={String(dow)}
+                  onValueChange={(v) => setDow(Number(v))}
+                  options={WEEKDAYS.map((d, i) => ({ value: String(i), label: d }))}
+                />
               </label>
             )}
             <label className="field">
@@ -144,10 +151,12 @@ function ScheduleModal({
         {mode !== "once" && (
           <label className="field">
             <span>Timezone</span>
-            <Select value={tz} onChange={(e) => setTz(e.target.value)} data-testid="schedule-tz">
-              <option value="">UTC (default)</option>
-              {tzOptions.map((z) => <option key={z} value={z}>{z}</option>)}
-            </Select>
+            <DropdownSelect
+              id="schedule-tz"
+              value={tz}
+              onValueChange={(v) => setTz(v)}
+              options={[{ value: "", label: "UTC (default)" }, ...tzOptions.map((z) => ({ value: z, label: z }))]}
+            />
           </label>
         )}
 

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -1,7 +1,7 @@
 import "./settings.css";
 import "./delegates.css";
 
-import { Input, RadioCard, RadioCardGroup, Select, Textarea } from "@protolabsai/ui/forms";
+import { DropdownSelect, Input, RadioCard, RadioCardGroup, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 
 import { StatusDot } from "@protolabsai/ui/data";
@@ -257,21 +257,19 @@ function DelegateForm({
       {type === "acp" && (acpAgents.data?.agents?.length ?? 0) > 0 ? (
         <label className="field">
           <span>Coding agent</span>
-          <Select
+          <DropdownSelect
             id="acp-preset"
             value={preset}
-            onChange={(e) => {
-              const id = e.target.value;
+            onValueChange={(id) => {
               setPreset(id);
               const a = acpAgents.data?.agents.find((x) => x.id === id);
               if (a) setVals((m) => ({ ...m, command: a.command, args: a.args.join(" ") }));
             }}
-          >
-            <option value="">Custom / pick a preset…</option>
-            {acpAgents.data?.agents.map((a) => (
-              <option key={a.id} value={a.id}>{a.label}</option>
-            ))}
-          </Select>
+            options={[
+              { value: "", label: "Custom / pick a preset…" },
+              ...(acpAgents.data?.agents.map((a) => ({ value: a.id, label: a.label })) ?? []),
+            ]}
+          />
           <small className="delegate-field-help">
             Pre-fills the launch fields below for a known coding agent. Claude Code needs the
             adapter (<code>npm i -g @agentclientprotocol/claude-agent-acp</code>).
@@ -320,9 +318,12 @@ function DelegateField({
   let control: React.ReactNode;
   if (field.kind === "select" && field.options.length) {
     control = (
-      <Select {...common}>
-        {field.options.map((o) => <option key={o} value={o}>{o || "(none)"}</option>)}
-      </Select>
+      <DropdownSelect
+        id={`del-${field.key}`}
+        value={value}
+        onValueChange={onChange}
+        options={field.options.map((o) => ({ value: o, label: o || "(none)" }))}
+      />
     );
   } else if (field.kind === "textarea") {
     control = <Textarea rows={3} placeholder={field.placeholder} {...common} />;

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -1,7 +1,7 @@
 import "./settings.css";
 
 import { Alert } from "@protolabsai/ui/data";
-import { Combobox, Input, Select, Switch, Textarea } from "@protolabsai/ui/forms";
+import { Combobox, DropdownSelect, Input, Switch, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Loader2, RotateCcw, Save } from "lucide-react";
@@ -430,9 +430,13 @@ export function SettingInput({ field, value, onChange }: { field: SettingsField;
   }
   if (field.type === "select" && field.options.length) {
     return (
-      <Select id={id} className="setting-input" value={String(value ?? "")} onChange={(e) => onChange(e.target.value)}>
-        {field.options.map((opt) => <option key={opt} value={opt}>{opt}</option>)}
-      </Select>
+      <DropdownSelect
+        id={id}
+        className="setting-input"
+        value={String(value ?? "")}
+        onValueChange={(v) => onChange(v)}
+        options={field.options.map((opt) => ({ value: opt, label: opt }))}
+      />
     );
   }
   // A string_list backed by gateway options (e.g. routing.fallback_models)

--- a/apps/web/src/setup/SetupWizard.tsx
+++ b/apps/web/src/setup/SetupWizard.tsx
@@ -1,5 +1,5 @@
 import { useQuery } from "@tanstack/react-query";
-import { Field, FormField, Input, RadioCard, RadioCardGroup, Select, Textarea } from "@protolabsai/ui/forms";
+import { DropdownSelect, Field, FormField, Input, RadioCard, RadioCardGroup, Textarea } from "@protolabsai/ui/forms";
 import { Button, Callout } from "@protolabsai/ui/primitives";
 import { Alert, Spinner } from "@protolabsai/ui/data";
 import {
@@ -498,14 +498,11 @@ export function SetupWizard({
                     </>
                   }
                 >
-                  <Select
+                  <DropdownSelect
                     value={state.acpAgent}
-                    onChange={(event) => update({ acpAgent: event.target.value })}
-                  >
-                    {acpAgentList.map((a) => (
-                      <option key={a.id} value={a.id}>{a.label}</option>
-                    ))}
-                  </Select>
+                    onValueChange={(v) => update({ acpAgent: v })}
+                    options={acpAgentList.map((a) => ({ value: a.id, label: a.label }))}
+                  />
                 </FormField>
               ) : (
                 <>

--- a/apps/web/src/workflows/WorkflowBuilder.tsx
+++ b/apps/web/src/workflows/WorkflowBuilder.tsx
@@ -1,4 +1,4 @@
-import { Checkbox, Input, Select, Textarea } from "@protolabsai/ui/forms";
+import { Checkbox, DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
 import { Loader2, Plus, Save, Trash2, X } from "lucide-react";
 
@@ -147,13 +147,11 @@ export function WorkflowBuilder({
                 placeholder="step id"
                 onChange={(e) => setStep(i, { id: e.target.value })}
               />
-              <Select value={step.subagent} onChange={(e) => setStep(i, { subagent: e.target.value })}>
-                {(subagents.length ? subagents : [fallback]).map((s) => (
-                  <option key={s} value={s}>
-                    {s}
-                  </option>
-                ))}
-              </Select>
+              <DropdownSelect
+                value={step.subagent}
+                onValueChange={(v) => setStep(i, { subagent: v })}
+                options={(subagents.length ? subagents : [fallback]).map((s) => ({ value: s, label: s }))}
+              />
               {steps.length > 1 && (
                 <Button icon variant="ghost" type="button" onClick={() => removeStep(i)} title="Remove step">
                   <Trash2 size={14} />

--- a/apps/web/src/workflows/WorkflowsSurface.tsx
+++ b/apps/web/src/workflows/WorkflowsSurface.tsx
@@ -1,6 +1,6 @@
 import "./workflows.css";
 
-import { Input, Select } from "@protolabsai/ui/forms";
+import { DropdownSelect, Input } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
 import {
   useMutation,
@@ -120,13 +120,11 @@ function WorkflowsBody() {
             ) : (
               <label className="field">
                 <span>Recipe</span>
-                <Select value={selectedName} onChange={(event) => selectRecipe(event.target.value)}>
-                  {workflows.map((w) => (
-                    <option key={w.name} value={w.name}>
-                      {w.name}
-                    </option>
-                  ))}
-                </Select>
+                <DropdownSelect
+                  value={selectedName}
+                  onValueChange={(v) => selectRecipe(v)}
+                  options={workflows.map((w) => ({ value: w.name, label: w.name }))}
+                />
               </label>
             )}
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.44.2",
+        "@protolabsai/ui": "^0.45.0",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.44.2",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.44.2.tgz",
-      "integrity": "sha512-pXbTYy++eUaaMPUCAFGqtpvBt2G+zh6+iqTe7pGPHfRwWrLZ4vyAdI+yfxXo/Ucy4NXKU+TSa/Eb5NuwwXE/6A==",
+      "version": "0.45.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.45.0.tgz",
+      "integrity": "sha512-usfE5Ne7f7L3u4H0+P9S9IPf+J/nrWYbAoqWRjsHf0nKnjjTcU7a86S0M726mcAuQotiJCe3kNjop7kqrWfUgg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
The DS shipped the two gaps filed during the styling pass — **protoContent #275** (closing #273/#274). This adopts them and removes the interim local overrides.

## Changes
- **Bump** `@protolabsai/ui` `^0.44.2` → `^0.45.0`.
- **Reasoning** → `surface="subtle"` (chat + palette): the "thinking" block now sits at a raised tier instead of the DS-default inset (which read as a dark hole on the chat panel). Replaces the interim `.pl-reasoning` override.
- **Select → DropdownSelect** across **all 13 native selects (9 files)**: Delegates, Settings, Schedule, MCP, Beads, HITL, SetupWizard, WorkflowBuilder, WorkflowsSurface. `DropdownSelect`'s option list is a Radix-portaled `.pl-menu` popover, so the **open** menu finally follows the theme (native `<select>`'s open menu is OS-drawn and can't be). Replaces the interim `.pl-select` override.
- **Remove** both interim overrides from `theme.css`.
- **e2e**: the two specs driving a native select (`schedule-freq`, `acp-preset`) now open the DropdownSelect trigger and click the portaled `menuitemradio` (data-testid → trigger `id`; the menu renders at `document.body`, so it's page-scoped).

## Verification
web build/typecheck clean · vitest 102 · **full e2e 110 passed**.

Follow-up to #1211 (which shipped the interim overrides). Closes the loop on protoContent #273/#274.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced dropdown component interactions across settings, scheduling, delegates, and workflow configuration.

* **Style**
  * Removed interim styling overrides for cleaner, more consistent visual presentation.

* **Chores**
  * Updated UI library dependency to ^0.45.0 for improved component compatibility.

* **Tests**
  * Updated end-to-end tests to reflect new dropdown interaction patterns.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->