### PR TITLE
fix(web): re-add missing core rail surfaces (Knowledge regression) + trim Knowledge footer

### DIFF
--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -234,6 +234,7 @@ export function App() {
   const setBottomCollapsed = useUI((s) => s.setBottomCollapsed);
   const railOrder = useUI((s) => s.railOrder);
   const reconcilePluginViews = useUI((s) => s.reconcilePluginViews);
+  const reconcileCoreSurfaces = useUI((s) => s.reconcileCoreSurfaces);
   const isMobile = useIsMobile();
   useActiveTheme(); // apply the focused agent's saved theme on boot + repaint on switch (ADR 0042)
   const mobileActive = useUI((s) => s.mobileActive);
@@ -574,6 +575,15 @@ export function App() {
     ]);
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [pluginViewSig, pluginViewsLoaded, reconcilePluginViews]);
+
+  // Self-heal a persisted railOrder that's missing a CORE surface (e.g. Knowledge lost from a
+  // layout saved before it existed / after an IA pass) — railSurfaces() never re-adds a missing
+  // core surface, only plugin views. Runs once on mount; idempotent (no-op when the layout is
+  // whole), so it can't churn or fight the operator's drag-and-drop order. Unlike plugin views
+  // this is NOT gated on runtime — the core set is static, so there's no "unresolved" race.
+  useEffect(() => {
+    reconcileCoreSurfaces(CORE_SURFACES.map((s) => s.id));
+  }, [reconcileCoreSurfaces]);
 
   // Active surface per rail, clamped to a member of that side (a moved surface never leaves a
   // stale active). Chat is no longer pinned — it lives on whichever rail holds it.

--- a/apps/web/src/knowledge/KnowledgeStore.tsx
+++ b/apps/web/src/knowledge/KnowledgeStore.tsx
@@ -1,7 +1,7 @@
 import { Input, Textarea } from "@protolabsai/ui/forms";
 import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
-import { Brain, Database, FileUp, Pencil, Plus, Trash2 } from "lucide-react";
+import { Database, FileUp, Pencil, Plus, Trash2 } from "lucide-react";
 
 import { useEffect, useState } from "react";
 
@@ -414,10 +414,6 @@ export function KnowledgeStore({ onError }: { onError: (message: string) => void
           ? `"${pendingDelete.heading || pendingDelete.preview.slice(0, 80)}" will be removed from the knowledge base — the agent will no longer recall it. This can't be undone.`
           : undefined}
       </ConfirmDialog>
-
-      <p className="playbook-foot">
-        <Brain size={13} /> This is the memory the agent retrieves into context before each turn — search it to see what it knows.
-      </p>
     </section>
   );
 }

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -185,3 +185,31 @@ describe("reconcilePluginViews", () => {
     expect(useUI.getState().railOrder.right).toEqual(["beads", "notes"]);
   });
 });
+
+// The general safety net for CORE surfaces (Knowledge regression, 2026-06): railSurfaces()
+// only renders ids already in a persisted railOrder and never re-adds a missing core surface,
+// so a layout saved before a surface existed silently drops its icon. reconcileCoreSurfaces
+// restores it on its default dock — replacing the per-surface v9-style migrations.
+describe("reconcileCoreSurfaces", () => {
+  const CORE = ["chat", "work", "knowledge"];
+
+  it("re-adds a CORE surface missing from a persisted railOrder to its default dock", () => {
+    useUI.setState({ railOrder: { left: ["chat", "plugins"], right: ["work"], bottom: [] } });
+    useUI.getState().reconcileCoreSurfaces(CORE);
+    expect(useUI.getState().railOrder.left).toContain("knowledge"); // restored on its default (left)
+  });
+
+  it("is a no-op (same ref, no write) when every core surface is already placed", () => {
+    useUI.setState({ railOrder: { left: ["chat", "knowledge"], right: ["work"], bottom: [] } });
+    const before = useUI.getState().railOrder;
+    useUI.getState().reconcileCoreSurfaces(CORE);
+    expect(useUI.getState().railOrder).toBe(before);
+  });
+
+  it("respects a surface the operator moved to another dock — no duplicate", () => {
+    useUI.setState({ railOrder: { left: ["chat"], right: ["work", "knowledge"], bottom: [] } });
+    useUI.getState().reconcileCoreSurfaces(CORE);
+    expect(useUI.getState().railOrder.left).not.toContain("knowledge");
+    expect(useUI.getState().railOrder.right).toContain("knowledge"); // left where the operator put it
+  });
+});

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -84,6 +84,11 @@ type UIState = {
   // Sync plugin views into railOrder (ADR 0036) — append newly-available ones to their placement
   // side, prune `plugin:` ids no longer present. Core surfaces are left untouched.
   reconcilePluginViews: (views: { id: string; side: "left" | "right" | "bottom" }[]) => void;
+  // Re-add any CORE surface missing from a persisted railOrder to its default dock. railSurfaces()
+  // renders only ids already in railOrder and never re-adds a missing core surface, so a layout
+  // saved before a surface existed (or that dropped one) silently loses the icon — this is the
+  // general safety net (replaces the per-surface v9-style migrations). Idempotent; no-op when whole.
+  reconcileCoreSurfaces: (ids: string[]) => void;
   // Bottom dock — active surface + height + collapse (mirror the right panel, on the Y axis).
   bottomPanel: string;
   bottomHeight: number;
@@ -110,6 +115,24 @@ type UIState = {
   pluginDots: Record<string, boolean>;
   setPluginDot: (key: string, on: boolean) => void;
 };
+
+// The pristine rail layout — the store's initial value AND the side-of-record for
+// `reconcileCoreSurfaces`, which re-adds a CORE surface to its default dock when a
+// persisted `railOrder` is missing it (see the action). Keep ids in sync with
+// CORE_SURFACES (apps/web/src/app/coreSurfaces.tsx).
+const DEFAULT_RAIL_ORDER: { left: string[]; right: string[]; bottom: string[] } = {
+  left: ["chat", "knowledge"],
+  right: ["work"],
+  bottom: [],
+};
+const coreDefaultSide = (id: string): "left" | "right" | "bottom" | null =>
+  DEFAULT_RAIL_ORDER.left.includes(id)
+    ? "left"
+    : DEFAULT_RAIL_ORDER.right.includes(id)
+      ? "right"
+      : DEFAULT_RAIL_ORDER.bottom.includes(id)
+        ? "bottom"
+        : null;
 
 /** persist v1→v2 migration: drop the obsolete `railOf` (side map); `railOrder`
  * falls back to the default via the store's merge. Exported for unit testing. */
@@ -242,11 +265,7 @@ export const useUI = create<UIState>()(
       bottomPanel: "",
       bottomHeight: 240,
       bottomCollapsed: false,
-      railOrder: {
-        left: ["chat", "studio", "knowledge"],
-        right: ["work"],
-        bottom: [],
-      },
+      railOrder: { left: [...DEFAULT_RAIL_ORDER.left], right: [...DEFAULT_RAIL_ORDER.right], bottom: [...DEFAULT_RAIL_ORDER.bottom] },
       moveSurface: (id, side) =>
         set((s) => {
           const arrs = {
@@ -287,6 +306,15 @@ export const useUI = create<UIState>()(
           for (const v of views) {
             if (!arrs.left.includes(v.id) && !arrs.right.includes(v.id) && !arrs.bottom.includes(v.id)) arrs[v.side].push(v.id);
           }
+          return { railOrder: arrs };
+        }),
+      reconcileCoreSurfaces: (ids) =>
+        set((s) => {
+          const placed = new Set([...s.railOrder.left, ...s.railOrder.right, ...s.railOrder.bottom]);
+          const missing = ids.filter((id) => !placed.has(id) && coreDefaultSide(id));
+          if (!missing.length) return {}; // whole already — avoid a needless state write
+          const arrs = { left: [...s.railOrder.left], right: [...s.railOrder.right], bottom: [...s.railOrder.bottom] };
+          for (const id of missing) arrs[coreDefaultSide(id)!].push(id);
           return { railOrder: arrs };
         }),
       setSurface: (surface) => set({ surface }),


### PR DESCRIPTION
### The bug
The **Knowledge rail icon vanished** in the desktop app. Root cause: the rail renders each dock **only from the persisted `railOrder`** (localStorage), and `railSurfaces()` has a safety-net that re-adds missing **plugin views — but not core surfaces** (`reconcilePluginViews` explicitly "leaves core surfaces untouched"). So a client whose saved `railOrder` lacks `knowledge` loses the icon with nothing to restore it. The code already documents this exact failure at `uiStore` **v9**, where *Settings* hit it and got a one-off migration. Not caused by any recent PR — it's structural.

### Fix (general, not another per-surface migration)
- New `reconcileCoreSurfaces(ids)` action: re-adds any CORE surface absent from `railOrder` to its **default dock** (from `DEFAULT_RAIL_ORDER`). Idempotent — no-op (same ref, no write) when the layout is whole, and it **respects** a surface the operator moved to another dock (won't duplicate).
- App calls it **once on mount** (not gated on runtime — the core set is static, no "unresolved" race like plugin views).
- Dropped the dead `"studio"` id from the default rail order.

This restores Knowledge **and** prevents the same vanishing for every future core surface.

### Also (requested)
- Removed the `<Brain>`-iconed footer from the Knowledge panel ("This is the memory the agent retrieves into context before each turn…") + its now-unused import.

### Verify
tsc clean; **104** web unit tests pass, incl. 3 new `reconcileCoreSurfaces` cases (re-add / no-op-same-ref / respects-moved-dock).

> Immediate workaround for the desktop app until this ships: ⌘K → "Knowledge" still opens it; resetting the app's saved layout (clear localStorage) also restores the icon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved navigation layout restoration when upgrading from older versions, ensuring all core surfaces are properly available after updates.

* **Improvements**
  * Enhanced deletion confirmation dialog to display specific entry details before removal, making the action clearer.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->