### PR TITLE
fix(web): show the chat-tab trash only on the hovered ✕ (#1373)

### DIFF
--- a/apps/web/e2e/chat-quick-delete.spec.ts
+++ b/apps/web/e2e/chat-quick-delete.spec.ts
@@ -15,6 +15,23 @@ test("Shift+click a tab's ✕ deletes it with no confirm dialog", async ({ page 
   await expect(page.getByRole("dialog", { name: /Delete this chat/i })).toHaveCount(0); // no confirm
 });
 
+test("with Shift held, the trash shows only on the hovered tab's ✕ (#1373)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.locator(".pl-tabbar__add:visible").click();
+  const tabs = page.locator(".pl-tabbar__tab");
+  await expect(tabs).toHaveCount(2);
+
+  await page.keyboard.down("Shift"); // arms quick-delete mode (the --del class)
+  const firstClose = tabs.first().locator(".pl-tabbar__close");
+  await firstClose.hover();
+  // The hovered ✕ renders the ::after trash silhouette (13px); the other tab's ✕ does not.
+  const hovered = await firstClose.evaluate((el) => getComputedStyle(el, "::after").width);
+  const other = await tabs.nth(1).locator(".pl-tabbar__close").evaluate((el) => getComputedStyle(el, "::after").width);
+  await page.keyboard.up("Shift");
+  expect(hovered).toBe("13px");
+  expect(other).not.toBe("13px");
+});
+
 test("plain click a tab's ✕ still opens the confirm dialog", async ({ page }) => {
   await page.goto("/app/", { waitUntil: "load" });
   await page.locator(".pl-tabbar__add:visible").click();

--- a/apps/web/src/chat/chat.css
+++ b/apps/web/src/chat/chat.css
@@ -144,16 +144,18 @@
   max-width: 230px;
 }
 
-/* Quick-delete mode: while Shift is held, the tab ✕ becomes a red trashcan (Shift+click
-   deletes with no confirm + no harvest). Swap the DS ✕ svg for a trash silhouette (mask
-   tinted via currentColor). */
-.chat-tabbar-wrap--del .pl-tabbar__close {
+/* Quick-delete mode: while Shift is held, the ✕ becomes a red trashcan (Shift+click deletes
+   with no confirm + no harvest). Scoped to :hover (#1373) so ONLY the tab whose ✕ you're
+   pointing at shows the trash — not every tab at once — for a clearer delete affordance and
+   fewer accidental clicks. Swap the DS ✕ svg for a trash silhouette (mask tinted via
+   currentColor). The Shift+click handler is unchanged; this only narrows the visual cue. */
+.chat-tabbar-wrap--del .pl-tabbar__close:hover {
   color: var(--pl-color-danger, #e5484d);
 }
-.chat-tabbar-wrap--del .pl-tabbar__close svg {
+.chat-tabbar-wrap--del .pl-tabbar__close:hover svg {
   display: none;
 }
-.chat-tabbar-wrap--del .pl-tabbar__close::after {
+.chat-tabbar-wrap--del .pl-tabbar__close:hover::after {
   content: "";
   display: inline-block;
   width: 13px;


### PR DESCRIPTION
Closes #1373.

## Problem
Holding **Shift** (quick-delete mode) turned **every** chat tab's ✕ into a red trashcan at once — visual clutter and easy to mis-click and delete the wrong chat.

## Fix
Scope the trash visual to the close button's `:hover`, so while Shift is held only the tab you're **pointing at** shows the trash; the rest keep their normal ✕. The Shift+click delete handler is untouched — this only narrows the visual cue.

A 6-line CSS scoping change (`.chat-tabbar-wrap--del .pl-tabbar__close` → `…:hover`).

## Verification
- New e2e (`chat-quick-delete.spec.ts`): with Shift held, the hovered ✕ renders the trash (`::after` 13px) while a second tab's ✕ does not. The existing Shift+click-deletes / plain-click-confirms behavior tests still pass (3/3).
- Visually confirmed: Shift + hover tab 1 → tab 1 shows the red trash, tabs 2–3 show ✕.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the quick-delete tab close button so the trash/delete styling now appears only on hover, instead of staying visible all the time.
  * Improved quick-delete behavior validation with a new end-to-end test covering Shift-hover interactions and confirming the correct close icon state.
  * Kept existing delete confirmation and Shift+click behaviors intact.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->