### PR TITLE
fix(web): collapse a delegation's nested tools (stable height, no bounce)

### DIFF
--- a/apps/web/e2e/nesting.spec.ts
+++ b/apps/web/e2e/nesting.spec.ts
@@ -1,28 +1,25 @@
 import { expect, test } from "@playwright/test";
 
-// When the agent delegates with the `task` tool, the child tool calls that run
-// inside the subagent are nested under the parent task card instead of a flat
-// list. (A tool that starts while a `task` is still running is its child.)
+// When the agent delegates with the `task` tool, the subagent's own tool calls collapse
+// INSIDE the task card (revealed on expand) and the header shows a running count — so the
+// card holds a stable height as the subagent works instead of growing a nested rail.
 
-test("subagent child tools nest under the task card", async ({ page }) => {
+test("subagent child tools collapse inside the task card with a count", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   const composer = page.getByPlaceholder(/Message protoAgent/i);
   await composer.waitFor({ state: "visible" });
   await composer.fill("SUBAGENT delegate this");
   await composer.press("Enter");
 
-  // The parent task card is top-level inside a group. Frame = DS ToolCard (#832):
-  // `.pl-toolcard-group` / `.pl-toolcard` / `.pl-toolcard__children`.
-  const group = page.locator(".tool-calls > .pl-toolcard-group");
-  await expect(group).toHaveCount(1);
-  await expect(group.locator("> .pl-toolcard .pl-toolcard__name")).toHaveText("task");
+  // The task renders as a single card; its header carries the nested-tool count.
+  const card = page.locator(".tool-calls .pl-toolcard").first();
+  await expect(card).toBeVisible();
+  await expect(card.locator(".pl-toolcard__name")).toContainText("task");
+  await expect(card.locator(".pl-toolcard__name")).toContainText("1 tool");
+  // The child is NOT rendered until you expand — no always-on rail (that's the bounce fix).
+  await expect(page.locator(".pl-toolcard__children")).toHaveCount(0);
 
-  // The web_search child renders inside the nested children container.
-  const children = group.locator("> .pl-toolcard__children");
-  await expect(children).toBeVisible();
-  await expect(children.locator(".pl-toolcard__name")).toHaveText("web_search");
-
-  // And it is NOT also rendered as a sibling top-level card.
-  await expect(page.locator(".tool-calls > .pl-toolcard-group")).toHaveCount(1);
-  await expect(page.locator(".tool-calls > .pl-toolcard")).toHaveCount(0);
+  // Expand → the subagent's web_search appears nested in the body.
+  await card.locator(".pl-toolcard__head").click();
+  await expect(card.locator(".pl-toolcard__children .pl-toolcard__name")).toHaveText("web_search");
 });

--- a/apps/web/e2e/tool-nesting-explicit.spec.ts
+++ b/apps/web/e2e/tool-nesting-explicit.spec.ts
@@ -11,12 +11,13 @@ test("a subagent tool nests under the task even when its frames arrive after the
   await composer.fill("NESTLATE delegate this");
   await composer.press("Enter");
 
-  // Final state: one top-level task group with web_search nested inside — NOT a stray
-  // top-level sibling, even though the child frames streamed after the task closed.
-  const group = page.locator(".tool-calls > .pl-toolcard-group");
-  await expect(group).toHaveCount(1);
-  await expect(group.locator("> .pl-toolcard .pl-toolcard__name")).toHaveText("task");
-  await expect(group.locator("> .pl-toolcard__children .pl-toolcard__name")).toHaveText("web_search");
-  // The child is nested, not rendered as a sibling top-level card.
-  await expect(page.locator(".tool-calls > .pl-toolcard")).toHaveCount(0);
+  // The task card counts the child in its header even though that child's frames streamed
+  // in AFTER the task closed — proof the explicit parent-id linkage attached it.
+  const card = page.locator(".tool-calls .pl-toolcard").first();
+  await expect(card).toBeVisible();
+  await expect(card.locator(".pl-toolcard__name")).toContainText("task");
+  await expect(card.locator(".pl-toolcard__name")).toContainText("1 tool");
+  // It's nested in the body (revealed on expand), not a stray top-level sibling.
+  await card.locator(".pl-toolcard__head").click();
+  await expect(card.locator(".pl-toolcard__children .pl-toolcard__name")).toHaveText("web_search");
 });

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -135,8 +135,11 @@ export function ToolCalls({
   return <ToolCardList className="tool-calls">{top.map(group)}</ToolCardList>;
 }
 
-/** A tool card plus, when it's a subagent `task`, its nested child tool cards.
- *  Subagent nesting rides the DS `ToolCard` `nested` prop (indented child rail). */
+/** A tool card. For a subagent `task`, its child tool cards collapse INSIDE the card's
+ *  body (revealed on expand) and the header shows a running count
+ *  ("task → researcher · 3 tools"). Keeping them in the collapsible body — not the DS
+ *  always-on `nested` rail — is what lets the card hold a STABLE one-row height while the
+ *  subagent works, instead of growing a rail and then collapsing when it folds. */
 function ToolGroup({
   call,
   childrenByParent,
@@ -147,21 +150,19 @@ function ToolGroup({
   onCancelDelegation?: (id: string) => void;
 }) {
   const kids = childrenByParent.get(call.id);
-  const nested = kids?.length
+  const nestedCards = kids?.length
     ? kids.map((kid) => (
         // Children inherit no cancel callback — they aren't independent delegations.
         <ToolGroup key={kid.id} call={kid} childrenByParent={childrenByParent} />
       ))
     : undefined;
 
-  // Collapsed by default and stays put — the header row (icon, name, status) is
-  // the stable at-a-glance view; expanding is an explicit, sticky choice so the
-  // message doesn't reflow as tools start and finish. Pass `children` only when
-  // there's detail so the DS gives us the disabled-caret behavior for empty cards
-  // (the DS gates `hasBody` on `children != null`, so a no-detail card omits it).
+  // Collapsed by default; expanding reveals the args/result AND the subagent's nested
+  // tools (the `.pl-toolcard__children` indented rail, but here gated by the card's open
+  // state instead of always-on — so the header row stays a stable height as kids stream in).
   const Icon = iconFor(call.name);
   const body =
-    call.input || call.output ? (
+    call.input || call.output || nestedCards ? (
       <>
         {call.input ? (
           <ToolSection label="input" copyText={call.input}>
@@ -173,6 +174,7 @@ function ToolGroup({
             <ToolValue raw={call.output} role="output" tool={call.name} />
           </ToolSection>
         ) : null}
+        {nestedCards ? <div className="pl-toolcard__children">{nestedCards}</div> : null}
       </>
     ) : undefined;
 
@@ -196,13 +198,28 @@ function ToolGroup({
       </button>
     ) : undefined;
 
+  // A running count of the subagent's tools, in the header — so a collapsed delegation
+  // reads "task → researcher · 3 tools" at a glance without expanding.
+  const kidCount = kids?.length ?? 0;
+  const name =
+    kidCount > 0 ? (
+      <>
+        {cardLabel(call)}
+        <span className="tool-nested-count">
+          {" · "}
+          {kidCount} {kidCount === 1 ? "tool" : "tools"}
+        </span>
+      </>
+    ) : (
+      cardLabel(call)
+    );
+
   return (
     <ToolCard
-      name={cardLabel(call)}
+      name={name}
       status={call.status}
       icon={<Icon size={13} />}
       duration={call.durationMs}
-      nested={nested}
       actions={actions}
     >
       {body}

--- a/apps/web/src/chat/ToolCalls.tsx
+++ b/apps/web/src/chat/ToolCalls.tsx
@@ -84,9 +84,8 @@ export function ToolCalls({
       top.push(call);
     }
   }
-  const running = top.filter((c) => c.status === "running");
   const settled = top.filter((c) => c.status !== "running");
-  const failedCount = settled.filter((c) => c.status === "error").length;
+  const failedCount = top.filter((c) => c.status === "error").length;
 
   // Only TOP-LEVEL `task` groups get the cancel callback (the Stop affordance only shows
   // for a running task); nested children and settled cards never need it.
@@ -99,30 +98,30 @@ export function ToolCalls({
     />
   );
 
-  // The folded summary chip — a running total of the whole block (running + settled), with
-  // the finished cards inside it.
-  const chip = (count: number) => (
+  // The folded summary chip — the block's running total, with the given finished cards inside.
+  const chip = (count: number, folded: ToolCall[]) => (
     <ToolCardSummary
       count={count}
       label={count === 1 ? "tool" : "tools"}
       status={failedCount > 0 ? "error" : "done"}
       failedCount={failedCount || undefined}
     >
-      {settled.map(group)}
+      {folded.map(group)}
     </ToolCardSummary>
   );
 
-  // PINNED SPOTLIGHT (live turn): the active card(s) sit in a fixed-height slot that never
-  // collapses as tools cycle (`.tool-spotlight` reserves one row), and everything finished
-  // folds into the chip below. So the block holds a stable height for the whole turn — the
-  // column doesn't bounce as cards pop in and out; a finishing tool just crossfades from
-  // the slot into the chip. The chip is the running total, so it's present from the first
-  // finished tool onward.
+  // LIVE TURN: keep the MOST-RECENT tool in the spotlight slot until a newer one replaces
+  // it — so the slot is never empty (no blank gap between tools, or during the answer tail
+  // after the last tool finishes). Everything older folds into the running-total chip; a
+  // new tool crossfades into the slot and the previous one drops into the chip.
   if (streaming) {
+    if (top.length === 0) return null;
+    const current = top[top.length - 1];
+    const folded = top.slice(0, -1);
     return (
       <ToolCardList className="tool-calls">
-        <div className="tool-spotlight">{running.map(group)}</div>
-        {settled.length > 0 && chip(top.length)}
+        <div className="tool-spotlight">{group(current)}</div>
+        {folded.length > 0 && chip(top.length, folded)}
       </ToolCardList>
     );
   }
@@ -130,7 +129,7 @@ export function ToolCalls({
   // SETTLED (turn done for this block): a lone finished tool renders inline (no pointless
   // "1 tool" chip); a real fan-out (≥2) stays folded.
   if (settled.length >= 2) {
-    return <ToolCardList className="tool-calls">{chip(settled.length)}</ToolCardList>;
+    return <ToolCardList className="tool-calls">{chip(settled.length, settled)}</ToolCardList>;
   }
   return <ToolCardList className="tool-calls">{top.map(group)}</ToolCardList>;
 }

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -25,6 +25,12 @@
   color: var(--pl-color-fg-muted);
 }
 
+/* "· 3 tools" — running count of a delegation's nested subagent tools, in the header. */
+.tool-nested-count {
+  color: var(--pl-color-fg-subtle);
+  font-variant-numeric: tabular-nums;
+}
+
 /* Pinned spotlight: while the turn streams, the active card(s) live in a slot that
    reserves one card-row of height and never collapses as tools cycle (so the column
    can't bounce). A finishing tool leaves the slot for the chip; the next crossfades in. */

--- a/apps/web/src/chat/tool-calls.css
+++ b/apps/web/src/chat/tool-calls.css
@@ -31,9 +31,9 @@
   font-variant-numeric: tabular-nums;
 }
 
-/* Pinned spotlight: while the turn streams, the active card(s) live in a slot that
-   reserves one card-row of height and never collapses as tools cycle (so the column
-   can't bounce). A finishing tool leaves the slot for the chip; the next crossfades in. */
+/* Spotlight: while the turn streams, the slot holds the MOST-RECENT tool — kept up until a
+   newer one replaces it (so it's never empty: no blank gap between tools or during the
+   answer tail). The next tool crossfades in; the previous one drops into the chip below. */
 .tool-spotlight {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
Follow-up to the nesting fix (#1321). That change put the subagent's tools in the DS always-on `nested` rail, so the task card **grew** as each child streamed in and then **collapsed** when it folded into the chip — the up/down bounce.

Now the subagent's tools live in the card's **collapsible body** (revealed on expand) and the header shows a **running count** (`task → researcher · 3 tools`), so the delegation card holds a stable one-row height while the subagent works. Nesting itself is unchanged (still by explicit parent id from #1321) — only its default visibility moved from always-on to on-expand, which the user chose.

Verified: `tsc`, build, and the tool-card e2e (nesting / explicit-nesting / fold / renderers) green; nesting specs updated to assert the count + expand-to-reveal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved nested tool rendering for subagent delegations: nested child tool calls now fold into the task card, showing a running nested-tool count in the header. Child tools are revealed only after expanding the card.

* **Tests**
  * Updated Playwright end-to-end tests to assert the new expand/collapse interaction and the presence of nested tool details within the task card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->