### PR TITLE
fix(plugins): auto-exempt console view pages from the auth gate

### DIFF
--- a/graph/plugins/manifest.py
+++ b/graph/plugins/manifest.py
@@ -153,6 +153,35 @@ def _parse_public_paths(paths, plugin_id: str) -> list[str]:
     return kept
 
 
+def _view_public_paths(views: list[dict]) -> list[str]:
+    """The page path of every console view (and its palette morph), to auto-exempt
+    from the auth gate.
+
+    A view page is public *chrome*: the console iframes it with a plain navigation
+    that cannot carry the operator bearer, so a gated page 401-blanks under a
+    token-gated deployment. Its DATA stays gated under ``/api/plugins/<id>/*`` and
+    is fetched from inside the loaded page with the postMessage handshake token.
+
+    Deriving these from ``views`` means a plugin's view loads under a token gate
+    automatically — authors don't have to re-declare each view path in
+    ``public_paths`` (the bundled notes/docs plugins didn't, and 401-blanked).
+    Query/fragment are stripped so the prefix match covers e.g.
+    ``/plugins/docs/view?mode=search``. Same-origin scoping is enforced later by
+    ``_parse_public_paths``.
+    """
+    out: list[str] = []
+    for v in views:
+        candidates = [v.get("path")]
+        palette = v.get("palette")
+        if isinstance(palette, dict):
+            candidates.append(palette.get("path"))
+        for c in candidates:
+            p = str(c or "").split("?", 1)[0].split("#", 1)[0].strip()
+            if p:
+                out.append(p)
+    return out
+
+
 def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     """Parse ``<plugin_dir>/protoagent.plugin.yaml`` → ``PluginManifest``.
 
@@ -186,7 +215,18 @@ def load_manifest(plugin_dir: Path) -> PluginManifest | None:
     secrets = data.get("secrets")
     settings = data.get("settings")
     views = _parse_views(data.get("views"), pid)
-    public_paths = _parse_public_paths(data.get("public_paths"), pid)
+    # public_paths = explicitly-declared exempt paths PLUS every view's own page
+    # path (view pages are public chrome — see _view_public_paths). Both run
+    # through the namespace validator; dict.fromkeys dedupes while preserving order
+    # (a view path a manifest also lists explicitly collapses to one).
+    public_paths = list(
+        dict.fromkeys(
+            [
+                *_parse_public_paths(data.get("public_paths"), pid),
+                *_parse_public_paths(_view_public_paths(views), pid),
+            ]
+        )
+    )
     emits = data.get("emits")
     subscribes = data.get("subscribes")
     requires_pip = data.get("requires_pip")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -352,6 +352,31 @@ def test_manifest_parses_views() -> None:
     assert m.views[0]["icon"] == "LayoutDashboard"
 
 
+def test_view_paths_are_auto_public(tmp_path) -> None:
+    # A view page is public chrome (the console iframes it; the nav can't carry a
+    # bearer), so its path — and its palette morph's path, query stripped — is
+    # auto-exempted from the auth gate WITHOUT the manifest re-declaring it in
+    # public_paths. (This is the bug that 401-blanked the bundled notes/docs views
+    # under a token gate.) Explicit public_paths still merge in, deduped.
+    _make_plugin(
+        tmp_path, "viewy", enabled=True,
+        manifest_extra=(
+            "views:\n"
+            '  - {id: main, label: Main, path: /plugins/viewy/view, palette: {path: "/plugins/viewy/quick?mode=search"}}\n'
+            "public_paths:\n"
+            "  - /plugins/viewy/view\n"          # also declared explicitly → not duplicated
+            "  - /api/plugins/viewy/webhook\n"   # a non-view exempt path → preserved
+        ),
+    )
+    m = load_manifest(tmp_path / "viewy")
+    assert m is not None
+    assert m.public_paths == [
+        "/plugins/viewy/view",          # from public_paths; the view path collapses onto it
+        "/api/plugins/viewy/webhook",
+        "/plugins/viewy/quick",         # palette path, query stripped, auto-added
+    ]
+
+
 def test_loader_meta_exposes_views_for_enabled_plugin(monkeypatch, tmp_path) -> None:
     root = tmp_path / "plugins"
     _make_plugin(


### PR DESCRIPTION
## Symptom
On a **token-gated** protoAgent, the bundled **notes and docs** plugin views 401-blank in the console (`/plugins/notes/view`, `/plugins/docs/view` → 401). Only `content` works.

## Root cause
A view page is public *chrome* — the console iframes it with a navigation that can't carry the operator bearer, so a gated page 401s; the page then fetches its DATA from the gated `/api/plugins/<id>/*` routes with the postMessage handshake token. But a plugin only got its page exempted if its manifest **re-declared** the path in `public_paths`. `content` did; the reference plugins `notes`/`docs` didn't — so they 401-blank under any token gate. Making every author duplicate a path the host already has in `views` is the footgun.

## Fix
Derive the auth exemption from `views[].path` (+ `palette.path`, query stripped) in `load_manifest`, merged with explicit `public_paths` (deduped). Every plugin's view loads under a token gate automatically; explicit `public_paths` is still honored for non-view exemptions (webhooks, a built SPA's `/assets`). Same-origin namespace scoping unchanged (routed through `_parse_public_paths`).

Fixes notes/docs/content **and** every future view-plugin across the fleet.

## Tests
`notes → [/plugins/notes/view, /plugins/notes/quick]`, `docs → [/plugins/docs/view]`. New `test_view_paths_are_auto_public`; full plugins + a2a-auth suites green (93 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)