### PR TITLE
chore: release v0.72.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.72.0] - 2026-06-28
+
+### Added
+- **Context-window meter + per-turn cost/time** (#1372) — the chat header shows a live
+  context-window usage meter, and each completed turn reports its token cost and wall-clock time,
+  so you can see how close a conversation is to the model's window and what each turn spent.
+- **Vision-describe pass for text-only models** (#1381) — attach images to a chat whose model has no
+  native vision: a describe pass turns each image into a text description the model can reason over,
+  instead of dropping the attachment.
+- **"Get models"** (#1386) — a Settings action that pulls a gateway's advertised model list and
+  populates the Primary model dropdown, so you pick from what the gateway actually serves instead of
+  typing model ids by hand.
+- **Inline components re-enabled** (#1323) — an extensible registry with clean, deterministic
+  ordering replaces the disabled inline-component path, so plugins can contribute inline chat
+  components again.
+- **Per-stimulus Activity attribution** (#1375) — each Activity response is attributed to the
+  specific stimulus it replies to, so the reactive thread reads as paired stimulus → response
+  instead of an undifferentiated stream.
+
+### Changed
+- **Inline action feedback → toasts** (#1389) — settings and seven panels now surface transient
+  action results (save / test / connect / CRUD) as DS toasts instead of inline status lines,
+  continuing the toast sweep.
+
+### Fixed
+- **Deduped inbox/Activity now-item notifications + deliver-before-fire** (#1375) — now-item
+  notifications no longer double-fire across the inbox and Activity surfaces, and a delivery now
+  lands before its fire event.
+- **Clear error for images on a text-only model** (#1374) — attaching an image to a text-only model
+  now shows a clear, actionable error instead of a cryptic extractor rejection.
+- **Chat-tab trash only on the hovered ✕** (#1373) — the delete affordance shows on the ✕ you're
+  hovering, not on every tab at once.
+
 ## [0.71.0] - 2026-06-27
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "protoagent"
-version = "0.71.0"
+version = "0.72.0"
 description = "protoAgent — LangGraph + A2A template for spawning protoLabs agents"
 requires-python = ">=3.11"
 

--- a/sites/marketing/data/changelog.json
+++ b/sites/marketing/data/changelog.json
@@ -1,5 +1,20 @@
 [
   {
+    "version": "v0.72.0",
+    "date": "2026-06-28",
+    "changes": [
+      "Context-window meter + per-turn cost/time",
+      "Vision-describe pass for text-only models",
+      "\"Get models\"",
+      "Inline components re-enabled",
+      "Per-stimulus Activity attribution",
+      "Inline action feedback → toasts",
+      "Deduped inbox/Activity now-item notifications + deliver-before-fire",
+      "Clear error for images on a text-only model",
+      "Chat-tab trash only on the hovered ✕"
+    ]
+  },
+  {
     "version": "v0.71.0",
     "date": "2026-06-27",
     "changes": [


### PR DESCRIPTION
Automated version bump to \`v0.72.0\` — cutting a release for the 9 PRs merged since v0.71.0 (the batch shipped without \`[Unreleased]\` changelog entries, so this PR also backfills them).

**Rolled into 0.72.0:**

_Added_
- Context-window meter + per-turn cost/time (#1372)
- Vision-describe pass for text-only models (#1381)
- "Get models" — pull a gateway's model list into the Primary model dropdown (#1386)
- Inline components re-enabled — extensible registry + clean ordering (#1323)
- Per-stimulus Activity attribution (#1375)

_Changed_
- Inline action feedback → toasts (settings + 7 panels) (#1389)

_Fixed_
- Deduped inbox/Activity now-item notifications + deliver-before-fire (#1375)
- Clear error for images on a text-only model (#1374)
- Chat-tab trash only on the hovered ✕ (#1373)

Review + merge through the normal CI/review gate, then push the tag to cut the release:
\`git checkout main && git pull && git tag -a v0.72.0 -m 'Release v0.72.0' && git push origin v0.72.0\`. The tag push triggers release.yml (Docker tags + GitHub Release + Discord) — don't also workflow_dispatch release.yml afterward.

🤖 Generated with [Claude Code](https://claude.com/claude-code)