### PR TITLE
feat(web): Shift+click a chat tab's ✕ to quick-delete (no confirm, no harvest)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- **Quick-delete a chat tab** — **Shift+click** a tab's ✕ to delete it with no confirmation dialog
+  and no knowledge harvest; while Shift is held the ✕ shows as a red trashcan to signal it. Plain
+  click keeps the confirm dialog.
 - **Hide a rail surface without disabling its plugin** (ADR 0035/0036) — `railOrder` gains a
   `hidden` bucket: a surface is on exactly one dock *or* hidden (enabled-but-not-shown). Right-click
   a rail icon → **Hide** to declutter the rails without disabling the plugin; restore it from ⌘K,

--- a/apps/web/e2e/chat-quick-delete.spec.ts
+++ b/apps/web/e2e/chat-quick-delete.spec.ts
@@ -1,0 +1,28 @@
+import { expect, test } from "@playwright/test";
+
+// Shift+click a chat tab's ✕ → quick-delete: no confirm dialog, no knowledge harvest.
+// (Plain click keeps the confirm dialog.)
+
+test("Shift+click a tab's ✕ deletes it with no confirm dialog", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-tabbar__add:visible").click(); // a 2nd tab so the surface stays put
+  const tabs = page.locator(".pl-tabbar__tab");
+  await expect(tabs).toHaveCount(2);
+
+  await tabs.first().locator(".pl-tabbar__close").click({ modifiers: ["Shift"] });
+
+  await expect(tabs).toHaveCount(1); // gone immediately
+  await expect(page.getByRole("dialog", { name: /Delete this chat/i })).toHaveCount(0); // no confirm
+});
+
+test("plain click a tab's ✕ still opens the confirm dialog", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-tabbar__add:visible").click();
+  const tabs = page.locator(".pl-tabbar__tab");
+  await expect(tabs).toHaveCount(2);
+
+  await tabs.first().locator(".pl-tabbar__close").click();
+
+  await expect(page.getByRole("dialog", { name: /Delete this chat/i })).toBeVisible();
+  await expect(tabs).toHaveCount(2); // not deleted until confirmed
+});

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -138,6 +138,38 @@ export function ChatSurface({
     chatStore.deleteSession(id);
   }
 
+  // Quick-delete: Shift+click a tab's ✕ → delete with NO confirm dialog and NO harvest.
+  // While Shift is held the ✕ shows as a red trashcan (the `--del` class → CSS) to signal it.
+  const [shiftDel, setShiftDel] = useState(false);
+  useEffect(() => {
+    const sync = (e: KeyboardEvent) => setShiftDel(e.shiftKey);
+    const clear = () => setShiftDel(false);
+    window.addEventListener("keydown", sync);
+    window.addEventListener("keyup", sync);
+    window.addEventListener("blur", clear);
+    return () => {
+      window.removeEventListener("keydown", sync);
+      window.removeEventListener("keyup", sync);
+      window.removeEventListener("blur", clear);
+    };
+  }, []);
+  // The DS TabBar's onClose always opens the confirm dialog, so intercept the close-button
+  // click in the CAPTURE phase (before the DS button's own onClick) when Shift is down and
+  // delete directly. Maps the clicked ✕ to its session by sibling index (DOM = sessions order).
+  function onTabBarClickCapture(e: ReactMouseEvent) {
+    if (!e.shiftKey) return;
+    const closeBtn = (e.target as HTMLElement).closest(".pl-tabbar__close");
+    if (!closeBtn) return;
+    const tabEl = closeBtn.closest(".pl-tabbar__tab") as HTMLElement | null;
+    if (!tabEl) return;
+    const tabs = Array.from((e.currentTarget as HTMLElement).querySelectorAll(".pl-tabbar__tab"));
+    const session = chat.sessions[tabs.indexOf(tabEl)];
+    if (!session) return;
+    e.preventDefault();
+    e.stopPropagation(); // beat the DS close button's onClick → no confirm dialog
+    closeSession(session.id, false); // false = no knowledge harvest
+  }
+
   // Right-click a chat tab → context menu (ADR 0036). The DS TabBar exposes no per-tab
   // context-menu hook, so we delegate from the tab-bar wrapper and map the clicked tab to its
   // session by sibling index (DOM order tracks the `items` = sessions order). Close reuses the
@@ -166,7 +198,11 @@ export function ChatSurface({
           `responsive` collapses to a DS-native <select> + add in a narrow panel
           (container query). The status dot rides the `icon` slot — wide-strip only:
           the collapsed <option> can't host markup, matching the old behavior. */}
-      <div className="chat-tabbar-wrap" onContextMenu={onTabBarContextMenu}>
+      <div
+        className={`chat-tabbar-wrap${shiftDel ? " chat-tabbar-wrap--del" : ""}`}
+        onContextMenu={onTabBarContextMenu}
+        onClickCapture={onTabBarClickCapture}
+      >
         <TabBar
           ariaLabel="Chat sessions"
           responsive

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -34,6 +34,25 @@
   display: contents;
 }
 
+/* Quick-delete mode: while Shift is held, the tab ✕ becomes a red trashcan (Shift+click
+   deletes with no confirm + no harvest). Swap the DS ✕ svg for a trash silhouette (mask
+   tinted via currentColor). */
+.chat-tabbar-wrap--del .pl-tabbar__close {
+  color: var(--pl-color-danger, #e5484d);
+}
+.chat-tabbar-wrap--del .pl-tabbar__close svg {
+  display: none;
+}
+.chat-tabbar-wrap--del .pl-tabbar__close::after {
+  content: "";
+  display: inline-block;
+  width: 13px;
+  height: 13px;
+  background-color: currentColor;
+  -webkit-mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M9 3v1H4v2h16V4h-5V3H9zM6 7l1 13h10l1-13H6z'/%3E%3C/svg%3E") center / contain no-repeat;
+  mask: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 24 24'%3E%3Cpath d='M9 3v1H4v2h16V4h-5V3H9zM6 7l1 13h10l1-13H6z'/%3E%3C/svg%3E") center / contain no-repeat;
+}
+
 .chat-session-slot {
   height: 100%;
   display: grid;


### PR DESCRIPTION
**Draft / local-test gate** — console UX. Test on HMR (http://127.0.0.1:5173/app/): open a 2nd chat tab, hold **Shift** (the ✕ turns into a red trashcan), click it → the tab deletes instantly, no dialog. Plain click still asks to confirm.

## What
Shift+click a chat tab's ✕ → delete with **no confirmation dialog** and **no knowledge harvest**. The DS `TabBar`'s `onClose` always opens the confirm dialog, so `ChatSurface` intercepts the close-button click in the **capture phase** on the tab-bar wrapper (before the DS button's own `onClick`) when `shiftKey` is down, maps the ✕ to its session by sibling index, and calls `closeSession(id, harvest=false)` directly. While Shift is held a `--del` class on the wrapper restyles the ✕ to a red trashcan (CSS mask).

## Tests / docs
- e2e (`chat-quick-delete.spec.ts`): shift+click deletes with no dialog; plain click still confirms.
- Gates green: tsc, 155 unit, full e2e (the `fleet.spec` flake passes solo / on CI retry).
- CHANGELOG.

🤖 Generated with [Claude Code](https://claude.com/claude-code)