### PR TITLE
chore: release v0.71.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.71.0] - 2026-06-27
+
 ### Added
 - **Panel-focus keybindings** (ADR 0063) — `⌃1`/`⌃2`/`⌃3`/`⌃4` move keyboard focus *into* the
   chat composer / left panel / right panel / bottom dock (so that region's scoped binds activate).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.70.0"
+version = "0.71.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,22 @@
 [
   {
+    "version": "v0.71.0",
+    "date": "2026-06-27",
+    "changes": [
+      "Panel-focus keybindings",
+      "⌘K palette chat streams with live text↔tool interleave",
+      "Streaming answer text is full-width, no loading side-bar",
+      "No hardcoded emojis in the UI",
+      "Full-screen document viewer",
+      "Keyboard shortcuts",
+      "Quick-delete a chat tab",
+      "Hide a rail surface without disabling its plugin",
+      "Configure a plugin from its rail icon or util-bar widget",
+      "Chat tab context menu",
+      "Fork-safe console behavior seams"
+    ]
+  },
+  {
     "version": "v0.70.0",
     "date": "2026-06-24",
     "changes": [


### PR DESCRIPTION
Automated version bump to `v0.71.0`. Review + merge through the normal CI/review gate, then push the tag to cut the release: `git checkout main && git pull && git tag -a v0.71.0 -m 'Release v0.71.0' && git push origin v0.71.0`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward (redundant; 422s on the duplicate).