### PR TITLE
fix(web): plugin views pick up the theme on first paint (handshake race)

### DIFF
--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -660,6 +660,9 @@ const server = createServer(async (req, res) => {
       `window.addEventListener("message",function(e){var m=e.data||{};` +
       `if(m.type!=="protoagent:init")return;` +
       `document.body.setAttribute("data-bridge",m.token?"authed":"anon");});` +
+      // Like the real plugin-kit: announce readiness so the console (re-)sends the
+      // bearer + theme, closing the race where load-time init beats our listener.
+      `try{parent&&parent!==window&&parent.postMessage({type:"protoagent:ready"},"*");}catch(_){}` +
       `</script></body></html>`,
     );
     return;

--- a/apps/web/src/app/PluginView.tsx
+++ b/apps/web/src/app/PluginView.tsx
@@ -47,7 +47,20 @@ export function PluginView({ view }: { view: PluginViewType }) {
   // bare {"detail":"Not Found"} body as the "view".
   const [reachable, setReachable] = useState(false);
   const frameRef = useRef<HTMLIFrameElement | null>(null);
+  // Pending init re-post timers (see handleLoad) — cleared on unmount / src change.
+  const initTimers = useRef<number[]>([]);
   const pluginId = useMemo(() => pluginIdFromPath(view.path), [view.path]);
+
+  // Post the bearer + theme to the iframe. Idempotent on the kit side (applyTheme just
+  // re-sets CSS vars), so it's safe to call repeatedly — which the handshake relies on.
+  const postInit = (win: Window) => {
+    try {
+      const origin = new URL(apiUrl(src), window.location.href).origin;
+      win.postMessage({ type: "protoagent:init", token: authToken() || null, theme: consoleTheme() }, origin);
+    } catch {
+      /* cross-origin / detached — best effort */
+    }
+  };
 
   // Probe the view URL before mounting the iframe. A same-origin HTTP error (a 404 from an
   // unmounted /api/plugins/<id>/<view>, FastAPI's {"detail":"Not Found"}) fires the iframe's
@@ -127,7 +140,15 @@ export function PluginView({ view }: { view: PluginViewType }) {
       // Only trust messages from THIS iframe's window.
       if (!frameRef.current || e.source !== frameRef.current.contentWindow) return;
       const m = e.data || {};
-      if (m.type === "protoagent:subscribe" && Array.isArray(m.patterns)) {
+      if (m.type === "protoagent:ready") {
+        // The kit announced it's now listening. It registers its `message` handler
+        // asynchronously (dynamic import of the plugin-kit), so the load-time init post
+        // can race ahead of it and be dropped — leaving the view on the kit's default
+        // theme until a manual switch. Re-send the bearer + theme now that we know it's
+        // listening, so it themes immediately. (Older kits don't ping; handleLoad's
+        // retry covers those.)
+        if (frameRef.current?.contentWindow) postInit(frameRef.current.contentWindow);
+      } else if (m.type === "protoagent:subscribe" && Array.isArray(m.patterns)) {
         patterns = m.patterns.filter((p: unknown) => typeof p === "string");
       } else if (m.type === "protoagent:publish" && typeof m.topic === "string") {
         // Force the plugin's namespace — a page can only publish under its own id.
@@ -156,6 +177,9 @@ export function PluginView({ view }: { view: PluginViewType }) {
     return () => {
       window.removeEventListener("message", onWindowMessage);
       off();
+      // Drop any pending init re-posts — the iframe is being torn down / re-pointed.
+      initTimers.current.forEach(clearTimeout);
+      initTimers.current = [];
     };
   }, [src, pluginId]);
 
@@ -184,16 +208,19 @@ export function PluginView({ view }: { view: PluginViewType }) {
     setLoaded(true);
     const win = e.currentTarget.contentWindow;
     if (!win) return;
-    // Hand the page the bearer + theme AFTER load — same origin, targeted, not in
-    // the URL. The plugin page listens for `message` and uses them.
-    try {
-      const origin = new URL(apiUrl(src), window.location.href).origin;
-      win.postMessage(
-        { type: "protoagent:init", token: authToken() || null, theme: consoleTheme() },
-        origin,
-      );
-    } catch {
-      /* cross-origin / detached — best effort */
+    // Hand the page the bearer + theme AFTER load — same origin, targeted, not in the URL.
+    // The plugin page registers its `message` listener asynchronously (dynamic import of the
+    // plugin-kit), so this first post can land BEFORE the kit is listening and be dropped —
+    // the view then renders with the kit's default theme until a manual theme switch (the
+    // "toggle around for it to load" bug). So re-post on a short schedule; the retry lands
+    // once the kit is ready, and postInit is idempotent so the extra posts are harmless. A
+    // newer kit that pings `protoagent:ready` makes this exact (handled above); the retry is
+    // the fallback for kits that only listen.
+    initTimers.current.forEach(clearTimeout);
+    initTimers.current = [];
+    postInit(win);
+    for (const ms of [100, 300, 700, 1500]) {
+      initTimers.current.push(window.setTimeout(() => postInit(win), ms));
     }
   }
 


### PR DESCRIPTION
## Symptom

Plugin-kit-hosted views (`PluginView` iframes) frequently load with the **kit's default theme** instead of the host/agent theme — and only snap to the right theme after you toggle the theme around.

## Root cause — a postMessage handshake race

`PluginView` posts `protoagent:init` (bearer + curated theme) to the iframe on its **`load`** event (`handleLoad`). But the plugin page registers its `message` listener **asynchronously** — it dynamic-`import()`s the plugin-kit, then calls `initPluginView()`, which is what adds the `window.addEventListener("message", …)`. That resolves *after* the `load` event in many cases, so the init post arrives **before anyone is listening** and is silently dropped. The view then stays on the kit's defaults until a manual theme switch fires `protoagent:theme` (which the kit *does* catch, because by then it's listening) — hence "toggle around for it to load."

## Fix (console side — works with the currently shipped kit)

- **Retry the init post** on a short schedule after load (`[100, 300, 700, 1500]ms`). `postInit` is idempotent (the kit just re-sets CSS vars), so whichever re-post lands once the kit is listening themes it correctly. Timers are cleared on unmount / src change.
- **Handle a `protoagent:ready` ping** from the kit by re-sending init immediately — the exact, race-free handshake. The shipped kit (`@protolabsai/ui` 0.48) only listens, so the retry covers it; a kit that pings makes it instant.

## Upstream companion

The clean half — the kit announcing `protoagent:ready` on `initPluginView` — lives in `@protolabsai/ui` (separate repo). Tracked/PR'd there; this console change already fixes the bug on its own and auto-upgrades to the exact handshake once the kit ships the ping.

## Tests

The e2e mock plugin page now emits `protoagent:ready` like the real kit, exercising the new console branch; the existing "console hands the plugin view a bearer + theme via postMessage" test stays green. `plugin-views` e2e → **9 passed**; `tsc` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)