### PR TITLE
feat: "Get models" — pull a gateway's model list into the Primary model dropdown (#1386)

### DIFF
--- a/apps/web/e2e/fixtures.mjs
+++ b/apps/web/e2e/fixtures.mjs
@@ -201,8 +201,11 @@ export const SETTINGS_SCHEMA = [
     section: "Model",
     category: "Agent",
     fields: [
-      // model.name is host-scoped + inherited from the host layer (inheritance badge).
-      { key: "model.name", label: "Primary model", type: "select", section: "Model", restart: false, description: "", options: ["protolabs/reasoning", "protolabs/fast"], value: "protolabs/reasoning", default: "protolabs/reasoning", scope: "host", source: "host" },
+      // model.name is host-scoped + inherited from the host layer (inheritance badge). Its
+      // options are gateway-probed (options_source "models") — the "Get models" action (#1386)
+      // refreshes them from the form's api_base/key.
+      { key: "model.name", label: "Primary model", type: "select", section: "Model", restart: false, description: "", options: ["protolabs/reasoning", "protolabs/fast"], options_source: "models", value: "protolabs/reasoning", default: "protolabs/reasoning", scope: "host", source: "host" },
+      { key: "model.api_base", label: "Gateway base URL", type: "string", section: "Model", restart: false, description: "", options: [], value: "https://gw.example/v1", default: "", scope: "host", source: "host" },
       // host-scoped but overridden in this agent (overridden-here badge + reset link).
       { key: "model.temperature", label: "Temperature", type: "number", section: "Model", restart: false, description: "", options: [], value: 0.2, default: 0.2, minimum: 0, maximum: 2, scope: "host", source: "agent" },
       { key: "model.api_key", label: "API key", type: "secret", section: "Model", restart: false, description: "Stored in secrets.yaml.", options: [], value: "", is_set: true, scope: "agent", source: "agent" },
@@ -243,6 +246,11 @@ export const SETTINGS_SCHEMA = [
     ],
   },
 ];
+
+/** The model list a freshly-probed gateway returns from POST /api/config/models (#1386) — a
+ *  DIFFERENT set than model.name's saved options, so the e2e can prove "Get models" refreshes
+ *  the dropdown with the new provider's models. */
+export const GATEWAY_MODELS = ["protolabs/smart", "protolabs/micro", "protolabs/nano"];
 
 /** restart_required for a flat updates payload, per the schema. */
 export function settingsRestartRequired(updates) {

--- a/apps/web/e2e/mock-server.mjs
+++ b/apps/web/e2e/mock-server.mjs
@@ -26,6 +26,7 @@ import {
   RUNTIME_STATUS,
   SCHEDULER_JOBS,
   SETTINGS_SCHEMA,
+  GATEWAY_MODELS,
   settingsRestartRequired,
   SLASH_COMMANDS,
   PLAYBOOKS,
@@ -409,6 +410,14 @@ const server = createServer(async (req, res) => {
     // `removed: true` is the happy path the #1103 e2e drives (cancel before drain).
     if (/^\/api\/chat\/sessions\/[^/]+\/steer\/[^/]+$/.test(pathname) && req.method === "DELETE") {
       return sendJson(res, { removed: true, pending: 0 });
+    }
+    if (pathname === "/api/config/models" && req.method === "POST") {
+      // "Get models" (#1386): probe the (form) gateway for its model list. The mock returns a
+      // DIFFERENT set than the saved dropdown, so the test can prove the dropdown refreshes.
+      return sendJson(res, { models: GATEWAY_MODELS, error: "" });
+    }
+    if (pathname === "/api/config/test-model" && req.method === "POST") {
+      return sendJson(res, { ok: true, error: "" });
     }
     if (pathname === "/api/knowledge/attach" && req.method === "POST") {
       // Chat attachment upload (#1002) — multipart, so DON'T JSON-parse the body.

--- a/apps/web/e2e/model-settings.spec.ts
+++ b/apps/web/e2e/model-settings.spec.ts
@@ -1,0 +1,37 @@
+import { expect, test } from "@playwright/test";
+
+// #1386 — switching the main model provider was a dead-end: the Primary model dropdown only
+// offered the SAVED gateway's models, so after changing the base URL/key you couldn't pick a
+// model the new key actually allows, and Test connection failed against the stale model. The
+// "Get models" action probes the form's gateway and refreshes the dropdown with its models.
+
+async function openModelSettings(page) {
+  await page.goto("/app/", { waitUntil: "load" });
+  await page.getByTestId("settings-widget").click();
+  await expect(page.locator(".settings-overlay")).toBeVisible();
+  await page.locator(".settings-overlay .pl-sidenav").getByRole("tab", { name: "Model & Routing", exact: true }).click();
+  // Field groups start collapsed — open them so the model field + actions are visible.
+  const triggers = page.locator(".pl-accordion__trigger");
+  await expect(triggers.first()).toBeVisible();
+  for (let i = 0; i < (await triggers.count()); i++) {
+    const t = triggers.nth(i);
+    if ((await t.getAttribute("aria-expanded")) !== "true") await t.click();
+  }
+}
+
+test("Get models refreshes the Primary model dropdown with the gateway's models (#1386)", async ({ page }) => {
+  await openModelSettings(page);
+  const model = page.locator("#set-model\\.name");
+  // The saved dropdown offers only protolabs/reasoning + protolabs/fast (the fixture).
+  await expect(model).toContainText("protolabs/reasoning");
+
+  // Pull the gateway's models (POST /api/config/models → the mock's GATEWAY_MODELS).
+  await page.getByRole("button", { name: "Get models" }).click();
+  await expect(page.locator(".settings-status")).toContainText(/found 3 models/i);
+
+  // The freshly-probed models are now selectable — picking protolabs/smart (which was NOT in the
+  // saved options) proves the dropdown refreshed, so switching gateway is no longer a dead-end.
+  await model.click();
+  await page.getByRole("menuitemradio", { name: "protolabs/smart" }).click();
+  await expect(model).toContainText("protolabs/smart");
+});

--- a/apps/web/src/lib/types.ts
+++ b/apps/web/src/lib/types.ts
@@ -248,6 +248,9 @@ export type SettingsField = {
   description?: string;
   restart: boolean;
   options: string[];
+  // Where `options` come from: "models" / "models+acp" → the gateway's model list. The Model
+  // settings "Get models" action (#1386) merges a freshly-probed list into these fields.
+  options_source?: string;
   default?: unknown;
   value?: unknown; // absent for secrets
   is_set?: boolean; // secrets only

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -4,7 +4,7 @@ import { Alert } from "@protolabsai/ui/data";
 import { Combobox, DropdownSelect, Input, Switch, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
 import { useMutation, useQueryClient, useSuspenseQuery } from "@tanstack/react-query";
-import { Loader2, RotateCcw, Save } from "lucide-react";
+import { Boxes, Loader2, RotateCcw, Save } from "lucide-react";
 
 import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
@@ -211,6 +211,38 @@ export function SettingsCategory({
     onError: (e) => setStatus(`connection test failed: ${errMsg(e)}`),
   });
 
+  // "Get models" (#1386): probe the gateway named on the FORM — its api_base/key, which may be
+  // a NEW provider you haven't saved yet — for its model list, so you can pick a valid model
+  // BEFORE saving and testing (the saved dropdown would otherwise be stuck on the old gateway's
+  // models → a dead-end). The result is merged into every model-backed dropdown below.
+  const [gatewayModels, setGatewayModels] = useState<string[] | null>(null);
+  const apiBaseField = useMemo(
+    () => groups.flatMap((g) => g.fields).find((f) => f.key === "model.api_base"),
+    [groups],
+  );
+  const getModels = useMutation({
+    // api_base: the form edit, else the saved value. api_key: the form edit, else blank — the
+    // server falls back to the saved (secret) key, which never leaves localStorage as plaintext.
+    mutationFn: () => api.models(asStr(dirty["model.api_base"]) || asStr(apiBaseField?.value), asStr(dirty["model.api_key"])),
+    onMutate: () => setStatus("fetching models from the gateway…"),
+    onSuccess: (r) => {
+      if (r.error) { setStatus(`couldn't fetch models — ${r.error}`); return; }
+      setGatewayModels(r.models);
+      setStatus(
+        r.models.length
+          ? `found ${r.models.length} model${r.models.length === 1 ? "" : "s"} — pick one in Primary model, then Test connection.`
+          : "the gateway returned no models.",
+      );
+    },
+    onError: (e) => setStatus(`couldn't fetch models — ${errMsg(e)}`),
+  });
+  // Merge the freshly-probed models into a model-backed field's options (new gateway's models
+  // first, then whatever was saved), so the dropdown isn't stuck on the old provider's list.
+  const withGatewayModels = (field: SettingsField): SettingsField =>
+    gatewayModels && (field.options_source === "models" || field.options_source === "models+acp")
+      ? { ...field, options: [...new Set([...gatewayModels, ...field.options])] }
+      : field;
+
   // Generic per-group "Test connection" (ADR 0029).
   const [testingSection, setTestingSection] = useState<string | null>(null);
   const groupFields = (group: SettingsGroup): Record<string, unknown> => {
@@ -239,7 +271,7 @@ export function SettingsCategory({
       {group.fields.filter(isVisible).map((field) => (
         <SettingRow
           key={field.key}
-          field={field}
+          field={withGatewayModels(field)}
           dirty={field.key in dirty}
           value={field.key in dirty ? dirty[field.key] : field.value}
           showInheritance={!hostLayer}
@@ -283,7 +315,14 @@ export function SettingsCategory({
         actions={
           <>
             {hasModel ? (
-              <TestConnectionButton onClick={() => testConn.mutate()} pending={testConn.isPending} disabled={save.isPending} />
+              <>
+                {/* #1386 — pull the form gateway's model list into the Primary model dropdown, so
+                    switching provider/key isn't a dead-end (the saved list is stale). */}
+                <Button type="button" onClick={() => getModels.mutate()} disabled={getModels.isPending || save.isPending}>
+                  {getModels.isPending ? <Loader2 className="spin" size={15} /> : <Boxes size={15} />} Get models
+                </Button>
+                <TestConnectionButton onClick={() => testConn.mutate()} pending={testConn.isPending} disabled={save.isPending} />
+              </>
             ) : null}
             {/* Pilot of the protoLabs design system (ADR 0037 D7) — the real @protolabsai/ui Button. */}
             <Button type="button" onClick={discard} disabled={save.isPending || !dirtyKeys.length}>

--- a/graph/settings_schema.py
+++ b/graph/settings_schema.py
@@ -826,6 +826,10 @@ def build_schema(
             "default": _jsonable(getattr(defaults, f.attr, None)),
             "scope": f.scope,  # ADR 0047: "agent" | "host"
             "source": _source_for(f.key, agent_doc, host_doc),  # which layer set the live value
+            # Lets the console refresh a model-backed dropdown from a DIFFERENT gateway than the
+            # saved one (#1386): a "Get models" action probes the form's api_base/key and merges
+            # the result into every field whose options come from "models".
+            "options_source": f.options_source,
         }
         if f.type == "secret":
             entry["value"] = ""

--- a/tests/test_settings_schema.py
+++ b/tests/test_settings_schema.py
@@ -45,6 +45,11 @@ def test_schema_groups_and_values():
     # The fallback list carries the gateway options too (rendered as combobox rows).
     fallback = next(f for f in fields if f["key"] == "routing.fallback_models")
     assert fallback["type"] == "string_list" and fallback["options"] == ["a", "b"]
+    # #1386 — every CORE entry carries options_source so the console knows which dropdowns to
+    # refresh from a freshly-probed gateway ("Get models"). Model-backed → "models"/"models+acp".
+    assert all("options_source" in f for f in fields if f["key"] in core_keys)
+    assert model["options_source"] == "models"
+    assert next(f for f in fields if f["key"] == "routing.aux_model")["options_source"] == "models+acp"
     # The main-brain runtime select offers native + every ACP agent (incl. gemini).
     runtime = next(f for f in fields if f["key"] == "agent_runtime")
     assert runtime["type"] == "select" and runtime["options"] == ["native", *ACP_MODEL_OPTIONS]


### PR DESCRIPTION
Closes #1386.

## The dead-end
Changing the main model provider couldn't be completed from the UI. The **Primary model** dropdown is filled server-side at schema-load from the **saved** gateway's models, so after you change `api_base`/`api_key` to a new provider, the dropdown still lists the *old* gateway's models — you can't pick one the new key allows. **Test connection** then fires the **stale** model against the **new** endpoint, producing exactly the reported error:

> `connection failed — HTTP 401: key not allowed to access model. This key can only access models=['protolabs/smart', 'protolabs/fast', …]`

(i.e. a `deepseek` alias requested against the protolabs gateway — the triage in the issue nailed it.)

## The fix
A **"Get models"** action in Settings ▸ Model & Routing that probes the gateway named on the **form** (its `api_base`/`api_key`, possibly unsaved) via the existing `POST /api/config/models`, and merges the result into every model-backed dropdown. New flow:

**change provider/key → Get models → pick a valid model → Test connection** (which already used the form's model).

## Changes
- **server** — the settings-schema field entry now carries `options_source`, so the console knows which dropdowns are gateway-backed (`graph/settings_schema.py` + test).
- **console** — `getModels` mutation + header button (next to Test connection) + `withGatewayModels` options merge. The API key falls back to the saved secret **server-side** when unchanged, so it's never sent as plaintext from the form.
- **e2e** — mock `POST /api/config/models` + a `model-settings` spec: Get models → *"found 3 models"* → `protolabs/smart` (absent from the saved options) becomes selectable.

## Verification
- **Live (:7871):** `POST /api/config/models` returned **19 real gateway models** (`protolabs/fast`, `protolabs/nano`, …).
- Python settings-schema + roundtrip green; console tsc/build; full unit (166) + e2e (155) green.

DRAFT — UI work under the local-test gate; please eyeball the full **change provider → Get models → pick → Test connection** flow on :7871 against the real gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a “Get models” action in settings to refresh available model choices from the selected gateway.
  * Model dropdowns now update dynamically after fetching gateway-provided models.

* **Bug Fixes**
  * Improved model selection so previously unavailable gateway models can appear without reloading or changing saved settings.
  * Settings now keep model-related options in sync with the current connection details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->