### PR TITLE
feat(plugins): late-tools seam — register_late_tool_factory

### DIFF
--- a/graph/agent.py
+++ b/graph/agent.py
@@ -640,6 +640,7 @@ def create_agent_graph(
     skills_index=None,
     extra_tools=None,
     extra_middleware=None,
+    late_tool_factories=None,
     include_subagents: bool = True,
     checkpointer=None,
     inbox_store=None,
@@ -718,6 +719,22 @@ def create_agent_graph(
             from tools.execute_code import build_execute_code_tool
 
             all_tools.append(build_execute_code_tool(all_tools, config=config))
+
+    # Plugin-contributed late tools (the late-tools seam) — factories that need the
+    # FULLY assembled toolset (core + subagent + plugin + MCP + execute_code). Built
+    # here, before the deferred meta-tool, so a late tool can wrap or proxy any other
+    # tool (but never itself) and is still surfaced by search_tools.
+    # factory(all_tools, config) -> tool | list[tool] | None; a raiser is skipped.
+    for _late_factory in late_tool_factories or ():
+        try:
+            _produced = _late_factory(all_tools, config)
+        except Exception:
+            import logging
+
+            logging.getLogger(__name__).exception("[plugins] late tool factory failed — skipped")
+            continue
+        if _produced:
+            all_tools.extend(_produced if isinstance(_produced, list) else [_produced])
 
     # Deferred tools (ADR 0005 #3) — opt-in progressive disclosure. The
     # search_tools meta-tool is built over the full set (so it can surface any

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -38,6 +38,7 @@ class PluginLoadResult:
     surfaces: list = field(default_factory=list)  # {plugin_id, name, start, stop}
     subagents: list = field(default_factory=list)  # SubagentConfig
     middleware: list = field(default_factory=list)  # factories: (config) -> AgentMiddleware|None (ADR 0032)
+    late_tool_factories: list = field(default_factory=list)  # (all_tools, config) -> tool|list (late seam)
     mcp_servers: list = field(default_factory=list)  # factories: config -> entry|None (ADR 0019)
     thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571); last plugin wins
     meta: list[dict] = field(default_factory=list)
@@ -366,6 +367,7 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
             result.surfaces.append({"plugin_id": manifest.id, **s})
         result.subagents.extend(registry.subagents)
         result.middleware.extend(registry.middleware)  # ADR 0032
+        result.late_tool_factories.extend(registry.late_tool_factories)  # late-tools seam
         for name, fn in registry.goal_verifiers.items():  # ADR 0028
             if name in result.goal_verifiers:
                 log.warning("[plugins] %s: goal verifier %s collides — skipped", manifest.id, name)

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -53,6 +53,7 @@ class PluginRegistry:
         self.surfaces: list[dict] = []  # {"name", "start", "stop"}
         self.subagents: list = []  # SubagentConfig instances
         self.middleware: list = []  # factories: (config) -> AgentMiddleware|None (ADR 0032)
+        self.late_tool_factories: list = []  # factories: (all_tools, config) -> tool|list|None (late seam)
         self.mcp_servers: list = []  # factories: config -> entry dict | None
         self.thread_id_resolver = None  # (request_metadata, session_id) -> str (#571)
         self.goal_verifiers: dict = {}  # name -> async (spec, ctx) -> VerifyResult (ADR 0028)
@@ -306,3 +307,21 @@ class PluginRegistry:
             log.warning("[plugins] %s: register_middleware needs a callable factory, got %r", self.plugin_id, factory)
             return
         self.middleware.append(factory)
+
+    def register_late_tool_factory(self, factory) -> None:
+        """Contribute a tool factory that runs AFTER the full toolset is assembled.
+
+        ``factory(all_tools, config) -> BaseTool | list[BaseTool] | None`` receives the
+        fully-resolved tool list (core + subagent + plugin + MCP tools) and the live
+        ``LangGraphConfig``; its result is appended last, before the deferred
+        ``search_tools`` meta-tool (so the late tool stays discoverable). For a
+        *meta-tool* that must see or wrap **every** other tool — e.g. programmatic
+        tool-calling that proxies the whole set — which a plain ``register_tool`` can't,
+        because plugin tools are registered before the set is complete. Built last, so
+        it can reference any tool but never itself. A raising factory is logged and
+        skipped, never breaking the graph build.
+        """
+        if not callable(factory):
+            log.warning("[plugins] %s: register_late_tool_factory needs a callable, got %r", self.plugin_id, factory)
+            return
+        self.late_tool_factories.append(factory)

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -45,6 +45,7 @@ class AppState:
     plugin_tools: list = field(default_factory=list)
     plugin_skill_dirs: list = field(default_factory=list)
     plugin_middleware: list = field(default_factory=list)  # resolved AgentMiddleware instances (ADR 0032)
+    plugin_late_tool_factories: list = field(default_factory=list)  # (all_tools, config) -> tool|list (late seam)
     plugin_workflow_dirs: list = field(default_factory=list)  # *.yaml recipe dirs (ADR 0027)
     plugin_a2a_skills: list = field(default_factory=list)  # A2A card skills from plugins (#570)
     thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571)

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -216,6 +216,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     _register_plugin_subagents(_plugins.subagents)
     _apply_config_subagents(STATE.graph_config)  # YAML subagent overrides (tools/max_turns/model)
     STATE.plugin_middleware = _resolve_plugin_middleware(STATE.graph_config, _plugins.middleware)  # ADR 0032
+    STATE.plugin_late_tool_factories = _plugins.late_tool_factories  # late-tools seam
 
     # MCP — external Model Context Protocol servers; their tools become agent
     # tools (namespaced <server>__<tool>). Off unless mcp.enabled OR a plugin
@@ -254,6 +255,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
         skills_index=STATE.skills_index,
         extra_tools=STATE.mcp_tools + STATE.plugin_tools,
         extra_middleware=STATE.plugin_middleware,
+        late_tool_factories=STATE.plugin_late_tool_factories,
         checkpointer=STATE.checkpointer,
         inbox_store=STATE.inbox_store,
         beads_store=STATE.beads_store,
@@ -1301,6 +1303,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
             _register_plugin_subagents(new_plugins.subagents)
             _apply_config_subagents(new_config)  # YAML subagent overrides take effect on reload
             new_middleware = _resolve_plugin_middleware(new_config, new_plugins.middleware)  # ADR 0032
+            new_late_tool_factories = new_plugins.late_tool_factories  # late-tools seam
             new_skills = _build_skills_index(new_config, extra_skill_dirs=new_plugin_skill_dirs)
             new_inbox_store = _build_inbox_store(new_config)
             new_graph = create_agent_graph(
@@ -1310,6 +1313,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
                 skills_index=new_skills,
                 extra_tools=new_mcp_tools + new_plugin_tools,
                 extra_middleware=new_middleware,
+                late_tool_factories=new_late_tool_factories,
                 checkpointer=STATE.checkpointer,
                 inbox_store=new_inbox_store,
                 # The background manager (ADR 0050) survives reloads unchanged — its
@@ -1329,6 +1333,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
         # reload 500s (e.g. installing a plugin during the wizard, whose
         # auto-enable reloads through here).
         new_middleware = []
+        new_late_tool_factories = []  # late-tools seam
 
     # Commit: config → A2A bearer → graph. All three reference the
     # same ``new_config`` so they stay consistent.
@@ -1359,6 +1364,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
         pass
     STATE.graph = new_graph
     STATE.plugin_middleware = new_middleware  # ADR 0032
+    STATE.plugin_late_tool_factories = new_late_tool_factories  # late-tools seam
     # STATE.workflow_registry / workflow_run were (re)set by the workflows plugin above.
     STATE.inbox_store = new_inbox_store
     # Commit the scheduler swap. start/stop are async — fire-and-forget

--- a/tests/test_plugin_late_tools.py
+++ b/tests/test_plugin_late_tools.py
@@ -1,0 +1,82 @@
+"""The late-tools plugin seam (``register_late_tool_factory``).
+
+A factory contributed via ``registry.register_late_tool_factory`` runs AFTER the
+full toolset is assembled: it receives the resolved tool list + the live config,
+and its result is appended (before the deferred ``search_tools`` meta-tool, so it
+stays discoverable). This is the only hook that sees every other tool — for a
+meta-tool that wraps/proxies the whole set (e.g. execute_code as a plugin).
+"""
+
+from pathlib import Path
+
+from langchain_core.tools import tool
+
+from graph.agent import create_agent_graph
+from graph.config import LangGraphConfig
+from graph.plugins.registry import PluginRegistry
+
+
+@tool
+def _sentinel(x: str) -> str:
+    """A late-seam sentinel tool."""
+    return x
+
+
+def _bound_names(graph) -> list[str]:
+    return [t.name for t in graph.bound_tools]
+
+
+def test_late_factory_receives_full_toolset_and_its_tool_lands():
+    seen: dict[str, list[str]] = {}
+
+    def factory(all_tools, config):
+        seen["names"] = [t.name for t in all_tools]
+        return _sentinel
+
+    graph = create_agent_graph(LangGraphConfig(), late_tool_factories=[factory])
+
+    # The factory saw the fully-assembled core toolset...
+    assert seen.get("names"), "factory should be called with the assembled toolset"
+    assert "current_time" in seen["names"]  # a known core tool
+    # ...and its tool was appended to the bound set.
+    assert "_sentinel" in _bound_names(graph)
+
+
+def test_late_factory_can_return_a_list_and_none_is_skipped():
+    @tool
+    def keeper(x: str) -> str:
+        """t."""
+        return x
+
+    graph = create_agent_graph(
+        LangGraphConfig(),
+        late_tool_factories=[lambda tools, cfg: [keeper], lambda tools, cfg: None],
+    )
+    assert "keeper" in _bound_names(graph)
+
+
+def test_raising_late_factory_is_isolated_and_later_ones_still_run():
+    @tool
+    def survivor(x: str) -> str:
+        """t."""
+        return x
+
+    def boom(all_tools, config):
+        raise RuntimeError("nope")
+
+    graph = create_agent_graph(LangGraphConfig(), late_tool_factories=[boom, lambda t, c: survivor])
+    assert "survivor" in _bound_names(graph)
+
+
+def test_no_late_factories_is_a_no_op():
+    # Default path (None) must not change the toolset or break the build.
+    graph = create_agent_graph(LangGraphConfig())
+    assert "current_time" in _bound_names(graph)
+    assert "_sentinel" not in _bound_names(graph)
+
+
+def test_registry_collects_late_factories_and_rejects_non_callables():
+    reg = PluginRegistry("p", Path("."))
+    reg.register_late_tool_factory(lambda tools, cfg: None)
+    reg.register_late_tool_factory("not-callable")  # ignored with a warning
+    assert len(reg.late_tool_factories) == 1


### PR DESCRIPTION
## What

Adds a plugin extension point — `registry.register_late_tool_factory(factory)` — for tools that need the **fully assembled toolset**.

## Why

`register_tool` runs early: a plugin's tools are added *before* the tool set is complete. But a **meta-tool that must see or wrap every other tool** — e.g. programmatic tool-calling that proxies the whole set — can't be a normal plugin tool. Today the one such tool (`execute_code`) is hardcoded into `graph/agent.py`, built last over `all_tools`. This seam is what lets it (and anything like it) live in a plugin instead.

This is **stage 1 of bd-37i** (extracting `execute_code` into an opt-in plugin) — the seam first, the extraction next.

## How

`factory(all_tools, config) -> tool | list[tool] | None`. `create_agent_graph` invokes the factories after the core + subagent + plugin + MCP tools (and `execute_code`) are assembled, **before** the deferred `search_tools` meta-tool — so a late tool can wrap any other tool but never itself, and is still surfaced by search. A raising factory is logged and skipped (never breaks the build).

Threaded through the exact same path as plugin middleware (ADR 0032):
`registry` → `PluginLoadResult.late_tool_factories` → `STATE.plugin_late_tool_factories` → `create_agent_graph`, on both the **init** and **reload** paths (mirroring `new_middleware`, with a default on the pre-setup branch).

## Files

`graph/plugins/registry.py` (the hook) · `graph/plugins/loader.py` (aggregate) · `runtime/state.py` + `server/agent_init.py` (thread it) · `graph/agent.py` (invoke) · `tests/test_plugin_late_tools.py` (new).

## Testing

New test proves a late factory (a) receives the assembled toolset incl. a known core tool, (b) lands its tool in `graph.bound_tools`, (c) supports list/None returns, (d) isolates a raising factory. `ruff` clean; **94 tests green** across the new test + every `create_agent_graph`-building suite (plugin-middleware, tools-inventory, checkpointer, goal, steering, model-override, background, wait-yield). `lint-imports` is CI-only locally; the change adds no cross-layer imports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Plugins can now register tools dynamically after the core toolset is assembled. Tool factories receive the complete toolset and current configuration, with failures isolated and logged without disrupting graph construction.

* **Tests**
  * Added comprehensive test coverage for dynamic plugin tool registration, including error handling, multiple factories, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->