### PR TITLE
chore(docs): bump @protolabsai/vitepress-theme to 0.3.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
       ],
       "devDependencies": {
         "@protolabsai/design": "^0.3.0",
-        "@protolabsai/vitepress-theme": "^0.3.0",
+        "@protolabsai/vitepress-theme": "^0.3.6",
         "vitepress": "^1.6.4"
       }
     },
@@ -2046,16 +2046,26 @@
       }
     },
     "node_modules/@protolabsai/vitepress-theme": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@protolabsai/vitepress-theme/-/vitepress-theme-0.3.0.tgz",
-      "integrity": "sha512-kDkmQ2RNnapmcpvfY7wdzWyJSdpbatVyzsaL5vuFZ+A7wA8V6/exl0l7PFNhSVKjXFNpkFo+CJ0E176wlf3n5Q==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@protolabsai/vitepress-theme/-/vitepress-theme-0.3.6.tgz",
+      "integrity": "sha512-ggYOh7+e6lHWEaIVgZmFswzMpJGgdEXB7ZLkblev9gD4NhfCwr0qFUd/GBU7XGq+STxXegB1JKjwnp+N32AuuA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@protolabsai/design": "0.3.0"
+        "@protolabsai/design": "0.7.0"
       },
       "peerDependencies": {
         "vitepress": ">=1.0.0"
+      }
+    },
+    "node_modules/@protolabsai/vitepress-theme/node_modules/@protolabsai/design": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@protolabsai/design/-/design-0.7.0.tgz",
+      "integrity": "sha512-QF/SShqPhP9SFPFiBnJkjOyp8/bbP07xi6dVtqZDkPb4U8QwnUtL1ld88xEZMa3SvY6GX2R53fa+JCgSiz3HGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "protolabs-sync-assets": "bin/sync-assets.mjs"
       }
     },
     "node_modules/@radix-ui/primitive": {

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "devDependencies": {
     "@protolabsai/design": "^0.3.0",
-    "@protolabsai/vitepress-theme": "^0.3.0",
+    "@protolabsai/vitepress-theme": "^0.3.6",
     "vitepress": "^1.6.4"
   }
 }


### PR DESCRIPTION
## What

Bumps the studio VitePress theme used by the docs site from `^0.3.0` (lockfile pinned `0.3.0`) to the latest **`^0.3.6`**.

| File | Change |
|------|--------|
| `package.json` | `@protolabsai/vitepress-theme` `^0.3.0` → `^0.3.6` |
| `package-lock.json` | theme → `0.3.6`; pulls its bundled `@protolabsai/design@0.7.0` nested under the theme |

## Why this is the whole change

The docs build (`docs/.vitepress/`) imports **only** `@protolabsai/vitepress-theme` — never `@protolabsai/design` directly — so the theme's own bundled `0.7.0` is what renders. The root `@protolabsai/design` devDep is intentionally left at `^0.3.0`: bumping it wouldn't change build output or dedupe anything (the web workspace already carries `0.5.1`/`0.6.0` independently — the multi-version spread is the existing monorepo norm).

## Verification

`npm run docs:build` runs clean — builds client + server bundles and renders all pages, no errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated a dependency to a newer patch version for improved compatibility and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->