### PR TITLE
chore(web): bump @protolabsai/ui → 0.45.1 (Tabs active underline → accent)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -68,9 +68,9 @@
       }
     },
     "apps/web/node_modules/@protolabsai/ui": {
-      "version": "0.45.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.45.0.tgz",
-      "integrity": "sha512-usfE5Ne7f7L3u4H0+P9S9IPf+J/nrWYbAoqWRjsHf0nKnjjTcU7a86S0M726mcAuQotiJCe3kNjop7kqrWfUgg==",
+      "version": "0.45.1",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.45.1.tgz",
+      "integrity": "sha512-oR608P2N0kd7wrVV5Y/uCEJNnLuGJz4cMD6k3uHUJJWN7KMeK5UXujyckjd1lyunkI5FiJVKV5+tpB7MjWk/gg==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Adopts the upstream DS fix for the Tabs active-underline color — the gap this console filed as **protoContent#278**, now shipped in **`@protolabsai/ui@0.45.1`**.

- `.pl-tab--active`'s `border-bottom-color` changed `--pl-color-fg` (white) → `--pl-color-accent`, matching the existing `.pl-tabbar__tab--active`. Active text color stays `--pl-color-fg` — only the indicator moved. No API change.
- `apps/web/package.json` already pins `^0.45.0` (permits `0.45.1`), so this is **lockfile-only** — a clean 3-line bump (version/resolved/integrity).
- No console-side override to remove — we filed upstream rather than patching `.pl-tab--active` locally (DS contribute-back rule), so adopting the bump is the whole change.

**Verified:** `0.45.1`'s `.pl-tab--active` resolves to `--pl-color-accent`, and a rebuilt web bundle picks it up. Every `<Tabs>` surface (e.g. the Work hub's Overview/Goals/Tasks/Schedule) now renders the active tab with the brand-accent underline in dark mode.

Closes #1227.

🤖 Generated with [Claude Code](https://claude.com/claude-code)