### PR TITLE
feat(web): "Report a bug" link in the hamburger menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   trigger autonomously. Precedence is `goal` > plugin command > workflow > subagent > skill, resolved
   once in `graph/slash_commands.py` so the chat dispatcher and the console palette can't drift. This is
   the seam that lets the GitHub `/issue` command move into a plugin.
+- **"Report a bug" link in the hamburger menu** (the header side panel), next to Docs /
+  Changelog / GitHub — opens the repo's new-issue chooser in a new tab. A lightweight,
+  always-present way to file a bug, independent of any GitHub plugin.
 
 ## [0.69.0] - 2026-06-24
 

--- a/apps/web/src/app/AppDrawer.tsx
+++ b/apps/web/src/app/AppDrawer.tsx
@@ -1,6 +1,6 @@
 import { useEffect } from "react";
 import type { ReactNode } from "react";
-import { BarChart3, BookOpen, Github, ScrollText, Settings2, X } from "lucide-react";
+import { BarChart3, BookOpen, Bug, Github, ScrollText, Settings2, X } from "lucide-react";
 
 import { Button } from "@protolabsai/ui/primitives";
 
@@ -120,6 +120,16 @@ export function AppDrawer({
             >
               <span className="app-drawer-ico"><Github size={16} /></span>
               GitHub
+            </a>
+            <a
+              className="app-drawer-item"
+              href="https://github.com/protoLabsAI/protoAgent/issues/new/choose"
+              target="_blank"
+              rel="noreferrer"
+              onClick={onClose}
+            >
+              <span className="app-drawer-ico"><Bug size={16} /></span>
+              Report a bug
             </a>
           </section>
         </div>


### PR DESCRIPTION
## What

Adds a **"Report a bug"** item to the header hamburger side panel (`AppDrawer`), next to Docs / Changelog / GitHub. It opens the repo's new-issue chooser (`/issues/new/choose`) in a new tab — a lightweight, always-present way to file a bug.

It's deliberately a **static external link** (mirrors the existing GitHub link there), so it works regardless of whether the GitHub plugin is installed — keeping core's bug-report affordance independent of the plugin extraction.

## Verification

- `tsc --noEmit` typecheck clean.
- `npm run test:unit --workspace @protoagent/web` → **121 passed**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)