### PR TITLE
feat(plugins): extract execute_code into an opt-in plugin (bd-37i)

### DIFF
--- a/graph/agent.py
+++ b/graph/agent.py
@@ -693,35 +693,14 @@ def create_agent_graph(
 
     # Fenced multi-project filesystem toolset (ADR 0007 — operator primitives).
     # Opt-in; inert unless filesystem.enabled + a non-empty projects registry.
-    # Added before execute_code/deferred so they're wrappable + discoverable.
+    # Added before the late-tools seam / deferred so they're wrappable + discoverable.
     if config.filesystem_enabled:
         from tools.fs_tools import build_fs_tools
 
         all_tools.extend(build_fs_tools(config))
 
-    # Programmatic tool calling — opt-in. Built last so it can wrap every
-    # other tool (including task/task_batch) but never itself.
-    # Not in the frozen desktop build: it spawns a Python subprocess, but the
-    # PyInstaller binary has no standalone interpreter (sys.executable is the
-    # server itself). Don't even offer it to the model there — the Settings
-    # toggle is hidden too (graph.settings_schema.build_schema). From source /
-    # Docker it works normally.
-    if config.execute_code_enabled:
-        import logging
-        import sys as _sys
-
-        if getattr(_sys, "frozen", False):
-            logging.getLogger(__name__).warning(
-                "execute_code is enabled but unavailable in the packaged desktop build "
-                "(no standalone Python interpreter) — not loading the tool."
-            )
-        else:
-            from tools.execute_code import build_execute_code_tool
-
-            all_tools.append(build_execute_code_tool(all_tools, config=config))
-
     # Plugin-contributed late tools (the late-tools seam) — factories that need the
-    # FULLY assembled toolset (core + subagent + plugin + MCP + execute_code). Built
+    # FULLY assembled toolset (core + subagent + plugin + MCP tools). Built
     # here, before the deferred meta-tool, so a late tool can wrap or proxy any other
     # tool (but never itself) and is still surfaced by search_tools.
     # factory(all_tools, config) -> tool | list[tool] | None; a raiser is skipped.

--- a/graph/config.py
+++ b/graph/config.py
@@ -318,19 +318,6 @@ class LangGraphConfig:
     compaction_keep_messages: int = 20
     compaction_model: str = ""  # blank = summarize with the main model
 
-    # Programmatic tool calling — the `execute_code` tool. Lets the model write
-    # one Python script that calls several tools, loops/filters/composes their
-    # results, and returns only stdout — collapsing a long tool-call chain into
-    # a single turn. The script runs in a subprocess with a scrubbed env (no
-    # secrets) and a hard timeout; tools are invoked back in the parent over an
-    # fd-based RPC bridge. OFF by default (run only trusted-model output, or in
-    # a hardened container). ``execute_code_tools`` empty = expose all tools
-    # except execute_code itself.
-    execute_code_enabled: bool = False
-    execute_code_timeout: float = 30.0
-    execute_code_tools: list[str] = field(default_factory=list)
-    execute_code_output_truncate: int = 6000
-
     # Deferred tools (ADR 0005 #3) — progressive tool disclosure for high tool
     # counts. When enabled, only a small base set + a ``search_tools`` meta-tool
     # are exposed to the model each turn; the rest are bound (callable) but their
@@ -807,12 +794,6 @@ class LangGraphConfig:
             compaction_trigger=data.get("compaction", {}).get("trigger", cls.compaction_trigger),
             compaction_keep_messages=data.get("compaction", {}).get("keep_messages", cls.compaction_keep_messages),
             compaction_model=data.get("compaction", {}).get("model", cls.compaction_model),
-            execute_code_enabled=data.get("execute_code", {}).get("enabled", cls.execute_code_enabled),
-            execute_code_timeout=data.get("execute_code", {}).get("timeout", cls.execute_code_timeout),
-            execute_code_tools=data.get("execute_code", {}).get("tools", []),
-            execute_code_output_truncate=data.get("execute_code", {}).get(
-                "output_truncate", cls.execute_code_output_truncate
-            ),
             tools_deferred_enabled=data.get("tools", {}).get("deferred", {}).get("enabled", cls.tools_deferred_enabled),
             tools_deferred_keep=list(data.get("tools", {}).get("deferred", {}).get("keep", []) or []),
             tools_disabled=list(data.get("tools", {}).get("disabled", []) or []),

--- a/graph/plugins/pconfig.py
+++ b/graph/plugins/pconfig.py
@@ -33,7 +33,6 @@ _RESERVED_SECTIONS = {
     "checkpoint",
     "routing",
     "goal",
-    "execute_code",
     # NB: plugin sections (e.g. `discord` from the external discord plugin) are NOT
     # reserved — a plugin (bundled or external) legitimately claims its own section.
     "operator",

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -211,21 +211,6 @@ FIELDS: list[Field] = [
         "with a coding agent.",
         options_source="models+acp",
     ),
-    # ── Programmatic tool calling ────────────────────────────────────────────
-    Field(
-        "execute_code.enabled",
-        "execute_code_enabled",
-        "Enable execute_code",
-        "bool",
-        "Tools",
-        "The model writes ONE Python script that calls several of its tools and returns "
-        "just the result — collapsing a long think→call→read tool chain into a single "
-        "turn. SECURITY: runs model-written code in a subprocess (its env scrubbed of "
-        "secrets + a hard timeout). That's isolation, NOT a true sandbox — the script "
-        "can still reach the disk/network as the server user, so enable it only for a "
-        "trusted model or inside a hardened container.",
-    ),
-    Field("execute_code.timeout", "execute_code_timeout", "Script timeout (s)", "number", "Tools", minimum=1),
     # ── Prompt caching ───────────────────────────────────────────────────────
     Field(
         "prompt_cache.enabled",
@@ -769,20 +754,11 @@ def build_schema(
 
     Secrets report ``value: ""`` plus ``is_set`` rather than echoing the secret.
     """
-    import sys as _sys
-
-    # In the frozen desktop build execute_code can't run (no standalone Python to
-    # spawn — see graph.agent), so hide its toggle entirely rather than offer a
-    # setting that does nothing. From source / Docker it shows as normal.
-    _frozen = getattr(_sys, "frozen", False)
-
     defaults = type(config)()
     groups: dict[str, dict[str, Any]] = {}
     for f in FIELDS:
         if f.ui_hidden:
             continue  # in FIELDS for config round-trip, but a dedicated panel owns the UI (#1076)
-        if _frozen and f.key.startswith("execute_code"):
-            continue
         current = getattr(config, f.attr, None)
         entry: dict[str, Any] = {
             "key": f.key,

--- a/operator_api/runtime.py
+++ b/operator_api/runtime.py
@@ -111,7 +111,6 @@ def build_runtime_status(
             "scheduler": bool(getattr(config, "scheduler_enabled", False)),
             "prompt_cache": bool(getattr(config, "prompt_cache_enabled", False)),
             "compaction": bool(getattr(config, "compaction_enabled", False)),
-            "execute_code": bool(getattr(config, "execute_code_enabled", False)),
         },
         "knowledge": {
             "enabled": _kn_on,

--- a/plugins/execute_code/__init__.py
+++ b/plugins/execute_code/__init__.py
@@ -1,0 +1,47 @@
+"""execute_code plugin — programmatic tool-calling as an opt-in plugin.
+
+Moved out of the lean core (bd-37i). The model writes ONE Python script that
+calls several of its tools and returns just the result — collapsing a long
+think→call→read chain into a single turn. The script runs in an isolated
+subprocess with a scrubbed environment (no credentials) and a hard timeout;
+tools are invoked back in the parent over an fd-based RPC bridge.
+
+This is **model-authored code execution** — isolation, NOT a true sandbox (the
+script can still reach the disk/network as the server user) — so it ships
+DISABLED; enable only for a trusted model or inside a hardened container.
+
+It uses the late-tools seam (``register_late_tool_factory``) because the tool
+must proxy the FULLY assembled toolset, which a normal ``register_tool`` can't
+see. Not loaded in the packaged desktop build (no standalone Python interpreter).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+
+from .engine import build_execute_code_tool
+
+log = logging.getLogger("protoagent.plugins.execute_code")
+
+
+def register(registry) -> None:
+    """Wire execute_code as a late tool (ADR 0001 + the late-tools seam)."""
+    cfg = registry.config  # the plugin's `execute_code` config section (ADR 0019)
+
+    # Frozen desktop build: spawning a Python subprocess needs a standalone
+    # interpreter the PyInstaller binary doesn't ship. Don't register the tool
+    # there at all — it simply won't exist (matches the old core behavior).
+    if getattr(sys, "frozen", False):
+        log.info("[execute_code] packaged desktop build — no standalone Python, tool not loaded")
+        return
+
+    def _factory(all_tools, config):
+        return build_execute_code_tool(
+            all_tools,
+            tools=cfg.get("tools") or None,
+            timeout=float(cfg.get("timeout", 30.0)),
+            truncate=int(cfg.get("output_truncate", 6000)),
+        )
+
+    registry.register_late_tool_factory(_factory)

--- a/plugins/execute_code/engine.py
+++ b/plugins/execute_code/engine.py
@@ -229,20 +229,19 @@ async def run_code(code: str, tool_map: dict, *, timeout: float = 30.0, truncate
             pass
 
 
-def build_execute_code_tool(all_tools: list, *, config):
+def build_execute_code_tool(all_tools: list, *, tools=None, timeout: float = 30.0, truncate: int = 6000):
     """Build the ``execute_code`` LangChain tool over an allowlist of tools.
 
     ``all_tools`` is the agent's full toolset; ``execute_code`` itself is never
-    exposed to the script (no recursion). ``config.execute_code_tools`` empty
-    means expose all other tools.
+    exposed to the script (no recursion). ``tools`` empty/None means expose all
+    other tools; ``timeout`` (seconds) and ``truncate`` (chars of stdout) come
+    from the plugin's ``execute_code`` config section.
     """
     from langchain_core.tools import tool
 
-    allow = set(config.execute_code_tools or [])
+    allow = set(tools or [])
     tool_map = {t.name: t for t in all_tools if t.name != "execute_code" and (not allow or t.name in allow)}
     available = ", ".join(sorted(tool_map)) or "(none)"
-    timeout = config.execute_code_timeout
-    truncate = config.execute_code_output_truncate
 
     description = (
         "Run a Python script that calls tools programmatically; returns its stdout.\n\n"

--- a/plugins/execute_code/protoagent.plugin.yaml
+++ b/plugins/execute_code/protoagent.plugin.yaml
@@ -1,0 +1,35 @@
+id: execute_code
+name: Execute Code
+version: 0.1.0
+description: >-
+  Programmatic tool-calling: the agent writes ONE Python script that calls
+  several of its tools, loops/filters/composes their results in code, and prints
+  only what matters — collapsing a multi-step tool chain into a single turn. The
+  script runs in an isolated subprocess with a scrubbed environment (no
+  credentials) and a hard timeout. SECURITY: this is model-authored code
+  execution — isolation, NOT a true sandbox (the script can reach the
+  disk/network as the server user) — so it ships disabled; enable only for a
+  trusted model or inside a hardened container. Unavailable in the packaged
+  desktop build (no standalone Python interpreter). Enable with
+  `plugins: { enabled: [execute_code] }`.
+enabled: false
+
+# Declarative (not yet enforced) — surfaced in the console for transparency.
+capabilities:
+  network: []
+  filesystem: workspace
+  subprocess: ["python"]
+
+# Plugin config (ADR 0019) — claims the top-level `execute_code` config section
+# (the same one the core tool used, so existing `execute_code:` YAML carries
+# over). Renders in Settings (group "Execute Code"). NOTE: enabling the tool is
+# now `plugins.enabled: [execute_code]`, not an `execute_code.enabled` flag.
+config_section: execute_code
+config:
+  timeout: 30.0
+  output_truncate: 6000
+  tools: []
+settings:
+  - { key: timeout, label: "Script timeout (s)", type: number, description: "Hard timeout (seconds) before the subprocess is killed." }
+  - { key: output_truncate, label: "Output truncate (chars)", type: number, description: "Max characters of stdout returned to the model." }
+  - { key: tools, label: "Exposed tools", type: string_list, description: "Restrict which tools the script may call (empty = all)." }

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -145,7 +145,6 @@ def test_config_to_dict_mirrors_yaml_shape() -> None:
         "agent_runtime",
         "checkpoint",
         "compaction",
-        "execute_code",
         "goal",
         "operator_mcp",
         "prompt_cache",

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -66,10 +66,6 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "enforcement_disallowed_tools": [],
     "enforcement_enabled": False,
     "enforcement_rate_limits": {},
-    "execute_code_enabled": False,
-    "execute_code_output_truncate": 6000,
-    "execute_code_timeout": 30,
-    "execute_code_tools": [],
     "filesystem_allow_run": True,
     "filesystem_enabled": True,
     "filesystem_projects": [],
@@ -195,10 +191,6 @@ CONFIG_TO_DICT_GOLDEN = {
         "keep_messages": 20,
         "model": "",
         "trigger": "fraction:0.8",
-    },
-    "execute_code": {
-        "enabled": False,
-        "timeout": 30,
     },
     "fleet": {
         "port_base": 7870,
@@ -415,9 +407,6 @@ EMITTED_ATTRS = {
     "goal_enabled",
     "goal_max_iterations",
     "goal_eval_model",
-    # execute_code.*
-    "execute_code_enabled",
-    "execute_code_timeout",
     # prompt_cache.* (incl. prompt_cache.warm.*)
     "prompt_cache_enabled",
     "prompt_cache_ttl",

--- a/tests/test_execute_code.py
+++ b/tests/test_execute_code.py
@@ -4,11 +4,15 @@ These run real child processes (the Docker CI image has python), exercising
 the subprocess + fd-based tool-RPC bridge end to end with fake tools.
 """
 
+import sys
+from pathlib import Path
+
 import pytest
 from langchain_core.tools import tool
 
-from graph.config import LangGraphConfig
-from tools.execute_code import build_execute_code_tool, run_code
+from graph.plugins.registry import PluginRegistry
+from plugins.execute_code import register
+from plugins.execute_code.engine import build_execute_code_tool, run_code
 
 
 @tool
@@ -91,9 +95,8 @@ async def test_output_truncation():
 
 
 def test_build_excludes_self_and_respects_allowlist():
-    cfg = LangGraphConfig(execute_code_enabled=True, execute_code_tools=["echo_tool"])
     # include a decoy + a self-named tool to prove filtering
-    ec = build_execute_code_tool([echo_tool, boom_tool], config=cfg)
+    ec = build_execute_code_tool([echo_tool, boom_tool], tools=["echo_tool"])
     assert ec.name == "execute_code"
     # allowlist limited to echo_tool; the docstring lists available tools
     assert "echo_tool" in ec.description
@@ -102,15 +105,35 @@ def test_build_excludes_self_and_respects_allowlist():
 
 @pytest.mark.asyncio
 async def test_built_tool_runs():
-    cfg = LangGraphConfig(execute_code_enabled=True)
-    ec = build_execute_code_tool([echo_tool], config=cfg)
+    ec = build_execute_code_tool([echo_tool])
     out = await ec.ainvoke({"code": "print(tools.echo_tool(text='hi'))"})
     assert out == "HI"
 
 
 @pytest.mark.asyncio
 async def test_built_tool_rejects_empty():
-    cfg = LangGraphConfig(execute_code_enabled=True)
-    ec = build_execute_code_tool([echo_tool], config=cfg)
+    ec = build_execute_code_tool([echo_tool])
     out = await ec.ainvoke({"code": "  "})
     assert "empty code" in out
+
+
+# --- plugin wiring ----------------------------------------------------------
+
+
+def test_plugin_register_wires_a_late_factory_that_builds_the_tool():
+    reg = PluginRegistry(
+        "execute_code", Path("."), config={"timeout": 5, "output_truncate": 100, "tools": ["echo_tool"]}
+    )
+    register(reg)
+    assert len(reg.late_tool_factories) == 1
+    ec = reg.late_tool_factories[0]([echo_tool, boom_tool], None)
+    assert ec.name == "execute_code"
+    # allowlist from the plugin's config section is applied
+    assert "echo_tool" in ec.description and "boom_tool" not in ec.description
+
+
+def test_plugin_not_loaded_in_frozen_build(monkeypatch):
+    monkeypatch.setattr(sys, "frozen", True, raising=False)
+    reg = PluginRegistry("execute_code", Path("."), config={})
+    register(reg)
+    assert reg.late_tool_factories == []  # no standalone Python in the packaged desktop build

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -132,7 +132,7 @@ def _core_tool_names() -> set[str]:
 
         names = {t.name for t in get_all_tools()}
         names |= set(MEMORY_TOOL_NAMES) | set(SCHEDULER_TOOL_NAMES) | set(INBOX_TOOL_NAMES)
-        names |= {"task", "task_batch", "execute_code"}
+        names |= {"task", "task_batch"}
         return names
     except Exception:  # noqa: BLE001 — collision check is best-effort
         return set()


### PR DESCRIPTION
## What

Moves **programmatic tool-calling (`execute_code`)** out of the lean core into a drop-in plugin, using the late-tools seam from #1240. This is **stage 2 of bd-37i** (stage 1 = the seam).

Model-authored code execution is "isolation, not a true sandbox" — exactly the opt-in-plugin risk profile — so it shouldn't ship in the default tool surface.

## The plugin

`plugins/execute_code/` — manifest (`config_section: execute_code`; settings `timeout`/`output_truncate`/`tools`; **ships disabled**) + `register()` that wires a **late-tool factory** (it must proxy the whole toolset, which a normal `register_tool` can't see). The tool itself is a **git rename** of `tools/execute_code.py` → `plugins/execute_code/engine.py`; `build_execute_code_tool` now takes `timeout`/`tools`/`truncate` params instead of reading `LangGraphConfig`. The frozen-desktop gate (no standalone Python in PyInstaller) moves into the plugin.

## Removed from core

- the hardcoded `execute_code` block in `graph/agent.py`
- `execute_code_*` config fields + `from_yaml` parsing + the roundtrip golden map
- the `settings_schema` fields + the `build_schema` frozen gate
- the runtime middleware-status line (`operator_api/runtime.py`)
- `execute_code` from `tools/mcp_tools.py` (core-name set) and pconfig `_RESERVED_SECTIONS` — **required** so the plugin can claim its own tool name + `execute_code` config section

`operator_mcp._STAR_EXCLUDE` keeps excluding `execute_code` when present (so `test_operator_mcp` stays green).

## ⚠️ Migration

Enabling is now **`plugins.enabled: [execute_code]`** instead of `execute_code.enabled: true`. The `timeout`/`tools`/`output_truncate` keys still live under the `execute_code:` YAML section (now owned by the plugin, so existing YAML carries over). Default behavior is unchanged: off.

## Testing

The tool's suite re-points to the plugin and gains `register()` + frozen-skip coverage. Plugin discovers + manifest parses (verified). **`ruff` clean; full `pytest tests/` suite green — 2243 passed.** `lint-imports` is CI-only locally; this PR only *removes* a core import.

Closes bd-37i.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Migrated the "execute code" tool from a core feature to a plugin-based architecture. The tool is now disabled by default and can be enabled and configured through the plugin system.

* **Tests**
  * Updated test suite to reflect the new plugin-based structure for the execute code tool.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->