### PR TITLE
docs(fleet): note last-write-wins merge semantics in bundle config defaults

### DIFF
--- a/graph/workspaces/manager.py
+++ b/graph/workspaces/manager.py
@@ -346,6 +346,11 @@ def _apply_bundle_config_defaults(cfg: Path, lock: Path) -> dict:
         data = json.loads(lock.read_text()) if lock.exists() else {}
     except (json.JSONDecodeError, OSError):
         return {}
+    # Merge every bundle's `config` into one {section: {...}} map. Last-write-wins per
+    # section (`dict.update`): if two installed bundles ship defaults for the SAME plugin
+    # section, the later bundle's block replaces the earlier one's. That's acceptable —
+    # a fresh workspace installs a single archetype bundle, so collisions don't arise in
+    # the create() path; the order is lock order if they ever do.
     merged: dict = {}
     for b in data.get("bundles") or []:
         merged.update(b.get("config") or {})


### PR DESCRIPTION
Addresses Quinn's LOW review note on the merged PR #1351.

`_apply_bundle_config_defaults` merges every installed bundle's `config:` into one map via `dict.update()`, so if two bundles ship defaults for the **same plugin section**, the later one silently wins. This documents the expected behavior — a fresh workspace installs a single archetype bundle, so collisions don't arise in the `create()` path; lock order decides if they ever do.

Comment-only, no behavior change. `ruff` clean, `test_workspaces.py` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)