### PR TITLE
Fix: instance-scope the per-agent theme.json

### DIFF
--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -161,6 +161,15 @@ def secret_paths() -> tuple[tuple[str, str], ...]:
 _BASE_SETUP_MARKER = _LIVE_CONFIG_DIR / ".setup-complete"
 SETUP_MARKER_PATH = _config_scope(_BASE_SETUP_MARKER)
 
+# Per-agent console theme (ADR 0042). Like the config/secrets/setup-marker above,
+# it's a config-dir-relative store, so it MUST be instance-scoped too — otherwise
+# co-located instances that differ only by PROTOAGENT_INSTANCE (the default + the
+# scripts/dev.sh sandbox) share one theme.json and clobber each other's theme.
+# `_config_scope` keeps the explicit-PROTOAGENT_CONFIG_DIR carve-out (fleet member /
+# desktop sidecar: already the isolated leaf, don't double-scope).
+_BASE_THEME_JSON = _LIVE_CONFIG_DIR / "theme.json"
+THEME_JSON_PATH = _config_scope(_BASE_THEME_JSON)
+
 
 # ---------------------------------------------------------------------------
 # YAML round-trip

--- a/operator_api/theme_routes.py
+++ b/operator_api/theme_routes.py
@@ -18,9 +18,11 @@ log = logging.getLogger("protoagent.server")
 
 
 def _theme_path():
-    from graph.config_io import _live_config_dir
+    # Instance-scoped (ADR 0004), same as config/secrets — co-located instances
+    # (default + scripts/dev.sh sandbox) must not share one theme.json.
+    from graph.config_io import THEME_JSON_PATH
 
-    return _live_config_dir() / "theme.json"
+    return THEME_JSON_PATH
 
 
 def register_theme_routes(app) -> None:


### PR DESCRIPTION
Closes #1293.

## Problem

Per-agent themes (`/api/theme`, ADR 0042) were the **one** config-dir-relative store that wasn't instance-scoped. `_theme_path()` derived the file straight from `_live_config_dir()`:

```python
def _theme_path():
    from graph.config_io import _live_config_dir
    return _live_config_dir() / "theme.json"
```

…while config YAML, secrets, and the setup marker all go through `_config_scope(...)`. With `PROTOAGENT_INSTANCE` set and `PROTOAGENT_CONFIG_DIR` unset (the `scripts/dev.sh` sandbox), config/secrets land in `config/<instance>/…` but the theme fell back to the unscoped `config/theme.json` — **shared with the default instance**, so the two clobber each other's theme.

Observed live (dev sandbox on `:7871`, `PROTOAGENT_INSTANCE=dev`):

```
$ curl -s -X PUT http://localhost:7871/api/theme -d '{"mode":"dark","overrides":{}}'
{"ok":true}
$ find . -name theme.json -not -path '*/node_modules/*'
./config/theme.json          # ← unscoped; expected ./config/dev/theme.json
```

## Fix

Add a scoped path constant next to its siblings and route the theme path through it:

```python
# graph/config_io.py
_BASE_THEME_JSON = _LIVE_CONFIG_DIR / "theme.json"
THEME_JSON_PATH = _config_scope(_BASE_THEME_JSON)
```

```python
# operator_api/theme_routes.py
def _theme_path():
    from graph.config_io import THEME_JSON_PATH
    return THEME_JSON_PATH
```

Using `_config_scope` (not a bare `scope_leaf`) keeps the existing carve-out: when `PROTOAGENT_CONFIG_DIR` is set explicitly (desktop per-user dir, fleet per-workspace dir) the dir is already the isolated leaf and must not be scoped again.

## Behavior change

- **`PROTOAGENT_INSTANCE`-scoped instances:** now read/write `config/<instance>/theme.json` (isolated, as intended).
- **Unscoped default instance:** unchanged (`config/theme.json`).
- **Explicit `PROTOAGENT_CONFIG_DIR`:** unchanged (no double-scope).

No new import-layering edges (`operator_api` → `graph.config_io` already existed). Existing `tests/test_theme_routes.py` is unaffected: with no instance configured, `THEME_JSON_PATH` resolves to the same path as before.

## Testing
- `ruff check graph/config_io.py operator_api/theme_routes.py` — clean.
- Surfaced while dogfooding the template in a fork (per-instance theming during `scripts/dev.sh` testing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)