### PR TITLE
fix(console): disable rail panel-toggle buttons when the rail is empty (#1234)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Empty-rail panel toggles fully disable.** The utility-bar left/right panel-toggle buttons are now greyed out and non-interactive when their rail holds no views (matching the bottom-dock toggle), instead of appearing active but doing nothing when clicked. (#1234)
+
 ## [0.67.0] - 2026-06-22
 
 ### Added

--- a/apps/web/e2e/layout.spec.ts
+++ b/apps/web/e2e/layout.spec.ts
@@ -89,3 +89,27 @@ test("the bottom-panel toggle sits with the layout buttons, gated until a surfac
   // Disabled by default — nothing is docked at the bottom (railOrder.bottom is empty).
   await expect(toggleBottom).toBeDisabled();
 });
+
+// #1234: each rail toggle is gated on whether its rail holds any views — the same
+// gate the bottom toggle already had, extended to left/right. In the default layout
+// the left rail (chat/knowledge) and right rail (work + the boardy "scratch" right
+// panel) are populated, so their toggles stay ENABLED and interactive; only the
+// empty bottom dock is disabled. This pins that the gate doesn't over-disable a
+// populated rail. (An empty left/right rail can't be seeded in this harness — the
+// on-mount core self-heal re-adds chat/work and the mock's right-placed plugin view
+// re-seeds the right rail — so the disabled state is covered for the bottom dock
+// above and verified visually for left/right per the PR.)
+test("populated left/right rail toggles stay enabled and interactive (#1234)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const toggleLeft = page.getByTestId("toggle-left");
+  const toggleRight = page.getByTestId("toggle-right");
+  await expect(toggleLeft).toBeEnabled();
+  await expect(toggleRight).toBeEnabled();
+  // Still toggles the right column (proves the gate left an enabled rail interactive).
+  const right = page.locator(".pl-appshell__col--right");
+  await expect(right).toBeVisible();
+  await toggleRight.click();
+  await expect(right).toHaveCount(0);
+  await toggleRight.click();
+  await expect(right).toBeVisible();
+});

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -955,7 +955,14 @@ export function App() {
                   type="button"
                   className={`util-btn ${leftCollapsed ? "is-off" : ""}`}
                   onClick={() => setLeftCollapsed(!leftCollapsed)}
-                  title={leftCollapsed ? "Show left panel" : "Hide left panel"}
+                  disabled={leftMembers.length === 0}
+                  title={
+                    leftMembers.length === 0
+                      ? "No panels in the left rail"
+                      : leftCollapsed
+                        ? "Show left panel"
+                        : "Hide left panel"
+                  }
                   aria-label="Toggle left panel"
                   data-testid="toggle-left"
                 >
@@ -965,7 +972,14 @@ export function App() {
                   type="button"
                   className={`util-btn ${rightCollapsed ? "is-off" : ""}`}
                   onClick={() => setRightCollapsed(!rightCollapsed)}
-                  title={rightCollapsed ? "Show side panel" : "Hide side panel"}
+                  disabled={rightMembers.length === 0}
+                  title={
+                    rightMembers.length === 0
+                      ? "No panels in the right rail"
+                      : rightCollapsed
+                        ? "Show side panel"
+                        : "Hide side panel"
+                  }
                   aria-label="Toggle side panel"
                   data-testid="toggle-right"
                 >

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -106,9 +106,16 @@
   cursor: pointer;
 }
 
-.util-btn:hover {
+.util-btn:not(:disabled):hover {
   background: var(--bg-elevated, #1a1a1f);
   color: var(--fg);
+}
+
+/* Fully disabled toggle (#1234): the rail/dock it controls has no views, so the
+   button is greyed out and non-interactive (no hover feedback, no pointer). */
+.util-btn:disabled {
+  opacity: 0.4;
+  cursor: default;
 }
 
 .util-btn svg {


### PR DESCRIPTION
## What & why

Fixes #1234. The console utility bar has panel-toggle buttons (bottom-right cluster) that show/hide each docked rail. The **bottom** toggle already disables itself when the bottom dock is empty, but the **left** and **right** toggles did not — they looked active but did nothing when their rail held no views. This extends the same gate to the left/right toggles.

## What changed

- **`apps/web/src/app/App.tsx`** — the left and right panel-toggle buttons now pass `disabled={leftMembers.length === 0}` / `disabled={rightMembers.length === 0}` (the rail's resolved view set, already computed via `railSurfaces(side)`), with a context-aware `title` ("No panels in the left/right rail" when empty). This mirrors the existing bottom toggle's `disabled={!bottomActive}` pattern.
- **`apps/web/src/app/theme.css`** — added a `.util-btn:disabled` rule (`opacity: 0.4; cursor: default`) and guarded the `:hover` rule against disabled buttons (`.util-btn:not(:disabled):hover`), so a disabled toggle is visibly greyed out and shows no hover feedback. This also tidies the already-`disabled` bottom toggle, which previously had no greyed-out styling.
- **`apps/web/e2e/layout.spec.ts`** — added a test asserting the populated left/right toggles stay enabled and interactive (the gate doesn't over-disable a populated rail).
- **`CHANGELOG.md`** — `### Fixed` entry under `[Unreleased]`.

### Exact "rail is empty" condition
`railSurfaces(side).length === 0` for the side — i.e. `leftMembers.length === 0` (left toggle) and `rightMembers.length === 0` (right toggle). These are the same `metaFor`-resolved view lists the rails render, so the toggle's enabled state tracks exactly what's in the rail.

## Gate results
- `npm run test:unit --workspace @protoagent/web` — **pass** (115/115).
- `npm run build --workspace @protoagent/web` (tsc + vite + CSS-comment guard) — **pass**.
- `npx playwright test layout.spec.ts` — **pass** (6/6, incl. the new test).

## Ambiguity / interpretation (issue was a screenshot only)
I interpreted "panel toggle buttons should fully disable when no views are currently in the rail" as: the left/right rail toggles should match the bottom toggle's existing empty-dock gate (`disabled` + a "no panels" title) and be greyed out / non-interactive. The bottom toggle was already correct, so the fix is the left/right toggles + the missing greyed-out CSS. **Please confirm against the intended behavior.**

## Needs a visual check
This is a UX change CI can't fully judge. In the default layout the left/right rails are always populated (core surfaces + a right-placed mock plugin view re-seed them on mount), so an empty left/right rail can't be reliably reproduced in the e2e harness — the empty-state disable is covered for the bottom dock and verified by code review for left/right. Please open the console, drag all views off a rail (e.g. move `work`/the right panels onto another dock so the right rail is empty), and confirm that rail's toggle goes greyed out + non-interactive with the "No panels in the … rail" tooltip.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Layout panel toggle buttons now disable when panels are empty, preventing unnecessary interaction
  * Toggle button tooltips now reflect current panel state ("No panels available" vs "Show/Hide panel")
  * Disabled toggle buttons display reduced opacity and standard cursor for improved visual clarity

* **Tests**
  * Added E2E test verifying layout toggle buttons remain interactive when panels are populated

<!-- end of auto-generated comment: release notes by coderabbit.ai -->