### PR TITLE
feat(web): panel-focus keybindings ⌃1–4 (ADR 0063)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Panel-focus keybindings** (ADR 0063) — `⌃1`/`⌃2`/`⌃3`/`⌃4` move keyboard focus *into* the
+  chat composer / left panel / right panel / bottom dock (so that region's scoped binds activate).
+  Literal `⌃` (mac) so they're distinct from `⌘1–9` tab-jump; `⌃2/3/4` land on the first
+  interactive element in the dock. Rebindable in Settings ▸ Keyboard.
+
 ### Changed
 - **⌘K palette chat streams with live text↔tool interleave** — PaletteChat now builds the same
   ordered `parts` the main chat does (via the shared `appendText`/`appendReasoning`/`addToolRef`

--- a/apps/web/src/keybindings/coreKeybindings.ts
+++ b/apps/web/src/keybindings/coreKeybindings.ts
@@ -137,3 +137,57 @@ registerKeybinding({
   allowInInput: true,
   run: toggle(() => useUI.getState().bottomCollapsed, (b) => useUI.getState().setBottomCollapsed(b)),
 });
+
+// ── Focus a dock (global) ────────────────────────────────────────────────────────────
+// Ctrl+1–4 move keyboard FOCUS into a region (so that region's scoped binds activate) —
+// distinct from ⌘1–9, which JUMP chat tabs. Literal `ctrl` (not `mod`): on mac that's a
+// different key from ⌘, so it never collides with ⌘1–9. (On Win/Linux `mod`=Ctrl, so
+// ctrl+1 overlaps ⌘1's tab-jump — the conflict detector flags it; rebind there.)
+function focusDock(colSelector: string): void {
+  const col = document.querySelector(colSelector);
+  if (!col) return;
+  // Land on the first interactive element so the user can act immediately; fall back to the
+  // column itself (made programmatically focusable) so the keyboard scope still activates.
+  const focusable = col.querySelector<HTMLElement>(
+    'input:not([disabled]), textarea:not([disabled]), button:not([disabled]), select:not([disabled]), a[href], [tabindex]:not([tabindex="-1"])',
+  );
+  if (focusable) {
+    focusable.focus();
+    return;
+  }
+  const el = col as HTMLElement;
+  if (el.tabIndex < 0) el.tabIndex = -1;
+  el.focus();
+}
+registerKeybinding({
+  id: "focus.chat",
+  label: "Focus chat composer",
+  group: "Focus",
+  defaultKeys: "ctrl+1",
+  allowInInput: true,
+  run: () => useKbIntents.getState().focusComposer(),
+});
+registerKeybinding({
+  id: "focus.left",
+  label: "Focus left panel",
+  group: "Focus",
+  defaultKeys: "ctrl+2",
+  allowInInput: true,
+  run: () => focusDock(".pl-appshell__col--left"),
+});
+registerKeybinding({
+  id: "focus.right",
+  label: "Focus right panel",
+  group: "Focus",
+  defaultKeys: "ctrl+3",
+  allowInInput: true,
+  run: () => focusDock(".pl-appshell__col--right"),
+});
+registerKeybinding({
+  id: "focus.bottom",
+  label: "Focus bottom dock",
+  group: "Focus",
+  defaultKeys: "ctrl+4",
+  allowInInput: true,
+  run: () => focusDock(".pl-appshell__bottom"),
+});

--- a/docs/adr/0063-keybinding-system.md
+++ b/docs/adr/0063-keybinding-system.md
@@ -36,7 +36,13 @@ registries — ADR 0061, the contextMenu store+host — ADR 0036, per-key persis
 - **Core defaults dogfood the seam** (`coreKeybindings.ts`): `⌘K` palette (adopted off the DS
   `usePaletteHotkey` — palette open-state moved to an intents store), `⌘,` Settings, `/` focus
   composer (global); `⌘T` new, `⌘⇧K` clear, `⌃Tab`/`⌃⇧Tab` prev/next, `⌘1–9` jump (scope `"chat"`);
-  global VS Code-style panel toggles `⌘B` left rail / `⌘⌥B` right panel / `⌘J` bottom dock.
+  global VS Code-style panel toggles `⌘B` left rail / `⌘⌥B` right panel / `⌘J` bottom dock; and
+  panel-**focus** binds `⌃1` chat composer / `⌃2` left / `⌃3` right / `⌃4` bottom — these move
+  keyboard focus *into* a dock (so its scoped binds activate), and use the **literal `⌃`** (the
+  secondary modifier on mac) precisely so they don't collide with `⌘1–9` tab-jump. `⌃2/3/4` focus
+  the first interactive element in the dock's AppShell column; `⌃1` reuses the composer-focus
+  intent. (The combo layer maps `Ctrl`→`mod` on Win/Linux, so the literal-`⌃` default is
+  mac-semantics — rebind elsewhere; the conflict detector flags the `⌘1`/`Ctrl+1` overlap there.)
 
 ## Consequences
 


### PR DESCRIPTION
The last item of the keybinding follow-up (#1364). **`⌃1`/`⌃2`/`⌃3`/`⌃4` move keyboard focus _into_ a dock** — chat composer / left panel / right panel / bottom dock — so that region's scoped binds activate.

- **Literal `⌃`** (the secondary modifier on mac), chosen so they never collide with `⌘1–9` tab-jump. `⌃1` reuses the existing composer-focus intent; `⌃2/3/4` focus the first interactive element in the dock's AppShell column (`.pl-appshell__col--left/--right`, `.pl-appshell__bottom`), falling back to the column itself.
- **Rebindable** in Settings ▸ Keyboard (new "Focus" group). The combo layer maps `Ctrl`→`mod` on Win/Linux, so the literal-`⌃` default is mac-semantics — rebind elsewhere (the conflict detector flags the overlap).

**Testing:** tsc · build · keybindings + chat + settings e2e green (24). The combo itself isn't headless-e2e-testable (literal `⌃` is unreachable in non-mac Chromium — it resolves to `mod+1`=tab-jump), so verified by build + registration + manual check on macOS.

Chosen scheme per your pick (Ctrl+1/2/3/4). Completes the console-UX program.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new keyboard shortcuts to move focus into key areas of the app: chat composer, left panel, right panel, and bottom dock.
  * Improved keyboard navigation so focus lands on the first usable control in a region when available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->