### PR TITLE
fix: ship MCP catalog in desktop + host badge in header + dialog padding

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Desktop: the common-MCP-servers picker is no longer empty.** `config/mcp-catalog.json`
+  wasn't bundled into the packaged desktop app, so "Browse common servers" showed "no
+  servers match"; the sidecar build now ships it (with a regression guard).
+
+### Changed
+- **Settings: the "Host · box defaults" badge moved into the dialog header** next to the
+  Settings title, instead of sitting atop the body where it pushed the panel content down.
+- **MCP: more breathing room in the "Browse common servers" dialog** — the search and card
+  grid no longer sit flush against the panel edge.
+
 ## [0.64.0] - 2026-06-20
 
 ### Added

--- a/apps/desktop/sidecar/build_sidecar.py
+++ b/apps/desktop/sidecar/build_sidecar.py
@@ -47,6 +47,11 @@ BUNDLED_DATA: list[tuple[str, str]] = [
     # REPO_ROOT/config (→ _MEIPASS/config when frozen); without it the desktop app's
     # Plugins ▸ Discover shows "0 official plugins" (every entry is unreachable).
     ("config/plugin-catalog.json", "config"),
+    # The curated common-MCP-server picker (Settings ▸ MCP ▸ Browse common servers).
+    # `/api/mcp/catalog` reads it from REPO_ROOT/config (→ _MEIPASS/config when frozen);
+    # without it the desktop app shows "no servers match" (same trap as the plugin
+    # catalog above).
+    ("config/mcp-catalog.json", "config"),
     ("config/soul-presets", "config/soul-presets"),
     # The bundled first-party skills (config/skills/*/SKILL.md — release-notes,
     # web-research). `_build_skills_index` (server/agent_init.py) seeds the skill

--- a/apps/web/src/app/McpCatalogDialog.tsx
+++ b/apps/web/src/app/McpCatalogDialog.tsx
@@ -110,7 +110,7 @@ export function McpCatalogDialog({
   const missing = selected?.inputs?.some((i) => i.required && !values[i.key]?.trim()) ?? false;
 
   return (
-    <Dialog open onClose={close} title="Add a common MCP server" width="min(720px, 95vw)">
+    <Dialog open onClose={close} title="Add a common MCP server" width="min(720px, 95vw)" className="mcp-catalog-dialog">
       {selected ? (
         <div className="mcp-catalog-configure">
           <button type="button" className="mcp-catalog-back" onClick={back}>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -654,6 +654,11 @@ select:disabled {
 
 /* MCP catalog quick-add (McpCatalogDialog) — a curated directory of common servers,
    self-contained styles so the dialog doesn't depend on the Plugins surface CSS. */
+/* A bit more breathing room than the DS default (16px) — the full-width search +
+   multi-column card grid feel cramped flush to the body edge. */
+.mcp-catalog-dialog .pl-dialog__body {
+  padding: var(--pl-space-6, 24px);
+}
 .mcp-browse-row {
   display: flex;
   align-items: center;

--- a/apps/web/src/settings/SettingsOverlay.tsx
+++ b/apps/web/src/settings/SettingsOverlay.tsx
@@ -1,7 +1,10 @@
 import "./settings.css";
 
 import { Dialog } from "@protolabsai/ui/overlays";
+import { Badge } from "@protolabsai/ui/primitives";
+import { Server } from "lucide-react";
 
+import { isHostConsole } from "../lib/api";
 import { SettingsSurface } from "./SettingsSurface";
 
 // The settings dialog (2026-06 consolidation) — the ONE settings surface (the focused
@@ -18,8 +21,24 @@ export function SettingsOverlay({
   section?: string;
 }) {
   if (!open) return null;
+  // On the host console these are the box defaults every agent inherits — mark it with a
+  // badge in the dialog header (next to "Settings"), not in the body where it pushed the
+  // panel content down.
+  const title = isHostConsole() ? (
+    <span className="settings-overlay-title">
+      Settings
+      <span
+        className="settings-scope-badge"
+        title="Box defaults — every agent on this machine inherits these unless it sets its own. Per-agent overrides live under each agent's Settings."
+      >
+        <Badge status="info"><Server size={12} /> Host · box defaults</Badge>
+      </span>
+    </span>
+  ) : (
+    "Settings"
+  );
   return (
-    <Dialog open onClose={onClose} title="Settings" width="min(960px, 94vw)" className="settings-overlay">
+    <Dialog open onClose={onClose} title={title} width="min(960px, 94vw)" className="settings-overlay">
       <SettingsSurface initialSection={section} key={section || "_"} />
     </Dialog>
   );

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -3,7 +3,6 @@ import type { LucideIcon } from "lucide-react";
 import { useEffect, type ReactNode } from "react";
 
 import { SideNav, Tabs } from "@protolabsai/ui/navigation";
-import { Badge } from "@protolabsai/ui/primitives";
 
 import { IdentityPanel } from "../agent/IdentityPanel";
 import { McpPanel } from "../app/McpPanel";
@@ -111,14 +110,6 @@ export function SettingsSurface({ initialSection }: { only?: "host" | "workspace
     <div className="settings-shell">
       <SideNav ariaLabel="Settings sections" groups={groups} active={active.id} onSelect={(id) => setSection(id)} />
       <div className="settings-content">
-        {onHost ? (
-          <div
-            className="settings-scope-badge"
-            title="Box defaults — every agent on this machine inherits these unless it sets its own. Per-agent overrides live under each agent's Settings."
-          >
-            <Badge status="info"><Server size={12} /> Host · box defaults</Badge>
-          </div>
-        ) : null}
         {active.render()}
       </div>
     </div>

--- a/apps/web/src/settings/settings.css
+++ b/apps/web/src/settings/settings.css
@@ -195,11 +195,15 @@
   cursor: pointer;
 }
 
-/* Host scope badge (2026-06) — a compact "you're editing the box defaults" marker atop
-   the settings content on the host console; replaces the old full-width inheritance banner. */
+/* Host scope badge (2026-06) — a compact "you're editing the box defaults" marker in the
+   dialog header next to the "Settings" title (host console only); replaces the old
+   full-width inheritance banner. */
+.settings-overlay-title {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+}
 .settings-scope-badge {
-  display: flex;
-  justify-content: flex-end;
-  margin: 0 0 10px;
-  flex: none;
+  display: inline-flex;
+  align-items: center;
 }

--- a/tests/test_mcp_routes.py
+++ b/tests/test_mcp_routes.py
@@ -204,3 +204,19 @@ def test_forget_unknown_is_404(monkeypatch, tmp_path):
     _wire(monkeypatch, servers=[])
     rs.STATE.graph_config.commons_path = str(tmp_path)
     assert _client().post("/api/mcp/servers/nope/forget").status_code == 404
+
+
+def test_mcp_catalog_is_bundled_in_the_desktop_sidecar():
+    """The frozen desktop app reads config/mcp-catalog.json from the bundle; if the
+    sidecar build forgets it, the picker shows "no servers match". Guard the
+    hand-maintained data-files list (the same trap the plugin catalog hit)."""
+    import importlib.util
+    from pathlib import Path
+
+    spec_path = Path(__file__).resolve().parents[1] / "apps" / "desktop" / "sidecar" / "build_sidecar.py"
+    spec = importlib.util.spec_from_file_location("build_sidecar", spec_path)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    bundled = {src for src, _dest in mod.BUNDLED_DATA}
+    assert "config/mcp-catalog.json" in bundled
+    assert "config/plugin-catalog.json" in bundled  # its sibling — same bundling trap


### PR DESCRIPTION
Three small follow-ups from using the v0.64.0 desktop build.

### 🐛 Desktop: common MCP servers were missing
`config/mcp-catalog.json` (the #1260 quick-add catalog) wasn't in the sidecar's `BUNDLED_DATA`, so the **frozen** desktop app's `/api/mcp/catalog` read nothing → "Browse common servers" showed **"no servers match."** Exactly the trap `config/plugin-catalog.json` hit (its sibling, which *was* bundled). Added the entry + a **regression guard** (`test_mcp_catalog_is_bundled_in_the_desktop_sidecar`) that imports the build's `BUNDLED_DATA` and asserts both catalogs ship.

### 💅 Host badge → dialog header
The "Host · box defaults" marker sat atop the settings **body**, pushing the panel content down. Moved it into the **Dialog header** next to the "Settings" title (the DS `Dialog.title` takes a ReactNode). Removed it from `SettingsSurface` body. The `.settings-overlay .settings-scope-badge` test selector still matches (now in the header, still inside `.settings-overlay`).

### 💅 MCP dialog padding
The "Browse common servers" dialog's full-width search + multi-column grid felt cramped at the DS default 16px body padding — bumped **this dialog** to 24px.

Local gates: tsc, ruff, vitest (100), vite build, css-guard, pytest (16 incl. the bundling guard) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host console indicator badge to Settings dialog to identify host-specific defaults

* **Style**
  * Improved MCP Catalog dialog layout with optimized width and padding
  * Enhanced host settings badge positioning in the dialog header

<!-- end of auto-generated comment: release notes by coderabbit.ai -->