### PR TITLE
refactor(settings): make enforcement a fork seam — out of the console

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -110,11 +110,13 @@ Adding a new subagent name to the YAML requires matching entries in `graph/subag
 | `audit` | `true` | Append every tool call to `/sandbox/audit/audit.jsonl`. |
 | `memory` | `true` | Persist a session summary on terminal turn and asynchronously index conversation findings under `domain='finding'`. |
 | `scheduler` | `true` | Wire the bundled scheduler backend (local sqlite, or `WorkstaceanScheduler` when env vars are set). Drops the `schedule_task` / `list_schedules` / `cancel_schedule` tools from the agent loop when `false`. Has the same effect as `SCHEDULER_DISABLED=1` — but `middleware.scheduler: false` is the canonical opt-out (drawer/wizard editable, survives restarts), while the env var is a runtime escape hatch for fleet operators who can't edit YAML in the moment. |
-| `enforcement` | `false` | Opt-in safety gate that blocks tool calls **before** they execute (see `enforcement` block below). No-op unless a deny list or rate limit is configured. |
+| `enforcement` | `false` | Opt-in safety gate that blocks tool calls **before** they execute (see `enforcement` block below). **YAML / code seam — not surfaced in the console**, since it's a no-op until a deny list, rate limit, or predicate is configured. |
 
 ## `enforcement`
 
 Optional pre-execution gate (`graph/middleware/enforcement.py`). Only read when `middleware.enforcement: true`. Blocked calls return a `ToolMessage` explaining the denial (the model reads it and adapts) instead of running the tool. Forks needing richer policy (scope/cost/etc.) can attach a `predicate(tool_name, args) -> reason|None` in code.
+
+This is intentionally a **fork seam**, not a console feature: the bare `middleware.enforcement` toggle is hidden from the operator settings UI (it does nothing until you add a `disallowed_tools` list, `rate_limits`, or a predicate here), so configure it in YAML / code.
 
 ```yaml
 middleware:

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -476,7 +476,11 @@ FIELDS: list[Field] = [
     Field("middleware.memory", "memory_middleware", "Memory middleware", "bool", "Middleware"),
     Field("middleware.audit", "audit_middleware", "Audit middleware", "bool", "Middleware"),
     Field("middleware.scheduler", "scheduler_enabled", "Scheduler", "bool", "Middleware"),
-    Field("middleware.enforcement", "enforcement_enabled", "Tool enforcement", "bool", "Middleware"),
+    # Enforcement is a code/YAML fork seam (deny-list + rate-limits + a pluggable
+    # predicate), not a console feature: the bare on/off toggle is a no-op until a
+    # policy is configured in YAML, so it's ui_hidden (kept in FIELDS for config
+    # round-trip). See docs/reference/configuration.md `## enforcement`.
+    Field("middleware.enforcement", "enforcement_enabled", "Tool enforcement", "bool", "Middleware", ui_hidden=True),
     # ── Telemetry (local cost/latency store, ADR 0006) ───────────────────────
     Field(
         "telemetry.enabled",

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -109,7 +109,6 @@ def build_runtime_status(
             "audit": bool(getattr(config, "audit_middleware", False)),
             "memory": bool(getattr(config, "memory_middleware", False)),
             "scheduler": bool(getattr(config, "scheduler_enabled", False)),
-            "enforcement": bool(getattr(config, "enforcement_enabled", False)),
             "prompt_cache": bool(getattr(config, "prompt_cache_enabled", False)),
             "compaction": bool(getattr(config, "compaction_enabled", False)),
             "execute_code": bool(getattr(config, "execute_code_enabled", False)),


### PR DESCRIPTION
## What

Pulls the `enforcement` middleware out of the console and keeps it as the code/YAML **fork seam** it was designed to be.

## Why

`EnforcementMiddleware` is the only middleware that can *block* a tool call — a genuinely useful primitive. But its console toggle was a **no-op**: `graph/agent.py` only wires it when a deny-list or rate-limit is configured, and those (`enforcement.disallowed_tools` / `enforcement.rate_limits`) live in top-level YAML with no UI. So flipping `middleware.enforcement` on in Settings did nothing, and the read-only Middleware panel showed a permanently-off pill you couldn't act on.

Building the missing UI would mean a tool multi-select **and** a per-tool rate-limit map editor (no map field type exists). Not worth it for a feature that's really a fork concern — so we make it honest instead.

## Changes

- `ui_hidden=True` on the `middleware.enforcement` field — removed from the Settings UI, still in `FIELDS` for config round-trip (drift guard + roundtrip stay green). Same pattern as `goal.enabled` / `identity.name`.
- Drop `enforcement` from the runtime middleware-status map (`operator_api/runtime.py`) so the Middleware panel no longer lists it.
- Document it as a YAML/code seam in `configuration.md`.

## Untouched (still a working seam)

The middleware, the `enforcement_*` config fields, the YAML parsing, and the `predicate(tool_name, args)` hook are all intact. A fork enables it via `middleware.enforcement: true` + `enforcement.{disallowed_tools, rate_limits}` or a code predicate.

## Testing

`ruff` clean · imports load · `test_config_drift_guard` + `test_config_roundtrip` + `test_settings_cascade` + `test_operator_api_runtime` green (336 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified middleware enforcement configuration behavior and its relationship to the settings UI.

* **Refactor**
  * Middleware enforcement setting is no longer visible in the operator settings UI.
  * Middleware status response structure updated to remove the enforcement flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->