### PR TITLE
fix(web): console SSE sends the sse-token the server requires under a bearer

### DIFF
--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -545,6 +545,15 @@ export const api = {
     return request<RuntimeStatus>("/api/runtime/status");
   },
 
+  // Short-lived HMAC token for the SSE EventSource, which can't send an
+  // Authorization header. Bearer-gated; in open mode the server returns "" and
+  // accepts a tokenless /api/events. events.ts fetches this before each
+  // (re)connect. Same slug routing as /api/events so the token is signed by
+  // whichever server actually terminates the stream (host or a proxied member).
+  sseToken() {
+    return request<{ token: string }>("/api/sse-token");
+  },
+
   // Gracefully restart the server process (POST /api/restart) — the server drains and
   // re-execs; the console reconnects via the boot gate. Always targets the HOST (the
   // process you're connected to), never a slug-routed agent.

--- a/apps/web/src/lib/events.test.ts
+++ b/apps/web/src/lib/events.test.ts
@@ -1,0 +1,134 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+// The SSE event-bus client (ADR 0003/0039). Focus: topic matching, the `?token=`
+// auth handshake (#873 — the server requires an sse-token once a bearer is set),
+// and `?since=` replay continuity on reconnect.
+
+// apiUrl is identity-ish for "/api/events"; sseToken is mocked per-test.
+const sseToken = vi.fn(async () => ({ token: "" }) as { token: string });
+vi.mock("./api", () => ({
+  apiUrl: (p: string) => p,
+  api: {
+    sseToken: () => sseToken(),
+  },
+}));
+
+// Minimal EventSource fake: records the URL it was constructed with and lets a
+// test drive onopen/onmessage/onerror.
+class FakeEventSource {
+  static instances: FakeEventSource[] = [];
+  url: string;
+  onopen: ((ev: unknown) => void) | null = null;
+  onerror: ((ev: unknown) => void) | null = null;
+  onmessage: ((ev: unknown) => void) | null = null;
+  closed = false;
+  constructor(url: string) {
+    this.url = url;
+    FakeEventSource.instances.push(this);
+  }
+  close() {
+    this.closed = true;
+  }
+  emit(data: unknown) {
+    this.onmessage?.({ data: JSON.stringify(data) } as MessageEvent);
+  }
+}
+
+// Re-import the module fresh each test so its module-level singleton state resets.
+async function loadEvents() {
+  vi.resetModules();
+  FakeEventSource.instances = [];
+  (globalThis as unknown as { EventSource: unknown }).EventSource = FakeEventSource;
+  return import("./events");
+}
+
+beforeEach(() => {
+  sseToken.mockReset();
+  sseToken.mockResolvedValue({ token: "" });
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("topicMatches", () => {
+  it("matches exact, single-segment *, and tail #", async () => {
+    const { topicMatches } = await loadEvents();
+    expect(topicMatches("a.b", "a.b")).toBe(true);
+    expect(topicMatches("a.*", "a.b")).toBe(true);
+    expect(topicMatches("a.*", "a.b.c")).toBe(false);
+    expect(topicMatches("a.#", "a.b.c")).toBe(true);
+    expect(topicMatches("#", "anything.here")).toBe(true);
+    expect(topicMatches("a.b", "a.c")).toBe(false);
+  });
+});
+
+describe("buildEventsUrl", () => {
+  it("returns the bare base when no token and no since", async () => {
+    const { buildEventsUrl } = await loadEvents();
+    expect(buildEventsUrl("/api/events", "", null)).toBe("/api/events");
+  });
+
+  it("appends token and since, joining with ? or &", async () => {
+    const { buildEventsUrl } = await loadEvents();
+    expect(buildEventsUrl("/api/events", "tok", null)).toBe("/api/events?token=tok");
+    expect(buildEventsUrl("/api/events", "", 7)).toBe("/api/events?since=7");
+    expect(buildEventsUrl("/api/events", "tok", 7)).toBe("/api/events?token=tok&since=7");
+    expect(buildEventsUrl("/api/events?x=1", "tok", null)).toBe("/api/events?x=1&token=tok");
+  });
+});
+
+describe("connect handshake", () => {
+  it("fetches an sse-token and opens EventSource with ?token=", async () => {
+    sseToken.mockResolvedValue({ token: "abc123" });
+    const { onTopic } = await loadEvents();
+    onTopic("x.*", () => {});
+    // connect() awaits the token fetch microtask before constructing EventSource.
+    await vi.waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    expect(sseToken).toHaveBeenCalledTimes(1);
+    expect(FakeEventSource.instances[0].url).toBe("/api/events?token=abc123");
+  });
+
+  it("opens a tokenless stream in open mode (token \"\")", async () => {
+    sseToken.mockResolvedValue({ token: "" });
+    const { onTopic } = await loadEvents();
+    onTopic("#", () => {});
+    await vi.waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    expect(FakeEventSource.instances[0].url).toBe("/api/events");
+  });
+
+  it("still connects (tokenless) when the sse-token fetch rejects", async () => {
+    sseToken.mockRejectedValue(new Error("401"));
+    const { onTopic } = await loadEvents();
+    onTopic("#", () => {});
+    await vi.waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    expect(FakeEventSource.instances[0].url).toBe("/api/events");
+  });
+});
+
+describe("reconnect", () => {
+  it("on error, refreshes the token and replays via ?since=<lastSeq>", async () => {
+    vi.useFakeTimers();
+    sseToken.mockResolvedValue({ token: "t1" });
+    const seen: number[] = [];
+    const { onTopic } = await loadEvents();
+    onTopic("job.*", (data) => seen.push((data as { n: number }).n));
+
+    await vi.waitFor(() => expect(FakeEventSource.instances.length).toBe(1));
+    const first = FakeEventSource.instances[0];
+    first.onopen?.({});
+    // Deliver an event carrying seq=42 so the next connect should resume after it.
+    first.emit({ topic: "job.start", data: { n: 1 }, seq: 42 });
+    expect(seen).toEqual([1]);
+
+    // Drop the connection; the token rotates server-side.
+    sseToken.mockResolvedValue({ token: "t2" });
+    first.onerror?.({});
+    expect(first.closed).toBe(true);
+
+    // Backoff timer (first attempt = 1s) → reconnect with fresh token + since.
+    await vi.advanceTimersByTimeAsync(1000);
+    await vi.waitFor(() => expect(FakeEventSource.instances.length).toBe(2));
+    expect(FakeEventSource.instances[1].url).toBe("/api/events?token=t2&since=42");
+  });
+});

--- a/apps/web/src/lib/events.ts
+++ b/apps/web/src/lib/events.ts
@@ -1,11 +1,17 @@
-import { apiUrl } from "./api";
+import { api, apiUrl } from "./api";
 
 // Client for the server→client event bus (ADR 0003, extended ADR 0039). One EventSource
 // is shared for the app's lifetime. Every event arrives as an unnamed SSE frame carrying
 // `{topic, data, seq}`, so we route in JS by topic with `*`/`#` wildcard matching — a
-// surface subscribes to an exact topic or a pattern. EventSource auto-reconnects and
-// (because frames carry `id:`) resends Last-Event-ID, so the server replays missed events
-// from its ring buffer.
+// surface subscribes to an exact topic or a pattern.
+//
+// Auth: when a bearer is configured the server requires a short-lived HMAC token on
+// `/api/events` (EventSource can't send an Authorization header). We fetch it from
+// `/api/sse-token` before each connect and pass it as `?token=`. Because that token
+// expires, we can't rely on EventSource's built-in reconnect (it would reuse the stale
+// token → a permanent 401); instead we tear down on error and reconnect with a fresh
+// token, passing `?since=<lastSeq>` so the server still replays missed events from its
+// ring buffer. In open mode the token is "" and the server accepts a tokenless stream.
 
 type Listener = (data: Record<string, unknown>, topic: string) => void;
 
@@ -15,6 +21,11 @@ const subs = new Set<Sub>();
 const connListeners = new Set<(connected: boolean) => void>();
 let source: EventSource | null = null;
 let connected = false;
+let connecting = false;
+// Highest bus seq we've dispatched — replayed via `?since=` on reconnect.
+let lastSeq: number | null = null;
+let reconnectAttempts = 0;
+let reconnectTimer: ReturnType<typeof setTimeout> | null = null;
 
 /** Topic matcher mirroring events/bus.py: `*` = one segment, `#` = tail. */
 export function topicMatches(pattern: string, topic: string): boolean {
@@ -36,27 +47,94 @@ function setConnected(next: boolean) {
   connListeners.forEach((fn) => fn(connected));
 }
 
-function dispatch(raw: string) {
-  let frame: { topic?: string; data?: Record<string, unknown> } = {};
+/** Route a raw SSE frame to matching subscribers. Returns the frame's bus seq
+ *  (for `?since=` replay) or null when the frame carries none. */
+function dispatch(raw: string): number | null {
+  let frame: { topic?: string; data?: Record<string, unknown>; seq?: number } = {};
   try {
     frame = JSON.parse(raw || "{}");
   } catch {
-    return;
+    return null;
   }
   const topic = frame.topic;
-  if (!topic) return;
+  if (!topic) return null;
   const data = (frame.data as Record<string, unknown>) || {};
   for (const sub of subs) {
     if (topicMatches(sub.pattern, topic)) sub.fn(data, topic);
   }
+  return typeof frame.seq === "number" ? frame.seq : null;
+}
+
+/** Build the EventSource URL, appending `?token=` (auth) and `?since=` (replay)
+ *  only when present. Exported for unit testing. */
+export function buildEventsUrl(base: string, token: string, since: number | null): string {
+  if (!token && since === null) return base;
+  const params = new URLSearchParams();
+  if (token) params.set("token", token);
+  if (since !== null) params.set("since", String(since));
+  return `${base}${base.includes("?") ? "&" : "?"}${params.toString()}`;
+}
+
+/** True while at least one consumer wants the stream open. */
+function wanted(): boolean {
+  return subs.size > 0 || connListeners.size > 0;
+}
+
+function teardownSource() {
+  if (source) {
+    source.onopen = null;
+    source.onerror = null;
+    source.onmessage = null;
+    source.close();
+    source = null;
+  }
+}
+
+function scheduleReconnect() {
+  if (reconnectTimer || !wanted()) return;
+  // Exponential backoff capped at 30s so a down server (or an operator who hasn't
+  // supplied a token yet) isn't hammered.
+  const delay = Math.min(1000 * 2 ** reconnectAttempts, 30000);
+  reconnectAttempts += 1;
+  reconnectTimer = setTimeout(() => {
+    reconnectTimer = null;
+    void connect();
+  }, delay);
+}
+
+async function connect() {
+  if (source || connecting || typeof EventSource === "undefined") return;
+  connecting = true;
+  let token = "";
+  try {
+    token = (await api.sseToken()).token || "";
+  } catch {
+    // Bearer missing/invalid → request() already tripped the AuthGate (#873). Still
+    // attempt a tokenless connect: it succeeds in open mode, and in bearer mode the
+    // onerror path will retry once the operator supplies a token.
+  }
+  connecting = false;
+  // A consumer may have torn everything down while we awaited the token.
+  if (!wanted() || source) return;
+  const es = new EventSource(buildEventsUrl(apiUrl("/api/events"), token, lastSeq));
+  source = es;
+  es.onopen = () => {
+    reconnectAttempts = 0;
+    setConnected(true);
+  };
+  es.onerror = () => {
+    setConnected(false);
+    teardownSource();
+    scheduleReconnect();
+  };
+  es.onmessage = (event) => {
+    const seq = dispatch((event as MessageEvent).data);
+    if (seq !== null) lastSeq = seq;
+  };
 }
 
 function ensureOpen() {
-  if (source || typeof EventSource === "undefined") return;
-  source = new EventSource(apiUrl("/api/events"));
-  source.onopen = () => setConnected(true);
-  source.onerror = () => setConnected(false); // EventSource auto-reconnects (with Last-Event-ID)
-  source.onmessage = (event) => dispatch((event as MessageEvent).data);
+  void connect();
 }
 
 /** Subscribe to a topic (exact, or a `*`/`#` pattern). Returns an unsubscribe function. */


### PR DESCRIPTION
## Problem

The console's event-bus client (`apps/web/src/lib/events.ts`) opened
`EventSource("/api/events")` with **no token**, on the assumption that the
endpoint is server-side exempt ("EventSource can't set headers"). But the auth
middleware (`a2a_impl/auth.py`) requires a valid short-lived HMAC token on
`/api/events` **whenever a bearer is configured**. The `/api/sse-token` endpoint
exists for exactly this handshake — the console just never called it.

- **No bearer** (default loopback / desktop): `_validate_sse_token("")` returns
  `True`, so the tokenless stream is accepted → the gap was invisible.
- **Bearer set** (any LAN-exposed / mDNS bind via `A2A_AUTH_TOKEN`): the server
  demands a token the client never sends → **every `/api/events` connection
  401s**, the live event bus dies, and the console silently degrades to polling.

Reproduced on a token-gated instance: `GET /api/events → 401`, while
`/api/sse-token` (bearer) → token and `/api/events?token=<token>` → 200. So the
server side was correct; only the client's half of the handshake was missing.

## Fix

`events.ts` now fetches `/api/sse-token` before each connect and passes it as
`?token=`. Because the token is short-lived, EventSource's built-in reconnect
(which would reuse the now-stale token → permanent 401) is replaced with a manual
teardown + exponential-backoff reconnect that:

- refreshes the token on every (re)connect, and
- passes `?since=<lastSeq>` so the server still replays missed events from its
  ring buffer (ADR 0039) — no Last-Event-ID regression, since `/api/events`
  already accepts `?since=` as an equivalent to the header.

Open mode is unchanged: `sseToken()` returns `""`, the URL stays bare, and the
server accepts the tokenless stream.

## Test

- New `apps/web/src/lib/events.test.ts`: `buildEventsUrl` query composition, the
  `?token=` handshake (incl. open-mode and a rejected token fetch), and
  reconnect refreshing the token + resuming via `?since=<lastSeq>`.
- Full web unit suite: 16 files / 140 tests pass. `tsc` typecheck + `vite build` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for authenticated live event connections, including automatic token fetching and reuse.
  * Live updates now resume from the last received event after reconnecting, helping prevent missed messages.

* **Bug Fixes**
  * Improved reconnect behavior for streaming connections so expired sessions are refreshed instead of reused.
  * Better handling of tokenless environments, allowing streams to continue when no token is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->