### PR TITLE
fix(web): drop the redundant "working…" status strip above the chat composer

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -222,7 +222,9 @@ function ChatSessionSlot({
   const session = useSession(sessionId);
   const chat = useChatState();
   const [draft, setDraft] = useState("");
-  const [statusMessage, setStatusMessage] = useState("");
+  // Turn status is still tracked (drives the stream lifecycle) but no longer surfaced as
+  // a spinner/"working…" strip above the composer — the inline indicators cover it now.
+  const [, setStatusMessage] = useState("");
   const [taskId, setTaskId] = useState("");
   const [hitl, setHitl] = useState<HitlPayload | null>(null);
   const abortRef = useRef<AbortController | null>(null);
@@ -1112,14 +1114,6 @@ function ChatSessionSlot({
           }
         }}
       >
-        {status === "streaming" ? (
-          // Live turn status. Stop now lives inside the composer (the DS busy mode's
-          // self-contained onStop), so this strip is just the "working…" readout.
-          <div className="composer-status">
-            <Loader2 className="spin" size={12} />
-            <span>{statusMessage || "working"}</span>
-          </div>
-        ) : null}
         <PromptInput
           value={draft}
           onChange={(v) => {

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -94,16 +94,6 @@
 .chat-session-slot .pl-message--system .pl-message__content .markdown > :first-child { margin-top: 0; }
 .chat-session-slot .pl-message--system .pl-message__content .markdown > :last-child { margin-bottom: 0; }
 
-/* Subtle live status above the composer while streaming (was a header pill). */
-.composer-status {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 4px 12px 0;
-  font-size: 11px;
-  color: var(--fg-secondary);
-}
-
 /* Stop (while streaming) and the queued-steer bubble are now the DS busy mode +
    <Message queued> (0.42.0) — see ChatSurface. No bespoke CSS needed here. */
 


### PR DESCRIPTION
The spinner + `TASK_STATE_WORKING` ("working…") readout above the chat composer is redundant now that the inline turn indicators convey the same thing. Remove it.

- `ChatSurface.tsx` — drop the `composer-status` block (`<Loader2 spin>` + `{statusMessage || "working"}`) rendered above the `PromptInput` while streaming. Turn status is still tracked internally (`setStatusMessage` drives the stream lifecycle); only the read binding for the removed strip is dropped.
- `chat.css` — remove the now-dead `.composer-status` rule.

tsc clean; bundle rebuilt and verified the strip is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed redundant status indicator from the composer area during message streaming, as related status updates are now handled by existing busy mode indicators and message queue notifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->