### PR TITLE
feat(web): console IA pass — Work hub, Plugins-in-Settings, single-header utility dialogs

### DIFF
--- a/apps/web/e2e/chat-bottom-dock.spec.ts
+++ b/apps/web/e2e/chat-bottom-dock.spec.ts
@@ -11,8 +11,8 @@ test("chat docks at the bottom and survives a bottom-dock surface switch", async
   const leftRail = page.locator(".pl-rail:not(.pl-rail--right):not(.pl-rail--bottom)");
   const bottomRail = page.locator(".pl-rail--bottom");
 
-  // Put a second surface AND chat on the bottom dock, so the dock can switch between them.
-  await rightRail.getByRole("button", { name: "Beads", exact: true }).click({ button: "right" });
+  // Put a second surface (Work) AND chat on the bottom dock, so the dock can switch between them.
+  await rightRail.getByRole("button", { name: "Work", exact: true }).click({ button: "right" });
   await page.locator(".pl-menu").getByText("Move to bottom dock").click();
   await leftRail.getByRole("button", { name: "Chat", exact: true }).click({ button: "right" });
   await page.locator(".pl-menu").getByText("Move to bottom dock").click();
@@ -28,8 +28,8 @@ test("chat docks at the bottom and survives a bottom-dock surface switch", async
   await composer.press("Enter");
   await expect(page.locator(".pl-message--user")).toHaveText(/remember this message/);
 
-  // Switch the bottom dock to Beads → chat hides but stays mounted (slot, not torn down).
-  await bottomRail.getByRole("button", { name: "Beads", exact: true }).click();
+  // Switch the bottom dock to Work → chat hides but stays mounted (slot, not torn down).
+  await bottomRail.getByRole("button", { name: "Work", exact: true }).click();
   await expect(page.locator(".chat-stage")).toHaveCount(1); // still in the DOM
   await expect(page.locator(".chat-stage")).not.toBeVisible(); // just hidden
 

--- a/apps/web/e2e/chat-continuity.spec.ts
+++ b/apps/web/e2e/chat-continuity.spec.ts
@@ -19,7 +19,7 @@ test("conversation survives navigating away and back (surface stays mounted)", a
 
   // Leave the Chat tab → the chat surface is hidden but still mounted in the DOM
   // (not unmounted), so its state + any in-flight stream are preserved.
-  await rail(page, "Schedule");
+  await rail(page, "Knowledge");
   await expect(page.locator(".chat-stage")).toHaveCount(1); // still in the DOM
   await expect(page.locator(".chat-stage")).not.toBeVisible(); // just hidden
   await expect(page.locator(".pl-message--user")).toHaveCount(1); // message not lost
@@ -44,7 +44,7 @@ test("tool-call cards survive navigating away and back", async ({ page }) => {
   await expect(card.locator(".pl-toolcard__name")).toHaveText("web_search");
 
   // Leave and return — the tool card must still be there (not torn down).
-  await rail(page, "Schedule");
+  await rail(page, "Knowledge");
   await expect(page.locator(".pl-toolcard")).toHaveCount(1); // still in the DOM while away
   await rail(page, "Chat");
   await expect(page.locator(".pl-toolcard").first().locator(".pl-toolcard__name")).toHaveText("web_search");

--- a/apps/web/e2e/chat-slot.spec.ts
+++ b/apps/web/e2e/chat-slot.spec.ts
@@ -54,7 +54,7 @@ test("a slot claimant stays mounted across surface switches (#613 contract)", as
 
   // Switch away — a NORMAL plugin view would unmount (plugin-views.spec asserts
   // count 0); the slot claimant must stay in the DOM, merely hidden.
-  await page.locator(".pl-rail").getByRole("button", { name: "Schedule", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Knowledge", exact: true }).click();
   await expect(slotFrame).toHaveCount(1);
   await expect(slotFrame).toBeHidden();
 

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -24,24 +24,37 @@ test("Studio lands directly on Workflows (Run tab removed — run is a chat gest
   await expect(page.locator(".pl-tabs").getByRole("tab", { name: "Run", exact: true })).toHaveCount(0);
 });
 
-test("schedule is a top-level rail surface that lists scheduled jobs", async ({ page }) => {
-  await page.locator(".pl-rail").getByRole("button", { name: "Schedule", exact: true }).click();
+// The Work hub (2026-06) consolidates the former Beads / Goals / Schedule rail surfaces
+// into one right-rail "Work" surface with Overview · Goals · Tasks · Schedule tabs.
+// Work is the default-active right panel, so it's already open — clicking its rail icon
+// when active would TOGGLE it closed, so only click when it's not the active surface.
+// In the narrow right panel the DS responsive Tabs collapse the role="tab" strip into a
+// native <select.pl-tabs__select>; pick the tab through it.
+const TAB_VALUE: Record<string, string> = { Overview: "overview", Goals: "goals", Tasks: "tasks", Schedule: "schedule" };
+async function openWorkTab(page, tab: string) {
+  const workBtn = page.locator(".pl-rail--right").getByRole("button", { name: "Work", exact: true });
+  const cls = (await workBtn.getAttribute("class")) ?? "";
+  if (!cls.includes("--active")) await workBtn.click();
+  await page.locator(".pl-tabs__select").first().selectOption(TAB_VALUE[tab]);
+}
+
+test("Work → Schedule tab lists scheduled jobs", async ({ page }) => {
+  await openWorkTab(page, "Schedule");
   await expect(page.getByRole("heading", { name: "Schedule" })).toBeVisible();
   await expect(page.getByText("Summarize overnight activity")).toBeVisible();
 });
 
-test("goals tab in the right sidebar lists active goals", async ({ page }) => {
-  // Goals moved out of Studio into the right sidebar (Notes / Beads / Goals).
-  await page.getByRole("button", { name: "Goals", exact: true }).click();
+test("Work → Goals tab lists active goals", async ({ page }) => {
+  // Goals folded into the Work hub's Goals tab (still renders the GoalsPanel verbatim).
+  await openWorkTab(page, "Goals");
   await expect(page.getByRole("heading", { name: "Goals" })).toBeVisible();
   await expect(page.getByText("All tests pass")).toBeVisible();
 });
 
-test("beads tab in the right sidebar lists issues (query-backed)", async ({ page }) => {
-  // Beads (TanStack Query / Suspense, ADR 0013) is the default-active right panel, and clicking an
-  // already-open panel now toggles it closed — so switch to Goals first, then back to Beads.
-  await page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true }).click();
-  await page.locator(".pl-rail--right").getByRole("button", { name: "Beads", exact: true }).click();
+test("Work → Tasks tab lists beads issues (query-backed)", async ({ page }) => {
+  // The tab is labeled "Tasks" but the panel content is still Beads (TanStack Query /
+  // Suspense, ADR 0013) — folded into the Work hub.
+  await openWorkTab(page, "Tasks");
   await expect(page.getByRole("heading", { name: "Beads" })).toBeVisible();
   await expect(page.getByText("Wire the telemetry rollup")).toBeVisible();
 });
@@ -61,7 +74,9 @@ test("workspace settings: identity lands, then tools and MCP sections", async ({
 });
 
 test("plugins section: Installed / Discover (config + advanced install folded in)", async ({ page }) => {
-  await page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true }).click();
+  // Plugins is a Settings section now (2026-06), not a standalone rail surface.
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "Plugins", exact: true }).click();
 
   // Two sections only now (ADR 0059 D4) — no separate "Install URL" tab.
   await expect(page.locator(".pl-tabs").getByRole("tab", { name: "Install URL", exact: true })).toHaveCount(0);
@@ -93,15 +108,16 @@ test("plugins section: Installed / Discover (config + advanced install folded in
 test("UI state persists across reload (ADR 0035 S1 — Zustand persist)", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 
-  // Move off the defaults: a left surface (Plugins) + a non-default right-panel tab (Goals — Beads
-  // is the default, and clicking the default-active one would toggle it closed).
-  await page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true }).click();
-  await page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true }).click();
+  // Move the left surface off its default (Chat) to Knowledge. Work is the default-active
+  // right panel (don't click it — that would toggle the panel closed). Both the moved-left
+  // surface and the open Work right panel should survive a reload via the persisted store.
+  await page.locator(".pl-rail").getByRole("button", { name: "Knowledge", exact: true }).click();
+  await expect(page.locator(".pl-rail--right").getByRole("button", { name: "Work", exact: true })).toHaveClass(/--active/);
 
-  // Reload — the persisted store restores both, instead of snapping back to Chat/Notes.
+  // Reload — the persisted store restores both, instead of snapping back to Chat.
   await page.reload({ waitUntil: "load" });
-  await expect(page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true })).toHaveClass(/active/);
-  await expect(page.locator(".pl-rail--right").getByRole("button", { name: "Goals", exact: true })).toHaveClass(/active/);
+  await expect(page.locator(".pl-rail").getByRole("button", { name: "Knowledge", exact: true })).toHaveClass(/--active/);
+  await expect(page.locator(".pl-rail--right").getByRole("button", { name: "Work", exact: true })).toHaveClass(/--active/);
 });
 
 
@@ -110,18 +126,18 @@ test("right-click a rail surface opens a context menu that moves it (ADR 0036)",
   const rightRail = page.locator(".pl-rail--right");
   const leftRail = page.locator(".pl-rail:not(.pl-rail--right)");
 
-  // Beads starts on the right rail.
-  await expect(rightRail.getByRole("button", { name: "Beads", exact: true })).toBeVisible();
+  // Work starts on the right rail.
+  await expect(rightRail.getByRole("button", { name: "Work", exact: true })).toBeVisible();
 
   // Right-click it → the context menu opens with the move item.
-  await rightRail.getByRole("button", { name: "Beads", exact: true }).click({ button: "right" });
+  await rightRail.getByRole("button", { name: "Work", exact: true }).click({ button: "right" });
   const menu = page.locator(".pl-menu");
   await expect(menu).toBeVisible();
   await menu.getByText("Move to left rail").click();
 
-  // Beads moved to the left rail (store-backed → persists, but checking the move is enough here).
-  await expect(leftRail.getByRole("button", { name: "Beads", exact: true })).toBeVisible();
-  await expect(rightRail.getByRole("button", { name: "Beads", exact: true })).toHaveCount(0);
+  // Work moved to the left rail (store-backed → persists, but checking the move is enough here).
+  await expect(leftRail.getByRole("button", { name: "Work", exact: true })).toBeVisible();
+  await expect(rightRail.getByRole("button", { name: "Work", exact: true })).toHaveCount(0);
 });
 
 test("Chat is movable too — right-click → move to the right rail (ADR 0036)", async ({ page }) => {
@@ -145,14 +161,15 @@ test("right-click → Move to bottom dock docks the surface at the bottom", asyn
   // The bottom rail exists as an (empty) drop target, but nothing is docked there by default.
   await expect(bottomRail.getByRole("button")).toHaveCount(0);
 
-  // Move Beads (right rail) → bottom dock.
-  await rightRail.getByRole("button", { name: "Beads", exact: true }).click({ button: "right" });
+  // Move Work (right rail) → bottom dock.
+  await rightRail.getByRole("button", { name: "Work", exact: true }).click({ button: "right" });
   await page.locator(".pl-menu").getByText("Move to bottom dock").click();
 
-  // Beads now lives in the (icon-only) bottom rail, off the right rail, and its panel opens.
-  await expect(bottomRail.getByRole("button", { name: "Beads", exact: true })).toBeVisible();
-  await expect(rightRail.getByRole("button", { name: "Beads", exact: true })).toHaveCount(0);
-  await expect(page.locator(".pl-appshell__bottom").getByRole("heading", { name: "Beads" })).toBeVisible();
+  // Work now lives in the (icon-only) bottom rail, off the right rail, and its panel opens.
+  await expect(bottomRail.getByRole("button", { name: "Work", exact: true })).toBeVisible();
+  await expect(rightRail.getByRole("button", { name: "Work", exact: true })).toHaveCount(0);
+  // Its panel renders — the Work hub's Tabs strip is present in the bottom dock.
+  await expect(page.locator(".pl-appshell__bottom .pl-tabs").getByRole("tab", { name: "Overview", exact: true })).toBeVisible();
 });
 
 test("mobile shell: bottom quick-bar + unified header drawer (ADR 0035 S4)", async ({ page }) => {
@@ -173,6 +190,6 @@ test("mobile shell: bottom quick-bar + unified header drawer (ADR 0035 S4)", asy
   await page.getByTestId("header-menu").click();
   const drawer = page.getByTestId("app-drawer");
   await expect(drawer).toBeVisible();
-  await drawer.getByRole("button", { name: "Beads", exact: true }).click();
+  await drawer.getByRole("button", { name: "Work", exact: true }).click();
   await expect(drawer).toHaveCount(0); // picking a surface closes the drawer
 });

--- a/apps/web/e2e/plugin-install.spec.ts
+++ b/apps/web/e2e/plugin-install.spec.ts
@@ -1,11 +1,12 @@
 import { expect, test } from "@playwright/test";
 
-// Console Plugins section — install a plugin from a git URL in the dedicated
-// Plugins rail section; the installed list round-trips install → uninstall.
+// Console Plugins manager (Settings ▸ Plugins, 2026-06) — install a plugin from a git
+// URL; the installed list round-trips install → uninstall.
 
 async function openPluginsPanel(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Plugins", exact: true }).click();
+  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "Plugins", exact: true }).click();
   // Install-from-URL is the advanced action under Installed (ADR 0059 D4) — expand it.
   await page.getByRole("button", { name: "Install from a git URL" }).click();
   await expect(page.getByRole("heading", { name: "Install from a git URL" })).toBeVisible();

--- a/apps/web/e2e/schedule.spec.ts
+++ b/apps/web/e2e/schedule.spec.ts
@@ -6,8 +6,13 @@ import { expect, test } from "@playwright/test";
 
 async function openScheduleModal(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  // Schedule is a top-level rail surface again.
-  await page.locator(".pl-rail").getByRole("button", { name: "Schedule", exact: true }).click();
+  // Schedule folded into the Work hub (2026-06): the right-rail Work surface, Schedule tab.
+  // Work is the default-active right panel; in the narrow panel the DS responsive Tabs
+  // collapse the role="tab" strip into a native <select.pl-tabs__select>.
+  const workBtn = page.locator(".pl-rail--right").getByRole("button", { name: "Work", exact: true });
+  const cls = (await workBtn.getAttribute("class")) ?? "";
+  if (!cls.includes("--active")) await workBtn.click();
+  await page.locator(".pl-tabs__select").first().selectOption("schedule");
   await page.getByTestId("schedule-new").click();
   await expect(page.getByTestId("schedule-modal")).toBeVisible();
 }

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -44,6 +44,7 @@ test("Workspace settings live in the rail (no scope toggle)", async ({ page }) =
   expect(await page.locator(".pl-sidenav").locator("button").allTextContents()).toEqual([
     "Identity",
     "Model & Routing",
+    "Plugins",
     "Tools",
     "MCP",
     "Subagents",
@@ -53,7 +54,6 @@ test("Workspace settings live in the rail (no scope toggle)", async ({ page }) =
     "Memory",
     "System",
     "Theme",
-    "Plugins",
   ]);
   await section(page, "System");
   await expect(page.locator(".pl-accordion__title").first()).toBeVisible();

--- a/apps/web/src/activity/ActivitySurface.tsx
+++ b/apps/web/src/activity/ActivitySurface.tsx
@@ -3,13 +3,12 @@ import "./activity.css";
 import { Empty } from "@protolabsai/ui/primitives";
 import { Clock, Inbox, MessageSquare, Users, Webhook, Zap } from "lucide-react";
 
-import { useEffect, useRef, useState } from "react";
+import { useCallback, useEffect, useRef, useState } from "react";
 
 import { Markdown } from "../chat/LazyMarkdown";
-import { RefreshButton } from "../app/ui-kit";
+import { useUtilityHeaderReload } from "../app/UtilityWidget";
 import { api } from "../lib/api";
 import { ago, errMsg } from "../lib/format";
-import { PanelHeader } from "@protolabsai/ui/navigation";
 import { onServerEvent } from "../lib/events";
 import type { ActivityEntry } from "../lib/types";
 
@@ -50,7 +49,7 @@ export function ActivitySurface() {
   const [error, setError] = useState<string | null>(null);
   const scrollRef = useRef<HTMLDivElement>(null);
 
-  async function load() {
+  const load = useCallback(async () => {
     setLoading(true);
     try {
       const r = await api.activity();
@@ -61,10 +60,13 @@ export function ActivitySurface() {
     } finally {
       setLoading(false);
     }
-  }
+  }, []);
   useEffect(() => {
     void load();
-  }, []);
+  }, [load]);
+
+  // The reload lives in the dialog header (UtilityWidget) — no second panel header here.
+  useUtilityHeaderReload(load, loading);
 
   // Live append: every completed Activity turn pushes `activity.message` with
   // the assistant text + provenance. Prepend (newest-first store order).
@@ -96,20 +98,13 @@ export function ActivitySurface() {
   const chronological = [...entries].reverse();
 
   return (
-    <section className="panel stage-panel" data-testid="activity-surface">
-      <PanelHeader
-        title="Activity"
-        kicker="what the agent did on its own — and why"
-        actions={<RefreshButton onClick={() => void load()} busy={loading} />}
-      />
-
-      <div className="stage-body activity-body">
-        {error ? (
-          <div className="activity-error" role="alert">
-            {error}
-          </div>
-        ) : null}
-        <div className="activity-feed" ref={scrollRef}>
+    <div className="activity-body util-dialog-fill" data-testid="activity-surface">
+      {error ? (
+        <div className="activity-error" role="alert">
+          {error}
+        </div>
+      ) : null}
+      <div className="activity-feed" ref={scrollRef}>
           {chronological.length === 0 && !loading ? (
             <Empty
               className="activity-empty"
@@ -125,8 +120,7 @@ export function ActivitySurface() {
               </div>
             </div>
           ))}
-        </div>
       </div>
-    </section>
+    </div>
   );
 }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -18,7 +18,6 @@ import {
   PanelRight,
   Plus,
   Puzzle,
-  Store,
   Save,
   Settings2,
   Sparkles,
@@ -86,7 +85,6 @@ import { HamburgerMenu } from "./HamburgerMenu";
 import { FleetSwitcher } from "./FleetSwitcher";
 import {
   useUI,
-  type PluginsTab,
   type RightPanel,
   type Surface,
 } from "../state/uiStore";
@@ -101,16 +99,12 @@ import { useIsMobile } from "../lib/useIsMobile";
 import { useActiveTheme } from "../lib/useActiveTheme";
 import { registeredSurfaces } from "../ext"; // build-time fork seam (ADR 0038 D3); also self-loads fork surfaces
 import { ContextMenuRenderer, openContextMenu } from "../contextMenu";
-import { Tabs } from "@protolabsai/ui/navigation";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { brandName } from "../lib/brand";
 import { onConnectionChange, onServerEvent, onTopic } from "../lib/events";
 import { useToast } from "@protolabsai/ui/overlays";
 import { StatusPill } from "./StatusPill";
-import { GoalsPanel } from "./GoalsPanel";
-import { BeadsPanel } from "./BeadsPanel";
-import { SchedulePanel } from "../schedule/SchedulePanel";
-import { PluginsSurface } from "../plugins/PluginsSurface";
+import { WorkPanel } from "./WorkPanel";
 import { SetupWizard } from "../setup/SetupWizard";
 import { hostRuntimeStatusQuery, runtimeStatusQuery } from "../lib/queries";
 import { buildViews } from "../lib/viewRegistry";
@@ -216,14 +210,6 @@ function useLocalStorageState(key: string, fallback: string) {
   return [value, setValue] as const;
 }
 
-// Adapt the app's sub-tab shape (Lucide icon *component* + optional badge) to the
-// DS `Tabs` `TabItem` (icon as a rendered ReactNode) — so call sites keep passing
-// `icon: SomeLucideIcon` while the strip renders through @protolabsai/ui.
-function toTab(t: { id: string; label: string; icon?: LucideIcon; badge?: ReactNode }) {
-  const Icon = t.icon;
-  return { id: t.id, label: t.label, icon: Icon ? <Icon size={15} /> : undefined, badge: t.badge };
-}
-
 export function App() {
   // Navigation/layout state lives in the persisted UI store (ADR 0035 D5) — a refresh
   // restores the active surface, sub-tabs, and right-panel width/collapse.
@@ -232,8 +218,6 @@ export function App() {
   // Background-streaming indicator for the Chat rail (narrow selector → only
   // re-renders when the boolean flips, not per token).
   const chatStreaming = useAnyChatStreaming();
-  const pluginsTab = useUI((s) => s.pluginsTab);
-  const setPluginsTab = useUI((s) => s.setPluginsTab);
   const setFleetStartNew = useUI((s) => s.setFleetStartNew);
   const rightPanel = useUI((s) => s.rightPanel);
   const setRightPanel = useUI((s) => s.setRightPanel);
@@ -551,23 +535,10 @@ export function App() {
 
   function renderSurface(id: string): ReactNode {
     switch (id) {
-      // Schedule is its own rail surface again (un-fold from #1075): cron triggers, but
-      // timed work earns a top-level rail rather than a tab buried in Activity.
-      case "schedule":
-        return <SchedulePanel />;
-      // The Agent surface folded into Settings ▸ Workspace (ADR 0048 S-C). Its tabs
-      // (Identity/Settings/Tools/MCP/Subagents/Skills/Middleware) are now Workspace
-      // sections in SettingsSurface.
-      case "plugins":
-        return (
-          <>
-            <Tabs responsive active={pluginsTab} onSelect={(t) => setPluginsTab(t as PluginsTab)} items={[
-              { id: "local", label: "Installed", icon: Boxes },
-              { id: "market", label: "Discover", icon: Store },
-            ].map(toTab)} />
-            <PluginsSurface tab={pluginsTab} />
-          </>
-        );
+      // The Work hub (2026-06) folds Goals + Tasks(Beads) + Schedule into one right-rail
+      // surface (Overview + tabs). It owns those three panels now — no standalone surfaces.
+      case "work":
+        return <WorkPanel confirm={setConfirmState} />;
       // Knowledge is the searchable Store; its Memory settings folded into
       // Settings ▸ Workspace ▸ Memory (ADR 0048 S-C).
       case "knowledge":
@@ -578,11 +549,6 @@ export function App() {
         return <SettingsSurface only="workspace" />;
       // Notes is now the first-party `notes` plugin (ADR 0034 S4) — rendered via the default
       // plugin-view case below, not a native surface.
-      case "beads":
-        return <BeadsPanel confirm={setConfirmState} />;
-      case "goals":
-        return <GoalsPanel />;
-      // "schedule" folded into the Activity surface as a 3rd tab (#1075) — no rail surface.
       default: {
         // Fork-contributed surface (src/ext seam, ADR 0038 D3) — rendered in-process.
         // Skip a requiresPlugin surface when its plugin is off (e.g. a stale saved order).

--- a/apps/web/src/app/UtilityWidget.tsx
+++ b/apps/web/src/app/UtilityWidget.tsx
@@ -1,15 +1,33 @@
-import { useState } from "react";
+import { createContext, useContext, useEffect, useState } from "react";
 import type { ReactNode } from "react";
 import { Dialog, Tooltip } from "@protolabsai/ui/overlays";
+import { RefreshButton } from "./ui-kit";
+
+// Lets a UtilityWidget's dialog BODY register an action (a reload button) into the dialog
+// HEADER — so the content can drop its own panel header and let its body fill the dialog
+// (no double header). No-op outside a UtilityWidget.
+const UtilityHeaderCtx = createContext<(n: ReactNode) => void>(() => {});
+
+/** Register a reload control in the enclosing UtilityWidget's dialog header. Pass a STABLE
+ *  `onClick` (e.g. a `useCallback` or a TanStack `refetch`) — the effect re-registers only
+ *  when `busy` flips, so an unstable handler would loop. No-op outside a UtilityWidget. */
+export function useUtilityHeaderReload(onClick: () => void, busy: boolean) {
+  const setAction = useContext(UtilityHeaderCtx);
+  useEffect(() => {
+    setAction(<RefreshButton onClick={onClick} busy={busy} />);
+    return () => setAction(null);
+  }, [setAction, onClick, busy]);
+}
 
 /**
  * A utility-bar WIDGET (2026-06 IA pass) — a pill in the bottom-left "widgets" cluster
  * that shows a hover info popover and opens its content in a dialog on click. The shared
- * shape behind the inbox and plugin-contributed utility views. Presentation only — the
- * host owns the badge, the hover info, and the dialog body.
+ * shape behind the inbox, activity, and plugin-contributed utility views. Presentation
+ * only — the host owns the badge, the hover info, and the dialog body.
  *
  * The dialog body mounts only while open (so the inbox / a plugin iframe loads on demand,
- * not on every render).
+ * not on every render). The body can register a reload into the dialog header via
+ * `useUtilityHeaderReload`, so it doesn't render a second (redundant) header of its own.
  */
 export function UtilityWidget({
   icon,
@@ -37,6 +55,9 @@ export function UtilityWidget({
   children: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
+  // A body-registered dialog-header action (e.g. a reload button). Reset on close so a
+  // stale action never lingers when the dialog re-opens.
+  const [headerAction, setHeaderAction] = useState<ReactNode>(null);
   const pill = (
     <button
       type="button"
@@ -61,12 +82,18 @@ export function UtilityWidget({
           open
           onClose={() => {
             setOpen(false);
+            setHeaderAction(null);
             onClose?.();
           }}
-          title={dialogTitle}
+          title={
+            <span className="util-dialog-title">
+              {dialogTitle}
+              {headerAction ? <span className="util-dialog-actions">{headerAction}</span> : null}
+            </span>
+          }
           width={dialogWidth}
         >
-          {children}
+          <UtilityHeaderCtx.Provider value={setHeaderAction}>{children}</UtilityHeaderCtx.Provider>
         </Dialog>
       ) : null}
     </>

--- a/apps/web/src/app/WorkPanel.tsx
+++ b/apps/web/src/app/WorkPanel.tsx
@@ -1,0 +1,165 @@
+import { useState, type ComponentProps, type ReactNode } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { Tabs } from "@protolabsai/ui/navigation";
+import { Boxes, CalendarClock, ChevronRight, LayoutDashboard, Target } from "lucide-react";
+import type { LucideIcon } from "lucide-react";
+
+import { StagePanel } from "./ErrorBoundary";
+import { GoalsPanel } from "./GoalsPanel";
+import { BeadsPanel } from "./BeadsPanel";
+import { SchedulePanel } from "../schedule/SchedulePanel";
+import { beadsIssuesQuery, goalsQuery, schedulesQuery } from "../lib/queries";
+import type { BeadsIssue, GoalState, ScheduledJob } from "../lib/types";
+
+import "./work.css";
+
+type WorkTab = "overview" | "goals" | "tasks" | "schedule";
+type Confirm = ComponentProps<typeof BeadsPanel>["confirm"];
+
+const TABS: { id: WorkTab; label: string; icon: LucideIcon }[] = [
+  { id: "overview", label: "Overview", icon: LayoutDashboard },
+  { id: "goals", label: "Goals", icon: Target },
+  { id: "tasks", label: "Tasks", icon: Boxes },
+  { id: "schedule", label: "Schedule", icon: CalendarClock },
+];
+
+/**
+ * The agent's WORK hub (2026-06) — one right-rail surface consolidating the three "what's
+ * the agent doing" panels: what it's steering toward (Goals), the concrete backlog
+ * (Tasks/Beads), and timed runs (Schedule), with a glanceable Overview roll-up on top. The
+ * Goals/Tasks/Schedule tabs reuse the standalone panels verbatim; only the Overview is new.
+ */
+export function WorkPanel({ confirm }: { confirm: Confirm }) {
+  const [tab, setTab] = useState<WorkTab>("overview");
+  return (
+    <>
+      <Tabs
+        responsive
+        active={tab}
+        onSelect={(t) => setTab(t as WorkTab)}
+        items={TABS.map((t) => ({ id: t.id, label: t.label, icon: <t.icon size={15} /> }))}
+      />
+      {tab === "overview" ? (
+        <StagePanel label="work" variant="side">
+          <WorkOverview onJump={setTab} />
+        </StagePanel>
+      ) : tab === "goals" ? (
+        <GoalsPanel />
+      ) : tab === "tasks" ? (
+        <BeadsPanel confirm={confirm} />
+      ) : (
+        <SchedulePanel />
+      )}
+    </>
+  );
+}
+
+const normStatus = (s: string | undefined) => (s ?? "").toLowerCase().replace(/[ _-]/g, "");
+
+function WorkOverview({ onJump }: { onJump: (t: WorkTab) => void }) {
+  const goals = useSuspenseQuery(goalsQuery()).data.goals;
+  const issues = useSuspenseQuery(beadsIssuesQuery()).data.issues;
+  const jobs = useSuspenseQuery(schedulesQuery()).data.jobs;
+
+  const activeGoals = goals.filter(
+    (g) => g.status !== "achieved" && g.status !== "failed" && !g.finished_at,
+  );
+  const ready = issues.filter((i) => normStatus(i.status) === "ready");
+  const inProgress = issues.filter((i) => normStatus(i.status) === "inprogress");
+  const upcoming = jobs
+    .filter((j) => j.enabled !== false && j.next_fire)
+    .sort((a, b) => ((a.next_fire ?? "") < (b.next_fire ?? "") ? -1 : 1))
+    .slice(0, 3);
+
+  return (
+    <div className="work-overview stage-body">
+      <OverviewCard
+        title="Goals"
+        count={activeGoals.length}
+        hint="active"
+        onOpen={() => onJump("goals")}
+        empty="No active goals — set one in chat with /goal …"
+      >
+        {activeGoals.slice(0, 4).map((g: GoalState) => (
+          <li className="work-row" key={g.session_id}>
+            <span className="work-row-title">{g.condition}</span>
+            <span className="work-row-meta">
+              {g.mode === "monitor" ? "monitor" : `${g.iteration ?? 0}/${g.max_iterations ?? "∞"}`}
+            </span>
+          </li>
+        ))}
+      </OverviewCard>
+
+      <OverviewCard
+        title="Tasks"
+        count={ready.length + inProgress.length}
+        hint={`${ready.length} ready · ${inProgress.length} in progress`}
+        onOpen={() => onJump("tasks")}
+        empty="No open tasks"
+      >
+        {[...inProgress, ...ready].slice(0, 5).map((i: BeadsIssue) => (
+          <li className="work-row" key={i.id}>
+            <span className="work-row-title">{i.title}</span>
+            <span className="work-row-meta">{i.id}</span>
+          </li>
+        ))}
+      </OverviewCard>
+
+      <OverviewCard
+        title="Next runs"
+        count={upcoming.length}
+        hint="scheduled"
+        onOpen={() => onJump("schedule")}
+        empty="Nothing scheduled"
+      >
+        {upcoming.map((j: ScheduledJob) => (
+          <li className="work-row" key={j.id}>
+            <span className="work-row-title">{j.prompt}</span>
+            <span className="work-row-meta">{whenLabel(j.next_fire)}</span>
+          </li>
+        ))}
+      </OverviewCard>
+    </div>
+  );
+}
+
+function OverviewCard({
+  title,
+  count,
+  hint,
+  onOpen,
+  empty,
+  children,
+}: {
+  title: string;
+  count: number;
+  hint?: string;
+  onOpen: () => void;
+  empty: string;
+  children: ReactNode;
+}) {
+  return (
+    <section className="work-card">
+      <button type="button" className="work-card-head" onClick={onOpen}>
+        <span className="work-card-title">{title}</span>
+        <span className="work-card-count">
+          {count}
+          {hint ? <span className="work-card-hint"> · {hint}</span> : null}
+        </span>
+        <ChevronRight size={15} className="work-card-go" />
+      </button>
+      {count > 0 ? (
+        <ul className="work-card-body">{children}</ul>
+      ) : (
+        <p className="work-card-empty">{empty}</p>
+      )}
+    </section>
+  );
+}
+
+function whenLabel(iso?: string | null): string {
+  if (!iso) return "";
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return "";
+  return d.toLocaleString(undefined, { month: "short", day: "numeric", hour: "2-digit", minute: "2-digit" });
+}

--- a/apps/web/src/app/coreSurfaces.tsx
+++ b/apps/web/src/app/coreSurfaces.tsx
@@ -2,7 +2,7 @@
 // desktop quick-launcher (ADR 0057) build their command lists from the SAME source —
 // add a core surface here and it shows up in both the rail and ⌘K / the launcher.
 import type { ReactNode } from "react";
-import { BookMarked, Boxes, CalendarClock, MessageSquare, Puzzle, Settings2, Target } from "lucide-react";
+import { BookMarked, LayoutDashboard, MessageSquare, Settings2 } from "lucide-react";
 
 export type CoreSurface = { id: string; label: string; icon: ReactNode };
 
@@ -10,15 +10,10 @@ export type CoreSurface = { id: string; label: string; icon: ReactNode };
 // pinned + always mounted), but is a valid palette/launcher "go to" target.
 export const CORE_SURFACES: CoreSurface[] = [
   { id: "chat", label: "Chat", icon: <MessageSquare size={18} /> },
-  // Activity left the rail in the 2026-06 IA pass — it's a read-only utility-bar widget
-  // now (ActivityWidget, bottom-left widgets cluster).
-  { id: "schedule", label: "Schedule", icon: <CalendarClock size={18} /> },
-  // "studio" (Workflows) is contributed via src/ext/workflows.tsx, gated on the
-  // workflows plugin (lean core) — no longer a hardcoded core surface.
+  // The Work hub (2026-06) folds the former Beads / Goals / Schedule rail surfaces into one
+  // right-rail surface (Overview + Goals/Tasks/Schedule tabs). Activity is a utility-bar
+  // widget; "agent" folded into Settings ▸ Workspace; "plugins" into Settings ▸ Plugins.
+  { id: "work", label: "Work", icon: <LayoutDashboard size={18} /> },
   { id: "knowledge", label: "Knowledge", icon: <BookMarked size={18} /> },
-  // "agent" folded into Settings ▸ Workspace (ADR 0048 S-C) — no longer a rail surface.
-  { id: "plugins", label: "Plugins", icon: <Puzzle size={18} /> },
   { id: "settings", label: "Settings", icon: <Settings2 size={18} /> },
-  { id: "beads", label: "Beads", icon: <Boxes size={18} /> },
-  { id: "goals", label: "Goals", icon: <Target size={18} /> },
 ];

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -119,6 +119,30 @@
   color: var(--accent, #7c8cff);
 }
 
+/* Utility-widget dialog (2026-06): the body registers its reload into the dialog header
+   (UtilityWidget) and drops its own panel header, so the body fills the dialog — no double
+   header. `util-dialog-title` lays the title + the registered reload in the dialog header;
+   `util-dialog-fill` strips the inner card chrome and gives the body a usable height. */
+.util-dialog-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
+.util-dialog-actions {
+  display: inline-flex;
+  align-items: center;
+  margin: -6px 0; /* keep the icon button from inflating the header row */
+}
+.util-dialog-fill {
+  border: 0;
+  border-radius: 0;
+  background: transparent;
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+  height: min(60vh, 560px);
+}
+
 /* Background subagents (ADR 0050 Phase 3) — UtilityBar pill + jobs dialog. */
 .bg-jobs-pill {
   position: relative;

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -78,8 +78,11 @@ export function applyNavIntent(intent: NavIntent) {
       openView(intent.id);
       break;
     case "plugins":
-      ui.setSurface("plugins");
+      // Plugins is a Settings section now (2026-06), not a standalone rail surface —
+      // open Settings ▸ Plugins (the rail Settings surface is Workspace-only) on the tab.
       ui.setPluginsTab(intent.tab);
+      ui.setSettingsSection("plugins");
+      ui.setSurface("settings");
       break;
     case "global":
       ui.openGlobalSettings(intent.section);

--- a/apps/web/src/app/work.css
+++ b/apps/web/src/app/work.css
@@ -1,0 +1,83 @@
+/* Work hub Overview (2026-06) — three roll-up cards (Goals · Tasks · Next runs) that each
+   click through to their tab. The Goals/Tasks/Schedule tabs reuse the standalone panels, so
+   they bring their own styles; this is only the Overview dashboard. */
+.work-overview {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 12px;
+  overflow-y: auto;
+}
+
+.work-card {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: var(--bg-panel);
+  overflow: hidden;
+}
+
+.work-card-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 9px 12px;
+  border: 0;
+  background: none;
+  color: var(--fg);
+  cursor: pointer;
+  text-align: left;
+  font: inherit;
+}
+.work-card-head:hover {
+  background: var(--bg-hover, rgba(255, 255, 255, 0.03));
+}
+.work-card-title {
+  font-weight: 600;
+}
+.work-card-count {
+  margin-left: auto;
+  color: var(--fg-muted);
+  font-variant-numeric: tabular-nums;
+  font-size: 13px;
+}
+.work-card-hint {
+  color: var(--fg-muted);
+}
+.work-card-go {
+  color: var(--fg-muted);
+  flex: none;
+}
+
+.work-card-body {
+  list-style: none;
+  margin: 0;
+  padding: 0 12px 10px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.work-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 10px;
+  min-width: 0;
+}
+.work-row-title {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.work-row-meta {
+  flex: none;
+  color: var(--fg-muted);
+  font-size: 12px;
+}
+
+.work-card-empty {
+  margin: 0;
+  padding: 0 12px 10px;
+  color: var(--fg-muted);
+  font-size: 13px;
+}

--- a/apps/web/src/inbox/InboxPanel.tsx
+++ b/apps/web/src/inbox/InboxPanel.tsx
@@ -10,8 +10,7 @@ import { Check } from "lucide-react";
 import { useEffect, useState } from "react";
 
 import { StagePanel } from "../app/ErrorBoundary";
-import { RefreshButton } from "../app/ui-kit";
-import { PanelHeader } from "@protolabsai/ui/navigation";
+import { useUtilityHeaderReload } from "../app/UtilityWidget";
 import { api } from "../lib/api";
 import { onServerEvent } from "../lib/events";
 import { inboxQuery, queryKeys } from "../lib/queries";
@@ -52,15 +51,10 @@ function InboxBody({
     onMutate: (id) => onDismiss(id),
   });
 
-  return (
-    <>
-      <PanelHeader
-        compact
-        title="Inbox"
-        kicker={`${items.length} pending`}
-        actions={<RefreshButton onClick={() => void refetch()} busy={isFetching} />}
-      />
+  // The reload lives in the dialog header (UtilityWidget) — no second panel header here.
+  useUtilityHeaderReload(refetch, isFetching);
 
+  return (
       <div className="inbox-list">
         {items.length === 0 ? (
           <Empty
@@ -92,7 +86,6 @@ function InboxBody({
           </div>
         ))}
       </div>
-    </>
   );
 }
 
@@ -101,7 +94,7 @@ export function InboxPanel() {
   // the live-event refetch cycle (the inner body remounts on re-suspend).
   const [dismissed, setDismissed] = useState<Set<number>>(() => new Set());
   return (
-    <StagePanel label="inbox" variant="side" className="inbox-panel">
+    <StagePanel label="inbox" variant="side" className="inbox-panel util-dialog-fill">
       <InboxBody
         dismissed={dismissed}
         onDismiss={(id) => setDismissed((s) => new Set(s).add(id))}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Library, Network, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Wrench } from "lucide-react";
+import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Library, Network, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Store, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useState, type ReactNode } from "react";
 
@@ -11,6 +11,7 @@ import { MiddlewarePanel } from "../app/MiddlewarePanel";
 import { SubagentsPanel } from "../app/SubagentsPanel";
 import { ToolsPanel } from "../app/ToolsPanel";
 import { isHostConsole } from "../lib/api";
+import { PluginsSurface } from "../plugins/PluginsSurface";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
 import { useUI, type SettingsScope } from "../state/uiStore";
@@ -58,6 +59,7 @@ const WORKSPACE_SECTIONS: Section[] = [
   { id: "identity", label: "Identity", icon: Sparkles, render: () => <IdentityPanel /> },
   // id stays "settings" for persisted-section compat; the label is the un-nested name.
   { id: "settings", label: "Model & Routing", icon: Settings2, render: () => <SettingsCategoryPanel category="Agent" title="Model & Routing" /> },
+  { id: "plugins", label: "Plugins", icon: Puzzle, render: () => <PluginSettingsHome /> },
   { id: "tools", label: "Tools", icon: Wrench, render: () => <ToolsPanel /> },
   { id: "mcp", label: "MCP", icon: Plug, render: () => <McpPanel /> },
   { id: "subagents", label: "Subagents", icon: Bot, render: () => <SubagentsPanel /> },
@@ -70,34 +72,27 @@ const WORKSPACE_SECTIONS: Section[] = [
   { id: "memory", label: "Memory", icon: Database, render: () => <SettingsCategoryPanel category="Memory" title="Memory" /> },
   { id: "system", label: "System", icon: Settings2, render: () => <SettingsCategoryPanel category="System" title="System" /> },
   { id: "theme", label: "Theme", icon: Palette, render: () => <ThemeSurface /> },
-  {
-    id: "plugins",
-    label: "Plugins",
-    icon: Puzzle,
-    render: () => <PluginSettingsHome />,
-  },
 ];
 
-// ADR 0059 — per-plugin config now lives with each plugin in the Plugins panel
-// (Installed → Configure). This section just points there. (The delegate registry is
-// built-in core infrastructure, so it has its own top-level Workspace ▸ Delegates
-// section rather than living under Plugins.)
+// The Plugins manager (install · enable · configure, plus the Discover directory) lives
+// HERE in Settings ▸ Plugins — folded in from the former standalone rail surface (2026-06).
+// Per-plugin config is inline per row (ADR 0059); the delegate registry is built-in core
+// infrastructure with its own Workspace ▸ Delegates section.
 function PluginSettingsHome() {
-  const setSurface = useUI((s) => s.setSurface);
+  const pluginsTab = useUI((s) => s.pluginsTab);
   const setPluginsTab = useUI((s) => s.setPluginsTab);
-  const openPlugins = () => { setPluginsTab("local"); setSurface("plugins"); };
   return (
     <>
-      <PanelHeader title="Plugins" kicker="manage + configure in the Plugins panel" />
-      <div className="stage-body">
-        <p className="muted" style={{ marginTop: 0 }}>
-          Browse, install, enable, and <strong>configure</strong> plugins in the dedicated Plugins panel —
-          each installed plugin's settings now live with it (Installed → <strong>Configure</strong>).
-        </p>
-        <Button variant="primary" type="button" onClick={openPlugins}>
-          <Puzzle size={15} /> Open Plugins
-        </Button>
-      </div>
+      <Tabs
+        responsive
+        active={pluginsTab}
+        onSelect={(t) => setPluginsTab(t as "local" | "market")}
+        items={[
+          { id: "local", label: "Installed", icon: <Boxes size={15} /> },
+          { id: "market", label: "Discover", icon: <Store size={15} /> },
+        ]}
+      />
+      <PluginsSurface tab={pluginsTab} />
     </>
   );
 }

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -28,44 +28,28 @@ describe("migrateUiState", () => {
   // persisted railOrder rather than leaving a dead rail id with no surface metadata.
   it("prunes the obsolete 'box' rail surface", () => {
     const out = migrateUiState({
-      railOrder: { left: ["chat", "schedule", "plugins", "box", "settings"], right: ["beads"] },
+      railOrder: { left: ["chat", "knowledge", "box", "settings"], right: ["work"] },
     }) as { railOrder: { left: string[]; right: string[] } };
-    expect(out.railOrder.left).toEqual(["chat", "schedule", "plugins", "settings"]);
+    expect(out.railOrder.left).toEqual(["chat", "knowledge", "settings"]);
     expect(out.railOrder.left).not.toContain("box");
-    expect(out.railOrder.right).toEqual(["beads"]);
+    expect(out.railOrder.right).toEqual(["work"]);
   });
 
-  // v7: "schedule" is a top-level rail surface again (un-fold from #1075). A persisted
-  // layout that lost it (it was pruned/folded) gets it re-injected where "activity" was —
-  // then v8 prunes "activity" itself, leaving "schedule" in its place.
-  it("restores the 'schedule' rail surface to a layout that lacks it", () => {
-    const out = migrateUiState({
-      railOrder: { left: ["chat", "activity", "settings"], right: ["beads", "goals"] },
-    }) as { railOrder: { left: string[]; right: string[] } };
-    expect(out.railOrder.left).toEqual(["chat", "schedule", "settings"]);
-  });
-
-  // …but if the user keeps "schedule" on some dock already, don't duplicate it.
-  it("keeps a user-placed 'schedule' where it is", () => {
-    const out = migrateUiState({
-      railOrder: { left: ["chat", "activity", "settings"], right: ["beads", "goals", "schedule"] },
-    }) as { railOrder: { left: string[]; right: string[] } };
-    expect(out.railOrder.right).toContain("schedule");
-    expect(out.railOrder.left).not.toContain("schedule");
-  });
+  // (The v7 "restore schedule" behavior is gone: schedule folded into the Work hub in v11,
+  // which prunes it — so re-adding it would be undone. Covered by the v11 fold test below.)
 
   // v8 (2026-06 IA pass): Activity moved off the rail to a utility-bar widget. Prune
   // "activity" from every dock + the mobile quick-bar so it doesn't linger as a dead id.
   it("prunes 'activity' from the rails and quick-bar", () => {
     const out = migrateUiState({
-      // "settings" present so the v9 re-add below is a no-op — this test is about activity.
-      railOrder: { left: ["chat", "activity", "schedule"], right: ["activity", "beads", "settings"], bottom: ["activity"] },
+      // "settings"/"work" present so the v9/v11 add steps are no-ops — this test is about activity.
+      railOrder: { left: ["chat", "activity", "knowledge"], right: ["activity", "work", "settings"], bottom: ["activity"] },
       quickBar: ["chat", "activity", "knowledge"],
     }) as { railOrder: { left: string[]; right: string[]; bottom: string[] }; quickBar: string[] };
     expect(out.railOrder.left).not.toContain("activity");
     expect(out.railOrder.right).not.toContain("activity");
     expect(out.railOrder.bottom).not.toContain("activity");
-    expect(out.railOrder.left).toEqual(["chat", "schedule"]);
+    expect(out.railOrder.left).toEqual(["chat", "knowledge"]);
     expect(out.quickBar).toEqual(["chat", "knowledge"]);
   });
 
@@ -73,25 +57,66 @@ describe("migrateUiState", () => {
   // to a persisted layout that lacks it so existing users don't lose the Settings icon.
   it("restores the 'settings' rail surface to a layout that lacks it", () => {
     const out = migrateUiState({
-      railOrder: { left: ["chat", "schedule"], right: ["beads", "goals", "plugins"], bottom: [] },
+      railOrder: { left: ["chat", "knowledge"], right: ["work"], bottom: [] },
     }) as { railOrder: { left: string[] } };
-    // No "plugins" on the left rail → appended to the end of it.
-    expect(out.railOrder.left).toEqual(["chat", "schedule", "settings"]);
+    // No "plugins" anchor on the left rail → settings appended to the end of it.
+    expect(out.railOrder.left).toEqual(["chat", "knowledge", "settings"]);
   });
 
-  it("re-adds 'settings' right after 'plugins' on the left when present", () => {
+  it("re-adds 'settings' where 'plugins' was, then v10 prunes 'plugins'", () => {
     const out = migrateUiState({
       railOrder: { left: ["chat", "schedule", "plugins", "knowledge"], right: ["beads"], bottom: [] },
     }) as { railOrder: { left: string[] } };
-    expect(out.railOrder.left).toEqual(["chat", "schedule", "plugins", "settings", "knowledge"]);
+    // v9 inserts settings after the (legacy) plugins anchor; v10 removes plugins, v11 schedule.
+    expect(out.railOrder.left).toEqual(["chat", "settings", "knowledge"]);
+  });
+
+  // v10 (2026-06): the Plugins manager moved into Settings ▸ Plugins. Prune "plugins" from
+  // every dock + the quick-bar so it doesn't linger as a dead rail id.
+  it("prunes 'plugins' from the rails and quick-bar", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "schedule", "plugins", "settings"], right: ["plugins", "beads"], bottom: ["plugins"] },
+      quickBar: ["chat", "plugins", "knowledge"],
+    }) as { railOrder: { left: string[]; right: string[]; bottom: string[] }; quickBar: string[] };
+    expect(out.railOrder.left).not.toContain("plugins");
+    expect(out.railOrder.right).not.toContain("plugins");
+    expect(out.railOrder.bottom).not.toContain("plugins");
+    expect(out.railOrder.left).toEqual(["chat", "settings"]);
+    expect(out.quickBar).toEqual(["chat", "knowledge"]);
   });
 
   it("keeps a user-placed 'settings' where it is", () => {
     const out = migrateUiState({
-      railOrder: { left: ["chat", "schedule"], right: ["settings", "beads"], bottom: [] },
+      railOrder: { left: ["chat", "knowledge"], right: ["settings", "work"], bottom: [] },
     }) as { railOrder: { left: string[]; right: string[] } };
     expect(out.railOrder.right).toContain("settings");
     expect(out.railOrder.left).not.toContain("settings");
+  });
+
+  // v11 (2026-06): Beads + Goals + Schedule folded into the unified "work" hub.
+  it("folds beads/goals/schedule into the 'work' hub", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "schedule", "knowledge", "settings"], right: ["beads", "goals"], bottom: [] },
+      rightPanel: "beads",
+      quickBar: ["chat", "beads", "knowledge"],
+    }) as { railOrder: { left: string[]; right: string[]; bottom: string[] }; rightPanel: string; quickBar: string[] };
+    for (const id of ["beads", "goals", "schedule"]) {
+      expect(out.railOrder.left).not.toContain(id);
+      expect(out.railOrder.right).not.toContain(id);
+      expect(out.quickBar).not.toContain(id);
+    }
+    expect(out.railOrder.left).toEqual(["chat", "knowledge", "settings"]);
+    expect(out.railOrder.right).toEqual(["work"]);
+    expect(out.rightPanel).toBe("work");
+    expect(out.quickBar).toEqual(["chat", "knowledge"]);
+  });
+
+  it("keeps a user-placed 'work' and doesn't duplicate it", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "work"], right: ["settings"], bottom: [] },
+    }) as { railOrder: { left: string[]; right: string[] } };
+    expect(out.railOrder.left.filter((x) => x === "work")).toHaveLength(1);
+    expect(out.railOrder.right).not.toContain("work");
   });
 
   // v5→v6 (bottom dock): railOrder gains a `bottom` dock; add the empty array to a
@@ -99,10 +124,10 @@ describe("migrateUiState", () => {
   it("adds the bottom dock to a pre-v6 railOrder", () => {
     // (schedule already present so the v7 inject is a no-op — keep this test on the dock)
     const out = migrateUiState({
-      railOrder: { left: ["chat", "schedule", "settings"], right: ["beads"] },
+      railOrder: { left: ["chat", "knowledge", "settings"], right: ["work"] },
     }) as { railOrder: { left: string[]; right: string[]; bottom: string[] } };
     expect(out.railOrder.bottom).toEqual([]);
-    expect(out.railOrder.left).toEqual(["chat", "schedule", "settings"]);
+    expect(out.railOrder.left).toEqual(["chat", "knowledge", "settings"]);
   });
 
   it("does not mutate the input object", () => {

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -185,8 +185,31 @@ export function migrateUiState(persisted: unknown): unknown {
         rest.railOrder = { ...ro6, left };
       }
     }
+    // v10 (2026-06): the Plugins manager moved off the rail into Settings ▸ Plugins (it's a
+    // settings section now, not a surface). Prune "plugins" from every dock + the quick-bar.
+    const ro7 = rest.railOrder as { left?: string[]; right?: string[]; bottom?: string[] } | undefined;
+    if (ro7) {
+      const noPlug = (arr?: string[]) => (Array.isArray(arr) ? arr.filter((x) => x !== "plugins") : []);
+      rest.railOrder = { left: noPlug(ro7.left), right: noPlug(ro7.right), bottom: noPlug(ro7.bottom) };
+    }
+    // v11 (2026-06): Beads + Goals + Schedule folded into the unified "work" hub. Prune the
+    // three old ids from every dock + the quick-bar; add "work" to the right rail if the
+    // layout has none of them placed; retarget a default-active right panel that pointed at one.
+    const FOLDED = new Set(["beads", "goals", "schedule"]);
+    const ro8 = rest.railOrder as { left?: string[]; right?: string[]; bottom?: string[] } | undefined;
+    if (ro8) {
+      const drop = (arr?: string[]) => (Array.isArray(arr) ? arr.filter((x) => !FOLDED.has(x)) : []);
+      const left = drop(ro8.left);
+      let right = drop(ro8.right);
+      const bottom = drop(ro8.bottom);
+      if (![...left, ...right, ...bottom].includes("work")) right = [...right, "work"];
+      rest.railOrder = { left, right, bottom };
+    }
+    if (rest.rightPanel === "beads" || rest.rightPanel === "goals") rest.rightPanel = "work";
     if (Array.isArray(rest.quickBar)) {
-      rest.quickBar = (rest.quickBar as string[]).filter((x) => x !== "activity");
+      rest.quickBar = (rest.quickBar as string[]).filter(
+        (x) => x !== "activity" && x !== "plugins" && !FOLDED.has(x),
+      );
     }
     return rest;
   }
@@ -197,7 +220,7 @@ export const useUI = create<UIState>()(
   persist(
     (set) => ({
       surface: "chat",
-      rightPanel: "beads",
+      rightPanel: "work",
       pluginsTab: "local",
       settingsScope: "host" as SettingsScope,
       settingsSection: "overview",
@@ -213,8 +236,8 @@ export const useUI = create<UIState>()(
       bottomHeight: 240,
       bottomCollapsed: false,
       railOrder: {
-        left: ["chat", "schedule", "studio", "knowledge", "plugins", "settings"],
-        right: ["beads", "goals"],
+        left: ["chat", "studio", "knowledge", "settings"],
+        right: ["work"],
         bottom: [],
       },
       moveSurface: (id, side) =>
@@ -293,7 +316,7 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 9, // …v6 +bottom dock · v7 Schedule→rail surface again · v8 Activity→utility widget · v9 re-add Settings rail surface
+      version: 11, // …v9 re-add Settings · v10 Plugins→Settings section · v11 Beads+Goals+Schedule→Work hub (prune ids, add work)
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
       // The Global settings overlay is ephemeral UI state — drop it from persistence so a
       // refresh never reopens it (everything else persists as before).


### PR DESCRIPTION
A console information-architecture pass folding four related UI changes. Live-verified on the isolated dev instance.

## Plugins → Settings
- The Plugins manager (install · enable · configure + the Discover directory) moved off the rail into **Settings ▸ Plugins** — it's a settings section now, not a standalone surface. ⌘K deep-links retargeted; v10 migration prunes the old `plugins` rail id. Plugins sits just **above Tools** in the Workspace sidebar.

## Work hub (Beads + Goals + Schedule → one surface)
- New `WorkPanel`: one right-rail **Work** surface with **Overview · Goals · Tasks · Schedule** tabs. Overview is a glanceable roll-up (active goals + iteration · ready/in-progress tasks · next scheduled runs), each card jumping to its tab; the three tabs reuse `GoalsPanel`/`BeadsPanel`/`SchedulePanel` verbatim. Removed the three standalone rail surfaces; **v11 migration** folds them in (prunes the ids, adds `work`, retargets the default right panel).

## Utility-dialog double-header fix
- Activity + Inbox showed a dialog header **and** an inner panel header. `UtilityWidget` now hosts the reload control in the **dialog header** (a small context the body registers into via `useUtilityHeaderReload`); `ActivitySurface` + `InboxPanel` drop their inner `PanelHeader` and fill the dialog body.

## Tests
- `uiStore` migration tests updated for v10/v11 + new coverage.
- **5 e2e specs reworked** for the Work consolidation (navigation/schedule/dock/continuity/slot) + the Plugins-in-Settings + sidebar-order moves. *(The narrow right panel collapses the responsive Tabs to a `<select>`, so tab selection there is via `.pl-tabs__select`.)*

## Verification
web build/typecheck clean · **vitest 103** · **full e2e 110**.

Follow-up already scoped: consolidating Global settings into the Workspace settings + moving the Settings entry to a utility-bar pill (separate PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)