### PR TITLE
feat(web): MCP commons tier badges + share/unshare in Settings ▸ MCP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,9 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Share MCP servers across the box (commons).** A new `mcp.scope` (scoped · layered)
   lets an agent also run the box-shared MCP commons (`~/.protoagent/commons/mcp-servers.json`),
   unioned with its own servers — private wins by name (ADR 0041, mirroring how skills &
-  knowledge share). `POST /api/mcp/servers/{name}/promote` and `/forget` move a server
-  between this agent's config and the commons. A shared server runs on every layered
-  agent on the box, so it only adds servers you trust box-wide.
+  knowledge share). In Settings ▸ MCP, layered servers show a commons/private tier badge
+  with one-click share / unshare, and a sharing-mode quick-set sits by the header. A
+  shared server runs on every layered agent on the box, so it only adds servers you trust
+  box-wide.
 
 ## [0.63.1] - 2026-06-20
 

--- a/apps/web/e2e/mcp.spec.ts
+++ b/apps/web/e2e/mcp.spec.ts
@@ -70,3 +70,28 @@ test("MCP catalog adds a no-input server in one click", async ({ page }) => {
   await expect(page.locator(".plugin-hint")).toContainText("Connected memory");
   await expect(page.getByText("memory · stdio")).toBeVisible();
 });
+
+// Box-commons sharing (ADR 0041): when the agent is layered, each server shows a
+// commons/private tier badge and a share / unshare action. (Runs last — the seed
+// replaces the MCP roster.)
+test("MCP servers show tier badges and share / unshare", async ({ page }) => {
+  await page.request.post("/api/__test__/mcp/layered");
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("settings-widget").click();
+  await page.locator(".pl-sidenav").getByRole("tab", { name: "MCP", exact: true }).click();
+
+  const sharedRow = page.locator(".table-row", { hasText: "shared-fs" });
+  const localRow = page.locator(".table-row", { hasText: "local-fs" });
+  await expect(sharedRow.getByText("commons")).toBeVisible();
+  await expect(localRow.getByText("private")).toBeVisible();
+
+  // Share the private server → it joins the commons (badge flips).
+  await page.getByRole("button", { name: "share local-fs" }).click();
+  await expect(localRow.getByText("commons")).toBeVisible();
+
+  // Unshare a commons server → confirm → it goes private again.
+  await page.getByRole("button", { name: "unshare shared-fs" }).click();
+  await page.getByRole("dialog", { name: "Unshare from the box commons?" })
+    .getByRole("button", { name: "Unshare", exact: true }).click();
+  await expect(sharedRow.getByText("private")).toBeVisible();
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -417,6 +417,16 @@ const server = createServer(async (req, res) => {
       playbooks = clonePlaybooks();
       return sendJson(res, { ok: true });
     }
+    if (pathname === "/api/__test__/mcp/layered" && req.method === "POST") {
+      // Put the MCP roster into "layered" mode (servers carry a tier) so the tier
+      // badges + share/unshare surface — exercised by the commons e2e.
+      RUNTIME_STATUS.mcp.servers = [
+        { name: "shared-fs", transport: "stdio", tool_count: 1, tier: "commons" },
+        { name: "local-fs", transport: "stdio", tool_count: 1, tier: "private" },
+      ];
+      RUNTIME_STATUS.mcp.tool_count = 2;
+      return sendJson(res, { ok: true });
+    }
     if (pathname === "/api/__test__/knowledge/reset" && req.method === "POST") {
       knowledgeChunks = cloneKnowledge();
       return sendJson(res, { ok: true });
@@ -554,6 +564,18 @@ const server = createServer(async (req, res) => {
       return sendJson(res, { ok: true, added, servers: added });
     }
     {
+      const mp = pathname.match(/^\/api\/mcp\/servers\/([^/]+)\/promote$/);
+      if (mp && req.method === "POST") {
+        const name = decodeURIComponent(mp[1]);
+        RUNTIME_STATUS.mcp.servers = RUNTIME_STATUS.mcp.servers.map((s) => (s.name === name ? { ...s, tier: "commons" } : s));
+        return sendJson(res, { ok: true, promoted: true, name });
+      }
+      const mf = pathname.match(/^\/api\/mcp\/servers\/([^/]+)\/forget$/);
+      if (mf && req.method === "POST") {
+        const name = decodeURIComponent(mf[1]);
+        RUNTIME_STATUS.mcp.servers = RUNTIME_STATUS.mcp.servers.map((s) => (s.name === name ? { ...s, tier: "private" } : s));
+        return sendJson(res, { ok: true, forgotten: true, name });
+      }
       const m = pathname.match(/^\/api\/mcp\/servers\/([^/]+)$/);
       if (m && req.method === "DELETE") {
         return sendJson(res, { ok: true, servers: [] });

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -419,12 +419,15 @@ const server = createServer(async (req, res) => {
     }
     if (pathname === "/api/__test__/mcp/layered" && req.method === "POST") {
       // Put the MCP roster into "layered" mode (servers carry a tier) so the tier
-      // badges + share/unshare surface — exercised by the commons e2e.
+      // badges + share/unshare surface — exercised by the commons e2e. Keep `echo`
+      // (the default fixture other specs assert against — RUNTIME_STATUS is shared
+      // across parallel spec files) and ADD the tiered servers.
       RUNTIME_STATUS.mcp.servers = [
+        { name: "echo", transport: "stdio", tool_count: 2 },
         { name: "shared-fs", transport: "stdio", tool_count: 1, tier: "commons" },
         { name: "local-fs", transport: "stdio", tool_count: 1, tier: "private" },
       ];
-      RUNTIME_STATUS.mcp.tool_count = 2;
+      RUNTIME_STATUS.mcp.tool_count = 4;
       return sendJson(res, { ok: true });
     }
     if (pathname === "/api/__test__/knowledge/reset" && req.method === "POST") {

--- a/apps/web/src/app/McpPanel.tsx
+++ b/apps/web/src/app/McpPanel.tsx
@@ -1,16 +1,20 @@
 import { DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
-import { Button } from "@protolabsai/ui/primitives";
+import { Badge, Button } from "@protolabsai/ui/primitives";
+import { ConfirmDialog } from "@protolabsai/ui/overlays";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { useState } from "react";
-import { Boxes, Loader2, Plus, Trash2 } from "lucide-react";
+import { ArrowDownFromLine, ArrowUpToLine, Boxes, Library, Loader2, Plus, Share2, Trash2 } from "lucide-react";
 
 import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
 import { runtimeStatusQuery } from "../lib/queries";
 import { StagePanel } from "./ErrorBoundary";
 import { StatusPill } from "./StatusPill";
 import { McpCatalogDialog } from "./McpCatalogDialog";
+import { QuickSetting } from "../settings/QuickSetting";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
+
+type McpServer = { name: string; transport: string; tool_count: number; tier?: "commons" | "private" | "managed" | null };
 
 // Agent → MCP: external Model Context Protocol servers whose tools are wired into
 // the agent (namespaced <server>__<tool>). Add/remove here hot-reloads — the new
@@ -131,8 +135,12 @@ function McpBody() {
   const qc = useQueryClient();
   const [hint, setHint] = useState<string | null>(null);
   const [catalogOpen, setCatalogOpen] = useState(false);
-  const servers = runtime.mcp?.servers ?? [];
+  const [forgetPending, setForgetPending] = useState<McpServer | null>(null);
+  const servers = (runtime.mcp?.servers ?? []) as McpServer[];
   const total = runtime.mcp?.tool_count ?? 0;
+  // The agent participates in the box commons (mcp.scope: layered) when any server
+  // carries a tier — then we surface tier badges + share/unshare (ADR 0041).
+  const layered = servers.some((s) => s.tier);
 
   const remove = useMutation({
     mutationFn: (n: string) => api.removeMcpServer(n),
@@ -143,6 +151,24 @@ function McpBody() {
     onError: (err: unknown, n) => setHint(`Couldn't remove ${n}: ${errMsg(err)}`),
   });
   const removingName = remove.isPending ? remove.variables : undefined;
+
+  const promote = useMutation({
+    mutationFn: (n: string) => api.promoteMcpServer(n),
+    onSuccess: (_res, n) => {
+      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      setHint(`Shared ${n} to the box commons — every layered agent on this box now runs it.`);
+    },
+    onError: (err: unknown, n) => setHint(`Couldn't share ${n}: ${errMsg(err)}`),
+  });
+  const forget = useMutation({
+    mutationFn: (n: string) => api.forgetMcpServer(n),
+    onSuccess: (_res, n) => {
+      qc.invalidateQueries({ queryKey: runtimeStatusQuery().queryKey });
+      setHint(`Unshared ${n} — it's private to this agent again.`);
+    },
+    onError: (err: unknown, n) => setHint(`Couldn't unshare ${n}: ${errMsg(err)}`),
+  });
+  const busyName = promote.isPending ? promote.variables : forget.isPending ? forget.variables : undefined;
 
   return (
     <>
@@ -156,6 +182,7 @@ function McpBody() {
           <Button type="button" variant="ghost" onClick={() => setCatalogOpen(true)} title="Add a common MCP server from a curated list">
             <Boxes size={14} /> Browse common servers
           </Button>
+          <QuickSetting keys={["mcp.scope"]} title="MCP server sharing" label="MCP server sharing" icon={<Share2 size={16} />} />
         </div>
         <AddServerForm onDone={setHint} />
         <McpCatalogDialog open={catalogOpen} onClose={() => setCatalogOpen(false)} onAdded={setHint} />
@@ -163,9 +190,36 @@ function McpBody() {
           {servers.length ? (
             servers.map((server) => (
               <div className="table-row" key={server.name}>
-                <span>{server.name} · {server.transport}</span>
+                <span className="mcp-server-name">
+                  {layered && server.tier === "commons" ? (
+                    <span title="Shared commons — runs on every layered agent on this box">
+                      <Badge status="neutral"><Library size={12} /> commons</Badge>
+                    </span>
+                  ) : layered && server.tier === "private" ? (
+                    <span title="Private to this agent — share to run it on every layered agent on this box">
+                      <Badge status="neutral">private</Badge>
+                    </span>
+                  ) : null}
+                  {server.name} · {server.transport}
+                </span>
                 <div className="plugin-row-actions">
                   <StatusPill label={`${server.tool_count} tool${server.tool_count === 1 ? "" : "s"}`} tone="success" />
+                  {layered && server.tier === "private" ? (
+                    <Button type="button" variant="ghost" disabled={busyName === server.name}
+                      onClick={() => { setHint(null); promote.mutate(server.name); }}
+                      title={`Share ${server.name} to the box commons`} aria-label={`share ${server.name}`}
+                    >
+                      <ArrowUpToLine size={14} className={busyName === server.name ? "spin" : ""} />
+                    </Button>
+                  ) : null}
+                  {layered && server.tier === "commons" ? (
+                    <Button type="button" variant="ghost" disabled={busyName === server.name}
+                      onClick={() => { setHint(null); setForgetPending(server); }}
+                      title={`Unshare ${server.name} from the box commons`} aria-label={`unshare ${server.name}`}
+                    >
+                      <ArrowDownFromLine size={14} />
+                    </Button>
+                  ) : null}
                   <Button type="button"
                     variant="ghost"
                     disabled={removingName === server.name}
@@ -185,6 +239,19 @@ function McpBody() {
           )}
         </div>
       </div>
+
+      <ConfirmDialog
+        open={forgetPending !== null}
+        title="Unshare from the box commons?"
+        confirmLabel="Unshare"
+        destructive
+        onConfirm={() => { if (forgetPending) forget.mutate(forgetPending.name); setForgetPending(null); }}
+        onClose={() => setForgetPending(null)}
+      >
+        {forgetPending
+          ? `"${forgetPending.name}" will be removed from the box commons and become private to this agent — no other agent on this box will run it.`
+          : undefined}
+      </ConfirmDialog>
     </>
   );
 }

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -655,7 +655,15 @@ select:disabled {
 /* MCP catalog quick-add (McpCatalogDialog) — a curated directory of common servers,
    self-contained styles so the dialog doesn't depend on the Plugins surface CSS. */
 .mcp-browse-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
   margin: 0 0 6px;
+}
+.mcp-server-name {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
 }
 .mcp-catalog-controls {
   display: flex;

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -1443,6 +1443,18 @@ export const api = {
   mcpCatalog() {
     return request<{ servers: McpCatalogEntry[] }>("/api/mcp/catalog");
   },
+  promoteMcpServer(name: string) {
+    return request<{ ok: boolean; promoted: boolean; name: string }>(
+      `/api/mcp/servers/${encodeURIComponent(name)}/promote`,
+      { method: "POST" },
+    );
+  },
+  forgetMcpServer(name: string) {
+    return request<{ ok: boolean; forgotten: boolean; name: string }>(
+      `/api/mcp/servers/${encodeURIComponent(name)}/forget`,
+      { method: "POST" },
+    );
+  },
   createDelegate(entry: Record<string, unknown>) {
     return request<{ ok: boolean; message: string; delegates: DelegateView[] }>("/api/delegates", {
       method: "POST",

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -69,7 +69,10 @@ export type RuntimeStatus = {
   };
   mcp?: {
     enabled: boolean;
-    servers: { name: string; transport: string; tool_count: number }[];
+    // tier (ADR 0041): "commons" (box-shared) · "private" (this agent) · "managed"
+    // (plugin-contributed) · null. Present only when the agent is layered; drives the
+    // console's tier badge + share/unshare.
+    servers: { name: string; transport: string; tool_count: number; tier?: "commons" | "private" | "managed" | null }[];
     tool_count: number;
   };
   plugins?: {


### PR DESCRIPTION
Final PR of the MCP-config stack: the console surface for box-commons MCP sharing (backend shipped in #1261; quick-add catalog in #1260).

## What
Settings ▸ MCP now mirrors the skills/knowledge tier UI:
- When the agent is **layered** (servers carry a tier), each server row shows a **commons / private** `Badge` with a one-click **share** (`ArrowUpToLine`) / **unshare** (`ArrowDownFromLine`, behind a `ConfirmDialog`) action.
- A **"MCP server sharing"** `QuickSetting` (`mcp.scope`) sits by the header — the same contextual-settings pattern PlaybooksSurface uses for `skills.scope`.
- **Scoped** agents (no tiers) see the plain list exactly as before.

## How
- `types.ts`: `runtime.mcp.servers[].tier`; `api.ts`: `promoteMcpServer` / `forgetMcpServer` (by name).
- `McpPanel`: `layered = servers.some(s => s.tier)` gates the tier UI; promote/forget mutations invalidate runtime status.
- e2e: a `__test__/mcp/layered` seed (keeps the default fixture untouched for the existing tests) drives a badge + share + unshare(confirm) flow.

Local gates: tsc, vitest (100), vite build, css-comment guard — all green. (e2e runs on CI.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)