### PR TITLE
chore: release v0.69.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.69.0] - 2026-06-24
+
 ### Changed
 - **Native reasoning — the agent's thinking now streams from the model, not a forced text
   protocol.** Dropped the `<scratch_pad>`/`<output>` convention; the chat renders the model's

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.68.0"
+version = "0.69.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.69.0",
+    "date": "2026-06-24",
+    "changes": [
+      "Native reasoning — the agent's thinking now streams from the model, not a forced text protocol.",
+      "Chat markdown now renders through the design system's Markdown renderer",
+      "Heavy research turns no longer wedge the server."
+    ]
+  },
+  {
     "version": "v0.68.0",
     "date": "2026-06-23",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.69.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.69.0 -m 'Release v0.69.0' && git push origin v0.69.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).