### PR TITLE
fix(web): full-width raw streaming text (drop the loading side-bar)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **Streaming answer text is full-width, no loading side-bar** — removed the DS streaming-pulse
+  (animated 2px accent left-border + inset) from the streaming message body, so the answer streams
+  as raw, full-width text instead of behind an animated rail. Applies to the main chat and the ⌘K
+  palette chat; tool cards keep their own loaders.
+
 ### Added
 - **Hide a rail surface without disabling its plugin** (ADR 0035/0036) — `railOrder` gains a
   `hidden` bucket: a surface is on exactly one dock *or* hidden (enabled-but-not-shown). Right-click

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -75,6 +75,17 @@
 .chat-session-slot .pl-message--system .pl-message__content .markdown > :first-child { margin-top: 0; }
 .chat-session-slot .pl-message--system .pl-message__content .markdown > :last-child { margin-bottom: 0; }
 
+/* No "loading side-bar" on streaming answer text. The DS pulses a 2px accent left-border +
+   10px inset on a streaming message body (ai.css) — but the streaming text itself is the cue,
+   and it should read FULL WIDTH, not inset behind an animated rail. Drop it (higher specificity
+   than the DS rule, so it wins regardless of import order; applies to BOTH the main chat and the
+   ⌘K palette chat). Tools keep their own loaders — their cards/WorkBlock are untouched. */
+.pl-message.pl-message--streaming .pl-message__body {
+  border-left: none;
+  padding-left: 0;
+  animation: none;
+}
+
 /* Stop (while streaming) and the queued-steer bubble are now the DS busy mode +
    <Message queued> (0.42.0) — see ChatSurface. No bespoke CSS needed here. */
 


### PR DESCRIPTION
**Draft / local-test gate.** The streaming answer text had the DS streaming-pulse — an animated 2px accent left-border + 10px inset (`ai.css`) — on the message body, putting the text behind an animated rail and insetting it. This overrides it off so the answer streams as **raw, full-width text** (the streaming text itself is the cue). Higher specificity than the DS rule, so it wins regardless of import order; applies to the **main chat and the ⌘K palette chat**. **Tool cards keep their own loaders** (untouched).

Gates green: build · chat/streaming/nesting e2e.

Part of the chat-streaming-UX cluster. The bigger piece — **extracting a shared `<ChatMessageView>`** so the palette chat reaches parity with the main chat — is held pending PR triage (see note below).

🤖 Generated with [Claude Code](https://claude.com/claude-code)