### PR TITLE
fix(coding_agent): show the bare tool name for MCP calls, not mcp__server__tool

### DIFF
--- a/plugins/coding_agent/acp_client.py
+++ b/plugins/coding_agent/acp_client.py
@@ -72,12 +72,17 @@ def _split_tool_title(title: str) -> tuple[str, str]:
 
 def _short_tool_name(title: str) -> str:
     """A compact card label from a (possibly verbose) ACP tool title: drop the inline
-    JSON args and a trailing ``(… MCP Server)`` source so the header stays a short
-    at-a-glance name (parity with the native runtime's clean tool names). The args +
-    source live in the card body instead."""
+    JSON args, a trailing ``(… MCP Server)`` source, and a leading ``mcp__<server>__``
+    namespace prefix, so the header stays a short at-a-glance name (parity with the
+    native runtime's clean tool names). The args + source live in the card body instead."""
     label, _ = _split_tool_title(title)
     # Drop a trailing "(… MCP Server)" source suffix only — NOT a legit "(beta)" / "(v2)".
     label = re.sub(r"\s*\([^)]*\b(?:MCP|server)\b[^)]*\)\s*$", "", label, flags=re.IGNORECASE).strip()
+    # Drop the `mcp__<server>__` prefix some agents (Claude Code) put on MCP tools —
+    # `mcp__protoagent-operator__current_time` → `current_time` — so the card reads as the
+    # bare tool name like the native runtime, not the wire-namespaced one. Non-greedy so it
+    # peels only the mcp+server segment; a non-namespaced name (`read_file`) is untouched.
+    label = re.sub(r"^mcp__.+?__", "", label).strip()
     return (label or (title or "").strip() or "tool")[:80]
 
 

--- a/tests/test_coding_agent_plugin.py
+++ b/tests/test_coding_agent_plugin.py
@@ -41,6 +41,13 @@ def test_short_tool_name_peels_inline_args_and_mcp_source():
     assert _short_tool_name("Skill: Use skill: 'browser-automation'") == "Skill: Use skill: 'browser-automation'"
     # A legit, non-MCP trailing parenthetical is PRESERVED (only "(… MCP Server)" is peeled).
     assert _short_tool_name("search (beta)") == "search (beta)"
+    # Claude Code's `mcp__<server>__<tool>` namespace prefix is peeled to the bare tool.
+    assert _short_tool_name("mcp__protoagent-operator__current_time") == "current_time"
+    assert _short_tool_name("mcp__proto_ops__list_issues") == "list_issues"
+    # …even with inline args attached.
+    assert _short_tool_name('mcp__protoagent-operator__fetch_url: {"url":"https://x"}') == "fetch_url"
+    # A non-namespaced native tool name is untouched.
+    assert _short_tool_name("read_file") == "read_file"
     # Defensive cap so an unbounded title can never blow out the header.
     assert len(_short_tool_name("x" * 500)) <= 80
 


### PR DESCRIPTION
## Symptom

When an ACP coding agent (Claude Code) calls a tool exposed by an MCP server — e.g. protoAgent's own **operator MCP** — the tool card showed the raw wire name:

```
mcp__protoagent-operator__current_time
```

instead of the clean `current_time` you get from the native runtime.

## Cause

Claude Code namespaces MCP tools as `mcp__<server>__<tool>`. `_short_tool_name` already peels inline JSON args and a trailing `(… MCP Server)` suffix, but not this **leading** prefix — so it passed through verbatim onto the start/end tool cards (and the narration).

## Fix

`_short_tool_name` now also strips the `mcp__<server>__` prefix:

```
mcp__protoagent-operator__current_time → current_time
```

Non-greedy (`^mcp__.+?__`), so it peels only the `mcp`+server segment; a non-namespaced native tool (`read_file`) is untouched, and it composes with the existing args/suffix stripping. Fixes both the start and end cards and the text narration in one place.

## Tests

`tests/test_coding_agent_plugin.py` — extends the `_short_tool_name` test: peels the prefix (with hyphen and underscore servers), peels prefix + inline args together, leaves a native name alone. `ruff` clean.