### PR TITLE
refactor(web): shared <ChatMessageView> (main + ⌘K palette chat parity)

### DIFF
--- a/apps/web/src/app/PaletteChat.tsx
+++ b/apps/web/src/app/PaletteChat.tsx
@@ -4,11 +4,8 @@
 // handlers. ONE preserved thread per agent (stable contextId + persisted transcript,
 // see paletteChatStore) — `/clear` wipes it (transcript + server checkpoint).
 import { useEffect, useRef, useState } from "react";
-import { Loader2 } from "lucide-react";
-import { Conversation, Message, PromptInput, Reasoning } from "@protolabsai/ui/ai";
-import { Markdown } from "../chat/LazyMarkdown";
-import { ToolCalls } from "../chat/ToolCalls";
-import { ChatComponent } from "../chat/ChatComponent";
+import { Conversation, Message, PromptInput } from "@protolabsai/ui/ai";
+import { ChatMessageView } from "../chat/ChatMessageView";
 import { api } from "../lib/api";
 import { chatStore, effectiveReasoningEffort } from "../chat/chat-store";
 import type { ChatMessage, ToolCall, ToolEvent } from "../lib/types";
@@ -135,8 +132,6 @@ export function PaletteChat({ agentName }: { agentName: string }) {
 
   const stop = () => abortRef.current?.abort();
   const empty = messages.length === 0;
-  const last = messages.length - 1;
-
   // Minimal slash menu — `/clear` hint while the draft starts with "/".
   const slashMatches = draft.startsWith("/")
     ? SLASH.filter((c) => c.name.startsWith(draft.slice(1).toLowerCase()))
@@ -153,28 +148,12 @@ export function PaletteChat({ agentName }: { agentName: string }) {
             <span style={{ color: "var(--pl-color-fg-muted)" }}>Ask {agentName} anything. /clear wipes this thread.</span>
           </Message>
         ) : null}
-        {messages.map((m, i) => {
-          const isStreaming = m.status === "streaming" && i === last;
-          if (m.role === "user") {
-            return (
-              <Message key={i} role="user">
-                <span className="chat-user-text">{m.content}</span>
-              </Message>
-            );
-          }
-          return (
-            <Message key={i} role={m.role} streaming={isStreaming}>
-              {m.reasoning ? <Reasoning surface="subtle" streaming={isStreaming && !m.content}>{m.reasoning}</Reasoning> : null}
-              {m.toolCalls && m.toolCalls.length ? <ToolCalls calls={m.toolCalls} /> : null}
-              {m.content ? (
-                <Markdown>{m.content}</Markdown>
-              ) : isStreaming && !m.toolCalls?.length && !m.reasoning ? (
-                <Loader2 className="spin" size={16} />
-              ) : null}
-              {m.components?.map((s, j) => <ChatComponent key={j} spec={s} />)}
-            </Message>
-          );
-        })}
+        {messages.map((m, i) => (
+          // Shared renderer (ADR 0035) — the SAME message tree as the main chat (reasoning,
+          // tools, content, components, the report card), so the ⌘K chat never drifts. No
+          // per-message action row (transient quick-chat). Streaming is read from m.status.
+          <ChatMessageView key={i} message={m} />
+        ))}
       </Conversation>
       <PromptInput
         value={draft}

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -1,0 +1,165 @@
+import { Button } from "@protolabsai/ui/primitives";
+import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
+import { Check, Copy, GitBranch, Loader2, Maximize2, RotateCcw } from "lucide-react";
+
+import { openDocument } from "../docviewer";
+import { api } from "../lib/api";
+import type { ChatMessage, ChatPart } from "../lib/types";
+import { ChatComponent } from "./ChatComponent";
+import { Markdown } from "./LazyMarkdown";
+import { ReasoningCard } from "./ReasoningCard";
+import { ToolCalls } from "./ToolCalls";
+import { WorkBlock } from "./WorkBlock";
+import { toolsForGroup } from "./parts";
+
+// Optional per-message action row (copy / fork / regenerate). Omit it (e.g. the ⌘K palette
+// chat) and no actions render. Each callback is independently optional.
+export type ChatMessageActions = {
+  copiedId?: string | null;
+  onCopy?: (m: ChatMessage) => void;
+  onFork?: (m: ChatMessage) => void;
+  onRegenerate?: (id: string) => void;
+  lastAssistantId?: string;
+  regenDisabled?: boolean;
+};
+
+// The single chat message renderer (ADR 0035) — shared by the main chat (ChatSurface) and the
+// ⌘K palette chat (PaletteChat) so they never drift. Renders one user/assistant/system message:
+// live ordered `parts` (text↔tool interleave, WorkBlock fold) or the history-loaded grouped
+// fallback, plus the streaming loader, inline components, the background-report card, and the
+// optional action row. Streaming state is read from `message.status`.
+export function ChatMessageView({
+  message,
+  onCancelDelegation,
+  actions,
+}: {
+  message: ChatMessage;
+  onCancelDelegation?: (id: string) => void;
+  actions?: ChatMessageActions;
+}) {
+  const streaming = message.status === "streaming";
+  return (
+    <Message role={message.role} streaming={streaming} className={message.report ? "chat-report" : undefined}>
+      {message.reasoning && !(message.parts && message.parts.length) ? (
+        // History-loaded turns have no ordered parts — fall back to the flat collapsed
+        // reasoning card. Live turns render reasoning inline via parts.
+        <ReasoningCard text={message.reasoning} streaming={streaming && !message.content} />
+      ) : null}
+      {message.parts && message.parts.length ? (
+        (() => {
+          // Fold the intermediate reason→tool timeline behind ONE WorkBlock so the answer
+          // leads — but ONLY when the turn interleaves reasoning WITH tools (the forever-stack
+          // case). Tool-only / reasoning-only turns keep their inline cards; a plain turn is
+          // just the answer. The "answer" is the trailing run of text parts; everything before
+          // it is the work. User messages carry only text.
+          const parts = message.parts!;
+          let split = parts.length;
+          while (split > 0 && parts[split - 1].kind === "text") split--;
+          const workParts = parts.slice(0, split);
+          const answerParts = parts.slice(split);
+          const hasTools = workParts.some((p) => p.kind === "tools");
+          const hasReasoning = workParts.some((p) => p.kind === "reasoning");
+          const renderText = (part: ChatPart, key: string) =>
+            part.kind !== "text" || !part.text.trim() ? null : message.role === "user" ? (
+              <span className="chat-user-text" key={key}>{part.text}</span>
+            ) : (
+              <Markdown key={key}>{part.text}</Markdown>
+            );
+          const renderInline = (part: ChatPart, i: number) =>
+            part.kind === "tools" ? (
+              <ToolCalls key={i} calls={toolsForGroup(part.ids, message.toolCalls)} streaming={streaming} onCancelDelegation={onCancelDelegation} />
+            ) : part.kind === "reasoning" ? (
+              part.text.trim() ? (
+                <ReasoningCard key={i} text={part.text} streaming={streaming && i === workParts.length - 1} />
+              ) : null
+            ) : (
+              renderText(part, `w${i}`)
+            );
+          return (
+            <>
+              {hasTools && hasReasoning ? (
+                <WorkBlock parts={workParts} toolCalls={message.toolCalls} streaming={streaming && answerParts.length === 0} />
+              ) : (
+                workParts.map(renderInline)
+              )}
+              {answerParts.map((part, i) => renderText(part, `a${i}`))}
+            </>
+          );
+        })()
+      ) : (
+        // History-loaded messages have no ordered parts — keep the grouped layout
+        // (tool cards above the text; order isn't recoverable from storage).
+        <>
+          {message.toolCalls && message.toolCalls.length > 0 ? (
+            <ToolCalls calls={message.toolCalls} onCancelDelegation={onCancelDelegation} />
+          ) : null}
+          {message.content ? (
+            message.role === "user" ? (
+              <span className="chat-user-text">{message.content}</span>
+            ) : (
+              <Markdown>{message.content}</Markdown>
+            )
+          ) : null}
+        </>
+      )}
+      {streaming &&
+      !(message.parts && message.parts.length) &&
+      !message.content &&
+      !(message.toolCalls && message.toolCalls.length) &&
+      !(message.components && message.components.length) &&
+      !message.reasoning ? (
+        <Loader2 className="spin" size={15} />
+      ) : null}
+      {message.components && message.components.length > 0
+        ? message.components.map((spec, i) => <ChatComponent key={i} spec={spec} />)
+        : null}
+      {/* Background-agent report (ADR 0050/0062): the bubble shows the server's preview; this
+          opens the FULL report in the full-screen document viewer (fetched by job id). */}
+      {message.report ? (
+        <Button
+          className="chat-report-open"
+          variant="ghost"
+          size="sm"
+          onClick={() =>
+            openDocument({
+              title: message.report!.title,
+              subtitle: "Background agent report",
+              load: () =>
+                api
+                  .background()
+                  .then(
+                    (r) =>
+                      r.jobs.find((j) => j.id === message.report!.jobId)?.result ||
+                      "_The full report is no longer available — it may have been cleared from the Background agents panel._",
+                  ),
+            })
+          }
+        >
+          <Maximize2 size={14} /> Read full report
+        </Button>
+      ) : null}
+      {actions && message.role === "assistant" && !streaming && message.content ? (
+        <MessageActions>
+          {actions.onCopy ? (
+            <MessageAction
+              label={actions.copiedId === message.id ? "Copied" : "Copy"}
+              icon={actions.copiedId === message.id ? <Check size={14} /> : <Copy size={14} />}
+              onClick={() => actions.onCopy!(message)}
+            />
+          ) : null}
+          {actions.onFork ? (
+            <MessageAction label="Fork from here" icon={<GitBranch size={14} />} onClick={() => actions.onFork!(message)} />
+          ) : null}
+          {actions.onRegenerate && message.id === actions.lastAssistantId ? (
+            <MessageAction
+              label="Regenerate"
+              icon={<RotateCcw size={14} />}
+              disabled={actions.regenDisabled}
+              onClick={() => actions.onRegenerate!(message.id!)}
+            />
+          ) : null}
+        </MessageActions>
+      ) : null}
+    </Message>
+  );
+}

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -1,29 +1,14 @@
 import "./chat.css";
 import { Button, Empty } from "@protolabsai/ui/primitives";
 import { Switch } from "@protolabsai/ui/forms";
-import {
-  Conversation,
-  Message,
-  MessageAction,
-  MessageActions,
-  PromptInput,
-} from "@protolabsai/ui/ai";
+import { Conversation, Message, PromptInput } from "@protolabsai/ui/ai";
 import { TabBar } from "@protolabsai/ui/navigation";
-import {
-  Check,
-  Copy,
-  GitBranch,
-  Loader2,
-  Maximize2,
-  RotateCcw,
-  TerminalSquare,
-} from "lucide-react";
+import { Check, TerminalSquare } from "lucide-react";
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { MouseEvent as ReactMouseEvent } from "react";
 import { useQuery } from "@tanstack/react-query";
 
 import { openContextMenu } from "../contextMenu";
-import { openDocument } from "../docviewer";
 import { useKbIntents } from "../keybindings/intents";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
@@ -40,14 +25,10 @@ import {
 import "./coreSlashCommands"; // registers /new, /clear, /effort via the slash-command seam (ADR 0061)
 import { findSlashCommand, registeredSlashCommands } from "../ext/slashRegistry";
 import { registeredComposerActions } from "../ext/composerRegistry";
-import { ChatComponent } from "./ChatComponent";
+import { ChatMessageView } from "./ChatMessageView";
 import { ComposerModelSelect } from "./ComposerModelSelect";
-import { Markdown } from "./LazyMarkdown";
-import { ReasoningCard } from "./ReasoningCard";
-import { WorkBlock } from "./WorkBlock";
 import { filesFromTransfer, isLargePaste, pastedTextFile } from "./paste";
-import { ToolCalls } from "./ToolCalls";
-import { addToolRef, appendReasoning, appendText, toolsForGroup } from "./parts";
+import { addToolRef, appendReasoning, appendText } from "./parts";
 
 function messageId() {
   return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
@@ -1050,138 +1031,19 @@ function ChatSessionSlot({
           <Empty icon={<TerminalSquare />} description="No messages in this session." />
         ) : (
           messages.map((message) => (
-            <Message
+            <ChatMessageView
               key={message.id || `${message.role}-${message.createdAt}`}
-              role={message.role}
-              streaming={message.status === "streaming"}
-              className={message.report ? "chat-report" : undefined}
-            >
-              {message.reasoning && !(message.parts && message.parts.length) ? (
-                // History-loaded turns have no ordered parts — fall back to the flat
-                // collapsed reasoning card. Live turns render reasoning inline via parts.
-                <ReasoningCard text={message.reasoning} streaming={message.status === "streaming" && !message.content} />
-              ) : null}
-              {message.parts && message.parts.length ? (
-                (() => {
-                  // Fold the intermediate reason→tool timeline behind ONE WorkBlock so the
-                  // answer leads — but ONLY when the turn interleaves reasoning WITH tools (the
-                  // forever-stack case). Tool-only / reasoning-only turns keep their inline
-                  // cards; a plain turn is just the answer. The "answer" is the trailing run of
-                  // text parts; everything before it is the work. User messages carry only text.
-                  const parts = message.parts!;
-                  let split = parts.length;
-                  while (split > 0 && parts[split - 1].kind === "text") split--;
-                  const workParts = parts.slice(0, split);
-                  const answerParts = parts.slice(split);
-                  const hasTools = workParts.some((p) => p.kind === "tools");
-                  const hasReasoning = workParts.some((p) => p.kind === "reasoning");
-                  const renderText = (part: ChatPart, key: string) =>
-                    part.kind !== "text" || !part.text.trim() ? null : message.role === "user" ? (
-                      <span className="chat-user-text" key={key}>{part.text}</span>
-                    ) : (
-                      <Markdown key={key}>{part.text}</Markdown>
-                    );
-                  const renderInline = (part: ChatPart, i: number) =>
-                    part.kind === "tools" ? (
-                      <ToolCalls key={i} calls={toolsForGroup(part.ids, message.toolCalls)} streaming={message.status === "streaming"} onCancelDelegation={cancelDelegation} />
-                    ) : part.kind === "reasoning" ? (
-                      part.text.trim() ? (
-                        <ReasoningCard key={i} text={part.text} streaming={message.status === "streaming" && i === workParts.length - 1} />
-                      ) : null
-                    ) : (
-                      renderText(part, `w${i}`)
-                    );
-                  return (
-                    <>
-                      {hasTools && hasReasoning ? (
-                        <WorkBlock
-                          parts={workParts}
-                          toolCalls={message.toolCalls}
-                          streaming={message.status === "streaming" && answerParts.length === 0}
-                        />
-                      ) : (
-                        workParts.map(renderInline)
-                      )}
-                      {answerParts.map((part, i) => renderText(part, `a${i}`))}
-                    </>
-                  );
-                })()
-              ) : (
-                // History-loaded messages have no ordered parts — keep the grouped layout
-                // (tool cards above the text; order isn't recoverable from storage).
-                <>
-                  {message.toolCalls && message.toolCalls.length > 0 ? (
-                    <ToolCalls calls={message.toolCalls} onCancelDelegation={cancelDelegation} />
-                  ) : null}
-                  {message.content ? (
-                    message.role === "user" ? (
-                      <span className="chat-user-text">{message.content}</span>
-                    ) : (
-                      <Markdown>{message.content}</Markdown>
-                    )
-                  ) : null}
-                </>
-              )}
-              {message.status === "streaming"
-                && !(message.parts && message.parts.length)
-                && !message.content
-                && !(message.toolCalls && message.toolCalls.length)
-                && !(message.components && message.components.length)
-                && !message.reasoning
-                ? <Loader2 className="spin" size={15} />
-                : null}
-              {message.components && message.components.length > 0
-                ? message.components.map((spec, i) => <ChatComponent key={i} spec={spec} />)
-                : null}
-              {/* Background-agent report (ADR 0050/0062): the bubble shows the server's
-                  preview; this opens the FULL report in the full-screen document viewer
-                  (fetched by job id) — no trip to the Activity/Background panel. */}
-              {message.report ? (
-                <Button
-                  className="chat-report-open"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() =>
-                    openDocument({
-                      title: message.report!.title,
-                      subtitle: "Background agent report",
-                      load: () =>
-                        api
-                          .background()
-                          .then(
-                            (r) =>
-                              r.jobs.find((j) => j.id === message.report!.jobId)?.result ||
-                              "_The full report is no longer available — it may have been cleared from the Background agents panel._",
-                          ),
-                    })
-                  }
-                >
-                  <Maximize2 size={14} /> Read full report
-                </Button>
-              ) : null}
-              {message.role === "assistant" && message.status !== "streaming" && message.content ? (
-                <MessageActions>
-                  <MessageAction
-                    label={copiedId === message.id ? "Copied" : "Copy"}
-                    icon={copiedId === message.id ? <Check size={14} /> : <Copy size={14} />}
-                    onClick={() => copyMessage(message)}
-                  />
-                  <MessageAction
-                    label="Fork from here"
-                    icon={<GitBranch size={14} />}
-                    onClick={() => forkAtMessage(message)}
-                  />
-                  {message.id === lastAssistantId ? (
-                    <MessageAction
-                      label="Regenerate"
-                      icon={<RotateCcw size={14} />}
-                      disabled={status === "streaming"}
-                      onClick={() => regenerate(message.id)}
-                    />
-                  ) : null}
-                </MessageActions>
-              ) : null}
-            </Message>
+              message={message}
+              onCancelDelegation={cancelDelegation}
+              actions={{
+                copiedId,
+                onCopy: copyMessage,
+                onFork: forkAtMessage,
+                onRegenerate: regenerate,
+                lastAssistantId,
+                regenDisabled: status === "streaming",
+              }}
+            />
           ))
         )}
         {steerQueue.map((q) => (


### PR DESCRIPTION
**Draft / local-test gate. Stacked on #1362** (base = `feat/document-viewer`) — the report-card render lives in the block being extracted, so basing here means the shared component captures it with zero conflict. **Retarget to `main` after #1362 merges.**

## Why
The ⌘K **palette chat** (`PaletteChat`) had fallen behind the main chat — it rendered a simpler tree (reasoning + tools + content) while the main chat has ordered `parts` interleaving, the WorkBlock fold, message actions, the report card, etc. You chose **"extract a shared renderer"** so they can't drift.

## What
New **`src/chat/ChatMessageView.tsx`** — one component rendering a single message: ordered `parts` (text↔tool interleave) + WorkBlock fold, the history-loaded grouped fallback, the streaming loader, inline components, the background-report card, and an **optional** action row (`actions` prop). Used by:
- **ChatSurface** — passes `actions` (copy / fork / regenerate); dead imports pruned.
- **PaletteChat** — renders `<ChatMessageView message={m} />`, no actions (transient quick-chat). Now gets the report card, components, and consistent reasoning/tools/content rendering.

## Tests
Behavior-preserved: **138 e2e + 155 unit green** (chat tool-cards, nesting, tool-renderers, message-actions, copy, fork, streaming, palette all pass). tsc clean.

## Follow-up
PaletteChat doesn't build ordered `parts` yet, so it uses the grouped history-fallback layout (same as history-loaded main-chat messages). Building `parts` in its stream handlers (the `./parts` helpers) would give it the live text↔tool interleave too — a small follow-up.

Pairs with #1367 (full-width raw streaming text), which removes the loading side-bar in both chats.

🤖 Generated with [Claude Code](https://claude.com/claude-code)