### PR TITLE
fix(fleet): _pick_port skips OS-occupied ports, not just fleet-known ones

### DIFF
--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -135,6 +135,26 @@ def _port_base() -> int:
     return PORT_BASE
 
 
+def _port_is_free(port: int) -> bool:
+    """True if 127.0.0.1:<port> can be bound right now — i.e. nothing (fleet OR an
+    unrelated process) is already listening.
+
+    ``_pick_port`` used to consider only fleet-registered ports, so it could hand out a
+    port already held by an UNRELATED instance (a dev server, another protoAgent fork on
+    the conventional :7871) — the spawned agent then died with ``EADDRINUSE`` at bind.
+    Probing the OS closes that gap. Best-effort: any bind failure reads as 'not free' (the
+    safe choice — skip it). A TOCTOU window remains between this check and the agent's own
+    bind, but it eliminates the common, durable collision."""
+    import socket
+
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        try:
+            s.bind(("127.0.0.1", port))
+            return True
+        except OSError:
+            return False
+
+
 def _pick_port(explicit: int | None) -> int:
     if explicit:
         return int(explicit)
@@ -148,10 +168,13 @@ def _pick_port(explicit: int | None) -> int:
             used.add(int(STATE.active_port))
     except Exception:  # noqa: BLE001 — best-effort; CLI/no-STATE context just skips it
         pass
-    p = _port_base() + 1
-    while p in used:
-        p += 1
-    return p
+    base = _port_base() + 1
+    # Skip registry-known ports AND OS-occupied ones (an unrelated process on the port).
+    # Bounded scan so a saturated range fails loudly instead of looping forever.
+    for p in range(base, base + 1000):
+        if p not in used and _port_is_free(p):
+            return p
+    raise WorkspaceError(f"no free port in {base}..{base + 999} — too many agents, or the range is occupied")
 
 
 _CONFIG_TEMPLATE = """\

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -11,6 +11,10 @@ from graph.workspaces import manager
 @pytest.fixture
 def root(tmp_path, monkeypatch):
     monkeypatch.setenv("PROTOAGENT_WORKSPACES_DIR", str(tmp_path / "ws"))
+    # Make port selection machine-independent: treat every port as OS-free, so _pick_port
+    # exercises only the registry logic (the OS probe is covered by its own test below —
+    # otherwise these assertions depend on whatever's listening on the test host).
+    monkeypatch.setattr(manager, "_port_is_free", lambda port: True)
     return tmp_path / "ws"
 
 
@@ -36,6 +40,21 @@ def test_new_ls_run_rm(root):
         manager.create("alpha")  # display-name collision
 
     assert "workspace" in manager.remove("alpha")["removed"] and not ws.exists()
+
+
+def test_pick_port_skips_os_occupied(root, monkeypatch):
+    """_pick_port skips a port held by an UNRELATED process (not just fleet-known ones), so
+    a spawned agent doesn't die with EADDRINUSE (the pokemonAgent-on-:7871 collision)."""
+    # 7871 is "occupied" by something outside the fleet registry → must be skipped.
+    monkeypatch.setattr(manager, "_port_is_free", lambda port: port != 7871)
+    assert manager.create("alpha")["port"] == 7872
+
+
+def test_pick_port_raises_when_range_saturated(root, monkeypatch):
+    """A fully-occupied range fails loudly instead of looping forever."""
+    monkeypatch.setattr(manager, "_port_is_free", lambda port: False)
+    with pytest.raises(manager.WorkspaceError):
+        manager.create("alpha")
 
 
 def test_rename_changes_display_not_id(root):


### PR DESCRIPTION
## What

`manager._pick_port` chose `fleet.port_base+1` considering only the **workspace registry** + the hub's own port — blind to **unrelated processes**. On a box also running a dev server or another protoAgent fork (the conventional `:7871`), it handed out an already-bound port and the spawned agent died at bind with `[Errno 48] EADDRINUSE`. (Hit live: a roxy-spawned team collided with a `pokemonAgent` fork on 7871.)

## Change
- `_port_is_free(port)`: a real `127.0.0.1` bind probe.
- `_pick_port`: bounded scan (`base..base+999`) skipping **both** registry-known and OS-occupied ports; raises `WorkspaceError` if saturated (was an unbounded `while` loop). A TOCTOU window vs the agent's own bind remains, but the common durable collision is eliminated.

## Tests
- Existing port-assertion tests pin `_port_is_free→True` in the shared fixture (machine-independent — they were implicitly assuming nothing listens on 7871/7872).
- +2: skips an OS-occupied port; raises on a saturated range. **8 pass; ruff clean.** Verified the probe detects a live vs. closed port.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace port assignment to detect and avoid ports already in use by other system processes, preventing port conflicts during workspace creation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->