### PR TITLE
docs(execute_code): drop the "one-shot REPL" framing — it's just an interpreter

### DIFF
--- a/plugins/execute_code/__init__.py
+++ b/plugins/execute_code/__init__.py
@@ -2,7 +2,7 @@
 
 Moved out of the lean core (bd-37i). The model writes a Python script that runs
 in an isolated subprocess; its stdout comes back. The script can do anything
-Python can — compute, parse, transform data — effectively a one-shot REPL. Its
+Python can — compute, parse, transform data. Its
 headline use is programmatic tool-calling (call several tools, compose their
 results in code, print only what matters — collapsing a think→call→read chain
 into one turn), but it is **not** limited to tool calls.

--- a/plugins/execute_code/engine.py
+++ b/plugins/execute_code/engine.py
@@ -2,9 +2,7 @@
 
 The model writes a single Python script; it runs in an isolated child process
 and its stdout comes back. This is **general-purpose code execution** — the
-script can do anything Python can (compute, parse, transform data, call out) —
-effectively a one-shot Python REPL (no state persists between calls; each runs
-in a fresh subprocess).
+script can do anything Python can (compute, parse, transform data, call out).
 
 Its headline use is **programmatic tool-calling**: instead of emitting one tool
 call per turn (think → call → read → think …), the script calls several tools,

--- a/plugins/execute_code/protoagent.plugin.yaml
+++ b/plugins/execute_code/protoagent.plugin.yaml
@@ -4,8 +4,7 @@ version: 0.1.0
 description: >-
   A sandboxed Python code interpreter for the agent: it writes a Python script,
   the script runs in an isolated subprocess, and its stdout comes back. The
-  script can do anything Python can — compute, parse, transform data — so it's
-  effectively a one-shot Python REPL (no state persists between calls). Its
+  script can do anything Python can — compute, parse, transform data. Its
   headline use is programmatic tool-calling (call several tools, compose their
   results in code, print only what matters — collapsing a multi-step tool chain
   into one turn), but it is not limited to tool calls. SECURITY: this runs


### PR DESCRIPTION
Follow-up to #1243 (which merged fast). "Code interpreter" / "general-purpose code execution" already says what it is — the "one-shot REPL" label adds nothing. Removes the three REPL phrases from the manifest + plugin/engine docstrings, keeping the interpreter framing + the security/allowlist clarifications. Docs-only; ruff clean, manifest parses, execute_code suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated descriptions for the execute_code plugin to refine how its capabilities and operational characteristics are communicated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->