### PR TITLE
chore(execute_code): tighten the plugin card description

### DIFF
--- a/plugins/execute_code/protoagent.plugin.yaml
+++ b/plugins/execute_code/protoagent.plugin.yaml
@@ -2,19 +2,12 @@ id: execute_code
 name: Execute Code
 version: 0.1.0
 description: >-
-  A sandboxed Python code interpreter for the agent: it writes a Python script,
-  the script runs in an isolated subprocess, and its stdout comes back. The
-  script can do anything Python can — compute, parse, transform data. Its
-  headline use is programmatic tool-calling (call several tools, compose their
-  results in code, print only what matters — collapsing a multi-step tool chain
-  into one turn), but it is not limited to tool calls. SECURITY: this runs
-  arbitrary model-authored code — subprocess + scrubbed env (no credentials) +
-  hard timeout is isolation, NOT a true sandbox (the script can reach the
-  disk/network as the server user; the `tools` allowlist scopes only the tool
-  bridge, not what code runs) — so it ships disabled; enable only for a trusted
-  model or inside a hardened container. Unavailable in the packaged desktop build
-  (no standalone Python interpreter). Enable with
-  `plugins: { enabled: [execute_code] }`.
+  A Python interpreter the agent runs code in — its headline use is programmatic
+  tool-calling (call several tools, compose the results in code, return only what
+  matters). It runs arbitrary model-authored code: a scrubbed-env subprocess with
+  a hard timeout is isolation, not a true sandbox (code can reach disk/network as
+  the server user), so it ships disabled — for a trusted model or hardened
+  container only.
 enabled: false
 
 # Declarative (not yet enforced) — surfaced in the console for transparency.


### PR DESCRIPTION
The Execute Code plugin card description was too long to display cleanly.
It restated things the card already shows on its own affordances — the
capability tags (`network`/`filesystem`/`subprocess`), the
"Bundled · enable execute_code in plugins.enabled" footer, Source/Docs links —
and the full security write-up also lives in the Settings ▸ Execute Code field.

This trims the manifest `description` from ~930 → ~407 chars (two sentences):
**what it is + its headline use** (programmatic tool-calling), and the
**non-negotiable security caveat** (runs arbitrary model-authored code;
subprocess + scrubbed env + hard timeout is isolation, *not* a true sandbox;
ships disabled). No behavior change — manifest metadata only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Revised the execute_code plugin description to focus on programmatic tool-calling capabilities.
  * Updated security notes to clarify system-level access limitations while preserving key safety information.
  * Streamlined documentation by removing redundant packaging and configuration details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->