### PR TITLE
feat(web): add-delegate form → dialog + roomier New-skill dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Settings: the Add/Edit delegate form is now a dialog** instead of rendering inline
+  in the Delegates panel and pushing the list down.
+- **Settings: the New/Edit skill dialog has more breathing room** — roomier padding and
+  more space between fields.
+
 ## [0.64.2] - 2026-06-20
 
 ### Changed

--- a/apps/web/e2e/delegates.spec.ts
+++ b/apps/web/e2e/delegates.spec.ts
@@ -23,27 +23,29 @@ test("lists configured delegates with type + secret badges", async ({ page }) =>
   await expect(row.locator(".pl-dot--success")).toBeVisible();
 });
 
-test("Add opens a type picker and a schema-driven form", async ({ page }) => {
+test("Add opens a dialog with a type picker and a schema-driven form", async ({ page }) => {
   await openIntegrations(page);
-  const panel = page.locator(".delegates-section");
-  await panel.getByRole("button", { name: /Add delegate/ }).click();
+  await page.locator(".delegates-section").getByRole("button", { name: /Add delegate/ }).click();
+
+  // The add/edit form is a dialog now (it used to render inline in the panel).
+  const dialog = page.getByRole("dialog", { name: "Add a delegate" });
+  await expect(dialog).toBeVisible();
 
   // Three type cards from /api/delegate-types (DS RadioCard).
-  const tiles = panel.locator(".pl-radiocard");
-  await expect(tiles).toHaveCount(3);
+  await expect(dialog.locator(".pl-radiocard")).toHaveCount(3);
 
   // Default type (a2a) renders its URL field; switching to acp renders Command.
-  await expect(panel.getByText("URL", { exact: false })).toBeVisible();
-  await panel.locator(".pl-radiocard", { hasText: "Coding agent" }).click();
-  await expect(panel.getByText("Command", { exact: false })).toBeVisible();
-  await expect(panel.getByText("Workdir", { exact: false })).toBeVisible();
+  await expect(dialog.getByText("URL", { exact: false })).toBeVisible();
+  await dialog.locator(".pl-radiocard", { hasText: "Coding agent" }).click();
+  await expect(dialog.getByText("Command", { exact: false })).toBeVisible();
+  await expect(dialog.getByText("Workdir", { exact: false })).toBeVisible();
 
   // The coding-agent preset picker (from the canonical /api/acp-agents catalog) fills
   // Command + Args when an agent is chosen.
-  await expect(panel.locator("#acp-preset")).toBeVisible();
+  await expect(dialog.locator("#acp-preset")).toBeVisible();
   // DropdownSelect (#274): open the trigger, then pick the portaled menu item (rendered at
-  // document.body, so it's page-scoped, not inside `panel`).
-  await panel.locator("#acp-preset").click();
+  // document.body, so it's page-scoped, not inside `dialog`).
+  await dialog.locator("#acp-preset").click();
   await page.getByRole("menuitemradio", { name: "Claude Code" }).click();
-  await expect(panel.locator("#del-command")).toHaveValue("npx");
+  await expect(dialog.locator("#del-command")).toHaveValue("npx");
 });

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -1889,6 +1889,13 @@ textarea {
 .knowledge-chunk-form-row > :first-child { flex: 1; min-width: 180px; }
 .knowledge-chunk-actions { display: flex; gap: 2px; }
 
+/* New/Edit skill dialog (PlaybooksSurface) — roomier than the DS default + a little
+   more space between fields than the knowledge inline form it grew out of. */
+.skill-dialog .pl-dialog__body { padding: var(--pl-space-6, 24px); }
+.skill-form { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
+/* The trailing action row gets a little separation from the fields above it. */
+.skill-form > .knowledge-chunk-form-row:last-child { margin-top: 4px; }
+
 /* Document ingestion drop-zone (ADR 0021) — file/URL "Add source". */
 .knowledge-ingest-drop {
   display: flex; align-items: center; gap: 8px;

--- a/apps/web/src/playbooks/PlaybooksSurface.tsx
+++ b/apps/web/src/playbooks/PlaybooksSurface.tsx
@@ -51,7 +51,7 @@ function SkillForm({
 }) {
   const incomplete = !draft.name.trim() || !draft.description.trim() || !draft.body.trim();
   return (
-    <div className="knowledge-chunk-form">
+    <div className="skill-form">
       <Input
         type="text"
         placeholder="name — e.g. “Release notes”"
@@ -516,6 +516,7 @@ export function PlaybooksSurface({ onError = () => {} }: { onError?: (message: s
         onClose={cancelForm}
         title={editingId !== null ? "Edit skill" : "New skill"}
         width="min(640px, 94vw)"
+        className="skill-dialog"
       >
         <SkillForm
           draft={draft}

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -3,13 +3,14 @@ import "./delegates.css";
 
 import { DropdownSelect, Input, RadioCard, RadioCardGroup, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
+import { Dialog } from "@protolabsai/ui/overlays";
 
 import { StatusDot } from "@protolabsai/ui/data";
 
 import { StatusPill } from "../app/StatusPill";
 import { HelpLink } from "../app/ui-kit";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { Loader2, Pencil, Plug, Plus, ShieldCheck, Trash2, X } from "lucide-react";
+import { Loader2, Pencil, Plug, Plus, ShieldCheck, Trash2 } from "lucide-react";
 import { useMemo, useState } from "react";
 
 import { api } from "../lib/api";
@@ -68,6 +69,7 @@ export function DelegatesSection() {
   const [probes, setProbes] = useState<Record<string, DelegateProbe>>({});
 
   const invalidate = () => qc.invalidateQueries({ queryKey: queryKeys.delegates });
+  const closeForm = () => { setAdding(false); setEditing(null); };
 
   const remove = useMutation({
     mutationFn: (name: string) => api.deleteDelegate(name),
@@ -151,28 +153,30 @@ export function DelegatesSection() {
 
       {status ? <p className="settings-inline-status">{status}</p> : null}
 
-      {editing ? (
+      <div className="settings-group-actions">
+        <Button type="button" onClick={() => { setEditing(null); setAdding(true); }} disabled={!typeSpecs.length}>
+          <Plus size={15} /> Add delegate
+        </Button>
+      </div>
+
+      {/* Add / edit happen in a dialog (the form used to render inline and push the
+          panel down). The DS Dialog supplies the header + close, so DelegateForm
+          carries only the fields + actions. */}
+      <Dialog
+        open={adding || editing != null}
+        onClose={closeForm}
+        title={editing ? `Edit ${editing.name}` : "Add a delegate"}
+        width="min(560px, 94vw)"
+        className="delegate-dialog"
+      >
         <DelegateForm
-          key={editing.name}
+          key={editing?.name ?? "_new"}
           spec={typeSpecs}
           initial={editing}
-          onClose={() => setEditing(null)}
-          onSaved={(msg) => { setEditing(null); setStatus(msg); void invalidate(); }}
+          onClose={closeForm}
+          onSaved={(msg) => { closeForm(); setStatus(msg); void invalidate(); }}
         />
-      ) : adding ? (
-        <DelegateForm
-          spec={typeSpecs}
-          initial={null}
-          onClose={() => setAdding(false)}
-          onSaved={(msg) => { setAdding(false); setStatus(msg); void invalidate(); }}
-        />
-      ) : (
-        <div className="settings-group-actions">
-          <Button type="button" onClick={() => setAdding(true)} disabled={!typeSpecs.length}>
-            <Plus size={15} /> Add delegate
-          </Button>
-        </div>
-      )}
+      </Dialog>
     </section>
   );
 }
@@ -227,11 +231,6 @@ function DelegateForm({
 
   return (
     <div className="delegate-form">
-      <div className="delegate-form-head">
-        <strong>{editing ? `Edit ${initial?.name}` : "New delegate"}</strong>
-        <Button icon variant="ghost" title="Cancel" onClick={onClose}><X size={15} /></Button>
-      </div>
-
       {!editing ? (
         <RadioCardGroup
           name="delegate-type"

--- a/apps/web/src/settings/delegates.css
+++ b/apps/web/src/settings/delegates.css
@@ -2,16 +2,12 @@
 .delegates-section .subagent-row strong { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
 /* .delegate-type-badge / .delegate-badge-warn / .delegate-badge-ok retired (#832) —
    now DS Badge (type) + StatusPill (unconfigured/secret-set). */
+/* Lives in a dialog now (DelegatesSection) — just the field grid; the dialog
+   supplies the header, padding, and border chrome. */
 .delegate-form {
-  margin-top: 14px;
-  padding: 14px;
-  border: 1px solid var(--border);
-  border-radius: 8px;
-  background: var(--bg);
   display: grid;
   gap: 12px;
 }
-.delegate-form-head { display: flex; align-items: center; justify-content: space-between; }
 /* The delegate-type picker is the DS RadioCardGroup/RadioCard now (matches the
    archetype picker in NewAgentPanel) — the hand-rolled .delegate-type-tile* tiles
    are retired. */


### PR DESCRIPTION
Two Settings dialog cleanups.

### Delegates: add/edit form → dialog
The Add/Edit delegate form rendered **inline** in the Delegates panel, pushing the list down. Moved it into a DS `Dialog` (matching the plugin-install and MCP-catalog dialogs). The dialog supplies the header + close, so `DelegateForm` now carries only the fields + actions (dropped its own header row). Edit uses the same dialog. The e2e "Add" test is scoped to `getByRole("dialog", { name: "Add a delegate" })`.

### Skills: New/Edit dialog padding + spacing
The skill create/edit dialog reused the tight `.knowledge-chunk-form` inline look (8px gap, DS-default 16px body padding). Gave it a dedicated `.skill-form` + `.skill-dialog` with 24px body padding and 12px field spacing so it isn't cramped.

CSS + small JSX; skill e2e is aria-based (unaffected). Local gates: tsc, vitest (100), build, css-guard — green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)