### PR TITLE
fix(coding_agent): find node/npx when the server runs as a service (nvm/fnm PATH)

### DIFF
--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -27,11 +27,14 @@ from __future__ import annotations
 
 import asyncio
 import contextlib
+import glob
 import json
 import logging
 import os
 import re
+import shutil
 import signal
+from functools import lru_cache
 from pathlib import Path
 from typing import Awaitable, Callable
 
@@ -124,18 +127,104 @@ _NESTED_CLAUDE_ENV_EXACT = frozenset({"CLAUDECODE"})
 _NESTED_CLAUDE_ENV_PREFIX = "CLAUDE_CODE_"
 
 
+# Node-based ACP backends (the `claude` agent launches via `npx`; codex-acp too) need
+# `node` on PATH. A protoAgent server started as a service — systemd, launchd, a bare
+# `nohup` — gets a MINIMAL PATH that never picked up the user's Node install: nvm / fnm /
+# volta / asdf / nodenv all prepend their bin dir from the *shell rc*, which a service
+# never sources. That's the #1 cause of "agent binary not found: 'npx'". So when `node`
+# isn't already resolvable on the launch PATH, we discover the version-manager bin dirs
+# and append them — making node tooling reachable regardless of how the server was started.
+_NODE_TOOL_BASENAMES = frozenset({"npx", "node", "npm", "pnpm", "yarn", "bun", "corepack"})
+
+
+def _version_sort_key(bin_dir: str) -> tuple[int, ...]:
+    """Sort key for a version-manager node `bin` dir, newest-first. The version is the
+    dir component holding the semver (``…/node/v22.22.0/bin`` → ``v22.22.0``; fnm's
+    ``…/<ver>/installation/bin`` → the grandparent). Non-versioned dirs sort last."""
+    p = Path(bin_dir)
+    for name in (p.parent.name, p.parent.parent.name):
+        nums = re.findall(r"\d+", name)
+        if nums:
+            return tuple(int(n) for n in nums[:3])
+    return (0,)
+
+
+@lru_cache(maxsize=1)
+def _discovered_node_dirs() -> tuple[str, ...]:
+    """Existing node `bin` dirs from the common version managers + standard locations,
+    most-preferred first (newest version), for augmenting a minimal launch PATH. Only
+    dirs that actually contain a ``node`` executable are returned. Cached — the
+    filesystem probe runs once per process. Best-effort: any error yields fewer dirs."""
+    home = Path.home()
+    cands: list[str] = []
+
+    def _versioned(root: str | os.PathLike, pattern: str) -> None:
+        try:
+            hits = glob.glob(os.path.join(str(root), pattern))
+        except OSError:
+            return
+        cands.extend(sorted(hits, key=_version_sort_key, reverse=True))
+
+    # nvm: ~/.nvm/versions/node/<ver>/bin   (NVM_DIR overrides the location)
+    _versioned(os.environ.get("NVM_DIR") or home / ".nvm", "versions/node/*/bin")
+    # fnm: <root>/node-versions/<ver>/installation/bin
+    for fnm_root in (os.environ.get("FNM_DIR"), home / ".local/share/fnm", home / ".fnm"):
+        if fnm_root:
+            _versioned(fnm_root, "node-versions/*/installation/bin")
+    # Single shim/bin dirs: volta, asdf, nodenv, homebrew, common system.
+    cands.append(str(Path(os.environ.get("VOLTA_HOME") or home / ".volta") / "bin"))
+    cands.append(str(Path(os.environ.get("ASDF_DATA_DIR") or home / ".asdf") / "shims"))
+    cands.append(str(home / ".nodenv" / "shims"))
+    cands.extend(["/opt/homebrew/bin", "/usr/local/bin"])
+
+    out: list[str] = []
+    seen: set[str] = set()
+    for d in cands:
+        if d in seen:
+            continue
+        seen.add(d)
+        if os.path.exists(os.path.join(d, "node")) or os.path.exists(os.path.join(d, "node.exe")):
+            out.append(d)
+    return tuple(out)
+
+
 def _launch_env(extra: dict[str, str] | None) -> dict[str, str]:
     """Build the subprocess environment for an ACP agent: the server's own ``os.environ``
     with the nested-Claude markers stripped (see above), then the delegate's ``env``
     overlaid last — so an operator who *deliberately* sets one of these in the delegate
-    env still wins."""
+    env still wins. Finally, if ``node`` isn't resolvable on the resulting PATH, append the
+    discovered node version-manager dirs so a service-launched server can still find npx."""
     env = {
         k: v
         for k, v in os.environ.items()
         if k not in _NESTED_CLAUDE_ENV_EXACT and not k.startswith(_NESTED_CLAUDE_ENV_PREFIX)
     }
     env.update(extra or {})
+
+    path = env.get("PATH") or os.defpath
+    if shutil.which("node", path=path) is None:
+        # APPEND (not prepend): an explicitly-configured PATH still wins for anything it
+        # already provides; we only add fallbacks for what it's missing.
+        present = path.split(os.pathsep)
+        extra_dirs = [d for d in _discovered_node_dirs() if d not in present]
+        if extra_dirs:
+            env["PATH"] = os.pathsep.join([path, *extra_dirs])
     return env
+
+
+def _missing_binary_message(command: str) -> str:
+    """The AcpError text for a launch that hit FileNotFoundError. For a node tool we add
+    the service-PATH hint, since a systemd/launchd server not seeing nvm/fnm node is by
+    far the most common cause."""
+    msg = f"agent binary not found: {command!r} (is it installed and on PATH?)"
+    if os.path.basename(command) in _NODE_TOOL_BASENAMES:
+        msg += (
+            " — if protoAgent runs as a service (systemd/launchd), its PATH likely doesn't "
+            "include your Node install: nvm/fnm/volta set PATH from your shell rc, which "
+            "services don't source. Add the node bin dir to the service PATH, or install "
+            "the agent's CLI on the system PATH."
+        )
+    return msg
 
 
 class AcpError(Exception):
@@ -259,7 +348,7 @@ class AcpClient:
                 limit=_STDOUT_LINE_LIMIT,
             )
         except FileNotFoundError as exc:
-            raise AcpError(f"agent binary not found: {self.command!r} (is it installed and on PATH?)") from exc
+            raise AcpError(_missing_binary_message(self.command)) from exc
 
         # The subprocess now exists. If the handshake raises OR the caller's wait_for
         # cancels us mid-initialize (the health prober's 45s probe timeout), reap the

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -18,7 +18,16 @@ import pytest
 
 import plugins.coding_agent as P
 from plugins.coding_agent import _make_permission
-from plugins.coding_agent.acp_client import AcpClient, AcpError, _short_tool_name, _split_tool_title
+from plugins.coding_agent import acp_client
+from plugins.coding_agent.acp_client import (
+    AcpClient,
+    AcpError,
+    _launch_env,
+    _missing_binary_message,
+    _short_tool_name,
+    _split_tool_title,
+    _version_sort_key,
+)
 
 
 def test_short_tool_name_peels_inline_args_and_mcp_source():
@@ -220,6 +229,70 @@ async def test_acp_client_missing_binary_raises_acp_error(tmp_path):
     client = AcpClient("definitely-not-a-real-binary-xyz", [], cwd=str(tmp_path))
     with pytest.raises(AcpError):
         await client.prompt("hi", timeout=10.0)
+
+
+# ── PATH augmentation for service-launched servers (nvm/fnm node not on PATH) ────────
+
+
+def _fake_node_dir(tmp_path) -> str:
+    """A dir that looks like a node bin dir (has an executable `node`)."""
+    d = tmp_path / "nodebin"
+    d.mkdir()
+    node = d / "node"
+    node.write_text("#!/bin/sh\n")
+    node.chmod(0o755)
+    return str(d)
+
+
+def test_launch_env_appends_node_dir_when_node_missing(tmp_path, monkeypatch):
+    """A service PATH that can't see node gets the discovered node dirs appended, so an
+    ACP agent that launches via `npx` can still find node — the systemd/nvm fix (#1)."""
+    node_dir = _fake_node_dir(tmp_path)
+    monkeypatch.setattr(acp_client, "_discovered_node_dirs", lambda: (node_dir,))
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")  # minimal, no node
+    env = _launch_env(None)
+    assert env["PATH"].endswith(node_dir)  # appended, not prepended
+    assert env["PATH"].startswith("/usr/bin:/bin")  # original PATH preserved & wins
+
+
+def test_launch_env_leaves_path_when_node_already_resolvable(tmp_path, monkeypatch):
+    """If node is already on PATH, don't touch it — no override of a working setup."""
+    node_dir = _fake_node_dir(tmp_path)
+    extra_dir = str(tmp_path / "should-not-be-added")
+    monkeypatch.setattr(acp_client, "_discovered_node_dirs", lambda: (extra_dir,))
+    monkeypatch.setenv("PATH", node_dir)  # node IS resolvable here
+    env = _launch_env(None)
+    assert env["PATH"] == node_dir  # untouched
+    assert extra_dir not in env["PATH"]
+
+
+def test_launch_env_no_node_dirs_discovered_is_safe(monkeypatch):
+    """Nothing discovered → PATH is left as-is (the error path still fires later)."""
+    monkeypatch.setattr(acp_client, "_discovered_node_dirs", lambda: ())
+    monkeypatch.setenv("PATH", "/usr/bin:/bin")
+    assert _launch_env(None)["PATH"] == "/usr/bin:/bin"
+
+
+def test_missing_binary_message_hints_at_service_path_for_node_tools():
+    """The error for a node tool points at the service-PATH gap; a non-node binary doesn't."""
+    npx = _missing_binary_message("npx")
+    assert "npx" in npx and "service" in npx and "nvm" in npx
+    # the hint also fires when the command is an absolute path to a node tool
+    assert "nvm" in _missing_binary_message("/home/u/.nvm/versions/node/v22/bin/npx")
+    codex = _missing_binary_message("codex")
+    assert "codex" in codex and "service" not in codex  # not a node tool → no node hint
+
+
+def test_version_sort_key_orders_newest_first():
+    """nvm/fnm version dirs sort newest-first so the preferred node wins on PATH."""
+    dirs = [
+        "/h/.nvm/versions/node/v18.20.0/bin",
+        "/h/.nvm/versions/node/v22.22.0/bin",
+        "/h/.nvm/versions/node/v20.16.0/bin",
+    ]
+    assert sorted(dirs, key=_version_sort_key, reverse=True)[0].endswith("v22.22.0/bin")
+    # fnm layout (version is the grandparent of bin) still parses
+    assert _version_sort_key("/h/.fnm/node-versions/v21.7.0/installation/bin") == (21, 7, 0)
 
 
 async def test_acp_client_bad_workdir_raises_acp_error():


### PR DESCRIPTION
## Problem

Using an ACP coding-agent runtime fails with:
```
(claude) failed: agent binary not found: 'npx' (is it installed and on PATH?)
```
…even though `npx` is installed.

**Cause:** the ACP runtime spawns node-based backends (the `claude` agent launches via `npx`) and resolves the binary against the **server's inherited PATH**. A protoAgent started as a service — **systemd**, launchd, a bare `nohup` — gets a minimal PATH. Node version managers (**nvm / fnm / volta / asdf / nodenv**) prepend their bin dir from your **shell rc**, which a service *never sources* — so `npx`/`node` aren't on PATH. This is the #1 ACP launch failure for self-hosted setups.

## Fix

`_launch_env` (the single chokepoint for every ACP subprocess) now augments the launch PATH:

- When `node` **isn't already resolvable** on the PATH, it discovers the version-manager node `bin` dirs — nvm/fnm versioned dirs **newest-first**, plus volta/asdf/nodenv/homebrew/standard shims — and **appends** the ones that actually contain a `node` executable.
- **Append, not prepend**, so an explicitly-configured PATH still wins for anything it already provides; we only add fallbacks for what's missing. Working setups are untouched.
- Discovery is **cached** (one filesystem probe per process) and best-effort.
- The "binary not found" error now also **hints at the service-PATH gap** for node tools.

Verified on a real nvm box: with a simulated systemd PATH (`~/.local/bin:/usr/local/bin:/usr/bin:/bin`, no node), `npx` becomes resolvable after `_launch_env` — discovery picks `~/.nvm/versions/node/v22.22.0/bin` (newest) first.

This makes the systemd+nvm case work **generally**, so no per-host service-unit PATH edit is needed.

## Tests

`tests/test_coding_agent_plugin.py`:
- appends discovered node dirs when node is missing (and preserves/prefers the original PATH)
- leaves PATH untouched when node is already resolvable
- safe no-op when nothing is discovered
- error message hints at the service-PATH gap for node tools but not for a non-node binary
- version dirs sort newest-first (nvm + fnm layouts)

`ruff` clean; 31 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)