### PR TITLE
feat(web): hide rail surfaces without disabling + Configure from the rail menu

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,9 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - **Hide a rail surface without disabling its plugin** (ADR 0035/0036) — `railOrder` gains a
   `hidden` bucket: a surface is on exactly one dock *or* hidden (enabled-but-not-shown). Right-click
-  a rail icon → **Hide** to declutter the rails without disabling the plugin; restore it from ⌘K
-  (opening a hidden view un-hides it) or "Move to …". The reconcilers respect `hidden`, so a reload
-  never resurrects a hidden view and uninstalling the plugin prunes it. Persist migration **v13**.
+  a rail icon → **Hide** to declutter the rails without disabling the plugin; restore it from ⌘K,
+  from **right-clicking the empty rail** (a "Hidden views" menu), or "Move to …". The reconcilers
+  respect `hidden`, so a reload never resurrects a hidden view and uninstalling the plugin prunes
+  it. Persist migration **v13**.
 - **Configure a plugin from its rail icon** (ADR 0036/0059) — a plugin view's right-click menu now
   offers **Configure…**, which opens that plugin's settings dialog (the same per-plugin dialog the
   Plugins manager uses), store-driven from a single root mount.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,9 +18,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from **right-clicking the empty rail** (a "Hidden views" menu), or "Move to …". The reconcilers
   respect `hidden`, so a reload never resurrects a hidden view and uninstalling the plugin prunes
   it. Persist migration **v13**.
-- **Configure a plugin from its rail icon** (ADR 0036/0059) — a plugin view's right-click menu now
-  offers **Configure…**, which opens that plugin's settings dialog (the same per-plugin dialog the
-  Plugins manager uses), store-driven from a single root mount.
+- **Configure a plugin from its rail icon or util-bar widget** (ADR 0036/0059) — right-clicking a
+  plugin view's rail icon, or its util-bar widget pill, now offers **Configure…**, which opens that
+  plugin's settings dialog (the same per-plugin dialog the Plugins manager uses), store-driven from
+  a single root mount.
+- **Chat tab context menu** (ADR 0036) — right-click a chat session tab for **New chat / Rename /
+  Close** (Close reuses the delete-confirm; Rename opens the inline tab editor).
 - **Fork-safe console behavior seams** (ADR 0061, #1337) — give the console the backend's
   "extend-without-editing-core, update-safe" property. Extends the `src/ext/` fork pattern
   with three registries mirroring `registerSurface` (static, first-wins, HMR-safe), so a fork

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Hide a rail surface without disabling its plugin** (ADR 0035/0036) — `railOrder` gains a
+  `hidden` bucket: a surface is on exactly one dock *or* hidden (enabled-but-not-shown). Right-click
+  a rail icon → **Hide** to declutter the rails without disabling the plugin; restore it from ⌘K
+  (opening a hidden view un-hides it) or "Move to …". The reconcilers respect `hidden`, so a reload
+  never resurrects a hidden view and uninstalling the plugin prunes it. Persist migration **v13**.
+- **Configure a plugin from its rail icon** (ADR 0036/0059) — a plugin view's right-click menu now
+  offers **Configure…**, which opens that plugin's settings dialog (the same per-plugin dialog the
+  Plugins manager uses), store-driven from a single root mount.
 - **Fork-safe console behavior seams** (ADR 0061, #1337) — give the console the backend's
   "extend-without-editing-core, update-safe" property. Extends the `src/ext/` fork pattern
   with three registries mirroring `registerSurface` (static, first-wins, HMR-safe), so a fork

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -99,3 +99,19 @@ test("long tool values do not overflow the chat horizontally", async ({ page }) 
   expect(metrics.docScroll).toBeLessThanOrEqual(metrics.win + 1);
   expect(metrics.bodyScroll).toBeLessThanOrEqual(metrics.bodyClient + 1);
 });
+
+test("right-click a chat tab → New chat / Rename / Close, and New chat adds a tab", async ({ page }) => {
+  // ADR 0036 — the chat tab context menu. Default has one session tab.
+  const tabs = page.locator(".pl-tabbar__tab");
+  await expect(tabs).toHaveCount(1);
+
+  await tabs.first().click({ button: "right" });
+  const menu = page.locator(".pl-menu");
+  await expect(menu).toBeVisible();
+  await expect(menu.getByText("New chat", { exact: true })).toBeVisible();
+  await expect(menu.getByText("Rename", { exact: true })).toBeVisible();
+  await expect(menu.getByText("Close chat", { exact: true })).toBeVisible();
+
+  await menu.getByText("New chat", { exact: true }).click();
+  await expect(tabs).toHaveCount(2);
+});

--- a/apps/web/e2e/navigation.spec.ts
+++ b/apps/web/e2e/navigation.spec.ts
@@ -185,6 +185,25 @@ test("right-click → Move to bottom dock docks the surface at the bottom", asyn
   await expect(page.locator(".pl-appshell__bottom .pl-tabs").getByRole("tab", { name: "Overview", exact: true })).toBeVisible();
 });
 
+test("right-click a core surface → Hide removes it; Chat offers no Hide (ADR 0035/0036)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  const leftRail = page.locator(".pl-rail:not(.pl-rail--right)");
+
+  // Knowledge can be hidden off the rail (enabled-but-not-shown — no plugin to disable here).
+  await expect(leftRail.getByRole("button", { name: "Knowledge", exact: true })).toBeVisible();
+  await leftRail.getByRole("button", { name: "Knowledge", exact: true }).click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Hide", { exact: true }).click();
+  await expect(leftRail.getByRole("button", { name: "Knowledge", exact: true })).toHaveCount(0);
+
+  // Chat mounts unconditionally on its dock, so it must NOT offer Hide (a hidden chat would
+  // render with no rail icon). Its menu still has the move actions.
+  await leftRail.getByRole("button", { name: "Chat", exact: true }).click({ button: "right" });
+  const menu = page.locator(".pl-menu");
+  await expect(menu).toBeVisible();
+  await expect(menu.getByText("Move to right rail")).toBeVisible();
+  await expect(menu.getByText("Hide", { exact: true })).toHaveCount(0);
+});
+
 test("mobile shell: bottom quick-bar + unified header drawer (ADR 0035 S4)", async ({ page }) => {
   await page.setViewportSize({ width: 390, height: 800 });
   await page.goto("/app/", { waitUntil: "load" });

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -147,6 +147,28 @@ test("right-click the empty rail → a 'Hidden views' menu restores a hidden sur
   await expect(rail.getByRole("button", { name: "Board", exact: true })).toBeVisible();
 });
 
+test("the Hidden views menu restores onto the rail it was opened on", async ({ page }) => {
+  // ADR 0035/0036 — restoring from a rail's background drops the view on THAT dock, not its default.
+  await page.goto("/app/", { waitUntil: "load" });
+  const leftRail = page.getByRole("complementary", { name: "Left surfaces" });
+  const rightRail = page.getByRole("complementary", { name: "Right surfaces" });
+  await expect(leftRail.getByRole("button", { name: "Board", exact: true })).toBeVisible();
+
+  // Hide Board (it lives on the left rail by default).
+  await leftRail.getByRole("button", { name: "Board", exact: true }).click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Hide", { exact: true }).click();
+  await expect(leftRail.getByRole("button", { name: "Board", exact: true })).toHaveCount(0);
+
+  // Right-click the RIGHT rail's empty area → restore Board THERE, not back on the left.
+  const box = await rightRail.boundingBox();
+  if (!box) throw new Error("right rail has no bounding box");
+  await rightRail.click({ button: "right", position: { x: box.width / 2, y: box.height - 8 } });
+  await page.locator(".pl-menu").getByText("Board", { exact: true }).click();
+
+  await expect(rightRail.getByRole("button", { name: "Board", exact: true })).toBeVisible();
+  await expect(leftRail.getByRole("button", { name: "Board", exact: true })).toHaveCount(0);
+});
+
 test("right-click a plugin view → Configure opens that plugin's settings dialog", async ({ page }) => {
   // ADR 0036/0059 — a plugin view's rail menu offers "Configure…", which opens the owning
   // plugin's per-plugin settings dialog (titled with the plugin's display name, "Boardy").

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -101,6 +101,35 @@ test("a 404-ing plugin view shows an actionable error, not a blank panel", async
   await expect(page.locator(".plugin-view-frame")).toHaveCount(0);
 });
 
+test("right-click a plugin view → Hide removes its rail icon, and it stays hidden across a reload", async ({ page }) => {
+  // ADR 0035/0036 — "hidden but enabled": hiding a plugin view drops its rail icon WITHOUT
+  // disabling the plugin, and the reconcile-on-load must NOT resurrect it (the layout-wipe trap).
+  await page.goto("/app/", { waitUntil: "load" });
+  const rail = page.locator(".pl-rail");
+  await expect(rail.getByRole("button", { name: "Board", exact: true })).toBeVisible();
+
+  await rail.getByRole("button", { name: "Board", exact: true }).click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Hide", { exact: true }).click();
+  await expect(rail.getByRole("button", { name: "Board", exact: true })).toHaveCount(0);
+  // Only Board is hidden — its sibling view (Stats) is untouched.
+  await expect(rail.getByRole("button", { name: "Stats", exact: true })).toBeVisible();
+
+  // Reload: boardy is still installed (the runtime status lists it), but Board stays hidden —
+  // reconcilePluginViews keeps it in the hidden bucket rather than re-docking it.
+  await page.reload({ waitUntil: "load" });
+  await expect(page.locator(".pl-rail").getByRole("button", { name: "Stats", exact: true })).toBeVisible();
+  await expect(page.locator(".pl-rail").getByRole("button", { name: "Board", exact: true })).toHaveCount(0);
+});
+
+test("right-click a plugin view → Configure opens that plugin's settings dialog", async ({ page }) => {
+  // ADR 0036/0059 — a plugin view's rail menu offers "Configure…", which opens the owning
+  // plugin's per-plugin settings dialog (titled with the plugin's display name, "Boardy").
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-rail").getByRole("button", { name: "Board", exact: true }).click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Configure", { exact: false }).click();
+  await expect(page.getByRole("dialog", { name: "Boardy" })).toBeVisible();
+});
+
 test("a plugin view with placement:right becomes a right-sidebar panel", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -121,6 +121,32 @@ test("right-click a plugin view → Hide removes its rail icon, and it stays hid
   await expect(page.locator(".pl-rail").getByRole("button", { name: "Board", exact: true })).toHaveCount(0);
 });
 
+test("right-click the empty rail → a 'Hidden views' menu restores a hidden surface", async ({ page }) => {
+  // ADR 0035/0036 — the rail-background menu is the discoverable counterpart to ⌘K for un-hiding.
+  await page.goto("/app/", { waitUntil: "load" });
+  // The left rail aside (full-height grid column) — by aria-label, so it's unambiguous vs the
+  // bottom rail (which also lacks the --right modifier).
+  const rail = page.getByRole("complementary", { name: "Left surfaces" });
+  await expect(rail.getByRole("button", { name: "Board", exact: true })).toBeVisible();
+
+  // Hide Board first.
+  await rail.getByRole("button", { name: "Board", exact: true }).click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Hide", { exact: true }).click();
+  await expect(rail.getByRole("button", { name: "Board", exact: true })).toHaveCount(0);
+
+  // Right-click the EMPTY rail area (near the bottom of the column, below the icons) → the
+  // Hidden views menu lists Board. Compute the point from the rail's box so it's robust to height.
+  const box = await rail.boundingBox();
+  if (!box) throw new Error("left rail has no bounding box");
+  await rail.click({ button: "right", position: { x: box.width / 2, y: box.height - 8 } });
+  const menu = page.locator(".pl-menu");
+  await expect(menu).toBeVisible();
+  await menu.getByText("Board", { exact: true }).click();
+
+  // Board is restored to the rail.
+  await expect(rail.getByRole("button", { name: "Board", exact: true })).toBeVisible();
+});
+
 test("right-click a plugin view → Configure opens that plugin's settings dialog", async ({ page }) => {
   // ADR 0036/0059 — a plugin view's rail menu offers "Configure…", which opens the owning
   // plugin's per-plugin settings dialog (titled with the plugin's display name, "Boardy").

--- a/apps/web/e2e/plugin-views.spec.ts
+++ b/apps/web/e2e/plugin-views.spec.ts
@@ -156,6 +156,14 @@ test("right-click a plugin view → Configure opens that plugin's settings dialo
   await expect(page.getByRole("dialog", { name: "Boardy" })).toBeVisible();
 });
 
+test("right-click a plugin's util-bar widget → Configure opens its settings dialog", async ({ page }) => {
+  // ADR 0036/0059 — the util-bar widget context menu mirrors the rail-icon Configure.
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("util-widget-snap").click({ button: "right" });
+  await page.locator(".pl-menu").getByText("Configure", { exact: false }).click();
+  await expect(page.getByRole("dialog", { name: "Boardy" })).toBeVisible();
+});
+
 test("a plugin view with placement:right becomes a right-sidebar panel", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
 

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -59,7 +59,7 @@ import {
 import type { LucideIcon } from "lucide-react";
 import { useQuery } from "@tanstack/react-query";
 import { lazy, Suspense, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import type { ComponentType, LazyExoticComponent, ReactNode } from "react";
+import type { ComponentType, LazyExoticComponent, MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { FleetTurnWatch } from "./FleetTurnWatch";
 import { UpdateNotice } from "./UpdateNotice";
 import { BackgroundWatch } from "./BackgroundWatch";
@@ -478,6 +478,19 @@ export function App() {
     return [...ordered, ...extra, ...ext];
   }
 
+  // Right-click the EMPTY rail background (not an icon) → the "Hidden views" restore menu
+  // (ADR 0035/0036). The DS AppShell only fires onRailContextMenu on icons, so we catch the
+  // rail-container right-click here via event delegation (the DS classnames are the contract)
+  // and hand the resolved hidden-surface labels to the `rail-background` menu. An icon click
+  // is handled by its own `rail-surface` menu, so bail when the target is a rail button.
+  const onShellContextMenu = (e: ReactMouseEvent) => {
+    const t = e.target as HTMLElement;
+    if (t.closest(".pl-rail__btn")) return; // an icon — its own menu handles it
+    if (!t.closest(".pl-rail")) return; // not the rail — leave the default menu
+    const hidden = (railOrder.hidden ?? []).map((id) => ({ id, label: metaFor(id)?.label ?? id }));
+    openContextMenu("rail-background", e, { hidden });
+  };
+
   // ── Command palette (⌘K, ADR 0057) ────────────────────────────────────────────
   // Every resolvable View becomes a "go to" command (via openView → setSurface);
   // deep-link actions ride alongside. Plugin-declared `commands:` + inline plugin
@@ -661,7 +674,7 @@ export function App() {
     {/* Command palette (⌘K, ADR 0057) — portals over the shell; the same component
         backs the desktop quick-command (step 4). */}
     <CommandPalette open={paletteOpen} onOpenChange={setPaletteOpen} registry={paletteRegistry} />
-    <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`}>
+    <div className={`app-shell${isTauriMac ? " is-tauri-mac" : ""}`} onContextMenu={onShellContextMenu}>
       {/* protoLabs.studio brand bumper — DS Splash (@protolabsai/ui/splash). Holds
           2.5s then hands off via the View Transitions API cross-fade (the
           protoAgent path); shows once per tab session (sessionStorage

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -79,6 +79,7 @@ import { ChatSlot } from "./ChatSlot";
 import { chatStore, useAnyChatStreaming } from "../chat/chat-store";
 import { KnowledgeStore } from "../knowledge/KnowledgeStore";
 import { SettingsOverlay } from "../settings/SettingsOverlay";
+import { PluginSettingsDialog } from "../plugins/PluginSettingsDialog";
 import { AppDrawer } from "./AppDrawer";
 import { HamburgerMenu } from "./HamburgerMenu";
 import { FleetSwitcher } from "./FleetSwitcher";
@@ -253,6 +254,8 @@ export function App() {
   const globalSettingsSection = useUI((s) => s.globalSettingsSection);
   const openGlobalSettings = useUI((s) => s.openGlobalSettings);
   const closeGlobalSettings = useUI((s) => s.closeGlobalSettings);
+  const configurePlugin = useUI((s) => s.configurePlugin);
+  const closePluginConfig = useUI((s) => s.closePluginConfig);
   const [drawerOpen, setDrawerOpen] = useState(false);
   const [projectPath, setProjectPath] = useLocalStorageState("protoagent.projectPath", "");
   // Shell-level runtime read (ADR 0013): non-suspense useQuery so the topbar
@@ -455,7 +458,9 @@ export function App() {
   );
   const metaFor = (id: string): RailItem | undefined => coreMeta.get(id) ?? pluginMeta.get(id);
   function railSurfaces(side: "left" | "right" | "bottom"): RailItem[] {
-    const placed = new Set([...railOrder.left, ...railOrder.right, ...railOrder.bottom]);
+    // `placed` includes the `hidden` bucket so the safety-net below never re-appends a
+    // view the operator hid (hidden = enabled-but-not-shown, ADR 0035/0036).
+    const placed = new Set([...railOrder.left, ...railOrder.right, ...railOrder.bottom, ...(railOrder.hidden ?? [])]);
     const ordered = (railOrder[side] ?? []).map(metaFor).filter((s): s is RailItem => Boolean(s));
     // Safety net: a plugin view that appeared before reconcile ran — append it for this side.
     const extra = (side === "left" ? pluginRail : side === "right" ? pluginRightPanels : pluginBottom)
@@ -808,7 +813,15 @@ export function App() {
             else { setBottomPanel(id); setBottomCollapsed(false); }
           }
         }}
-        onRailContextMenu={(side, e, id) => openContextMenu("rail-surface", e, { id, side })}
+        onRailContextMenu={(side, e, id) => {
+          // A plugin view's rail id is `plugin:<pluginId>:<viewId>` — resolve the owning
+          // plugin's id + display name so the menu can offer "Configure…" (ADR 0036/0059).
+          const pluginId = id.startsWith("plugin:") ? id.split(":")[1] : undefined;
+          const pluginName = pluginId
+            ? (runtime?.plugins?.find((p) => p.id === pluginId)?.name ?? pluginId)
+            : undefined;
+          openContextMenu("rail-surface", e, { id, side, pluginId, pluginName });
+        }}
         onRailReorder={(next) => {
           // Chat can dock anywhere now — left, right, or the bottom dock. Its slot mounts
           // unconditionally on whichever dock holds it (bottomContent mirrors the side rails),
@@ -1049,6 +1062,16 @@ export function App() {
       section={globalSettingsSection}
       onClose={closeGlobalSettings}
     />
+    {/* Per-plugin Configure dialog (ADR 0059) — opened from a rail context-menu "Configure…"
+        (ADR 0036). Store-driven so it can be triggered from anywhere; one root mount. */}
+    {configurePlugin && (
+      <PluginSettingsDialog
+        pluginId={configurePlugin.id}
+        pluginName={configurePlugin.name}
+        open
+        onClose={closePluginConfig}
+      />
+    )}
     </>
   );
 }

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -486,9 +486,16 @@ export function App() {
   const onShellContextMenu = (e: ReactMouseEvent) => {
     const t = e.target as HTMLElement;
     if (t.closest(".pl-rail__btn")) return; // an icon — its own menu handles it
-    if (!t.closest(".pl-rail")) return; // not the rail — leave the default menu
+    const railEl = t.closest(".pl-rail") as HTMLElement | null;
+    if (!railEl) return; // not the rail — leave the default menu
+    // Which rail was right-clicked → restore a hidden view to THIS dock (not its default).
+    const side: "left" | "right" | "bottom" = railEl.classList.contains("pl-rail--right")
+      ? "right"
+      : railEl.classList.contains("pl-rail--bottom")
+        ? "bottom"
+        : "left";
     const hidden = (railOrder.hidden ?? []).map((id) => ({ id, label: metaFor(id)?.label ?? id }));
-    openContextMenu("rail-background", e, { hidden });
+    openContextMenu("rail-background", e, { side, hidden });
   };
 
   // ── Command palette (⌘K, ADR 0057) ────────────────────────────────────────────

--- a/apps/web/src/app/App.tsx
+++ b/apps/web/src/app/App.tsx
@@ -942,7 +942,10 @@ export function App() {
                 <ActivityWidget />
                 {/* Plugin-contributed utility widgets (`views[].utility`): a pill that opens
                     the plugin's iframe in a dialog, with hover info. Reuses PluginView. */}
-                {utilityWidgetViews.map((v) => (
+                {utilityWidgetViews.map((v) => {
+                  const pluginId = v.key.split(":")[1];
+                  const pluginName = runtime?.plugins?.find((p) => p.id === pluginId)?.name ?? pluginId;
+                  return (
                   <UtilityWidget
                     key={v.key}
                     testId={`util-widget-${v.id}`}
@@ -951,12 +954,14 @@ export function App() {
                     info={typeof v.utility === "object" && v.utility?.info ? v.utility.info : `Open ${v.label}`}
                     dialogTitle={v.label}
                     dialogWidth="min(900px, 96vw)"
+                    onContextMenu={(e) => openContextMenu("util-widget", e, { pluginId, pluginName })}
                   >
                     <div className="plugin-widget-dialog">
                       <PluginView view={v} />
                     </div>
                   </UtilityWidget>
-                ))}
+                  );
+                })}
               </>
             }
             end={

--- a/apps/web/src/app/UtilityWidget.tsx
+++ b/apps/web/src/app/UtilityWidget.tsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import type { ReactNode } from "react";
+import type { MouseEvent as ReactMouseEvent, ReactNode } from "react";
 import { Dialog, Tooltip } from "@protolabsai/ui/overlays";
 import { RefreshButton } from "./ui-kit";
 
@@ -39,6 +39,7 @@ export function UtilityWidget({
   testId,
   onOpen,
   onClose,
+  onContextMenu,
   children,
 }: {
   icon: ReactNode;
@@ -52,6 +53,8 @@ export function UtilityWidget({
   testId?: string;
   onOpen?: () => void;
   onClose?: () => void;
+  /** Right-click the pill — wired to the context-menu system (ADR 0036). */
+  onContextMenu?: (e: ReactMouseEvent) => void;
   children: ReactNode;
 }) {
   const [open, setOpen] = useState(false);
@@ -69,6 +72,7 @@ export function UtilityWidget({
         onOpen?.();
         setOpen(true);
       }}
+      onContextMenu={onContextMenu}
     >
       {icon}
       {badge}

--- a/apps/web/src/app/usePaletteRegistry.ts
+++ b/apps/web/src/app/usePaletteRegistry.ts
@@ -43,16 +43,21 @@ export type InlinePluginView = {
 };
 
 /** Open any view by id, routed to the dock it actually lives on (and uncollapsed).
- *  Reads live state via the store's `getState()` so it isn't a render subscription. */
+ *  Reads live state via the store's `getState()` so it isn't a render subscription.
+ *  A HIDDEN surface (railOrder.hidden — enabled but not shown) is un-hidden first: the
+ *  palette is the restore point, so ⌘K → a hidden view's name brings it back onto a dock. */
 export function openView(id: string) {
   const ui = useUI.getState();
-  if (ui.railOrder.right.includes(id)) {
+  if ((ui.railOrder.hidden ?? []).includes(id)) ui.showSurface(id); // restore onto its dock, then route
+  const ro = useUI.getState().railOrder; // re-read: showSurface mutated it
+  if (ro.right.includes(id)) {
     ui.setRightCollapsed(false);
     ui.setRightPanel(id);
-  } else if (ui.railOrder.bottom.includes(id)) {
+  } else if (ro.bottom.includes(id)) {
     ui.setBottomCollapsed(false);
     ui.setBottomPanel(id);
   } else {
+    ui.setLeftCollapsed(false);
     ui.setSurface(id);
   }
 }

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -18,8 +18,10 @@ import {
   TerminalSquare,
 } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
+import type { MouseEvent as ReactMouseEvent } from "react";
 import { useQuery } from "@tanstack/react-query";
 
+import { openContextMenu } from "../contextMenu";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { runtimeStatusQuery } from "../lib/queries";
@@ -136,6 +138,27 @@ export function ChatSurface({
     chatStore.deleteSession(id);
   }
 
+  // Right-click a chat tab → context menu (ADR 0036). The DS TabBar exposes no per-tab
+  // context-menu hook, so we delegate from the tab-bar wrapper and map the clicked tab to its
+  // session by sibling index (DOM order tracks the `items` = sessions order). Close reuses the
+  // confirm dialog; Rename fires the TabBar's inline editor via a synthetic dblclick on the tab.
+  function onTabBarContextMenu(e: ReactMouseEvent) {
+    const tabEl = (e.target as HTMLElement).closest(".pl-tabbar__tab") as HTMLElement | null;
+    if (!tabEl) {
+      openContextMenu("chat-tab", e, { onNew: () => chatStore.createSession() });
+      return;
+    }
+    const tabs = Array.from((e.currentTarget as HTMLElement).querySelectorAll(".pl-tabbar__tab"));
+    const session = chat.sessions[tabs.indexOf(tabEl)];
+    if (!session) return;
+    openContextMenu("chat-tab", e, {
+      sessionId: session.id,
+      onNew: () => chatStore.createSession(),
+      onRename: () => tabEl.dispatchEvent(new MouseEvent("dblclick", { bubbles: true })),
+      onClose: () => setPendingClose(session.id),
+    });
+  }
+
   return (
     <section className="panel stage-panel chat-stage" style={active ? undefined : { display: "none" }} aria-hidden={!active}>
       {/* DS TabBar (#832): a tab per session (status dot · title · close) + "+".
@@ -143,25 +166,27 @@ export function ChatSurface({
           `responsive` collapses to a DS-native <select> + add in a narrow panel
           (container query). The status dot rides the `icon` slot — wide-strip only:
           the collapsed <option> can't host markup, matching the old behavior. */}
-      <TabBar
-        ariaLabel="Chat sessions"
-        responsive
-        activeId={chat.currentSessionId ?? ""}
-        items={chat.sessions.map((session) => {
-          const status = chat.sessionStatusMap[session.id] || "idle";
-          return {
-            id: session.id,
-            label: session.title,
-            icon: <span className={`session-dot ${status}`} title={status} />,
-          };
-        })}
-        onSelect={(id) => chatStore.switchSession(id)}
-        onClose={(id) => setPendingClose(id)}
-        onRename={(id, label) => chatStore.renameSession(id, label)}
-        onReorder={(next) => chatStore.reorderSessions(next.map((t) => t.id))}
-        onAdd={() => chatStore.createSession()}
-        addLabel="New chat"
-      />
+      <div className="chat-tabbar-wrap" onContextMenu={onTabBarContextMenu}>
+        <TabBar
+          ariaLabel="Chat sessions"
+          responsive
+          activeId={chat.currentSessionId ?? ""}
+          items={chat.sessions.map((session) => {
+            const status = chat.sessionStatusMap[session.id] || "idle";
+            return {
+              id: session.id,
+              label: session.title,
+              icon: <span className={`session-dot ${status}`} title={status} />,
+            };
+          })}
+          onSelect={(id) => chatStore.switchSession(id)}
+          onClose={(id) => setPendingClose(id)}
+          onRename={(id, label) => chatStore.renameSession(id, label)}
+          onReorder={(next) => chatStore.reorderSessions(next.map((t) => t.id))}
+          onAdd={() => chatStore.createSession()}
+          addLabel="New chat"
+        />
+      </div>
 
       <div className="chat-session-pool">
         {chat.activeSessions.map((sessionId) => (

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -28,6 +28,12 @@
   min-height: 0;
 }
 
+/* The tab-bar wrapper exists only to scope the right-click context menu (ADR 0036) to the
+   tab strip — it generates no box, so the DS TabBar stays the flex child it was. */
+.chat-tabbar-wrap {
+  display: contents;
+}
+
 .chat-session-slot {
   height: 100%;
   display: grid;

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -1,4 +1,4 @@
-import { ArrowLeftRight, ChevronDown, ChevronUp, Eye, EyeOff, SlidersHorizontal } from "lucide-react";
+import { ArrowLeftRight, ChevronDown, ChevronUp, Eye, EyeOff, Pencil, Plus, SlidersHorizontal, X } from "lucide-react";
 
 import { openView } from "../app/usePaletteRegistry";
 import { useUI } from "../state/uiStore";
@@ -115,5 +115,50 @@ registerContextMenu({
         }),
       ),
     ];
+  },
+});
+
+// Right-click a plugin's util-bar widget (a bottom-left pill) → Configure its plugin (ADR
+// 0036/0059), mirroring the rail-icon Configure. The App-side trigger resolves the owning
+// plugin's id/name from the `plugin:<id>:<view>` widget key into `ctx`.
+registerContextMenu({
+  type: "util-widget",
+  items: (ctx: { pluginId?: string; pluginName?: string }): MenuEntry[] => {
+    if (!ctx?.pluginId) return [];
+    const pid = ctx.pluginId;
+    const pname = ctx.pluginName ?? ctx.pluginId;
+    return [
+      {
+        id: "configure",
+        label: "Configure…",
+        icon: <SlidersHorizontal size={14} />,
+        run: () => useUI.getState().openPluginConfig(pid, pname),
+      },
+    ];
+  },
+});
+
+// Right-click a chat session tab → New chat / Rename / Close (ADR 0036). ChatSurface owns the
+// behavior and passes it in `ctx` as closures: Close reuses its confirm-dialog flow, Rename
+// triggers the DS TabBar's inline editor (a synthetic dblclick on the tab). Right-clicking empty
+// tab-bar space carries only `onNew`. (The DS TabBar exposes no per-tab context-menu hook — a
+// DS gap noted for contribute-back; ChatSurface delegates from the tab-bar wrapper meanwhile.)
+registerContextMenu({
+  type: "chat-tab",
+  items: (ctx: {
+    sessionId?: string;
+    onNew?: () => void;
+    onRename?: () => void;
+    onClose?: () => void;
+  }): MenuEntry[] => {
+    const out: MenuEntry[] = [
+      { id: "new", label: "New chat", icon: <Plus size={14} />, run: () => ctx?.onNew?.() },
+    ];
+    if (ctx?.sessionId) {
+      out.push({ id: "rename", label: "Rename", icon: <Pencil size={14} />, run: () => ctx.onRename?.() });
+      out.push({ id: "tab-div", divider: true });
+      out.push({ id: "close", label: "Close chat", icon: <X size={14} />, danger: true, run: () => ctx.onClose?.() });
+    }
+    return out;
   },
 });

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -92,13 +92,13 @@ registerContextMenu({
 });
 
 // Right-click the EMPTY rail background (not an icon) → the "Hidden views" menu: one entry per
-// hidden surface (railOrder.hidden), restoring it via openView (un-hide → route to its dock). The
-// App-side trigger resolves each hidden id's label (core/plugin/ext metadata lives there) into
-// `ctx.hidden`. When nothing is hidden, a disabled hint shows so the menu still confirms the
-// feature. This is the discoverable counterpart to ⌘K for un-hiding (ADR 0035/0036).
+// hidden surface (railOrder.hidden), each restored onto the dock whose background was clicked
+// (`ctx.side`) and then opened. The App-side trigger resolves each hidden id's label (core/plugin/
+// ext metadata lives there) + the clicked side into `ctx`. When nothing is hidden, a disabled hint
+// shows so the menu still confirms the feature. The discoverable counterpart to ⌘K (ADR 0035/0036).
 registerContextMenu({
   type: "rail-background",
-  items: (ctx: { hidden?: { id: string; label: string }[] }): MenuEntry[] => {
+  items: (ctx: { side?: "left" | "right" | "bottom"; hidden?: { id: string; label: string }[] }): MenuEntry[] => {
     const hidden = ctx?.hidden ?? [];
     if (!hidden.length) {
       return [{ id: "none", label: "No hidden views", disabled: true, run: () => {} }];
@@ -111,7 +111,11 @@ registerContextMenu({
           id: `show-${h.id}`,
           label: h.label,
           icon: <Eye size={14} />,
-          run: () => openView(h.id),
+          // Restore to the dock the menu was opened on, then open it there.
+          run: () => {
+            useUI.getState().showSurface(h.id, ctx?.side);
+            openView(h.id);
+          },
         }),
       ),
     ];

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -1,15 +1,22 @@
-import { ArrowLeftRight, ChevronDown, ChevronUp } from "lucide-react";
+import { ArrowLeftRight, ChevronDown, ChevronUp, EyeOff, SlidersHorizontal } from "lucide-react";
 
 import { useUI } from "../state/uiStore";
 import { registerContextMenu } from "./registry";
 import type { MenuEntry } from "./types";
 
 // First customer (ADR 0036 D6 / ADR 0035 D2): right-click a rail icon → reorder it within its
-// rail (Move up/down) and move it to another dock (append to the end). Chat is movable across all
-// three docks like any other surface; plugin views follow their manifest placement (no items yet).
+// rail (Move up/down), move it to another dock, Configure the owning plugin, or Hide it from the
+// rails (without disabling the plugin). Chat is movable across all three docks like any other
+// surface; plugin views carry their owning plugin's id/name in `ctx` (resolved by the App-side
+// trigger) so Configure can open that plugin's settings dialog.
 registerContextMenu({
   type: "rail-surface",
-  items: (ctx: { id: string; side: "left" | "right" | "bottom" }): MenuEntry[] => {
+  items: (ctx: {
+    id: string;
+    side: "left" | "right" | "bottom";
+    pluginId?: string;
+    pluginName?: string;
+  }): MenuEntry[] => {
     if (!ctx) return [];
     const ui = useUI.getState();
     const list = ui.railOrder[ctx.side] ?? [];
@@ -29,6 +36,29 @@ registerContextMenu({
       { side: "right", label: "Move to right rail" },
       { side: "bottom", label: "Move to bottom dock" },
     ];
+    // Management actions, gathered so the divider only shows when at least one applies:
+    // Configure (plugin views only) opens the owning plugin's settings dialog; Hide moves the
+    // surface to railOrder.hidden (restore from ⌘K or "Move to …"). Chat is never hidden — it
+    // mounts unconditionally on its dock, so a hidden chat would render with no rail icon.
+    const manage: MenuEntry[] = [];
+    if (ctx.pluginId) {
+      const pid = ctx.pluginId;
+      const pname = ctx.pluginName ?? ctx.pluginId;
+      manage.push({
+        id: "configure",
+        label: "Configure…",
+        icon: <SlidersHorizontal size={14} />,
+        run: () => useUI.getState().openPluginConfig(pid, pname),
+      });
+    }
+    if (ctx.id !== "chat") {
+      manage.push({
+        id: "hide",
+        label: "Hide",
+        icon: <EyeOff size={14} />,
+        run: () => useUI.getState().hideSurface(ctx.id),
+      });
+    }
     // Any surface — core, plugin, or chat — reorders within its dock and moves across, including
     // chat to the bottom dock (its slot mounts unconditionally there too). Moving chat across docks
     // remounts it: a brief blip on an in-flight stream; a deliberate action.
@@ -55,6 +85,7 @@ registerContextMenu({
           icon: <ArrowLeftRight size={14} />,
           run: () => moveTo(d.side),
         })),
+      ...(manage.length ? [{ id: "manage-div", divider: true } as MenuEntry, ...manage] : []),
     ];
   },
 });

--- a/apps/web/src/contextMenu/registrations.tsx
+++ b/apps/web/src/contextMenu/registrations.tsx
@@ -1,5 +1,6 @@
-import { ArrowLeftRight, ChevronDown, ChevronUp, EyeOff, SlidersHorizontal } from "lucide-react";
+import { ArrowLeftRight, ChevronDown, ChevronUp, Eye, EyeOff, SlidersHorizontal } from "lucide-react";
 
+import { openView } from "../app/usePaletteRegistry";
 import { useUI } from "../state/uiStore";
 import { registerContextMenu } from "./registry";
 import type { MenuEntry } from "./types";
@@ -86,6 +87,33 @@ registerContextMenu({
           run: () => moveTo(d.side),
         })),
       ...(manage.length ? [{ id: "manage-div", divider: true } as MenuEntry, ...manage] : []),
+    ];
+  },
+});
+
+// Right-click the EMPTY rail background (not an icon) → the "Hidden views" menu: one entry per
+// hidden surface (railOrder.hidden), restoring it via openView (un-hide → route to its dock). The
+// App-side trigger resolves each hidden id's label (core/plugin/ext metadata lives there) into
+// `ctx.hidden`. When nothing is hidden, a disabled hint shows so the menu still confirms the
+// feature. This is the discoverable counterpart to ⌘K for un-hiding (ADR 0035/0036).
+registerContextMenu({
+  type: "rail-background",
+  items: (ctx: { hidden?: { id: string; label: string }[] }): MenuEntry[] => {
+    const hidden = ctx?.hidden ?? [];
+    if (!hidden.length) {
+      return [{ id: "none", label: "No hidden views", disabled: true, run: () => {} }];
+    }
+    return [
+      { id: "hidden-header", label: "Show hidden view", disabled: true, run: () => {} },
+      { id: "hidden-div", divider: true },
+      ...hidden.map(
+        (h): MenuEntry => ({
+          id: `show-${h.id}`,
+          label: h.label,
+          icon: <Eye size={14} />,
+          run: () => openView(h.id),
+        }),
+      ),
     ];
   },
 });

--- a/apps/web/src/contextMenu/types.ts
+++ b/apps/web/src/contextMenu/types.ts
@@ -1,7 +1,15 @@
 import type { ReactNode } from "react";
 
 // ADR 0036 — what was right-clicked. Open string so plugins can define their own types.
-export type ContextType = "rail-surface" | "chat-message" | "note" | "bead" | "background" | (string & {});
+// `rail-background` = empty rail space (not an icon) → the "Hidden views" restore menu.
+export type ContextType =
+  | "rail-surface"
+  | "rail-background"
+  | "chat-message"
+  | "note"
+  | "bead"
+  | "background"
+  | (string & {});
 
 export interface MenuHelpers { close: () => void; }
 

--- a/apps/web/src/contextMenu/types.ts
+++ b/apps/web/src/contextMenu/types.ts
@@ -2,9 +2,12 @@ import type { ReactNode } from "react";
 
 // ADR 0036 — what was right-clicked. Open string so plugins can define their own types.
 // `rail-background` = empty rail space (not an icon) → the "Hidden views" restore menu.
+// `util-widget` = a plugin's util-bar pill → Configure. `chat-tab` = a chat session tab.
 export type ContextType =
   | "rail-surface"
   | "rail-background"
+  | "util-widget"
+  | "chat-tab"
   | "chat-message"
   | "note"
   | "bead"

--- a/apps/web/src/state/uiStore.test.ts
+++ b/apps/web/src/state/uiStore.test.ts
@@ -142,8 +142,8 @@ describe("migrateUiState", () => {
 // set would prune every persisted entry and the reload would re-seed by manifest —
 // the layout-wipe bug this contract pins down.)
 describe("reconcilePluginViews", () => {
-  const seed = (left: string[], right: string[], bottom: string[] = []) =>
-    useUI.setState({ railOrder: { left, right, bottom } });
+  const seed = (left: string[], right: string[], bottom: string[] = [], hidden: string[] = []) =>
+    useUI.setState({ railOrder: { left, right, bottom, hidden } });
 
   beforeEach(() => seed(["chat", "plugin:doom:panel"], ["tasks", "plugin:board:board", "notes"]));
 
@@ -194,22 +194,111 @@ describe("reconcileCoreSurfaces", () => {
   const CORE = ["chat", "work", "knowledge"];
 
   it("re-adds a CORE surface missing from a persisted railOrder to its default dock", () => {
-    useUI.setState({ railOrder: { left: ["chat", "plugins"], right: ["work"], bottom: [] } });
+    useUI.setState({ railOrder: { left: ["chat", "plugins"], right: ["work"], bottom: [], hidden: [] } });
     useUI.getState().reconcileCoreSurfaces(CORE);
     expect(useUI.getState().railOrder.left).toContain("knowledge"); // restored on its default (left)
   });
 
   it("is a no-op (same ref, no write) when every core surface is already placed", () => {
-    useUI.setState({ railOrder: { left: ["chat", "knowledge"], right: ["work"], bottom: [] } });
+    useUI.setState({ railOrder: { left: ["chat", "knowledge"], right: ["work"], bottom: [], hidden: [] } });
     const before = useUI.getState().railOrder;
     useUI.getState().reconcileCoreSurfaces(CORE);
     expect(useUI.getState().railOrder).toBe(before);
   });
 
   it("respects a surface the operator moved to another dock — no duplicate", () => {
-    useUI.setState({ railOrder: { left: ["chat"], right: ["work", "knowledge"], bottom: [] } });
+    useUI.setState({ railOrder: { left: ["chat"], right: ["work", "knowledge"], bottom: [], hidden: [] } });
     useUI.getState().reconcileCoreSurfaces(CORE);
     expect(useUI.getState().railOrder.left).not.toContain("knowledge");
     expect(useUI.getState().railOrder.right).toContain("knowledge"); // left where the operator put it
+  });
+
+  it("does NOT re-add a core surface the operator hid (hidden counts as placed)", () => {
+    useUI.setState({ railOrder: { left: ["chat"], right: ["work"], bottom: [], hidden: ["knowledge"] } });
+    useUI.getState().reconcileCoreSurfaces(CORE);
+    expect(useUI.getState().railOrder.left).not.toContain("knowledge");
+    expect(useUI.getState().railOrder.hidden).toEqual(["knowledge"]); // stays hidden, not resurrected
+  });
+});
+
+// hideSurface / showSurface — the "hidden but enabled" bucket (ADR 0035/0036). A surface is on
+// exactly one dock OR in `hidden`; hiding removes its rail icon without disabling the plugin, and
+// showing restores it (to its core default dock, else left). The reconcilers respect `hidden` so a
+// reload never resurrects a hidden view; uninstalling the plugin prunes it from `hidden`.
+describe("hideSurface / showSurface", () => {
+  const seed = (left: string[], right: string[], bottom: string[] = [], hidden: string[] = []) =>
+    useUI.setState({ railOrder: { left, right, bottom, hidden } });
+
+  it("hides a surface off its dock into the hidden bucket", () => {
+    seed(["chat", "knowledge"], ["work"]);
+    useUI.getState().hideSurface("knowledge");
+    expect(useUI.getState().railOrder.left).toEqual(["chat"]);
+    expect(useUI.getState().railOrder.hidden).toEqual(["knowledge"]);
+  });
+
+  it("hiding is idempotent — re-hiding a hidden id is a no-op (same ref)", () => {
+    seed(["chat"], ["work"], [], ["knowledge"]);
+    const before = useUI.getState().railOrder;
+    useUI.getState().hideSurface("knowledge");
+    expect(useUI.getState().railOrder).toBe(before);
+  });
+
+  it("shows a hidden core surface back on its default dock", () => {
+    seed(["chat"], [], [], ["work", "knowledge"]);
+    useUI.getState().showSurface("work"); // work's core default is the right dock
+    expect(useUI.getState().railOrder.right).toContain("work");
+    expect(useUI.getState().railOrder.hidden).toEqual(["knowledge"]);
+  });
+
+  it("shows a hidden plugin view on the left rail by default (no known dock)", () => {
+    seed(["chat"], ["work"], [], ["plugin:board:board"]);
+    useUI.getState().showSurface("plugin:board:board");
+    expect(useUI.getState().railOrder.left).toContain("plugin:board:board");
+    expect(useUI.getState().railOrder.hidden).toEqual([]);
+  });
+
+  it("shows onto an explicit dock when asked", () => {
+    seed(["chat"], ["work"], [], ["plugin:board:board"]);
+    useUI.getState().showSurface("plugin:board:board", "right");
+    expect(useUI.getState().railOrder.right).toEqual(["work", "plugin:board:board"]);
+  });
+
+  it("moveSurface un-hides (move doubles as restore)", () => {
+    seed(["chat"], ["work"], [], ["plugin:board:board"]);
+    useUI.getState().moveSurface("plugin:board:board", "bottom");
+    expect(useUI.getState().railOrder.hidden).toEqual([]);
+    expect(useUI.getState().railOrder.bottom).toEqual(["plugin:board:board"]);
+  });
+
+  it("reconcilePluginViews keeps a hidden view hidden and never re-docks it", () => {
+    seed(["chat"], ["work"], [], ["plugin:board:board"]);
+    // board is still installed (declares its right placement) — but the operator hid it.
+    useUI.getState().reconcilePluginViews([{ id: "plugin:board:board", side: "right" }]);
+    expect(useUI.getState().railOrder.right).toEqual(["work"]); // NOT resurrected
+    expect(useUI.getState().railOrder.hidden).toEqual(["plugin:board:board"]);
+  });
+
+  it("reconcilePluginViews prunes a hidden view when its plugin is uninstalled", () => {
+    seed(["chat"], ["work"], [], ["plugin:board:board"]);
+    useUI.getState().reconcilePluginViews([]); // board gone from the loaded set
+    expect(useUI.getState().railOrder.hidden).toEqual([]);
+  });
+});
+
+// The v13 migration adds the `hidden` bucket to a persisted railOrder that predates it, so the
+// shape is complete (actions also fall back to [] defensively).
+describe("migrateUiState — v13 hidden bucket", () => {
+  it("adds an empty hidden array to a railOrder without one", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat", "knowledge"], right: ["work"], bottom: [] },
+    }) as { railOrder: { hidden: string[] } };
+    expect(out.railOrder.hidden).toEqual([]);
+  });
+
+  it("preserves an existing hidden array", () => {
+    const out = migrateUiState({
+      railOrder: { left: ["chat"], right: ["work"], bottom: [], hidden: ["knowledge"] },
+    }) as { railOrder: { hidden: string[] } };
+    expect(out.railOrder.hidden).toEqual(["knowledge"]);
   });
 });

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -68,6 +68,12 @@ type UIState = {
   globalSettingsSection?: string;
   openGlobalSettings: (section?: string) => void;
   closeGlobalSettings: () => void;
+  // Per-plugin Configure dialog (ADR 0059), opened from the plugin manager OR a rail
+  // context-menu "Configure…" (ADR 0036). EPHEMERAL — partialized out of persistence so a
+  // refresh never reopens it. App mounts one root `PluginSettingsDialog` driven by this.
+  configurePlugin?: { id: string; name: string };
+  openPluginConfig: (id: string, name: string) => void;
+  closePluginConfig: () => void;
   rightCollapsed: boolean;
   leftCollapsed: boolean;
   rightWidth: number;
@@ -76,11 +82,20 @@ type UIState = {
   // is pinned left (mounts unconditionally for streaming continuity) — never moved across rails.
   // Three docks now (DS AppShell bottom dock): left/right rails + the bottom dock (a
   // horizontal icon rail in the util bar + a full-width panel). A surface is on exactly
-  // one dock, at a position.
-  railOrder: { left: string[]; right: string[]; bottom: string[] };
-  moveSurface: (id: string, side: "left" | "right" | "bottom") => void; // splice out → append to the target dock
+  // one dock, at a position — OR in `hidden`. `hidden` holds surfaces the operator hid
+  // from the rails WITHOUT disabling the plugin: enabled-but-not-shown. railSurfaces()
+  // renders only the dock arrays, so a hidden id has no rail icon; restore it from ⌘K
+  // (openView un-hides) or by moving it to a dock. The reconcilers never resurrect a
+  // hidden id onto a dock (only prune it from `hidden` when the plugin is uninstalled).
+  railOrder: { left: string[]; right: string[]; bottom: string[]; hidden: string[] };
+  moveSurface: (id: string, side: "left" | "right" | "bottom") => void; // splice out (incl. hidden) → append to the target dock
   reorderSurface: (id: string, dir: -1 | 1) => void; // swap with the neighbour within its rail
-  setRailOrder: (next: { left: string[]; right: string[]; bottom: string[] }) => void; // DS AppShell DnD — whole new order
+  setRailOrder: (next: { left: string[]; right: string[]; bottom: string[] }) => void; // DS AppShell DnD — new dock order (hidden preserved)
+  // Hide a surface from the rails without disabling its plugin (move it to `hidden`); show
+  // it again on a dock (default: its core dock, else left). `showSurface` is a no-op-safe
+  // un-hide if the id is already on a dock. Chat is never hidden (it mounts unconditionally).
+  hideSurface: (id: string) => void;
+  showSurface: (id: string, side?: "left" | "right" | "bottom") => void;
   // Sync plugin views into railOrder (ADR 0036) — append newly-available ones to their placement
   // side, prune `plugin:` ids no longer present. Core surfaces are left untouched.
   reconcilePluginViews: (views: { id: string; side: "left" | "right" | "bottom" }[]) => void;
@@ -120,10 +135,11 @@ type UIState = {
 // `reconcileCoreSurfaces`, which re-adds a CORE surface to its default dock when a
 // persisted `railOrder` is missing it (see the action). Keep ids in sync with
 // CORE_SURFACES (apps/web/src/app/coreSurfaces.tsx).
-const DEFAULT_RAIL_ORDER: { left: string[]; right: string[]; bottom: string[] } = {
+const DEFAULT_RAIL_ORDER: { left: string[]; right: string[]; bottom: string[]; hidden: string[] } = {
   left: ["chat", "knowledge"],
   right: ["work"],
   bottom: [],
+  hidden: [],
 };
 const coreDefaultSide = (id: string): "left" | "right" | "bottom" | null =>
   DEFAULT_RAIL_ORDER.left.includes(id)
@@ -241,6 +257,16 @@ export function migrateUiState(persisted: unknown): unknown {
         (x) => x !== "activity" && x !== "plugins" && x !== "settings" && !FOLDED.has(x),
       );
     }
+    // v13 (hidden surfaces): railOrder gains a `hidden` bucket (enabled-but-not-shown
+    // surfaces). Complete the shape with [] for a layout that predates it. Runs LAST — the
+    // v2/v8/v10/v11/v12 steps rebuild railOrder as {left,right,bottom} and would drop a
+    // `hidden` added earlier — so reapply the ORIGINAL persisted hidden (read off the
+    // untouched input) here, making a re-run on an already-current state idempotent too.
+    const origHidden = (persisted as { railOrder?: { hidden?: unknown } }).railOrder?.hidden;
+    const roH = rest.railOrder as { left?: string[]; right?: string[]; bottom?: string[]; hidden?: string[] } | undefined;
+    if (roH) {
+      rest.railOrder = { ...roH, hidden: Array.isArray(origHidden) ? (origHidden as string[]) : [] };
+    }
     return rest;
   }
   return persisted;
@@ -259,19 +285,30 @@ export const useUI = create<UIState>()(
       globalSettingsSection: undefined,
       openGlobalSettings: (section) => set({ globalSettingsOpen: true, globalSettingsSection: section }),
       closeGlobalSettings: () => set({ globalSettingsOpen: false }),
+      configurePlugin: undefined,
+      openPluginConfig: (id, name) => set({ configurePlugin: { id, name } }),
+      closePluginConfig: () => set({ configurePlugin: undefined }),
       rightCollapsed: false,
       leftCollapsed: false,
       rightWidth: 360,
       bottomPanel: "",
       bottomHeight: 240,
       bottomCollapsed: false,
-      railOrder: { left: [...DEFAULT_RAIL_ORDER.left], right: [...DEFAULT_RAIL_ORDER.right], bottom: [...DEFAULT_RAIL_ORDER.bottom] },
+      railOrder: {
+        left: [...DEFAULT_RAIL_ORDER.left],
+        right: [...DEFAULT_RAIL_ORDER.right],
+        bottom: [...DEFAULT_RAIL_ORDER.bottom],
+        hidden: [...DEFAULT_RAIL_ORDER.hidden],
+      },
       moveSurface: (id, side) =>
         set((s) => {
+          // Moving to a dock also un-hides (splice from every bucket incl. hidden), so
+          // "Move to …" doubles as a restore for a hidden surface.
           const arrs = {
             left: s.railOrder.left.filter((x) => x !== id),
             right: s.railOrder.right.filter((x) => x !== id),
             bottom: s.railOrder.bottom.filter((x) => x !== id),
+            hidden: (s.railOrder.hidden ?? []).filter((x) => x !== id),
           };
           arrs[side].push(id); // append to the target dock's end
           return { railOrder: arrs };
@@ -286,9 +323,48 @@ export const useUI = create<UIState>()(
             [next[i], next[j]] = [next[j], next[i]];
             return next;
           };
-          return { railOrder: { left: swap(s.railOrder.left), right: swap(s.railOrder.right), bottom: swap(s.railOrder.bottom) } };
+          return {
+            railOrder: {
+              left: swap(s.railOrder.left),
+              right: swap(s.railOrder.right),
+              bottom: swap(s.railOrder.bottom),
+              hidden: s.railOrder.hidden ?? [],
+            },
+          };
         }),
-      setRailOrder: (railOrder) => set({ railOrder }),
+      // DS AppShell DnD reports the three DOCK orders only — preserve the `hidden` bucket.
+      setRailOrder: (next) => set((s) => ({ railOrder: { ...next, hidden: s.railOrder.hidden ?? [] } })),
+      hideSurface: (id) =>
+        set((s) => {
+          const hidden = s.railOrder.hidden ?? [];
+          if (hidden.includes(id)) return {}; // already hidden — no write
+          return {
+            railOrder: {
+              left: s.railOrder.left.filter((x) => x !== id),
+              right: s.railOrder.right.filter((x) => x !== id),
+              bottom: s.railOrder.bottom.filter((x) => x !== id),
+              hidden: [...hidden, id],
+            },
+          };
+        }),
+      showSurface: (id, side) =>
+        set((s) => {
+          const hidden = (s.railOrder.hidden ?? []).filter((x) => x !== id);
+          const placed = new Set([...s.railOrder.left, ...s.railOrder.right, ...s.railOrder.bottom]);
+          // Already on a dock — just clear it from hidden (defensive; shouldn't co-occur).
+          if (placed.has(id)) return { railOrder: { ...s.railOrder, hidden } };
+          // Restore to its core default dock when known (work→right), else the left rail.
+          // A plugin view has no known dock here, so it lands left; the operator can re-dock it.
+          const target = side ?? coreDefaultSide(id) ?? "left";
+          const arrs = {
+            left: [...s.railOrder.left],
+            right: [...s.railOrder.right],
+            bottom: [...s.railOrder.bottom],
+            hidden,
+          };
+          arrs[target].push(id);
+          return { railOrder: arrs };
+        }),
       mobileActive: "chat",
       setMobileActive: (mobileActive) => set({ mobileActive }),
       quickBar: ["chat", "knowledge", "plugins"],
@@ -302,18 +378,25 @@ export const useUI = create<UIState>()(
         set((s) => {
           const ids = new Set(views.map((v) => v.id));
           const keep = (arr: string[]) => arr.filter((x) => !x.startsWith("plugin:") || ids.has(x));
-          const arrs = { left: keep(s.railOrder.left), right: keep(s.railOrder.right), bottom: keep(s.railOrder.bottom) };
+          // `hidden` is reconciled too: prune uninstalled plugin views from it, but KEEP a
+          // hidden id so it stays enabled-but-not-shown across reloads.
+          const hidden = keep(s.railOrder.hidden ?? []);
+          const hiddenSet = new Set(hidden);
+          const arrs = { left: keep(s.railOrder.left), right: keep(s.railOrder.right), bottom: keep(s.railOrder.bottom), hidden };
           for (const v of views) {
+            if (hiddenSet.has(v.id)) continue; // operator hid it — don't resurrect onto a dock
             if (!arrs.left.includes(v.id) && !arrs.right.includes(v.id) && !arrs.bottom.includes(v.id)) arrs[v.side].push(v.id);
           }
           return { railOrder: arrs };
         }),
       reconcileCoreSurfaces: (ids) =>
         set((s) => {
-          const placed = new Set([...s.railOrder.left, ...s.railOrder.right, ...s.railOrder.bottom]);
+          // A hidden core surface counts as "placed" — don't re-add it to a dock.
+          const hidden = s.railOrder.hidden ?? [];
+          const placed = new Set([...s.railOrder.left, ...s.railOrder.right, ...s.railOrder.bottom, ...hidden]);
           const missing = ids.filter((id) => !placed.has(id) && coreDefaultSide(id));
           if (!missing.length) return {}; // whole already — avoid a needless state write
-          const arrs = { left: [...s.railOrder.left], right: [...s.railOrder.right], bottom: [...s.railOrder.bottom] };
+          const arrs = { left: [...s.railOrder.left], right: [...s.railOrder.right], bottom: [...s.railOrder.bottom], hidden };
           for (const id of missing) arrs[coreDefaultSide(id)!].push(id);
           return { railOrder: arrs };
         }),
@@ -351,11 +434,11 @@ export const useUI = create<UIState>()(
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)
       storage: _layoutStorage,
-      version: 12, // …v10 Plugins→Settings section · v11 Tasks+Goals+Schedule→Work hub · v12 Settings→utility pill (prune rail id)
+      version: 13, // …v11 Tasks+Goals+Schedule→Work hub · v12 Settings→utility pill · v13 railOrder.hidden bucket
       migrate: (persisted: unknown) => migrateUiState(persisted) as never,
-      // The Global settings overlay is ephemeral UI state — drop it from persistence so a
-      // refresh never reopens it (everything else persists as before).
-      partialize: ({ globalSettingsOpen: _o, globalSettingsSection: _s, ...rest }) => rest,
+      // Ephemeral overlay state — dropped from persistence so a refresh never reopens it
+      // (the Global settings overlay + the per-plugin Configure dialog).
+      partialize: ({ globalSettingsOpen: _o, globalSettingsSection: _s, configurePlugin: _c, ...rest }) => rest,
     },
   ),
 );

--- a/docs/adr/0036-context-menu-system.md
+++ b/docs/adr/0036-context-menu-system.md
@@ -95,9 +95,31 @@ is a later, lower-trust option for iframe plugins.
 3. **More core menus** — `chat-message`, `note`, `bead` (retire their ad-hoc buttons).
 4. *(optional)* manifest-declared static items for iframe/untrusted plugins.
 
+## Addendum (2026-06-26) — rail-surface management actions + the `hidden` bucket
+
+The `rail-surface` menu grew two management actions beyond move/reorder:
+
+- **Hide** — moves the surface into a new `railOrder.hidden` bucket (uiStore): a surface is now on
+  exactly one dock *or* hidden. "Hidden" = *enabled-but-not-shown* — it declutters the rails without
+  disabling the plugin (previously the only way to remove a plugin view from a rail). `railSurfaces()`
+  renders only the dock arrays, so a hidden id has no rail icon; its safety-net append counts
+  `hidden` as "placed" so it never re-adds one. Both reconcilers (`reconcilePluginViews`,
+  `reconcileCoreSurfaces`) treat `hidden` as placed, so a reload never resurrects a hidden surface;
+  `reconcilePluginViews` prunes a hidden id only when its plugin is uninstalled. **Chat is never
+  hidden** (it mounts unconditionally on its dock — a hidden chat would render with no rail icon).
+  Restore is via the command palette (ADR 0057): `openView()` un-hides before routing, so ⌘K → a
+  hidden view's name brings it back to a dock (its core default dock, else the left rail). Persist
+  migration **v13** adds the empty bucket to older layouts.
+- **Configure…** (plugin views only) — opens the owning plugin's settings dialog (ADR 0059). The
+  App-side `onRailContextMenu` resolves the owning plugin's id + name from the `plugin:<id>:<view>`
+  rail id and passes them in `ctx`; the action sets a store-driven `configurePlugin`, mounted once at
+  the app root — the same per-plugin dialog the Plugins manager uses, now reached from the rail.
+
 ## References
 
 - `rabbit-hole.io` context-menu module (`apps/rabbit-hole/app/context-menu/` — the registry +
   imperative-open pattern this adopts).
 - ADR 0034 (plugin UI as first-class React — the SDK that re-exports `registerContextMenu`, and
-  the trust gate it inherits), ADR 0035 (rail surfaces — the `rail-surface` menu is customer #1).
+  the trust gate it inherits), ADR 0035 (rail surfaces — the `rail-surface` menu is customer #1),
+  ADR 0057 (command palette — the restore point for hidden surfaces), ADR 0059 (the per-plugin
+  settings dialog that "Configure…" opens).

--- a/docs/adr/0036-context-menu-system.md
+++ b/docs/adr/0036-context-menu-system.md
@@ -112,10 +112,12 @@ The `rail-surface` menu grew two management actions beyond move/reorder:
   a dock (its core default dock, else the left rail). Persist migration **v13** adds the empty bucket
   to older layouts.
 - **Hidden-views menu on the rail background** (`rail-background` ContextType) — right-clicking empty
-  rail space (not an icon) lists the hidden surfaces, each restoring via `openView`. The DS `AppShell`
-  only fires `onRailContextMenu` on icons, so the App catches the rail-container right-click by event
-  delegation (`onContextMenu` on the shell wrapper, keyed off the stable `.pl-rail` / `.pl-rail__btn`
-  classnames) and resolves each hidden id's label before opening the menu.
+  rail space (not an icon) lists the hidden surfaces; selecting one restores it **onto the dock whose
+  background was clicked** (`showSurface(id, side)`) and opens it there — so it lands where you asked,
+  not its default dock. The DS `AppShell` only fires `onRailContextMenu` on icons, so the App catches
+  the rail-container right-click by event delegation (`onContextMenu` on the shell wrapper, keyed off
+  the stable `.pl-rail` / `.pl-rail__btn` classnames), derives the side from the rail's modifier
+  class, and resolves each hidden id's label before opening the menu.
 - **Util-bar widget menu** (`util-widget` ContextType) — right-clicking a plugin's util-bar pill
   offers **Configure…** (same per-plugin dialog as the rail). `UtilityWidget` gained an `onContextMenu`
   passthrough to its pill; the App resolves the plugin id/name from the widget's `plugin:<id>:<view>`

--- a/docs/adr/0036-context-menu-system.md
+++ b/docs/adr/0036-context-menu-system.md
@@ -115,9 +115,21 @@ The `rail-surface` menu grew two management actions beyond move/reorder:
   rail space (not an icon) lists the hidden surfaces, each restoring via `openView`. The DS `AppShell`
   only fires `onRailContextMenu` on icons, so the App catches the rail-container right-click by event
   delegation (`onContextMenu` on the shell wrapper, keyed off the stable `.pl-rail` / `.pl-rail__btn`
-  classnames) and resolves each hidden id's label before opening the menu. **DS gap to contribute
-  back:** `AppShell` should expose a rail-background context-menu hook so this needn't sniff DOM
-  classes.
+  classnames) and resolves each hidden id's label before opening the menu.
+- **Util-bar widget menu** (`util-widget` ContextType) — right-clicking a plugin's util-bar pill
+  offers **Configure…** (same per-plugin dialog as the rail). `UtilityWidget` gained an `onContextMenu`
+  passthrough to its pill; the App resolves the plugin id/name from the widget's `plugin:<id>:<view>`
+  key.
+- **Chat tab menu** (`chat-tab` ContextType) — right-clicking a chat session tab offers **New chat /
+  Rename / Close**. The DS `TabBar` exposes no per-tab context-menu hook, so `ChatSurface` delegates
+  from a (layout-transparent) tab-bar wrapper, maps the clicked `.pl-tabbar__tab` to its session by
+  sibling index (DOM order tracks the `items` = sessions order), and passes the behavior into the
+  menu as `ctx` closures — Close reuses the delete-confirm dialog; Rename fires the TabBar's inline
+  editor via a synthetic `dblclick`.
+
+**DS gaps to contribute back:** both `AppShell` (rail background) and `TabBar` (per-tab) should
+expose context-menu hooks so the console needn't delegate off DOM classnames / map by sibling
+index. Until then, the stable `pl-*` classnames are the contract.
 - **Configure…** (plugin views only) — opens the owning plugin's settings dialog (ADR 0059). The
   App-side `onRailContextMenu` resolves the owning plugin's id + name from the `plugin:<id>:<view>`
   rail id and passes them in `ctx`; the action sets a store-driven `configurePlugin`, mounted once at

--- a/docs/adr/0036-context-menu-system.md
+++ b/docs/adr/0036-context-menu-system.md
@@ -107,9 +107,17 @@ The `rail-surface` menu grew two management actions beyond move/reorder:
   `reconcileCoreSurfaces`) treat `hidden` as placed, so a reload never resurrects a hidden surface;
   `reconcilePluginViews` prunes a hidden id only when its plugin is uninstalled. **Chat is never
   hidden** (it mounts unconditionally on its dock — a hidden chat would render with no rail icon).
-  Restore is via the command palette (ADR 0057): `openView()` un-hides before routing, so ⌘K → a
-  hidden view's name brings it back to a dock (its core default dock, else the left rail). Persist
-  migration **v13** adds the empty bucket to older layouts.
+  Restore is via the command palette (ADR 0057) **or the new `rail-background` menu**: `openView()`
+  un-hides before routing, so ⌘K — or right-clicking empty rail space — brings a hidden view back to
+  a dock (its core default dock, else the left rail). Persist migration **v13** adds the empty bucket
+  to older layouts.
+- **Hidden-views menu on the rail background** (`rail-background` ContextType) — right-clicking empty
+  rail space (not an icon) lists the hidden surfaces, each restoring via `openView`. The DS `AppShell`
+  only fires `onRailContextMenu` on icons, so the App catches the rail-container right-click by event
+  delegation (`onContextMenu` on the shell wrapper, keyed off the stable `.pl-rail` / `.pl-rail__btn`
+  classnames) and resolves each hidden id's label before opening the menu. **DS gap to contribute
+  back:** `AppShell` should expose a rail-background context-menu hook so this needn't sniff DOM
+  classes.
 - **Configure…** (plugin views only) — opens the owning plugin's settings dialog (ADR 0059). The
   App-side `onRailContextMenu` resolves the owning plugin's id + name from the `plugin:<id>:<view>`
   rail id and passes them in `ctx`; the action sets a store-driven `configurePlugin`, mounted once at


### PR DESCRIPTION
**Draft / local-test gate** — console layout UX, so this is a draft for local review; do not auto-merge on green (CI can't judge the UX). Try it: `scripts/dev.sh` (:7871) → right-click a plugin's rail icon → **Hide** / **Configure…**, then ⌘K to restore a hidden view.

Iteration 1 of improving console management of plugins/visible views from the **rails + context menu** (ADR 0035/0036). Follows the plugin-system arc (GitHub extraction, ADR 0061 fork seams).

## The gap
A surface lived on **exactly one dock** (`railOrder:{left,right,bottom}`) — the only way to remove a plugin view from the rails was to disable the whole plugin. The `rail-surface` context menu only offered move/reorder.

## What this adds
- **`railOrder.hidden` bucket** — a surface is on one dock **or** hidden (enabled-but-not-shown). `hideSurface`/`showSurface`; every action and **both reconcilers** treat `hidden` as placed, so a reload never resurrects a hidden view and `reconcilePluginViews` prunes it only on uninstall. Persist migration **v13** (added last in `migrateUiState` — the v2/v8/v10/v11/v12 steps rebuild `railOrder` and would clobber an earlier-added bucket).
- **Hide** in the rail context menu — every surface except `chat` (it mounts unconditionally; a hidden chat would render with no icon).
- **Configure…** for plugin views — opens the owning plugin's settings dialog (ADR 0059), store-driven from a single root-mounted `PluginSettingsDialog`. `App.onRailContextMenu` resolves the plugin id/name from the `plugin:<id>:<view>` rail id.
- **Restore via ⌘K** — `openView()` un-hides before routing (the palette is the restore point; no new dialog this iteration).
- Fix: `railSurfaces()` now counts `hidden` as "placed" so its safety-net never re-appends a hidden plugin view (caught by e2e).

## Tests / docs
- `uiStore.test.ts`: hide/show, reconcile-respects-hidden, v13 migration.
- e2e: Hide persists across reload, Configure opens the dialog, core-surface Hide, Chat offers no Hide.
- Gates green: `tsc`, 155 unit, 133 e2e. CHANGELOG + ADR 0036 addendum.

## Deferred (next iterations)
Context menu on util-bar widgets / plugin-view headers / chat tabs; a central "Manage views" dialog (the other restore/visibility surface). Ext (`src/ext`) surfaces aren't in `railOrder`, so they currently get no context menu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added right-click menus for chat tabs, rail surfaces, hidden rail backgrounds, and plugin widgets.
  * Users can now hide/show views, create new chats, rename chats, close chats, and open plugin settings from menus.
  * Hidden views are now restored to the correct rail side and persist after reload.

* **Bug Fixes**
  * Improved rail behavior so hidden items stay hidden and don’t reappear unexpectedly.
  * Restoring a view now returns it to the correct dock placement.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->