### PR TITLE
feat(mcp): quick-add common MCP servers from a curated picker

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Quick-add for common MCP servers.** Settings ▸ MCP has a "Browse common servers"
+  picker — a curated directory (filesystem, git, fetch, GitHub, Brave Search, memory,
+  sequential-thinking, time) that one-click adds a server, prompting only for the path
+  or API token it needs. Backed by `config/mcp-catalog.json` + `GET /api/mcp/catalog`.
+
 ## [0.63.1] - 2026-06-20
 
 ### Fixed

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -39,13 +39,15 @@ test("MCP catalog quick-adds a common server that needs an input", async ({ page
   await page.locator(".pl-sidenav").getByRole("tab", { name: "MCP", exact: true }).click();
 
   await page.getByRole("button", { name: /Browse common servers/ }).click();
-  // The catalog search field renders only in the dialog's browse view — a clean open signal.
-  await expect(page.getByLabel("search MCP servers")).toBeVisible();
+  // Scope to the dialog — the panel behind it has its own "Add server" trigger. The
+  // catalog search field renders only in the dialog's browse view (a clean open signal).
+  const dialog = page.getByRole("dialog", { name: "Add a common MCP server" });
+  await expect(dialog.getByLabel("search MCP servers")).toBeVisible();
 
   // Filesystem needs a path → picking it opens a configure step before adding.
-  await page.locator(".mcp-catalog-card", { hasText: "Filesystem" }).getByRole("button", { name: "Add" }).click();
-  await page.getByLabel("Allowed directory").fill("/data");
-  await page.getByRole("button", { name: "Add server", exact: true }).click();
+  await dialog.locator(".mcp-catalog-card", { hasText: "Filesystem" }).getByRole("button", { name: "Add" }).click();
+  await dialog.getByLabel("Allowed directory").fill("/data");
+  await dialog.getByRole("button", { name: "Add server", exact: true }).click();
 
   // A successful add closes the dialog, hints, and the server joins the list.
   await expect(page.getByLabel("search MCP servers")).toHaveCount(0);
@@ -59,10 +61,11 @@ test("MCP catalog adds a no-input server in one click", async ({ page }) => {
   await page.locator(".pl-sidenav").getByRole("tab", { name: "MCP", exact: true }).click();
 
   await page.getByRole("button", { name: /Browse common servers/ }).click();
-  await expect(page.getByLabel("search MCP servers")).toBeVisible();
+  const dialog = page.getByRole("dialog", { name: "Add a common MCP server" });
+  await expect(dialog.getByLabel("search MCP servers")).toBeVisible();
 
   // Memory needs no config → one click adds it and closes the dialog.
-  await page.locator(".mcp-catalog-card", { hasText: "Memory" }).getByRole("button", { name: "Add" }).click();
+  await dialog.locator(".mcp-catalog-card", { hasText: "Memory" }).getByRole("button", { name: "Add" }).click();
   await expect(page.getByLabel("search MCP servers")).toHaveCount(0);
   await expect(page.locator(".plugin-hint")).toContainText("Connected memory");
   await expect(page.getByText("memory · stdio")).toBeVisible();

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -32,3 +32,38 @@ test("MCP tab imports servers from pasted JSON", async ({ page }) => {
   await page.getByRole("button", { name: "Import", exact: true }).click();
   await expect(page.locator(".plugin-hint")).toContainText("Imported 2 servers: filesystem, weather");
 });
+
+test("MCP catalog quick-adds a common server that needs an input", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("settings-widget").click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "MCP", exact: true }).click();
+
+  await page.getByRole("button", { name: /Browse common servers/ }).click();
+  // The catalog search field renders only in the dialog's browse view — a clean open signal.
+  await expect(page.getByLabel("search MCP servers")).toBeVisible();
+
+  // Filesystem needs a path → picking it opens a configure step before adding.
+  await page.locator(".mcp-catalog-card", { hasText: "Filesystem" }).getByRole("button", { name: "Add" }).click();
+  await page.getByLabel("Allowed directory").fill("/data");
+  await page.getByRole("button", { name: "Add server", exact: true }).click();
+
+  // A successful add closes the dialog, hints, and the server joins the list.
+  await expect(page.getByLabel("search MCP servers")).toHaveCount(0);
+  await expect(page.locator(".plugin-hint")).toContainText("Connected filesystem");
+  await expect(page.getByText("filesystem · stdio")).toBeVisible();
+});
+
+test("MCP catalog adds a no-input server in one click", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("settings-widget").click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "MCP", exact: true }).click();
+
+  await page.getByRole("button", { name: /Browse common servers/ }).click();
+  await expect(page.getByLabel("search MCP servers")).toBeVisible();
+
+  // Memory needs no config → one click adds it and closes the dialog.
+  await page.locator(".mcp-catalog-card", { hasText: "Memory" }).getByRole("button", { name: "Add" }).click();
+  await expect(page.getByLabel("search MCP servers")).toHaveCount(0);
+  await expect(page.locator(".plugin-hint")).toContainText("Connected memory");
+  await expect(page.getByText("memory · stdio")).toBeVisible();
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -184,6 +184,28 @@ function handleApiGet(pathname, fleet = FLEET) {
           },
         ],
       };
+    case "/api/mcp/catalog": {
+      // Curated common-MCP-server directory (quick-add picker). `installed` mirrors
+      // whatever is already in the runtime roster.
+      const configured = new Set(RUNTIME_STATUS.mcp.servers.map((s) => s.name));
+      return {
+        servers: [
+          {
+            id: "memory", name: "Memory", category: "Reasoning",
+            tagline: "A persistent knowledge-graph memory.", requires: "node", official: true,
+            template: { name: "memory", transport: "stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-memory"] },
+            installed: configured.has("memory"),
+          },
+          {
+            id: "filesystem", name: "Filesystem", category: "Files",
+            tagline: "Read and write files under a directory you allow.", requires: "node", official: true,
+            template: { name: "filesystem", transport: "stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "${path}"] },
+            inputs: [{ key: "path", label: "Allowed directory", placeholder: "/data", required: true }],
+            installed: configured.has("filesystem"),
+          },
+        ],
+      };
+    }
     case "/api/plugins/updates":
       // Per-plugin freshness (ADR 0027). Console-installed plugins are up to date
       // (their resolved_sha is the latest); the seeded fixtures exercise the other
@@ -515,26 +537,6 @@ const server = createServer(async (req, res) => {
           restart_recommended: !body.enabled && m[1] === "boardy",
         });
       }
-    }
-    if (pathname === "/api/mcp/catalog" && req.method === "GET") {
-      const configured = new Set(RUNTIME_STATUS.mcp.servers.map((s) => s.name));
-      return sendJson(res, {
-        servers: [
-          {
-            id: "memory", name: "Memory", category: "Reasoning",
-            tagline: "A persistent knowledge-graph memory.", requires: "node", official: true,
-            template: { name: "memory", transport: "stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-memory"] },
-            installed: configured.has("memory"),
-          },
-          {
-            id: "filesystem", name: "Filesystem", category: "Files",
-            tagline: "Read and write files under a directory you allow.", requires: "node", official: true,
-            template: { name: "filesystem", transport: "stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "${path}"] },
-            inputs: [{ key: "path", label: "Allowed directory", placeholder: "/data", required: true }],
-            installed: configured.has("filesystem"),
-          },
-        ],
-      });
     }
     if (pathname === "/api/mcp/servers" && req.method === "POST") {
       const name = body.name || "server";

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -516,8 +516,32 @@ const server = createServer(async (req, res) => {
         });
       }
     }
+    if (pathname === "/api/mcp/catalog" && req.method === "GET") {
+      const configured = new Set(RUNTIME_STATUS.mcp.servers.map((s) => s.name));
+      return sendJson(res, {
+        servers: [
+          {
+            id: "memory", name: "Memory", category: "Reasoning",
+            tagline: "A persistent knowledge-graph memory.", requires: "node", official: true,
+            template: { name: "memory", transport: "stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-memory"] },
+            installed: configured.has("memory"),
+          },
+          {
+            id: "filesystem", name: "Filesystem", category: "Files",
+            tagline: "Read and write files under a directory you allow.", requires: "node", official: true,
+            template: { name: "filesystem", transport: "stdio", command: "npx", args: ["-y", "@modelcontextprotocol/server-filesystem", "${path}"] },
+            inputs: [{ key: "path", label: "Allowed directory", placeholder: "/data", required: true }],
+            installed: configured.has("filesystem"),
+          },
+        ],
+      });
+    }
     if (pathname === "/api/mcp/servers" && req.method === "POST") {
-      return sendJson(res, { ok: true, name: body.name, servers: [body.name] });
+      const name = body.name || "server";
+      RUNTIME_STATUS.mcp.servers = RUNTIME_STATUS.mcp.servers
+        .filter((s) => s.name !== name)
+        .concat({ name, transport: body.transport || "stdio", tool_count: 1 });
+      return sendJson(res, { ok: true, name, servers: RUNTIME_STATUS.mcp.servers.map((s) => s.name) });
     }
     if (pathname === "/api/mcp/servers/import" && req.method === "POST") {
       let added = ["imported"];

--- a/apps/web/src/app/McpCatalogDialog.tsx
+++ b/apps/web/src/app/McpCatalogDialog.tsx
@@ -1,0 +1,217 @@
+import { Input } from "@protolabsai/ui/forms";
+import { Dialog } from "@protolabsai/ui/overlays";
+import { Badge, Button } from "@protolabsai/ui/primitives";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { ArrowLeft, ExternalLink, Loader2, Plus, Search } from "lucide-react";
+import { useMemo, useState } from "react";
+
+import { api } from "../lib/api";
+import { errMsg } from "../lib/format";
+import { runtimeStatusQuery } from "../lib/queries";
+import type { McpCatalogEntry } from "../lib/types";
+
+// Quick-add for common MCP servers (Settings ▸ MCP). A curated directory
+// (GET /api/mcp/catalog) of cards; picking one fills its `${input}` placeholders
+// (a path, an API token) and POSTs the composed entry through the normal add path,
+// so its tools wire in immediately (hot reload). Servers needing no input add in
+// one click; the rest open a small configure step.
+
+const MCP_CATALOG_KEY = ["mcp-catalog"] as const;
+
+// Substitute ${key} placeholders in every string of the template (args, env,
+// url, headers) with the operator-supplied values.
+function fillTemplate(
+  template: Record<string, unknown>,
+  values: Record<string, string>,
+): Record<string, unknown> {
+  const sub = (v: unknown): unknown => {
+    if (typeof v === "string") return v.replace(/\$\{(\w+)\}/g, (_m, k: string) => values[k] ?? "");
+    if (Array.isArray(v)) return v.map(sub);
+    if (v && typeof v === "object") {
+      return Object.fromEntries(
+        Object.entries(v as Record<string, unknown>).map(([k, val]) => [k, sub(val)]),
+      );
+    }
+    return v;
+  };
+  return sub(template) as Record<string, unknown>;
+}
+
+export function McpCatalogDialog({
+  open,
+  onClose,
+  onAdded,
+}: {
+  open: boolean;
+  onClose: () => void;
+  onAdded: (msg: string) => void;
+}) {
+  const qc = useQueryClient();
+  const catalog = useQuery({
+    queryKey: MCP_CATALOG_KEY,
+    queryFn: () => api.mcpCatalog(),
+    enabled: open,
+    retry: false,
+  });
+  const [query, setQuery] = useState("");
+  const [cat, setCat] = useState("All");
+  const [selected, setSelected] = useState<McpCatalogEntry | null>(null);
+  const [values, setValues] = useState<Record<string, string>>({});
+  const [err, setErr] = useState<string | null>(null);
+
+  const servers = catalog.data?.servers ?? [];
+  const categories = useMemo(
+    () => ["All", ...Array.from(new Set(servers.map((s) => s.category || "Other"))).sort()],
+    [servers],
+  );
+  const shown = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return servers.filter((s) => {
+      if (cat !== "All" && (s.category || "Other") !== cat) return false;
+      if (!q) return true;
+      return `${s.name} ${s.tagline ?? ""} ${s.id}`.toLowerCase().includes(q);
+    });
+  }, [servers, query, cat]);
+
+  const add = useMutation({
+    mutationFn: (entry: McpCatalogEntry) => api.addMcpServer(fillTemplate(entry.template, values)),
+    onSuccess: (res) => {
+      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      qc.invalidateQueries({ queryKey: MCP_CATALOG_KEY });
+      onAdded(`Connected ${res.name} — its tools are live.`);
+      close();
+    },
+    onError: (e: unknown) => setErr(errMsg(e)),
+  });
+
+  function back() {
+    setSelected(null);
+    setValues({});
+    setErr(null);
+  }
+  function close() {
+    back();
+    setQuery("");
+    setCat("All");
+    onClose();
+  }
+  function pick(entry: McpCatalogEntry) {
+    setErr(null);
+    if (entry.inputs?.length) {
+      setSelected(entry);
+      setValues(Object.fromEntries(entry.inputs.map((i) => [i.key, ""])));
+    } else {
+      add.mutate(entry);
+    }
+  }
+
+  if (!open) return null;
+
+  const missing = selected?.inputs?.some((i) => i.required && !values[i.key]?.trim()) ?? false;
+
+  return (
+    <Dialog open onClose={close} title="Add a common MCP server" width="min(720px, 95vw)">
+      {selected ? (
+        <div className="mcp-catalog-configure">
+          <button type="button" className="mcp-catalog-back" onClick={back}>
+            <ArrowLeft size={14} /> All servers
+          </button>
+          <div className="mcp-catalog-config-head">
+            <strong>{selected.name}</strong>
+            {selected.requires ? <span className="mcp-catalog-chip">needs {selected.requires}</span> : null}
+          </div>
+          <p className="mcp-catalog-tagline">{selected.tagline}</p>
+          {selected.inputs?.map((inp) => (
+            <label key={inp.key} className="mcp-catalog-field">
+              <span>
+                {inp.label}
+                {inp.required ? " *" : ""}
+              </span>
+              <Input
+                type={inp.secret ? "password" : "text"}
+                placeholder={inp.placeholder}
+                value={values[inp.key] ?? ""}
+                onChange={(e) => setValues((v) => ({ ...v, [inp.key]: e.target.value }))}
+                aria-label={inp.label}
+              />
+            </label>
+          ))}
+          {err ? <p className="plugin-hint">{err}</p> : null}
+          <div className="mcp-add-actions">
+            <Button
+              type="button"
+              variant="primary"
+              disabled={missing || add.isPending}
+              onClick={() => add.mutate(selected)}
+            >
+              {add.isPending ? <Loader2 size={14} className="spin" /> : <Plus size={14} />} Add server
+            </Button>
+            <Button type="button" variant="ghost" onClick={back}>
+              Cancel
+            </Button>
+          </div>
+        </div>
+      ) : (
+        <>
+          <div className="mcp-catalog-controls">
+            <div className="mcp-catalog-search">
+              <Search size={14} />
+              <input
+                placeholder="Search servers"
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                aria-label="search MCP servers"
+              />
+            </div>
+            <div className="mcp-catalog-cats">
+              {categories.map((c) => (
+                <button
+                  key={c}
+                  type="button"
+                  className={`mcp-catalog-cat${c === cat ? " on" : ""}`}
+                  onClick={() => setCat(c)}
+                >
+                  {c}
+                </button>
+              ))}
+            </div>
+          </div>
+          {err ? <p className="plugin-hint">{err}</p> : null}
+          {catalog.isError ? (
+            <p className="plugin-hint">Couldn't load the server directory.</p>
+          ) : !shown.length ? (
+            <p className="plugin-hint">{catalog.isLoading ? "Loading…" : "No servers match."}</p>
+          ) : (
+            <div className="mcp-catalog-grid">
+              {shown.map((s) => (
+                <div className="mcp-catalog-card" key={s.id}>
+                  <div className="mcp-catalog-card-head">
+                    <strong>{s.name}</strong>
+                    {s.category ? <span className="mcp-catalog-chip">{s.category}</span> : null}
+                  </div>
+                  <p className="mcp-catalog-tagline">{s.tagline}</p>
+                  <div className="mcp-catalog-foot">
+                    {s.docs ? (
+                      <a className="mcp-catalog-docs" href={s.docs} target="_blank" rel="noreferrer">
+                        <ExternalLink size={12} /> docs
+                      </a>
+                    ) : (
+                      <span />
+                    )}
+                    {s.installed ? (
+                      <Badge status="success">added</Badge>
+                    ) : (
+                      <Button type="button" variant="ghost" onClick={() => pick(s)} disabled={add.isPending}>
+                        <Plus size={14} /> Add
+                      </Button>
+                    )}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </Dialog>
+  );
+}

--- a/apps/web/src/app/McpPanel.tsx
+++ b/apps/web/src/app/McpPanel.tsx
@@ -2,12 +2,13 @@ import { DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { Loader2, Plus, Trash2 } from "lucide-react";
+import { Boxes, Loader2, Plus, Trash2 } from "lucide-react";
 
 import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
 import { runtimeStatusQuery } from "../lib/queries";
 import { StagePanel } from "./ErrorBoundary";
 import { StatusPill } from "./StatusPill";
+import { McpCatalogDialog } from "./McpCatalogDialog";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 
@@ -129,6 +130,7 @@ function McpBody() {
   const { data: runtime } = useSuspenseQuery(runtimeStatusQuery());
   const qc = useQueryClient();
   const [hint, setHint] = useState<string | null>(null);
+  const [catalogOpen, setCatalogOpen] = useState(false);
   const servers = runtime.mcp?.servers ?? [];
   const total = runtime.mcp?.tool_count ?? 0;
 
@@ -150,7 +152,13 @@ function McpBody() {
       />
       <div className="stage-body">
         {hint ? <p className="plugin-hint">{hint}</p> : null}
+        <div className="mcp-browse-row">
+          <Button type="button" variant="ghost" onClick={() => setCatalogOpen(true)} title="Add a common MCP server from a curated list">
+            <Boxes size={14} /> Browse common servers
+          </Button>
+        </div>
         <AddServerForm onDone={setHint} />
+        <McpCatalogDialog open={catalogOpen} onClose={() => setCatalogOpen(false)} onAdded={setHint} />
         <div className="table-list">
           {servers.length ? (
             servers.map((server) => (

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -652,6 +652,153 @@ select:disabled {
   line-height: 1.5;
 }
 
+/* MCP catalog quick-add (McpCatalogDialog) — a curated directory of common servers,
+   self-contained styles so the dialog doesn't depend on the Plugins surface CSS. */
+.mcp-browse-row {
+  margin: 0 0 6px;
+}
+.mcp-catalog-controls {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin: 2px 0 12px;
+}
+.mcp-catalog-search {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  flex: 1;
+  min-width: 200px;
+  padding: 6px 10px;
+  background: var(--bg-raised);
+  border: 1px solid var(--border);
+  border-radius: 7px;
+}
+.mcp-catalog-search > svg {
+  color: var(--fg-muted);
+  flex-shrink: 0;
+}
+.mcp-catalog-search input {
+  flex: 1;
+  min-width: 0;
+  border: 0;
+  background: transparent;
+  color: var(--fg);
+  font-size: 13px;
+  outline: none;
+}
+.mcp-catalog-cats {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+.mcp-catalog-cat {
+  padding: 4px 10px;
+  font-size: 12px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  background: transparent;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  transition: border-color 0.15s, color 0.15s;
+}
+.mcp-catalog-cat:hover {
+  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 45%, transparent);
+}
+.mcp-catalog-cat.on {
+  background: color-mix(in srgb, var(--pl-color-brand-lavender) 18%, transparent);
+  border-color: color-mix(in srgb, var(--pl-color-brand-lavender) 55%, transparent);
+  color: var(--fg);
+}
+.mcp-catalog-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 10px;
+  max-height: 52vh;
+  overflow: auto;
+}
+.mcp-catalog-card {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid var(--border);
+  border-radius: 9px;
+  background: var(--bg-raised);
+}
+.mcp-catalog-card-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+}
+.mcp-catalog-card-head strong {
+  font-size: 14px;
+}
+.mcp-catalog-chip {
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  padding: 1px 7px;
+  border-radius: 999px;
+  background: var(--bg-hover);
+  color: var(--fg-muted);
+  white-space: nowrap;
+}
+.mcp-catalog-tagline {
+  font-size: 12px;
+  color: var(--fg-secondary);
+  margin: 0;
+  flex: 1;
+}
+.mcp-catalog-foot {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  margin-top: 2px;
+}
+.mcp-catalog-docs {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  font-size: 11px;
+  color: var(--fg-muted);
+  text-decoration: none;
+}
+.mcp-catalog-docs:hover {
+  color: var(--fg-secondary);
+}
+.mcp-catalog-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  background: none;
+  border: 0;
+  color: var(--fg-secondary);
+  cursor: pointer;
+  font-size: 12px;
+  padding: 0;
+  margin-bottom: 8px;
+}
+.mcp-catalog-back:hover {
+  color: var(--fg);
+}
+.mcp-catalog-config-head {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.mcp-catalog-field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  margin: 10px 0 0;
+  font-size: 12px;
+  color: var(--fg-secondary);
+}
+
 /* Scroll regions use @protolabsai/ui <ScrollArea> (.pl-scroll). Bridge the bits
    the DS primitive doesn't carry yet: min-height:0 so it scrolls inside a flex/
    grid parent, overscroll containment, a stable gutter, and a focus ring for the

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -18,6 +18,7 @@ import type {
   HitlPayload,
   InboxItem,
   CatalogPlugin,
+  McpCatalogEntry,
   InstalledPlugin,
   PluginInstallSummary,
   PluginUpdate,
@@ -1438,6 +1439,9 @@ export const api = {
       "/api/mcp/servers/import",
       { method: "POST", body: { raw } },
     );
+  },
+  mcpCatalog() {
+    return request<{ servers: McpCatalogEntry[] }>("/api/mcp/catalog");
   },
   createDelegate(entry: Record<string, unknown>) {
     return request<{ ok: boolean; message: string; delegates: DelegateView[] }>("/api/delegates", {

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -171,6 +171,34 @@ export type CatalogPlugin = {
   enabled: boolean;
 };
 
+// A value the operator must supply before a catalog server is added — a filesystem
+// path, an API token. `secret` renders a password field; the value is substituted
+// into the `${key}` placeholders in the entry's template.
+export type McpCatalogInput = {
+  key: string;
+  label: string;
+  placeholder?: string;
+  secret?: boolean;
+  required?: boolean;
+};
+
+// An entry in the curated common-MCP-servers directory (GET /api/mcp/catalog).
+// `template` is a partial mcp.servers config with `${input}` placeholders; filling
+// the `inputs` and substituting yields the entry POSTed to /api/mcp/servers.
+// `installed` = a server with this name is already configured.
+export type McpCatalogEntry = {
+  id: string;
+  name: string;
+  category?: string;
+  tagline?: string;
+  docs?: string;
+  requires?: string;
+  official?: boolean;
+  template: Record<string, unknown>;
+  inputs?: McpCatalogInput[];
+  installed?: boolean;
+};
+
 // Per-plugin update status (GET /api/plugins/updates, ADR 0027). The backend
 // TTL-caches these — a *pinned* plugin (its requested_ref is a full SHA) skips
 // the network; the rest ls-remote their ref. `behind` ⇒ the recorded

--- a/config/mcp-catalog.json
+++ b/config/mcp-catalog.json
@@ -1,0 +1,152 @@
+{
+  "_comment": "Curated common MCP servers for the console quick-add picker (Settings ▸ MCP ▸ Browse common servers). Each entry's `template` is a partial mcp.servers config with ${input} placeholders the operator fills in before adding. Commands verified against upstream 2026-06-20: the reference servers live in modelcontextprotocol/servers (npx for Node, uvx for Python); GitHub/Brave have moved to their own official homes. Keep this in sync with sites/marketing if a public directory is added later.",
+  "servers": [
+    {
+      "id": "filesystem",
+      "name": "Filesystem",
+      "category": "Files",
+      "tagline": "Read and write files under a directory you allow.",
+      "docs": "https://github.com/modelcontextprotocol/servers/tree/main/src/filesystem",
+      "requires": "node",
+      "official": true,
+      "template": {
+        "name": "filesystem",
+        "transport": "stdio",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-filesystem", "${path}"]
+      },
+      "inputs": [
+        { "key": "path", "label": "Allowed directory", "placeholder": "/Users/you/project", "required": true }
+      ]
+    },
+    {
+      "id": "git",
+      "name": "Git",
+      "category": "Dev",
+      "tagline": "Inspect and operate on a local git repository.",
+      "docs": "https://github.com/modelcontextprotocol/servers/tree/main/src/git",
+      "requires": "uv",
+      "official": true,
+      "template": {
+        "name": "git",
+        "transport": "stdio",
+        "command": "uvx",
+        "args": ["mcp-server-git", "--repository", "${path}"]
+      },
+      "inputs": [
+        { "key": "path", "label": "Repository path", "placeholder": "/Users/you/project", "required": true }
+      ]
+    },
+    {
+      "id": "fetch",
+      "name": "Fetch",
+      "category": "Web",
+      "tagline": "Fetch a URL and convert it to markdown for the model.",
+      "docs": "https://github.com/modelcontextprotocol/servers/tree/main/src/fetch",
+      "requires": "uv",
+      "official": true,
+      "template": {
+        "name": "fetch",
+        "transport": "stdio",
+        "command": "uvx",
+        "args": ["mcp-server-fetch"]
+      }
+    },
+    {
+      "id": "memory",
+      "name": "Memory",
+      "category": "Reasoning",
+      "tagline": "A persistent knowledge-graph memory the agent reads and writes.",
+      "docs": "https://github.com/modelcontextprotocol/servers/tree/main/src/memory",
+      "requires": "node",
+      "official": true,
+      "template": {
+        "name": "memory",
+        "transport": "stdio",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-memory"]
+      }
+    },
+    {
+      "id": "sequential-thinking",
+      "name": "Sequential Thinking",
+      "category": "Reasoning",
+      "tagline": "A structured step-by-step reasoning scratchpad tool.",
+      "docs": "https://github.com/modelcontextprotocol/servers/tree/main/src/sequentialthinking",
+      "requires": "node",
+      "official": true,
+      "template": {
+        "name": "sequential-thinking",
+        "transport": "stdio",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-sequentialthinking"]
+      }
+    },
+    {
+      "id": "time",
+      "name": "Time",
+      "category": "Utilities",
+      "tagline": "Current time and timezone conversions.",
+      "docs": "https://github.com/modelcontextprotocol/servers/tree/main/src/time",
+      "requires": "uv",
+      "official": true,
+      "template": {
+        "name": "time",
+        "transport": "stdio",
+        "command": "uvx",
+        "args": ["mcp-server-time"]
+      }
+    },
+    {
+      "id": "github",
+      "name": "GitHub",
+      "category": "Dev",
+      "tagline": "Repos, issues, PRs and code search via GitHub's hosted MCP server.",
+      "docs": "https://github.com/github/github-mcp-server",
+      "official": true,
+      "template": {
+        "name": "github",
+        "transport": "http",
+        "url": "https://api.githubcopilot.com/mcp/",
+        "headers": { "Authorization": "Bearer ${token}" }
+      },
+      "inputs": [
+        { "key": "token", "label": "GitHub personal access token", "placeholder": "ghp_…", "secret": true, "required": true }
+      ]
+    },
+    {
+      "id": "brave-search",
+      "name": "Brave Search",
+      "category": "Web",
+      "tagline": "Web and local search via the Brave Search API.",
+      "docs": "https://github.com/brave/brave-search-mcp-server",
+      "requires": "node",
+      "official": true,
+      "template": {
+        "name": "brave-search",
+        "transport": "stdio",
+        "command": "npx",
+        "args": ["-y", "@brave/brave-search-mcp-server"],
+        "env": { "BRAVE_API_KEY": "${apiKey}" }
+      },
+      "inputs": [
+        { "key": "apiKey", "label": "Brave Search API key", "placeholder": "BSA…", "secret": true, "required": true }
+      ]
+    },
+    {
+      "id": "everything",
+      "name": "Everything (reference)",
+      "category": "Reference",
+      "tagline": "A demo server exercising every MCP feature — handy for testing.",
+      "docs": "https://github.com/modelcontextprotocol/servers/tree/main/src/everything",
+      "requires": "node",
+      "official": true,
+      "template": {
+        "name": "everything",
+        "transport": "stdio",
+        "command": "npx",
+        "args": ["-y", "@modelcontextprotocol/server-everything"]
+      }
+    }
+  ]
+}

--- a/operator_api/mcp_routes.py
+++ b/operator_api/mcp_routes.py
@@ -153,6 +153,40 @@ def register_mcp_routes(app) -> None:
             raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
         return {"ok": True, "added": sorted(names), "servers": [s["name"] for s in servers]}
 
+    @app.get("/api/mcp/catalog")
+    async def _catalog():
+        """Curated common MCP servers (`config/mcp-catalog.json`, live dir overrides the
+        bundle) — each a templated `mcp.servers` entry the console can one-click add. Marks
+        `installed` by name so the picker shows what's already configured."""
+        import json
+
+        from graph.config_io import _BUNDLE_CONFIG_DIR, _live_config_dir
+
+        entries: list[dict] = []
+        for base in (_live_config_dir(), _BUNDLE_CONFIG_DIR):
+            f = base / "mcp-catalog.json"
+            if f.exists():
+                try:
+                    entries = (json.loads(f.read_text()) or {}).get("servers") or []
+                except (json.JSONDecodeError, OSError):
+                    log.warning("[mcp] mcp-catalog.json unreadable at %s", f)
+                break
+
+        cfg = STATE.graph_config
+        configured = {
+            str(s.get("name", "")).strip().lower()
+            for s in (getattr(cfg, "mcp_servers", []) or [])
+            if isinstance(s, dict)
+        }
+        out: list[dict] = []
+        for e in entries:
+            if not isinstance(e, dict):
+                continue
+            tmpl = e.get("template") if isinstance(e.get("template"), dict) else {}
+            nm = str(tmpl.get("name") or e.get("id") or "").strip().lower()
+            out.append({**e, "installed": bool(nm) and nm in configured})
+        return {"servers": out}
+
     @app.delete("/api/mcp/servers/{name}")
     async def _remove(name: str):
         cfg = STATE.graph_config

--- a/tests/test_mcp_routes.py
+++ b/tests/test_mcp_routes.py
@@ -135,3 +135,18 @@ def test_import_invalid_json_is_400(monkeypatch):
 def test_import_requires_raw(monkeypatch):
     _wire(monkeypatch, servers=[])
     assert _client().post("/api/mcp/servers/import", json={}).status_code == 400
+
+
+def test_catalog_lists_servers_and_marks_installed(monkeypatch):
+    """GET /api/mcp/catalog serves the bundled config/mcp-catalog.json and flags which
+    entries are already configured (by name)."""
+    _wire(monkeypatch, servers=[{"name": "filesystem", "transport": "stdio", "command": "npx"}])
+    body = _client().get("/api/mcp/catalog").json()
+    by_id = {s["id"]: s for s in body["servers"]}
+    assert {"filesystem", "github", "memory"} <= set(by_id)  # curated entries present
+    # GitHub ships as a remote streamable-http template gated on a secret token.
+    assert by_id["github"]["template"]["transport"] == "http"
+    assert any(i.get("secret") for i in by_id["github"].get("inputs", []))
+    # The configured server is flagged installed; the rest aren't.
+    assert by_id["filesystem"]["installed"] is True
+    assert by_id["memory"]["installed"] is False


### PR DESCRIPTION
First of two PRs adding MCP config ergonomics. This one is the **quick-add catalog**; a follow-up adds the **box-commons share model** for MCP servers.

## What
Settings ▸ MCP gains a **"Browse common servers"** picker — a curated directory of well-known MCP servers as searchable cards. Picking one fills its `${input}` placeholders (a filesystem path, an API token) and POSTs the composed entry through the **existing** `addMcpServer` path, so tools wire in immediately (hot reload). Servers needing no config add in one click; the rest open a small configure step. Secrets render as password fields and are substituted into `args`/`env`/`headers` — the catalog itself persists nothing.

## How
- **`config/mcp-catalog.json`** — 9 curated entries: filesystem, git, fetch, memory, sequential-thinking, time, github, brave-search, everything. Each is a partial `mcp.servers` template + declared `inputs`.
- **`GET /api/mcp/catalog`** (`operator_api/mcp_routes.py`) — serves it (live dir overrides bundle, mirroring the plugin catalog) and marks `installed` by name.
- **`McpCatalogDialog.tsx`** — DS `Dialog` with search + category filter + card grid + a configure step; self-contained CSS (no dependency on the Plugins surface stylesheet).

## Accuracy
Catalog commands **verified against upstream (2026-06-20)**, not training data: reference servers live in `modelcontextprotocol/servers` (npx for Node, **uvx** for the Python ones — fetch/git/time; `sequentialthinking` has no hyphen); GitHub moved to its **hosted streamable-http endpoint** (`https://api.githubcopilot.com/mcp/`, Bearer token); Brave Search relocated to `@brave/brave-search-mcp-server`.

## Tests
- `tests/test_mcp_routes.py::test_catalog_lists_servers_and_marks_installed`
- e2e: input-flow (Filesystem) + one-click (Memory) in `mcp.spec.ts`
- Local gates green: tsc, ruff, vitest (100), vite build, css-comment guard, pytest mcp routes (11).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added a curated “common servers” catalog to the MCP settings panel, with search and category filtering.
  * Users can now add catalog servers directly, including a guided setup step for servers that require inputs (with secret/password masking).

* **Bug Fixes**
  * Updated the mock MCP backend so newly added servers immediately appear in the MCP servers list and connection hints update accordingly.

* **Tests**
  * Added end-to-end tests for browsing the catalog and adding both preconfigured and setup-required servers.
  * Added backend tests for the new catalog endpoint, including “installed” status marking and secret input coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->