### PR TITLE
feat(web): consolidate settings — one surface, utility-bar pill, host-aware inheritance

### DIFF
--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -7,7 +7,7 @@ import { expect, test } from "@playwright/test";
 
 async function openIntegrations(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByTestId("settings-widget").click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Delegates", exact: true }).click();
 }
 

--- a/apps/web/e2e/fleet.spec.ts
+++ b/apps/web/e2e/fleet.spec.ts
@@ -19,10 +19,10 @@ test.beforeEach(async ({ page }, testInfo) => {
 });
 
 async function openFleet(page) {
-  // Fleet lives under the Global settings overlay now, opened from the header
-  // hamburger → app drawer → Global settings (folded in from the old Box rail surface).
+  // Fleet lives in the Box group of the consolidated settings dialog (host console), opened
+  // from the header hamburger → app drawer → Settings (folded in from the old Box rail surface).
   await page.getByTestId("header-menu").click();
-  await page.getByTestId("app-drawer").getByRole("button", { name: "Global settings", exact: true }).click();
+  await page.getByTestId("app-drawer").getByRole("button", { name: "Settings", exact: true }).click();
   await page.locator(".settings-overlay .pl-sidenav").getByRole("tab", { name: "Fleet", exact: true }).click();
 }
 
@@ -31,7 +31,7 @@ async function openAgents(page) {
   await openFleet(page);
 }
 
-// Fleet lives in the Global settings overlay (a modal) now, so its backdrop intercepts
+// Fleet lives in the consolidated settings dialog (a modal) now, so its backdrop intercepts
 // the topbar switcher — close it before interacting with the top bar.
 async function closeOverlay(page) {
   await page.locator(".settings-overlay .pl-dialog__close").click();
@@ -170,8 +170,10 @@ test("discover → add to fleet → switch into the remote member (ADR 0042 §I)
   await expect(page).toHaveURL(/\/app\/agent\/remy-re01\//);
   await expect(page.getByTestId("fleet-switcher")).toContainText("remy");
 
-  // Unregister from the fleet manager (the remote agent itself is untouched).
-  await openFleet(page);
+  // Unregister from the fleet manager (the remote agent itself is untouched). Fleet is a
+  // host-console-only Box section now (2026-06 settings consolidation), so return to the host
+  // console first — the member window we navigated into doesn't carry the Box group.
+  await openAgents(page);
   await page.locator(".fleet-row", { hasText: "remy" })
     .getByRole("button", { name: /Remove from this fleet/ }).click();
   await expect(page.locator(".fleet-row", { hasText: "remy" })).toHaveCount(0);

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 
 test("MCP tab lists servers and adds one inline", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByTestId("settings-widget").click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "MCP", exact: true }).click();
 
   await expect(page.getByRole("heading", { name: "MCP servers" })).toBeVisible();
@@ -21,7 +21,7 @@ test("MCP tab lists servers and adds one inline", async ({ page }) => {
 
 test("MCP tab imports servers from pasted JSON", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByTestId("settings-widget").click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "MCP", exact: true }).click();
 
   await page.getByRole("button", { name: /Add server/ }).click();

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -59,11 +59,12 @@ test("Work → Tasks tab lists beads issues (query-backed)", async ({ page }) =>
   await expect(page.getByText("Wire the telemetry rollup")).toBeVisible();
 });
 
-test("workspace settings: identity lands, then tools and MCP sections", async ({ page }) => {
-  // The agent makeup folded into Settings ▸ Workspace (ADR 0048 S-C); the rail
-  // Settings surface is Workspace-direct now (Global moved to the header drawer).
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
-  await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible(); // landing section
+test("settings dialog: Identity, then Tools and MCP sections", async ({ page }) => {
+  // Settings is the consolidated dialog now (2026-06), opened from the utility-bar pill
+  // (no longer a rail surface). Navigate the Agent group's Identity / Tools / MCP sections.
+  await page.getByTestId("settings-widget").click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "Identity", exact: true }).click();
+  await expect(page.getByRole("heading", { name: "Identity" })).toBeVisible();
   await expect(page.getByTestId("identity-name")).toBeVisible();
 
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Tools", exact: true }).click();
@@ -74,8 +75,8 @@ test("workspace settings: identity lands, then tools and MCP sections", async ({
 });
 
 test("plugins section: Installed / Discover (config + advanced install folded in)", async ({ page }) => {
-  // Plugins is a Settings section now (2026-06), not a standalone rail surface.
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  // Plugins is a Settings dialog section now (2026-06), opened from the utility-bar pill.
+  await page.getByTestId("settings-widget").click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Plugins", exact: true }).click();
 
   // Two sections only now (ADR 0059 D4) — no separate "Install URL" tab.

--- a/apps/web/e2e/playbooks.spec.ts
+++ b/apps/web/e2e/playbooks.spec.ts
@@ -16,7 +16,7 @@ test.beforeEach(async ({ page }) => {
 
 test("Agent → Skills lists pinned + learned skills and supports search", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByTestId("settings-widget").click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Skills", exact: true }).click();
 
   const surface = page.getByTestId("playbooks-surface");
@@ -36,7 +36,7 @@ test("Agent → Skills lists pinned + learned skills and supports search", async
 
 test("the + button opens the New skill DIALOG, not an inline panel form", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByTestId("settings-widget").click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
@@ -60,7 +60,7 @@ test("the + button opens the New skill DIALOG, not an inline panel form", async 
 
 test("layered skills show tier badges and promote a private skill to the commons", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByTestId("settings-widget").click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();
@@ -80,7 +80,7 @@ test("layered skills show tier badges and promote a private skill to the commons
 
 test("deleting a playbook confirms first, then removes it", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByTestId("settings-widget").click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Skills", exact: true }).click();
   const surface = page.getByTestId("playbooks-surface");
   await expect(surface).toBeVisible();

--- a/apps/web/e2e/plugin-install.spec.ts
+++ b/apps/web/e2e/plugin-install.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 
 async function openPluginsPanel(page) {
   await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+  await page.getByTestId("settings-widget").click();
   await page.locator(".pl-sidenav").getByRole("tab", { name: "Plugins", exact: true }).click();
   // Install-from-URL is the advanced action under Installed (ADR 0059 D4) — expand it.
   await page.getByRole("button", { name: "Install from a git URL" }).click();

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -5,14 +5,15 @@ import { expect, test } from "@playwright/test";
 // two-home one-stop-shop is also openable as an overlay from the topbar.
 
 // The header hamburger opens the app drawer (2026-06-18 IA pass): global actions
-// (Global settings, Telemetry) + the Docs/GitHub links. "Global settings" opens the
-// Global-only overlay — Workspace settings live in the rail surface, not here.
-test("the header hamburger opens the app drawer → Global settings overlay", async ({ page }) => {
+// (Settings, Telemetry) + the Docs/GitHub links. "Settings" opens the one consolidated
+// settings dialog (the same dialog the utility-bar pill opens — Global is no longer a
+// separate home).
+test("the header hamburger opens the app drawer → Settings dialog", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByTestId("header-menu").click();
   const drawer = page.getByTestId("app-drawer");
   await expect(drawer).toBeVisible();
-  await expect(drawer.getByRole("button", { name: "Global settings", exact: true })).toBeVisible();
+  await expect(drawer.getByRole("button", { name: "Settings", exact: true })).toBeVisible();
   await expect(drawer.getByRole("button", { name: "Telemetry", exact: true })).toBeVisible();
   await expect(drawer.getByRole("link", { name: "Docs" })).toBeVisible();
   await expect(drawer.getByRole("link", { name: "GitHub" })).toBeVisible();
@@ -22,10 +23,10 @@ test("the header hamburger opens the app drawer → Global settings overlay", as
   await expect(built).toBeVisible();
   await expect(built).toHaveAttribute("href", "https://protolabs.studio");
 
-  await drawer.getByRole("button", { name: "Global settings", exact: true }).click();
-  const dialog = page.getByRole("dialog", { name: "Global settings" });
+  await drawer.getByRole("button", { name: "Settings", exact: true }).click();
+  const dialog = page.getByRole("dialog", { name: "Settings" });
   await expect(dialog).toBeVisible();
-  // Global-only — no scope toggle inside (the two-home toggle is gone).
+  // One consolidated surface — no scope toggle inside (the two-home toggle is gone).
   await expect(dialog.locator(".pl-tabs--segmented")).toHaveCount(0);
 });
 

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -1,19 +1,23 @@
 import { expect, test } from "@playwright/test";
 
-// Settings IA (2026-06-18 pass): WORKSPACE settings live in the rail "Settings"
-// surface (no scope toggle); GLOBAL settings open from the header hamburger → app
-// drawer → an overlay dialog. Each section renders GET /api/settings/schema groups
-// and saves via POST /api/settings (auto-reload).
+// Settings IA (2026-06-18 consolidation): there is ONE settings surface — a DS Dialog
+// (title "Settings") opened from the utility-bar Settings PILL (data-testid
+// "settings-widget"), the header drawer's "Settings" item, or a ⌘K deep-link. The dialog's
+// sidenav splits into two labeled groups — Agent (always) and Box (host console only). The
+// old Global overlay + the old rail Settings surface both fold into this one dialog; there is
+// no scope toggle and no "Configuration" section (host-scoped FIELDS edit inline in the Agent
+// group with a "box default" badge). Each section renders GET /api/settings/schema groups and
+// saves via POST /api/settings.
 
-// The rail Settings surface — Workspace-only now.
-async function openSettings(page) {
-  await page.goto("/app/", { waitUntil: "load" });
-  await page.locator(".pl-rail").getByRole("button", { name: "Settings", exact: true }).click();
+// Open the consolidated settings dialog from the utility-bar pill.
+async function openSettings(page, url = "/app/") {
+  await page.goto(url, { waitUntil: "load" });
+  await page.getByTestId("settings-widget").click();
+  await expect(page.locator(".settings-overlay")).toBeVisible();
 }
 
-// Global settings open from the header drawer; `item` picks the drawer entry
-// ("Global settings" lands on Overview, "Telemetry" deep-links that section).
-async function openGlobal(page, item = "Global settings") {
+// Open the same dialog from the header drawer's "Settings" item (the former "Global settings").
+async function openFromDrawer(page, item = "Settings") {
   await page.goto("/app/", { waitUntil: "load" });
   await page.getByTestId("header-menu").click();
   const drawer = page.getByTestId("app-drawer");
@@ -22,8 +26,9 @@ async function openGlobal(page, item = "Global settings") {
   await expect(page.locator(".settings-overlay")).toBeVisible();
 }
 
-// Click a section in a sidenav (the rail's, or — scoped — the overlay's).
-async function section(page, name, scope = ".pl-sidenav") {
+// Click a section in the dialog's sidenav (the dialog is wide enough that the DS SideNav is
+// NOT responsive-collapsed, so role="tab" works).
+async function section(page, name, scope = ".settings-overlay .pl-sidenav") {
   await page.locator(scope).getByRole("tab", { name, exact: true }).click();
 }
 
@@ -37,11 +42,15 @@ async function expandAllGroups(page) {
   }
 }
 
-test("Workspace settings live in the rail (no scope toggle)", async ({ page }) => {
+test("the settings dialog lists the grouped Agent + Box sections (host, no scope toggle)", async ({ page }) => {
   await openSettings(page);
-  // No Global/Workspace segmented toggle anymore — the rail is Workspace directly.
+  // One consolidated surface — no Global/Workspace segmented toggle.
   await expect(page.locator(".pl-tabs--segmented")).toHaveCount(0);
-  expect(await page.locator(".pl-sidenav").locator("button").allTextContents()).toEqual([
+  // The e2e default (/app/, no /agent/<slug>/) is the host console, so both the Agent group
+  // and the host-only Box group render.
+  const sidenav = page.locator(".settings-overlay .pl-sidenav");
+  expect(await sidenav.locator("button").allTextContents()).toEqual([
+    // Agent group
     "Identity",
     "Model & Routing",
     "Plugins",
@@ -54,22 +63,28 @@ test("Workspace settings live in the rail (no scope toggle)", async ({ page }) =
     "Memory",
     "System",
     "Theme",
+    // Box group (host console only)
+    "Overview",
+    "Fleet",
+    "Telemetry",
+    "Shared Skills",
   ]);
   await section(page, "System");
   await expect(page.locator(".pl-accordion__title").first()).toBeVisible();
   expect(await page.locator(".pl-accordion__title").allTextContents()).toEqual(["Compaction", "Runtime"]);
 });
 
-test("Global settings open from the header drawer → overlay (Overview · Configuration · Fleet · Telemetry · Shared Skills)", async ({ page }) => {
-  await openGlobal(page);
+test("the host inheritance banner explains box defaults", async ({ page }) => {
+  await openSettings(page);
+  await expect(page.locator(".settings-overlay .pl-alert").first()).toContainText("box defaults every agent inherits");
+});
+
+test("opening from the header drawer's Settings item shows the same dialog + the Box sections", async ({ page }) => {
+  await openFromDrawer(page);
   const sidenav = page.locator(".settings-overlay .pl-sidenav");
-  expect(await sidenav.locator("button").allTextContents()).toEqual([
-    "Overview",
-    "Configuration",
-    "Fleet",
-    "Telemetry",
-    "Shared Skills",
-  ]);
+  // The Box group (host console) — Configuration is GONE (host fields are inline in the Agent group).
+  await expect(sidenav.getByRole("tab", { name: "Overview", exact: true })).toBeVisible();
+  await expect(sidenav.getByRole("tab", { name: "Configuration", exact: true })).toHaveCount(0);
   // Fleet section shows the agents panel; Telemetry renders the dashboard.
   await sidenav.getByRole("tab", { name: "Fleet", exact: true }).click();
   await expect(page.getByRole("heading", { name: "Agents" })).toBeVisible();
@@ -77,12 +92,12 @@ test("Global settings open from the header drawer → overlay (Overview · Confi
   await expect(page.getByTestId("telemetry-surface")).toBeVisible();
 });
 
-test("the drawer's Telemetry item deep-links the Global Telemetry section", async ({ page }) => {
-  await openGlobal(page, "Telemetry");
+test("the drawer's Telemetry item deep-links the Telemetry section", async ({ page }) => {
+  await openFromDrawer(page, "Telemetry");
   await expect(page.getByTestId("telemetry-surface")).toBeVisible();
 });
 
-test("Workspace ▸ Model & Routing shows the agent's Model + Routing fields", async ({ page }) => {
+test("Model & Routing shows the agent's Model + Routing fields", async ({ page }) => {
   await openSettings(page);
   await section(page, "Model & Routing");
   await expect(page.locator(".pl-accordion__title").first()).toBeVisible();
@@ -113,14 +128,44 @@ test("a restart-flagged System field shows the restart banner", async ({ page })
   await expect(page.locator(".settings-banner")).toContainText("restart");
 });
 
-// ADR 0047 hybrid layered settings — per-agent settings show every field with an
-// inheritance badge; an overridden host-scoped field offers reset-to-inherited.
-test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ page }) => {
+// On the HOST console the host-scoped fields ARE the box defaults — they carry a "box
+// default" badge inline in Model & Routing (the former Global ▸ Configuration section is
+// gone; editing these writes the host layer). model.name / routing.aux_model are host-scoped.
+test("host-scoped fields show the 'box default' badge inline in Model & Routing", async ({ page }) => {
   await openSettings(page);
   await section(page, "Model & Routing");
   await expandAllGroups(page);
+  await expect(page.locator('.setting-row[data-key="model.name"] .setting-inheritance')).toContainText("box default");
+  await expect(page.locator('.setting-row[data-key="routing.aux_model"] .setting-inheritance')).toContainText(
+    "box default",
+  );
+  // An agent-scoped field (no host layer) carries no inheritance badge on the host.
+  await expect(page.locator('.setting-row[data-key="routing.fallback_models"] .setting-inheritance')).toHaveCount(0);
+});
+
+// On the host these same host-scoped edits save to the host layer (ADR 0047): the mock echoes
+// "config saved (host)". This is the new home of the former "Configuration (Global)" behavior —
+// the host-scoped subset now edits inline in Model & Routing, writing the box-shared host layer.
+test("a host-scoped edit on the host console saves to the host layer", async ({ page }) => {
+  await openSettings(page);
+  await section(page, "Model & Routing");
+  await expandAllGroups(page);
+  await page.locator('.setting-row[data-key="routing.aux_model"] input').fill("protolabs/host-fast");
+  await page.getByRole("button", { name: /Save & apply/ }).click();
+  await expect(page.locator(".settings-status")).toContainText("(host)");
+});
+
+// On a FLEET MEMBER console (/agent/<slug>/) the same fields show the ADR 0047 inheritance
+// view instead — inherited-from / overridden-here badges + reset-to-inherited. There is no
+// Box group on a member.
+test("per-agent (fleet member) settings show ADR 0047 inheritance badges + reset", async ({ page }) => {
+  await openSettings(page, "/app/agent/ava/");
+  // No Box group on a fleet member.
+  await expect(page.locator(".settings-overlay .pl-sidenav").getByRole("tab", { name: "Fleet", exact: true })).toHaveCount(0);
+  await section(page, "Model & Routing");
+  await expandAllGroups(page);
   await expect(page.locator('.setting-row[data-key="model.name"] .setting-inheritance')).toContainText(
-    "inherited from Global",
+    "inherited from host",
   );
   await expect(page.locator('.setting-row[data-key="routing.aux_model"] .setting-inheritance')).toContainText(
     "inherited from default",
@@ -130,18 +175,4 @@ test("per-agent settings show ADR 0047 inheritance badges + reset", async ({ pag
   await temp.getByRole("button", { name: /Reset to inherited/ }).click();
   await expect(page.locator(".settings-status")).toContainText("inherited");
   await expect(page.locator('.setting-row[data-key="routing.fallback_models"] .setting-inheritance')).toHaveCount(0);
-});
-
-test("Configuration (Global) edits the host-scoped subset and saves to the host layer", async ({ page }) => {
-  await openGlobal(page);
-  await section(page, "Configuration", ".settings-overlay .pl-sidenav");
-  await expect(page.locator(".settings-banner").first()).toContainText("box-shared");
-  await expandAllGroups(page);
-  await expect(page.locator('.setting-row[data-key="model.name"]')).toBeVisible();
-  await expect(page.locator('.setting-row[data-key="model.api_key"]')).toHaveCount(0);
-  await expect(page.locator('.setting-row[data-key="routing.fallback_models"]')).toHaveCount(0);
-  await page.locator('.setting-row[data-key="routing.aux_model"] input').fill("protolabs/host-fast");
-  const save = page.getByRole("button", { name: /Save & apply/ }).first();
-  await save.click();
-  await expect(page.locator(".settings-status").first()).toContainText("(host)");
 });

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -78,7 +78,6 @@ import { InboxWidget } from "../inbox/InboxWidget";
 import { ChatSlot } from "./ChatSlot";
 import { useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
-import { SettingsSurface } from "../settings/SettingsSurface";
 import { SettingsOverlay } from "../settings/SettingsOverlay";
 import { AppDrawer } from "./AppDrawer";
 import { HamburgerMenu } from "./HamburgerMenu";
@@ -543,11 +542,9 @@ export function App() {
       // Settings ▸ Workspace ▸ Memory (ADR 0048 S-C).
       case "knowledge":
         return <KnowledgeStore onError={setError} />;
-      case "settings":
-        // The rail Settings surface is Workspace-only now (2026-06-18 IA pass) — no
-        // scope toggle. Global settings live in the header drawer's overlay instead.
-        return <SettingsSurface only="workspace" />;
-      // Notes is now the first-party `notes` plugin (ADR 0034 S4) — rendered via the default
+      // Settings is no longer a rail surface (2026-06 consolidation) — it's a utility-bar
+      // pill opening the settings dialog (SettingsOverlay). Notes is the first-party `notes`
+      // plugin (ADR 0034 S4) — rendered via the default
       // plugin-view case below, not a native surface.
       default: {
         // Fork-contributed surface (src/ext seam, ADR 0038 D3) — rendered in-process.
@@ -887,6 +884,19 @@ export function App() {
             // GitHub moved into the header drawer.
             start={
               <>
+                {/* Settings (far left, 2026-06 consolidation) — opens the one settings dialog
+                    (SettingsOverlay). A plain pill, not a UtilityWidget, so the drawer + ⌘K
+                    deep-links can open it too via the store flag (openGlobalSettings). */}
+                <button
+                  type="button"
+                  className="util-btn"
+                  aria-label="Settings"
+                  title="Settings"
+                  data-testid="settings-widget"
+                  onClick={() => openGlobalSettings()}
+                >
+                  <Settings2 size={14} />
+                </button>
                 {/* Widgets (bottom-left): background subagents (ADR 0050 Phase 3), the
                     inbox, and the read-only Activity feed — each a pill with a hover info
                     popover + a click dialog. */}

--- a/apps/web/src/app/AppDrawer.tsx
+++ b/apps/web/src/app/AppDrawer.tsx
@@ -81,7 +81,7 @@ export function AppDrawer({
             <p className="app-drawer-label">Settings</p>
             <button type="button" className="app-drawer-item" onClick={act(() => onOpenGlobal())}>
               <span className="app-drawer-ico"><Settings2 size={16} /></span>
-              Global settings
+              Settings
             </button>
             <button type="button" className="app-drawer-item" onClick={act(() => onOpenGlobal("telemetry"))}>
               <span className="app-drawer-ico"><BarChart3 size={16} /></span>

--- a/apps/web/src/app/coreSurfaces.tsx
+++ b/apps/web/src/app/coreSurfaces.tsx
@@ -2,7 +2,7 @@
 // desktop quick-launcher (ADR 0057) build their command lists from the SAME source —
 // add a core surface here and it shows up in both the rail and ⌘K / the launcher.
 import type { ReactNode } from "react";
-import { BookMarked, LayoutDashboard, MessageSquare, Settings2 } from "lucide-react";
+import { BookMarked, LayoutDashboard, MessageSquare } from "lucide-react";
 
 export type CoreSurface = { id: string; label: string; icon: ReactNode };
 
@@ -15,5 +15,6 @@ export const CORE_SURFACES: CoreSurface[] = [
   // widget; "agent" folded into Settings ▸ Workspace; "plugins" into Settings ▸ Plugins.
   { id: "work", label: "Work", icon: <LayoutDashboard size={18} /> },
   { id: "knowledge", label: "Knowledge", icon: <BookMarked size={18} /> },
-  { id: "settings", label: "Settings", icon: <Settings2 size={18} /> },
+  // Settings moved off the rail into a utility-bar pill (2026-06 consolidation) → the
+  // settings dialog. It's still a valid ⌘K "go to" via the global deep-links.
 ];

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -67,7 +67,7 @@ export function openView(id: string) {
 export type NavIntent =
   | { kind: "view"; id: string }
   | { kind: "plugins"; tab: "local" | "market" }
-  | { kind: "global"; section: "fleet" | "telemetry" | "commons" };
+  | { kind: "global"; section?: string };
 
 /** Apply an intent to THIS window's UI store. The default navigator, and what the main
  *  window calls when it receives a forwarded intent from the launcher. */
@@ -78,11 +78,10 @@ export function applyNavIntent(intent: NavIntent) {
       openView(intent.id);
       break;
     case "plugins":
-      // Plugins is a Settings section now (2026-06), not a standalone rail surface —
-      // open Settings ▸ Plugins (the rail Settings surface is Workspace-only) on the tab.
+      // Plugins is a Settings section; Settings is the dialog now (2026-06). Open it on the
+      // Plugins section with the right inner tab (Installed/Discover).
       ui.setPluginsTab(intent.tab);
-      ui.setSettingsSection("plugins");
-      ui.setSurface("settings");
+      ui.openGlobalSettings("plugins");
       break;
     case "global":
       ui.openGlobalSettings(intent.section);
@@ -131,9 +130,10 @@ function deepLinkCommands(): Command[] {
       kind: "plugins",
       tab: "local",
     }),
-    // Global settings (Fleet/Telemetry/Commons) is the header-drawer overlay now
-    // (2026-06-18 IA pass) — open it deep-linked to the section.
-    link("box:fleet", "Settings: Fleet", ["fleet", "agents", "box", "global"], { kind: "global", section: "fleet" }),
+    // Settings is the consolidated dialog now (2026-06) — opened from the utility-bar pill,
+    // the drawer, or these ⌘K commands. A bare "Settings" command + Box-section deep-links.
+    link("settings", "Settings", ["settings", "config", "preferences", "options"], { kind: "global" }),
+    link("box:fleet", "Settings: Fleet", ["fleet", "agents", "box"], { kind: "global", section: "fleet" }),
     link("box:telemetry", "Settings: Telemetry", ["telemetry", "metrics", "box", "global"], {
       kind: "global",
       section: "telemetry",

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -12,7 +12,7 @@ import type { ReactNode } from "react";
 import { Accordion, AccordionItem, PanelHeader } from "@protolabsai/ui/navigation";
 import { StagePanel } from "../app/ErrorBoundary";
 import { HelpLink, TestConnectionButton } from "../app/ui-kit";
-import { agentHref, api } from "../lib/api";
+import { agentHref, api, isHostConsole } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { queryKeys, settingsSchemaQuery } from "../lib/queries";
 import type { SettingsField, SettingsGroup } from "../lib/types";
@@ -152,8 +152,30 @@ export function SettingsCategory({
     return labels;
   }, [groups, dirty]);
 
+  // Which layer a Save lands in (ADR 0047). On the HOST console a host-scoped field sets the
+  // box default (host layer) while an agent-scoped field is the host agent's own (agent leaf)
+  // — so split the write by scope. On a fleet member everything overrides into that agent's
+  // leaf. (`hostLayer` is the legacy host-defaults panel, kept for embedded/plugin callers.)
+  const onHost = isHostConsole();
   const save = useMutation({
-    mutationFn: () => api.saveSettings(dirty, hostLayer ? "host" : "agent"),
+    mutationFn: async () => {
+      if (hostLayer) return api.saveSettings(dirty, "host");
+      if (!onHost) return api.saveSettings(dirty, "agent");
+      const scopeOf = (k: string) =>
+        groups.flatMap((g) => g.fields).find((f) => f.key === k)?.scope ?? "agent";
+      const hostU: Record<string, unknown> = {};
+      const agentU: Record<string, unknown> = {};
+      for (const [k, v] of Object.entries(dirty)) (scopeOf(k) === "host" ? hostU : agentU)[k] = v;
+      const rs = await Promise.all([
+        ...(Object.keys(hostU).length ? [api.saveSettings(hostU, "host")] : []),
+        ...(Object.keys(agentU).length ? [api.saveSettings(agentU, "agent")] : []),
+      ]);
+      return {
+        ok: rs.every((r) => r.ok),
+        messages: rs.flatMap((r) => r.messages),
+        restart_required: rs.flatMap((r) => r.restart_required),
+      };
+    },
     onMutate: () => setStatus("saving…"),
     onSuccess: (r) => {
       if (!r.ok) { setStatus(`save failed: ${r.messages.join(" · ")}`); return; }
@@ -221,6 +243,7 @@ export function SettingsCategory({
           dirty={field.key in dirty}
           value={field.key in dirty ? dirty[field.key] : field.value}
           showInheritance={!hostLayer}
+          onHost={onHost}
           onChange={(v) => setDirty((d) => ({ ...d, [field.key]: v }))}
           onReset={() => reset.mutate([field.key])}
           resetting={reset.isPending}
@@ -341,8 +364,15 @@ export function SettingsCategory({
 //   source=="default"                 → inherited from default (App dataclass)
 //   source=="agent" && scope=="host"  → overridden here (offer reset-to-inherited)
 //   source=="agent" && scope=="agent" → a plain agent setting (no badge)
-function inheritance(field: SettingsField): { label: string; status: "neutral" | "info" | "warning"; overridden: boolean } | null {
-  if (field.source === "host") return { label: "inherited from Global", status: "neutral", overridden: false };
+function inheritance(field: SettingsField, onHost: boolean): { label: string; status: "neutral" | "info" | "warning"; overridden: boolean } | null {
+  if (onHost) {
+    // On the host console you ARE the box: a host-scoped field is the shared default every
+    // agent inherits (not "inherited from" anything); agent-scoped fields are the host's own.
+    if (field.scope === "host") return { label: "box default", status: "info", overridden: false };
+    return null;
+  }
+  // A fleet member (non-host): the ADR 0047 inheritance view.
+  if (field.source === "host") return { label: "inherited from host", status: "neutral", overridden: false };
   if (field.source === "default") return { label: "inherited from default", status: "neutral", overridden: false };
   if (field.source === "agent" && field.scope === "host") return { label: "overridden here", status: "warning", overridden: true };
   return null; // source=="agent" && scope=="agent" — just an agent setting.
@@ -354,6 +384,7 @@ function SettingRow({
   dirty,
   onChange,
   showInheritance = true,
+  onHost = false,
   onReset,
   resetting = false,
 }: {
@@ -362,10 +393,11 @@ function SettingRow({
   dirty: boolean;
   onChange: (value: unknown) => void;
   showInheritance?: boolean;
+  onHost?: boolean;
   onReset?: () => void;
   resetting?: boolean;
 }) {
-  const inherit = showInheritance ? inheritance(field) : null;
+  const inherit = showInheritance ? inheritance(field, onHost) : null;
   return (
     <div className={`setting-row${dirty ? " dirty" : ""}`} data-key={field.key}>
       <div className="setting-meta">
@@ -391,8 +423,8 @@ function SettingRow({
         ) : null}
         {/* Editing a still-inherited box-shared field in the Workspace view writes a
             per-agent leaf override (not the box default) — make that effect explicit. */}
-        {showInheritance && dirty && field.scope === "host" && field.source !== "agent" ? (
-          <p className="setting-override-note">Saving overrides the Global default for this agent only.</p>
+        {showInheritance && !onHost && dirty && field.scope === "host" && field.source !== "agent" ? (
+          <p className="setting-override-note">Saving overrides the box default for this agent only.</p>
         ) : null}
       </div>
       <div className="setting-control">

--- a/apps/web/src/settings/SettingsOverlay.tsx
+++ b/apps/web/src/settings/SettingsOverlay.tsx
@@ -4,11 +4,10 @@ import { Dialog } from "@protolabsai/ui/overlays";
 
 import { SettingsSurface } from "./SettingsSurface";
 
-// Global (box-shared) settings as an overlay, opened from the header drawer
-// (2026-06-18 IA pass): the Global home — Overview · Configuration · Fleet ·
-// Telemetry · Commons — without the scope toggle. Workspace settings live in the
-// rail surface, not here. `section` deep-links a Global section (e.g. the drawer's
-// "Telemetry" item opens straight to it); the `key` re-seeds the surface per open.
+// The settings dialog (2026-06 consolidation) — the ONE settings surface (the focused
+// agent's settings; the Box group on the host), opened from the utility-bar Settings pill,
+// the header drawer, or a ⌘K deep-link. `section` deep-links a section; `key` re-seeds the
+// surface per open. (Replaces the rail "Settings" surface + the Global-only overlay.)
 export function SettingsOverlay({
   open,
   onClose,
@@ -20,8 +19,8 @@ export function SettingsOverlay({
 }) {
   if (!open) return null;
   return (
-    <Dialog open onClose={onClose} title="Global settings" width="min(960px, 94vw)" className="settings-overlay">
-      <SettingsSurface only="host" initialSection={section} key={section || "_"} />
+    <Dialog open onClose={onClose} title="Settings" width="min(960px, 94vw)" className="settings-overlay">
+      <SettingsSurface initialSection={section} key={section || "_"} />
     </Dialog>
   );
 }

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,9 +1,9 @@
-import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, HardDrive, Layers, Library, Network, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Store, Wrench } from "lucide-react";
+import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, Layers, Library, Network, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Store, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
-import { useState, type ReactNode } from "react";
+import { useEffect, type ReactNode } from "react";
 
-import { PanelHeader, SideNav, Tabs } from "@protolabsai/ui/navigation";
-import { Button } from "@protolabsai/ui/primitives";
+import { SideNav, Tabs } from "@protolabsai/ui/navigation";
+import { Alert } from "@protolabsai/ui/data";
 
 import { IdentityPanel } from "../agent/IdentityPanel";
 import { McpPanel } from "../app/McpPanel";
@@ -14,48 +14,30 @@ import { isHostConsole } from "../lib/api";
 import { PluginsSurface } from "../plugins/PluginsSurface";
 import { PlaybooksSurface } from "../playbooks/PlaybooksSurface";
 import { TelemetrySurface } from "../telemetry/TelemetrySurface";
-import { useUI, type SettingsScope } from "../state/uiStore";
+import { useUI } from "../state/uiStore";
 import { CommonsPanel } from "./CommonsPanel";
 import { DelegatesSection } from "./DelegatesSection";
 import { FleetSurface } from "./FleetSurface";
 import { OverviewPanel } from "./OverviewPanel";
-import { HostConfigLocked, HostDefaultsPanel, SettingsCategoryPanel } from "./SettingsCategory";
+import { SettingsCategoryPanel } from "./SettingsCategory";
 import { ThemeSurface } from "./ThemeSurface";
 
-// Settings IA (ADR 0048 + PR4) — scope is the primary axis. TWO homes, each with its
-// own section sub-nav:
+// Settings IA (ADR 0047/0048 — consolidated 2026-06). There is ONE settings surface: the
+// focused agent's settings. "Global" is no longer a separate home — it's simply this surface
+// when your focused agent is the host (host-scoped fields are the box defaults every agent
+// inherits). The sidenav splits into two labeled groups:
 //
-//   🖥 Global       — box-shared: the host cascade (Overview + Configuration, ADR 0047)
-//                     PLUS the box-level ops — Fleet, Telemetry, Commons (folded back in
-//                     from the old standalone Box rail surface). Set once, every agent
-//                     inherits; per-agent overrides win.
-//   🧩 Workspace    — the focused agent: everything that defines it.
+//   Agent — everything that defines the focused agent. Host-scoped fields here carry an
+//           inheritance badge (ADR 0047): on a fleet member, "inherited from host" + override;
+//           on the host console, "box default" (you're setting what others inherit).
+//   Box   — box-wide ops (Fleet · Telemetry · Shared Skills). Host-console only.
 
 type Section = { id: string; label: string; icon: LucideIcon; render: () => ReactNode };
-type Home = { id: SettingsScope; label: string; icon: LucideIcon; sections: Section[] };
 
-// Global = box-shared: the host cascade (Overview + the host-scoped Configuration
-// fields, ADR 0047) + the box-level ops Fleet / Telemetry / Commons (folded in here
-// from the former standalone "Box" rail surface). Host config is gated to the host
-// console; a workspace console sees a read-only pointer instead (ADR 0047 §7.7).
-const HOST_SECTIONS: Section[] = [
-  { id: "overview", label: "Overview", icon: Gauge, render: () => <OverviewPanel /> },
-  // The host-scoped FIELDS (model gateway · routing · caching · org + the commons
-  // location) in ONE panel, saving to the box's host-config.yaml (ADR 0047).
-  { id: "config", label: "Configuration", icon: HardDrive, render: () => (isHostConsole() ? <HostDefaultsPanel title="Configuration" /> : <HostConfigLocked />) },
-  // Box-level operations (formerly the standalone Box rail surface).
-  { id: "fleet", label: "Fleet", icon: Server, render: () => <FleetSurface /> },
-  { id: "telemetry", label: "Telemetry", icon: BarChart3, render: () => <TelemetrySurface /> },
-  { id: "commons", label: "Shared Skills", icon: Library, render: () => <CommonsPanel /> },
-];
-
-// The Workspace home (ADR 0048 §3.2) — the focused agent, everything that defines it:
-// the makeup panels (Identity/Tools/MCP/Subagents/Skills/Middleware) folded in from the
-// old Agent rail surface + Theme, plus the agent-scoped field settings (Agent/Memory/
-// System/Plugins categories). Host-scoped fields that appear here (e.g. model.name)
-// keep their ADR 0047 "inherited from Host" badge + override. The agent-scoped field
-// panel is "Model & Routing" (not a generic "Settings" item nested under Settings).
-const WORKSPACE_SECTIONS: Section[] = [
+// The focused agent's makeup + field settings. Host-scoped fields (model gateway · routing ·
+// caching · org · telemetry/fleet runtime) appear inline in Model & Routing / Memory / System
+// with their ADR 0047 inheritance badge.
+const AGENT_SECTIONS: Section[] = [
   { id: "identity", label: "Identity", icon: Sparkles, render: () => <IdentityPanel /> },
   // id stays "settings" for persisted-section compat; the label is the un-nested name.
   { id: "settings", label: "Model & Routing", icon: Settings2, render: () => <SettingsCategoryPanel category="Agent" title="Model & Routing" /> },
@@ -63,9 +45,6 @@ const WORKSPACE_SECTIONS: Section[] = [
   { id: "tools", label: "Tools", icon: Wrench, render: () => <ToolsPanel /> },
   { id: "mcp", label: "MCP", icon: Plug, render: () => <McpPanel /> },
   { id: "subagents", label: "Subagents", icon: Bot, render: () => <SubagentsPanel /> },
-  // The delegate registry (ADR 0025) is built-in core infrastructure — its config
-  // lives here alongside the agent's other call-out surfaces (Tools/MCP/Subagents),
-  // not under Plugins.
   { id: "delegates", label: "Delegates", icon: Network, render: () => <DelegatesSection /> },
   { id: "skills", label: "Skills", icon: BookMarked, render: () => <PlaybooksSurface /> },
   { id: "middleware", label: "Middleware", icon: Layers, render: () => <MiddlewarePanel /> },
@@ -74,10 +53,19 @@ const WORKSPACE_SECTIONS: Section[] = [
   { id: "theme", label: "Theme", icon: Palette, render: () => <ThemeSurface /> },
 ];
 
+// Box-wide operations (host console only) — the former Global ▸ Fleet/Telemetry/Shared Skills.
+// The old Global ▸ Configuration section is GONE: host-scoped FIELDS are edited inline in the
+// Agent group (on the host they write the host layer; elsewhere they override per-agent).
+const BOX_SECTIONS: Section[] = [
+  { id: "overview", label: "Overview", icon: Gauge, render: () => <OverviewPanel /> },
+  { id: "fleet", label: "Fleet", icon: Server, render: () => <FleetSurface /> },
+  { id: "telemetry", label: "Telemetry", icon: BarChart3, render: () => <TelemetrySurface /> },
+  { id: "commons", label: "Shared Skills", icon: Library, render: () => <CommonsPanel /> },
+];
+
 // The Plugins manager (install · enable · configure, plus the Discover directory) lives
-// HERE in Settings ▸ Plugins — folded in from the former standalone rail surface (2026-06).
-// Per-plugin config is inline per row (ADR 0059); the delegate registry is built-in core
-// infrastructure with its own Workspace ▸ Delegates section.
+// in Settings ▸ Plugins. Per-plugin config is inline per row (ADR 0059); the delegate
+// registry is built-in core infrastructure with its own Delegates section.
 function PluginSettingsHome() {
   const pluginsTab = useUI((s) => s.pluginsTab);
   const setPluginsTab = useUI((s) => s.setPluginsTab);
@@ -97,71 +85,38 @@ function PluginSettingsHome() {
   );
 }
 
-export const SETTINGS_HOMES: Home[] = [
-  { id: "host", label: "Global", icon: HardDrive, sections: HOST_SECTIONS },
-  { id: "workspace", label: "Workspace", icon: Boxes, sections: WORKSPACE_SECTIONS },
-];
-
-// `only` renders a single scope's sections WITHOUT the Global/Workspace toggle —
-// Workspace lives in the rail surface, Global in the header-drawer's overlay
-// (separated per the 2026-06-18 IA pass). The Global overlay keeps its own section
-// in local state (seeded by `initialSection`) so it never fights the rail's persisted
-// workspace section. Bare `<SettingsSurface />` keeps the legacy two-home toggle.
-export function SettingsSurface({ only, initialSection }: { only?: SettingsScope; initialSection?: string } = {}) {
-  const persistedScope = useUI((s) => s.settingsScope);
+// One consolidated settings surface. `only` is accepted but ignored (legacy callers) — there
+// is a single home now; the Box group is gated to the host console. `initialSection`
+// deep-links a section (the overlay / a ⌘K command).
+export function SettingsSurface({ initialSection }: { only?: "host" | "workspace"; initialSection?: string } = {}) {
+  const onHost = isHostConsole();
   const persistedSection = useUI((s) => s.settingsSection);
-  const setScope = useUI((s) => s.setSettingsScope);
-  const setPersistedSection = useUI((s) => s.setSettingsSection);
+  const setSection = useUI((s) => s.setSettingsSection);
 
-  const scope: SettingsScope = only ?? persistedScope;
-  const home = SETTINGS_HOMES.find((h) => h.id === scope) ?? SETTINGS_HOMES[0];
+  // Deep-link: select the requested section once when opened on one (overlay / palette).
+  useEffect(() => {
+    if (initialSection) setSection(initialSection);
+  }, [initialSection, setSection]);
 
-  // The Global overlay (only="host") tracks its section locally; the rail (workspace
-  // or the legacy toggle) uses the persisted store.
-  const overlay = only === "host";
-  const [localSection, setLocalSection] = useState(initialSection ?? home.sections[0].id);
-  const section = overlay ? localSection : persistedSection;
-  const setSection = overlay ? setLocalSection : setPersistedSection;
-  const active = home.sections.find((s) => s.id === section) ?? home.sections[0];
+  const sections = onHost ? [...AGENT_SECTIONS, ...BOX_SECTIONS] : AGENT_SECTIONS;
+  const active = sections.find((s) => s.id === persistedSection) ?? sections[0];
+  const toItem = (s: Section) => ({ id: s.id, label: s.label, icon: <s.icon size={15} /> });
+  const groups = [
+    { label: "Agent", items: AGENT_SECTIONS.map(toItem) },
+    ...(onHost ? [{ label: "Box", items: BOX_SECTIONS.map(toItem) }] : []),
+  ];
 
-  // Switching home lands on its first section unless the current section id also
-  // exists in the new home (it usually won't — the homes don't share section ids).
-  function selectHome(next: SettingsScope) {
-    const h = SETTINGS_HOMES.find((x) => x.id === next) ?? SETTINGS_HOMES[0];
-    setScope(next);
-    if (!h.sections.some((s) => s.id === section)) setSection(h.sections[0].id);
-  }
-
-  // Two-column settings shell: the DS SideNav rail (scope toggle pinned in its header
-  // slot + the sections down the side, ADR 0048) + the active section's panel filling
-  // the rest. Adopted from the interim hand-rolled rail once SideNav shipped in
-  // @protolabsai/ui 0.30.0 (protoContent#225 → #227). We deliberately DON'T pass
-  // `responsive`: its collapse-to-<select> fires at wrap ≤ 15rem, but our compact
-  // in-rail settings column sits below that, so it would render as a dropdown instead
-  // of the vertical nav — the opposite of the ask. The rail stays vertical in both the
-  // overlay and the stage; the narrow case is the separate mobile shell (ADR 0035 S4).
   return (
     <div className="settings-shell">
-      <SideNav
-        ariaLabel="Settings sections"
-        active={active.id}
-        onSelect={(t) => setSection(t)}
-        items={home.sections.map((s) => ({ id: s.id, label: s.label, icon: <s.icon size={15} /> }))}
-        // Scope toggle pinned atop the rail — only for the legacy two-home surface.
-        // A scoped surface (`only`) shows just its own sections, no toggle.
-        header={
-          only ? undefined : (
-            <Tabs
-              variant="segmented"
-              ariaLabel="Settings scope"
-              active={scope}
-              onSelect={(t) => selectHome(t as SettingsScope)}
-              items={SETTINGS_HOMES.map((h) => ({ id: h.id, label: h.label }))}
-            />
-          )
-        }
-      />
-      <div className="settings-content">{active.render()}</div>
+      <SideNav ariaLabel="Settings sections" groups={groups} active={active.id} onSelect={(id) => setSection(id)} />
+      <div className="settings-content">
+        <Alert status="info" className="settings-inheritance-banner">
+          {onHost
+            ? "Editing the host — these are the box defaults every agent inherits, unless an agent overrides them."
+            : "Editing this agent — it inherits the box defaults from the host; changes here override for this agent only."}
+        </Alert>
+        {active.render()}
+      </div>
     </div>
   );
 }

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -194,3 +194,10 @@
   color: var(--fg-secondary);
   cursor: pointer;
 }
+
+/* Inheritance banner (2026-06 settings consolidation) — sits atop the settings content,
+   above the active section, clarifying host (box defaults) vs member (overrides) context. */
+.settings-inheritance-banner {
+  margin: 0 0 14px;
+  flex: none;
+}

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -28,9 +28,9 @@ describe("migrateUiState", () => {
   // persisted railOrder rather than leaving a dead rail id with no surface metadata.
   it("prunes the obsolete 'box' rail surface", () => {
     const out = migrateUiState({
-      railOrder: { left: ["chat", "knowledge", "box", "settings"], right: ["work"] },
+      railOrder: { left: ["chat", "knowledge", "box"], right: ["work"] },
     }) as { railOrder: { left: string[]; right: string[] } };
-    expect(out.railOrder.left).toEqual(["chat", "knowledge", "settings"]);
+    expect(out.railOrder.left).toEqual(["chat", "knowledge"]);
     expect(out.railOrder.left).not.toContain("box");
     expect(out.railOrder.right).toEqual(["work"]);
   });
@@ -53,50 +53,41 @@ describe("migrateUiState", () => {
     expect(out.quickBar).toEqual(["chat", "knowledge"]);
   });
 
-  // v9 (2026-06-18 IA pass): Workspace settings became a rail surface; re-add "settings"
-  // to a persisted layout that lacks it so existing users don't lose the Settings icon.
-  it("restores the 'settings' rail surface to a layout that lacks it", () => {
-    const out = migrateUiState({
-      railOrder: { left: ["chat", "knowledge"], right: ["work"], bottom: [] },
-    }) as { railOrder: { left: string[] } };
-    // No "plugins" anchor on the left rail → settings appended to the end of it.
-    expect(out.railOrder.left).toEqual(["chat", "knowledge", "settings"]);
-  });
-
-  it("re-adds 'settings' where 'plugins' was, then v10 prunes 'plugins'", () => {
-    const out = migrateUiState({
-      railOrder: { left: ["chat", "schedule", "plugins", "knowledge"], right: ["beads"], bottom: [] },
-    }) as { railOrder: { left: string[] } };
-    // v9 inserts settings after the (legacy) plugins anchor; v10 removes plugins, v11 schedule.
-    expect(out.railOrder.left).toEqual(["chat", "settings", "knowledge"]);
-  });
+  // (v9 "re-add settings to the rail" is gone: Settings moved to a utility-bar pill in v12,
+  // which prunes the "settings" rail id — re-adding it would be undone. See the v12 test.)
 
   // v10 (2026-06): the Plugins manager moved into Settings ▸ Plugins. Prune "plugins" from
   // every dock + the quick-bar so it doesn't linger as a dead rail id.
   it("prunes 'plugins' from the rails and quick-bar", () => {
     const out = migrateUiState({
-      railOrder: { left: ["chat", "schedule", "plugins", "settings"], right: ["plugins", "beads"], bottom: ["plugins"] },
+      railOrder: { left: ["chat", "plugins", "knowledge"], right: ["plugins", "work"], bottom: ["plugins"] },
       quickBar: ["chat", "plugins", "knowledge"],
     }) as { railOrder: { left: string[]; right: string[]; bottom: string[] }; quickBar: string[] };
     expect(out.railOrder.left).not.toContain("plugins");
     expect(out.railOrder.right).not.toContain("plugins");
     expect(out.railOrder.bottom).not.toContain("plugins");
-    expect(out.railOrder.left).toEqual(["chat", "settings"]);
+    expect(out.railOrder.left).toEqual(["chat", "knowledge"]);
     expect(out.quickBar).toEqual(["chat", "knowledge"]);
   });
 
-  it("keeps a user-placed 'settings' where it is", () => {
+  // v12 (2026-06): Settings moved off the rail into a utility-bar pill. Prune "settings" from
+  // every dock + the quick-bar so it doesn't linger as a dead rail id.
+  it("prunes 'settings' from the rails and quick-bar", () => {
     const out = migrateUiState({
-      railOrder: { left: ["chat", "knowledge"], right: ["settings", "work"], bottom: [] },
-    }) as { railOrder: { left: string[]; right: string[] } };
-    expect(out.railOrder.right).toContain("settings");
+      railOrder: { left: ["chat", "settings", "knowledge"], right: ["settings", "work"], bottom: ["settings"] },
+      quickBar: ["chat", "settings", "knowledge"],
+    }) as { railOrder: { left: string[]; right: string[]; bottom: string[] }; quickBar: string[] };
     expect(out.railOrder.left).not.toContain("settings");
+    expect(out.railOrder.right).not.toContain("settings");
+    expect(out.railOrder.bottom).not.toContain("settings");
+    expect(out.railOrder.left).toEqual(["chat", "knowledge"]);
+    expect(out.quickBar).toEqual(["chat", "knowledge"]);
   });
 
   // v11 (2026-06): Beads + Goals + Schedule folded into the unified "work" hub.
   it("folds beads/goals/schedule into the 'work' hub", () => {
     const out = migrateUiState({
-      railOrder: { left: ["chat", "schedule", "knowledge", "settings"], right: ["beads", "goals"], bottom: [] },
+      railOrder: { left: ["chat", "schedule", "knowledge"], right: ["beads", "goals"], bottom: [] },
       rightPanel: "beads",
       quickBar: ["chat", "beads", "knowledge"],
     }) as { railOrder: { left: string[]; right: string[]; bottom: string[] }; rightPanel: string; quickBar: string[] };
@@ -105,7 +96,7 @@ describe("migrateUiState", () => {
       expect(out.railOrder.right).not.toContain(id);
       expect(out.quickBar).not.toContain(id);
     }
-    expect(out.railOrder.left).toEqual(["chat", "knowledge", "settings"]);
+    expect(out.railOrder.left).toEqual(["chat", "knowledge"]);
     expect(out.railOrder.right).toEqual(["work"]);
     expect(out.rightPanel).toBe("work");
     expect(out.quickBar).toEqual(["chat", "knowledge"]);
@@ -124,10 +115,10 @@ describe("migrateUiState", () => {
   it("adds the bottom dock to a pre-v6 railOrder", () => {
     // (schedule already present so the v7 inject is a no-op — keep this test on the dock)
     const out = migrateUiState({
-      railOrder: { left: ["chat", "knowledge", "settings"], right: ["work"] },
+      railOrder: { left: ["chat", "knowledge"], right: ["work"] },
     }) as { railOrder: { left: string[]; right: string[]; bottom: string[] } };
     expect(out.railOrder.bottom).toEqual([]);
-    expect(out.railOrder.left).toEqual(["chat", "knowledge", "settings"]);
+    expect(out.railOrder.left).toEqual(["chat", "knowledge"]);
   });
 
   it("does not mutate the input object", () => {

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -206,9 +206,16 @@ export function migrateUiState(persisted: unknown): unknown {
       rest.railOrder = { left, right, bottom };
     }
     if (rest.rightPanel === "beads" || rest.rightPanel === "goals") rest.rightPanel = "work";
+    // v12 (2026-06): Settings moved off the rail into a utility-bar pill (the settings
+    // dialog). Prune "settings" from every dock + the quick-bar — it's no longer a surface.
+    const ro9 = rest.railOrder as { left?: string[]; right?: string[]; bottom?: string[] } | undefined;
+    if (ro9) {
+      const noSettings = (arr?: string[]) => (Array.isArray(arr) ? arr.filter((x) => x !== "settings") : []);
+      rest.railOrder = { left: noSettings(ro9.left), right: noSettings(ro9.right), bottom: noSettings(ro9.bottom) };
+    }
     if (Array.isArray(rest.quickBar)) {
       rest.quickBar = (rest.quickBar as string[]).filter(
-        (x) => x !== "activity" && x !== "plugins" && !FOLDED.has(x),
+        (x) => x !== "activity" && x !== "plugins" && x !== "settings" && !FOLDED.has(x),
       );
     }
     return rest;
@@ -236,7 +243,7 @@ export const useUI = create<UIState>()(
       bottomHeight: 240,
       bottomCollapsed: false,
       railOrder: {
-        left: ["chat", "studio", "knowledge", "settings"],
+        left: ["chat", "studio", "knowledge"],
         right: ["work"],
         bottom: [],
       },
@@ -316,7 +323,7 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 11, // …v9 re-add Settings · v10 Plugins→Settings section · v11 Beads+Goals+Schedule→Work hub (prune ids, add work)
+      version: 12, // …v10 Plugins→Settings section · v11 Beads+Goals+Schedule→Work hub · v12 Settings→utility pill (prune rail id)
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
       // The Global settings overlay is ephemeral UI state — drop it from persistence so a
       // refresh never reopens it (everything else persists as before).


### PR DESCRIPTION
There aren't two kinds of settings — there's **one** set of agent settings over a 3-layer cascade (ADR 0047: App default → Host layer → Agent override). "Global ▸ Configuration" was just the Host layer, redundant with the inline host-scoped fields in the Workspace panels. So this collapses the two homes into **one surface** and moves the entry off the rail. (Built + verified in phases on the host console.)

## Consolidated surface
- `SettingsSurface` is a single home: an **Agent** group (Identity · Model & Routing · Plugins · Tools · MCP · Subagents · Delegates · Skills · Middleware · Memory · System · Theme) + a **host-only "Box"** group (Overview · Fleet · Telemetry · Shared Skills), via the DS SideNav `groups`. No Global/Workspace scope toggle. **Dropped the "Configuration" section** — host-scoped fields are edited inline in their categories.
- An **inheritance banner**: host → "these are the box defaults every agent inherits"; member → "overrides for this agent only".

## Save layer / badges (the correctness-sensitive bit)
- On the **host** console a Save splits by field scope: host-scoped fields write the **host layer** (the box default), agent-scoped write the host agent's leaf. On a **fleet member** everything overrides into that agent's leaf. The badge is host-aware — **"box default"** on the host vs **"inherited from host" / "overridden here" + Reset** on a member (ADR 0047).

## Entry point
- Settings is **no longer a rail surface** — it's a **utility-bar pill** (bottom-far-left) opening the one settings dialog (`SettingsOverlay`, retitled "Settings"). Removed the rail surface + the Global-only overlay; the pill, the header drawer ("Settings"), and ⌘K all open the same dialog. **v12 migration** prunes the `settings` rail id.

## Tests
- `uiStore` migration tests updated for v12 (removed the now-moot v9 settings re-add).
- `settings`/`navigation`/`mcp`/`delegates`/`playbooks`/`quick-settings`/`fleet` e2e reworked for the pill + grouped dialog; the dropped Configuration test **rewritten** to cover the inline **"box default"** badge + the host-layer save.

## Verification
web build/typecheck clean · **vitest 101** · **full e2e 112**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Consolidated Settings interface now accessible via utility bar button instead of the rail panel.
  * Host-scoped settings fields display inline with "box default" indicators on the host console.

* **Improvements**
  * Unified Settings dialog combines agent and host settings in one cohesive interface.
  * Simplified navigation and cleaner layout for accessing application settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->