### PR TITLE
fix(web): clear error for images on a text-only model (#1374)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -20,6 +20,7 @@ export const RUNTIME_STATUS = {
     name: "protolabs/reasoning",
     api_base: "https://api.proto-labs.ai/v1",
     api_key_configured: true,
+    vision: true, // a vision-capable model: attached images go inline (the happy path)
     temperature: 0.2,
     max_tokens: 2048,
     max_iterations: 8,

--- a/apps/web/e2e/image-attach.spec.ts
+++ b/apps/web/e2e/image-attach.spec.ts
@@ -1,0 +1,52 @@
+import { expect, test } from "@playwright/test";
+
+// #1374: dropping/attaching an image (e.g. a macOS screenshot — PNG) only works on a
+// vision-capable model. On a TEXT-ONLY model the file pipeline can't read images (no OCR),
+// so the composer short-circuits with a clear, actionable error instead of the cryptic
+// "unsupported file type" the extractor returns.
+
+const PNG_1X1 = Buffer.from(
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==",
+  "base64",
+);
+
+test("a vision model attaches an image inline (no error)", async ({ page }) => {
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+  const slot = page.locator(".chat-session-slot:not([hidden])");
+
+  await slot.locator('input[type="file"]').setInputFiles({
+    name: "Screenshot.png",
+    mimeType: "image/png",
+    buffer: PNG_1X1,
+  });
+
+  const chips = slot.locator(".pl-prompt__attachments");
+  await expect(chips).toContainText("Screenshot.png");
+  await expect(chips).not.toContainText("uploading"); // settled (native inline)
+  await expect(chips).not.toContainText(/vision-capable model/i); // no error
+});
+
+test("a text-only model rejects an image with a clear 'needs a vision model' error", async ({ page }) => {
+  // Force the model non-vision (like protolabs/reasoning → deepseek) for this test only.
+  await page.route("**/api/runtime/status", async (route) => {
+    const resp = await route.fetch();
+    const json = await resp.json();
+    if (json?.model) json.model.vision = false;
+    await route.fulfill({ json });
+  });
+  await page.goto("/app/", { waitUntil: "load" });
+  await expect(page.getByPlaceholder(/Message protoAgent/i)).toBeVisible();
+  const slot = page.locator(".chat-session-slot:not([hidden])");
+
+  await slot.locator('input[type="file"]').setInputFiles({
+    name: "Screenshot.png",
+    mimeType: "image/png",
+    buffer: PNG_1X1,
+  });
+
+  // The chip appears (in an error state), and the clear, actionable message surfaces in the
+  // alert banner — NOT a cryptic "unsupported file type" from the extractor (never called).
+  await expect(slot.locator(".pl-prompt__attachments")).toContainText("Screenshot.png");
+  await expect(page.getByText(/vision-capable model/i)).toBeVisible();
+});

--- a/apps/web/src/chat/ChatSurface.tsx
+++ b/apps/web/src/chat/ChatSurface.tsx
@@ -320,6 +320,16 @@ function ChatSessionSlot({
     const kind: "file" | "image" = file.type.startsWith("image/") ? "image" : "file";
     setAttachments((a) => [...a, { id, name: file.name, kind, status: "uploading" }]);
 
+    // A text-only model can't see images, and the file pipeline can't read them either (it
+    // extracts text — no OCR), so an image would otherwise bounce off the extractor with a
+    // cryptic "unsupported file type" (#1374). Short-circuit with a clear, actionable error.
+    if (kind === "image" && !visionModel) {
+      const msg = "This model can't see images. Switch to a vision-capable model to send a screenshot.";
+      setAttachments((a) => a.map((x) => (x.id === id ? { ...x, status: "error", error: msg } : x)));
+      onError(msg);
+      return;
+    }
+
     // Native vision: a vision model sees the image directly — base64 it and send
     // it as a multimodal part, no pipeline round-trip.
     if (kind === "image" && visionModel) {


### PR DESCRIPTION
Closes #1374.

## The actual bug (not what the issue describes)
Dragging a freshly-taken macOS **screenshot** (a PNG) into chat threw a "system error". Traced it end-to-end:

- A **vision model already accepts PNG** — images go inline as `image_url` data URIs, any `image/*` mime, no format restriction. Not the problem.
- On a **text-only model** (e.g. the default `protolabs/reasoning` → deepseek, `model_vision: false`), the image falls through to the file-ingestion pipeline (`/api/knowledge/attach` → `extract_bytes`), whose `SUPPORTED_EXTENSIONS` are text/MD/HTML/PDF/audio/video — **no images**. It raises `UnsupportedSource: unsupported file type '.png'`, surfaced as the "system error".

So the issue's framing is off: **format was never the cause** — JPEG/WebP 415 identically (no OCR), and there's no `sharp` in this Python+browser stack. Converting wouldn't help. It's "image on a text model."

## Fix
The composer now short-circuits an image attached to a **text-only** model with a clear, actionable message — *"This model can't see images. Switch to a vision-capable model to send a screenshot."* — instead of the cryptic extractor reject. Vision models are unchanged (images still go inline).

## Tests
- The e2e mock model was non-vision **and** its fake `/attach` swallowed images — which is exactly what **hid this bug from CI**. Made the mock vision-capable so the happy path is real, and added `image-attach.spec`: a vision model attaches an image inline (no error); a route-forced text-only model shows the actionable error. `file-only-send` / `paste-attach` unchanged. Full suite green (one unrelated `nesting` parallel-load flake, passes in isolation).

## Follow-up (not this PR)
To make a screenshot **understandable by a text model**, add a vision-describe/OCR pass to the ingestion path (mirrors the existing audio-transcription hook). Happy to file that as the real feature if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved image attachment handling in chat by recognizing when the selected model supports vision.
  * Added clearer guidance for users when they try to attach an image to a text-only model.

* **Bug Fixes**
  * Prevented image uploads from failing with a generic file-type error when the model cannot process images.
  * Added end-to-end coverage for both successful and rejected image attachment flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->