### PR TITLE
chore: purge remaining Workstacean references (cost/effect extension + doc stragglers)

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,8 +181,8 @@ to list it on the directory. See [Install & publish plugins](./docs/guides/plugi
 
 Declare additional extensions on the card in
 `server/a2a.py::_build_agent_card_proto` when your agent's skills
-actually mutate shared state (see `effect-domain-v1` in the
-Workstacean docs for when this applies).
+actually mutate shared state (see `effect-domain-v1` in
+[Extensions](./docs/reference/extensions.md) for when this applies).
 
 ## Push notification support
 

--- a/TEMPLATE.md
+++ b/TEMPLATE.md
@@ -142,7 +142,7 @@ a2a:
 - `capabilities.extensions` — `cost-v1` is declared by default
   (the runtime emits it automatically); add `effect-domain-v1`
   in `server/a2a.py::_build_agent_card_proto` if your skills
-  mutate shared state Workstacean's planner should know about.
+  mutate shared state a planner should know about.
 
 ## 7. Set up the model
 
@@ -210,7 +210,7 @@ python -m server
 
 Multi-fork safety: every job is namespaced by `AGENT_NAME`, so
 spinning up `gina-personal` next to `gina-work` (or any number of
-ginas under one Workstacean) doesn't cross-fire prompts. See
+ginas sharing a sqlite path) doesn't cross-fire prompts. See
 [Schedule future work](./docs/guides/scheduler.md) for the full
 firing model and integration notes.
 

--- a/docs/explanation/cost-and-trace.md
+++ b/docs/explanation/cost-and-trace.md
@@ -11,13 +11,13 @@ A multi-agent fleet needs to answer: *how much is each (agent, skill) costing, a
 cost-v1 is the measurement. Every terminal task carries a DataPart with:
 
 - `usage.input_tokens`, `usage.output_tokens`, `usage.total_tokens`
-- `usage.cache_read_input_tokens`, `usage.cache_creation_input_tokens` — Anthropic-shaped prompt-cache tokens (ADR 0006), matching Workstacean's `CostArtifactUsage`
+- `usage.cache_read_input_tokens`, `usage.cache_creation_input_tokens` — Anthropic-shaped prompt-cache tokens (ADR 0006)
 - `durationMs`
 - `costUsd` — the in-process estimate accumulated across the turn's LLM calls (`pricing.py`); consumers prefer it over recomputing from tokens
 
-The agent also **declares the extension** in its card (`capabilities.extensions`, URI `https://proto-labs.ai/a2a/ext/cost-v1`), which is what gates Workstacean's cost interceptor.
+The agent also **declares the extension** in its card (`capabilities.extensions`, URI `https://proto-labs.ai/a2a/ext/cost-v1`), which is what gates a consumer's cost interceptor.
 
-The consuming system (Workstacean's `defaultCostStore`) keeps a rolling window of samples per `(agent, skill)` key and uses them to rank candidates for dispatch — replacing self-advertisement with observation after 5+ samples. See [ADR 0006](/adr/0006-observability-and-the-self-improving-flywheel).
+A consuming system can keep a rolling window of samples per `(agent, skill)` key and use them to rank candidates for dispatch — replacing self-advertisement with observation after enough samples. See [ADR 0006](/adr/0006-observability-and-the-self-improving-flywheel).
 
 ### Why token capture lives where it does
 

--- a/docs/guides/add-a-skill.md
+++ b/docs/guides/add-a-skill.md
@@ -5,7 +5,7 @@ A *skill* is a named capability A2A callers can dispatch to. Skills live on the 
 ## When you need a skill
 
 - You want another agent (via A2A) to invoke a specific mode of behaviour — e.g. `pr_review` vs. `bug_triage`.
-- You want Workstacean's planner to rank your agent against a specific goal.
+- You want a planner to rank your agent against a specific goal.
 - You want per-skill cost telemetry (cost-v1 samples are keyed by `(agent, skill)`).
 
 You don't need a skill for "things the chat UI does" — the React console chat is already covered by the default dispatch path.
@@ -27,11 +27,11 @@ a2a:
 
 The server merges these (plus any contributed by plugins via `register_a2a_skill`) and falls back to the template's `chat` placeholder when none are set. A plugin can ship card skills the same way — `registry.register_a2a_skill(spec)` — so a distributable extension carries its own advertised capabilities.
 
-**IDs are sticky**. `cost-v1` samples, `effect-domain-v1` declarations, and Workstacean's routing all key off the `id`. Pick one and don't rename later.
+**IDs are sticky**. `cost-v1` samples, `effect-domain-v1` declarations, and a consumer's routing all key off the `id`. Pick one and don't rename later.
 
 ## 2. (Optional) Declare an effect
 
-If the skill actually mutates shared state Workstacean cares about (creates a PR, files an issue, updates a board), declare it under `effect-domain-v1`:
+If the skill actually mutates shared state a planner cares about (creates a PR, files an issue, updates a board), declare it under `effect-domain-v1`:
 
 ```python
 "capabilities": {

--- a/docs/guides/index.md
+++ b/docs/guides/index.md
@@ -18,7 +18,7 @@ Shape how the agent's loop behaves — standing goals, timers, middleware hooks,
 | Guide | When to read |
 |---|---|
 | [Goal mode](/guides/goal-mode) | You want the agent to pursue a standing goal across turns, not just answer one-shot |
-| [Schedule future work](/guides/scheduler) | You want the agent to defer tasks to itself ("remind me tomorrow", recurring sweeps) — local sqlite or Workstacean-backed |
+| [Schedule future work](/guides/scheduler) | You want the agent to defer tasks to itself ("remind me tomorrow", recurring sweeps) — bundled local sqlite |
 | [Middleware](/guides/middleware) | You want pre/post hooks on the agent turn (plugin-contributed) |
 | [Run on a coding agent (ACP runtime)](/guides/acp-runtime) | You want an external coding agent (proto/Codex/Claude/Copilot/OpenCode) to *be* the runtime brain, with protoAgent as the shell |
 

--- a/docs/guides/operator-fork.md
+++ b/docs/guides/operator-fork.md
@@ -75,7 +75,7 @@ a dirty tree on main. Summarize per project (flowing / stalled / blocked), then
 
 - **Summon via A2A** — Roxy is reached over the A2A endpoint (`message/send` /
   `message/stream`); set an `auth.token` so inbound is authenticated.
-- **The Workstacean bus** — protoWorkstacean dispatches to Roxy as an A2A agent
+- **An external dispatcher** — any A2A planner can dispatch to Roxy as an A2A agent
   (it already speaks the `cost-v1`/`confidence-v1` extensions Roxy emits).
 - **Scheduled sweeps** — a periodic `schedule_task` (or an external cron hitting
   A2A) fires a "sweep all projects" turn; the skill + persona do the rest.

--- a/docs/reference/a2a-endpoints.md
+++ b/docs/reference/a2a-endpoints.md
@@ -203,7 +203,7 @@ Outgoing webhook URLs are resolved once and checked against an allowlist before 
 To permit trusted docker-network hostnames, set:
 
 ```bash
-PUSH_NOTIFICATION_ALLOWED_HOSTS=workstacean,automaker-server
+PUSH_NOTIFICATION_ALLOWED_HOSTS=automaker-server,internal-hooks
 PUSH_NOTIFICATION_ALLOWED_CIDRS=10.0.0.0/8,172.16.0.0/12
 ```
 

--- a/docs/reference/agent-card.md
+++ b/docs/reference/agent-card.md
@@ -105,8 +105,8 @@ Each entry describes one dispatchable capability:
 }
 ```
 
-- `id` — **sticky**. `cost-v1` samples, `worldstate-delta-v1` declarations, and Workstacean's routing all key on it. Don't rename.
-- `tags` — free-form. Workstacean's planner does substring matching against goals.
+- `id` — **sticky**. `cost-v1` samples, `worldstate-delta-v1` declarations, and a consumer's routing all key on it. Don't rename.
+- `tags` — free-form. A planner can do substring matching against goals.
 - `examples` — few-shot-ish prompts consumers can surface in their UI.
 - `inputModes` / `outputModes` — override `defaultInputModes` / `defaultOutputModes` for this specific skill.
 

--- a/docs/reference/extensions.md
+++ b/docs/reference/extensions.md
@@ -27,7 +27,7 @@ Every terminal task carries a DataPart with token usage and duration:
 
 Captured by the `on_chat_model_end` handler in `_chat_langgraph_stream`. Requires `stream_usage=True` on the ChatOpenAI client — the template sets this in `graph/llm.py`.
 
-**Consumers** (like Workstacean's A2AExecutor) extract this DataPart onto `result.data` and record per-(agent, skill) samples. The consumer keys on the `skill` ID from the card, so skill IDs must be stable.
+**Consumers** (any A2A executor) extract this DataPart onto `result.data` and record per-(agent, skill) samples. The consumer keys on the `skill` ID from the card, so skill IDs must be stable.
 
 `costUsd` **is** emitted: `pricing.py::cost_usd` derives it from the model's rates and the captured `usage`, and it rides this DataPart (and the telemetry store). Consumers still tolerate a missing/zero `costUsd` (unknown model → no rate) and can recompute from `usage` themselves.
 
@@ -90,7 +90,7 @@ Declares a human-in-the-loop **approval policy** per skill: `autonomous` (run wi
 **Direction**: declared by this agent
 **Declared on card**: no (template has no mutating skills)
 
-Advertises per-skill world-state mutations so Workstacean's L1 planner can rank your agent against goals that target those state selectors.
+Advertises per-skill world-state mutations so a planner can rank your agent against goals that target those state selectors.
 
 ```json
 {
@@ -123,7 +123,7 @@ Only declare effects that actually mutate shared state. Over-declaring confuses 
 
 **Pair with runtime emission**: if you declare an effect, emit a matching `worldstate-delta-v1` DataPart when the tool succeeds at runtime — yield a `delta` event from the tool and the executor (`a2a_executor.py`) accumulates them onto the terminal artifact. Divergence between declared and observed mutations breaks the planner's scoring model.
 
-See `docs/extensions/effect-domain-v1` in the [protoWorkstacean repo](https://github.com/protoLabsAI/protoWorkstacean) for the full spec.
+The fields above define the full `effect-domain-v1` shape (a proto-labs A2A extension).
 
 ## `worldstate-delta-v1`
 

--- a/docs/reference/starter-tools.md
+++ b/docs/reference/starter-tools.md
@@ -6,7 +6,7 @@ The default tool set (from `tools/lg_tools.py::get_all_tools`):
 - Two **HITL tools** — `ask_human` (a free-text question) and `request_user_input` (a structured multi-step form) — pause the turn (A2A `input-required`) for the operator and resume with their answer (lead-agent only).
 - One **render tool** — `show_component` — emits a structured component (table, key-value, timeline, …) that the console renders inline in chat ([ADR 0051](/adr/0051-a2a-realtime-streaming-and-component-rendering)), instead of formatting it as prose.
 - Four **memory tools** — `memory_ingest`, `memory_recall`, `memory_list`, `memory_stats` — bound to the bundled `KnowledgeStore` (sqlite + FTS5, see [Configuration](/reference/configuration#knowledge)). Omitted when no store.
-- Three **scheduler tools** — `schedule_task`, `list_schedules`, `cancel_schedule` — bound to the bundled scheduler backend (local sqlite or the Workstacean adapter, see [Schedule future work](/guides/scheduler)). Omitted when no scheduler.
+- Three **scheduler tools** — `schedule_task`, `list_schedules`, `cancel_schedule` — bound to the bundled scheduler backend (local sqlite, see [Schedule future work](/guides/scheduler)). Omitted when no scheduler.
 - Four **beads tools** — `beads_create`, `beads_list`, `beads_update`, `beads_close` — the agent's in-process planning board, bridged to the console Beads panel. Bound when a beads store is present (default in `server/agent_init.py`).
 - One **inbox tool** — `check_inbox` — bound to the durable inbound inbox (ADR 0003) when configured; pulls stimuli pushed to `POST /api/inbox`.
 - One **goal tool** — `set_goal` — sets a standing, plugin-verified goal for the session ([ADR 0028](/adr/0028-plugin-goal-verifiers); goal mode is **always on**). See [Goal mode](/guides/goal-mode).
@@ -203,8 +203,6 @@ List the current scheduled jobs for *this* agent. Multi-agent isolation: each ag
 
 Output: one job per line with id, next-fire timestamp, schedule, and prompt preview. Returns `"No scheduled jobs."` when empty.
 
-The Workstacean adapter intentionally returns `[]` (Workstacean owns scheduling state and its `list` action publishes asynchronously to a topic). Run the local backend or query Workstacean directly for live introspection there.
-
 ## `cancel_schedule`
 
 ```python
@@ -214,7 +212,7 @@ async def cancel_schedule(job_id: str) -> str
 
 Cancel a scheduled job by id. Returns `"Canceled <id>."` or `"Error: no such job <id>."`.
 
-Cross-agent cancellation is blocked — `gina-personal` cannot cancel `gina-work`'s jobs even when sharing a sqlite path or a Workstacean install.
+Cross-agent cancellation is blocked — `gina-personal` cannot cancel `gina-work`'s jobs even when sharing a sqlite path.
 
 ## `ask_human`
 

--- a/observability/pricing.py
+++ b/observability/pricing.py
@@ -1,11 +1,9 @@
 """Per-model token pricing → USD cost (ADR 0006, Slice 1).
 
-Rates mirror the structure + overlapping values of Workstacean's ``MODEL_RATES``
-(``protoWorkstacean/lib/types/budget.ts``) so protoAgent's emitted ``costUsd``
-agrees with the fleet's fallback computation. Cost is best-effort: an unknown
-model resolves by substring match (gateway aliases like
-``anthropic/claude-opus-4-8``), else falls back to the ``default`` rate. Never
-raises.
+``costUsd`` is emitted on the A2A cost-v1 extension so any consumer agrees on the
+per-call cost. Best-effort: an unknown model resolves by substring match (gateway
+aliases like ``anthropic/claude-opus-4-8``), else falls back to the ``default``
+rate. Never raises.
 
 ``costUsd`` here bills ``input_tokens`` + ``output_tokens`` at the base rates —
 the portion every consumer agrees on. Prompt-cache tokens are captured + emitted
@@ -17,7 +15,7 @@ semantics are validated end-to-end (different gateways disagree on whether
 
 from __future__ import annotations
 
-# USD per token, (input, output). Keep in sync with Workstacean MODEL_RATES.
+# USD per token, (input, output).
 MODEL_RATES: dict[str, dict[str, float]] = {
     "claude-opus-4-8": {"input": 0.000015, "output": 0.000075},
     "claude-opus-4-6": {"input": 0.000015, "output": 0.000075},
@@ -30,7 +28,7 @@ MODEL_RATES: dict[str, dict[str, float]] = {
     # spend, so these are a low nominal local-compute estimate (trackable, not
     # billing) rather than the Claude-ish `default` which would overstate cost
     # ~30x. Substring match covers the gateway aliases (protolabs/reasoning →
-    # protolabs/smart backend, etc.). Keep in sync with Workstacean MODEL_RATES.
+    # protolabs/smart backend, etc.).
     "protolabs/reasoning": {"input": 0.0000001, "output": 0.0000004},
     "protolabs/smart": {"input": 0.0000001, "output": 0.0000004},
     "protolabs/fast": {"input": 0.00000005, "output": 0.0000002},

--- a/server/chat.py
+++ b/server/chat.py
@@ -973,8 +973,8 @@ async def _chat_langgraph_stream(
             yield ("done", final_text)
 
         except GeneratorExit:
-            # Expected: A2A consumers (e.g. Workstacean's A2AExecutor) break
-            # out of the SSE loop after capturing the initial task event,
+            # Expected: A2A consumers break out of the SSE loop after
+            # capturing the initial task event,
             # then hand off to TaskTracker for polling. Re-raise so Python
             # finalizes the generator cleanly; the OTel cross-context detach
             # noise this used to emit is silenced at the logger level in

--- a/tests/test_a2a_integration.py
+++ b/tests/test_a2a_integration.py
@@ -120,7 +120,7 @@ def test_agent_card_declares_all_four_protolabs_extensions() -> None:
 
 
 def test_agent_card_declares_cost_v1_extension() -> None:
-    """cost-v1 specifically — Workstacean's cost interceptor engages on this
+    """cost-v1 specifically — a consumer's cost interceptor engages on this
     canonical URI."""
     import protolabs_a2a as pa
 

--- a/tests/test_a2a_stores.py
+++ b/tests/test_a2a_stores.py
@@ -261,9 +261,9 @@ def test_ssrf_guard_accepts_public(url):
 
 def test_ssrf_guard_honors_host_allowlist(monkeypatch):
     """A hostname in PUSH_NOTIFICATION_ALLOWED_HOSTS bypasses the IP check."""
-    # workstacean resolves to an RFC1918 docker address by design.
-    monkeypatch.setenv("PUSH_NOTIFICATION_ALLOWED_HOSTS", "workstacean")
-    assert is_safe_webhook_url("http://workstacean:7860/hook") is True
+    # automaker-server resolves to an RFC1918 docker address by design.
+    monkeypatch.setenv("PUSH_NOTIFICATION_ALLOWED_HOSTS", "automaker-server")
+    assert is_safe_webhook_url("http://automaker-server:7860/hook") is True
     # Anything not on the list still gets the IP check (and rejected).
     assert is_safe_webhook_url("http://10.0.0.1/hook") is False
 

--- a/tests/test_cost_v1_emission.py
+++ b/tests/test_cost_v1_emission.py
@@ -1,7 +1,7 @@
 """cost-v1 DataPart: cache fields + costUsd emission (ADR 0006 Slice 1, A2A 1.0).
 
-The terminal artifact carries Workstacean's Anthropic-shaped cache fields and a
-top-level costUsd. The bespoke ``_cost_payload`` was replaced by
+The terminal artifact carries the Anthropic-shaped cache fields and a top-level
+costUsd. The bespoke ``_cost_payload`` was replaced by
 ``protolabs_a2a.emit_cost``; the executor accumulates usage across LLM calls and
 passes it in. Also verifies ``metrics.record_llm_call`` accepts the enriched
 signature without a live Prometheus registry.
@@ -42,8 +42,9 @@ def test_cost_payload_omits_costusd_when_not_supplied() -> None:
     assert "costUsd" not in payload
 
 
-def test_extension_uri_is_the_canonical_workstacean_uri() -> None:
-    # Must match protoWorkstacean's COST_URI for its interceptor to engage.
+def test_extension_uri_is_the_canonical_cost_uri() -> None:
+    # The published proto-labs cost-v1 extension URI a consumer gates its cost
+    # interceptor on — frozen so we don't silently break the wire contract.
     assert pa.COST_EXT_URI == "https://proto-labs.ai/a2a/ext/cost-v1"
     assert pa.COST_MIME == "application/vnd.protolabs.cost-v1+json"
 

--- a/tests/test_tracing.py
+++ b/tests/test_tracing.py
@@ -236,7 +236,7 @@ def test_no_legacy_shims_exist():
 
 
 def test_otel_cross_context_detach_error_is_silenced():
-    """When an SSE consumer (e.g. Workstacean's A2AExecutor) closes
+    """When an SSE consumer (e.g. an A2A executor) closes
     the stream early, GeneratorExit propagates through
     trace_session's __aexit__. The Langfuse span's underlying OTel
     token was attached in a child task's contextvar snapshot, so the


### PR DESCRIPTION
Follow-up to #1278 (scheduler backend removal). Scrubs the rest of the Workstacean naming — all comments / test names / docs, **no behavior change, no wire values touched**.

- **`observability/pricing.py`** — the rate table is protoAgent's own; dropped the "keep in sync with Workstacean `MODEL_RATES`" provenance notes (values unchanged).
- **A2A cost-v1 / effect-domain / worldstate extensions** — reframed "Workstacean's interceptor / planner / A2AExecutor" → generic "a consumer / a planner / an A2A executor" across `server/chat.py` + the cost-and-trace / extensions / agent-card / add-a-skill docs. The published URI stays `https://proto-labs.ai/a2a/ext/cost-v1`.
- Renamed `test_extension_uri_is_the_canonical_workstacean_uri` → `..._cost_uri` (the assertion — the canonical proto-labs URI — is unchanged).
- Doc stragglers #1278 didn't reach (`starter-tools`, `guides/index`, `TEMPLATE` multi-fork note) → local-only framing.
- SSRF/webhook allowlist examples that used `workstacean` as a sample hostname → `automaker-server`/`internal-hooks`.

**Left intact deliberately:** `CHANGELOG.md` + the ADRs (historical record of what shipped), and the one test in `test_scheduler_local.py` that *intentionally* sets stale `WORKSTACEAN_*` env to prove they're now ignored.

After this, `grep -ri workstacean` returns only those historical/intentional hits.

Tests: 49 affected Python tests green, ruff clean. Net −3 lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)