### PR TITLE
feat(chat): interleave reasoning inline with tools + text (not hoisted to the top)

### DIFF
--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -40,7 +40,7 @@ import { ComposerModelSelect } from "./ComposerModelSelect";
 import { Markdown } from "./LazyMarkdown";
 import { filesFromTransfer, isLargePaste, pastedTextFile } from "./paste";
 import { ToolCalls } from "./ToolCalls";
-import { addToolRef, appendText, toolsForGroup } from "./parts";
+import { addToolRef, appendReasoning, appendText, toolsForGroup } from "./parts";
 
 function messageId() {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -830,15 +830,21 @@ function ChatSessionSlot({
           );
         },
         onReasoning: (delta) => {
-          // Accumulate the streamed scratch_pad into the assistant message's
-          // collapsible reasoning block (separate from the answer text).
+          // Accumulate the streamed scratch_pad two ways: into `reasoning` (the
+          // flat block kept for history/persistence) AND into the ordered `parts`,
+          // so live turns render thinking inline at the point it occurred — between
+          // the tool calls it precedes — rather than hoisted to the top.
           const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
           if (!latest) return;
           chatStore.updateMessages(
             session.id,
             latest.messages.map((message) =>
               message.id === assistantId
-                ? { ...message, reasoning: `${message.reasoning ?? ""}${delta}` }
+                ? {
+                    ...message,
+                    reasoning: `${message.reasoning ?? ""}${delta}`,
+                    parts: appendReasoning(message.parts, delta),
+                  }
                 : message,
             ),
           );
@@ -992,19 +998,28 @@ function ChatSessionSlot({
               role={message.role}
               streaming={message.status === "streaming"}
             >
-              {message.reasoning ? (
-                // Collapsible "thinking" — open while the model is still reasoning
-                // (no answer text yet), auto-collapses once the answer starts.
+              {message.reasoning && !(message.parts && message.parts.length) ? (
+                // History-loaded turns have no ordered parts — fall back to the flat
+                // collapsible "thinking" block (open while still reasoning, auto-collapses
+                // once the answer starts). Live turns render reasoning inline via parts.
                 <Reasoning surface="subtle" streaming={message.status === "streaming" && !message.content}>
                   {message.reasoning}
                 </Reasoning>
               ) : null}
               {message.parts && message.parts.length ? (
-                // Live turns: text runs and tool groups in emission order, so a pre-tool
-                // preamble renders above the tool cards and the answer below them.
-                message.parts.map((part, i) =>
+                // Live turns: reasoning, text runs and tool groups in emission order, so a
+                // pre-tool preamble renders above the cards, the answer below them, and
+                // "thinking" inline next to the step it precedes.
+                message.parts.map((part, i, arr) =>
                   part.kind === "tools" ? (
                     <ToolCalls key={i} calls={toolsForGroup(part.ids, message.toolCalls)} onCancelDelegation={cancelDelegation} />
+                  ) : part.kind === "reasoning" ? (
+                    part.text.trim() ? (
+                      // Stream the animation only on the trailing run (thinking in progress).
+                      <Reasoning key={i} surface="subtle" streaming={message.status === "streaming" && i === arr.length - 1}>
+                        {part.text}
+                      </Reasoning>
+                    ) : null
                   ) : part.text.trim() ? (
                     message.role === "user" ? (
                       <span className="chat-user-text" key={i}>{part.text}</span>

--- a/apps/web/src/chat/parts.test.ts
+++ b/apps/web/src/chat/parts.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from "vitest";
 
 import type { ChatPart, ToolCall } from "../lib/types";
-import { addToolRef, appendText, toolsForGroup } from "./parts";
+import { addToolRef, appendReasoning, appendText, toolsForGroup } from "./parts";
 
 describe("appendText", () => {
   it("starts a run, then appends deltas to it", () => {
@@ -46,6 +46,46 @@ describe("appendText", () => {
       { kind: "tools", ids: ["a"] },
       { kind: "text", text: "Here's the answer" },
     ]);
+  });
+});
+
+describe("appendReasoning", () => {
+  it("extends the open reasoning run on consecutive deltas", () => {
+    let p: ChatPart[] | undefined;
+    p = appendReasoning(p, "Let me ");
+    p = appendReasoning(p, "think");
+    expect(p).toEqual([{ kind: "reasoning", text: "Let me think" }]);
+  });
+
+  it("interleaves reasoning between tools (reason · tool · reason · answer)", () => {
+    let p: ChatPart[] | undefined;
+    p = appendReasoning(p, "First I'll search");
+    p = addToolRef(p, "web_search");
+    p = appendReasoning(p, "Now I'll read it"); // resumes thinking after the tool — inline
+    p = addToolRef(p, "fetch_url");
+    p = appendText(p, "Here's the answer", true);
+    expect(p).toEqual([
+      { kind: "reasoning", text: "First I'll search" },
+      { kind: "tools", ids: ["web_search"] },
+      { kind: "reasoning", text: "Now I'll read it" },
+      { kind: "tools", ids: ["fetch_url"] },
+      { kind: "text", text: "Here's the answer" },
+    ]);
+  });
+
+  it("starts a fresh reasoning run after text/tools, trimming leading whitespace", () => {
+    let p: ChatPart[] | undefined = [{ kind: "tools", ids: ["a"] }];
+    p = appendReasoning(p, "\n\nreconsidering");
+    expect(p).toEqual([
+      { kind: "tools", ids: ["a"] },
+      { kind: "reasoning", text: "reconsidering" },
+    ]);
+  });
+
+  it("skips a pure-whitespace reasoning delta after a tool group", () => {
+    let p: ChatPart[] | undefined = [{ kind: "tools", ids: ["a"] }];
+    p = appendReasoning(p, "\n");
+    expect(p).toEqual([{ kind: "tools", ids: ["a"] }]);
   });
 });
 

--- a/apps/web/src/chat/parts.ts
+++ b/apps/web/src/chat/parts.ts
@@ -1,9 +1,11 @@
 import type { ChatPart, ToolCall } from "../lib/types";
 
 // Ordered-parts accumulation for a streaming assistant turn. These keep the
-// emission order of answer text and tool calls so a pre-tool preamble renders
-// above the tool cards and post-tool text below them (instead of the old layout
-// that grouped all text after all tool cards). Pure + unit-tested (parts.test.ts).
+// emission order of reasoning, answer text and tool calls so a pre-tool preamble
+// renders above the tool cards and post-tool text below them, and "thinking"
+// renders inline next to the step it precedes (instead of the old layout that
+// hoisted reasoning to the top and grouped all text after all tool cards). Pure +
+// unit-tested (parts.test.ts).
 
 /** Append a streamed text delta to the ordered parts. Extends the open text run,
  *  or starts a new one when the previous block was a tool group (so post-tool text
@@ -24,6 +26,24 @@ export function appendText(parts: ChatPart[] | undefined, text: string, append: 
   const trimmed = text.replace(/^\s+/, "");
   if (!trimmed) return next;
   next.push({ kind: "text", text: trimmed });
+  return next;
+}
+
+/** Append a streamed reasoning ("thinking") delta to the ordered parts. Extends the
+ *  open reasoning run, or starts a new one when the previous block was text/tools — so
+ *  thinking that resumes between tool calls renders inline at that point rather than
+ *  hoisted to the top. Leading whitespace is dropped on a new run (same empty-block
+ *  guard as appendText). Always streamed, so it only ever appends. */
+export function appendReasoning(parts: ChatPart[] | undefined, text: string): ChatPart[] {
+  const next = [...(parts ?? [])];
+  const last = next[next.length - 1];
+  if (last?.kind === "reasoning") {
+    next[next.length - 1] = { kind: "reasoning", text: last.text + text };
+    return next;
+  }
+  const trimmed = text.replace(/^\s+/, "");
+  if (!trimmed) return next;
+  next.push({ kind: "reasoning", text: trimmed });
   return next;
 }
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -410,6 +410,7 @@ export type ComponentSpec = { component: string; props: Record<string, unknown> 
 // live status + subagent nesting stay in one place (resolved at render).
 export type ChatPart =
   | { kind: "text"; text: string }
+  | { kind: "reasoning"; text: string }
   | { kind: "tools"; ids: string[] };
 
 export type ChatMessage = {


### PR DESCRIPTION
## Why

Reasoning ("thinking") rendered as a **single block hoisted above all the tool cards**. So when the model resumed thinking *between* tool calls, that thought lost its place — you couldn't tell which step it preceded. (This is the other half of what the flagged thread showed: text + tools interleaved, but reasoning didn't.)

## What

Reasoning is now threaded into the ordered `parts` — the same emission-order accumulation #1272 added for text + tools — so a **live** turn renders `reason → tool → reason → tool → answer` in the order it actually happened, like the proto CLI shows thinking between tool calls.

- **`types.ts`** — `ChatPart` gains the `reasoning` variant.
- **`parts.ts`** — `appendReasoning(parts, delta)`: extends the open reasoning run, or starts a new one after text/tools (same leading-whitespace/empty guard as `appendText`, so no stray gaps).
- **`ChatSurface`** — `onReasoning` accumulates into **both** `reasoning` (flat, kept for history/persistence) and `parts` (live inline). The render maps a `reasoning` part to an inline `<Reasoning>` (animated only on the trailing run); the old hoisted block now renders **only** for history-loaded turns (which have no `parts`).

## Tests
`parts.test.ts` — run extension, `reason·tool·reason·answer` interleaving, fresh-run-trims-whitespace, whitespace-only skip. 115 web unit tests green, tsc clean. No e2e fixture emits reasoning, so the existing streaming spec is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)