### PR TITLE
chore(web): strip hardcoded emojis from UI strings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **No hardcoded emojis in the UI** — stripped emoji/glyph literals from user-facing strings: the
+  chat paste-attachment label (`📎` → `Attached:`), background-agent completion headers (`✅`/`⚠️`),
+  the `/effort` notes (`⚙`/`⚠`), delegate/plugin-install status strings (`✓`/`✗`/`⚠`), and the
+  background-job tool glyphs (now lucide icons). Status is carried by text/tone/icons, not emoji.
+
 ### Added
 - **Hide a rail surface without disabling its plugin** (ADR 0035/0036) — `railOrder` gains a
   `hidden` bucket: a surface is on exactly one dock *or* hidden (enabled-but-not-shown). Right-click

--- a/apps/web/src/app/BackgroundJobs.tsx
+++ b/apps/web/src/app/BackgroundJobs.tsx
@@ -274,7 +274,7 @@ function BgJobRow({
               <span className="bg-jobs-tools">
                 {recentTools.map((t) => (
                   <span key={t.id} className={`bg-jobs-tool ${t.error ? "is-err" : t.done ? "is-done" : "is-run"}`}>
-                    {t.error ? "✗" : t.done ? "✓" : "⊷"} {t.tool}
+                    {t.error ? <XCircle size={11} /> : t.done ? <CheckCircle2 size={11} /> : <Loader2 size={11} className="spin" />} {t.tool}
                   </span>
                 ))}
               </span>

--- a/apps/web/src/app/BackgroundWatch.tsx
+++ b/apps/web/src/app/BackgroundWatch.tsx
@@ -79,8 +79,8 @@ export function BackgroundWatch() {
       const desc = String(data.description ?? "background task");
       const result = String(data.result ?? "");
       const header = failed
-        ? `⚠️ Background agent failed — ${desc}`
-        : `✅ Background agent finished — ${desc}`;
+        ? `Background agent failed — ${desc}`
+        : `Background agent finished — ${desc}`;
       const injected = appendSystem(session, result ? `${header}\n\n${result}` : header);
       toast({
         tone: failed ? "error" : "success",

--- a/apps/web/src/app/PaletteChat.tsx
+++ b/apps/web/src/app/PaletteChat.tsx
@@ -117,14 +117,14 @@ export function PaletteChat({ agentName }: { agentName: string }) {
           onReasoning: (d) => update((m) => ({ ...m, reasoning: (m.reasoning ?? "") + d })),
           onToolCall: (evt) => update((m) => upsertTool(m, evt)),
           onComponent: (spec) => update((m) => ({ ...m, components: [...(m.components ?? []), spec] })),
-          onFailed: (detail) => update((m) => ({ ...m, content: m.content || `⚠️ ${detail}`, status: "error" })),
+          onFailed: (detail) => update((m) => ({ ...m, content: m.content || detail, status: "error" })),
           onDone: () => update(finalize),
         },
         { model, reasoningEffort: effectiveReasoningEffort(sess) },
       );
     } catch (e) {
       if (!controller.signal.aborted) {
-        update((m) => ({ ...m, content: m.content || `⚠️ ${(e as Error).message || "Chat failed."}`, status: "error" }));
+        update((m) => ({ ...m, content: m.content || (e as Error).message || "Chat failed.", status: "error" }));
       }
     } finally {
       setStreaming(false);

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -550,7 +550,7 @@ function ChatSessionSlot({
     // user bubble shows only the typed text + a 📎 list (never a raw doc/data dump).
     const sent = [...piped.map((a) => a.context as string), text].join("\n\n").trim();
     const names = [...piped, ...nativeImgs].map((a) => a.name).join(", ");
-    const display = text ? `${text}\n\n📎 ${names}` : `📎 ${names}`;
+    const display = text ? `${text}\n\nAttached: ${names}` : `Attached: ${names}`;
     setAttachments([]);
     void runTurn(display, { sendAs: sent, images });
   }

--- a/apps/web/src/chat/coreSlashCommands.ts
+++ b/apps/web/src/chat/coreSlashCommands.ts
@@ -42,13 +42,13 @@ registerSlashCommand({
     if (!arg) {
       const session = chatStore.getSnapshot().sessions.find((s) => s.id === ctx.sessionId);
       const cur = session?.reasoningEffort ?? `${DEFAULT_REASONING_EFFORT} (default)`;
-      ctx.noteToThread(`⚙ Reasoning effort: **${cur}**. Set it with \`/effort ${REASONING_EFFORTS.join("|")}\`.`);
+      ctx.noteToThread(`Reasoning effort: **${cur}**. Set it with \`/effort ${REASONING_EFFORTS.join("|")}\`.`);
     } else if ((REASONING_EFFORTS as readonly string[]).includes(arg)) {
       chatStore.setSessionReasoningEffort(ctx.sessionId, arg);
       const off = arg === "off" ? " — reasoning disabled for this tab" : "";
-      ctx.noteToThread(`⚙ Reasoning effort set to **${arg}**${off}. Applies to the next message.`);
+      ctx.noteToThread(`Reasoning effort set to **${arg}**${off}. Applies to the next message.`);
     } else {
-      ctx.noteToThread(`⚠ Unknown effort \`${arg}\`. Options: ${opts}.`);
+      ctx.noteToThread(`Unknown effort \`${arg}\`. Options: ${opts}.`);
     }
     ctx.focusComposer();
     return true;

--- a/apps/web/src/plugins/InstallPluginDialog.tsx
+++ b/apps/web/src/plugins/InstallPluginDialog.tsx
@@ -41,11 +41,11 @@ export function InstallPluginDialog({ open, onClose }: { open: boolean; onClose:
       const deps = s.requires_pip?.length ? ` — declares deps (install manually): ${s.requires_pip.join(", ")}` : "";
       setStatus(
         res.enable_error
-          ? `✓ installed ${who} — auto-enable failed (${res.enable_error}); enable it from the list${deps}`
-          : `✓ installed ${who}${deps}`,
+          ? `Installed ${who} — auto-enable failed (${res.enable_error}); enable it from the list${deps}`
+          : `Installed ${who}${deps}`,
       );
     },
-    onError: (e: unknown) => setStatus(`✗ ${e instanceof Error ? e.message : "install failed"}`),
+    onError: (e: unknown) => setStatus(e instanceof Error ? e.message : "install failed"),
   });
 
   if (!open) return null;

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -54,9 +54,9 @@ function coerce(field: DelegateFieldSpec, raw: unknown): unknown {
 function probeLine(p: DelegateProbe): string {
   if (p.ok) {
     const lat = p.latency_ms != null ? ` (${p.latency_ms} ms)` : "";
-    return `✓ ${p.detail || "reachable"}${lat}`;
+    return `${p.detail || "reachable"}${lat}`;
   }
-  return `✗ ${p.error || "unreachable"}`;
+  return `${p.error || "unreachable"}`;
 }
 
 export function DelegatesSection() {
@@ -129,7 +129,7 @@ export function DelegatesSection() {
                     </span>
                   ) : null}
                   {d.name} <Badge status="neutral">{d.type}</Badge>
-                  {!d.configured ? <StatusPill label="⚠ unconfigured" tone="warning" /> : null}
+                  {!d.configured ? <StatusPill label="unconfigured" tone="warning" /> : null}
                   {d.has_secret ? <StatusPill label="secret set" tone="muted" /> : null}
                 </strong>
                 <span>{p ? probeLine(p) : d.description || d.error || ""}</span>


### PR DESCRIPTION
**Strict no-emoji in the UI.** Removed emoji/glyph literals from user-facing strings:
- Chat paste label: `📎 Pasted text.txt` → `Attached: …`
- Background-agent completion headers: `✅`/`⚠️` dropped (the words carry it)
- `/effort` notes: `⚙`/`⚠` dropped
- Delegate probe + plugin-install status: `✓`/`✗`/`⚠` dropped (tone/text carry it)
- Background-job tool glyphs: `✗`/`✓`/`⊷` → lucide `XCircle`/`CheckCircle2`/`Loader2`

Code comments that mention glyphs are left (not UI). Gates green: tsc · 155 unit · 137 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)