### PR TITLE
test(chat-e2e): cover the ✕-cancel of a queued steer (closes #1103)

### DIFF
--- a/apps/web/e2e/chat-steer-cancel.spec.ts
+++ b/apps/web/e2e/chat-steer-cancel.spec.ts
@@ -1,0 +1,39 @@
+import { expect, test } from "@playwright/test";
+
+// Mid-turn steering ✕-cancel (#1103, shipped in #1104). While a turn streams, a
+// message the user submits is QUEUED as a steer (folds into the agent's work at its
+// next model call) and shown as a dimmed pending bubble with a ✕. Clicking the ✕
+// must dequeue it server-side (DELETE /api/chat/sessions/{id}/steer/{msgId}) and drop
+// the bubble — so a cancelled steer never reaches the agent. The DS `Message queued`
+// renders `.pl-message--queued` + a "Cancel queued message" button (@protolabsai/ui).
+
+test("✕ on a queued steer dequeues it and removes the pending bubble", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await expect(composer).toBeVisible();
+
+  // Start a turn the mock HOLDS OPEN, so the surface stays "streaming" — the state
+  // where Enter queues a steer instead of sending a fresh turn.
+  await composer.fill("hold the turn open");
+  await composer.press("Enter");
+
+  // The composer flips to its steering placeholder once the turn is running.
+  const steerComposer = page.getByPlaceholder(/Steer the agent/i);
+  await expect(steerComposer).toBeVisible();
+
+  // Queue a steer → an optimistic dimmed bubble with a ✕ appears.
+  await steerComposer.fill("actually, do X instead");
+  await steerComposer.press("Enter");
+  const queued = page.locator(".pl-message--queued");
+  await expect(queued).toHaveText(/do X instead/);
+
+  // Clicking ✕ must hit the dequeue endpoint — prove it, not just the optimistic drop.
+  const deleted = page.waitForRequest(
+    (r) => r.method() === "DELETE" && /\/api\/chat\/sessions\/[^/]+\/steer\/[^/]+$/.test(r.url()),
+  );
+  await page.getByRole("button", { name: "Cancel queued message" }).click();
+  await deleted;
+
+  // The bubble is gone — the steer was cancelled before the agent saw it.
+  await expect(page.locator(".pl-message--queued")).toHaveCount(0);
+});

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -279,6 +279,18 @@ async function handleA2AStream(req, res, body) {
     "cache-control": "no-cache",
     connection: "keep-alive",
   });
+  // A turn a spec can HOLD OPEN: stream only the opening frames (so the surface
+  // enters its "streaming" / steering state) and never the terminal frame, until
+  // the client disconnects. Lets the mid-turn steering ✕-cancel e2e (#1103) keep a
+  // turn running deterministically instead of racing the ~40ms-gapped frames.
+  if (/hold the turn open/i.test(prompt)) {
+    for (const frame of frames.slice(0, 2)) {
+      res.write(`data: ${JSON.stringify(frame)}\r\n\r\n`);
+      await new Promise((r) => setTimeout(r, 40));
+    }
+    await new Promise((resolve) => req.on("close", resolve));
+    return res.end();
+  }
   for (const frame of frames) {
     // CRLF frame separator — the a2a-sdk emits SSE with `\r\n\r\n`, not `\n\n`.
     // The mock must mirror that so this e2e exercises the real wire shape: an
@@ -392,6 +404,11 @@ const server = createServer(async (req, res) => {
     if (/^\/api\/chat\/sessions\/[^/]+\/steer$/.test(pathname) && req.method === "POST") {
       const body = await readBody(req);
       return sendJson(res, { ok: true, id: body.id ?? null, pending: 0 });
+    }
+    // Mid-turn steering cancel (the ✕ on a queued bubble) — dequeue still-queued.
+    // `removed: true` is the happy path the #1103 e2e drives (cancel before drain).
+    if (/^\/api\/chat\/sessions\/[^/]+\/steer\/[^/]+$/.test(pathname) && req.method === "DELETE") {
+      return sendJson(res, { removed: true, pending: 0 });
     }
     if (pathname === "/api/knowledge/attach" && req.method === "POST") {
       // Chat attachment upload (#1002) — multipart, so DON'T JSON-parse the body.


### PR DESCRIPTION
Closes #1103.

#1103's feature — cancelling a still-queued mid-turn steer via the ✕ on its pending bubble — was actually **shipped in #1104**: the backend `dequeue()` + `DELETE /api/chat/sessions/{id}/steer/{msgId}` → `{removed, pending}`, `api.cancelSteer`, and the wired `onCancel` (optimistic bubble-drop, `settleConsumed` reconcile when `removed:false`, error-restore). It's covered by unit tests (`tests/test_steering.py` dequeue-before/after-drain, `tests/test_chat_routes.py` the DELETE route). The issue stayed open because the **last acceptance item — an e2e that clicks the ✕ — was never added.** This PR adds it and closes the issue out.

## What's here
- **`mock-server.mjs`** — two additive, guarded hooks:
  - a `hold the turn open` prompt streams the opening `task`/`working` frames then holds the SSE open (never the terminal frame), so the surface stays in its `streaming`/steering state deterministically — no racing the ~40ms-gapped frames.
  - a `DELETE /api/chat/sessions/{id}/steer/{msgId}` handler returning `{removed:true, pending:0}` (the cancel-before-drain happy path).
- **`chat-steer-cancel.spec.ts`** — start a held turn → queue a steer (asserts the dimmed `.pl-message--queued` bubble) → click **Cancel queued message** → assert the `DELETE` request fires **and** the bubble disappears (the steer never reaches the agent).

## Verification (local, against a fresh `npm run build`)
- `chat-steer-cancel` ✓
- chat e2e batch (`chat`, `chat-continuity`, `chat-bottom-dock`, `chat-delete`, `chat-steer-cancel`) — 10 passed (mock change is additive/guarded; no regressions)
- `test:unit --workspace @protoagent/web` — 115 passed

No `src/` or `dist/` changes — e2e-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for chat steering functionality, including validation of mid-turn steering cancellation and stream state management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->