### PR TITLE
feat(config): parse acp.agents launch overrides (ADR 0033)

### DIFF
--- a/config/langgraph-config.example.yaml
+++ b/config/langgraph-config.example.yaml
@@ -231,6 +231,15 @@ checkpoint:
 #   fallback_models:
 #    - claude-haiku-4-5
 
+# ACP runtime adapters (ADR 0033) — only relevant when `agent_runtime: acp:<agent>` (or
+# an `acp:<agent>` aux/eval/compaction model) routes a turn through a coding agent. Each
+# agent has a built-in default launch command (an `npx -y …` fetch); override it here to
+# point at a locally-installed binary (faster cold-start, no network). `args` optional.
+# acp:
+#   agents:
+#     claude: { command: claude-agent-acp, args: [] }   # use the installed adapter, not npx
+#     codex:  { command: codex-acp,        args: [] }
+
 # Goal mode — route the goal verifier to a cheaper model with `eval_model`
 # (else it uses routing.aux_model, else the main model).
 goal:

--- a/graph/config.py
+++ b/graph/config.py
@@ -544,6 +544,12 @@ class LangGraphConfig:
     # LangGraph loop (default). "acp:<agent>" (e.g. "acp:codex", "acp:claude") = an
     # external coding agent drives the turn over ACP, mounting the operator MCP bus.
     agent_runtime: str = "native"
+    # ACP launch overrides (ADR 0033) — per-agent ``{command, args}`` from the YAML
+    # ``acp.agents`` block, e.g. ``acp: {agents: {claude: {command: claude-agent-acp}}}``.
+    # ``runtime.acp_runtime.adapter_for`` reads this to override the built-in default
+    # adapter (an ``npx -y …`` fetch) with a locally-installed binary. Empty = use the
+    # defaults. Not a settings-UI field — an advanced, machine-local launch knob.
+    acp_agents: dict = field(default_factory=dict)
 
     # Plugins — drop-in packages (manifest + register()) that contribute tools
     # and bundled skills. Run IN-PROCESS with the agent's privileges, so a
@@ -753,6 +759,7 @@ class LangGraphConfig:
         skills = data.get("skills", {})
         mcp = data.get("mcp", {})
         operator_mcp = data.get("operator_mcp", {})
+        acp = data.get("acp", {}) or {}
         plugins = data.get("plugins", {})
         identity = data.get("identity", {})
         # `or {}` (not a default arg): a section present but empty/commented in
@@ -887,6 +894,7 @@ class LangGraphConfig:
             operator_mcp_enabled=operator_mcp.get("enabled", cls.operator_mcp_enabled),
             operator_mcp_tools=list(operator_mcp.get("tools", []) or []),
             agent_runtime=str(data.get("agent_runtime", cls.agent_runtime) or "native"),
+            acp_agents=dict(acp.get("agents", {}) or {}),
             plugins_enabled=list(plugins.get("enabled", []) or []),
             plugins_disabled=list(plugins.get("disabled", []) or []),
             plugins_dir=plugins.get("dir", cls.plugins_dir),

--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -36,6 +36,7 @@ FROM_YAML_EXAMPLE_FIELDS = {
     "a2a_description": "",
     "a2a_require_routable_url": False,
     "a2a_skills": [],
+    "acp_agents": {},
     "agent_runtime": "native",
     "api_base": "http://gateway:4000/v1",
     "audit_middleware": True,


### PR DESCRIPTION
## What

`agent_runtime: acp:<agent>` routes a turn through a coding agent, but the per-agent **launch override** (`acp.agents.<name>.{command,args}`) was silently ignored: `LangGraphConfig` had no `acp_agents` attribute, so `runtime.acp_runtime.adapter_for` always fell back to the built-in default adapter — an `npx -y @agentclientprotocol/…` fetch — even when a locally-installed binary (`claude-agent-acp`, `codex-acp`) was configured. Slower cold-start + a network dependency on every ACP spawn.

## Change
- `graph/config.py`: new `acp_agents` dataclass field + `from_yaml` parse of the `acp: {agents: {...}}` block (`or {}` for the commented-empty case, matching the other sections).
- Kept **out of `settings_schema.FIELDS`** (advanced, machine-local launch knob, not a UI setting) → `config_to_dict` is unchanged, `CONFIG_TO_DICT_GOLDEN` untouched.
- `config/langgraph-config.example.yaml`: documents the block, commented (so it parses to `{}`).
- `tests/test_config_roundtrip.py`: `acp_agents: {}` added to the `from_yaml` field-map golden.

## Verified
```
acp.agents.claude: {command: claude-agent-acp} →
  adapter_for("claude") = {'command': 'claude-agent-acp', 'args': []}   # was npx default
```
`test_from_yaml_example_golden` passes.

> Note: `test_config_to_dict_golden` / `test_round_trip_preserves_emitted_fields` are **already red on main** (an `artifact` settings section is emitted but missing from the golden) — unrelated to this change; this PR neither causes nor fixes it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Configuration now supports per-agent ACP runtime adapter overrides with customizable command and arguments.

* **Documentation**
  * Added example configuration documenting ACP adapter setup for coding agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->