### PR TITLE
fix(acp): reap coding-agent subprocesses — kill the process group, hard-stop on cancel

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **ACP coding-agent subprocesses no longer leak as orphaned processes.** `delegate_to`
+  and the delegate health prober spawn CLI coding agents (`codex-acp`, `claude-agent-acp`,
+  …) over ACP, but teardown signalled only the direct child — the backend each adapter
+  spawns reparented to init and survived — and `dispatch` awaited a *pooled* client that
+  it never reaped on cancel, so stopping a turn left the agent running ("I stopped the
+  main thread and the delegate didn't stop"). Over days these piled up to hundreds of
+  `ppid 1` orphans holding ~20 GB. Now the agent is spawned in its own process group and
+  teardown SIGTERM→SIGKILLs the whole group; `dispatch` hard-kills + drops the pooled
+  client synchronously on cancel; the `_start` handshake self-reaps if it fails or is
+  cancelled mid-flight (the prober's probe-timeout path); and a shutdown hook drains every
+  pooled client so a server stop strands nothing.
 - **Dialogs no longer render their content cramped flush to the body edge.** The shared
   DS dialog defaulted to a tight 16px body padding, and roomier dialogs (MCP catalog,
   New-skill) each hand-added a 24px override — so every newly-converted dialog (the

--- a/plugins/coding_agent/__init__.py
+++ b/plugins/coding_agent/__init__.py
@@ -121,6 +121,30 @@ def _client_for(spec: dict) -> AcpClient:
     return client
 
 
+def _drop_client(spec: dict) -> AcpClient | None:
+    """Synchronously pop the cached client for ``spec`` (no await) and return it, so
+    a cancellation handler can ``kill_now()`` it and remove it from the pool without
+    risking that an awaited teardown is itself cancelled. Returns None if none cached."""
+    return _CLIENTS.pop(_cache_key(spec), None)
+
+
+async def close_all() -> bool:
+    """Reap EVERY cached ACP client + its subprocess tree — the shutdown hook so a
+    server stop doesn't strand pooled ``delegate_to`` agents as init-reparented
+    orphans (the leak that piled up to ~20 GB). Idempotent; returns True if any were
+    closed."""
+    clients = list(_CLIENTS.values())
+    _CLIENTS.clear()
+    closed = False
+    for client in clients:
+        try:
+            await client.close()
+            closed = True
+        except Exception:  # noqa: BLE001 — shutdown reap is best-effort
+            log.warning("[coding_agent] close during close_all failed", exc_info=True)
+    return closed
+
+
 async def evict_client(spec: dict) -> bool:
     """Drop the cached client for ``spec`` AND terminate its subprocess.
 

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -26,10 +26,12 @@ Surface:
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import json
 import logging
 import os
 import re
+import signal
 from pathlib import Path
 from typing import Awaitable, Callable
 
@@ -204,6 +206,12 @@ class AcpClient:
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
                 env={**os.environ, **(self.env or {})},
+                # Put the agent in its OWN session/process group so teardown can kill
+                # the WHOLE tree (the adapter *and* the backend it spawns). Without
+                # this, terminate() signals only the adapter; its child reparents to
+                # init and leaks — the codex-acp / claude-agent-acp orphan pile that
+                # piled up to ~20 GB. POSIX-only (start_new_session ⇒ setsid()).
+                start_new_session=True,
                 # Raise the per-line buffer ceiling — ACP messages exceed the 64 KB
                 # default and would otherwise raise LimitOverrunError (kills the turn).
                 limit=_STDOUT_LINE_LIMIT,
@@ -211,10 +219,18 @@ class AcpClient:
         except FileNotFoundError as exc:
             raise AcpError(f"agent binary not found: {self.command!r} (is it installed and on PATH?)") from exc
 
-        self._reader_task = asyncio.create_task(self._read_loop())
-        self._stderr_task = asyncio.create_task(self._drain_stderr())
-        await self._initialize()
-        await self._open_session()
+        # The subprocess now exists. If the handshake raises OR the caller's wait_for
+        # cancels us mid-initialize (the health prober's 45s probe timeout), reap the
+        # tree we just spawned instead of leaking it — close() is idempotent.
+        try:
+            self._reader_task = asyncio.create_task(self._read_loop())
+            self._stderr_task = asyncio.create_task(self._drain_stderr())
+            await self._initialize()
+            await self._open_session()
+        except BaseException:
+            with contextlib.suppress(Exception):
+                await self.close()
+            raise
         logger.info(
             "[acp/%s] up (pid=%s, session=%s, cwd=%s)",
             self.name,
@@ -223,32 +239,61 @@ class AcpClient:
             self.cwd,
         )
 
+    @staticmethod
+    def _signal_group(proc: asyncio.subprocess.Process, sig: int) -> None:
+        """Send ``sig`` to the subprocess's whole process GROUP (the agent plus the
+        backend it spawned), falling back to the bare process if the group is already
+        gone. Synchronous syscall + swallows ProcessLookup, so it's safe to call from
+        a teardown/cancel path where the event loop won't run our coroutines."""
+        try:
+            os.killpg(os.getpgid(proc.pid), sig)
+        except (ProcessLookupError, PermissionError, OSError):
+            with contextlib.suppress(ProcessLookupError, OSError):
+                proc.send_signal(sig)
+
+    def kill_now(self) -> None:
+        """Synchronously SIGKILL the agent's whole process group — no awaits, so it's
+        safe from a CancelledError handler where awaiting cleanup would itself be
+        cancelled. The zombie is reaped later by ``proc.wait()`` / the child watcher.
+        Use this on the hard-stop path (operator stops the turn); ``close()`` is the
+        graceful one."""
+        proc = self._proc
+        if proc and proc.returncode is None:
+            self._signal_group(proc, signal.SIGKILL)
+        for task in (self._reader_task, self._stderr_task):
+            if task and not task.done():
+                task.cancel()
+
     async def close(self) -> None:
-        """Cancel the I/O tasks and reap the subprocess. Crucially this ``await``s
+        """Cancel the I/O tasks and reap the subprocess TREE. Crucially this ``await``s
         ``proc.wait()`` so the child is reaped *while the loop is alive* — without
         it the subprocess transport lingers and its ``__del__`` fires after the loop
         closes ("Event loop is closed"), and the stderr-drain task leaks.
 
         Sends a best-effort ``session/close`` first — the graceful, spec-aligned
-        shutdown (and what matters if an agent ever serves multiple sessions per
-        process) before the SIGTERM that actually frees this one-process-per-session."""
-        await self._close_session()
+        shutdown — then SIGTERM→SIGKILL the agent's whole PROCESS GROUP, not just the
+        direct child, so the backend it spawned dies with it instead of reparenting to
+        init. The kill is a synchronous syscall, so even if this runs on a cancelled
+        task the tree still dies."""
+        with contextlib.suppress(Exception):
+            await self._close_session()
         for task in (self._reader_task, self._stderr_task):
             if task and not task.done():
                 task.cancel()
         proc = self._proc
         if proc and proc.returncode is None:
+            self._signal_group(proc, signal.SIGTERM)
             try:
-                proc.terminate()
                 await asyncio.wait_for(proc.wait(), timeout=5.0)
             except asyncio.TimeoutError:
-                try:
-                    proc.kill()
+                self._signal_group(proc, signal.SIGKILL)
+                with contextlib.suppress(Exception):
                     await proc.wait()
-                except ProcessLookupError:
-                    pass
-            except ProcessLookupError:
-                pass
+            except asyncio.CancelledError:
+                # We're being torn down — guarantee the tree is dead, then let the
+                # cancellation propagate (don't swallow it).
+                self._signal_group(proc, signal.SIGKILL)
+                raise
         # Close the subprocess transport too, so its pipe transports don't linger to
         # a post-loop-close GC — reaping the process (above) leaves the stdin write-
         # pipe transport open, whose __del__ then fires "Event loop is closed".

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -362,7 +362,13 @@ class AcpAdapter(Adapter):
                 placeholder="proto",
                 help="Binary on PATH that speaks ACP (e.g. proto). For Claude Code use `claude-code` — an alias for the claude-agent-acp adapter.",
             ),
-            FieldSpec("args", "Args", "args", placeholder="--acp", help="Launch args (e.g. --acp). Leave empty for claude-code."),
+            FieldSpec(
+                "args",
+                "Args",
+                "args",
+                placeholder="--acp",
+                help="Launch args (e.g. --acp). Leave empty for claude-code.",
+            ),
             FieldSpec(
                 "workdir",
                 "Workdir",
@@ -438,7 +444,7 @@ class AcpAdapter(Adapter):
 
     async def dispatch(self, d: Delegate, query: str, *, timeout: float | None = None) -> str:
         # Reuse the ADR 0024 ACP client + by-kind permission policy.
-        from plugins.coding_agent import _client_for, _make_permission
+        from plugins.coding_agent import _client_for, _drop_client, _make_permission
         from plugins.coding_agent.acp_client import AcpError
 
         spec = self._spec(d)
@@ -446,6 +452,15 @@ class AcpAdapter(Adapter):
         client._permission = _make_permission(spec)
         try:
             return await client.prompt(query, timeout=timeout or d.timeout_s)
+        except asyncio.CancelledError:
+            # The turn was stopped (operator hit stop, or an orchestrator watchdog
+            # fired). The client is POOLED, so without this its subprocess keeps
+            # running detached — exactly "I stopped the main thread and the delegate
+            # didn't stop". Drop it from the pool + SIGKILL the agent tree NOW
+            # (synchronous, no awaits — we're mid-cancellation) before re-raising.
+            _drop_client(spec)
+            client.kill_now()
+            raise
         except AcpError as exc:
             raise DelegateError(str(exc))
 

--- a/plugins/delegates/health.py
+++ b/plugins/delegates/health.py
@@ -79,3 +79,12 @@ async def stop() -> None:
     if _task and not _task.done():
         _task.cancel()
     _task = None
+    # Server shutdown: reap every pooled ACP client so dispatch agents don't strand
+    # as init-reparented orphans. (This surface's stop() is the delegates plugin's
+    # process-scoped shutdown hook.)
+    try:
+        from plugins.coding_agent import close_all
+
+        await close_all()
+    except Exception:  # noqa: BLE001 — shutdown reap is best-effort
+        log.exception("[delegates/health] reaping ACP clients on shutdown failed")

--- a/tests/test_acp_reaping.py
+++ b/tests/test_acp_reaping.py
@@ -1,0 +1,148 @@
+"""Regression tests for ACP subprocess reaping — the orphan leak.
+
+`delegate_to` / the health prober spawn CLI coding agents (codex-acp, claude-agent-acp)
+over ACP. Two bugs leaked their processes until ~20 GB of `ppid 1` orphans piled up:
+
+  1. teardown signalled only the DIRECT child, so the backend the adapter spawned
+     reparented to init and survived (no process-group kill);
+  2. `dispatch` awaited a POOLED client and never reaped it on cancel, so stopping the
+     turn left the agent running ("I stopped the main thread and the delegate didn't
+     stop").
+
+These tests pin the fixes: a spawned grandchild dies with the group, the cancel path
+hard-kills synchronously, and the shutdown hook drains the whole pool.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+import subprocess
+
+import pytest
+
+from plugins.coding_agent.acp_client import AcpClient
+
+
+def _alive(pid: int) -> bool:
+    """True if ``pid`` is a live (non-zombie) process."""
+    try:
+        os.kill(pid, 0)
+    except ProcessLookupError:
+        return False
+    except PermissionError:
+        return True
+    # Exists, but a zombie/defunct is effectively dead — distinguish via ps.
+    out = subprocess.run(["ps", "-o", "stat=", "-p", str(pid)], capture_output=True, text=True).stdout.strip()
+    return bool(out) and not out.startswith("Z")
+
+
+async def _wait_dead(*pids: int, timeout: float = 5.0) -> None:
+    for _ in range(int(timeout / 0.1)):
+        if not any(_alive(p) for p in pids):
+            return
+        await asyncio.sleep(0.1)
+
+
+async def _spawn_group_with_grandchild() -> tuple[asyncio.subprocess.Process, int]:
+    """A parent shell in its OWN process group that backgrounds a grandchild ``sleep``
+    (the stand-in for the adapter's backend), prints the grandchild pid, then waits."""
+    proc = await asyncio.create_subprocess_exec(
+        "sh",
+        "-c",
+        "sleep 300 & echo $! ; wait",
+        stdin=asyncio.subprocess.PIPE,
+        stdout=asyncio.subprocess.PIPE,
+        stderr=asyncio.subprocess.PIPE,
+        start_new_session=True,  # same isolation _start() now uses
+    )
+    line = await asyncio.wait_for(proc.stdout.readline(), timeout=5)
+    return proc, int(line.decode().strip())
+
+
+def _client_holding(proc: asyncio.subprocess.Process) -> AcpClient:
+    client = AcpClient("sh", ["-c", "true"], cwd="/tmp", name="reap-test")
+    client._proc = proc  # bypass the ACP handshake — we only exercise teardown
+    return client
+
+
+@pytest.mark.asyncio
+async def test_close_reaps_whole_process_group():
+    """close() must kill the backend the agent spawned, not just the agent."""
+    proc, grandchild = await _spawn_group_with_grandchild()
+    assert _alive(proc.pid) and _alive(grandchild)
+
+    await _client_holding(proc).close()
+
+    await _wait_dead(proc.pid, grandchild)
+    assert not _alive(grandchild), "grandchild leaked — process-group kill regressed"
+    assert not _alive(proc.pid)
+
+
+@pytest.mark.asyncio
+async def test_kill_now_is_synchronous_and_reaps_group():
+    """kill_now() is the cancel-path hard stop: no awaits, whole group dies."""
+    proc, grandchild = await _spawn_group_with_grandchild()
+    assert _alive(proc.pid) and _alive(grandchild)
+
+    _client_holding(proc).kill_now()  # synchronous — no await
+
+    await _wait_dead(proc.pid, grandchild)
+    assert not _alive(grandchild), "grandchild survived kill_now — group SIGKILL regressed"
+    assert not _alive(proc.pid)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_hard_reaps_on_cancel(monkeypatch):
+    """A cancelled dispatch must drop the pooled client AND kill its agent tree —
+    otherwise the subprocess keeps running detached after the turn is stopped."""
+    import plugins.coding_agent as ca
+    from plugins.delegates.adapters import ADAPTERS
+
+    killed = {"now": False}
+    dropped: list = []
+
+    class _FakeClient:
+        _permission = None
+
+        async def prompt(self, *a, **k):
+            raise asyncio.CancelledError()
+
+        def kill_now(self):
+            killed["now"] = True
+
+    fake = _FakeClient()
+    monkeypatch.setattr(ca, "_client_for", lambda spec: fake)
+    monkeypatch.setattr(ca, "_make_permission", lambda spec: None)
+    monkeypatch.setattr(ca, "_drop_client", lambda spec: dropped.append(spec))
+
+    d = ADAPTERS["acp"].parse({"name": "coder", "type": "acp", "command": "proto", "workdir": "/tmp"})
+    with pytest.raises(asyncio.CancelledError):
+        await ADAPTERS["acp"].dispatch(d, "do a thing")
+
+    assert killed["now"], "dispatch did not hard-kill the agent tree on cancel"
+    assert dropped, "dispatch did not drop the dead client from the pool on cancel"
+
+
+@pytest.mark.asyncio
+async def test_close_all_drains_the_pool():
+    """The shutdown hook reaps every pooled client and clears the cache."""
+    import plugins.coding_agent as ca
+
+    closed: list[str] = []
+
+    class _FakeClient:
+        def __init__(self, name):
+            self.name = name
+
+        async def close(self):
+            closed.append(self.name)
+
+    ca._CLIENTS.clear()
+    ca._CLIENTS[("a",)] = _FakeClient("a")
+    ca._CLIENTS[("b",)] = _FakeClient("b")
+
+    assert await ca.close_all() is True
+    assert sorted(closed) == ["a", "b"]
+    assert ca._CLIENTS == {}
+    assert await ca.close_all() is False  # idempotent


### PR DESCRIPTION
## The leak

`delegate_to` and the delegate **health prober** spawn CLI coding agents (`codex-acp`, `claude-agent-acp`, `@zed-industries/codex-acp`, …) over ACP. Two subprocess-lifecycle bugs leaked these processes until **hundreds of `ppid 1` orphans piled up holding ~20 GB** (observed live across three running instances):

1. **No process group.** `close()` did `proc.terminate()` on the *direct* child only — the node ACP adapter. The backend that adapter spawns reparented to `init`/`launchd` and survived. Every probe/dispatch could leak its grandchild.
2. **`dispatch()` never reaped on cancel.** It awaits a **pooled, long-lived** `AcpClient`; on external cancel it only sent a soft `session/cancel` and re-raised, leaving the agent subprocess running. This is exactly *"I stopped the main thread and the delegate didn't stop."*
3. **Probe-timeout orphan.** The prober probes each agent with a 45s `wait_for`; a timeout cancelled `_start` *after* the subprocess was already spawned but before the handshake completed — orphaning it with no `self._proc` reap.

## The fix

- **Process-group isolation + group kill.** Spawn ACP agents with `start_new_session=True`; `close()` now `SIGTERM`→`SIGKILL`s the whole group via `os.killpg`. Grandchildren die with the agent.
- **Synchronous hard-stop on cancel.** New `AcpClient.kill_now()` — a group `SIGKILL` with **no awaits**, safe from a `CancelledError` handler. `dispatch()` drops the pooled client (`_drop_client`) and `kill_now()`s its tree before re-raising.
- **Self-reaping handshake.** `_start()` `close()`s the just-spawned tree if the handshake raises or is cancelled mid-flight.
- **Shutdown drain.** `coding_agent.close_all()`, wired into the `delegate-health` surface's `stop()`, reaps every pooled client on server shutdown.

## Tests

`tests/test_acp_reaping.py` — spawns a **real grandchild** and proves it dies with the group (fails against the old `terminate()`-only path, since `sh`'s SIGTERM doesn't reach a backgrounded child), that `kill_now` is synchronous, that a cancelled `dispatch` hard-reaps + drops the pooled client, and that `close_all` drains the pool.

Gates: `ruff check` ✓ · `ruff format --check` ✓ · `lint-imports` (3 kept, 0 broken) ✓ · delegates/coding/acp suites + new tests: **89 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed issue where ACP agent subprocesses could become orphaned and continue running after client termination
  * Improved handling of cancellation operations to ensure complete process cleanup
  * Enhanced shutdown logic to properly terminate process groups and free resources

* **Tests**
  * Added regression tests for subprocess lifecycle management and process cleanup

<!-- end of auto-generated comment: release notes by coderabbit.ai -->