### PR TITLE
chore: release v0.61.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.61.0] - 2026-06-20
+
 ## [0.60.0] - 2026-06-19
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.61.0] - 2026-06-20
 
+### Changed
+- **An ACP coding-agent runtime now gets protoAgent's full toolset by default.** Under
+  `agent_runtime: acp:<agent>` the external coding agent *is* the brain, so it now has every
+  tool — parity with the native runtime, where the gateway model does. `operator_mcp.tools`
+  is now an optional *restriction* rather than a required allowlist (empty = everything, minus
+  the redundant `execute_code` the coding agent already has), so a skill handed to the coding
+  agent can actually run its `web_search`/`fetch_url`/… tools instead of getting a procedure it
+  can't execute. The chat also labels the active runtime ("`<agent>` · coding agent") instead
+  of the gateway model that never ran the turn. (#1224)
+- **Removed the redundant "working…" status strip above the chat composer** — the spinner +
+  status readout is covered by the inline turn indicators now. (#1225)
+
 ## [0.60.0] - 2026-06-19
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.60.0"
+version = "0.61.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.61.0",
+    "date": "2026-06-20",
+    "changes": [
+      "An ACP coding-agent runtime now gets protoAgent's full toolset by default.",
+      "Removed the redundant \"working…\" status strip above the chat composer"
+    ]
+  },
+  {
     "version": "v0.60.0",
     "date": "2026-06-19",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.61.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.61.0 -m 'Release v0.61.0' && git push origin v0.61.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * ACP coding-agent runtime now receives the full protoAgent toolset by default for improved out-of-the-box capabilities.
* **Bug Fixes**
  * Removed the redundant “working…” status strip above the chat composer to reduce visual noise.
* **Chores**
  * Version updated to 0.61.0 and a matching changelog entry was added.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->