### PR TITLE
fix: nest subagent tool cards under the task by explicit parent id

### DIFF
--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -554,6 +554,11 @@ def _tool_call_part(event_type: str, payload: Any) -> Part | None:
             phase,
             **kwargs,
         )
+        # A subagent's tool frame carries its parent delegation's tool-call id so the
+        # console nests it under the `task` card by id (the contract dict has no field
+        # for it, so ride it as an extra payload key the console reads).
+        if payload.get("parentId"):
+            emit["content"]["value"]["parentToolCallId"] = str(payload["parentId"])
         return _ext_data_part(emit)
     if payload:
         return _text_part(str(payload))

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -310,6 +310,19 @@ function scenarioFor(prompt) {
         { id: "task-1", name: "task", phase: "end", output: "Subagent finished: found 1 result." },
       ],
     };
+  if (t.includes("NESTLATE"))
+    // Out-of-order delegation: the `task` card CLOSES before the subagent's child frames
+    // arrive (the real detached-delegation ordering). Only the explicit parentToolCallId
+    // lets the console still nest the child under the task — the timing heuristic can't.
+    return {
+      answer: "Delegated; the child frame arrived after the task closed.",
+      events: [
+        { id: "task-late", name: "task", phase: "start", input: JSON.stringify({ description: "Research", prompt: "Find it." }) },
+        { id: "task-late", name: "task", phase: "end", output: "Subagent finished." },
+        { id: "kid-late", name: "web_search", phase: "start", input: JSON.stringify({ query: "late" }), parentId: "task-late" },
+        { id: "kid-late", name: "web_search", phase: "end", output: "1 result(s) for 'late':\n1. Ex — https://example.com/x\n   snip.", parentId: "task-late" },
+      ],
+    };
   if (t.includes("FANOUT"))
     // Two INDEPENDENT top-level tool calls (no task wrapping them) → both settle, so the
     // console folds them behind a single "2 tools" summary chip (clutter cleanup).
@@ -373,6 +386,8 @@ export function buildFrames({ rpcId, contextId, taskId, prompt }) {
     phase: ev.phase === "start" ? "started" : "completed",
     args: ev.input,
     result: ev.output,
+    // A subagent's own tool frame carries its parent `task` id so the console nests it.
+    ...(ev.parentId ? { parentToolCallId: ev.parentId } : {}),
   });
   const statusFrame = (text, toolEvent) =>
     wrap({

--- a/apps/web/e2e/tool-nesting-explicit.spec.ts
+++ b/apps/web/e2e/tool-nesting-explicit.spec.ts
@@ -1,0 +1,22 @@
+import { expect, test } from "@playwright/test";
+
+// The robust nesting fix: a subagent's tool frames carry their parent `task` id
+// (`parentToolCallId` on the wire), so the console nests them under the delegation card
+// even when those frames arrive AFTER the task card has closed — the detached-delegation
+// ordering the old "last open task wins" timing heuristic could not handle.
+test("a subagent tool nests under the task even when its frames arrive after the task closes", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const composer = page.getByPlaceholder(/Message protoAgent/i);
+  await composer.waitFor({ state: "visible" });
+  await composer.fill("NESTLATE delegate this");
+  await composer.press("Enter");
+
+  // Final state: one top-level task group with web_search nested inside — NOT a stray
+  // top-level sibling, even though the child frames streamed after the task closed.
+  const group = page.locator(".tool-calls > .pl-toolcard-group");
+  await expect(group).toHaveCount(1);
+  await expect(group.locator("> .pl-toolcard .pl-toolcard__name")).toHaveText("task");
+  await expect(group.locator("> .pl-toolcard__children .pl-toolcard__name")).toHaveText("web_search");
+  // The child is nested, not rendered as a sibling top-level card.
+  await expect(page.locator(".tool-calls > .pl-toolcard")).toHaveCount(0);
+});

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -872,9 +872,10 @@ function ChatSessionSlot({
               // so they don't get their own block.
               let nextParts = message.parts;
               if (evt.phase === "start") {
-                // A tool that starts while a `task` is still running is a child
-                // of that subagent delegation — nest it. (Last open task wins,
-                // so nested task() calls group correctly.)
+                // Nest a subagent's own tool under its `task` card. The server tags the
+                // child frame with the parent delegation's id (authoritative — works even
+                // though the task's end races AHEAD of the child); fall back to "last open
+                // task wins" only for older servers that don't send it.
                 const openTask = [...calls]
                   .reverse()
                   .find((c) => c.name === "task" && c.status === "running" && c.id !== evt.id);
@@ -884,7 +885,7 @@ function ChatSessionSlot({
                   input: evt.input,
                   status: "running",
                   startedAt: now,
-                  parentId: openTask?.id,
+                  parentId: evt.parentId ?? openTask?.id,
                 };
                 if (idx >= 0) calls[idx] = { ...calls[idx], ...card };
                 else calls.push(card);

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -399,7 +399,15 @@ function dataByMime(parts: RawPart[] | undefined, mime: string): unknown {
  * single ever-overwriting card — the "only one tool at a time" symptom. */
 function toolEventFromParts(parts?: RawPart[]): ToolEvent | null {
   const d = dataByMime(parts, TOOL_CALL_MIME) as
-    | { toolCallId?: string; name?: string; phase?: string; args?: string; result?: string; error?: string }
+    | {
+        toolCallId?: string;
+        name?: string;
+        phase?: string;
+        args?: string;
+        result?: string;
+        error?: string;
+        parentToolCallId?: string;
+      }
     | null;
   if (!d) return null;
   return {
@@ -410,6 +418,8 @@ function toolEventFromParts(parts?: RawPart[]): ToolEvent | null {
     // A "failed" end carries the error text in `error`; fall back to it for the body.
     output: d.result ?? d.error,
     error: d.phase === "failed" || Boolean(d.error),
+    // Set only for a subagent's own tool calls → nest under the `task` card by id.
+    ...(d.parentToolCallId ? { parentId: d.parentToolCallId } : {}),
   };
 }
 

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -386,6 +386,9 @@ export type ToolEvent = {
   input?: string;
   output?: string;
   error?: boolean; // an "end" that failed (phase "failed" on the wire) → card shows the X
+  /** id of the enclosing `task` delegation when this is a subagent's own tool call —
+   *  set server-side so nesting is explicit (by id), not inferred from frame order. */
+  parentId?: string;
 };
 
 // A background subagent job (ADR 0050) as returned by GET /api/background and

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -211,12 +211,16 @@ async def _run_subagent(
     prompt: str,
     subagent_type: str,
     truncate: int | None = None,
+    parent_task_id: str | None = None,
 ) -> str:
     """Run a single subagent delegation and return its output text.
 
     Shared by the single ``task`` tool and the concurrent ``task_batch`` tool.
     ``truncate`` (chars) bounds the returned body so a wide fan-out can't blow
     the parent context; ``None`` means unbounded (single-task path).
+    ``parent_task_id`` is the delegating ``task``/``task_batch`` tool-call id; when
+    set, every event the subagent emits is tagged with it so the console can nest
+    the subagent's own tool cards under the delegation card.
     """
     sub_config = SUBAGENT_REGISTRY.get(subagent_type)
     if not sub_config:
@@ -254,10 +258,19 @@ async def _run_subagent(
         system_prompt=build_subagent_prompt(subagent_type),
     )
 
+    # Tag every event the subagent emits with the parent delegation's tool-call id.
+    # LangChain propagates config metadata to all child runs, so the subagent's own
+    # tool frames carry `parent_task_id` — letting the console nest them under the
+    # `task` card BY ID rather than by frame ordering (the delegation runs detached
+    # via ensure_future, so its on_tool_end races AHEAD of these child frames).
+    sub_run_config: dict[str, Any] = {"recursion_limit": sub_config.max_turns}
+    if parent_task_id:
+        sub_run_config["metadata"] = {"parent_task_id": parent_task_id}
+
     try:
         result = await subagent.ainvoke(
             {"messages": [{"role": "user", "content": prompt}]},
-            config={"recursion_limit": sub_config.max_turns},
+            config=sub_run_config,
         )
 
         messages = result.get("messages", [])
@@ -485,6 +498,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
                     prompt=prompt,
                     subagent_type=subagent_type,
                     truncate=None,
+                    parent_task_id=tool_call_id,
                 )
             )
             done, _pending = await asyncio.wait({inline}, timeout=auto_s)
@@ -527,6 +541,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
                 prompt=prompt,
                 subagent_type=subagent_type,
                 truncate=None,
+                parent_task_id=tool_call_id,
             )
         )
         delegations.register(session_id, tool_call_id, deleg, label=description)
@@ -557,7 +572,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
             delegations.unregister(session_id, tool_call_id)
 
     @tool
-    async def task_batch(tasks: list[dict]) -> str:
+    async def task_batch(tasks: list[dict], tool_call_id: Annotated[str, InjectedToolCallId] = "") -> str:
         """Delegate several independent tasks to subagents concurrently.
 
         Prefer this over multiple sequential ``task`` calls whenever the
@@ -601,6 +616,7 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
                         prompt=prm,
                         subagent_type=spec.get("subagent_type", "researcher"),
                         truncate=truncate,
+                        parent_task_id=tool_call_id,
                     )
                 except SubagentError as e:
                     # One failed delegation is reported inline; the batch goes on.

--- a/server/chat.py
+++ b/server/chat.py
@@ -322,6 +322,11 @@ async def _run_turn_stream(
     ):
         kind = event.get("event", "")
         name = event.get("name", "")
+        # A subagent's events carry the delegating `task`/`task_batch` tool-call id (set
+        # as run metadata in graph.agent._run_subagent), so the console can nest the
+        # subagent's own tool cards under the delegation card BY ID — not by frame order
+        # (the delegation runs detached, so the task's on_tool_end races ahead of these).
+        parent_tool_id = (event.get("metadata") or {}).get("parent_task_id")
         # Skills are no longer auto-retrieved per turn (ADR 0060 — progressive
         # disclosure); the model loads one on demand via the `load_skill` tool,
         # which surfaces as an ordinary tool card. No `skills_loaded` event to forward.
@@ -362,6 +367,7 @@ async def _run_turn_stream(
                     "name": name,
                     "output": coerced,
                     "error": getattr(output, "status", None) == "error",
+                    **({"parentId": parent_tool_id} if parent_tool_id else {}),
                 },
             )
         elif kind == "on_chat_model_stream":
@@ -376,7 +382,10 @@ async def _run_turn_stream(
                 tcid, tcname = tcc.get("id"), tcc.get("name")
                 if tcid and tcname and tcid not in announced_tools:
                     announced_tools.add(tcid)
-                    yield ("tool_start", {"id": tcid, "name": tcname, "input": ""})
+                    yield (
+                        "tool_start",
+                        {"id": tcid, "name": tcname, "input": "", **({"parentId": parent_tool_id} if parent_tool_id else {})},
+                    )
             if hasattr(chunk, "content") and chunk.content:
                 accumulated_raw += chunk.content if isinstance(chunk.content, str) else str(chunk.content)
                 # Stream only the user-facing <output> region, token by token —
@@ -404,7 +413,12 @@ async def _run_turn_stream(
                     announced_tools.add(tcid)
                     yield (
                         "tool_start",
-                        {"id": tcid, "name": tc.get("name", ""), "input": _coerce_tool_value(tc.get("args", ""))},
+                        {
+                            "id": tcid,
+                            "name": tc.get("name", ""),
+                            "input": _coerce_tool_value(tc.get("args", "")),
+                            **({"parentId": parent_tool_id} if parent_tool_id else {}),
+                        },
                     )
             usage = getattr(output, "usage_metadata", None) if output else None
             rid = event.get("run_id")

--- a/tests/test_subagent_nesting_stream.py
+++ b/tests/test_subagent_nesting_stream.py
@@ -1,22 +1,19 @@
-"""task-tool-rendering audit #4: does a subagent's OWN tool activity nest under the
-`task` card in the live stream? Drives the real `_run_turn_stream` frame emitter with a
-fake model scripting lead → task → subagent → current_time → done, and inspects the
-interleaved frame order.
+"""task-tool-rendering audit #4 (FIXED): a subagent's OWN tool activity nests under the
+`task` card in the live stream. Drives the real `_run_turn_stream` frame emitter with a
+fake model scripting lead → task → subagent → current_time → done.
 
-FINDING: the subagent's tool frames DO propagate into the parent stream (good), but the
-`task` tool's on_tool_end is emitted BEFORE them (because the delegation is detached via
-ensure_future for cancellation). The console nests by "last open task wins", which needs
-the task still running when the child starts — so the child arrives too late and renders
-as a top-level card, never nested. The nesting rail is effectively dead code for streamed
-delegations until child frames carry an explicit parent-task id. This test pins that real
-ordering so a future linkage fix trips it.
+The delegation runs detached (asyncio.ensure_future, for Tier-2 cancellation), so the
+task's on_tool_end can race ahead of the subagent's child frames — defeating the console's
+old "last open task wins" heuristic (which also mis-attributes concurrent task_batch
+delegations). The fix tags the subagent's run with the delegating task's tool-call id
+(`_run_subagent` sets it as run metadata), so every child frame carries `parentId` and the
+console nests by id, order-independent. This test asserts the linkage on the wire frames.
 """
 
 from __future__ import annotations
 
 import itertools
 import json
-from unittest.mock import patch
 
 import pytest
 from langchain_core.language_models.fake_chat_models import GenericFakeChatModel
@@ -69,10 +66,13 @@ def _install(monkeypatch, messages):
     # a structured-output kicker) ends cleanly instead of exhausting the script.
     stream = itertools.chain(iter(messages), itertools.repeat(AIMessage(content="<output>done</output>")))
     fake = _ToolFake(messages=stream)
-    with patch("graph.agent.create_llm", lambda *a, **k: fake):
-        from graph.agent import create_agent_graph
+    # Persist the fake for the whole turn — the subagent builds ITS model lazily at
+    # runtime (in _run_subagent), so a patch that exits after construction would leave the
+    # subagent on the real gateway model (and miss the parent-id metadata propagation).
+    monkeypatch.setattr("graph.agent.create_llm", lambda *a, **k: fake)
+    from graph.agent import create_agent_graph
 
-        g = create_agent_graph(LangGraphConfig(), include_subagents=True, checkpointer=MemorySaver())
+    g = create_agent_graph(LangGraphConfig(), include_subagents=True, checkpointer=MemorySaver())
     monkeypatch.setattr(rs.STATE, "graph", g, raising=False)
     monkeypatch.setattr(rs.STATE, "goal_controller", None, raising=False)
     monkeypatch.setattr(rs.STATE, "graph_config", LangGraphConfig(), raising=False)
@@ -87,7 +87,7 @@ def _delegate(**args):
 
 
 @pytest.mark.asyncio
-async def test_subagent_tool_calls_surface_but_do_not_nest_live(monkeypatch):
+async def test_subagent_tool_calls_nest_via_explicit_parent_id(monkeypatch):
     from server.chat import _run_turn_stream
 
     _install(
@@ -103,48 +103,31 @@ async def test_subagent_tool_calls_surface_but_do_not_nest_live(monkeypatch):
         ],
     )
 
-    # Track the interleaved frame order AND, per frame, which `task` cards are still
-    # open — replaying the console's "last open task wins" nesting (ChatSurface): a
-    # child nests only if a `task` is still running when its start arrives.
+    # Capture every tool frame with its parent linkage. The fix tags a subagent's own
+    # frames with the delegating task's tool-call id (server-side), so the console nests
+    # them BY ID rather than by timing.
+    frames: list[tuple[str, str, str | None]] = []  # (kind, name, parentId)
     seq: list[tuple[str, str]] = []
-    open_tasks: set[str] = set()
-    nested_under_task = False
-    for_status: dict[str, str] = {}  # id → running/closed (dedupe the twin start frames)
     async for kind, payload in _run_turn_stream("ask the researcher the time", "s4", {"configurable": {"thread_id": "s4"}}):
         if kind not in ("tool_start", "tool_end"):
             continue
-        name, tid = payload.get("name"), payload.get("id")
-        if kind == "tool_start":
-            seq.append(("start", name))
-            if name == "task":
-                open_tasks.add(tid)
-            elif open_tasks and for_status.get(tid) is None:
-                nested_under_task = True  # a non-task tool started while a task was open
-            for_status.setdefault(tid, "running")
-        elif kind == "tool_end":
-            seq.append(("end", name))
-            open_tasks.discard(tid)
+        frames.append((kind, payload.get("name"), payload.get("parentId")))
+        seq.append(("start" if kind == "tool_start" else "end", payload.get("name")))
 
-    print(f"\n[#4] interleaved frames: {seq}")
+    print(f"\n[#4] frames: {frames}")
     starts = [n for k, n in seq if k == "start"]
     ends = [n for k, n in seq if k == "end"]
-    assert "task" in starts, f"the delegation itself should surface a card; saw {seq}"
+    assert "task" in starts, f"the delegation itself should surface a card; saw {frames}"
+    # The subagent's OWN tool call surfaces in the parent stream (propagation works)…
+    assert "current_time" in starts and "current_time" in ends, f"subagent tool didn't surface; {frames}"
 
-    # Propagation works: the subagent's OWN tool call surfaces in the parent stream.
-    assert "current_time" in starts, f"subagent's nested tool did not surface; saw {seq}"
-    assert "current_time" in ends, f"subagent's nested tool never closed; saw {seq}"
-
-    # KNOWN LIMITATION (audit #4) — the delegation runs its subagent via
-    # asyncio.ensure_future + await (for Tier-2 cancellation), which DETACHES it, so in
-    # astream_events the task's on_tool_end is emitted BEFORE the subagent's child
-    # frames. The child therefore arrives after the task card has already closed, and
-    # the console's "last open task wins" nesting can't attach it — subagent tools
-    # render as top-level cards, NOT nested under the delegation. The nesting rail
-    # (parentId / pl-toolcard__children) is effectively unreachable for streamed
-    # delegations. The real fix is to tag child frames with their parent task's
-    # tool_call_id (a delegation contextvar) so nesting is explicit, not timing-based.
-    # These assertions pin the current ordering so that fix trips this test.
-    task_end_i = seq.index(("end", "task"))
-    child_start_i = next(i for i, f in enumerate(seq) if f == ("start", "current_time"))
-    assert task_end_i < child_start_i, f"task should close before its child today; saw {seq}"
-    assert not nested_under_task, f"nesting unexpectedly worked — update this test + audit; saw {seq}"
+    # …and EVERY child frame carries the parent delegation's tool-call id ("t1"), so the
+    # console nests it under the `task` card BY ID — order-independent. (The delegation
+    # runs detached via ensure_future, so the task's on_tool_end can race ahead of the
+    # child frames; the old "last open task wins" heuristic broke on that and on
+    # concurrent task_batch delegations. Explicit linkage fixes both.)
+    child_parents = {p for k, n, p in frames if n == "current_time"}
+    assert child_parents == {"t1"}, f"subagent tool must carry parentId=t1; saw {child_parents} in {frames}"
+    # The delegation card itself stays top-level (no parent).
+    task_parents = {p for k, n, p in frames if n == "task"}
+    assert task_parents == {None}, f"the task card must not be nested; saw {task_parents}"

--- a/tests/test_task_batch.py
+++ b/tests/test_task_batch.py
@@ -34,6 +34,13 @@ def _build(monkeypatch, config=None, recorder=None):
     return {t.name: t for t in tools}
 
 
+async def _batch(tool, tasks):
+    """Invoke task_batch the way the ToolNode does — a full model ToolCall (it carries
+    an InjectedToolCallId now, the parent id for nesting) — and return the string body."""
+    out = await tool.ainvoke({"name": "task_batch", "args": {"tasks": tasks}, "id": "tb-test", "type": "tool_call"})
+    return getattr(out, "content", out)
+
+
 def test_build_returns_task_and_batch(monkeypatch):
     tools = _build(monkeypatch)
     assert set(tools) == {"task", "task_batch"}
@@ -62,14 +69,13 @@ async def test_single_task_is_unbounded(monkeypatch):
 @pytest.mark.asyncio
 async def test_batch_orders_results_by_index(monkeypatch):
     tools = _build(monkeypatch)
-    out = await tools["task_batch"].ainvoke(
-        {
-            "tasks": [
-                {"description": "alpha", "prompt": "p1"},
-                {"description": "beta", "prompt": "p2"},
-                {"description": "gamma", "prompt": "p3"},
-            ]
-        }
+    out = await _batch(
+        tools["task_batch"],
+        [
+            {"description": "alpha", "prompt": "p1"},
+            {"description": "beta", "prompt": "p2"},
+            {"description": "gamma", "prompt": "p3"},
+        ],
     )
     # ordered 1..3 regardless of completion order
     assert out.index("Task 1/3") < out.index("Task 2/3") < out.index("Task 3/3")
@@ -81,7 +87,7 @@ async def test_batch_passes_truncate_from_config(monkeypatch):
     rec = []
     cfg = LangGraphConfig(subagent_output_truncate=1234)
     tools = _build(monkeypatch, config=cfg, recorder=rec)
-    await tools["task_batch"].ainvoke({"tasks": [{"description": "d", "prompt": "p"}]})
+    await _batch(tools["task_batch"], [{"description": "d", "prompt": "p"}])
     assert rec[0]["truncate"] == 1234
 
 
@@ -99,27 +105,26 @@ async def test_batch_respects_concurrency_cap(monkeypatch):
 
     monkeypatch.setattr(agent_mod, "_run_subagent", fake_run)
     tools = {t.name: t for t in agent_mod._build_task_tools(cfg, [])}
-    await tools["task_batch"].ainvoke({"tasks": [{"description": f"t{i}", "prompt": "p"} for i in range(6)]})
+    await _batch(tools["task_batch"], [{"description": f"t{i}", "prompt": "p"} for i in range(6)])
     assert state["peak"] <= 2
 
 
 @pytest.mark.asyncio
 async def test_batch_empty_list(monkeypatch):
     tools = _build(monkeypatch)
-    out = await tools["task_batch"].ainvoke({"tasks": []})
+    out = await _batch(tools["task_batch"], [])
     assert "empty task list" in out
 
 
 @pytest.mark.asyncio
 async def test_batch_missing_prompt_isolated(monkeypatch):
     tools = _build(monkeypatch)
-    out = await tools["task_batch"].ainvoke(
-        {
-            "tasks": [
-                {"description": "good", "prompt": "p"},
-                {"description": "bad"},  # no prompt
-            ]
-        }
+    out = await _batch(
+        tools["task_batch"],
+        [
+            {"description": "good", "prompt": "p"},
+            {"description": "bad"},  # no prompt
+        ],
     )
     assert "OUT:good" in out
     assert "missing 'prompt'" in out
@@ -134,13 +139,12 @@ async def test_batch_failure_isolated(monkeypatch):
 
     monkeypatch.setattr(agent_mod, "_run_subagent", fake_run)
     tools = {t.name: t for t in agent_mod._build_task_tools(LangGraphConfig(), [])}
-    out = await tools["task_batch"].ainvoke(
-        {
-            "tasks": [
-                {"description": "ok", "prompt": "p"},
-                {"description": "boom", "prompt": "p"},
-            ]
-        }
+    out = await _batch(
+        tools["task_batch"],
+        [
+            {"description": "ok", "prompt": "p"},
+            {"description": "boom", "prompt": "p"},
+        ],
     )
     assert "OUT:ok" in out
     assert "RuntimeError" in out and "kaboom" in out


### PR DESCRIPTION
Closes the open finding from the task-tool rendering audit (#1319): a subagent's own tool cards didn't reliably nest under the `task` delegation card.

## The bug
The console inferred nesting from timing — "last open task wins" — which fails because the delegation runs detached (`asyncio.ensure_future`, for Tier-2 cancellation), so the task's `on_tool_end` can race **ahead** of the subagent's child frames. It also mis-attributes concurrent `task_batch` delegations (no single "open task").

## The fix — explicit linkage, order-independent
- **`graph/agent.py`**: `_run_subagent` tags the subagent's run with the delegating tool-call id as run **metadata** (`parent_task_id`); LangChain propagates it to every child event. Threaded from `task` (foreground + auto-background) and `task_batch` (now carries an `InjectedToolCallId`).
- **`server/chat.py`**: reads `parent_task_id` off each event and emits it as `parentId` on the tool frames.
- **`a2a_impl/executor.py`**: rides it on the tool-call-v1 DataPart as `parentToolCallId`.
- **console** (`api.ts` / `types.ts` / `ChatSurface.tsx`): parses it into `ToolEvent.parentId` and nests by that id; the timing heuristic stays only as a fallback for older servers.

## Verification
- `pytest tests/ -q` → **2543 passed** (nesting integration test now asserts the wire carries `parentId`; `task_batch` tests invoke via the tool-call envelope).
- New e2e `tool-nesting-explicit.spec.ts`: a child whose frames arrive **after** the task closes still nests under it. `tsc`, build, and the tool-card e2e suite green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Tool calls from sub-agent delegations now properly nest under their parent delegation in the console, even when events arrive out of order.

* **Improvements**
  * Better visual organization of nested tool calls in delegation chains with improved frame ordering handling.

* **Tests**
  * Added end-to-end tests for nested delegation with out-of-order event delivery.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->