### PR TITLE
fix(settings): host edits stop 'resetting' — clear shadowing agent keys + don't seed host-scoped fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ __pycache__/
 *.pyo
 .env
 .venv/
+.venv
 .venv-*/
 venv/
 

--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -7,13 +7,16 @@
 # registered in ``tools/lg_tools.py``.
 
 model:
-  provider: openai
-  # Default LiteLLM gateway alias. Set an alias called ``protolabs/reasoning``
-  # (or whatever you rename it to) in your gateway config pointing at the
-  # real model — swapping the model becomes a gateway edit, not a code
-  # change in the fork.
-  name: protolabs/reasoning
-  api_base: http://gateway:4000/v1
+  # provider / name / api_base are HOST-scoped (ADR 0047) — box-wide defaults set
+  # on the Host console (Settings ▸ Host ▸ Model & Routing) or in host-config.yaml,
+  # NOT here. Uncommenting them in this agent layer would shadow the host value
+  # (agent > host in the cascade), so a Host-console edit would appear to "reset".
+  # The App defaults (shown below) already apply; uncomment ONLY to pin a per-agent
+  # override that should deliberately outrank the box default.
+  #   provider: openai
+  #   name: protolabs/reasoning        # LiteLLM gateway alias → swapping the model
+  #                                    # is a gateway edit, not a fork code change
+  #   api_base: http://gateway:4000/v1
   api_key: ""  # falls back to OPENAI_API_KEY env
   temperature: 0.2
   max_tokens: 32768  # 32k — required headroom for the Qwen models we run
@@ -220,10 +223,13 @@ checkpoint:
 #     through a coding agent instead of a gateway model — same for goal.eval_model
 #     and compaction.model. (The main brain itself is selected via agent_runtime.)
 #   fallback_models: on a primary error, retry on each in order. Empty = none.
-routing:
-  # aux_model: protolabs/fast
-  fallback_models: []
-  #  - claude-haiku-4-5
+# routing.aux_model / routing.fallback_models are HOST-scoped (ADR 0047) — set on
+# the Host console (Settings ▸ Host ▸ Model & Routing) or host-config.yaml, NOT here
+# (an agent-layer copy would shadow the host value). App default = none on both.
+# routing:
+#   aux_model: protolabs/fast
+#   fallback_models:
+#    - claude-haiku-4-5
 
 # Goal mode — route the goal verifier to a cheaper model with `eval_model`
 # (else it uses routing.aux_model, else the main model).

--- a/graph/config.py
+++ b/graph/config.py
@@ -736,6 +736,13 @@ class LangGraphConfig:
         bare dict. Behavior is identical to the old inline ``from_yaml`` parse.
         """
         data = data or {}
+        # A top-level section present but empty/commented-out in YAML parses to
+        # None (e.g. a bare `routing:` with every key commented). The many
+        # `data.get("x", {}).get(...)` reads below would then return None and
+        # crash on `.get`. Normalize null sections to {} so editing the example —
+        # commenting a whole block out — can't break the loader. (Subsumes the
+        # per-section `or {}` guards; top-level config keys are all mappings.)
+        data = {k: ({} if v is None else v) for k, v in data.items()}
         secrets = secrets or {}
         config_dir = Path(config_dir) if config_dir is not None else Path(".")
 

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -1559,6 +1559,51 @@ def _filter_nested_to_host_keys(config: dict) -> tuple[dict, list[str]]:
     return host_only, dropped
 
 
+def _prune_shadowing_agent_keys(host_only: dict) -> list[str]:
+    """Delete the just-saved host-scoped keys from the AGENT leaf so the host
+    default actually wins.
+
+    A host-console save writes the box-shared host file, but the agent leaf
+    (``langgraph-config.yaml``) sits ABOVE the host layer in the ADR 0047
+    cascade (agent > host > app). An agent-layer copy of the same key — almost
+    always an unmodified seed from ``langgraph-config.example.yaml`` — silently
+    shadows the host value the operator just set on the Host console, so the
+    edit appears to "reset". On a host save we therefore remove those keys from
+    the agent leaf; the effective value then resolves from the host file.
+
+    ``host_only`` is the nested dict of host-scoped leaves written to the host
+    file. Returns the dotted paths cleared (for the operator message); empty
+    when nothing shadowed."""
+    import graph.config_io as _cio
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+
+    leaf = _cio.CONFIG_YAML_PATH  # resolved at call time (honors a repoint)
+    if not Path(leaf).exists():
+        return []  # no agent leaf on disk → nothing can shadow; don't seed one
+    doc = load_yaml_doc(leaf)
+    removed: list[str] = []
+
+    def _walk(node: Any, keys: Any, prefix: str) -> None:
+        if not isinstance(node, dict) or not isinstance(keys, dict):
+            return
+        for k, v in list(keys.items()):
+            if k not in node:
+                continue
+            dotted = f"{prefix}.{k}" if prefix else k
+            if isinstance(v, dict) and isinstance(node.get(k), dict):
+                _walk(node[k], v, dotted)
+                if not node[k]:  # parent map emptied by the prune → drop it too
+                    del node[k]
+            else:
+                del node[k]
+                removed.append(dotted)
+
+    _walk(doc, host_only, "")
+    if removed:
+        save_yaml_doc(doc, leaf)
+    return removed
+
+
 @_serialized_config_write
 def _apply_settings_changes(
     config: dict | None = None,
@@ -1609,6 +1654,15 @@ def _apply_settings_changes(
                 strip_secrets_from_doc(doc)  # belt-and-suspenders: never a secret on host
                 save_yaml_doc(doc, hp)
                 messages.append("host config saved")
+                # The agent leaf outranks the host file (ADR 0047 agent > host),
+                # so a leftover agent-layer copy of the same key would shadow the
+                # value just set — clear it so the host default takes effect.
+                cleared = _prune_shadowing_agent_keys(host_only)
+                if cleared:
+                    messages.append(
+                        "cleared shadowing agent override(s) so the host value wins: "
+                        + ", ".join(sorted(cleared))
+                    )
             except Exception as e:
                 log.exception("[config] host YAML write failed")
                 return False, [f"host config write: {e}"]

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -819,6 +819,17 @@ def test_plugins_sources_empty_section_is_empty_list(tmp_path):
     assert cfg.plugins_sources_allow == []
 
 
+def test_null_top_level_section_falls_back_to_defaults(tmp_path):
+    """A whole section commented out parses to `routing: null`; the loader must
+    treat it as absent (use defaults), not crash on `None.get(...)`. Guards the
+    example, which a user edits by commenting blocks out."""
+    path = _write_yaml(tmp_path, "model:\nrouting:\ngoal:\n")  # all three null
+    cfg = LangGraphConfig.from_yaml(path)
+    assert cfg.api_base == "http://gateway:4000/v1"  # model.* defaults
+    assert cfg.routing_fallback_models == []  # routing.* defaults
+    assert cfg.goal_enabled is True  # goal.* defaults
+
+
 def test_plugins_disabled_and_sources_allow_survive_config_to_dict():
     """N6 (2026-06-10 prod-readiness audit): config_to_dict emitted only
     plugins.{enabled, dir}, dropping `disabled` + `sources.allow`. The YAML file

--- a/tests/test_settings_cascade.py
+++ b/tests/test_settings_cascade.py
@@ -216,6 +216,63 @@ def test_host_layer_save_writes_host_config(tmp_path, monkeypatch):
     assert cfg.model_name == "box-default-model"
 
 
+def test_host_save_clears_shadowing_agent_key(tmp_path, monkeypatch):
+    """A host save deletes a leftover agent-layer copy of the same key so the host
+    value actually wins (agent > host in the cascade) — without touching unrelated
+    agent-scoped keys. Reproduces the 'Host edit keeps resetting' bug."""
+    import yaml as _yaml
+
+    from server.agent_init import _apply_settings_changes
+
+    leaf = _point_config_at(tmp_path, monkeypatch)
+    hp = _host_file(tmp_path, monkeypatch)
+    _no_reload(monkeypatch)
+
+    # Agent leaf carries a stale api_base (a seed shadow) alongside an agent-scoped key.
+    leaf.write_text("model:\n  api_base: http://stale-agent-gw/v1\n  temperature: 0.5\n")
+
+    ok, messages = _apply_settings_changes(
+        config={"model": {"api_base": "http://new-host-gw/v1"}}, layer="host"
+    )
+    assert ok
+
+    # Host file got the new value.
+    assert _yaml.safe_load(hp.read_text())["model"]["api_base"] == "http://new-host-gw/v1"
+
+    # The shadowing agent key is gone; the unrelated agent-scoped key survives.
+    agent_doc = _yaml.safe_load(leaf.read_text())
+    assert "api_base" not in agent_doc["model"]
+    assert agent_doc["model"]["temperature"] == 0.5
+
+    # The clearing is surfaced to the operator.
+    assert any("model.api_base" in m for m in messages)
+
+    # Effective value now resolves from the host file, not the stale shadow.
+    assert LangGraphConfig.from_yaml(str(leaf)).api_base == "http://new-host-gw/v1"
+
+
+def test_host_save_prunes_emptied_parent_map(tmp_path, monkeypatch):
+    """When clearing the only key under a nested map leaves it empty, the now-empty
+    parent map is pruned too (no dangling ``model: {}`` in the agent leaf)."""
+    import yaml as _yaml
+
+    from server.agent_init import _apply_settings_changes
+
+    leaf = _point_config_at(tmp_path, monkeypatch)
+    _host_file(tmp_path, monkeypatch)
+    _no_reload(monkeypatch)
+
+    # model.api_base is the sole agent-leaf key; goal.enabled is unrelated.
+    leaf.write_text("model:\n  api_base: http://stale/v1\ngoal:\n  enabled: true\n")
+
+    ok, _ = _apply_settings_changes(config={"model": {"api_base": "http://new/v1"}}, layer="host")
+    assert ok
+
+    agent_doc = _yaml.safe_load(leaf.read_text())
+    assert "model" not in agent_doc  # emptied parent pruned
+    assert agent_doc["goal"]["enabled"] is True  # untouched
+
+
 def test_host_layer_refuses_secret(tmp_path, monkeypatch):
     """D5: a secret-typed key (model.api_key) is stripped/refused on the host layer —
     the host file is non-secret only."""


### PR DESCRIPTION
## The bug

Saving a host-scoped field on the **Host console** (e.g. the gateway **base URL** under Settings ▸ Host ▸ Model & Routing) appeared to **reset** to `http://gateway:4000/v1` no matter how many times you saved it.

**Root cause:** the save *was* writing `host-config.yaml` correctly — but the agent leaf (`langgraph-config.yaml`) sits **above** the host file in the ADR 0047 cascade (`agent > host > app`). The example seeds host-scoped fields (`model.provider/name/api_base`, `routing.*`) **into the agent layer**, so the agent-layer copy silently shadowed the host value. The "Host · box defaults" panel was effectively defeated for any single-agent box.

## The fix (both halves, per the chosen approach)

**A — host-save clears the shadow (the behavioral fix, generic):**
`server/agent_init.py` — on a `layer="host"` save, prune the just-saved host-scoped keys from the agent leaf so the host value wins, and surface what was cleared to the operator (`cleared shadowing agent override(s) so the host value wins: model.api_base`). Covers **all** host-scoped fields and **self-heals existing installs** on the first host save. No-ops when there's no agent leaf (nothing to shadow).

**B — stop seeding host-scoped fields (preventive):**
`config/langgraph-config.example.yaml` — the seeded `model.provider/name/api_base` and `routing.aux_model/fallback_models` exactly equalled the App dataclass defaults, so they were pure redundancy that only created the shadow. They're now documented as host-scoped (set on the Host console / `host-config.yaml`) and commented out, so fresh installs never get the shadow.

**Hardening:** `graph/config.py` — commenting a whole block out of the example parses to `routing: null`, which crashed `from_dict` on `None.get(...)`. Normalize null top-level sections to `{}` (subsumes the existing per-section `or {}` guards) so editing the example can't break the loader.

## Tests
- `test_host_save_clears_shadowing_agent_key` — host save drops the stale agent `api_base`, keeps unrelated agent-scoped keys, effective value resolves from the host file.
- `test_host_save_prunes_emptied_parent_map` — an emptied parent map is pruned (no dangling `model: {}`).
- `test_null_top_level_section_falls_back_to_defaults` — `model:`/`routing:`/`goal:` null sections load defaults instead of crashing.
- Existing `test_config_roundtrip` golden + cascade suites unchanged-green (example values == App defaults).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed configuration system to handle empty sections without errors.
  * Resolved issue where host-layer configuration settings were being overridden by agent-layer copies, preventing intended configuration changes from taking effect.

* **Documentation**
  * Updated example configuration to clarify which settings are host-scoped and should be configured via host console or host configuration file.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->