### PR TITLE
fix: dedup inbox/activity now-item notifications + deliver-before-fire (#1375)

### DIFF
--- a/inbox/store.py
+++ b/inbox/store.py
@@ -144,6 +144,24 @@ class InboxStore:
         finally:
             db.close()
 
+    def mark_pending(self, ids: list[int]) -> int:
+        """Un-deliver: clear ``delivered_at`` so an item re-enters the pending queue. The
+        inverse of ``mark_delivered`` — used to RESTORE a now-item that was optimistically
+        delivered (so its fired turn couldn't double-read it) but whose fire then failed."""
+        if not ids:
+            return 0
+        db = self._connect()
+        try:
+            placeholders = ",".join("?" for _ in ids)
+            cur = db.execute(
+                f"UPDATE inbox SET delivered_at = NULL WHERE id IN ({placeholders})",
+                tuple(ids),
+            )
+            db.commit()
+            return cur.rowcount
+        finally:
+            db.close()
+
     def pending_count(self, *, priority_floor: str = "next") -> int:
         return len(self.list(priority_floor=priority_floor, limit=1000))
 

--- a/operator_api/console_handlers.py
+++ b/operator_api/console_handlers.py
@@ -465,25 +465,38 @@ async def _operator_inbox_add(payload: dict) -> dict:
     )
     if item is None:
         return {"ok": True, "deduped": True}
-    _event_bus.publish(
-        "inbox.item",
-        {
-            "id": item["id"],
-            "priority": item["priority"],
-            "source": item.get("source") or "",
-            "text": item["text"],
-        },
-    )
-    fired = await _fire_activity_from_inbox(item) if item["priority"] == "now" else False
-    if fired:
-        # A now-item that fired has been delivered to the agent (its Activity turn
-        # ran) — mark it delivered so it doesn't linger as pending and get
-        # re-surfaced by the next check_inbox (bd-jus). A FAILED fire stays pending
-        # so check_inbox remains the fallback delivery path for it.
+
+    fired = False
+    if item["priority"] == "now":
+        # Deliver-BEFORE-fire (#1375): mark the now-item delivered before its Activity turn
+        # runs, so the fired turn can't re-read its own trigger via check_inbox (double
+        # processing). If the fire never happens (storm-blocked / failed), restore it to
+        # pending so it isn't lost — check_inbox stays the fallback delivery path.
         try:
             await asyncio.to_thread(STATE.inbox_store.mark_delivered, [item["id"]])
-        except Exception:  # noqa: BLE001 — best-effort; a missed mark just re-surfaces
-            log.warning("[inbox] could not mark fired now-item %s delivered", item.get("id"))
+        except Exception:  # noqa: BLE001 — best-effort; a missed mark just means a double-read
+            log.warning("[inbox] could not pre-mark now-item %s delivered", item.get("id"))
+        fired = await _fire_activity_from_inbox(item)
+        if not fired:
+            try:
+                await asyncio.to_thread(STATE.inbox_store.mark_pending, [item["id"]])
+            except Exception:  # noqa: BLE001 — restore is best-effort
+                log.warning("[inbox] could not restore unfired now-item %s to pending", item.get("id"))
+
+    # Badge dedup (#1375): publish `inbox.item` ONLY for items that actually LAND in the queue
+    # — next/later items, or a now-item whose fire failed (now pending again). A fired now-item
+    # is an Activity event (the `activity.message` push covers it), not an inbox arrival, so it
+    # no longer double-bumps both the Inbox and Activity widget badges.
+    if not fired:
+        _event_bus.publish(
+            "inbox.item",
+            {
+                "id": item["id"],
+                "priority": item["priority"],
+                "source": item.get("source") or "",
+                "text": item["text"],
+            },
+        )
     return {"ok": True, "item": item, "fired": fired}
 
 

--- a/tests/test_inbox.py
+++ b/tests/test_inbox.py
@@ -73,6 +73,16 @@ def test_mark_delivered_removes_from_pending(tmp_path):
     assert s.mark_delivered([a["id"]]) == 0  # already delivered
 
 
+def test_mark_pending_restores_to_queue(tmp_path):
+    """Un-deliver puts an item back in the pending queue (restore-on-failed-fire, #1375)."""
+    s = _store(tmp_path)
+    a = s.add("a", priority="now")
+    assert s.mark_delivered([a["id"]]) == 1
+    assert s.list(priority_floor="later") == []  # delivered → out of the queue
+    assert s.mark_pending([a["id"]]) == 1
+    assert len(s.list(priority_floor="later")) == 1  # back in the queue
+
+
 def test_add_rejects_empty_and_bad_priority(tmp_path):
     s = _store(tmp_path)
     with pytest.raises(ValueError):
@@ -194,7 +204,66 @@ async def test_failed_now_fire_stays_pending(tmp_path, monkeypatch):
 
     res = await ch._operator_inbox_add({"text": "bg done", "priority": "now"})
     assert res["fired"] is False
-    assert len(store.list(priority_floor="later")) == 1  # still pending for check_inbox
+    assert len(store.list(priority_floor="later")) == 1  # restored to pending for check_inbox
+
+
+# ── badge dedup: inbox.item fires only for items that land in the queue (#1375) ──
+
+
+def _capture_inbox_events(monkeypatch):
+    import operator_api.console_handlers as ch
+
+    published: list[str] = []
+    monkeypatch.setattr(ch._event_bus, "publish", lambda topic, payload=None: published.append(topic))
+    return published
+
+
+@pytest.mark.asyncio
+async def test_fired_now_item_does_not_publish_inbox_item(tmp_path, monkeypatch):
+    """A fired now-item is an Activity event (activity.message), not an inbox-queue arrival —
+    so it must NOT publish inbox.item, which would double-bump the Inbox + Activity badges."""
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "inbox_store", _store(tmp_path), raising=False)
+    published = _capture_inbox_events(monkeypatch)
+
+    async def _fire_ok(_item):
+        return True
+
+    monkeypatch.setattr(ch, "_fire_activity_from_inbox", _fire_ok)
+    await ch._operator_inbox_add({"text": "x", "priority": "now"})
+    assert "inbox.item" not in published
+
+
+@pytest.mark.asyncio
+async def test_queued_item_publishes_inbox_item(tmp_path, monkeypatch):
+    """A next/later item lands in the queue → publishes inbox.item (one badge)."""
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "inbox_store", _store(tmp_path), raising=False)
+    published = _capture_inbox_events(monkeypatch)
+    await ch._operator_inbox_add({"text": "x", "priority": "next"})
+    assert "inbox.item" in published
+
+
+@pytest.mark.asyncio
+async def test_failed_now_fire_publishes_inbox_item(tmp_path, monkeypatch):
+    """A now-item whose fire FAILED is pending again → it DOES publish inbox.item (the
+    check_inbox fallback path needs the operator to see it)."""
+    import operator_api.console_handlers as ch
+    import runtime.state as rs
+
+    monkeypatch.setattr(rs.STATE, "inbox_store", _store(tmp_path), raising=False)
+    published = _capture_inbox_events(monkeypatch)
+
+    async def _fire_fail(_item):
+        return False
+
+    monkeypatch.setattr(ch, "_fire_activity_from_inbox", _fire_fail)
+    await ch._operator_inbox_add({"text": "x", "priority": "now"})
+    assert "inbox.item" in published
 
 
 # ── POST /api/inbox route ────────────────────────────────────────────────────


### PR DESCRIPTION
Closes #1375 — the consolidation half of the inbox/activity audit (the stimulus-attribution half shipped in #1383).

## What the audit found
Inbox and Activity are complementary (intake **queue** vs. provenance **timeline**), but a `now`-priority inbox item is the seam where they double up:
- **Double notification** — it bumps the **Inbox** badge (on intake) *and* the **Activity** badge (on its fired turn). Two pings for one event.
- **Double processing risk** — the auto-fired turn could re-read its own trigger via `check_inbox` (the item was only marked delivered *after* the turn), and a failed `mark_delivered`-after-fire left it pending to re-surface.

## Fix (backend-only — the console widget is unchanged)
`_operator_inbox_add`:
- **Deliver-before-fire** — mark the now-item delivered **before** its Activity turn runs, so the turn can't double-read it; **restore to pending** (new `InboxStore.mark_pending`) if the fire never happens (storm-blocked / failed), so nothing is lost.
- **Badge dedup** — publish `inbox.item` **only** for items that actually land in the queue (next/later, or a now-item whose fire failed). A fired now-item is an Activity event (`activity.message` covers it), not an inbox arrival — so it no longer double-bumps both badges.

Net: **one notification per stimulus**, in the right place (Activity for fired now-items, Inbox for queued ones), and a now-item is processed exactly once.

## What I deliberately did NOT do
Collapsing the two stores/events into one — the audit confirmed the split is correct (different lifecycles); merging would be churn without payoff.

## Tests
`mark_pending` round-trip; dedup (fired-now → no `inbox.item`; queued + failed-now → `inbox.item`); existing fired/failed end-state tests still hold. Full suite (2550) green; ruff + import-linter clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inbox items can now be moved back to a pending state, making them available for delivery again.

* **Bug Fixes**
  * Improved handling for urgent inbox items so delivered status is updated more safely.
  * Reduced duplicate inbox badge/event updates for items that are already processed.
  * If an urgent item fails to process immediately, it can now still be picked up by the normal delivery flow.

* **Tests**
  * Added coverage for restoring items to pending and for inbox event publishing behavior across delivery scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->