### PR TITLE
chore: release v0.66.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.66.0] - 2026-06-21
+
 ### Changed
 - **The agent's task board is now "tasks", not "beads."** The in-process board — the
   console panel *and* the agent's task tools — was never the real `br` beads: it's a

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.65.0"
+version = "0.66.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.66.0",
+    "date": "2026-06-21",
+    "changes": [
+      "The agent's task board is now \"tasks\", not \"beads.\"",
+      "Create a task from a dialog.",
+      "Dropped the dead br fallback from the core task board."
+    ]
+  },
+  {
     "version": "v0.65.0",
     "date": "2026-06-21",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.66.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.66.0 -m 'Release v0.66.0' && git push origin v0.66.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Version 0.66.0 released.
  * Project dependencies updated with new packages included.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->