### PR TITLE
chore: release v0.64.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.64.3] - 2026-06-20
+
 ### Changed
 - **Settings: the Add/Edit delegate form is now a dialog** instead of rendering inline
   in the Delegates panel and pushing the list down.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.64.2"
+version = "0.64.3"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -3,8 +3,8 @@
     "version": "v0.64.3",
     "date": "2026-06-20",
     "changes": [
-      "Settings: the Add/Edit delegate form is now a dialog",
-      "Settings: the New/Edit skill dialog has more breathing room"
+      "Adding or editing a delegate now opens in a dialog instead of pushing the Delegates panel around.",
+      "The New/Edit skill dialog has more breathing room — roomier padding and field spacing."
     ]
   },
   {

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,13 @@
 [
   {
+    "version": "v0.64.3",
+    "date": "2026-06-20",
+    "changes": [
+      "Settings: the Add/Edit delegate form is now a dialog",
+      "Settings: the New/Edit skill dialog has more breathing room"
+    ]
+  },
+  {
     "version": "v0.64.2",
     "date": "2026-06-20",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.64.3`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.64.3 -m 'Release v0.64.3' && git push origin v0.64.3`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).