### PR TITLE
chore(issues): issue forms + silent validation gate

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -1,0 +1,54 @@
+name: Bug report
+description: Something is broken or behaves incorrectly.
+title: "bug: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for filing. The required fields below map 1:1 to the issue gate
+        (`.github/workflows/issue-gate.yml`) — fill them and the gate passes.
+        See #1300 / #1310 for the house style.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / what's wrong
+      description: What's broken, and where? Name the file / subsystem, and link the relevant ADR if any.
+      placeholder: "`server/chat.py` does X every chunk but the contract says Y…"
+    validations:
+      required: true
+  - type: textarea
+    id: repro
+    attributes:
+      label: Steps to reproduce / evidence
+      description: Minimal steps, logs, or a stack trace that demonstrate it.
+    validations:
+      required: true
+  - type: textarea
+    id: expected-actual
+    attributes:
+      label: Expected vs. actual
+      description: What you expected to happen, and what actually happened.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: How we'll know it's fixed — verifiable criteria.
+    validations:
+      required: true
+  - type: input
+    id: env
+    attributes:
+      label: Environment
+      description: Instance (default/dev), OS, app vs. CLI, version / commit.
+    validations:
+      required: false
+  - type: textarea
+    id: refs
+    attributes:
+      label: Refs
+      description: Related issues / PRs / ADRs (e.g. #1298, ADR 0047).
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,11 @@
+# Keep blank issues enabled: maintainers/agents may file intentional free-form
+# issues (tracking notes, quick split-outs). The gate flags those unless they
+# carry the `gate-exempt` label — see CONTRIBUTING.md.
+blank_issues_enabled: true
+contact_links:
+  - name: Issue standard & contributing
+    url: https://github.com/protoLabsAI/protoAgent/blob/main/CONTRIBUTING.md
+    about: What a good issue needs (the same checks the silent gate runs) and how to clear the needs-info label.
+  - name: Report a security vulnerability
+    url: https://github.com/protoLabsAI/protoAgent/security/advisories/new
+    about: Disclose vulnerabilities privately — do not open a public issue.

--- a/.github/ISSUE_TEMPLATE/enhancement.yml
+++ b/.github/ISSUE_TEMPLATE/enhancement.yml
@@ -1,0 +1,39 @@
+name: Enhancement / feature
+description: A new capability, or an improvement to an existing one.
+title: "feat: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        The required fields below map 1:1 to the issue gate
+        (`.github/workflows/issue-gate.yml`) — fill them and the gate passes.
+        See #1159 for the house style.
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem / motivation
+      description: What gap or pain motivates this? Who's affected, and where does it live today?
+    validations:
+      required: true
+  - type: textarea
+    id: proposal
+    attributes:
+      label: Proposed direction
+      description: Sketch the approach. Multiple options are fine — note the trade-offs.
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance
+      description: Verifiable criteria for "done".
+    validations:
+      required: true
+  - type: textarea
+    id: refs
+    attributes:
+      label: Refs
+      description: Related issues / PRs / ADRs.
+    validations:
+      required: false

--- a/.github/workflows/issue-gate.yml
+++ b/.github/workflows/issue-gate.yml
@@ -1,0 +1,92 @@
+name: Issue gate
+
+# Validates every opened/edited issue against the issue standard (CONTRIBUTING.md).
+# Non-conforming issues get the `needs-info` label and NOTHING else — the gate is
+# silent (never comments) and never closes. Editing an issue to conform removes the
+# label automatically. Issues labeled `gate-exempt` are skipped (maintainer escape).
+on:
+  issues:
+    types: [opened, edited, reopened]
+
+permissions:
+  issues: write
+
+concurrency:
+  group: issue-gate-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/github-script@v7
+        with:
+          script: |
+            const GATE_LABEL = 'needs-info';
+            const EXEMPT_LABEL = 'gate-exempt';
+
+            const issue = context.payload.issue;
+            const num = issue.number;
+            const body = issue.body || '';
+            const labels = (issue.labels || [])
+              .map(l => (typeof l === 'string' ? l : l.name).toLowerCase());
+
+            async function ensureLabel(name, color, description) {
+              try {
+                await github.rest.issues.getLabel({ ...context.repo, name });
+              } catch (e) {
+                if (e.status === 404) {
+                  await github.rest.issues.createLabel({ ...context.repo, name, color, description });
+                } else { throw e; }
+              }
+            }
+
+            // Make both gate labels available in the picker (idempotent).
+            await ensureLabel(GATE_LABEL, 'fbca04',
+              'Issue is missing required sections — see CONTRIBUTING.md (silent issue gate).');
+            await ensureLabel(EXEMPT_LABEL, 'c5def5',
+              'Intentional free-form issue — skipped by the issue gate.');
+
+            if (labels.includes(EXEMPT_LABEL)) {
+              core.info(`#${num} is ${EXEMPT_LABEL}; skipping gate.`);
+              return;
+            }
+
+            // A "section" is a markdown heading (#..######) or a bold line (**…**).
+            const lines = body.split('\n');
+            const hasSection = (re) => lines.some(line => {
+              const m = line.match(/^\s*(?:#{1,6}\s+|\*\*\s*)(.+?)(?:\s*\*\*)?\s*$/);
+              return m && re.test(m[1]);
+            });
+
+            const text = body.replace(/\s+/g, ' ').trim();
+            const longEnough = text.length >= 80;
+            const hasProblem = hasSection(/problem|what'?s? wrong|motivation|background|context|summary/i);
+            const hasRepro = hasSection(/repro|reproduce|steps|evidence|expected|actual|observed/i);
+            const hasProposal = hasSection(/propos|solution|approach|direction|fix|design/i);
+            const hasAcceptance = hasSection(/acceptance|done when|success criteria|definition of done/i);
+
+            const missing = [];
+            if (!longEnough) missing.push('a substantive description (>= 80 chars)');
+            if (!hasProblem) missing.push('a Problem / What-is-wrong / Motivation section');
+            if (labels.includes('bug') && !hasRepro)
+              missing.push('Steps to reproduce / Evidence / Expected-vs-actual (bug)');
+            if (labels.includes('enhancement') && !hasProposal && !hasAcceptance)
+              missing.push('a Proposed-direction or Acceptance section (enhancement)');
+
+            const conforms = missing.length === 0;
+            const hasGate = labels.includes(GATE_LABEL);
+
+            if (conforms && hasGate) {
+              await github.rest.issues.removeLabel({
+                ...context.repo, issue_number: num, name: GATE_LABEL,
+              }).catch(() => {});
+              core.info(`#${num} now conforms; removed ${GATE_LABEL}.`);
+            } else if (!conforms && !hasGate) {
+              await github.rest.issues.addLabels({
+                ...context.repo, issue_number: num, labels: [GATE_LABEL],
+              });
+              core.warning(`#${num} missing: ${missing.join('; ')} -> labeled ${GATE_LABEL} (silent).`);
+            } else {
+              core.info(`#${num} unchanged (conforms=${conforms}, labeled=${hasGate}).`);
+            }

--- a/.github/workflows/issue-gate.yml
+++ b/.github/workflows/issue-gate.yml
@@ -17,7 +17,7 @@ concurrency:
 
 jobs:
   validate:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     steps:
       - uses: actions/github-script@v7
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing
+
+protoAgent's full contributor guide — run commands, the **must-pass-before-PR
+gates**, and the gotchas that recur — lives in **[PROTO.md](./PROTO.md)**. Read it
+before sending code.
+
+This file covers the one thing GitHub surfaces directly on the *New issue* page:
+**what a good issue needs.**
+
+## Filing an issue
+
+Use a template — **Bug report** or **Enhancement / feature** — whenever you can.
+A template's required fields are exactly what the gate checks, so a template-filed
+issue always passes.
+
+Every issue — however it's filed (web, `gh issue create`, or an agent) — should have:
+
+- **A substantive description.** Not just a title; state the actual problem.
+- **A Problem / What's-wrong / Motivation section** — *why* it matters, and
+  *where* (name the file / subsystem / ADR).
+- **Type-specific detail:**
+  - *Bug* (`bug` label): **Steps to reproduce / Evidence** and **Expected vs.
+    actual**.
+  - *Enhancement* (`enhancement` label): a **Proposed direction** and/or
+    **Acceptance** criteria.
+- **Refs** to related issues / PRs / ADRs where relevant (`#1300`, `ADR 0047`).
+
+See #1159, #1300, #1310 for the house style: Problem → (What's wrong / Proposed
+direction) → Acceptance → Refs.
+
+## The issue gate
+
+`.github/workflows/issue-gate.yml` runs on every opened/edited issue and checks
+the requirements above. It is **silent** — it never comments. An issue missing
+required sections just gets the **`needs-info`** label, nothing else.
+
+- **To clear it:** edit the issue to add the missing sections. The gate re-runs
+  on edit and **removes `needs-info`** automatically once the issue conforms.
+- **Intentional free-form** (a maintainer tracking note, a quick agent split-out):
+  add the **`gate-exempt`** label and the gate skips the issue.
+
+No required field blocks you from *opening* an issue — the gate only flags, it
+never closes.

--- a/PROTO.md
+++ b/PROTO.md
@@ -54,6 +54,17 @@ before the PR, not after. CI is the merge gate; a red PR is wasted cycles.
 If a change is genuinely test-free (docs, config, pure refactor), say so
 explicitly in the PR description — but that is the exception, not the default.
 
+## Filing issues
+
+Issues are gated too — but only **flagged**, never blocked. The silent
+`issue-gate` workflow (`.github/workflows/issue-gate.yml`) labels any issue
+missing the required structure with **`needs-info`** (no comment) and removes it
+once you edit the issue to conform. Use the **Bug** / **Enhancement** issue forms
+— their required fields match the gate; a free-form issue needs at least a
+*Problem / What's-wrong* section, plus repro + evidence (bugs) or a
+proposed-direction / acceptance (enhancements). Intentional free-form → add the
+`gate-exempt` label. Full checklist: **[CONTRIBUTING.md](./CONTRIBUTING.md)**.
+
 ---
 
 ## House rules & gotchas that bite


### PR DESCRIPTION
## What & why
We had **no issue templates, no CONTRIBUTING, and no issue gating** — only PR gates were documented. Yet our issues already follow a consistent implicit shape (Problem → What's-wrong / Proposed direction → Acceptance → Refs; see #1159/#1300/#1310). This codifies that standard and enforces it **without blocking authors**.

The workflow here is heavily CLI/agent-driven (`gh issue create`, board agents), and GitHub Issue Forms only enforce in the web UI — so forms alone would be silently bypassed. Hence: **forms to guide + a server-side workflow to gate everything**.

## Changes
- **`.github/ISSUE_TEMPLATE/bug.yml`, `enhancement.yml`** — issue forms whose *required field labels render as the exact `### headings` the gate greps for*, so a form-filed issue always passes. Auto-apply `bug` / `enhancement`.
- **`.github/ISSUE_TEMPLATE/config.yml`** — `blank_issues_enabled: true` (maintainer/agent free-form escape) + contact links (CONTRIBUTING, private security advisory).
- **`.github/workflows/issue-gate.yml`** — runs on `issues: opened/edited/reopened`. Flags non-conforming issues with **`needs-info`** and **nothing else** — it is **silent** (never comments) and **never closes**. Re-runs on edit and **removes the label once the issue conforms**. Skips `gate-exempt`. Ensures both labels exist (idempotent).
- **`CONTRIBUTING.md`** — the issue standard, which GitHub surfaces on the *New issue* page (the discoverable home for a silent gate's rules).
- **`PROTO.md`** — short *Filing issues* note pointing at the gate + CONTRIBUTING.

## Gate contract (what counts as conforming)
Non-exempt issues need: a substantive body (≥80 chars) + a *Problem / What's-wrong / Motivation* section; **bugs** also need repro/evidence/expected-vs-actual; **enhancements** also need a proposed-direction or acceptance section.

## Verification
Logic tested against real bodies — **#1159 (enhancement) PASS, #1300 PASS, form-bug PASS**; **#1310 (free-form perf, no Problem heading) FLAG, thin issue FLAG**. All four template/workflow YAMLs parse.

## Notes for review
- Decisions per request: forms+workflow, **label-only/silent on failure**, templates for **bug + enhancement + blank escape** (no separate perf template).
- First run creates labels `needs-info` (amber) and `gate-exempt` (blue).
- Docs-only/config change — no app tests apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added standardized GitHub issue templates for bug reports and enhancement requests
  * Implemented an automated issue validation workflow that checks issues against required sections and labels
  * Enabled blank issue submission and added clearer contribution/security guidance links
<!-- end of auto-generated comment: release notes by coderabbit.ai -->