### PR TITLE
docs(marketing): point the GitHub plugin directory entry at the standalone repo

### DIFF
--- a/sites/marketing/data/plugins.json
+++ b/sites/marketing/data/plugins.json
@@ -89,18 +89,20 @@
   },
   {
     "id": "github",
-    "name": "GitHub (read tools)",
+    "name": "GitHub (read/write tools)",
     "category": "Integrations",
     "official": true,
-    "tagline": "Read-only GitHub over the gh CLI — fetch a PR, an issue, list issues, a commit diff. Opt-in; not every agent needs GitHub.",
+    "tagline": "Read AND write GitHub over the gh CLI — PRs, issues, diffs, CI, repo files; plus gated create/edit/merge/close, comments, labels (per-agent write gating). Ships a read-only Issues/PRs board, a util-bar New-issue widget, and the user-only /issue command.",
     "adds": [
-      "tool"
+      "tool",
+      "view"
     ],
-    "bundled": true,
+    "bundled": false,
+    "install": "https://github.com/protoLabsAI/github-plugin",
     "enable": "github",
     "links": {
-      "source": "https://github.com/protoLabsAI/protoAgent/tree/main/plugins/github",
-      "docs": "/docs/guides/plugins"
+      "source": "https://github.com/protoLabsAI/github-plugin",
+      "docs": "https://github.com/protoLabsAI/github-plugin#readme"
     }
   },
   {


### PR DESCRIPTION
## What

The GitHub plugin moved out of core (#1336) into [`protoLabsAI/github-plugin`](https://github.com/protoLabsAI/github-plugin), but the plugin-directory entry (`sites/marketing/data/plugins.json`) still described the **old in-tree read-only shim** — wrong name, `bundled: true`, and a `source` pointing at the now-deleted `plugins/github` tree path (no install URL).

Updated the entry to the standalone plugin:
- name → **"GitHub (read/write tools)"**, tagline covers read **and** write + the board / util-bar New-issue / `/issue` command.
- `bundled: false` + **`install`** = the standalone repo URL (so the directory's install action points at the right place).
- `adds: [tool, view]`; `source`/`docs` links → the standalone repo.

Paired with the repo's new **`protoagent-plugin` GitHub topic** (just added), the plugin now surfaces in both the directory and the topic search. The plugin's README already links back to protoAgent, so the crosslink is bidirectional.

🤖 Generated with [Claude Code](https://claude.com/claude-code)