### PR TITLE
perf: off-loop console handlers + inbox/activity retention (#875)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **Console-poll handlers no longer block the event loop.** `GET /api/runtime/status`
+  shelled out to `ps` (the per-poll co-location + fleet version-skew probes) and the
+  inbox/activity console handlers ran sync SQLite reads/writes directly on the loop; both
+  are now offloaded via `asyncio.to_thread`, matching the scheduler/goals handlers and the
+  startup-path co-location check. The inbox and activity stores also gained age-based
+  retention pruning wired into the hourly prune loop (`inbox`/`activity` `retention_days`,
+  default 90) so they can't grow unbounded like telemetry/checkpoints already prune. (#875)
+
 ## [0.67.0] - 2026-06-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,9 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   shelled out to `ps` (the per-poll co-location + fleet version-skew probes) and the
   inbox/activity console handlers ran sync SQLite reads/writes directly on the loop; both
   are now offloaded via `asyncio.to_thread`, matching the scheduler/goals handlers and the
-  startup-path co-location check. The inbox and activity stores also gained age-based
-  retention pruning wired into the hourly prune loop (`inbox`/`activity` `retention_days`,
-  default 90) so they can't grow unbounded like telemetry/checkpoints already prune. (#875)
+  startup-path co-location check. (#875)
 - **The Docker image now serves the React console and stays in dep-lockstep with
   pyproject.** A new node builder stage builds `apps/web/dist` and copies it into the
   runtime image, so `-e PROTOAGENT_UI=console` actually mounts `/app` instead of silently

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -47,24 +47,30 @@ def _operator_allowed_dirs() -> list[str]:
     return list(dict.fromkeys(roots))
 
 
-def _operator_runtime_status():
+async def _operator_runtime_status():
+    import asyncio
+
     # Live co-location check (#706) — re-evaluated per poll so the shell banner
     # appears/clears as siblings come and go. Quiet (empty `.instances/`) costs one
     # is_dir(); the `ps` guard only runs when sibling heartbeats actually exist.
+    # The probe shells out to `ps` per sibling, so it's offloaded off the event
+    # loop (#875) — matching the startup-path co-location check in server._main.
     from infra.paths import colocation_warning, instance_uid, package_version
 
     try:
-        warnings = [w for w in (colocation_warning(),) if w]
+        warn = await asyncio.to_thread(colocation_warning)
+        warnings = [warn] if warn else []
     except Exception:  # noqa: BLE001 — status must never raise
         warnings = []
     # Fleet version skew (version-coherence P2) — also live + self-clearing: a
     # member that survived an app update keeps running the OLD binary until
     # restarted; banner it the same way as a co-located sibling. Inside a member
-    # the scoped fleet.json is empty, so this no-ops.
+    # the scoped fleet.json is empty, so this no-ops. It probes sibling liveness
+    # (a `ps` shell-out under the hood), so it's offloaded off the loop too (#875).
     try:
         from graph.fleet import supervisor as _sup
 
-        skew = _sup.version_skew_warning()
+        skew = await asyncio.to_thread(_sup.version_skew_warning)
         if skew:
             warnings.append(skew)
     except Exception:  # noqa: BLE001 — status must never raise
@@ -341,7 +347,13 @@ async def _operator_activity_list() -> dict:
     with origin/trigger/priority — plus the thread's message history from the
     checkpointer (for the continue view). The console renders the feed and
     opens the thread on demand."""
-    entries = STATE.activity_log.recent(limit=100) if STATE.activity_log is not None else []
+    import asyncio
+
+    # recent() is sync sqlite — offload it off the loop (#875), mirroring the
+    # scheduler/goals handlers above.
+    entries = (
+        await asyncio.to_thread(STATE.activity_log.recent, 100) if STATE.activity_log is not None else []
+    )
     messages: list[dict] = []
     if STATE.checkpointer is not None:
         thread_id = f"a2a:{ACTIVITY_CONTEXT}"
@@ -439,9 +451,13 @@ async def _fire_activity_from_inbox(item: dict) -> bool:
 async def _operator_inbox_add(payload: dict) -> dict:
     """Ingest an inbound item (ADR 0003). now-priority fires an Activity turn;
     others queue for check_inbox. Dedup is handled by the store."""
+    import asyncio
+
     if STATE.inbox_store is None:
         raise RuntimeError("inbox not loaded; finish setup first")
-    item = STATE.inbox_store.add(
+    # add() is sync sqlite — offload it off the loop (#875).
+    item = await asyncio.to_thread(
+        STATE.inbox_store.add,
         payload.get("text", ""),
         priority=payload.get("priority", "next") or "next",
         source=payload.get("source", "") or "",
@@ -465,16 +481,20 @@ async def _operator_inbox_add(payload: dict) -> dict:
         # re-surfaced by the next check_inbox (bd-jus). A FAILED fire stays pending
         # so check_inbox remains the fallback delivery path for it.
         try:
-            STATE.inbox_store.mark_delivered([item["id"]])
+            await asyncio.to_thread(STATE.inbox_store.mark_delivered, [item["id"]])
         except Exception:  # noqa: BLE001 — best-effort; a missed mark just re-surfaces
             log.warning("[inbox] could not mark fired now-item %s delivered", item.get("id"))
     return {"ok": True, "item": item, "fired": fired}
 
 
 async def _operator_inbox_list(floor: str, include_delivered: bool) -> dict:
+    import asyncio
+
     if STATE.inbox_store is None:
         return {"items": []}
-    items = STATE.inbox_store.list(
+    # list() is sync sqlite — offload it off the loop (#875).
+    items = await asyncio.to_thread(
+        STATE.inbox_store.list,
         priority_floor=floor or "later",
         include_delivered=include_delivered,
         limit=200,
@@ -483,9 +503,13 @@ async def _operator_inbox_list(floor: str, include_delivered: bool) -> dict:
 
 
 async def _operator_inbox_deliver(item_id: int) -> dict:
+    import asyncio
+
     if STATE.inbox_store is None:
         raise RuntimeError("inbox not loaded; finish setup first")
-    return {"ok": True, "delivered": STATE.inbox_store.mark_delivered([item_id])}
+    # mark_delivered() is sync sqlite — offload it off the loop (#875).
+    delivered = await asyncio.to_thread(STATE.inbox_store.mark_delivered, [item_id])
+    return {"ok": True, "delivered": delivered}
 
 
 def _operator_chat_commands() -> dict:

--- a/operator_api/routes.py
+++ b/operator_api/routes.py
@@ -170,7 +170,7 @@ class _TaskStoreAdapter:
 def register_operator_routes(
     app,
     *,
-    runtime_status: Callable[[], dict[str, Any]],
+    runtime_status: Callable[[], dict[str, Any] | Awaitable[dict[str, Any]]],
     subagent_list: Callable[[], list[dict[str, Any]]],
     tools_list: Callable[[], dict[str, Any]] = lambda: {"tools": [], "count": 0},
     subagent_run: Callable[[dict[str, Any]], Awaitable[str]],
@@ -205,7 +205,11 @@ def register_operator_routes(
 
     @app.get("/api/runtime/status")
     async def _runtime_status():
-        return runtime_status()
+        # The console handler is async (it offloads the per-poll `ps` co-location
+        # probe off the loop, #875); accept a plain dict too so sync test doubles
+        # and forks that wire a sync accessor keep working.
+        res = runtime_status()
+        return await res if asyncio.iscoroutine(res) else res
 
     @app.get("/api/subagents")
     async def _subagents():

--- a/tests/test_operator_api_routes.py
+++ b/tests/test_operator_api_routes.py
@@ -64,6 +64,26 @@ def test_tasks_store_route_ignores_project_path() -> None:
     assert client.get("/api/tasks/issues").status_code == 200
 
 
+def test_runtime_status_accepts_async_accessor() -> None:
+    """The real console handler is async (#875 offloads the per-poll `ps`
+    co-location probe off the loop); the route must await a coroutine accessor
+    while still accepting a plain-dict (sync) one for forks/test doubles."""
+    app = FastAPI()
+
+    async def _async_status():
+        return {"graph_loaded": True, "async": True}
+
+    register_operator_routes(
+        app,
+        runtime_status=_async_status,
+        subagent_list=lambda: [],
+        subagent_run=lambda req: "",
+        subagent_batch=lambda req: "",
+        tasks_store=_FakeTaskStore(),
+    )
+    assert TestClient(app).get("/api/runtime/status").json() == {"graph_loaded": True, "async": True}
+
+
 def test_operator_routes_return_expected_shapes(tmp_path) -> None:
     client = _client()
 


### PR DESCRIPTION
Addresses the **SAFE subset** of the perf-audit tail (#875).

## Items addressed (2, 7, 8)

### Item 8 — `colocation_warning()` `ps` subprocess off the event loop
`_operator_runtime_status` (`operator_api/console_handlers.py`) is now `async` and offloads the two per-poll probes that shell out to `ps` / probe sibling liveness — `infra.paths.colocation_warning()` and `graph.fleet.supervisor.version_skew_warning()` — via `asyncio.to_thread`, matching the startup-path co-location check in `server._main`. The `/api/runtime/status` route (`operator_api/routes.py`) awaits a coroutine accessor and still accepts a plain dict, so sync test doubles and forks that wire a sync accessor keep working. Both `try/except` guards remain non-raising.

### Item 7 — sync SQLite in the async inbox/activity console handlers
The async handlers in `operator_api/console_handlers.py` now offload their blocking sync-SQLite store calls via `asyncio.to_thread`, mirroring the scheduler/goals neighbors. Behavior and return shapes are unchanged:
- `_operator_activity_list` → `ActivityLog.recent`
- `_operator_inbox_add` → `InboxStore.add` + `InboxStore.mark_delivered` (the fired-now branch)
- `_operator_inbox_list` → `InboxStore.list`
- `_operator_inbox_deliver` → `InboxStore.mark_delivered`

### Item 2 — inbox + activity retention
**Already shipped on `main`** (PR #1059): `inbox_retention_days` / `activity_retention_days` config knobs (default 90) with `from_dict` parsing + roundtrip golden entries, `InboxStore.prune` / `ActivityLog.prune` methods, the hourly-prune-loop wiring in `server/agent_init.py` next to the checkpoint/telemetry prunes, and prune tests (`tests/test_inbox.py`, `tests/test_activity.py`). No work needed; left untouched. (Mentioned in the CHANGELOG bullet for completeness.)

## Status of the rest of the audit checklist
- **Deferred (out of scope, risky):** item 5 (O(n²) `stream_visible_output` rescan — critical streaming hot path, needs dedicated regression tests) and item 9 (frontend event-bus invalidation).
- **Already done before this PR:** item 1 (telemetry export streaming, #1061), item 3 (`supervisor.status()` `to_thread`'d in `fleet_routes.py`), item 4 (`_ACP_RUNTIMES` idle+LRU eviction in `server/chat.py`).

## Config knob
No new config field added (item 2's knobs already exist on `main`), so the `graph/config.py` ↔ `tests/test_config_roundtrip.py` golden field map needed no update — confirmed `tests/test_config_roundtrip.py` still passes (26 passed).

## Tests
Added `test_runtime_status_accepts_async_accessor` (`tests/test_operator_api_routes.py`) covering the route's new sync/async-accessor handling.

## Gates (all green)
- `ruff check .` → All checks passed
- `lint-imports` → 3 kept, 0 broken
- `python -m pytest tests/ -q` → **2288 passed**, 124 warnings
- `python scripts/live_smoke.py` → LIVE SMOKE PASSED ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Performance Improvements**
  * Improved responsiveness of console status monitoring, activity feed updates, and inbox operations by preventing blocking operations from impacting the event loop.

* **New Features**
  * Extended API runtime status endpoint to support both synchronous and asynchronous status providers.

* **Tests**
  * Added test coverage for async runtime status endpoint support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->