### PR TITLE
feat(skills): tier-aware curator — commons is dedupe-only (bd-2mc)

### DIFF
--- a/docs/guides/skills.md
+++ b/docs/guides/skills.md
@@ -145,14 +145,22 @@ The commons is **host-level and un-scoped** — every agent pointing at the same
 one host by giving each a distinct `commons.path`. The boot log names the active
 tier and path (`[skills] tier=layered into …`).
 
-Curate the commons from the CLI (the curator only decays/prunes the *private*
-tier, so promoted skills are otherwise permanent):
+Curate the skill library from the CLI:
 
 ```bash
-python -m server skills ls                 # list both tiers + the commons path
-python -m server skills promote <name>     # lift a private skill into the commons (upsert)
-python -m server skills forget  <name>     # remove a skill from the commons
+python -m server skills ls                  # list both tiers + the commons path
+python -m server skills promote <name>      # lift a private skill into the commons (upsert)
+python -m server skills forget  <name>      # remove a skill from the commons
+python -m server skills curate              # curate the PRIVATE tier (decay + dedupe + prune)
+python -m server skills curate --tier commons   # curate the COMMONS — dedupe ONLY
 ```
+
+`curate` runs the skill curator against **one concrete tier**. The **private** tier
+gets the full pass (idle-decay → dedupe → prune-below-threshold). The shared
+**commons** is curated + trusted, so it only **dedupes** — it never idle-decays (a
+promoted runbook mustn't rot because the fleet was idle) and never auto-prunes
+(removal is the explicit `forget`; pass `--prune` to also prune the commons). Add
+`--dry-run` to preview.
 
 ## Notes
 
@@ -162,9 +170,10 @@ python -m server skills forget  <name>     # remove a skill from the commons
 - The agent can also **author its own** skills: the `/distill` subagent looks back
   over recent work and turns a proven, repeated workflow into a new skill (its
   companion `/dream` consolidates memory). Both are schedulable (ADR 0054). The
-  skill curator (`graph/skills/curator.py`) decays and prunes non-pinned **private**
-  skills; disk skills (your `SKILL.md` files) are pinned, and commons skills are
-  curator-immutable (manage them with `skills promote`/`forget`).
+  skill curator (`graph/skills/curator.py`, run via `skills curate`) decays + dedupes
+  + prunes non-pinned **private** skills; disk skills (your `SKILL.md` files) are
+  pinned; the **commons** is dedupe-only (no decay/auto-prune) and removed from via
+  `skills forget`.
 - Only `name` / `description` / `tools` / `user_facing` / `slash` are read; any other
   frontmatter keys are ignored. See the [Skills reference](/reference/skills) for the exact
   field + config schema.

--- a/docs/reference/skills.md
+++ b/docs/reference/skills.md
@@ -61,8 +61,9 @@ Skills live in a SQLite/FTS5 index (`skills.db`). Each row carries a `source`:
 | `distilled` | the `/distill` subagent (`save_skill`) | yes (curator) |
 | `promoted` | `python -m server skills promote <name>` → the **commons** | **no** — the curator writes the private tier only, so promoted skills never auto-decay. Remove one with `python -m server skills forget <name>`. |
 
-The curator (`python -m graph.skills.curator`) decays + prunes non-`disk` **private** skills; see the
-[Skills guide](/guides/skills).
+Run the curator with `python -m server skills curate [--tier private|commons]`: the **private** tier
+decays + dedupes + prunes non-`disk` skills; the **commons** is trusted, so it **dedupes only** (no
+idle-decay, no auto-prune — `--prune` opts in). See the [Skills guide](/guides/skills).
 
 ## Configuration (`skills:` block)
 

--- a/graph/skills/cli.py
+++ b/graph/skills/cli.py
@@ -1,9 +1,12 @@
 """``python -m server skills …`` — inspect/curate the skills index (ADR 0041).
 
 ``ls`` lists skills (tagged by tier when layered); ``promote <name>`` lifts a private
-skill into the shared commons; ``forget <name>`` removes a skill FROM the commons (the
-only way to curate it — the curator writes private-only). Builds the same layered index
-the running agent uses, scoped to this config's ``instance.id``.
+skill into the shared commons; ``forget <name>`` removes a skill FROM the commons.
+``curate [--tier]`` runs the skill curator on ONE concrete tier: the **private** tier
+gets the full pass (idle-decay + dedupe + prune-below-threshold); the shared **commons**
+is trusted, so it only **dedupes** — no idle-decay (a promoted skill mustn't rot because
+the fleet was idle) and no auto-prune (removal is the explicit ``forget``). Builds the
+same tier paths the running agent uses, scoped to this config's ``instance.id``.
 """
 
 from __future__ import annotations
@@ -23,6 +26,17 @@ def _build_parser() -> argparse.ArgumentParser:
     pp.add_argument("name", help="the skill name to promote")
     fp = sub.add_parser("forget", help="remove a skill FROM the shared commons (inverse of promote)")
     fp.add_argument("name", help="the commons skill name to forget")
+    cp = sub.add_parser(
+        "curate",
+        help="run the curator on ONE tier (private: decay+dedupe+prune · commons: dedupe only)",
+    )
+    cp.add_argument("--tier", choices=("private", "commons"), default="private", help="tier to curate (default: private)")
+    cp.add_argument(
+        "--prune",
+        action="store_true",
+        help="also prune below-threshold skills on the commons (private prunes by default)",
+    )
+    cp.add_argument("--dry-run", action="store_true", help="compute changes but write nothing")
     return p
 
 
@@ -46,8 +60,58 @@ def _layered_index():
     return LayeredSkillsIndex(private, shared), shared_path
 
 
+def _resolve_tier_db(tier: str) -> str:
+    """Resolve the concrete on-disk DB path for ONE tier (private | commons) using the
+    same resolution the running agent uses — so the curator targets a single backend
+    (never a layered union, which would make rowid-based deletes ambiguous)."""
+    from graph.config import LangGraphConfig
+    from graph.config_io import _live_config_dir
+    from server.agent_init import _commons_dir, _resolve_skills_db, _seed_instance_env
+
+    cfg = LangGraphConfig.from_yaml(str(_live_config_dir() / "langgraph-config.yaml"))
+    _seed_instance_env(cfg)
+    if tier == "commons":
+        return _resolve_skills_db(cfg.skills_db_path, shared=True, commons=_commons_dir(cfg))
+    return _resolve_skills_db(cfg.skills_db_path, shared=False)
+
+
+def _run_curate(args) -> int:
+    """`skills curate --tier` — run the curator on one concrete tier with the tier's
+    policy (private: full pass; commons: dedupe only unless --prune, never decay)."""
+    from pathlib import Path
+
+    from graph.skills.curator import SkillCurator
+    from graph.skills.index import SkillsIndex
+
+    tier = args.tier
+    db_path = _resolve_tier_db(tier)
+    index = SkillsIndex(db_path=db_path)
+    decay = tier == "private"  # commons is trusted — never idle-decays
+    prune = True if tier == "private" else bool(args.prune)  # commons prunes only on --prune
+    # Audit next to the tier's DB (not a global default) — the commons audit lives with
+    # the commons, the private audit with the private store.
+    audit_path = str(Path(db_path).with_name(f"curator-audit-{tier}.jsonl"))
+    curator = SkillCurator(
+        db_path=db_path, audit_path=audit_path, index=index, tier=tier, decay=decay, prune=prune, dry_run=args.dry_run
+    )
+    try:
+        entry = curator.run()
+    finally:
+        index.close()
+    mode = "dry-run, nothing written" if args.dry_run else "applied"
+    print(
+        f"✓ curated tier={tier} ({mode}) — {db_path}\n"
+        f"  before={entry['skills_before']} after={entry['skills_after']} · "
+        f"decay={len(entry['decay_applied'])} dedup_clusters={len(entry['deduplicated'])} "
+        f"pruned={len(entry['pruned'])}"
+    )
+    return 0
+
+
 def run_skills_cli(argv: list[str]) -> int:
     args = _build_parser().parse_args(argv)
+    if args.cmd == "curate":
+        return _run_curate(args)  # single-tier — no layered index
     idx, commons_path = _layered_index()
     try:
         if args.cmd == "ls":

--- a/graph/skills/curator.py
+++ b/graph/skills/curator.py
@@ -163,6 +163,9 @@ class SkillCurator:
         prune_threshold: float = PRUNE_THRESHOLD,
         similarity_threshold: float = SIMILARITY_THRESHOLD,
         index=None,
+        tier: str = "private",
+        decay: bool = True,
+        prune: bool = True,
     ) -> None:
         self.db_path = db_path
         self.audit_path = audit_path
@@ -170,6 +173,14 @@ class SkillCurator:
         self.half_life_days = half_life_days
         self.prune_threshold = prune_threshold
         self.similarity_threshold = similarity_threshold
+        # Tier label for the audit + the curation POLICY (ADR 0041 / bd-2mc): the
+        # private tier decays-on-idle + prunes-below-threshold + dedupes; the shared
+        # commons is curated + TRUSTED, so it only dedupes — `decay=False` (a promoted
+        # skill must not rot just because the fleet was idle) and `prune=False` by
+        # default (removal is the explicit `skills forget`). Caller sets these per tier.
+        self.tier = tier
+        self.decay = decay
+        self.prune = prune
         # The live SkillsIndex (SQLite). Injectable for tests; built lazily
         # from db_path otherwise.
         self._index = index
@@ -179,6 +190,16 @@ class SkillCurator:
             from graph.skills.index import SkillsIndex
 
             self._index = SkillsIndex(self.db_path)
+        # Guard: the curator deletes/updates by ROWID, which is only unambiguous
+        # within ONE backend. A LayeredSkillsIndex routes writes to private while
+        # all_skills() returns both tiers' rowids — a commons rowid could collide
+        # with a private one and reap the wrong skill. So refuse a layered index:
+        # curate one concrete tier at a time (the `skills curate --tier` path does).
+        if hasattr(self._index, "_private") or hasattr(self._index, "promote"):
+            raise ValueError(
+                "SkillCurator must run against a single concrete tier, not a layered index — "
+                "curate one tier's DB at a time (see `python -m server skills curate --tier`)."
+            )
         return self._index
 
     # ── Public API ─────────────────────────────────────────────────────────────
@@ -195,15 +216,18 @@ class SkillCurator:
         skills = self._load_index()
         skills_before = len(skills)
 
-        decay_report = self._apply_decay(skills)
+        # Per-tier policy (bd-2mc): the commons doesn't decay (trusted/curated) and
+        # doesn't auto-prune (removal is the explicit `skills forget`); it only dedupes.
+        decay_report = self._apply_decay(skills) if self.decay else []
         dedup_report = self._deduplicate(skills)
-        prune_report, skills = self._prune(skills)
+        prune_report, skills = self._prune(skills) if self.prune else ([], skills)
 
         skills_after = len(skills)
 
         audit_entry = {
             "run_id": run_id,
             "timestamp": started_at.isoformat(),
+            "tier": self.tier,
             "dry_run": self.dry_run,
             "skills_before": skills_before,
             "skills_after": skills_after,

--- a/tests/test_skill_curator.py
+++ b/tests/test_skill_curator.py
@@ -15,6 +15,7 @@ import os
 import uuid
 from datetime import datetime, timedelta, timezone
 
+import pytest
 
 from graph.skills.curator import (
     PRUNE_THRESHOLD,
@@ -437,3 +438,63 @@ class TestCuratorRun:
         assert remaining[0]["name"] == "active summarizer"
         # Survivor's decayed confidence was written back (< its seeded 0.9).
         assert remaining[0]["confidence"] < 0.9
+
+
+# ── Per-tier curation policy (bd-2mc / ADR 0041) ────────────────────────────────
+
+
+class TestTierPolicy:
+    """The shared commons is curated + trusted: dedupe-only — no idle-decay (a promoted
+    skill mustn't rot because the fleet was idle) and no auto-prune (removal is the
+    explicit `skills forget`). The private tier keeps the full pass. And the curator
+    refuses a layered index outright (rowid deletes are only unambiguous per-backend)."""
+
+    def _audit(self, tmp_path):
+        return str(tmp_path / "audit.jsonl")
+
+    def test_commons_does_not_decay_or_prune(self, tmp_path):
+        # A long-idle skill the PRIVATE policy would decay + prune (see the contrast below).
+        idx = _seed_index(
+            str(tmp_path / "commons.db"),
+            [_make_skill(name="rare runbook", description="emergency restore steps", confidence=1.0, last_used_days_ago=400)],
+        )
+        entry = SkillCurator(
+            index=idx, audit_path=self._audit(tmp_path), tier="commons", decay=False, prune=False, dry_run=False
+        ).run()
+
+        kept = idx.all_skills()
+        assert len(kept) == 1  # survives — not pruned
+        assert kept[0]["confidence"] == 1.0  # not decayed
+        assert entry["tier"] == "commons"
+        assert entry["decay_applied"] == [] and entry["pruned"] == []
+
+    def test_commons_still_dedupes(self, tmp_path):
+        idx = _seed_index(
+            str(tmp_path / "commons.db"),
+            [
+                _make_skill(name="deploy", description="ship the service then verify it", confidence=1.0),
+                _make_skill(name="deploy", description="ship the service then verify it", confidence=0.8),
+            ],
+        )
+        entry = SkillCurator(
+            index=idx, audit_path=self._audit(tmp_path), tier="commons", decay=False, prune=False, dry_run=False
+        ).run()
+        assert len(idx.all_skills()) == 1  # deduped despite decay/prune being off
+        assert entry["deduplicated"]  # a duplicate cluster was reported
+
+    def test_private_policy_decays_and_prunes(self, tmp_path):
+        # Contrast: the same long-idle skill IS reaped under the private (default) policy.
+        idx = _seed_index(
+            str(tmp_path / "priv.db"),
+            [_make_skill(name="rare runbook", description="emergency restore steps", confidence=1.0, last_used_days_ago=400)],
+        )
+        SkillCurator(index=idx, audit_path=self._audit(tmp_path), tier="private").run()
+        assert idx.all_skills() == []  # decayed below threshold → pruned
+
+    def test_refuses_a_layered_index(self, tmp_path):
+        from graph.skills.index import SkillsIndex
+        from graph.skills.layered import LayeredSkillsIndex
+
+        layered = LayeredSkillsIndex(SkillsIndex(str(tmp_path / "p.db")), SkillsIndex(str(tmp_path / "c.db")))
+        with pytest.raises(ValueError, match="single concrete tier"):
+            SkillCurator(index=layered, audit_path=self._audit(tmp_path)).run()

--- a/tests/test_skills_layered.py
+++ b/tests/test_skills_layered.py
@@ -124,6 +124,35 @@ def test_skills_cli_forget(tmp_path, monkeypatch, capsys):
     assert cli.run_skills_cli(["forget", "nope"]) == 1  # nothing to forget
 
 
+def test_skills_cli_curate_commons_dedupes_only(tmp_path, monkeypatch, capsys):
+    """`skills curate --tier commons` dedupes but does NOT decay/prune (bd-2mc): a
+    long-idle promoted skill survives, duplicates collapse."""
+    from graph.skills import cli
+    from graph.skills.index import SkillsIndex
+
+    comm = str(tmp_path / "commons.db")
+    idx = SkillsIndex(comm)
+    idx.add_skill(_art("deploy", "ship then verify the service"))  # dup pair → dedupe
+    idx.add_skill(_art("deploy", "ship then verify the service"))
+    # A stale, high-value skill seeded with an ancient last_used (private would prune it).
+    conn = idx._open_conn()
+    conn.execute(
+        "INSERT INTO skills_fts (name, description, prompt_template, tools_used, "
+        "source_session_id, created_at, confidence, last_used) VALUES (?,?,?,?,?,?,?,?)",
+        ("rare runbook", "emergency restore", "do it", "", "", "2025-01-01T00:00:00+00:00", 1.0, "2025-01-01T00:00:00+00:00"),
+    )
+    conn.commit()
+    idx.close()
+
+    monkeypatch.setattr(cli, "_resolve_tier_db", lambda tier: comm)
+    assert cli.run_skills_cli(["curate", "--tier", "commons"]) == 0
+    assert "tier=commons" in capsys.readouterr().out
+
+    after = SkillsIndex(comm).all_skills()
+    assert "rare runbook" in [s["name"] for s in after]  # not decayed/pruned despite being stale
+    assert len([s for s in after if s["name"] == "deploy"]) == 1  # deduped
+
+
 def test_skills_scope_config_parses(tmp_path):
     from graph.config import LangGraphConfig
 


### PR DESCRIPTION
Builds **bd-2mc** from the shared-skills audit. The curator was CLI-only, built a plain single-DB `SkillsIndex` against a raw `--db` (default `/sandbox/skills.db`), and was **tier-unaware** — so the shared commons was never reachable by a normal run, and the curator had no notion of the runtime's private/commons tier paths.

### What's new
- **`python -m server skills curate [--tier private|commons]`** — runs the curator against **one concrete tier's DB**, resolved via the same helpers the runtime uses (in `graph/skills/cli.py`, the layering-legal place to reach `server.agent_init`).
- **Per-tier policy** (the decision we locked): the **private** tier keeps the full pass (idle-decay → dedupe → prune-below-threshold); the **commons** is curated + trusted, so it **dedupes only** — no idle-decay (a promoted runbook mustn't rot because the fleet was idle) and no auto-prune (removal is the explicit `skills forget`; `--prune` opts in). `SkillCurator` gains `tier`/`decay`/`prune` knobs; the audit is tagged with the tier and lives next to the tier's DB.
- **Safety guard**: `SkillCurator` now **refuses a layered index** — it deletes by rowid, which is only unambiguous within one backend (a commons rowid could collide with a private one and reap the wrong skill). `curate` always builds one concrete `SkillsIndex`, so this can't happen via the supported path. This also closes the latent corruption class I flagged in the audit.

### Layering
The curator stays **server-free** (no new `graph→server` import); tier→path resolution lives in `cli.py`, which is already on the import-linter allowlist for `server.agent_init`.

### Verification
`ruff` ✅ · 189 skills/curator/cli tests ✅. New tests: commons no-decay/no-prune, commons-still-dedupes, private full-pass contrast, layered-index refusal, and the `skills curate --tier commons` CLI path. Docs (guide + reference) updated.

Remaining from the audit: **bd-2wu** (shared knowledge tier — full hybrid, promotion-defined, one fleet/one embed model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `skills curate` command with `--tier` option (private or commons)
  * Private tier: decays idle skills, deduplicates, and prunes low-confidence items
  * Commons tier: deduplicates only; no automatic decay or pruning
  * New `--dry-run` and `--prune` flags for curation control

* **Documentation**
  * Updated skills curator guidance with tier-specific workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->