### PR TITLE
chore: release v0.62.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.62.0] - 2026-06-20
 
+### Fixed
+- **The Knowledge rail icon no longer disappears.** A core rail surface (Knowledge, Work, …)
+  missing from a saved layout is now re-added on load — `railSurfaces()` previously only restored
+  plugin views, so a layout saved before a surface existed (or that dropped one) silently lost its
+  icon, with no migration to bring it back. This is now a general safety net for every core surface.
+  (#1230)
+- **The active tab's underline is the brand accent again, not white.** Adopted the upstream
+  design-system fix (`@protolabsai/ui` 0.45.1) — every `<Tabs>` surface (e.g. the Work hub) now
+  marks the active tab with the accent. (#1229)
+
+### Changed
+- **Removed the "This is the memory the agent retrieves into context…" footer** from the Knowledge
+  panel. (#1230)
+- **Docs accuracy pass.** Corrected the starter-tools reference (the default tool set no longer
+  lists plugin or retired tools — notes/github/discord/peer aren't in `get_all_tools`) and closed
+  feature-coverage gaps (ACP full-tool-parity, the middleware chain, and the artifacts capability).
+  Also retired the misnamed `tools/peer_tools.py` → `tools/a2a_parse.py`. (#1228, #1231)
+
 ## [0.61.0] - 2026-06-20
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.62.0] - 2026-06-20
+
 ## [0.61.0] - 2026-06-20
 
 ### Changed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.61.0"
+version = "0.62.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "v0.62.0",
+    "date": "2026-06-20",
+    "changes": [
+      "The Knowledge rail icon no longer disappears.",
+      "The active tab's underline is the brand accent again, not white.",
+      "Removed the \"This is the memory the agent retrieves into context…\" footer",
+      "Docs accuracy pass."
+    ]
+  },
+  {
     "version": "v0.61.0",
     "date": "2026-06-20",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.62.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.62.0 -m 'Release v0.62.0' && git push origin v0.62.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved visibility of the Knowledge rail icon.
  * Updated the active tab underline color.
  * Removed an outdated “memory footer” message.
* **Documentation**
  * Refreshed documentation for accuracy.
* **Chores**
  * Bumped the app version to **0.62.0**.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->