### PR TITLE
chore: release v0.65.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.65.0] - 2026-06-21
+
 ### Added
 - **Schedule view: open a job to read the full prompt + edit it in place.** Clicking a
   scheduled job now opens a detail dialog with the full (un-truncated) prompt, the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.64.3"
+version = "0.65.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,19 @@
 [
   {
+    "version": "v0.65.0",
+    "date": "2026-06-21",
+    "changes": [
+      "Schedule view: open a job to read the full prompt + edit it in place.",
+      "Chat: reasoning renders inline, in emission order.",
+      "Deleting a scheduled job confirms first.",
+      "Removed the Workstacean scheduler backend.",
+      "Chat: assistant text and tool calls render in emission order.",
+      "Settings: Host-console edits stop \"resetting.\"",
+      "ACP: load_skill works through the operator sidecar.",
+      "Chat: no stray gap between tool calls."
+    ]
+  },
+  {
     "version": "v0.64.3",
     "date": "2026-06-20",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.65.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.65.0 -m 'Release v0.65.0' && git push origin v0.65.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).