### PR TITLE
fix(a2a): drop legacy pre-SDK tasks table on boot so the SDK can recreate it

### DIFF
--- a/a2a_impl/stores.py
+++ b/a2a_impl/stores.py
@@ -391,6 +391,37 @@ async def reconcile_interrupted_tasks(engine: AsyncEngine, *, now: datetime | No
         return result.rowcount or 0
 
 
+async def drop_legacy_task_table(engine: AsyncEngine) -> bool:
+    """Drop a pre-SDK bespoke ``tasks`` table so the SDK store can recreate it.
+
+    The bespoke ``a2a_task_store.py`` (removed in the #443 SDK migration) created
+    ``tasks(task_id, state, updated_at, data)``. The SDK's ``DatabaseTaskStore``
+    expects ``tasks(id, context_id, status, …)`` and creates it via
+    ``Base.metadata.create_all`` — which **skips a table that already exists**. So
+    an instance upgraded across the migration keeps the legacy table, and every
+    task op 500s with ``no such column: tasks.id`` (the console chat path included).
+
+    Detect the legacy schema (``tasks`` present but no ``id`` column) and drop it
+    — task rows are transient, regenerable state — so the subsequent
+    ``create_all`` rebuilds the correct schema. No-op when the table is absent
+    (fresh db) or already on the SDK schema. Returns True when a drop occurred.
+    """
+    async with engine.begin() as conn:
+        cols = [r[1] for r in (await conn.execute(text("PRAGMA table_info('tasks')"))).fetchall()]
+        if not cols or "id" in cols:
+            return False  # no table yet, or already the SDK schema — nothing to do
+        n = (await conn.execute(text("SELECT count(*) FROM tasks"))).scalar()
+        await conn.execute(text("DROP TABLE tasks"))
+        log.warning(
+            "[a2a] dropped legacy pre-SDK 'tasks' table (%s row(s), columns=%s) so the SDK "
+            "DatabaseTaskStore can recreate its schema — fixes 'no such column: tasks.id' on "
+            "instances upgraded across the #443 store migration",
+            n,
+            cols,
+        )
+        return True
+
+
 async def initialize_a2a_stores(
     task_store: DatabaseTaskStore,
     push_store: ValidatingPushNotificationConfigStore,
@@ -405,6 +436,13 @@ async def initialize_a2a_stores(
     ``input_required`` / ``auth_required`` pauses are left alone (resumable from
     the checkpoint).
     """
+    # Upgrade guard: a legacy bespoke ``tasks`` table would survive create_all and
+    # break every task op with "no such column: tasks.id". Drop it first so the
+    # SDK rebuilds the correct schema.
+    try:
+        await drop_legacy_task_table(task_store.engine)
+    except Exception:
+        log.exception("[a2a] legacy task-table migration check failed; continuing")
     await task_store.initialize()
     await push_store.initialize()
     try:

--- a/tests/test_a2a_stores.py
+++ b/tests/test_a2a_stores.py
@@ -364,3 +364,90 @@ async def test_async_paths_resolve_dns_off_the_event_loop(tmp_path, monkeypatch)
     assert ok is False
     assert resolver_threads and all(t != loop_thread for t in resolver_threads)
     await engine.dispose()
+
+
+# ── (c) upgrade guard: legacy pre-SDK 'tasks' table is dropped + recreated ──────
+
+
+async def _make_legacy_tasks_db(db_path: str, rows: int = 2) -> None:
+    """Create the bespoke pre-#443 ``tasks`` schema (no ``id`` column) + some rows,
+    mimicking a db file left by the old a2a_task_store before the SDK migration."""
+    from sqlalchemy import text
+
+    engine = make_sqlite_engine(db_path)
+    async with engine.begin() as conn:
+        await conn.execute(
+            text(
+                "CREATE TABLE tasks ("
+                "task_id TEXT PRIMARY KEY, state TEXT NOT NULL, "
+                "updated_at TEXT NOT NULL, data TEXT NOT NULL)"
+            )
+        )
+        for i in range(rows):
+            await conn.execute(
+                text("INSERT INTO tasks (task_id, state, updated_at, data) VALUES (:i, 'working', '2026-01-01', '{}')"),
+                {"i": f"legacy-{i}"},
+            )
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_drop_legacy_task_table_drops_bespoke_schema(tmp_path):
+    """A legacy ``tasks`` table (no ``id``) is detected and dropped → True."""
+    from sqlalchemy import text
+
+    db = str(tmp_path / "a2a-tasks.db")
+    await _make_legacy_tasks_db(db)
+
+    engine = make_sqlite_engine(db)
+    dropped = await stores.drop_legacy_task_table(engine)
+    assert dropped is True
+    async with engine.begin() as conn:
+        cols = [r[1] for r in (await conn.execute(text("PRAGMA table_info('tasks')"))).fetchall()]
+    assert cols == []  # table gone; create_all will rebuild it
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_drop_legacy_task_table_noop_on_fresh_and_sdk_schema(tmp_path):
+    """No-op (False) when the table is absent, and again once the SDK schema exists."""
+    db = str(tmp_path / "a2a-tasks.db")
+
+    engine = make_sqlite_engine(db)
+    # Fresh db, no tasks table yet.
+    assert await stores.drop_legacy_task_table(engine) is False
+
+    # SDK schema present (has ``id``) → must be left untouched.
+    store = DatabaseTaskStore(engine)
+    await store.initialize()
+    assert await stores.drop_legacy_task_table(engine) is False
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_initialize_recreates_sdk_schema_over_legacy_db(tmp_path):
+    """End-to-end: a legacy db survives initialize_a2a_stores and a task round-trips
+    (regression for 'no such column: tasks.id')."""
+    from a2a.types import a2a_pb2
+
+    db = str(tmp_path / "a2a-tasks.db")
+    await _make_legacy_tasks_db(db)
+
+    task_engine = make_sqlite_engine(db)
+    task_store = DatabaseTaskStore(task_engine)
+    push_store, push_engine = await _fresh_push_store(str(tmp_path / "a2a-push.db"))
+
+    await initialize_a2a_stores(task_store, push_store)
+
+    ctx = _ctx()
+    task = a2a_pb2.Task(
+        id="t-new",
+        context_id="ctx-new",
+        status=a2a_pb2.TaskStatus(state=a2a_pb2.TASK_STATE_COMPLETED),
+    )
+    await task_store.save(task, ctx)  # would 500 with the legacy schema
+    got = await task_store.get("t-new", ctx)
+    assert got is not None and got.id == "t-new"
+
+    await task_engine.dispose()
+    await push_engine.dispose()


### PR DESCRIPTION
## Problem

An instance whose `a2a-tasks.db` predates the #443 migration (bespoke
`a2a_task_store.py` → a2a-sdk `DatabaseTaskStore`) still carries the old
`tasks(task_id, state, updated_at, data)` schema. The SDK store creates its
table via `Base.metadata.create_all`, which **skips a table that already
exists** — so the legacy table survives and every task op 500s with:

```
sqlite3.OperationalError: no such column: tasks.id
```

The console chat path runs through A2A `message/send`, so **chat is dead** on
any upgraded instance until the db is wiped by hand. Hit live on a real instance
(diagnosed via `journalctl`: `Request Error (ID: web-…): no such column: tasks.id`).

## Fix

`drop_legacy_task_table()`, called from `initialize_a2a_stores()` *before*
`task_store.initialize()`: detect the legacy schema (`tasks` present but no `id`
column) and drop it — task rows are transient, regenerable state — so the
subsequent `create_all` rebuilds the correct schema. No-op on a fresh db or one
already on the SDK schema. The drop logs a `warning` with the row count + columns.

## Test

- `tasks` legacy table detected + dropped → `True`.
- No-op (`False`) on a fresh db, and again once the SDK schema (with `id`) exists.
- End-to-end: a legacy db survives `initialize_a2a_stores` and a task then
  round-trips through `save`/`get` — regression guard for `no such column: tasks.id`.
- Full `tests/test_a2a_stores.py`: 26 passed. `ruff` + `lint-imports` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)