### PR TITLE
refactor(web): inline action feedback → toasts (settings + 7 panels)

### DIFF
--- a/apps/web/e2e/model-settings.spec.ts
+++ b/apps/web/e2e/model-settings.spec.ts
@@ -27,7 +27,7 @@ test("Get models refreshes the Primary model dropdown with the gateway's models 
 
   // Pull the gateway's models (POST /api/config/models → the mock's GATEWAY_MODELS).
   await page.getByRole("button", { name: "Get models" }).click();
-  await expect(page.locator(".settings-status")).toContainText(/found 3 models/i);
+  await expect(page.locator(".pl-toast", { hasText: /found 3 models/i })).toBeVisible();
 
   // The freshly-probed models are now selectable — picking protolabs/smart (which was NOT in the
   // saved options) proves the dropdown refreshed, so switching gateway is no longer a dead-end.

--- a/apps/web/e2e/settings.spec.ts
+++ b/apps/web/e2e/settings.spec.ts
@@ -117,7 +117,7 @@ test("editing an Agent setting enables save and round-trips", async ({ page }) =
   await page.locator('.setting-row[data-key="routing.aux_model"] input').fill("protolabs/turbo");
   await expect(save).toBeEnabled();
   await save.click();
-  await expect(page.locator(".settings-status")).toContainText("config saved");
+  await expect(page.locator(".pl-toast", { hasText: "config saved" })).toBeVisible();
 });
 
 test("a restart-flagged System field shows the restart banner", async ({ page }) => {
@@ -153,7 +153,7 @@ test("a host-scoped edit on the host console saves to the host layer", async ({ 
   await expandAllGroups(page);
   await page.locator('.setting-row[data-key="routing.aux_model"] input').fill("protolabs/host-fast");
   await page.getByRole("button", { name: /Save & apply/ }).click();
-  await expect(page.locator(".settings-status")).toContainText("(host)");
+  await expect(page.locator(".pl-toast", { hasText: "(host)" })).toBeVisible();
 });
 
 // On a FLEET MEMBER console (/agent/<slug>/) the same fields show the ADR 0047 inheritance
@@ -174,6 +174,6 @@ test("per-agent (fleet member) settings show ADR 0047 inheritance badges + reset
   const temp = page.locator('.setting-row[data-key="model.temperature"]');
   await expect(temp.locator(".setting-inheritance")).toContainText("overridden here");
   await temp.getByRole("button", { name: /Reset to inherited/ }).click();
-  await expect(page.locator(".settings-status")).toContainText("inherited");
+  await expect(page.locator(".pl-toast", { hasText: /inherited/i })).toBeVisible();
   await expect(page.locator('.setting-row[data-key="routing.fallback_models"] .setting-inheritance')).toHaveCount(0);
 });

--- a/apps/web/src/app/TasksPanel.tsx
+++ b/apps/web/src/app/TasksPanel.tsx
@@ -1,6 +1,6 @@
 import { DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Button, Empty } from "@protolabsai/ui/primitives";
-import { Dialog } from "@protolabsai/ui/overlays";
+import { Dialog, useToast } from "@protolabsai/ui/overlays";
 import {
   QueryErrorResetBoundary,
   useMutation,
@@ -21,6 +21,7 @@ import {
 import { Suspense, useEffect, useState } from "react";
 
 import { api } from "../lib/api";
+import { errMsg } from "../lib/format";
 import { onServerEvent } from "../lib/events";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { tasksQuery, queryKeys } from "../lib/queries";
@@ -64,13 +65,11 @@ function TaskCreateDialog({
   onClose,
   onCreate,
   busy,
-  error,
 }: {
   open: boolean;
   onClose: () => void;
   onCreate: (draft: IssueDraft) => void;
   busy: boolean;
-  error?: string | null;
 }) {
   const [draft, setDraft] = useState<IssueDraft>(emptyIssueDraft);
   // Reset to a blank draft each time the dialog opens.
@@ -102,7 +101,6 @@ function TaskCreateDialog({
       }
     >
       <div className="task-create-form" data-testid="task-create-dialog">
-        {error ? <p className="settings-status">Couldn't create: {error}</p> : null}
         <label className="field">
           <span>Title</span>
           <Input
@@ -165,6 +163,9 @@ function TasksBody({ confirm }: { confirm: (req: ConfirmRequest) => void }) {
   const issues = data.issues;
   const queryClient = useQueryClient();
   const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.tasks });
+  // Transient action feedback is a TOAST, not an inline line — the in-progress state
+  // already shows on the Create button's pending spinner.
+  const toast = useToast();
 
   // Live: the agent created/closed/updated an issue mid-turn — refresh off the
   // `task.changed` bus push instead of polling every 5s (#1310), like the inbox panel.
@@ -181,7 +182,11 @@ function TasksBody({ confirm }: { confirm: (req: ConfirmRequest) => void }) {
         priority: d.priority,
         description: d.description.trim() || undefined,
       }),
-    onSuccess: () => setDialogOpen(false),
+    onSuccess: () => {
+      setDialogOpen(false);
+      toast({ tone: "success", title: "Task created", message: "Added to the board." });
+    },
+    onError: (e) => toast({ tone: "error", title: "Couldn't create task", message: errMsg(e) }),
     onSettled: invalidate,
   });
   const update = useMutation({
@@ -324,7 +329,6 @@ function TasksBody({ confirm }: { confirm: (req: ConfirmRequest) => void }) {
         onClose={() => { setDialogOpen(false); create.reset(); }}
         onCreate={(d) => create.mutate(d)}
         busy={create.isPending}
-        error={create.isError ? (create.error as Error).message : null}
       />
     </>
   );

--- a/apps/web/src/app/theme.css
+++ b/apps/web/src/app/theme.css
@@ -668,6 +668,16 @@ select:disabled {
   padding: var(--pl-space-6, 24px);
 }
 
+/* Toasts anchor TOP-right, not the DS default bottom-right — they read as app-level
+   notifications and shouldn't collide with the bottom utility bar / composer. `column-reverse`
+   keeps the NEWEST toast nearest the top-right corner (mirrors the DS's newest-nearest-the-anchor
+   behavior). Loads after the DS overlays.css, so equal specificity wins. */
+.pl-toast-stack {
+  top: var(--pl-space-4, 16px);
+  bottom: auto;
+  flex-direction: column-reverse;
+}
+
 /* MCP catalog quick-add (McpCatalogDialog) — a curated directory of common servers,
    self-contained styles so the dialog doesn't depend on the Plugins surface CSS. */
 /* Browse (grid) view: pin the dialog to a tall, consistent height and let the card

--- a/apps/web/src/schedule/SchedulePanel.tsx
+++ b/apps/web/src/schedule/SchedulePanel.tsx
@@ -2,7 +2,7 @@ import "./schedule.css";
 
 import { DropdownSelect, Input, Textarea } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
-import { ConfirmDialog, Dialog } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, Dialog, useToast } from "@protolabsai/ui/overlays";
 import {
   useMutation,
   useQueryClient,
@@ -189,14 +189,12 @@ function ScheduleDetailDialog({
   onSave,
   onDelete,
   busy,
-  error,
 }: {
   job: ScheduledJob | null;
   onClose: () => void;
   onSave: (id: string, body: { prompt: string; schedule: string; timezone?: string }) => void;
   onDelete: (id: string) => void;
   busy: boolean;
-  error?: string | null;
 }) {
   const [editing, setEditing] = useState(false);
   const [prompt, setPrompt] = useState("");
@@ -250,7 +248,6 @@ function ScheduleDetailDialog({
       }
     >
       <div className="schedule-form" data-testid="schedule-detail">
-        {error ? <p className="settings-status">Couldn't save: {error}</p> : null}
         {editing ? (
           <>
             <label className="field">
@@ -303,10 +300,17 @@ function ScheduleBody() {
   const confirmJob = jobs.find((j) => j.id === confirmDeleteId) ?? null;
 
   const invalidate = () => queryClient.invalidateQueries({ queryKey: queryKeys.schedules });
+  // Transient action feedback is a TOAST, not an inline line — the in-progress state
+  // already shows on each button's disabled/pending affordance.
+  const toast = useToast();
 
   const add = useMutation({
     mutationFn: (body: { prompt: string; schedule: string; job_id?: string; timezone?: string }) => api.addSchedule(body),
-    onSuccess: () => setModalOpen(false),
+    onSuccess: () => {
+      setModalOpen(false);
+      toast({ tone: "success", title: "Scheduled", message: "The job was added." });
+    },
+    onError: (e) => toast({ tone: "error", title: "Couldn't schedule", message: errMsg(e) }),
     onSettled: invalidate,
   });
   const cancel = useMutation({ mutationFn: (id: string) => api.cancelSchedule(id), onSettled: invalidate });
@@ -315,7 +319,11 @@ function ScheduleBody() {
   const edit = useMutation({
     mutationFn: ({ id, body }: { id: string; body: { prompt: string; schedule: string; timezone?: string } }) =>
       api.updateSchedule(id, body),
-    onSuccess: () => setDetailId(null),
+    onSuccess: () => {
+      setDetailId(null);
+      toast({ tone: "success", title: "Schedule updated", message: "Your changes were saved." });
+    },
+    onError: (e) => toast({ tone: "error", title: "Couldn't save the job", message: errMsg(e) }),
     onSettled: invalidate,
   });
   const busy = add.isPending || cancel.isPending || edit.isPending;
@@ -337,7 +345,6 @@ function ScheduleBody() {
       />
 
       <div className="stage-body">
-        {add.isError ? <p className="settings-status">Couldn't schedule: {errMsg(add.error)}</p> : null}
         <div className="subagent-list">
           {jobs.length ? (
             jobs.map((job) => (
@@ -376,7 +383,6 @@ function ScheduleBody() {
         onSave={(id, body) => edit.mutate({ id, body })}
         onDelete={(id) => setConfirmDeleteId(id)}
         busy={busy}
-        error={edit.isError ? errMsg(edit.error) : null}
       />
       <ConfirmDialog
         open={confirmDeleteId !== null}

--- a/apps/web/src/settings/DelegatesSection.tsx
+++ b/apps/web/src/settings/DelegatesSection.tsx
@@ -3,7 +3,7 @@ import "./delegates.css";
 
 import { DropdownSelect, Input, RadioCard, RadioCardGroup, Textarea } from "@protolabsai/ui/forms";
 import { Badge, Button } from "@protolabsai/ui/primitives";
-import { Dialog } from "@protolabsai/ui/overlays";
+import { Dialog, useToast } from "@protolabsai/ui/overlays";
 
 import { StatusDot } from "@protolabsai/ui/data";
 
@@ -65,8 +65,9 @@ export function DelegatesSection() {
   const types = useQuery(delegateTypesQuery());
   const [editing, setEditing] = useState<DelegateView | null>(null);
   const [adding, setAdding] = useState(false);
-  const [status, setStatus] = useState("");
+  // Per-row probe chips (test results) stay inline; transient add/remove/save feedback toasts.
   const [probes, setProbes] = useState<Record<string, DelegateProbe>>({});
+  const toast = useToast();
 
   const invalidate = () => qc.invalidateQueries({ queryKey: queryKeys.delegates });
   const closeForm = () => { setAdding(false); setEditing(null); };
@@ -74,10 +75,10 @@ export function DelegatesSection() {
   const remove = useMutation({
     mutationFn: (name: string) => api.deleteDelegate(name),
     onSuccess: (r) => {
-      setStatus(r.message || "deleted");
+      toast({ tone: "success", title: "Delegate removed", message: r.message || "Removed." });
       void invalidate();
     },
-    onError: (e) => setStatus(`delete failed: ${errMsg(e)}`),
+    onError: (e) => toast({ tone: "error", title: "Remove failed", message: errMsg(e) }),
   });
 
   const testRow = useMutation({
@@ -151,8 +152,6 @@ export function DelegatesSection() {
         {!delegates.length ? <p className="setting-desc">No delegates yet — add one below.</p> : null}
       </div>
 
-      {status ? <p className="settings-inline-status">{status}</p> : null}
-
       <div className="settings-group-actions">
         <Button type="button" onClick={() => { setEditing(null); setAdding(true); }} disabled={!typeSpecs.length}>
           <Plus size={15} /> Add delegate
@@ -174,7 +173,7 @@ export function DelegatesSection() {
           spec={typeSpecs}
           initial={editing}
           onClose={closeForm}
-          onSaved={(msg) => { closeForm(); setStatus(msg); void invalidate(); }}
+          onSaved={(msg) => { closeForm(); toast({ tone: "success", title: "Delegate saved", message: msg }); void invalidate(); }}
         />
       </Dialog>
     </section>

--- a/apps/web/src/settings/FleetManagerPanel.tsx
+++ b/apps/web/src/settings/FleetManagerPanel.tsx
@@ -7,10 +7,11 @@ import { useState } from "react";
 import { Badge, Button, Empty } from "@protolabsai/ui/primitives";
 import { Alert, StatusDot } from "@protolabsai/ui/data";
 import { EditableText, Switch } from "@protolabsai/ui/forms";
-import { ConfirmDialog } from "@protolabsai/ui/overlays";
+import { ConfirmDialog, useToast } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 
 import { api, currentSlug } from "../lib/api";
+import { errMsg } from "../lib/format";
 import { fleetQuery, queryKeys } from "../lib/queries";
 import type { DiscoveredAgent, FleetAgent } from "../lib/types";
 
@@ -21,16 +22,19 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   const qc = useQueryClient();
   const fleet = useQuery(fleetQuery());
   const [busy, setBusy] = useState<string | null>(null); // name currently being acted on
-  const [error, setError] = useState<string | null>(null);
   const [confirmRemove, setConfirmRemove] = useState<FleetAgent | null>(null);
   const [purge, setPurge] = useState(false);
+  // Transient action feedback (rename / start / stop / add / discover failures) is a TOAST —
+  // the global toaster, not an inline line. The in-progress state already rides each button's
+  // disabled spinner, so there's no "…ing" toast. (The one exception is the actionable
+  // enable-delegates banner below, which carries a retry button a toast can't.)
+  const toast = useToast();
 
   // Display rename (the id — and so the URL slug + data scope — never changes).
   const [renaming, setRenaming] = useState<string | null>(null); // the id being renamed
   const rename = useMutation({
     mutationFn: ({ id, name }: { id: string; name: string }) => api.renameAgent(id, name),
-    onMutate: () => setError(null),
-    onError: (e: Error) => setError(e.message),
+    onError: (e) => toast({ tone: "error", title: "Rename failed", message: errMsg(e) }),
     onSettled: () => {
       setRenaming(null);
       qc.invalidateQueries({ queryKey: queryKeys.fleet });
@@ -45,8 +49,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
 
   const run = useMutation({
     mutationFn: async (fn: () => Promise<unknown>) => fn(),
-    onMutate: () => setError(null),
-    onError: (e: Error) => setError(e.message),
+    onError: (e) => toast({ tone: "error", title: "Action failed", message: errMsg(e) }),
     onSettled: () => {
       setBusy(null);
       qc.invalidateQueries({ queryKey: queryKeys.fleet });
@@ -71,16 +74,15 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   const addDelegate = useMutation({
     mutationFn: (entry: { name: string; url: string }) =>
       api.createDelegate({ name: entry.name, type: "a2a", url: entry.url }),
-    onMutate: () => {
-      setError(null);
-      setNeedsEnable(null);
-    },
+    onMutate: () => setNeedsEnable(null),
     onError: (e: Error, entry) => {
+      // A 404 means the focused agent doesn't serve /api/delegates yet — surface the
+      // actionable enable-and-retry banner (needsEnable) instead of a transient toast,
+      // since it carries a retry button. Any other failure is a plain error toast.
       if (/404|not found/i.test(e.message)) {
         setNeedsEnable(entry);
-        setError("This agent can't hold delegates yet — the delegates plugin isn't enabled on it.");
       } else {
-        setError(e.message);
+        toast({ tone: "error", title: "Couldn't add delegate", message: errMsg(e) });
       }
     },
     onSettled: () => {
@@ -97,12 +99,11 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
       }
       return entry;
     },
-    onMutate: () => setError(null),
     onSuccess: (entry) => {
       setNeedsEnable(null);
       addDelegate.mutate(entry); // routes are hot-mounted on the reload — retry the add now
     },
-    onError: (e: Error) => setError(e.message),
+    onError: (e) => toast({ tone: "error", title: "Couldn't enable delegates", message: errMsg(e) }),
   });
 
   // Network discovery (ADR 0042 §I) — scan the box + LAN for OTHER protoAgents (not in this
@@ -111,11 +112,10 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   const [discovered, setDiscovered] = useState<DiscoveredAgent[] | null>(null);
   const scan = async () => {
     setScanning(true);
-    setError(null);
     try {
       setDiscovered((await api.discoverAgents()).discovered);
     } catch (e) {
-      setError((e as Error).message);
+      toast({ tone: "error", title: "Discovery failed", message: errMsg(e) });
     } finally {
       setScanning(false);
     }
@@ -129,8 +129,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   // collide with existing agents (every template fork is "protoagent") — suffix on 400.
   const addMember = useMutation({
     mutationFn: (d: DiscoveredAgent) => api.addRemoteAgent({ name: d.name, url: d.url }),
-    onMutate: () => setError(null),
-    onError: (e: Error) => setError(e.message),
+    onError: (e) => toast({ tone: "error", title: "Couldn't add to fleet", message: errMsg(e) }),
     onSettled: () => {
       qc.invalidateQueries({ queryKey: queryKeys.fleet });
       void scan(); // the new member drops out of the discover list
@@ -138,8 +137,7 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
   });
   const removeMember = useMutation({
     mutationFn: (a: FleetAgent) => api.removeRemoteAgent(a.id),
-    onMutate: () => setError(null),
-    onError: (e: Error) => setError(e.message),
+    onError: (e) => toast({ tone: "error", title: "Couldn't remove member", message: errMsg(e) }),
     onSettled: () => qc.invalidateQueries({ queryKey: queryKeys.fleet }),
   });
 
@@ -155,10 +153,13 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
         }
       />
       <div className="stage-body">
-        {error ? (
+        {/* The one error that stays inline: a 404 add-delegate carries an actionable
+            enable-and-retry banner (the focused agent's delegates plugin isn't enabled).
+            Plain action failures are transient toasts; this one needs its retry button. */}
+        {needsEnable ? (
           <Alert
             status="error"
-            action={needsEnable ? (
+            action={
               <Button
                 variant="default"
                 disabled={enableDelegates.isPending || addDelegate.isPending}
@@ -166,9 +167,9 @@ export function FleetManagerPanel({ onNew }: { onNew?: () => void }) {
                 data-testid="enable-delegates">
                 {enableDelegates.isPending ? "Enabling…" : "Enable delegates on this agent"}
               </Button>
-            ) : undefined}
+            }
           >
-            {error}
+            This agent can't hold delegates yet — the delegates plugin isn't enabled on it.
           </Alert>
         ) : null}
         {fleet.isLoading ? (

--- a/apps/web/src/settings/NewAgentPanel.tsx
+++ b/apps/web/src/settings/NewAgentPanel.tsx
@@ -4,8 +4,8 @@ import { useState } from "react";
 
 import { Input, RadioCard, RadioCardGroup } from "@protolabsai/ui/forms";
 import { Button } from "@protolabsai/ui/primitives";
-import { Alert } from "@protolabsai/ui/data";
 import { PanelHeader } from "@protolabsai/ui/navigation";
+import { useToast } from "@protolabsai/ui/overlays";
 
 import { api } from "../lib/api";
 import { archetypesQuery, queryKeys } from "../lib/queries";
@@ -19,10 +19,10 @@ const NAME_RE = /^[A-Za-z0-9-_]+$/;
 // POST returns once the agent is up, so the button shows a spinner until then.
 export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) => void; onCancel?: () => void }) {
   const qc = useQueryClient();
+  const toast = useToast();
   const archetypes = useQuery(archetypesQuery());
   const [picked, setPicked] = useState<string>("basic");
   const [name, setName] = useState("");
-  const [error, setError] = useState<string | null>(null);
 
   // "custom" is a wizard-only persona (write-your-own SOUL) — this picker creates an
   // agent from a bundle and has no SOUL editor, so Custom would just duplicate Basic.
@@ -32,11 +32,12 @@ export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) =>
 
   const create = useMutation({
     mutationFn: () => api.createAgent({ name: name.trim(), bundle: archetype?.bundle ?? null }),
-    onMutate: () => setError(null),
-    onError: (e: Error) => setError(e.message),
+    onError: (e: Error) => toast({ tone: "error", title: "Couldn't create agent", message: e.message }),
     onSuccess: (res) => {
       qc.invalidateQueries({ queryKey: queryKeys.fleet });
-      onDone?.(res.agent?.name ?? name.trim());
+      const created = res.agent?.name ?? name.trim();
+      toast({ tone: "success", title: "Agent created", message: `${created} is ready.` });
+      onDone?.(created);
     },
   });
 
@@ -54,8 +55,6 @@ export function NewAgentPanel({ onDone, onCancel }: { onDone?: (name: string) =>
         }
       />
       <div className="stage-body">
-        {error ? <Alert status="error">{error}</Alert> : null}
-
         <p className="fleet-section-label">Archetype</p>
         <RadioCardGroup name="archetype" min="160px" value={picked} onValueChange={setPicked}>
           {list.map((a: Archetype) => (

--- a/apps/web/src/settings/QuickSetting.tsx
+++ b/apps/web/src/settings/QuickSetting.tsx
@@ -1,7 +1,7 @@
 import "./settings.css";
 
 import { Badge, Button } from "@protolabsai/ui/primitives";
-import { Dialog } from "@protolabsai/ui/overlays";
+import { Dialog, useToast } from "@protolabsai/ui/overlays";
 import { PanelHeader } from "@protolabsai/ui/navigation";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { ExternalLink, Loader2, Save, Settings2 } from "lucide-react";
@@ -85,7 +85,9 @@ function QuickSettingDialog({
   const queryClient = useQueryClient();
   const schema = useQuery(settingsSchemaQuery());
   const [dirty, setDirty] = useState<Record<string, unknown>>({});
-  const [status, setStatus] = useState("");
+  // Action feedback is a TOAST, not an inline line — the in-progress state is on the Save
+  // button's pending spinner; transient success/error belongs in the global toaster.
+  const toast = useToast();
 
   const fields = useMemo<SettingsField[]>(() => {
     const byKey = new globalThis.Map<string, SettingsField>();
@@ -99,16 +101,16 @@ function QuickSettingDialog({
 
   const save = useMutation({
     mutationFn: () => api.saveSettings(dirty, layer),
-    onMutate: () => setStatus("saving…"),
     onSuccess: (r) => {
       if (!r.ok) {
-        setStatus(`save failed: ${r.messages.join(" · ")}`);
+        toast({ tone: "error", title: "Save failed", message: r.messages.join(" · ") });
         return;
       }
+      toast({ tone: "success", title: "Saved", message: "Settings applied." });
       void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
       onClose();
     },
-    onError: (e) => setStatus(`save failed: ${errMsg(e)}`),
+    onError: (e) => toast({ tone: "error", title: "Save failed", message: errMsg(e) }),
   });
 
   const dirtyKeys = Object.keys(dirty);
@@ -161,7 +163,6 @@ function QuickSettingDialog({
           ))}
         </div>
       )}
-      {status ? <p className="settings-status">{status}</p> : null}
     </Dialog>
   );
 }

--- a/apps/web/src/settings/SettingsCategory.tsx
+++ b/apps/web/src/settings/SettingsCategory.tsx
@@ -10,6 +10,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import type { ReactNode } from "react";
 
 import { Accordion, AccordionItem, PanelHeader } from "@protolabsai/ui/navigation";
+import { useToast } from "@protolabsai/ui/overlays";
 import { StagePanel } from "../app/ErrorBoundary";
 import { HelpLink, TestConnectionButton } from "../app/ui-kit";
 import { agentHref, api, isHostConsole } from "../lib/api";
@@ -123,8 +124,10 @@ export function SettingsCategory({
       .filter((g) => g.fields.length);
   }, [data.groups, category, categories, hostLayer, pluginId]);
   const [dirty, setDirty] = useState<Record<string, unknown>>({});
-  const [status, setStatus] = useState("");
   const dirtyKeys = Object.keys(dirty);
+  // Action feedback is a TOAST, not an inline line — transient success/error belongs in the
+  // global toaster (the in-progress state is already on each button's pending spinner).
+  const toast = useToast();
 
   // #963 — conditional field visibility. The live value of every in-scope field
   // (the dirty edit if any, else the saved value), so a `depends_on` predicate is
@@ -176,15 +179,14 @@ export function SettingsCategory({
         restart_required: rs.flatMap((r) => r.restart_required),
       };
     },
-    onMutate: () => setStatus("saving…"),
     onSuccess: (r) => {
-      if (!r.ok) { setStatus(`save failed: ${r.messages.join(" · ")}`); return; }
-      const restartNote = r.restart_required.length ? ` — restart required for: ${r.restart_required.join(", ")}` : "";
-      setStatus(`${r.messages.join(" · ")}${restartNote}`);
+      if (!r.ok) { toast({ tone: "error", title: "Save failed", message: r.messages.join(" · ") }); return; }
+      const restartNote = r.restart_required.length ? `Restart required for: ${r.restart_required.join(", ")}` : "";
+      toast({ tone: "success", title: "Settings saved", message: restartNote || r.messages.join(" · ") || "Applied." });
       setDirty({});
       void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
     },
-    onError: (e) => setStatus(`save failed: ${errMsg(e)}`),
+    onError: (e) => toast({ tone: "error", title: "Save failed", message: errMsg(e) }),
   });
 
   // ADR 0047 reset-to-inherited — pop one (or more) overridden keys from the agent
@@ -192,23 +194,24 @@ export function SettingsCategory({
   // so the badges + values re-resolve to the inherited source (consistent with save).
   const reset = useMutation({
     mutationFn: (keys: string[]) => api.resetSettings(keys),
-    onMutate: () => setStatus("resetting to inherited…"),
     onSuccess: (r, keys) => {
-      if (!r.ok) { setStatus(`reset failed: ${r.messages.join(" · ")}`); return; }
-      setStatus(r.messages.join(" · "));
+      if (!r.ok) { toast({ tone: "error", title: "Reset failed", message: r.messages.join(" · ") }); return; }
+      toast({ tone: "success", title: "Reset to inherited", message: r.messages.join(" · ") || "Back to the inherited value." });
       // Drop any pending edit on the reset keys — the inherited value is now authoritative.
       setDirty((d) => { const next = { ...d }; for (const k of keys) delete next[k]; return next; });
       void queryClient.invalidateQueries({ queryKey: queryKeys.settings });
     },
-    onError: (e) => setStatus(`reset failed: ${errMsg(e)}`),
+    onError: (e) => toast({ tone: "error", title: "Reset failed", message: errMsg(e) }),
   });
 
   const asStr = (v: unknown) => (typeof v === "string" ? v : "");
   const testConn = useMutation({
     mutationFn: () => api.testModel(asStr(dirty["model.api_base"]), asStr(dirty["model.api_key"]), asStr(dirty["model.name"])),
-    onMutate: () => setStatus("testing connection…"),
-    onSuccess: (r) => setStatus(r.ok ? "connection OK — the model responded." : `connection failed — ${r.error || "no response"}`),
-    onError: (e) => setStatus(`connection test failed: ${errMsg(e)}`),
+    onSuccess: (r) =>
+      r.ok
+        ? toast({ tone: "success", title: "Connection OK", message: "The model responded." })
+        : toast({ tone: "error", title: "Connection failed", message: r.error || "no response" }),
+    onError: (e) => toast({ tone: "error", title: "Connection test failed", message: errMsg(e) }),
   });
 
   // "Get models" (#1386): probe the gateway named on the FORM — its api_base/key, which may be
@@ -224,17 +227,16 @@ export function SettingsCategory({
     // api_base: the form edit, else the saved value. api_key: the form edit, else blank — the
     // server falls back to the saved (secret) key, which never leaves localStorage as plaintext.
     mutationFn: () => api.models(asStr(dirty["model.api_base"]) || asStr(apiBaseField?.value), asStr(dirty["model.api_key"])),
-    onMutate: () => setStatus("fetching models from the gateway…"),
     onSuccess: (r) => {
-      if (r.error) { setStatus(`couldn't fetch models — ${r.error}`); return; }
+      if (r.error) { toast({ tone: "error", title: "Couldn't fetch models", message: r.error }); return; }
       setGatewayModels(r.models);
-      setStatus(
+      toast(
         r.models.length
-          ? `found ${r.models.length} model${r.models.length === 1 ? "" : "s"} — pick one in Primary model, then Test connection.`
-          : "the gateway returned no models.",
+          ? { tone: "success", title: `Found ${r.models.length} model${r.models.length === 1 ? "" : "s"}`, message: "Pick one in Primary model, then Test connection." }
+          : { tone: "info", title: "No models", message: "The gateway returned no models." },
       );
     },
-    onError: (e) => setStatus(`couldn't fetch models — ${errMsg(e)}`),
+    onError: (e) => toast({ tone: "error", title: "Couldn't fetch models", message: errMsg(e) }),
   });
   // Merge the freshly-probed models into a model-backed field's options (new gateway's models
   // first, then whatever was saved), so the dropdown isn't stuck on the old provider's list.
@@ -256,13 +258,15 @@ export function SettingsCategory({
   };
   const testGroup = useMutation({
     mutationFn: (vars: { endpoint: string; fields: Record<string, unknown> }) => api.testConfig(vars.endpoint, vars.fields),
-    onMutate: () => setStatus("testing connection…"),
-    onSuccess: (r) => setStatus(r.ok ? `connection OK${r.identity ? ` — ${r.identity}` : ""}` : `connection failed — ${r.error || "no response"}`),
-    onError: (e) => setStatus(`connection test failed: ${errMsg(e)}`),
+    onSuccess: (r) =>
+      r.ok
+        ? toast({ tone: "success", title: "Connection OK", message: r.identity || "Connected." })
+        : toast({ tone: "error", title: "Connection failed", message: r.error || "no response" }),
+    onError: (e) => toast({ tone: "error", title: "Connection test failed", message: errMsg(e) }),
     onSettled: () => setTestingSection(null),
   });
 
-  const discard = () => { setDirty({}); setStatus(""); };
+  const discard = () => setDirty({});
 
   // The fields + Test/Connect for one group — rendered inside an AccordionItem in the
   // full Settings view, or flat (no accordion) when folded into a plugin's row (ADR 0059).
@@ -355,7 +359,6 @@ export function SettingsCategory({
             Needs a restart to take effect: {pendingRestart.join(", ")}
           </Alert>
         ) : null}
-        {status ? <p className="settings-status">{status}</p> : null}
         {!groups.length && !footer ? <p className="muted">{emptyHint || "Nothing to configure here."}</p> : null}
 
         {/* Each field group is a collapsible accordion (DS 0.29) so a dense category

--- a/apps/web/src/workflows/WorkflowBuilder.tsx
+++ b/apps/web/src/workflows/WorkflowBuilder.tsx
@@ -7,6 +7,7 @@ import { useState } from "react";
 import { api } from "../lib/api";
 import { errMsg } from "../lib/format";
 import { PanelHeader } from "@protolabsai/ui/navigation";
+import { useToast } from "@protolabsai/ui/overlays";
 
 // Author a workflow recipe from the console (Sprint C): name + inputs + steps
 // (id, subagent, prompt, depends_on) + output → POST /api/workflows, which
@@ -26,6 +27,7 @@ export function WorkflowBuilder({
   onSaved: (name: string) => void;
   onCancel: () => void;
 }) {
+  const toast = useToast();
   const fallback = subagents[0] || "researcher";
   const [name, setName] = useState("");
   const [description, setDescription] = useState("");
@@ -35,7 +37,6 @@ export function WorkflowBuilder({
   ]);
   const [output, setOutput] = useState("");
   const [saving, setSaving] = useState(false);
-  const [error, setError] = useState("");
 
   const setStep = (i: number, patch: Partial<Step>) =>
     setSteps((s) => s.map((st, j) => (j === i ? { ...st, ...patch } : st)));
@@ -57,7 +58,6 @@ export function WorkflowBuilder({
 
   async function save() {
     setSaving(true);
-    setError("");
     const last = steps[steps.length - 1].id.trim();
     const recipe: Record<string, unknown> = {
       name: name.trim(),
@@ -76,9 +76,11 @@ export function WorkflowBuilder({
     if (description.trim()) recipe.description = description.trim();
     try {
       const r = await api.saveWorkflow(recipe);
-      onSaved(r.name || name.trim());
+      const saved = r.name || name.trim();
+      toast({ tone: "success", title: "Workflow saved", message: `${saved} is ready to run.` });
+      onSaved(saved);
     } catch (e) {
-      setError(errMsg(e));
+      toast({ tone: "error", title: "Couldn't save workflow", message: errMsg(e) });
     } finally {
       setSaving(false);
     }
@@ -193,8 +195,6 @@ export function WorkflowBuilder({
           placeholder={`default: {{steps.${steps[steps.length - 1].id.trim() || "lastStep"}.output}}`}
         />
       </label>
-
-      {error && <p className="workflow-failed">{error}</p>}
 
       <div className="panel-actions">
         <Button variant="ghost" type="button" onClick={onCancel} disabled={saving}>


### PR DESCRIPTION
Follow-on to the Model settings work — you asked to move the panel's success/error messaging to an actual toast, and to do the same anywhere else we message inline.

## What changed
Transient **action feedback** (the result of a save / test / connect / add / remove / create) moves from a panel-local inline line (`<p className="settings-status">…</p>` + a `status`/`error` state) to the **design-system toast** (`useToast()` → `toast({tone, title, message})` — the pattern `ThemeSurface` already uses). Success → success toast, error → error toast. The in-progress "…ing" text is dropped — each button's pending spinner already shows that.

Panels swept:
- **SettingsCategory** (Model & Routing + every category) — save / reset / **Test connection** / **Get models** / per-group test
- **QuickSetting** · **DelegatesSection** (remove + saved) · **FleetManagerPanel** (rename / start-stop / add / remove / discover / delegates) · **SchedulePanel** (schedule + edit) · **TasksPanel** (create) · **NewAgentPanel** (create) · **WorkflowBuilder** (save)

## Deliberately left inline (structural, not toasts)
- Persistent banners (restart-required, ACP-runtime note), empty-states, field-validation hints.
- **FleetManagerPanel's 404 "enable delegates" banner** — has an actionable retry button a toast can't carry (still asserted by `fleet.spec.ts`).
- **DelegateForm's per-row probe chips** — inline status next to each row.
- **InstallPluginDialog's `plugin-install-status`** — multi-step live install progress whose partial-success path keeps the dialog open with actionable detail; splitting only the terminal error to a toast would report failure inconsistently. Left whole.

## Verification
- The 4 e2e specs that asserted `.settings-status` now assert `.pl-toast`.
- Full **unit (166) + e2e (155)** green; **tsc** clean across all 10 files.
- Three of the mechanical per-panel conversions were done by subagents against a fixed canonical pattern, then verified centrally.

DRAFT — UI work under the local-test gate. Please eyeball the toasts on :7871 (save a setting, Test connection, Get models, schedule a job, create a task) and confirm the tone/wording feels right.

🤖 Generated with [Claude Code](https://claude.com/claude-code)