### PR TITLE
chore: release v0.60.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.60.0] - 2026-06-19
 
+### Added
+- **The app side drawer now has a Changelog link.** A *Changelog* entry joins Docs/GitHub in the
+  drawer's Links section and opens the marketing-site changelog
+  (`agent.protolabs.studio/changelog`) in a new tab. (#1220)
+
+### Changed
+- **Goal mode is always on.** Its on/off controls are removed from the operator console — the
+  Overview "Goal mode" metric, the "Enable goal mode" Settings toggle (now `ui_hidden`), and the
+  `goal` block in the `/api/runtime/status` response. The config field stays (default on) so
+  existing configs round-trip; the `set_goal` tool, goal controller, and `/api/goals*` endpoints
+  are unchanged, and the tuning knobs (max continuations, verifier model) remain editable. (#1222)
+
+### Fixed
+- **The frozen desktop app now bundles `config/skills`.** The PyInstaller sidecar shipped every
+  read-only config default *except* `config/skills`, so the skill index had nothing to seed from
+  at `_MEIPASS/config/skills` in the packaged desktop build. It's now included alongside SOUL.md
+  and the other bundled config. (#1221)
+
 ## [0.59.0] - 2026-06-19
 
 ## [0.58.0] - 2026-06-19

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.60.0] - 2026-06-19
+
 ## [0.59.0] - 2026-06-19
 
 ## [0.58.0] - 2026-06-19

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.59.0"
+version = "0.60.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.60.0",
+    "date": "2026-06-19",
+    "changes": [
+      "The app side drawer now has a Changelog link.",
+      "Goal mode is always on.",
+      "The frozen desktop app now bundles config/skills."
+    ]
+  },
+  {
     "version": "v0.56.1",
     "date": "2026-06-19",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.60.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.60.0 -m 'Release v0.60.0' && git push origin v0.60.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Bumped the project version to **0.60.0**.
* **Documentation**
  * Updated the marketing changelog to include **v0.60.0** (dated **2026-06-19**) and the latest listed changes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->