### PR TITLE
fix(task-tool): error-state cards + subagent label + fold settled tools into a chip

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -310,6 +310,18 @@ function scenarioFor(prompt) {
         { id: "task-1", name: "task", phase: "end", output: "Subagent finished: found 1 result." },
       ],
     };
+  if (t.includes("FANOUT"))
+    // Two INDEPENDENT top-level tool calls (no task wrapping them) → both settle, so the
+    // console folds them behind a single "2 tools" summary chip (clutter cleanup).
+    return {
+      answer: "Ran a search and a calculation.",
+      events: [
+        { id: "fan-1", name: "web_search", phase: "start", input: JSON.stringify({ query: "coding agents" }) },
+        { id: "fan-1", name: "web_search", phase: "end", output: "1 result(s) for 'coding agents':\n1. Example — https://example.com/x\n   A snippet." },
+        { id: "fan-2", name: "calculator", phase: "start", input: JSON.stringify({ expression: "2 + 2" }) },
+        { id: "fan-2", name: "calculator", phase: "end", output: "2 + 2 = 4" },
+      ],
+    };
   if (t.includes("NOEND"))
     // A tool whose `end` frame never arrives (e.g. a workflow card whose end
     // races with the terminal `done`). The turn still completes — the client

--- a/apps/web/e2e/tool-fold.spec.ts
+++ b/apps/web/e2e/tool-fold.spec.ts
@@ -1,0 +1,23 @@
+import { expect, test } from "@playwright/test";
+
+// Clutter cleanup: once a turn fans out (≥2 finished tool calls), the settled cards fold
+// into a single expandable "N tools" summary chip so the answer isn't buried under a wall
+// of cards. The chip is collapsed by default; expanding it reveals the folded cards.
+test("settled tool cards fold into a summary chip", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+  await composer.fill("FANOUT do two things");
+  await composer.press("Enter");
+
+  // Both finished tools collapse behind one chip — the cards aren't rendered while folded.
+  const chip = page.locator(".pl-toolcard-summary");
+  await expect(chip).toBeVisible();
+  await expect(chip.locator(".pl-toolcard-summary__text")).toHaveText("2 tools");
+  await expect(page.locator(".pl-toolcard")).toHaveCount(0);
+
+  // Expand → both folded cards appear.
+  await chip.locator(".pl-toolcard-summary__head").click();
+  await expect(page.locator(".pl-toolcard")).toHaveCount(2);
+  await expect(page.locator(".pl-toolcard__name").first()).toHaveText("web_search");
+});

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1020,7 +1020,7 @@ function ChatSessionSlot({
                 // "thinking" inline next to the step it precedes.
                 message.parts.map((part, i, arr) =>
                   part.kind === "tools" ? (
-                    <ToolCalls key={i} calls={toolsForGroup(part.ids, message.toolCalls)} onCancelDelegation={cancelDelegation} />
+                    <ToolCalls key={i} calls={toolsForGroup(part.ids, message.toolCalls)} streaming={message.status === "streaming"} onCancelDelegation={cancelDelegation} />
                   ) : part.kind === "reasoning" ? (
                     part.text.trim() ? (
                       // Stream the animation only on the trailing run (thinking in progress).

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -89,32 +89,38 @@ export function ToolCalls({
   const running = top.filter((c) => c.status === "running");
   const settled = top.filter((c) => c.status !== "running");
   const failedCount = settled.filter((c) => c.status === "error").length;
+  // A lone finished tool isn't clutter — fold only once there are ≥2 settled cards, so a
+  // simple one-tool turn still reads as a normal card rather than a pointless "1 tool" chip.
+  const fold = settled.length >= 2;
 
-  // Only TOP-LEVEL groups get the cancel callback — a delegation is always a top-level
-  // `task`; its nested children (the subagent's own tools) aren't independently
-  // cancellable. Settled cards can't be cancelled either, so the chip's groups drop it.
-  const group = (call: ToolCall, cancellable: boolean) => (
+  // Only TOP-LEVEL `task` groups get the cancel callback (the Stop affordance only shows
+  // for a running task); nested children and settled cards never need it.
+  const group = (call: ToolCall) => (
     <ToolGroup
       key={call.id}
       call={call}
       childrenByParent={childrenByParent}
-      onCancelDelegation={cancellable ? onCancelDelegation : undefined}
+      onCancelDelegation={call.status === "running" ? onCancelDelegation : undefined}
     />
   );
 
+  // Common case (no fan-out): render every card inline in emission order — identical to a
+  // flat list, so a card never changes position (and never loses its expanded state) as it
+  // settles. Only a real fan-out (≥2 finished) splits running-vs-folded.
+  if (!fold) {
+    return <ToolCardList className="tool-calls">{top.map(group)}</ToolCardList>;
+  }
+
   return (
     <ToolCardList className="tool-calls">
-      {running.map((call) => group(call, true))}
-      {settled.length > 0 && (
-        <ToolCardSummary
-          count={settled.length}
-          label={settled.length === 1 ? "tool" : "tools"}
-          status={failedCount > 0 ? "error" : "done"}
-          failedCount={failedCount || undefined}
-        >
-          {settled.map((call) => group(call, false))}
-        </ToolCardSummary>
-      )}
+      {running.map(group)}
+      <ToolCardSummary
+        count={settled.length}
+        status={failedCount > 0 ? "error" : "done"}
+        failedCount={failedCount || undefined}
+      >
+        {settled.map(group)}
+      </ToolCardSummary>
     </ToolCardList>
   );
 }

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -62,9 +62,13 @@ function cardLabel(call: ToolCall): ReactNode {
  */
 export function ToolCalls({
   calls,
+  streaming = false,
   onCancelDelegation,
 }: {
   calls: ToolCall[];
+  /** The turn is still live. Keeps the spotlight slot reserved for the whole turn so the
+   *  layout doesn't bounce in the gap between one tool finishing and the next starting. */
+  streaming?: boolean;
   /** Abort a running top-level `task` delegation by its tool-call id (Tier 2). When
    *  omitted, no Stop affordance renders (e.g. historical/finished messages). */
   onCancelDelegation?: (id: string) => void;
@@ -81,17 +85,9 @@ export function ToolCalls({
       top.push(call);
     }
   }
-  // Spotlight the active work: running top-level cards render in full; finished ones
-  // fold into a single expandable summary chip ("N tools"), so a fan-out turn doesn't
-  // bury the answer under a wall of cards. "Settled" is the card's own status — a
-  // running subagent `task` stays full so its nested children stay visible. Once the
-  // turn ends nothing is running, so the whole run collapses into the chip.
   const running = top.filter((c) => c.status === "running");
   const settled = top.filter((c) => c.status !== "running");
   const failedCount = settled.filter((c) => c.status === "error").length;
-  // A lone finished tool isn't clutter — fold only once there are ≥2 settled cards, so a
-  // simple one-tool turn still reads as a normal card rather than a pointless "1 tool" chip.
-  const fold = settled.length >= 2;
 
   // Only TOP-LEVEL `task` groups get the cancel callback (the Stop affordance only shows
   // for a running task); nested children and settled cards never need it.
@@ -104,27 +100,40 @@ export function ToolCalls({
     />
   );
 
-  // Common case (no fan-out): render every card inline in emission order — identical to a
-  // flat list, so a card never changes position (and never loses its expanded state) as it
-  // settles. Only a real fan-out (≥2 finished) splits running-vs-folded.
-  if (!fold) {
-    return <ToolCardList className="tool-calls">{top.map(group)}</ToolCardList>;
+  // The folded summary chip — a running total of the whole block (running + settled), with
+  // the finished cards inside it.
+  const chip = (count: number) => (
+    <ToolCardSummary
+      count={count}
+      label={count === 1 ? "tool" : "tools"}
+      status={failedCount > 0 ? "error" : "done"}
+      failedCount={failedCount || undefined}
+    >
+      {settled.map(group)}
+    </ToolCardSummary>
+  );
+
+  // PINNED SPOTLIGHT (live turn): the active card(s) sit in a fixed-height slot that never
+  // collapses as tools cycle (`.tool-spotlight` reserves one row), and everything finished
+  // folds into the chip below. So the block holds a stable height for the whole turn — the
+  // column doesn't bounce as cards pop in and out; a finishing tool just crossfades from
+  // the slot into the chip. The chip is the running total, so it's present from the first
+  // finished tool onward.
+  if (streaming) {
+    return (
+      <ToolCardList className="tool-calls">
+        <div className="tool-spotlight">{running.map(group)}</div>
+        {settled.length > 0 && chip(top.length)}
+      </ToolCardList>
+    );
   }
 
-  return (
-    <ToolCardList className="tool-calls">
-      {running.map(group)}
-      <ToolCardSummary
-        // Running total for the block — counts every tool call (running + settled), so
-        // the tally ticks up live as tools fire, not just what's currently folded.
-        count={top.length}
-        status={failedCount > 0 ? "error" : "done"}
-        failedCount={failedCount || undefined}
-      >
-        {settled.map(group)}
-      </ToolCardSummary>
-    </ToolCardList>
-  );
+  // SETTLED (turn done for this block): a lone finished tool renders inline (no pointless
+  // "1 tool" chip); a real fan-out (≥2) stays folded.
+  if (settled.length >= 2) {
+    return <ToolCardList className="tool-calls">{chip(settled.length)}</ToolCardList>;
+  }
+  return <ToolCardList className="tool-calls">{top.map(group)}</ToolCardList>;
 }
 
 /** A tool card plus, when it's a subagent `task`, its nested child tool cards.

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -10,10 +10,12 @@ import {
   Wrench,
 } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
+import type { ReactNode } from "react";
 
 import { ToolCard, ToolCardList, ToolSection } from "@protolabsai/ui/tool-card";
 
 import type { ToolCall } from "../lib/types";
+import { ToolCardSummary } from "./ToolCardSummary";
 import { ToolValue } from "./tool-renderers";
 
 /** Map a tool name to a recognizable icon; falls back to a generic wrench. */
@@ -25,6 +27,29 @@ function iconFor(name: string): LucideIcon {
   if (name === "task") return Network; // subagent delegation
   if (name.startsWith("memory")) return Database;
   return Wrench;
+}
+
+/** Header label for a card. A `task` delegation surfaces WHICH subagent it ran
+ *  (`task → researcher`), read from the call's args, so the roster is visible at a
+ *  glance without expanding. The subagent type rides in `input` from the start frame,
+ *  so it shows while the delegation is still running; falls back to the bare name until
+ *  the args parse. */
+function cardLabel(call: ToolCall): ReactNode {
+  if (call.name !== "task" || !call.input) return call.name;
+  try {
+    const args = JSON.parse(call.input) as { subagent_type?: unknown };
+    const sub = args.subagent_type;
+    if (typeof sub === "string" && sub) {
+      return (
+        <>
+          task <span className="tool-subagent">→ {sub}</span>
+        </>
+      );
+    }
+  } catch {
+    /* args not valid JSON yet (mid-stream) — fall back to the bare name */
+  }
+  return call.name;
 }
 
 /**
@@ -56,19 +81,40 @@ export function ToolCalls({
       top.push(call);
     }
   }
+  // Spotlight the active work: running top-level cards render in full; finished ones
+  // fold into a single expandable summary chip ("N tools"), so a fan-out turn doesn't
+  // bury the answer under a wall of cards. "Settled" is the card's own status — a
+  // running subagent `task` stays full so its nested children stay visible. Once the
+  // turn ends nothing is running, so the whole run collapses into the chip.
+  const running = top.filter((c) => c.status === "running");
+  const settled = top.filter((c) => c.status !== "running");
+  const failedCount = settled.filter((c) => c.status === "error").length;
+
+  // Only TOP-LEVEL groups get the cancel callback — a delegation is always a top-level
+  // `task`; its nested children (the subagent's own tools) aren't independently
+  // cancellable. Settled cards can't be cancelled either, so the chip's groups drop it.
+  const group = (call: ToolCall, cancellable: boolean) => (
+    <ToolGroup
+      key={call.id}
+      call={call}
+      childrenByParent={childrenByParent}
+      onCancelDelegation={cancellable ? onCancelDelegation : undefined}
+    />
+  );
+
   return (
     <ToolCardList className="tool-calls">
-      {top.map((call) => (
-        // Only TOP-LEVEL groups get the cancel callback — a delegation is always a
-        // top-level `task`; its nested children (the subagent's own tools) aren't
-        // independently cancellable, so recursion drops `onCancelDelegation`.
-        <ToolGroup
-          key={call.id}
-          call={call}
-          childrenByParent={childrenByParent}
-          onCancelDelegation={onCancelDelegation}
-        />
-      ))}
+      {running.map((call) => group(call, true))}
+      {settled.length > 0 && (
+        <ToolCardSummary
+          count={settled.length}
+          label={settled.length === 1 ? "tool" : "tools"}
+          status={failedCount > 0 ? "error" : "done"}
+          failedCount={failedCount || undefined}
+        >
+          {settled.map((call) => group(call, false))}
+        </ToolCardSummary>
+      )}
     </ToolCardList>
   );
 }
@@ -136,7 +182,7 @@ function ToolGroup({
 
   return (
     <ToolCard
-      name={call.name}
+      name={cardLabel(call)}
       status={call.status}
       icon={<Icon size={13} />}
       duration={call.durationMs}

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -115,7 +115,9 @@ export function ToolCalls({
     <ToolCardList className="tool-calls">
       {running.map(group)}
       <ToolCardSummary
-        count={settled.length}
+        // Running total for the block — counts every tool call (running + settled), so
+        // the tally ticks up live as tools fire, not just what's currently folded.
+        count={top.length}
         status={failedCount > 0 ? "error" : "done"}
         failedCount={failedCount || undefined}
       >

--- a/apps/web/src/chat/ToolCardSummary.tsx
+++ b/apps/web/src/chat/ToolCardSummary.tsx
@@ -1,0 +1,59 @@
+import { useState, type ReactNode } from "react";
+
+/**
+ * TEMPORARY local mirror of the proposed `@protolabsai/ui` `ToolCardSummary`
+ * (protoContent#292). Folds a run of SETTLED tool cards into one expandable chip
+ * ("6 tools" / "6 tools · 1 failed") so the active card stays prominent. The API + DS
+ * class names match the upstream primitive 1:1, so once `@protolabsai/ui` releases it
+ * this file is deleted and the import swaps to `@protolabsai/ui/tool-card`.
+ */
+export function ToolCardSummary({
+  count,
+  label = "tools",
+  status = "done",
+  failedCount,
+  defaultOpen = false,
+  children,
+}: {
+  count: number;
+  label?: string;
+  status?: "done" | "error";
+  failedCount?: number;
+  defaultOpen?: boolean;
+  children: ReactNode;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const text = failedCount ? `${count} ${label} · ${failedCount} failed` : `${count} ${label}`;
+  return (
+    <div className={`pl-toolcard-summary pl-toolcard-summary--${status}`}>
+      <button
+        type="button"
+        className="pl-toolcard-summary__head"
+        aria-expanded={open}
+        onClick={() => setOpen((v) => !v)}
+      >
+        <span
+          className={`pl-toolcard__caret${open ? " pl-toolcard__caret--open" : ""}`}
+          aria-hidden
+        >
+          <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+            <path d="M9 6l6 6-6 6" />
+          </svg>
+        </span>
+        <span className={`pl-toolcard__status pl-toolcard__status--${status}`} aria-hidden>
+          {status === "error" ? (
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round">
+              <path d="M6 6l12 12M18 6L6 18" />
+            </svg>
+          ) : (
+            <svg viewBox="0 0 24 24" width="13" height="13" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+              <path d="M20 6L9 17l-5-5" />
+            </svg>
+          )}
+        </span>
+        <span className="pl-toolcard-summary__text">{text}</span>
+      </button>
+      {open && <div className="pl-toolcard-summary__body">{children}</div>}
+    </div>
+  );
+}

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -32,8 +32,9 @@
   align-items: center;
   gap: 7px;
   padding: 5px 9px;
-  background: none;
-  border: var(--pl-border-width) solid transparent;
+  /* Reads as a card even at rest — solid border + raised fill always visible (#1319). */
+  background: var(--pl-color-bg-raised);
+  border: var(--pl-border-width) solid var(--pl-color-border);
   border-radius: var(--pl-radius);
   color: var(--pl-color-fg-muted);
   font: inherit;
@@ -42,8 +43,7 @@
   cursor: pointer;
 }
 .pl-toolcard-summary__head:hover {
-  background: var(--pl-color-bg-raised);
-  border-color: var(--pl-color-border);
+  color: var(--pl-color-fg);
 }
 .pl-toolcard-summary__text {
   flex: 1 1 auto;

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -67,6 +67,34 @@
   color: var(--pl-color-fg-muted);
 }
 
+/* Pinned spotlight: while the turn streams, the active card(s) live in a slot that
+   reserves one card-row of height and never collapses as tools cycle (so the column
+   can't bounce). A finishing tool leaves the slot for the chip; the next crossfades in. */
+.tool-spotlight {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pl-space-2);
+  min-height: 30px; /* ~ one collapsed ToolCard head row */
+}
+.tool-spotlight > * {
+  animation: tool-spotlight-in var(--pl-motion-base, 160ms) var(--pl-motion-ease, ease) both;
+}
+@keyframes tool-spotlight-in {
+  from {
+    opacity: 0;
+    transform: translateY(-2px);
+  }
+  to {
+    opacity: 1;
+    transform: none;
+  }
+}
+@media (prefers-reduced-motion: reduce) {
+  .tool-spotlight > * {
+    animation: none;
+  }
+}
+
 /* Tier 2: Stop a running subagent delegation. Rides the DS header `actions` slot
    (.pl-toolcard__actions) as a compact, error-toned text button — quiet until
    hover so a long delegation reads as "running" first, "abortable" on intent. */

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -17,6 +17,56 @@
   white-space: normal;
 }
 
+/* TEMPORARY — mirrors the proposed DS `.pl-toolcard-summary*` (protoContent#292).
+   The summary chip folds a run of SETTLED cards into one expandable row so the active
+   card stays prominent. Delete this block once `@protolabsai/ui` ships the primitive
+   (its styles.css bundle then supplies these same rules) and ToolCardSummary.tsx swaps
+   to the DS import. */
+.pl-toolcard-summary {
+  min-width: 0;
+}
+.pl-toolcard-summary__head {
+  width: 100%;
+  min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  padding: 5px 9px;
+  background: none;
+  border: var(--pl-border-width) solid transparent;
+  border-radius: var(--pl-radius);
+  color: var(--pl-color-fg-muted);
+  font: inherit;
+  font-size: 12px;
+  text-align: left;
+  cursor: pointer;
+}
+.pl-toolcard-summary__head:hover {
+  background: var(--pl-color-bg-raised);
+  border-color: var(--pl-color-border);
+}
+.pl-toolcard-summary__text {
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.pl-toolcard-summary--error .pl-toolcard-summary__text {
+  color: var(--pl-color-status-error);
+}
+.pl-toolcard-summary__body {
+  display: flex;
+  flex-direction: column;
+  gap: var(--pl-space-2);
+  margin-top: 6px;
+}
+
+/* `task → researcher` — the subagent type in the delegation card header. */
+.tool-subagent {
+  color: var(--pl-color-fg-muted);
+}
+
 /* Tier 2: Stop a running subagent delegation. Rides the DS header `actions` slot
    (.pl-toolcard__actions) as a compact, error-toned text button — quiet until
    hover so a long delegation reads as "running" first, "abortable" on intent. */

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -7,6 +7,7 @@ Uses langchain's create_agent() with AgentMiddleware for the DeerFlow pattern.
 from typing import Annotated, Any
 
 from langchain.agents import create_agent
+from langchain_core.messages import ToolMessage
 from langchain_core.tools import BaseTool
 from langgraph.prebuilt import InjectedState
 
@@ -194,6 +195,13 @@ def _parse_compaction_trigger(spec: str):
     return ("fraction", 0.8)
 
 
+class SubagentError(RuntimeError):
+    """A subagent delegation failed hard (the subagent itself raised). The ``task``
+    tool converts this into a ``status="error"`` ToolMessage so the console renders
+    the delegation card as a failure (X) — not a green "done" wrapping an ``Error:``
+    string (which read as success). ``task_batch`` reports it inline and continues."""
+
+
 async def _run_subagent(
     *,
     config,
@@ -270,7 +278,10 @@ async def _run_subagent(
 
         return f"[{subagent_type} completed: {description}]\n\n{body}"
     except Exception as e:
-        return f"Error: Subagent '{subagent_type}' failed: {e}"
+        # Surface a hard subagent failure as a tool ERROR (X) rather than a green
+        # "done" wrapping an "Error:" string. Callers (``task``/``task_batch``)
+        # turn this into a status="error" ToolMessage or an inline batch error line.
+        raise SubagentError(f"Subagent '{subagent_type}' failed: {e}") from e
 
 
 async def run_manual_subagent(
@@ -478,7 +489,14 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
             )
             done, _pending = await asyncio.wait({inline}, timeout=auto_s)
             if inline in done:
-                return inline.result()
+                try:
+                    return inline.result()
+                except SubagentError as e:
+                    return ToolMessage(
+                        content=f"[{e}. Continue without its result.]",
+                        tool_call_id=tool_call_id,
+                        status="error",
+                    )
             inline.cancel()
             try:
                 await inline
@@ -518,11 +536,23 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
             # User-initiated delegation cancel → swallow and let the lead keep going;
             # a turn-level cancel (flag unset) → re-raise so the whole turn unwinds.
             if delegations.was_cancelled(session_id, tool_call_id):
-                return (
-                    f"[delegation cancelled by the user before it finished: "
-                    f"{subagent_type} — {description}. Continue without its result.]"
+                return ToolMessage(
+                    content=(
+                        f"[delegation cancelled by the user before it finished: "
+                        f"{subagent_type} — {description}. Continue without its result.]"
+                    ),
+                    tool_call_id=tool_call_id,
+                    status="error",  # cancelled → the card closes as an X, not green "done"
                 )
             raise
+        except SubagentError as e:
+            # Subagent crashed → close the delegation card as a failure (X) while still
+            # handing the lead a readable result so it can continue without it.
+            return ToolMessage(
+                content=f"[{e}. Continue without its result.]",
+                tool_call_id=tool_call_id,
+                status="error",
+            )
         finally:
             delegations.unregister(session_id, tool_call_id)
 
@@ -562,15 +592,19 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
             if not prm:
                 return f"Error: task '{desc}' is missing 'prompt'."
             async with sem:
-                return await _run_subagent(
-                    config=config,
-                    tool_map=tool_map,
-                    available_subagents=available_subagents,
-                    description=desc,
-                    prompt=prm,
-                    subagent_type=spec.get("subagent_type", "researcher"),
-                    truncate=truncate,
-                )
+                try:
+                    return await _run_subagent(
+                        config=config,
+                        tool_map=tool_map,
+                        available_subagents=available_subagents,
+                        description=desc,
+                        prompt=prm,
+                        subagent_type=spec.get("subagent_type", "researcher"),
+                        truncate=truncate,
+                    )
+                except SubagentError as e:
+                    # One failed delegation is reported inline; the batch goes on.
+                    return f"Error: {e}"
 
         results = await asyncio.gather(*(_one(s) for s in tasks), return_exceptions=True)
 

--- a/tests/test_subagent_nesting_stream.py
+++ b/tests/test_subagent_nesting_stream.py
@@ -1,0 +1,150 @@
+"""task-tool-rendering audit #4: does a subagent's OWN tool activity nest under the
+`task` card in the live stream? Drives the real `_run_turn_stream` frame emitter with a
+fake model scripting lead → task → subagent → current_time → done, and inspects the
+interleaved frame order.
+
+FINDING: the subagent's tool frames DO propagate into the parent stream (good), but the
+`task` tool's on_tool_end is emitted BEFORE them (because the delegation is detached via
+ensure_future for cancellation). The console nests by "last open task wins", which needs
+the task still running when the child starts — so the child arrives too late and renders
+as a top-level card, never nested. The nesting rail is effectively dead code for streamed
+delegations until child frames carry an explicit parent-task id. This test pins that real
+ordering so a future linkage fix trips it.
+"""
+
+from __future__ import annotations
+
+import itertools
+import json
+from unittest.mock import patch
+
+import pytest
+from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
+from langchain_core.messages import AIMessage, AIMessageChunk
+from langchain_core.outputs import ChatGenerationChunk
+
+
+class _ToolFake(GenericFakeChatModel):
+    """Replays preset AIMessages (incl. tool calls) over the STREAMING path so it drops
+    into create_agent for BOTH the lead and the subagent (same patched create_llm). The
+    stock GenericFakeChatModel chunks `content` and yields nothing for an empty-content
+    tool-call message — which breaks astream_events — so we emit one chunk carrying the
+    tool calls as `tool_call_chunks` (the wire shape the agent re-aggregates)."""
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    def _chunk(self):
+        msg = next(self.messages)
+        return ChatGenerationChunk(
+            message=AIMessageChunk(
+                content=msg.content,
+                tool_call_chunks=[
+                    {"name": tc["name"], "args": json.dumps(tc["args"]), "id": tc["id"], "index": i}
+                    for i, tc in enumerate(getattr(msg, "tool_calls", None) or [])
+                ],
+            )
+        )
+
+    def _stream(self, messages, stop=None, run_manager=None, **kwargs):
+        yield self._chunk()
+
+    async def _astream(self, messages, stop=None, run_manager=None, **kwargs):
+        # Yield control like a real model's network I/O would, so astream_events can
+        # flush the detached subagent's events in real-time order (not a sync burst).
+        import asyncio
+
+        await asyncio.sleep(0)
+        chunk = self._chunk()
+        await asyncio.sleep(0)
+        yield chunk
+
+
+def _install(monkeypatch, messages):
+    import runtime.state as rs
+    from graph.config import LangGraphConfig
+    from langgraph.checkpoint.memory import MemorySaver
+
+    # Pad with a no-tool-call finisher forever so an extra lead/subagent step (a retry,
+    # a structured-output kicker) ends cleanly instead of exhausting the script.
+    stream = itertools.chain(iter(messages), itertools.repeat(AIMessage(content="<output>done</output>")))
+    fake = _ToolFake(messages=stream)
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+
+        g = create_agent_graph(LangGraphConfig(), include_subagents=True, checkpointer=MemorySaver())
+    monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
+    monkeypatch.setattr(rs.STATE, "goal_controller", None, raising=False)
+    monkeypatch.setattr(rs.STATE, "graph_config", LangGraphConfig(), raising=False)
+    return g
+
+
+def _delegate(**args):
+    return AIMessage(
+        content="",
+        tool_calls=[{"name": "task", "args": args, "id": "t1", "type": "tool_call"}],
+    )
+
+
+@pytest.mark.asyncio
+async def test_subagent_tool_calls_surface_but_do_not_nest_live(monkeypatch):
+    from server.chat import _run_turn_stream
+
+    _install(
+        monkeypatch,
+        [
+            _delegate(description="check the time", prompt="what time is it", subagent_type="researcher"),
+            # subagent's turn 1 → call a nested tool (current_time is in researcher's allowlist)
+            AIMessage(content="", tool_calls=[{"name": "current_time", "args": {}, "id": "s1", "type": "tool_call"}]),
+            # subagent's turn 2 → finish
+            AIMessage(content="it is noon"),
+            # lead's turn 2 → finish
+            AIMessage(content="<output>the subagent says it is noon</output>"),
+        ],
+    )
+
+    # Track the interleaved frame order AND, per frame, which `task` cards are still
+    # open — replaying the console's "last open task wins" nesting (ChatSurface): a
+    # child nests only if a `task` is still running when its start arrives.
+    seq: list[tuple[str, str]] = []
+    open_tasks: set[str] = set()
+    nested_under_task = False
+    for_status: dict[str, str] = {}  # id → running/closed (dedupe the twin start frames)
+    async for kind, payload in _run_turn_stream("ask the researcher the time", "s4", {"configurable": {"thread_id": "s4"}}):
+        if kind not in ("tool_start", "tool_end"):
+            continue
+        name, tid = payload.get("name"), payload.get("id")
+        if kind == "tool_start":
+            seq.append(("start", name))
+            if name == "task":
+                open_tasks.add(tid)
+            elif open_tasks and for_status.get(tid) is None:
+                nested_under_task = True  # a non-task tool started while a task was open
+            for_status.setdefault(tid, "running")
+        elif kind == "tool_end":
+            seq.append(("end", name))
+            open_tasks.discard(tid)
+
+    print(f"\n[#4] interleaved frames: {seq}")
+    starts = [n for k, n in seq if k == "start"]
+    ends = [n for k, n in seq if k == "end"]
+    assert "task" in starts, f"the delegation itself should surface a card; saw {seq}"
+
+    # Propagation works: the subagent's OWN tool call surfaces in the parent stream.
+    assert "current_time" in starts, f"subagent's nested tool did not surface; saw {seq}"
+    assert "current_time" in ends, f"subagent's nested tool never closed; saw {seq}"
+
+    # KNOWN LIMITATION (audit #4) — the delegation runs its subagent via
+    # asyncio.ensure_future + await (for Tier-2 cancellation), which DETACHES it, so in
+    # astream_events the task's on_tool_end is emitted BEFORE the subagent's child
+    # frames. The child therefore arrives after the task card has already closed, and
+    # the console's "last open task wins" nesting can't attach it — subagent tools
+    # render as top-level cards, NOT nested under the delegation. The nesting rail
+    # (parentId / pl-toolcard__children) is effectively unreachable for streamed
+    # delegations. The real fix is to tag child frames with their parent task's
+    # tool_call_id (a delegation contextvar) so nesting is explicit, not timing-based.
+    # These assertions pin the current ordering so that fix trips this test.
+    task_end_i = seq.index(("end", "task"))
+    child_start_i = next(i for i, f in enumerate(seq) if f == ("start", "current_time"))
+    assert task_end_i < child_start_i, f"task should close before its child today; saw {seq}"
+    assert not nested_under_task, f"nesting unexpectedly worked — update this test + audit; saw {seq}"

--- a/tests/test_task_tool_error.py
+++ b/tests/test_task_tool_error.py
@@ -1,0 +1,67 @@
+"""A failed or user-cancelled `task` delegation must close its tool card as an ERROR
+(X), not a green "done" wrapping an "Error:" string. The fix: the tool returns a
+``ToolMessage(status="error")`` (which the on_tool_end → tool-call-v1 path reads via
+``status == "error"``), instead of a plain string. Invoking the tool with a tool-call
+envelope mirrors how the ToolNode runs it, so a preserved status here = a red card live.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from langchain_core.messages import ToolMessage
+
+import graph.agent as agent_mod
+from graph.config import LangGraphConfig
+
+
+def _task_tool():
+    tools = agent_mod._build_task_tools(LangGraphConfig(), all_tools=[], background_mgr=None)
+    return next(t for t in tools if t.name == "task")
+
+
+def _invoke(task, **args):
+    call = {"name": "task", "args": args, "id": "tc-1", "type": "tool_call"}
+    return asyncio.run(task.ainvoke(call))
+
+
+def test_failed_delegation_returns_error_toolmessage(monkeypatch):
+    async def _boom(**kwargs):
+        raise agent_mod.SubagentError("Subagent 'researcher' failed: boom")
+
+    monkeypatch.setattr(agent_mod, "_run_subagent", _boom)
+    result = _invoke(_task_tool(), description="dig", prompt="go", subagent_type="researcher")
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert result.tool_call_id == "tc-1"
+    assert "researcher" in result.content  # the lead still gets a readable reason
+    assert "Continue without its result" in result.content
+
+
+def test_cancelled_delegation_returns_error_toolmessage(monkeypatch):
+    from graph import delegations
+
+    async def _cancel(**kwargs):
+        raise asyncio.CancelledError()
+
+    monkeypatch.setattr(agent_mod, "_run_subagent", _cancel)
+    monkeypatch.setattr(delegations, "was_cancelled", lambda *a, **k: True)
+    result = _invoke(_task_tool(), description="dig", prompt="go", subagent_type="researcher")
+
+    assert isinstance(result, ToolMessage)
+    assert result.status == "error"
+    assert "cancelled by the user" in result.content
+
+
+def test_successful_delegation_stays_plain_text(monkeypatch):
+    async def _ok(**kwargs):
+        return "[researcher completed: dig]\n\nfound it"
+
+    monkeypatch.setattr(agent_mod, "_run_subagent", _ok)
+    result = _invoke(_task_tool(), description="dig", prompt="go", subagent_type="researcher")
+
+    # Success path is unchanged: the string is wrapped (as any tool return is), but its
+    # status is NOT "error" — so the card renders a green "done", not the X.
+    assert result.status != "error"
+    assert "found it" in result.content


### PR DESCRIPTION
Audit + fix of how the `task` (subagent delegation) tool renders in the chat console, plus a clutter cleanup. Companion DS primitive: **protoLabsAI/protoContent#292**.

## What changed

**1. Failed / cancelled delegations now render as error cards (was: green ✓).**
A subagent crash returned an `"Error: …"` string and a user-cancel returned a `"[cancelled…]"` string — both rode the green "done" card, because the tool-call frame's error flag is read from the `ToolMessage.status`, which a plain string never sets (so the header said success while the expanded body showed red — they disagreed). Now `_run_subagent` raises `SubagentError` on a hard failure and the `task` tool converts failure + cancellation into `ToolMessage(status="error")` (curated content so the lead still gets a readable "continue without it" result). `task_batch` reports a failed sub-delegation inline and continues. `graph/agent.py` + `tests/test_task_tool_error.py`.

**2. `task` cards show which subagent ran.** Header now reads `task → researcher` (read from the call args), instead of a bare `task`, visible while the delegation is still running. `apps/web` `ToolCalls.tsx`.

**3. Clutter cleanup — settled tools fold into a summary chip.** Running top-level cards render full; finished ones collapse into one expandable **`N tools`** chip (aggregate status → `N failed` when any errored). A fan-out turn no longer buries the answer under a wall of cards; once the turn ends, the whole run folds into the chip. `ToolCardSummary` is a thin local mirror of the proposed DS primitive (protoContent#292) — swaps to `@protolabsai/ui` on release.

**4. Live finding: subagent tools don't nest under the task card (today).** Verified via the real `_run_turn_stream` frame emitter (`tests/test_subagent_nesting_stream.py`): a subagent's own tool calls **do** propagate into the parent stream, but the `task` tool's `on_tool_end` is emitted **before** them — because the delegation is detached via `asyncio.ensure_future` (for Tier-2 cancellation). So the child arrives after the task card has closed, and the console's "last open task wins" nesting can't attach it; subagent tools render as top-level cards (now folded into the chip as siblings). The nesting rail (`parentId` / `pl-toolcard__children`) is effectively unreachable for streamed delegations. **Not fixed here** — the real fix is to tag child frames with their parent task's `tool_call_id` (a delegation contextvar) so nesting is explicit rather than timing-based. The test pins the current ordering so that fix trips it.

## Verification
- `ruff check` ✓ · `lint-imports` ✓ (3 kept, 0 broken) · `pytest tests/ -q` → **2542 passed** (+6 new)
- `apps/web`: `tsc --noEmit` ✓ · `vitest run` → **121 passed**

## Why draft
UI/UX change — held for local visual review per the console local-test gate (CI can't judge UX). To eyeball: run `scripts/dev.sh` (:7871), ask the agent to delegate (e.g. "use the researcher subagent to …"), and watch the `task → researcher` header, the Stop affordance, the fold-into-chip on completion, and a forced failure showing the X.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Tool cards now automatically collapse into a summary chip when multiple tools complete, with an option to expand and view individual tool details.
  * Improved labeling for delegated tool calls to display subagent types where applicable.
  * Enhanced visualization for in-progress tool calls with a spotlight effect highlighting running tools during streaming.

* **Bug Fixes**
  * Failed task delegations now correctly display as error status in the UI.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->