### PR TITLE
fix(docker): multi-stage console build + dep-drift guard (closes #874)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -41,9 +41,15 @@ tests/
 
 # Docs site — VitePress builds to gh-pages, not into the container
 docs/
+
+# node_modules NEVER enter the build context — the web-builder stage runs a fresh
+# `npm ci` and the python runtime installs via pip, so a host's node_modules would
+# only bloat the context and risk leaking platform-specific binaries.
 node_modules/
-package.json
-package-lock.json
+# NOTE: package.json / package-lock.json are deliberately NOT excluded — the
+# web-builder stage COPYs them to run `npm ci` and build the React console
+# (apps/web/dist). Re-excluding them breaks that stage (the #874 console-never-
+# ships bug). They're harmless in the runtime image (Python ignores them).
 
 # Seccomp profile — Docker reads this on the host at runtime
 # (via docker-compose security_opt), NOT from inside the image

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+- **The Docker image now serves the React console and stays in dep-lockstep with
+  pyproject.** A new node builder stage builds `apps/web/dist` and copies it into the
+  runtime image, so `-e PROTOAGENT_UI=console` actually mounts `/app` instead of silently
+  404'ing (`.dockerignore` no longer drops the workspace manifests the build needs); the
+  server now warns loudly when the `console` tier is requested but the console build is
+  absent. A new `tests/test_requirements_core_sync.py` guard fails CI if
+  `requirements-core.txt` (what the image installs) misses any core `pyproject`
+  dependency — it had silently lost `pypdf`, `youtube-transcript-api`, and
+  `markdown-it-py`, now restored. (#874)
+
 ## [0.67.0] - 2026-06-22
 
 ### Added

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,32 @@
+# ---------------------------------------------------------------------------
+# Stage 1 — node builder: build the React operator console (apps/web → dist/).
+#
+# `apps/web/dist` is .gitignored (build output, never committed), so the final
+# image can't just `COPY` it from the context — it has to be BUILT here. Without
+# this stage the `console` tier 404s at /app: mount_react_app finds no
+# dist/index.html and silently returns False (the #874 bug). We build only the
+# `@protoagent/web` workspace; `npm ci` at the root resolves the npm workspaces
+# (web + desktop), but the desktop workspace only pulls a JS CLI, so the install
+# stays light and these node_modules never reach the final image.
+# ---------------------------------------------------------------------------
+FROM node:20-slim AS web-builder
+WORKDIR /build
+# Copy only what the web build needs (lockfile-first so this layer caches across
+# source-only churn): the workspace manifests + lockfile, then the app sources.
+# The root + both workspace package.json files are required for `npm ci` to
+# reconstruct the workspace tree the committed package-lock.json describes.
+COPY package.json package-lock.json ./
+COPY apps/web/package.json apps/web/
+COPY apps/desktop/package.json apps/desktop/
+RUN npm ci
+# `prebuild` (check-css-comments + copy-plugin-kit) + `build` (tsc typecheck +
+# vite build) — emits apps/web/dist/, including dist/_ds/ from the plugin-kit.
+COPY apps/web/ apps/web/
+RUN npm run build --workspace @protoagent/web
+
+# ---------------------------------------------------------------------------
+# Stage 2 — python runtime: the agent core + the built console copied in.
+# ---------------------------------------------------------------------------
 FROM python:3.12-slim
 
 # System deps. iproute2 is required when running under NVIDIA OpenShell —
@@ -55,10 +84,12 @@ RUN useradd -m -s /bin/bash -u ${SANDBOX_UID} sandbox
 # add them to requirements.txt.
 # UI tier (ADR 0010): the build-arg bakes PROTOAGENT_UI so the image runs the
 # matching tier — default 'none' (API + A2A + /metrics only, the lean headless
-# image) or 'console' (also serves the React console, which ships as COPY'd static
-# assets, not a pip dep). Either tier uses the same lean core deps, so the install
-# is unconditional; forks that need extras (the google/Discord MCP surfaces,
-# agent-browser, …) add them to requirements-core.txt (note above).
+# image) or 'console' (also serves the React console, built in the web-builder
+# stage above and copied in below as static assets, not a pip dep). Either tier
+# uses the same lean core deps — and the console dist always ships regardless of
+# UI — so the install is unconditional; forks that need extras (the
+# google/Discord MCP surfaces, agent-browser, …) add them to
+# requirements-core.txt (note above).
 ARG UI=none
 COPY requirements*.txt /tmp/
 RUN pip install --no-cache-dir -r /tmp/requirements-core.txt
@@ -68,6 +99,13 @@ RUN pip install --no-cache-dir -r /tmp/requirements-core.txt
 # new top-level source file later does NOT require a Dockerfile update.
 COPY . /opt/protoagent/
 RUN chmod +x /opt/protoagent/entrypoint.sh
+
+# The React console — copied from the node builder stage, NOT from the build
+# context (apps/web/dist is .gitignored and node_modules is .dockerignore'd, so
+# the source COPY above ships no built console). This is what makes the
+# `console` tier serve /app instead of 404'ing (the #874 bug). Only the static
+# dist/ lands here — the builder's node_modules stay in the discarded stage.
+COPY --from=web-builder /build/apps/web/dist /opt/protoagent/apps/web/dist
 
 # Sandbox workspace + knowledge/audit dirs
 RUN mkdir -p /sandbox /tmp/sandbox /sandbox/audit /sandbox/knowledge \

--- a/requirements-core.txt
+++ b/requirements-core.txt
@@ -63,3 +63,11 @@ croniter>=2.0
 # via Gradio → huggingface_hub; the lean tiers must declare it (the #426 class).
 filelock>=3.12
 zeroconf>=0.131  # mDNS fleet discovery (ADR 0042 §I)
+
+# Document ingestion engine (ADR 0021) — light pure-Python extractors. Declared
+# in pyproject [project.dependencies] (the source of truth); mirrored here so the
+# Docker image (which installs from this file) matches. tests/test_requirements_core_sync.py
+# fails CI if these two lists drift again (the #874 dep-drift class).
+pypdf>=4.0                    # PDF → text
+youtube-transcript-api>=1.0   # YouTube captions → text (1.x instance API)
+markdown-it-py>=3.0           # Markdown → HTML for the `docs` plugin reader view (server-side, offline)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -799,8 +799,23 @@ def _main():
     mount_ds_plugin_kit(fastapi_app, web_dist_dir)
 
     # The console SPA (/app) — console/full tiers only; 'none' (members/headless) skip it.
-    if ui != "none" and mount_react_app(fastapi_app, web_dist_dir):
-        log.info("React operator console mounted at /app")
+    if ui != "none":
+        if mount_react_app(fastapi_app, web_dist_dir):
+            log.info("React operator console mounted at /app")
+        else:
+            # The console tier was requested but the build output is missing — /app
+            # would silently 404 (the #874 footgun: a no-Node Docker image, or a
+            # source checkout that never ran `npm run build`). Warn LOUDLY with the
+            # exact fix instead of a single quiet log line.
+            log.warning(
+                "--ui %s requested but the React console build is missing at %s — "
+                "/app will 404. Build it with `npm ci && npm run build --workspace "
+                "@protoagent/web` (or use a Docker image built from the multi-stage "
+                "Dockerfile, which builds it for you). Use `--ui none` to run headless "
+                "without the console.",
+                ui,
+                web_dist_dir,
+            )
 
     # --- Static + PWA assets (skipped in 'none') ---------------------------
     if ui != "none" and static_dir.exists():

--- a/tests/test_requirements_core_sync.py
+++ b/tests/test_requirements_core_sync.py
@@ -1,0 +1,126 @@
+"""Drift guard: requirements-core.txt ⊇ the core pyproject [project.dependencies].
+
+``pyproject.toml [project.dependencies]`` is the single source of truth for the
+runtime deps (``pip install .`` / ``uv sync`` read it). But the Docker image
+installs from ``requirements-core.txt`` (``pip install -r requirements-core.txt``),
+which is hand-mirrored — so a dep added only to pyproject passes every CI gate
+(tests run against the pyproject install) yet silently MISSES the production
+image. That's the #874 dep-drift class: the runtime image quietly lacks a package
+the agent imports, and the failure only surfaces in production.
+
+This test makes that drift a CI failure: every package name declared in
+``[project.dependencies]`` must also appear in ``requirements-core.txt``. It
+compares by *normalized package name* (PEP 503) only — version pins and extras
+are formatting and intentionally NOT asserted, so a ``>=`` vs ``==`` or an extras
+list difference doesn't cause false failures.
+
+CORE-SUBSET DEFINITION: today the ENTIRE ``[project.dependencies]`` table IS the
+core tier — pyproject's own comment marks it "core (the `none`/`console` tiers) —
+mirrors requirements-core.txt", and there is no separate full-tier section. If a
+full-tier-only section is ever added to pyproject, mark those deps so they can be
+excluded from the core subset here (see ``_FULL_TIER_ONLY`` below).
+"""
+
+from __future__ import annotations
+
+import sys
+import tomllib
+from pathlib import Path
+
+from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+_PYPROJECT = _REPO_ROOT / "pyproject.toml"
+_REQUIREMENTS_CORE = _REPO_ROOT / "requirements-core.txt"
+
+# Full-tier-only deps to exclude from the "core subset". Empty today — the whole
+# [project.dependencies] table is the core tier (the lean none/console tiers).
+# If a full-only section is added to pyproject, list its package names here (PEP
+# 503 canonical form) with a comment, so this guard only enforces the core subset.
+_FULL_TIER_ONLY: set[str] = set()
+
+
+def _canonical_names(specifiers: list[str]) -> set[str]:
+    """Normalize a list of PEP 508 requirement strings to canonical package names.
+
+    Skips blank lines / comments and tolerates direct git references (``pkg @
+    git+https://…``), which ``packaging.requirements.Requirement`` parses fine.
+    """
+    names: set[str] = set()
+    for raw in specifiers:
+        line = raw.strip()
+        if not line or line.startswith("#"):
+            continue
+        # Strip trailing inline comments (`foo>=1  # why`) — not part of the spec.
+        line = line.split("#", 1)[0].strip()
+        if not line:
+            continue
+        try:
+            names.add(canonicalize_name(Requirement(line).name))
+        except InvalidRequirement:
+            # Non-requirement lines (e.g. `-e .`, `-r other.txt`) aren't package
+            # specs — ignore them; this guard is about named-package coverage.
+            continue
+    return names
+
+
+def _pyproject_core_deps() -> set[str]:
+    data = tomllib.loads(_PYPROJECT.read_text(encoding="utf-8"))
+    deps = data["project"]["dependencies"]
+    return _canonical_names(deps) - _FULL_TIER_ONLY
+
+
+def _requirements_core_deps() -> set[str]:
+    lines = _REQUIREMENTS_CORE.read_text(encoding="utf-8").splitlines()
+    return _canonical_names(lines)
+
+
+def test_requirements_core_covers_pyproject_core_dependencies() -> None:
+    """Every core ``[project.dependencies]`` package must be in requirements-core.txt.
+
+    A package present in pyproject but absent here means the Docker image (which
+    installs from requirements-core.txt) ships without it — the silent prod gap.
+    """
+    pyproject = _pyproject_core_deps()
+    req_core = _requirements_core_deps()
+    missing = pyproject - req_core
+    assert not missing, (
+        "requirements-core.txt is missing core deps declared in pyproject.toml "
+        f"[project.dependencies]: {sorted(missing)}. Add them to requirements-core.txt "
+        "(the Docker image installs from that file) — or, if one is genuinely "
+        "full-tier-only, add it to _FULL_TIER_ONLY with a reason."
+    )
+
+
+def test_requirements_core_has_no_unknown_named_packages() -> None:
+    """Belt-and-suspenders: requirements-core.txt declares no NAMED package that
+    isn't in pyproject's core deps.
+
+    Keeps the mirror tight in both directions — a stray pin in requirements-core.txt
+    that no longer exists in the source of truth surfaces here rather than lingering.
+    (pyproject is authoritative; this catches the reverse drift.)
+    """
+    pyproject = _pyproject_core_deps()
+    req_core = _requirements_core_deps()
+    extra = req_core - pyproject - _FULL_TIER_ONLY
+    assert not extra, (
+        "requirements-core.txt declares package(s) not in pyproject.toml "
+        f"[project.dependencies]: {sorted(extra)}. pyproject is the source of truth — "
+        "add them there too, or remove the stale line from requirements-core.txt."
+    )
+
+
+def test_parser_skips_non_package_lines() -> None:
+    """The name extractor ignores comments, blanks, and pip directives (`-e .`)."""
+    assert _canonical_names(["", "# comment", "-e .", "-r other.txt"]) == set()
+    # canonicalize_name (PEP 503): lowercase + collapse runs of -_. to a single '-'.
+    assert _canonical_names(["Foo.Bar_Baz>=1.0  # inline"]) == {"foo-bar-baz"}
+    assert _canonical_names(["pkg @ git+https://example.com/pkg.git@v1"]) == {"pkg"}
+
+
+# Guard the floor: tomllib is stdlib on 3.11+, which is requires-python. If this
+# ever runs on an older interpreter the import above would already have failed —
+# this assertion documents the expectation explicitly.
+def test_running_on_supported_python() -> None:
+    assert sys.version_info >= (3, 11), "requires-python is >=3.11 (tomllib is stdlib there)"


### PR DESCRIPTION
Fixes #874 — the Docker image couldn't serve the React console, and the image's deps drifted from `pyproject.toml`.

## Problem 1 — the console never shipped (`-e PROTOAGENT_UI=console` 404'd at `/app`)

`apps/web/dist` is `.gitignored`, the Dockerfile had **no Node stage**, and `.dockerignore` excluded the npm workspace manifests — so `COPY . /opt/protoagent/` shipped no built console and `mount_react_app` silently returned `False`. The only signal was one quiet "not mounted" log line.

**Fix:**
- **Multi-stage Dockerfile.** New `node:20-slim` `web-builder` stage runs `npm ci` (lockfile-first for layer caching) then `npm run build --workspace @protoagent/web`, and the runtime stage `COPY --from=web-builder /build/apps/web/dist …`. Only the static `dist/` (including `dist/_ds/` plugin-kit) lands in the final image — the builder's `node_modules` stay in the discarded stage.
- **`.dockerignore`.** `node_modules/` stays excluded (the builder installs fresh; avoids context bloat + platform-binary leakage), but `package.json` / `package-lock.json` are **no longer excluded** — the builder stage needs them for `npm ci`. The console dist now ships regardless of the `UI` build-arg.
- **Loud boot warning.** When `--ui console` is requested but the build is absent, the server now logs a `WARNING` with the exact fix (`npm ci && npm run build …`, or use the multi-stage image, or run `--ui none`) instead of failing quietly.

## Problem 2 — dep drift between the image and `pyproject.toml`

The Dockerfile installs `requirements-core.txt` while `pyproject.toml [project.dependencies]` is the declared source of truth, with no sync test. `requirements-core.txt` had **silently lost `pypdf`, `youtube-transcript-api`, and `markdown-it-py`** — so the prod image lacked the document-ingestion deps while CI (which installs via `pyproject`) stayed green.

**Fix:**
- Restored the three missing deps in `requirements-core.txt`.
- Added **`tests/test_requirements_core_sync.py`** (modeled on `tests/test_config_drift_guard.py`): parses `[project.dependencies]` with `tomllib` + `packaging.requirements.Requirement`, compares by canonical PEP 503 name (so version-pin / extras formatting never causes false failures), and **fails CI if `requirements-core.txt` misses any core pyproject dependency**. A `_FULL_TIER_ONLY` set documents the "core subset" definition — today the entire dependency table *is* the core tier (pyproject's own comment says so; no full-only section exists), and the set is empty.

### "Core subset" judgment call
There is no separate full-tier section in `pyproject.toml` today — the whole `[project.dependencies]` table is annotated "core (the `none`/`console` tiers) — mirrors requirements-core.txt". So the test enforces `requirements-core ⊇ all of [project.dependencies]`, with a documented escape hatch (`_FULL_TIER_ONLY`) if a full-only section is ever added.

## Gate results (run locally with `.venv/bin/…`)
- `ruff check .` → **All checks passed!**
- `lint-imports` → **3 contracts kept, 0 broken**
- `python -m pytest tests/test_requirements_core_sync.py -q` → **4 passed**
- `python -m pytest tests/ -q` → **2291 passed** (pre-existing deprecation warnings only)

## Docker build — VERIFIED for real
Docker **was** available (28.5.1 / buildx 0.29.1), so this was validated end-to-end, not just syntax-checked:
- `docker build --check` → no warnings.
- Built the `web-builder` stage and the full image (`--build-arg UI=console`) successfully.
- Booted the container with `PROTOAGENT_UI=console`: logs show `React operator console mounted at /app`; `curl /app` → **200 + HTML**, `curl /app/assets/*.js` → **200**, `curl /_ds/plugin-kit.css` → **200**.
- Confirmed in the built image: console `dist/` present with `index.html` + `_ds/`; `pypdf` / `youtube_transcript_api` / `markdown_it` all import; **no `node_modules` leaked** into the final image.
- Confirmed the loud warning branch fires when `dist` is absent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)