### PR TITLE
fix(web): replace the host inheritance banner with a compact host badge

### DIFF
--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -73,9 +73,9 @@ test("the settings dialog lists the grouped Agent + Box sections (host, no scope
   expect(await page.locator(".pl-accordion__title").allTextContents()).toEqual(["Compaction", "Runtime"]);
 });
 
-test("the host inheritance banner explains box defaults", async ({ page }) => {
+test("the host scope badge marks box defaults", async ({ page }) => {
   await openSettings(page);
-  await expect(page.locator(".settings-overlay .pl-alert").first()).toContainText("box defaults every agent inherits");
+  await expect(page.locator(".settings-overlay .settings-scope-badge")).toContainText("Host · box defaults");
 });
 
 test("opening from the header drawer's Settings item shows the same dialog + the Box sections", async ({ page }) => {

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -3,7 +3,7 @@ import type { LucideIcon } from "lucide-react";
 import { useEffect, type ReactNode } from "react";
 
 import { SideNav, Tabs } from "@protolabsai/ui/navigation";
-import { Alert } from "@protolabsai/ui/data";
+import { Badge } from "@protolabsai/ui/primitives";
 
 import { IdentityPanel } from "../agent/IdentityPanel";
 import { McpPanel } from "../app/McpPanel";
@@ -111,11 +111,14 @@ export function SettingsSurface({ initialSection }: { only?: "host" | "workspace
     <div className="settings-shell">
       <SideNav ariaLabel="Settings sections" groups={groups} active={active.id} onSelect={(id) => setSection(id)} />
       <div className="settings-content">
-        <Alert status="info" className="settings-inheritance-banner">
-          {onHost
-            ? "Editing the host — these are the box defaults every agent inherits, unless an agent overrides them."
-            : "Editing this agent — it inherits the box defaults from the host; changes here override for this agent only."}
-        </Alert>
+        {onHost ? (
+          <div
+            className="settings-scope-badge"
+            title="Box defaults — every agent on this machine inherits these unless it sets its own. Per-agent overrides live under each agent's Settings."
+          >
+            <Badge status="info"><Server size={12} /> Host · box defaults</Badge>
+          </div>
+        ) : null}
         {active.render()}
       </div>
     </div>

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -195,9 +195,11 @@
   cursor: pointer;
 }
 
-/* Inheritance banner (2026-06 settings consolidation) — sits atop the settings content,
-   above the active section, clarifying host (box defaults) vs member (overrides) context. */
-.settings-inheritance-banner {
-  margin: 0 0 14px;
+/* Host scope badge (2026-06) — a compact "you're editing the box defaults" marker atop
+   the settings content on the host console; replaces the old full-width inheritance banner. */
+.settings-scope-badge {
+  display: flex;
+  justify-content: flex-end;
+  margin: 0 0 10px;
   flex: none;
 }


### PR DESCRIPTION
Per request: the full-width *"Editing the host — these are the box defaults every agent inherits…"* Alert that sat atop every settings section is replaced by a compact **`Host · box defaults`** badge at the top of the settings content (the same explanation as a hover tooltip). On an agent console there's no banner at all — the per-field inherited/override badges already convey inheritance (ADR 0047). Swaps Alert→Badge, repurposes the banner CSS, updates the e2e assertion. `tsc` clean · build green · 100 unit tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the Settings dialog on the host console with a refined scope indicator design, replacing the inheritance message banner with a compact host-scope badge to provide clearer visual distinction of default settings and improve overall interface clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->