### PR TITLE
chore(web): bump @protolabsai/ui to 0.48.3 (plugin-kit ready handshake)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,7 +16,7 @@
   },
   "dependencies": {
     "@protolabsai/design": "^0.5.1",
-    "@protolabsai/ui": "^0.48.1",
+    "@protolabsai/ui": "^0.48.3",
     "@radix-ui/react-dropdown-menu": "^2.1.17",
     "@tanstack/react-query": "^5.100.14",
     "class-variance-authority": "^0.7.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@protolabsai/design": "^0.5.1",
-        "@protolabsai/ui": "^0.48.1",
+        "@protolabsai/ui": "^0.48.3",
         "@radix-ui/react-dropdown-menu": "^2.1.17",
         "@tanstack/react-query": "^5.100.14",
         "class-variance-authority": "^0.7.1",
@@ -1683,9 +1683,9 @@
       }
     },
     "node_modules/@protolabsai/ui": {
-      "version": "0.48.1",
-      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.48.1.tgz",
-      "integrity": "sha512-ZjnYzurmN/vny/L7peKUDI/fSvAwSnHt14Jf4wGp5rVLbpbiNEdIuHRnVj6q3wZk4KNh777tEeNdxtbXOKRy2Q==",
+      "version": "0.48.3",
+      "resolved": "https://registry.npmjs.org/@protolabsai/ui/-/ui-0.48.3.tgz",
+      "integrity": "sha512-6sJ8Tcm1Ko+AJMjJxVW0fWOBQs/+hsF8D5g6Sn2P3g13qJ64afYchofQw3dnv5U/Qq9PLj56COKbTZATQ9JmxA==",
       "license": "MIT",
       "dependencies": {
         "@dnd-kit/core": "^6.3.1",


### PR DESCRIPTION
Bumps `@protolabsai/ui` `^0.48.1` → `^0.48.3`.

0.48.3 ([protoContent #337](https://github.com/protoLabsAI/protoContent/pull/337), now published) adds the `protoagent:ready` ping from the plugin-kit's `initPluginView`. The console's `PluginView` already handles `protoagent:ready` (shipped in #1355), so plugin views now get the **exact, race-free theme handshake** — the post-load retry fallback becomes a no-op safety net rather than the mechanism.

- **Surgical lockfile edit** — `@protolabsai/ui`'s dependency tree is identical across 0.48.1→0.48.3 (code-only patch), so only the version/resolved/integrity + the dep spec changed. `npm ci` validates the lockfile clean (no churn).
- The bundled `public/_ds/plugin-kit.js` is a gitignored build artifact; CI regenerates it from this dep via the `prebuild` copy step.

Unit (140) + plugin-views e2e (incl. the theme-handshake test) green; build clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)