### PR TITLE
fix(acp): initialize-only health probe + strip nested-Claude env + round-trip logging

### DIFF
--- a/docs/adr/0024-spawn-cli-coding-agents-acp.md
+++ b/docs/adr/0024-spawn-cli-coding-agents-acp.md
@@ -20,6 +20,15 @@ lifecycle:
   launch signature), `session/close` on teardown, real `protocolVersion`
   negotiation (closes if the agent counters with an unsupported version), and
   `agent_thought_chunk` surfaced as the reasoning trace.
+- **#1296 / #1300** — launch + probe hardening. The ACP launch env now **strips the
+  nested-Claude markers** (`CLAUDECODE` / `CLAUDE_CODE_*`) so a `claude-agent-acp`
+  backend doesn't hit the "inside another Claude Code session" guard when protoAgent
+  itself runs inside a Claude session (the dogfooding case); the round-trip
+  (`initialize` → session → `session/prompt` → `request_permission`) is now logged so
+  an idle freeze is diagnosable. A new `AcpClient.handshake()` runs **`initialize`
+  only** (no `session/new`/`session/load`), and the delegate health prober uses it —
+  so a status probe is genuinely cheap + side-effect-free instead of opening a real
+  session every 120s.
 
 Validated end-to-end against both `proto --acp` and Claude Code (via
 `@zed-industries/claude-code-acp`) — the client is agent-agnostic. See the

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -76,12 +76,16 @@ don't have to know the incantation. (The older `@zed-industries/claude-code-acp`
 `command: claude` directly does **not** work — `claude` isn't an ACP server, and the
 probe will tell you so.
 
-> **Caveat:** the adapter launches the `claude` binary, which **refuses to start
-> nested inside another Claude Code session** (`Error: Claude Code cannot be launched
-> inside another Claude Code session`). Run protoAgent from a normal shell / the
-> desktop app — not from within a `claude` session — when using the Claude Code agent.
-> (If you must run nested, strip `CLAUDECODE` + `CLAUDE_CODE_*` from protoAgent's
-> environment at launch — e.g. `env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT …`.)
+> **Nested Claude:** the adapter launches the `claude` binary, which **refuses to
+> start nested inside another Claude Code session** (`Error: Claude Code cannot be
+> launched inside another Claude Code session`). protoAgent now **strips the
+> nested-session markers** (`CLAUDECODE` and the whole `CLAUDE_CODE_*` family) from
+> the ACP launch env automatically ([#1296](https://github.com/protoLabsAI/protoAgent/issues/1296)),
+> so launching protoAgent from *within* a `claude` session — the dogfooding case —
+> works without the manual `env -u …` dance. (Partial strips were the footgun: missing
+> just one of `CLAUDE_CODE_SESSION_ID` / `CLAUDE_CODE_ENTRYPOINT` / … still tripped the
+> guard, so the agent respawned every ~2 min with no surfaced error.) A value you set
+> explicitly in the delegate `env` still wins.
 
 **Codex has no native ACP mode either.** Recent `codex` CLI (≥ 0.13x) dropped the
 `acp` subcommand — it speaks **MCP** natively, not ACP, so `command: codex, args:
@@ -141,9 +145,10 @@ Action kinds come from the ACP request (`toolCall.kind`: `read` / `edit` /
 
 ### Environment
 
-The subprocess **inherits protoAgent's environment** (plus any per-delegate `env`).
-Run protoAgent under an account whose ambient credentials you're willing to lend the
-coding agent, or scope the `workdir` to a throwaway checkout.
+The subprocess **inherits protoAgent's environment** (plus any per-delegate `env`),
+**minus** the nested-Claude markers (`CLAUDECODE` / `CLAUDE_CODE_*`) — see the caveat
+above. Run protoAgent under an account whose ambient credentials you're willing to lend
+the coding agent, or scope the `workdir` to a throwaway checkout.
 
 ## How it works
 

--- a/docs/guides/delegates.md
+++ b/docs/guides/delegates.md
@@ -26,7 +26,10 @@ MCP, and Subagents). The panel:
 - **lists** your delegates with a type badge, a `secret set` / `⚠ unconfigured`
   marker, a **live health dot** (a background prober probes each delegate
   periodically — green reachable / red down / grey not-yet-checked), and a per-row
-  **Test** button for an on-demand probe;
+  **Test** button for an on-demand probe. For an `acp` (coding-agent) delegate the
+  probe runs only the ACP `initialize` handshake — **not** a session — so it's cheap
+  and side-effect-free, never opening a thread against the agent on a timer
+  ([#1300](https://github.com/protoLabsAI/protoAgent/issues/1300));
 - **adds** one via a **type picker** (A2A agent / Model endpoint / Coding agent)
   and a form generated from each type's field schema;
 - **edits / deletes** existing ones; secrets you enter are routed to

--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -112,6 +112,31 @@ _STDOUT_LINE_LIMIT = 32 * 1024 * 1024  # 32 MB
 # resolved auth (ACP `AUTH_REQUIRED`). The client surfaces an actionable message.
 AUTH_REQUIRED = -32000
 
+# Env markers Claude Code sets so a nested `claude` can detect "am I already running
+# inside another Claude Code session?". When protoAgent's own server was launched from
+# within a Claude Code session (the dogfooding case), these are inherited — and the
+# claude-agent-acp backend we spawn then hits the *"cannot be launched inside another
+# Claude Code session"* guard, evicting + respawning every ~2 min with zero progress
+# and no surfaced error (#1296). Stripped from the ACP launch env: ``CLAUDECODE`` plus
+# the whole ``CLAUDE_CODE_*`` family (SESSION_ID / CHILD_SESSION / EXECPATH / ENTRYPOINT
+# / …). Harmless for non-Claude agents (proto/codex don't read them).
+_NESTED_CLAUDE_ENV_EXACT = frozenset({"CLAUDECODE"})
+_NESTED_CLAUDE_ENV_PREFIX = "CLAUDE_CODE_"
+
+
+def _launch_env(extra: dict[str, str] | None) -> dict[str, str]:
+    """Build the subprocess environment for an ACP agent: the server's own ``os.environ``
+    with the nested-Claude markers stripped (see above), then the delegate's ``env``
+    overlaid last — so an operator who *deliberately* sets one of these in the delegate
+    env still wins."""
+    env = {
+        k: v
+        for k, v in os.environ.items()
+        if k not in _NESTED_CLAUDE_ENV_EXACT and not k.startswith(_NESTED_CLAUDE_ENV_PREFIX)
+    }
+    env.update(extra or {})
+    return env
+
 
 class AcpError(Exception):
     """Any ACP transport / protocol failure. The caller speaks the message.
@@ -189,12 +214,26 @@ class AcpClient:
     # -- lifecycle -----------------------------------------------------------
 
     async def _ensure_started(self) -> None:
+        """Start the agent for a real dispatch: spawn + ``initialize`` + open the
+        session (reattach or new). Idempotent — a no-op when already up."""
         async with self._start_lock:
             if self._proc is not None and self._proc.returncode is None:
                 return
             await self._start()
 
-    async def _start(self) -> None:
+    async def handshake(self) -> None:
+        """Start the agent for a *liveness check only*: spawn + run the ACP
+        ``initialize`` round-trip and STOP — no ``session/new``, no ``session/load``,
+        no session state touched. The genuinely cheap, side-effect-free probe the
+        health prober wants (#1300; the old probe went through ``_ensure_started``,
+        which also opened a real session every 120s). The caller ``close()``s it.
+        Idempotent — a no-op when already up."""
+        async with self._start_lock:
+            if self._proc is not None and self._proc.returncode is None:
+                return
+            await self._start(open_session=False)
+
+    async def _start(self, *, open_session: bool = True) -> None:
         if not Path(self.cwd).is_dir():
             raise AcpError(f"workdir does not exist: {self.cwd}")
         try:
@@ -205,7 +244,10 @@ class AcpClient:
                 stdin=asyncio.subprocess.PIPE,
                 stdout=asyncio.subprocess.PIPE,
                 stderr=asyncio.subprocess.PIPE,
-                env={**os.environ, **(self.env or {})},
+                # Strip the inherited nested-Claude markers (CLAUDECODE / CLAUDE_CODE_*)
+                # so a spawned Claude backend doesn't refuse to launch "inside another
+                # Claude Code session" (#1296); the delegate's env is overlaid last.
+                env=_launch_env(self.env),
                 # Put the agent in its OWN session/process group so teardown can kill
                 # the WHOLE tree (the adapter *and* the backend it spawns). Without
                 # this, terminate() signals only the adapter; its child reparents to
@@ -226,7 +268,10 @@ class AcpClient:
             self._reader_task = asyncio.create_task(self._read_loop())
             self._stderr_task = asyncio.create_task(self._drain_stderr())
             await self._initialize()
-            await self._open_session()
+            # The probe path (handshake) stops here — a liveness check must NOT open a
+            # session. A real dispatch opens (reattaches or news) the session.
+            if open_session:
+                await self._open_session()
         except BaseException:
             with contextlib.suppress(Exception):
                 await self.close()
@@ -434,8 +479,18 @@ class AcpClient:
         method = msg.get("method")
         rid = msg.get("id")
         if method == "session/request_permission":
+            params = msg.get("params") or {}
             resolver = self._permission or self._auto_allow
-            option_id = resolver(msg.get("params") or {})
+            option_id = resolver(params)
+            # Trace the decision — a permission the resolver can't answer (→ cancelled)
+            # can leave the agent blocked, a prime suspect for the idle freeze (#1296).
+            kind = str(((params.get("toolCall") or {}).get("kind") or "")).lower()
+            logger.info(
+                "[acp/%s] request_permission kind=%s → %s",
+                self.name,
+                kind or "?",
+                "selected" if option_id else "cancelled",
+            )
             outcome = {"outcome": "selected", "optionId": option_id} if option_id else {"outcome": "cancelled"}
             await self._respond(rid, {"outcome": outcome})
         else:
@@ -580,6 +635,16 @@ class AcpClient:
                     f"client so their ACP versions match."
                 )
             self._protocol_version = negotiated
+        # Log the handshake outcome so the ACP round-trip (initialize → session →
+        # prompt → permission → result) is traceable from the server log — an idle
+        # freeze with no diagnostics is the hard-to-debug half of #1296.
+        logger.info(
+            "[acp/%s] initialize OK (protocol v%s, loadSession=%s, authMethods=%d)",
+            self.name,
+            self._protocol_version,
+            bool(self._agent_capabilities.get("loadSession")),
+            len(self._auth_methods),
+        )
 
     async def _open_session(self) -> None:
         """Reattach the persisted session when possible, else start a fresh one.
@@ -698,6 +763,13 @@ class AcpClient:
         self._on_tool = tool_callback
         self._on_text = text_callback
         self._on_thought = thought_callback
+        logger.info(
+            "[acp/%s] → session/prompt (session=%s, %d chars, timeout=%ss)",
+            self.name,
+            self._session_id,
+            len(text),
+            int(timeout),
+        )
         try:
             result = await self._request(
                 "session/prompt",

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -488,13 +488,17 @@ class AcpAdapter(Adapter):
         return await forget_session(self._spec(d))
 
     async def probe(self, d: Delegate) -> dict:
-        """Reachability check for the panel's Test button.
+        """Reachability check for the panel's Test button (also the periodic health
+        prober's per-delegate check).
 
         Does a REAL ACP `initialize` handshake (spawn the command, complete the
-        protocol handshake, close — no session/prompt), so a launch command that's
-        on PATH and workdir-valid but doesn't actually speak ACP FAILS the probe
-        instead of showing green (issue #1116 — the old PATH+workdir check passed
-        `command: claude` while every dispatch failed with an opaque `agent exited`).
+        protocol handshake, close) — and NOTHING more: no `session/new`, no
+        `session/load`, no `session/prompt`. So a launch command that's on PATH and
+        workdir-valid but doesn't actually speak ACP FAILS the probe instead of
+        showing green (issue #1116 — the old PATH+workdir check passed `command:
+        claude` while every dispatch failed with an opaque `agent exited`), while a
+        probe stays genuinely cheap + side-effect-free: it never opens a session every
+        120s the way the old `_ensure_started` path did (#1300).
         """
         import asyncio
         import os
@@ -522,13 +526,14 @@ class AcpAdapter(Adapter):
         if not os.path.isdir(wd):
             return {"ok": False, "error": f"workdir does not exist: {wd}"}
 
-        # Real handshake. `_ensure_started` spawns the agent and runs ACP `initialize`
-        # (it does NOT open a session), so it's a cheap, side-effect-free liveness check.
+        # Real handshake — `handshake()` spawns the agent and runs ACP `initialize`
+        # ONLY (no session/new, no session/load), so it's a cheap, genuinely
+        # side-effect-free liveness check (#1300).
         from plugins.coding_agent.acp_client import AcpClient
 
         client = AcpClient(command=d.command, args=d.args, cwd=wd, env=(d.env or None), name=d.name)
         try:
-            await asyncio.wait_for(client._ensure_started(), timeout=45)
+            await asyncio.wait_for(client.handshake(), timeout=45)
         except asyncio.TimeoutError:
             return {"ok": False, "error": f"ACP handshake timed out — does {d.command!r} speak ACP?"}
         except Exception as exc:  # noqa: BLE001 — spawn/handshake failure → tool-visible string

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -131,6 +131,74 @@ async def test_close_reaps_the_subprocess(fake_agent, tmp_path):
     assert client._stderr_task is not None and client._stderr_task.done()  # not leaked
 
 
+# ── handshake-only liveness check + launch-env hygiene ────────────────────────
+
+# Records (to a marker) every CLAUDECODE / CLAUDE_CODE_* var visible in its env at
+# initialize time, so a test can prove the launch env stripped the inherited ones.
+_ENV_PROBE_AGENT = r"""
+import sys, json, os
+MARKER = os.environ.get("ENV_MARKER", "")
+def send(obj):
+    sys.stdout.write(json.dumps(obj) + "\n"); sys.stdout.flush()
+while True:
+    line = sys.stdin.readline()
+    if not line:
+        break
+    line = line.strip()
+    if not line:
+        continue
+    msg = json.loads(line)
+    if msg.get("method") == "initialize":
+        leaked = sorted(k for k in os.environ if k == "CLAUDECODE" or k.startswith("CLAUDE_CODE_"))
+        if MARKER:
+            with open(MARKER, "w") as fh:
+                fh.write(json.dumps(leaked))
+        send({"jsonrpc": "2.0", "id": msg.get("id"), "result": {"protocolVersion": 1}})
+"""
+
+
+async def test_handshake_runs_initialize_without_opening_a_session(fake_agent, tmp_path):
+    """handshake() runs ONLY the ACP initialize round-trip — no session/new or
+    session/load — so the health prober's liveness check is genuinely
+    side-effect-free (#1300). The process is up and initialize negotiated, but no
+    session id was ever assigned."""
+    client = AcpClient(sys.executable, [str(fake_agent)], cwd=str(tmp_path), name="probe")
+    try:
+        await client.handshake()
+        assert client._proc is not None and client._proc.returncode is None  # up
+        assert client._protocol_version == 1  # initialize completed
+        assert client._session_id is None  # but NO session was opened
+    finally:
+        await client.close()
+
+
+async def test_launch_env_strips_inherited_nested_claude_markers(tmp_path, monkeypatch):
+    """The ACP launch env strips the inherited CLAUDECODE / CLAUDE_CODE_* markers so a
+    spawned Claude backend doesn't refuse to launch "inside another Claude Code
+    session" (#1296) — but a value explicitly set in the delegate env still wins."""
+    script = tmp_path / "env_agent.py"
+    script.write_text(_ENV_PROBE_AGENT, encoding="utf-8")
+    marker = tmp_path / "env.marker"
+    monkeypatch.setenv("CLAUDECODE", "1")
+    monkeypatch.setenv("CLAUDE_CODE_SESSION_ID", "parent-sess")
+    monkeypatch.setenv("CLAUDE_CODE_ENTRYPOINT", "cli")
+    client = AcpClient(
+        sys.executable,
+        [str(script)],
+        cwd=str(tmp_path),
+        name="env",
+        # ENV_MARKER survives (not a CLAUDE_CODE_* var); the explicit CHILD_SESSION
+        # overlays the (stripped) inherited markers and must reach the child.
+        env={"ENV_MARKER": str(marker), "CLAUDE_CODE_CHILD_SESSION": "keepme"},
+    )
+    try:
+        await client.handshake()
+    finally:
+        await client.close()
+    leaked = json.loads(marker.read_text(encoding="utf-8"))
+    assert leaked == ["CLAUDE_CODE_CHILD_SESSION"]  # inherited stripped, explicit kept
+
+
 async def test_acp_client_readonly_policy_denies_edit(fake_agent, tmp_path):
     # A readonly policy must reject the fake's `edit` permission request — the
     # client picks the reject_once option, which the fake echoes back.

--- a/tests/test_delegates_api.py
+++ b/tests/test_delegates_api.py
@@ -128,15 +128,15 @@ def test_test_endpoint_acp_probe(client, monkeypatch):
 
     from plugins.coding_agent.acp_client import AcpClient
 
-    # The acp probe now does a real ACP `initialize` handshake (#1116), so mock it —
-    # the python exe is on PATH + /tmp exists, but it doesn't speak ACP for real.
+    # The acp probe does a real ACP `initialize`-only handshake (#1116/#1300), so mock
+    # it — the python exe is on PATH + /tmp exists, but it doesn't speak ACP for real.
     async def _ok(self):
         self._protocol_version = 1
 
     async def _noop(self):
         pass
 
-    monkeypatch.setattr(AcpClient, "_ensure_started", _ok)
+    monkeypatch.setattr(AcpClient, "handshake", _ok)
     monkeypatch.setattr(AcpClient, "close", _noop)
     r = client.post(
         "/api/delegates/test", json={"name": "t", "type": "acp", "command": sys.executable, "workdir": "/tmp"}
@@ -170,7 +170,7 @@ def test_test_endpoint_probes_saved_delegate_by_name(client, monkeypatch):
     async def _noop(self):
         pass
 
-    monkeypatch.setattr(AcpClient, "_ensure_started", _ok)
+    monkeypatch.setattr(AcpClient, "handshake", _ok)
     monkeypatch.setattr(AcpClient, "close", _noop)
     client.post("/api/delegates", json={"name": "proto", "type": "acp", "command": sys.executable, "workdir": "/tmp"})
     r = client.post("/api/delegates/test", json={"name": "proto", "type": "acp"})

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -98,7 +98,7 @@ async def test_acp_probe_fails_when_handshake_fails(monkeypatch):
     async def _noop(self):
         pass
 
-    monkeypatch.setattr(AcpClient, "_ensure_started", _boom)
+    monkeypatch.setattr(AcpClient, "handshake", _boom)
     monkeypatch.setattr(AcpClient, "close", _noop)
     d = ADAPTERS["acp"].parse({"name": "x", "type": "acp", "command": sys.executable, "workdir": "/tmp"})
     res = await ADAPTERS["acp"].probe(d)
@@ -116,7 +116,7 @@ async def test_acp_probe_ok_on_successful_handshake(monkeypatch):
     async def _noop(self):
         pass
 
-    monkeypatch.setattr(AcpClient, "_ensure_started", _ok)
+    monkeypatch.setattr(AcpClient, "handshake", _ok)
     monkeypatch.setattr(AcpClient, "close", _noop)
     d = ADAPTERS["acp"].parse({"name": "x", "type": "acp", "command": sys.executable, "workdir": "/tmp"})
     res = await ADAPTERS["acp"].probe(d)


### PR DESCRIPTION
Hardens the ACP delegate launch + probe path. Closes #1300 and #1296.

## #1300 — health probe was opening a real session every 120s
The delegate health prober calls `AcpAdapter.probe` for every `acp` delegate on a 120s timer. The probe documented itself as a cheap, side-effect-free `initialize`-only liveness check, but it went through `AcpClient._ensure_started()` → `_start()`, which runs **both** `_initialize()` **and** `_open_session()` — spawning a full coding-agent backend and opening a real `session/new`/`session/load` (touching persisted session state, #970) every sweep.

- New `AcpClient.handshake()` runs the ACP `initialize` round-trip **only** (`_start(open_session=False)`), then leaves the process for the caller to `close()`.
- `AcpAdapter.probe` now uses `handshake()`. The probe is genuinely cheap + side-effect-free, and still distinguishes "speaks ACP" from "on PATH but not an ACP agent" (#1116's false-green guard is intact).

## #1296 — ACP `delegate_to` hangs
**Mode 1 (respawn loop):** when protoAgent's server is itself launched from inside a Claude Code session, the spawned `claude-agent-acp` backend inherits `CLAUDECODE` / `CLAUDE_CODE_*` and hits the "cannot be launched inside another Claude Code session" guard — respawning every ~2 min with no surfaced error. The partial-strip footgun (missing one of `CLAUDE_CODE_SESSION_ID` / `_ENTRYPOINT` / …) made the manual workaround fragile.
- `_launch_env()` strips the whole marker family from the launch env automatically. An explicit value in the delegate `env` still wins (overlaid last).

**Mode 2 (idle freeze):** the prompt was never processed and the only signal was an eventual timeout, with nothing logged.
- Added round-trip logging at INFO: `initialize OK (protocol/loadSession/auth)` → `→ session/prompt (session, chars, timeout)` → `request_permission kind=… → selected|cancelled`. A stalled prompt or an unanswerable permission (a prime freeze suspect) is now visible in the server log.

## Tests
- `test_handshake_runs_initialize_without_opening_a_session` — wire-level: `handshake()` negotiates `initialize` but assigns no `session_id` and opens no session.
- `test_launch_env_strips_inherited_nested_claude_markers` — wire-level: inherited `CLAUDECODE`/`CLAUDE_CODE_*` are stripped, an explicit delegate-env marker survives.
- Existing probe tests repointed `_ensure_started` → `handshake` (`test_delegates_plugin.py`, `test_delegates_api.py`).

## Docs
- `docs/guides/coding-agents.md` — nested-Claude caveat now describes the auto-strip; Environment section notes the minus-markers behavior.
- `docs/guides/delegates.md` — health dot note: acp probe is `initialize`-only.
- ADR 0024 — update bullet for #1296/#1300.

## Gates (local)
`ruff check .` ✓ · `lint-imports` ✓ (3 kept, 0 broken) · `pytest tests/` ✓ (2286 passed) · `live_smoke.py` ✓

## Follow-up
The Tauri-sidecar `PATH` half of #1299 (and the probe-honors-`d.env`-PATH secondary) lands in a separate PR — it touches the same `probe()` block and is desktop-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed nested Claude Code marker stripping to allow agents to run inside Claude Code sessions without environment conflicts.

* **New Features**
  * Improved health checks for coding agents with lightweight, side-effect-free probes.
  * Enhanced diagnostic logging for initialization, session workflows, and permission handling.

* **Documentation**
  * Updated guides explaining nested Claude Code behavior, health check mechanics, and delegate configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->