### PR TITLE
Sync the tab favicon + theme-color with the active per-agent theme

### DIFF
--- a/apps/web/src/lib/agentTheme.ts
+++ b/apps/web/src/lib/agentTheme.ts
@@ -52,10 +52,50 @@ export function applyAgentTheme(theme: unknown, animate = true) {
   }
 }
 
+// The tab favicon — mirrors apps/web/public/protolabs-icon-outline.svg, with the stroke
+// color injected at runtime. A static favicon SVG can't read the page's CSS vars (browsers
+// render it in an isolated context where `currentColor` resolves to black), so we rebuild a
+// data-URI whenever the theme changes. Keep the geometry in sync with the source asset.
+const faviconSvg = (color: string) =>
+  `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="protoLabs">` +
+  `<g transform="translate(224, 32) scale(-8, 8)" fill="none" stroke="${color}" stroke-width="2" ` +
+  `stroke-linecap="round" stroke-linejoin="round">` +
+  `<path d="M12 8V4H8"/><rect width="16" height="12" x="4" y="8" rx="2"/>` +
+  `<path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>` +
+  `</g></svg>`;
+
+/** Point the tab favicon + `<meta name="theme-color">` at the active theme's accent
+ *  (`--pl-color-accent`), so an agent/theme switch (ADR 0042) reaches the browser chrome
+ *  too — otherwise the tab stays the frozen brand default while the rest of the console
+ *  repaints. Fail-safe: bails if the var doesn't resolve, leaving the static default. */
+export function syncBrowserChrome() {
+  if (typeof document === "undefined") return;
+  const accent = getComputedStyle(root()).getPropertyValue("--pl-color-accent").trim();
+  if (!accent) return;
+
+  let icon = document.querySelector<HTMLLinkElement>('link[rel~="icon"]');
+  if (!icon) {
+    icon = document.createElement("link");
+    icon.rel = "icon";
+    document.head.appendChild(icon);
+  }
+  icon.type = "image/svg+xml";
+  icon.href = `data:image/svg+xml,${encodeURIComponent(faviconSvg(accent))}`;
+
+  let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (!meta) {
+    meta = document.createElement("meta");
+    meta.name = "theme-color";
+    document.head.appendChild(meta);
+  }
+  meta.content = accent;
+}
+
 // Broadcast a single `protoagent:theme` window event whenever the document's theme changes —
 // applyAgentTheme (switch/save/reset) AND the ThemePanel's live picker edits both mutate the
 // root's `style`/`data-theme`, so one MutationObserver catches everything. PluginView listens
-// and re-posts the theme to its iframe, so embedded plugin views repaint live too (ADR 0026/0042).
+// and re-posts the theme to its iframe, so embedded plugin views repaint live too (ADR 0026/0042);
+// the same hook keeps the tab favicon + theme-color on the active accent.
 let _watching = false;
 export function watchThemeChanges() {
   if (_watching || typeof window === "undefined") return;
@@ -63,9 +103,13 @@ export function watchThemeChanges() {
   let raf = 0;
   const fire = () => {
     cancelAnimationFrame(raf);
-    raf = requestAnimationFrame(() => window.dispatchEvent(new Event("protoagent:theme")));
+    raf = requestAnimationFrame(() => {
+      syncBrowserChrome();
+      window.dispatchEvent(new Event("protoagent:theme"));
+    });
   };
   new MutationObserver(fire).observe(root(), { attributes: true, attributeFilter: ["style", "data-theme"] });
+  syncBrowserChrome(); // initial sync — covers a theme applied before the observer was wired
 }
 
 /** The panel's current blob (what "Save to this agent" PUTs), or null if untouched. */

--- a/apps/web/src/lib/agentTheme.ts
+++ b/apps/web/src/lib/agentTheme.ts
@@ -54,8 +54,8 @@ export function applyAgentTheme(theme: unknown, animate = true) {
 
 // The tab favicon — mirrors apps/web/public/protolabs-icon-outline.svg, with the stroke
 // color injected at runtime. A static favicon SVG can't read the page's CSS vars (browsers
-// render it in an isolated context where `currentColor` resolves to black), so we rebuild a
-// data-URI whenever the theme changes. Keep the geometry in sync with the source asset.
+// render it in an isolated context where `currentColor` resolves to black), so when a theme
+// is active we swap in a recolored data-URI. Keep the geometry in sync with the source asset.
 const faviconSvg = (color: string) =>
   `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="protoLabs">` +
   `<g transform="translate(224, 32) scale(-8, 8)" fill="none" stroke="${color}" stroke-width="2" ` +
@@ -64,31 +64,79 @@ const faviconSvg = (color: string) =>
   `<path d="M2 14h2"/><path d="M20 14h2"/><path d="M15 13v2"/><path d="M9 13v2"/>` +
   `</g></svg>`;
 
+// Validate + normalize a CSS color before it's interpolated into SVG/markup. The accent comes
+// from the opaque, agent-supplied theme blob (--pl-color-accent), so a malformed or hostile
+// token must never reach the favicon data-URI or the meta tag. Returns null if it isn't a real
+// color, so callers bail instead of emitting broken markup.
+function safeColor(value: string): string | null {
+  const v = value.trim();
+  if (!v) return null;
+  if (typeof CSS !== "undefined" && typeof CSS.supports === "function" && !CSS.supports("color", v)) return null;
+  const probe = document.createElement("span");
+  probe.style.color = v; // the browser drops anything it can't parse as a color
+  return probe.style.color || null;
+}
+
+// Is a per-agent theme currently applied (vs. the shipped DS defaults)? The theme machinery
+// sets `data-theme` and inline `--pl-*` overrides on <html>; absent both, we leave index.html's
+// static favicon/meta in place (and the base-path regression guard that e2e/assets.spec.ts owns).
+function isThemed(): boolean {
+  const r = root();
+  if (r.hasAttribute("data-theme")) return true;
+  const s = r.style;
+  for (let i = 0; i < s.length; i++) if (s[i].startsWith("--pl-")) return true;
+  return false;
+}
+
+// Shipped defaults from index.html, snapshotted (raw attributes) before we first mutate them,
+// so clearing a theme restores the exact static favicon + brand theme-color.
+let _chromeDefaults: { iconHref: string | null; themeColor: string | null } | null = null;
+let _chromeThemed = false;
+
 /** Point the tab favicon + `<meta name="theme-color">` at the active theme's accent
- *  (`--pl-color-accent`), so an agent/theme switch (ADR 0042) reaches the browser chrome
- *  too — otherwise the tab stays the frozen brand default while the rest of the console
- *  repaints. Fail-safe: bails if the var doesn't resolve, leaving the static default. */
+ *  (`--pl-color-accent`), so an agent/theme switch (ADR 0042) reaches the browser chrome too —
+ *  otherwise the tab stays the frozen brand default while the rest of the console repaints.
+ *  With no theme active it leaves (or restores) index.html's static favicon. Fail-safe: bails
+ *  if the accent isn't a valid color. */
 export function syncBrowserChrome() {
   if (typeof document === "undefined") return;
-  const accent = getComputedStyle(root()).getPropertyValue("--pl-color-accent").trim();
+  const icon = document.querySelector<HTMLLinkElement>('link[rel~="icon"]');
+  const meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
+  if (!_chromeDefaults) {
+    _chromeDefaults = { iconHref: icon?.getAttribute("href") ?? null, themeColor: meta?.getAttribute("content") ?? null };
+  }
+
+  if (!isThemed()) {
+    // Restore the shipped static chrome only if WE themed it — otherwise don't touch the
+    // default favicon link at all (keeps it a real, fetchable asset, not a data-URI).
+    if (_chromeThemed) {
+      if (icon && _chromeDefaults.iconHref != null) icon.setAttribute("href", _chromeDefaults.iconHref);
+      if (meta && _chromeDefaults.themeColor != null) meta.setAttribute("content", _chromeDefaults.themeColor);
+      _chromeThemed = false;
+    }
+    return;
+  }
+
+  const accent = safeColor(getComputedStyle(root()).getPropertyValue("--pl-color-accent"));
   if (!accent) return;
 
-  let icon = document.querySelector<HTMLLinkElement>('link[rel~="icon"]');
-  if (!icon) {
-    icon = document.createElement("link");
-    icon.rel = "icon";
-    document.head.appendChild(icon);
+  let link = icon;
+  if (!link) {
+    link = document.createElement("link");
+    link.rel = "icon";
+    document.head.appendChild(link);
   }
-  icon.type = "image/svg+xml";
-  icon.href = `data:image/svg+xml,${encodeURIComponent(faviconSvg(accent))}`;
+  link.type = "image/svg+xml";
+  link.setAttribute("href", `data:image/svg+xml,${encodeURIComponent(faviconSvg(accent))}`);
 
-  let meta = document.querySelector<HTMLMetaElement>('meta[name="theme-color"]');
-  if (!meta) {
-    meta = document.createElement("meta");
-    meta.name = "theme-color";
-    document.head.appendChild(meta);
+  let mc = meta;
+  if (!mc) {
+    mc = document.createElement("meta");
+    mc.name = "theme-color";
+    document.head.appendChild(mc);
   }
-  meta.content = accent;
+  mc.setAttribute("content", accent);
+  _chromeThemed = true;
 }
 
 // Broadcast a single `protoagent:theme` window event whenever the document's theme changes —


### PR DESCRIPTION
Closes #1295.

## Problem

The per-agent theme (`/api/theme`, ADR 0042) repaints the whole console on an agent switch, but the **browser tab** didn't follow. The favicon and `theme-color` were hard-coded to the brand default:

```html
<!-- apps/web/index.html -->
<meta name="theme-color" content="#9b87f2" />
<link rel="icon" type="image/svg+xml" href="%BASE_URL%protolabs-icon-outline.svg" />
```
```xml
<!-- apps/web/public/protolabs-icon-outline.svg -->
<g ... stroke="#9b87f2" ...>
```

So every agent/theme looked identical in the tab strip, and PWA / mobile browser chrome was always lavender.

## Fix

Add `syncBrowserChrome()` in `apps/web/src/lib/agentTheme.ts`. It reads the resolved accent (`getComputedStyle(root).getPropertyValue('--pl-color-accent')`), rebuilds the favicon as a recolored `data:image/svg+xml` URI, and updates `<meta name="theme-color">`.

It's wired into the **existing** `watchThemeChanges()` MutationObserver — the single broadcast point that already fires `protoagent:theme` on every theme change (agent switch, save/reset, and the ThemePanel's live picker edits) — so no new event plumbing. One initial sync covers a theme applied before the observer was wired. Fail-safe: if `--pl-color-accent` doesn't resolve, it bails and the static default stands.

A static favicon SVG can't solve this on its own: browsers render the favicon in an isolated context, so `currentColor` resolves to black rather than the page's CSS vars — the accent has to be injected at runtime, hence the data-URI rebuild.

## Notes / tradeoffs
- The favicon geometry is embedded in the helper (a comment points back at `public/protolabs-icon-outline.svg`) so the recolor stays synchronous — no fetch, no async ordering against the theme apply, no failure mode for a tab icon. Keep the two in sync if the mark changes.
- `theme-color` / SVG accept any CSS color, so themes whose accent is `oklch(...)` (DS defaults, some presets) carry through on engines that support it and degrade gracefully elsewhere.
- `index.html` is unchanged — its static favicon + meta remain the correct pre-JS default.

## Testing
- `tsc -p tsconfig.json --noEmit` — clean.
- Surfaced while dogfooding the template in a fork (per-agent theming — the tab not following the theme was the visible tell).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Browser tab appearance (favicon and theme color) now automatically synchronizes with your active app theme for a more cohesive look.
  * When the app theme changes, updates are applied with validation and promptly reflected in the tab chrome.
  * If no theme is currently active, the tab’s original favicon and theme color are restored when previously modified.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->