### PR TITLE
test(config): isolate roundtrip goldens from dev-installed plugins

### DIFF
--- a/tests/test_config_roundtrip.py
+++ b/tests/test_config_roundtrip.py
@@ -15,6 +15,8 @@ import dataclasses
 import textwrap
 from pathlib import Path
 
+import pytest
+
 from graph.config import LangGraphConfig, SubagentDef
 from graph.config_io import (
     apply_updates_to_yaml,
@@ -23,6 +25,18 @@ from graph.config_io import (
 )
 
 EXAMPLE_PATH = "config/langgraph-config.example.yaml"
+
+
+@pytest.fixture(autouse=True)
+def _isolate_from_installed_plugins(monkeypatch):
+    """Freeze the CORE config surface, independent of whatever plugins a dev has installed.
+
+    ``from_yaml`` resolves ``plugin_config`` by DISCOVERING installed plugins (ADR 0019),
+    and ``config_to_dict`` reflects it — so a dev with any plugin under ``config/plugins/``
+    (dev-local, gitignored state) gets extra sections and these goldens spuriously fail,
+    while CI (no plugins installed) is green. Plugin-config resolution has its own tests;
+    here we pin it empty so the golden means the same thing everywhere."""
+    monkeypatch.setattr("graph.config._resolve_plugin_config", lambda *a, **k: {})
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

`test_config_to_dict_golden` / `test_round_trip_preserves_emitted_fields` are **non-deterministic w.r.t. a developer's installed plugins**. `from_yaml` resolves `plugin_config` by *discovering* installed plugins (ADR 0019), and `config_to_dict` reflects it — so any plugin under `config/plugins/` (dev-local, gitignored) adds a section the golden (the clean core surface) lacks, and the test fails **locally** even though **CI is green** (no plugins installed there).

This is a real papercut: it makes the local suite look broken when it isn't, and sends you hunting a phantom "pre-existing main failure." (Hit exactly this with a locally-installed `artifact` plugin.)

## Fix
An autouse fixture pins `_resolve_plugin_config → {}` so these goldens freeze the **core** config surface identically on every machine. Plugin-config discovery/resolution keeps its own coverage (`graph/plugins/pconfig` tests); this module isn't testing discovery.

## Verified
26 pass **with an `artifact` plugin still installed locally** (the previously-failing condition); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Configuration round-trip tests improved for consistency across development environments. Tests now operate independently of locally installed plugins, ensuring reliable and stable results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->