### PR TITLE
feat(schedule): click a job to open a detail dialog — read the full prompt + edit it

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -146,11 +146,13 @@ export const SCHEDULER_JOBS = {
   jobs: [
     {
       id: "job-1",
-      prompt: "Summarize overnight activity",
+      prompt:
+        "Summarize overnight activity across all repos, then post the digest to the team channel and open issues for anything that needs follow-up before standup.",
       schedule: "0 9 * * *",
       agent_name: "protoAgent",
       enabled: true,
       next_fire: "2026-05-30T09:00:00Z",
+      timezone: "America/Chicago",
     },
   ],
 };

--- a/apps/web/e2e/schedule.spec.ts
+++ b/apps/web/e2e/schedule.spec.ts
@@ -4,7 +4,7 @@ import { expect, test } from "@playwright/test";
 // you — calendar for one-off, presets for recurring, raw cron as the escape hatch —
 // with a live plain-English preview. (No hand-written cron required.)
 
-async function openScheduleModal(page) {
+async function gotoSchedule(page) {
   await page.goto("/app/", { waitUntil: "load" });
   // Schedule folded into the Work hub (2026-06): the right-rail Work surface, Schedule tab.
   // Work is the default-active right panel; in the narrow panel the DS responsive Tabs
@@ -13,6 +13,10 @@ async function openScheduleModal(page) {
   const cls = (await workBtn.getAttribute("class")) ?? "";
   if (!cls.includes("--active")) await workBtn.click();
   await page.locator(".pl-tabs__select").first().selectOption("schedule");
+}
+
+async function openScheduleModal(page) {
+  await gotoSchedule(page);
   await page.getByTestId("schedule-new").click();
   await expect(page.getByTestId("schedule-modal")).toBeVisible();
 }
@@ -51,4 +55,34 @@ test("submit is gated until prompt + schedule are set", async ({ page }) => {
   await expect(page.getByTestId("schedule-submit")).toBeDisabled(); // no prompt yet
   await page.getByTestId("schedule-prompt").fill("Run the daily brief");
   await expect(page.getByTestId("schedule-submit")).toBeEnabled();
+});
+
+test("clicking a job opens a detail dialog with the FULL (un-truncated) prompt", async ({ page }) => {
+  await gotoSchedule(page);
+  // The row only shows a truncated prompt + delete; clicking it pops the full detail.
+  await page.getByTestId("schedule-row-job-1").click();
+  const detail = page.getByTestId("schedule-detail");
+  await expect(detail).toBeVisible();
+  // The full prompt (longer than the 80-char row truncation) is shown in full.
+  await expect(page.getByTestId("schedule-detail-promptbody")).toContainText(
+    "open issues for anything that needs follow-up before standup",
+  );
+  // Schedule (human + raw cron), timezone and id are all surfaced.
+  await expect(detail).toContainText("every day at");
+  await expect(detail).toContainText("0 9 * * *");
+  await expect(detail).toContainText("America/Chicago");
+  await expect(detail).toContainText("job-1");
+});
+
+test("the detail dialog edits prompt + schedule, gated until something changes", async ({ page }) => {
+  await gotoSchedule(page);
+  await page.getByTestId("schedule-row-job-1").click();
+  await page.getByTestId("schedule-detail-edit").click();
+  // Edit fields are pre-filled with the current values.
+  await expect(page.getByTestId("schedule-detail-schedule")).toHaveValue("0 9 * * *");
+  await expect(page.getByTestId("schedule-detail-prompt")).toHaveValue(/Summarize overnight activity/);
+  // Save is gated until a real change.
+  await expect(page.getByTestId("schedule-detail-save")).toBeDisabled();
+  await page.getByTestId("schedule-detail-schedule").fill("0 8 * * 1-5");
+  await expect(page.getByTestId("schedule-detail-save")).toBeEnabled();
 });

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -341,6 +341,8 @@ export type ScheduledJob = {
   next_fire?: string | null;
   last_fire?: string | null;
   enabled?: boolean;
+  /** IANA tz the cron is evaluated in (recurring jobs only); null/absent = UTC. */
+  timezone?: string | null;
 };
 
 export type Subagent = {

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -8,8 +8,8 @@ import {
   useQueryClient,
   useSuspenseQuery,
 } from "@tanstack/react-query";
-import { CalendarClock, Plus, Trash2 } from "lucide-react";
-import { useMemo, useState } from "react";
+import { CalendarClock, Pencil, Plus, Trash2 } from "lucide-react";
+import { useEffect, useMemo, useState } from "react";
 
 import { StagePanel } from "../app/ErrorBoundary";
 import { RefreshButton } from "../app/ui-kit";
@@ -17,6 +17,7 @@ import { PanelHeader, Tabs } from "@protolabsai/ui/navigation";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { queryKeys, schedulesQuery } from "../lib/queries";
+import type { ScheduledJob } from "../lib/types";
 import {
   buildOnce,
   buildRepeat,
@@ -179,12 +180,125 @@ function ScheduleModal({
   );
 }
 
+// Click a job row to open this — read the FULL prompt + every field, or flip to Edit
+// to change the prompt / schedule. The backend has no in-place update (add errors on a
+// duplicate id), so Save is a cancel-then-re-add of the same id (done by the parent).
+function ScheduleDetailDialog({
+  job,
+  onClose,
+  onSave,
+  onDelete,
+  busy,
+  error,
+}: {
+  job: ScheduledJob | null;
+  onClose: () => void;
+  onSave: (id: string, body: { prompt: string; schedule: string; timezone?: string }) => void;
+  onDelete: (id: string) => void;
+  busy: boolean;
+  error?: string | null;
+}) {
+  const [editing, setEditing] = useState(false);
+  const [prompt, setPrompt] = useState("");
+  const [schedule, setSchedule] = useState("");
+  // Re-seed the editable fields whenever a different job is opened; always start in view mode.
+  useEffect(() => {
+    setPrompt(job?.prompt ?? "");
+    setSchedule(job?.schedule ?? "");
+    setEditing(false);
+  }, [job]);
+
+  if (!job) return null;
+  const preview = describeSchedule(schedule);
+  const dirty = prompt.trim() !== job.prompt || schedule.trim() !== job.schedule;
+  const canSave = !!prompt.trim() && !!schedule.trim() && dirty && !busy;
+
+  return (
+    <Dialog
+      open={!!job}
+      onClose={onClose}
+      title={<><CalendarClock size={16} /> {editing ? "Edit schedule" : "Scheduled job"}</>}
+      width="min(560px, 94vw)"
+      className="schedule-dialog"
+      footer={
+        editing ? (
+          <>
+            <Button type="button" onClick={() => setEditing(false)} disabled={busy}>Cancel</Button>
+            <Button
+              type="button"
+              variant="primary"
+              disabled={!canSave}
+              data-testid="schedule-detail-save"
+              onClick={() => onSave(job.id, { prompt: prompt.trim(), schedule: schedule.trim(), timezone: job.timezone || undefined })}
+            >
+              Save changes
+            </Button>
+          </>
+        ) : (
+          <>
+            <Button type="button" onClick={onClose}>Close</Button>
+            <Button type="button" variant="ghost" data-testid="schedule-detail-delete"
+                    onClick={() => onDelete(job.id)} disabled={busy} title="Delete job">
+              <Trash2 size={16} /> Delete
+            </Button>
+            <Button type="button" variant="primary" data-testid="schedule-detail-edit"
+                    onClick={() => setEditing(true)} disabled={busy}>
+              <Pencil size={16} /> Edit
+            </Button>
+          </>
+        )
+      }
+    >
+      <div className="schedule-form" data-testid="schedule-detail">
+        {error ? <p className="settings-status">Couldn't save: {error}</p> : null}
+        {editing ? (
+          <>
+            <label className="field">
+              <span>When it runs (cron expression, or an ISO date for one-off)</span>
+              <Input value={schedule} onChange={(e) => setSchedule(e.target.value)}
+                     data-testid="schedule-detail-schedule" />
+            </label>
+            <p className="schedule-preview">
+              {preview
+                ? <>Runs <strong>{preview}</strong> <code>{schedule}</code>{job.timezone ? <span className="muted"> · {job.timezone}</span> : null}</>
+                : <span className="muted">Enter a cron expression or an ISO date</span>}
+            </p>
+            <label className="field">
+              <span>Prompt (delivered to the agent when it fires)</span>
+              <Textarea value={prompt} onChange={(e) => setPrompt(e.target.value)} rows={6}
+                        data-testid="schedule-detail-prompt" />
+            </label>
+          </>
+        ) : (
+          <dl className="schedule-detail-grid">
+            <dt>Schedule</dt>
+            <dd>
+              {describeSchedule(job.schedule)} <code>{job.schedule}</code>
+              {job.timezone ? <span className="muted"> · {job.timezone}</span> : null}
+            </dd>
+            {job.next_fire ? (<><dt>Next fire</dt><dd>{job.next_fire}</dd></>) : null}
+            {job.last_fire ? (<><dt>Last fire</dt><dd>{job.last_fire}</dd></>) : null}
+            {job.created_at ? (<><dt>Created</dt><dd>{job.created_at}</dd></>) : null}
+            <dt>Job id</dt>
+            <dd><code>{job.id}</code></dd>
+            <dt>Prompt</dt>
+            <dd className="schedule-detail-promptbody" data-testid="schedule-detail-promptbody">{job.prompt}</dd>
+          </dl>
+        )}
+      </div>
+    </Dialog>
+  );
+}
+
 function ScheduleBody() {
   const queryClient = useQueryClient();
   const { data, isFetching, refetch } = useSuspenseQuery(schedulesQuery());
   const jobs = data.jobs;
   const backend = data.backend;
   const [modalOpen, setModalOpen] = useState(false);
+  const [detailId, setDetailId] = useState<string | null>(null);
+  // Track the open job by id so it follows live refetches (and closes if it's deleted).
+  const detailJob = jobs.find((j) => j.id === detailId) ?? null;
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.schedules });
 
@@ -194,7 +308,18 @@ function ScheduleBody() {
     onSettled: invalidate,
   });
   const cancel = useMutation({ mutationFn: (id: string) => api.cancelSchedule(id), onSettled: invalidate });
-  const busy = add.isPending || cancel.isPending;
+  // No in-place update endpoint (add rejects a duplicate id), so an edit is a
+  // cancel-then-re-add of the same id. Client-validated first (prompt + schedule
+  // non-empty) so the re-add rarely fails after the cancel.
+  const edit = useMutation({
+    mutationFn: async ({ id, body }: { id: string; body: { prompt: string; schedule: string; timezone?: string } }) => {
+      await api.cancelSchedule(id);
+      return api.addSchedule({ ...body, job_id: id });
+    },
+    onSuccess: () => setDetailId(null),
+    onSettled: invalidate,
+  });
+  const busy = add.isPending || cancel.isPending || edit.isPending;
 
   return (
     <>
@@ -218,7 +343,8 @@ function ScheduleBody() {
           {jobs.length ? (
             jobs.map((job) => (
               <div className="subagent-row" key={job.id}>
-                <div>
+                <button type="button" className="schedule-row-open" onClick={() => setDetailId(job.id)}
+                        data-testid={`schedule-row-${job.id}`} title="Open details">
                   <strong>{job.id}</strong>
                   <span>
                     {describeSchedule(job.schedule)}
@@ -226,7 +352,7 @@ function ScheduleBody() {
                     {" · "}
                     {job.prompt.length > 80 ? `${job.prompt.slice(0, 80)}…` : job.prompt}
                   </span>
-                </div>
+                </button>
                 <Button icon variant="ghost" type="button" onClick={() => cancel.mutate(job.id)}
                         disabled={busy} title="Cancel job">
                   <Trash2 size={16} />
@@ -245,6 +371,14 @@ function ScheduleBody() {
       </div>
 
       <ScheduleModal open={modalOpen} onClose={() => setModalOpen(false)} onAdd={(b) => add.mutate(b)} busy={busy} />
+      <ScheduleDetailDialog
+        job={detailJob}
+        onClose={() => { setDetailId(null); edit.reset(); }}
+        onSave={(id, body) => edit.mutate({ id, body })}
+        onDelete={(id) => cancel.mutate(id, { onSuccess: () => setDetailId(null) })}
+        busy={busy}
+        error={edit.isError ? errMsg(edit.error) : null}
+      />
     </>
   );
 }

--- a/apps/web/src/schedule/schedule.css
+++ b/apps/web/src/schedule/schedule.css
@@ -51,3 +51,59 @@
   font-size: 12px;
 }
 .schedule-preview .muted { color: var(--fg-muted, #71717a); }
+
+/* A job row's content is a button so the whole row opens the detail dialog; it must
+   look like the plain .subagent-row > div content (grid, no button chrome). */
+.schedule-row-open {
+  flex: 1;
+  min-width: 0;
+  display: grid;
+  gap: 6px;
+  border: 0;
+  background: transparent;
+  padding: 0;
+  margin: 0;
+  text-align: left;
+  cursor: pointer;
+  color: inherit;
+  font: inherit;
+}
+.schedule-row-open:hover strong { color: var(--accent, #9b87f2); }
+.schedule-row-open strong {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 13px;
+}
+.schedule-row-open span {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+/* Detail dialog: a label/value grid + the full (un-truncated) prompt. */
+.schedule-detail-grid {
+  display: grid;
+  grid-template-columns: max-content 1fr;
+  gap: 8px 16px;
+  margin: 0;
+  font-size: 13px;
+}
+.schedule-detail-grid dt { color: var(--fg-muted, #71717a); }
+.schedule-detail-grid dd { margin: 0; min-width: 0; overflow-wrap: anywhere; }
+.schedule-detail-grid code {
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: var(--bg-raised, #131316);
+  border: 1px solid var(--border);
+  font-size: 12px;
+}
+.schedule-detail-grid .muted { color: var(--fg-muted, #71717a); }
+.schedule-detail-promptbody {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+  max-height: 320px;
+  overflow-y: auto;
+}


### PR DESCRIPTION
## Why

The Schedule view only showed each job as a row with a **truncated** prompt (80 chars) and a delete button — you couldn't read the whole prompt or change a job once created.

## What

Clicking a job row now opens a **detail dialog**:

- **View** — the FULL prompt (un-truncated, scrollable), the human-readable + raw schedule, next/last fire, created, timezone, and id.
- **Edit** — flip to edit mode to change the **prompt** and/or **schedule** (raw cron or ISO date, with the same live plain-English preview the New-schedule builder uses). Save is gated until something actually changes.
- **Delete** moves into the dialog too (the row keeps its quick-delete button).

## Notes
- The scheduler backend has no in-place update (`add_job` rejects a duplicate id), so **Save = cancel-then-re-add of the same id**. It's client-validated first (prompt + schedule non-empty, changed) so the re-add rarely fails after the cancel, and any error surfaces in the dialog. A dedicated `PUT /api/scheduler/jobs/{id}` would make it atomic — a reasonable follow-up if we want it.
- `ScheduledJob` gained `timezone` (already in the backend `as_dict()` DTO, just wasn't typed on the client).
- The row content is now a `<button>` (opens the dialog), styled to match the old row; the delete button stays a separate sibling (no nested buttons).

## Tests
e2e: open-detail shows the full prompt + schedule + tz + id; edit pre-fills the fields and gates Save on a real change. (Fixture prompt lengthened + tz added to exercise the truncation→full path.) tsc clean, 115 unit + 6 schedule e2e green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)