### PR TITLE
feat(fleet): auto-enable a bundle's plugins when creating an agent from an archetype

### DIFF
--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -466,6 +466,11 @@ def _install_bundle(
             "requested_ref": ref or "",
             "resolved_sha": bundle_sha,
             "plugins": [s["id"] for s in installed],
+            # The bundle's curated turn-on list (a subset of `plugins`). Cached here so a
+            # consumer that only sees the lock — e.g. the fleet new-agent path, which
+            # installs via a CLI subprocess and never sees the live install summary — can
+            # auto-enable exactly what the bundle author intended. Empty = enable all members.
+            "enabled": list(bundle.get("enabled") or []),
             # Archetype metadata (ADR 0042) cached here so the new-agent picker can offer
             # this bundle as a starter type without re-reading its manifest.
             "archetype": bundle.get("archetype") or {},

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -280,10 +280,53 @@ def create(
     try:
         if bundle:
             installed = _install_bundle_into(ws, bundle)
+            # Auto-enable the bundle's plugins so a new agent boots WITH its tools live —
+            # matching the console install path (which auto-enables on install, ADR 0027).
+            # The CLI installer deliberately doesn't enable, so without this the agent
+            # comes up with the bundle installed-but-off and the operator has to flip each
+            # one on in Settings ▸ Plugins (#1346).
+            _enable_installed_in_config(cfg, ws / "plugins.lock")
     except Exception:
         shutil.rmtree(ws, ignore_errors=True)
         raise
     return {**rec, "path": str(ws), "installed": installed}
+
+
+def _enable_installed_in_config(cfg: Path, lock: Path) -> list[str]:
+    """Add a freshly-installed bundle's plugins to ``plugins.enabled`` in the workspace
+    config, so the agent starts with them on. Honors each bundle's curated ``enabled``
+    subset (cached in the lock by ``_install_bundle``), falling back to every installed
+    member; for a bare single-plugin install with no bundle entry, enables that plugin.
+    Unions with whatever the template already enabled (``delegates``); returns the ids
+    newly added. Best-effort — a malformed lock/config leaves enablement untouched."""
+    import json
+
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+
+    try:
+        data = json.loads(lock.read_text()) if lock.exists() else {}
+    except (json.JSONDecodeError, OSError):
+        return []
+    bundles = data.get("bundles") or []
+    want: list[str] = []
+    if bundles:
+        for b in bundles:
+            want += [str(x) for x in (b.get("enabled") or b.get("plugins") or [])]
+    else:  # a bare plugin install (no bundle record) — enable what landed
+        want += [str(p["id"]) for p in (data.get("plugins") or []) if p.get("id")]
+    if not want:
+        return []
+
+    doc = load_yaml_doc(cfg)
+    if not isinstance(doc, dict):
+        return []
+    plugins = doc.setdefault("plugins", {})
+    enabled = list(plugins.get("enabled") or [])
+    added = [p for p in want if p not in enabled]
+    if added:
+        plugins["enabled"] = enabled + added
+        save_yaml_doc(doc, cfg)
+    return added
 
 
 def _overlay_model(cfg: Path, ws: Path, src: str) -> None:

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -267,6 +267,9 @@ def test_install_bundle_fans_out_and_records_provenance(env):
     bundles = lock.get("bundles") or []
     assert bundles and bundles[0]["id"] == "demo_stack"
     assert set(bundles[0]["plugins"]) == {"demo_a", "demo_b"}
+    # the curated turn-on list is persisted in the lock (#1346) so a lock-only consumer
+    # (the fleet new-agent path) can auto-enable exactly what the author intended.
+    assert bundles[0]["enabled"] == ["delegates", "demo_a", "demo_b"]
 
 
 def test_install_bundle_member_missing_url_errors(env):

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -115,3 +115,71 @@ def test_fleet_state_follows_scoped_root(root, monkeypatch):
     monkeypatch.setenv("PROTOAGENT_INSTANCE", "roxy")
     assert supervisor._state_path() == manager.workspaces_root() / "fleet.json"
     assert "roxy" in supervisor._state_path().parts
+
+
+# ── bundle auto-enable on create (#1346) ──────────────────────────────────────
+def _seed_config(ws, enabled=("delegates",)):
+    """Write a minimal workspace config with the given plugins.enabled list."""
+    ws.mkdir(parents=True, exist_ok=True)
+    cfg = ws / "langgraph-config.yaml"
+    cfg.write_text(f"plugins:\n  enabled: [{', '.join(enabled)}]\n")
+    return cfg
+
+
+def test_enable_installed_honors_bundle_curated_subset(root):
+    """A bundle's curated `enabled` subset is what gets turned on — not every member —
+    and `delegates` from the template is preserved."""
+    import json
+
+    ws = root / "agent"
+    cfg = _seed_config(ws)
+    (ws / "plugins.lock").write_text(
+        json.dumps(
+            {
+                "plugins": [{"id": "a"}, {"id": "b"}, {"id": "extra"}],
+                "bundles": [{"id": "stack", "plugins": ["a", "b", "extra"], "enabled": ["a", "b"]}],
+            }
+        )
+    )
+    added = manager._enable_installed_in_config(cfg, ws / "plugins.lock")
+    assert added == ["a", "b"]
+    enabled = yaml.safe_load(cfg.read_text())["plugins"]["enabled"]
+    assert enabled == ["delegates", "a", "b"]  # delegates kept, curated subset added, `extra` left off
+
+
+def test_enable_installed_falls_back_to_all_members(root):
+    """A bundle with no curated `enabled` list enables every installed member."""
+    import json
+
+    ws = root / "agent"
+    cfg = _seed_config(ws)
+    (ws / "plugins.lock").write_text(
+        json.dumps({"plugins": [{"id": "a"}, {"id": "b"}], "bundles": [{"id": "stack", "plugins": ["a", "b"]}]})
+    )
+    added = manager._enable_installed_in_config(cfg, ws / "plugins.lock")
+    assert added == ["a", "b"]
+    assert yaml.safe_load(cfg.read_text())["plugins"]["enabled"] == ["delegates", "a", "b"]
+
+
+def test_enable_installed_bare_plugin_no_bundle(root):
+    """A single-plugin install (no bundle record) enables that plugin."""
+    import json
+
+    ws = root / "agent"
+    cfg = _seed_config(ws)
+    (ws / "plugins.lock").write_text(json.dumps({"plugins": [{"id": "solo"}]}))
+    added = manager._enable_installed_in_config(cfg, ws / "plugins.lock")
+    assert added == ["solo"]
+    assert yaml.safe_load(cfg.read_text())["plugins"]["enabled"] == ["delegates", "solo"]
+
+
+def test_enable_installed_idempotent_and_missing_lock(root):
+    """Already-enabled ids aren't duplicated; a missing lock is a no-op."""
+    import json
+
+    ws = root / "agent"
+    cfg = _seed_config(ws, enabled=("delegates", "a"))
+    assert manager._enable_installed_in_config(cfg, ws / "nope.lock") == []  # no lock → no change
+    (ws / "plugins.lock").write_text(json.dumps({"bundles": [{"id": "s", "enabled": ["a"]}]}))
+    assert manager._enable_installed_in_config(cfg, ws / "plugins.lock") == []  # already on
+    assert yaml.safe_load(cfg.read_text())["plugins"]["enabled"] == ["delegates", "a"]


### PR DESCRIPTION
## Problem (#1346)

Creating a new agent from a **bundle archetype** in the fleet new-agent picker (e.g. **Project Manager** → `pm-stack`) installed the bundle's plugins but left them **disabled**. The agent booted with its tools installed-but-off, so the operator had to go into **Settings ▸ Plugins** and flip each one on by hand.

## Root cause

Two paths install bundles, and they diverged:

- The **console install route** (`operator_api/plugin_routes.py`) auto-enables on install (ADR 0027, trust-by-default) — it adds the bundle's plugins to `plugins.enabled` and hot-reloads.
- The **fleet create path** (`graph/workspaces/manager.py::create`) installs the bundle via a `python -m server plugin install` **CLI subprocess**, which *deliberately* doesn't enable (it just prints "NOT enabled — add these to plugins.enabled"). `create()` never wrote `plugins.enabled`, so the new workspace kept only the template default `enabled: [delegates]`.

The bundle's curated `enabled:` turn-on list was also only ever available in the **live HTTP install summary** — `_install_bundle` dropped it from the persisted lock record, so a lock-only consumer (the fleet path) couldn't recover the author's intended subset.

## Fix

1. **`graph/plugins/installer.py`** — persist the bundle's curated `enabled` subset into the lock bundle record (additive, alongside the already-cached `archetype`).
2. **`graph/workspaces/manager.py`** — after a bundle install, `create()` adds the bundle's plugins to `plugins.enabled` in the new workspace config via `_enable_installed_in_config()`:
   - honors the bundle's curated `enabled` subset (so an author can ship a member that stays off),
   - falls back to **every installed member** when no subset is declared,
   - enables the lone plugin for a bare single-plugin install (no bundle record),
   - **unions** with the template's `delegates` (never drops it), is **idempotent**, and a malformed/missing lock is a safe no-op.

The new agent now boots with its bundle live — no manual enable step.

> Note: the console first-run **Setup Wizard** path already auto-enables (it uses the HTTP route), so it was unaffected. This fix brings the **fleet** create path to parity.
>
> Out of scope (noted for a follow-up): the bundle's recommended `config:` defaults still aren't applied on either path — only `enabled` is. That's a separate parity gap from this enablement fix.

## Tests

- `tests/test_plugin_installer.py` — bundle install now persists the curated `enabled` subset in the lock.
- `tests/test_workspaces.py` — `_enable_installed_in_config` honors a curated subset, falls back to all members, handles a bare plugin, is idempotent, and no-ops on a missing lock.

```
$ python -m pytest tests/test_workspaces.py tests/test_plugin_installer.py tests/test_fleet_routes.py tests/test_plugin_routes.py -q
97 passed
$ ruff check graph/plugins/installer.py graph/workspaces/manager.py tests/test_workspaces.py tests/test_plugin_installer.py
All checks passed!
```

Closes #1346

🤖 Generated with [Claude Code](https://claude.com/claude-code)