### PR TITLE
refactor(memory): make SessionSummaryMiddleware write-only — drop the prior-sessions fallback

### DIFF
--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -108,7 +108,7 @@ Adding a new subagent name to the YAML requires matching entries in `graph/subag
 |---|---|---|
 | `knowledge` | `true` | Inject retrieved knowledge into state before LLM calls. Backed by the bundled `KnowledgeStore` (sqlite + FTS5). Set `false` for a stateless agent. |
 | `audit` | `true` | Append every tool call to `/sandbox/audit/audit.jsonl`. |
-| `memory` | `true` | Persist a session summary on terminal turn and asynchronously index conversation findings under `domain='finding'`. |
+| `memory` | `true` | Persist a reasoning-stripped session summary at terminal turn / session end (read back as `<prior_sessions>` by the knowledge middleware). |
 | `scheduler` | `true` | Wire the bundled scheduler backend (local sqlite, or `WorkstaceanScheduler` when env vars are set). Drops the `schedule_task` / `list_schedules` / `cancel_schedule` tools from the agent loop when `false`. Has the same effect as `SCHEDULER_DISABLED=1` — but `middleware.scheduler: false` is the canonical opt-out (drawer/wizard editable, survives restarts), while the env var is a runtime escape hatch for fleet operators who can't edit YAML in the moment. |
 | `enforcement` | `false` | Opt-in safety gate that blocks tool calls **before** they execute (see `enforcement` block below). **YAML / code seam — not surfaced in the console**, since it's a no-op until a deny list, rate limit, or predicate is configured. |
 

--- a/graph/middleware/memory.py
+++ b/graph/middleware/memory.py
@@ -42,28 +42,10 @@ MEMORY_PATH = str(scope_leaf(os.environ.get("MEMORY_PATH") or data_home() / "mem
 _DISABLE_ENV = os.environ.get("PROTOAGENT_DISABLE_MEMORY", "")
 _PERSISTENCE_DISABLED = _DISABLE_ENV.lower() in ("1", "true", "yes")
 
-# How long the <prior_sessions> block is cached before a disk reload (bounds
-# staleness vs per-turn I/O). Mirrors KnowledgeMiddleware's constant.
-_PRIOR_SESSIONS_TTL_S = 60.0
-
 if _PERSISTENCE_DISABLED:
     log.debug("[memory] persistence disabled via PROTOAGENT_DISABLE_MEMORY")
 else:
     log.info("[memory] session persistence enabled — path: %s", MEMORY_PATH)
-
-
-def _in_goal_turn() -> bool:
-    """Whether the current turn is a goal-driven invocation.
-
-    Lazy import keeps memory decoupled from the goals package and fail-safe
-    (treat as a normal turn if the marker module is unavailable).
-    """
-    try:
-        from graph.goals.goal_turn import in_goal_turn
-
-        return in_goal_turn()
-    except Exception:
-        return False
 
 
 # ---------------------------------------------------------------------------
@@ -288,78 +270,17 @@ class SessionSummaryMiddleware(AgentMiddleware):
 
     Writes a reasoning-stripped JSON summary to ``MEMORY_PATH``, read back by
     ``KnowledgeMiddleware`` as ``<prior_sessions>`` for cross-session continuity.
-    Does **not** write to the knowledge store (ADR 0021 — see ``after_agent``).
 
-    Also injects ``<prior_sessions>`` itself, but only as a fallback when no
-    ``KnowledgeMiddleware`` is active (``self._store is None``) — otherwise
-    Knowledge owns that injection.
+    **Write-only.** It does not write to the knowledge store (ADR 0021 — see
+    ``after_agent``) and does not inject ``<prior_sessions>``: that read/inject
+    path is owned solely by ``KnowledgeMiddleware``, so cross-session continuity
+    requires the knowledge middleware (on by default).
     """
 
     def __init__(self, knowledge_store=None):
         super().__init__()
+        # Accepted for ctor compatibility; unused now that this is write-only.
         self._store = knowledge_store
-        # TTL cache (see _PRIOR_SESSIONS_TTL_S): refreshed periodically so
-        # sessions persisted after boot become visible, not frozen at first load.
-        self._prior_sessions_cache: str | None = None
-        self._prior_sessions_loaded_at: float = 0.0
-
-    # --- Session memory loading (only used when no KnowledgeMiddleware is active) ---
-
-    def _load_prior_sessions(self) -> str:
-        """Prior-session continuity when standalone (no KnowledgeMiddleware).
-
-        Delegates to the shared :func:`load_prior_sessions` (ADR 0021) — one
-        source of truth for both middlewares. Runs only when ``self._store is
-        None``, so there's no double-injection with KnowledgeMiddleware.
-        """
-        return load_prior_sessions(MEMORY_PATH)
-
-    def before_model(self, state, runtime) -> dict | None:
-        """Inject `<prior_sessions>` into system prompt when running standalone.
-
-        When KnowledgeMiddleware is present it handles this; we only act when
-        `self._store is None`.
-        """
-        if self._store is not None:
-            return None
-        # Suppressed on goal-driven turns (see graph.goals.goal_turn):
-        # unrelated cross-session history biases the self-driving loop.
-        if _in_goal_turn():
-            return None
-        import time
-
-        now = time.monotonic()
-        if self._prior_sessions_cache is None or (now - self._prior_sessions_loaded_at) > _PRIOR_SESSIONS_TTL_S:
-            self._prior_sessions_cache = self._load_prior_sessions()
-            self._prior_sessions_loaded_at = now
-        if not self._prior_sessions_cache:
-            return None
-        messages = state.get("messages", [])
-        if not messages:
-            return None
-        # Prepend as a system-adjacent HumanMessage block. LangGraph has no
-        # dedicated system-context append hook on state, so we piggyback on
-        # the first human message by modifying its content.
-        from langchain_core.messages import SystemMessage
-
-        first = messages[0]
-        if isinstance(first, SystemMessage):
-            # Already has a system message — append prior_sessions to it
-            new_content = first.content + "\n\n" + self._prior_sessions_cache
-            new_msgs = [SystemMessage(content=new_content)] + list(messages[1:])
-            return {"messages": new_msgs}
-        # Otherwise prepend a new SystemMessage
-        new_msgs = [SystemMessage(content=self._prior_sessions_cache)] + list(messages)
-        return {"messages": new_msgs}
-
-    async def abefore_model(self, state, runtime) -> dict | None:
-        # before_model reads prior sessions from disk — keep that I/O off the
-        # event loop (same pattern as graph/checkpointer.py).
-        import asyncio
-
-        return await asyncio.to_thread(self.before_model, state, runtime)
-
-    # --- Knowledge extraction (existing) ---
 
     def after_agent(self, state, runtime) -> dict | None:
         """Persist a session summary on the terminal turn.

--- a/tests/test_memory_load.py
+++ b/tests/test_memory_load.py
@@ -357,28 +357,3 @@ async def test_abefore_model_runs_search_off_event_loop():
     # …but the blocking search ran on a worker thread, not the event loop.
     assert seen_threads, "store.search was never called"
     assert seen_threads[0] is not threading.main_thread()
-
-
-async def test_memory_middleware_abefore_model_off_loop(tmp_path, monkeypatch):
-    """SessionSummaryMiddleware.abefore_model (standalone mode, disk reads) also
-    dispatches via to_thread."""
-    import threading
-
-    from langchain_core.messages import HumanMessage
-
-    import graph.middleware.memory as memmod
-
-    seen_threads: list[threading.Thread] = []
-
-    def _fake_load(self):
-        seen_threads.append(threading.current_thread())
-        return "<prior_sessions>old</prior_sessions>"
-
-    monkeypatch.setattr(memmod.SessionSummaryMiddleware, "_load_prior_sessions", _fake_load)
-    mw = memmod.SessionSummaryMiddleware(knowledge_store=None)
-
-    state = {"messages": [HumanMessage(content="hello")]}
-    result = await mw.abefore_model(state, runtime=None)
-
-    assert result is not None  # prior sessions injected
-    assert seen_threads and seen_threads[0] is not threading.main_thread()


### PR DESCRIPTION
## What

Collapses the duplicated `<prior_sessions>` cache flagged in #1247: **`KnowledgeMiddleware` becomes the sole owner** of reading/injecting prior sessions, and **`SessionSummaryMiddleware` becomes purely write-side** (persist a session summary on the terminal turn / session end).

## Why this over a shared helper

The dup was real but ~6 test files poke `_prior_sessions_cache` / `_prior_sessions_loaded_at` directly. Sharing a `PriorSessionsCache` helper meant a ~15-site test rework for ~10 lines. **Dropping the no-knowledge-store fallback removes the duplication outright** — only `KnowledgeMiddleware` keeps the cache (and the tests that poke it are on `KnowledgeMiddleware`, untouched).

## Changes

- `memory.py`: remove the fallback `before_model`/`abefore_model`, `_load_prior_sessions`, the cache fields, and the now-unused module-level `_in_goal_turn` + `_PRIOR_SESSIONS_TTL_S`.
- Delete the fallback's off-loop test; correct the stale `middleware.memory` toggle doc.
- `KnowledgeMiddleware` is **unchanged** (keeps its own cache / `_in_goal_turn` / constant).

## ⚠️ Behavior change

Cross-session `<prior_sessions>` continuity now requires the **knowledge middleware** (`middleware.knowledge: true`, the default). The rare `knowledge: false` + `memory: true` combo no longer injects prior sessions. (Approved.)

## Testing

`ruff` clean; full `pytest tests/` suite green — **2271 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)