### PR TITLE
feat(web): add Changelog link to the app side drawer

### DIFF
--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -20,6 +20,8 @@ test("the header hamburger opens the app drawer → Settings dialog", async ({ p
   await expect(changelog).toBeVisible();
   await expect(changelog).toHaveAttribute("href", "https://agent.protolabs.studio/changelog/");
   await expect(changelog).toHaveAttribute("target", "_blank");
+  // External link — assert rel guards against tabnabbing (security regression guard).
+  await expect(changelog).toHaveAttribute("rel", "noreferrer");
   await expect(drawer.getByRole("link", { name: "GitHub" })).toBeVisible();
   // Footer: version badge + protoLabs.studio branding link.
   await expect(drawer.getByText("v9.9.9", { exact: true })).toBeVisible();

--- a/apps/web/e2e/quick-settings.spec.ts
+++ b/apps/web/e2e/quick-settings.spec.ts
@@ -5,7 +5,7 @@ import { expect, test } from "@playwright/test";
 // two-home one-stop-shop is also openable as an overlay from the topbar.
 
 // The header hamburger opens the app drawer (2026-06-18 IA pass): global actions
-// (Settings, Telemetry) + the Docs/GitHub links. "Settings" opens the one consolidated
+// (Settings, Telemetry) + the Docs/Changelog/GitHub links. "Settings" opens the one consolidated
 // settings dialog (the same dialog the utility-bar pill opens — Global is no longer a
 // separate home).
 test("the header hamburger opens the app drawer → Settings dialog", async ({ page }) => {
@@ -16,6 +16,10 @@ test("the header hamburger opens the app drawer → Settings dialog", async ({ p
   await expect(drawer.getByRole("button", { name: "Settings", exact: true })).toBeVisible();
   await expect(drawer.getByRole("button", { name: "Telemetry", exact: true })).toBeVisible();
   await expect(drawer.getByRole("link", { name: "Docs" })).toBeVisible();
+  const changelog = drawer.getByRole("link", { name: "Changelog" });
+  await expect(changelog).toBeVisible();
+  await expect(changelog).toHaveAttribute("href", "https://agent.protolabs.studio/changelog/");
+  await expect(changelog).toHaveAttribute("target", "_blank");
   await expect(drawer.getByRole("link", { name: "GitHub" })).toBeVisible();
   // Footer: version badge + protoLabs.studio branding link.
   await expect(drawer.getByText("v9.9.9", { exact: true })).toBeVisible();

--- a/apps/web/src/app/AppDrawer.tsx
+++ b/apps/web/src/app/AppDrawer.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import type { ReactNode } from "react";
-import { BarChart3, BookOpen, Github, Settings2, X } from "lucide-react";
+import { BarChart3, BookOpen, Github, ScrollText, Settings2, X } from "lucide-react";
 
 import { Button } from "@protolabsai/ui/primitives";
 
@@ -11,7 +11,7 @@ type SurfaceItem = { id: string; label: string; icon: ReactNode };
 /**
  * The app menu drawer — a right-side sheet opened by the header hamburger (2026-06-18
  * IA pass). One drawer for both modes: on desktop it holds the box-level/global actions
- * (Global settings, Telemetry) + the GitHub/Docs links; on mobile it ALSO lists the
+ * (Global settings, Telemetry) + the Docs/Changelog/GitHub links; on mobile it ALSO lists the
  * surfaces (it's the mobile "more"). Workspace settings stay in the rail surface, not here.
  */
 export function AppDrawer({
@@ -100,6 +100,16 @@ export function AppDrawer({
             >
               <span className="app-drawer-ico"><BookOpen size={16} /></span>
               Docs
+            </a>
+            <a
+              className="app-drawer-item"
+              href="https://agent.protolabs.studio/changelog/"
+              target="_blank"
+              rel="noreferrer"
+              onClick={onClose}
+            >
+              <span className="app-drawer-ico"><ScrollText size={16} /></span>
+              Changelog
             </a>
             <a
               className="app-drawer-item"


### PR DESCRIPTION
## What

Adds a **Changelog** link to the app side drawer's **Links** section (next to Docs and GitHub) that opens the marketing-site changelog at `https://agent.protolabs.studio/changelog/` in a new tab.

## Why

Users had no in-app path to "what's new". The drawer's Links group is where the other external resources (Docs, GitHub) already live, so the changelog belongs there.

## Changes

- **`apps/web/src/app/AppDrawer.tsx`** — new external `<a>` between Docs and GitHub using the `ScrollText` icon, `target="_blank"` + `rel="noreferrer"`, and `onClick={onClose}` to dismiss the drawer (matching the sibling links).
- **`apps/web/e2e/quick-settings.spec.ts`** — assert the Changelog link is visible, points at the marketing changelog URL, and opens externally.

## Testing

- `npm run build` (web workspace) — clean
- `npx playwright test quick-settings.spec.ts` — 2 passed (incl. the new Changelog assertions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a Changelog link to the app drawer, enabling quick access to the latest updates.
* **Bug Fixes**
  * Enhanced the end-to-end test coverage to verify the Changelog link is visible and opens correctly (including expected link attributes).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->