### PR TITLE
chore: release v0.64.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shared server runs on every layered agent on the box, so it only adds servers you trust
   box-wide.
 
+### Changed
+- **Desktop in-app updater shows the curated changelog.** The updater's release notes now
+  come from the hand-written `CHANGELOG.md` section for the new version (the
+  `### Added/Changed/Fixed` markdown) instead of auto-generated commit subjects, falling
+  back gracefully when a section is empty. First applies to this release. (#1263)
+
 ## [0.63.1] - 2026-06-20
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.0] - 2026-06-20
+
 ### Added
 - **Quick-add for common MCP servers.** Settings ▸ MCP has a "Browse common servers"
   picker — a curated directory (filesystem, git, fetch, GitHub, Brave Search, memory,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.63.1"
+version = "0.64.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -3,8 +3,9 @@
     "version": "v0.64.0",
     "date": "2026-06-20",
     "changes": [
-      "Quick-add for common MCP servers.",
-      "Share MCP servers across the box (commons)."
+      "Quick-add common MCP servers from a curated picker in Settings ▸ MCP — one click (or a path/token) and the server's tools are live.",
+      "Share MCP servers across the box: a layered agent runs a shared commons of servers alongside its own, with one-click share/unshare and tier badges.",
+      "The desktop in-app updater now shows the curated changelog for the new version instead of raw commit subjects."
     ]
   },
   {

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.64.0",
+    "date": "2026-06-20",
+    "changes": [
+      "Quick-add for common MCP servers.",
+      "Share MCP servers across the box (commons)."
+    ]
+  },
+  {
     "version": "v0.63.1",
     "date": "2026-06-20",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.64.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.64.0 -m 'Release v0.64.0' && git push origin v0.64.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).