### PR TITLE
feat(plugins): live config accessor + comma-separated string_list inputs

### DIFF
--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -6,7 +6,7 @@ import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
 import { Loader2, RotateCcw, Save } from "lucide-react";
 
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import { Accordion, AccordionItem, PanelHeader } from "@protolabsai/ui/navigation";
@@ -434,6 +434,49 @@ function SettingRow({
   );
 }
 
+// A free-form string list (repos, allowed dirs, …) edited as ONE text field. Items are
+// separated by a comma OR a newline — both work, so you can paste "a, b, c" or one per
+// line. It keeps its own raw text while focused so a separator isn't eaten mid-type (the
+// old controlled `value={list.join(...)}` re-derived the text every keystroke, dropping
+// the trailing separator via filter(Boolean) — which made adding a 2nd item impossible).
+// Parsed → a clean string[] on every change; re-syncs from `value` on an external change
+// (discard / reset / load).
+// Split a string-list text field into clean items: comma OR newline separated, trimmed,
+// empties dropped — so "a, b", "a\nb", and "a , , b\n" all yield ["a","b"].
+export function parseStringList(text: string): string[] {
+  return text.split(/[,\n]/).map((s) => s.trim()).filter(Boolean);
+}
+
+function StringListInput({ id, value, onChange }: { id: string; value: unknown; onChange: (v: unknown) => void }) {
+  const items = Array.isArray(value) ? value.filter((v): v is string => typeof v === "string") : [];
+  const [text, setText] = useState(items.join(", "));
+  const lastParsed = useRef(items);
+  useEffect(() => {
+    // Adopt the parent value only when it changed to something we didn't just emit
+    // (e.g. Discard reverted it) — otherwise leave the user's in-progress text alone.
+    if (JSON.stringify(items) !== JSON.stringify(lastParsed.current)) {
+      setText(items.join(", "));
+      lastParsed.current = items;
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [value]);
+  return (
+    <Textarea
+      id={id}
+      className="setting-input setting-textarea"
+      rows={2}
+      value={text}
+      placeholder="comma-separated (e.g. owner/repo, owner/repo2)"
+      onChange={(e) => {
+        setText(e.target.value);
+        const parsed = parseStringList(e.target.value);
+        lastParsed.current = parsed;
+        onChange(parsed);
+      }}
+    />
+  );
+}
+
 export function SettingInput({ field, value, onChange }: { field: SettingsField; value: unknown; onChange: (value: unknown) => void }) {
   const id = `set-${field.key}`;
 
@@ -502,17 +545,7 @@ export function SettingInput({ field, value, onChange }: { field: SettingsField;
     );
   }
   if (field.type === "string_list") {
-    const text = Array.isArray(value) ? value.join("\n") : "";
-    return (
-      <Textarea
-        id={id}
-        className="setting-input setting-textarea"
-        rows={3}
-        value={text}
-        placeholder="one per line"
-        onChange={(e) => onChange(e.target.value.split("\n").map((s) => s.trim()).filter(Boolean))}
-      />
-    );
+    return <StringListInput id={id} value={value} onChange={onChange} />;
   }
   if (field.type === "text") {
     // A scalar multiline string (#964) — a system prompt, template, or blurb. Renders

--- a/apps/web/src/settings/stringList.test.ts
+++ b/apps/web/src/settings/stringList.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from "vitest";
+
+import { parseStringList } from "./SettingsCategory";
+
+describe("parseStringList", () => {
+  it("splits on commas", () => {
+    expect(parseStringList("owner/a, owner/b")).toEqual(["owner/a", "owner/b"]);
+  });
+  it("splits on newlines too (back-compat with one-per-line)", () => {
+    expect(parseStringList("owner/a\nowner/b")).toEqual(["owner/a", "owner/b"]);
+  });
+  it("mixes separators, trims, and drops empties", () => {
+    expect(parseStringList("a , , b\n , c ")).toEqual(["a", "b", "c"]);
+  });
+  it("is empty for blank input", () => {
+    expect(parseStringList("   ")).toEqual([]);
+  });
+});

--- a/graph/plugins/loader.py
+++ b/graph/plugins/loader.py
@@ -315,7 +315,7 @@ def load_plugins(config, *, core_tool_names: set[str] | None = None) -> PluginLo
             # Resolved config section (ADR 0019) — defaults if not in plugin_config.
             section = manifest.config_section or manifest.id
             pconf = (getattr(config, "plugin_config", {}) or {}).get(section) or dict(manifest.config or {})
-            registry = PluginRegistry(manifest.id, manifest.path, config=pconf)
+            registry = PluginRegistry(manifest.id, manifest.path, config=pconf, config_section=section)
             register(registry)
         except Exception as exc:  # noqa: BLE001 — a bad plugin must not break boot
             # Clear diagnostic when an enabled plugin's declared deps aren't

--- a/graph/plugins/registry.py
+++ b/graph/plugins/registry.py
@@ -35,13 +35,20 @@ class PluginRegistry:
     them — changing ``plugins.enabled`` needs a restart (ADR 0018).
     """
 
-    def __init__(self, plugin_id: str, plugin_dir: Path, config: dict | None = None):
+    def __init__(
+        self, plugin_id: str, plugin_dir: Path, config: dict | None = None, config_section: str | None = None
+    ):
         self.plugin_id = plugin_id
         self.plugin_dir = plugin_dir
         # The plugin's resolved config section (ADR 0019) — manifest defaults ⊕
         # YAML ⊕ secrets. Read it in register() and close over it for your
-        # tools/routes/surface, e.g. ``registry.config.get("api_key")``.
+        # tools/routes/surface, e.g. ``registry.config.get("api_key")``. This is a
+        # register-time SNAPSHOT; for a mounted router/surface that must reflect config
+        # edits without a restart, use ``live_config()`` instead.
         self.config: dict = dict(config or {})
+        # The top-level config key this plugin's section lives under (``config_section``
+        # or the id) — the lookup key for ``live_config()``.
+        self.config_section: str = config_section or plugin_id
         # Host services (agent invoke + event bus) a surface/route can use — the
         # server populates these before startup; guard for None (e.g. in tests).
         from graph.plugins.host import HOST
@@ -63,6 +70,26 @@ class PluginRegistry:
         self.knowledge_stores: dict = {}  # name -> (config) -> KnowledgeBackend (ADR 0031)
         self.embedders: dict = {}  # name -> (config) -> (text -> vector) embed_fn (ADR 0031)
         self.chat_commands: dict = {}  # token -> async (rest, session_id) -> str|None (user-only control commands)
+
+    def live_config(self) -> dict:
+        """The plugin's CURRENT resolved config, re-read from the host on each call.
+
+        ``self.config`` is a register-time snapshot, so a hot-reload after a config save
+        can't refresh it for an already-mounted router or running surface (FastAPI can't
+        re-mount a router). But the reload DOES rebuild ``STATE.graph_config`` — so a
+        handler that reads this on each request reflects config edits with no restart.
+        Falls back to the snapshot when the host state isn't available (unit tests, or a
+        section that resolved empty)."""
+        try:
+            from runtime.state import STATE
+
+            pconf = getattr(getattr(STATE, "graph_config", None), "plugin_config", None) or {}
+            live = pconf.get(self.config_section)
+            if isinstance(live, dict):
+                return live
+        except Exception:  # noqa: BLE001 — best-effort; any failure ⇒ the snapshot
+            pass
+        return self.config
 
     def register_tool(self, tool) -> None:
         """Expose a LangChain tool to the agent."""

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -528,3 +528,28 @@ def test_reload_picks_up_edited_sibling_submodule(tmp_path, monkeypatch) -> None
     res2 = load_plugins(_cfg(plugins_enabled=["multi"]))
     say2 = next(t for t in res2.tools if getattr(t, "name", "") == "say")
     assert say2.invoke({}) == "v2"
+
+
+def test_registry_live_config_reads_state_then_falls_back(monkeypatch) -> None:
+    """live_config() re-reads the section from STATE.graph_config on each call (so a
+    mounted router reflects config edits without a restart), falling back to the
+    register-time snapshot when the host state/section isn't available."""
+    import types
+
+    from graph.plugins.registry import PluginRegistry
+
+    reg = PluginRegistry("github", Path("."), config={"repos": ["o/snap"]}, config_section="github")
+    import runtime.state as rs
+
+    # No graph_config → snapshot.
+    monkeypatch.setattr(rs.STATE, "graph_config", None, raising=False)
+    assert reg.live_config() == {"repos": ["o/snap"]}
+
+    # Live section present → live wins (the edited value, no restart).
+    cfg = types.SimpleNamespace(plugin_config={"github": {"repos": ["o/live"]}})
+    monkeypatch.setattr(rs.STATE, "graph_config", cfg, raising=False)
+    assert reg.live_config() == {"repos": ["o/live"]}
+
+    # Section missing from live config → snapshot.
+    cfg.plugin_config = {"other": {}}
+    assert reg.live_config() == {"repos": ["o/snap"]}


### PR DESCRIPTION
Two plugin-config ergonomics fixes, both surfaced by the GitHub board plugin (its repo picker config wasn't usable). Each is generic.

## 1. `PluginRegistry.live_config()` — config without a restart

A plugin that contributes a **router or background surface** captures its config at register time. A config save hot-reloads the graph, but FastAPI **can't re-mount a router** — so the mounted view keeps serving the *old* config until a full restart (the "restart recommended" friction).

`live_config()` re-reads the plugin's resolved config from `STATE.graph_config.plugin_config[section]` on each call (the reload **does** rebuild `graph_config`), falling back to the register-time snapshot when host state isn't available (unit tests / older host). A handler that reads it per request reflects edits live. The loader now passes `config_section` so the lookup key is correct even when `config_section != id`.

(`graph → runtime.state` is an already-established import — agent.py/sdk.py/manager.py/etc. — so no layering change.)

## 2. `string_list` settings inputs are comma-friendly — and actually usable

The plain `string_list` field was a controlled textarea that re-derived its text from `value.join(\"\\n\")` **every keystroke**. Typing a separator produced a trailing empty segment that `filter(Boolean)` dropped, so the re-join erased the separator — you **could not add a second item**. (That's the real reason adding repos \"did nothing.\")

Extracted `StringListInput` with its own raw-text state: parse on change, re-sync from `value` only on an external change (Discard/reset/load). Splits on **comma OR newline**, displays comma-separated, placeholder `\"comma-separated (e.g. owner/repo, owner/repo2)\"`. Both separators work; nothing gets eaten.

## Tests
- `live_config()` reads STATE live, falls back to the snapshot when the section/host is absent (`tests/test_plugins.py`)
- `parseStringList` — comma, newline, mixed, trims, drops empties (`apps/web/src/settings/stringList.test.ts`)
- Python 55 passed (plugins + routes); web unit 144 passed; `tsc` + `ruff` clean.

> Companion: github-plugin PR #11 uses `live_config()` so its board reflects repo edits without a restart.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved the settings editor for list-style values, making it easier to add and edit items with commas or line breaks.
  * Updated plugin configuration handling so the app can use the latest available settings when they change.

* **Bug Fixes**
  * Prevented the list editor from resetting while typing.
  * Preserved backward compatibility for existing newline-separated list entries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->