### PR TITLE
feat(desktop): in-app updater notes from the curated CHANGELOG section

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -367,6 +367,14 @@ jobs:
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 10
     steps:
+      # Checkout at the tag so we can read the rolled CHANGELOG.md section for the
+      # in-app updater notes (below). By tag-push time CHANGELOG.md already holds the
+      # dated `## [VERSION]` section — the bump PR (prepare-release.yml) merged before
+      # the tag. Without this the job has no working tree (it only `gh release`s).
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref_name }}
+
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
@@ -388,12 +396,14 @@ jobs:
             echo "::notice::No signed updater bundles on the release — skipping latest.json (in-app updates disabled for ${TAG})."
             exit 0
           fi
-          # Use the real GitHub Release body as the updater notes, so the in-app
-          # UpdateNotice shows the actual changelog (not a generic placeholder). By the
-          # time this fan-in runs (after the long desktop matrix), release.yml has long
-          # since created + populated the release. Fall back to the placeholder if the
-          # body is somehow empty.
-          NOTES="$(gh release view "$TAG" --repo "${{ github.repository }}" --json body -q .body 2>/dev/null || true)"
+          # Updater notes, best → worst source:
+          #   1. The curated CHANGELOG.md section for this version (the human-written
+          #      "### Added/Changed/Fixed" markdown) — what the in-app UpdateNotice renders.
+          #   2. The GitHub Release body (auto-generated commit subjects) — used when the
+          #      CHANGELOG section is empty (e.g. a patch with no [Unreleased] bullets).
+          #   3. A generic placeholder, if both are empty.
+          NOTES="$(python3 scripts/changelog.py notes "$VERSION" 2>/dev/null || true)"
+          [ -z "$NOTES" ] && NOTES="$(gh release view "$TAG" --repo "${{ github.repository }}" --json body -q .body 2>/dev/null || true)"
           [ -z "$NOTES" ] && NOTES="protoAgent ${TAG} — see the GitHub Release for details."
           npx --yes -p '@protolabsai/release-tools@latest' build-updater-manifest \
             --version "$VERSION" \

--- a/scripts/changelog.py
+++ b/scripts/changelog.py
@@ -141,6 +141,17 @@ def scaffold(version: str) -> bool:
     return True
 
 
+def notes(version: str) -> str:
+    """Return the CHANGELOG.md section body for *version* (markdown), or '' if absent/empty.
+
+    Fed to the desktop updater-manifest job so the in-app UpdateNotice shows the curated
+    CHANGELOG section instead of raw commit subjects. Empty output is the caller's signal
+    to fall back (GitHub release body → placeholder) — e.g. a patch with no bullets.
+    """
+    _date, body = _section(CHANGELOG.read_text(encoding="utf-8"), version)
+    return body.strip()
+
+
 def roll(text: str, version: str, date: str) -> str:
     """Return *text* with the Unreleased section promoted to ``[version] - date``.
 
@@ -182,6 +193,11 @@ def main() -> None:
         help="prepend a concise DRAFT changelog.json entry for a version (curated content stays)",
     )
     p_sc.add_argument("version", help="version released, e.g. 0.26.0")
+    p_notes = sub.add_parser(
+        "notes",
+        help="print the CHANGELOG.md section body for a version (the desktop in-app updater notes)",
+    )
+    p_notes.add_argument("version", help="version released, e.g. 0.60.0")
     sub.add_parser("check", help="fail if any released version is missing from changelog.json")
     args = parser.parse_args()
 
@@ -195,6 +211,10 @@ def main() -> None:
             f"changelog: {'scaffolded draft' if added else 'already present'} v{args.version}"
             f" in {MARKETING_JSON.name} (polish the wording by hand)"
         )
+    elif args.cmd == "notes":
+        body = notes(args.version)
+        if body:  # empty → print nothing so the caller's fallback chain kicks in
+            print(body)
     elif args.cmd == "check":
         missing = missing_versions()
         if missing:

--- a/tests/test_changelog.py
+++ b/tests/test_changelog.py
@@ -134,6 +134,29 @@ def test_scaffold_omits_empty_release(tmp_path, monkeypatch):
     assert changelog.missing_versions() == []
 
 
+def test_notes_returns_section_body_markdown(tmp_path, monkeypatch):
+    """`notes <version>` returns the curated CHANGELOG section (for the desktop updater)."""
+    cl = tmp_path / "CHANGELOG.md"
+    cl.write_text(_SCAFFOLD_MD, encoding="utf-8")
+    monkeypatch.setattr(changelog, "CHANGELOG", cl)
+
+    body = changelog.notes("0.2.0")
+    assert body.startswith("### Added")
+    assert "**Bold title**" in body  # markdown preserved (UpdateNotice renders it)
+    assert "## [0.2.0]" not in body  # the heading itself is not included
+    assert "## [Unreleased]" not in body  # and it doesn't bleed into other sections
+
+
+def test_notes_is_empty_for_missing_or_empty_section(tmp_path, monkeypatch):
+    """Empty output signals the workflow to fall back (release body → placeholder)."""
+    cl = tmp_path / "CHANGELOG.md"
+    cl.write_text("# Changelog\n\n## [Unreleased]\n\n## [0.3.0] - 2026-03-03\n\n", encoding="utf-8")
+    monkeypatch.setattr(changelog, "CHANGELOG", cl)
+
+    assert changelog.notes("0.3.0") == ""  # section exists but has no body
+    assert changelog.notes("9.9.9") == ""  # section absent entirely
+
+
 def test_no_released_version_is_missing_from_marketing_changelog():
     """Staleness guard (the original 'stuck at 0.21' bug): every dated CHANGELOG.md
     version must have a marketing changelog.json entry."""


### PR DESCRIPTION
## What

The desktop in-app updater (`UpdateNotice`) shows release notes by rendering `update.notes` as markdown. Today those notes come from the **GitHub Release body** — auto-generated, chore/docs-filtered commit subjects. This swaps the source to the **hand-written `CHANGELOG.md` `## [VERSION]` section** (the `### Added/Changed/Fixed` markdown), which is what users actually want to read and renders cleanly in the existing `<Markdown>` pane.

## Why CHANGELOG.md (not marketing `changelog.json`)

By tag-push time, `CHANGELOG.md` at the tag already holds the final rolled `## [VERSION] - DATE` section (the bump PR merged before the tag). The marketing `changelog.json` is only a *scaffolded draft* at that point — humans polish it asynchronously after release — so it isn't reliable for the updater.

## How

- **`scripts/changelog.py`** — new `notes <version>` subcommand reusing the existing, tested `_section()` extractor. Prints nothing when the section is absent/empty, signalling the caller to fall back.
- **`.github/workflows/desktop-build.yml`** (`updater-manifest` job) — adds a checkout at the tag (the job previously had no working tree), then sources notes best→worst:
  1. curated `CHANGELOG.md` section
  2. GitHub Release body (commit subjects) — used when the section is empty (e.g. a patch with no `[Unreleased]` bullets)
  3. generic placeholder
- **`tests/test_changelog.py`** — covers the populated and empty/missing-section paths.

## Scope / impact

Takes effect on the **next release** (the manifest is composed at tag-push); existing `latest.json` files are unchanged. Empty releases gracefully keep the commit-subject fallback, so nothing regresses to blank.

## Verification

- `python3 -m pytest tests/test_changelog.py -q` → 12 passed
- `ruff check` clean; workflow YAML parses
- Live smoke: `notes 0.60.0` emits the full `### Added/Changed/Fixed` markdown; `notes 0.59.0` (an empty release) prints nothing → fallback fires

🤖 Generated with [Claude Code](https://claude.com/claude-code)