### PR TITLE
perf(console): goals/tasks panels invalidate on the event bus, drop the 5s poll (closes #1310)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **The Goals and Tasks panels refresh on a bus push instead of polling every 5s.** Both
+  panels held a 5s `refetchInterval`; now the goal store publishes `goal.changed` (on
+  set/advance/clear) and the task store publishes `task.changed` (on create/update/
+  close/delete), and the panels invalidate off those `/api/events` pushes — the same
+  pattern the inbox panel already used. Live updates are now immediate (the agent files a
+  task → it appears at once) and steady-state polling is gone. (#1310)
+
 ### Fixed
 - **Mid-stream output rendering no longer rescans the whole response on every chunk.**
   The chat stream recomputed the visible `<output>` (and the live reasoning view) by

--- a/apps/web/src/app/GoalsPanel.tsx
+++ b/apps/web/src/app/GoalsPanel.tsx
@@ -9,10 +9,11 @@ import {
   useSuspenseQuery,
 } from "@tanstack/react-query";
 import { Trash2 } from "lucide-react";
-import { Suspense } from "react";
+import { Suspense, useEffect } from "react";
 
 import { api } from "../lib/api";
 import { ago } from "../lib/format";
+import { onServerEvent } from "../lib/events";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { goalsQuery, queryKeys } from "../lib/queries";
 import { ErrorBoundary, PanelError, PanelSkeleton } from "./ErrorBoundary";
@@ -42,6 +43,13 @@ function GoalsList() {
     mutationFn: (sessionId: string) => api.clearGoal(sessionId),
     onSettled: () => queryClient.invalidateQueries({ queryKey: queryKeys.goals }),
   });
+
+  // Live: the agent set/advanced/cleared a goal mid-turn — refresh off the `goal.changed`
+  // bus push instead of polling every 5s (#1310), the same pattern as the inbox panel.
+  useEffect(
+    () => onServerEvent("goal.changed", () => void queryClient.invalidateQueries({ queryKey: queryKeys.goals })),
+    [queryClient],
+  );
 
   if (!goals.length) {
     return (

--- a/apps/web/src/app/TasksPanel.tsx
+++ b/apps/web/src/app/TasksPanel.tsx
@@ -21,6 +21,7 @@ import {
 import { Suspense, useEffect, useState } from "react";
 
 import { api } from "../lib/api";
+import { onServerEvent } from "../lib/events";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { tasksQuery, queryKeys } from "../lib/queries";
 import type { Task } from "../lib/types";
@@ -42,10 +43,11 @@ import { ScrollArea } from "@protolabsai/ui/data";
 import { StatusPill } from "./StatusPill";
 
 // The agent's task board (in-process tasks store), on the TanStack Query data
-// layer (ADR 0013): the issue list is a `useSuspenseQuery` (refetching while
-// mounted), create/start/close/reopen/delete are `useMutation`s that invalidate
-// it. The store is always initialized, so there's no init flow. Delete routes
-// through the App-owned confirm dialog via the `confirm` prop.
+// layer (ADR 0013): the issue list is a `useSuspenseQuery` that invalidates on the
+// `task.changed` bus push (the agent files/closes issues mid-turn) instead of
+// polling; create/start/close/reopen/delete are `useMutation`s that invalidate it.
+// The store is always initialized, so there's no init flow. Delete routes through
+// the App-owned confirm dialog via the `confirm` prop.
 
 type ConfirmRequest = {
   title: string;
@@ -163,6 +165,10 @@ function TasksBody({ confirm }: { confirm: (req: ConfirmRequest) => void }) {
   const issues = data.issues;
   const queryClient = useQueryClient();
   const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.tasks });
+
+  // Live: the agent created/closed/updated an issue mid-turn — refresh off the
+  // `task.changed` bus push instead of polling every 5s (#1310), like the inbox panel.
+  useEffect(() => onServerEvent("task.changed", invalidate), [queryClient]);
 
   const [dialogOpen, setDialogOpen] = useState(false);
   const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set(["closed"]));

--- a/apps/web/src/lib/queries.ts
+++ b/apps/web/src/lib/queries.ts
@@ -41,23 +41,22 @@ export const archetypesQuery = () =>
     queryFn: () => api.archetypes(),
   });
 
-// Goals the agent works toward (goal mode). Lives in the right sidebar and
-// refetches every 5s while mounted — the agent advances/clears goals mid-turn,
-// so the panel should track that without a manual refresh.
+// Goals the agent works toward (goal mode). Lives in the right sidebar; the panel
+// invalidates this on the `goal.changed` bus push (the agent set/advances/clears goals
+// mid-turn) instead of a 5s poll (#1310) — same pattern as the inbox.
 export const goalsQuery = () =>
   queryOptions({
     queryKey: queryKeys.goals,
     queryFn: () => api.goals(),
-    refetchInterval: 5_000,
   });
 
-// The agent's task board (in-process tasks store — always available). Refetches
-// while mounted so the panel tracks issues the agent files/closes mid-turn.
+// The agent's task board (in-process tasks store — always available). The panel
+// invalidates this on the `task.changed` bus push (issues the agent files/closes
+// mid-turn) instead of a 5s poll (#1310).
 export const tasksQuery = () =>
   queryOptions({
     queryKey: queryKeys.tasks,
     queryFn: () => api.tasks(),
-    refetchInterval: 5_000,
   });
 
 // Registered workflow recipes + the subagent registry — config, not live, so no

--- a/graph/goals/store.py
+++ b/graph/goals/store.py
@@ -20,6 +20,19 @@ from graph.goals.types import GoalState
 log = logging.getLogger(__name__)
 
 
+def _publish(topic: str, data: dict) -> None:
+    """Best-effort bus push so the console Goals panel can invalidate live on a change
+    instead of polling every 5s (#1310). No-op when the host hasn't wired a publisher
+    (unit tests / standalone use); a bus hiccup must never break a goal write."""
+    try:
+        from graph.plugins.host import HOST
+
+        if HOST.publish:
+            HOST.publish(topic, data)
+    except Exception:  # noqa: BLE001
+        pass
+
+
 def _resolve_base() -> Path:
     # Per-instance scoping (ADR 0004): namespace by PROTOAGENT_INSTANCE so two
     # agents on one machine don't share a goals dir — without this, scheduled /
@@ -116,6 +129,7 @@ class GoalStore:
                 json.dump(state.to_dict(), fh, indent=2, default=str)
             os.rename(tmp_path, path)
             tmp_path = None
+            _publish("goal.changed", {"session_id": state.session_id})
         except OSError as exc:
             log.error("[goal] write failed for session %s: %s", state.session_id, exc)
         finally:
@@ -133,6 +147,7 @@ class GoalStore:
         path = self._path(session_id)
         try:
             path.unlink()
+            _publish("goal.changed", {"session_id": session_id})
             return True
         except FileNotFoundError:
             return False

--- a/tasks/store.py
+++ b/tasks/store.py
@@ -21,6 +21,19 @@ from typing import Any
 
 from infra.paths import scope_leaf
 
+
+def _publish(topic: str, data: dict) -> None:
+    """Best-effort bus push so the console Tasks panel can invalidate live on a change
+    instead of polling every 5s (#1310). No-op when the host hasn't wired a publisher
+    (unit tests / standalone use); a bus hiccup must never break a task write."""
+    try:
+        from graph.plugins.host import HOST
+
+        if HOST.publish:
+            HOST.publish(topic, data)
+    except Exception:  # noqa: BLE001
+        pass
+
 DEFAULT_DB_PATH = "/sandbox/tasks/issues.db"
 
 # Open lifecycle states (closed is terminal). Mirrors the console's
@@ -136,6 +149,7 @@ class TaskStore:
                 ),
             )
             self._conn.commit()
+            _publish("task.changed", {"id": issue_id, "action": "created"})
             return dict(self._row(issue_id))
 
     def list(self, *, include_closed: bool = True) -> list[dict[str, Any]]:
@@ -176,6 +190,7 @@ class TaskStore:
             vals.append(_now())
             self._conn.execute(f"UPDATE issues SET {', '.join(sets)} WHERE id = ?", (*vals, issue_id))
             self._conn.commit()
+            _publish("task.changed", {"id": issue_id, "action": "updated"})
             return dict(self._row(issue_id))
 
     def close(self, issue_id: str, reason: str | None = None) -> dict[str, Any]:
@@ -190,10 +205,13 @@ class TaskStore:
                 (now, reason or "", now, issue_id),
             )
             self._conn.commit()
+            _publish("task.changed", {"id": issue_id, "action": "closed"})
             return dict(self._row(issue_id))
 
     def delete(self, issue_id: str) -> bool:
         with self._lock:
             cur = self._conn.execute("DELETE FROM issues WHERE id = ?", (issue_id,))
             self._conn.commit()
+            if cur.rowcount > 0:
+                _publish("task.changed", {"id": issue_id, "action": "deleted"})
             return cur.rowcount > 0

--- a/tests/test_goal_hooks.py
+++ b/tests/test_goal_hooks.py
@@ -98,9 +98,12 @@ async def test_finish_emits_goal_event_on_the_bus(tmp_path):
         c = GoalController(config=None, store=GoalStore(base_dir=str(tmp_path)))
         c.set_goal_safe("s", "reach target", {"type": "plugin", "check": "p:always"})
         await c.evaluate("s", last_text="done")
-        assert events and events[0][0] == "goal.achieved"
-        assert events[0][1]["condition"] == "reach target"
-        assert events[0][1]["status"] == "achieved"
+        # goal.achieved is broadcast on finish — alongside the lightweight goal.changed
+        # store pushes (#1310), so find it rather than assume it's first.
+        achieved = [d for t, d in events if t == "goal.achieved"]
+        assert achieved, f"goal.achieved not on the bus: {[t for t, _ in events]}"
+        assert achieved[0]["condition"] == "reach target"
+        assert achieved[0]["status"] == "achieved"
     finally:
         HOST.publish = orig
         set_plugin_verifiers({})

--- a/tests/test_goal_store.py
+++ b/tests/test_goal_store.py
@@ -82,3 +82,26 @@ def test_resolve_base_is_instance_scoped(monkeypatch, tmp_path):
     # No instance id → unscoped (single-instance back-compat).
     monkeypatch.delenv("PROTOAGENT_INSTANCE", raising=False)
     assert goal_store._resolve_base() == tmp_path
+
+
+def test_set_and_clear_publish_goal_changed(tmp_path, monkeypatch):
+    """A goal write/clear pushes `goal.changed` on the bus so the console Goals panel
+    invalidates live instead of polling every 5s (#1310)."""
+    from graph.plugins import host
+
+    events: list[tuple] = []
+    monkeypatch.setattr(host.HOST, "publish", lambda topic, data: events.append((topic, data)))
+    store = GoalStore(tmp_path)
+    store.set(GoalState(session_id="s1", condition="x"))
+    assert store.clear("s1") is True
+    assert [t for t, _ in events] == ["goal.changed", "goal.changed"]
+    assert events[0][1]["session_id"] == "s1"
+
+
+def test_clear_missing_does_not_publish(tmp_path, monkeypatch):
+    from graph.plugins import host
+
+    events: list[tuple] = []
+    monkeypatch.setattr(host.HOST, "publish", lambda topic, data: events.append((topic, data)))
+    assert GoalStore(tmp_path).clear("nope") is False
+    assert events == []  # nothing was cleared → no event

--- a/tests/test_tasks_store.py
+++ b/tests/test_tasks_store.py
@@ -113,3 +113,31 @@ def test_operator_adapter_maps_to_store(store):
     a.close("/x", "task-1", "shipped")
     assert store.get("task-1")["status"] == "closed"
     assert a.delete("/x", "task-1") == {"deleted": True}
+
+
+def test_mutations_publish_task_changed(store, monkeypatch):
+    """create/update/close/delete push `task.changed` so the console Tasks panel
+    invalidates live instead of polling every 5s (#1310)."""
+    from graph.plugins import host
+
+    events: list[tuple] = []
+    monkeypatch.setattr(host.HOST, "publish", lambda topic, data: events.append((topic, data)))
+    issue = store.create("do a thing")
+    store.update(issue["id"], status="in_progress")
+    store.close(issue["id"])
+    assert store.delete(issue["id"]) is True
+    assert [(t, d["action"]) for t, d in events] == [
+        ("task.changed", "created"),
+        ("task.changed", "updated"),
+        ("task.changed", "closed"),
+        ("task.changed", "deleted"),
+    ]
+
+
+def test_delete_missing_does_not_publish(store, monkeypatch):
+    from graph.plugins import host
+
+    events: list[tuple] = []
+    monkeypatch.setattr(host.HOST, "publish", lambda topic, data: events.append((topic, data)))
+    assert store.delete("bd-404") is False
+    assert events == []  # nothing deleted → no event


### PR DESCRIPTION
Closes #1310 (the second item; the O(N²) item shipped in #1311).

The **Goals** and **Tasks** right-sidebar panels each held a `refetchInterval: 5_000` — so the console polled goals + the tasks board every 5s, per mounted panel, forever. The inbox panel already does it right: invalidate off an `/api/events` push. This brings goals/tasks to the same model.

## Backend — publish change events at the store seam
The store is the single seam, so this fires for **both** agent-tool writes (mid-turn) and console-API writes:
- `graph/goals/store.py` — `set()` / `clear()` publish **`goal.changed`** (covers create, each goal-loop iteration, finish, and clear — the controller routes them all through the store).
- `tasks/store.py` — `create` / `update` / `close` / `delete` publish **`task.changed`** (delete only when a row was actually removed).

Both go through the best-effort `HOST.publish` seam, are **no-ops when no publisher is wired** (unit tests / standalone), and never break a write on a bus hiccup.

## Frontend
- `GoalsPanel` / `TasksPanel` subscribe to `goal.changed` / `task.changed` and invalidate their query (mirrors `InboxPanel`).
- `queries.ts` — drop the 5s `refetchInterval` from `goalsQuery` + `tasksQuery`.

Net: live updates are now **immediate** (agent files a task → it shows at once) and steady-state polling is gone.

## Tests
- Store-level: each mutation publishes the right `*.changed` event; a no-op clear/delete publishes nothing.
- Updated the goal-hooks bus test to find `goal.achieved` among the new `goal.changed` pushes rather than assuming it's the first event.
- `ruff` ✓ · `lint-imports` ✓ (3 kept, 0 broken) · `pytest tests/` ✓ (2507) · `live_smoke` ✓ · web `vitest` ✓ (115) · goals/tasks e2e batch ✓ (20).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Goals and tasks now update in real-time as changes occur, eliminating the previous polling delay.

* **Tests**
  * Added test coverage for real-time event publication on goal and task modifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->