### PR TITLE
perf(chat): incremental mid-stream output/reasoning views — kill the O(N²) rescan (#1310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Fixed
+- **Mid-stream output rendering no longer rescans the whole response on every chunk.**
+  The chat stream recomputed the visible `<output>` (and the live reasoning view) by
+  re-running regexes over the *entire* accumulated text per token chunk — O(N²) over a
+  turn. New incremental `StreamingOutputView` / `StreamingReasoningView` scan only the
+  newly-appended tail (a cheap pre-`<output>` scan, then fast-append in the steady
+  answer body), falling back to the authoritative parser on any tag boundary; an
+  equivalence + fuzz test pins them byte-for-byte to the original functions. (#1310)
 - **Empty-rail panel toggles fully disable.** The utility-bar left/right panel-toggle buttons are now greyed out and non-interactive when their rail holds no views (matching the bottom-dock toggle), instead of appearing active but doing nothing when clicked. (#1234)
 - **Console-poll handlers no longer block the event loop.** `GET /api/runtime/status`
   shelled out to `ps` (the per-poll co-location + fleet version-skew probes) and the

--- a/graph/output_format.py
+++ b/graph/output_format.py
@@ -249,6 +249,118 @@ def stream_visible_reasoning(raw: str) -> str:
     return "\n\n".join(chunks)
 
 
+# Compiled openers for the incremental streaming views below. The lookbehind skips a
+# backticked mention (matching the pure functions); `Pattern.search(raw, pos)` keeps the
+# FULL string visible to the lookbehind, so backing the search start up by the tag length
+# catches a tag that straddles a chunk boundary without a slice false-positive.
+_OUTPUT_OPEN_RE = re.compile(r"(?<!`)<output>", re.IGNORECASE)
+_REASONING_OPEN_RE = re.compile(r"(?<!`)<(?:scratch_pad|think)>", re.IGNORECASE)
+
+
+class StreamingOutputView:
+    """Incremental, amortized-O(total) equivalent of :func:`stream_visible_output`.
+
+    ``stream_visible_output`` re-scans the ENTIRE accumulated text every chunk, so a turn
+    streaming N chars over ~N chunks costs O(N²) (#1310). This keeps the same contract —
+    feed it the monotonically growing accumulated raw, get the full visible-so-far back —
+    but only looks at the newly-appended tail in the common cases:
+
+      * before ``<output>`` opens, it scans only the tail for the opener (the
+        ``<scratch_pad>`` is never re-scanned), returning ``""`` meanwhile;
+      * once ``<output>`` is open with no ``<`` in the output region (the steady
+        answer-body stream), it just appends the delta.
+
+    Anything ambiguous — a ``<`` that may begin ``</output>`` / ``<think>`` /
+    ``<confidence>`` / a partial tag, or the closed state — falls back to the
+    authoritative ``stream_visible_output``, the oracle the equivalence test pins this
+    against. Construct one per turn; call :meth:`update` per chunk.
+    """
+
+    __slots__ = ("_opened", "_fast", "_prev_len", "_visible")
+
+    def __init__(self) -> None:
+        self._opened = False
+        self._fast = False
+        self._prev_len = 0
+        self._visible = ""
+
+    def update(self, raw: str) -> str:
+        delta_start = self._prev_len
+        self._prev_len = len(raw)
+        # Steady answer-body stream: open, unclosed, no `<` in the region — the visible
+        # simply grows by a delta that adds no tag-significant character.
+        if self._fast and "<" not in raw[delta_start:]:
+            self._visible += raw[delta_start:]
+            return self._visible
+        # Pre-output: scan only the tail for the opener (never re-scan the scratch_pad).
+        if not self._opened:
+            start = max(0, delta_start - 8)  # catch a "<output>" split across the boundary
+            if _OUTPUT_OPEN_RE.search(raw, start) is None:
+                return ""  # still in scratch_pad — nothing user-facing yet
+            self._opened = True
+        # Authoritative recompute (close / <think> / partial-tag handling), then decide
+        # whether the next chunks can take the fast path.
+        self._visible = stream_visible_output(raw)
+        m = _OUTPUT_OPEN_RE.search(raw)
+        self._fast = m is not None and "<" not in raw[m.end() :]
+        return self._visible
+
+
+class StreamingReasoningView:
+    """Incremental, amortized-O(total) equivalent of :func:`stream_visible_reasoning`.
+
+    Same idea as :class:`StreamingOutputView` for the hidden "thinking" stream: only the
+    open trailing reasoning block grows on a plain delta (closed blocks are committed and
+    not re-joined; ``str.strip`` scans only end-whitespace, not the whole body). A ``<``
+    (a block open/close, a nested or partial tag) drops to the authoritative
+    ``stream_visible_reasoning`` — the oracle the equivalence test pins this against.
+    """
+
+    __slots__ = ("_opened", "_fast", "_prev_len", "_committed", "_open_raw", "_visible")
+
+    def __init__(self) -> None:
+        self._opened = False
+        self._fast = False
+        self._prev_len = 0
+        self._committed = ""  # joined, stripped bodies of CLOSED reasoning blocks
+        self._open_raw = ""  # raw body of the open trailing block (fast mode only)
+        self._visible = ""
+
+    def _join(self, body: str) -> str:
+        if not body:
+            return self._committed
+        if not self._committed:
+            return body
+        return self._committed + "\n\n" + body
+
+    def update(self, raw: str) -> str:
+        delta_start = self._prev_len
+        self._prev_len = len(raw)
+        # Steady deliberation: inside one open trailing block, delta adds no tag char —
+        # extend that block's body and re-join.
+        if self._fast and "<" not in raw[delta_start:]:
+            self._open_raw += raw[delta_start:]
+            self._visible = self._join(self._open_raw.strip())
+            return self._visible
+        # Pre-reasoning: cheap tail-scan for the first scratch_pad/think opener.
+        if not self._opened:
+            start = max(0, delta_start - 13)  # catch a "<scratch_pad>" split across the boundary
+            if _REASONING_OPEN_RE.search(raw, start) is None:
+                return ""
+            self._opened = True
+        # Authoritative recompute, then refresh fast-mode state.
+        self._visible = stream_visible_reasoning(raw)
+        self._committed = "\n\n".join(b for m in _REASONING_BLOCK_RE.finditer(raw) if (b := m.group(2).strip()))
+        tail = _REASONING_OPEN_TAIL_RE.search(raw)
+        if tail is not None and "<" not in tail.group(2):
+            self._open_raw = tail.group(2)
+            self._fast = True
+        else:
+            self._open_raw = ""
+            self._fast = False
+        return self._visible
+
+
 def extract_confidence(text: str) -> tuple[float | None, str | None]:
     """Parse an optional self-reported ``<confidence>`` (and explanation).
 

--- a/server/chat.py
+++ b/server/chat.py
@@ -21,11 +21,11 @@ from typing import Any
 
 from graph.output_format import (
     DROPPED_SCRATCH_KICKER,
+    StreamingOutputView,
+    StreamingReasoningView,
     extract_confidence,
     extract_output,
     is_dropped_scratch_turn,
-    stream_visible_output,
-    stream_visible_reasoning,
 )
 from runtime.state import STATE
 
@@ -308,6 +308,11 @@ async def _run_turn_stream(
     accumulated_raw = ""
     streamed_len = 0  # chars of visible <output> already emitted as text frames
     reasoned_len = 0  # chars of scratch_pad reasoning already emitted (live thinking)
+    # Incremental views: same visible-so-far as stream_visible_output/_reasoning, but
+    # they scan only the new tail instead of re-running regexes over the whole
+    # accumulated text every chunk — turning the per-turn O(N²) rescan into ~O(N) (#1310).
+    out_view = StreamingOutputView()
+    reason_view = StreamingReasoningView()
     _llm_started: dict[str, float] = {}  # run_id → monotonic start (per-call latency)
     announced_tools: set[str] = set()  # tool_call ids already surfaced as a start frame
     async for event in STATE.graph.astream_events(
@@ -377,13 +382,13 @@ async def _run_turn_stream(
                 # Stream only the user-facing <output> region, token by token —
                 # never the scratch_pad. The terminal artifact (extract_output)
                 # reconciles any partial tail held back here.
-                visible = stream_visible_output(accumulated_raw)
+                visible = out_view.update(accumulated_raw)
                 if len(visible) > streamed_len:
                     yield ("text", visible[streamed_len:])
                     streamed_len = len(visible)
                 # Stream the scratch_pad reasoning on its own channel — a collapsible
                 # "thinking" view in the console (never folded into the answer text).
-                reasoning = stream_visible_reasoning(accumulated_raw)
+                reasoning = reason_view.update(accumulated_raw)
                 if len(reasoning) > reasoned_len:
                     yield ("reasoning", reasoning[reasoned_len:])
                     reasoned_len = len(reasoning)

--- a/tests/test_output_format.py
+++ b/tests/test_output_format.py
@@ -15,8 +15,14 @@ terminal ``extract_output`` reconciles any held-back tail. Both are covered.
 
 from __future__ import annotations
 
+import random
+
+import pytest
+
 from graph.output_format import (
     OUTPUT_FORMAT_INSTRUCTIONS,
+    StreamingOutputView,
+    StreamingReasoningView,
     _strip_reasoning,
     extract_output,
     stream_visible_output,
@@ -310,3 +316,63 @@ def test_stream_visible_is_monotonic_prefix():
     assert seen == "Hello world"
     # The terminal extractor agrees with the final streamed text.
     assert extract_output(raw) == "Hello world"
+
+
+# ── incremental streaming views == the pure functions (oracle equivalence, #1310) ──
+# StreamingOutputView / StreamingReasoningView only scan the new tail per chunk, so they
+# must return EXACTLY what the (O(N²)) pure functions return at every growing prefix.
+# These pin the fast incremental paths to the proven pure implementations.
+
+_STREAM_CASES = [
+    "",
+    "no tags at all, just a bare answer",
+    "<scratch_pad>thinking</scratch_pad><output>Hello world</output>",
+    "<scratch_pad>plan the work</scratch_pad><output>answer with a < b and c > d comparison</output>",
+    "<output>partial answer with no closing tag yet",  # orphan open (max_tokens truncation)
+    "<scratch_pad>step 1</scratch_pad><scratch_pad>step 2</scratch_pad><output>done</output>",  # multi scratch
+    "<output>before<think>leaked provider reasoning</think>after</output>",  # think inside output
+    "<output>x</output><confidence>0.9</confidence>",
+    "<scratch_pad>reasoning that mentions `<output>` in backticks</scratch_pad><output>the real answer</output>",
+    "<think>provider think block</think><output>ok</output>",
+    "<output>```python\nxs: list[int] = []\nif a < b and c > d:\n    pass\n```\ndone</output>",  # code: many < >
+    "<output>trailing partial close </outp",  # partial </output> at the very end
+    "<output>answer</output>\n<confidence>0.8</confidence>\n<confidence_explanation>why it scored</confidence_explanation>",
+    "<scratch_pad>only reasoning, model never opened output and stopped</scratch_pad>",
+    "<scratch_pad>a</scratch_pad><output>one</output>more raw<output>two</output>",  # second (ignored) output
+]
+
+
+@pytest.mark.parametrize("text", _STREAM_CASES)
+@pytest.mark.parametrize("chunk", [1, 2, 3, 5, 7, 13, 50])
+def test_streaming_output_view_matches_pure(text, chunk):
+    view = StreamingOutputView()
+    for i in range(chunk, len(text) + chunk, chunk):
+        prefix = text[:i]
+        assert view.update(prefix) == stream_visible_output(prefix), f"mismatch at prefix {prefix!r}"
+
+
+@pytest.mark.parametrize("text", _STREAM_CASES)
+@pytest.mark.parametrize("chunk", [1, 2, 3, 5, 7, 13, 50])
+def test_streaming_reasoning_view_matches_pure(text, chunk):
+    view = StreamingReasoningView()
+    for i in range(chunk, len(text) + chunk, chunk):
+        prefix = text[:i]
+        assert view.update(prefix) == stream_visible_reasoning(prefix), f"mismatch at prefix {prefix!r}"
+
+
+def test_streaming_views_match_pure_under_random_fuzz():
+    """Random documents from a tag-heavy alphabet, chunked at random offsets — the
+    incremental views must equal the pure functions at every step (catches boundary /
+    holdback / whitespace edges the curated cases miss)."""
+    rng = random.Random(1310)
+    alphabet = ["<output>", "</output>", "<scratch_pad>", "</scratch_pad>", "<think>", "</think>",
+                "<confidence>", "</confidence>", "`", "<", ">", " ", "\n", "a", "b", "x", "word"]
+    for _ in range(300):
+        text = "".join(rng.choice(alphabet) for _ in range(rng.randint(0, 40)))
+        out_view, reason_view = StreamingOutputView(), StreamingReasoningView()
+        pos = 0
+        while pos < len(text):
+            pos = min(len(text), pos + rng.randint(1, 6))
+            prefix = text[:pos]
+            assert out_view.update(prefix) == stream_visible_output(prefix), f"output mismatch: {prefix!r}"
+            assert reason_view.update(prefix) == stream_visible_reasoning(prefix), f"reasoning mismatch: {prefix!r}"


### PR DESCRIPTION
Addresses the headline item of #1310 (the O(N²) mid-stream rescan). The goals/beads polling→event-bus item stays open on #1310 — it needs backend task-change events first, so it's not a clean frontend-only swap.

## Problem
`server/chat.py` `_chat_langgraph_stream` recomputed the visible `<output>` and the live reasoning view by re-running regexes over the **entire** `accumulated_raw` on every token chunk:
```python
visible   = stream_visible_output(accumulated_raw)     # O(N) per chunk
reasoning = stream_visible_reasoning(accumulated_raw)  # O(N) per chunk
```
A turn streaming N chars over ~N chunks → **O(N²)**, measurable on long answers.

## Fix
New `StreamingOutputView` / `StreamingReasoningView` (`graph/output_format.py`) keep the exact same "return the full visible-so-far" contract but only look at the new tail:
- **pre-`<output>`**: scan only the appended tail for the opener (the `<scratch_pad>` is never re-scanned), return `""` meanwhile;
- **steady answer body** (open, unclosed, no `<` in the region): fast-append the delta;
- **anything ambiguous** (a `<` that may start `</output>` / `<think>` / `<confidence>` / a partial tag, or the closed state): fall back to the authoritative pure function.

`server/chat.py` instantiates one of each per turn and calls `.update(accumulated_raw)`; `streamed_len`/`reasoned_len` logic is unchanged.

## Why it's safe
The pure functions remain the **oracle**. Two tests pin the incremental views to them:
- `test_streaming_output_view_matches_pure` / `..._reasoning_..._matches_pure` — 15 curated cases (scratch+output, `<think>` inside output, backticked mentions, confidence, orphan open, code full of `<`/`>`, partial trailing tag, multi-scratch, …) × chunk sizes {1,2,3,5,7,13,50}, asserting `view.update(prefix) == pure(prefix)` at **every** growing prefix.
- `test_streaming_views_match_pure_under_random_fuzz` — 300 random docs from a tag-heavy alphabet, chunked at random offsets, same equality assertion.

So the views are byte-identical to today's behavior — just ~O(N).

## Gates
`ruff` ✓ · `lint-imports` ✓ (3 kept, 0 broken) · `pytest tests/` ✓ (2503 passed) · `live_smoke.py` ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved streaming response performance with incremental processing that eliminates repeated full-text rescanning.

* **Tests**
  * Added comprehensive tests for streaming implementation to ensure consistency with existing output behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->