### PR TITLE
feat(web): goal mode always on — drop its Settings toggle, Overview metric, and status field

### DIFF
--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -39,11 +39,6 @@ export type RuntimeStatus = {
     enabled: boolean;
     backend: string;
   };
-  goal: {
-    enabled: boolean;
-    controller_loaded: boolean;
-    max_iterations?: number | null;
-  };
   cache_warmer: {
     enabled: boolean;
     loaded: boolean;

--- a/apps/web/src/settings/OverviewPanel.tsx
+++ b/apps/web/src/settings/OverviewPanel.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { Bot, Database, HardDrive, Settings2, Sparkles, Tag } from "lucide-react";
+import { Bot, Database, HardDrive, Settings2, Tag } from "lucide-react";
 import { type ReactNode } from "react";
 
 import { brandName } from "../lib/brand";
@@ -8,7 +8,7 @@ import { runtimeStatusQuery } from "../lib/queries";
 import { StagePanel } from "../app/ErrorBoundary";
 
 // Settings → Overview: the agent's read-only status at a glance (model, knowledge,
-// goal, on-disk store sizes). Telemetry is its own tab now. The editable
+// on-disk store sizes). Telemetry is its own tab now. The editable
 // bits (name, persona, middleware, tools) live under the Agent section.
 
 function fmtBytes(n: number | null | undefined): string {
@@ -58,7 +58,6 @@ function StatusBody() {
                   (runtime.knowledge.enabled ? "enabled" : "disabled")
             }
           />
-          <Metric icon={<Sparkles size={16} />} label="Goal mode" value={runtime.goal.enabled ? "on" : "off"} />
         </div>
         {runtime.storage ? (
           <>

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -195,7 +195,10 @@ FIELDS: list[Field] = [
         options_source="models+acp",
     ),
     # ── Goal mode ────────────────────────────────────────────────────────────
-    Field("goal.enabled", "goal_enabled", "Enable goal mode", "bool", "Goal mode"),
+    # Goal mode is always on (config default True). The on/off toggle is hidden from
+    # the Settings UI; the field stays in FIELDS so existing configs round-trip and the
+    # YAML value (if any) is still honored. Tuning knobs below remain user-editable.
+    Field("goal.enabled", "goal_enabled", "Enable goal mode", "bool", "Goal mode", ui_hidden=True),
     Field("goal.max_iterations", "goal_max_iterations", "Max continuations", "number", "Goal mode", minimum=1),
     Field(
         "goal.eval_model",

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -78,7 +78,6 @@ def _operator_runtime_status():
         knowledge_store=STATE.knowledge_store,
         scheduler=STATE.scheduler,
         cache_warmer=STATE.cache_warmer,
-        goal_controller=STATE.goal_controller,
         skills_index=STATE.skills_index,
         mcp={
             "enabled": bool(getattr(STATE.graph_config, "mcp_enabled", False)) if STATE.graph_config else False,

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -15,7 +15,6 @@ def build_runtime_status(
     knowledge_store: Any = None,
     scheduler: Any = None,
     cache_warmer: Any = None,
-    goal_controller: Any = None,
     skills_index: Any = None,
     mcp: dict[str, Any] | None = None,
     plugins: list[dict[str, Any]] | None = None,
@@ -67,7 +66,6 @@ def build_runtime_status(
             "mcp": mcp_block,
             "plugins": plugins_block,
             "scheduler": {"enabled": False, "backend": "disabled"},
-            "goal": {"enabled": False, "controller_loaded": False},
             "cache_warmer": {"enabled": False, "loaded": False},
             "warnings": warnings_block,
             "instance_uid": instance_uid,
@@ -129,12 +127,6 @@ def build_runtime_status(
         "scheduler": {
             "enabled": bool(getattr(config, "scheduler_enabled", False)),
             "backend": getattr(scheduler, "name", "disabled") if scheduler else "disabled",
-        },
-        "goal": {
-            "enabled": bool(getattr(config, "goal_enabled", False)),
-            "controller_loaded": goal_controller is not None,
-            "max_iterations": getattr(config, "goal_max_iterations", None),
-            "no_progress_limit": getattr(config, "goal_no_progress_limit", None),
         },
         "cache_warmer": {
             "enabled": bool(getattr(config, "cache_warming_enabled", False)),

--- a/tests/test_operator_api_runtime.py
+++ b/tests/test_operator_api_runtime.py
@@ -31,7 +31,6 @@ def test_runtime_status_redacts_secret_values() -> None:
         knowledge_store=_Store(),
         scheduler=_Scheduler(),
         cache_warmer=object(),
-        goal_controller=object(),
     )
 
     assert status["model"]["name"] == "protolabs/reasoning"

--- a/tests/test_settings_cascade.py
+++ b/tests/test_settings_cascade.py
@@ -129,18 +129,20 @@ def test_build_schema_reports_scope_and_source():
     cfg = LangGraphConfig()  # App defaults
     groups = build_schema(
         cfg,
-        agent_doc={"goal": {"enabled": False}},  # agent leaf sets an agent-scoped key
+        # goal.max_iterations is an agent-scoped knob (goal.enabled is ui_hidden now —
+        # goal mode is always on — so it no longer appears in build_schema output).
+        agent_doc={"goal": {"max_iterations": 5}},  # agent leaf sets an agent-scoped key
         host_doc={"model": {"name": "host-m"}},  # host layer sets a host-scoped key
     )
     by_key = {e["key"]: e for g in groups for e in g["fields"]}
 
     # scope reflects ADR 0047 §2.1
     assert by_key["model.name"]["scope"] == "host"
-    assert by_key["goal.enabled"]["scope"] == "agent"
+    assert by_key["goal.max_iterations"]["scope"] == "agent"
 
     # source = the layer the live value came from
     assert by_key["model.name"]["source"] == "host"  # inherited from Host
-    assert by_key["goal.enabled"]["source"] == "agent"  # set in the agent leaf
+    assert by_key["goal.max_iterations"]["source"] == "agent"  # set in the agent leaf
     assert by_key["compaction.enabled"]["source"] == "default"  # neither layer → App default
 
 


### PR DESCRIPTION
Goal mode ships always-enabled (config default stays `True`). Its on/off controls are removed from the operator console.

> Rebased onto `main` after the settings-consolidation work landed separately as #1218 — this PR is now **just the goal-mode change** (7 files) on top of v0.59.0.

## Changes
- **Overview panel** — dropped the read-only "Goal mode: on/off" metric (`OverviewPanel.tsx`).
- **Settings** — hid the "Enable goal mode" toggle via `ui_hidden` (`settings_schema.py`). The field stays in `FIELDS` so existing configs round-trip and any YAML value is still honored; the goal machinery is untouched. Tuning knobs (max continuations, verifier model) stay editable.
- **Runtime-status API** — stripped the `goal` block and the now-unused `goal_controller` param from `build_runtime_status` (`operator_api/runtime.py`, `console_handlers.py`) and the matching `goal` block from the `RuntimeStatus` type (`types.ts`).
- **Tests** — `test_settings_cascade.py` moves its canonical agent-scoped example off `goal.enabled` (now hidden) to `goal.max_iterations`; dropped the `goal_controller=object()` arg from `test_operator_api_runtime.py`.

`set_goal`, the goal controller, and `/api/goals*` endpoints are unchanged — goal mode is always on, just no longer surfaced as a toggle or status field.

## Gates run locally
- `ruff check .` — clean
- `pytest` (cascade / runtime / console / goal suites) — green
- `npm run test:unit --workspace @protoagent/web` — 101/101
- `tsc --noEmit` — clean
- Rebuilt `apps/web/dist`; confirmed "Goal mode" absent from the bundle, other Overview labels intact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed "Goal mode" performance metric from the Overview settings panel display. Goal mode is now permanently enabled by default system configuration. The configuration toggle has been hidden from the Settings UI, as this feature is no longer manually configurable by users. This streamlines the user experience and reduces unnecessary configuration options.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->