### PR TITLE
fix(skills): respect skills_top_k=0 in ACP feed + cap load_skill hint

### DIFF
--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -380,7 +380,11 @@ FIELDS: list[Field] = [
         "length inlined — so a big document never gets dumped into the turn.",
         minimum=1,
     ),
-    Field("skills.top_k", "skills_top_k", "Skills listed in context", "number", "Knowledge", minimum=1),
+    # minimum=0 (not 1): 0 = "index off, but /slash + load_skill still work" — a
+    # coherent middle ground vs skills.enabled:false (which kills everything). The
+    # runtime (KnowledgeMiddleware + runtime/context.py) honors 0, so the schema must
+    # let it through validation (ADR 0060).
+    Field("skills.top_k", "skills_top_k", "Skills listed in context", "number", "Knowledge", minimum=0),
     Field(
         "checkpoint.db_path",
         "checkpoint_db_path",

--- a/runtime/context.py
+++ b/runtime/context.py
@@ -109,7 +109,10 @@ def retrieve_volatile(
     # disclosure, ADR 0060) — inject it whenever an index is present, not gated on q.
     if skills_index is not None:
         try:
-            k = int(getattr(config, "skills_top_k", 5) or 5)
+            # Default to 5 only when unset — an explicit skills_top_k=0 means "list
+            # none" (an `or 5` would silently override it, unlike the middleware path).
+            top_k = getattr(config, "skills_top_k", 5)
+            k = int(top_k if top_k is not None else 5)
             summaries = skills_index.skill_summaries(limit=k)
             if summaries:
                 blocks.append(_format_skills(summaries, skills_index.discoverable_count()))

--- a/tests/test_dream_distill.py
+++ b/tests/test_dream_distill.py
@@ -196,6 +196,18 @@ def test_load_skill_unknown_name_lists_available(tmp_path, monkeypatch):
     assert "Real skill" in out  # recovers by offering the discoverable set
 
 
+def test_load_skill_unknown_name_caps_the_hint(tmp_path, monkeypatch):
+    """A large library must not blow up the not-found hint — cap at 40 + "+N more"."""
+    idx = SkillsIndex(str(tmp_path / "s.db"))
+    monkeypatch.setattr(STATE, "skills_index", idx)
+    save_skill = _by_name(_build_curation_tools())["save_skill"]
+    for i in range(50):
+        save_skill.invoke({"name": f"skill-{i:02d}", "description": "d", "body": "b"})
+    out = load_skill.invoke({"name": "nope"})
+    assert out.count("skill-") == 40  # only 40 names listed
+    assert "+10 more — call list_skills" in out
+
+
 def test_load_skill_no_index(monkeypatch):
     monkeypatch.setattr(STATE, "skills_index", None)
     assert "not available" in load_skill.invoke({"name": "anything"})

--- a/tests/test_runtime_context.py
+++ b/tests/test_runtime_context.py
@@ -50,6 +50,15 @@ def test_no_query_means_no_knowledge_but_skills_still_listed():
     assert "deploy: how to deploy" in ctx.volatile_delta
 
 
+def test_skills_top_k_zero_lists_no_skills():
+    """An explicit skills_top_k=0 means "list none" — it must NOT be coerced to the
+    default 5 (the `or 5` bug). Matches the middleware path, which respects 0."""
+    cfg = types.SimpleNamespace(knowledge_top_k=5, skills_top_k=0)
+    ctx = assemble_context(cfg, query="x", knowledge_store=_FakeStore(), skills_index=_FakeSkills())
+    assert "deploy" not in ctx.volatile_delta
+    assert not any(s.startswith("skills:") for s in ctx.sources)
+
+
 def test_as_prompt_keeps_prefix_first_then_volatile_then_message():
     ctx = AssembledContext(stable_prefix="PERSONA", volatile_delta="KB", sources=[])
     prompt = ctx.as_prompt("do the thing")

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -97,6 +97,10 @@ def test_validate_rejects_bad_types_and_bounds():
     assert validate_flat({"prompt_cache.ttl": "9m"})[0] is False  # not in options
     assert validate_flat({"nope.nope": 1})[0] is False  # unknown key
     assert validate_flat({"model.temperature": 0.5, "compaction.enabled": True})[0] is True
+    # skills.top_k allows 0 ("index off, /slash + load_skill still work" — ADR 0060),
+    # so the schema agrees with the runtime that honors 0; negatives still rejected.
+    assert validate_flat({"skills.top_k": 0})[0] is True
+    assert validate_flat({"skills.top_k": -1})[0] is False
 
 
 def test_nest_updates_builds_yaml_shape_and_drops_blank_secrets():

--- a/tools/lg_tools.py
+++ b/tools/lg_tools.py
@@ -890,12 +890,15 @@ def load_skill(name: str) -> str:
         return "Skills index is not available."
     rec = idx.get_skill((name or "").strip())
     if rec is None:
-        # Recover from a typo'd name by offering the discoverable set.
+        # Recover from a typo'd name by offering the discoverable set — capped so a
+        # large library can't blow up the error string.
         try:
             names = [s["name"] for s in idx.skill_summaries()]
         except Exception:  # noqa: BLE001
             names = []
-        hint = f" Available skills: {', '.join(names)}." if names else ""
+        shown = names[:40]
+        more = f" (+{len(names) - len(shown)} more — call list_skills)" if len(names) > len(shown) else ""
+        hint = f" Available skills: {', '.join(shown)}.{more}" if shown else ""
         return f"No skill named {name!r}.{hint}"
 
     desc = " ".join((rec.get("description") or "").split())


### PR DESCRIPTION
Two minor follow-ups from CodeRabbit on #1235 (both `Minor`/quick-win; non-blocking on that PR, folded in here).

- **`runtime/context.py`** — `int(getattr(config, "skills_top_k", 5) or 5)` coerced an explicit `skills_top_k: 0` ("list none") to `5`. The middleware path passes `skills_top_k` straight to `skill_summaries(limit=...)` and respects `0`, so the ACP external-brain feed silently disagreed. Now defaults to 5 only when the attr is unset/None.
- **`tools/lg_tools.py`** — `load_skill`'s not-found recovery hint enumerated **every** discoverable skill name uncapped, so a large library could blow up the error string. Capped at 40 names + a `+N more — call list_skills` tail.

## Verification
- `ruff check` ✅ · `pytest tests/test_runtime_context.py tests/test_dream_distill.py` ✅ (17 passed)
- New tests: `test_skills_top_k_zero_lists_no_skills`, `test_load_skill_unknown_name_caps_the_hint`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed skill-index retrieval to respect an explicitly configured `skills_top_k=0` instead of falling back to the default.
  * Improved unknown-skill messaging to limit suggestions to 40 entries and indicate when more matches exist.

* **New Features**
  * Allowed `skills.top_k` to be configured with a minimum of `0` (enabling the disable behavior while still permitting manual skill loading).

* **Tests**
  * Added coverage to verify `skills_top_k=0` results in no skills being included.
  * Added coverage for the capped “available skills” hint when the skills library is large.
  * Extended schema validation tests to accept `0` and reject negative values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->