### PR TITLE
feat(subagents): allow_skill_emission flag to opt a subagent out of distillation

### DIFF
--- a/graph/subagents/config.py
+++ b/graph/subagents/config.py
@@ -39,6 +39,14 @@ class SubagentConfig:
     # the main model. Pin a subagent that needs heavy reasoning to the main
     # model even when aux_model routes the others to a cheaper alias.
     model: str = ""
+    # Whether this subagent's runs are eligible to become a reusable skill-v1
+    # artifact via the skill-emission path. When False, emission is suppressed for
+    # this subagent even if the caller requests it — set it on subagents whose
+    # output is context-specific, sensitive, or non-deterministic (per-invocation
+    # conformance/verdict reviewers, agents over private data) so one-off runs
+    # don't pollute the distilled-skills index. Default True preserves the
+    # current behavior; honored wherever a runtime wires per-task skill emission.
+    allow_skill_emission: bool = True
 
 
 RESEARCHER_CONFIG = SubagentConfig(

--- a/tests/test_subagent_model_config.py
+++ b/tests/test_subagent_model_config.py
@@ -94,22 +94,28 @@ def test_allow_skill_emission_defaults_true_and_is_settable():
     assert opted_out.allow_skill_emission is False
 
 
-def test_config_overlay_preserves_allow_skill_emission():
-    """A YAML model/tools override must not clobber allow_skill_emission — _apply_config_subagents
-    rebuilds from the base entry, which carries the flag (replace() leaves it untouched)."""
+def test_config_overlay_preserves_allow_skill_emission(monkeypatch):
+    """A YAML model/tools override must not RESET allow_skill_emission to the dataclass
+    default — _apply_config_subagents rebuilds via replace(base, ...). Seed the base with
+    the flag OFF (the non-default) so this fails if a refactor reconstructs the config
+    without carrying it through, not just when it happens to match the default."""
+    import graph.subagents.config as sub_config
+
     original = SUBAGENT_REGISTRY.get("researcher")
+    # _apply_config_subagents reads the module-level RESEARCHER_CONFIG as its base.
+    monkeypatch.setattr(sub_config, "RESEARCHER_CONFIG", dataclasses.replace(RESEARCHER_CONFIG, allow_skill_emission=False))
     try:
-        RESEARCHER_CONFIG_BASE = dataclasses.replace(RESEARCHER_CONFIG)
-        SUBAGENT_REGISTRY["researcher"] = dataclasses.replace(RESEARCHER_CONFIG_BASE)
         cfg = LangGraphConfig()
         cfg.researcher = dataclasses.replace(cfg.researcher, model="protolabs/reasoning")
         _apply_config_subagents(cfg)
         entry = SUBAGENT_REGISTRY["researcher"]
-        assert entry.model == "protolabs/reasoning"
-        assert entry.allow_skill_emission is RESEARCHER_CONFIG.allow_skill_emission
+        assert entry.model == "protolabs/reasoning"  # overlay applied
+        assert entry.allow_skill_emission is False  # base flag preserved, NOT reset to default True
     finally:
         if original is not None:
             SUBAGENT_REGISTRY["researcher"] = original
+        else:
+            SUBAGENT_REGISTRY.pop("researcher", None)  # don't leave a temp entry behind
 
 
 def test_disabled_removes_subagent():

--- a/tests/test_subagent_model_config.py
+++ b/tests/test_subagent_model_config.py
@@ -84,6 +84,34 @@ def test_tools_and_max_turns_override_applies(tmp_path):
             SUBAGENT_REGISTRY["researcher"] = original
 
 
+def test_allow_skill_emission_defaults_true_and_is_settable():
+    """The opt-out field (#1347) defaults True so stock subagents stay distillable,
+    and is settable so a plugin/fork can mark a subagent's runs non-emittable."""
+    from graph.subagents.config import SubagentConfig
+
+    assert RESEARCHER_CONFIG.allow_skill_emission is True
+    opted_out = SubagentConfig(name="verdict", description="d", system_prompt="p", allow_skill_emission=False)
+    assert opted_out.allow_skill_emission is False
+
+
+def test_config_overlay_preserves_allow_skill_emission():
+    """A YAML model/tools override must not clobber allow_skill_emission — _apply_config_subagents
+    rebuilds from the base entry, which carries the flag (replace() leaves it untouched)."""
+    original = SUBAGENT_REGISTRY.get("researcher")
+    try:
+        RESEARCHER_CONFIG_BASE = dataclasses.replace(RESEARCHER_CONFIG)
+        SUBAGENT_REGISTRY["researcher"] = dataclasses.replace(RESEARCHER_CONFIG_BASE)
+        cfg = LangGraphConfig()
+        cfg.researcher = dataclasses.replace(cfg.researcher, model="protolabs/reasoning")
+        _apply_config_subagents(cfg)
+        entry = SUBAGENT_REGISTRY["researcher"]
+        assert entry.model == "protolabs/reasoning"
+        assert entry.allow_skill_emission is RESEARCHER_CONFIG.allow_skill_emission
+    finally:
+        if original is not None:
+            SUBAGENT_REGISTRY["researcher"] = original
+
+
 def test_disabled_removes_subagent():
     import dataclasses
 


### PR DESCRIPTION
## What

Adds a per-subagent `allow_skill_emission: bool = True` field to `SubagentConfig` (`graph/subagents/config.py`), implementing the request in #1347.

When `False`, a runtime suppresses skill-v1 artifact emission for that subagent's runs even if the caller requests it. Use it for subagents whose output is **context-specific, sensitive, or non-deterministic** — per-invocation conformance/verdict reviewers, agents over private data, non-deterministic workflows — so their one-off runs don't pollute the distilled-skills index with "skills" that don't generalize.

## Why upstream

This is a template repo, so shared-runtime/extension surface lands here. Plugins instantiate `SubagentConfig(...)` directly, so without the field a plugin that sets `allow_skill_emission=False` (e.g. the `content-plugin` port of `protoLabsAI/jon`'s verdict subagents — `content_review`, `idea_refine`, `cut_review`) fails to construct. Landing it upstream lets forks/plugins stay pure.

## Shape

- **Purely additive** — default `True` preserves current behavior.
- The config overlay (`_apply_config_subagents`) rebuilds entries via `replace(base, ...)`, overriding only `tools`/`max_turns`/`model`, so a YAML override never clobbers the flag.

## Notes / scope

The flag is read **wherever a runtime wires per-task skill emission**. Stock protoAgent's skill capture today is the LLM-driven `distill` subagent calling `save_skill` over `recent_activity` — there is no programmatic per-task emission gate in stock, so in the stock distill flow the field is forward-compat surface honored by forks/plugins that wire a per-task emit path (matching the issue's "purely additive" framing). Wiring a stock enforcement point can be a follow-up if/when stock grows a per-task emit path.

## Test

`tests/test_subagent_model_config.py`:
- defaults `True` on stock subagents and is settable to `False`
- a YAML model/tools overlay preserves the flag (not clobbered by `_apply_config_subagents`)

```
$ python -m pytest tests/test_subagent_model_config.py -q
8 passed
$ ruff check graph/subagents/config.py tests/test_subagent_model_config.py
All checks passed!
```

Closes #1347

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new setting for subagents that lets them be marked as eligible or ineligible for reusable skill creation.
  * This setting defaults to enabled, so existing behavior stays unchanged unless explicitly adjusted.

* **Bug Fixes**
  * Preserved the existing eligibility setting when updating subagent model configuration, preventing it from being overwritten unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->