### PR TITLE
feat(schedule): confirm before deleting a job (no more one-click delete)

### DIFF
--- a/apps/web/e2e/schedule.spec.ts
+++ b/apps/web/e2e/schedule.spec.ts
@@ -86,3 +86,41 @@ test("the detail dialog edits prompt + schedule, gated until something changes",
   await page.getByTestId("schedule-detail-schedule").fill("0 8 * * 1-5");
   await expect(page.getByTestId("schedule-detail-save")).toBeEnabled();
 });
+
+test("the row delete button confirms first — Cancel keeps the job", async ({ page }) => {
+  await gotoSchedule(page);
+  // The row's trash no longer deletes on one click; it summons a ConfirmDialog.
+  await page.getByRole("button", { name: "Delete job" }).click();
+  const confirm = page.getByRole("dialog", { name: "Delete scheduled job?" });
+  await expect(confirm).toBeVisible();
+  // The confirm names what's being deleted (human schedule + prompt).
+  await expect(confirm).toContainText("every day at");
+  await expect(confirm).toContainText("Summarize overnight activity");
+  // Cancel aborts — dialog closes, the job row is still there.
+  await page.getByRole("button", { name: "Cancel" }).click();
+  await expect(confirm).toBeHidden();
+  await expect(page.getByTestId("schedule-row-job-1")).toBeVisible();
+});
+
+test("Escape aborts the delete confirm; confirming fires it", async ({ page }) => {
+  await gotoSchedule(page);
+  await page.getByRole("button", { name: "Delete job" }).click();
+  const confirm = page.getByRole("dialog", { name: "Delete scheduled job?" });
+  await expect(confirm).toBeVisible();
+  await page.keyboard.press("Escape"); // click-outside / Esc cancels (no delete)
+  await expect(confirm).toBeHidden();
+  await expect(page.getByTestId("schedule-row-job-1")).toBeVisible();
+
+  // Re-open and actually confirm → the dialog closes (the cancel mutation fires).
+  await page.getByRole("button", { name: "Delete job" }).click();
+  await confirm.getByRole("button", { name: "Delete" }).click();
+  await expect(confirm).toBeHidden();
+});
+
+test("the detail dialog's Delete also routes through the confirm", async ({ page }) => {
+  await gotoSchedule(page);
+  await page.getByTestId("schedule-row-job-1").click();
+  await page.getByTestId("schedule-detail-delete").click();
+  // The detail dialog's Delete opens the same confirm (no immediate delete).
+  await expect(page.getByRole("dialog", { name: "Delete scheduled job?" })).toBeVisible();
+});

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -2,7 +2,7 @@ import "./schedule.css";
 
 import { DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
-import { Dialog } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, Dialog } from "@protolabsai/ui/overlays";
 import {
   useMutation,
   useQueryClient,
@@ -297,8 +297,10 @@ function ScheduleBody() {
   const backend = data.backend;
   const [modalOpen, setModalOpen] = useState(false);
   const [detailId, setDetailId] = useState<string | null>(null);
-  // Track the open job by id so it follows live refetches (and closes if it's deleted).
+  const [confirmDeleteId, setConfirmDeleteId] = useState<string | null>(null);
+  // Track jobs by id so they follow live refetches (and the dialogs close if deleted).
   const detailJob = jobs.find((j) => j.id === detailId) ?? null;
+  const confirmJob = jobs.find((j) => j.id === confirmDeleteId) ?? null;
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.schedules });
 
@@ -350,8 +352,8 @@ function ScheduleBody() {
                     {job.prompt.length > 80 ? `${job.prompt.slice(0, 80)}…` : job.prompt}
                   </span>
                 </button>
-                <Button icon variant="ghost" type="button" onClick={() => cancel.mutate(job.id)}
-                        disabled={busy} title="Cancel job">
+                <Button icon variant="ghost" type="button" onClick={() => setConfirmDeleteId(job.id)}
+                        disabled={busy} title="Delete job">
                   <Trash2 size={16} />
                 </Button>
               </div>
@@ -372,10 +374,25 @@ function ScheduleBody() {
         job={detailJob}
         onClose={() => { setDetailId(null); edit.reset(); }}
         onSave={(id, body) => edit.mutate({ id, body })}
-        onDelete={(id) => cancel.mutate(id, { onSuccess: () => setDetailId(null) })}
+        onDelete={(id) => setConfirmDeleteId(id)}
         busy={busy}
         error={edit.isError ? errMsg(edit.error) : null}
       />
+      <ConfirmDialog
+        open={confirmDeleteId !== null}
+        title="Delete scheduled job?"
+        confirmLabel="Delete"
+        destructive
+        onConfirm={() => {
+          if (confirmDeleteId) cancel.mutate(confirmDeleteId, { onSuccess: () => setDetailId(null) });
+          setConfirmDeleteId(null);
+        }}
+        onClose={() => setConfirmDeleteId(null)}
+      >
+        {confirmJob
+          ? `"${describeSchedule(confirmJob.schedule)}" — ${confirmJob.prompt.length > 80 ? `${confirmJob.prompt.slice(0, 80)}…` : confirmJob.prompt}. It will stop firing and be removed. This can't be undone.`
+          : undefined}
+      </ConfirmDialog>
     </>
   );
 }


### PR DESCRIPTION
## Why
Deleting a scheduled job was a **single click** — the row's trash button (and the detail dialog's Delete) cancelled the job immediately. A stray click silently dropped a schedule. (Reported from live use.)

## What
Both delete entry points now summon the DS **`ConfirmDialog`** — the same pattern as chat-tab delete and MCP unshare. The confirm **names what's being removed** (human-readable schedule + prompt preview) and the delete only fires on explicit confirm; **Cancel / Escape / click-outside abort**.

- `SchedulePanel.tsx` — a `confirmDeleteId` drives one shared `ConfirmDialog`; the row trash and the detail-dialog Delete both set it instead of calling `cancel.mutate` directly. Row trash tooltip `"Cancel job"` → `"Delete job"` (matches the dialog's verb).

## Tests
3 new e2e: row-delete confirms (Cancel keeps the job) · Escape aborts then confirm fires · the detail dialog's Delete also routes through the confirm. 9 schedule e2e + tsc green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)