### PR TITLE
chore: release v0.67.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.67.0] - 2026-06-22
+
 ### Added
 - **Per-agent ACP launch overrides are honored.** `acp.agents.<name>.{command,args}` is
   now parsed (it was silently dropped — `LangGraphConfig` had no `acp_agents` field), so an

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.66.0"
+version = "0.67.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "v0.67.0",
+    "date": "2026-06-22",
+    "changes": [
+      "Per-agent ACP launch overrides are honored.",
+      "ACP delegate health probe is initialize-only — it no longer opens a session every 120s.",
+      "macOS desktop app finds Homebrew/nvm/Volta/asdf-installed binaries.",
+      "Workspace port assignment skips OS-occupied ports.",
+      "The per-agent theme is instance-scoped.",
+      "The browser tab favicon + theme-color follow the active per-agent theme.",
+      "ACP coding-agent subprocesses no longer leak as orphaned processes.",
+      "Dialogs no longer render their content cramped flush to the body edge.",
+      "Coding-agents guide: Codex needs the codex-acp adapter."
+    ]
+  },
+  {
     "version": "v0.66.0",
     "date": "2026-06-21",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.67.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.67.0 -m 'Release v0.67.0' && git push origin v0.67.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * ACP launch overrides
  * ACP delegate probe behavior
  * macOS binary discovery
  * Workspace port assignment
  * Per-agent theme behavior
  * Favicon and theme-color syncing

* **Bug Fixes**
  * Fixed ACP subprocess orphan leak
  * Improved dialog layout spacing

* **Improvements**
  * Enhanced Codex adapter support

<!-- end of auto-generated comment: release notes by coderabbit.ai -->