### PR TITLE
chore: release v0.64.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.2] - 2026-06-20
+
 ### Changed
 - **MCP: the "Browse common servers" card grid now fills the dialog height** instead of
   capping short and leaving dead space below it; the search/filter row stays pinned and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.64.1"
+version = "0.64.2"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,12 @@
 [
   {
+    "version": "v0.64.2",
+    "date": "2026-06-20",
+    "changes": [
+      "MCP: the \"Browse common servers\" card grid now fills the dialog height"
+    ]
+  },
+  {
     "version": "v0.64.1",
     "date": "2026-06-20",
     "changes": [

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -3,7 +3,7 @@
     "version": "v0.64.2",
     "date": "2026-06-20",
     "changes": [
-      "MCP: the \"Browse common servers\" card grid now fills the dialog height"
+      "The \"Browse common servers\" dialog now fills its height with the card grid — search stays pinned, no dead space below the cards."
     ]
   },
   {


### PR DESCRIPTION
Automated version bump to `v0.64.2`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.64.2 -m 'Release v0.64.2' && git push origin v0.64.2`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).