### PR TITLE
feat(web): declutter plugin rows — drop redundant badges, fix title spacing

### DIFF
--- a/apps/web/src/plugins/PluginFreshness.tsx
+++ b/apps/web/src/plugins/PluginFreshness.tsx
@@ -3,26 +3,21 @@ import { Badge } from "@protolabsai/ui/primitives";
 import type { PluginUpdate } from "../lib/types";
 
 // Shared freshness indicator (ADR 0027) — joins an installed plugin to its
-// update status (GET /api/plugins/updates) and renders a single DS Badge next to
-// the v{version}. Used by BOTH the Settings → Integrations list (PluginsSection)
-// and the Plugins rail Local tab (PluginsSurface) so the copy/tone stay identical.
+// update status (GET /api/plugins/updates) and renders a DS Badge next to the
+// v{version} ONLY when there's something to say. Used by BOTH the Settings →
+// Integrations list (PluginsSection) and the Plugins Local tab (PluginsSurface).
 //
-//   not behind        → "up to date"  (success)
 //   behind            → "update available" (info)
-//   pinned (SHA ref)  → "pinned"       (neutral, muted — never auto-updates)
 //   check errored     → "check failed" (warning, error surfaced in the title)
+//   up to date        → nothing — the healthy default stays quiet (a badge on
+//                       every current plugin is just noise); the Update action
+//                       only appears when behind, so "up to date" needs no label
+//   pinned (SHA ref)  → nothing — it simply never offers an update
 //
 // `update` is undefined while the updates query is loading or unavailable (the
 // query degrades gracefully) — render nothing then, the row is still complete.
 export function PluginFreshness({ update }: { update?: PluginUpdate }) {
-  if (!update) return null;
-  if (update.pinned) {
-    return (
-      <Badge status="neutral">
-        <span title="Pinned to a commit SHA — won't auto-update">pinned</span>
-      </Badge>
-    );
-  }
+  if (!update || update.pinned) return null;
   if (update.error) {
     return (
       <Badge status="warning">
@@ -39,5 +34,5 @@ export function PluginFreshness({ update }: { update?: PluginUpdate }) {
       </Badge>
     );
   }
-  return <Badge status="success">up to date</Badge>;
+  return null; // up to date — no badge
 }

--- a/apps/web/src/plugins/PluginsSurface.tsx
+++ b/apps/web/src/plugins/PluginsSurface.tsx
@@ -64,20 +64,20 @@ function PluginRow({
     <div className="plugin-row-wrap">
       <div className="subagent-row">
         <div>
-          <strong>
-            {p.name}
-            {p.version ? <span className="muted"> v{p.version}</span> : null}
+          {/* Name · version · (only-when-actionable) freshness/error badge. The loaded
+              vs disabled state is already the section this row sits under, so it carries
+              no per-row status pill — only a genuine error gets a badge. */}
+          <div className="plugin-row-head">
+            <strong>{p.name}</strong>
+            {p.version ? <span className="plugin-ver">v{p.version}</span> : null}
             <PluginFreshness update={update} />
-          </strong>
+            {p.error ? <StatusPill label="error" tone="error" /> : null}
+          </div>
           <span>{contributionsLabel(p)}</span>
         </div>
         {/* Compact action cluster: secondary actions (update / configure / uninstall) are
             icon-only with tooltips; only the primary Enable/Disable toggle keeps its label. */}
         <div className="plugin-row-actions">
-          <StatusPill
-            label={p.loaded ? "loaded" : p.error ? "error" : p.enabled ? "enabled" : "disabled"}
-            tone={p.loaded ? "success" : p.error ? "error" : "muted"}
-          />
           {update?.behind ? (
             <Button
               type="button"

--- a/apps/web/src/settings/plugins.css
+++ b/apps/web/src/settings/plugins.css
@@ -77,6 +77,11 @@
 /* Installed plugin row. Configure now opens a per-plugin settings dialog (ADR 0059) —
    the row is a single line; the icon action cluster shouldn't shrink under a long name. */
 .plugin-row-wrap { display: flex; flex-direction: column; }
+/* Name · version · badge on one baseline-aligned line with real breathing room
+   (the old layout jammed the version + badge straight against the name). */
+.plugin-row-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; min-width: 0; }
+.plugin-row-head > strong { min-width: 0; }
+.plugin-row-head .plugin-ver { font-weight: 400; }
 /* Keep the action cluster a tight HORIZONTAL row. `.subagent-row > div { display: grid }`
    (theme.css) otherwise out-specifies the base `.plugin-row-actions { display: flex }` and
    stacks the buttons into a column — the bulk this rework is removing. This selector


### PR DESCRIPTION
Follow-up polish on the Settings ▸ Plugins list. Each row was carrying indicators that just restated context the layout already gives, and the title was cramped.

## Changes

- **Dropped the per-row status pill** (`loaded` / `enabled` / `disabled`). Rows already sit under **"Loaded · N"** / **"Disabled · N"** section headers, so the pill repeated the section *and* sat redundantly next to the Disable/Enable button. Only a genuine **load error** now gets a badge (the error detail still shows in the meta line).
- **`PluginFreshness` no longer shows an "up to date" (or "pinned") badge** — a badge on every healthy plugin is pure noise. It renders only when there's something to act on: **"update available"** or **"check failed"**. (The Update action itself already only appears when a plugin is behind.)
- **Title gets its own spaced line** — `name · vX.Y.Z · badge` via a flex row with real gaps; the version + badge were jammed straight against the name.

Net result: most rows are now just **`Name  vX.Y.Z  …  Disable`**.

## Before → after
A loaded plugin went from `Name vX.Y.Z [up to date] … [loaded] Disable` to `Name  vX.Y.Z  …  Disable`. Disabled-section rows lost their redundant `[disabled]` pill, leaving just `Enable`.

## Tests
`npm run test:unit` → **140 passed**; plugin/nav e2e (`navigation`, `plugin-install`, `plugin-views`) → **12 passed**; `tsc` clean. Verified visually.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Simplified plugin status display so only relevant alerts appear: warning for update errors, info when an update is available, and no badge for pinned or up-to-date plugins.
  * Improved plugin row layout for installed, marketplace, and local plugins, making names, versions, and status indicators align more cleanly and wrap better on smaller screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->