### PR TITLE
feat(mcp): box-commons sharing for MCP servers (backend)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   picker — a curated directory (filesystem, git, fetch, GitHub, Brave Search, memory,
   sequential-thinking, time) that one-click adds a server, prompting only for the path
   or API token it needs. Backed by `config/mcp-catalog.json` + `GET /api/mcp/catalog`.
+- **Share MCP servers across the box (commons).** A new `mcp.scope` (scoped · layered)
+  lets an agent also run the box-shared MCP commons (`~/.protoagent/commons/mcp-servers.json`),
+  unioned with its own servers — private wins by name (ADR 0041, mirroring how skills &
+  knowledge share). `POST /api/mcp/servers/{name}/promote` and `/forget` move a server
+  between this agent's config and the commons. A shared server runs on every layered
+  agent on the box, so it only adds servers you trust box-wide.
 
 ## [0.63.1] - 2026-06-20
 

--- a/graph/config.py
+++ b/graph/config.py
@@ -525,6 +525,13 @@ class LangGraphConfig:
     mcp_servers: list[dict] = field(default_factory=list)
     mcp_timeout_seconds: float = 20.0
     mcp_denylist: list[str] = field(default_factory=list)
+    # Tier (ADR 0041) — does this agent run the box-shared MCP commons? "scoped"
+    # (default/blank) = only this agent's ``mcp.servers``; "layered" = also run the
+    # box commons (``~/.protoagent/commons/mcp-servers.json``), ∪ private (private
+    # wins by name). Share/unshare moves an entry between this agent's config and the
+    # commons (operator_api/mcp_routes). A shared server runs as a subprocess with its
+    # configured secrets on every agent on the box.
+    mcp_scope: str = ""
 
     # Operator MCP server (ADR 0033 slice 1) — expose THIS agent's tools as an MCP
     # server so any MCP client (Claude Desktop, Cursor) or an ACP coding-agent runtime
@@ -869,6 +876,7 @@ class LangGraphConfig:
             mcp_servers=list(mcp.get("servers", []) or []),
             mcp_timeout_seconds=mcp.get("timeout_seconds", cls.mcp_timeout_seconds),
             mcp_denylist=list(mcp.get("denylist", []) or []),
+            mcp_scope=mcp.get("scope", cls.mcp_scope),
             operator_mcp_enabled=operator_mcp.get("enabled", cls.operator_mcp_enabled),
             operator_mcp_tools=list(operator_mcp.get("tools", []) or []),
             agent_runtime=str(data.get("agent_runtime", cls.agent_runtime) or "native"),

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -469,6 +469,21 @@ FIELDS: list[Field] = [
         "Box-shared skill library read by every agent on this machine. Blank = ~/.protoagent/commons.",
         scope="host",
     ),
+    # MCP server sharing tier (ADR 0041) — mirrors skills.scope. The commons of shared
+    # servers lives at `commons.path`/mcp-servers.json; share/unshare moves a server
+    # between this agent's config and that commons (Settings ▸ MCP).
+    Field(
+        "mcp.scope",
+        "mcp_scope",
+        "MCP server sharing",
+        "select",
+        "MCP",
+        "How this agent uses MCP servers: scoped (only this agent's servers) · layered "
+        "(also run the box commons — every agent on this machine shares those — ∪ your "
+        "own). Blank = scoped. A shared server runs as a subprocess with its configured "
+        "secrets on every agent, so share only servers you trust box-wide.",
+        options=["scoped", "layered"],
+    ),
     # ── Middleware toggles ───────────────────────────────────────────────────
     Field("middleware.knowledge", "knowledge_middleware", "Knowledge middleware", "bool", "Middleware"),
     Field("middleware.memory", "memory_middleware", "Memory middleware", "bool", "Middleware"),
@@ -708,6 +723,9 @@ _SECTION_CATEGORY = {
     # category today (Agent ▸ Settings); folds into Workspace ▸ Skills, with
     # commons.path (host-scoped) surfacing in Host/App (ADR 0048).
     "Skills": "Agent",
+    # MCP — the agent's MCP-server sharing tier (ADR 0041), alongside Skills in the
+    # Agent category; the dedicated MCP panel (Settings ▸ MCP) is the primary home.
+    "MCP": "Agent",
     # System — runtime + performance knobs (central Settings → System).
     "Compaction": "System",
     "Caching": "System",

--- a/operator_api/mcp_routes.py
+++ b/operator_api/mcp_routes.py
@@ -198,3 +198,53 @@ def register_mcp_routes(app) -> None:
         if not ok:
             raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
         return {"ok": True, "servers": [s["name"] for s in servers]}
+
+    @app.post("/api/mcp/servers/{name}/promote")
+    async def _promote(name: str):
+        """Share a configured server to the box commons (ADR 0041): MOVE it from this
+        agent's ``mcp.servers`` into ``commons/mcp-servers.json``. With ``mcp.scope:
+        layered`` the agent keeps running it (now as the commons tier) and every other
+        layered agent on the box picks it up."""
+        from tools.mcp_tools import read_mcp_commons, write_mcp_commons
+
+        cfg = STATE.graph_config
+        private = [s for s in (getattr(cfg, "mcp_servers", []) or []) if isinstance(s, dict)]
+        entry = next((s for s in private if s.get("name") == name), None)
+        if entry is None:
+            raise HTTPException(status_code=404, detail=f"no configured server named {name!r}")
+
+        commons = [s for s in read_mcp_commons(cfg) if s.get("name") != name]
+        commons.append(entry)
+        write_mcp_commons(cfg, commons)
+
+        remaining = [s for s in private if s.get("name") != name]
+        from server.agent_init import _apply_settings_changes
+
+        ok, messages = _apply_settings_changes(config={"mcp": {"servers": remaining}})
+        if not ok:
+            raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
+        return {"ok": True, "promoted": True, "name": name}
+
+    @app.post("/api/mcp/servers/{name}/forget")
+    async def _forget(name: str):
+        """Unshare a commons server (the inverse of promote): MOVE it out of the box
+        commons back into this agent's ``mcp.servers``. No other agent on the box will
+        run it after this."""
+        from tools.mcp_tools import read_mcp_commons, write_mcp_commons
+
+        cfg = STATE.graph_config
+        commons = read_mcp_commons(cfg)
+        entry = next((s for s in commons if s.get("name") == name), None)
+        if entry is None:
+            raise HTTPException(status_code=404, detail=f"no commons server named {name!r}")
+
+        write_mcp_commons(cfg, [s for s in commons if s.get("name") != name])
+
+        private = [s for s in (getattr(cfg, "mcp_servers", []) or []) if isinstance(s, dict) and s.get("name") != name]
+        private.append(entry)
+        from server.agent_init import _apply_settings_changes
+
+        ok, messages = _apply_settings_changes(config={"mcp": {"enabled": True, "servers": private}})
+        if not ok:
+            raise HTTPException(status_code=500, detail="; ".join(messages) or "reload failed")
+        return {"ok": True, "forgotten": True, "name": name}

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -108,6 +108,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "max_tokens": 32768,
     "mcp_denylist": [],
     "mcp_enabled": False,
+    "mcp_scope": "",
     "mcp_servers": [],
     "mcp_timeout_seconds": 20.0,
     "memory_middleware": True,
@@ -239,6 +240,7 @@ CONFIG_TO_DICT_GOLDEN = {
     "mcp": {
         "denylist": [],
         "enabled": False,
+        "scope": "",
         "servers": [],
         "timeout_seconds": 20.0,
     },
@@ -374,6 +376,7 @@ EMITTED_ATTRS = {
     "mcp_servers",
     "mcp_timeout_seconds",
     "mcp_denylist",
+    "mcp_scope",
     # plugins.* (disabled + sources.allow added by the 2026-06-10 N6 fix —
     # config_to_dict used to emit only enabled/dir, so any complete-dict
     # consumer lost them)

--- a/tests/test_mcp_routes.py
+++ b/tests/test_mcp_routes.py
@@ -150,3 +150,57 @@ def test_catalog_lists_servers_and_marks_installed(monkeypatch):
     # The configured server is flagged installed; the rest aren't.
     assert by_id["filesystem"]["installed"] is True
     assert by_id["memory"]["installed"] is False
+
+
+# ── Box-commons share/unshare (ADR 0041) ──────────────────────────────────────
+
+
+def test_promote_moves_server_to_commons(monkeypatch, tmp_path):
+    import json
+
+    import runtime.state as rs
+
+    captured = _wire(monkeypatch, servers=[{"name": "echo", "transport": "stdio", "command": "x"}])
+    rs.STATE.graph_config.commons_path = str(tmp_path)
+    body = _client().post("/api/mcp/servers/echo/promote").json()
+    assert body["promoted"] is True and body["name"] == "echo"
+    # Removed from this agent's private config (persisted via _apply_settings_changes)…
+    assert captured["config"]["mcp"]["servers"] == []
+    # …and written into the box commons file.
+    commons = json.loads((tmp_path / "mcp-servers.json").read_text())
+    assert [s["name"] for s in commons["servers"]] == ["echo"]
+
+
+def test_promote_unknown_is_404(monkeypatch, tmp_path):
+    import runtime.state as rs
+
+    _wire(monkeypatch, servers=[])
+    rs.STATE.graph_config.commons_path = str(tmp_path)
+    assert _client().post("/api/mcp/servers/nope/promote").status_code == 404
+
+
+def test_forget_moves_server_back_to_private(monkeypatch, tmp_path):
+    import json
+
+    import runtime.state as rs
+
+    captured = _wire(monkeypatch, servers=[])
+    rs.STATE.graph_config.commons_path = str(tmp_path)
+    (tmp_path / "mcp-servers.json").write_text(
+        json.dumps({"servers": [{"name": "shared", "transport": "stdio", "command": "y"}]})
+    )
+    body = _client().post("/api/mcp/servers/shared/forget").json()
+    assert body["forgotten"] is True
+    # Moved back into this agent's private config…
+    assert [s["name"] for s in captured["config"]["mcp"]["servers"]] == ["shared"]
+    # …and removed from the commons.
+    commons = json.loads((tmp_path / "mcp-servers.json").read_text())
+    assert commons["servers"] == []
+
+
+def test_forget_unknown_is_404(monkeypatch, tmp_path):
+    import runtime.state as rs
+
+    _wire(monkeypatch, servers=[])
+    rs.STATE.graph_config.commons_path = str(tmp_path)
+    assert _client().post("/api/mcp/servers/nope/forget").status_code == 404

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -108,7 +108,7 @@ def test_build_collects_tools_and_meta(monkeypatch) -> None:
         _cfg([{"name": "echo", "transport": "stdio", "command": "python", "args": ["s.py"]}])
     )
     assert [t.name for t in tools] == ["echo__echo"]
-    assert meta == [{"name": "echo", "transport": "stdio", "tool_count": 1}]
+    assert meta == [{"name": "echo", "transport": "stdio", "tool_count": 1, "tier": "private"}]
     assert len(clients) == 1
 
 
@@ -338,3 +338,77 @@ def test_config_to_dict_includes_mcp() -> None:
     d = config_to_dict(LangGraphConfig(mcp_enabled=True))
     assert d["mcp"]["enabled"] is True
     assert "servers" in d["mcp"] and "denylist" in d["mcp"]
+    assert d["mcp"]["scope"] == ""  # tier field round-trips
+
+
+# ── Box-commons sharing (ADR 0041) ────────────────────────────────────────────
+
+
+def test_commons_round_trip(tmp_path) -> None:
+    from types import SimpleNamespace
+
+    from tools.mcp_tools import read_mcp_commons, write_mcp_commons
+
+    cfg = SimpleNamespace(commons_path=str(tmp_path))
+    assert read_mcp_commons(cfg) == []  # absent → empty
+    write_mcp_commons(cfg, [{"name": "s", "transport": "stdio", "command": "x"}])
+    assert [s["name"] for s in read_mcp_commons(cfg)] == ["s"]
+
+
+def test_layered_unions_commons_and_tags_tiers(monkeypatch, tmp_path) -> None:
+    from tools.mcp_tools import write_mcp_commons
+
+    _fake_client_factory(
+        monkeypatch,
+        by_server={"shared": [SimpleNamespace(name="shared__a")], "mine": [SimpleNamespace(name="mine__b")]},
+    )
+    cfg = LangGraphConfig(
+        mcp_enabled=True,
+        mcp_scope="layered",
+        commons_path=str(tmp_path),
+        mcp_servers=[{"name": "mine", "transport": "stdio", "command": "python", "args": ["m.py"]}],
+    )
+    write_mcp_commons(cfg, [{"name": "shared", "transport": "stdio", "command": "python", "args": ["s.py"]}])
+    _clients, tools, meta = build_mcp_tools(cfg)
+    by_name = {m["name"]: m for m in meta}
+    assert by_name["shared"]["tier"] == "commons"
+    assert by_name["mine"]["tier"] == "private"
+    assert {t.name for t in tools} == {"shared__a", "mine__b"}
+
+
+def test_layered_commons_activates_mcp_without_enabled(monkeypatch, tmp_path) -> None:
+    # Opting into the commons (layered) with a shared server activates MCP even when
+    # mcp.enabled is off and there are no private servers.
+    from tools.mcp_tools import write_mcp_commons
+
+    _fake_client_factory(monkeypatch, by_server={"shared": [SimpleNamespace(name="shared__a")]})
+    cfg = LangGraphConfig(mcp_enabled=False, mcp_scope="layered", commons_path=str(tmp_path), mcp_servers=[])
+    write_mcp_commons(cfg, [{"name": "shared", "transport": "stdio", "command": "python", "args": ["s.py"]}])
+    _clients, tools, meta = build_mcp_tools(cfg)
+    assert [t.name for t in tools] == ["shared__a"]
+    assert meta[0]["tier"] == "commons"
+
+
+def test_scoped_ignores_commons(monkeypatch, tmp_path) -> None:
+    from tools.mcp_tools import write_mcp_commons
+
+    _fake_client_factory(monkeypatch, by_server={"shared": [SimpleNamespace(name="shared__a")]})
+    cfg = LangGraphConfig(mcp_enabled=False, mcp_scope="scoped", commons_path=str(tmp_path), mcp_servers=[])
+    write_mcp_commons(cfg, [{"name": "shared", "transport": "stdio", "command": "python", "args": ["s.py"]}])
+    # scoped + no private servers → the commons is not read, MCP stays inert.
+    assert build_mcp_tools(cfg) == ([], [], [])
+
+
+def test_private_shadows_commons_by_name(monkeypatch, tmp_path) -> None:
+    from tools.mcp_tools import write_mcp_commons
+
+    _fake_client_factory(monkeypatch, by_server={"dup": [SimpleNamespace(name="dup__x")]})
+    cfg = LangGraphConfig(
+        mcp_enabled=True,
+        mcp_scope="layered",
+        commons_path=str(tmp_path),
+        mcp_servers=[{"name": "dup", "transport": "stdio", "command": "private", "args": []}],
+    )
+    write_mcp_commons(cfg, [{"name": "dup", "transport": "stdio", "command": "commons", "args": []}])
+    _clients, _tools, meta = build_mcp_tools(cfg)
+    assert len(meta) == 1 and meta[0]["tier"] == "private"  # private wins by name

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -20,6 +20,42 @@ from typing import Any
 log = logging.getLogger("protoagent.mcp")
 
 
+def _mcp_commons_path(config):
+    """The box-shared MCP-server commons file (ADR 0041) — read by every agent on the
+    host, never per-instance scoped. Under ``commons.path`` (blank → ``~/.protoagent/
+    commons``)."""
+    from pathlib import Path
+
+    raw = (getattr(config, "commons_path", "") or "").strip()
+    base = Path(raw).expanduser() if raw else (Path.home() / ".protoagent" / "commons")
+    return base / "mcp-servers.json"
+
+
+def read_mcp_commons(config) -> list[dict]:
+    """The shared MCP servers (``{"servers": [...]}``); [] when absent/unreadable."""
+    import json
+
+    path = _mcp_commons_path(config)
+    if not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text())
+    except (json.JSONDecodeError, OSError):
+        log.warning("[mcp] commons file unreadable at %s — ignoring", path)
+        return []
+    servers = data.get("servers") if isinstance(data, dict) else data
+    return [s for s in (servers or []) if isinstance(s, dict) and s.get("name")]
+
+
+def write_mcp_commons(config, servers: list[dict]) -> None:
+    """Persist the shared MCP-server commons (used by promote/unshare)."""
+    import json
+
+    path = _mcp_commons_path(config)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps({"servers": list(servers)}, indent=2) + "\n")
+
+
 def _mcp_tool_error_handler(exc: Exception) -> str:
     """Turn an MCP tool failure into a recoverable tool result (roxy #58).
 
@@ -161,10 +197,32 @@ def build_mcp_tools(config, *, plugin_servers=None) -> tuple[list, list, list[di
     tools: list = []
     meta: list[dict] = []
 
-    # Plugin-contributed managed MCP servers (ADR 0019). A factory returns an
-    # entry only when its surface is on + connected, so the
-    # server comes and goes with config without the operator touching mcp.servers.
-    servers = list(getattr(config, "mcp_servers", []) or [])
+    # Tiered merge (ADR 0041), lowest precedence first so a later layer wins by name:
+    #   box commons (mcp.scope: layered) < this agent's mcp.servers < plugin-managed.
+    # Each surviving server is tagged with its tier for runtime status (drives the
+    # console's commons/private badges + share/unshare).
+    servers: list = []
+    tier_by_name: dict[str, str] = {}
+
+    def _layer(entries, tier):
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            nm = str(entry.get("name") or "").strip()
+            if not nm:
+                continue
+            servers[:] = [s for s in servers if str(s.get("name") or "").strip() != nm]
+            servers.append(entry)
+            tier_by_name[nm] = tier
+
+    scope = str(getattr(config, "mcp_scope", "") or "").strip().lower()
+    commons_servers = read_mcp_commons(config) if scope == "layered" else []
+    _layer(commons_servers, "commons")
+    _layer(list(getattr(config, "mcp_servers", []) or []), "private")
+
+    # Plugin-contributed managed MCP servers (ADR 0019). A factory returns an entry
+    # only when its surface is on + connected, so the server comes and goes with
+    # config without the operator touching mcp.servers.
     plugin_entries = []
     for factory in plugin_servers or []:
         try:
@@ -174,12 +232,11 @@ def build_mcp_tools(config, *, plugin_servers=None) -> tuple[list, list, list[di
             continue
         if entry:
             plugin_entries.append(entry)
-    for entry in plugin_entries:
-        name = str(entry.get("name") or "")
-        servers = [s for s in servers if not (isinstance(s, dict) and str(s.get("name") or "") == name)]
-        servers.append(entry)
+    _layer(plugin_entries, "managed")
 
-    if not (getattr(config, "mcp_enabled", False) or plugin_entries):
+    # MCP is active if the operator enabled it, a plugin contributes a server, or the
+    # agent opted into the box commons (layered) and that commons has servers.
+    if not (getattr(config, "mcp_enabled", False) or plugin_entries or commons_servers):
         return clients, tools, meta
 
     timeout = float(getattr(config, "mcp_timeout_seconds", 20.0))
@@ -256,6 +313,7 @@ def build_mcp_tools(config, *, plugin_servers=None) -> tuple[list, list, list[di
                 "name": name,
                 "transport": conn["transport"],
                 "tool_count": len(kept),
+                "tier": tier_by_name.get(name),
             }
         )
         log.info("[mcp] server %s (%s): %d tool(s)", name, conn["transport"], len(kept))


### PR DESCRIPTION
Second of the MCP-config stack (PR1 #1260 shipped the quick-add catalog). This is the **backend** for sharing MCP servers across the box; a follow-up adds the console UI (tier badges + share/unshare + scope quick-set).

## What
Extends the **commons tier model** (ADR 0041, already used by skills & knowledge) to MCP servers — but box-scoped and config-list-based, so it's lighter than the SQLite stores:

- **`mcp.scope`** (`scoped` default · `layered`): `layered` makes the agent also run the **box commons** at `~/.protoagent/commons/mcp-servers.json`, unioned with its own `mcp.servers`. Precedence **commons < private < plugin-managed**; private wins by name. Each resolved server is **tier-tagged** in runtime status (`STATE.mcp_meta`), which drives the console badges in the UI PR.
- **`POST /api/mcp/servers/{name}/promote`** / **`/forget`** — *move* a server between this agent's config and the commons (hot reload). Promote is gated in the UI to layered mode so the server keeps running locally (now as the commons tier).

## Why move, not copy
A server lives in exactly one tier, so the badge is unambiguous and there's no stale private duplicate. `scoped|layered` (not the 3-way skills/knowledge scope) because "commons-only" would drop an agent's own configured servers — wrong for a config list.

## Security
A shared server runs as a subprocess with its configured secrets on **every layered agent on the box** — the field help and PR/commit say so. Default is `scoped` (commons ignored), so nothing changes until an operator opts in.

## Tests
`test_mcp_tools.py` (commons round-trip, layered union + tiers, scoped ignores commons, private-shadows-commons, layered activates MCP), `test_mcp_routes.py` (promote/forget moves + 404s), `test_config_roundtrip.py` (the `mcp.scope` golden). Local: 67 mcp+roundtrip pass, settings/schema 68 pass, ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added MCP scope configuration setting to control server sharing behavior
  * Added new settings UI fields for MCP sharing tier selection (scoped or layered modes)
  * Added two new API endpoints to promote private servers to shared commons and forget shared servers back to private
  * Implemented layered MCP server configuration merging with server precedence tiers

* **Tests**
  * Added comprehensive test coverage for MCP server sharing, promotion, and configuration round-tripping

<!-- end of auto-generated comment: release notes by coderabbit.ai -->