### PR TITLE
feat: attribute each Activity response to its stimulus (#1375)

### DIFF
--- a/a2a_impl/executor.py
+++ b/a2a_impl/executor.py
@@ -88,6 +88,9 @@ class TurnOutcome:
     origin: str = ""
     trigger: str = ""
     priority: str = ""
+    # The triggering input text (the scheduled prompt / inbound message / webhook body),
+    # truncated — so the Activity feed can show the response as an explicit reply to it (#1375).
+    stimulus: str = ""
 
 
 # A terminal hook the host can register (ADR 0003 / 0006): invoked with a
@@ -249,6 +252,11 @@ class ProtoAgentExecutor(AgentExecutor):
         _origin = str(_md.get("origin", "") or "")
         _priority = str(_md.get("priority", "") or "")
         _trigger = str(_md.get("trigger") or _md.get("scheduler_job_id") or _md.get("inbox_source") or "")
+        # The stimulus = this turn's input text, kept as a truncated preview so the Activity
+        # feed can show the response as an explicit reply to what triggered it (#1375).
+        _stimulus = (text or "").strip()
+        if len(_stimulus) > 600:
+            _stimulus = _stimulus[:600] + "…"
 
         started = time.monotonic()
         accumulated = ""
@@ -351,6 +359,7 @@ class ProtoAgentExecutor(AgentExecutor):
                 origin=_origin,
                 trigger=_trigger,
                 priority=_priority,
+                stimulus=_stimulus,
             )
 
         try:

--- a/activity/store.py
+++ b/activity/store.py
@@ -27,7 +27,8 @@ CREATE TABLE IF NOT EXISTS activity (
     priority    TEXT,
     state       TEXT,
     text        TEXT NOT NULL,
-    task_id     TEXT
+    task_id     TEXT,
+    stimulus    TEXT
 );
 CREATE INDEX IF NOT EXISTS idx_activity_created_at ON activity(created_at);
 """
@@ -49,6 +50,14 @@ class ActivityLog:
         try:
             db = self._connect()
             db.executescript(_SCHEMA)
+            # Additive migration: `stimulus` (the triggering input text, so a response can be
+            # shown as "in response to X") was added after the table shipped. ALTER is a no-op
+            # on a fresh DB (the column is already in _SCHEMA) and "duplicate column" on a
+            # migrated one — both fine.
+            try:
+                db.execute("ALTER TABLE activity ADD COLUMN stimulus TEXT")
+            except sqlite3.OperationalError:
+                pass
             db.commit()
             db.close()
         except sqlite3.DatabaseError:
@@ -71,17 +80,20 @@ class ActivityLog:
         priority: str = "",
         state: str = "completed",
         task_id: str = "",
+        stimulus: str = "",
     ) -> int | None:
-        """Append a feed entry. ``origin`` empty ⇒ "operator" (a reply/live turn)."""
+        """Append a feed entry. ``origin`` empty ⇒ "operator" (a reply/live turn).
+        ``stimulus`` is the triggering input text (the scheduled prompt / inbound message),
+        so the feed can show the response as an explicit reply to it."""
         if not text or not text.strip():
             return None
         try:
             db = self._connect()
             cur = db.execute(
                 "INSERT INTO activity "
-                "(created_at, context_id, origin, trigger, priority, state, text, task_id) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?)",
-                (_now_iso(), context_id, origin or "operator", trigger, priority, state, text, task_id),
+                "(created_at, context_id, origin, trigger, priority, state, text, task_id, stimulus) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                (_now_iso(), context_id, origin or "operator", trigger, priority, state, text, task_id, stimulus),
             )
             db.commit()
             return int(cur.lastrowid)
@@ -119,7 +131,7 @@ class ActivityLog:
         try:
             db = self._connect()
             rows = db.execute(
-                "SELECT id, created_at, context_id, origin, trigger, priority, state, text, task_id "
+                "SELECT id, created_at, context_id, origin, trigger, priority, state, text, task_id, stimulus "
                 "FROM activity ORDER BY id DESC LIMIT ?",
                 (limit,),
             ).fetchall()

--- a/apps/web/e2e/activity.spec.ts
+++ b/apps/web/e2e/activity.spec.ts
@@ -23,8 +23,15 @@ test("widget badge → dialog feed with provenance + live append", async ({ page
   await expect(feed.getByText("Build failed on main — investigating.")).toBeVisible();
   await expect(feed.getByText("inbox").first()).toBeVisible(); // inbox origin badge
 
-  // A pushed event appends live while the dialog is open.
+  // Each response is explicitly attributed to the stimulus it replies to (#1375).
+  const sched = feed.locator(".activity-entry", { hasText: "3 PRs merged overnight, CI green." });
+  await expect(sched.locator(".activity-stimulus")).toContainText("in response to");
+  await expect(sched.locator(".activity-stimulus-text")).toContainText("Summarize overnight repo activity");
+
+  // A pushed event appends live while the dialog is open — carrying its stimulus.
   await expect(feed.getByText("live activity ping").first()).toBeVisible();
+  const live = feed.locator(".activity-entry", { hasText: "live activity ping" });
+  await expect(live.locator(".activity-stimulus-text")).toContainText("Hourly heartbeat check");
 
   // Read-only since the IA pass — there is no reply composer.
   await expect(page.locator(".activity-composer")).toHaveCount(0);

--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -81,8 +81,8 @@ export const SUBAGENTS = [
 export const ACTIVITY_HISTORY = {
   context_id: "system:activity",
   entries: [
-    { id: 1, created_at: "2026-06-05T09:00:00+00:00", origin: "scheduler", trigger: "daily-brief", priority: "", state: "completed", text: "3 PRs merged overnight, CI green.", task_id: "t1" },
-    { id: 2, created_at: "2026-06-05T09:05:00+00:00", origin: "inbox", trigger: "ci", priority: "now", state: "completed", text: "Build failed on main — investigating.", task_id: "t2" },
+    { id: 1, created_at: "2026-06-05T09:00:00+00:00", origin: "scheduler", trigger: "daily-brief", priority: "", state: "completed", text: "3 PRs merged overnight, CI green.", task_id: "t1", stimulus: "Summarize overnight repo activity and CI status." },
+    { id: 2, created_at: "2026-06-05T09:05:00+00:00", origin: "inbox", trigger: "ci", priority: "now", state: "completed", text: "Build failed on main — investigating.", task_id: "t2", stimulus: "CI webhook: build #4821 failed on main (test_a2a_handler)." },
   ],
   messages: [
     { role: "user", content: "morning standup" },

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -380,7 +380,7 @@ const server = createServer(async (req, res) => {
     // Push periodically so the unread badge (off-surface), live append (on-surface), and
     // the plugin notification dot (a `boardy.*` event) are all deterministically testable.
     const t = setInterval(() => {
-      frame("activity.message", { text: "live activity ping", origin: "scheduler", trigger: "heartbeat" });
+      frame("activity.message", { text: "live activity ping", origin: "scheduler", trigger: "heartbeat", stimulus: "Hourly heartbeat check." });
       frame("inbox.item", { id: 99, priority: "next", source: "mock", text: "live inbox ping" });
       frame("boardy.created", { id: "b1" }); // ADR 0039 — exercises the rail notification dot
     }, 500);

--- a/apps/web/src/activity/ActivitySurface.tsx
+++ b/apps/web/src/activity/ActivitySurface.tsx
@@ -1,7 +1,7 @@
 import "./activity.css";
 
 import { Empty } from "@protolabsai/ui/primitives";
-import { Clock, Inbox, Maximize2, MessageSquare, Users, Webhook, Zap } from "lucide-react";
+import { Clock, CornerDownRight, Inbox, Maximize2, MessageSquare, Users, Webhook, Zap } from "lucide-react";
 
 import { useCallback, useEffect, useRef, useState } from "react";
 
@@ -85,6 +85,7 @@ export function ActivitySurface() {
           state: "completed",
           text,
           task_id: "",
+          stimulus: typeof data.stimulus === "string" ? data.stimulus : "",
         };
         setEntries((prev) => [entry, ...prev]);
       }),
@@ -128,13 +129,24 @@ export function ActivitySurface() {
                     openDocument({
                       title: ORIGIN[e.origin]?.label ?? e.origin ?? "Activity",
                       subtitle: [e.trigger, e.created_at ? ago(e.created_at) : ""].filter(Boolean).join(" · ") || undefined,
-                      content: e.text,
+                      content: e.stimulus
+                        ? `> **In response to**\n>\n> ${e.stimulus.replace(/\n/g, "\n> ")}\n\n---\n\n${e.text}`
+                        : e.text,
                     })
                   }
                 >
                   <Maximize2 size={13} />
                 </button>
               </div>
+              {/* Explicit stimulus attribution (#1375): the input this response is replying to,
+                  so the feed isn't an unanchored wall of agent output. Full text on hover. */}
+              {e.stimulus ? (
+                <div className="activity-stimulus" title={e.stimulus}>
+                  <CornerDownRight size={12} aria-hidden />
+                  <span className="activity-stimulus-label">in response to</span>
+                  <span className="activity-stimulus-text">{e.stimulus}</span>
+                </div>
+              ) : null}
               <div className="activity-content">
                 <Markdown>{e.text}</Markdown>
               </div>

--- a/apps/web/src/activity/activity.css
+++ b/apps/web/src/activity/activity.css
@@ -43,6 +43,39 @@
   font-size: 14px;
 }
 
+/* Stimulus attribution (#1375): a quiet quoted line above the response naming what it
+   replies to — a scheduled prompt, an inbound message, a webhook body. Truncated to one
+   line; the full text is in the title tooltip + the full-screen reader. */
+.activity-stimulus {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  margin: 0 0 6px;
+  padding-left: 8px;
+  border-left: 2px solid var(--border);
+  color: var(--fg-muted);
+  font-size: 12px;
+  min-width: 0;
+}
+.activity-stimulus svg {
+  flex: none;
+  opacity: 0.7;
+}
+.activity-stimulus-label {
+  flex: none;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.03em;
+  font-size: 10px;
+  opacity: 0.85;
+}
+.activity-stimulus-text {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
 .activity-user .activity-content {
   background: color-mix(in srgb, var(--accent, #7c8cff) 12%, transparent);
 }

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -311,8 +311,11 @@ export type ActivityEntry = {
   trigger: string;       // job id / inbox source (human label), may be ""
   priority: string;      // inbox tier when applicable, else ""
   state: string;
-  text: string;
+  text: string;          // the agent's RESPONSE
   task_id: string;
+  /** The triggering input text this turn is a response to (scheduled prompt / inbound
+   *  message / webhook body), truncated. Shown as "in response to …" (#1375). */
+  stimulus?: string;
 };
 
 export type ActivityHistory = {

--- a/server/a2a.py
+++ b/server/a2a.py
@@ -500,7 +500,9 @@ def _a2a_terminal(outcome) -> None:
     origin = getattr(outcome, "origin", "") or "operator"
     trigger = getattr(outcome, "trigger", "") or ""
     priority = getattr(outcome, "priority", "") or ""
-    # Provenance feed (ADR 0022): durably log the turn + what triggered it.
+    stimulus = getattr(outcome, "stimulus", "") or ""
+    # Provenance feed (ADR 0022): durably log the turn + what triggered it + the stimulus it
+    # responds to (#1375), so the feed reads as an explicit reply.
     if STATE.activity_log is not None:
         STATE.activity_log.add(
             context_id=ACTIVITY_CONTEXT,
@@ -510,6 +512,7 @@ def _a2a_terminal(outcome) -> None:
             state=getattr(outcome, "state", "completed"),
             text=text,
             task_id=getattr(outcome, "task_id", "") or "",
+            stimulus=stimulus,
         )
     _event_bus.publish(
         "activity.message",
@@ -520,5 +523,6 @@ def _a2a_terminal(outcome) -> None:
             "origin": origin,
             "trigger": trigger,
             "priority": priority,
+            "stimulus": stimulus,
         },
     )

--- a/tests/test_activity.py
+++ b/tests/test_activity.py
@@ -123,6 +123,52 @@ def test_prune_activity_removes_old(tmp_path):
     assert remaining[0]["text"] == "recent entry"
 
 
+def test_activity_add_round_trips_stimulus(tmp_path):
+    """The stimulus (triggering input) is stored + returned so the feed can show the
+    response as an explicit reply to it (#1375)."""
+    al = _activity_log(tmp_path)
+    al.add(
+        context_id="system:activity",
+        origin="inbox",
+        trigger="ci",
+        priority="now",
+        text="Build failed on main — investigating.",
+        stimulus="CI webhook: build #4821 failed on main.",
+    )
+    row = al.recent(limit=1)[0]
+    assert row["stimulus"] == "CI webhook: build #4821 failed on main."
+    # Omitted stimulus is fine (empty), not an error.
+    al.add(context_id="system:activity", origin="operator", text="a manual note")
+    assert al.recent(limit=1)[0]["stimulus"] in ("", None)
+
+
+def test_activity_migrates_pre_stimulus_db(tmp_path):
+    """A DB created before the `stimulus` column gets it added on open (additive ALTER),
+    and existing rows read back with stimulus = None."""
+    import sqlite3
+
+    path = str(tmp_path / "activity.db")
+    db = sqlite3.connect(path)
+    # The original (pre-#1375) schema — no `stimulus` column.
+    db.execute(
+        "CREATE TABLE activity (id INTEGER PRIMARY KEY AUTOINCREMENT, created_at TEXT NOT NULL, "
+        "context_id TEXT NOT NULL, origin TEXT NOT NULL DEFAULT '', trigger TEXT, priority TEXT, "
+        "state TEXT, text TEXT NOT NULL, task_id TEXT)"
+    )
+    db.execute(
+        "INSERT INTO activity (created_at, context_id, origin, text) VALUES (?, ?, ?, ?)",
+        (datetime(2026, 1, 1, tzinfo=UTC).isoformat(), "ctx", "scheduler", "old entry"),
+    )
+    db.commit()
+    db.close()
+
+    al = ActivityLog(path)  # opening migrates the schema
+    al.add(context_id="ctx", origin="inbox", text="new entry", stimulus="ping")
+    rows = {r["text"]: r for r in al.recent(limit=10)}
+    assert rows["old entry"]["stimulus"] is None  # legacy row, back-filled column
+    assert rows["new entry"]["stimulus"] == "ping"
+
+
 def test_prune_activity_keep_all_zero(tmp_path):
     """keep_days=0 removes nothing (keep forever)."""
     al = _activity_log(tmp_path)


### PR DESCRIPTION
Part of #1375. Makes each LLM response in the **Activity** feed explicitly a *reply to the stimulus that triggered it*.

## Before / after
The feed showed the agent's response + a provenance badge (`scheduled · daily-brief`, `inbox · ci · now`) — but never **what** it was responding to, so a turn read as unanchored output. Now each entry shows the triggering input above the response:

```
◷ scheduled · daily-brief · 23d ago
↳ IN RESPONSE TO  Summarize overnight repo activity and CI status.
┌────────────────────────────────────────────┐
│ 3 PRs merged overnight, CI green.          │
└────────────────────────────────────────────┘
```

## How (minimal new plumbing — the provenance chain already existed)
- **`activity/store.py`**: new `stimulus` column with an additive `ALTER TABLE` migration for existing DBs; `add()`/`recent()` carry it.
- **`a2a_impl/executor.py`**: `TurnOutcome.stimulus` = the turn's input text (truncated to 600 chars), set in `_outcome` next to the existing origin/trigger/priority.
- **`server/a2a.py`**: the terminal hook persists `stimulus` on the row + the `activity.message` event.
- **Console**: `ActivityEntry.stimulus`; `ActivitySurface` renders a quiet `↳ in response to …` line (one-line, truncated; full text on hover + prepended in the full-screen reader).

## Tests
- Python: store round-trips `stimulus`; a **pre-`stimulus` DB migrates** on open (legacy rows back-fill the column). Full suite (2546) green; ruff + import-linter clean.
- Web: e2e asserts the attribution on a loaded entry **and** a live-pushed one. `tsc` + `vitest` + full `playwright` (153) green.

## The rest of the #1375 audit (separate)
I audited both surfaces. **Inbox** (durable now/next/later intake queue, dismiss-only) and **Activity** (provenance timeline) are complementary, not redundant — but they overlap in three measurable spots: a `now` inbox item is recorded in *both* stores, fires *two* bus events (`inbox.item` + `activity.message`), and bumps *two* widget badges. I'll summarize the consolidation options for your call rather than fold them in here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)