### PR TITLE
refactor(memory): rename MemoryMiddleware → SessionSummaryMiddleware + fix stale docs

### DIFF
--- a/docs/explanation/architecture.md
+++ b/docs/explanation/architecture.md
@@ -66,7 +66,7 @@ The template's middleware chain (`_build_middleware` in `graph/agent.py`) is ord
 3. **KnowledgeMiddleware** (optional) — injects retrieved knowledge + human-authored skills before each LLM call; also loads prior session memory
 4. **ToolDeferralMiddleware** (optional) — progressive tool disclosure (ADR 0005)
 5. **AuditMiddleware** — records every tool call to JSONL + Langfuse
-6. **MemoryMiddleware** (optional) — extracts conversation findings to the knowledge store
+6. **SessionSummaryMiddleware** (optional) — persists a session summary on session end (read back as `<prior_sessions>`)
 7. **CountingSummarizationMiddleware** (optional) — context compaction with a Prometheus counter (ADR 0006)
 8. **ModelFallbackMiddleware** (optional) — retry on fallback models (`routing.fallback_models`)
 9. **MessageCaptureMiddleware** — captures `message()` tool calls; runs last so every upstream transformation is already applied
@@ -75,7 +75,7 @@ Order matters: prompt-cache + knowledge run before audit (so injected context is
 
 ## Session memory
 
-Memory is **enabled by default** (`middleware.memory: true` in `langgraph-config.yaml`). At session end `MemoryMiddleware` writes a JSON summary to `/sandbox/memory/`. On the next session, `KnowledgeMiddleware.load_memory()` reads the 10 most recent summaries and injects them as a `<prior_sessions>` XML block into the system prompt context, giving the agent continuity across restarts without any external store.
+Memory is **enabled by default** (`middleware.memory: true` in `langgraph-config.yaml`). At session end `SessionSummaryMiddleware` writes a JSON summary to `/sandbox/memory/`. On the next session, `KnowledgeMiddleware.load_memory()` reads the 10 most recent summaries and injects them as a `<prior_sessions>` XML block into the system prompt context, giving the agent continuity across restarts without any external store.
 
 **Token budget:** the prior-sessions block is capped at 2 000 tokens (character approximation: chars ÷ 4). Oldest sessions are dropped first when the budget is exceeded.
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -344,7 +344,7 @@ Only read when `middleware.knowledge` is `true`.
 | `facts` | `true` | Extract semantic facts during the conversation-harvest pass. |
 | `top_k` | `5` | Results per query fed into state. |
 
-The bundled store is hybrid by default — FTS5 keyword search fused with vector similarity (RRF), with an embedding circuit breaker that falls back to FTS5 on an outage; set `embeddings: false` for keyword-only. One `chunks` table; the `domain` column distinguishes operator-set notes (`memory_ingest`), daily-log entries (`daily_log`), and conversation findings extracted by `MemoryMiddleware` (`domain='finding'`).
+The bundled store is hybrid by default — FTS5 keyword search fused with vector similarity (RRF), with an embedding circuit breaker that falls back to FTS5 on an outage; set `embeddings: false` for keyword-only. One `chunks` table; the `domain` column distinguishes operator-set notes (`memory_ingest`), daily-log entries (`daily_log`), and conversation findings extracted by `conversation_harvest` (`domain='finding'`).
 
 **Hot memory** — chunks stored under `domain='hot'` are *always-on*: `KnowledgeMiddleware` injects them into context every turn (vs. retrieved-on-relevance), re-read each turn so a freshly-added hot fact is seen immediately. Set one with `memory_ingest(content, domain="hot")` for facts the agent should never forget (operator preferences, standing constraints).
 

--- a/docs/reference/environment-variables.md
+++ b/docs/reference/environment-variables.md
@@ -72,7 +72,7 @@ Session memory is enabled by default. See [architecture § Session memory](/expl
 
 | Variable | Default | What |
 |---|---|---|
-| `MEMORY_PATH` | `/sandbox/memory/` | Directory where `MemoryMiddleware` writes JSON session summaries and where `KnowledgeMiddleware.load_memory()` reads them. Writes are atomic (temp file + rename). |
+| `MEMORY_PATH` | `/sandbox/memory/` | Directory where `SessionSummaryMiddleware` writes JSON session summaries and where `KnowledgeMiddleware.load_memory()` reads them. Writes are atomic (temp file + rename). |
 | `PROTOAGENT_DISABLE_MEMORY` | (unset) | Set to `1` (or any non-empty value) to suppress disk persistence without changing `langgraph-config.yaml`. Loading still occurs if summaries exist from prior runs. |
 
 To persist memory across container restarts, mount a volume at whatever `MEMORY_PATH` resolves to. Without a volume the directory is ephemeral.

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -15,7 +15,7 @@ from graph.llm import create_llm
 from graph.prompts import build_system_prompt, build_subagent_prompt
 from graph.middleware.audit import AuditMiddleware
 from graph.middleware.knowledge import KnowledgeMiddleware
-from graph.middleware.memory import MemoryMiddleware
+from graph.middleware.memory import SessionSummaryMiddleware
 from graph.middleware.message_capture import MessageCaptureMiddleware
 from graph.state import ProtoAgentState
 from graph.subagents.config import SUBAGENT_REGISTRY
@@ -106,7 +106,7 @@ def _build_middleware(config: LangGraphConfig, knowledge_store=None, skills_inde
         middleware.append(AuditMiddleware())
 
     if config.memory_middleware:
-        middleware.append(MemoryMiddleware(knowledge_store))
+        middleware.append(SessionSummaryMiddleware(knowledge_store))
 
     # Context compaction — summarize old history near the context limit.
     # CountingSummarizationMiddleware adds a Prometheus compaction counter on top

--- a/graph/middleware/knowledge.py
+++ b/graph/middleware/knowledge.py
@@ -92,7 +92,7 @@ class KnowledgeMiddleware(AgentMiddleware):
 
         Delegates to the shared :func:`graph.middleware.memory.load_prior_sessions`
         (ADR 0021) — one source of truth, with read-time reasoning stripping —
-        so this and ``MemoryMiddleware`` can't drift. ``memory_path`` defaults
+        so this and ``SessionSummaryMiddleware`` can't drift. ``memory_path`` defaults
         to the writer's resolved ``MEMORY_PATH`` (no duplicate path literal,
         same can't-drift reasoning). Never raises.
         """

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -1,10 +1,13 @@
-"""MemoryMiddleware — queues conversation for async knowledge extraction.
+"""SessionSummaryMiddleware — persists a session summary on each terminal turn.
 
-After the agent responds, extracts key topics/findings from the
-conversation and stores them in the knowledge base asynchronously.
+Writes a reasoning-stripped JSON summary of the session to disk (``MEMORY_PATH``)
+on the terminal turn and on session end, enabling cross-session memory across
+restarts — read back by ``KnowledgeMiddleware`` as a ``<prior_sessions>`` block.
 
-Also persists a session summary to disk when sessions end via the
-on_session_end lifecycle hook, enabling session memory across restarts.
+It does **not** write to the knowledge store: the old per-turn finding extraction
+was removed in ADR 0021 (it dumped raw, truncated, scratch_pad-laden turns). KB
+capture now lives in ``conversation_harvest`` (on thread retire) + the fact
+extractor — extract, don't dump.
 """
 
 import json
@@ -210,7 +213,7 @@ def load_prior_sessions(
 ) -> str:
     """Format the most-recent persisted sessions as a ``<prior_sessions>`` block.
 
-    The canonical loader used by *both* ``MemoryMiddleware`` and
+    The canonical loader used by *both* ``SessionSummaryMiddleware`` and
     ``KnowledgeMiddleware`` — previously two copy-pasted implementations. Reads
     up to ``max_sessions`` newest JSON files, drops oldest-first to fit
     ``max_tokens`` (char/4 approximation), and **strips reasoning at read** so a
@@ -280,10 +283,16 @@ def load_prior_sessions(
 # ---------------------------------------------------------------------------
 
 
-class MemoryMiddleware(AgentMiddleware):
-    """Extract and store QA findings after agent responses.
+class SessionSummaryMiddleware(AgentMiddleware):
+    """Persist a session summary on the terminal turn (+ on session end).
 
-    Also persists a session summary on session end via on_session_end.
+    Writes a reasoning-stripped JSON summary to ``MEMORY_PATH``, read back by
+    ``KnowledgeMiddleware`` as ``<prior_sessions>`` for cross-session continuity.
+    Does **not** write to the knowledge store (ADR 0021 — see ``after_agent``).
+
+    Also injects ``<prior_sessions>`` itself, but only as a fallback when no
+    ``KnowledgeMiddleware`` is active (``self._store is None``) — otherwise
+    Knowledge owns that injection.
     """
 
     def __init__(self, knowledge_store=None):

--- a/knowledge/store.py
+++ b/knowledge/store.py
@@ -3,7 +3,7 @@
 The template's default knowledge surface. One ``chunks`` table holds
 every piece of stored content (operator notes via ``memory_ingest``,
 daily-log entries, conversation findings extracted by
-``MemoryMiddleware``); the ``domain`` column distinguishes them.
+``conversation_harvest``); the ``domain`` column distinguishes them.
 
 Search uses sqlite FTS5 when available (true on virtually all modern
 sqlite builds). When FTS5 is missing — sandboxed sqlite, custom builds

--- a/tests/test_memory_load.py
+++ b/tests/test_memory_load.py
@@ -360,7 +360,7 @@ async def test_abefore_model_runs_search_off_event_loop():
 
 
 async def test_memory_middleware_abefore_model_off_loop(tmp_path, monkeypatch):
-    """MemoryMiddleware.abefore_model (standalone mode, disk reads) also
+    """SessionSummaryMiddleware.abefore_model (standalone mode, disk reads) also
     dispatches via to_thread."""
     import threading
 
@@ -374,8 +374,8 @@ async def test_memory_middleware_abefore_model_off_loop(tmp_path, monkeypatch):
         seen_threads.append(threading.current_thread())
         return "<prior_sessions>old</prior_sessions>"
 
-    monkeypatch.setattr(memmod.MemoryMiddleware, "_load_prior_sessions", _fake_load)
-    mw = memmod.MemoryMiddleware(knowledge_store=None)
+    monkeypatch.setattr(memmod.SessionSummaryMiddleware, "_load_prior_sessions", _fake_load)
+    mw = memmod.SessionSummaryMiddleware(knowledge_store=None)
 
     state = {"messages": [HumanMessage(content="hello")]}
     result = await mw.abefore_model(state, runtime=None)

--- a/tests/test_memory_persistence.py
+++ b/tests/test_memory_persistence.py
@@ -442,11 +442,11 @@ def test_persist_session_unknown_only_when_no_session_id_anywhere(tmp_path):
 
 
 def test_on_session_end_calls_persist_session(tmp_path):
-    """MemoryMiddleware.on_session_end must call _persist_session."""
+    """SessionSummaryMiddleware.on_session_end must call _persist_session."""
     mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
 
     store = MagicMock()
-    mw = mod.MemoryMiddleware(knowledge_store=store)
+    mw = mod.SessionSummaryMiddleware(knowledge_store=store)
 
     state = _make_state("hook-session")
     runtime = MagicMock()
@@ -471,7 +471,7 @@ def test_after_agent_persists_on_terminal_turn(tmp_path):
     mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
 
     store = MagicMock()
-    mw = mod.MemoryMiddleware(knowledge_store=store)
+    mw = mod.SessionSummaryMiddleware(knowledge_store=store)
 
     messages = [
         HumanMessage(content="Hello"),
@@ -496,7 +496,7 @@ def test_after_agent_does_not_dump_findings_to_store(tmp_path):
     mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
 
     store = MagicMock()
-    mw = mod.MemoryMiddleware(knowledge_store=store)
+    mw = mod.SessionSummaryMiddleware(knowledge_store=store)
 
     messages = [
         HumanMessage(content="What's the release cadence?"),
@@ -516,7 +516,7 @@ def test_after_agent_does_not_persist_when_tool_calls_pending(tmp_path):
     mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
 
     store = MagicMock()
-    mw = mod.MemoryMiddleware(knowledge_store=store)
+    mw = mod.SessionSummaryMiddleware(knowledge_store=store)
 
     ai_msg = AIMessage(content="")
     ai_msg.tool_calls = [{"id": "tc1", "name": "search", "args": {"query": "x"}}]
@@ -541,7 +541,7 @@ def test_after_agent_does_not_persist_when_last_msg_not_ai(tmp_path):
     mod = _reload_memory({"MEMORY_PATH": str(tmp_path), "PROTOAGENT_DISABLE_MEMORY": ""})
 
     store = MagicMock()
-    mw = mod.MemoryMiddleware(knowledge_store=store)
+    mw = mod.SessionSummaryMiddleware(knowledge_store=store)
 
     messages = [
         HumanMessage(content="Hello"),

--- a/tests/test_prior_sessions.py
+++ b/tests/test_prior_sessions.py
@@ -1,7 +1,7 @@
 """ADR 0021 Phase 3: one shared <prior_sessions> loader, with read-time
 reasoning stripping.
 
-The loader is the single source of truth for both MemoryMiddleware and
+The loader is the single source of truth for both SessionSummaryMiddleware and
 KnowledgeMiddleware (previously two copy-pasted copies). It strips reasoning at
 read so a session file written by an older build can't inject <scratch_pad> into
 the prompt.


### PR DESCRIPTION
## What

Renames `MemoryMiddleware` → **`SessionSummaryMiddleware`** and corrects the docs that still describe a role ADR 0021 removed.

## Why

The class hasn't extracted findings to the knowledge store since **ADR 0021** stripped that per-turn dump (it was *"the junk — remove"*). All it does now is **persist a reasoning-stripped session summary to disk**, read back by `KnowledgeMiddleware` as `<prior_sessions>`. But the name + several docs still claimed it "extracts conversation findings to the knowledge store" — flat wrong.

This came out of a `memory` vs `knowledge` middleware audit: they're a clean **producer/consumer pair** (Memory *writes* session summaries; Knowledge *reads* them + does KB retrieval), so the names should say so.

## Changes

- Rename the class + the agent wiring + 3 test files (the `middleware.memory` config toggle is **unchanged** — stable/user-facing).
- Fix the stale "extracts findings to the KB" claims → the real producer is **`conversation_harvest`** (`architecture.md`, `configuration.md`, `knowledge/store.py`, plus the `memory.py` module/class docstrings).
- ADR 0021 + CHANGELOG left as historical records.

No behavior change.

## Deliberately NOT done

The prior-sessions **TTL-cache de-dup** (shared by both middlewares). Digging in, ~6 test files poke `_prior_sessions_cache`/`_prior_sessions_loaded_at` directly, so collapsing it into one helper is a ~15-test-site rework for ~10 duplicated lines — a worse trade than it looked. Flagged for a separate call.

## Testing

`ruff` clean; full `pytest tests/` suite green — **2250 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)