### PR TITLE
fix(chat): drop stray whitespace between tool calls (no empty gap, keep the group)

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1005,7 +1005,7 @@ function ChatSessionSlot({
                 message.parts.map((part, i) =>
                   part.kind === "tools" ? (
                     <ToolCalls key={i} calls={toolsForGroup(part.ids, message.toolCalls)} onCancelDelegation={cancelDelegation} />
-                  ) : part.text ? (
+                  ) : part.text.trim() ? (
                     message.role === "user" ? (
                       <span className="chat-user-text" key={i}>{part.text}</span>
                     ) : (

--- a/apps/web/src/chat/parts.test.ts
+++ b/apps/web/src/chat/parts.test.ts
@@ -29,6 +29,24 @@ describe("appendText", () => {
       { kind: "text", text: "answer" },
     ]);
   });
+
+  it("skips a whitespace-only delta between tools, keeping the group open", () => {
+    // The "left a space" bug: a stray "\n" between two tool calls became an empty
+    // text part (a rendered gap) AND split the tool group.
+    let p: ChatPart[] | undefined = [{ kind: "tools", ids: ["a"] }];
+    p = appendText(p, "\n", true);
+    p = addToolRef(p, "b"); // extends the SAME group — no empty text part in between
+    expect(p).toEqual([{ kind: "tools", ids: ["a", "b"] }]);
+  });
+
+  it("trims leading whitespace when a text run starts after a tool group", () => {
+    let p: ChatPart[] | undefined = [{ kind: "tools", ids: ["a"] }];
+    p = appendText(p, "\n\nHere's the answer", true);
+    expect(p).toEqual([
+      { kind: "tools", ids: ["a"] },
+      { kind: "text", text: "Here's the answer" },
+    ]);
+  });
 });
 
 describe("addToolRef", () => {

--- a/apps/web/src/chat/parts.ts
+++ b/apps/web/src/chat/parts.ts
@@ -14,9 +14,16 @@ export function appendText(parts: ChatPart[] | undefined, text: string, append: 
   const last = next[next.length - 1];
   if (last?.kind === "text") {
     next[next.length - 1] = { kind: "text", text: append ? last.text + text : text };
-  } else {
-    next.push({ kind: "text", text });
+    return next;
   }
+  // Starting a NEW text run (first part, or after a tool group). Drop leading
+  // whitespace: a stray "\n" the model emits between two tool calls would otherwise
+  // become its own text part — rendering an empty markdown block (a visible gap) AND
+  // splitting the tool group so the next call can't extend it. Pure whitespace ⇒ skip
+  // entirely, keeping the tool group open.
+  const trimmed = text.replace(/^\s+/, "");
+  if (!trimmed) return next;
+  next.push({ kind: "text", text: trimmed });
   return next;
 }
 


### PR DESCRIPTION
## The bug

In a thread with several tool calls, the interleaved-parts layout from #1272 **"interleaved some and left a space elsewhere"**:
- a **blank gap** appeared in the thread, and
- consecutive tool calls drew as **separate cards** instead of one grouped block.

## Cause

A whitespace-only text delta the model emits **between** two tool calls (a stray `"\n"`) was pushed as its own `text` part. That part:
1. rendered an **empty `<Markdown>` block** → the visible gap, and
2. sat between the two `tools` groups → `addToolRef` saw the last part wasn't a tool group, so it **opened a new group** instead of extending the existing one (the split).

## Fix

- **`parts.ts`** — when a text run *starts* (first part, or after a tool group), drop leading whitespace. A pure-whitespace delta is **skipped entirely**, so the tool group stays open and the next call extends it. (Mid-run deltas are untouched — real text between tools still splits the group, as intended.)
- **`ChatSurface.tsx`** — the render guard now uses `part.text.trim()`, so a whitespace-only part can never draw a block (belt-and-suspenders).

## Tests
`parts.test.ts` — a whitespace-only delta between tools keeps the group open (`["a","b"]`, no text part); leading whitespace is trimmed when a post-tool text run starts. 111 web unit tests green, tsc clean.

> Note: this addresses the **spacing/grouping**. Reasoning is still rendered as a single hoisted block above the parts (not interleaved between tool calls) — a separate, larger change if we want inline reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced chat message formatting to prevent unnecessary whitespace and empty lines from appearing in conversations.

* **Tests**
  * Added test cases for whitespace handling in message processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->