### PR TITLE
feat(plugins): apply a bundle's recommended config defaults on install

### DIFF
--- a/graph/plugins/installer.py
+++ b/graph/plugins/installer.py
@@ -435,6 +435,26 @@ def load_bundle(repo: Path) -> dict | None:
     return doc
 
 
+def bundle_config_overlay(bundle_config: dict | None, current: dict | None) -> dict:
+    """Reduce a bundle's recommended ``config:`` ({section: {key: val}}) to a DEFAULTS
+    overlay: only the keys the operator hasn't already set in ``current`` (the live
+    config sections). Per-section, per-leaf — an operator value always wins and a
+    present key is left untouched, so applying this never clobbers existing settings.
+    Empty sections are dropped. Shared by the console install route and the fleet
+    create path so both apply bundle defaults identically (#1350)."""
+    overlay: dict = {}
+    cur = current if isinstance(current, dict) else {}
+    for section, values in (bundle_config or {}).items():
+        if not isinstance(values, dict):
+            continue
+        existing = cur.get(section)
+        existing = existing if isinstance(existing, dict) else {}
+        fill = {k: v for k, v in values.items() if k not in existing}
+        if fill:
+            overlay[str(section)] = fill
+    return overlay
+
+
 def _install_bundle(
     bundle: dict, bundle_url: str, bundle_sha: str, ref: str | None, *, force: bool, by: str, allow: list[str] | None
 ) -> dict:
@@ -471,6 +491,10 @@ def _install_bundle(
             # installs via a CLI subprocess and never sees the live install summary — can
             # auto-enable exactly what the bundle author intended. Empty = enable all members.
             "enabled": list(bundle.get("enabled") or []),
+            # The bundle's recommended per-plugin config defaults ({section: {key: val}}).
+            # Cached for the same lock-only consumer; applied as DEFAULTS (operator values
+            # win, present keys are never clobbered — see `bundle_config_overlay`).
+            "config": dict(bundle.get("config") or {}),
             # Archetype metadata (ADR 0042) cached here so the new-agent picker can offer
             # this bundle as a starter type without re-reading its manifest.
             "archetype": bundle.get("archetype") or {},

--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -284,8 +284,10 @@ def create(
             # matching the console install path (which auto-enables on install, ADR 0027).
             # The CLI installer deliberately doesn't enable, so without this the agent
             # comes up with the bundle installed-but-off and the operator has to flip each
-            # one on in Settings ▸ Plugins (#1346).
+            # one on in Settings ▸ Plugins (#1346). Then seed the bundle's recommended
+            # per-plugin config defaults (#1350) — a fresh workspace, so nothing to clobber.
             _enable_installed_in_config(cfg, ws / "plugins.lock")
+            _apply_bundle_config_defaults(cfg, ws / "plugins.lock")
     except Exception:
         shutil.rmtree(ws, ignore_errors=True)
         raise
@@ -327,6 +329,43 @@ def _enable_installed_in_config(cfg: Path, lock: Path) -> list[str]:
         plugins["enabled"] = enabled + added
         save_yaml_doc(doc, cfg)
     return added
+
+
+def _apply_bundle_config_defaults(cfg: Path, lock: Path) -> dict:
+    """Seed a freshly-installed bundle's recommended per-plugin ``config:`` defaults
+    into the workspace config (#1350). Defaults only — `bundle_config_overlay` drops any
+    key already set in the config, so an operator value is never clobbered. Each plugin's
+    config is a top-level section keyed by its id (ADR 0019). Returns the applied overlay.
+    Best-effort — a malformed lock/config is a no-op."""
+    import json
+
+    from graph.config_io import load_yaml_doc, save_yaml_doc
+    from graph.plugins.installer import bundle_config_overlay
+
+    try:
+        data = json.loads(lock.read_text()) if lock.exists() else {}
+    except (json.JSONDecodeError, OSError):
+        return {}
+    merged: dict = {}
+    for b in data.get("bundles") or []:
+        merged.update(b.get("config") or {})
+    if not merged:
+        return {}
+
+    doc = load_yaml_doc(cfg)
+    if not isinstance(doc, dict):
+        return {}
+    overlay = bundle_config_overlay(merged, doc)
+    if not overlay:
+        return {}
+    for section, fill in overlay.items():
+        dest = doc.setdefault(section, {})
+        if not isinstance(dest, dict):
+            continue
+        for k, v in fill.items():
+            dest[k] = v
+    save_yaml_doc(doc, cfg)
+    return overlay
 
 
 def _overlay_model(cfg: Path, ws: Path, src: str) -> None:

--- a/operator_api/plugin_routes.py
+++ b/operator_api/plugin_routes.py
@@ -233,9 +233,22 @@ def register_plugin_routes(app) -> None:
                     enabled.append(pid)
             from server.agent_init import _apply_settings_changes
 
-            ok, messages = _apply_settings_changes(
-                config={"plugins": {"enabled": enabled, "disabled": disabled}},
-            )
+            config_updates: dict = {"plugins": {"enabled": enabled, "disabled": disabled}}
+            # Seed the bundle's recommended per-plugin config defaults (#1350) — same trust
+            # gate as auto-enable. Defaults only: reduce against the current YAML config so an
+            # operator value (or a key they've already set) is never clobbered.
+            bundle_config = summary.get("config") if "bundle" in summary else None
+            if bundle_config:
+                from graph.config_io import load_yaml_doc
+                from graph.plugins.installer import bundle_config_overlay
+
+                import graph.config_io as _cio
+
+                current = load_yaml_doc(_cio.CONFIG_YAML_PATH)
+                overlay = bundle_config_overlay(bundle_config, current if isinstance(current, dict) else {})
+                config_updates.update(overlay)
+
+            ok, messages = _apply_settings_changes(config=config_updates)
             if ok:
                 reloaded, enabled_now = True, ids
             else:

--- a/tests/test_plugin_installer.py
+++ b/tests/test_plugin_installer.py
@@ -270,6 +270,32 @@ def test_install_bundle_fans_out_and_records_provenance(env):
     # the curated turn-on list is persisted in the lock (#1346) so a lock-only consumer
     # (the fleet new-agent path) can auto-enable exactly what the author intended.
     assert bundles[0]["enabled"] == ["delegates", "demo_a", "demo_b"]
+    # ...and the recommended config defaults too (#1350), for the same consumer.
+    assert bundles[0]["config"] == {"demo_a": {"k": "v"}}
+
+
+def test_bundle_config_overlay_fills_only_unset_keys():
+    """Defaults overlay: a key the operator already set is left untouched; only the
+    unset keys are filled, and a fully-set section is dropped (#1350)."""
+    bundle_config = {
+        "agent_browser": {"panel_mode": "full", "timeout": 30},
+        "board": {"theme": "dark"},
+    }
+    current = {
+        "agent_browser": {"panel_mode": "compact"},  # operator already chose this — keep it
+        "board": {"theme": "light"},  # fully set → section dropped
+    }
+    overlay = installer.bundle_config_overlay(bundle_config, current)
+    assert overlay == {"agent_browser": {"timeout": 30}}  # only the unset key; operator value wins
+
+
+def test_bundle_config_overlay_empty_and_malformed():
+    assert installer.bundle_config_overlay(None, {}) == {}
+    assert installer.bundle_config_overlay({}, None) == {}
+    # a non-dict section value is skipped, not crashed on
+    assert installer.bundle_config_overlay({"x": "notadict"}, {}) == {}
+    # no current → every key is unset, so all fill
+    assert installer.bundle_config_overlay({"x": {"a": 1}}, {}) == {"x": {"a": 1}}
 
 
 def test_install_bundle_member_missing_url_errors(env):

--- a/tests/test_plugin_routes.py
+++ b/tests/test_plugin_routes.py
@@ -151,6 +151,33 @@ def test_install_bundle_without_declared_enable_enables_every_member(monkeypatch
     assert body["enabled"] == ["a", "b"]
 
 
+def test_install_bundle_seeds_config_defaults_without_clobbering(monkeypatch):
+    """A bundle's recommended config defaults ride the same enable write (#1350) —
+    filling only keys the operator hasn't already set in the live config."""
+    from graph.plugins import installer
+
+    captured = _wire(monkeypatch, enabled=[], disabled=[], meta=[])
+    monkeypatch.setattr(
+        installer,
+        "install",
+        lambda url, ref=None, **k: {
+            "bundle": "pm-stack",
+            "installed": [{"id": "browser"}],
+            "enabled": ["browser"],
+            "config": {"browser": {"panel_mode": "full", "timeout": 30}},
+        },
+    )
+    # Operator already set browser.panel_mode — the default must NOT overwrite it.
+    import graph.config_io as _cio
+
+    monkeypatch.setattr(_cio, "load_yaml_doc", lambda p=None: {"browser": {"panel_mode": "compact"}})
+    body = _client().post("/api/plugins/install", json={"url": "https://x/pm-stack"}).json()
+    assert body["enabled"] == ["browser"]
+    # only the unset key is seeded; the operator's panel_mode is left for apply_updates_to_yaml to keep
+    assert captured["config"]["browser"] == {"timeout": 30}
+    assert captured["config"]["plugins"]["enabled"] == ["browser"]
+
+
 def test_install_opt_out_stays_install_not_enable(monkeypatch):
     from graph.plugins import installer
 

--- a/tests/test_workspaces.py
+++ b/tests/test_workspaces.py
@@ -183,3 +183,44 @@ def test_enable_installed_idempotent_and_missing_lock(root):
     (ws / "plugins.lock").write_text(json.dumps({"bundles": [{"id": "s", "enabled": ["a"]}]}))
     assert manager._enable_installed_in_config(cfg, ws / "plugins.lock") == []  # already on
     assert yaml.safe_load(cfg.read_text())["plugins"]["enabled"] == ["delegates", "a"]
+
+
+# ── bundle config defaults on create (#1350) ──────────────────────────────────
+def test_apply_bundle_config_defaults_seeds_unset_keys(root):
+    """A bundle's recommended config defaults land in the workspace config, filling only
+    keys the operator hasn't set (a fresh workspace, so everything is unset)."""
+    import json
+
+    ws = root / "agent"
+    cfg = _seed_config(ws)
+    cfg.write_text(cfg.read_text() + "agent_browser:\n  panel_mode: compact\n")  # operator pre-set
+    (ws / "plugins.lock").write_text(
+        json.dumps(
+            {
+                "bundles": [
+                    {
+                        "id": "stack",
+                        "config": {"agent_browser": {"panel_mode": "full", "timeout": 30}, "board": {"theme": "dark"}},
+                    }
+                ]
+            }
+        )
+    )
+    overlay = manager._apply_bundle_config_defaults(cfg, ws / "plugins.lock")
+    assert overlay == {"agent_browser": {"timeout": 30}, "board": {"theme": "dark"}}
+    doc = yaml.safe_load(cfg.read_text())
+    assert doc["agent_browser"] == {"panel_mode": "compact", "timeout": 30}  # operator value kept, default added
+    assert doc["board"] == {"theme": "dark"}  # brand-new section seeded
+
+
+def test_apply_bundle_config_defaults_noop_without_config(root):
+    """A bundle with no `config:` block (or a missing lock) writes nothing."""
+    import json
+
+    ws = root / "agent"
+    cfg = _seed_config(ws)
+    before = cfg.read_text()
+    assert manager._apply_bundle_config_defaults(cfg, ws / "nope.lock") == {}
+    (ws / "plugins.lock").write_text(json.dumps({"bundles": [{"id": "stack", "plugins": ["a"]}]}))
+    assert manager._apply_bundle_config_defaults(cfg, ws / "plugins.lock") == {}
+    assert cfg.read_text() == before  # untouched


### PR DESCRIPTION
## Problem (#1350)

A bundle manifest declares two recommended-defaults blocks:

```yaml
enabled: [delegates, project_board, agent_browser]   # turn-on list
config:                                              # per-plugin defaults
  agent_browser:
    panel_mode: full
```

Both install paths honor **`enabled`** (#1346, now on main). But the **`config:`** block was surfaced in the install summary and then dropped — never written to the agent's config. So a bundle came up **enabled but unconfigured**, and the operator had to re-enter those defaults by hand in Settings. Follow-up split out of #1346.

## Fix — apply `config:` as DEFAULTS, never clobbering operator values

- **`installer.py`** — persist the bundle's `config` into the lock record (additive, beside `enabled`), so the lock-only fleet path can read it. Add shared **`bundle_config_overlay(bundle_config, current)`**: reduces a bundle's config to only the keys the operator hasn't already set (operator value wins, a present key is untouched, empty sections dropped).
- **`operator_api/plugin_routes.py`** (console route) — fold that overlay into the same `_apply_settings_changes` write that does the enable, under the same trust gate (skipped when the `install≠enable` opt-out is set). The per-leaf YAML merge keeps sibling operator keys.
- **`graph/workspaces/manager.py`** (fleet create) — after enabling, seed the lock's bundle `config` into the new workspace config via `_apply_bundle_config_defaults`.

Each plugin's config is a top-level section keyed by id (ADR 0019). **Precedence: operator config > bundle defaults > manifest defaults.**

## Tests

- `bundle_config_overlay`: fills only unset keys, drops fully-set sections, safe on empty/malformed input.
- lock persists `config` on bundle install.
- console route: defaults ride the enable write and don't overwrite a key the operator already set.
- fleet create: defaults seed the workspace config, keep a pre-set operator value, no-op without a `config:` block.

```
$ python -m pytest tests/test_plugin_routes.py tests/test_workspaces.py tests/test_plugin_installer.py tests/test_fleet_routes.py tests/test_plugins.py tests/test_plugin_lifecycle_smoke.py -q
131 passed
$ ruff check <changed files> → All checks passed!
```

Closes #1350

🤖 Generated with [Claude Code](https://claude.com/claude-code)