### PR TITLE
fix(desktop): bundle config/skills into the frozen sidecar (0 skills in desktop app)

### DIFF
--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -48,6 +48,13 @@ BUNDLED_DATA: list[tuple[str, str]] = [
     # Plugins ▸ Discover shows "0 official plugins" (every entry is unreachable).
     ("config/plugin-catalog.json", "config"),
     ("config/soul-presets", "config/soul-presets"),
+    # The bundled first-party skills (config/skills/*/SKILL.md — release-notes,
+    # web-research). `_build_skills_index` (server/agent_init.py) seeds the skill
+    # index from REPO_ROOT/config/skills (→ _MEIPASS/config/skills when frozen),
+    # exactly like SOUL.md/soul-presets above. Without this entry the directory
+    # never lands in the bundle, so the frozen desktop app indexes 0 SKILL.md
+    # skills — the `/skill` library is silently empty.
+    ("config/skills", "config/skills"),
     ("static", "static"),
     # The DS plugin-kit (/_ds/plugin-kit.{css,js}) — the theme kit every plugin iframe
     # loads to match the console (operator_api/web.py serves it from


### PR DESCRIPTION
## Problem

The desktop app ships with **0 skills** — none of the bundled `SKILL.md` skills (release-notes, web-research) are available, even though they work under `python -m server`.

## Root cause

The PyInstaller sidecar's `BUNDLED_DATA` list (`apps/desktop/sidecar/build_sidecar.py`) bundles every read-only config default — `SOUL.md`, `soul-presets`, `plugin-catalog.json`, `langgraph-config.example.yaml` — **except `config/skills`**. So nothing landed at `_MEIPASS/config/skills` in the frozen binary.

`_build_skills_index` (`server/agent_init.py`) seeds the skill index from `_BUNDLE_CONFIG_DIR / "skills"` (= `REPO_ROOT/config/skills` → `_MEIPASS/config/skills` when frozen) — the **same** bundle dir that resolves `SOUL.md` correctly. Since SOUL.md/soul-presets/catalog all work in the desktop app, the path resolution was never the issue; the directory simply wasn't in the bundle. The skill loader globbed an empty/absent dir → indexed 0 skills.

## Fix

Add `("config/skills", "config/skills")` to `BUNDLED_DATA`. One line + comment.

- Plugin-bundled skills (`plugins/*/skills/`) were **already** shipped via the existing `("plugins", "plugins")` tree — only the core `config/skills` was missing.
- The static `build/sidecar/*.spec` is a git-ignored regenerated artifact; CI builds via `build_sidecar.py` (desktop-build.yml line 161), so this is the authoritative path.

## Verification

- `ruff check` passes on the changed file.
- `config/skills/release-notes/SKILL.md` and `config/skills/web-research/SKILL.md` exist in-repo, so the `(REPO / src).exists()` guard won't skip the entry.
- Takes effect on the **next `.0` desktop build** (the desktop matrix only fires on minor/major tags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed missing skills configuration data in the application bundle, ensuring all built-in skills are properly available at runtime.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->