### PR TITLE
fix(web): MCP catalog grid fills the dialog height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **MCP: the "Browse common servers" card grid now fills the dialog height** instead of
+  capping short and leaving dead space below it; the search/filter row stays pinned and
+  the grid scrolls.
+
 ## [0.64.1] - 2026-06-20
 
 ### Fixed

--- a/apps/web/src/app/McpCatalogDialog.tsx
+++ b/apps/web/src/app/McpCatalogDialog.tsx
@@ -110,7 +110,13 @@ export function McpCatalogDialog({
   const missing = selected?.inputs?.some((i) => i.required && !values[i.key]?.trim()) ?? false;
 
   return (
-    <Dialog open onClose={close} title="Add a common MCP server" width="min(720px, 95vw)" className="mcp-catalog-dialog">
+    <Dialog
+      open
+      onClose={close}
+      title="Add a common MCP server"
+      width="min(720px, 95vw)"
+      className={`mcp-catalog-dialog${selected ? "" : " mcp-catalog-dialog--browse"}`}
+    >
       {selected ? (
         <div className="mcp-catalog-configure">
           <button type="button" className="mcp-catalog-back" onClick={back}>

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -659,6 +659,17 @@ select:disabled {
 .mcp-catalog-dialog .pl-dialog__body {
   padding: var(--pl-space-6, 24px);
 }
+/* Browse (grid) view: pin the dialog to a tall, consistent height and let the card
+   grid fill the space below the search/filter controls instead of capping the grid
+   short and leaving dead space under it. The configure step keeps its content height. */
+.mcp-catalog-dialog--browse .pl-dialog {
+  height: min(82vh, calc(100vh - 2 * var(--pl-space-4, 16px)));
+}
+.mcp-catalog-dialog--browse .pl-dialog__body {
+  display: flex;
+  flex-direction: column;
+  min-height: 0;
+}
 .mcp-browse-row {
   display: flex;
   align-items: center;
@@ -728,7 +739,9 @@ select:disabled {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
   gap: 10px;
-  max-height: 52vh;
+  /* Fill the dialog body below the controls (flex parent); scroll internally. */
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: auto;
 }
 .mcp-catalog-card {


### PR DESCRIPTION
Follow-up polish on the "Browse common servers" dialog (screenshot: the card grid was capped short, leaving a big empty gap between the cards and the dialog bottom).

**Cause:** `.mcp-catalog-grid` had `max-height: 52vh` while the DS dialog (`.pl-overlay` centers it, content-height, body not `flex:1`) rendered taller.

**Fix (browse view only):** pin the dialog to `min(82vh, 100vh - 32px)` and make the body a flex column — the search/filter row stays pinned (`flex: none`), and the grid `flex: 1` fills the remaining height with its own scroll (so the search bar never scrolls away). Scoped to a `--browse` modifier so the short *configure* step keeps its natural content height.

CSS + a one-line className change; existing e2e selectors (`.mcp-catalog-grid`, `.mcp-catalog-card`, the search field) are unchanged. Local: tsc, vitest (100), build, css-guard — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)