### PR TITLE
fix(skills): harden the shared-skills commons (ADR 0041)

### DIFF
--- a/docs/adr/0041-workspaces-and-tiered-stores.md
+++ b/docs/adr/0041-workspaces-and-tiered-stores.md
@@ -180,3 +180,29 @@ isolation: enable/config/secrets stay per-workspace.)
 
 Slices 1–2 deliver the whole user-visible story (shared skills + named, isolated, bundle-installable
 agents); 3–4 deepen it.
+
+## As-built notes (2026-06)
+
+Where the implementation diverges from the plan above — recorded so the *why* survives:
+
+- **Skills ship `scoped` by default, not `shared`.** Slice 1 above planned "skills → shared", but
+  the shipped default is **`scoped`** (`skills.shared: false`, blank `skills.scope` → `scoped`;
+  `graph/config.py`, derived in `server/agent_init.py:_build_skills_index`). Deliberate: a fresh
+  agent should not auto-publish everything it learns into a host-wide commons that co-located agents
+  read. Sharing is **opt-in** — set `skills.scope: shared` (whole library is the commons) or
+  `layered` (read commons ∪ private, write private, `promote` to lift). This is the safe default;
+  the "canonical commons" in the store table is the *opt-in* target, not the out-of-box state.
+- **Only skills are tiered — shared *knowledge* (slice 3) is unbuilt.** There is no
+  `knowledge.scope`/commons; the knowledge store is always scoped. Promoting curated/reference
+  knowledge into a commons remains future work (tracked separately).
+- **The commons is host-level and un-scoped.** A `shared`/`layered` skills DB resolves to
+  `commons.path` (default `~/.protoagent/commons/skills.db`), bypassing `scope_leaf`, so **every
+  agent on the host reads the same commons regardless of `instance.id`**. To run two *isolated*
+  fleets on one host, give each a distinct `commons.path`. Boot logs the active tier + path
+  (`[skills] tier=… into …`) so this is visible.
+- **The commons is curator-immutable; curate it with the CLI.** The curator (decay/dedupe/prune)
+  writes the **private** tier only, so a promoted skill never auto-decays. Manage the commons by
+  hand: `python -m server skills promote <name>` lifts a private skill in (an **upsert** —
+  re-promoting refreshes, never duplicates; it surfaces a write failure instead of silently
+  swallowing an unwritable commons), and `python -m server skills forget <name>` removes one (the
+  inverse). `ls` prints the commons path. Automated commons GC is future work.

--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -121,6 +121,39 @@ and any one's full body loads on demand via `load_skill`) — not what's usable.
 `GET /api/runtime/status` reports `skills.count` so you can confirm how many
 loaded.
 
+## Sharing skills across a fleet (the commons)
+
+By default each agent's skill library is **private** (`scope: scoped`) — a fresh
+agent never auto-publishes what it learns. To let a fleet pool skills, opt a
+store into a shared **commons** ([ADR 0041](/adr/0041-workspaces-and-tiered-stores)):
+
+```yaml
+skills:
+  scope: layered          # read commons ∪ private, write private, promote to share
+commons:
+  path: ~/.protoagent/commons   # host-level, shared by every agent that points here
+```
+
+- **`scope: shared`** — the whole skills library *is* the commons (read + write).
+- **`scope: layered`** — "shared brain, private hands": the agent reads
+  `commons ∪ private` (private shadows commons on a name clash) and writes to its
+  **private** tier, so half-baked learned skills never pollute the fleet. You lift
+  a proven one explicitly.
+
+The commons is **host-level and un-scoped** — every agent pointing at the same
+`commons.path` reads it, regardless of `instance.id`. Run two *isolated* fleets on
+one host by giving each a distinct `commons.path`. The boot log names the active
+tier and path (`[skills] tier=layered into …`).
+
+Curate the commons from the CLI (the curator only decays/prunes the *private*
+tier, so promoted skills are otherwise permanent):
+
+```bash
+python -m server skills ls                 # list both tiers + the commons path
+python -m server skills promote <name>     # lift a private skill into the commons (upsert)
+python -m server skills forget  <name>     # remove a skill from the commons
+```
+
 ## Notes
 
 - The `description` is the skill's **summary in the index** — the only thing the
@@ -129,8 +162,9 @@ loaded.
 - The agent can also **author its own** skills: the `/distill` subagent looks back
   over recent work and turns a proven, repeated workflow into a new skill (its
   companion `/dream` consolidates memory). Both are schedulable (ADR 0054). The
-  skill curator (`graph/skills/curator.py`) decays and prunes non-pinned skills;
-  disk skills (your `SKILL.md` files) are pinned.
+  skill curator (`graph/skills/curator.py`) decays and prunes non-pinned **private**
+  skills; disk skills (your `SKILL.md` files) are pinned, and commons skills are
+  curator-immutable (manage them with `skills promote`/`forget`).
 - Only `name` / `description` / `tools` / `user_facing` / `slash` are read; any other
   frontmatter keys are ignored. See the [Skills reference](/reference/skills) for the exact
   field + config schema.

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -59,9 +59,9 @@ Skills live in a SQLite/FTS5 index (`skills.db`). Each row carries a `source`:
 |---|---|---|
 | `disk` | `SKILL.md` files + console CRUD (re-seeded each boot) | **pinned** — never decayed/pruned |
 | `distilled` | the `/distill` subagent (`save_skill`) | yes (curator) |
-| `promoted` | `python -m server skills promote <name>` → the commons (layered tier) | yes (curator) |
+| `promoted` | `python -m server skills promote <name>` → the **commons** | **no** — the curator writes the private tier only, so promoted skills never auto-decay. Remove one with `python -m server skills forget <name>`. |
 
-The curator (`python -m graph.skills.curator`) decays + prunes non-`disk` skills; see the
+The curator (`python -m graph.skills.curator`) decays + prunes non-`disk` **private** skills; see the
 [Skills guide](/guides/skills).
 
 ## Configuration (`skills:` block)
@@ -72,8 +72,12 @@ The curator (`python -m graph.skills.curator`) decays + prunes non-`disk` skills
 | `db_path` | `/sandbox/skills.db` | Index location (→ `~/.protoagent/skills.db` fallback) |
 | `top_k` | `5` | Max skills listed in the always-on `<available_skills>` index per turn (rest via `list_skills`; bodies via `load_skill`) |
 | `dir` | `""` | Override the writable skills root |
-| `scope` | `""` (→ `scoped`) | Tier: `scoped` (private) · `shared` (one commons) · `layered` (read commons ∪ private, write private) ([ADR 0041](/adr/0041-workspaces-and-tiered-stores)) |
+| `scope` | `""` (→ `scoped`) | Tier: `scoped` (private, **default**) · `shared` (one commons) · `layered` (read commons ∪ private, write private, `promote` to lift) ([ADR 0041](/adr/0041-workspaces-and-tiered-stores)). Sharing is opt-in — a fresh agent keeps its learned skills private. |
 | `shared` | `false` | Back-compat boolean — `true` → `scope: shared` when `scope` is blank |
 
-The shared-tier commons base dir is `commons.path` (blank → `~/.protoagent/commons`).
+The shared-tier **commons** base dir is `commons.path` (blank → `~/.protoagent/commons`). The commons
+is **host-level and un-scoped** — every agent on the host reads the same `commons.path` regardless of
+`instance.id`, so isolate two co-located fleets by giving each a distinct `commons.path`. Boot logs
+the active tier + path (`[skills] tier=… into …`). Curate the commons by hand —
+`skills promote`/`forget` (it's curator-immutable; see the source table above).
 `GET /api/runtime/status` reports `skills.count`.

--- a/graph/skills/cli.py
+++ b/graph/skills/cli.py
@@ -1,8 +1,9 @@
 """``python -m server skills …`` — inspect/curate the skills index (ADR 0041).
 
 ``ls`` lists skills (tagged by tier when layered); ``promote <name>`` lifts a private
-skill into the shared commons. Builds the same layered index the running agent uses,
-scoped to this config's ``instance.id``.
+skill into the shared commons; ``forget <name>`` removes a skill FROM the commons (the
+only way to curate it — the curator writes private-only). Builds the same layered index
+the running agent uses, scoped to this config's ``instance.id``.
 """
 
 from __future__ import annotations
@@ -20,12 +21,16 @@ def _build_parser() -> argparse.ArgumentParser:
     sub.add_parser("ls", help="list skills (private + commons tiers)")
     pp = sub.add_parser("promote", help="lift a private skill into the shared commons")
     pp.add_argument("name", help="the skill name to promote")
+    fp = sub.add_parser("forget", help="remove a skill FROM the shared commons (inverse of promote)")
+    fp.add_argument("name", help="the commons skill name to forget")
     return p
 
 
 def _layered_index():
     """Build the layered (private ∪ commons) index from the live config, scoped to its
-    instance — so the CLI sees exactly what the running agent does."""
+    instance — so the CLI sees exactly what the running agent does. Returns
+    ``(index, commons_path)`` so the caller can surface which commons is in use: it's
+    host-level + un-scoped, so showing the path guards the shared-host footgun (ADR 0041)."""
     from graph.config import LangGraphConfig
     from graph.config_io import _live_config_dir
     from graph.skills.index import SkillsIndex
@@ -36,15 +41,17 @@ def _layered_index():
     _seed_instance_env(cfg)  # so the private path resolves to THIS agent's scope
     commons = _commons_dir(cfg)
     private = SkillsIndex(db_path=_resolve_skills_db(cfg.skills_db_path, shared=False))
-    shared = SkillsIndex(db_path=_resolve_skills_db(cfg.skills_db_path, shared=True, commons=commons))
-    return LayeredSkillsIndex(private, shared)
+    shared_path = _resolve_skills_db(cfg.skills_db_path, shared=True, commons=commons)
+    shared = SkillsIndex(db_path=shared_path)
+    return LayeredSkillsIndex(private, shared), shared_path
 
 
 def run_skills_cli(argv: list[str]) -> int:
     args = _build_parser().parse_args(argv)
-    idx = _layered_index()
+    idx, commons_path = _layered_index()
     try:
         if args.cmd == "ls":
+            print(f"commons: {commons_path}")  # host-level + shared by every agent (ADR 0041)
             rows = idx.all_skills()
             if not rows:
                 print("(no skills indexed)")
@@ -55,9 +62,20 @@ def run_skills_cli(argv: list[str]) -> int:
         if args.cmd == "promote":
             ok = idx.promote(args.name)
             if ok:
-                print(f"✓ promoted {args.name!r} into the shared commons")
+                print(f"✓ promoted {args.name!r} into the shared commons ({commons_path})")
                 return 0
-            print(f"✗ no private skill named {args.name!r}", file=sys.stderr)
+            print(
+                f"✗ promote {args.name!r} failed — no private skill by that name, "
+                f"or the commons ({commons_path}) isn't writable",
+                file=sys.stderr,
+            )
+            return 1
+        if args.cmd == "forget":
+            ok = idx.forget_from_commons(args.name)
+            if ok:
+                print(f"✓ forgot {args.name!r} from the shared commons ({commons_path})")
+                return 0
+            print(f"✗ no commons skill named {args.name!r}", file=sys.stderr)
             return 1
     finally:
         idx.close()

--- a/graph/skills/layered.py
+++ b/graph/skills/layered.py
@@ -66,6 +66,24 @@ class LayeredSkillsIndex:
     def rebuild_index(self, artifacts: list) -> None:
         self._private.rebuild_index(artifacts)
 
+    # ── commons curation — the inverse of promote ─────────────────────────────
+    @staticmethod
+    def _forget_from_backend(backend, name: str) -> bool:
+        """Delete every row named *name* from one backend. Returns True if any went."""
+        removed = False
+        for s in backend.all_skills():
+            if s.get("name") == name and s.get("id") is not None:
+                backend.delete_skill(s["id"])
+                removed = True
+        return removed
+
+    def forget_from_commons(self, name: str) -> bool:
+        """Remove a skill from the shared commons by name — the inverse of
+        :meth:`promote`, and the only way to curate the otherwise curator-immutable
+        commons (the curator writes private-only). Returns False when no commons
+        skill by that name exists. Never touches the private tier."""
+        return self._forget_from_backend(self._commons, name)
+
     # ── introspection + promotion ─────────────────────────────────────────────
     def all_skills(self) -> list[dict]:
         return [{**s, "tier": "private"} for s in self._private.all_skills()] + [
@@ -86,8 +104,12 @@ class LayeredSkillsIndex:
         return list(merged.values())
 
     def promote(self, name: str) -> bool:
-        """Copy a private skill (by name) into the commons. Returns False if no
-        private skill by that name exists. Curated, explicit — the commons is trusted."""
+        """Lift a private skill (by name) into the commons. **Upsert**: re-promoting
+        refreshes the commons copy instead of leaving a duplicate row (``add_skill``
+        has no dedup of its own). Returns False if no private skill by that name
+        exists, or if the commons write didn't land (e.g. an unwritable commons path,
+        which ``add_skill`` would otherwise swallow). Curated, explicit — the commons
+        is trusted."""
         match = next((s for s in self._private.all_skills() if s.get("name") == name), None)
         if match is None:
             return False
@@ -99,8 +121,19 @@ class LayeredSkillsIndex:
             source_session_id=match.get("source_session_id", ""),
             user_facing=bool(match.get("user_facing", False)),
             slash=match.get("slash", "") or "",
+            # Preserve user_only across promotion — a /slash-only private skill must
+            # stay /slash-only in the commons, not become agent-discoverable.
+            user_only=bool(match.get("user_only", False)),
         )
+        # Upsert: drop any prior commons copy first so re-promoting refreshes rather
+        # than duplicating (the layered read de-dups by name, hiding the dupes in-app).
+        self._forget_from_backend(self._commons, name)
         self._commons.add_skill(artifact, source="promoted")
+        # add_skill swallows write errors; confirm the row actually landed so an
+        # unwritable commons surfaces as a failure instead of a false success.
+        if self._commons.get_skill(name) is None:
+            log.error("[skills] promote(%r): commons write did not land — is the commons writable?", name)
+            return False
         log.info("[skills] promoted %r to the commons", name)
         return True
 

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -463,7 +463,10 @@ def _build_skills_index(config, extra_skill_dirs=None):
 
         roots.append(user_skills_dir())
         count = seed_skills_index(index, roots)
-        log.info("[skills] indexed %d SKILL.md skill(s) into %s", count, db_path)
+        # Name the tier explicitly: a `shared`/`layered` commons is host-level and
+        # un-scoped (every agent on the box reads it), so making that visible at boot
+        # guards the shared-host footgun (ADR 0041).
+        log.info("[skills] tier=%s — indexed %d SKILL.md skill(s) into %s", scope, count, db_path)
         return index
     except Exception as exc:  # noqa: BLE001 — skills are optional, never fatal
         log.warning("[skills] index init failed: %s; running without SKILL.md skills", exc)

--- a/tests/test_skills_layered.py
+++ b/tests/test_skills_layered.py
@@ -42,6 +42,88 @@ def test_layered_union_write_private_promote(tmp_path):
     idx.close()
 
 
+def test_promote_is_upsert_no_duplicate_rows(tmp_path):
+    """Re-promoting refreshes the commons copy instead of leaving duplicate rows
+    (add_skill has no dedup; the layered read hides dupes by name)."""
+    private, commons = _idx(tmp_path)
+    private.add_skill(_art("nightly", "v1 — buy low"))
+    idx = LayeredSkillsIndex(private, commons)
+    assert idx.promote("nightly") is True
+
+    # Update the private copy, re-promote → commons reflects v2, still ONE row.
+    private.add_skill(_art("nightly", "v2 — buy lower"))  # private now has 2 rows; promote uses all_skills match
+    assert idx.promote("nightly") is True
+    commons_rows = [s for s in commons.all_skills() if s["name"] == "nightly"]
+    assert len(commons_rows) == 1  # upsert — not duplicated
+    idx.close()
+
+
+def test_promote_preserves_user_only(tmp_path):
+    """A user_only (slash-only) private skill stays user_only in the commons — it
+    must not become agent-discoverable just by being promoted."""
+    private, commons = _idx(tmp_path)
+    private.add_skill(
+        types.SimpleNamespace(
+            name="deploy", description="deploy + verify", prompt_template="run it",
+            tools_used=(), source_session_id="", user_facing=True, slash="deploy", user_only=True,
+        )
+    )
+    idx = LayeredSkillsIndex(private, commons)
+    assert idx.promote("deploy") is True
+    rec = commons.get_skill("deploy")
+    assert rec is not None and rec["user_only"] is True
+    # Withheld from the agent index, but resolvable as a /slash on the commons.
+    assert "deploy" not in [s["name"] for s in commons.skill_summaries()]
+    assert "deploy" in [s["slash"] for s in commons.user_facing_skills()]
+    idx.close()
+
+
+def test_forget_from_commons(tmp_path):
+    """forget_from_commons removes a commons skill (the inverse of promote) without
+    touching the private tier; missing name → False."""
+    private, commons = _idx(tmp_path)
+    private.add_skill(_art("scrape", "a private skill"))
+    idx = LayeredSkillsIndex(private, commons)
+    idx.promote("scrape")
+    assert "scrape" in [s["name"] for s in commons.all_skills()]
+
+    assert idx.forget_from_commons("scrape") is True
+    assert "scrape" not in [s["name"] for s in commons.all_skills()]
+    assert "scrape" in [s["name"] for s in private.all_skills()]  # private untouched
+    assert idx.forget_from_commons("scrape") is False  # already gone
+    idx.close()
+
+
+def test_skills_cli_forget(tmp_path, monkeypatch, capsys):
+    """`skills forget <name>` removes from the commons + reports the commons path;
+    a missing name exits 1. (run_skills_cli closes its index, so build a fresh one
+    per call over the same on-disk dbs — mirroring real invocations.)"""
+    from graph.skills import cli
+    from graph.skills.index import SkillsIndex
+
+    priv_path = str(tmp_path / "priv.db")
+    comm_path = str(tmp_path / "commons" / "skills.db")
+    (tmp_path / "commons").mkdir(parents=True, exist_ok=True)
+
+    def _fresh():
+        return LayeredSkillsIndex(SkillsIndex(priv_path), SkillsIndex(comm_path)), comm_path
+
+    # Seed: a skill promoted into the commons.
+    seed_idx, _ = _fresh()
+    seed_idx._private.add_skill(_art("ore_run", "a private skill"))
+    assert seed_idx.promote("ore_run") is True
+    seed_idx.close()
+
+    monkeypatch.setattr(cli, "_layered_index", _fresh)
+
+    assert cli.run_skills_cli(["forget", "ore_run"]) == 0
+    out = capsys.readouterr().out
+    assert "forgot 'ore_run'" in out and "commons" in out
+    assert "ore_run" not in [s["name"] for s in SkillsIndex(comm_path).all_skills()]
+
+    assert cli.run_skills_cli(["forget", "nope"]) == 1  # nothing to forget
+
+
 def test_skills_scope_config_parses(tmp_path):
     from graph.config import LangGraphConfig
 


### PR DESCRIPTION
Acting on the **shared skills** audit ([ADR 0041 tiered stores](https://github.com/protoLabsAI/protoAgent/blob/main/docs/adr/0041-workspaces-and-tiered-stores.md)). Decision locked: the **`scoped` default stays** — a fresh agent shouldn't auto-publish learned skills into a host-wide commons; sharing is opt-in via `scope: shared|layered`.

### `promote` hardening — `graph/skills/layered.py`
- **Preserve `user_only`** across promotion. It was dropped when rebuilding the artifact, so a `/slash`-only private skill would silently become **agent-discoverable** once promoted.
- **Upsert, not blind insert.** `add_skill` has no dedup, so re-promoting left **duplicate commons rows** (the layered read hid them by name). Now drops the prior copy first → re-promote *refreshes*.
- **Surface write failures.** `add_skill` swallows errors; `promote` now confirms the row landed, so an **unwritable commons fails loudly** instead of reporting false success.

### Commons curation — it's curator-immutable
The curator (decay/dedupe/prune) writes the **private** tier only, so promoted skills never auto-decay and the commons grew unbounded.
- New `LayeredSkillsIndex.forget_from_commons()` + **`python -m server skills forget <name>`** (inverse of `promote`).
- `skills ls` / `promote` / `forget` now print the **commons path**.

### Host-level commons footgun — visibility
A `shared`/`layered` commons is host-level and **un-scoped** (every agent on the box reads it). Boot now logs the active tier: **`[skills] tier=… into <path>`**.

### Docs
- ADR 0041 **"As-built notes"**: scoped-default vs the slice-1 plan, commons is host-level + un-scoped (isolate fleets via distinct `commons.path`), shared *knowledge* unbuilt, commons curation via CLI.
- Skills **guide** gains a *"Sharing skills across a fleet (the commons)"* section; **reference** corrects that promoted skills are **not** curated.

### Backlog (the larger initiatives — too big to inline)
- **bd-2wu** — shared *knowledge* tier (ADR 0041 slice 3): only skills are tiered today.
- **bd-2mc** — automated commons GC: the curator can't prune promoted skills.

### Verification
`ruff check` ✅ · `pytest -k "skill or fleet or config or curator"` ✅ (256 passed) — new tests cover promote upsert/`user_only`-preservation, `forget_from_commons`, and the `skills forget` CLI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `skills forget` CLI command to remove skills from the shared commons store.
  * Documented fleet-wide skill sharing via host-level commons store with `skills.scope: shared` or `layered` configuration.

* **Documentation**
  * Clarified skills curator behavior: only affects private skills, not commons or disk skills.
  * Added comprehensive guides for sharing skills across agent fleets and managing commons via CLI commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->