### PR TITLE
ci(web-e2e): cache Playwright browsers + timeout/retry the install (fixes #1167)

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -151,8 +151,37 @@ jobs:
         # the uiStore persist migration). Fast — runs before the heavier
         # Playwright path so a reducer regression fails the job early.
         run: npm run test:unit --workspace @protoagent/web
-      - name: Install Playwright chromium
-        run: npm --workspace @protoagent/web exec -- playwright install --with-deps chromium
+      - name: Resolve Playwright version
+        id: pw
+        run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
+      - name: Cache Playwright browsers
+        id: pw-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}
+      - name: Install Playwright browser + deps
+        # The chromium binary is the slow ~100MB CDN download that intermittently
+        # stalled ~10min until the job-level orphan-kill fired (#1167). Cache it keyed
+        # on the Playwright version (skips the download entirely on a hit — only the
+        # fast apt system-deps run then), and hard-cap each attempt with `timeout` so
+        # a stalled download fails fast and retries instead of hanging the whole job.
+        timeout-minutes: 8
+        run: |
+          if [ "${{ steps.pw-cache.outputs.cache-hit }}" = "true" ]; then
+            cmd="playwright install-deps chromium"   # binary cached → apt deps only
+          else
+            cmd="playwright install --with-deps chromium"
+          fi
+          for attempt in 1 2 3; do
+            if timeout 240 npm --workspace @protoagent/web exec -- $cmd; then
+              exit 0
+            fi
+            echo "::warning::playwright install attempt $attempt stalled/failed; retrying…"
+            sleep 5
+          done
+          echo "::error::playwright install failed after 3 attempts"
+          exit 1
       - name: Run E2E smoke (built SPA vs mock backend)
         # Builds the web app, then drives it with Playwright against the
         # deterministic mock backend (apps/web/e2e/mock-server.mjs) — no Python,


### PR DESCRIPTION
Closes #1167.

The **Web E2E smoke** job ran `playwright install --with-deps chromium` on every run with no cache, no timeout, and no retry — so a stalled CDN download for the ~100MB chromium binary hung the step ~10 min until the job-level orphan-kill fired (`Terminate orphan process … playwright install`). A recurring false-red that masked real E2E signal and cost a manual `gh run rerun --failed` each hit (recurred on #1158/#1161/#1164 this week).

## Fix (stacks suggestions 1 + 2 from the issue)
- **Cache** `~/.cache/ms-playwright` keyed on the resolved Playwright version (`@playwright/test` 1.60.0). On a cache hit the slow binary download is skipped entirely — only the fast apt system-deps run (`playwright install-deps chromium`).
- **Timeout + retry**: each attempt is hard-capped with `timeout 240` and retried up to 3×, so a stalled download fails fast and self-heals instead of hanging to the ~10 min orphan-kill. Step capped at `timeout-minutes: 8`.

## Verification
YAML validated locally. The behavior is CI-only — **this PR's own run is the first exercise**: it's a cache *miss* (full `--with-deps` install, populates the cache), and subsequent runs on the same Playwright version hit the cache. No app code touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced end-to-end testing pipeline with optimized browser installation, caching mechanisms, and improved error recovery to ensure faster and more reliable test execution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->