### PR TITLE
feat(chat): render reasoning, text & tool calls in emission order

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Chat: assistant text and tool calls render in emission order.** A pre-tool preamble
+  ("let me look that up") used to render *after* the tool cards because the message
+  grouped all text below all tool cards; it now renders above them with the answer
+  below (interleaved render blocks). The server also flushes buffered answer text before
+  a tool frame, so the preamble reaches the console first — making the in-place streaming
+  visible as it arrives rather than appearing to land after the tools.
+
 ## [0.64.3] - 2026-06-20
 
 ### Changed

--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -346,6 +346,11 @@ class ProtoAgentExecutor(AgentExecutor):
                         await _flush_text()
 
                 elif event_type in ("tool_start", "tool_end"):
+                    # Flush any buffered preamble text BEFORE the tool frame so the
+                    # console renders pre-tool text above the tool card (ordering fix)
+                    # rather than after it — the client builds its ordered render blocks
+                    # in frame-arrival order, so text must reach it before the tool.
+                    await _flush_text()
                     if event_type == "tool_start":
                         tool_calls += 1
                     part = _tool_call_part(event_type, payload)

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -286,6 +286,16 @@ function scenarioFor(prompt) {
       output: "[200] https://example.com\n\nExample Domain. This domain is for use in examples.",
       answer: "Fetched example.com.",
     };
+  if (t.includes("PREAMBLE"))
+    // Pre-tool narration (`preText`) streams as an answer artifact BEFORE the tool —
+    // it must render ABOVE the tool card, with the final answer BELOW it (ordering fix).
+    return {
+      preText: "Let me look that up. ",
+      name: "web_search",
+      input: { query: "agent client protocol" },
+      output: "1 result(s): Agent Client Protocol — https://agentclientprotocol.com",
+      answer: "Found it — Agent Client Protocol.",
+    };
   if (t.includes("SUBAGENT"))
     return {
       answer: "Delegated research to a subagent and summarized.",
@@ -380,6 +390,20 @@ export function buildFrames({ rpcId, contextId, taskId, prompt }) {
     wrap({ kind: "task", id: taskId, contextId, status: { state: "submitted" }, artifacts: [] }),
     statusFrame("working…", null),
   ];
+  // Pre-tool answer text (ordering scenario) — streamed as an artifact BEFORE the
+  // tool frames, mirroring the backend flushing buffered text before a tool frame.
+  if (scenario.preText) {
+    frames.push(
+      wrap({
+        kind: "artifact-update",
+        taskId,
+        contextId,
+        artifact: { artifactId: taskId, parts: [{ kind: "text", text: scenario.preText }] },
+        append: true,
+        lastChunk: false,
+      }),
+    );
+  }
   for (const ev of toolEvents) {
     const text = ev.phase === "start" ? `🔧 ${ev.name}: ${ev.input ?? ""}` : `✅ ${ev.name} → ${ev.output ?? ""}`;
     frames.push(statusFrame(text, ev));

--- a/apps/web/e2e/streaming.spec.ts
+++ b/apps/web/e2e/streaming.spec.ts
@@ -18,3 +18,29 @@ test("assistant answer streams in and reconciles to the final text", async ({ pa
   // Final reconciled text — concatenated cleanly, not duplicated.
   await expect(answer).toHaveText("Testing catches bugs before users do.");
 });
+
+test("pre-tool preamble renders above the tool card, the answer below it", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+  await composer.fill("PREAMBLE then search the web");
+  await composer.press("Enter");
+
+  const msg = page.locator(".pl-message--assistant").last();
+  const preamble = msg.getByText("Let me look that up.");
+  const card = msg.locator(".pl-toolcard").first();
+  const final = msg.getByText("Found it — Agent Client Protocol.");
+  await expect(preamble).toBeVisible();
+  await expect(card).toBeVisible();
+  await expect(final).toBeVisible();
+
+  // Visual order top→bottom: preamble · tool card · answer. The bug was the preamble
+  // rendering AFTER the card; stacked vertically, so y-order == DOM/render order.
+  const [pre, tool, ans] = await Promise.all([
+    preamble.boundingBox(),
+    card.boundingBox(),
+    final.boundingBox(),
+  ]);
+  expect(pre!.y).toBeLessThan(tool!.y);
+  expect(tool!.y).toBeLessThan(ans!.y);
+});

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -40,6 +40,7 @@ import { ComposerModelSelect } from "./ComposerModelSelect";
 import { Markdown } from "./LazyMarkdown";
 import { filesFromTransfer, isLargePaste, pastedTextFile } from "./paste";
 import { ToolCalls } from "./ToolCalls";
+import { addToolRef, appendText, toolsForGroup } from "./parts";
 
 function messageId() {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -821,6 +822,7 @@ function ChatSessionSlot({
                 ? {
                     ...message,
                     content: append ? `${message.content}${text}` : text,
+                    parts: appendText(message.parts, text, append),
                     status: "streaming",
                   }
                 : message,
@@ -851,6 +853,10 @@ function ChatSessionSlot({
               const calls = [...(message.toolCalls || [])];
               const idx = calls.findIndex((c) => c.id === evt.id);
               const now = Date.now();
+              // Ordered render blocks: a top-level tool opens/extends a tool group in
+              // emission order; children (parentId set) nest under their parent's card,
+              // so they don't get their own block.
+              let nextParts = message.parts;
               if (evt.phase === "start") {
                 // A tool that starts while a `task` is still running is a child
                 // of that subagent delegation — nest it. (Last open task wins,
@@ -868,6 +874,7 @@ function ChatSessionSlot({
                 };
                 if (idx >= 0) calls[idx] = { ...calls[idx], ...card };
                 else calls.push(card);
+                if (card.parentId == null) nextParts = addToolRef(message.parts, evt.id);
               } else {
                 // end — flip the matching card to done/error (or create one if the
                 // start frame was missed). A failed end (e.g. a declined run_command)
@@ -878,10 +885,12 @@ function ChatSessionSlot({
                 if (idx >= 0) {
                   calls[idx] = { ...calls[idx], output: evt.output, status: endStatus, durationMs };
                 } else {
+                  // Missed start — treat as a fresh top-level call so it still renders.
                   calls.push({ id: evt.id, name: evt.name, output: evt.output, status: endStatus });
+                  nextParts = addToolRef(message.parts, evt.id);
                 }
               }
-              return { ...message, toolCalls: calls };
+              return { ...message, toolCalls: calls, parts: nextParts };
             }),
           );
         },
@@ -990,23 +999,45 @@ function ChatSessionSlot({
                   {message.reasoning}
                 </Reasoning>
               ) : null}
-              {message.toolCalls && message.toolCalls.length > 0 ? (
-                <ToolCalls calls={message.toolCalls} onCancelDelegation={cancelDelegation} />
-              ) : null}
-              {message.content
-                ? message.role === "user"
-                  ? // Literal user input — preserve newlines (markdown reflows assistant text).
-                    <span className="chat-user-text">{message.content}</span>
-                  : // assistant + system (e.g. background-completion notifications,
-                    // ADR 0050) carry markdown — render it; only the user's own input
-                    // stays literal.
-                    <Markdown>{message.content}</Markdown>
-                : message.status === "streaming"
-                    && !(message.toolCalls && message.toolCalls.length)
-                    && !(message.components && message.components.length)
-                    && !message.reasoning
-                  ? <Loader2 className="spin" size={15} />
-                  : null}
+              {message.parts && message.parts.length ? (
+                // Live turns: text runs and tool groups in emission order, so a pre-tool
+                // preamble renders above the tool cards and the answer below them.
+                message.parts.map((part, i) =>
+                  part.kind === "tools" ? (
+                    <ToolCalls key={i} calls={toolsForGroup(part.ids, message.toolCalls)} onCancelDelegation={cancelDelegation} />
+                  ) : part.text ? (
+                    message.role === "user" ? (
+                      <span className="chat-user-text" key={i}>{part.text}</span>
+                    ) : (
+                      // assistant + system carry markdown; only the user's own input stays literal.
+                      <Markdown key={i}>{part.text}</Markdown>
+                    )
+                  ) : null,
+                )
+              ) : (
+                // History-loaded messages have no ordered parts — keep the grouped layout
+                // (tool cards above the text; order isn't recoverable from storage).
+                <>
+                  {message.toolCalls && message.toolCalls.length > 0 ? (
+                    <ToolCalls calls={message.toolCalls} onCancelDelegation={cancelDelegation} />
+                  ) : null}
+                  {message.content ? (
+                    message.role === "user" ? (
+                      <span className="chat-user-text">{message.content}</span>
+                    ) : (
+                      <Markdown>{message.content}</Markdown>
+                    )
+                  ) : null}
+                </>
+              )}
+              {message.status === "streaming"
+                && !(message.parts && message.parts.length)
+                && !message.content
+                && !(message.toolCalls && message.toolCalls.length)
+                && !(message.components && message.components.length)
+                && !message.reasoning
+                ? <Loader2 className="spin" size={15} />
+                : null}
               {message.components && message.components.length > 0
                 ? message.components.map((spec, i) => <ChatComponent key={i} spec={spec} />)
                 : null}

--- a/apps/web/src/chat/parts.test.ts
+++ b/apps/web/src/chat/parts.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "vitest";
+
+import type { ChatPart, ToolCall } from "../lib/types";
+import { addToolRef, appendText, toolsForGroup } from "./parts";
+
+describe("appendText", () => {
+  it("starts a run, then appends deltas to it", () => {
+    let p: ChatPart[] | undefined;
+    p = appendText(p, "Let me ", false); // first frame (server sends append=false)
+    p = appendText(p, "search", true);
+    p = appendText(p, ".", true);
+    expect(p).toEqual([{ kind: "text", text: "Let me search." }]);
+  });
+
+  it("replaces the open run when append=false (terminal non-streamed answer)", () => {
+    let p: ChatPart[] | undefined = [{ kind: "text", text: "partial" }];
+    p = appendText(p, "the whole answer", false);
+    expect(p).toEqual([{ kind: "text", text: "the whole answer" }]);
+  });
+
+  it("starts a NEW text run after a tool group, even on append=true", () => {
+    let p: ChatPart[] | undefined;
+    p = appendText(p, "preamble", false);
+    p = addToolRef(p, "t1");
+    p = appendText(p, "answer", true); // post-tool delta — must not extend the preamble
+    expect(p).toEqual([
+      { kind: "text", text: "preamble" },
+      { kind: "tools", ids: ["t1"] },
+      { kind: "text", text: "answer" },
+    ]);
+  });
+});
+
+describe("addToolRef", () => {
+  it("groups consecutive tool calls into one block", () => {
+    let p: ChatPart[] | undefined;
+    p = appendText(p, "searching", false);
+    p = addToolRef(p, "web_search");
+    p = addToolRef(p, "fetch_url");
+    expect(p).toEqual([
+      { kind: "text", text: "searching" },
+      { kind: "tools", ids: ["web_search", "fetch_url"] },
+    ]);
+  });
+
+  it("is idempotent on a repeated id", () => {
+    let p = addToolRef(undefined, "t1");
+    p = addToolRef(p, "t1");
+    expect(p).toEqual([{ kind: "tools", ids: ["t1"] }]);
+  });
+
+  it("opens a fresh group when text intervenes between tools", () => {
+    let p: ChatPart[] | undefined = [{ kind: "tools", ids: ["a"] }];
+    p = appendText(p, "mid", false);
+    p = addToolRef(p, "b");
+    expect(p).toEqual([
+      { kind: "tools", ids: ["a"] },
+      { kind: "text", text: "mid" },
+      { kind: "tools", ids: ["b"] },
+    ]);
+  });
+});
+
+describe("toolsForGroup", () => {
+  const calls: ToolCall[] = [
+    { id: "task1", name: "task", status: "running" },
+    { id: "child1", name: "web_search", status: "done", parentId: "task1" },
+    { id: "other", name: "fetch_url", status: "done" },
+  ];
+
+  it("returns a group's top-level calls plus their nested children", () => {
+    expect(toolsForGroup(["task1"], calls).map((c) => c.id)).toEqual(["task1", "child1"]);
+  });
+
+  it("excludes tools from other groups", () => {
+    expect(toolsForGroup(["other"], calls).map((c) => c.id)).toEqual(["other"]);
+  });
+
+  it("is empty-safe", () => {
+    expect(toolsForGroup(["x"], undefined)).toEqual([]);
+  });
+});

--- a/apps/web/src/chat/parts.ts
+++ b/apps/web/src/chat/parts.ts
@@ -1,0 +1,43 @@
+import type { ChatPart, ToolCall } from "../lib/types";
+
+// Ordered-parts accumulation for a streaming assistant turn. These keep the
+// emission order of answer text and tool calls so a pre-tool preamble renders
+// above the tool cards and post-tool text below them (instead of the old layout
+// that grouped all text after all tool cards). Pure + unit-tested (parts.test.ts).
+
+/** Append a streamed text delta to the ordered parts. Extends the open text run,
+ *  or starts a new one when the previous block was a tool group (so post-tool text
+ *  renders below the cards). `append=false` replaces the open run (the terminal,
+ *  non-streamed answer) or starts the first run. */
+export function appendText(parts: ChatPart[] | undefined, text: string, append: boolean): ChatPart[] {
+  const next = [...(parts ?? [])];
+  const last = next[next.length - 1];
+  if (last?.kind === "text") {
+    next[next.length - 1] = { kind: "text", text: append ? last.text + text : text };
+  } else {
+    next.push({ kind: "text", text });
+  }
+  return next;
+}
+
+/** Record a new TOP-LEVEL tool call in emission order: extend the current tool
+ *  group if the last block is one, else open a new group after the preceding text.
+ *  Child calls (parentId set) don't open a block — they nest under their parent's
+ *  card via `toolCalls` at render time, so only pass top-level ids here. */
+export function addToolRef(parts: ChatPart[] | undefined, id: string): ChatPart[] {
+  const next = [...(parts ?? [])];
+  const last = next[next.length - 1];
+  if (last?.kind === "tools") {
+    if (!last.ids.includes(id)) next[next.length - 1] = { kind: "tools", ids: [...last.ids, id] };
+    return next;
+  }
+  next.push({ kind: "tools", ids: [id] });
+  return next;
+}
+
+/** The tool calls to render for a `tools` part: its top-level calls (by id) plus any
+ *  subagent children nested under them — so ToolCalls can rebuild the nesting. */
+export function toolsForGroup(ids: string[], calls: ToolCall[] | undefined): ToolCall[] {
+  const set = new Set(ids);
+  return (calls ?? []).filter((c) => set.has(c.id) || (c.parentId != null && set.has(c.parentId)));
+}

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -403,12 +403,25 @@ export type BackgroundJobDTO = {
 // rendered inline by the curated chat component registry.
 export type ComponentSpec = { component: string; props: Record<string, unknown> };
 
+// An ordered render block of an assistant turn (bug-fix: preserve text↔tool order).
+// A run of answer text, or a group of consecutive top-level tool calls, in emission
+// order — so a pre-tool preamble renders ABOVE the tool cards and post-tool text
+// below them. `ids` reference the canonical entries in `ChatMessage.toolCalls`, so
+// live status + subagent nesting stay in one place (resolved at render).
+export type ChatPart =
+  | { kind: "text"; text: string }
+  | { kind: "tools"; ids: string[] };
+
 export type ChatMessage = {
   id?: string;
   role: "user" | "assistant" | "system";
   content: string;
   toolCalls?: ToolCall[];
   components?: ComponentSpec[];
+  /** Ordered render blocks (text runs + tool groups) built during streaming so the
+   *  text/tool-call order is preserved. Absent on history-loaded messages, which fall
+   *  back to the grouped reasoning→toolCalls→content layout. */
+  parts?: ChatPart[];
   /** Streamed scratch_pad reasoning ("thinking") — rendered as a collapsible block
    *  above the answer; never part of `content`. */
   reasoning?: string;


### PR DESCRIPTION
Fixes the bug where a pre-tool preamble ("Ah — my bad, let me go find the right one") rendered **after** the tool cards instead of before them.

## Root cause
The chat message model was *flattened*: all assistant text concatenated into one `content` string, all tool calls into a `toolCalls` array, and the renderer always drew `reasoning → toolCalls → content`. So pre-tool text and the final answer both landed in `content`, rendered **below** the tool cards. The 24-char text buffer vs immediate tool emission on the server made the *frames* arrive tool-first too.

## Fix (both halves)
- **Client** (`ChatSurface` + new `parts.ts`): `ChatMessage` gains an ordered `parts: (text-run | tool-group)[]`, built during streaming so text and tool groups render in **emission order** — preamble above the cards, answer below. `content`/`toolCalls` stay canonical (copy, subagent nesting). History-loaded messages (no `parts`) keep the grouped fallback. Pure accumulation helpers are unit-tested (9 tests).
- **Server** (`a2a_impl/executor.py`): flush buffered answer text **before** emitting a `tool_start`/`tool_end` frame, so the preamble reaches the console before the tool card (the client builds blocks in frame-arrival order). This also makes streaming visible *in place* as it arrives, rather than appearing to land after the tools.

## Tests
- `parts.test.ts` — 9 unit tests for the accumulation (preamble→tool→answer ⇒ `[text, tools, text]`, consecutive-tool grouping, child nesting).
- `streaming.spec.ts` — new `PREAMBLE` scenario asserts the visual order **preamble · tool card · answer**.
- Local: tsc, vitest (109), build, css-guard, 160 Python a2a/executor/chat tests — all green.

Note: this fixes the **ordering** bug and makes streaming render in-place. If true token-level *smoothness* still feels off, that's the `<output>`-gate / 24-char batch — a smaller follow-up I can take once we confirm it on a live turn.

🤖 Generated with [Claude Code](https://claude.com/claude-code)