### PR TITLE
feat(plugins): let a plugin declare auth-exempt paths in its manifest

### DIFF
--- a/a2a_impl/auth.py
+++ b/a2a_impl/auth.py
@@ -61,13 +61,43 @@ _PUBLIC_PREFIXES = (
     "/_ds/",
 )
 
+# Plugin-declared auth-exempt prefixes. Set once at startup (and on reload) from
+# enabled plugins' manifest ``public_paths`` — each already validated to the
+# plugin's own ``/plugins/<id>/`` namespace by the manifest parser. This lets a
+# plugin serve an inbound webhook (no bearer — verified by its own HMAC) or a
+# public view page even when a bearer gates everything else. A plugin can ONLY
+# exempt its own routes; ``set_public_prefixes`` rejects anything else as
+# defence-in-depth.
+_PLUGIN_PUBLIC: list[str] = []
+
 # SSE token lifetime (seconds).
 _SSE_TOKEN_LIFETIME = 30
 
 
+def set_public_prefixes(prefixes) -> None:
+    """Replace the plugin-declared public-prefix set (idempotent + reload-safe).
+
+    Each prefix must live under a ``/plugins/<id>/`` namespace — a plugin can
+    exempt its own routes, never a core path. Non-conforming entries are dropped
+    with a warning."""
+    cleaned: list[str] = []
+    for p in prefixes or []:
+        s = str(p).strip()
+        if not s:
+            continue
+        if s.startswith("/plugins/") or s.startswith("/api/plugins/"):
+            cleaned.append(s)
+        else:
+            logger.warning("[a2a] ignoring plugin public prefix %r — must live under /plugins/<id>/", s)
+    _PLUGIN_PUBLIC[:] = cleaned
+    if cleaned:
+        logger.info("[a2a] %d plugin-declared auth-exempt path(s): %s", len(cleaned), ", ".join(cleaned))
+
+
 def _is_public(path: str) -> bool:
     """Return True when ``path`` is on the public allowlist (no auth needed)."""
-    return any(path.startswith(p) for p in _PUBLIC_PREFIXES)
+    return (any(path.startswith(p) for p in _PUBLIC_PREFIXES)
+            or any(path.startswith(p) for p in _PLUGIN_PUBLIC))
 
 
 def set_bearer_token(token: str | None) -> None:

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -35,6 +35,7 @@ class PluginLoadResult:
     embedders: dict = field(default_factory=dict)  # name -> embed_fn factory (ADR 0031)
     a2a_skills: list = field(default_factory=list)  # A2A card skill specs (#570)
     routers: list = field(default_factory=list)  # {plugin_id, router, prefix} (ADR 0018)
+    public_paths: list = field(default_factory=list)  # manifest-declared auth-exempt prefixes
     surfaces: list = field(default_factory=list)  # {plugin_id, name, start, stop}
     subagents: list = field(default_factory=list)  # SubagentConfig
     middleware: list = field(default_factory=list)  # factories: (config) -> AgentMiddleware|None (ADR 0032)
@@ -360,6 +361,10 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
         # the server can namespace + report them.
         for r in registry.routers:
             result.routers.append({"plugin_id": manifest.id, **r})
+        # Manifest-declared auth-exempt prefixes (already namespace-scoped by the
+        # parser) — the server hands these to the auth middleware so an inbound
+        # webhook / public view page works under a token gate.
+        result.public_paths.extend(manifest.public_paths)
         # Cross-check: every declared view must be served by one of this plugin's
         # routers, else the iframe renders blank/404. Catches "declared a view but
         # forgot register_router" / a path typo that fails silently today.

--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -66,6 +66,13 @@ class PluginManifest:
     # postMessage token handshake. See `_parse_views` (warns on non-same-origin)
     # and docs/guides/building-react-plugin-views.md.
     views: list[dict] = field(default_factory=list)
+    # Auth-exempt paths — prefixes under THIS plugin's own /plugins/<id>/ (or
+    # /api/plugins/<id>/) namespace that the default-deny auth middleware lets
+    # through WITHOUT a bearer. The escape hatch for an inbound webhook (no bearer
+    # — the plugin verifies its own signature) or a public view page that must load
+    # in a browser iframe under a token-gated deployment. Namespace-scoped by the
+    # parser so a plugin can never exempt a core route.
+    public_paths: list[str] = field(default_factory=list)
     # Event contract (ADR 0039) — the topics this plugin broadcasts / listens for.
     # Declarative for discoverability (surfaced in /api/runtime/status): a plugin
     # "ships" its events as its public API so others subscribe by topic without
@@ -123,6 +130,29 @@ def _parse_views(views, plugin_id: str) -> list[dict]:
     return kept
 
 
+def _parse_public_paths(paths, plugin_id: str) -> list[str]:
+    """Keep auth-exempt paths that live under THIS plugin's namespace
+    (``/plugins/<id>/…`` or ``/api/plugins/<id>/…``); drop + warn on anything else.
+
+    Namespace-scoping is the security boundary: a plugin can exempt only its own
+    routes from the auth gate, never a core path like ``/api/config``."""
+    if not isinstance(paths, (list, tuple)):
+        return []
+    roots = (f"/plugins/{plugin_id}", f"/api/plugins/{plugin_id}")
+    kept: list[str] = []
+    for p in paths:
+        s = str(p).strip()
+        if s.startswith(roots):
+            kept.append(s)
+        elif s:
+            log.warning(
+                "[plugins] %s: public_path %r is outside the plugin namespace "
+                "(/plugins/%s/… or /api/plugins/%s/…) — ignored",
+                plugin_id, s, plugin_id, plugin_id,
+            )
+    return kept
+
+
 def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     """Parse ``<plugin_dir>/protoagent.plugin.yaml`` → ``PluginManifest``.
 
@@ -156,6 +186,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     secrets = data.get("secrets")
     settings = data.get("settings")
     views = _parse_views(data.get("views"), pid)
+    public_paths = _parse_public_paths(data.get("public_paths"), pid)
     emits = data.get("emits")
     subscribes = data.get("subscribes")
     requires_pip = data.get("requires_pip")
@@ -177,6 +208,7 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
         test=bool(data.get("test", False)),
         guide_url=str(data.get("guide_url", "") or "").strip(),
         views=views,
+        public_paths=public_paths,
         emits=[str(x) for x in emits] if isinstance(emits, (list, tuple)) else [],
         subscribes=[str(x) for x in subscribes] if isinstance(subscribes, (list, tuple)) else [],
         requires_pip=[str(x) for x in requires_pip] if isinstance(requires_pip, (list, tuple)) else [],

--- a/runtime/state.py
+++ b/runtime/state.py
@@ -51,6 +51,7 @@ class AppState:
     plugin_chat_commands: dict = field(default_factory=dict)  # token -> handler; user-only /<name> control commands
     thread_id_resolver: object = None  # (request_metadata, session_id) -> str (#571)
     plugin_routers: list = field(default_factory=list)
+    plugin_public_paths: list = field(default_factory=list)  # manifest auth-exempt prefixes
     # The live FastAPI app + the (plugin_id, prefix) keys already mounted on it —
     # lets a config reload hot-mount a newly-enabled plugin's routes (no restart).
     fastapi_app: object = None

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -716,6 +716,10 @@ def _main():
     # that to ``None`` so configure() applies the documented A2A_AUTH_TOKEN env
     # fallback. (configure() treats an explicit "" as "bearer off, no fallback";
     # protoAgent has no separate apiKey-only flag, so unset ⇒ env, not off.)
+    # Plugin-declared auth-exempt prefixes (namespace-scoped in the manifest parser)
+    # — registered before the gate is installed so an inbound webhook / public view
+    # page passes under a token-gated deployment.
+    auth.set_public_prefixes(getattr(STATE, "plugin_public_paths", []) or [])
     auth.install(
         fastapi_app,
         bearer_token=((STATE.graph_config.auth_token if STATE.graph_config else "") or None),

--- a/server/agent_init.py
+++ b/server/agent_init.py
@@ -151,6 +151,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
                 _pre.surfaces,
                 _pre.meta,
             )
+            STATE.plugin_public_paths = _pre.public_paths
             _register_plugin_subagents(_pre.subagents)
             log.info(
                 "Setup wizard has not been completed — graph not compiled "
@@ -212,6 +213,7 @@ def _init_langgraph_agent(headless_setup: bool = False):
     # build below so the first compile (and every reload) can delegate to them.
     # (`global STATE.plugin_routers, STATE.plugin_surfaces` is declared at the top of the fn.)
     STATE.plugin_routers, STATE.plugin_surfaces = _plugins.routers, _plugins.surfaces
+    STATE.plugin_public_paths = _plugins.public_paths
     _register_plugin_subagents(_plugins.subagents)
     _apply_config_subagents(STATE.graph_config)  # YAML subagent overrides (tools/max_turns/model)
     STATE.plugin_middleware = _resolve_plugin_middleware(STATE.graph_config, _plugins.middleware)  # ADR 0032

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -169,6 +169,25 @@ def test_ac4_agent_card_public(monkeypatch):
     assert _client_multi().get("/.well-known/agent-card.json").status_code == 200
 
 
+# A plugin-declared public prefix is exempted; a core path can never be, and the
+# set replaces cleanly (reload-safe).
+def test_plugin_public_prefix_exempts_only_namespaced(monkeypatch):
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    auth.configure(bearer_token="secret", api_key="", allowed_origins_raw="")
+    try:
+        auth.set_public_prefixes(["/plugins/example/status"])
+        c = _client_multi()
+        assert c.get("/plugins/example/status").status_code == 200   # now exempt (e.g. a webhook)
+        assert c.post("/plugins/example/status").status_code == 200
+        assert c.get("/api/config").status_code == 401               # core path untouched
+        # A plugin cannot exempt a core path — set_public_prefixes drops it.
+        auth.set_public_prefixes(["/api/config"])
+        assert _client_multi().get("/api/config").status_code == 401
+    finally:
+        auth.set_public_prefixes([])  # reset module state for other tests
+        assert _client_multi().get("/plugins/example/status").status_code == 401
+
+
 # AC5: /app is public (SPA served without auth)
 def test_ac5_app_public(monkeypatch):
     monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -57,6 +57,23 @@ def test_manifest_parse(tmp_path) -> None:
     assert load_manifest(tmp_path / "bad") is None  # missing id
 
 
+def test_public_paths_namespace_scoped(tmp_path) -> None:
+    # A plugin may declare auth-exempt paths only under its OWN namespace; anything
+    # else (a core path, another plugin's path) is dropped by the parser.
+    _make_plugin(
+        tmp_path, "wh", enabled=True,
+        manifest_extra=(
+            "public_paths:\n"
+            "  - /plugins/wh/webhook\n"
+            "  - /api/plugins/wh/data\n"
+            "  - /api/config\n"
+            "  - /plugins/other/x\n"
+        ),
+    )
+    m = load_manifest(tmp_path / "wh")
+    assert m.public_paths == ["/plugins/wh/webhook", "/api/plugins/wh/data"]
+
+
 def test_discover_live_overrides_bundle(tmp_path, monkeypatch) -> None:
     bundle = tmp_path / "bundle"
     live = tmp_path / "live"


### PR DESCRIPTION
## Problem

Under a configured bearer, the default-deny auth middleware (`a2a_impl/auth.py`) gates **every** path — including `/plugins/<id>/*`. That blocks two legitimate plugin needs:

- an **inbound webhook** — the caller is a third party (Linear, GitHub, …) that sends no bearer; it signs the request body instead;
- a **public view page** — a browser iframe page-load can't carry an `Authorization` header.

There was no way to open a scoped hole, so e.g. the Linear plugin's webhook 401s before its handler ever runs.

## Change

A plugin declares the paths it needs unauthenticated in its manifest:

```yaml
# protoagent.plugin.yaml
public_paths:
  - /plugins/linear/webhook
```

- **Manifest** (`graph/plugins/manifest.py`): new `public_paths` field + `_parse_public_paths`, which keeps only paths under the plugin's **own** namespace (`/plugins/<id>/…` or `/api/plugins/<id>/…`) and drops/warns on anything else — a plugin can never exempt a core route.
- **Loader** (`graph/plugins/loader.py`): collects declared paths from enabled plugins into `PluginLoadResult.public_paths`.
- **Server** (`server/__init__.py`, `server/agent_init.py`, `runtime/state.py`): the collected set is handed to the middleware via `auth.set_public_prefixes(...)` right before `auth.install`. Replace-semantics → reload-safe.
- **Auth** (`a2a_impl/auth.py`): `set_public_prefixes` (re-validates `/plugins/` scope as defence-in-depth) + `_is_public` honours the plugin set alongside the static allowlist.

## Security

Namespace-scoped at **parse** time and re-checked in `set_public_prefixes` (drops anything not under `/plugins/`). The exemption only gets a request past the bearer gate — a webhook still verifies its own signature.

## Test

- `tests/test_plugins.py::test_public_paths_namespace_scoped` — parser keeps own-namespace paths, drops a core path and another plugin's path.
- `tests/test_a2a_auth.py::test_plugin_public_prefix_exempts_only_namespaced` — a declared `/plugins/example/*` path returns 200 under a bearer; `/api/config` stays 401; declaring `/api/config` is dropped; the set resets cleanly.
- 91 passed across both files; `ruff` + `lint-imports` clean.

Unblocks the Linear plugin's optional webhook fast-path (it opts in with `public_paths: [/plugins/linear/webhook]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)