### PR TITLE
feat(tooling): scripts/reset.sh — CLI factory-reset for the default instance (closes #1159)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **`scripts/reset.sh` — factory-reset the default (prod) instance from the CLI.** Wipes
+  the prod instance's data + local config back to a clean slate so the next boot runs the
+  setup wizard (for testing the fresh-user flow). Safe on a multi-instance machine: every
+  *other* instance (any `~/.protoagent/<name>` with an `.instance-uid`, the dev sandbox,
+  fleet members) and every scoped `<store>/<instance>` leaf is preserved — only prod's
+  unscoped DBs + direct files are removed; tracked `config/` files are `git checkout`-
+  restored, gitignored local config deleted. `--dry-run` prints the exact plan;
+  `--keep-secrets` / `--include-dev` / `--backup` / `--force` / `--yes`. No in-app reset
+  (deliberately CLI-only). (#1159)
+
 ### Changed
 - **The Goals and Tasks panels refresh on a bus push instead of polling every 5s.** Both
   panels held a 5s `refetchInterval`; now the goal store publishes `goal.changed` (on

--- a/PROTO.md
+++ b/PROTO.md
@@ -21,6 +21,17 @@ TypeScript is the console.
   chat/tasks/knowledge. The default instance (`config/` + `~/.protoagent`, `:7870`)
   is untouched. `scripts/dev-reset.sh` wipes just the sandbox. Use this for feature
   testing instead of the default instance.
+- **Factory-reset the default instance:** `scripts/reset.sh` wipes the **prod**
+  instance's data + local config back to a clean slate (next boot runs the setup
+  wizard) — for testing the fresh-user flow via CLI (there is no in-app reset).
+  **Always `scripts/reset.sh --dry-run` first** to read the plan. It's safe on a
+  multi-instance machine: every *other* instance (any `~/.protoagent/<name>` with an
+  `.instance-uid`, the dev sandbox, fleet members) and every scoped
+  `<store>/<instance>` leaf is preserved — only prod's unscoped DBs + the direct
+  files in shared store dirs are removed; tracked `config/` files are `git checkout`-
+  restored, gitignored local config deleted. Flags: `--yes`, `--backup`,
+  `--keep-secrets` (keep gateway creds), `--include-dev`, `--force` (stop a bound
+  server first).
 - **Python deps:** managed with `uv` (`pyproject.toml [project.dependencies]` is
   the source of truth; `uv.lock` is tracked). `uv sync` to install.
 - **Console deps:** `npm ci` at the repo root (npm workspaces; the web app is

--- a/scripts/reset.sh
+++ b/scripts/reset.sh
@@ -1,0 +1,191 @@
+#!/usr/bin/env bash
+#
+# Factory-reset the DEFAULT ("prod") protoAgent instance: wipe its data + local
+# config back to a clean slate so the next boot runs the setup wizard. For local
+# testing of the fresh-user flow. (Reset ONLY the dev sandbox instead with
+# scripts/dev-reset.sh; there is intentionally NO in-app factory reset — #1159.)
+#
+# SAFE ON A MULTI-INSTANCE MACHINE — it preserves EVERY OTHER instance:
+#   * any  ~/.protoagent/<name>  that carries an instance marker (.instance-uid /
+#     checkpoints.db) is left untouched (the dev sandbox, fleet members, forks);
+#   * inside a shared store dir (knowledge/, memory/, tasks/, …) every
+#     <store>/<instance> leaf (a SUBDIRECTORY) is preserved — only prod's own
+#     unscoped top-level DBs and the direct files in those store dirs are removed.
+# Shipped/tracked files in config/ are RESTORED to pristine (git checkout); only
+# gitignored local config is deleted.
+#
+#   scripts/reset.sh --dry-run       # print exactly what would change; delete nothing
+#   scripts/reset.sh                 # confirm, then reset prod (keeps every other instance)
+#   scripts/reset.sh --yes           # skip the typed confirmation
+#   scripts/reset.sh --backup        # timestamped tar.gz of data + config first
+#   scripts/reset.sh --keep-secrets  # keep secrets.yaml + langgraph-config.yaml (no re-auth)
+#   scripts/reset.sh --include-dev   # ALSO wipe the `dev` sandbox (its data + config/dev)
+#   scripts/reset.sh --force         # stop a server still bound to the port first
+#
+# ALWAYS run --dry-run first on a busy machine and read the plan.
+set -euo pipefail
+cd "$(dirname "$0")/.."
+REPO="$(pwd)"
+
+# ── flags ─────────────────────────────────────────────────────────────────────
+DRY_RUN=false; ASSUME_YES=false; DO_BACKUP=false
+KEEP_SECRETS=false; INCLUDE_DEV=false; FORCE=false
+for arg in "$@"; do
+  case "$arg" in
+    --dry-run|-n) DRY_RUN=true ;;
+    --yes|-y) ASSUME_YES=true ;;
+    --backup) DO_BACKUP=true ;;
+    --keep-secrets) KEEP_SECRETS=true ;;
+    --include-dev) INCLUDE_DEV=true ;;
+    --force) FORCE=true ;;
+    -h|--help) sed -n '2,33p' "$0"; exit 0 ;;
+    *) echo "unknown option: $arg (try --help)" >&2; exit 2 ;;
+  esac
+done
+
+# ── paths ─────────────────────────────────────────────────────────────────────
+# Mirror infra.paths.data_home(): /sandbox in a container, else ~/.protoagent.
+if [ -d /sandbox ]; then DATA="/sandbox"; else DATA="${HOME}/.protoagent"; fi
+CONFIG="${PROTOAGENT_CONFIG_DIR:-${REPO}/config}"
+PORT="${PORT:-7870}"
+
+# Gitignored local config to DELETE (the prod instance's machine-local state).
+CONFIG_IGNORED=(langgraph-config.yaml secrets.yaml .setup-complete plugins)
+# Shipped/tracked config to RESTORE to pristine (git checkout, never delete).
+CONFIG_TRACKED=(config/SOUL.md config/skills config/plugin-catalog.json
+                config/mcp-catalog.json config/soul-presets config/langgraph-config.example.yaml
+                plugins.lock)
+
+# ── helpers ───────────────────────────────────────────────────────────────────
+say()  { printf '%s\n' "$*"; }
+plan() { printf '  %s\n' "$*"; }
+run() { if $DRY_RUN; then printf '  [dry-run] %s\n' "$*"; else "$@"; fi; }
+
+is_instance_root() { [ -e "$1/.instance-uid" ] || [ -e "$1/checkpoints.db" ]; }
+
+# A server still bound to PORT holds WAL handles — a wipe is pointless until it exits.
+running_pids() { command -v lsof >/dev/null 2>&1 && lsof -ti "tcp:${PORT}" -sTCP:LISTEN 2>/dev/null || true; }
+
+# ── 0. running-server guard ───────────────────────────────────────────────────
+PIDS="$(running_pids)"
+if [ -n "$PIDS" ]; then
+  if $FORCE && ! $DRY_RUN; then
+    say "▶ stopping server on :${PORT} (pids: ${PIDS//$'\n'/ })"
+    # shellcheck disable=SC2086
+    kill $PIDS 2>/dev/null || true
+    for _ in 1 2 3 4 5 6 7 8 9 10; do [ -n "$(running_pids)" ] || break; sleep 0.5; done
+    # shellcheck disable=SC2046
+    [ -z "$(running_pids)" ] || kill -9 $(running_pids) 2>/dev/null || true
+  elif ! $DRY_RUN; then
+    say "✗ a server is bound to :${PORT} (pids: ${PIDS//$'\n'/ })."
+    say "  Stop it first, or pass --force to SIGTERM it. (A live process holds WAL handles.)"
+    exit 1
+  else
+    plan "NOTE: a server is bound to :${PORT} (pids: ${PIDS//$'\n'/ }) — stop it (or --force) before a real run."
+  fi
+fi
+
+# ── 1. the plan ───────────────────────────────────────────────────────────────
+KEEP="dev"; $INCLUDE_DEV && KEEP=""
+say ""
+say "Factory reset — DEFAULT (prod) instance"
+say "  data:   ${DATA}"
+say "  config: ${CONFIG}"
+$DRY_RUN && say "  mode:   DRY RUN (nothing will be deleted)"
+say ""
+
+if [ -d "$DATA" ]; then
+  say "Data home (${DATA}):"
+  PRESERVED=()
+  while IFS= read -r entry; do
+    name="$(basename "$entry")"
+    if [ -d "$entry" ] && is_instance_root "$entry"; then
+      if [ -n "$KEEP" ] || [ "$name" != "dev" ]; then PRESERVED+=("$name"); continue; fi
+    fi
+    if [ -f "$entry" ] || [ -L "$entry" ]; then
+      plan "delete prod file:  ${name}"
+    elif [ -d "$entry" ]; then
+      # A store dir: prod's content is its DIRECT FILES; every subdir is a
+      # <store>/<instance> leaf and is preserved (unless --include-dev → drop dev/).
+      files=$(find "$entry" -mindepth 1 -maxdepth 1 -type f 2>/dev/null | wc -l | tr -d ' ')
+      leaves=$(find "$entry" -mindepth 1 -maxdepth 1 -type d 2>/dev/null | wc -l | tr -d ' ')
+      plan "store dir ${name}/: drop ${files} prod file(s); keep ${leaves} instance leaf(s)$( $INCLUDE_DEV && [ -d "$entry/dev" ] && echo ' (minus dev/)')"
+    fi
+  done < <(find "$DATA" -mindepth 1 -maxdepth 1 | sort)
+  [ ${#PRESERVED[@]} -gt 0 ] && plan "PRESERVE other instances: ${PRESERVED[*]}"
+else
+  plan "(no data home at ${DATA})"
+fi
+
+say ""
+say "Config (${CONFIG}):"
+for f in "${CONFIG_IGNORED[@]}"; do
+  if $KEEP_SECRETS && { [ "$f" = "secrets.yaml" ] || [ "$f" = "langgraph-config.yaml" ]; }; then
+    [ -e "${CONFIG}/${f}" ] && plan "keep (--keep-secrets): ${f}"
+    continue
+  fi
+  [ -e "${CONFIG}/${f}" ] && plan "delete local:  ${f}"
+done
+$INCLUDE_DEV && [ -e "${CONFIG}/dev" ] && plan "delete dev config:  dev/"
+for p in "${CONFIG_TRACKED[@]}"; do plan "restore tracked: ${p}"; done
+
+if $DRY_RUN; then
+  say ""
+  say "Dry run complete — nothing was changed."
+  exit 0
+fi
+
+# ── 2. confirm ────────────────────────────────────────────────────────────────
+if ! $ASSUME_YES; then
+  say ""
+  printf "Type 'reset' to wipe the prod instance (other instances are preserved): "
+  read -r reply
+  [ "$reply" = "reset" ] || { say "aborted."; exit 1; }
+fi
+
+# ── 3. backup ─────────────────────────────────────────────────────────────────
+if $DO_BACKUP; then
+  TS="$(date +%Y%m%d-%H%M%S)"
+  BK="${HOME}/protoagent-backup-${TS}.tar.gz"
+  say "▶ backing up data + config → ${BK}"
+  tar czf "$BK" -C "$HOME" "$(realpath --relative-to="$HOME" "$DATA" 2>/dev/null || echo .protoagent)" \
+      -C "$REPO" config 2>/dev/null || say "  (backup best-effort; some paths skipped)"
+fi
+
+# ── 4. wipe prod data (preserving every other instance) ───────────────────────
+if [ -d "$DATA" ]; then
+  while IFS= read -r entry; do
+    name="$(basename "$entry")"
+    if [ -d "$entry" ] && is_instance_root "$entry"; then
+      if [ -n "$KEEP" ] || [ "$name" != "dev" ]; then continue; fi
+    fi
+    if [ -f "$entry" ] || [ -L "$entry" ]; then
+      run rm -f "$entry"
+    elif [ -d "$entry" ]; then
+      # delete prod's direct files; preserve every <store>/<instance> subdir
+      while IFS= read -r f; do run rm -f "$f"; done < <(find "$entry" -mindepth 1 -maxdepth 1 -type f)
+      if $INCLUDE_DEV && [ -d "$entry/dev" ]; then run rm -rf "$entry/dev"; fi
+      rmdir "$entry" 2>/dev/null || true  # remove if now empty (held no instance leaf)
+    fi
+  done < <(find "$DATA" -mindepth 1 -maxdepth 1 | sort)
+fi
+# --include-dev: also drop the dev instance root + its scoped data leaves.
+if $INCLUDE_DEV; then
+  run rm -rf "${DATA:?}/dev"
+  while IFS= read -r leaf; do run rm -rf "$leaf"; done \
+    < <(find "$DATA" -mindepth 2 -maxdepth 2 -type d -name dev 2>/dev/null)
+fi
+
+# ── 5. config: delete gitignored local state, restore tracked to pristine ─────
+for f in "${CONFIG_IGNORED[@]}"; do
+  if $KEEP_SECRETS && { [ "$f" = "secrets.yaml" ] || [ "$f" = "langgraph-config.yaml" ]; }; then continue; fi
+  [ -e "${CONFIG}/${f}" ] && run rm -rf "${CONFIG:?}/${f}"
+done
+$INCLUDE_DEV && [ -e "${CONFIG}/dev" ] && run rm -rf "${CONFIG:?}/dev"
+# Restore the shipped/tracked files only if they're tracked in this repo.
+for p in "${CONFIG_TRACKED[@]}"; do
+  git -C "$REPO" ls-files --error-unmatch "$p" >/dev/null 2>&1 && run git -C "$REPO" checkout -- "$p"
+done
+
+say ""
+say "✓ prod instance reset. Next boot (python -m server) runs the setup wizard."

--- a/tests/test_reset_script.py
+++ b/tests/test_reset_script.py
@@ -1,0 +1,114 @@
+"""`scripts/reset.sh` dry-run safety (#1159).
+
+The factory-reset script is destructive, so its dangerous logic — "target prod's
+unscoped data, preserve EVERY sibling instance + every scoped <store>/<instance>
+leaf" — is pinned here by running it in `--dry-run` against a synthetic data tree
+and asserting (a) the plan targets the right things and (b) it deletes NOTHING.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+from pathlib import Path
+
+import pytest
+
+REPO = Path(__file__).resolve().parents[1]
+SCRIPT = REPO / "scripts" / "reset.sh"
+
+# data_home() prefers /sandbox over $HOME/.protoagent; if it exists the script
+# would target it instead of our test HOME, so skip there (CI has no /sandbox).
+_SANDBOX = pytest.mark.skipif(Path("/sandbox").is_dir(), reason="data_home() would target /sandbox")
+
+
+def _run(args: list[str], home: Path, cfg: Path):
+    env = {**os.environ, "HOME": str(home), "PROTOAGENT_CONFIG_DIR": str(cfg)}
+    return subprocess.run(
+        ["bash", str(SCRIPT), *args], capture_output=True, text=True, env=env, cwd=str(REPO)
+    )
+
+
+@_SANDBOX
+def test_dry_run_targets_prod_only_and_preserves_siblings(tmp_path):
+    home = tmp_path / "home"
+    data = home / ".protoagent"
+    data.mkdir(parents=True)
+    # prod (unscoped) state
+    (data / "checkpoints.db").write_text("x")
+    (data / "telemetry.db").write_text("x")
+    (data / ".instance-uid").write_text("x")
+    # a shared store dir: prod's direct file + two scoped instance leaves
+    (data / "knowledge" / "dev").mkdir(parents=True)
+    (data / "knowledge" / "roxy").mkdir(parents=True)
+    (data / "knowledge" / "agent.db").write_text("prod")
+    (data / "knowledge" / "dev" / "agent.db").write_text("dev")
+    (data / "knowledge" / "roxy" / "agent.db").write_text("roxy")
+    # a sibling instance ROOT (must be preserved wholesale)
+    (data / "sib").mkdir()
+    (data / "sib" / ".instance-uid").write_text("sib")
+
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "langgraph-config.yaml").write_text("x")
+    (cfg / "secrets.yaml").write_text("x")
+    (cfg / "plugins").mkdir()
+
+    out = _run(["--dry-run", "--yes"], home, cfg)
+    assert out.returncode == 0, out.stderr
+    plan = out.stdout
+
+    assert "delete prod file:  checkpoints.db" in plan
+    assert "delete prod file:  telemetry.db" in plan
+    assert "delete prod file:  .instance-uid" in plan
+    # the shared store dir: drop prod's 1 file, KEEP the 2 instance leaves
+    assert "store dir knowledge/: drop 1 prod file(s); keep 2 instance leaf(s)" in plan
+    # sibling instance root preserved + dev (default keeps dev too)
+    assert "PRESERVE other instances:" in plan and "sib" in plan
+    assert "delete local:  langgraph-config.yaml" in plan
+    assert "delete local:  plugins" in plan
+    assert "restore tracked: config/SOUL.md" in plan
+
+    # CRITICAL: a dry run deletes NOTHING.
+    assert (data / "checkpoints.db").exists()
+    assert (data / "knowledge" / "agent.db").exists()
+    assert (data / "knowledge" / "dev" / "agent.db").exists()
+    assert (data / "sib" / ".instance-uid").exists()
+    assert (cfg / "langgraph-config.yaml").exists()
+    assert (cfg / "plugins").is_dir()
+
+
+@_SANDBOX
+def test_dry_run_keep_secrets_preserves_creds(tmp_path):
+    home = tmp_path / "home"
+    (home / ".protoagent").mkdir(parents=True)
+    cfg = tmp_path / "config"
+    cfg.mkdir()
+    (cfg / "secrets.yaml").write_text("x")
+    (cfg / "langgraph-config.yaml").write_text("x")
+    (cfg / "plugins").mkdir()
+
+    out = _run(["--dry-run", "--yes", "--keep-secrets"], home, cfg)
+    assert out.returncode == 0, out.stderr
+    plan = out.stdout
+    assert "keep (--keep-secrets): secrets.yaml" in plan
+    assert "keep (--keep-secrets): langgraph-config.yaml" in plan
+    assert "delete local:  langgraph-config.yaml" not in plan
+    assert "delete local:  plugins" in plan  # plugins still wiped
+
+
+@_SANDBOX
+def test_dry_run_include_dev_wipes_dev(tmp_path):
+    home = tmp_path / "home"
+    data = home / ".protoagent"
+    (data / "dev").mkdir(parents=True)
+    (data / "dev" / ".instance-uid").write_text("dev")
+    cfg = tmp_path / "config"
+    (cfg / "dev").mkdir(parents=True)
+
+    out = _run(["--dry-run", "--yes", "--include-dev"], home, cfg)
+    assert out.returncode == 0, out.stderr
+    plan = out.stdout
+    # default keeps dev; --include-dev drops it from the preserve set + wipes its config
+    assert "PRESERVE other instances:" not in plan or "dev" not in plan.split("PRESERVE")[-1]
+    assert "delete dev config:  dev/" in plan


### PR DESCRIPTION
Closes #1159 — the **CLI** half. The in-app factory reset is **deliberately not built**: a running server deleting its own WAL-locked data and relaunching is too risky for the value; the supported path is this script (run with the server stopped). Scoped down per discussion on the issue.

## What it does
`scripts/reset.sh` wipes the default ("prod") instance's data + local config back to a clean slate, so the next `python -m server` boots into the setup wizard — for testing the fresh-user flow.

## Safe on a multi-instance machine
Validated against a **real `~/.protoagent`** with 5 sibling instance roots (`cismoke`, `coding`, `dev`, `ptcg`, `roxy`) + dozens of roxy-spawned scoped team leaves. The script:
- **preserves every other instance** — any `~/.protoagent/<name>` carrying an `.instance-uid` / `checkpoints.db` is left untouched;
- **preserves every scoped `<store>/<instance>` leaf** — inside shared store dirs (`knowledge/`, `tasks/`, `background/`, …) only prod's *direct files* are removed; all subdirectories (instance leaves) stay;
- removes prod's unscoped top-level DBs (`checkpoints.db`, `telemetry.db`, `a2a-*.db`, `skills.db`, `.instance-uid`, …);
- `git checkout`-restores tracked `config/` files to pristine (SOUL.md, skills/, catalogs, soul-presets, example yaml, plugins.lock); deletes only gitignored local config (`langgraph-config.yaml`, `secrets.yaml`, `.setup-complete`, `plugins/`).

```
$ scripts/reset.sh --dry-run        # ← ALWAYS run first; prints the exact plan, deletes nothing
  store dir knowledge/: drop 1 prod file(s); keep 26 instance leaf(s)
  ...
  PRESERVE other instances: cismoke coding dev ptcg roxy
```

## Flags
`--dry-run` · `--yes` · `--backup` (timestamped tar.gz) · `--keep-secrets` (keep `secrets.yaml` + `langgraph-config.yaml`, no gateway re-auth) · `--include-dev` (also wipe the dev sandbox) · `--force` (SIGTERM a server still bound to `:7870` — refuses otherwise, since a live process holds WAL handles).

## Tests / verification
- `tests/test_reset_script.py` — drives `--dry-run` against a synthetic tree and asserts the plan targets prod-only, **preserves siblings + leaves, and deletes NOTHING** (plus `--keep-secrets` / `--include-dev` plan variants). 3 pass.
- Verified the **real deletion** path end-to-end in an isolated tmp `HOME`: prod files gone, dev + roxy leaves + sibling instance intact.
- `ruff` ✓ · `bash -n` ✓ · docs in `PROTO.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced factory-reset utility with configurable safety options: dry-run mode for planning, user confirmation, backup creation, selective credential preservation, development-environment isolation, and automatic server cleanup.
  * Smart preservation of sibling instances and shared storage during reset operations.

* **Tests**
  * Added comprehensive test coverage for reset operations ensuring safety and correct multi-instance handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->