### PR TITLE
feat(acp): full tool parity for the ACP runtime + honest console surfaces

### DIFF
--- a/apps/web/src/chat/ComposerModelSelect.tsx
+++ b/apps/web/src/chat/ComposerModelSelect.tsx
@@ -3,7 +3,7 @@ import { useQuery } from "@tanstack/react-query";
 import { Badge } from "@protolabsai/ui/primitives";
 import { Menu, MenuItem } from "@protolabsai/ui/menu";
 
-import { settingsSchemaQuery } from "../lib/queries";
+import { runtimeStatusQuery, settingsSchemaQuery } from "../lib/queries";
 import { chatStore, useChatState } from "./chat-store";
 
 // The composer's inline model picker — rendered in the DS PromptInput `actions` slot.
@@ -15,6 +15,7 @@ import { chatStore, useChatState } from "./chat-store";
 // picker uses.
 export function ComposerModelSelect() {
   const schema = useQuery(settingsSchemaQuery());
+  const runtime = useQuery(runtimeStatusQuery());
   const { sessions, currentSessionId } = useChatState();
   const field = schema.data?.groups.flatMap((g) => g.fields).find((f) => f.key === "model.name");
 
@@ -22,6 +23,21 @@ export function ComposerModelSelect() {
   const options = field?.options?.length ? field.options : globalModel ? [globalModel] : [];
   const session = sessions.find((s) => s.id === currentSessionId);
   const selected = session?.model ?? "";
+
+  // Under an ACP runtime the turn is driven by an external coding agent, not the
+  // gateway model — so showing/picking a gateway model is misleading and inert.
+  // Surface the active runtime as a static label instead of the model menu.
+  const acpAgent = (runtime.data?.agent_runtime ?? "").startsWith("acp:")
+    ? runtime.data!.agent_runtime!.slice("acp:".length)
+    : "";
+  if (acpAgent && currentSessionId) {
+    return (
+      <span className="composer-model-select" aria-label="Active runtime" title={`This chat runs on the ${acpAgent} coding agent (agent_runtime: acp:${acpAgent}) — not a gateway model.`}>
+        {acpAgent}
+        <Badge>coding agent</Badge>
+      </span>
+    );
+  }
 
   if (!options.length || !currentSessionId) return null;
 

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -42,6 +42,18 @@
   flex: none;
 }
 
+/* Defensive: an ACP coding agent can report a long/unbroken tool NAME (e.g. a verbose
+   MCP tool title). Let the header shrink + the name wrap so it can never force the card
+   wider than the chat panel — the args/source live in the expandable body, not here. */
+.tool-calls .pl-toolcard__head-row,
+.tool-calls .pl-toolcard__label {
+  min-width: 0;
+}
+.tool-calls .pl-toolcard__name {
+  overflow-wrap: anywhere;
+  word-break: break-word;
+}
+
 /* Generic JSON-blob fallback box, scoped to the DS body slot. */
 .pl-toolcard__body pre {
   margin: 0;

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -51,7 +51,6 @@
 }
 .tool-calls .pl-toolcard__name {
   overflow-wrap: anywhere;
-  word-break: break-word;
 }
 
 /* Generic JSON-blob fallback box, scoped to the DS body slot. */

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -8,6 +8,11 @@ export type RuntimeStatus = {
     path: string;
     allowed_dirs?: string[];
   };
+  /** Which brain drives a turn (ADR 0033): "native" = the LangGraph loop, or
+   *  "acp:<agent>" = an external coding agent. The console reads this to label the
+   *  active runtime instead of the gateway model and to flag that protoAgent
+   *  skills/commands don't apply in coding-agent mode. */
+  agent_runtime?: string;
   model: null | {
     provider: string;
     name: string;

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -73,11 +73,12 @@ FIELDS: list[Field] = [
     Field(
         "operator_mcp.tools",
         "operator_mcp_tools",
-        "Tools exposed to the ACP brain",
+        "Restrict tools for the ACP brain",
         "string_list",
         "Agent runtime",
-        "Allowlist of operator tools an external (ACP) brain may call via MCP — "
-        "one per line, or `*` for all (minus execute_code). Empty = none. Ignored by native.",
+        "Optional restriction on which operator tools an external (ACP) brain may call via "
+        "MCP — one per line, or `*` for all. Empty = the full toolset (parity with the native "
+        "runtime, minus execute_code the coding agent already has). Ignored by native.",
     ),
     # ── Model ────────────────────────────────────────────────────────────────
     Field(

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -58,6 +58,7 @@ def build_runtime_status(
             "setup_complete": bool(setup_complete),
             "graph_loaded": False,
             "project": project,
+            "agent_runtime": "native",
             "model": None,
             "identity": None,
             "middleware": {},
@@ -83,6 +84,11 @@ def build_runtime_status(
         "setup_complete": bool(setup_complete),
         "graph_loaded": bool(graph_loaded),
         "project": project,
+        # Which brain drives a turn (ADR 0033): "native" = the LangGraph loop, or
+        # "acp:<agent>" = an external coding agent. The console reads this to stop
+        # misrepresenting an ACP turn as the gateway model + to flag that protoAgent
+        # skills/commands don't apply in coding-agent mode.
+        "agent_runtime": str(getattr(config, "agent_runtime", "native") or "native"),
         "model": {
             "provider": getattr(config, "model_provider", ""),
             "name": getattr(config, "model_name", ""),

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -29,6 +29,7 @@ import asyncio
 import json
 import logging
 import os
+import re
 from pathlib import Path
 from typing import Awaitable, Callable
 
@@ -50,6 +51,28 @@ def _tool_output_preview(update: dict, limit: int = 300) -> str:
         elif isinstance(block.get("text"), str):
             out.append(block["text"])
     return " ".join(o for o in out if o).strip()[:limit]
+
+
+def _split_tool_title(title: str) -> tuple[str, str]:
+    """Split an ACP tool ``title`` into (label, inline_input). Many agents format the
+    title as ``tool_name (… MCP Server): {json args}`` — the inline JSON blows out the
+    card header and overflows the chat panel, so peel it into the body. Returns
+    ``(label, inline_json)`` where ``inline_json`` is ``""`` when there's none."""
+    s = (title or "").strip()
+    i = s.find("{")
+    if i > 0:
+        return s[:i].rstrip().rstrip(":").rstrip(), s[i:].strip()
+    return s, ""
+
+
+def _short_tool_name(title: str) -> str:
+    """A compact card label from a (possibly verbose) ACP tool title: drop the inline
+    JSON args and a trailing ``(… MCP Server)`` source so the header stays a short
+    at-a-glance name (parity with the native runtime's clean tool names). The args +
+    source live in the card body instead."""
+    label, _ = _split_tool_title(title)
+    label = re.sub(r"\s*\([^)]*\)\s*$", "", label).strip()  # drop trailing "(… server)"
+    return (label or (title or "").strip() or "tool")[:80]
 
 
 def _content_text(content) -> str:
@@ -320,15 +343,27 @@ class AcpClient:
                 await self._emit_thought(text)
         elif kind == "tool_call":
             # A tool call STARTED — narrate its title + emit a structured start event so the
-            # UI can render a card (parity with the native runtime's tool_start).
-            title = update.get("title") or update.get("kind") or "working"
-            await self._narrate(str(title))
+            # UI can render a card (parity with the native runtime's tool_start). The card
+            # NAME is a short label; the verbose args (structured rawInput, else the title's
+            # inline JSON) go into the card BODY so they don't overflow the chat header.
+            title = str(update.get("title") or update.get("kind") or "working")
+            name = _short_tool_name(title)
+            await self._narrate(name)
+            raw_input = update.get("rawInput")
+            if raw_input not in (None, "", {}, []):
+                try:
+                    tool_input = json.dumps(raw_input, ensure_ascii=False)
+                except (TypeError, ValueError):
+                    tool_input = str(raw_input)
+            else:
+                _, inline = _split_tool_title(title)
+                tool_input = inline or str(update.get("kind") or "")
             await self._emit_tool(
                 {
                     "phase": "start",
                     "id": str(update.get("toolCallId") or title),
-                    "name": str(title),
-                    "input": str(update.get("kind") or ""),
+                    "name": name,
+                    "input": tool_input,
                 }
             )
         elif kind == "tool_call_update":
@@ -339,7 +374,7 @@ class AcpClient:
                     {
                         "phase": "end",
                         "id": str(update.get("toolCallId") or ""),
-                        "name": str(update.get("title") or ""),
+                        "name": _short_tool_name(str(update.get("title") or "")),
                         "output": _tool_output_preview(update),
                         "status": status,
                     }

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -71,7 +71,8 @@ def _short_tool_name(title: str) -> str:
     at-a-glance name (parity with the native runtime's clean tool names). The args +
     source live in the card body instead."""
     label, _ = _split_tool_title(title)
-    label = re.sub(r"\s*\([^)]*\)\s*$", "", label).strip()  # drop trailing "(… server)"
+    # Drop a trailing "(… MCP Server)" source suffix only — NOT a legit "(beta)" / "(v2)".
+    label = re.sub(r"\s*\([^)]*\b(?:MCP|server)\b[^)]*\)\s*$", "", label, flags=re.IGNORECASE).strip()
     return (label or (title or "").strip() or "tool")[:80]
 
 

--- a/runtime/acp_runtime.py
+++ b/runtime/acp_runtime.py
@@ -66,11 +66,17 @@ def adapter_for(agent: str, config=None) -> dict:
     raise ValueError(f"no ACP adapter for {agent!r} — add acp.agents.{agent}.command in config")
 
 
-def operator_mcp_server_spec(config) -> dict | None:
-    """The ``mcpServers`` entry mounting slice 1's operator MCP server, or None when no
-    tools are allowlisted (nothing to expose)."""
-    if not (getattr(config, "operator_mcp_tools", None) or []):
-        return None
+def operator_mcp_server_spec(config) -> dict:
+    """The ``mcpServers`` entry mounting slice 1's operator MCP server.
+
+    Under an ACP runtime the coding agent IS the brain, so it gets protoAgent's FULL
+    toolset by default — parity with the native runtime, where the gateway model has
+    every tool. There is no "enable tools for ACP" step: ``operator_mcp.tools`` is an
+    optional *restriction* (a named allowlist), not a requirement. Empty/unset ⇒ ``"*"``
+    (everything, minus the redundant code-exec tool the coding agent already has — see
+    ``server.operator_mcp._STAR_EXCLUDE``)."""
+    configured = list(getattr(config, "operator_mcp_tools", None) or [])
+    allow = configured or ["*"]  # empty ⇒ full toolset, parity with the native runtime
     # ACP's stdio MCP-server schema wants env as an array of {name, value} (not a dict).
     # The agent spawns this command in its OWN cwd, so put the repo on PYTHONPATH — else
     # `-m server.operator_mcp` can't import (unless protoagent is pip-installed).
@@ -80,10 +86,9 @@ def operator_mcp_server_spec(config) -> dict | None:
     inst = os.environ.get("PROTOAGENT_INSTANCE")
     if inst:
         env.append({"name": "PROTOAGENT_INSTANCE", "value": inst})  # share this instance's data
-    # Pass the runtime's allowlist to the child explicitly — the spawned server otherwise
-    # reads operator_mcp.tools from YAML, which may not match this runtime's intent.
-    tools = ",".join(getattr(config, "operator_mcp_tools", []) or [])
-    env.append({"name": "OPERATOR_MCP_TOOLS", "value": tools})
+    # Pass the resolved allowlist to the child explicitly — the spawned server otherwise
+    # reads operator_mcp.tools from YAML, which wouldn't carry the "*" default.
+    env.append({"name": "OPERATOR_MCP_TOOLS", "value": ",".join(allow)})
     return {
         "name": "protoagent-operator",
         "command": sys.executable,

--- a/server/operator_mcp.py
+++ b/server/operator_mcp.py
@@ -8,9 +8,13 @@ subagents, set goals, schedule work — whatever you allowlist.
 
 Design (ADR 0033 D3 + D5):
 
-- **Opt-in + allowlist-gated.** Only tools named in ``operator_mcp.tools`` are exposed
-  (empty → nothing, mirroring how the comps default external brains to no framework
-  tools). Don't hand ``execute_code`` etc. to an outside agent unless you mean to.
+- **Allowlist-gated resolver, ACP-brain defaults to all.** ``operator_tools`` exposes only
+  the tools named in its allowlist (empty → nothing) — so a *foreign* MCP client (Claude
+  Desktop, Cursor) gets nothing it wasn't granted. But when the operator MCP is the BRAIN's
+  own tool bridge (``agent_runtime: acp:<agent>``), ``operator_mcp_server_spec`` defaults the
+  allowlist to ``"*"`` — full parity with the native runtime, where the model has every tool.
+  ``operator_mcp.tools`` then only *restricts* the ACP brain. (``execute_code`` is dropped
+  from ``"*"`` — the coding agent already has its own; allowlist it by name to override.)
 - **Core + plugin, uniformly.** Plugin tools live in the same registry, so they ride
   this one bridge for free — no per-plugin MCP. (Plugins that *are* an MCP server, via
   ``register_mcp_server``, are mounted directly by the client, not re-wrapped here.)

--- a/tests/test_acp_runtime.py
+++ b/tests/test_acp_runtime.py
@@ -48,11 +48,21 @@ def test_adapter_default_and_override():
         adapter_for("nonexistent")
 
 
-def test_operator_mcp_spec_gated_on_allowlist():
-    assert operator_mcp_server_spec(types.SimpleNamespace(operator_mcp_tools=[])) is None
-    spec = operator_mcp_server_spec(types.SimpleNamespace(operator_mcp_tools=["beads_list"]))
+def test_operator_mcp_spec_defaults_to_full_toolset():
+    """No "enable tools for ACP" step: an empty operator_mcp.tools defaults to "*" — the
+    coding-agent brain gets protoAgent's full toolset, parity with the native runtime."""
+    spec = operator_mcp_server_spec(types.SimpleNamespace(operator_mcp_tools=[]))
     assert spec["name"] == "protoagent-operator"
     assert spec["args"] == ["-m", "server.operator_mcp"]
+    env = {e["name"]: e["value"] for e in spec["env"]}
+    assert env["OPERATOR_MCP_TOOLS"] == "*"  # empty ⇒ everything
+
+
+def test_operator_mcp_spec_honors_explicit_restriction():
+    """A configured allowlist is honored verbatim as a *restriction* on the ACP brain."""
+    spec = operator_mcp_server_spec(types.SimpleNamespace(operator_mcp_tools=["beads_list", "web_search"]))
+    env = {e["name"]: e["value"] for e in spec["env"]}
+    assert env["OPERATOR_MCP_TOOLS"] == "beads_list,web_search"
 
 
 class _FakeCtx:

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -30,6 +30,8 @@ def test_short_tool_name_peels_inline_args_and_mcp_source():
     assert _short_tool_name('fetch_url (protoagent-operator MCP Server): {"url":"https://x"}') == "fetch_url"
     # No inline args / no parenthetical → left mostly as-is.
     assert _short_tool_name("Skill: Use skill: 'browser-automation'") == "Skill: Use skill: 'browser-automation'"
+    # A legit, non-MCP trailing parenthetical is PRESERVED (only "(… MCP Server)" is peeled).
+    assert _short_tool_name("search (beta)") == "search (beta)"
     # Defensive cap so an unbounded title can never blow out the header.
     assert len(_short_tool_name("x" * 500)) <= 80
 

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -18,7 +18,29 @@ import pytest
 
 import plugins.coding_agent as P
 from plugins.coding_agent import _make_permission
-from plugins.coding_agent.acp_client import AcpClient, AcpError
+from plugins.coding_agent.acp_client import AcpClient, AcpError, _short_tool_name, _split_tool_title
+
+
+def test_short_tool_name_peels_inline_args_and_mcp_source():
+    # A verbose MCP tool title → a compact card label (args + source go to the body).
+    assert (
+        _short_tool_name('web_search (protoagent-operator MCP Server): {"query":"pdx weather"}')
+        == "web_search"
+    )
+    assert _short_tool_name('fetch_url (protoagent-operator MCP Server): {"url":"https://x"}') == "fetch_url"
+    # No inline args / no parenthetical → left mostly as-is.
+    assert _short_tool_name("Skill: Use skill: 'browser-automation'") == "Skill: Use skill: 'browser-automation'"
+    # Defensive cap so an unbounded title can never blow out the header.
+    assert len(_short_tool_name("x" * 500)) <= 80
+
+
+def test_split_tool_title_separates_inline_json():
+    label, inline = _split_tool_title('web_search (proto MCP Server): {"query":"pdx"}')
+    assert label == "web_search (proto MCP Server)"
+    assert inline == '{"query":"pdx"}'
+    # No JSON → empty inline, label unchanged.
+    assert _split_tool_title("current_time") == ("current_time", "")
+
 
 # ── a minimal ACP "agent" (server side) we can drive over stdio ───────────────
 # Speaks just enough of the protocol: handshakes, opens a session, and on a

--- a/tests/test_operator_api_runtime.py
+++ b/tests/test_operator_api_runtime.py
@@ -42,6 +42,7 @@ def test_runtime_status_redacts_secret_values() -> None:
     # Flag on (default) + store built → ready.
     assert status["knowledge"]["status"] == "ready"
     assert status["scheduler"]["backend"] == "local"
+    assert status["agent_runtime"] == "native"  # no agent_runtime set → native
     assert "sk-secret" not in repr(status)
 
 
@@ -56,6 +57,7 @@ def test_runtime_status_handles_missing_config() -> None:
     assert status["graph_loaded"] is False
     assert status["model"] is None
     assert status["knowledge"]["enabled"] is False
+    assert status["agent_runtime"] == "native"  # no config → default native
     # No config yet (booting) → initializing, not "disabled".
     assert status["knowledge"]["status"] == "initializing"
     assert status["project"]["allowed_dirs"] == []


### PR DESCRIPTION
Under `agent_runtime: acp:<agent>` the coding agent IS the brain — but it had **none** of protoAgent's tools unless you manually populated `operator_mcp.tools` (empty by default). So a skill fed to the coding agent (slash-expanded or retrieved into context) was handed a procedure with no `web_search`/`fetch_url` to run it. This makes the ACP runtime behave like the native one: the brain gets the full toolset.

## Full tool parity
- **`runtime/acp_runtime.py`** — `operator_mcp_server_spec` now defaults an empty `operator_mcp.tools` to `"*"` (everything, minus the redundant `execute_code` the coding agent already has). No "enable tools for ACP" step; the setting is now an optional **restriction**, not a requirement.
- **`graph/settings_schema.py` / `server/operator_mcp.py`** — relabel + document: foreign MCP clients (Claude Desktop/Cursor) stay allowlist-gated; the ACP **brain** defaults to all.

## Console honesty
The turn runs on the coding agent, not the gateway model — so the console shouldn't claim otherwise.
- **`operator_api/runtime.py` + `types.ts`** — expose `agent_runtime` in runtime status.
- **`ComposerModelSelect`** — under ACP, show **"\<agent\> · coding agent"** instead of the gateway model that never runs the turn.

## Tool-card overflow
- **`plugins/coding_agent/acp_client.py`** — an ACP tool title like `web_search (… MCP Server): {"query":…}` was used verbatim as the card **name**, shoving the chat width. Peel a short label for the header; route the real args (`rawInput`, else the title's inline JSON) into the expandable body.
- **`tool-calls.css`** — defensive: a long tool name wraps instead of overflowing the panel.

## Tests / verification
- `pytest tests/test_acp_runtime.py tests/test_coding_agent_plugin.py tests/test_operator_api_runtime.py` — green (new: `defaults_to_full_toolset`, `honors_explicit_restriction`, `short_tool_name_*`).
- `ruff check` + web `tsc --noEmit` — clean.
- Live-verified on the dev instance (`acp:proto`): `/web-research` now calls `web_search`/`fetch_url` over the operator MCP and returns a real result; tool cards show clean names.

## Note
Full parity means the ACP brain can call **all** operator tools by default (subagents, goals, scheduling, fs, beads, memory) — the same surface the native model has. Clamp a specific instance by setting `operator_mcp.tools` to a named list.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Active ACP coding agent now shows a static “coding agent” label with badge in chat instead of the gateway model picker.

* **UI Improvements**
  * Tool cards wrap long titles correctly to prevent layout overflow.
  * Tool-call displays are more compact, with cleaner names and improved input rendering.

* **Settings & Runtime Behavior**
  * Operator MCP tool restriction messaging was updated, and empty restrictions now default to the full toolset for matching runtime behavior.

* **Tests**
  * Updated and expanded coverage for runtime-status defaults, tool allowlist behavior, and tool title shortening/parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->