### PR TITLE
feat(plugins): seam for plugin-owned /<name> chat commands

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Plugins can own `/<name>` chat control commands** via `registry.register_chat_command(name, handler)`
+  — the generalized form of the core `/goal`. The handler is `async (rest, session_id) -> str | None`:
+  a reply string short-circuits the turn (the model never runs), `None` passes through. It is
+  **user-only by design** (not an agent tool), so a plugin can expose a write action the model can't
+  trigger autonomously. Precedence is `goal` > plugin command > workflow > subagent > skill, resolved
+  once in `graph/slash_commands.py` so the chat dispatcher and the console palette can't drift. This is
+  the seam that lets the GitHub `/issue` command move into a plugin.
+
 ## [0.69.0] - 2026-06-24
 
 ### Changed

--- a/docs/guides/plugin-registry.md
+++ b/docs/guides/plugin-registry.md
@@ -132,9 +132,19 @@ def register(registry):
     registry.register_subagent(my_subagent)    # a SubagentConfig
     registry.register_router(my_router)         # FastAPI routes at /plugins/<id>
     registry.register_mcp_server(my_factory)    # a managed MCP server
+    registry.register_chat_command("issue", h)  # a user-only /<name> control command
     # skills/ and workflows/ are auto-discovered — no call needed. For a
     # non-standard location: registry.register_workflow_dir("recipes")
 ```
+
+`register_chat_command(name, handler)` lets a plugin **own a `/<name>` chat
+control command** — the generalized form of the core `/goal`. The handler is
+`async (rest, session_id) -> str | None`: return a reply string to short-circuit
+the turn (the model never runs), or `None` to pass the message through. It is
+**user-only by design** — not an agent tool — so a plugin can expose a write
+action (file an issue, open a PR) that the model can't trigger autonomously. Close
+over `registry.config` to read your own settings. Precedence is `goal` > plugin
+command > workflow > subagent > skill; `goal` is reserved.
 
 `skills/` and `workflows/` are **data**, so they're auto-discovered from those
 conventional subdirs — no boilerplate. **Console views** (a rail icon + page) are

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -41,6 +41,7 @@ class PluginLoadResult:
     late_tool_factories: list = field(default_factory=list)  # (all_tools, config) -> tool|list (late seam)
     mcp_servers: list = field(default_factory=list)  # factories: config -> entry|None (ADR 0019)
     thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571); last plugin wins
+    chat_commands: dict = field(default_factory=dict)  # token -> handler; user-only chat control commands
     meta: list[dict] = field(default_factory=list)
 
 
@@ -386,6 +387,11 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
             result.embedders[name] = factory
         for f in registry.mcp_servers:
             result.mcp_servers.append({"plugin_id": manifest.id, "factory": f})
+        for token, handler in registry.chat_commands.items():  # user-only chat control commands
+            if token in result.chat_commands:
+                log.warning("[plugins] %s: chat command /%s collides — skipped", manifest.id, token)
+                continue
+            result.chat_commands[token] = handler
         entry["loaded"] = True
         entry["tools"] = [t.name for t in kept]
         entry["skills"] = len(registry.skill_dirs)
@@ -393,6 +399,7 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         entry["surfaces"] = len(registry.surfaces)
         entry["subagents"] = [getattr(c, "name", "?") for c in registry.subagents]
         entry["mcp_servers"] = len(registry.mcp_servers)
+        entry["chat_commands"] = [f"/{t}" for t in registry.chat_commands]
         result.meta.append(entry)
         log.info(
             "[plugins] loaded %s: %d tool(s), %d skill dir(s), %d route(s), "

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -28,6 +28,8 @@ class PluginRegistry:
       (``register_subagent``).
     - ``mcp_servers`` — managed MCP server factories ``config -> entry|None``
       injected into MCP discovery (``register_mcp_server``).
+    - ``chat_commands`` — user-only ``/<name>`` control commands that short-circuit
+      the turn, like ``/goal`` (``register_chat_command``).
 
     Routes mount + surfaces start **once** at process init; a config reload reuses
     them — changing ``plugins.enabled`` needs a restart (ADR 0018).
@@ -60,6 +62,7 @@ class PluginRegistry:
         self.goal_hooks: list = []  # {on_achieved, on_failed} terminal reactions (ADR 0028)
         self.knowledge_stores: dict = {}  # name -> (config) -> KnowledgeBackend (ADR 0031)
         self.embedders: dict = {}  # name -> (config) -> (text -> vector) embed_fn (ADR 0031)
+        self.chat_commands: dict = {}  # token -> async (rest, session_id) -> str|None (user-only control commands)
 
     def register_tool(self, tool) -> None:
         """Expose a LangChain tool to the agent."""
@@ -72,6 +75,39 @@ class PluginRegistry:
         """Convenience: register an iterable of tools."""
         for tool in tools or []:
             self.register_tool(tool)
+
+    def register_chat_command(self, name: str, handler) -> None:
+        """Own a user-only chat control command — ``/<name> …`` short-circuits the
+        turn with the handler's reply, like the core ``/goal`` (and the old, now
+        plugin-owned, ``/issue``).
+
+        ``handler`` is ``async (rest: str, session_id: str) -> str | None``: ``rest``
+        is everything after the token; return the reply string to send (the turn is
+        NOT run through the agent), or ``None`` to pass the message through as a
+        normal turn. This is **user-only by design** — it is NOT an agent tool, so a
+        plugin can expose a write action (file an issue, open a PR) that the model
+        can't invoke autonomously. Read your own config in ``register()`` and close
+        over it, e.g. ``repo = self.config.get("default_repo")``.
+
+        The token is slugified + lowercased (``/Issue`` == ``/issue``). The reserved
+        core token ``goal`` is refused; a collision with a token another enabled
+        plugin already registered keeps the first and warns (resolved in the loader).
+        """
+        from graph.slash_commands import slugify_slash  # intra-graph, import-safe
+
+        token = slugify_slash(name)
+        if not token or not callable(handler):
+            log.warning(
+                "[plugins] %s: register_chat_command needs a name + callable: %r / %r", self.plugin_id, name, handler
+            )
+            return
+        if token == "goal":
+            log.warning("[plugins] %s: chat command /%s is reserved — skipped", self.plugin_id, token)
+            return
+        if token in self.chat_commands:
+            log.warning("[plugins] %s: chat command /%s registered twice — keeping the first", self.plugin_id, token)
+            return
+        self.chat_commands[token] = handler
 
     def emit(self, topic: str, data: dict | None = None) -> None:
         """Broadcast an event on the bus (ADR 0039) — fire-and-forget.

--- a/graph/slash_commands.py
+++ b/graph/slash_commands.py
@@ -51,16 +51,50 @@ def find_user_facing_skill(name: str):
     return None
 
 
+def find_plugin_chat_command(name: str):
+    """The plugin-registered chat command handler whose token matches ``/<name>``,
+    or ``None``. Tokens are slugified+lowercased at registration, so we match the
+    lowercased name (exact) and its slug (so ``/Issue`` and ``/foo_bar`` resolve a
+    ``foo-bar`` token). User-only control commands (``register_chat_command``)."""
+    commands = getattr(STATE, "plugin_chat_commands", None) or {}
+    if not name or not commands:
+        return None
+    return commands.get(name.strip().lower()) or commands.get(slugify_slash(name))
+
+
+async def run_plugin_chat_command(name: str, rest: str, session_id: str) -> str | None:
+    """Invoke the plugin chat command matching ``/<name>`` and return its reply (the
+    dispatcher short-circuits the turn with it), or ``None`` to fall through. A
+    handler that itself returns ``None`` falls through too (it decided not to handle
+    the message); precedence still excludes a same-named workflow/skill from firing
+    because ``slash_kind`` reports ``plugin_command`` for the token. A raising handler
+    is logged + swallowed into a ``⚠️`` reply so one bad plugin can't 500 the turn."""
+    handler = find_plugin_chat_command(name)
+    if handler is None:
+        return None
+    try:
+        return await handler(rest, session_id)
+    except Exception as exc:  # noqa: BLE001 — a bad plugin command must not break the turn
+        log.warning("[slash] plugin chat command /%s failed: %s", name, exc)
+        return f"⚠️ /{name} failed: {exc}"
+
+
 def slash_kind(name: str) -> str | None:
     """The kind a ``/<name>`` slash command resolves to — the SINGLE source of
     precedence shared by the chat dispatcher and the console palette, so they can
-    never disagree about what a token does. Reserved: ``goal``, ``issue``. Precedence:
-    workflow > subagent > user-facing skill. Returns ``None`` for an unknown token.
-    (Workflows/subagents match the bare name; skills match a slug.)"""
+    never disagree about what a token does. Reserved: ``goal``, ``issue`` (``issue``
+    moves to the github plugin). Precedence:
+    goal > plugin chat command > workflow > subagent > user-facing skill. Returns
+    ``None`` for an unknown token. (Plugin commands/workflows/subagents match the
+    bare name or its slug; skills match a slug.)"""
     if not name:
         return None
     if name == "goal" or slugify_slash(name) == "goal":
         return "goal"
+    if find_plugin_chat_command(name) is not None:
+        return "plugin_command"
+    # ``issue`` is a core-reserved control command today; it moves to the github
+    # plugin (resolving as ``plugin_command`` above) and this branch is removed then.
     if name == "issue" or slugify_slash(name) == "issue":
         return "issue"
     if STATE.workflow_registry is not None and STATE.workflow_registry.get(name) is not None:
@@ -92,8 +126,17 @@ def resolve_slash_commands() -> list[dict]:
         seen.add(name)
         cmds.append({"name": name, "kind": kind, "description": description, "usage": usage})
 
+    # Plugin chat commands first — they sit just below ``goal`` in precedence, so a
+    # workflow/skill of the same token must not shadow them in the palette.
+    for token, handler in (getattr(STATE, "plugin_chat_commands", None) or {}).items():
+        doc = (getattr(handler, "__doc__", "") or "").strip()
+        desc = doc.splitlines()[0] if doc else f"Run the /{token} command."
+        _add(token, "plugin_command", desc, f"/{token} …")
+
     if STATE.workflow_registry is not None:
         for wf in STATE.workflow_registry.list():
+            if slash_kind(wf["name"]) != "workflow":  # a goal/plugin-command/issue of the same token wins
+                continue
             declared = wf.get("inputs", []) or []
             req = "".join(f" <{i['name']}>" for i in declared if i.get("required"))
             opt = "".join(f" [{i['name']}]" for i in declared if not i.get("required"))

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -48,6 +48,7 @@ class AppState:
     plugin_late_tool_factories: list = field(default_factory=list)  # (all_tools, config) -> tool|list (late seam)
     plugin_workflow_dirs: list = field(default_factory=list)  # *.yaml recipe dirs (ADR 0027)
     plugin_a2a_skills: list = field(default_factory=list)  # A2A card skills from plugins (#570)
+    plugin_chat_commands: dict = field(default_factory=dict)  # token -> handler; user-only /<name> control commands
     thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571)
     plugin_routers: list = field(default_factory=list)
     # The live FastAPI app + the (plugin_id, prefix) keys already mounted on it —

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -193,6 +193,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     )
     STATE.plugin_workflow_dirs = _plugins.workflow_dirs
     STATE.plugin_a2a_skills = _plugins.a2a_skills  # A2A card skills (#570)
+    STATE.plugin_chat_commands = _plugins.chat_commands  # user-only /<name> control commands
     STATE.thread_id_resolver = _plugins.thread_id_resolver  # thread_id seam (#571)
     # A plugin may provide the knowledge backend (ADR 0031) — swap it in now (the
     # graph compiles below with STATE.knowledge_store). Default built-in store stays
@@ -1285,6 +1286,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     new_skills = None
     new_mcp_clients, new_mcp_tools, new_mcp_meta = [], [], []
     new_plugin_tools, new_plugin_skill_dirs, new_plugin_meta = [], [], []
+    new_plugin_chat_commands: dict = {}  # user-only /<name> control commands
     if is_setup_complete():
         try:
             new_store = _build_knowledge_store(new_config)
@@ -1305,6 +1307,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
             new_plugin_tools = new_plugins.tools
             new_plugin_skill_dirs = new_plugins.skill_dirs
             new_plugin_meta = new_plugins.meta
+            new_plugin_chat_commands = new_plugins.chat_commands  # user-only /<name> control commands
             # Plugin knowledge backend (ADR 0031) — swap before the graph rebuild.
             new_store = _apply_plugin_knowledge_backend(new_config, new_store, new_plugins)
             _register_plugin_subagents(new_plugins.subagents)
@@ -1372,6 +1375,7 @@ def _reload_langgraph_agent() -> tuple[bool, str]:
     STATE.graph = new_graph
     STATE.plugin_middleware = new_middleware  # ADR 0032
     STATE.plugin_late_tool_factories = new_late_tool_factories  # late-tools seam
+    STATE.plugin_chat_commands = new_plugin_chat_commands  # user-only /<name> control commands
     # STATE.workflow_registry / workflow_run were (re)set by the workflows plugin above.
     STATE.inbox_store = new_inbox_store
     # Commit the scheduler swap. start/stop are async — fire-and-forget

--- a/server/chat.py
+++ b/server/chat.py
@@ -599,6 +599,7 @@ async def _run_parsed_subagent(subagent_type: str, prompt: str) -> str:
 # the two can't drift (operator_api may not import server, so it can't live here).
 from graph.slash_commands import (  # noqa: E402
     find_user_facing_skill as _find_user_facing_skill,
+    run_plugin_chat_command as _run_plugin_chat_command,
     slash_kind as _slash_kind,
 )
 
@@ -687,6 +688,17 @@ async def _chat_langgraph_stream(
                 reply = await STATE.goal_controller.parse_control(message, session_id)
                 if reply is not None:
                     yield ("done", reply)
+                    return
+
+            # Plugin-registered chat control command (/<name> …) short-circuits the
+            # turn with the plugin's reply — user-only, like /goal. Sits above the
+            # core /issue handler below, which moves onto this same seam in the github
+            # plugin (PR2). No plugin claims a token by default ⇒ falls through.
+            name, rest = _parse_slash_command(message)
+            if name:
+                cmd_reply = await _run_plugin_chat_command(name, rest, session_id)
+                if cmd_reply is not None:
+                    yield ("done", cmd_reply)
                     return
 
             # Issue control command (/issue ...) short-circuits the turn: file a
@@ -1037,6 +1049,15 @@ async def _chat_langgraph(message: str, session_id: str, *, model: str | None = 
                 reply = await STATE.goal_controller.parse_control(message, session_id)
                 if reply is not None:
                     return [{"role": "assistant", "content": reply}]
+
+            # Plugin-registered chat control command (/<name> …) short-circuits —
+            # user-only, like /goal. Above the core /issue handler (PR2 moves /issue
+            # onto this seam). No plugin claims a token by default ⇒ falls through.
+            name, rest = _parse_slash_command(message)
+            if name:
+                cmd_reply = await _run_plugin_chat_command(name, rest, session_id)
+                if cmd_reply is not None:
+                    return [{"role": "assistant", "content": cmd_reply}]
 
             # Issue control command (/issue ...) short-circuits — file a GitHub
             # issue (user-only; never an agent tool). See the streaming path.

--- a/tests/test_plugin_chat_commands.py
+++ b/tests/test_plugin_chat_commands.py
@@ -1,0 +1,169 @@
+"""Tests for the plugin chat-command seam (register_chat_command).
+
+A plugin can own a user-only ``/<name>`` control command that short-circuits the
+turn with a reply — the generalized form of the core ``/goal`` (and the soon
+plugin-owned ``/issue``). The seam spans the registry (collect), the loader
+(``PluginLoadResult.chat_commands`` + first-wins de-dupe), ``runtime.state`` and
+``graph.slash_commands`` (resolve + precedence + palette).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from graph.config import LangGraphConfig
+from graph.plugins import loader as plugin_loader
+from graph.plugins.loader import load_plugins
+from graph.plugins.registry import PluginRegistry
+
+# A plugin whose register() owns a chat command. The token is mixed-case to prove
+# it is slugified+lowercased ("Issue" -> "issue"). The handler passes through
+# (returns None) on an empty rest, else replies — mirroring a real control command.
+_CMD_PLUGIN = '''
+def register(registry):
+    async def _handler(rest, session_id):
+        """File a GitHub issue."""
+        if not rest.strip():
+            return None
+        return f"handled:{rest}:{session_id}"
+    registry.register_chat_command("Issue", _handler)
+'''
+
+
+def _make_plugin(root: Path, pid: str, *, body: str, enabled: bool = True) -> Path:
+    d = root / pid
+    d.mkdir(parents=True, exist_ok=True)
+    (d / "protoagent.plugin.yaml").write_text(
+        f"id: {pid}\nname: {pid} plugin\nversion: 0.1.0\nenabled: {'true' if enabled else 'false'}\n",
+        encoding="utf-8",
+    )
+    (d / "__init__.py").write_text(body, encoding="utf-8")
+    return d
+
+
+def _cfg(**kw):
+    return LangGraphConfig(**kw)
+
+
+# --- registry-level surface --------------------------------------------------
+
+
+def test_register_chat_command_slugifies_reserves_goal_and_dedupes() -> None:
+    reg = PluginRegistry("p", Path("/tmp"))
+
+    async def h(rest, session_id):
+        return "first"
+
+    async def h2(rest, session_id):
+        return "second"
+
+    reg.register_chat_command("My Cmd", h)
+    assert "my-cmd" in reg.chat_commands  # slugified + lowercased
+
+    reg.register_chat_command("goal", h)  # reserved core token — refused
+    assert "goal" not in reg.chat_commands
+
+    reg.register_chat_command("my-cmd", h2)  # same token again — keep the first
+    assert reg.chat_commands["my-cmd"] is h
+
+    reg.register_chat_command("", h)  # empty / no token — ignored
+    reg.register_chat_command("bad", None)  # non-callable — ignored
+    assert set(reg.chat_commands) == {"my-cmd"}
+
+
+# --- loader collection -------------------------------------------------------
+
+
+def test_loader_collects_chat_command(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "plugins"
+    _make_plugin(root, "cmdp", body=_CMD_PLUGIN)
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+
+    res = load_plugins(_cfg())
+    assert set(res.chat_commands) == {"issue"}  # slugified token landed
+    assert res.meta[0]["chat_commands"] == ["/issue"]  # surfaced for the console
+
+
+async def test_loader_first_wins_on_collision(tmp_path, monkeypatch) -> None:
+    root = tmp_path / "plugins"
+    # Discovery is sorted by dir name, so "ap" is collected before "bp".
+    _make_plugin(root, "ap", body=_dup_plugin("A"))
+    _make_plugin(root, "bp", body=_dup_plugin("B"))
+    monkeypatch.setattr(plugin_loader, "_plugin_roots", lambda config: [root])
+
+    res = load_plugins(_cfg())
+    assert set(res.chat_commands) == {"dup"}
+    # The first plugin's handler wins; the second is dropped.
+    assert await res.chat_commands["dup"]("x", "s") == "A:x"
+
+
+def _dup_plugin(tag: str) -> str:
+    return (
+        "def register(registry):\n"
+        "    async def _h(rest, session_id):\n"
+        f"        return '{tag}:' + rest\n"
+        "    registry.register_chat_command('dup', _h)\n"
+    )
+
+
+# --- resolution + precedence + palette (graph.slash_commands) ----------------
+
+
+async def test_resolve_run_and_passthrough(monkeypatch) -> None:
+    from graph import slash_commands as sc
+    from runtime.state import STATE
+
+    async def handler(rest, session_id):
+        """File a GitHub issue."""
+        return None if rest == "skip" else f"ok:{rest}:{session_id}"
+
+    monkeypatch.setattr(STATE, "plugin_chat_commands", {"issue": handler})
+
+    assert sc.find_plugin_chat_command("issue") is handler
+    assert sc.find_plugin_chat_command("Issue") is handler  # case-insensitive
+    assert sc.slash_kind("issue") == "plugin_command"
+
+    assert await sc.run_plugin_chat_command("issue", "hello", "sess1") == "ok:hello:sess1"
+    assert await sc.run_plugin_chat_command("issue", "skip", "s") is None  # handler passes through
+    assert await sc.run_plugin_chat_command("nope", "x", "s") is None  # no such command
+
+
+async def test_raising_handler_is_swallowed(monkeypatch) -> None:
+    from graph import slash_commands as sc
+    from runtime.state import STATE
+
+    async def boom(rest, session_id):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(STATE, "plugin_chat_commands", {"boom": boom})
+    out = await sc.run_plugin_chat_command("boom", "", "s")
+    assert out.startswith("⚠️") and "boom" in out  # turn still short-circuits, no 500
+
+
+def test_precedence_over_workflow_and_palette(monkeypatch) -> None:
+    from graph import slash_commands as sc
+    from runtime.state import STATE
+
+    async def handler(rest, session_id):
+        """File a GitHub issue."""
+        return "ok"
+
+    class _WF:
+        def get(self, name):
+            return {"name": name} if name in ("issue", "deploy") else None
+
+        def list(self):
+            return [{"name": "issue", "description": "wf"}, {"name": "deploy", "description": "Deploy it"}]
+
+    monkeypatch.setattr(STATE, "plugin_chat_commands", {"issue": handler})
+    monkeypatch.setattr(STATE, "workflow_registry", _WF())
+    monkeypatch.setattr(STATE, "skills_index", None)
+
+    # A plugin command outranks a same-named workflow; an unclaimed token stays a workflow.
+    assert sc.slash_kind("issue") == "plugin_command"
+    assert sc.slash_kind("deploy") == "workflow"
+
+    inv = {c["name"]: c for c in sc.resolve_slash_commands()}
+    assert inv["issue"]["kind"] == "plugin_command"  # not double-listed as a workflow
+    assert inv["deploy"]["kind"] == "workflow"
+    assert inv["issue"]["description"] == "File a GitHub issue."  # from the handler docstring


### PR DESCRIPTION
## What & why

First PR of the **GitHub-extraction** effort ([plan](https://github.com/protoLabsAI/protoAgent)): move all GitHub functionality into a standalone plugin and keep core light. Today `/issue` is a control command **hardcoded** in `server/chat.py` and reserved in `graph/slash_commands.py` — there's no way for a plugin to own a `/<name>` chat command. This PR adds that generic, reusable seam so `/issue` (and future write commands) can live in a plugin.

This is **additive and behavior-preserving** — `/issue` stays hardcoded; the new seam runs first and falls through when no plugin claims the token. The follow-up PR moves `/issue` onto it.

## The seam

`registry.register_chat_command(name, handler)` — `handler` is `async (rest, session_id) -> str | None`. A reply string short-circuits the turn (the model never runs, like `/goal`); `None` passes through. **User-only by design** — not an agent tool — so a plugin can expose a write action (file an issue, open a PR) the model can't trigger autonomously. Handlers close over `registry.config` to read their own settings.

Precedence: `goal` > **plugin command** > workflow > subagent > skill, resolved **once** in `graph/slash_commands.py` so the chat dispatcher and the console palette can't drift. Import-layering holds (the resolver stays in `graph/`, reads only `STATE`; net effect *removes* a `server → tools.gh_issue` import in the follow-up).

## Changes

- `runtime/state.py` — `plugin_chat_commands` dict on `STATE` (init + reload paths).
- `graph/plugins/{registry,loader}.py` — `register_chat_command` + first-wins collection; meta surfaces the tokens.
- `graph/slash_commands.py` — `find_plugin_chat_command`, `run_plugin_chat_command` (bad handler → `⚠️` reply, never a 500), `slash_kind` `plugin_command` band, palette emission + workflow-loop precedence guard.
- `server/chat.py` — both dispatch paths consult the seam after `/goal`, before the still-hardcoded `/issue`.
- Tests (`tests/test_plugin_chat_commands.py`), plugin-registry guide, CHANGELOG.

## Verification

- `tests/test_plugin_chat_commands.py` — 6 new tests: registry slugify/reserve-goal/dedupe, loader collection + first-wins, resolve/run/passthrough, raising-handler swallow, precedence over a same-named workflow + palette listing.
- Full gate green: `ruff check .`, `lint-imports` (3 contracts kept), `python -m pytest tests/ -q` → **2548 passed, 2 skipped**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)