### PR TITLE
feat(config): PROTOAGENT_SEED_CONFIG + Docker config-as-code deploy guide

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -142,6 +142,7 @@ export default defineConfig({
           collapsed: true,
           items: [
             { text: "Deploy via GHCR", link: "/guides/deploy" },
+            { text: "Deploy in Docker (seed + UI override)", link: "/guides/deploy-docker" },
             { text: "Releasing", link: "/guides/releasing" },
             { text: "Run multiple instances", link: "/guides/multi-instance" },
             { text: "Sandboxing & egress", link: "/guides/sandboxing" },

--- a/docs/guides/deploy-docker.md
+++ b/docs/guides/deploy-docker.md
@@ -1,0 +1,65 @@
+# Deploy in Docker (config-as-code: seed + UI override)
+
+Run protoAgent in a container so it boots **pre-configured** from a config baked into the image (the *seed*), while operators can still **override settings in the console** and have those edits **persist**. No setup wizard on a fresh instance, no force-overriding live edits.
+
+The copy-me reference is **[`examples/docker`](https://github.com/protoLabsAI/protoAgent/tree/main/examples/docker)**:
+
+```bash
+cp -r examples/docker my-agent && cd my-agent
+# edit langgraph-config.seed.yaml, then:
+export OPENAI_API_KEY=sk-... A2A_AUTH_TOKEN=$(openssl rand -hex 24)
+docker compose up -d --build
+```
+
+## The one trap to avoid
+
+The image declares `VOLUME /opt/protoagent/config`. That's deliberate — it persists wizard/console edits — but it means a config **volume** holds the live `langgraph-config.yaml`. So if you bake your config **as the live file** (`COPY my-config.yaml /opt/protoagent/config/langgraph-config.yaml`), the volume freezes your first-boot copy and **silently shadows every later image update**: enabling a plugin in a new image just… does nothing. Don't bake the live file.
+
+## The pattern
+
+**1. Bake your config as a *seed*, not the live file.** Put it on a plain (non-volume) path and point `PROTOAGENT_SEED_CONFIG` at it:
+
+```dockerfile
+FROM ghcr.io/protolabsai/protoagent:latest
+COPY langgraph-config.seed.yaml /opt/agent/seed/langgraph-config.yaml
+ENV PROTOAGENT_SEED_CONFIG=/opt/agent/seed/langgraph-config.yaml
+```
+
+On first boot, protoAgent copies the seed to the live `langgraph-config.yaml` and **never clobbers it afterward** (`ensure_live_config` is idempotent). Updating the seed in a new image re-seeds only a **fresh** instance — an existing one keeps its live config.
+
+**2. Persist the live config on a *named* volume** (not the image's anonymous one):
+
+```yaml
+volumes:
+  - agent-config:/opt/protoagent/config
+```
+
+Console/settings edits write here and survive reboots + image rolls.
+
+**3. Skip the wizard on a fresh instance** with `PROTOAGENT_HEADLESS_SETUP=1` — protoAgent validates the seed and auto-marks setup complete, so the instance comes up configured. Omit it if you'd rather complete setup interactively in the wizard.
+
+**4. Keep secrets in the env, not the seed.** The model key is read from `OPENAI_API_KEY`; the seed (and your image) carry no credentials. In the console the api-key field shows blank (`api_key_configured: false`) — that's expected, the key is env-sourced.
+
+## Binding & auth
+
+protoAgent refuses to bind `0.0.0.0` with an **open** operator API (`/api/*`, `/v1/*` include plugin-install + config rewrite). Pick one:
+
+- set `A2A_AUTH_TOKEN` and send it as `Authorization: Bearer <token>` (recommended);
+- bind `127.0.0.1` (single-host);
+- or, only behind a trusted network boundary, `PROTOAGENT_ALLOW_OPEN=1`.
+
+## Day-2
+
+| Want to… | Do |
+| --- | --- |
+| Change a setting | Edit it in the console — it persists on the config volume. |
+| Roll out a new image | `docker compose pull && docker compose up -d` — live config (your edits) is preserved. |
+| Re-seed from an updated seed | `docker compose down && docker volume rm <project>_agent-config && docker compose up -d`. |
+| Inspect the effective config | `GET /api/config` (or `/healthz` for `setup_complete`). |
+
+## Reference
+
+- `PROTOAGENT_SEED_CONFIG` — file to seed the live config from on first boot (config-as-code).
+- `PROTOAGENT_CONFIG_DIR` — where the live config + setup marker live (default `/opt/protoagent/config`).
+- `PROTOAGENT_HEADLESS_SETUP` — validate the seed + auto-complete setup (no wizard).
+- `PROTOAGENT_UI` — `console` (default) serves the operator console at `/app`.

--- a/examples/docker/Dockerfile
+++ b/examples/docker/Dockerfile
@@ -1,0 +1,17 @@
+# Reference: deploy protoAgent in Docker as config-as-code (seed + UI override).
+# Full walkthrough: docs/guides/deploy-docker.md
+FROM ghcr.io/protolabsai/protoagent:latest
+
+# Bake your agent's config as a SEED — NOT as the live /opt/protoagent/config/
+# langgraph-config.yaml. That path is a VOLUME; baking the live file there means a
+# config volume freezes your first-boot config and silently shadows every later
+# image update. Instead point PROTOAGENT_SEED_CONFIG at a plain (non-volume) path:
+# protoAgent's first-boot seeder copies it to the live config once, then leaves it
+# alone, so console edits persist on the volume and image rebuilds still re-seed a
+# FRESH instance.
+COPY langgraph-config.seed.yaml /opt/agent/seed/langgraph-config.yaml
+ENV PROTOAGENT_SEED_CONFIG=/opt/agent/seed/langgraph-config.yaml
+
+# (Add your plugins the same way bundle/fork images do, e.g.
+#   RUN git clone --depth 1 https://github.com/you/your-plugin /opt/protoagent/plugins/yours
+# and list it under plugins.enabled in the seed.)

--- a/examples/docker/README.md
+++ b/examples/docker/README.md
@@ -1,0 +1,31 @@
+# Docker deploy — config-as-code (seed + UI override)
+
+A reference for running protoAgent in a container where:
+
+- the agent boots **pre-configured** from a config baked into the image (the *seed*), and
+- operators can still **override settings in the console**, and those edits **persist**.
+
+It's the protoAgent-native flow — no force-overriding a live config, no setup wizard on a fresh instance.
+
+## Files
+
+| File | Role |
+| --- | --- |
+| `langgraph-config.seed.yaml` | Your agent's config — the **seed** (no secrets). |
+| `Dockerfile` | `FROM protoagent`, bakes the seed, sets `PROTOAGENT_SEED_CONFIG`. |
+| `docker-compose.yml` | Named config volume + `PROTOAGENT_HEADLESS_SETUP` + the model key / A2A token. |
+
+## Run
+
+```bash
+export OPENAI_API_KEY=sk-...        # your model/gateway key
+export A2A_AUTH_TOKEN=$(openssl rand -hex 24)
+docker compose up -d --build
+# console at http://localhost:7870/app  (paste A2A_AUTH_TOKEN to log in)
+```
+
+Edit a setting in the console → it persists. Reboot / `docker compose up -d` after an
+image rebuild → your edits survive. Want to start clean from an updated seed?
+`docker compose down && docker volume rm <project>_agent-config && docker compose up -d`.
+
+See **[docs/guides/deploy-docker.md](../../docs/guides/deploy-docker.md)** for the full explanation.

--- a/examples/docker/docker-compose.yml
+++ b/examples/docker/docker-compose.yml
@@ -1,0 +1,31 @@
+# Reference compose for a config-as-code protoAgent deploy (seed + UI override).
+# Walkthrough: docs/guides/deploy-docker.md
+services:
+  agent:
+    build: .                       # or: image: your-registry/your-agent:latest
+    container_name: my-agent
+    restart: unless-stopped
+    environment:
+      PROTOAGENT_UI: console
+      # Seed validates + auto-marks setup complete on boot, so a fresh instance comes
+      # up configured with NO setup wizard. (Omit to drive setup via the wizard.)
+      PROTOAGENT_HEADLESS_SETUP: "1"
+      # The model/gateway key — kept in the env, never in the seed/image.
+      OPENAI_API_KEY: ${OPENAI_API_KEY:?set your model/gateway key}
+      # protoAgent refuses to bind 0.0.0.0 with an OPEN operator API. Give A2A a token
+      # (then send it as `Authorization: Bearer`), or bind 127.0.0.1, or — only behind
+      # a trusted network boundary — set PROTOAGENT_ALLOW_OPEN=1.
+      A2A_AUTH_TOKEN: ${A2A_AUTH_TOKEN:?set an operator token}
+    ports:
+      - "7870:7870"
+    volumes:
+      # NAMED config volume: protoAgent seeds the live config here on first boot, then
+      # console edits persist across reboots + image rolls. Re-seed = remove it
+      # (`docker volume rm <project>_agent-config`). Do NOT rely on the image's
+      # anonymous VOLUME — it silently shadows config.
+      - agent-config:/opt/protoagent/config
+      - agent-sandbox:/sandbox
+
+volumes:
+  agent-config:
+  agent-sandbox:

--- a/examples/docker/langgraph-config.seed.yaml
+++ b/examples/docker/langgraph-config.seed.yaml
@@ -1,0 +1,18 @@
+# Seed config (config-as-code). protoAgent copies this to the live
+# langgraph-config.yaml on FIRST boot only (via PROTOAGENT_SEED_CONFIG), then never
+# clobbers it — operators override settings in the console and those edits persist
+# on the config volume. Updating this seed only affects a FRESH instance (or one
+# whose config volume you've cleared); existing instances keep their live config.
+#
+# Secrets do NOT go here — the api_key is read from the OPENAI_API_KEY env, so this
+# file (and your image) carries no credentials.
+identity:
+  name: my-agent
+
+model:
+  provider: openai
+  name: gpt-4o-mini
+  api_base: https://api.openai.com/v1   # OPENAI_API_KEY supplies the key (env)
+
+plugins:
+  enabled: []   # e.g. [notes, docs] — bundled plugins, or ones you've installed

--- a/graph/config_io.py
+++ b/graph/config_io.py
@@ -215,8 +215,14 @@ def ensure_live_config() -> bool:
     """Seed the live config on first run. Returns True only when it created the file.
 
     The live ``langgraph-config.yaml`` is untracked, so a fresh clone / new container
-    volume / **new instance** won't have one. Seed source:
+    volume / **new instance** won't have one. Seed source, in precedence order:
 
+    - ``PROTOAGENT_SEED_CONFIG`` — an explicit baked config file. A container/fleet
+      deploy points at it so a fresh instance comes up **pre-configured** (then
+      console edits override it, persisted on the config volume). This is the
+      config-as-code seed: bake your config into the image, point this env at it, and
+      you never hand-bake the live ``langgraph-config.yaml`` (which a config volume
+      would then freeze + shadow on later image updates).
     - An **instance-scoped** path (PROTOAGENT_INSTANCE set) inherits the unscoped *base*
       config + secrets + setup-marker when they exist — so `--instance foo` boots from
       the default's setup, then diverges on its own saves (graceful, no re-setup).
@@ -234,7 +240,19 @@ def ensure_live_config() -> bool:
     # fleet member's explicit dir is its own base, so it seeds from the template, not
     # a self-copy.
     scoped = CONFIG_YAML_PATH != _BASE_CONFIG_YAML
-    source = _BASE_CONFIG_YAML if (scoped and _BASE_CONFIG_YAML.exists()) else CONFIG_EXAMPLE_PATH
+    # An explicit baked seed (PROTOAGENT_SEED_CONFIG) wins over the scoped-base /
+    # .example fallbacks. Missing/blank env → unchanged behaviour.
+    seed_override = os.environ.get("PROTOAGENT_SEED_CONFIG", "").strip()
+    seed_path = Path(seed_override).expanduser() if seed_override else None
+    if seed_path is not None and seed_path.is_file():
+        source = seed_path
+    else:
+        if seed_override:
+            log.warning(
+                "[config] PROTOAGENT_SEED_CONFIG=%r is not a readable file — "
+                "seeding from the default template instead", seed_override
+            )
+        source = _BASE_CONFIG_YAML if (scoped and _BASE_CONFIG_YAML.exists()) else CONFIG_EXAMPLE_PATH
     if not source.exists():
         return False
 

--- a/plugins/docs/nav.json
+++ b/plugins/docs/nav.json
@@ -176,6 +176,10 @@
           "title": "Deploy via GHCR"
         },
         {
+          "path": "guides/deploy-docker.md",
+          "title": "Deploy in Docker (seed + UI override)"
+        },
+        {
           "path": "guides/releasing.md",
           "title": "Releasing"
         },

--- a/tests/test_config_io.py
+++ b/tests/test_config_io.py
@@ -274,6 +274,41 @@ def test_ensure_live_config_noop_without_example(monkeypatch, tmp_path: Path) ->
     assert not (tmp_path / "langgraph-config.yaml").exists()
 
 
+def test_ensure_live_config_seeds_from_seed_config_env(monkeypatch, tmp_path: Path) -> None:
+    # PROTOAGENT_SEED_CONFIG (a baked config-as-code seed) wins over the .example.
+    from graph import config_io
+
+    example = tmp_path / "langgraph-config.example.yaml"
+    seed = tmp_path / "my-seed.yaml"
+    live = tmp_path / "langgraph-config.yaml"
+    example.write_text("model:\n  name: from-template\n")
+    seed.write_text("model:\n  name: from-seed\n")
+    monkeypatch.setattr(config_io, "CONFIG_EXAMPLE_PATH", example)
+    monkeypatch.setattr(config_io, "CONFIG_YAML_PATH", live)
+    monkeypatch.setattr(config_io, "_BASE_CONFIG_YAML", live)
+    monkeypatch.setenv("PROTOAGENT_SEED_CONFIG", str(seed))
+
+    assert config_io.ensure_live_config() is True
+    assert "from-seed" in live.read_text()  # seeded from the env file, not the template
+
+
+def test_seed_config_env_missing_falls_back_to_example(monkeypatch, tmp_path: Path) -> None:
+    # A misconfigured PROTOAGENT_SEED_CONFIG (nonexistent file) degrades to the
+    # .example template rather than failing the boot.
+    from graph import config_io
+
+    example = tmp_path / "langgraph-config.example.yaml"
+    live = tmp_path / "langgraph-config.yaml"
+    example.write_text("model:\n  name: from-template\n")
+    monkeypatch.setattr(config_io, "CONFIG_EXAMPLE_PATH", example)
+    monkeypatch.setattr(config_io, "CONFIG_YAML_PATH", live)
+    monkeypatch.setattr(config_io, "_BASE_CONFIG_YAML", live)
+    monkeypatch.setenv("PROTOAGENT_SEED_CONFIG", str(tmp_path / "does-not-exist.yaml"))
+
+    assert config_io.ensure_live_config() is True
+    assert "from-template" in live.read_text()
+
+
 # ── SOUL.md dual-path ────────────────────────────────────────────────────────
 
 


### PR DESCRIPTION
Makes **config-as-code Docker deploys** a first-class, documented path: seed a fresh instance from a config baked into the image, let operators override in the console, and have those edits persist.

## Why
The image declares `VOLUME /opt/protoagent/config`. If you bake the **live** `langgraph-config.yaml` there, a config volume freezes your first-boot config and **silently shadows every later image update** (enable a plugin in a new image → nothing happens). The only way around it was an undocumented `.example`-rename trick. (Hit in anger deploying the `jon` agent.)

## What
- **`PROTOAGENT_SEED_CONFIG`** (`graph/config_io.ensure_live_config`): point it at a baked seed file; it's copied to the live config on first boot (highest precedence over scoped-base / `.example`), then **never clobbered** — console edits persist on the volume. Unset/blank → unchanged behaviour; set-but-missing → warns + falls back to the template.
- **`examples/docker/`** — copy-me reference: `FROM protoagent` + baked seed + `PROTOAGENT_SEED_CONFIG`, a **named** config volume (not the anonymous one), `PROTOAGENT_HEADLESS_SETUP` for a no-wizard boot, and an `A2A_AUTH_TOKEN` for the open-bind guard.
- **`docs/guides/deploy-docker.md`** (added to the *Operate & deploy* sidebar) — the pattern, the VOLUME trap, secrets-in-env, binding/auth, and day-2 (roll a new image / re-seed).

## Tests
`test_ensure_live_config_seeds_from_seed_config_env`, `test_seed_config_env_missing_falls_back_to_example`; full `config_io` suite green (49). ruff clean.

Backwards-compatible — no behaviour change unless `PROTOAGENT_SEED_CONFIG` is set.

🤖 Generated with [Claude Code](https://claude.com/claude-code)