### PR TITLE
chore: release v0.63.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.63.1] - 2026-06-20
+
 ## [0.63.0] - 2026-06-20
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.63.1] - 2026-06-20
 
+### Fixed
+- **Plugin manager: uninstall restored.** A regression had left git-installed plugins
+  installable and toggleable but not removable; uninstall works again, gated on the
+  lock-backed plugin inventory. (#1255)
+
+### Changed
+- **Consolidated plugin manager.** Plugin management now lives in one surface, and
+  "Install from URL" became a dialog opened from the Installed toolbar (ADR 0059). (#1255)
+- **Settings host cue.** The full-width host inheritance banner is now a compact
+  "Host · box defaults" badge by the settings header. (#1256)
+- **Execute Code plugin card.** Trimmed its catalog-card description (~2.3×) so it fits
+  the display, keeping the headline use and the "isolation, not a true sandbox" caveat. (#1257)
+
 ## [0.63.0] - 2026-06-20
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.63.0"
+version = "0.63.1"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,15 @@
 [
   {
+    "version": "v0.63.1",
+    "date": "2026-06-20",
+    "changes": [
+      "Uninstall works again for git-installed plugins — a regression had left them installable and toggleable but not removable.",
+      "Plugin management is consolidated into one surface, and Install-from-URL is now a dialog opened from the Installed toolbar.",
+      "The host-scope cue in Settings is a compact \"Host · box defaults\" badge instead of a full-width banner.",
+      "Tightened the Execute Code plugin's catalog-card description so it fits the display."
+    ]
+  },
+  {
     "version": "v0.63.0",
     "date": "2026-06-20",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.63.1`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.63.1 -m 'Release v0.63.1' && git push origin v0.63.1`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).