### PR TITLE
chore: release v0.64.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.1] - 2026-06-20
+
 ### Fixed
 - **Desktop: the common-MCP-servers picker is no longer empty.** `config/mcp-catalog.json`
   wasn't bundled into the packaged desktop app, so "Browse common servers" showed "no

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.64.0"
+version = "0.64.1"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.64.1",
+    "date": "2026-06-20",
+    "changes": [
+      "Desktop: the common-MCP-servers picker is no longer empty.",
+      "Settings: the \"Host · box defaults\" badge moved into the dialog header",
+      "MCP: more breathing room in the \"Browse common servers\" dialog"
+    ]
+  },
+  {
     "version": "v0.64.0",
     "date": "2026-06-20",
     "changes": [

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -3,9 +3,9 @@
     "version": "v0.64.1",
     "date": "2026-06-20",
     "changes": [
-      "Desktop: the common-MCP-servers picker is no longer empty.",
-      "Settings: the \"Host · box defaults\" badge moved into the dialog header",
-      "MCP: more breathing room in the \"Browse common servers\" dialog"
+      "Desktop: the \"Browse common servers\" picker now lists the curated MCP servers — they weren't being bundled into the packaged app.",
+      "The \"Host · box defaults\" badge moved into the Settings dialog header so it no longer pushes the panel content down.",
+      "More breathing room in the \"Browse common servers\" dialog — the search and cards no longer sit flush to the edge."
     ]
   },
   {


### PR DESCRIPTION
Automated version bump to `v0.64.1`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.64.1 -m 'Release v0.64.1' && git push origin v0.64.1`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).