### PR TITLE
chore: release v0.70.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.70.0] - 2026-06-24
+
 ### Added
 - **Plugins can own `/<name>` chat control commands** via `registry.register_chat_command(name, handler)`
   — the generalized form of the core `/goal`. The handler is `async (rest, session_id) -> str | None`:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.69.0"
+version = "0.70.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,14 @@
 [
   {
+    "version": "v0.70.0",
+    "date": "2026-06-24",
+    "changes": [
+      "Plugins can own /<name> chat control commands",
+      "\"Report a bug\" link in the hamburger menu",
+      "GitHub is no longer in core — it's a standalone plugin"
+    ]
+  },
+  {
     "version": "v0.69.0",
     "date": "2026-06-24",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.70.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.70.0 -m 'Release v0.70.0' && git push origin v0.70.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).