### PR TITLE
feat: context-window meter + per-turn cost/time in chat (#1372, #1378)

### DIFF
--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -325,6 +325,7 @@ class ProtoAgentExecutor(AgentExecutor):
                 confidence_expl,
                 context_meta,
                 success=True,
+                duration_ms=int((time.monotonic() - started) * 1000),
             )
             parts = await self._append_structured(parts, context, final_text)
             if parts:
@@ -601,6 +602,7 @@ def _terminal_parts(
     context: dict | None = None,
     *,
     success: bool,
+    duration_ms: int | None = None,
 ) -> list[Part]:
     """Assemble the terminal artifact's parts: text first, then the cost /
     confidence / worldstate-delta / context extension DataParts that have content.
@@ -619,6 +621,7 @@ def _terminal_parts(
             _ext_data_part(
                 pa.emit_cost(
                     usage,
+                    duration_ms=duration_ms,
                     cost_usd=round(cost_usd, 6) if cost_usd > 0 else None,
                     success=success,
                 )

--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -186,6 +186,7 @@ class ProtoAgentExecutor(AgentExecutor):
         self,
         stream_fn_factory: Callable[..., AsyncGenerator[tuple[str, Any], None]],
         structured_finalizer: Callable[[str, str], Any] | None = None,
+        context_meta_provider: Callable[[], dict[str, Any]] | None = None,
     ) -> None:
         # ``stream_fn_factory(text, context_id, *, resume, caller_trace,
         # request_metadata)`` → async generator of (event_type, payload). This is
@@ -197,6 +198,10 @@ class ProtoAgentExecutor(AgentExecutor):
         # or None (#476). Injected by server.py so the executor stays decoupled
         # from the skill registry (no circular import).
         self._structured_finalizer = structured_finalizer
+        # ``context_meta_provider()`` → the static compaction context for the context-v1
+        # DataPart (#1372): {enabled, trigger, compactionAtTokens?}. Injected by server.py
+        # (it reads STATE.graph_config) so the executor needn't import the config (layering).
+        self._context_meta_provider = context_meta_provider
 
     async def _append_structured(self, parts: list[Part], context: RequestContext, final_text: str) -> list[Part]:
         """If the turn targets a structured skill (``skillHint`` + a declared
@@ -256,6 +261,10 @@ class ProtoAgentExecutor(AgentExecutor):
         }
         cost_usd = 0.0
         had_usage = False
+        # Peak prompt size this turn = the largest single model call's input_tokens (the
+        # model's own count of all prompt tokens, incl. cache reads). Unlike the summed
+        # usage above, this is the live context-window FILL, not per-turn spend (#1372).
+        context_tokens = 0
         confidence: float | None = None
         confidence_expl: str | None = None
         llm_calls = 0
@@ -295,6 +304,18 @@ class ProtoAgentExecutor(AgentExecutor):
             text once (the non-streaming path: workflow/subagent short-circuits)."""
             # text="" yields a dataparts-only list (the text part is conditional).
             body = "" if _answer_started else final_text
+            # Compaction context (#1372): the live prompt size + the configured trigger /
+            # token threshold, merged into one context-v1 DataPart. Provider failures
+            # degrade to "size only" — never break the turn's finalization.
+            context_meta: dict[str, Any] | None = None
+            if context_tokens > 0:
+                meta: dict[str, Any] = {}
+                if self._context_meta_provider is not None:
+                    try:
+                        meta = self._context_meta_provider() or {}
+                    except Exception:  # noqa: BLE001 — telemetry must never break a turn
+                        meta = {}
+                context_meta = {"contextTokens": context_tokens, **meta}
             parts = _terminal_parts(
                 body,
                 deltas,
@@ -302,6 +323,7 @@ class ProtoAgentExecutor(AgentExecutor):
                 cost_usd,
                 confidence,
                 confidence_expl,
+                context_meta,
                 success=True,
             )
             parts = await self._append_structured(parts, context, final_text)
@@ -392,6 +414,7 @@ class ProtoAgentExecutor(AgentExecutor):
                     if isinstance(payload, dict):
                         had_usage = True
                         llm_calls += 1
+                        context_tokens = max(context_tokens, int(payload.get("input_tokens", 0) or 0))
                         usage["input_tokens"] += int(payload.get("input_tokens", 0) or 0)
                         usage["output_tokens"] += int(payload.get("output_tokens", 0) or 0)
                         usage["cache_read_input_tokens"] += int(payload.get("cache_read_input_tokens", 0) or 0)
@@ -565,6 +588,9 @@ def _tool_call_part(event_type: str, payload: Any) -> Part | None:
     return None
 
 
+_CONTEXT_MIME = "application/vnd.protolabs.context-v1+json"
+
+
 def _terminal_parts(
     text: str,
     deltas: list[dict],
@@ -572,15 +598,16 @@ def _terminal_parts(
     cost_usd: float,
     confidence: float | None,
     confidence_expl: str | None,
+    context: dict | None = None,
     *,
     success: bool,
 ) -> list[Part]:
     """Assemble the terminal artifact's parts: text first, then the cost /
-    confidence / worldstate-delta extension DataParts that have content.
+    confidence / worldstate-delta / context extension DataParts that have content.
 
     Mirrors the hand-rolled handler's ``_terminal_artifact_parts`` ordering
     (text → worldstate → cost → confidence) so consumers reading parts in
-    order are unchanged.
+    order are unchanged; the context-v1 part trails as a pure append.
     """
     parts: list[Part] = []
     if text:
@@ -607,4 +634,8 @@ def _terminal_parts(
                 )
             )
         )
+    # Compaction context-window readout (#1372) — a template extension (no SDK helper),
+    # built with the generic DataPart packer. Only when we actually measured a prompt.
+    if context and context.get("contextTokens"):
+        parts.append(_ext_data_part(pa.data_part(context, _CONTEXT_MIME)))
     return parts

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -89,9 +89,29 @@ test("a completed turn shows a context meter + token/cost footer (#1372)", async
   await expect(usage).toContainText("$0.04"); // costUsd 0.0412
   // The fill bar renders (token-based trigger → chartable).
   await expect(usage.locator(".chat-usage-bar-fill")).toBeVisible();
-  // Tooltip carries the compaction threshold + the honest scope note.
-  await expect(usage).toHaveAttribute("title", /Compacts old history near 120,000 tokens/);
-  await expect(usage).toHaveAttribute("title", /cost is summed across the turn/);
+
+  // The full breakdown is a rich hover card (DS Tooltip) — the compaction threshold + the
+  // honest scope note live there, not in a native title attribute.
+  // The full breakdown is a rich hover card (DS Tooltip) that mounts only on hover. Radix
+  // double-renders the content (positioned + a11y copy) with identical text — assert on the
+  // first; its presence proves the card opened.
+  await expect(page.locator(".chat-usage-tip")).toHaveCount(0); // closed → not mounted
+  await usage.hover();
+  const tip = page.locator(".chat-usage-tip").first();
+  await expect(tip).toContainText("near 120,000 tokens");
+  await expect(tip).toContainText("Context is the live prompt size");
+});
+
+test("Settings ▸ Chat can hide the token/cost footer (#1372)", async ({ page }) => {
+  await send(page, "what is the capital of France?");
+  await expect(page.locator(".pl-message--assistant .chat-usage")).toBeVisible();
+
+  // Flip it off in Settings ▸ Chat — the chat stays mounted behind the overlay, so the footer
+  // clears live the moment the pref changes (no reload).
+  await page.getByTestId("settings-widget").click();
+  await page.locator(".settings-overlay .pl-sidenav").getByRole("tab", { name: "Chat", exact: true }).click();
+  await page.locator('.setting-row[data-key="chat.showUsage"] .pl-switch').click();
+  await expect(page.locator(".pl-message--assistant .chat-usage")).toHaveCount(0);
 });
 
 test("long tool values do not overflow the chat horizontally", async ({ page }) => {

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -77,18 +77,21 @@ test("expanded state is sticky and the assistant answer renders as markdown", as
   await expect(md.locator("pre code")).toContainText("const x = 1;");
 });
 
-test("a completed turn shows a per-turn token + cost footer (#1372)", async ({ page }) => {
+test("a completed turn shows a context meter + token/cost footer (#1372)", async ({ page }) => {
   await send(page, "what is the capital of France?");
 
-  // The terminal cost-v1 DataPart → a quiet footer under the answer: prompt ↑ / output ↓ / $.
+  // The terminal cost-v1 + context-v1 DataParts → a quiet footer under the answer:
+  // context-window fill (with a compaction bar) / output ↓ / $cost.
   const usage = page.locator(".pl-message--assistant .chat-usage").first();
   await expect(usage).toBeVisible();
-  await expect(usage).toContainText("12.3k"); // input_tokens 12_340 → compact
+  await expect(usage).toContainText("12.3k / 120k"); // contextTokens 12_340 / compactionAtTokens 120_000
   await expect(usage).toContainText("1.2k"); // output_tokens 1_200
   await expect(usage).toContainText("$0.04"); // costUsd 0.0412
-  // Full breakdown rides the tooltip, and is honest about scope.
-  await expect(usage).toHaveAttribute("title", /Total 13,540 tokens/);
-  await expect(usage).toHaveAttribute("title", /not live context-window fill/);
+  // The fill bar renders (token-based trigger → chartable).
+  await expect(usage.locator(".chat-usage-bar-fill")).toBeVisible();
+  // Tooltip carries the compaction threshold + the honest scope note.
+  await expect(usage).toHaveAttribute("title", /Compacts old history near 120,000 tokens/);
+  await expect(usage).toHaveAttribute("title", /cost is summed across the turn/);
 });
 
 test("long tool values do not overflow the chat horizontally", async ({ page }) => {

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -77,6 +77,20 @@ test("expanded state is sticky and the assistant answer renders as markdown", as
   await expect(md.locator("pre code")).toContainText("const x = 1;");
 });
 
+test("a completed turn shows a per-turn token + cost footer (#1372)", async ({ page }) => {
+  await send(page, "what is the capital of France?");
+
+  // The terminal cost-v1 DataPart → a quiet footer under the answer: prompt ↑ / output ↓ / $.
+  const usage = page.locator(".pl-message--assistant .chat-usage").first();
+  await expect(usage).toBeVisible();
+  await expect(usage).toContainText("12.3k"); // input_tokens 12_340 → compact
+  await expect(usage).toContainText("1.2k"); // output_tokens 1_200
+  await expect(usage).toContainText("$0.04"); // costUsd 0.0412
+  // Full breakdown rides the tooltip, and is honest about scope.
+  await expect(usage).toHaveAttribute("title", /Total 13,540 tokens/);
+  await expect(usage).toHaveAttribute("title", /not live context-window fill/);
+});
+
 test("long tool values do not overflow the chat horizontally", async ({ page }) => {
   await send(page, "OVERFLOW: trigger a long token");
 

--- a/apps/web/e2e/chat.spec.ts
+++ b/apps/web/e2e/chat.spec.ts
@@ -86,6 +86,7 @@ test("a completed turn shows a context meter + token/cost footer (#1372)", async
   await expect(usage).toBeVisible();
   await expect(usage).toContainText("12.3k / 120k"); // contextTokens 12_340 / compactionAtTokens 120_000
   await expect(usage).toContainText("1.2k"); // output_tokens 1_200
+  await expect(usage).toContainText("2.3s"); // durationMs 2300
   await expect(usage).toContainText("$0.04"); // costUsd 0.0412
   // The fill bar renders (token-based trigger → chartable).
   await expect(usage.locator(".chat-usage-bar-fill")).toBeVisible();

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -7,6 +7,7 @@
 
 export const TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json";
 export const COST_MIME = "application/vnd.protolabs.cost-v1+json";
+export const CONTEXT_MIME = "application/vnd.protolabs.context-v1+json";
 
 export const RUNTIME_STATUS = {
   setup_complete: true,
@@ -529,6 +530,16 @@ export function buildFrames({ rpcId, contextId, taskId, prompt }) {
               success: true,
             },
             metadata: { mimeType: COST_MIME },
+          },
+          {
+            kind: "data",
+            data: {
+              contextTokens: 12_340,
+              compactionAtTokens: 120_000,
+              trigger: "tokens:120000",
+              enabled: true,
+            },
+            metadata: { mimeType: CONTEXT_MIME },
           },
         ],
       },

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -6,6 +6,7 @@
 // constants to assert against, so the contract can't drift between the two.
 
 export const TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json";
+export const COST_MIME = "application/vnd.protolabs.cost-v1+json";
 
 export const RUNTIME_STATUS = {
   setup_complete: true,
@@ -503,12 +504,34 @@ export function buildFrames({ rpcId, contextId, taskId, prompt }) {
       }),
     );
   }
+  // The terminal answer artifact also carries the cost-v1 DataPart (token usage + cost),
+  // exactly as a2a_impl's executor emits it — so the per-turn usage footer (#1372) renders.
   frames.push(
     wrap({
       kind: "artifact-update",
       taskId,
       contextId,
-      artifact: { artifactId: taskId, parts: [{ kind: "text", text: scenario.answer }] },
+      artifact: {
+        artifactId: taskId,
+        parts: [
+          { kind: "text", text: scenario.answer },
+          {
+            kind: "data",
+            data: {
+              usage: {
+                input_tokens: 12_340,
+                output_tokens: 1_200,
+                cache_read_input_tokens: 8_000,
+                cache_creation_input_tokens: 0,
+              },
+              costUsd: 0.0412,
+              durationMs: 2300,
+              success: true,
+            },
+            metadata: { mimeType: COST_MIME },
+          },
+        ],
+      },
       append: false,
       lastChunk: true,
     }),

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -63,6 +63,7 @@ test("the settings dialog lists the grouped Agent + Box sections (host, no scope
     "Memory",
     "System",
     "Theme",
+    "Chat",
     "Keyboard",
     // Box group (host console only). (Shared Skills folded into Agent ▸ Skills.)
     "Overview",

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -1,10 +1,10 @@
 import { Button } from "@protolabsai/ui/primitives";
 import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
-import { ArrowDown, ArrowUp, Check, Copy, GitBranch, Loader2, Maximize2, RotateCcw } from "lucide-react";
+import { ArrowDown, Check, Copy, GitBranch, Gauge, Loader2, Maximize2, RotateCcw } from "lucide-react";
 
 import { openDocument } from "../docviewer";
 import { api } from "../lib/api";
-import type { ChatMessage, ChatPart, TurnUsage } from "../lib/types";
+import type { ChatMessage, ChatPart, ContextWindow, TurnUsage } from "../lib/types";
 import { ChatComponent } from "./ChatComponent";
 import { Markdown } from "./LazyMarkdown";
 import { ReasoningCard } from "./ReasoningCard";
@@ -138,8 +138,8 @@ export function ChatMessageView({
           <Maximize2 size={14} /> Read full report
         </Button>
       ) : null}
-      {message.role === "assistant" && !streaming && message.usage ? (
-        <UsageFooter usage={message.usage} />
+      {message.role === "assistant" && !streaming && (message.usage || message.contextWindow) ? (
+        <UsageFooter usage={message.usage} context={message.contextWindow} />
       ) : null}
       {actions && message.role === "assistant" && !streaming && message.content ? (
         <MessageActions>
@@ -180,30 +180,60 @@ function fmtCost(usd: number): string {
   return usd < 0.01 ? `$${usd.toFixed(4)}` : `$${usd.toFixed(2)}`;
 }
 
-/** The per-turn token/cost footer under an assistant answer: prompt ↑ · output ↓ · cost,
- *  with the full breakdown (incl. cache + duration) on hover. Honest about scope — this is
- *  the turn's accumulated spend, not a live context-window gauge (see TurnUsage). */
-function UsageFooter({ usage }: { usage: TurnUsage }) {
+/** The per-turn footer under an assistant answer: a context-window meter (fill ⊙, with a
+ *  "/ threshold" bar when compaction is token-based) · output ↓ · cost, with the full
+ *  breakdown on hover. Honest about scope: `contextTokens` is the live prompt size; the cost
+ *  is summed across the turn's calls (see ContextWindow / TurnUsage). */
+function UsageFooter({ usage, context }: { usage?: TurnUsage; context?: ContextWindow }) {
+  // Prefer the true context-window fill (peak prompt); fall back to the summed input only
+  // for history saved before context-v1 shipped.
+  const ctxTokens = context?.contextTokens ?? usage?.inputTokens;
+  const threshold = context?.compactionAtTokens;
+  const pct =
+    ctxTokens != null && threshold ? Math.min(100, Math.round((ctxTokens / threshold) * 100)) : null;
+
+  const compactionLine = context
+    ? context.enabled === false
+      ? "Compaction off"
+      : threshold
+        ? `Compacts old history near ${threshold.toLocaleString()} tokens${context.trigger ? ` (${context.trigger})` : ""}`
+        : context.trigger
+          ? `Compaction trigger: ${context.trigger} (no token threshold to chart here)`
+          : ""
+    : "";
   const title = [
-    `Input ${usage.inputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · Total ${usage.totalTokens.toLocaleString()} tokens`,
-    usage.cacheReadTokens ? `${usage.cacheReadTokens.toLocaleString()} input tokens served from cache` : "",
-    usage.costUsd != null ? `Cost ${fmtCost(usage.costUsd)}` : "",
-    usage.durationMs ? `Took ${(usage.durationMs / 1000).toFixed(1)}s` : "",
-    "Per-turn total (summed across this turn's model calls), not live context-window fill.",
+    ctxTokens != null ? `Context window: ${ctxTokens.toLocaleString()} tokens (this turn's prompt)` : "",
+    compactionLine,
+    usage ? `Output ${usage.outputTokens.toLocaleString()} tokens` : "",
+    usage?.cacheReadTokens ? `${usage.cacheReadTokens.toLocaleString()} input tokens served from cache` : "",
+    usage?.costUsd != null ? `Cost ${fmtCost(usage.costUsd)}` : "",
+    usage?.durationMs ? `Took ${(usage.durationMs / 1000).toFixed(1)}s` : "",
+    "Context = the live prompt size; cost is summed across the turn's model calls.",
   ]
     .filter(Boolean)
     .join("\n");
+
   return (
     <div className="chat-usage" title={title}>
-      <span className="chat-usage-item" aria-label="prompt tokens">
-        <ArrowUp size={11} aria-hidden />
-        {fmtTokens(usage.inputTokens)}
-      </span>
-      <span className="chat-usage-item" aria-label="output tokens">
-        <ArrowDown size={11} aria-hidden />
-        {fmtTokens(usage.outputTokens)}
-      </span>
-      {usage.costUsd != null ? <span className="chat-usage-item">{fmtCost(usage.costUsd)}</span> : null}
+      {ctxTokens != null ? (
+        <span className="chat-usage-item" aria-label="context window">
+          <Gauge size={11} aria-hidden />
+          {fmtTokens(ctxTokens)}
+          {threshold ? ` / ${fmtTokens(threshold)}` : ""}
+          {pct != null ? (
+            <span className="chat-usage-bar" aria-hidden>
+              <span className="chat-usage-bar-fill" style={{ width: `${pct}%` }} data-warn={pct >= 80} />
+            </span>
+          ) : null}
+        </span>
+      ) : null}
+      {usage ? (
+        <span className="chat-usage-item" aria-label="output tokens">
+          <ArrowDown size={11} aria-hidden />
+          {fmtTokens(usage.outputTokens)}
+        </span>
+      ) : null}
+      {usage?.costUsd != null ? <span className="chat-usage-item">{fmtCost(usage.costUsd)}</span> : null}
     </div>
   );
 }

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -1,7 +1,7 @@
 import { Button } from "@protolabsai/ui/primitives";
 import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
 import { Tooltip } from "@protolabsai/ui/overlays";
-import { ArrowDownToLine, Check, Coins, Copy, GitBranch, Gauge, Loader2, Maximize2, RotateCcw } from "lucide-react";
+import { ArrowDownToLine, Check, Clock, Coins, Copy, GitBranch, Gauge, Loader2, Maximize2, RotateCcw } from "lucide-react";
 
 import { openDocument } from "../docviewer";
 import { api } from "../lib/api";
@@ -184,6 +184,11 @@ function fmtCost(usd: number): string {
   return usd < 0.01 ? `$${usd.toFixed(4)}` : `$${usd.toFixed(2)}`;
 }
 
+/** Turn duration, matching the tool-card style: sub-second in ms, else one-decimal seconds. */
+function fmtDuration(ms: number): string {
+  return ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+}
+
 /** One labelled row inside the hover tooltip. */
 function TipRow({ label, value, sub }: { label: string; value: string; sub?: string }) {
   return (
@@ -229,9 +234,8 @@ function UsageTip({
       {usage?.cacheReadTokens ? (
         <TipRow label="Cache" value={`${usage.cacheReadTokens.toLocaleString()} tokens`} sub="reused from cache" />
       ) : null}
-      {usage?.costUsd != null ? (
-        <TipRow label="Cost" value={fmtCost(usage.costUsd)} sub={usage.durationMs ? `${(usage.durationMs / 1000).toFixed(1)}s` : undefined} />
-      ) : null}
+      {usage?.durationMs ? <TipRow label="Time" value={fmtDuration(usage.durationMs)} /> : null}
+      {usage?.costUsd != null ? <TipRow label="Cost" value={fmtCost(usage.costUsd)} /> : null}
       <p className="chat-usage-tip-note">Context is the live prompt size; cost is summed across the turn's calls.</p>
     </div>
   );
@@ -268,6 +272,12 @@ function UsageFooter({ usage, context }: { usage?: TurnUsage; context?: ContextW
           <span className="chat-usage-item" aria-label="output tokens">
             <ArrowDownToLine size={13} aria-hidden />
             {fmtTokens(usage.outputTokens)}
+          </span>
+        ) : null}
+        {usage?.durationMs ? (
+          <span className="chat-usage-item" aria-label="duration">
+            <Clock size={13} aria-hidden />
+            {fmtDuration(usage.durationMs)}
           </span>
         ) : null}
         {usage?.costUsd != null ? (

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -1,9 +1,11 @@
 import { Button } from "@protolabsai/ui/primitives";
 import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
-import { ArrowDown, Check, Copy, GitBranch, Gauge, Loader2, Maximize2, RotateCcw } from "lucide-react";
+import { Tooltip } from "@protolabsai/ui/overlays";
+import { ArrowDownToLine, Check, Coins, Copy, GitBranch, Gauge, Loader2, Maximize2, RotateCcw } from "lucide-react";
 
 import { openDocument } from "../docviewer";
 import { api } from "../lib/api";
+import { useUI } from "../state/uiStore";
 import type { ChatMessage, ChatPart, ContextWindow, TurnUsage } from "../lib/types";
 import { ChatComponent } from "./ChatComponent";
 import { Markdown } from "./LazyMarkdown";
@@ -38,6 +40,8 @@ export function ChatMessageView({
   actions?: ChatMessageActions;
 }) {
   const streaming = message.status === "streaming";
+  // Per-turn token/cost footer is an opt-out display pref (Settings ▸ Chat, #1372).
+  const showChatUsage = useUI((s) => s.showChatUsage);
   return (
     <Message role={message.role} streaming={streaming} className={message.report ? "chat-report" : undefined}>
       {message.reasoning && !(message.parts && message.parts.length) ? (
@@ -138,7 +142,7 @@ export function ChatMessageView({
           <Maximize2 size={14} /> Read full report
         </Button>
       ) : null}
-      {message.role === "assistant" && !streaming && (message.usage || message.contextWindow) ? (
+      {showChatUsage && message.role === "assistant" && !streaming && (message.usage || message.contextWindow) ? (
         <UsageFooter usage={message.usage} context={message.contextWindow} />
       ) : null}
       {actions && message.role === "assistant" && !streaming && message.content ? (
@@ -180,10 +184,63 @@ function fmtCost(usd: number): string {
   return usd < 0.01 ? `$${usd.toFixed(4)}` : `$${usd.toFixed(2)}`;
 }
 
+/** One labelled row inside the hover tooltip. */
+function TipRow({ label, value, sub }: { label: string; value: string; sub?: string }) {
+  return (
+    <div className="chat-usage-tip-row">
+      <span className="chat-usage-tip-label">{label}</span>
+      <span className="chat-usage-tip-value">
+        {value}
+        {sub ? <span className="chat-usage-tip-sub">{sub}</span> : null}
+      </span>
+    </div>
+  );
+}
+
+/** Structured hover card: the full per-turn breakdown, honest about what each number means. */
+function UsageTip({
+  ctxTokens,
+  threshold,
+  context,
+  usage,
+}: {
+  ctxTokens?: number;
+  threshold?: number;
+  context?: ContextWindow;
+  usage?: TurnUsage;
+}) {
+  const compaction =
+    context == null
+      ? null
+      : context.enabled === false
+        ? "off"
+        : threshold
+          ? `near ${threshold.toLocaleString()} tokens${context.trigger ? ` · ${context.trigger}` : ""}`
+          : context.trigger
+            ? `${context.trigger} · no token threshold to chart`
+            : null;
+  return (
+    <div className="chat-usage-tip">
+      {ctxTokens != null ? (
+        <TipRow label="Context" value={`${ctxTokens.toLocaleString()} tokens`} sub="this turn's prompt" />
+      ) : null}
+      {compaction ? <TipRow label="Compaction" value={compaction} /> : null}
+      {usage ? <TipRow label="Output" value={`${usage.outputTokens.toLocaleString()} tokens`} /> : null}
+      {usage?.cacheReadTokens ? (
+        <TipRow label="Cache" value={`${usage.cacheReadTokens.toLocaleString()} tokens`} sub="reused from cache" />
+      ) : null}
+      {usage?.costUsd != null ? (
+        <TipRow label="Cost" value={fmtCost(usage.costUsd)} sub={usage.durationMs ? `${(usage.durationMs / 1000).toFixed(1)}s` : undefined} />
+      ) : null}
+      <p className="chat-usage-tip-note">Context is the live prompt size; cost is summed across the turn's calls.</p>
+    </div>
+  );
+}
+
 /** The per-turn footer under an assistant answer: a context-window meter (fill ⊙, with a
- *  "/ threshold" bar when compaction is token-based) · output ↓ · cost, with the full
- *  breakdown on hover. Honest about scope: `contextTokens` is the live prompt size; the cost
- *  is summed across the turn's calls (see ContextWindow / TurnUsage). */
+ *  "/ threshold" bar when compaction is token-based) · output ↓ · cost. The full breakdown is
+ *  a rich hover card. Honest about scope: `contextTokens` is the live prompt size; the cost is
+ *  summed across the turn's calls (see ContextWindow / TurnUsage). */
 function UsageFooter({ usage, context }: { usage?: TurnUsage; context?: ContextWindow }) {
   // Prefer the true context-window fill (peak prompt); fall back to the summed input only
   // for history saved before context-v1 shipped.
@@ -192,48 +249,34 @@ function UsageFooter({ usage, context }: { usage?: TurnUsage; context?: ContextW
   const pct =
     ctxTokens != null && threshold ? Math.min(100, Math.round((ctxTokens / threshold) * 100)) : null;
 
-  const compactionLine = context
-    ? context.enabled === false
-      ? "Compaction off"
-      : threshold
-        ? `Compacts old history near ${threshold.toLocaleString()} tokens${context.trigger ? ` (${context.trigger})` : ""}`
-        : context.trigger
-          ? `Compaction trigger: ${context.trigger} (no token threshold to chart here)`
-          : ""
-    : "";
-  const title = [
-    ctxTokens != null ? `Context window: ${ctxTokens.toLocaleString()} tokens (this turn's prompt)` : "",
-    compactionLine,
-    usage ? `Output ${usage.outputTokens.toLocaleString()} tokens` : "",
-    usage?.cacheReadTokens ? `${usage.cacheReadTokens.toLocaleString()} input tokens served from cache` : "",
-    usage?.costUsd != null ? `Cost ${fmtCost(usage.costUsd)}` : "",
-    usage?.durationMs ? `Took ${(usage.durationMs / 1000).toFixed(1)}s` : "",
-    "Context = the live prompt size; cost is summed across the turn's model calls.",
-  ]
-    .filter(Boolean)
-    .join("\n");
-
   return (
-    <div className="chat-usage" title={title}>
-      {ctxTokens != null ? (
-        <span className="chat-usage-item" aria-label="context window">
-          <Gauge size={11} aria-hidden />
-          {fmtTokens(ctxTokens)}
-          {threshold ? ` / ${fmtTokens(threshold)}` : ""}
-          {pct != null ? (
-            <span className="chat-usage-bar" aria-hidden>
-              <span className="chat-usage-bar-fill" style={{ width: `${pct}%` }} data-warn={pct >= 80} />
-            </span>
-          ) : null}
-        </span>
-      ) : null}
-      {usage ? (
-        <span className="chat-usage-item" aria-label="output tokens">
-          <ArrowDown size={11} aria-hidden />
-          {fmtTokens(usage.outputTokens)}
-        </span>
-      ) : null}
-      {usage?.costUsd != null ? <span className="chat-usage-item">{fmtCost(usage.costUsd)}</span> : null}
-    </div>
+    <Tooltip label={<UsageTip ctxTokens={ctxTokens} threshold={threshold} context={context} usage={usage} />} side="top" align="start">
+      <div className="chat-usage">
+        {ctxTokens != null ? (
+          <span className="chat-usage-item" aria-label="context window">
+            <Gauge size={13} aria-hidden />
+            {fmtTokens(ctxTokens)}
+            {threshold ? ` / ${fmtTokens(threshold)}` : ""}
+            {pct != null ? (
+              <span className="chat-usage-bar" aria-hidden>
+                <span className="chat-usage-bar-fill" style={{ width: `${pct}%` }} data-warn={pct >= 80} />
+              </span>
+            ) : null}
+          </span>
+        ) : null}
+        {usage ? (
+          <span className="chat-usage-item" aria-label="output tokens">
+            <ArrowDownToLine size={13} aria-hidden />
+            {fmtTokens(usage.outputTokens)}
+          </span>
+        ) : null}
+        {usage?.costUsd != null ? (
+          <span className="chat-usage-item" aria-label="cost">
+            <Coins size={13} aria-hidden />
+            {fmtCost(usage.costUsd)}
+          </span>
+        ) : null}
+      </div>
+    </Tooltip>
   );
 }

--- a/apps/web/src/chat/ChatMessageView.tsx
+++ b/apps/web/src/chat/ChatMessageView.tsx
@@ -1,10 +1,10 @@
 import { Button } from "@protolabsai/ui/primitives";
 import { Message, MessageAction, MessageActions } from "@protolabsai/ui/ai";
-import { Check, Copy, GitBranch, Loader2, Maximize2, RotateCcw } from "lucide-react";
+import { ArrowDown, ArrowUp, Check, Copy, GitBranch, Loader2, Maximize2, RotateCcw } from "lucide-react";
 
 import { openDocument } from "../docviewer";
 import { api } from "../lib/api";
-import type { ChatMessage, ChatPart } from "../lib/types";
+import type { ChatMessage, ChatPart, TurnUsage } from "../lib/types";
 import { ChatComponent } from "./ChatComponent";
 import { Markdown } from "./LazyMarkdown";
 import { ReasoningCard } from "./ReasoningCard";
@@ -138,6 +138,9 @@ export function ChatMessageView({
           <Maximize2 size={14} /> Read full report
         </Button>
       ) : null}
+      {message.role === "assistant" && !streaming && message.usage ? (
+        <UsageFooter usage={message.usage} />
+      ) : null}
       {actions && message.role === "assistant" && !streaming && message.content ? (
         <MessageActions>
           {actions.onCopy ? (
@@ -161,5 +164,46 @@ export function ChatMessageView({
         </MessageActions>
       ) : null}
     </Message>
+  );
+}
+
+/** Compact tokens (12340 → "12.3k", 1_200_000 → "1.2M"); raw under 1k. */
+function fmtTokens(n: number): string {
+  if (n < 1000) return String(n);
+  if (n < 1_000_000) return `${(n / 1000).toFixed(1).replace(/\.0$/, "")}k`;
+  return `${(n / 1_000_000).toFixed(2).replace(/\.?0+$/, "")}M`;
+}
+
+/** Dollars: sub-cent gets 4 decimals so a fraction-of-a-cent turn still reads non-zero. */
+function fmtCost(usd: number): string {
+  if (usd === 0) return "$0";
+  return usd < 0.01 ? `$${usd.toFixed(4)}` : `$${usd.toFixed(2)}`;
+}
+
+/** The per-turn token/cost footer under an assistant answer: prompt ↑ · output ↓ · cost,
+ *  with the full breakdown (incl. cache + duration) on hover. Honest about scope — this is
+ *  the turn's accumulated spend, not a live context-window gauge (see TurnUsage). */
+function UsageFooter({ usage }: { usage: TurnUsage }) {
+  const title = [
+    `Input ${usage.inputTokens.toLocaleString()} · Output ${usage.outputTokens.toLocaleString()} · Total ${usage.totalTokens.toLocaleString()} tokens`,
+    usage.cacheReadTokens ? `${usage.cacheReadTokens.toLocaleString()} input tokens served from cache` : "",
+    usage.costUsd != null ? `Cost ${fmtCost(usage.costUsd)}` : "",
+    usage.durationMs ? `Took ${(usage.durationMs / 1000).toFixed(1)}s` : "",
+    "Per-turn total (summed across this turn's model calls), not live context-window fill.",
+  ]
+    .filter(Boolean)
+    .join("\n");
+  return (
+    <div className="chat-usage" title={title}>
+      <span className="chat-usage-item" aria-label="prompt tokens">
+        <ArrowUp size={11} aria-hidden />
+        {fmtTokens(usage.inputTokens)}
+      </span>
+      <span className="chat-usage-item" aria-label="output tokens">
+        <ArrowDown size={11} aria-hidden />
+        {fmtTokens(usage.outputTokens)}
+      </span>
+      {usage.costUsd != null ? <span className="chat-usage-item">{fmtCost(usage.costUsd)}</span> : null}
+    </div>
   );
 }

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -952,6 +952,18 @@ function ChatSessionSlot({
             ),
           );
         },
+        onCost: (usage) => {
+          // This turn's token/cost readout (terminal cost-v1) — pin it to the assistant
+          // message so the per-turn footer survives reload with the rest of the message.
+          const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
+          if (!latest) return;
+          chatStore.updateMessages(
+            session.id,
+            latest.messages.map((message) =>
+              message.id === assistantId ? { ...message, usage } : message,
+            ),
+          );
+        },
         onDone: () => {
           const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
           if (!latest) return;

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -964,6 +964,18 @@ function ChatSessionSlot({
             ),
           );
         },
+        onContext: (contextWindow) => {
+          // This turn's context-window fill + compaction threshold (terminal context-v1) —
+          // pinned to the message so the footer meter persists with history.
+          const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
+          if (!latest) return;
+          chatStore.updateMessages(
+            session.id,
+            latest.messages.map((message) =>
+              message.id === assistantId ? { ...message, contextWindow } : message,
+            ),
+          );
+        },
         onDone: () => {
           const latest = chatStore.getSnapshot().sessions.find((item) => item.id === session.id);
           if (!latest) return;

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -61,21 +61,22 @@
   display: flex;
   flex-wrap: wrap;
   align-items: center;
-  gap: 10px;
-  margin-top: 6px;
-  color: var(--fg-muted);
+  gap: 12px;
+  margin-top: 7px;
+  color: var(--fg-secondary, var(--fg-muted));
   font-family: var(--font-mono);
-  font-size: 11px;
+  font-size: 12.5px;
+  font-weight: 500;
   font-variant-numeric: tabular-nums;
   cursor: default;
 }
 .chat-usage-item {
   display: inline-flex;
   align-items: center;
-  gap: 3px;
+  gap: 4px;
 }
 .chat-usage-item svg {
-  opacity: 0.7;
+  opacity: 0.85;
 }
 /* Context-window fill bar — quiet until it nears the compaction threshold, then warns. */
 .chat-usage-bar {
@@ -96,6 +97,51 @@
 }
 .chat-usage-bar-fill[data-warn="true"] {
   background: var(--warning, #d98324);
+}
+
+/* Hover card (DS Tooltip content): a compact label/value breakdown of the turn. */
+.chat-usage-tip {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  min-width: 190px;
+  font-family: var(--font-mono);
+  font-variant-numeric: tabular-nums;
+  text-align: left;
+}
+.chat-usage-tip-row {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 16px;
+}
+.chat-usage-tip-label {
+  color: var(--fg-muted);
+  font-size: 11px;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.chat-usage-tip-value {
+  font-size: 12px;
+  font-weight: 500;
+  text-align: right;
+}
+.chat-usage-tip-sub {
+  display: block;
+  color: var(--fg-muted);
+  font-weight: 400;
+  font-size: 10.5px;
+}
+.chat-usage-tip-note {
+  margin: 3px 0 0;
+  padding-top: 6px;
+  border-top: 1px solid color-mix(in srgb, currentColor 18%, transparent);
+  color: var(--fg-muted);
+  font-family: var(--font-sans, inherit);
+  font-size: 11px;
+  line-height: 1.4;
+  white-space: normal;
+  max-width: 230px;
 }
 
 /* Quick-delete mode: while Shift is held, the tab ✕ becomes a red trashcan (Shift+click

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -77,6 +77,26 @@
 .chat-usage-item svg {
   opacity: 0.7;
 }
+/* Context-window fill bar — quiet until it nears the compaction threshold, then warns. */
+.chat-usage-bar {
+  display: inline-block;
+  width: 42px;
+  height: 4px;
+  margin-left: 2px;
+  border-radius: 2px;
+  background: var(--border);
+  overflow: hidden;
+  vertical-align: middle;
+}
+.chat-usage-bar-fill {
+  display: block;
+  height: 100%;
+  border-radius: 2px;
+  background: var(--fg-muted);
+}
+.chat-usage-bar-fill[data-warn="true"] {
+  background: var(--warning, #d98324);
+}
 
 /* Quick-delete mode: while Shift is held, the tab ✕ becomes a red trashcan (Shift+click
    deletes with no confirm + no harvest). Swap the DS ✕ svg for a trash silhouette (mask

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -55,6 +55,29 @@
   margin-top: 8px;
 }
 
+/* Per-turn token/cost footer under an assistant answer (#1372) — a quiet, monospace row of
+   prompt ↑ / output ↓ / cost chips; full breakdown lives in the title tooltip. */
+.chat-usage {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 10px;
+  margin-top: 6px;
+  color: var(--fg-muted);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  font-variant-numeric: tabular-nums;
+  cursor: default;
+}
+.chat-usage-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+}
+.chat-usage-item svg {
+  opacity: 0.7;
+}
+
 /* Quick-delete mode: while Shift is held, the tab ✕ becomes a red trashcan (Shift+click
    deletes with no confirm + no harvest). Swap the DS ✕ svg for a trash silhouette (mask
    tinted via currentColor). */

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -8,6 +8,7 @@ import type {
   ChatMessage,
   ComponentSpec,
   ConfigPayload,
+  ContextWindow,
   DelegateProbe,
   DelegateTypeSpec,
   DelegateView,
@@ -367,6 +368,7 @@ const HITL_MIME = "application/vnd.protolabs.hitl-v1+json";
 const COMPONENT_MIME = "application/vnd.protolabs.component-v1+json";
 const REASONING_MIME = "application/vnd.protolabs.reasoning-v1+json";
 const COST_MIME = "application/vnd.protolabs.cost-v1+json";
+const CONTEXT_MIME = "application/vnd.protolabs.context-v1+json";
 
 type RawPart = {
   kind?: string;
@@ -473,6 +475,30 @@ export function costFromParts(parts?: RawPart[]): TurnUsage | null {
     cacheCreationTokens: Number(d.usage.cache_creation_input_tokens || 0),
     ...(typeof d.costUsd === "number" ? { costUsd: d.costUsd } : {}),
     ...(typeof d.durationMs === "number" ? { durationMs: d.durationMs } : {}),
+  };
+}
+
+/** Decode the terminal context-v1 DataPart (#1372) → the turn's context-window fill +
+ * compaction threshold, or null. `compactionAtTokens` / `maxTokens` are present only when the
+ * server could resolve a token denominator (token-based trigger); otherwise the meter shows
+ * the raw size. */
+export function contextFromParts(parts?: RawPart[]): ContextWindow | null {
+  const d = dataByMime(parts, CONTEXT_MIME) as
+    | {
+        contextTokens?: number;
+        compactionAtTokens?: number;
+        maxTokens?: number;
+        trigger?: string;
+        enabled?: boolean;
+      }
+    | null;
+  if (!d || typeof d.contextTokens !== "number") return null;
+  return {
+    contextTokens: d.contextTokens,
+    ...(typeof d.compactionAtTokens === "number" ? { compactionAtTokens: d.compactionAtTokens } : {}),
+    ...(typeof d.maxTokens === "number" ? { maxTokens: d.maxTokens } : {}),
+    ...(typeof d.trigger === "string" ? { trigger: d.trigger } : {}),
+    ...(typeof d.enabled === "boolean" ? { enabled: d.enabled } : {}),
   };
 }
 
@@ -1097,6 +1123,8 @@ export const api = {
       onComponent?: (spec: ComponentSpec) => void;
       // This turn's token usage + cost — lifted off the terminal cost-v1 DataPart.
       onCost?: (usage: TurnUsage) => void;
+      // This turn's context-window fill + compaction threshold — terminal context-v1 DataPart.
+      onContext?: (ctx: ContextWindow) => void;
       onInputRequired?: (payload: HitlPayload) => void;
       // Terminal failure (A2A `TASK_STATE_FAILED`) — e.g. the model rejected the
       // turn (bad API key → 401). Carries the gateway's error text. Without this
@@ -1172,10 +1200,12 @@ export const api = {
         const aParts = artifactUpdate.artifact?.parts;
         const text = textFromParts(aParts);
         if (text) handlers.onText?.(text, artifactUpdate.append !== false);
-        // The terminal answer artifact also carries the cost-v1 DataPart (a2a_impl
-        // executor) — surface this turn's token usage + cost for the per-turn footer.
+        // The terminal answer artifact also carries the cost-v1 + context-v1 DataParts
+        // (a2a_impl executor) — surface this turn's spend and its context-window fill.
         const usage = costFromParts(aParts);
         if (usage) handlers.onCost?.(usage);
+        const ctx = contextFromParts(aParts);
+        if (ctx) handlers.onContext?.(ctx);
       }
     };
 

--- a/apps/web/src/lib/api.ts
+++ b/apps/web/src/lib/api.ts
@@ -35,6 +35,7 @@ import type {
   TelemetrySummary,
   TelemetryTurn,
   ToolEvent,
+  TurnUsage,
   WorkflowRunResult,
   WorkflowSummary,
 } from "./types";
@@ -365,6 +366,7 @@ const TOOL_CALL_MIME = "application/vnd.protolabs.tool-call-v1+json";
 const HITL_MIME = "application/vnd.protolabs.hitl-v1+json";
 const COMPONENT_MIME = "application/vnd.protolabs.component-v1+json";
 const REASONING_MIME = "application/vnd.protolabs.reasoning-v1+json";
+const COST_MIME = "application/vnd.protolabs.cost-v1+json";
 
 type RawPart = {
   kind?: string;
@@ -441,6 +443,37 @@ export function hitlFromParts(parts?: RawPart[]): HitlPayload | null {
 function reasoningFromParts(parts?: RawPart[]): string | null {
   const d = dataByMime(parts, REASONING_MIME) as { text?: string } | null;
   return d?.text || null;
+}
+
+/** Decode the terminal cost-v1 DataPart (A2A ext) → this turn's token usage + cost, or null.
+ * Wire shape: `{ usage: {input_tokens, output_tokens, cache_read_input_tokens,
+ * cache_creation_input_tokens}, costUsd?, durationMs? }`. The snake_case `usage` fields are
+ * mapped to the camelCase `TurnUsage` the console renders; totalTokens is derived. */
+export function costFromParts(parts?: RawPart[]): TurnUsage | null {
+  const d = dataByMime(parts, COST_MIME) as
+    | {
+        usage?: {
+          input_tokens?: number;
+          output_tokens?: number;
+          cache_read_input_tokens?: number;
+          cache_creation_input_tokens?: number;
+        };
+        costUsd?: number;
+        durationMs?: number;
+      }
+    | null;
+  if (!d || !d.usage) return null;
+  const inputTokens = Number(d.usage.input_tokens || 0);
+  const outputTokens = Number(d.usage.output_tokens || 0);
+  return {
+    inputTokens,
+    outputTokens,
+    totalTokens: inputTokens + outputTokens,
+    cacheReadTokens: Number(d.usage.cache_read_input_tokens || 0),
+    cacheCreationTokens: Number(d.usage.cache_creation_input_tokens || 0),
+    ...(typeof d.costUsd === "number" ? { costUsd: d.costUsd } : {}),
+    ...(typeof d.durationMs === "number" ? { durationMs: d.durationMs } : {}),
+  };
 }
 
 function textFromTerminalTask(result: NonNullable<A2AFrame["result"]>) {
@@ -1062,6 +1095,8 @@ export const api = {
       onReasoning?: (delta: string) => void;
       onToolCall?: (evt: ToolEvent) => void;
       onComponent?: (spec: ComponentSpec) => void;
+      // This turn's token usage + cost — lifted off the terminal cost-v1 DataPart.
+      onCost?: (usage: TurnUsage) => void;
       onInputRequired?: (payload: HitlPayload) => void;
       // Terminal failure (A2A `TASK_STATE_FAILED`) — e.g. the model rejected the
       // turn (bad API key → 401). Carries the gateway's error text. Without this
@@ -1134,8 +1169,13 @@ export const api = {
         }
       }
       if (artifactUpdate) {
-        const text = textFromParts(artifactUpdate.artifact?.parts);
+        const aParts = artifactUpdate.artifact?.parts;
+        const text = textFromParts(aParts);
         if (text) handlers.onText?.(text, artifactUpdate.append !== false);
+        // The terminal answer artifact also carries the cost-v1 DataPart (a2a_impl
+        // executor) — surface this turn's token usage + cost for the per-turn footer.
+        const usage = costFromParts(aParts);
+        if (usage) handlers.onCost?.(usage);
       }
     };
 

--- a/apps/web/src/lib/cost-parts.test.ts
+++ b/apps/web/src/lib/cost-parts.test.ts
@@ -1,8 +1,9 @@
 import { describe, expect, it } from "vitest";
 
-import { costFromParts } from "./api";
+import { contextFromParts, costFromParts } from "./api";
 
 const COST_MIME = "application/vnd.protolabs.cost-v1+json";
+const CONTEXT_MIME = "application/vnd.protolabs.context-v1+json";
 
 // costFromParts lifts the terminal cost-v1 DataPart (A2A ext) into the camelCase TurnUsage
 // the per-turn footer renders. It must map snake_case wire fields, derive totalTokens, and
@@ -61,5 +62,36 @@ describe("costFromParts", () => {
     expect(costFromParts(undefined)).toBeNull();
     expect(costFromParts([{ metadata: { mimeType: "text/plain" }, data: { usage: {} } }])).toBeNull();
     expect(costFromParts([{ metadata: { mimeType: COST_MIME }, data: { costUsd: 1 } }])).toBeNull();
+  });
+});
+
+describe("contextFromParts", () => {
+  it("decodes the token-based context-v1 readout (with a compaction threshold)", () => {
+    const ctx = contextFromParts([
+      {
+        metadata: { mimeType: CONTEXT_MIME },
+        data: { contextTokens: 48_000, compactionAtTokens: 120_000, trigger: "tokens:120000", enabled: true },
+      },
+    ]);
+    expect(ctx).toEqual({
+      contextTokens: 48_000,
+      compactionAtTokens: 120_000,
+      trigger: "tokens:120000",
+      enabled: true,
+    });
+  });
+
+  it("keeps the size but omits the threshold for a non-token trigger (fraction/messages)", () => {
+    const ctx = contextFromParts([
+      { metadata: { mimeType: CONTEXT_MIME }, content: { $case: "data", value: { contextTokens: 9_000, trigger: "messages:80", enabled: true } } },
+    ]);
+    expect(ctx?.contextTokens).toBe(9_000);
+    expect(ctx).not.toHaveProperty("compactionAtTokens");
+    expect(ctx?.trigger).toBe("messages:80");
+  });
+
+  it("returns null with no context part or no contextTokens", () => {
+    expect(contextFromParts(undefined)).toBeNull();
+    expect(contextFromParts([{ metadata: { mimeType: CONTEXT_MIME }, data: { trigger: "tokens:1" } }])).toBeNull();
   });
 });

--- a/apps/web/src/lib/cost-parts.test.ts
+++ b/apps/web/src/lib/cost-parts.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from "vitest";
+
+import { costFromParts } from "./api";
+
+const COST_MIME = "application/vnd.protolabs.cost-v1+json";
+
+// costFromParts lifts the terminal cost-v1 DataPart (A2A ext) into the camelCase TurnUsage
+// the per-turn footer renders. It must map snake_case wire fields, derive totalTokens, and
+// match across every DataPart encoding the fleet emits (flattened `data` + 1.0 `content.value`).
+
+describe("costFromParts", () => {
+  const payload = {
+    usage: {
+      input_tokens: 12_340,
+      output_tokens: 1_200,
+      cache_read_input_tokens: 8_000,
+      cache_creation_input_tokens: 320,
+    },
+    costUsd: 0.0412,
+    durationMs: 2300,
+    success: true,
+  };
+
+  it("maps the flattened-`data` encoding → camelCase usage, deriving totalTokens", () => {
+    const usage = costFromParts([{ metadata: { mimeType: COST_MIME }, data: payload }]);
+    expect(usage).toEqual({
+      inputTokens: 12_340,
+      outputTokens: 1_200,
+      totalTokens: 13_540,
+      cacheReadTokens: 8_000,
+      cacheCreationTokens: 320,
+      costUsd: 0.0412,
+      durationMs: 2300,
+    });
+  });
+
+  it("matches the A2A 1.0 member-discriminated encoding (content.$case === 'data')", () => {
+    const usage = costFromParts([
+      { metadata: { mimeType: COST_MIME }, content: { $case: "data", value: payload } },
+    ]);
+    expect(usage?.inputTokens).toBe(12_340);
+    expect(usage?.totalTokens).toBe(13_540);
+  });
+
+  it("omits costUsd / durationMs when the wire payload omits them", () => {
+    const usage = costFromParts([
+      { metadata: { mimeType: COST_MIME }, data: { usage: { input_tokens: 10, output_tokens: 5 } } },
+    ]);
+    expect(usage).toEqual({
+      inputTokens: 10,
+      outputTokens: 5,
+      totalTokens: 15,
+      cacheReadTokens: 0,
+      cacheCreationTokens: 0,
+    });
+    expect(usage).not.toHaveProperty("costUsd");
+    expect(usage).not.toHaveProperty("durationMs");
+  });
+
+  it("returns null when there's no cost part, or the part lacks a usage block", () => {
+    expect(costFromParts(undefined)).toBeNull();
+    expect(costFromParts([{ metadata: { mimeType: "text/plain" }, data: { usage: {} } }])).toBeNull();
+    expect(costFromParts([{ metadata: { mimeType: COST_MIME }, data: { costUsd: 1 } }])).toBeNull();
+  });
+});

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -434,6 +434,21 @@ export type TurnUsage = {
   durationMs?: number;
 };
 
+/** Live context-window readout for a turn (terminal context-v1 DataPart, #1372). Unlike
+ *  TurnUsage (per-turn spend), `contextTokens` is the PEAK single-call prompt size — the
+ *  actual context-window fill. `compactionAtTokens` is the absolute summarization threshold
+ *  when the operator's trigger is token-based (`tokens:N`); fraction:/messages: triggers have
+ *  no surfaceable token denominator (the gateway exposes no per-model window), so the meter
+ *  shows the size without a bar. */
+export type ContextWindow = {
+  contextTokens: number;
+  compactionAtTokens?: number;
+  maxTokens?: number;
+  /** The configured compaction trigger string, for the tooltip (e.g. "tokens:120000"). */
+  trigger?: string;
+  enabled?: boolean;
+};
+
 export type ChatMessage = {
   id?: string;
   role: "user" | "assistant" | "system";
@@ -459,6 +474,9 @@ export type ChatMessage = {
   /** This turn's token usage + cost (terminal cost-v1 DataPart). Shown as a small footer
    *  under the answer; absent on user turns and history saved before this shipped. */
   usage?: TurnUsage;
+  /** This turn's context-window fill + compaction threshold (terminal context-v1 DataPart).
+   *  Drives the meter in the same footer; absent on user turns / pre-ship history. */
+  contextWindow?: ContextWindow;
 };
 
 // HITL (human-in-the-loop) request surfaced when a turn pauses as input-required

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -418,6 +418,22 @@ export type ChatPart =
   | { kind: "reasoning"; text: string }
   | { kind: "tools"; ids: string[] };
 
+/** Per-turn token usage + cost, accumulated across the turn's LLM calls — lifted off the
+ *  terminal cost-v1 DataPart (A2A ext, ADR 0006). `inputTokens` is the SUM of prompt tokens
+ *  across the turn's calls (so a tool-loop turn counts each model call's prompt), NOT the live
+ *  context-window fill; it's a per-turn spend/size readout, not a context-fullness gauge. */
+export type TurnUsage = {
+  inputTokens: number;
+  outputTokens: number;
+  totalTokens: number;
+  /** Prompt tokens served from the model's cache (subset of inputTokens). */
+  cacheReadTokens: number;
+  /** Prompt tokens written to the cache this turn (subset of inputTokens). */
+  cacheCreationTokens: number;
+  costUsd?: number;
+  durationMs?: number;
+};
+
 export type ChatMessage = {
   id?: string;
   role: "user" | "assistant" | "system";
@@ -440,6 +456,9 @@ export type ChatMessage = {
    *  shows the server's preview; this lets the card open the FULL report in the document
    *  viewer (fetched by id) instead of forcing a trip to the Activity/Background panel. */
   report?: { jobId: string; title: string };
+  /** This turn's token usage + cost (terminal cost-v1 DataPart). Shown as a small footer
+   *  under the answer; absent on user turns and history saved before this shipped. */
+  usage?: TurnUsage;
 };
 
 // HITL (human-in-the-loop) request surfaced when a turn pauses as input-required

--- a/apps/web/src/settings/ChatSettingsPanel.tsx
+++ b/apps/web/src/settings/ChatSettingsPanel.tsx
@@ -1,0 +1,35 @@
+import { PanelHeader } from "@protolabsai/ui/navigation";
+import { Switch } from "@protolabsai/ui/forms";
+
+import { useUI } from "../state/uiStore";
+
+// Settings → Chat: client-side display preferences for the chat transcript. These live in the
+// persisted UI store (this device), NOT the agent config — they change what THIS console shows,
+// not how the agent behaves. First member: the per-turn token/cost + context-window footer (#1372).
+export function ChatSettingsPanel() {
+  const showChatUsage = useUI((s) => s.showChatUsage);
+  const setShowChatUsage = useUI((s) => s.setShowChatUsage);
+
+  return (
+    <section className="panel stage-panel">
+      <PanelHeader title="Chat" kicker="how this console renders the transcript — saved on this device" />
+      <div className="stage-body">
+        <div className="setting-row" data-key="chat.showUsage">
+          <div className="setting-meta">
+            <span className="setting-label">Token &amp; cost footer</span>
+            <p className="setting-desc">
+              Show the context-window meter, output tokens, and cost under each answer. Turn off for
+              a cleaner transcript.
+            </p>
+          </div>
+          <Switch
+            id="chat-show-usage"
+            checked={showChatUsage}
+            onCheckedChange={setShowChatUsage}
+            label={showChatUsage ? "on" : "off"}
+          />
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/settings/SettingsSurface.tsx
+++ b/apps/web/src/settings/SettingsSurface.tsx
@@ -1,4 +1,4 @@
-import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, Keyboard, Layers, Network, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Store, Wrench } from "lucide-react";
+import { BarChart3, Bot, BookMarked, Boxes, Database, Gauge, Keyboard, Layers, MessageSquare, Network, Palette, Plug, Puzzle, Server, Settings2, Sparkles, Store, Wrench } from "lucide-react";
 import type { LucideIcon } from "lucide-react";
 import { useEffect, type ReactNode } from "react";
 
@@ -17,6 +17,7 @@ import { useUI } from "../state/uiStore";
 import { DelegatesSection } from "./DelegatesSection";
 import { FleetSurface } from "./FleetSurface";
 import { KeybindingsPanel } from "./KeybindingsPanel";
+import { ChatSettingsPanel } from "./ChatSettingsPanel";
 import { OverviewPanel } from "./OverviewPanel";
 import { SettingsCategoryPanel } from "./SettingsCategory";
 import { ThemeSurface } from "./ThemeSurface";
@@ -51,6 +52,7 @@ const AGENT_SECTIONS: Section[] = [
   { id: "memory", label: "Memory", icon: Database, render: () => <SettingsCategoryPanel category="Memory" title="Memory" /> },
   { id: "system", label: "System", icon: Settings2, render: () => <SettingsCategoryPanel category="System" title="System" /> },
   { id: "theme", label: "Theme", icon: Palette, render: () => <ThemeSurface /> },
+  { id: "chat", label: "Chat", icon: MessageSquare, render: () => <ChatSettingsPanel /> },
   { id: "keybindings", label: "Keyboard", icon: Keyboard, render: () => <KeybindingsPanel /> },
 ];
 

--- a/apps/web/src/state/uiStore.ts
+++ b/apps/web/src/state/uiStore.ts
@@ -129,6 +129,10 @@ type UIState = {
   // bus activity shows a rail dot until opened. Persisted so the dot survives a refresh.
   pluginDots: Record<string, boolean>;
   setPluginDot: (key: string, on: boolean) => void;
+  // Chat display: show the per-turn token/cost + context-window footer under each answer
+  // (#1372). On by default; operators who want a cleaner transcript turn it off (this device).
+  showChatUsage: boolean;
+  setShowChatUsage: (b: boolean) => void;
 };
 
 // The pristine rail layout — the store's initial value AND the side-of-record for
@@ -430,6 +434,8 @@ export const useUI = create<UIState>()(
           else delete next[key];
           return { pluginDots: next };
         }),
+      showChatUsage: true,
+      setShowChatUsage: (showChatUsage) => set({ showChatUsage }),
     }),
     {
       name: "protoagent.ui", // localStorage key (per-agent-suffixed in fleet mode — see _layoutStorage)

--- a/graph/llm.py
+++ b/graph/llm.py
@@ -154,6 +154,18 @@ def create_llm(
     # caches per (model, effort) so the rebuild is paid once.
     if reasoning_effort:
         kwargs["reasoning_effort"] = reasoning_effort
+    # Context window (#1378): seed the model profile with the gateway's reported
+    # max_input_tokens so SummarizationMiddleware can resolve fraction:/tokens: compaction
+    # (instead of falling back to a message count) and the chat context meter (#1372) gets a
+    # real denominator. Best-effort + cached — an unknown window just omits the profile.
+    try:
+        from graph.model_window import context_window_for
+
+        win = context_window_for(config, kwargs.get("model"))
+        if win:
+            kwargs.setdefault("profile", {"max_input_tokens": win})
+    except Exception:  # noqa: BLE001 — model-info must never break model creation
+        log.debug("[llm] context-window resolution skipped", exc_info=True)
     return _ReasoningChatOpenAI(**kwargs)
 
 

--- a/graph/model_window.py
+++ b/graph/model_window.py
@@ -1,0 +1,97 @@
+"""Resolve a model's input context window from the LiteLLM gateway (#1378).
+
+LangChain's ``SummarizationMiddleware`` needs ``model.profile["max_input_tokens"]`` to turn a
+``fraction:`` / ``tokens:`` compaction trigger into an absolute token threshold; a bare gateway
+alias has no built-in profile, so without this it falls back to a message-count trigger and the
+chat context meter (#1372) has no ``/ window`` denominator.
+
+The LiteLLM proxy already knows each model's window — declared ``model_info.max_input_tokens``
+for self-hosted models, derived from its registry for recognized ones — and serves it at
+``/v1/model/group/info``. We fetch that map ONCE per gateway base (best-effort, short timeout)
+and cache it; ``create_llm`` sets the profile from it, and the cost/context emitter reads it for
+the meter denominator. A gateway that's down or omits the model just leaves the window unknown —
+exactly today's behavior (message-count fallback, size-only meter).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from graph.config import LangGraphConfig
+
+log = logging.getLogger(__name__)
+
+# api_base -> {model_name: max_input_tokens}. Attempted bases are recorded so a miss/outage
+# doesn't refetch on every turn (the cost emitter calls this per turn).
+_WINDOWS: dict[str, dict[str, int]] = {}
+_ATTEMPTED: set[str] = set()
+
+_GATEWAY_UA = "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)"
+
+
+def _fetch_window_map(api_base: str, api_key: str) -> dict[str, int]:
+    """GET the LiteLLM proxy's per-group context windows → ``{model_group: max_input_tokens}``.
+
+    Bounded: a connection error / timeout on the first path returns empty (don't hammer the
+    second). ``/v1/model/group/info`` is the grouped view (top-level ``max_input_tokens`` per
+    ``model_group``); ``/model/group/info`` is the un-versioned alias — proxies differ on prefix.
+    """
+    import httpx
+
+    root = (api_base or "").rstrip("/")
+    if root.endswith("/v1"):
+        root = root[:-3]
+    headers = {"User-Agent": _GATEWAY_UA}
+    if api_key:
+        headers["Authorization"] = f"Bearer {api_key}"
+
+    out: dict[str, int] = {}
+    for i, url in enumerate((f"{root}/v1/model/group/info", f"{root}/model/group/info")):
+        try:
+            resp = httpx.get(url, headers=headers, timeout=2.5)
+        except Exception:  # noqa: BLE001 — host unreachable/timeout: don't try the second path
+            return out
+        if resp.status_code != 200:
+            # 404 on the versioned path → try the un-versioned one; any other status → give up.
+            if i == 0 and resp.status_code == 404:
+                continue
+            return out
+        try:
+            data = resp.json().get("data") or []
+        except Exception:  # noqa: BLE001 — non-JSON body
+            return out
+        for entry in data:
+            if not isinstance(entry, dict):
+                continue
+            name = entry.get("model_group") or entry.get("model_name")
+            win = entry.get("max_input_tokens")
+            if isinstance(name, str) and isinstance(win, int) and win > 0:
+                out[name] = win
+        return out
+    return out
+
+
+def context_window_for(config: LangGraphConfig, model_name: str | None = None) -> int | None:
+    """The input context window (``max_input_tokens``) for a model on the gateway, or ``None``.
+
+    Fetched once per gateway base and cached, so it's safe to call per turn. Returns ``None``
+    when the gateway is unreachable or doesn't report the model — callers degrade gracefully
+    (no profile → message-count compaction; size-only meter)."""
+    base = (config.api_base or "").rstrip("/")
+    if not base:
+        return None
+    if base not in _ATTEMPTED:
+        _ATTEMPTED.add(base)
+        try:
+            _WINDOWS[base] = _fetch_window_map(base, config.api_key or "")
+        except Exception:  # noqa: BLE001 — never let model-info break model creation / a turn
+            _WINDOWS[base] = {}
+            log.debug("[model-window] fetch failed for %s", base, exc_info=True)
+    model = (model_name or config.model_name or "").strip()
+    return _WINDOWS.get(base, {}).get(model)
+
+
+def reset_window_cache() -> None:
+    """Drop the cached windows — call after a config change (gateway/key) or in tests."""
+    _WINDOWS.clear()
+    _ATTEMPTED.clear()

--- a/graph/model_window.py
+++ b/graph/model_window.py
@@ -29,12 +29,25 @@ _ATTEMPTED: set[str] = set()
 _GATEWAY_UA = "protoAgent/0.1 (+https://github.com/protoLabsAI/protoAgent)"
 
 
-def _fetch_window_map(api_base: str, api_key: str) -> dict[str, int]:
-    """GET the LiteLLM proxy's per-group context windows → ``{model_group: max_input_tokens}``.
+def _window_from_entry(entry: dict) -> tuple[str | None, int | None]:
+    """(model name, max_input_tokens) from one LiteLLM info row, across both shapes:
+    ``/model/info`` nests it under ``model_info.max_input_tokens`` (per deployment); the
+    grouped ``/model/group/info`` view puts ``max_input_tokens`` top-level on ``model_group``."""
+    name = entry.get("model_name") or entry.get("model_group")
+    info = entry.get("model_info") if isinstance(entry.get("model_info"), dict) else {}
+    win = info.get("max_input_tokens")
+    if win is None:
+        win = entry.get("max_input_tokens")
+    return (name if isinstance(name, str) else None, win if isinstance(win, int) and win > 0 else None)
 
-    Bounded: a connection error / timeout on the first path returns empty (don't hammer the
-    second). ``/v1/model/group/info`` is the grouped view (top-level ``max_input_tokens`` per
-    ``model_group``); ``/model/group/info`` is the un-versioned alias — proxies differ on prefix.
+
+def _fetch_window_map(api_base: str, api_key: str) -> dict[str, int]:
+    """GET the LiteLLM proxy's model metadata → ``{model_name: max_input_tokens}``.
+
+    Tries the per-deployment ``/model/info`` first (what our gateway exposes — window nested
+    under ``model_info``), then the grouped ``/model/group/info`` (top-level window), each in
+    its ``/v1``-prefixed and un-prefixed form (proxies differ). Bounded: a connection error /
+    timeout stops the probe (the host is unreachable), so worst case is one timeout.
     """
     import httpx
 
@@ -46,28 +59,25 @@ def _fetch_window_map(api_base: str, api_key: str) -> dict[str, int]:
         headers["Authorization"] = f"Bearer {api_key}"
 
     out: dict[str, int] = {}
-    for i, url in enumerate((f"{root}/v1/model/group/info", f"{root}/model/group/info")):
+    for path in ("/v1/model/info", "/model/info", "/v1/model/group/info", "/model/group/info"):
         try:
-            resp = httpx.get(url, headers=headers, timeout=2.5)
-        except Exception:  # noqa: BLE001 — host unreachable/timeout: don't try the second path
+            resp = httpx.get(f"{root}{path}", headers=headers, timeout=2.5)
+        except Exception:  # noqa: BLE001 — host unreachable/timeout: stop probing
             return out
         if resp.status_code != 200:
-            # 404 on the versioned path → try the un-versioned one; any other status → give up.
-            if i == 0 and resp.status_code == 404:
-                continue
-            return out
+            continue  # wrong shape/path for this proxy — try the next
         try:
             data = resp.json().get("data") or []
         except Exception:  # noqa: BLE001 — non-JSON body
-            return out
+            continue
         for entry in data:
             if not isinstance(entry, dict):
                 continue
-            name = entry.get("model_group") or entry.get("model_name")
-            win = entry.get("max_input_tokens")
-            if isinstance(name, str) and isinstance(win, int) and win > 0:
+            name, win = _window_from_entry(entry)
+            if name and win:
                 out[name] = win
-        return out
+        if out:
+            return out
     return out
 
 

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -766,15 +766,29 @@ def _main():
 
     def _context_meta() -> dict:
         """Static compaction context for the context-v1 DataPart (#1372): whether compaction
-        is on, the configured trigger, and the absolute token threshold when the trigger is
-        token-based. fraction:/messages: triggers have no surfaceable token denominator here
-        (a gateway alias exposes no model window), so the console shows the size without a bar."""
+        is on, the configured trigger, the model's context window, and the absolute token
+        threshold compaction fires at. The window comes from the gateway (#1378), so a
+        `fraction:` trigger now resolves to `fraction × window`; `tokens:N` is taken verbatim;
+        `messages:` has no token threshold (the meter shows size without a bar)."""
         cfg = STATE.graph_config
         trigger = str(getattr(cfg, "compaction_trigger", "") or "")
         meta: dict = {"enabled": bool(getattr(cfg, "compaction_enabled", False)), "trigger": trigger}
+        from graph.model_window import context_window_for
+
+        window = context_window_for(cfg)
+        if window:
+            meta["maxTokens"] = window
         kind, _, val = trigger.partition(":")
-        if kind == "tokens" and val.strip().isdigit():
-            meta["compactionAtTokens"] = int(val.strip())
+        val = val.strip()
+        if kind == "tokens" and val.isdigit():
+            meta["compactionAtTokens"] = int(val)
+        elif kind == "fraction" and window:
+            try:
+                frac = float(val)
+            except ValueError:
+                frac = 0.0
+            if 0 < frac <= 1:
+                meta["compactionAtTokens"] = int(window * frac)
         return meta
 
     _a2a_push_client = httpx.AsyncClient(timeout=30)

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -764,9 +764,26 @@ def _main():
 
         return await finalize_structured(skill_id, spec["schema"], spec["mime"], final_text, STATE.graph_config)
 
+    def _context_meta() -> dict:
+        """Static compaction context for the context-v1 DataPart (#1372): whether compaction
+        is on, the configured trigger, and the absolute token threshold when the trigger is
+        token-based. fraction:/messages: triggers have no surfaceable token denominator here
+        (a gateway alias exposes no model window), so the console shows the size without a bar."""
+        cfg = STATE.graph_config
+        trigger = str(getattr(cfg, "compaction_trigger", "") or "")
+        meta: dict = {"enabled": bool(getattr(cfg, "compaction_enabled", False)), "trigger": trigger}
+        kind, _, val = trigger.partition(":")
+        if kind == "tokens" and val.strip().isdigit():
+            meta["compactionAtTokens"] = int(val.strip())
+        return meta
+
     _a2a_push_client = httpx.AsyncClient(timeout=30)
     a2a_request_handler = DefaultRequestHandler(
-        agent_executor=ProtoAgentExecutor(_chat_langgraph_stream, structured_finalizer=_structured_finalizer),
+        agent_executor=ProtoAgentExecutor(
+            _chat_langgraph_stream,
+            structured_finalizer=_structured_finalizer,
+            context_meta_provider=_context_meta,
+        ),
         task_store=task_store,
         agent_card=a2a_card,
         push_config_store=push_config_store,

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -292,10 +292,12 @@ async def test_terminal_artifact_carries_all_extensions_in_order():
     assert parts[0]["text"] == "done text"
     mimes = [p.get("metadata", {}).get("mimeType") for p in parts[1:]]
     assert mimes == [pa.WORLDSTATE_DELTA_MIME, pa.COST_MIME, pa.CONFIDENCE_MIME, _CONTEXT_MIME]
-    # cost-v1 payload carries the SUMMED token usage (100+140 input).
+    # cost-v1 payload carries the SUMMED token usage (100+140 input) + the turn duration.
     cost = pa.parse_cost(parts[2])
     assert cost["usage"]["input_tokens"] == 240
     assert cost["success"] is True
+    # durationMs is present (proto-JSON round-trips numbers as floats, so compare numerically).
+    assert isinstance(cost["durationMs"], (int, float)) and cost["durationMs"] >= 0
     # context-v1 carries the PEAK prompt size (max single call's input_tokens), the live
     # context-window fill — distinct from the summed spend above.
     _ctx_mime, ctx = pa.read_data(parts[4])

--- a/tests/test_a2a_handler.py
+++ b/tests/test_a2a_handler.py
@@ -37,7 +37,7 @@ from fastapi import FastAPI
 from google.protobuf.json_format import MessageToDict
 
 import protolabs_a2a as pa
-from a2a_impl.executor import ProtoAgentExecutor, TurnOutcome, set_terminal_hook
+from a2a_impl.executor import _CONTEXT_MIME, ProtoAgentExecutor, TurnOutcome, set_terminal_hook
 
 A2A_HEADERS = {"A2A-Version": "1.0"}
 
@@ -271,12 +271,14 @@ async def test_send_message_runs_to_completed_with_text_artifact():
 
 @pytest.mark.asyncio
 async def test_terminal_artifact_carries_all_extensions_in_order():
-    """text → worldstate-delta → cost-v1 → confidence-v1, matching the order
-    the hand-rolled handler emitted (consumers read parts in order)."""
+    """text → worldstate-delta → cost-v1 → confidence-v1 → context-v1, matching
+    the order the hand-rolled handler emitted (consumers read parts in order); the
+    context-v1 readout (#1372) trails as a pure append."""
 
     async def stream(text, ctx, *, resume=False, caller_trace=None, **kwargs):
         yield ("text", "done text")
         yield ("usage", {"input_tokens": 100, "output_tokens": 50, "cost_usd": 0.001})
+        yield ("usage", {"input_tokens": 140, "output_tokens": 20, "cost_usd": 0.001})
         yield ("delta", {"domain": "board", "path": "data.backlog", "op": "inc", "value": 1})
         yield ("confidence", {"confidence": 0.9, "explanation": "sure"})
         yield ("done", "done text")
@@ -289,12 +291,16 @@ async def test_terminal_artifact_carries_all_extensions_in_order():
     parts = final["artifacts"][0]["parts"]
     assert parts[0]["text"] == "done text"
     mimes = [p.get("metadata", {}).get("mimeType") for p in parts[1:]]
-    assert mimes == [pa.WORLDSTATE_DELTA_MIME, pa.COST_MIME, pa.CONFIDENCE_MIME]
-    # cost-v1 payload carries the token usage (parsed via protolabs_a2a, which
-    # tolerates the SDK's flattened proto-JSON DataPart shape).
+    assert mimes == [pa.WORLDSTATE_DELTA_MIME, pa.COST_MIME, pa.CONFIDENCE_MIME, _CONTEXT_MIME]
+    # cost-v1 payload carries the SUMMED token usage (100+140 input).
     cost = pa.parse_cost(parts[2])
-    assert cost["usage"]["input_tokens"] == 100
+    assert cost["usage"]["input_tokens"] == 240
     assert cost["success"] is True
+    # context-v1 carries the PEAK prompt size (max single call's input_tokens), the live
+    # context-window fill — distinct from the summed spend above.
+    _ctx_mime, ctx = pa.read_data(parts[4])
+    assert _ctx_mime == _CONTEXT_MIME
+    assert ctx["contextTokens"] == 140
 
 
 @pytest.mark.asyncio

--- a/tests/test_model_window.py
+++ b/tests/test_model_window.py
@@ -38,41 +38,40 @@ def _clear_cache():
     model_window.reset_window_cache()
 
 
-def test_resolves_window_and_caches(monkeypatch):
+def test_resolves_window_from_model_info_and_caches(monkeypatch):
     calls: list[str] = []
 
+    # The real gateway shape: /v1/model/info with the window nested under model_info.
     def fake_get(url, headers=None, timeout=None):
         calls.append(url)
         return _Resp(200, {"data": [
-            {"model_group": "protolabs/smart", "max_input_tokens": 196608},
-            {"model_group": "protolabs/fast", "max_input_tokens": 32768},
+            {"model_name": "protolabs/smart", "model_info": {"max_input_tokens": 196608}},
+            {"model_name": "protolabs/fast", "model_info": {"max_input_tokens": 32768}},
         ]})
 
     monkeypatch.setattr(httpx, "get", fake_get)
 
     assert model_window.context_window_for(_cfg()) == 196608
     assert model_window.context_window_for(_cfg(), "protolabs/fast") == 32768
-    # Hits /v1/model/group/info on the /v1-stripped root, exactly once (cached after).
-    assert calls == ["https://gw.example/v1/model/group/info"]
+    # Hits /v1/model/info on the /v1-stripped root, exactly once (cached after).
+    assert calls == ["https://gw.example/v1/model/info"]
 
 
-def test_falls_back_to_unversioned_path_on_404(monkeypatch):
-    seen: list[str] = []
-
+def test_also_parses_top_level_group_info_shape(monkeypatch):
+    # The grouped /model/group/info view carries the window top-level on model_group — and
+    # /v1/model/info 404s on a proxy that only exposes the grouped endpoint.
     def fake_get(url, headers=None, timeout=None):
-        seen.append(url)
-        if url.endswith("/v1/model/group/info"):
-            return _Resp(404)
-        return _Resp(200, {"data": [{"model_group": "protolabs/smart", "max_input_tokens": 196608}]})
+        if "group/info" in url:
+            return _Resp(200, {"data": [{"model_group": "protolabs/smart", "max_input_tokens": 196608}]})
+        return _Resp(404)
 
     monkeypatch.setattr(httpx, "get", fake_get)
     assert model_window.context_window_for(_cfg()) == 196608
-    assert seen[-1].endswith("/model/group/info")
 
 
 def test_unknown_model_is_none(monkeypatch):
     monkeypatch.setattr(httpx, "get", lambda *a, **k: _Resp(200, {"data": [
-        {"model_group": "protolabs/smart", "max_input_tokens": 196608},
+        {"model_name": "protolabs/smart", "model_info": {"max_input_tokens": 196608}},
     ]}))
     assert model_window.context_window_for(_cfg(model_name="claude-opus-4-8")) is None
 

--- a/tests/test_model_window.py
+++ b/tests/test_model_window.py
@@ -1,0 +1,90 @@
+"""graph/model_window.py — resolving a model's context window from the LiteLLM gateway (#1378).
+
+Verifies the /v1/model/group/info parse, the un-versioned fallback, caching (one fetch per
+base, safe to call per turn), and graceful None on an unknown model / unreachable gateway.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import httpx
+import pytest
+
+from graph import model_window
+
+
+def _cfg(**kw):
+    return SimpleNamespace(
+        api_base=kw.get("api_base", "https://gw.example/v1"),
+        api_key=kw.get("api_key", "sk-test"),
+        model_name=kw.get("model_name", "protolabs/smart"),
+    )
+
+
+class _Resp:
+    def __init__(self, status_code, payload=None):
+        self.status_code = status_code
+        self._payload = payload or {}
+
+    def json(self):
+        return self._payload
+
+
+@pytest.fixture(autouse=True)
+def _clear_cache():
+    model_window.reset_window_cache()
+    yield
+    model_window.reset_window_cache()
+
+
+def test_resolves_window_and_caches(monkeypatch):
+    calls: list[str] = []
+
+    def fake_get(url, headers=None, timeout=None):
+        calls.append(url)
+        return _Resp(200, {"data": [
+            {"model_group": "protolabs/smart", "max_input_tokens": 196608},
+            {"model_group": "protolabs/fast", "max_input_tokens": 32768},
+        ]})
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    assert model_window.context_window_for(_cfg()) == 196608
+    assert model_window.context_window_for(_cfg(), "protolabs/fast") == 32768
+    # Hits /v1/model/group/info on the /v1-stripped root, exactly once (cached after).
+    assert calls == ["https://gw.example/v1/model/group/info"]
+
+
+def test_falls_back_to_unversioned_path_on_404(monkeypatch):
+    seen: list[str] = []
+
+    def fake_get(url, headers=None, timeout=None):
+        seen.append(url)
+        if url.endswith("/v1/model/group/info"):
+            return _Resp(404)
+        return _Resp(200, {"data": [{"model_group": "protolabs/smart", "max_input_tokens": 196608}]})
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+    assert model_window.context_window_for(_cfg()) == 196608
+    assert seen[-1].endswith("/model/group/info")
+
+
+def test_unknown_model_is_none(monkeypatch):
+    monkeypatch.setattr(httpx, "get", lambda *a, **k: _Resp(200, {"data": [
+        {"model_group": "protolabs/smart", "max_input_tokens": 196608},
+    ]}))
+    assert model_window.context_window_for(_cfg(model_name="claude-opus-4-8")) is None
+
+
+def test_unreachable_gateway_is_none_and_not_refetched(monkeypatch):
+    n = {"calls": 0}
+
+    def boom(*a, **k):
+        n["calls"] += 1
+        raise httpx.ConnectError("refused")
+
+    monkeypatch.setattr(httpx, "get", boom)
+    assert model_window.context_window_for(_cfg()) is None
+    assert model_window.context_window_for(_cfg()) is None  # cached miss → no second fetch
+    assert n["calls"] == 1


### PR DESCRIPTION
Closes #1372 and #1378. Also fills the cost-v1 console-extractor gap from #1327.

A glanceable **context-window meter + per-turn cost/time** under each assistant answer:

```
⊙ 14.3k / 800k ▬   ⤓ 1.2k   ⏱ 2.3s   ◎ $0.04
```

context fill (with a compaction bar) · output ↓ · time · cost — full breakdown in a rich hover card.

## How it works
**Three terminal DataParts** ride the answer artifact (`a2a_impl/executor.py`):
- **cost-v1** (was discarded by the console) — the turn's summed token usage + `costUsd` + `durationMs` → the `$` + `⏱`.
- **context-v1** (new template ext) — `contextTokens` = the **peak single model call's `input_tokens`** (live context fill), plus the compaction `trigger`, `maxTokens` (model window) and absolute `compactionAtTokens`.

**Model window (#1378).** `graph/model_window.py` fetches the LiteLLM proxy's `/v1/model/info` (`model_info.max_input_tokens`, grouped-view fallback), cached per gateway; `graph/llm.py` seeds the `ChatOpenAI` `profile` from it (so `SummarizationMiddleware` resolves `fraction:`/`tokens:` compaction instead of falling back to a message count), and `server/__init__.py` resolves `compactionAtTokens = fraction × window`. So the bar shows on the **default `fraction:0.8`** trigger — verified live: `protolabs/reasoning` → 1,000,000 window → 800k threshold.

**Console** (`apps/web`): `costFromParts` / `contextFromParts` extractors + handlers, pinned to the assistant `ChatMessage` (persists across reload). The footer lives in the shared `ChatMessageView` (main + ⌘K palette chat); icons Gauge/ArrowDownToLine/Clock/Coins; the breakdown is a DS `Tooltip` card.

**Opt-out**: persisted `showChatUsage` pref + a **Settings ▸ Chat** toggle to hide the footer.

## Honest scope
`contextTokens` is the live prompt size (model-reported), not the per-turn sum (which drives `$`). The window/threshold use the lead model's window; a gateway that doesn't report a model's window degrades to size-only (no bar) + message-count compaction — exactly as before.

## Test plan
- `pytest` green (a2a-handler asserts context-v1 peak vs cost-v1 sum + durationMs; `test_model_window` covers both gateway shapes + caching + outage); `ruff` + `lint-imports` clean
- `tsc` + `vitest` (cost/context extractor cases) + full `playwright` (meter, hover card, hide toggle) green
- Verified live on the homelab gateway: `protolabs/reasoning` resolves a 1M window → `/ 800k` bar

## Gate
Chat UX → local-test gate. **DRAFT** for your eyeball before merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)