### PR TITLE
fix(desktop): give the sidecar the user's real PATH; probe honors delegate env PATH

### DIFF
--- a/apps/desktop/src-tauri/src/lib.rs
+++ b/apps/desktop/src-tauri/src/lib.rs
@@ -33,6 +33,59 @@ fn pick_free_port() -> u16 {
 #[derive(Default)]
 struct SidecarProcess(Mutex<Option<CommandChild>>);
 
+/// Split a `:`-delimited PATH string and append each new, non-empty dir to `entries`,
+/// preserving order and skipping duplicates.
+#[cfg(target_os = "macos")]
+fn dedup_push_path(entries: &mut Vec<String>, raw: &str) {
+    for dir in raw.split(':') {
+        if !dir.is_empty() && !entries.iter().any(|e| e == dir) {
+            entries.push(dir.to_string());
+        }
+    }
+}
+
+/// Ask the user's interactive login shell for its `PATH`
+/// (`$SHELL -ilc 'printf %s "$PATH"'`). `None` if `$SHELL` is unknown, the shell
+/// errors, or it returns nothing — callers fall back to a fixed prefix.
+#[cfg(target_os = "macos")]
+fn login_shell_path() -> Option<String> {
+    let shell = std::env::var("SHELL").unwrap_or_else(|_| "/bin/zsh".to_string());
+    let output = std::process::Command::new(&shell)
+        .args(["-ilc", "printf %s \"$PATH\""])
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    let path = String::from_utf8_lossy(&output.stdout).trim().to_string();
+    if path.is_empty() {
+        None
+    } else {
+        Some(path)
+    }
+}
+
+/// The PATH to hand the bundled sidecar on macOS. A GUI app launched from
+/// Finder/Dock/`launchd` only inherits `launchd`'s minimal PATH
+/// (`/usr/bin:/bin:/usr/sbin:/sbin`), so Homebrew (`/opt/homebrew/bin`), nvm, Volta,
+/// and asdf bin dirs — where `npx`, `node`, and ACP coding-agent adapters live — are
+/// invisible to the server, and a delegate launch command like `npx` fails with
+/// "binary not on PATH" (#1299). Compose: the login-shell PATH (covers nvm/Volta/asdf),
+/// then the common Homebrew/local dirs (belt-and-suspenders if shell resolution failed),
+/// then whatever the process already inherited (never drop a dir that already worked).
+#[cfg(target_os = "macos")]
+fn augmented_sidecar_path() -> String {
+    let mut entries: Vec<String> = Vec::new();
+    if let Some(shell_path) = login_shell_path() {
+        dedup_push_path(&mut entries, &shell_path);
+    }
+    dedup_push_path(&mut entries, "/opt/homebrew/bin:/usr/local/bin");
+    if let Ok(existing) = std::env::var("PATH") {
+        dedup_push_path(&mut entries, &existing);
+    }
+    entries.join(":")
+}
+
 /// Launch the bundled protoAgent server (console UI tier) as a sidecar.
 ///
 /// The frozen binary is read-only, so its writable state (live config,
@@ -60,7 +113,8 @@ fn spawn_sidecar<R: Runtime>(app: &AppHandle<R>, port: u16) {
         }
     };
     let port_arg = port.to_string();
-    let command = command
+    #[allow(unused_mut)] // `mut` is only used on the macOS PATH branch below.
+    let mut command = command
         // The desktop renders the React operator console, so run the server in
         // its 'console' UI tier (API + A2A + console, no Gradio) — ADR 0010.
         // (Was the now-deprecated --headless / PROTOAGENT_HEADLESS alias.)
@@ -70,6 +124,14 @@ fn spawn_sidecar<R: Runtime>(app: &AppHandle<R>, port: u16) {
         // onefile's child process otherwise outlives us, holding its port).
         .env("PROTOAGENT_PARENT_PID", std::process::id().to_string())
         .env("PROTOAGENT_CONFIG_DIR", config_dir.to_string_lossy().to_string());
+
+    // A Finder/Dock/launchd launch strips PATH down to launchd's minimal set, hiding
+    // Homebrew/nvm/Volta/asdf — so delegate launch commands (`npx`, ACP adapters) fail
+    // with "binary not on PATH" (#1299). Hand the sidecar the user's real PATH.
+    #[cfg(target_os = "macos")]
+    {
+        command = command.env("PATH", augmented_sidecar_path());
+    }
 
     let (mut rx, child) = match command.spawn() {
         Ok(pair) => pair,

--- a/docs/guides/coding-agents.md
+++ b/docs/guides/coding-agents.md
@@ -66,6 +66,20 @@ The binary must be installed and on the `PATH` of the process running protoAgent
 The delegates panel's **Test** button performs a real ACP `initialize` handshake — so
 a wrong launch command **fails the probe** instead of showing green (it's not just a
 missing-binary check). A misconfigured delegate surfaces at Test, not at first dispatch.
+The probe resolves the command against the **same** PATH the spawn uses — the process
+PATH with the delegate's `env` PATH overlaid — so probe and dispatch never disagree.
+
+::: warning macOS desktop app & `PATH`
+A GUI app launched from Finder/Dock/`launchd` inherits only `launchd`'s minimal `PATH`
+(`/usr/bin:/bin:/usr/sbin:/sbin`), **not** your login-shell `PATH` — so Homebrew
+(`/opt/homebrew/bin`), nvm, Volta, and asdf installs (where `npx`/`node`/ACP adapters
+live) are invisible, and a `command: npx` delegate fails with `binary not on PATH`
+([#1299](https://github.com/protoLabsAI/protoAgent/issues/1299)). The desktop build now
+hands the bundled server your real login-shell `PATH`, so this works out of the box.
+If you still hit it (an unusual shell setup), either set an **absolute** `command`
+(`/opt/homebrew/bin/npx`) or add a `PATH` to the delegate **`env`** — both pass the
+probe too. The web app (terminal-launched server) is unaffected.
+:::
 
 **Claude Code has no native ACP mode.** Drive it through the
 [`claude-agent-acp`](https://www.npmjs.com/package/@agentclientprotocol/claude-agent-acp)

--- a/docs/guides/react-tauri-ui.md
+++ b/docs/guides/react-tauri-ui.md
@@ -128,6 +128,12 @@ frozen build bundles the `plugins/` tree and `--collect-all`s `tools`/`websocket
 plugin, ADR 0058, can only import what's bundled). Signed macOS DMG / Linux AppImage+deb /
 Windows NSIS artifacts + an in-app updater ship from the desktop-build CI on release tags.
 
+On macOS, `spawn_sidecar` augments the sidecar's `PATH` with the user's login-shell `PATH`
+(via `$SHELL -ilc`, plus the Homebrew/local fallbacks) before spawning. A Finder/Dock launch
+otherwise inherits only `launchd`'s minimal `PATH`, so `npx`/`node`/ACP coding-agent adapters
+would be invisible and a `delegate_to` ACP launch would fail with `binary not on PATH`
+([#1299](https://github.com/protoLabsAI/protoAgent/issues/1299)).
+
 ## Testing the console
 
 A Playwright smoke suite (`apps/web/e2e/`) drives the **built** SPA against a deterministic

--- a/plugins/delegates/adapters.py
+++ b/plugins/delegates/adapters.py
@@ -511,7 +511,14 @@ class AcpAdapter(Adapter):
                     "command: claude-code (an alias) or claude-agent-acp."
                 ),
             }
-        if not shutil.which(d.command):
+        # Resolve the command against the SAME PATH the real spawn will use — the
+        # delegate's env PATH overlaid on the process PATH — not just os.environ.
+        # The actual ACP launch merges d.env (acp_client `_launch_env`/`env=…`), so a
+        # delegate that supplies its own PATH (or runs under the desktop app's
+        # augmented PATH) would spawn fine, yet the probe's bare `shutil.which` still
+        # red-X'd it. Probe and spawn now agree on where to look (#1299).
+        merged_path = (d.env or {}).get("PATH") or os.environ.get("PATH")
+        if not shutil.which(d.command, path=merged_path):
             if os.path.basename(d.command) == "claude-agent-acp":
                 return {
                     "ok": False,

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -123,6 +123,28 @@ async def test_acp_probe_ok_on_successful_handshake(monkeypatch):
     assert res["ok"] is True and "handshake OK" in res["detail"]
 
 
+async def test_acp_probe_resolves_command_against_delegate_env_path(monkeypatch):
+    # The probe must resolve the command against the SAME PATH the real spawn uses —
+    # the delegate's env PATH overlaid on the process PATH — so a command reachable
+    # only via the delegate env doesn't red-X the Test button while the spawn would
+    # actually find it (#1299 probe-vs-spawn disagreement).
+    import shutil
+
+    seen: dict = {}
+
+    def fake_which(cmd, path=None):
+        seen["path"] = path
+        return None  # force the not-on-PATH branch (so we never spawn a real process)
+
+    monkeypatch.setattr(shutil, "which", fake_which)
+    d = ADAPTERS["acp"].parse(
+        {"name": "x", "type": "acp", "command": "npx", "workdir": "/tmp", "env": {"PATH": "/custom/bin"}}
+    )
+    res = await ADAPTERS["acp"].probe(d)
+    assert res["ok"] is False and "not on PATH" in res["error"]
+    assert seen["path"] == "/custom/bin"  # resolved against the delegate's env PATH
+
+
 def test_secret_value_wins_then_env(monkeypatch):
     assert _secret({"token": "explicit"}, "token", "credentialsEnv") == "explicit"
     monkeypatch.setenv("MY_TOK", "fromenv")


### PR DESCRIPTION
Closes #1299. Two halves of the same "probe and spawn disagree about where to find the launch binary" problem.

## Primary — macOS desktop app strips `PATH`
A Tauri app launched from Finder/Dock/`launchd` inherits only `launchd`'s minimal `PATH` (`/usr/bin:/bin:/usr/sbin:/sbin`), **not** the user's login-shell `PATH`. So Homebrew (`/opt/homebrew/bin`), nvm, Volta, and asdf bin dirs — where `npx`, `node`, and ACP coding-agent adapters live — are invisible to the bundled server, and a `command: npx` delegate fails with `binary not on PATH`. The web app (terminal-launched) is unaffected because it inherits the interactive shell `PATH`.

`spawn_sidecar` (`apps/desktop/src-tauri/src/lib.rs`) now augments the sidecar's `PATH` before `.spawn()`:
1. the **login-shell `PATH`** (`$SHELL -ilc 'printf %s "$PATH"'`) — covers nvm/Volta/asdf and any custom setup,
2. the common **Homebrew/local** dirs (`/opt/homebrew/bin`, `/usr/local/bin`) as a belt-and-suspenders fallback,
3. then whatever the process already inherited (never drop a dir that already worked).

macOS-only (`#[cfg(target_os = "macos")]`); other platforms are untouched.

## Secondary — probe ignored the delegate's `env`
The actual ACP spawn merges `d.env` over the process env, but `AcpAdapter.probe` checked `shutil.which(d.command)` against `os.environ` only — so a delegate that set its own `PATH` (the documented workaround) spawned fine yet the **Test** button still red-X'd it. The probe now resolves against the merged PATH: `shutil.which(d.command, path=(d.env or {}).get("PATH") or os.environ.get("PATH"))`. Probe and spawn now agree.

## Verification
- `cargo check` ✓ (the 2 `FALLBACK_PORT` / `pick_free_port` dead-code warnings are pre-existing — the desktop pins port 7870).
- `pytest` ✓ — new `test_acp_probe_resolves_command_against_delegate_env_path` asserts the probe passes the delegate's env `PATH` to `shutil.which`.
- `ruff` ✓ · `lint-imports` ✓ · `live_smoke.py` ✓.
- **The macOS stripped-`PATH` behavior only manifests in a real `.app` launch** — CI can't reproduce it. Worth a smoke test on a packaged build (or `cargo tauri dev`) launched from Finder before relying on it.

## Relationship to #1301
Stacked conceptually on #1301 (closes #1300/#1296). They touch the same `probe()` but different lines (this changes the `shutil.which` guard; #1301 changes the handshake call) — merges cleanly in either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed command resolution for delegates in macOS desktop app environments by ensuring the correct PATH configuration is available when launching delegate processes, improving support for tools like npx.

* **Documentation**
  * Updated guides to explain PATH handling in macOS desktop applications and provided recommendations for configuring delegate command environments to ensure proper command resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->