### PR TITLE
fix(security): secure defaults — gate /metrics + strip secrets from MCP env (launch-hardening B3)

### DIFF
--- a/a2a_impl/auth.py
+++ b/a2a_impl/auth.py
@@ -50,7 +50,6 @@ _ALLOWED_ORIGINS: list[list[str] | None] = [None]
 # ---------------------------------------------------------------------------
 _PUBLIC_PREFIXES = (
     "/healthz",
-    "/metrics",
     "/.well-known/",
     "/app",
     "/manifest.json",
@@ -60,6 +59,12 @@ _PUBLIC_PREFIXES = (
     "/static/",
     "/_ds/",
 )
+
+# /metrics is CONDITIONALLY public — see ``_metrics_public``. It carries
+# operational data (model/tool inventory, cost, traffic) so it is exposed without
+# auth only in open mode (no token configured). Once a bearer / X-API-Key gates
+# the surface, the Prometheus scraper must authenticate too — set
+# ``PROTOAGENT_PUBLIC_METRICS=1`` to keep it anonymous behind a network boundary.
 
 # Plugin-declared auth-exempt prefixes. Set once at startup (and on reload) from
 # enabled plugins' manifest ``public_paths`` — each already validated to the
@@ -94,10 +99,28 @@ def set_public_prefixes(prefixes) -> None:
         logger.info("[a2a] %d plugin-declared auth-exempt path(s): %s", len(cleaned), ", ".join(cleaned))
 
 
+def _metrics_public() -> bool:
+    """Whether ``/metrics`` is reachable without auth.
+
+    Default: only in open mode (no bearer AND no X-API-Key configured), where the
+    whole surface is already unauthenticated. When any token gates the surface,
+    ``/metrics`` is gated too — unless ``PROTOAGENT_PUBLIC_METRICS=1`` keeps it
+    open for an anonymous Prometheus scraper fenced by a network boundary.
+    """
+    if os.environ.get("PROTOAGENT_PUBLIC_METRICS", "").strip().lower() in ("1", "true", "yes"):
+        return True
+    return _BEARER[0] is None and not _API_KEY[0]
+
+
 def _is_public(path: str) -> bool:
     """Return True when ``path`` is on the public allowlist (no auth needed)."""
-    return (any(path.startswith(p) for p in _PUBLIC_PREFIXES)
-            or any(path.startswith(p) for p in _PLUGIN_PUBLIC))
+    if any(path.startswith(p) for p in _PUBLIC_PREFIXES):
+        return True
+    if any(path.startswith(p) for p in _PLUGIN_PUBLIC):
+        return True
+    if path.startswith("/metrics") and _metrics_public():
+        return True
+    return False
 
 
 def set_bearer_token(token: str | None) -> None:

--- a/docs/dev/launch-hardening-tasklist.md
+++ b/docs/dev/launch-hardening-tasklist.md
@@ -1,0 +1,166 @@
+# Launch-hardening tasklist
+
+Pre-launch security/correctness hardening, derived from the antagonistic multi-agent
+review of 2026-06-28 (13 finder dimensions → every finding double-verified by an
+independent reachability skeptic + impact skeptic; 30 findings survived, 0 refuted,
+several severity-recalibrated downward by the verifiers).
+
+Organized by **churn risk** (regression blast-radius of the *fix*) × **LOE** (effort to
+land it well), not by raw severity — so it doubles as an execution order. Severity is
+kept as a tag.
+
+**Scales** — LOE: `XS` 1–3 lines · `S` one function/<1h · `M` multi-file+tests/hours ·
+`L` design + broad regression/day+. Churn: `Low` isolated/additive · `Med` shared
+helper or trafficked path · `High` auth semantics, behavior-changing *default*, or
+hot streaming/concurrency path.
+
+**Default-posture context** (why most criticals land at high, not critical): binds
+`127.0.0.1` by default; boot-gate refuses a non-loopback bind without a token
+(`auth.evaluate_open_bind`); `/a2a` and `/v1` are default-deny. Most high-severity
+items require *installing a malicious plugin*, *a shared A2A/API token*, or *deliberate
+network exposure*.
+
+Status legend: `[ ]` todo · `[~]` in progress · `[x]` done · `[>]` deferred (post-launch).
+
+---
+
+## Batch 1 — Low churn × Low LOE → ship now (one PR off `main`)
+
+Additive guards / one-liners; near-zero regression risk, high security ROI.
+
+- [ ] **Ingestion SSRF guard** — `High` · churn Low · LOE S — `ingestion/engine.py:334-398`.
+  Route `extract_url`/`_http_fetch` through the existing `security.egress.check_url`
+  (as `fetch_url` already does), set `follow_redirects=False` and re-check every hop.
+  Closes internal/metadata-fetch-into-KB. *(Two finders flagged this; asymmetric with
+  the already-guarded `fetch_url` tool.)*
+- [ ] **`KnowledgeStore` missing `busy_timeout`** — Med · Low · XS — `knowledge/store.py:273`.
+  `PRAGMA busy_timeout=5000` in `_connect` (concurrent writes silently lost today;
+  error swallowed at `400-402`).
+- [ ] **Scheduler raw `database is locked`** — Low · Low · XS — `scheduler/local.py:245`.
+  Same PRAGMA in `LocalScheduler._connect`.
+- [ ] **Non-constant-time credential compare** — Low · Low · XS — `a2a_impl/auth.py:218`,
+  `operator_api/console_handlers.py:389`. Use `hmac.compare_digest` for X-API-Key and
+  the inbox token (bearer already does).
+- [ ] **`requestForm` double-body-read masks 401** — Med · Low · XS–S —
+  `apps/web/src/lib/api.ts:345`. Read body once (`text()` then best-effort
+  `JSON.parse`); restores the real error + the 401 AuthGate on uploads.
+- [ ] **Boot TTL sweep deletes HITL tasks** — Low · Low · XS–S —
+  `a2a_impl/stores.py:291`. Exclude `INPUT_REQUIRED`/`AUTH_REQUIRED` from
+  `sweep_expired_tasks` (mirror reconcile's preserved states).
+- [ ] **`requires_pip` arg injection** — Med · Low · S — `graph/plugins/installer.py:630`.
+  Validate each entry as a plain PEP 508 requirement: reject leading `-`
+  (`--index-url`/`-e`), reject VCS/URL/`@`/`file:` refs, pass `--` before specs.
+- [ ] **Subagent return-value mis-parse** — Low · Med · S — `graph/agent.py:278`.
+  Select the last `AIMessage` (not "any message with content"); drop the
+  `startswith("Error")` heuristic — use the `SubagentError` path for failures.
+- [ ] **Palette deep-link dead-ends on workspace console** — Low · Low · S —
+  `apps/web/src/app/usePaletteRegistry.ts:142`. Gate `box:fleet`/`box:telemetry`
+  registrations behind `isHostConsole()`. *(Surfaced on the settings-IA branch.)*
+- [ ] **SSE token in URL** — Low · Low · XS — `apps/web/src/lib/events.ts:70`. Scrub
+  `token` from server access logs (cookie-bound SSE token is a bigger change; defer).
+  Already mitigated by 30s HMAC TTL + `/api/events`-only scope.
+
+## Batch 2 — Med churn × Low–Med LOE → contained, needs regression tests (one PR each)
+
+- [ ] **Plugin `public_paths` prefix-match auth bypass** — `High` · churn Med · LOE S–M —
+  `graph/plugins/manifest.py:141-146` + `a2a_impl/auth.py:88-100`. Boundary-less
+  `startswith` lets a plugin with `id: install` + `public_paths:["/api/plugins/install"]`
+  strip the bearer gate off the core install (RCE) route. Fix: require a trailing-slash
+  boundary (`/api/plugins/{id}/`), validate `plugin_id` against `^[a-z0-9][a-z0-9_-]*$`,
+  reserved-name denylist (`install`,`installed`,`sync`,`updates`,`catalog`,`enabled`).
+  Test that legit plugin public pages still pass.
+- [ ] **Secret-redaction fail-open trio** — Med×2/Low · Med · S–M — `graph/config_io.py`.
+  Root cause: discovery-empty is indistinguishable from discovery-failure. Fix all three:
+  (a) `GET /api/config` echoes plugin secrets when schema discovery returns empty
+  (`423-438`) → redact the whole section when no schema; (b) dead `secret_paths()` `#877`
+  fallback cache (`139-153`) → make discovery signal failure distinctly; (c) MCP inline
+  env/header secrets returned + stored unredacted (`386-391`) → route to `secrets.yaml`
+  / mask.
+- [ ] **Plugin install/update/sync block the event loop** — `High` · Med · S–M —
+  `operator_api/plugin_routes.py:192,324,337,382` → `graph/plugins/installer.py`.
+  `await asyncio.to_thread(installer.…)` in the handlers + bounded subprocess timeouts
+  on clone/ls-remote. Self-DoS: one install freezes all chat/A2A/scheduler.
+- [ ] **`data` goal-verifier `eval()` escapable sandbox** — Low (adj) · Low–Med · S —
+  `graph/goals/verifiers.py:178-184`. Replace `eval()` with the AST-whitelist approach
+  from `tools/lg_tools.py:_safe_eval` (reject `Attribute`/`Call`/comprehensions); fix the
+  misleading "blocks exec/eval" comment. *(Low on its own — the sibling `command`
+  verifier already gives RCE on the same surface — but see Batch 3 trust-gate.)*
+
+## Batch 3 — High churn × Med LOE → behavior-changing defaults / cross-surface signature
+
+- [x] **Gate `/metrics` behind auth** — Low · Med (*ops*) · XS — `a2a_impl/auth.py:51`.
+  Public only in open mode (no bearer & no api-key) or via `PROTOAGENT_PUBLIC_METRICS=1`
+  opt-out. **Breaks anonymous Prometheus scrapers on token-gated deploys** — they must
+  send `Authorization: Bearer` or set the opt-out. *(Authorized for launch; shipped on
+  this branch.)*
+- [x] **Strip secrets from stdio MCP subprocess env** — `High` · High · M —
+  `tools/mcp_tools.py:108-118`. Default (`inherit_env` unset) → secret-filtered
+  passthrough (strip `*_TOKEN`/`*_SECRET`/`*API_KEY`/`*PASSWORD`/`*_KEY`/…); `inherit_env:
+  true` = explicit full passthrough escape hatch; `inherit_env: false` = minimal.
+  **Breaks servers that relied on an implicitly-inherited secret env var** — they set
+  `inherit_env: true` or a per-server `env:`. *(Authorized for launch; shipped on this
+  branch.)*
+- [ ] **"Operator-only" goal trust gate** — `High` · High · M — `server/chat.py:692,1036`
+  → `graph/goals/controller.py:98`. Thread `trusted: bool` from the calling surface into
+  `parse_control`; refuse `command`/`test`/`ci`/`data` verifiers on the A2A and `/v1`
+  paths (route through `set_goal_safe`'s allowlist). Today a shared-token A2A peer gets
+  `bash -c` on the host. Pairs with the Batch 2 `eval` fix.
+- [ ] **ACP runtime eviction race** — Med · Med–High · M — `server/chat.py:102-141`,
+  `runtime/acp_runtime.py:216`. LRU/idle eviction closes an in-flight runtime mid-turn;
+  registry dicts mutated lock-free. Add a per-thread busy flag/refcount (never evict
+  busy) + `asyncio.Lock`; `pop(tid, None)` to tolerate concurrent eviction. ACP opt-in
+  bounds blast radius.
+
+## Batch 4 — High churn × Med–High LOE → design-first, isolate (own initiative)
+
+The chat-finalization + concurrency cluster sits on the hottest paths; the codebase has
+been burned here before (the `#1328` native-reasoning rewrite, the CSS-minifier trap).
+**Coordinate with inflight DRAFT PR #1394 (`fix/subagent-stream-isolation`)** — it
+touches the same chat/subagent streaming surface.
+
+- [>] **`extract_output` truncates on literal `<think>`/`<scratch_pad>`** — Med · High · M
+  — `graph/output_format.py:104-137,421`. Strategy-3 balanced-only stripping + a
+  `(?<!\`)` backtick guard; must preserve leaked-reasoning stripping (LiteLLM #22392).
+- [>] **Dropped empty-turn → silent empty answer (streaming)** — Med · High · M —
+  `server/chat.py:919-997`. Detect empty-text-and-no-tool-call; give the streaming path
+  the non-streaming path's empty-answer fallback.
+- [>] **A2A artifact append-vs-replace divergence** — Med · High · M —
+  `a2a_impl/executor.py:308-345`. On the terminal frame, replace the answer artifact
+  (`append=False`) when `final_text` differs from what streamed — the docstring already
+  claims this; the impl appends.
+- [>] **Concurrent A2A turns corrupt history** — Med · High · M —
+  `a2a_impl/executor.py:366-373`, `server/chat.py:862`. Serialize per `context_id`
+  (`asyncio.Lock`/queue) before `astream_events`, mirroring the console steering queue.
+- [>] **chat-store cross-tab clobber** — Med · Med–High · M —
+  `apps/web/src/chat/chat-store.ts:141`. `storage`-event merge (union by id, newest
+  `updatedAt` wins) or a `BroadcastChannel` single-writer.
+- [>] **`localStorage` bearer (XSS-exfiltratable)** — Low · High · L —
+  `apps/web/src/lib/auth.ts:42`. Move to an httpOnly SameSite cookie, or accept-risk +
+  guarantee no raw-HTML/JS render sink (none found today — DS markdown only). Interim:
+  document as a known sink.
+
+## Doc-only / optional
+
+- [ ] **Plugin iframe `allow-scripts`+`allow-same-origin`** — Low · Low · XS —
+  `apps/web/src/app/PluginView.tsx:266` (+ `App.tsx:529`, `Launcher.tsx:67`). No
+  functional change (plugins are trusted code, given the bearer by design); document the
+  trusted-code contract + standardize the sandbox string in one helper so the three call
+  sites can't drift.
+- [ ] **`MiddlewarePanel` removal lost a runtime diagnostic** — Info — settings-IA branch.
+  Fold a read-only wired-middleware status strip into the Behavior/Overview panel from
+  `runtime.middleware`, or note the intentional removal in ADR 0048.
+
+---
+
+## Sequencing notes
+
+- **Effort ≠ risk.** `/metrics` and the MCP-env fix are tiny diffs but high churn — they
+  break *working external setups*, so they need coordination + a migration note, not just
+  a commit. The ingestion SSRF (High severity) is Batch-1-easy.
+- **Three clusters share a root** — keep each as one PR: the secret-redaction trio
+  (discovery-empty ≠ failure), the plugin-blocking-loop pair (`install` + `updates`), and
+  the chat-finalization quintet.
+- **Batch 1 + ingestion SSRF** is the "merge today" set: ~10 additive fixes closing one
+  High + several Meds at near-zero regression risk.
+- All work lands via the `feat/launch-hardening*` worktree off `main` — never the inflight
+  `feat/settings-ia-domain-first` (PR #1393) tree.

--- a/docs/dev/launch-hardening-tasklist.md
+++ b/docs/dev/launch-hardening-tasklist.md
@@ -95,8 +95,8 @@ Additive guards / one-liners; near-zero regression risk, high security ROI.
   this branch.)*
 - [x] **Strip secrets from stdio MCP subprocess env** — `High` · High · M —
   `tools/mcp_tools.py:108-118`. Default (`inherit_env` unset) → secret-filtered
-  passthrough (strip `*_TOKEN`/`*_SECRET`/`*API_KEY`/`*PASSWORD`/`*_KEY` + SSH/Kerberos/GPG
-  agent sockets); `inherit_env:
+  passthrough (strip `*_TOKEN`/`*_SECRET`/`*API_KEY`/`*PASSWORD`/`*_KEY` + DSN/DB
+  connection-strings + SSH/Kerberos/GPG agent sockets; base-URLs kept); `inherit_env:
   true` = explicit full passthrough escape hatch; `inherit_env: false` = minimal.
   **Breaks servers that relied on an implicitly-inherited secret env var** — they set
   `inherit_env: true` or a per-server `env:`. *(Authorized for launch; shipped on this

--- a/docs/dev/launch-hardening-tasklist.md
+++ b/docs/dev/launch-hardening-tasklist.md
@@ -95,7 +95,8 @@ Additive guards / one-liners; near-zero regression risk, high security ROI.
   this branch.)*
 - [x] **Strip secrets from stdio MCP subprocess env** — `High` · High · M —
   `tools/mcp_tools.py:108-118`. Default (`inherit_env` unset) → secret-filtered
-  passthrough (strip `*_TOKEN`/`*_SECRET`/`*API_KEY`/`*PASSWORD`/`*_KEY`/…); `inherit_env:
+  passthrough (strip `*_TOKEN`/`*_SECRET`/`*API_KEY`/`*PASSWORD`/`*_KEY` + SSH/Kerberos/GPG
+  agent sockets); `inherit_env:
   true` = explicit full passthrough escape hatch; `inherit_env: false` = minimal.
   **Breaks servers that relied on an implicitly-inherited secret env var** — they set
   `inherit_env: true` or a per-server `env:`. *(Authorized for launch; shipped on this

--- a/tests/test_a2a_auth.py
+++ b/tests/test_a2a_auth.py
@@ -155,11 +155,38 @@ def test_ac2_healthz_public(monkeypatch):
     assert _client_multi().get("/healthz").status_code == 200
 
 
-# AC3: /metrics is public
-def test_ac3_metrics_public(monkeypatch):
+# AC3: /metrics is gated when a token is configured, public only in open mode,
+# and can be re-opened for an anonymous scraper via PROTOAGENT_PUBLIC_METRICS=1.
+def test_ac3_metrics_gated_when_token_set(monkeypatch):
     monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("PROTOAGENT_PUBLIC_METRICS", raising=False)
+    auth.configure(bearer_token="secret", api_key="", allowed_origins_raw="")
+    c = _client_multi()
+    assert c.get("/metrics").status_code == 401
+    assert c.get("/metrics", headers={"Authorization": "Bearer secret"}).status_code == 200
+
+
+def test_metrics_public_in_open_mode(monkeypatch):
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("PROTOAGENT_PUBLIC_METRICS", raising=False)
+    auth.configure(bearer_token=None, api_key="", allowed_origins_raw="")
+    assert _client_multi().get("/metrics").status_code == 200
+
+
+def test_metrics_public_optin_env(monkeypatch):
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    monkeypatch.setenv("PROTOAGENT_PUBLIC_METRICS", "1")
     auth.configure(bearer_token="secret", api_key="", allowed_origins_raw="")
     assert _client_multi().get("/metrics").status_code == 200
+
+
+def test_metrics_gated_when_only_api_key_set(monkeypatch):
+    monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
+    monkeypatch.delenv("PROTOAGENT_PUBLIC_METRICS", raising=False)
+    auth.configure(bearer_token=None, api_key="k", allowed_origins_raw="")
+    c = _client_multi()
+    assert c.get("/metrics").status_code == 401
+    assert c.get("/metrics", headers={"x-api-key": "k"}).status_code == 200
 
 
 # AC4: /.well-known/agent-card.json is public
@@ -395,9 +422,9 @@ def test_public_paths_stay_public_when_token_set(monkeypatch):
     monkeypatch.delenv("A2A_AUTH_TOKEN", raising=False)
     auth.configure(bearer_token="secret", api_key="", allowed_origins_raw="")
     c = _client_multi()
-    # Public allowlist paths are always accessible.
+    # Public allowlist paths are always accessible (/metrics is conditional now —
+    # covered by the metrics-policy tests above — so it is intentionally omitted).
     assert c.get("/healthz").status_code == 200
-    assert c.get("/metrics").status_code == 200
     assert c.get("/.well-known/agent-card.json").status_code == 200
     assert c.get("/app").status_code == 200
     assert c.get("/manifest.json").status_code == 200
@@ -448,7 +475,6 @@ def test_open_bind_optin_allowed_with_warning():
     "path,expected",
     [
         ("/healthz", True),
-        ("/metrics", True),
         ("/.well-known/agent-card.json", True),
         ("/.well-known/other", True),
         ("/app", True),

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -55,13 +55,15 @@ def test_stdio_default_strips_secret_named_vars(monkeypatch) -> None:
     monkeypatch.setenv("FOO_TOKEN", "t")
     monkeypatch.setenv("FOO_SECRET", "s")
     monkeypatch.setenv("FOO_PASSWORD", "p")
-    monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/sock")  # not a credential name → kept
+    monkeypatch.setenv("SSH_AUTH_SOCK", "/run/ssh-agent.sock")  # capability handle → stripped
+    monkeypatch.setenv("MCP_TEST_PLAIN", "ok")                  # ordinary var → kept
     conn = _server_connection({"name": "fs", "transport": "stdio", "command": "npx"})
     env = conn["env"]
     assert "FOO_TOKEN" not in env
     assert "FOO_SECRET" not in env
     assert "FOO_PASSWORD" not in env
-    assert env.get("SSH_AUTH_SOCK") == "/tmp/sock"
+    assert "SSH_AUTH_SOCK" not in env
+    assert env.get("MCP_TEST_PLAIN") == "ok"
 
 
 def test_http_connection_mapping_and_alias() -> None:

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -56,13 +56,15 @@ def test_stdio_default_strips_secret_named_vars(monkeypatch) -> None:
     monkeypatch.setenv("FOO_SECRET", "s")
     monkeypatch.setenv("FOO_PASSWORD", "p")
     monkeypatch.setenv("SSH_AUTH_SOCK", "/run/ssh-agent.sock")  # capability handle → stripped
+    monkeypatch.setenv("DATABASE_URL", "postgres://u:pw@h/db")  # DSN w/ creds → stripped
+    monkeypatch.setenv("SENTRY_DSN", "https://k@sentry/1")      # DSN → stripped
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://gw/v1")      # base URL, not a secret → kept
     monkeypatch.setenv("MCP_TEST_PLAIN", "ok")                  # ordinary var → kept
     conn = _server_connection({"name": "fs", "transport": "stdio", "command": "npx"})
     env = conn["env"]
-    assert "FOO_TOKEN" not in env
-    assert "FOO_SECRET" not in env
-    assert "FOO_PASSWORD" not in env
-    assert "SSH_AUTH_SOCK" not in env
+    for stripped in ("FOO_TOKEN", "FOO_SECRET", "FOO_PASSWORD", "SSH_AUTH_SOCK", "DATABASE_URL", "SENTRY_DSN"):
+        assert stripped not in env, f"{stripped} should be stripped"
+    assert env.get("OPENAI_BASE_URL") == "https://gw/v1"  # base URLs are deliberately kept
     assert env.get("MCP_TEST_PLAIN") == "ok"
 
 

--- a/tests/test_mcp_tools.py
+++ b/tests/test_mcp_tools.py
@@ -9,7 +9,6 @@ The real stdio round-trip is covered by the end-to-end check in the PR.
 from __future__ import annotations
 
 import asyncio
-import os
 from types import SimpleNamespace
 
 from graph.config import LangGraphConfig
@@ -19,16 +18,20 @@ from tools.mcp_tools import _run_blocking, _server_connection, build_mcp_tools
 # ── connection mapping ───────────────────────────────────────────────────────
 
 
-def test_stdio_connection_mapping() -> None:
+def test_stdio_connection_mapping(monkeypatch) -> None:
+    monkeypatch.setenv("MCP_TEST_PLAINVAR", "keep")
+    monkeypatch.setenv("MCP_TEST_API_KEY", "secret")
     conn = _server_connection(
         {"name": "fs", "transport": "stdio", "command": "npx", "args": ["-y", "x"], "env": {"A": "1"}}
     )
-    # stdio servers inherit the parent env by default, with the per-server
-    # override layered on top.
+    # stdio servers inherit the parent env by default, but credential-looking vars
+    # are stripped and the per-server override is layered on top.
     assert conn["transport"] == "stdio"
     assert conn["command"] == "npx"
     assert conn["args"] == ["-y", "x"]
-    assert conn["env"] == {**os.environ, "A": "1"}
+    assert conn["env"]["A"] == "1"                     # per-server override wins
+    assert conn["env"]["MCP_TEST_PLAINVAR"] == "keep"  # ordinary var inherited
+    assert "MCP_TEST_API_KEY" not in conn["env"]       # secret-named var stripped
 
 
 def test_stdio_connection_inherit_env_false() -> None:
@@ -37,6 +40,28 @@ def test_stdio_connection_inherit_env_false() -> None:
         {"name": "fs", "transport": "stdio", "command": "npx", "inherit_env": False, "env": {"A": "1"}}
     )
     assert conn["env"] == {"A": "1"}
+
+
+def test_stdio_inherit_env_true_passes_full(monkeypatch) -> None:
+    # inherit_env: true → the FULL parent env, secrets included (escape hatch).
+    monkeypatch.setenv("MCP_TEST_API_KEY", "secret")
+    conn = _server_connection(
+        {"name": "fs", "transport": "stdio", "command": "npx", "inherit_env": True}
+    )
+    assert conn["env"]["MCP_TEST_API_KEY"] == "secret"
+
+
+def test_stdio_default_strips_secret_named_vars(monkeypatch) -> None:
+    monkeypatch.setenv("FOO_TOKEN", "t")
+    monkeypatch.setenv("FOO_SECRET", "s")
+    monkeypatch.setenv("FOO_PASSWORD", "p")
+    monkeypatch.setenv("SSH_AUTH_SOCK", "/tmp/sock")  # not a credential name → kept
+    conn = _server_connection({"name": "fs", "transport": "stdio", "command": "npx"})
+    env = conn["env"]
+    assert "FOO_TOKEN" not in env
+    assert "FOO_SECRET" not in env
+    assert "FOO_PASSWORD" not in env
+    assert env.get("SSH_AUTH_SOCK") == "/tmp/sock"
 
 
 def test_http_connection_mapping_and_alias() -> None:

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -78,9 +78,13 @@ def _mcp_tool_error_handler(exc: Exception) -> str:
 # Env-var NAMES that look like a credential — stripped from a stdio MCP server's
 # inherited environment by default. A third-party server (npx/uvx) gets the
 # operational env it needs (PATH/HOME/LANG/proxy/...) but NOT the agent's secrets
-# (LLM gateway key, GITHUB_TOKEN, A2A_AUTH_TOKEN, *_API_KEY, ...).
+# (LLM gateway key, GITHUB_TOKEN, A2A_AUTH_TOKEN, *_API_KEY, ...) nor
+# capability-bearing agent handles (SSH_AUTH_SOCK / KRB5CCNAME / GPG_AGENT_INFO),
+# which would let an untrusted server impersonate the user via the SSH / Kerberos
+# / GPG agent. A server that genuinely needs one opts in with ``inherit_env: true``.
 _SECRET_ENV_RE = re.compile(
-    r"(SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIAL|_KEY$)",
+    r"(SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|"
+    r"CREDENTIAL|_KEY$|^SSH_AUTH_SOCK$|^KRB5CCNAME$|^GPG_AGENT_INFO$)",
     re.IGNORECASE,
 )
 

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -77,14 +77,22 @@ def _mcp_tool_error_handler(exc: Exception) -> str:
 
 # Env-var NAMES that look like a credential — stripped from a stdio MCP server's
 # inherited environment by default. A third-party server (npx/uvx) gets the
-# operational env it needs (PATH/HOME/LANG/proxy/...) but NOT the agent's secrets
-# (LLM gateway key, GITHUB_TOKEN, A2A_AUTH_TOKEN, *_API_KEY, ...) nor
-# capability-bearing agent handles (SSH_AUTH_SOCK / KRB5CCNAME / GPG_AGENT_INFO),
-# which would let an untrusted server impersonate the user via the SSH / Kerberos
-# / GPG agent. A server that genuinely needs one opts in with ``inherit_env: true``.
+# operational env it needs (PATH/HOME/LANG/proxy/base-URLs/...) but NOT the agent's
+# secrets. We strip: generic *_SECRET/*_TOKEN/*_PASSWORD/*_KEY and API/access/
+# private keys; connection strings / DSNs that embed ``user:password@host``
+# (DATABASE_URL, REDIS_URL, SENTRY_DSN, ...); and capability-bearing agent handles
+# (SSH_AUTH_SOCK / KRB5CCNAME / GPG_AGENT_INFO) that would let an untrusted server
+# impersonate the user via the SSH / Kerberos / GPG agent. We deliberately KEEP
+# plain ``*_BASE_URL``/``*_URL`` that don't carry creds, so a base-URL-only server
+# still works. A server that genuinely needs a stripped var opts in with
+# ``inherit_env: true`` or a per-server ``env:`` block.
 _SECRET_ENV_RE = re.compile(
-    r"(SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|"
-    r"CREDENTIAL|_KEY$|^SSH_AUTH_SOCK$|^KRB5CCNAME$|^GPG_AGENT_INFO$)",
+    r"(SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIAL|_KEY$"
+    r"|_DSN$"
+    r"|^(?:DATABASE|POSTGRES(?:QL)?|MYSQL|MARIADB|REDIS|MONGO(?:DB)?|RABBITMQ|AMQP|"
+    r"CLICKHOUSE|ELASTIC(?:SEARCH)?|OPENSEARCH)[_-]?(?:URL|URI)$"
+    r"|^SQLALCHEMY_DATABASE_URI$"
+    r"|^SSH_AUTH_SOCK$|^KRB5CCNAME$|^GPG_AGENT_INFO$)",
     re.IGNORECASE,
 )
 

--- a/tools/mcp_tools.py
+++ b/tools/mcp_tools.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import logging
 import os
+import re
 from typing import Any
 
 log = logging.getLogger("protoagent.mcp")
@@ -74,6 +75,39 @@ def _mcp_tool_error_handler(exc: Exception) -> str:
     )
 
 
+# Env-var NAMES that look like a credential — stripped from a stdio MCP server's
+# inherited environment by default. A third-party server (npx/uvx) gets the
+# operational env it needs (PATH/HOME/LANG/proxy/...) but NOT the agent's secrets
+# (LLM gateway key, GITHUB_TOKEN, A2A_AUTH_TOKEN, *_API_KEY, ...).
+_SECRET_ENV_RE = re.compile(
+    r"(SECRET|TOKEN|PASSWORD|PASSWD|API[_-]?KEY|ACCESS[_-]?KEY|PRIVATE[_-]?KEY|CREDENTIAL|_KEY$)",
+    re.IGNORECASE,
+)
+
+
+def _inherited_env(server_env: dict[str, str], *, inherit) -> dict[str, str] | None:
+    """Build the env for a stdio MCP subprocess.
+
+    ``inherit`` is the server's ``inherit_env`` value (``None`` = unset):
+
+      - unset (default) → parent env with credential-looking NAMES stripped, then
+        the per-server ``env:`` overlaid — a server still gets PATH/HOME/etc. but
+        not the agent's secrets;
+      - ``True`` → the FULL parent env (explicit opt-in escape hatch, e.g. a
+        trusted server that needs a secret injected via the environment);
+      - ``False`` → only the explicit per-server ``env:`` (minimal), or ``None``
+        so the SDK applies its own minimal default.
+
+    A per-server ``env:`` value always wins over an inherited one.
+    """
+    if inherit is False:
+        return dict(server_env) if server_env else None
+    if inherit is True:
+        return {**os.environ, **server_env}
+    base = {k: v for k, v in os.environ.items() if not _SECRET_ENV_RE.search(k)}
+    return {**base, **server_env}
+
+
 def _server_connection(server: dict) -> dict | None:
     """Map a config ``mcp.servers[]`` entry to a langchain-mcp-adapters
     connection dict. Returns ``None`` for an entry missing its essential fields
@@ -105,17 +139,16 @@ def _server_connection(server: dict) -> dict | None:
     if not command:
         return None
     conn = {"transport": "stdio", "command": str(command), "args": list(server.get("args") or [])}
-    # Pass the parent environment through to the stdio subprocess by default.
-    # The MCP SDK's stdio client uses a MINIMAL default env, so custom vars set
-    # on the agent process (API keys, base URLs) are stripped from the server —
-    # a common failure in containerized deploys where those are injected into
-    # the agent's env, not the config YAML. Set ``inherit_env: false`` on the
-    # server to opt out; a per-server ``env:`` block always overrides on top.
+    # Build the subprocess env (secret-filtered parent env by default). The MCP
+    # SDK's stdio client otherwise uses a MINIMAL env, dropping vars a server may
+    # need; we inherit the operational env but strip credential-looking NAMES so a
+    # third-party server can't read the agent's secrets. ``inherit_env: true``
+    # passes the FULL env (escape hatch); ``false`` passes only the per-server
+    # ``env:``. See ``_inherited_env``.
     server_env = {str(k): str(v) for k, v in (server.get("env") or {}).items()}
-    if server.get("inherit_env", True):
-        conn["env"] = {**os.environ, **server_env}
-    elif server_env:
-        conn["env"] = server_env
+    env = _inherited_env(server_env, inherit=server.get("inherit_env"))
+    if env is not None:
+        conn["env"] = env
     if server.get("cwd"):
         conn["cwd"] = str(server["cwd"])
     return conn


### PR DESCRIPTION
First execution of the **launch-hardening plan** (`docs/dev/launch-hardening-tasklist.md`, added here) derived from the 2026-06-28 antagonistic multi-agent review (30 findings, each double-verified by an independent reachability + impact skeptic). This PR lands the two **breaking-default** security fixes that are cheapest to do pre-launch — Batch 3 items where the small diff changes behavior external setups may depend on.

## 1. Gate `/metrics` behind auth unless in open mode
`a2a_impl/auth.py` — `/metrics` was unconditionally public (model/tool inventory, cost, traffic profiling to any unauthenticated network caller, even on a token-gated, network-exposed deploy).

- **New behavior:** public only in *open mode* (no bearer **and** no X-API-Key configured), or when `PROTOAGENT_PUBLIC_METRICS=1` is set.
- **⚠️ Breaking (token-gated deploys only):** a Prometheus scraper must now send `Authorization: Bearer <token>`, or set `PROTOAGENT_PUBLIC_METRICS=1` to keep anonymous scraping behind a network boundary. Local/default (tokenless) deploys are unaffected.

## 2. Strip credential env vars from stdio MCP subprocesses by default
`tools/mcp_tools.py` — a stdio MCP server (the normal `npx`/`uvx` supply-chain surface) inherited the **full** agent env, silently handing every secret (LLM gateway key, `GITHUB_TOKEN`, `A2A_AUTH_TOKEN`, `*_API_KEY`) to third-party code.

- **New default:** inherit the operational env (`PATH`/`HOME`/`LANG`/proxy/…) but strip credential-looking variable **names**.
- **Escape hatches (unchanged config keys):** `inherit_env: true` → full passthrough (for a trusted server that needs a secret injected via env); `inherit_env: false` → minimal; a per-server `env:` block always overrides explicitly.
- **⚠️ Breaking:** a server relying on an *implicitly-inherited* secret env var must now set `inherit_env: true` or pass it via a per-server `env:` block.

## Gates (run in an isolated worktree off `main`)
- `ruff check .` (0.15.10, CI pin) — **pass**
- `lint-imports` — **3 kept / 0 broken**
- `python -m pytest tests/ -q` — **2557 passed**, incl. new metrics-policy + MCP-env coverage. No frontend changes (npm gates N/A).

## Notes
- The remaining 28 findings are tracked in the tasklist doc across Batches 1–4. Batch 1 (additive, low-regression — incl. the ingestion SSRF guard) is the natural next PR.
- Breaking-default changes → flagged for an explicit merge decision rather than auto-merge.

Provenance: antagonistic review, 2026-06-28 (auth-authz + supply-chain dimensions).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Metrics endpoint availability is now conditionally public, requiring explicit enablement instead of being always open.

* **Security Improvements**
  * Reduced risk of leaking credential-like environment variables to stdio background processes by default.
  * Added optional behavior to allow full environment inheritance for those processes when explicitly configured.

* **Documentation**
  * Added a launch hardening checklist to guide ordered reliability and security work.

* **Tests**
  * Updated authorization and stdio environment handling tests to reflect the new conditional behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->