### PR TITLE
ci: bump GitHub Actions off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
       - name: Verify workspace config (.beads / .automaker / owned runners)
@@ -64,8 +64,8 @@ jobs:
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
       - name: Ruff check
@@ -89,8 +89,8 @@ jobs:
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -112,8 +112,8 @@ jobs:
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: "3.12"
           cache: pip
@@ -139,8 +139,8 @@ jobs:
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: "20"
           cache: npm
@@ -156,7 +156,7 @@ jobs:
         run: echo "version=$(node -p "require('@playwright/test/package.json').version")" >> "$GITHUB_OUTPUT"
       - name: Cache Playwright browsers
         id: pw-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.pw.outputs.version }}

--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -82,17 +82,17 @@ jobs:
             target: x86_64-pc-windows-msvc
             bundles: nsis
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ inputs.tag || github.ref }}
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 
@@ -337,7 +337,7 @@ jobs:
 
       - name: Upload dispatch artifact
         if: github.event_name == 'workflow_dispatch'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v6
         with:
           name: protoAgent-${{ steps.version.outputs.version }}-${{ matrix.target }}
           path: dist-desktop/*
@@ -371,12 +371,12 @@ jobs:
       # in-app updater notes (below). By tag-push time CHANGELOG.md already holds the
       # dated `## [VERSION]` section — the bump PR (prepare-release.yml) merged before
       # the tag. Without this the job has no working tree (it only `gh release`s).
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: ${{ github.ref_name }}
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v5
         with:
           node-version: '20'
 

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -34,13 +34,13 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -48,7 +48,7 @@ jobs:
 
       - name: Generate image metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           tags: |
@@ -62,7 +62,7 @@ jobs:
 
       - name: Build and push
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,14 +26,14 @@ jobs:
   build:
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v5
+      - uses: actions/setup-node@v5
         with:
           node-version: 20
           cache: npm
       - run: npm install
       - run: npm run docs:build
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         # Only needed to feed the deploy job — skip on PRs (build-only gate).
         if: github.event_name != 'pull_request'
         with:
@@ -49,4 +49,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/issue-gate.yml
+++ b/.github/workflows/issue-gate.yml
@@ -19,7 +19,7 @@ jobs:
   validate:
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v8
         with:
           script: |
             const GATE_LABEL = 'needs-info';

--- a/.github/workflows/marketing-deploy.yml
+++ b/.github/workflows/marketing-deploy.yml
@@ -28,9 +28,9 @@ jobs:
     name: Build & deploy to Cloudflare Pages
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           node-version: 22
 

--- a/.github/workflows/prepare-release.yml
+++ b/.github/workflows/prepare-release.yml
@@ -43,7 +43,7 @@ jobs:
       pull-requests: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           ref: main
           fetch-depth: 0
@@ -52,7 +52,7 @@ jobs:
           # downstream workflows on pushes it makes.
           token: ${{ secrets.GH_PAT }}
 
-      - uses: actions/setup-python@v5
+      - uses: actions/setup-python@v6
         with:
           python-version: '3.12'
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -34,7 +34,7 @@ jobs:
       attestations: write
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           ref: ${{ inputs.tag || github.ref }}
@@ -56,10 +56,10 @@ jobs:
       # ── Docker ────────────────────────────────────────────────────────────────
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Log in to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ${{ env.REGISTRY }}
           username: ${{ github.actor }}
@@ -67,7 +67,7 @@ jobs:
 
       - name: Docker metadata
         id: meta
-        uses: docker/metadata-action@v5
+        uses: docker/metadata-action@v6
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           # `latest` is pushed on every main merge by docker-publish.yml;
@@ -84,7 +84,7 @@ jobs:
 
       - name: Build and push Docker image
         id: build
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: Dockerfile
@@ -109,7 +109,7 @@ jobs:
       - name: Attest build provenance
         if: vars.ATTESTATIONS_ENABLED == 'true'
         continue-on-error: true
-        uses: actions/attest-build-provenance@v1
+        uses: actions/attest-build-provenance@v3
         with:
           subject-name: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
           subject-digest: ${{ steps.build.outputs.digest }}

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest  # workspace-config: allow-hosted-runner public repo — GH-hosted is free
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - name: Install gitleaks
         run: |
           VER=8.21.2

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+- **CI off the deprecated Node 20 action runtime** (#1391) — bumped every GitHub Actions pin across
+  the nine workflow files to the lowest major that runs natively on Node 24, so runs no longer log
+  GitHub's "Node.js 20 is deprecated" annotation. Notable non-`+1` jumps where the next major was
+  still Node 20: `upload-artifact` v4 → **v6**, `build-push-action` v5 → **v7**, and
+  `attest-build-provenance` v1 → **v3** (its v2 leaf `actions/attest` was still Node 20). All are
+  pure-runtime bumps for our usage — no input/behavior changes; the new majors need Actions Runner
+  ≥ 2.327.1, which GitHub-hosted runners (all we use) already satisfy.
+
 ## [0.72.0] - 2026-06-28
 
 ### Added


### PR DESCRIPTION
Closes #1391.

The v0.72.0 release run logged GitHub's [Node 20 deprecation](https://github.blog/changelog/2025-09-19-deprecation-of-node-20-on-github-actions-runners/) warning — several pinned actions still target Node 20 and were being force-run on Node 24. This bumps every action pin across all nine workflow files to the lowest major that runs **natively** on Node 24.

### Method
For each action I queried the GitHub API and confirmed the target major's `action.yml` declares `runs.using: node24` (or is a composite whose leaf node-actions are node24) — not just "latest major". This caught two traps:
- **`upload-artifact` v5 is still Node 20** → bumped to **v6**.
- **`build-push-action` v6 is still Node 20** → bumped to **v7**.
- **`attest-build-provenance` v2's leaf `actions/attest@v2.4.0` is still Node 20** → bumped to **v3** (leaf `actions/attest@v3.0.0` = node24).

### Bumps
| Action | From | To |
|---|---|---|
| actions/checkout | v4 | v5 |
| actions/setup-python | v5 | v6 |
| actions/setup-node | v4 | v5 |
| actions/cache | v4 | v5 |
| actions/upload-artifact | v4 | **v6** |
| docker/setup-buildx-action | v3 | v4 |
| docker/login-action | v3 | v4 |
| docker/metadata-action | v5 | v6 |
| docker/build-push-action | v5 | **v7** |
| actions/upload-pages-artifact | v3 | v5 |
| actions/deploy-pages | v4 | v5 |
| actions/github-script | v7 | v8 |
| actions/attest-build-provenance | v1 | **v3** |

`dtolnay/rust-toolchain@stable` (composite, no node) and `protoLabsAI/release-tools@<sha>` (our own, SHA-pinned) were not flagged and are unchanged.

### Compatibility
- Chose the **lowest** node24 major for each to minimize input/behavior-change blast radius — most of these workflows (release, docker-publish, desktop-build, docs, marketing) don't run on PR CI, so the diff has to be safe by construction.
- Confirmed no input/behavior changes for our usage: `upload-artifact@v6` is a pure runtime bump; `build-push-action@v7` only drops envs we don't set; `attest-build-provenance@v3` accepts the same `subject-name`/`subject-digest`/`push-to-registry` inputs release.yml passes (and that step is `continue-on-error` + gated on `ATTESTATIONS_ENABLED`).
- New majors (`upload-artifact@v6`, `build-push-action@v7`) require **Actions Runner ≥ 2.327.1** — satisfied by GitHub-hosted runners, which is all this repo uses (`ubuntu-latest` / hosted mac+win).
- All nine workflow files still parse as valid YAML.

### Acceptance (#1391)
- [x] Pins updated consistently across every workflow file.
- [ ] Next runs complete with no "Node.js 20 is deprecated" annotation (verifiable once merged — `checks.yml` exercises checkout/setup-python/setup-node/cache on this very PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple GitHub Actions workflows to newer major versions of common actions used across CI, builds, docs, releases, Docker publishing, and security scanning.
  * Improved compatibility and maintenance across checkout, setup, cache, artifact upload, Docker, Pages deploy, release prep, and issue validation steps.
  * No workflow logic, triggers, build commands, or deployment behavior was changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->