### PR TITLE
feat(background): task_batch(run_in_background=True) + background concurrency cap

### DIFF
--- a/background/manager.py
+++ b/background/manager.py
@@ -26,6 +26,7 @@ from background.store import BackgroundStore
 log = logging.getLogger(__name__)
 
 _DEFAULT_FIRE_TIMEOUT_S = 1800.0  # background turns can run long (research + tools); generous
+_DEFAULT_MAX_CONCURRENCY = 3  # cap on concurrent background turns so a fan-out can't swamp the gateway
 
 
 class BackgroundManager:
@@ -40,6 +41,7 @@ class BackgroundManager:
         api_key: str | None = None,
         bearer_token: str | None = None,
         fire_timeout_s: float | None = None,
+        max_concurrency: int | None = None,
         event_publish=None,
     ) -> None:
         self.agent_name = agent_name
@@ -58,6 +60,21 @@ class BackgroundManager:
                 self._fire_timeout_s = float(os.environ.get("BACKGROUND_FIRE_TIMEOUT_S", _DEFAULT_FIRE_TIMEOUT_S))
             except ValueError:
                 self._fire_timeout_s = _DEFAULT_FIRE_TIMEOUT_S
+        # Bound how many background turns run at once. A wide fan-out — ``task_batch`` with
+        # run_in_background, or several ``task(run_in_background=True)`` calls — would
+        # otherwise open one full lead-graph turn per job against the gateway at the same
+        # time. The cap gates the actual self-POST in ``_fire`` (which holds its slot for the
+        # whole turn); jobs past the cap queue at the semaphore. A queued job's store row
+        # still reads ``running`` (it IS accepted) — cancel/reconcile both handle a row whose
+        # turn hasn't fired yet. Override with ``BACKGROUND_MAX_CONCURRENCY``.
+        if max_concurrency is not None:
+            self._max_concurrency = max(1, int(max_concurrency))
+        else:
+            try:
+                self._max_concurrency = max(1, int(os.environ.get("BACKGROUND_MAX_CONCURRENCY", _DEFAULT_MAX_CONCURRENCY)))
+            except ValueError:
+                self._max_concurrency = _DEFAULT_MAX_CONCURRENCY
+        self._sem = asyncio.Semaphore(self._max_concurrency)
         # Hold the detached fire tasks so they aren't GC'd mid-flight (the cause of
         # "Task was destroyed but it is pending"); discard on completion.
         self._fire_tasks: set[asyncio.Task] = set()
@@ -191,20 +208,25 @@ class BackgroundManager:
                 },
             },
         }
-        try:
-            async with httpx.AsyncClient(timeout=self._fire_timeout_s) as client:
-                r = await client.post(f"{self._invoke_url}/a2a", headers=headers, json=body)
-            if r.status_code >= 400:
-                log.error(
-                    "[background] fire failed for %s: HTTP %d %s",
-                    job_id,
-                    r.status_code,
-                    r.text[:200],
-                )
-                self.store.mark_complete(job_id, "failed", f"Background turn failed to start: HTTP {r.status_code}.")
-        except Exception as exc:  # noqa: BLE001
-            log.exception("[background] fire exception for %s", job_id)
-            self.store.mark_complete(job_id, "failed", f"Background turn delivery error: {exc}")
+        # Gate the actual self-POST on the concurrency semaphore so a fan-out can't open more
+        # than ``_max_concurrency`` full turns at once. The slot is held for the WHOLE turn —
+        # the A2A handler runs the turn synchronously before the POST returns — which is
+        # exactly the bound we want (concurrent running turns, not just in-flight requests).
+        async with self._sem:
+            try:
+                async with httpx.AsyncClient(timeout=self._fire_timeout_s) as client:
+                    r = await client.post(f"{self._invoke_url}/a2a", headers=headers, json=body)
+                if r.status_code >= 400:
+                    log.error(
+                        "[background] fire failed for %s: HTTP %d %s",
+                        job_id,
+                        r.status_code,
+                        r.text[:200],
+                    )
+                    self.store.mark_complete(job_id, "failed", f"Background turn failed to start: HTTP {r.status_code}.")
+            except Exception as exc:  # noqa: BLE001
+                log.exception("[background] fire exception for %s", job_id)
+                self.store.mark_complete(job_id, "failed", f"Background turn delivery error: {exc}")
 
 
 def _build_fired_prompt(subagent_type: str, description: str, prompt: str) -> str:

--- a/docs/adr/0050-background-subagents-reactive-notifications.md
+++ b/docs/adr/0050-background-subagents-reactive-notifications.md
@@ -177,6 +177,22 @@ the thing to check first when it lands.)
   long synchronous delegation transparently detaches and becomes killable — the direct cure for
   the audited incident.
 
+### Follow-up — background batch + concurrency cap (shipped)
+- **`task_batch(run_in_background=True)`** fans a whole batch out detached: every spec spawns as
+  its own background job and the call returns immediately with the job ids, instead of blocking
+  until all finish (the foreground `task_batch` path). It's the multi-task analog of
+  `task(run_in_background=True)` and goes through the same `BackgroundManager.spawn`; each
+  completion drains back into the spawning session independently — one task-notification per job —
+  reusing Phase 1's exactly-once drain. Bad specs (missing prompt / unknown subagent) are skipped
+  inline; the good ones still spawn. With no manager configured it degrades to the foreground batch.
+- **Concurrency cap (the missing backpressure).** `BackgroundManager` now bounds concurrent
+  background turns with a semaphore that gates the self-POST in `_fire` (held for the whole turn).
+  A fan-out can no longer open one full lead-graph turn per job against the gateway at once; jobs
+  past the cap queue at the semaphore. Default 3, override `BACKGROUND_MAX_CONCURRENCY`. It applies
+  to *every* spawn — so several ad-hoc `task(run_in_background=True)` calls are bounded too. A
+  queued job's row reads `running` until a slot frees (it is accepted); `cancel` and
+  `reconcile_interrupted` both already handle a row whose turn hasn't fired yet.
+
 ## Consequences
 
 - **The chat stays live.** A delegation marked `run_in_background` returns in milliseconds; the
@@ -196,6 +212,10 @@ the thing to check first when it lands.)
   but `BACKGROUND_WAKE=0` disables it for cost-sensitive or non-reactive deployments.
 - **A background turn could itself spawn background turns.** Bounded in practice by focused
   prompts + the prompt contract; a hard depth fence is a later refinement.
+- **Background fan-out is bounded.** A `task_batch(run_in_background=True)` — or many single
+  `task(run_in_background=True)` calls — can't swamp the gateway: at most `BACKGROUND_MAX_CONCURRENCY`
+  turns run at once, the rest queue. Trade-off: a queued job reports `running` before its turn
+  actually starts (a small cosmetic lie the console's running-count inherits).
 - **Long jobs vs. the self-POST timeout.** `_fire` holds the connection open for the whole turn
   (like the scheduler); a job exceeding the fire timeout is marked `failed` even if still
   running. The timeout default is generous and configurable; a true submit-and-detach (A2A

--- a/graph/agent.py
+++ b/graph/agent.py
@@ -572,7 +572,12 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
             delegations.unregister(session_id, tool_call_id)
 
     @tool
-    async def task_batch(tasks: list[dict], tool_call_id: Annotated[str, InjectedToolCallId] = "") -> str:
+    async def task_batch(
+        tasks: list[dict],
+        run_in_background: bool = False,
+        state: Annotated[Any, InjectedState] = None,
+        tool_call_id: Annotated[str, InjectedToolCallId] = "",
+    ) -> str:
         """Delegate several independent tasks to subagents concurrently.
 
         Prefer this over multiple sequential ``task`` calls whenever the
@@ -587,15 +592,62 @@ def _build_task_tools(config: LangGraphConfig, all_tools: list[BaseTool], backgr
                 - ``description`` (str, required): short summary of the task
                 - ``prompt`` (str, required): detailed instructions
                 - ``subagent_type`` (str, optional): defaults to "researcher"
+            run_in_background: Set True to fan the whole batch out DETACHED — every
+                task spawns as its own background agent and this returns IMMEDIATELY
+                with their job ids, instead of blocking until they finish. Use it for a
+                wide fan-out of long / independent / quota-heavy work (research several
+                topics at once) you don't need to wait on; you'll be notified as each
+                finishes. When you set this, do NOT poll, re-check, or re-spawn — just
+                continue. Leave False (the default) when you need the results in this
+                turn. Concurrency is capped either way.
 
         Returns the results concatenated in the same order as ``tasks``, each
         prefixed with its 1-based index. Individual failures are reported
-        inline and do not abort the batch.
+        inline and do not abort the batch. With ``run_in_background`` the return is
+        instead the list of started job ids (results arrive later as notifications).
         """
         if not tasks:
             return "Error: task_batch called with an empty task list."
         if not isinstance(tasks, list):
             return "Error: 'tasks' must be a list of task objects."
+
+        # Background fan-out (ADR 0050): spawn every spec detached and return immediately
+        # with the job ids — the multi-task analog of task(run_in_background=True), through
+        # the same BackgroundManager.spawn. Each completion drains back into this session
+        # independently (one task-notification per job); the manager's concurrency cap bounds
+        # how many run at once. Degrades to the foreground batch below when no manager exists.
+        if run_in_background and background_mgr is not None:
+            session_id = _session_id_from(state)
+            lines: list[str] = []
+            started = 0
+            for i, spec in enumerate(tasks, start=1):
+                if not isinstance(spec, dict):
+                    lines.append(f"Task {i}: skipped — each task must be an object.")
+                    continue
+                desc = spec.get("description") or "(no description)"
+                prm = spec.get("prompt")
+                st = spec.get("subagent_type", "researcher")
+                if not prm:
+                    lines.append(f"Task {i} ({desc}): skipped — missing 'prompt'.")
+                    continue
+                if st not in SUBAGENT_REGISTRY:
+                    lines.append(f"Task {i} ({desc}): skipped — unknown subagent '{st}'.")
+                    continue
+                job_id = await background_mgr.spawn(
+                    origin_session=session_id,
+                    subagent_type=st,
+                    description=desc,
+                    prompt=prm,
+                )
+                started += 1
+                lines.append(f"Task {i}: {job_id} ({st}: {desc})")
+            if not started:
+                return "No background tasks started:\n" + "\n".join(lines)
+            return (
+                f"Started {started} background agent(s), running detached. You will be "
+                "notified automatically as each finishes — do NOT poll, re-check, or "
+                "re-spawn; continue with other work.\n" + "\n".join(lines)
+            )
 
         sem = asyncio.Semaphore(max_concurrency)
 

--- a/tests/test_background.py
+++ b/tests/test_background.py
@@ -283,6 +283,49 @@ class TestManager:
         await _drain_fire_tasks(mgr)
         assert mgr.store.get(jid).status == "failed"
 
+    async def test_fire_respects_concurrency_cap(self, tmp_path, monkeypatch):
+        """A fan-out of background jobs runs at most ``max_concurrency`` turns at once —
+        the semaphore gates the self-POST, which holds its slot for the whole turn. Without
+        the cap all N would POST concurrently and hammer the gateway."""
+        import httpx
+
+        live = {"n": 0, "peak": 0}
+
+        class _SlowClient:
+            def __init__(self, **_kw):
+                pass
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *_a):
+                return False
+
+            async def post(self, url, headers=None, json=None):
+                live["n"] += 1
+                live["peak"] = max(live["peak"], live["n"])
+                await asyncio.sleep(0.03)  # stand in for a whole turn running server-side
+                live["n"] -= 1
+                return _FakeResponse(200)
+
+        monkeypatch.setattr(httpx, "AsyncClient", lambda **kw: _SlowClient(**kw))
+        mgr = _manager(tmp_path, max_concurrency=2)
+        for i in range(6):
+            await mgr.spawn(origin_session="s", subagent_type="researcher", description=f"d{i}", prompt="p")
+        # Drain all six fires (longer budget than the default helper — 6 jobs / cap 2).
+        for _ in range(400):
+            if not mgr._fire_tasks:
+                break
+            await asyncio.sleep(0.01)
+        assert not mgr._fire_tasks, "fires did not all complete"
+        assert 1 <= live["peak"] <= 2, f"peak concurrency {live['peak']} should be capped at 2"
+
+    async def test_default_concurrency_from_env(self, tmp_path, monkeypatch):
+        monkeypatch.setenv("BACKGROUND_MAX_CONCURRENCY", "7")
+        assert _manager(tmp_path)._max_concurrency == 7
+        monkeypatch.setenv("BACKGROUND_MAX_CONCURRENCY", "bogus")
+        assert _manager(tmp_path)._max_concurrency == 3  # default on a bad value
+
 
 # ── Phase 2: autonomous idle-wake (server/a2a.py) ────────────────────────────
 
@@ -597,3 +640,64 @@ async def test_background_task_stamps_the_turn_session_as_origin(monkeypatch):
         config={"configurable": {"thread_id": "t1"}},
     )
     assert bg.seen_origin == "sess-BG"
+
+
+# ── task_batch(run_in_background=True) stamps the session + spawns every spec ──
+# The batch background path reads origin_session from injected graph state (same
+# contextvar-empty-in-tool-body class as the single task). Drive a REAL graph so a
+# monkeypatch can't mask it.
+
+
+class _RecordingBatchBG:
+    def __init__(self):
+        self.spawns: list[dict] = []
+
+    async def spawn(self, *, origin_session, subagent_type, description, prompt):
+        self.spawns.append({"origin": origin_session, "subagent_type": subagent_type, "description": description})
+        return f"bg-{len(self.spawns)}"
+
+
+@pytest.mark.asyncio
+async def test_background_batch_stamps_session_and_spawns_all(monkeypatch):
+    from unittest.mock import patch
+
+    from langchain_core.messages import HumanMessage
+    from langgraph.checkpoint.memory import MemorySaver
+
+    from graph.config import LangGraphConfig
+
+    batch_call = AIMessage(
+        content="",
+        tool_calls=[
+            {
+                "name": "task_batch",
+                "args": {
+                    "tasks": [
+                        {"description": "topic a", "prompt": "research a"},
+                        {"description": "topic b", "prompt": "research b", "subagent_type": "researcher"},
+                    ],
+                    "run_in_background": True,
+                },
+                "id": "c1",
+                "type": "tool_call",
+            }
+        ],
+    )
+    fake = _ToolFake(messages=iter([batch_call, AIMessage(content="all three kicked off, moving on")]))
+    bg = _RecordingBatchBG()
+    with patch("graph.agent.create_llm", lambda *a, **k: fake):
+        from graph.agent import create_agent_graph
+
+        graph = create_agent_graph(
+            LangGraphConfig(),
+            include_subagents=True,
+            background_mgr=bg,
+            checkpointer=MemorySaver(),
+        )
+    await graph.ainvoke(
+        {"messages": [HumanMessage("research these in the background")], "session_id": "sess-BB"},
+        config={"configurable": {"thread_id": "t1"}},
+    )
+    assert len(bg.spawns) == 2
+    assert {s["origin"] for s in bg.spawns} == {"sess-BB"}
+    assert {s["description"] for s in bg.spawns} == {"topic a", "topic b"}

--- a/tests/test_task_batch.py
+++ b/tests/test_task_batch.py
@@ -148,3 +148,120 @@ async def test_batch_failure_isolated(monkeypatch):
     )
     assert "OUT:ok" in out
     assert "RuntimeError" in out and "kaboom" in out
+
+
+# ── background fan-out: task_batch(run_in_background=True) (ADR 0050) ──────────
+
+
+class _RecordingBG:
+    """Stands in for BackgroundManager: records each spawn and hands back a job id."""
+
+    def __init__(self):
+        self.calls: list[dict] = []
+
+    async def spawn(self, *, origin_session, subagent_type, description, prompt):
+        self.calls.append(
+            {
+                "origin": origin_session,
+                "subagent_type": subagent_type,
+                "description": description,
+                "prompt": prompt,
+            }
+        )
+        return f"bg-{len(self.calls)}"
+
+
+def test_task_batch_exposes_run_in_background():
+    """The batch tool advertises the background switch in its JSON schema so the model
+    can fan a whole batch out detached (parity with `task`'s run_in_background)."""
+    tools = {t.name: t for t in agent_mod._build_task_tools(LangGraphConfig(), [])}
+    props = tools["task_batch"].args_schema.model_json_schema()["properties"]
+    assert "run_in_background" in props
+
+
+@pytest.mark.asyncio
+async def test_batch_background_spawns_each_spec(monkeypatch):
+    """run_in_background=True spawns one background job per spec (not a blocking
+    foreground run) and returns the started job ids. _run_subagent must NOT be called."""
+    called = {"foreground": 0}
+
+    async def fake_run(**kwargs):
+        called["foreground"] += 1
+        return "should-not-run"
+
+    monkeypatch.setattr(agent_mod, "_run_subagent", fake_run)
+    rec = _RecordingBG()
+    tools = {t.name: t for t in agent_mod._build_task_tools(LangGraphConfig(), [], background_mgr=rec)}
+    out = await tools["task_batch"].ainvoke(
+        {
+            "name": "task_batch",
+            "args": {
+                "tasks": [
+                    {"description": "alpha", "prompt": "p1", "subagent_type": "researcher"},
+                    {"description": "beta", "prompt": "p2"},  # subagent_type defaults
+                ],
+                "run_in_background": True,
+            },
+            "id": "tb-bg",
+            "type": "tool_call",
+        }
+    )
+    body = getattr(out, "content", out)
+    assert called["foreground"] == 0, "background batch must not run subagents inline"
+    assert len(rec.calls) == 2
+    assert {c["description"] for c in rec.calls} == {"alpha", "beta"}
+    assert rec.calls[1]["subagent_type"] == "researcher"  # default applied
+    assert "bg-1" in body and "bg-2" in body
+    assert "Started 2 background" in body
+
+
+@pytest.mark.asyncio
+async def test_batch_background_isolates_bad_specs(monkeypatch):
+    """A bad spec (missing prompt / unknown subagent) is skipped inline; the good ones
+    still spawn — the batch is not aborted."""
+    rec = _RecordingBG()
+    tools = {t.name: t for t in agent_mod._build_task_tools(LangGraphConfig(), [], background_mgr=rec)}
+    out = await tools["task_batch"].ainvoke(
+        {
+            "name": "task_batch",
+            "args": {
+                "tasks": [
+                    {"description": "good", "prompt": "p"},
+                    {"description": "noprompt"},  # missing prompt → skipped
+                    {"description": "weird", "prompt": "p", "subagent_type": "does-not-exist"},
+                ],
+                "run_in_background": True,
+            },
+            "id": "tb-bg2",
+            "type": "tool_call",
+        }
+    )
+    body = getattr(out, "content", out)
+    assert len(rec.calls) == 1 and rec.calls[0]["description"] == "good"
+    assert "missing 'prompt'" in body
+    assert "unknown subagent" in body
+    assert "Started 1 background" in body
+
+
+@pytest.mark.asyncio
+async def test_batch_background_degrades_without_manager(monkeypatch):
+    """With no background manager, run_in_background falls back to the FOREGROUND batch
+    (runs the subagents) rather than silently dropping the work."""
+    rec = []
+
+    async def fake_run(**kwargs):
+        rec.append(kwargs)
+        return f"OUT:{kwargs['description']}"
+
+    monkeypatch.setattr(agent_mod, "_run_subagent", fake_run)
+    tools = {t.name: t for t in agent_mod._build_task_tools(LangGraphConfig(), [])}  # no background_mgr
+    out = await tools["task_batch"].ainvoke(
+        {
+            "name": "task_batch",
+            "args": {"tasks": [{"description": "a", "prompt": "p"}], "run_in_background": True},
+            "id": "tb-bg3",
+            "type": "tool_call",
+        }
+    )
+    body = getattr(out, "content", out)
+    assert len(rec) == 1 and "OUT:a" in body  # ran in the foreground


### PR DESCRIPTION
## The unlock

Subagent delegation had three of four quadrants. This fills the fourth.

|              | Foreground (blocks turn) | Background (detached, notified later) |
|--------------|--------------------------|----------------------------------------|
| Single task  | `task(...)`              | `task(..., run_in_background=True)` ✅  |
| Batch (N)    | `task_batch([...])` ✅   | **this PR** ✅                          |

You could run *one* task in the background, or a *batch* in the foreground — but not a batch in the background. Now you can fan a whole batch out detached and keep working.

## What changed

**1. `task_batch(run_in_background=True)`** (`graph/agent.py`)
Spawns every spec detached via the same `BackgroundManager.spawn` as `task(run_in_background=True)`, returns immediately with the job ids. Each completion drains back into the spawning session independently (one `<task-notification>` per job — reuses ADR 0050 Phase 1's exactly-once drain). Bad specs (missing prompt / unknown subagent) are skipped inline; with no manager configured it degrades to the foreground batch rather than dropping work. Session id comes from `InjectedState` (the contextvar reads empty in a tool body).

**2. Background concurrency cap** (`background/manager.py`) — the backpressure that was missing
`BackgroundManager` now bounds concurrent background turns with a semaphore that gates the self-POST in `_fire` (held for the whole turn, so it bounds *running turns*, not just in-flight requests). A wide fan-out can no longer open one full lead-graph turn per job against the gateway at once; excess jobs queue. **Default 3, override `BACKGROUND_MAX_CONCURRENCY`.** Applies to *every* spawn — so several ad-hoc `task(run_in_background=True)` calls are bounded too, closing the "nothing caps the background path" gap I flagged during research.

Known cosmetic trade-off (documented in the ADR): a queued job's row reads `running` before its turn actually fires; `cancel`/`reconcile_interrupted` already handle a not-yet-fired row.

## Tests (`tests/test_task_batch.py`, `tests/test_background.py`)
- batch-background spawns one job per spec + returns the ids; `_run_subagent` is NOT called inline
- bad-spec isolation; no-manager → foreground degrade; schema exposes the switch
- **real-graph** session stamping through `InjectedState` (a monkeypatch can't mask it)
- concurrency-cap `peak <= N` under a slow fake client; env-configured cap
- 64 passed across the batch/background/subagent surface

## Gates
- `ruff check` ✅ · `lint-imports` ✅ (3 kept, 0 broken) · pytest ✅ 64 passed

## Docs
- ADR 0050 amended: a "background batch + concurrency cap (shipped)" follow-up subsection + a consequence bullet.

## Notes
- Independent of #1394 (different files) — merge in any order.
- Builds on #1394's premise: subagent streams are isolated, so a background fan-out won't garble the live view. Background turns already run in isolated `background:<job_id>` contexts regardless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running batch subagent tasks in the background and returning job IDs immediately.
  * Background processing now respects a configurable concurrency limit to avoid overload.

* **Bug Fixes**
  * Invalid batch entries are skipped more gracefully while valid tasks still proceed.
  * If background processing isn’t available, batch tasks fall back to normal execution.

* **Tests**
  * Added coverage for background task spawning, concurrency limits, and fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->