### PR TITLE
feat(delegates): add list_agents tool alongside delegate_to

### DIFF
--- a/plugins/delegates/__init__.py
+++ b/plugins/delegates/__init__.py
@@ -55,6 +55,35 @@ def _build_delegate_to(registry: DelegateRegistry):
     return delegate_to
 
 
+def _build_list_agents(registry: DelegateRegistry):
+    @tool
+    def list_agents() -> str:
+        """List the agents/delegates you can reach with `delegate_to`, with each one's
+        type, description, and current reachability (🟢 reachable · 🔴 down · ⚪ unknown).
+
+        Read this before assuming who's available — the roster is configuration, not a
+        fixed set, and it changes as delegates are added or removed."""
+        try:
+            from .health import health_snapshot
+
+            health = health_snapshot() or {}
+        except Exception:  # noqa: BLE001 — prober not running; reachability stays unknown
+            health = {}
+        roster = registry.roster()
+        if not roster:
+            return "No delegates configured."
+        lines = []
+        for r in roster:
+            ok = (health.get(r["name"]) or {}).get("ok")
+            badge = "🟢" if ok is True else "🔴" if ok is False else "⚪"
+            typ = f" ({r['type']})" if r["type"] else ""
+            desc = f" — {r['description']}" if r["description"] else ""
+            lines.append(f"{badge} {r['name']}{typ}{desc}")
+        return "\n".join(lines)
+
+    return list_agents
+
+
 def _load_delegates_config() -> list:
     """Read the top-level ``delegates: [...]`` list from the live config doc.
 
@@ -107,4 +136,6 @@ def register(registry) -> None:
         )
         return
     registry.register_tool(_build_delegate_to(reg))
-    log.info("[delegates] registered delegate_to for %d delegate(s): %s", len(reg.names()), ", ".join(reg.names()))
+    registry.register_tool(_build_list_agents(reg))
+    log.info("[delegates] registered delegate_to + list_agents for %d delegate(s): %s",
+             len(reg.names()), ", ".join(reg.names()))

--- a/plugins/delegates/registry.py
+++ b/plugins/delegates/registry.py
@@ -56,6 +56,13 @@ class DelegateRegistry:
             f"`{d.name}` ({d.type}{' — ' + d.description if d.description else ''})" for d in self._items.values()
         )
 
+    def roster(self) -> list[dict]:
+        """Structured one-entry-per-delegate roster (for the ``list_agents`` tool)."""
+        return [
+            {"name": d.name, "type": d.type, "description": d.description, "url": d.url}
+            for d in self._items.values()
+        ]
+
     async def dispatch(self, name: str, query: str) -> str:
         d = self._items.get(name)
         if d is None:

--- a/tests/test_delegates_plugin.py
+++ b/tests/test_delegates_plugin.py
@@ -211,10 +211,31 @@ def test_register_no_delegates_registers_nothing(monkeypatch):
     assert r.tools == []
 
 
-def test_register_exposes_delegate_to_with_listing(monkeypatch):
+def test_register_exposes_delegate_to_and_list_agents(monkeypatch):
     r = _register([{"name": "opus", "type": "openai", "url": "https://g/v1", "model": "m"}], monkeypatch)
-    assert [t.name for t in r.tools] == ["delegate_to"]
+    assert [t.name for t in r.tools] == ["delegate_to", "list_agents"]
     assert "opus" in r.tools[0].description
+
+
+def test_registry_roster_shape():
+    reg = DelegateRegistry([{"name": "opus", "type": "openai", "url": "https://g/v1",
+                             "model": "m", "description": "a model"}])
+    assert reg.roster() == [{"name": "opus", "type": "openai", "description": "a model", "url": "https://g/v1"}]
+
+
+def test_list_agents_lists_roster_with_health(monkeypatch):
+    r = _register([{"name": "opus", "type": "openai", "url": "https://g/v1",
+                    "model": "m", "description": "a model"}], monkeypatch)
+    la = next(t for t in r.tools if t.name == "list_agents")
+    monkeypatch.setattr("plugins.delegates.health.health_snapshot", lambda: {"opus": {"ok": True}})
+    assert "🟢 opus (openai) — a model" in la.invoke({})
+
+
+def test_list_agents_unknown_health_is_neutral(monkeypatch):
+    r = _register([{"name": "opus", "type": "openai", "url": "https://g/v1", "model": "m"}], monkeypatch)
+    la = next(t for t in r.tools if t.name == "list_agents")
+    monkeypatch.setattr("plugins.delegates.health.health_snapshot", lambda: {})
+    assert "⚪ opus (openai)" in la.invoke({})
 
 
 async def test_delegate_to_unknown_and_empty(monkeypatch):


### PR DESCRIPTION
## What

Adds a **`list_agents`** tool to the always-on `delegates` plugin, registered alongside `delegate_to` (only when delegates are configured). It returns the agent's live roster — each delegate's name, type, description, and current reachability (🟢 reachable · 🔴 down · ⚪ unknown, from the health prober).

- `DelegateRegistry.roster()` — structured one-entry-per-delegate accessor.
- `list_agents` reads `roster()` + the in-package `health_snapshot()` — no cross-plugin imports.

## Why

`list_agents` is intrinsically about the delegate registry — the natural companion to `delegate_to`. It was briefly prototyped as a standalone plugin that reached into `plugins.delegates.store`/`health`; folding it into the delegates plugin removes that coupling and the extra plugin.

## Test

`tests/test_delegates_plugin.py`: registration now exposes `delegate_to` + `list_agents`; `roster()` shape; `list_agents` formatting with known and unknown health. Full file: 25 passed. `ruff` + `lint-imports` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “list agents” view for delegates, making it easier to see available agents in a readable roster.
  * Delegate listings now include availability indicators, helping users quickly spot which agents are reachable.
  * Registration now exposes both delegate actions when delegate support is enabled.

* **Bug Fixes**
  * Improved delegate listings so they fall back gracefully when availability information can’t be retrieved.
  * Delegate metadata is now shown more consistently in agent lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->