### PR TITLE
fix(acp): build the skills index in the operator MCP sidecar so load_skill works

### DIFF
--- a/server/operator_mcp.py
+++ b/server/operator_mcp.py
@@ -66,8 +66,15 @@ def _boot_stores_only(config):
         ),
     )
     STATE.plugin_tools = plugins.tools
+    STATE.plugin_skill_dirs = plugins.skill_dirs
     STATE.plugin_meta = plugins.meta
     STATE.knowledge_store = ai._apply_plugin_knowledge_backend(config, STATE.knowledge_store, plugins)
+    # Build the skills index too (mirrors agent_init) — load_skill / list_skills /
+    # save_skill read STATE.skills_index, which is None in a fresh sidecar process.
+    # Without this, an ACP agent calling load_skill through this server got
+    # "Skills index is not available." even though the prompt's <available_skills>
+    # block (built in the host process) listed the skill.
+    STATE.skills_index = ai._build_skills_index(config, extra_skill_dirs=plugins.skill_dirs)
 
 
 def operator_tools(config):

--- a/tests/test_operator_mcp.py
+++ b/tests/test_operator_mcp.py
@@ -34,6 +34,38 @@ def test_empty_allowlist_exposes_nothing():
     assert operator_tools(_cfg([])) == []
 
 
+def test_boot_stores_builds_skills_index(tmp_path, monkeypatch):
+    """The sidecar must build STATE.skills_index, not just the other stores —
+    load_skill / list_skills / save_skill read it, and a fresh sidecar process
+    starts with it None. Regression: an ACP agent calling load_skill through this
+    server got "Skills index is not available." despite the prompt listing skills."""
+    import types
+
+    import server.agent_init as ai
+    from server.operator_mcp import _boot_stores_only
+
+    # Stub the heavy/side-effecting store builders; let the REAL _build_skills_index run.
+    monkeypatch.setattr(ai, "_build_knowledge_store", lambda c: None)
+    monkeypatch.setattr(ai, "_build_scheduler", lambda c: None)
+    monkeypatch.setattr(ai, "_build_inbox_store", lambda c: None)
+    monkeypatch.setattr(ai, "_apply_plugin_knowledge_backend", lambda c, ks, p: ks)
+    monkeypatch.setattr(
+        ai,
+        "_build_plugins",
+        lambda config, existing_tools=None: types.SimpleNamespace(tools=[], skill_dirs=[], meta={}),
+    )
+    monkeypatch.setattr(STATE, "beads_store", object(), raising=False)  # skip real BeadsStore
+    monkeypatch.setattr(STATE, "skills_index", None, raising=False)
+
+    cfg = _cfg([])
+    cfg.skills_db_path = str(tmp_path / "skills.db")  # don't touch the real DB
+    _boot_stores_only(cfg)
+
+    assert STATE.skills_index is not None  # the fix — was None before
+    # It's a real index the curation tools can query (bundled config/skills seed).
+    assert {s["name"] for s in STATE.skills_index.skill_summaries()}
+
+
 def test_plugin_tools_ride_the_same_bridge(monkeypatch):
     @tool
     def my_plugin_tool(x: str) -> str:


### PR DESCRIPTION
## The bug

An ACP agent asked to render something (e.g. a comic-book-panel website) called `load_skill("rendering-artifacts")` and got back **`Skills index is not available.`** — even though that skill was listed in the prompt's `<available_skills>` block.

## Root cause — a process/state mismatch

`load_skill` / `list_skills` / `save_skill` read the module singleton `STATE.skills_index`. The operator MCP server (`python -m server.operator_mcp`) runs as a **separate process** with its **own fresh `STATE`** (`runtime/acp_runtime.py` spawns it as the sidecar that exposes this agent's tools to the ACP agent).

Its boot, `_boot_stores_only`, built every store — knowledge, scheduler, inbox, beads, plugins — **except the skills index**. So in that process `STATE.skills_index` stayed `None`, and every `load_skill` returned "index not available." Meanwhile the `<available_skills>` block was built in the **host** process (where the index *is* populated), so the prompt and the tool disagreed.

## Fix

`server/operator_mcp.py` — in `_boot_stores_only`, set `STATE.plugin_skill_dirs` and build `STATE.skills_index` via `ai._build_skills_index(config, extra_skill_dirs=...)`, exactly as `agent_init` does for the host process. One line of real change + its plumbing.

## Test
`test_boot_stores_builds_skills_index` — stubs the heavy store builders, runs the real skills-index build, and asserts the sidecar boot leaves a populated, queryable `STATE.skills_index` (was `None` before).

🤖 Generated with [Claude Code](https://claude.com/claude-code)