### PR TITLE
fix(web): roomier dialog body padding by default (no more cramped dialogs)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,7 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   add-delegate form, schedule, the new task dialog) shipped cramped until someone
   remembered to bump it. Raised the app-wide `.pl-dialog__body` default to 24px once and
   dropped the now-redundant per-dialog overrides. Surfaces that embed a full panel
-  (Settings, theme quick-pick) keep their intentional zero padding. (#1287)
+  (Settings, theme quick-pick) keep their intentional zero padding. (#1288)
 
 ## [0.66.0] - 2026-06-21
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Dialogs no longer render their content cramped flush to the body edge.** The shared
+  DS dialog defaulted to a tight 16px body padding, and roomier dialogs (MCP catalog,
+  New-skill) each hand-added a 24px override — so every newly-converted dialog (the
+  add-delegate form, schedule, the new task dialog) shipped cramped until someone
+  remembered to bump it. Raised the app-wide `.pl-dialog__body` default to 24px once and
+  dropped the now-redundant per-dialog overrides. Surfaces that embed a full panel
+  (Settings, theme quick-pick) keep their intentional zero padding. (#1287)
+
 ## [0.66.0] - 2026-06-21
 
 ### Changed

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -652,13 +652,17 @@ select:disabled {
   line-height: 1.5;
 }
 
-/* MCP catalog quick-add (McpCatalogDialog) — a curated directory of common servers,
-   self-contained styles so the dialog doesn't depend on the Plugins surface CSS. */
-/* A bit more breathing room than the DS default (16px) — the full-width search +
-   multi-column card grid feel cramped flush to the body edge. */
-.mcp-catalog-dialog .pl-dialog__body {
+/* Roomier dialog body padding than the bare DS default (16px). Content dialogs —
+   forms, card pickers, the full-width search + multi-column grids — read as cramped
+   flush to the body edge, so the app-wide default is 24px. Dialogs that embed a full
+   surface override back to padding:0 at higher specificity (.settings-overlay /
+   .theme-quick-dialog). Loads after the DS overlays.css, so equal specificity wins. */
+.pl-dialog__body {
   padding: var(--pl-space-6, 24px);
 }
+
+/* MCP catalog quick-add (McpCatalogDialog) — a curated directory of common servers,
+   self-contained styles so the dialog doesn't depend on the Plugins surface CSS. */
 /* Browse (grid) view: pin the dialog to a tall, consistent height and let the card
    grid fill the space below the search/filter controls instead of capping the grid
    short and leaving dead space under it. The configure step keeps its content height. */
@@ -1902,9 +1906,9 @@ textarea {
 .knowledge-chunk-form-row > :first-child { flex: 1; min-width: 180px; }
 .knowledge-chunk-actions { display: flex; gap: 2px; }
 
-/* New/Edit skill dialog (PlaybooksSurface) — roomier than the DS default + a little
-   more space between fields than the knowledge inline form it grew out of. */
-.skill-dialog .pl-dialog__body { padding: var(--pl-space-6, 24px); }
+/* New/Edit skill dialog (PlaybooksSurface) — a little more space between fields than
+   the knowledge inline form it grew out of. (Body padding is the app-wide
+   .pl-dialog__body default now.) */
 .skill-form { display: flex; flex-direction: column; gap: 12px; min-width: 0; }
 /* The trailing action row gets a little separation from the fields above it. */
 .skill-form > .knowledge-chunk-form-row:last-child { margin-top: 4px; }


### PR DESCRIPTION
## What

The "Add a delegate" dialog (and others) rendered their content cramped flush to the body edge. Root cause: the shared DS `Dialog` defaults `.pl-dialog__body` to a tight **16px** padding (`var(--pl-space-4)`), and the repo had been compensating **per-dialog** — the MCP catalog (#1265) and New-skill (#1269) dialogs each hand-added the identical `padding: var(--pl-space-6, 24px)` override. Every newly-converted inline-form→dialog that *didn't* get the override (add-delegate — created in #1269 — plus schedule and the new task dialog #1284) shipped cramped. Classic whack-a-mole.

## Fix

Raise the **app-wide** `.pl-dialog__body` default to 24px once, in `apps/web/src/app/theme.css`, and drop the two now-redundant per-dialog overrides.

- The global rule loads after the DS `overlays.css`, so at equal specificity it wins.
- Surfaces that intentionally embed a full panel (`.settings-overlay`, `.theme-quick-dialog`) keep their `padding: 0` — they override at higher specificity.
- The MCP `--browse` flex/height rules are untouched.

Every dialog now gets proper breathing room by default; no new dialog can regress into this.

## Before / after

| | Body padding |
|---|---|
| Before | 16px DS default, with 24px hand-added on a per-dialog basis (delegate/schedule/task missed) |
| After | 24px app-wide default; intentional zero-padding surfaces preserved |

## Testing

- CSS-only change.
- `scripts/check-css-comments.mjs` (prebuild minifier-trap guard) passes.
- Verified the cascade: global 24px applies to delegate/skill/mcp/task dialogs; `.settings-overlay`/`.theme-quick-dialog` keep `padding: 0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)