### PR TITLE
chore: release v0.68.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.68.0] - 2026-06-23
+
 ### Added
 - **`scripts/reset.sh` — factory-reset the default (prod) instance from the CLI.** Wipes
   the prod instance's data + local config back to a clean slate so the next boot runs the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.67.0"
+version = "0.68.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,21 @@
 [
   {
+    "version": "v0.68.0",
+    "date": "2026-06-23",
+    "changes": [
+      "scripts/reset.sh — factory-reset the default (prod) instance from the CLI.",
+      "Chat tool-call rendering overhaul.",
+      "show_component (inline component rendering, ADR 0051) is temporarily disabled",
+      "The Goals and Tasks panels refresh on a bus push instead of polling every 5s.",
+      "Failed or user-cancelled task delegations now close as error cards (the X).",
+      "A subagent's own tool calls reliably nest under the delegation card.",
+      "Mid-stream output rendering no longer rescans the whole response on every chunk.",
+      "Empty-rail panel toggles fully disable.",
+      "Console-poll handlers no longer block the event loop.",
+      "The Docker image now serves the React console and stays in dep-lockstep with pyproject."
+    ]
+  },
+  {
     "version": "v0.67.0",
     "date": "2026-06-22",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.68.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.68.0 -m 'Release v0.68.0' && git push origin v0.68.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced chat interface with improved tool-call rendering and nested visualization
  * Improved panel refresh and polling behavior

* **Bug Fixes**
  * Resolved mid-stream rendering issues
  * Enhanced error handling for failed and cancelled task delegations

* **Improvements**
  * Updated reset command behavior
  * Optimized console handler operations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->