### PR TITLE
feat(web): compact plugin rows + Configure opens a per-plugin settings dialog

### DIFF
--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -89,10 +89,14 @@ test("plugins section: Installed / Discover (config + advanced install folded in
     .getByRole("button", { name: "Enable" }).click();
   await expect(page.locator(".plugin-hint")).toContainText("Zzz Disabled enabled");
 
-  // Config folded in (ADR 0059, bd-23a.3) — Demo Plugin's row exposes Configure → fields inline.
+  // Configure opens a per-plugin settings DIALOG now (2026-06) — not an inline row expander.
+  // The (icon-only) Configure button is labelled "Configure <name>"; the dialog is
+  // role="dialog" named by the plugin.
   const demoRow = page.locator(".plugin-row-wrap", { hasText: "Demo Plugin" });
   await demoRow.getByRole("button", { name: "Configure" }).click();
-  await expect(demoRow.locator('.plugin-row-config .setting-row[data-key="demo.greeting"]')).toBeVisible();
+  const configDialog = page.getByRole("dialog", { name: "Demo Plugin" });
+  await expect(configDialog.locator('.setting-row[data-key="demo.greeting"]')).toBeVisible();
+  await configDialog.locator(".pl-dialog__close").click(); // close so it doesn't overlay later steps
 
   // Install-from-URL is a dialog opened from the Installed toolbar (2026-06 consolidation).
   // The DS Dialog title is role="dialog" (not a heading); assert via the URL field, which

--- a/apps/web/src/plugins/PluginSettingsDialog.tsx
+++ b/apps/web/src/plugins/PluginSettingsDialog.tsx
@@ -1,0 +1,30 @@
+import { Dialog } from "@protolabsai/ui/overlays";
+import { Suspense } from "react";
+
+import { SettingsCategory } from "../settings/SettingsCategory";
+
+// Per-plugin settings dialog (ADR 0059, supersedes the inline row expander). Configure
+// on a plugin row opens this instead of growing the row — the form gets real breathing
+// room for large schemas, and the row stays a single compact line. Reuses the same
+// `SettingsCategory` (pluginId-scoped) the inline form used, so save / validate / restart
+// behavior is unchanged; only the container moved from an inline panel to a modal.
+export function PluginSettingsDialog({
+  pluginId,
+  pluginName,
+  open,
+  onClose,
+}: {
+  pluginId: string;
+  pluginName: string;
+  open: boolean;
+  onClose: () => void;
+}) {
+  if (!open) return null;
+  return (
+    <Dialog open onClose={onClose} title={pluginName} width="min(640px, 95vw)" className="plugin-settings-dialog">
+      <Suspense fallback={<p className="muted">Loading settings…</p>}>
+        <SettingsCategory category="Plugins" pluginId={pluginId} title="Configuration" />
+      </Suspense>
+    </Dialog>
+  );
+}

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -4,7 +4,7 @@ import { Button } from "@protolabsai/ui/primitives";
 import { Alert } from "@protolabsai/ui/data";
 import { useMutation, useQuery, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 
-import { Suspense, useState, type JSX } from "react";
+import { useState, type JSX } from "react";
 import { Download, DownloadCloud, ExternalLink, Github, Loader2, RefreshCw, Search, Settings2, Store, Trash2 } from "lucide-react";
 
 import { PanelHeader } from "@protolabsai/ui/navigation";
@@ -13,7 +13,7 @@ import { StagePanel } from "../app/ErrorBoundary";
 import { errMsg } from "../lib/format";
 import { StatusPill } from "../app/StatusPill";
 import { InstallPluginDialog } from "./InstallPluginDialog";
-import { SettingsCategory } from "../settings/SettingsCategory";
+import { PluginSettingsDialog } from "./PluginSettingsDialog";
 import { PluginFreshness } from "./PluginFreshness";
 import { catalogCategories, filterCatalog } from "./catalog";
 import { api } from "../lib/api";
@@ -59,7 +59,7 @@ function PluginRow({
   removing: boolean;
 }) {
   const on = p.enabled;
-  const [open, setOpen] = useState(false);
+  const [configOpen, setConfigOpen] = useState(false);
   return (
     <div className="plugin-row-wrap">
       <div className="subagent-row">
@@ -71,6 +71,8 @@ function PluginRow({
           </strong>
           <span>{contributionsLabel(p)}</span>
         </div>
+        {/* Compact action cluster: secondary actions (update / configure / uninstall) are
+            icon-only with tooltips; only the primary Enable/Disable toggle keeps its label. */}
         <div className="plugin-row-actions">
           <StatusPill
             label={p.loaded ? "loaded" : p.error ? "error" : p.enabled ? "enabled" : "disabled"}
@@ -79,29 +81,34 @@ function PluginRow({
           {update?.behind ? (
             <Button
               type="button"
+              icon
               variant="ghost"
               disabled={updating}
               onClick={() => onUpdate(p)}
               title={`Update ${p.name} to the latest commit`}
+              aria-label={`Update ${p.name}`}
             >
-              {updating ? <Loader2 size={14} className="spin" /> : <RefreshCw size={14} />} Update
+              {updating ? <Loader2 size={15} className="spin" /> : <RefreshCw size={15} />}
             </Button>
           ) : null}
-          {/* Config folded in (ADR 0059, bd-23a.3) — expand to edit this plugin's settings inline. */}
+          {/* Configure opens a per-plugin settings dialog (ADR 0059) rather than expanding
+              the row, so the row stays one line and the form gets room. */}
           {configurable ? (
             <Button
               type="button"
+              icon
               variant="ghost"
-              aria-expanded={open}
-              onClick={() => setOpen((o) => !o)}
+              onClick={() => setConfigOpen(true)}
               title={`Configure ${p.name}`}
+              aria-label={`Configure ${p.name}`}
             >
-              <Settings2 size={14} /> Configure
+              <Settings2 size={15} />
             </Button>
           ) : null}
           <Button
             type="button"
             variant="ghost"
+            size="sm"
             disabled={busy}
             onClick={() => onToggle(p)}
             title={on ? `Disable ${p.name}` : `Enable ${p.name}`}
@@ -114,23 +121,26 @@ function PluginRow({
           {removable ? (
             <Button
               type="button"
+              icon
               variant="ghost"
+              className="plugin-row-danger"
               disabled={removing}
               onClick={() => onRemove(p)}
               title={`Uninstall ${p.name}`}
               aria-label={`uninstall ${p.id}`}
             >
-              {removing ? <Loader2 size={14} className="spin" /> : <Trash2 size={14} />} Uninstall
+              {removing ? <Loader2 size={15} className="spin" /> : <Trash2 size={15} />}
             </Button>
           ) : null}
         </div>
       </div>
-      {configurable && open ? (
-        <div className="plugin-row-config">
-          <Suspense fallback={<p className="muted">Loading settings…</p>}>
-            <SettingsCategory category="Plugins" pluginId={p.id} title={`${p.name} settings`} />
-          </Suspense>
-        </div>
+      {configurable ? (
+        <PluginSettingsDialog
+          pluginId={p.id}
+          pluginName={p.name}
+          open={configOpen}
+          onClose={() => setConfigOpen(false)}
+        />
       ) : null}
     </div>
   );

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -74,8 +74,14 @@
 .plugin-card-repo { display: inline-flex; align-items: center; gap: 4px; font-size: 11px; color: var(--fg-muted); text-decoration: none; }
 .plugin-card-repo:hover { color: var(--fg-secondary); }
 
-/* Config folded into the Installed plugin rows (ADR 0059) — the Configure expander. */
+/* Installed plugin row. Configure now opens a per-plugin settings dialog (ADR 0059) —
+   the row is a single line; the icon action cluster shouldn't shrink under a long name. */
 .plugin-row-wrap { display: flex; flex-direction: column; }
-.plugin-row-config { margin: 0 0 10px; padding: 4px 12px 10px; border: 1px solid var(--border); border-radius: 9px; background: color-mix(in srgb, var(--bg-raised) 55%, transparent); }
+/* Keep the action cluster a tight HORIZONTAL row. `.subagent-row > div { display: grid }`
+   (theme.css) otherwise out-specifies the base `.plugin-row-actions { display: flex }` and
+   stacks the buttons into a column — the bulk this rework is removing. This selector
+   (two classes) wins that specificity battle. */
+.subagent-row > .plugin-row-actions { display: flex; align-items: center; gap: 6px; flex-shrink: 0; }
+.plugin-row-danger:hover:not(:disabled) { color: var(--danger); }
 .settings-flat-group { display: flex; flex-direction: column; }
 .plugin-install-advanced { margin-top: 14px; padding-top: 12px; border-top: 1px solid var(--border); }


### PR DESCRIPTION
## Why

The **Settings ▸ Plugins** list was spending too much space on each plugin:

- The per-row action cluster **stacked into a column** — a latent `.subagent-row > div { display: grid }` rule (theme.css) out-specified `.plugin-row-actions { display: flex }`, so `[status] / [configure] / [Disable]` rendered vertically, making every row ~3 lines tall.
- Every action was a full **text+icon button** (Update / Configure / Disable / Uninstall), eating horizontal width.
- **Configure expanded an inline config form** inside the row, shoving the rest of the list around while you edited.

## What changed

- **Compact action cluster** — now a tight horizontal row (a two-class selector `.subagent-row > .plugin-row-actions` wins the specificity fight that was stacking it). Secondary actions (**Update**, **Configure**, **Uninstall**) are **icon-only** with tooltips + `aria-label`s; only the primary **Enable/Disable** toggle keeps its text label (`size="sm"`). Uninstall icon turns red on hover.
- **Configure opens a dialog** — new `PluginSettingsDialog` (reuses the DS `Dialog`, same pattern as `InstallPluginDialog`) replaces the inline expander. It wraps the **same** `pluginId`-scoped `SettingsCategory`, so save / validate / restart behavior is unchanged — only the container moved from an inline panel to a modal. Large schemas get real room; each row stays one line.
- Drops the inline `.plugin-row-config` expander state + CSS.

## Before → after

Rows went from a 3-line, full-width-button layout to a single line: `Demo Plugin v1.0.0 · 1 tool · 1 skill … [loaded] ⚙ Disable`. Clicking ⚙ opens a centered **"Demo Plugin → Configuration"** dialog with the field + Save & apply / Discard.

## Tests

- `e2e/navigation.spec.ts` updated: asserts the per-plugin **dialog** (`role="dialog"` named by the plugin) instead of the old inline `.plugin-row-config`.
- `npm run test:unit` → **140 passed**; plugin/nav e2e (`navigation`, `plugin-install`, `plugin-views`) → **22 passed**; `tsc -p tsconfig.json --noEmit` clean.
- Verified visually (screenshots of the compact list + the Configure dialog).

🤖 Generated with [Claude Code](https://claude.com/claude-code)